### PR TITLE
chore(bumba): promote nix image sha-75a13c6aa8fe2b03ec0d43475d3adbfa48f931d3

### DIFF
--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -73,7 +73,7 @@ spec:
             - name: TEMPORAL_TASK_QUEUE
               value: bumba
             - name: TEMPORAL_WORKER_BUILD_ID
-              value: bumba@762c6c7a4a1a03f6c31dda3a41531f1bb523d0c9
+              value: bumba@75a13c6aa8fe2b03ec0d43475d3adbfa48f931d3
             - name: TEMPORAL_WORKFLOW_CONCURRENCY
               value: "12"
             - name: TEMPORAL_ACTIVITY_CONCURRENCY

--- a/argocd/applications/bumba/kustomization.yaml
+++ b/argocd/applications/bumba/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
   - deployment.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/bumba
-    digest: sha256:7068d0a5ce1a3c743cffc518267c2f7ad1f7f21f99a9c3f8c33481c5b51127bd
+    digest: sha256:eea1a616054940f29e9573da7602df287f9600368e8102161101e85080d55284
     newName: registry.ide-newton.ts.net/lab/bumba


### PR DESCRIPTION
## Summary

- Promote `bumba` to `registry.ide-newton.ts.net/lab/bumba@sha256:eea1a616054940f29e9573da7602df287f9600368e8102161101e85080d55284`.
- Source commit: `75a13c6aa8fe2b03ec0d43475d3adbfa48f931d3`.
- Built by the shared Nix OCI workflow without Docker Buildx.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/bumba@sha256:eea1a616054940f29e9573da7602df287f9600368e8102161101e85080d55284" linux/amd64 linux/arm64`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.