### PR TITLE
fix(torghut): tighten archive write budget

### DIFF
--- a/argocd/applications/torghut-options/archive/configmap.yaml
+++ b/argocd/applications/torghut-options/archive/configmap.yaml
@@ -10,10 +10,10 @@ data:
   OPTIONS_CONTRACT_ARCHIVE_REFRESH_SEC: "86400"
   # Keep each catalog status transaction inside the current Ceph-backed
   # PostgreSQL write budget. A 1,000-row batch exceeded the existing 30s
-  # statement timeout even though the indexed candidate lookup completed in
-  # milliseconds; use 10x smaller writes with a 1s recovery interval.
-  OPTIONS_CONTRACT_ARCHIVE_FINALIZE_BATCH_SIZE: "100"
-  OPTIONS_CONTRACT_ARCHIVE_FINALIZE_INTERVAL_MS: "1000"
+  # statement timeout; 100-row batches completed but still produced sustained
+  # wal_buffers_full pressure. Use 10-row writes with a 2s recovery interval.
+  OPTIONS_CONTRACT_ARCHIVE_FINALIZE_BATCH_SIZE: "10"
+  OPTIONS_CONTRACT_ARCHIVE_FINALIZE_INTERVAL_MS: "2000"
   OPTIONS_CONTRACT_ARCHIVE_STATEMENT_TIMEOUT_MS: "30000"
   OPTIONS_CONTRACT_ARCHIVE_LOCK_TIMEOUT_MS: "5000"
   OPTIONS_CONTRACT_ARCHIVE_RETRY_BASE_SEC: "30"

--- a/argocd/applications/torghut-options/archive/deployment.yaml
+++ b/argocd/applications/torghut-options/archive/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Bump with archive ConfigMap changes so GitOps starts a pod with the
         # new write budget instead of leaving the existing env snapshot alive.
-        proompteng.ai/config-revision: archive-finalize-write-budget-20260713a
+        proompteng.ai/config-revision: archive-finalize-write-budget-20260714b
     spec:
       terminationGracePeriodSeconds: 45
       nodeSelector:

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -539,13 +539,13 @@ describe('Torghut manifest scheduling', () => {
   it('bounds options archive finalization writes and rolls ConfigMap changes', () => {
     const config = parseManifest('argocd/applications/torghut-options/archive/configmap.yaml')
     const data = getAtPath(config, ['data'])
-    expect(data.OPTIONS_CONTRACT_ARCHIVE_FINALIZE_BATCH_SIZE).toBe('100')
-    expect(data.OPTIONS_CONTRACT_ARCHIVE_FINALIZE_INTERVAL_MS).toBe('1000')
+    expect(data.OPTIONS_CONTRACT_ARCHIVE_FINALIZE_BATCH_SIZE).toBe('10')
+    expect(data.OPTIONS_CONTRACT_ARCHIVE_FINALIZE_INTERVAL_MS).toBe('2000')
     expect(data.OPTIONS_CONTRACT_ARCHIVE_STATEMENT_TIMEOUT_MS).toBe('30000')
 
     const deployment = parseManifest('argocd/applications/torghut-options/archive/deployment.yaml')
     expect(getAtPath(deployment, ['spec', 'template', 'metadata', 'annotations'])).toMatchObject({
-      'proompteng.ai/config-revision': 'archive-finalize-write-budget-20260713a',
+      'proompteng.ai/config-revision': 'archive-finalize-write-budget-20260714b',
     })
   })
 


### PR DESCRIPTION
## Summary

- Reduce options archive finalization transactions from 100 to 10 catalog rows after live 100-row execution produced 2,004 new `wal_buffers_full` events.
- Increase the recovery interval between transactions from 1,000 ms to 2,000 ms without changing the 30-second statement timeout.
- Bump the archive pod-template config revision so Argo rolls the singleton with the tighter budget.
- Update the manifest regression contract for the live-proven values.

## Related Issues

Follow-up to #12470.

## Testing

- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `kustomize build --enable-helm argocd/applications/torghut-options`
- `kubectl apply --server-side --dry-run=server --field-manager=argocd-controller -n torghut -f argocd/applications/torghut-options/archive/configmap.yaml -f argocd/applications/torghut-options/archive/deployment.yaml`
- `bun run lint:argocd`
- `git diff --check`

## Breaking Changes

None. Archive throughput is intentionally reduced to protect the Ceph-backed PostgreSQL WAL path; transaction timeout and correctness semantics are unchanged.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
