### PR TITLE
fix(torghut): keep historical scope empty

### DIFF
--- a/services/torghut/scripts/historical_simulation_analysis/report_builder.py
+++ b/services/torghut/scripts/historical_simulation_analysis/report_builder.py
@@ -37,6 +37,7 @@ from .report_helpers import (
     _decimal_to_str,
     _extract_run_scope_decisions,
     _extract_signal_event_ts,
+    _filter_rows_by_scope_ids,
     _fifo_trade_pnl,
     _json_default,
     _load_json,
@@ -109,14 +110,11 @@ def _build_report(args: argparse.Namespace) -> dict[str, Any]:
             "execution_actual_adapter, execution_fallback_reason, execution_fallback_count "
             "FROM executions ORDER BY created_at ASC",
         )
-        if decision_ids:
-            executions = [
-                row
-                for row in executions_all
-                if str(row.get("trade_decision_id") or "") in decision_ids
-            ]
-        else:
-            executions = executions_all
+        executions = _filter_rows_by_scope_ids(
+            executions_all,
+            foreign_key="trade_decision_id",
+            scope_ids=decision_ids,
+        )
         execution_ids = {str(row.get("id")) for row in executions}
 
         order_events_all = _query_rows(
@@ -127,14 +125,11 @@ def _build_report(args: argparse.Namespace) -> dict[str, Any]:
         order_events_unlinked = sum(
             1 for row in order_events_all if row.get("execution_id") is None
         )
-        if execution_ids:
-            order_events = [
-                row
-                for row in order_events_all
-                if str(row.get("execution_id") or "") in execution_ids
-            ]
-        else:
-            order_events = order_events_all
+        order_events = _filter_rows_by_scope_ids(
+            order_events_all,
+            foreign_key="execution_id",
+            scope_ids=execution_ids,
+        )
 
         tca_all = _query_rows(
             conn,
@@ -142,14 +137,11 @@ def _build_report(args: argparse.Namespace) -> dict[str, Any]:
             "arrival_price, shortfall_notional, slippage_bps, realized_shortfall_bps, divergence_bps, computed_at "
             "FROM execution_tca_metrics ORDER BY computed_at ASC",
         )
-        if execution_ids:
-            tca_rows = [
-                row
-                for row in tca_all
-                if str(row.get("execution_id") or "") in execution_ids
-            ]
-        else:
-            tca_rows = tca_all
+        tca_rows = _filter_rows_by_scope_ids(
+            tca_all,
+            foreign_key="execution_id",
+            scope_ids=execution_ids,
+        )
 
         llm_reviews_all = _query_rows(
             conn,
@@ -157,14 +149,11 @@ def _build_report(args: argparse.Namespace) -> dict[str, Any]:
             "tokens_completion, risk_flags, response_json, created_at "
             "FROM llm_decision_reviews ORDER BY created_at ASC",
         )
-        if decision_ids:
-            llm_reviews = [
-                row
-                for row in llm_reviews_all
-                if str(row.get("trade_decision_id") or "") in decision_ids
-            ]
-        else:
-            llm_reviews = llm_reviews_all
+        llm_reviews = _filter_rows_by_scope_ids(
+            llm_reviews_all,
+            foreign_key="trade_decision_id",
+            scope_ids=decision_ids,
+        )
 
         trade_cursor_rows = _query_rows(
             conn,

--- a/services/torghut/scripts/historical_simulation_analysis/report_builder.py
+++ b/services/torghut/scripts/historical_simulation_analysis/report_builder.py
@@ -37,6 +37,7 @@ from .report_helpers import (
     _decimal_to_str,
     _extract_run_scope_decisions,
     _extract_signal_event_ts,
+    _filter_rows_by_any_scope_id,
     _filter_rows_by_scope_ids,
     _fifo_trade_pnl,
     _json_default,
@@ -119,16 +120,19 @@ def _build_report(args: argparse.Namespace) -> dict[str, Any]:
 
         order_events_all = _query_rows(
             conn,
-            "SELECT execution_id, event_ts, created_at, status, event_type FROM execution_order_events ORDER BY created_at ASC",
+            "SELECT execution_id, trade_decision_id, event_ts, created_at, status, event_type "
+            "FROM execution_order_events ORDER BY created_at ASC",
         )
         order_events_total = len(order_events_all)
         order_events_unlinked = sum(
             1 for row in order_events_all if row.get("execution_id") is None
         )
-        order_events = _filter_rows_by_scope_ids(
+        order_events = _filter_rows_by_any_scope_id(
             order_events_all,
-            foreign_key="execution_id",
-            scope_ids=execution_ids,
+            scope_ids_by_foreign_key={
+                "execution_id": execution_ids,
+                "trade_decision_id": decision_ids,
+            },
         )
 
         tca_all = _query_rows(

--- a/services/torghut/scripts/historical_simulation_analysis/report_builder.py
+++ b/services/torghut/scripts/historical_simulation_analysis/report_builder.py
@@ -133,15 +133,15 @@ def _build_report(args: argparse.Namespace) -> dict[str, Any]:
             "FROM execution_order_events ORDER BY created_at ASC",
         )
         order_events_total = len(order_events_all)
-        order_events_unlinked = sum(
-            1 for row in order_events_all if row.get("execution_id") is None
-        )
         order_events = _filter_rows_by_any_scope_id(
             order_events_all,
             scope_ids_by_foreign_key={
                 "execution_id": execution_ids,
                 "trade_decision_id": decision_ids,
             },
+        )
+        order_events_unlinked = sum(
+            1 for row in order_events if row.get("execution_id") is None
         )
 
         tca_all = _query_rows(
@@ -500,7 +500,7 @@ def _build_report(args: argparse.Namespace) -> dict[str, Any]:
         ),
         "unlinked_order_event_count": order_events_unlinked,
         "unlinked_order_event_ratio": (
-            (order_events_unlinked / order_events_total) if order_events_total else 0.0
+            (order_events_unlinked / len(order_events)) if order_events else 0.0
         ),
         "latency_ms": {
             "signal_to_decision_p50": _percentile(signal_to_decision_ms, 50),
@@ -645,7 +645,11 @@ def _build_report(args: argparse.Namespace) -> dict[str, Any]:
 
     if len(executions) > 0 and executions_with_events == 0:
         warn_reasons.append("execution_order_events_missing")
-    if len(executions) > 0 and executions_with_events == 0 and order_events_total > 0:
+    if (
+        len(executions) > 0
+        and executions_with_events == 0
+        and order_events_unlinked > 0
+    ):
         warn_reasons.append("execution_order_events_unlinked")
     if execution_quality["adapter_mismatch_ratio"] > 0:
         warn_reasons.append("execution_adapter_mismatch_detected")

--- a/services/torghut/scripts/historical_simulation_analysis/report_builder.py
+++ b/services/torghut/scripts/historical_simulation_analysis/report_builder.py
@@ -39,6 +39,7 @@ from .report_helpers import (
     _extract_signal_event_ts,
     _filter_rows_by_any_scope_id,
     _filter_rows_by_scope_ids,
+    _resolve_scoped_execution_id,
     _fifo_trade_pnl,
     _json_default,
     _load_json,
@@ -117,6 +118,14 @@ def _build_report(args: argparse.Namespace) -> dict[str, Any]:
             scope_ids=decision_ids,
         )
         execution_ids = {str(row.get("id")) for row in executions}
+        execution_ids_by_decision: dict[str, list[str]] = {}
+        for execution in executions:
+            decision_id = str(execution.get("trade_decision_id") or "")
+            execution_id = str(execution.get("id") or "")
+            if decision_id and execution_id:
+                execution_ids_by_decision.setdefault(decision_id, []).append(
+                    execution_id
+                )
 
         order_events_all = _query_rows(
             conn,
@@ -199,7 +208,11 @@ def _build_report(args: argparse.Namespace) -> dict[str, Any]:
 
     first_order_event_by_execution: dict[str, datetime] = {}
     for event in order_events:
-        execution_id = str(event.get("execution_id") or "")
+        execution_id = _resolve_scoped_execution_id(
+            event,
+            execution_ids=execution_ids,
+            execution_ids_by_decision=execution_ids_by_decision,
+        )
         event_ts = event.get("event_ts")
         created_at = event.get("created_at")
         resolved_ts: datetime | None = None
@@ -207,7 +220,7 @@ def _build_report(args: argparse.Namespace) -> dict[str, Any]:
             resolved_ts = event_ts
         elif isinstance(created_at, datetime):
             resolved_ts = created_at
-        if execution_id and resolved_ts is not None:
+        if execution_id is not None and resolved_ts is not None:
             existing = first_order_event_by_execution.get(execution_id)
             if existing is None or resolved_ts < existing:
                 first_order_event_by_execution[execution_id] = resolved_ts
@@ -602,7 +615,7 @@ def _build_report(args: argparse.Namespace) -> dict[str, Any]:
         stability_anomalies.append("no_trade_decisions")
     if len(executions) == 0:
         stability_anomalies.append("no_executions")
-    if len(executions) > 0 and len(order_events) == 0:
+    if len(executions) > 0 and executions_with_events == 0:
         stability_anomalies.append("no_execution_order_events")
     if coverage_ratio is not None and coverage_ratio < strict_coverage_ratio:
         stability_anomalies.append("dump_coverage_below_95pct")
@@ -630,9 +643,9 @@ def _build_report(args: argparse.Namespace) -> dict[str, Any]:
     if coverage_ratio is not None and coverage_ratio < strict_coverage_ratio:
         fail_reasons.append("window_coverage_ratio_below_95pct")
 
-    if len(executions) > 0 and len(order_events) == 0:
+    if len(executions) > 0 and executions_with_events == 0:
         warn_reasons.append("execution_order_events_missing")
-    if len(executions) > 0 and len(order_events) == 0 and order_events_total > 0:
+    if len(executions) > 0 and executions_with_events == 0 and order_events_total > 0:
         warn_reasons.append("execution_order_events_unlinked")
     if execution_quality["adapter_mismatch_ratio"] > 0:
         warn_reasons.append("execution_adapter_mismatch_detected")

--- a/services/torghut/scripts/historical_simulation_analysis/report_helpers.py
+++ b/services/torghut/scripts/historical_simulation_analysis/report_helpers.py
@@ -548,6 +548,22 @@ def _filter_rows_by_any_scope_id(
     ]
 
 
+def _resolve_scoped_execution_id(
+    event: dict[str, Any],
+    *,
+    execution_ids: set[str],
+    execution_ids_by_decision: Mapping[str, list[str]],
+) -> str | None:
+    """Resolve an order event to one scoped execution without guessing."""
+    execution_id = str(event.get("execution_id") or "")
+    if execution_id in execution_ids:
+        return execution_id
+
+    decision_id = str(event.get("trade_decision_id") or "")
+    candidates = execution_ids_by_decision.get(decision_id, [])
+    return candidates[0] if len(candidates) == 1 else None
+
+
 def _csv_write(path: Path, rows_payload: list[dict[str, Any]]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     if not rows_payload:
@@ -686,6 +702,7 @@ __all__ = [
     "_extract_run_scope_decisions",
     "_filter_rows_by_scope_ids",
     "_filter_rows_by_any_scope_id",
+    "_resolve_scoped_execution_id",
     "_build_last_price_map",
     "_last_prices_from_clickhouse",
     "_last_prices_from_clickhouse_field",

--- a/services/torghut/scripts/historical_simulation_analysis/report_helpers.py
+++ b/services/torghut/scripts/historical_simulation_analysis/report_helpers.py
@@ -532,6 +532,22 @@ def _realized_by_symbol_payload(state: _FifoPnlState) -> list[dict[str, Any]]:
     ]
 
 
+def _filter_rows_by_any_scope_id(
+    rows: list[dict[str, Any]],
+    *,
+    scope_ids_by_foreign_key: Mapping[str, set[str]],
+) -> list[dict[str, Any]]:
+    """Keep rows linked through any explicitly scoped parent reference."""
+    return [
+        row
+        for row in rows
+        if any(
+            str(row.get(foreign_key) or "") in scope_ids
+            for foreign_key, scope_ids in scope_ids_by_foreign_key.items()
+        )
+    ]
+
+
 def _csv_write(path: Path, rows_payload: list[dict[str, Any]]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     if not rows_payload:
@@ -669,6 +685,7 @@ __all__ = [
     "_extract_signal_event_ts",
     "_extract_run_scope_decisions",
     "_filter_rows_by_scope_ids",
+    "_filter_rows_by_any_scope_id",
     "_build_last_price_map",
     "_last_prices_from_clickhouse",
     "_last_prices_from_clickhouse_field",

--- a/services/torghut/scripts/historical_simulation_analysis/report_helpers.py
+++ b/services/torghut/scripts/historical_simulation_analysis/report_helpers.py
@@ -556,8 +556,8 @@ def _resolve_scoped_execution_id(
 ) -> str | None:
     """Resolve an order event to one scoped execution without guessing."""
     execution_id = str(event.get("execution_id") or "")
-    if execution_id in execution_ids:
-        return execution_id
+    if execution_id:
+        return execution_id if execution_id in execution_ids else None
 
     decision_id = str(event.get("trade_decision_id") or "")
     candidates = execution_ids_by_decision.get(decision_id, [])

--- a/services/torghut/scripts/historical_simulation_analysis/report_helpers.py
+++ b/services/torghut/scripts/historical_simulation_analysis/report_helpers.py
@@ -240,6 +240,16 @@ def _extract_run_scope_decisions(
     return scoped
 
 
+def _filter_rows_by_scope_ids(
+    rows: list[dict[str, Any]],
+    *,
+    foreign_key: str,
+    scope_ids: set[str],
+) -> list[dict[str, Any]]:
+    """Keep only rows linked to the explicitly scoped parent records."""
+    return [row for row in rows if str(row.get(foreign_key) or "") in scope_ids]
+
+
 def _build_last_price_map(
     *,
     clickhouse_config: ClickHouseRuntimeConfig | None,
@@ -658,6 +668,7 @@ __all__ = [
     "_extract_simulation_context",
     "_extract_signal_event_ts",
     "_extract_run_scope_decisions",
+    "_filter_rows_by_scope_ids",
     "_build_last_price_map",
     "_last_prices_from_clickhouse",
     "_last_prices_from_clickhouse_field",

--- a/services/torghut/tests/test_analyze_historical_simulation.py
+++ b/services/torghut/tests/test_analyze_historical_simulation.py
@@ -14,6 +14,7 @@ from scripts.historical_simulation_analysis.report_builder import _build_report
 from scripts.historical_simulation_analysis.report_helpers import (
     _build_last_price_map,
     _extract_run_scope_decisions,
+    _filter_rows_by_any_scope_id,
     _filter_rows_by_scope_ids,
     _fifo_trade_pnl,
     _query_rows,
@@ -217,10 +218,17 @@ class TestAnalyzeHistoricalSimulation(TestCase):
         self.assertEqual(scoped_decisions, [])
         self.assertEqual(executions, [])
         self.assertEqual(
-            _filter_rows_by_scope_ids(
-                [{"execution_id": "execution-other"}],
-                foreign_key="execution_id",
-                scope_ids=execution_ids,
+            _filter_rows_by_any_scope_id(
+                [
+                    {
+                        "execution_id": "execution-other",
+                        "trade_decision_id": "decision-other",
+                    }
+                ],
+                scope_ids_by_foreign_key={
+                    "execution_id": execution_ids,
+                    "trade_decision_id": decision_ids,
+                },
             ),
             [],
         )
@@ -231,6 +239,34 @@ class TestAnalyzeHistoricalSimulation(TestCase):
                 scope_ids=decision_ids,
             ),
             [],
+        )
+
+    def test_order_events_accept_scoped_decision_without_execution_link(self) -> None:
+        scoped = _filter_rows_by_any_scope_id(
+            [
+                {
+                    "execution_id": None,
+                    "trade_decision_id": "decision-scoped",
+                },
+                {
+                    "execution_id": "execution-other",
+                    "trade_decision_id": "decision-other",
+                },
+            ],
+            scope_ids_by_foreign_key={
+                "execution_id": set(),
+                "trade_decision_id": {"decision-scoped"},
+            },
+        )
+
+        self.assertEqual(
+            scoped,
+            [
+                {
+                    "execution_id": None,
+                    "trade_decision_id": "decision-scoped",
+                }
+            ],
         )
 
     def test_fifo_trade_pnl_computes_realized_and_unrealized(self) -> None:

--- a/services/torghut/tests/test_analyze_historical_simulation.py
+++ b/services/torghut/tests/test_analyze_historical_simulation.py
@@ -14,6 +14,7 @@ from scripts.historical_simulation_analysis.report_builder import _build_report
 from scripts.historical_simulation_analysis.report_helpers import (
     _build_last_price_map,
     _extract_run_scope_decisions,
+    _filter_rows_by_scope_ids,
     _fifo_trade_pnl,
     _query_rows,
 )
@@ -181,6 +182,56 @@ class TestAnalyzeHistoricalSimulation(TestCase):
         scoped = _extract_run_scope_decisions(decisions, run_id="run-b")
         self.assertEqual(len(scoped), 1)
         self.assertEqual(scoped[0]["id"], "d2")
+
+    def test_empty_run_scope_does_not_admit_unrelated_child_rows(self) -> None:
+        decisions = [
+            {
+                "id": "decision-other",
+                "decision_json": {
+                    "params": {
+                        "simulation_context": {
+                            "simulation_run_id": "other-run",
+                        }
+                    }
+                },
+            }
+        ]
+
+        scoped_decisions = _extract_run_scope_decisions(
+            decisions,
+            run_id="requested-run",
+        )
+        decision_ids = {str(row.get("id")) for row in scoped_decisions}
+        executions = _filter_rows_by_scope_ids(
+            [
+                {
+                    "id": "execution-other",
+                    "trade_decision_id": "decision-other",
+                }
+            ],
+            foreign_key="trade_decision_id",
+            scope_ids=decision_ids,
+        )
+        execution_ids = {str(row.get("id")) for row in executions}
+
+        self.assertEqual(scoped_decisions, [])
+        self.assertEqual(executions, [])
+        self.assertEqual(
+            _filter_rows_by_scope_ids(
+                [{"execution_id": "execution-other"}],
+                foreign_key="execution_id",
+                scope_ids=execution_ids,
+            ),
+            [],
+        )
+        self.assertEqual(
+            _filter_rows_by_scope_ids(
+                [{"trade_decision_id": "decision-other"}],
+                foreign_key="trade_decision_id",
+                scope_ids=decision_ids,
+            ),
+            [],
+        )
 
     def test_fifo_trade_pnl_computes_realized_and_unrealized(self) -> None:
         executions = [

--- a/services/torghut/tests/test_analyze_historical_simulation.py
+++ b/services/torghut/tests/test_analyze_historical_simulation.py
@@ -298,6 +298,22 @@ class TestAnalyzeHistoricalSimulation(TestCase):
             )
         )
 
+    def test_decision_fallback_does_not_override_mismatched_execution_link(
+        self,
+    ) -> None:
+        self.assertIsNone(
+            _resolve_scoped_execution_id(
+                {
+                    "execution_id": "execution-other",
+                    "trade_decision_id": "decision-scoped",
+                },
+                execution_ids={"execution-scoped"},
+                execution_ids_by_decision={
+                    "decision-scoped": ["execution-scoped"],
+                },
+            )
+        )
+
     def test_fifo_trade_pnl_computes_realized_and_unrealized(self) -> None:
         executions = [
             {
@@ -553,7 +569,15 @@ class TestAnalyzeHistoricalSimulation(TestCase):
 
             self.assertEqual(report["verdict"]["status"], "WARN")
             self.assertEqual(report["funnel"]["trade_decisions"], 1)
+            self.assertEqual(report["funnel"]["execution_order_events_total"], 2)
+            self.assertEqual(report["funnel"]["execution_order_events_unlinked"], 0)
             self.assertEqual(report["execution_quality"]["adapter_mismatch_count"], 1)
+            self.assertEqual(
+                report["execution_quality"]["unlinked_order_event_count"], 0
+            )
+            self.assertEqual(
+                report["execution_quality"]["unlinked_order_event_ratio"], 0.0
+            )
             self.assertEqual(report["llm"]["tokens"]["total"], 15)
             self.assertEqual(report["pnl"]["realized_pnl"], "3")
             self.assertTrue((report_dir / "simulation-report.json").exists())

--- a/services/torghut/tests/test_analyze_historical_simulation.py
+++ b/services/torghut/tests/test_analyze_historical_simulation.py
@@ -16,6 +16,7 @@ from scripts.historical_simulation_analysis.report_helpers import (
     _extract_run_scope_decisions,
     _filter_rows_by_any_scope_id,
     _filter_rows_by_scope_ids,
+    _resolve_scoped_execution_id,
     _fifo_trade_pnl,
     _query_rows,
 )
@@ -267,6 +268,34 @@ class TestAnalyzeHistoricalSimulation(TestCase):
                     "trade_decision_id": "decision-scoped",
                 }
             ],
+        )
+
+    def test_decision_linked_order_event_resolves_only_when_execution_is_unique(
+        self,
+    ) -> None:
+        event = {
+            "execution_id": None,
+            "trade_decision_id": "decision-scoped",
+        }
+
+        self.assertEqual(
+            _resolve_scoped_execution_id(
+                event,
+                execution_ids={"execution-1"},
+                execution_ids_by_decision={
+                    "decision-scoped": ["execution-1"],
+                },
+            ),
+            "execution-1",
+        )
+        self.assertIsNone(
+            _resolve_scoped_execution_id(
+                event,
+                execution_ids={"execution-1", "execution-2"},
+                execution_ids_by_decision={
+                    "decision-scoped": ["execution-1", "execution-2"],
+                },
+            )
         )
 
     def test_fifo_trade_pnl_computes_realized_and_unrealized(self) -> None:


### PR DESCRIPTION
## Summary

- Remove the empty-scope fallback that admitted all executions, order events, TCA rows, and LLM reviews when no decisions matched the requested simulation run.
- Filter every dependent evidence table through explicit scoped parent IDs.
- Add a regression proving a no-match run cannot inherit unrelated child rows.

## Related Issues

Follow-up to Codex review on #3742.

## Testing

- Historical simulation analysis pytest: 8 passed
- Ruff check and format check
- Python bytecode compilation
- `git diff --check`

## Breaking Changes

None.
