### PR TITLE
fix(agents): bump chart version for Codex config

### DIFF
--- a/charts/agents/Chart.yaml
+++ b/charts/agents/Chart.yaml
@@ -6,7 +6,7 @@ sources:
   - https://github.com/proompteng/charts/tree/main/charts/agents
 type: application
 kubeVersion: '>=1.25.0-0'
-version: 0.9.27
+version: 0.9.28
 appVersion: '0.9.0'
 icon: https://avatars.githubusercontent.com/u/234536857
 keywords:

--- a/charts/agents/artifacthub-pkg.yml
+++ b/charts/agents/artifacthub-pkg.yml
@@ -1,4 +1,4 @@
-version: 0.9.27
+version: 0.9.28
 name: agents
 displayName: Agents Control Plane
 description: Minimal Agents control plane with CRDs and native workflow runtime.


### PR DESCRIPTION
## Summary

- Bump the Agents Helm chart from `0.9.27` to `0.9.28` after PR #12526 changed a published chart example.
- Keep `Chart.yaml` and Artifact Hub package metadata on the same release version.
- Unblock `agents-sync`, which correctly rejected different chart contents under the already-published `0.9.27` version.

## Related Issues

Follow-up to #12526 and failed [agents-sync run 29391036492](https://github.com/proompteng/lab/actions/runs/29391036492).

## Testing

- `nix develop --command helm lint charts/agents` (1 chart linted, 0 failed)
- `nix develop --command helm package charts/agents --destination <temp-dir>` (produced `agents-0.9.28.tgz`)
- Parsed `Chart.yaml` and `artifacthub-pkg.yml` and asserted both versions equal `0.9.28`
- `git diff --check`

## Rollout / Impact

The main-branch `agents-sync` workflow will split and publish chart `0.9.28` through the existing GitHub Actions path. No cluster resource was applied directly.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (screenshots not applicable; Breaking Changes filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked (release metadata updated in both chart surfaces).