### PR TITLE
chore(bumba): promote nix image sha-8de0fb5c87a4130247d70a0941eea29b91c0eb9f

### DIFF
--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -73,7 +73,7 @@ spec:
             - name: TEMPORAL_TASK_QUEUE
               value: bumba
             - name: TEMPORAL_WORKER_BUILD_ID
-              value: bumba@5f0de9927949cba274c5b434bced5a5b4735a4c4
+              value: bumba@8de0fb5c87a4130247d70a0941eea29b91c0eb9f
             - name: TEMPORAL_WORKFLOW_CONCURRENCY
               value: "12"
             - name: TEMPORAL_ACTIVITY_CONCURRENCY

--- a/argocd/applications/bumba/kustomization.yaml
+++ b/argocd/applications/bumba/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
   - deployment.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/bumba
-    digest: sha256:cb99f190a49ee3752bf0219457f0df02325ee0879c6f542de61da0679243f4cc
+    digest: sha256:2543efd2a9dc9b41dac6bcf51e347dd74b134e88aececed69bb568b1f5469306
     newName: registry.ide-newton.ts.net/lab/bumba


### PR DESCRIPTION
## Summary

- Promote `bumba` to `registry.ide-newton.ts.net/lab/bumba@sha256:2543efd2a9dc9b41dac6bcf51e347dd74b134e88aececed69bb568b1f5469306`.
- Source commit: `8de0fb5c87a4130247d70a0941eea29b91c0eb9f`.
- Built by the shared Nix OCI workflow without Docker Buildx.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/bumba@sha256:2543efd2a9dc9b41dac6bcf51e347dd74b134e88aececed69bb568b1f5469306" linux/amd64 linux/arm64`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.