### PR TITLE
feat(bumba): enable Atlas event consumer

### DIFF
--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -134,9 +134,9 @@ spec:
               value: "2"
             - name: BUMBA_GITHUB_EVENT_POLL_INTERVAL_MS
               value: "30000"
-            # Keep event ingestion stopped through the destructive Atlas rebuild. Re-enable only after atlas:verify.
+            # One consumer reconciles default-branch events after the Atlas production verification gates pass.
             - name: BUMBA_GITHUB_EVENT_CONSUMER_ENABLED
-              value: "false"
+              value: "true"
             - name: BUMBA_ATLAS_DEFAULT_REF
               value: main
             - name: BUMBA_ATLAS_PREPARE_CONCURRENCY


### PR DESCRIPTION
## Summary

- enable the single Bumba GitHub event consumer after the Atlas production gates passed
- preserve the repository-scoped reconciliation workflow fence and current single-schema design
- update the cutover comment to describe steady-state ownership

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/bumba | kubectl apply --dry-run=client -n jangar -f -`
- rendered output contains exactly one `BUMBA_GITHUB_EVENT_CONSUMER_ENABLED: "true"` entry
- `bun run lint:argocd` (0 invalid resources)
- live `atlas:verify` passed on current `origin/main` at `76dcee73eba51daedde29768933574ea0a979be6`
- pre-cutover database: one pending main event, zero nonterminal ingestions, zero processed events with unfinished ingestions

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.