### PR TITLE
test(torghut): align migration safety contracts

### DIFF
--- a/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
@@ -495,6 +495,7 @@ describe('torghut build-push workflow', () => {
     expect(postgresJobBody).toContain('tests/execution/test_broker_mutation_linked_receipts_postgres.py')
     expect(postgresJobBody).toContain('tests/execution/test_broker_mutation_receipt_boundaries_postgres.py')
     expect(postgresJobBody).toContain('tests/execution/test_linked_submission_terminal_postgres.py')
+    expect(postgresJobBody).toContain('tests/trading/test_strategy_capital_authority_postgres.py')
     expect(postgresJobBody).not.toContain('-n auto')
 
     const aggregateStart = ciWorkflow.indexOf('\n  lint-and-tests:')

--- a/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
+++ b/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
@@ -268,6 +268,7 @@ describe('update-manifests', () => {
 
     expect(migrationManifest).toContain('backoffLimit: 6')
     expect(migrationManifest).toContain('activeDeadlineSeconds: 3600')
+    expect(migrationManifest).toContain("migration's 45-minute statement timeout")
     expect(migrationManifest).toContain('wait_for_database()')
     expect(migrationManifest).toContain("connection.execute(text('select 1'))")
     expect(migrationManifest).toContain('wait_for_database "torghut app database" "${DB_DSN}" 300')


### PR DESCRIPTION
## Summary

- Assert that the PostgreSQL mutation-fencing CI job includes the strategy-capital-authority regression suite.
- Assert that the 3,600-second migration deadline remains documented as covering the 45-minute concurrent-index timeout.

## Related Issues

None.

## Testing

- `bun test packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts packages/scripts/src/torghut/__tests__/update-manifests.test.ts` (30 passed)
- `bunx oxfmt --check packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts packages/scripts/src/torghut/__tests__/update-manifests.test.ts`
- `git diff --check`
- Normal pre-commit lint-staged and commitlint hooks.

## Screenshots (if applicable)

N/A; test-contract-only change.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
