### PR TITLE
fix(torghut): classify quote coverage failures

### DIFF
--- a/argocd/applications/observability/graf-mimir-rules.yaml
+++ b/argocd/applications/observability/graf-mimir-rules.yaml
@@ -1494,6 +1494,18 @@ data:
                   )
                 ) == 0
               )
+              and
+              (
+                sum(
+                  rate(
+                    torghut_trading_strategy_events_total{
+                      job="torghut",
+                      namespace="torghut",
+                      service="torghut-scheduler"
+                    }[5m]
+                  )
+                ) == 0
+              )
               and on()
               (
                 (day_of_week(vector(time())) >= 1)
@@ -1507,8 +1519,51 @@ data:
             annotations:
               summary: Torghut trading decisions stalled (market hours)
               description: |
-                No Torghut trading decisions have been recorded for 15 minutes during market hours (UTC schedule).
-                This stalls quant control-plane snapshots and freshness.
+                No Torghut trading decisions or strategy evaluation events have been recorded for 15 minutes during
+                market hours (UTC schedule). This indicates a stalled decision pipeline rather than a valid fail-closed
+                quote-quality rejection.
+              runbook_url: docs/runbooks/torghut-quant-control-plane.md
+          - alert: TorghutExecutableQuoteCoverageDegradedDuringMarketHours
+            expr: |
+              (
+                sum(
+                  increase(
+                    torghut_trading_rejected_signal_reason_total{
+                      job="torghut",
+                      namespace="torghut",
+                      service="torghut-scheduler",
+                      reason=~"missing_executable_quote|spread_bps_exceeded"
+                    }[10m]
+                  )
+                ) >= 10
+              )
+              and
+              (
+                sum(
+                  rate(
+                    torghut_trading_decisions_total{
+                      job="torghut",
+                      namespace="torghut",
+                      service="torghut-scheduler"
+                    }[10m]
+                  )
+                ) == 0
+              )
+              and on()
+              (
+                (day_of_week(vector(time())) >= 1)
+                * (day_of_week(vector(time())) <= 5)
+                * (hour(vector(time())) >= 14)
+                * (hour(vector(time())) < 21)
+              )
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              summary: Torghut executable quote coverage is degraded
+              description: |
+                At least ten candidate signals failed executable quote validation in ten minutes while no decision was
+                produced. Check quote-source entitlement and venue coverage; do not weaken spread or freshness gates.
               runbook_url: docs/runbooks/torghut-quant-control-plane.md
           - alert: TorghutAutonomyNoSignalStreakDuringMarketHours
             expr: |

--- a/argocd/applications/observability/graf-mimir-rules.yaml
+++ b/argocd/applications/observability/graf-mimir-rules.yaml
@@ -1506,6 +1506,19 @@ data:
                   )
                 ) == 0
               )
+              and
+              (
+                sum(
+                  increase(
+                    torghut_trading_rejected_signal_reason_total{
+                      job="torghut",
+                      namespace="torghut",
+                      service="torghut-scheduler",
+                      reason=~"missing_executable_quote|spread_bps_exceeded"
+                    }[5m]
+                  )
+                ) == 0
+              )
               and on()
               (
                 (day_of_week(vector(time())) >= 1)
@@ -1519,9 +1532,9 @@ data:
             annotations:
               summary: Torghut trading decisions stalled (market hours)
               description: |
-                No Torghut trading decisions or strategy evaluation events have been recorded for 15 minutes during
-                market hours (UTC schedule). This indicates a stalled decision pipeline rather than a valid fail-closed
-                quote-quality rejection.
+                No Torghut trading decisions, strategy evaluation events, or executable quote-quality rejections have
+                been recorded for 15 minutes during market hours (UTC schedule). This indicates a stalled decision
+                pipeline rather than a valid fail-closed quote-quality rejection.
               runbook_url: docs/runbooks/torghut-quant-control-plane.md
           - alert: TorghutExecutableQuoteCoverageDegradedDuringMarketHours
             expr: |

--- a/docs/runbooks/torghut-quant-control-plane.md
+++ b/docs/runbooks/torghut-quant-control-plane.md
@@ -31,8 +31,8 @@ Alert rules are defined in `argocd/applications/observability/graf-mimir-rules.y
 `torghut-quant-control-plane.rules` plus upstream signal chain groups (`torghut-ws.rules`,
 `torghut-clickhouse.guardrails.rules`).
 
-- **TorghutQuantDecisionsStalledDuringMarketHours**: No trading decisions and no strategy evaluation events for 15
-  minutes during market hours.
+- **TorghutQuantDecisionsStalledDuringMarketHours**: No trading decisions, strategy evaluation events, or executable
+  quote-quality rejections for 15 minutes during market hours.
 - **TorghutExecutableQuoteCoverageDegradedDuringMarketHours**: At least ten candidate signals fail executable quote
   validation in ten minutes while no decision is produced.
 - **TorghutAutonomyNoSignalStreakDuringMarketHours**: Autonomy has consecutive no-signal windows in market hours.

--- a/docs/runbooks/torghut-quant-control-plane.md
+++ b/docs/runbooks/torghut-quant-control-plane.md
@@ -31,7 +31,10 @@ Alert rules are defined in `argocd/applications/observability/graf-mimir-rules.y
 `torghut-quant-control-plane.rules` plus upstream signal chain groups (`torghut-ws.rules`,
 `torghut-clickhouse.guardrails.rules`).
 
-- **TorghutQuantDecisionsStalledDuringMarketHours**: No trading decisions for 15 minutes during market hours.
+- **TorghutQuantDecisionsStalledDuringMarketHours**: No trading decisions and no strategy evaluation events for 15
+  minutes during market hours.
+- **TorghutExecutableQuoteCoverageDegradedDuringMarketHours**: At least ten candidate signals fail executable quote
+  validation in ten minutes while no decision is produced.
 - **TorghutAutonomyNoSignalStreakDuringMarketHours**: Autonomy has consecutive no-signal windows in market hours.
 - **TorghutAutonomyCursorAheadOfStreamDuringMarketHours**: Autonomy repeatedly reports cursor_ahead_of_stream in market hours.
 - **TorghutSignalContinuityActionableDuringMarketHours**: Continuity classifier is actionable for sustained windows in market hours.
@@ -204,6 +207,18 @@ Alert rules are defined in `argocd/applications/observability/graf-mimir-rules.y
     ClickHouse config changed.
   - Avoid broad `max()` scans on large tables; use bounded UTC-window queries and exporter gauges first.
   - Keep monitoring on low-memory mode until fallback rate returns to zero.
+- If `TorghutExecutableQuoteCoverageDegradedDuringMarketHours` is active:
+  - Compare `increase(torghut_trading_rejected_signal_reason_total{reason=~"missing_executable_quote|spread_bps_exceeded"}[10m])`
+    with `increase(torghut_trading_strategy_events_total[10m])` and `increase(torghut_trading_decisions_total[10m])`.
+  - Inspect the latest quote source, timestamp, bid, ask, and spread for the rejected symbols. A running strategy loop
+    with fresh TA and sustained quote-quality rejects is market-data coverage degradation, not a scheduler stall.
+  - Alpaca IEX is a single-exchange feed and is not equivalent to consolidated SIP/NBBO coverage. Recent SIP latest
+    quotes require the corresponding account entitlement. Keep `TRADING_ALPACA_QUOTE_FEED=iex` until that entitlement
+    is verified; setting `sip` without entitlement produces provider errors instead of executable quotes. Confirm the
+    account tier against Alpaca's [market-data feed documentation](https://docs.alpaca.markets/us/docs/about-market-data-api)
+    and [market-data FAQ](https://docs.alpaca.markets/us/docs/market-data-faq) before changing the feed.
+  - Do not synthesize bid/ask values, use delayed SIP as a live quote, widen the executable spread bound, or expand quote
+    age to make the alert clear. Restore an entitled real-time consolidated quote source and prove fresh, bounded spreads.
 - If reject rate is high with `alpaca_order_rejected code=40310000`:
   - Compare open sell order qty vs current position qty (`qty_available` / held inventory).
   - Cancel stale duplicate sell orders; verify new rejects shift to local precheck (`precheck_sell_qty_exceeds_available`) instead of broker reject.

--- a/packages/scripts/src/torghut/__tests__/quant-control-plane-observability.test.ts
+++ b/packages/scripts/src/torghut/__tests__/quant-control-plane-observability.test.ts
@@ -16,6 +16,8 @@ describe('Torghut quant control-plane alerts', () => {
     expect(rules).toContain('alert: TorghutQuantDecisionsStalledDuringMarketHours')
     expect(stalledAlert).toContain('torghut_trading_decisions_total')
     expect(stalledAlert).toContain('torghut_trading_strategy_events_total')
+    expect(stalledAlert).toContain('torghut_trading_rejected_signal_reason_total')
+    expect(stalledAlert).toContain('reason=~"missing_executable_quote|spread_bps_exceeded"')
   })
 
   it('alerts on sustained executable quote coverage failures without weakening safety gates', () => {

--- a/packages/scripts/src/torghut/__tests__/quant-control-plane-observability.test.ts
+++ b/packages/scripts/src/torghut/__tests__/quant-control-plane-observability.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { repoRoot } from '../../shared/cli'
+
+const rules = readFileSync(join(repoRoot, 'argocd/applications/observability/graf-mimir-rules.yaml'), 'utf8')
+const runbook = readFileSync(join(repoRoot, 'docs/runbooks/torghut-quant-control-plane.md'), 'utf8')
+
+describe('Torghut quant control-plane alerts', () => {
+  it('distinguishes a stalled strategy loop from fail-closed quote rejection', () => {
+    const stalledAlert = rules
+      .split('- alert: TorghutQuantDecisionsStalledDuringMarketHours')[1]
+      .split('- alert: TorghutExecutableQuoteCoverageDegradedDuringMarketHours')[0]
+
+    expect(rules).toContain('alert: TorghutQuantDecisionsStalledDuringMarketHours')
+    expect(stalledAlert).toContain('torghut_trading_decisions_total')
+    expect(stalledAlert).toContain('torghut_trading_strategy_events_total')
+  })
+
+  it('alerts on sustained executable quote coverage failures without weakening safety gates', () => {
+    expect(rules).toContain('alert: TorghutExecutableQuoteCoverageDegradedDuringMarketHours')
+    expect(rules).toContain('reason=~"missing_executable_quote|spread_bps_exceeded"')
+    expect(rules).toContain(
+      'Check quote-source entitlement and venue coverage; do not weaken spread or freshness gates.',
+    )
+    expect(runbook).toContain('Alpaca IEX is a single-exchange feed')
+    expect(runbook).toContain('Do not synthesize bid/ask values')
+  })
+})


### PR DESCRIPTION
## Summary

- Require both zero decisions and zero strategy events before classifying the Torghut decision pipeline as stalled.
- Add a distinct warning for sustained executable-quote coverage failures while the strategy loop remains active.
- Document the IEX versus SIP entitlement boundary and preserve fail-closed spread and freshness safeguards.

## Related Issues

None.

## Testing

- `bun test packages/scripts/src/torghut/__tests__/quant-control-plane-observability.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/__tests__/quant-control-plane-observability.test.ts`
- `bun run lint:argocd`
- `kustomize build --enable-helm argocd/applications/observability | yq 'select(.kind == "ConfigMap" and .metadata.name == "graf-mimir-rules")' | kubectl apply --server-side --dry-run=server --field-manager=argocd-controller -n observability -f -`
- Evaluated both changed PromQL expressions through the live Mimir query API; the stalled-pipeline expression was inactive and the quote-coverage expression matched the current coverage failure without parser errors.

## Screenshots (if applicable)

N/A.

## Breaking Changes

None. Enabling real-time SIP quotes remains an external account-entitlement action and is not performed by this PR.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
