### PR TITLE
feat(torghut): activate Kafka ClickHouse shadow writer

### DIFF
--- a/argocd/applications/torghut-hyperliquid-feed/parity-cronjob.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/parity-cronjob.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: torghut
   annotations:
     argocd.argoproj.io/sync-wave: "1"
-    argocd.argoproj.io/ignore-healthcheck: "true"
   labels:
     app: torghut-hyperliquid-clickhouse-parity
 spec:

--- a/argocd/applications/torghut-hyperliquid-feed/parity-cronjob.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/parity-cronjob.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: torghut
   annotations:
     argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/ignore-healthcheck: "true"
   labels:
     app: torghut-hyperliquid-clickhouse-parity
 spec:

--- a/argocd/applications/torghut-hyperliquid-feed/writer-deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/writer-deployment.yaml
@@ -8,9 +8,9 @@ metadata:
   labels:
     app: torghut-hyperliquid-clickhouse-writer
 spec:
-  # Activated only after the new image, staging schema, and consumer-group
-  # lineage checks are live. The direct sink remains authoritative meanwhile.
-  replicas: 0
+  # Shadow-writes Kafka records into suffixed staging tables. The direct sink
+  # remains authoritative until the bounded parity gate passes.
+  replicas: 1
   revisionHistoryLimit: 2
   strategy:
     type: Recreate

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -361,7 +361,6 @@ describe('Torghut manifest scheduling', () => {
     const parityJob = getAtPath(parity, ['spec', 'jobTemplate', 'spec'])
     const parityPod = getAtPath(parityJob, ['template', 'spec'])
     const parityContainer = getAtPath(parityPod, ['containers', 0])
-    expect(getAtPath(parity, ['metadata', 'annotations'])['argocd.argoproj.io/ignore-healthcheck']).toBe('true')
     expect(getAtPath(parity, ['spec']).suspend).toBe(true)
     expect(getAtPath(parity, ['spec']).concurrencyPolicy).toBe('Forbid')
     expect(parityJob.backoffLimit).toBe(0)

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -306,6 +306,8 @@ describe('Torghut manifest scheduling', () => {
     expect(data.CLICKHOUSE_WRITER_HIGH_THROUGHPUT_MAX_AGE_MS).toBe('300000')
     expect(data.CLICKHOUSE_WRITER_SPARSE_BATCH_SIZE).toBe('100')
     expect(data.CLICKHOUSE_WRITER_SPARSE_MAX_AGE_MS).toBe('300000')
+    expect(data.CLICKHOUSE_WRITER_AUTO_OFFSET_RESET).toBe('earliest')
+    expect(data.CLICKHOUSE_WRITER_DESTINATION_SUFFIX).toBe('_kafka_staging')
     expect(data.CLICKHOUSE_WRITER_REQUEST_TIMEOUT_MS).toBe('10000')
     expect(data.CLICKHOUSE_PARITY_REQUEST_TIMEOUT_MS).toBe('120000')
     expect(data.CLICKHOUSE_WRITER_KAFKA_OPERATION_TIMEOUT_MS).toBe('10000')
@@ -348,7 +350,7 @@ describe('Torghut manifest scheduling', () => {
 
     const writer = parseManifest('argocd/applications/torghut-hyperliquid-feed/writer-deployment.yaml')
     const writerContainer = getAtPath(writer, ['spec', 'template', 'spec', 'containers', 0])
-    expect(getAtPath(writer, ['spec']).replicas).toBe(0)
+    expect(getAtPath(writer, ['spec']).replicas).toBe(1)
     expect(getAtPath(writer, ['spec', 'strategy']).type).toBe('Recreate')
     expect(String(writerContainer.image)).toMatch(
       /^registry\.ide-newton\.ts\.net\/lab\/torghut-hyperliquid-feed@sha256:[0-9a-f]{64}$/,
@@ -359,6 +361,7 @@ describe('Torghut manifest scheduling', () => {
     const parityJob = getAtPath(parity, ['spec', 'jobTemplate', 'spec'])
     const parityPod = getAtPath(parityJob, ['template', 'spec'])
     const parityContainer = getAtPath(parityPod, ['containers', 0])
+    expect(getAtPath(parity, ['metadata', 'annotations'])['argocd.argoproj.io/ignore-healthcheck']).toBe('true')
     expect(getAtPath(parity, ['spec']).suspend).toBe(true)
     expect(getAtPath(parity, ['spec']).concurrencyPolicy).toBe('Forbid')
     expect(parityJob.backoffLimit).toBe(0)

--- a/services/torghut/tests/live_config_manifest_contract/test_hyperliquid_kafka_clickhouse_staging_manifests.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_hyperliquid_kafka_clickhouse_staging_manifests.py
@@ -22,19 +22,3 @@ def test_kafka_clickhouse_writer_is_active_only_against_staging_tables() -> None
     assert data.get("CLICKHOUSE_ENABLED") == "true"
     assert data.get("CLICKHOUSE_WRITER_AUTO_OFFSET_RESET") == "earliest"
     assert data.get("CLICKHOUSE_WRITER_DESTINATION_SUFFIX") == "_kafka_staging"
-
-
-def test_parity_cronjob_is_an_operator_gate_without_degrading_argo_health() -> None:
-    cronjob = _load_yaml_mapping(
-        "argocd/applications/torghut-hyperliquid-feed/parity-cronjob.yaml"
-    )
-    metadata = cast(Mapping[str, object], cronjob.get("metadata", {}))
-    annotations = cast(Mapping[str, object], metadata.get("annotations", {}))
-    assert annotations.get("argocd.argoproj.io/ignore-healthcheck") == "true"
-
-    spec = cast(Mapping[str, object], cronjob.get("spec", {}))
-    assert spec.get("suspend") is True
-    assert spec.get("concurrencyPolicy") == "Forbid"
-    job_template = cast(Mapping[str, object], spec.get("jobTemplate", {}))
-    job_spec = cast(Mapping[str, object], job_template.get("spec", {}))
-    assert job_spec.get("backoffLimit") == 0

--- a/services/torghut/tests/live_config_manifest_contract/test_hyperliquid_kafka_clickhouse_staging_manifests.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_hyperliquid_kafka_clickhouse_staging_manifests.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from tests.live_config_manifest_contract.support import (
+    Mapping,
+    _load_yaml_mapping,
+    cast,
+)
+
+
+def test_kafka_clickhouse_writer_is_active_only_against_staging_tables() -> None:
+    deployment = _load_yaml_mapping(
+        "argocd/applications/torghut-hyperliquid-feed/writer-deployment.yaml"
+    )
+    spec = cast(Mapping[str, object], deployment.get("spec", {}))
+    assert spec.get("replicas") == 1
+    assert spec.get("strategy") == {"type": "Recreate"}
+
+    config = _load_yaml_mapping(
+        "argocd/applications/torghut-hyperliquid-feed/configmap.yaml"
+    )
+    data = cast(Mapping[str, object], config.get("data", {}))
+    assert data.get("CLICKHOUSE_ENABLED") == "true"
+    assert data.get("CLICKHOUSE_WRITER_AUTO_OFFSET_RESET") == "earliest"
+    assert data.get("CLICKHOUSE_WRITER_DESTINATION_SUFFIX") == "_kafka_staging"
+
+
+def test_parity_cronjob_is_an_operator_gate_without_degrading_argo_health() -> None:
+    cronjob = _load_yaml_mapping(
+        "argocd/applications/torghut-hyperliquid-feed/parity-cronjob.yaml"
+    )
+    metadata = cast(Mapping[str, object], cronjob.get("metadata", {}))
+    annotations = cast(Mapping[str, object], metadata.get("annotations", {}))
+    assert annotations.get("argocd.argoproj.io/ignore-healthcheck") == "true"
+
+    spec = cast(Mapping[str, object], cronjob.get("spec", {}))
+    assert spec.get("suspend") is True
+    assert spec.get("concurrencyPolicy") == "Forbid"
+    job_template = cast(Mapping[str, object], spec.get("jobTemplate", {}))
+    job_spec = cast(Mapping[str, object], job_template.get("spec", {}))
+    assert job_spec.get("backoffLimit") == 0

--- a/services/torghut/tests/live_config_manifest_contract/test_hyperliquid_kafka_clickhouse_staging_manifests.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_hyperliquid_kafka_clickhouse_staging_manifests.py
@@ -22,3 +22,5 @@ def test_kafka_clickhouse_writer_is_active_only_against_staging_tables() -> None
     assert data.get("CLICKHOUSE_ENABLED") == "true"
     assert data.get("CLICKHOUSE_WRITER_AUTO_OFFSET_RESET") == "earliest"
     assert data.get("CLICKHOUSE_WRITER_DESTINATION_SUFFIX") == "_kafka_staging"
+    assert data.get("CLICKHOUSE_WRITER_CATCH_UP_MAX_PARTITION_LAG_RECORDS") == "1000"
+    assert "CLICKHOUSE_WRITER_READINESS_MAX_PARTITION_LAG_RECORDS" not in data


### PR DESCRIPTION
## Summary

- Scale the Kafka-backed Hyperliquid ClickHouse writer from zero to one replica only after the merged storage-repair gate passes.
- Keep all replay writes isolated to `_kafka_staging` tables while the direct ClickHouse sink remains authoritative.
- Require earliest-offset replay, the explicit catch-up lag threshold, staging isolation, and the non-overlapping `Recreate` deployment contract.
- Use the live multi-arch image from #12512/#12513, where operational readiness is independent from retained-history catch-up.
- Keep this PR draft and unmerged while the Ceph SAS reset, flush EIO, SMART, and Kafka stability gates fail.

## Related Issues

None

## Testing

- `./.venv/bin/pytest -q tests/live_config_manifest_contract/test_hyperliquid_kafka_clickhouse_staging_manifests.py` (1 passed)
- `./.venv/bin/ruff check tests/live_config_manifest_contract/test_hyperliquid_kafka_clickhouse_staging_manifests.py`
- `./.venv/bin/ruff format --check tests/live_config_manifest_contract/test_hyperliquid_kafka_clickhouse_staging_manifests.py`
- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts` (16 passed)
- `bun run lint:argocd`
- `nix develop -c kustomize build --enable-helm argocd/applications/torghut-hyperliquid-feed | kubectl apply -n torghut --server-side --dry-run=server --field-manager=argocd-controller -f -`
- CI must rerun all Torghut Pyright, pytest, lint, coverage, manifest, Argo, and kubeconform gates on the rebased head.

## Breaking Changes

None. This adds a shadow consumer and staging-table writes only. It does not change direct-sink authority, Kafka topics, schemas, public endpoints, or runtime readers.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation and rollout follow-ups are tracked in the merged storage-remediation design and evidence runbook.
