### PR TITLE
fix(jangar): use indexed Atlas exact candidates

### DIFF
--- a/services/jangar/src/server/__tests__/atlas-store.test.ts
+++ b/services/jangar/src/server/__tests__/atlas-store.test.ts
@@ -458,6 +458,22 @@ describe('atlas store', () => {
     expect(calls.some((call) => call.sql.toLowerCase().includes("set_config('statement_timeout'"))).toBe(true)
   })
 
+  it('isolates exact-match candidates without whole-content similarity scans', async () => {
+    const { db, calls } = makeFakeDb({ selectRows: [] })
+    const store = createPostgresAtlasStore({
+      url: 'postgresql://user:pass@localhost:5432/db',
+      createDb: () => db,
+    })
+
+    await store.codeSearch({ query: 'createAtlasCodeSearchHandlers', repository: 'proompteng/lab', ref: 'main' })
+
+    const exactSql = calls.find((call) => call.sql.toLowerCase().includes(' as exact_rank'))
+    expect(exactSql).toBeDefined()
+    expect(exactSql?.sql.toLowerCase()).toContain('with exact_candidates as materialized')
+    expect(exactSql?.sql.toLowerCase()).toContain('file_chunks.content ilike')
+    expect(exactSql?.sql.toLowerCase()).not.toMatch(/file_chunks\.content\s+%\s+\$/)
+  })
+
   it('reports complete reconciliation metadata without sampling rows', async () => {
     const { db, calls } = makeFakeDb({
       repositoryRows: [

--- a/services/jangar/src/server/atlas-code-search.ts
+++ b/services/jangar/src/server/atlas-code-search.ts
@@ -488,6 +488,21 @@ export const createAtlasCodeSearchHandlers = ({
       await sql`SELECT set_config('statement_timeout', ${`${statementTimeoutMs}ms`}, true);`.execute(trx)
 
       const exactResult = await sql<AtlasCodeSearchRow>`
+        WITH exact_candidates AS MATERIALIZED (
+          SELECT file_chunks.id AS chunk_id
+          FROM atlas.file_chunks AS file_chunks
+          WHERE file_chunks.content IS NOT NULL
+            AND file_chunks.content ILIKE ${containsPattern} ESCAPE '\'
+
+          UNION
+
+          SELECT file_chunks.id AS chunk_id
+          FROM atlas.file_keys AS file_keys
+          INNER JOIN atlas.file_versions AS file_versions ON file_versions.file_key_id = file_keys.id
+          INNER JOIN atlas.file_chunks AS file_chunks ON file_chunks.file_version_id = file_versions.id
+          WHERE file_keys.path ILIKE ${containsPattern} ESCAPE '\'
+             OR file_keys.path % ${resolvedQuery}::text
+        )
         SELECT
           ${sql.raw(codeSearchRawSelectColumns)},
           CASE
@@ -495,22 +510,14 @@ export const createAtlasCodeSearchHandlers = ({
             WHEN lower(file_keys.path) = lower(${resolvedQuery}) THEN 0.99
             WHEN file_chunks.content ILIKE ${containsPattern} ESCAPE '\' THEN 0.95
             WHEN file_keys.path ILIKE ${containsPattern} ESCAPE '\' THEN 0.90
-            ELSE GREATEST(
-              similarity(file_keys.path, ${resolvedQuery}::text),
-              similarity(file_chunks.content, ${resolvedQuery}::text)
-            )
+            ELSE similarity(file_keys.path, ${resolvedQuery}::text)
           END AS exact_rank
-        FROM atlas.file_chunks AS file_chunks
+        FROM exact_candidates
+        INNER JOIN atlas.file_chunks AS file_chunks ON file_chunks.id = exact_candidates.chunk_id
         INNER JOIN atlas.file_versions AS file_versions ON file_versions.id = file_chunks.file_version_id
         INNER JOIN atlas.file_keys AS file_keys ON file_keys.id = file_versions.file_key_id
         INNER JOIN atlas.repositories AS repositories ON repositories.id = file_keys.repository_id
         ${whereClause}
-          AND (
-            file_keys.path ILIKE ${containsPattern} ESCAPE '\'
-            OR file_chunks.content ILIKE ${containsPattern} ESCAPE '\'
-            OR file_keys.path % ${resolvedQuery}::text
-            OR file_chunks.content % ${resolvedQuery}::text
-          )
         ORDER BY exact_rank DESC, file_keys.path, file_chunks.chunk_index
         LIMIT ${candidateLimit};
       `.execute(trx)


### PR DESCRIPTION
## Summary

- split Atlas exact retrieval into indexed content and path candidate scans
- remove whole-content trigram similarity, which forced a corpus scan before lexical and ANN retrieval
- add a regression assertion for the indexable exact-search SQL contract

## Related Issues

None

## Testing

- `bun test services/jangar/src/server/__tests__/atlas-store.test.ts` (14 passed)
- real PostgreSQL: `ATLAS_REQUIRE_INTEGRATION_TESTS=1 bun test services/jangar/src/server/__tests__/atlas-code-search.integration.test.ts` (4 passed)
- `bun run --filter @proompteng/jangar tsc`
- `bun run --filter @proompteng/jangar lint:oxlint` (0 errors)
- `bunx oxfmt --check services/jangar/src/server/atlas-code-search.ts services/jangar/src/server/__tests__/atlas-store.test.ts`
- live current corpus `EXPLAIN (ANALYZE, BUFFERS)`: exact identifier retrieval reduced from 6359 ms to 7 ms

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
