### PR TITLE
fix(argocd): track Torghut metadata drift

### DIFF
--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -311,6 +311,7 @@ spec:
                     jsonPointers:
                       # Ignore only operator-defaulted fields. User-controlled metadata must remain diff-visible.
                       - /spec/traffic
+                      - /spec/template/metadata/annotations/client.knative.dev~1updateTimestamp
                       - /spec/template/metadata/creationTimestamp
                       - /spec/template/spec/containers/0/ports/0/protocol
                       - /spec/template/spec/containers/0/readinessProbe

--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -309,13 +309,9 @@ spec:
                   - group: serving.knative.dev
                     kind: Service
                     jsonPointers:
-                      # Keep metadata ignores granular; ignoring /spec/template/metadata can block SSA reconciliation.
-                      - /metadata/annotations
-                      - /metadata/labels
+                      # Ignore only operator-defaulted fields. User-controlled metadata must remain diff-visible.
                       - /spec/traffic
-                      - /spec/template/metadata/annotations
                       - /spec/template/metadata/creationTimestamp
-                      - /spec/template/metadata/labels
                       - /spec/template/spec/containers/0/ports/0/protocol
                       - /spec/template/spec/containers/0/readinessProbe
                       - /spec/template/spec/enableServiceLinks

--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -310,6 +310,7 @@ spec:
                     kind: Service
                     jsonPointers:
                       # Ignore only operator-defaulted fields. User-controlled metadata must remain diff-visible.
+                      - /metadata/annotations/serving.knative.dev~1lastModifier
                       - /spec/traffic
                       - /spec/template/metadata/annotations/client.knative.dev~1updateTimestamp
                       - /spec/template/metadata/creationTimestamp

--- a/packages/scripts/src/shared/__tests__/torghut-ignore-differences.test.ts
+++ b/packages/scripts/src/shared/__tests__/torghut-ignore-differences.test.ts
@@ -15,15 +15,23 @@ test('Torghut keeps Knative metadata drift visible to Argo CD', () => {
   expect(end).toBeGreaterThan(start)
 
   const torghutElement = productApplicationSet.slice(start, end)
+  const ignoredPaths = new Set(
+    torghutElement
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.startsWith('- /'))
+      .map((line) => line.slice(2)),
+  )
   for (const path of [
     '/metadata/annotations',
     '/metadata/labels',
     '/spec/template/metadata/annotations',
     '/spec/template/metadata/labels',
   ]) {
-    expect(torghutElement).not.toContain(`- ${path}`)
+    expect(ignoredPaths.has(path)).toBeFalse()
   }
 
-  expect(torghutElement).toContain('- /spec/template/metadata/creationTimestamp')
-  expect(torghutElement).toContain('- /spec/template/spec/containers/0/readinessProbe')
+  expect(ignoredPaths.has('/spec/template/metadata/annotations/client.knative.dev~1updateTimestamp')).toBeTrue()
+  expect(ignoredPaths.has('/spec/template/metadata/creationTimestamp')).toBeTrue()
+  expect(ignoredPaths.has('/spec/template/spec/containers/0/readinessProbe')).toBeTrue()
 })

--- a/packages/scripts/src/shared/__tests__/torghut-ignore-differences.test.ts
+++ b/packages/scripts/src/shared/__tests__/torghut-ignore-differences.test.ts
@@ -32,6 +32,7 @@ test('Torghut keeps Knative metadata drift visible to Argo CD', () => {
   }
 
   expect(ignoredPaths.has('/spec/template/metadata/annotations/client.knative.dev~1updateTimestamp')).toBeTrue()
+  expect(ignoredPaths.has('/metadata/annotations/serving.knative.dev~1lastModifier')).toBeTrue()
   expect(ignoredPaths.has('/spec/template/metadata/creationTimestamp')).toBeTrue()
   expect(ignoredPaths.has('/spec/template/spec/containers/0/readinessProbe')).toBeTrue()
 })

--- a/packages/scripts/src/shared/__tests__/torghut-ignore-differences.test.ts
+++ b/packages/scripts/src/shared/__tests__/torghut-ignore-differences.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs'
+
+import { expect, test } from 'bun:test'
+
+const productApplicationSet = readFileSync(
+  new URL('../../../../../argocd/applicationsets/product.yaml', import.meta.url),
+  'utf8',
+)
+
+test('Torghut keeps Knative metadata drift visible to Argo CD', () => {
+  const start = productApplicationSet.indexOf('              - name: torghut\n')
+  const end = productApplicationSet.indexOf('              - name: torghut-options\n', start)
+
+  expect(start).toBeGreaterThanOrEqual(0)
+  expect(end).toBeGreaterThan(start)
+
+  const torghutElement = productApplicationSet.slice(start, end)
+  for (const path of [
+    '/metadata/annotations',
+    '/metadata/labels',
+    '/spec/template/metadata/annotations',
+    '/spec/template/metadata/labels',
+  ]) {
+    expect(torghutElement).not.toContain(`- ${path}`)
+  }
+
+  expect(torghutElement).toContain('- /spec/template/metadata/creationTimestamp')
+  expect(torghutElement).toContain('- /spec/template/spec/containers/0/readinessProbe')
+})


### PR DESCRIPTION
## Summary

- Stop ignoring all Knative Service and revision-template annotations/labels for Torghut.
- Keep only operator-defaulted fields in `ignoreDifferences`.
- Add a regression that prevents rollout/routing metadata from becoming diff-invisible again.

## Related Issues

Follow-up to Codex review on #2213.

## Testing

- Focused Bun contract test
- Oxfmt
- Oxlint
- ApplicationSet server-side dry run against the installed CRD
- `git diff --check`

Local Argo lint was not runnable because this shell image does not include the `argo` CLI; CI provides that gate.

## Breaking Changes

None.
