### PR TITLE
fix(atlas): bound ANN search and rank definitions

### DIFF
--- a/services/jangar/src/server/__tests__/atlas-code-search.integration.test.ts
+++ b/services/jangar/src/server/__tests__/atlas-code-search.integration.test.ts
@@ -313,14 +313,14 @@ integration('Atlas code search PostgreSQL integration', () => {
           CASE
             WHEN file_keys.path LIKE '%atlas-code-search.ts'
               THEN 'export const createAtlasCodeSearchHandlers = () => full HNSW code search'
-            ELSE 'export const shouldSkipAtlasPath = path => versioned Git file eligibility'
+            ELSE '// createAtlasCodeSearchHandlers is referenced here\nexport const shouldSkipAtlasPath = path => versioned Git file eligibility'
           END,
           to_tsvector(
             'simple',
             CASE
               WHEN file_keys.path LIKE '%atlas-code-search.ts'
                 THEN 'export const createAtlasCodeSearchHandlers = () => full HNSW code search'
-              ELSE 'export const shouldSkipAtlasPath = path => versioned Git file eligibility'
+              ELSE '// createAtlasCodeSearchHandlers is referenced here\nexport const shouldSkipAtlasPath = path => versioned Git file eligibility'
             END
           ),
           10,

--- a/services/jangar/src/server/__tests__/atlas-store.test.ts
+++ b/services/jangar/src/server/__tests__/atlas-store.test.ts
@@ -455,7 +455,10 @@ describe('atlas store', () => {
     expect(semanticSql).toBeDefined()
     expect(semanticSql?.sql.toLowerCase()).not.toContain('candidate_chunks')
     expect(semanticSql?.sql.toLowerCase()).toContain('order by chunk_embeddings.embedding <=> $')
+    expect(semanticSql?.params.at(-1)).toBe(20)
     expect(calls.some((call) => call.sql.toLowerCase().includes("set_config('statement_timeout'"))).toBe(true)
+    const hnswBudgetSql = calls.find((call) => call.sql.toLowerCase().includes("set_config('hnsw.ef_search'"))
+    expect(hnswBudgetSql?.params).toContain('20')
   })
 
   it('isolates exact-match candidates without whole-content similarity scans', async () => {
@@ -471,7 +474,27 @@ describe('atlas store', () => {
     expect(exactSql).toBeDefined()
     expect(exactSql?.sql.toLowerCase()).toContain('with exact_candidates as materialized')
     expect(exactSql?.sql.toLowerCase()).toContain('file_chunks.content ilike')
+    expect(exactSql?.sql.toLowerCase()).toContain('file_chunks.content ~ $')
     expect(exactSql?.sql.toLowerCase()).not.toMatch(/file_chunks\.content\s+%\s+\$/)
+  })
+
+  it('relaxes natural-language lexical queries by one content term', async () => {
+    const { db, calls } = makeFakeDb({ selectRows: [] })
+    const store = createPostgresAtlasStore({
+      url: 'postgresql://user:pass@localhost:5432/db',
+      createDb: () => db,
+    })
+
+    await store.codeSearch({
+      query: 'source preview verifies the indexed commit and content hash',
+      repository: 'proompteng/lab',
+      ref: 'main',
+    })
+
+    const lexicalSql = calls.find((call) => call.sql.toLowerCase().includes(' as lexical_rank'))
+    expect(lexicalSql?.params).toContain(
+      'preview verifies indexed commit content hash OR source verifies indexed commit content hash OR source preview indexed commit content hash OR source preview verifies commit content hash OR source preview verifies indexed content hash OR source preview verifies indexed commit hash OR source preview verifies indexed commit content',
+    )
   })
 
   it('reports complete reconciliation metadata without sampling rows', async () => {

--- a/services/jangar/src/server/atlas-code-search.ts
+++ b/services/jangar/src/server/atlas-code-search.ts
@@ -116,12 +116,37 @@ type CreateAtlasCodeSearchHandlersOptions = {
 
 const DEFAULT_SEARCH_LIMIT = 10
 const MAX_SEARCH_LIMIT = 200
+const MIN_SEMANTIC_CANDIDATES = 20
+const SEMANTIC_CANDIDATE_MULTIPLIER = 2
 const DEFAULT_CODE_SEARCH_SEMANTIC_TIMEOUT_MS = 12_000
 const DEFAULT_CODE_SEARCH_STATEMENT_TIMEOUT_MS = 750
 const MAX_CODE_SEARCH_STATEMENT_TIMEOUT_MS = 900
 const DEFAULT_CODE_SEARCH_QUERY_EMBEDDING_CACHE_TTL_MS = 60_000
 const RRF_K = 60
 const ATLAS_QUERY_INSTRUCTION = 'Given a query, retrieve relevant source-code chunks from the repository'
+const LEXICAL_STOP_WORDS = new Set([
+  'a',
+  'an',
+  'and',
+  'are',
+  'as',
+  'at',
+  'be',
+  'by',
+  'for',
+  'from',
+  'how',
+  'in',
+  'is',
+  'it',
+  'of',
+  'on',
+  'or',
+  'the',
+  'to',
+  'which',
+  'with',
+])
 
 const vectorToPgArray = (values: number[]) => `[${values.join(',')}]`
 
@@ -186,6 +211,24 @@ const parsePositiveIntEnv = (name: string, fallback: number, max = Number.MAX_SA
 const buildAtlasQueryInstruction = (query: string) => `Instruct: ${ATLAS_QUERY_INSTRUCTION}\nQuery: ${query}`
 
 const escapeLikePattern = (value: string) => value.replace(/[\\%_]/g, (match) => `\\${match}`)
+
+const buildDefinitionPattern = (query: string) => {
+  if (!/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(query)) return null
+  const escaped = query.replace(/\$/g, '\\$')
+  return `(^|\\n)[[:space:]]*(export[[:space:]]+)?(default[[:space:]]+)?(async[[:space:]]+)?(const|let|var|function|class|interface|type|enum)[[:space:]]+${escaped}([^A-Za-z0-9_$]|$)`
+}
+
+const buildLexicalQuery = (query: string) => {
+  const terms = [
+    ...new Set(
+      (query.match(/[A-Za-z0-9_$]+/g) ?? [])
+        .map((term) => term.toLowerCase())
+        .filter((term) => term.length > 2 && !LEXICAL_STOP_WORDS.has(term)),
+    ),
+  ].slice(0, 10)
+  if (terms.length < 3) return query
+  return terms.map((_, omitted) => terms.filter((__, index) => index !== omitted).join(' ')).join(' OR ')
+}
 
 const resolveCodeSearchFilters = ({
   repository,
@@ -469,10 +512,19 @@ export const createAtlasCodeSearchHandlers = ({
 
     const identifiers = extractIdentifierTokens(resolvedQuery)
     const candidateLimit = Math.min(MAX_SEARCH_LIMIT, Math.max(resolvedLimit * 5, resolvedLimit))
+    const semanticCandidateLimit = Math.min(
+      MAX_SEARCH_LIMIT,
+      Math.max(MIN_SEMANTIC_CANDIDATES, resolvedLimit * SEMANTIC_CANDIDATE_MULTIPLIER),
+    )
     const embeddingConfig = loadEmbeddingConfig()
     const embedding = await embedCodeSearchQuery(resolvedQuery, embeddingConfig)
     const vectorString = vectorToPgArray(embedding)
     const containsPattern = `%${escapeLikePattern(resolvedQuery)}%`
+    const definitionPattern = buildDefinitionPattern(resolvedQuery)
+    const definitionRankClause = definitionPattern
+      ? sql`WHEN file_chunks.content ~ ${definitionPattern} THEN 0.98`
+      : sql``
+    const lexicalQuery = buildLexicalQuery(resolvedQuery)
     const whereClause = searchWhereClause(filters)
     const semanticTimeoutMs = parsePositiveIntEnv(
       'ATLAS_CODE_SEARCH_SEMANTIC_TIMEOUT_MS',
@@ -508,8 +560,9 @@ export const createAtlasCodeSearchHandlers = ({
           CASE
             WHEN file_keys.path = ${resolvedQuery} THEN 1.0
             WHEN lower(file_keys.path) = lower(${resolvedQuery}) THEN 0.99
-            WHEN file_chunks.content ILIKE ${containsPattern} ESCAPE '\' THEN 0.95
+            ${definitionRankClause}
             WHEN file_keys.path ILIKE ${containsPattern} ESCAPE '\' THEN 0.90
+            WHEN file_chunks.content ILIKE ${containsPattern} ESCAPE '\' THEN 0.75
             ELSE similarity(file_keys.path, ${resolvedQuery}::text)
           END AS exact_rank
         FROM exact_candidates
@@ -525,16 +578,18 @@ export const createAtlasCodeSearchHandlers = ({
       const lexicalResult = await sql<AtlasCodeSearchRow>`
         SELECT
           ${sql.raw(codeSearchRawSelectColumns)},
-          ts_rank_cd(file_chunks.text_tsvector, websearch_to_tsquery('simple', ${resolvedQuery}::text)) AS lexical_rank
+          ts_rank_cd(file_chunks.text_tsvector, websearch_to_tsquery('simple', ${lexicalQuery}::text)) AS lexical_rank
         FROM atlas.file_chunks AS file_chunks
         INNER JOIN atlas.file_versions AS file_versions ON file_versions.id = file_chunks.file_version_id
         INNER JOIN atlas.file_keys AS file_keys ON file_keys.id = file_versions.file_key_id
         INNER JOIN atlas.repositories AS repositories ON repositories.id = file_keys.repository_id
         ${whereClause}
-          AND file_chunks.text_tsvector @@ websearch_to_tsquery('simple', ${resolvedQuery}::text)
+          AND file_chunks.text_tsvector @@ websearch_to_tsquery('simple', ${lexicalQuery}::text)
         ORDER BY lexical_rank DESC, file_keys.path, file_chunks.chunk_index
         LIMIT ${candidateLimit};
       `.execute(trx)
+
+      await sql`SELECT set_config('hnsw.ef_search', ${String(semanticCandidateLimit)}, true);`.execute(trx)
 
       const semanticResult = await sql<AtlasCodeSearchRow>`
         SELECT
@@ -549,7 +604,7 @@ export const createAtlasCodeSearchHandlers = ({
           AND chunk_embeddings.model = ${embeddingConfig.model}
           AND chunk_embeddings.dimension = ${embeddingConfig.dimension}
         ORDER BY chunk_embeddings.embedding <=> ${vectorString}::vector
-        LIMIT ${candidateLimit};
+        LIMIT ${semanticCandidateLimit};
       `.execute(trx)
 
       return {
@@ -580,7 +635,10 @@ export const createAtlasCodeSearchHandlers = ({
         }
         entry.score += weight / (RRF_K + index + 1)
         entry.modes.add(mode)
-        if (mode === 'exact') entry.exactRank = Number(row.exact_rank)
+        if (mode === 'exact') {
+          entry.exactRank = Number(row.exact_rank)
+          if (Number.isFinite(entry.exactRank)) entry.score += entry.exactRank
+        }
         if (mode === 'lexical') entry.lexicalRank = Number(row.lexical_rank)
         if (mode === 'semantic') entry.semanticDistance = Number(row.semantic_distance)
         merged.set(row.chunk_id, entry)


### PR DESCRIPTION
## Summary

- Bound HNSW search breadth and semantic result count to the requested result budget so cold ANN reads stay inside the existing SQL timeout.
- Rank actual identifier definitions above references and use bounded leave-one-term-out lexical matching for natural-language queries.
- Add unit and real-PostgreSQL regressions for ANN settings, definition-versus-reference ranking, and statement cancellation.

## Related Issues

None

## Testing

- `bun test services/jangar/src/server/__tests__/atlas-store.test.ts` (15 passed)
- `ATLAS_INTEGRATION_DATABASE_URL=<temporary-db> ATLAS_REQUIRE_INTEGRATION_TESTS=1 bun test --timeout 30000 services/jangar/src/server/__tests__/atlas-code-search.integration.test.ts` (4 passed)
- `bun run --filter @proompteng/jangar tsc`
- `bunx oxfmt --check services/jangar/src/server/atlas-code-search.ts services/jangar/src/server/__tests__/atlas-store.test.ts services/jangar/src/server/__tests__/atlas-code-search.integration.test.ts`
- `bunx oxlint --config .oxlintrc.json services/jangar/src/server/atlas-code-search.ts services/jangar/src/server/__tests__/atlas-store.test.ts services/jangar/src/server/__tests__/atlas-code-search.integration.test.ts`
- Local handler against the live 72,808-chunk corpus: all seven fixed gold queries passed; exact definition ranked first; observed 471-831 ms.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.