### PR TITLE
fix(torghut): ignore suspended parity health

### DIFF
--- a/argocd/applications/torghut-hyperliquid-feed/parity-cronjob.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/parity-cronjob.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: torghut
   annotations:
     argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/ignore-healthcheck: "true"
   labels:
     app: torghut-hyperliquid-clickhouse-parity
 spec:

--- a/packages/scripts/src/torghut/__tests__/parity-health.test.ts
+++ b/packages/scripts/src/torghut/__tests__/parity-health.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import YAML from 'yaml'
+
+import { repoRoot } from '../../shared/cli'
+
+test('ignores the intentionally suspended Hyperliquid parity gate in Argo health', () => {
+  const path = join(repoRoot, 'argocd/applications/torghut-hyperliquid-feed/parity-cronjob.yaml')
+  const manifest = YAML.parse(readFileSync(path, 'utf8')) as {
+    metadata?: { annotations?: Record<string, string> }
+    spec?: { suspend?: boolean }
+  }
+
+  expect(manifest.spec?.suspend).toBe(true)
+  expect(manifest.metadata?.annotations?.['argocd.argoproj.io/ignore-healthcheck']).toBe('true')
+})


### PR DESCRIPTION
## Summary

- mark the intentionally suspended Hyperliquid parity CronJob as ignored for Argo health aggregation
- preserve the parity gate as suspended until the Kafka-backed writer is intentionally activated
- add a manifest regression test covering both the suspension and health-ignore contract

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/parity-health.test.ts`
- `bunx oxfmt --check argocd/applications/torghut-hyperliquid-feed/parity-cronjob.yaml packages/scripts/src/torghut/__tests__/parity-health.test.ts`
- `nix develop --command bun run lint:argocd`
- `nix develop --command kustomize build --enable-helm argocd/applications/torghut-hyperliquid-feed`
- rendered manifests applied with `kubectl apply --server-side --dry-run=server -n torghut -f /tmp/torghut-hyperliquid-parity-health.yaml`

## Breaking Changes

None. The CronJob remains suspended; this only prevents intentional suspension from degrading the parent Argo application.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked; no additional documentation is required for this health-only correction.
