### PR TITLE
fix(torghut): continue closeout after released preflight race

### DIFF
--- a/services/torghut/app/trading/scheduler/capital_controls.py
+++ b/services/torghut/app/trading/scheduler/capital_controls.py
@@ -18,6 +18,9 @@ from sqlalchemy.orm import Session
 
 from ...config import settings
 from ...models import PositionSnapshot
+from ..broker_mutation_submit_coordinator import (
+    BrokerMutationSubmissionPreflightFailed,
+)
 from ..execution_adapters import ExecutionAdapter, OrderSubmission
 from ..models import SignalEnvelope, StrategyDecision
 from ..prices import PriceFetcher
@@ -341,7 +344,15 @@ class CapitalSafetyController:
                         now=now,
                         attempt=attempt,
                     )
-                    self.execution_adapter.submit_risk_reducing_order(submission)
+                    try:
+                        self.execution_adapter.submit_risk_reducing_order(submission)
+                    except BrokerMutationSubmissionPreflightFailed:
+                        logger.info(
+                            "Capital closeout position changed before broker I/O; "
+                            "continuing account=%s symbol=%s",
+                            self.account_label,
+                            submission.symbol,
+                        )
                 self.state.capital_closeout_attempts = attempt
                 self.sleep(max(0.0, settings.trading_closeout_reprice_seconds))
 

--- a/services/torghut/tests/test_capital_controls.py
+++ b/services/torghut/tests/test_capital_controls.py
@@ -8,6 +8,9 @@ from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
 from app.config import settings
+from app.trading.broker_mutation_submit_coordinator import (
+    BrokerMutationSubmissionPreflightFailed,
+)
 from app.trading.prices import MarketSnapshot
 from app.trading.models import StrategyDecision
 from app.trading.scheduler.capital_controls import (
@@ -348,6 +351,47 @@ class TestCapitalSafetyController(TestCase):
         submission = adapter.submissions[0]
         self.assertEqual(submission.side, "buy")
         self.assertEqual(submission.qty, 2.0)
+
+    def test_closeout_continues_after_released_preflight_race(self) -> None:
+        adapter = _ExecutionAdapter(
+            [
+                {
+                    "symbol": "NVDA",
+                    "qty": "1",
+                    "side": "long",
+                    "current_price": "100",
+                },
+                {
+                    "symbol": "AMD",
+                    "qty": "2",
+                    "side": "long",
+                    "current_price": "100",
+                },
+            ]
+        )
+        submitted_symbols: list[str] = []
+
+        def submit(submission):
+            submitted_symbols.append(submission.symbol)
+            if submission.symbol == "NVDA":
+                adapter.positions = [adapter.positions[1]]
+                raise BrokerMutationSubmissionPreflightFailed(
+                    "risk_reduction_preflight_failed:position_disappeared"
+                )
+            adapter.positions = []
+            return {"id": "close-amd", "status": "accepted"}
+
+        adapter.submit_risk_reducing_order = submit
+        controller = self._controller(adapter)
+
+        controller._flatten(
+            reason="scheduled_closeout",
+            now=datetime(2026, 7, 10, 19, 45, tzinfo=ZoneInfo("UTC")),
+        )
+
+        self.assertEqual(submitted_symbols, ["NVDA", "AMD"])
+        self.assertFalse(controller.state.emergency_stop_active)
+        self.assertIsNotNone(controller.state.capital_flat_confirmed_at)
 
     def test_closeout_fails_closed_when_order_cancellation_is_not_confirmed(
         self,


### PR DESCRIPTION
## Summary

- Treat a closeout submission preflight failure as a released, no-broker-I/O race rather than a fatal flatten error.
- Continue submitting the remaining stale-position snapshot entries; each entry is independently revalidated at the submit boundary.
- Refresh positions on the next closeout attempt and confirm flat without adding a `closeout_error` latch.

## Related Issues

Resolves the actionable Codex finding in https://github.com/proompteng/lab/pull/12509#discussion_r3584932384 after merge.

## Testing

- `DB_DSN=sqlite+pysqlite:////tmp/torghut-capital-controls-test.db pytest -q tests/test_capital_controls.py --disable-warnings --maxfail=1` (13 passed)
- `python -m compileall -q app/trading/scheduler/capital_controls.py tests/test_capital_controls.py`
- Ruff format/check on both changed files
- Pyright profiles: default, alpha, scripts (0 errors each)
- `git diff --check origin/main...HEAD`

## Breaking Changes

None.

## Checklist

- [x] Exact validation is documented.
- [x] Screenshots are not applicable; breaking changes are stated.
- [x] Historical source thread will be replied to and resolved after merge.