### PR TITLE
fix(bumba): refresh Nix dependency hashes

### DIFF
--- a/nix/images/bumba.nix
+++ b/nix/images/bumba.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "bumba";
   packageName = "@proompteng/bumba";
   depsHash = {
-    x86_64-linux = "sha256-JpFHbVLyQVNTeLvvDwduPqoo4jkiKG5jirKOMNSbjEI=";
-    aarch64-linux = "sha256-yK4n/Pe08AAtYybtEFhcLOP2ky+rujiRas9kOFJ2/88=";
+    x86_64-linux = "sha256-/y9Fddzh7o4/Oa2wQniHYgqkE0Rs+sM1u8Edm0Lc80o=";
+    aarch64-linux = "sha256-CmO+ZzanZxA+J6u+8RI99lO5tTmKC1801U3672c5AwE=";
   };
   installFilters = [
     "@proompteng/bumba"


### PR DESCRIPTION
## Summary

- Refresh the x86_64-linux Bumba Bun dependency hash from the release builder output.
- Refresh the aarch64-linux Bumba Bun dependency hash from the release builder output.
- Unblock the Atlas maintenance image rollout after the merged source change invalidated both fixed-output derivations.

## Related Issues

None

## Testing

- `nix eval --raw .#packages.x86_64-linux.bumba-image.drvPath`
- Failed release jobs 87127857863 and 87127857887 produced the replacement hashes deterministically.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.