### PR TITLE
chore(agents): promote images 2b4b9a36

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/agents-controller
-  tag: sha-350c4bde2ca3ed0f704c959eb2c386c9010cc606
-  digest: sha256:c60652f0ca10496edb27116e1b7afa7c8e59b73e3b7361173602491d9b32d7e5
+  tag: sha-2b4b9a368e5821c77ae960b8df65b95685e81d25
+  digest: sha256:44a827e4fbe51df032aabe91180f7bff2ffb7563ca6dbea8c5c4cd8e6656d076
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -14,32 +14,32 @@ tolerations:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-control-plane
-    tag: sha-350c4bde2ca3ed0f704c959eb2c386c9010cc606
-    digest: sha256:bf03a79b1fce3ed2f404e4fe04b2c7e5711740dd9b2ad530a9c3381112202cb3
+    tag: sha-2b4b9a368e5821c77ae960b8df65b95685e81d25
+    digest: sha256:ea65df6b6f82d9a53c9a0b5e13bd08046efe8a5ef9ef823f3b182d994a3b8dbb
   env:
     vars:
       AGENTS_CONTROL_PLANE_CACHE_ENABLED: "true"
       AGENTS_CONTROL_PLANE_CACHE_ALLOW_STALE: "false"
       AGENTS_CONTROL_PLANE_CACHE_RESYNC_SECONDS: "60"
       AGENTS_CONTROL_PLANE_CACHE_MAX_PENDING_WRITES: "5000"
-      AGENTS_SOURCE_HEAD_SHA: 350c4bde2ca3ed0f704c959eb2c386c9010cc606
-      AGENTS_GITOPS_REVISION: 350c4bde2ca3ed0f704c959eb2c386c9010cc606
-      AGENTS_SOURCE_CI_RUN_ID: "28757704145"
+      AGENTS_SOURCE_HEAD_SHA: 2b4b9a368e5821c77ae960b8df65b95685e81d25
+      AGENTS_GITOPS_REVISION: 2b4b9a368e5821c77ae960b8df65b95685e81d25
+      AGENTS_SOURCE_CI_RUN_ID: "29391036635"
       AGENTS_SOURCE_CI_CONCLUSION: success
-      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:bf03a79b1fce3ed2f404e4fe04b2c7e5711740dd9b2ad530a9c3381112202cb3
-      AGENTS_SERVING_BUILD_COMMIT: 350c4bde2ca3ed0f704c959eb2c386c9010cc606
-      AGENTS_SERVING_IMAGE_DIGEST: sha256:bf03a79b1fce3ed2f404e4fe04b2c7e5711740dd9b2ad530a9c3381112202cb3
+      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:ea65df6b6f82d9a53c9a0b5e13bd08046efe8a5ef9ef823f3b182d994a3b8dbb
+      AGENTS_SERVING_BUILD_COMMIT: 2b4b9a368e5821c77ae960b8df65b95685e81d25
+      AGENTS_SERVING_IMAGE_DIGEST: sha256:ea65df6b6f82d9a53c9a0b5e13bd08046efe8a5ef9ef823f3b182d994a3b8dbb
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-codex-runner
-    tag: sha-350c4bde2ca3ed0f704c959eb2c386c9010cc606
-    digest: sha256:1e9e47aaedadf5429de22359e48262520cb2787f38dbd29bc0971aaaf52e80c7
+    tag: sha-2b4b9a368e5821c77ae960b8df65b95685e81d25
+    digest: sha256:ba3819736c70bbabb83b8e7ac0f0ec239c5aed05aedbedc8261c3cec36f3e8f7
 agentsShell:
   enabled: true
   image:
     repository: registry.ide-newton.ts.net/lab/agents-shell
-    tag: sha-350c4bde2ca3ed0f704c959eb2c386c9010cc606
-    digest: sha256:837942c706d7bde2462b08e053b6c91fb3c0d4d30db95874fb0de460438837d0
+    tag: sha-2b4b9a368e5821c77ae960b8df65b95685e81d25
+    digest: sha256:c2d544eb5e7e082171fe49591311fb0b285d4b71283230b58d5fcd70d009bdee
     pullPolicy: IfNotPresent
   env:
     vars:
@@ -159,8 +159,8 @@ controllers:
   replicaCount: 2
   image:
     repository: registry.ide-newton.ts.net/lab/agents-controller
-    tag: sha-350c4bde2ca3ed0f704c959eb2c386c9010cc606
-    digest: sha256:c60652f0ca10496edb27116e1b7afa7c8e59b73e3b7361173602491d9b32d7e5
+    tag: sha-2b4b9a368e5821c77ae960b8df65b95685e81d25
+    digest: sha256:44a827e4fbe51df032aabe91180f7bff2ffb7563ca6dbea8c5c4cd8e6656d076
   autoscaling:
     enabled: false
 swarm:


### PR DESCRIPTION
## Summary
Promote Agents Nix-built service and runner images into GitOps manifests.

- Source commit: `2b4b9a368e5821c77ae960b8df65b95685e81d25`
- Image tag: `2b4b9a36`
- Agents build run: `29391036635`
- Promotion source: `manual_dispatch`
- Service images: `agents-controller`, `agents-control-plane`, `agents-shell`
- Runner image: `agents-codex-runner`