### PR TITLE
fix(temporal): align Nexus replay operation ids

### DIFF
--- a/packages/temporal-bun-sdk/src/workflow/context.ts
+++ b/packages/temporal-bun-sdk/src/workflow/context.ts
@@ -648,9 +648,18 @@ const buildScheduleNexusOperationIntent = (
   options: ScheduleNexusOperationOptions,
 ): ScheduleNexusOperationCommandIntent => {
   const sequence = ctx.nextSequence()
-  const operationId = options.operationId ?? `nexus-${sequence}`
-  const nexusHeader = { ...(options.nexusHeader ?? {}) }
-  if (!nexusHeader[NEXUS_OPERATION_ID_HEADER]) {
+  const previous = ctx.previousIntent(sequence)
+  const previousSchedule = previous?.kind === 'schedule-nexus-operation' ? previous : undefined
+  const operationId = options.operationId ?? previousSchedule?.operationId ?? `nexus-${sequence}`
+  const nexusHeader =
+    options.nexusHeader !== undefined
+      ? { ...options.nexusHeader }
+      : previousSchedule?.nexusHeader
+        ? { ...previousSchedule.nexusHeader }
+        : previousSchedule
+          ? undefined
+          : { [NEXUS_OPERATION_ID_HEADER]: operationId }
+  if (nexusHeader && !nexusHeader[NEXUS_OPERATION_ID_HEADER]) {
     nexusHeader[NEXUS_OPERATION_ID_HEADER] = operationId
   }
   return {

--- a/packages/temporal-bun-sdk/src/workflow/context.ts
+++ b/packages/temporal-bun-sdk/src/workflow/context.ts
@@ -651,15 +651,16 @@ const buildScheduleNexusOperationIntent = (
   const previous = ctx.previousIntent(sequence)
   const previousSchedule = previous?.kind === 'schedule-nexus-operation' ? previous : undefined
   const operationId = options.operationId ?? previousSchedule?.operationId ?? `nexus-${sequence}`
+  const reusingPreviousHeader = options.nexusHeader === undefined && previousSchedule !== undefined
   const nexusHeader =
     options.nexusHeader !== undefined
       ? { ...options.nexusHeader }
-      : previousSchedule?.nexusHeader
+      : previousSchedule?.nexusHeader !== undefined
         ? { ...previousSchedule.nexusHeader }
         : previousSchedule
           ? undefined
           : { [NEXUS_OPERATION_ID_HEADER]: operationId }
-  if (nexusHeader && !nexusHeader[NEXUS_OPERATION_ID_HEADER]) {
+  if (!reusingPreviousHeader && nexusHeader && !nexusHeader[NEXUS_OPERATION_ID_HEADER]) {
     nexusHeader[NEXUS_OPERATION_ID_HEADER] = operationId
   }
   return {

--- a/packages/temporal-bun-sdk/src/workflow/replay.ts
+++ b/packages/temporal-bun-sdk/src/workflow/replay.ts
@@ -1169,7 +1169,12 @@ const reconstructDeterminismState = (
           if (event.attributes?.case !== 'nexusOperationScheduledEventAttributes') {
             break
           }
-          const intent = yield* fromNexusOperationScheduled(event.attributes.value, sequence, intake)
+          const intent = yield* fromNexusOperationScheduled(
+            event.attributes.value,
+            sequence,
+            intake,
+            normalizeEventId(event.eventId),
+          )
           if (intent) {
             commandHistory.push({
               intent,
@@ -1431,6 +1436,7 @@ const fromNexusOperationScheduled = (
   attributes: NexusOperationScheduledEventAttributes,
   sequence: number,
   intake: ReplayIntake,
+  scheduledEventId?: string | null,
 ): Effect.Effect<ScheduleNexusOperationCommandIntent | undefined, unknown, never> =>
   Effect.gen(function* () {
     if (!attributes.endpoint || !attributes.service || !attributes.operation) {
@@ -1440,7 +1446,7 @@ const fromNexusOperationScheduled = (
     const input = attributes.input
       ? yield* Effect.tryPromise(async () => await intake.dataConverter.fromPayload(attributes.input))
       : undefined
-    const operationId = attributes.nexusHeader?.[NEXUS_OPERATION_ID_HEADER] ?? `nexus-${sequence}`
+    const operationId = attributes.nexusHeader?.[NEXUS_OPERATION_ID_HEADER] ?? `nexus-${scheduledEventId ?? sequence}`
 
     const intent: ScheduleNexusOperationCommandIntent = {
       id: `schedule-nexus-operation-${sequence}`,

--- a/packages/temporal-bun-sdk/tests/workflow/primitives.test.ts
+++ b/packages/temporal-bun-sdk/tests/workflow/primitives.test.ts
@@ -151,6 +151,46 @@ test('child workflow defaults reuse recorded ids on replay', async () => {
   }
 })
 
+test('Nexus schedule defaults reuse headerless replay operation ids', async () => {
+  const previous: WorkflowDeterminismState = {
+    commandHistory: [
+      {
+        intent: {
+          id: 'schedule-nexus-operation-0',
+          kind: 'schedule-nexus-operation',
+          sequence: 0,
+          endpoint: 'payments',
+          service: 'billing',
+          operation: 'charge',
+          operationId: 'nexus-42',
+          input: { amount: 100 },
+        },
+      },
+    ],
+    randomValues: [],
+    timeValues: [],
+    signals: [],
+    queries: [],
+  }
+  const guard = new DeterminismGuard({ previousState: previous })
+  const { context } = createWorkflowContext({
+    input: [],
+    info: baseInfo,
+    determinismGuard: guard,
+    nexusResults: new Map([['nexus-42', { status: 'completed', value: 'ok' }]]),
+  })
+
+  const result = await Effect.runPromise(context.nexus.schedule('payments', 'billing', 'charge', { amount: 100 }))
+
+  expect(result).toBe('ok')
+  const intent = guard.snapshot.commandHistory[0]?.intent
+  expect(intent?.kind).toBe('schedule-nexus-operation')
+  if (intent?.kind === 'schedule-nexus-operation') {
+    expect(intent.operationId).toBe('nexus-42')
+    expect(intent.nexusHeader).toBeUndefined()
+  }
+})
+
 test('intentsEqual normalizes activity timeout defaults', () => {
   const expected = {
     id: 'schedule-activity-0',

--- a/packages/temporal-bun-sdk/tests/workflow/primitives.test.ts
+++ b/packages/temporal-bun-sdk/tests/workflow/primitives.test.ts
@@ -164,6 +164,7 @@ test('Nexus schedule defaults reuse headerless replay operation ids', async () =
           operation: 'charge',
           operationId: 'nexus-42',
           input: { amount: 100 },
+          nexusHeader: {},
         },
       },
     ],
@@ -187,7 +188,7 @@ test('Nexus schedule defaults reuse headerless replay operation ids', async () =
   expect(intent?.kind).toBe('schedule-nexus-operation')
   if (intent?.kind === 'schedule-nexus-operation') {
     expect(intent.operationId).toBe('nexus-42')
-    expect(intent.nexusHeader).toBeUndefined()
+    expect(intent.nexusHeader).toEqual({})
   }
 })
 

--- a/packages/temporal-bun-sdk/tests/workflow/replay.test.ts
+++ b/packages/temporal-bun-sdk/tests/workflow/replay.test.ts
@@ -19,6 +19,7 @@ import {
   ActivityTaskCancelRequestedEventAttributesSchema,
   HistoryEventSchema,
   MarkerRecordedEventAttributesSchema,
+  NexusOperationScheduledEventAttributesSchema,
   SignalExternalWorkflowExecutionInitiatedEventAttributesSchema,
   StartChildWorkflowExecutionInitiatedEventAttributesSchema,
   TimerStartedEventAttributesSchema,
@@ -970,6 +971,36 @@ test('ingestWorkflowHistory reconstructs command history from legacy events when
     expect(cont.backoffStartIntervalMs).toBe(1000)
     expect(replay.determinismState.commandHistory[4]?.metadata?.eventId).toBe('5')
   }
+})
+
+test('ingestWorkflowHistory derives Nexus fallback operation IDs from the scheduled event ID', async () => {
+  const converter = createDefaultDataConverter()
+  const info: WorkflowInfo = {
+    namespace: 'default',
+    taskQueue: 'replay-fixtures',
+    workflowId: 'wf-nexus-fallback',
+    runId: 'run-nexus-fallback',
+    workflowType: 'nexusWorkflow',
+  }
+  const event = create(HistoryEventSchema, {
+    eventId: 42n,
+    eventType: EventType.NEXUS_OPERATION_SCHEDULED,
+    attributes: {
+      case: 'nexusOperationScheduledEventAttributes',
+      value: create(NexusOperationScheduledEventAttributesSchema, {
+        endpoint: 'payments',
+        service: 'billing',
+        operation: 'charge',
+      }),
+    },
+  })
+
+  const replay = await Effect.runPromise(
+    ingestWorkflowHistory({ info, history: [event], dataConverter: converter }),
+  )
+  const intent = replay.determinismState.commandHistory[0]?.intent
+  expect(intent?.kind).toBe('schedule-nexus-operation')
+  expect(intent?.kind === 'schedule-nexus-operation' ? intent.operationId : null).toBe('nexus-42')
 })
 
 test('ingestWorkflowHistory captures failure metadata from workflow events', async () => {


### PR DESCRIPTION
## Summary

- Derives headerless Nexus operation fallback IDs from the scheduled history event ID.
- Keeps reconstructed schedule and cancel mappings consistent for older and cross-SDK histories.
- Adds a focused replay regression test for a headerless Nexus scheduled event.

## Related Issues

Addresses historical Codex review: https://github.com/proompteng/lab/pull/2489#discussion_r2697396514

## Testing

- `bun test packages/temporal-bun-sdk/tests/workflow/replay.test.ts` — 17 passed.
- `tsc --noEmit --project packages/temporal-bun-sdk/tsconfig.json --pretty false` — passed.
- Oxfmt and Oxlint on changed files — 0 warnings, 0 errors.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] No documentation or release-note update is required for this internal replay correction.
