### PR TITLE
fix(torghut): require volatility feature for entry

### DIFF
--- a/services/torghut/app/trading/intraday_tsmom_contract/decimal.py
+++ b/services/torghut/app/trading/intraday_tsmom_contract/decimal.py
@@ -128,7 +128,7 @@ def _volatility_within_budget(
     ceil: Decimal | None,
 ) -> bool:
     if volatility is None:
-        return True
+        return False
     if floor is not None and volatility < floor:
         return False
     if ceil is not None and volatility > ceil:

--- a/services/torghut/tests/test_intraday_tsmom_contract.py
+++ b/services/torghut/tests/test_intraday_tsmom_contract.py
@@ -1,11 +1,22 @@
 from __future__ import annotations
 
 import unittest
+from decimal import Decimal
 
 from app.trading.intraday_tsmom_contract import validate_intraday_tsmom_params
+from app.trading.intraday_tsmom_contract.decimal import volatility_within_budget
 
 
 class TestIntradayTsmomContract(unittest.TestCase):
+    def test_volatility_budget_fails_closed_when_feature_is_missing(self) -> None:
+        self.assertFalse(
+            volatility_within_budget(
+                None,
+                floor=Decimal("0.0001"),
+                ceil=Decimal("0.01"),
+            )
+        )
+
     def test_validate_intraday_tsmom_params_rejects_invalid_live_quality_fields(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Makes intraday TSMOM volatility-budget validation fail closed when the volatility feature is missing.
- Prevents a buy decision from passing a configured volatility floor and ceiling without an observed value.
- Adds a focused contract regression for the missing-feature case.

## Related Issues

Addresses historical Codex review: https://github.com/proompteng/lab/pull/3044#discussion_r2800597815

## Testing

- Python 3.12 `pytest -q tests/test_intraday_tsmom_contract.py` — 2 passed.
- Pyright `pyrightconfig.json` — 0 errors, 0 warnings.
- Pyright `pyrightconfig.alpha.json` — 0 errors, 0 warnings.
- Pyright `pyrightconfig.scripts.json` — 0 errors, 0 warnings.
- Ruff format and lint on changed files — passed.
- `uv sync --frozen --extra dev` remains blocked in agents-shell by the missing standard `/lib64` loader; validation used the repository’s existing synced Python 3.12 environment through the pinned Nix loader.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents exact validation and the local toolchain limitation.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] No documentation or release-note update is required for this fail-closed signal-quality correction.
