### PR TITLE
chore(jangar): promote image sha-5f0de9927949cba274c5b434bced5a5b4735a4c4

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/part-of: lab
   annotations:
     argocd.argoproj.io/sync-wave: "0"
-    deploy.knative.dev/rollout: 2026-07-14T19:52:16Z
+    deploy.knative.dev/rollout: 2026-07-14T21:59:11Z
 spec:
   replicas: 1
   strategy:
@@ -58,9 +58,9 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 895bc644f22517952fda0c19c80185257535ffd6
+              value: 5f0de9927949cba274c5b434bced5a5b4735a4c4
             - name: JANGAR_GITOPS_REVISION
-              value: 895bc644f22517952fda0c19c80185257535ffd6
+              value: 5f0de9927949cba274c5b434bced5a5b4735a4c4
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -358,15 +358,15 @@ spec:
             - name: ATLAS_CODE_SEARCH_STATEMENT_TIMEOUT_MS
               value: "750"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "29362546470"
+              value: "29370646011"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:5059aebadec608350c60f16c102e0a2f1c9c927232b458dc464932cceb74734a
+              value: sha256:c900ba77e0b4a0b39fdebf18ccae30dd2d9b6f63b3aa8ccc63bc62427683df90
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: 895bc644f22517952fda0c19c80185257535ffd6
+              value: 5f0de9927949cba274c5b434bced5a5b4735a4c4
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:5059aebadec608350c60f16c102e0a2f1c9c927232b458dc464932cceb74734a
+              value: sha256:c900ba77e0b4a0b39fdebf18ccae30dd2d9b6f63b3aa8ccc63bc62427683df90
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -37,5 +37,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: sha-895bc644f22517952fda0c19c80185257535ffd6
-    digest: sha256:5059aebadec608350c60f16c102e0a2f1c9c927232b458dc464932cceb74734a
+    newTag: sha-5f0de9927949cba274c5b434bced5a5b4735a4c4
+    digest: sha256:c900ba77e0b4a0b39fdebf18ccae30dd2d9b6f63b3aa8ccc63bc62427683df90


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `5f0de9927949cba274c5b434bced5a5b4735a4c4`
- Image tag: `sha-5f0de9927949cba274c5b434bced5a5b4735a4c4`
- Image digest: `sha256:c900ba77e0b4a0b39fdebf18ccae30dd2d9b6f63b3aa8ccc63bc62427683df90`
- Source CI run: `29370646011`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates