### PR TITLE
test(temporal): tolerate completed update races

### DIFF
--- a/packages/temporal-bun-sdk/tests/integration/load/runner.test.ts
+++ b/packages/temporal-bun-sdk/tests/integration/load/runner.test.ts
@@ -90,6 +90,41 @@ test('worker load update termination keeps unrelated not-found failures fatal', 
   ).toBe(false)
 })
 
+test('worker load update drive tolerates workflows that complete before an update', async () => {
+  type DriveClient = Parameters<typeof __workerLoadTestHooks.driveWorkflowUpdates>[0]
+  type DriveSubmission = Parameters<typeof __workerLoadTestHooks.driveWorkflowUpdates>[1][number]
+  type DriveConfig = Parameters<typeof __workerLoadTestHooks.driveWorkflowUpdates>[2]
+  let terminateCalls = 0
+  const client = {
+    workflow: {
+      update: async () => {
+        throw new ConnectError('workflow execution already completed', Code.NotFound)
+      },
+      terminate: async () => {
+        terminateCalls += 1
+      },
+    },
+  } as unknown as DriveClient
+  const submission = {
+    plan: {
+      id: 'completed-before-update',
+      workflowType: 'workerLoadUpdateWorkflow',
+      input: { cycles: 2, holdMs: 250, delayMs: 50 },
+    },
+    handle: { workflowId: 'completed-before-update', runId: 'run-1' },
+  } satisfies DriveSubmission
+  const config = {
+    updatesPerWorkflow: 1,
+    updateDelayMs: 50,
+  } as DriveConfig
+
+  const events = await __workerLoadTestHooks.driveWorkflowUpdates(client, [submission], config)
+
+  expect(events).toHaveLength(1)
+  expect(events[0]?.status).toBe('already-completed')
+  expect(terminateCalls).toBe(0)
+})
+
 test('worker load update termination classifies shard-status cleanup transients', () => {
   expect(
     __workerLoadTestHooks.isTransientWorkflowTerminationCleanupFailure(

--- a/packages/temporal-bun-sdk/tests/integration/load/runner.ts
+++ b/packages/temporal-bun-sdk/tests/integration/load/runner.ts
@@ -600,35 +600,40 @@ const driveWorkflowUpdates = async (
   const terminationEvents = await Promise.all(
     submissions.map(async ({ handle }) => {
       const workflowHandle = { workflowId: handle.workflowId, runId: handle.runId }
-      for (let index = 0; index < config.updatesPerWorkflow; index += 1) {
+      const requestedAt = new Date().toISOString()
+      let phase: 'updates' | 'termination' = 'updates'
+      try {
+        for (let index = 0; index < config.updatesPerWorkflow; index += 1) {
+          await client.workflow.update(workflowHandle, {
+            updateName: 'workerLoad.setStatus',
+            args: [{ status: `phase-${index}` }],
+            waitForStage: 'completed',
+          })
+        }
         await client.workflow.update(workflowHandle, {
-          updateName: 'workerLoad.setStatus',
-          args: [{ status: `phase-${index}` }],
+          updateName: 'workerLoad.delayedSetStatus',
+          args: [{ status: 'delayed', delayMs: config.updateDelayMs }],
           waitForStage: 'completed',
         })
-      }
-      await client.workflow.update(workflowHandle, {
-        updateName: 'workerLoad.delayedSetStatus',
-        args: [{ status: 'delayed', delayMs: config.updateDelayMs }],
-        waitForStage: 'completed',
-      })
-      try {
+        try {
+          await client.workflow.update(workflowHandle, {
+            updateName: 'workerLoad.guardStatus',
+            args: [{ level: -1 }],
+            waitForStage: 'completed',
+          })
+        } catch (error) {
+          if (isWorkflowAlreadyCompletedForTermination(error)) {
+            throw error
+          }
+          // Intentionally provoke a validation failure to exercise rejection paths.
+        }
         await client.workflow.update(workflowHandle, {
           updateName: 'workerLoad.guardStatus',
-          args: [{ level: -1 }],
+          args: [{ level: 1 }],
           waitForStage: 'completed',
         })
-      } catch {
-        // Intentionally provoke a validation failure to exercise rejection paths.
-      }
-      await client.workflow.update(workflowHandle, {
-        updateName: 'workerLoad.guardStatus',
-        args: [{ level: 1 }],
-        waitForStage: 'completed',
-      })
-      // After exercising update flows, terminate to keep the load suite bounded.
-      const requestedAt = new Date().toISOString()
-      try {
+        // After exercising update flows, terminate to keep the load suite bounded.
+        phase = 'termination'
         await client.workflow.terminate(workflowHandle, { reason: 'worker-load-finish' })
         return {
           workflowId: handle.workflowId,
@@ -648,7 +653,7 @@ const driveWorkflowUpdates = async (
             error: error instanceof Error ? error.message : String(error),
           }
         }
-        if (isTransientWorkflowTerminationCleanupFailure(error)) {
+        if (phase === 'termination' && isTransientWorkflowTerminationCleanupFailure(error)) {
           return {
             workflowId: handle.workflowId,
             runId: handle.runId,
@@ -1159,6 +1164,7 @@ export const __workerLoadTestHooks = {
   calculateLoadCompletionBudgetMs,
   calculateWorkerLoadTestTimeoutBudgetMs,
   cleanupSubmittedWorkflows,
+  driveWorkflowUpdates,
   isWorkflowAlreadyCompletedForTermination,
   isTransientWorkflowTerminationCleanupFailure,
   normalizeWorkflowStatus,


### PR DESCRIPTION
## Summary

- Treats a workflow that completes naturally before or during update failure injection as a terminal load-test outcome.
- Preserves fatal behavior for unrelated update failures and limits transient cleanup suppression to the termination phase.
- Adds a focused regression that verifies an already-completed update race skips the termination call.

## Related Issues

Prerequisite repair discovered while validating #12422.

## Testing

- `bun test packages/temporal-bun-sdk/tests/integration/load/runner.test.ts` — 12 passed.
- `tsc --noEmit --project packages/temporal-bun-sdk/tsconfig.json --pretty false` — passed.
- `git diff --check` — passed.
- The integration-load directory is excluded by the repository’s Oxc ignore rules, so Oxfmt/Oxlint cannot target these files through the normal configuration.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed and the Oxc exclusion.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] The focused regression documents the intended load-harness race policy.
