### PR TITLE
chore(torghut): promote image sha-47a3f7c9260daa924c57a4aafb8006fb80001c3a

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -54,7 +54,7 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: 819410485ebbd9d95477694bbf46e342a2b0d726
+              value: 47a3f7c9260daa924c57a4aafb8006fb80001c3a
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:a9c27b0742359da87ccd55f4d271c5b1640c14f1a17c5687cad1e04a20fcac5e
             - name: PYTHONPATH

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -46,7 +46,7 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: 819410485ebbd9d95477694bbf46e342a2b0d726
+              value: 47a3f7c9260daa924c57a4aafb8006fb80001c3a
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:a9c27b0742359da87ccd55f4d271c5b1640c14f1a17c5687cad1e04a20fcac5e
             - name: DB_DSN

--- a/argocd/applications/torghut-options/archive/deployment.yaml
+++ b/argocd/applications/torghut-options/archive/deployment.yaml
@@ -125,9 +125,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1905-g819410485
+              value: v0.596.0-1910-g47a3f7c92
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 819410485ebbd9d95477694bbf46e342a2b0d726
+              value: 47a3f7c9260daa924c57a4aafb8006fb80001c3a
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -81,9 +81,9 @@ spec:
                   name: torghut-ws-config
                   key: SYMBOLS_ALLOWLIST
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1905-g819410485
+              value: v0.596.0-1910-g47a3f7c92
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 819410485ebbd9d95477694bbf46e342a2b0d726
+              value: 47a3f7c9260daa924c57a4aafb8006fb80001c3a
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -77,9 +77,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1905-g819410485
+              value: v0.596.0-1910-g47a3f7c92
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 819410485ebbd9d95477694bbf46e342a2b0d726
+              value: 47a3f7c9260daa924c57a4aafb8006fb80001c3a
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-14T16:07:32Z"
+        client.knative.dev/updateTimestamp: "2026-07-14T16:50:42Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -523,9 +523,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1905-g819410485
+              value: v0.596.0-1910-g47a3f7c92
             - name: TORGHUT_COMMIT
-              value: 819410485ebbd9d95477694bbf46e342a2b0d726
+              value: 47a3f7c9260daa924c57a4aafb8006fb80001c3a
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:a9c27b0742359da87ccd55f4d271c5b1640c14f1a17c5687cad1e04a20fcac5e
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-14T16:07:32Z"
+        client.knative.dev/updateTimestamp: "2026-07-14T16:50:42Z"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
     spec:
@@ -448,9 +448,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1905-g819410485
+              value: v0.596.0-1910-g47a3f7c92
             - name: TORGHUT_COMMIT
-              value: 819410485ebbd9d95477694bbf46e342a2b0d726
+              value: 47a3f7c9260daa924c57a4aafb8006fb80001c3a
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:a9c27b0742359da87ccd55f4d271c5b1640c14f1a17c5687cad1e04a20fcac5e
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -464,9 +464,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1905-g819410485
+              value: v0.596.0-1910-g47a3f7c92
             - name: TORGHUT_COMMIT
-              value: 819410485ebbd9d95477694bbf46e342a2b0d726
+              value: 47a3f7c9260daa924c57a4aafb8006fb80001c3a
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:a9c27b0742359da87ccd55f4d271c5b1640c14f1a17c5687cad1e04a20fcac5e
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `47a3f7c9260daa924c57a4aafb8006fb80001c3a`
- Image tag: `sha-47a3f7c9260daa924c57a4aafb8006fb80001c3a`
- Image digest: `sha256:a9c27b0742359da87ccd55f4d271c5b1640c14f1a17c5687cad1e04a20fcac5e`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher