### PR TITLE
fix(torghut): require parity dump evidence

### DIFF
--- a/services/torghut/scripts/verify_historical_simulation_parity.py
+++ b/services/torghut/scripts/verify_historical_simulation_parity.py
@@ -122,6 +122,8 @@ def build_historical_parity_report(*, run_dirs: list[Path]) -> dict[str, Any]:
             failed_reasons.append(f"legacy_path_count_nonzero:{snapshot.run_id}")
         if snapshot.fallback_count != 0:
             failed_reasons.append(f"fallback_count_nonzero:{snapshot.run_id}")
+        if not snapshot.dump_sha256:
+            failed_reasons.append(f"dump_sha256_missing:{snapshot.run_id}")
         if snapshot.parity_hash != baseline.parity_hash:
             failed_reasons.append(f"parity_hash_mismatch:{snapshot.run_id}")
         if snapshot.dump_sha256 != baseline.dump_sha256:

--- a/services/torghut/tests/test_verify_historical_simulation_parity.py
+++ b/services/torghut/tests/test_verify_historical_simulation_parity.py
@@ -55,6 +55,30 @@ class TestVerifyHistoricalSimulationParity(TestCase):
             self.assertFalse(report["passed"])
             self.assertIn("parity_hash_mismatch:run-b", report["failed_reasons"])
 
+    def test_fails_when_any_run_is_missing_dump_sha(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            run_a = _write_run(
+                root=root,
+                run_name="run-a",
+                trade_decisions=10,
+                executions=4,
+                net_pnl="12.5",
+            )
+            run_b = _write_run(
+                root=root,
+                run_name="run-b",
+                trade_decisions=10,
+                executions=4,
+                net_pnl="12.5",
+                dump_sha256="",
+            )
+
+            report = build_historical_parity_report(run_dirs=[run_a, run_b])
+
+            self.assertFalse(report["passed"])
+            self.assertIn("dump_sha256_missing:run-b", report["failed_reasons"])
+
 
 def _write_run(
     *,
@@ -63,6 +87,7 @@ def _write_run(
     trade_decisions: int,
     executions: int,
     net_pnl: str,
+    dump_sha256: str = "dump-sha",
 ) -> Path:
     run_dir = root / run_name
     run_dir.mkdir(parents=True, exist_ok=True)
@@ -71,7 +96,7 @@ def _write_run(
             {
                 "run_id": run_name,
                 "replay": {
-                    "dump_sha256": "dump-sha",
+                    "dump_sha256": dump_sha256,
                 },
                 "monitor": {
                     "activity_classification": "success",


### PR DESCRIPTION
## Summary

- Fails historical simulation parity when any run omits its source dump SHA.
- Prevents two missing hashes from comparing equal and producing a false parity pass.
- Adds a focused regression test for a run with missing dump evidence.

## Related Issues

Addresses historical Codex review: https://github.com/proompteng/lab/pull/4556#discussion_r2940655990

## Testing

- Python 3.12 `pytest -q tests/test_verify_historical_simulation_parity.py` — 3 passed.
- Pyright `pyrightconfig.json` — 0 errors, 0 warnings.
- Pyright `pyrightconfig.alpha.json` — 0 errors, 0 warnings.
- Pyright `pyrightconfig.scripts.json` — 0 errors, 0 warnings.
- Ruff format check and Ruff lint on changed files — passed.
- `uv sync --frozen --extra dev` was attempted; agents-shell lacks the standard `/lib64` ELF loader required by the uv-managed CPython binary. Validation used the repository’s existing synced Python 3.12 environment through the pinned Nix loader.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed and the local toolchain limitation.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] No documentation or release-note update is required for this parity-evidence correction.
