### PR TITLE
chore(torghut): promote image sha-2551ef69cd01c2cd10244fc4e13d14a4be8b1973

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -54,7 +54,7 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: 20c0fcfecd1f89b1e4ed404515a7a10e2201544d
+              value: 2551ef69cd01c2cd10244fc4e13d14a4be8b1973
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
             - name: PYTHONPATH

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -46,7 +46,7 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: 20c0fcfecd1f89b1e4ed404515a7a10e2201544d
+              value: 2551ef69cd01c2cd10244fc4e13d14a4be8b1973
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
             - name: DB_DSN

--- a/argocd/applications/torghut-options/archive/deployment.yaml
+++ b/argocd/applications/torghut-options/archive/deployment.yaml
@@ -101,9 +101,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1935-g20c0fcfec
+              value: v0.596.0-1937-g2551ef69c
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 20c0fcfecd1f89b1e4ed404515a7a10e2201544d
+              value: 2551ef69cd01c2cd10244fc4e13d14a4be8b1973
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -110,9 +110,9 @@ spec:
                   name: torghut-ws-config
                   key: SYMBOLS_ALLOWLIST
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1935-g20c0fcfec
+              value: v0.596.0-1937-g2551ef69c
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 20c0fcfecd1f89b1e4ed404515a7a10e2201544d
+              value: 2551ef69cd01c2cd10244fc4e13d14a4be8b1973
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -106,9 +106,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1935-g20c0fcfec
+              value: v0.596.0-1937-g2551ef69c
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 20c0fcfecd1f89b1e4ed404515a7a10e2201544d
+              value: 2551ef69cd01c2cd10244fc4e13d14a4be8b1973
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-14T23:35:46Z"
+        client.knative.dev/updateTimestamp: "2026-07-14T23:56:03Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -507,9 +507,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1935-g20c0fcfec
+              value: v0.596.0-1937-g2551ef69c
             - name: TORGHUT_COMMIT
-              value: 20c0fcfecd1f89b1e4ed404515a7a10e2201544d
+              value: 2551ef69cd01c2cd10244fc4e13d14a4be8b1973
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-14T23:35:46Z"
+        client.knative.dev/updateTimestamp: "2026-07-14T23:56:03Z"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
     spec:
@@ -442,9 +442,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1935-g20c0fcfec
+              value: v0.596.0-1937-g2551ef69c
             - name: TORGHUT_COMMIT
-              value: 20c0fcfecd1f89b1e4ed404515a7a10e2201544d
+              value: 2551ef69cd01c2cd10244fc4e13d14a4be8b1973
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -458,9 +458,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1935-g20c0fcfec
+              value: v0.596.0-1937-g2551ef69c
             - name: TORGHUT_COMMIT
-              value: 20c0fcfecd1f89b1e4ed404515a7a10e2201544d
+              value: 2551ef69cd01c2cd10244fc4e13d14a4be8b1973
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `2551ef69cd01c2cd10244fc4e13d14a4be8b1973`
- Image tag: `sha-2551ef69cd01c2cd10244fc4e13d14a4be8b1973`
- Image digest: `sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher