### PR TITLE
fix(jangar): ingest review thread webhooks

### DIFF
--- a/services/jangar/src/server/__tests__/github-review-ingest.test.ts
+++ b/services/jangar/src/server/__tests__/github-review-ingest.test.ts
@@ -154,6 +154,81 @@ describe('github review ingest', () => {
     expect(store.updateUnresolvedThreadCount).toHaveBeenCalled()
   })
 
+  it.each([
+    { action: 'resolved', resolved: true, unresolvedCount: 0 },
+    { action: 'unresolved', resolved: false, unresolvedCount: 1 },
+  ])('updates review thread resolution for $action webhooks', async ({ action, resolved, unresolvedCount }) => {
+    const handler = await requireHandler()
+    const store = requireStore()
+    ;(store.getUnresolvedThreadCount as ReturnType<typeof vi.fn>).mockResolvedValueOnce(unresolvedCount)
+
+    const payload: GithubWebhookEvent = {
+      event: 'pull_request_review_thread',
+      action,
+      deliveryId: `delivery-thread-${action}`,
+      repository: 'proompteng/lab',
+      sender: 'reviewer',
+      payload: {
+        pull_request: {
+          number: 123,
+          head: { sha: 'deadbeef' },
+          base: { repo: { full_name: 'proompteng/lab' } },
+        },
+        repository: { full_name: 'proompteng/lab' },
+        thread: {
+          node_id: 'PRRT_thread_node',
+          comments: [
+            {
+              id: 556,
+              in_reply_to_id: 555,
+              path: 'services/jangar/src/server/db.ts',
+              line: 12,
+              body: 'Follow-up',
+              user: { login: 'reviewer' },
+            },
+            {
+              id: 555,
+              path: 'services/jangar/src/server/db.ts',
+              line: 10,
+              body: 'Root review comment',
+              user: { login: 'reviewer' },
+            },
+          ],
+        },
+      },
+    }
+
+    const result = await handler(payload)
+
+    expect(result.ok).toBe(true)
+    expect(store.upsertReviewThread).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repository: 'proompteng/lab',
+        prNumber: 123,
+        commitSha: 'deadbeef',
+        threadKey: '555',
+        threadId: 'PRRT_thread_node',
+        isResolved: resolved,
+      }),
+    )
+    expect(store.updateThreadResolution).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repository: 'proompteng/lab',
+        prNumber: 123,
+        threadKey: '555',
+        threadId: 'PRRT_thread_node',
+        resolved,
+      }),
+    )
+    expect(store.updateUnresolvedThreadCount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repository: 'proompteng/lab',
+        prNumber: 123,
+        count: unresolvedCount,
+      }),
+    )
+  })
+
   it('skips duplicate delivery ids', async () => {
     const handler = await requireHandler()
     const store = requireStore()

--- a/services/jangar/src/server/github-review-ingest.ts
+++ b/services/jangar/src/server/github-review-ingest.ts
@@ -378,6 +378,36 @@ const buildReviewThread = (
   }
 }
 
+const buildReviewThreadResolution = (
+  payload: Record<string, unknown>,
+  action: string | null,
+  receivedAt: string,
+): GithubReviewThread | null => {
+  if (!isRecord(payload.thread) || !Array.isArray(payload.thread.comments)) return null
+  const resolved = action === 'resolved' ? true : action === 'unresolved' ? false : null
+  if (resolved === null) return null
+
+  const comments = payload.thread.comments.filter(isRecord)
+  const rootComment = comments.find(
+    (comment) => comment.in_reply_to_id === null || comment.in_reply_to_id === undefined,
+  )
+  const fallbackComment = comments[0]
+  const comment = rootComment ?? fallbackComment
+  if (!comment) return null
+
+  const threadKey = normalizeString(comment.id) || String(comment.id ?? '')
+  if (!threadKey) return null
+  const threadId = normalizeString(payload.thread.node_id) || null
+  const thread = buildReviewThread({ comment }, threadKey, receivedAt)
+  if (!thread) return null
+
+  return {
+    ...thread,
+    threadId,
+    isResolved: resolved,
+  }
+}
+
 const buildReviewComment = (payload: Record<string, unknown>, receivedAt: string): GithubReviewComment | null => {
   if (!isRecord(payload.comment)) return null
   const comment = payload.comment
@@ -603,6 +633,35 @@ export const ingestGithubReviewEvent = async (input: GithubWebhookEvent): Promis
       count: unresolvedThreadsCount,
       receivedAt,
     })
+  }
+
+  if (input.event === 'pull_request_review_thread') {
+    const thread = buildReviewThreadResolution(input.payload, input.action, receivedAt)
+    if (thread) {
+      await store.upsertReviewThread({
+        ...thread,
+        repository,
+        prNumber,
+        commitSha,
+        receivedAt,
+      })
+      await store.updateThreadResolution({
+        repository,
+        prNumber,
+        threadKey: thread.threadKey,
+        threadId: thread.threadId,
+        resolved: thread.isResolved,
+        receivedAt,
+      })
+
+      const unresolvedThreadsCount = await store.getUnresolvedThreadCount({ repository, prNumber })
+      await store.updateUnresolvedThreadCount({
+        repository,
+        prNumber,
+        count: unresolvedThreadsCount,
+        receivedAt,
+      })
+    }
   }
 
   if (input.event === 'issue_comment') {


### PR DESCRIPTION
## Summary

- Handle GitHub `pull_request_review_thread` resolved and unresolved webhook events.
- Use the root review comment ID as the stable local thread key and preserve the GraphQL thread node ID.
- Materialize/update thread state and recompute the PR unresolved-thread summary.
- Add regressions for both webhook actions, including payloads where a reply precedes the root comment.

## Related Issues

Follow-up to Codex review on #2304.

## Testing

- Focused Jangar ingest suite (7 tests)
- Full Jangar TypeScript check
- Architecture inventory check
- Oxfmt
- Oxlint
- `git diff --check`

## Breaking Changes

None.
