### PR TITLE
chore(torghut): promote ta image sha-47a3f7c9260daa924c57a4aafb8006fb80001c3a

### DIFF
--- a/argocd/applications/torghut-options/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut-options/ta/flinkdeployment.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     app: torghut-options-ta
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:42795996988cbe90c5c9c06a8b97a4710ac0fa9df3799cadff0839fac640bc12
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:f0acc631d1f49273af38b3e15a726391ff29314fcd80f6815f7d7e014d9c778e
   imagePullPolicy: IfNotPresent
-  restartNonce: 30
+  restartNonce: 31
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   flinkConfiguration:
@@ -88,9 +88,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: sha-ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00
+              value: sha-47a3f7c9260daa924c57a4aafb8006fb80001c3a
             - name: TORGHUT_TA_COMMIT
-              value: ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00
+              value: 47a3f7c9260daa924c57a4aafb8006fb80001c3a
           ports:
             - containerPort: 9249
               name: metrics

--- a/argocd/applications/torghut/ta-sim/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta-sim/flinkdeployment.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     app: torghut-ta-sim
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:42795996988cbe90c5c9c06a8b97a4710ac0fa9df3799cadff0839fac640bc12
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:f0acc631d1f49273af38b3e15a726391ff29314fcd80f6815f7d7e014d9c778e
   imagePullPolicy: IfNotPresent
-  restartNonce: 32
+  restartNonce: 33
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   logConfiguration:
@@ -157,9 +157,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: sha-ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00
+              value: sha-47a3f7c9260daa924c57a4aafb8006fb80001c3a
             - name: TORGHUT_TA_COMMIT
-              value: ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00
+              value: 47a3f7c9260daa924c57a4aafb8006fb80001c3a
           ports:
             - containerPort: 9249
               name: metrics

--- a/argocd/applications/torghut/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta/flinkdeployment.yaml
@@ -8,9 +8,9 @@ metadata:
   labels:
     app: torghut-ta
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:42795996988cbe90c5c9c06a8b97a4710ac0fa9df3799cadff0839fac640bc12
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:f0acc631d1f49273af38b3e15a726391ff29314fcd80f6815f7d7e014d9c778e
   imagePullPolicy: IfNotPresent
-  restartNonce: 29
+  restartNonce: 30
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   logConfiguration:
@@ -159,9 +159,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: sha-ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00
+              value: sha-47a3f7c9260daa924c57a4aafb8006fb80001c3a
             - name: TORGHUT_TA_COMMIT
-              value: ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00
+              value: 47a3f7c9260daa924c57a4aafb8006fb80001c3a
           ports:
             - containerPort: 9249
               name: metrics


### PR DESCRIPTION
## Summary
Promote the Torghut TA image into GitOps manifests.

- Source commit: `47a3f7c9260daa924c57a4aafb8006fb80001c3a`
- Image tag: `sha-47a3f7c9260daa924c57a4aafb8006fb80001c3a`
- Image digest: `sha256:f0acc631d1f49273af38b3e15a726391ff29314fcd80f6815f7d7e014d9c778e`
- Manifests: live TA, sim TA, options TA