### PR TITLE
chore(kafka): resume Strimzi reconciliation

### DIFF
--- a/argocd/applications/kafka/strimzi-kafka-cluster.yaml
+++ b/argocd/applications/kafka/strimzi-kafka-cluster.yaml
@@ -4,12 +4,9 @@ metadata:
   name: kafka
   namespace: kafka
   annotations:
-    argocd.argoproj.io/sync-wave: "-1"
     argocd.argoproj.io/sync-options: Replace=true
     strimzi.io/node-pools: enabled
     strimzi.io/kraft: enabled
-    # Freeze the legacy cluster while the local-controller replacement is built and validated.
-    strimzi.io/pause-reconciliation: "true"
 spec:
   kafka:
     version: 4.2.0


### PR DESCRIPTION
## Summary

- Remove the temporary Strimzi reconciliation pause from the existing `Kafka/kafka` resource.
- Remove the pause-only sync wave so the live Strimzi 1.1.0 operator can reconcile the existing Kafka 4.2.0 cluster normally.
- Keep Kafka binaries, metadata version, KRaft feature level, storage, listeners, replication policy, and controller containment settings unchanged.

## Related Issues

None

## Testing

- `nix develop --command bash -lc 'kustomize build --enable-helm argocd/applications/kafka > /tmp/kafka-inplace-rendered.yaml'`
- `kubectl apply --server-side --dry-run=server --field-manager=argocd-controller -n kafka -f /tmp/kafka-inplace-rendered.yaml`
- `bun run lint:argocd`
- Confirmed the rendered output has no `Namespace` resources or delete patches.
- Live preflight: Ceph `HEALTH_OK`; Kafka 139 topics / 565 partitions / zero under-replicated or offline partitions; three KRaft voters; metadata `4.2-IV1`; active consumer lag zero; Torghut feed `/readyz` reports `ready=true` and `kafka=true`.

## Breaking Changes

None. This resumes reconciliation and will roll the existing Kafka 4.2.0 pods to the Strimzi 1.1.0 image. Kafka 4.3.0 remains a separate follow-up after this rollout is stable.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked. The Kafka 4.3.0 binary and metadata upgrades remain separate staged PRs.
