### PR TITLE
fix(jangar): make routing verification deterministic

### DIFF
--- a/.github/workflows/jangar-post-deploy-verify.yml
+++ b/.github/workflows/jangar-post-deploy-verify.yml
@@ -33,6 +33,21 @@ jobs:
         with:
           bun-version: 1.3.14
 
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.11.1
+
+      - name: Install Temporal routing dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          bun install --frozen-lockfile --ignore-scripts \
+            --filter @proompteng/source \
+            --filter @proompteng/scripts \
+            --filter @proompteng/temporal-bun-sdk
+          bun run --filter @proompteng/temporal-bun-sdk build
+
       - name: Set up kubectl
         uses: azure/setup-kubectl@v5
         with:

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -1062,6 +1062,13 @@ describe('native OCI build workflows', () => {
     expect(jangarPostDeployVerifyWorkflow).toContain('contents: read')
     expect(jangarPostDeployVerifyWorkflow).toContain('Verify deployment health and digest')
     expect(jangarPostDeployVerifyWorkflow).toContain('Sync Temporal routing after rollout')
+    expect(jangarPostDeployVerifyWorkflow).toContain('bun install --frozen-lockfile --ignore-scripts')
+    expect(jangarPostDeployVerifyWorkflow).toContain('--filter @proompteng/scripts')
+    expect(jangarPostDeployVerifyWorkflow).toContain('--filter @proompteng/temporal-bun-sdk')
+    expect(jangarPostDeployVerifyWorkflow).toContain('bun run --filter @proompteng/temporal-bun-sdk build')
+    expect(jangarPostDeployVerifyWorkflow.indexOf('Install Temporal routing dependencies')).toBeLessThan(
+      jangarPostDeployVerifyWorkflow.indexOf('Sync Temporal routing after rollout'),
+    )
     expect(jangarPostDeployVerifyWorkflow).not.toContain('contents: write')
     expect(jangarPostDeployVerifyWorkflow).not.toContain('pull-requests: write')
     expect(jangarPostDeployVerifyWorkflow).not.toContain('Prepare rollback manifests')


### PR DESCRIPTION
## Summary

- Install the filtered monorepo dependencies before the Jangar post-deploy routing sync.
- Build the checked-out Temporal Bun SDK so the verifier cannot resolve a stale runner-cached package surface.
- Add a workflow contract regression assertion that dependency setup precedes Temporal routing synchronization.

## Related Issues

None.

## Testing

- `/nix/var/nix/profiles/default/bin/nix develop -c bun install --frozen-lockfile --ignore-scripts --filter @proompteng/source --filter @proompteng/scripts --filter @proompteng/temporal-bun-sdk`
- `/nix/var/nix/profiles/default/bin/nix develop -c bun run --filter @proompteng/temporal-bun-sdk build`
- `/nix/var/nix/profiles/default/bin/nix develop -c bun run packages/scripts/src/jangar/sync-temporal-routing.ts --help`
- `/nix/var/nix/profiles/default/bin/nix develop -c bun test packages/scripts/src/jangar/__tests__/sync-temporal-routing.test.ts packages/scripts/src/shared/__tests__/oci.test.ts` (55 tests, 1,313 assertions)
- `/nix/var/nix/profiles/default/bin/nix develop -c bunx oxfmt --check .github/workflows/jangar-post-deploy-verify.yml packages/scripts/src/shared/__tests__/oci.test.ts`
- `/nix/var/nix/profiles/default/bin/nix develop -c bunx oxlint --config .oxlintrc.json packages/scripts/src/shared/__tests__/oci.test.ts`
- `git diff --check`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] The workflow contract test documents the required dependency boundary; no release notes or follow-up issue is required.
