### PR TITLE
fix(ansible): restore Rancher firewall playbook

### DIFF
--- a/ansible/playbooks/disable_firewall.yml
+++ b/ansible/playbooks/disable_firewall.yml
@@ -1,0 +1,16 @@
+---
+- name: Disable firewall
+  hosts: rancher_bootstrap
+  become: true
+  tasks:
+    - name: Stop UFW service
+      ansible.builtin.systemd:
+        name: ufw
+        state: stopped
+      ignore_errors: true
+
+    - name: Disable UFW service at boot
+      ansible.builtin.systemd:
+        name: ufw
+        enabled: false
+      ignore_errors: true

--- a/packages/scripts/src/shared/__tests__/ansible-playbook-imports.test.ts
+++ b/packages/scripts/src/shared/__tests__/ansible-playbook-imports.test.ts
@@ -1,0 +1,23 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { expect, test } from 'bun:test'
+
+const repoRoot = fileURLToPath(new URL('../../../../../', import.meta.url))
+const playbooksDir = resolve(repoRoot, 'ansible/playbooks')
+
+test('Ansible playbook imports resolve to tracked files', () => {
+  const playbooks = readdirSync(playbooksDir)
+    .filter((name) => name.endsWith('.yml') || name.endsWith('.yaml'))
+    .map((name) => resolve(playbooksDir, name))
+
+  for (const playbook of playbooks) {
+    const content = readFileSync(playbook, 'utf8')
+    const imports = content.matchAll(/^\s*(?:ansible\.builtin\.)?import_playbook:\s*['"]?([^'"\s#]+)['"]?/gm)
+
+    for (const [, target] of imports) {
+      expect(existsSync(resolve(dirname(playbook), target!))).toBeTrue()
+    }
+  }
+})


### PR DESCRIPTION
## Summary

- Restore the UFW shutdown/disable playbook still imported by `rancher2.yml`.
- Use fully-qualified Ansible modules.
- Add a repository-wide regression ensuring local `import_playbook` targets exist.

## Related Issues

Follow-up to Codex review on #1025.

## Testing

- Bun import-resolution regression
- Oxfmt
- Oxlint
- `git diff --check`

## Breaking Changes

None.
