### PR TITLE
chore(torghut): promote image sha-cd9e04b9652e8b4b1a1cf15d0281ca2b13e1f4fe

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -22,7 +22,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: migrate
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:183ed61bb63e28cb4487c08e3b1e0ce9b9675f7530d101b9f4e3d018fc9611b5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
           imagePullPolicy: Always
           workingDir: /app
           command:
@@ -52,9 +52,9 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: 8338c3fcaf84ab649f5b1dbe4d178e71ea6d4208
+              value: cd9e04b9652e8b4b1a1cf15d0281ca2b13e1f4fe
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:183ed61bb63e28cb4487c08e3b1e0ce9b9675f7530d101b9f4e3d018fc9611b5
+              value: sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
             - name: PYTHONPATH
               value: /app
             - name: DB_DSN

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-hyperliquid-runtime
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:183ed61bb63e28cb4487c08e3b1e0ce9b9675f7530d101b9f4e3d018fc9611b5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
           imagePullPolicy: Always
           command:
             - uvicorn
@@ -46,9 +46,9 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: 8338c3fcaf84ab649f5b1dbe4d178e71ea6d4208
+              value: cd9e04b9652e8b4b1a1cf15d0281ca2b13e1f4fe
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:183ed61bb63e28cb4487c08e3b1e0ce9b9675f7530d101b9f4e3d018fc9611b5
+              value: sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
             - name: DB_DSN
               valueFrom:
                 secretKeyRef:

--- a/argocd/applications/torghut-options/archive/deployment.yaml
+++ b/argocd/applications/torghut-options/archive/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   # The image promotion activates this replica. The startup gate below keeps it
   # from serving until the independently reconciled core app applies migration 0062.
-  replicas: 0
+  replicas: 1
   revisionHistoryLimit: 2
   strategy:
     type: Recreate
@@ -32,7 +32,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-archive
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:929fb34236555d86e17b473996e8ff19a8779cb0c9b3f7a2845718f7b09a2556
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -106,9 +106,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1868-g298c9b856
+              value: v0.596.0-1880-gcd9e04b96
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 298c9b856eb00705acfd703952ec920144df274c
+              value: cd9e04b9652e8b4b1a1cf15d0281ca2b13e1f4fe
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -33,7 +33,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:183ed61bb63e28cb4487c08e3b1e0ce9b9675f7530d101b9f4e3d018fc9611b5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -81,9 +81,9 @@ spec:
                   name: torghut-ws-config
                   key: SYMBOLS_ALLOWLIST
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1878-g8338c3fca
+              value: v0.596.0-1880-gcd9e04b96
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 8338c3fcaf84ab649f5b1dbe4d178e71ea6d4208
+              value: cd9e04b9652e8b4b1a1cf15d0281ca2b13e1f4fe
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:183ed61bb63e28cb4487c08e3b1e0ce9b9675f7530d101b9f4e3d018fc9611b5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -77,9 +77,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1878-g8338c3fca
+              value: v0.596.0-1880-gcd9e04b96
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 8338c3fcaf84ab649f5b1dbe4d178e71ea6d4208
+              value: cd9e04b9652e8b4b1a1cf15d0281ca2b13e1f4fe
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:183ed61bb63e28cb4487c08e3b1e0ce9b9675f7530d101b9f4e3d018fc9611b5
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:183ed61bb63e28cb4487c08e3b1e0ce9b9675f7530d101b9f4e3d018fc9611b5
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:183ed61bb63e28cb4487c08e3b1e0ce9b9675f7530d101b9f4e3d018fc9611b5
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:183ed61bb63e28cb4487c08e3b1e0ce9b9675f7530d101b9f4e3d018fc9611b5
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:183ed61bb63e28cb4487c08e3b1e0ce9b9675f7530d101b9f4e3d018fc9611b5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
           workingDir: /app
           command:
             - /bin/sh

--- a/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
+++ b/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-generated-resource-retention
           containers:
             - name: prune-generated-residue
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:183ed61bb63e28cb4487c08e3b1e0ce9b9675f7530d101b9f4e3d018fc9611b5
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:183ed61bb63e28cb4487c08e3b1e0ce9b9675f7530d101b9f4e3d018fc9611b5
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-14T08:54:18Z"
+        client.knative.dev/updateTimestamp: "2026-07-14T10:07:43Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:183ed61bb63e28cb4487c08e3b1e0ce9b9675f7530d101b9f4e3d018fc9611b5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
           ports:
             - name: http1
               containerPort: 8181
@@ -523,11 +523,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1878-g8338c3fca
+              value: v0.596.0-1880-gcd9e04b96
             - name: TORGHUT_COMMIT
-              value: 8338c3fcaf84ab649f5b1dbe4d178e71ea6d4208
+              value: cd9e04b9652e8b4b1a1cf15d0281ca2b13e1f4fe
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:183ed61bb63e28cb4487c08e3b1e0ce9b9675f7530d101b9f4e3d018fc9611b5
+              value: sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-14T08:54:18Z"
+        client.knative.dev/updateTimestamp: "2026-07-14T10:07:43Z"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
     spec:
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:183ed61bb63e28cb4487c08e3b1e0ce9b9675f7530d101b9f4e3d018fc9611b5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
           ports:
             - name: http1
               containerPort: 8181
@@ -448,11 +448,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1878-g8338c3fca
+              value: v0.596.0-1880-gcd9e04b96
             - name: TORGHUT_COMMIT
-              value: 8338c3fcaf84ab649f5b1dbe4d178e71ea6d4208
+              value: cd9e04b9652e8b4b1a1cf15d0281ca2b13e1f4fe
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:183ed61bb63e28cb4487c08e3b1e0ce9b9675f7530d101b9f4e3d018fc9611b5
+              value: sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -37,7 +37,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:183ed61bb63e28cb4487c08e3b1e0ce9b9675f7530d101b9f4e3d018fc9611b5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
           command:
             - uvicorn
           args:
@@ -464,11 +464,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1878-g8338c3fca
+              value: v0.596.0-1880-gcd9e04b96
             - name: TORGHUT_COMMIT
-              value: 8338c3fcaf84ab649f5b1dbe4d178e71ea6d4208
+              value: cd9e04b9652e8b4b1a1cf15d0281ca2b13e1f4fe
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:183ed61bb63e28cb4487c08e3b1e0ce9b9675f7530d101b9f4e3d018fc9611b5
+              value: sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: smoke
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:183ed61bb63e28cb4487c08e3b1e0ce9b9675f7530d101b9f4e3d018fc9611b5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
           imagePullPolicy: IfNotPresent
           securityContext:
             seccompProfile:


### PR DESCRIPTION
## Summary

- Promote immutable Torghut image `sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b` built from `cd9e04b9652e8b4b1a1cf15d0281ca2b13e1f4fe`.
- Use the same image and source identity for both database migration jobs and every affected Torghut runtime.
- Activate the singleton options archive worker after migration 0062 creates its UNLOGGED membership table.
- Preserve the archive startup gate so independent Argo applications cannot start the worker before the schema exists.

## Related Issues

None.

## Testing

- `torghut-release` run `29324156861` validated the release contract, image platforms, migration gate, and manifest update.
- `torghut-ci` release-manifest validation passed on this PR.
- `argo-lint` and `kubeconform` passed on this PR.
- Live preflight: CNPG `torghut-db` is healthy at Alembic revision `0061_linked_submission_terminal`, the migration target table is absent as expected, and `torghut-options-archive` is safely scaled to zero before promotion.
- Reviewed the PR diff to confirm migration jobs, runtimes, and archive use the same immutable digest and source commit.

## Breaking Changes

Migration 0062 creates `public.torghut_options_archive_membership` as an empty UNLOGGED staging table. The archive worker is activated only with this promotion and waits for the table before starting. No existing table is rewritten or locked beyond catalog-level DDL for the new table.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes documents the migration and rollout behavior.
- [x] The design document and archive runtime documentation were shipped in source PR #12438.
