### PR TITLE
chore(bumba): promote nix image sha-6c36a4d3d224f0b52f81b7fe2db69e191d566cf9

### DIFF
--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -73,7 +73,7 @@ spec:
             - name: TEMPORAL_TASK_QUEUE
               value: bumba
             - name: TEMPORAL_WORKER_BUILD_ID
-              value: bumba@8de0fb5c87a4130247d70a0941eea29b91c0eb9f
+              value: bumba@6c36a4d3d224f0b52f81b7fe2db69e191d566cf9
             - name: TEMPORAL_WORKFLOW_CONCURRENCY
               value: "12"
             - name: TEMPORAL_ACTIVITY_CONCURRENCY

--- a/argocd/applications/bumba/kustomization.yaml
+++ b/argocd/applications/bumba/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
   - deployment.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/bumba
-    digest: sha256:2543efd2a9dc9b41dac6bcf51e347dd74b134e88aececed69bb568b1f5469306
+    digest: sha256:0b1394adb244f27b5a2256308a3b1081705c5da8c700b9900440e39810345961
     newName: registry.ide-newton.ts.net/lab/bumba


### PR DESCRIPTION
## Summary

- Promote `bumba` to `registry.ide-newton.ts.net/lab/bumba@sha256:0b1394adb244f27b5a2256308a3b1081705c5da8c700b9900440e39810345961`.
- Source commit: `6c36a4d3d224f0b52f81b7fe2db69e191d566cf9`.
- Built by the shared Nix OCI workflow without Docker Buildx.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/bumba@sha256:0b1394adb244f27b5a2256308a3b1081705c5da8c700b9900440e39810345961" linux/amd64 linux/arm64`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.