### PR TITLE
chore(kafka): upgrade brokers to 4.3.0

### DIFF
--- a/argocd/applications/kafka/strimzi-kafka-cluster.yaml
+++ b/argocd/applications/kafka/strimzi-kafka-cluster.yaml
@@ -9,7 +9,8 @@ metadata:
     strimzi.io/kraft: enabled
 spec:
   kafka:
-    version: 4.2.0
+    version: 4.3.0
+    metadataVersion: "4.2-IV1"
     listeners:
       - name: plain
         port: 9092


### PR DESCRIPTION
## Summary

- Upgrade the existing `Kafka/kafka` cluster binaries from Kafka 4.2.0 to 4.3.0.
- Pin `metadataVersion` to `4.2-IV1` so the binary rollout remains rollback-compatible with Kafka 4.2.0.
- Keep the existing cluster identity, KRaft feature level, node pools, storage, listeners, credentials, replication settings, and endpoints unchanged.

## Related Issues

None

## Testing

- `nix develop --command bash -lc 'kustomize build --enable-helm argocd/applications/kafka > /tmp/kafka-4.3-inplace-rendered.yaml'`
- `kubectl apply --server-side --dry-run=server --force-conflicts --field-manager=argocd-controller -n kafka -f /tmp/kafka-4.3-inplace-rendered.yaml`
- `bun run lint:argocd`
- Confirmed the rendered `Kafka/kafka` resource has `version: 4.3.0`, `metadataVersion: 4.2-IV1`, and unchanged `kraft.version` behavior.
- Confirmed the rendered output has no `Namespace` resources or delete patches.

## Breaking Changes

This causes a rolling binary upgrade of the existing Kafka cluster. Metadata remains at `4.2-IV1`; finalizing to `4.3-IV0` is intentionally excluded because that would prohibit rollback to Kafka 4.2.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked. Metadata finalization remains a separate staged change after the binary soak.
