### PR TITLE
fix(ceph): cap concurrent OSD scrubs

### DIFF
--- a/argocd/applications/observability/graf-mimir-rules.yaml
+++ b/argocd/applications/observability/graf-mimir-rules.yaml
@@ -239,9 +239,9 @@ data:
           - record: ceph_storage:pool_read_bytes_per_second:rate5m
             expr: sum(rate(ceph_pool_rd_bytes{job="ceph-storage"}[5m]))
           - record: ceph_storage:scrubbing_pgs:sum
-            expr: |
-              sum(ceph_pg_scrubbing{job="ceph-storage"}) +
-              sum(ceph_pg_deep{job="ceph-storage"})
+            # ceph_pg_deep is a subset of ceph_pg_scrubbing. Adding both counts
+            # every deep-scrubbing PG twice and overstates live concurrency.
+            expr: sum(ceph_pg_scrubbing{job="ceph-storage"})
           - record: ceph_storage:rbd_pod_write_bytes_per_second:rate5m
             expr: |
               sum by (namespace, pod, device) (

--- a/argocd/applications/rook-ceph/cluster-values.yaml
+++ b/argocd/applications/rook-ceph/cluster-values.yaml
@@ -47,6 +47,9 @@ cephClusterSpec:
       # Automatically repair small scrub inconsistencies. Larger damage still requires operator review.
       osd_scrub_auto_repair: "true"
       osd_scrub_auto_repair_num_errors: "5"
+      # Keep client fsync latency ahead of maintenance on the shared two-host HDD path.
+      # Scrub-debt alerts remain enabled, so deferred work cannot accumulate silently.
+      osd_max_scrubs: "1"
     # Per-OSD mClock HDD IOPS capacity, measured with Ceph's documented 4 KiB OSD bench path on 2026-07-07.
     osd.0:
       osd_mclock_max_capacity_iops_hdd: "210"

--- a/packages/scripts/src/docs/__tests__/rook-ceph-runbook.test.ts
+++ b/packages/scripts/src/docs/__tests__/rook-ceph-runbook.test.ts
@@ -48,6 +48,7 @@ it('rolls OSDs when scrub configuration changes', () => {
 
   expect(values).toContain('osd_scrub_auto_repair: "true"')
   expect(values).toContain('osd_scrub_auto_repair_num_errors: "5"')
+  expect(values).toContain('osd_max_scrubs: "1"')
   expect(kustomization).toContain('path: cephcluster-osd-config-rollout.yaml')
   expect(kustomization).toContain('kind: CephCluster')
   expect(kustomization).toContain('name: rook-ceph')

--- a/packages/scripts/src/shared/__tests__/storage-observability-contract.test.ts
+++ b/packages/scripts/src/shared/__tests__/storage-observability-contract.test.ts
@@ -47,6 +47,7 @@ test('Mimir records the storage baseline and alerts on actionable pressure', () 
     'torghut_postgres:requested_checkpoint_ratio:rate1h',
     'ceph_storage:osd_commit_latency_ms:max',
     'ceph_storage:pool_write_bytes_per_second:rate5m',
+    'ceph_storage:scrubbing_pgs:sum',
     'ceph_storage:rbd_pod_write_bytes_per_second:rate5m',
     'ceph_storage:rbd_pod_write_iops:rate5m',
     'alert: TorghutPostgresMetricsMissing',
@@ -70,6 +71,8 @@ test('Mimir records the storage baseline and alerts on actionable pressure', () 
 
   expect(rules).toContain('max(ceph_osd_flag_noscrub{job="ceph-storage"}) > 0 or')
   expect(rules).toContain('max(ceph_osd_flag_nodeep_scrub{job="ceph-storage"}) > 0')
+  expect(rules).toContain('expr: sum(ceph_pg_scrubbing{job="ceph-storage"})')
+  expect(rules).not.toContain('sum(ceph_pg_scrubbing{job="ceph-storage"}) +')
   expect(rules).toContain(
     'sum(\n                increase(\n                  cnpg_pg_stat_checkpointer_checkpoints_req{',
   )


### PR DESCRIPTION
## Summary

- Set steady-state `osd_max_scrubs` to one per OSD on the shared two-host Ceph path.
- Preserve the `high_client_ops` mClock profile, automatic scrub repair, and existing overdue-scrub alerts.
- Add a contract assertion so the client-latency protection cannot be removed silently.
- Correct the scrub-concurrency recording rule so deep-scrubbing PGs are not counted twice.
- Leave scrub-hour scheduling unchanged until the accepted seven-day traffic baseline exists.

## Related Issues

None.

## Testing

- `bun test ./packages/scripts/src/docs/__tests__/rook-ceph-runbook.test.ts ./packages/scripts/src/shared/__tests__/storage-observability-contract.test.ts` (7 passed)
- `bunx oxfmt --check packages/scripts/src/docs/__tests__/rook-ceph-runbook.test.ts packages/scripts/src/shared/__tests__/storage-observability-contract.test.ts`
- `bun run lint:argocd`
- `kustomize build --enable-helm argocd/applications/rook-ceph | kubectl apply --server-side --dry-run=server --field-manager=argocd-controller -n rook-ceph -f -`
- Confirmed the rendered `CephCluster/rook-ceph` contains `spec.cephConfig.osd.osd_max_scrubs: "1"` and no `Namespace` object.
- Server-side dry-run of the rendered `ConfigMap/graf-mimir-rules` with Argo's live field manager.
- Live readback showed the effective default was `3`; OSD 5 was primary for three simultaneous scrub operations while Kafka controller durable events reached 4.3 seconds.
- Live metrics confirmed `ceph_pg_deep` is a subset of `ceph_pg_scrubbing`; the old sum reported 13 while only seven PGs were actively scrubbing at the sampled instant.
- Emergency containment applied the same value with `ceph config set osd osd_max_scrubs 1`; live readback reports `1` on OSDs 0-5. This PR removes that config-database deviation by making GitOps authoritative.

## Screenshots (if applicable)

N/A; configuration-only change.

## Breaking Changes

Scrub work may take longer during sustained client traffic, but overdue scrub/deep-scrub debt remains alerted. Pool durability, repair behavior, and client I/O settings are unchanged.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] The accepted storage write-pressure design and rollout evidence track the remaining measured scrub-window follow-up.
