### PR TITLE
fix(torghut): stabilize DSPy compile hashes

### DIFF
--- a/services/torghut/app/trading/llm/dspy_compile/compiler.py
+++ b/services/torghut/app/trading/llm/dspy_compile/compiler.py
@@ -13,7 +13,7 @@ from urllib.parse import unquote, urlsplit
 import yaml
 
 from ..schema import LLMReviewResponse
-from .hashing import canonical_json, hash_payload
+from .hashing import canonical_json, canonical_metric_bundle_for_hash, hash_payload
 from .schemas import DSPyCompileResult
 from .workflow import build_compile_result
 
@@ -101,16 +101,16 @@ def compile_dspy_program_artifacts(
     metric_policy_path = _resolve_local_ref_path(
         normalized_metric_policy_ref, field_name="metric_policy_ref"
     )
-    canonical_dataset_ref = _canonical_local_ref(dataset_path)
-    canonical_metric_policy_ref = _canonical_local_ref(metric_policy_path)
-
-    canonical_dataset_ref = str(dataset_path)
-    canonical_metric_policy_ref = str(metric_policy_path)
 
     dataset_payload = _load_json_mapping(dataset_path, field_name="dataset_ref")
     metric_policy_payload = _load_yaml_mapping(
         metric_policy_path, field_name="metric_policy_ref"
     )
+
+    dataset_hash = hash_payload(dataset_payload)
+    metric_policy_hash = hash_payload(metric_policy_payload)
+    canonical_dataset_ref = f"sha256:{dataset_hash}"
+    canonical_metric_policy_ref = f"sha256:{metric_policy_hash}"
 
     output_dir = Path(normalized_artifact_ref).resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -122,8 +122,6 @@ def compile_dspy_program_artifacts(
     compiled_artifact_path = output_dir / normalized_compiled_artifact_name
 
     signature_versions = {"trade_review": normalized_signature_version}
-    dataset_hash = hash_payload(dataset_payload)
-    metric_policy_hash = hash_payload(metric_policy_payload)
     row_counts_by_split = _count_rows_by_split(dataset_payload.get("rows"))
     dataset_rows = sum(row_counts_by_split.values())
 
@@ -146,7 +144,7 @@ def compile_dspy_program_artifacts(
         latency_p95_ms=latency_p95_ms,
     )
     metric_bundle.update(observed_metrics)
-    metric_bundle_hash = hash_payload(metric_bundle)
+    metric_bundle_hash = hash_payload(canonical_metric_bundle_for_hash(metric_bundle))
 
     compiled_artifact_payload: dict[str, Any] = {
         "schemaVersion": COMPILED_ARTIFACT_SCHEMA_VERSION,
@@ -253,10 +251,6 @@ def _resolve_local_ref_path(ref: str, *, field_name: str) -> Path:
     if not candidate.exists() or not candidate.is_file():
         raise ValueError(f"{field_name}_not_found")
     return candidate.resolve()
-
-
-def _canonical_local_ref(path: Path) -> str:
-    return path.resolve().as_uri()
 
 
 def _load_json_mapping(path: Path, *, field_name: str) -> dict[str, Any]:

--- a/services/torghut/app/trading/llm/dspy_compile/evaluator.py
+++ b/services/torghut/app/trading/llm/dspy_compile/evaluator.py
@@ -383,20 +383,32 @@ def _evaluate_deterministic_compatibility(
         if not _required_key_present(key=key, compile_result=compile_result)
     )
 
+    artifact_hash_payload = {
+        "program_name": compile_result.program_name,
+        "signature_versions": dict(compile_result.signature_versions),
+        "optimizer": compile_result.optimizer,
+        "dataset_hash": compile_result.dataset_hash,
+        "compiled_prompt_hash": compile_result.compiled_prompt_hash,
+        "reproducibility_hash": compile_result.reproducibility_hash,
+    }
     recomputed_artifact_hash = hash_payload(
         {
-            "program_name": compile_result.program_name,
-            "signature_versions": dict(compile_result.signature_versions),
-            "optimizer": compile_result.optimizer,
-            "dataset_hash": compile_result.dataset_hash,
-            "compiled_prompt_hash": compile_result.compiled_prompt_hash,
+            **artifact_hash_payload,
             "compiled_artifact_uri": canonical_artifact_uri_for_hash(
                 compile_result.compiled_artifact_uri
             ),
-            "reproducibility_hash": compile_result.reproducibility_hash,
         }
     )
-    artifact_hash_matches = recomputed_artifact_hash == compile_result.artifact_hash
+    legacy_artifact_hash = hash_payload(
+        {
+            **artifact_hash_payload,
+            "compiled_artifact_uri": compile_result.compiled_artifact_uri,
+        }
+    )
+    artifact_hash_matches = compile_result.artifact_hash in {
+        recomputed_artifact_hash,
+        legacy_artifact_hash,
+    }
 
     failures: list[str] = []
     if missing_keys:

--- a/services/torghut/app/trading/llm/dspy_compile/evaluator.py
+++ b/services/torghut/app/trading/llm/dspy_compile/evaluator.py
@@ -12,7 +12,7 @@ from urllib.parse import unquote, urlsplit
 
 import yaml
 
-from .hashing import canonical_json, hash_payload
+from .hashing import canonical_artifact_uri_for_hash, canonical_json, hash_payload
 from .schemas import DSPyCompileResult, DSPyEvalReport
 from .workflow import build_eval_report
 
@@ -390,7 +390,9 @@ def _evaluate_deterministic_compatibility(
             "optimizer": compile_result.optimizer,
             "dataset_hash": compile_result.dataset_hash,
             "compiled_prompt_hash": compile_result.compiled_prompt_hash,
-            "compiled_artifact_uri": compile_result.compiled_artifact_uri,
+            "compiled_artifact_uri": canonical_artifact_uri_for_hash(
+                compile_result.compiled_artifact_uri
+            ),
             "reproducibility_hash": compile_result.reproducibility_hash,
         }
     )

--- a/services/torghut/app/trading/llm/dspy_compile/hashing.py
+++ b/services/torghut/app/trading/llm/dspy_compile/hashing.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import hashlib
 import json
-from typing import Any
+from typing import Mapping
+from urllib.parse import unquote, urlsplit
 
 
-def canonical_json(value: Any) -> str:
+def canonical_json(value: object) -> str:
     return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
 
 
@@ -15,8 +16,39 @@ def sha256_hex(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
 
 
-def hash_payload(value: Any) -> str:
+def hash_payload(value: object) -> str:
     return sha256_hex(canonical_json(value))
 
 
-__all__ = ["canonical_json", "hash_payload", "sha256_hex"]
+def canonical_metric_bundle_for_hash(
+    metric_bundle: Mapping[str, object],
+) -> dict[str, object]:
+    """Replace checkout-local references with their content-addressed identities."""
+    normalized = dict(metric_bundle)
+    dataset_hash = normalized.get("datasetHash")
+    if isinstance(dataset_hash, str) and dataset_hash.strip():
+        normalized["datasetRef"] = f"sha256:{dataset_hash.strip().lower()}"
+    metric_policy_hash = normalized.get("metricPolicyHash")
+    if isinstance(metric_policy_hash, str) and metric_policy_hash.strip():
+        normalized["metricPolicyRef"] = f"sha256:{metric_policy_hash.strip().lower()}"
+    return normalized
+
+
+def canonical_artifact_uri_for_hash(artifact_uri: str) -> str:
+    """Normalize local artifact locations while preserving remote object identity."""
+    normalized = artifact_uri.strip()
+    parsed = urlsplit(normalized)
+    if parsed.scheme not in {"", "file"}:
+        return normalized
+    local_path = unquote(parsed.path) if parsed.scheme == "file" else normalized
+    artifact_name = local_path.replace("\\", "/").rstrip("/").split("/")[-1]
+    return f"artifact:///{artifact_name}" if artifact_name else "artifact:///"
+
+
+__all__ = [
+    "canonical_artifact_uri_for_hash",
+    "canonical_json",
+    "canonical_metric_bundle_for_hash",
+    "hash_payload",
+    "sha256_hex",
+]

--- a/services/torghut/app/trading/llm/dspy_compile/workflow/shared_context.py
+++ b/services/torghut/app/trading/llm/dspy_compile/workflow/shared_context.py
@@ -17,7 +17,11 @@ from sqlalchemy.orm import Session
 
 from .....config import settings
 from .....models import LLMDSPyWorkflowArtifact, coerce_json_payload
-from ..hashing import hash_payload
+from ..hashing import (
+    canonical_artifact_uri_for_hash,
+    canonical_metric_bundle_for_hash,
+    hash_payload,
+)
 from ..schemas import (
     DSPyArtifactBundle,
     DSPyCompileResult,
@@ -160,7 +164,7 @@ def build_compile_result(
             "dataset_hash": dataset_hash,
             "compiled_prompt_hash": compiled_prompt_hash,
             "seed": seed,
-            "metric_bundle": dict(metric_bundle),
+            "metric_bundle": canonical_metric_bundle_for_hash(metric_bundle),
         }
     )
     artifact_hash = hash_payload(
@@ -170,7 +174,9 @@ def build_compile_result(
             "optimizer": optimizer,
             "dataset_hash": dataset_hash,
             "compiled_prompt_hash": compiled_prompt_hash,
-            "compiled_artifact_uri": compiled_artifact_uri,
+            "compiled_artifact_uri": canonical_artifact_uri_for_hash(
+                compiled_artifact_uri
+            ),
             "reproducibility_hash": reproducibility_hash,
         }
     )

--- a/services/torghut/app/trading/llm/dspy_programs/runtime.py
+++ b/services/torghut/app/trading/llm/dspy_programs/runtime.py
@@ -322,20 +322,31 @@ class DSPyReviewRuntime:
                 "dspy_artifact_missing_reproducibility_fields"
             )
 
-        computed_hash = hash_payload(
-            {
-                "program_name": program_name,
-                "signature_versions": signature_versions,
-                "optimizer": row.optimizer,
-                "dataset_hash": row.dataset_hash,
-                "compiled_prompt_hash": row.compiled_prompt_hash,
-                "compiled_artifact_uri": canonical_artifact_uri_for_hash(
-                    row.artifact_uri
-                ),
-                "reproducibility_hash": row.reproducibility_hash,
-            }
-        )
-        if computed_hash != artifact_hash:
+        hash_payload_base = {
+            "program_name": program_name,
+            "signature_versions": signature_versions,
+            "optimizer": row.optimizer,
+            "dataset_hash": row.dataset_hash,
+            "compiled_prompt_hash": row.compiled_prompt_hash,
+            "reproducibility_hash": row.reproducibility_hash,
+        }
+        accepted_hashes = {
+            hash_payload(
+                {
+                    **hash_payload_base,
+                    "compiled_artifact_uri": canonical_artifact_uri_for_hash(
+                        row.artifact_uri
+                    ),
+                }
+            ),
+            hash_payload(
+                {
+                    **hash_payload_base,
+                    "compiled_artifact_uri": row.artifact_uri,
+                }
+            ),
+        }
+        if artifact_hash not in accepted_hashes:
             raise DSPyRuntimeUnsupportedStateError("dspy_artifact_hash_mismatch")
 
         metadata: dict[str, Any] = {}

--- a/services/torghut/app/trading/llm/dspy_programs/runtime.py
+++ b/services/torghut/app/trading/llm/dspy_programs/runtime.py
@@ -9,7 +9,7 @@ from urllib.parse import urlsplit
 from typing import Any, Literal, Mapping, cast
 
 from ....config import settings
-from ..dspy_compile.hashing import hash_payload
+from ..dspy_compile.hashing import canonical_artifact_uri_for_hash, hash_payload
 from ..schema import LLMReviewRequest, LLMReviewResponse
 from .adapters import dspy_output_to_llm_response, review_request_to_dspy_input
 from .committee_programs import (
@@ -329,7 +329,9 @@ class DSPyReviewRuntime:
                 "optimizer": row.optimizer,
                 "dataset_hash": row.dataset_hash,
                 "compiled_prompt_hash": row.compiled_prompt_hash,
-                "compiled_artifact_uri": row.artifact_uri,
+                "compiled_artifact_uri": canonical_artifact_uri_for_hash(
+                    row.artifact_uri
+                ),
                 "reproducibility_hash": row.reproducibility_hash,
             }
         )

--- a/services/torghut/app/trading/llm/dspy_programs/runtime.py
+++ b/services/torghut/app/trading/llm/dspy_programs/runtime.py
@@ -277,7 +277,7 @@ class DSPyReviewRuntime:
 
     def _load_manifest_from_db(self, artifact_hash: str) -> DSPyArtifactManifest | None:
         try:
-            from sqlalchemy import select
+            from sqlalchemy import case, select
 
             from ....db import SessionLocal
             from ....models import LLMDSPyWorkflowArtifact
@@ -291,7 +291,16 @@ class DSPyReviewRuntime:
                 session.execute(
                     select(LLMDSPyWorkflowArtifact)
                     .where(LLMDSPyWorkflowArtifact.artifact_hash == artifact_hash)
-                    .order_by(LLMDSPyWorkflowArtifact.created_at.desc())
+                    .order_by(
+                        case(
+                            (
+                                LLMDSPyWorkflowArtifact.gate_compatibility == "pass",
+                                0,
+                            ),
+                            else_=1,
+                        ),
+                        LLMDSPyWorkflowArtifact.created_at.desc(),
+                    )
                 )
                 .scalars()
                 .first()

--- a/services/torghut/app/trading/llm/dspy_programs/runtime.py
+++ b/services/torghut/app/trading/llm/dspy_programs/runtime.py
@@ -277,7 +277,7 @@ class DSPyReviewRuntime:
 
     def _load_manifest_from_db(self, artifact_hash: str) -> DSPyArtifactManifest | None:
         try:
-            from sqlalchemy import case, select
+            from sqlalchemy import select
 
             from ....db import SessionLocal
             from ....models import LLMDSPyWorkflowArtifact
@@ -290,17 +290,11 @@ class DSPyReviewRuntime:
             row = (
                 session.execute(
                     select(LLMDSPyWorkflowArtifact)
-                    .where(LLMDSPyWorkflowArtifact.artifact_hash == artifact_hash)
-                    .order_by(
-                        case(
-                            (
-                                LLMDSPyWorkflowArtifact.gate_compatibility == "pass",
-                                0,
-                            ),
-                            else_=1,
-                        ),
-                        LLMDSPyWorkflowArtifact.created_at.desc(),
+                    .where(
+                        LLMDSPyWorkflowArtifact.artifact_hash == artifact_hash,
+                        LLMDSPyWorkflowArtifact.gate_compatibility == "pass",
                     )
+                    .order_by(LLMDSPyWorkflowArtifact.created_at.desc())
                 )
                 .scalars()
                 .first()
@@ -309,7 +303,7 @@ class DSPyReviewRuntime:
         if row is None:
             return None
 
-        if row.gate_compatibility and row.gate_compatibility != "pass":
+        if row.gate_compatibility != "pass":
             raise DSPyRuntimeUnsupportedStateError(
                 "dspy_artifact_gate_compatibility_failed"
             )

--- a/services/torghut/tests/test_llm_dspy_compiler.py
+++ b/services/torghut/tests/test_llm_dspy_compiler.py
@@ -5,7 +5,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
-from urllib.parse import urlsplit, unquote
 
 from app.trading.llm.dspy_compile.compiler import (
     _percentile_disc,
@@ -17,13 +16,6 @@ from app.trading.llm.dspy_compile.hashing import canonical_json
 class TestLLMDSPyCompiler(TestCase):
     def test_percentile_disc_selects_upper_tail_for_two_samples(self) -> None:
         self.assertEqual(_percentile_disc([110, 190], percentile=0.95), 190)
-
-    @staticmethod
-    def _normalize_ref(ref: str) -> str:
-        parsed = urlsplit(ref)
-        if parsed.scheme == "file":
-            return str(Path(unquote(parsed.path)))
-        return ref
 
     def test_compile_artifacts_emit_hashes_and_compiled_uri(self) -> None:
         with TemporaryDirectory() as tmp:
@@ -90,16 +82,12 @@ class TestLLMDSPyCompiler(TestCase):
             )
             self.assertEqual(compile_result_payload["optimizer"], "miprov2")
             self.assertEqual(
-                self._normalize_ref(
-                    compile_result_payload["metricBundle"]["metricPolicyRef"]
-                ),
-                f"{metric_policy_path.resolve()}",
+                compile_result_payload["metricBundle"]["metricPolicyRef"],
+                f"sha256:{compile_result_payload['metricBundle']['metricPolicyHash']}",
             )
             self.assertEqual(
-                self._normalize_ref(
-                    compile_result_payload["metricBundle"]["datasetRef"]
-                ),
-                f"{dataset_path.resolve()}",
+                compile_result_payload["metricBundle"]["datasetRef"],
+                f"sha256:{compile_result_payload['datasetHash']}",
             )
             self.assertEqual(
                 compile_result_payload["metricBundle"]["rowCountsBySplit"],
@@ -227,10 +215,67 @@ class TestLLMDSPyCompiler(TestCase):
                 from_file_uri.compile_result.artifact_hash,
             )
             self.assertEqual(
-                self._normalize_ref(
-                    from_path.compile_result.metric_bundle["datasetRef"]
-                ),
-                f"{dataset_path.resolve()}",
+                from_path.compile_result.metric_bundle["datasetRef"],
+                f"sha256:{from_path.compile_result.dataset_hash}",
+            )
+
+    def test_compile_hashes_are_stable_across_checkout_roots(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            results = []
+            for checkout_name in ("checkout-a", "checkout-b"):
+                checkout = root / checkout_name
+                checkout.mkdir()
+                dataset_path = checkout / "dspy-dataset.json"
+                metric_policy_path = checkout / "dspy-metrics.yaml"
+                dataset_path.write_text(
+                    canonical_json(
+                        {
+                            "schemaVersion": "torghut.dspy.dataset.v1",
+                            "rows": [{"rowId": "row-1", "split": "train"}],
+                        }
+                    )
+                    + "\n",
+                    encoding="utf-8",
+                )
+                metric_policy_path.write_text(
+                    "schemaVersion: torghut.dspy.metrics.v1\npolicy:\n  schemaValidRateMin: 0.995\n",
+                    encoding="utf-8",
+                )
+                results.append(
+                    compile_dspy_program_artifacts(
+                        repository="proompteng/lab",
+                        base="main",
+                        head="codex/dspy-compile-test",
+                        artifact_path=checkout / "compile",
+                        dataset_ref=str(dataset_path),
+                        metric_policy_ref=str(metric_policy_path),
+                        optimizer="miprov2",
+                        created_at=datetime(2026, 2, 27, 13, 0, tzinfo=timezone.utc),
+                    )
+                )
+
+            first, second = results
+            self.assertNotEqual(
+                first.compile_result.compiled_artifact_uri,
+                second.compile_result.compiled_artifact_uri,
+            )
+            self.assertEqual(
+                first.compile_result.compiled_prompt_hash,
+                second.compile_result.compiled_prompt_hash,
+            )
+            self.assertEqual(
+                first.compile_result.reproducibility_hash,
+                second.compile_result.reproducibility_hash,
+            )
+            self.assertEqual(
+                first.compile_result.artifact_hash,
+                second.compile_result.artifact_hash,
+            )
+            self.assertEqual(first.metric_bundle_hash, second.metric_bundle_hash)
+            self.assertEqual(
+                first.compiled_artifact_path.read_text(encoding="utf-8"),
+                second.compiled_artifact_path.read_text(encoding="utf-8"),
             )
 
     def test_compile_rejects_non_local_dataset_ref(self) -> None:
@@ -407,7 +452,7 @@ class TestLLMDSPyCompiler(TestCase):
             self.assertEqual(metric_bundle["vetoAlignmentRate"], 1.0)
             self.assertEqual(metric_bundle["falseVetoRate"], 1.0)
             self.assertEqual(metric_bundle["fallbackRate"], 2 / 3)
-            self.assertEqual(metric_bundle["latencyP95Ms"], 190)
+            self.assertEqual(metric_bundle["latencyP95Ms"], 110)
 
     def test_compile_rejects_partial_observed_metrics(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/services/torghut/tests/test_llm_dspy_compiler.py
+++ b/services/torghut/tests/test_llm_dspy_compiler.py
@@ -452,7 +452,7 @@ class TestLLMDSPyCompiler(TestCase):
             self.assertEqual(metric_bundle["vetoAlignmentRate"], 1.0)
             self.assertEqual(metric_bundle["falseVetoRate"], 1.0)
             self.assertEqual(metric_bundle["fallbackRate"], 2 / 3)
-            self.assertEqual(metric_bundle["latencyP95Ms"], 110)
+            self.assertEqual(metric_bundle["latencyP95Ms"], 190)
 
     def test_compile_rejects_partial_observed_metrics(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/services/torghut/tests/test_llm_dspy_eval.py
+++ b/services/torghut/tests/test_llm_dspy_eval.py
@@ -24,7 +24,9 @@ class TestLLMDSPyEval(TestCase):
                 optimizer="miprov2",
                 dataset_payload={"rows": [{"rowId": "row-1", "split": "train"}]},
                 metric_bundle={"schema_valid_rate": 1.0},
-                compiled_prompt_payload={"promptTemplate": "torghut.dspy.trade-review.v1"},
+                compiled_prompt_payload={
+                    "promptTemplate": "torghut.dspy.trade-review.v1"
+                },
                 compiled_artifact_uri=artifact_uri,
                 seed="seed-1",
                 created_at=datetime(2026, 2, 27, 12, 0, tzinfo=timezone.utc),

--- a/services/torghut/tests/test_llm_dspy_eval.py
+++ b/services/torghut/tests/test_llm_dspy_eval.py
@@ -10,10 +10,68 @@ from app.trading.llm.dspy_compile import (
     build_compile_result,
     evaluate_dspy_compile_artifact,
 )
-from app.trading.llm.dspy_compile.hashing import canonical_json
+from app.trading.llm.dspy_compile.hashing import canonical_json, hash_payload
 
 
 class TestLLMDSPyEval(TestCase):
+    def test_eval_accepts_legacy_local_artifact_uri_hash(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            artifact_uri = str(root / "compile" / "dspy-compiled-program.json")
+            compile_result = build_compile_result(
+                program_name="trade-review-committee-v1",
+                signature_versions={"trade_review": "v1"},
+                optimizer="miprov2",
+                dataset_payload={"rows": [{"rowId": "row-1", "split": "train"}]},
+                metric_bundle={"schema_valid_rate": 1.0},
+                compiled_prompt_payload={"promptTemplate": "torghut.dspy.trade-review.v1"},
+                compiled_artifact_uri=artifact_uri,
+                seed="seed-1",
+                created_at=datetime(2026, 2, 27, 12, 0, tzinfo=timezone.utc),
+            )
+            payload = compile_result.model_dump(mode="json", by_alias=True)
+            payload["artifactHash"] = hash_payload(
+                {
+                    "program_name": compile_result.program_name,
+                    "signature_versions": dict(compile_result.signature_versions),
+                    "optimizer": compile_result.optimizer,
+                    "dataset_hash": compile_result.dataset_hash,
+                    "compiled_prompt_hash": compile_result.compiled_prompt_hash,
+                    "compiled_artifact_uri": artifact_uri,
+                    "reproducibility_hash": compile_result.reproducibility_hash,
+                }
+            )
+            compile_result_path = root / "compile" / "dspy-compile-result.json"
+            compile_result_path.parent.mkdir(parents=True, exist_ok=True)
+            compile_result_path.write_text(
+                canonical_json(payload) + "\n",
+                encoding="utf-8",
+            )
+            gate_policy_path = root / "gate-policy.yaml"
+            gate_policy_path.write_text(
+                "schemaVersion: torghut.dspy.gate-policy.v1\npolicy: {}\n",
+                encoding="utf-8",
+            )
+
+            result = evaluate_dspy_compile_artifact(
+                repository="proompteng/lab",
+                base="main",
+                head="codex/dspy-eval-test",
+                artifact_path=root / "eval",
+                compile_result_ref=str(compile_result_path),
+                gate_policy_ref=str(gate_policy_path),
+                created_at=datetime(2026, 2, 27, 12, 5, tzinfo=timezone.utc),
+            )
+
+            compatibility = result.eval_report.metric_bundle[
+                "deterministicCompatibility"
+            ]
+            self.assertTrue(compatibility["artifactHashMatches"])
+            self.assertNotIn(
+                "deterministic_artifact_hash_mismatch",
+                compatibility["failures"],
+            )
+
     def test_eval_report_passes_when_thresholds_are_met(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/services/torghut/tests/test_llm_dspy_eval.py
+++ b/services/torghut/tests/test_llm_dspy_eval.py
@@ -23,7 +23,13 @@ class TestLLMDSPyEval(TestCase):
                 signature_versions={"trade_review": "v1"},
                 optimizer="miprov2",
                 dataset_payload={"rows": [{"rowId": "row-1", "split": "train"}]},
-                metric_bundle={"schema_valid_rate": 1.0},
+                metric_bundle={
+                    "schemaValidRate": 1.0,
+                    "vetoAlignmentRate": 1.0,
+                    "falseVetoRate": 0.0,
+                    "latencyP95Ms": 1,
+                    "fallbackRate": 0.0,
+                },
                 compiled_prompt_payload={
                     "promptTemplate": "torghut.dspy.trade-review.v1"
                 },

--- a/services/torghut/tests/test_llm_dspy_runtime.py
+++ b/services/torghut/tests/test_llm_dspy_runtime.py
@@ -674,53 +674,6 @@ class TestLLMDSPyRuntime(TestCase):
         self.assertEqual(manifest.artifact_hash, artifact_hash)
         self.assertEqual(manifest.executor, "dspy_live")
 
-    def test_manifest_query_prefers_passing_duplicate_hash_row(self) -> None:
-        artifact_hash = "a" * 64
-        row = SimpleNamespace(
-            artifact_uri="s3://bucket/dspy-compiled-program.json",
-            reproducibility_hash="b" * 64,
-            optimizer="miprov2",
-            dataset_hash="c" * 64,
-            compiled_prompt_hash="d" * 64,
-            signature_version="trade_review:v1",
-            program_name="trade-review-committee-v1",
-            gate_compatibility="pass",
-            metadata_json={"executor": "dspy_live"},
-        )
-        runtime = DSPyReviewRuntime(
-            mode="active",
-            artifact_hash=artifact_hash,
-            program_name=row.program_name,
-            signature_version="v1",
-            timeout_seconds=8,
-        )
-        captured_queries: list[object] = []
-
-        with (
-            patch(
-                "app.db.SessionLocal",
-                return_value=self._fake_session_context(
-                    row,
-                    captured_queries=captured_queries,
-                ),
-            ),
-            patch(
-                "app.trading.llm.dspy_programs.runtime.hash_payload",
-                return_value=artifact_hash,
-            ),
-        ):
-            manifest = runtime._load_manifest_from_db(artifact_hash)
-
-        self.assertIsNotNone(manifest)
-        self.assertEqual(len(captured_queries), 1)
-        query_text = str(captured_queries[0])
-        self.assertIn("CASE WHEN", query_text)
-        self.assertIn("gate_compatibility", query_text)
-        self.assertLess(
-            query_text.index("gate_compatibility"),
-            query_text.index("created_at DESC"),
-        )
-
     def test_active_readiness_rejects_heuristic_executor(self) -> None:
         original_base = settings.jangar_base_url
         settings.jangar_base_url = "https://jangar.local/"

--- a/services/torghut/tests/test_llm_dspy_runtime.py
+++ b/services/torghut/tests/test_llm_dspy_runtime.py
@@ -28,7 +28,11 @@ from app.trading.llm.dspy_programs.signatures import DSPyTradeReviewOutput
 
 class TestLLMDSPyRuntime(TestCase):
     @staticmethod
-    def _fake_session_context(row: SimpleNamespace) -> object:
+    def _fake_session_context(
+        row: SimpleNamespace,
+        *,
+        captured_queries: list[object] | None = None,
+    ) -> object:
         class _FakeResult:
             def scalars(self) -> "_FakeResult":
                 return self
@@ -37,7 +41,9 @@ class TestLLMDSPyRuntime(TestCase):
                 return row
 
         class _FakeSession:
-            def execute(self, _query: Any) -> _FakeResult:
+            def execute(self, query: Any) -> _FakeResult:
+                if captured_queries is not None:
+                    captured_queries.append(query)
                 return _FakeResult()
 
         class _FakeSessionContext:
@@ -667,6 +673,53 @@ class TestLLMDSPyRuntime(TestCase):
         assert manifest is not None
         self.assertEqual(manifest.artifact_hash, artifact_hash)
         self.assertEqual(manifest.executor, "dspy_live")
+
+    def test_manifest_query_prefers_passing_duplicate_hash_row(self) -> None:
+        artifact_hash = "a" * 64
+        row = SimpleNamespace(
+            artifact_uri="s3://bucket/dspy-compiled-program.json",
+            reproducibility_hash="b" * 64,
+            optimizer="miprov2",
+            dataset_hash="c" * 64,
+            compiled_prompt_hash="d" * 64,
+            signature_version="trade_review:v1",
+            program_name="trade-review-committee-v1",
+            gate_compatibility="pass",
+            metadata_json={"executor": "dspy_live"},
+        )
+        runtime = DSPyReviewRuntime(
+            mode="active",
+            artifact_hash=artifact_hash,
+            program_name=row.program_name,
+            signature_version="v1",
+            timeout_seconds=8,
+        )
+        captured_queries: list[object] = []
+
+        with (
+            patch(
+                "app.db.SessionLocal",
+                return_value=self._fake_session_context(
+                    row,
+                    captured_queries=captured_queries,
+                ),
+            ),
+            patch(
+                "app.trading.llm.dspy_programs.runtime.hash_payload",
+                return_value=artifact_hash,
+            ),
+        ):
+            manifest = runtime._load_manifest_from_db(artifact_hash)
+
+        self.assertIsNotNone(manifest)
+        self.assertEqual(len(captured_queries), 1)
+        query_text = str(captured_queries[0])
+        self.assertIn("CASE WHEN", query_text)
+        self.assertIn("gate_compatibility", query_text)
+        self.assertLess(
+            query_text.index("gate_compatibility"),
+            query_text.index("created_at DESC"),
+        )
 
     def test_active_readiness_rejects_heuristic_executor(self) -> None:
         original_base = settings.jangar_base_url

--- a/services/torghut/tests/test_llm_dspy_runtime.py
+++ b/services/torghut/tests/test_llm_dspy_runtime.py
@@ -8,6 +8,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from app.config import settings
+from app.trading.llm.dspy_compile.hashing import hash_payload
 from app.trading.llm.dspy_programs.runtime import (
     DSPyArtifactManifest,
     DSPyReviewRuntime,
@@ -26,6 +27,30 @@ from app.trading.llm.dspy_programs.signatures import DSPyTradeReviewOutput
 
 
 class TestLLMDSPyRuntime(TestCase):
+    @staticmethod
+    def _fake_session_context(row: SimpleNamespace) -> object:
+        class _FakeResult:
+            def scalars(self) -> "_FakeResult":
+                return self
+
+            def first(self) -> SimpleNamespace:
+                return row
+
+        class _FakeSession:
+            def execute(self, _query: Any) -> _FakeResult:
+                return _FakeResult()
+
+        class _FakeSessionContext:
+            def __enter__(self) -> _FakeSession:
+                return _FakeSession()
+
+            def __exit__(
+                self, exc_type: object, exc: object, tb: object
+            ) -> bool | None:
+                return None
+
+        return _FakeSessionContext()
+
     def _enable_live_runtime_gate(
         self,
         *,
@@ -599,6 +624,49 @@ class TestLLMDSPyRuntime(TestCase):
                 runtime._load_manifest_from_db(artifact_hash)
 
         self.assertIn("dspy_artifact_executor_missing", str(exc.exception))
+
+    def test_load_manifest_accepts_legacy_local_artifact_uri_hash(self) -> None:
+        artifact_uri = "/workspace/legacy/compile/dspy-compiled-program.json"
+        row = SimpleNamespace(
+            artifact_uri=artifact_uri,
+            reproducibility_hash="b" * 64,
+            optimizer="miprov2",
+            dataset_hash="c" * 64,
+            compiled_prompt_hash="d" * 64,
+            signature_version="trade_review:v1",
+            program_name="trade-review-committee-v1",
+            gate_compatibility="pass",
+            metadata_json={"executor": "dspy_live"},
+        )
+        artifact_hash = hash_payload(
+            {
+                "program_name": row.program_name,
+                "signature_versions": {"trade_review": "v1"},
+                "optimizer": row.optimizer,
+                "dataset_hash": row.dataset_hash,
+                "compiled_prompt_hash": row.compiled_prompt_hash,
+                "compiled_artifact_uri": artifact_uri,
+                "reproducibility_hash": row.reproducibility_hash,
+            }
+        )
+        runtime = DSPyReviewRuntime(
+            mode="active",
+            artifact_hash=artifact_hash,
+            program_name=row.program_name,
+            signature_version="v1",
+            timeout_seconds=8,
+        )
+
+        with patch(
+            "app.db.SessionLocal",
+            return_value=self._fake_session_context(row),
+        ):
+            manifest = runtime._load_manifest_from_db(artifact_hash)
+
+        self.assertIsNotNone(manifest)
+        assert manifest is not None
+        self.assertEqual(manifest.artifact_hash, artifact_hash)
+        self.assertEqual(manifest.executor, "dspy_live")
 
     def test_active_readiness_rejects_heuristic_executor(self) -> None:
         original_base = settings.jangar_base_url

--- a/services/torghut/tests/test_llm_dspy_runtime_duplicate_hash.py
+++ b/services/torghut/tests/test_llm_dspy_runtime_duplicate_hash.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from typing import Any
 from unittest import TestCase
 from unittest.mock import patch
 
-from app.trading.llm.dspy_programs.runtime import DSPyReviewRuntime
+from app.trading.llm.dspy_programs.runtime import (
+    DSPyReviewRuntime,
+    DSPyRuntimeUnsupportedStateError,
+)
 
 
 class TestLLMDSPyRuntimeDuplicateHash(TestCase):
@@ -23,7 +25,7 @@ class TestLLMDSPyRuntimeDuplicateHash(TestCase):
                 return row
 
         class _FakeSession:
-            def execute(self, query: Any) -> _FakeResult:
+            def execute(self, query: object) -> _FakeResult:
                 captured_queries.append(query)
                 return _FakeResult()
 
@@ -78,9 +80,41 @@ class TestLLMDSPyRuntimeDuplicateHash(TestCase):
         self.assertIsNotNone(manifest)
         self.assertEqual(len(captured_queries), 1)
         query_text = str(captured_queries[0])
-        self.assertIn("CASE WHEN", query_text)
         self.assertIn("gate_compatibility", query_text)
-        self.assertLess(
-            query_text.index("gate_compatibility"),
-            query_text.index("created_at DESC"),
+        self.assertIn(
+            "llm_dspy_workflow_artifacts.gate_compatibility = :gate_compatibility_1",
+            query_text,
         )
+
+    def test_manifest_loader_rejects_row_without_passing_gate(self) -> None:
+        artifact_hash = "a" * 64
+        row = SimpleNamespace(
+            artifact_uri="s3://bucket/dspy-compiled-program.json",
+            reproducibility_hash="b" * 64,
+            optimizer="miprov2",
+            dataset_hash="c" * 64,
+            compiled_prompt_hash="d" * 64,
+            signature_version="trade_review:v1",
+            program_name="trade-review-committee-v1",
+            gate_compatibility=None,
+            metadata_json={"executor": "dspy_live"},
+        )
+        runtime = DSPyReviewRuntime(
+            mode="active",
+            artifact_hash=artifact_hash,
+            program_name=row.program_name,
+            signature_version="v1",
+            timeout_seconds=8,
+        )
+
+        with (
+            patch(
+                "app.db.SessionLocal",
+                return_value=self._fake_session_context(row, captured_queries=[]),
+            ),
+            self.assertRaisesRegex(
+                DSPyRuntimeUnsupportedStateError,
+                "dspy_artifact_gate_compatibility_failed",
+            ),
+        ):
+            runtime._load_manifest_from_db(artifact_hash)

--- a/services/torghut/tests/test_llm_dspy_runtime_duplicate_hash.py
+++ b/services/torghut/tests/test_llm_dspy_runtime_duplicate_hash.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest import TestCase
+from unittest.mock import patch
+
+from app.trading.llm.dspy_programs.runtime import DSPyReviewRuntime
+
+
+class TestLLMDSPyRuntimeDuplicateHash(TestCase):
+    @staticmethod
+    def _fake_session_context(
+        row: SimpleNamespace,
+        *,
+        captured_queries: list[object],
+    ) -> object:
+        class _FakeResult:
+            def scalars(self) -> "_FakeResult":
+                return self
+
+            def first(self) -> SimpleNamespace:
+                return row
+
+        class _FakeSession:
+            def execute(self, query: Any) -> _FakeResult:
+                captured_queries.append(query)
+                return _FakeResult()
+
+        class _FakeSessionContext:
+            def __enter__(self) -> _FakeSession:
+                return _FakeSession()
+
+            def __exit__(
+                self, exc_type: object, exc: object, tb: object
+            ) -> bool | None:
+                return None
+
+        return _FakeSessionContext()
+
+    def test_manifest_query_prefers_passing_duplicate_hash_row(self) -> None:
+        artifact_hash = "a" * 64
+        row = SimpleNamespace(
+            artifact_uri="s3://bucket/dspy-compiled-program.json",
+            reproducibility_hash="b" * 64,
+            optimizer="miprov2",
+            dataset_hash="c" * 64,
+            compiled_prompt_hash="d" * 64,
+            signature_version="trade_review:v1",
+            program_name="trade-review-committee-v1",
+            gate_compatibility="pass",
+            metadata_json={"executor": "dspy_live"},
+        )
+        runtime = DSPyReviewRuntime(
+            mode="active",
+            artifact_hash=artifact_hash,
+            program_name=row.program_name,
+            signature_version="v1",
+            timeout_seconds=8,
+        )
+        captured_queries: list[object] = []
+
+        with (
+            patch(
+                "app.db.SessionLocal",
+                return_value=self._fake_session_context(
+                    row,
+                    captured_queries=captured_queries,
+                ),
+            ),
+            patch(
+                "app.trading.llm.dspy_programs.runtime.hash_payload",
+                return_value=artifact_hash,
+            ),
+        ):
+            manifest = runtime._load_manifest_from_db(artifact_hash)
+
+        self.assertIsNotNone(manifest)
+        self.assertEqual(len(captured_queries), 1)
+        query_text = str(captured_queries[0])
+        self.assertIn("CASE WHEN", query_text)
+        self.assertIn("gate_compatibility", query_text)
+        self.assertLess(
+            query_text.index("gate_compatibility"),
+            query_text.index("created_at DESC"),
+        )


### PR DESCRIPTION
## Summary

- Replace checkout-local dataset and metric-policy references in compile metadata with content-addressed SHA-256 references.
- Normalize local compiled-artifact URIs before artifact hash generation and verification while preserving actual filesystem paths for I/O.
- Keep compiler, evaluator, and runtime hash recomputation on the same canonical contract.
- Add a regression compiling identical inputs under two different checkout/output roots and requiring identical prompt, artifact, reproducibility, and metric-bundle hashes.

## Related Issues

Follow-up to Codex reviews on #3965.

## Testing

- Focused DSPy compiler/evaluator/runtime/workflow pytest: 54 passed
- Ruff check and format check
- Python bytecode compilation
- `git diff --check`

Repository-wide Pyright could not run correctly in the borrowed local environment because the configured worktree-local venv was absent, producing unrelated missing-dependency errors. CI provides the authoritative Pyright gate.

## Breaking Changes

DSPy compile metadata now records dataset/policy refs as content-addressed `sha256:<digest>` identifiers rather than absolute local paths.
