### PR TITLE
fix(jangar): cut over bloated quant series writes

### DIFF
--- a/docs/torghut/jangar-quant-write-pressure-remediation.md
+++ b/docs/torghut/jangar-quant-write-pressure-remediation.md
@@ -36,6 +36,46 @@ change. That is the rollout baseline for the primary and asynchronous replica RB
 Every pipeline-health reader selects only the newest row for a strategy, account, window, and stage. Retaining every
 historical heartbeat in PostgreSQL therefore adds no runtime capability.
 
+## Post-rollout physical-I/O finding
+
+The first rollout reduced a clean 30-second Jangar WAL sample to **0.181 MiB/s**, below the 0.3015 MiB/s gate. That
+average did not make the shared storage path stable. Kafka controller 2 still produced two-to-seven-second controller
+events while controllers 0 and 1 timed out Raft fetches.
+
+Live PostgreSQL and RBD evidence isolated the remaining Jangar cost:
+
+- `quant_metrics_series` contains about 7.47 million live rows whose recent and oldest samples average only 188-192
+  bytes each, but the relation occupies 146 GiB;
+- the heap is 78 GiB and its indexes are 68 GiB: 48 GiB for the lookup index, 16 GiB for the random-UUID primary key,
+  and 3.8 GiB for the global `as_of` index;
+- active series inserts wait on PostgreSQL `DataFileRead`, proving that index pages are no longer a cache-resident hot
+  write set; and
+- during a fresh RBD sample, the Jangar replica issued 110 small writes/s at 229 ms average latency and the primary
+  issued 67 writes/s at 252 ms. An unrelated registry image write had the most bandwidth in that sample, so it is not a
+  clean baseline, but Jangar remained the largest small-write IOPS source.
+
+The old five-second sampling regime created and later removed far more index entries than the current live row count.
+Ordinary vacuum can make dead space reusable but cannot shrink those B-trees. Reindexing or `VACUUM FULL` would scan or
+rewrite the live 146 GiB relation on the already contended pool, so neither is an acceptable incident-time operation.
+
+### No-copy active-series cutover
+
+The next migration therefore performs only metadata and empty-table work:
+
+1. Rename the existing table to `quant_metrics_series_legacy`; its rows and indexes remain untouched.
+2. Create a logged `quant_metrics_series_active` table hash-partitioned 16 ways by `strategy_id`. Queries always provide
+   a strategy ID, so partition pruning keeps the active lookup index set bounded without a calendar-partition time bomb.
+3. Give the active table only the required strategy/account/window/metric/time lookup index plus a compact BRIN time
+   index. Do not recreate the unused random-UUID primary-key or global time B-tree write costs.
+4. Recreate `quant_metrics_series` as a `UNION ALL` compatibility view over legacy and active history.
+5. Route inserts on that view to the active table with an `INSTEAD OF INSERT` trigger. Both the new image and the prior
+   image keep the same read/write contract, so an image rollback does not lose access to either side of the cutover.
+
+The forward migration does not select from, copy, reindex, vacuum, truncate, or delete the legacy relation. Its reverse
+path first merges active rows back by UUID before restoring the original table name, preserving data if an explicit
+database rollback is required. A five-second local lock timeout makes the metadata cutover fail closed instead of
+waiting behind a long analytical query.
+
 ## Implementation
 
 ### Latest metrics

--- a/services/jangar/src/server/__tests__/kysely-migrations.test.ts
+++ b/services/jangar/src/server/__tests__/kysely-migrations.test.ts
@@ -99,6 +99,21 @@ describe('migration registration', () => {
     expect(normalized).not.toContain('quant_pipeline_health;')
   })
 
+  it('keeps the no-copy quant-series active-store migration rollback-compatible', () => {
+    const migrationPath = new URL('../migrations/20260715_torghut_quant_series_active.ts', import.meta.url)
+    const normalized = readFileSync(fileURLToPath(migrationPath), 'utf8').toLowerCase().replace(/\s+/g, ' ')
+
+    expect(normalized).toContain('partition_count = 16')
+    expect(normalized).toContain('partition by hash (strategy_id)')
+    expect(normalized).toContain('using brin (as_of)')
+    expect(normalized).toContain('create view torghut_control_plane.quant_metrics_series as')
+    expect(normalized).toContain('instead of insert on torghut_control_plane.quant_metrics_series')
+    expect(normalized).toContain('on conflict (id) do nothing')
+    expect(normalized).not.toContain('vacuum full')
+    expect(normalized).not.toContain('reindex')
+    expect(normalized).not.toContain('unlogged')
+  })
+
   it('keeps the Codex judge AgentRun column migration registered as a retired Agents backfill handoff', () => {
     expect(__test__.getRegisteredMigrations()).toContain('20260520_codex_judge_agentrun_columns')
     expect(__test__.getRetiredMigrationNames()).toContain('20260520_codex_judge_agentrun_columns')

--- a/services/jangar/src/server/__tests__/torghut-quant-metrics-store.test.ts
+++ b/services/jangar/src/server/__tests__/torghut-quant-metrics-store.test.ts
@@ -122,6 +122,35 @@ describe('torghut quant metrics store', () => {
     expect(normalized.join(' ')).not.toContain('torghut_control_plane.quant_pipeline_health ')
   })
 
+  it('cuts series writes over to an empty partitioned store without copying legacy history', async () => {
+    const { db, calls } = makeFakeDb()
+    const { up } = await import('../migrations/20260715_torghut_quant_series_active')
+
+    await up(db)
+
+    expect(calls).toHaveLength(24)
+    const normalized = calls.map((call) => call.sql.toLowerCase().replace(/\s+/g, ' '))
+    expect(normalized[0]).toContain("set local lock_timeout = '5s'")
+    expect(normalized[1]).toContain(
+      'alter table torghut_control_plane.quant_metrics_series rename to quant_metrics_series_legacy',
+    )
+    expect(normalized[2]).toContain('create table "torghut_control_plane"."quant_metrics_series_active"')
+    expect(normalized[2]).toContain('partition by hash (strategy_id)')
+
+    const partitions = normalized.filter((statement) => statement.includes('partition of'))
+    expect(partitions).toHaveLength(16)
+    expect(partitions[0]).toContain('modulus 16, remainder 0')
+    expect(partitions[15]).toContain('modulus 16, remainder 15')
+
+    expect(normalized.join(' ')).toContain('torghut_qm_series_active_lookup_idx')
+    expect(normalized.join(' ')).toContain('torghut_qm_series_active_as_of_brin')
+    expect(normalized.join(' ')).toContain('create view torghut_control_plane.quant_metrics_series as')
+    expect(normalized.join(' ')).toContain('union all')
+    expect(normalized.join(' ')).toContain('instead of insert on torghut_control_plane.quant_metrics_series')
+    expect(normalized.join(' ')).not.toContain('insert into torghut_control_plane.quant_metrics_series_legacy select')
+    expect(normalized.join(' ')).not.toContain('create table as select')
+  })
+
   it('avoids physical latest-metric updates when every material value is unchanged', async () => {
     const { db, calls } = makeFakeDb()
     dbMocks.getDb.mockReturnValue(db)

--- a/services/jangar/src/server/kysely-migrations.ts
+++ b/services/jangar/src/server/kysely-migrations.ts
@@ -22,6 +22,7 @@ import * as torghutQuantPipelineHealthAccountWindowCreatedAtIndexMigration from 
 import * as atlasCodeSearchPerformanceIndexesMigration from '~/server/migrations/20260531_atlas_code_search_performance_indexes'
 import * as atlasCurrentCorpusMigration from '~/server/migrations/20260714_atlas_current_corpus'
 import * as torghutQuantPipelineHealthLatestMigration from '~/server/migrations/20260715_torghut_quant_pipeline_health_latest'
+import * as torghutQuantSeriesActiveMigration from '~/server/migrations/20260715_torghut_quant_series_active'
 
 type MigrationMap = Record<string, Migration>
 
@@ -58,6 +59,7 @@ const migrations: MigrationMap = {
   '20260531_atlas_code_search_performance_indexes': atlasCodeSearchPerformanceIndexesMigration,
   '20260714_atlas_current_corpus': atlasCurrentCorpusMigration,
   '20260715_torghut_quant_pipeline_health_latest': torghutQuantPipelineHealthLatestMigration,
+  '20260715_torghut_quant_series_active': torghutQuantSeriesActiveMigration,
 }
 
 export const getRegisteredMigrationNames = () => Object.keys(migrations).sort()

--- a/services/jangar/src/server/migrations/20260715_torghut_quant_series_active.ts
+++ b/services/jangar/src/server/migrations/20260715_torghut_quant_series_active.ts
@@ -1,0 +1,158 @@
+import { type Kysely, sql } from 'kysely'
+
+import type { Database } from '../db'
+
+const ACTIVE_TABLE = 'torghut_control_plane.quant_metrics_series_active'
+const PARTITION_COUNT = 16
+
+const SERIES_COLUMNS = `
+  id,
+  strategy_id,
+  account,
+  "window",
+  metric_name,
+  status,
+  quality,
+  unit,
+  value_numeric,
+  value_json,
+  meta_json,
+  formula_version,
+  as_of,
+  freshness_seconds,
+  created_at
+`
+
+export const up = async (db: Kysely<Database>) => {
+  await sql`SET LOCAL lock_timeout = '5s';`.execute(db)
+
+  // The legacy relation is 146 GiB even though its 7.47 million live rows are
+  // small. Renaming it is metadata-only and preserves every historical row.
+  await sql`
+    ALTER TABLE torghut_control_plane.quant_metrics_series
+    RENAME TO quant_metrics_series_legacy;
+  `.execute(db)
+
+  // Hash partitioning is static and matches the mandatory strategy filter on
+  // every series read. The active table stays logged; this changes layout, not
+  // PostgreSQL durability.
+  await sql`
+    CREATE TABLE ${sql.table(ACTIVE_TABLE)} (
+      LIKE torghut_control_plane.quant_metrics_series_legacy
+      INCLUDING DEFAULTS
+      INCLUDING GENERATED
+      INCLUDING STORAGE
+    ) PARTITION BY HASH (strategy_id);
+  `.execute(db)
+
+  for (let remainder = 0; remainder < PARTITION_COUNT; remainder += 1) {
+    const partition = `${ACTIVE_TABLE}_p${String(remainder).padStart(2, '0')}`
+    await sql`
+      CREATE TABLE ${sql.table(partition)}
+      PARTITION OF ${sql.table(ACTIVE_TABLE)}
+      FOR VALUES WITH (
+        MODULUS ${sql.raw(String(PARTITION_COUNT))},
+        REMAINDER ${sql.raw(String(remainder))}
+      );
+    `.execute(db)
+  }
+
+  await sql`
+    CREATE INDEX torghut_qm_series_active_lookup_idx
+    ON ${sql.table(ACTIVE_TABLE)} (strategy_id, account, "window", metric_name, as_of DESC);
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX torghut_qm_series_active_as_of_brin
+    ON ${sql.table(ACTIVE_TABLE)} USING BRIN (as_of) WITH (pages_per_range = 64);
+  `.execute(db)
+
+  await sql
+    .raw(`
+    CREATE VIEW torghut_control_plane.quant_metrics_series AS
+    SELECT ${SERIES_COLUMNS}
+    FROM torghut_control_plane.quant_metrics_series_legacy
+    UNION ALL
+    SELECT ${SERIES_COLUMNS}
+    FROM torghut_control_plane.quant_metrics_series_active;
+  `)
+    .execute(db)
+
+  await sql`
+    CREATE FUNCTION torghut_control_plane.insert_quant_metrics_series_active()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+    BEGIN
+      INSERT INTO torghut_control_plane.quant_metrics_series_active (
+        id,
+        strategy_id,
+        account,
+        "window",
+        metric_name,
+        status,
+        quality,
+        unit,
+        value_numeric,
+        value_json,
+        meta_json,
+        formula_version,
+        as_of,
+        freshness_seconds,
+        created_at
+      ) VALUES (
+        COALESCE(NEW.id, gen_random_uuid()),
+        NEW.strategy_id,
+        COALESCE(NEW.account, ''),
+        NEW."window",
+        NEW.metric_name,
+        COALESCE(NEW.status, 'ok'),
+        COALESCE(NEW.quality, 'good'),
+        COALESCE(NEW.unit, ''),
+        NEW.value_numeric,
+        COALESCE(NEW.value_json, '{}'::jsonb),
+        COALESCE(NEW.meta_json, '{}'::jsonb),
+        NEW.formula_version,
+        NEW.as_of,
+        COALESCE(NEW.freshness_seconds, 0),
+        COALESCE(NEW.created_at, now())
+      )
+      RETURNING * INTO NEW;
+
+      RETURN NEW;
+    END;
+    $$;
+  `.execute(db)
+
+  await sql`
+    CREATE TRIGGER quant_metrics_series_active_insert
+    INSTEAD OF INSERT ON torghut_control_plane.quant_metrics_series
+    FOR EACH ROW
+    EXECUTE FUNCTION torghut_control_plane.insert_quant_metrics_series_active();
+  `.execute(db)
+}
+
+export const down = async (db: Kysely<Database>) => {
+  // Preserve rows written after cutover before restoring the physical legacy
+  // table. This is intentionally the only data-copying path.
+  await sql
+    .raw(`
+    INSERT INTO torghut_control_plane.quant_metrics_series_legacy (${SERIES_COLUMNS})
+    SELECT ${SERIES_COLUMNS}
+    FROM torghut_control_plane.quant_metrics_series_active
+    ON CONFLICT (id) DO NOTHING;
+  `)
+    .execute(db)
+
+  await sql`
+    DROP TRIGGER IF EXISTS quant_metrics_series_active_insert
+    ON torghut_control_plane.quant_metrics_series;
+  `.execute(db)
+  await sql`DROP VIEW torghut_control_plane.quant_metrics_series;`.execute(db)
+  await sql`DROP FUNCTION torghut_control_plane.insert_quant_metrics_series_active();`.execute(db)
+  await sql`DROP TABLE ${sql.table(ACTIVE_TABLE)} CASCADE;`.execute(db)
+  await sql`
+    ALTER TABLE torghut_control_plane.quant_metrics_series_legacy
+    RENAME TO quant_metrics_series;
+  `.execute(db)
+}


### PR DESCRIPTION
## Summary

- Preserve the 146 GiB quant-series history as a read-only legacy relation without copying or reindexing it.
- Route compatible reads and inserts through a union view into a fresh logged, 16-way strategy-hash-partitioned active store.
- Add fail-closed lock handling, data-preserving rollback, migration regressions, and the measured production rationale.

## Related Issues

None.

## Testing

- `/nix/var/nix/profiles/default/bin/nix develop -c bun run --cwd services/jangar test` (128 files passed, 1 skipped; 697 tests passed, 4 skipped)
- `/nix/var/nix/profiles/default/bin/nix develop -c bunx vitest run --config vitest.config.ts src/server/__tests__/torghut-quant-metrics-store.test.ts src/server/__tests__/kysely-migrations.test.ts` (20 tests)
- `/nix/var/nix/profiles/default/bin/nix develop -c bun run --cwd services/jangar tsc`
- `/nix/var/nix/profiles/default/bin/nix develop -c bunx oxlint --config .oxlintrc.json services/jangar/src/server/migrations/20260715_torghut_quant_series_active.ts services/jangar/src/server/kysely-migrations.ts services/jangar/src/server/__tests__/torghut-quant-metrics-store.test.ts services/jangar/src/server/__tests__/kysely-migrations.test.ts`
- `/nix/var/nix/profiles/default/bin/nix develop -c bunx oxfmt --check docs/torghut/jangar-quant-write-pressure-remediation.md services/jangar/src/server/migrations/20260715_torghut_quant_series_active.ts services/jangar/src/server/kysely-migrations.ts services/jangar/src/server/__tests__/torghut-quant-metrics-store.test.ts services/jangar/src/server/__tests__/kysely-migrations.test.ts`
- PostgreSQL 17.10 local smoke: applied the real migration over a seeded legacy table, inserted through the compatibility view, confirmed one legacy plus one active row were both readable, then ran `down` and confirmed both rows were restored to the physical table.
- `git diff --check origin/main...HEAD`

## Breaking Changes

None. The existing `torghut_control_plane.quant_metrics_series` read/insert contract remains available as a compatibility view.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] The production evidence and rollback behavior are documented in the existing remediation design.
