### PR TITLE
chore(bumba): promote nix image sha-762c6c7a4a1a03f6c31dda3a41531f1bb523d0c9

### DIFF
--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -73,7 +73,7 @@ spec:
             - name: TEMPORAL_TASK_QUEUE
               value: bumba
             - name: TEMPORAL_WORKER_BUILD_ID
-              value: bumba@e136cc653fce5dd649322658cd5b6885d5ac0bdc
+              value: bumba@762c6c7a4a1a03f6c31dda3a41531f1bb523d0c9
             - name: TEMPORAL_WORKFLOW_CONCURRENCY
               value: "12"
             - name: TEMPORAL_ACTIVITY_CONCURRENCY

--- a/argocd/applications/bumba/kustomization.yaml
+++ b/argocd/applications/bumba/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
   - deployment.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/bumba
-    digest: sha256:058f0d1c1d294904ebb3fe4ecffb1503a0cf94cc50f2d9b58c02aac2a89fce25
+    digest: sha256:7068d0a5ce1a3c743cffc518267c2f7ad1f7f21f99a9c3f8c33481c5b51127bd
     newName: registry.ide-newton.ts.net/lab/bumba


### PR DESCRIPTION
## Summary

- Promote `bumba` to `registry.ide-newton.ts.net/lab/bumba@sha256:7068d0a5ce1a3c743cffc518267c2f7ad1f7f21f99a9c3f8c33481c5b51127bd`.
- Source commit: `762c6c7a4a1a03f6c31dda3a41531f1bb523d0c9`.
- Built by the shared Nix OCI workflow without Docker Buildx.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/bumba@sha256:7068d0a5ce1a3c743cffc518267c2f7ad1f7f21f99a9c3f8c33481c5b51127bd" linux/amd64 linux/arm64`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.