### PR TITLE
chore(jangar): promote image sha-b8f4c6bd3095f58d07cdd59f0f2b197ee85a23c6

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/part-of: lab
   annotations:
     argocd.argoproj.io/sync-wave: "0"
-    deploy.knative.dev/rollout: 2026-07-15T05:04:26Z
+    deploy.knative.dev/rollout: 2026-07-15T06:02:05Z
 spec:
   replicas: 1
   strategy:
@@ -58,9 +58,9 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 2a7b93797ec1183dc81736d5b502c7a1b56a773f
+              value: b8f4c6bd3095f58d07cdd59f0f2b197ee85a23c6
             - name: JANGAR_GITOPS_REVISION
-              value: 2a7b93797ec1183dc81736d5b502c7a1b56a773f
+              value: b8f4c6bd3095f58d07cdd59f0f2b197ee85a23c6
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -360,15 +360,15 @@ spec:
             - name: ATLAS_CODE_SEARCH_STATEMENT_TIMEOUT_MS
               value: "750"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "29389910135"
+              value: "29392301068"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:07b55faf0bb0886b145b3969b7b5d44f930a68f55ff3fff8bf133d0a6a897391
+              value: sha256:d50e5228b6d92f1b96c2f215d1e96bc4495cede7f7a4ceb363fa769dc6eab4d6
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: 2a7b93797ec1183dc81736d5b502c7a1b56a773f
+              value: b8f4c6bd3095f58d07cdd59f0f2b197ee85a23c6
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:07b55faf0bb0886b145b3969b7b5d44f930a68f55ff3fff8bf133d0a6a897391
+              value: sha256:d50e5228b6d92f1b96c2f215d1e96bc4495cede7f7a4ceb363fa769dc6eab4d6
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -37,5 +37,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: sha-2a7b93797ec1183dc81736d5b502c7a1b56a773f
-    digest: sha256:07b55faf0bb0886b145b3969b7b5d44f930a68f55ff3fff8bf133d0a6a897391
+    newTag: sha-b8f4c6bd3095f58d07cdd59f0f2b197ee85a23c6
+    digest: sha256:d50e5228b6d92f1b96c2f215d1e96bc4495cede7f7a4ceb363fa769dc6eab4d6


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `b8f4c6bd3095f58d07cdd59f0f2b197ee85a23c6`
- Image tag: `sha-b8f4c6bd3095f58d07cdd59f0f2b197ee85a23c6`
- Image digest: `sha256:d50e5228b6d92f1b96c2f215d1e96bc4495cede7f7a4ceb363fa769dc6eab4d6`
- Source CI run: `29392301068`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates