### PR TITLE
chore(jangar): promote image sha-b715d5d588c05373a99d88a62675eb103d822d14

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/part-of: lab
   annotations:
     argocd.argoproj.io/sync-wave: "0"
-    deploy.knative.dev/rollout: 2026-07-14T22:21:36Z
+    deploy.knative.dev/rollout: 2026-07-15T03:35:45Z
 spec:
   replicas: 1
   strategy:
@@ -58,9 +58,9 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 8de0fb5c87a4130247d70a0941eea29b91c0eb9f
+              value: b715d5d588c05373a99d88a62675eb103d822d14
             - name: JANGAR_GITOPS_REVISION
-              value: 8de0fb5c87a4130247d70a0941eea29b91c0eb9f
+              value: b715d5d588c05373a99d88a62675eb103d822d14
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -358,15 +358,15 @@ spec:
             - name: ATLAS_CODE_SEARCH_STATEMENT_TIMEOUT_MS
               value: "750"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "29371945784"
+              value: "29386347399"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:ec7de792d8e3323f3c8f4f07275d7b5582cbfadb90e4f9efcc9d5c39ae7441be
+              value: sha256:eb161f458ab522f10b06bc0964ee3a90e4d343a73acfdf504cb6e188f20876f1
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: 8de0fb5c87a4130247d70a0941eea29b91c0eb9f
+              value: b715d5d588c05373a99d88a62675eb103d822d14
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:ec7de792d8e3323f3c8f4f07275d7b5582cbfadb90e4f9efcc9d5c39ae7441be
+              value: sha256:eb161f458ab522f10b06bc0964ee3a90e4d343a73acfdf504cb6e188f20876f1
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -37,5 +37,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: sha-8de0fb5c87a4130247d70a0941eea29b91c0eb9f
-    digest: sha256:ec7de792d8e3323f3c8f4f07275d7b5582cbfadb90e4f9efcc9d5c39ae7441be
+    newTag: sha-b715d5d588c05373a99d88a62675eb103d822d14
+    digest: sha256:eb161f458ab522f10b06bc0964ee3a90e4d343a73acfdf504cb6e188f20876f1


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `b715d5d588c05373a99d88a62675eb103d822d14`
- Image tag: `sha-b715d5d588c05373a99d88a62675eb103d822d14`
- Image digest: `sha256:eb161f458ab522f10b06bc0964ee3a90e4d343a73acfdf504cb6e188f20876f1`
- Source CI run: `29386347399`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates