### PR TITLE
fix(sag): skip deploy verification while disabled

### DIFF
--- a/.github/workflows/sag-post-deploy-verify.yml
+++ b/.github/workflows/sag-post-deploy-verify.yml
@@ -28,12 +28,51 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Determine Sag ApplicationSet state
+        id: sag
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          enabled="$(
+            awk '
+              /^[[:space:]]+- name: sag[[:space:]]*$/ {
+                in_sag = 1
+                next
+              }
+              in_sag && /^[[:space:]]+- name:/ {
+                exit
+              }
+              in_sag && $1 == "enabled:" {
+                gsub(/["[:space:]]/, "", $2)
+                print $2
+                exit
+              }
+            ' argocd/applicationsets/product.yaml
+          )"
+
+          case "${enabled}" in
+            true)
+              echo "enabled=true" >> "${GITHUB_OUTPUT}"
+              ;;
+            false)
+              echo "enabled=false" >> "${GITHUB_OUTPUT}"
+              echo "Sag is disabled in the product ApplicationSet; post-deploy verification is not applicable."
+              ;;
+            *)
+              echo "Unable to resolve the Sag enabled state from argocd/applicationsets/product.yaml" >&2
+              exit 1
+              ;;
+          esac
+
       - name: Set up kubectl
+        if: steps.sag.outputs.enabled == 'true'
         uses: azure/setup-kubectl@v4
         with:
           version: v1.31.2
 
       - name: Configure in-cluster kubeconfig when context is missing
+        if: steps.sag.outputs.enabled == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -72,6 +111,7 @@ jobs:
           kubectl config use-context in-cluster --kubeconfig="${KUBECONFIG_PATH}"
 
       - name: Verify Sag Argo health and deployment digest
+        if: steps.sag.outputs.enabled == 'true'
         shell: bash
         env:
           EXPECTED_REVISION_INPUT: ${{ inputs.expected_revision || '' }}

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -1000,6 +1000,12 @@ describe('native OCI build workflows', () => {
     expect(sagReleaseWorkflow).toContain('test "${service}" = "sag"')
     expect(sagReleaseWorkflow).not.toContain('packages/scripts/src/shared/nix-oci-deploy.ts')
     expect(sagReleaseWorkflow).not.toContain('docker buildx')
+    expect(sagPostDeployVerifyWorkflow).toContain('Determine Sag ApplicationSet state')
+    expect(sagPostDeployVerifyWorkflow).toContain('argocd/applicationsets/product.yaml')
+    expect(sagPostDeployVerifyWorkflow).toContain("if: steps.sag.outputs.enabled == 'true'")
+    expect(sagPostDeployVerifyWorkflow).toContain(
+      'Sag is disabled in the product ApplicationSet; post-deploy verification is not applicable.',
+    )
     expect(sagPostDeployVerifyWorkflow).toContain('kubectl -n sag rollout status deployment/sag')
     expect(sagPostDeployVerifyWorkflow).toContain('desired_replicas=')
     expect(sagPostDeployVerifyWorkflow).toContain(


### PR DESCRIPTION
## Summary

- Detect the Sag ApplicationSet enabled state before setting up cluster tooling.
- Skip post-deploy cluster verification when Sag is intentionally disabled, while failing closed on an unknown state.
- Preserve the full live digest and rollout verification path for enabled Sag deployments and cover the guard contract.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/oci.test.ts` (48 passed)
- `actionlint 1.7.12 .github/workflows/sag-post-deploy-verify.yml`
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/oci.test.ts`
- `git diff --check`
- Extracted the current Sag ApplicationSet state with the workflow AWK expression and confirmed `false`.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (screenshots not applicable; section removed).
- [x] Documentation, release notes, and follow-ups are updated or tracked.