### PR TITLE
fix(torghut): increase PostgreSQL WAL buffers

### DIFF
--- a/argocd/applications/torghut/postgres-cluster.yaml
+++ b/argocd/applications/torghut/postgres-cluster.yaml
@@ -6,6 +6,11 @@ metadata:
 spec:
   instances: 1
   primaryUpdateStrategy: unsupervised
+  postgresql:
+    parameters:
+      # The automatic 4 MiB allocation exhausted repeatedly under short write bursts.
+      # Keep durability intact and absorb those bursts with a bounded 16 MiB buffer.
+      wal_buffers: "16MB"
   storage:
     storageClass: rook-ceph-block
     size: 50Gi

--- a/packages/scripts/src/torghut/__tests__/postgres-wal-settings.test.ts
+++ b/packages/scripts/src/torghut/__tests__/postgres-wal-settings.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import YAML from 'yaml'
+
+import { repoRoot } from '../../shared/cli'
+
+type PostgresCluster = {
+  spec: {
+    postgresql: {
+      parameters: Record<string, string>
+    }
+  }
+}
+
+const cluster = YAML.parse(
+  readFileSync(join(repoRoot, 'argocd/applications/torghut/postgres-cluster.yaml'), 'utf8'),
+) as PostgresCluster
+
+describe('Torghut PostgreSQL WAL settings', () => {
+  it('uses a bounded WAL buffer sized for observed production bursts', () => {
+    expect(cluster.spec.postgresql.parameters.wal_buffers).toBe('16MB')
+  })
+
+  it('does not weaken PostgreSQL durability', () => {
+    const parameters = cluster.spec.postgresql.parameters
+
+    expect(parameters.fsync).not.toBe('off')
+    expect(parameters.full_page_writes).not.toBe('off')
+    expect(parameters.synchronous_commit).not.toBe('off')
+  })
+})


### PR DESCRIPTION
## Summary

- Set Torghut PostgreSQL `wal_buffers` to 16 MiB after production repeatedly exhausted the automatic 4 MiB allocation during short write bursts.
- Preserve `fsync`, `full_page_writes`, and `synchronous_commit`; this change does not weaken durability or mask the storage path with timeouts.
- Add a manifest regression test that pins the bounded buffer and prevents durability settings from being disabled.

## Related Issues

None.

## Testing

- `bun test packages/scripts/src/torghut/__tests__/postgres-wal-settings.test.ts` (2 passed)
- `bunx oxfmt --check packages/scripts/src/torghut/__tests__/postgres-wal-settings.test.ts`
- `kustomize build --enable-helm argocd/applications/torghut`
- `kubectl apply -n torghut --server-side --dry-run=server --field-manager=argocd-controller -f argocd/applications/torghut/postgres-cluster.yaml`
- `bun run lint:argocd`
- Live preflight: CNPG `torghut-db` healthy with one ready primary; Ceph `HEALTH_OK`; no active scrub; Kafka ready on 4.3.0/4.3-IV0.

## Screenshots (if applicable)

N/A. This is a PostgreSQL configuration change.

## Breaking Changes

No API or schema break. `wal_buffers` is a postmaster setting, so the single-instance CNPG cluster must restart and will have a brief database interruption during rollout.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are filled in.
- [x] The rollout impact and follow-up live verification are documented.
