### PR TITLE
fix(jangar): bound backup pressure and restore headroom

### DIFF
--- a/argocd/applications/jangar/postgres-cluster.yaml
+++ b/argocd/applications/jangar/postgres-cluster.yaml
@@ -18,6 +18,7 @@ spec:
         - CREATE EXTENSION IF NOT EXISTS pgcrypto;
         - CREATE EXTENSION IF NOT EXISTS vector;
   backup:
+    target: prefer-standby
     barmanObjectStore:
       destinationPath: s3://cnpg
       serverName: jangar-db-live
@@ -29,8 +30,15 @@ spec:
         secretAccessKey:
           name: cnpg-jangar-db
           key: AWS_SECRET_ACCESS_KEY
+      data:
+        compression: snappy
+        jobs: 1
+        additionalCommandArgs:
+          - --max-bandwidth
+          - 8MB
       wal:
-        maxParallel: 8
+        compression: snappy
+        maxParallel: 2
     retentionPolicy: "14d"
   inheritedMetadata:
     annotations:

--- a/argocd/applications/jangar/postgres-cluster.yaml
+++ b/argocd/applications/jangar/postgres-cluster.yaml
@@ -7,7 +7,7 @@ spec:
   primaryUpdateStrategy: unsupervised
   storage:
     storageClass: rook-ceph-block
-    size: 200Gi
+    size: 300Gi
   bootstrap:
     initdb:
       database: jangar

--- a/argocd/applications/jangar/postgres-scheduled-backup.yaml
+++ b/argocd/applications/jangar/postgres-scheduled-backup.yaml
@@ -4,7 +4,8 @@ metadata:
   name: jangar-db-daily
   namespace: jangar
 spec:
-  schedule: "0 0 11 * * *"
+  # Start after the smaller Torghut backup; the bandwidth cap protects the shared path for the full run.
+  schedule: "0 0 4 * * *"
   backupOwnerReference: self
   method: barmanObjectStore
   cluster:

--- a/packages/scripts/src/shared/__tests__/cnpg-backup-pressure-contract.test.ts
+++ b/packages/scripts/src/shared/__tests__/cnpg-backup-pressure-contract.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs'
+
+import { expect, test } from 'bun:test'
+
+const repoRoot = new URL('../../../../../', import.meta.url)
+const readRepoFile = (path: string): string => readFileSync(new URL(path, repoRoot), 'utf8')
+
+test('Jangar base backups cannot saturate the shared Ceph path', () => {
+  const cluster = readRepoFile('argocd/applications/jangar/postgres-cluster.yaml')
+
+  expect(cluster).toContain('target: prefer-standby')
+  expect(cluster).toContain('data:\n        compression: snappy\n        jobs: 1')
+  expect(cluster).toContain('additionalCommandArgs:\n          - --max-bandwidth\n          - 8MB')
+  expect(cluster).toContain('wal:\n        compression: snappy\n        maxParallel: 2')
+})
+
+test('Jangar backup has an isolated start window after the Torghut backup', () => {
+  const scheduledBackup = readRepoFile('argocd/applications/jangar/postgres-scheduled-backup.yaml')
+
+  expect(scheduledBackup).toContain('schedule: "0 0 4 * * *"')
+})

--- a/packages/scripts/src/shared/__tests__/cnpg-backup-pressure-contract.test.ts
+++ b/packages/scripts/src/shared/__tests__/cnpg-backup-pressure-contract.test.ts
@@ -14,6 +14,12 @@ test('Jangar base backups cannot saturate the shared Ceph path', () => {
   expect(cluster).toContain('wal:\n        compression: snappy\n        maxParallel: 2')
 })
 
+test('Jangar database volumes retain operating headroom', () => {
+  const cluster = readRepoFile('argocd/applications/jangar/postgres-cluster.yaml')
+
+  expect(cluster).toContain('storageClass: rook-ceph-block\n    size: 300Gi')
+})
+
 test('Jangar backup has an isolated start window after the Torghut backup', () => {
   const scheduledBackup = readRepoFile('argocd/applications/jangar/postgres-scheduled-backup.yaml')
 


### PR DESCRIPTION
## Summary

- Limit Jangar base-backup uploads to one Snappy-compressed stream capped at 8 MiB/s so the shared Ceph/RGW path retains headroom for Kafka controller fsyncs.
- Prefer a standby for base backups and reduce WAL archive upload parallelism from eight workers to two.
- Move the daily backup from 11:00 UTC to 04:00 UTC, after the smaller Torghut backup window, while preserving 14-day retention and continuous WAL archiving.
- Expand both online Jangar database volumes from 200 GiB to 300 GiB after live readback found only 2.5% free capacity.
- Add a contract test that prevents removal of the concurrency, bandwidth, compression, target, and schedule safeguards.

## Related Issues

None.

## Testing

- `bun test packages/scripts/src/shared/__tests__/cnpg-backup-pressure-contract.test.ts` (3 passed, 6 assertions)
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/cnpg-backup-pressure-contract.test.ts`
- `nix develop --command kustomize build --enable-helm argocd/applications/jangar`
- Server-side dry-run of the rendered `Cluster/jangar-db` and `ScheduledBackup/jangar-db-daily` with field manager `argocd-controller`.
- `bun run lint:argocd`
- Parsed the exact `--snappy --jobs 1 --max-bandwidth 8MB` argument set with the live Barman 3.11.1 runtime; it resolves to one uploader and an 8,388,608-byte/s cap.
- Confirmed the live PostgreSQL image contains python-snappy 0.7.3 and supports Snappy for both base backups and WAL archives.

## Screenshots (if applicable)

N/A.

## Breaking Changes

The daily base-backup start moves from 11:00 UTC to 04:00 UTC. Both Jangar CNPG PVC requests expand online from 200 GiB to 300 GiB; shrinking is not supported. Backup destination, server name, retention, credentials, and recovery format remain unchanged.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
