### PR TITLE
chore(torghut): promote image sha-023fd5e54742bb8a39d7f47a5bbc06a7959e4a81

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -22,7 +22,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: migrate
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:a18f1ee7c671dd86964e1dcf37fd1a934f7c76b732c12b2366f00c283410edbd
           imagePullPolicy: Always
           workingDir: /app
           command:
@@ -52,9 +52,9 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: cd9e04b9652e8b4b1a1cf15d0281ca2b13e1f4fe
+              value: 023fd5e54742bb8a39d7f47a5bbc06a7959e4a81
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
+              value: sha256:a18f1ee7c671dd86964e1dcf37fd1a934f7c76b732c12b2366f00c283410edbd
             - name: PYTHONPATH
               value: /app
             - name: DB_DSN

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-hyperliquid-runtime
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:a18f1ee7c671dd86964e1dcf37fd1a934f7c76b732c12b2366f00c283410edbd
           imagePullPolicy: Always
           command:
             - uvicorn
@@ -46,9 +46,9 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: cd9e04b9652e8b4b1a1cf15d0281ca2b13e1f4fe
+              value: 023fd5e54742bb8a39d7f47a5bbc06a7959e4a81
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
+              value: sha256:a18f1ee7c671dd86964e1dcf37fd1a934f7c76b732c12b2366f00c283410edbd
             - name: DB_DSN
               valueFrom:
                 secretKeyRef:

--- a/argocd/applications/torghut-options/archive/deployment.yaml
+++ b/argocd/applications/torghut-options/archive/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-archive
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:a18f1ee7c671dd86964e1dcf37fd1a934f7c76b732c12b2366f00c283410edbd
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -106,9 +106,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1880-gcd9e04b96
+              value: v0.596.0-1882-g023fd5e54
             - name: TORGHUT_OPTIONS_COMMIT
-              value: cd9e04b9652e8b4b1a1cf15d0281ca2b13e1f4fe
+              value: 023fd5e54742bb8a39d7f47a5bbc06a7959e4a81
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -33,7 +33,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:a18f1ee7c671dd86964e1dcf37fd1a934f7c76b732c12b2366f00c283410edbd
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -81,9 +81,9 @@ spec:
                   name: torghut-ws-config
                   key: SYMBOLS_ALLOWLIST
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1880-gcd9e04b96
+              value: v0.596.0-1882-g023fd5e54
             - name: TORGHUT_OPTIONS_COMMIT
-              value: cd9e04b9652e8b4b1a1cf15d0281ca2b13e1f4fe
+              value: 023fd5e54742bb8a39d7f47a5bbc06a7959e4a81
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:a18f1ee7c671dd86964e1dcf37fd1a934f7c76b732c12b2366f00c283410edbd
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -77,9 +77,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1880-gcd9e04b96
+              value: v0.596.0-1882-g023fd5e54
             - name: TORGHUT_OPTIONS_COMMIT
-              value: cd9e04b9652e8b4b1a1cf15d0281ca2b13e1f4fe
+              value: 023fd5e54742bb8a39d7f47a5bbc06a7959e4a81
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:a18f1ee7c671dd86964e1dcf37fd1a934f7c76b732c12b2366f00c283410edbd
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:a18f1ee7c671dd86964e1dcf37fd1a934f7c76b732c12b2366f00c283410edbd
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:a18f1ee7c671dd86964e1dcf37fd1a934f7c76b732c12b2366f00c283410edbd
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:a18f1ee7c671dd86964e1dcf37fd1a934f7c76b732c12b2366f00c283410edbd
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:a18f1ee7c671dd86964e1dcf37fd1a934f7c76b732c12b2366f00c283410edbd
           workingDir: /app
           command:
             - /bin/sh

--- a/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
+++ b/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-generated-resource-retention
           containers:
             - name: prune-generated-residue
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:a18f1ee7c671dd86964e1dcf37fd1a934f7c76b732c12b2366f00c283410edbd
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:a18f1ee7c671dd86964e1dcf37fd1a934f7c76b732c12b2366f00c283410edbd
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-14T10:07:43Z"
+        client.knative.dev/updateTimestamp: "2026-07-14T11:52:11Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:a18f1ee7c671dd86964e1dcf37fd1a934f7c76b732c12b2366f00c283410edbd
           ports:
             - name: http1
               containerPort: 8181
@@ -523,11 +523,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1880-gcd9e04b96
+              value: v0.596.0-1882-g023fd5e54
             - name: TORGHUT_COMMIT
-              value: cd9e04b9652e8b4b1a1cf15d0281ca2b13e1f4fe
+              value: 023fd5e54742bb8a39d7f47a5bbc06a7959e4a81
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
+              value: sha256:a18f1ee7c671dd86964e1dcf37fd1a934f7c76b732c12b2366f00c283410edbd
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-14T10:07:43Z"
+        client.knative.dev/updateTimestamp: "2026-07-14T11:52:11Z"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
     spec:
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:a18f1ee7c671dd86964e1dcf37fd1a934f7c76b732c12b2366f00c283410edbd
           ports:
             - name: http1
               containerPort: 8181
@@ -448,11 +448,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1880-gcd9e04b96
+              value: v0.596.0-1882-g023fd5e54
             - name: TORGHUT_COMMIT
-              value: cd9e04b9652e8b4b1a1cf15d0281ca2b13e1f4fe
+              value: 023fd5e54742bb8a39d7f47a5bbc06a7959e4a81
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
+              value: sha256:a18f1ee7c671dd86964e1dcf37fd1a934f7c76b732c12b2366f00c283410edbd
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -37,7 +37,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:a18f1ee7c671dd86964e1dcf37fd1a934f7c76b732c12b2366f00c283410edbd
           command:
             - uvicorn
           args:
@@ -464,11 +464,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1880-gcd9e04b96
+              value: v0.596.0-1882-g023fd5e54
             - name: TORGHUT_COMMIT
-              value: cd9e04b9652e8b4b1a1cf15d0281ca2b13e1f4fe
+              value: 023fd5e54742bb8a39d7f47a5bbc06a7959e4a81
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
+              value: sha256:a18f1ee7c671dd86964e1dcf37fd1a934f7c76b732c12b2366f00c283410edbd
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: smoke
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:47736d5ab0ea9c9025d99131a7f44e052623740414c17cbfaa88e1e1a240038b
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:a18f1ee7c671dd86964e1dcf37fd1a934f7c76b732c12b2366f00c283410edbd
           imagePullPolicy: IfNotPresent
           securityContext:
             seccompProfile:


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `023fd5e54742bb8a39d7f47a5bbc06a7959e4a81`
- Image tag: `sha-023fd5e54742bb8a39d7f47a5bbc06a7959e4a81`
- Image digest: `sha256:a18f1ee7c671dd86964e1dcf37fd1a934f7c76b732c12b2366f00c283410edbd`
- Migration change detected under `services/torghut/migrations/**`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher
- Added `do-not-automerge`; manual DB migration approval required before merge