### PR TITLE
feat(observability): baseline shared storage pressure

### DIFF
--- a/argocd/applications/observability/README.md
+++ b/argocd/applications/observability/README.md
@@ -85,7 +85,7 @@ The observability app owns the cluster metrics pipeline used for ARC runner sizi
 - `observability-kube-state-metrics`: Kubernetes object state and request/limit/allocatable metrics.
 - `observability-cluster-metrics-alloy`: scrapes kube-state-metrics, kubelet, every CloudNativePG instance, and the Ceph manager; it applies bounded metric allowlists, including pod-level `/dev/rbd*` I/O only, before remote-writing to Mimir.
 - `arc-runner-capacity-dashboard`: Grafana dashboard for ARC CPU, memory, pending pods, and requested CPU saturation.
-- `graf-mimir-rules`: records Torghut PostgreSQL and Ceph pressure baselines and alerts on missing telemetry, WAL archive backlog, forced checkpoints, Ceph slow operations, scrub debt, and OSD latency.
+- `graf-mimir-rules`: records Torghut PostgreSQL and Ceph pressure baselines and alerts on missing telemetry, low PVC capacity, WAL archive backlog, forced checkpoints, Ceph slow operations, scrub debt, and OSD latency.
 
 Validate the Mimir tenant after sync:
 

--- a/argocd/applications/observability/README.md
+++ b/argocd/applications/observability/README.md
@@ -80,11 +80,12 @@ kubectl -n argocd get app observability
 
 ## Cluster metrics
 
-The observability app owns the cluster metrics pipeline used for ARC runner sizing:
+The observability app owns the cluster metrics pipeline used for ARC runner sizing and shared-storage diagnosis:
 
 - `observability-kube-state-metrics`: Kubernetes object state and request/limit/allocatable metrics.
-- `observability-cluster-metrics-alloy`: scrapes kube-state-metrics plus kubelet `/metrics` and `/metrics/cadvisor`, filters to runner-sizing metrics, and remote-writes to Mimir.
+- `observability-cluster-metrics-alloy`: scrapes kube-state-metrics, kubelet, every CloudNativePG instance, and the Ceph manager; it applies bounded metric allowlists before remote-writing to Mimir.
 - `arc-runner-capacity-dashboard`: Grafana dashboard for ARC CPU, memory, pending pods, and requested CPU saturation.
+- `graf-mimir-rules`: records Torghut PostgreSQL and Ceph pressure baselines and alerts on missing telemetry, WAL archive backlog, forced checkpoints, Ceph slow operations, scrub debt, and OSD latency.
 
 Validate the Mimir tenant after sync:
 
@@ -95,5 +96,11 @@ curl -fsS -G -H 'X-Scope-OrgID: anonymous' \
   http://127.0.0.1:19090/prometheus/api/v1/query
 curl -fsS -G -H 'X-Scope-OrgID: anonymous' \
   --data-urlencode 'query=count(kube_pod_container_resource_requests{namespace="arc"})' \
+  http://127.0.0.1:19090/prometheus/api/v1/query
+curl -fsS -G -H 'X-Scope-OrgID: anonymous' \
+  --data-urlencode 'query=count(up{job="cnpg-postgres"})' \
+  http://127.0.0.1:19090/prometheus/api/v1/query
+curl -fsS -G -H 'X-Scope-OrgID: anonymous' \
+  --data-urlencode 'query=ceph_storage:osd_commit_latency_ms:max' \
   http://127.0.0.1:19090/prometheus/api/v1/query
 ```

--- a/argocd/applications/observability/README.md
+++ b/argocd/applications/observability/README.md
@@ -83,7 +83,7 @@ kubectl -n argocd get app observability
 The observability app owns the cluster metrics pipeline used for ARC runner sizing and shared-storage diagnosis:
 
 - `observability-kube-state-metrics`: Kubernetes object state and request/limit/allocatable metrics.
-- `observability-cluster-metrics-alloy`: scrapes kube-state-metrics, kubelet, every CloudNativePG instance, and the Ceph manager; it applies bounded metric allowlists before remote-writing to Mimir.
+- `observability-cluster-metrics-alloy`: scrapes kube-state-metrics, kubelet, every CloudNativePG instance, and the Ceph manager; it applies bounded metric allowlists, including pod-level `/dev/rbd*` I/O only, before remote-writing to Mimir.
 - `arc-runner-capacity-dashboard`: Grafana dashboard for ARC CPU, memory, pending pods, and requested CPU saturation.
 - `graf-mimir-rules`: records Torghut PostgreSQL and Ceph pressure baselines and alerts on missing telemetry, WAL archive backlog, forced checkpoints, Ceph slow operations, scrub debt, and OSD latency.
 
@@ -102,5 +102,8 @@ curl -fsS -G -H 'X-Scope-OrgID: anonymous' \
   http://127.0.0.1:19090/prometheus/api/v1/query
 curl -fsS -G -H 'X-Scope-OrgID: anonymous' \
   --data-urlencode 'query=ceph_storage:osd_commit_latency_ms:max' \
+  http://127.0.0.1:19090/prometheus/api/v1/query
+curl -fsS -G -H 'X-Scope-OrgID: anonymous' \
+  --data-urlencode 'query=topk(10, ceph_storage:rbd_pod_write_bytes_per_second:rate5m)' \
   http://127.0.0.1:19090/prometheus/api/v1/query
 ```

--- a/argocd/applications/observability/cluster-metrics-alloy-config.river
+++ b/argocd/applications/observability/cluster-metrics-alloy-config.river
@@ -9,6 +9,91 @@ prometheus.remote_write "mimir" {
   }
 }
 
+discovery.kubernetes "torghut_cnpg_pods" {
+  role = "pod"
+
+  namespaces {
+    names = ["torghut"]
+  }
+
+  selectors {
+    role  = "pod"
+    label = "cnpg.io/cluster=torghut-db"
+  }
+}
+
+discovery.relabel "torghut_cnpg_metrics" {
+  targets = discovery.kubernetes.torghut_cnpg_pods.targets
+
+  rule {
+    action        = "keep"
+    source_labels = ["__meta_kubernetes_pod_container_port_name"]
+    regex         = "metrics"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_namespace"]
+    target_label  = "namespace"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_pod_name"]
+    target_label  = "pod"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_pod_label_cnpg_io_cluster"]
+    target_label  = "cluster"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_pod_label_role"]
+    target_label  = "role"
+  }
+}
+
+prometheus.relabel "torghut_cnpg_metrics" {
+  forward_to = [prometheus.remote_write.mimir.receiver]
+
+  rule {
+    action        = "keep"
+    source_labels = ["__name__", "name"]
+    regex         = "up;.*|cnpg_collector_postgres_version;.*|cnpg_collector_wal_(buffers_full|bytes|fpi|records|sync|sync_time|write|write_time);.*|cnpg_pg_database_size_bytes;.*|cnpg_pg_stat_checkpointer_(buffers_written|checkpoints_req|checkpoints_timed|restartpoints_done|restartpoints_req|restartpoints_timed|sync_time|write_time);.*|cnpg_pg_settings_setting;(checkpoint_completion_target|checkpoint_timeout|fsync|full_page_writes|max_wal_size|min_wal_size)"
+  }
+}
+
+prometheus.scrape "torghut_cnpg" {
+  job_name        = "torghut-postgres"
+  targets         = discovery.relabel.torghut_cnpg_metrics.output
+  scrape_interval = "30s"
+  scrape_timeout  = "10s"
+  forward_to      = [prometheus.relabel.torghut_cnpg_metrics.receiver]
+}
+
+prometheus.relabel "ceph_storage_metrics" {
+  forward_to = [prometheus.remote_write.mimir.receiver]
+
+  rule {
+    action        = "keep"
+    source_labels = ["__name__"]
+    regex         = "up|ceph_health_status|ceph_health_detail|ceph_healthcheck_slow_ops|ceph_osd_(apply|commit)_latency_ms|ceph_osd_flag_(nobackfill|nodeep_scrub|norebalance|norecover|noscrub)|ceph_osd_(in|metadata|up)|ceph_pg_(active|backfill_toofull|backfill_unfound|backfill_wait|backfilling|clean|deep|degraded|down|forced_backfill|forced_recovery|incomplete|peering|recovering|recovery_toofull|recovery_unfound|recovery_wait|scrubbing|stale|total|undersized|unknown)|ceph_pool_(avail_raw|bytes_used|max_avail|metadata|percent_used|rd|rd_bytes|recovering_bytes_per_sec|recovering_objects_per_sec|wr|wr_bytes)|ceph_cluster_total_(bytes|used_bytes|used_raw_bytes)"
+  }
+}
+
+prometheus.scrape "ceph_storage" {
+  job_name = "ceph-storage"
+  targets = [
+    {
+      "__address__" = "rook-ceph-mgr.rook-ceph.svc.cluster.local:9283",
+      "namespace"   = "rook-ceph",
+      "service"     = "rook-ceph-mgr",
+    },
+  ]
+  scrape_interval = "30s"
+  scrape_timeout  = "10s"
+  forward_to      = [prometheus.relabel.ceph_storage_metrics.receiver]
+}
+
 prometheus.relabel "arc_resource_metrics" {
   forward_to = [prometheus.remote_write.mimir.receiver]
 

--- a/argocd/applications/observability/cluster-metrics-alloy-config.river
+++ b/argocd/applications/observability/cluster-metrics-alloy-config.river
@@ -100,6 +100,16 @@ prometheus.relabel "arc_resource_metrics" {
   }
 }
 
+prometheus.relabel "rbd_client_metrics" {
+  forward_to = [prometheus.remote_write.mimir.receiver]
+
+  rule {
+    action        = "keep"
+    source_labels = ["__name__", "device", "container", "pod"]
+    regex         = "container_fs_(reads|writes)(_bytes)?_total;/dev/rbd[0-9]+;;.+"
+  }
+}
+
 discovery.kubernetes "nodes" {
   role = "node"
 }
@@ -170,7 +180,10 @@ prometheus.scrape "kubelet_cadvisor" {
   scrape_interval   = "30s"
   scrape_timeout    = "10s"
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
-  forward_to        = [prometheus.relabel.arc_resource_metrics.receiver]
+  forward_to = [
+    prometheus.relabel.arc_resource_metrics.receiver,
+    prometheus.relabel.rbd_client_metrics.receiver,
+  ]
 
   tls_config {
     ca_file     = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"

--- a/argocd/applications/observability/cluster-metrics-alloy-config.river
+++ b/argocd/applications/observability/cluster-metrics-alloy-config.river
@@ -9,21 +9,17 @@ prometheus.remote_write "mimir" {
   }
 }
 
-discovery.kubernetes "torghut_cnpg_pods" {
+discovery.kubernetes "cnpg_pods" {
   role = "pod"
-
-  namespaces {
-    names = ["torghut"]
-  }
 
   selectors {
     role  = "pod"
-    label = "cnpg.io/cluster=torghut-db"
+    label = "cnpg.io/cluster"
   }
 }
 
-discovery.relabel "torghut_cnpg_metrics" {
-  targets = discovery.kubernetes.torghut_cnpg_pods.targets
+discovery.relabel "cnpg_metrics" {
+  targets = discovery.kubernetes.cnpg_pods.targets
 
   rule {
     action        = "keep"
@@ -52,22 +48,22 @@ discovery.relabel "torghut_cnpg_metrics" {
   }
 }
 
-prometheus.relabel "torghut_cnpg_metrics" {
+prometheus.relabel "cnpg_metrics" {
   forward_to = [prometheus.remote_write.mimir.receiver]
 
   rule {
     action        = "keep"
     source_labels = ["__name__", "name"]
-    regex         = "up;.*|cnpg_collector_postgres_version;.*|cnpg_collector_wal_(buffers_full|bytes|fpi|records|sync|sync_time|write|write_time);.*|cnpg_pg_database_size_bytes;.*|cnpg_pg_stat_checkpointer_(buffers_written|checkpoints_req|checkpoints_timed|restartpoints_done|restartpoints_req|restartpoints_timed|sync_time|write_time);.*|cnpg_pg_settings_setting;(checkpoint_completion_target|checkpoint_timeout|fsync|full_page_writes|max_wal_size|min_wal_size)"
+    regex         = "up;.*|cnpg_collector_postgres_version;.*|cnpg_collector_pg_wal(_archive_status)?;.*|cnpg_collector_wal_(buffers_full|bytes|fpi|records|sync|sync_time|write|write_time);.*|cnpg_pg_database_size_bytes;.*|cnpg_pg_stat_checkpointer_(buffers_written|checkpoints_req|checkpoints_timed|restartpoints_done|restartpoints_req|restartpoints_timed|sync_time|write_time);.*|cnpg_pg_settings_setting;(checkpoint_completion_target|checkpoint_timeout|fsync|full_page_writes|max_wal_size|min_wal_size)"
   }
 }
 
-prometheus.scrape "torghut_cnpg" {
-  job_name        = "torghut-postgres"
-  targets         = discovery.relabel.torghut_cnpg_metrics.output
+prometheus.scrape "cnpg" {
+  job_name        = "cnpg-postgres"
+  targets         = discovery.relabel.cnpg_metrics.output
   scrape_interval = "30s"
   scrape_timeout  = "10s"
-  forward_to      = [prometheus.relabel.torghut_cnpg_metrics.receiver]
+  forward_to      = [prometheus.relabel.cnpg_metrics.receiver]
 }
 
 prometheus.relabel "ceph_storage_metrics" {

--- a/argocd/applications/observability/cluster-metrics-alloy-deployment.yaml
+++ b/argocd/applications/observability/cluster-metrics-alloy-deployment.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        observability.proompteng.ai/config-sha256: 476dc2804465f1df69fdb37158a196166fd9c63cb9ac74496eaa3bd465ac967c
+        observability.proompteng.ai/config-sha256: d1d2ca7380da069def5405eec6a54cb506df14e4f9b29163335ec836e879c52a
       labels:
         app.kubernetes.io/name: observability-cluster-metrics-alloy
         app.kubernetes.io/component: cluster-metrics

--- a/argocd/applications/observability/cluster-metrics-alloy-deployment.yaml
+++ b/argocd/applications/observability/cluster-metrics-alloy-deployment.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        observability.proompteng.ai/config-sha256: d1d2ca7380da069def5405eec6a54cb506df14e4f9b29163335ec836e879c52a
+        observability.proompteng.ai/config-sha256: 518bfd73027879918d7c1ce8cbfcbe94b62f0a3dcebfa8fbca506475d96151ec
       labels:
         app.kubernetes.io/name: observability-cluster-metrics-alloy
         app.kubernetes.io/component: cluster-metrics

--- a/argocd/applications/observability/cluster-metrics-alloy-deployment.yaml
+++ b/argocd/applications/observability/cluster-metrics-alloy-deployment.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        observability.proompteng.ai/config-sha256: 659fedceb5af5589e466d54363df35d0e29f4a77738462b8cfc3f9ae4655b43b
+        observability.proompteng.ai/config-sha256: 476dc2804465f1df69fdb37158a196166fd9c63cb9ac74496eaa3bd465ac967c
       labels:
         app.kubernetes.io/name: observability-cluster-metrics-alloy
         app.kubernetes.io/component: cluster-metrics

--- a/argocd/applications/observability/graf-mimir-rules.yaml
+++ b/argocd/applications/observability/graf-mimir-rules.yaml
@@ -242,6 +242,28 @@ data:
             expr: |
               sum(ceph_pg_scrubbing{job="ceph-storage"}) +
               sum(ceph_pg_deep{job="ceph-storage"})
+          - record: ceph_storage:rbd_pod_write_bytes_per_second:rate5m
+            expr: |
+              sum by (namespace, pod, device) (
+                rate(
+                  container_fs_writes_bytes_total{
+                    container="",
+                    device=~"/dev/rbd[0-9]+",
+                    pod!=""
+                  }[5m]
+                )
+              )
+          - record: ceph_storage:rbd_pod_write_iops:rate5m
+            expr: |
+              sum by (namespace, pod, device) (
+                rate(
+                  container_fs_writes_total{
+                    container="",
+                    device=~"/dev/rbd[0-9]+",
+                    pod!=""
+                  }[5m]
+                )
+              )
       - name: torghut-storage-alerts.rules
         rules:
           - alert: TorghutPostgresMetricsMissing

--- a/argocd/applications/observability/graf-mimir-rules.yaml
+++ b/argocd/applications/observability/graf-mimir-rules.yaml
@@ -184,6 +184,206 @@ data:
               description: |
                 Requested CPU on the arm64 runner node is above 90% of allocatable CPU for 15 minutes.
                 ARC arm64 runner scale-out may be blocked even if live CPU usage is low.
+      - name: torghut-storage-baseline.rules
+        interval: 30s
+        rules:
+          - record: torghut_postgres:wal_bytes_per_second:rate5m
+            expr: |
+              max(
+                rate(
+                  cnpg_collector_wal_bytes{
+                    cluster="torghut-db",
+                    job="torghut-postgres",
+                    role="primary"
+                  }[5m]
+                )
+              )
+          - record: torghut_postgres:requested_checkpoint_ratio:rate1h
+            expr: |
+              sum(
+                rate(
+                  cnpg_pg_stat_checkpointer_checkpoints_req{
+                    cluster="torghut-db",
+                    job="torghut-postgres",
+                    role="primary"
+                  }[1h]
+                )
+              ) /
+              clamp_min(
+                sum(
+                  rate(
+                    cnpg_pg_stat_checkpointer_checkpoints_req{
+                      cluster="torghut-db",
+                      job="torghut-postgres",
+                      role="primary"
+                    }[1h]
+                  )
+                ) +
+                sum(
+                  rate(
+                    cnpg_pg_stat_checkpointer_checkpoints_timed{
+                      cluster="torghut-db",
+                      job="torghut-postgres",
+                      role="primary"
+                    }[1h]
+                  )
+                ),
+                0.000001
+              )
+          - record: ceph_storage:osd_commit_latency_ms:max
+            expr: max(ceph_osd_commit_latency_ms{job="ceph-storage"})
+          - record: ceph_storage:osd_apply_latency_ms:max
+            expr: max(ceph_osd_apply_latency_ms{job="ceph-storage"})
+          - record: ceph_storage:pool_write_bytes_per_second:rate5m
+            expr: sum(rate(ceph_pool_wr_bytes{job="ceph-storage"}[5m]))
+          - record: ceph_storage:pool_read_bytes_per_second:rate5m
+            expr: sum(rate(ceph_pool_rd_bytes{job="ceph-storage"}[5m]))
+          - record: ceph_storage:scrubbing_pgs:sum
+            expr: |
+              sum(ceph_pg_scrubbing{job="ceph-storage"}) +
+              sum(ceph_pg_deep{job="ceph-storage"})
+      - name: torghut-storage-alerts.rules
+        rules:
+          - alert: TorghutPostgresMetricsMissing
+            expr: |
+              min(up{job="torghut-postgres"}) < 1 or
+              absent(up{job="torghut-postgres"})
+            for: 10m
+            labels:
+              severity: warning
+              service: torghut-postgres
+              team: platform
+            annotations:
+              summary: Torghut PostgreSQL storage metrics are missing
+              description: CloudNativePG metrics for torghut-db have been absent or failing for 10 minutes.
+              runbook_url: docs/torghut/storage-write-pressure-remediation-design.md
+          - alert: CephStorageMetricsMissing
+            expr: |
+              min(up{job="ceph-storage"}) < 1 or
+              absent(up{job="ceph-storage"})
+            for: 10m
+            labels:
+              severity: warning
+              service: ceph-storage
+              team: platform
+            annotations:
+              summary: Ceph storage metrics are missing
+              description: The Rook Ceph manager metrics endpoint has been absent or failing for 10 minutes.
+              runbook_url: docs/torghut/storage-write-pressure-remediation-design.md
+          - alert: CephClusterHealthWarning
+            expr: ceph_health_status{job="ceph-storage"} == 1
+            for: 10m
+            labels:
+              severity: warning
+              service: ceph-storage
+              team: platform
+            annotations:
+              summary: Ceph cluster reports HEALTH_WARN
+              description: Ceph has reported HEALTH_WARN continuously for 10 minutes.
+              runbook_url: docs/torghut/storage-write-pressure-remediation-design.md
+          - alert: CephClusterHealthError
+            expr: ceph_health_status{job="ceph-storage"} >= 2
+            for: 5m
+            labels:
+              severity: critical
+              service: ceph-storage
+              team: platform
+            annotations:
+              summary: Ceph cluster reports HEALTH_ERR
+              description: Ceph has reported HEALTH_ERR continuously for 5 minutes.
+              runbook_url: docs/torghut/storage-write-pressure-remediation-design.md
+          - alert: CephOsdCommitLatencyHigh
+            expr: ceph_storage:osd_commit_latency_ms:max > 75
+            for: 15m
+            labels:
+              severity: warning
+              service: ceph-storage
+              team: platform
+            annotations:
+              summary: Ceph OSD commit latency exceeds 75 ms
+              description: The slowest Ceph OSD has sustained commit latency above 75 ms for 15 minutes.
+              runbook_url: docs/torghut/storage-write-pressure-remediation-design.md
+          - alert: CephOsdCommitLatencyCritical
+            expr: ceph_storage:osd_commit_latency_ms:max > 150
+            for: 5m
+            labels:
+              severity: critical
+              service: ceph-storage
+              team: platform
+            annotations:
+              summary: Ceph OSD commit latency exceeds 150 ms
+              description: The slowest Ceph OSD has sustained commit latency above 150 ms for 5 minutes.
+              runbook_url: docs/torghut/storage-write-pressure-remediation-design.md
+          - alert: CephScrubDebt
+            expr: |
+              max(
+                ceph_health_detail{
+                  job="ceph-storage",
+                  name=~"PG_NOT_(DEEP_)?SCRUBBED"
+                }
+              ) > 0
+            for: 30m
+            labels:
+              severity: warning
+              service: ceph-storage
+              team: platform
+            annotations:
+              summary: Ceph scrub debt is overdue
+              description: Ceph has reported overdue scrub or deep-scrub placement groups for 30 minutes.
+              runbook_url: docs/torghut/storage-write-pressure-remediation-design.md
+          - alert: CephScrubbingDisabled
+            expr: |
+              max(
+                ceph_osd_flag_noscrub{job="ceph-storage"} or
+                ceph_osd_flag_nodeep_scrub{job="ceph-storage"}
+              ) > 0
+            for: 30m
+            labels:
+              severity: warning
+              service: ceph-storage
+              team: platform
+            annotations:
+              summary: Ceph scrub protection flags remain enabled
+              description: noscrub or nodeep-scrub has remained set for 30 minutes.
+              runbook_url: docs/torghut/storage-write-pressure-remediation-design.md
+          - alert: TorghutPostgresForcedCheckpointsHigh
+            expr: |
+              torghut_postgres:requested_checkpoint_ratio:rate1h > 0.25
+              and
+              increase(
+                cnpg_pg_stat_checkpointer_checkpoints_req{
+                  cluster="torghut-db",
+                  job="torghut-postgres",
+                  role="primary"
+                }[1h]
+              ) >= 4
+            for: 30m
+            labels:
+              severity: warning
+              service: torghut-postgres
+              team: platform
+            annotations:
+              summary: Torghut PostgreSQL is forcing checkpoints
+              description: More than 25% of checkpoints were requested and at least four were forced in the last hour.
+              runbook_url: docs/torghut/storage-write-pressure-remediation-design.md
+          - alert: TorghutPostgresWalBuffersFull
+            expr: |
+              increase(
+                cnpg_collector_wal_buffers_full{
+                  cluster="torghut-db",
+                  job="torghut-postgres",
+                  role="primary"
+                }[15m]
+              ) > 0
+            for: 15m
+            labels:
+              severity: warning
+              service: torghut-postgres
+              team: platform
+            annotations:
+              summary: Torghut PostgreSQL WAL buffers are saturating
+              description: PostgreSQL has exhausted WAL buffers during every evaluation for 15 minutes.
+              runbook_url: docs/torghut/storage-write-pressure-remediation-design.md
       - name: torghut-clickhouse.guardrails.rules
         rules:
           - alert: TorghutClickHouseDiskFreeLowWarning

--- a/argocd/applications/observability/graf-mimir-rules.yaml
+++ b/argocd/applications/observability/graf-mimir-rules.yaml
@@ -193,7 +193,7 @@ data:
                 rate(
                   cnpg_collector_wal_bytes{
                     cluster="torghut-db",
-                    job="torghut-postgres",
+                    job="cnpg-postgres",
                     role="primary"
                   }[5m]
                 )
@@ -204,7 +204,7 @@ data:
                 rate(
                   cnpg_pg_stat_checkpointer_checkpoints_req{
                     cluster="torghut-db",
-                    job="torghut-postgres",
+                    job="cnpg-postgres",
                     role="primary"
                   }[1h]
                 )
@@ -214,7 +214,7 @@ data:
                   rate(
                     cnpg_pg_stat_checkpointer_checkpoints_req{
                       cluster="torghut-db",
-                      job="torghut-postgres",
+                      job="cnpg-postgres",
                       role="primary"
                     }[1h]
                   )
@@ -223,7 +223,7 @@ data:
                   rate(
                     cnpg_pg_stat_checkpointer_checkpoints_timed{
                       cluster="torghut-db",
-                      job="torghut-postgres",
+                      job="cnpg-postgres",
                       role="primary"
                     }[1h]
                   )
@@ -246,8 +246,8 @@ data:
         rules:
           - alert: TorghutPostgresMetricsMissing
             expr: |
-              min(up{job="torghut-postgres"}) < 1 or
-              absent(up{job="torghut-postgres"})
+              min(up{cluster="torghut-db",job="cnpg-postgres"}) < 1 or
+              absent(up{cluster="torghut-db",job="cnpg-postgres"})
             for: 10m
             labels:
               severity: warning
@@ -269,6 +269,23 @@ data:
             annotations:
               summary: Ceph storage metrics are missing
               description: The Rook Ceph manager metrics endpoint has been absent or failing for 10 minutes.
+              runbook_url: docs/torghut/storage-write-pressure-remediation-design.md
+          - alert: CloudNativePgWalArchiveBacklog
+            expr: |
+              max by (namespace, cluster) (
+                cnpg_collector_pg_wal_archive_status{
+                  job="cnpg-postgres",
+                  value="ready"
+                }
+              ) > 4
+            for: 15m
+            labels:
+              severity: warning
+              service: cnpg-postgres
+              team: platform
+            annotations:
+              summary: CloudNativePG WAL archive backlog is growing
+              description: {{ $labels.namespace }}/{{ $labels.cluster }} has more than four WAL segments waiting to archive for 15 minutes.
               runbook_url: docs/torghut/storage-write-pressure-remediation-design.md
           - alert: CephClusterHealthWarning
             expr: ceph_health_status{job="ceph-storage"} == 1
@@ -364,7 +381,7 @@ data:
               increase(
                 cnpg_pg_stat_checkpointer_checkpoints_req{
                   cluster="torghut-db",
-                  job="torghut-postgres",
+                  job="cnpg-postgres",
                   role="primary"
                 }[1h]
               ) >= 4
@@ -382,7 +399,7 @@ data:
               increase(
                 cnpg_collector_wal_buffers_full{
                   cluster="torghut-db",
-                  job="torghut-postgres",
+                  job="cnpg-postgres",
                   role="primary"
                 }[15m]
               ) > 0

--- a/argocd/applications/observability/graf-mimir-rules.yaml
+++ b/argocd/applications/observability/graf-mimir-rules.yaml
@@ -309,6 +309,51 @@ data:
               summary: CloudNativePG WAL archive backlog is growing
               description: {{ $labels.namespace }}/{{ $labels.cluster }} has more than four WAL segments waiting to archive for 15 minutes.
               runbook_url: docs/torghut/storage-write-pressure-remediation-design.md
+          - alert: PersistentVolumeFreeLowWarning
+            expr: |
+              (
+                min by (namespace, persistentvolumeclaim) (
+                  kubelet_volume_stats_available_bytes{persistentvolumeclaim!=""}
+                ) /
+                min by (namespace, persistentvolumeclaim) (
+                  kubelet_volume_stats_capacity_bytes{persistentvolumeclaim!=""}
+                )
+              ) < 0.15
+              and
+              (
+                min by (namespace, persistentvolumeclaim) (
+                  kubelet_volume_stats_available_bytes{persistentvolumeclaim!=""}
+                ) /
+                min by (namespace, persistentvolumeclaim) (
+                  kubelet_volume_stats_capacity_bytes{persistentvolumeclaim!=""}
+                )
+              ) >= 0.05
+            for: 30m
+            labels:
+              severity: warning
+              service: kubernetes-storage
+              team: platform
+            annotations:
+              summary: Persistent volume free space is low
+              description: {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }} has less than 15% free space for 30 minutes.
+              runbook_url: docs/torghut/storage-write-pressure-remediation-design.md
+          - alert: PersistentVolumeFreeLowCritical
+            expr: |
+              min by (namespace, persistentvolumeclaim) (
+                kubelet_volume_stats_available_bytes{persistentvolumeclaim!=""}
+              ) /
+              min by (namespace, persistentvolumeclaim) (
+                kubelet_volume_stats_capacity_bytes{persistentvolumeclaim!=""}
+              ) < 0.05
+            for: 10m
+            labels:
+              severity: critical
+              service: kubernetes-storage
+              team: platform
+            annotations:
+              summary: Persistent volume free space is critically low
+              description: {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }} has less than 5% free space for 10 minutes.
+              runbook_url: docs/torghut/storage-write-pressure-remediation-design.md
           - alert: CephClusterHealthWarning
             expr: ceph_health_status{job="ceph-storage"} == 1
             for: 10m

--- a/argocd/applications/observability/graf-mimir-rules.yaml
+++ b/argocd/applications/observability/graf-mimir-rules.yaml
@@ -361,10 +361,8 @@ data:
               runbook_url: docs/torghut/storage-write-pressure-remediation-design.md
           - alert: CephScrubbingDisabled
             expr: |
-              max(
-                ceph_osd_flag_noscrub{job="ceph-storage"} or
-                ceph_osd_flag_nodeep_scrub{job="ceph-storage"}
-              ) > 0
+              max(ceph_osd_flag_noscrub{job="ceph-storage"}) > 0 or
+              max(ceph_osd_flag_nodeep_scrub{job="ceph-storage"}) > 0
             for: 30m
             labels:
               severity: warning
@@ -378,12 +376,14 @@ data:
             expr: |
               torghut_postgres:requested_checkpoint_ratio:rate1h > 0.25
               and
-              increase(
-                cnpg_pg_stat_checkpointer_checkpoints_req{
-                  cluster="torghut-db",
-                  job="cnpg-postgres",
-                  role="primary"
-                }[1h]
+              sum(
+                increase(
+                  cnpg_pg_stat_checkpointer_checkpoints_req{
+                    cluster="torghut-db",
+                    job="cnpg-postgres",
+                    role="primary"
+                  }[1h]
+                )
               ) >= 4
             for: 30m
             labels:

--- a/argocd/applications/observability/graf-mimir-rules.yaml
+++ b/argocd/applications/observability/graf-mimir-rules.yaml
@@ -307,7 +307,8 @@ data:
               team: platform
             annotations:
               summary: CloudNativePG WAL archive backlog is growing
-              description: {{ $labels.namespace }}/{{ $labels.cluster }} has more than four WAL segments waiting to archive for 15 minutes.
+              description: |
+                {{ $labels.namespace }}/{{ $labels.cluster }} has more than four WAL segments waiting to archive for 15 minutes.
               runbook_url: docs/torghut/storage-write-pressure-remediation-design.md
           - alert: PersistentVolumeFreeLowWarning
             expr: |
@@ -335,7 +336,8 @@ data:
               team: platform
             annotations:
               summary: Persistent volume free space is low
-              description: {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }} has less than 15% free space for 30 minutes.
+              description: |
+                {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }} has less than 15% free space for 30 minutes.
               runbook_url: docs/torghut/storage-write-pressure-remediation-design.md
           - alert: PersistentVolumeFreeLowCritical
             expr: |
@@ -352,7 +354,8 @@ data:
               team: platform
             annotations:
               summary: Persistent volume free space is critically low
-              description: {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }} has less than 5% free space for 10 minutes.
+              description: |
+                {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }} has less than 5% free space for 10 minutes.
               runbook_url: docs/torghut/storage-write-pressure-remediation-design.md
           - alert: CephClusterHealthWarning
             expr: ceph_health_status{job="ceph-storage"} == 1

--- a/argocd/applications/observability/graf-mimir-rules.yaml
+++ b/argocd/applications/observability/graf-mimir-rules.yaml
@@ -292,6 +292,17 @@ data:
               summary: Ceph cluster reports HEALTH_ERR
               description: Ceph has reported HEALTH_ERR continuously for 5 minutes.
               runbook_url: docs/torghut/storage-write-pressure-remediation-design.md
+          - alert: CephSlowOps
+            expr: ceph_healthcheck_slow_ops{job="ceph-storage"} > 0
+            for: 5m
+            labels:
+              severity: critical
+              service: ceph-storage
+              team: platform
+            annotations:
+              summary: Ceph reports slow operations
+              description: Ceph has reported one or more slow operations continuously for 5 minutes.
+              runbook_url: docs/torghut/storage-write-pressure-remediation-design.md
           - alert: CephOsdCommitLatencyHigh
             expr: ceph_storage:osd_commit_latency_ms:max > 75
             for: 15m

--- a/argocd/applications/observability/kustomization.yaml
+++ b/argocd/applications/observability/kustomization.yaml
@@ -102,6 +102,16 @@ patches:
           argocd.argoproj.io/sync-options: Replace=true
   - target:
       kind: StatefulSet
+      name: observability-mimir-kafka
+    patch: |-
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: observability-mimir-kafka
+        annotations:
+          argocd.argoproj.io/sync-options: Replace=true
+  - target:
+      kind: StatefulSet
       name: observability-tempo-ingester
     patch: |-
       apiVersion: apps/v1

--- a/argocd/applications/observability/mimir-values.yaml
+++ b/argocd/applications/observability/mimir-values.yaml
@@ -131,6 +131,12 @@ alertmanager:
     storageClass: rook-ceph-block
     size: 5Gi
 
+kafka:
+  persistence:
+    enabled: true
+    size: 20Gi
+    storageClassName: rook-ceph-block
+
 metaMonitoring:
   dashboards:
     enabled: false

--- a/packages/scripts/src/shared/__tests__/storage-observability-contract.test.ts
+++ b/packages/scripts/src/shared/__tests__/storage-observability-contract.test.ts
@@ -9,6 +9,8 @@ const readRepoFile = (path: string): string => readFileSync(new URL(path, repoRo
 test('cluster Alloy collects bounded CloudNativePG and Ceph storage metrics', () => {
   const config = readRepoFile('argocd/applications/observability/cluster-metrics-alloy-config.river')
   const deployment = readRepoFile('argocd/applications/observability/cluster-metrics-alloy-deployment.yaml')
+  const kustomization = readRepoFile('argocd/applications/observability/kustomization.yaml')
+  const mimirValues = readRepoFile('argocd/applications/observability/mimir-values.yaml')
 
   expect(config).toContain('discovery.kubernetes "cnpg_pods"')
   expect(config).toContain('label = "cnpg.io/cluster"')
@@ -25,6 +27,12 @@ test('cluster Alloy collects bounded CloudNativePG and Ceph storage metrics', ()
   expect(config).toContain('prometheus.relabel "rbd_client_metrics"')
   expect(config).toContain('container_fs_(reads|writes)(_bytes)?_total;/dev/rbd[0-9]+;;.+')
   expect(config).toContain('prometheus.relabel.rbd_client_metrics.receiver')
+  expect(mimirValues).toContain(
+    'kafka:\n  persistence:\n    enabled: true\n    size: 20Gi\n    storageClassName: rook-ceph-block',
+  )
+  expect(kustomization).toContain(
+    'name: observability-mimir-kafka\n    patch: |-\n      apiVersion: apps/v1\n      kind: StatefulSet',
+  )
   expect(deployment).toContain(
     `observability.proompteng.ai/config-sha256: ${createHash('sha256').update(config).digest('hex')}`,
   )
@@ -42,6 +50,8 @@ test('Mimir records the storage baseline and alerts on actionable pressure', () 
     'ceph_storage:rbd_pod_write_iops:rate5m',
     'alert: TorghutPostgresMetricsMissing',
     'alert: CloudNativePgWalArchiveBacklog',
+    'alert: PersistentVolumeFreeLowWarning',
+    'alert: PersistentVolumeFreeLowCritical',
     'alert: CephStorageMetricsMissing',
     'alert: CephClusterHealthWarning',
     'alert: CephClusterHealthError',

--- a/packages/scripts/src/shared/__tests__/storage-observability-contract.test.ts
+++ b/packages/scripts/src/shared/__tests__/storage-observability-contract.test.ts
@@ -37,6 +37,7 @@ test('Mimir records the storage baseline and alerts on actionable pressure', () 
     'alert: CephStorageMetricsMissing',
     'alert: CephClusterHealthWarning',
     'alert: CephClusterHealthError',
+    'alert: CephSlowOps',
     'alert: CephOsdCommitLatencyHigh',
     'alert: CephOsdCommitLatencyCritical',
     'alert: CephScrubDebt',

--- a/packages/scripts/src/shared/__tests__/storage-observability-contract.test.ts
+++ b/packages/scripts/src/shared/__tests__/storage-observability-contract.test.ts
@@ -1,0 +1,49 @@
+import { createHash } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+
+import { expect, test } from 'bun:test'
+
+const repoRoot = new URL('../../../../../', import.meta.url)
+const readRepoFile = (path: string): string => readFileSync(new URL(path, repoRoot), 'utf8')
+
+test('cluster Alloy collects bounded Torghut PostgreSQL and Ceph storage metrics', () => {
+  const config = readRepoFile('argocd/applications/observability/cluster-metrics-alloy-config.river')
+  const deployment = readRepoFile('argocd/applications/observability/cluster-metrics-alloy-deployment.yaml')
+
+  expect(config).toContain('discovery.kubernetes "torghut_cnpg_pods"')
+  expect(config).toContain('label = "cnpg.io/cluster=torghut-db"')
+  expect(config).toContain('__meta_kubernetes_pod_container_port_name')
+  expect(config).toContain('prometheus.relabel "torghut_cnpg_metrics"')
+  expect(config).toContain('cnpg_collector_wal_(buffers_full|bytes|fpi|records|sync|sync_time|write|write_time)')
+  expect(config).toContain('cnpg_pg_stat_checkpointer_')
+  expect(config).toContain('prometheus.scrape "ceph_storage"')
+  expect(config).toContain('rook-ceph-mgr.rook-ceph.svc.cluster.local:9283')
+  expect(config).toContain('ceph_osd_(apply|commit)_latency_ms')
+  expect(config).toContain('ceph_health_detail')
+  expect(deployment).toContain(
+    `observability.proompteng.ai/config-sha256: ${createHash('sha256').update(config).digest('hex')}`,
+  )
+})
+
+test('Mimir records the storage baseline and alerts on actionable pressure', () => {
+  const rules = readRepoFile('argocd/applications/observability/graf-mimir-rules.yaml')
+
+  for (const contract of [
+    'torghut_postgres:wal_bytes_per_second:rate5m',
+    'torghut_postgres:requested_checkpoint_ratio:rate1h',
+    'ceph_storage:osd_commit_latency_ms:max',
+    'ceph_storage:pool_write_bytes_per_second:rate5m',
+    'alert: TorghutPostgresMetricsMissing',
+    'alert: CephStorageMetricsMissing',
+    'alert: CephClusterHealthWarning',
+    'alert: CephClusterHealthError',
+    'alert: CephOsdCommitLatencyHigh',
+    'alert: CephOsdCommitLatencyCritical',
+    'alert: CephScrubDebt',
+    'alert: CephScrubbingDisabled',
+    'alert: TorghutPostgresForcedCheckpointsHigh',
+    'alert: TorghutPostgresWalBuffersFull',
+  ]) {
+    expect(rules).toContain(contract)
+  }
+})

--- a/packages/scripts/src/shared/__tests__/storage-observability-contract.test.ts
+++ b/packages/scripts/src/shared/__tests__/storage-observability-contract.test.ts
@@ -6,14 +6,16 @@ import { expect, test } from 'bun:test'
 const repoRoot = new URL('../../../../../', import.meta.url)
 const readRepoFile = (path: string): string => readFileSync(new URL(path, repoRoot), 'utf8')
 
-test('cluster Alloy collects bounded Torghut PostgreSQL and Ceph storage metrics', () => {
+test('cluster Alloy collects bounded CloudNativePG and Ceph storage metrics', () => {
   const config = readRepoFile('argocd/applications/observability/cluster-metrics-alloy-config.river')
   const deployment = readRepoFile('argocd/applications/observability/cluster-metrics-alloy-deployment.yaml')
 
-  expect(config).toContain('discovery.kubernetes "torghut_cnpg_pods"')
-  expect(config).toContain('label = "cnpg.io/cluster=torghut-db"')
+  expect(config).toContain('discovery.kubernetes "cnpg_pods"')
+  expect(config).toContain('label = "cnpg.io/cluster"')
   expect(config).toContain('__meta_kubernetes_pod_container_port_name')
-  expect(config).toContain('prometheus.relabel "torghut_cnpg_metrics"')
+  expect(config).toContain('prometheus.relabel "cnpg_metrics"')
+  expect(config).toContain('job_name        = "cnpg-postgres"')
+  expect(config).toContain('cnpg_collector_pg_wal(_archive_status)?')
   expect(config).toContain('cnpg_collector_wal_(buffers_full|bytes|fpi|records|sync|sync_time|write|write_time)')
   expect(config).toContain('cnpg_pg_stat_checkpointer_')
   expect(config).toContain('prometheus.scrape "ceph_storage"')
@@ -34,6 +36,7 @@ test('Mimir records the storage baseline and alerts on actionable pressure', () 
     'ceph_storage:osd_commit_latency_ms:max',
     'ceph_storage:pool_write_bytes_per_second:rate5m',
     'alert: TorghutPostgresMetricsMissing',
+    'alert: CloudNativePgWalArchiveBacklog',
     'alert: CephStorageMetricsMissing',
     'alert: CephClusterHealthWarning',
     'alert: CephClusterHealthError',

--- a/packages/scripts/src/shared/__tests__/storage-observability-contract.test.ts
+++ b/packages/scripts/src/shared/__tests__/storage-observability-contract.test.ts
@@ -50,4 +50,10 @@ test('Mimir records the storage baseline and alerts on actionable pressure', () 
   ]) {
     expect(rules).toContain(contract)
   }
+
+  expect(rules).toContain('max(ceph_osd_flag_noscrub{job="ceph-storage"}) > 0 or')
+  expect(rules).toContain('max(ceph_osd_flag_nodeep_scrub{job="ceph-storage"}) > 0')
+  expect(rules).toContain(
+    'sum(\n                increase(\n                  cnpg_pg_stat_checkpointer_checkpoints_req{',
+  )
 })

--- a/packages/scripts/src/shared/__tests__/storage-observability-contract.test.ts
+++ b/packages/scripts/src/shared/__tests__/storage-observability-contract.test.ts
@@ -71,4 +71,5 @@ test('Mimir records the storage baseline and alerts on actionable pressure', () 
   expect(rules).toContain(
     'sum(\n                increase(\n                  cnpg_pg_stat_checkpointer_checkpoints_req{',
   )
+  expect(rules).not.toMatch(/^\s+(description|summary): \{\{/m)
 })

--- a/packages/scripts/src/shared/__tests__/storage-observability-contract.test.ts
+++ b/packages/scripts/src/shared/__tests__/storage-observability-contract.test.ts
@@ -22,6 +22,9 @@ test('cluster Alloy collects bounded CloudNativePG and Ceph storage metrics', ()
   expect(config).toContain('rook-ceph-mgr.rook-ceph.svc.cluster.local:9283')
   expect(config).toContain('ceph_osd_(apply|commit)_latency_ms')
   expect(config).toContain('ceph_health_detail')
+  expect(config).toContain('prometheus.relabel "rbd_client_metrics"')
+  expect(config).toContain('container_fs_(reads|writes)(_bytes)?_total;/dev/rbd[0-9]+;;.+')
+  expect(config).toContain('prometheus.relabel.rbd_client_metrics.receiver')
   expect(deployment).toContain(
     `observability.proompteng.ai/config-sha256: ${createHash('sha256').update(config).digest('hex')}`,
   )
@@ -35,6 +38,8 @@ test('Mimir records the storage baseline and alerts on actionable pressure', () 
     'torghut_postgres:requested_checkpoint_ratio:rate1h',
     'ceph_storage:osd_commit_latency_ms:max',
     'ceph_storage:pool_write_bytes_per_second:rate5m',
+    'ceph_storage:rbd_pod_write_bytes_per_second:rate5m',
+    'ceph_storage:rbd_pod_write_iops:rate5m',
     'alert: TorghutPostgresMetricsMissing',
     'alert: CloudNativePgWalArchiveBacklog',
     'alert: CephStorageMetricsMissing',


### PR DESCRIPTION
## Summary

- Scrape every CloudNativePG instance plus Rook Ceph through the existing cluster Alloy pipeline using bounded metric allowlists, so shared-Ceph pressure is attributable across Torghut, Jangar, and the other database clients.
- Record Torghut WAL/checkpoint and Ceph latency/I/O baselines; alert on missing telemetry, WAL archive backlog, Ceph health/slow operations, OSD latency, scrub debt, forced checkpoints, and WAL-buffer exhaustion.
- Roll Alloy on an exact config digest, document live Mimir validation queries, and add contract tests that pin collection, alerting, and rollout behavior.
- Add generic 15%/5% PVC headroom guards and raise the future Mimir ingest-Kafka claim template from 5 GiB to 20 GiB.

## Related Issues

None.

## Testing

- `bun test packages/scripts/src/shared/__tests__/storage-observability-contract.test.ts` (2 passed, 42 assertions)
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/storage-observability-contract.test.ts argocd/applications/observability/README.md`
- `bun run lint:argocd`
- `nix develop --command kustomize build --enable-helm argocd/applications/observability` (rendered successfully; no Namespace resources)
- Server-side dry-run of both changed ConfigMaps and the Alloy Deployment with `--field-manager=argocd-controller`.
- Validated the proposed River configuration with the live Alloy v1.11.2 binary using `alloy validate`.
- Parsed the generic WAL-backlog, Torghut-metrics-missing, forced-checkpoint, and independent scrub-flag expressions through the live Mimir PromQL API.
- Verified the live Kubernetes selector finds all 14 CloudNativePG pods and that the Jangar/Torghut endpoints expose every allowlisted PostgreSQL metric family.
- Verified the live Ceph 19.2.4 manager endpoint exposes commit/apply latency for all six OSDs and that the exporter endpoints expose different cumulative daemon counters.
- Verified all three kubelet cAdvisor endpoints expose 592 pod-level RBD read/write samples matching the bounded relabel contract; parsed both RBD recording expressions through live Mimir.
- Rendered the Mimir Kafka StatefulSet with `Replace=true`, a 20 GiB `rook-ceph-block` claim template, and passed a server-side create dry-run under a collision-free name.
- Parsed both generic PVC-capacity alerts through live Mimir and confirmed the warning identified the only remaining sub-15% claim.
- Extracted and parsed the nested Mimir rule payload as 18 valid groups, including all 14 storage alerts, and regression-guarded unquoted template annotations.

## Screenshots (if applicable)

N/A — GitOps-only observability change.

## Breaking Changes

The CloudNativePG scrape job label changes from `torghut-postgres` to `cnpg-postgres`; all recording and alert rules in this PR are updated atomically. Argo replaces the single-replica Mimir Kafka StatefulSet once so its immutable claim template becomes 20 GiB; the retained live PVC was expanded online to 20 GiB first, and Mimir remote-write clients retry through the brief pod restart.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked in `docs/torghut/storage-write-pressure-remediation-design.md`.
