### PR TITLE
fix(torghut): bind paper proof to validation permits

### DIFF
--- a/docs/torghut/production-readiness-proof-runbook.md
+++ b/docs/torghut/production-readiness-proof-runbook.md
@@ -101,11 +101,13 @@ python services/torghut/scripts/verify_quant_readiness.py \
   ...
 ```
 
-### 3. Live paper broker proof (blocked until mutation fencing is wired)
+### 3. Live paper broker proof
 
-Do not execute a broker mutation while `broker_mutation_safety.runtime_wired=false`. After the mutation coordinator,
-recovery worker, and reduction fencing are deployed, execute the production-real Alpaca paper proof on the next live US
-equities session only through Torghut's normal coordinator under a short-lived `InfrastructureValidationPermit`.
+Do not execute a broker mutation while `broker_mutation_safety.runtime_wired=false`. Once the bounded validation submit
+path reports wired, follow the [infrastructure-validation runbook](profitability/infrastructure-validation-runbook.md)
+exactly. Use Torghut's dedicated coordinator path and a short-lived `InfrastructureValidationPermit`; direct
+script-to-broker submission is not admissible. The continuous Alpaca crypto exercise does not need a US equities
+session. If broker I/O becomes ambiguous, do not retry: preserve the receipt for the Slice 5 recovery path.
 
 Required outcome:
 
@@ -113,9 +115,9 @@ Required outcome:
 - pre-submit validation succeeds
 - order submit succeeds
 - readback succeeds
-- terminal cancel or fill is observed
-
-Direct script-to-broker submission is not admissible proof.
+- terminal cancel, expiry, or rejection with zero filled quantity is observed
+- the account returns to zero positions and zero open orders
+- the receipt and any asynchronous order event remain explicitly non-promotable and unlinked from candidate evidence
 
 ### 4. Session readiness proof
 

--- a/docs/torghut/profitability/README.md
+++ b/docs/torghut/profitability/README.md
@@ -35,6 +35,8 @@ readback. The audit snapshot records what was observed at its stated time.
   dictionary, causal data rules, statistical validation, capacity/TCA methodology, strategy queue, and capital ladder.
 - [Strategy capital authority](strategy-capital-authority.md): immutable per-strategy grant, immediate pre-broker
   enforcement, evidence separation, catalog baseline, and live proof contract.
+- [Infrastructure validation runbook](infrastructure-validation-runbook.md): v2 permit authority, exact paper-account
+  boundary, one-dollar IOC proof, no-retry failure handling, and independent broker/CNPG readback.
 - [Implementation roadmap](implementation-roadmap.md): ordered PR-sized delivery slices, tests, rollout proof,
   dependencies, and rollback posture.
 - [Slice 3 production evidence](evidence/slice-03-autoresearch-completion-2026-07-14.md): committed revision, CI and

--- a/docs/torghut/profitability/adversarial-profitability-system-design.md
+++ b/docs/torghut/profitability/adversarial-profitability-system-design.md
@@ -213,14 +213,25 @@ paper probation. Those tests use one typed `InfrastructureValidationPermit`, not
 The permit is valid only when all of these are encoded and enforced:
 
 - purpose is exactly `control_plane_validation`, with no strategy/candidate promotion identity;
+- schema `torghut.infrastructure-validation-permit.v2` includes the asset class; v1 is rejected because adding that
+  required field changed the authority contract;
 - venue and account are a dedicated paper or exchange sandbox identity allowlisted as non-live at configuration and
-  broker-adapter boundaries;
+  broker-adapter boundaries; for Alpaca, the configured label must equal the broker-returned `account_number`;
+- the venue, asset, account, and session matrix is exact: Alpaca equity is paper/regular, Alpaca crypto is
+  paper/continuous, and Hyperliquid perpetual is sandbox/continuous;
 - symbols, sides, order types, maximum order/notional/loss, maximum outstanding intents, session, issuer, and a short
   expiry are explicit;
 - a known-null test plan and expected terminal economic state are immutable inputs;
 - every decision, order, activity, fill, ledger row, and report is tagged `non_promotable_validation` and excluded from
   candidate statistics, PnL targets, trial selection, and promotion evidence;
 - the permit cannot be converted, inherited, or mapped to `paper_probation` or a real-capital stage.
+
+The Slice 4 Alpaca submit exercise is narrower than the reusable permit: continuous-session crypto only, one buy limit
+IOC, one outstanding intent, one order, and at most `$1` notional and loss. The client validates the exact paper
+endpoint, broker account status, crypto status, asset class, and known-null account before I/O. The database rejects
+widened or promotable canonical intents. Broker order events resolve their validation receipt before persistence,
+receive an explicit non-promotable evidence marker, remain unlinked from executions and trade decisions, and are
+excluded from TigerBeetle and repair relinking.
 
 Issuance requires explicit infrastructure-owner approval. A research agent, candidate, global live flag, account name,
 or healthy route cannot issue it. Any attempt to target a live account, omit the non-promotable tag, exceed a bound, or

--- a/docs/torghut/profitability/implementation-roadmap.md
+++ b/docs/torghut/profitability/implementation-roadmap.md
@@ -120,7 +120,8 @@ receipt or unresolved state afterward.
 - Deliverable: route all production submit entry points through one mutation coordinator using deterministic idempotency
   keys and transactional claim state.
 - Primary surfaces: broker adapters and order-routing entry points under `services/torghut/app/**`, claim migrations,
-  `services/torghut/tests/test_broker_mutation_receipts_unwired.py`, and readiness metrics.
+  `services/torghut/tests/test_broker_mutation_receipts_unwired.py`, readiness metrics, and the
+  [infrastructure-validation runbook](infrastructure-validation-runbook.md).
 - Tests: process death before claim, after claim, during broker timeout, after broker acceptance, and before receipt
   persistence; duplicate request and concurrent-leader property tests.
 - Runtime proof: fault-injected submissions under a short-lived `InfrastructureValidationPermit` produce one dedicated

--- a/docs/torghut/profitability/infrastructure-validation-runbook.md
+++ b/docs/torghut/profitability/infrastructure-validation-runbook.md
@@ -1,0 +1,187 @@
+# Infrastructure Validation Permit Runbook
+
+Status: operator contract for non-promotable broker-control exercises.
+
+This runbook exercises Torghut's shipped broker-mutation coordinator against a dedicated non-live account. It is not a
+candidate trial, profitability evidence, paper-probation authority, or permission to increase real-capital exposure.
+Ordinary risk-increasing submission remains blocked throughout the exercise.
+
+## Authority Boundary
+
+An exercise requires `torghut.infrastructure-validation-permit.v2`. The permit is immutable, expires within 15 minutes,
+and has different `issued_by` and `approved_by` identities. Approval must come from the infrastructure owner; a research
+agent, strategy, healthy route, global trading flag, or account name cannot self-authorize it.
+
+The shipped Slice 4 submit proof accepts only this matrix:
+
+| Venue  | Asset class | Account                                                 | Session      | Submit shape  | Absolute bound |
+| ------ | ----------- | ------------------------------------------------------- | ------------ | ------------- | -------------- |
+| Alpaca | `crypto`    | exact paper endpoint and broker-reported account number | `continuous` | buy limit IOC | at most `$1`   |
+
+The reusable permit schema also recognizes Alpaca equity/regular-session and Hyperliquid testnet perpetual boundaries
+for later exercises. The Slice 4 submit authority intentionally accepts neither route because it does not implement
+their independent session and adapter proof. Do not substitute an account with existing orders or positions.
+
+The Alpaca endpoint must canonicalize to exactly `https://paper-api.alpaca.markets`. A terminal SDK-style `/v2` is
+removed before classification; the runtime rejects credentials, ports, alternate hosts, every other path, queries,
+fragments, and a caller-supplied paper/live mode that conflicts with the URL.
+The configured Torghut account label must equal Alpaca's returned `account_number`; endpoint classification alone is
+not sufficient.
+
+## Preconditions
+
+Before issuing a permit, record and independently verify:
+
+1. source merge, immutable image digest, promotion merge, active scheduler pod, and active container digest;
+2. migration head includes `0068_validation_submit`;
+3. scheduler `/healthz` and `/scheduler/readyz` are healthy, while ordinary entry authority remains false;
+4. `TRADING_KILL_SWITCH_ENABLED` is false for the bounded exercise;
+5. Alpaca returns the expected paper `account_number`, active account status, and active crypto status when applicable;
+6. the account has zero positions and zero open orders;
+7. the selected asset is active, tradable, and has the requested asset class;
+8. no earlier receipt uses the proposed `permit_id` or deterministic client-order ID.
+
+Stop if any identity is missing, aliased, or contradictory. Never infer paper safety from `TRADING_MODE`; the endpoint
+and broker account response are authoritative.
+
+## Build The Input
+
+The input is one JSON object with `plan` and `permit`. Build the plan first, then compute the two immutable digests with
+the deployed implementation:
+
+```sh
+kubectl -n torghut exec -i deployment/torghut-scheduler -c torghut-scheduler -- \
+  python -c '
+import json, sys
+from app.trading.infrastructure_validation import InfrastructureValidationOrderPlan
+from app.trading.infrastructure_validation import infrastructure_validation_order_plan_sha256
+from app.trading.infrastructure_validation import infrastructure_validation_terminal_state_sha256
+plan = InfrastructureValidationOrderPlan.model_validate(json.load(sys.stdin))
+print(json.dumps({"test_plan_digest": infrastructure_validation_order_plan_sha256(plan),
+                  "expected_terminal_state_digest": infrastructure_validation_terminal_state_sha256()},
+                 sort_keys=True))
+' < plan.json
+```
+
+Use this plan shape for the continuous-session crypto proof:
+
+```json
+{
+  "schema_version": "torghut.infrastructure-validation-order-plan.v1",
+  "venue": "alpaca",
+  "asset_class": "crypto",
+  "symbol": "BTC/USD",
+  "side": "buy",
+  "qty": "1",
+  "order_type": "limit",
+  "time_in_force": "ioc",
+  "limit_price": "1",
+  "stop_price": null
+}
+```
+
+The limit makes the maximum executable notional `$1`; a fill still causes the proof to fail because the expected
+terminal state is a known-null account. Do not widen the permit to compensate for broker rejection.
+
+Create a permit with:
+
+- a unique `permit_id`;
+- `purpose=control_plane_validation`;
+- the exact broker account number and paper URL;
+- one symbol, `buy`, `limit`, `max_orders=1`, and `max_outstanding_intents=1`;
+- `max_notional_usd=1` and `max_loss_usd=1` or lower;
+- an issuance-to-expiry interval no longer than 15 minutes;
+- the computed plan and terminal-state digests;
+- `evidence_tag=non_promotable_validation` and `promotable=false`.
+
+The permit digest, plan digest, expected terminal-state digest, and deterministic `ivp-...` client-order ID are sealed
+into the durable canonical intent. PostgreSQL independently rejects promotable, widened, reused, expired, wrong-side,
+wrong-session, wrong-endpoint, or structurally inconsistent validation receipts.
+
+## Execute Once
+
+Pipe the completed object to the active scheduler image:
+
+```sh
+kubectl -n torghut exec -i deployment/torghut-scheduler -c torghut-scheduler -- \
+  python -m app.trading.infrastructure_validation_submit --input-file - < permit-and-plan.json
+```
+
+The runner performs these checks and state transitions:
+
+1. validates the permit, plan, endpoint, configured label, broker account, asset, positions, and open orders;
+2. races two coordinators over the same deterministic intent while holding the winner at the broker boundary;
+3. requires the contender to be fenced before releasing exactly one broker call;
+4. replays the terminal intent and requires `already_processed`;
+5. resolves the broker order by the exact client-order ID and requires the same broker order ID, an allowed terminal
+   status, and zero filled quantity;
+6. waits for zero open orders and zero positions;
+7. proves one settled mutation receipt, no trade-decision submission claim, execution, or trade decision, and no
+   candidate-linked or TigerBeetle-journaled validation event;
+8. emits a compact JSON report tagged `non_promotable_validation` and `promotable=false`.
+
+An acknowledged receipt records the response observed at submit time; the independent client-order-ID read establishes
+the later broker terminal state. Neither one substitutes for the other.
+
+## Independent Readback
+
+Capture the emitted client-order ID, permit ID, receipt ID, broker order ID, and timestamps. Query CNPG directly:
+
+```sql
+SELECT id, account_label, operation, risk_class, purpose, client_request_id,
+       canonical_intent_sha256, created_at
+  FROM broker_mutation_receipts
+ WHERE client_request_id = '<client-order-id>';
+
+SELECT sequence_no, event_type, state, settlement_outcome,
+       broker_reference, recorded_at
+  FROM broker_mutation_receipt_events
+ WHERE receipt_id = '<receipt-id>'
+ ORDER BY sequence_no;
+
+SELECT
+  (SELECT count(*) FROM trade_decision_submission_claims
+    WHERE client_order_id = '<client-order-id>') AS submission_claims,
+  (SELECT count(*) FROM executions
+    WHERE client_order_id = '<client-order-id>') AS executions,
+  (SELECT count(*) FROM trade_decisions
+    WHERE decision_hash = '<client-order-id>') AS trade_decisions;
+
+SELECT id, execution_id, trade_decision_id,
+       raw_event -> '_torghut_evidence_contract' AS evidence_contract
+  FROM execution_order_events
+ WHERE client_order_id = '<client-order-id>';
+```
+
+Any matching order event must have `provenance=non_promotable_validation`, `authoritative=false`, `promotable=false`,
+and null execution and trade-decision links. It must have no `tigerbeetle_transfer_refs` row. Independently query Alpaca
+by client-order ID and re-read positions and open orders. A green Argo badge or a successful CLI exit is not
+broker-economic proof by itself.
+
+## Ambiguous Or Failed Outcome
+
+- If failure occurs before broker I/O, retain the rejected/deferred receipt and correct the input only with a new
+  permit ID.
+- If broker I/O started and the response is missing or ambiguous, do not rerun the command or create a new client ID.
+  Preserve the unresolved receipt and query Alpaca by the original deterministic ID. Slice 5 recovery owns resolution.
+- If an order filled, an open order remains, or a position exists, stop. Do not claim success. Use an independently
+  authorized risk-reduction path after fresh broker observation; never disguise a cleanup order as validation.
+- If an event links to candidate data or reaches TigerBeetle, treat it as an evidence-contamination incident and keep
+  capital blocked.
+- Never delete a permit, receipt, event, or broker fact to make the proof pass.
+
+## External Contract Checked
+
+This implementation was checked on 2026-07-14 against Alpaca's official documentation:
+
+- the [Account object](https://docs.alpaca.markets/us/docs/account-plans) exposes `account_number`, status, block flags,
+  and crypto status;
+- [Alpaca order rules](https://docs.alpaca.markets/us/docs/orders-at-alpaca) support limit IOC for crypto and describe
+  terminal order states;
+- the official [Order properties](https://docs.alpaca.markets/us/docs/brokerapi-trading) expose the broker order ID,
+  client order ID, status, and cumulative `filled_qty` used by the zero-fill readback;
+- the [Assets API](https://docs.alpaca.markets/us/reference/get-v2-assets-1) is served from the paper endpoint and
+  identifies tradable assets by class;
+- [client-order-ID lookup](https://docs.alpaca.markets/us/reference/getorderbyclientorderid) is the recovery identity.
+
+Recheck these primary sources before changing the order envelope or interpreting a new broker response.

--- a/services/torghut/app/alpaca_client.py
+++ b/services/torghut/app/alpaca_client.py
@@ -10,6 +10,7 @@ from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from enum import Enum
 from typing import Any, Dict, List, Optional, Protocol, cast
+from urllib.parse import urlsplit
 from uuid import UUID
 
 from alpaca.common.exceptions import APIError
@@ -241,13 +242,16 @@ class TorghutAlpacaClient:
         base = _normalize_alpaca_base_url(base_url or settings.apca_api_base_url)
         data_base = _normalize_alpaca_base_url(settings.apca_data_api_base_url)
 
-        use_paper = paper if paper is not None else settings.trading_mode != "live"
-        self.endpoint_class = "paper" if use_paper else "live"
         self.endpoint_url = base or (
             "https://paper-api.alpaca.markets"
-            if use_paper
+            if (paper if paper is not None else settings.trading_mode != "live")
             else "https://api.alpaca.markets"
         )
+        endpoint_class = _classify_alpaca_trading_endpoint(self.endpoint_url)
+        if paper is not None and endpoint_class != ("paper" if paper else "live"):
+            raise ValueError("alpaca_endpoint_paper_mode_mismatch")
+        self.endpoint_class = endpoint_class
+        use_paper = endpoint_class == "paper"
 
         # Broker mutations use a dedicated single-attempt client so an ambiguous
         # response cannot cause a hidden resubmission. Reads keep the SDK's retry
@@ -542,6 +546,26 @@ def _normalize_alpaca_base_url(base_url: Optional[str]) -> Optional[str]:
     if trimmed.endswith("/v2"):
         return trimmed[:-3]
     return trimmed
+
+
+def _classify_alpaca_trading_endpoint(endpoint_url: str) -> str:
+    parsed = urlsplit(endpoint_url)
+    host = (parsed.hostname or "").lower()
+    if (
+        parsed.scheme != "https"
+        or parsed.username
+        or parsed.password
+        or parsed.port
+        or parsed.path not in {"", "/"}
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ValueError("alpaca_trading_endpoint_invalid")
+    if host == "paper-api.alpaca.markets":
+        return "paper"
+    if host == "api.alpaca.markets":
+        return "live"
+    raise ValueError("alpaca_trading_endpoint_unrecognized")
 
 
 __all__ = [

--- a/services/torghut/app/models/entities/broker_mutation_records.py
+++ b/services/torghut/app/models/entities/broker_mutation_records.py
@@ -94,7 +94,7 @@ class BrokerMutationReceipt(Base):
             "purpose IN ('initial_submission', 'repricing', "
             "'inventory_conflict', 'opposite_side_cleanup', 'kill_switch', "
             "'governance', 'closeout', 'flatten', "
-            "'operator')",
+            "'operator', 'control_plane_validation')",
             name="purpose",
         ),
         CheckConstraint(
@@ -114,6 +114,9 @@ class BrokerMutationReceipt(Base):
             "((broker_route = 'alpaca' AND (submission_claim_id IS NOT NULL OR "
             "(submission_claim_id IS NULL AND risk_class = 'risk_reducing' "
             "AND purpose IN ('closeout', 'flatten')))) OR "
+            "(broker_route = 'alpaca' AND submission_claim_id IS NULL "
+            "AND risk_class = 'risk_neutral' "
+            "AND purpose = 'control_plane_validation') OR "
             "(broker_route = 'hyperliquid' AND submission_claim_id IS NULL "
             "AND risk_class = 'risk_increasing' "
             "AND purpose = 'initial_submission'))) OR "

--- a/services/torghut/app/trading/broker_mutation_receipts/canonicalization.py
+++ b/services/torghut/app/trading/broker_mutation_receipts/canonicalization.py
@@ -69,6 +69,7 @@ _PURPOSES: tuple[BrokerMutationPurpose, ...] = (
     "closeout",
     "flatten",
     "operator",
+    "control_plane_validation",
 )
 _TARGET_KINDS: tuple[BrokerMutationTargetKind, ...] = (
     "order",
@@ -616,8 +617,17 @@ def _validate_operation_contract(
             and risk_class == "risk_increasing"
             and purpose == "initial_submission"
         )
+        alpaca_validation_valid = (
+            broker_route == "alpaca"
+            and submission_claim_id is None
+            and risk_class == "risk_neutral"
+            and purpose == "control_plane_validation"
+        )
         if target.kind != "order" or not (
-            linked_claim_valid or alpaca_closeout_valid or hyperliquid_entry_valid
+            linked_claim_valid
+            or alpaca_closeout_valid
+            or hyperliquid_entry_valid
+            or alpaca_validation_valid
         ):
             raise BrokerMutationReceiptValidationError(
                 "submit_order_route_claim_contract_invalid"

--- a/services/torghut/app/trading/broker_mutation_receipts/types.py
+++ b/services/torghut/app/trading/broker_mutation_receipts/types.py
@@ -47,6 +47,7 @@ BrokerMutationPurpose = Literal[
     "closeout",
     "flatten",
     "operator",
+    "control_plane_validation",
 ]
 BrokerMutationTargetKind = Literal["order", "position", "account"]
 BrokerMutationReceiptState = Literal["claimed", "released", "broker_io", "settled"]

--- a/services/torghut/app/trading/broker_mutation_submit_coordinator.py
+++ b/services/torghut/app/trading/broker_mutation_submit_coordinator.py
@@ -109,7 +109,6 @@ class InfrastructureValidationOrderSubmission:
     permit: InfrastructureValidationPermit
     plan: InfrastructureValidationOrderPlan
     account_label: str
-    account_mode: str
     endpoint_url: str
 
 
@@ -213,7 +212,6 @@ class BrokerMutationSubmitCoordinator:
             request.permit,
             request.plan,
             account_label=request.account_label,
-            account_mode=request.account_mode,
             broker_base_url=request.endpoint_url,
             now=evaluated_at,
         )

--- a/services/torghut/app/trading/broker_mutation_submit_coordinator.py
+++ b/services/torghut/app/trading/broker_mutation_submit_coordinator.py
@@ -8,6 +8,7 @@ import time
 import uuid
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from functools import lru_cache
 from typing import Generic, TypeVar
 
@@ -39,6 +40,13 @@ from .decision_submission_claims.types import (
     DecisionSubmissionClaimSnapshot,
 )
 from .decision_submission_claims import acquire_decision_submission_claim
+from .infrastructure_validation import (
+    InfrastructureValidationOrderPlan,
+    InfrastructureValidationPermit,
+    authorize_infrastructure_validation_order,
+    infrastructure_validation_client_order_id,
+    infrastructure_validation_request_payload,
+)
 
 
 _BrokerResult = TypeVar("_BrokerResult")
@@ -94,6 +102,15 @@ class UnlinkedOrderSubmissionCallbacks(Generic[_BrokerResult]):
     broker_call: Callable[[BrokerMutationIoPermit], _BrokerResult]
     persist_terminal: Callable[[_BrokerResult], None]
     build_settlement: Callable[[_BrokerResult], BrokerMutationSettlement]
+
+
+@dataclass(frozen=True, slots=True)
+class InfrastructureValidationOrderSubmission:
+    permit: InfrastructureValidationPermit
+    plan: InfrastructureValidationOrderPlan
+    account_label: str
+    account_mode: str
+    endpoint_url: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -165,6 +182,69 @@ class BrokerMutationSubmitCoordinator:
         )
 
     def submit_unlinked_order(
+        self,
+        session: Session,
+        *,
+        intent: BrokerMutationIntent,
+        callbacks: UnlinkedOrderSubmissionCallbacks[_BrokerResult],
+    ) -> _BrokerResult:
+        if intent.purpose == "control_plane_validation":
+            raise BrokerMutationSubmissionRejected(
+                "infrastructure_validation_requires_dedicated_submit_authority"
+            )
+        return self._submit_unlinked_order(
+            session,
+            intent=intent,
+            callbacks=callbacks,
+        )
+
+    def submit_infrastructure_validation_order(
+        self,
+        session: Session,
+        *,
+        request: InfrastructureValidationOrderSubmission,
+        callbacks: UnlinkedOrderSubmissionCallbacks[_BrokerResult],
+        now: datetime | None = None,
+    ) -> _BrokerResult:
+        """Submit one permit-bound, non-promotable paper validation order."""
+
+        evaluated_at = now or datetime.now(timezone.utc)
+        authorize_infrastructure_validation_order(
+            request.permit,
+            request.plan,
+            account_label=request.account_label,
+            account_mode=request.account_mode,
+            broker_base_url=request.endpoint_url,
+            now=evaluated_at,
+        )
+        client_order_id = infrastructure_validation_client_order_id(
+            request.permit,
+            request.plan,
+        )
+        intent = build_broker_mutation_intent(
+            BrokerMutationIntentRequest(
+                broker_route="alpaca",
+                account_label=request.account_label,
+                endpoint_fingerprint=fingerprint_broker_endpoint(request.endpoint_url),
+                operation="submit_order",
+                risk_class="risk_neutral",
+                purpose="control_plane_validation",
+                workflow_id=client_order_id,
+                client_request_id=client_order_id,
+                target=BrokerMutationTarget(kind="order", key=client_order_id),
+                request_payload=infrastructure_validation_request_payload(
+                    request.permit,
+                    request.plan,
+                ),
+            )
+        )
+        return self._submit_unlinked_order(
+            session,
+            intent=intent,
+            callbacks=callbacks,
+        )
+
+    def _submit_unlinked_order(
         self,
         session: Session,
         *,
@@ -440,6 +520,7 @@ __all__ = [
     "BrokerMutationSubmissionRejected",
     "BrokerMutationSubmissionUnresolved",
     "BrokerMutationSubmitCoordinator",
+    "InfrastructureValidationOrderSubmission",
     "LinkedOrderSubmission",
     "LinkedOrderSubmissionCallbacks",
     "UnlinkedOrderSubmissionCallbacks",

--- a/services/torghut/app/trading/firewall.py
+++ b/services/torghut/app/trading/firewall.py
@@ -345,7 +345,6 @@ class OrderFirewall:
             permit,
             plan,
             account_label=self.account_label,
-            account_mode="paper",
             broker_base_url=self.broker_endpoint_url,
             now=evaluated_at,
         )

--- a/services/torghut/app/trading/firewall.py
+++ b/services/torghut/app/trading/firewall.py
@@ -120,7 +120,7 @@ def alpaca_submit_request_payload(request: AlpacaSubmitRequest) -> dict[str, obj
     }
 
 
-class _OrderFirewallBrokerClient(Protocol):
+class OrderFirewallBrokerClient(Protocol):
     """Broker methods the order firewall is allowed to call."""
 
     def submit_order(
@@ -165,7 +165,7 @@ class OrderFirewall:
 
     def __init__(
         self,
-        client: _OrderFirewallBrokerClient,
+        client: OrderFirewallBrokerClient,
         *,
         account_label: str | None = None,
     ) -> None:

--- a/services/torghut/app/trading/firewall.py
+++ b/services/torghut/app/trading/firewall.py
@@ -6,6 +6,7 @@ import json
 import logging
 from collections.abc import Mapping
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation
 from typing import Any, Protocol
 
@@ -24,6 +25,13 @@ from .broker_mutation_receipts import (
     BrokerMutationIoPermitExpectation,
     consume_broker_mutation_io_permit,
     fingerprint_broker_endpoint,
+)
+from .infrastructure_validation import (
+    InfrastructureValidationOrderPlan,
+    InfrastructureValidationPermit,
+    authorize_infrastructure_validation_order,
+    infrastructure_validation_client_order_id,
+    infrastructure_validation_request_payload,
 )
 
 logger = logging.getLogger(__name__)
@@ -321,6 +329,58 @@ class OrderFirewall:
             ),
         )
         return self._submit_payload(request_payload, normalized_request.extra_params)
+
+    def submit_verified_infrastructure_validation_order(
+        self,
+        permit: InfrastructureValidationPermit,
+        plan: InfrastructureValidationOrderPlan,
+        *,
+        mutation_permit: BrokerMutationIoPermit,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        """Submit one exact paper IOC whose evidence can never promote capital."""
+
+        evaluated_at = now or datetime.now(timezone.utc)
+        authorize_infrastructure_validation_order(
+            permit,
+            plan,
+            account_label=self.account_label,
+            account_mode="paper",
+            broker_base_url=self.broker_endpoint_url,
+            now=evaluated_at,
+        )
+        client_order_id = infrastructure_validation_client_order_id(permit, plan)
+        request = AlpacaSubmitRequest(
+            symbol=plan.symbol,
+            side=plan.side,
+            qty=plan.qty,
+            order_type=plan.order_type,
+            time_in_force=plan.time_in_force,
+            limit_price=plan.limit_price,
+            stop_price=None,
+            extra_params={"client_order_id": client_order_id},
+        )
+        broker_request = alpaca_submit_request_payload(request)
+        status = self.status()
+        if status.kill_switch_enabled:
+            raise OrderFirewallBlocked(status.reason)
+        consume_broker_mutation_io_permit(
+            mutation_permit,
+            expectation=BrokerMutationIoPermitExpectation(
+                broker_route="alpaca",
+                operation="submit_order",
+                risk_class="risk_neutral",
+                account_label=self.account_label,
+                endpoint_fingerprint=fingerprint_broker_endpoint(
+                    self.broker_endpoint_url
+                ),
+                request_payload=infrastructure_validation_request_payload(
+                    permit,
+                    plan,
+                ),
+            ),
+        )
+        return self._submit_payload(broker_request, request.extra_params)
 
     def _submit_payload(
         self,

--- a/services/torghut/app/trading/infrastructure_validation.py
+++ b/services/torghut/app/trading/infrastructure_validation.py
@@ -1,11 +1,13 @@
-"""Fail-closed schema for non-promotable broker infrastructure exercises."""
+"""Fail-closed authority for non-promotable broker infrastructure exercises."""
 
 from __future__ import annotations
 
+import hashlib
+import json
 import re
 from datetime import datetime, timedelta
 from decimal import Decimal
-from typing import Annotated, Literal
+from typing import Annotated, Literal, Mapping
 
 from pydantic import (
     AnyHttpUrl,
@@ -18,11 +20,14 @@ from pydantic import (
 )
 
 _MAX_PERMIT_LIFETIME = timedelta(minutes=15)
+_MAX_SUBMIT_PROOF_NOTIONAL_USD = Decimal("1")
 _VALIDATION_HOSTS = {
     "alpaca": "paper-api.alpaca.markets",
     "hyperliquid": "api.hyperliquid-testnet.xyz",
 }
 _Digest = Annotated[str, StringConstraints(pattern=r"^[0-9a-f]{64}$")]
+_EXPECTED_TERMINAL_STATE = "no_open_orders_no_positions_no_unsettled_claims"
+_EXPECTED_TERMINAL_SCHEMA_VERSION = "torghut.infrastructure-validation-terminal.v1"
 
 
 class InfrastructureValidationPermit(BaseModel):
@@ -30,13 +35,14 @@ class InfrastructureValidationPermit(BaseModel):
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    schema_version: Literal["torghut.infrastructure-validation-permit.v1"]
+    schema_version: Literal["torghut.infrastructure-validation-permit.v2"]
     permit_id: Annotated[str, StringConstraints(min_length=1, max_length=128)]
     purpose: Literal["control_plane_validation"]
     venue: Literal["alpaca", "hyperliquid"]
+    asset_class: Literal["equity", "crypto", "perpetual"]
     account_mode: Literal["paper", "sandbox"]
     market_session: Literal["regular", "continuous"]
-    account_label: Annotated[str, StringConstraints(min_length=1, max_length=128)]
+    account_label: Annotated[str, StringConstraints(min_length=1, max_length=64)]
     broker_base_url: AnyHttpUrl
     symbols: tuple[str, ...] = Field(min_length=1, max_length=20)
     sides: tuple[Literal["buy", "sell"], ...] = Field(min_length=1, max_length=2)
@@ -68,14 +74,11 @@ class InfrastructureValidationPermit(BaseModel):
     @field_validator("symbols")
     @classmethod
     def _normalize_symbols(cls, values: tuple[str, ...]) -> tuple[str, ...]:
-        normalized = tuple(value.strip().upper() for value in values)
+        normalized = tuple(value.strip() for value in values)
         if (
             not normalized
-            or len(set(normalized)) != len(normalized)
-            or any(
-                re.fullmatch(r"[A-Z0-9][A-Z0-9.-]{0,31}", value) is None
-                for value in normalized
-            )
+            or len({value.casefold() for value in normalized}) != len(normalized)
+            or any(not value for value in normalized)
         ):
             raise ValueError("validation_symbols_must_be_unique_and_nonempty")
         return normalized
@@ -108,13 +111,62 @@ class InfrastructureValidationPermit(BaseModel):
         if self.max_loss_usd > self.max_notional_usd:
             raise ValueError("validation_permit_loss_exceeds_notional")
         expected_mode_and_session = {
-            "alpaca": ("paper", "regular"),
-            "hyperliquid": ("sandbox", "continuous"),
-        }[self.venue]
+            ("alpaca", "equity"): ("paper", "regular"),
+            ("alpaca", "crypto"): ("paper", "continuous"),
+            ("hyperliquid", "perpetual"): ("sandbox", "continuous"),
+        }.get((self.venue, self.asset_class))
+        if expected_mode_and_session is None:
+            raise ValueError("validation_permit_asset_class_boundary_mismatch")
         if (self.account_mode, self.market_session) != expected_mode_and_session:
             raise ValueError("validation_permit_venue_boundary_mismatch")
+        if any(
+            not _valid_symbol_for_asset_class(symbol, self.asset_class)
+            for symbol in self.symbols
+        ):
+            raise ValueError("validation_permit_symbol_asset_class_mismatch")
         _validate_endpoint(self.venue, str(self.broker_base_url))
         return self
+
+
+class InfrastructureValidationOrderPlan(BaseModel):
+    """One known-null Alpaca IOC submit plan bound into a validation permit."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal["torghut.infrastructure-validation-order-plan.v1"]
+    venue: Literal["alpaca"]
+    asset_class: Literal["crypto"]
+    symbol: Annotated[str, StringConstraints(min_length=1, max_length=32)]
+    side: Literal["buy"]
+    qty: Decimal = Field(gt=0)
+    order_type: Literal["limit"]
+    time_in_force: Literal["ioc"]
+    limit_price: Decimal = Field(gt=0)
+    stop_price: None = None
+
+    @field_validator("symbol")
+    @classmethod
+    def _normalize_symbol(cls, value: str) -> str:
+        return value.strip().upper()
+
+    @field_validator("qty", "limit_price")
+    @classmethod
+    def _require_finite_order_decimal(cls, value: Decimal) -> Decimal:
+        if not value.is_finite():
+            raise ValueError("infrastructure_validation_order_decimal_not_finite")
+        return value
+
+    @model_validator(mode="after")
+    def _validate_asset_symbol(self) -> "InfrastructureValidationOrderPlan":
+        if not _valid_symbol_for_asset_class(self.symbol, self.asset_class):
+            raise ValueError("infrastructure_validation_order_symbol_invalid")
+        if not (self.qty * self.limit_price).is_finite():
+            raise ValueError("infrastructure_validation_order_notional_not_finite")
+        return self
+
+    @property
+    def notional_usd(self) -> Decimal:
+        return self.qty * self.limit_price
 
 
 def authorize_infrastructure_validation(
@@ -139,6 +191,132 @@ def authorize_infrastructure_validation(
         raise ValueError("infrastructure_validation_account_mismatch")
     _validate_endpoint(permit.venue, broker_base_url)
     return permit
+
+
+def authorize_infrastructure_validation_order(
+    permit: InfrastructureValidationPermit,
+    plan: InfrastructureValidationOrderPlan,
+    *,
+    account_label: str,
+    account_mode: str,
+    broker_base_url: str,
+    now: datetime,
+) -> InfrastructureValidationPermit:
+    """Bind one deterministic known-null IOC plan to one non-live account."""
+
+    authorize_infrastructure_validation(
+        permit,
+        account_label=account_label,
+        account_mode=account_mode,
+        broker_base_url=broker_base_url,
+        now=now,
+    )
+    if permit.venue != "alpaca" or plan.venue != permit.venue:
+        raise ValueError("infrastructure_validation_order_venue_mismatch")
+    if plan.asset_class != permit.asset_class:
+        raise ValueError("infrastructure_validation_order_asset_class_mismatch")
+    if permit.max_orders != 1 or permit.max_outstanding_intents != 1:
+        raise ValueError("infrastructure_validation_submit_requires_single_intent")
+    if plan.symbol not in permit.symbols:
+        raise ValueError("infrastructure_validation_order_symbol_out_of_bounds")
+    if plan.side not in permit.sides:
+        raise ValueError("infrastructure_validation_order_side_out_of_bounds")
+    if plan.order_type not in permit.order_types:
+        raise ValueError("infrastructure_validation_order_type_out_of_bounds")
+    if (
+        permit.symbols != (plan.symbol,)
+        or permit.sides != (plan.side,)
+        or permit.order_types != (plan.order_type,)
+    ):
+        raise ValueError("infrastructure_validation_submit_bounds_not_exact")
+    if plan.notional_usd > permit.max_notional_usd:
+        raise ValueError("infrastructure_validation_order_notional_out_of_bounds")
+    if plan.notional_usd > permit.max_loss_usd:
+        raise ValueError("infrastructure_validation_order_loss_out_of_bounds")
+    if (
+        permit.max_notional_usd > _MAX_SUBMIT_PROOF_NOTIONAL_USD
+        or permit.max_loss_usd > _MAX_SUBMIT_PROOF_NOTIONAL_USD
+        or plan.notional_usd > _MAX_SUBMIT_PROOF_NOTIONAL_USD
+    ):
+        raise ValueError("infrastructure_validation_submit_exceeds_absolute_cap")
+    if infrastructure_validation_order_plan_sha256(plan) != permit.test_plan_digest:
+        raise ValueError("infrastructure_validation_order_plan_digest_mismatch")
+    if (
+        infrastructure_validation_terminal_state_sha256()
+        != permit.expected_terminal_state_digest
+    ):
+        raise ValueError("infrastructure_validation_terminal_digest_mismatch")
+    return permit
+
+
+def infrastructure_validation_order_plan_sha256(
+    plan: InfrastructureValidationOrderPlan,
+) -> str:
+    return _canonical_model_sha256(plan)
+
+
+def infrastructure_validation_terminal_state_payload() -> dict[str, str]:
+    return {
+        "schema_version": _EXPECTED_TERMINAL_SCHEMA_VERSION,
+        "state": _EXPECTED_TERMINAL_STATE,
+    }
+
+
+def infrastructure_validation_terminal_state_sha256() -> str:
+    payload = infrastructure_validation_terminal_state_payload()
+    return hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def infrastructure_validation_permit_sha256(
+    permit: InfrastructureValidationPermit,
+) -> str:
+    return _canonical_model_sha256(permit)
+
+
+def infrastructure_validation_client_order_id(
+    permit: InfrastructureValidationPermit,
+    plan: InfrastructureValidationOrderPlan,
+) -> str:
+    """Return the sole broker identity available to this immutable permit."""
+
+    identity = hashlib.sha256(
+        (
+            f"{permit.permit_id}\x1f{infrastructure_validation_permit_sha256(permit)}"
+            f"\x1f{infrastructure_validation_order_plan_sha256(plan)}"
+        ).encode("utf-8")
+    ).hexdigest()
+    return f"ivp-{identity[:44]}"
+
+
+def infrastructure_validation_request_payload(
+    permit: InfrastructureValidationPermit,
+    plan: InfrastructureValidationOrderPlan,
+) -> dict[str, object]:
+    """Build the exact non-promotable envelope sealed into the durable intent."""
+
+    client_order_id = infrastructure_validation_client_order_id(permit, plan)
+    permit_payload = permit.model_dump(mode="json")
+    plan_payload = plan.model_dump(mode="json")
+    return {
+        "broker_request": {
+            "symbol": plan.symbol,
+            "side": plan.side,
+            "qty": str(plan.qty),
+            "order_type": plan.order_type,
+            "time_in_force": plan.time_in_force,
+            "limit_price": str(plan.limit_price),
+            "stop_price": None,
+            "extra_params": {"client_order_id": client_order_id},
+        },
+        "infrastructure_validation": {
+            "permit": permit_payload,
+            "permit_sha256": infrastructure_validation_permit_sha256(permit),
+            "test_plan": plan_payload,
+            "test_plan_sha256": infrastructure_validation_order_plan_sha256(plan),
+            "expected_terminal_state": infrastructure_validation_terminal_state_payload(),
+            "expected_terminal_state_sha256": infrastructure_validation_terminal_state_sha256(),
+        },
+    }
 
 
 def _validate_endpoint(venue: str, endpoint: str) -> None:
@@ -166,7 +344,41 @@ def _parse_endpoint(endpoint: str) -> AnyHttpUrl:
     return parsed
 
 
+def _valid_symbol_for_asset_class(symbol: str, asset_class: str) -> bool:
+    patterns = {
+        "equity": r"[A-Z][A-Z0-9.-]{0,31}",
+        "crypto": r"[A-Z0-9][A-Z0-9.-]{0,15}/[A-Z0-9][A-Z0-9.-]{0,15}",
+        "perpetual": r"(?:[A-Z0-9][A-Z0-9.-]{0,31}|[a-z][a-z0-9-]{0,15}:[A-Z0-9][A-Z0-9.-]{0,31})",
+    }
+    pattern = patterns.get(asset_class)
+    return pattern is not None and re.fullmatch(pattern, symbol) is not None
+
+
+def _canonical_model_sha256(model: BaseModel) -> str:
+    return hashlib.sha256(
+        _canonical_json(model.model_dump(mode="json")).encode("utf-8")
+    ).hexdigest()
+
+
+def _canonical_json(payload: Mapping[str, object]) -> str:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+
+
 __all__ = [
     "InfrastructureValidationPermit",
+    "InfrastructureValidationOrderPlan",
     "authorize_infrastructure_validation",
+    "authorize_infrastructure_validation_order",
+    "infrastructure_validation_client_order_id",
+    "infrastructure_validation_order_plan_sha256",
+    "infrastructure_validation_permit_sha256",
+    "infrastructure_validation_request_payload",
+    "infrastructure_validation_terminal_state_payload",
+    "infrastructure_validation_terminal_state_sha256",
 ]

--- a/services/torghut/app/trading/infrastructure_validation.py
+++ b/services/torghut/app/trading/infrastructure_validation.py
@@ -198,7 +198,6 @@ def authorize_infrastructure_validation_order(
     plan: InfrastructureValidationOrderPlan,
     *,
     account_label: str,
-    account_mode: str,
     broker_base_url: str,
     now: datetime,
 ) -> InfrastructureValidationPermit:
@@ -207,7 +206,7 @@ def authorize_infrastructure_validation_order(
     authorize_infrastructure_validation(
         permit,
         account_label=account_label,
-        account_mode=account_mode,
+        account_mode="paper",
         broker_base_url=broker_base_url,
         now=now,
     )

--- a/services/torghut/app/trading/infrastructure_validation_records.py
+++ b/services/torghut/app/trading/infrastructure_validation_records.py
@@ -1,0 +1,146 @@
+"""Database-backed exclusion contract for infrastructure-validation events."""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, cast
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from ..models import BrokerMutationReceipt, coerce_json_payload
+from .evidence_contracts import (
+    ArtifactProvenance,
+    EvidenceMaturity,
+    evidence_contract_payload,
+)
+
+
+_EVIDENCE_KEY = "_torghut_evidence_contract"
+_EVIDENCE_SCHEMA_VERSION = "torghut.order-event-evidence-contract.v1"
+_EVIDENCE_TAG = ArtifactProvenance.NON_PROMOTABLE_VALIDATION.value
+
+
+@dataclass(frozen=True, slots=True)
+class InfrastructureValidationEvidence:
+    receipt_id: uuid.UUID
+    permit_id: str
+    permit_sha256: str
+
+
+def load_infrastructure_validation_evidence(
+    session: Session,
+    *,
+    account_label: str,
+    client_order_id: str | None,
+) -> InfrastructureValidationEvidence | None:
+    """Resolve a broker order identity to its immutable validation receipt."""
+
+    normalized_client_order_id = str(client_order_id or "").strip()
+    if not normalized_client_order_id.startswith("ivp-"):
+        return None
+    receipts = (
+        session.execute(
+            select(BrokerMutationReceipt).where(
+                BrokerMutationReceipt.account_label == account_label,
+                BrokerMutationReceipt.client_request_id == normalized_client_order_id,
+                BrokerMutationReceipt.purpose == "control_plane_validation",
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if not receipts:
+        return None
+    if len(receipts) != 1:
+        raise RuntimeError("infrastructure_validation_receipt_identity_split")
+    receipt = receipts[0]
+    try:
+        intent = json.loads(receipt.canonical_intent_json)
+        validation = intent["request"]["infrastructure_validation"]
+        permit = validation["permit"]
+        permit_id = str(permit["permit_id"]).strip()
+        permit_sha256 = str(validation["permit_sha256"]).strip()
+        evidence_tag = permit["evidence_tag"]
+        promotable = permit["promotable"]
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise RuntimeError(
+            "infrastructure_validation_receipt_evidence_invalid"
+        ) from exc
+    if (
+        not permit_id
+        or re.fullmatch(r"[0-9a-f]{64}", permit_sha256) is None
+        or evidence_tag != _EVIDENCE_TAG
+        or promotable is not False
+    ):
+        raise RuntimeError("infrastructure_validation_receipt_evidence_invalid")
+    return InfrastructureValidationEvidence(
+        receipt_id=receipt.id,
+        permit_id=permit_id,
+        permit_sha256=permit_sha256,
+    )
+
+
+def tag_infrastructure_validation_event(
+    raw_event: object,
+    evidence: InfrastructureValidationEvidence,
+) -> Any:
+    """Attach a database-proven non-promotable marker to one broker event."""
+
+    coerced = coerce_json_payload(raw_event)
+    payload = (
+        {str(key): value for key, value in cast(Mapping[object, Any], coerced).items()}
+        if isinstance(coerced, Mapping)
+        else {"payload": coerced}
+    )
+    payload[_EVIDENCE_KEY] = {
+        "schema_version": _EVIDENCE_SCHEMA_VERSION,
+        **evidence_contract_payload(
+            provenance=ArtifactProvenance.NON_PROMOTABLE_VALIDATION,
+            maturity=EvidenceMaturity.EMPIRICALLY_VALIDATED,
+        ),
+        "promotable": False,
+        "broker_mutation_receipt_id": str(evidence.receipt_id),
+        "permit_id": evidence.permit_id,
+        "permit_sha256": evidence.permit_sha256,
+    }
+    return coerce_json_payload(payload)
+
+
+def is_non_promotable_validation_event(raw_event: object) -> bool:
+    """Return whether a persisted event carries the exact exclusion marker."""
+
+    coerced = coerce_json_payload(raw_event)
+    if not isinstance(coerced, Mapping):
+        return False
+    evidence = cast(Mapping[object, Any], coerced).get(_EVIDENCE_KEY)
+    if not isinstance(evidence, Mapping):
+        return False
+    values = cast(Mapping[object, Any], evidence)
+    return (
+        values.get("schema_version") == _EVIDENCE_SCHEMA_VERSION
+        and values.get("provenance") == _EVIDENCE_TAG
+        and values.get("maturity") == EvidenceMaturity.EMPIRICALLY_VALIDATED.value
+        and values.get("authoritative") is False
+        and values.get("placeholder") is False
+        and values.get("promotable") is False
+        and bool(str(values.get("broker_mutation_receipt_id") or "").strip())
+        and bool(str(values.get("permit_id") or "").strip())
+        and re.fullmatch(
+            r"[0-9a-f]{64}",
+            str(values.get("permit_sha256") or ""),
+        )
+        is not None
+    )
+
+
+__all__ = [
+    "InfrastructureValidationEvidence",
+    "is_non_promotable_validation_event",
+    "load_infrastructure_validation_evidence",
+    "tag_infrastructure_validation_event",
+]

--- a/services/torghut/app/trading/infrastructure_validation_records.py
+++ b/services/torghut/app/trading/infrastructure_validation_records.py
@@ -7,7 +7,7 @@ import re
 import uuid
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import cast
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -88,12 +88,15 @@ def load_infrastructure_validation_evidence(
 def tag_infrastructure_validation_event(
     raw_event: object,
     evidence: InfrastructureValidationEvidence,
-) -> Any:
+) -> object:
     """Attach a database-proven non-promotable marker to one broker event."""
 
     coerced = coerce_json_payload(raw_event)
     payload = (
-        {str(key): value for key, value in cast(Mapping[object, Any], coerced).items()}
+        {
+            str(key): value
+            for key, value in cast(Mapping[object, object], coerced).items()
+        }
         if isinstance(coerced, Mapping)
         else {"payload": coerced}
     )
@@ -117,10 +120,10 @@ def is_non_promotable_validation_event(raw_event: object) -> bool:
     coerced = coerce_json_payload(raw_event)
     if not isinstance(coerced, Mapping):
         return False
-    evidence = cast(Mapping[object, Any], coerced).get(_EVIDENCE_KEY)
+    evidence = cast(Mapping[object, object], coerced).get(_EVIDENCE_KEY)
     if not isinstance(evidence, Mapping):
         return False
-    values = cast(Mapping[object, Any], evidence)
+    values = cast(Mapping[object, object], evidence)
     return (
         values.get("schema_version") == _EVIDENCE_SCHEMA_VERSION
         and values.get("provenance") == _EVIDENCE_TAG

--- a/services/torghut/app/trading/infrastructure_validation_submit.py
+++ b/services/torghut/app/trading/infrastructure_validation_submit.py
@@ -1,0 +1,600 @@
+"""Bounded runtime proof for one permit-fenced Alpaca paper submission."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import threading
+import time
+from collections.abc import Callable, Mapping
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any, Protocol, cast
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from ..alpaca_client import TorghutAlpacaClient
+from ..config import settings
+from ..db import SessionLocal
+from ..models import (
+    BrokerMutationReceipt,
+    BrokerMutationReceiptEvent,
+    Execution,
+    ExecutionOrderEvent,
+    TigerBeetleTransferRef,
+    TradeDecision,
+    TradeDecisionSubmissionClaim,
+)
+from .broker_mutation_receipts import (
+    BrokerMutationIoPermit,
+    BrokerMutationSettlement,
+    BrokerMutationSettlementRequest,
+    build_broker_mutation_settlement,
+)
+from .broker_mutation_submit_coordinator import (
+    BrokerMutationSubmissionAlreadyProcessed,
+    BrokerMutationSubmissionDeferred,
+    BrokerMutationSubmitCoordinator,
+    InfrastructureValidationOrderSubmission,
+    UnlinkedOrderSubmissionCallbacks,
+)
+from .firewall import OrderFirewall
+from .infrastructure_validation import (
+    InfrastructureValidationOrderPlan,
+    InfrastructureValidationPermit,
+    authorize_infrastructure_validation_order,
+    infrastructure_validation_client_order_id,
+    infrastructure_validation_permit_sha256,
+)
+from .infrastructure_validation_records import (
+    is_non_promotable_validation_event,
+)
+
+
+_TERMINAL_ORDER_STATUSES = frozenset(
+    {"canceled", "cancelled", "done_for_day", "expired", "filled", "rejected"}
+)
+_KNOWN_NULL_ORDER_STATUSES = frozenset({"canceled", "cancelled", "expired", "rejected"})
+
+
+class _ValidationAlpacaClient(Protocol):
+    endpoint_class: str
+    endpoint_url: str
+
+    def get_account(self) -> dict[str, Any]: ...
+
+    def get_asset(self, symbol_or_asset_id: str) -> dict[str, Any] | None: ...
+
+    def get_order_by_client_order_id_strict(
+        self,
+        client_order_id: str,
+    ) -> dict[str, object] | None: ...
+
+    def list_open_orders(self) -> list[dict[str, Any]]: ...
+
+    def list_positions(self) -> list[dict[str, Any]]: ...
+
+
+@dataclass(frozen=True, slots=True)
+class InfrastructureValidationSubmitReport:
+    schema_version: str
+    observed_at: str
+    permit_id: str
+    permit_sha256: str
+    broker_account_number: str
+    client_order_id: str
+    broker_order_id: str
+    broker_order_status: str
+    receipt_id: str
+    receipt_state: str
+    settlement_outcome: str
+    race_outcomes: tuple[str, ...]
+    replay_outcome: str
+    broker_call_count: int
+    receipt_count: int
+    submission_claim_count: int
+    execution_count: int
+    trade_decision_count: int
+    order_event_count: int
+    linked_order_event_count: int
+    tigerbeetle_transfer_ref_count: int
+    preflight_position_count: int
+    preflight_open_order_count: int
+    terminal_position_count: int
+    terminal_open_order_count: int
+    evidence_tag: str
+    promotable: bool
+
+    def to_payload(self) -> dict[str, object]:
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class _WorkerResult:
+    outcome: str
+    broker_result: Mapping[str, object] | None = None
+    error: str | None = None
+
+
+@dataclass(slots=True)
+class _BrokerCallCounter:
+    value: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class _DatabaseProof:
+    receipt_id: object
+    receipt_state: str
+    settlement_outcome: str
+    broker_reference: str
+    receipt_count: int
+    submission_claim_count: int
+    execution_count: int
+    trade_decision_count: int
+    order_event_count: int
+    linked_order_event_count: int
+    tigerbeetle_transfer_ref_count: int
+
+
+def run_infrastructure_validation_submit(
+    *,
+    permit: InfrastructureValidationPermit,
+    plan: InfrastructureValidationOrderPlan,
+    client: _ValidationAlpacaClient,
+    session_factory: Callable[[], Session],
+    configured_account_label: str,
+    now: datetime | None = None,
+    race_timeout_seconds: float = 10.0,
+    terminal_timeout_seconds: float = 30.0,
+) -> InfrastructureValidationSubmitReport:
+    """Race one duplicate intent and prove one broker call plus one receipt."""
+
+    evaluated_at = now or datetime.now(timezone.utc)
+    account_label = configured_account_label.strip()
+    if not account_label or account_label != permit.account_label:
+        raise RuntimeError("infrastructure_validation_configured_account_mismatch")
+    if client.endpoint_class != "paper":
+        raise RuntimeError("infrastructure_validation_client_not_paper")
+    authorize_infrastructure_validation_order(
+        permit,
+        plan,
+        account_label=account_label,
+        account_mode="paper",
+        broker_base_url=client.endpoint_url,
+        now=evaluated_at,
+    )
+    account = client.get_account()
+    broker_account_number = _validate_broker_account(
+        account,
+        permit=permit,
+        plan=plan,
+    )
+    asset = client.get_asset(plan.symbol)
+    _validate_broker_asset(asset, plan=plan)
+    preflight_positions = client.list_positions()
+    preflight_orders = client.list_open_orders()
+    if preflight_positions or preflight_orders:
+        raise RuntimeError("infrastructure_validation_account_not_known_null")
+
+    firewall = OrderFirewall(cast(Any, client), account_label=account_label)
+    if firewall.status().kill_switch_enabled:
+        raise RuntimeError("infrastructure_validation_kill_switch_enabled")
+    request = InfrastructureValidationOrderSubmission(
+        permit=permit,
+        plan=plan,
+        account_label=account_label,
+        account_mode="paper",
+        endpoint_url=client.endpoint_url,
+    )
+    broker_started = threading.Event()
+    contender_finished = threading.Event()
+    broker_call_lock = threading.Lock()
+    broker_call_counter = _BrokerCallCounter()
+
+    def broker_call(mutation_permit: BrokerMutationIoPermit) -> Mapping[str, object]:
+        with broker_call_lock:
+            broker_call_counter.value += 1
+        broker_started.set()
+        if not contender_finished.wait(timeout=race_timeout_seconds):
+            raise RuntimeError("infrastructure_validation_race_contender_timeout")
+        return firewall.submit_verified_infrastructure_validation_order(
+            permit,
+            plan,
+            mutation_permit=mutation_permit,
+        )
+
+    callbacks = UnlinkedOrderSubmissionCallbacks(
+        broker_call=broker_call,
+        persist_terminal=lambda _result: None,
+        build_settlement=lambda result: _validation_settlement(
+            result,
+            permit=permit,
+            plan=plan,
+        ),
+    )
+
+    def submit(component: str) -> _WorkerResult:
+        with session_factory() as session:
+            try:
+                result = BrokerMutationSubmitCoordinator(
+                    component
+                ).submit_infrastructure_validation_order(
+                    session,
+                    request=request,
+                    callbacks=callbacks,
+                )
+            except BrokerMutationSubmissionAlreadyProcessed as exc:
+                return _WorkerResult("already_processed", error=str(exc))
+            except BrokerMutationSubmissionDeferred as exc:
+                return _WorkerResult(
+                    "deferred",
+                    error=f"{type(exc).__name__}:{exc}",
+                )
+        return _WorkerResult("submitted", result)
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            winner = executor.submit(submit, "validation-primary")
+            if not broker_started.wait(timeout=race_timeout_seconds):
+                raise RuntimeError("infrastructure_validation_broker_boundary_timeout")
+            contender = executor.submit(submit, "validation-contender")
+            try:
+                contender_result = contender.result(timeout=race_timeout_seconds)
+            finally:
+                contender_finished.set()
+            winner_result = winner.result(timeout=race_timeout_seconds)
+    finally:
+        contender_finished.set()
+
+    race_results = (winner_result, contender_result)
+    if sorted(result.outcome for result in race_results) != ["deferred", "submitted"]:
+        reasons = ";".join(
+            f"{result.outcome}:{result.error or 'none'}" for result in race_results
+        )
+        raise RuntimeError(f"infrastructure_validation_race_outcome_invalid:{reasons}")
+    if broker_call_counter.value != 1:
+        raise RuntimeError("infrastructure_validation_broker_call_count_invalid")
+    submitted = next(result for result in race_results if result.outcome == "submitted")
+    if submitted.broker_result is None:
+        raise RuntimeError("infrastructure_validation_broker_result_missing")
+
+    replay = submit("validation-replay")
+    if replay.outcome != "already_processed":
+        raise RuntimeError("infrastructure_validation_replay_not_fenced")
+
+    client_order_id = infrastructure_validation_client_order_id(permit, plan)
+    broker_order = _wait_for_terminal_order(
+        client,
+        client_order_id=client_order_id,
+        timeout_seconds=terminal_timeout_seconds,
+    )
+    terminal_positions, terminal_orders = _wait_for_known_null_account(
+        client,
+        timeout_seconds=terminal_timeout_seconds,
+    )
+
+    database = _load_database_proof(
+        session_factory,
+        client_order_id=client_order_id,
+    )
+    broker_order_id = str(broker_order.get("id") or "").strip()
+    if broker_order_id != database.broker_reference:
+        raise RuntimeError("infrastructure_validation_broker_reference_mismatch")
+    return InfrastructureValidationSubmitReport(
+        schema_version="torghut.infrastructure-validation-submit-report.v1",
+        observed_at=datetime.now(timezone.utc).isoformat(),
+        permit_id=permit.permit_id,
+        permit_sha256=infrastructure_validation_permit_sha256(permit),
+        broker_account_number=broker_account_number,
+        client_order_id=client_order_id,
+        broker_order_id=broker_order_id,
+        broker_order_status=str(broker_order.get("status") or "").lower(),
+        receipt_id=str(database.receipt_id),
+        receipt_state=database.receipt_state,
+        settlement_outcome=database.settlement_outcome,
+        race_outcomes=tuple(result.outcome for result in race_results),
+        replay_outcome=replay.outcome,
+        broker_call_count=broker_call_counter.value,
+        receipt_count=database.receipt_count,
+        submission_claim_count=database.submission_claim_count,
+        execution_count=database.execution_count,
+        trade_decision_count=database.trade_decision_count,
+        order_event_count=database.order_event_count,
+        linked_order_event_count=database.linked_order_event_count,
+        tigerbeetle_transfer_ref_count=database.tigerbeetle_transfer_ref_count,
+        preflight_position_count=len(preflight_positions),
+        preflight_open_order_count=len(preflight_orders),
+        terminal_position_count=len(terminal_positions),
+        terminal_open_order_count=len(terminal_orders),
+        evidence_tag="non_promotable_validation",
+        promotable=False,
+    )
+
+
+def _validation_settlement(
+    result: Mapping[str, object],
+    *,
+    permit: InfrastructureValidationPermit,
+    plan: InfrastructureValidationOrderPlan,
+) -> BrokerMutationSettlement:
+    broker_reference = str(result.get("id") or result.get("order_id") or "").strip()
+    if not broker_reference:
+        raise ValueError("infrastructure_validation_broker_reference_missing")
+    return build_broker_mutation_settlement(
+        BrokerMutationSettlementRequest(
+            source="primary",
+            outcome="acknowledged",
+            broker_reference=broker_reference,
+            execution_id=None,
+            evidence_payload={
+                "schema_version": "torghut.infrastructure-validation-submit-terminal.v1",
+                "broker_status": str(result.get("status") or "unknown").lower(),
+                "client_order_id": infrastructure_validation_client_order_id(
+                    permit,
+                    plan,
+                ),
+                "evidence_tag": "non_promotable_validation",
+                "permit_id": permit.permit_id,
+                "permit_sha256": infrastructure_validation_permit_sha256(permit),
+                "promotable": False,
+            },
+        )
+    )
+
+
+def _wait_for_terminal_order(
+    client: _ValidationAlpacaClient,
+    *,
+    client_order_id: str,
+    timeout_seconds: float,
+) -> Mapping[str, object]:
+    deadline = time.monotonic() + timeout_seconds
+    latest: Mapping[str, object] | None = None
+    while time.monotonic() < deadline:
+        latest = client.get_order_by_client_order_id_strict(client_order_id)
+        status = str((latest or {}).get("status") or "").strip().lower()
+        if latest is not None and status in _TERMINAL_ORDER_STATUSES:
+            _require_known_null_terminal_order(
+                latest,
+                client_order_id=client_order_id,
+            )
+            return latest
+        time.sleep(0.5)
+    raise RuntimeError(
+        "infrastructure_validation_broker_order_not_terminal:"
+        f"{str((latest or {}).get('status') or 'missing')}"
+    )
+
+
+def _require_known_null_terminal_order(
+    order: Mapping[str, object],
+    *,
+    client_order_id: str,
+) -> None:
+    if str(order.get("client_order_id") or "").strip() != client_order_id:
+        raise RuntimeError("infrastructure_validation_broker_order_identity_mismatch")
+    if not str(order.get("id") or "").strip():
+        raise RuntimeError("infrastructure_validation_broker_order_identity_missing")
+    status = str(order.get("status") or "").strip().lower()
+    if status not in _KNOWN_NULL_ORDER_STATUSES:
+        raise RuntimeError("infrastructure_validation_broker_order_status_invalid")
+    try:
+        filled_qty = Decimal(str(order.get("filled_qty")))
+    except (InvalidOperation, ValueError) as exc:
+        raise RuntimeError(
+            "infrastructure_validation_broker_order_filled_qty_invalid"
+        ) from exc
+    if not filled_qty.is_finite() or filled_qty < 0:
+        raise RuntimeError("infrastructure_validation_broker_order_filled_qty_invalid")
+    if filled_qty != 0:
+        raise RuntimeError("infrastructure_validation_broker_order_fill_observed")
+
+
+def _wait_for_known_null_account(
+    client: _ValidationAlpacaClient,
+    *,
+    timeout_seconds: float,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    deadline = time.monotonic() + timeout_seconds
+    positions: list[dict[str, Any]] = []
+    orders: list[dict[str, Any]] = []
+    while time.monotonic() < deadline:
+        positions = client.list_positions()
+        orders = client.list_open_orders()
+        if not positions and not orders:
+            return positions, orders
+        time.sleep(0.5)
+    raise RuntimeError(
+        "infrastructure_validation_terminal_account_not_null:"
+        f"positions={len(positions)}:open_orders={len(orders)}"
+    )
+
+
+def _validate_broker_account(
+    account: Mapping[str, object],
+    *,
+    permit: InfrastructureValidationPermit,
+    plan: InfrastructureValidationOrderPlan,
+) -> str:
+    account_number = str(account.get("account_number") or "").strip()
+    if not account_number or account_number != permit.account_label:
+        raise RuntimeError("infrastructure_validation_broker_account_mismatch")
+    if str(account.get("status") or "").strip().upper() != "ACTIVE":
+        raise RuntimeError("infrastructure_validation_broker_account_not_active")
+    if any(
+        account.get(field) is True
+        for field in ("account_blocked", "trading_blocked", "trade_suspended_by_user")
+    ):
+        raise RuntimeError("infrastructure_validation_broker_account_blocked")
+    if str(account.get("crypto_status") or "").strip().upper() != "ACTIVE":
+        raise RuntimeError("infrastructure_validation_broker_crypto_not_active")
+    return account_number
+
+
+def _validate_broker_asset(
+    asset: Mapping[str, object] | None,
+    *,
+    plan: InfrastructureValidationOrderPlan,
+) -> None:
+    if not asset or not bool(asset.get("tradable")):
+        raise RuntimeError("infrastructure_validation_asset_not_tradable")
+    observed_asset_class = str(asset.get("asset_class") or "").strip().lower()
+    if observed_asset_class != "crypto":
+        raise RuntimeError("infrastructure_validation_broker_asset_class_mismatch")
+    if str(asset.get("status") or "").strip().lower() != "active":
+        raise RuntimeError("infrastructure_validation_asset_not_active")
+
+
+def _load_database_proof(
+    session_factory: Callable[[], Session],
+    *,
+    client_order_id: str,
+) -> _DatabaseProof:
+    with session_factory() as session:
+        receipts = (
+            session.execute(
+                select(BrokerMutationReceipt).where(
+                    BrokerMutationReceipt.client_request_id == client_order_id
+                )
+            )
+            .scalars()
+            .all()
+        )
+        if len(receipts) != 1:
+            raise RuntimeError("infrastructure_validation_receipt_count_invalid")
+        receipt = receipts[0]
+        latest = session.execute(
+            select(BrokerMutationReceiptEvent)
+            .where(BrokerMutationReceiptEvent.receipt_id == receipt.id)
+            .order_by(BrokerMutationReceiptEvent.sequence_no.desc())
+            .limit(1)
+        ).scalar_one()
+        if latest.state != "settled" or latest.settlement_outcome != "acknowledged":
+            raise RuntimeError("infrastructure_validation_receipt_not_terminal")
+        broker_reference = str(latest.broker_reference or "").strip()
+        if not broker_reference:
+            raise RuntimeError("infrastructure_validation_receipt_reference_missing")
+        intent = json.loads(receipt.canonical_intent_json)
+        validation = intent["request"]["infrastructure_validation"]
+        if (
+            validation["permit"]["evidence_tag"] != "non_promotable_validation"
+            or validation["permit"]["promotable"] is not False
+        ):
+            raise RuntimeError("infrastructure_validation_evidence_tag_invalid")
+        claim_count = session.scalar(
+            select(func.count())
+            .select_from(TradeDecisionSubmissionClaim)
+            .where(TradeDecisionSubmissionClaim.client_order_id == client_order_id)
+        )
+        execution_count = session.scalar(
+            select(func.count())
+            .select_from(Execution)
+            .where(Execution.client_order_id == client_order_id)
+        )
+        trade_decision_count = session.scalar(
+            select(func.count())
+            .select_from(TradeDecision)
+            .where(TradeDecision.decision_hash == client_order_id)
+        )
+        order_events = session.execute(
+            select(
+                ExecutionOrderEvent.id,
+                ExecutionOrderEvent.execution_id,
+                ExecutionOrderEvent.trade_decision_id,
+                ExecutionOrderEvent.raw_event,
+            ).where(ExecutionOrderEvent.client_order_id == client_order_id)
+        ).all()
+        linked_order_event_count = sum(
+            1
+            for event in order_events
+            if event.execution_id is not None or event.trade_decision_id is not None
+        )
+        untagged_order_event_count = sum(
+            1
+            for event in order_events
+            if not is_non_promotable_validation_event(event.raw_event)
+        )
+        order_event_ids = [event.id for event in order_events]
+        tigerbeetle_transfer_ref_count = (
+            session.scalar(
+                select(func.count())
+                .select_from(TigerBeetleTransferRef)
+                .where(
+                    TigerBeetleTransferRef.execution_order_event_id.in_(order_event_ids)
+                )
+            )
+            if order_event_ids
+            else 0
+        )
+    if claim_count or execution_count or trade_decision_count:
+        raise RuntimeError("infrastructure_validation_candidate_evidence_leak")
+    if linked_order_event_count or untagged_order_event_count:
+        raise RuntimeError("infrastructure_validation_order_event_evidence_leak")
+    if tigerbeetle_transfer_ref_count:
+        raise RuntimeError("infrastructure_validation_ledger_evidence_leak")
+    return _DatabaseProof(
+        receipt_id=receipt.id,
+        receipt_state=latest.state,
+        settlement_outcome=cast(str, latest.settlement_outcome),
+        broker_reference=broker_reference,
+        receipt_count=len(receipts),
+        submission_claim_count=int(claim_count or 0),
+        execution_count=int(execution_count or 0),
+        trade_decision_count=int(trade_decision_count or 0),
+        order_event_count=len(order_events),
+        linked_order_event_count=linked_order_event_count,
+        tigerbeetle_transfer_ref_count=int(tigerbeetle_transfer_ref_count or 0),
+    )
+
+
+def _load_input(
+    path: str,
+) -> tuple[InfrastructureValidationPermit, InfrastructureValidationOrderPlan]:
+    raw = sys.stdin.read() if path == "-" else Path(path).read_text(encoding="utf-8")
+    payload = json.loads(raw)
+    if not isinstance(payload, dict):
+        raise ValueError("infrastructure_validation_input_must_be_object")
+    input_payload = cast(Mapping[str, object], payload)
+    return (
+        InfrastructureValidationPermit.model_validate(input_payload.get("permit")),
+        InfrastructureValidationOrderPlan.model_validate(input_payload.get("plan")),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Run one permit-bound Alpaca-paper durable-submit proof."
+    )
+    parser.add_argument(
+        "--input-file",
+        required=True,
+        help="JSON file containing permit and plan, or - for one stdin line.",
+    )
+    args = parser.parse_args(argv)
+    permit, plan = _load_input(args.input_file)
+    client = TorghutAlpacaClient()
+    report = run_infrastructure_validation_submit(
+        permit=permit,
+        plan=plan,
+        client=client,
+        session_factory=SessionLocal,
+        configured_account_label=settings.trading_account_label,
+    )
+    print(json.dumps(report.to_payload(), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised from the deployed image
+    raise SystemExit(main())
+
+
+__all__ = [
+    "InfrastructureValidationSubmitReport",
+    "main",
+    "run_infrastructure_validation_submit",
+]

--- a/services/torghut/app/trading/infrastructure_validation_submit.py
+++ b/services/torghut/app/trading/infrastructure_validation_submit.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import sys
 import threading
 import time
@@ -81,6 +82,18 @@ class _ValidationAlpacaClient(Protocol):
 
 
 @dataclass(frozen=True, slots=True)
+class InfrastructureValidationSubmitContext:
+    """Runtime dependencies and bounded waits for one validation exercise."""
+
+    client: _ValidationAlpacaClient
+    session_factory: Callable[[], Session]
+    configured_account_label: str
+    evaluated_at: datetime | None = None
+    race_timeout_seconds: float = 10.0
+    terminal_timeout_seconds: float = 30.0
+
+
+@dataclass(frozen=True, slots=True)
 class InfrastructureValidationSubmitReport:
     schema_version: str
     observed_at: str
@@ -127,6 +140,30 @@ class _BrokerCallCounter:
 
 
 @dataclass(frozen=True, slots=True)
+class _ValidationPreflight:
+    account_label: str
+    broker_account_number: str
+    position_count: int
+    open_order_count: int
+    firewall: OrderFirewall
+    request: InfrastructureValidationOrderSubmission
+
+
+@dataclass(frozen=True, slots=True)
+class _SubmissionRaceState:
+    broker_started: threading.Event
+    contender_finished: threading.Event
+    call_counter: _BrokerCallCounter
+
+
+@dataclass(frozen=True, slots=True)
+class _SubmissionRaceProof:
+    outcomes: tuple[str, ...]
+    replay_outcome: str
+    broker_call_count: int
+
+
+@dataclass(frozen=True, slots=True)
 class _DatabaseProof:
     receipt_id: object
     receipt_state: str
@@ -141,30 +178,95 @@ class _DatabaseProof:
     tigerbeetle_transfer_ref_count: int
 
 
+@dataclass(frozen=True, slots=True)
+class _ReceiptProof:
+    receipt_id: object
+    receipt_state: str
+    settlement_outcome: str
+    broker_reference: str
+    receipt_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class _CandidateEvidenceProof:
+    submission_claim_count: int
+    execution_count: int
+    trade_decision_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class _OrderEventProof:
+    order_event_count: int
+    linked_order_event_count: int
+    untagged_order_event_count: int
+    tigerbeetle_transfer_ref_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class _TerminalProof:
+    client_order_id: str
+    broker_order_id: str
+    broker_order_status: str
+    position_count: int
+    open_order_count: int
+    database: _DatabaseProof
+
+
 def run_infrastructure_validation_submit(
     *,
     permit: InfrastructureValidationPermit,
     plan: InfrastructureValidationOrderPlan,
-    client: _ValidationAlpacaClient,
-    session_factory: Callable[[], Session],
-    configured_account_label: str,
-    now: datetime | None = None,
-    race_timeout_seconds: float = 10.0,
-    terminal_timeout_seconds: float = 30.0,
+    context: InfrastructureValidationSubmitContext,
 ) -> InfrastructureValidationSubmitReport:
     """Race one duplicate intent and prove one broker call plus one receipt."""
 
-    evaluated_at = now or datetime.now(timezone.utc)
-    account_label = configured_account_label.strip()
+    account_label, evaluated_at = _validate_submit_context(permit, context)
+    preflight = _prepare_validation_preflight(
+        permit,
+        plan,
+        context,
+        account_label,
+        evaluated_at,
+    )
+    race = _run_submission_race(permit, plan, preflight, context)
+    client_order_id = infrastructure_validation_client_order_id(permit, plan)
+    terminal = _collect_terminal_proof(
+        context,
+        client_order_id=client_order_id,
+    )
+    return _build_submit_report(permit, preflight, race, terminal)
+
+
+def _validate_submit_context(
+    permit: InfrastructureValidationPermit,
+    context: InfrastructureValidationSubmitContext,
+) -> tuple[str, datetime]:
+    account_label = context.configured_account_label.strip()
     if not account_label or account_label != permit.account_label:
         raise RuntimeError("infrastructure_validation_configured_account_mismatch")
+    evaluated_at = context.evaluated_at or datetime.now(timezone.utc)
+    if evaluated_at.tzinfo is None:
+        raise ValueError("infrastructure_validation_now_must_be_timezone_aware")
+    for timeout in (context.race_timeout_seconds, context.terminal_timeout_seconds):
+        if not math.isfinite(timeout) or timeout <= 0:
+            raise ValueError("infrastructure_validation_timeout_must_be_positive")
+    return account_label, evaluated_at
+
+
+def _prepare_validation_preflight(
+    permit: InfrastructureValidationPermit,
+    plan: InfrastructureValidationOrderPlan,
+    context: InfrastructureValidationSubmitContext,
+    account_label: str,
+    evaluated_at: datetime,
+) -> _ValidationPreflight:
+    client = context.client
     if client.endpoint_class != "paper":
         raise RuntimeError("infrastructure_validation_client_not_paper")
     authorize_infrastructure_validation_order(
         permit,
         plan,
         account_label=account_label,
-        account_mode="paper",
         broker_base_url=client.endpoint_url,
         now=evaluated_at,
     )
@@ -172,13 +274,11 @@ def run_infrastructure_validation_submit(
     broker_account_number = _validate_broker_account(
         account,
         permit=permit,
-        plan=plan,
     )
-    asset = client.get_asset(plan.symbol)
-    _validate_broker_asset(asset, plan=plan)
-    preflight_positions = client.list_positions()
-    preflight_orders = client.list_open_orders()
-    if preflight_positions or preflight_orders:
+    _validate_broker_asset(client.get_asset(plan.symbol))
+    positions = client.list_positions()
+    open_orders = client.list_open_orders()
+    if positions or open_orders:
         raise RuntimeError("infrastructure_validation_account_not_known_null")
 
     firewall = OrderFirewall(
@@ -191,27 +291,83 @@ def run_infrastructure_validation_submit(
         permit=permit,
         plan=plan,
         account_label=account_label,
-        account_mode="paper",
         endpoint_url=client.endpoint_url,
     )
-    broker_started = threading.Event()
-    contender_finished = threading.Event()
+    return _ValidationPreflight(
+        account_label=account_label,
+        broker_account_number=broker_account_number,
+        position_count=len(positions),
+        open_order_count=len(open_orders),
+        firewall=firewall,
+        request=request,
+    )
+
+
+def _run_submission_race(
+    permit: InfrastructureValidationPermit,
+    plan: InfrastructureValidationOrderPlan,
+    preflight: _ValidationPreflight,
+    context: InfrastructureValidationSubmitContext,
+) -> _SubmissionRaceProof:
+    state = _SubmissionRaceState(
+        broker_started=threading.Event(),
+        contender_finished=threading.Event(),
+        call_counter=_BrokerCallCounter(),
+    )
+    callbacks = _build_submission_callbacks(
+        permit,
+        plan,
+        preflight,
+        context,
+        state,
+    )
+
+    def submit(component: str) -> _WorkerResult:
+        return _submit_validation_candidate(
+            component,
+            session_factory=context.session_factory,
+            request=preflight.request,
+            callbacks=callbacks,
+        )
+
+    race_results = _race_validation_submissions(
+        submit,
+        state=state,
+        timeout_seconds=context.race_timeout_seconds,
+    )
+    _require_valid_race_results(race_results, state.call_counter.value)
+    replay = submit("validation-replay")
+    if replay.outcome != "already_processed":
+        raise RuntimeError("infrastructure_validation_replay_not_fenced")
+    return _SubmissionRaceProof(
+        outcomes=tuple(result.outcome for result in race_results),
+        replay_outcome=replay.outcome,
+        broker_call_count=state.call_counter.value,
+    )
+
+
+def _build_submission_callbacks(
+    permit: InfrastructureValidationPermit,
+    plan: InfrastructureValidationOrderPlan,
+    preflight: _ValidationPreflight,
+    context: InfrastructureValidationSubmitContext,
+    state: _SubmissionRaceState,
+) -> UnlinkedOrderSubmissionCallbacks[Mapping[str, object]]:
     broker_call_lock = threading.Lock()
-    broker_call_counter = _BrokerCallCounter()
 
     def broker_call(mutation_permit: BrokerMutationIoPermit) -> Mapping[str, object]:
         with broker_call_lock:
-            broker_call_counter.value += 1
-        broker_started.set()
-        if not contender_finished.wait(timeout=race_timeout_seconds):
+            state.call_counter.value += 1
+        state.broker_started.set()
+        if not state.contender_finished.wait(timeout=context.race_timeout_seconds):
             raise RuntimeError("infrastructure_validation_race_contender_timeout")
-        return firewall.submit_verified_infrastructure_validation_order(
+        return preflight.firewall.submit_verified_infrastructure_validation_order(
             permit,
             plan,
             mutation_permit=mutation_permit,
         )
 
-    callbacks = UnlinkedOrderSubmissionCallbacks(
+    return UnlinkedOrderSubmissionCallbacks(
         broker_call=broker_call,
         persist_terminal=lambda _result: None,
         build_settlement=lambda result: _validation_settlement(
@@ -221,88 +377,124 @@ def run_infrastructure_validation_submit(
         ),
     )
 
-    def submit(component: str) -> _WorkerResult:
-        with session_factory() as session:
-            try:
-                result = BrokerMutationSubmitCoordinator(
-                    component
-                ).submit_infrastructure_validation_order(
-                    session,
-                    request=request,
-                    callbacks=callbacks,
-                )
-            except BrokerMutationSubmissionAlreadyProcessed as exc:
-                return _WorkerResult("already_processed", error=str(exc))
-            except BrokerMutationSubmissionDeferred as exc:
-                return _WorkerResult(
-                    "deferred",
-                    error=f"{type(exc).__name__}:{exc}",
-                )
-        return _WorkerResult("submitted", result)
 
+def _submit_validation_candidate(
+    component: str,
+    *,
+    session_factory: Callable[[], Session],
+    request: InfrastructureValidationOrderSubmission,
+    callbacks: UnlinkedOrderSubmissionCallbacks[Mapping[str, object]],
+) -> _WorkerResult:
+    with session_factory() as session:
+        try:
+            result = BrokerMutationSubmitCoordinator(
+                component
+            ).submit_infrastructure_validation_order(
+                session,
+                request=request,
+                callbacks=callbacks,
+            )
+        except BrokerMutationSubmissionAlreadyProcessed as exc:
+            return _WorkerResult("already_processed", error=str(exc))
+        except BrokerMutationSubmissionDeferred as exc:
+            return _WorkerResult(
+                "deferred",
+                error=f"{type(exc).__name__}:{exc}",
+            )
+    return _WorkerResult("submitted", result)
+
+
+def _race_validation_submissions(
+    submit: Callable[[str], _WorkerResult],
+    *,
+    state: _SubmissionRaceState,
+    timeout_seconds: float,
+) -> tuple[_WorkerResult, _WorkerResult]:
     try:
         with ThreadPoolExecutor(max_workers=2) as executor:
             winner = executor.submit(submit, "validation-primary")
-            if not broker_started.wait(timeout=race_timeout_seconds):
+            if not state.broker_started.wait(timeout=timeout_seconds):
                 raise RuntimeError("infrastructure_validation_broker_boundary_timeout")
             contender = executor.submit(submit, "validation-contender")
             try:
-                contender_result = contender.result(timeout=race_timeout_seconds)
+                contender_result = contender.result(timeout=timeout_seconds)
             finally:
-                contender_finished.set()
-            winner_result = winner.result(timeout=race_timeout_seconds)
+                state.contender_finished.set()
+            winner_result = winner.result(timeout=timeout_seconds)
     finally:
-        contender_finished.set()
+        state.contender_finished.set()
+    return winner_result, contender_result
 
-    race_results = (winner_result, contender_result)
+
+def _require_valid_race_results(
+    race_results: tuple[_WorkerResult, _WorkerResult],
+    broker_call_count: int,
+) -> None:
     if sorted(result.outcome for result in race_results) != ["deferred", "submitted"]:
         reasons = ";".join(
             f"{result.outcome}:{result.error or 'none'}" for result in race_results
         )
         raise RuntimeError(f"infrastructure_validation_race_outcome_invalid:{reasons}")
-    if broker_call_counter.value != 1:
+    if broker_call_count != 1:
         raise RuntimeError("infrastructure_validation_broker_call_count_invalid")
     submitted = next(result for result in race_results if result.outcome == "submitted")
     if submitted.broker_result is None:
         raise RuntimeError("infrastructure_validation_broker_result_missing")
 
-    replay = submit("validation-replay")
-    if replay.outcome != "already_processed":
-        raise RuntimeError("infrastructure_validation_replay_not_fenced")
 
-    client_order_id = infrastructure_validation_client_order_id(permit, plan)
+def _collect_terminal_proof(
+    context: InfrastructureValidationSubmitContext,
+    *,
+    client_order_id: str,
+) -> _TerminalProof:
     broker_order = _wait_for_terminal_order(
-        client,
+        context.client,
         client_order_id=client_order_id,
-        timeout_seconds=terminal_timeout_seconds,
+        timeout_seconds=context.terminal_timeout_seconds,
     )
     terminal_positions, terminal_orders = _wait_for_known_null_account(
-        client,
-        timeout_seconds=terminal_timeout_seconds,
+        context.client,
+        timeout_seconds=context.terminal_timeout_seconds,
     )
-
     database = _load_database_proof(
-        session_factory,
+        context.session_factory,
         client_order_id=client_order_id,
     )
     broker_order_id = str(broker_order.get("id") or "").strip()
     if broker_order_id != database.broker_reference:
         raise RuntimeError("infrastructure_validation_broker_reference_mismatch")
+    return _TerminalProof(
+        client_order_id=client_order_id,
+        broker_order_id=broker_order_id,
+        broker_order_status=str(broker_order.get("status") or "").lower(),
+        position_count=len(terminal_positions),
+        open_order_count=len(terminal_orders),
+        database=database,
+    )
+
+
+def _build_submit_report(
+    permit: InfrastructureValidationPermit,
+    preflight: _ValidationPreflight,
+    race: _SubmissionRaceProof,
+    terminal: _TerminalProof,
+) -> InfrastructureValidationSubmitReport:
+    database = terminal.database
     return InfrastructureValidationSubmitReport(
         schema_version="torghut.infrastructure-validation-submit-report.v1",
         observed_at=datetime.now(timezone.utc).isoformat(),
         permit_id=permit.permit_id,
         permit_sha256=infrastructure_validation_permit_sha256(permit),
-        broker_account_number=broker_account_number,
-        client_order_id=client_order_id,
-        broker_order_id=broker_order_id,
-        broker_order_status=str(broker_order.get("status") or "").lower(),
+        broker_account_number=preflight.broker_account_number,
+        client_order_id=terminal.client_order_id,
+        broker_order_id=terminal.broker_order_id,
+        broker_order_status=terminal.broker_order_status,
         receipt_id=str(database.receipt_id),
         receipt_state=database.receipt_state,
         settlement_outcome=database.settlement_outcome,
-        race_outcomes=tuple(result.outcome for result in race_results),
-        replay_outcome=replay.outcome,
-        broker_call_count=broker_call_counter.value,
+        race_outcomes=race.outcomes,
+        replay_outcome=race.replay_outcome,
+        broker_call_count=race.broker_call_count,
         receipt_count=database.receipt_count,
         submission_claim_count=database.submission_claim_count,
         execution_count=database.execution_count,
@@ -310,10 +502,10 @@ def run_infrastructure_validation_submit(
         order_event_count=database.order_event_count,
         linked_order_event_count=database.linked_order_event_count,
         tigerbeetle_transfer_ref_count=database.tigerbeetle_transfer_ref_count,
-        preflight_position_count=len(preflight_positions),
-        preflight_open_order_count=len(preflight_orders),
-        terminal_position_count=len(terminal_positions),
-        terminal_open_order_count=len(terminal_orders),
+        preflight_position_count=preflight.position_count,
+        preflight_open_order_count=preflight.open_order_count,
+        terminal_position_count=terminal.position_count,
+        terminal_open_order_count=terminal.open_order_count,
         evidence_tag="non_promotable_validation",
         promotable=False,
     )
@@ -422,7 +614,6 @@ def _validate_broker_account(
     account: Mapping[str, object],
     *,
     permit: InfrastructureValidationPermit,
-    plan: InfrastructureValidationOrderPlan,
 ) -> str:
     account_number = str(account.get("account_number") or "").strip()
     if not account_number or account_number != permit.account_label:
@@ -441,8 +632,6 @@ def _validate_broker_account(
 
 def _validate_broker_asset(
     asset: Mapping[str, object] | None,
-    *,
-    plan: InfrastructureValidationOrderPlan,
 ) -> None:
     if not asset or not bool(asset.get("tradable")):
         raise RuntimeError("infrastructure_validation_asset_not_tradable")
@@ -459,100 +648,148 @@ def _load_database_proof(
     client_order_id: str,
 ) -> _DatabaseProof:
     with session_factory() as session:
-        receipts = (
-            session.execute(
-                select(BrokerMutationReceipt).where(
-                    BrokerMutationReceipt.client_request_id == client_order_id
-                )
-            )
-            .scalars()
-            .all()
+        receipt = _load_receipt_proof(session, client_order_id)
+        candidate = _load_candidate_evidence_proof(session, client_order_id)
+        order_events = _load_order_event_proof(session, client_order_id)
+    if any(
+        (
+            candidate.submission_claim_count,
+            candidate.execution_count,
+            candidate.trade_decision_count,
         )
-        if len(receipts) != 1:
-            raise RuntimeError("infrastructure_validation_receipt_count_invalid")
-        receipt = receipts[0]
-        latest = session.execute(
-            select(BrokerMutationReceiptEvent)
-            .where(BrokerMutationReceiptEvent.receipt_id == receipt.id)
-            .order_by(BrokerMutationReceiptEvent.sequence_no.desc())
-            .limit(1)
-        ).scalar_one()
-        if latest.state != "settled" or latest.settlement_outcome != "acknowledged":
-            raise RuntimeError("infrastructure_validation_receipt_not_terminal")
-        broker_reference = str(latest.broker_reference or "").strip()
-        if not broker_reference:
-            raise RuntimeError("infrastructure_validation_receipt_reference_missing")
-        intent = json.loads(receipt.canonical_intent_json)
-        validation = intent["request"]["infrastructure_validation"]
-        if (
-            validation["permit"]["evidence_tag"] != "non_promotable_validation"
-            or validation["permit"]["promotable"] is not False
-        ):
-            raise RuntimeError("infrastructure_validation_evidence_tag_invalid")
-        claim_count = session.scalar(
-            select(func.count())
-            .select_from(TradeDecisionSubmissionClaim)
-            .where(TradeDecisionSubmissionClaim.client_order_id == client_order_id)
-        )
-        execution_count = session.scalar(
-            select(func.count())
-            .select_from(Execution)
-            .where(Execution.client_order_id == client_order_id)
-        )
-        trade_decision_count = session.scalar(
-            select(func.count())
-            .select_from(TradeDecision)
-            .where(TradeDecision.decision_hash == client_order_id)
-        )
-        order_events = session.execute(
-            select(
-                ExecutionOrderEvent.id,
-                ExecutionOrderEvent.execution_id,
-                ExecutionOrderEvent.trade_decision_id,
-                ExecutionOrderEvent.raw_event,
-            ).where(ExecutionOrderEvent.client_order_id == client_order_id)
-        ).all()
-        linked_order_event_count = sum(
-            1
-            for event in order_events
-            if event.execution_id is not None or event.trade_decision_id is not None
-        )
-        untagged_order_event_count = sum(
-            1
-            for event in order_events
-            if not is_non_promotable_validation_event(event.raw_event)
-        )
-        order_event_ids = [event.id for event in order_events]
-        tigerbeetle_transfer_ref_count = (
-            session.scalar(
-                select(func.count())
-                .select_from(TigerBeetleTransferRef)
-                .where(
-                    TigerBeetleTransferRef.execution_order_event_id.in_(order_event_ids)
-                )
-            )
-            if order_event_ids
-            else 0
-        )
-    if claim_count or execution_count or trade_decision_count:
+    ):
         raise RuntimeError("infrastructure_validation_candidate_evidence_leak")
-    if linked_order_event_count or untagged_order_event_count:
+    if order_events.linked_order_event_count or order_events.untagged_order_event_count:
         raise RuntimeError("infrastructure_validation_order_event_evidence_leak")
-    if tigerbeetle_transfer_ref_count:
+    if order_events.tigerbeetle_transfer_ref_count:
         raise RuntimeError("infrastructure_validation_ledger_evidence_leak")
     return _DatabaseProof(
+        receipt_id=receipt.receipt_id,
+        receipt_state=receipt.receipt_state,
+        settlement_outcome=receipt.settlement_outcome,
+        broker_reference=receipt.broker_reference,
+        receipt_count=receipt.receipt_count,
+        submission_claim_count=candidate.submission_claim_count,
+        execution_count=candidate.execution_count,
+        trade_decision_count=candidate.trade_decision_count,
+        order_event_count=order_events.order_event_count,
+        linked_order_event_count=order_events.linked_order_event_count,
+        tigerbeetle_transfer_ref_count=order_events.tigerbeetle_transfer_ref_count,
+    )
+
+
+def _load_receipt_proof(session: Session, client_order_id: str) -> _ReceiptProof:
+    receipts = (
+        session.execute(
+            select(BrokerMutationReceipt).where(
+                BrokerMutationReceipt.client_request_id == client_order_id
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if len(receipts) != 1:
+        raise RuntimeError("infrastructure_validation_receipt_count_invalid")
+    receipt = receipts[0]
+    latest = session.execute(
+        select(BrokerMutationReceiptEvent)
+        .where(BrokerMutationReceiptEvent.receipt_id == receipt.id)
+        .order_by(BrokerMutationReceiptEvent.sequence_no.desc())
+        .limit(1)
+    ).scalar_one()
+    if latest.state != "settled" or latest.settlement_outcome != "acknowledged":
+        raise RuntimeError("infrastructure_validation_receipt_not_terminal")
+    broker_reference = str(latest.broker_reference or "").strip()
+    if not broker_reference:
+        raise RuntimeError("infrastructure_validation_receipt_reference_missing")
+    _require_non_promotable_receipt(receipt.canonical_intent_json)
+    return _ReceiptProof(
         receipt_id=receipt.id,
         receipt_state=latest.state,
         settlement_outcome=cast(str, latest.settlement_outcome),
         broker_reference=broker_reference,
         receipt_count=len(receipts),
-        submission_claim_count=int(claim_count or 0),
+    )
+
+
+def _require_non_promotable_receipt(canonical_intent_json: str) -> None:
+    intent = json.loads(canonical_intent_json)
+    validation = intent["request"]["infrastructure_validation"]
+    if (
+        validation["permit"]["evidence_tag"] != "non_promotable_validation"
+        or validation["permit"]["promotable"] is not False
+    ):
+        raise RuntimeError("infrastructure_validation_evidence_tag_invalid")
+
+
+def _load_candidate_evidence_proof(
+    session: Session,
+    client_order_id: str,
+) -> _CandidateEvidenceProof:
+    submission_claim_count = session.scalar(
+        select(func.count())
+        .select_from(TradeDecisionSubmissionClaim)
+        .where(TradeDecisionSubmissionClaim.client_order_id == client_order_id)
+    )
+    execution_count = session.scalar(
+        select(func.count())
+        .select_from(Execution)
+        .where(Execution.client_order_id == client_order_id)
+    )
+    trade_decision_count = session.scalar(
+        select(func.count())
+        .select_from(TradeDecision)
+        .where(TradeDecision.decision_hash == client_order_id)
+    )
+    return _CandidateEvidenceProof(
+        submission_claim_count=int(submission_claim_count or 0),
         execution_count=int(execution_count or 0),
         trade_decision_count=int(trade_decision_count or 0),
-        order_event_count=len(order_events),
-        linked_order_event_count=linked_order_event_count,
-        tigerbeetle_transfer_ref_count=int(tigerbeetle_transfer_ref_count or 0),
     )
+
+
+def _load_order_event_proof(
+    session: Session,
+    client_order_id: str,
+) -> _OrderEventProof:
+    events = session.execute(
+        select(
+            ExecutionOrderEvent.id,
+            ExecutionOrderEvent.execution_id,
+            ExecutionOrderEvent.trade_decision_id,
+            ExecutionOrderEvent.raw_event,
+        ).where(ExecutionOrderEvent.client_order_id == client_order_id)
+    ).all()
+    linked_count = sum(
+        1
+        for event in events
+        if event.execution_id is not None or event.trade_decision_id is not None
+    )
+    untagged_count = sum(
+        1 for event in events if not is_non_promotable_validation_event(event.raw_event)
+    )
+    event_ids = [event.id for event in events]
+    transfer_ref_count = _load_tigerbeetle_transfer_ref_count(session, event_ids)
+    return _OrderEventProof(
+        order_event_count=len(events),
+        linked_order_event_count=linked_count,
+        untagged_order_event_count=untagged_count,
+        tigerbeetle_transfer_ref_count=transfer_ref_count,
+    )
+
+
+def _load_tigerbeetle_transfer_ref_count(
+    session: Session,
+    order_event_ids: list[object],
+) -> int:
+    if not order_event_ids:
+        return 0
+    count = session.scalar(
+        select(func.count())
+        .select_from(TigerBeetleTransferRef)
+        .where(TigerBeetleTransferRef.execution_order_event_id.in_(order_event_ids))
+    )
+    return int(count or 0)
 
 
 def _load_input(
@@ -584,9 +821,11 @@ def main(argv: list[str] | None = None) -> int:
     report = run_infrastructure_validation_submit(
         permit=permit,
         plan=plan,
-        client=client,
-        session_factory=SessionLocal,
-        configured_account_label=settings.trading_account_label,
+        context=InfrastructureValidationSubmitContext(
+            client=client,
+            session_factory=SessionLocal,
+            configured_account_label=settings.trading_account_label,
+        ),
     )
     print(json.dumps(report.to_payload(), sort_keys=True))
     return 0
@@ -597,6 +836,7 @@ if __name__ == "__main__":  # pragma: no cover - exercised from the deployed ima
 
 
 __all__ = [
+    "InfrastructureValidationSubmitContext",
     "InfrastructureValidationSubmitReport",
     "main",
     "run_infrastructure_validation_submit",

--- a/services/torghut/app/trading/infrastructure_validation_submit.py
+++ b/services/torghut/app/trading/infrastructure_validation_submit.py
@@ -152,7 +152,8 @@ class _ValidationPreflight:
 @dataclass(frozen=True, slots=True)
 class _SubmissionRaceState:
     broker_started: threading.Event
-    contender_finished: threading.Event
+    contender_resolved: threading.Event
+    contender_fenced: threading.Event
     call_counter: _BrokerCallCounter
 
 
@@ -311,7 +312,8 @@ def _run_submission_race(
 ) -> _SubmissionRaceProof:
     state = _SubmissionRaceState(
         broker_started=threading.Event(),
-        contender_finished=threading.Event(),
+        contender_resolved=threading.Event(),
+        contender_fenced=threading.Event(),
         call_counter=_BrokerCallCounter(),
     )
     callbacks = _build_submission_callbacks(
@@ -359,8 +361,10 @@ def _build_submission_callbacks(
         with broker_call_lock:
             state.call_counter.value += 1
         state.broker_started.set()
-        if not state.contender_finished.wait(timeout=context.race_timeout_seconds):
+        if not state.contender_resolved.wait(timeout=context.race_timeout_seconds):
             raise RuntimeError("infrastructure_validation_race_contender_timeout")
+        if not state.contender_fenced.is_set():
+            raise RuntimeError("infrastructure_validation_race_contender_not_fenced")
         return preflight.firewall.submit_verified_infrastructure_validation_order(
             permit,
             plan,
@@ -410,16 +414,24 @@ def _race_validation_submissions(
     state: _SubmissionRaceState,
     timeout_seconds: float,
 ) -> tuple[_WorkerResult, _WorkerResult]:
-    with ThreadPoolExecutor(max_workers=2) as executor:
+    deadline = time.monotonic() + timeout_seconds
+    executor = ThreadPoolExecutor(max_workers=2)
+    try:
         winner = executor.submit(submit, "validation-primary")
-        if not state.broker_started.wait(timeout=timeout_seconds):
+        if not state.broker_started.wait(timeout=max(0.0, deadline - time.monotonic())):
             raise RuntimeError("infrastructure_validation_broker_boundary_timeout")
         contender = executor.submit(submit, "validation-contender")
-        contender_result = contender.result(timeout=timeout_seconds)
+        contender_result = contender.result(
+            timeout=max(0.0, deadline - time.monotonic())
+        )
         if contender_result.outcome != "deferred":
             raise RuntimeError("infrastructure_validation_race_contender_not_fenced")
-        state.contender_finished.set()
-        winner_result = winner.result(timeout=timeout_seconds)
+        state.contender_fenced.set()
+        state.contender_resolved.set()
+        winner_result = winner.result(timeout=max(0.0, deadline - time.monotonic()))
+    finally:
+        state.contender_resolved.set()
+        executor.shutdown(wait=False, cancel_futures=True)
     return winner_result, contender_result
 
 

--- a/services/torghut/app/trading/infrastructure_validation_submit.py
+++ b/services/torghut/app/trading/infrastructure_validation_submit.py
@@ -9,10 +9,11 @@ import sys
 import threading
 import time
 from collections.abc import Callable, Mapping
-from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation
+from multiprocessing import TimeoutError as MultiprocessingTimeoutError
+from multiprocessing.pool import ThreadPool
 from pathlib import Path
 from typing import Protocol, cast
 
@@ -415,23 +416,26 @@ def _race_validation_submissions(
     timeout_seconds: float,
 ) -> tuple[_WorkerResult, _WorkerResult]:
     deadline = time.monotonic() + timeout_seconds
-    executor = ThreadPoolExecutor(max_workers=2)
+    pool = ThreadPool(processes=2)
     try:
-        winner = executor.submit(submit, "validation-primary")
+        winner = pool.apply_async(submit, ("validation-primary",))
         if not state.broker_started.wait(timeout=max(0.0, deadline - time.monotonic())):
             raise RuntimeError("infrastructure_validation_broker_boundary_timeout")
-        contender = executor.submit(submit, "validation-contender")
-        contender_result = contender.result(
-            timeout=max(0.0, deadline - time.monotonic())
-        )
+        contender = pool.apply_async(submit, ("validation-contender",))
+        contender_result = contender.get(timeout=max(0.0, deadline - time.monotonic()))
         if contender_result.outcome != "deferred":
             raise RuntimeError("infrastructure_validation_race_contender_not_fenced")
         state.contender_fenced.set()
         state.contender_resolved.set()
-        winner_result = winner.result(timeout=max(0.0, deadline - time.monotonic()))
+        winner_result = winner.get(timeout=max(0.0, deadline - time.monotonic()))
+    except MultiprocessingTimeoutError as exc:
+        raise TimeoutError("infrastructure_validation_race_timeout") from exc
     finally:
         state.contender_resolved.set()
-        executor.shutdown(wait=False, cancel_futures=True)
+        # ThreadPool workers are daemons and terminate() does not join a hung task.
+        # ThreadPoolExecutor workers are joined at interpreter exit even after
+        # shutdown(wait=False), which cannot enforce this one-shot CLI deadline.
+        pool.terminate()
     return winner_result, contender_result
 
 

--- a/services/torghut/app/trading/infrastructure_validation_submit.py
+++ b/services/torghut/app/trading/infrastructure_validation_submit.py
@@ -410,19 +410,16 @@ def _race_validation_submissions(
     state: _SubmissionRaceState,
     timeout_seconds: float,
 ) -> tuple[_WorkerResult, _WorkerResult]:
-    try:
-        with ThreadPoolExecutor(max_workers=2) as executor:
-            winner = executor.submit(submit, "validation-primary")
-            if not state.broker_started.wait(timeout=timeout_seconds):
-                raise RuntimeError("infrastructure_validation_broker_boundary_timeout")
-            contender = executor.submit(submit, "validation-contender")
-            try:
-                contender_result = contender.result(timeout=timeout_seconds)
-            finally:
-                state.contender_finished.set()
-            winner_result = winner.result(timeout=timeout_seconds)
-    finally:
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        winner = executor.submit(submit, "validation-primary")
+        if not state.broker_started.wait(timeout=timeout_seconds):
+            raise RuntimeError("infrastructure_validation_broker_boundary_timeout")
+        contender = executor.submit(submit, "validation-contender")
+        contender_result = contender.result(timeout=timeout_seconds)
+        if contender_result.outcome != "deferred":
+            raise RuntimeError("infrastructure_validation_race_contender_not_fenced")
         state.contender_finished.set()
+        winner_result = winner.result(timeout=timeout_seconds)
     return winner_result, contender_result
 
 

--- a/services/torghut/app/trading/infrastructure_validation_submit.py
+++ b/services/torghut/app/trading/infrastructure_validation_submit.py
@@ -13,7 +13,7 @@ from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
-from typing import Any, Protocol, cast
+from typing import Protocol, cast
 
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
@@ -43,7 +43,7 @@ from .broker_mutation_submit_coordinator import (
     InfrastructureValidationOrderSubmission,
     UnlinkedOrderSubmissionCallbacks,
 )
-from .firewall import OrderFirewall
+from .firewall import OrderFirewall, OrderFirewallBrokerClient
 from .infrastructure_validation import (
     InfrastructureValidationOrderPlan,
     InfrastructureValidationPermit,
@@ -66,18 +66,18 @@ class _ValidationAlpacaClient(Protocol):
     endpoint_class: str
     endpoint_url: str
 
-    def get_account(self) -> dict[str, Any]: ...
+    def get_account(self) -> dict[str, object]: ...
 
-    def get_asset(self, symbol_or_asset_id: str) -> dict[str, Any] | None: ...
+    def get_asset(self, symbol_or_asset_id: str) -> dict[str, object] | None: ...
 
     def get_order_by_client_order_id_strict(
         self,
         client_order_id: str,
     ) -> dict[str, object] | None: ...
 
-    def list_open_orders(self) -> list[dict[str, Any]]: ...
+    def list_open_orders(self) -> list[dict[str, object]]: ...
 
-    def list_positions(self) -> list[dict[str, Any]]: ...
+    def list_positions(self) -> list[dict[str, object]]: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -181,7 +181,10 @@ def run_infrastructure_validation_submit(
     if preflight_positions or preflight_orders:
         raise RuntimeError("infrastructure_validation_account_not_known_null")
 
-    firewall = OrderFirewall(cast(Any, client), account_label=account_label)
+    firewall = OrderFirewall(
+        cast(OrderFirewallBrokerClient, client),
+        account_label=account_label,
+    )
     if firewall.status().kill_switch_enabled:
         raise RuntimeError("infrastructure_validation_kill_switch_enabled")
     request = InfrastructureValidationOrderSubmission(
@@ -399,10 +402,10 @@ def _wait_for_known_null_account(
     client: _ValidationAlpacaClient,
     *,
     timeout_seconds: float,
-) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+) -> tuple[list[dict[str, object]], list[dict[str, object]]]:
     deadline = time.monotonic() + timeout_seconds
-    positions: list[dict[str, Any]] = []
-    orders: list[dict[str, Any]] = []
+    positions: list[dict[str, object]] = []
+    orders: list[dict[str, object]] = []
     while time.monotonic() < deadline:
         positions = client.list_positions()
         orders = client.list_open_orders()

--- a/services/torghut/app/trading/infrastructure_validation_submit.py
+++ b/services/torghut/app/trading/infrastructure_validation_submit.py
@@ -9,8 +9,8 @@ import sys
 import threading
 import time
 from collections.abc import Callable, Mapping
-from dataclasses import asdict, dataclass
-from datetime import datetime, timezone
+from dataclasses import asdict, dataclass, replace
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal, InvalidOperation
 from multiprocessing import TimeoutError as MultiprocessingTimeoutError
 from multiprocessing.pool import ThreadPool
@@ -144,6 +144,7 @@ class _BrokerCallCounter:
 class _ValidationPreflight:
     account_label: str
     broker_account_number: str
+    evaluated_at: datetime
     position_count: int
     open_order_count: int
     firewall: OrderFirewall
@@ -230,6 +231,12 @@ def run_infrastructure_validation_submit(
         account_label,
         evaluated_at,
     )
+    preflight = _authorize_submission_window(
+        permit,
+        plan,
+        preflight,
+        context,
+    )
     race = _run_submission_race(permit, plan, preflight, context)
     client_order_id = infrastructure_validation_client_order_id(permit, plan)
     terminal = _collect_terminal_proof(
@@ -298,11 +305,44 @@ def _prepare_validation_preflight(
     return _ValidationPreflight(
         account_label=account_label,
         broker_account_number=broker_account_number,
+        evaluated_at=evaluated_at,
         position_count=len(positions),
         open_order_count=len(open_orders),
         firewall=firewall,
         request=request,
     )
+
+
+def _authorize_submission_window(
+    permit: InfrastructureValidationPermit,
+    plan: InfrastructureValidationOrderPlan,
+    preflight: _ValidationPreflight,
+    context: InfrastructureValidationSubmitContext,
+) -> _ValidationPreflight:
+    evaluated_at = context.evaluated_at or datetime.now(timezone.utc)
+    authorize_infrastructure_validation_order(
+        permit,
+        plan,
+        account_label=preflight.account_label,
+        broker_base_url=context.client.endpoint_url,
+        now=evaluated_at,
+    )
+    _require_submission_validity_window(
+        expires_at=permit.expires_at,
+        evaluated_at=evaluated_at,
+        timeout_seconds=context.race_timeout_seconds,
+    )
+    return replace(preflight, evaluated_at=evaluated_at)
+
+
+def _require_submission_validity_window(
+    *,
+    expires_at: datetime,
+    evaluated_at: datetime,
+    timeout_seconds: float,
+) -> None:
+    if expires_at <= evaluated_at + timedelta(seconds=timeout_seconds):
+        raise ValueError("infrastructure_validation_permit_window_too_short")
 
 
 def _run_submission_race(
@@ -331,6 +371,7 @@ def _run_submission_race(
             session_factory=context.session_factory,
             request=preflight.request,
             callbacks=callbacks,
+            now=preflight.evaluated_at,
         )
 
     race_results = _race_validation_submissions(
@@ -370,6 +411,7 @@ def _build_submission_callbacks(
             permit,
             plan,
             mutation_permit=mutation_permit,
+            now=preflight.evaluated_at,
         )
 
     return UnlinkedOrderSubmissionCallbacks(
@@ -389,6 +431,7 @@ def _submit_validation_candidate(
     session_factory: Callable[[], Session],
     request: InfrastructureValidationOrderSubmission,
     callbacks: UnlinkedOrderSubmissionCallbacks[Mapping[str, object]],
+    now: datetime,
 ) -> _WorkerResult:
     with session_factory() as session:
         try:
@@ -398,6 +441,7 @@ def _submit_validation_candidate(
                 session,
                 request=request,
                 callbacks=callbacks,
+                now=now,
             )
         except BrokerMutationSubmissionAlreadyProcessed as exc:
             return _WorkerResult("already_processed", error=str(exc))

--- a/services/torghut/app/trading/order_feed/normalize_order_feed_record.py
+++ b/services/torghut/app/trading/order_feed/normalize_order_feed_record.py
@@ -22,6 +22,10 @@ from ...models import (
 )
 from ..tca import upsert_execution_tca_metric
 from ..tigerbeetle_journal import TigerBeetleLedgerJournal
+from ..infrastructure_validation_records import (
+    load_infrastructure_validation_evidence,
+    tag_infrastructure_validation_event,
+)
 
 
 from .shared_context import (
@@ -360,12 +364,27 @@ def persist_order_event(
 ) -> tuple[ExecutionOrderEvent, bool]:
     """Persist a normalized event and link it to execution/trade_decision rows."""
 
+    validation_evidence = load_infrastructure_validation_evidence(
+        session,
+        account_label=event.alpaca_account_label,
+        client_order_id=event.client_order_id,
+    )
     existing = session.execute(
         select(ExecutionOrderEvent).where(
             ExecutionOrderEvent.event_fingerprint == event.event_fingerprint
         )
     ).scalar_one_or_none()
     if existing is not None:
+        if validation_evidence is not None:
+            existing.raw_event = tag_infrastructure_validation_event(
+                existing.raw_event,
+                validation_evidence,
+            )
+            existing.execution_id = None
+            existing.trade_decision_id = None
+            session.add(existing)
+            if existing.source_window_id is not None:
+                _refresh_source_window_linkage_counts(session, existing)
         if existing.source_window_id is None and source_window_id is not None:
             existing.source_window_id = source_window_id
             session.add(existing)
@@ -376,45 +395,51 @@ def persist_order_event(
     filled_qty_delta, filled_notional_delta, fill_quantity_basis = _fill_delta_fields(
         session, event
     )
-    execution_linkage = _resolve_execution_linkage_for_identity(
-        session,
-        account_label=event.alpaca_account_label,
-        alpaca_order_id=event.alpaca_order_id,
-        client_order_id=event.client_order_id,
-        execution_correlation_id=event.execution_correlation_id,
-    )
-    execution = execution_linkage.execution
+    execution = None
     raw_event = event.raw_event
     trade_decision_id = None
-    if execution is not None:
-        trade_decision_id = execution.trade_decision_id
-    elif not execution_linkage.blockers:
-        decision_linkage = _resolve_trade_decision_linkage_for_identity(
-            session,
-            account_label=event.alpaca_account_label,
-            client_order_id=event.client_order_id,
-        )
-        if decision_linkage.trade_decision is not None:
-            trade_decision_id = decision_linkage.trade_decision.id
-        linkage_blockers = list(
-            _missing_linkage_blockers(
-                execution_missing=True,
-                decision_missing=decision_linkage.trade_decision is None
-                and not decision_linkage.blockers,
-            )
-        )
-        linkage_blockers.extend(decision_linkage.blockers)
-        raw_event = _raw_event_with_linkage_blockers(
+    if validation_evidence is not None:
+        raw_event = tag_infrastructure_validation_event(
             event.raw_event,
-            linkage_blockers,
+            validation_evidence,
         )
     else:
-        raw_event = _raw_event_with_linkage_blockers(
-            event.raw_event,
-            execution_linkage.blockers,
+        execution_linkage = _resolve_execution_linkage_for_identity(
+            session,
+            account_label=event.alpaca_account_label,
+            alpaca_order_id=event.alpaca_order_id,
+            client_order_id=event.client_order_id,
+            execution_correlation_id=event.execution_correlation_id,
         )
-    if execution is not None:
-        raw_event = _raw_event_with_linkage_blockers(event.raw_event, ())
+        execution = execution_linkage.execution
+        if execution is not None:
+            trade_decision_id = execution.trade_decision_id
+            raw_event = _raw_event_with_linkage_blockers(event.raw_event, ())
+        elif not execution_linkage.blockers:
+            decision_linkage = _resolve_trade_decision_linkage_for_identity(
+                session,
+                account_label=event.alpaca_account_label,
+                client_order_id=event.client_order_id,
+            )
+            if decision_linkage.trade_decision is not None:
+                trade_decision_id = decision_linkage.trade_decision.id
+            linkage_blockers = list(
+                _missing_linkage_blockers(
+                    execution_missing=True,
+                    decision_missing=decision_linkage.trade_decision is None
+                    and not decision_linkage.blockers,
+                )
+            )
+            linkage_blockers.extend(decision_linkage.blockers)
+            raw_event = _raw_event_with_linkage_blockers(
+                event.raw_event,
+                linkage_blockers,
+            )
+        else:
+            raw_event = _raw_event_with_linkage_blockers(
+                event.raw_event,
+                execution_linkage.blockers,
+            )
 
     row = ExecutionOrderEvent(
         event_fingerprint=event.event_fingerprint,
@@ -721,6 +746,15 @@ def link_order_events_to_execution(
     linked = 0
     latest_event: ExecutionOrderEvent | None = None
     for event in events:
+        if (
+            load_infrastructure_validation_evidence(
+                session,
+                account_label=event.alpaca_account_label,
+                client_order_id=event.client_order_id,
+            )
+            is not None
+        ):
+            continue
         event_execution_linkage = _resolve_execution_linkage_for_identity(
             session,
             account_label=execution.alpaca_account_label,

--- a/services/torghut/app/trading/order_feed/repair_order_feed_execution_links.py
+++ b/services/torghut/app/trading/order_feed/repair_order_feed_execution_links.py
@@ -15,6 +15,9 @@ from ...models import (
     ExecutionOrderEvent,
     OrderFeedSourceWindow,
 )
+from ..infrastructure_validation_records import (
+    load_infrastructure_validation_evidence,
+)
 from ..tca import upsert_execution_tca_metric
 
 
@@ -215,6 +218,15 @@ def repair_order_feed_execution_links(
     for event in events:
         if counters["events_linked"] >= bounded_limit:
             break
+        if (
+            load_infrastructure_validation_evidence(
+                session,
+                account_label=event.alpaca_account_label,
+                client_order_id=event.client_order_id,
+            )
+            is not None
+        ):
+            continue
         event_client_order_id = _order_event_client_identity(event)
         event_correlation_id = _order_event_execution_correlation_identity(event)
         execution_linkage = _resolve_execution_linkage_for_identity(

--- a/services/torghut/app/trading/simulation_progress.py
+++ b/services/torghut/app/trading/simulation_progress.py
@@ -22,6 +22,7 @@ from ..models.entities import (
     TradeCursor,
     TradeDecision,
 )
+from .infrastructure_validation_records import is_non_promotable_validation_event
 
 logger = logging.getLogger(__name__)
 
@@ -540,6 +541,8 @@ def _execution_order_event_after_insert(
     connection: Connection,
     target: ExecutionOrderEvent,
 ) -> None:
+    if is_non_promotable_validation_event(target.raw_event):
+        return
     upsert_simulation_progress(
         connection,
         component=COMPONENT_TORGHUT,

--- a/services/torghut/app/trading/tigerbeetle_journal/transfer_refs.py
+++ b/services/torghut/app/trading/tigerbeetle_journal/transfer_refs.py
@@ -22,6 +22,9 @@ from app.models import (
     TigerBeetleTransferRef,
     coerce_json_payload,
 )
+from app.trading.infrastructure_validation_records import (
+    load_infrastructure_validation_evidence,
+)
 from app.trading.tigerbeetle_ids import stable_u128, u128_decimal
 from app.trading.tigerbeetle_ledger_model import (
     ACCOUNT_CODE_CASH_CONTROL,
@@ -427,6 +430,15 @@ def build_order_event_transfer_plan(
     settings_obj: Settings = settings,
     prefer_pending_ref: bool = True,
 ) -> TigerBeetleOrderEventTransferPlan | None:
+    if (
+        load_infrastructure_validation_evidence(
+            session,
+            account_label=event.alpaca_account_label,
+            client_order_id=event.client_order_id,
+        )
+        is not None
+    ):
+        return None
     transfer_kind = transfer_kind_for_event(event.event_type, event.status)
     if transfer_kind is None:
         return None

--- a/services/torghut/migrations/versions/0068_infrastructure_validation_submit.py
+++ b/services/torghut/migrations/versions/0068_infrastructure_validation_submit.py
@@ -1,0 +1,397 @@
+"""Authorize one non-promotable, permit-bound Alpaca paper submit.
+
+Revision ID: 0068_validation_submit
+Revises: 0067_options_archive_status
+Create Date: 2026-07-14 23:05:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0068_validation_submit"
+down_revision = "0067_options_archive_status"
+branch_labels = None
+depends_on = None
+
+
+_PURPOSE_CONSTRAINT = "ck_bm_receipt_purpose"
+_OPERATION_CONSTRAINT = "ck_bm_receipt_operation_contract"
+_VALIDATION_CONSTRAINT = "ck_bm_receipt_validation_authority"
+_VALIDATION_PERMIT_INDEX = "uq_bm_receipt_validation_permit"
+_PURPOSES_0066 = """
+purpose IN ('initial_submission', 'repricing', 'inventory_conflict',
+            'opposite_side_cleanup', 'kill_switch', 'governance',
+            'closeout', 'flatten', 'operator')
+"""
+_PURPOSES_0068 = """
+purpose IN ('initial_submission', 'repricing', 'inventory_conflict',
+            'opposite_side_cleanup', 'kill_switch', 'governance',
+            'closeout', 'flatten', 'operator', 'control_plane_validation')
+"""
+_OPERATION_CONTRACT_0066 = """
+((operation = 'submit_order' AND target_kind = 'order' AND
+  ((broker_route = 'alpaca' AND
+    (submission_claim_id IS NOT NULL OR
+     (submission_claim_id IS NULL AND risk_class = 'risk_reducing'
+      AND purpose IN ('closeout', 'flatten')))) OR
+   (broker_route = 'hyperliquid' AND submission_claim_id IS NULL
+    AND risk_class = 'risk_increasing'
+    AND purpose = 'initial_submission'))) OR
+ (operation = 'replace_order' AND target_kind = 'order'
+  AND submission_claim_id IS NOT NULL) OR
+ (operation = 'cancel_order' AND target_kind = 'order'
+  AND submission_claim_id IS NULL) OR
+ (operation = 'cancel_all_orders' AND target_kind = 'account'
+  AND target_key = account_label AND submission_claim_id IS NULL) OR
+ (operation = 'close_position' AND target_kind = 'position'
+  AND submission_claim_id IS NULL AND risk_class = 'risk_reducing') OR
+ (operation = 'close_all_positions' AND target_kind = 'account'
+  AND target_key = account_label AND submission_claim_id IS NULL
+  AND risk_class = 'risk_reducing'))
+"""
+_OPERATION_CONTRACT_0068 = """
+((operation = 'submit_order' AND target_kind = 'order' AND
+  ((broker_route = 'alpaca' AND
+    (submission_claim_id IS NOT NULL OR
+     (submission_claim_id IS NULL AND risk_class = 'risk_reducing'
+      AND purpose IN ('closeout', 'flatten')) OR
+     (submission_claim_id IS NULL AND risk_class = 'risk_neutral'
+      AND purpose = 'control_plane_validation'))) OR
+   (broker_route = 'hyperliquid' AND submission_claim_id IS NULL
+    AND risk_class = 'risk_increasing'
+    AND purpose = 'initial_submission'))) OR
+ (operation = 'replace_order' AND target_kind = 'order'
+  AND submission_claim_id IS NOT NULL) OR
+ (operation = 'cancel_order' AND target_kind = 'order'
+  AND submission_claim_id IS NULL) OR
+ (operation = 'cancel_all_orders' AND target_kind = 'account'
+  AND target_key = account_label AND submission_claim_id IS NULL) OR
+ (operation = 'close_position' AND target_kind = 'position'
+  AND submission_claim_id IS NULL AND risk_class = 'risk_reducing') OR
+ (operation = 'close_all_positions' AND target_kind = 'account'
+  AND target_key = account_label AND submission_claim_id IS NULL
+  AND risk_class = 'risk_reducing'))
+"""
+_VALIDATION_AUTHORITY = """
+purpose <> 'control_plane_validation' OR COALESCE((
+  broker_route = 'alpaca'
+  AND endpoint_fingerprint =
+      'e7ce2f426f96cfc1606a46bc494cdfff68192ac2de4529bf406007d11d059ad7'
+  AND operation = 'submit_order'
+  AND risk_class = 'risk_neutral'
+  AND submission_claim_id IS NULL
+  AND workflow_id = client_request_id
+  AND client_request_id ~ '^ivp-[0-9a-f]{44}$'
+  AND target_kind = 'order'
+  AND target_key = client_request_id
+  AND canonical_intent_json::jsonb #>>
+      '{request,broker_request,extra_params,client_order_id}' = client_request_id
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,schema_version}' =
+      'torghut.infrastructure-validation-permit.v2'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,purpose}' =
+      'control_plane_validation'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,venue}' = 'alpaca'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,account_mode}' = 'paper'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,account_label}' = account_label
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,broker_base_url}' IN
+      ('https://paper-api.alpaca.markets',
+       'https://paper-api.alpaca.markets/')
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,asset_class}' = 'crypto'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,market_session}' = 'continuous'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,evidence_tag}' =
+      'non_promotable_validation'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,promotable}' = 'false'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,max_orders}' = '1'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,max_outstanding_intents}' = '1'
+  AND (canonical_intent_json::jsonb #>>
+       '{request,infrastructure_validation,permit,max_notional_usd}')::numeric
+      > 0
+  AND (canonical_intent_json::jsonb #>>
+       '{request,infrastructure_validation,permit,max_notional_usd}')::numeric
+      <= 1
+  AND (canonical_intent_json::jsonb #>>
+       '{request,infrastructure_validation,permit,max_loss_usd}')::numeric
+      > 0
+  AND (canonical_intent_json::jsonb #>>
+       '{request,infrastructure_validation,permit,max_loss_usd}')::numeric
+      <= 1
+  AND (canonical_intent_json::jsonb #>>
+       '{request,infrastructure_validation,permit,max_loss_usd}')::numeric
+      <= (canonical_intent_json::jsonb #>>
+          '{request,infrastructure_validation,permit,max_notional_usd}')::numeric
+  AND lower(canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,issued_by}') <>
+      lower(canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,approved_by}')
+  AND length(canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,issued_by}') BETWEEN 1 AND 128
+  AND length(canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,approved_by}') BETWEEN 1 AND 128
+  AND length(canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,permit_id}') BETWEEN 1 AND 128
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit_sha256}' ~ '^[0-9a-f]{64}$'
+  AND created_at >= (canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,issued_at}')::timestamptz
+  AND created_at < (canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,expires_at}')::timestamptz
+  AND (canonical_intent_json::jsonb #>>
+       '{request,infrastructure_validation,permit,expires_at}')::timestamptz
+      - (canonical_intent_json::jsonb #>>
+         '{request,infrastructure_validation,permit,issued_at}')::timestamptz
+      <= interval '15 minutes'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,test_plan_digest}' =
+      canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,test_plan_sha256}'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,test_plan_sha256}' ~ '^[0-9a-f]{64}$'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,expected_terminal_state_digest}' =
+      canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,expected_terminal_state_sha256}'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,expected_terminal_state_sha256}' =
+      '796e64c0dfebb4e72c3c56990b7976a952ff772822b3b02104af024a5fefd03e'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,expected_terminal_state}' =
+      'no_open_orders_no_positions_no_unsettled_claims'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,expected_terminal_state,schema_version}' =
+      'torghut.infrastructure-validation-terminal.v1'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,expected_terminal_state,state}' =
+      'no_open_orders_no_positions_no_unsettled_claims'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,test_plan,schema_version}' =
+      'torghut.infrastructure-validation-order-plan.v1'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,test_plan,venue}' = 'alpaca'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,test_plan,asset_class}' =
+      canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,asset_class}'
+  AND canonical_intent_json::jsonb #>>
+      '{request,broker_request,symbol}' =
+      canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,test_plan,symbol}'
+  AND canonical_intent_json::jsonb #>
+      '{request,infrastructure_validation,permit,symbols}' =
+      jsonb_build_array(canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,test_plan,symbol}')
+  AND canonical_intent_json::jsonb #>>
+      '{request,broker_request,side}' = 'buy'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,test_plan,side}' = 'buy'
+  AND canonical_intent_json::jsonb #>
+      '{request,infrastructure_validation,permit,sides}' = '["buy"]'::jsonb
+  AND canonical_intent_json::jsonb #>>
+      '{request,broker_request,order_type}' = 'limit'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,test_plan,order_type}' = 'limit'
+  AND canonical_intent_json::jsonb #>
+      '{request,infrastructure_validation,permit,order_types}' = '["limit"]'::jsonb
+  AND canonical_intent_json::jsonb #>>
+      '{request,broker_request,time_in_force}' = 'ioc'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,test_plan,time_in_force}' = 'ioc'
+  AND (canonical_intent_json::jsonb #>>
+       '{request,infrastructure_validation,test_plan,qty}')::numeric > 0
+  AND (canonical_intent_json::jsonb #>>
+       '{request,infrastructure_validation,test_plan,limit_price}')::numeric > 0
+  AND (canonical_intent_json::jsonb #>>
+       '{request,broker_request,qty}')::numeric =
+      (canonical_intent_json::jsonb #>>
+       '{request,infrastructure_validation,test_plan,qty}')::numeric
+  AND (canonical_intent_json::jsonb #>>
+       '{request,broker_request,limit_price}')::numeric =
+      (canonical_intent_json::jsonb #>>
+       '{request,infrastructure_validation,test_plan,limit_price}')::numeric
+  AND (canonical_intent_json::jsonb #>>
+       '{request,infrastructure_validation,test_plan,qty}')::numeric *
+      (canonical_intent_json::jsonb #>>
+       '{request,infrastructure_validation,test_plan,limit_price}')::numeric
+      <= (canonical_intent_json::jsonb #>>
+          '{request,infrastructure_validation,permit,max_notional_usd}')::numeric
+  AND (canonical_intent_json::jsonb #>>
+       '{request,infrastructure_validation,test_plan,qty}')::numeric *
+      (canonical_intent_json::jsonb #>>
+       '{request,infrastructure_validation,test_plan,limit_price}')::numeric
+      <= (canonical_intent_json::jsonb #>>
+          '{request,infrastructure_validation,permit,max_loss_usd}')::numeric
+  AND canonical_intent_json::jsonb #>
+      '{request,broker_request,extra_params}' =
+      jsonb_build_object('client_order_id', client_request_id)
+  AND canonical_intent_json::jsonb #>
+      '{request,broker_request,stop_price}' = 'null'::jsonb
+  AND canonical_intent_json::jsonb #>
+      '{request,infrastructure_validation,test_plan,stop_price}' = 'null'::jsonb
+), FALSE)
+"""
+
+
+def _replace_check(name: str, condition: str) -> None:
+    op.drop_constraint(name, "broker_mutation_receipts", type_="check")
+    op.create_check_constraint(name, "broker_mutation_receipts", condition)
+
+
+def _replace_claim_guard(*, allow_validation: bool) -> None:
+    validation_contract = (
+        """
+                       OR (NEW.broker_route = 'alpaca'
+                           AND NEW.risk_class = 'risk_neutral'
+                           AND NEW.purpose = 'control_plane_validation')
+        """
+        if allow_validation
+        else ""
+    )
+    op.execute(
+        sa.text(
+            f"""
+            CREATE OR REPLACE FUNCTION torghut_guard_bm_claim_0060()
+            RETURNS trigger LANGUAGE plpgsql AS $$
+            DECLARE
+                claim_account text;
+                claim_client_request_id text;
+                claim_lease_expires_at timestamptz;
+                claim_owner text;
+                claim_released_at timestamptz;
+                claim_state text;
+            BEGIN
+                IF NEW.operation = 'replace_order' THEN
+                    RAISE EXCEPTION
+                        'broker mutation replace receipts remain disabled'
+                        USING ERRCODE = '23514';
+                END IF;
+                IF NEW.operation <> 'submit_order' THEN
+                    RETURN NEW;
+                END IF;
+                IF NEW.submission_claim_id IS NULL THEN
+                    IF (NEW.broker_route = 'alpaca'
+                        AND NEW.risk_class = 'risk_reducing'
+                        AND NEW.purpose IN ('closeout', 'flatten'))
+                       {validation_contract}
+                       OR (NEW.broker_route = 'hyperliquid'
+                           AND NEW.risk_class = 'risk_increasing'
+                           AND NEW.purpose = 'initial_submission') THEN
+                        RETURN NEW;
+                    END IF;
+                    RAISE EXCEPTION
+                        'unlinked broker mutation submit contract invalid'
+                        USING ERRCODE = '23514';
+                END IF;
+                SELECT claim.account_label, claim.client_order_id,
+                       claim.lease_expires_at, claim.claim_owner,
+                       claim.released_at, claim.state
+                  INTO claim_account, claim_client_request_id,
+                       claim_lease_expires_at, claim_owner, claim_released_at,
+                       claim_state
+                  FROM trade_decision_submission_claims AS claim
+                 WHERE claim.trade_decision_id = NEW.submission_claim_id
+                   FOR UPDATE;
+                IF NOT FOUND
+                   OR claim_account IS DISTINCT FROM NEW.account_label
+                   OR claim_client_request_id IS DISTINCT FROM NEW.client_request_id
+                   OR claim_owner IS DISTINCT FROM NEW.creator_owner
+                   OR claim_state IS DISTINCT FROM 'claimed' THEN
+                    RAISE EXCEPTION
+                        'broker mutation submit claim identity or state mismatch'
+                        USING ERRCODE = '23514';
+                END IF;
+                IF claim_released_at IS NOT NULL
+                   OR claim_lease_expires_at <= clock_timestamp() THEN
+                    RAISE EXCEPTION
+                        'broker mutation submit claim lease is not live'
+                        USING ERRCODE = '23514';
+                END IF;
+                RETURN NEW;
+            END;
+            $$
+            """
+        )
+    )
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text("LOCK TABLE broker_mutation_receipts IN ACCESS EXCLUSIVE MODE NOWAIT")
+    )
+    _replace_check(_PURPOSE_CONSTRAINT, _PURPOSES_0068)
+    _replace_check(_OPERATION_CONSTRAINT, _OPERATION_CONTRACT_0068)
+    _replace_claim_guard(allow_validation=True)
+    op.execute(
+        sa.text(
+            f"""
+            ALTER TABLE broker_mutation_receipts
+              ADD CONSTRAINT {_VALIDATION_CONSTRAINT}
+              CHECK ({_VALIDATION_AUTHORITY}) NOT VALID
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            f"""
+            ALTER TABLE broker_mutation_receipts
+              VALIDATE CONSTRAINT {_VALIDATION_CONSTRAINT}
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            f"""
+            CREATE UNIQUE INDEX {_VALIDATION_PERMIT_INDEX}
+              ON broker_mutation_receipts
+              ((canonical_intent_json::jsonb #>>
+                '{{request,infrastructure_validation,permit,permit_id}}'))
+             WHERE purpose = 'control_plane_validation'
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text("LOCK TABLE broker_mutation_receipts IN ACCESS EXCLUSIVE MODE NOWAIT")
+    )
+    op.execute(
+        sa.text(
+            """
+            DO $torghut$
+            BEGIN
+                IF EXISTS (
+                    SELECT 1
+                      FROM broker_mutation_receipts
+                     WHERE purpose = 'control_plane_validation'
+                ) THEN
+                    RAISE EXCEPTION
+                        'cannot downgrade with infrastructure-validation receipts';
+                END IF;
+            END
+            $torghut$;
+            """
+        )
+    )
+    op.execute(sa.text(f"DROP INDEX {_VALIDATION_PERMIT_INDEX}"))
+    op.drop_constraint(
+        _VALIDATION_CONSTRAINT,
+        "broker_mutation_receipts",
+        type_="check",
+    )
+    _replace_claim_guard(allow_validation=False)
+    _replace_check(_OPERATION_CONSTRAINT, _OPERATION_CONTRACT_0066)
+    _replace_check(_PURPOSE_CONSTRAINT, _PURPOSES_0066)

--- a/services/torghut/tests/execution/test_broker_mutation_submit_coordinator_postgres.py
+++ b/services/torghut/tests/execution/test_broker_mutation_submit_coordinator_postgres.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
 
+import hashlib
+import json
 import uuid
 from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from threading import Barrier, Event, Lock
+from typing import cast
 
 import pytest
 from alembic import command
 from alembic.config import Config as AlembicConfig
 from sqlalchemy import select, text
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, sessionmaker
 
 from app.config import settings
@@ -29,15 +34,29 @@ from app.trading.broker_mutation_receipts import (
     build_broker_mutation_intent,
     build_broker_mutation_settlement,
     consume_broker_mutation_io_permit,
+    fingerprint_broker_endpoint,
     validate_broker_mutation_io_permit,
 )
 from app.trading.broker_mutation_submit_coordinator import (
     BrokerMutationSubmissionAlreadyProcessed,
     BrokerMutationSubmissionDeferred,
+    BrokerMutationSubmissionRejected,
     BrokerMutationSubmitCoordinator,
+    InfrastructureValidationOrderSubmission,
     LinkedOrderSubmission,
     LinkedOrderSubmissionCallbacks,
     UnlinkedOrderSubmissionCallbacks,
+)
+from app.trading.infrastructure_validation import (
+    InfrastructureValidationOrderPlan,
+    InfrastructureValidationPermit,
+    infrastructure_validation_client_order_id,
+    infrastructure_validation_order_plan_sha256,
+    infrastructure_validation_request_payload,
+    infrastructure_validation_terminal_state_sha256,
+)
+from app.trading.infrastructure_validation_submit import (
+    run_infrastructure_validation_submit,
 )
 from tests.execution.decision_submission_claims_postgres_support import (
     POSTGRES_DSN,
@@ -315,6 +334,519 @@ def test_postgres_unlinked_alpaca_closeout_settles_once(
         )
     finally:
         drop_schema(schema, admin_engine, schema_engine)
+
+
+@pytest.mark.skipif(
+    not POSTGRES_DSN,
+    reason="set TORGHUT_TEST_POSTGRES_DSN for the validation-permit race test",
+)
+def test_postgres_validation_permit_race_makes_one_non_promotable_broker_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    schema, admin_engine, schema_engine, schema_dsn = create_schema_engines(
+        "validation_submit"
+    )
+    sessions = sessionmaker(
+        bind=schema_engine,
+        class_=Session,
+        autoflush=False,
+        expire_on_commit=False,
+        future=True,
+    )
+    now = datetime.now(timezone.utc)
+    permit, plan = _validation_fixture(now)
+    request = InfrastructureValidationOrderSubmission(
+        permit=permit,
+        plan=plan,
+        account_label=permit.account_label,
+        account_mode="paper",
+        endpoint_url="https://paper-api.alpaca.markets",
+    )
+    request_payload = infrastructure_validation_request_payload(permit, plan)
+    broker_started = Event()
+    release_broker = Event()
+    broker_call_lock = Lock()
+    broker_calls = 0
+
+    def broker_call(permit_to_consume: BrokerMutationIoPermit) -> Mapping[str, object]:
+        nonlocal broker_calls
+        consume_broker_mutation_io_permit(
+            permit_to_consume,
+            expectation=BrokerMutationIoPermitExpectation(
+                broker_route="alpaca",
+                operation="submit_order",
+                risk_class="risk_neutral",
+                account_label=permit.account_label,
+                endpoint_fingerprint=permit_to_consume.endpoint_fingerprint,
+                request_payload=request_payload,
+            ),
+        )
+        with broker_call_lock:
+            broker_calls += 1
+        broker_started.set()
+        assert release_broker.wait(timeout=10)
+        return {"id": "validation-order-1", "status": "canceled"}
+
+    callbacks = UnlinkedOrderSubmissionCallbacks(
+        broker_call=broker_call,
+        persist_terminal=lambda _result: None,
+        build_settlement=_validation_settlement,
+    )
+
+    try:
+        monkeypatch.setattr(settings, "db_dsn", schema_dsn)
+        alembic = AlembicConfig(str(SERVICE_ROOT / "alembic.ini"))
+        command.stamp(alembic, "0057_generic_multifactor_machine")
+        command.upgrade(alembic, "0061_linked_submission_terminal")
+        command.stamp(alembic, "0065_strategy_capital_compat")
+        command.upgrade(alembic, "0068_validation_submit")
+
+        def run(component: str) -> str:
+            with sessions() as session:
+                try:
+                    BrokerMutationSubmitCoordinator(
+                        component
+                    ).submit_infrastructure_validation_order(
+                        session,
+                        request=request,
+                        callbacks=callbacks,
+                        now=now,
+                    )
+                except BrokerMutationSubmissionAlreadyProcessed:
+                    return "already_processed"
+                except BrokerMutationSubmissionDeferred:
+                    return "deferred"
+            return "submitted"
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            first = executor.submit(run, "validation-a")
+            assert broker_started.wait(timeout=10)
+            second = executor.submit(run, "validation-b")
+            assert second.result(timeout=10) == "deferred"
+            release_broker.set()
+            assert first.result(timeout=15) == "submitted"
+
+        with (
+            sessions() as session,
+            pytest.raises(BrokerMutationSubmissionAlreadyProcessed),
+        ):
+            BrokerMutationSubmitCoordinator(
+                "validation-replay"
+            ).submit_infrastructure_validation_order(
+                session,
+                request=request,
+                callbacks=callbacks,
+                now=now,
+            )
+
+        with sessions() as session:
+            receipt = session.execute(select(BrokerMutationReceipt)).scalar_one()
+            latest = session.execute(
+                select(BrokerMutationReceiptEvent)
+                .where(BrokerMutationReceiptEvent.receipt_id == receipt.id)
+                .order_by(BrokerMutationReceiptEvent.sequence_no.desc())
+                .limit(1)
+            ).scalar_one()
+        intent_payload = json.loads(receipt.canonical_intent_json)
+        validation = intent_payload["request"]["infrastructure_validation"]
+        assert broker_calls == 1
+        assert (
+            receipt.risk_class,
+            receipt.purpose,
+            receipt.submission_claim_id,
+        ) == ("risk_neutral", "control_plane_validation", None)
+        assert validation["permit"]["evidence_tag"] == "non_promotable_validation"
+        assert validation["permit"]["promotable"] is False
+        assert (latest.state, latest.settlement_outcome) == (
+            "settled",
+            "acknowledged",
+        )
+
+        reused_permit, reused_plan = _validation_fixture(
+            now,
+            permit_id=permit.permit_id,
+            symbol="ETH/USD",
+        )
+        with sessions() as session, pytest.raises(BrokerMutationSubmissionDeferred):
+            BrokerMutationSubmitCoordinator(
+                "validation-reuse"
+            ).submit_infrastructure_validation_order(
+                session,
+                request=InfrastructureValidationOrderSubmission(
+                    permit=reused_permit,
+                    plan=reused_plan,
+                    account_label=reused_permit.account_label,
+                    account_mode="paper",
+                    endpoint_url="https://paper-api.alpaca.markets",
+                ),
+                callbacks=callbacks,
+                now=now,
+            )
+        assert broker_calls == 1
+    finally:
+        release_broker.set()
+        drop_schema(schema, admin_engine, schema_engine)
+
+
+def test_control_plane_validation_cannot_use_generic_unlinked_entrypoint() -> None:
+    now = datetime.now(timezone.utc)
+    permit, plan = _validation_fixture(now)
+    request_payload = infrastructure_validation_request_payload(permit, plan)
+    intent = build_broker_mutation_intent(
+        BrokerMutationIntentRequest(
+            broker_route="alpaca",
+            account_label=permit.account_label,
+            endpoint_fingerprint=fingerprint_broker_endpoint(
+                "https://paper-api.alpaca.markets"
+            ),
+            operation="submit_order",
+            risk_class="risk_neutral",
+            purpose="control_plane_validation",
+            workflow_id="generic-bypass",
+            client_request_id="generic-bypass",
+            target=BrokerMutationTarget(kind="order", key="generic-bypass"),
+            request_payload=request_payload,
+        )
+    )
+
+    with pytest.raises(
+        BrokerMutationSubmissionRejected,
+        match="requires_dedicated_submit_authority",
+    ):
+        BrokerMutationSubmitCoordinator("validation-bypass").submit_unlinked_order(
+            cast(Session, object()),
+            intent=intent,
+            callbacks=UnlinkedOrderSubmissionCallbacks(
+                broker_call=lambda _permit: {},
+                persist_terminal=lambda _result: None,
+                build_settlement=_validation_settlement,
+            ),
+        )
+
+
+@pytest.mark.skipif(
+    not POSTGRES_DSN,
+    reason="set TORGHUT_TEST_POSTGRES_DSN for validation authority constraints",
+)
+def test_postgres_validation_authority_rejects_forged_or_incomplete_intents(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    schema, admin_engine, schema_engine, schema_dsn = create_schema_engines(
+        "validation_authority"
+    )
+    now = datetime.now(timezone.utc)
+    permit, plan = _validation_fixture(now, permit_id="ivp-authority-test")
+    client_order_id = infrastructure_validation_client_order_id(permit, plan)
+    intent = build_broker_mutation_intent(
+        BrokerMutationIntentRequest(
+            broker_route="alpaca",
+            account_label=permit.account_label,
+            endpoint_fingerprint="a" * 64,
+            operation="submit_order",
+            risk_class="risk_neutral",
+            purpose="control_plane_validation",
+            workflow_id=client_order_id,
+            client_request_id=client_order_id,
+            target=BrokerMutationTarget(kind="order", key=client_order_id),
+            request_payload=infrastructure_validation_request_payload(permit, plan),
+        )
+    )
+    try:
+        monkeypatch.setattr(settings, "db_dsn", schema_dsn)
+        alembic = AlembicConfig(str(SERVICE_ROOT / "alembic.ini"))
+        command.stamp(alembic, "0057_generic_multifactor_machine")
+        command.upgrade(alembic, "0061_linked_submission_terminal")
+        command.stamp(alembic, "0065_strategy_capital_compat")
+        command.upgrade(alembic, "0068_validation_submit")
+
+        base_document = json.loads(intent.canonical_intent_json)
+        forged_documents: list[dict[str, object]] = []
+        promotable = json.loads(json.dumps(base_document))
+        promotable["request"]["infrastructure_validation"]["permit"]["promotable"] = (
+            True
+        )
+        forged_documents.append(promotable)
+        wide = json.loads(json.dumps(base_document))
+        wide["request"]["infrastructure_validation"]["permit"]["max_notional_usd"] = "2"
+        forged_documents.append(wide)
+        wrong_side = json.loads(json.dumps(base_document))
+        wrong_side["request"]["broker_request"]["side"] = "sell"
+        forged_documents.append(wrong_side)
+        incomplete = json.loads(json.dumps(base_document))
+        del incomplete["request"]["infrastructure_validation"]
+        forged_documents.append(incomplete)
+
+        for document in forged_documents:
+            canonical_json = json.dumps(
+                document,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            with pytest.raises(IntegrityError) as captured:
+                with schema_engine.begin() as connection:
+                    connection.execute(
+                        text(
+                            """
+                            INSERT INTO broker_mutation_receipts (
+                                id, broker_route, account_label,
+                                endpoint_fingerprint, operation, risk_class,
+                                purpose, submission_claim_id, workflow_id,
+                                client_request_id, target_kind, target_key,
+                                intent_schema_version, canonical_intent_json,
+                                canonical_intent_sha256, creator_owner,
+                                origin_writer_generation
+                            ) VALUES (
+                                :id, 'alpaca', :account_label,
+                                :endpoint_fingerprint, 'submit_order',
+                                'risk_neutral', 'control_plane_validation',
+                                NULL, :client_order_id, :client_order_id,
+                                'order', :client_order_id,
+                                'torghut.broker-mutation-intent.v1',
+                                :canonical_intent_json,
+                                :canonical_intent_sha256,
+                                'validation-authority-test', 1
+                            )
+                            """
+                        ),
+                        {
+                            "id": uuid.uuid4(),
+                            "account_label": permit.account_label,
+                            "endpoint_fingerprint": intent.endpoint_fingerprint,
+                            "client_order_id": client_order_id,
+                            "canonical_intent_json": canonical_json,
+                            "canonical_intent_sha256": hashlib.sha256(
+                                canonical_json.encode("utf-8")
+                            ).hexdigest(),
+                        },
+                    )
+            assert (
+                captured.value.orig.diag.constraint_name
+                == "ck_bm_receipt_validation_authority"
+            )
+
+        with schema_engine.connect() as connection:
+            assert (
+                connection.scalar(text("SELECT count(*) FROM broker_mutation_receipts"))
+                == 0
+            )
+    finally:
+        drop_schema(schema, admin_engine, schema_engine)
+
+
+@pytest.mark.skipif(
+    not POSTGRES_DSN,
+    reason="set TORGHUT_TEST_POSTGRES_DSN for the deployed validation runner test",
+)
+def test_postgres_validation_runner_proves_known_null_terminal_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    schema, admin_engine, schema_engine, schema_dsn = create_schema_engines(
+        "validation_runner"
+    )
+    sessions = sessionmaker(
+        bind=schema_engine,
+        class_=Session,
+        autoflush=False,
+        expire_on_commit=False,
+        future=True,
+    )
+    now = datetime.now(timezone.utc)
+    permit, plan = _validation_fixture(now, permit_id="ivp-runner-one")
+    client = _FakeValidationAlpacaClient()
+    try:
+        monkeypatch.setattr(settings, "db_dsn", schema_dsn)
+        monkeypatch.setattr(settings, "trading_kill_switch_enabled", False)
+        alembic = AlembicConfig(str(SERVICE_ROOT / "alembic.ini"))
+        command.stamp(alembic, "0057_generic_multifactor_machine")
+        command.upgrade(alembic, "0061_linked_submission_terminal")
+        command.stamp(alembic, "0065_strategy_capital_compat")
+        command.upgrade(alembic, "0068_validation_submit")
+        with schema_engine.begin() as connection:
+            connection.execute(
+                text(
+                    """
+                    CREATE TABLE execution_order_events (
+                        id UUID PRIMARY KEY,
+                        client_order_id VARCHAR(128),
+                        execution_id UUID,
+                        trade_decision_id UUID,
+                        raw_event JSONB NOT NULL
+                    );
+                    CREATE TABLE tigerbeetle_transfer_refs (
+                        execution_order_event_id UUID
+                    )
+                    """
+                )
+            )
+
+        report = run_infrastructure_validation_submit(
+            permit=permit,
+            plan=plan,
+            client=client,
+            session_factory=sessions,
+            configured_account_label=permit.account_label,
+            now=now,
+        )
+
+        assert report.broker_call_count == 1
+        assert sorted(report.race_outcomes) == ["deferred", "submitted"]
+        assert report.replay_outcome == "already_processed"
+        assert report.receipt_count == 1
+        assert report.receipt_state == "settled"
+        assert report.submission_claim_count == 0
+        assert report.execution_count == 0
+        assert report.trade_decision_count == 0
+        assert report.order_event_count == 0
+        assert report.linked_order_event_count == 0
+        assert report.tigerbeetle_transfer_ref_count == 0
+        assert report.broker_account_number == permit.account_label
+        assert report.terminal_position_count == 0
+        assert report.terminal_open_order_count == 0
+        assert report.evidence_tag == "non_promotable_validation"
+        assert report.promotable is False
+        assert len(client.submissions) == 1
+    finally:
+        drop_schema(schema, admin_engine, schema_engine)
+
+
+class _FakeValidationAlpacaClient:
+    endpoint_class = "paper"
+    endpoint_url = "https://paper-api.alpaca.markets"
+
+    def __init__(self) -> None:
+        self.submissions: list[dict[str, object]] = []
+
+    def get_account(self) -> dict[str, object]:
+        return {
+            "account_number": "dedicated-validation-paper",
+            "status": "ACTIVE",
+            "crypto_status": "ACTIVE",
+            "account_blocked": False,
+            "trading_blocked": False,
+            "trade_suspended_by_user": False,
+        }
+
+    def get_asset(self, _symbol: str) -> dict[str, object]:
+        return {"asset_class": "crypto", "status": "active", "tradable": True}
+
+    def get_order_by_client_order_id_strict(
+        self,
+        client_order_id: str,
+    ) -> dict[str, object] | None:
+        return next(
+            (
+                order
+                for order in self.submissions
+                if order.get("client_order_id") == client_order_id
+            ),
+            None,
+        )
+
+    def list_open_orders(self) -> list[dict[str, object]]:
+        return []
+
+    def list_positions(self) -> list[dict[str, object]]:
+        return []
+
+    def submit_order(
+        self,
+        *,
+        symbol: str,
+        side: str,
+        qty: float,
+        order_type: str,
+        time_in_force: str,
+        limit_price: float | None = None,
+        stop_price: float | None = None,
+        extra_params: dict[str, object] | None = None,
+        firewall_token: object | None = None,
+    ) -> dict[str, object]:
+        del qty, limit_price, stop_price, firewall_token
+        order = {
+            "id": "validation-paper-order-1",
+            "client_order_id": str((extra_params or {})["client_order_id"]),
+            "status": "canceled",
+            "filled_qty": "0",
+            "symbol": symbol,
+            "side": side,
+            "type": order_type,
+            "time_in_force": time_in_force,
+        }
+        self.submissions.append(order)
+        return order
+
+
+def _validation_fixture(
+    now: datetime,
+    *,
+    permit_id: str = "ivp-postgres-one",
+    symbol: str = "BTC/USD",
+) -> tuple[InfrastructureValidationPermit, InfrastructureValidationOrderPlan]:
+    plan = InfrastructureValidationOrderPlan.model_validate(
+        {
+            "schema_version": "torghut.infrastructure-validation-order-plan.v1",
+            "venue": "alpaca",
+            "asset_class": "crypto",
+            "symbol": symbol,
+            "side": "buy",
+            "qty": "1",
+            "order_type": "limit",
+            "time_in_force": "ioc",
+            "limit_price": "1",
+            "stop_price": None,
+        }
+    )
+    return (
+        InfrastructureValidationPermit.model_validate(
+            {
+                "schema_version": "torghut.infrastructure-validation-permit.v2",
+                "permit_id": permit_id,
+                "purpose": "control_plane_validation",
+                "venue": "alpaca",
+                "asset_class": "crypto",
+                "account_mode": "paper",
+                "market_session": "continuous",
+                "account_label": "dedicated-validation-paper",
+                "broker_base_url": "https://paper-api.alpaca.markets",
+                "symbols": [symbol],
+                "sides": ["buy"],
+                "order_types": ["limit"],
+                "max_orders": 1,
+                "max_outstanding_intents": 1,
+                "max_notional_usd": "1",
+                "max_loss_usd": "1",
+                "issued_by": "infrastructure-owner",
+                "approved_by": "independent-infrastructure-owner",
+                "issued_at": now - timedelta(seconds=1),
+                "expires_at": now + timedelta(minutes=5),
+                "test_plan_digest": infrastructure_validation_order_plan_sha256(plan),
+                "expected_terminal_state": "no_open_orders_no_positions_no_unsettled_claims",
+                "expected_terminal_state_digest": infrastructure_validation_terminal_state_sha256(),
+                "evidence_tag": "non_promotable_validation",
+                "promotable": False,
+            }
+        ),
+        plan,
+    )
+
+
+def _validation_settlement(
+    result: Mapping[str, object],
+) -> BrokerMutationSettlement:
+    return build_broker_mutation_settlement(
+        BrokerMutationSettlementRequest(
+            source="primary",
+            outcome="acknowledged",
+            broker_reference=str(result.get("id") or "validation-rejected"),
+            execution_id=None,
+            evidence_payload={
+                "schema_version": "torghut.infrastructure-validation-submit-terminal.v1",
+                "evidence_tag": "non_promotable_validation",
+                "promotable": False,
+                "broker_status": str(result.get("status") or "unknown"),
+            },
+        )
+    )
 
 
 def _persist_execution(

--- a/services/torghut/tests/execution/test_broker_mutation_submit_coordinator_postgres.py
+++ b/services/torghut/tests/execution/test_broker_mutation_submit_coordinator_postgres.py
@@ -56,6 +56,7 @@ from app.trading.infrastructure_validation import (
     infrastructure_validation_terminal_state_sha256,
 )
 from app.trading.infrastructure_validation_submit import (
+    InfrastructureValidationSubmitContext,
     run_infrastructure_validation_submit,
 )
 from tests.execution.decision_submission_claims_postgres_support import (
@@ -359,7 +360,6 @@ def test_postgres_validation_permit_race_makes_one_non_promotable_broker_call(
         permit=permit,
         plan=plan,
         account_label=permit.account_label,
-        account_mode="paper",
         endpoint_url="https://paper-api.alpaca.markets",
     )
     request_payload = infrastructure_validation_request_payload(permit, plan)
@@ -476,7 +476,6 @@ def test_postgres_validation_permit_race_makes_one_non_promotable_broker_call(
                     permit=reused_permit,
                     plan=reused_plan,
                     account_label=reused_permit.account_label,
-                    account_mode="paper",
                     endpoint_url="https://paper-api.alpaca.markets",
                 ),
                 callbacks=callbacks,
@@ -682,10 +681,12 @@ def test_postgres_validation_runner_proves_known_null_terminal_state(
         report = run_infrastructure_validation_submit(
             permit=permit,
             plan=plan,
-            client=client,
-            session_factory=sessions,
-            configured_account_label=permit.account_label,
-            now=now,
+            context=InfrastructureValidationSubmitContext(
+                client=client,
+                session_factory=sessions,
+                configured_account_label=permit.account_label,
+                evaluated_at=now,
+            ),
         )
 
         assert report.broker_call_count == 1

--- a/services/torghut/tests/execution/test_broker_mutation_submit_coordinator_postgres.py
+++ b/services/torghut/tests/execution/test_broker_mutation_submit_coordinator_postgres.py
@@ -14,6 +14,7 @@ import pytest
 from alembic import command
 from alembic.config import Config as AlembicConfig
 from sqlalchemy import select, text
+from sqlalchemy.engine import Engine
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -66,6 +67,29 @@ from tests.execution.decision_submission_claims_postgres_support import (
     drop_schema,
     insert_decision,
 )
+
+
+def _upgrade_validation_submit_schema(
+    alembic: AlembicConfig,
+    schema_engine: Engine,
+) -> None:
+    """Apply the accelerated receipt lineage with its historical catalog prerequisite."""
+
+    command.stamp(alembic, "0057_generic_multifactor_machine")
+    command.upgrade(alembic, "0061_linked_submission_terminal")
+    command.stamp(alembic, "0065_strategy_capital_compat")
+    with schema_engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                CREATE TABLE torghut_options_contract_catalog (
+                    contract_symbol TEXT PRIMARY KEY,
+                    status TEXT NOT NULL
+                )
+                """
+            )
+        )
+    command.upgrade(alembic, "0068_validation_submit")
 
 
 @pytest.mark.skipif(
@@ -396,10 +420,7 @@ def test_postgres_validation_permit_race_makes_one_non_promotable_broker_call(
     try:
         monkeypatch.setattr(settings, "db_dsn", schema_dsn)
         alembic = AlembicConfig(str(SERVICE_ROOT / "alembic.ini"))
-        command.stamp(alembic, "0057_generic_multifactor_machine")
-        command.upgrade(alembic, "0061_linked_submission_terminal")
-        command.stamp(alembic, "0065_strategy_capital_compat")
-        command.upgrade(alembic, "0068_validation_submit")
+        _upgrade_validation_submit_schema(alembic, schema_engine)
 
         def run(component: str) -> str:
             with sessions() as session:
@@ -553,10 +574,7 @@ def test_postgres_validation_authority_rejects_forged_or_incomplete_intents(
     try:
         monkeypatch.setattr(settings, "db_dsn", schema_dsn)
         alembic = AlembicConfig(str(SERVICE_ROOT / "alembic.ini"))
-        command.stamp(alembic, "0057_generic_multifactor_machine")
-        command.upgrade(alembic, "0061_linked_submission_terminal")
-        command.stamp(alembic, "0065_strategy_capital_compat")
-        command.upgrade(alembic, "0068_validation_submit")
+        _upgrade_validation_submit_schema(alembic, schema_engine)
 
         base_document = json.loads(intent.canonical_intent_json)
         forged_documents: list[dict[str, object]] = []
@@ -656,10 +674,7 @@ def test_postgres_validation_runner_proves_known_null_terminal_state(
         monkeypatch.setattr(settings, "db_dsn", schema_dsn)
         monkeypatch.setattr(settings, "trading_kill_switch_enabled", False)
         alembic = AlembicConfig(str(SERVICE_ROOT / "alembic.ini"))
-        command.stamp(alembic, "0057_generic_multifactor_machine")
-        command.upgrade(alembic, "0061_linked_submission_terminal")
-        command.stamp(alembic, "0065_strategy_capital_compat")
-        command.upgrade(alembic, "0068_validation_submit")
+        _upgrade_validation_submit_schema(alembic, schema_engine)
         with schema_engine.begin() as connection:
             connection.execute(
                 text(

--- a/services/torghut/tests/execution/test_broker_mutation_submit_coordinator_postgres.py
+++ b/services/torghut/tests/execution/test_broker_mutation_submit_coordinator_postgres.py
@@ -18,6 +18,9 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, sessionmaker
 
+import app.trading.broker_mutation_submit_coordinator as submit_coordinator_module
+import app.trading.firewall as firewall_module
+import app.trading.infrastructure_validation_submit as validation_submit_module
 from app.config import settings
 from app.models import (
     BrokerMutationReceipt,
@@ -51,6 +54,7 @@ from app.trading.broker_mutation_submit_coordinator import (
 from app.trading.infrastructure_validation import (
     InfrastructureValidationOrderPlan,
     InfrastructureValidationPermit,
+    authorize_infrastructure_validation_order,
     infrastructure_validation_client_order_id,
     infrastructure_validation_order_plan_sha256,
     infrastructure_validation_request_payload,
@@ -670,7 +674,36 @@ def test_postgres_validation_runner_proves_known_null_terminal_state(
     now = datetime.now(timezone.utc)
     permit, plan = _validation_fixture(now, permit_id="ivp-runner-one")
     client = _FakeValidationAlpacaClient()
+    observed_authorization_times: list[datetime] = []
+
+    def recording_authorize(
+        permit_to_authorize: InfrastructureValidationPermit,
+        plan_to_authorize: InfrastructureValidationOrderPlan,
+        *,
+        account_label: str,
+        broker_base_url: str,
+        now: datetime,
+    ) -> InfrastructureValidationPermit:
+        observed_authorization_times.append(now)
+        return authorize_infrastructure_validation_order(
+            permit_to_authorize,
+            plan_to_authorize,
+            account_label=account_label,
+            broker_base_url=broker_base_url,
+            now=now,
+        )
+
     try:
+        for module in (
+            validation_submit_module,
+            submit_coordinator_module,
+            firewall_module,
+        ):
+            monkeypatch.setattr(
+                module,
+                "authorize_infrastructure_validation_order",
+                recording_authorize,
+            )
         monkeypatch.setattr(settings, "db_dsn", schema_dsn)
         monkeypatch.setattr(settings, "trading_kill_switch_enabled", False)
         alembic = AlembicConfig(str(SERVICE_ROOT / "alembic.ini"))
@@ -721,6 +754,7 @@ def test_postgres_validation_runner_proves_known_null_terminal_state(
         assert report.evidence_tag == "non_promotable_validation"
         assert report.promotable is False
         assert len(client.submissions) == 1
+        assert observed_authorization_times == [now] * 6
     finally:
         drop_schema(schema, admin_engine, schema_engine)
 

--- a/services/torghut/tests/order_feed/test_infrastructure_validation_exclusion.py
+++ b/services/torghut/tests/order_feed/test_infrastructure_validation_exclusion.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import uuid
+
+from app.models import BrokerMutationReceipt
+from app.trading.broker_mutation_receipts import (
+    BrokerMutationIntentRequest,
+    BrokerMutationTarget,
+    build_broker_mutation_intent,
+    fingerprint_broker_endpoint,
+)
+from app.trading.infrastructure_validation import (
+    InfrastructureValidationOrderPlan,
+    InfrastructureValidationPermit,
+    infrastructure_validation_client_order_id,
+    infrastructure_validation_order_plan_sha256,
+    infrastructure_validation_request_payload,
+    infrastructure_validation_terminal_state_sha256,
+)
+from app.trading.infrastructure_validation_records import (
+    is_non_promotable_validation_event,
+)
+
+from tests.order_feed.support import (
+    FakeRecord,
+    FakeTigerBeetleClient,
+    OrderFeedTestCase,
+    Session,
+    TigerBeetleTransferRef,
+    datetime,
+    link_order_events_to_execution,
+    normalize_order_feed_record,
+    patch,
+    persist_order_event,
+    repair_order_feed_execution_links,
+    select,
+    settings,
+    timedelta,
+    timezone,
+)
+
+
+class TestInfrastructureValidationExclusion(OrderFeedTestCase):
+    def test_validation_order_event_is_tagged_unlinked_and_not_journaled(
+        self,
+    ) -> None:
+        now = datetime.now(timezone.utc)
+        plan = InfrastructureValidationOrderPlan.model_validate(
+            {
+                "schema_version": "torghut.infrastructure-validation-order-plan.v1",
+                "venue": "alpaca",
+                "asset_class": "crypto",
+                "symbol": "BTC/USD",
+                "side": "buy",
+                "qty": "1",
+                "order_type": "limit",
+                "time_in_force": "ioc",
+                "limit_price": "1",
+                "stop_price": None,
+            }
+        )
+        permit = InfrastructureValidationPermit.model_validate(
+            {
+                "schema_version": "torghut.infrastructure-validation-permit.v2",
+                "permit_id": "ivp-order-feed-test",
+                "purpose": "control_plane_validation",
+                "venue": "alpaca",
+                "asset_class": "crypto",
+                "account_mode": "paper",
+                "market_session": "continuous",
+                "account_label": "paper",
+                "broker_base_url": "https://paper-api.alpaca.markets",
+                "symbols": ["BTC/USD"],
+                "sides": ["buy"],
+                "order_types": ["limit"],
+                "max_orders": 1,
+                "max_outstanding_intents": 1,
+                "max_notional_usd": "1",
+                "max_loss_usd": "1",
+                "issued_by": "infrastructure-owner",
+                "approved_by": "independent-infrastructure-owner",
+                "issued_at": now - timedelta(seconds=1),
+                "expires_at": now + timedelta(minutes=5),
+                "test_plan_digest": infrastructure_validation_order_plan_sha256(plan),
+                "expected_terminal_state": "no_open_orders_no_positions_no_unsettled_claims",
+                "expected_terminal_state_digest": infrastructure_validation_terminal_state_sha256(),
+                "evidence_tag": "non_promotable_validation",
+                "promotable": False,
+            }
+        )
+        client_order_id = infrastructure_validation_client_order_id(permit, plan)
+        intent = build_broker_mutation_intent(
+            BrokerMutationIntentRequest(
+                broker_route="alpaca",
+                account_label="paper",
+                endpoint_fingerprint=fingerprint_broker_endpoint(
+                    "https://paper-api.alpaca.markets"
+                ),
+                operation="submit_order",
+                risk_class="risk_neutral",
+                purpose="control_plane_validation",
+                workflow_id=client_order_id,
+                client_request_id=client_order_id,
+                target=BrokerMutationTarget(kind="order", key=client_order_id),
+                request_payload=infrastructure_validation_request_payload(
+                    permit,
+                    plan,
+                ),
+            )
+        )
+        payload = (
+            '{"channel":"trade_updates","payload":{"event":"fill",'
+            '"timestamp":"2026-07-14T10:00:00Z","order":{'
+            f'"id":"validation-order-1","client_order_id":"{client_order_id}",'
+            '"symbol":"BTC/USD","status":"filled","qty":"1",'
+            '"filled_qty":"1","filled_avg_price":"1"}},"seq":10}'
+        ).encode()
+        settings.tigerbeetle_enabled = True
+        settings.tigerbeetle_journal_enabled = True
+
+        with Session(self.engine) as session:
+            session.add(
+                BrokerMutationReceipt(
+                    id=uuid.uuid4(),
+                    broker_route=intent.broker_route,
+                    account_label=intent.account_label,
+                    endpoint_fingerprint=intent.endpoint_fingerprint,
+                    operation=intent.operation,
+                    risk_class=intent.risk_class,
+                    purpose=intent.purpose,
+                    submission_claim_id=None,
+                    workflow_id=intent.workflow_id,
+                    client_request_id=intent.client_request_id,
+                    target_kind=intent.target.kind,
+                    target_key=intent.target.key,
+                    intent_schema_version=intent.intent_schema_version,
+                    canonical_intent_json=intent.canonical_intent_json,
+                    canonical_intent_sha256=intent.canonical_intent_sha256,
+                    creator_owner="validation-test",
+                    origin_writer_generation=1,
+                )
+            )
+            execution = self._seed_execution(
+                session,
+                account_label="paper",
+                order_id="validation-order-1",
+                client_order_id=client_order_id,
+            )
+            session.flush()
+            normalized = normalize_order_feed_record(
+                FakeRecord(value=payload, offset=91),
+                default_topic="torghut.trade-updates.v1",
+                default_account_label="paper",
+            )
+            assert normalized.event is not None
+            with patch(
+                "app.trading.tigerbeetle_journal.ledger_journal.create_tigerbeetle_client",
+                return_value=FakeTigerBeetleClient(),
+            ):
+                persisted, duplicate = persist_order_event(session, normalized.event)
+            session.commit()
+
+            self.assertFalse(duplicate)
+            self.assertIsNone(persisted.execution_id)
+            self.assertIsNone(persisted.trade_decision_id)
+            self.assertTrue(is_non_promotable_validation_event(persisted.raw_event))
+            self.assertEqual(link_order_events_to_execution(session, execution), 0)
+            repair = repair_order_feed_execution_links(session, account_label="paper")
+            self.assertEqual(repair["events_linked"], 0)
+            session.refresh(persisted)
+            self.assertIsNone(persisted.execution_id)
+            self.assertIsNone(persisted.trade_decision_id)
+            self.assertEqual(
+                session.execute(select(TigerBeetleTransferRef)).scalars().all(),
+                [],
+            )

--- a/services/torghut/tests/test_alpaca_client.py
+++ b/services/torghut/tests/test_alpaca_client.py
@@ -745,6 +745,67 @@ class TestAlpacaClient(TestCase):
         finally:
             config.settings.trading_mode = original
 
+    def test_paper_endpoint_is_authoritative_over_live_runtime_label(self) -> None:
+        from app import config
+
+        original = config.settings.trading_mode
+        config.settings.trading_mode = "live"
+
+        try:
+            with (
+                patch("app.alpaca_client.TradingClient") as mock_read_trading_client,
+                patch(
+                    "app.alpaca_client._SingleAttemptTradingClient"
+                ) as mock_mutation_trading_client,
+                patch(
+                    "app.alpaca_client.StockHistoricalDataClient"
+                ) as mock_data_client,
+            ):
+                client = TorghutAlpacaClient(
+                    api_key="k",
+                    secret_key="s",
+                    base_url="https://paper-api.alpaca.markets",
+                )
+
+                self.assertEqual(client.endpoint_class, "paper")
+                self.assertTrue(mock_read_trading_client.call_args.kwargs["paper"])
+                self.assertTrue(mock_mutation_trading_client.call_args.kwargs["paper"])
+                self.assertTrue(mock_data_client.call_args.kwargs["sandbox"])
+        finally:
+            config.settings.trading_mode = original
+
+    def test_explicit_mode_cannot_conflict_with_endpoint(self) -> None:
+        with self.assertRaisesRegex(ValueError, "alpaca_endpoint_paper_mode_mismatch"):
+            TorghutAlpacaClient(
+                api_key="k",
+                secret_key="s",
+                base_url="https://paper-api.alpaca.markets",
+                paper=False,
+                trading_client=DummyTradingClient(),
+                data_client=DummyDataClient(),
+            )
+
+    def test_trading_endpoint_rejects_noncanonical_paths_or_queries(self) -> None:
+        for endpoint in (
+            "https://paper-api.alpaca.markets/proxy",
+            "https://paper-api.alpaca.markets?route=paper",
+            "https://paper-api.alpaca.markets#paper",
+        ):
+            with (
+                self.subTest(endpoint=endpoint),
+                self.assertRaisesRegex(
+                    ValueError,
+                    "alpaca_trading_endpoint_invalid",
+                ),
+            ):
+                TorghutAlpacaClient(
+                    api_key="k",
+                    secret_key="s",
+                    base_url=endpoint,
+                    trading_client=DummyTradingClient(),
+                    data_client=DummyDataClient(),
+                )
+
     def test_alpaca_base_url_strips_v2_suffix(self) -> None:
         with (
             patch("app.alpaca_client.TradingClient") as mock_read_trading_client,

--- a/services/torghut/tests/test_broker_mutation_submit_wiring.py
+++ b/services/torghut/tests/test_broker_mutation_submit_wiring.py
@@ -20,6 +20,7 @@ def test_every_production_entry_submit_uses_the_durable_coordinator() -> None:
     alpaca_firewall = _source("app/trading/firewall.py")
     hyperliquid_entry = _source("app/hyperliquid_execution/entry_processing.py")
     hyperliquid_exchange = _source("app/hyperliquid_execution/exchange.py")
+    validation_runner = _source("app/trading/infrastructure_validation_submit.py")
 
     assert "BrokerMutationSubmitCoordinator" in alpaca_executor
     assert ".submit_linked_order(" in alpaca_executor
@@ -28,6 +29,21 @@ def test_every_production_entry_submit_uses_the_durable_coordinator() -> None:
 
     assert ".submit_unlinked_order(" in hyperliquid_entry
     assert "consume_broker_mutation_io_permit(" in hyperliquid_exchange
+    assert ".submit_infrastructure_validation_order(" in validation_runner
+    assert "submit_verified_infrastructure_validation_order(" in alpaca_firewall
+
+
+def test_validation_authority_cannot_fall_through_generic_unlinked_submit() -> None:
+    coordinator = _source("app/trading/broker_mutation_submit_coordinator.py")
+    migration = _source("migrations/versions/0068_infrastructure_validation_submit.py")
+
+    assert (
+        "infrastructure_validation_requires_dedicated_submit_authority" in coordinator
+    )
+    assert 'purpose="control_plane_validation"' in coordinator
+    assert 'risk_class="risk_neutral"' in coordinator
+    assert "non_promotable_validation" in migration
+    assert "uq_bm_receipt_validation_permit" in migration
 
 
 def test_retired_live_submit_adapters_cannot_reintroduce_a_bypass() -> None:

--- a/services/torghut/tests/test_infrastructure_validation_permit.py
+++ b/services/torghut/tests/test_infrastructure_validation_permit.py
@@ -169,7 +169,6 @@ def test_crypto_ioc_plan_is_immutably_bound_to_one_non_promotable_identity() -> 
         permit,
         plan,
         account_label=permit.account_label,
-        account_mode="paper",
         broker_base_url="https://paper-api.alpaca.markets",
         now=_NOW,
     )
@@ -245,7 +244,6 @@ def test_order_plan_cannot_escape_permit_bounds(
             permit,
             plan,
             account_label=permit.account_label,
-            account_mode="paper",
             broker_base_url="https://paper-api.alpaca.markets",
             now=_NOW,
         )

--- a/services/torghut/tests/test_infrastructure_validation_permit.py
+++ b/services/torghut/tests/test_infrastructure_validation_permit.py
@@ -12,8 +12,14 @@ from app.trading.evidence_contracts import (
     parse_evidence_contract,
 )
 from app.trading.infrastructure_validation import (
+    InfrastructureValidationOrderPlan,
     InfrastructureValidationPermit,
     authorize_infrastructure_validation,
+    authorize_infrastructure_validation_order,
+    infrastructure_validation_client_order_id,
+    infrastructure_validation_order_plan_sha256,
+    infrastructure_validation_request_payload,
+    infrastructure_validation_terminal_state_sha256,
 )
 
 
@@ -22,10 +28,11 @@ _NOW = datetime(2026, 7, 14, 12, 0, tzinfo=timezone.utc)
 
 def _permit_payload(**overrides: object) -> dict[str, object]:
     payload: dict[str, object] = {
-        "schema_version": "torghut.infrastructure-validation-permit.v1",
+        "schema_version": "torghut.infrastructure-validation-permit.v2",
         "permit_id": "ivp-20260714-001",
         "purpose": "control_plane_validation",
         "venue": "alpaca",
+        "asset_class": "equity",
         "account_mode": "paper",
         "market_session": "regular",
         "account_label": "dedicated-validation-paper",
@@ -118,6 +125,7 @@ def test_hyperliquid_permit_requires_the_testnet_boundary() -> None:
     permit = InfrastructureValidationPermit.model_validate(
         _permit_payload(
             venue="hyperliquid",
+            asset_class="perpetual",
             account_mode="sandbox",
             market_session="continuous",
             broker_base_url="https://api.hyperliquid-testnet.xyz",
@@ -126,6 +134,157 @@ def test_hyperliquid_permit_requires_the_testnet_boundary() -> None:
 
     assert permit.venue == "hyperliquid"
     assert permit.account_mode == "sandbox"
+
+
+def test_crypto_ioc_plan_is_immutably_bound_to_one_non_promotable_identity() -> None:
+    plan = InfrastructureValidationOrderPlan.model_validate(
+        {
+            "schema_version": "torghut.infrastructure-validation-order-plan.v1",
+            "venue": "alpaca",
+            "asset_class": "crypto",
+            "symbol": "BTC/USD",
+            "side": "buy",
+            "qty": "1",
+            "order_type": "limit",
+            "time_in_force": "ioc",
+            "limit_price": "1",
+            "stop_price": None,
+        }
+    )
+    permit = InfrastructureValidationPermit.model_validate(
+        _permit_payload(
+            asset_class="crypto",
+            market_session="continuous",
+            symbols=["BTC/USD"],
+            sides=["buy"],
+            order_types=["limit"],
+            max_notional_usd="1",
+            max_loss_usd="1",
+            test_plan_digest=infrastructure_validation_order_plan_sha256(plan),
+            expected_terminal_state_digest=infrastructure_validation_terminal_state_sha256(),
+        )
+    )
+
+    authorize_infrastructure_validation_order(
+        permit,
+        plan,
+        account_label=permit.account_label,
+        account_mode="paper",
+        broker_base_url="https://paper-api.alpaca.markets",
+        now=_NOW,
+    )
+    client_order_id = infrastructure_validation_client_order_id(permit, plan)
+    payload = infrastructure_validation_request_payload(permit, plan)
+
+    assert len(client_order_id) == 48
+    assert client_order_id.startswith("ivp-")
+    assert payload["broker_request"]["extra_params"] == {
+        "client_order_id": client_order_id
+    }
+    validation = payload["infrastructure_validation"]
+    assert validation["permit"]["evidence_tag"] == "non_promotable_validation"
+    assert validation["permit"]["promotable"] is False
+
+
+@pytest.mark.parametrize(
+    ("permit_overrides", "plan_overrides", "error"),
+    [
+        ({"max_orders": 2}, {}, "requires_single_intent"),
+        ({"symbols": ["BTC/USD", "ETH/USD"]}, {}, "bounds_not_exact"),
+        ({"sides": ["buy", "sell"]}, {}, "bounds_not_exact"),
+        ({"order_types": ["limit", "market"]}, {}, "bounds_not_exact"),
+        (
+            {"max_notional_usd": "0.5", "max_loss_usd": "0.5"},
+            {},
+            "notional_out_of_bounds",
+        ),
+        (
+            {"max_notional_usd": "2", "max_loss_usd": "1"},
+            {},
+            "exceeds_absolute_cap",
+        ),
+        ({"symbols": ["ETH/USD"]}, {}, "symbol_out_of_bounds"),
+        ({"sides": ["sell"]}, {}, "side_out_of_bounds"),
+    ],
+)
+def test_order_plan_cannot_escape_permit_bounds(
+    permit_overrides: dict[str, object],
+    plan_overrides: dict[str, object],
+    error: str,
+) -> None:
+    plan_payload: dict[str, object] = {
+        "schema_version": "torghut.infrastructure-validation-order-plan.v1",
+        "venue": "alpaca",
+        "asset_class": "crypto",
+        "symbol": "BTC/USD",
+        "side": "buy",
+        "qty": "1",
+        "order_type": "limit",
+        "time_in_force": "ioc",
+        "limit_price": "1",
+        "stop_price": None,
+    }
+    plan_payload.update(plan_overrides)
+    plan = InfrastructureValidationOrderPlan.model_validate(plan_payload)
+    permit_payload = _permit_payload(
+        asset_class="crypto",
+        market_session="continuous",
+        symbols=["BTC/USD"],
+        sides=["buy"],
+        order_types=["limit"],
+        max_notional_usd="1",
+        max_loss_usd="1",
+        test_plan_digest=infrastructure_validation_order_plan_sha256(plan),
+        expected_terminal_state_digest=infrastructure_validation_terminal_state_sha256(),
+    )
+    permit_payload.update(permit_overrides)
+    permit = InfrastructureValidationPermit.model_validate(permit_payload)
+
+    with pytest.raises(ValueError, match=error):
+        authorize_infrastructure_validation_order(
+            permit,
+            plan,
+            account_label=permit.account_label,
+            account_mode="paper",
+            broker_base_url="https://paper-api.alpaca.markets",
+            now=_NOW,
+        )
+
+
+def test_submit_plan_rejects_a_short_or_sell_probe() -> None:
+    with pytest.raises(ValidationError):
+        InfrastructureValidationOrderPlan.model_validate(
+            {
+                "schema_version": "torghut.infrastructure-validation-order-plan.v1",
+                "venue": "alpaca",
+                "asset_class": "crypto",
+                "symbol": "BTC/USD",
+                "side": "sell",
+                "qty": "1",
+                "order_type": "limit",
+                "time_in_force": "ioc",
+                "limit_price": "1",
+                "stop_price": None,
+            }
+        )
+
+
+def test_submit_plan_does_not_claim_unimplemented_equity_session_authority() -> None:
+    with pytest.raises(ValidationError):
+        InfrastructureValidationOrderPlan.model_validate(
+            {
+                "schema_version": "torghut.infrastructure-validation-order-plan.v1",
+                "venue": "alpaca",
+                "asset_class": "equity",
+                "symbol": "AAPL",
+                "side": "buy",
+                "qty": "1",
+                "order_type": "limit",
+                "time_in_force": "ioc",
+                "limit_price": "1",
+                "stop_price": None,
+            }
+        )
 
 
 def test_validation_provenance_is_non_authoritative() -> None:

--- a/services/torghut/tests/test_infrastructure_validation_submit.py
+++ b/services/torghut/tests/test_infrastructure_validation_submit.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import threading
+import time
 
 import pytest
 
@@ -16,7 +17,8 @@ from app.trading.infrastructure_validation_submit import (
 def _new_race_state() -> _SubmissionRaceState:
     return _SubmissionRaceState(
         broker_started=threading.Event(),
-        contender_finished=threading.Event(),
+        contender_resolved=threading.Event(),
+        contender_fenced=threading.Event(),
         call_counter=_BrokerCallCounter(),
     )
 
@@ -29,7 +31,10 @@ def test_contender_failure_does_not_open_broker_gate() -> None:
         if component == "validation-contender":
             raise RuntimeError("contender_database_failure")
         state.broker_started.set()
-        if state.contender_finished.wait(timeout=0.1):
+        if (
+            state.contender_resolved.wait(timeout=0.1)
+            and state.contender_fenced.is_set()
+        ):
             broker_gate_opened.set()
         return _WorkerResult("submitted")
 
@@ -40,7 +45,8 @@ def test_contender_failure_does_not_open_broker_gate() -> None:
             timeout_seconds=0.1,
         )
 
-    assert not state.contender_finished.is_set()
+    assert state.contender_resolved.is_set()
+    assert not state.contender_fenced.is_set()
     assert not broker_gate_opened.is_set()
 
 
@@ -51,21 +57,31 @@ def test_contender_timeout_does_not_open_broker_gate() -> None:
 
     def submit(component: str) -> _WorkerResult:
         if component == "validation-contender":
-            hold_contender.wait(timeout=0.1)
+            hold_contender.wait(timeout=0.5)
             return _WorkerResult("deferred")
         state.broker_started.set()
-        if state.contender_finished.wait(timeout=0.1):
+        if (
+            state.contender_resolved.wait(timeout=0.1)
+            and state.contender_fenced.is_set()
+        ):
             broker_gate_opened.set()
         return _WorkerResult("submitted")
 
-    with pytest.raises(TimeoutError):
-        _race_validation_submissions(
-            submit,
-            state=state,
-            timeout_seconds=0.01,
-        )
+    started_at = time.monotonic()
+    try:
+        with pytest.raises(TimeoutError):
+            _race_validation_submissions(
+                submit,
+                state=state,
+                timeout_seconds=0.01,
+            )
+    finally:
+        hold_contender.set()
+    elapsed = time.monotonic() - started_at
 
-    assert not state.contender_finished.is_set()
+    assert elapsed < 0.25
+    assert state.contender_resolved.is_set()
+    assert not state.contender_fenced.is_set()
     assert not broker_gate_opened.is_set()
 
 

--- a/services/torghut/tests/test_infrastructure_validation_submit.py
+++ b/services/torghut/tests/test_infrastructure_validation_submit.py
@@ -28,6 +28,8 @@ def _new_race_state() -> _SubmissionRaceState:
 
 def test_contender_failure_does_not_open_broker_gate() -> None:
     state = _new_race_state()
+    # Exercise contender failure independently of thread-start latency.
+    state.broker_started.set()
     broker_gate_opened = threading.Event()
 
     def submit(component: str) -> _WorkerResult:
@@ -45,7 +47,7 @@ def test_contender_failure_does_not_open_broker_gate() -> None:
         _race_validation_submissions(
             submit,
             state=state,
-            timeout_seconds=0.1,
+            timeout_seconds=2.0,
         )
 
     assert state.contender_resolved.is_set()
@@ -55,6 +57,8 @@ def test_contender_failure_does_not_open_broker_gate() -> None:
 
 def test_contender_timeout_does_not_open_broker_gate() -> None:
     state = _new_race_state()
+    # Exercise the contender deadline independently of thread-start latency.
+    state.broker_started.set()
     broker_gate_opened = threading.Event()
     hold_contender = threading.Event()
 
@@ -82,7 +86,7 @@ def test_contender_timeout_does_not_open_broker_gate() -> None:
         hold_contender.set()
     elapsed = time.monotonic() - started_at
 
-    assert elapsed < 0.25
+    assert elapsed < 1.0
     assert state.contender_resolved.is_set()
     assert not state.contender_fenced.is_set()
     assert not broker_gate_opened.is_set()
@@ -91,6 +95,7 @@ def test_contender_timeout_does_not_open_broker_gate() -> None:
 def test_timeout_does_not_keep_cli_process_alive() -> None:
     script = r"""
 import threading
+import time
 
 from app.trading.infrastructure_validation_submit import (
     _BrokerCallCounter,
@@ -105,6 +110,8 @@ state = _SubmissionRaceState(
     contender_fenced=threading.Event(),
     call_counter=_BrokerCallCounter(),
 )
+# The process-exit assertion targets a hung contender, not worker scheduling.
+state.broker_started.set()
 
 def submit(component: str) -> _WorkerResult:
     if component == "validation-contender":
@@ -114,19 +121,22 @@ def submit(component: str) -> _WorkerResult:
     state.contender_resolved.wait(timeout=1.0)
     return _WorkerResult("failed")
 
+started_at = time.monotonic()
 try:
     _race_validation_submissions(submit, state=state, timeout_seconds=0.01)
 except TimeoutError:
     pass
 else:
     raise AssertionError("race did not time out")
+if time.monotonic() - started_at >= 1.0:
+    raise AssertionError("race exceeded its process-local deadline bound")
 """
 
     subprocess.run(
         [sys.executable, "-c", script],
         cwd=Path(__file__).resolve().parents[1],
         check=True,
-        timeout=5.0,
+        timeout=15.0,
     )
 
 

--- a/services/torghut/tests/test_infrastructure_validation_submit.py
+++ b/services/torghut/tests/test_infrastructure_validation_submit.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import pytest
+
+from app.trading.infrastructure_validation_submit import (
+    _require_known_null_terminal_order,
+)
+
+
+@pytest.mark.parametrize("status", ["canceled", "cancelled", "expired", "rejected"])
+def test_known_null_terminal_order_requires_exact_identity_and_zero_fill(
+    status: str,
+) -> None:
+    order = {
+        "id": "paper-order-1",
+        "client_order_id": "ivp-" + "a" * 44,
+        "status": status,
+        "filled_qty": "0",
+    }
+
+    _require_known_null_terminal_order(
+        order,
+        client_order_id="ivp-" + "a" * 44,
+    )
+
+
+@pytest.mark.parametrize(
+    ("overrides", "error"),
+    [
+        ({"client_order_id": "ivp-" + "b" * 44}, "identity_mismatch"),
+        ({"id": ""}, "identity_missing"),
+        ({"status": "filled", "filled_qty": "1"}, "status_invalid"),
+        ({"status": "canceled", "filled_qty": "0.01"}, "fill_observed"),
+        ({"status": "canceled", "filled_qty": None}, "filled_qty_invalid"),
+    ],
+)
+def test_terminal_order_rejects_wrong_identity_or_any_fill(
+    overrides: dict[str, object],
+    error: str,
+) -> None:
+    order: dict[str, object] = {
+        "id": "paper-order-1",
+        "client_order_id": "ivp-" + "a" * 44,
+        "status": "canceled",
+        "filled_qty": "0",
+    }
+    order.update(overrides)
+
+    with pytest.raises(RuntimeError, match=error):
+        _require_known_null_terminal_order(
+            order,
+            client_order_id="ivp-" + "a" * 44,
+        )

--- a/services/torghut/tests/test_infrastructure_validation_submit.py
+++ b/services/torghut/tests/test_infrastructure_validation_submit.py
@@ -1,10 +1,72 @@
 from __future__ import annotations
 
+import threading
+
 import pytest
 
 from app.trading.infrastructure_validation_submit import (
+    _BrokerCallCounter,
+    _SubmissionRaceState,
+    _WorkerResult,
+    _race_validation_submissions,
     _require_known_null_terminal_order,
 )
+
+
+def _new_race_state() -> _SubmissionRaceState:
+    return _SubmissionRaceState(
+        broker_started=threading.Event(),
+        contender_finished=threading.Event(),
+        call_counter=_BrokerCallCounter(),
+    )
+
+
+def test_contender_failure_does_not_open_broker_gate() -> None:
+    state = _new_race_state()
+    broker_gate_opened = threading.Event()
+
+    def submit(component: str) -> _WorkerResult:
+        if component == "validation-contender":
+            raise RuntimeError("contender_database_failure")
+        state.broker_started.set()
+        if state.contender_finished.wait(timeout=0.1):
+            broker_gate_opened.set()
+        return _WorkerResult("submitted")
+
+    with pytest.raises(RuntimeError, match="contender_database_failure"):
+        _race_validation_submissions(
+            submit,
+            state=state,
+            timeout_seconds=0.1,
+        )
+
+    assert not state.contender_finished.is_set()
+    assert not broker_gate_opened.is_set()
+
+
+def test_contender_timeout_does_not_open_broker_gate() -> None:
+    state = _new_race_state()
+    broker_gate_opened = threading.Event()
+    hold_contender = threading.Event()
+
+    def submit(component: str) -> _WorkerResult:
+        if component == "validation-contender":
+            hold_contender.wait(timeout=0.1)
+            return _WorkerResult("deferred")
+        state.broker_started.set()
+        if state.contender_finished.wait(timeout=0.1):
+            broker_gate_opened.set()
+        return _WorkerResult("submitted")
+
+    with pytest.raises(TimeoutError):
+        _race_validation_submissions(
+            submit,
+            state=state,
+            timeout_seconds=0.01,
+        )
+
+    assert not state.contender_finished.is_set()
+    assert not broker_gate_opened.is_set()
 
 
 @pytest.mark.parametrize("status", ["canceled", "cancelled", "expired", "rejected"])

--- a/services/torghut/tests/test_infrastructure_validation_submit.py
+++ b/services/torghut/tests/test_infrastructure_validation_submit.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import subprocess
+import sys
 import threading
 import time
+from pathlib import Path
 
 import pytest
 
@@ -83,6 +86,48 @@ def test_contender_timeout_does_not_open_broker_gate() -> None:
     assert state.contender_resolved.is_set()
     assert not state.contender_fenced.is_set()
     assert not broker_gate_opened.is_set()
+
+
+def test_timeout_does_not_keep_cli_process_alive() -> None:
+    script = r"""
+import threading
+
+from app.trading.infrastructure_validation_submit import (
+    _BrokerCallCounter,
+    _SubmissionRaceState,
+    _WorkerResult,
+    _race_validation_submissions,
+)
+
+state = _SubmissionRaceState(
+    broker_started=threading.Event(),
+    contender_resolved=threading.Event(),
+    contender_fenced=threading.Event(),
+    call_counter=_BrokerCallCounter(),
+)
+
+def submit(component: str) -> _WorkerResult:
+    if component == "validation-contender":
+        threading.Event().wait()
+        raise AssertionError("unreachable")
+    state.broker_started.set()
+    state.contender_resolved.wait(timeout=1.0)
+    return _WorkerResult("failed")
+
+try:
+    _race_validation_submissions(submit, state=state, timeout_seconds=0.01)
+except TimeoutError:
+    pass
+else:
+    raise AssertionError("race did not time out")
+"""
+
+    subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=Path(__file__).resolve().parents[1],
+        check=True,
+        timeout=5.0,
+    )
 
 
 @pytest.mark.parametrize("status", ["canceled", "cancelled", "expired", "rejected"])

--- a/services/torghut/tests/test_infrastructure_validation_submit.py
+++ b/services/torghut/tests/test_infrastructure_validation_submit.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 import threading
 import time
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -14,6 +15,7 @@ from app.trading.infrastructure_validation_submit import (
     _WorkerResult,
     _race_validation_submissions,
     _require_known_null_terminal_order,
+    _require_submission_validity_window,
 )
 
 
@@ -23,6 +25,26 @@ def _new_race_state() -> _SubmissionRaceState:
         contender_resolved=threading.Event(),
         contender_fenced=threading.Event(),
         call_counter=_BrokerCallCounter(),
+    )
+
+
+def test_submission_window_cannot_reach_permit_expiry() -> None:
+    evaluated_at = datetime(2026, 7, 14, tzinfo=timezone.utc)
+
+    with pytest.raises(
+        ValueError,
+        match="infrastructure_validation_permit_window_too_short",
+    ):
+        _require_submission_validity_window(
+            expires_at=evaluated_at + timedelta(seconds=10),
+            evaluated_at=evaluated_at,
+            timeout_seconds=10,
+        )
+
+    _require_submission_validity_window(
+        expires_at=evaluated_at + timedelta(seconds=10, microseconds=1),
+        evaluated_at=evaluated_at,
+        timeout_seconds=10,
     )
 
 

--- a/services/torghut/tests/test_infrastructure_validation_submit_migration.py
+++ b/services/torghut/tests/test_infrastructure_validation_submit_migration.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from tests.migration_testing import load_migration_module
+
+
+MIGRATION_FILENAME = "0068_infrastructure_validation_submit.py"
+
+
+def test_revision_follows_current_migration_head() -> None:
+    module = load_migration_module(MIGRATION_FILENAME)
+
+    assert module.revision == "0068_validation_submit"
+    assert module.down_revision == "0067_options_archive_status"
+    assert len(module.revision) <= 32
+    assert (
+        len(Path(module.__file__ or "").read_text(encoding="utf-8").splitlines())
+        <= 1000
+    )
+
+
+def test_upgrade_hard_binds_one_non_promotable_permit() -> None:
+    module = load_migration_module(MIGRATION_FILENAME)
+
+    with (
+        patch.object(module.op, "execute") as execute,
+        patch.object(module.op, "drop_constraint") as drop_constraint,
+        patch.object(module.op, "create_check_constraint") as create_check,
+    ):
+        module.upgrade()
+
+    sql = "\n".join(str(call.args[0]) for call in execute.call_args_list)
+    conditions = "\n".join(str(call.args[2]) for call in create_check.call_args_list)
+    assert "ACCESS EXCLUSIVE MODE NOWAIT" in sql
+    assert "control_plane_validation" in sql
+    assert "non_promotable_validation" in sql
+    assert "max_outstanding_intents}' = '1'" in sql
+    assert "CREATE UNIQUE INDEX uq_bm_receipt_validation_permit" in sql
+    assert "CREATE OR REPLACE FUNCTION torghut_guard_bm_claim_0060" in sql
+    assert "control_plane_validation" in conditions
+    assert "OR COALESCE((" in sql
+    assert "^ivp-[0-9a-f]{44}$" in sql
+    assert "e7ce2f426f96cfc1606a46bc494cdfff" in sql
+    assert "permit,asset_class}' = 'crypto'" in sql
+    assert "permit,market_session}' = 'continuous'" in sql
+    assert "= '[\"buy\"]'::jsonb" in sql
+    assert drop_constraint.call_count == 2
+
+
+def test_downgrade_refuses_to_erase_validation_history() -> None:
+    module = load_migration_module(MIGRATION_FILENAME)
+
+    with (
+        patch.object(module.op, "execute") as execute,
+        patch.object(module.op, "drop_constraint") as drop_constraint,
+        patch.object(module.op, "create_check_constraint") as create_check,
+    ):
+        module.downgrade()
+
+    sql = "\n".join(str(call.args[0]) for call in execute.call_args_list)
+    conditions = "\n".join(str(call.args[2]) for call in create_check.call_args_list)
+    assert "cannot downgrade with infrastructure-validation receipts" in sql
+    assert "DROP INDEX uq_bm_receipt_validation_permit" in sql
+    assert "control_plane_validation" not in conditions
+    drop_constraint.assert_any_call(
+        "ck_bm_receipt_validation_authority",
+        "broker_mutation_receipts",
+        type_="check",
+    )

--- a/services/torghut/tests/test_order_firewall.py
+++ b/services/torghut/tests/test_order_firewall.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from datetime import datetime, timedelta, timezone
 from typing import Any
 from unittest import TestCase
 
@@ -11,6 +12,13 @@ from app.trading.firewall import (
     OrderFirewall,
     OrderFirewallBlocked,
 )
+from app.trading.infrastructure_validation import (
+    InfrastructureValidationOrderPlan,
+    InfrastructureValidationPermit,
+    infrastructure_validation_order_plan_sha256,
+    infrastructure_validation_request_payload,
+    infrastructure_validation_terminal_state_sha256,
+)
 from tests.broker_mutation_test_support import (
     alpaca_broker_mutation_test_permit,
     broker_mutation_test_permit,
@@ -18,6 +26,8 @@ from tests.broker_mutation_test_support import (
 
 
 class FakeAlpacaClient:
+    endpoint_url = "https://paper-api.alpaca.markets"
+
     def __init__(self) -> None:
         self.submissions: list[dict[str, Any]] = []
         self.cancel_all_calls = 0
@@ -148,6 +158,54 @@ class TestOrderFirewall(TestCase):
 
         self.assertEqual(response["symbol"], "AAPL")
         self.assertEqual(len(client.submissions), 1)
+
+    def test_validation_submit_requires_exact_non_promotable_permit(self) -> None:
+        settings.trading_kill_switch_enabled = False
+        client = FakeAlpacaClient()
+        firewall = OrderFirewall(client, account_label="dedicated-validation-paper")
+        now = datetime(2026, 7, 14, 21, 30, tzinfo=timezone.utc)
+        permit, plan = _infrastructure_validation_fixture(now)
+        mutation_permit = broker_mutation_test_permit(
+            request_payload=infrastructure_validation_request_payload(permit, plan),
+            broker_route="alpaca",
+            risk_class="risk_neutral",
+            account_label=firewall.account_label,
+            endpoint_url=firewall.broker_endpoint_url,
+        )
+
+        response = firewall.submit_verified_infrastructure_validation_order(
+            permit,
+            plan,
+            mutation_permit=mutation_permit,
+            now=now,
+        )
+
+        self.assertEqual(response["symbol"], "BTC/USD")
+        self.assertEqual(len(client.submissions), 1)
+
+    def test_validation_submit_rejects_wrong_mutation_class(self) -> None:
+        settings.trading_kill_switch_enabled = False
+        client = FakeAlpacaClient()
+        firewall = OrderFirewall(client, account_label="dedicated-validation-paper")
+        now = datetime(2026, 7, 14, 21, 30, tzinfo=timezone.utc)
+        permit, plan = _infrastructure_validation_fixture(now)
+        mutation_permit = broker_mutation_test_permit(
+            request_payload=infrastructure_validation_request_payload(permit, plan),
+            broker_route="alpaca",
+            risk_class="risk_increasing",
+            account_label=firewall.account_label,
+            endpoint_url=firewall.broker_endpoint_url,
+        )
+
+        with self.assertRaises(BrokerMutationReceiptValidationError):
+            firewall.submit_verified_infrastructure_validation_order(
+                permit,
+                plan,
+                mutation_permit=mutation_permit,
+                now=now,
+            )
+
+        self.assertEqual(client.submissions, [])
 
     def test_local_request_validation_precedes_permit_consumption(self) -> None:
         settings.trading_kill_switch_enabled = False
@@ -368,3 +426,52 @@ class TestOrderFirewall(TestCase):
         self.assertEqual(client.asset_calls, ["AAPL"])
         self.assertEqual(client.order_lookup_calls, ["order-123"])
         self.assertEqual(client.client_order_lookup_calls, ["client-123"])
+
+
+def _infrastructure_validation_fixture(
+    now: datetime,
+) -> tuple[InfrastructureValidationPermit, InfrastructureValidationOrderPlan]:
+    plan = InfrastructureValidationOrderPlan.model_validate(
+        {
+            "schema_version": "torghut.infrastructure-validation-order-plan.v1",
+            "venue": "alpaca",
+            "asset_class": "crypto",
+            "symbol": "BTC/USD",
+            "side": "buy",
+            "qty": "1",
+            "order_type": "limit",
+            "time_in_force": "ioc",
+            "limit_price": "1",
+            "stop_price": None,
+        }
+    )
+    permit = InfrastructureValidationPermit.model_validate(
+        {
+            "schema_version": "torghut.infrastructure-validation-permit.v2",
+            "permit_id": "ivp-firewall-test",
+            "purpose": "control_plane_validation",
+            "venue": "alpaca",
+            "asset_class": "crypto",
+            "account_mode": "paper",
+            "market_session": "continuous",
+            "account_label": "dedicated-validation-paper",
+            "broker_base_url": "https://paper-api.alpaca.markets",
+            "symbols": ["BTC/USD"],
+            "sides": ["buy"],
+            "order_types": ["limit"],
+            "max_orders": 1,
+            "max_outstanding_intents": 1,
+            "max_notional_usd": "1",
+            "max_loss_usd": "1",
+            "issued_by": "infrastructure-owner",
+            "approved_by": "independent-infrastructure-owner",
+            "issued_at": now - timedelta(seconds=1),
+            "expires_at": now + timedelta(minutes=5),
+            "test_plan_digest": infrastructure_validation_order_plan_sha256(plan),
+            "expected_terminal_state": "no_open_orders_no_positions_no_unsettled_claims",
+            "expected_terminal_state_digest": infrastructure_validation_terminal_state_sha256(),
+            "evidence_tag": "non_promotable_validation",
+            "promotable": False,
+        }
+    )
+    return permit, plan

--- a/services/torghut/tests/test_strategy_capital_authority_migration_compat.py
+++ b/services/torghut/tests/test_strategy_capital_authority_migration_compat.py
@@ -28,9 +28,10 @@ def test_migration_graph_has_one_merged_head_and_knows_the_released_revision() -
     config = AlembicConfig(str(SERVICE_ROOT / "alembic.ini"))
     scripts = ScriptDirectory.from_config(config)
 
-    assert scripts.get_heads() == ["0067_options_archive_status"]
+    assert scripts.get_heads() == ["0068_validation_submit"]
     assert scripts.get_revision("0063_strategy_capital_authority") is not None
     assert scripts.get_revision("0064_strategy_capital_authority") is not None
     assert scripts.get_revision("0065_strategy_capital_compat") is not None
     assert scripts.get_revision("0066_broker_submit_coordinator") is not None
     assert scripts.get_revision("0067_options_archive_status") is not None
+    assert scripts.get_revision("0068_validation_submit") is not None

--- a/services/torghut/tests/trading_scheduler_autonomy/test_emergency_stop_incident_contains_hooks_and_provenance.py
+++ b/services/torghut/tests/trading_scheduler_autonomy/test_emergency_stop_incident_contains_hooks_and_provenance.py
@@ -393,7 +393,7 @@ class TestEmergencyStopIncidentContainsHooksAndProvenance(
             label="paper-x",
             api_key="k",
             secret_key="s",
-            base_url="https://api.example.invalid",
+            base_url="https://paper-api.alpaca.markets",
             enabled=True,
         )
         pipeline = scheduler._build_pipeline_for_account(lane)


### PR DESCRIPTION
## Summary

- Route the bounded Alpaca paper proof through a dedicated v2 InfrastructureValidationPermit coordinator/firewall path with endpoint-derived paper classification, exact broker-account binding, one crypto buy-limit IOC, and a hard one-dollar ceiling.
- Add migration 0068 with fail-closed structural checks, exact endpoint fingerprint and permit bounds, single-use permit identity, and no generic unlinked-submit fallback.
- Keep asynchronous validation events non-promotable, unlinked from trade decisions/executions, and excluded from simulation progress and TigerBeetle projection.
- Add a deployed concurrency/readback runner, real-PostgreSQL race and forgery coverage, and the operator runbook with independent broker/CNPG proof requirements.
- Require the permit to outlive the bounded race and use one authorization instant across preflight, primary, contender, replay, coordinator, and firewall checks.

## Related Issues

None

## Testing

- Exact head `799d66b137dc8ee24c14ea14a3e940354487b51a`: Torghut CI run 29378311600 and repository CI run 29378311601 passed in full; all eight pytest shards, all four autoresearch shards, PostgreSQL mutation fencing, aggregate coverage, quality/security, and migration guards were green.
- `uv run --frozen pytest -q tests/test_infrastructure_validation_submit.py` (13 passed).
- Real-PostgreSQL `tests/execution/test_broker_mutation_submit_coordinator_postgres.py` (6 passed), including exact authorization-time propagation across all six checks.
- All five repository Pyright profiles (0 errors, 0 warnings).
- Ruff format/check, compileall, structural and changed-file design Pylint gates, migration graph, file-length gate, and Torghut tech-debt ratchet (passed).
- Earlier full local suite before the final review regressions: 5114 passed, 33 skipped; the exact-head CI shards supersede that snapshot.
- Oxfmt check for all touched Torghut profitability and production-readiness documents (passed).

## Breaking Changes

InfrastructureValidationPermit submit authority now requires schema v2 and asset_class. A permit whose remaining lifetime does not strictly exceed the race timeout is rejected before submission. Migration 0068 permits only the dedicated non-promotable Alpaca paper crypto proof; ordinary risk-increasing capital authority remains blocked.

## Checklist

- [x] Testing section documents the exact validation performed (or N/A with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (screenshots not applicable).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
