### PR TITLE
fix(torghut): compute upper-tail DSPy p95

### DIFF
--- a/services/torghut/app/trading/llm/dspy_compile/compiler.py
+++ b/services/torghut/app/trading/llm/dspy_compile/compiler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -507,7 +508,7 @@ def _percentile_disc(values: list[int], *, percentile: float) -> int:
         raise ValueError("percentile_values_required")
     normalized = min(max(float(percentile), 0.0), 1.0)
     ordered = sorted(values)
-    index = max(int((len(ordered) - 1) * normalized), 0)
+    index = max(math.ceil(len(ordered) * normalized) - 1, 0)
     return ordered[index]
 
 

--- a/services/torghut/tests/test_llm_dspy_compiler.py
+++ b/services/torghut/tests/test_llm_dspy_compiler.py
@@ -7,11 +7,17 @@ from tempfile import TemporaryDirectory
 from unittest import TestCase
 from urllib.parse import urlsplit, unquote
 
-from app.trading.llm.dspy_compile.compiler import compile_dspy_program_artifacts
+from app.trading.llm.dspy_compile.compiler import (
+    _percentile_disc,
+    compile_dspy_program_artifacts,
+)
 from app.trading.llm.dspy_compile.hashing import canonical_json
 
 
 class TestLLMDSPyCompiler(TestCase):
+    def test_percentile_disc_selects_upper_tail_for_two_samples(self) -> None:
+        self.assertEqual(_percentile_disc([110, 190], percentile=0.95), 190)
+
     @staticmethod
     def _normalize_ref(ref: str) -> str:
         parsed = urlsplit(ref)
@@ -401,7 +407,7 @@ class TestLLMDSPyCompiler(TestCase):
             self.assertEqual(metric_bundle["vetoAlignmentRate"], 1.0)
             self.assertEqual(metric_bundle["falseVetoRate"], 1.0)
             self.assertEqual(metric_bundle["fallbackRate"], 2 / 3)
-            self.assertEqual(metric_bundle["latencyP95Ms"], 110)
+            self.assertEqual(metric_bundle["latencyP95Ms"], 190)
 
     def test_compile_rejects_partial_observed_metrics(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

- Compute discrete percentiles with nearest-rank upper-tail selection.
- Prevent two-sample p95 latency from incorrectly returning the minimum sample.
- Update derived-metric coverage and add a direct two-sample regression.

## Related Issues

Follow-up to Codex review on #4603.

## Testing

- DSPy compiler pytest: 11 passed
- Ruff check and format check
- Python bytecode compilation
- `git diff --check`

## Breaking Changes

None.
