### PR TITLE
fix(temporal): remove broken workflow runtime export

### DIFF
--- a/packages/temporal-bun-sdk/package.json
+++ b/packages/temporal-bun-sdk/package.json
@@ -58,10 +58,6 @@
       "types": "./dist/src/workflow/index.d.ts",
       "default": "./dist/src/workflow/index.js"
     },
-    "./workflow/runtime": {
-      "types": "./dist/src/workflow/runtime/index.d.ts",
-      "default": "./dist/src/workflow/runtime/index.js"
-    },
     "./worker": {
       "types": "./dist/src/worker.d.ts",
       "default": "./dist/src/worker.js"

--- a/packages/temporal-bun-sdk/tests/packaging/manifest-packaging.test.ts
+++ b/packages/temporal-bun-sdk/tests/packaging/manifest-packaging.test.ts
@@ -10,6 +10,7 @@ type TemporalSdkPackageJson = {
   files?: string[]
   scripts?: Record<string, string>
   keywords?: string[]
+  exports?: Record<string, string | { default?: string; types?: string }>
 }
 
 const packageRoot = join(import.meta.dir, '../..')
@@ -91,6 +92,18 @@ describe('temporal-bun-sdk packaging manifest', () => {
     expect(bins['temporal-bun']).toBe('./dist/src/bin/temporal-bun.js')
     expect(bins['temporal-bun-skill']).toBe('./dist/src/bin/temporal-bun-skill.js')
     expect(bins['temporal-bun-worker']).toBe('./dist/src/bin/start-worker.js')
+  })
+
+  test('exports only subpaths backed by source modules', async () => {
+    const packageJson = await loadPackageJson()
+
+    for (const [subpath, target] of Object.entries(packageJson.exports ?? {})) {
+      const defaultTarget = typeof target === 'string' ? target : target.default
+      if (!defaultTarget?.startsWith('./dist/src/') || !defaultTarget.endsWith('.js')) continue
+
+      const sourcePath = join(packageRoot, defaultTarget.replace('./dist/', '').replace(/\.js$/, '.ts'))
+      expect(existsSync(sourcePath), `${subpath} -> ${defaultTarget}`).toBeTrue()
+    }
   })
 
   test('exposes adoption metadata for npm and agent discovery', async () => {


### PR DESCRIPTION
## Summary

- Removes the published `./workflow/runtime` subpath that points to a source and build output that do not exist.
- Adds a packaging-manifest regression that verifies every `dist/src/*.js` export is backed by a source module.
- Prevents consumers from resolving an advertised Temporal SDK entrypoint that can never load.

## Related Issues

Addresses historical Codex review: https://github.com/proompteng/lab/pull/1845#discussion_r2551910542

## Testing

- `bun test packages/temporal-bun-sdk/tests/packaging/manifest-packaging.test.ts` — 12 passed.
- `tsc --noEmit --project packages/temporal-bun-sdk/tsconfig.json --pretty false` — passed.
- Oxfmt and `git diff --check` on changed files — passed.

## Breaking Changes

Removes the nonfunctional `@proompteng/temporal-bun-sdk/workflow/runtime` export. No working consumer could load this subpath because neither its source module nor its published build output existed.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] The packaging regression documents and enforces the corrected public surface.
