### PR TITLE
fix(rook-ceph): roll OSDs for scrub config

### DIFF
--- a/argocd/applications/rook-ceph/cephcluster-osd-config-rollout.yaml
+++ b/argocd/applications/rook-ceph/cephcluster-osd-config-rollout.yaml
@@ -1,0 +1,6 @@
+apiVersion: ceph.rook.io/v1
+kind: CephCluster
+metadata:
+  name: rook-ceph
+  annotations:
+    ops.proompteng.ai/osd-config-revision: scrub-auto-repair-v1

--- a/argocd/applications/rook-ceph/cephcluster-osd-config-rollout.yaml
+++ b/argocd/applications/rook-ceph/cephcluster-osd-config-rollout.yaml
@@ -2,5 +2,7 @@ apiVersion: ceph.rook.io/v1
 kind: CephCluster
 metadata:
   name: rook-ceph
+spec:
   annotations:
-    ops.proompteng.ai/osd-config-revision: scrub-auto-repair-v1
+    osd:
+      ops.proompteng.ai/osd-config-revision: scrub-auto-repair-v1

--- a/argocd/applications/rook-ceph/kustomization.yaml
+++ b/argocd/applications/rook-ceph/kustomization.yaml
@@ -24,3 +24,11 @@ helmCharts:
     namespace: rook-ceph
     includeCRDs: true
     valuesFile: cluster-values.yaml
+
+patches:
+  - path: cephcluster-osd-config-rollout.yaml
+    target:
+      group: ceph.rook.io
+      version: v1
+      kind: CephCluster
+      name: rook-ceph

--- a/packages/scripts/src/docs/__tests__/rook-ceph-runbook.test.ts
+++ b/packages/scripts/src/docs/__tests__/rook-ceph-runbook.test.ts
@@ -37,3 +37,19 @@ it('overrides and restores daemon-scoped mClock capacity during recovery surge',
   expect(runbook).toContain('for osd_value in 0:210 1:250 2:260 3:200 4:220 5:240; do')
   expect(runbook).toContain('ceph config set "osd.${osd_id}" osd_mclock_max_capacity_iops_hdd "${capacity}"')
 })
+
+it('rolls OSDs when scrub configuration changes', () => {
+  const values = readFileSync(join(repoRoot, 'argocd/applications/rook-ceph/cluster-values.yaml'), 'utf8')
+  const kustomization = readFileSync(join(repoRoot, 'argocd/applications/rook-ceph/kustomization.yaml'), 'utf8')
+  const rolloutPatch = readFileSync(
+    join(repoRoot, 'argocd/applications/rook-ceph/cephcluster-osd-config-rollout.yaml'),
+    'utf8',
+  )
+
+  expect(values).toContain('osd_scrub_auto_repair: "true"')
+  expect(values).toContain('osd_scrub_auto_repair_num_errors: "5"')
+  expect(kustomization).toContain('path: cephcluster-osd-config-rollout.yaml')
+  expect(kustomization).toContain('kind: CephCluster')
+  expect(kustomization).toContain('name: rook-ceph')
+  expect(rolloutPatch).toContain('ops.proompteng.ai/osd-config-revision: scrub-auto-repair-v1')
+})

--- a/packages/scripts/src/docs/__tests__/rook-ceph-runbook.test.ts
+++ b/packages/scripts/src/docs/__tests__/rook-ceph-runbook.test.ts
@@ -51,5 +51,7 @@ it('rolls OSDs when scrub configuration changes', () => {
   expect(kustomization).toContain('path: cephcluster-osd-config-rollout.yaml')
   expect(kustomization).toContain('kind: CephCluster')
   expect(kustomization).toContain('name: rook-ceph')
+  expect(rolloutPatch).toContain('spec:\n  annotations:\n    osd:')
   expect(rolloutPatch).toContain('ops.proompteng.ai/osd-config-revision: scrub-auto-repair-v1')
+  expect(rolloutPatch).not.toContain('metadata:\n  name: rook-ceph\n  annotations:')
 })


### PR DESCRIPTION
## Summary

- Patch the chart-generated `CephCluster/rook-ceph` with an explicit OSD configuration revision annotation.
- Tie the rollout revision to the durable scrub auto-repair settings so existing OSD daemons do not retain stale custom ceph.conf state.
- Add a protected regression assertion for the scrub settings, Kustomize target, and revision annotation.

## Related Issues

Follow-up to Codex review on #11904.

## Testing

- Live read-only verification confirmed the target is `CephCluster/rook-ceph`.
- `bun test packages/scripts/src/docs/__tests__/rook-ceph-runbook.test.ts` (5 passed)
- Oxfmt and Oxlint on the changed test
- `git diff --check`

## Breaking Changes

None.

## Checklist

- [x] The rollout trigger targets the chart-generated CephCluster.
- [x] The scrub configuration remains GitOps-owned.
- [x] Regression coverage ties the rollout revision to the settings.
