### PR TITLE
fix(bumba): refresh Atlas dependency hashes

### DIFF
--- a/nix/images/bumba.nix
+++ b/nix/images/bumba.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "bumba";
   packageName = "@proompteng/bumba";
   depsHash = {
-    x86_64-linux = "sha256-/y9Fddzh7o4/Oa2wQniHYgqkE0Rs+sM1u8Edm0Lc80o=";
-    aarch64-linux = "sha256-CmO+ZzanZxA+J6u+8RI99lO5tTmKC1801U3672c5AwE=";
+    x86_64-linux = "sha256-1/wV3iFBqYwcQ0PeRvjIQ18nzTXUr0qSSNtBoAOp4B0=";
+    aarch64-linux = "sha256-yTCJnzAHvsV9P++1xQbem0AOeTlAyeDT3Oke+hBl+O8=";
   };
   installFilters = [
     "@proompteng/bumba"


### PR DESCRIPTION
## Summary

- Refresh the Bumba Bun dependency NAR hash for AMD64 from the exact failed production image derivation.
- Refresh the matching ARM64 dependency hash reported by the same main build.
- Unblock production promotion of the merged Atlas reconciliation worker without changing runtime behavior.

## Related Issues

None

## Testing

- GitHub Actions run 29362546628 reported got sha256-1/wV3iFBqYwcQ0PeRvjIQ18nzTXUr0qSSNtBoAOp4B0= for x86_64-linux.
- GitHub Actions run 29362546628 reported got sha256-yTCJnzAHvsV9P++1xQbem0AOeTlAyeDT3Oke+hBl+O8= for aarch64-linux.
- /nix/var/nix/profiles/default/bin/nix eval --raw .#packages.x86_64-linux.bumba-image.drvPath
- /nix/var/nix/profiles/default/bin/nix eval --raw .#packages.aarch64-linux.bumba-image.drvPath
- /nix/var/nix/profiles/default/bin/nix derivation show on both bumba-bun-deps derivations confirms the declared output hashes.
- git diff --check

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or N/A with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.