### PR TITLE
fix(torghut): preserve released migration revision

### DIFF
--- a/services/torghut/migrations/versions/0063_strategy_capital_authority_compat.py
+++ b/services/torghut/migrations/versions/0063_strategy_capital_authority_compat.py
@@ -1,0 +1,28 @@
+"""Preserve the previously shipped strategy-capital revision identifier.
+
+Revision ID: 0063_strategy_capital_authority
+Revises: 0062_options_archive_members
+Create Date: 2026-07-14 06:40:00.000000
+
+This revision was released before the strategy-capital migration was moved to
+0064 to linearize the options archive index. Databases stamped at the old ID
+already contain the strategy-capital schema, so this node must remain a no-op.
+The idempotent 0064 migration repairs or completes that schema on the path to
+the merge revision.
+"""
+
+from __future__ import annotations
+
+
+revision = "0063_strategy_capital_authority"
+down_revision = "0062_options_archive_members"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/services/torghut/migrations/versions/0065_strategy_capital_authority_compat.py
+++ b/services/torghut/migrations/versions/0065_strategy_capital_authority_compat.py
@@ -1,0 +1,25 @@
+"""Merge the released strategy-capital revision with the linearized chain.
+
+Revision ID: 0065_strategy_capital_compat
+Revises: 0064_strategy_capital_authority, 0063_strategy_capital_authority
+Create Date: 2026-07-14 06:41:00.000000
+"""
+
+from __future__ import annotations
+
+
+revision = "0065_strategy_capital_compat"
+down_revision = (
+    "0064_strategy_capital_authority",
+    "0063_strategy_capital_authority",
+)
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/services/torghut/tests/test_strategy_capital_authority_migration_compat.py
+++ b/services/torghut/tests/test_strategy_capital_authority_migration_compat.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from alembic.config import Config as AlembicConfig
+from alembic.script import ScriptDirectory
+
+from tests.migration_testing import load_migration_module
+
+
+SERVICE_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_released_strategy_capital_revision_remains_addressable() -> None:
+    compatibility = load_migration_module("0063_strategy_capital_authority_compat.py")
+    merge = load_migration_module("0065_strategy_capital_authority_compat.py")
+
+    assert compatibility.revision == "0063_strategy_capital_authority"
+    assert compatibility.down_revision == "0062_options_archive_members"
+    assert merge.revision == "0065_strategy_capital_compat"
+    assert set(merge.down_revision) == {
+        "0064_strategy_capital_authority",
+        "0063_strategy_capital_authority",
+    }
+
+
+def test_migration_graph_has_one_merged_head_and_knows_the_released_revision() -> None:
+    config = AlembicConfig(str(SERVICE_ROOT / "alembic.ini"))
+    scripts = ScriptDirectory.from_config(config)
+
+    assert scripts.get_heads() == ["0065_strategy_capital_compat"]
+    assert scripts.get_revision("0063_strategy_capital_authority") is not None
+    assert scripts.get_revision("0064_strategy_capital_authority") is not None
+    assert scripts.get_revision("0065_strategy_capital_compat") is not None

--- a/services/torghut/tests/trading/test_strategy_capital_authority_postgres.py
+++ b/services/torghut/tests/trading/test_strategy_capital_authority_postgres.py
@@ -438,3 +438,67 @@ def test_postgres_authority_migration_lock_timeout_is_retry_safe(
         with admin_engine.begin() as connection:
             connection.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
         admin_engine.dispose()
+
+
+@pytest.mark.skipif(
+    not POSTGRES_DSN,
+    reason="set TORGHUT_TEST_POSTGRES_DSN for the opt-in authority migration test",
+)
+def test_released_0063_strategy_capital_revision_upgrades_to_merged_head(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert POSTGRES_DSN is not None
+    schema = f"strategy_authority_compat_{uuid.uuid4().hex}"
+    admin_engine = create_engine(POSTGRES_DSN, future=True)
+    schema_url = make_url(POSTGRES_DSN).update_query_dict(
+        {"options": f"-csearch_path={schema}"}
+    )
+    schema_engine = create_engine(schema_url, future=True)
+    try:
+        with admin_engine.begin() as connection:
+            connection.execute(text(f'CREATE SCHEMA "{schema}"'))
+        _create_pre_migration_schema(schema_engine)
+        monkeypatch.setattr(
+            settings,
+            "db_dsn",
+            schema_url.render_as_string(hide_password=False),
+        )
+        alembic = AlembicConfig(str(SERVICE_ROOT / "alembic.ini"))
+        command.stamp(alembic, "0062_options_archive_members")
+        command.upgrade(alembic, "0064_strategy_capital_authority")
+
+        with schema_engine.begin() as connection:
+            connection.execute(
+                text("DROP INDEX ix_options_catalog_active_expiration_symbol")
+            )
+            connection.execute(text("DELETE FROM alembic_version"))
+            connection.execute(
+                text(
+                    "INSERT INTO alembic_version (version_num) "
+                    "VALUES ('0063_strategy_capital_authority')"
+                )
+            )
+
+        command.upgrade(alembic, "heads")
+
+        with schema_engine.connect() as connection:
+            revisions = set(
+                connection.execute(text("SELECT version_num FROM alembic_version"))
+                .scalars()
+                .all()
+            )
+            archive_index = connection.execute(
+                text(
+                    "SELECT indisvalid FROM pg_index "
+                    "WHERE indexrelid = "
+                    "'ix_options_catalog_active_expiration_symbol'::regclass"
+                )
+            ).scalar_one()
+        assert revisions == {"0065_strategy_capital_compat"}
+        assert archive_index is True
+        assert inspect(schema_engine).has_table("strategy_capital_authorities")
+    finally:
+        schema_engine.dispose()
+        with admin_engine.begin() as connection:
+            connection.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+        admin_engine.dispose()


### PR DESCRIPTION
## Summary

- Restore the previously released `0063_strategy_capital_authority` Alembic revision as a no-op compatibility node.
- Merge that released branch with the linearized options-index and strategy-capital chain at one `0065_strategy_capital_compat` head.
- Keep fresh installs linear at one head while allowing databases stamped at the old 0063 to run the idempotent 0064 repair path.
- Add graph and PostgreSQL 17 regression coverage for the exact stranded-revision upgrade.

## Related Issues

Follow-up for the unresolved P1 review on #12448.

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff check` on all changed Python files
- `uv run --frozen ruff format --check` on all changed Python files
- `uv run --frozen pytest -q tests/test_strategy_capital_authority_migration_compat.py tests/test_strategy_capital_authority_migration.py tests/test_check_migration_graph.py` (12 passed)
- `uv run --frozen python scripts/check_migration_graph.py` (one head, one root, no orphan or duplicate revisions)
- PostgreSQL 17: `TORGHUT_TEST_POSTGRES_DSN=... uv run --frozen pytest -q tests/trading/test_strategy_capital_authority_postgres.py` (3 passed)
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A; migration-graph compatibility change.

## Breaking Changes

The sole Alembic head advances from `0064_strategy_capital_authority` to `0065_strategy_capital_compat`. The new head performs no DDL; it only merges the previously released revision identity into the current graph.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] The merged-PR P1 is linked and has a production-image follow-up path.
