### PR TITLE
chore(kafka): finalize 4.3 metadata version

### DIFF
--- a/argocd/applications/kafka/strimzi-kafka-cluster.yaml
+++ b/argocd/applications/kafka/strimzi-kafka-cluster.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   kafka:
     version: 4.3.0
-    metadataVersion: "4.2-IV1"
+    metadataVersion: "4.3-IV0"
     listeners:
       - name: plain
         port: 9092


### PR DESCRIPTION
## Summary

- Finalize the Kafka cluster metadata level from `4.2-IV1` to `4.3-IV0`.
- Keep Strimzi at `1.1.0` and Kafka binaries at `4.3.0`.
- Establish the Kafka 4.3 roll-forward-only boundary after Argo CD applies this change.

## Related Issues

None

## Testing

- `nix develop --command bash -lc 'kustomize build --enable-helm argocd/applications/kafka >/dev/null'`
- `nix develop --command bash -lc 'set -o pipefail; kustomize build --enable-helm argocd/applications/kafka | kubectl apply --server-side --dry-run=server --force-conflicts -n kafka -f - >/dev/null'`
- `nix develop --command bash -lc 'bun run lint:argocd'`
- Live preflight: Kafka Ready on `4.3.0` with full ISR across 565 partitions, stable three-voter quorum, zero broker fencing in the preceding 10 minutes, Argo CD Synced/Healthy, and Torghut feed ready.

## Breaking Changes

After the cluster accepts metadata version `4.3-IV0`, rollback to Kafka 4.2 is prohibited; recovery must roll forward on Kafka 4.3.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
