### PR TITLE
chore(torghut): promote hyperliquid feed image sha-9abb853c837fd369e1d96e70f0d54c5576f86277

### DIFF
--- a/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
@@ -32,18 +32,18 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-hyperliquid-feed
-          image: registry.ide-newton.ts.net/lab/torghut-hyperliquid-feed@sha256:b532dcf3e1a50266bbeded855d0ae6938f4afe55a6ff90293a74278d868356f1
+          image: registry.ide-newton.ts.net/lab/torghut-hyperliquid-feed@sha256:068f5f2f97eee3d7bdcd1b8a942cc7128408f97bcad2da7c5309f8da636620d4
           imagePullPolicy: Always
           envFrom:
             - configMapRef:
                 name: torghut-hyperliquid-feed-config
           env:
             - name: TORGHUT_HYPERLIQUID_FEED_VERSION
-              value: main-sha-272f07d74aa1f4f75ff425b4ae6ce9a8d5622a30
+              value: main-sha-9abb853c837fd369e1d96e70f0d54c5576f86277
             - name: TORGHUT_HYPERLIQUID_FEED_COMMIT
-              value: 272f07d74aa1f4f75ff425b4ae6ce9a8d5622a30
+              value: 9abb853c837fd369e1d96e70f0d54c5576f86277
             - name: TORGHUT_HYPERLIQUID_FEED_IMAGE_DIGEST
-              value: sha256:b532dcf3e1a50266bbeded855d0ae6938f4afe55a6ff90293a74278d868356f1
+              value: sha256:068f5f2f97eee3d7bdcd1b8a942cc7128408f97bcad2da7c5309f8da636620d4
             - name: KAFKA_SASL_USER
               value: torghut-hyperliquid-feed
             - name: KAFKA_SASL_PASSWORD

--- a/argocd/applications/torghut-hyperliquid-feed/parity-cronjob.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/parity-cronjob.yaml
@@ -38,7 +38,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: torghut-hyperliquid-clickhouse-parity
-              image: registry.ide-newton.ts.net/lab/torghut-hyperliquid-feed@sha256:b532dcf3e1a50266bbeded855d0ae6938f4afe55a6ff90293a74278d868356f1
+              image: registry.ide-newton.ts.net/lab/torghut-hyperliquid-feed@sha256:068f5f2f97eee3d7bdcd1b8a942cc7128408f97bcad2da7c5309f8da636620d4
               imagePullPolicy: Always
               envFrom:
                 - configMapRef:
@@ -47,11 +47,11 @@ spec:
                 - name: TORGHUT_HYPERLIQUID_MODE
                   value: clickhouse-parity
                 - name: TORGHUT_HYPERLIQUID_FEED_VERSION
-                  value: main-sha-272f07d74aa1f4f75ff425b4ae6ce9a8d5622a30
+                  value: main-sha-9abb853c837fd369e1d96e70f0d54c5576f86277
                 - name: TORGHUT_HYPERLIQUID_FEED_COMMIT
-                  value: 272f07d74aa1f4f75ff425b4ae6ce9a8d5622a30
+                  value: 9abb853c837fd369e1d96e70f0d54c5576f86277
                 - name: TORGHUT_HYPERLIQUID_FEED_IMAGE_DIGEST
-                  value: sha256:b532dcf3e1a50266bbeded855d0ae6938f4afe55a6ff90293a74278d868356f1
+                  value: sha256:068f5f2f97eee3d7bdcd1b8a942cc7128408f97bcad2da7c5309f8da636620d4
                 - name: KAFKA_SASL_USER
                   value: torghut-hyperliquid-feed
                 - name: KAFKA_SASL_PASSWORD

--- a/argocd/applications/torghut-hyperliquid-feed/writer-deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/writer-deployment.yaml
@@ -33,7 +33,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-hyperliquid-clickhouse-writer
-          image: registry.ide-newton.ts.net/lab/torghut-hyperliquid-feed@sha256:b532dcf3e1a50266bbeded855d0ae6938f4afe55a6ff90293a74278d868356f1
+          image: registry.ide-newton.ts.net/lab/torghut-hyperliquid-feed@sha256:068f5f2f97eee3d7bdcd1b8a942cc7128408f97bcad2da7c5309f8da636620d4
           imagePullPolicy: Always
           envFrom:
             - configMapRef:
@@ -42,11 +42,11 @@ spec:
             - name: TORGHUT_HYPERLIQUID_MODE
               value: clickhouse-writer
             - name: TORGHUT_HYPERLIQUID_FEED_VERSION
-              value: main-sha-272f07d74aa1f4f75ff425b4ae6ce9a8d5622a30
+              value: main-sha-9abb853c837fd369e1d96e70f0d54c5576f86277
             - name: TORGHUT_HYPERLIQUID_FEED_COMMIT
-              value: 272f07d74aa1f4f75ff425b4ae6ce9a8d5622a30
+              value: 9abb853c837fd369e1d96e70f0d54c5576f86277
             - name: TORGHUT_HYPERLIQUID_FEED_IMAGE_DIGEST
-              value: sha256:b532dcf3e1a50266bbeded855d0ae6938f4afe55a6ff90293a74278d868356f1
+              value: sha256:068f5f2f97eee3d7bdcd1b8a942cc7128408f97bcad2da7c5309f8da636620d4
             - name: KAFKA_SASL_USER
               value: torghut-hyperliquid-feed
             - name: KAFKA_SASL_PASSWORD


### PR DESCRIPTION
## Summary

- Promote the immutable Torghut Hyperliquid feed image built from `9abb853c837fd369e1d96e70f0d54c5576f86277`.
- Pin the feed, Kafka-backed ClickHouse writer, and suspended parity gate to `sha256:068f5f2f97eee3d7bdcd1b8a942cc7128408f97bcad2da7c5309f8da636620d4`.
- Preserve one source commit and image digest across all runtime modes.

## Related Issues

None.

## Testing

- The source commit passed its required CI before merge to `main`.
- The release workflow verified the multi-architecture image contract before creating this PR.
- The deploy gate validates both manifests against source `9abb853c837fd369e1d96e70f0d54c5576f86277` and tag `sha-9abb853c837fd369e1d96e70f0d54c5576f86277`.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact automated release validation.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] All runtime manifests carry the same immutable source and image identity.