### PR TITLE
fix(torghut): require candidate ownership

### DIFF
--- a/services/torghut/scripts/orchestration_guard.py
+++ b/services/torghut/scripts/orchestration_guard.py
@@ -152,6 +152,16 @@ def _state_run_id(state: JsonDict) -> str | None:
     return state_run_id or None
 
 
+def _state_candidate_id(state: JsonDict) -> str | None:
+    candidate_id_raw = state.get("candidateId")
+    if not isinstance(candidate_id_raw, str):
+        candidate_id_raw = state.get("candidate_id")
+    if not isinstance(candidate_id_raw, str):
+        return None
+    state_candidate_id = candidate_id_raw.strip()
+    return state_candidate_id or None
+
+
 def _validate_transition_state(
     *,
     state: JsonDict,
@@ -179,7 +189,10 @@ def _validate_transition_state(
     if to_stage not in allowed_targets:
         return _deny(f"illegal_transition:{source_stage}->{to_stage}")
 
-    if str(state.get("candidateId", candidate_id)) != candidate_id:
+    state_candidate_id = _state_candidate_id(state)
+    if not state_candidate_id:
+        return _deny("missing_candidate_id")
+    if state_candidate_id != candidate_id:
         return _deny("candidate_mismatch")
     if bool(state.get("paused", False)):
         return _deny("candidate_paused_for_review", "human_review")

--- a/services/torghut/tests/test_orchestration_guard.py
+++ b/services/torghut/tests/test_orchestration_guard.py
@@ -181,6 +181,60 @@ class TestOrchestrationGuard(TestCase):
         self.assertEqual(result["nextAction"], "halt")
         self.assertEqual(result["reason"], "run_mismatch:run-stale-1")
 
+    def test_blocks_transition_when_candidate_ownership_is_missing(self) -> None:
+        state: dict[str, Any] = {
+            "runId": "run-abc123",
+            "activeStage": "gate-evaluation",
+            "paused": False,
+            "failureCounts": {},
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            artifact = Path(tmpdir) / "report.json"
+            artifact.write_text('{"ok":true}', encoding="utf-8")
+            result = evaluate_transition(
+                policy=self.policy,
+                state=state,
+                candidate_id="cand-abc123",
+                run_id="run-abc123",
+                from_stage="gate-evaluation",
+                to_stage="promotion-prerequisites",
+                previous_artifact=artifact,
+                previous_gate_passed=True,
+                risk_controls_passed=True,
+                execution_controls_passed=True,
+                mode="gitops",
+                emergency_ticket=None,
+            )
+        self.assertFalse(result["allowed"])
+        self.assertEqual(result["reason"], "missing_candidate_id")
+
+    def test_accepts_snake_case_candidate_ownership(self) -> None:
+        state: dict[str, Any] = {
+            "candidate_id": "cand-abc123",
+            "runId": "run-abc123",
+            "activeStage": "gate-evaluation",
+            "paused": False,
+            "failureCounts": {},
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            artifact = Path(tmpdir) / "report.json"
+            artifact.write_text('{"ok":true}', encoding="utf-8")
+            result = evaluate_transition(
+                policy=self.policy,
+                state=state,
+                candidate_id="cand-abc123",
+                run_id="run-abc123",
+                from_stage="gate-evaluation",
+                to_stage="promotion-prerequisites",
+                previous_artifact=artifact,
+                previous_gate_passed=True,
+                risk_controls_passed=True,
+                execution_controls_passed=True,
+                mode="gitops",
+                emergency_ticket=None,
+            )
+        self.assertTrue(result["allowed"])
+
     def test_allows_ticketed_emergency_transition(self) -> None:
         state: dict[str, Any] = {
             "candidateId": "cand-abc123",


### PR DESCRIPTION
## Summary

- Reject orchestration transitions when candidate ownership is missing from state.
- Accept either `candidateId` or `candidate_id` as the persisted ownership field.
- Preserve mismatch rejection and add focused regressions for missing and snake-case ownership.

## Related Issues

Follow-up to Codex review on #3036.

## Testing

- Orchestration guard unittest suite: 11 passed
- Ruff check and format check
- Python bytecode compilation
- `git diff --check`

## Breaking Changes

None.
