### PR TITLE
fix(torghut): prefer latest duplicate ingest row

### DIFF
--- a/services/torghut/app/trading/ingest/clickhouse_signal_ingestor_persistence_methods.py
+++ b/services/torghut/app/trading/ingest/clickhouse_signal_ingestor_persistence_methods.py
@@ -464,7 +464,14 @@ def _prefer_preferred_signal(
 
 def _signal_preference_key(
     signal: SignalEnvelope,
-) -> tuple[int, int, int, str, int, str]:
+) -> tuple[int, int, int, str, int, str, datetime]:
+    ingest_ts = signal.ingest_ts
+    if ingest_ts is None:
+        normalized_ingest_ts = datetime.min.replace(tzinfo=timezone.utc)
+    elif ingest_ts.tzinfo is None:
+        normalized_ingest_ts = ingest_ts.replace(tzinfo=timezone.utc)
+    else:
+        normalized_ingest_ts = ingest_ts.astimezone(timezone.utc)
     return (
         1 if _signal_matches_active_simulation_run(signal) else 0,
         _signal_provenance_completeness(signal),
@@ -472,6 +479,7 @@ def _signal_preference_key(
         _signal_payload_context_fingerprint(signal),
         _coerce_seq(signal.seq) or -1,
         signal.source or "",
+        normalized_ingest_ts,
     )
 
 

--- a/services/torghut/tests/signal_ingest/test_fetch_signals_between_dedupes_replay_duplicates_by_stable_identity.py
+++ b/services/torghut/tests/signal_ingest/test_fetch_signals_between_dedupes_replay_duplicates_by_stable_identity.py
@@ -24,6 +24,50 @@ from tests.signal_ingest.support import (
 class TestFetchSignalsBetweenDedupesReplayDuplicatesByStableIdentity(
     _TestSignalIngestBase
 ):
+    def test_fetch_signals_between_prefers_latest_ingest_timestamp_for_exact_duplicates(
+        self,
+    ) -> None:
+        rows = [
+            {
+                "event_ts": "2026-03-06T14:50:00Z",
+                "ingest_ts": "2026-03-06T14:50:01Z",
+                "symbol": "AAPL",
+                "payload": {"rsi14": 30},
+                "seq": 100,
+                "source": "ta",
+                "window_size": "PT1S",
+            },
+            {
+                "event_ts": "2026-03-06T14:50:00Z",
+                "ingest_ts": "2026-03-06T14:50:02Z",
+                "symbol": "AAPL",
+                "payload": {"rsi14": 30},
+                "seq": 100,
+                "source": "ta",
+                "window_size": "PT1S",
+            },
+        ]
+
+        class DuplicateEnvelopeIngestor(ClickHouseSignalIngestor):
+            def _query_clickhouse(self, query: str) -> list[dict[str, object]]:
+                return rows
+
+        ingestor = DuplicateEnvelopeIngestor(
+            schema="envelope",
+            table="torghut.ta_signals",
+            url="http://example",
+        )
+        signals = ingestor.fetch_signals_between(
+            start=datetime(2026, 3, 6, 14, 50, tzinfo=timezone.utc),
+            end=datetime(2026, 3, 6, 14, 51, tzinfo=timezone.utc),
+        )
+
+        self.assertEqual(len(signals), 1)
+        self.assertEqual(
+            signals[0].ingest_ts,
+            datetime(2026, 3, 6, 14, 50, 2, tzinfo=timezone.utc),
+        )
+
     def test_fetch_signals_between_dedupes_replay_duplicates_by_stable_identity(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Adds normalized `ingest_ts` as the final duplicate-signal preference key.
- Makes replay duplicate selection deterministic when provenance, payload, sequence, and source are otherwise identical.
- Prefers the later ingestion record while treating missing timestamps as the oldest candidate.

## Related Issues

Addresses historical Codex review: https://github.com/proompteng/lab/pull/4564#discussion_r2941693263

## Testing

- Python 3.12 `pytest -q tests/signal_ingest/test_fetch_signals_between_dedupes_replay_duplicates_by_stable_identity.py` — 24 passed.
- Pyright `pyrightconfig.json` — 0 errors, 0 warnings.
- Pyright `pyrightconfig.alpha.json` — 0 errors, 0 warnings.
- Pyright `pyrightconfig.scripts.json` — 0 errors, 0 warnings.
- Ruff format and lint on changed files — passed.
- `uv sync --frozen --extra dev` remains blocked in agents-shell by the missing standard `/lib64` loader; validation used the repository’s existing synced Python 3.12 environment through the pinned Nix loader.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents exact validation and the local toolchain limitation.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] No documentation or release-note update is required for this duplicate-selection correction.
