### PR TITLE
perf(torghut): extend options ClickHouse flush

### DIFF
--- a/argocd/applications/torghut-options/ta/configmap.yaml
+++ b/argocd/applications/torghut-options/ta/configmap.yaml
@@ -12,7 +12,9 @@ data:
   OPTIONS_TA_CONTRACT_BARS_TOPIC: "torghut.options.ta.contract-bars.1s.v1"
   OPTIONS_TA_CONTRACT_FEATURES_TOPIC: "torghut.options.ta.contract-features.v1"
   OPTIONS_TA_CLICKHOUSE_BATCH_SIZE: "1000"
-  OPTIONS_TA_CLICKHOUSE_FLUSH_MS: "5000"
+  # Sparse after-hours tables need the accepted 30-second age bound to avoid
+  # recreating tiny parts while staying inside the 120-second freshness SLO.
+  OPTIONS_TA_CLICKHOUSE_FLUSH_MS: "30000"
   OPTIONS_TA_CLICKHOUSE_SINK_PARALLELISM: "1"
   OPTIONS_TA_SURFACE_FEATURES_TOPIC: "torghut.options.ta.surface-features.v1"
   OPTIONS_TA_STATUS_TOPIC: "torghut.options.ta.status.v1"

--- a/argocd/applications/torghut-options/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut-options/ta/flinkdeployment.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:f0acc631d1f49273af38b3e15a726391ff29314fcd80f6815f7d7e014d9c778e
   imagePullPolicy: IfNotPresent
-  restartNonce: 32
+  restartNonce: 33
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   flinkConfiguration:

--- a/services/torghut/tests/live_config_manifest_contract/test_product_applicationset_renders_torghut_namespace_security_metadata.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_product_applicationset_renders_torghut_namespace_security_metadata.py
@@ -116,14 +116,14 @@ class TestProductApplicationsetRendersTorghutNamespaceSecurityMetadata(
         config_data = cast(Mapping[str, object], data)
 
         self.assertEqual(config_data.get("OPTIONS_TA_CLICKHOUSE_BATCH_SIZE"), "1000")
-        self.assertEqual(config_data.get("OPTIONS_TA_CLICKHOUSE_FLUSH_MS"), "5000")
+        self.assertEqual(config_data.get("OPTIONS_TA_CLICKHOUSE_FLUSH_MS"), "30000")
         self.assertEqual(config_data.get("OPTIONS_TA_CLICKHOUSE_SINK_PARALLELISM"), "1")
 
         deployment = _load_yaml_mapping(
             "argocd/applications/torghut-options/ta/flinkdeployment.yaml"
         )
         spec = cast(Mapping[str, object], deployment.get("spec", {}))
-        self.assertGreaterEqual(int(str(spec.get("restartNonce"))), 32)
+        self.assertGreaterEqual(int(str(spec.get("restartNonce"))), 33)
 
     def test_direct_torghut_deployments_bound_replica_set_history(self) -> None:
         deployment_paths = [


### PR DESCRIPTION
## Summary

- extend the Options TA ClickHouse age-triggered flush from 5 seconds to the accepted 30-second write-pressure bound
- restart the Flink deployment so the new batching age takes effect immediately after GitOps reconciliation
- update the manifest contract regression test for the production value and restart nonce

## Related Issues

None.

## Testing

- `uv run --frozen pytest tests/live_config_manifest_contract/test_product_applicationset_renders_torghut_namespace_security_metadata.py -k production_options_ta_clickhouse_sink_uses_batched_inserts -q`
- `uv run --frozen ruff format --check tests/live_config_manifest_contract/test_product_applicationset_renders_torghut_namespace_security_metadata.py`
- `uv run --frozen ruff check tests/live_config_manifest_contract/test_product_applicationset_renders_torghut_namespace_security_metadata.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `nix develop --command bun run lint:argocd`
- `nix develop --command kustomize build --enable-helm argocd/applications/torghut-options`
- server-side forced-conflict dry-run of the rendered manifests against the live `torghut` namespace; forcing is dry-run-only and covers the two intentionally changed Argo-owned fields

## Screenshots (if applicable)

N/A; this is a GitOps runtime configuration change.

## Breaking Changes

None. The 30-second flush age remains within the existing 120-second ClickHouse freshness SLO.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked; live before/after evidence will be recorded in the existing storage rollout evidence document after reconciliation.
