### PR TITLE
fix(temporal-bun-sdk): harden guardrails

### DIFF
--- a/.github/workflows/temporal-bun-sdk.yml
+++ b/.github/workflows/temporal-bun-sdk.yml
@@ -371,7 +371,7 @@ jobs:
         run: |
           set -euo pipefail
           branch="release-please--branches--main--components--temporal-bun-sdk"
-          pr_number=$(gh pr list --head "$branch" --state merged --limit 1 --json number --jq '.[0].number')
+          pr_number=$(gh pr list --head "$branch" --state merged --limit 1 --json number --jq '.[0].number // empty')
           if [[ -n "$pr_number" ]]; then
             if gh pr edit "$pr_number" --remove-label "autorelease: pending" --add-label "autorelease: tagged"; then
               echo "Updated labels on release PR #$pr_number"

--- a/.github/workflows/temporal-static-libraries.yml
+++ b/.github/workflows/temporal-static-libraries.yml
@@ -14,6 +14,7 @@ on:
         type: boolean
 
 permissions:
+  actions: write
   contents: write
 
 jobs:

--- a/packages/scripts/src/shared/__tests__/temporal-static-libraries-workflow.test.ts
+++ b/packages/scripts/src/shared/__tests__/temporal-static-libraries-workflow.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { repoRoot } from '../cli'
+
+test('Temporal static library workflow preserves artifact permissions', () => {
+  const workflow = readFileSync(join(repoRoot, '.github/workflows/temporal-static-libraries.yml'), 'utf8')
+  const permissions = workflow.match(/\npermissions:\n([\s\S]*?)\n\njobs:/)?.[1]
+
+  expect(permissions).toContain('actions: write')
+  expect(permissions).toContain('contents: write')
+  expect(workflow).toContain('actions/upload-artifact@v5')
+  expect(workflow).toContain('actions/download-artifact@v6')
+})

--- a/packages/scripts/src/shared/__tests__/temporal-static-libraries-workflow.test.ts
+++ b/packages/scripts/src/shared/__tests__/temporal-static-libraries-workflow.test.ts
@@ -13,3 +13,10 @@ test('Temporal static library workflow preserves artifact permissions', () => {
   expect(workflow).toContain('actions/upload-artifact@v5')
   expect(workflow).toContain('actions/download-artifact@v6')
 })
+
+test('Temporal package release skips label updates when no release PR is found', () => {
+  const workflow = readFileSync(join(repoRoot, '.github/workflows/temporal-bun-sdk.yml'), 'utf8')
+
+  expect(workflow).toContain("--jq '.[0].number // empty'")
+  expect(workflow).toContain('if [[ -n "$pr_number" ]]; then')
+})

--- a/packages/temporal-bun-sdk/src/bin/lint-workflows-command.ts
+++ b/packages/temporal-bun-sdk/src/bin/lint-workflows-command.ts
@@ -142,7 +142,15 @@ const listChangedFiles = async (cwdPath: string): Promise<Set<string>> => {
     stdout: 'pipe',
     stderr: 'pipe',
   })
-  const text = await new Response(child.stdout).text()
+  const [exitCode, text, errorText] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ])
+  if (exitCode !== 0) {
+    const detail = errorText.trim() || `git diff exited with code ${exitCode}`
+    throw new WorkflowLintCommandError(`Unable to determine changed workflow files: ${detail}`)
+  }
   const files = text
     .split('\n')
     .map((line) => line.trim())

--- a/packages/temporal-bun-sdk/src/client/serialization.ts
+++ b/packages/temporal-bun-sdk/src/client/serialization.ts
@@ -431,7 +431,7 @@ const serializeRetryPolicy = (policy?: RetryPolicyOptions): RetryPolicy | undefi
 
   return create(RetryPolicySchema, {
     initialInterval: toDuration(policy.initialIntervalMs),
-    backoffCoefficient: policy.backoffCoefficient ?? 0,
+    backoffCoefficient: policy.backoffCoefficient ?? 2,
     maximumInterval: toDuration(policy.maximumIntervalMs),
     maximumAttempts: policy.maximumAttempts ?? 0,
     nonRetryableErrorTypes: policy.nonRetryableErrorTypes ?? [],

--- a/packages/temporal-bun-sdk/src/index.ts
+++ b/packages/temporal-bun-sdk/src/index.ts
@@ -21,6 +21,7 @@ export {
   TemporalTlsHandshakeError,
   temporalCallOptions,
 } from './client'
+export * from './common'
 export { createTemporalClientLayer, TemporalClientLayer, TemporalClientService } from './client/layer'
 export type { TemporalRpcRetryPolicy } from './client/retries'
 export type {
@@ -58,6 +59,7 @@ export {
   TemporalTestServerUnavailableError,
   TestWorkflowEnvironment,
 } from './testing'
+export * from './worker'
 export {
   createWorkerRuntimeLayer,
   makeWorkerRuntimeEffect,
@@ -68,3 +70,4 @@ export {
 export type { WorkerPlugin, WorkerPluginContext } from './worker/plugins'
 export type { WorkerTuner } from './worker/tuner'
 export { createStaticWorkerTuner } from './worker/tuner'
+export * from './workflow'

--- a/packages/temporal-bun-sdk/src/workflow/guards.ts
+++ b/packages/temporal-bun-sdk/src/workflow/guards.ts
@@ -587,7 +587,7 @@ export const installWorkflowRuntimeGuards = (options: { mode: WorkflowGuardsMode
   if (typeof originalWebSocket === 'function') {
     globalRef[ORIGINAL_WEBSOCKET_SYMBOL] = originalWebSocket
     // biome-ignore lint/complexity/useArrowFunction: must remain constructable (usable with `new`)
-    ;(globalThis as unknown as { WebSocket: unknown }).WebSocket = function (...args: unknown[]) {
+    const PatchedWebSocket = function (...args: unknown[]) {
       const ctx = currentWorkflowLogContext()
       if (!ctx) {
         handleViolation({
@@ -604,6 +604,11 @@ export const installWorkflowRuntimeGuards = (options: { mode: WorkflowGuardsMode
       })
       return new (originalWebSocket as unknown as new (...args: unknown[]) => unknown)(...args)
     }
+    ;(PatchedWebSocket as unknown as { prototype: unknown }).prototype = (
+      originalWebSocket as unknown as { prototype: unknown }
+    ).prototype
+    Object.setPrototypeOf(PatchedWebSocket, originalWebSocket)
+    ;(globalThis as unknown as { WebSocket: unknown }).WebSocket = PatchedWebSocket
   }
 
   const processRef = (globalThis as unknown as { process?: { env?: Record<string, string | undefined> } }).process

--- a/packages/temporal-bun-sdk/tests/cli/temporal-bun-lint-workflows.test.ts
+++ b/packages/temporal-bun-sdk/tests/cli/temporal-bun-lint-workflows.test.ts
@@ -205,3 +205,22 @@ test('lint-workflows fails on eval and Function constructors in workflow modules
     expect(result.violations.some((v) => v.rule === 'deny-global' && v.message.includes('Function'))).toBeTrue()
   })
 })
+
+test('lint-workflows changed-only mode fails closed when the merge-base ref is unavailable', async () => {
+  await withTempDir(async (dir) => {
+    const workflowsDir = join(dir, 'workflows')
+    await mkdir(workflowsDir, { recursive: true })
+    const entry = join(workflowsDir, 'index.ts')
+    await writeFile(entry, 'export const run = () => "ok"\n')
+
+    await expect(
+      executeLintWorkflows({
+        cwd: dir,
+        workflows: [entry],
+        mode: 'strict',
+        format: 'json',
+        changedOnly: true,
+      }),
+    ).rejects.toThrow('Unable to determine changed workflow files')
+  })
+})

--- a/packages/temporal-bun-sdk/tests/client/serialization.test.ts
+++ b/packages/temporal-bun-sdk/tests/client/serialization.test.ts
@@ -91,6 +91,27 @@ test('buildStartWorkflowRequest defaults to unversioned behavior', async () => {
   expect(request.versioningOverride).toBeUndefined()
 })
 
+test('buildStartWorkflowRequest preserves the server retry backoff default for partial policies', async () => {
+  const request = await buildStartWorkflowRequest(
+    {
+      options: {
+        workflowId: 'wf-partial-retry',
+        workflowType: 'exampleWorkflow',
+        retryPolicy: { maximumAttempts: 3 },
+      },
+      defaults: {
+        namespace: 'default',
+        identity: 'test-worker',
+        taskQueue: 'example',
+      },
+    },
+    dataConverter,
+  )
+
+  expect(request.retryPolicy?.maximumAttempts).toBe(3)
+  expect(request.retryPolicy?.backoffCoefficient).toBe(2)
+})
+
 test('buildStartWorkflowRequest preserves workflow ID reuse policy', async () => {
   const request = await buildStartWorkflowRequest(
     {

--- a/packages/temporal-bun-sdk/tests/root-exports.test.ts
+++ b/packages/temporal-bun-sdk/tests/root-exports.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from 'bun:test'
+
+import {
+  BunWorker,
+  createDefaultDataConverter,
+  createWorker,
+  defineWorkflow,
+  runWorker,
+  WorkflowRegistry,
+} from '../src'
+
+test('package root preserves worker, workflow, and common exports', () => {
+  expect(typeof BunWorker).toBe('function')
+  expect(typeof createWorker).toBe('function')
+  expect(typeof runWorker).toBe('function')
+  expect(typeof createDefaultDataConverter).toBe('function')
+  expect(typeof defineWorkflow).toBe('function')
+  expect(typeof WorkflowRegistry).toBe('function')
+})

--- a/packages/temporal-bun-sdk/tests/workflow/runtime-guards.test.ts
+++ b/packages/temporal-bun-sdk/tests/workflow/runtime-guards.test.ts
@@ -287,6 +287,20 @@ test('WebSocket constructor throws in strict mode when called from workflow code
   )
 })
 
+test('WebSocket guard preserves constructor prototype and static members when available', () => {
+  installWorkflowRuntimeGuards({ mode: 'strict' })
+  const globalRef = globalThis as unknown as Record<symbol, unknown>
+  const original = globalRef[Symbol.for('@proompteng/temporal-bun-sdk.original.WebSocket')] as
+    | (Function & { prototype?: unknown; OPEN?: unknown })
+    | undefined
+  const patched = (globalThis as unknown as { WebSocket?: Function & { prototype?: unknown; OPEN?: unknown } }).WebSocket
+  if (!original || !patched) return
+
+  expect(patched.prototype).toBe(original.prototype)
+  expect(Object.getPrototypeOf(patched)).toBe(original)
+  expect(patched.OPEN).toBe(original.OPEN)
+})
+
 test('Bun.spawn() throws in strict mode when called from workflow code', async () => {
   const { registry, executor } = makeExecutor()
   registry.register(


### PR DESCRIPTION
## Summary

- Preserve Temporal's default retry backoff when callers provide a partial workflow retry policy.
- Fail changed-only workflow linting closed when the git comparison cannot be resolved.
- Preserve WebSocket constructor prototype and static members while installing workflow nondeterminism guards.
- Add focused regressions for all three contracts.

## Related Issues

Follow-up to Codex reviews on #1686 and #2934.

## Testing

- TypeScript compilation for `packages/temporal-bun-sdk`
- 38 focused Bun tests
- Oxfmt
- Oxlint
- `git diff --check`

## Breaking Changes

None.
