### PR TITLE
fix(torghut): align deploy verifier with migration deadline

### DIFF
--- a/.github/workflows/torghut-post-deploy-verify.yml
+++ b/.github/workflows/torghut-post-deploy-verify.yml
@@ -163,8 +163,11 @@ jobs:
             request_argocd_sync "${app}" "${EXPECTED_REVISION}"
           done
 
-          ARGO_SYNC_POLL_ATTEMPTS=150
+          # The PreSync database migration may run for up to one hour. Keep the verifier
+          # alive for that deadline plus five minutes of Argo reconciliation headroom.
+          ARGO_SYNC_TIMEOUT_SECONDS=3900
           ARGO_SYNC_POLL_INTERVAL_SECONDS=2
+          ARGO_SYNC_POLL_ATTEMPTS=$((ARGO_SYNC_TIMEOUT_SECONDS / ARGO_SYNC_POLL_INTERVAL_SECONDS))
 
           for app in torghut torghut-options; do
             for attempt in $(seq 1 "${ARGO_SYNC_POLL_ATTEMPTS}"); do

--- a/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
@@ -472,7 +472,7 @@ describe('torghut build-push workflow', () => {
     expect(postgresJobStart).toBeGreaterThan(-1)
     expect(postgresJobEnd).toBeGreaterThan(postgresJobStart)
     expect(postgresJobBody).toContain('name: PostgreSQL mutation fencing CAS')
-    expect(postgresJobBody).toContain('image: postgres:18-trixie')
+    expect(postgresJobBody).toContain('image: postgres:17-bookworm')
     expect(postgresJobBody).toContain('--health-cmd "pg_isready -U torghut -d torghut_test"')
     expect(postgresJobBody).toContain(
       'TORGHUT_TEST_POSTGRES_DSN: postgresql+psycopg://torghut:torghut@127.0.0.1:5432/torghut_test',

--- a/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
@@ -6,6 +6,10 @@ const workflow = readFileSync(
   new URL('../../../../../.github/workflows/torghut-post-deploy-verify.yml', import.meta.url),
   'utf8',
 )
+const dbMigrationJob = readFileSync(
+  new URL('../../../../../argocd/applications/torghut/db-migrations-job.yaml', import.meta.url),
+  'utf8',
+)
 const agentsCiClusterRbac = readFileSync(
   new URL('../../../../../argocd/applications/agents-ci/runner-rbac-cluster.yaml', import.meta.url),
   'utf8',
@@ -224,8 +228,14 @@ describe('torghut post-deploy verifier workflow', () => {
   })
 
   it('bounds Argo convergence waits and prints resource diagnostics on timeout', () => {
-    expect(workflow).toContain('ARGO_SYNC_POLL_ATTEMPTS=150')
+    const syncTimeoutSeconds = Number(workflow.match(/ARGO_SYNC_TIMEOUT_SECONDS=(\d+)/)?.[1])
+    const migrationDeadlineSeconds = Number(dbMigrationJob.match(/activeDeadlineSeconds:\s*(\d+)/)?.[1])
+
+    expect(syncTimeoutSeconds).toBeGreaterThanOrEqual(migrationDeadlineSeconds + 300)
     expect(workflow).toContain('ARGO_SYNC_POLL_INTERVAL_SECONDS=2')
+    expect(workflow).toContain(
+      'ARGO_SYNC_POLL_ATTEMPTS=$((ARGO_SYNC_TIMEOUT_SECONDS / ARGO_SYNC_POLL_INTERVAL_SECONDS))',
+    )
     expect(workflow).toContain('for attempt in $(seq 1 "${ARGO_SYNC_POLL_ATTEMPTS}"); do')
     expect(workflow).toContain('sleep "${ARGO_SYNC_POLL_INTERVAL_SECONDS}"')
     expect(workflow).toContain(

--- a/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
+++ b/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
@@ -267,7 +267,7 @@ describe('update-manifests', () => {
     const migrationManifest = readFileSync(join(repoRoot, 'argocd/applications/torghut/db-migrations-job.yaml'), 'utf8')
 
     expect(migrationManifest).toContain('backoffLimit: 6')
-    expect(migrationManifest).toContain('activeDeadlineSeconds: 900')
+    expect(migrationManifest).toContain('activeDeadlineSeconds: 3600')
     expect(migrationManifest).toContain('wait_for_database()')
     expect(migrationManifest).toContain("connection.execute(text('select 1'))")
     expect(migrationManifest).toContain('wait_for_database "torghut app database" "${DB_DSN}" 300')


### PR DESCRIPTION
## Summary

- extend the bounded Torghut Argo convergence window from five minutes to 65 minutes so it covers the one-hour PreSync migration deadline plus reconciliation headroom
- derive poll attempts from an explicit timeout while preserving the existing two-second polling interval and timeout diagnostics
- add a regression assertion that the verifier timeout stays at least five minutes beyond the migration Job deadline
- repair stale rollout tests that still asserted the retired 15-minute migration budget and PostgreSQL 18 instead of the production PostgreSQL 17 contract

## Related Issues

None

## Testing

- `bun test packages/scripts/src`
- `bun run --filter @proompteng/scripts lint`
- `bun run --cwd packages/scripts lint:oxlint:type`
- `actionlint .github/workflows/torghut-post-deploy-verify.yml`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.