### PR TITLE
docs(torghut): add adversarial profitability design

### DIFF
--- a/docs/torghut/README.md
+++ b/docs/torghut/README.md
@@ -20,6 +20,8 @@ Trust these surfaces in order:
 
 ## Current Runbooks
 
+- Profitability architecture, audit, research gates, and implementation handoff:
+  `docs/torghut/profitability/README.md`
 - Torghut app GitOps and TA replay: `argocd/applications/torghut/README.md`
 - Trading service local development: `services/torghut/README.md`
 - Current source-state map: `docs/torghut/current-source-state.md`

--- a/docs/torghut/profitability/README.md
+++ b/docs/torghut/profitability/README.md
@@ -1,0 +1,68 @@
+# Torghut Profitability Design Pack
+
+Status: Current design and implementation handoff.
+
+Source baseline: `9f6487ada0cf9222b65cbb1ee9b10d50a09b216e`.
+
+Audit snapshot: `2026-07-14T05:48:00Z` through `2026-07-14T06:06:33Z`.
+
+This directory defines the production design required to make Torghut profitability economically true, statistically
+defensible, operationally safe, and independently reproducible. It does not claim that Torghut is profitable or grant
+paper/live capital authority.
+
+## Authority And Reading Order
+
+Live source and runtime still outrank these documents. For a capital or operational decision, read in this order:
+
+1. live broker state and immutable broker economic events;
+2. `GET /readyz`, direct scheduler `GET /trading/status`, and current Argo/Kubernetes state;
+3. current GitOps under `argocd/applications/torghut/**`;
+4. current service code and tests under `services/torghut/**`;
+5. the time-stamped audit snapshot in this directory;
+6. the normative design and roadmap in this directory;
+7. dated material under `docs/torghut/design-system/**` as historical rationale only.
+
+Do not copy a runtime count, blocker, revision, account state, or candidate result from these documents without a fresh
+readback. The audit snapshot records what was observed at its stated time.
+
+## Documents
+
+- [Current audit snapshot](current-audit-snapshot-2026-07-14.md): source, cluster, CNPG, accounting, candidate, and
+  Hyperliquid evidence that motivated the design.
+- [Adversarial profitability system design](adversarial-profitability-system-design.md): target architecture,
+  authority boundaries, economic ledger, execution, data, risk, and proof contracts.
+- [Research validation and promotion design](research-validation-and-promotion-design.md): objective function, KPI
+  dictionary, causal data rules, statistical validation, capacity/TCA methodology, strategy queue, and capital ladder.
+- [Implementation roadmap](implementation-roadmap.md): ordered PR-sized delivery slices, tests, rollout proof,
+  dependencies, and rollback posture.
+
+## Current Decision
+
+Ordinary live risk-increasing submission must remain blocked. A separately bounded, expiring micro-live experiment may
+become eligible only after, at minimum:
+
+- strategy-scoped capital authority is enforced before risk-increasing broker I/O;
+- every broker mutation uses durable claim and receipt fencing;
+- an independent broker-activity reducer reconciles orders, fills, positions, cash, equity, fees, corrections, and
+  corporate actions with zero unexplained settled delta;
+- current order-feed, runtime-ledger, TCA, and TigerBeetle evidence is complete and fresh;
+- the same versioned policy and execution envelope is proven through replay, shadow, and bounded paper probation;
+- a candidate passes selection-adjusted statistical, after-cost, tail-risk, and capacity gates.
+
+Scaling beyond the initial micro-live tranche requires a new completed, reconciled proof window at that tranche.
+Cancellation and strictly exposure-reducing closeout must remain available when capital, profitability, data, or
+accounting gates block entries. Those actions remain durably fenced and must not side-flip or increase gross/net
+exposure, but they do not depend on an active candidate capital grant.
+
+## Definition Of Done
+
+No capability is complete because a class, migration, table, test fixture, API field, green Argo badge, or design file
+exists. Material work is complete only after this common chain passes:
+
+`reachable production code -> regression/property tests -> fault injection -> CI -> built image identity -> Argo sync -> controlled runtime observation -> capability-specific independent proof`
+
+The terminal proof must match the capability: broker/capital work requires independent broker-economic reconciliation;
+research work requires immutable receipt/trial replay reproduction; storage work requires preserved hashes plus
+failover/restore evidence; operational work requires the declared fault/SLO recovery. Inapplicable proof fields are
+recorded as such with a reason, never fabricated. Missing any applicable link means the capability is not
+production-proven.

--- a/docs/torghut/profitability/adversarial-profitability-system-design.md
+++ b/docs/torghut/profitability/adversarial-profitability-system-design.md
@@ -1,0 +1,570 @@
+# Torghut Adversarial Profitability System Design
+
+Status: Proposed normative design.
+
+Source baseline: `9f6487ada0cf9222b65cbb1ee9b10d50a09b216e`.
+
+Companion evidence: [current audit snapshot](current-audit-snapshot-2026-07-14.md).
+
+Implementation handoff: [implementation roadmap](implementation-roadmap.md).
+
+Research contract: [research validation and promotion design](research-validation-and-promotion-design.md).
+
+## Decision Summary
+
+Torghut must optimize independently verified, after-cost, risk-adjusted return at executable capacity. It must not
+optimize the number of strategies, backtest point estimates, generated reports, fills, turnover, or green status
+surfaces.
+
+The design makes five changes to the system boundary:
+
+1. broker economic events become the external accounting authority;
+2. every candidate-evidence or real-capital risk-increasing mutation requires strategy-scoped capital authority and
+   durable fencing before broker I/O;
+3. one versioned economic policy and execution envelope follows a candidate through replay, shadow, paper, and live;
+4. promotion requires independent recomputation and adversarial falsification, not self-attestation;
+5. capital increases only through completed proof windows, with automatic demotion and reduce-only exits.
+
+The system is not capital-ready while any of those contracts is absent. Platform availability and singleton scheduling
+are prerequisites, not profitability evidence.
+
+## Problem Statement
+
+The current source contains many strong components: a singleton scheduler, advisory leadership, exact-ledger research,
+runtime-ledger blockers, TCA rows, TigerBeetle journaling, replay stress, promotion contracts, and research orchestration.
+The audit also found that component presence is not end-to-end economic proof:
+
+- `services/torghut/tests/test_broker_mutation_receipts_unwired.py` requires broker-mutation receipt APIs to remain
+  absent from production mutation paths;
+- `StrategyConfig` in `services/torghut/app/strategies/catalog.py` persists `enabled` but no typed capital stage;
+- `family_template_id_from_strategy_id` in
+  `services/torghut/app/trading/runtime_strategy_resolution.py` removes the `@...` suffix used by GitOps to describe
+  `paper` and `research` strategies;
+- `run_strategy_autoresearch_loop.py` can set the run-level `objective_met` flag before checking whether the candidate
+  was retained;
+- current research and live GitOps use materially different economic envelopes, including roughly 1x research gross
+  exposure versus 4x live gross exposure;
+- internal execution, TCA, ledger, and TigerBeetle rows can agree with one another while broker exits, corrections,
+  actual fees, cash movements, or position truth are incomplete.
+
+These are not documentation gaps. They allow false confidence even when individual components behave as implemented.
+
+## Goals
+
+- Reconstruct every broker economic event exactly once and preserve corrections and reversals.
+- Reconcile orders, fills, positions, cash, equity, costs, and PnL to the broker with zero unexplained settled delta.
+- Enforce strategy-scoped capital authority before all risk-increasing broker mutations.
+- Keep cancellation, strictly risk-reducing replacement, and closeout available during capital, profitability, data,
+  or accounting blocks.
+- Use point-in-time data, deterministic execution semantics, complete trial lineage, and selection-adjusted statistics.
+- Measure spread, fees, slippage, impact, borrow, opportunity cost, and capacity using live-calibrated evidence.
+- Apply portfolio-level factor, sector, beta, cluster, liquidity, tail-risk, and concentration budgets.
+- Produce an immutable proof bundle that a second implementation can reproduce from raw evidence.
+- Fail closed when authority, freshness, lineage, policy, reconciliation, or evidence is missing or contradictory.
+
+## Non-Goals
+
+- Promise a fixed return or claim to be the best trading system in the market.
+- Treat `$500/day`, Sharpe, win rate, gross PnL, or fill count as sufficient promotion evidence.
+- Make an LLM, foundation model, synthetic generator, local artifact, or design document a capital authority.
+- Rewrite Torghut around an external framework solely to match its branding or API.
+- Combine the equities and Hyperliquid economic ledgers, promotion evidence, or capital authority.
+- Block emergency risk reduction because a profitability or accounting dependency is unavailable.
+
+## Design Principles
+
+### External Facts Before Internal Claims
+
+The broker is authoritative for externally accepted orders, fills, corrections, fees, cash movements, positions, and
+equity. Torghut is authoritative for strategy intent, policy, attribution, expected costs, and its own control decisions.
+An internal row is a claim until reconciled with the relevant external fact.
+
+### One Economic Event, Many Projections
+
+Postgres, TigerBeetle, TCA, strategy PnL, runtime status, and reports must project the same immutable event stream. A
+projection may be rebuilt. It must not create a new economic fact or validate itself through another projection derived
+from the same incomplete input.
+
+### Authority Is Typed And Strategy-Scoped
+
+`enabled`, a strategy name suffix, an operationally healthy route, and a global live-submit flag do not grant capital.
+Every decision and mutation cites an unexpired strategy authority record, policy digest, evidence epoch, and maximum
+notional.
+
+### Evidence Must Be Able To Falsify The System
+
+Known-bad strategies, duplicate events, corrections, future timestamps, cost shocks, leader deaths, database failover,
+and contradictory readiness surfaces are required tests. A proof system that never rejects its own candidates is not a
+proof system.
+
+### Scaling Is A New Experiment
+
+Execution cost and capacity are nonlinear. Every capital increase creates a new evidence window at the new size. A
+previously approved point estimate cannot authorize indefinite scaling.
+
+## Target Architecture
+
+```mermaid
+flowchart LR
+    MD["SIP market data\ncorporate actions\nborrow metadata"] --> RAW["Immutable raw event store\nevent/source/ingest clocks"]
+    BR["Broker Activities\nTrade Events\norders/positions/equity"] --> RAW
+    RAW --> FEAT["Point-in-time feature receipts"]
+    FEAT --> RES["Hypothesis + trial ledger\nexact replay + shadow"]
+    RES --> AUTH["StrategyCapitalAuthority\npolicy + evidence epoch"]
+    AUTH --> RISK["Portfolio allocator + risk gates"]
+    RISK --> EXEC["Claim + mutation receipt\nsubmit/cancel/replace/closeout"]
+    EXEC --> BR
+    BR --> REDUCE["RiskReductionPermit\nfresh order/position bound"]
+    REDUCE --> EXEC
+    BR --> RED1["Canonical broker-economic reducer"]
+    BR --> RED2["Independent shadow reducer"]
+    RED1 --> PG["Postgres projections\nstrategy ledger + TCA"]
+    RED1 --> TB["TigerBeetle transfer parity"]
+    RED2 --> RECON["Economic reconciliation"]
+    PG --> RECON
+    TB --> RECON
+    RECON --> AUTH
+```
+
+### Plane Responsibilities
+
+| Plane          | Owns                                                          | Must not own                 |
+| -------------- | ------------------------------------------------------------- | ---------------------------- |
+| Raw data       | Immutable provider and broker payloads, clocks, identities    | Strategy conclusions         |
+| Research       | Hypotheses, trials, frozen data, replay, selection statistics | Live capital                 |
+| Authority      | Stage, policy, evidence epoch, notional and expiry            | Recomputed PnL               |
+| Execution      | Exactly-once economic intent and recovery                     | Promotion decisions          |
+| Accounting     | Inventory, cash, costs, NAV and PnL projections               | Alpha selection              |
+| Reconciliation | Cross-source equality, freshness and unexplained deltas       | Creating missing facts       |
+| Portfolio risk | Exposure and tail-risk budgets                                | Overriding missing authority |
+| Operations     | Availability, rollout identity, SLOs and incidents            | Declaring profitability      |
+
+## Strategy Capital Authority
+
+Extend the existing promotion authority into one persisted strategy-scoped contract. Do not create a second permissive
+authority beside it.
+
+Canonical stages:
+
+```text
+disabled / quarantined
+        -> research_only -> replay_verified -> shadow_allowed
+        -> paper_probation -> paper_verified -> micro_live_allowed
+        -> capital_allowed -> scaled
+```
+
+Only `capital_allowed` and `scaled` may increase real exposure. `micro_live_allowed` may increase exposure only within
+the explicitly encoded experimental tranche. `paper_probation` grants bounded evidence collection in a paper account;
+`paper_verified` records that the probation exit gate passed but grants no real capital by itself.
+
+This enum replaces, rather than coexists with, existing permissive vocabularies. During migration,
+`EvidenceEpochDecision` is an evidence input to `StrategyCapitalAuthority`, not a capital grant. Apply this conservative
+mapping:
+
+| Existing evidence decision | Canonical stage      | Migration rule                                                                                         |
+| -------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------ |
+| `shadow_only`              | `shadow_allowed`     | No broker mutation                                                                                     |
+| `research_allowed`         | `research_only`      | Research artifacts only                                                                                |
+| `paper_allowed`            | `paper_probation`    | Paper evidence collection only                                                                         |
+| `canary_allowed`           | `micro_live_allowed` | Reissue only with complete bounds, expiry, proof epoch, and explicit approval; otherwise `quarantined` |
+| `live_allowed`             | `capital_allowed`    | Reissue only with the complete new contract; otherwise `quarantined`                                   |
+| `scale_allowed`            | `scaled`             | Reissue only from a completed proof window at the current tranche; otherwise `quarantined`             |
+| `quarantined` or unknown   | `quarantined`        | No risk-increasing broker mutation                                                                     |
+
+Inventory and migrate every issuer and consumer of evidence epochs, promotion authority, proof-floor state, submission
+council state, global live flags, and strategy-name stages before enabling the new enforcement path. At cutover, legacy
+real-capital decisions fail closed until explicitly reissued; there is no compatibility fallback from a missing
+strategy authority to an older global authority.
+
+Minimum authority payload:
+
+| Field                          | Contract                                                             |
+| ------------------------------ | -------------------------------------------------------------------- |
+| `authority_id`                 | Immutable unique identifier                                          |
+| `strategy_id` / `candidate_id` | Exact strategy and candidate identity; suffixes are descriptive only |
+| `stage`                        | Typed enum; unknown values reject                                    |
+| `policy_digest`                | Versioned economic, statistical, risk, and data policy               |
+| `evidence_epoch_id`            | Frozen proof bundle that produced the decision                       |
+| `code_commit` / `image_digest` | Exact evaluated runtime implementation                               |
+| `data_snapshot_digest`         | Exact causal input snapshot                                          |
+| `execution_envelope_digest`    | Sizing, leverage, route, lifecycle, cost and fallback semantics      |
+| `max_notional`                 | Maximum risk-increasing notional for this authority                  |
+| `max_loss` / `risk_budget`     | Sleeve loss and tail-risk limits                                     |
+| `issued_at` / `expires_at`     | Bounded validity; expiry fails closed                                |
+| `blockers`                     | Typed current blockers; empty only after evaluation                  |
+| `approver`                     | Independent policy actor; never the candidate model                  |
+
+For a risk-increasing action, pre-I/O checks must atomically prove:
+
+- the authority exists, is unexpired, and matches the exact strategy and candidate;
+- the decision action is allowed for the stage;
+- the mutation remains within notional, exposure, liquidity, and loss budgets;
+- the policy, data, code, image, and execution digests match the active runtime;
+- reconciliation, source freshness, and operational gates are current;
+- a risk-increasing claim has not already been accepted.
+
+The check produces a denial receipt on failure. It must never silently fall back from a missing strategy authority to a
+global operational flag. Risk reduction uses the separate, non-capital permit below.
+
+### Infrastructure Validation Permit
+
+P0 must fault-test submit, cancel, recovery, activity ingestion, and ledger behavior before any candidate can enter
+paper probation. Those tests use one typed `InfrastructureValidationPermit`, not a hidden bypass or candidate stage.
+The permit is valid only when all of these are encoded and enforced:
+
+- purpose is exactly `control_plane_validation`, with no strategy/candidate promotion identity;
+- venue and account are a dedicated paper or exchange sandbox identity allowlisted as non-live at configuration and
+  broker-adapter boundaries;
+- symbols, sides, order types, maximum order/notional/loss, maximum outstanding intents, session, issuer, and a short
+  expiry are explicit;
+- a known-null test plan and expected terminal economic state are immutable inputs;
+- every decision, order, activity, fill, ledger row, and report is tagged `non_promotable_validation` and excluded from
+  candidate statistics, PnL targets, trial selection, and promotion evidence;
+- the permit cannot be converted, inherited, or mapped to `paper_probation` or a real-capital stage.
+
+Issuance requires explicit infrastructure-owner approval. A research agent, candidate, global live flag, account name,
+or healthy route cannot issue it. Any attempt to target a live account, omit the non-promotable tag, exceed a bound, or
+use the resulting events in promotion fails closed and opens an incident.
+
+## Broker Mutation Protocol
+
+Every submit, cancel, replace, targeted unwind, pair leg, and emergency closeout uses the same durable claim, receipt,
+idempotency, and recovery protocol. Capital authorization differs by action class:
+
+- a **risk-increasing** action requires an active `StrategyCapitalAuthority` and all profitability, data,
+  reconciliation, portfolio-risk, and operational gates;
+- a **strictly risk-reducing** action requires a per-action `RiskReductionPermit`, not an active candidate capital
+  grant. The permit is derived from a fresh broker order/position observation or broker-enforced reduction primitive,
+  caps quantity to observed exposure, forbids a side flip or new symbol, and proves gross and net exposure cannot
+  increase under conservative marks;
+- a **control-plane validation** action requires an `InfrastructureValidationPermit`, can reach only a dedicated
+  paper/sandbox account, and can never contribute candidate or promotion evidence;
+- canceling a referenced open entry order may proceed without profitability evidence, but its ambiguous outcome remains
+  fenced and must be recovered before replacement or new exposure.
+
+Missing or expired candidate authority, stale TCA, stale profitability evidence, and ledger mismatch block entries but
+must not block a provably monotonic reduction. If broker state is too stale or unavailable to prove reduction, cancel
+known entry orders, persist the unresolved reduction intent, perform strict broker anti-entropy, and retry recovery; do
+not guess a closeout quantity.
+
+1. Persist the economic intent and deterministic broker client identity.
+2. Classify the action and atomically acquire either strategy capital authority or a bounded risk-reduction permit.
+3. Acquire the decision/mutation claim.
+4. Create a broker-mutation receipt in `claimed` state before network I/O.
+5. Persist `broker_io_started` with the fencing epoch.
+6. Perform at most the authorized broker mutation.
+7. Atomically settle receipt, claim, execution identity, and observed broker response.
+8. Ingest asynchronous Trade Events and Activities as independent broker facts.
+9. Reconcile the terminal broker state and release or retain the claim explicitly.
+
+Unknown broker state is a durable state, not an exception to retry. Recovery acquires a lease, performs one strict
+lookup by the exact broker identity, and records `accepted`, `rejected`, `not_found`, or `unknown`. `unknown` blocks new
+exposure until anti-entropy resolves it.
+
+### Crash Invariants
+
+- Leader death before I/O produces no broker mutation.
+- Leader death after broker acceptance produces one broker mutation and one recovered terminal receipt.
+- Leader death after response but before local commit cannot produce a second economic intent.
+- Competing writers cannot hold the same claim or settle conflicting terminal receipts.
+- Duplicate broker events and Kafka offsets do not change inventory, cash, or PnL twice.
+- Cancel or closeout uncertainty blocks entries but never disables continued risk-reduction recovery.
+
+### Multi-Leg Execution
+
+Pairs and other multi-leg strategies require a durable group record with reserved pending exposure, leg identities,
+hedge deadline, partial-fill state, targeted unwind policy, and group terminal state. Account-wide flattening is a last
+resort controlled by portfolio risk, not the default response to one failed leg.
+
+## Broker Economic Event Store
+
+Use the broker's financial Activity stream for new economic events and paginated REST retrieval for bounded
+anti-entropy. Keep order lifecycle Trade Events separate and link them by immutable external identities. Alpaca's
+[Account Activities](https://docs.alpaca.markets/us/docs/account-activities) include fills and non-order financial
+activity, while its [Activity SSE](https://docs.alpaca.markets/us/docs/activity-sse) explicitly complements, rather
+than replaces, the order Trade Events stream.
+
+Canonical event fields:
+
+- provider, account scope, environment, event type, external event ID, external order ID, client order ID;
+- original and correction/reversal identities;
+- event, effective, source, ingest, and first-observed timestamps;
+- symbol/instrument, side, quantity, price, notional, currency, fee and fee type;
+- cash amount, corporate-action type, borrow/interest/tax classification;
+- raw payload digest, raw payload retention reference, schema version, and ingestion cursor;
+- linked Torghut decision, execution, mutation receipt, candidate, strategy, and evidence epoch when known.
+
+Provider IDs and correction semantics define idempotency. A missing Torghut link does not discard an economic event; it
+creates reconciliation debt and blocks promotion.
+
+## Canonical And Independent Ledgers
+
+Build two reducers from the same raw broker events:
+
+- the canonical reducer produces production inventory, cash, cost, NAV, strategy attribution, and TigerBeetle transfer
+  plans;
+- the independent reducer uses separate code and state, reads no canonical derived rows, and produces the equality
+  check used by promotion and incident response.
+
+Both reducers must support partial fills, buy/sell, short/cover, corrections, busts, dividends, interest, borrow and
+regulatory fees, deposits, withdrawals, splits, mergers, symbol changes, overnight positions, and mark-to-market.
+
+Required equations:
+
+```text
+cash ending
+= cash starting
+ + external cash flows
+ + sell/short proceeds
+ - buy/cover cost
+ - fees, borrow, interest and taxes
+ + corporate-action cash
+
+NAV = cash + marked positions
+
+strategy net PnL
+= realized PnL
+ + marked unrealized change
+ - explicit costs
+ - allocated borrow, interest and taxes
+```
+
+Deposits and withdrawals affect cash and NAV but are removed from trading return and drawdown calculations. Realized
+strategy PnL, account NAV, and closed-round-trip PnL are separate measures and must not be substituted for one another.
+TCA measures execution quality; it is never a PnL proxy.
+
+### Reconciliation States
+
+| State             | Meaning                                                    | Capital consequence           |
+| ----------------- | ---------------------------------------------------------- | ----------------------------- |
+| `current_exact`   | All mandatory settled events and balances agree            | May satisfy accounting gate   |
+| `current_pending` | Only documented unsettled/provider-lag events remain       | Entries follow bounded policy |
+| `stale`           | Reconciliation exceeded its freshness SLO                  | Block entries                 |
+| `mismatch`        | Quantity, cash, fee, position, equity, or identity differs | Block entries; open incident  |
+| `unknown`         | Source unavailable or ambiguous                            | Block entries                 |
+
+TigerBeetle supplies durable transfer parity. Protocol health or a bounded sample cannot set profitability or capital
+authority. Risk-increasing orders require the configured reconciliation freshness and coverage; risk-reducing orders do
+not.
+
+## Point-In-Time Market And Feature Data
+
+US-equity research and live evidence must preserve the selected feed identity. Alpaca documents SIP as consolidated
+exchange data and IEX as a single-exchange feed in its [market-data FAQ](https://docs.alpaca.markets/us/docs/market-data-faq).
+Research/live parity therefore includes feed, subscription, symbol universe, corporate-action adjustment, calendar,
+timezone, and clock semantics.
+
+Every research and runtime feature batch emits an immutable receipt containing:
+
+- source, event, exchange, ingest, availability, and decision timestamps;
+- dataset, code, schema, calendar, universe, corporate-action, and adjustment digests;
+- field x symbol x session coverage and null/stale/duplicate rates;
+- fallback and proxy use by field and row;
+- source cursor/offset windows and detected gaps;
+- family-required feature contract and rejection reasons.
+
+A family-required field missing or temporally unavailable invalidates the run. It cannot become a warning-only proxy.
+Feature event time after decision time, unavailable future corporate-action knowledge, or negative feature age is a
+hard causal failure.
+
+## One Execution And Economic Envelope
+
+The same envelope digest follows the candidate through every stage. It covers:
+
+- code, candidate parameters, feature schema, universe, clock, and data snapshot;
+- start equity, sizing, leverage, gross/net/symbol/cluster limits, cash reserve, and rounding;
+- broker/environment, order types, time in force, repricing, retries, cancel and closeout behavior;
+- spread, fee, slippage, impact, borrow, latency, fill-survival, queue, and missed-fill models;
+- market calendar, session gates, shortability, corporate actions, and fallback behavior.
+
+Any mismatch invalidates parity and blocks promotion. In particular, a candidate evaluated near 1x gross cannot inherit
+a 4x live envelope without a separate capacity, drawdown, and micro-live proof.
+
+## Portfolio Risk And Allocation
+
+Pre-trade allocation must enforce both strategy authority and portfolio constraints:
+
+- cash-flow-adjusted daily loss, drawdown, expected shortfall, and stress loss;
+- gross, net, symbol, sector, factor, beta, volatility, cluster, and correlated-sleeve exposure;
+- ADV/participation, spread, borrow, concentration, pending orders, and reserved pair-leg exposure;
+- turnover, side flips, position age, liquidity deterioration, and market-session controls;
+- current positions plus pending accepted/unknown mutations.
+
+The current semiconductor universe must be treated as one correlated risk cluster until measured factor/correlation
+evidence supports finer diversification. Fractional Kelly or other aggressive sizing may be a capped research
+challenger only after outcome probabilities and costs are live-calibrated.
+
+## Readiness And Observability
+
+One typed state reducer supplies action-specific projections to every surface. `/readyz`, `/trading/status`, submission,
+metrics, and alerting must not independently reinterpret the same facts, but they also must not collapse distinct
+authorities into one boolean:
+
+- `service_healthy`: the process can serve status and safely persist or continue recovery work;
+- `entry_allowed`: every strategy-capital, source, economic, portfolio-risk, and operational entry gate passes;
+- `reduce_only_allowed`: the broker state and mutation infrastructure can prove and fence a monotonic reduction;
+- `recovery_degraded`: unresolved intents or unavailable dependencies require anti-entropy or operator action.
+
+`entry_allowed=false` does not imply `service_healthy=false` or `reduce_only_allowed=false`. Kubernetes readiness follows
+`service_healthy`, not capital authorization, so a stale ledger, closed market, expired candidate grant, or failed alpha
+gate does not remove the singleton control/recovery endpoint from its Service. If a separate worker truly cannot serve
+or persist safe recovery, its readiness may fail, but a read-only status/control surface must remain addressable.
+
+Required public fields, without secrets or raw account identifiers:
+
+- active source, code, image, policy, data, envelope, and evidence digests;
+- process role, leadership epoch, broker route, market-session state, and stream ownership;
+- strategy authority counts by stage and risk-increasing/reduce-only action;
+- event, cursor, symbol, feature, order, fill, correction, and reconciliation freshness;
+- mutation claim/receipt states and unresolved unknown economic intents;
+- canonical versus independent ledger deltas;
+- actual-cost, TCA prediction, markout, capacity, drawdown, expected-shortfall, and concentration coverage;
+- exact typed blockers and the authority that emitted them.
+
+API proxy status must expose scheduler unavailability rather than serving stale local state. Liveness, Kubernetes
+service readiness, entry authorization, reduction authorization, and capital stage remain separately observable. Argo
+Synced/Healthy remains deployment evidence only.
+
+## Database Reliability
+
+The economic truth plane cannot depend on an unbounded query or a single unrehearsed database instance.
+
+- Use bounded statements and explicit transaction deadlines on scheduler/readiness paths.
+- Eliminate idle-in-transaction sessions and keep outcome labeling outside long-held transactions.
+- Partition or index high-volume event and options data using measured PostgreSQL plans.
+- Tune autovacuum/WAL behavior from observed table churn, not estimated tuple ratios alone.
+- Run CNPG with tested recovery point/recovery time objectives, continuous backups, at least one replica where the
+  infrastructure allows, and a documented failover/restore rehearsal.
+- Prove claims, receipts, cursors, and ledgers survive primary failover without duplicate economic effects.
+
+Schema-current does not mean query-current, available, or economically reconciled.
+
+## Adversarial Proof Bundle
+
+Every promotion or scaling decision consumes one immutable evidence epoch containing:
+
+- raw source inventory and retention references;
+- dataset, feature, code, image, policy, and execution-envelope digests;
+- complete trial ledger, selection count, negative controls, and statistical outputs;
+- exact replay, shadow, paper, broker activity, TCA, ledger, and reconciliation artifacts;
+- regime, symbol, day, concentration, tail-risk, and capacity slices;
+- mutation crash/fault results and database failover result;
+- canonical and independent reducer equality result;
+- current typed blockers, approver, decision, expiry, and capital tranche.
+
+The bundle is reproducible offline from raw inputs. Derived summaries are conveniences, not authority.
+
+## Adversarial Definition Of Done
+
+Each material slice must prove all of the following:
+
+1. **Reachability:** a production caller inventory shows the new path is used everywhere intended.
+2. **Contract:** regression, property, and negative tests cover invariants and denial behavior.
+3. **Fault tolerance:** timeout, duplicate, correction, crash, and failover tests pass.
+4. **Artifact identity:** the built image cites the exact source commit and digest.
+5. **Rollout identity:** Argo and live children run that image and configuration.
+6. **Controlled behavior:** a bounded paper or zero-notional session moves the expected runtime counters and rows.
+7. **Terminal proof:** broker/capital work reconciles independent economic state; research work reproduces immutable
+   trial receipts; storage work restores preserved hashes; operational work demonstrates the declared fault/SLO
+   recovery.
+8. **Rollback:** injected blockers stop new exposure, preserve reduce-only exits, and demote authority.
+
+A fixture-only test, an unwired API, a static status field, a self-generated proof payload, or an irrelevant economic
+check cannot satisfy these requirements.
+
+## Failure Modes And Required Responses
+
+| Failure                             | Detection                                                 | Required response                                           |
+| ----------------------------------- | --------------------------------------------------------- | ----------------------------------------------------------- |
+| Market stream owner conflict        | Provider connection errors, duplicate owners, cursor gaps | Block entries; elect one owner; re-prove symbol coverage    |
+| Broker mutation ambiguous           | Receipt `unknown`, timeout, malformed lookup              | Block entries; strict anti-entropy; do not resubmit blindly |
+| Order/fill/cash mismatch            | Independent reducer delta                                 | Block entries; preserve raw events; reconcile or reverse    |
+| Source or feature causality failure | Timestamp/coverage receipt invalid                        | Invalidate research/runtime window                          |
+| Policy/envelope drift               | Digest mismatch                                           | Block promotion and submission                              |
+| Ledger or TigerBeetle stale         | Freshness SLO breach                                      | Block entries; keep closeout                                |
+| Database primary/query failure      | Readiness/query/failover SLO                              | Stop entries; use durable recovery after failover           |
+| Tail-risk/concentration breach      | Portfolio risk reducer                                    | Cancel pending entries; targeted reduce-only unwind         |
+| Candidate performance decay         | After-cost LCB, TCA, drift, regime gates                  | Demote one stage; require a new proof window                |
+| Readiness contradiction             | Cross-surface parity check                                | Treat the strictest state as authoritative; open incident   |
+
+## Security, Privacy, And Audit
+
+- Never place broker credentials, tokens, raw account identifiers, or private activity payloads in status, metrics,
+  design documents, proof bundles intended for broad access, or logs.
+- Restrict raw broker activities and account projections by least privilege and environment.
+- Make capital-authority issuance, override, expiry, denial, and demotion append-only and attributable.
+- Require explicit operator approval for any emergency override; make it time-bounded, lower-notional, and visible.
+- Preserve market-access risk controls independent of strategy code, consistent with the intent of
+  [SEC Rule 15c3-5](https://www.sec.gov/rules-regulations/2011/06/risk-management-controls-brokers-or-dealers-market-access).
+- Keep research, paper, live, and testnet account scopes cryptographically and operationally distinct.
+
+## Alternatives Rejected
+
+### Tune Strategies First
+
+Rejected because missing exits, broker costs, event attribution, policy parity, or causal data can make the target label
+wrong. More search would overfit an untrustworthy outcome.
+
+### Treat TigerBeetle As Profitability Authority
+
+Rejected because TigerBeetle proves transfer recording and parity, not that source economic facts or strategy
+attribution are complete.
+
+### Use One Internal Ledger As Its Own Verifier
+
+Rejected because shared code and inputs create correlated failure. Promotion requires a second reducer that reads raw
+broker evidence directly.
+
+### Infer Capital Stage From Strategy Names
+
+Rejected because string suffixes are descriptive, are currently stripped during family resolution, and cannot carry
+policy, expiry, notional, evidence, or approval.
+
+### Increase Leverage To Reach A Dollar Target
+
+Rejected because it changes the economic envelope and magnifies model, execution, and tail error. Capacity and risk
+proof must precede leverage.
+
+### Let AI Grant Capital
+
+Rejected. AI may propose hypotheses, rank candidates, summarize evidence, or generate stress scenarios. Deterministic
+policy using independently reproducible evidence grants or denies capital.
+
+## Acceptance Criteria For The Architecture
+
+### Paper-Probation Entry
+
+A candidate may receive bounded, expiring `paper_probation` evidence-collection authority only after:
+
+- the canonical authority migration and caller inventory prove there is no legacy risk-increasing bypass;
+- every mutation path uses claims, receipts, idempotency, and recovery in controlled paper/sandbox fault exercises under
+  an `InfrastructureValidationPermit` whose events are excluded from promotion evidence;
+- risk-increasing actions require strategy capital authority, while missing/expired capital evidence still permits a
+  broker-state-proven risk-reduction permit;
+- broker activity ingestion and both reducers reconcile a controlled lifecycle, including partial fills, fees,
+  corrections, and closeout, with zero unexplained settled delta;
+- replay and shadow cite the same policy and execution-envelope digest;
+- point-in-time poison, known-bad strategy, duplicate-event, crash, and stale-evidence tests fail as designed;
+- entry, reduce-only, recovery, service, and Kubernetes readiness surfaces remain consistent and distinct.
+
+This entry gate authorizes paper evidence collection only. It does not assert profitability and does not require the
+paper observations it is intended to collect.
+
+### Paper-Verification Exit And Micro-Live Entry
+
+After paper probation, `paper_verified` requires the preregistered minimum observation window and a controlled market
+sample demonstrating:
+
+- every risk-increasing mutation cites valid strategy authority, claim, receipt, policy, and evidence identities;
+- duplicate writers and injected crash points produce exactly one broker economic intent;
+- every broker order, fill, partial fill, correction, fee, cash movement, position, and equity change is ingested;
+- canonical and independent ledgers match each other and the broker with zero unexplained settled delta;
+- runtime-ledger and TCA rows use actual costs and complete closed-round-trip lineage;
+- source, feature, cursor, order-feed, reconciliation, and database SLOs remain current;
+- replay, shadow, and paper share the same envelope digest;
+- injected accounting, freshness, risk, and performance failures automatically block or demote entries;
+- reduce-only closeout remains available throughout.
+
+Only a `paper_verified` candidate with explicit approval and a separately bounded loss/notional budget may receive
+`micro_live_allowed`. Completing micro-live then supplies the evidence required for `capital_allowed`; no stage can use
+evidence that only becomes observable after entering that same stage as its entry condition.

--- a/docs/torghut/profitability/current-audit-snapshot-2026-07-14.md
+++ b/docs/torghut/profitability/current-audit-snapshot-2026-07-14.md
@@ -1,0 +1,496 @@
+# Torghut Profitability Audit Snapshot - 2026-07-14
+
+Status: Time-stamped observed evidence. Not a capital authorization.
+
+Repository source baseline: `9f6487ada0cf9222b65cbb1ee9b10d50a09b216e`.
+
+Live audit window: `2026-07-14T05:48:00Z` through `2026-07-14T06:06:33Z`.
+
+Normative design: [adversarial profitability system design](adversarial-profitability-system-design.md).
+
+## Authority And Scope
+
+This document records a bounded read-only audit of current source, Git history, Argo/Kubernetes state, direct runtime
+status, CNPG/Postgres evidence, and primary external research. Counts and live states are historical immediately after
+capture. A current decision must repeat the probes.
+
+Evidence priority for this snapshot was:
+
+1. broker economic facts when exposed by the audited system;
+2. direct scheduler and websocket endpoints;
+3. CNPG source rows and exact bounded SQL;
+4. Argo and Kubernetes child-resource state;
+5. source code, tests, GitOps, and Git history;
+6. dated design documents as context only.
+
+No cluster, database, broker, GitOps, or application mutation was performed. Account labels, credentials, tokens, and
+raw private broker payloads are intentionally omitted.
+
+## Audit Conclusion
+
+Torghut was contained but not profitability-ready:
+
+- the latest position snapshot was flat;
+- Argo was Synced/Healthy and the singleton scheduler was running;
+- the scheduler remained `503 degraded` and denied live submission;
+- there was no current live runtime ledger;
+- recent executions were not canonically linked to order-feed events;
+- broker-mutation fencing code was present but explicitly unwired from production mutation paths;
+- TigerBeetle reconciliation was stale and bounded rather than exhaustive;
+- the only blocker-free candidate evidence was paper-stage, stale, and too small for inference;
+- Hyperliquid remained disabled/testnet-only and failed timestamp, fill-linkage, sample, and after-fee checks.
+
+The current evidence therefore supports continued blocking of risk-increasing submission. It does not establish that
+any strategy is profitable, that the `$500/day` objective is feasible, or that the production economic ledger is exact.
+
+## Source And Git History Audit
+
+The worktree was clean and matched `origin/main` at the source baseline above.
+
+Relevant current source findings:
+
+- `argocd/applications/torghut/scheduler-deployment.yaml` defines one scheduler replica and a Postgres advisory
+  leadership contract, so the process-level singleton containment is real.
+- `services/torghut/tests/test_broker_mutation_receipts_unwired.py` asserts that the receipt package is absent from all
+  listed Alpaca, execution, closeout, governance, and Hyperliquid mutation paths.
+- `services/torghut/app/strategies/catalog.py::StrategyConfig` has `enabled` and sizing fields but no typed strategy
+  capital stage.
+- `services/torghut/app/trading/evidence_epochs.py::EvidenceEpochDecision` uses
+  `shadow_only/research_allowed/paper_allowed/canary_allowed/live_allowed/scale_allowed/quarantined`, while proof-floor,
+  submission-council, global flags, and strategy-name stages add adjacent authority surfaces. No audited contract
+  consolidated them into one bounded strategy authority.
+- `services/torghut/app/trading/runtime_strategy_resolution.py::family_template_id_from_strategy_id` removes text
+  after the first `@`; GitOps uses `@paper` and `@research` in strategy IDs.
+- `services/torghut/scripts/strategy_autoresearch_loop/run_strategy_autoresearch_loop.py` sets run-level
+  `objective_met` for any objective-hitting top candidate before skipping candidates whose status is `discard`.
+- `services/torghut/app/trading/discovery/promotion_contract.py` defines a strong final contract, including 20
+  source-backed trading days, 300 closed trades, daily-distribution, drawdown, concentration, and target-implied
+  notional requirements. It correctly separates bounded probation evidence collection from final authority.
+- `services/torghut/config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml` evaluates near 1x
+  gross, while live GitOps permits 4x gross. That is an execution-envelope mismatch, not promotion parity.
+- current scheduler and API GitOps require the TigerBeetle protocol but set
+  `TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED=false`, so stale or mismatched economic reconciliation is not itself a
+  readiness blocker.
+- the runtime-ledger implementation rejects TCA as a profit shortcut and records blockers for missing fills, costs,
+  closed round trips, policy hashes, and lineage. The ledger design is stronger than the available current evidence.
+
+Relevant July merge history separated the safety components:
+
+| Merge commit                 | Change                                                                                 |
+| ---------------------------- | -------------------------------------------------------------------------------------- |
+| `3f89079a5`                  | isolate singleton trading scheduler, PR `#12233`                                       |
+| `94d81f2c0`                  | fence broker submission claims, PR `#12236`                                            |
+| `f8e4da31e`                  | fence broker mutation receipts, PR `#12237`                                            |
+| `5841bc594`                  | settle linked submissions atomically, PR `#12239`                                      |
+| `1390a27e3`                  | add strict Alpaca order lookup, PR `#12282`                                            |
+| `6b977cddd` then `bbae62039` | schedule, then remove, scheduled TigerBeetle reconciliation, PRs `#12107` and `#12227` |
+
+The source audit found that landing those data structures and isolated controls did not establish production
+reachability or a complete broker-economic proof chain.
+
+## Final Live Readback
+
+At `2026-07-14T06:06:33Z`:
+
+| Surface                     | Observed state                                                                           |
+| --------------------------- | ---------------------------------------------------------------------------------------- |
+| Argo application            | `Synced/Healthy`, revision `9f6487ada0cf9222b65cbb1ee9b10d50a09b216e`                    |
+| Scheduler build             | commit `d8d24cd01df091dedde7e32c262fea96cc3d7d11`                                        |
+| Scheduler image             | `sha256:9ac44017971f0c95d8ddabff556b113e23e121a22dc0e17d25a4ed39a59f9c9f`                |
+| Scheduler process           | singleton, running, current leader                                                       |
+| Scheduler `/readyz`         | HTTP `503`, `signal_continuity_alert_active`                                             |
+| Operational submission gate | `allowed=false`                                                                          |
+| Gate blockers               | `signal_continuity_alert_active`, `mainnet_route_unavailable`                            |
+| Market route                | pre-market, closed because the regular session was closed                                |
+| Last decision               | `2026-07-10T16:18:28Z`                                                                   |
+| Live runtime ledger         | zero buckets, `runtime_ledger_missing`                                                   |
+| TCA                         | last computed `2026-07-10T16:18:46Z`, expected-shortfall coverage `0`, lineage `blocked` |
+| TigerBeetle                 | protocol reachable; reconciliation stale by `261269` seconds                             |
+| Websocket forwarder         | final re-read `ready=true`; all four gates true                                          |
+
+The websocket result requires context. Earlier in the same audit window, the pod had a prolonged provider `406
+connection limit exceeded` incident and repeated reconnect/readiness changes. The final re-read proved recovery at that
+instant, not market-open continuity. Only four of the ten configured symbols appeared in the latest accepted readiness
+window, and scheduler signal continuity still reported `cursor_ahead_of_stream`.
+
+Argo health, pod readiness, websocket recovery, scheduler readiness, and capital readiness were therefore distinct
+truth surfaces.
+
+## CNPG And Postgres State
+
+CNPG reported one healthy primary, current Alembic head `0061_linked_submission_terminal`, healthy backup/archive
+conditions, a `50 GiB` volume with approximately `21 GiB` used, and a database size near `19 GB`.
+
+It was not a high-availability topology: there was one database instance and no replica. The audit also observed:
+
+- API-to-scheduler and simulation readiness query timeouts;
+- an `IdleInTransactionSessionTimeout` in scheduler outcome-labeling work;
+- a long-running autovacuum on the options catalog waiting on WAL I/O;
+- one transaction-ID lock waiter in a bounded activity snapshot;
+- high dead-tuple estimates in options tables whose statistics were not accurate enough to quote as exact bloat.
+
+Those are maintenance and availability signals. They do not prove data loss, but they show that schema-current and
+CNPG Healthy are insufficient evidence for bounded runtime-query behavior or failover safety.
+
+### Economic Evidence Inventory
+
+| Dataset                            |    Rows | Latest timestamp       | Interpretation                                             |
+| ---------------------------------- | ------: | ---------------------- | ---------------------------------------------------------- |
+| `trade_decisions`                  | 154,339 | `2026-07-10T16:18:28Z` | no current-session decisions                               |
+| `executions`                       |  14,995 | `2026-07-10T16:18:34Z` | no current-session executions                              |
+| `execution_order_events`           |  15,364 | `2026-07-09T20:00:14Z` | stopped before latest executions                           |
+| `execution_tca_metrics`            |  14,991 | `2026-07-10T16:18:46Z` | expected-shortfall prediction coverage zero in live status |
+| `position_snapshots`               | 297,478 | `2026-07-14T05:52:52Z` | latest snapshot flat                                       |
+| `order_feed_source_windows`        |  15,754 | `2026-07-09T20:02:34Z` | source windows stale                                       |
+| `trade_decision_submission_claims` |       0 | none                   | no observed production proof session                       |
+| `strategy_runtime_ledger_buckets`  |      60 | `2026-05-28T16:40:11Z` | all paper-stage; no live ledger                            |
+| `tigerbeetle_reconciliation_runs`  |     647 | `2026-07-11T05:32:10Z` | stale versus one-hour threshold                            |
+
+### Lifecycle Coverage
+
+Cohort: decisions/executions created in the preceding 14 days.
+
+| Evidence stage                                  | Numerator | Denominator | Coverage |
+| ----------------------------------------------- | --------: | ----------: | -------: |
+| Executed decision to fenced submission claim    |         0 |       1,172 |    0.00% |
+| Executed decision to execution row              |     1,172 |       1,172 |  100.00% |
+| Execution row to positive fill                  |       838 |       1,172 |   71.50% |
+| Filled execution to TCA row                     |       838 |         838 |  100.00% |
+| Filled execution to explicit-cost lineage       |       835 |         838 |   99.64% |
+| Filled execution to fully source-backed lineage |       834 |         838 |   99.52% |
+| Recent execution to order-feed event            |        18 |       1,172 |    1.54% |
+| Recent filled execution to order-feed event     |        13 |         838 |    1.55% |
+
+The entire claim cohort predates the current fenced-scheduler rollout. `0/1172` shows that this pre-rollout cohort has
+no claim rows and supplies no post-rollout production observation; it cannot characterize behavior of the new writer.
+Source reachability still blocks the feature because the repository explicitly asserts that mutation receipt APIs
+remain unwired.
+
+The TCA coverage numbers show row presence, not accurate economics. Three recent fills lacked explicit cost lineage,
+four were not fully source-backed, expected-shortfall prediction coverage was zero, and the endpoint described its
+bounded lineage sample as blocked.
+
+## Accounting And Order-Lifecycle Contradictions
+
+The strongest economic contradiction was July 10:
+
+- Postgres recorded 819 filled buys and no sells;
+- the latest position snapshot was flat.
+
+Either the exits/flattening happened without canonical execution and order-feed records, or the stored filled rows were
+not broker-authoritative. Both interpretations block reliable realized PnL and inventory attribution.
+
+Additional observed inconsistencies:
+
+- 825 of 838 recent filled executions had no linked order-feed event;
+- 1,411 historical order events lacked `execution_id` and 1,410 lacked `trade_decision_id`;
+- order-feed cursors had processed duplicates and one observed offset gap;
+- three recent decisions remained `submitted` while their execution rows were `filled`;
+- 16 canceled execution rows had positive filled quantity, so canceled status cannot be interpreted as zero fill and
+  requires explicit partial-fill semantics;
+- direct emergency closeout code did not create the same durable decision/execution/receipt lifecycle as ordinary
+  strategy orders.
+
+The system had no audited Alpaca Account Activities importer. Actual fees, corrections, busts, dividends, interest,
+borrow costs, deposits, withdrawals, and broker cash/equity parity were therefore outside the canonical strategy PnL
+authority.
+
+## Runtime Ledger And Candidate Evidence
+
+The runtime ledger contained 60 paper-stage buckets and no live-stage bucket. Three duplicate economic grains created
+three extra rows. A later reconstructed pairs aggregate appeared to earn about `$16.5k`, but repeated identical buckets
+inflated it and every contributing row carried non-promotion-grade reconstruction, cost, lineage, or open-position
+blockers. It is not profit evidence.
+
+Only six candidate variants had rows with no stored blockers:
+
+| Candidate                   | Active days | Closed trades | Filled notional |    Net PnL | Net expectancy |
+| --------------------------- | ----------: | ------------: | --------------: | ---------: | -------------: |
+| `H-PAIRS-01 / c88421d6`     |           5 |             8 |   `$506,783.47` |  `$832.27` |    `16.42 bps` |
+| `H-PAIRS-01 / 3e49d7da`     |           3 |             3 |   `$949,670.85` |  `$916.47` |     `9.65 bps` |
+| `H-PAIRS-01 / 494798c7`     |           1 |             1 |    `$61,316.50` |   `$16.46` |     `2.68 bps` |
+| `H-PAIRS-01 / 728383d3`     |           1 |             1 |   `$316,321.01` |  `-$52.84` |    `-1.67 bps` |
+| `H-TSMOM-LIQ-01 / ca4e6e3c` |           4 |             7 |   `$330,677.66` | `-$177.82` |    `-5.38 bps` |
+| `H-TSMOM-LIQ-01 / e3b166f2` |           1 |             1 |    `$29,982.15` |  `-$65.79` |   `-21.94 bps` |
+
+All of those rows ended by May 21 and contained one to eight closed trades. They are descriptive directions, not
+statistical or capacity evidence. The positive pairs rows warrant a properly controlled research hypothesis; the
+negative TSMOM-liquidity rows do not justify promotion.
+
+At the audit-time equity, `$500/day` would require approximately `1.21%` of NAV per active day. At `$300,000` daily
+filled notional it would require `16.67` net basis points. The best tiny historical row was below that point estimate
+and had no confidence, impact, or capacity margin. The target remains a hypothesis.
+
+## TigerBeetle Evidence
+
+The latest reconciliation finished `2026-07-11T05:32:10Z`, more than 72 hours before the final readback and beyond the
+configured one-hour threshold.
+
+Its reported `ok` state was bounded accounting-parity evidence:
+
+- 42,896 transfer references existed;
+- 526 transfers were checked by the latest run;
+- the checked sample had zero missing or mismatched transfers;
+- 26 runtime-ledger references were signed;
+- 20,554 stable references existed;
+- 22,342 stable-reference gaps were classified as diagnostic.
+
+Typed source links existed for execution, TCA, order-event, and runtime-ledger projections. That is useful integrity
+evidence, but protocol health and a bounded sample cannot override stale reconciliation, missing broker facts, or an
+absent live profit ledger.
+
+## Hyperliquid Snapshot
+
+Hyperliquid was disabled and testnet-only. The independent lane showed:
+
+- 1,473 testnet fills with aggregate after-fee net PnL of `-$431.328127`;
+- 466 fills, `31.6%`, without `order_id`;
+- one order marked filled without a fill row;
+- 69,997 of 73,671 recent signals with `feature_event_ts > generated_at`;
+- 68,725 signals more than 60 seconds in the future;
+- a latest performance snapshot with zero recent fills/notional/PnL but `sample_ready=true`.
+
+These defects block causal research, order/fill reconciliation, minimum-sample readiness, and profitability. The lane
+must remain separate from equities and cannot supply capital evidence.
+
+## Ranked Blockers At Snapshot Time
+
+1. Enforce typed strategy-scoped capital authority before any risk-increasing broker I/O.
+2. Wire submission claims and broker-mutation receipts into every mutation path and prove them under crashes.
+3. Ingest immutable broker Activities and Trade Events and independently reconstruct positions, cash, equity, costs,
+   and PnL.
+4. Repair exit/closeout and order-feed attribution; resolve the July 10 buy-only/flat contradiction.
+5. Produce current source-backed runtime-ledger buckets with exact costs and closed-round-trip lineage.
+6. Restore fresh incremental and periodic exhaustive TigerBeetle reconciliation.
+7. Fix autoresearch completion so a discarded candidate cannot declare the objective complete.
+8. Unify research, promotion, paper, and live policy/execution envelopes.
+9. Prove one websocket stream owner and full symbol/cursor continuity at market open.
+10. Repair CNPG query/transaction/WAL behavior and add rehearsed HA.
+11. Only then refresh the candidate board and run capacity-aware research.
+12. Keep Hyperliquid disabled until timestamp, linkage, sample, and after-fee evidence passes independently.
+
+## Reproduction Commands
+
+Use an explicit namespace and read-only queries.
+
+```sh
+git fetch origin main
+git rev-parse HEAD
+git rev-parse origin/main
+
+kubectl -n argocd get application torghut \
+  -o jsonpath='{.status.sync.status}{"|"}{.status.health.status}{"|"}{.status.sync.revision}{"\n"}'
+
+kubectl -n torghut get pods -o wide
+kubectl -n torghut get clusters.postgresql.cnpg.io -o wide
+
+kubectl -n torghut exec <scheduler-pod> -- \
+  python -c 'import urllib.request; print(urllib.request.urlopen("http://127.0.0.1:8183/trading/status", timeout=30).read().decode())'
+
+kubectl -n torghut exec -i <scheduler-pod> -- python - <<'PY'
+import urllib.error
+import urllib.request
+
+request = urllib.request.Request("http://127.0.0.1:8183/readyz")
+try:
+    response = urllib.request.urlopen(request, timeout=30)
+except urllib.error.HTTPError as error:
+    print(error.code)
+    print(error.read().decode())
+else:
+    print(response.status)
+    print(response.read().decode())
+PY
+
+kubectl -n torghut exec <ws-pod> -- \
+  sh -lc 'wget -qO- http://127.0.0.1:8080/readyz'
+
+kubectl -n torghut logs <ws-pod> --since=30m --tail=200
+
+kubectl cnpg psql -n torghut torghut-db -- \
+  -d torghut -X -v ON_ERROR_STOP=1 -A -F '|' -P pager=off -c '<bounded SQL>'
+```
+
+### Buy-Only Execution Versus Flat Position SQL
+
+This fixed-window query reproduces the strongest accounting contradiction without printing account labels. It joins
+the July 10 execution account to the last position snapshot observed by the audit cutoff.
+
+```sql
+SET statement_timeout = '20s';
+
+WITH fills AS (
+  SELECT
+    alpaca_account_label,
+    count(*) FILTER (WHERE filled_qty > 0 AND side = 'buy') AS buy_rows,
+    count(*) FILTER (WHERE filled_qty > 0 AND side = 'sell') AS sell_rows,
+    max(created_at) AS latest_fill
+  FROM executions
+  WHERE created_at >= timestamptz '2026-07-10 00:00:00+00'
+    AND created_at < timestamptz '2026-07-11 00:00:00+00'
+  GROUP BY alpaca_account_label
+),
+ranked_snapshots AS (
+  SELECT
+    alpaca_account_label,
+    as_of,
+    created_at,
+    positions::jsonb AS positions,
+    row_number() OVER (
+      PARTITION BY alpaca_account_label
+      ORDER BY as_of DESC, created_at DESC, id DESC
+    ) AS row_number
+  FROM position_snapshots
+  WHERE as_of <= timestamptz '2026-07-14 06:06:33+00'
+    AND created_at <= timestamptz '2026-07-14 06:06:33+00'
+)
+SELECT
+  row_number() OVER (ORDER BY fills.alpaca_account_label) AS account_ordinal,
+  fills.buy_rows,
+  fills.sell_rows,
+  fills.latest_fill,
+  snapshots.as_of AS latest_snapshot_as_of,
+  CASE
+    WHEN snapshots.positions IN ('[]'::jsonb, '{}'::jsonb, 'null'::jsonb) THEN 0
+    ELSE jsonb_array_length(snapshots.positions)
+  END AS position_count
+FROM fills
+LEFT JOIN ranked_snapshots AS snapshots
+  ON snapshots.alpaca_account_label = fills.alpaca_account_label
+  AND snapshots.row_number = 1
+ORDER BY account_ordinal;
+```
+
+Observed result: one account, `819` buy rows, `0` sell rows, and `0` positions in its latest snapshot. The query proves a
+database-accounting contradiction, not what the broker independently held.
+
+### Lifecycle Coverage SQL
+
+The bounds below reproduce the audit snapshot. A fresh audit must choose and record a new cutoff rather than silently
+replace these bounds with `now()`.
+
+```sql
+SET statement_timeout = '20s';
+
+WITH bounds AS (
+  SELECT
+    timestamptz '2026-06-30 06:06:33+00' AS start_at,
+    timestamptz '2026-07-14 06:06:33+00' AS end_at
+),
+decision_cohort AS (
+  SELECT id
+  FROM trade_decisions, bounds
+  WHERE created_at >= bounds.start_at
+    AND created_at <= bounds.end_at
+    AND executed_at IS NOT NULL
+),
+decision_evidence AS (
+  SELECT
+    d.id,
+    EXISTS (
+      SELECT 1
+      FROM trade_decision_submission_claims c
+      WHERE c.trade_decision_id = d.id
+    ) AS has_claim,
+    EXISTS (
+      SELECT 1
+      FROM executions e
+      WHERE e.trade_decision_id = d.id
+    ) AS has_execution,
+    EXISTS (
+      SELECT 1
+      FROM executions e
+      WHERE e.trade_decision_id = d.id
+        AND e.filled_qty > 0
+    ) AS has_fill
+  FROM decision_cohort d
+),
+execution_evidence AS (
+  SELECT
+    e.id,
+    e.filled_qty > 0 AS has_fill,
+    EXISTS (
+      SELECT 1
+      FROM execution_order_events o
+      WHERE o.execution_id = e.id
+    ) AS has_order_event,
+    COALESCE(
+      e.execution_audit_json -> 'runtime_ledger_lineage',
+      e.execution_audit_json -> 'execution_tca_cost_lineage'
+    ) AS lineage
+  FROM executions e, bounds
+  WHERE e.created_at >= bounds.start_at
+    AND e.created_at <= bounds.end_at
+),
+filled_evidence AS (
+  SELECT
+    e.*,
+    EXISTS (
+      SELECT 1
+      FROM execution_tca_metrics t
+      WHERE t.execution_id = e.id
+    ) AS has_tca
+  FROM execution_evidence e
+  WHERE has_fill
+)
+SELECT 'claim' AS stage, count(*) FILTER (WHERE has_claim) AS numerator, count(*) AS denominator
+FROM decision_evidence
+UNION ALL
+SELECT 'execution', count(*) FILTER (WHERE has_execution), count(*) FROM decision_evidence
+UNION ALL
+SELECT 'fill', count(*) FILTER (WHERE has_fill), count(*) FROM decision_evidence
+UNION ALL
+SELECT 'tca', count(*) FILTER (WHERE has_tca), count(*) FROM filled_evidence
+UNION ALL
+SELECT 'explicit_cost', count(*) FILTER (WHERE lineage ->> 'explicit_cost_amount' IS NOT NULL), count(*)
+FROM filled_evidence
+UNION ALL
+SELECT 'source_backed', count(*) FILTER (WHERE (lineage ->> 'source_backed')::boolean IS TRUE), count(*)
+FROM filled_evidence
+UNION ALL
+SELECT 'order_event', count(*) FILTER (WHERE has_order_event), count(*) FROM execution_evidence
+UNION ALL
+SELECT 'filled_order_event', count(*) FILTER (WHERE has_order_event), count(*) FROM filled_evidence;
+```
+
+### Candidate Ledger SQL
+
+Both economic time and row-creation time are capped at the audit cutoff so later windows or backfills do not change the
+snapshot result.
+
+```sql
+SELECT
+  hypothesis_id || ' / ' || left(candidate_id, 8) AS candidate,
+  count(DISTINCT bucket_started_at::date) AS active_days,
+  sum(closed_trade_count) AS closed_trades,
+  round(sum(filled_notional), 2) AS filled_notional_usd,
+  round(sum(net_strategy_pnl_after_costs), 2) AS net_pnl_usd,
+  round(
+    10000 * sum(net_strategy_pnl_after_costs) / nullif(sum(filled_notional), 0),
+    2
+  ) AS net_bps,
+  min(bucket_started_at)::date AS first_day,
+  max(bucket_ended_at)::date AS last_day
+FROM strategy_runtime_ledger_buckets
+WHERE (
+    blockers_json::text IN ('[]', '{}', 'null')
+    OR blockers_json IS NULL
+  )
+  AND bucket_ended_at <= timestamptz '2026-07-14 06:06:33+00'
+  AND created_at <= timestamptz '2026-07-14 06:06:33+00'
+GROUP BY candidate_id, hypothesis_id
+ORDER BY net_bps DESC;
+```
+
+## Limitations
+
+- The final readback was pre-market. Market-open continuity was not observed.
+- Direct ClickHouse SQL was not executed because the audit did not inject credentials. TA evidence came from the
+  scheduler's ClickHouse-backed status and websocket logs.
+- Broker state was observed through Torghut runtime/database surfaces, not an independently authenticated broker pull.
+  Building that independent read is a primary design requirement.
+- PostgreSQL statistics were not treated as exact bloat measurements.
+- The candidate rows were too small and stale to support inference.
+- External research informed the normative design but cannot prove Torghut performance.
+
+These limitations strengthen the fail-closed conclusion; none provides a basis to widen capital.

--- a/docs/torghut/profitability/implementation-roadmap.md
+++ b/docs/torghut/profitability/implementation-roadmap.md
@@ -210,9 +210,11 @@ rather than silently excluded.
 **Invariant:** protocol health and journal writes are not accepted as proof of economic parity.
 
 - Deliverable: reconcile the full broker-derived economic projection against TigerBeetle balances/transfers, publish
-  source watermark and age, and make freshness plus zero unexplained settled delta a blocking readiness dependency.
+  source watermark and age, and make freshness plus zero unexplained settled delta blocking dependencies for
+  `entry_allowed`, accounting authority, and promotion. They must not make `service_healthy` or Kubernetes readiness
+  false while the control/recovery endpoint can still serve safely.
 - Primary surfaces: `services/torghut/scripts/audit_tigerbeetle_runtime_ledger_parity.py`, verification scripts,
-  `argocd/applications/torghut/tigerbeetle-smoke-job.yaml`, scheduler readiness, and GitOps schedules.
+  `argocd/applications/torghut/tigerbeetle-smoke-job.yaml`, scheduler entry/status projections, and GitOps schedules.
 - Tests: missing transfers, duplicate transfers, stale watermark, source lag, correction events, and protocol-up/parity-
   down behavior.
 - Runtime proof: scheduled parity completes from the broker event watermark through both ledgers and fails closed when a

--- a/docs/torghut/profitability/implementation-roadmap.md
+++ b/docs/torghut/profitability/implementation-roadmap.md
@@ -1,0 +1,423 @@
+# Torghut Profitability Implementation Roadmap
+
+Status: ordered implementation handoff.
+
+Source baseline: `9f6487ada0cf9222b65cbb1ee9b10d50a09b216e`.
+
+This roadmap converts the [adversarial system design](adversarial-profitability-system-design.md) and
+[research and promotion design](research-validation-and-promotion-design.md) into independently reviewable,
+PR-sized changes. The [audit snapshot](current-audit-snapshot-2026-07-14.md) is evidence for the ordering, not a
+substitute for fresh runtime readback.
+
+## Delivery Contract
+
+Each slice has one principal invariant and must remain narrow enough to review, revert, and prove independently. A
+slice is not complete when code or schema merely exists. Completion requires, in order:
+
+1. the behavior is reachable from the production entry point;
+2. regression, property, and fault-injection tests cover its failure boundaries;
+3. required CI passes on the committed revision;
+4. CI publishes an immutable image identity;
+5. GitOps promotes that identity and Argo reports the expected revision;
+6. a controlled runtime exercise reaches the new path;
+7. capability-specific independent evidence proves the intended state transition: broker/capital reconciliation,
+   immutable trial/replay reproduction, preserved storage hashes plus restore/failover, or the declared operational
+   fault/SLO recovery;
+8. the proof bundle records commands, timestamps, revisions, digests, and unresolved deltas.
+
+The implementation must not increase capital authority merely because a slice ships. Capital stage changes are
+separate, explicit decisions governed by the promotion ladder.
+
+## Global Safety Posture
+
+- Keep all live and candidate evidence-collecting risk-increasing submission disabled until Phase 0 exits. P0 broker
+  fault exercises may use only an explicit, short-lived `InfrastructureValidationPermit` bound to a dedicated
+  paper/sandbox account and tagged as non-promotable.
+- Preserve reduce-only cancel, closeout, and emergency liquidation paths during every containment state.
+- Keep Hyperliquid testnet-only until its identifiers, timestamps, and economic ledger reconcile independently.
+- Do not infer capital stage from strategy IDs, deployment names, account names, namespaces, or environment variables.
+- Do not repair historical data by overwriting evidence. Append corrections and retain original payload hashes.
+- Roll back application behavior through GitOps. Never roll back a database migration by deleting economic evidence.
+- Stop a rollout on any unexplained broker-versus-ledger settled delta, stale proof dependency, or loss of mutation
+  fencing.
+
+## Phase And Gate Summary
+
+| Phase                                      | Slices | Capital posture                                    | Exit gate                                                                                                                                          |
+| ------------------------------------------ | ------ | -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| P0: Contain and make truth observable      | 1-10   | Risk-increasing submission blocked                 | Durable mutation fencing, independent broker reducer, repaired lifecycle linkage, and fresh zero-unexplained-delta reconciliation                  |
+| P1: Make research and runtime comparable   | 11-16  | Replay/shadow only; paper remains separately gated | HA evidence store, one economic policy and envelope, immutable point-in-time receipts, registered trials, and a selection-adjusted candidate board |
+| P2: Prove execution and portfolio behavior | 17-18  | Shadow, then bounded paper only                    | Causal execution-policy evidence and portfolio allocator stress proof                                                                              |
+| P3: Earn and ratchet capital               | 19-20  | Paper probation, then explicit micro-live grants   | Full-session paper evidence, reconciled micro-live economics, automatic demotion, and champion/challenger governance                               |
+
+Effort classes below are planning estimates, not deadlines: `S` is a small focused PR, `M` spans a subsystem boundary,
+and `L` requires coordinated schema/runtime/proof work. Market-session requirements are stated separately because wall
+clock time cannot be compressed safely.
+
+## P0: Contain And Make Economic Truth Observable
+
+### Slice 1 - Freeze Capital And Publish A Safety Baseline
+
+**Invariant:** no strategy can increase exposure while the audited proof chain is incomplete; reduce-only exits remain
+available.
+
+- Deliverable: make the current capital freeze explicit in GitOps and expose one typed reducer with separate
+  `service_healthy`, `entry_allowed`, `reduce_only_allowed`, and `recovery_degraded` projections, including reason,
+  effective policy revision, and timestamp through trading status. Define the infrastructure-validation permit schema,
+  hard-bind it away from live accounts, and exclude its events from all candidate evidence.
+- Primary surfaces: `argocd/applications/torghut/**`, `services/torghut/app/trading/**`, readiness/status tests, and the
+  operator runbook.
+- Tests: policy parsing, fail-closed entry behavior for missing or malformed authority, validation-permit attempts
+  against live accounts or promotion evidence, and regressions proving an entry blocker neither removes a healthy
+  control endpoint from Kubernetes service nor disables provable reduce-only closeout.
+- Runtime proof: direct scheduler status and readiness, workload environment/config digest, rejected risk-increasing
+  order, and accepted controlled reduce-only request without broker mutation when no position exists.
+- Dependency: none. Effort: `S`.
+- Rollback: revert the status/UI addition only; never restore risk-increasing submission as a rollback.
+
+### Slice 2 - Add Typed `StrategyCapitalAuthority`
+
+**Invariant:** strategy-scoped capital authority is explicit, typed, versioned, and enforced before risk-increasing
+broker I/O.
+
+- Deliverable: add the one canonical enum (`disabled`, `quarantined`, `research_only`, `replay_verified`,
+  `shadow_allowed`, `paper_probation`, `paper_verified`, `micro_live_allowed`, `capital_allowed`, `scaled`) plus account,
+  venue, notional, gross, net, order-rate, symbol, session, expiry, and reduce-only constraints. Map legacy
+  `EvidenceEpochDecision` values conservatively and reissue legacy canary/live/scale decisions only when every new
+  field and approval exists.
+- Primary surfaces: `services/torghut/app/strategies/catalog.py`, `services/torghut/app/trading/evidence_epochs.py`,
+  promotion/proof-floor/submission-council issuers and consumers, strategy schema/loaders, global live flags, trading
+  policy evaluation, status payloads, and `argocd/applications/torghut/strategy-configmap.yaml`.
+- Tests: complete caller inventory, one-to-one legacy mapping, unknown/partial states quarantined, schema compatibility,
+  deny-by-default, expired grants, per-strategy isolation, and property tests that neither a legacy global flag nor a
+  request outside any bound can reach the broker adapter.
+- Runtime proof: two concurrently enabled strategies with different stages cannot inherit or cross-use one another's
+  authority; status reports the exact authority digest.
+- Dependency: slice 1. Effort: `M`.
+- Rollback: retain the schema and set every strategy to `disabled`; do not restore a parallel legacy or name-derived
+  authority.
+
+### Slice 3 - Fix Autoresearch Completion Semantics
+
+**Invariant:** a discarded, invalid, or unproved candidate can never satisfy the research objective or stop the search.
+
+- Deliverable: compute objective satisfaction only after terminal candidate validation and persist the reason for every
+  continuation or stop decision.
+- Primary surfaces: `services/torghut/scripts/strategy_autoresearch_loop/run_strategy_autoresearch_loop.py`, its modular
+  package, result writers, and focused tests.
+- Tests: discarded candidate above the raw objective, valid candidate below it, valid candidate above it, interrupted
+  runs, duplicate candidate identities, and deterministic resume.
+- Runtime proof: a bounded replay containing an intentionally high-scoring discarded candidate continues and records a
+  non-objective terminal state.
+- Dependency: none; may proceed in parallel with slice 2. Effort: `S`.
+- Rollback: disable automated stopping and require an explicit operator-selected terminal trial.
+
+### Slice 4 - Wire Durable Claims And Receipts Into Submit
+
+**Invariant:** every production order submission has a durable intent claim before the first broker mutation and a
+receipt or unresolved state afterward.
+
+- Deliverable: route all production submit entry points through one mutation coordinator using deterministic idempotency
+  keys and transactional claim state.
+- Primary surfaces: broker adapters and order-routing entry points under `services/torghut/app/**`, claim migrations,
+  `services/torghut/tests/test_broker_mutation_receipts_unwired.py`, and readiness metrics.
+- Tests: process death before claim, after claim, during broker timeout, after broker acceptance, and before receipt
+  persistence; duplicate request and concurrent-leader property tests.
+- Runtime proof: fault-injected submissions under a short-lived `InfrastructureValidationPermit` produce one dedicated
+  paper/sandbox order and one terminal claim, with zero unclaimed mutations, zero duplicated broker intents, and zero
+  rows admissible as candidate evidence.
+- Dependency: slice 2. Effort: `L`.
+- Rollback: block submit and preserve unresolved claims for reconciliation; never retry blindly or delete claims.
+
+### Slice 5 - Implement Strict Submit Recovery
+
+**Invariant:** an ambiguous submit resolves through broker observation before any retry.
+
+- Deliverable: add a recovery worker and state machine for `claimed`, `submitted_unknown`, `acknowledged`, `rejected`,
+  `expired`, and `manual_review`; use client order IDs and broker activity as evidence.
+- Primary surfaces: mutation coordinator, broker query/activity APIs, scheduler jobs, metrics, and operator actions.
+- Tests: lost response with accepted order, lost response with no order, delayed activity, conflicting broker IDs,
+  restart/re-election, and bounded recovery timeout.
+- Runtime proof: injected response loss recovers the original paper order without producing a second order.
+- Dependency: slice 4. Effort: `M`.
+- Rollback: stop recovery retries, retain unresolved claims, and require manual broker reconciliation.
+
+### Slice 6 - Fence Cancel, Replace, And Closeout Mutations
+
+**Invariant:** submit is not the only fenced mutation; every broker-side state change is claimed, receipted, and
+recoverable.
+
+- Deliverable: extend the coordinator to cancel, cancel-all, replace, multi-leg unwind, reduce-only closeout, and
+  emergency liquidation, including causal links to the original order. Add a per-action `RiskReductionPermit` derived
+  from broker-observed orders/positions that forbids new symbols, side flips, and any gross/net exposure increase; it
+  must remain issuable when candidate authority or profitability evidence is missing or expired.
+- Primary surfaces: all broker mutation adapters, closeout/kill-switch paths, claim schema, and emergency runbooks.
+- Tests: cancel/replace races with fills, partial-fill closeout, duplicate cancel, multi-leg partial failure, stale
+  candidate authority, stale profitability/reconciliation evidence, no-side-flip and no-increase properties, and broker
+  outage during emergency reduction.
+- Runtime proof: an infrastructure-validation paper/sandbox lifecycle exercises each mutation, reconciles a single
+  causal chain, and remains excluded from every promotion/trial query.
+- Dependency: slices 4-5. Effort: `L`.
+- Rollback: keep submit blocked; preserve the already-fenced reduce-only closeout path and disable replace.
+
+### Slice 7 - Ingest Immutable Broker Economic Activities
+
+**Invariant:** the broker, not an internal strategy loop, is the source of truth for executed economics.
+
+- Deliverable: ingest account activities and order updates through streaming plus paginated backfill, append raw payloads
+  with hashes, and normalize orders, fills, fees, cash movements, corrections, and corporate actions.
+- Primary surfaces: Alpaca broker client/worker code, CNPG migrations, event schemas, Kafka topics if retained, and
+  freshness/readiness metrics.
+- Tests: reconnect and cursor recovery, pagination boundaries, out-of-order and duplicate events, correction events,
+  split/dividend handling, and raw-payload immutability.
+- Runtime proof: stream interruption followed by backfill yields the same normalized event multiset and source hashes.
+- Dependency: may begin after slice 4; final integration depends on slice 6. Effort: `L`.
+- Rollback: stop projection consumers but retain raw append-only events and cursor state.
+
+### Slice 8 - Build An Independent Economic Ledger
+
+**Invariant:** profitability is reconstructed from broker economic events by a reducer independent of trading decisions
+and the existing runtime ledger.
+
+- Deliverable: deterministic double-entry projections for positions, cash, equity, realized/unrealized P&L, fees,
+  dividends, corrections, and corporate actions; retain both canonical and independent reducers.
+- Primary surfaces: new isolated ledger package, CNPG migrations/views, reconciliation API, and deterministic replay CLI.
+- Tests: golden broker fixtures, accounting identities, shuffled/duplicated events, partial fills, shorts, splits,
+  dividends, corrections, restart determinism, and reducer differential tests.
+- Runtime proof: two independently implemented projections converge to broker state from the same immutable activity
+  set, with an enumerated explanation for every unsettled difference.
+- Dependency: slice 7. Effort: `L`.
+- Rollback: mark projections invalid and rebuild from raw events; never mutate the source event store.
+
+### Slice 9 - Repair Order-Feed And Decision-Lineage Coverage
+
+**Invariant:** each order/fill is causally linked where possible, and all unlinked external/manual activity is explicit
+rather than silently excluded.
+
+- Deliverable: populate stable execution, order, decision, strategy, claim, and broker-event links; backfill append-only
+  repair receipts with confidence and provenance.
+- Primary surfaces: `services/torghut/scripts/reconcile_cross_dsn_order_feed_links.py`, lifecycle import SQL/package,
+  migrations, and coverage metrics.
+- Tests: one-to-many partial fills, legacy null IDs, ambiguous matches, manual orders, corrections, and non-destructive
+  repeatable backfill.
+- Runtime proof: fresh paper activity achieves complete claim/order/fill/event linkage; historical residuals are
+  classified, counted, and excluded from promotion when causal identity is unproved.
+- Dependency: slices 6-8. Effort: `M`.
+- Rollback: invalidate repair receipts by version; retain original rows and prior mappings.
+
+### Slice 10 - Require Fresh Full TigerBeetle Parity
+
+**Invariant:** protocol health and journal writes are not accepted as proof of economic parity.
+
+- Deliverable: reconcile the full broker-derived economic projection against TigerBeetle balances/transfers, publish
+  source watermark and age, and make freshness plus zero unexplained settled delta a blocking readiness dependency.
+- Primary surfaces: `services/torghut/scripts/audit_tigerbeetle_runtime_ledger_parity.py`, verification scripts,
+  `argocd/applications/torghut/tigerbeetle-smoke-job.yaml`, scheduler readiness, and GitOps schedules.
+- Tests: missing transfers, duplicate transfers, stale watermark, source lag, correction events, and protocol-up/parity-
+  down behavior.
+- Runtime proof: scheduled parity completes from the broker event watermark through both ledgers and fails closed when a
+  controlled discrepancy is introduced.
+- Dependency: slices 8-9. Effort: `M`.
+- Rollback: leave trading blocked and restore the last verified projection for inspection only, never for fresh proof.
+
+## P1: Make Research And Runtime Comparable
+
+### Slice 11 - Harden CNPG Evidence Storage And Recovery
+
+**Invariant:** the economic evidence store has measured recovery characteristics and no single untested database failure
+mode.
+
+- Deliverable: benchmark the heavy lifecycle/reconciliation queries, add justified indexes or projections, define CNPG
+  HA/backup/PITR objectives, and exercise restore into an isolated target.
+- Primary surfaces: Torghut migrations, query plans, CNPG GitOps, backup/restore configuration, and database runbooks.
+- Tests: migration graph, representative `EXPLAIN (ANALYZE, BUFFERS)`, replica/failover continuity, backup integrity,
+  and isolated point-in-time restore.
+- Runtime proof: recorded RPO/RTO exercise plus query latency and resource envelopes at current and projected volume.
+- Dependency: stable schemas from slices 7-10. Effort: `L`.
+- Rollback: revert performance settings/index use through a forward migration; preserve evidence and backups.
+
+### Slice 12 - Define One Versioned Economic Policy
+
+**Invariant:** replay, shadow, paper, and live use the same versioned session, sizing, fee, slippage, risk, and accounting
+policy rather than divergent defaults.
+
+- Deliverable: a typed `EconomicPolicy` artifact with immutable digest, including leverage, participation, sessions,
+  fees, borrow, latency, slippage, stale-data behavior, and risk limits.
+- Primary surfaces: strategy/runtime configuration, replay runners, broker adapters, promotion manifests, status, and
+  GitOps. Remove the research/live gross-exposure mismatch.
+- Tests: serialization compatibility, digest stability, default rejection, and cross-engine fixture parity.
+- Runtime proof: the same fixture and policy digest produce identical pre-broker intents in replay, shadow, and paper.
+- Dependency: slice 2. Effort: `M`.
+- Rollback: pin the prior policy digest with all capital disabled; do not reintroduce stage-specific hidden defaults.
+
+### Slice 13 - Persist Immutable Point-In-Time Data Receipts
+
+**Invariant:** every result names the exact causal market, corporate-action, universe, feature, and code inputs available
+at each decision time.
+
+- Deliverable: dataset and feature receipts with event-time/arrival-time boundaries, source watermarks, universe version,
+  adjustment policy, artifact hashes, and code/policy digests.
+- Primary surfaces: replay importers, feature pipelines, ClickHouse/CNPG metadata, artifact storage, and research reports.
+- Tests: look-ahead traps, late data, revised bars, delistings, corporate-action restatement, timezone/session edges, and
+  receipt hash reproducibility.
+- Runtime proof: an independent rerun from a receipt reproduces the exact input row set and feature matrix hash.
+- Dependency: slice 12. Effort: `L`.
+- Rollback: reject unreceipted trials; retain prior artifacts as non-promotable historical diagnostics.
+
+### Slice 14 - Unify Engine Semantics With An Envelope Digest
+
+**Invariant:** a candidate is not promoted when research and runtime transform the same signal differently.
+
+- Deliverable: one versioned order-intent/execution envelope or a differential conformance layer that covers signal
+  timing, session rules, rounding, sizing, costs, latency, order type, partial fills, and risk checks.
+- Primary surfaces: replay execution packages, trading runtime, TCA calculation, policy artifacts, and parity tooling.
+- Tests: golden event streams across replay/shadow/paper, randomized differential tests, and counterexamples for every
+  former divergence.
+- Runtime proof: envelope digests match for a controlled shadow/paper session and all differences are zero or explicitly
+  classified as venue observations.
+- Dependency: slices 12-13. Effort: `L`.
+- Rollback: demote candidates to replay and block promotion when envelope parity is unknown.
+
+### Slice 15 - Add A Registered Trial Ledger And Statistical Gates
+
+**Invariant:** selection history, failed trials, degrees of freedom, and untouched test sets cannot be erased from the
+promotion decision.
+
+- Deliverable: immutable hypothesis/trial registration, purged walk-forward folds, embargo, family-aware search counts,
+  Deflated Sharpe Ratio, probabilistic backtest-overfitting analysis, White Reality Check/Hansen SPA where applicable,
+  negative controls, and signed terminal reports.
+- Primary surfaces: autoresearch runner, candidate board, promotion validation, schemas, and reproducibility artifacts.
+- Tests: deterministic folds, purge/embargo leakage, duplicate trial identity, hidden failed-trial deletion, synthetic
+  null strategies, and known statistical fixtures.
+- Runtime proof: seeded null candidates fail at the expected rate and a complete trial can be reproduced from receipts.
+- Dependency: slices 3 and 13-14. Effort: `L`.
+- Rollback: freeze promotion and retain all registered trials; never delete unfavorable history.
+
+### Slice 16 - Rebuild The Candidate Board From Admissible Evidence
+
+**Invariant:** a candidate cannot rank on duplicated, stale, tiny-sample, unlinked, or non-runtime evidence.
+
+- Deliverable: regenerate the board using current ledger lineage, minimum sample/session requirements, selection-adjusted
+  statistics, after-cost capacity, tail risk, and an explicit admissibility state.
+- Primary surfaces: `services/torghut/scripts/whitepaper_autoresearch_runner/candidate_board_*`, profitability frontier
+  scripts, promotion manifests, and operator reporting.
+- Tests: duplicate ledger windows, overlapping samples, stale sources, below-minimum trades/days, missing costs, blocked
+  lineage, and deterministic ranking.
+- Runtime proof: the prior six tiny-sample blocker-free variants are either rejected with reasons or re-established on
+  new independent evidence; no historical aggregate is presented as deployable P&L.
+- Dependency: slices 8-10 and 13-15. Effort: `M`.
+- Rollback: publish no champion; retain the previous board as a clearly marked non-authoritative snapshot.
+
+## P2: Prove Execution And Portfolio Behavior
+
+### Slice 17 - Run A Causal Execution-Policy Experiment
+
+**Invariant:** execution changes are promoted on causal after-cost evidence, not aggregate correlation or simulated
+fill-rate alone.
+
+- Deliverable: randomized or matched shadow/paper comparison of order types, urgency, participation, and cancel/replace
+  policies; preregister primary TCA outcomes and safety guardrails.
+- Primary surfaces: execution router, TCA refresh pipeline, policy assignments, broker activity ledger, and experiment
+  report.
+- Tests: assignment determinism, no cross-arm leakage, arrival-price timing, censored orders, partial fills, fees, and
+  adverse-selection horizons.
+- Runtime proof: enough independent market sessions to estimate implementation shortfall and tails with confidence;
+  zero missing expected-shortfall or lineage fields.
+- Dependency: slices 7-10 and 12-16. Effort: `M` plus market sessions.
+- Rollback: restore the prior envelope digest and demote the experimental policy; retain assignments and outcomes.
+
+### Slice 18 - Implement Portfolio Risk Allocation And Capacity Limits
+
+**Invariant:** portfolio capital is allocated by after-cost edge, covariance, liquidity, and drawdown constraints; no
+strategy scales itself independently.
+
+- Deliverable: centralized allocator with gross/net, factor, sector, symbol, turnover, participation, concentration,
+  drawdown, volatility, correlation, and aggregate loss limits; conservative covariance shrinkage and stress scenarios.
+- Primary surfaces: risk engine, capital authority, sizing, status/metrics, promotion manifests, and kill switches.
+- Tests: correlated strategies, covariance singularity, liquidity shock, gap/volatility shock, stale inputs, allocator
+  restart, bound monotonicity, and reduce-only behavior during breach.
+- Runtime proof: shadow and paper portfolios respect every bound under recorded stress replay and live session movement;
+  broker-derived exposures equal allocator observations.
+- Dependency: slices 2, 10, 12, 16-17. Effort: `L`.
+- Rollback: zero new allocation, preserve reduce-only exits, and revert to explicit per-strategy caps below the last
+  proven aggregate envelope.
+
+## P3: Earn And Ratchet Capital
+
+### Slice 19 - Conduct Paper Probation
+
+**Invariant:** paper authority is earned by a named candidate and expires; it is not inherited by a family or deployment.
+
+- Deliverable: grant bounded `paper_probation` evidence-collection authority to one admissible champion and at least one
+  null/challenger control, with automatic expiry, demotion, and daily proof bundles. It is not final promotion authority.
+- Required entry: P0 and P1 complete; slices 17-18 pass; current market route healthy; fresh zero-delta reconciliation;
+  no unresolved submission claims; policy and envelope digests match.
+- Required observation: at least 20 source-backed trading days and 300 closed trades unless a stricter preregistered
+  family-specific gate applies; multiple regimes/sessions; complete TCA and broker lineage.
+- Exit proof: after-cost expectancy and tails pass preregistered selection-adjusted thresholds; drawdown, turnover,
+  capacity, and reconciliation guardrails remain within limits; null controls do not show the same result. A pass
+  creates `paper_verified`, not real-capital authority.
+- Primary surfaces: capital grants, promotion validator, scheduler status, daily report/proof artifacts, and runbook.
+- Dependency: slices 1-18. Effort: `M` plus the required market sessions.
+- Rollback: automatic authority expiry or immediate demotion to shadow; close risk reduce-only and retain the full bundle.
+
+### Slice 20 - Introduce Micro-Live Ratchets And Champion/Challenger Governance
+
+**Invariant:** live capital starts at a loss-tolerant amount, scales only on new reconciled evidence, and automatically
+shrinks faster than it grows.
+
+- Deliverable: explicit human-approved micro-live grants, loss budget, notional ceiling, daily/weekly ratchet rules,
+  champion/challenger allocation, shadow holdout, automatic demotion, and emergency revoke.
+- Required entry: slice 19 reaches `paper_verified`; broker/account permissions verified; independent ledger and
+  TigerBeetle parity fresh; recovery drill passes; no unresolved settled delta; SEC 15c3-5-style pre-trade controls and
+  kill paths evidenced.
+- Scale rule: each increase is a new experiment with a new authority version and expiry. Require stable after-cost edge,
+  unchanged envelope parity, adequate sample, acceptable market impact, and no tail or reconciliation breach.
+- Immediate demotion: unexplained economic delta, mutation-fencing loss, stale broker events, TCA lineage gap, limit
+  breach, policy mismatch, drawdown breach, or statistically material edge decay.
+- Runtime proof: broker-originated cash/position/P&L matches both ledgers; injected readiness and risk failures revoke
+  new orders while reduce-only closeout remains operable.
+- Dependency: slice 19 plus explicit capital-owner approval. Effort: `L` plus multiple market regimes.
+- Rollback: revoke the grant, stop risk-increasing orders, reduce exposure within the approved closeout policy, and
+  return the candidate to paper or shadow.
+
+## Cross-Cutting Proof Bundle
+
+Every slice that reaches the cluster must publish one immutable bundle containing the applicable fields below. Mark a
+field `not_applicable` with a reason when the slice does not touch that authority; never manufacture a broker event for
+a research-only change.
+
+- repository commit, CI run, image digest, GitOps commit, Argo application revision, and pod image IDs;
+- configuration, capital-authority, economic-policy, strategy, dataset, feature, and execution-envelope digests;
+- exact test and fault-injection commands with outcomes;
+- controlled runtime request IDs and mutation claims/receipts;
+- broker activity cursor/watermark and raw-event hash range;
+- canonical ledger, independent ledger, broker, and TigerBeetle reconciliation summaries;
+- TCA completeness, order/fill/decision lineage coverage, and all residual rows with classifications;
+- entry gate, exit gate, approver for any capital change, expiry, rollback trigger, and rollback evidence;
+- known limitations and an explicit statement of which claims the bundle does **not** establish.
+
+Proof bundles are append-only. A later successful bundle does not erase an earlier failure or unresolved delta.
+
+## Program-Level Acceptance Criteria
+
+The roadmap is complete only when all of the following are true on fresh evidence:
+
+- every production broker mutation is fenced and recoverable, with no reachable bypass;
+- broker economic events reconstruct cash, positions, equity, fees, and P&L through two independent reducers;
+- broker, both reducers, and TigerBeetle have zero unexplained settled delta at a fresh watermark;
+- every promotion result is point-in-time, reproducible, trial-registered, selection-adjusted, after-cost, and
+  capacity-constrained;
+- replay, shadow, paper, and live share one policy and execution envelope or have zero unexplained differential;
+- capital authority is strategy-scoped, bounded, versioned, expiring, observable, and enforced before risk-increasing
+  broker I/O;
+- stale or missing economic evidence blocks risk increase but does not prevent reduce-only risk removal;
+- paper and micro-live results survive preregistered minimum samples and market regimes without relying on duplicated
+  windows or the same data used for selection;
+- scaling, demotion, kill, recovery, database failover, and evidence restore have all been exercised rather than merely
+  documented;
+- an independent reviewer can reproduce the promotion decision from the proof bundle without trusting a dashboard or a
+  self-reported strategy aggregate.
+
+Until these criteria pass, Torghut may be a useful research and execution platform, but it must not represent itself as
+a proven profitable production trading system.

--- a/docs/torghut/profitability/research-validation-and-promotion-design.md
+++ b/docs/torghut/profitability/research-validation-and-promotion-design.md
@@ -1,0 +1,489 @@
+# Torghut Research Validation And Promotion Design
+
+Status: Proposed normative research and capital-promotion contract.
+
+Source baseline: `9f6487ada0cf9222b65cbb1ee9b10d50a09b216e`.
+
+Observed evidence: [current audit snapshot](current-audit-snapshot-2026-07-14.md).
+
+System boundary: [adversarial profitability system design](adversarial-profitability-system-design.md).
+
+## Purpose
+
+This document defines how Torghut may discover, reject, validate, promote, size, monitor, and demote trading strategies.
+It is intentionally stricter than a backtest-ranking workflow because selection, data, execution, accounting, capacity,
+and live behavior can each erase an apparent edge.
+
+The contract applies to US-equity strategy research first. Hyperliquid remains a separate testnet research system with
+its own evidence, accounting, and capital authority.
+
+## Objective Function
+
+The system optimizes sustainable after-cost return under explicit risk and capacity constraints:
+
+```text
+net PnL
+= filled notional
+ x (gross alpha - spread - fees - slippage - impact - borrow/interest/tax)
+ / 10,000
+```
+
+```text
+capacity-adjusted net expectancy (bps)
+= 10,000 x broker-reconciled net PnL / filled notional
+```
+
+```text
+target-implied daily notional
+= dollar target x 10,000 / conservative net-expectancy lower bound (bps)
+```
+
+The primary optimization is the lower confidence bound of capacity-adjusted net expectancy subject to portfolio
+drawdown, expected shortfall, concentration, liquidity, operational, and reconciliation constraints. Dollar PnL is a
+derived business result, not a shortcut around those constraints.
+
+### `$500/day` Is A Capacity Hypothesis
+
+The current repository target is useful for feasibility analysis but must not be reported as an expected return. At
+the audit-time equity it implied about `1.21%` NAV per active day. At `$300,000` daily filled notional it requires
+`16.67` net basis points before uncertainty. The best tiny historical row in the audit had `16.42 bps` on eight closed
+trades, leaving no statistical, cost, impact, or capacity margin.
+
+The target passes only if:
+
+- broker-reconciled net-expectancy lower bounds remain positive at target-implied notional;
+- nonlinear impact, participation, queue, missed-fill, borrow, concentration, and margin constraints allow that
+  notional;
+- return and loss expressed as `%NAV`, drawdown, and expected shortfall remain within approved budgets;
+- paper and micro-live results remain inside the replay predictive envelope.
+
+Otherwise the target is infeasible at the current capital, strategy, or capacity and must not be reached by increasing
+leverage.
+
+## Metric Dictionary
+
+### North-Star Outcomes
+
+| Metric                                   | Definition                                                                                           | Decision use                          |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| Broker-reconciled net PnL per active day | Realized plus marked unrealized strategy PnL less actual economic costs; exclude external cash flows | Business outcome and capital increase |
+| Net return on cash-flow-adjusted NAV     | Broker-reconciled net PnL divided by NAV adjusted for deposits/withdrawals                           | Cross-capital comparability           |
+| Capacity-adjusted net expectancy         | Net PnL in bps of filled notional at the tested participation                                        | Candidate comparison and sizing       |
+| Drawdown                                 | Cash-flow-adjusted peak-to-trough NAV and sleeve equity                                              | Hard stop and demotion                |
+| Expected shortfall                       | Mean loss beyond the approved portfolio tail quantile                                                | Tail-risk budget                      |
+
+No single metric authorizes capital. The decision uses the joint statistical, economic, risk, data, and operational
+contract.
+
+### Evidence And Integrity Guardrails
+
+| Metric                         | Exact contract                                                                         | Required state                                  |
+| ------------------------------ | -------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| Broker reconciliation coverage | Settled mandatory economic events reconciled / settled mandatory events                | `100%`, unexplained settled delta `0`           |
+| Mutation lifecycle coverage    | Decision -> authority -> claim -> receipt -> broker event -> execution -> fill linkage | `100%`, duplicate economic intents `0`          |
+| Point-in-time feature coverage | Causally available family-required field x symbol x session cells / required cells     | `100%`; fallback explicitly allowed and bounded |
+| Cursor continuity              | Monotonic provider/Kafka/database positions with duplicate/gap accounting              | Gaps `0` or repaired before evidence use        |
+| Cost-lineage coverage          | Fills with actual fee/cost identity, model digest, filled notional, and source lineage | `100%` for promoted evidence                    |
+| Closed-round-trip coverage     | Attributed exits and open inventory explain every fill                                 | `100%`                                          |
+| Envelope parity                | Replay/shadow/paper/live rows with identical envelope digest                           | `100%`                                          |
+| Independent-ledger parity      | Canonical and independent reducers matching broker positions, cash, equity and PnL     | Exact within currency/rounding contract         |
+
+### Research Diagnostics
+
+- active and positive day ratios;
+- profit factor and payoff ratio;
+- hit rate with trade count and confidence interval;
+- mean, median, p10, worst-day, best-day-share, and serial dependence of daily net PnL;
+- Sharpe, Sortino, Calmar, drawdown duration, expected shortfall, skew, and tail concentration;
+- deflated Sharpe probability, probability of backtest overfitting, White Reality Check, and Hansen SPA;
+- performance by regime, volatility, liquidity, symbol, sector, time of day, weekday, long/short side, and market trend;
+- turnover, holding period, side flips, fill rate, rejection rate, cancel rate, and unfilled opportunity cost;
+- implementation shortfall, spread capture, fees, impact, and 1s/10s/60s markouts;
+- sensitivity to delay, depth, queue depletion, participation, borrow, and cost shocks;
+- contribution to portfolio return, drawdown, expected shortfall, factors, and correlated clusters.
+
+Each metric declares formula, unit, grain, time window, denominator, source, material exclusions, and whether it is a
+gate, diagnostic, or business target.
+
+## Research Data Contract
+
+### Point-In-Time Requirements
+
+Every research row must prove what was available at the decision timestamp. Store separately:
+
+- exchange/provider event time;
+- provider publication/source time;
+- Torghut ingest time;
+- feature availability time;
+- decision time;
+- order-arrival and broker-event time.
+
+Reject negative feature age, future timestamps, late corrections treated as contemporaneous knowledge, or corporate
+actions unavailable at the historical decision time.
+
+### Dataset Receipt
+
+Every frozen dataset includes:
+
+- dataset ID and content digest;
+- source/feed identity and entitlement class;
+- symbol universe and membership history;
+- exchange calendar, timezone, session, and bar/event construction rules;
+- raw/adjusted prices and corporate-action version;
+- delisting, symbol-change, split, dividend, borrow, shortability, and survivor handling;
+- field schema, unit, null, stale, duplicate, outlier, and repair policy;
+- event/source/ingest time coverage;
+- cursor/offset bounds and gap report;
+- source retention reference and expiry.
+
+For US equities, preserve whether the source is SIP or IEX. Alpaca describes SIP as consolidated US-exchange data and
+IEX as a single-exchange feed in its [market-data FAQ](https://docs.alpaca.markets/us/docs/market-data-faq). Feed
+identity is part of the model, not incidental metadata.
+
+### Feature Receipt
+
+Every candidate declares family-required fields. The receipt records coverage, freshness, source lineage, fallback,
+proxy, and transformation by field x symbol x session. Required-field absence invalidates the run. Optional features
+may fall back only when the family contract specifies the fallback and the research contains an explicit ablation.
+
+No feature may be considered available merely because its name exists in the schema.
+
+## Hypothesis And Trial Registry
+
+Before evaluation, register:
+
+- falsifiable economic hypothesis and expected mechanism;
+- target universe, horizon, side, rebalance frequency, and capacity expectation;
+- required data and features;
+- baseline and negative-control strategies;
+- primary metric and risk/capacity guardrails;
+- train, validation, walk-forward, embargo, and untouched OOS plan;
+- allowed parameter search space and maximum trial budget;
+- expected failure modes and rejection conditions.
+
+Every attempted variant is append-only, including parse failures, zero-trade runs, discarded candidates, retries, and
+operator overrides. Record candidate/spec ID, parent, code/config/data/policy/envelope digests, random seed, parameters,
+start/end time, status, metrics, blockers, and artifact references.
+
+A discarded candidate cannot set run-level `objective_met`. A run stops only when a retained candidate or portfolio
+passes the full configured gate and is eligible for the next authority stage.
+
+## Evaluation Protocol
+
+### Stage 1: Causal Sanity And Baselines
+
+Before tuning:
+
+- validate timestamp ordering, adjustment, universe, and feature receipts;
+- compare against flat, long-only/market, random-entry, time-shifted, sign-flipped, and simple linear/rule baselines;
+- run shuffled-label/block-permutation placebos that preserve relevant dependence;
+- require the known-bad and future-leaking canaries to fail.
+
+### Stage 2: Purged Walk-Forward Selection
+
+Use chronological walk-forward folds with purge and embargo sized to the label horizon and holding period. Parameter
+selection occurs inside each training window; validation and test windows cannot feed feature, parameter, universe, or
+stopping decisions backward.
+
+Use enough folds and observations to cover the intended regimes. The proposed initial policy requires at least five
+walk-forward folds, but the final count is a versioned function of data horizon, dependence, and strategy frequency.
+
+### Stage 3: Multiple-Testing Control
+
+Naive best Sharpe is not a gate. The trial registry supplies the search count and dependence needed for:
+
+- Deflated Sharpe Ratio, following Bailey and Lopez de Prado's
+  [selection-aware Sharpe framework](https://www.davidhbailey.com/dhbpapers/deflated-sharpe.pdf);
+- White's [Reality Check](https://onlinelibrary.wiley.com/doi/10.1111/1468-0262.00152);
+- Hansen's [Superior Predictive Ability test](https://www.tandfonline.com/doi/abs/10.1198/073500105000000063);
+- probability-of-backtest-overfitting diagnostics and Sharpe/profit haircuts informed by
+  [Harvey and Liu's backtesting work](https://people.duke.edu/~charvey/backtesting/).
+
+Provisional research defaults are:
+
+- Deflated Sharpe probability at least `0.95`;
+- probability of backtest overfitting at most `0.10`;
+- White Reality Check or Hansen SPA `p <= 0.05` for the declared trial family.
+
+These are policy defaults, not universal constants. Calibrate bootstrap/block length, dependence, trial family, and
+sample sufficiency before implementation. Failure keeps the candidate research-only.
+
+### Stage 4: Untouched Out-Of-Sample Release
+
+Evaluate one frozen candidate/portfolio once on the untouched OOS interval after selection is complete. Opening the OOS
+result consumes it. Further changes require a new future OOS interval and a new evidence epoch.
+
+### Stage 5: Economic And Capacity Stress
+
+Recompute from exact order/fill mechanics under:
+
+- actual broker fees and observed spread/slippage distributions;
+- `2x` observed variable-cost stress as an initial minimum;
+- nonlinear impact and multiple participation rates;
+- latency, delay, stale quote, queue position/depletion, partial fill, cancel, and missed-fill opportunity cost;
+- shortability, borrow, buying power, cash reserve, rounding, and market-session rules;
+- order-type and passive/marketable ablations;
+- concentration, correlation, factor, and portfolio stress;
+- block/bootstrap uncertainty around the after-cost estimate.
+
+The net-expectancy `95%` lower bound must remain positive at the target-implied notional. The capacity curve must show
+where marginal after-cost PnL turns nonpositive; that point caps capital even if account buying power is larger.
+
+### Stage 6: Runtime Parity
+
+Run the same code/config/data/policy/execution envelope through deterministic warm reruns, live shadow, paper, and
+micro-live. Any digest mismatch or unexplained decision/fill difference invalidates the comparison.
+
+## Execution And TCA Methodology
+
+Every fill records:
+
+- strategy decision and arrival price;
+- bid, ask, mid, spread, quote age, and available depth at the decision;
+- order route/type/time in force, limit, attempt, latency, participation, and queue assumptions;
+- fill price, quantity, partial-fill sequence, fees, modeled/actual costs, and cancellation result;
+- side-adjusted implementation shortfall;
+- 1s, 10s, and 60s post-fill markouts;
+- predicted p50/p95 shortfall and realized calibration error;
+- missed-fill counterfactual/opportunity cost when an order does not execute.
+
+TCA compares complete policies, not individual favorable fills. The initial experiment keeps the current conservative
+one-attempt policy as control and evaluates bounded passive/aggressive schedules only after prediction coverage is
+complete. Optimize net implementation shortfall plus missed opportunity, not fill rate.
+
+Execution models follow the principle used by LEAN's
+[reality-modeling contracts](https://www.quantconnect.com/docs/v2/writing-algorithms/reality-modeling/key-concepts):
+fills, slippage, fees, buying power, and capacity are explicit versioned inputs. Torghut may implement those contracts
+itself; adopting a framework is not required.
+
+For larger orders, calibrate the risk/impact tradeoff rather than assuming linear cost, consistent with the
+[Almgren-Chriss execution framework](https://www.smallake.kr/wp-content/uploads/2016/03/optliq.pdf). Queue/depth models
+must be fitted to source-backed live observations before they can influence capital.
+
+## Portfolio Construction And Risk
+
+Candidate promotion and portfolio allocation are separate decisions. A statistically valid sleeve may receive zero
+capital when it duplicates existing risk.
+
+The allocator uses:
+
+- volatility targeting with explicit estimation horizon and bounds;
+- robust/shrunk covariance and factor exposure estimates;
+- gross, net, beta, sector, factor, symbol, cluster, and correlated-sleeve limits;
+- expected shortfall, drawdown, stress loss, and liquidity-adjusted risk;
+- pending and unknown broker mutations plus reserved multi-leg exposure;
+- turnover, borrow, ADV/participation, concentration, and cash reserve;
+- marginal after-cost PnL and marginal contribution to tail risk.
+
+The current semiconductor universe is one correlated cluster until evidence supports otherwise. Diversification claims
+must be measured through factor and tail co-movement, not symbol count.
+
+Volatility management is a research hypothesis, not an automatic improvement; test it against the evidence described
+by [Moreira and Muir](https://onlinelibrary.wiley.com/doi/abs/10.1111/jofi.12513). Covariance estimation may use
+shrinkage approaches such as
+[Ledoit-Wolf](https://econ-papers.upf.edu/en/onepaper.php?id=691), with all parameters frozen in the envelope.
+Fractional Kelly is not allowed until probabilities and costs are independently calibrated, and then remains capped by
+the harder portfolio constraints.
+
+## Strategy Research Queue
+
+### 1. Residual Pairs And Statistical Arbitrage
+
+Priority: first controlled challenger because the audit's only small positive clean rows were `H-PAIRS-01` variants.
+
+Required design:
+
+- diversify beyond one semiconductor cluster after data quality is proven;
+- remove market, sector, beta, and common-factor returns before relationship testing;
+- test rolling relationship/cointegration stability and break detection;
+- model both legs, partial fills, legging risk, borrow, targeted unwind, and capacity;
+- compare against simple distance/cointegration baselines such as the original
+  [pairs-trading evidence](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=141615).
+
+The historical 1-8 trade samples are motivation only.
+
+### 2. Intraday Cross-Sectional Continuation And Reversal
+
+Use causal spread, volatility, liquidity, relative return, quote validity, and order-flow features to determine when the
+current chip-universe signals are executable. Evaluate continuation and reversal as competing hypotheses, with
+time-of-day, opening/closing auction, sector, and market-regime controls.
+
+### 3. Time-Series Momentum
+
+Keep TSMOM as a diversification and control sleeve rather than the lead candidate while current clean rows are
+negative. Reproduce the mechanism in
+[Time Series Momentum](https://pages.stern.nyu.edu/~lpederse/papers/TimeSeriesMomentum.pdf), then explicitly test the
+reversal and crash behavior documented in
+[Momentum Crashes](https://www.kentdaniel.net/papers/published/jfe_16.pdf). Regime filters must be selected inside the
+trial protocol, not added after observing OOS losses.
+
+### 4. Order-Flow Imbalance And Microprice
+
+Start as execution and timing features. The empirical relationship between order-flow imbalance and price impact is
+described by [Cont, Kukanov, and Stoikov](https://arxiv.org/abs/1011.6402), but Torghut must prove causal L1/L2 coverage,
+latency, queue semantics, and net live benefit. Schema names or proxy features are not sufficient.
+
+### 5. Events And Options
+
+Defer capital research until corporate actions, news/event availability time, OPRA/options-surface quality, borrow,
+multi-leg execution, and assignment/exercise accounting are production-grade. They may run zero-notional data-quality
+and replay studies earlier.
+
+### 6. ML, Foundation Models, Synthetic Data, And RL
+
+Allowed roles:
+
+- hypothesis and feature proposal;
+- bounded candidate ranking;
+- residual/nonlinear challenger against simple baselines;
+- synthetic rare-event and microstructure stress generation;
+- explanation and incident summarization.
+
+Forbidden roles:
+
+- selecting or modifying untouched OOS after viewing it;
+- generating synthetic outcomes used as source-backed profit evidence;
+- bypassing causal feature receipts or the trial budget;
+- granting, widening, or overriding capital authority;
+- submitting broker mutations outside deterministic policy.
+
+A model artifact must beat declared simple baselines on untouched OOS and broker-calibrated costs. Interpretability,
+stability, latency, calibration, and failure behavior are part of the gate.
+
+## Strategy-Scoped Promotion Ladder
+
+This ladder must extend the existing promotion authority rather than coexist as a permissive second authority.
+
+| Stage                | Capital                        | Entry evidence                                                                                           | Failure action                  |
+| -------------------- | ------------------------------ | -------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| `disabled`           | None                           | Explicit containment or no authority                                                                     | Remain disabled                 |
+| `quarantined`        | None                           | Any blocking or unknown legacy state                                                                     | Resolve evidence; never infer   |
+| `research_only`      | `$0`                           | Pre-registered hypothesis, causal data receipt, complete trial entry                                     | Reject run or continue research |
+| `replay_verified`    | `$0`                           | Purged walk-forward, multiple-testing gates, untouched OOS, positive stressed net-expectancy lower bound | Remain research-only            |
+| `shadow_allowed`     | `$0`                           | Exact live source path and envelope, complete decision lineage, no broker mutation                       | Automatic demotion              |
+| `paper_probation`    | Bounded paper evidence only    | Paper entry gate below; explicit expiry/notional; no real-capital or final promotion authority           | Expire or demote                |
+| `paper_verified`     | Paper only                     | Probation exit: at least 20 source-backed sessions, 300 closed trades, exact ledger/TCA/reconciliation   | Extend probation or demote      |
+| `micro_live_allowed` | Smallest explicit tranche      | `paper_verified`, exact paper/live digest, rollback rehearsal, fresh mutation and reconciliation proof   | Stop entries, reduce-only close |
+| `capital_allowed`    | Approved sleeve budget         | Completed micro-live proof, positive live lower bound, capacity and portfolio risk pass                  | Step down automatically         |
+| `scaled`             | At most one approved increment | New completed proof window at current size; marginal after-cost PnL positive                             | Return to prior tranche         |
+
+Initial scaling increments may be capped at `25%`, but the policy must derive the actual increment from liquidity,
+uncertainty, drawdown, and tail-risk evidence. It is a provisional maximum, not a right to scale.
+
+### Paper Probation Entry Gate
+
+Preserve the distinction already expressed by
+`services/torghut/app/trading/discovery/promotion_contract.py::probation_evidence_collection_contract`: probation may
+collect bounded evidence but may not set final promotion authority. Entry requires:
+
+- `replay_verified` plus live shadow validation on the exact source, policy, code, data, and envelope identities;
+- selection-adjusted untouched-OOS and stressed capacity evidence sufficient to justify the paper experiment;
+- the architecture's mutation fencing, strict recovery, broker activity, dual-ledger, risk-reduction, and readiness
+  entry gate;
+- an explicit paper account, maximum notional/order rate, loss guardrail, expiry, candidate identity, and proof epoch;
+- automatic demotion on any causal-data, policy, lineage, mutation, reconciliation, or operational blocker.
+
+This is evidence-collection authority, not evidence that the candidate is profitable.
+
+### Paper Verification Exit Gate
+
+Align the exit with
+`services/torghut/app/trading/discovery/promotion_contract.py::final_authority_parameter_contract`:
+
+- at least 20 source-backed trading days;
+- at least 300 closed trades;
+- broker-reconciled mean/median/p10/worst-day distribution;
+- best-day and symbol/strategy concentration limits;
+- absolute and sleeve-equity drawdown limits;
+- target-implied filled-notional evidence;
+- exact policy, source, code, image, data, and envelope identity;
+- complete broker event, cost, TCA, ledger, and independent-reducer parity.
+
+The sample thresholds are operational minimums, not a guarantee of statistical power. Low-frequency strategies need a
+longer window. Passing creates `paper_verified`; it does not itself grant real capital.
+
+### Micro-Live Gate
+
+- use the smallest broker-executable tranche inside a separately approved loss budget;
+- require the same candidate, code, data rules, and execution envelope proven in paper;
+- validate actual fees, spread, slippage, markouts, fill survival, opportunity cost, and reconciliation;
+- inject source, accounting, risk, and performance failures and prove automatic demotion;
+- keep reduce-only exits available through every injected failure;
+- open a new evidence epoch for any code, policy, feature, universe, execution, or sizing change.
+
+### Scaling Gate
+
+Scale one tranche only after a complete live proof window at the current tranche. Require:
+
+- after-cost lower bound and marginal PnL still positive;
+- TCA prediction calibrated and within the replay/paper distribution;
+- no unresolved broker, ledger, data, database, or authority incident;
+- portfolio expected shortfall, drawdown, factor, cluster, and liquidity budgets passing;
+- nonlinear impact and participation evidence supporting the next size;
+- a rehearsed automatic return to the prior size.
+
+## Continuous Monitoring And Demotion
+
+Every promoted strategy is a champion with at least one simple or new challenger running at zero notional. Monitor:
+
+- rolling broker-reconciled net expectancy and confidence interval;
+- actual versus predicted TCA and markouts;
+- data/feature coverage, schema, fallback, and drift;
+- regime and portfolio factor exposure;
+- drawdown, expected shortfall, concentration, turnover, and capacity;
+- reconciliation freshness, unexplained deltas, and mutation unknowns;
+- code, image, policy, data, and envelope identity.
+
+Demote on a hard integrity failure immediately. Use versioned statistical rules for performance decay so optional
+stopping cannot become another unrecorded research degree of freedom.
+
+## Required Negative Controls
+
+- random-entry strategy with matched turnover and holding period;
+- flat/no-trade strategy;
+- market/sector beta benchmark;
+- time-shifted and future-leaking features that must be rejected;
+- sign-flipped and label/block-permuted outcomes;
+- deliberately high-turnover tiny-edge strategy that must fail after costs;
+- duplicate fill, correction, bust, and cursor-gap fixtures;
+- replay/live envelope mismatch;
+- missing required feature and unauthorized proxy;
+- stale/missing broker reconciliation;
+- discarded objective-hitting candidate;
+- readiness surface that claims green while its authority gate is false.
+
+The promotion implementation itself fails validation if these controls can pass.
+
+## Reproducibility And Reporting
+
+Every reported result includes:
+
+- hypothesis and trial-family identifiers;
+- complete attempted-variant count;
+- data, feature, code, image, policy, and envelope digests;
+- train/validation/walk-forward/OOS boundaries and release count;
+- gross and broker-reconciled after-cost results with formulas;
+- trade/day counts, confidence intervals, selection adjustments, and failure cases;
+- capacity curve, participation, impact, and liquidity assumptions;
+- regime, symbol, concentration, and tail-risk slices;
+- raw evidence references and exact reproduction command;
+- current authority stage and explicit blockers.
+
+Reports must distinguish observed facts, computed metrics, model estimates, policy thresholds, and recommendations. A
+chart or summary produced by the same candidate pipeline cannot promote the candidate.
+
+## Acceptance Criteria
+
+The research and promotion design is implemented when:
+
+- every trial, including discarded and failed variants, is preserved;
+- a discarded candidate cannot complete a run;
+- point-in-time poison and known-bad strategies reliably fail;
+- purged walk-forward, selection-adjusted, untouched OOS, cost, and capacity gates are reproducible;
+- `paper_probation` can begin without circularly requiring its future observations, and `paper_verified` contains at
+  least the current 20-session/300-trade minimum plus exact broker economics;
+- replay, shadow, paper, and live cite one execution-envelope digest;
+- only typed, unexpired strategy authority can increase risk;
+- micro-live and scale decisions use completed evidence windows and automatic rollback;
+- the canonical and independent ledgers match the broker with zero unexplained settled delta;
+- no AI-generated verdict, synthetic outcome, report, or local artifact can grant capital.


### PR DESCRIPTION
## Summary

- Add a time-stamped, read-only Torghut profitability audit grounded in current source, Git history, live cluster status, CNPG evidence, and reproducible fixed-window SQL.
- Define the adversarial production architecture for typed strategy capital authority, mutation fencing, fail-safe risk reduction, broker-economic ledgers, reconciliation, readiness, and proof bundles.
- Define selection-adjusted research/promotion gates and an ordered 20-slice implementation roadmap from containment through paper probation and micro-live capital ratchets.
- Link the current design pack from the Torghut documentation index and keep dated design-system material explicitly historical.

## Related Issues

None

## Testing

- `bunx oxfmt --check docs/torghut/README.md docs/torghut/profitability/*.md`
- `git diff --check`
- Local relative-Markdown-link existence check across `docs/torghut/profitability/*.md` (`all local Markdown links resolve`).
- `uv run --extra dev pytest -q tests/test_broker_mutation_receipts_unwired.py tests/test_promotion_truthfulness.py` from `services/torghut` (`12 passed`).
- Executed the audit's fixed-window buy/flat, lifecycle-coverage, and candidate-ledger SQL through `kubectl cnpg psql -n torghut torghut-db`; results reproduced `819/0/0`, all eight lifecycle ratios, and all six candidate rows.
- Three independent read-only reviews checked source assertions, design contradictions, links/tables/fences, roadmap dependencies, rollback paths, and release scope; all material findings were corrected and re-reviewed clear.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
