### PR TITLE
fix(bumba): release tree-sitter resources

### DIFF
--- a/services/bumba/src/activities/index.test.ts
+++ b/services/bumba/src/activities/index.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'bun:test'
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { Language } from 'web-tree-sitter'
+import { Language, type Tree } from 'web-tree-sitter'
 
 import productionActivities, { __test__, activities, parseCompletionOutput } from './index'
 
@@ -132,6 +132,75 @@ describe('Atlas chunk coverage', () => {
     expect(chunks.some((chunk) => chunk.content.includes('createAtlasCodeSearchHandlers'))).toBe(true)
     expect(chunks.every((chunk) => chunk.metadata.chunkerVersion === __test__.ATLAS_CHUNKER_VERSION)).toBe(true)
     expect(() => __test__.assertChunkCoverage(source, chunks)).not.toThrow()
+  })
+})
+
+describe('tree-sitter resource lifecycle', () => {
+  const language = {} as Language
+
+  it('deletes the syntax tree and parser after reading a tree', () => {
+    let treeDeletes = 0
+    let parserDeletes = 0
+    const tree = { delete: () => (treeDeletes += 1) } as unknown as Tree
+    const parser = {
+      setLanguage: () => parser,
+      parse: () => tree,
+      delete: () => (parserDeletes += 1),
+    }
+
+    expect(
+      __test__.withParsedTree(
+        language,
+        'const value = 1',
+        () => 'read',
+        () => parser,
+      ),
+    ).toBe('read')
+    expect(treeDeletes).toBe(1)
+    expect(parserDeletes).toBe(1)
+  })
+
+  it('deletes the syntax tree and parser when reading throws', () => {
+    let treeDeletes = 0
+    let parserDeletes = 0
+    const tree = { delete: () => (treeDeletes += 1) } as unknown as Tree
+    const parser = {
+      setLanguage: () => parser,
+      parse: () => tree,
+      delete: () => (parserDeletes += 1),
+    }
+
+    expect(() =>
+      __test__.withParsedTree(
+        language,
+        'const value = 1',
+        () => {
+          throw new Error('read failed')
+        },
+        () => parser,
+      ),
+    ).toThrow('read failed')
+    expect(treeDeletes).toBe(1)
+    expect(parserDeletes).toBe(1)
+  })
+
+  it('deletes the parser when parsing returns no tree', () => {
+    let parserDeletes = 0
+    const parser = {
+      setLanguage: () => parser,
+      parse: () => null,
+      delete: () => (parserDeletes += 1),
+    }
+
+    expect(
+      __test__.withParsedTree(
+        language,
+        'const value = 1',
+        () => 'unreachable',
+        () => parser,
+      ),
+    ).toBeNull()
+    expect(parserDeletes).toBe(1)
   })
 })
 

--- a/services/bumba/src/activities/index.ts
+++ b/services/bumba/src/activities/index.ts
@@ -5,7 +5,7 @@ import { basename, extname, relative, resolve, sep } from 'node:path'
 import { SQL } from 'bun'
 import { Effect } from 'effect'
 import * as TSemaphore from 'effect/TSemaphore'
-import { Language, Parser } from 'web-tree-sitter'
+import { Language, Parser, type Tree } from 'web-tree-sitter'
 import { isMap, isScalar, isSeq, LineCounter, parseAllDocuments } from 'yaml'
 
 import { currentActivityContext } from '@proompteng/temporal-bun-sdk/worker'
@@ -952,6 +952,34 @@ type LoadedLanguage = {
   language: Language
 }
 
+type TreeSitterParserResource = {
+  setLanguage: (language: Language) => unknown
+  parse: (source: string) => Tree | null
+  delete: () => void
+}
+
+const withParsedTree = <T>(
+  language: Language,
+  source: string,
+  read: (tree: Tree) => T,
+  createParser: () => TreeSitterParserResource = () => new Parser(),
+): T | null => {
+  const parser = createParser()
+  let tree: Tree | null = null
+
+  try {
+    parser.setLanguage(language)
+    tree = parser.parse(source)
+    return tree ? read(tree) : null
+  } finally {
+    try {
+      tree?.delete()
+    } finally {
+      parser.delete()
+    }
+  }
+}
+
 const require = createRequire(import.meta.url)
 const runtimeWasmPath = require.resolve('web-tree-sitter/web-tree-sitter.wasm')
 
@@ -1776,42 +1804,42 @@ const parseAst = async (source: string, filePath: string): Promise<AstSummaryOut
   }
 
   try {
-    const parser = new Parser()
-    parser.setLanguage(entry.language)
-    const tree = parser.parse(source)
-    if (!tree) {
+    const result = withParsedTree(entry.language, source, (tree) => {
+      const root = tree.rootNode as AstNode
+      const facts = collectFacts(root, source, maxFacts, maxFactChars)
+      const astSummary = buildAstSummary(root, source, maxSummaryNodes, maxFactChars)
+      if (facts.length === 0) {
+        const fallback = parsePlainTextAst(source, maxFacts, maxFactChars, maxSummaryNodes, fallbackLanguage, 'text')
+        return {
+          astSummary,
+          facts: fallback.facts,
+          metadata: {
+            language: entry.name,
+            factCount: fallback.facts.length,
+            factsFallback: 'text',
+            factsFallbackLanguage: fallbackLanguage,
+          },
+        }
+      }
+
+      return {
+        astSummary,
+        facts,
+        metadata: {
+          language: entry.name,
+          factCount: facts.length,
+        },
+      }
+    })
+
+    if (!result) {
       return {
         astSummary: 'Tree-sitter parse failed.',
         facts: [],
         metadata: { skipped: true, reason: 'parse_failed', language: entry.name },
       }
     }
-    const root = tree.rootNode as AstNode
-
-    const facts = collectFacts(root, source, maxFacts, maxFactChars)
-    const astSummary = buildAstSummary(root, source, maxSummaryNodes, maxFactChars)
-    if (facts.length === 0) {
-      const fallback = parsePlainTextAst(source, maxFacts, maxFactChars, maxSummaryNodes, fallbackLanguage, 'text')
-      return {
-        astSummary,
-        facts: fallback.facts,
-        metadata: {
-          language: entry.name,
-          factCount: fallback.facts.length,
-          factsFallback: 'text',
-          factsFallbackLanguage: fallbackLanguage,
-        },
-      }
-    }
-
-    return {
-      astSummary,
-      facts,
-      metadata: {
-        language: entry.name,
-        factCount: facts.length,
-      },
-    }
+    return result
   } catch (error) {
     const fallback = parsePlainTextAst(source, maxFacts, maxFactChars, maxSummaryNodes, fallbackLanguage, 'text')
     return {
@@ -2088,17 +2116,13 @@ const extractFileChunks = async (source: string, filePath: string): Promise<Extr
   }
 
   try {
-    const parser = new Parser()
-    parser.setLanguage(entry.language)
-    const tree = parser.parse(source)
-    const root = tree?.rootNode as AstNode | undefined
-    if (!root) {
-      return finalizeFileChunks(source, extractFixedLineChunks(source, config), config)
-    }
-    const chunks = extractTreeSitterChunks(root, source, config)
-    const completeChunks =
-      chunks.length > 0 ? addUncoveredLineChunks(source, chunks, config) : extractFixedLineChunks(source, config)
-    return finalizeFileChunks(source, completeChunks, config)
+    const chunks = withParsedTree(entry.language, source, (tree) => {
+      const extracted = extractTreeSitterChunks(tree.rootNode as AstNode, source, config)
+      return extracted.length > 0
+        ? addUncoveredLineChunks(source, extracted, config)
+        : extractFixedLineChunks(source, config)
+    })
+    return finalizeFileChunks(source, chunks ?? extractFixedLineChunks(source, config), config)
   } catch {
     return finalizeFileChunks(source, extractFixedLineChunks(source, config), config)
   }
@@ -5192,6 +5216,7 @@ export const __test__ = {
   assertChunkCoverage,
   extractFileChunks,
   shouldUseNullCommitConflictTarget,
+  withParsedTree,
   resetAtlasDb: async () => {
     if (atlasDb) await atlasDb.close()
     atlasDb = undefined


### PR DESCRIPTION
## Summary

- close every web-tree-sitter syntax tree and parser after Atlas AST extraction and chunking
- preserve fixed-line and plain-text fallback behavior while guaranteeing cleanup on success, null parses, and exceptions
- add focused lifecycle regressions for tree and parser disposal

## Related Issues

None

## Testing

- `bun run --filter @proompteng/bumba test` (75 passed, 2 database-gated tests skipped)
- `bun run --filter @proompteng/bumba tsc`
- `bunx oxfmt --check services/bumba/src/activities/index.ts services/bumba/src/activities/index.test.ts`
- `bunx oxlint services/bumba/src/activities/index.ts services/bumba/src/activities/index.test.ts`
- `bun run --filter @proompteng/bumba lint:oxlint:type` (0 errors; 17 pre-existing warnings)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] No documentation or release-note update is required for this resource-lifecycle fix.