### PR TITLE
fix(torghut): honor disabled universe fallback

### DIFF
--- a/services/torghut/app/trading/llm/dspy_compile/dataset.py
+++ b/services/torghut/app/trading/llm/dspy_compile/dataset.py
@@ -203,6 +203,9 @@ def _resolve_symbol_filter(*, session: Session, universe_ref: str) -> _UniverseF
         if enabled_symbols:
             return _UniverseFilter(mode="equity_enabled", symbols=enabled_symbols)
 
+        if not settings.trading_universe_static_fallback_enabled:
+            return _UniverseFilter(mode="equity_enabled", symbols=set())
+
         static_fallback_symbols = {
             symbol.strip().upper()
             for symbol in settings.trading_universe_static_fallback_symbols

--- a/services/torghut/tests/test_llm_dspy_dataset.py
+++ b/services/torghut/tests/test_llm_dspy_dataset.py
@@ -247,6 +247,10 @@ class TestLLMDSPyDatasetBuilder(TestCase):
                     "app.trading.llm.dspy_compile.dataset.settings.trading_universe_static_fallback_symbols_raw",
                     "AAPL,MSFT",
                 ),
+                patch(
+                    "app.trading.llm.dspy_compile.dataset.settings.trading_universe_static_fallback_enabled",
+                    True,
+                ),
             ):
                 result = build_dspy_dataset_artifacts(
                     session,
@@ -266,6 +270,57 @@ class TestLLMDSPyDatasetBuilder(TestCase):
                 self.assertEqual(
                     metadata_payload.get("filters", {}).get("symbolFilterMode"),
                     "equity_enabled_static_fallback",
+                )
+
+    def test_build_dataset_artifacts_does_not_use_static_symbols_when_fallback_disabled(
+        self,
+    ) -> None:
+        now = datetime(2026, 2, 27, 9, 30, tzinfo=timezone.utc)
+        with Session(self.engine) as session:
+            disabled_strategy = self._create_strategy(
+                session,
+                name="disabled-strategy",
+                universe_symbols=["AAPL"],
+                enabled=False,
+            )
+            self._insert_reviewed_decision(
+                session=session,
+                strategy_id=str(disabled_strategy.id),
+                symbol="AAPL",
+                created_at=now - timedelta(hours=1),
+                verdict="approve",
+                include_market_context=True,
+            )
+
+            with (
+                TemporaryDirectory() as tmp,
+                patch(
+                    "app.trading.llm.dspy_compile.dataset.settings.trading_universe_static_fallback_symbols_raw",
+                    "AAPL",
+                ),
+                patch(
+                    "app.trading.llm.dspy_compile.dataset.settings.trading_universe_static_fallback_enabled",
+                    False,
+                ),
+            ):
+                result = build_dspy_dataset_artifacts(
+                    session,
+                    repository="proompteng/lab",
+                    base="main",
+                    head="codex/dspy-dataset",
+                    artifact_path=tmp,
+                    dataset_window="P10D",
+                    universe_ref="torghut:equity:enabled",
+                    window_end=now,
+                )
+
+                self.assertEqual(result.total_rows, 0)
+                metadata_payload = json.loads(
+                    result.metadata_path.read_text(encoding="utf-8")
+                )
+                self.assertEqual(
+                    metadata_payload.get("filters", {}).get("symbolFilterMode"),
+                    "equity_enabled",
                 )
 
     def test_build_dataset_artifacts_rejects_empty_explicit_symbol_filter(self) -> None:


### PR DESCRIPTION
## Summary

- Honors `trading_universe_static_fallback_enabled` when the enabled equity universe is empty.
- Returns an empty fail-closed symbol set when operators disable the static fallback.
- Keeps explicit static fallback behavior covered when the feature flag is enabled.

## Related Issues

Addresses historical Codex review: https://github.com/proompteng/lab/pull/4614#discussion_r2958587350

## Testing

- Python 3.12 `pytest -q tests/test_llm_dspy_dataset.py` — 7 passed.
- Pyright `pyrightconfig.json` — 0 errors, 0 warnings.
- Pyright `pyrightconfig.alpha.json` — 0 errors, 0 warnings.
- Pyright `pyrightconfig.scripts.json` — 0 errors, 0 warnings.
- Ruff format check and Ruff lint on changed files — passed.
- `uv sync --frozen --extra dev` was attempted; agents-shell lacks the standard `/lib64` ELF loader required by the uv-managed CPython binary. Validation used the repository’s existing synced Python 3.12 environment through the pinned Nix loader.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed and the local toolchain limitation.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] No documentation or release-note update is required for this fail-closed universe correction.
