### PR TITLE
chore(kafka): upgrade Strimzi to 1.1.0

### DIFF
--- a/argocd/applications/kafka/kustomization.yaml
+++ b/argocd/applications/kafka/kustomization.yaml
@@ -2,34 +2,34 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kafka
 resources:
-  # Strimzi operator install (pinned to 1.0.0) - remote raw files
-  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.0.0/install/cluster-operator/010-ServiceAccount-strimzi-cluster-operator.yaml
-  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.0.0/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
-  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.0.0/install/cluster-operator/020-RoleBinding-strimzi-cluster-operator.yaml
-  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.0.0/install/cluster-operator/021-ClusterRole-strimzi-cluster-operator-role.yaml
-  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.0.0/install/cluster-operator/021-ClusterRoleBinding-strimzi-cluster-operator.yaml
-  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.0.0/install/cluster-operator/022-ClusterRole-strimzi-cluster-operator-role.yaml
-  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.0.0/install/cluster-operator/022-RoleBinding-strimzi-cluster-operator.yaml
-  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.0.0/install/cluster-operator/023-ClusterRole-strimzi-cluster-operator-role.yaml
-  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.0.0/install/cluster-operator/023-RoleBinding-strimzi-cluster-operator.yaml
-  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.0.0/install/cluster-operator/030-ClusterRole-strimzi-kafka-broker.yaml
-  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.0.0/install/cluster-operator/030-ClusterRoleBinding-strimzi-cluster-operator-kafka-broker-delegation.yaml
-  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.0.0/install/cluster-operator/031-ClusterRole-strimzi-entity-operator.yaml
-  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.0.0/install/cluster-operator/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml
-  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.0.0/install/cluster-operator/033-ClusterRole-strimzi-kafka-client.yaml
-  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.0.0/install/cluster-operator/033-ClusterRoleBinding-strimzi-cluster-operator-kafka-client-delegation.yaml
-  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.0.0/install/cluster-operator/040-Crd-kafka.yaml
-  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.0.0/install/cluster-operator/041-Crd-kafkaconnect.yaml
-  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.0.0/install/cluster-operator/042-Crd-strimzipodset.yaml
-  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.0.0/install/cluster-operator/043-Crd-kafkatopic.yaml
-  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.0.0/install/cluster-operator/044-Crd-kafkauser.yaml
-  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.0.0/install/cluster-operator/045-Crd-kafkanodepool.yaml
-  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.0.0/install/cluster-operator/046-Crd-kafkabridge.yaml
-  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.0.0/install/cluster-operator/047-Crd-kafkaconnector.yaml
-  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.0.0/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
-  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.0.0/install/cluster-operator/049-Crd-kafkarebalance.yaml
-  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.0.0/install/cluster-operator/050-ConfigMap-strimzi-cluster-operator.yaml
-  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.0.0/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
+  # Strimzi operator install (pinned to 1.1.0) - remote raw files
+  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.1.0/install/cluster-operator/010-ServiceAccount-strimzi-cluster-operator.yaml
+  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.1.0/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
+  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.1.0/install/cluster-operator/020-RoleBinding-strimzi-cluster-operator.yaml
+  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.1.0/install/cluster-operator/021-ClusterRole-strimzi-cluster-operator-role.yaml
+  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.1.0/install/cluster-operator/021-ClusterRoleBinding-strimzi-cluster-operator.yaml
+  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.1.0/install/cluster-operator/022-ClusterRole-strimzi-cluster-operator-role.yaml
+  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.1.0/install/cluster-operator/022-RoleBinding-strimzi-cluster-operator.yaml
+  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.1.0/install/cluster-operator/023-ClusterRole-strimzi-cluster-operator-role.yaml
+  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.1.0/install/cluster-operator/023-RoleBinding-strimzi-cluster-operator.yaml
+  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.1.0/install/cluster-operator/030-ClusterRole-strimzi-kafka-broker.yaml
+  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.1.0/install/cluster-operator/030-ClusterRoleBinding-strimzi-cluster-operator-kafka-broker-delegation.yaml
+  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.1.0/install/cluster-operator/031-ClusterRole-strimzi-entity-operator.yaml
+  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.1.0/install/cluster-operator/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml
+  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.1.0/install/cluster-operator/033-ClusterRole-strimzi-kafka-client.yaml
+  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.1.0/install/cluster-operator/033-ClusterRoleBinding-strimzi-cluster-operator-kafka-client-delegation.yaml
+  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.1.0/install/cluster-operator/040-Crd-kafka.yaml
+  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.1.0/install/cluster-operator/041-Crd-kafkaconnect.yaml
+  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.1.0/install/cluster-operator/042-Crd-strimzipodset.yaml
+  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.1.0/install/cluster-operator/043-Crd-kafkatopic.yaml
+  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.1.0/install/cluster-operator/044-Crd-kafkauser.yaml
+  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.1.0/install/cluster-operator/045-Crd-kafkanodepool.yaml
+  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.1.0/install/cluster-operator/046-Crd-kafkabridge.yaml
+  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.1.0/install/cluster-operator/047-Crd-kafkaconnector.yaml
+  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.1.0/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.1.0/install/cluster-operator/049-Crd-kafkarebalance.yaml
+  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.1.0/install/cluster-operator/050-ConfigMap-strimzi-cluster-operator.yaml
+  - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/1.1.0/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
   - strimzi-operator-watched-crb.yaml
   - load-balancer.yaml
   - ingressroute-kafka-ui-k8s-private.yaml

--- a/argocd/applications/kafka/strimzi-kafka-cluster.yaml
+++ b/argocd/applications/kafka/strimzi-kafka-cluster.yaml
@@ -7,6 +7,8 @@ metadata:
     argocd.argoproj.io/sync-options: Replace=true
     strimzi.io/node-pools: enabled
     strimzi.io/kraft: enabled
+    # Freeze the legacy cluster while the local-controller replacement is built and validated.
+    strimzi.io/pause-reconciliation: "true"
 spec:
   kafka:
     version: 4.2.0

--- a/argocd/applications/kafka/strimzi-kafka-cluster.yaml
+++ b/argocd/applications/kafka/strimzi-kafka-cluster.yaml
@@ -4,6 +4,7 @@ metadata:
   name: kafka
   namespace: kafka
   annotations:
+    argocd.argoproj.io/sync-wave: "-1"
     argocd.argoproj.io/sync-options: Replace=true
     strimzi.io/node-pools: enabled
     strimzi.io/kraft: enabled


### PR DESCRIPTION
## Summary

- Pin every Strimzi installation manifest at 1.1.0 while preserving the all-namespace watch and existing RBAC patches.
- Keep the legacy Kafka cluster on Kafka 4.2.0 with metadata 4.2-IV1.
- Pause legacy-cluster reconciliation so the operator upgrade cannot roll its Ceph-backed controllers while the parallel replacement is built.

## Related Issues

None

## Testing

- `nix develop --command bash -lc 'kustomize build --enable-helm argocd/applications/kafka > /tmp/kafka-operator-1-1-rendered.yaml'`
- `kubectl apply --server-side --force-conflicts --dry-run=server -f /tmp/kafka-operator-1-1-rendered.yaml`
- `bun run lint:argocd`
- Compared rendered resource identities against fresh `origin/main`; no resources were added or removed.
- Confirmed the render contains zero `Namespace` objects, operator image `quay.io/strimzi/operator:1.1.0`, Kafka `4.2.0`, and `strimzi.io/pause-reconciliation: "true"`.
- `git diff --check`

## Breaking Changes

None. Kafka client endpoints, credentials, topics, Kafka version, and metadata version are unchanged. Legacy Kafka reconciliation remains intentionally paused until replacement-cluster cutover.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
