### PR TITLE
docs(torghut): finalize storage rollout evidence

### DIFF
--- a/docs/torghut/rollouts/2026-07-14-storage-write-pressure-remediation.md
+++ b/docs/torghut/rollouts/2026-07-14-storage-write-pressure-remediation.md
@@ -1,6 +1,6 @@
 # Torghut and Ceph Write-Pressure Remediation Rollout
 
-Last updated: **2026-07-14 13:50 UTC**
+Last updated: **2026-07-14 15:03 UTC**
 
 Status: **in progress**
 
@@ -14,19 +14,23 @@ physical network upgrade remain external constraints defined by the accepted des
 
 ## Delivered changes
 
-| Slice                                                 | Pull request   | Production state                                                               |
-| ----------------------------------------------------- | -------------- | ------------------------------------------------------------------------------ |
-| Accepted design and source map                        | #12403         | Merged                                                                         |
-| Delta-only options subscription reconciliation        | #12407         | Merged and live                                                                |
-| Per-table Hyperliquid ClickHouse batching             | #12409, #12410 | Merged and live                                                                |
-| Bounded live discovery                                | #12421, #12432 | Merged and live                                                                |
-| Set-based options persistence                         | #12435, #12437 | Merged and live                                                                |
-| Resumable archival reconciliation                     | #12438, #12439 | Merged; archive worker contained at zero replicas pending finalizer correction |
-| Bounded archive finalization                          | #12441, #12449 | Source and image promoted; composite-key correction #12452 pending             |
-| Released migration revision compatibility             | #12454         | PostgreSQL 17 proof complete; merge and image promotion pending                |
-| Shared CNPG, Ceph, and RBD-client observability       | #12443         | Merged and live                                                                |
-| Ceph scrub concurrency and count correction           | #12453         | Runtime containment live; GitOps merge pending                                 |
-| Bilig PostgreSQL capacity and logical-WAL containment | #12447         | Merged and live                                                                |
+| Slice                                                 | Pull request    | Production state                                                               |
+| ----------------------------------------------------- | --------------- | ------------------------------------------------------------------------------ |
+| Accepted design and source map                        | #12403          | Merged                                                                         |
+| Delta-only options subscription reconciliation        | #12407          | Merged and live                                                                |
+| Per-table Hyperliquid ClickHouse batching             | #12409, #12410  | Merged and live                                                                |
+| Options TA ClickHouse batching                        | #12455          | Source review rerun pending; digest-pinned activation PR follows publication   |
+| Kafka-backed Hyperliquid ClickHouse writer            | #12440          | CI green; current-head source review pending; staged at zero replicas          |
+| Kafka/ClickHouse retained-record parity gate          | local 92cce1849 | Validated dependent slice; publish after #12440 lands                          |
+| Bounded live discovery                                | #12421, #12432  | Merged and live                                                                |
+| Set-based options persistence                         | #12435, #12437  | Merged and live                                                                |
+| Resumable archival reconciliation                     | #12438, #12439  | Merged; archive worker contained at zero replicas pending finalizer correction |
+| Bounded archive finalization                          | #12441, #12449  | Source and image promoted; composite-key correction #12452 pending             |
+| Released migration revision compatibility             | #12454          | PostgreSQL 17 proof complete; merge and image promotion pending                |
+| Shared CNPG, Ceph, and RBD-client observability       | #12443          | Merged and live                                                                |
+| Ceph scrub concurrency and count correction           | #12453          | Runtime containment live; GitOps merge pending                                 |
+| Bilig PostgreSQL capacity and logical-WAL containment | #12447          | Merged and live                                                                |
+| Torghut PostgreSQL WAL-buffer containment             | #12457          | 16 MiB setting validated; current-head review and scrub-safe restart pending   |
 
 ## Live proof
 
@@ -47,6 +51,20 @@ ClickHouse `system.part_log` shows the production transition at 07:00 UTC:
 
 Sparse tables flush on the 30-second age limit when they cannot reach 100 rows. They are evaluated separately from the
 size-triggered BBO gate.
+
+### Options TA direct-sink diagnosis
+
+The next dominant ClickHouse writer was traced to the Options Flink JDBC sinks rather than the Hyperliquid feed. In a
+15-minute production sample, `options_contract_features`, `options_contract_bars_1s`, and `options_surface_features`
+created 5,359 new parts at only 19-43 rows per part. The live Flink graph showed all three JDBC sinks at parallelism
+four, the client flushed every 250 milliseconds, and shared code capped the requested batch at 100 rows.
+
+PR #12455 adds a live-Options-specific 1,000-row ceiling and configurable sink parallelism while preserving the
+100-row full-day replay guardrail. Its current head intentionally leaves the immutable deployment image and GitOps
+values unchanged. After that source image is published, a separate digest-pinned activation PR will set one writer per
+destination table and a bounded 30-second age flush under the existing 120-second ClickHouse freshness SLO. The live
+rollout must reduce aggregate Options `NewPart` and `MergeParts` rates by at least 80% without freshness, checkpoint, or
+Kafka-source regression.
 
 ### Options archival containment
 
@@ -85,6 +103,33 @@ At 13:31 UTC, OSD 5 was primary for three simultaneous scrub operations while Ka
 limit authoritative in GitOps and corrects the recording rule that counted every deep-scrubbing PG twice. This direct
 config-database change is the only current Ceph drift and must disappear after Argo reconciles the PR.
 
+At 14:02 UTC, three deep scrubs were still active on three different primary OSDs. This is expected with
+`osd_max_scrubs=1`: the setting is per OSD, not a cluster-wide cap. Controller 2 completed 305 events at an average of
+1.39 seconds, with the slowest `writeNoOpRecord` taking 8.07 seconds. The cap removed the prior same-OSD concurrency but
+does not replace the accepted low-traffic scrub window.
+
+At 14:46 UTC, one regular scrub in the RGW bucket-data pool overlapped roughly 12.8 MiB/s of RBD-pool writes and OSD
+commit/apply latency peaks of 99-279 ms. Controller 2 completed 363 events at an average of 863 ms, and its slowest
+`writeNoOpRecord` took 8.52 seconds. The scrub then finished and Ceph returned to 601 active+clean PGs, but controller
+events continued reaching 2-4 seconds while the queue drained; the one-minute average fell to 297 ms by 14:49 UTC.
+Kafka remained available and all 37 managed topics stayed ready. This is improvement after containment, not evidence
+that controller durability is safe at default timeouts.
+
+The 14:46 RBD breakdown identifies the application pressure precisely: the two Torghut ClickHouse replicas wrote
+about 7.26 MiB/s at 440 IOPS, Torghut PostgreSQL wrote 1.23 MiB/s at 53 IOPS, and the Jangar primary and replica wrote
+1.99 MiB/s at 135 IOPS. Kafka controller PVCs wrote only about 2 IOPS each, but those synchronous metadata writes share
+the latency tail created by the much larger ClickHouse, PostgreSQL, Jangar, and scrub workload.
+
+The cluster started three more scrub operations on distinct primary OSDs by 14:51 UTC, including one deep scrub.
+Controller 2 then completed 332 events at a 1.58-second average and hit an 11.91-second `writeNoOpRecord`. This confirms
+that `osd_max_scrubs=1` prevents same-OSD concurrency but cannot impose a cluster-wide maintenance limit. The PostgreSQL
+restart and Kafka timeout cleanup must not run while scrubs are active; a measured scrub window remains mandatory.
+
+The seven-day window gate cannot yet be evaluated from Mimir: the raw Ceph series and new recording rules first became
+available with today's observability rollout at 13:00 UTC. Historical Mimir queries for unrelated metrics still work,
+so this is a new-series baseline rather than general retention loss. No scrub-hour window will be guessed from an
+assumed clock. Collection continues through at least 2026-07-21; Ceph remains `HEALTH_OK` with no scrub debt warning.
+
 Kafka remained `Ready` with version 4.3.0, metadata `4.3-IV0`, three controller pods, three broker pods, and no
 not-ready KafkaTopic resources. That status does not establish controller durability: controller 2 continued logging
 2-7.5 second `writeNoOpRecord`, broker-heartbeat, and stale-broker-fencing events, while controllers 0 and 1 repeatedly
@@ -96,12 +141,33 @@ must not be removed yet.
 Torghut PostgreSQL has a 50 GiB PVC with 29 GiB available and a 19 GiB database. Current settings remain the PostgreSQL
 defaults: `wal_buffers=4MB`, `max_wal_size=1GB`, `checkpoint_timeout=5min`, and `wal_compression=off`.
 
-The `TorghutPostgresWalBuffersFull` warning is currently pending. In the latest 15-minute sample PostgreSQL generated
-about 13.9 MiB of WAL, only 0.015 MiB/s and well below the 0.25 MiB/s gate, but still reported about 1,976
-WAL-buffer-full events. Since the statistics reset on 2026-07-03, 62.2% of checkpoints have been requested rather than
-timed (`2,681` requested versus `1,628` timed). This supports a later bounded increase in WAL buffers and checkpoint
-headroom after the archive load is proven; it is not a reason to weaken `fsync`, `full_page_writes`, or
-`synchronous_commit`.
+The `TorghutPostgresWalBuffersFull` warning is firing. In the latest 15-minute sample PostgreSQL generated only about
+0.019 MiB/s of WAL, well below the 0.25 MiB/s gate, but still reported about 2,450 WAL-buffer-full events. Since the
+statistics reset on 2026-07-03, 62.2% of checkpoints have been requested rather than timed (`2,681` requested versus
+`1,636` timed), although the latest hour had zero requested checkpoints. PR #12457 sets `wal_buffers` to 16 MiB while
+preserving `fsync`, `full_page_writes`, and `synchronous_commit`. Because `wal_buffers` is a postmaster setting and
+Torghut has one CNPG instance, the change carries a brief expected database interruption. CI is green, but the
+current-head automatic review has not arrived. The latest preflight found Ceph `HEALTH_OK` with one active deep scrub,
+so merge and restart remain gated. Checkpoint and WAL-size changes still wait for the post-application baseline.
+
+The separate `TorghutWSRestartsOrOOM` alert at 13:59 UTC was caused by the liveness controller intentionally restarting
+the forwarder after market-data channels remained starved for two minutes. Kafka and Alpaca-session gates stayed true,
+the new process restored all channels, readiness returned true, and the 10-minute restart-window alert resolved without
+changing a timeout or suppressing the alert.
+
+### Torghut decision-stall incident
+
+`TorghutQuantDecisionsStalledDuringMarketHours` fired at 14:51 UTC after the last persisted decision at 14:30 UTC. The
+scheduler remained ready, its accepted TA source was current, and all ten configured symbols had fresh signal rows. The
+new scheduler process evaluated 126 signals but safely rejected 85 for missing executable quotes and 41 for spreads
+above the existing quality ceiling.
+
+The executable-quote fallback was configured for Alpaca `sip`, while the account is not entitled to recent SIP data.
+Every fallback attempt returned HTTP 403 with the provider's subscription error. A read-only production probe against
+the same credentials returned fresh HTTP 200 IEX quotes for NVDA, CRDO, SNDK, and WDC, matching the IEX feed already
+used by the websocket forwarder. PR #12461 changes only the live service and scheduler fallback feed to `iex`; quote
+age, spread, session, and provider-backoff gates remain unchanged. Resolution requires the GitOps rollout followed by
+real decision traffic, not an alert silence.
 
 ### Jangar backup containment
 
@@ -117,12 +183,16 @@ is accepted as proof.
    Merge and promote migration-graph compatibility #12454 so databases parked on the released strategy-capital 0063
    revision can reach the sole 0065 head.
 2. Merge and publish the Kafka-backed writer with replicas at zero, then activate it against staging tables.
-3. Capture Kafka retained-record manifests and prove each retained offset exists exactly once in staging under the
-   delete-only and compacted-topic contracts before cutover.
+3. Publish the validated parity gate from local commit `92cce1849` after #12440 lands. It reads live topic cleanup
+   policy, captures fixed per-partition high watermarks, requires contiguous lineage for delete-only topics, enumerates
+   the retained record set for compacted topics, and fails unless every required staging offset exists exactly once.
 4. Merge the Jangar backup-pressure policy and prove a throttled backup does not destabilize Kafka or Ceph.
-5. Merge #12453, verify one-scrub-per-OSD convergence and scrub-debt health, then continue collecting the accepted
-   baseline before selecting a scrub-hour window or changing PostgreSQL.
-6. Remove the two Kafka timeout overrides only after controller events, quorum, ISR, and client traffic remain stable at
+5. Merge #12455, publish its TA image, activate it through a digest-pinned GitOps PR, and prove at least 80% fewer
+   Options ClickHouse parts before promoting the prepared 16 MiB PostgreSQL WAL-buffer change through its controlled
+   single-instance restart.
+6. Merge #12453, verify one-scrub-per-OSD convergence and scrub-debt health, then collect the accepted Ceph baseline
+   through at least 2026-07-21 before selecting a scrub-hour window.
+7. Remove the two Kafka timeout overrides only after controller events, quorum, ISR, and client traffic remain stable at
    default timeout behavior.
 
 ## Rollback boundaries

--- a/docs/torghut/rollouts/2026-07-14-storage-write-pressure-remediation.md
+++ b/docs/torghut/rollouts/2026-07-14-storage-write-pressure-remediation.md
@@ -1,204 +1,255 @@
 # Torghut and Ceph Write-Pressure Remediation Rollout
 
-Last updated: **2026-07-14 15:03 UTC**
+Last updated: **2026-07-15 00:09 UTC**
 
-Status: **in progress**
+Status: **software containment live; write-heavy activation gated on physical SAS repair**
 
 Design: `docs/torghut/storage-write-pressure-remediation-design.md`
 
-## Outcome
+## Executive outcome
 
-This document is the durable production evidence for the Torghut and shared-Ceph write-pressure remediation. It
-separates changes that are merged and live from work that is still gated. Kafka controller-local storage and the
-physical network upgrade remain external constraints defined by the accepted design.
+The application-side write amplification identified in the accepted design has been removed or contained:
 
-## Delivered changes
+- options subscription reconciliation is delta-only and live discovery is bounded;
+- Hyperliquid and Options TA ClickHouse writes are batched per destination table;
+- archival reconciliation uses bounded, restartable finalization and avoids unchanged catalog rewrites;
+- the Kafka-backed ClickHouse writer and retained-record parity gate are merged, but the writer remains at zero replicas;
+- PostgreSQL WAL buffers are 16 MiB with durability settings unchanged;
+- Ceph scrub concurrency is one per OSD; and
+- Kafka remains on the in-place Strimzi 1.1.0 / Kafka 4.3.0 cluster with metadata `4.3-IV0`.
 
-| Slice                                                 | Pull request    | Production state                                                               |
-| ----------------------------------------------------- | --------------- | ------------------------------------------------------------------------------ |
-| Accepted design and source map                        | #12403          | Merged                                                                         |
-| Delta-only options subscription reconciliation        | #12407          | Merged and live                                                                |
-| Per-table Hyperliquid ClickHouse batching             | #12409, #12410  | Merged and live                                                                |
-| Options TA ClickHouse batching                        | #12455          | Source review rerun pending; digest-pinned activation PR follows publication   |
-| Kafka-backed Hyperliquid ClickHouse writer            | #12440          | CI green; current-head source review pending; staged at zero replicas          |
-| Kafka/ClickHouse retained-record parity gate          | local 92cce1849 | Validated dependent slice; publish after #12440 lands                          |
-| Bounded live discovery                                | #12421, #12432  | Merged and live                                                                |
-| Set-based options persistence                         | #12435, #12437  | Merged and live                                                                |
-| Resumable archival reconciliation                     | #12438, #12439  | Merged; archive worker contained at zero replicas pending finalizer correction |
-| Bounded archive finalization                          | #12441, #12449  | Source and image promoted; composite-key correction #12452 pending             |
-| Released migration revision compatibility             | #12454          | PostgreSQL 17 proof complete; merge and image promotion pending                |
-| Shared CNPG, Ceph, and RBD-client observability       | #12443          | Merged and live                                                                |
-| Ceph scrub concurrency and count correction           | #12453          | Runtime containment live; GitOps merge pending                                 |
-| Bilig PostgreSQL capacity and logical-WAL containment | #12447          | Merged and live                                                                |
-| Torghut PostgreSQL WAL-buffer containment             | #12457          | 16 MiB setting validated; current-head review and scrub-safe restart pending   |
+The remaining storage alert is not an application timeout problem. Talos and Ceph record a real cache-flush I/O error
+on the Altra storage host, followed by an OSD.3 crash, and correlated resets across all three disks behind the same
+SAS3008 controller path. The archive worker and Kafka staging writer therefore remain off until that physical path is
+repaired and the validation gate below passes.
 
-## Live proof
+There is no third Ceph storage host in this plan. The incoming network hardware is a separate change window and cannot
+repair a failed local SAS flush path.
 
-### Hyperliquid direct-sink batching
+## Delivered slices
 
-The feed stayed ready throughout the observation. At 12:59 UTC `/readyz` returned HTTP 200 with `websocket=true`,
-`kafka=true`, `clickhouse=true`, and all twelve markets present.
+| Capability                                       | Pull requests                          | Live state                                              |
+| ------------------------------------------------ | -------------------------------------- | ------------------------------------------------------- |
+| Accepted production design                       | #12403                                 | Merged                                                  |
+| Delta-only options subscription reconciliation   | #12407                                 | Merged and live                                         |
+| Bounded live discovery                           | #12421, #12432                         | Merged and live                                         |
+| Set-based options catalog persistence            | #12435, #12437                         | Merged and live                                         |
+| Resumable archive and bounded finalization       | #12438, #12439, #12441, #12449, #12452 | Merged; deployment held at zero                         |
+| Low-WAL archive finalization and overlap fencing | #12493, #12497, #12500, #12502         | Merged and live; schema-gated image promoted            |
+| Hyperliquid per-table ClickHouse batching        | #12409, #12410                         | Merged and live                                         |
+| Options TA ClickHouse batching                   | #12455, #12495, #12501                 | Merged and live                                         |
+| Kafka-backed ClickHouse writer                   | #12440                                 | Source and staging resources merged; deployment at zero |
+| Retained-record parity gate                      | #12472                                 | Merged; CronJob intentionally suspended                 |
+| Shared storage observability                     | #12443                                 | Merged and live                                         |
+| Ceph one-scrub-per-OSD limit                     | #12453                                 | Merged and live                                         |
+| Torghut PostgreSQL WAL buffers                   | #12457                                 | Merged and live                                         |
+| Suspended parity health handling                 | #12498                                 | Merged and live                                         |
 
-ClickHouse `system.part_log` shows the production transition at 07:00 UTC:
+## Live application proof
 
-| Table/event             |             Before: 05:00-06:59 UTC | After: representative full hours | Result                            |
-| ----------------------- | ----------------------------------: | -------------------------------: | --------------------------------- |
-| BBO `NewPart`           | 2,089-2,296/hour; median 36-40 rows |  111-168/hour; median 1,000 rows | 92-95% fewer parts; size gate met |
-| BBO `MergeParts`        |                    1,340-1,525/hour |                       24-36/hour | 97-98% fewer merges               |
-| Candles `NewPart`       |         828-882/hour; median 2 rows |    43-63/hour; median 62-67 rows | 92-95% fewer parts                |
-| Candles `MergeParts`    |                        828-882/hour |                       12-26/hour | 97-99% fewer merges               |
-| Asset-context `NewPart` |         337-362/hour; median 2 rows |    43-56/hour; median 27-29 rows | 83-88% fewer parts                |
+### Options reconciliation and PostgreSQL
 
-Sparse tables flush on the 30-second age limit when they cannot reach 100 rows. They are evaluated separately from the
-size-triggered BBO gate.
+The original discovery path generated approximately 53,397 physical subscription-state updates in 15.8 seconds and
+36.34 MiB of WAL, or about 2.29 MiB/s. The replacement path:
 
-### Options TA direct-sink diagnosis
+- preserves the last completed hot/warm set during partial scans;
+- mutates only materially changed assignments;
+- performs explicit displacement instead of a blanket `tier = 'off'` update;
+- bounds live discovery separately from the 730-day archive; and
+- finalizes archive shards in restartable batches of no more than 1,000 rows.
 
-The next dominant ClickHouse writer was traced to the Options Flink JDBC sinks rather than the Hyperliquid feed. In a
-15-minute production sample, `options_contract_features`, `options_contract_bars_1s`, and `options_surface_features`
-created 5,359 new parts at only 19-43 rows per part. The live Flink graph showed all three JDBC sinks at parallelism
-four, the client flushed every 250 milliseconds, and shared code capped the requested batch at 100 rows.
+The live Torghut PostgreSQL cluster is healthy with one ready instance. Readback shows:
 
-PR #12455 adds a live-Options-specific 1,000-row ceiling and configurable sink parallelism while preserving the
-100-row full-day replay guardrail. Its current head intentionally leaves the immutable deployment image and GitOps
-values unchanged. After that source image is published, a separate digest-pinned activation PR will set one writer per
-destination table and a bounded 30-second age flush under the existing 120-second ClickHouse freshness SLO. The live
-rollout must reduce aggregate Options `NewPart` and `MergeParts` rates by at least 80% without freshness, checkpoint, or
-Kafka-source regression.
+| Setting                        | Live value             |
+| ------------------------------ | ---------------------- |
+| `wal_buffers`                  | 2,048 x 8 KiB = 16 MiB |
+| `fsync`                        | `on`                   |
+| `full_page_writes`             | `on`                   |
+| `synchronous_commit`           | `on`                   |
+| `max_wal_size`                 | 1 GiB                  |
+| `checkpoint_timeout`           | 5 minutes              |
+| `checkpoint_completion_target` | 0.9                    |
+| `wal_compression`              | `off`                  |
 
-### Options archival containment
+With the archive worker off, a 30-second live sample at 23:55 UTC generated **0.0100 MiB/s** of WAL, below the accepted
+0.25 MiB/s gate. Checkpoint-size and WAL-compression changes remain evidence-driven follow-up tuning; durability is not
+weakened.
 
-Promotion #12449 installed image digest
-`sha256:bac85c5b24ba543aee521f2a3505546c97027d8ff76fa678e31e6d0b368280f6` and ran the migration chain. The live
-database now reports Alembic head `0064_strategy_capital_authority`; `ix_options_catalog_active_expiration_symbol` is
-valid and ready.
+### Hyperliquid ClickHouse batching
 
-The archive worker then exposed a separate finalization-plan defect. Candidate selection was bounded to 1,000 paired
-expiration-date and symbol rows, but the transition statement joined them back to the four-million-row catalog by
-symbol alone. Every populated shard hit the 30-second statement timeout and rolled back. The deployment was immediately
-returned to zero replicas under an exact Argo CD deny window. Twelve shard watermarks remain restartable in
-`finalizing`; no contract transition was committed and no data was lost.
+The feed remained ready during rollout. Representative full-hour ClickHouse `system.part_log` samples showed:
 
-Correction #12452 joins a typed, zipped candidate relation on both expiration date and symbol. A production
-`EXPLAIN (COSTS OFF)` selected `ix_options_catalog_active_expiration_symbol` for the catalog lookup and the archive
-membership primary key for the anti-join. The sync hold remains in place until that correction is merged, published,
-and desired by Git.
+| Table/event             |                              Before |                           After | Result              |
+| ----------------------- | ----------------------------------: | ------------------------------: | ------------------- |
+| BBO `NewPart`           | 2,089-2,296/hour; median 36-40 rows | 111-168/hour; median 1,000 rows | 92-95% fewer parts  |
+| BBO `MergeParts`        |                    1,340-1,525/hour |                      24-36/hour | 97-98% fewer merges |
+| Candles `NewPart`       |         828-882/hour; median 2 rows |   43-63/hour; median 62-67 rows | 92-95% fewer parts  |
+| Candles `MergeParts`    |                        828-882/hour |                      12-26/hour | 97-99% fewer merges |
+| Asset context `NewPart` |         337-362/hour; median 2 rows |   43-56/hour; median 27-29 rows | 83-88% fewer parts  |
 
-### Shared storage telemetry
+The high-rate BBO table reaches the 1,000-row size trigger. Sparse tables are age-triggered and are evaluated separately.
 
-The observability rollout is scraping all 14 CNPG targets, six Ceph OSD latency series, and per-pod `/dev/rbd*` write
-bytes and IOPS. At 12:55 UTC:
+### Options TA ClickHouse batching
 
-- Ceph was `HEALTH_OK` with all six OSDs up and in.
-- Client traffic was about 39 MiB/s read and 8.2 MiB/s write.
-- Four PGs were scrubbing: three deep scrubs and one regular scrub. At 13:30 UTC, six PGs were deep-scrubbing.
-- `osd_max_scrubs=3` came from the Ceph default, not an out-of-band config-database override.
-- OSD commit latency was 39-110 ms at the sampled instant.
-- The largest RBD writers were the Jangar primary and replica, followed by both Torghut ClickHouse replicas.
+Before batching, a 15-minute sample across `options_contract_bars_1s`, `options_contract_features`, and
+`options_surface_features` created 5,359 new parts at only 19-43 rows per part. The live sink now has:
 
-At 13:31 UTC, OSD 5 was primary for three simultaneous scrub operations while Kafka controller durable events reached
-4.3 seconds. At 13:47 UTC, OSDs 2 and 5 were each running two deep scrubs and controller events were still reaching
-3.9 seconds. Emergency containment set the runtime `osd_max_scrubs` value from its default of three to one for the
-`osd` section; effective readback is now one on OSDs 0-5. Existing scrubs are allowed to finish. PR #12453 makes that
-limit authoritative in GitOps and corrects the recording rule that counted every deep-scrubbing PG twice. This direct
-config-database change is the only current Ceph drift and must disappear after Argo reconciles the PR.
+- one writer per destination table;
+- a 1,000-row size threshold;
+- a 30-second maximum age; and
+- Flink restart nonce 33.
 
-At 14:02 UTC, three deep scrubs were still active on three different primary OSDs. This is expected with
-`osd_max_scrubs=1`: the setting is per OSD, not a cluster-wide cap. Controller 2 completed 305 events at an average of
-1.39 seconds, with the slowest `writeNoOpRecord` taking 8.07 seconds. The cap removed the prior same-OSD concurrency but
-does not replace the accepted low-traffic scrub window.
+The batching change first reconciled at commit `2551ef69cd01c2cd10244fc4e13d14a4be8b1973`; all four Torghut Argo
+applications are now `Synced/Healthy` at descendant promotion `bf26c61adb399687353c8f972249d4f00904a2f4`. Flink
+generation 43 is observed at generation 43, and job `0089f4f0d810bef590a70e77966fe475` is `STABLE`, `READY`,
+and `RUNNING`.
 
-At 14:46 UTC, one regular scrub in the RGW bucket-data pool overlapped roughly 12.8 MiB/s of RBD-pool writes and OSD
-commit/apply latency peaks of 99-279 ms. Controller 2 completed 363 events at an average of 863 ms, and its slowest
-`writeNoOpRecord` took 8.52 seconds. The scrub then finished and Ceph returned to 601 active+clean PGs, but controller
-events continued reaching 2-4 seconds while the queue drained; the one-minute average fell to 297 ms by 14:49 UTC.
-Kafka remained available and all 37 managed topics stayed ready. This is improvement after containment, not evidence
-that controller durability is safe at default timeouts.
+The adjacent live path remained healthy: the Hyperliquid feed `/readyz` returned `ready=true`, `websocket=true`,
+`kafka=true`, and `clickhouse=true`; Knative revision `torghut-01462` was ready.
 
-The 14:46 RBD breakdown identifies the application pressure precisely: the two Torghut ClickHouse replicas wrote
-about 7.26 MiB/s at 440 IOPS, Torghut PostgreSQL wrote 1.23 MiB/s at 53 IOPS, and the Jangar primary and replica wrote
-1.99 MiB/s at 135 IOPS. Kafka controller PVCs wrote only about 2 IOPS each, but those synchronous metadata writes share
-the latency tail created by the much larger ClickHouse, PostgreSQL, Jangar, and scrub workload.
+The fixed 15-minute window from 23:54:04 through 00:09:04 UTC produced:
 
-The cluster started three more scrub operations on distinct primary OSDs by 14:51 UTC, including one deep scrub.
-Controller 2 then completed 332 events at a 1.58-second average and hit an 11.91-second `writeNoOpRecord`. This confirms
-that `osd_max_scrubs=1` prevents same-OSD concurrency but cannot impose a cluster-wide maintenance limit. The PostgreSQL
-restart and Kafka timeout cleanup must not run while scrubs are active; a measured scrub window remains mandatory.
+| Table                       | Replica 0 `NewPart` / median rows | Replica 1 `NewPart` / median rows | Combined `MergeParts` |
+| --------------------------- | --------------------------------: | --------------------------------: | --------------------: |
+| `options_contract_bars_1s`  |                           8 / 113 |                            4 / 60 |                     7 |
+| `options_contract_features` |                           6 / 108 |                           6 / 115 |                     5 |
+| `options_surface_features`  |                            7 / 44 |                            5 / 66 |                     3 |
 
-The seven-day window gate cannot yet be evaluated from Mimir: the raw Ceph series and new recording rules first became
-available with today's observability rollout at 13:00 UTC. Historical Mimir queries for unrelated metrics still work,
-so this is a new-series baseline rather than general retention loss. No scrub-hour window will be guessed from an
-assumed clock. Collection continues through at least 2026-07-21; Ceph remains `HEALTH_OK` with no scrub debt warning.
+That is 36 `NewPart` events across both replicas, **99.3% fewer** than the original 5,359-event 15-minute sample.
+The intermediate five-second configuration produced 40 `NewPart` events in five minutes, or 8.0/minute; the final
+30-second configuration produced 2.4/minute, a further **70% rate reduction**. This after-hours window is
+age-triggered, so rows per part are intentionally below the 1,000-row size threshold.
 
-Kafka remained `Ready` with version 4.3.0, metadata `4.3-IV0`, three controller pods, three broker pods, and no
-not-ready KafkaTopic resources. That status does not establish controller durability: controller 2 continued logging
-2-7.5 second `writeNoOpRecord`, broker-heartbeat, and stale-broker-fencing events, while controllers 0 and 1 repeatedly
-timed out two-second Raft fetches to controller 2. Kafka timeout overrides therefore remain required containment and
-must not be removed yet.
+Flink completed 16 of 16 checkpoints with zero failures; the latest acknowledged all 31 subtasks in 932 ms. The job
+manager and both task managers were ready with zero restarts.
 
-### PostgreSQL baseline
+### Archive and Kafka staging containment
 
-Torghut PostgreSQL has a 50 GiB PVC with 29 GiB available and a 19 GiB database. Current settings remain the PostgreSQL
-defaults: `wal_buffers=4MB`, `max_wal_size=1GB`, `checkpoint_timeout=5min`, and `wal_compression=off`.
+The database is at Alembic revision `0067_options_archive_status`. The shared init gate verifies the required archive
+membership table, status table, active-catalog view, and ready composite index before any archive/catalog/enricher
+process can start. The gate image is digest-identical to the application image.
 
-The `TorghutPostgresWalBuffersFull` warning is firing. In the latest 15-minute sample PostgreSQL generated only about
-0.019 MiB/s of WAL, well below the 0.25 MiB/s gate, but still reported about 2,450 WAL-buffer-full events. Since the
-statistics reset on 2026-07-03, 62.2% of checkpoints have been requested rather than timed (`2,681` requested versus
-`1,636` timed), although the latest hour had zero requested checkpoints. PR #12457 sets `wal_buffers` to 16 MiB while
-preserving `fsync`, `full_page_writes`, and `synchronous_commit`. Because `wal_buffers` is a postmaster setting and
-Torghut has one CNPG instance, the change carries a brief expected database interruption. CI is green, but the
-current-head automatic review has not arrived. The latest preflight found Ceph `HEALTH_OK` with one active deep scrub,
-so merge and restart remain gated. Checkpoint and WAL-size changes still wait for the post-application baseline.
+The archive deployment is declaratively at **zero replicas**; there is no temporary Argo deny window and no live drift.
+Catalog and enricher are ready on digest
+`sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb`.
 
-The separate `TorghutWSRestartsOrOOM` alert at 13:59 UTC was caused by the liveness controller intentionally restarting
-the forwarder after market-data channels remained starved for two minutes. Kafka and Alpaca-session gates stayed true,
-the new process restored all channels, readiness returned true, and the 10-minute restart-window alert resolved without
-changing a timeout or suppressing the alert.
+The Kafka writer deployment is also at **zero replicas**. Nine `_kafka_staging` tables exist and contain zero rows.
+The direct sink remains authoritative. Activation PR #12496 is intentionally draft and cannot merge until the physical
+storage gate passes.
 
-### Torghut decision-stall incident
+## Physical storage root cause
 
-`TorghutQuantDecisionsStalledDuringMarketHours` fired at 14:51 UTC after the last persisted decision at 14:30 UTC. The
-scheduler remained ready, its accepted TA source was current, and all ten configured symbols had fresh signal rows. The
-new scheduler process evaluated 126 signals but safely rejected 85 for missing executable quotes and 41 for spreads
-above the existing quality ceiling.
+### Evidence
 
-The executable-quote fallback was configured for Alpaca `sip`, while the account is not entitled to recent SIP data.
-Every fallback attempt returned HTTP 403 with the provider's subscription error. A read-only production probe against
-the same credentials returned fresh HTTP 200 IEX quotes for NVDA, CRDO, SNDK, and WDC, matching the IEX feed already
-used by the websocket forwarder. PR #12461 changes only the live service and scheduler fallback feed to `iex`; quote
-age, spread, session, and provider-backoff gates remain unchanged. Resolution requires the GitOps rollout followed by
-real decision traffic, not an alert silence.
+Ceph is `HEALTH_WARN` with six of six OSDs up and in and all placement groups clean or actively scrubbing. The warnings
+are:
 
-### Jangar backup containment
+- OSD.5 BlueStore slow-operation indications; and
+- a recent OSD.3 crash at `2026-07-14T20:18:05Z`.
 
-The 2026-07-14 11:00 UTC base backup was terminated after it amplified shared Ceph writes and Kafka controller stalls.
-The preceding daily backup completed successfully on 2026-07-13. Both Jangar database PVCs are now 300 GiB and bound;
-no backup is currently running. GitOps policy #12444 is still pending and must be live before another scheduled backup
-is accepted as proof.
+The OSD.3 crash path is `KernelDevice::flush()` -> `bstore_kv_sync` -> `fdatasync`, ending in Linux error 5
+(`EIO`). Talos recorded immediately beforehand:
 
-## Remaining gates
+```text
+sd 0:0:0:0: [sda] CDB: Synchronize Cache(10)
+I/O error, dev sda, sector 0 op WRITE
+```
 
-1. Merge and publish composite-key archive correction #12452, remove the exact temporary Argo sync hold, and prove
-   restartable batches of no more than 1,000 rows without statement timeouts or WAL regression.
-   Merge and promote migration-graph compatibility #12454 so databases parked on the released strategy-capital 0063
-   revision can reach the sole 0065 head.
-2. Merge and publish the Kafka-backed writer with replicas at zero, then activate it against staging tables.
-3. Publish the validated parity gate from local commit `92cce1849` after #12440 lands. It reads live topic cleanup
-   policy, captures fixed per-partition high watermarks, requires contiguous lineage for delete-only topics, enumerates
-   the retained record set for compacted topics, and fails unless every required staging offset exists exactly once.
-4. Merge the Jangar backup-pressure policy and prove a throttled backup does not destabilize Kafka or Ceph.
-5. Merge #12455, publish its TA image, activate it through a digest-pinned GitOps PR, and prove at least 80% fewer
-   Options ClickHouse parts before promoting the prepared 16 MiB PostgreSQL WAL-buffer change through its controlled
-   single-instance restart.
-6. Merge #12453, verify one-scrub-per-OSD convergence and scrub-debt health, then collect the accepted Ceph baseline
-   through at least 2026-07-21 before selecting a scrub-hour window.
-7. Remove the two Kafka timeout overrides only after controller events, quorum, ISR, and client traffic remain stable at
-   default timeout behavior.
+Talos also recorded power-on/device-reset events for `sda`, `sdb`, and `sdc` together at 20:12 UTC, followed by
+additional `sda` and `sdc` resets around the OSD.3 crash. Similar all-disk resets occurred on July 12.
 
-## Rollback boundaries
+The affected topology is:
 
-- Stop the archive worker without changing the last completed live-universe state if bounded finalization regresses.
-- Stop the Kafka writer before cutover; its uncommitted offsets remain replayable.
-- Re-enable the direct sink only at a recorded offset boundary after cutover.
-- Revert PostgreSQL and Ceph settings individually through GitOps.
-- Restoring Kafka timeout overrides is temporary containment, not a completed remediation.
+| SAS path           | Linux disk | Ceph OSD | Disk serial |
+| ------------------ | ---------- | -------- | ----------- |
+| phy 0:1 / port 0:0 | `sda`      | OSD.3    | `ZXA12R7C`  |
+| phy 0:6 / port 0:1 | `sdb`      | OSD.4    | `ZXA0LKW9`  |
+| phy 0:7 / port 0:2 | `sdc`      | OSD.5    | `ZXA0HS7E`  |
+
+All three disks report SMART passed with zero reallocated, pending, offline-uncorrectable, and interface-CRC sectors.
+Their high hardware-reset and COMRESET counters, combined with simultaneous resets behind the Broadcom/LSI SAS3008,
+make the shared HBA/backplane/cable/power path the leading root cause. Talos identifies the adapter as an INSPUR 3008IT
+running firmware `16.00.14.00` and BIOS `08.37.00.00`. This is not an NVMe-capacity problem and cannot be fixed by
+increasing Kafka timeouts.
+
+### Required physical maintenance
+
+The Ceph pools are replicated `size=2`, `min_size=1` across exactly two storage hosts. Taking the Altra storage host
+offline removes one of the two durable copies for every placement group. The production-quality repair is therefore
+a scheduled storage maintenance outage, not an online controller experiment:
+
+1. Require no degraded, undersized, backfilling, or recovering placement groups and record Ceph status, OSD tree,
+   crash detail, SMART data, and Talos logs.
+2. Stop or quiesce RBD-backed writers, including Kafka, ClickHouse, PostgreSQL, and other stateful clients, so the
+   remaining host is not accepted as normal single-copy durability.
+3. Set a bounded Ceph `noout` maintenance flag, cordon the Altra node, and perform an orderly Talos shutdown.
+4. Reseat or replace the SAS cables and backplane path, verify HBA power/cooling, and update SAS3008 firmware only from
+   a verified vendor image and separate rollback procedure.
+5. Boot the node and require all three OSDs to return without new `mpt3sas`, reset, `Synchronize Cache`, EIO, or
+   BlueStore slow-op events.
+6. Wait for every placement group to be `active+clean`, clear the bounded `noout` flag, uncordon, and restore writers
+   in dependency order.
+7. Run SMART extended tests and a controlled durable-write validation. Require at least 24 hours with no new transport
+   resets, OSD crashes, or flush errors before starting the archive worker or Kafka staging writer.
+
+Acknowledging or silencing the Ceph warning is not evidence of repair.
+
+## Remaining activation gates
+
+### Archive worker
+
+After the physical-storage gate passes:
+
+1. start one archive replica;
+2. prove the advisory lock prevents overlap;
+3. verify each transaction processes no more than 1,000 composite-key rows;
+4. require no statement timeout, lock timeout, or unchanged-row rewrite;
+5. require PostgreSQL WAL below 0.25 MiB/s and no Ceph/Kafka regression; and
+6. stop and return to zero replicas immediately if any gate fails.
+
+### Kafka-backed ClickHouse writer
+
+After archive proof:
+
+1. merge the current-head activation PR against `_kafka_staging` tables only;
+2. catch up from the retained Kafka record set with offset-after-ClickHouse-ack semantics;
+3. require writer readiness, bounded lag, and no uncommitted-range duplication;
+4. run the suspended parity gate at fixed partition high watermarks;
+5. require every retained delete-only offset exactly once and the compacted-topic record-set contract to pass; and
+6. record a cutover boundary before disabling the direct sink.
+
+### Kafka timeout cleanup
+
+The live Kafka resource still contains the temporary 60-second controller election and 180-second controller fetch
+timeouts. Kafka itself is `Ready` on 4.3.0 / `4.3-IV0`, all three controller and three broker pods are ready, and no
+managed topic is not ready. That availability is containment, not latency proof: at 00:01 UTC controller 2 reported a
+60-second average controller-event duration of 1,664 ms and a slowest `writeNoOpRecord` of 11,952 ms while controllers
+0 and 1 repeatedly timed out Raft fetches to controller 2. Remove both overrides only after the physical repair and
+application activation remain stable at default timeout behavior with:
+
+- three stable KRaft voters and a stable leader;
+- full ISR and zero offline partitions;
+- no broker fencing or sustained follower lag;
+- healthy Torghut producers and consumers; and
+- no controller durable event above the accepted baseline.
+
+No further timeout increase is an accepted remediation.
+
+## Alerts and rollback boundaries
+
+At 00:09 UTC Alertmanager contained only `CephClusterHealthWarning`. The false critical Argo alert for the intentionally
+suspended parity CronJob expired after #12498 reconciled. The genuine Ceph alert remains unsilenced.
+
+- Archive rollback: scale the declarative deployment back to zero; preserve its committed shard cursor.
+- Kafka writer rollback before cutover: stop the writer; uncommitted offsets remain replayable.
+- Direct-sink cutover rollback: re-enable only at the recorded partition boundary.
+- PostgreSQL/Ceph tuning rollback: revert one parameter at a time through GitOps.
+- Kafka timeout rollback: temporary containment only; reopening the storage incident is mandatory.
+
+## Explicit external boundaries
+
+- Kafka controller-local storage remains unsupported with the current static KRaft quorum and immutable Strimzi
+  controller node pool. No manual metadata copy or replacement cluster is part of this rollout.
+- The incoming network upgrade is implemented in its own change window with the old path retained for rollback.
+- A third Ceph storage host is not planned. The resulting two-host durability ceiling is accepted and drives the
+  maintenance-outage requirement above.

--- a/docs/torghut/rollouts/2026-07-14-storage-write-pressure-remediation.md
+++ b/docs/torghut/rollouts/2026-07-14-storage-write-pressure-remediation.md
@@ -1,0 +1,134 @@
+# Torghut and Ceph Write-Pressure Remediation Rollout
+
+Last updated: **2026-07-14 13:50 UTC**
+
+Status: **in progress**
+
+Design: `docs/torghut/storage-write-pressure-remediation-design.md`
+
+## Outcome
+
+This document is the durable production evidence for the Torghut and shared-Ceph write-pressure remediation. It
+separates changes that are merged and live from work that is still gated. Kafka controller-local storage and the
+physical network upgrade remain external constraints defined by the accepted design.
+
+## Delivered changes
+
+| Slice                                                 | Pull request   | Production state                                                               |
+| ----------------------------------------------------- | -------------- | ------------------------------------------------------------------------------ |
+| Accepted design and source map                        | #12403         | Merged                                                                         |
+| Delta-only options subscription reconciliation        | #12407         | Merged and live                                                                |
+| Per-table Hyperliquid ClickHouse batching             | #12409, #12410 | Merged and live                                                                |
+| Bounded live discovery                                | #12421, #12432 | Merged and live                                                                |
+| Set-based options persistence                         | #12435, #12437 | Merged and live                                                                |
+| Resumable archival reconciliation                     | #12438, #12439 | Merged; archive worker contained at zero replicas pending finalizer correction |
+| Bounded archive finalization                          | #12441, #12449 | Source and image promoted; composite-key correction #12452 pending             |
+| Released migration revision compatibility             | #12454         | PostgreSQL 17 proof complete; merge and image promotion pending                |
+| Shared CNPG, Ceph, and RBD-client observability       | #12443         | Merged and live                                                                |
+| Ceph scrub concurrency and count correction           | #12453         | Runtime containment live; GitOps merge pending                                 |
+| Bilig PostgreSQL capacity and logical-WAL containment | #12447         | Merged and live                                                                |
+
+## Live proof
+
+### Hyperliquid direct-sink batching
+
+The feed stayed ready throughout the observation. At 12:59 UTC `/readyz` returned HTTP 200 with `websocket=true`,
+`kafka=true`, `clickhouse=true`, and all twelve markets present.
+
+ClickHouse `system.part_log` shows the production transition at 07:00 UTC:
+
+| Table/event             |             Before: 05:00-06:59 UTC | After: representative full hours | Result                            |
+| ----------------------- | ----------------------------------: | -------------------------------: | --------------------------------- |
+| BBO `NewPart`           | 2,089-2,296/hour; median 36-40 rows |  111-168/hour; median 1,000 rows | 92-95% fewer parts; size gate met |
+| BBO `MergeParts`        |                    1,340-1,525/hour |                       24-36/hour | 97-98% fewer merges               |
+| Candles `NewPart`       |         828-882/hour; median 2 rows |    43-63/hour; median 62-67 rows | 92-95% fewer parts                |
+| Candles `MergeParts`    |                        828-882/hour |                       12-26/hour | 97-99% fewer merges               |
+| Asset-context `NewPart` |         337-362/hour; median 2 rows |    43-56/hour; median 27-29 rows | 83-88% fewer parts                |
+
+Sparse tables flush on the 30-second age limit when they cannot reach 100 rows. They are evaluated separately from the
+size-triggered BBO gate.
+
+### Options archival containment
+
+Promotion #12449 installed image digest
+`sha256:bac85c5b24ba543aee521f2a3505546c97027d8ff76fa678e31e6d0b368280f6` and ran the migration chain. The live
+database now reports Alembic head `0064_strategy_capital_authority`; `ix_options_catalog_active_expiration_symbol` is
+valid and ready.
+
+The archive worker then exposed a separate finalization-plan defect. Candidate selection was bounded to 1,000 paired
+expiration-date and symbol rows, but the transition statement joined them back to the four-million-row catalog by
+symbol alone. Every populated shard hit the 30-second statement timeout and rolled back. The deployment was immediately
+returned to zero replicas under an exact Argo CD deny window. Twelve shard watermarks remain restartable in
+`finalizing`; no contract transition was committed and no data was lost.
+
+Correction #12452 joins a typed, zipped candidate relation on both expiration date and symbol. A production
+`EXPLAIN (COSTS OFF)` selected `ix_options_catalog_active_expiration_symbol` for the catalog lookup and the archive
+membership primary key for the anti-join. The sync hold remains in place until that correction is merged, published,
+and desired by Git.
+
+### Shared storage telemetry
+
+The observability rollout is scraping all 14 CNPG targets, six Ceph OSD latency series, and per-pod `/dev/rbd*` write
+bytes and IOPS. At 12:55 UTC:
+
+- Ceph was `HEALTH_OK` with all six OSDs up and in.
+- Client traffic was about 39 MiB/s read and 8.2 MiB/s write.
+- Four PGs were scrubbing: three deep scrubs and one regular scrub. At 13:30 UTC, six PGs were deep-scrubbing.
+- `osd_max_scrubs=3` came from the Ceph default, not an out-of-band config-database override.
+- OSD commit latency was 39-110 ms at the sampled instant.
+- The largest RBD writers were the Jangar primary and replica, followed by both Torghut ClickHouse replicas.
+
+At 13:31 UTC, OSD 5 was primary for three simultaneous scrub operations while Kafka controller durable events reached
+4.3 seconds. At 13:47 UTC, OSDs 2 and 5 were each running two deep scrubs and controller events were still reaching
+3.9 seconds. Emergency containment set the runtime `osd_max_scrubs` value from its default of three to one for the
+`osd` section; effective readback is now one on OSDs 0-5. Existing scrubs are allowed to finish. PR #12453 makes that
+limit authoritative in GitOps and corrects the recording rule that counted every deep-scrubbing PG twice. This direct
+config-database change is the only current Ceph drift and must disappear after Argo reconciles the PR.
+
+Kafka remained `Ready` with version 4.3.0, metadata `4.3-IV0`, three controller pods, three broker pods, and no
+not-ready KafkaTopic resources. That status does not establish controller durability: controller 2 continued logging
+2-7.5 second `writeNoOpRecord`, broker-heartbeat, and stale-broker-fencing events, while controllers 0 and 1 repeatedly
+timed out two-second Raft fetches to controller 2. Kafka timeout overrides therefore remain required containment and
+must not be removed yet.
+
+### PostgreSQL baseline
+
+Torghut PostgreSQL has a 50 GiB PVC with 29 GiB available and a 19 GiB database. Current settings remain the PostgreSQL
+defaults: `wal_buffers=4MB`, `max_wal_size=1GB`, `checkpoint_timeout=5min`, and `wal_compression=off`.
+
+The `TorghutPostgresWalBuffersFull` warning is currently pending. In the latest 15-minute sample PostgreSQL generated
+about 13.9 MiB of WAL, only 0.015 MiB/s and well below the 0.25 MiB/s gate, but still reported about 1,976
+WAL-buffer-full events. Since the statistics reset on 2026-07-03, 62.2% of checkpoints have been requested rather than
+timed (`2,681` requested versus `1,628` timed). This supports a later bounded increase in WAL buffers and checkpoint
+headroom after the archive load is proven; it is not a reason to weaken `fsync`, `full_page_writes`, or
+`synchronous_commit`.
+
+### Jangar backup containment
+
+The 2026-07-14 11:00 UTC base backup was terminated after it amplified shared Ceph writes and Kafka controller stalls.
+The preceding daily backup completed successfully on 2026-07-13. Both Jangar database PVCs are now 300 GiB and bound;
+no backup is currently running. GitOps policy #12444 is still pending and must be live before another scheduled backup
+is accepted as proof.
+
+## Remaining gates
+
+1. Merge and publish composite-key archive correction #12452, remove the exact temporary Argo sync hold, and prove
+   restartable batches of no more than 1,000 rows without statement timeouts or WAL regression.
+   Merge and promote migration-graph compatibility #12454 so databases parked on the released strategy-capital 0063
+   revision can reach the sole 0065 head.
+2. Merge and publish the Kafka-backed writer with replicas at zero, then activate it against staging tables.
+3. Capture Kafka retained-record manifests and prove each retained offset exists exactly once in staging under the
+   delete-only and compacted-topic contracts before cutover.
+4. Merge the Jangar backup-pressure policy and prove a throttled backup does not destabilize Kafka or Ceph.
+5. Merge #12453, verify one-scrub-per-OSD convergence and scrub-debt health, then continue collecting the accepted
+   baseline before selecting a scrub-hour window or changing PostgreSQL.
+6. Remove the two Kafka timeout overrides only after controller events, quorum, ISR, and client traffic remain stable at
+   default timeout behavior.
+
+## Rollback boundaries
+
+- Stop the archive worker without changing the last completed live-universe state if bounded finalization regresses.
+- Stop the Kafka writer before cutover; its uncommitted offsets remain replayable.
+- Re-enable the direct sink only at a recorded offset boundary after cutover.
+- Revert PostgreSQL and Ceph settings individually through GitOps.
+- Restoring Kafka timeout overrides is temporary containment, not a completed remediation.


### PR DESCRIPTION
## Summary

- replace the stale mid-incident rollout note with the merged and live Torghut/Ceph remediation state
- record fixed-window PostgreSQL WAL, ClickHouse part-rate, Flink checkpoint, Argo, readiness, Kafka, Ceph, and Alertmanager evidence
- document the confirmed SAS3008-path flush failure and the production maintenance gate required before activating archive or Kafka staging writes

## Related Issues

None.

## Testing

- `nix develop --command oxfmt docs/torghut/rollouts/2026-07-14-storage-write-pressure-remediation.md`
- `nix develop --command oxfmt --check docs/torghut/rollouts/2026-07-14-storage-write-pressure-remediation.md`
- `git diff --check`
- live Argo, Flink, ClickHouse, PostgreSQL, Kafka, Ceph, Talos, readiness, and Alertmanager readback recorded in the document

## Screenshots (if applicable)

N/A; this is a production evidence and maintenance-runbook document.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
