### PR TITLE
chore(torghut): promote image sha-b623a45511f912a51bdfdc6408224dda62091c0c

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -54,7 +54,7 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: 7bdbf1ac3c9169feaaf5f86f34deb19f4d2926a3
+              value: b623a45511f912a51bdfdc6408224dda62091c0c
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:8d4085c525439bad98f3f248addb3cbb956beeaca5e23ecd0b8ef50a71b262b3
             - name: PYTHONPATH

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -46,7 +46,7 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: 7bdbf1ac3c9169feaaf5f86f34deb19f4d2926a3
+              value: b623a45511f912a51bdfdc6408224dda62091c0c
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:8d4085c525439bad98f3f248addb3cbb956beeaca5e23ecd0b8ef50a71b262b3
             - name: DB_DSN

--- a/argocd/applications/torghut-options/archive/deployment.yaml
+++ b/argocd/applications/torghut-options/archive/deployment.yaml
@@ -101,9 +101,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1948-g7bdbf1ac3
+              value: v0.596.0-1958-gb623a4551
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 7bdbf1ac3c9169feaaf5f86f34deb19f4d2926a3
+              value: b623a45511f912a51bdfdc6408224dda62091c0c
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -110,9 +110,9 @@ spec:
                   name: torghut-ws-config
                   key: SYMBOLS_ALLOWLIST
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1948-g7bdbf1ac3
+              value: v0.596.0-1958-gb623a4551
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 7bdbf1ac3c9169feaaf5f86f34deb19f4d2926a3
+              value: b623a45511f912a51bdfdc6408224dda62091c0c
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -106,9 +106,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1948-g7bdbf1ac3
+              value: v0.596.0-1958-gb623a4551
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 7bdbf1ac3c9169feaaf5f86f34deb19f4d2926a3
+              value: b623a45511f912a51bdfdc6408224dda62091c0c
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-15T01:53:47Z"
+        client.knative.dev/updateTimestamp: "2026-07-15T04:45:46Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -507,9 +507,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1948-g7bdbf1ac3
+              value: v0.596.0-1958-gb623a4551
             - name: TORGHUT_COMMIT
-              value: 7bdbf1ac3c9169feaaf5f86f34deb19f4d2926a3
+              value: b623a45511f912a51bdfdc6408224dda62091c0c
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:8d4085c525439bad98f3f248addb3cbb956beeaca5e23ecd0b8ef50a71b262b3
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-15T01:53:47Z"
+        client.knative.dev/updateTimestamp: "2026-07-15T04:45:46Z"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
     spec:
@@ -442,9 +442,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1948-g7bdbf1ac3
+              value: v0.596.0-1958-gb623a4551
             - name: TORGHUT_COMMIT
-              value: 7bdbf1ac3c9169feaaf5f86f34deb19f4d2926a3
+              value: b623a45511f912a51bdfdc6408224dda62091c0c
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:8d4085c525439bad98f3f248addb3cbb956beeaca5e23ecd0b8ef50a71b262b3
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -458,9 +458,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1948-g7bdbf1ac3
+              value: v0.596.0-1958-gb623a4551
             - name: TORGHUT_COMMIT
-              value: 7bdbf1ac3c9169feaaf5f86f34deb19f4d2926a3
+              value: b623a45511f912a51bdfdc6408224dda62091c0c
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:8d4085c525439bad98f3f248addb3cbb956beeaca5e23ecd0b8ef50a71b262b3
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `b623a45511f912a51bdfdc6408224dda62091c0c`
- Image tag: `sha-b623a45511f912a51bdfdc6408224dda62091c0c`
- Image digest: `sha256:8d4085c525439bad98f3f248addb3cbb956beeaca5e23ecd0b8ef50a71b262b3`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher