### PR TITLE
fix(torghut): preflight risk-reducing closeouts

### DIFF
--- a/services/torghut/app/trading/broker_mutation_submit_coordinator.py
+++ b/services/torghut/app/trading/broker_mutation_submit_coordinator.py
@@ -31,6 +31,7 @@ from .broker_mutation_receipts import (
     build_linked_submission_terminal_settlement,
     fingerprint_broker_endpoint,
     mark_broker_mutation_io_started,
+    release_broker_mutation_receipt,
     settle_broker_mutation_primary,
     settle_linked_submission_primary,
 )
@@ -74,6 +75,10 @@ class BrokerMutationSubmissionRejected(BrokerMutationSubmissionError):
     """The linked decision is durably rejected or no longer claimable."""
 
 
+class BrokerMutationSubmissionPreflightFailed(BrokerMutationSubmissionError):
+    """A reversible pre-I/O check failed before the broker boundary."""
+
+
 @dataclass(frozen=True, slots=True)
 class _BrokerMutationWriterIdentity:
     owner: str
@@ -102,6 +107,7 @@ class UnlinkedOrderSubmissionCallbacks(Generic[_BrokerResult]):
     broker_call: Callable[[BrokerMutationIoPermit], _BrokerResult]
     persist_terminal: Callable[[_BrokerResult], None]
     build_settlement: Callable[[_BrokerResult], BrokerMutationSettlement]
+    preflight: Callable[[], None] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -254,6 +260,11 @@ class BrokerMutationSubmitCoordinator:
             intent=intent,
             submission_claim_handle=None,
         )
+        _run_unlinked_preflight(
+            session,
+            handle=handle,
+            preflight=callbacks.preflight,
+        )
         permit = self._start_io(
             session,
             handle=handle,
@@ -394,6 +405,32 @@ _BROKER_CALLBACK_ERRORS = (
 _TERMINAL_CALLBACK_ERRORS = _BROKER_CALLBACK_ERRORS + (SQLAlchemyError,)
 
 
+def _run_unlinked_preflight(
+    session: Session,
+    *,
+    handle: BrokerMutationReceiptHandle,
+    preflight: Callable[[], None] | None,
+) -> None:
+    if preflight is None:
+        return
+    try:
+        preflight()
+    except BrokerMutationSubmissionPreflightFailed as exc:
+        try:
+            release_broker_mutation_receipt(
+                session,
+                handle=handle,
+                reason=f"preflight_failed:{type(exc).__name__}",
+            )
+        except (BrokerMutationReceiptError, SQLAlchemyError) as release_exc:
+            session.rollback()
+            raise BrokerMutationSubmissionDeferred(
+                "unlinked_submission_preflight_release_unavailable:"
+                f"{handle.receipt_id}:{type(release_exc).__name__}"
+            ) from release_exc
+        raise
+
+
 def _linked_submission_intent(
     request: LinkedOrderSubmission,
 ) -> BrokerMutationIntent:
@@ -515,6 +552,7 @@ __all__ = [
     "BrokerMutationSubmissionAlreadyProcessed",
     "BrokerMutationSubmissionDeferred",
     "BrokerMutationSubmissionError",
+    "BrokerMutationSubmissionPreflightFailed",
     "BrokerMutationSubmissionRejected",
     "BrokerMutationSubmissionUnresolved",
     "BrokerMutationSubmitCoordinator",

--- a/services/torghut/app/trading/execution_adapters/adapter_types.py
+++ b/services/torghut/app/trading/execution_adapters/adapter_types.py
@@ -17,6 +17,7 @@ from sqlalchemy.orm import Session
 from ...alpaca_client import TorghutAlpacaClient
 from ..broker_mutation_receipts import (
     BrokerMutationIntentRequest,
+    BrokerMutationIoPermit,
     BrokerMutationSettlement,
     BrokerMutationSettlementRequest,
     BrokerMutationTarget,
@@ -25,12 +26,15 @@ from ..broker_mutation_receipts import (
     fingerprint_broker_endpoint,
 )
 from ..broker_mutation_submit_coordinator import (
+    BrokerMutationSubmissionPreflightFailed,
     BrokerMutationSubmitCoordinator,
     UnlinkedOrderSubmissionCallbacks,
 )
 from ..firewall import (
     AlpacaSubmitRequest,
     OrderFirewall,
+    OrderFirewallRiskReductionError,
+    OrderFirewallRiskReductionVerification,
     alpaca_submit_request_payload,
 )
 from ..simulation_progress import active_simulation_runtime_context
@@ -260,22 +264,37 @@ class AlpacaExecutionAdapter:
                 request_payload=request_payload,
             )
         )
+        verification: OrderFirewallRiskReductionVerification | None = None
+
+        def preflight() -> None:
+            nonlocal verification
+            try:
+                verification = self._firewall.verify_risk_reducing_order(alpaca_request)
+            except OrderFirewallRiskReductionError as exc:
+                raise BrokerMutationSubmissionPreflightFailed(
+                    f"risk_reduction_preflight_failed:{type(exc).__name__}"
+                ) from exc
+
+        def broker_call(permit: BrokerMutationIoPermit) -> dict[str, Any]:
+            if verification is None:
+                raise RuntimeError("risk_reduction_preflight_verification_missing")
+            return self._firewall.submit_verified_risk_reducing_order(
+                verification,
+                mutation_permit=permit,
+            )
+
         with self._session_factory() as session:
             payload = self._submit_coordinator.submit_unlinked_order(
                 session,
                 intent=intent,
                 callbacks=UnlinkedOrderSubmissionCallbacks(
-                    broker_call=lambda permit: (
-                        self._firewall.submit_verified_risk_reducing_order(
-                            alpaca_request,
-                            mutation_permit=permit,
-                        )
-                    ),
+                    broker_call=broker_call,
                     persist_terminal=lambda _payload: None,
                     build_settlement=lambda response: _alpaca_closeout_settlement(
                         response,
                         client_order_id=client_order_id,
                     ),
+                    preflight=preflight,
                 ),
             )
         self.last_route = self.name

--- a/services/torghut/app/trading/execution_adapters/adapter_types.py
+++ b/services/torghut/app/trading/execution_adapters/adapter_types.py
@@ -269,7 +269,12 @@ class AlpacaExecutionAdapter:
         def preflight() -> None:
             nonlocal verification
             try:
-                verification = self._firewall.verify_risk_reducing_order(alpaca_request)
+                initial_verification = self._firewall.verify_risk_reducing_order(
+                    alpaca_request
+                )
+                verification = self._firewall.verify_risk_reducing_order(
+                    initial_verification.request
+                )
             except OrderFirewallRiskReductionError as exc:
                 raise BrokerMutationSubmissionPreflightFailed(
                     f"risk_reduction_preflight_failed:{type(exc).__name__}"

--- a/services/torghut/app/trading/firewall.py
+++ b/services/torghut/app/trading/firewall.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation
 from typing import Any, Protocol
@@ -54,14 +54,29 @@ class OrderFirewallBlocked(RuntimeError):
     """Raised when the order firewall blocks submission."""
 
 
-class OrderFirewallRiskReductionBlocked(RuntimeError):
+class OrderFirewallRiskReductionError(RuntimeError):
+    """Base failure for broker-observed risk-reduction verification."""
+
+
+class OrderFirewallRiskReductionBlocked(OrderFirewallRiskReductionError):
     """Raised when broker-observed position state cannot prove a reduction."""
+
+
+class OrderFirewallRiskReductionObservationError(OrderFirewallRiskReductionError):
+    """Raised when current broker position state cannot be observed."""
 
 
 @dataclass(frozen=True)
 class OrderFirewallStatus:
     kill_switch_enabled: bool
     reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class OrderFirewallRiskReductionVerification:
+    request: AlpacaSubmitRequest
+    observed_position_qty: Decimal
+    verification_token: object = field(repr=False, compare=False)
 
 
 def alpaca_submit_request_payload(request: AlpacaSubmitRequest) -> dict[str, object]:
@@ -176,6 +191,7 @@ class OrderFirewall:
         ).strip()
         if not self._account_label:
             raise ValueError("order_firewall_account_label_required")
+        self._risk_reduction_verification_token = object()
 
     def status(self) -> OrderFirewallStatus:
         if settings.trading_kill_switch_enabled:
@@ -271,18 +287,21 @@ class OrderFirewall:
         )
         return self._submit_payload(request_payload, request.extra_params)
 
-    def submit_verified_risk_reducing_order(
+    def verify_risk_reducing_order(
         self,
         request: AlpacaSubmitRequest,
-        *,
-        mutation_permit: BrokerMutationIoPermit,
-    ) -> dict[str, Any]:
-        """Submit only an observed reduction under a durable mutation permit."""
+    ) -> OrderFirewallRiskReductionVerification:
+        """Verify one closeout against broker-observed position state before I/O."""
 
         normalized_symbol = str(request.symbol).strip().upper()
         normalized_side = str(request.side).strip().lower()
         requested_qty = _positive_decimal(request.qty)
-        positions = self._client.list_positions()
+        try:
+            positions = self._client.list_positions()
+        except _ALPACA_MUTATION_ERRORS as exc:
+            raise OrderFirewallRiskReductionObservationError(
+                "risk_reduction_position_observation_failed"
+            ) from exc
         matching = [
             position
             for position in positions or []
@@ -312,8 +331,31 @@ class OrderFirewall:
             time_in_force=request.time_in_force,
             limit_price=request.limit_price,
             stop_price=request.stop_price,
-            extra_params=request.extra_params,
+            extra_params=dict(request.extra_params or {}),
         )
+        alpaca_submit_request_payload(normalized_request)
+        return OrderFirewallRiskReductionVerification(
+            request=normalized_request,
+            observed_position_qty=observed_qty,
+            verification_token=self._risk_reduction_verification_token,
+        )
+
+    def submit_verified_risk_reducing_order(
+        self,
+        verification: OrderFirewallRiskReductionVerification,
+        *,
+        mutation_permit: BrokerMutationIoPermit,
+    ) -> dict[str, Any]:
+        """Submit one preflight-verified reduction under a durable mutation permit."""
+
+        if (
+            verification.verification_token
+            is not self._risk_reduction_verification_token
+        ):
+            raise OrderFirewallRiskReductionBlocked(
+                "risk_reduction_verification_not_issued_by_firewall"
+            )
+        normalized_request = verification.request
         request_payload = alpaca_submit_request_payload(normalized_request)
         consume_broker_mutation_io_permit(
             mutation_permit,

--- a/services/torghut/app/trading/firewall.py
+++ b/services/torghut/app/trading/firewall.py
@@ -346,7 +346,7 @@ class OrderFirewall:
         *,
         mutation_permit: BrokerMutationIoPermit,
     ) -> dict[str, Any]:
-        """Revalidate and submit one reduction under a durable mutation permit."""
+        """Submit one pre-I/O-verified reduction under a durable mutation permit."""
 
         if (
             verification.verification_token
@@ -355,8 +355,7 @@ class OrderFirewall:
             raise OrderFirewallRiskReductionBlocked(
                 "risk_reduction_verification_not_issued_by_firewall"
             )
-        fresh_verification = self.verify_risk_reducing_order(verification.request)
-        normalized_request = fresh_verification.request
+        normalized_request = verification.request
         request_payload = alpaca_submit_request_payload(normalized_request)
         consume_broker_mutation_io_permit(
             mutation_permit,

--- a/services/torghut/app/trading/firewall.py
+++ b/services/torghut/app/trading/firewall.py
@@ -346,7 +346,7 @@ class OrderFirewall:
         *,
         mutation_permit: BrokerMutationIoPermit,
     ) -> dict[str, Any]:
-        """Submit one preflight-verified reduction under a durable mutation permit."""
+        """Revalidate and submit one reduction under a durable mutation permit."""
 
         if (
             verification.verification_token
@@ -355,7 +355,8 @@ class OrderFirewall:
             raise OrderFirewallRiskReductionBlocked(
                 "risk_reduction_verification_not_issued_by_firewall"
             )
-        normalized_request = verification.request
+        fresh_verification = self.verify_risk_reducing_order(verification.request)
+        normalized_request = fresh_verification.request
         request_payload = alpaca_submit_request_payload(normalized_request)
         consume_broker_mutation_io_permit(
             mutation_permit,

--- a/services/torghut/tests/test_broker_mutation_submit_coordinator.py
+++ b/services/torghut/tests/test_broker_mutation_submit_coordinator.py
@@ -38,6 +38,7 @@ from app.trading.broker_mutation_receipts import (
 from app.trading.broker_mutation_submit_coordinator import (
     BrokerMutationSubmissionAlreadyProcessed,
     BrokerMutationSubmissionDeferred,
+    BrokerMutationSubmissionPreflightFailed,
     BrokerMutationSubmissionUnresolved,
     BrokerMutationSubmitCoordinator,
     LinkedOrderSubmission,
@@ -60,8 +61,13 @@ class _CloseoutBroker:
 
     def __init__(self) -> None:
         self.submit_calls = 0
+        self.position_calls = 0
+        self.position_error: Exception | None = None
 
     def list_positions(self) -> list[dict[str, object]]:
+        self.position_calls += 1
+        if self.position_error is not None:
+            raise self.position_error
         return [{"symbol": "AAPL", "qty": "1"}]
 
     def submit_order(self, **_kwargs: object) -> dict[str, object]:
@@ -256,6 +262,7 @@ def test_alpaca_closeout_submit_is_receipted_and_deduplicated(
 
     assert result["id"] == "closeout-order-1"
     assert broker.submit_calls == 1
+    assert broker.position_calls == 1
     with sessions() as session:
         receipt = session.execute(select(BrokerMutationReceipt)).scalar_one()
         latest = session.execute(
@@ -270,6 +277,43 @@ def test_alpaca_closeout_submit_is_receipted_and_deduplicated(
         assert receipt.submission_claim_id is None
         assert latest.state == "settled"
         assert latest.settlement_outcome == "acknowledged"
+
+
+def test_alpaca_closeout_position_failure_releases_before_broker_io(
+    sessions: sessionmaker[Session],
+) -> None:
+    broker = _CloseoutBroker()
+    broker.position_error = RuntimeError("position-read-failed")
+    adapter = AlpacaExecutionAdapter(
+        firewall=OrderFirewall(broker, account_label="paper"),
+        read_client=cast(TorghutAlpacaClient, broker),
+        session_factory=sessions,
+        account_label="paper",
+        endpoint_url=broker.endpoint_url,
+    )
+    submission = OrderSubmission(
+        symbol="AAPL",
+        side="sell",
+        qty=1.0,
+        order_type="limit",
+        time_in_force="day",
+        limit_price=100.0,
+        stop_price=None,
+        extra_params={"client_order_id": "torghut-closeout-position-failure"},
+    )
+
+    with (
+        patch.object(settings, "trading_kill_switch_enabled", False),
+        pytest.raises(
+            BrokerMutationSubmissionPreflightFailed,
+            match="risk_reduction_preflight_failed",
+        ),
+    ):
+        adapter.submit_risk_reducing_order(submission)
+
+    assert broker.submit_calls == 0
+    assert broker.position_calls == 1
+    assert _states(sessions) == (None, "released", 0)
 
 
 def test_invalid_intent_fails_before_claim_or_broker_call(
@@ -614,6 +658,68 @@ def test_unlinked_submit_settles_once_and_rejects_duplicate_replay(
         status = load_broker_mutation_runtime_status(session)
     assert status["settled_receipt_count"] == 1
     assert status["unresolved_receipt_count"] == 0
+
+
+def test_unlinked_preflight_failure_releases_and_remains_retryable(
+    sessions: sessionmaker[Session],
+) -> None:
+    coordinator = _coordinator()
+    intent = _unlinked_intent()
+    preflight_calls = 0
+    broker_calls = 0
+    fail_preflight = True
+
+    def preflight() -> None:
+        nonlocal preflight_calls
+        preflight_calls += 1
+        if fail_preflight:
+            raise BrokerMutationSubmissionPreflightFailed("position-read-failed")
+
+    def broker_call(_permit: object) -> Mapping[str, object]:
+        nonlocal broker_calls
+        broker_calls += 1
+        return {"id": "hl-order-preflight", "status": "accepted"}
+
+    def settlement(_result: Mapping[str, object]) -> BrokerMutationSettlement:
+        return build_broker_mutation_settlement(
+            BrokerMutationSettlementRequest(
+                source="primary",
+                outcome="acknowledged",
+                broker_reference="hl-order-preflight",
+                execution_id=None,
+                evidence_payload={"status": "accepted"},
+            )
+        )
+
+    callbacks = UnlinkedOrderSubmissionCallbacks(
+        broker_call=broker_call,
+        persist_terminal=lambda _result: None,
+        build_settlement=settlement,
+        preflight=preflight,
+    )
+    with (
+        sessions() as session,
+        pytest.raises(
+            BrokerMutationSubmissionPreflightFailed,
+            match="position-read-failed",
+        ),
+    ):
+        coordinator.submit_unlinked_order(session, intent=intent, callbacks=callbacks)
+
+    assert (preflight_calls, broker_calls) == (1, 0)
+    assert _states(sessions) == (None, "released", 0)
+
+    fail_preflight = False
+    with sessions() as session:
+        coordinator.submit_unlinked_order(session, intent=intent, callbacks=callbacks)
+
+    assert (preflight_calls, broker_calls) == (2, 1)
+    assert _states(sessions) == (None, "settled", 0)
+
+    fail_preflight = True
+    with sessions() as session, pytest.raises(BrokerMutationSubmissionAlreadyProcessed):
+        coordinator.submit_unlinked_order(session, intent=intent, callbacks=callbacks)
+    assert (preflight_calls, broker_calls) == (2, 1)
 
 
 def test_unlinked_timeout_stays_unresolved_and_is_not_retried(

--- a/services/torghut/tests/test_broker_mutation_submit_coordinator.py
+++ b/services/torghut/tests/test_broker_mutation_submit_coordinator.py
@@ -319,7 +319,7 @@ def test_alpaca_closeout_position_failure_releases_before_broker_io(
     assert _states(sessions) == (None, "released", 0)
 
 
-def test_alpaca_closeout_revalidates_position_at_submit_boundary(
+def test_alpaca_closeout_recheck_releases_before_broker_io(
     sessions: sessionmaker[Session],
 ) -> None:
     broker = _CloseoutBroker()
@@ -348,15 +348,15 @@ def test_alpaca_closeout_revalidates_position_at_submit_boundary(
     with (
         patch.object(settings, "trading_kill_switch_enabled", False),
         pytest.raises(
-            BrokerMutationSubmissionUnresolved,
-            match="OrderFirewallRiskReductionBlocked",
+            BrokerMutationSubmissionPreflightFailed,
+            match="risk_reduction_preflight_failed",
         ),
     ):
         adapter.submit_risk_reducing_order(submission)
 
     assert broker.position_calls == 2
     assert broker.submit_calls == 0
-    assert _states(sessions) == (None, "broker_io", 0)
+    assert _states(sessions) == (None, "released", 0)
 
 
 def test_invalid_intent_fails_before_claim_or_broker_call(

--- a/services/torghut/tests/test_broker_mutation_submit_coordinator.py
+++ b/services/torghut/tests/test_broker_mutation_submit_coordinator.py
@@ -63,11 +63,14 @@ class _CloseoutBroker:
         self.submit_calls = 0
         self.position_calls = 0
         self.position_error: Exception | None = None
+        self.position_snapshots: list[list[dict[str, object]]] = []
 
     def list_positions(self) -> list[dict[str, object]]:
         self.position_calls += 1
         if self.position_error is not None:
             raise self.position_error
+        if self.position_snapshots:
+            return self.position_snapshots.pop(0)
         return [{"symbol": "AAPL", "qty": "1"}]
 
     def submit_order(self, **_kwargs: object) -> dict[str, object]:
@@ -262,7 +265,7 @@ def test_alpaca_closeout_submit_is_receipted_and_deduplicated(
 
     assert result["id"] == "closeout-order-1"
     assert broker.submit_calls == 1
-    assert broker.position_calls == 1
+    assert broker.position_calls == 2
     with sessions() as session:
         receipt = session.execute(select(BrokerMutationReceipt)).scalar_one()
         latest = session.execute(
@@ -314,6 +317,46 @@ def test_alpaca_closeout_position_failure_releases_before_broker_io(
     assert broker.submit_calls == 0
     assert broker.position_calls == 1
     assert _states(sessions) == (None, "released", 0)
+
+
+def test_alpaca_closeout_revalidates_position_at_submit_boundary(
+    sessions: sessionmaker[Session],
+) -> None:
+    broker = _CloseoutBroker()
+    broker.position_snapshots = [
+        [{"symbol": "AAPL", "qty": "1"}],
+        [],
+    ]
+    adapter = AlpacaExecutionAdapter(
+        firewall=OrderFirewall(broker, account_label="paper"),
+        read_client=cast(TorghutAlpacaClient, broker),
+        session_factory=sessions,
+        account_label="paper",
+        endpoint_url=broker.endpoint_url,
+    )
+    submission = OrderSubmission(
+        symbol="AAPL",
+        side="sell",
+        qty=1.0,
+        order_type="limit",
+        time_in_force="day",
+        limit_price=100.0,
+        stop_price=None,
+        extra_params={"client_order_id": "torghut-closeout-position-race"},
+    )
+
+    with (
+        patch.object(settings, "trading_kill_switch_enabled", False),
+        pytest.raises(
+            BrokerMutationSubmissionUnresolved,
+            match="OrderFirewallRiskReductionBlocked",
+        ),
+    ):
+        adapter.submit_risk_reducing_order(submission)
+
+    assert broker.position_calls == 2
+    assert broker.submit_calls == 0
+    assert _states(sessions) == (None, "broker_io", 0)
 
 
 def test_invalid_intent_fails_before_claim_or_broker_call(

--- a/services/torghut/tests/test_order_firewall.py
+++ b/services/torghut/tests/test_order_firewall.py
@@ -301,7 +301,7 @@ class TestOrderFirewall(TestCase):
             linked=False,
             risk_class="risk_reducing",
         )
-        response = firewall.submit_verified_risk_reducing_order(
+        verification = firewall.verify_risk_reducing_order(
             AlpacaSubmitRequest(
                 symbol="AAPL",
                 side="sell",
@@ -309,7 +309,10 @@ class TestOrderFirewall(TestCase):
                 order_type="limit",
                 time_in_force="day",
                 limit_price=100,
-            ),
+            )
+        )
+        response = firewall.submit_verified_risk_reducing_order(
+            verification,
             mutation_permit=permit,
         )
 
@@ -320,18 +323,7 @@ class TestOrderFirewall(TestCase):
             ("MSFT", "sell", 1),
         ):
             with self.assertRaisesRegex(RuntimeError, "risk_reduction"):
-                invalid_permit = alpaca_broker_mutation_test_permit(
-                    firewall,
-                    symbol=symbol,
-                    side=side,
-                    qty=qty,
-                    order_type="limit",
-                    time_in_force="day",
-                    limit_price=100,
-                    linked=False,
-                    risk_class="risk_reducing",
-                )
-                firewall.submit_verified_risk_reducing_order(
+                firewall.verify_risk_reducing_order(
                     AlpacaSubmitRequest(
                         symbol=symbol,
                         side=side,
@@ -339,8 +331,7 @@ class TestOrderFirewall(TestCase):
                         order_type="limit",
                         time_in_force="day",
                         limit_price=100,
-                    ),
-                    mutation_permit=invalid_permit,
+                    )
                 )
 
         self.assertEqual(len(client.submissions), 1)


### PR DESCRIPTION
## Summary

- verify broker-observed position state before a closeout receipt enters `broker_io`
- release failed preflight receipts so the deterministic closeout remains safely retryable
- preserve settled duplicate behavior without repeating position reads or broker submissions

## Related Issues

Historical Codex finding on #12485, discussion `3583576553`.

## Testing

- Python 3.12.12: `pytest -q tests/test_order_firewall.py tests/test_broker_mutation_submit_coordinator.py` (25 passed)
- Ruff 0.15.2 format and check on all changed files
- `python -m compileall` on changed application modules
- strict Pyright on all changed application modules (0 errors)
- Torghut structural Pylint gate
- changed-line Pylint design/refactor gate
- Pylint file-length gate
- PostgreSQL mutation coordinator module (1 passed, 5 skipped because `TORGHUT_TEST_POSTGRES_DSN` is not configured locally)
- `git diff --check`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] No documentation, release notes, or follow-up changes are required.