### PR TITLE
chore(torghut): promote image sha-78440b8b57bf720b59e164403b23451cbd830117

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -24,7 +24,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: migrate
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:3796127310ecd2668a7911c7547fcfb1e789450dec761302e5aaef7efbb60e76
           imagePullPolicy: Always
           workingDir: /app
           command:
@@ -54,9 +54,9 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: 2551ef69cd01c2cd10244fc4e13d14a4be8b1973
+              value: 78440b8b57bf720b59e164403b23451cbd830117
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
+              value: sha256:3796127310ecd2668a7911c7547fcfb1e789450dec761302e5aaef7efbb60e76
             - name: PYTHONPATH
               value: /app
             - name: DB_DSN

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-hyperliquid-runtime
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:3796127310ecd2668a7911c7547fcfb1e789450dec761302e5aaef7efbb60e76
           imagePullPolicy: Always
           command:
             - uvicorn
@@ -46,9 +46,9 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: 2551ef69cd01c2cd10244fc4e13d14a4be8b1973
+              value: 78440b8b57bf720b59e164403b23451cbd830117
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
+              value: sha256:3796127310ecd2668a7911c7547fcfb1e789450dec761302e5aaef7efbb60e76
             - name: DB_DSN
               valueFrom:
                 secretKeyRef:

--- a/argocd/applications/torghut-options/archive/deployment.yaml
+++ b/argocd/applications/torghut-options/archive/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: await-options-schema
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:3796127310ecd2668a7911c7547fcfb1e789450dec761302e5aaef7efbb60e76
           imagePullPolicy: IfNotPresent
           command:
             - python
@@ -65,7 +65,7 @@ spec:
                 - ALL
       containers:
         - name: torghut-options-archive
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:3796127310ecd2668a7911c7547fcfb1e789450dec761302e5aaef7efbb60e76
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -101,9 +101,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1937-g2551ef69c
+              value: v0.596.0-1940-g78440b8b5
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 2551ef69cd01c2cd10244fc4e13d14a4be8b1973
+              value: 78440b8b57bf720b59e164403b23451cbd830117
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -33,7 +33,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: await-options-schema
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:3796127310ecd2668a7911c7547fcfb1e789450dec761302e5aaef7efbb60e76
           imagePullPolicy: IfNotPresent
           command:
             - python
@@ -62,7 +62,7 @@ spec:
                 - ALL
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:3796127310ecd2668a7911c7547fcfb1e789450dec761302e5aaef7efbb60e76
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -110,9 +110,9 @@ spec:
                   name: torghut-ws-config
                   key: SYMBOLS_ALLOWLIST
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1937-g2551ef69c
+              value: v0.596.0-1940-g78440b8b5
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 2551ef69cd01c2cd10244fc4e13d14a4be8b1973
+              value: 78440b8b57bf720b59e164403b23451cbd830117
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: await-options-schema
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:3796127310ecd2668a7911c7547fcfb1e789450dec761302e5aaef7efbb60e76
           imagePullPolicy: IfNotPresent
           command:
             - python
@@ -63,7 +63,7 @@ spec:
                 - ALL
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:3796127310ecd2668a7911c7547fcfb1e789450dec761302e5aaef7efbb60e76
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -106,9 +106,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1937-g2551ef69c
+              value: v0.596.0-1940-g78440b8b5
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 2551ef69cd01c2cd10244fc4e13d14a4be8b1973
+              value: 78440b8b57bf720b59e164403b23451cbd830117
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:3796127310ecd2668a7911c7547fcfb1e789450dec761302e5aaef7efbb60e76
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:3796127310ecd2668a7911c7547fcfb1e789450dec761302e5aaef7efbb60e76
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:3796127310ecd2668a7911c7547fcfb1e789450dec761302e5aaef7efbb60e76
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:3796127310ecd2668a7911c7547fcfb1e789450dec761302e5aaef7efbb60e76
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -27,7 +27,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:3796127310ecd2668a7911c7547fcfb1e789450dec761302e5aaef7efbb60e76
           workingDir: /app
           command:
             - /bin/sh

--- a/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
+++ b/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-generated-resource-retention
           containers:
             - name: prune-generated-residue
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:3796127310ecd2668a7911c7547fcfb1e789450dec761302e5aaef7efbb60e76
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:3796127310ecd2668a7911c7547fcfb1e789450dec761302e5aaef7efbb60e76
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-14T23:56:03Z"
+        client.knative.dev/updateTimestamp: "2026-07-15T00:23:26Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:3796127310ecd2668a7911c7547fcfb1e789450dec761302e5aaef7efbb60e76
           ports:
             - name: http1
               containerPort: 8181
@@ -507,11 +507,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1937-g2551ef69c
+              value: v0.596.0-1940-g78440b8b5
             - name: TORGHUT_COMMIT
-              value: 2551ef69cd01c2cd10244fc4e13d14a4be8b1973
+              value: 78440b8b57bf720b59e164403b23451cbd830117
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
+              value: sha256:3796127310ecd2668a7911c7547fcfb1e789450dec761302e5aaef7efbb60e76
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-14T23:56:03Z"
+        client.knative.dev/updateTimestamp: "2026-07-15T00:23:26Z"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
     spec:
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:3796127310ecd2668a7911c7547fcfb1e789450dec761302e5aaef7efbb60e76
           ports:
             - name: http1
               containerPort: 8181
@@ -442,11 +442,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1937-g2551ef69c
+              value: v0.596.0-1940-g78440b8b5
             - name: TORGHUT_COMMIT
-              value: 2551ef69cd01c2cd10244fc4e13d14a4be8b1973
+              value: 78440b8b57bf720b59e164403b23451cbd830117
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
+              value: sha256:3796127310ecd2668a7911c7547fcfb1e789450dec761302e5aaef7efbb60e76
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -37,7 +37,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:3796127310ecd2668a7911c7547fcfb1e789450dec761302e5aaef7efbb60e76
           command:
             - uvicorn
           args:
@@ -458,11 +458,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1937-g2551ef69c
+              value: v0.596.0-1940-g78440b8b5
             - name: TORGHUT_COMMIT
-              value: 2551ef69cd01c2cd10244fc4e13d14a4be8b1973
+              value: 78440b8b57bf720b59e164403b23451cbd830117
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
+              value: sha256:3796127310ecd2668a7911c7547fcfb1e789450dec761302e5aaef7efbb60e76
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: smoke
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:dad1156a0e92e551052997de77cd2da733aaf1bb06f3ff59e821d79fe9fc2dbb
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:3796127310ecd2668a7911c7547fcfb1e789450dec761302e5aaef7efbb60e76
           imagePullPolicy: IfNotPresent
           securityContext:
             seccompProfile:


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `78440b8b57bf720b59e164403b23451cbd830117`
- Image tag: `sha-78440b8b57bf720b59e164403b23451cbd830117`
- Image digest: `sha256:3796127310ecd2668a7911c7547fcfb1e789450dec761302e5aaef7efbb60e76`
- Migration change detected under `services/torghut/migrations/**`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher
- Added `do-not-automerge`; manual DB migration approval required before merge