### PR TITLE
chore(torghut): promote image sha-3cd1df85c59599c2901940ad13b0a503c1c8f635

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -24,7 +24,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: migrate
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:80b173524e1a0307f8a5a61900bb437b8aecfbdb2eaa443cc66df72d14bde674
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
           imagePullPolicy: Always
           workingDir: /app
           command:
@@ -54,9 +54,9 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: 756d79651464414fc3147a7852197e6197e9f007
+              value: 3cd1df85c59599c2901940ad13b0a503c1c8f635
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:80b173524e1a0307f8a5a61900bb437b8aecfbdb2eaa443cc66df72d14bde674
+              value: sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
             - name: PYTHONPATH
               value: /app
             - name: DB_DSN

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-hyperliquid-runtime
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:80b173524e1a0307f8a5a61900bb437b8aecfbdb2eaa443cc66df72d14bde674
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
           imagePullPolicy: Always
           command:
             - uvicorn
@@ -46,9 +46,9 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: 756d79651464414fc3147a7852197e6197e9f007
+              value: 3cd1df85c59599c2901940ad13b0a503c1c8f635
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:80b173524e1a0307f8a5a61900bb437b8aecfbdb2eaa443cc66df72d14bde674
+              value: sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
             - name: DB_DSN
               valueFrom:
                 secretKeyRef:

--- a/argocd/applications/torghut-options/archive/configmap.yaml
+++ b/argocd/applications/torghut-options/archive/configmap.yaml
@@ -8,12 +8,11 @@ data:
   OPTIONS_CONTRACT_ARCHIVE_PAGE_LIMIT: "10000"
   OPTIONS_CONTRACT_ARCHIVE_REQUESTS_PER_SECOND: "0.1"
   OPTIONS_CONTRACT_ARCHIVE_REFRESH_SEC: "86400"
-  # Keep each catalog status transaction inside the current Ceph-backed
-  # PostgreSQL write budget. A 1,000-row batch exceeded the existing 30s
-  # statement timeout; 100-row batches completed but still produced sustained
-  # wal_buffers_full pressure. Use 10-row writes with a 2s recovery interval.
-  OPTIONS_CONTRACT_ARCHIVE_FINALIZE_BATCH_SIZE: "10"
-  OPTIONS_CONTRACT_ARCHIVE_FINALIZE_INTERVAL_MS: "2000"
+  # Migration 0067 records archive state in a narrow overlay instead of
+  # rewriting the wide catalog rows. Keep the first live rollout bounded to
+  # 100 inserts per transaction with a one-second recovery interval.
+  OPTIONS_CONTRACT_ARCHIVE_FINALIZE_BATCH_SIZE: "100"
+  OPTIONS_CONTRACT_ARCHIVE_FINALIZE_INTERVAL_MS: "1000"
   OPTIONS_CONTRACT_ARCHIVE_STATEMENT_TIMEOUT_MS: "30000"
   OPTIONS_CONTRACT_ARCHIVE_LOCK_TIMEOUT_MS: "5000"
   OPTIONS_CONTRACT_ARCHIVE_RETRY_BASE_SEC: "30"

--- a/argocd/applications/torghut-options/archive/deployment.yaml
+++ b/argocd/applications/torghut-options/archive/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-archive
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:80b173524e1a0307f8a5a61900bb437b8aecfbdb2eaa443cc66df72d14bde674
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -125,9 +125,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1924-g756d79651
+              value: v0.596.0-1932-g3cd1df85c
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 756d79651464414fc3147a7852197e6197e9f007
+              value: 3cd1df85c59599c2901940ad13b0a503c1c8f635
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/archive/deployment.yaml
+++ b/argocd/applications/torghut-options/archive/deployment.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     app: torghut-options-archive
 spec:
-  # Keep the regressed archive contained until the fixed image promotion activates
-  # this replica. The startup gate below also requires migration 0063's valid index.
-  replicas: 1
+  # Image promotion and schema migration must not activate this write workload.
+  # A separate gated Git change enables it after the shared storage path is healthy.
+  replicas: 0
   revisionHistoryLimit: 2
   strategy:
     type: Recreate
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Bump with archive ConfigMap changes so GitOps starts a pod with the
         # new write budget instead of leaving the existing env snapshot alive.
-        proompteng.ai/config-revision: archive-finalize-write-budget-20260714b
+        proompteng.ai/config-revision: archive-overlay-write-budget-20260714a
     spec:
       terminationGracePeriodSeconds: 45
       nodeSelector:
@@ -34,70 +34,46 @@ spec:
         runAsGroup: 999
         seccompProfile:
           type: RuntimeDefault
+      initContainers:
+        - name: await-options-schema
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
+          imagePullPolicy: IfNotPresent
+          command:
+            - python
+            - /schema-gate/await-options-schema.py
+          env:
+            - name: DB_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: torghut-db-app
+                  key: uri
+          volumeMounts:
+            - name: options-schema-gate
+              mountPath: /schema-gate
+              readOnly: true
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
       containers:
         - name: torghut-options-archive
           image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
           imagePullPolicy: IfNotPresent
           command:
-            - /bin/sh
-            - -ec
-          args:
-            - |
-              python - <<'PY'
-              import os
-              import time
-
-              from sqlalchemy import create_engine, text
-              from sqlalchemy.exc import SQLAlchemyError
-
-              raw_dsn = os.environ["DB_DSN"]
-              if raw_dsn.startswith("postgresql://"):
-                  dsn = "postgresql+psycopg://" + raw_dsn.removeprefix("postgresql://")
-              elif raw_dsn.startswith("postgres://"):
-                  dsn = "postgresql+psycopg://" + raw_dsn.removeprefix("postgres://")
-              else:
-                  dsn = raw_dsn
-              deadline = time.monotonic() + 900
-              attempts = 0
-              while True:
-                  attempts += 1
-                  try:
-                      engine = create_engine(dsn, pool_pre_ping=True)
-                      try:
-                          with engine.connect() as connection:
-                              ready = connection.execute(
-                                  text(
-                                      """
-                                      SELECT
-                                        to_regclass('public.torghut_options_archive_membership') IS NOT NULL
-                                        AND COALESCE(
-                                          (
-                                            SELECT index_entry.indisvalid AND index_entry.indisready
-                                            FROM pg_index AS index_entry
-                                            WHERE index_entry.indexrelid = to_regclass(
-                                              'public.ix_options_catalog_active_expiration_symbol'
-                                            )
-                                          ),
-                                          FALSE
-                                        )
-                                      """
-                                  )
-                              ).scalar_one()
-                      finally:
-                          engine.dispose()
-                      if ready:
-                          print(f"options archive migration gate ready after {attempts} attempt(s)")
-                          break
-                  except SQLAlchemyError as error:
-                      print(
-                          "waiting for options archive migration: "
-                          f"attempt={attempts} last_error={type(error).__name__}"
-                      )
-                  if time.monotonic() >= deadline:
-                      raise SystemExit("options archive migrations through 0063 were not ready within 900 seconds")
-                  time.sleep(5)
-              PY
-              exec uvicorn app.options_lane.archive_service:app --host 0.0.0.0 --port 8080
+            - uvicorn
+            - app.options_lane.archive_service:app
+            - --host
+            - 0.0.0.0
+            - --port
+            - "8080"
           envFrom:
             - configMapRef:
                 name: torghut-options-archive-config
@@ -161,3 +137,7 @@ spec:
             capabilities:
               drop:
                 - ALL
+      volumes:
+        - name: options-schema-gate
+          configMap:
+            name: torghut-options-schema-gate

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -31,6 +31,35 @@ spec:
         runAsGroup: 999
         seccompProfile:
           type: RuntimeDefault
+      initContainers:
+        - name: await-options-schema
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
+          imagePullPolicy: IfNotPresent
+          command:
+            - python
+            - /schema-gate/await-options-schema.py
+          env:
+            - name: DB_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: torghut-db-app
+                  key: uri
+          volumeMounts:
+            - name: options-schema-gate
+              mountPath: /schema-gate
+              readOnly: true
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
       containers:
         - name: torghut-options-catalog
           image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
@@ -111,3 +140,7 @@ spec:
             capabilities:
               drop:
                 - ALL
+      volumes:
+        - name: options-schema-gate
+          configMap:
+            name: torghut-options-schema-gate

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -33,7 +33,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:80b173524e1a0307f8a5a61900bb437b8aecfbdb2eaa443cc66df72d14bde674
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -81,9 +81,9 @@ spec:
                   name: torghut-ws-config
                   key: SYMBOLS_ALLOWLIST
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1924-g756d79651
+              value: v0.596.0-1932-g3cd1df85c
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 756d79651464414fc3147a7852197e6197e9f007
+              value: 3cd1df85c59599c2901940ad13b0a503c1c8f635
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:80b173524e1a0307f8a5a61900bb437b8aecfbdb2eaa443cc66df72d14bde674
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -77,9 +77,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1924-g756d79651
+              value: v0.596.0-1932-g3cd1df85c
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 756d79651464414fc3147a7852197e6197e9f007
+              value: 3cd1df85c59599c2901940ad13b0a503c1c8f635
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -32,6 +32,35 @@ spec:
         runAsGroup: 999
         seccompProfile:
           type: RuntimeDefault
+      initContainers:
+        - name: await-options-schema
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
+          imagePullPolicy: IfNotPresent
+          command:
+            - python
+            - /schema-gate/await-options-schema.py
+          env:
+            - name: DB_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: torghut-db-app
+                  key: uri
+          volumeMounts:
+            - name: options-schema-gate
+              mountPath: /schema-gate
+              readOnly: true
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
       containers:
         - name: torghut-options-enricher
           image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
@@ -107,3 +136,7 @@ spec:
             capabilities:
               drop:
                 - ALL
+      volumes:
+        - name: options-schema-gate
+          configMap:
+            name: torghut-options-schema-gate

--- a/argocd/applications/torghut-options/kustomization.yaml
+++ b/argocd/applications/torghut-options/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: torghut
 resources:
   - sealed-secrets.yaml
+  - schema-gate-configmap.yaml
   - archive
   - catalog
   - ws

--- a/argocd/applications/torghut-options/schema-gate-configmap.yaml
+++ b/argocd/applications/torghut-options/schema-gate-configmap.yaml
@@ -1,0 +1,72 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: torghut-options-schema-gate
+  namespace: torghut
+data:
+  await-options-schema.py: |
+    import os
+    import time
+
+    from sqlalchemy import create_engine, text
+    from sqlalchemy.exc import SQLAlchemyError
+
+
+    def sqlalchemy_dsn(raw_dsn: str) -> str:
+        if raw_dsn.startswith("postgresql://"):
+            return "postgresql+psycopg://" + raw_dsn.removeprefix("postgresql://")
+        if raw_dsn.startswith("postgres://"):
+            return "postgresql+psycopg://" + raw_dsn.removeprefix("postgres://")
+        return raw_dsn
+
+
+    timeout_seconds = int(os.environ.get("OPTIONS_SCHEMA_GATE_TIMEOUT_SECONDS", "3600"))
+    deadline = time.monotonic() + timeout_seconds
+    attempts = 0
+    engine = create_engine(sqlalchemy_dsn(os.environ["DB_DSN"]), pool_pre_ping=True)
+
+    try:
+        while True:
+            attempts += 1
+            try:
+                with engine.connect() as connection:
+                    ready = connection.execute(
+                        text(
+                            """
+                            SELECT
+                              to_regclass('public.torghut_options_archive_membership') IS NOT NULL
+                              AND to_regclass('public.torghut_options_contract_archive_status') IS NOT NULL
+                              AND to_regclass('public.torghut_options_active_contract_catalog') IS NOT NULL
+                              AND COALESCE(
+                                (
+                                  SELECT index_entry.indisvalid AND index_entry.indisready
+                                  FROM pg_index AS index_entry
+                                  WHERE index_entry.indexrelid = to_regclass(
+                                    'public.ix_options_catalog_active_expiration_symbol'
+                                  )
+                                ),
+                                FALSE
+                              )
+                            """
+                        )
+                    ).scalar_one()
+                if ready:
+                    print(f"options schema gate ready after {attempts} attempt(s)")
+                    break
+                if attempts == 1 or attempts % 12 == 0:
+                    print(f"waiting for options migration 0067 schema: attempt={attempts}")
+            except SQLAlchemyError as error:
+                print(
+                    "waiting for options schema: "
+                    f"attempt={attempts} last_error={type(error).__name__}"
+                )
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise SystemExit(
+                    "options migrations through 0067 were not ready within "
+                    f"{timeout_seconds} seconds after {attempts} attempt(s)"
+                )
+            time.sleep(min(5, max(1, remaining)))
+    finally:
+        engine.dispose()

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:80b173524e1a0307f8a5a61900bb437b8aecfbdb2eaa443cc66df72d14bde674
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:80b173524e1a0307f8a5a61900bb437b8aecfbdb2eaa443cc66df72d14bde674
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:80b173524e1a0307f8a5a61900bb437b8aecfbdb2eaa443cc66df72d14bde674
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:80b173524e1a0307f8a5a61900bb437b8aecfbdb2eaa443cc66df72d14bde674
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -27,7 +27,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:80b173524e1a0307f8a5a61900bb437b8aecfbdb2eaa443cc66df72d14bde674
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
           workingDir: /app
           command:
             - /bin/sh

--- a/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
+++ b/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-generated-resource-retention
           containers:
             - name: prune-generated-residue
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:80b173524e1a0307f8a5a61900bb437b8aecfbdb2eaa443cc66df72d14bde674
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:80b173524e1a0307f8a5a61900bb437b8aecfbdb2eaa443cc66df72d14bde674
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-14T20:51:36Z"
+        client.knative.dev/updateTimestamp: "2026-07-14T23:00:06Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:80b173524e1a0307f8a5a61900bb437b8aecfbdb2eaa443cc66df72d14bde674
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
           ports:
             - name: http1
               containerPort: 8181
@@ -507,11 +507,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1924-g756d79651
+              value: v0.596.0-1932-g3cd1df85c
             - name: TORGHUT_COMMIT
-              value: 756d79651464414fc3147a7852197e6197e9f007
+              value: 3cd1df85c59599c2901940ad13b0a503c1c8f635
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:80b173524e1a0307f8a5a61900bb437b8aecfbdb2eaa443cc66df72d14bde674
+              value: sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-14T20:51:36Z"
+        client.knative.dev/updateTimestamp: "2026-07-14T23:00:06Z"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
     spec:
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:80b173524e1a0307f8a5a61900bb437b8aecfbdb2eaa443cc66df72d14bde674
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
           ports:
             - name: http1
               containerPort: 8181
@@ -442,11 +442,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1924-g756d79651
+              value: v0.596.0-1932-g3cd1df85c
             - name: TORGHUT_COMMIT
-              value: 756d79651464414fc3147a7852197e6197e9f007
+              value: 3cd1df85c59599c2901940ad13b0a503c1c8f635
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:80b173524e1a0307f8a5a61900bb437b8aecfbdb2eaa443cc66df72d14bde674
+              value: sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -37,7 +37,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:80b173524e1a0307f8a5a61900bb437b8aecfbdb2eaa443cc66df72d14bde674
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
           command:
             - uvicorn
           args:
@@ -458,11 +458,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1924-g756d79651
+              value: v0.596.0-1932-g3cd1df85c
             - name: TORGHUT_COMMIT
-              value: 756d79651464414fc3147a7852197e6197e9f007
+              value: 3cd1df85c59599c2901940ad13b0a503c1c8f635
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:80b173524e1a0307f8a5a61900bb437b8aecfbdb2eaa443cc66df72d14bde674
+              value: sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: smoke
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:80b173524e1a0307f8a5a61900bb437b8aecfbdb2eaa443cc66df72d14bde674
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
           imagePullPolicy: IfNotPresent
           securityContext:
             seccompProfile:

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -555,13 +555,13 @@ describe('Torghut manifest scheduling', () => {
   it('bounds options archive finalization writes and rolls ConfigMap changes', () => {
     const config = parseManifest('argocd/applications/torghut-options/archive/configmap.yaml')
     const data = getAtPath(config, ['data'])
-    expect(data.OPTIONS_CONTRACT_ARCHIVE_FINALIZE_BATCH_SIZE).toBe('10')
-    expect(data.OPTIONS_CONTRACT_ARCHIVE_FINALIZE_INTERVAL_MS).toBe('2000')
+    expect(data.OPTIONS_CONTRACT_ARCHIVE_FINALIZE_BATCH_SIZE).toBe('100')
+    expect(data.OPTIONS_CONTRACT_ARCHIVE_FINALIZE_INTERVAL_MS).toBe('1000')
     expect(data.OPTIONS_CONTRACT_ARCHIVE_STATEMENT_TIMEOUT_MS).toBe('30000')
 
     const deployment = parseManifest('argocd/applications/torghut-options/archive/deployment.yaml')
     expect(getAtPath(deployment, ['spec', 'template', 'metadata', 'annotations'])).toMatchObject({
-      'proompteng.ai/config-revision': 'archive-finalize-write-budget-20260714b',
+      'proompteng.ai/config-revision': 'archive-overlay-write-budget-20260714a',
     })
   })
 

--- a/packages/scripts/src/torghut/__tests__/options-schema-gate.test.ts
+++ b/packages/scripts/src/torghut/__tests__/options-schema-gate.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import YAML from 'yaml'
+
+import { repoRoot } from '../../shared/cli'
+
+const optionsRoot = join(repoRoot, 'argocd/applications/torghut-options')
+const deployments = ['archive', 'catalog', 'enricher']
+
+test('gates promoted options workloads on the complete migration 0067 schema', () => {
+  const gate = YAML.parse(readFileSync(join(optionsRoot, 'schema-gate-configmap.yaml'), 'utf8')) as {
+    data?: Record<string, string>
+  }
+  const gateScript = gate.data?.['await-options-schema.py'] ?? ''
+
+  expect(gateScript).toContain('torghut_options_archive_membership')
+  expect(gateScript).toContain('ix_options_catalog_active_expiration_symbol')
+  expect(gateScript).toContain('torghut_options_contract_archive_status')
+  expect(gateScript).toContain('torghut_options_active_contract_catalog')
+  expect(gateScript).toContain('migrations through 0067')
+
+  for (const component of deployments) {
+    const deployment = YAML.parse(readFileSync(join(optionsRoot, component, 'deployment.yaml'), 'utf8')) as {
+      spec?: {
+        template?: {
+          spec?: {
+            containers?: Array<{ image?: string }>
+            initContainers?: Array<{
+              command?: string[]
+              env?: Array<{ name?: string; valueFrom?: { secretKeyRef?: { key?: string; name?: string } } }>
+              image?: string
+              name?: string
+              volumeMounts?: Array<{ mountPath?: string; name?: string; readOnly?: boolean }>
+            }>
+            volumes?: Array<{ configMap?: { name?: string }; name?: string }>
+          }
+        }
+      }
+    }
+    const pod = deployment.spec?.template?.spec
+    const appImage = pod?.containers?.[0]?.image
+    const initContainer = pod?.initContainers?.find((container) => container.name === 'await-options-schema')
+    const dsn = initContainer?.env?.find((env) => env.name === 'DB_DSN')
+
+    expect(initContainer?.image, `${component} gate image`).toBe(appImage)
+    expect(initContainer?.command).toEqual(['python', '/schema-gate/await-options-schema.py'])
+    expect(dsn?.valueFrom?.secretKeyRef).toEqual({ name: 'torghut-db-app', key: 'uri' })
+    expect(initContainer?.volumeMounts).toContainEqual({
+      name: 'options-schema-gate',
+      mountPath: '/schema-gate',
+      readOnly: true,
+    })
+    expect(pod?.volumes).toContainEqual({
+      name: 'options-schema-gate',
+      configMap: { name: 'torghut-options-schema-gate' },
+    })
+  }
+})
+
+test('keeps archive activation separate from image promotion', () => {
+  const archive = YAML.parse(readFileSync(join(optionsRoot, 'archive', 'deployment.yaml'), 'utf8')) as {
+    spec?: { replicas?: number }
+  }
+
+  expect(archive.spec?.replicas).toBe(0)
+})

--- a/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
+++ b/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
@@ -149,6 +149,9 @@ kind: Deployment
 spec:
 ${container === 'torghut-options-archive' ? '  replicas: 0\n' : ''}  template:
     spec:
+      initContainers:
+        - name: await-options-schema
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1111111111111111111111111111111111111111111111111111111111111111
       containers:
         - name: ${container}
           image: registry.ide-newton.ts.net/lab/torghut@sha256:1111111111111111111111111111111111111111111111111111111111111111
@@ -361,10 +364,15 @@ describe('update-manifests', () => {
       expect(manifest).toContain(
         'image: registry.ide-newton.ts.net/lab/torghut@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
       )
+      expect(
+        manifest.match(
+          /image: registry\.ide-newton\.ts\.net\/lab\/torghut@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e/g,
+        )?.length,
+      ).toBe(2)
       expect(manifest).toContain('value: v0.600.0')
       expect(manifest).toContain('value: 1234567890abcdef1234567890abcdef12345678')
     }
-    expect(optionsArchiveManifest).toContain('  replicas: 1')
+    expect(optionsArchiveManifest).toContain('  replicas: 0')
     expect(result.changed).toBe(true)
     expect(result.imageRef).toBe(
       'registry.ide-newton.ts.net/lab/torghut@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
@@ -389,6 +397,11 @@ describe('update-manifests', () => {
       expect(manifest).toContain(
         'image: registry.ide-newton.ts.net/lab/torghut@sha256:1111111111111111111111111111111111111111111111111111111111111111',
       )
+      expect(
+        manifest.match(
+          /image: registry\.ide-newton\.ts\.net\/lab\/torghut@sha256:1111111111111111111111111111111111111111111111111111111111111111/g,
+        )?.length,
+      ).toBe(2)
       expect(manifest).toContain('value: old-version')
       expect(manifest).toContain('value: old-commit')
     }

--- a/packages/scripts/src/torghut/update-manifests.ts
+++ b/packages/scripts/src/torghut/update-manifests.ts
@@ -265,6 +265,11 @@ const updateVersionedDeploymentManifest = (
     `$1${imageRef}`,
     label,
   )
+  updated = replaceAllIfPresent(
+    updated,
+    new RegExp(`(\\n\\s*image:\\s*)${escapeRegex(options.imageName)}(?:@sha256:[0-9a-f]{64}|:[^\\s\\n]+)?`, 'g'),
+    `$1${imageRef}`,
+  )
   updated = replaceSingle(
     updated,
     new RegExp(`(- name:\\s*${escapeRegex(versionEnvName)}\\s*\\n\\s*value:\\s*)([^\\n]+)`),
@@ -286,19 +291,6 @@ const updateVersionedDeploymentManifest = (
     manifestPath,
     imageRef,
     changed: updated !== source,
-  }
-}
-
-const activateDeploymentManifest = (result: ReturnType<typeof updateVersionedDeploymentManifest>) => {
-  const source = readFileSync(result.manifestPath, 'utf8')
-  if (/^  replicas:\s*1\s*$/m.test(source)) {
-    return result
-  }
-  const updated = replaceSingle(source, /^  replicas:\s*0\s*$/m, '  replicas: 1', 'options archive replica activation')
-  writeFileSync(result.manifestPath, updated, 'utf8')
-  return {
-    ...result,
-    changed: true,
   }
 }
 
@@ -362,15 +354,13 @@ const updateTorghutManifests = (options: UpdateManifestsOptions) => {
   const includeOptionsManifests = options.includeOptionsManifests ?? true
   const optionalResults = includeOptionsManifests
     ? [
-        activateDeploymentManifest(
-          updateVersionedDeploymentManifest(
-            options,
-            options.optionsArchiveManifestPath ?? defaultOptionsArchiveManifestPath,
-            'torghut-options-archive',
-            'TORGHUT_OPTIONS_VERSION',
-            'TORGHUT_OPTIONS_COMMIT',
-            'torghut-options-archive image reference',
-          ),
+        updateVersionedDeploymentManifest(
+          options,
+          options.optionsArchiveManifestPath ?? defaultOptionsArchiveManifestPath,
+          'torghut-options-archive',
+          'TORGHUT_OPTIONS_VERSION',
+          'TORGHUT_OPTIONS_COMMIT',
+          'torghut-options-archive image reference',
         ),
         updateVersionedDeploymentManifest(
           options,


### PR DESCRIPTION
## Summary

- promote Torghut source `3cd1df85c59599c2901940ad13b0a503c1c8f635` as digest `sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb`
- include migration 0067 and gate options catalog, enricher, and archive startup on its complete schema
- keep the archive worker declaratively at zero replicas so image promotion cannot activate the write workload
- update promotion tooling to advance application and schema-gate images together
- configure the future archive overlay rollout for bounded 100-row transactions with a one-second interval

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/options-schema-gate.test.ts packages/scripts/src/torghut/__tests__/update-manifests.test.ts packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `bun run --filter @proompteng/scripts lint`
- `nix develop --command bun run lint:argocd`
- compile the embedded schema-gate Python with `python` after YAML extraction
- `nix develop --command kustomize build --enable-helm argocd/applications/torghut-options`
- rendered options manifests accepted by `kubectl apply --server-side --dry-run=server -n torghut`

## Breaking Changes

None. Migration 0067 is additive. Options workloads wait for its structural objects, and the archive remains disabled until a separate storage-health-gated activation.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately; screenshots are not applicable to this backend and GitOps rollout.
- [x] Documentation, release notes, and follow-ups are updated or tracked in the storage remediation design and rollout evidence.
