### PR TITLE
fix(torghut): stabilize options catalog changes

### DIFF
--- a/services/torghut/app/options_lane/catalog_change_detection.py
+++ b/services/torghut/app/options_lane/catalog_change_detection.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Mapping
 
 
 _CONTRACT_CATALOG_CHANGE_FIELDS = (
@@ -26,8 +26,8 @@ _CONTRACT_CATALOG_CHANGE_FIELDS = (
 
 def contract_catalog_row_changed(
     *,
-    current: dict[str, Any] | None,
-    payload: dict[str, Any],
+    current: Mapping[str, object] | None,
+    payload: Mapping[str, object],
 ) -> bool:
     """Return whether a provider payload changes a persisted catalog field."""
     return current is None or any(

--- a/services/torghut/app/options_lane/catalog_change_detection.py
+++ b/services/torghut/app/options_lane/catalog_change_detection.py
@@ -1,0 +1,39 @@
+"""Persisted-field change detection for options contract catalog rows."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+_CONTRACT_CATALOG_CHANGE_FIELDS = (
+    "contract_id",
+    "status",
+    "tradable",
+    "expiration_date",
+    "root_symbol",
+    "underlying_symbol",
+    "option_type",
+    "style",
+    "strike_price",
+    "contract_size",
+    "open_interest",
+    "open_interest_date",
+    "close_price",
+    "close_price_date",
+    "provider_updated_ts",
+)
+
+
+def contract_catalog_row_changed(
+    *,
+    current: dict[str, Any] | None,
+    payload: dict[str, Any],
+) -> bool:
+    """Return whether a provider payload changes a persisted catalog field."""
+    return current is None or any(
+        payload.get(field) != current.get(field)
+        for field in _CONTRACT_CATALOG_CHANGE_FIELDS
+    )
+
+
+__all__ = ["contract_catalog_row_changed"]

--- a/services/torghut/app/options_lane/repository.py
+++ b/services/torghut/app/options_lane/repository.py
@@ -26,6 +26,7 @@ from app.options_lane.subscription_state_repository import (
     load_non_off_subscription_symbols,
     reconcile_subscription_state,
 )
+from .catalog_change_detection import contract_catalog_row_changed
 
 
 logger = logging.getLogger(__name__)
@@ -229,26 +230,9 @@ class OptionsRepository:
                 payload = dict(contract)
                 payload["first_seen_ts"] = first_seen_ts
 
-                changed = current is None or any(
-                    payload.get(field) != current.get(field)
-                    for field in (
-                        "contract_id",
-                        "status",
-                        "tradable",
-                        "expiration_date",
-                        "root_symbol",
-                        "underlying_symbol",
-                        "underlying_asset_id",
-                        "option_type",
-                        "style",
-                        "strike_price",
-                        "contract_size",
-                        "open_interest",
-                        "open_interest_date",
-                        "close_price",
-                        "close_price_date",
-                        "provider_updated_ts",
-                    )
+                changed = contract_catalog_row_changed(
+                    current=current,
+                    payload=payload,
                 )
                 upsert_rows.append(
                     {

--- a/services/torghut/tests/test_options_lane.py
+++ b/services/torghut/tests/test_options_lane.py
@@ -23,6 +23,7 @@ from app.options_lane.options_status import build_status_payload
 from app.options_lane.repository import (
     OptionsRepository,
     SubscriptionReconcileResult,
+    _contract_catalog_row_changed,
     merge_top_ranked_contract_rows,
     ranked_contract_rows,
     top_ranked_contract_rows,
@@ -370,6 +371,32 @@ class TestOptionsLaneSettings(TestCase):
 
 
 class TestOptionsRepositoryStatusCounts(TestCase):
+    def test_contract_change_detection_ignores_nonpersisted_underlying_asset_id(
+        self,
+    ) -> None:
+        current = {
+            "contract_id": "contract-1",
+            "status": "active",
+            "tradable": True,
+            "expiration_date": date(2026, 3, 20),
+            "root_symbol": "AAPL",
+            "underlying_symbol": "AAPL",
+            "option_type": "call",
+            "style": "american",
+            "strike_price": 100.0,
+            "contract_size": 100,
+            "open_interest": 25,
+            "open_interest_date": date(2026, 3, 8),
+            "close_price": 4.5,
+            "close_price_date": date(2026, 3, 8),
+            "provider_updated_ts": datetime(2026, 3, 8, 18, 0, tzinfo=timezone.utc),
+        }
+        payload = {**current, "underlying_asset_id": "provider-asset-1"}
+
+        self.assertFalse(
+            _contract_catalog_row_changed(current=current, payload=payload)
+        )
+
     def test_count_active_contracts_uses_bounded_statement_timeout(self) -> None:
         session = _FakeCountSession(value=42)
         repo = _FakeCountRepository(session)

--- a/services/torghut/tests/test_options_lane.py
+++ b/services/torghut/tests/test_options_lane.py
@@ -20,10 +20,10 @@ from app.options_lane.alpaca import (
 )
 from app.options_lane.catalog_watermark_repository import CatalogCycleSummary
 from app.options_lane.options_status import build_status_payload
+from app.options_lane.catalog_change_detection import contract_catalog_row_changed
 from app.options_lane.repository import (
     OptionsRepository,
     SubscriptionReconcileResult,
-    _contract_catalog_row_changed,
     merge_top_ranked_contract_rows,
     ranked_contract_rows,
     top_ranked_contract_rows,
@@ -393,9 +393,7 @@ class TestOptionsRepositoryStatusCounts(TestCase):
         }
         payload = {**current, "underlying_asset_id": "provider-asset-1"}
 
-        self.assertFalse(
-            _contract_catalog_row_changed(current=current, payload=payload)
-        )
+        self.assertFalse(contract_catalog_row_changed(current=current, payload=payload))
 
     def test_count_active_contracts_uses_bounded_statement_timeout(self) -> None:
         session = _FakeCountSession(value=42)


### PR DESCRIPTION
## Summary

- Compare options catalog changes only across fields persisted by `torghut_options_contract_catalog`.
- Exclude provider-only `underlying_asset_id` from the republish decision while preserving it in emitted contract payloads.
- Add a regression proving a non-null provider asset ID does not republish an otherwise unchanged contract.

## Related Issues

Follow-up to Codex review on #4243.

## Testing

- Options lane pytest: 17 passed
- Ruff check and format check
- Python bytecode compilation
- `git diff --check`

## Breaking Changes

None.
