### PR TITLE
chore(product): promote nix product images

### DIFF
--- a/argocd/applications/app/kustomization.yaml
+++ b/argocd/applications/app/kustomization.yaml
@@ -8,5 +8,5 @@ resources:
   - secret.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/app
-    digest: sha256:5be62419bcd1414551198b4de234408d0cfd231f46775d6b4b2fcda94683cd0a
+    digest: sha256:e8c53561712e9fb5ee336a9b5b88a2257ca117556c5cc707c23856dda8fcca49
     newName: registry.ide-newton.ts.net/lab/app

--- a/argocd/applications/docs/kustomization.yaml
+++ b/argocd/applications/docs/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
   - generated
 images:
   - name: registry.ide-newton.ts.net/lab/docs
-    digest: sha256:10689e1e095f6b05388f0dd5791c89545cd539a7a9988e29c02f3b2d7d6c240e
+    digest: sha256:00bc193a1675fd3850e20504ff06b4d3b39a445691d55aa498874dcb686cfa2d
     newName: registry.ide-newton.ts.net/lab/docs

--- a/argocd/applications/olden/kustomization.yaml
+++ b/argocd/applications/olden/kustomization.yaml
@@ -5,5 +5,5 @@ resources:
   - service.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/olden
-    digest: sha256:72994d0daa7fc852f0a160b673a121138164f39bb5a4dc1148ef7dc0610cf2d2
+    digest: sha256:17c826dda8f922d3be374e0a81c1321b232925aeb1ce97b8d1a67a769f8c0527
     newName: registry.ide-newton.ts.net/lab/olden

--- a/argocd/applications/proompteng/kustomization.yaml
+++ b/argocd/applications/proompteng/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
 - ingressroute.yaml
 images:
 - name: registry.ide-newton.ts.net/lab/proompteng
-  digest: sha256:3943c22c108b558abb3f69f15498b0d7ddea48e7778ff23f70eeec4d5532f80b
+  digest: sha256:83b774c60f423a5415f57d06aea2bda9f90eb7673b3297ee64a16520497b5f10
   newName: registry.ide-newton.ts.net/lab/proompteng

--- a/argocd/applications/synthesis/kustomization.yaml
+++ b/argocd/applications/synthesis/kustomization.yaml
@@ -11,5 +11,5 @@ resources:
   - agents-domain
 images:
   - name: registry.ide-newton.ts.net/lab/synthesis
-    digest: sha256:bfebc1dc998a19daddeb3063647e9fd5d5cbb143f34c5f76faf87d7d97ec8cba
+    digest: sha256:8f99b91c900a1006937041f1e7d3a6c0b6721c4ee96592e5b268cf3bd08d8572
     newName: registry.ide-newton.ts.net/lab/synthesis


### PR DESCRIPTION
## Summary

- Promote enabled product app image digests built by the shared Nix OCI workflow.
- `app`: `registry.ide-newton.ts.net/lab/app@sha256:e8c53561712e9fb5ee336a9b5b88a2257ca117556c5cc707c23856dda8fcca49` from `e18dc55987f66b9ae9bb2f293b1286c81a514db1`
- `docs`: `registry.ide-newton.ts.net/lab/docs@sha256:00bc193a1675fd3850e20504ff06b4d3b39a445691d55aa498874dcb686cfa2d` from `e18dc55987f66b9ae9bb2f293b1286c81a514db1`
- `olden`: `registry.ide-newton.ts.net/lab/olden@sha256:17c826dda8f922d3be374e0a81c1321b232925aeb1ce97b8d1a67a769f8c0527` from `e18dc55987f66b9ae9bb2f293b1286c81a514db1`
- `proompteng`: `registry.ide-newton.ts.net/lab/proompteng@sha256:83b774c60f423a5415f57d06aea2bda9f90eb7673b3297ee64a16520497b5f10` from `e18dc55987f66b9ae9bb2f293b1286c81a514db1`
- `synthesis`: `registry.ide-newton.ts.net/lab/synthesis@sha256:8f99b91c900a1006937041f1e7d3a6c0b6721c4ee96592e5b268cf3bd08d8572` from `e18dc55987f66b9ae9bb2f293b1286c81a514db1`

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- <image>@<digest> linux/amd64 linux/arm64` for each promoted image.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.