### PR TITLE
fix(torghut): follow consolidated release checks

### DIFF
--- a/.github/workflows/torghut-deploy-automerge.yml
+++ b/.github/workflows/torghut-deploy-automerge.yml
@@ -364,8 +364,8 @@ jobs:
           required_checks=(
             'Semantic Commits|Lint commit messages'
             'Semantic Pull Request|Validate PR title'
-            'argo-lint|lint'
-            'kubeconform|validate'
+            'CI|PR validation (argo-lint)'
+            'CI|PR validation (kubeconform)'
           )
           if [ "${RELEASE_LANE}" != 'hyperliquid-feed' ]; then
             required_checks+=('torghut-ci|Release manifest changes')

--- a/packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts
@@ -125,6 +125,13 @@ describe('torghut-deploy-automerge workflow', () => {
     expect(deployAutomergeWorkflow).not.toContain('deadline=$((SECONDS + 2700))')
   })
 
+  test('waits for the consolidated pull-request validation checks', () => {
+    expect(deployAutomergeWorkflow).toContain("'CI|PR validation (argo-lint)'")
+    expect(deployAutomergeWorkflow).toContain("'CI|PR validation (kubeconform)'")
+    expect(deployAutomergeWorkflow).not.toContain("'argo-lint|lint'")
+    expect(deployAutomergeWorkflow).not.toContain("'kubeconform|validate'")
+  })
+
   test('squash-merges generated release PRs after explicit gates instead of enabling brittle automerge', () => {
     expect(deployAutomergeWorkflow).toContain('name: Squash merge release PR')
     expect(deployAutomergeWorkflow).toContain('--json state,mergeStateStatus,isDraft')


### PR DESCRIPTION
## Summary

- Update Torghut deploy-automerge to wait for the consolidated CI matrix check names.
- Remove references to the retired standalone argo-lint and kubeconform pull-request checks.
- Add regression coverage that locks the release workflow to the current check contract.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts`
- `actionlint -shellcheck '' -pyflakes '' .github/workflows/torghut-deploy-automerge.yml`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
