### PR TITLE
chore(jangar): promote image sha-51baa74469e3cf4ab04a823482a17dbc94bc5966

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-07-13T17:37:24Z
+    deploy.knative.dev/rollout: 2026-07-14T07:16:33Z
 spec:
   replicas: 1
   strategy:
@@ -57,9 +57,9 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: e86ccecb474f32e61436951b55cc75a450dd6e52
+              value: 51baa74469e3cf4ab04a823482a17dbc94bc5966
             - name: JANGAR_GITOPS_REVISION
-              value: e86ccecb474f32e61436951b55cc75a450dd6e52
+              value: 51baa74469e3cf4ab04a823482a17dbc94bc5966
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -355,15 +355,15 @@ spec:
             - name: ATLAS_CODE_SEARCH_HEALTH_SAMPLE_LIMIT
               value: "50"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "29270220010"
+              value: "29313232070"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:120832ffb578d6301ee4644186f2d2e46fb7db92cf6aed6613dfdf5e6f12fb40
+              value: sha256:6eff407ab80fb919febe77e2d25022102ccfc89fe8f23af92aa3d989979de4d3
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: e86ccecb474f32e61436951b55cc75a450dd6e52
+              value: 51baa74469e3cf4ab04a823482a17dbc94bc5966
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:120832ffb578d6301ee4644186f2d2e46fb7db92cf6aed6613dfdf5e6f12fb40
+              value: sha256:6eff407ab80fb919febe77e2d25022102ccfc89fe8f23af92aa3d989979de4d3
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -37,5 +37,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: sha-e86ccecb474f32e61436951b55cc75a450dd6e52
-    digest: sha256:120832ffb578d6301ee4644186f2d2e46fb7db92cf6aed6613dfdf5e6f12fb40
+    newTag: sha-51baa74469e3cf4ab04a823482a17dbc94bc5966
+    digest: sha256:6eff407ab80fb919febe77e2d25022102ccfc89fe8f23af92aa3d989979de4d3


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `51baa74469e3cf4ab04a823482a17dbc94bc5966`
- Image tag: `sha-51baa74469e3cf4ab04a823482a17dbc94bc5966`
- Image digest: `sha256:6eff407ab80fb919febe77e2d25022102ccfc89fe8f23af92aa3d989979de4d3`
- Source CI run: `29313232070`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates