### PR TITLE
fix(torghut): use composite archive finalization keys

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -9,7 +9,9 @@ metadata:
     argocd.argoproj.io/sync-wave: "-1"
 spec:
   backoffLimit: 6
-  activeDeadlineSeconds: 900
+  # This hook runs the same migration heads as the core Torghut hook. Keep the
+  # deadline above the 45-minute concurrent index-build statement timeout.
+  activeDeadlineSeconds: 3600
   ttlSecondsAfterFinished: 600
   template:
     metadata:

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -430,6 +430,7 @@ describe('Torghut manifest scheduling', () => {
     )
 
     const runtimeMigrationJob = parseManifest('argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml')
+    expect(getAtPath(runtimeMigrationJob, ['spec']).activeDeadlineSeconds).toBe(3600)
     const migrationContainer = getAtPath(runtimeMigrationJob, ['spec', 'template', 'spec', 'containers', 0])
     expect(String(migrationContainer.image)).toMatch(
       /^registry\.ide-newton\.ts\.net\/lab\/torghut@sha256:[0-9a-f]{64}$/,

--- a/services/torghut/app/options_lane/archive_repository.py
+++ b/services/torghut/app/options_lane/archive_repository.py
@@ -724,6 +724,9 @@ class OptionsArchiveRepository:
                     transitioned_count=current.transitioned_count,
                 )
 
+            candidate_expiration_dates = [
+                cast(date, row["expiration_date"]) for row in candidate_rows
+            ]
             candidate_symbols = [str(row["contract_symbol"]) for row in candidate_rows]
             transition_result = cast(
                 CursorResult[object],
@@ -731,6 +734,14 @@ class OptionsArchiveRepository:
                     session,
                     text(
                         f"""
+                    WITH candidates AS (
+                      SELECT candidate.expiration_date,
+                             candidate.contract_symbol
+                      FROM unnest(
+                        CAST(:candidate_expiration_dates AS DATE[]),
+                        CAST(:candidate_symbols AS TEXT[])
+                      ) AS candidate(expiration_date, contract_symbol)
+                    )
                     UPDATE torghut_options_contract_catalog AS catalog
                     SET status = CASE
                           WHEN catalog.expiration_date < CAST(:observed_at AS DATE)
@@ -738,9 +749,9 @@ class OptionsArchiveRepository:
                           ELSE 'inactive'
                         END,
                         last_seen_ts = :observed_at
-                    WHERE catalog.contract_symbol = ANY(
-                            CAST(:candidate_symbols AS TEXT[])
-                          )
+                    FROM candidates
+                    WHERE catalog.expiration_date = candidates.expiration_date
+                      AND catalog.contract_symbol = candidates.contract_symbol
                       AND catalog.status = 'active'
                       AND NOT EXISTS (
                         SELECT 1
@@ -754,6 +765,7 @@ class OptionsArchiveRepository:
                     ),
                     {
                         "observed_at": observed_at,
+                        "candidate_expiration_dates": candidate_expiration_dates,
                         "candidate_symbols": candidate_symbols,
                         "component": ARCHIVE_COMPONENT,
                         "query_fingerprint": query_fingerprint,

--- a/services/torghut/tests/test_options_archive.py
+++ b/services/torghut/tests/test_options_archive.py
@@ -610,14 +610,27 @@ def test_finalize_scans_one_bounded_batch_and_persists_cursor() -> None:
     )
     assert "LIMIT :batch_size" in candidate_sql
     assert "ORDER BY catalog.expiration_date, catalog.contract_symbol" in candidate_sql
-    transition_sql = next(
-        sql
-        for sql, _ in session.calls
+    transition_sql, transition_parameters = next(
+        (sql, parameters)
+        for sql, parameters in session.calls
         if "UPDATE torghut_options_contract_catalog" in sql
     )
+    assert "WITH candidates AS" in transition_sql
+    assert "CAST(:candidate_expiration_dates AS DATE[])" in transition_sql
     assert "CAST(:candidate_symbols AS TEXT[])" in transition_sql
+    assert "catalog.expiration_date = candidates.expiration_date" in transition_sql
+    assert "catalog.contract_symbol = candidates.contract_symbol" in transition_sql
     assert "membership.query_fingerprint = :query_fingerprint" in transition_sql
     assert "membership.shard_key = :shard_key" in transition_sql
+    assert isinstance(transition_parameters, dict)
+    assert transition_parameters["candidate_expiration_dates"] == [
+        date(2026, 7, 14),
+        date(2026, 7, 15),
+    ]
+    assert transition_parameters["candidate_symbols"] == [
+        "AAPL-CONTRACT",
+        "MSFT-CONTRACT",
+    ]
     assert not any(
         "DELETE FROM torghut_options_archive_membership" in sql
         for sql, _ in session.calls


### PR DESCRIPTION
## Summary

- Finalize archive candidates by paired expiration-date and contract-symbol keys so PostgreSQL can use the bounded active-catalog index.
- Preserve exact candidate identity with zipped typed arrays and retain the existing archive-membership anti-join.
- Raise the Hyperliquid migration hook deadline above the shared 45-minute concurrent-index timeout.
- Add regression contracts for the composite update parameters and migration deadline.

## Related Issues

None.

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff check app/options_lane/archive_repository.py tests/test_options_archive.py`
- `uv run --frozen ruff format --check app/options_lane/archive_repository.py tests/test_options_archive.py`
- `uv run --frozen pytest -q tests/test_options_archive.py` (21 passed)
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts` (15 passed)
- `bun run lint:argocd`
- `kustomize build --enable-helm argocd/applications/torghut-hyperliquid-runtime | kubectl apply --server-side --dry-run=server -n torghut -f -`
- Production `EXPLAIN (COSTS OFF)` selected `ix_options_catalog_active_expiration_symbol` and the archive-membership primary key for the corrected update; it did not scan the catalog.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Rollout evidence and containment state are tracked in the storage-remediation rollout document.
