### PR TITLE
docs(argocd): record Sag disable outcome

### DIFF
--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -274,6 +274,7 @@ spec:
                 path: argocd/sag
                 namespace: sag
                 renderWithLovely: false
+                # Keep disabled apps non-cascading unless destructive removal is explicitly staged and reviewed.
                 annotations:
                   argocd.argoproj.io/sync-wave: "6"
                 managedNamespaceMetadata:

--- a/docs/nix-enabled-app-rollout-evidence-2026-07-05.md
+++ b/docs/nix-enabled-app-rollout-evidence-2026-07-05.md
@@ -1040,8 +1040,13 @@ TA/WS/feed build should capture the newer release-contract shape.
 
 Sag is a disabled repo-owned image app with `sag-image`. This checkpoint preserves its historical build/release proof,
 but Sag is no longer counted as an enabled rollout target while the product ApplicationSet keeps `enabled: "false"`.
-The product ApplicationSet uses `preserveResourcesOnDeletion: true` so the generated Argo Application can be disabled
-without intentionally pruning the historical Sag resources it managed.
+The product ApplicationSet now uses `preserveResourcesOnDeletion: true` and keeps Sag non-cascading for future
+disable/re-enable transitions. That protection was added in the same change that first disabled Sag, so it did not
+stage removal of the pre-existing Application finalizer before deletion.
+
+Live verification on 2026-07-13 found no `Application/sag` and no Sag workload resources in namespace `sag`; only
+namespace bootstrap ConfigMaps and the default ServiceAccount remained. Historical Sag resources therefore were not
+preserved by the original transition. The build/release proof below remains historical evidence only.
 
 ### Sag Main Build Proof
 

--- a/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
+++ b/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
@@ -42,6 +42,8 @@ describe('enabled app inventory', () => {
 
   it('records preservation intent when a product app is disabled', () => {
     expect(productApplicationSet.spec?.syncPolicy?.preserveResourcesOnDeletion).toBe(true)
+    const productElements = productApplicationSet.spec?.generators?.[0]?.matrix?.generators?.[1]?.list?.elements ?? []
+    expect(productElements.find((candidate) => candidate.name === 'sag')?.cascadeResourcesOnDeletion).not.toBe(true)
   })
 
   it('cascades resources for generated Applications that are disabled destructively', () => {


### PR DESCRIPTION
## Summary

- Correct the Sag rollout record: the original disable transition did not preserve the pre-existing workload resources.
- Record live verification that `Application/sag` and Sag workload resources are absent.
- Keep future Sag disables explicitly non-cascading under `preserveResourcesOnDeletion` and protect that contract with a regression assertion.

## Related Issues

Follow-up to Codex review on #12061.

## Testing

- Live read-only verification: `Application/sag` is absent; namespace `sag` contains no workload resources.
- `bun test packages/scripts/src/shared/__tests__/enabled-apps.test.ts` (18 passed)
- Oxfmt and Oxlint on the changed test
- `git diff --check`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Documentation reflects observed live state.
- [x] Future non-destructive disable behavior is regression-tested.
