### PR TITLE
fix(atlas): classify standalone path queries

### DIFF
--- a/services/jangar/src/server/__tests__/atlas-store.test.ts
+++ b/services/jangar/src/server/__tests__/atlas-store.test.ts
@@ -515,6 +515,24 @@ describe('atlas store', () => {
     expect(calls.some((call) => call.sql.toLowerCase().includes('from atlas.chunk_embeddings'))).toBe(false)
   })
 
+  it('keeps content and semantic retrieval for natural-language queries containing a path', async () => {
+    const { db, calls } = makeFakeDb({ selectRows: [] })
+    const store = createPostgresAtlasStore({
+      url: 'postgresql://user:pass@localhost:5432/db',
+      createDb: () => db,
+    })
+
+    await store.codeSearch({
+      query: 'where is services/deleted/old-atlas.ts implemented',
+      repository: 'proompteng/lab',
+      ref: 'main',
+    })
+
+    const exactSql = calls.find((call) => call.sql.toLowerCase().includes(' as exact_rank'))
+    expect(exactSql?.sql).toMatch(/FROM atlas\.file_chunks AS file_chunks\s+WHERE file_chunks\.content IS NOT NULL/)
+    expect(calls.some((call) => call.sql.toLowerCase().includes('from atlas.chunk_embeddings'))).toBe(true)
+  })
+
   it('reports complete reconciliation metadata without sampling rows', async () => {
     const { db, calls } = makeFakeDb({
       repositoryRows: [

--- a/services/jangar/src/server/atlas-code-search.ts
+++ b/services/jangar/src/server/atlas-code-search.ts
@@ -212,6 +212,9 @@ const buildAtlasQueryInstruction = (query: string) => `Instruct: ${ATLAS_QUERY_I
 
 const escapeLikePattern = (value: string) => value.replace(/[\\%_]/g, (match) => `\\${match}`)
 
+const isStandalonePathQuery = (query: string) =>
+  /^(?:\.{0,2}\/|\/)?[A-Za-z0-9_@+~%#=.,()[\]{}$-]+(?:\/[A-Za-z0-9_@+~%#=.,()[\]{}$-]+)+\/?$/.test(query)
+
 const buildDefinitionPattern = (query: string) => {
   if (!/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(query)) return null
   const escaped = query.replace(/\$/g, '\\$')
@@ -510,7 +513,7 @@ export const createAtlasCodeSearchHandlers = ({
     const health = await codeSearchHealth({ repository, ref, pathPrefix, language })
     if (health.status !== 'ok') throw new Error(`Atlas code search is not ready: ${health.message}`)
 
-    const isPathQuery = resolvedQuery.includes('/')
+    const isPathQuery = isStandalonePathQuery(resolvedQuery)
     const identifiers = extractIdentifierTokens(resolvedQuery)
     const candidateLimit = Math.min(MAX_SEARCH_LIMIT, Math.max(resolvedLimit * 5, resolvedLimit))
     const semanticCandidateLimit = Math.min(


### PR DESCRIPTION
## Summary

- restrict the Atlas path fast path to standalone repository-style paths
- retain content and semantic retrieval for natural-language queries that mention a path
- add regression coverage for both standalone and mixed path queries

## Related Issues

- Follow-up to the actionable Codex finding on #12528: https://github.com/proompteng/lab/pull/12528#discussion_r3584664508

## Testing

- `bunx vitest run --config vitest.config.ts src/server/__tests__/atlas-store.test.ts` (17 passed)
- `bun run tsc`
- `bunx oxfmt --check src/server/atlas-code-search.ts src/server/__tests__/atlas-store.test.ts`
- `bunx oxlint --config ../../.oxlintrc.json src/server/atlas-code-search.ts src/server/__tests__/atlas-store.test.ts`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.