### PR TITLE
chore(sag): promote image sha-2b4b9a368e5821c77ae960b8df65b95685e81d25

### DIFF
--- a/argocd/sag/kustomization.yaml
+++ b/argocd/sag/kustomization.yaml
@@ -12,4 +12,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/sag
     newName: registry.ide-newton.ts.net/lab/sag
-    digest: sha256:d6accf1ff4f7eecb4f97b772dd0bcb5cd303030c007ed5bfda2b7bd123808b9d
+    digest: sha256:da99a22b2eca5ca1264abfbf048204659768ac53d8987033880d92c5b0b75ab9


### PR DESCRIPTION
## Summary
Promote the Sag image into GitOps manifests.

- Source commit: `2b4b9a368e5821c77ae960b8df65b95685e81d25`
- Image tag: `sha-2b4b9a368e5821c77ae960b8df65b95685e81d25`
- Image digest: `sha256:da99a22b2eca5ca1264abfbf048204659768ac53d8987033880d92c5b0b75ab9`