### PR TITLE
fix(torghut): idle stalled TA watermarks

### DIFF
--- a/argocd/applications/torghut/ta-sim/configmap.yaml
+++ b/argocd/applications/torghut/ta-sim/configmap.yaml
@@ -25,6 +25,7 @@ data:
   TA_CHECKPOINT_TIMEOUT_MS: "300000"
   TA_CHECKPOINT_PAUSE_MS: "10000"
   TA_MAX_OUT_OF_ORDER_MS: "2000"
+  TA_WATERMARK_IDLE_TIMEOUT_MS: "30000"
   # IEX quote cadence can be sparse for the capped chip universe; keep TA quotes
   # fresh enough for execution gates without admitting overnight/stale state.
   TA_QUOTE_STALE_AFTER_MS: "15000"

--- a/argocd/applications/torghut/ta/configmap.yaml
+++ b/argocd/applications/torghut/ta/configmap.yaml
@@ -25,6 +25,7 @@ data:
   TA_CHECKPOINT_TIMEOUT_MS: "300000"
   TA_CHECKPOINT_PAUSE_MS: "10000"
   TA_MAX_OUT_OF_ORDER_MS: "2000"
+  TA_WATERMARK_IDLE_TIMEOUT_MS: "30000"
   # IEX quote cadence can be sparse for the capped chip universe; keep TA quotes
   # fresh enough for execution gates without admitting overnight/stale state.
   TA_QUOTE_STALE_AFTER_MS: "15000"

--- a/services/dorvud/technical-analysis-flink/src/main/kotlin/ai/proompteng/dorvud/ta/flink/FlinkTaConfig.kt
+++ b/services/dorvud/technical-analysis-flink/src/main/kotlin/ai/proompteng/dorvud/ta/flink/FlinkTaConfig.kt
@@ -28,6 +28,7 @@ data class FlinkTaConfig(
   val checkpointTimeoutMs: Long,
   val minPauseBetweenCheckpointsMs: Long,
   val maxOutOfOrderMs: Long,
+  val watermarkIdleTimeoutMs: Long,
   val quoteStaleAfterMs: Long,
   val sourceLagDegradedAfterMs: Long,
   val marketHolidays: Set<LocalDate>,
@@ -136,6 +137,10 @@ data class FlinkTaConfig(
         checkpointTimeoutMs = envLong("TA_CHECKPOINT_TIMEOUT_MS", 120_000),
         minPauseBetweenCheckpointsMs = envLong("TA_CHECKPOINT_PAUSE_MS", 5_000),
         maxOutOfOrderMs = envLong("TA_MAX_OUT_OF_ORDER_MS", 2_000),
+        watermarkIdleTimeoutMs =
+          normalizeWatermarkIdleTimeoutMs(
+            envLong("TA_WATERMARK_IDLE_TIMEOUT_MS", DEFAULT_WATERMARK_IDLE_TIMEOUT_MS),
+          ),
         quoteStaleAfterMs = quoteStaleAfterMs,
         sourceLagDegradedAfterMs = sourceLagDegradedAfterMs,
         marketHolidays =
@@ -181,6 +186,10 @@ data class FlinkTaConfig(
     }
   }
 }
+
+internal const val DEFAULT_WATERMARK_IDLE_TIMEOUT_MS: Long = 30_000
+
+internal fun normalizeWatermarkIdleTimeoutMs(value: Long): Long = value.coerceAtLeast(1_000)
 
 private val DEFAULT_US_EQUITY_MARKET_HOLIDAYS: Set<LocalDate> =
   setOf(

--- a/services/dorvud/technical-analysis-flink/src/main/kotlin/ai/proompteng/dorvud/ta/flink/FlinkTechnicalAnalysisJob.kt
+++ b/services/dorvud/technical-analysis-flink/src/main/kotlin/ai/proompteng/dorvud/ta/flink/FlinkTechnicalAnalysisJob.kt
@@ -458,6 +458,7 @@ private fun applyS3SystemProperties(config: FlinkTaConfig) {
 private fun <T> watermarkStrategy(config: FlinkTaConfig): WatermarkStrategy<Envelope<T>> =
   WatermarkStrategy
     .forBoundedOutOfOrderness<Envelope<T>>(Duration.ofMillis(config.maxOutOfOrderMs))
+    .withIdleness(Duration.ofMillis(config.watermarkIdleTimeoutMs))
     .withTimestampAssigner(SerializableTimestampAssigner<Envelope<T>> { event, _ -> event.eventTs.toEpochMilli() })
 
 private fun <T> emptyWatermarks(): WatermarkStrategy<T> = WatermarkStrategy.noWatermarks()

--- a/services/dorvud/technical-analysis-flink/src/test/kotlin/ai/proompteng/dorvud/ta/flink/SerializationSchemasTest.kt
+++ b/services/dorvud/technical-analysis-flink/src/test/kotlin/ai/proompteng/dorvud/ta/flink/SerializationSchemasTest.kt
@@ -130,6 +130,16 @@ class SerializationSchemasTest {
   }
 
   @Test
+  fun `watermark idle timeout is bounded away from zero`() {
+    assertEquals(1_000, normalizeWatermarkIdleTimeoutMs(0))
+    assertEquals(1_000, normalizeWatermarkIdleTimeoutMs(999))
+    assertEquals(
+      DEFAULT_WATERMARK_IDLE_TIMEOUT_MS,
+      normalizeWatermarkIdleTimeoutMs(DEFAULT_WATERMARK_IDLE_TIMEOUT_MS),
+    )
+  }
+
+  @Test
   fun `clickhouse insert batch size is capped to safe ceiling`() {
     assertEquals(1, normalizeClickhouseInsertBatchSize(0))
     assertEquals(64, normalizeClickhouseInsertBatchSize(64))


### PR DESCRIPTION
## Summary

- Mark inactive TA Kafka inputs idle so quiet partitions no longer pin the operator watermark.
- Add a bounded `TA_WATERMARK_IDLE_TIMEOUT_MS` setting with a 30-second default.
- Configure the live and simulation TA deployments explicitly.
- Add regression coverage for idle-timeout normalization.

## Related Issues

Follow-up to Codex review on #1945.

## Testing

- `git diff --check`
- Gradle module validation is delegated to CI because this agents-shell image has no JDK/`java` executable.

## Breaking Changes

None.
