### PR TITLE
fix(bumba): validate Atlas manifests by path

### DIFF
--- a/services/bumba/src/activities/index.ts
+++ b/services/bumba/src/activities/index.ts
@@ -12,6 +12,7 @@ import { currentActivityContext } from '@proompteng/temporal-bun-sdk/worker'
 
 import { shouldSkipAtlasPath } from '../atlas/file-eligibility'
 import {
+  assertAtlasManifestMatches,
   type AtlasCurrentFile,
   type AtlasGitFile,
   parseAtlasGitTree,
@@ -3331,19 +3332,15 @@ const applyAtlasReconciliation = async (input: {
       WHERE fk.repository_id = ${lockedRepository.id}
       ORDER BY fk.path;
     `) as Array<{ path: string; repository_commit: string | null; object_id: string | null }>
-    if (indexedRows.length !== manifest.files.length) {
-      throw new Error(`Atlas file count mismatch: expected ${manifest.files.length}, indexed ${indexedRows.length}`)
-    }
-    for (let index = 0; index < manifest.files.length; index += 1) {
-      const expected = manifest.files[index]
-      const actual = indexedRows[index]
-      if (!expected || !actual || actual.path !== expected.path || actual.object_id !== expected.objectId) {
-        throw new Error(`Atlas manifest mismatch at ${expected?.path ?? actual?.path ?? `index ${index}`}`)
-      }
-      if (actual.repository_commit !== commit) {
-        throw new Error(`Atlas commit mismatch for ${actual.path}`)
-      }
-    }
+    assertAtlasManifestMatches(
+      manifest,
+      indexedRows.map((row) => ({
+        path: row.path,
+        repositoryCommit: row.repository_commit,
+        gitObjectId: row.object_id,
+      })),
+      commit,
+    )
 
     const coverageRows = (await tx`
       SELECT

--- a/services/bumba/src/atlas/reconciliation.integration.test.ts
+++ b/services/bumba/src/atlas/reconciliation.integration.test.ts
@@ -185,6 +185,7 @@ integrationTest(
   async () => {
     if (!db) throw new Error('integration database was not initialized')
     await mkdir(join(checkout, 'src'), { recursive: true })
+    await mkdir(join(checkout, '.github', 'ISSUE_TEMPLATE'), { recursive: true })
     await writeFile(
       join(checkout, 'src', 'atlas.ts'),
       [
@@ -198,6 +199,8 @@ integrationTest(
     )
     await writeFile(join(checkout, 'README.md'), '# Atlas\n\nComplete Git corpus.\n')
     await writeFile(join(checkout, 'deleted.ts'), 'export const deletedFixture = true\n')
+    await writeFile(join(checkout, '.github', 'actionlint.yaml'), 'self-hosted-runner:\n  labels: [arc]\n')
+    await writeFile(join(checkout, '.github', 'ISSUE_TEMPLATE', 'codex-task.md'), '# Codex task\n')
     await writeFile(join(checkout, 'image.png'), Buffer.from([0x89, 0x50, 0x4e, 0x47]))
     const firstCommit = await commitAndPush('initial')
 
@@ -207,7 +210,7 @@ integrationTest(
       ref: 'main',
       commit: firstCommit,
     })
-    expect(initial).toMatchObject({ expectedFiles: 3, indexedFiles: 3, embeddings: initial.chunks })
+    expect(initial).toMatchObject({ expectedFiles: 5, indexedFiles: 5, embeddings: initial.chunks })
 
     const firstRows = (await db`
     SELECT fk.path, fv.id, fv.content_hash, fv.repository_commit,
@@ -229,9 +232,15 @@ integrationTest(
       chunks: number
       embeddings: number
     }>
-    expect(firstRows.map((row) => row.path)).toHaveLength(3)
+    expect(firstRows.map((row) => row.path)).toHaveLength(5)
     expect(firstRows.map((row) => row.path)).toEqual(
-      expect.arrayContaining(['README.md', 'deleted.ts', 'src/atlas.ts']),
+      expect.arrayContaining([
+        '.github/ISSUE_TEMPLATE/codex-task.md',
+        '.github/actionlint.yaml',
+        'README.md',
+        'deleted.ts',
+        'src/atlas.ts',
+      ]),
     )
     expect(firstRows.every((row) => row.metadata_type === 'object' && row.chunks === row.embeddings)).toBe(true)
     const oldAtlasVersion = firstRows.find((row) => row.path === 'src/atlas.ts')?.id
@@ -251,7 +260,7 @@ integrationTest(
       commit: firstCommit,
     })
     expect(changed.commit).toBe(secondCommit)
-    expect(changed).toMatchObject({ expectedFiles: 2, indexedFiles: 2, deletedFiles: 2 })
+    expect(changed).toMatchObject({ expectedFiles: 4, indexedFiles: 4, deletedFiles: 2 })
 
     const replay = await activities.reconcileAtlasRepository({
       repoRoot: checkout,
@@ -259,7 +268,7 @@ integrationTest(
       ref: 'main',
       commit: secondCommit,
     })
-    expect(replay).toMatchObject({ commit: secondCommit, changedFiles: 0, unchangedFiles: 2 })
+    expect(replay).toMatchObject({ commit: secondCommit, changedFiles: 0, unchangedFiles: 4 })
 
     const finalRows = (await db`
     SELECT fk.path, fv.id, fv.repository_commit, fv.content_hash,
@@ -281,8 +290,15 @@ integrationTest(
       chunks: number
       embeddings: number
     }>
-    expect(finalRows.map((row) => row.path)).toHaveLength(2)
-    expect(finalRows.map((row) => row.path)).toEqual(expect.arrayContaining(['ATLAS.md', 'src/atlas.ts']))
+    expect(finalRows.map((row) => row.path)).toHaveLength(4)
+    expect(finalRows.map((row) => row.path)).toEqual(
+      expect.arrayContaining([
+        '.github/ISSUE_TEMPLATE/codex-task.md',
+        '.github/actionlint.yaml',
+        'ATLAS.md',
+        'src/atlas.ts',
+      ]),
+    )
     expect(finalRows.every((row) => row.repository_commit === secondCommit && row.chunks === row.embeddings)).toBe(true)
     expect(finalRows.find((row) => row.path === 'src/atlas.ts')?.id).not.toBe(oldAtlasVersion)
     const oldVersionRows = (await db`
@@ -320,8 +336,8 @@ integrationTest(
       metadata: {
         indexStatus: 'ready',
         indexedCommit: secondCommit,
-        expectedFiles: 2,
-        indexedFiles: 2,
+        expectedFiles: 4,
+        indexedFiles: 4,
         embeddingDimension: 1024,
         missingPaths: 0,
         stalePaths: 0,

--- a/services/bumba/src/atlas/reconciliation.test.ts
+++ b/services/bumba/src/atlas/reconciliation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test'
 
 import {
+  assertAtlasManifestMatches,
   buildAtlasReconciliationWorkflowId,
   computeAtlasTreeHash,
   parseAtlasGitTree,
@@ -44,5 +45,39 @@ describe('Atlas Git reconciliation', () => {
     expect(plan.unchanged.map((file) => file.path)).toEqual(['docs/README.md'])
     expect(plan.changed.map((file) => file.path)).toEqual(['services/jangar/src/server/atlas.ts'])
     expect(plan.deleted.map((file) => file.path)).toEqual(['deleted.ts'])
+  })
+
+  it('validates the manifest by path when database and JavaScript row orders differ', () => {
+    const commit = 'dddddddddddddddddddddddddddddddddddddddd'
+    const manifest = parseAtlasGitTree(
+      [
+        '100644 blob aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 12\t.github/actionlint.yaml',
+        '100644 blob bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb 24\t.github/ISSUE_TEMPLATE/codex-task.md',
+        '',
+      ].join('\0'),
+    )
+
+    expect(manifest.files.map((file) => file.path)).toEqual([
+      '.github/ISSUE_TEMPLATE/codex-task.md',
+      '.github/actionlint.yaml',
+    ])
+    expect(() =>
+      assertAtlasManifestMatches(
+        manifest,
+        [
+          {
+            path: '.github/actionlint.yaml',
+            repositoryCommit: commit,
+            gitObjectId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          },
+          {
+            path: '.github/ISSUE_TEMPLATE/codex-task.md',
+            repositoryCommit: commit,
+            gitObjectId: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+          },
+        ],
+        commit,
+      ),
+    ).not.toThrow()
   })
 })

--- a/services/bumba/src/atlas/reconciliation.ts
+++ b/services/bumba/src/atlas/reconciliation.ts
@@ -22,6 +22,12 @@ export type AtlasCurrentFile = {
   gitObjectId: string | null
 }
 
+export type AtlasIndexedFile = {
+  path: string
+  repositoryCommit: string | null
+  gitObjectId: string | null
+}
+
 const GIT_TREE_ENTRY = /^(\d{6})\s+(\w+)\s+([0-9a-f]+)\s+(\d+|-)\t([\s\S]+)$/i
 
 export const buildAtlasReconciliationWorkflowId = (repository: string) => {
@@ -41,6 +47,12 @@ export const computeAtlasTreeHash = (files: AtlasGitFile[]) => {
     hash.update('\0')
   }
   return hash.digest('hex')
+}
+
+const compareAtlasPaths = (left: string, right: string) => {
+  if (left < right) return -1
+  if (left > right) return 1
+  return 0
 }
 
 export const parseAtlasGitTree = (
@@ -68,12 +80,37 @@ export const parseAtlasGitTree = (
     files.push(file)
   }
 
-  files.sort((left, right) => left.path.localeCompare(right.path))
+  files.sort((left, right) => compareAtlasPaths(left.path, right.path))
   return {
     eligibilityVersion: ATLAS_ELIGIBILITY_VERSION,
     files,
     skipped,
     treeHash: computeAtlasTreeHash(files),
+  }
+}
+
+export const assertAtlasManifestMatches = (
+  manifest: Pick<AtlasGitManifest, 'files'>,
+  indexedFiles: AtlasIndexedFile[],
+  commit: string,
+) => {
+  if (indexedFiles.length !== manifest.files.length) {
+    throw new Error(`Atlas file count mismatch: expected ${manifest.files.length}, indexed ${indexedFiles.length}`)
+  }
+
+  const indexedByPath = new Map(indexedFiles.map((file) => [file.path, file]))
+  if (indexedByPath.size !== indexedFiles.length) {
+    throw new Error('Atlas indexed file paths are not unique')
+  }
+
+  for (const expected of manifest.files) {
+    const actual = indexedByPath.get(expected.path)
+    if (!actual || actual.gitObjectId !== expected.objectId) {
+      throw new Error(`Atlas manifest mismatch at ${expected.path}`)
+    }
+    if (actual.repositoryCommit !== commit) {
+      throw new Error(`Atlas commit mismatch for ${actual.path}`)
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- validate the finalized Atlas manifest by path instead of assuming PostgreSQL and JavaScript return identical collation order
- use deterministic bytewise ordering for the Git manifest and tree hash
- cover the production mixed-case .github path failure in unit and PostgreSQL integration tests

## Related Issues

None

## Testing

- PATH=/Users/gregkonush/.bun/bin:/opt/homebrew/bin:/usr/bin:/bin bun run --filter @proompteng/bumba lint
- PATH=/Users/gregkonush/.bun/bin:/opt/homebrew/bin:/usr/bin:/bin bun run --filter @proompteng/bumba lint:oxlint
- PATH=/Users/gregkonush/.bun/bin:/opt/homebrew/bin:/usr/bin:/bin bun run --filter @proompteng/bumba tsc
- bun test services/bumba/src/atlas/reconciliation.test.ts services/bumba/src/activities/index.test.ts services/bumba/src/workflows/index.test.ts
- ATLAS_REQUIRE_INTEGRATION_TESTS=1 ATLAS_INTEGRATION_DATABASE_URL=<isolated PostgreSQL database> bun test services/bumba/src/atlas/reconciliation.integration.test.ts

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] No documentation or release-note update is required for this regression fix.