### PR TITLE
fix(torghut): preserve seq-aware ingest cursors

### DIFF
--- a/services/torghut/app/trading/ingest/clickhouse_signal_ingestor_core_methods.py
+++ b/services/torghut/app/trading/ingest/clickhouse_signal_ingestor_core_methods.py
@@ -563,6 +563,7 @@ class _ClickHouseSignalIngestorCoreMethods(_ClickHouseSignalIngestorCoreBase):
                 cursor_seq=cursor_seq,
                 cursor_symbol=cursor_symbol,
                 latest_signal_at=latest_signal_at,
+                time_column=time_column,
                 poll_started_at=poll_started_at,
                 query_window_end=query_end,
                 no_signal_reason=no_signal_reason,
@@ -619,6 +620,7 @@ class _ClickHouseSignalIngestorCoreMethods(_ClickHouseSignalIngestorCoreBase):
         cursor_seq: Optional[int],
         cursor_symbol: Optional[str],
         latest_signal_at: Optional[datetime],
+        time_column: str,
         poll_started_at: datetime,
         query_window_end: datetime,
         no_signal_reason: str,
@@ -640,7 +642,9 @@ class _ClickHouseSignalIngestorCoreMethods(_ClickHouseSignalIngestorCoreBase):
                 no_signal_reason,
                 signal_lag_seconds,
             )
-        if cursor_seq is not None or cursor_symbol is not None:
+        if self._supports_seq_for_time_column(time_column) and (
+            cursor_seq is not None or cursor_symbol is not None
+        ):
             return (
                 cursor_at,
                 cursor_seq,

--- a/services/torghut/app/trading/ingest/clickhouse_signal_ingestor_core_methods.py
+++ b/services/torghut/app/trading/ingest/clickhouse_signal_ingestor_core_methods.py
@@ -640,6 +640,14 @@ class _ClickHouseSignalIngestorCoreMethods(_ClickHouseSignalIngestorCoreBase):
                 no_signal_reason,
                 signal_lag_seconds,
             )
+        if cursor_seq is not None or cursor_symbol is not None:
+            return (
+                cursor_at,
+                cursor_seq,
+                cursor_symbol,
+                no_signal_reason,
+                signal_lag_seconds,
+            )
 
         cursor_advance = poll_started_at - timedelta(
             seconds=self.empty_batch_advance_seconds

--- a/services/torghut/tests/test_trading_ingest.py
+++ b/services/torghut/tests/test_trading_ingest.py
@@ -155,22 +155,64 @@ def test_empty_fetch_does_not_advance_seq_aware_cursor() -> None:
         fast_forward_stale_cursor=False,
     )
     ingestor.empty_batch_advance_seconds = 60
+    ingestor._columns = {"event_ts", "seq", "symbol"}
 
-    batch = ingestor._empty_fetch_batch(
-        cursor_at=cursor_at,
-        cursor_seq=42,
-        cursor_symbol="MSFT",
-        latest_signal_at=cursor_at + timedelta(minutes=1),
-        time_column="event_ts",
-        query_start=cursor_at,
-        query_end=poll_started_at,
-        poll_started_at=poll_started_at,
-    )
+    with patch.object(
+        ingestor,
+        "_query_clickhouse",
+        side_effect=AssertionError("unit test must not query ClickHouse"),
+    ) as query_clickhouse:
+        batch = ingestor._empty_fetch_batch(
+            cursor_at=cursor_at,
+            cursor_seq=42,
+            cursor_symbol="MSFT",
+            latest_signal_at=cursor_at + timedelta(minutes=1),
+            time_column="event_ts",
+            query_start=cursor_at,
+            query_end=poll_started_at,
+            poll_started_at=poll_started_at,
+        )
 
+    query_clickhouse.assert_not_called()
     assert batch.no_signal_reason == "no_signals_in_window"
     assert batch.cursor_at == cursor_at
     assert batch.cursor_symbol == "MSFT"
     assert batch.cursor_seq == 42
+
+
+def test_empty_fetch_advances_non_seq_cursor_with_symbol_tiebreaker() -> None:
+    cursor_at = datetime(2026, 6, 17, 13, 45, tzinfo=timezone.utc)
+    poll_started_at = cursor_at + timedelta(minutes=5)
+    ingestor = ClickHouseSignalIngestor(
+        schema="flat",
+        table="torghut.ta_signals",
+        url="http://clickhouse.test",
+        fast_forward_stale_cursor=False,
+    )
+    ingestor.empty_batch_advance_seconds = 60
+    ingestor._columns = {"ts", "symbol"}
+
+    with patch.object(
+        ingestor,
+        "_query_clickhouse",
+        side_effect=AssertionError("unit test must not query ClickHouse"),
+    ) as query_clickhouse:
+        batch = ingestor._empty_fetch_batch(
+            cursor_at=cursor_at,
+            cursor_seq=None,
+            cursor_symbol="MSFT",
+            latest_signal_at=cursor_at + timedelta(minutes=1),
+            time_column="ts",
+            query_start=cursor_at,
+            query_end=poll_started_at,
+            poll_started_at=poll_started_at,
+        )
+
+    query_clickhouse.assert_not_called()
+    assert batch.no_signal_reason == "empty_batch_advanced"
+    assert batch.cursor_at == poll_started_at - timedelta(seconds=60)
+    assert batch.cursor_symbol is None
+    assert batch.cursor_seq is None
 
 
 def test_scoped_timeout_returns_only_non_authority_last_good_fallback() -> None:

--- a/services/torghut/tests/test_trading_ingest.py
+++ b/services/torghut/tests/test_trading_ingest.py
@@ -145,6 +145,34 @@ def test_empty_fetch_preserves_event_cursor_tiebreakers_at_stream_tail() -> None
     assert batch.cursor_seq == 42
 
 
+def test_empty_fetch_does_not_advance_seq_aware_cursor() -> None:
+    cursor_at = datetime(2026, 6, 17, 13, 45, tzinfo=timezone.utc)
+    poll_started_at = cursor_at + timedelta(minutes=5)
+    ingestor = ClickHouseSignalIngestor(
+        schema="envelope",
+        table="torghut.ta_signals",
+        url="http://clickhouse.test",
+        fast_forward_stale_cursor=False,
+    )
+    ingestor.empty_batch_advance_seconds = 60
+
+    batch = ingestor._empty_fetch_batch(
+        cursor_at=cursor_at,
+        cursor_seq=42,
+        cursor_symbol="MSFT",
+        latest_signal_at=cursor_at + timedelta(minutes=1),
+        time_column="event_ts",
+        query_start=cursor_at,
+        query_end=poll_started_at,
+        poll_started_at=poll_started_at,
+    )
+
+    assert batch.no_signal_reason == "no_signals_in_window"
+    assert batch.cursor_at == cursor_at
+    assert batch.cursor_symbol == "MSFT"
+    assert batch.cursor_seq == 42
+
+
 def test_scoped_timeout_returns_only_non_authority_last_good_fallback() -> None:
     engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
     Base.metadata.create_all(engine)


### PR DESCRIPTION
## Summary

- Stops empty polls from advancing a sequence-aware ClickHouse cursor to a newer timestamp while discarding its sequence and symbol tie-breakers.
- Preserves the complete `(timestamp, sequence, symbol)` checkpoint so late arrivals at the original timestamp remain ingestible.
- Retains empty-batch time advancement for timestamp-only legacy cursors.
- Seeds ClickHouse column metadata in both regressions and asserts no network query occurs.

## Related Issues

Addresses historical Codex review: https://github.com/proompteng/lab/pull/3052#discussion_r2801951040

## Testing

- `pytest -q tests/test_trading_ingest.py` — 9 passed.
- Pyright default, alpha, and scripts profiles — 0 errors.
- Full Ruff format/check, compileall, structural Pylint, changed-line quality/design, file-length, tech-debt ratchet, migration graph, and `git diff --check` — passed.
- Exact frozen environment installed with `uv sync --frozen --extra dev`.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents exact validation and the local toolchain limitation.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] No documentation or release-note update is required for this cursor-correctness fix.
