### PR TITLE
chore(torghut): promote image sha-272f07d74aa1f4f75ff425b4ae6ce9a8d5622a30

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -54,7 +54,7 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: 47a3f7c9260daa924c57a4aafb8006fb80001c3a
+              value: 272f07d74aa1f4f75ff425b4ae6ce9a8d5622a30
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:a9c27b0742359da87ccd55f4d271c5b1640c14f1a17c5687cad1e04a20fcac5e
             - name: PYTHONPATH

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -46,7 +46,7 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: 47a3f7c9260daa924c57a4aafb8006fb80001c3a
+              value: 272f07d74aa1f4f75ff425b4ae6ce9a8d5622a30
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:a9c27b0742359da87ccd55f4d271c5b1640c14f1a17c5687cad1e04a20fcac5e
             - name: DB_DSN

--- a/argocd/applications/torghut-options/archive/deployment.yaml
+++ b/argocd/applications/torghut-options/archive/deployment.yaml
@@ -125,9 +125,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1910-g47a3f7c92
+              value: v0.596.0-1915-g272f07d74
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 47a3f7c9260daa924c57a4aafb8006fb80001c3a
+              value: 272f07d74aa1f4f75ff425b4ae6ce9a8d5622a30
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -81,9 +81,9 @@ spec:
                   name: torghut-ws-config
                   key: SYMBOLS_ALLOWLIST
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1910-g47a3f7c92
+              value: v0.596.0-1915-g272f07d74
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 47a3f7c9260daa924c57a4aafb8006fb80001c3a
+              value: 272f07d74aa1f4f75ff425b4ae6ce9a8d5622a30
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -77,9 +77,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1910-g47a3f7c92
+              value: v0.596.0-1915-g272f07d74
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 47a3f7c9260daa924c57a4aafb8006fb80001c3a
+              value: 272f07d74aa1f4f75ff425b4ae6ce9a8d5622a30
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-14T16:50:42Z"
+        client.knative.dev/updateTimestamp: "2026-07-14T17:08:23Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -523,9 +523,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1910-g47a3f7c92
+              value: v0.596.0-1915-g272f07d74
             - name: TORGHUT_COMMIT
-              value: 47a3f7c9260daa924c57a4aafb8006fb80001c3a
+              value: 272f07d74aa1f4f75ff425b4ae6ce9a8d5622a30
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:a9c27b0742359da87ccd55f4d271c5b1640c14f1a17c5687cad1e04a20fcac5e
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-14T16:50:42Z"
+        client.knative.dev/updateTimestamp: "2026-07-14T17:08:23Z"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
     spec:
@@ -448,9 +448,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1910-g47a3f7c92
+              value: v0.596.0-1915-g272f07d74
             - name: TORGHUT_COMMIT
-              value: 47a3f7c9260daa924c57a4aafb8006fb80001c3a
+              value: 272f07d74aa1f4f75ff425b4ae6ce9a8d5622a30
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:a9c27b0742359da87ccd55f4d271c5b1640c14f1a17c5687cad1e04a20fcac5e
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -464,9 +464,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1910-g47a3f7c92
+              value: v0.596.0-1915-g272f07d74
             - name: TORGHUT_COMMIT
-              value: 47a3f7c9260daa924c57a4aafb8006fb80001c3a
+              value: 272f07d74aa1f4f75ff425b4ae6ce9a8d5622a30
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:a9c27b0742359da87ccd55f4d271c5b1640c14f1a17c5687cad1e04a20fcac5e
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `272f07d74aa1f4f75ff425b4ae6ce9a8d5622a30`
- Image tag: `sha-272f07d74aa1f4f75ff425b4ae6ce9a8d5622a30`
- Image digest: `sha256:a9c27b0742359da87ccd55f4d271c5b1640c14f1a17c5687cad1e04a20fcac5e`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher