### PR TITLE
chore(bumba): promote nix image sha-5f0de9927949cba274c5b434bced5a5b4735a4c4

### DIFF
--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -73,7 +73,7 @@ spec:
             - name: TEMPORAL_TASK_QUEUE
               value: bumba
             - name: TEMPORAL_WORKER_BUILD_ID
-              value: bumba@75a13c6aa8fe2b03ec0d43475d3adbfa48f931d3
+              value: bumba@5f0de9927949cba274c5b434bced5a5b4735a4c4
             - name: TEMPORAL_WORKFLOW_CONCURRENCY
               value: "12"
             - name: TEMPORAL_ACTIVITY_CONCURRENCY

--- a/argocd/applications/bumba/kustomization.yaml
+++ b/argocd/applications/bumba/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
   - deployment.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/bumba
-    digest: sha256:eea1a616054940f29e9573da7602df287f9600368e8102161101e85080d55284
+    digest: sha256:cb99f190a49ee3752bf0219457f0df02325ee0879c6f542de61da0679243f4cc
     newName: registry.ide-newton.ts.net/lab/bumba


### PR DESCRIPTION
## Summary

- Promote `bumba` to `registry.ide-newton.ts.net/lab/bumba@sha256:cb99f190a49ee3752bf0219457f0df02325ee0879c6f542de61da0679243f4cc`.
- Source commit: `5f0de9927949cba274c5b434bced5a5b4735a4c4`.
- Built by the shared Nix OCI workflow without Docker Buildx.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/bumba@sha256:cb99f190a49ee3752bf0219457f0df02325ee0879c6f542de61da0679243f4cc" linux/amd64 linux/arm64`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.