### PR TITLE
chore(torghut): promote hyperliquid feed image sha-bf6d10ebebc63e55322a5d4d08a2c4f8b20c7bcf

### DIFF
--- a/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
@@ -32,18 +32,18 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-hyperliquid-feed
-          image: registry.ide-newton.ts.net/lab/torghut-hyperliquid-feed@sha256:dd853157f98d3e9ddecfc2bc62edd608b71036c4cf7a86e539f6b9bf53e06264
+          image: registry.ide-newton.ts.net/lab/torghut-hyperliquid-feed@sha256:40598685cc3298597be18666959510683789d1c59521f089724a7a3724198ec1
           imagePullPolicy: Always
           envFrom:
             - configMapRef:
                 name: torghut-hyperliquid-feed-config
           env:
             - name: TORGHUT_HYPERLIQUID_FEED_VERSION
-              value: main-sha-10bd17cdd5a053c431624bf743cdc30338a2ab21
+              value: main-sha-bf6d10ebebc63e55322a5d4d08a2c4f8b20c7bcf
             - name: TORGHUT_HYPERLIQUID_FEED_COMMIT
-              value: 10bd17cdd5a053c431624bf743cdc30338a2ab21
+              value: bf6d10ebebc63e55322a5d4d08a2c4f8b20c7bcf
             - name: TORGHUT_HYPERLIQUID_FEED_IMAGE_DIGEST
-              value: sha256:dd853157f98d3e9ddecfc2bc62edd608b71036c4cf7a86e539f6b9bf53e06264
+              value: sha256:40598685cc3298597be18666959510683789d1c59521f089724a7a3724198ec1
             - name: KAFKA_SASL_USER
               value: torghut-hyperliquid-feed
             - name: KAFKA_SASL_PASSWORD


### PR DESCRIPTION
## Summary
Promote the Torghut Hyperliquid feed image into GitOps manifests.

- Source commit: `bf6d10ebebc63e55322a5d4d08a2c4f8b20c7bcf`
- Image tag: `sha-bf6d10ebebc63e55322a5d4d08a2c4f8b20c7bcf`
- Image digest: `sha256:40598685cc3298597be18666959510683789d1c59521f089724a7a3724198ec1`
- Manifest: Hyperliquid feed Deployment