### PR TITLE
fix(torghut): avoid archive catalog rewrites

### DIFF
--- a/docs/torghut/storage-write-pressure-remediation-design.md
+++ b/docs/torghut/storage-write-pressure-remediation-design.md
@@ -214,6 +214,23 @@ The live trading universe and the archival catalog are separate workloads:
 - Treat statement and lock timeouts as secondary safety bounds, not as the remediation. Shutdown explicitly cancels an
   in-flight archive statement and each committed batch remains independently replay-safe.
 
+### Low-WAL archive status overlay
+
+Live validation of the initial finalizer showed that pacing alone was insufficient. Even ten catalog status updates per
+transaction rewrote a roughly 3.1 GiB heap and four status-dependent indexes in a roughly 3.2 GiB index set, pushing
+PostgreSQL WAL above the discovery budget. Archive finalization therefore must not update or row-lock the wide catalog.
+
+Missing archive contracts are recorded in the logged, narrow
+`torghut_options_contract_archive_status` table. `torghut_options_active_contract_catalog` exposes the effective active
+set by excluding those overrides, and every active-catalog read uses that view. A provider page conditionally deletes
+matching overrides and publishes the effective reactivation even when the wide catalog row itself is unchanged.
+
+The finalizer writes one compact row keyed by contract symbol, updates it only when status, shard, or query fingerprint
+materially changes, and protects every non-off subscription from archival deactivation. A transaction-scoped advisory
+lock serializes status-overlay insertion with provider-page reactivation without dirtying catalog heap pages. The
+existing physical catalog status remains the bounded live-discovery state and is the rollback source if the overlay is
+disabled.
+
 ## Design 2: ClickHouse ingestion
 
 ### Per-table buffering

--- a/services/torghut/app/api/health_checks/load_options_catalog_freshness_summary.py
+++ b/services/torghut/app/api/health_checks/load_options_catalog_freshness_summary.py
@@ -59,6 +59,7 @@ from app.api.health_checks.tigerbeetle_health import (
 from app.config import settings
 from app.db import SessionLocal
 from app.models import TradeDecision
+from app.options_lane.archive_status import ACTIVE_CATALOG_VIEW
 from app.trading.hypotheses import (
     JangarDependencyQuorumStatus,
     load_hypothesis_registry,
@@ -200,7 +201,7 @@ def _load_options_catalog_freshness_summary(
         session.execute(text("SET LOCAL statement_timeout = 500"))
         if scoped_symbols:
             scoped_query = text(
-                """
+                f"""
 SELECT
   underlying_symbol,
   COUNT(*) AS active_contracts,
@@ -209,7 +210,7 @@ SELECT
   MAX(provider_updated_ts) AS newest_provider_updated_ts,
   COUNT(*) FILTER (WHERE close_price IS NULL) AS missing_close_price_count,
   COUNT(*) FILTER (WHERE COALESCE(open_interest, 0) <= 0) AS zero_open_interest_count
-FROM torghut_options_contract_catalog
+FROM {ACTIVE_CATALOG_VIEW}
 WHERE underlying_symbol IN :route_symbols
   AND status = 'active'
 GROUP BY underlying_symbol
@@ -266,14 +267,14 @@ GROUP BY underlying_symbol
             global_rows = list(
                 session.execute(
                     text(
-                        """
+                        f"""
 SELECT
   underlying_symbol,
   last_seen_ts,
   provider_updated_ts,
   close_price,
   open_interest
-FROM torghut_options_contract_catalog
+FROM {ACTIVE_CATALOG_VIEW}
 WHERE status = 'active'
 ORDER BY last_seen_ts DESC NULLS LAST
 LIMIT 200

--- a/services/torghut/app/api/health_checks/remember_alpaca_success.py
+++ b/services/torghut/app/api/health_checks/remember_alpaca_success.py
@@ -34,6 +34,7 @@ from app.api.health_checks.shared_context import (
 from app.config import settings
 from app.db import SessionLocal
 from app.models import ExecutionTCAMetric
+from app.options_lane.archive_status import ACTIVE_CATALOG_VIEW
 from app.trading.ingest import ClickHouseSignalIngestor
 from app.trading.scheduler import TradingScheduler
 from app.trading.tca import build_tca_gate_inputs
@@ -433,14 +434,14 @@ def load_bounded_options_catalog_freshness_summary(
         fallback_reason_codes.append(reason)
     rows: list[Mapping[str, object]] = []
     bounded_query = text(
-        """
+        f"""
 SELECT
   underlying_symbol,
   last_seen_ts,
   provider_updated_ts,
   close_price,
   open_interest
-FROM torghut_options_contract_catalog
+FROM {ACTIVE_CATALOG_VIEW}
 WHERE underlying_symbol = :route_symbol
   AND status = 'active'
 LIMIT 1

--- a/services/torghut/app/options_lane/archive_repository.py
+++ b/services/torghut/app/options_lane/archive_repository.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
-from dataclasses import dataclass
 from datetime import date, datetime, timedelta
-import json
 import threading
 from typing import cast
 
@@ -18,6 +16,17 @@ from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.sql import Executable
 
 from .archive_model import ARCHIVE_COMPONENT, ARCHIVE_SCOPE_TYPE, ArchiveShard
+from .archive_repository_types import (
+    ArchiveCheckpoint,
+    ArchiveCompletion,
+    ArchiveFailure,
+    ArchiveResetRequest,
+    as_date as _as_date,
+    as_datetime as _as_datetime,
+    as_int as _as_int,
+    metadata_from_value as _metadata,
+    metadata_json as _metadata_json,
+)
 from .archive_status import (
     ACTIVE_CATALOG_VIEW,
     ARCHIVE_STATUS_RECONCILE_LOCK_ID,
@@ -37,127 +46,6 @@ class ArchiveStateError(RuntimeError):
 
 class ArchiveLeaseLostError(ArchiveStateError):
     """Raised when the singleton archive lease is no longer held."""
-
-
-@dataclass(frozen=True, slots=True)
-class ArchiveCheckpoint:
-    shard: ArchiveShard
-    query_fingerprint: str
-    status: str
-    cursor: str | None
-    page_count: int
-    seen_count: int
-    retry_count: int
-    next_eligible_at: datetime | None
-    last_success_at: datetime | None
-    finalize_snapshot_at: datetime | None = None
-    finalize_after_expiration_date: date | None = None
-    finalize_after_contract_symbol: str | None = None
-    transitioned_count: int = 0
-
-    def due(self, now: datetime) -> bool:
-        return self.next_eligible_at is None or self.next_eligible_at <= now
-
-
-@dataclass(frozen=True, slots=True)
-class ArchiveCompletion:
-    checkpoint: ArchiveCheckpoint
-    transitioned_count: int
-    batch_scanned_count: int = 0
-    batch_transitioned_count: int = 0
-
-
-@dataclass(frozen=True, slots=True)
-class ArchiveFailure:
-    error_code: str
-    error_detail: str
-    retry_base_seconds: int
-    retry_max_seconds: int
-
-
-@dataclass(frozen=True, slots=True)
-class ArchiveResetRequest:
-    shard: ArchiveShard
-    query_fingerprint: str
-    observed_at: datetime
-    reason: str
-    last_success_at: datetime | None
-
-
-def _metadata(value: object) -> dict[str, object]:
-    if isinstance(value, dict):
-        raw = cast(dict[object, object], value)
-        return {str(key): item for key, item in raw.items()}
-    if isinstance(value, str):
-        try:
-            parsed = json.loads(value)
-        except json.JSONDecodeError:
-            return {}
-        if isinstance(parsed, dict):
-            raw = cast(dict[object, object], parsed)
-            return {str(key): item for key, item in raw.items()}
-    return {}
-
-
-def _metadata_json(
-    checkpoint: ArchiveCheckpoint,
-    *,
-    extra: Mapping[str, object] | None = None,
-) -> str:
-    payload: dict[str, object] = {
-        "expiration_date_gte": checkpoint.shard.start.isoformat(),
-        "expiration_date_lte": checkpoint.shard.end.isoformat(),
-        "page_count": checkpoint.page_count,
-        "query_fingerprint": checkpoint.query_fingerprint,
-        "seen_count": checkpoint.seen_count,
-        "status": checkpoint.status,
-        "finalize_snapshot_at": (
-            checkpoint.finalize_snapshot_at.isoformat()
-            if checkpoint.finalize_snapshot_at is not None
-            else None
-        ),
-        "finalize_after_expiration_date": (
-            checkpoint.finalize_after_expiration_date.isoformat()
-            if checkpoint.finalize_after_expiration_date is not None
-            else None
-        ),
-        "finalize_after_contract_symbol": checkpoint.finalize_after_contract_symbol,
-        "transitioned_count": checkpoint.transitioned_count,
-    }
-    if extra:
-        payload.update(extra)
-    return json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
-
-
-def _as_int(value: object, default: int = 0) -> int:
-    try:
-        return int(cast(int | float | str, value))
-    except (TypeError, ValueError, ArithmeticError):
-        return default
-
-
-def _as_date(value: object) -> date | None:
-    if isinstance(value, datetime):
-        return value.date()
-    if isinstance(value, date):
-        return value
-    if isinstance(value, str):
-        try:
-            return date.fromisoformat(value)
-        except ValueError:
-            return None
-    return None
-
-
-def _as_datetime(value: object) -> datetime | None:
-    if isinstance(value, datetime):
-        return value
-    if isinstance(value, str):
-        try:
-            return datetime.fromisoformat(value.replace("Z", "+00:00"))
-        except ValueError:
-            return None
-    return None
 
 
 class OptionsArchiveRepository:

--- a/services/torghut/app/options_lane/archive_repository.py
+++ b/services/torghut/app/options_lane/archive_repository.py
@@ -6,7 +6,6 @@ from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
-import hashlib
 import json
 import threading
 from typing import cast
@@ -19,10 +18,16 @@ from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.sql import Executable
 
 from .archive_model import ARCHIVE_COMPONENT, ARCHIVE_SCOPE_TYPE, ArchiveShard
+from .archive_status import (
+    ACTIVE_CATALOG_VIEW,
+    ARCHIVE_STATUS_RECONCILE_LOCK_ID,
+    ARCHIVE_STATUS_TABLE,
+    DEFAULT_ARCHIVE_LOCK_NAME,
+    archive_advisory_lock_id,
+)
 
 
 ARCHIVE_MEMBERSHIP_TABLE = "torghut_options_archive_membership"
-DEFAULT_ARCHIVE_LOCK_NAME = "torghut:options-catalog-archive"
 _IN_PROGRESS_STATUSES = frozenset({"running", "retry", "finalizing"})
 
 
@@ -45,6 +50,7 @@ class ArchiveCheckpoint:
     retry_count: int
     next_eligible_at: datetime | None
     last_success_at: datetime | None
+    finalize_snapshot_at: datetime | None = None
     finalize_after_expiration_date: date | None = None
     finalize_after_contract_symbol: str | None = None
     transitioned_count: int = 0
@@ -78,15 +84,6 @@ class ArchiveResetRequest:
     last_success_at: datetime | None
 
 
-def archive_advisory_lock_id(
-    name: str = DEFAULT_ARCHIVE_LOCK_NAME,
-) -> int:
-    """Return a stable signed 64-bit PostgreSQL advisory-lock identifier."""
-
-    digest = hashlib.sha256(name.encode("utf-8")).digest()
-    return int.from_bytes(digest[:8], byteorder="big", signed=True)
-
-
 def _metadata(value: object) -> dict[str, object]:
     if isinstance(value, dict):
         raw = cast(dict[object, object], value)
@@ -114,6 +111,11 @@ def _metadata_json(
         "query_fingerprint": checkpoint.query_fingerprint,
         "seen_count": checkpoint.seen_count,
         "status": checkpoint.status,
+        "finalize_snapshot_at": (
+            checkpoint.finalize_snapshot_at.isoformat()
+            if checkpoint.finalize_snapshot_at is not None
+            else None
+        ),
         "finalize_after_expiration_date": (
             checkpoint.finalize_after_expiration_date.isoformat()
             if checkpoint.finalize_after_expiration_date is not None
@@ -142,6 +144,17 @@ def _as_date(value: object) -> date | None:
     if isinstance(value, str):
         try:
             return date.fromisoformat(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _as_datetime(value: object) -> datetime | None:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
         except ValueError:
             return None
     return None
@@ -290,9 +303,9 @@ class OptionsArchiveRepository:
         with self.session() as session:
             value = session.execute(
                 text(
-                    """
+                    f"""
                     SELECT min(expiration_date)
-                    FROM torghut_options_contract_catalog
+                    FROM {ACTIVE_CATALOG_VIEW}
                     WHERE status = 'active'
                       AND expiration_date < :before
                     """
@@ -336,6 +349,11 @@ class OptionsArchiveRepository:
                     != (checkpoint.finalize_after_contract_symbol is None)
                 ):
                     reset_reason = "invalid_finalization_cursor"
+                elif (
+                    checkpoint.status == "finalizing"
+                    and checkpoint.finalize_snapshot_at is None
+                ):
+                    reset_reason = "missing_finalization_snapshot"
                 elif checkpoint.status in _IN_PROGRESS_STATUSES:
                     membership_count = self._membership_count(
                         session,
@@ -459,6 +477,7 @@ class OptionsArchiveRepository:
                 retry_count=0,
                 next_eligible_at=None,
                 last_success_at=current.last_success_at,
+                finalize_snapshot_at=(observed_at if status == "finalizing" else None),
             )
             session.execute(
                 text(
@@ -521,6 +540,7 @@ class OptionsArchiveRepository:
                 retry_count=retry_count,
                 next_eligible_at=next_eligible_at,
                 last_success_at=current.last_success_at,
+                finalize_snapshot_at=current.finalize_snapshot_at,
                 finalize_after_expiration_date=(current.finalize_after_expiration_date),
                 finalize_after_contract_symbol=(current.finalize_after_contract_symbol),
                 transitioned_count=current.transitioned_count,
@@ -594,10 +614,16 @@ class OptionsArchiveRepository:
             has_finalize_symbol = current.finalize_after_contract_symbol is not None
             if has_finalize_date != has_finalize_symbol:
                 raise ArchiveStateError("archive finalization cursor is incomplete")
+            if current.finalize_snapshot_at is None:
+                raise ArchiveStateError("archive finalization snapshot is missing")
 
             session.execute(text(f"SET LOCAL lock_timeout = {lock_timeout_ms}"))
             session.execute(
                 text(f"SET LOCAL statement_timeout = {statement_timeout_ms}")
+            )
+            session.execute(
+                text("SELECT pg_advisory_xact_lock(:lock_id)"),
+                {"lock_id": ARCHIVE_STATUS_RECONCILE_LOCK_ID},
             )
 
             if not has_finalize_date:
@@ -616,12 +642,11 @@ class OptionsArchiveRepository:
                         self._execute_cancellable(
                             session,
                             text(
-                                """
+                                f"""
                                 SELECT EXISTS (
                                   SELECT 1
-                                  FROM torghut_options_contract_catalog
-                                  WHERE status = 'active'
-                                    AND expiration_date BETWEEN :start_date AND :end_date
+                                  FROM {ACTIVE_CATALOG_VIEW}
+                                  WHERE expiration_date BETWEEN :start_date AND :end_date
                                 )
                                 """
                             ),
@@ -670,7 +695,6 @@ class OptionsArchiveRepository:
                               {cursor_predicate}
                             ORDER BY catalog.expiration_date, catalog.contract_symbol
                             LIMIT :batch_size
-                            FOR UPDATE OF catalog
                             """
                         ),
                         parameters,
@@ -692,6 +716,7 @@ class OptionsArchiveRepository:
                     retry_count=0,
                     next_eligible_at=next_eligible_at,
                     last_success_at=observed_at,
+                    finalize_snapshot_at=current.finalize_snapshot_at,
                     transitioned_count=current.transitioned_count,
                 )
                 session.execute(
@@ -742,17 +767,27 @@ class OptionsArchiveRepository:
                         CAST(:candidate_symbols AS TEXT[])
                       ) AS candidate(expiration_date, contract_symbol)
                     )
-                    UPDATE torghut_options_contract_catalog AS catalog
-                    SET status = CASE
-                          WHEN catalog.expiration_date < CAST(:observed_at AS DATE)
-                            THEN 'expired'
-                          ELSE 'inactive'
-                        END,
-                        last_seen_ts = :observed_at
+                    INSERT INTO {ARCHIVE_STATUS_TABLE} (
+                      contract_symbol,
+                      effective_status,
+                      query_fingerprint,
+                      shard_key,
+                      observed_at
+                    )
+                    SELECT catalog.contract_symbol,
+                           CASE
+                             WHEN catalog.expiration_date < CAST(:observed_at AS DATE)
+                               THEN 'expired'
+                             ELSE 'inactive'
+                           END,
+                           :query_fingerprint,
+                           :shard_key,
+                           :finalize_snapshot_at
                     FROM candidates
-                    WHERE catalog.expiration_date = candidates.expiration_date
+                    JOIN torghut_options_contract_catalog AS catalog
+                      ON catalog.expiration_date = candidates.expiration_date
                       AND catalog.contract_symbol = candidates.contract_symbol
-                      AND catalog.status = 'active'
+                    WHERE catalog.status = 'active'
                       AND NOT EXISTS (
                         SELECT 1
                         FROM {ARCHIVE_MEMBERSHIP_TABLE} AS membership
@@ -761,10 +796,31 @@ class OptionsArchiveRepository:
                           AND membership.shard_key = :shard_key
                           AND membership.contract_symbol = catalog.contract_symbol
                       )
+                      AND NOT EXISTS (
+                        SELECT 1
+                        FROM torghut_options_subscription_state AS subscription
+                        WHERE subscription.contract_symbol = catalog.contract_symbol
+                          AND subscription.tier IS DISTINCT FROM 'off'
+                      )
+                    ON CONFLICT (contract_symbol) DO UPDATE
+                    SET effective_status = EXCLUDED.effective_status,
+                        query_fingerprint = EXCLUDED.query_fingerprint,
+                        shard_key = EXCLUDED.shard_key,
+                        observed_at = EXCLUDED.observed_at
+                    WHERE (
+                      {ARCHIVE_STATUS_TABLE}.effective_status,
+                      {ARCHIVE_STATUS_TABLE}.query_fingerprint,
+                      {ARCHIVE_STATUS_TABLE}.shard_key
+                    ) IS DISTINCT FROM (
+                      EXCLUDED.effective_status,
+                      EXCLUDED.query_fingerprint,
+                      EXCLUDED.shard_key
+                    )
                         """
                     ),
                     {
                         "observed_at": observed_at,
+                        "finalize_snapshot_at": current.finalize_snapshot_at,
                         "candidate_expiration_dates": candidate_expiration_dates,
                         "candidate_symbols": candidate_symbols,
                         "component": ARCHIVE_COMPONENT,
@@ -786,6 +842,7 @@ class OptionsArchiveRepository:
                 retry_count=0,
                 next_eligible_at=None,
                 last_success_at=current.last_success_at,
+                finalize_snapshot_at=current.finalize_snapshot_at,
                 finalize_after_expiration_date=cast(
                     date, last_candidate["expiration_date"]
                 ),
@@ -830,6 +887,7 @@ class OptionsArchiveRepository:
                 text(
                     """
                     SELECT cursor,
+                           last_event_ts,
                            last_success_ts,
                            next_eligible_ts,
                            retry_count,
@@ -974,6 +1032,14 @@ class OptionsArchiveRepository:
             retry_count=_as_int(row.get("retry_count")),
             next_eligible_at=cast(datetime | None, row.get("next_eligible_ts")),
             last_success_at=cast(datetime | None, row.get("last_success_ts")),
+            finalize_snapshot_at=(
+                _as_datetime(metadata.get("finalize_snapshot_at"))
+                or (
+                    cast(datetime | None, row.get("last_event_ts"))
+                    if str(metadata.get("status") or "") == "finalizing"
+                    else None
+                )
+            ),
             finalize_after_expiration_date=_as_date(
                 metadata.get("finalize_after_expiration_date")
             ),

--- a/services/torghut/app/options_lane/archive_repository_types.py
+++ b/services/torghut/app/options_lane/archive_repository_types.py
@@ -1,0 +1,132 @@
+"""Persistence value objects and serializers for the options archive."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import date, datetime
+import json
+from typing import cast
+
+from .archive_model import ArchiveShard
+
+
+@dataclass(frozen=True, slots=True)
+class ArchiveCheckpoint:
+    shard: ArchiveShard
+    query_fingerprint: str
+    status: str
+    cursor: str | None
+    page_count: int
+    seen_count: int
+    retry_count: int
+    next_eligible_at: datetime | None
+    last_success_at: datetime | None
+    finalize_snapshot_at: datetime | None = None
+    finalize_after_expiration_date: date | None = None
+    finalize_after_contract_symbol: str | None = None
+    transitioned_count: int = 0
+
+    def due(self, now: datetime) -> bool:
+        return self.next_eligible_at is None or self.next_eligible_at <= now
+
+
+@dataclass(frozen=True, slots=True)
+class ArchiveCompletion:
+    checkpoint: ArchiveCheckpoint
+    transitioned_count: int
+    batch_scanned_count: int = 0
+    batch_transitioned_count: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class ArchiveFailure:
+    error_code: str
+    error_detail: str
+    retry_base_seconds: int
+    retry_max_seconds: int
+
+
+@dataclass(frozen=True, slots=True)
+class ArchiveResetRequest:
+    shard: ArchiveShard
+    query_fingerprint: str
+    observed_at: datetime
+    reason: str
+    last_success_at: datetime | None
+
+
+def metadata_from_value(value: object) -> dict[str, object]:
+    if isinstance(value, dict):
+        raw = cast(dict[object, object], value)
+        return {str(key): item for key, item in raw.items()}
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        if isinstance(parsed, dict):
+            raw = cast(dict[object, object], parsed)
+            return {str(key): item for key, item in raw.items()}
+    return {}
+
+
+def metadata_json(
+    checkpoint: ArchiveCheckpoint,
+    *,
+    extra: Mapping[str, object] | None = None,
+) -> str:
+    payload: dict[str, object] = {
+        "expiration_date_gte": checkpoint.shard.start.isoformat(),
+        "expiration_date_lte": checkpoint.shard.end.isoformat(),
+        "page_count": checkpoint.page_count,
+        "query_fingerprint": checkpoint.query_fingerprint,
+        "seen_count": checkpoint.seen_count,
+        "status": checkpoint.status,
+        "finalize_snapshot_at": (
+            checkpoint.finalize_snapshot_at.isoformat()
+            if checkpoint.finalize_snapshot_at is not None
+            else None
+        ),
+        "finalize_after_expiration_date": (
+            checkpoint.finalize_after_expiration_date.isoformat()
+            if checkpoint.finalize_after_expiration_date is not None
+            else None
+        ),
+        "finalize_after_contract_symbol": checkpoint.finalize_after_contract_symbol,
+        "transitioned_count": checkpoint.transitioned_count,
+    }
+    if extra:
+        payload.update(extra)
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def as_int(value: object, default: int = 0) -> int:
+    try:
+        return int(cast(int | float | str, value))
+    except (TypeError, ValueError, ArithmeticError):
+        return default
+
+
+def as_date(value: object) -> date | None:
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        try:
+            return date.fromisoformat(value)
+        except ValueError:
+            return None
+    return None
+
+
+def as_datetime(value: object) -> datetime | None:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    return None

--- a/services/torghut/app/options_lane/archive_status.py
+++ b/services/torghut/app/options_lane/archive_status.py
@@ -1,0 +1,23 @@
+"""Shared contracts for low-WAL options archive status reconciliation."""
+
+from __future__ import annotations
+
+import hashlib
+
+
+ARCHIVE_STATUS_TABLE = "torghut_options_contract_archive_status"
+ACTIVE_CATALOG_VIEW = "torghut_options_active_contract_catalog"
+DEFAULT_ARCHIVE_LOCK_NAME = "torghut:options-catalog-archive"
+ARCHIVE_STATUS_RECONCILE_LOCK_NAME = "torghut:options-catalog-archive-status"
+
+
+def archive_advisory_lock_id(name: str = DEFAULT_ARCHIVE_LOCK_NAME) -> int:
+    """Return a stable signed 64-bit PostgreSQL advisory-lock identifier."""
+
+    digest = hashlib.sha256(name.encode("utf-8")).digest()
+    return int.from_bytes(digest[:8], byteorder="big", signed=True)
+
+
+ARCHIVE_STATUS_RECONCILE_LOCK_ID = archive_advisory_lock_id(
+    ARCHIVE_STATUS_RECONCILE_LOCK_NAME
+)

--- a/services/torghut/app/options_lane/repository.py
+++ b/services/torghut/app/options_lane/repository.py
@@ -297,6 +297,10 @@ class OptionsRepository:
 
         with self.session() as session, session.begin():
             session.execute(
+                text("SELECT pg_advisory_xact_lock(:lock_id)"),
+                {"lock_id": ARCHIVE_STATUS_RECONCILE_LOCK_ID},
+            )
+            session.execute(
                 text(
                     """
                     CREATE TEMPORARY TABLE options_catalog_seen_contracts (
@@ -334,6 +338,11 @@ class OptionsRepository:
                         FROM options_catalog_seen_contracts AS seen
                         WHERE seen.contract_symbol = catalog.contract_symbol
                       )
+                      AND NOT EXISTS (
+                        SELECT 1
+                        FROM torghut_options_contract_archive_status AS archive_status
+                        WHERE archive_status.contract_symbol = catalog.contract_symbol
+                      )
                     RETURNING catalog.*
                     """
                     ),
@@ -350,6 +359,11 @@ class OptionsRepository:
                           WHERE catalog.status = 'active'
                             AND catalog.underlying_symbol = ANY(:underlying_symbols)
                             AND catalog.expiration_date < :expiration_date_gte
+                            AND NOT EXISTS (
+                              SELECT 1
+                              FROM torghut_options_contract_archive_status AS archive_status
+                              WHERE archive_status.contract_symbol = catalog.contract_symbol
+                            )
                           LIMIT :expired_cleanup_limit
                           FOR UPDATE SKIP LOCKED
                         )

--- a/services/torghut/app/options_lane/repository.py
+++ b/services/torghut/app/options_lane/repository.py
@@ -15,6 +15,11 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, sessionmaker
 
+from app.options_lane.archive_status import (
+    ACTIVE_CATALOG_VIEW,
+    ARCHIVE_STATUS_RECONCILE_LOCK_ID,
+    ARCHIVE_STATUS_TABLE,
+)
 from app.options_lane.catalog_watermark_repository import (
     CatalogCycleSummary,
     record_catalog_cycle_success,
@@ -215,14 +220,21 @@ class OptionsRepository:
         published_rows: list[dict[str, Any]] = []
 
         with self.session() as session, session.begin():
+            session.execute(
+                text("SELECT pg_advisory_xact_lock(:lock_id)"),
+                {"lock_id": ARCHIVE_STATUS_RECONCILE_LOCK_ID},
+            )
             existing_rows = {
                 row["contract_symbol"]: dict(row)
                 for row in session.execute(
                     text(
-                        """
-                        SELECT *
-                        FROM torghut_options_contract_catalog
-                        WHERE contract_symbol = ANY(:symbols)
+                        f"""
+                        SELECT catalog.*,
+                               archive_status.contract_symbol AS archive_status_symbol
+                        FROM torghut_options_contract_catalog AS catalog
+                        LEFT JOIN {ARCHIVE_STATUS_TABLE} AS archive_status
+                          ON archive_status.contract_symbol = catalog.contract_symbol
+                        WHERE catalog.contract_symbol = ANY(:symbols)
                         """
                     ),
                     {"symbols": list(seen_symbols) or [""]},
@@ -245,8 +257,12 @@ class OptionsRepository:
                     current=current,
                     payload=payload,
                 )
-                if changed:
+                effective_status_changed = bool(
+                    current and current.get("archive_status_symbol")
+                )
+                if changed or effective_status_changed:
                     published_rows.append(payload)
+                if changed:
                     upsert_rows.append(payload)
 
             if upsert_rows:
@@ -254,6 +270,15 @@ class OptionsRepository:
                     CATALOG_PAGE_UPSERT,
                     {"rows": _coerce_json(upsert_rows)},
                 )
+            session.execute(
+                text(
+                    f"""
+                    DELETE FROM {ARCHIVE_STATUS_TABLE}
+                    WHERE contract_symbol = ANY(:symbols)
+                    """
+                ),
+                {"symbols": list(seen_symbols) or [""]},
+            )
 
         return published_rows
 
@@ -364,7 +389,7 @@ class OptionsRepository:
         with self.session() as session:
             rows = session.execute(
                 text(
-                    """
+                    f"""
                     SELECT catalog.contract_symbol,
                            catalog.status,
                            catalog.underlying_symbol,
@@ -372,8 +397,8 @@ class OptionsRepository:
                            catalog.strike_price,
                            catalog.close_price,
                            catalog.open_interest,
-                           COALESCE(subs.ranking_inputs, '{}'::JSONB) AS ranking_inputs
-                    FROM torghut_options_contract_catalog AS catalog
+                           COALESCE(subs.ranking_inputs, '{{}}'::JSONB) AS ranking_inputs
+                    FROM {ACTIVE_CATALOG_VIEW} AS catalog
                     LEFT JOIN torghut_options_subscription_state AS subs
                       ON subs.contract_symbol = catalog.contract_symbol
                     WHERE catalog.status = 'active'
@@ -389,7 +414,7 @@ class OptionsRepository:
         with self.session() as session:
             rows = session.execute(
                 text(
-                    """
+                    f"""
                     SELECT catalog.contract_symbol,
                            catalog.status,
                            catalog.underlying_symbol,
@@ -397,8 +422,8 @@ class OptionsRepository:
                            catalog.strike_price,
                            catalog.close_price,
                            catalog.open_interest,
-                           COALESCE(subs.ranking_inputs, '{}'::JSONB) AS ranking_inputs
-                    FROM torghut_options_contract_catalog AS catalog
+                           COALESCE(subs.ranking_inputs, '{{}}'::JSONB) AS ranking_inputs
+                    FROM {ACTIVE_CATALOG_VIEW} AS catalog
                     LEFT JOIN torghut_options_subscription_state AS subs
                       ON subs.contract_symbol = catalog.contract_symbol
                     WHERE catalog.status = 'active'
@@ -454,10 +479,10 @@ class OptionsRepository:
         with self.session() as session:
             rows = session.execute(
                 text(
-                    """
+                    f"""
                     SELECT subscriptions.contract_symbol
                     FROM torghut_options_subscription_state AS subscriptions
-                    JOIN torghut_options_contract_catalog AS catalog
+                    JOIN {ACTIVE_CATALOG_VIEW} AS catalog
                       ON catalog.contract_symbol = subscriptions.contract_symbol
                     WHERE subscriptions.tier = 'hot'
                       AND catalog.status = 'active'
@@ -490,7 +515,7 @@ class OptionsRepository:
         with self.session() as session:
             rows = session.execute(
                 text(
-                    """
+                    f"""
                     SELECT catalog.contract_symbol,
                            catalog.underlying_symbol,
                            catalog.expiration_date,
@@ -499,7 +524,7 @@ class OptionsRepository:
                            subs.tier,
                            watermarks.last_success_ts
                     FROM torghut_options_subscription_state AS subs
-                    JOIN torghut_options_contract_catalog AS catalog
+                    JOIN {ACTIVE_CATALOG_VIEW} AS catalog
                       ON catalog.contract_symbol = subs.contract_symbol
                     LEFT JOIN torghut_options_watermarks AS watermarks
                       ON watermarks.component = 'enricher'
@@ -617,9 +642,7 @@ class OptionsRepository:
             return None
 
     def count_active_contracts(self) -> int | None:
-        return self._bounded_count(
-            "SELECT COUNT(*) FROM torghut_options_contract_catalog WHERE status = 'active'"
-        )
+        return self._bounded_count(f"SELECT COUNT(*) FROM {ACTIVE_CATALOG_VIEW}")
 
     def count_hot_contracts(self) -> int | None:
         return self._bounded_count(
@@ -631,9 +654,9 @@ class OptionsRepository:
             return int(
                 session.execute(
                     text(
-                        """
+                        f"""
                         SELECT COALESCE(MAX(open_interest), 0)
-                        FROM torghut_options_contract_catalog
+                        FROM {ACTIVE_CATALOG_VIEW}
                         WHERE status = 'active'
                           AND underlying_symbol = ANY(:underlying_symbols)
                           AND expiration_date BETWEEN :expiration_date_gte AND :expiration_date_lte
@@ -650,15 +673,24 @@ class OptionsRepository:
         with self.session() as session:
             rows = session.execute(
                 text(
-                    """
-                    SELECT *
-                    FROM torghut_options_contract_catalog
-                    WHERE contract_symbol = ANY(:symbols)
+                    f"""
+                    SELECT catalog.*,
+                           COALESCE(archive_status.effective_status, catalog.status)
+                             AS effective_status
+                    FROM torghut_options_contract_catalog AS catalog
+                    LEFT JOIN {ARCHIVE_STATUS_TABLE} AS archive_status
+                      ON archive_status.contract_symbol = catalog.contract_symbol
+                    WHERE catalog.contract_symbol = ANY(:symbols)
                     """
                 ),
                 {"symbols": symbols},
             ).mappings()
-            return {cast(str, row["contract_symbol"]): dict(row) for row in rows}
+            result: dict[str, dict[str, Any]] = {}
+            for row in rows:
+                payload = dict(row)
+                payload["status"] = payload.pop("effective_status")
+                result[cast(str, row["contract_symbol"])] = payload
+            return result
 
 
 def ranked_contract_rows(

--- a/services/torghut/app/options_lane/subscription_state_repository.py
+++ b/services/torghut/app/options_lane/subscription_state_repository.py
@@ -11,6 +11,7 @@ from typing import cast
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
+from app.options_lane.archive_status import ACTIVE_CATALOG_VIEW
 from app.options_lane.catalog_scope import OptionsCatalogScope
 
 
@@ -32,7 +33,7 @@ def load_live_subscription_candidates(
 
     rows = session.execute(
         text(
-            """
+            f"""
             SELECT catalog.contract_symbol,
                    catalog.status,
                    catalog.underlying_symbol,
@@ -41,12 +42,12 @@ def load_live_subscription_candidates(
                    catalog.close_price,
                    catalog.open_interest,
                    subs.ranking_score,
-                   COALESCE(subs.ranking_inputs, '{}'::JSONB) AS ranking_inputs,
+                   COALESCE(subs.ranking_inputs, '{{}}'::JSONB) AS ranking_inputs,
                    subs.tier,
                    subs.desired_channels,
                    subs.provider_cap_generation
             FROM torghut_options_subscription_state AS subs
-            JOIN torghut_options_contract_catalog AS catalog
+            JOIN {ACTIVE_CATALOG_VIEW} AS catalog
               ON catalog.contract_symbol = subs.contract_symbol
             WHERE catalog.status = 'active'
               AND subs.tier IN ('hot', 'warm')

--- a/services/torghut/migrations/versions/0067_options_archive_status_overlay.py
+++ b/services/torghut/migrations/versions/0067_options_archive_status_overlay.py
@@ -1,0 +1,62 @@
+"""Add a narrow durable status overlay for archive reconciliation.
+
+Revision ID: 0067_options_archive_status
+Revises: 0066_broker_submit_coordinator
+Create Date: 2026-07-14 22:30:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0067_options_archive_status"
+down_revision = "0066_broker_submit_coordinator"
+branch_labels = None
+depends_on = None
+
+
+_TABLE = "torghut_options_contract_archive_status"
+_VIEW = "torghut_options_active_contract_catalog"
+
+
+def upgrade() -> None:
+    op.create_table(
+        _TABLE,
+        sa.Column("contract_symbol", sa.Text(), nullable=False),
+        sa.Column("effective_status", sa.Text(), nullable=False),
+        sa.Column("query_fingerprint", sa.String(length=64), nullable=False),
+        sa.Column("shard_key", sa.Text(), nullable=False),
+        sa.Column("observed_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint(
+            "contract_symbol",
+            name="pk_torghut_options_contract_archive_status",
+        ),
+        sa.CheckConstraint(
+            "effective_status IN ('inactive', 'expired')",
+            name="ck_torghut_options_contract_archive_status_value",
+        ),
+        sa.CheckConstraint(
+            "query_fingerprint ~ '^[0-9a-f]{64}$'",
+            name="ck_torghut_options_contract_archive_status_fingerprint",
+        ),
+    )
+    op.execute(
+        f"""
+        CREATE VIEW {_VIEW} AS
+        SELECT catalog.*
+        FROM torghut_options_contract_catalog AS catalog
+        WHERE catalog.status = 'active'
+          AND NOT EXISTS (
+            SELECT 1
+            FROM {_TABLE} AS archive_status
+            WHERE archive_status.contract_symbol = catalog.contract_symbol
+          )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(f"DROP VIEW IF EXISTS {_VIEW}")
+    op.drop_table(_TABLE)

--- a/services/torghut/tests/api/test_trading_api_forecast_options.py
+++ b/services/torghut/tests/api/test_trading_api_forecast_options.py
@@ -140,7 +140,7 @@ class TestTradingApiForecastOptions(TradingApiTestCaseBase):
         self.assertIn("AND status = 'active'", fake_session.calls[1][0])
         self.assertEqual(
             sum(
-                "FROM torghut_options_contract_catalog" in sql
+                "FROM torghut_options_active_contract_catalog" in sql
                 for sql, _params in fake_session.calls
             ),
             1,
@@ -197,7 +197,7 @@ class TestTradingApiForecastOptions(TradingApiTestCaseBase):
         self.assertIn("LIMIT 200", fake_session.calls[1][0])
         self.assertEqual(
             sum(
-                "FROM torghut_options_contract_catalog" in sql
+                "FROM torghut_options_active_contract_catalog" in sql
                 for sql, _params in fake_session.calls
             ),
             1,
@@ -519,7 +519,7 @@ class TestTradingApiForecastOptions(TradingApiTestCaseBase):
         self.assertEqual(payload["route_symbols"], ["AAPL"])
         self.assertEqual(
             sum(
-                "FROM torghut_options_contract_catalog" in sql
+                "FROM torghut_options_active_contract_catalog" in sql
                 for sql, _params in fake_session.calls
             ),
             1,

--- a/services/torghut/tests/test_options_archive.py
+++ b/services/torghut/tests/test_options_archive.py
@@ -81,7 +81,7 @@ class _ArchiveSession:
             return _Result(scalar=self.active_count > 0)
         if "SELECT catalog.expiration_date" in sql:
             return _Result(rows=self.candidate_rows)
-        if "UPDATE torghut_options_contract_catalog" in sql:
+        if "INSERT INTO torghut_options_contract_archive_status" in sql:
             return _Result(rowcount=self.transition_count)
         return _Result()
 
@@ -204,10 +204,14 @@ def _watermark_row(
     next_eligible_ts: datetime | None = None,
     finalize_after_expiration_date: date | None = None,
     finalize_after_contract_symbol: str | None = None,
+    finalize_snapshot_at: datetime | None = None,
     transitioned_count: int = 0,
 ) -> dict[str, object]:
+    if status == "finalizing" and finalize_snapshot_at is None:
+        finalize_snapshot_at = datetime(2026, 7, 14, 11, tzinfo=UTC)
     return {
         "cursor": cursor,
+        "last_event_ts": finalize_snapshot_at,
         "last_success_ts": None,
         "next_eligible_ts": next_eligible_ts,
         "retry_count": retry_count,
@@ -216,6 +220,7 @@ def _watermark_row(
             "status": status,
             "page_count": page_count,
             "seen_count": seen_count,
+            "finalize_snapshot_at": finalize_snapshot_at,
             "finalize_after_expiration_date": (
                 finalize_after_expiration_date.isoformat()
                 if finalize_after_expiration_date is not None
@@ -504,6 +509,46 @@ def test_page_checkpoint_persists_exact_membership_and_next_cursor() -> None:
     ]
 
 
+def test_terminal_page_captures_stable_finalization_snapshot() -> None:
+    fingerprint = archive_query_fingerprint(shard=_shard(), page_limit=10_000)
+    observed_at = datetime(2026, 7, 14, 12, tzinfo=UTC)
+    session = _ArchiveSession()
+    repository = _ArchiveRepository(
+        row=_watermark_row(
+            fingerprint=fingerprint,
+            status="running",
+            cursor="page-2",
+            page_count=2,
+            seen_count=2,
+        ),
+        membership_count=2,
+        session=session,
+    )
+
+    checkpoint = repository.checkpoint_page(
+        checkpoint=ArchiveCheckpoint(
+            shard=_shard(),
+            query_fingerprint=fingerprint,
+            status="running",
+            cursor="page-2",
+            page_count=2,
+            seen_count=2,
+            retry_count=0,
+            next_eligible_at=None,
+            last_success_at=None,
+        ),
+        observed_at=observed_at,
+        contract_symbols=set(),
+        next_cursor=None,
+    )
+
+    assert checkpoint.status == "finalizing"
+    assert checkpoint.finalize_snapshot_at == observed_at
+    watermark_parameters = session.calls[-1][1]
+    assert isinstance(watermark_parameters, dict)
+    assert observed_at.isoformat() in str(watermark_parameters["metadata"])
+
+
 def test_record_failure_retains_cursor_and_caps_exponential_backoff() -> None:
     fingerprint = archive_query_fingerprint(shard=_shard(), page_limit=10_000)
     observed_at = datetime(2026, 7, 14, 12, tzinfo=UTC)
@@ -613,15 +658,19 @@ def test_finalize_scans_one_bounded_batch_and_persists_cursor() -> None:
     transition_sql, transition_parameters = next(
         (sql, parameters)
         for sql, parameters in session.calls
-        if "UPDATE torghut_options_contract_catalog" in sql
+        if "INSERT INTO torghut_options_contract_archive_status" in sql
     )
     assert "WITH candidates AS" in transition_sql
+    assert "INSERT INTO torghut_options_contract_archive_status" in transition_sql
+    assert "UPDATE torghut_options_contract_catalog" not in transition_sql
     assert "CAST(:candidate_expiration_dates AS DATE[])" in transition_sql
     assert "CAST(:candidate_symbols AS TEXT[])" in transition_sql
     assert "catalog.expiration_date = candidates.expiration_date" in transition_sql
     assert "catalog.contract_symbol = candidates.contract_symbol" in transition_sql
     assert "membership.query_fingerprint = :query_fingerprint" in transition_sql
     assert "membership.shard_key = :shard_key" in transition_sql
+    assert "subscription.tier IS DISTINCT FROM 'off'" in transition_sql
+    assert "ON CONFLICT (contract_symbol) DO UPDATE" in transition_sql
     assert isinstance(transition_parameters, dict)
     assert transition_parameters["candidate_expiration_dates"] == [
         date(2026, 7, 14),

--- a/services/torghut/tests/test_options_archive_status_overlay_migration.py
+++ b/services/torghut/tests/test_options_archive_status_overlay_migration.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from tests.migration_testing import load_migration_module
+
+
+MIGRATION_FILENAME = "0067_options_archive_status_overlay.py"
+
+
+def test_archive_status_overlay_is_logged_narrow_and_extends_current_head() -> None:
+    module = load_migration_module(MIGRATION_FILENAME)
+
+    assert module.revision == "0067_options_archive_status"
+    assert module.down_revision == "0066_broker_submit_coordinator"
+    assert len(module.revision) <= 32
+
+    with (
+        patch.object(module.op, "create_table") as create_table,
+        patch.object(module.op, "execute") as execute,
+    ):
+        module.upgrade()
+
+    assert create_table.call_args.args[0] == "torghut_options_contract_archive_status"
+    assert "prefixes" not in create_table.call_args.kwargs
+    view_sql = str(execute.call_args.args[0])
+    assert "CREATE VIEW torghut_options_active_contract_catalog" in view_sql
+    assert "archive_status.contract_symbol = catalog.contract_symbol" in view_sql
+    assert "catalog.status = 'active'" in view_sql
+
+
+def test_archive_status_overlay_downgrade_drops_view_before_table() -> None:
+    module = load_migration_module(MIGRATION_FILENAME)
+
+    with (
+        patch.object(module.op, "execute") as execute,
+        patch.object(module.op, "drop_table") as drop_table,
+    ):
+        module.downgrade()
+
+    execute.assert_called_once_with(
+        "DROP VIEW IF EXISTS torghut_options_active_contract_catalog"
+    )
+    drop_table.assert_called_once_with("torghut_options_contract_archive_status")

--- a/services/torghut/tests/test_options_catalog_scope_repository.py
+++ b/services/torghut/tests/test_options_catalog_scope_repository.py
@@ -44,7 +44,7 @@ class _CatalogSession:
     def execute(self, statement: object, parameters: object = None) -> _RowsResult:
         sql = str(statement)
         self.calls.append((sql, parameters))
-        if "SELECT *" in sql and "contract_symbol = ANY" in sql:
+        if "SELECT catalog.*" in sql and "contract_symbol = ANY" in sql:
             return _RowsResult(self.existing_rows)
         if "WITH expired_batch AS" in sql:
             return _RowsResult(self.expired_transition_rows)
@@ -144,8 +144,34 @@ def test_unchanged_catalog_page_performs_no_upsert_or_publication() -> None:
         repository.sync_contract_catalog_page([contract], observed_at=observed_at) == []
     )
 
-    assert len(session.calls) == 1
-    assert "SELECT *" in session.calls[0][0]
+    assert len(session.calls) == 3
+    assert "pg_advisory_xact_lock" in session.calls[0][0]
+    assert "SELECT catalog.*" in session.calls[1][0]
+    assert "DELETE FROM torghut_options_contract_archive_status" in session.calls[2][0]
+
+
+def test_seen_catalog_row_clears_archive_overlay_and_publishes_reactivation() -> None:
+    observed_at = datetime(2026, 7, 14, 15, tzinfo=UTC)
+    contract = _contract(
+        "AAPL260717C00200000", observed_at=observed_at, open_interest=42
+    )
+    existing = _persisted_contract_row(contract)
+    existing["first_seen_ts"] = observed_at - timedelta(days=1)
+    existing["last_seen_ts"] = observed_at - timedelta(minutes=5)
+    existing["archive_status_symbol"] = contract["contract_symbol"]
+    session = _CatalogSession(existing_rows=[existing])
+    repository = _CatalogRepository(session)
+
+    changed_rows = repository.sync_contract_catalog_page(
+        [contract], observed_at=observed_at
+    )
+
+    assert [row["contract_symbol"] for row in changed_rows] == ["AAPL260717C00200000"]
+    assert changed_rows[0]["status"] == "active"
+    assert not any("jsonb_to_recordset" in sql for sql, _ in session.calls)
+    delete_sql, delete_parameters = session.calls[-1]
+    assert "DELETE FROM torghut_options_contract_archive_status" in delete_sql
+    assert delete_parameters == {"symbols": ["AAPL260717C00200000"]}
 
 
 def test_catalog_upserts_changed_rows_in_stable_order_with_database_guard() -> None:
@@ -165,7 +191,7 @@ def test_catalog_upserts_changed_rows_in_stable_order_with_database_guard() -> N
         "AAPL260717C00200000",
         "MSFT260717C00400000",
     ]
-    insert_sql, insert_parameters = session.calls[1]
+    insert_sql, insert_parameters = session.calls[2]
     assert "jsonb_to_recordset" in insert_sql
     assert "IS DISTINCT FROM" in insert_sql
     assert isinstance(insert_parameters, dict)

--- a/services/torghut/tests/test_options_catalog_scope_repository.py
+++ b/services/torghut/tests/test_options_catalog_scope_repository.py
@@ -10,6 +10,7 @@ import pytest
 from sqlalchemy.orm import Session
 
 from app.options_lane.alpaca import normalize_contract_record
+from app.options_lane.archive_status import ARCHIVE_STATUS_RECONCILE_LOCK_ID
 from app.options_lane.catalog_scope import OptionsCatalogScope
 from app.options_lane.repository import OptionsRepository
 
@@ -230,25 +231,34 @@ def test_missing_contract_transition_is_scoped_to_exact_completed_scan() -> None
 
     assert rows[0]["catalog_status_reason"] == "not_seen_in_active_discovery_run"
     assert rows[1]["catalog_status_reason"] == "expired_below_live_discovery_window"
+    assert "pg_advisory_xact_lock" in session.calls[0][0]
+    assert session.calls[0][1] == {"lock_id": ARCHIVE_STATUS_RECONCILE_LOCK_ID}
     assert (
-        "CREATE TEMPORARY TABLE options_catalog_seen_contracts" in session.calls[0][0]
+        "CREATE TEMPORARY TABLE options_catalog_seen_contracts" in session.calls[1][0]
     )
-    assert session.calls[1][1] == {
+    assert session.calls[2][1] == {
         "seen_symbols": ["AAPL260717C00200000", "MSFT260717C00400000"]
     }
-    transition_sql, transition_parameters = session.calls[2]
+    transition_sql, transition_parameters = session.calls[3]
     assert "catalog.underlying_symbol = ANY(:underlying_symbols)" in transition_sql
     assert "catalog.expiration_date BETWEEN :expiration_date_gte" in transition_sql
     assert "AND :expiration_date_lte" in transition_sql
     assert "catalog.expiration_date < :expiration_date_gte" not in transition_sql
     assert "NOT EXISTS" in transition_sql
+    assert (
+        "FROM torghut_options_contract_archive_status AS archive_status"
+        in transition_sql
+    )
     assert "last_seen_ts <" not in transition_sql
     assert transition_parameters == {
         "observed_at": observed_at,
         **_scope().query_parameters,
     }
-    expired_sql, expired_parameters = session.calls[3]
+    expired_sql, expired_parameters = session.calls[4]
     assert "WITH expired_batch AS" in expired_sql
+    assert (
+        "FROM torghut_options_contract_archive_status AS archive_status" in expired_sql
+    )
     assert "LIMIT :expired_cleanup_limit" in expired_sql
     assert "FOR UPDATE SKIP LOCKED" in expired_sql
     assert expired_parameters == {

--- a/services/torghut/tests/test_options_lane.py
+++ b/services/torghut/tests/test_options_lane.py
@@ -393,7 +393,10 @@ class TestOptionsRepositoryStatusCounts(TestCase):
             )
         )
         self.assertTrue(
-            any("torghut_options_contract_catalog" in sql for sql in session.statements)
+            any(
+                "torghut_options_active_contract_catalog" in sql
+                for sql in session.statements
+            )
         )
 
     def test_count_hot_contracts_returns_none_when_telemetry_count_times_out(

--- a/services/torghut/tests/test_strategy_capital_authority_migration_compat.py
+++ b/services/torghut/tests/test_strategy_capital_authority_migration_compat.py
@@ -28,8 +28,9 @@ def test_migration_graph_has_one_merged_head_and_knows_the_released_revision() -
     config = AlembicConfig(str(SERVICE_ROOT / "alembic.ini"))
     scripts = ScriptDirectory.from_config(config)
 
-    assert scripts.get_heads() == ["0066_broker_submit_coordinator"]
+    assert scripts.get_heads() == ["0067_options_archive_status"]
     assert scripts.get_revision("0063_strategy_capital_authority") is not None
     assert scripts.get_revision("0064_strategy_capital_authority") is not None
     assert scripts.get_revision("0065_strategy_capital_compat") is not None
     assert scripts.get_revision("0066_broker_submit_coordinator") is not None
+    assert scripts.get_revision("0067_options_archive_status") is not None


### PR DESCRIPTION
## Summary

- replace archive finalization updates to the 6.3 GiB options catalog and its status-dependent indexes with a narrow, logged status overlay
- route active-catalog reads through an effective-active view, preserve non-off subscriptions, and publish provider-driven reactivations without rewriting unchanged catalog rows
- add a stable finalization snapshot, transaction-scoped reconciliation fencing, Alembic migration coverage, and the measured design amendment

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format --check` on all 12 touched Python files
- `uv run --frozen ruff check` on all 12 touched Python files
- `uv run --frozen pytest -q tests/test_options*.py tests/api/test_trading_api_forecast_options.py` (108 passed)
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen alembic heads` (`0067_options_archive_status (head)`)
- `bunx oxfmt --check docs/torghut/storage-write-pressure-remediation-design.md`
- `git diff --check`

## Breaking Changes

None. Migration `0067_options_archive_status` creates the logged overlay table and effective-active view before the new service image is activated.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
