### PR TITLE
fix(torghut): reconcile options subscriptions by delta

### DIFF
--- a/services/torghut/app/options_lane/catalog_service.py
+++ b/services/torghut/app/options_lane/catalog_service.py
@@ -206,6 +206,7 @@ def _run_discovery_cycle() -> None:
     contract_count = 0
     changed_count = 0
     persisted_subscription_rows = _repository.list_live_subscription_candidates()
+    cold_symbols = _repository.list_cold_subscription_symbols()
     live_seed_rows = [
         row for row in persisted_subscription_rows if row.get("tier") in {"hot", "warm"}
     ]
@@ -225,6 +226,7 @@ def _run_discovery_cycle() -> None:
         warm_symbols=frozenset(protected_warm_symbols),
         hot_limit=hot_limit,
         warm_limit=warm_limit,
+        cold_symbols=cold_symbols,
     )
     cycle_owned_symbols: set[str] = set()
     active_seed_rows = [row for row in live_seed_rows if row.get("status") == "active"]

--- a/services/torghut/app/options_lane/catalog_service.py
+++ b/services/torghut/app/options_lane/catalog_service.py
@@ -18,10 +18,12 @@ from .options_status import build_status_payload
 from .repository import (
     OptionsRepository,
     merge_top_ranked_contract_rows,
+    subscription_tier_limits,
     top_ranked_contract_rows,
 )
 from .session import session_state, utc_now
 from .settings import get_options_lane_settings
+from .subscription_reconciliation import plan_provisional_subscription_reconciliation
 
 logger = logging.getLogger("uvicorn.error")
 
@@ -203,7 +205,18 @@ def _run_discovery_cycle() -> None:
     live_seed_rows = [
         row for row in persisted_subscription_rows if row.get("tier") in {"hot", "warm"}
     ]
-    persisted_symbols = {str(row["contract_symbol"]) for row in live_seed_rows}
+    protected_hot_symbols = {
+        str(row["contract_symbol"]) for row in live_seed_rows if row["tier"] == "hot"
+    }
+    protected_warm_symbols = {
+        str(row["contract_symbol"]) for row in live_seed_rows if row["tier"] == "warm"
+    }
+    hot_limit, warm_limit = subscription_tier_limits(
+        hot_cap=settings.options_subscription_hot_cap,
+        warm_cap=settings.options_subscription_warm_cap,
+        provider_cap_bootstrap=settings.options_provider_cap_bootstrap,
+    )
+    cycle_owned_symbols: set[str] = set()
     active_seed_rows = [row for row in live_seed_rows if row.get("status") == "active"]
     max_open_interest = max(
         (cast(int, row.get("open_interest") or 0) for row in active_seed_rows),
@@ -266,35 +279,45 @@ def _run_discovery_cycle() -> None:
             underlying_priority=settings.underlying_priority_set,
         )
         flush_time = monotonic()
-        subscription_flush_due = (
+        subscription_flush_due = bool(page_token) and (
             page_count == 1
             or page_count % PROVISIONAL_SUBSCRIPTION_FLUSH_PAGES == 0
-            or not page_token
             or flush_time - last_subscription_flush
             >= PROVISIONAL_SUBSCRIPTION_FLUSH_SECONDS
         )
-        if provisional_ranked_rows and subscription_flush_due:
-            provisional_symbols = {
-                str(row["contract_symbol"]) for row in provisional_ranked_rows
-            }
-            reconcile_result = _repository.write_subscription_state(
-                ranked_rows=provisional_ranked_rows,
-                deactivate_symbols=persisted_symbols - provisional_symbols,
-                observed_at=observed_at,
+        if subscription_flush_due:
+            provisional_plan = plan_provisional_subscription_reconciliation(
+                provisional_ranked_rows,
+                protected_hot_symbols=protected_hot_symbols,
+                protected_warm_symbols=protected_warm_symbols,
+                previously_owned_symbols=cycle_owned_symbols,
+                hot_limit=hot_limit,
+                warm_limit=warm_limit,
             )
-            _state.record_subscription_reconciliation(
-                changed_count=reconcile_result.changed_count,
-                deactivated_count=reconcile_result.deactivated_count,
-                observed_at=observed_at,
-            )
-            persisted_symbols = provisional_symbols
+            changed_count_for_flush = 0
+            deactivated_count_for_flush = 0
+            if provisional_plan.ranked_rows or provisional_plan.deactivate_symbols:
+                reconcile_result = _repository.write_subscription_state(
+                    ranked_rows=provisional_plan.ranked_rows,
+                    deactivate_symbols=provisional_plan.deactivate_symbols,
+                    observed_at=observed_at,
+                )
+                changed_count_for_flush = reconcile_result.changed_count
+                deactivated_count_for_flush = reconcile_result.deactivated_count
+                _state.record_subscription_reconciliation(
+                    changed_count=changed_count_for_flush,
+                    deactivated_count=deactivated_count_for_flush,
+                    observed_at=observed_at,
+                )
+            cycle_owned_symbols = provisional_plan.owned_symbols
             last_subscription_flush = flush_time
             logger.info(
-                "options catalog subscription reconciliation pages=%s desired=%s changed=%s deactivated=%s",
+                "options catalog subscription reconciliation pages=%s protected=%s cycle_owned=%s changed=%s deactivated=%s",
                 page_count,
-                len(provisional_ranked_rows),
-                reconcile_result.changed_count,
-                reconcile_result.deactivated_count,
+                len(protected_hot_symbols) + len(protected_warm_symbols),
+                len(provisional_plan.ranked_rows),
+                changed_count_for_flush,
+                deactivated_count_for_flush,
             )
             if not _state.snapshot()["ready"] and any(
                 row["tier"] == "hot" for row in provisional_ranked_rows

--- a/services/torghut/app/options_lane/catalog_service.py
+++ b/services/torghut/app/options_lane/catalog_service.py
@@ -13,6 +13,7 @@ from typing import Any, cast
 from fastapi import FastAPI, HTTPException
 
 from .alpaca import AlpacaApiError, AlpacaOptionsClient, normalize_contract_record
+from .catalog_watermark_repository import CatalogCycleSummary
 from .kafka import OptionsKafkaProducer, SequenceGenerator, build_envelope
 from .options_status import build_status_payload
 from .repository import (
@@ -374,14 +375,28 @@ def _run_discovery_cycle() -> None:
         deactivated_count=final_reconcile_result.deactivated_count,
         observed_at=observed_at,
     )
+    hot_count = sum(1 for row in ranked_rows if row["tier"] == "hot")
+    warm_count = sum(1 for row in ranked_rows if row["tier"] == "warm")
+    cycle_summary = CatalogCycleSummary(
+        observed_at=observed_at,
+        page_count=page_count,
+        contract_count=contract_count,
+        catalog_changed_count=changed_count,
+        transition_count=len(transition_rows),
+        hot_count=hot_count,
+        warm_count=warm_count,
+        subscription_changed_count=final_reconcile_result.changed_count,
+        subscription_deactivated_count=final_reconcile_result.deactivated_count,
+    )
+    _repository.record_catalog_cycle_success(cycle_summary)
     logger.info(
         "options catalog discovery cycle completed pages=%s contracts=%s changed=%s transitions=%s hot=%s warm=%s subscription_changes=%s subscription_deactivations=%s",
         page_count,
         contract_count,
         changed_count,
         len(transition_rows),
-        sum(1 for row in ranked_rows if row["tier"] == "hot"),
-        sum(1 for row in ranked_rows if row["tier"] == "warm"),
+        hot_count,
+        warm_count,
         final_reconcile_result.changed_count,
         final_reconcile_result.deactivated_count,
     )

--- a/services/torghut/app/options_lane/catalog_service.py
+++ b/services/torghut/app/options_lane/catalog_service.py
@@ -201,9 +201,7 @@ def _run_discovery_cycle() -> None:
     changed_count = 0
     persisted_subscription_rows = _repository.list_live_subscription_candidates()
     live_seed_rows = [
-        row
-        for row in persisted_subscription_rows
-        if row.get("tier") in {"hot", "warm"}
+        row for row in persisted_subscription_rows if row.get("tier") in {"hot", "warm"}
     ]
     persisted_symbols = {str(row["contract_symbol"]) for row in live_seed_rows}
     active_seed_rows = [row for row in live_seed_rows if row.get("status") == "active"]
@@ -336,10 +334,7 @@ def _run_discovery_cycle() -> None:
         underlying_priority=settings.underlying_priority_set,
     )
     final_symbols = {str(row["contract_symbol"]) for row in ranked_rows}
-    current_non_off_symbols = {
-        str(row["contract_symbol"])
-        for row in _repository.list_live_subscription_candidates()
-    }
+    current_non_off_symbols = _repository.list_non_off_subscription_symbols()
     final_reconcile_result = _repository.write_subscription_state(
         ranked_rows=ranked_rows,
         deactivate_symbols=current_non_off_symbols - final_symbols,

--- a/services/torghut/app/options_lane/catalog_service.py
+++ b/services/torghut/app/options_lane/catalog_service.py
@@ -7,6 +7,7 @@ from contextlib import asynccontextmanager
 import logging
 import threading
 from datetime import datetime, timedelta
+from time import monotonic
 from typing import Any, cast
 
 from fastapi import FastAPI, HTTPException
@@ -25,6 +26,8 @@ from .settings import get_options_lane_settings
 logger = logging.getLogger("uvicorn.error")
 
 settings = get_options_lane_settings()
+PROVISIONAL_SUBSCRIPTION_FLUSH_PAGES = 10
+PROVISIONAL_SUBSCRIPTION_FLUSH_SECONDS = 30.0
 
 
 class _CatalogState:
@@ -34,6 +37,10 @@ class _CatalogState:
         self.last_error_code: str | None = None
         self.last_error_detail: str | None = None
         self.ready = False
+        self.subscription_reconciliations_total = 0
+        self.subscription_rows_changed_total = 0
+        self.subscription_rows_deactivated_total = 0
+        self.last_subscription_reconcile_ts: str | None = None
         self.stop_event = threading.Event()
         self.thread: threading.Thread | None = None
 
@@ -53,6 +60,15 @@ class _CatalogState:
             self.last_error_code = code
             self.last_error_detail = detail
 
+    def record_subscription_reconciliation(
+        self, *, changed_count: int, deactivated_count: int, observed_at: datetime
+    ) -> None:
+        with self._lock:
+            self.subscription_reconciliations_total += 1
+            self.subscription_rows_changed_total += max(changed_count, 0)
+            self.subscription_rows_deactivated_total += max(deactivated_count, 0)
+            self.last_subscription_reconcile_ts = observed_at.isoformat()
+
     def snapshot(self) -> dict[str, Any]:
         with self._lock:
             return {
@@ -60,6 +76,10 @@ class _CatalogState:
                 "last_error_code": self.last_error_code,
                 "last_error_detail": self.last_error_detail,
                 "ready": self.ready,
+                "subscription_reconciliations_total": self.subscription_reconciliations_total,
+                "subscription_rows_changed_total": self.subscription_rows_changed_total,
+                "subscription_rows_deactivated_total": self.subscription_rows_deactivated_total,
+                "last_subscription_reconcile_ts": self.last_subscription_reconcile_ts,
             }
 
 
@@ -179,8 +199,28 @@ def _run_discovery_cycle() -> None:
     page_count = 0
     contract_count = 0
     changed_count = 0
-    max_open_interest = 0
-    provisional_ranked_rows: list[dict[str, Any]] = []
+    persisted_subscription_rows = _repository.list_live_subscription_candidates()
+    live_seed_rows = [
+        row
+        for row in persisted_subscription_rows
+        if row.get("tier") in {"hot", "warm"}
+    ]
+    persisted_symbols = {str(row["contract_symbol"]) for row in live_seed_rows}
+    active_seed_rows = [row for row in live_seed_rows if row.get("status") == "active"]
+    max_open_interest = max(
+        (cast(int, row.get("open_interest") or 0) for row in active_seed_rows),
+        default=0,
+    )
+    provisional_ranked_rows = top_ranked_contract_rows(
+        iter(active_seed_rows),
+        observed_at=observed_at,
+        hot_cap=settings.options_subscription_hot_cap,
+        warm_cap=settings.options_subscription_warm_cap,
+        max_open_interest=max(max_open_interest, 1),
+        provider_cap_bootstrap=settings.options_provider_cap_bootstrap,
+        underlying_priority=settings.underlying_priority_set,
+    )
+    last_subscription_flush = monotonic()
 
     while True:
         while not _repository.acquire_rate_bucket("contracts", 1.0, 4):
@@ -227,9 +267,36 @@ def _run_discovery_cycle() -> None:
             provider_cap_bootstrap=settings.options_provider_cap_bootstrap,
             underlying_priority=settings.underlying_priority_set,
         )
-        if provisional_ranked_rows:
-            _repository.write_subscription_state(
-                ranked_rows=provisional_ranked_rows, observed_at=observed_at
+        flush_time = monotonic()
+        subscription_flush_due = (
+            page_count == 1
+            or page_count % PROVISIONAL_SUBSCRIPTION_FLUSH_PAGES == 0
+            or not page_token
+            or flush_time - last_subscription_flush
+            >= PROVISIONAL_SUBSCRIPTION_FLUSH_SECONDS
+        )
+        if provisional_ranked_rows and subscription_flush_due:
+            provisional_symbols = {
+                str(row["contract_symbol"]) for row in provisional_ranked_rows
+            }
+            reconcile_result = _repository.write_subscription_state(
+                ranked_rows=provisional_ranked_rows,
+                deactivate_symbols=persisted_symbols - provisional_symbols,
+                observed_at=observed_at,
+            )
+            _state.record_subscription_reconciliation(
+                changed_count=reconcile_result.changed_count,
+                deactivated_count=reconcile_result.deactivated_count,
+                observed_at=observed_at,
+            )
+            persisted_symbols = provisional_symbols
+            last_subscription_flush = flush_time
+            logger.info(
+                "options catalog subscription reconciliation pages=%s desired=%s changed=%s deactivated=%s",
+                page_count,
+                len(provisional_ranked_rows),
+                reconcile_result.changed_count,
+                reconcile_result.deactivated_count,
             )
             if not _state.snapshot()["ready"] and any(
                 row["tier"] == "hot" for row in provisional_ranked_rows
@@ -268,17 +335,31 @@ def _run_discovery_cycle() -> None:
         provider_cap_bootstrap=settings.options_provider_cap_bootstrap,
         underlying_priority=settings.underlying_priority_set,
     )
-    _repository.write_subscription_state(
-        ranked_rows=ranked_rows, observed_at=observed_at
+    final_symbols = {str(row["contract_symbol"]) for row in ranked_rows}
+    current_non_off_symbols = {
+        str(row["contract_symbol"])
+        for row in _repository.list_live_subscription_candidates()
+    }
+    final_reconcile_result = _repository.write_subscription_state(
+        ranked_rows=ranked_rows,
+        deactivate_symbols=current_non_off_symbols - final_symbols,
+        observed_at=observed_at,
+    )
+    _state.record_subscription_reconciliation(
+        changed_count=final_reconcile_result.changed_count,
+        deactivated_count=final_reconcile_result.deactivated_count,
+        observed_at=observed_at,
     )
     logger.info(
-        "options catalog discovery cycle completed pages=%s contracts=%s changed=%s transitions=%s hot=%s warm=%s",
+        "options catalog discovery cycle completed pages=%s contracts=%s changed=%s transitions=%s hot=%s warm=%s subscription_changes=%s subscription_deactivations=%s",
         page_count,
         contract_count,
         changed_count,
         len(transition_rows),
         sum(1 for row in ranked_rows if row["tier"] == "hot"),
         sum(1 for row in ranked_rows if row["tier"] == "warm"),
+        final_reconcile_result.changed_count,
+        final_reconcile_result.deactivated_count,
     )
     _publish_status(status_value="ok", observed_at=observed_at)
     _producer.flush()

--- a/services/torghut/app/options_lane/catalog_service.py
+++ b/services/torghut/app/options_lane/catalog_service.py
@@ -23,7 +23,10 @@ from .repository import (
 )
 from .session import session_state, utc_now
 from .settings import get_options_lane_settings
-from .subscription_reconciliation import plan_provisional_subscription_reconciliation
+from .subscription_reconciliation import (
+    ProtectedSubscriptionSeed,
+    plan_provisional_subscription_reconciliation,
+)
 
 logger = logging.getLogger("uvicorn.error")
 
@@ -216,6 +219,12 @@ def _run_discovery_cycle() -> None:
         warm_cap=settings.options_subscription_warm_cap,
         provider_cap_bootstrap=settings.options_provider_cap_bootstrap,
     )
+    protected_seed = ProtectedSubscriptionSeed(
+        hot_symbols=frozenset(protected_hot_symbols),
+        warm_symbols=frozenset(protected_warm_symbols),
+        hot_limit=hot_limit,
+        warm_limit=warm_limit,
+    )
     cycle_owned_symbols: set[str] = set()
     active_seed_rows = [row for row in live_seed_rows if row.get("status") == "active"]
     max_open_interest = max(
@@ -288,11 +297,8 @@ def _run_discovery_cycle() -> None:
         if subscription_flush_due:
             provisional_plan = plan_provisional_subscription_reconciliation(
                 provisional_ranked_rows,
-                protected_hot_symbols=protected_hot_symbols,
-                protected_warm_symbols=protected_warm_symbols,
+                protected_seed=protected_seed,
                 previously_owned_symbols=cycle_owned_symbols,
-                hot_limit=hot_limit,
-                warm_limit=warm_limit,
             )
             changed_count_for_flush = 0
             deactivated_count_for_flush = 0

--- a/services/torghut/app/options_lane/catalog_watermark_repository.py
+++ b/services/torghut/app/options_lane/catalog_watermark_repository.py
@@ -1,0 +1,76 @@
+"""Catalog-cycle watermark persistence for the options lane."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime
+import json
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+
+@dataclass(frozen=True)
+class CatalogCycleSummary:
+    observed_at: datetime
+    page_count: int
+    contract_count: int
+    catalog_changed_count: int
+    transition_count: int
+    hot_count: int
+    warm_count: int
+    subscription_changed_count: int
+    subscription_deactivated_count: int
+
+
+def record_catalog_cycle_success(
+    session: Session, summary: CatalogCycleSummary
+) -> None:
+    """Record one successful complete scan without rewriting stable subscriptions."""
+
+    metadata = asdict(summary)
+    metadata.pop("observed_at")
+    with session.begin():
+        session.execute(
+            text(
+                """
+                INSERT INTO torghut_options_watermarks (
+                  component,
+                  scope_type,
+                  scope_key,
+                  cursor,
+                  last_event_ts,
+                  last_success_ts,
+                  next_eligible_ts,
+                  retry_count,
+                  metadata
+                ) VALUES (
+                  'catalog',
+                  'universe',
+                  'live',
+                  NULL,
+                  :observed_at,
+                  :observed_at,
+                  NULL,
+                  0,
+                  CAST(:metadata AS JSONB)
+                )
+                ON CONFLICT (component, scope_type, scope_key) DO UPDATE
+                SET cursor = NULL,
+                    last_event_ts = EXCLUDED.last_event_ts,
+                    last_success_ts = EXCLUDED.last_success_ts,
+                    next_eligible_ts = NULL,
+                    retry_count = 0,
+                    metadata = EXCLUDED.metadata
+                """
+            ),
+            {
+                "observed_at": summary.observed_at,
+                "metadata": json.dumps(
+                    metadata,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    default=str,
+                ),
+            },
+        )

--- a/services/torghut/app/options_lane/repository.py
+++ b/services/torghut/app/options_lane/repository.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from contextlib import contextmanager
+from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
 import heapq
-from itertools import chain
 import json
 import logging
 from typing import Any, Iterator, cast
@@ -20,6 +20,14 @@ from sqlalchemy.orm import Session, sessionmaker
 logger = logging.getLogger(__name__)
 
 OPTIONS_STATUS_COUNT_TIMEOUT_MS = 500
+
+
+@dataclass(frozen=True)
+class SubscriptionReconcileResult:
+    hot_count: int
+    warm_count: int
+    changed_count: int
+    deactivated_count: int
 
 
 def _utc_now() -> datetime:
@@ -479,24 +487,97 @@ class OptionsRepository:
                 for row in batch:
                     yield dict(row)
 
+    def list_live_subscription_candidates(self) -> list[dict[str, Any]]:
+        """Return only the persisted hot/warm candidate seed."""
+
+        with self.session() as session:
+            rows = session.execute(
+                text(
+                    """
+                    SELECT catalog.contract_symbol,
+                           catalog.status,
+                           catalog.underlying_symbol,
+                           catalog.expiration_date,
+                           catalog.strike_price,
+                           catalog.close_price,
+                           catalog.open_interest,
+                           subs.ranking_score,
+                           COALESCE(subs.ranking_inputs, '{}'::JSONB) AS ranking_inputs,
+                           subs.tier,
+                           subs.desired_channels,
+                           subs.provider_cap_generation
+                    FROM torghut_options_subscription_state AS subs
+                    JOIN torghut_options_contract_catalog AS catalog
+                      ON catalog.contract_symbol = subs.contract_symbol
+                    WHERE subs.tier IN ('hot', 'warm')
+                    ORDER BY subs.ranking_score DESC, catalog.contract_symbol ASC
+                    """
+                )
+            ).mappings()
+            return [dict(row) for row in rows]
+
     def write_subscription_state(
         self,
         *,
         ranked_rows: list[dict[str, Any]],
+        deactivate_symbols: Iterable[str],
         observed_at: datetime,
-    ) -> tuple[int, int]:
+    ) -> SubscriptionReconcileResult:
         hot_count = 0
         warm_count = 0
+        desired_rows: list[dict[str, Any]] = []
+        desired_symbols: set[str] = set()
+        for row in ranked_rows:
+            contract_symbol = str(row["contract_symbol"])
+            if contract_symbol in desired_symbols:
+                raise ValueError(
+                    f"duplicate subscription contract symbol: {contract_symbol}"
+                )
+            desired_symbols.add(contract_symbol)
+            tier = cast(str, row["tier"])
+            if tier == "hot":
+                hot_count += 1
+            elif tier == "warm":
+                warm_count += 1
+            desired_rows.append(
+                {
+                    "contract_symbol": contract_symbol,
+                    "ranking_score": float(row["ranking_score"]),
+                    "ranking_inputs": row["ranking_inputs"],
+                    "tier": tier,
+                    "desired_channels": list(row["desired_channels"]),
+                    "provider_cap_generation": int(row["provider_cap_generation"]),
+                }
+            )
+
+        explicit_deactivations = sorted(
+            {
+                str(contract_symbol)
+                for contract_symbol in deactivate_symbols
+                if str(contract_symbol)
+            }
+            - desired_symbols
+        )
+        changed_count = 0
+        deactivated_count = 0
         with self.session() as session, session.begin():
-            for row in ranked_rows:
-                tier = cast(str, row["tier"])
-                if tier == "hot":
-                    hot_count += 1
-                elif tier == "warm":
-                    warm_count += 1
-                session.execute(
+            if desired_rows:
+                result = session.execute(
                     text(
                         """
+                        WITH desired AS (
+                          SELECT item ->> 'contract_symbol' AS contract_symbol,
+                                 CAST(item ->> 'ranking_score' AS DOUBLE PRECISION) AS ranking_score,
+                                 COALESCE(item -> 'ranking_inputs', '{}'::JSONB) AS ranking_inputs,
+                                 item ->> 'tier' AS tier,
+                                 ARRAY(
+                                   SELECT jsonb_array_elements_text(
+                                     COALESCE(item -> 'desired_channels', '[]'::JSONB)
+                                   )
+                                 ) AS desired_channels,
+                                 CAST(item ->> 'provider_cap_generation' AS BIGINT) AS provider_cap_generation
+                          FROM jsonb_array_elements(CAST(:ranked_rows AS JSONB)) AS source(item)
+                        )
                         INSERT INTO torghut_options_subscription_state (
                           contract_symbol,
                           ranking_score,
@@ -506,16 +587,16 @@ class OptionsRepository:
                           subscribed_channels,
                           provider_cap_generation,
                           last_ranked_ts
-                        ) VALUES (
-                          :contract_symbol,
-                          :ranking_score,
-                          CAST(:ranking_inputs AS JSONB),
-                          :tier,
-                          :desired_channels,
-                          ARRAY[]::TEXT[],
-                          :provider_cap_generation,
-                          :last_ranked_ts
                         )
+                        SELECT contract_symbol,
+                          ranking_score,
+                          ranking_inputs,
+                          tier,
+                          desired_channels,
+                          ARRAY[]::TEXT[],
+                          provider_cap_generation,
+                          :last_ranked_ts
+                        FROM desired
                         ON CONFLICT (contract_symbol) DO UPDATE
                         SET ranking_score = EXCLUDED.ranking_score,
                             ranking_inputs = EXCLUDED.ranking_inputs,
@@ -523,33 +604,50 @@ class OptionsRepository:
                             desired_channels = EXCLUDED.desired_channels,
                             provider_cap_generation = EXCLUDED.provider_cap_generation,
                             last_ranked_ts = EXCLUDED.last_ranked_ts
+                        WHERE (
+                          torghut_options_subscription_state.ranking_score,
+                          torghut_options_subscription_state.ranking_inputs,
+                          torghut_options_subscription_state.tier,
+                          torghut_options_subscription_state.desired_channels,
+                          torghut_options_subscription_state.provider_cap_generation
+                        ) IS DISTINCT FROM (
+                          EXCLUDED.ranking_score,
+                          EXCLUDED.ranking_inputs,
+                          EXCLUDED.tier,
+                          EXCLUDED.desired_channels,
+                          EXCLUDED.provider_cap_generation
+                        )
                         """
                     ),
                     {
-                        "contract_symbol": row["contract_symbol"],
-                        "ranking_score": row["ranking_score"],
-                        "ranking_inputs": _coerce_json(row["ranking_inputs"]),
-                        "tier": tier,
-                        "desired_channels": row["desired_channels"],
-                        "provider_cap_generation": row["provider_cap_generation"],
+                        "ranked_rows": _coerce_json(desired_rows),
                         "last_ranked_ts": observed_at,
                     },
                 )
-            session.execute(
-                text(
-                    """
-                    UPDATE torghut_options_subscription_state
-                    SET tier = 'off',
-                        last_ranked_ts = :last_ranked_ts
-                    WHERE contract_symbol <> ALL(:symbols)
-                    """
-                ),
-                {
-                    "symbols": [row["contract_symbol"] for row in ranked_rows] or [""],
-                    "last_ranked_ts": observed_at,
-                },
-            )
-        return hot_count, warm_count
+                changed_count = max(int(getattr(result, "rowcount", 0) or 0), 0)
+            if explicit_deactivations:
+                result = session.execute(
+                    text(
+                        """
+                        UPDATE torghut_options_subscription_state
+                        SET tier = 'off',
+                            last_ranked_ts = :last_ranked_ts
+                        WHERE contract_symbol = ANY(:symbols)
+                          AND tier IS DISTINCT FROM 'off'
+                        """
+                    ),
+                    {
+                        "symbols": explicit_deactivations,
+                        "last_ranked_ts": observed_at,
+                    },
+                )
+                deactivated_count = max(int(getattr(result, "rowcount", 0) or 0), 0)
+        return SubscriptionReconcileResult(
+            hot_count=hot_count,
+            warm_count=warm_count,
+            changed_count=changed_count,
+            deactivated_count=deactivated_count,
+        )
 
     def get_hot_symbols(self, limit: int) -> list[str]:
         with self.session() as session:
@@ -858,8 +956,20 @@ def merge_top_ranked_contract_rows(
 ) -> list[dict[str, Any]]:
     """Merge new contract rows into the current hot/warm candidate set."""
 
+    rows_by_symbol = {
+        str(row["contract_symbol"]): row
+        for row in ranked_rows
+        if row.get("contract_symbol")
+    }
+    rows_by_symbol.update(
+        {
+            str(row["contract_symbol"]): row
+            for row in contracts
+            if row.get("contract_symbol")
+        }
+    )
     return top_ranked_contract_rows(
-        iter(chain(ranked_rows, contracts)),
+        iter(rows_by_symbol.values()),
         observed_at=observed_at,
         hot_cap=hot_cap,
         warm_cap=warm_cap,

--- a/services/torghut/app/options_lane/repository.py
+++ b/services/torghut/app/options_lane/repository.py
@@ -15,6 +15,10 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, sessionmaker
 
+from app.options_lane.catalog_watermark_repository import (
+    CatalogCycleSummary,
+    record_catalog_cycle_success,
+)
 from app.options_lane.subscription_state_repository import (
     SubscriptionReconcileResult,
     load_live_subscription_candidates,
@@ -517,16 +521,26 @@ class OptionsRepository:
             rows = session.execute(
                 text(
                     """
-                    SELECT contract_symbol
-                    FROM torghut_options_subscription_state
-                    WHERE tier = 'hot'
-                    ORDER BY ranking_score DESC, contract_symbol ASC
+                    SELECT subscriptions.contract_symbol
+                    FROM torghut_options_subscription_state AS subscriptions
+                    JOIN torghut_options_contract_catalog AS catalog
+                      ON catalog.contract_symbol = subscriptions.contract_symbol
+                    WHERE subscriptions.tier = 'hot'
+                      AND catalog.status = 'active'
+                    ORDER BY subscriptions.ranking_score DESC,
+                             subscriptions.contract_symbol ASC
                     LIMIT :limit
                     """
                 ),
                 {"limit": limit},
             )
             return [cast(str, row[0]) for row in rows]
+
+    def record_catalog_cycle_success(self, summary: CatalogCycleSummary) -> None:
+        """Persist complete-cycle freshness in one watermark row."""
+
+        with self.session() as session:
+            record_catalog_cycle_success(session, summary)
 
     def get_due_snapshot_contracts(
         self,

--- a/services/torghut/app/options_lane/repository.py
+++ b/services/torghut/app/options_lane/repository.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from contextlib import contextmanager
-from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
 import heapq
 import json
@@ -16,18 +15,17 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, sessionmaker
 
+from app.options_lane.subscription_state_repository import (
+    SubscriptionReconcileResult,
+    load_live_subscription_candidates,
+    load_non_off_subscription_symbols,
+    reconcile_subscription_state,
+)
+
 
 logger = logging.getLogger(__name__)
 
 OPTIONS_STATUS_COUNT_TIMEOUT_MS = 500
-
-
-@dataclass(frozen=True)
-class SubscriptionReconcileResult:
-    hot_count: int
-    warm_count: int
-    changed_count: int
-    deactivated_count: int
 
 
 def _utc_now() -> datetime:
@@ -491,45 +489,13 @@ class OptionsRepository:
         """Return only the persisted hot/warm candidate seed."""
 
         with self.session() as session:
-            rows = session.execute(
-                text(
-                    """
-                    SELECT catalog.contract_symbol,
-                           catalog.status,
-                           catalog.underlying_symbol,
-                           catalog.expiration_date,
-                           catalog.strike_price,
-                           catalog.close_price,
-                           catalog.open_interest,
-                           subs.ranking_score,
-                           COALESCE(subs.ranking_inputs, '{}'::JSONB) AS ranking_inputs,
-                           subs.tier,
-                           subs.desired_channels,
-                           subs.provider_cap_generation
-                    FROM torghut_options_subscription_state AS subs
-                    JOIN torghut_options_contract_catalog AS catalog
-                      ON catalog.contract_symbol = subs.contract_symbol
-                    WHERE subs.tier IN ('hot', 'warm')
-                    ORDER BY subs.ranking_score DESC, catalog.contract_symbol ASC
-                    """
-                )
-            ).mappings()
-            return [dict(row) for row in rows]
+            return load_live_subscription_candidates(session)
 
     def list_non_off_subscription_symbols(self) -> set[str]:
         """Return every symbol eligible for final-cycle cleanup."""
 
         with self.session() as session:
-            rows = session.execute(
-                text(
-                    """
-                    SELECT contract_symbol
-                    FROM torghut_options_subscription_state
-                    WHERE tier IS DISTINCT FROM 'off'
-                    """
-                )
-            )
-            return {cast(str, row[0]) for row in rows}
+            return load_non_off_subscription_symbols(session)
 
     def write_subscription_state(
         self,
@@ -538,131 +504,13 @@ class OptionsRepository:
         deactivate_symbols: Iterable[str],
         observed_at: datetime,
     ) -> SubscriptionReconcileResult:
-        hot_count = 0
-        warm_count = 0
-        desired_rows: list[dict[str, Any]] = []
-        desired_symbols: set[str] = set()
-        for row in ranked_rows:
-            contract_symbol = str(row["contract_symbol"])
-            if contract_symbol in desired_symbols:
-                raise ValueError(
-                    f"duplicate subscription contract symbol: {contract_symbol}"
-                )
-            desired_symbols.add(contract_symbol)
-            tier = cast(str, row["tier"])
-            if tier == "hot":
-                hot_count += 1
-            elif tier == "warm":
-                warm_count += 1
-            desired_rows.append(
-                {
-                    "contract_symbol": contract_symbol,
-                    "ranking_score": float(row["ranking_score"]),
-                    "ranking_inputs": row["ranking_inputs"],
-                    "tier": tier,
-                    "desired_channels": list(row["desired_channels"]),
-                    "provider_cap_generation": int(row["provider_cap_generation"]),
-                }
+        with self.session() as session:
+            return reconcile_subscription_state(
+                session,
+                ranked_rows=ranked_rows,
+                deactivate_symbols=deactivate_symbols,
+                observed_at=observed_at,
             )
-
-        explicit_deactivations = sorted(
-            {
-                str(contract_symbol)
-                for contract_symbol in deactivate_symbols
-                if str(contract_symbol)
-            }
-            - desired_symbols
-        )
-        changed_count = 0
-        deactivated_count = 0
-        with self.session() as session, session.begin():
-            if desired_rows:
-                result = session.execute(
-                    text(
-                        """
-                        WITH desired AS (
-                          SELECT item ->> 'contract_symbol' AS contract_symbol,
-                                 CAST(item ->> 'ranking_score' AS DOUBLE PRECISION) AS ranking_score,
-                                 COALESCE(item -> 'ranking_inputs', '{}'::JSONB) AS ranking_inputs,
-                                 item ->> 'tier' AS tier,
-                                 ARRAY(
-                                   SELECT jsonb_array_elements_text(
-                                     COALESCE(item -> 'desired_channels', '[]'::JSONB)
-                                   )
-                                 ) AS desired_channels,
-                                 CAST(item ->> 'provider_cap_generation' AS BIGINT) AS provider_cap_generation
-                          FROM jsonb_array_elements(CAST(:ranked_rows AS JSONB)) AS source(item)
-                        )
-                        INSERT INTO torghut_options_subscription_state (
-                          contract_symbol,
-                          ranking_score,
-                          ranking_inputs,
-                          tier,
-                          desired_channels,
-                          subscribed_channels,
-                          provider_cap_generation,
-                          last_ranked_ts
-                        )
-                        SELECT contract_symbol,
-                          ranking_score,
-                          ranking_inputs,
-                          tier,
-                          desired_channels,
-                          ARRAY[]::TEXT[],
-                          provider_cap_generation,
-                          :last_ranked_ts
-                        FROM desired
-                        ON CONFLICT (contract_symbol) DO UPDATE
-                        SET ranking_score = EXCLUDED.ranking_score,
-                            ranking_inputs = EXCLUDED.ranking_inputs,
-                            tier = EXCLUDED.tier,
-                            desired_channels = EXCLUDED.desired_channels,
-                            provider_cap_generation = EXCLUDED.provider_cap_generation,
-                            last_ranked_ts = EXCLUDED.last_ranked_ts
-                        WHERE (
-                          torghut_options_subscription_state.ranking_score,
-                          torghut_options_subscription_state.ranking_inputs,
-                          torghut_options_subscription_state.tier,
-                          torghut_options_subscription_state.desired_channels,
-                          torghut_options_subscription_state.provider_cap_generation
-                        ) IS DISTINCT FROM (
-                          EXCLUDED.ranking_score,
-                          EXCLUDED.ranking_inputs,
-                          EXCLUDED.tier,
-                          EXCLUDED.desired_channels,
-                          EXCLUDED.provider_cap_generation
-                        )
-                        """
-                    ),
-                    {
-                        "ranked_rows": _coerce_json(desired_rows),
-                        "last_ranked_ts": observed_at,
-                    },
-                )
-                changed_count = max(int(getattr(result, "rowcount", 0) or 0), 0)
-            if explicit_deactivations:
-                result = session.execute(
-                    text(
-                        """
-                        UPDATE torghut_options_subscription_state
-                        SET tier = 'off',
-                            last_ranked_ts = :last_ranked_ts
-                        WHERE contract_symbol = ANY(:symbols)
-                          AND tier IS DISTINCT FROM 'off'
-                        """
-                    ),
-                    {
-                        "symbols": explicit_deactivations,
-                        "last_ranked_ts": observed_at,
-                    },
-                )
-                deactivated_count = max(int(getattr(result, "rowcount", 0) or 0), 0)
-        return SubscriptionReconcileResult(
-            hot_count=hot_count,
-            warm_count=warm_count,
-            changed_count=changed_count,
-            deactivated_count=deactivated_count,
-        )
 
     def get_hot_symbols(self, limit: int) -> list[str]:
         with self.session() as session:

--- a/services/torghut/app/options_lane/repository.py
+++ b/services/torghut/app/options_lane/repository.py
@@ -516,6 +516,21 @@ class OptionsRepository:
             ).mappings()
             return [dict(row) for row in rows]
 
+    def list_non_off_subscription_symbols(self) -> set[str]:
+        """Return every symbol eligible for final-cycle cleanup."""
+
+        with self.session() as session:
+            rows = session.execute(
+                text(
+                    """
+                    SELECT contract_symbol
+                    FROM torghut_options_subscription_state
+                    WHERE tier IS DISTINCT FROM 'off'
+                    """
+                )
+            )
+            return {cast(str, row[0]) for row in rows}
+
     def write_subscription_state(
         self,
         *,

--- a/services/torghut/app/options_lane/repository.py
+++ b/services/torghut/app/options_lane/repository.py
@@ -739,7 +739,7 @@ def ranked_contract_rows(
     ranked.sort(
         key=lambda row: (-float(row["ranking_score"]), str(row["contract_symbol"]))
     )
-    hot_count, warm_count = _tier_limits(
+    hot_count, warm_count = subscription_tier_limits(
         hot_cap=hot_cap,
         warm_cap=warm_cap,
         provider_cap_bootstrap=provider_cap_bootstrap,
@@ -766,7 +766,7 @@ def top_ranked_contract_rows(
 ) -> list[dict[str, Any]]:
     """Rank only the hot and warm candidates while streaming the active universe."""
 
-    hot_count, warm_count = _tier_limits(
+    hot_count, warm_count = subscription_tier_limits(
         hot_cap=hot_cap,
         warm_cap=warm_cap,
         provider_cap_bootstrap=provider_cap_bootstrap,
@@ -842,7 +842,7 @@ def merge_top_ranked_contract_rows(
     )
 
 
-def _tier_limits(
+def subscription_tier_limits(
     *, hot_cap: int, warm_cap: int, provider_cap_bootstrap: int
 ) -> tuple[int, int]:
     hot_count = min(hot_cap, max(int(provider_cap_bootstrap * 0.8), 0))

--- a/services/torghut/app/options_lane/repository.py
+++ b/services/torghut/app/options_lane/repository.py
@@ -21,6 +21,7 @@ from app.options_lane.catalog_watermark_repository import (
 )
 from app.options_lane.subscription_state_repository import (
     SubscriptionReconcileResult,
+    load_cold_subscription_symbols,
     load_live_subscription_candidates,
     load_non_off_subscription_symbols,
     reconcile_subscription_state,
@@ -500,6 +501,12 @@ class OptionsRepository:
 
         with self.session() as session:
             return load_non_off_subscription_symbols(session)
+
+    def list_cold_subscription_symbols(self) -> frozenset[str]:
+        """Return rows that only final reconciliation may retier or deactivate."""
+
+        with self.session() as session:
+            return load_cold_subscription_symbols(session)
 
     def write_subscription_state(
         self,

--- a/services/torghut/app/options_lane/subscription_reconciliation.py
+++ b/services/torghut/app/options_lane/subscription_reconciliation.py
@@ -15,28 +15,36 @@ class ProvisionalSubscriptionPlan:
     owned_symbols: set[str]
 
 
+@dataclass(frozen=True)
+class ProtectedSubscriptionSeed:
+    """Immutable initial membership and effective tier capacity for one scan."""
+
+    hot_symbols: frozenset[str]
+    warm_symbols: frozenset[str]
+    hot_limit: int
+    warm_limit: int
+
+    def __post_init__(self) -> None:
+        if self.hot_limit < 0 or self.warm_limit < 0:
+            raise ValueError("subscription tier limits must be non-negative")
+
+
 def plan_provisional_subscription_reconciliation(
     ranked_rows: Iterable[Mapping[str, object]],
     *,
-    protected_hot_symbols: set[str],
-    protected_warm_symbols: set[str],
+    protected_seed: ProtectedSubscriptionSeed,
     previously_owned_symbols: set[str],
-    hot_limit: int,
-    warm_limit: int,
 ) -> ProvisionalSubscriptionPlan:
     """Fill only capacity not occupied by the cycle's immutable live seed."""
 
-    if hot_limit < 0 or warm_limit < 0:
-        raise ValueError("subscription tier limits must be non-negative")
-
-    protected_symbols = protected_hot_symbols | protected_warm_symbols
+    protected_symbols = protected_seed.hot_symbols | protected_seed.warm_symbols
     eligible_rows = [
         row
         for row in ranked_rows
         if str(row.get("contract_symbol") or "") not in protected_symbols
     ]
-    hot_slots = max(hot_limit - len(protected_hot_symbols), 0)
-    warm_slots = max(warm_limit - len(protected_warm_symbols), 0)
+    hot_slots = max(protected_seed.hot_limit - len(protected_seed.hot_symbols), 0)
+    warm_slots = max(protected_seed.warm_limit - len(protected_seed.warm_symbols), 0)
     selected_rows: list[dict[str, object]] = []
     for index, row in enumerate(eligible_rows[: hot_slots + warm_slots]):
         selected_row = dict(row)

--- a/services/torghut/app/options_lane/subscription_reconciliation.py
+++ b/services/torghut/app/options_lane/subscription_reconciliation.py
@@ -2,22 +2,21 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
-from typing import Any
 
 
 @dataclass(frozen=True)
 class ProvisionalSubscriptionPlan:
     """Rows owned by the current scan and prior cycle-owned rows to deactivate."""
 
-    ranked_rows: list[dict[str, Any]]
+    ranked_rows: list[dict[str, object]]
     deactivate_symbols: set[str]
     owned_symbols: set[str]
 
 
 def plan_provisional_subscription_reconciliation(
-    ranked_rows: Iterable[dict[str, Any]],
+    ranked_rows: Iterable[Mapping[str, object]],
     *,
     protected_hot_symbols: set[str],
     protected_warm_symbols: set[str],
@@ -38,7 +37,7 @@ def plan_provisional_subscription_reconciliation(
     ]
     hot_slots = max(hot_limit - len(protected_hot_symbols), 0)
     warm_slots = max(warm_limit - len(protected_warm_symbols), 0)
-    selected_rows: list[dict[str, Any]] = []
+    selected_rows: list[dict[str, object]] = []
     for index, row in enumerate(eligible_rows[: hot_slots + warm_slots]):
         selected_row = dict(row)
         selected_row["tier"] = "hot" if index < hot_slots else "warm"

--- a/services/torghut/app/options_lane/subscription_reconciliation.py
+++ b/services/torghut/app/options_lane/subscription_reconciliation.py
@@ -1,0 +1,52 @@
+"""Pure planning helpers for provisional options subscription reconciliation."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ProvisionalSubscriptionPlan:
+    """Rows owned by the current scan and prior cycle-owned rows to deactivate."""
+
+    ranked_rows: list[dict[str, Any]]
+    deactivate_symbols: set[str]
+    owned_symbols: set[str]
+
+
+def plan_provisional_subscription_reconciliation(
+    ranked_rows: Iterable[dict[str, Any]],
+    *,
+    protected_hot_symbols: set[str],
+    protected_warm_symbols: set[str],
+    previously_owned_symbols: set[str],
+    hot_limit: int,
+    warm_limit: int,
+) -> ProvisionalSubscriptionPlan:
+    """Fill only capacity not occupied by the cycle's immutable live seed."""
+
+    if hot_limit < 0 or warm_limit < 0:
+        raise ValueError("subscription tier limits must be non-negative")
+
+    protected_symbols = protected_hot_symbols | protected_warm_symbols
+    eligible_rows = [
+        row
+        for row in ranked_rows
+        if str(row.get("contract_symbol") or "") not in protected_symbols
+    ]
+    hot_slots = max(hot_limit - len(protected_hot_symbols), 0)
+    warm_slots = max(warm_limit - len(protected_warm_symbols), 0)
+    selected_rows: list[dict[str, Any]] = []
+    for index, row in enumerate(eligible_rows[: hot_slots + warm_slots]):
+        selected_row = dict(row)
+        selected_row["tier"] = "hot" if index < hot_slots else "warm"
+        selected_rows.append(selected_row)
+
+    owned_symbols = {str(row["contract_symbol"]) for row in selected_rows}
+    return ProvisionalSubscriptionPlan(
+        ranked_rows=selected_rows,
+        deactivate_symbols=previously_owned_symbols - owned_symbols,
+        owned_symbols=owned_symbols,
+    )

--- a/services/torghut/app/options_lane/subscription_reconciliation.py
+++ b/services/torghut/app/options_lane/subscription_reconciliation.py
@@ -23,6 +23,7 @@ class ProtectedSubscriptionSeed:
     warm_symbols: frozenset[str]
     hot_limit: int
     warm_limit: int
+    cold_symbols: frozenset[str] = frozenset()
 
     def __post_init__(self) -> None:
         if self.hot_limit < 0 or self.warm_limit < 0:
@@ -37,7 +38,11 @@ def plan_provisional_subscription_reconciliation(
 ) -> ProvisionalSubscriptionPlan:
     """Fill only capacity not occupied by the cycle's immutable live seed."""
 
-    protected_symbols = protected_seed.hot_symbols | protected_seed.warm_symbols
+    protected_symbols = (
+        protected_seed.hot_symbols
+        | protected_seed.warm_symbols
+        | protected_seed.cold_symbols
+    )
     eligible_rows = [
         row
         for row in ranked_rows

--- a/services/torghut/app/options_lane/subscription_state_repository.py
+++ b/services/torghut/app/options_lane/subscription_state_repository.py
@@ -12,6 +12,9 @@ from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 
+_DEACTIVATION_BATCH_SIZE = 1_000
+
+
 @dataclass(frozen=True)
 class SubscriptionReconcileResult:
     hot_count: int
@@ -149,7 +152,8 @@ def reconcile_subscription_state(
                 },
             )
             changed_count = max(int(getattr(result, "rowcount", 0) or 0), 0)
-        if explicit_deactivations:
+        for offset in range(0, len(explicit_deactivations), _DEACTIVATION_BATCH_SIZE):
+            symbols = explicit_deactivations[offset : offset + _DEACTIVATION_BATCH_SIZE]
             result = session.execute(
                 text(
                     """
@@ -161,11 +165,11 @@ def reconcile_subscription_state(
                     """
                 ),
                 {
-                    "symbols": explicit_deactivations,
+                    "symbols": symbols,
                     "last_ranked_ts": observed_at,
                 },
             )
-            deactivated_count = max(int(getattr(result, "rowcount", 0) or 0), 0)
+            deactivated_count += max(int(getattr(result, "rowcount", 0) or 0), 0)
     return SubscriptionReconcileResult(
         hot_count=hot_count,
         warm_count=warm_count,

--- a/services/torghut/app/options_lane/subscription_state_repository.py
+++ b/services/torghut/app/options_lane/subscription_state_repository.py
@@ -1,0 +1,214 @@
+"""Persistence operations for options subscription-state reconciliation."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import datetime
+import json
+from typing import cast
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+
+@dataclass(frozen=True)
+class SubscriptionReconcileResult:
+    hot_count: int
+    warm_count: int
+    changed_count: int
+    deactivated_count: int
+
+
+def load_live_subscription_candidates(session: Session) -> list[dict[str, object]]:
+    """Return only persisted hot/warm rows eligible to seed live ranking."""
+
+    rows = session.execute(
+        text(
+            """
+            SELECT catalog.contract_symbol,
+                   catalog.status,
+                   catalog.underlying_symbol,
+                   catalog.expiration_date,
+                   catalog.strike_price,
+                   catalog.close_price,
+                   catalog.open_interest,
+                   subs.ranking_score,
+                   COALESCE(subs.ranking_inputs, '{}'::JSONB) AS ranking_inputs,
+                   subs.tier,
+                   subs.desired_channels,
+                   subs.provider_cap_generation
+            FROM torghut_options_subscription_state AS subs
+            JOIN torghut_options_contract_catalog AS catalog
+              ON catalog.contract_symbol = subs.contract_symbol
+            WHERE subs.tier IN ('hot', 'warm')
+            ORDER BY subs.ranking_score DESC, catalog.contract_symbol ASC
+            """
+        )
+    ).mappings()
+    return [dict(row) for row in rows]
+
+
+def load_non_off_subscription_symbols(session: Session) -> set[str]:
+    """Return every symbol eligible for final-cycle cleanup."""
+
+    rows = session.execute(
+        text(
+            """
+            SELECT contract_symbol
+            FROM torghut_options_subscription_state
+            WHERE tier IS DISTINCT FROM 'off'
+            """
+        )
+    )
+    return {cast(str, row[0]) for row in rows}
+
+
+def reconcile_subscription_state(
+    session: Session,
+    *,
+    ranked_rows: list[dict[str, object]],
+    deactivate_symbols: Iterable[str],
+    observed_at: datetime,
+) -> SubscriptionReconcileResult:
+    """Apply one conditional desired-state upsert and explicit deactivation set."""
+
+    desired_rows, desired_symbols, hot_count, warm_count = _desired_rows(ranked_rows)
+    explicit_deactivations = sorted(
+        {
+            str(contract_symbol)
+            for contract_symbol in deactivate_symbols
+            if str(contract_symbol)
+        }
+        - desired_symbols
+    )
+    changed_count = 0
+    deactivated_count = 0
+    with session.begin():
+        if desired_rows:
+            result = session.execute(
+                text(
+                    """
+                    WITH desired AS (
+                      SELECT item ->> 'contract_symbol' AS contract_symbol,
+                             CAST(item ->> 'ranking_score' AS DOUBLE PRECISION) AS ranking_score,
+                             COALESCE(item -> 'ranking_inputs', '{}'::JSONB) AS ranking_inputs,
+                             item ->> 'tier' AS tier,
+                             ARRAY(
+                               SELECT jsonb_array_elements_text(
+                                 COALESCE(item -> 'desired_channels', '[]'::JSONB)
+                               )
+                             ) AS desired_channels,
+                             CAST(item ->> 'provider_cap_generation' AS BIGINT) AS provider_cap_generation
+                      FROM jsonb_array_elements(CAST(:ranked_rows AS JSONB)) AS source(item)
+                    )
+                    INSERT INTO torghut_options_subscription_state (
+                      contract_symbol,
+                      ranking_score,
+                      ranking_inputs,
+                      tier,
+                      desired_channels,
+                      subscribed_channels,
+                      provider_cap_generation,
+                      last_ranked_ts
+                    )
+                    SELECT contract_symbol,
+                      ranking_score,
+                      ranking_inputs,
+                      tier,
+                      desired_channels,
+                      ARRAY[]::TEXT[],
+                      provider_cap_generation,
+                      :last_ranked_ts
+                    FROM desired
+                    ON CONFLICT (contract_symbol) DO UPDATE
+                    SET ranking_score = EXCLUDED.ranking_score,
+                        ranking_inputs = EXCLUDED.ranking_inputs,
+                        tier = EXCLUDED.tier,
+                        desired_channels = EXCLUDED.desired_channels,
+                        provider_cap_generation = EXCLUDED.provider_cap_generation,
+                        last_ranked_ts = EXCLUDED.last_ranked_ts
+                    WHERE (
+                      torghut_options_subscription_state.ranking_score,
+                      torghut_options_subscription_state.ranking_inputs,
+                      torghut_options_subscription_state.tier,
+                      torghut_options_subscription_state.desired_channels,
+                      torghut_options_subscription_state.provider_cap_generation
+                    ) IS DISTINCT FROM (
+                      EXCLUDED.ranking_score,
+                      EXCLUDED.ranking_inputs,
+                      EXCLUDED.tier,
+                      EXCLUDED.desired_channels,
+                      EXCLUDED.provider_cap_generation
+                    )
+                    """
+                ),
+                {
+                    "ranked_rows": _coerce_json(desired_rows),
+                    "last_ranked_ts": observed_at,
+                },
+            )
+            changed_count = max(int(getattr(result, "rowcount", 0) or 0), 0)
+        if explicit_deactivations:
+            result = session.execute(
+                text(
+                    """
+                    UPDATE torghut_options_subscription_state
+                    SET tier = 'off',
+                        last_ranked_ts = :last_ranked_ts
+                    WHERE contract_symbol = ANY(:symbols)
+                      AND tier IS DISTINCT FROM 'off'
+                    """
+                ),
+                {
+                    "symbols": explicit_deactivations,
+                    "last_ranked_ts": observed_at,
+                },
+            )
+            deactivated_count = max(int(getattr(result, "rowcount", 0) or 0), 0)
+    return SubscriptionReconcileResult(
+        hot_count=hot_count,
+        warm_count=warm_count,
+        changed_count=changed_count,
+        deactivated_count=deactivated_count,
+    )
+
+
+def _desired_rows(
+    ranked_rows: list[dict[str, object]],
+) -> tuple[list[dict[str, object]], set[str], int, int]:
+    desired_rows: list[dict[str, object]] = []
+    desired_symbols: set[str] = set()
+    hot_count = 0
+    warm_count = 0
+    for row in ranked_rows:
+        contract_symbol = str(row["contract_symbol"])
+        if contract_symbol in desired_symbols:
+            raise ValueError(
+                f"duplicate subscription contract symbol: {contract_symbol}"
+            )
+        desired_symbols.add(contract_symbol)
+        tier = cast(str, row["tier"])
+        if tier == "hot":
+            hot_count += 1
+        elif tier == "warm":
+            warm_count += 1
+        desired_rows.append(
+            {
+                "contract_symbol": contract_symbol,
+                "ranking_score": float(cast(int | float | str, row["ranking_score"])),
+                "ranking_inputs": row["ranking_inputs"],
+                "tier": tier,
+                "desired_channels": list(
+                    cast(Iterable[object], row["desired_channels"])
+                ),
+                "provider_cap_generation": int(
+                    cast(int | float | str, row["provider_cap_generation"])
+                ),
+            }
+        )
+    return desired_rows, desired_symbols, hot_count, warm_count
+
+
+def _coerce_json(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)

--- a/services/torghut/app/options_lane/subscription_state_repository.py
+++ b/services/torghut/app/options_lane/subscription_state_repository.py
@@ -68,6 +68,21 @@ def load_non_off_subscription_symbols(session: Session) -> set[str]:
     return {cast(str, row[0]) for row in rows}
 
 
+def load_cold_subscription_symbols(session: Session) -> frozenset[str]:
+    """Return the pre-existing cold set that provisional scans must preserve."""
+
+    rows = session.execute(
+        text(
+            """
+            SELECT contract_symbol
+            FROM torghut_options_subscription_state
+            WHERE tier = 'cold'
+            """
+        )
+    )
+    return frozenset(cast(str, row[0]) for row in rows)
+
+
 def reconcile_subscription_state(
     session: Session,
     *,

--- a/services/torghut/app/options_lane/subscription_state_repository.py
+++ b/services/torghut/app/options_lane/subscription_state_repository.py
@@ -44,7 +44,8 @@ def load_live_subscription_candidates(session: Session) -> list[dict[str, object
             FROM torghut_options_subscription_state AS subs
             JOIN torghut_options_contract_catalog AS catalog
               ON catalog.contract_symbol = subs.contract_symbol
-            WHERE subs.tier IN ('hot', 'warm')
+            WHERE catalog.status = 'active'
+              AND subs.tier IN ('hot', 'warm')
             ORDER BY subs.ranking_score DESC, catalog.contract_symbol ASC
             """
         )
@@ -144,6 +145,8 @@ def reconcile_subscription_state(
                       EXCLUDED.desired_channels,
                       EXCLUDED.provider_cap_generation
                     )
+                    -- Per-row freshness means material assignment change. Successful
+                    -- cycle freshness is recorded once in the catalog watermark.
                     """
                 ),
                 {

--- a/services/torghut/tests/test_options_catalog_watermark_repository.py
+++ b/services/torghut/tests/test_options_catalog_watermark_repository.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from contextlib import AbstractContextManager, nullcontext
+from datetime import UTC, datetime
+import json
+from typing import cast
+
+from sqlalchemy.orm import Session
+
+from app.options_lane.catalog_watermark_repository import (
+    CatalogCycleSummary,
+    record_catalog_cycle_success,
+)
+
+
+class _RecordingSession:
+    def __init__(self) -> None:
+        self.statement = ""
+        self.parameters: dict[str, object] = {}
+
+    def begin(self) -> AbstractContextManager[None]:
+        return nullcontext()
+
+    def execute(self, statement: object, parameters: dict[str, object]) -> None:
+        self.statement = str(statement)
+        self.parameters = parameters
+
+
+def test_catalog_success_uses_one_cycle_watermark() -> None:
+    session = _RecordingSession()
+    observed_at = datetime(2026, 7, 14, 6, 30, tzinfo=UTC)
+
+    record_catalog_cycle_success(
+        cast(Session, session),
+        CatalogCycleSummary(
+            observed_at=observed_at,
+            page_count=3,
+            contract_count=250,
+            catalog_changed_count=2,
+            transition_count=1,
+            hot_count=160,
+            warm_count=800,
+            subscription_changed_count=4,
+            subscription_deactivated_count=3,
+        ),
+    )
+
+    assert "'catalog'" in session.statement
+    assert "'universe'" in session.statement
+    assert "'live'" in session.statement
+    assert "last_success_ts = EXCLUDED.last_success_ts" in session.statement
+    assert session.parameters["observed_at"] == observed_at
+    metadata = json.loads(cast(str, session.parameters["metadata"]))
+    assert metadata["contract_count"] == 250
+    assert metadata["subscription_changed_count"] == 4

--- a/services/torghut/tests/test_options_lane.py
+++ b/services/torghut/tests/test_options_lane.py
@@ -249,6 +249,9 @@ class _SeededCycleRepository:
             "ARCHIVE260717P00100000",
         }
 
+    def list_cold_subscription_symbols(self) -> frozenset[str]:
+        return frozenset({"ARCHIVE260717P00100000"})
+
     def sync_contract_catalog_page(
         self, *_: object, **__: object
     ) -> list[dict[str, object]]:

--- a/services/torghut/tests/test_options_lane.py
+++ b/services/torghut/tests/test_options_lane.py
@@ -547,7 +547,7 @@ class TestOptionsServiceStatusHeartbeat(TestCase):
         self.assertIsNone(payload["hot_contracts"])
         self.assertEqual(payload["rest_backlog"], 11)
 
-    def test_partial_catalog_cycle_keeps_unseen_persisted_candidate(self) -> None:
+    def test_partial_catalog_cycle_protects_unseen_persisted_candidate(self) -> None:
         service = cast(
             _CatalogDiscoveryServiceModule,
             self._import_service("app.options_lane.catalog_service"),
@@ -563,13 +563,13 @@ class TestOptionsServiceStatusHeartbeat(TestCase):
 
         self.assertEqual(len(repository.reconciliations), 1)
         desired_symbols, deactivate_symbols = repository.reconciliations[0]
-        self.assertIn("AAPL260717C00200000", desired_symbols)
-        self.assertIn("MSFT260717C00400000", desired_symbols)
+        self.assertEqual(desired_symbols, ["MSFT260717C00400000"])
         self.assertNotIn("ARCHIVE260717P00100000", desired_symbols)
+        self.assertNotIn("AAPL260717C00200000", deactivate_symbols)
         self.assertEqual(deactivate_symbols, set())
         snapshot = service._state.snapshot()
         self.assertEqual(snapshot["subscription_reconciliations_total"], 1)
-        self.assertEqual(snapshot["subscription_rows_changed_total"], 2)
+        self.assertEqual(snapshot["subscription_rows_changed_total"], 1)
         self.assertEqual(snapshot["subscription_rows_deactivated_total"], 0)
 
     def test_complete_catalog_cycle_deactivates_cold_rows_only_at_final_cleanup(
@@ -585,11 +585,8 @@ class TestOptionsServiceStatusHeartbeat(TestCase):
 
         service._run_discovery_cycle()
 
-        self.assertEqual(len(repository.reconciliations), 2)
-        provisional_symbols, provisional_deactivations = repository.reconciliations[0]
-        final_symbols, final_deactivations = repository.reconciliations[1]
-        self.assertEqual(provisional_symbols, ["AAPL260717C00200000"])
-        self.assertEqual(provisional_deactivations, set())
+        self.assertEqual(len(repository.reconciliations), 1)
+        final_symbols, final_deactivations = repository.reconciliations[0]
         self.assertEqual(final_symbols, ["AAPL260717C00200000"])
         self.assertEqual(final_deactivations, {"ARCHIVE260717P00100000"})
 

--- a/services/torghut/tests/test_options_lane.py
+++ b/services/torghut/tests/test_options_lane.py
@@ -18,6 +18,7 @@ from app.options_lane.alpaca import (
     normalize_contract_record,
     normalize_snapshot_record,
 )
+from app.options_lane.catalog_watermark_repository import CatalogCycleSummary
 from app.options_lane.options_status import build_status_payload
 from app.options_lane.repository import (
     OptionsRepository,
@@ -211,6 +212,7 @@ class _CompleteCatalogClient:
 class _SeededCycleRepository:
     def __init__(self) -> None:
         self.reconciliations: list[tuple[list[str], set[str]]] = []
+        self.completed_cycles: list[CatalogCycleSummary] = []
 
     def list_live_subscription_candidates(self) -> list[dict[str, object]]:
         return [
@@ -290,6 +292,9 @@ class _SeededCycleRepository:
             changed_count=len(ranked_rows),
             deactivated_count=len(deactivate_symbols),
         )
+
+    def record_catalog_cycle_success(self, summary: CatalogCycleSummary) -> None:
+        self.completed_cycles.append(summary)
 
 
 class _CatalogStatusServiceModule(Protocol):
@@ -571,6 +576,7 @@ class TestOptionsServiceStatusHeartbeat(TestCase):
         self.assertEqual(snapshot["subscription_reconciliations_total"], 1)
         self.assertEqual(snapshot["subscription_rows_changed_total"], 1)
         self.assertEqual(snapshot["subscription_rows_deactivated_total"], 0)
+        self.assertEqual(repository.completed_cycles, [])
 
     def test_complete_catalog_cycle_deactivates_cold_rows_only_at_final_cleanup(
         self,
@@ -589,6 +595,9 @@ class TestOptionsServiceStatusHeartbeat(TestCase):
         final_symbols, final_deactivations = repository.reconciliations[0]
         self.assertEqual(final_symbols, ["AAPL260717C00200000"])
         self.assertEqual(final_deactivations, {"ARCHIVE260717P00100000"})
+        self.assertEqual(len(repository.completed_cycles), 1)
+        self.assertEqual(repository.completed_cycles[0].contract_count, 1)
+        self.assertEqual(repository.completed_cycles[0].hot_count, 1)
 
 
 class TestOptionsLaneNormalization(TestCase):

--- a/services/torghut/tests/test_options_lane.py
+++ b/services/torghut/tests/test_options_lane.py
@@ -6,7 +6,7 @@ import os
 import sys
 from contextlib import contextmanager
 from datetime import date, datetime, timezone
-from typing import Any, Iterator, Protocol, cast
+from typing import Iterator, Protocol, cast
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -273,7 +273,7 @@ class _SeededCycleRepository:
     def write_subscription_state(
         self,
         *,
-        ranked_rows: list[dict[str, Any]],
+        ranked_rows: list[dict[str, object]],
         deactivate_symbols: set[str],
         observed_at: datetime,
     ) -> SubscriptionReconcileResult:
@@ -301,6 +301,18 @@ class _CatalogStatusServiceModule(Protocol):
         error_code: str | None = None,
         error_detail: str | None = None,
     ) -> None: ...
+
+
+class _CatalogDiscoveryState(Protocol):
+    def snapshot(self) -> dict[str, object]: ...
+
+
+class _CatalogDiscoveryServiceModule(Protocol):
+    _repository: object
+    _client: object
+    _state: _CatalogDiscoveryState
+
+    def _run_discovery_cycle(self) -> None: ...
 
 
 class _EnricherStatusServiceModule(Protocol):
@@ -537,7 +549,7 @@ class TestOptionsServiceStatusHeartbeat(TestCase):
 
     def test_partial_catalog_cycle_keeps_unseen_persisted_candidate(self) -> None:
         service = cast(
-            Any,
+            _CatalogDiscoveryServiceModule,
             self._import_service("app.options_lane.catalog_service"),
         )
         repository = _SeededCycleRepository()
@@ -564,7 +576,7 @@ class TestOptionsServiceStatusHeartbeat(TestCase):
         self,
     ) -> None:
         service = cast(
-            Any,
+            _CatalogDiscoveryServiceModule,
             self._import_service("app.options_lane.catalog_service"),
         )
         repository = _SeededCycleRepository()

--- a/services/torghut/tests/test_options_lane.py
+++ b/services/torghut/tests/test_options_lane.py
@@ -186,6 +186,28 @@ class _PartialCatalogClient:
         )
 
 
+class _CompleteCatalogClient:
+    def list_contracts(self, **_: object) -> tuple[list[dict[str, object]], None]:
+        return (
+            [
+                {
+                    "id": "contract-aapl",
+                    "symbol": "AAPL260717C00200000",
+                    "status": "active",
+                    "expiration_date": "2026-07-17",
+                    "root_symbol": "AAPL",
+                    "underlying_symbol": "AAPL",
+                    "type": "call",
+                    "style": "american",
+                    "strike_price": "200",
+                    "size": "100",
+                    "open_interest": "100",
+                }
+            ],
+            None,
+        )
+
+
 class _SeededCycleRepository:
     def __init__(self) -> None:
         self.reconciliations: list[tuple[list[str], set[str]]] = []
@@ -219,10 +241,34 @@ class _SeededCycleRepository:
     def acquire_rate_bucket(self, *_: object) -> bool:
         return True
 
+    def list_non_off_subscription_symbols(self) -> set[str]:
+        return {
+            "AAPL260717C00200000",
+            "ARCHIVE260717P00100000",
+        }
+
     def sync_contract_catalog_page(
         self, *_: object, **__: object
     ) -> list[dict[str, object]]:
         return []
+
+    def mark_contracts_missing_from_cycle(self, **_: object) -> list[dict[str, object]]:
+        return []
+
+    def iter_active_contracts_for_ranking(self) -> Iterator[dict[str, object]]:
+        yield {
+            "contract_symbol": "AAPL260717C00200000",
+            "status": "active",
+            "underlying_symbol": "AAPL",
+            "expiration_date": date(2026, 7, 17),
+            "strike_price": 200.0,
+            "close_price": 200.0,
+            "open_interest": 100,
+            "ranking_inputs": {},
+        }
+
+    def max_active_open_interest(self) -> int:
+        return 100
 
     def write_subscription_state(
         self,
@@ -513,6 +559,27 @@ class TestOptionsServiceStatusHeartbeat(TestCase):
         self.assertEqual(snapshot["subscription_reconciliations_total"], 1)
         self.assertEqual(snapshot["subscription_rows_changed_total"], 2)
         self.assertEqual(snapshot["subscription_rows_deactivated_total"], 0)
+
+    def test_complete_catalog_cycle_deactivates_cold_rows_only_at_final_cleanup(
+        self,
+    ) -> None:
+        service = cast(
+            Any,
+            self._import_service("app.options_lane.catalog_service"),
+        )
+        repository = _SeededCycleRepository()
+        service._repository = repository
+        service._client = _CompleteCatalogClient()
+
+        service._run_discovery_cycle()
+
+        self.assertEqual(len(repository.reconciliations), 2)
+        provisional_symbols, provisional_deactivations = repository.reconciliations[0]
+        final_symbols, final_deactivations = repository.reconciliations[1]
+        self.assertEqual(provisional_symbols, ["AAPL260717C00200000"])
+        self.assertEqual(provisional_deactivations, set())
+        self.assertEqual(final_symbols, ["AAPL260717C00200000"])
+        self.assertEqual(final_deactivations, {"ARCHIVE260717P00100000"})
 
 
 class TestOptionsLaneNormalization(TestCase):

--- a/services/torghut/tests/test_options_lane.py
+++ b/services/torghut/tests/test_options_lane.py
@@ -6,7 +6,7 @@ import os
 import sys
 from contextlib import contextmanager
 from datetime import date, datetime, timezone
-from typing import Iterator, Protocol, cast
+from typing import Any, Iterator, Protocol, cast
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -21,6 +21,7 @@ from app.options_lane.alpaca import (
 from app.options_lane.options_status import build_status_payload
 from app.options_lane.repository import (
     OptionsRepository,
+    SubscriptionReconcileResult,
     merge_top_ranked_contract_rows,
     ranked_contract_rows,
     top_ranked_contract_rows,
@@ -86,6 +87,35 @@ class _FakeCountRepository(OptionsRepository):
         yield cast(Session, self.fake_session)
 
 
+class _FakeWriteResult:
+    def __init__(self, rowcount: int) -> None:
+        self.rowcount = rowcount
+
+
+class _FakeWriteSession:
+    def __init__(self) -> None:
+        self.statements: list[tuple[str, dict[str, object]]] = []
+
+    def begin(self) -> _FakeBegin:
+        return _FakeBegin()
+
+    def execute(
+        self, statement: object, parameters: dict[str, object] | None = None
+    ) -> _FakeWriteResult:
+        sql = str(statement)
+        self.statements.append((sql, parameters or {}))
+        return _FakeWriteResult(2 if "INSERT INTO" in sql else 1)
+
+
+class _FakeWriteRepository(OptionsRepository):
+    def __init__(self, session: _FakeWriteSession) -> None:
+        self.fake_session = session
+
+    @contextmanager
+    def session(self) -> Iterator[Session]:
+        yield cast(Session, self.fake_session)
+
+
 class _NoCountRepository:
     active_count_calls = 0
     hot_count_calls = 0
@@ -126,6 +156,94 @@ class _FakeProducer:
 class _FakeAlpacaClient:
     def __init__(self, **_: object) -> None:
         pass
+
+
+class _PartialCatalogClient:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def list_contracts(self, **_: object) -> tuple[list[dict[str, object]], str]:
+        self.calls += 1
+        if self.calls > 1:
+            raise RuntimeError("provider interrupted after first page")
+        return (
+            [
+                {
+                    "id": "contract-new",
+                    "symbol": "MSFT260717C00400000",
+                    "status": "active",
+                    "expiration_date": "2026-07-17",
+                    "root_symbol": "MSFT",
+                    "underlying_symbol": "MSFT",
+                    "type": "call",
+                    "style": "american",
+                    "strike_price": "400",
+                    "size": "100",
+                    "open_interest": "1",
+                }
+            ],
+            "next-page",
+        )
+
+
+class _SeededCycleRepository:
+    def __init__(self) -> None:
+        self.reconciliations: list[tuple[list[str], set[str]]] = []
+
+    def list_live_subscription_candidates(self) -> list[dict[str, object]]:
+        return [
+            {
+                "contract_symbol": "AAPL260717C00200000",
+                "status": "active",
+                "underlying_symbol": "AAPL",
+                "expiration_date": date(2026, 7, 17),
+                "strike_price": 200.0,
+                "close_price": 200.0,
+                "open_interest": 100,
+                "ranking_inputs": {},
+                "tier": "hot",
+            },
+            {
+                "contract_symbol": "ARCHIVE260717P00100000",
+                "status": "active",
+                "underlying_symbol": "ARCHIVE",
+                "expiration_date": date(2026, 7, 17),
+                "strike_price": 100.0,
+                "close_price": 100.0,
+                "open_interest": 1_000,
+                "ranking_inputs": {},
+                "tier": "cold",
+            },
+        ]
+
+    def acquire_rate_bucket(self, *_: object) -> bool:
+        return True
+
+    def sync_contract_catalog_page(
+        self, *_: object, **__: object
+    ) -> list[dict[str, object]]:
+        return []
+
+    def write_subscription_state(
+        self,
+        *,
+        ranked_rows: list[dict[str, Any]],
+        deactivate_symbols: set[str],
+        observed_at: datetime,
+    ) -> SubscriptionReconcileResult:
+        del observed_at
+        self.reconciliations.append(
+            (
+                [str(row["contract_symbol"]) for row in ranked_rows],
+                set(deactivate_symbols),
+            )
+        )
+        return SubscriptionReconcileResult(
+            hot_count=sum(row["tier"] == "hot" for row in ranked_rows),
+            warm_count=sum(row["tier"] == "warm" for row in ranked_rows),
+            changed_count=len(ranked_rows),
+            deactivated_count=len(deactivate_symbols),
+        )
 
 
 class _CatalogStatusServiceModule(Protocol):
@@ -222,6 +340,85 @@ class TestOptionsRepositoryStatusCounts(TestCase):
         )
 
 
+class TestOptionsRepositorySubscriptionReconciliation(TestCase):
+    def test_reconciliation_uses_one_conditional_upsert_and_explicit_deactivation(
+        self,
+    ) -> None:
+        session = _FakeWriteSession()
+        repo = _FakeWriteRepository(session)
+        observed_at = datetime(2026, 7, 13, 15, 0, tzinfo=timezone.utc)
+
+        result = repo.write_subscription_state(
+            ranked_rows=[
+                {
+                    "contract_symbol": "AAPL260717C00200000",
+                    "ranking_score": 0.91,
+                    "ranking_inputs": {"liquidity_score": 1.0},
+                    "tier": "hot",
+                    "desired_channels": ["trades", "quotes"],
+                    "provider_cap_generation": 200,
+                },
+                {
+                    "contract_symbol": "MSFT260717P00400000",
+                    "ranking_score": 0.72,
+                    "ranking_inputs": {"liquidity_score": 0.5},
+                    "tier": "warm",
+                    "desired_channels": ["trades", "quotes"],
+                    "provider_cap_generation": 200,
+                },
+            ],
+            deactivate_symbols={"STALE260717C00100000"},
+            observed_at=observed_at,
+        )
+
+        self.assertEqual(len(session.statements), 2)
+        upsert_sql, upsert_parameters = session.statements[0]
+        deactivate_sql, deactivate_parameters = session.statements[1]
+        self.assertIn("jsonb_array_elements", upsert_sql)
+        self.assertIn("IS DISTINCT FROM", upsert_sql)
+        self.assertNotIn("contract_symbol <> ALL", upsert_sql)
+        self.assertEqual(
+            json.loads(cast(str, upsert_parameters["ranked_rows"]))[0][
+                "contract_symbol"
+            ],
+            "AAPL260717C00200000",
+        )
+        self.assertIn("contract_symbol = ANY", deactivate_sql)
+        self.assertIn("tier IS DISTINCT FROM 'off'", deactivate_sql)
+        self.assertNotIn("contract_symbol <> ALL", deactivate_sql)
+        self.assertEqual(deactivate_parameters["symbols"], ["STALE260717C00100000"])
+        self.assertEqual(result.hot_count, 1)
+        self.assertEqual(result.warm_count, 1)
+        self.assertEqual(result.changed_count, 2)
+        self.assertEqual(result.deactivated_count, 1)
+
+    def test_reconciliation_skips_deactivation_statement_without_displacements(
+        self,
+    ) -> None:
+        session = _FakeWriteSession()
+        repo = _FakeWriteRepository(session)
+
+        repo.write_subscription_state(
+            ranked_rows=[
+                {
+                    "contract_symbol": "AAPL260717C00200000",
+                    "ranking_score": 0.91,
+                    "ranking_inputs": {},
+                    "tier": "hot",
+                    "desired_channels": ["trades", "quotes"],
+                    "provider_cap_generation": 200,
+                }
+            ],
+            deactivate_symbols=set(),
+            observed_at=datetime(2026, 7, 13, 15, 0, tzinfo=timezone.utc),
+        )
+
+        self.assertEqual(len(session.statements), 1)
+        self.assertNotIn(
+            "UPDATE torghut_options_subscription_state", session.statements[0][0]
+        )
+
+
 class TestOptionsServiceStatusHeartbeat(TestCase):
     def setUp(self) -> None:
         _NoCountRepository.active_count_calls = 0
@@ -291,6 +488,31 @@ class TestOptionsServiceStatusHeartbeat(TestCase):
         self.assertIsNone(payload["active_contracts"])
         self.assertIsNone(payload["hot_contracts"])
         self.assertEqual(payload["rest_backlog"], 11)
+
+    def test_partial_catalog_cycle_keeps_unseen_persisted_candidate(self) -> None:
+        service = cast(
+            Any,
+            self._import_service("app.options_lane.catalog_service"),
+        )
+        repository = _SeededCycleRepository()
+        service._repository = repository
+        service._client = _PartialCatalogClient()
+
+        with self.assertRaisesRegex(
+            RuntimeError, "provider interrupted after first page"
+        ):
+            service._run_discovery_cycle()
+
+        self.assertEqual(len(repository.reconciliations), 1)
+        desired_symbols, deactivate_symbols = repository.reconciliations[0]
+        self.assertIn("AAPL260717C00200000", desired_symbols)
+        self.assertIn("MSFT260717C00400000", desired_symbols)
+        self.assertNotIn("ARCHIVE260717P00100000", desired_symbols)
+        self.assertEqual(deactivate_symbols, set())
+        snapshot = service._state.snapshot()
+        self.assertEqual(snapshot["subscription_reconciliations_total"], 1)
+        self.assertEqual(snapshot["subscription_rows_changed_total"], 2)
+        self.assertEqual(snapshot["subscription_rows_deactivated_total"], 0)
 
 
 class TestOptionsLaneNormalization(TestCase):
@@ -598,6 +820,35 @@ class TestOptionsLaneRanking(TestCase):
             ["AAPL260320C00100000", "AAPL260320P00100000"],
         )
         self.assertEqual([row["tier"] for row in ranked], ["hot", "warm"])
+
+    def test_merge_top_ranked_contract_rows_replaces_duplicate_symbols(self) -> None:
+        observed_at = datetime(2026, 7, 13, 15, 0, tzinfo=timezone.utc)
+        existing = {
+            "contract_symbol": "AAPL260717C00200000",
+            "status": "active",
+            "underlying_symbol": "AAPL",
+            "expiration_date": date(2026, 7, 17),
+            "strike_price": 200.0,
+            "close_price": 200.0,
+            "open_interest": 10,
+            "ranking_inputs": {},
+        }
+        refreshed = {**existing, "open_interest": 100}
+
+        ranked = merge_top_ranked_contract_rows(
+            [existing],
+            [refreshed],
+            observed_at=observed_at,
+            hot_cap=1,
+            warm_cap=1,
+            max_open_interest=100,
+            provider_cap_bootstrap=2,
+            underlying_priority={"AAPL"},
+        )
+
+        self.assertEqual(len(ranked), 1)
+        self.assertEqual(ranked[0]["contract_symbol"], existing["contract_symbol"])
+        self.assertEqual(ranked[0]["open_interest"], 100)
 
 
 class TestOptionsStatusPayload(TestCase):

--- a/services/torghut/tests/test_options_subscription_reconciliation.py
+++ b/services/torghut/tests/test_options_subscription_reconciliation.py
@@ -43,3 +43,29 @@ def test_provisional_plan_uses_full_capacity_during_bootstrap() -> None:
         ("C", "warm"),
     ]
     assert plan.deactivate_symbols == {"D"}
+
+
+def test_provisional_plan_never_owns_or_deactivates_preexisting_cold_rows() -> None:
+    seed = ProtectedSubscriptionSeed(
+        hot_symbols=frozenset(),
+        warm_symbols=frozenset(),
+        hot_limit=1,
+        warm_limit=0,
+        cold_symbols=frozenset({"COLD"}),
+    )
+
+    first_plan = plan_provisional_subscription_reconciliation(
+        [_ranked_row("COLD"), _ranked_row("FIRST")],
+        protected_seed=seed,
+        previously_owned_symbols=set(),
+    )
+    second_plan = plan_provisional_subscription_reconciliation(
+        [_ranked_row("COLD"), _ranked_row("SECOND")],
+        protected_seed=seed,
+        previously_owned_symbols=first_plan.owned_symbols,
+    )
+
+    assert first_plan.owned_symbols == {"FIRST"}
+    assert second_plan.owned_symbols == {"SECOND"}
+    assert second_plan.deactivate_symbols == {"FIRST"}
+    assert "COLD" not in second_plan.deactivate_symbols

--- a/services/torghut/tests/test_options_subscription_reconciliation.py
+++ b/services/torghut/tests/test_options_subscription_reconciliation.py
@@ -1,4 +1,5 @@
 from app.options_lane.subscription_reconciliation import (
+    ProtectedSubscriptionSeed,
     plan_provisional_subscription_reconciliation,
 )
 
@@ -10,11 +11,13 @@ def _ranked_row(symbol: str) -> dict[str, object]:
 def test_provisional_plan_never_displaces_protected_seed() -> None:
     plan = plan_provisional_subscription_reconciliation(
         [_ranked_row("NEW-BEST"), _ranked_row("SEED-HOT"), _ranked_row("SEED-WARM")],
-        protected_hot_symbols={"SEED-HOT"},
-        protected_warm_symbols={"SEED-WARM"},
+        protected_seed=ProtectedSubscriptionSeed(
+            hot_symbols=frozenset({"SEED-HOT"}),
+            warm_symbols=frozenset({"SEED-WARM"}),
+            hot_limit=1,
+            warm_limit=2,
+        ),
         previously_owned_symbols={"OLD-CYCLE"},
-        hot_limit=1,
-        warm_limit=2,
     )
 
     assert plan.ranked_rows == [{"contract_symbol": "NEW-BEST", "tier": "warm"}]
@@ -25,11 +28,13 @@ def test_provisional_plan_never_displaces_protected_seed() -> None:
 def test_provisional_plan_uses_full_capacity_during_bootstrap() -> None:
     plan = plan_provisional_subscription_reconciliation(
         [_ranked_row("A"), _ranked_row("B"), _ranked_row("C"), _ranked_row("D")],
-        protected_hot_symbols=set(),
-        protected_warm_symbols=set(),
+        protected_seed=ProtectedSubscriptionSeed(
+            hot_symbols=frozenset(),
+            warm_symbols=frozenset(),
+            hot_limit=2,
+            warm_limit=1,
+        ),
         previously_owned_symbols={"D"},
-        hot_limit=2,
-        warm_limit=1,
     )
 
     assert [(row["contract_symbol"], row["tier"]) for row in plan.ranked_rows] == [

--- a/services/torghut/tests/test_options_subscription_reconciliation.py
+++ b/services/torghut/tests/test_options_subscription_reconciliation.py
@@ -1,0 +1,40 @@
+from app.options_lane.subscription_reconciliation import (
+    plan_provisional_subscription_reconciliation,
+)
+
+
+def _ranked_row(symbol: str) -> dict[str, object]:
+    return {"contract_symbol": symbol, "tier": "hot"}
+
+
+def test_provisional_plan_never_displaces_protected_seed() -> None:
+    plan = plan_provisional_subscription_reconciliation(
+        [_ranked_row("NEW-BEST"), _ranked_row("SEED-HOT"), _ranked_row("SEED-WARM")],
+        protected_hot_symbols={"SEED-HOT"},
+        protected_warm_symbols={"SEED-WARM"},
+        previously_owned_symbols={"OLD-CYCLE"},
+        hot_limit=1,
+        warm_limit=2,
+    )
+
+    assert plan.ranked_rows == [{"contract_symbol": "NEW-BEST", "tier": "warm"}]
+    assert plan.deactivate_symbols == {"OLD-CYCLE"}
+    assert plan.owned_symbols == {"NEW-BEST"}
+
+
+def test_provisional_plan_uses_full_capacity_during_bootstrap() -> None:
+    plan = plan_provisional_subscription_reconciliation(
+        [_ranked_row("A"), _ranked_row("B"), _ranked_row("C"), _ranked_row("D")],
+        protected_hot_symbols=set(),
+        protected_warm_symbols=set(),
+        previously_owned_symbols={"D"},
+        hot_limit=2,
+        warm_limit=1,
+    )
+
+    assert [(row["contract_symbol"], row["tier"]) for row in plan.ranked_rows] == [
+        ("A", "hot"),
+        ("B", "hot"),
+        ("C", "warm"),
+    ]
+    assert plan.deactivate_symbols == {"D"}

--- a/services/torghut/tests/test_options_subscription_state_repository.py
+++ b/services/torghut/tests/test_options_subscription_state_repository.py
@@ -9,6 +9,7 @@ from typing import cast
 from sqlalchemy.orm import Session
 
 from app.options_lane.subscription_state_repository import (
+    load_live_subscription_candidates,
     reconcile_subscription_state,
 )
 
@@ -30,6 +31,20 @@ class _RecordingSession:
         return SimpleNamespace(rowcount=len(symbols))
 
 
+class _EmptyMappingResult:
+    def mappings(self) -> list[dict[str, object]]:
+        return []
+
+
+class _CandidateSession:
+    def __init__(self) -> None:
+        self.statement = ""
+
+    def execute(self, statement: object) -> _EmptyMappingResult:
+        self.statement = str(statement)
+        return _EmptyMappingResult()
+
+
 def test_reconcile_chunks_large_deactivation_sets() -> None:
     session = _RecordingSession()
     symbols = {f"CONTRACT-{index:05d}" for index in range(2_501)}
@@ -46,3 +61,11 @@ def test_reconcile_chunks_large_deactivation_sets() -> None:
         symbol for batch in session.deactivation_batches for symbol in batch
     ] == sorted(symbols)
     assert result.deactivated_count == len(symbols)
+
+
+def test_live_seed_excludes_inactive_catalog_rows() -> None:
+    session = _CandidateSession()
+
+    assert load_live_subscription_candidates(cast(Session, session)) == []
+
+    assert "catalog.status = 'active'" in session.statement

--- a/services/torghut/tests/test_options_subscription_state_repository.py
+++ b/services/torghut/tests/test_options_subscription_state_repository.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from contextlib import AbstractContextManager, nullcontext
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import cast
+
+from sqlalchemy.orm import Session
+
+from app.options_lane.subscription_state_repository import (
+    reconcile_subscription_state,
+)
+
+
+class _RecordingSession:
+    def __init__(self) -> None:
+        self.deactivation_batches: list[list[str]] = []
+
+    def begin(self) -> AbstractContextManager[None]:
+        return nullcontext()
+
+    def execute(
+        self, _statement: object, parameters: Mapping[str, object]
+    ) -> SimpleNamespace:
+        symbols = parameters["symbols"]
+        assert isinstance(symbols, list)
+        assert all(isinstance(symbol, str) for symbol in symbols)
+        self.deactivation_batches.append(symbols)
+        return SimpleNamespace(rowcount=len(symbols))
+
+
+def test_reconcile_chunks_large_deactivation_sets() -> None:
+    session = _RecordingSession()
+    symbols = {f"CONTRACT-{index:05d}" for index in range(2_501)}
+
+    result = reconcile_subscription_state(
+        cast(Session, session),
+        ranked_rows=[],
+        deactivate_symbols=symbols,
+        observed_at=datetime(2026, 7, 14, tzinfo=UTC),
+    )
+
+    assert [len(batch) for batch in session.deactivation_batches] == [1_000, 1_000, 501]
+    assert [
+        symbol for batch in session.deactivation_batches for symbol in batch
+    ] == sorted(symbols)
+    assert result.deactivated_count == len(symbols)


### PR DESCRIPTION
## Summary

- Seed provisional ranking from persisted hot/warm subscriptions while excluding cold snapshot rows from live ranking.
- Replace per-row and global subscription rewrites with one conditional set-based upsert plus explicit deactivations.
- Preserve existing cold-row cleanup only after a complete successful catalog scan.
- Extract subscription-state persistence into a focused module, keeping the core repository below the 1,000-line quality gate.
- Expose reconciliation counters and add regression coverage for partial scans, final cleanup, duplicate refreshes, and SQL shape.

## Related Issues

None. Implements the delta-reconciliation slice of #12403.

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `uv run --frozen ruff format --check app tests scripts migrations`
- `uv run --frozen ruff check app/options_lane/catalog_service.py app/options_lane/repository.py tests/test_options_lane.py`
- `uv run --frozen pytest tests/test_options_lane.py -q` (21 passed)
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python scripts/run_pylint_torghut_structural_gate.py`
- `uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base 9f6487ada0cf9222b65cbb1ee9b10d50a09b216e app/options_lane/catalog_service.py app/options_lane/repository.py app/options_lane/subscription_state_repository.py tests/test_options_lane.py`
- `uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base 9f6487ada0cf9222b65cbb1ee9b10d50a09b216e app/options_lane/catalog_service.py app/options_lane/repository.py app/options_lane/subscription_state_repository.py tests/test_options_lane.py`
- PostgreSQL 17 `EXPLAIN (COSTS OFF)` against the live Torghut schema validated the set-based upsert syntax without executing a write.
- `git diff --check`

## Screenshots (if applicable)

N/A. This is a service and persistence change.

## Breaking Changes

None. The database schema and public HTTP contracts remain compatible; health responses gain reconciliation counters.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
