### PR TITLE
fix(atlas): observe canceled queries by relation lock

### DIFF
--- a/packages/scripts/src/atlas/verify.test.ts
+++ b/packages/scripts/src/atlas/verify.test.ts
@@ -3,6 +3,19 @@ import { describe, expect, it } from 'bun:test'
 import { __private } from './verify'
 
 describe('atlas verify', () => {
+  it('observes Atlas queries by relation lock instead of truncated activity text', async () => {
+    let statement = ''
+    const db = ((strings: TemplateStringsArray) => {
+      statement = strings.join('')
+      return Promise.resolve([{ active: 2n }])
+    }) as Parameters<typeof __private.activeAtlasQueryCount>[0]
+
+    expect(await __private.activeAtlasQueryCount(db)).toBe(2)
+    expect(statement).toContain('INNER JOIN pg_locks AS relation_lock')
+    expect(statement).toContain("relation_lock.relation = 'atlas.chunk_embeddings'::regclass")
+    expect(statement).not.toContain('activity.query')
+  })
+
   it('uses a unique cold query for every performance request', () => {
     const queries = [
       { query: 'exact identifier', expectedPaths: ['src/exact.ts'] },

--- a/packages/scripts/src/atlas/verify.ts
+++ b/packages/scripts/src/atlas/verify.ts
@@ -296,11 +296,13 @@ const buildColdPerformanceQueries = (queries: GoldQuery[], runs: number, nonce: 
 
 const activeAtlasQueryCount = async (db: SQL) => {
   const rows = (await db`
-    SELECT count(*)::bigint AS active
-    FROM pg_stat_activity
-    WHERE state = 'active'
-      AND query ILIKE '%atlas.chunk_embeddings%'
-      AND pid <> pg_backend_pid();
+    SELECT count(DISTINCT activity.pid)::bigint AS active
+    FROM pg_stat_activity AS activity
+    INNER JOIN pg_locks AS relation_lock ON relation_lock.pid = activity.pid
+    WHERE activity.state = 'active'
+      AND relation_lock.locktype = 'relation'
+      AND relation_lock.relation = 'atlas.chunk_embeddings'::regclass
+      AND activity.pid <> pg_backend_pid();
   `) as Array<{ active: unknown }>
   return count(rows[0]?.active)
 }
@@ -379,7 +381,7 @@ const runCancellationProbe = async (input: {
   return { reachedDatabase, observedBlockedQueries, lingeringQueries }
 }
 
-export const __private = { buildColdPerformanceQueries }
+export const __private = { activeAtlasQueryCount, buildColdPerformanceQueries }
 
 const main = async () => {
   const options = parseArgs(Bun.argv.slice(2))


### PR DESCRIPTION
## Summary

- observe active Atlas SQL through `pg_locks` on `atlas.chunk_embeddings`
- avoid relying on `pg_stat_activity.query`, which PostgreSQL truncates at 1 kB before the relation name
- add regression coverage and prove live cancellation reaches PostgreSQL with no lingering queries

## Related Issues

None

## Testing

- `bun test src/atlas/verify.test.ts` (2 passed)
- `bunx oxfmt --check src/atlas/verify.ts src/atlas/verify.test.ts`
- `bunx oxlint --config ../../.oxlintrc.json src/atlas/verify.ts src/atlas/verify.test.ts`
- live `atlas:verify`: cancellation reached PostgreSQL with 2 blocked queries and 0 lingering queries
- `bunx tsc --noEmit -p tsconfig.json` remains blocked by pre-existing unrelated package errors; no errors referenced the changed Atlas files

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.