### PR TITLE
fix(kafka): schedule pods on OSD-backed nodes

### DIFF
--- a/argocd/applications/kafka/strimzi-kafka-cluster.yaml
+++ b/argocd/applications/kafka/strimzi-kafka-cluster.yaml
@@ -61,6 +61,23 @@ spec:
   template:
     pod:
       affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - talos-192-168-1-85
+                      - turin
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - turin
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
@@ -104,6 +121,23 @@ spec:
   template:
     pod:
       affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - talos-192-168-1-85
+                      - turin
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - turin
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100


### PR DESCRIPTION
## Summary

- Restrict Kafka controller and broker node pools to the two nodes backed by Ceph OSDs.
- Prefer `turin` for new Kafka placements.
- Exclude `talos-192-168-1-194`, which has no OSDs, while preserving replica distribution across two nodes.

## Related Issues

None

## Testing

- `git diff --check`
- `kubectl kustomize argocd/applications/kafka` (expected Helm flag error)
- `kustomize build --enable-helm argocd/applications/kafka`
- `nix develop -c kustomize build --enable-helm argocd/applications/kafka`
- Commit hooks: lint-staged and commitlint

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable.
- [x] No documentation or release-note change is required.