### PR TITLE
build(bumba): refresh Nix dependency hashes

### DIFF
--- a/nix/images/bumba.nix
+++ b/nix/images/bumba.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "bumba";
   packageName = "@proompteng/bumba";
   depsHash = {
-    x86_64-linux = "sha256-1/wV3iFBqYwcQ0PeRvjIQ18nzTXUr0qSSNtBoAOp4B0=";
-    aarch64-linux = "sha256-yTCJnzAHvsV9P++1xQbem0AOeTlAyeDT3Oke+hBl+O8=";
+    x86_64-linux = "sha256-UahTkwRO669+IQpk7gyKK/8Fy7YAbHshT1BbcQ1O8R4=";
+    aarch64-linux = "sha256-eidimz6P4IdohNW/uIQu5AXDQqnxq+piV0C/rS4UiCk=";
   };
   installFilters = [
     "@proompteng/bumba"


### PR DESCRIPTION
## Summary

- update the Bumba fixed-output dependency hashes for the merged Atlas manifest fix
- use the exact amd64 and arm64 hashes reported by the failed main-branch Nix derivations
- restore the normal multi-architecture Bumba image release path

## Related Issues

None

## Testing

- git diff --check
- amd64 expected hash captured from https://github.com/proompteng/lab/actions/runs/29386347394/job/87260345722
- arm64 expected hash captured from https://github.com/proompteng/lab/actions/runs/29386347394/job/87260345713

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] No documentation or release-note update is required for generated dependency hashes.