### PR TITLE
feat(kafka): add parallel 4.3 replacement

### DIFF
--- a/argocd/applications/kafka-next/kafka-cluster.yaml
+++ b/argocd/applications/kafka-next/kafka-cluster.yaml
@@ -1,0 +1,112 @@
+apiVersion: kafka.strimzi.io/v1
+kind: Kafka
+metadata:
+  name: kafka-next
+  annotations:
+    argocd.argoproj.io/sync-options: Replace=true
+    strimzi.io/kraft: enabled
+    strimzi.io/node-pools: enabled
+spec:
+  kafka:
+    version: 4.3.0
+    metadataVersion: "4.2-IV1"
+    listeners:
+      - name: plain
+        port: 9092
+        type: internal
+        tls: false
+        authentication:
+          type: scram-sha-512
+      - name: plain2
+        port: 9093
+        type: internal
+        tls: false
+      - name: phingest
+        port: 9094
+        type: internal
+        tls: true
+    config:
+      default.replication.factor: 3
+      min.insync.replicas: 2
+      offsets.topic.replication.factor: 3
+      transaction.state.log.min.isr: 2
+      transaction.state.log.replication.factor: 3
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}
+---
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaNodePool
+metadata:
+  name: controllers
+  labels:
+    strimzi.io/cluster: kafka-next
+spec:
+  replicas: 3
+  roles:
+    - controller
+  template:
+    pod:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  strimzi.io/cluster: kafka-next
+                  strimzi.io/pool-name: controllers
+              topologyKey: kubernetes.io/hostname
+      topologySpreadConstraints:
+        - labelSelector:
+            matchLabels:
+              strimzi.io/cluster: kafka-next
+              strimzi.io/pool-name: controllers
+          maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+  resources:
+    requests:
+      cpu: "2000m"
+      memory: 4Gi
+  storage:
+    type: persistent-claim
+    class: local-path
+    size: 30Gi
+    deleteClaim: false
+---
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaNodePool
+metadata:
+  name: brokers
+  labels:
+    strimzi.io/cluster: kafka-next
+spec:
+  replicas: 3
+  roles:
+    - broker
+  template:
+    pod:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  strimzi.io/cluster: kafka-next
+                  strimzi.io/pool-name: brokers
+              topologyKey: kubernetes.io/hostname
+      topologySpreadConstraints:
+        - labelSelector:
+            matchLabels:
+              strimzi.io/cluster: kafka-next
+              strimzi.io/pool-name: brokers
+          maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+  resources:
+    requests:
+      cpu: "2000m"
+      memory: 4Gi
+  storage:
+    type: persistent-claim
+    class: rook-ceph-block
+    size: 200Gi
+    deleteClaim: false

--- a/argocd/applications/kafka-next/kafka-users.yaml
+++ b/argocd/applications/kafka-next/kafka-users.yaml
@@ -1,0 +1,152 @@
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaUser
+metadata:
+  name: user1
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  labels:
+    strimzi.io/cluster: kafka-next
+spec:
+  authentication:
+    type: scram-sha-512
+    password:
+      valueFrom:
+        secretKeyRef:
+          name: user1-source
+          key: password
+---
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaUser
+metadata:
+  name: karapace
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  labels:
+    strimzi.io/cluster: kafka-next
+spec:
+  authentication:
+    type: scram-sha-512
+    password:
+      valueFrom:
+        secretKeyRef:
+          name: karapace-source
+          key: password
+---
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaUser
+metadata:
+  name: facteur
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  labels:
+    strimzi.io/cluster: kafka-next
+spec:
+  authentication:
+    type: scram-sha-512
+    password:
+      valueFrom:
+        secretKeyRef:
+          name: facteur-source
+          key: password
+---
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaUser
+metadata:
+  name: kafka-codex-credentials
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  labels:
+    strimzi.io/cluster: kafka-next
+spec:
+  authentication:
+    type: scram-sha-512
+    password:
+      valueFrom:
+        secretKeyRef:
+          name: kafka-codex-credentials-source
+          key: password
+---
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaUser
+metadata:
+  name: froussard
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  labels:
+    strimzi.io/cluster: kafka-next
+spec:
+  authentication:
+    type: scram-sha-512
+    password:
+      valueFrom:
+        secretKeyRef:
+          name: froussard-source
+          key: password
+---
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaUser
+metadata:
+  name: flink
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  labels:
+    strimzi.io/cluster: kafka-next
+spec:
+  authentication:
+    type: scram-sha-512
+    password:
+      valueFrom:
+        secretKeyRef:
+          name: flink-source
+          key: password
+---
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaUser
+metadata:
+  name: torghut-hyperliquid-feed
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  labels:
+    strimzi.io/cluster: kafka-next
+spec:
+  authentication:
+    type: scram-sha-512
+    password:
+      valueFrom:
+        secretKeyRef:
+          name: torghut-hyperliquid-feed-source
+          key: password
+---
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaUser
+metadata:
+  name: torghut-options
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  labels:
+    strimzi.io/cluster: kafka-next
+spec:
+  authentication:
+    type: scram-sha-512
+    password:
+      valueFrom:
+        secretKeyRef:
+          name: torghut-options-source
+          key: password
+---
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaUser
+metadata:
+  name: torghut-ws
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  labels:
+    strimzi.io/cluster: kafka-next
+spec:
+  authentication:
+    type: scram-sha-512
+    password:
+      valueFrom:
+        secretKeyRef:
+          name: torghut-ws-source
+          key: password

--- a/argocd/applications/kafka-next/kustomization.yaml
+++ b/argocd/applications/kafka-next/kustomization.yaml
@@ -7,3 +7,32 @@ resources:
   - source-credential-reflections.yaml
   - kafka-users.yaml
   - mirror-maker-2.yaml
+patches:
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: RoleBinding
+      name: strimzi-cluster-operator
+    patch: |-
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: strimzi-cluster-operator
+      subjects:
+        - kind: ServiceAccount
+          name: strimzi-cluster-operator
+          namespace: kafka
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: RoleBinding
+      name: strimzi-cluster-operator-entity-operator-delegation
+    patch: |-
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: strimzi-cluster-operator-entity-operator-delegation
+      subjects:
+        - kind: ServiceAccount
+          name: strimzi-cluster-operator
+          namespace: kafka

--- a/argocd/applications/kafka-next/kustomization.yaml
+++ b/argocd/applications/kafka-next/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kafka-next
+resources:
+  - rbac.yaml
+  - kafka-cluster.yaml
+  - source-credential-reflections.yaml
+  - kafka-users.yaml
+  - mirror-maker-2.yaml

--- a/argocd/applications/kafka-next/mirror-maker-2.yaml
+++ b/argocd/applications/kafka-next/mirror-maker-2.yaml
@@ -62,5 +62,5 @@ spec:
           replication.policy.class: org.apache.kafka.connect.mirror.IdentityReplicationPolicy
           sync.group.offsets.enabled: "true"
           sync.group.offsets.interval.seconds: 10
-      topicsPattern: '^(?!torghut\.sim\..*\.sim_).*$'
+      topicsPattern: '^(?!torghut\.sim\..*\.(?:options_)?sim_).*$'
       groupsPattern: ".*"

--- a/argocd/applications/kafka-next/mirror-maker-2.yaml
+++ b/argocd/applications/kafka-next/mirror-maker-2.yaml
@@ -1,0 +1,65 @@
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaMirrorMaker2
+metadata:
+  name: kafka-next-mirror
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  version: 4.3.0
+  replicas: 2
+  resources:
+    requests:
+      cpu: "500m"
+      memory: 1Gi
+    limits:
+      cpu: "2000m"
+      memory: 4Gi
+  template:
+    pod:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  strimzi.io/cluster: kafka-next-mirror
+              topologyKey: kubernetes.io/hostname
+  target:
+    alias: target
+    bootstrapServers: kafka-next-kafka-bootstrap.kafka-next.svc:9093
+    groupId: kafka-next-mirror
+    configStorageTopic: __kafka-next-mirror-config
+    offsetStorageTopic: __kafka-next-mirror-offset
+    statusStorageTopic: __kafka-next-mirror-status
+    config:
+      config.storage.replication.factor: 3
+      offset.storage.replication.factor: 3
+      status.storage.replication.factor: 3
+      plugin.discovery: service_load
+  mirrors:
+    - source:
+        alias: source
+        bootstrapServers: kafka-kafka-bootstrap.kafka.svc:9093
+      sourceConnector:
+        tasksMax: 4
+        config:
+          replication.factor: 3
+          offset-syncs.topic.replication.factor: 3
+          offset-syncs.topic.location: target
+          refresh.topics.interval.seconds: 30
+          replication.policy.class: org.apache.kafka.connect.mirror.IdentityReplicationPolicy
+          sync.topic.acls.enabled: "false"
+          sync.topic.configs.enabled: "true"
+          sync.topic.configs.interval.seconds: 30
+      checkpointConnector:
+        tasksMax: 4
+        config:
+          checkpoints.topic.replication.factor: 3
+          emit.checkpoints.enabled: "true"
+          emit.checkpoints.interval.seconds: 10
+          offset-syncs.topic.location: target
+          refresh.groups.interval.seconds: 30
+          replication.policy.class: org.apache.kafka.connect.mirror.IdentityReplicationPolicy
+          sync.group.offsets.enabled: "true"
+          sync.group.offsets.interval.seconds: 10
+      topicsPattern: '^(?!torghut\.sim\..*\.sim_).*$'
+      groupsPattern: ".*"

--- a/argocd/applications/kafka-next/mirror-maker-2.yaml
+++ b/argocd/applications/kafka-next/mirror-maker-2.yaml
@@ -42,6 +42,7 @@ spec:
       sourceConnector:
         tasksMax: 4
         config:
+          emit.offset-syncs.enabled: "true"
           replication.factor: 3
           offset-syncs.topic.replication.factor: 3
           offset-syncs.topic.location: target

--- a/argocd/applications/kafka-next/rbac.yaml
+++ b/argocd/applications/kafka-next/rbac.yaml
@@ -1,0 +1,33 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: strimzi-cluster-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  labels:
+    app: strimzi
+subjects:
+  - kind: ServiceAccount
+    name: strimzi-cluster-operator
+    namespace: kafka
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: strimzi-cluster-operator-namespaced
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: strimzi-cluster-operator-entity-operator-delegation
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  labels:
+    app: strimzi
+subjects:
+  - kind: ServiceAccount
+    name: strimzi-cluster-operator
+    namespace: kafka
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: strimzi-entity-operator

--- a/argocd/applications/kafka-next/source-credential-reflections.yaml
+++ b/argocd/applications/kafka-next/source-credential-reflections.yaml
@@ -1,0 +1,71 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: user1-source
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+    reflector.v1.k8s.emberstack.com/reflects: kafka/user1
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: karapace-source
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+    reflector.v1.k8s.emberstack.com/reflects: kafka/karapace
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: facteur-source
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+    reflector.v1.k8s.emberstack.com/reflects: kafka/facteur
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kafka-codex-credentials-source
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+    reflector.v1.k8s.emberstack.com/reflects: kafka/kafka-codex-credentials
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: froussard-source
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+    reflector.v1.k8s.emberstack.com/reflects: kafka/froussard
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: flink-source
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+    reflector.v1.k8s.emberstack.com/reflects: kafka/flink
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: torghut-hyperliquid-feed-source
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+    reflector.v1.k8s.emberstack.com/reflects: kafka/torghut-hyperliquid-feed
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: torghut-options-source
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+    reflector.v1.k8s.emberstack.com/reflects: kafka/torghut-options
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: torghut-ws-source
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+    reflector.v1.k8s.emberstack.com/reflects: kafka/torghut-ws

--- a/argocd/applications/kafka/strimzi-kafka-cluster.yaml
+++ b/argocd/applications/kafka/strimzi-kafka-cluster.yaml
@@ -146,6 +146,12 @@ metadata:
 spec:
   authentication:
     type: scram-sha-512
+  template:
+    secret:
+      metadata:
+        annotations:
+          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "kafka-next"
 ---
 apiVersion: kafka.strimzi.io/v1
 kind: KafkaUser
@@ -157,6 +163,12 @@ metadata:
 spec:
   authentication:
     type: scram-sha-512
+  template:
+    secret:
+      metadata:
+        annotations:
+          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "kafka-next"
 ---
 apiVersion: kafka.strimzi.io/v1
 kind: KafkaUser
@@ -175,7 +187,7 @@ spec:
           kafka.eventing.knative.dev/kafka-secret: "true"
         annotations:
           reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "facteur"
+          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "facteur,kafka-next"
           reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
           reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "facteur"
 ---
@@ -196,7 +208,7 @@ spec:
           kafka.eventing.knative.dev/kafka-secret: "true"
         annotations:
           reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "agents,argo-workflows,jangar"
+          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "agents,argo-workflows,jangar,kafka-next"
           reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
           reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "agents,argo-workflows,jangar"
 ---
@@ -217,7 +229,7 @@ spec:
           kafka.eventing.knative.dev/kafka-secret: "true"
         annotations:
           reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "froussard"
+          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "froussard,kafka-next"
           reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
           reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "froussard"
 ---
@@ -238,6 +250,6 @@ spec:
           kafka.eventing.knative.dev/kafka-secret: "true"
         annotations:
           reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "flink"
+          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "flink,kafka-next"
           reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
           reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "flink"

--- a/argocd/applications/kafka/torghut-hyperliquid-feed-kafkauser.yaml
+++ b/argocd/applications/kafka/torghut-hyperliquid-feed-kafkauser.yaml
@@ -13,6 +13,6 @@ spec:
       metadata:
         annotations:
           reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "torghut"
+          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "torghut,kafka-next"
           reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
           reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "torghut"

--- a/argocd/applications/kafka/torghut-options-kafkauser.yaml
+++ b/argocd/applications/kafka/torghut-options-kafkauser.yaml
@@ -13,6 +13,6 @@ spec:
       metadata:
         annotations:
           reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "torghut"
+          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "torghut,kafka-next"
           reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
           reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "torghut"

--- a/argocd/applications/kafka/torghut-ws-kafkauser.yaml
+++ b/argocd/applications/kafka/torghut-ws-kafkauser.yaml
@@ -13,6 +13,6 @@ spec:
       metadata:
         annotations:
           reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "torghut"
+          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "torghut,kafka-next"
           reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
           reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "torghut"

--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -297,6 +297,16 @@ spec:
                   argocd.argoproj.io/sync-wave: "2"
                 automation: auto
                 enabled: "true"
+              - name: kafka-next
+                path: argocd/applications/kafka-next
+                namespace: kafka-next
+                annotations:
+                  argocd.argoproj.io/sync-wave: "3"
+                automation: auto
+                enabled: "true"
+                managedNamespaceMetadata:
+                  annotations:
+                    argocd.argoproj.io/sync-options: Prune=false
               - name: nats
                 path: argocd/applications/nats
                 namespace: nats

--- a/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
+++ b/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
@@ -30,14 +30,22 @@ const entry = (name: string) => {
 
 describe('enabled app inventory', () => {
   it('loads only root-enabled ApplicationSet entries plus direct root-managed Applications', () => {
-    expect(inventory.applicationSetEntryCount).toBe(68)
+    expect(inventory.applicationSetEntryCount).toBe(69)
     expect(inventory.directApplicationCount).toBe(1)
-    expect(inventory.entries).toHaveLength(69)
+    expect(inventory.entries).toHaveLength(70)
     expect(inventory.entries.some((candidate) => candidate.name === 'facteur')).toBe(false)
     expect(inventory.entries.some((candidate) => candidate.name === 'bonjour')).toBe(false)
     expect(inventory.entries.some((candidate) => candidate.name === 'olden')).toBe(false)
     expect(inventory.entries.some((candidate) => candidate.name === 'posthog')).toBe(false)
     expect(inventory.entries.some((candidate) => candidate.name === 'sag')).toBe(false)
+  })
+
+  it('classifies the parallel Kafka replacement as a vendor-managed manifest app', () => {
+    expect(entry('kafka-next')).toMatchObject({
+      class: 'vendor-manifest',
+      hasHelmChart: false,
+      repoImages: [],
+    })
   })
 
   it('records preservation intent when a product app is disabled', () => {


### PR DESCRIPTION
## Summary

- Add an isolated Kafka 4.3.0 replacement cluster pinned to `metadataVersion: 4.2-IV1`, with three local-path KRaft controllers and three 200 GiB Ceph-backed brokers.
- Register the `kafka-next` Argo CD application and grant the all-namespace Strimzi 1.1.0 operator only the namespaced permissions it needs to reconcile the replacement.
- Preserve all nine live SCRAM credentials through explicitly allowed reflector copies, without changing existing client secrets or bootstrap endpoints.
- Add a two-worker MirrorMaker 2 deployment that preserves topic names and consumer offsets while excluding the 92 unused historical `torghut.sim.*.sim_*` topics observed during preflight.
- Create new resources only; the legacy Kafka 4.2 data plane remains reconciliation-paused and continues serving production traffic.

## Related Issues

None.

## Testing

- `nix develop --command bash -lc 'kustomize build argocd/applications/kafka-next > /tmp/kafka-next-rendered.yaml && kustomize build --enable-helm argocd/applications/kafka > /tmp/kafka-source-rendered.yaml'`
- Verified the replacement render contains 24 resources, zero `Namespace` objects, Kafka 4.3.0 with metadata 4.2-IV1, local-path controllers, and 200 GiB Ceph brokers.
- `yq '(.metadata.namespace) = "default"' /tmp/kafka-next-rendered.yaml | kubectl apply --server-side --force-conflicts --dry-run=server -f -`
- `yq eval-all 'select(.kind == "KafkaUser")' /tmp/kafka-source-rendered.yaml | kubectl apply --server-side --force-conflicts --dry-run=server -f -`
- `bun run lint:argocd` (zero invalid resources)
- `bun test packages/scripts/src/shared/__tests__/enabled-apps.test.ts` (19 passed)
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/enabled-apps.test.ts`
- `git diff --check`
- Live preflight confirmed nine source Kafka users, 139 topics, 92 excluded historical simulation topics, and zero lag on the only active consumer group.

## Screenshots (if applicable)

N/A; this is a GitOps infrastructure change.

## Breaking Changes

None. This PR does not change client endpoints or finalize the metadata feature level.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] The staged client cutover and metadata finalization remain separate rollout PRs after live mirror validation.
