### PR TITLE
fix(bilig): bound logical WAL retention

### DIFF
--- a/argocd/applications/bilig/postgres-cluster.yaml
+++ b/argocd/applications/bilig/postgres-cluster.yaml
@@ -41,7 +41,7 @@ spec:
           name: bilig-db-app
   storage:
     storageClass: rook-ceph-block
-    size: 10Gi
+    size: 30Gi
     resizeInUseVolumes: true
   switchoverDelay: 3600
   bootstrap:
@@ -82,6 +82,7 @@ spec:
       logging_collector: "on"
       max_parallel_workers: "32"
       max_replication_slots: "32"
+      max_slot_wal_keep_size: 8GB
       max_worker_processes: "32"
       shared_memory_type: mmap
       shared_preload_libraries: ""

--- a/argocd/applications/observability/README.md
+++ b/argocd/applications/observability/README.md
@@ -83,9 +83,9 @@ kubectl -n argocd get app observability
 The observability app owns the cluster metrics pipeline used for ARC runner sizing and shared-storage diagnosis:
 
 - `observability-kube-state-metrics`: Kubernetes object state and request/limit/allocatable metrics.
-- `observability-cluster-metrics-alloy`: scrapes kube-state-metrics, kubelet, every CloudNativePG instance, and the Ceph manager; it applies bounded metric allowlists, including pod-level `/dev/rbd*` I/O only, before remote-writing to Mimir.
+- `observability-cluster-metrics-alloy`: scrapes kube-state-metrics, kubelet, every CloudNativePG instance, and the Ceph manager; it applies bounded metric allowlists, including logical-slot WAL retention and pod-level `/dev/rbd*` I/O only, before remote-writing to Mimir.
 - `arc-runner-capacity-dashboard`: Grafana dashboard for ARC CPU, memory, pending pods, and requested CPU saturation.
-- `graf-mimir-rules`: records Torghut PostgreSQL and Ceph pressure baselines and alerts on missing telemetry, low PVC capacity, WAL archive backlog, forced checkpoints, Ceph slow operations, scrub debt, and OSD latency.
+- `graf-mimir-rules`: records Torghut PostgreSQL and Ceph pressure baselines and alerts on missing telemetry, low PVC capacity, WAL archive backlog, logical-slot WAL retention, forced checkpoints, Ceph slow operations, scrub debt, and OSD latency.
 
 Validate the Mimir tenant after sync:
 

--- a/argocd/applications/observability/cluster-metrics-alloy-config.river
+++ b/argocd/applications/observability/cluster-metrics-alloy-config.river
@@ -54,7 +54,7 @@ prometheus.relabel "cnpg_metrics" {
   rule {
     action        = "keep"
     source_labels = ["__name__", "name"]
-    regex         = "up;.*|cnpg_collector_postgres_version;.*|cnpg_collector_pg_wal(_archive_status)?;.*|cnpg_collector_wal_(buffers_full|bytes|fpi|records|sync|sync_time|write|write_time);.*|cnpg_pg_database_size_bytes;.*|cnpg_pg_stat_checkpointer_(buffers_written|checkpoints_req|checkpoints_timed|restartpoints_done|restartpoints_req|restartpoints_timed|sync_time|write_time);.*|cnpg_pg_settings_setting;(checkpoint_completion_target|checkpoint_timeout|fsync|full_page_writes|max_wal_size|min_wal_size)"
+    regex         = "up;.*|cnpg_collector_postgres_version;.*|cnpg_collector_pg_wal(_archive_status)?;.*|cnpg_collector_wal_(buffers_full|bytes|fpi|records|sync|sync_time|write|write_time);.*|cnpg_pg_database_size_bytes;.*|cnpg_pg_replication_slots_(active|pg_wal_lsn_diff);.*|cnpg_pg_stat_checkpointer_(buffers_written|checkpoints_req|checkpoints_timed|restartpoints_done|restartpoints_req|restartpoints_timed|sync_time|write_time);.*|cnpg_pg_settings_setting;(checkpoint_completion_target|checkpoint_timeout|fsync|full_page_writes|max_slot_wal_keep_size|max_wal_size|min_wal_size)"
   }
 }
 

--- a/argocd/applications/observability/cluster-metrics-alloy-deployment.yaml
+++ b/argocd/applications/observability/cluster-metrics-alloy-deployment.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        observability.proompteng.ai/config-sha256: 518bfd73027879918d7c1ce8cbfcbe94b62f0a3dcebfa8fbca506475d96151ec
+        observability.proompteng.ai/config-sha256: 8d1e1567e18ad03309649c631f05115457978357b2c48b84bc8a09b0c230a43d
       labels:
         app.kubernetes.io/name: observability-cluster-metrics-alloy
         app.kubernetes.io/component: cluster-metrics

--- a/argocd/applications/observability/graf-mimir-rules.yaml
+++ b/argocd/applications/observability/graf-mimir-rules.yaml
@@ -310,6 +310,24 @@ data:
               description: |
                 {{ $labels.namespace }}/{{ $labels.cluster }} has more than four WAL segments waiting to archive for 15 minutes.
               runbook_url: docs/torghut/storage-write-pressure-remediation-design.md
+          - alert: CloudNativePgReplicationSlotWalRetentionHigh
+            expr: |
+              max by (namespace, cluster, slot_name) (
+                cnpg_pg_replication_slots_pg_wal_lsn_diff{
+                  job="cnpg-postgres",
+                  slot_type="logical"
+                }
+              ) > 2147483648
+            for: 15m
+            labels:
+              severity: warning
+              service: cnpg-postgres
+              team: platform
+            annotations:
+              summary: CloudNativePG logical replication slot is retaining WAL
+              description: |
+                {{ $labels.namespace }}/{{ $labels.cluster }} slot {{ $labels.slot_name }} has retained more than 2 GiB of WAL for 15 minutes.
+              runbook_url: docs/torghut/storage-write-pressure-remediation-design.md
           - alert: PersistentVolumeFreeLowWarning
             expr: |
               (

--- a/packages/scripts/src/shared/__tests__/bilig-postgres-storage-contract.test.ts
+++ b/packages/scripts/src/shared/__tests__/bilig-postgres-storage-contract.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs'
+
+import { expect, test } from 'bun:test'
+
+const repoRoot = new URL('../../../../../', import.meta.url)
+
+test('Bilig PostgreSQL retains recovered storage headroom and bounds logical-slot WAL', () => {
+  const cluster = readFileSync(new URL('argocd/applications/bilig/postgres-cluster.yaml', repoRoot), 'utf8')
+
+  expect(cluster).toContain('storageClass: rook-ceph-block\n    size: 30Gi\n    resizeInUseVolumes: true')
+  expect(cluster).toContain('max_slot_wal_keep_size: 8GB')
+})

--- a/packages/scripts/src/shared/__tests__/storage-observability-contract.test.ts
+++ b/packages/scripts/src/shared/__tests__/storage-observability-contract.test.ts
@@ -20,6 +20,7 @@ test('cluster Alloy collects bounded CloudNativePG and Ceph storage metrics', ()
   expect(config).toContain('cnpg_collector_pg_wal(_archive_status)?')
   expect(config).toContain('cnpg_collector_wal_(buffers_full|bytes|fpi|records|sync|sync_time|write|write_time)')
   expect(config).toContain('cnpg_pg_stat_checkpointer_')
+  expect(config).toContain('cnpg_pg_replication_slots_(active|pg_wal_lsn_diff)')
   expect(config).toContain('prometheus.scrape "ceph_storage"')
   expect(config).toContain('rook-ceph-mgr.rook-ceph.svc.cluster.local:9283')
   expect(config).toContain('ceph_osd_(apply|commit)_latency_ms')
@@ -50,6 +51,7 @@ test('Mimir records the storage baseline and alerts on actionable pressure', () 
     'ceph_storage:rbd_pod_write_iops:rate5m',
     'alert: TorghutPostgresMetricsMissing',
     'alert: CloudNativePgWalArchiveBacklog',
+    'alert: CloudNativePgReplicationSlotWalRetentionHigh',
     'alert: PersistentVolumeFreeLowWarning',
     'alert: PersistentVolumeFreeLowCritical',
     'alert: CephStorageMetricsMissing',


### PR DESCRIPTION
## Summary

- Increase the Bilig CNPG data volume from 10 GiB to 30 GiB after the live database exhausted its WAL filesystem.
- Bound logical replication-slot WAL retention at 8 GiB so a stalled Zero consumer cannot exhaust PostgreSQL storage again.
- Export per-slot retained-WAL metrics and alert after 2 GiB is retained for 15 minutes.
- Add manifest contracts for the recovered capacity, WAL bound, Alloy allowlist, and Mimir alert.

## Related Issues

None.

## Testing

- `nix develop -c alloy validate argocd/applications/observability/cluster-metrics-alloy-config.river`
- `bun test packages/scripts/src/shared/__tests__/bilig-postgres-storage-contract.test.ts packages/scripts/src/shared/__tests__/storage-observability-contract.test.ts` (3 pass, 46 assertions)
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/bilig-postgres-storage-contract.test.ts packages/scripts/src/shared/__tests__/storage-observability-contract.test.ts`
- `kustomize build --enable-helm argocd/applications/{bilig,observability}`
- Server-side dry-run of both rendered applications against the live Kubernetes API.
- `bun run lint:argocd`
- Live PromQL parser check for the replication-slot retained-WAL alert expression.
- Emergency recovery proof: expanded `bilig-db-1` PVC online to 30 GiB, remounted it, observed PostgreSQL remove 583 stale WAL segments and return `Cluster in healthy state`, and confirmed Zero's logical slot active with 56 bytes retained.

## Screenshots (if applicable)

N/A.

## Breaking Changes

None. If a logical slot falls more than 8 GiB behind, PostgreSQL may invalidate it; Zero detects invalidated slots and performs a full replica resync. The current Bilig database is 21 MiB, so this preserves database availability with a bounded recovery cost.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
