### PR TITLE
chore(symphony): promote image sha-0f419b56784ec3e32fbb4d90d3c4d5ef44a88ed1

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-13T03:12:22Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-15T00:31:26Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -22,5 +22,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-d8d24cd01df091dedde7e32c262fea96cc3d7d11"
-    digest: sha256:eb332d09be94988b76d106d8c657ae03a30045174defa946cc51eb62d213267b
+    newTag: "sha-0f419b56784ec3e32fbb4d90d3c4d5ef44a88ed1"
+    digest: sha256:d34ebf5b061b5af9bc8e4ced9d54f97d914f2072e14a535b92692ac1a499a2a7

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-13T03:12:22Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-15T00:31:26Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-d8d24cd01df091dedde7e32c262fea96cc3d7d11"
-    digest: sha256:eb332d09be94988b76d106d8c657ae03a30045174defa946cc51eb62d213267b
+    newTag: "sha-0f419b56784ec3e32fbb4d90d3c4d5ef44a88ed1"
+    digest: sha256:d34ebf5b061b5af9bc8e4ced9d54f97d914f2072e14a535b92692ac1a499a2a7

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-13T03:12:22Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-15T00:31:26Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -16,5 +16,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-d8d24cd01df091dedde7e32c262fea96cc3d7d11"
-    digest: sha256:eb332d09be94988b76d106d8c657ae03a30045174defa946cc51eb62d213267b
+    newTag: "sha-0f419b56784ec3e32fbb4d90d3c4d5ef44a88ed1"
+    digest: sha256:d34ebf5b061b5af9bc8e4ced9d54f97d914f2072e14a535b92692ac1a499a2a7


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `0f419b56784ec3e32fbb4d90d3c4d5ef44a88ed1`
- Image tag: `sha-0f419b56784ec3e32fbb4d90d3c4d5ef44a88ed1`
- Image digest: `sha256:d34ebf5b061b5af9bc8e4ced9d54f97d914f2072e14a535b92692ac1a499a2a7`