### PR TITLE
ci(nix): rebuild image attrs on flake changes

### DIFF
--- a/.github/workflows/headlamp-ci.yml
+++ b/.github/workflows/headlamp-ci.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths:
       - 'services/headlamp/**'
+      - 'flake.nix'
       - 'flake.lock'
       - 'nix/images/headlamp.nix'
       - 'nix/packages.nix'
@@ -20,6 +21,7 @@ on:
       - main
     paths:
       - 'services/headlamp/**'
+      - 'flake.nix'
       - 'flake.lock'
       - 'nix/images/headlamp.nix'
       - 'nix/packages.nix'

--- a/.github/workflows/headlamp-release.yml
+++ b/.github/workflows/headlamp-release.yml
@@ -117,6 +117,7 @@ jobs:
             nix/ci-run-timed.sh
             nix/oci-inspect-archive.sh
             nix/oci-push.sh
+            flake.nix
             flake.lock
           )
 

--- a/.github/workflows/torghut-build-push.yaml
+++ b/.github/workflows/torghut-build-push.yaml
@@ -18,6 +18,7 @@ on:
       - 'nix/ci-run-timed.sh'
       - 'nix/oci-inspect-archive.sh'
       - 'nix/oci-push.sh'
+      - 'flake.nix'
       - 'flake.lock'
       - 'services/torghut/uv.lock'
   push:
@@ -36,6 +37,7 @@ on:
       - 'nix/ci-run-timed.sh'
       - 'nix/oci-inspect-archive.sh'
       - 'nix/oci-push.sh'
+      - 'flake.nix'
       - 'flake.lock'
       - 'services/torghut/uv.lock'
   workflow_dispatch:

--- a/.github/workflows/torghut-hyperliquid-feed-build-push.yaml
+++ b/.github/workflows/torghut-hyperliquid-feed-build-push.yaml
@@ -20,6 +20,7 @@ on:
       - 'nix/ci-run-timed.sh'
       - 'nix/oci-inspect-archive.sh'
       - 'nix/oci-push.sh'
+      - 'flake.nix'
       - 'flake.lock'
   push:
     branches:
@@ -39,6 +40,7 @@ on:
       - 'nix/ci-run-timed.sh'
       - 'nix/oci-inspect-archive.sh'
       - 'nix/oci-push.sh'
+      - 'flake.nix'
       - 'flake.lock'
   workflow_dispatch:
 

--- a/.github/workflows/torghut-hyperliquid-feed-release.yml
+++ b/.github/workflows/torghut-hyperliquid-feed-release.yml
@@ -130,6 +130,7 @@ jobs:
                     nix/ci-run-timed.sh \
                     nix/oci-inspect-archive.sh \
                     nix/oci-push.sh \
+                    flake.nix \
                     flake.lock
                 )"
                 if [ -n "${FEED_CHANGES}" ]; then

--- a/.github/workflows/torghut-release.yml
+++ b/.github/workflows/torghut-release.yml
@@ -132,6 +132,7 @@ jobs:
                     nix/ci-run-timed.sh \
                     nix/oci-inspect-archive.sh \
                     nix/oci-push.sh \
+                    flake.nix \
                     flake.lock \
                     services/torghut/uv.lock
                 )"

--- a/.github/workflows/torghut-ta-build-push.yaml
+++ b/.github/workflows/torghut-ta-build-push.yaml
@@ -20,6 +20,7 @@ on:
       - 'nix/ci-run-timed.sh'
       - 'nix/oci-inspect-archive.sh'
       - 'nix/oci-push.sh'
+      - 'flake.nix'
       - 'flake.lock'
   push:
     branches:
@@ -39,6 +40,7 @@ on:
       - 'nix/ci-run-timed.sh'
       - 'nix/oci-inspect-archive.sh'
       - 'nix/oci-push.sh'
+      - 'flake.nix'
       - 'flake.lock'
   workflow_dispatch:
 

--- a/.github/workflows/torghut-ta-release.yml
+++ b/.github/workflows/torghut-ta-release.yml
@@ -130,6 +130,7 @@ jobs:
                     nix/ci-run-timed.sh \
                     nix/oci-inspect-archive.sh \
                     nix/oci-push.sh \
+                    flake.nix \
                     flake.lock
                 )"
                 if [ -n "${TA_CHANGES}" ]; then

--- a/.github/workflows/torghut-ws-build-push.yaml
+++ b/.github/workflows/torghut-ws-build-push.yaml
@@ -20,6 +20,7 @@ on:
       - 'nix/ci-run-timed.sh'
       - 'nix/oci-inspect-archive.sh'
       - 'nix/oci-push.sh'
+      - 'flake.nix'
       - 'flake.lock'
   push:
     branches:
@@ -39,6 +40,7 @@ on:
       - 'nix/ci-run-timed.sh'
       - 'nix/oci-inspect-archive.sh'
       - 'nix/oci-push.sh'
+      - 'flake.nix'
       - 'flake.lock'
   workflow_dispatch:
 

--- a/.github/workflows/torghut-ws-release.yml
+++ b/.github/workflows/torghut-ws-release.yml
@@ -130,6 +130,7 @@ jobs:
                     nix/ci-run-timed.sh \
                     nix/oci-inspect-archive.sh \
                     nix/oci-push.sh \
+                    flake.nix \
                     flake.lock
                 )"
                 if [ -n "${WS_CHANGES}" ]; then

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -593,7 +593,6 @@ describe('native OCI build workflows', () => {
       jangarBuildWorkflow,
       symphonyBuildWorkflow,
       sagBuildWorkflow,
-      headlampWorkflow,
     ]) {
       expect(workflow).not.toContain("'package.json'")
     }
@@ -729,7 +728,6 @@ describe('native OCI build workflows', () => {
       jangarBuildWorkflow,
       symphonyBuildWorkflow,
       sagBuildWorkflow,
-      headlampWorkflow,
     ]) {
       expect(workflow).not.toContain("- 'flake.nix'")
       expect(workflow).not.toContain('- flake.nix')
@@ -756,6 +754,8 @@ describe('native OCI build workflows', () => {
     }
     expect(atticWorkflow).toContain("- 'flake.lock'")
     expect(atticWorkflow).toContain("- 'nix/images/attic.nix'")
+    expect(headlampWorkflow.split("- 'flake.nix'")).toHaveLength(3)
+    expect(headlampReleaseWorkflow).toContain('flake.nix')
   })
 
   it('allows Nix dockerTools archives without Docker repo tags', () => {

--- a/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
@@ -76,6 +76,7 @@ describe('torghut build-push workflow', () => {
       'packages/scripts/src/shared/cli.ts',
       'packages/scripts/src/shared/git.ts',
       'nix/images/torghut.nix',
+      'flake.nix',
     ]
 
     for (const pattern of requiredPatterns) {
@@ -155,6 +156,7 @@ describe('torghut build-push workflow', () => {
       'nix/ci-run-timed.sh',
       'nix/oci-inspect-archive.sh',
       'nix/oci-push.sh',
+      'flake.nix',
       'flake.lock',
       'services/torghut/uv.lock',
     ]
@@ -202,6 +204,7 @@ describe('torghut build-push workflow', () => {
       expect(serviceWorkflow).toContain(`- '${servicePath}'`)
       expect(serviceWorkflow).toContain("- 'services/dorvud/platform/**'")
       expect(serviceWorkflow).toContain("- 'services/dorvud/settings.gradle.kts'")
+      expect(serviceWorkflow.split("- 'flake.nix'")).toHaveLength(3)
       expect(serviceWorkflow).not.toContain("- 'services/dorvud/**'")
       expect(serviceWorkflow).not.toContain('workflow_run:')
       expect(serviceWorkflow).toContain("github.event_name == 'push'")
@@ -220,6 +223,7 @@ describe('torghut build-push workflow', () => {
     expect(hyperliquidFeedWorkflow).toContain("- 'services/dorvud/hyperliquid-feed/**'")
     expect(hyperliquidFeedWorkflow).toContain("- 'services/dorvud/platform/**'")
     expect(hyperliquidFeedWorkflow).toContain("- 'services/dorvud/settings.gradle.kts'")
+    expect(hyperliquidFeedWorkflow.split("- 'flake.nix'")).toHaveLength(3)
     expect(hyperliquidFeedWorkflow).not.toContain("- 'nix/oci-release-contract.sh'")
     expect(hyperliquidFeedWorkflow).not.toContain("- 'services/dorvud/**'")
     expect(hyperliquidFeedWorkflow).not.toContain('workflow_run:')
@@ -492,6 +496,7 @@ describe('torghut build-push workflow', () => {
       expect(staleDiffBlock).toContain('nix/ci-run-timed.sh')
       expect(staleDiffBlock).toContain('nix/oci-inspect-archive.sh')
       expect(staleDiffBlock).toContain('nix/oci-push.sh')
+      expect(staleDiffBlock).toContain('flake.nix')
       expect(staleDiffBlock).not.toContain('nix/oci-release-contract.sh')
       expect(staleDiffBlock).toContain('flake.lock')
       expect(staleDiffBlock).not.toContain('.github/workflows/')
@@ -515,6 +520,7 @@ describe('torghut build-push workflow', () => {
     expect(staleDiffBlock).toContain('nix/ci-run-timed.sh')
     expect(staleDiffBlock).toContain('nix/oci-inspect-archive.sh')
     expect(staleDiffBlock).toContain('nix/oci-push.sh')
+    expect(staleDiffBlock).toContain('flake.nix')
     expect(staleDiffBlock).not.toContain('nix/oci-release-contract.sh')
     expect(staleDiffBlock).toContain('flake.lock')
     expect(staleDiffBlock).not.toContain('.github/workflows/')


### PR DESCRIPTION
## Summary

- Trigger Headlamp and all Torghut-family Nix image builds when `flake.nix` changes their package wiring.
- Add `flake.nix` to the matching workflow-run stale guards so pre-change image contracts cannot be promoted afterward.
- Update workflow regression tests for the expanded input contract.

## Related Issues

Follow-up to Codex reviews on #11843 and #11988.

## Testing

- `bun test packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts` (22 passed)
- Focused `packages/scripts/src/shared/__tests__/oci.test.ts` policy tests (3 passed)
- Oxfmt and Oxlint on changed tests
- `git diff --check`

## Breaking Changes

None.

## Checklist

- [x] Build triggers and stale guards contain the same new input.
- [x] Headlamp and four Torghut-family workflows are covered.
- [x] Regression tests reject future drift.
