### PR TITLE
feat(torghut): freeze capital and publish safety baseline

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -405,7 +405,9 @@ spec:
             - name: TRADING_PERSISTENT_DRAWDOWN_STOP_PCT_EQUITY
               value: "0.05"
             - name: TRADING_NEW_EXPOSURE_CUTOFF_TIME_ET
-              value: "15:30:00"
+              # Mirror the scheduler's P0 capital-freeze policy so status and
+              # scheduler configuration cannot report different authority.
+              value: "00:00:00"
             - name: TRADING_FLATTEN_START_TIME_ET
               value: "15:45:00"
             - name: TRADING_FLAT_CONFIRMATION_TIME_ET

--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -421,7 +421,9 @@ spec:
             - name: TRADING_PERSISTENT_DRAWDOWN_STOP_PCT_EQUITY
               value: "0.05"
             - name: TRADING_NEW_EXPOSURE_CUTOFF_TIME_ET
-              value: "15:30:00"
+              # P0 capital freeze: the scheduler stays healthy for recovery and
+              # closeout, while every risk-increasing decision is rejected.
+              value: "00:00:00"
             - name: TRADING_FLATTEN_START_TIME_ET
               value: "15:45:00"
             - name: TRADING_FLAT_CONFIRMATION_TIME_ET

--- a/docs/torghut/production-readiness-proof-runbook.md
+++ b/docs/torghut/production-readiness-proof-runbook.md
@@ -10,6 +10,27 @@ This runbook is the authoritative operator sequence for a production-readiness s
 - Broker target: Alpaca `paper`
 - Signoff rule: every proof lane must pass on the same `image_digest`
 
+## Current P0 Capital Hold
+
+Production-readiness signoff is blocked while the profitability roadmap P0 mutation and reconciliation proofs remain
+incomplete. GitOps keeps `TRADING_NEW_EXPOSURE_CUTOFF_TIME_ET=00:00:00`: the scheduler continues status, reconciliation,
+cancel, and closeout work, but strategy decisions cannot increase exposure.
+
+The authoritative baseline is `GET /trading/status` on the scheduler owner. Record all of these independently:
+
+- `action_authority.service_healthy`
+- `action_authority.entry_allowed`
+- `action_authority.reduce_only_allowed`
+- `action_authority.recovery_degraded`
+- `broker_mutation_safety.runtime_wired`
+- `broker_mutation_safety.*_fencing_proven`
+- `broker_mutation_safety.reason_codes`
+
+Do not reinterpret `live_submission_gate.allowed`, Kubernetes readiness, or Argo health as capital authority. Until the
+broker-mutation coordinator and recovery worker are production-wired and fault-proved, the expected truthful baseline
+is `entry_allowed=false`, `reduce_only_allowed=false`, and `recovery_degraded=true`; the existing emergency closeout
+path remains operational but is not yet a durably fenced reduction authority.
+
 ## Preconditions
 
 1. Freeze the candidate digest and confirm it is the active digest on:
@@ -80,9 +101,11 @@ python services/torghut/scripts/verify_quant_readiness.py \
   ...
 ```
 
-### 3. Live paper broker proof
+### 3. Live paper broker proof (blocked until mutation fencing is wired)
 
-Execute the production-real Alpaca paper proof on the next live US equities session.
+Do not execute a broker mutation while `broker_mutation_safety.runtime_wired=false`. After the mutation coordinator,
+recovery worker, and reduction fencing are deployed, execute the production-real Alpaca paper proof on the next live US
+equities session only through Torghut's normal coordinator under a short-lived `InfrastructureValidationPermit`.
 
 Required outcome:
 
@@ -92,13 +115,7 @@ Required outcome:
 - readback succeeds
 - terminal cancel or fill is observed
 
-Suggested command:
-
-```bash
-python services/torghut/scripts/verify_alpaca_broker.py \
-  --mode paper \
-  --output <bundle-dir>/broker-proof.raw.json
-```
+Direct script-to-broker submission is not admissible proof.
 
 ### 4. Session readiness proof
 
@@ -106,11 +123,11 @@ Capture the live readiness gate on the same digest used for the replay and broke
 
 Required outcome:
 
-- `GET /readyz` returns `200`
-- `GET /trading/health` returns `200`
-- Jangar dependency quorum returns `allow`
-- broker status is `broker_ok`
-- no rollback-required blocker is active
+- `GET /scheduler/readyz` returns `200` for the scheduler workload;
+- `GET /trading/status` reports `action_authority.service_healthy=true`;
+- entry, reduction, recovery, and broker-mutation fields match the intended capital stage;
+- the core `/readyz` result is recorded separately and may be `503` while capital entry is intentionally blocked;
+- no rollback-required service blocker is active.
 
 Persist the captured readiness payload as `session-ready.json`.
 
@@ -127,12 +144,13 @@ out="/tmp/torghut-proof-rerun-${stamp}"
 mkdir -p "${out}"
 ```
 
-After the rerun, capture:
+After the rerun, capture only the current operational endpoints:
 
 ```bash
 curl -fsS http://torghut.torghut.svc.cluster.local/trading/status > "${out}/status.json"
-curl -fsS http://torghut.torghut.svc.cluster.local/trading/empirical-jobs > "${out}/empirical-jobs.json"
-curl -fsS http://torghut.torghut.svc.cluster.local/trading/revenue-repair > "${out}/revenue-repair.json"
+kubectl -n torghut get --raw \
+  '/api/v1/namespaces/torghut/services/http:torghut-scheduler:8183/proxy/scheduler/readyz' \
+  > "${out}/scheduler-ready.json"
 ```
 
 Do not submit or fabricate an Alpaca order from this runbook. Broker execution evidence must come from Torghut’s normal

--- a/services/torghut/app/api/health_checks/__init__.py
+++ b/services/torghut/app/api/health_checks/__init__.py
@@ -12,13 +12,11 @@ from app.api.health_checks.shared_context import (
 )
 
 from .load_options_catalog_freshness_summary import (
-    api_live_submission_gate_payload,
     load_last_decision_at,
     load_options_catalog_freshness_summary,
     raw_hypothesis_runtime_payload,
 )
 from .remember_alpaca_success import (
-    budget_exhausted_live_submission_gate_payload,
     budget_exhausted_options_catalog_freshness_payload,
     check_alpaca,
     decimal_or_none,
@@ -42,7 +40,6 @@ check_alpaca_dependency = check_alpaca
 check_clickhouse_dependency = check_clickhouse
 check_postgres_dependency = check_postgres
 build_hypothesis_runtime_payload = raw_hypothesis_runtime_payload
-build_api_live_submission_gate_payload = api_live_submission_gate_payload
 lean_authority_status = lean_authority_status_payload
 
 __all__ = (
@@ -64,7 +61,6 @@ __all__ = (
     "load_tca_summary",
     "load_clickhouse_ta_status",
     "tca_row_payload",
-    "budget_exhausted_live_submission_gate_payload",
     "budget_exhausted_options_catalog_freshness_payload",
     "route_claim_symbols",
     "load_options_catalog_freshness_summary",
@@ -72,5 +68,4 @@ __all__ = (
     "sqlalchemy_error_indicates_statement_timeout",
     "load_last_decision_at",
     "build_hypothesis_runtime_payload",
-    "build_api_live_submission_gate_payload",
 )

--- a/services/torghut/app/api/health_checks/load_options_catalog_freshness_summary.py
+++ b/services/torghut/app/api/health_checks/load_options_catalog_freshness_summary.py
@@ -68,20 +68,13 @@ from app.trading.lean_runtime import lean_authority_status as _lean_authority_st
 from app.trading.scheduler import TradingScheduler
 from app.trading.submission_council import build_hypothesis_runtime_summary
 from app.trading.submission_council import (
-    build_live_submission_gate_payload as _raw_build_live_submission_gate_payload,
-)
-from app.trading.submission_council import (
     build_shadow_first_toggle_parity as _build_shadow_first_toggle_parity,
 )
 from app.trading.submission_council import (
     resolve_active_capital_stage as _resolve_active_capital_stage,
 )
-from ..application import get_app
 from .remember_alpaca_success import (
     alpaca_cached_last_good as _alpaca_cached_last_good,
-)
-from .remember_alpaca_success import (
-    budget_exhausted_live_submission_gate_payload as _budget_exhausted_live_submission_gate_payload,
 )
 from .remember_alpaca_success import (
     budget_exhausted_options_catalog_freshness_payload as _budget_exhausted_options_catalog_freshness_payload,
@@ -505,28 +498,6 @@ def _build_hypothesis_runtime_payload(
     )
 
 
-def _build_live_submission_gate_payload(
-    state: object,
-    *,
-    clickhouse_ta_status: Mapping[str, Any] | None = None,
-) -> dict[str, object]:
-    resolved_clickhouse_ta_status = clickhouse_ta_status
-    if resolved_clickhouse_ta_status is None:
-        resolved_clickhouse_ta_status = _load_clickhouse_ta_status(
-            cast(
-                TradingScheduler | None,
-                getattr(get_app().state, "trading_scheduler", None),
-            )
-        )
-    shared_gate_builder = build_live_submission_gate_payload
-    if shared_gate_builder is _PUBLIC_BUILD_LIVE_SUBMISSION_GATE_PAYLOAD:
-        shared_gate_builder = _raw_build_live_submission_gate_payload
-    return shared_gate_builder(
-        state,
-        clickhouse_ta_status=resolved_clickhouse_ta_status,
-    )
-
-
 def build_hypothesis_runtime_payload(
     scheduler: TradingScheduler,
     *,
@@ -544,25 +515,10 @@ def build_hypothesis_runtime_payload(
     )
 
 
-def build_live_submission_gate_payload(
-    state: object,
-    *,
-    clickhouse_ta_status: Mapping[str, Any] | None = None,
-) -> dict[str, object]:
-    return _build_live_submission_gate_payload(
-        state,
-        clickhouse_ta_status=clickhouse_ta_status,
-    )
-
-
-_PUBLIC_BUILD_LIVE_SUBMISSION_GATE_PAYLOAD = build_live_submission_gate_payload
-
-
 ensure_utc_datetime = _ensure_utc_datetime
 load_last_decision_at = _load_last_decision_at
 load_options_catalog_freshness_summary = _load_options_catalog_freshness_summary
 raw_hypothesis_runtime_payload = _build_hypothesis_runtime_payload
-api_live_submission_gate_payload = _build_live_submission_gate_payload
 resolve_tca_scope_symbols = _resolve_tca_scope_symbols
 
 
@@ -592,7 +548,6 @@ __all__ = [
     "_tca_row_payload",
     "_load_tca_summary",
     "_load_clickhouse_ta_status",
-    "_budget_exhausted_live_submission_gate_payload",
     "_budget_exhausted_options_catalog_freshness_payload",
     "_route_claim_symbols",
     "_load_cached_options_catalog_freshness_summary",
@@ -605,10 +560,7 @@ __all__ = [
     "_ensure_utc_datetime",
     "_load_last_decision_at",
     "_build_hypothesis_runtime_payload",
-    "_build_live_submission_gate_payload",
-    "api_live_submission_gate_payload",
     "build_hypothesis_runtime_payload",
-    "build_live_submission_gate_payload",
     "ensure_utc_datetime",
     "load_last_decision_at",
     "load_options_catalog_freshness_summary",

--- a/services/torghut/app/api/health_checks/remember_alpaca_success.py
+++ b/services/torghut/app/api/health_checks/remember_alpaca_success.py
@@ -292,34 +292,6 @@ def load_clickhouse_ta_status(
     ).latest_signal_status()
 
 
-def budget_exhausted_live_submission_gate_payload(
-    *,
-    reason: str,
-) -> dict[str, object]:
-    operational_blockers = [reason]
-    if not settings.trading_simple_submit_enabled:
-        operational_blockers.append("submit_disabled")
-    return {
-        "schema_version": "torghut.operational-submission-gate.v2",
-        "allowed": False,
-        "reason": reason,
-        "blocked_reasons": list(dict.fromkeys(operational_blockers)),
-        "reason_codes": [reason],
-        "read_model_unavailable": True,
-        "read_model_status": "timeout",
-        "capital_stage": "blocked",
-        "capital_state": "blocked",
-        "authority_scope": "operational_submission",
-        "configured_live_submit": settings.trading_live_submit_enabled,
-        "simple_submit_enabled": settings.trading_simple_submit_enabled,
-        "operational_submission_gate": {
-            "allowed": False,
-            "reason": reason,
-            "blocked_reasons": list(dict.fromkeys(operational_blockers)),
-        },
-    }
-
-
 def budget_exhausted_options_catalog_freshness_payload(
     *,
     reason: str,
@@ -582,7 +554,6 @@ __all__: tuple[str, ...] = (
     "TorghutAlpacaClient",
     "_alpaca_probe_account",
     "alpaca_cached_last_good",
-    "budget_exhausted_live_submission_gate_payload",
     "budget_exhausted_options_catalog_freshness_payload",
     "build_tca_gate_inputs",
     "check_alpaca",

--- a/services/torghut/app/api/readiness_helpers/readiness_surface.py
+++ b/services/torghut/app/api/readiness_helpers/readiness_surface.py
@@ -193,7 +193,7 @@ def readiness_live_submission_gate(
 
     try:
         freshness = status_dependencies.load_clickhouse_ta_status(scheduler)
-        gate = status_dependencies.build_api_live_submission_gate_payload(
+        gate = status_dependencies.build_live_submission_gate_payload(
             scheduler.state,
             clickhouse_ta_status=freshness,
         )

--- a/services/torghut/app/api/readiness_helpers/status_dependencies.py
+++ b/services/torghut/app/api/readiness_helpers/status_dependencies.py
@@ -3,11 +3,9 @@
 from __future__ import annotations
 
 from app.trading.scheduler import TradingScheduler
+from app.trading.submission_council import build_live_submission_gate_payload
 
-from ..health_checks import (
-    build_api_live_submission_gate_payload,
-    load_clickhouse_ta_status,
-)
+from ..health_checks import load_clickhouse_ta_status
 
 
 def refresh_universe_state_for_readiness(
@@ -23,7 +21,7 @@ def refresh_universe_state_for_readiness(
 
 
 __all__ = (
-    "build_api_live_submission_gate_payload",
+    "build_live_submission_gate_payload",
     "load_clickhouse_ta_status",
     "refresh_universe_state_for_readiness",
 )

--- a/services/torghut/app/api/trading_status.py
+++ b/services/torghut/app/api/trading_status.py
@@ -15,12 +15,17 @@ from sqlalchemy.orm import Session
 from app.api.build_metadata import BUILD_COMMIT, BUILD_IMAGE_DIGEST, BUILD_VERSION
 from app.config import settings
 from app.db import SessionLocal
+from app.trading.action_authority import reduce_runtime_action_authority
+from app.trading.broker_mutation_receipts.runtime_status import (
+    build_broker_mutation_runtime_status,
+)
 from app.trading.execution_runtime import build_execution_status_payload
 from app.trading.scheduler import TradingScheduler
+from app.trading.scheduler.runtime_health import scheduler_readiness_payload
+from app.trading.submission_council import build_live_submission_gate_payload
 
 from .application import get_app, runtime_owner_for_role
 from .health_checks import (
-    build_api_live_submission_gate_payload,
     build_tigerbeetle_ledger_status,
     load_clickhouse_ta_status,
     load_last_decision_at,
@@ -125,9 +130,16 @@ def trading_status() -> dict[str, object] | Response:
     scheduler = get_trading_scheduler()
     state = scheduler.state
     accepted_source = load_clickhouse_ta_status(scheduler)
-    live_gate = build_api_live_submission_gate_payload(
+    live_gate = build_live_submission_gate_payload(
         state,
         clickhouse_ta_status=accepted_source,
+    )
+    broker_mutation = build_broker_mutation_runtime_status()
+    action_authority = reduce_runtime_action_authority(
+        service_status=scheduler_readiness_payload(scheduler),
+        live_submission_gate=live_gate,
+        broker_mutation_status=broker_mutation,
+        state=state,
     )
     tigerbeetle = _read_with_session(
         build_tigerbeetle_ledger_status,
@@ -168,6 +180,8 @@ def trading_status() -> dict[str, object] | Response:
         "last_error": state.last_error,
         "accepted_source_freshness": accepted_source,
         "live_submission_gate": live_gate,
+        "action_authority": action_authority.to_payload(),
+        "broker_mutation_safety": broker_mutation,
         "capital_controls": _capital_controls(state),
         "execution": build_execution_status_payload(
             state=state,

--- a/services/torghut/app/scheduler_main.py
+++ b/services/torghut/app/scheduler_main.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import logging
 from contextlib import asynccontextmanager
-from dataclasses import dataclass
-from datetime import datetime, timezone
 from typing import cast
 
 from fastapi import FastAPI, Request
@@ -19,180 +17,13 @@ from .config import settings
 from .db import SessionLocal, ensure_schema
 from .trading.autonomy import assert_runtime_gate_policy_contract
 from .trading.scheduler import TradingScheduler
+from .trading.scheduler.runtime_health import (
+    scheduler_liveness_payload,
+    scheduler_readiness_payload,
+)
 from .whitepapers import WhitepaperKafkaWorker, whitepaper_workflow_enabled
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass(frozen=True, slots=True)
-class _SchedulerSuccessFreshness:
-    observed: bool
-    observed_at: datetime | None
-    age_seconds: float | None
-    is_fresh: bool
-
-
-def _scheduler_success_age_seconds(last_run_at: object) -> float | None:
-    if not isinstance(last_run_at, datetime):
-        return None
-    normalized = last_run_at
-    if normalized.tzinfo is None:
-        normalized = normalized.replace(tzinfo=timezone.utc)
-    return (datetime.now(timezone.utc) - normalized).total_seconds()
-
-
-def _scheduler_success_freshness(
-    last_success_at: object,
-) -> _SchedulerSuccessFreshness:
-    age_seconds = _scheduler_success_age_seconds(last_success_at)
-    return _SchedulerSuccessFreshness(
-        observed=last_success_at is not None,
-        observed_at=last_success_at if isinstance(last_success_at, datetime) else None,
-        age_seconds=age_seconds,
-        is_fresh=(
-            age_seconds is not None
-            and 0 <= age_seconds <= settings.trading_scheduler_success_max_age_seconds
-        ),
-    )
-
-
-def _scheduler_readiness_detail(
-    *,
-    running: bool,
-    trading_success: _SchedulerSuccessFreshness,
-    reconcile_success: _SchedulerSuccessFreshness,
-    cycle_failed: bool,
-    leadership_ok: bool,
-) -> str:
-    failed_conditions = (
-        (not running, "scheduler_not_running"),
-        (cycle_failed, "scheduler_cycle_failed"),
-        (not trading_success.observed, "scheduler_success_missing"),
-        (not trading_success.is_fresh, "scheduler_success_stale"),
-        (not reconcile_success.observed, "scheduler_reconcile_success_missing"),
-        (not reconcile_success.is_fresh, "scheduler_reconcile_success_stale"),
-        (not leadership_ok, "scheduler_leadership_unhealthy"),
-    )
-    return next(
-        (detail for failed, detail in failed_conditions if failed),
-        "ok",
-    )
-
-
-def scheduler_readiness_payload(scheduler: TradingScheduler) -> dict[str, object]:
-    """Require fresh trading and reconciliation success plus healthy leadership."""
-
-    state = scheduler.state
-    running = bool(getattr(state, "running", False))
-    loop_errors = {
-        "last_error": getattr(state, "last_error", None),
-        "last_trading_error": getattr(state, "last_trading_error", None),
-        "last_reconcile_error": getattr(state, "last_reconcile_error", None),
-        "last_autonomy_error": getattr(state, "last_autonomy_error", None),
-        "last_evidence_error": getattr(state, "last_evidence_error", None),
-    }
-    trading_success = _scheduler_success_freshness(getattr(state, "last_run_at", None))
-    reconcile_success = _scheduler_success_freshness(
-        getattr(state, "last_reconcile_at", None)
-    )
-    leadership = scheduler_liveness_payload(scheduler)
-    leadership_ok = bool(leadership["ok"])
-    cycle_failed = any(error is not None for error in loop_errors.values())
-    ready = (
-        running
-        and trading_success.is_fresh
-        and reconcile_success.is_fresh
-        and not cycle_failed
-        and leadership_ok
-    )
-    payload: dict[str, object] = {
-        "ok": ready,
-        "process_role": settings.process_role,
-        "running": running,
-        "detail": _scheduler_readiness_detail(
-            running=running,
-            trading_success=trading_success,
-            reconcile_success=reconcile_success,
-            cycle_failed=cycle_failed,
-            leadership_ok=leadership_ok,
-        ),
-        "success_max_age_seconds": settings.trading_scheduler_success_max_age_seconds,
-        "trading_success_is_fresh": trading_success.is_fresh,
-        "reconcile_success_is_fresh": reconcile_success.is_fresh,
-        "leadership": leadership.get("leadership"),
-    }
-    if trading_success.observed_at is not None:
-        payload["last_run_at"] = trading_success.observed_at.isoformat()
-    if trading_success.age_seconds is not None:
-        payload["success_age_seconds"] = trading_success.age_seconds
-        payload["trading_success_age_seconds"] = trading_success.age_seconds
-    if reconcile_success.observed_at is not None:
-        payload["last_reconcile_at"] = reconcile_success.observed_at.isoformat()
-    if reconcile_success.age_seconds is not None:
-        payload["reconcile_success_age_seconds"] = reconcile_success.age_seconds
-    for key, error in loop_errors.items():
-        if error is not None:
-            payload[key] = str(error)
-    return payload
-
-
-def scheduler_liveness_payload(scheduler: TradingScheduler) -> dict[str, object]:
-    """Require a healthy trading loop and leadership when trading is enabled."""
-
-    trading_enabled = bool(settings.trading_enabled)
-    running = bool(getattr(scheduler.state, "running", False))
-    leadership_status = getattr(scheduler, "leadership_status", None)
-    if callable(leadership_status):
-        leadership_status = leadership_status()
-    trading_payload = {
-        "enabled": trading_enabled,
-        "loop_required": trading_enabled,
-        "running": running,
-    }
-    if leadership_status is None:
-        if not trading_enabled:
-            return {
-                "ok": True,
-                "process_role": settings.process_role,
-                "detail": "trading_disabled",
-                "trading": trading_payload,
-            }
-        return {
-            "ok": False,
-            "process_role": settings.process_role,
-            "detail": "leadership_status_unavailable",
-            "trading": trading_payload,
-        }
-
-    required = bool(getattr(leadership_status, "required", True))
-    acquired = bool(getattr(leadership_status, "acquired", False))
-    healthy = bool(getattr(leadership_status, "healthy", False))
-    leadership_ok = healthy and (acquired or not required)
-    leadership_payload = {
-        "required": required,
-        "acquired": acquired,
-        "healthy": healthy,
-        "failure_reason": getattr(leadership_status, "failure_reason", None),
-    }
-    if not trading_enabled:
-        ok = True
-        detail = "trading_disabled"
-    elif not leadership_ok:
-        ok = False
-        detail = "scheduler_leadership_unhealthy"
-    elif not running:
-        ok = False
-        detail = "scheduler_loop_not_running"
-    else:
-        ok = True
-        detail = "ok"
-    return {
-        "ok": ok,
-        "process_role": settings.process_role,
-        "detail": detail,
-        "trading": trading_payload,
-        "leadership": leadership_payload,
-    }
 
 
 async def scheduler_healthz(request: Request) -> JSONResponse:

--- a/services/torghut/app/trading/action_authority.py
+++ b/services/torghut/app/trading/action_authority.py
@@ -1,0 +1,298 @@
+"""Typed action-specific authority projections for the trading runtime."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import cast
+
+OPERATIONAL_SUBMISSION_GATE_SCHEMA_VERSION = "torghut.operational-submission-gate.v2"
+BROKER_MUTATION_RUNTIME_STATUS_SCHEMA_VERSION = (
+    "torghut.broker-mutation-runtime-status.v1"
+)
+RUNTIME_ACTION_AUTHORITY_SCHEMA_VERSION = "torghut.runtime-action-authority.v1"
+RUNTIME_ACTION_AUTHORITY_POLICY_REVISION = "p0-capital-freeze.v1"
+
+_REDUCTION_BLOCKERS = frozenset(
+    {
+        "broker_unavailable",
+        "kill_switch_enabled",
+        "live_submit_disabled",
+        "mainnet_route_unavailable",
+        "submit_disabled",
+        "trading_disabled",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _SubmissionRouteProjection:
+    """Operational route facts before mutation-fencing authority is applied."""
+
+    entry_allowed: bool
+    reduce_only_allowed: bool
+    recovery_degraded: bool
+    reason_codes: Mapping[str, tuple[str, ...]]
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeActionAuthority:
+    """Service and capital projections published to operators."""
+
+    service_healthy: bool
+    entry_allowed: bool
+    reduce_only_allowed: bool
+    recovery_degraded: bool
+    reason_codes: Mapping[str, tuple[str, ...]]
+    evaluated_at: datetime
+    policy_revision: str = RUNTIME_ACTION_AUTHORITY_POLICY_REVISION
+    schema_version: str = RUNTIME_ACTION_AUTHORITY_SCHEMA_VERSION
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "policy_revision": self.policy_revision,
+            "evaluated_at": self.evaluated_at.isoformat(),
+            "service_healthy": self.service_healthy,
+            "entry_allowed": self.entry_allowed,
+            "reduce_only_allowed": self.reduce_only_allowed,
+            "recovery_degraded": self.recovery_degraded,
+            "reason_codes": {
+                name: list(reasons) for name, reasons in self.reason_codes.items()
+            },
+        }
+
+
+def _reduce_submission_route(
+    *,
+    live_submission_gate: Mapping[str, object],
+    state: object,
+) -> _SubmissionRouteProjection:
+    """Project route availability without pretending mutation safety is wired."""
+
+    if not _valid_gate_contract(live_submission_gate):
+        invalid = ("live_submission_gate_contract_invalid",)
+        return _SubmissionRouteProjection(
+            entry_allowed=False,
+            reduce_only_allowed=False,
+            recovery_degraded=True,
+            reason_codes={
+                "entry": invalid,
+                "reduce_only": invalid,
+                "recovery": invalid,
+            },
+        )
+
+    blocked_reasons = _strings(live_submission_gate.get("blocked_reasons"))
+    entry_reasons: list[str] = []
+    if live_submission_gate.get("allowed") is not True:
+        entry_reasons.extend(
+            blocked_reasons
+            or _strings(live_submission_gate.get("reason"))
+            or ("operational_submission_blocked",)
+        )
+    if live_submission_gate.get("new_exposure_allowed") is not True:
+        entry_reasons.append("new_exposure_cutoff_active")
+
+    route = _mapping(live_submission_gate.get("execution_route"))
+    reduction_reasons = [
+        reason for reason in blocked_reasons if reason in _REDUCTION_BLOCKERS
+    ]
+    if route.get("route") != "alpaca":
+        reduction_reasons.append("mainnet_route_unavailable")
+
+    recovery_reasons: list[str] = []
+    if bool(getattr(state, "capital_closeout_in_progress", False)):
+        recovery_reasons.append("capital_closeout_in_progress")
+    if bool(getattr(state, "emergency_stop_active", False)):
+        recovery_reasons.append("emergency_stop_active")
+    if "broker_unavailable" in blocked_reasons:
+        recovery_reasons.append("broker_unavailable")
+
+    entry_codes = _unique(entry_reasons)
+    reduction_codes = _unique(reduction_reasons)
+    recovery_codes = _unique(recovery_reasons)
+    return _SubmissionRouteProjection(
+        entry_allowed=not entry_codes,
+        reduce_only_allowed=not reduction_codes,
+        recovery_degraded=bool(recovery_codes),
+        reason_codes={
+            "entry": entry_codes,
+            "reduce_only": reduction_codes,
+            "recovery": recovery_codes,
+        },
+    )
+
+
+def reduce_runtime_action_authority(
+    *,
+    service_status: Mapping[str, object],
+    live_submission_gate: Mapping[str, object],
+    broker_mutation_status: Mapping[str, object],
+    state: object,
+    evaluated_at: datetime | None = None,
+) -> RuntimeActionAuthority:
+    """Combine process health with action-specific submission authority."""
+
+    observed_at = evaluated_at or datetime.now(timezone.utc)
+    if observed_at.tzinfo is None:
+        raise ValueError("runtime_action_authority_timestamp_must_be_timezone_aware")
+
+    service_healthy = service_status.get("ok") is True
+    service_reasons = () if service_healthy else (_service_reason(service_status),)
+    submission = _reduce_submission_route(
+        live_submission_gate=live_submission_gate,
+        state=state,
+    )
+    mutation_entry_reasons = _mutation_authority_reasons(
+        broker_mutation_status,
+        required_field="entry_fencing_proven",
+        fallback_reason="broker_mutation_entry_fencing_unproven",
+    )
+    mutation_reduction_reasons = _mutation_authority_reasons(
+        broker_mutation_status,
+        required_field="reduction_fencing_proven",
+        fallback_reason="broker_mutation_reduction_fencing_unproven",
+    )
+    mutation_recovery_reasons = _mutation_recovery_reasons(broker_mutation_status)
+    entry_reasons = _unique(
+        (
+            *service_reasons,
+            *submission.reason_codes["entry"],
+            *mutation_entry_reasons,
+        )
+    )
+    reduction_reasons = _unique(
+        (
+            *service_reasons,
+            *submission.reason_codes["reduce_only"],
+            *mutation_reduction_reasons,
+        )
+    )
+    recovery_reasons = _unique(
+        (
+            *service_reasons,
+            *submission.reason_codes["recovery"],
+            *mutation_recovery_reasons,
+        )
+    )
+    return RuntimeActionAuthority(
+        service_healthy=service_healthy,
+        entry_allowed=not entry_reasons,
+        reduce_only_allowed=not reduction_reasons,
+        recovery_degraded=bool(recovery_reasons),
+        reason_codes={
+            "service": service_reasons,
+            "entry": entry_reasons,
+            "reduce_only": reduction_reasons,
+            "recovery": recovery_reasons,
+        },
+        evaluated_at=observed_at,
+    )
+
+
+def _valid_gate_contract(gate: Mapping[str, object]) -> bool:
+    route = gate.get("execution_route")
+    blocked = gate.get("blocked_reasons")
+    return (
+        gate.get("schema_version") == OPERATIONAL_SUBMISSION_GATE_SCHEMA_VERSION
+        and isinstance(gate.get("allowed"), bool)
+        and isinstance(gate.get("new_exposure_allowed"), bool)
+        and isinstance(route, Mapping)
+        and isinstance(cast(Mapping[object, object], route).get("route"), str)
+        and isinstance(blocked, Sequence)
+        and not isinstance(blocked, (str, bytes, bytearray))
+        and all(isinstance(reason, str) for reason in cast(Sequence[object], blocked))
+    )
+
+
+def _valid_mutation_status(status: Mapping[str, object]) -> bool:
+    reason_codes = status.get("reason_codes")
+    return (
+        status.get("schema_version") == BROKER_MUTATION_RUNTIME_STATUS_SCHEMA_VERSION
+        and all(
+            isinstance(status.get(field), bool)
+            for field in (
+                "runtime_wired",
+                "entry_fencing_proven",
+                "reduction_fencing_proven",
+                "recovery_worker_wired",
+                "recovery_degraded",
+            )
+        )
+        and isinstance(reason_codes, Sequence)
+        and not isinstance(reason_codes, (str, bytes, bytearray))
+        and all(
+            isinstance(reason, str) for reason in cast(Sequence[object], reason_codes)
+        )
+    )
+
+
+def _mutation_authority_reasons(
+    status: Mapping[str, object],
+    *,
+    required_field: str,
+    fallback_reason: str,
+) -> tuple[str, ...]:
+    if not _valid_mutation_status(status):
+        return ("broker_mutation_status_contract_invalid",)
+    if status.get("runtime_wired") is True and status.get(required_field) is True:
+        return ()
+    return _strings(status.get("reason_codes")) or (fallback_reason,)
+
+
+def _mutation_recovery_reasons(
+    status: Mapping[str, object],
+) -> tuple[str, ...]:
+    if not _valid_mutation_status(status):
+        return ("broker_mutation_status_contract_invalid",)
+    if (
+        status.get("runtime_wired") is True
+        and status.get("recovery_worker_wired") is True
+        and status.get("recovery_degraded") is False
+    ):
+        return ()
+    return _strings(status.get("reason_codes")) or (
+        "broker_mutation_recovery_unproven",
+    )
+
+
+def _service_reason(service_status: Mapping[str, object]) -> str:
+    detail = service_status.get("detail")
+    if isinstance(detail, str) and detail.strip():
+        return detail.strip()
+    return "service_health_unavailable"
+
+
+def _mapping(value: object) -> Mapping[str, object]:
+    if isinstance(value, Mapping):
+        return cast(Mapping[str, object], value)
+    return {}
+
+
+def _strings(value: object) -> tuple[str, ...]:
+    if isinstance(value, str):
+        normalized = value.strip()
+        return (normalized,) if normalized else ()
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        return tuple(
+            normalized
+            for item in cast(Sequence[object], value)
+            if (normalized := str(item).strip())
+        )
+    return ()
+
+
+def _unique(values: Sequence[str]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(value for value in values if value))
+
+
+__all__ = [
+    "BROKER_MUTATION_RUNTIME_STATUS_SCHEMA_VERSION",
+    "OPERATIONAL_SUBMISSION_GATE_SCHEMA_VERSION",
+    "RUNTIME_ACTION_AUTHORITY_POLICY_REVISION",
+    "RUNTIME_ACTION_AUTHORITY_SCHEMA_VERSION",
+    "RuntimeActionAuthority",
+    "reduce_runtime_action_authority",
+]

--- a/services/torghut/app/trading/broker_mutation_receipts/runtime_status.py
+++ b/services/torghut/app/trading/broker_mutation_receipts/runtime_status.py
@@ -1,0 +1,35 @@
+"""Operator-visible code wiring status for broker-mutation safety."""
+
+from __future__ import annotations
+
+from ..action_authority import BROKER_MUTATION_RUNTIME_STATUS_SCHEMA_VERSION
+
+# The durable receipt package is deliberately isolated from every broker runtime.
+# These facts must change only in the PRs that wire and fault-prove those paths.
+BROKER_MUTATION_RUNTIME_WIRED = False
+BROKER_MUTATION_ENTRY_FENCING_PROVEN = False
+BROKER_MUTATION_REDUCTION_FENCING_PROVEN = False
+BROKER_MUTATION_RECOVERY_WORKER_WIRED = False
+
+
+def build_broker_mutation_runtime_status() -> dict[str, object]:
+    """Return current code wiring truth without adding status-path database load."""
+
+    return {
+        "schema_version": BROKER_MUTATION_RUNTIME_STATUS_SCHEMA_VERSION,
+        "runtime_wired": BROKER_MUTATION_RUNTIME_WIRED,
+        "entry_fencing_proven": BROKER_MUTATION_ENTRY_FENCING_PROVEN,
+        "reduction_fencing_proven": BROKER_MUTATION_REDUCTION_FENCING_PROVEN,
+        "recovery_worker_wired": BROKER_MUTATION_RECOVERY_WORKER_WIRED,
+        "recovery_degraded": True,
+        "reason_codes": ["broker_mutation_receipts_unwired"],
+    }
+
+
+__all__ = [
+    "BROKER_MUTATION_ENTRY_FENCING_PROVEN",
+    "BROKER_MUTATION_RECOVERY_WORKER_WIRED",
+    "BROKER_MUTATION_REDUCTION_FENCING_PROVEN",
+    "BROKER_MUTATION_RUNTIME_WIRED",
+    "build_broker_mutation_runtime_status",
+]

--- a/services/torghut/app/trading/evidence_contracts.py
+++ b/services/torghut/app/trading/evidence_contracts.py
@@ -12,6 +12,7 @@ class ArtifactProvenance(str, Enum):
     HISTORICAL_MARKET_REPLAY = "historical_market_replay"
     PAPER_RUNTIME_OBSERVED = "paper_runtime_observed"
     LIVE_RUNTIME_OBSERVED = "live_runtime_observed"
+    NON_PROMOTABLE_VALIDATION = "non_promotable_validation"
 
 
 class EvidenceMaturity(str, Enum):
@@ -22,6 +23,14 @@ class EvidenceMaturity(str, Enum):
 
 
 NON_AUTHORITATIVE_PROVENANCE: frozenset[ArtifactProvenance] = frozenset(
+    {
+        ArtifactProvenance.STRUCTURAL_PLACEHOLDER,
+        ArtifactProvenance.SYNTHETIC_GENERATED,
+        ArtifactProvenance.NON_PROMOTABLE_VALIDATION,
+    }
+)
+
+PLACEHOLDER_PROVENANCE: frozenset[ArtifactProvenance] = frozenset(
     {
         ArtifactProvenance.STRUCTURAL_PLACEHOLDER,
         ArtifactProvenance.SYNTHETIC_GENERATED,
@@ -39,15 +48,11 @@ def evidence_contract_payload(
     deviation_summary: Mapping[str, Any] | None = None,
     notes: str | None = None,
 ) -> dict[str, Any]:
-    resolved_authoritative = (
-        authoritative
-        if authoritative is not None
-        else provenance not in NON_AUTHORITATIVE_PROVENANCE
+    resolved_authoritative = provenance not in NON_AUTHORITATIVE_PROVENANCE and (
+        authoritative if authoritative is not None else True
     )
     resolved_placeholder = (
-        placeholder
-        if placeholder is not None
-        else provenance in NON_AUTHORITATIVE_PROVENANCE
+        placeholder if placeholder is not None else provenance in PLACEHOLDER_PROVENANCE
     )
     payload: dict[str, Any] = {
         "provenance": provenance.value,
@@ -69,11 +74,10 @@ def parse_evidence_contract(value: Any) -> dict[str, Any]:
     provenance = _coerce_provenance(payload.get("provenance"))
     maturity = _coerce_maturity(payload.get("maturity"))
     authoritative = bool(
-        payload.get("authoritative", provenance not in NON_AUTHORITATIVE_PROVENANCE)
+        provenance not in NON_AUTHORITATIVE_PROVENANCE
+        and payload.get("authoritative", True)
     )
-    placeholder = bool(
-        payload.get("placeholder", provenance in NON_AUTHORITATIVE_PROVENANCE)
-    )
+    placeholder = bool(payload.get("placeholder", provenance in PLACEHOLDER_PROVENANCE))
     normalized: dict[str, Any] = {
         "provenance": provenance.value,
         "maturity": maturity.value,
@@ -127,6 +131,7 @@ __all__ = [
     "ArtifactProvenance",
     "EvidenceMaturity",
     "NON_AUTHORITATIVE_PROVENANCE",
+    "PLACEHOLDER_PROVENANCE",
     "contract_from_artifact_payload",
     "evidence_contract_payload",
     "parse_evidence_contract",

--- a/services/torghut/app/trading/infrastructure_validation.py
+++ b/services/torghut/app/trading/infrastructure_validation.py
@@ -1,0 +1,172 @@
+"""Fail-closed schema for non-promotable broker infrastructure exercises."""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timedelta
+from decimal import Decimal
+from typing import Annotated, Literal
+
+from pydantic import (
+    AnyHttpUrl,
+    BaseModel,
+    ConfigDict,
+    Field,
+    StringConstraints,
+    field_validator,
+    model_validator,
+)
+
+_MAX_PERMIT_LIFETIME = timedelta(minutes=15)
+_VALIDATION_HOSTS = {
+    "alpaca": "paper-api.alpaca.markets",
+    "hyperliquid": "api.hyperliquid-testnet.xyz",
+}
+_Digest = Annotated[str, StringConstraints(pattern=r"^[0-9a-f]{64}$")]
+
+
+class InfrastructureValidationPermit(BaseModel):
+    """Short-lived authority that cannot target or generate live evidence."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal["torghut.infrastructure-validation-permit.v1"]
+    permit_id: Annotated[str, StringConstraints(min_length=1, max_length=128)]
+    purpose: Literal["control_plane_validation"]
+    venue: Literal["alpaca", "hyperliquid"]
+    account_mode: Literal["paper", "sandbox"]
+    market_session: Literal["regular", "continuous"]
+    account_label: Annotated[str, StringConstraints(min_length=1, max_length=128)]
+    broker_base_url: AnyHttpUrl
+    symbols: tuple[str, ...] = Field(min_length=1, max_length=20)
+    sides: tuple[Literal["buy", "sell"], ...] = Field(min_length=1, max_length=2)
+    order_types: tuple[Literal["market", "limit", "stop", "stop_limit"], ...] = Field(
+        min_length=1, max_length=4
+    )
+    max_orders: int = Field(gt=0, le=20)
+    max_outstanding_intents: int = Field(gt=0, le=20)
+    max_notional_usd: Decimal = Field(gt=0)
+    max_loss_usd: Decimal = Field(gt=0)
+    issued_by: Annotated[str, StringConstraints(min_length=1, max_length=128)]
+    approved_by: Annotated[str, StringConstraints(min_length=1, max_length=128)]
+    issued_at: datetime
+    expires_at: datetime
+    test_plan_digest: _Digest
+    expected_terminal_state: Literal["no_open_orders_no_positions_no_unsettled_claims"]
+    expected_terminal_state_digest: _Digest
+    evidence_tag: Literal["non_promotable_validation"]
+    promotable: Literal[False]
+
+    @field_validator("permit_id", "account_label", "issued_by", "approved_by")
+    @classmethod
+    def _normalize_required_text(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("validation_permit_required_text_empty")
+        return normalized
+
+    @field_validator("symbols")
+    @classmethod
+    def _normalize_symbols(cls, values: tuple[str, ...]) -> tuple[str, ...]:
+        normalized = tuple(value.strip().upper() for value in values)
+        if (
+            not normalized
+            or len(set(normalized)) != len(normalized)
+            or any(
+                re.fullmatch(r"[A-Z0-9][A-Z0-9.-]{0,31}", value) is None
+                for value in normalized
+            )
+        ):
+            raise ValueError("validation_symbols_must_be_unique_and_nonempty")
+        return normalized
+
+    @field_validator("sides", "order_types")
+    @classmethod
+    def _require_unique_bounds(cls, values: tuple[str, ...]) -> tuple[str, ...]:
+        if len(set(values)) != len(values):
+            raise ValueError("validation_permit_bounds_must_be_unique")
+        return values
+
+    @field_validator("max_notional_usd", "max_loss_usd")
+    @classmethod
+    def _require_finite_money_bound(cls, value: Decimal) -> Decimal:
+        if not value.is_finite():
+            raise ValueError("validation_permit_money_bound_must_be_finite")
+        return value
+
+    @model_validator(mode="after")
+    def _validate_safety_boundary(self) -> "InfrastructureValidationPermit":
+        if self.issued_at.tzinfo is None or self.expires_at.tzinfo is None:
+            raise ValueError("validation_permit_timestamps_must_be_timezone_aware")
+        lifetime = self.expires_at - self.issued_at
+        if lifetime <= timedelta(0) or lifetime > _MAX_PERMIT_LIFETIME:
+            raise ValueError("validation_permit_lifetime_out_of_bounds")
+        if self.issued_by.casefold() == self.approved_by.casefold():
+            raise ValueError("validation_permit_requires_independent_approval")
+        if self.max_outstanding_intents > self.max_orders:
+            raise ValueError("validation_permit_outstanding_exceeds_order_limit")
+        if self.max_loss_usd > self.max_notional_usd:
+            raise ValueError("validation_permit_loss_exceeds_notional")
+        expected_mode_and_session = {
+            "alpaca": ("paper", "regular"),
+            "hyperliquid": ("sandbox", "continuous"),
+        }[self.venue]
+        if (self.account_mode, self.market_session) != expected_mode_and_session:
+            raise ValueError("validation_permit_venue_boundary_mismatch")
+        _validate_endpoint(self.venue, str(self.broker_base_url))
+        return self
+
+
+def authorize_infrastructure_validation(
+    permit: InfrastructureValidationPermit,
+    *,
+    account_label: str,
+    account_mode: str,
+    broker_base_url: str,
+    now: datetime,
+) -> InfrastructureValidationPermit:
+    """Bind a validated permit to the exact configured non-live account."""
+
+    if now.tzinfo is None:
+        raise ValueError("infrastructure_validation_now_must_be_timezone_aware")
+    if now < permit.issued_at:
+        raise ValueError("infrastructure_validation_permit_not_yet_active")
+    if now >= permit.expires_at:
+        raise ValueError("infrastructure_validation_permit_expired")
+    if account_mode not in {"paper", "sandbox"} or account_mode != permit.account_mode:
+        raise ValueError("infrastructure_validation_account_mode_mismatch")
+    if account_label.strip() != permit.account_label:
+        raise ValueError("infrastructure_validation_account_mismatch")
+    _validate_endpoint(permit.venue, broker_base_url)
+    return permit
+
+
+def _validate_endpoint(venue: str, endpoint: str) -> None:
+    expected_host = _VALIDATION_HOSTS.get(venue)
+    parsed = _parse_endpoint(endpoint)
+    if expected_host is None or str(parsed.host or "").lower() != expected_host:
+        raise ValueError("infrastructure_validation_endpoint_not_sandbox")
+
+
+def _parse_endpoint(endpoint: str) -> AnyHttpUrl:
+    try:
+        parsed = AnyHttpUrl(endpoint)
+    except ValueError as exc:
+        raise ValueError("infrastructure_validation_endpoint_invalid") from exc
+    if (
+        parsed.scheme != "https"
+        or parsed.username
+        or parsed.password
+        or parsed.port != 443
+        or parsed.path != "/"
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ValueError("infrastructure_validation_endpoint_invalid")
+    return parsed
+
+
+__all__ = [
+    "InfrastructureValidationPermit",
+    "authorize_infrastructure_validation",
+]

--- a/services/torghut/app/trading/scheduler/runtime_health.py
+++ b/services/torghut/app/trading/scheduler/runtime_health.py
@@ -1,0 +1,183 @@
+"""Canonical scheduler liveness and Kubernetes readiness projections."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from ...config import settings
+from .runtime import TradingScheduler
+
+
+@dataclass(frozen=True, slots=True)
+class _SchedulerSuccessFreshness:
+    observed: bool
+    observed_at: datetime | None
+    age_seconds: float | None
+    is_fresh: bool
+
+
+def _scheduler_success_age_seconds(last_run_at: object) -> float | None:
+    if not isinstance(last_run_at, datetime):
+        return None
+    normalized = last_run_at
+    if normalized.tzinfo is None:
+        normalized = normalized.replace(tzinfo=timezone.utc)
+    return (datetime.now(timezone.utc) - normalized).total_seconds()
+
+
+def _scheduler_success_freshness(
+    last_success_at: object,
+) -> _SchedulerSuccessFreshness:
+    age_seconds = _scheduler_success_age_seconds(last_success_at)
+    return _SchedulerSuccessFreshness(
+        observed=last_success_at is not None,
+        observed_at=last_success_at if isinstance(last_success_at, datetime) else None,
+        age_seconds=age_seconds,
+        is_fresh=(
+            age_seconds is not None
+            and 0 <= age_seconds <= settings.trading_scheduler_success_max_age_seconds
+        ),
+    )
+
+
+def _scheduler_readiness_detail(
+    *,
+    running: bool,
+    trading_success: _SchedulerSuccessFreshness,
+    reconcile_success: _SchedulerSuccessFreshness,
+    cycle_failed: bool,
+    leadership_ok: bool,
+) -> str:
+    failed_conditions = (
+        (not running, "scheduler_not_running"),
+        (cycle_failed, "scheduler_cycle_failed"),
+        (not trading_success.observed, "scheduler_success_missing"),
+        (not trading_success.is_fresh, "scheduler_success_stale"),
+        (not reconcile_success.observed, "scheduler_reconcile_success_missing"),
+        (not reconcile_success.is_fresh, "scheduler_reconcile_success_stale"),
+        (not leadership_ok, "scheduler_leadership_unhealthy"),
+    )
+    return next(
+        (detail for failed, detail in failed_conditions if failed),
+        "ok",
+    )
+
+
+def scheduler_readiness_payload(scheduler: TradingScheduler) -> dict[str, object]:
+    """Require fresh trading and reconciliation success plus healthy leadership."""
+
+    state = scheduler.state
+    running = bool(getattr(state, "running", False))
+    loop_errors = {
+        "last_error": getattr(state, "last_error", None),
+        "last_trading_error": getattr(state, "last_trading_error", None),
+        "last_reconcile_error": getattr(state, "last_reconcile_error", None),
+        "last_autonomy_error": getattr(state, "last_autonomy_error", None),
+        "last_evidence_error": getattr(state, "last_evidence_error", None),
+    }
+    trading_success = _scheduler_success_freshness(getattr(state, "last_run_at", None))
+    reconcile_success = _scheduler_success_freshness(
+        getattr(state, "last_reconcile_at", None)
+    )
+    leadership = scheduler_liveness_payload(scheduler)
+    leadership_ok = bool(leadership["ok"])
+    cycle_failed = any(error is not None for error in loop_errors.values())
+    ready = (
+        running
+        and trading_success.is_fresh
+        and reconcile_success.is_fresh
+        and not cycle_failed
+        and leadership_ok
+    )
+    payload: dict[str, object] = {
+        "ok": ready,
+        "process_role": settings.process_role,
+        "running": running,
+        "detail": _scheduler_readiness_detail(
+            running=running,
+            trading_success=trading_success,
+            reconcile_success=reconcile_success,
+            cycle_failed=cycle_failed,
+            leadership_ok=leadership_ok,
+        ),
+        "success_max_age_seconds": settings.trading_scheduler_success_max_age_seconds,
+        "trading_success_is_fresh": trading_success.is_fresh,
+        "reconcile_success_is_fresh": reconcile_success.is_fresh,
+        "leadership": leadership.get("leadership"),
+    }
+    if trading_success.observed_at is not None:
+        payload["last_run_at"] = trading_success.observed_at.isoformat()
+    if trading_success.age_seconds is not None:
+        payload["success_age_seconds"] = trading_success.age_seconds
+        payload["trading_success_age_seconds"] = trading_success.age_seconds
+    if reconcile_success.observed_at is not None:
+        payload["last_reconcile_at"] = reconcile_success.observed_at.isoformat()
+    if reconcile_success.age_seconds is not None:
+        payload["reconcile_success_age_seconds"] = reconcile_success.age_seconds
+    for key, error in loop_errors.items():
+        if error is not None:
+            payload[key] = str(error)
+    return payload
+
+
+def scheduler_liveness_payload(scheduler: TradingScheduler) -> dict[str, object]:
+    """Require a healthy trading loop and leadership when trading is enabled."""
+
+    trading_enabled = bool(settings.trading_enabled)
+    running = bool(getattr(scheduler.state, "running", False))
+    leadership_status = getattr(scheduler, "leadership_status", None)
+    if callable(leadership_status):
+        leadership_status = leadership_status()
+    trading_payload = {
+        "enabled": trading_enabled,
+        "loop_required": trading_enabled,
+        "running": running,
+    }
+    if leadership_status is None:
+        if not trading_enabled:
+            return {
+                "ok": True,
+                "process_role": settings.process_role,
+                "detail": "trading_disabled",
+                "trading": trading_payload,
+            }
+        return {
+            "ok": False,
+            "process_role": settings.process_role,
+            "detail": "leadership_status_unavailable",
+            "trading": trading_payload,
+        }
+
+    required = bool(getattr(leadership_status, "required", True))
+    acquired = bool(getattr(leadership_status, "acquired", False))
+    healthy = bool(getattr(leadership_status, "healthy", False))
+    leadership_ok = healthy and (acquired or not required)
+    leadership_payload = {
+        "required": required,
+        "acquired": acquired,
+        "healthy": healthy,
+        "failure_reason": getattr(leadership_status, "failure_reason", None),
+    }
+    if not trading_enabled:
+        ok = True
+        detail = "trading_disabled"
+    elif not leadership_ok:
+        ok = False
+        detail = "scheduler_leadership_unhealthy"
+    elif not running:
+        ok = False
+        detail = "scheduler_loop_not_running"
+    else:
+        ok = True
+        detail = "ok"
+    return {
+        "ok": ok,
+        "process_role": settings.process_role,
+        "detail": detail,
+        "trading": trading_payload,
+        "leadership": leadership_payload,
+    }
+
+
+__all__ = ["scheduler_liveness_payload", "scheduler_readiness_payload"]

--- a/services/torghut/tests/api/test_trading_api_status_contract.py
+++ b/services/torghut/tests/api/test_trading_api_status_contract.py
@@ -42,8 +42,12 @@ class TestTradingApiStatusContract(TradingApiTestCaseBase):
                 return_value=freshness,
             ),
             patch(
-                "app.api.trading_status.build_api_live_submission_gate_payload",
+                "app.api.trading_status.build_live_submission_gate_payload",
                 return_value=gate,
+            ),
+            patch(
+                "app.api.trading_status.scheduler_readiness_payload",
+                return_value={"ok": True, "detail": "ok"},
             ),
             patch(
                 "app.api.trading_status._read_with_session",
@@ -82,6 +86,8 @@ class TestTradingApiStatusContract(TradingApiTestCaseBase):
                 "last_error",
                 "accepted_source_freshness",
                 "live_submission_gate",
+                "action_authority",
+                "broker_mutation_safety",
                 "capital_controls",
                 "execution",
                 "signal_continuity",
@@ -103,6 +109,9 @@ class TestTradingApiStatusContract(TradingApiTestCaseBase):
             "scheduler_startup_failed:SchedulerLeadershipError",
         )
         self.assertEqual(payload["live_submission_gate"], gate)
+        self.assertFalse(payload["action_authority"]["entry_allowed"])
+        self.assertFalse(payload["action_authority"]["reduce_only_allowed"])
+        self.assertFalse(payload["broker_mutation_safety"]["runtime_wired"])
         self.assertEqual(payload["capital_controls"]["gross_limit"], 4.0)
         self.assertEqual(payload["capital_controls"]["net_limit"], 0.5)
         self.assertEqual(payload["capital_controls"]["symbol_limit"], 0.5)

--- a/services/torghut/tests/api/trading_api_support.py
+++ b/services/torghut/tests/api/trading_api_support.py
@@ -67,9 +67,6 @@ _OPTIONS_CATALOG_FRESHNESS_CACHE = health_cache_state.OPTIONS_CATALOG_FRESHNESS_
 _TRADING_DEPENDENCY_HEALTH_CACHE = health_cache_state.TRADING_DEPENDENCY_HEALTH_CACHE
 _assert_dspy_cutover_migration_guard = app_bootstrap.assert_dspy_cutover_migration_guard
 _build_hypothesis_runtime_payload = health_checks_api.build_hypothesis_runtime_payload
-_build_live_submission_gate_payload = (
-    health_checks_api.build_api_live_submission_gate_payload
-)
 _check_alpaca = health_checks_api.check_alpaca_dependency
 _daily_runtime_ledger_portfolio_summary = daily_runtime_ledger_portfolio_summary
 _decimal_or_none = health_checks_api.decimal_or_none
@@ -697,7 +694,6 @@ __all__: tuple[str, ...] = (
     "_TimedOutBoundedOptionsFreshnessSession",
     "_assert_dspy_cutover_migration_guard",
     "_build_hypothesis_runtime_payload",
-    "_build_live_submission_gate_payload",
     "_check_alpaca",
     "_daily_runtime_ledger_portfolio_summary",
     "_decimal_or_none",

--- a/services/torghut/tests/live_config_manifest_contract/test_single_writer_scheduler_manifest.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_single_writer_scheduler_manifest.py
@@ -90,6 +90,10 @@ class SingleWriterSchedulerManifestTests(TestCase):
         )
         self.assertEqual(env["TORGHUT_PROCESS_ROLE"].get("value"), "scheduler")
         self.assertEqual(env["TRADING_ENABLED"].get("value"), "true")
+        self.assertEqual(
+            env["TRADING_NEW_EXPOSURE_CUTOFF_TIME_ET"].get("value"),
+            "00:00:00",
+        )
         self.assertEqual(env["TRADING_ORDER_MAX_ATTEMPTS"].get("value"), "1")
         self.assertEqual(env["TRADING_EXECUTION_MAX_RETRIES"].get("value"), "0")
         self.assertEqual(

--- a/services/torghut/tests/test_broker_mutation_runtime_status.py
+++ b/services/torghut/tests/test_broker_mutation_runtime_status.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from app.trading.broker_mutation_receipts.runtime_status import (
+    build_broker_mutation_runtime_status,
+)
+
+
+def test_unwired_runtime_reports_code_truth_without_overclaim() -> None:
+    payload = build_broker_mutation_runtime_status()
+
+    assert payload["runtime_wired"] is False
+    assert payload["entry_fencing_proven"] is False
+    assert payload["reduction_fencing_proven"] is False
+    assert payload["recovery_degraded"] is True
+    assert payload["schema_version"] == "torghut.broker-mutation-runtime-status.v1"
+    assert payload["reason_codes"] == ["broker_mutation_receipts_unwired"]

--- a/services/torghut/tests/test_capital_controls.py
+++ b/services/torghut/tests/test_capital_controls.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, time, timezone
 from decimal import Decimal
 from types import SimpleNamespace
 from unittest import TestCase
@@ -259,6 +259,32 @@ class TestCapitalSafetyController(TestCase):
 
         self.assertFalse(controller.state.capital_new_exposure_allowed)
         self.assertFalse(controller.state.emergency_stop_active)
+
+    def test_midnight_cutoff_freezes_entry_without_disabling_closeout_controller(
+        self,
+    ) -> None:
+        adapter = _ExecutionAdapter([])
+        controller = self._controller(adapter)
+        now = datetime(2026, 7, 10, 9, 30, tzinfo=ZoneInfo("America/New_York"))
+        risk = CapitalRiskSnapshot(
+            current_equity=Decimal("10000"),
+            daily_start_equity=Decimal("10000"),
+            high_water_equity=Decimal("10000"),
+            daily_loss_ratio=Decimal("0"),
+            drawdown_ratio=Decimal("0"),
+        )
+
+        with (
+            patch.object(controller, "_load_risk_snapshot", return_value=risk),
+            patch.object(settings, "trading_mode", "live"),
+            patch.object(settings, "trading_new_exposure_cutoff_time_et", time(0, 0)),
+        ):
+            controller.evaluate(SimpleNamespace(), SimpleNamespace(as_of=now))
+
+        self.assertFalse(controller.state.capital_new_exposure_allowed)
+        self.assertFalse(controller.state.emergency_stop_active)
+        self.assertEqual(adapter.cancel_calls, 0)
+        self.assertEqual(adapter.submissions, [])
 
     def test_closeout_uses_marketable_limit_and_confirms_flat(self) -> None:
         adapter = _ExecutionAdapter(

--- a/services/torghut/tests/test_infrastructure_validation_permit.py
+++ b/services/torghut/tests/test_infrastructure_validation_permit.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from app.trading.evidence_contracts import (
+    ArtifactProvenance,
+    EvidenceMaturity,
+    evidence_contract_payload,
+    parse_evidence_contract,
+)
+from app.trading.infrastructure_validation import (
+    InfrastructureValidationPermit,
+    authorize_infrastructure_validation,
+)
+
+
+_NOW = datetime(2026, 7, 14, 12, 0, tzinfo=timezone.utc)
+
+
+def _permit_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_version": "torghut.infrastructure-validation-permit.v1",
+        "permit_id": "ivp-20260714-001",
+        "purpose": "control_plane_validation",
+        "venue": "alpaca",
+        "account_mode": "paper",
+        "market_session": "regular",
+        "account_label": "dedicated-validation-paper",
+        "broker_base_url": "https://paper-api.alpaca.markets",
+        "symbols": ["AAPL"],
+        "sides": ["buy", "sell"],
+        "order_types": ["limit"],
+        "max_orders": 1,
+        "max_outstanding_intents": 1,
+        "max_notional_usd": "10",
+        "max_loss_usd": "1",
+        "issued_by": "infrastructure-owner",
+        "approved_by": "independent-infrastructure-owner",
+        "issued_at": _NOW,
+        "expires_at": _NOW + timedelta(minutes=5),
+        "test_plan_digest": "a" * 64,
+        "expected_terminal_state": "no_open_orders_no_positions_no_unsettled_claims",
+        "expected_terminal_state_digest": "b" * 64,
+        "evidence_tag": "non_promotable_validation",
+        "promotable": False,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_dedicated_paper_permit_is_short_lived_and_non_promotable() -> None:
+    permit = InfrastructureValidationPermit.model_validate(_permit_payload())
+
+    authorize_infrastructure_validation(
+        permit,
+        account_label="dedicated-validation-paper",
+        account_mode="paper",
+        broker_base_url="https://paper-api.alpaca.markets",
+        now=_NOW,
+    )
+    assert permit.promotable is False
+    assert permit.evidence_tag == "non_promotable_validation"
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"account_mode": "live"},
+        {"broker_base_url": "https://api.alpaca.markets"},
+        {"broker_base_url": "https://paper-api.alpaca.markets:444"},
+        {"broker_base_url": "https://paper-api.alpaca.markets/v2"},
+        {"broker_base_url": "https://paper-api.alpaca.markets?token=secret"},
+        {"market_session": "continuous"},
+        {"promotable": True},
+        {"evidence_tag": "paper_runtime_observed"},
+        {"approved_by": "infrastructure-owner"},
+        {"expires_at": _NOW + timedelta(hours=2)},
+        {"max_notional_usd": "Infinity"},
+        {"symbols": ["AAPL", "aapl"]},
+        {"symbols": ["AAPL", ""]},
+        {"sides": ["buy", "buy"]},
+        {"approved_by": "Infrastructure-Owner"},
+        {"max_orders": 1, "max_outstanding_intents": 2},
+    ],
+)
+def test_live_promotable_or_unbounded_permits_fail_schema_validation(
+    overrides: dict[str, object],
+) -> None:
+    with pytest.raises(ValidationError):
+        InfrastructureValidationPermit.model_validate(_permit_payload(**overrides))
+
+
+def test_runtime_binding_rejects_an_expired_or_different_account() -> None:
+    permit = InfrastructureValidationPermit.model_validate(_permit_payload())
+
+    with pytest.raises(ValueError, match="infrastructure_validation_permit_expired"):
+        authorize_infrastructure_validation(
+            permit,
+            account_label=permit.account_label,
+            account_mode="paper",
+            broker_base_url=str(permit.broker_base_url),
+            now=permit.expires_at,
+        )
+    with pytest.raises(ValueError, match="account_mismatch"):
+        authorize_infrastructure_validation(
+            permit,
+            account_label="some-other-paper-account",
+            account_mode="paper",
+            broker_base_url=str(permit.broker_base_url),
+            now=_NOW,
+        )
+
+
+def test_hyperliquid_permit_requires_the_testnet_boundary() -> None:
+    permit = InfrastructureValidationPermit.model_validate(
+        _permit_payload(
+            venue="hyperliquid",
+            account_mode="sandbox",
+            market_session="continuous",
+            broker_base_url="https://api.hyperliquid-testnet.xyz",
+        )
+    )
+
+    assert permit.venue == "hyperliquid"
+    assert permit.account_mode == "sandbox"
+
+
+def test_validation_provenance_is_non_authoritative() -> None:
+    contract = evidence_contract_payload(
+        provenance=ArtifactProvenance.NON_PROMOTABLE_VALIDATION,
+        maturity=EvidenceMaturity.EMPIRICALLY_VALIDATED,
+        authoritative=True,
+    )
+
+    assert contract["authoritative"] is False
+    assert contract["placeholder"] is False
+    assert (
+        parse_evidence_contract(
+            {
+                **contract,
+                "authoritative": True,
+            }
+        )["authoritative"]
+        is False
+    )

--- a/services/torghut/tests/test_promotion_truthfulness.py
+++ b/services/torghut/tests/test_promotion_truthfulness.py
@@ -66,10 +66,9 @@ class TestPromotionTruthfulness(TestCase):
                         "benchmark_parity": {
                             "artifact_ref": "gates/benchmark-parity-report-v1.json",
                             "artifact_authority": evidence_contract_payload(
-                                provenance=ArtifactProvenance.SYNTHETIC_GENERATED,
-                                maturity=EvidenceMaturity.STUB,
-                                authoritative=False,
-                                placeholder=True,
+                                provenance=ArtifactProvenance.NON_PROMOTABLE_VALIDATION,
+                                maturity=EvidenceMaturity.EMPIRICALLY_VALIDATED,
+                                authoritative=True,
                             ),
                         }
                     },

--- a/services/torghut/tests/test_runtime_action_authority.py
+++ b/services/torghut/tests/test_runtime_action_authority.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from app.trading.action_authority import reduce_runtime_action_authority
+
+
+_NOW = datetime(2026, 7, 14, 12, 0, tzinfo=timezone.utc)
+
+
+def _service(*, ok: bool = True, detail: str = "ok") -> dict[str, object]:
+    return {"ok": ok, "detail": detail}
+
+
+def _gate(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_version": "torghut.operational-submission-gate.v2",
+        "allowed": True,
+        "reason": "operational_submission_ready",
+        "blocked_reasons": [],
+        "new_exposure_allowed": True,
+        "execution_route": {
+            "route": "alpaca",
+            "reason": "alpaca_regular_session_open",
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _state(**overrides: object) -> SimpleNamespace:
+    payload: dict[str, object] = {
+        "capital_closeout_in_progress": False,
+        "emergency_stop_active": False,
+    }
+    payload.update(overrides)
+    return SimpleNamespace(**payload)
+
+
+def _mutation_status(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_version": "torghut.broker-mutation-runtime-status.v1",
+        "runtime_wired": True,
+        "entry_fencing_proven": True,
+        "reduction_fencing_proven": True,
+        "recovery_worker_wired": True,
+        "recovery_degraded": False,
+        "reason_codes": [],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_capital_freeze_separates_service_entry_and_reduction_authority() -> None:
+    authority = reduce_runtime_action_authority(
+        service_status=_service(),
+        live_submission_gate=_gate(new_exposure_allowed=False),
+        broker_mutation_status=_mutation_status(),
+        state=_state(),
+        evaluated_at=_NOW,
+    )
+
+    assert authority.service_healthy is True
+    assert authority.entry_allowed is False
+    assert authority.reduce_only_allowed is True
+    assert authority.recovery_degraded is False
+    assert authority.reason_codes["entry"] == ("new_exposure_cutoff_active",)
+    assert authority.evaluated_at == _NOW
+
+
+def test_entry_data_blocker_does_not_disable_reduction_authority() -> None:
+    authority = reduce_runtime_action_authority(
+        service_status=_service(),
+        live_submission_gate=_gate(
+            allowed=False,
+            reason="accepted_ta_signal_stale",
+            blocked_reasons=["accepted_ta_signal_stale"],
+        ),
+        broker_mutation_status=_mutation_status(),
+        state=_state(),
+        evaluated_at=_NOW,
+    )
+
+    assert authority.entry_allowed is False
+    assert authority.reduce_only_allowed is True
+    assert authority.reason_codes["entry"] == ("accepted_ta_signal_stale",)
+    assert authority.reason_codes["reduce_only"] == ()
+
+
+def test_global_submission_switch_blocks_reduction_authority() -> None:
+    authority = reduce_runtime_action_authority(
+        service_status=_service(),
+        live_submission_gate=_gate(
+            allowed=False,
+            reason="submit_disabled",
+            blocked_reasons=["submit_disabled"],
+        ),
+        broker_mutation_status=_mutation_status(),
+        state=_state(),
+        evaluated_at=_NOW,
+    )
+
+    assert authority.entry_allowed is False
+    assert authority.reduce_only_allowed is False
+    assert authority.reason_codes["reduce_only"] == ("submit_disabled",)
+
+
+def test_missing_or_malformed_gate_fails_closed() -> None:
+    authority = reduce_runtime_action_authority(
+        service_status=_service(),
+        live_submission_gate={"allowed": True},
+        broker_mutation_status=_mutation_status(),
+        state=_state(),
+        evaluated_at=_NOW,
+    )
+
+    assert authority.service_healthy is True
+    assert authority.entry_allowed is False
+    assert authority.reduce_only_allowed is False
+    assert authority.reason_codes["entry"] == ("live_submission_gate_contract_invalid",)
+
+
+def test_unhealthy_service_blocks_actions_and_marks_recovery_degraded() -> None:
+    authority = reduce_runtime_action_authority(
+        service_status=_service(ok=False, detail="scheduler_reconcile_success_stale"),
+        live_submission_gate=_gate(),
+        broker_mutation_status=_mutation_status(),
+        state=_state(),
+        evaluated_at=_NOW,
+    )
+
+    assert authority.service_healthy is False
+    assert authority.entry_allowed is False
+    assert authority.reduce_only_allowed is False
+    assert authority.recovery_degraded is True
+    assert authority.reason_codes["service"] == ("scheduler_reconcile_success_stale",)
+
+
+def test_emergency_stop_preserves_reduction_but_requires_recovery() -> None:
+    authority = reduce_runtime_action_authority(
+        service_status=_service(),
+        live_submission_gate=_gate(
+            allowed=False,
+            reason="emergency_stop_active",
+            blocked_reasons=["emergency_stop_active"],
+            new_exposure_allowed=False,
+        ),
+        broker_mutation_status=_mutation_status(),
+        state=_state(emergency_stop_active=True),
+        evaluated_at=_NOW,
+    )
+
+    assert authority.entry_allowed is False
+    assert authority.reduce_only_allowed is True
+    assert authority.recovery_degraded is True
+    assert authority.reason_codes["recovery"] == ("emergency_stop_active",)
+
+
+def test_unwired_mutation_runtime_cannot_claim_entry_or_reduction_safety() -> None:
+    authority = reduce_runtime_action_authority(
+        service_status=_service(),
+        live_submission_gate=_gate(),
+        broker_mutation_status=_mutation_status(
+            runtime_wired=False,
+            entry_fencing_proven=False,
+            reduction_fencing_proven=False,
+            recovery_worker_wired=False,
+            recovery_degraded=True,
+            reason_codes=["broker_mutation_receipts_unwired"],
+        ),
+        state=_state(),
+        evaluated_at=_NOW,
+    )
+
+    assert authority.service_healthy is True
+    assert authority.entry_allowed is False
+    assert authority.reduce_only_allowed is False
+    assert authority.recovery_degraded is True
+    assert authority.reason_codes["entry"] == ("broker_mutation_receipts_unwired",)
+    assert authority.reason_codes["reduce_only"] == (
+        "broker_mutation_receipts_unwired",
+    )
+
+
+def test_unwired_runtime_cannot_enable_actions_with_incoherent_fencing_flags() -> None:
+    authority = reduce_runtime_action_authority(
+        service_status=_service(),
+        live_submission_gate=_gate(),
+        broker_mutation_status=_mutation_status(
+            runtime_wired=False,
+            entry_fencing_proven=True,
+            reduction_fencing_proven=True,
+            reason_codes=[],
+        ),
+        state=_state(),
+        evaluated_at=_NOW,
+    )
+
+    assert authority.entry_allowed is False
+    assert authority.reduce_only_allowed is False
+    assert authority.reason_codes["entry"] == (
+        "broker_mutation_entry_fencing_unproven",
+    )


### PR DESCRIPTION
## Summary

- make the P0 capital hold explicit in GitOps by moving the live new-exposure cutoff to midnight while preserving the scheduler, reconciliation, cancellation, and closeout paths
- publish one fail-closed action-authority reducer with independent service, entry, reduce-only, and recovery projections, plus truthful broker-mutation wiring status
- add a short-lived paper/sandbox-only InfrastructureValidationPermit and force its evidence provenance to remain non-authoritative and non-promotable
- remove the duplicate live-gate wrapper chain, a zero-caller fallback payload, and status-path database work; extract the existing scheduler probe logic as the canonical shared health projection

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `.venv/bin/pytest -q tests/api` (39 passed)
- `.venv/bin/pytest -q tests/submission_council tests/test_runtime_action_authority.py tests/test_infrastructure_validation_permit.py tests/test_broker_mutation_runtime_status.py tests/test_broker_mutation_receipts_unwired.py tests/test_capital_controls.py tests/test_promotion_truthfulness.py tests/test_process_roles.py tests/live_config_manifest_contract/test_single_writer_scheduler_manifest.py` (162 passed)
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --name-only origin/main...HEAD -- 'services/torghut/**/*.py' | xargs services/torghut/.venv/bin/ruff check`
- `bash scripts/kubeconform.sh argocd/applications/torghut/knative-service.yaml argocd/applications/torghut/scheduler-deployment.yaml`
- live read-only proof: CNPG was healthy; receipt, receipt-event, and submission-claim tables were empty; scheduler readiness returned 200 on the deployed pre-change digest

## Breaking Changes

Risk-increasing live strategy decisions are intentionally rejected by the P0 capital hold until the roadmap's mutation, reconciliation, and promotion gates are proven. Scheduler health, reconciliation, cancellation, and closeout execution remain enabled.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
