### PR TITLE
fix(torghut): preserve structured outputs on status updates

### DIFF
--- a/services/torghut/app/whitepapers/workflow/whitepaper_workflow_api_methods.py
+++ b/services/torghut/app/whitepapers/workflow/whitepaper_workflow_api_methods.py
@@ -63,7 +63,10 @@ class WhitepaperWorkflowApiMethods(_WhitepaperWorkflowApiBase):
             "experiment_specs",
             "contradiction_events",
         )
-        return "synthesis" in payload or any(key in payload for key in keys)
+        if any(key in payload for key in keys):
+            return True
+        synthesis = payload.get("synthesis")
+        return isinstance(synthesis, Mapping) and any(key in synthesis for key in keys)
 
     def _compiled_experiment_specs_from_templates(
         self,

--- a/services/torghut/app/whitepapers/workflow/whitepaper_workflow_api_methods.py
+++ b/services/torghut/app/whitepapers/workflow/whitepaper_workflow_api_methods.py
@@ -63,12 +63,7 @@ class WhitepaperWorkflowApiMethods(_WhitepaperWorkflowApiBase):
             "experiment_specs",
             "contradiction_events",
         )
-        if any(key in payload for key in keys):
-            return True
-        synthesis_payload = payload.get("synthesis")
-        return isinstance(synthesis_payload, Mapping) and any(
-            key in synthesis_payload for key in keys
-        )
+        return "synthesis" in payload or any(key in payload for key in keys)
 
     def _compiled_experiment_specs_from_templates(
         self,

--- a/services/torghut/app/whitepapers/workflow/whitepaper_workflow_api_methods.py
+++ b/services/torghut/app/whitepapers/workflow/whitepaper_workflow_api_methods.py
@@ -54,6 +54,22 @@ else:
 
 
 class WhitepaperWorkflowApiMethods(_WhitepaperWorkflowApiBase):
+    @staticmethod
+    def _has_structured_research_outputs(payload: Mapping[str, Any]) -> bool:
+        keys = (
+            "claims",
+            "claim_relations",
+            "strategy_templates",
+            "experiment_specs",
+            "contradiction_events",
+        )
+        if any(key in payload for key in keys):
+            return True
+        synthesis_payload = payload.get("synthesis")
+        return isinstance(synthesis_payload, Mapping) and any(
+            key in synthesis_payload for key in keys
+        )
+
     def _compiled_experiment_specs_from_templates(
         self,
         *,
@@ -172,6 +188,9 @@ class WhitepaperWorkflowApiMethods(_WhitepaperWorkflowApiBase):
         run: WhitepaperAnalysisRun,
         payload: Mapping[str, Any],
     ) -> None:
+        if not self._has_structured_research_outputs(payload):
+            return
+
         claims = self._structured_output_list(payload, key="claims")
         relations = self._structured_output_list(payload, key="claim_relations")
         templates = self._structured_output_list(payload, key="strategy_templates")

--- a/services/torghut/tests/whitepaper_workflow/test_marker_and_attachment_parsing.py
+++ b/services/torghut/tests/whitepaper_workflow/test_marker_and_attachment_parsing.py
@@ -562,6 +562,46 @@ https://example.com/paper.pdf
                 1,
             )
 
+            third_result = service.finalize_run(
+                session,
+                run_id=run_row.run_id,
+                payload={
+                    "status": "completed",
+                    "synthesis": {"summary": "replacement without structured outputs"},
+                },
+            )
+            self.assertEqual(third_result["status"], "completed")
+            session.commit()
+
+            self.assertEqual(
+                len(session.execute(select(WhitepaperClaim)).scalars().all()), 0
+            )
+            self.assertEqual(
+                len(session.execute(select(WhitepaperClaimRelation)).scalars().all()),
+                0,
+            )
+            self.assertEqual(
+                len(
+                    session.execute(select(WhitepaperStrategyTemplate)).scalars().all()
+                ),
+                0,
+            )
+            self.assertEqual(
+                len(session.execute(select(WhitepaperExperimentSpec)).scalars().all()),
+                0,
+            )
+            self.assertEqual(
+                len(session.execute(select(VNextExperimentSpec)).scalars().all()), 0
+            )
+            self.assertEqual(
+                len(
+                    session.execute(select(WhitepaperContradictionEvent))
+                    .scalars()
+                    .all()
+                ),
+                0,
+            )
+
     def test_structured_output_helpers_cover_direct_nested_and_gating_merge(
         self,
     ) -> None:

--- a/services/torghut/tests/whitepaper_workflow/test_marker_and_attachment_parsing.py
+++ b/services/torghut/tests/whitepaper_workflow/test_marker_and_attachment_parsing.py
@@ -567,10 +567,57 @@ https://example.com/paper.pdf
                 run_id=run_row.run_id,
                 payload={
                     "status": "completed",
-                    "synthesis": {"summary": "replacement without structured outputs"},
+                    "synthesis": {"executive_summary": "narrative-only refresh"},
                 },
             )
             self.assertEqual(third_result["status"], "completed")
+            session.commit()
+
+            self.assertEqual(
+                len(session.execute(select(WhitepaperClaim)).scalars().all()), 2
+            )
+            self.assertEqual(
+                len(session.execute(select(WhitepaperClaimRelation)).scalars().all()),
+                1,
+            )
+            self.assertEqual(
+                len(
+                    session.execute(select(WhitepaperStrategyTemplate)).scalars().all()
+                ),
+                1,
+            )
+            self.assertEqual(
+                len(session.execute(select(WhitepaperExperimentSpec)).scalars().all()),
+                1,
+            )
+            self.assertEqual(
+                len(session.execute(select(VNextExperimentSpec)).scalars().all()), 1
+            )
+            self.assertEqual(
+                len(
+                    session.execute(select(WhitepaperContradictionEvent))
+                    .scalars()
+                    .all()
+                ),
+                1,
+            )
+
+            fourth_result = service.finalize_run(
+                session,
+                run_id=run_row.run_id,
+                payload={
+                    "status": "completed",
+                    "synthesis": {
+                        "executive_summary": "explicit structured replacement",
+                        "claims": [],
+                        "claim_relations": [],
+                        "strategy_templates": [],
+                        "experiment_specs": [],
+                        "contradiction_events": [],
+                    },
+                },
+            )
+            self.assertEqual(fourth_result["status"], "completed")
             session.commit()
 
             self.assertEqual(

--- a/services/torghut/tests/whitepaper_workflow/test_marker_and_attachment_parsing.py
+++ b/services/torghut/tests/whitepaper_workflow/test_marker_and_attachment_parsing.py
@@ -525,6 +525,43 @@ https://example.com/paper.pdf
                 contradiction_events[0].required_action, "revalidate_linked_family"
             )
 
+            second_result = service.finalize_run(
+                session,
+                run_id=run_row.run_id,
+                payload={"status": "completed"},
+            )
+            self.assertEqual(second_result["status"], "completed")
+            session.commit()
+
+            self.assertEqual(
+                len(session.execute(select(WhitepaperClaim)).scalars().all()), 2
+            )
+            self.assertEqual(
+                len(session.execute(select(WhitepaperClaimRelation)).scalars().all()),
+                1,
+            )
+            self.assertEqual(
+                len(
+                    session.execute(select(WhitepaperStrategyTemplate)).scalars().all()
+                ),
+                1,
+            )
+            self.assertEqual(
+                len(session.execute(select(WhitepaperExperimentSpec)).scalars().all()),
+                1,
+            )
+            self.assertEqual(
+                len(session.execute(select(VNextExperimentSpec)).scalars().all()), 1
+            )
+            self.assertEqual(
+                len(
+                    session.execute(select(WhitepaperContradictionEvent))
+                    .scalars()
+                    .all()
+                ),
+                1,
+            )
+
     def test_structured_output_helpers_cover_direct_nested_and_gating_merge(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Preserve previously persisted whitepaper claims, relations, templates, experiment specs, mirrored vNext specs, and contradiction events when a finalize retry contains only status or other non-structured fields.
- Continue treating explicitly present structured-output keys, including empty lists, as authoritative replacement payloads.
- Add regression coverage for a status-only second finalize after structured research outputs have already been persisted.

## Related Issues

Resolves the actionable Codex finding in https://github.com/proompteng/lab/pull/4881#discussion_r3046277713 after merge.

## Testing

- `pytest -q tests/whitepaper_workflow/test_marker_and_attachment_parsing.py --disable-warnings --maxfail=1` (18 passed)
- `python -m compileall -q app/whitepapers/workflow/whitepaper_workflow_api_methods.py tests/whitepaper_workflow/test_marker_and_attachment_parsing.py`
- `git diff --check origin/main...HEAD`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (screenshots not applicable; breaking changes stated above).
- [x] Documentation, release notes, and follow-ups are updated or tracked (historical source thread will be replied to and resolved after merge).