### PR TITLE
chore(jangar): promote image sha-e18dc55987f66b9ae9bb2f293b1286c81a514db1

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/part-of: lab
   annotations:
     argocd.argoproj.io/sync-wave: "0"
-    deploy.knative.dev/rollout: 2026-07-14T07:16:33Z
+    deploy.knative.dev/rollout: 2026-07-14T15:45:58Z
 spec:
   replicas: 1
   strategy:
@@ -58,9 +58,9 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 51baa74469e3cf4ab04a823482a17dbc94bc5966
+              value: e18dc55987f66b9ae9bb2f293b1286c81a514db1
             - name: JANGAR_GITOPS_REVISION
-              value: 51baa74469e3cf4ab04a823482a17dbc94bc5966
+              value: e18dc55987f66b9ae9bb2f293b1286c81a514db1
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -358,15 +358,15 @@ spec:
             - name: ATLAS_CODE_SEARCH_STATEMENT_TIMEOUT_MS
               value: "750"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "29313232070"
+              value: "29345459599"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:6eff407ab80fb919febe77e2d25022102ccfc89fe8f23af92aa3d989979de4d3
+              value: sha256:e74fd496c077e294d1c22f0397a6979ca7a6fa9997d7dc7198b727800be9b781
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: 51baa74469e3cf4ab04a823482a17dbc94bc5966
+              value: e18dc55987f66b9ae9bb2f293b1286c81a514db1
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:6eff407ab80fb919febe77e2d25022102ccfc89fe8f23af92aa3d989979de4d3
+              value: sha256:e74fd496c077e294d1c22f0397a6979ca7a6fa9997d7dc7198b727800be9b781
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -37,5 +37,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: sha-51baa74469e3cf4ab04a823482a17dbc94bc5966
-    digest: sha256:6eff407ab80fb919febe77e2d25022102ccfc89fe8f23af92aa3d989979de4d3
+    newTag: sha-e18dc55987f66b9ae9bb2f293b1286c81a514db1
+    digest: sha256:e74fd496c077e294d1c22f0397a6979ca7a6fa9997d7dc7198b727800be9b781


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `e18dc55987f66b9ae9bb2f293b1286c81a514db1`
- Image tag: `sha-e18dc55987f66b9ae9bb2f293b1286c81a514db1`
- Image digest: `sha256:e74fd496c077e294d1c22f0397a6979ca7a6fa9997d7dc7198b727800be9b781`
- Source CI run: `29345459599`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates