### PR TITLE
fix(bumba): preserve pending atlas workflow state

### DIFF
--- a/services/bumba/src/activities/index.ts
+++ b/services/bumba/src/activities/index.ts
@@ -11,6 +11,7 @@ import { isMap, isScalar, isSeq, LineCounter, parseAllDocuments } from 'yaml'
 import { currentActivityContext } from '@proompteng/temporal-bun-sdk/worker'
 
 import { shouldSkipAtlasPath } from '../atlas/file-eligibility'
+import { LEGACY_RECONCILE_PENDING_ERROR } from '../atlas/ingestion-status'
 import {
   assertAtlasManifestMatches,
   type AtlasCurrentFile,
@@ -190,6 +191,7 @@ export type UpsertIngestionInput = {
   error?: string | null
   startedAt?: string | null
   finishedAt?: string | null
+  correctLegacyPendingFailure?: boolean
 }
 
 export type UpsertIngestionOutput = {
@@ -4968,6 +4970,10 @@ export const activities = {
     const status = input.status.trim()
     const errorText = typeof input.error === 'string' ? input.error.trim() : ''
     const error = errorText.length > 0 ? errorText : null
+    const correctLegacyPendingFailure = input.correctLegacyPendingFailure === true
+    const validLegacyCorrection =
+      (status === 'completed' && error === null) ||
+      (status === 'failed' && error !== null && error !== LEGACY_RECONCILE_PENDING_ERROR)
 
     if (!deliveryId || !workflowId || !status) {
       logActivity('info', 'skipped', 'upsertIngestion', {
@@ -4978,6 +4984,9 @@ export const activities = {
         durationMs: Date.now() - startedAt,
       })
       return null
+    }
+    if (correctLegacyPendingFailure && !validLegacyCorrection) {
+      throw new Error('Legacy pending-failure correction requires completion or a real failure')
     }
 
     logActivity('info', 'started', 'upsertIngestion', {
@@ -5023,18 +5032,31 @@ export const activities = {
         )
         ON CONFLICT (event_id, workflow_id) DO UPDATE
         SET status = CASE
+              WHEN ${correctLegacyPendingFailure}
+                AND atlas.ingestions.status = 'failed'
+                AND atlas.ingestions.error = ${LEGACY_RECONCILE_PENDING_ERROR}
+              THEN EXCLUDED.status
               WHEN atlas.ingestions.status IN ('completed', 'failed', 'skipped') THEN atlas.ingestions.status
               ELSE EXCLUDED.status
             END,
-            error = COALESCE(EXCLUDED.error, atlas.ingestions.error),
+            error = CASE
+              WHEN ${correctLegacyPendingFailure}
+                AND atlas.ingestions.status = 'failed'
+                AND atlas.ingestions.error = ${LEGACY_RECONCILE_PENDING_ERROR}
+              THEN EXCLUDED.error
+              ELSE COALESCE(EXCLUDED.error, atlas.ingestions.error)
+            END,
             started_at = COALESCE(EXCLUDED.started_at, atlas.ingestions.started_at),
             finished_at = COALESCE(EXCLUDED.finished_at, atlas.ingestions.finished_at)
-        RETURNING id, event_id;
-      `) as Array<{ id: string; event_id: string }>
+        RETURNING id, event_id, status, error;
+      `) as Array<{ id: string; event_id: string; status: string; error: string | null }>
 
       const row = rows[0]
       if (!row) {
         throw new Error('ingestion upsert failed')
+      }
+      if (correctLegacyPendingFailure && (row.status !== status || row.error !== error)) {
+        throw new Error('Ingestion does not match the legacy pending-failure correction guard')
       }
 
       logActivity('info', 'completed', 'upsertIngestion', {

--- a/services/bumba/src/atlas/ingestion-status.ts
+++ b/services/bumba/src/atlas/ingestion-status.ts
@@ -1,0 +1,1 @@
+export const LEGACY_RECONCILE_PENDING_ERROR = 'Workflow blocked: Activity activity-1 pending'

--- a/services/bumba/src/atlas/reconciliation.integration.test.ts
+++ b/services/bumba/src/atlas/reconciliation.integration.test.ts
@@ -9,6 +9,8 @@ import { SQL } from 'bun'
 import { runWithActivityContext, type ActivityContext } from '@proompteng/temporal-bun-sdk/worker'
 
 import activities, { __test__ as activityTest } from '../activities/index'
+import { __test__ as eventConsumerTest } from '../event-consumer'
+import { LEGACY_RECONCILE_PENDING_ERROR } from './ingestion-status'
 
 const databaseUrl = process.env.ATLAS_INTEGRATION_DATABASE_URL?.trim()
 if (process.env.ATLAS_REQUIRE_INTEGRATION_TESTS === '1' && !databaseUrl) {
@@ -167,6 +169,24 @@ beforeAll(async () => {
       created_at timestamptz NOT NULL DEFAULT now()
     );
   `
+  await db`
+    CREATE TABLE atlas.github_events (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      delivery_id text NOT NULL UNIQUE
+    );
+  `
+  await db`
+    CREATE TABLE atlas.ingestions (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      event_id uuid NOT NULL REFERENCES atlas.github_events(id) ON DELETE CASCADE,
+      workflow_id text NOT NULL,
+      status text NOT NULL,
+      error text,
+      started_at timestamptz NOT NULL DEFAULT now(),
+      finished_at timestamptz,
+      UNIQUE (event_id, workflow_id)
+    );
+  `
 })
 
 afterAll(async () => {
@@ -178,6 +198,144 @@ afterAll(async () => {
     if (value === undefined) delete process.env[key]
     else process.env[key] = value
   }
+})
+
+integrationTest('legacy ingestion correction and aging preserve real failures', async () => {
+  if (!db) throw new Error('integration database was not initialized')
+  const workflowId = 'bumba-atlas-reconcile-proompteng-lab-legacy'
+  const eventRows = (await db`
+    INSERT INTO atlas.github_events (delivery_id)
+    VALUES
+      ('legacy-pending-delivery'),
+      ('real-failure-delivery'),
+      ('legacy-real-failure-delivery'),
+      ('stale-legacy-delivery')
+    RETURNING id, delivery_id;
+  `) as Array<{ id: string; delivery_id: string }>
+  const legacyEventId = eventRows.find((row) => row.delivery_id === 'legacy-pending-delivery')?.id
+  const realFailureEventId = eventRows.find((row) => row.delivery_id === 'real-failure-delivery')?.id
+  const legacyRealFailureEventId = eventRows.find((row) => row.delivery_id === 'legacy-real-failure-delivery')?.id
+  const staleLegacyEventId = eventRows.find((row) => row.delivery_id === 'stale-legacy-delivery')?.id
+  if (!legacyEventId || !realFailureEventId || !legacyRealFailureEventId || !staleLegacyEventId) {
+    throw new Error('integration events were not created')
+  }
+
+  await activities.upsertIngestion({
+    deliveryId: 'legacy-pending-delivery',
+    workflowId,
+    status: 'failed',
+    error: LEGACY_RECONCILE_PENDING_ERROR,
+  })
+  await activities.upsertIngestion({
+    deliveryId: 'legacy-pending-delivery',
+    workflowId,
+    status: 'completed',
+  })
+
+  const preservedRows = (await db`
+    SELECT status, error
+    FROM atlas.ingestions
+    WHERE workflow_id = ${workflowId};
+  `) as Array<{ status: string; error: string | null }>
+  expect(preservedRows[0]).toEqual({ status: 'failed', error: LEGACY_RECONCILE_PENDING_ERROR })
+  await expect(eventConsumerTest.getIngestionCounts(db as never, legacyEventId)).resolves.toMatchObject({
+    total: 1,
+    terminal: 0,
+    failed: 0,
+    nonterminal: 1,
+  })
+
+  await activities.upsertIngestion({
+    deliveryId: 'legacy-pending-delivery',
+    workflowId,
+    status: 'completed',
+    correctLegacyPendingFailure: true,
+  })
+
+  const correctedRows = (await db`
+    SELECT status, error
+    FROM atlas.ingestions
+    WHERE workflow_id = ${workflowId};
+  `) as Array<{ status: string; error: string | null }>
+  expect(correctedRows[0]).toEqual({ status: 'completed', error: null })
+  await expect(eventConsumerTest.getIngestionCounts(db as never, legacyEventId)).resolves.toMatchObject({
+    total: 1,
+    terminal: 1,
+    failed: 0,
+    nonterminal: 0,
+  })
+
+  await activities.upsertIngestion({
+    deliveryId: 'real-failure-delivery',
+    workflowId,
+    status: 'failed',
+    error: 'real reconciliation failure',
+  })
+  await expect(
+    activities.upsertIngestion({
+      deliveryId: 'real-failure-delivery',
+      workflowId,
+      status: 'completed',
+      correctLegacyPendingFailure: true,
+    }),
+  ).rejects.toThrow('does not match the legacy pending-failure correction guard')
+
+  const realFailureRows = (await db`
+    SELECT status, error
+    FROM atlas.ingestions i
+    JOIN atlas.github_events e ON e.id = i.event_id
+    WHERE e.delivery_id = 'real-failure-delivery';
+  `) as Array<{ status: string; error: string | null }>
+  expect(realFailureRows[0]).toEqual({ status: 'failed', error: 'real reconciliation failure' })
+  await expect(eventConsumerTest.getIngestionCounts(db as never, realFailureEventId)).resolves.toMatchObject({
+    total: 1,
+    terminal: 1,
+    failed: 1,
+    nonterminal: 0,
+  })
+
+  await activities.upsertIngestion({
+    deliveryId: 'legacy-real-failure-delivery',
+    workflowId,
+    status: 'failed',
+    error: LEGACY_RECONCILE_PENDING_ERROR,
+  })
+  await activities.upsertIngestion({
+    deliveryId: 'legacy-real-failure-delivery',
+    workflowId,
+    status: 'failed',
+    error: 'real reconciliation failure after pending',
+    correctLegacyPendingFailure: true,
+  })
+  await expect(eventConsumerTest.getIngestionCounts(db as never, legacyRealFailureEventId)).resolves.toMatchObject({
+    total: 1,
+    terminal: 1,
+    failed: 1,
+    nonterminal: 0,
+  })
+
+  const staleStartedAt = new Date(Date.now() - 60_000).toISOString()
+  await activities.upsertIngestion({
+    deliveryId: 'stale-legacy-delivery',
+    workflowId,
+    status: 'failed',
+    error: LEGACY_RECONCILE_PENDING_ERROR,
+    startedAt: staleStartedAt,
+  })
+  await expect(eventConsumerTest.markStaleIngestionsFailed(db as never, staleLegacyEventId, 1_000)).resolves.toBe(1)
+  await expect(eventConsumerTest.getIngestionCounts(db as never, staleLegacyEventId)).resolves.toMatchObject({
+    total: 1,
+    terminal: 1,
+    failed: 1,
+    nonterminal: 0,
+  })
+  const staleRows = (await db`
+    SELECT error
+    FROM atlas.ingestions i
+    JOIN atlas.github_events e ON e.id = i.event_id
+    WHERE e.delivery_id = 'stale-legacy-delivery';
+  `) as Array<{ error: string | null }>
+  expect(staleRows[0]?.error).toContain('stale nonterminal ingestion auto-failed by bumba event-consumer')
 })
 
 integrationTest(

--- a/services/bumba/src/event-consumer.ts
+++ b/services/bumba/src/event-consumer.ts
@@ -8,6 +8,7 @@ import { Effect } from 'effect'
 
 import { runCommandIsolated } from './command-runner'
 import { shouldSkipAtlasPath } from './atlas/file-eligibility'
+import { LEGACY_RECONCILE_PENDING_ERROR } from './atlas/ingestion-status'
 import { buildAtlasReconciliationWorkflowId } from './atlas/reconciliation'
 
 const DEFAULT_TASK_QUEUE = 'bumba'
@@ -816,10 +817,21 @@ const getIngestionCounts = async (db: SqlClient, eventId: string): Promise<Inges
   const rows = (await db`
     SELECT
       count(*)::bigint AS total,
-      count(*) FILTER (WHERE status IN ('completed', 'failed', 'skipped'))::bigint AS terminal,
-      count(*) FILTER (WHERE status = 'failed')::bigint AS failed,
-      count(*) FILTER (WHERE status NOT IN ('completed', 'failed', 'skipped'))::bigint AS nonterminal,
-      min(started_at) FILTER (WHERE status NOT IN ('completed', 'failed', 'skipped')) AS oldest_nonterminal_started_at
+      count(*) FILTER (
+        WHERE status IN ('completed', 'failed', 'skipped')
+          AND NOT (status = 'failed' AND error IS NOT DISTINCT FROM ${LEGACY_RECONCILE_PENDING_ERROR})
+      )::bigint AS terminal,
+      count(*) FILTER (
+        WHERE status = 'failed' AND error IS DISTINCT FROM ${LEGACY_RECONCILE_PENDING_ERROR}
+      )::bigint AS failed,
+      count(*) FILTER (
+        WHERE status NOT IN ('completed', 'failed', 'skipped')
+          OR (status = 'failed' AND error IS NOT DISTINCT FROM ${LEGACY_RECONCILE_PENDING_ERROR})
+      )::bigint AS nonterminal,
+      min(started_at) FILTER (
+        WHERE status NOT IN ('completed', 'failed', 'skipped')
+          OR (status = 'failed' AND error IS NOT DISTINCT FROM ${LEGACY_RECONCILE_PENDING_ERROR})
+      ) AS oldest_nonterminal_started_at
     FROM atlas.ingestions
     WHERE event_id = ${eventId};
   `) as IngestionCountsRow[]
@@ -857,7 +869,10 @@ const markStaleIngestionsFailed = async (db: SqlClient, eventId: string, staleMs
       END,
       finished_at = COALESCE(finished_at, now())
     WHERE event_id = ${eventId}
-      AND status NOT IN ('completed', 'failed', 'skipped')
+      AND (
+        status NOT IN ('completed', 'failed', 'skipped')
+        OR (status = 'failed' AND error IS NOT DISTINCT FROM ${LEGACY_RECONCILE_PENDING_ERROR})
+      )
       AND started_at < now() - (${staleMs}::bigint * interval '1 millisecond')
     RETURNING id;
   `) as Array<{ id: string }>
@@ -1316,5 +1331,7 @@ export const __test__ = {
   normalizeGeneratedMemoryNote,
   isMainBranchRef,
   mainMergeMemoryNamespace,
+  getIngestionCounts,
+  markStaleIngestionsFailed,
   TERMINAL_INGESTION_STATUSES,
 }

--- a/services/bumba/src/workflows/index.test.ts
+++ b/services/bumba/src/workflows/index.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'bun:test'
 import type {
+  ActivityResolution,
   ExecuteWorkflowInput,
   WorkflowDefinitions,
   WorkflowExecutionOutput,
@@ -79,8 +80,10 @@ test('reconcileAtlasRepository schedules one bounded full-repository activity', 
   const output = await execute(executor, { workflowType: 'reconcileAtlasRepository', arguments: input })
 
   expect(output.completion).toBe('pending')
-  expect(output.commands).toHaveLength(1)
-  const schedule = output.commands[0]
+  expect(output.commands).toHaveLength(2)
+  expect(output.commands[0]?.commandType).toBe(CommandType.RECORD_MARKER)
+  const schedule = output.commands[1]
+  if (!schedule) throw new Error('Expected Atlas reconciliation activity command.')
   expect(schedule.commandType).toBe(CommandType.SCHEDULE_ACTIVITY_TASK)
   if (schedule.attributes?.case !== 'scheduleActivityTaskCommandAttributes') {
     throw new Error('Expected Atlas reconciliation activity command.')
@@ -92,6 +95,206 @@ test('reconcileAtlasRepository schedules one bounded full-repository activity', 
   expect(Number(attributes.heartbeatTimeout?.seconds ?? 0n)).toBe(90)
   expect(attributes.retryPolicy?.maximumAttempts).toBe(0)
   expect(await decodePayloadsToValues(dataConverter, attributes.input?.payloads ?? [])).toEqual([input])
+})
+
+test('reconcileAtlasRepository waits for the reconciliation activity before finalizing ingestion', async () => {
+  const { executor } = makeExecutor()
+  const input = {
+    repoRoot: '/workspace/lab',
+    repository: 'proompteng/lab',
+    ref: 'main',
+    commit: 'abcdef1234567890abcdef1234567890abcdef1234',
+    eventDeliveryId: 'delivery-1',
+  }
+
+  const initial = await execute(executor, { workflowType: 'reconcileAtlasRepository', arguments: input })
+  expect(initial.completion).toBe('pending')
+
+  const runningUpsertCompleted = new Map<string, ActivityResolution>([
+    ['activity-0', { status: 'completed', value: { ingestionId: 'ingestion-1' } }],
+  ])
+  const reconciliationPending = await execute(executor, {
+    workflowType: 'reconcileAtlasRepository',
+    arguments: input,
+    determinismState: initial.determinismState,
+    activityResults: runningUpsertCompleted,
+  })
+
+  expect(reconciliationPending.completion).toBe('pending')
+  const pendingIntents = reconciliationPending.determinismState.commandHistory
+    .map((entry) => entry.intent)
+    .filter((intent) => intent.kind === 'schedule-activity')
+  expect(pendingIntents.map((intent) => intent.activityType)).toEqual(['upsertIngestion', 'reconcileAtlasRepository'])
+
+  const reconciliationResult = { repository: input.repository, ref: input.ref, commit: input.commit }
+  const reconciliationCompleted = await execute(executor, {
+    workflowType: 'reconcileAtlasRepository',
+    arguments: input,
+    determinismState: reconciliationPending.determinismState,
+    activityResults: new Map<string, ActivityResolution>([
+      ...runningUpsertCompleted,
+      ['activity-2', { status: 'completed', value: reconciliationResult }],
+    ]),
+  })
+
+  expect(reconciliationCompleted.completion).toBe('pending')
+  const completedIntent = reconciliationCompleted.determinismState.commandHistory[3]?.intent
+  expect(completedIntent?.kind).toBe('schedule-activity')
+  if (completedIntent?.kind !== 'schedule-activity') throw new Error('expected completed ingestion upsert')
+  expect(completedIntent.activityType).toBe('upsertIngestion')
+  expect(completedIntent.input).toEqual([
+    { deliveryId: input.eventDeliveryId, workflowId: 'test-workflow-id', status: 'completed' },
+  ])
+
+  const terminal = await execute(executor, {
+    workflowType: 'reconcileAtlasRepository',
+    arguments: input,
+    determinismState: reconciliationCompleted.determinismState,
+    activityResults: new Map<string, ActivityResolution>([
+      ...runningUpsertCompleted,
+      ['activity-2', { status: 'completed', value: reconciliationResult }],
+      ['activity-3', { status: 'completed', value: { ingestionId: 'ingestion-1' } }],
+    ]),
+  })
+
+  expect(terminal.completion).toBe('completed')
+  expect(terminal.result).toEqual(reconciliationResult)
+})
+
+test('reconcileAtlasRepository consumes the legacy failed upsert before correcting it', async () => {
+  const { executor } = makeExecutor()
+  const input = {
+    repoRoot: '/workspace/lab',
+    repository: 'proompteng/lab',
+    ref: 'main',
+    commit: 'abcdef1234567890abcdef1234567890abcdef1234',
+    eventDeliveryId: 'delivery-legacy',
+  }
+  const runningUpsertCompleted = new Map<string, ActivityResolution>([
+    ['activity-0', { status: 'completed', value: { ingestionId: 'ingestion-legacy' } }],
+  ])
+
+  const initial = await execute(executor, { workflowType: 'reconcileAtlasRepository', arguments: input })
+  const patchedPending = await execute(executor, {
+    workflowType: 'reconcileAtlasRepository',
+    arguments: input,
+    determinismState: initial.determinismState,
+    activityResults: runningUpsertCompleted,
+  })
+  const patchedReconcileIntent = patchedPending.determinismState.commandHistory
+    .map((entry) => entry.intent)
+    .find((intent) => intent.kind === 'schedule-activity' && intent.activityType === 'reconcileAtlasRepository')
+  if (patchedReconcileIntent?.kind !== 'schedule-activity') throw new Error('expected reconciliation intent')
+
+  const legacyReconcileIntent = {
+    ...patchedReconcileIntent,
+    id: 'schedule-activity-1',
+    sequence: 1,
+    activityId: 'activity-1',
+  }
+  const legacyPending = await execute(executor, {
+    workflowType: 'reconcileAtlasRepository',
+    arguments: input,
+    determinismState: {
+      ...initial.determinismState,
+      commandHistory: [...initial.determinismState.commandHistory, { intent: legacyReconcileIntent }],
+    },
+    activityResults: runningUpsertCompleted,
+  })
+
+  expect(legacyPending.completion).toBe('pending')
+  const legacyFailedIntent = legacyPending.determinismState.commandHistory[2]?.intent
+  expect(legacyFailedIntent?.kind).toBe('schedule-activity')
+  if (legacyFailedIntent?.kind !== 'schedule-activity') throw new Error('expected legacy failed ingestion upsert')
+  expect(legacyFailedIntent.input).toEqual([
+    {
+      deliveryId: input.eventDeliveryId,
+      workflowId: 'test-workflow-id',
+      status: 'failed',
+      error: 'Workflow blocked: Activity activity-1 pending',
+    },
+  ])
+
+  const reconciliationResult = { repository: input.repository, ref: input.ref, commit: input.commit }
+  const legacyCorrecting = await execute(executor, {
+    workflowType: 'reconcileAtlasRepository',
+    arguments: input,
+    determinismState: legacyPending.determinismState,
+    activityResults: new Map<string, ActivityResolution>([
+      ...runningUpsertCompleted,
+      ['activity-1', { status: 'completed', value: reconciliationResult }],
+      ['activity-2', { status: 'completed', value: { ingestionId: 'ingestion-legacy' } }],
+    ]),
+  })
+
+  expect(legacyCorrecting.completion).toBe('pending')
+  const correctedIntent = legacyCorrecting.determinismState.commandHistory[3]?.intent
+  expect(correctedIntent?.kind).toBe('schedule-activity')
+  if (correctedIntent?.kind !== 'schedule-activity') throw new Error('expected corrected ingestion upsert')
+  expect(correctedIntent.input).toEqual([
+    {
+      deliveryId: input.eventDeliveryId,
+      workflowId: 'test-workflow-id',
+      status: 'completed',
+      correctLegacyPendingFailure: true,
+    },
+  ])
+
+  const terminal = await execute(executor, {
+    workflowType: 'reconcileAtlasRepository',
+    arguments: input,
+    determinismState: legacyCorrecting.determinismState,
+    activityResults: new Map<string, ActivityResolution>([
+      ...runningUpsertCompleted,
+      ['activity-1', { status: 'completed', value: reconciliationResult }],
+      ['activity-2', { status: 'completed', value: { ingestionId: 'ingestion-legacy' } }],
+      ['activity-3', { status: 'completed', value: { ingestionId: 'ingestion-legacy' } }],
+    ]),
+  })
+
+  expect(terminal.completion).toBe('completed')
+  expect(terminal.result).toEqual(reconciliationResult)
+
+  const realFailure = new Error('real reconciliation failure')
+  const legacyFailing = await execute(executor, {
+    workflowType: 'reconcileAtlasRepository',
+    arguments: input,
+    determinismState: legacyPending.determinismState,
+    activityResults: new Map<string, ActivityResolution>([
+      ...runningUpsertCompleted,
+      ['activity-1', { status: 'failed', error: realFailure }],
+      ['activity-2', { status: 'completed', value: { ingestionId: 'ingestion-legacy' } }],
+    ]),
+  })
+
+  expect(legacyFailing.completion).toBe('pending')
+  const realFailureIntent = legacyFailing.determinismState.commandHistory[3]?.intent
+  expect(realFailureIntent?.kind).toBe('schedule-activity')
+  if (realFailureIntent?.kind !== 'schedule-activity') throw new Error('expected real failure ingestion upsert')
+  expect(realFailureIntent.input).toEqual([
+    {
+      deliveryId: input.eventDeliveryId,
+      workflowId: 'test-workflow-id',
+      status: 'failed',
+      error: realFailure.message,
+      correctLegacyPendingFailure: true,
+    },
+  ])
+
+  const failedTerminal = await execute(executor, {
+    workflowType: 'reconcileAtlasRepository',
+    arguments: input,
+    determinismState: legacyFailing.determinismState,
+    activityResults: new Map<string, ActivityResolution>([
+      ...runningUpsertCompleted,
+      ['activity-1', { status: 'failed', error: realFailure }],
+      ['activity-2', { status: 'completed', value: { ingestionId: 'ingestion-legacy' } }],
+      ['activity-3', { status: 'completed', value: { ingestionId: 'ingestion-legacy' } }],
+    ]),
+  })
+
+  expect(failedTerminal.completion).toBe('failed')
+  expect((failedTerminal.failure as Error).message).toContain(realFailure.message)
 })
 
 test('only the authoritative repository reconciliation workflow is registered for Atlas ingestion', () => {

--- a/services/bumba/src/workflows/index.ts
+++ b/services/bumba/src/workflows/index.ts
@@ -1,10 +1,11 @@
-import { defineWorkflow, log } from '@proompteng/temporal-bun-sdk/workflow'
+import { defineWorkflow, log, WorkflowBlockedError } from '@proompteng/temporal-bun-sdk/workflow'
 import { Effect } from 'effect'
 import * as Cause from 'effect/Cause'
 import * as Chunk from 'effect/Chunk'
 import * as Schema from 'effect/Schema'
 
 import type { ReconcileAtlasRepositoryInput, ReconcileAtlasRepositoryOutput } from '../activities/index'
+import { LEGACY_RECONCILE_PENDING_ERROR } from '../atlas/ingestion-status'
 import type { MainMergeMemoryNoteInput } from '../event-consumer'
 
 const activityRetry = {
@@ -18,6 +19,8 @@ const upsertIngestionTimeouts = {
   startToCloseTimeoutMs: 30_000,
   scheduleToCloseTimeoutMs: 900_000,
 }
+
+const reconcilePendingPatchId = 'reconcileAtlasRepository.preserve-pending.v1'
 
 const logWorkflow = (event: string, fields: Record<string, unknown> = {}) => {
   log.info('[bumba:workflow]', { event, ...fields })
@@ -35,6 +38,8 @@ const getCauseError = (cause: Cause.Cause<unknown>): Error | undefined => {
   }
   return undefined
 }
+
+const isWorkflowBlocked = (cause: Cause.Cause<unknown>): boolean => getCauseError(cause) instanceof WorkflowBlockedError
 
 const MainMergeMemoryNoteWorkflowInput = Schema.Struct({
   eventId: Schema.String,
@@ -80,31 +85,79 @@ export const workflows = [
       })
     }),
   ),
-  defineWorkflow('reconcileAtlasRepository', ReconcileAtlasRepositoryWorkflowInput, ({ input, activities, info }) =>
-    Effect.gen(function* () {
-      const eventDeliveryId = input.eventDeliveryId
-      if (eventDeliveryId) {
-        yield* activities.schedule(
-          'upsertIngestion',
-          [{ deliveryId: eventDeliveryId, workflowId: info.workflowId, status: 'running' }],
-          { ...upsertIngestionTimeouts, retry: activityRetry },
+  defineWorkflow(
+    'reconcileAtlasRepository',
+    ReconcileAtlasRepositoryWorkflowInput,
+    ({ input, activities, determinism, info }) =>
+      Effect.gen(function* () {
+        const eventDeliveryId = input.eventDeliveryId
+        if (eventDeliveryId) {
+          yield* activities.schedule(
+            'upsertIngestion',
+            [{ deliveryId: eventDeliveryId, workflowId: info.workflowId, status: 'running' }],
+            { ...upsertIngestionTimeouts, retry: activityRetry },
+          )
+        }
+
+        const preservePendingReconciliation = determinism.patched(reconcilePendingPatchId)
+
+        const reconcile = activities.schedule('reconcileAtlasRepository', [input as ReconcileAtlasRepositoryInput], {
+          startToCloseTimeoutMs: 24 * 60 * 60 * 1_000,
+          scheduleToCloseTimeoutMs: 3 * 24 * 60 * 60 * 1_000,
+          heartbeatTimeoutMs: 90_000,
+          retry: {
+            initialIntervalMs: 30_000,
+            backoffCoefficient: 2,
+            maximumIntervalMs: 15 * 60 * 1_000,
+          },
+        }) as Effect.Effect<ReconcileAtlasRepositoryOutput, unknown, never>
+
+        const result = yield* Effect.catchAllCause(reconcile, (cause) =>
+          Effect.gen(function* () {
+            const workflowBlocked = isWorkflowBlocked(cause)
+            if (preservePendingReconciliation && workflowBlocked) {
+              return yield* Effect.failCause(cause)
+            }
+            if (eventDeliveryId) {
+              if (!preservePendingReconciliation) {
+                yield* activities.schedule(
+                  'upsertIngestion',
+                  [
+                    {
+                      deliveryId: eventDeliveryId,
+                      workflowId: info.workflowId,
+                      status: 'failed',
+                      error: LEGACY_RECONCILE_PENDING_ERROR,
+                    },
+                  ],
+                  { ...upsertIngestionTimeouts, retry: activityRetry },
+                )
+              }
+              if (workflowBlocked) {
+                return yield* Effect.failCause(cause)
+              }
+              yield* activities.schedule(
+                'upsertIngestion',
+                [
+                  {
+                    deliveryId: eventDeliveryId,
+                    workflowId: info.workflowId,
+                    status: 'failed',
+                    error: getCauseError(cause)?.message,
+                    ...(preservePendingReconciliation ? {} : { correctLegacyPendingFailure: true }),
+                  },
+                ],
+                { ...upsertIngestionTimeouts, retry: activityRetry },
+              )
+            }
+            return yield* Effect.failCause(cause)
+          }),
         )
-      }
 
-      const reconcile = activities.schedule('reconcileAtlasRepository', [input as ReconcileAtlasRepositoryInput], {
-        startToCloseTimeoutMs: 24 * 60 * 60 * 1_000,
-        scheduleToCloseTimeoutMs: 3 * 24 * 60 * 60 * 1_000,
-        heartbeatTimeoutMs: 90_000,
-        retry: {
-          initialIntervalMs: 30_000,
-          backoffCoefficient: 2,
-          maximumIntervalMs: 15 * 60 * 1_000,
-        },
-      }) as Effect.Effect<ReconcileAtlasRepositoryOutput, unknown, never>
-
-      const result = yield* Effect.catchAllCause(reconcile, (cause) =>
-        Effect.gen(function* () {
-          if (eventDeliveryId) {
+        if (eventDeliveryId) {
+          if (!preservePendingReconciliation) {
+            // Pre-patch histories recorded this command while activity-1 was pending. Consume that command and its
+            // existing result before emitting the corrective completed upsert so those histories remain replayable.
             yield* activities.schedule(
               'upsertIngestion',
               [
@@ -112,25 +165,27 @@ export const workflows = [
                   deliveryId: eventDeliveryId,
                   workflowId: info.workflowId,
                   status: 'failed',
-                  error: getCauseError(cause)?.message,
+                  error: LEGACY_RECONCILE_PENDING_ERROR,
                 },
               ],
               { ...upsertIngestionTimeouts, retry: activityRetry },
             )
           }
-          return yield* Effect.failCause(cause)
-        }),
-      )
-
-      if (eventDeliveryId) {
-        yield* activities.schedule(
-          'upsertIngestion',
-          [{ deliveryId: eventDeliveryId, workflowId: info.workflowId, status: 'completed' }],
-          { ...upsertIngestionTimeouts, retry: activityRetry },
-        )
-      }
-      return result
-    }),
+          yield* activities.schedule(
+            'upsertIngestion',
+            [
+              {
+                deliveryId: eventDeliveryId,
+                workflowId: info.workflowId,
+                status: 'completed',
+                ...(preservePendingReconciliation ? {} : { correctLegacyPendingFailure: true }),
+              },
+            ],
+            { ...upsertIngestionTimeouts, retry: activityRetry },
+          )
+        }
+        return result
+      }),
   ),
 ]
 


### PR DESCRIPTION
## Summary

- keep new Atlas reconciliation workflows pending while their repository activity is still running
- version-gate the command stream and replay the recorded legacy pending command before either success or real failure
- narrowly replace only the exact synthetic legacy failure with the repository activity's completed or real-failed result
- keep that synthetic row nonterminal until correction and age it into a terminal stale failure if recovery never arrives
- preserve all other terminal failures and cover new, legacy-success, legacy-failure, and stale-escape paths

## Related Issues

None

## Testing

- `bun test services/bumba/src/workflows/index.test.ts` (5 passed)
- `bun run --filter @proompteng/bumba test` (78 passed, 3 environment-gated integration tests skipped locally)
- `bun run --filter @proompteng/bumba tsc`
- `bunx oxfmt --check services/bumba/src/activities/index.ts services/bumba/src/atlas/ingestion-status.ts services/bumba/src/atlas/reconciliation.integration.test.ts services/bumba/src/event-consumer.ts services/bumba/src/workflows/index.ts services/bumba/src/workflows/index.test.ts`
- `bunx oxlint --config .oxlintrc.json services/bumba/src/activities/index.ts services/bumba/src/atlas/ingestion-status.ts services/bumba/src/atlas/reconciliation.integration.test.ts services/bumba/src/event-consumer.ts services/bumba/src/workflows/index.ts services/bumba/src/workflows/index.test.ts`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.