### PR TITLE
fix(torghut): make capital migrations production safe

### DIFF
--- a/.github/workflows/torghut-ci.yml
+++ b/.github/workflows/torghut-ci.yml
@@ -609,7 +609,7 @@ jobs:
     if: ${{ needs.changes.outputs.service == 'true' }}
     services:
       postgres:
-        image: postgres:18-trixie
+        image: postgres:17-bookworm
         env:
           POSTGRES_USER: torghut
           POSTGRES_PASSWORD: torghut
@@ -682,7 +682,8 @@ jobs:
             tests/execution/test_broker_mutation_receipts_postgres.py \
             tests/execution/test_broker_mutation_linked_receipts_postgres.py \
             tests/execution/test_broker_mutation_receipt_boundaries_postgres.py \
-            tests/execution/test_linked_submission_terminal_postgres.py
+            tests/execution/test_linked_submission_terminal_postgres.py \
+            tests/trading/test_strategy_capital_authority_postgres.py
 
       - name: Upload PostgreSQL coverage data
         if: always()

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -11,7 +11,9 @@ metadata:
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
 spec:
   backoffLimit: 6
-  activeDeadlineSeconds: 900
+  # Online index builds cover the live 6+ GiB options catalog; keep this above
+  # the migration's 45-minute statement timeout so Kubernetes does not kill a healthy build.
+  activeDeadlineSeconds: 3600
   ttlSecondsAfterFinished: 600
   template:
     metadata:

--- a/docs/torghut/profitability/strategy-capital-authority.md
+++ b/docs/torghut/profitability/strategy-capital-authority.md
@@ -91,6 +91,37 @@ Existing `StrategyCapitalAllocation`, `StrategyPromotionDecision`, and evidence-
 They are not rewritten, do not project a capital stage, and are not consulted as broker authority. A complete new
 authority must be independently issued and selected before any legacy evidence can participate in a broker grant.
 
+### Production migration safety
+
+Revision `0063` is an online, retry-safe migration because `trade_decisions` is a live multi-gigabyte table. The
+migration contract is:
+
+- run each revision in its own Alembic transaction and put the online DDL in an explicit autocommit block; Alembic
+  documents that entering an autocommit block commits prior work, so every statement after that boundary must be safe
+  to retry;
+- set a five-second `lock_timeout`, so a busy table causes a failed deployment and retry instead of an unbounded
+  scheduler write outage;
+- add the four nullable decision columns without defaults in one metadata-only `ALTER TABLE`, which PostgreSQL does
+  without a table rewrite;
+- add the four checks and composite foreign key as `NOT VALID`, then validate them separately. PostgreSQL enforces a
+  not-valid constraint for new writes while skipping the initial scan, and `VALIDATE CONSTRAINT` uses a lock that does
+  not exclude concurrent inserts, updates, or deletes;
+- build only the query-serving partial index, with
+  `WHERE strategy_capital_authority_allowed IS TRUE`, using `CREATE INDEX CONCURRENTLY`. Historical rows with no
+  authority verdict do not consume index space or future index-maintenance work;
+- detect and remove an invalid interrupted concurrent index before retry, and skip already-present columns,
+  constraints, triggers, and valid indexes;
+- run the required PostgreSQL integration test in CI. It must prove a complete upgrade, a second idempotent upgrade,
+  immutable history, exact constraint validation, the partial-index predicate, a forced lock timeout, the retained
+  `0062` revision after partial progress, and successful retry to `0063`.
+
+These choices follow the production PostgreSQL 17 major version's documented
+[`ALTER TABLE ... NOT VALID` and `VALIDATE CONSTRAINT`](https://www.postgresql.org/docs/17/sql-altertable.html),
+[`CREATE INDEX CONCURRENTLY`](https://www.postgresql.org/docs/17/sql-createindex.html), and
+[`lock_timeout`](https://www.postgresql.org/docs/17/runtime-config-client.html) behavior, plus Alembic's
+[`autocommit_block`](https://alembic.sqlalchemy.org/en/latest/api/runtime.html#alembic.runtime.migration.MigrationContext.autocommit_block)
+transaction warning. A green unit test that only inspects emitted method calls is not release evidence.
+
 ## Immediate Pre-Broker Evaluation
 
 For every risk-increasing order, the scheduler performs this conjunction immediately before broker submission:

--- a/docs/torghut/profitability/strategy-capital-authority.md
+++ b/docs/torghut/profitability/strategy-capital-authority.md
@@ -65,7 +65,7 @@ not accepted.
 
 ## Persistence
 
-Migration `0063_strategy_capital_authority` creates `strategy_capital_authorities` and
+Migration `0064_strategy_capital_authority` creates `strategy_capital_authorities` and
 `strategies.active_capital_authority_id`. It also adds the exact authority ID, digest, decision, and evaluation time to
 each `trade_decisions` row. These columns are the durable pre-broker reservation used for rate limits; event time and
 accepted executions are not substitutes for an attempted broker mutation.
@@ -93,7 +93,7 @@ authority must be independently issued and selected before any legacy evidence c
 
 ### Production migration safety
 
-Revision `0063` is an online, retry-safe migration because `trade_decisions` is a live multi-gigabyte table. The
+Revision `0064` is an online, retry-safe migration because `trade_decisions` is a live multi-gigabyte table. The
 migration contract is:
 
 - run each revision in its own Alembic transaction and put the online DDL in an explicit autocommit block; Alembic
@@ -121,6 +121,13 @@ These choices follow the production PostgreSQL 17 major version's documented
 [`lock_timeout`](https://www.postgresql.org/docs/17/runtime-config-client.html) behavior, plus Alembic's
 [`autocommit_block`](https://alembic.sqlalchemy.org/en/latest/api/runtime.html#alembic.runtime.migration.MigrationContext.autocommit_block)
 transaction warning. A green unit test that only inspects emitted method calls is not release evidence.
+
+The immediate predecessor, `0063_options_archive_final_idx`, follows the same autocommit, timeout, structural-index
+verification, invalid-index cleanup, and retry contract. The pre-cutover live readback was approximately 6.0 GiB and
+3.97 million planner-estimated rows for `torghut_options_contract_catalog`, plus 1.9 GiB and 154,339 exact rows for
+`trade_decisions`. The GitOps migration Job therefore has a one-hour active deadline; its former 15-minute deadline
+could terminate a healthy 45-minute concurrent index statement. This changes only the failure budget for the PreSync
+hook. It does not bypass migration failure, permit direct deployment, or increase capital authority.
 
 ## Immediate Pre-Broker Evaluation
 

--- a/services/torghut/app/models/entities/strategy_capital_records.py
+++ b/services/torghut/app/models/entities/strategy_capital_records.py
@@ -13,8 +13,10 @@ from sqlalchemy import (
     Index,
     String,
     UniqueConstraint,
+    column,
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.schema import conv
 
 from ..base import Base, GUID, JSONType
 from .model_mixins import CreatedAtMixin
@@ -29,7 +31,14 @@ class StrategyCapitalAuthorityRecord(Base, CreatedAtMixin):
     id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
     authority_id: Mapped[str] = mapped_column(String(length=128), nullable=False)
     strategy_id: Mapped[uuid.UUID] = mapped_column(
-        GUID(), ForeignKey("strategies.id", ondelete="RESTRICT"), nullable=False
+        GUID(),
+        ForeignKey(
+            "strategies.id",
+            name=conv("fk_strategy_capital_authorities_strategy"),
+            ondelete="RESTRICT",
+            onupdate="RESTRICT",
+        ),
+        nullable=False,
     )
     schema_version: Mapped[str] = mapped_column(String(length=64), nullable=False)
     stage: Mapped[str] = mapped_column(String(length=32), nullable=False)
@@ -47,42 +56,48 @@ class StrategyCapitalAuthorityRecord(Base, CreatedAtMixin):
     __table_args__ = (
         CheckConstraint(
             "schema_version = 'torghut.strategy-capital-authority.v1'",
-            name="ck_strategy_capital_authorities_schema",
+            name=conv("ck_strategy_capital_authorities_schema"),
         ),
         CheckConstraint(
             "stage IN ('disabled', 'quarantined', 'research_only', "
             "'replay_verified', 'shadow_allowed', 'paper_probation', "
             "'paper_verified', 'micro_live_allowed', 'capital_allowed', 'scaled')",
-            name="ck_strategy_capital_authorities_stage",
+            name=conv("ck_strategy_capital_authorities_stage"),
         ),
         CheckConstraint(
-            "length(authority_digest) = 71 AND authority_digest LIKE 'sha256:%'",
-            name="ck_strategy_capital_authorities_digest",
+            column("authority_digest").regexp_match(r"^sha256:[0-9a-f]{64}$"),
+            name=conv("ck_strategy_capital_authorities_digest"),
+        ),
+        CheckConstraint(
+            "length(authority_id) BETWEEN 1 AND 128",
+            name=conv("ck_strategy_capital_authorities_id"),
         ),
         CheckConstraint(
             "expires_at IS NULL OR issued_at IS NOT NULL",
-            name="ck_strategy_capital_authorities_expiry_issuance",
+            name=conv("ck_strategy_capital_authorities_expiry_issuance"),
         ),
         CheckConstraint(
             "expires_at IS NULL OR expires_at > issued_at",
-            name="ck_strategy_capital_authorities_expiry_order",
+            name=conv("ck_strategy_capital_authorities_expiry_order"),
         ),
         UniqueConstraint(
-            "authority_id", name="uq_strategy_capital_authorities_authority_id"
+            "authority_id",
+            name=conv("uq_strategy_capital_authorities_authority_id"),
         ),
         UniqueConstraint(
-            "authority_digest", name="uq_strategy_capital_authorities_digest"
+            "authority_digest",
+            name=conv("uq_strategy_capital_authorities_digest"),
         ),
         UniqueConstraint(
             "id",
             "strategy_id",
-            name="uq_strategy_capital_authorities_record_strategy",
+            name=conv("uq_strategy_capital_authorities_record_strategy"),
         ),
         UniqueConstraint(
             "authority_id",
             "authority_digest",
             "strategy_id",
-            name="uq_strategy_capital_authorities_identity",
+            name=conv("uq_strategy_capital_authorities_identity"),
         ),
         Index(
             "ix_strategy_capital_authorities_strategy_created",

--- a/services/torghut/app/models/entities/trading_records.py
+++ b/services/torghut/app/models/entities/trading_records.py
@@ -19,10 +19,12 @@ from sqlalchemy import (
     String,
     Text,
     UniqueConstraint,
+    column,
     text,
 )
 from sqlalchemy import func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.schema import conv
 
 from ..base import Base, GUID, JSONType
 from .model_mixins import CreatedAtMixin, TimestampMixin
@@ -78,7 +80,7 @@ class Strategy(Base, TimestampMixin):
                 "strategy_capital_authorities.id",
                 "strategy_capital_authorities.strategy_id",
             ],
-            name="fk_strategies_active_capital_authority_identity",
+            name=conv("fk_strategies_active_capital_authority_identity"),
             ondelete="RESTRICT",
             onupdate="RESTRICT",
         ),
@@ -156,7 +158,7 @@ class TradeDecision(Base, CreatedAtMixin):
                 "strategy_capital_authorities.authority_digest",
                 "strategy_capital_authorities.strategy_id",
             ],
-            name="fk_trade_decisions_strategy_capital_authority_identity",
+            name=conv("fk_trade_decisions_strategy_capital_authority_identity"),
             ondelete="RESTRICT",
             onupdate="RESTRICT",
         ),
@@ -183,28 +185,31 @@ class TradeDecision(Base, CreatedAtMixin):
             "strategy_id",
             "alpaca_account_label",
             "strategy_capital_authority_evaluated_at",
+            postgresql_where=text("strategy_capital_authority_allowed IS TRUE"),
+            sqlite_where=text("strategy_capital_authority_allowed IS TRUE"),
         ),
         CheckConstraint(
             "strategy_capital_authority_allowed IS NULL OR "
             "strategy_capital_authority_evaluated_at IS NOT NULL",
-            name="ck_trade_decisions_capital_authority_evaluated",
+            name=conv("ck_trade_decisions_capital_authority_evaluated"),
         ),
         CheckConstraint(
             "strategy_capital_authority_allowed IS NOT TRUE OR "
             "(strategy_capital_authority_id IS NOT NULL AND "
             "strategy_capital_authority_digest IS NOT NULL)",
-            name="ck_trade_decisions_capital_authority_allowed_identity",
+            name=conv("ck_trade_decisions_capital_authority_allowed_identity"),
         ),
         CheckConstraint(
             "(strategy_capital_authority_id IS NULL) = "
             "(strategy_capital_authority_digest IS NULL)",
-            name="ck_trade_decisions_capital_authority_identity_pair",
+            name=conv("ck_trade_decisions_capital_authority_identity_pair"),
         ),
         CheckConstraint(
-            "strategy_capital_authority_digest IS NULL OR "
-            "(length(strategy_capital_authority_digest) = 71 AND "
-            "strategy_capital_authority_digest LIKE 'sha256:%')",
-            name="ck_trade_decisions_capital_authority_digest",
+            column("strategy_capital_authority_digest").is_(None)
+            | column("strategy_capital_authority_digest").regexp_match(
+                r"^sha256:[0-9a-f]{64}$"
+            ),
+            name=conv("ck_trade_decisions_capital_authority_digest"),
         ),
         Index(
             "uq_trade_decisions_account_decision_hash",

--- a/services/torghut/migrations/env.py
+++ b/services/torghut/migrations/env.py
@@ -32,6 +32,7 @@ def run_migrations_offline() -> None:
         target_metadata=target_metadata,
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},
+        transaction_per_migration=True,
     )
 
     with context.begin_transaction():
@@ -50,7 +51,11 @@ def run_migrations_online() -> None:
     )
 
     with connectable.connect() as connection:
-        context.configure(connection=connection, target_metadata=target_metadata)
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            transaction_per_migration=True,
+        )
 
         with context.begin_transaction():
             context.run_migrations()

--- a/services/torghut/migrations/versions/0063_options_archive_finalization_index.py
+++ b/services/torghut/migrations/versions/0063_options_archive_finalization_index.py
@@ -21,34 +21,63 @@ INDEX_NAME = "ix_options_catalog_active_expiration_symbol"
 TABLE_NAME = "torghut_options_contract_catalog"
 
 
+def _index_is_current() -> bool | None:
+    value = (
+        op.get_bind()
+        .execute(
+            sa.text(
+                """
+                SELECT COALESCE((
+                    indisvalid
+                    AND indisready
+                    AND NOT indisunique
+                    AND indnkeyatts = 2
+                    AND pg_get_indexdef(indexrelid, 1, true) = 'expiration_date'
+                    AND pg_get_indexdef(indexrelid, 2, true) = 'contract_symbol'
+                    AND pg_get_expr(indpred, indrelid) =
+                        '(status = ''active''::text)'
+                ), false) AS is_current
+                FROM pg_index
+                WHERE indexrelid = to_regclass(:index_name)
+                """
+            ),
+            {"index_name": INDEX_NAME},
+        )
+        .scalar_one_or_none()
+    )
+    if value is None:
+        return None
+    return bool(value)
+
+
 def upgrade() -> None:
     bind = op.get_bind()
     if getattr(getattr(bind, "dialect", None), "name", "") != "postgresql":
         return
 
-    index_valid = bind.execute(
-        sa.text(
-            """
-            SELECT index_entry.indisvalid AND index_entry.indisready
-            FROM pg_index AS index_entry
-            WHERE index_entry.indexrelid = to_regclass(:index_name)
-            """
-        ),
-        {"index_name": f"public.{INDEX_NAME}"},
-    ).scalar_one_or_none()
     with op.get_context().autocommit_block():
-        if index_valid is False:
-            op.execute(sa.text(f"DROP INDEX CONCURRENTLY IF EXISTS {INDEX_NAME}"))
-        if index_valid is not True:
+        op.execute(sa.text("SET lock_timeout = '5s'"))
+        op.execute(sa.text("SET statement_timeout = '45min'"))
+        try:
+            state = _index_is_current()
+            if state is True:
+                return
+            if state is False:
+                op.execute(sa.text(f"DROP INDEX CONCURRENTLY IF EXISTS {INDEX_NAME}"))
             op.execute(
                 sa.text(
                     f"""
-                    CREATE INDEX CONCURRENTLY {INDEX_NAME}
+                    CREATE INDEX CONCURRENTLY IF NOT EXISTS {INDEX_NAME}
                     ON {TABLE_NAME} (expiration_date, contract_symbol)
                     WHERE status = 'active'
                     """
                 )
             )
+            if _index_is_current() is not True:
+                raise RuntimeError(f"{INDEX_NAME} was not created as a valid index")
+        finally:
+            op.execute(sa.text("RESET statement_timeout"))
+            op.execute(sa.text("RESET lock_timeout"))
 
 
 def downgrade() -> None:

--- a/services/torghut/migrations/versions/0063_strategy_capital_authority.py
+++ b/services/torghut/migrations/versions/0063_strategy_capital_authority.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
+from sqlalchemy.schema import conv
 
 
 revision = "0063_strategy_capital_authority"
@@ -22,6 +23,35 @@ _TABLE = "strategy_capital_authorities"
 _IMMUTABILITY_FUNCTION = "torghut_reject_strategy_capital_authority_mutation"
 _EVIDENCE_TABLE = "evidence_epochs"
 _EVIDENCE_IMMUTABILITY_FUNCTION = "torghut_reject_evidence_epoch_mutation"
+_STRATEGY_AUTHORITY_FK = "fk_strategies_active_capital_authority_identity"
+_USAGE_INDEX = "ix_trade_decisions_capital_authority_usage"
+_DECISION_AUTHORITY_FK = "fk_trade_decisions_strategy_capital_authority_identity"
+_DECISION_CHECKS: tuple[tuple[str, str], ...] = (
+    (
+        "ck_trade_decisions_capital_authority_evaluated",
+        "strategy_capital_authority_allowed IS NULL OR "
+        "strategy_capital_authority_evaluated_at IS NOT NULL",
+    ),
+    (
+        "ck_trade_decisions_capital_authority_allowed_identity",
+        "strategy_capital_authority_allowed IS NOT TRUE OR "
+        "(strategy_capital_authority_id IS NOT NULL AND "
+        "strategy_capital_authority_digest IS NOT NULL)",
+    ),
+    (
+        "ck_trade_decisions_capital_authority_identity_pair",
+        "(strategy_capital_authority_id IS NULL) = "
+        "(strategy_capital_authority_digest IS NULL)",
+    ),
+    (
+        "ck_trade_decisions_capital_authority_digest",
+        "strategy_capital_authority_digest IS NULL OR "
+        "strategy_capital_authority_digest ~ '^sha256:[0-9a-f]{64}$'",
+    ),
+)
+_DECISION_CONSTRAINTS = tuple(name for name, _condition in _DECISION_CHECKS) + (
+    _DECISION_AUTHORITY_FK,
+)
 
 
 def _create_authority_table() -> None:
@@ -48,63 +78,65 @@ def _create_authority_table() -> None:
         ),
         sa.CheckConstraint(
             "schema_version = 'torghut.strategy-capital-authority.v1'",
-            name="ck_strategy_capital_authorities_schema",
+            name=conv("ck_strategy_capital_authorities_schema"),
         ),
         sa.CheckConstraint(
             "stage IN ('disabled', 'quarantined', 'research_only', "
             "'replay_verified', 'shadow_allowed', 'paper_probation', "
             "'paper_verified', 'micro_live_allowed', 'capital_allowed', 'scaled')",
-            name="ck_strategy_capital_authorities_stage",
+            name=conv("ck_strategy_capital_authorities_stage"),
         ),
         sa.CheckConstraint(
             "authority_digest ~ '^sha256:[0-9a-f]{64}$'",
-            name="ck_strategy_capital_authorities_digest",
+            name=conv("ck_strategy_capital_authorities_digest"),
         ),
         sa.CheckConstraint(
             "length(authority_id) BETWEEN 1 AND 128",
-            name="ck_strategy_capital_authorities_id",
+            name=conv("ck_strategy_capital_authorities_id"),
         ),
         sa.CheckConstraint(
             "expires_at IS NULL OR issued_at IS NOT NULL",
-            name="ck_strategy_capital_authorities_expiry_issuance",
+            name=conv("ck_strategy_capital_authorities_expiry_issuance"),
         ),
         sa.CheckConstraint(
             "expires_at IS NULL OR expires_at > issued_at",
-            name="ck_strategy_capital_authorities_expiry_order",
+            name=conv("ck_strategy_capital_authorities_expiry_order"),
         ),
         sa.ForeignKeyConstraint(
             ["strategy_id"],
             ["strategies.id"],
-            name="fk_strategy_capital_authorities_strategy",
+            name=conv("fk_strategy_capital_authorities_strategy"),
             ondelete="RESTRICT",
             onupdate="RESTRICT",
         ),
-        sa.PrimaryKeyConstraint("id", name="pk_strategy_capital_authorities"),
+        sa.PrimaryKeyConstraint("id", name=conv("pk_strategy_capital_authorities")),
         sa.UniqueConstraint(
             "authority_id",
-            name="uq_strategy_capital_authorities_authority_id",
+            name=conv("uq_strategy_capital_authorities_authority_id"),
         ),
         sa.UniqueConstraint(
             "authority_digest",
-            name="uq_strategy_capital_authorities_digest",
+            name=conv("uq_strategy_capital_authorities_digest"),
         ),
         sa.UniqueConstraint(
             "id",
             "strategy_id",
-            name="uq_strategy_capital_authorities_record_strategy",
+            name=conv("uq_strategy_capital_authorities_record_strategy"),
         ),
         sa.UniqueConstraint(
             "authority_id",
             "authority_digest",
             "strategy_id",
-            name="uq_strategy_capital_authorities_identity",
+            name=conv("uq_strategy_capital_authorities_identity"),
         ),
+        if_not_exists=True,
     )
     op.create_index(
         "ix_strategy_capital_authorities_strategy_created",
         _TABLE,
         ["strategy_id", "created_at"],
         unique=False,
+        if_not_exists=True,
     )
 
 
@@ -117,7 +149,7 @@ def _create_immutability_guard(
     op.execute(
         sa.text(
             f"""
-            CREATE FUNCTION {function}()
+            CREATE OR REPLACE FUNCTION {function}()
             RETURNS trigger LANGUAGE plpgsql AS $$
             BEGIN
                 RAISE EXCEPTION '{message}'
@@ -128,138 +160,214 @@ def _create_immutability_guard(
         )
     )
     for operation in ("UPDATE", "DELETE"):
+        trigger = f"trg_{table}_no_{operation.lower()}"
         op.execute(
             sa.text(
-                f"CREATE TRIGGER trg_{table}_no_{operation.lower()} "
-                f"BEFORE {operation} ON {table} FOR EACH ROW "
-                f"EXECUTE FUNCTION {function}()"
+                f"""
+                DO $torghut$
+                BEGIN
+                    IF NOT EXISTS (
+                        SELECT 1
+                        FROM pg_trigger
+                        WHERE tgrelid = '{table}'::regclass
+                          AND tgname = '{trigger}'
+                          AND NOT tgisinternal
+                    ) THEN
+                        CREATE TRIGGER {trigger}
+                        BEFORE {operation} ON {table} FOR EACH ROW
+                        EXECUTE FUNCTION {function}();
+                    END IF;
+                END
+                $torghut$;
+                """
             )
         )
 
 
-def _link_active_authority() -> None:
-    op.add_column(
-        "strategies",
-        sa.Column(
-            "active_capital_authority_id",
-            postgresql.UUID(as_uuid=True),
-            nullable=True,
+def _existing_column_names(table: str) -> set[str]:
+    rows = op.get_bind().execute(
+        sa.text(
+            """
+            SELECT attname
+            FROM pg_attribute
+            WHERE attrelid = to_regclass(:table_name)
+              AND attnum > 0
+              AND NOT attisdropped
+            """
         ),
+        {"table_name": table},
     )
-    op.create_foreign_key(
-        "fk_strategies_active_capital_authority_identity",
-        "strategies",
-        _TABLE,
-        ["active_capital_authority_id", "id"],
-        ["id", "strategy_id"],
-        ondelete="RESTRICT",
-        onupdate="RESTRICT",
+    return {str(value) for value in rows.scalars()}
+
+
+def _existing_constraint_names(table: str) -> set[str]:
+    rows = op.get_bind().execute(
+        sa.text(
+            """
+            SELECT conname
+            FROM pg_constraint
+            WHERE conrelid = to_regclass(:table_name)
+            """
+        ),
+        {"table_name": table},
     )
+    return {str(value) for value in rows.scalars()}
+
+
+def _unvalidated_constraint_names(table: str) -> set[str]:
+    rows = op.get_bind().execute(
+        sa.text(
+            """
+            SELECT conname
+            FROM pg_constraint
+            WHERE conrelid = to_regclass(:table_name)
+              AND NOT convalidated
+            """
+        ),
+        {"table_name": table},
+    )
+    return {str(value) for value in rows.scalars()}
+
+
+def _execute_alter_actions(table: str, actions: list[str]) -> None:
+    if not actions:
+        return
+    op.execute(sa.text(f"ALTER TABLE {table}\n" + ",\n".join(actions)))
+
+
+def _link_active_authority() -> None:
+    columns = _existing_column_names("strategies")
+    constraints = _existing_constraint_names("strategies")
+    actions: list[str] = []
+    if "active_capital_authority_id" not in columns:
+        actions.append("ADD COLUMN active_capital_authority_id UUID")
+    if _STRATEGY_AUTHORITY_FK not in constraints:
+        actions.append(
+            f"ADD CONSTRAINT {_STRATEGY_AUTHORITY_FK} "
+            f"FOREIGN KEY (active_capital_authority_id, id) "
+            f"REFERENCES {_TABLE} (id, strategy_id) "
+            "ON DELETE RESTRICT ON UPDATE RESTRICT"
+        )
+    _execute_alter_actions("strategies", actions)
     op.create_index(
         "ix_strategies_active_capital_authority",
         "strategies",
         ["active_capital_authority_id"],
         unique=False,
+        if_not_exists=True,
     )
 
 
 def _add_decision_authority_reservation() -> None:
-    op.add_column(
-        "trade_decisions",
-        sa.Column(
-            "strategy_capital_authority_id",
-            sa.String(length=128),
-            nullable=True,
-        ),
+    columns = _existing_column_names("trade_decisions")
+    constraints = _existing_constraint_names("trade_decisions")
+    actions: list[str] = []
+    for name, sql_type in (
+        ("strategy_capital_authority_id", "VARCHAR(128)"),
+        ("strategy_capital_authority_digest", "VARCHAR(71)"),
+        ("strategy_capital_authority_evaluated_at", "TIMESTAMPTZ"),
+        ("strategy_capital_authority_allowed", "BOOLEAN"),
+    ):
+        if name not in columns:
+            actions.append(f"ADD COLUMN {name} {sql_type}")
+    for name, condition in _DECISION_CHECKS:
+        if name not in constraints:
+            actions.append(f"ADD CONSTRAINT {name} CHECK ({condition}) NOT VALID")
+    if _DECISION_AUTHORITY_FK not in constraints:
+        actions.append(
+            f"ADD CONSTRAINT {_DECISION_AUTHORITY_FK} "
+            "FOREIGN KEY (strategy_capital_authority_id, "
+            "strategy_capital_authority_digest, strategy_id) "
+            f"REFERENCES {_TABLE} (authority_id, authority_digest, strategy_id) "
+            "ON DELETE RESTRICT ON UPDATE RESTRICT NOT VALID"
+        )
+    _execute_alter_actions("trade_decisions", actions)
+
+    unvalidated = _unvalidated_constraint_names("trade_decisions")
+    validation_actions = [
+        f"VALIDATE CONSTRAINT {name}"
+        for name in _DECISION_CONSTRAINTS
+        if name in unvalidated
+    ]
+    _execute_alter_actions("trade_decisions", validation_actions)
+
+
+def _usage_index_is_current() -> bool | None:
+    value = (
+        op.get_bind()
+        .execute(
+            sa.text(
+                """
+                SELECT COALESCE((
+                    indisvalid
+                    AND indisready
+                    AND NOT indisunique
+                    AND indnkeyatts = 3
+                    AND pg_get_indexdef(indexrelid, 1, true) = 'strategy_id'
+                    AND pg_get_indexdef(indexrelid, 2, true) = 'alpaca_account_label'
+                    AND pg_get_indexdef(indexrelid, 3, true) =
+                        'strategy_capital_authority_evaluated_at'
+                    AND pg_get_expr(indpred, indrelid) =
+                        '(strategy_capital_authority_allowed IS TRUE)'
+                ), false) AS is_current
+                FROM pg_index
+                WHERE indexrelid = to_regclass(:index_name)
+                """
+            ),
+            {"index_name": _USAGE_INDEX},
+        )
+        .scalar_one_or_none()
     )
-    op.add_column(
-        "trade_decisions",
-        sa.Column(
-            "strategy_capital_authority_digest",
-            sa.String(length=71),
-            nullable=True,
-        ),
+    if value is None:
+        return None
+    return bool(value)
+
+
+def _create_usage_index() -> None:
+    state = _usage_index_is_current()
+    if state is True:
+        return
+    if state is False:
+        op.execute(sa.text(f"DROP INDEX CONCURRENTLY IF EXISTS {_USAGE_INDEX}"))
+    op.execute(
+        sa.text(
+            f"""
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS {_USAGE_INDEX}
+            ON trade_decisions (
+                strategy_id,
+                alpaca_account_label,
+                strategy_capital_authority_evaluated_at
+            )
+            WHERE strategy_capital_authority_allowed IS TRUE
+            """
+        )
     )
-    op.add_column(
-        "trade_decisions",
-        sa.Column(
-            "strategy_capital_authority_evaluated_at",
-            sa.DateTime(timezone=True),
-            nullable=True,
-        ),
-    )
-    op.add_column(
-        "trade_decisions",
-        sa.Column(
-            "strategy_capital_authority_allowed",
-            sa.Boolean(),
-            nullable=True,
-        ),
-    )
-    op.create_check_constraint(
-        "ck_trade_decisions_capital_authority_evaluated",
-        "trade_decisions",
-        "strategy_capital_authority_allowed IS NULL OR "
-        "strategy_capital_authority_evaluated_at IS NOT NULL",
-    )
-    op.create_check_constraint(
-        "ck_trade_decisions_capital_authority_allowed_identity",
-        "trade_decisions",
-        "strategy_capital_authority_allowed IS NOT TRUE OR "
-        "(strategy_capital_authority_id IS NOT NULL AND "
-        "strategy_capital_authority_digest IS NOT NULL)",
-    )
-    op.create_check_constraint(
-        "ck_trade_decisions_capital_authority_identity_pair",
-        "trade_decisions",
-        "(strategy_capital_authority_id IS NULL) = "
-        "(strategy_capital_authority_digest IS NULL)",
-    )
-    op.create_check_constraint(
-        "ck_trade_decisions_capital_authority_digest",
-        "trade_decisions",
-        "strategy_capital_authority_digest IS NULL OR "
-        "strategy_capital_authority_digest ~ '^sha256:[0-9a-f]{64}$'",
-    )
-    op.create_foreign_key(
-        "fk_trade_decisions_strategy_capital_authority_identity",
-        "trade_decisions",
-        _TABLE,
-        [
-            "strategy_capital_authority_id",
-            "strategy_capital_authority_digest",
-            "strategy_id",
-        ],
-        ["authority_id", "authority_digest", "strategy_id"],
-        ondelete="RESTRICT",
-        onupdate="RESTRICT",
-    )
-    op.create_index(
-        "ix_trade_decisions_capital_authority_usage",
-        "trade_decisions",
-        [
-            "strategy_id",
-            "alpaca_account_label",
-            "strategy_capital_authority_evaluated_at",
-        ],
-        unique=False,
-    )
+    if _usage_index_is_current() is not True:
+        raise RuntimeError(f"{_USAGE_INDEX} was not created as a valid index")
 
 
 def upgrade() -> None:
-    _create_authority_table()
-    _create_immutability_guard(
-        table=_TABLE,
-        function=_IMMUTABILITY_FUNCTION,
-        message="strategy capital authority records are immutable",
-    )
-    _create_immutability_guard(
-        table=_EVIDENCE_TABLE,
-        function=_EVIDENCE_IMMUTABILITY_FUNCTION,
-        message="evidence epoch records are immutable",
-    )
-    _link_active_authority()
-    _add_decision_authority_reservation()
+    with op.get_context().autocommit_block():
+        op.execute(sa.text("SET lock_timeout = '5s'"))
+        op.execute(sa.text("SET statement_timeout = '30min'"))
+        try:
+            _create_authority_table()
+            _create_immutability_guard(
+                table=_TABLE,
+                function=_IMMUTABILITY_FUNCTION,
+                message="strategy capital authority records are immutable",
+            )
+            _create_immutability_guard(
+                table=_EVIDENCE_TABLE,
+                function=_EVIDENCE_IMMUTABILITY_FUNCTION,
+                message="evidence epoch records are immutable",
+            )
+            _link_active_authority()
+            _add_decision_authority_reservation()
+            _create_usage_index()
+        finally:
+            op.execute(sa.text("RESET statement_timeout"))
+            op.execute(sa.text("RESET lock_timeout"))
 
 
 def downgrade() -> None:
@@ -284,27 +392,22 @@ def downgrade() -> None:
     )
     op.drop_index("ix_strategies_active_capital_authority", table_name="strategies")
     op.drop_constraint(
-        "fk_strategies_active_capital_authority_identity",
+        conv(_STRATEGY_AUTHORITY_FK),
         "strategies",
         type_="foreignkey",
     )
     op.drop_column("strategies", "active_capital_authority_id")
     op.drop_index(
-        "ix_trade_decisions_capital_authority_usage",
+        _USAGE_INDEX,
         table_name="trade_decisions",
     )
     op.drop_constraint(
-        "fk_trade_decisions_strategy_capital_authority_identity",
+        conv(_DECISION_AUTHORITY_FK),
         "trade_decisions",
         type_="foreignkey",
     )
-    for constraint in (
-        "ck_trade_decisions_capital_authority_digest",
-        "ck_trade_decisions_capital_authority_identity_pair",
-        "ck_trade_decisions_capital_authority_allowed_identity",
-        "ck_trade_decisions_capital_authority_evaluated",
-    ):
-        op.drop_constraint(constraint, "trade_decisions", type_="check")
+    for constraint, _condition in reversed(_DECISION_CHECKS):
+        op.drop_constraint(conv(constraint), "trade_decisions", type_="check")
     for column in (
         "strategy_capital_authority_allowed",
         "strategy_capital_authority_evaluated_at",

--- a/services/torghut/migrations/versions/0064_strategy_capital_authority.py
+++ b/services/torghut/migrations/versions/0064_strategy_capital_authority.py
@@ -1,8 +1,8 @@
 """Add immutable strategy-scoped capital authorities.
 
-Revision ID: 0063_strategy_capital_authority
-Revises: 0062_options_archive_members
-Create Date: 2026-07-13 00:00:00.000000
+Revision ID: 0064_strategy_capital_authority
+Revises: 0063_options_archive_final_idx
+Create Date: 2026-07-14 02:00:00.000000
 """
 
 from __future__ import annotations
@@ -13,8 +13,8 @@ from sqlalchemy.dialects import postgresql
 from sqlalchemy.schema import conv
 
 
-revision = "0063_strategy_capital_authority"
-down_revision = "0062_options_archive_members"
+revision = "0064_strategy_capital_authority"
+down_revision = "0063_options_archive_final_idx"
 branch_labels = None
 depends_on = None
 

--- a/services/torghut/tests/test_options_archive_finalization_index_migration.py
+++ b/services/torghut/tests/test_options_archive_finalization_index_migration.py
@@ -10,16 +10,15 @@ from tests.migration_testing import load_migration_module
 MIGRATION_FILENAME = "0063_options_archive_finalization_index.py"
 
 
-def _postgres_bind(*, index_valid: bool | None) -> MagicMock:
+def _postgres_bind() -> MagicMock:
     bind = MagicMock()
     bind.dialect = SimpleNamespace(name="postgresql")
-    bind.execute.return_value.scalar_one_or_none.return_value = index_valid
     return bind
 
 
 def test_archive_finalization_index_is_concurrent_partial_and_extends_head() -> None:
     module = load_migration_module(MIGRATION_FILENAME)
-    bind = _postgres_bind(index_valid=None)
+    bind = _postgres_bind()
     context = MagicMock()
     context.autocommit_block.return_value = nullcontext()
 
@@ -31,18 +30,25 @@ def test_archive_finalization_index_is_concurrent_partial_and_extends_head() -> 
         patch.object(module.op, "get_bind", return_value=bind),
         patch.object(module.op, "get_context", return_value=context),
         patch.object(module.op, "execute") as execute,
+        patch.object(module, "_index_is_current", side_effect=(None, True)),
     ):
         module.upgrade()
 
-    sql = str(execute.call_args.args[0])
+    context.autocommit_block.assert_called_once_with()
+    sql = "\n".join(str(call.args[0]) for call in execute.call_args_list)
+    assert "SET lock_timeout = '5s'" in sql
+    assert "SET statement_timeout = '45min'" in sql
     assert "CREATE INDEX CONCURRENTLY" in sql
+    assert "IF NOT EXISTS" in sql
     assert "(expiration_date, contract_symbol)" in sql
     assert "WHERE status = 'active'" in sql
+    assert "RESET statement_timeout" in sql
+    assert "RESET lock_timeout" in sql
 
 
 def test_archive_finalization_index_repairs_invalid_concurrent_build() -> None:
     module = load_migration_module(MIGRATION_FILENAME)
-    bind = _postgres_bind(index_valid=False)
+    bind = _postgres_bind()
     context = MagicMock()
     context.autocommit_block.return_value = nullcontext()
 
@@ -50,9 +56,13 @@ def test_archive_finalization_index_repairs_invalid_concurrent_build() -> None:
         patch.object(module.op, "get_bind", return_value=bind),
         patch.object(module.op, "get_context", return_value=context),
         patch.object(module.op, "execute") as execute,
+        patch.object(module, "_index_is_current", side_effect=(False, True)),
     ):
         module.upgrade()
 
     statements = [str(call.args[0]) for call in execute.call_args_list]
-    assert statements[0].startswith("DROP INDEX CONCURRENTLY IF EXISTS")
-    assert "CREATE INDEX CONCURRENTLY" in statements[1]
+    assert any(
+        statement.startswith("DROP INDEX CONCURRENTLY IF EXISTS")
+        for statement in statements
+    )
+    assert any("CREATE INDEX CONCURRENTLY" in statement for statement in statements)

--- a/services/torghut/tests/test_strategy_capital_authority_migration.py
+++ b/services/torghut/tests/test_strategy_capital_authority_migration.py
@@ -12,7 +12,7 @@ from app.models import StrategyCapitalAuthorityRecord, TradeDecision
 from tests.migration_testing import load_migration_module
 
 
-MIGRATION_FILENAME = "0063_strategy_capital_authority.py"
+MIGRATION_FILENAME = "0064_strategy_capital_authority.py"
 REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
 
 
@@ -43,8 +43,8 @@ class TestStrategyCapitalAuthorityMigration(TestCase):
     def test_revision_extends_options_archive_membership(self) -> None:
         module = load_migration_module(MIGRATION_FILENAME)
 
-        self.assertEqual(module.revision, "0063_strategy_capital_authority")
-        self.assertEqual(module.down_revision, "0062_options_archive_members")
+        self.assertEqual(module.revision, "0064_strategy_capital_authority")
+        self.assertEqual(module.down_revision, "0063_options_archive_final_idx")
         self.assertLessEqual(len(module.revision), 32)
         self.assertLessEqual(
             len(Path(module.__file__ or "").read_text(encoding="utf-8").splitlines()),

--- a/services/torghut/tests/test_strategy_capital_authority_migration.py
+++ b/services/torghut/tests/test_strategy_capital_authority_migration.py
@@ -6,15 +6,27 @@ from unittest.mock import patch
 
 from sqlalchemy import CheckConstraint, ForeignKeyConstraint, UniqueConstraint, select
 from sqlalchemy.dialects import postgresql
+from sqlalchemy.schema import CreateIndex
 
-from app.models import TradeDecision
+from app.models import StrategyCapitalAuthorityRecord, TradeDecision
 from tests.migration_testing import load_migration_module
 
 
 MIGRATION_FILENAME = "0063_strategy_capital_authority.py"
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
 
 
 class TestStrategyCapitalAuthorityMigration(TestCase):
+    def test_postgres_migration_contract_runs_in_required_ci(self) -> None:
+        workflow = (REPOSITORY_ROOT / ".github/workflows/torghut-ci.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn(
+            "tests/trading/test_strategy_capital_authority_postgres.py",
+            workflow,
+        )
+
     def test_authority_columns_are_explicitly_loaded_for_historical_schema_tests(
         self,
     ) -> None:
@@ -46,14 +58,26 @@ class TestStrategyCapitalAuthorityMigration(TestCase):
             patch.object(module.op, "create_table") as create_table,
             patch.object(module.op, "create_index") as create_index,
             patch.object(module.op, "execute") as execute,
-            patch.object(module.op, "add_column") as add_column,
-            patch.object(module.op, "create_foreign_key") as create_foreign_key,
-            patch.object(module.op, "create_check_constraint") as create_check,
+            patch.object(module.op, "get_context") as get_context,
+            patch.object(module, "_existing_column_names", return_value=set()),
+            patch.object(module, "_existing_constraint_names", return_value=set()),
+            patch.object(
+                module,
+                "_unvalidated_constraint_names",
+                return_value=set(module._DECISION_CONSTRAINTS),
+            ),
+            patch.object(
+                module,
+                "_usage_index_is_current",
+                side_effect=(None, True),
+            ),
         ):
             module.upgrade()
 
+        get_context.return_value.autocommit_block.assert_called_once_with()
         create_table.assert_called_once()
         self.assertEqual(create_table.call_args.args[0], "strategy_capital_authorities")
+        self.assertTrue(create_table.call_args.kwargs["if_not_exists"])
         rendered = "\n".join(str(item) for item in create_table.call_args.args[1:])
         for column in (
             "authority_id",
@@ -86,52 +110,105 @@ class TestStrategyCapitalAuthorityMigration(TestCase):
         self.assertIn("shadow_allowed", checks)
         self.assertIn("capital_allowed", checks)
         self.assertIn("sha256", checks)
-
-        self.assertEqual(add_column.call_count, 5)
-        decision_columns = {
-            call.args[1].name
-            for call in add_column.call_args_list
-            if call.args[0] == "trade_decisions"
-        }
-        self.assertEqual(
-            decision_columns,
-            {
-                "strategy_capital_authority_id",
-                "strategy_capital_authority_digest",
-                "strategy_capital_authority_evaluated_at",
-                "strategy_capital_authority_allowed",
-            },
+        self.assertEqual(create_index.call_count, 2)
+        self.assertTrue(
+            all(call.kwargs["if_not_exists"] for call in create_index.call_args_list)
         )
-        self.assertEqual(create_check.call_count, 4)
-        self.assertEqual(create_foreign_key.call_count, 2)
-        create_foreign_key.assert_any_call(
-            "fk_strategies_active_capital_authority_identity",
-            "strategies",
-            "strategy_capital_authorities",
-            ["active_capital_authority_id", "id"],
-            ["id", "strategy_id"],
-            ondelete="RESTRICT",
-            onupdate="RESTRICT",
-        )
-        create_foreign_key.assert_any_call(
-            "fk_trade_decisions_strategy_capital_authority_identity",
-            "trade_decisions",
-            "strategy_capital_authorities",
-            [
-                "strategy_capital_authority_id",
-                "strategy_capital_authority_digest",
-                "strategy_id",
-            ],
-            ["authority_id", "authority_digest", "strategy_id"],
-            ondelete="RESTRICT",
-            onupdate="RESTRICT",
-        )
-        self.assertEqual(create_index.call_count, 3)
         sql = "\n".join(str(call.args[0]) for call in execute.call_args_list)
+        self.assertIn("SET lock_timeout = '5s'", sql)
+        self.assertIn("SET statement_timeout = '30min'", sql)
+        self.assertIn("ADD COLUMN active_capital_authority_id UUID", sql)
+        self.assertIn("ADD COLUMN strategy_capital_authority_id VARCHAR(128)", sql)
+        self.assertEqual(sql.count("NOT VALID"), 5)
+        self.assertIn("VALIDATE CONSTRAINT", sql)
+        self.assertIn("CREATE INDEX CONCURRENTLY IF NOT EXISTS", sql)
+        self.assertIn("WHERE strategy_capital_authority_allowed IS TRUE", sql)
         self.assertIn("strategy capital authority records are immutable", sql)
         self.assertIn("BEFORE UPDATE", sql)
         self.assertIn("BEFORE DELETE", sql)
         self.assertIn("evidence epoch records are immutable", sql)
+        self.assertIn("RESET statement_timeout", sql)
+        self.assertIn("RESET lock_timeout", sql)
+
+    def test_upgrade_is_retry_safe_after_autocommit_progress(self) -> None:
+        module = load_migration_module(MIGRATION_FILENAME)
+        columns = {
+            "active_capital_authority_id",
+            "strategy_capital_authority_id",
+            "strategy_capital_authority_digest",
+            "strategy_capital_authority_evaluated_at",
+            "strategy_capital_authority_allowed",
+        }
+        constraints = set(module._DECISION_CONSTRAINTS) | {
+            module._STRATEGY_AUTHORITY_FK
+        }
+
+        with (
+            patch.object(module.op, "create_table"),
+            patch.object(module.op, "create_index"),
+            patch.object(module.op, "execute") as execute,
+            patch.object(module.op, "get_context"),
+            patch.object(module, "_existing_column_names", return_value=columns),
+            patch.object(
+                module,
+                "_existing_constraint_names",
+                return_value=constraints,
+            ),
+            patch.object(
+                module,
+                "_unvalidated_constraint_names",
+                return_value=set(),
+            ),
+            patch.object(module, "_usage_index_is_current", return_value=True),
+        ):
+            module.upgrade()
+
+        sql = "\n".join(str(call.args[0]) for call in execute.call_args_list)
+        self.assertNotIn("ALTER TABLE strategies", sql)
+        self.assertNotIn("ALTER TABLE trade_decisions", sql)
+        self.assertNotIn("CREATE INDEX CONCURRENTLY", sql)
+
+    def test_invalid_concurrent_usage_index_is_removed_before_retry(self) -> None:
+        module = load_migration_module(MIGRATION_FILENAME)
+
+        with (
+            patch.object(
+                module,
+                "_usage_index_is_current",
+                side_effect=(False, True),
+            ),
+            patch.object(module.op, "execute") as execute,
+        ):
+            module._create_usage_index()
+
+        sql = "\n".join(str(call.args[0]) for call in execute.call_args_list)
+        self.assertIn("DROP INDEX CONCURRENTLY IF EXISTS", sql)
+        self.assertIn("CREATE INDEX CONCURRENTLY IF NOT EXISTS", sql)
+
+    def test_usage_index_and_digest_metadata_match_production_contract(self) -> None:
+        usage_index = next(
+            index
+            for index in TradeDecision.__table__.indexes
+            if index.name == "ix_trade_decisions_capital_authority_usage"
+        )
+        index_sql = str(CreateIndex(usage_index).compile(dialect=postgresql.dialect()))
+        self.assertIn("WHERE strategy_capital_authority_allowed IS TRUE", index_sql)
+
+        authority_checks = {
+            str(constraint.name): str(
+                constraint.sqltext.compile(
+                    dialect=postgresql.dialect(),
+                    compile_kwargs={"literal_binds": True},
+                )
+            )
+            for constraint in StrategyCapitalAuthorityRecord.__table__.constraints
+            if isinstance(constraint, CheckConstraint)
+        }
+        self.assertIn("~", authority_checks["ck_strategy_capital_authorities_digest"])
+        self.assertIn(
+            "BETWEEN 1 AND 128",
+            authority_checks["ck_strategy_capital_authorities_id"],
+        )
 
     def test_downgrade_refuses_to_destroy_authority_history(self) -> None:
         module = load_migration_module(MIGRATION_FILENAME)

--- a/services/torghut/tests/trading/test_strategy_capital_authority_postgres.py
+++ b/services/torghut/tests/trading/test_strategy_capital_authority_postgres.py
@@ -66,6 +66,28 @@ def _create_pre_migration_schema(
                 """
             )
         )
+        connection.execute(
+            text(
+                """
+                CREATE TABLE torghut_options_contract_catalog (
+                    contract_symbol TEXT PRIMARY KEY,
+                    expiration_date DATE NOT NULL,
+                    status TEXT NOT NULL
+                )
+                """
+            )
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO torghut_options_contract_catalog (
+                    contract_symbol, expiration_date, status
+                ) VALUES
+                    ('ACTIVE', DATE '2026-07-18', 'active'),
+                    ('INACTIVE', DATE '2026-07-18', 'inactive')
+                """
+            )
+        )
         if historical_strategy_id is None or historical_decision_id is None:
             return
         connection.execute(
@@ -118,7 +140,7 @@ def test_postgres_authority_history_is_database_immutable(
         )
         alembic = AlembicConfig(str(SERVICE_ROOT / "alembic.ini"))
         command.stamp(alembic, "0062_options_archive_members")
-        command.upgrade(alembic, "0063_strategy_capital_authority")
+        command.upgrade(alembic, "0064_strategy_capital_authority")
         assert inspect(schema_engine).has_table("strategy_capital_authorities")
         with schema_engine.begin() as connection:
             connection.execute(
@@ -136,8 +158,22 @@ def test_postgres_authority_history_is_database_immutable(
                     """
                 )
             )
+            connection.execute(
+                text("DROP INDEX ix_options_catalog_active_expiration_symbol")
+            )
+            connection.execute(
+                text(
+                    """
+                    CREATE INDEX ix_options_catalog_active_expiration_symbol
+                    ON torghut_options_contract_catalog (
+                        expiration_date,
+                        contract_symbol
+                    )
+                    """
+                )
+            )
         command.stamp(alembic, "0062_options_archive_members")
-        command.upgrade(alembic, "0063_strategy_capital_authority")
+        command.upgrade(alembic, "0064_strategy_capital_authority")
 
         expected_constraints = {
             "ck_trade_decisions_capital_authority_evaluated",
@@ -176,6 +212,19 @@ def test_postgres_authority_history_is_database_immutable(
             assert "strategy_capital_authority_allowed IS TRUE" in str(
                 usage_index.predicate
             )
+
+            archive_index = connection.execute(
+                text(
+                    """
+                    SELECT indisvalid, pg_get_expr(indpred, indrelid) AS predicate
+                    FROM pg_index
+                    WHERE indexrelid =
+                        'ix_options_catalog_active_expiration_symbol'::regclass
+                    """
+                )
+            ).one()
+            assert archive_index.indisvalid is True
+            assert "status = 'active'::text" in str(archive_index.predicate)
 
             historical_authority = connection.execute(
                 text(
@@ -358,7 +407,7 @@ def test_postgres_authority_migration_lock_timeout_is_retry_safe(
             blocker.execute(text("LOCK TABLE trade_decisions IN ROW EXCLUSIVE MODE"))
             started_at = monotonic()
             with pytest.raises(DBAPIError) as timed_out:
-                command.upgrade(alembic, "0063_strategy_capital_authority")
+                command.upgrade(alembic, "0064_strategy_capital_authority")
             elapsed = monotonic() - started_at
 
         assert getattr(timed_out.value.orig, "sqlstate", None) == "55P03"
@@ -368,19 +417,19 @@ def test_postgres_authority_migration_lock_timeout_is_retry_safe(
             revision = connection.execute(
                 text("SELECT version_num FROM alembic_version")
             ).scalar_one()
-        assert revision == "0062_options_archive_members"
+        assert revision == "0063_options_archive_final_idx"
         decision_columns = {
             column["name"]
             for column in inspect(schema_engine).get_columns("trade_decisions")
         }
         assert "strategy_capital_authority_id" not in decision_columns
 
-        command.upgrade(alembic, "0063_strategy_capital_authority")
+        command.upgrade(alembic, "0064_strategy_capital_authority")
         with schema_engine.connect() as connection:
             revision = connection.execute(
                 text("SELECT version_num FROM alembic_version")
             ).scalar_one()
-        assert revision == "0063_strategy_capital_authority"
+        assert revision == "0064_strategy_capital_authority"
     finally:
         schema_engine.dispose()
         with admin_engine.begin() as connection:

--- a/services/torghut/tests/trading/test_strategy_capital_authority_postgres.py
+++ b/services/torghut/tests/trading/test_strategy_capital_authority_postgres.py
@@ -4,12 +4,13 @@ import json
 import os
 import uuid
 from pathlib import Path
+from time import monotonic
 
 import pytest
 from alembic import command
 from alembic.config import Config as AlembicConfig
 from sqlalchemy import create_engine, inspect, text
-from sqlalchemy.engine import make_url
+from sqlalchemy.engine import Engine, make_url
 from sqlalchemy.exc import DBAPIError
 
 from app.config import settings
@@ -17,6 +18,72 @@ from app.config import settings
 
 POSTGRES_DSN = os.getenv("TORGHUT_TEST_POSTGRES_DSN")
 SERVICE_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _create_pre_migration_schema(
+    engine: Engine,
+    *,
+    historical_strategy_id: uuid.UUID | None = None,
+    historical_decision_id: uuid.UUID | None = None,
+) -> None:
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                CREATE TABLE strategies (
+                    id UUID PRIMARY KEY,
+                    name VARCHAR(255) NOT NULL
+                )
+                """
+            )
+        )
+        connection.execute(
+            text(
+                """
+                CREATE TABLE evidence_epochs (
+                    id UUID PRIMARY KEY,
+                    evidence_epoch_id VARCHAR(64) NOT NULL UNIQUE,
+                    payload_json JSONB
+                )
+                """
+            )
+        )
+        connection.execute(
+            text(
+                "INSERT INTO evidence_epochs (id, evidence_epoch_id, payload_json) "
+                "VALUES (:id, :epoch_id, '{}'::jsonb)"
+            ),
+            {"id": uuid.uuid4(), "epoch_id": "tee-postgres-safe"},
+        )
+        connection.execute(
+            text(
+                """
+                CREATE TABLE trade_decisions (
+                    id UUID PRIMARY KEY,
+                    strategy_id UUID NOT NULL,
+                    alpaca_account_label VARCHAR(64) NOT NULL
+                )
+                """
+            )
+        )
+        if historical_strategy_id is None or historical_decision_id is None:
+            return
+        connection.execute(
+            text("INSERT INTO strategies (id, name) VALUES (:id, :name)"),
+            {"id": historical_strategy_id, "name": "historical-safe"},
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO trade_decisions (id, strategy_id, alpaca_account_label)
+                VALUES (:id, :strategy_id, 'paper')
+                """
+            ),
+            {
+                "id": historical_decision_id,
+                "strategy_id": historical_strategy_id,
+            },
+        )
 
 
 @pytest.mark.skipif(
@@ -33,49 +100,16 @@ def test_postgres_authority_history_is_database_immutable(
         {"options": f"-csearch_path={schema}"}
     )
     schema_engine = create_engine(schema_url, future=True)
+    historical_strategy_id = uuid.uuid4()
+    historical_decision_id = uuid.uuid4()
     try:
         with admin_engine.begin() as connection:
             connection.execute(text(f'CREATE SCHEMA "{schema}"'))
-        with schema_engine.begin() as connection:
-            connection.execute(
-                text(
-                    """
-                    CREATE TABLE strategies (
-                        id UUID PRIMARY KEY,
-                        name VARCHAR(255) NOT NULL
-                    )
-                    """
-                )
-            )
-            connection.execute(
-                text(
-                    """
-                    CREATE TABLE evidence_epochs (
-                        id UUID PRIMARY KEY,
-                        evidence_epoch_id VARCHAR(64) NOT NULL UNIQUE,
-                        payload_json JSONB
-                    )
-                    """
-                )
-            )
-            connection.execute(
-                text(
-                    "INSERT INTO evidence_epochs (id, evidence_epoch_id, payload_json) "
-                    "VALUES (:id, :epoch_id, '{}'::jsonb)"
-                ),
-                {"id": uuid.uuid4(), "epoch_id": "tee-postgres-safe"},
-            )
-            connection.execute(
-                text(
-                    """
-                    CREATE TABLE trade_decisions (
-                        id UUID PRIMARY KEY,
-                        strategy_id UUID NOT NULL,
-                        alpaca_account_label VARCHAR(64) NOT NULL
-                    )
-                    """
-                )
-            )
+        _create_pre_migration_schema(
+            schema_engine,
+            historical_strategy_id=historical_strategy_id,
+            historical_decision_id=historical_decision_id,
+        )
 
         monkeypatch.setattr(
             settings,
@@ -86,6 +120,77 @@ def test_postgres_authority_history_is_database_immutable(
         command.stamp(alembic, "0062_options_archive_members")
         command.upgrade(alembic, "0063_strategy_capital_authority")
         assert inspect(schema_engine).has_table("strategy_capital_authorities")
+        with schema_engine.begin() as connection:
+            connection.execute(
+                text("DROP INDEX ix_trade_decisions_capital_authority_usage")
+            )
+            connection.execute(
+                text(
+                    """
+                    CREATE INDEX ix_trade_decisions_capital_authority_usage
+                    ON trade_decisions (
+                        strategy_id,
+                        alpaca_account_label,
+                        strategy_capital_authority_evaluated_at
+                    )
+                    """
+                )
+            )
+        command.stamp(alembic, "0062_options_archive_members")
+        command.upgrade(alembic, "0063_strategy_capital_authority")
+
+        expected_constraints = {
+            "ck_trade_decisions_capital_authority_evaluated",
+            "ck_trade_decisions_capital_authority_allowed_identity",
+            "ck_trade_decisions_capital_authority_identity_pair",
+            "ck_trade_decisions_capital_authority_digest",
+            "fk_trade_decisions_strategy_capital_authority_identity",
+        }
+        with schema_engine.connect() as connection:
+            constraint_rows = connection.execute(
+                text(
+                    """
+                    SELECT conname, convalidated
+                    FROM pg_constraint
+                    WHERE conrelid = 'trade_decisions'::regclass
+                    """
+                )
+            ).all()
+            validation_state = {
+                str(row.conname): bool(row.convalidated) for row in constraint_rows
+            }
+            assert expected_constraints <= validation_state.keys()
+            assert all(validation_state[name] for name in expected_constraints)
+
+            usage_index = connection.execute(
+                text(
+                    """
+                    SELECT indisvalid, pg_get_expr(indpred, indrelid) AS predicate
+                    FROM pg_index
+                    WHERE indexrelid =
+                        'ix_trade_decisions_capital_authority_usage'::regclass
+                    """
+                )
+            ).one()
+            assert usage_index.indisvalid is True
+            assert "strategy_capital_authority_allowed IS TRUE" in str(
+                usage_index.predicate
+            )
+
+            historical_authority = connection.execute(
+                text(
+                    """
+                    SELECT strategy_capital_authority_id,
+                           strategy_capital_authority_digest,
+                           strategy_capital_authority_evaluated_at,
+                           strategy_capital_authority_allowed
+                    FROM trade_decisions
+                    WHERE id = :id
+                    """
+                ),
+                {"id": historical_decision_id},
+            ).one()
+            assert tuple(historical_authority) == (None, None, None, None)
 
         strategy_id = uuid.uuid4()
         authority_record_id = uuid.uuid4()
@@ -203,7 +308,8 @@ def test_postgres_authority_history_is_database_immutable(
         for statement in (
             "UPDATE strategy_capital_authorities SET stage = 'research_only'",
             "DELETE FROM strategy_capital_authorities",
-            "UPDATE evidence_epochs SET payload_json = '{\"tampered\":true}'::jsonb",
+            "UPDATE evidence_epochs SET payload_json = "
+            "jsonb_build_object('tampered', true)",
             "DELETE FROM evidence_epochs",
         ):
             with pytest.raises(DBAPIError) as blocked:
@@ -215,6 +321,66 @@ def test_postgres_authority_history_is_database_immutable(
             command.downgrade(alembic, "0062_options_archive_members")
         assert getattr(downgrade.value.orig, "sqlstate", None) == "55000"
         assert inspect(schema_engine).has_table("strategy_capital_authorities")
+    finally:
+        schema_engine.dispose()
+        with admin_engine.begin() as connection:
+            connection.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+        admin_engine.dispose()
+
+
+@pytest.mark.skipif(
+    not POSTGRES_DSN,
+    reason="set TORGHUT_TEST_POSTGRES_DSN for the opt-in authority migration test",
+)
+def test_postgres_authority_migration_lock_timeout_is_retry_safe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert POSTGRES_DSN is not None
+    schema = f"strategy_authority_lock_{uuid.uuid4().hex}"
+    admin_engine = create_engine(POSTGRES_DSN, future=True)
+    schema_url = make_url(POSTGRES_DSN).update_query_dict(
+        {"options": f"-csearch_path={schema}"}
+    )
+    schema_engine = create_engine(schema_url, future=True)
+    try:
+        with admin_engine.begin() as connection:
+            connection.execute(text(f'CREATE SCHEMA "{schema}"'))
+        _create_pre_migration_schema(schema_engine)
+        monkeypatch.setattr(
+            settings,
+            "db_dsn",
+            schema_url.render_as_string(hide_password=False),
+        )
+        alembic = AlembicConfig(str(SERVICE_ROOT / "alembic.ini"))
+        command.stamp(alembic, "0062_options_archive_members")
+
+        with schema_engine.connect() as blocker, blocker.begin():
+            blocker.execute(text("LOCK TABLE trade_decisions IN ROW EXCLUSIVE MODE"))
+            started_at = monotonic()
+            with pytest.raises(DBAPIError) as timed_out:
+                command.upgrade(alembic, "0063_strategy_capital_authority")
+            elapsed = monotonic() - started_at
+
+        assert getattr(timed_out.value.orig, "sqlstate", None) == "55P03"
+        assert elapsed < 12.0
+        assert inspect(schema_engine).has_table("strategy_capital_authorities")
+        with schema_engine.connect() as connection:
+            revision = connection.execute(
+                text("SELECT version_num FROM alembic_version")
+            ).scalar_one()
+        assert revision == "0062_options_archive_members"
+        decision_columns = {
+            column["name"]
+            for column in inspect(schema_engine).get_columns("trade_decisions")
+        }
+        assert "strategy_capital_authority_id" not in decision_columns
+
+        command.upgrade(alembic, "0063_strategy_capital_authority")
+        with schema_engine.connect() as connection:
+            revision = connection.execute(
+                text("SELECT version_num FROM alembic_version")
+            ).scalar_one()
+        assert revision == "0063_strategy_capital_authority"
     finally:
         schema_engine.dispose()
         with admin_engine.begin() as connection:

--- a/services/torghut/tests/trading/test_strategy_capital_authority_postgres.py
+++ b/services/torghut/tests/trading/test_strategy_capital_authority_postgres.py
@@ -108,6 +108,235 @@ def _create_pre_migration_schema(
         )
 
 
+def _upgrade_and_repair_online_indexes(
+    engine: Engine,
+    alembic: AlembicConfig,
+) -> None:
+    command.stamp(alembic, "0062_options_archive_members")
+    command.upgrade(alembic, "0064_strategy_capital_authority")
+    assert inspect(engine).has_table("strategy_capital_authorities")
+
+    with engine.begin() as connection:
+        connection.execute(
+            text("DROP INDEX ix_trade_decisions_capital_authority_usage")
+        )
+        connection.execute(
+            text(
+                """
+                CREATE INDEX ix_trade_decisions_capital_authority_usage
+                ON trade_decisions (
+                    strategy_id,
+                    alpaca_account_label,
+                    strategy_capital_authority_evaluated_at
+                )
+                """
+            )
+        )
+        connection.execute(
+            text("DROP INDEX ix_options_catalog_active_expiration_symbol")
+        )
+        connection.execute(
+            text(
+                """
+                CREATE INDEX ix_options_catalog_active_expiration_symbol
+                ON torghut_options_contract_catalog (
+                    expiration_date,
+                    contract_symbol
+                )
+                """
+            )
+        )
+
+    command.stamp(alembic, "0062_options_archive_members")
+    command.upgrade(alembic, "0064_strategy_capital_authority")
+
+
+def _assert_online_schema(
+    engine: Engine,
+    historical_decision_id: uuid.UUID,
+) -> None:
+    expected_constraints = {
+        "ck_trade_decisions_capital_authority_evaluated",
+        "ck_trade_decisions_capital_authority_allowed_identity",
+        "ck_trade_decisions_capital_authority_identity_pair",
+        "ck_trade_decisions_capital_authority_digest",
+        "fk_trade_decisions_strategy_capital_authority_identity",
+    }
+    with engine.connect() as connection:
+        constraint_rows = connection.execute(
+            text(
+                """
+                SELECT conname, convalidated
+                FROM pg_constraint
+                WHERE conrelid = 'trade_decisions'::regclass
+                """
+            )
+        ).all()
+        validation_state = {
+            str(row.conname): bool(row.convalidated) for row in constraint_rows
+        }
+        assert expected_constraints <= validation_state.keys()
+        assert all(validation_state[name] for name in expected_constraints)
+
+        index_rows = connection.execute(
+            text(
+                """
+                SELECT indexrelid::regclass::text AS index_name,
+                       indisvalid,
+                       pg_get_expr(indpred, indrelid) AS predicate
+                FROM pg_index
+                WHERE indexrelid IN (
+                    'ix_trade_decisions_capital_authority_usage'::regclass,
+                    'ix_options_catalog_active_expiration_symbol'::regclass
+                )
+                """
+            )
+        ).all()
+        indexes = {str(row.index_name): row for row in index_rows}
+        usage_index = indexes["ix_trade_decisions_capital_authority_usage"]
+        archive_index = indexes["ix_options_catalog_active_expiration_symbol"]
+        assert usage_index.indisvalid is True
+        assert "strategy_capital_authority_allowed IS TRUE" in str(
+            usage_index.predicate
+        )
+        assert archive_index.indisvalid is True
+        assert "status = 'active'::text" in str(archive_index.predicate)
+
+        historical_authority = connection.execute(
+            text(
+                """
+                SELECT strategy_capital_authority_id,
+                       strategy_capital_authority_digest,
+                       strategy_capital_authority_evaluated_at,
+                       strategy_capital_authority_allowed
+                FROM trade_decisions
+                WHERE id = :id
+                """
+            ),
+            {"id": historical_decision_id},
+        ).one()
+        assert tuple(historical_authority) == (None, None, None, None)
+
+
+def _insert_active_capital_authority(engine: Engine) -> uuid.UUID:
+    strategy_id = uuid.uuid4()
+    authority_record_id = uuid.uuid4()
+    payload = {
+        "schema_version": "torghut.strategy-capital-authority.v1",
+        "authority_id": "postgres-safe-v1",
+        "strategy_ref": "postgres-safe",
+        "stage": "shadow_allowed",
+        "account_mode": "none",
+        "venue": "none",
+        "allowed_symbols": [],
+        "max_order_notional": "0",
+        "max_gross_notional": "0",
+        "max_net_notional": "0",
+        "max_loss": "0",
+        "max_orders_per_minute": 0,
+        "max_orders_per_session": 0,
+        "reduce_only": True,
+        "blockers": ["p0_capital_freeze"],
+    }
+    with engine.begin() as connection:
+        connection.execute(
+            text("INSERT INTO strategies (id, name) VALUES (:id, :name)"),
+            {"id": strategy_id, "name": "postgres-safe"},
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO strategy_capital_authorities (
+                    id, authority_id, strategy_id, schema_version, stage,
+                    authority_digest, payload_json
+                ) VALUES (
+                    :id, :authority_id, :strategy_id, :schema_version, :stage,
+                    :authority_digest, CAST(:payload_json AS jsonb)
+                )
+                """
+            ),
+            {
+                "id": authority_record_id,
+                "authority_id": "postgres-safe-v1",
+                "strategy_id": strategy_id,
+                "schema_version": "torghut.strategy-capital-authority.v1",
+                "stage": "shadow_allowed",
+                "authority_digest": "sha256:" + "a" * 64,
+                "payload_json": json.dumps(payload),
+            },
+        )
+        connection.execute(
+            text(
+                "UPDATE strategies SET active_capital_authority_id = :authority_id "
+                "WHERE id = :strategy_id"
+            ),
+            {"authority_id": authority_record_id, "strategy_id": strategy_id},
+        )
+    return strategy_id
+
+
+def _insert_authorized_decision(engine: Engine, strategy_id: uuid.UUID) -> None:
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                INSERT INTO trade_decisions (
+                    id, strategy_id, alpaca_account_label,
+                    strategy_capital_authority_id,
+                    strategy_capital_authority_digest,
+                    strategy_capital_authority_evaluated_at,
+                    strategy_capital_authority_allowed
+                ) VALUES (
+                    :id, :strategy_id, 'paper', :authority_id,
+                    :authority_digest, clock_timestamp(), true
+                )
+                """
+            ),
+            {
+                "id": uuid.uuid4(),
+                "strategy_id": strategy_id,
+                "authority_id": "postgres-safe-v1",
+                "authority_digest": "sha256:" + "a" * 64,
+            },
+        )
+
+
+def _assert_strategy_scope_fence(engine: Engine, strategy_id: uuid.UUID) -> None:
+    other_strategy_id = uuid.uuid4()
+    with engine.begin() as connection:
+        connection.execute(
+            text("INSERT INTO strategies (id, name) VALUES (:id, :name)"),
+            {"id": other_strategy_id, "name": "postgres-other"},
+        )
+    with pytest.raises(DBAPIError) as cross_strategy:
+        _insert_authorized_decision(engine, other_strategy_id)
+    assert getattr(cross_strategy.value.orig, "sqlstate", None) == "23503"
+
+    _insert_authorized_decision(engine, strategy_id)
+
+
+def _assert_authority_history_is_immutable(engine: Engine) -> None:
+    statements = (
+        "UPDATE strategy_capital_authorities SET stage = 'research_only'",
+        "DELETE FROM strategy_capital_authorities",
+        "UPDATE evidence_epochs SET payload_json = "
+        "jsonb_build_object('tampered', true)",
+        "DELETE FROM evidence_epochs",
+    )
+    for statement in statements:
+        with pytest.raises(DBAPIError) as blocked:
+            with engine.begin() as connection:
+                connection.execute(text(statement))
+        assert getattr(blocked.value.orig, "sqlstate", None) == "23514"
+
+
+def _assert_downgrade_is_refused(engine: Engine, alembic: AlembicConfig) -> None:
+    with pytest.raises(DBAPIError) as downgrade:
+        command.downgrade(alembic, "0062_options_archive_members")
+    assert getattr(downgrade.value.orig, "sqlstate", None) == "55000"
+    assert inspect(engine).has_table("strategy_capital_authorities")
+
+
 @pytest.mark.skipif(
     not POSTGRES_DSN,
     reason="set TORGHUT_TEST_POSTGRES_DSN for the opt-in authority migration test",
@@ -122,14 +351,13 @@ def test_postgres_authority_history_is_database_immutable(
         {"options": f"-csearch_path={schema}"}
     )
     schema_engine = create_engine(schema_url, future=True)
-    historical_strategy_id = uuid.uuid4()
     historical_decision_id = uuid.uuid4()
     try:
         with admin_engine.begin() as connection:
             connection.execute(text(f'CREATE SCHEMA "{schema}"'))
         _create_pre_migration_schema(
             schema_engine,
-            historical_strategy_id=historical_strategy_id,
+            historical_strategy_id=uuid.uuid4(),
             historical_decision_id=historical_decision_id,
         )
 
@@ -139,237 +367,12 @@ def test_postgres_authority_history_is_database_immutable(
             schema_url.render_as_string(hide_password=False),
         )
         alembic = AlembicConfig(str(SERVICE_ROOT / "alembic.ini"))
-        command.stamp(alembic, "0062_options_archive_members")
-        command.upgrade(alembic, "0064_strategy_capital_authority")
-        assert inspect(schema_engine).has_table("strategy_capital_authorities")
-        with schema_engine.begin() as connection:
-            connection.execute(
-                text("DROP INDEX ix_trade_decisions_capital_authority_usage")
-            )
-            connection.execute(
-                text(
-                    """
-                    CREATE INDEX ix_trade_decisions_capital_authority_usage
-                    ON trade_decisions (
-                        strategy_id,
-                        alpaca_account_label,
-                        strategy_capital_authority_evaluated_at
-                    )
-                    """
-                )
-            )
-            connection.execute(
-                text("DROP INDEX ix_options_catalog_active_expiration_symbol")
-            )
-            connection.execute(
-                text(
-                    """
-                    CREATE INDEX ix_options_catalog_active_expiration_symbol
-                    ON torghut_options_contract_catalog (
-                        expiration_date,
-                        contract_symbol
-                    )
-                    """
-                )
-            )
-        command.stamp(alembic, "0062_options_archive_members")
-        command.upgrade(alembic, "0064_strategy_capital_authority")
-
-        expected_constraints = {
-            "ck_trade_decisions_capital_authority_evaluated",
-            "ck_trade_decisions_capital_authority_allowed_identity",
-            "ck_trade_decisions_capital_authority_identity_pair",
-            "ck_trade_decisions_capital_authority_digest",
-            "fk_trade_decisions_strategy_capital_authority_identity",
-        }
-        with schema_engine.connect() as connection:
-            constraint_rows = connection.execute(
-                text(
-                    """
-                    SELECT conname, convalidated
-                    FROM pg_constraint
-                    WHERE conrelid = 'trade_decisions'::regclass
-                    """
-                )
-            ).all()
-            validation_state = {
-                str(row.conname): bool(row.convalidated) for row in constraint_rows
-            }
-            assert expected_constraints <= validation_state.keys()
-            assert all(validation_state[name] for name in expected_constraints)
-
-            usage_index = connection.execute(
-                text(
-                    """
-                    SELECT indisvalid, pg_get_expr(indpred, indrelid) AS predicate
-                    FROM pg_index
-                    WHERE indexrelid =
-                        'ix_trade_decisions_capital_authority_usage'::regclass
-                    """
-                )
-            ).one()
-            assert usage_index.indisvalid is True
-            assert "strategy_capital_authority_allowed IS TRUE" in str(
-                usage_index.predicate
-            )
-
-            archive_index = connection.execute(
-                text(
-                    """
-                    SELECT indisvalid, pg_get_expr(indpred, indrelid) AS predicate
-                    FROM pg_index
-                    WHERE indexrelid =
-                        'ix_options_catalog_active_expiration_symbol'::regclass
-                    """
-                )
-            ).one()
-            assert archive_index.indisvalid is True
-            assert "status = 'active'::text" in str(archive_index.predicate)
-
-            historical_authority = connection.execute(
-                text(
-                    """
-                    SELECT strategy_capital_authority_id,
-                           strategy_capital_authority_digest,
-                           strategy_capital_authority_evaluated_at,
-                           strategy_capital_authority_allowed
-                    FROM trade_decisions
-                    WHERE id = :id
-                    """
-                ),
-                {"id": historical_decision_id},
-            ).one()
-            assert tuple(historical_authority) == (None, None, None, None)
-
-        strategy_id = uuid.uuid4()
-        authority_record_id = uuid.uuid4()
-        payload = {
-            "schema_version": "torghut.strategy-capital-authority.v1",
-            "authority_id": "postgres-safe-v1",
-            "strategy_ref": "postgres-safe",
-            "stage": "shadow_allowed",
-            "account_mode": "none",
-            "venue": "none",
-            "allowed_symbols": [],
-            "max_order_notional": "0",
-            "max_gross_notional": "0",
-            "max_net_notional": "0",
-            "max_loss": "0",
-            "max_orders_per_minute": 0,
-            "max_orders_per_session": 0,
-            "reduce_only": True,
-            "blockers": ["p0_capital_freeze"],
-        }
-        with schema_engine.begin() as connection:
-            connection.execute(
-                text("INSERT INTO strategies (id, name) VALUES (:id, :name)"),
-                {"id": strategy_id, "name": "postgres-safe"},
-            )
-            connection.execute(
-                text(
-                    """
-                    INSERT INTO strategy_capital_authorities (
-                        id, authority_id, strategy_id, schema_version, stage,
-                        authority_digest, payload_json
-                    ) VALUES (
-                        :id, :authority_id, :strategy_id, :schema_version, :stage,
-                        :authority_digest, CAST(:payload_json AS jsonb)
-                    )
-                    """
-                ),
-                {
-                    "id": authority_record_id,
-                    "authority_id": "postgres-safe-v1",
-                    "strategy_id": strategy_id,
-                    "schema_version": "torghut.strategy-capital-authority.v1",
-                    "stage": "shadow_allowed",
-                    "authority_digest": "sha256:" + "a" * 64,
-                    "payload_json": json.dumps(payload),
-                },
-            )
-            connection.execute(
-                text(
-                    "UPDATE strategies SET active_capital_authority_id = :authority_id "
-                    "WHERE id = :strategy_id"
-                ),
-                {
-                    "authority_id": authority_record_id,
-                    "strategy_id": strategy_id,
-                },
-            )
-
-        other_strategy_id = uuid.uuid4()
-        with schema_engine.begin() as connection:
-            connection.execute(
-                text("INSERT INTO strategies (id, name) VALUES (:id, :name)"),
-                {"id": other_strategy_id, "name": "postgres-other"},
-            )
-        with pytest.raises(DBAPIError) as cross_strategy:
-            with schema_engine.begin() as connection:
-                connection.execute(
-                    text(
-                        """
-                        INSERT INTO trade_decisions (
-                            id, strategy_id, alpaca_account_label,
-                            strategy_capital_authority_id,
-                            strategy_capital_authority_digest,
-                            strategy_capital_authority_evaluated_at,
-                            strategy_capital_authority_allowed
-                        ) VALUES (
-                            :id, :strategy_id, 'paper', :authority_id,
-                            :authority_digest, clock_timestamp(), true
-                        )
-                        """
-                    ),
-                    {
-                        "id": uuid.uuid4(),
-                        "strategy_id": other_strategy_id,
-                        "authority_id": "postgres-safe-v1",
-                        "authority_digest": "sha256:" + "a" * 64,
-                    },
-                )
-        assert getattr(cross_strategy.value.orig, "sqlstate", None) == "23503"
-
-        with schema_engine.begin() as connection:
-            connection.execute(
-                text(
-                    """
-                    INSERT INTO trade_decisions (
-                        id, strategy_id, alpaca_account_label,
-                        strategy_capital_authority_id,
-                        strategy_capital_authority_digest,
-                        strategy_capital_authority_evaluated_at,
-                        strategy_capital_authority_allowed
-                    ) VALUES (
-                        :id, :strategy_id, 'paper', :authority_id,
-                        :authority_digest, clock_timestamp(), true
-                    )
-                    """
-                ),
-                {
-                    "id": uuid.uuid4(),
-                    "strategy_id": strategy_id,
-                    "authority_id": "postgres-safe-v1",
-                    "authority_digest": "sha256:" + "a" * 64,
-                },
-            )
-
-        for statement in (
-            "UPDATE strategy_capital_authorities SET stage = 'research_only'",
-            "DELETE FROM strategy_capital_authorities",
-            "UPDATE evidence_epochs SET payload_json = "
-            "jsonb_build_object('tampered', true)",
-            "DELETE FROM evidence_epochs",
-        ):
-            with pytest.raises(DBAPIError) as blocked:
-                with schema_engine.begin() as connection:
-                    connection.execute(text(statement))
-            assert getattr(blocked.value.orig, "sqlstate", None) == "23514"
-
-        with pytest.raises(DBAPIError) as downgrade:
-            command.downgrade(alembic, "0062_options_archive_members")
-        assert getattr(downgrade.value.orig, "sqlstate", None) == "55000"
-        assert inspect(schema_engine).has_table("strategy_capital_authorities")
+        _upgrade_and_repair_online_indexes(schema_engine, alembic)
+        _assert_online_schema(schema_engine, historical_decision_id)
+        strategy_id = _insert_active_capital_authority(schema_engine)
+        _assert_strategy_scope_fence(schema_engine, strategy_id)
+        _assert_authority_history_is_immutable(schema_engine)
+        _assert_downgrade_is_refused(schema_engine, alembic)
     finally:
         schema_engine.dispose()
         with admin_engine.begin() as connection:


### PR DESCRIPTION
## Summary

- convert the strategy-capital migration to a bounded, retry-safe online migration using short lock timeouts, validated constraints, and structurally verified concurrent indexes
- linearize the Alembic chain after the options-archive migration and harden both new migrations against partial or incorrectly shaped indexes
- test the migrations on PostgreSQL 17, add the authority migration to required mutation-fencing CI, align CI with the production PostgreSQL major, and allow the GitOps migration Job enough time for the measured live table sizes
- remove the new oversized-test debt by splitting the PostgreSQL proof into focused helpers while preserving the full database contract

## Related Issues

None

## Testing

- `uv run --frozen pytest -q tests/test_options_archive_finalization_index_migration.py tests/test_strategy_capital_authority_migration.py tests/trading/test_strategy_capital_authority.py tests/trading/test_strategy_capital_authority_store.py` — 43 passed
- required PostgreSQL 17 mutation-fencing suite from `torghut-ci.yml` — 27 passed
- all five Pyright project profiles — 0 errors
- `uv run --frozen ruff format --check app tests scripts migrations`
- `uv run --frozen ruff check app tests scripts migrations`
- Pylint structural, changed-line quality, design-complexity, and file-length gates
- tech-debt ratchet — passed; `functions_ge_250` returned from 104 to 103
- migration lineage guardrail — one head: `0064_strategy_capital_authority`
- `actionlint .github/workflows/torghut-ci.yml`
- `kubectl apply --dry-run=client -n torghut -f argocd/applications/torghut/db-migrations-job.yaml`

## Breaking Changes

The new capital-authority schema intentionally refuses downgrade after application because the authority and evidence tables are append-only audit records. Deployment remains fail-closed: lock contention aborts in about five seconds, leaves Alembic at the last completed revision, and is safe to retry.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
