### PR TITLE
fix(argocd): seal Dex password hash

### DIFF
--- a/.github/ci/impact-map.yml
+++ b/.github/ci/impact-map.yml
@@ -214,6 +214,7 @@ targets:
     paths:
       - packages/scripts/**
       - argocd/root.yaml
+      - argocd/applications/argocd/**
       - argocd/applicationsets/**
       - docs/runbooks/rook-ceph-client-ops-performance.md
       - docs/nix-enabled-app-build-performance-rollout-plan.md

--- a/.github/workflows/scripts-ci.yml
+++ b/.github/workflows/scripts-ci.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'packages/scripts/**'
       - 'argocd/root.yaml'
+      - 'argocd/applications/argocd/**'
       - 'argocd/applicationsets/**'
       - 'docs/runbooks/rook-ceph-client-ops-performance.md'
       - 'docs/nix-enabled-app-build-performance-rollout-plan.md'
@@ -15,6 +16,7 @@ on:
     paths:
       - 'packages/scripts/**'
       - 'argocd/root.yaml'
+      - 'argocd/applications/argocd/**'
       - 'argocd/applicationsets/**'
       - 'docs/runbooks/rook-ceph-client-ops-performance.md'
       - 'docs/nix-enabled-app-build-performance-rollout-plan.md'

--- a/argocd/applications/argocd/overlays/argocd-cm.yaml
+++ b/argocd/applications/argocd/overlays/argocd-cm.yaml
@@ -133,6 +133,6 @@ data:
         secretEnv: ARGO_WORKFLOWS_SSO_CLIENT_SECRET
     staticPasswords:
       - email: admin@proompteng.ai
-        hash: "$2b$10$ra1qX8LB233SZ/rgZ08n4eHlPfOpc5FMYAXYVN5csb6LPgg7VFUHq"
+        hashFromEnv: ARGO_WORKFLOWS_SSO_PASSWORD_HASH
         username: admin
         userID: 86c47abf-4b23-4818-9b4c-76a2d17e7c98

--- a/packages/scripts/src/ci/__tests__/impact-router.test.ts
+++ b/packages/scripts/src/ci/__tests__/impact-router.test.ts
@@ -83,6 +83,12 @@ describe('impact router', () => {
     expect(plan.validationTargets).toEqual(['kubeconform'])
   })
 
+  test('routes Argo CD application changes through scripts contract tests', () => {
+    const plan = selectImpactPlan(['argocd/applications/argocd/overlays/argocd-cm.yaml'], map)
+    expect(plan.validationTargets).toEqual(['argo-lint', 'kubeconform'])
+    expect(plan.delegatedWorkflows).toEqual(['scripts-ci'])
+  })
+
   test('keeps mixed service changes deterministic', () => {
     const plan = selectImpactPlan(['services/jangar/src/server.ts', 'services/torghut/src/main.py'], map)
     expect(plan.validationTargets).toEqual(['planner'])

--- a/packages/scripts/src/shared/__tests__/argocd-dex-sso.test.ts
+++ b/packages/scripts/src/shared/__tests__/argocd-dex-sso.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs'
+
+import { expect, test } from 'bun:test'
+
+const repoRoot = new URL('../../../../../', import.meta.url)
+const readRepoFile = (path: string): string => readFileSync(new URL(path, repoRoot), 'utf8')
+
+test('Argo CD Dex reads the static password hash from the sealed secret environment', () => {
+  const config = readRepoFile('argocd/applications/argocd/overlays/argocd-cm.yaml')
+  const deployment = readRepoFile('argocd/applications/argocd/overlays/argocd-dex-server-deployment.yaml')
+  const secret = readRepoFile('argocd/applications/argocd/base/argo-workflows-sso-sealedsecret.yaml')
+
+  expect(config).toContain('hashFromEnv: ARGO_WORKFLOWS_SSO_PASSWORD_HASH')
+  expect(config).not.toMatch(/\bhash:\s*["']?\$2[aby]\$/)
+  expect(deployment).toContain('name: ARGO_WORKFLOWS_SSO_PASSWORD_HASH')
+  expect(deployment).toContain('key: hash')
+  expect(secret).toMatch(/^\s+hash:\s+Ag/m)
+})


### PR DESCRIPTION
## Summary

- Replace the committed Dex bcrypt hash with Dex's supported `hashFromEnv` field.
- Reuse the existing `ARGO_WORKFLOWS_SSO_PASSWORD_HASH` environment variable sourced from the sealed `argo-workflows-sso` Secret.
- Add a regression that forbids committed bcrypt hashes and verifies the complete sealed-secret wiring.

## Related Issues

Follow-up to Codex reviews on #1100 and #1102.

## Testing

- Bun Dex SSO contract test
- Oxfmt
- Oxlint
- `git diff --check`
- Verified bundled Dex v2.43.0 supports `hashFromEnv`

## Breaking Changes

None.
