### PR TITLE
fix(observability): force Alloy config rollouts

### DIFF
--- a/argocd/applications/observability/cluster-metrics-alloy-deployment.yaml
+++ b/argocd/applications/observability/cluster-metrics-alloy-deployment.yaml
@@ -13,6 +13,8 @@ spec:
       app.kubernetes.io/name: observability-cluster-metrics-alloy
   template:
     metadata:
+      annotations:
+        observability.proompteng.ai/config-sha256: 659fedceb5af5589e466d54363df35d0e29f4a77738462b8cfc3f9ae4655b43b
       labels:
         app.kubernetes.io/name: observability-cluster-metrics-alloy
         app.kubernetes.io/component: cluster-metrics

--- a/argocd/applications/observability/kustomization.yaml
+++ b/argocd/applications/observability/kustomization.yaml
@@ -6,6 +6,9 @@ configMapGenerator:
     files:
       - config.river=cluster-metrics-alloy-config.river
 
+generatorOptions:
+  disableNameSuffixHash: true
+
 resources:
   - rook-ceph-rgw-loki-reflected-secret.yaml
   - tailscale-ingresses.yaml

--- a/packages/scripts/src/shared/__tests__/flink-observability-contract.test.ts
+++ b/packages/scripts/src/shared/__tests__/flink-observability-contract.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { readFileSync } from 'node:fs'
 
 import { expect, test } from 'bun:test'
@@ -20,7 +21,11 @@ test('Alloy scrapes Flink operator and TA metrics with alert-compatible labels',
   expect(config).toContain('forward_to      = [prometheus.remote_write.mimir.receiver]')
   expect(kustomization).toContain('configMapGenerator:')
   expect(kustomization).toContain('config.river=cluster-metrics-alloy-config.river')
+  expect(kustomization).toContain('disableNameSuffixHash: true')
   expect(deployment).toContain('name: observability-cluster-metrics-alloy')
+  expect(deployment).toContain(
+    `observability.proompteng.ai/config-sha256: ${createHash('sha256').update(config).digest('hex')}`,
+  )
 })
 
 test('Ceph migration guide uses Hadoop S3A configuration keys', () => {


### PR DESCRIPTION
## Summary

- Keep the generated Alloy ConfigMap name stable for the Argo `lovely` plugin.
- Pin the Alloy pod template to the exact SHA-256 of its River configuration so config changes force a rollout.
- Enforce config/annotation parity in the existing observability contract test.

## Related Issues

Follow-up to #12398.

## Testing

- `nix develop -c kustomize build --enable-helm argocd/applications/observability`
- `nix develop -c sh -lc 'kustomize build --enable-helm argocd/applications/observability | kubectl apply --dry-run=server -n observability -f -'`
- `bun run lint:argocd`
- `bun test packages/scripts/src` (532 passing)
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/flink-observability-contract.test.ts`

## Screenshots (if applicable)

N/A. Manifest-only change.

## Breaking Changes

None. The stable ConfigMap is recreated and the SHA annotation rolls Alloy once.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked; the config hash contract is covered in tests.
