### PR TITLE
perf(torghut): bulk upsert options catalog pages

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -8,6 +8,10 @@ metadata:
 spec:
   replicas: 1
   revisionHistoryLimit: 2
+  # The catalog is a singleton database reconciler. Recreate prevents old and
+  # new revisions from scanning and writing the same universe concurrently.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: torghut-options-catalog

--- a/services/torghut/app/options_lane/catalog_page_upsert.py
+++ b/services/torghut/app/options_lane/catalog_page_upsert.py
@@ -1,0 +1,127 @@
+"""Set-based PostgreSQL statement for options catalog page upserts."""
+
+from sqlalchemy import text
+
+
+CATALOG_PAGE_UPSERT = text(
+    """
+    WITH incoming AS (
+      SELECT *
+      FROM jsonb_to_recordset(CAST(:rows AS JSONB)) AS payload (
+        contract_symbol TEXT,
+        contract_id TEXT,
+        root_symbol TEXT,
+        underlying_symbol TEXT,
+        expiration_date DATE,
+        strike_price NUMERIC(18, 6),
+        option_type TEXT,
+        style TEXT,
+        contract_size INTEGER,
+        status TEXT,
+        tradable BOOLEAN,
+        open_interest BIGINT,
+        open_interest_date DATE,
+        close_price NUMERIC(18, 6),
+        close_price_date DATE,
+        provider_updated_ts TIMESTAMPTZ,
+        first_seen_ts TIMESTAMPTZ,
+        last_seen_ts TIMESTAMPTZ,
+        metadata JSONB
+      )
+    )
+    INSERT INTO torghut_options_contract_catalog (
+      contract_symbol,
+      contract_id,
+      root_symbol,
+      underlying_symbol,
+      expiration_date,
+      strike_price,
+      option_type,
+      style,
+      contract_size,
+      status,
+      tradable,
+      open_interest,
+      open_interest_date,
+      close_price,
+      close_price_date,
+      provider_updated_ts,
+      first_seen_ts,
+      last_seen_ts,
+      metadata
+    )
+    SELECT contract_symbol,
+           contract_id,
+           root_symbol,
+           underlying_symbol,
+           expiration_date,
+           strike_price,
+           option_type,
+           style,
+           contract_size,
+           status,
+           tradable,
+           open_interest,
+           open_interest_date,
+           close_price,
+           close_price_date,
+           provider_updated_ts,
+           first_seen_ts,
+           last_seen_ts,
+           metadata
+    FROM incoming
+    ON CONFLICT (contract_symbol) DO UPDATE
+    SET contract_id = EXCLUDED.contract_id,
+        root_symbol = EXCLUDED.root_symbol,
+        underlying_symbol = EXCLUDED.underlying_symbol,
+        expiration_date = EXCLUDED.expiration_date,
+        strike_price = EXCLUDED.strike_price,
+        option_type = EXCLUDED.option_type,
+        style = EXCLUDED.style,
+        contract_size = EXCLUDED.contract_size,
+        status = EXCLUDED.status,
+        tradable = EXCLUDED.tradable,
+        open_interest = EXCLUDED.open_interest,
+        open_interest_date = EXCLUDED.open_interest_date,
+        close_price = EXCLUDED.close_price,
+        close_price_date = EXCLUDED.close_price_date,
+        provider_updated_ts = EXCLUDED.provider_updated_ts,
+        last_seen_ts = EXCLUDED.last_seen_ts,
+        metadata = EXCLUDED.metadata
+    WHERE (
+      torghut_options_contract_catalog.contract_id,
+      torghut_options_contract_catalog.root_symbol,
+      torghut_options_contract_catalog.underlying_symbol,
+      torghut_options_contract_catalog.expiration_date,
+      torghut_options_contract_catalog.strike_price,
+      torghut_options_contract_catalog.option_type,
+      torghut_options_contract_catalog.style,
+      torghut_options_contract_catalog.contract_size,
+      torghut_options_contract_catalog.status,
+      torghut_options_contract_catalog.tradable,
+      torghut_options_contract_catalog.open_interest,
+      torghut_options_contract_catalog.open_interest_date,
+      torghut_options_contract_catalog.close_price,
+      torghut_options_contract_catalog.close_price_date,
+      torghut_options_contract_catalog.provider_updated_ts,
+      torghut_options_contract_catalog.metadata
+    ) IS DISTINCT FROM (
+      EXCLUDED.contract_id,
+      EXCLUDED.root_symbol,
+      EXCLUDED.underlying_symbol,
+      EXCLUDED.expiration_date,
+      EXCLUDED.strike_price,
+      EXCLUDED.option_type,
+      EXCLUDED.style,
+      EXCLUDED.contract_size,
+      EXCLUDED.status,
+      EXCLUDED.tradable,
+      EXCLUDED.open_interest,
+      EXCLUDED.open_interest_date,
+      EXCLUDED.close_price,
+      EXCLUDED.close_price_date,
+      EXCLUDED.provider_updated_ts,
+      EXCLUDED.metadata
+    )
+    """
+)

--- a/services/torghut/app/options_lane/repository.py
+++ b/services/torghut/app/options_lane/repository.py
@@ -19,6 +19,7 @@ from app.options_lane.catalog_watermark_repository import (
     CatalogCycleSummary,
     record_catalog_cycle_success,
 )
+from app.options_lane.catalog_page_upsert import CATALOG_PAGE_UPSERT
 from app.options_lane.catalog_scope import OptionsCatalogScope
 from app.options_lane.catalog_change_detection import contract_catalog_row_changed
 from app.options_lane.subscription_state_repository import (
@@ -33,6 +34,7 @@ from app.options_lane.subscription_state_repository import (
 logger = logging.getLogger(__name__)
 
 OPTIONS_STATUS_COUNT_TIMEOUT_MS = 500
+OPTIONS_EXPIRED_CLEANUP_BATCH_LIMIT = 1_000
 
 
 def _utc_now() -> datetime:
@@ -245,114 +247,12 @@ class OptionsRepository:
                 )
                 if changed:
                     published_rows.append(payload)
-                    upsert_rows.append(
-                        {
-                            **payload,
-                            "metadata": _coerce_json(payload["metadata"]),
-                        }
-                    )
+                    upsert_rows.append(payload)
 
             if upsert_rows:
                 session.execute(
-                    text(
-                        """
-                    INSERT INTO torghut_options_contract_catalog (
-                      contract_symbol,
-                      contract_id,
-                      root_symbol,
-                      underlying_symbol,
-                      expiration_date,
-                      strike_price,
-                      option_type,
-                      style,
-                      contract_size,
-                      status,
-                      tradable,
-                      open_interest,
-                      open_interest_date,
-                      close_price,
-                      close_price_date,
-                      provider_updated_ts,
-                      first_seen_ts,
-                      last_seen_ts,
-                      metadata
-                    ) VALUES (
-                      :contract_symbol,
-                      :contract_id,
-                      :root_symbol,
-                      :underlying_symbol,
-                      :expiration_date,
-                      :strike_price,
-                      :option_type,
-                      :style,
-                      :contract_size,
-                      :status,
-                      :tradable,
-                      :open_interest,
-                      :open_interest_date,
-                      :close_price,
-                      :close_price_date,
-                      :provider_updated_ts,
-                      :first_seen_ts,
-                      :last_seen_ts,
-                      CAST(:metadata AS JSONB)
-                    )
-                    ON CONFLICT (contract_symbol) DO UPDATE
-                    SET contract_id = EXCLUDED.contract_id,
-                        root_symbol = EXCLUDED.root_symbol,
-                        underlying_symbol = EXCLUDED.underlying_symbol,
-                        expiration_date = EXCLUDED.expiration_date,
-                        strike_price = EXCLUDED.strike_price,
-                        option_type = EXCLUDED.option_type,
-                        style = EXCLUDED.style,
-                        contract_size = EXCLUDED.contract_size,
-                        status = EXCLUDED.status,
-                        tradable = EXCLUDED.tradable,
-                        open_interest = EXCLUDED.open_interest,
-                        open_interest_date = EXCLUDED.open_interest_date,
-                        close_price = EXCLUDED.close_price,
-                        close_price_date = EXCLUDED.close_price_date,
-                        provider_updated_ts = EXCLUDED.provider_updated_ts,
-                        last_seen_ts = EXCLUDED.last_seen_ts,
-                        metadata = EXCLUDED.metadata
-                    WHERE (
-                      torghut_options_contract_catalog.contract_id,
-                      torghut_options_contract_catalog.root_symbol,
-                      torghut_options_contract_catalog.underlying_symbol,
-                      torghut_options_contract_catalog.expiration_date,
-                      torghut_options_contract_catalog.strike_price,
-                      torghut_options_contract_catalog.option_type,
-                      torghut_options_contract_catalog.style,
-                      torghut_options_contract_catalog.contract_size,
-                      torghut_options_contract_catalog.status,
-                      torghut_options_contract_catalog.tradable,
-                      torghut_options_contract_catalog.open_interest,
-                      torghut_options_contract_catalog.open_interest_date,
-                      torghut_options_contract_catalog.close_price,
-                      torghut_options_contract_catalog.close_price_date,
-                      torghut_options_contract_catalog.provider_updated_ts,
-                      torghut_options_contract_catalog.metadata
-                    ) IS DISTINCT FROM (
-                      EXCLUDED.contract_id,
-                      EXCLUDED.root_symbol,
-                      EXCLUDED.underlying_symbol,
-                      EXCLUDED.expiration_date,
-                      EXCLUDED.strike_price,
-                      EXCLUDED.option_type,
-                      EXCLUDED.style,
-                      EXCLUDED.contract_size,
-                      EXCLUDED.status,
-                      EXCLUDED.tradable,
-                      EXCLUDED.open_interest,
-                      EXCLUDED.open_interest_date,
-                      EXCLUDED.close_price,
-                      EXCLUDED.close_price_date,
-                      EXCLUDED.provider_updated_ts,
-                      EXCLUDED.metadata
-                    )
-                        """
-                    ),
-                    upsert_rows,
+                    CATALOG_PAGE_UPSERT,
+                    {"rows": _coerce_json(upsert_rows)},
                 )
 
         return published_rows
@@ -390,9 +290,10 @@ class OptionsRepository:
                 ),
                 {"seen_symbols": normalized_seen_symbols},
             )
-            transition_rows = session.execute(
-                text(
-                    """
+            transition_rows = list(
+                session.execute(
+                    text(
+                        """
                     UPDATE torghut_options_contract_catalog AS catalog
                     SET status = CASE
                           WHEN catalog.expiration_date < CAST(:observed_at AS DATE) THEN 'expired'
@@ -401,27 +302,63 @@ class OptionsRepository:
                         last_seen_ts = :observed_at
                     WHERE catalog.status = 'active'
                       AND catalog.underlying_symbol = ANY(:underlying_symbols)
-                      AND catalog.expiration_date <= :expiration_date_lte
-                      AND (
-                        catalog.expiration_date < :expiration_date_gte
-                        OR NOT EXISTS (
-                          SELECT 1
-                          FROM options_catalog_seen_contracts AS seen
-                          WHERE seen.contract_symbol = catalog.contract_symbol
-                        )
+                      AND catalog.expiration_date BETWEEN :expiration_date_gte
+                                                      AND :expiration_date_lte
+                      AND NOT EXISTS (
+                        SELECT 1
+                        FROM options_catalog_seen_contracts AS seen
+                        WHERE seen.contract_symbol = catalog.contract_symbol
                       )
                     RETURNING catalog.*
                     """
-                ),
-                {"observed_at": observed_at, **scope.query_parameters},
-            ).mappings()
-            return [
+                    ),
+                    {"observed_at": observed_at, **scope.query_parameters},
+                ).mappings()
+            )
+            expired_rows = list(
+                session.execute(
+                    text(
+                        """
+                        WITH expired_batch AS (
+                          SELECT catalog.contract_symbol
+                          FROM torghut_options_contract_catalog AS catalog
+                          WHERE catalog.status = 'active'
+                            AND catalog.underlying_symbol = ANY(:underlying_symbols)
+                            AND catalog.expiration_date < :expiration_date_gte
+                          LIMIT :expired_cleanup_limit
+                          FOR UPDATE SKIP LOCKED
+                        )
+                        UPDATE torghut_options_contract_catalog AS catalog
+                        SET status = 'expired',
+                            last_seen_ts = :observed_at
+                        FROM expired_batch
+                        WHERE catalog.contract_symbol = expired_batch.contract_symbol
+                        RETURNING catalog.*
+                        """
+                    ),
+                    {
+                        "observed_at": observed_at,
+                        "underlying_symbols": list(scope.underlying_symbols),
+                        "expiration_date_gte": scope.expiration_date_gte,
+                        "expired_cleanup_limit": OPTIONS_EXPIRED_CLEANUP_BATCH_LIMIT,
+                    },
+                ).mappings()
+            )
+            missing_transitions = [
                 {
                     **dict(row),
                     "catalog_status_reason": "not_seen_in_active_discovery_run",
                 }
                 for row in transition_rows
             ]
+            expired_transitions = [
+                {
+                    **dict(row),
+                    "catalog_status_reason": "expired_below_live_discovery_window",
+                }
+                for row in expired_rows
+            ]
+            return [*missing_transitions, *expired_transitions]
 
     def list_active_contracts(self) -> list[dict[str, Any]]:
         with self.session() as session:

--- a/services/torghut/tests/test_options_catalog_scope_repository.py
+++ b/services/torghut/tests/test_options_catalog_scope_repository.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager, nullcontext
 from datetime import UTC, date, datetime, timedelta
+import json
 from typing import cast
 
 import pytest
@@ -30,9 +31,11 @@ class _CatalogSession:
         *,
         existing_rows: Sequence[Mapping[str, object]] = (),
         transition_rows: Sequence[Mapping[str, object]] = (),
+        expired_transition_rows: Sequence[Mapping[str, object]] = (),
     ) -> None:
         self.existing_rows = existing_rows
         self.transition_rows = transition_rows
+        self.expired_transition_rows = expired_transition_rows
         self.calls: list[tuple[str, object]] = []
 
     def begin(self) -> object:
@@ -43,6 +46,8 @@ class _CatalogSession:
         self.calls.append((sql, parameters))
         if "SELECT *" in sql and "contract_symbol = ANY" in sql:
             return _RowsResult(self.existing_rows)
+        if "WITH expired_batch AS" in sql:
+            return _RowsResult(self.expired_transition_rows)
         if "RETURNING catalog.*" in sql:
             return _RowsResult(self.transition_rows)
         return _RowsResult()
@@ -161,9 +166,11 @@ def test_catalog_upserts_changed_rows_in_stable_order_with_database_guard() -> N
         "MSFT260717C00400000",
     ]
     insert_sql, insert_parameters = session.calls[1]
+    assert "jsonb_to_recordset" in insert_sql
     assert "IS DISTINCT FROM" in insert_sql
-    assert isinstance(insert_parameters, list)
-    assert [row["contract_symbol"] for row in insert_parameters] == [
+    assert isinstance(insert_parameters, dict)
+    serialized_rows = json.loads(str(insert_parameters["rows"]))
+    assert [row["contract_symbol"] for row in serialized_rows] == [
         "AAPL260717C00200000",
         "MSFT260717C00400000",
     ]
@@ -178,7 +185,14 @@ def test_missing_contract_transition_is_scoped_to_exact_completed_scan() -> None
                 "status": "inactive",
                 "expiration_date": date(2026, 7, 17),
             }
-        ]
+        ],
+        expired_transition_rows=[
+            {
+                "contract_symbol": "AAPL260710P00190000",
+                "status": "expired",
+                "expiration_date": date(2026, 7, 10),
+            }
+        ],
     )
     repository = _CatalogRepository(session)
 
@@ -189,6 +203,7 @@ def test_missing_contract_transition_is_scoped_to_exact_completed_scan() -> None
     )
 
     assert rows[0]["catalog_status_reason"] == "not_seen_in_active_discovery_run"
+    assert rows[1]["catalog_status_reason"] == "expired_below_live_discovery_window"
     assert (
         "CREATE TEMPORARY TABLE options_catalog_seen_contracts" in session.calls[0][0]
     )
@@ -197,13 +212,24 @@ def test_missing_contract_transition_is_scoped_to_exact_completed_scan() -> None
     }
     transition_sql, transition_parameters = session.calls[2]
     assert "catalog.underlying_symbol = ANY(:underlying_symbols)" in transition_sql
-    assert "catalog.expiration_date <= :expiration_date_lte" in transition_sql
-    assert "catalog.expiration_date < :expiration_date_gte" in transition_sql
+    assert "catalog.expiration_date BETWEEN :expiration_date_gte" in transition_sql
+    assert "AND :expiration_date_lte" in transition_sql
+    assert "catalog.expiration_date < :expiration_date_gte" not in transition_sql
     assert "NOT EXISTS" in transition_sql
     assert "last_seen_ts <" not in transition_sql
     assert transition_parameters == {
         "observed_at": observed_at,
         **_scope().query_parameters,
+    }
+    expired_sql, expired_parameters = session.calls[3]
+    assert "WITH expired_batch AS" in expired_sql
+    assert "LIMIT :expired_cleanup_limit" in expired_sql
+    assert "FOR UPDATE SKIP LOCKED" in expired_sql
+    assert expired_parameters == {
+        "observed_at": observed_at,
+        "underlying_symbols": ["AAPL", "MSFT"],
+        "expiration_date_gte": date(2026, 7, 14),
+        "expired_cleanup_limit": 1000,
     }
 
 


### PR DESCRIPTION
## Summary

- Replace per-row SQLAlchemy executemany catalog writes with one typed `jsonb_to_recordset` upsert per changed provider page.
- Preserve stable symbol ordering, first-seen timestamps, material-delta filtering, and the database-side `IS DISTINCT FROM` guard.
- Bound complete-cycle deactivation to the exact live date window and retire older active contracts in index-backed 1,000-row `SKIP LOCKED` batches until the archive owns full history.
- Use `Recreate` for the singleton catalog Deployment so image rollouts cannot run two database reconcilers concurrently.

## Related Issues

None

## Testing

- `uv run --frozen pytest -q tests/test_options_catalog_scope_repository.py` (5 passed)
- `uv run --frozen ruff format --check app/options_lane/catalog_page_upsert.py app/options_lane/repository.py tests/test_options_catalog_scope_repository.py`
- `uv run --frozen ruff check app/options_lane/catalog_page_upsert.py app/options_lane/repository.py tests/test_options_catalog_scope_repository.py`
- Changed-file Pylint structural, quality-diff, and file-length gates passed.
- All five Pyright profiles passed with zero errors: main, alpha, scripts, alpha strict, and scripts strict.
- Production PostgreSQL read-only `EXPLAIN` accepted the exact parameterized set-based upsert (`set_based_upsert_explain=ok`); no statement was executed.
- Production PostgreSQL read-only `EXPLAIN` confirmed the bounded expired-contract cleanup uses the underlying/date index and primary-key update lookup; no statement was executed.
- `kustomize build --enable-helm argocd/applications/torghut-options | kubectl apply --dry-run=server -n torghut -f -`
- `bun run lint:argocd`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked; the rollout rationale is covered by `docs/torghut/storage-write-pressure-remediation-design.md`.
