### PR TITLE
fix(torghut): degrade recovery when receipt DB is unavailable

### DIFF
--- a/services/torghut/app/trading/broker_mutation_receipts/runtime_status.py
+++ b/services/torghut/app/trading/broker_mutation_receipts/runtime_status.py
@@ -244,6 +244,7 @@ def unavailable_broker_mutation_runtime_status() -> dict[str, object]:
     )
     payload.update(
         entry_fencing_proven=False,
+        recovery_degraded=True,
         database_status="unavailable",
         receipt_state_counts=None,
         recovery_resolution_state_counts=None,
@@ -254,6 +255,7 @@ def unavailable_broker_mutation_runtime_status() -> dict[str, object]:
         latest_receipt_event_at=None,
         reason_codes=[
             "broker_mutation_database_status_unavailable",
+            "broker_mutation_recovery_database_status_unavailable",
             *existing_reason_codes,
         ],
     )

--- a/services/torghut/tests/test_broker_mutation_runtime_status.py
+++ b/services/torghut/tests/test_broker_mutation_runtime_status.py
@@ -26,5 +26,9 @@ def test_database_status_unavailability_fails_entry_capability_closed() -> None:
 
     assert payload["runtime_wired"] is True
     assert payload["entry_fencing_proven"] is False
+    assert payload["recovery_degraded"] is True
     assert payload["database_status"] == "unavailable"
-    assert payload["reason_codes"][0] == "broker_mutation_database_status_unavailable"
+    assert payload["reason_codes"][:2] == [
+        "broker_mutation_database_status_unavailable",
+        "broker_mutation_recovery_database_status_unavailable",
+    ]


### PR DESCRIPTION
## Summary

- mark submit recovery degraded when durable receipt state cannot be read
- publish a recovery-specific reason so runtime authority reports the failed recovery dependency
- add regression coverage for the unavailable database projection

## Related review

- PR #12522, Codex discussion `3584681917`

## Testing

- Python 3.12.12: `pytest -q tests/test_broker_mutation_runtime_status.py tests/test_runtime_action_authority.py` (14 passed)
- `python -m compileall` on changed files
- `git diff --check`
- Local Ruff/Pyright binaries were unavailable because the container toolchain dynamic loader and isolated uv build environment are broken; authoritative CI is required for these gates.

## Breaking Changes

None.