### PR TITLE
fix(observability): read Alloy contract source

### DIFF
--- a/services/torghut/tests/live_config_manifest_contract/test_scheduler_observability_manifest.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_scheduler_observability_manifest.py
@@ -49,10 +49,10 @@ class SchedulerObservabilityManifestTests(TestCase):
         self.assertIsInstance(collectors, list)
         self.assertIn("services", cast(list[object], collectors))
 
-        alloy_config = _configmap_data(
-            "argocd/applications/observability/cluster-metrics-alloy-configmap.yaml",
-            "config.river",
-        )
+        alloy_config = (
+            _repo_root()
+            / "argocd/applications/observability/cluster-metrics-alloy-config.river"
+        ).read_text(encoding="utf-8")
         self.assertIn("kube_deployment_spec_replicas", alloy_config)
         self.assertIn("kube_service_info", alloy_config)
 


### PR DESCRIPTION
## Summary

- Update the scheduler observability regression to read the current standalone Alloy River source.
- Remove the stale expectation that the configuration is embedded in a deleted ConfigMap manifest.

## Testing

- Scheduler observability contract: 5 passed
- Ruff check and format check
- `git diff --check`

## Breaking Changes

None.
