### PR TITLE
fix(torghut): validate directional liquidity

### DIFF
--- a/services/torghut/app/hyperliquid_execution/entry_processing.py
+++ b/services/torghut/app/hyperliquid_execution/entry_processing.py
@@ -198,6 +198,7 @@ def _submit_order(
             now=runtime.context.started_at,
         )
         intent = _normalize_order_intent(runtime.exchange, intent)
+        _validate_order_intent_crossability(runtime.exchange, intent)
         result = runtime.exchange.submit_order(intent)
     except _ORDER_SUBMISSION_ERRORS as exc:
         runtime.counts.record_order_error(type(exc).__name__)
@@ -226,6 +227,15 @@ def _normalize_order_intent(
     if not callable(normalize):
         return intent
     return cast(Callable[[OrderIntent], OrderIntent], normalize)(intent)
+
+
+def _validate_order_intent_crossability(
+    exchange: HyperliquidExecutionExchange,
+    intent: OrderIntent,
+) -> None:
+    validate = getattr(exchange, "validate_order_intent_crossability", None)
+    if callable(validate):
+        cast(Callable[[OrderIntent], None], validate)(intent)
 
 
 def _reduce_only_consumed_order_slot(action: dict[str, object]) -> bool:

--- a/services/torghut/app/hyperliquid_execution/exchange.py
+++ b/services/torghut/app/hyperliquid_execution/exchange.py
@@ -192,15 +192,22 @@ class HyperliquidSdkExecutionExchange:
             best_bid = _best_level_price(book, 0)
             best_ask = _best_level_price(book, 1)
             book_empty = best_bid is None or best_ask is None
+            rounded_limit_price = sdk_slippage_limit_price(
+                info,
+                sdk_name,
+                intent.side == "buy",
+                intent.limit_price,
+                Decimal("0"),
+            )
             buy_not_crossable = (
                 not book_empty
                 and intent.side == "buy"
-                and intent.limit_price < cast(Decimal, best_ask)
+                and rounded_limit_price < cast(Decimal, best_ask)
             )
             sell_not_crossable = (
                 not book_empty
                 and intent.side == "sell"
-                and intent.limit_price > cast(Decimal, best_bid)
+                and rounded_limit_price > cast(Decimal, best_bid)
             )
         except _BOOK_UNAVAILABLE_EXCEPTIONS as exc:
             raise ValueError(f"order_book_unavailable:{type(exc).__name__}") from exc

--- a/services/torghut/app/hyperliquid_execution/exchange.py
+++ b/services/torghut/app/hyperliquid_execution/exchange.py
@@ -182,6 +182,24 @@ class HyperliquidSdkExecutionExchange:
     def normalize_order_intent(self, intent: OrderIntent) -> OrderIntent:
         return self._normalize_order_intent(intent)
 
+    def validate_order_intent_crossability(self, intent: OrderIntent) -> None:
+        try:
+            info = self._info()
+            sdk_name = _sdk_market_name(intent.coin, intent.dex)
+            _register_sdk_market_alias(info, sdk_name, intent.coin)
+            book = cast(dict[str, object], info.l2_snapshot(sdk_name))
+            self._last_read_at = datetime.now(timezone.utc)
+        except _BOOK_UNAVAILABLE_EXCEPTIONS as exc:
+            raise ValueError(f"order_book_unavailable:{type(exc).__name__}") from exc
+        best_bid = _best_level_price(book, 0)
+        best_ask = _best_level_price(book, 1)
+        if best_bid is None or best_ask is None:
+            raise ValueError("order_book_empty")
+        if intent.side == "buy" and intent.limit_price < best_ask:
+            raise ValueError("order_not_crossable:buy")
+        if intent.side == "sell" and intent.limit_price > best_bid:
+            raise ValueError("order_not_crossable:sell")
+
     def submit_order(self, intent: OrderIntent) -> OrderResult:
         if intent.tif not in _SUPPORTED_LIMIT_TIFS:
             return OrderResult(
@@ -413,11 +431,11 @@ class HyperliquidSdkExecutionExchange:
             )
         except _BOOK_UNAVAILABLE_EXCEPTIONS as exc:
             return f"book_unavailable:{type(exc).__name__}"
-        if buy_limit >= best_ask and (
-            not self._config.allow_short_entries or sell_limit <= best_bid
-        ):
+        buy_crossable = buy_limit >= best_ask
+        sell_crossable = sell_limit <= best_bid
+        if buy_crossable or (self._config.allow_short_entries and sell_crossable):
             return None
-        expected_sides = "buy,sell" if self._config.allow_short_entries else "buy"
+        expected_sides = "buy|sell" if self._config.allow_short_entries else "buy"
         return (
             f"book_not_crossable:sides={expected_sides}:"
             f"bid={best_bid}:ask={best_ask}:buy_limit={buy_limit}:sell_limit={sell_limit}"

--- a/services/torghut/app/hyperliquid_execution/exchange.py
+++ b/services/torghut/app/hyperliquid_execution/exchange.py
@@ -189,15 +189,26 @@ class HyperliquidSdkExecutionExchange:
             _register_sdk_market_alias(info, sdk_name, intent.coin)
             book = cast(dict[str, object], info.l2_snapshot(sdk_name))
             self._last_read_at = datetime.now(timezone.utc)
+            best_bid = _best_level_price(book, 0)
+            best_ask = _best_level_price(book, 1)
+            book_empty = best_bid is None or best_ask is None
+            buy_not_crossable = (
+                not book_empty
+                and intent.side == "buy"
+                and intent.limit_price < cast(Decimal, best_ask)
+            )
+            sell_not_crossable = (
+                not book_empty
+                and intent.side == "sell"
+                and intent.limit_price > cast(Decimal, best_bid)
+            )
         except _BOOK_UNAVAILABLE_EXCEPTIONS as exc:
             raise ValueError(f"order_book_unavailable:{type(exc).__name__}") from exc
-        best_bid = _best_level_price(book, 0)
-        best_ask = _best_level_price(book, 1)
-        if best_bid is None or best_ask is None:
+        if book_empty:
             raise ValueError("order_book_empty")
-        if intent.side == "buy" and intent.limit_price < best_ask:
+        if buy_not_crossable:
             raise ValueError("order_not_crossable:buy")
-        if intent.side == "sell" and intent.limit_price > best_bid:
+        if sell_not_crossable:
             raise ValueError("order_not_crossable:sell")
 
     def submit_order(self, intent: OrderIntent) -> OrderResult:

--- a/services/torghut/tests/hyperliquid_execution/test_liquidity_gate.py
+++ b/services/torghut/tests/hyperliquid_execution/test_liquidity_gate.py
@@ -11,7 +11,11 @@ from pytest import MonkeyPatch
 
 from app.hyperliquid_execution.config import HyperliquidExecutionConfig
 from app.hyperliquid_execution.exchange import HyperliquidSdkExecutionExchange
-from app.hyperliquid_execution.models import ExecutionMarket, OrderIntent, RuntimeDependencyStatus
+from app.hyperliquid_execution.models import (
+    ExecutionMarket,
+    OrderIntent,
+    RuntimeDependencyStatus,
+)
 from app.hyperliquid_execution.service import HyperliquidExecutionService
 from tests.hyperliquid_execution.test_runtime_surfaces import (
     _FakeSession,
@@ -186,7 +190,9 @@ def test_exchange_validates_the_generated_order_side_before_submission() -> None
     )
 
     with pytest.raises(ValueError, match="order_not_crossable:buy"):
-        exchange.validate_order_intent_crossability(_intent(side="buy", limit_price="102"))
+        exchange.validate_order_intent_crossability(
+            _intent(side="buy", limit_price="102")
+        )
     exchange.validate_order_intent_crossability(_intent(side="sell", limit_price="98"))
 
 

--- a/services/torghut/tests/hyperliquid_execution/test_liquidity_gate.py
+++ b/services/torghut/tests/hyperliquid_execution/test_liquidity_gate.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from decimal import Decimal
-from typing import Literal
+from typing import Literal, cast
 
 import pytest
 from pytest import MonkeyPatch
@@ -196,6 +196,34 @@ def test_exchange_validates_the_generated_order_side_before_submission() -> None
     exchange.validate_order_intent_crossability(_intent(side="sell", limit_price="98"))
 
 
+def test_exchange_fails_closed_on_malformed_pre_submit_price() -> None:
+    exchange = _Exchange(
+        HyperliquidExecutionConfig.from_env({}),
+        sdk=_Sdk(),
+        info=_Info(
+            {"xyz:NVDA": {"levels": [[{"px": "not-a-number"}], [{"px": "103"}]]}}
+        ),
+    )
+
+    with pytest.raises(ValueError, match="order_book_unavailable:InvalidOperation"):
+        exchange.validate_order_intent_crossability(
+            _intent(side="buy", limit_price="102")
+        )
+
+
+def test_exchange_fails_closed_on_non_mapping_pre_submit_book() -> None:
+    exchange = _Exchange(
+        HyperliquidExecutionConfig.from_env({}),
+        sdk=_Sdk(),
+        info=_MalformedBookInfo([{"px": "99"}]),
+    )
+
+    with pytest.raises(ValueError, match="order_book_unavailable:AttributeError"):
+        exchange.validate_order_intent_crossability(
+            _intent(side="buy", limit_price="102")
+        )
+
+
 def test_exchange_reports_mid_lookup_failure_as_unavailable_liquidity() -> None:
     exchange = _Exchange(
         HyperliquidExecutionConfig.from_env(
@@ -348,6 +376,16 @@ class _FailingMidInfo(_Info):
     def _load_mids(self, *, dex: str = "") -> dict[str, object]:
         self.mid_dexes.append(dex)
         raise RuntimeError("mid_lookup_failed")
+
+
+class _MalformedBookInfo(_Info):
+    def __init__(self, book: object) -> None:
+        super().__init__({"xyz:NVDA": {}})
+        self._book = book
+
+    def l2_snapshot(self, name: str) -> dict[str, object]:
+        self.name_to_coin[name]
+        return cast(dict[str, object], self._book)
 
 
 class _Exchange(HyperliquidSdkExecutionExchange):

--- a/services/torghut/tests/hyperliquid_execution/test_liquidity_gate.py
+++ b/services/torghut/tests/hyperliquid_execution/test_liquidity_gate.py
@@ -196,6 +196,19 @@ def test_exchange_validates_the_generated_order_side_before_submission() -> None
     exchange.validate_order_intent_crossability(_intent(side="sell", limit_price="98"))
 
 
+def test_exchange_validates_sdk_rounded_limit_price_before_submission() -> None:
+    exchange = _Exchange(
+        HyperliquidExecutionConfig.from_env({}),
+        sdk=_Sdk(),
+        info=_Info({"xyz:NVDA": {"levels": [[{"px": "99"}], [{"px": "100.004"}]]}}),
+    )
+
+    with pytest.raises(ValueError, match="order_not_crossable:buy"):
+        exchange.validate_order_intent_crossability(
+            _intent(side="buy", limit_price="100.004")
+        )
+
+
 def test_exchange_fails_closed_on_malformed_pre_submit_price() -> None:
     exchange = _Exchange(
         HyperliquidExecutionConfig.from_env({}),

--- a/services/torghut/tests/hyperliquid_execution/test_liquidity_gate.py
+++ b/services/torghut/tests/hyperliquid_execution/test_liquidity_gate.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from decimal import Decimal
+from typing import Literal
 
+import pytest
 from pytest import MonkeyPatch
 
 from app.hyperliquid_execution.config import HyperliquidExecutionConfig
 from app.hyperliquid_execution.exchange import HyperliquidSdkExecutionExchange
-from app.hyperliquid_execution.models import ExecutionMarket, RuntimeDependencyStatus
+from app.hyperliquid_execution.models import ExecutionMarket, OrderIntent, RuntimeDependencyStatus
 from app.hyperliquid_execution.service import HyperliquidExecutionService
 from tests.hyperliquid_execution.test_runtime_surfaces import (
     _FakeSession,
@@ -145,7 +148,7 @@ def test_exchange_applies_sdk_price_rounding_before_selecting_market() -> None:
     }
 
 
-def test_exchange_requires_buy_crossability_when_short_entries_are_enabled() -> None:
+def test_exchange_keeps_sell_crossable_market_when_short_entries_are_enabled() -> None:
     exchange = _Exchange(
         HyperliquidExecutionConfig.from_env(
             {
@@ -162,11 +165,29 @@ def test_exchange_requires_buy_crossability_when_short_entries_are_enabled() -> 
 
     selected, status = exchange.filter_crossable_markets((_market("NVDA", "xyz"),))
 
-    assert selected == ()
-    assert status.ready is False
-    assert status.details["skipped"] == {
-        "NVDA": "book_not_crossable:sides=buy,sell:bid=99:ask=103:buy_limit=102.0:sell_limit=98.0"
-    }
+    assert [market.coin for market in selected] == ["NVDA"]
+    assert status.ready is True
+    assert status.details["skipped"] == {}
+
+
+def test_exchange_validates_the_generated_order_side_before_submission() -> None:
+    exchange = _Exchange(
+        HyperliquidExecutionConfig.from_env(
+            {
+                "HYPERLIQUID_EXECUTION_ALLOW_SHORT_ENTRIES": "true",
+                "HYPERLIQUID_EXECUTION_MARKETABLE_IOC_SLIPPAGE_BPS": "200",
+            }
+        ),
+        sdk=_Sdk(),
+        info=_Info(
+            {"xyz:NVDA": {"levels": [[{"px": "99"}], [{"px": "103"}]]}},
+            mids={"NVDA": "100"},
+        ),
+    )
+
+    with pytest.raises(ValueError, match="order_not_crossable:buy"):
+        exchange.validate_order_intent_crossability(_intent(side="buy", limit_price="102"))
+    exchange.validate_order_intent_crossability(_intent(side="sell", limit_price="98"))
 
 
 def test_exchange_reports_mid_lookup_failure_as_unavailable_liquidity() -> None:
@@ -371,4 +392,21 @@ def _market(coin: str, dex: str) -> ExecutionMarket:
         dex=dex,
         network="mainnet",
         day_notional_volume_usd=Decimal("1000"),
+    )
+
+
+def _intent(*, side: Literal["buy", "sell"], limit_price: str) -> OrderIntent:
+    return OrderIntent(
+        market_id="hl:perp:xyz:NVDA",
+        coin="NVDA",
+        dex="xyz",
+        side=side,
+        size=Decimal("0.1"),
+        limit_price=Decimal(limit_price),
+        notional_usd=Decimal(limit_price) / Decimal("10"),
+        cloid="0xabc",
+        tif="Ioc",
+        reduce_only=False,
+        signal_id="signal",
+        expires_at=datetime.now(timezone.utc),
     )

--- a/services/torghut/tests/hyperliquid_execution/test_service_normalized_intents.py
+++ b/services/torghut/tests/hyperliquid_execution/test_service_normalized_intents.py
@@ -37,6 +37,7 @@ def test_service_persists_exchange_normalized_order_intent() -> None:
     result = service.run_once(session)
 
     assert result.orders_submitted == 1
+    assert exchange.validated_intents == exchange.submitted_intents
     assert exchange.submitted_intents[0].size == Decimal("0.2")
     assert exchange.submitted_intents[0].limit_price == Decimal("101.000000")
     assert exchange.submitted_intents[0].notional_usd == Decimal("20.200000")
@@ -62,6 +63,7 @@ class _NormalizingServiceExchange(_ServiceExchange):
     def __init__(self, *args: object, **kwargs: object) -> None:
         super().__init__(*args, **kwargs)
         self.submitted_intents: list[OrderIntent] = []
+        self.validated_intents: list[OrderIntent] = []
 
     def normalize_order_intent(self, intent: OrderIntent) -> OrderIntent:
         return replace(
@@ -74,3 +76,6 @@ class _NormalizingServiceExchange(_ServiceExchange):
     def submit_order(self, intent: OrderIntent) -> OrderResult:
         self.submitted_intents.append(intent)
         return super().submit_order(intent)
+
+    def validate_order_intent_crossability(self, intent: OrderIntent) -> None:
+        self.validated_intents.append(intent)


### PR DESCRIPTION
## Summary

- Allow pre-signal Hyperliquid market selection when either executable side is crossable for short-enabled runtimes.
- Revalidate the generated normalized order intent against the actual buy/sell side immediately before submission.
- Fail closed on unavailable/empty books and non-crossable directional intents.
- Add focused regressions for sell-only crossability and normalized-intent validation order.

## Related Issues

Follow-up to Codex review on #11962.

## Testing

- Python 3.12 focused pytest: 13 passed
- Ruff on all changed Python files: passed
- `python3 -m py_compile` on all changed Python files: passed
- `git diff --check`
- Repository-wide Pyright is delegated to CI; the available borrowed local environment lacked current workspace dependencies and produced unrelated missing-import errors.

## Breaking Changes

None.

## Checklist

- [x] Pre-signal filtering no longer requires both directions.
- [x] Submission remains fail-closed for the actual generated side.
- [x] Focused behavior is regression-tested.
