### PR TITLE
chore(torghut): promote image sha-07f3173acf4671b58670dafda318d5aa5cea1c56

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -24,7 +24,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: migrate
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:adfd41333c1b3239406f74a640f1bf6298b0f6c122ca535d10245412731cf845
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8d4085c525439bad98f3f248addb3cbb956beeaca5e23ecd0b8ef50a71b262b3
           imagePullPolicy: Always
           workingDir: /app
           command:
@@ -54,9 +54,9 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: f076ec73b7fe956f150df609cb1415e11cb1bfd9
+              value: 07f3173acf4671b58670dafda318d5aa5cea1c56
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:adfd41333c1b3239406f74a640f1bf6298b0f6c122ca535d10245412731cf845
+              value: sha256:8d4085c525439bad98f3f248addb3cbb956beeaca5e23ecd0b8ef50a71b262b3
             - name: PYTHONPATH
               value: /app
             - name: DB_DSN

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-hyperliquid-runtime
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:adfd41333c1b3239406f74a640f1bf6298b0f6c122ca535d10245412731cf845
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8d4085c525439bad98f3f248addb3cbb956beeaca5e23ecd0b8ef50a71b262b3
           imagePullPolicy: Always
           command:
             - uvicorn
@@ -46,9 +46,9 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: f076ec73b7fe956f150df609cb1415e11cb1bfd9
+              value: 07f3173acf4671b58670dafda318d5aa5cea1c56
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:adfd41333c1b3239406f74a640f1bf6298b0f6c122ca535d10245412731cf845
+              value: sha256:8d4085c525439bad98f3f248addb3cbb956beeaca5e23ecd0b8ef50a71b262b3
             - name: DB_DSN
               valueFrom:
                 secretKeyRef:

--- a/argocd/applications/torghut-options/archive/deployment.yaml
+++ b/argocd/applications/torghut-options/archive/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: await-options-schema
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:adfd41333c1b3239406f74a640f1bf6298b0f6c122ca535d10245412731cf845
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8d4085c525439bad98f3f248addb3cbb956beeaca5e23ecd0b8ef50a71b262b3
           imagePullPolicy: IfNotPresent
           command:
             - python
@@ -65,7 +65,7 @@ spec:
                 - ALL
       containers:
         - name: torghut-options-archive
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:adfd41333c1b3239406f74a640f1bf6298b0f6c122ca535d10245412731cf845
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8d4085c525439bad98f3f248addb3cbb956beeaca5e23ecd0b8ef50a71b262b3
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -101,9 +101,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1944-gf076ec73b
+              value: v0.596.0-1946-g07f3173ac
             - name: TORGHUT_OPTIONS_COMMIT
-              value: f076ec73b7fe956f150df609cb1415e11cb1bfd9
+              value: 07f3173acf4671b58670dafda318d5aa5cea1c56
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -33,7 +33,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: await-options-schema
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:adfd41333c1b3239406f74a640f1bf6298b0f6c122ca535d10245412731cf845
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8d4085c525439bad98f3f248addb3cbb956beeaca5e23ecd0b8ef50a71b262b3
           imagePullPolicy: IfNotPresent
           command:
             - python
@@ -62,7 +62,7 @@ spec:
                 - ALL
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:adfd41333c1b3239406f74a640f1bf6298b0f6c122ca535d10245412731cf845
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8d4085c525439bad98f3f248addb3cbb956beeaca5e23ecd0b8ef50a71b262b3
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -110,9 +110,9 @@ spec:
                   name: torghut-ws-config
                   key: SYMBOLS_ALLOWLIST
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1944-gf076ec73b
+              value: v0.596.0-1946-g07f3173ac
             - name: TORGHUT_OPTIONS_COMMIT
-              value: f076ec73b7fe956f150df609cb1415e11cb1bfd9
+              value: 07f3173acf4671b58670dafda318d5aa5cea1c56
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: await-options-schema
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:adfd41333c1b3239406f74a640f1bf6298b0f6c122ca535d10245412731cf845
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8d4085c525439bad98f3f248addb3cbb956beeaca5e23ecd0b8ef50a71b262b3
           imagePullPolicy: IfNotPresent
           command:
             - python
@@ -63,7 +63,7 @@ spec:
                 - ALL
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:adfd41333c1b3239406f74a640f1bf6298b0f6c122ca535d10245412731cf845
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8d4085c525439bad98f3f248addb3cbb956beeaca5e23ecd0b8ef50a71b262b3
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -106,9 +106,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1944-gf076ec73b
+              value: v0.596.0-1946-g07f3173ac
             - name: TORGHUT_OPTIONS_COMMIT
-              value: f076ec73b7fe956f150df609cb1415e11cb1bfd9
+              value: 07f3173acf4671b58670dafda318d5aa5cea1c56
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:adfd41333c1b3239406f74a640f1bf6298b0f6c122ca535d10245412731cf845
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8d4085c525439bad98f3f248addb3cbb956beeaca5e23ecd0b8ef50a71b262b3
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:adfd41333c1b3239406f74a640f1bf6298b0f6c122ca535d10245412731cf845
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8d4085c525439bad98f3f248addb3cbb956beeaca5e23ecd0b8ef50a71b262b3
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:adfd41333c1b3239406f74a640f1bf6298b0f6c122ca535d10245412731cf845
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8d4085c525439bad98f3f248addb3cbb956beeaca5e23ecd0b8ef50a71b262b3
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:adfd41333c1b3239406f74a640f1bf6298b0f6c122ca535d10245412731cf845
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8d4085c525439bad98f3f248addb3cbb956beeaca5e23ecd0b8ef50a71b262b3
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -27,7 +27,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:adfd41333c1b3239406f74a640f1bf6298b0f6c122ca535d10245412731cf845
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8d4085c525439bad98f3f248addb3cbb956beeaca5e23ecd0b8ef50a71b262b3
           workingDir: /app
           command:
             - /bin/sh

--- a/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
+++ b/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-generated-resource-retention
           containers:
             - name: prune-generated-residue
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:adfd41333c1b3239406f74a640f1bf6298b0f6c122ca535d10245412731cf845
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:8d4085c525439bad98f3f248addb3cbb956beeaca5e23ecd0b8ef50a71b262b3
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:adfd41333c1b3239406f74a640f1bf6298b0f6c122ca535d10245412731cf845
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:8d4085c525439bad98f3f248addb3cbb956beeaca5e23ecd0b8ef50a71b262b3
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-15T00:51:04Z"
+        client.knative.dev/updateTimestamp: "2026-07-15T01:32:03Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:adfd41333c1b3239406f74a640f1bf6298b0f6c122ca535d10245412731cf845
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8d4085c525439bad98f3f248addb3cbb956beeaca5e23ecd0b8ef50a71b262b3
           ports:
             - name: http1
               containerPort: 8181
@@ -507,11 +507,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1944-gf076ec73b
+              value: v0.596.0-1946-g07f3173ac
             - name: TORGHUT_COMMIT
-              value: f076ec73b7fe956f150df609cb1415e11cb1bfd9
+              value: 07f3173acf4671b58670dafda318d5aa5cea1c56
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:adfd41333c1b3239406f74a640f1bf6298b0f6c122ca535d10245412731cf845
+              value: sha256:8d4085c525439bad98f3f248addb3cbb956beeaca5e23ecd0b8ef50a71b262b3
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-15T00:51:04Z"
+        client.knative.dev/updateTimestamp: "2026-07-15T01:32:03Z"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
     spec:
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:adfd41333c1b3239406f74a640f1bf6298b0f6c122ca535d10245412731cf845
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8d4085c525439bad98f3f248addb3cbb956beeaca5e23ecd0b8ef50a71b262b3
           ports:
             - name: http1
               containerPort: 8181
@@ -442,11 +442,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1944-gf076ec73b
+              value: v0.596.0-1946-g07f3173ac
             - name: TORGHUT_COMMIT
-              value: f076ec73b7fe956f150df609cb1415e11cb1bfd9
+              value: 07f3173acf4671b58670dafda318d5aa5cea1c56
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:adfd41333c1b3239406f74a640f1bf6298b0f6c122ca535d10245412731cf845
+              value: sha256:8d4085c525439bad98f3f248addb3cbb956beeaca5e23ecd0b8ef50a71b262b3
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -37,7 +37,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:adfd41333c1b3239406f74a640f1bf6298b0f6c122ca535d10245412731cf845
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8d4085c525439bad98f3f248addb3cbb956beeaca5e23ecd0b8ef50a71b262b3
           command:
             - uvicorn
           args:
@@ -458,11 +458,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1944-gf076ec73b
+              value: v0.596.0-1946-g07f3173ac
             - name: TORGHUT_COMMIT
-              value: f076ec73b7fe956f150df609cb1415e11cb1bfd9
+              value: 07f3173acf4671b58670dafda318d5aa5cea1c56
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:adfd41333c1b3239406f74a640f1bf6298b0f6c122ca535d10245412731cf845
+              value: sha256:8d4085c525439bad98f3f248addb3cbb956beeaca5e23ecd0b8ef50a71b262b3
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: smoke
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:adfd41333c1b3239406f74a640f1bf6298b0f6c122ca535d10245412731cf845
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8d4085c525439bad98f3f248addb3cbb956beeaca5e23ecd0b8ef50a71b262b3
           imagePullPolicy: IfNotPresent
           securityContext:
             seccompProfile:


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `07f3173acf4671b58670dafda318d5aa5cea1c56`
- Image tag: `sha-07f3173acf4671b58670dafda318d5aa5cea1c56`
- Image digest: `sha256:8d4085c525439bad98f3f248addb3cbb956beeaca5e23ecd0b8ef50a71b262b3`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher