### PR TITLE
docs(agents): fix handoff shell quoting

### DIFF
--- a/.github/workflows/scripts-ci.yml
+++ b/.github/workflows/scripts-ci.yml
@@ -11,6 +11,7 @@ on:
       - 'argocd/applications/observability/**'
       - 'argocd/applicationsets/**'
       - 'docs/torghut/ceph-migration.md'
+      - 'docs/agents/designs/handoff-common.md'
       - 'docs/runbooks/rook-ceph-client-ops-performance.md'
       - 'docs/nix-enabled-app-build-performance-rollout-plan.md'
       - '.github/workflows/scripts-ci.yml'
@@ -22,6 +23,7 @@ on:
       - 'argocd/applications/observability/**'
       - 'argocd/applicationsets/**'
       - 'docs/torghut/ceph-migration.md'
+      - 'docs/agents/designs/handoff-common.md'
       - 'docs/runbooks/rook-ceph-client-ops-performance.md'
       - 'docs/nix-enabled-app-build-performance-rollout-plan.md'
 

--- a/docs/agents/designs/handoff-common.md
+++ b/docs/agents/designs/handoff-common.md
@@ -67,7 +67,7 @@ Render the full desired install (Helm via kustomize, matching Argo CD):
 
 ```bash
 mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml
-rg -n \"^kind: (Deployment|Service|CustomResourceDefinition)$\" /tmp/agents.yaml | head
+rg -n '^kind: (Deployment|Service|CustomResourceDefinition)$' /tmp/agents.yaml | head
 ```
 
 Validate schema / examples / chart renderability (includes kubeconform and size checks):
@@ -99,7 +99,7 @@ kubectl version --short
 kubectl get --raw /version
 
 # Argo CD view (requires access to namespace argocd)
-kubectl get application -n argocd agents -o yaml | rg -n \"sync|health|revision\"
+kubectl get application -n argocd agents -o yaml | rg -n 'sync|health|revision'
 
 # Workloads
 kubectl get deploy -n agents
@@ -107,7 +107,7 @@ kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 
 # CRDs (cluster-scoped)
-kubectl get crd | rg 'proompteng\\.ai'
+kubectl get crd | rg 'proompteng\.ai'
 ```
 
 ## Rollout discipline (GitOps)

--- a/packages/scripts/src/docs/__tests__/agents-handoff-runbook.test.ts
+++ b/packages/scripts/src/docs/__tests__/agents-handoff-runbook.test.ts
@@ -1,0 +1,18 @@
+import { expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { repoRoot } from '../../shared/cli'
+
+it('keeps Agents handoff shell snippets directly executable', () => {
+  const runbook = readFileSync(join(repoRoot, 'docs/agents/designs/handoff-common.md'), 'utf8')
+  const scriptsWorkflow = readFileSync(join(repoRoot, '.github/workflows/scripts-ci.yml'), 'utf8')
+
+  expect(runbook).not.toContain('\\"')
+  expect(runbook).toContain("rg -n '^kind: (Deployment|Service|CustomResourceDefinition)$' /tmp/agents.yaml | head")
+  expect(runbook).toContain("kubectl get application -n argocd agents -o yaml | rg -n 'sync|health|revision'")
+  expect(runbook).toContain("kubectl get crd | rg 'proompteng\\.ai'")
+  expect(
+    scriptsWorkflow.split('\n').filter((line) => line.trim() === "- 'docs/agents/designs/handoff-common.md'"),
+  ).toHaveLength(2)
+})


### PR DESCRIPTION
## Summary

- Replaces literal escaped quote sequences in the Agents handoff shell examples with real shell quoting.
- Normalizes the CRD regex escaping so copied commands execute as written.
- Adds a docs regression that protects the render, Argo CD, and CRD validation commands.
- Routes doc-only edits to this runbook through `scripts-ci` so the regression actually runs.

## Related Issues

Addresses historical Codex review: https://github.com/proompteng/lab/pull/2868#discussion_r2776511100

## Testing

- `bun test packages/scripts/src/docs/__tests__/agents-handoff-runbook.test.ts` — 1 passed with 5 assertions.
- `packages/scripts/tsconfig.atlas.json`, Oxfmt, Oxlint, and `git diff --check` — passed.
- Full scripts tests progressed through the new docs regression locally; the remaining Docker-dependent test requires CI's Ubuntu runner.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] The documentation regression protects the corrected copy-paste workflow.
