### PR TITLE
fix(torghut): align breakout exit trace

### DIFF
--- a/services/torghut/app/trading/research_sleeve_evaluators/breakout_exit.py
+++ b/services/torghut/app/trading/research_sleeve_evaluators/breakout_exit.py
@@ -7,9 +7,8 @@ from typing import Any, Mapping, cast
 from .core import (
     SleeveSignalEvaluation,
     SleeveSignalResult,
-    build_gate,
     build_sleeve_result,
-    threshold_bool,
+    exit_trigger_gate,
 )
 from .helpers import (
     decimal_param,
@@ -198,22 +197,19 @@ def breakout_exit_result(
             )
         )
     )
-    exit_gate = build_gate(
-        name="exit",
-        category="exit",
-        thresholds=(
-            threshold_bool(
-                metric="breakout_failure_confirmed",
-                passed=breakout_failure_confirmed,
-                threshold=True,
-            ),
-            threshold_bool(
-                metric="session_strength_reversal_confirmed",
-                passed=session_strength_reversal_confirmed,
-                threshold=False,
-                value=session_strength_reversal_confirmed,
-            ),
-        ),
+    price_below_opening_range_high = (
+        resolved_request.price_vs_opening_range_high_bps is not None
+        and optional_max_threshold(
+            resolved_request.price_vs_opening_range_high_bps,
+            exit_price_below_opening_range_high_bps,
+        )
+    )
+    exit_gate = exit_trigger_gate(
+        reason_flags={
+            "breakout_failure_confirmed": breakout_failure_confirmed,
+            "price_below_opening_range_high": price_below_opening_range_high,
+            "session_strength_reversal_confirmed": session_strength_reversal_confirmed,
+        }
     )
     if breakout_failure_confirmed:
         return build_sleeve_result(
@@ -231,13 +227,6 @@ def breakout_exit_result(
             trace_enabled=resolved_request.trace_enabled,
             context=resolved_request.trace_context,
         )
-    price_below_opening_range_high = (
-        resolved_request.price_vs_opening_range_high_bps is not None
-        and optional_max_threshold(
-            resolved_request.price_vs_opening_range_high_bps,
-            exit_price_below_opening_range_high_bps,
-        )
-    )
     if price_below_opening_range_high or session_strength_reversal_confirmed:
         return build_sleeve_result(
             strategy_id=resolved_request.strategy_id,

--- a/services/torghut/tests/strategy_runtime/test_runtime_breakout_b.py
+++ b/services/torghut/tests/strategy_runtime/test_runtime_breakout_b.py
@@ -555,7 +555,7 @@ class TestStrategyRuntimeBreakoutB(TestCase):
         )
 
         feature_contract = normalize_feature_vector_v3(signal)
-        runtime = StrategyRuntime()
+        runtime = StrategyRuntime(trace_enabled=True)
         decision = runtime.evaluate(strategy, feature_contract, timeframe="1Sec")
 
         self.assertIsNotNone(decision)
@@ -563,6 +563,11 @@ class TestStrategyRuntimeBreakoutB(TestCase):
         self.assertEqual(decision.intent.action, "sell")
         self.assertEqual(decision.plugin_id, "breakout_continuation_long")
         self.assertIn("breakout_failed", decision.intent.rationale)
+        self.assertIsNotNone(decision.trace)
+        assert decision.trace is not None
+        exit_gate = decision.trace.gates[-1]
+        self.assertTrue(exit_gate.passed)
+        self.assertTrue(exit_gate.context["reasons"]["breakout_failure_confirmed"])
 
     def test_breakout_continuation_plugin_does_not_exit_on_momentum_rollover_above_structure(
         self,


### PR DESCRIPTION
## Summary

- Uses the shared OR-semantics exit-trigger gate for breakout continuation exits.
- Records breakout failure, loss of opening-range structure, and session-strength reversal as the actual independent sell triggers.
- Adds trace coverage proving a confirmed breakout failure produces a passing exit gate.

## Related Issues

Addresses historical Codex review: https://github.com/proompteng/lab/pull/4815#discussion_r3007401925

## Testing

- Python 3.12 `pytest -q tests/strategy_runtime/test_runtime_breakout_b.py` — 13 passed.
- Pyright `pyrightconfig.json` — 0 errors, 0 warnings.
- Pyright `pyrightconfig.alpha.json` — 0 errors, 0 warnings.
- Pyright `pyrightconfig.scripts.json` — 0 errors, 0 warnings.
- Ruff format and lint on changed files — passed.
- `uv sync --frozen --extra dev` remains blocked in agents-shell by the missing standard `/lib64` loader; validation used the repository’s existing synced Python 3.12 environment through the pinned Nix loader.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents exact validation and the local toolchain limitation.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] No documentation or release-note update is required for this trace-semantics correction.
