### PR TITLE
chore(torghut): promote image sha-fa957dd06c058590a52f0dde207ff163cb0f0686

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -22,7 +22,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: migrate
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9ac44017971f0c95d8ddabff556b113e23e121a22dc0e17d25a4ed39a59f9c9f
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:41e39f631fbb4811f48cc1c281de2deb1be0fa3aa824c881dbb1a6fa52b7fbdb
           imagePullPolicy: Always
           workingDir: /app
           command:
@@ -52,9 +52,9 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: d8d24cd01df091dedde7e32c262fea96cc3d7d11
+              value: fa957dd06c058590a52f0dde207ff163cb0f0686
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:9ac44017971f0c95d8ddabff556b113e23e121a22dc0e17d25a4ed39a59f9c9f
+              value: sha256:41e39f631fbb4811f48cc1c281de2deb1be0fa3aa824c881dbb1a6fa52b7fbdb
             - name: PYTHONPATH
               value: /app
             - name: DB_DSN

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-hyperliquid-runtime
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9ac44017971f0c95d8ddabff556b113e23e121a22dc0e17d25a4ed39a59f9c9f
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:41e39f631fbb4811f48cc1c281de2deb1be0fa3aa824c881dbb1a6fa52b7fbdb
           imagePullPolicy: Always
           command:
             - uvicorn
@@ -46,9 +46,9 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: d8d24cd01df091dedde7e32c262fea96cc3d7d11
+              value: fa957dd06c058590a52f0dde207ff163cb0f0686
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:9ac44017971f0c95d8ddabff556b113e23e121a22dc0e17d25a4ed39a59f9c9f
+              value: sha256:41e39f631fbb4811f48cc1c281de2deb1be0fa3aa824c881dbb1a6fa52b7fbdb
             - name: DB_DSN
               valueFrom:
                 secretKeyRef:

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9ac44017971f0c95d8ddabff556b113e23e121a22dc0e17d25a4ed39a59f9c9f
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:41e39f631fbb4811f48cc1c281de2deb1be0fa3aa824c881dbb1a6fa52b7fbdb
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -72,9 +72,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1811-gd8d24cd01
+              value: v0.596.0-1853-gfa957dd06
             - name: TORGHUT_OPTIONS_COMMIT
-              value: d8d24cd01df091dedde7e32c262fea96cc3d7d11
+              value: fa957dd06c058590a52f0dde207ff163cb0f0686
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9ac44017971f0c95d8ddabff556b113e23e121a22dc0e17d25a4ed39a59f9c9f
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:41e39f631fbb4811f48cc1c281de2deb1be0fa3aa824c881dbb1a6fa52b7fbdb
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -77,9 +77,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1811-gd8d24cd01
+              value: v0.596.0-1853-gfa957dd06
             - name: TORGHUT_OPTIONS_COMMIT
-              value: d8d24cd01df091dedde7e32c262fea96cc3d7d11
+              value: fa957dd06c058590a52f0dde207ff163cb0f0686
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:9ac44017971f0c95d8ddabff556b113e23e121a22dc0e17d25a4ed39a59f9c9f
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:41e39f631fbb4811f48cc1c281de2deb1be0fa3aa824c881dbb1a6fa52b7fbdb
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:9ac44017971f0c95d8ddabff556b113e23e121a22dc0e17d25a4ed39a59f9c9f
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:41e39f631fbb4811f48cc1c281de2deb1be0fa3aa824c881dbb1a6fa52b7fbdb
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:9ac44017971f0c95d8ddabff556b113e23e121a22dc0e17d25a4ed39a59f9c9f
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:41e39f631fbb4811f48cc1c281de2deb1be0fa3aa824c881dbb1a6fa52b7fbdb
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:9ac44017971f0c95d8ddabff556b113e23e121a22dc0e17d25a4ed39a59f9c9f
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:41e39f631fbb4811f48cc1c281de2deb1be0fa3aa824c881dbb1a6fa52b7fbdb
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9ac44017971f0c95d8ddabff556b113e23e121a22dc0e17d25a4ed39a59f9c9f
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:41e39f631fbb4811f48cc1c281de2deb1be0fa3aa824c881dbb1a6fa52b7fbdb
           workingDir: /app
           command:
             - /bin/sh

--- a/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
+++ b/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-generated-resource-retention
           containers:
             - name: prune-generated-residue
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:9ac44017971f0c95d8ddabff556b113e23e121a22dc0e17d25a4ed39a59f9c9f
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:41e39f631fbb4811f48cc1c281de2deb1be0fa3aa824c881dbb1a6fa52b7fbdb
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:9ac44017971f0c95d8ddabff556b113e23e121a22dc0e17d25a4ed39a59f9c9f
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:41e39f631fbb4811f48cc1c281de2deb1be0fa3aa824c881dbb1a6fa52b7fbdb
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-13T03:11:16Z"
+        client.knative.dev/updateTimestamp: "2026-07-13T22:34:33Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9ac44017971f0c95d8ddabff556b113e23e121a22dc0e17d25a4ed39a59f9c9f
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:41e39f631fbb4811f48cc1c281de2deb1be0fa3aa824c881dbb1a6fa52b7fbdb
           ports:
             - name: http1
               containerPort: 8181
@@ -523,11 +523,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1811-gd8d24cd01
+              value: v0.596.0-1853-gfa957dd06
             - name: TORGHUT_COMMIT
-              value: d8d24cd01df091dedde7e32c262fea96cc3d7d11
+              value: fa957dd06c058590a52f0dde207ff163cb0f0686
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:9ac44017971f0c95d8ddabff556b113e23e121a22dc0e17d25a4ed39a59f9c9f
+              value: sha256:41e39f631fbb4811f48cc1c281de2deb1be0fa3aa824c881dbb1a6fa52b7fbdb
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-13T03:11:16Z"
+        client.knative.dev/updateTimestamp: "2026-07-13T22:34:33Z"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
     spec:
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9ac44017971f0c95d8ddabff556b113e23e121a22dc0e17d25a4ed39a59f9c9f
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:41e39f631fbb4811f48cc1c281de2deb1be0fa3aa824c881dbb1a6fa52b7fbdb
           ports:
             - name: http1
               containerPort: 8181
@@ -446,11 +446,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1811-gd8d24cd01
+              value: v0.596.0-1853-gfa957dd06
             - name: TORGHUT_COMMIT
-              value: d8d24cd01df091dedde7e32c262fea96cc3d7d11
+              value: fa957dd06c058590a52f0dde207ff163cb0f0686
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:9ac44017971f0c95d8ddabff556b113e23e121a22dc0e17d25a4ed39a59f9c9f
+              value: sha256:41e39f631fbb4811f48cc1c281de2deb1be0fa3aa824c881dbb1a6fa52b7fbdb
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -37,7 +37,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9ac44017971f0c95d8ddabff556b113e23e121a22dc0e17d25a4ed39a59f9c9f
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:41e39f631fbb4811f48cc1c281de2deb1be0fa3aa824c881dbb1a6fa52b7fbdb
           command:
             - uvicorn
           args:
@@ -462,11 +462,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1811-gd8d24cd01
+              value: v0.596.0-1853-gfa957dd06
             - name: TORGHUT_COMMIT
-              value: d8d24cd01df091dedde7e32c262fea96cc3d7d11
+              value: fa957dd06c058590a52f0dde207ff163cb0f0686
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:9ac44017971f0c95d8ddabff556b113e23e121a22dc0e17d25a4ed39a59f9c9f
+              value: sha256:41e39f631fbb4811f48cc1c281de2deb1be0fa3aa824c881dbb1a6fa52b7fbdb
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: smoke
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9ac44017971f0c95d8ddabff556b113e23e121a22dc0e17d25a4ed39a59f9c9f
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:41e39f631fbb4811f48cc1c281de2deb1be0fa3aa824c881dbb1a6fa52b7fbdb
           imagePullPolicy: IfNotPresent
           securityContext:
             seccompProfile:


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `fa957dd06c058590a52f0dde207ff163cb0f0686`
- Image tag: `sha-fa957dd06c058590a52f0dde207ff163cb0f0686`
- Image digest: `sha256:41e39f631fbb4811f48cc1c281de2deb1be0fa3aa824c881dbb1a6fa52b7fbdb`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher