### PR TITLE
chore(torghut): promote image sha-da8860567f33f70c2d5392a4ebe6e2e725e1fd4d

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -22,7 +22,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: migrate
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9c643f62e3defd6abd77aadce5b71771c7121bd24f06566ced8150bf531a987f
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d68f79114a115754e39a1a3f48d3f5a1e9cc42aac4aff629791b0f35749ff90e
           imagePullPolicy: Always
           workingDir: /app
           command:
@@ -52,9 +52,9 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: 11d676e9e4c3b5b7a8b3a82b7cb812e88b9a9317
+              value: da8860567f33f70c2d5392a4ebe6e2e725e1fd4d
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:9c643f62e3defd6abd77aadce5b71771c7121bd24f06566ced8150bf531a987f
+              value: sha256:d68f79114a115754e39a1a3f48d3f5a1e9cc42aac4aff629791b0f35749ff90e
             - name: PYTHONPATH
               value: /app
             - name: DB_DSN

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-hyperliquid-runtime
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9c643f62e3defd6abd77aadce5b71771c7121bd24f06566ced8150bf531a987f
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d68f79114a115754e39a1a3f48d3f5a1e9cc42aac4aff629791b0f35749ff90e
           imagePullPolicy: Always
           command:
             - uvicorn
@@ -46,9 +46,9 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: 11d676e9e4c3b5b7a8b3a82b7cb812e88b9a9317
+              value: da8860567f33f70c2d5392a4ebe6e2e725e1fd4d
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:9c643f62e3defd6abd77aadce5b71771c7121bd24f06566ced8150bf531a987f
+              value: sha256:d68f79114a115754e39a1a3f48d3f5a1e9cc42aac4aff629791b0f35749ff90e
             - name: DB_DSN
               valueFrom:
                 secretKeyRef:

--- a/argocd/applications/torghut-options/archive/deployment.yaml
+++ b/argocd/applications/torghut-options/archive/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-archive
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9c643f62e3defd6abd77aadce5b71771c7121bd24f06566ced8150bf531a987f
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d68f79114a115754e39a1a3f48d3f5a1e9cc42aac4aff629791b0f35749ff90e
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -121,9 +121,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1889-g11d676e9e
+              value: v0.596.0-1892-gda8860567
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 11d676e9e4c3b5b7a8b3a82b7cb812e88b9a9317
+              value: da8860567f33f70c2d5392a4ebe6e2e725e1fd4d
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -33,7 +33,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9c643f62e3defd6abd77aadce5b71771c7121bd24f06566ced8150bf531a987f
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d68f79114a115754e39a1a3f48d3f5a1e9cc42aac4aff629791b0f35749ff90e
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -81,9 +81,9 @@ spec:
                   name: torghut-ws-config
                   key: SYMBOLS_ALLOWLIST
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1889-g11d676e9e
+              value: v0.596.0-1892-gda8860567
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 11d676e9e4c3b5b7a8b3a82b7cb812e88b9a9317
+              value: da8860567f33f70c2d5392a4ebe6e2e725e1fd4d
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9c643f62e3defd6abd77aadce5b71771c7121bd24f06566ced8150bf531a987f
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d68f79114a115754e39a1a3f48d3f5a1e9cc42aac4aff629791b0f35749ff90e
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -77,9 +77,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1889-g11d676e9e
+              value: v0.596.0-1892-gda8860567
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 11d676e9e4c3b5b7a8b3a82b7cb812e88b9a9317
+              value: da8860567f33f70c2d5392a4ebe6e2e725e1fd4d
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:9c643f62e3defd6abd77aadce5b71771c7121bd24f06566ced8150bf531a987f
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:d68f79114a115754e39a1a3f48d3f5a1e9cc42aac4aff629791b0f35749ff90e
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:9c643f62e3defd6abd77aadce5b71771c7121bd24f06566ced8150bf531a987f
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:d68f79114a115754e39a1a3f48d3f5a1e9cc42aac4aff629791b0f35749ff90e
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:9c643f62e3defd6abd77aadce5b71771c7121bd24f06566ced8150bf531a987f
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:d68f79114a115754e39a1a3f48d3f5a1e9cc42aac4aff629791b0f35749ff90e
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:9c643f62e3defd6abd77aadce5b71771c7121bd24f06566ced8150bf531a987f
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:d68f79114a115754e39a1a3f48d3f5a1e9cc42aac4aff629791b0f35749ff90e
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -27,7 +27,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9c643f62e3defd6abd77aadce5b71771c7121bd24f06566ced8150bf531a987f
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d68f79114a115754e39a1a3f48d3f5a1e9cc42aac4aff629791b0f35749ff90e
           workingDir: /app
           command:
             - /bin/sh

--- a/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
+++ b/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-generated-resource-retention
           containers:
             - name: prune-generated-residue
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:9c643f62e3defd6abd77aadce5b71771c7121bd24f06566ced8150bf531a987f
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:d68f79114a115754e39a1a3f48d3f5a1e9cc42aac4aff629791b0f35749ff90e
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:9c643f62e3defd6abd77aadce5b71771c7121bd24f06566ced8150bf531a987f
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:d68f79114a115754e39a1a3f48d3f5a1e9cc42aac4aff629791b0f35749ff90e
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-14T14:51:07Z"
+        client.knative.dev/updateTimestamp: "2026-07-14T15:23:42Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9c643f62e3defd6abd77aadce5b71771c7121bd24f06566ced8150bf531a987f
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d68f79114a115754e39a1a3f48d3f5a1e9cc42aac4aff629791b0f35749ff90e
           ports:
             - name: http1
               containerPort: 8181
@@ -523,11 +523,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1889-g11d676e9e
+              value: v0.596.0-1892-gda8860567
             - name: TORGHUT_COMMIT
-              value: 11d676e9e4c3b5b7a8b3a82b7cb812e88b9a9317
+              value: da8860567f33f70c2d5392a4ebe6e2e725e1fd4d
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:9c643f62e3defd6abd77aadce5b71771c7121bd24f06566ced8150bf531a987f
+              value: sha256:d68f79114a115754e39a1a3f48d3f5a1e9cc42aac4aff629791b0f35749ff90e
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-14T14:51:07Z"
+        client.knative.dev/updateTimestamp: "2026-07-14T15:23:42Z"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
     spec:
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9c643f62e3defd6abd77aadce5b71771c7121bd24f06566ced8150bf531a987f
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d68f79114a115754e39a1a3f48d3f5a1e9cc42aac4aff629791b0f35749ff90e
           ports:
             - name: http1
               containerPort: 8181
@@ -448,11 +448,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1889-g11d676e9e
+              value: v0.596.0-1892-gda8860567
             - name: TORGHUT_COMMIT
-              value: 11d676e9e4c3b5b7a8b3a82b7cb812e88b9a9317
+              value: da8860567f33f70c2d5392a4ebe6e2e725e1fd4d
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:9c643f62e3defd6abd77aadce5b71771c7121bd24f06566ced8150bf531a987f
+              value: sha256:d68f79114a115754e39a1a3f48d3f5a1e9cc42aac4aff629791b0f35749ff90e
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -37,7 +37,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9c643f62e3defd6abd77aadce5b71771c7121bd24f06566ced8150bf531a987f
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d68f79114a115754e39a1a3f48d3f5a1e9cc42aac4aff629791b0f35749ff90e
           command:
             - uvicorn
           args:
@@ -464,11 +464,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1889-g11d676e9e
+              value: v0.596.0-1892-gda8860567
             - name: TORGHUT_COMMIT
-              value: 11d676e9e4c3b5b7a8b3a82b7cb812e88b9a9317
+              value: da8860567f33f70c2d5392a4ebe6e2e725e1fd4d
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:9c643f62e3defd6abd77aadce5b71771c7121bd24f06566ced8150bf531a987f
+              value: sha256:d68f79114a115754e39a1a3f48d3f5a1e9cc42aac4aff629791b0f35749ff90e
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: smoke
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9c643f62e3defd6abd77aadce5b71771c7121bd24f06566ced8150bf531a987f
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d68f79114a115754e39a1a3f48d3f5a1e9cc42aac4aff629791b0f35749ff90e
           imagePullPolicy: IfNotPresent
           securityContext:
             seccompProfile:


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `da8860567f33f70c2d5392a4ebe6e2e725e1fd4d`
- Image tag: `sha-da8860567f33f70c2d5392a4ebe6e2e725e1fd4d`
- Image digest: `sha256:d68f79114a115754e39a1a3f48d3f5a1e9cc42aac4aff629791b0f35749ff90e`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher