### PR TITLE
fix(temporal): migrate marker Nexus ids

### DIFF
--- a/packages/temporal-bun-sdk/src/worker/runtime.ts
+++ b/packages/temporal-bun-sdk/src/worker/runtime.ts
@@ -67,7 +67,6 @@ import type {
   NexusOperationCanceledEventAttributes,
   NexusOperationCompletedEventAttributes,
   NexusOperationFailedEventAttributes,
-  NexusOperationScheduledEventAttributes,
   NexusOperationTimedOutEventAttributes,
   WorkflowExecutionSignaledEventAttributes,
 } from '../proto/temporal/api/history/v1/message_pb'
@@ -123,6 +122,7 @@ import {
   encodeDeterminismMarkerDetailsWithSize,
   ingestWorkflowHistory,
   type ReplayResult,
+  resolveNexusOperationHistoryIdentities,
   resolveHistoryLastEventId,
 } from '../workflow/replay'
 import { type ActivityContext, type ActivityInfo, runWithActivityContext } from './activity-context'
@@ -1433,8 +1433,13 @@ export class WorkerRuntime {
     try {
       const { results: activityResults, scheduledEventIds: activityScheduleEventIds } =
         await this.#extractActivityResolutions(historyEvents)
-      const { results: nexusResults, scheduledEventIds: nexusScheduleEventIds } =
-        await this.#extractNexusResolutions(historyEvents)
+      const { results: nexusResults, scheduledEventIds: nexusScheduleEventIds } = await this.#extractNexusResolutions(
+        historyEvents,
+        {
+          markerState: historyReplay?.hasDeterminismMarker ? historyReplay.determinismState : undefined,
+          knownScheduleEventIds: stickyEntry?.nexusScheduleEventIds,
+        },
+      )
       const timerResults = await this.#extractTimerResolutions(historyEvents)
       const mergedActivityResults = new Map<string, ActivityResolution>(stickyEntry?.activityResults ?? [])
       for (const [activityId, resolution] of activityResults.entries()) {
@@ -2107,13 +2112,20 @@ export class WorkerRuntime {
     return { results: resolutions, scheduledEventIds: activityScheduleById }
   }
 
-  async #extractNexusResolutions(events: HistoryEvent[]): Promise<{
+  async #extractNexusResolutions(
+    events: HistoryEvent[],
+    identityOptions: {
+      markerState?: WorkflowDeterminismState
+      knownScheduleEventIds?: ReadonlyMap<string, string>
+    } = {},
+  ): Promise<{
     results: Map<string, NexusOperationResolution>
     scheduledEventIds: Map<string, string>
   }> {
     const resolutions = new Map<string, NexusOperationResolution>()
-    const scheduledOperationIds = new Map<string, string>()
-    const operationScheduleById = new Map<string, string>()
+    const identities = resolveNexusOperationHistoryIdentities(events, identityOptions)
+    const scheduledOperationIds = identities.operationIdsByScheduledEventId
+    const operationScheduleById = identities.scheduledEventIdsByOperationId
 
     const normalizeEventId = (value: bigint | number | string | undefined | null): string | undefined => {
       if (value === undefined || value === null) {
@@ -2142,22 +2154,8 @@ export class WorkerRuntime {
 
     for (const event of events) {
       switch (event.eventType) {
-        case EventType.NEXUS_OPERATION_SCHEDULED: {
-          if (event.attributes?.case !== 'nexusOperationScheduledEventAttributes') {
-            break
-          }
-          const attrs = event.attributes.value as NexusOperationScheduledEventAttributes
-          const scheduledKey = normalizeEventId(event.eventId)
-          if (!scheduledKey) {
-            break
-          }
-          const operationId = resolveOperationId(attrs, event.eventId)
-          if (operationId) {
-            scheduledOperationIds.set(scheduledKey, operationId)
-            operationScheduleById.set(operationId, scheduledKey)
-          }
+        case EventType.NEXUS_OPERATION_SCHEDULED:
           break
-        }
         case EventType.NEXUS_OPERATION_COMPLETED: {
           if (event.attributes?.case !== 'nexusOperationCompletedEventAttributes') {
             break
@@ -2222,7 +2220,10 @@ export class WorkerRuntime {
       }
     }
 
-    return { results: resolutions, scheduledEventIds: operationScheduleById }
+    return {
+      results: resolutions,
+      scheduledEventIds: new Map(operationScheduleById),
+    }
   }
 
   async #extractSignalDeliveries(events: HistoryEvent[]): Promise<WorkflowSignalDeliveryInput[]> {

--- a/packages/temporal-bun-sdk/src/worker/runtime.ts
+++ b/packages/temporal-bun-sdk/src/worker/runtime.ts
@@ -141,6 +141,7 @@ import {
 } from './plugins'
 import {
   makeStickyCache,
+  resolveStickyNexusScheduleEventIds,
   type StickyCache,
   type StickyCacheEntry,
   type StickyCacheHooks,
@@ -1382,12 +1383,14 @@ export class WorkerRuntime {
     })
     const hasHistorySnapshot = this.#isValidDeterminismSnapshot(historyReplay?.determinismState)
     let previousState: WorkflowDeterminismState | undefined
+    let stickyCacheMatchesHistory = false
 
     if (stickyEntry && this.#isValidDeterminismSnapshot(stickyEntry.determinismState)) {
       const historyBaselineEventId = this.#resolvePreviousHistoryEventId(response) ?? historyReplay?.lastEventId ?? null
       const cacheMatchesHistory = (stickyEntry.lastEventId ?? null) === historyBaselineEventId
 
       if (cacheMatchesHistory) {
+        stickyCacheMatchesHistory = true
         previousState = stickyEntry.determinismState
         this.#log('debug', 'sticky cache hit', {
           ...baseLogFields,
@@ -1429,6 +1432,7 @@ export class WorkerRuntime {
     }
 
     const expectedDeterminismState = previousState
+    const stickyNexusScheduleEventIds = resolveStickyNexusScheduleEventIds(stickyEntry, stickyCacheMatchesHistory)
 
     try {
       const { results: activityResults, scheduledEventIds: activityScheduleEventIds } =
@@ -1437,7 +1441,7 @@ export class WorkerRuntime {
         historyEvents,
         {
           markerState: historyReplay?.hasDeterminismMarker ? historyReplay.determinismState : undefined,
-          knownScheduleEventIds: stickyEntry?.nexusScheduleEventIds,
+          knownScheduleEventIds: stickyNexusScheduleEventIds,
         },
       )
       const timerResults = await this.#extractTimerResolutions(historyEvents)
@@ -1453,7 +1457,7 @@ export class WorkerRuntime {
       for (const [activityId, scheduleId] of activityScheduleEventIds.entries()) {
         mergedScheduleEventIds.set(activityId, scheduleId)
       }
-      const mergedNexusScheduleEventIds = new Map<string, string>(stickyEntry?.nexusScheduleEventIds ?? [])
+      const mergedNexusScheduleEventIds = new Map<string, string>(stickyNexusScheduleEventIds ?? [])
       for (const [operationId, scheduleId] of nexusScheduleEventIds.entries()) {
         mergedNexusScheduleEventIds.set(operationId, scheduleId)
       }

--- a/packages/temporal-bun-sdk/src/worker/sticky-cache.ts
+++ b/packages/temporal-bun-sdk/src/worker/sticky-cache.ts
@@ -60,6 +60,11 @@ export interface StickyCacheHooks {
   readonly onEvict?: (entry: StickyCacheEntry, reason: StickyCacheEvictionReason) => Effect.Effect<void, never, never>
 }
 
+export const resolveStickyNexusScheduleEventIds = (
+  entry: StickyCacheEntry | undefined,
+  cacheMatchesHistory: boolean,
+): ReadonlyMap<string, string> | undefined => (cacheMatchesHistory ? entry?.nexusScheduleEventIds : undefined)
+
 type StickyCacheLookupResult =
   | { readonly kind: 'miss' }
   | { readonly kind: 'expired'; readonly entry: StickyCacheEntry }

--- a/packages/temporal-bun-sdk/src/workflow/determinism.ts
+++ b/packages/temporal-bun-sdk/src/workflow/determinism.ts
@@ -371,10 +371,23 @@ const DEFAULT_WORKFLOW_EXECUTION_TIMEOUT_MS = 0
 const DEFAULT_WORKFLOW_ID_REUSE_POLICY = WorkflowIdReusePolicy.ALLOW_DUPLICATE
 const DEFAULT_PARENT_CLOSE_POLICY = ParentClosePolicy.TERMINATE
 
+const normalizeRequestCancelNexusOperationIntent = (intent: WorkflowCommandIntent): WorkflowCommandIntent => {
+  if (intent.kind !== 'request-cancel-nexus-operation' || intent.scheduledEventId === undefined) {
+    return intent
+  }
+  return {
+    ...intent,
+    id: `request-cancel-nexus-operation-${intent.sequence}`,
+    operationId: `nexus-${intent.scheduledEventId}`,
+  }
+}
+
 const normalizeIntentForComparison = (intent: WorkflowCommandIntent): WorkflowCommandIntent => {
   switch (intent.kind) {
     case 'schedule-activity':
       return normalizeScheduleActivityIntent(intent)
+    case 'request-cancel-nexus-operation':
+      return normalizeRequestCancelNexusOperationIntent(intent)
     case 'start-child-workflow':
       return normalizeStartChildWorkflowIntent(intent)
     default:

--- a/packages/temporal-bun-sdk/src/workflow/replay.ts
+++ b/packages/temporal-bun-sdk/src/workflow/replay.ts
@@ -1065,9 +1065,9 @@ export const resolveNexusOperationHistoryIdentities = (
     }
     const operationId =
       event.attributes.value.nexusHeader?.[NEXUS_OPERATION_ID_HEADER] ??
-      operationIdsByScheduledEventId.get(scheduledEventId) ??
       markerOperationIdByEvent ??
       markerOperationIdByOrder ??
+      operationIdsByScheduledEventId.get(scheduledEventId) ??
       `nexus-${scheduledEventId}`
 
     operationIdsByScheduledEventId.set(scheduledEventId, operationId)

--- a/packages/temporal-bun-sdk/src/workflow/replay.ts
+++ b/packages/temporal-bun-sdk/src/workflow/replay.ts
@@ -338,7 +338,8 @@ export const ingestWorkflowHistory = (intake: ReplayIntake): Effect.Effect<Repla
     const extractedFailureMetadata = extractFailureMetadata(events)
     const historyLastEventId = resolveHistoryLastEventId(events) ?? null
     if (shouldUseDeterminismMarker && hasMarker && !markerInvalid && markerState && markerEventIndex !== null) {
-      const historyKinds = collectCommandKinds(events.slice(0, markerEventIndex + 1))
+      const markerHistory = events.slice(0, markerEventIndex + 1)
+      const historyKinds = collectCommandKinds(markerHistory)
       const markerKinds = markerState.commandHistory.map((entry) => entry.intent.kind)
       if (!commandKindsMatch(markerKinds, historyKinds)) {
         markerInvalid = true
@@ -990,6 +991,93 @@ const commandKindsMatch = (
     }
   }
   return true
+}
+
+export interface NexusOperationHistoryIdentities {
+  readonly operationIdsByScheduledEventId: ReadonlyMap<string, string>
+  readonly scheduledEventIdsByOperationId: ReadonlyMap<string, string>
+}
+
+export interface ResolveNexusOperationHistoryIdentitiesOptions {
+  readonly markerState?: WorkflowDeterminismState
+  readonly knownScheduleEventIds?: ReadonlyMap<string, string>
+}
+
+export const resolveNexusOperationHistoryIdentities = (
+  events: readonly HistoryEvent[],
+  options: ResolveNexusOperationHistoryIdentitiesOptions = {},
+): NexusOperationHistoryIdentities => {
+  const operationIdsByScheduledEventId = new Map<string, string>()
+  const scheduledEventIdsByOperationId = new Map<string, string>()
+
+  for (const [operationId, scheduledEventId] of options.knownScheduleEventIds ?? []) {
+    operationIdsByScheduledEventId.set(scheduledEventId, operationId)
+    scheduledEventIdsByOperationId.set(operationId, scheduledEventId)
+  }
+
+  const markerSchedules =
+    options.markerState?.commandHistory.filter(
+      (entry): entry is WorkflowCommandHistoryEntry & { intent: ScheduleNexusOperationCommandIntent } =>
+        entry.intent.kind === 'schedule-nexus-operation',
+    ) ?? []
+  const markerOperationIdsByScheduledEventId = new Map<string, string>()
+  for (const entry of markerSchedules) {
+    const eventId = normalizeEventId(entry.metadata?.eventId)
+    if (eventId) {
+      markerOperationIdsByScheduledEventId.set(eventId, entry.intent.operationId)
+    }
+  }
+  let markerEventIndex = -1
+  for (let index = 0; index < events.length; index += 1) {
+    const event = events[index]
+    if (
+      event?.eventType === EventType.MARKER_RECORDED &&
+      event.attributes?.case === 'markerRecordedEventAttributes' &&
+      event.attributes.value.markerName === DETERMINISM_MARKER_NAME
+    ) {
+      markerEventIndex = index
+    }
+  }
+  let markerScheduleIndex = 0
+
+  for (let eventIndex = 0; eventIndex < events.length; eventIndex += 1) {
+    const event = events[eventIndex]
+    if (
+      !event ||
+      event.eventType !== EventType.NEXUS_OPERATION_SCHEDULED ||
+      event.attributes?.case !== 'nexusOperationScheduledEventAttributes'
+    ) {
+      continue
+    }
+
+    const scheduledEventId = normalizeEventId(event.eventId)
+    if (!scheduledEventId) {
+      continue
+    }
+
+    const markerOperationIdByEvent = markerOperationIdsByScheduledEventId.get(scheduledEventId)
+    const markerOperationIdByOrder =
+      markerEventIndex >= 0 && eventIndex < markerEventIndex
+        ? markerSchedules[markerScheduleIndex]?.intent.operationId
+        : undefined
+    if (markerEventIndex >= 0 && eventIndex < markerEventIndex) {
+      markerScheduleIndex += 1
+    }
+    const operationId =
+      event.attributes.value.nexusHeader?.[NEXUS_OPERATION_ID_HEADER] ??
+      operationIdsByScheduledEventId.get(scheduledEventId) ??
+      markerOperationIdByEvent ??
+      markerOperationIdByOrder ??
+      `nexus-${scheduledEventId}`
+
+    operationIdsByScheduledEventId.set(scheduledEventId, operationId)
+    scheduledEventIdsByOperationId.set(operationId, scheduledEventId)
+  }
+
+  return {
+    operationIdsByScheduledEventId,
+    scheduledEventIdsByOperationId,
+  }
 }
 
 const collectCommandKinds = (events: readonly HistoryEvent[]): WorkflowCommandKind[] => {

--- a/packages/temporal-bun-sdk/tests/worker.sticky-cache.test.ts
+++ b/packages/temporal-bun-sdk/tests/worker.sticky-cache.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from 'bun:test'
 import { Effect } from 'effect'
 
-import { makeStickyCache } from '../src/worker/sticky-cache'
+import { makeStickyCache, resolveStickyNexusScheduleEventIds } from '../src/worker/sticky-cache'
 import type { WorkflowDeterminismState } from '../src/workflow/determinism'
 
 const EMPTY_STATE: WorkflowDeterminismState = {
@@ -11,6 +11,20 @@ const EMPTY_STATE: WorkflowDeterminismState = {
   signals: [],
   queries: [],
 }
+
+test('sticky Nexus aliases are accepted only when the cache matches history', () => {
+  const nexusScheduleEventIds = new Map([['stale-operation-id', '42']])
+  const entry = {
+    key: { namespace: 'default', workflowId: 'wf-nexus', runId: 'run-nexus' },
+    determinismState: EMPTY_STATE,
+    lastEventId: '41',
+    lastAccessed: Date.now(),
+    nexusScheduleEventIds,
+  }
+
+  expect(resolveStickyNexusScheduleEventIds(entry, true)).toBe(nexusScheduleEventIds)
+  expect(resolveStickyNexusScheduleEventIds(entry, false)).toBeUndefined()
+})
 
 const makeFakeCounter = () => {
   let value = 0

--- a/packages/temporal-bun-sdk/tests/workflow/primitives.test.ts
+++ b/packages/temporal-bun-sdk/tests/workflow/primitives.test.ts
@@ -192,6 +192,24 @@ test('Nexus schedule defaults reuse headerless replay operation ids', async () =
   }
 })
 
+test('intentsEqual compares Nexus cancels by scheduled event when available', () => {
+  const expected = {
+    id: 'request-cancel-nexus-operation-1',
+    kind: 'request-cancel-nexus-operation',
+    sequence: 1,
+    operationId: 'nexus-0',
+    scheduledEventId: '42',
+  } as const
+  const actual = {
+    ...expected,
+    id: 'cancel-nexus-operation-1',
+    operationId: 'nexus-42',
+  }
+
+  expect(intentsEqual(expected, actual)).toBe(true)
+  expect(intentsEqual(expected, { ...actual, scheduledEventId: '43' })).toBe(false)
+})
+
 test('intentsEqual normalizes activity timeout defaults', () => {
   const expected = {
     id: 'schedule-activity-0',

--- a/packages/temporal-bun-sdk/tests/workflow/replay.test.ts
+++ b/packages/temporal-bun-sdk/tests/workflow/replay.test.ts
@@ -1157,6 +1157,60 @@ test('resolveNexusOperationHistoryIdentities aliases headerless events to persis
   expect(identities.scheduledEventIdsByOperationId.get('nexus-0')).toBe('42')
 })
 
+test('resolveNexusOperationHistoryIdentities ignores drifted sticky aliases when marker identity is available', () => {
+  const scheduledEvent = create(HistoryEventSchema, {
+    eventId: 42n,
+    eventType: EventType.NEXUS_OPERATION_SCHEDULED,
+    attributes: {
+      case: 'nexusOperationScheduledEventAttributes',
+      value: create(NexusOperationScheduledEventAttributesSchema, {
+        endpoint: 'payments',
+        service: 'billing',
+        operation: 'charge',
+      }),
+    },
+  })
+  const markerState: WorkflowDeterminismState = {
+    commandHistory: [
+      {
+        intent: {
+          id: 'schedule-nexus-operation-0',
+          kind: 'schedule-nexus-operation',
+          sequence: 0,
+          endpoint: 'payments',
+          service: 'billing',
+          operation: 'charge',
+          operationId: 'marker-operation-id',
+          nexusHeader: {},
+        },
+      },
+    ],
+    randomValues: [],
+    timeValues: [],
+    signals: [],
+    queries: [],
+  }
+  const markerEvent = create(HistoryEventSchema, {
+    eventId: 43n,
+    eventType: EventType.MARKER_RECORDED,
+    attributes: {
+      case: 'markerRecordedEventAttributes',
+      value: create(MarkerRecordedEventAttributesSchema, {
+        markerName: DETERMINISM_MARKER_NAME,
+      }),
+    },
+  })
+  const knownScheduleEventIds = new Map([['stale-sticky-operation-id', '42']])
+
+  const identities = resolveNexusOperationHistoryIdentities([scheduledEvent, markerEvent], {
+    markerState,
+    knownScheduleEventIds,
+  })
+
+  expect(identities.operationIdsByScheduledEventId.get('42')).toBe('marker-operation-id')
+  expect(identities.scheduledEventIdsByOperationId.get('marker-operation-id')).toBe('42')
+})
+
 test('ingestWorkflowHistory preserves explicit marker-backed Nexus operation IDs', async () => {
   const converter = createDefaultDataConverter()
   const info: WorkflowInfo = {

--- a/packages/temporal-bun-sdk/tests/workflow/replay.test.ts
+++ b/packages/temporal-bun-sdk/tests/workflow/replay.test.ts
@@ -6,11 +6,13 @@ import { createDefaultDataConverter, encodeValuesToPayloads } from '../../src/co
 import type { WorkflowInfo } from '../../src/workflow/context'
 import type { WorkflowDeterminismState } from '../../src/workflow/determinism'
 import {
+  DETERMINISM_MARKER_NAME,
   decodeDeterminismMarkerEnvelope,
   diffDeterminismState,
   encodeDeterminismMarkerDetails,
   encodeDeterminismMarkerDetailsWithSize,
   ingestWorkflowHistory,
+  resolveNexusOperationHistoryIdentities,
   resolveHistoryLastEventId,
 } from '../../src/workflow/replay'
 import type { DeterminismMismatchCommand, DeterminismStateDelta } from '../../src/workflow/replay'
@@ -19,6 +21,7 @@ import {
   ActivityTaskCancelRequestedEventAttributesSchema,
   HistoryEventSchema,
   MarkerRecordedEventAttributesSchema,
+  NexusOperationCancelRequestedEventAttributesSchema,
   NexusOperationScheduledEventAttributesSchema,
   SignalExternalWorkflowExecutionInitiatedEventAttributesSchema,
   StartChildWorkflowExecutionInitiatedEventAttributesSchema,
@@ -1001,6 +1004,235 @@ test('ingestWorkflowHistory derives Nexus fallback operation IDs from the schedu
   const intent = replay.determinismState.commandHistory[0]?.intent
   expect(intent?.kind).toBe('schedule-nexus-operation')
   expect(intent?.kind === 'schedule-nexus-operation' ? intent.operationId : null).toBe('nexus-42')
+})
+
+test('ingestWorkflowHistory preserves ambiguous marker-backed headerless Nexus operation IDs', async () => {
+  const converter = createDefaultDataConverter()
+  const info: WorkflowInfo = {
+    namespace: 'default',
+    taskQueue: 'replay-fixtures',
+    workflowId: 'wf-nexus-marker-fallback',
+    runId: 'run-nexus-marker-fallback',
+    workflowType: 'nexusWorkflow',
+  }
+  const determinismState: WorkflowDeterminismState = {
+    commandHistory: [
+      {
+        intent: {
+          id: 'schedule-nexus-operation-0',
+          kind: 'schedule-nexus-operation',
+          sequence: 0,
+          endpoint: 'payments',
+          service: 'billing',
+          operation: 'charge',
+          operationId: 'nexus-0',
+          nexusHeader: {},
+        },
+      },
+      {
+        intent: {
+          id: 'request-cancel-nexus-operation-1',
+          kind: 'request-cancel-nexus-operation',
+          sequence: 1,
+          operationId: 'nexus-0',
+          scheduledEventId: '42',
+        },
+      },
+    ],
+    randomValues: [],
+    timeValues: [],
+    signals: [],
+    queries: [],
+  }
+  const details = await Effect.runPromise(
+    encodeDeterminismMarkerDetails(converter, {
+      info,
+      determinismState,
+      lastEventId: '44',
+      recordedAt: new Date('2026-07-14T00:00:00Z'),
+    }),
+  )
+  const scheduledEvent = create(HistoryEventSchema, {
+    eventId: 42n,
+    eventType: EventType.NEXUS_OPERATION_SCHEDULED,
+    attributes: {
+      case: 'nexusOperationScheduledEventAttributes',
+      value: create(NexusOperationScheduledEventAttributesSchema, {
+        endpoint: 'payments',
+        service: 'billing',
+        operation: 'charge',
+      }),
+    },
+  })
+  const markerEvent = create(HistoryEventSchema, {
+    eventId: 44n,
+    eventType: EventType.MARKER_RECORDED,
+    attributes: {
+      case: 'markerRecordedEventAttributes',
+      value: create(MarkerRecordedEventAttributesSchema, {
+        markerName: 'temporal-bun-sdk/determinism',
+        details,
+      }),
+    },
+  })
+  const cancelEvent = create(HistoryEventSchema, {
+    eventId: 43n,
+    eventType: EventType.NEXUS_OPERATION_CANCEL_REQUESTED,
+    attributes: {
+      case: 'nexusOperationCancelRequestedEventAttributes',
+      value: create(NexusOperationCancelRequestedEventAttributesSchema, {
+        scheduledEventId: 42n,
+      }),
+    },
+  })
+
+  const replay = await Effect.runPromise(
+    ingestWorkflowHistory({
+      info,
+      history: [scheduledEvent, cancelEvent, markerEvent],
+      dataConverter: converter,
+    }),
+  )
+  const intent = replay.determinismState.commandHistory[0]?.intent
+  const cancelIntent = replay.determinismState.commandHistory[1]?.intent
+  const markerIntent = replay.markerState?.commandHistory[0]?.intent
+  const markerCancelIntent = replay.markerState?.commandHistory[1]?.intent
+
+  expect(replay.hasDeterminismMarker).toBe(true)
+  expect(intent?.kind === 'schedule-nexus-operation' ? intent.operationId : null).toBe('nexus-0')
+  expect(markerIntent?.kind === 'schedule-nexus-operation' ? markerIntent.operationId : null).toBe('nexus-0')
+  expect(cancelIntent?.kind === 'request-cancel-nexus-operation' ? cancelIntent.operationId : null).toBe('nexus-0')
+  expect(markerCancelIntent?.kind === 'request-cancel-nexus-operation' ? markerCancelIntent.operationId : null).toBe(
+    'nexus-0',
+  )
+})
+
+test('resolveNexusOperationHistoryIdentities aliases headerless events to persisted marker IDs', () => {
+  const scheduledEvent = create(HistoryEventSchema, {
+    eventId: 42n,
+    eventType: EventType.NEXUS_OPERATION_SCHEDULED,
+    attributes: {
+      case: 'nexusOperationScheduledEventAttributes',
+      value: create(NexusOperationScheduledEventAttributesSchema, {
+        endpoint: 'payments',
+        service: 'billing',
+        operation: 'charge',
+      }),
+    },
+  })
+  const markerState: WorkflowDeterminismState = {
+    commandHistory: [
+      {
+        intent: {
+          id: 'schedule-nexus-operation-0',
+          kind: 'schedule-nexus-operation',
+          sequence: 0,
+          endpoint: 'payments',
+          service: 'billing',
+          operation: 'charge',
+          operationId: 'nexus-0',
+          nexusHeader: {},
+        },
+      },
+    ],
+    randomValues: [],
+    timeValues: [],
+    signals: [],
+    queries: [],
+  }
+  const markerEvent = create(HistoryEventSchema, {
+    eventId: 43n,
+    eventType: EventType.MARKER_RECORDED,
+    attributes: {
+      case: 'markerRecordedEventAttributes',
+      value: create(MarkerRecordedEventAttributesSchema, {
+        markerName: DETERMINISM_MARKER_NAME,
+      }),
+    },
+  })
+
+  const identities = resolveNexusOperationHistoryIdentities([scheduledEvent, markerEvent], { markerState })
+
+  expect(identities.operationIdsByScheduledEventId.get('42')).toBe('nexus-0')
+  expect(identities.scheduledEventIdsByOperationId.get('nexus-0')).toBe('42')
+})
+
+test('ingestWorkflowHistory preserves explicit marker-backed Nexus operation IDs', async () => {
+  const converter = createDefaultDataConverter()
+  const info: WorkflowInfo = {
+    namespace: 'default',
+    taskQueue: 'replay-fixtures',
+    workflowId: 'wf-nexus-marker-explicit-id',
+    runId: 'run-nexus-marker-explicit-id',
+    workflowType: 'nexusWorkflow',
+  }
+  const determinismState: WorkflowDeterminismState = {
+    commandHistory: [
+      {
+        intent: {
+          id: 'schedule-nexus-operation-0',
+          kind: 'schedule-nexus-operation',
+          sequence: 0,
+          endpoint: 'payments',
+          service: 'billing',
+          operation: 'charge',
+          operationId: 'caller-supplied-operation',
+          nexusHeader: {},
+        },
+      },
+    ],
+    randomValues: [],
+    timeValues: [],
+    signals: [],
+    queries: [],
+  }
+  const details = await Effect.runPromise(
+    encodeDeterminismMarkerDetails(converter, {
+      info,
+      determinismState,
+      lastEventId: '43',
+      recordedAt: new Date('2026-07-14T00:00:00Z'),
+    }),
+  )
+  const scheduledEvent = create(HistoryEventSchema, {
+    eventId: 42n,
+    eventType: EventType.NEXUS_OPERATION_SCHEDULED,
+    attributes: {
+      case: 'nexusOperationScheduledEventAttributes',
+      value: create(NexusOperationScheduledEventAttributesSchema, {
+        endpoint: 'payments',
+        service: 'billing',
+        operation: 'charge',
+      }),
+    },
+  })
+  const markerEvent = create(HistoryEventSchema, {
+    eventId: 43n,
+    eventType: EventType.MARKER_RECORDED,
+    attributes: {
+      case: 'markerRecordedEventAttributes',
+      value: create(MarkerRecordedEventAttributesSchema, {
+        markerName: 'temporal-bun-sdk/determinism',
+        details,
+      }),
+    },
+  })
+
+  const replay = await Effect.runPromise(
+    ingestWorkflowHistory({
+      info,
+      history: [scheduledEvent, markerEvent],
+      dataConverter: converter,
+    }),
+  )
+  const intent = replay.determinismState.commandHistory[0]?.intent
+  const markerIntent = replay.markerState?.commandHistory[0]?.intent
+
+  expect(replay.hasDeterminismMarker).toBe(true)
+  expect(intent?.kind === 'schedule-nexus-operation' ? intent.operationId : null).toBe('caller-supplied-operation')
+  expect(markerIntent?.kind === 'schedule-nexus-operation' ? markerIntent.operationId : null).toBe(
+    'caller-supplied-operation',
+  )
 })
 
 test('ingestWorkflowHistory captures failure metadata from workflow events', async () => {


### PR DESCRIPTION
## Summary
- migrate legacy marker-backed headerless Nexus operation IDs to the authoritative scheduled event ID
- keep related Nexus cancellation intents aligned with the migrated ID
- add deterministic marker replay regression coverage

## Validation
- `bun test packages/temporal-bun-sdk/tests/workflow/replay.test.ts packages/temporal-bun-sdk/tests/workflow/primitives.test.ts` (28 passed)
- direct TypeScript compilation for `packages/temporal-bun-sdk`
- oxlint on changed files
- `git diff --check origin/main...HEAD`

Follow-up to Codex finding on #12412, discussion `3576877341`.