### PR TITLE
chore(jangar): promote image sha-aea7f648e062306d357cfb670e78c13b7d7e9296

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-07-13T04:21:17Z
+    deploy.knative.dev/rollout: 2026-07-13T08:25:27Z
 spec:
   replicas: 1
   strategy:
@@ -57,9 +57,9 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: e136cc653fce5dd649322658cd5b6885d5ac0bdc
+              value: aea7f648e062306d357cfb670e78c13b7d7e9296
             - name: JANGAR_GITOPS_REVISION
-              value: e136cc653fce5dd649322658cd5b6885d5ac0bdc
+              value: aea7f648e062306d357cfb670e78c13b7d7e9296
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -355,15 +355,15 @@ spec:
             - name: ATLAS_CODE_SEARCH_HEALTH_SAMPLE_LIMIT
               value: "50"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "29223143744"
+              value: "29234552471"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:071a2daf8a9bc058915130860a32700ceabed9a318d01d5e7f3e5f0ef4f69126
+              value: sha256:4ebccc712e4ea8a0c7925e4cd7fd99becab02fb5cf563a4dff47c4445936df39
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: e136cc653fce5dd649322658cd5b6885d5ac0bdc
+              value: aea7f648e062306d357cfb670e78c13b7d7e9296
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:071a2daf8a9bc058915130860a32700ceabed9a318d01d5e7f3e5f0ef4f69126
+              value: sha256:4ebccc712e4ea8a0c7925e4cd7fd99becab02fb5cf563a4dff47c4445936df39
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -37,5 +37,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: sha-e136cc653fce5dd649322658cd5b6885d5ac0bdc
-    digest: sha256:071a2daf8a9bc058915130860a32700ceabed9a318d01d5e7f3e5f0ef4f69126
+    newTag: sha-aea7f648e062306d357cfb670e78c13b7d7e9296
+    digest: sha256:4ebccc712e4ea8a0c7925e4cd7fd99becab02fb5cf563a4dff47c4445936df39


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `aea7f648e062306d357cfb670e78c13b7d7e9296`
- Image tag: `sha-aea7f648e062306d357cfb670e78c13b7d7e9296`
- Image digest: `sha256:4ebccc712e4ea8a0c7925e4cd7fd99becab02fb5cf563a4dff47c4445936df39`
- Source CI run: `29234552471`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates