### PR TITLE
fix(torghut): settle recovered linked submissions atomically

### DIFF
--- a/services/torghut/app/trading/alpaca_mutation_recovery.py
+++ b/services/torghut/app/trading/alpaca_mutation_recovery.py
@@ -7,7 +7,7 @@ import re
 from collections.abc import Mapping
 from datetime import datetime, timedelta
 from decimal import Decimal, InvalidOperation
-from typing import Literal, cast
+from typing import Literal, Protocol, cast
 
 from alpaca.common.exceptions import APIError, RetryException
 from requests.exceptions import RequestException
@@ -37,7 +37,7 @@ from .broker_mutation_recovery_worker import (
     BrokerMutationRecoveryRouteError,
     BrokerMutationRecoveryRead,
 )
-from .execution import OrderExecutor
+from .decision_submission_claims.types import DecisionSubmissionClaimHandle
 from .firewall import OrderFirewall
 from .risk_reduction import (
     BrokerPositionObservation,
@@ -77,6 +77,19 @@ _ALPACA_ACKNOWLEDGED_ORDER_STATUSES = frozenset(
 _ALPACA_REJECTED_ORDER_STATUSES = frozenset({"rejected"})
 
 
+class LinkedSubmissionRecoveryExecutor(Protocol):
+    """Executor surface required to persist one recovered linked order."""
+
+    def recover_linked_order_submission(
+        self,
+        *,
+        session: Session,
+        execution_client: object,
+        claim_handle: DecisionSubmissionClaimHandle,
+        order_response: Mapping[str, object],
+    ) -> Execution: ...
+
+
 class AlpacaMutationRecoveryRoute:
     """Alpaca recovery route that has no broker-mutation surface."""
 
@@ -87,7 +100,7 @@ class AlpacaMutationRecoveryRoute:
         *,
         client: TorghutAlpacaClient,
         firewall: OrderFirewall,
-        executor: OrderExecutor,
+        executor: LinkedSubmissionRecoveryExecutor,
         account_label: str,
         endpoint_url: str,
     ) -> None:
@@ -478,67 +491,12 @@ class AlpacaMutationRecoveryRoute:
     ) -> BrokerMutationSettlement:
         if receipt.intent.operation != "submit_order":
             return self._build_reduction_settlement(receipt, read)
-        order = read.broker_result
-        if not isinstance(order, Mapping):
-            raise ValueError("alpaca_recovery_found_order_required")
-        normalized = _validated_alpaca_order(receipt, order)
-        broker_status = cast(str, normalized["status"])
-        broker_reference = cast(str, normalized["broker_reference"])
-        submission_resolution = cast(str, normalized["submission_resolution"])
-        recovery_evidence = {
-            "schema_version": ALPACA_SUBMIT_RECOVERY_READ_SCHEMA_VERSION,
-            "resolution_state": submission_resolution,
-            "observation": dict(read.evidence),
-            "automatic_resubmission_attempted": False,
-        }
-        claim_handle = receipt.submission_claim_handle
-        if claim_handle is not None:
-            if submission_resolution == "rejected":
-                return build_linked_submission_terminal_settlement(
-                    BrokerMutationLinkedSubmissionSettlementRequest(
-                        source="recovery",
-                        outcome="rejected",
-                        claim_handle=claim_handle,
-                        broker_status=broker_status,
-                        rejection_code="broker_rejected",
-                        broker_reference=None,
-                        execution_id=None,
-                        recovery_evidence_payload=recovery_evidence,
-                    )
-                )
-            execution = self._executor.recover_linked_order_submission(
-                session=session,
-                execution_client=self._firewall,
-                claim_handle=claim_handle,
-                order_response=order,
-            )
-            return build_linked_submission_terminal_settlement(
-                BrokerMutationLinkedSubmissionSettlementRequest(
-                    source="recovery",
-                    outcome="reconciled",
-                    claim_handle=claim_handle,
-                    broker_status=broker_status,
-                    rejection_code=None,
-                    broker_reference=broker_reference,
-                    execution_id=execution.id,
-                    recovery_evidence_payload=recovery_evidence,
-                )
-            )
-        return build_broker_mutation_settlement(
-            BrokerMutationSettlementRequest(
-                source="recovery",
-                outcome=(
-                    "rejected" if submission_resolution == "rejected" else "reconciled"
-                ),
-                broker_reference=broker_reference,
-                execution_id=None,
-                evidence_payload={
-                    "route": self.broker_route,
-                    "client_order_id": receipt.intent.client_request_id,
-                    "broker_status": broker_status,
-                    **recovery_evidence,
-                },
-            )
+        return build_alpaca_found_settlement(
+            session,
+            receipt,
+            read,
+            executor=self._executor,
+            firewall=self._firewall,
         )
 
     def _build_reduction_settlement(
@@ -631,6 +589,80 @@ class AlpacaMutationRecoveryRoute:
                 exact_lookup == "not_found" and history_complete and match_count == 0
             ),
         }
+
+
+def build_alpaca_found_settlement(
+    session: Session,
+    receipt: BrokerMutationReceiptSnapshot,
+    read: BrokerMutationRecoveryRead,
+    *,
+    executor: LinkedSubmissionRecoveryExecutor,
+    firewall: OrderFirewall,
+) -> BrokerMutationSettlement:
+    """Persist and describe one validated Alpaca submission recovery observation."""
+
+    order = read.broker_result
+    if not isinstance(order, Mapping):
+        raise ValueError("alpaca_recovery_found_order_required")
+    normalized = _validated_alpaca_order(receipt, order)
+    broker_status = cast(str, normalized["status"])
+    broker_reference = cast(str, normalized["broker_reference"])
+    submission_resolution = cast(str, normalized["submission_resolution"])
+    recovery_evidence = {
+        "schema_version": ALPACA_SUBMIT_RECOVERY_READ_SCHEMA_VERSION,
+        "resolution_state": submission_resolution,
+        "observation": dict(read.evidence),
+        "automatic_resubmission_attempted": False,
+    }
+    claim_handle = receipt.submission_claim_handle
+    if claim_handle is not None:
+        if submission_resolution == "rejected":
+            return build_linked_submission_terminal_settlement(
+                BrokerMutationLinkedSubmissionSettlementRequest(
+                    source="recovery",
+                    outcome="rejected",
+                    claim_handle=claim_handle,
+                    broker_status=broker_status,
+                    rejection_code="broker_rejected",
+                    broker_reference=None,
+                    execution_id=None,
+                    recovery_evidence_payload=recovery_evidence,
+                )
+            )
+        execution = executor.recover_linked_order_submission(
+            session=session,
+            execution_client=firewall,
+            claim_handle=claim_handle,
+            order_response=order,
+        )
+        return build_linked_submission_terminal_settlement(
+            BrokerMutationLinkedSubmissionSettlementRequest(
+                source="recovery",
+                outcome="reconciled",
+                claim_handle=claim_handle,
+                broker_status=broker_status,
+                rejection_code=None,
+                broker_reference=broker_reference,
+                execution_id=execution.id,
+                recovery_evidence_payload=recovery_evidence,
+            )
+        )
+    return build_broker_mutation_settlement(
+        BrokerMutationSettlementRequest(
+            source="recovery",
+            outcome=(
+                "rejected" if submission_resolution == "rejected" else "reconciled"
+            ),
+            broker_reference=broker_reference,
+            execution_id=None,
+            evidence_payload={
+                "route": "alpaca",
+                "client_order_id": receipt.intent.client_request_id,
+                "broker_status": broker_status,
+                **recovery_evidence,
+            },
+        )
+    )
 
 
 def _required_string_set(value: object, *, field: str) -> set[str]:
@@ -791,4 +823,6 @@ def _optional_decimal(value: object) -> Decimal | None:
 __all__ = [
     "ALPACA_SUBMIT_RECOVERY_READ_SCHEMA_VERSION",
     "AlpacaMutationRecoveryRoute",
+    "LinkedSubmissionRecoveryExecutor",
+    "build_alpaca_found_settlement",
 ]

--- a/services/torghut/app/trading/broker_mutation_recovery_worker.py
+++ b/services/torghut/app/trading/broker_mutation_recovery_worker.py
@@ -232,6 +232,12 @@ def _recovery_writer_identity(component: str) -> tuple[str, int]:
     )
 
 
+def broker_mutation_recovery_writer_identity(component: str) -> tuple[str, int]:
+    """Return one process-unique writer identity for direct fenced recovery."""
+
+    return _recovery_writer_identity(component)
+
+
 class BrokerMutationRecoveryWorker:
     """Recover due mutation receipts using reads only; this class cannot mutate."""
 
@@ -658,4 +664,5 @@ __all__ = [
     "BrokerMutationRecoveryRunResult",
     "BrokerMutationRecoveryWorker",
     "BrokerMutationRecoveryRead",
+    "broker_mutation_recovery_writer_identity",
 ]

--- a/services/torghut/app/trading/execution/durable_existing_order_recovery.py
+++ b/services/torghut/app/trading/execution/durable_existing_order_recovery.py
@@ -1,0 +1,396 @@
+"""Fenced recovery for broker-observed orders with durable linked submissions."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import cast
+
+from sqlalchemy import select, text
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from ...models import BrokerMutationReceipt, Execution, TradeDecision
+from ..alpaca_mutation_recovery import (
+    ALPACA_SUBMIT_RECOVERY_READ_SCHEMA_VERSION,
+    LinkedSubmissionRecoveryExecutor,
+    build_alpaca_found_settlement,
+)
+from ..broker_mutation_receipts import (
+    BrokerMutationReceiptSnapshot,
+    BrokerMutationRecoveryAcquireOptions,
+    BrokerMutationRecoveryHandle,
+    acquire_broker_mutation_recovery,
+    fingerprint_broker_endpoint,
+    get_broker_mutation_receipt,
+    release_broker_mutation_recovery,
+    settle_linked_submission_recovery,
+)
+from ..broker_mutation_recovery_worker import (
+    BrokerMutationRecoveryRead,
+    broker_mutation_recovery_writer_identity,
+)
+from ..broker_mutation_coordinator import BrokerMutationDeferred
+from ..decision_submission_claims import (
+    DecisionSubmissionRecoveryHandle,
+    acquire_decision_submission_recovery_claim,
+)
+from ..firewall import OrderFirewall
+from .durable_existing_order_rejection import stage_broker_rejected_decision
+
+
+logger = logging.getLogger(__name__)
+_RECOVERY_LEASE_SECONDS = 60
+_RECOVERY_OWNER, _RECOVERY_WRITER_GENERATION = broker_mutation_recovery_writer_identity(
+    "order-executor"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class DurableExistingOrderRecoveryRequest:
+    executor: LinkedSubmissionRecoveryExecutor
+    session: Session
+    firewall: OrderFirewall
+    decision_row: TradeDecision
+    account_label: str
+    existing_orders: Sequence[Mapping[str, object]]
+
+
+@dataclass(frozen=True, slots=True)
+class DurableExistingOrderRecoveryResult:
+    """Whether an existing order was handled and the recovered execution, if any."""
+
+    handled: bool
+    execution: Execution | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _DurableRecoveryContext:
+    request: DurableExistingOrderRecoveryRequest
+    receipt_id: uuid.UUID
+    order_response: Mapping[str, object]
+
+
+@dataclass(frozen=True, slots=True)
+class _LinkedRecoveryLeases:
+    receipt: BrokerMutationReceiptSnapshot
+    receipt_handle: BrokerMutationRecoveryHandle
+    claim_handle: DecisionSubmissionRecoveryHandle
+
+
+def recover_durable_linked_existing_order(
+    request: DurableExistingOrderRecoveryRequest,
+) -> DurableExistingOrderRecoveryResult:
+    """Settle a broker-observed linked submit or defer it to fenced recovery.
+
+    Returns ``False`` only when no durable linked receipt exists, allowing the
+    caller to retain the legacy backfill path for pre-receipt orders.
+    """
+
+    context = _resolve_recovery_context(request)
+    if context is None:
+        return DurableExistingOrderRecoveryResult(handled=False)
+    receipt = get_broker_mutation_receipt(request.session, context.receipt_id)
+    if receipt is None:  # pragma: no cover - immutable header was just observed
+        raise RuntimeError("linked_submission_recovery_receipt_not_found")
+    if receipt.state == "settled":
+        execution = _restore_settled_recovery_state(context, receipt)
+        return DurableExistingOrderRecoveryResult(
+            handled=True,
+            execution=execution,
+        )
+    if receipt.state != "broker_io":
+        raise RuntimeError(
+            "linked_submission_existing_order_without_broker_io:"
+            f"{request.decision_row.id}:{receipt.state}"
+        )
+    leases = _acquire_linked_recovery_leases(context)
+    execution = _settle_observed_order(context, leases)
+    return DurableExistingOrderRecoveryResult(
+        handled=True,
+        execution=execution,
+    )
+
+
+def _resolve_recovery_context(
+    request: DurableExistingOrderRecoveryRequest,
+) -> _DurableRecoveryContext | None:
+    endpoint_fingerprint = fingerprint_broker_endpoint(
+        request.firewall.broker_endpoint_url
+    )
+    receipt_id = request.session.execute(
+        select(BrokerMutationReceipt.id).where(
+            BrokerMutationReceipt.submission_claim_id == request.decision_row.id,
+            BrokerMutationReceipt.broker_route == "alpaca",
+            BrokerMutationReceipt.operation == "submit_order",
+            BrokerMutationReceipt.account_label == request.account_label,
+            BrokerMutationReceipt.endpoint_fingerprint == endpoint_fingerprint,
+            BrokerMutationReceipt.client_request_id
+            == request.decision_row.decision_hash,
+        )
+    ).scalar_one_or_none()
+    request.session.rollback()
+    if receipt_id is None:
+        foreign_receipt_id = request.session.execute(
+            select(BrokerMutationReceipt.id)
+            .where(
+                BrokerMutationReceipt.submission_claim_id == request.decision_row.id,
+                BrokerMutationReceipt.broker_route == "alpaca",
+                BrokerMutationReceipt.operation == "submit_order",
+                BrokerMutationReceipt.account_label == request.account_label,
+                BrokerMutationReceipt.client_request_id
+                == request.decision_row.decision_hash,
+            )
+            .limit(1)
+        ).scalar_one_or_none()
+        request.session.rollback()
+        if foreign_receipt_id is not None:
+            raise RuntimeError(
+                "linked_submission_recovery_endpoint_mismatch:"
+                f"{request.decision_row.id}:{endpoint_fingerprint}"
+            )
+        return None
+    if len(request.existing_orders) != 1:
+        raise RuntimeError(
+            "linked_submission_recovery_existing_order_count_invalid:"
+            f"{request.decision_row.id}:{len(request.existing_orders)}"
+        )
+    return _DurableRecoveryContext(
+        request=request,
+        receipt_id=receipt_id,
+        order_response=request.existing_orders[0],
+    )
+
+
+def _restore_settled_recovery_state(
+    context: _DurableRecoveryContext,
+    receipt: BrokerMutationReceiptSnapshot,
+) -> Execution | None:
+    if receipt.settlement.outcome == "rejected":
+        stage_broker_rejected_decision(
+            context.request.session,
+            decision_row=context.request.decision_row,
+            account_label=context.request.account_label,
+        )
+        context.request.session.commit()
+        execution = None
+    else:
+        execution = _load_recovered_execution(
+            context.request.session,
+            execution_id=receipt.settlement.execution_id,
+            required=receipt.settlement.outcome in {"acknowledged", "reconciled"},
+        )
+    logger.info(
+        "Durable linked submission already settled decision_id=%s receipt_id=%s",
+        context.request.decision_row.id,
+        context.receipt_id,
+    )
+    return execution
+
+
+def _acquire_linked_recovery_leases(
+    context: _DurableRecoveryContext,
+) -> _LinkedRecoveryLeases:
+    request = context.request
+    recovery_token = uuid.uuid4()
+    acquired_receipt = acquire_broker_mutation_recovery(
+        request.session,
+        receipt_id=context.receipt_id,
+        recovery_owner=_RECOVERY_OWNER,
+        writer_generation=_RECOVERY_WRITER_GENERATION,
+        options=BrokerMutationRecoveryAcquireOptions(
+            recovery_token=recovery_token,
+            lease_seconds=_RECOVERY_LEASE_SECONDS,
+        ),
+    )
+    if not acquired_receipt.acquired or acquired_receipt.receipt is None:
+        logger.info(
+            "Deferred durable linked existing-order recovery decision_id=%s "
+            "receipt_id=%s outcome=%s",
+            request.decision_row.id,
+            context.receipt_id,
+            acquired_receipt.outcome,
+        )
+        raise BrokerMutationDeferred(
+            "linked_submission_existing_order_recovery_deferred:"
+            f"{request.decision_row.id}:receipt:{acquired_receipt.outcome}"
+        )
+    receipt = acquired_receipt.receipt
+    receipt_handle = receipt.recovery_handle
+    if receipt_handle is None:  # pragma: no cover - acquired result contract
+        raise RuntimeError("linked_submission_recovery_receipt_handle_missing")
+
+    acquired_claim = acquire_decision_submission_recovery_claim(
+        request.session,
+        decision_id=request.decision_row.id,
+        recovery_owner=_RECOVERY_OWNER,
+        recovery_token=recovery_token,
+        lease_seconds=_RECOVERY_LEASE_SECONDS,
+    )
+    if not acquired_claim.acquired or acquired_claim.claim is None:
+        release_broker_mutation_recovery(request.session, handle=receipt_handle)
+        logger.info(
+            "Deferred durable linked existing-order recovery decision_id=%s "
+            "receipt_id=%s claim_outcome=%s",
+            request.decision_row.id,
+            context.receipt_id,
+            acquired_claim.outcome,
+        )
+        raise BrokerMutationDeferred(
+            "linked_submission_existing_order_recovery_deferred:"
+            f"{request.decision_row.id}:claim:{acquired_claim.outcome}"
+        )
+    claim_handle = acquired_claim.claim.recovery_handle
+    if claim_handle is None:  # pragma: no cover - acquired result contract
+        release_broker_mutation_recovery(request.session, handle=receipt_handle)
+        raise RuntimeError("linked_submission_recovery_claim_handle_missing")
+    return _LinkedRecoveryLeases(
+        receipt=receipt,
+        receipt_handle=receipt_handle,
+        claim_handle=claim_handle,
+    )
+
+
+def _settle_observed_order(
+    context: _DurableRecoveryContext,
+    leases: _LinkedRecoveryLeases,
+) -> Execution | None:
+    request = context.request
+    read = BrokerMutationRecoveryRead(
+        outcome="found",
+        broker_result=dict(context.order_response),
+        evidence={
+            "schema_version": ALPACA_SUBMIT_RECOVERY_READ_SCHEMA_VERSION,
+            "route": "alpaca",
+            "exact_client_order_lookup": "found",
+            "history_status": "all",
+            "history_limit": 1,
+            "history_count": 0,
+            "history_complete": False,
+            "history_match_count": 1,
+            "absence_proof_complete": False,
+            "recovery_entrypoint": "order_executor_existing_order",
+        },
+    )
+    try:
+        settlement = build_alpaca_found_settlement(
+            request.session,
+            leases.receipt,
+            read,
+            executor=request.executor,
+            firewall=request.firewall,
+        )
+        if settlement.outcome == "rejected":
+            stage_broker_rejected_decision(
+                request.session,
+                decision_row=request.decision_row,
+                account_label=request.account_label,
+            )
+        execution = _load_recovered_execution(
+            request.session,
+            execution_id=settlement.execution_id,
+            required=settlement.outcome in {"acknowledged", "reconciled"},
+        )
+        terminal = settle_linked_submission_recovery(
+            request.session,
+            handle=leases.receipt_handle,
+            submission_recovery_handle=leases.claim_handle,
+            settlement=settlement,
+        )
+    except (SQLAlchemyError, TypeError, ValueError, RuntimeError):
+        request.session.rollback()
+        raise
+    logger.info(
+        "Recovered durable linked existing order decision_id=%s receipt_id=%s "
+        "result=%s",
+        request.decision_row.id,
+        context.receipt_id,
+        terminal.runtime_result,
+    )
+    return execution
+
+
+def _load_recovered_execution(
+    session: Session,
+    *,
+    execution_id: uuid.UUID | None,
+    required: bool,
+) -> Execution | None:
+    if execution_id is None:
+        if required:
+            raise RuntimeError("linked_submission_recovery_execution_missing")
+        return None
+    identity_key = session.identity_key(Execution, execution_id)
+    execution = session.identity_map.get(identity_key)
+    if execution is not None:
+        return cast(Execution, execution)
+
+    available_columns = set(
+        session.execute(
+            text(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_schema = current_schema() AND table_name = 'executions'"
+            )
+        ).scalars()
+    )
+    projection_columns = [
+        column
+        for column in (
+            "id",
+            "alpaca_order_id",
+            "status",
+            "filled_qty",
+            "raw_order",
+            "execution_audit_json",
+            "execution_actual_adapter",
+            "execution_expected_adapter",
+            "execution_fallback_reason",
+            "execution_fallback_count",
+            "execution_correlation_id",
+            "execution_idempotency_key",
+        )
+        if column in available_columns
+    ]
+    if "id" not in projection_columns:
+        if required:
+            raise RuntimeError("linked_submission_recovery_execution_schema_missing")
+        return None
+    row = (
+        session.execute(
+            text(
+                f"SELECT {', '.join(projection_columns)} FROM executions "
+                "WHERE id = :execution_id"
+            ),
+            {"execution_id": execution_id},
+        )
+        .mappings()
+        .one_or_none()
+    )
+    if row is None:
+        raise RuntimeError("linked_submission_recovery_execution_not_found")
+    payload: dict[str, object] = {
+        "id": execution_id,
+        "alpaca_order_id": None,
+        "status": "",
+        "filled_qty": None,
+        "raw_order": {},
+        "execution_audit_json": {},
+        "execution_actual_adapter": None,
+        "execution_expected_adapter": None,
+        "execution_fallback_reason": None,
+        "execution_fallback_count": 0,
+        "execution_correlation_id": None,
+        "execution_idempotency_key": None,
+    }
+    payload.update(dict(row))
+    return cast(Execution, SimpleNamespace(**payload))
+
+
+__all__ = [
+    "DurableExistingOrderRecoveryRequest",
+    "DurableExistingOrderRecoveryResult",
+    "recover_durable_linked_existing_order",
+]

--- a/services/torghut/app/trading/execution/durable_existing_order_rejection.py
+++ b/services/torghut/app/trading/execution/durable_existing_order_rejection.py
@@ -1,0 +1,49 @@
+"""Decision-state staging for durable existing-order rejection recovery."""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from ...models import TradeDecision
+from .order_executor_core_support import (
+    coerce_json,
+    coerce_string_list,
+    merge_unique_strings,
+    normalize_reject_reasons,
+)
+
+
+_BROKER_REJECTED_REASON = "broker_rejected"
+
+
+def stage_broker_rejected_decision(
+    session: Session,
+    *,
+    decision_row: TradeDecision,
+    account_label: str,
+) -> None:
+    """Stage durable broker-rejection metadata without committing the session."""
+
+    decision_json = coerce_json(decision_row.decision_json)
+    decision_json["submission_stage"] = "rejected"
+    decision_json["risk_reasons"] = merge_unique_strings(
+        coerce_string_list(decision_json.get("risk_reasons")),
+        [_BROKER_REJECTED_REASON],
+    )
+    normalized_reasons = normalize_reject_reasons(_BROKER_REJECTED_REASON)
+    reject_atomic = merge_unique_strings(
+        coerce_string_list(decision_json.get("reject_reason_atomic")),
+        [normalized.atomic_reason for normalized in normalized_reasons],
+    )
+    if reject_atomic:
+        primary = normalized_reasons[0]
+        decision_json["reject_reason_atomic"] = reject_atomic
+        decision_json["reject_class"] = primary.reject_class
+        decision_json["reject_origin"] = primary.reject_origin
+    decision_row.status = "rejected"
+    decision_row.alpaca_account_label = account_label
+    decision_row.decision_json = decision_json
+    session.add(decision_row)
+
+
+__all__ = ["stage_broker_rejected_decision"]

--- a/services/torghut/app/trading/execution/order_executor_core_methods.py
+++ b/services/torghut/app/trading/execution/order_executor_core_methods.py
@@ -12,12 +12,7 @@ from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.orm import Session
 
-from ...models import (
-    Execution,
-    Strategy,
-    TradeDecision,
-    coerce_json_payload,
-)
+from ...models import Execution, Strategy, TradeDecision, coerce_json_payload
 from ...config import settings
 from ...snapshots import link_pending_order_feed_events, sync_order_to_db
 from ..route_metadata import resolve_order_route_metadata
@@ -41,13 +36,8 @@ from .order_lifecycle import (
     fetch_existing_orders,
 )
 from . import durable_existing_order_recovery as durable_recovery
-from ..quantity_rules import (
-    min_qty_for_symbol,
-    quantize_qty_for_symbol,
-)
-from ..simulation import (
-    resolve_event_persisted_at,
-)
+from ..quantity_rules import min_qty_for_symbol, quantize_qty_for_symbol
+from ..simulation import resolve_event_persisted_at
 from ..tca import upsert_execution_tca_metric
 
 from .shared_context import (
@@ -633,7 +623,11 @@ class _OrderExecutorCoreMethods(_OrderExecutorCoreBase):
             _attach_execution_policy_context(execution, execution_policy_context)
             upsert_execution_tca_metric(session, execution)
             _apply_execution_status(decision_row, execution, account_label)
-            recovered_execution = execution
+            if recovered_execution is None or (
+                (_optional_decimal(execution.filled_qty) or Decimal("0"))
+                >= (_optional_decimal(recovered_execution.filled_qty) or Decimal("0"))
+            ):
+                recovered_execution = execution
         session.add(decision_row)
         session.commit()
         logger.info(

--- a/services/torghut/app/trading/execution/order_executor_core_methods.py
+++ b/services/torghut/app/trading/execution/order_executor_core_methods.py
@@ -40,6 +40,7 @@ from .order_lifecycle import (
     HISTORICAL_LIVE_ORDER_ATTEMPT_SCAN_LIMIT,
     fetch_existing_orders,
 )
+from . import durable_existing_order_recovery as durable_recovery
 from ..quantity_rules import (
     min_qty_for_symbol,
     quantize_qty_for_symbol,
@@ -48,7 +49,6 @@ from ..simulation import (
     resolve_event_persisted_at,
 )
 from ..tca import upsert_execution_tca_metric
-
 
 from .shared_context import (
     OrderExecutorContract as _OrderExecutorContract,
@@ -216,16 +216,19 @@ class _OrderExecutorCoreMethods(_OrderExecutorCoreBase):
         execution_policy_context = _extract_execution_policy_context(
             decision, decision_row=decision_row
         )
-        if self._sync_existing_order_if_present(
-            session=session,
-            execution_client=execution_client,
-            decision=decision,
-            decision_row=decision_row,
-            account_label=account_label,
-            execution_expected_adapter=execution_expected_adapter,
-            execution_policy_context=execution_policy_context,
-        ):
-            return None
+        existing_order_handled, existing_execution = (
+            self._sync_existing_order_if_present(
+                session=session,
+                execution_client=execution_client,
+                decision=decision,
+                decision_row=decision_row,
+                account_label=account_label,
+                execution_expected_adapter=execution_expected_adapter,
+                execution_policy_context=execution_policy_context,
+            )
+        )
+        if existing_order_handled:
+            return existing_execution
 
         prepared = self._prepare_order_submission(
             _OrderPreparationInputs(
@@ -586,7 +589,7 @@ class _OrderExecutorCoreMethods(_OrderExecutorCoreBase):
         account_label: str,
         execution_expected_adapter: Optional[str],
         execution_policy_context: dict[str, Any],
-    ) -> bool:
+    ) -> tuple[bool, Execution | None]:
         existing_orders = fetch_existing_orders(
             execution_client,
             decision_row.decision_hash,
@@ -597,7 +600,21 @@ class _OrderExecutorCoreMethods(_OrderExecutorCoreBase):
             ),
         )
         if not existing_orders:
-            return False
+            return False, None
+        if isinstance(execution_client, OrderFirewall):
+            recovery = durable_recovery.recover_durable_linked_existing_order(
+                durable_recovery.DurableExistingOrderRecoveryRequest(
+                    executor=cast(Any, self),
+                    session=session,
+                    firewall=execution_client,
+                    decision_row=decision_row,
+                    account_label=account_label,
+                    existing_orders=existing_orders,
+                )
+            )
+            if recovery.handled:
+                return True, recovery.execution
+        recovered_execution: Execution | None = None
         for existing_order in existing_orders:
             existing_payload = _order_payload_with_execution_metadata(
                 existing_order,
@@ -616,6 +633,7 @@ class _OrderExecutorCoreMethods(_OrderExecutorCoreBase):
             _attach_execution_policy_context(execution, execution_policy_context)
             upsert_execution_tca_metric(session, execution)
             _apply_execution_status(decision_row, execution, account_label)
+            recovered_execution = execution
         session.add(decision_row)
         session.commit()
         logger.info(
@@ -623,7 +641,7 @@ class _OrderExecutorCoreMethods(_OrderExecutorCoreBase):
             len(existing_orders),
             decision_row.id,
         )
-        return True
+        return True, recovered_execution
 
     def _raise_if_conflicting_open_order(
         self,

--- a/services/torghut/app/trading/scheduler/pipeline/runtime_gates.py
+++ b/services/torghut/app/trading/scheduler/pipeline/runtime_gates.py
@@ -56,7 +56,13 @@ from .support import (
 )
 
 
-_TERMINAL_ORDER_STATUSES = {"canceled", "cancelled", "expired", "rejected"}
+_TERMINAL_ORDER_STATUSES = {
+    "canceled",
+    "cancelled",
+    "done_for_day",
+    "expired",
+    "rejected",
+}
 
 
 def terminal_unfilled_execution_reason(execution: object) -> str | None:
@@ -377,6 +383,8 @@ class TradingPipelineRuntimeGatesMixin(TradingPipelineRuntime):
                 self.account_label,
                 execution_expected_adapter=request.selected_adapter_name,
             )
+            if execution is None and request.decision_row.status == "rejected":
+                return self._handle_recovered_submission_rejection(request=request)
             terminal_reason = terminal_unfilled_execution_reason(execution)
             if terminal_reason is not None:
                 return self._handle_terminal_unfilled_execution(
@@ -404,6 +412,39 @@ class TradingPipelineRuntimeGatesMixin(TradingPipelineRuntime):
                 request=request,
                 exc=exc,
             )
+
+    def _handle_recovered_submission_rejection(
+        self,
+        *,
+        request: OrderSubmissionRequest,
+    ) -> tuple[None, bool]:
+        reason = "broker_rejected"
+        self.state.metrics.orders_rejected_total += 1
+        self.state.metrics.record_decision_state("rejected")
+        self.state.metrics.record_decision_rejection_reasons([reason])
+        self.state.metrics.record_execution_submit_result(
+            status="rejected",
+            adapter=request.selected_adapter_name,
+        )
+        self._emit_domain_telemetry(
+            DomainTelemetryEvent(
+                event_name="torghut.execution.rejected",
+                severity="warning",
+                decision=request.decision,
+                decision_row=request.decision_row,
+                reason_codes=[reason],
+                extra_properties={
+                    "rejection_type": "recovered_broker_rejection",
+                },
+            )
+        )
+        logger.warning(
+            "Recovered broker rejection strategy_id=%s decision_id=%s symbol=%s",
+            request.decision.strategy_id,
+            request.decision_row.id,
+            request.decision.symbol,
+        )
+        return None, True
 
     def _handle_terminal_unfilled_execution(
         self,

--- a/services/torghut/tests/execution/test_broker_mutation_linked_receipts_postgres.py
+++ b/services/torghut/tests/execution/test_broker_mutation_linked_receipts_postgres.py
@@ -28,6 +28,7 @@ from app.trading.broker_mutation_receipts import (
     acquire_broker_mutation_recovery,
     acquire_broker_mutation_receipt,
     build_broker_mutation_settlement,
+    fingerprint_broker_endpoint,
     get_broker_mutation_receipt_history,
     mark_broker_mutation_io_started,
     renew_broker_mutation_receipt,
@@ -278,14 +279,25 @@ def create_linked_submit_fixture(schema_engine: Engine) -> LinkedSubmitFixture:
         BrokerMutationIntentRequest(
             broker_route="alpaca",
             account_label="paper",
-            endpoint_fingerprint="a" * 64,
+            endpoint_fingerprint=fingerprint_broker_endpoint(
+                "https://paper-api.alpaca.markets"
+            ),
             operation="submit_order",
             risk_class="risk_increasing",
             purpose="initial_submission",
             workflow_id="workflow-linked",
             client_request_id=client_request_id,
             target=BrokerMutationTarget(kind="order", key=client_request_id),
-            request_payload={"symbol": "AAPL", "qty": Decimal("1")},
+            request_payload={
+                "symbol": "AAPL",
+                "side": "buy",
+                "qty": Decimal("1"),
+                "order_type": "market",
+                "time_in_force": "day",
+                "limit_price": None,
+                "stop_price": None,
+                "extra_params": {"client_order_id": client_request_id},
+            },
             submission_claim_id=decision_id,
         )
     )

--- a/services/torghut/tests/execution/test_linked_submission_recovery_postgres.py
+++ b/services/torghut/tests/execution/test_linked_submission_recovery_postgres.py
@@ -1,14 +1,20 @@
 from __future__ import annotations
 
 import uuid
+from collections.abc import Mapping
 from dataclasses import replace
 from datetime import timedelta
+from types import SimpleNamespace
+from typing import cast
 
 import pytest
 from alembic import command
 from sqlalchemy import text
 from sqlalchemy.exc import DBAPIError
+from sqlalchemy.orm import Session
 
+from app.models import Execution, TradeDecision
+from app.trading.alpaca_mutation_recovery import LinkedSubmissionRecoveryExecutor
 from app.trading.broker_mutation_receipts import (
     BrokerMutationLinkedSubmissionSettlementRequest,
     BrokerMutationReceiptAcquireResult,
@@ -26,8 +32,14 @@ from app.trading.broker_mutation_receipts import (
     settle_linked_submission_recovery,
 )
 from app.trading.decision_submission_claims import (
+    DecisionSubmissionClaimHandle,
     acquire_decision_submission_recovery_claim,
 )
+from app.trading.execution.durable_existing_order_recovery import (
+    DurableExistingOrderRecoveryRequest,
+    recover_durable_linked_existing_order,
+)
+from app.trading.firewall import OrderFirewall
 from app.trading.broker_mutation_receipts.persistence import (
     append_full_state_event,
     full_state_values_from_event,
@@ -50,6 +62,80 @@ from tests.execution.test_linked_submission_terminal_postgres import (
 )
 
 __all__ = ("terminal_harness",)
+
+
+def _recovery_firewall() -> OrderFirewall:
+    return cast(
+        OrderFirewall,
+        SimpleNamespace(
+            broker_endpoint_url="https://paper-api.alpaca.markets",
+        ),
+    )
+
+
+class _ObservedOrderExecutor:
+    def __init__(self, *, fail_after_insert: bool = False) -> None:
+        self.calls = 0
+        self._fail_after_insert = fail_after_insert
+
+    def recover_linked_order_submission(
+        self,
+        *,
+        session: Session,
+        execution_client: object,
+        claim_handle: DecisionSubmissionClaimHandle,
+        order_response: Mapping[str, object],
+    ) -> Execution:
+        _ = execution_client
+        self.calls += 1
+        execution_id = uuid.uuid4()
+        session.execute(
+            text(
+                """
+                INSERT INTO executions (
+                    id, trade_decision_id, alpaca_account_label,
+                    client_order_id, alpaca_order_id, status
+                ) VALUES (
+                    :execution_id, :decision_id, 'paper',
+                    :client_order_id, :broker_order_id, :status
+                )
+                """
+            ),
+            {
+                "execution_id": execution_id,
+                "decision_id": claim_handle.decision_id,
+                "client_order_id": claim_handle.client_order_id,
+                "broker_order_id": order_response["id"],
+                "status": str(order_response.get("status") or "accepted"),
+            },
+        )
+        if self._fail_after_insert:
+            raise RuntimeError("injected_after_execution_insert")
+        return cast(Execution, SimpleNamespace(id=execution_id))
+
+
+def _observed_order(fixture: LinkedSubmitFixture) -> dict[str, object]:
+    return {
+        "id": "recovered-existing-order",
+        "client_order_id": fixture.claim_handle.client_order_id,
+        "symbol": "AAPL",
+        "side": "buy",
+        "qty": "1",
+        "type": "market",
+        "time_in_force": "day",
+        "limit_price": None,
+        "stop_price": None,
+        "status": "accepted",
+    }
+
+
+def _recovery_decision(
+    session: Session,
+    fixture: LinkedSubmitFixture,
+) -> TradeDecision:
+    decision_row = session.get(TradeDecision, fixture.decision_id)
+    assert decision_row is not None
+    return decision_row
 
 
 def _upgrade_to_strict_submit_recovery(harness: _TerminalHarness) -> None:
@@ -715,3 +801,154 @@ def test_postgres_0069_refuses_downgrade_after_recovery_terminal(
         ).scalar_one()
     assert revision == "0069_strict_submit_recovery"
     assert state == "rejected"
+
+
+def test_order_executor_existing_order_recovery_settles_linked_records_once(
+    terminal_harness: _TerminalHarness,
+) -> None:
+    _upgrade_to_strict_submit_recovery(terminal_harness)
+    fixture, acquired = _enter_linked_io(terminal_harness)
+    _force_linked_recovery_due(
+        terminal_harness,
+        fixture=fixture,
+        receipt_id=acquired.receipt.receipt_id,
+    )
+    executor = _ObservedOrderExecutor()
+    order = _observed_order(fixture)
+    with terminal_harness.sessions() as session:
+        result = recover_durable_linked_existing_order(
+            DurableExistingOrderRecoveryRequest(
+                executor=cast(LinkedSubmissionRecoveryExecutor, executor),
+                session=session,
+                firewall=_recovery_firewall(),
+                decision_row=_recovery_decision(session, fixture),
+                account_label="paper",
+                existing_orders=(order,),
+            )
+        )
+    assert result.handled
+    assert result.execution is not None
+    assert result.execution.status == "accepted"
+    assert executor.calls == 1
+    with terminal_harness.engine.connect() as connection:
+        claim = connection.execute(
+            text(
+                "SELECT state, recovery_outcome, execution_id "
+                "FROM trade_decision_submission_claims "
+                "WHERE trade_decision_id = :decision_id"
+            ),
+            {"decision_id": fixture.decision_id},
+        ).one()
+        receipt = connection.execute(
+            text(
+                "SELECT state, settlement_source, settlement_outcome, execution_id "
+                "FROM broker_mutation_receipt_events "
+                "WHERE receipt_id = :receipt_id "
+                "ORDER BY sequence_no DESC LIMIT 1"
+            ),
+            {"receipt_id": acquired.receipt.receipt_id},
+        ).one()
+        execution_count = connection.execute(
+            text(
+                "SELECT count(*) FROM executions WHERE trade_decision_id = :decision_id"
+            ),
+            {"decision_id": fixture.decision_id},
+        ).scalar_one()
+    assert claim.state == "submitted"
+    assert claim.recovery_outcome == "found"
+    assert claim.execution_id is not None
+    assert tuple(receipt[:3]) == ("settled", "recovery", "reconciled")
+    assert receipt.execution_id == claim.execution_id
+    assert execution_count == 1
+    with terminal_harness.sessions() as session:
+        repeated = recover_durable_linked_existing_order(
+            DurableExistingOrderRecoveryRequest(
+                executor=cast(LinkedSubmissionRecoveryExecutor, executor),
+                session=session,
+                firewall=_recovery_firewall(),
+                decision_row=_recovery_decision(session, fixture),
+                account_label="paper",
+                existing_orders=(order,),
+            )
+        )
+    assert repeated.handled
+    assert repeated.execution is not None
+    assert repeated.execution.id == result.execution.id
+    assert executor.calls == 1
+    with terminal_harness.engine.connect() as connection:
+        repeated_execution_count = connection.execute(
+            text(
+                "SELECT count(*) FROM executions WHERE trade_decision_id = :decision_id"
+            ),
+            {"decision_id": fixture.decision_id},
+        ).scalar_one()
+    assert repeated_execution_count == 1
+
+
+def test_order_executor_existing_order_recovery_preserves_rejection_state(
+    terminal_harness: _TerminalHarness,
+) -> None:
+    _upgrade_to_strict_submit_recovery(terminal_harness)
+    fixture, acquired = _enter_linked_io(terminal_harness)
+    _force_linked_recovery_due(
+        terminal_harness,
+        fixture=fixture,
+        receipt_id=acquired.receipt.receipt_id,
+    )
+    executor = _ObservedOrderExecutor()
+    order = _observed_order(fixture)
+    order["status"] = "rejected"
+    with terminal_harness.sessions() as session:
+        result = recover_durable_linked_existing_order(
+            DurableExistingOrderRecoveryRequest(
+                executor=cast(LinkedSubmissionRecoveryExecutor, executor),
+                session=session,
+                firewall=_recovery_firewall(),
+                decision_row=_recovery_decision(session, fixture),
+                account_label="paper",
+                existing_orders=(order,),
+            )
+        )
+    assert result.handled
+    assert result.execution is None
+    assert executor.calls == 0
+    with terminal_harness.engine.connect() as connection:
+        decision = connection.execute(
+            text(
+                "SELECT status, decision_json FROM trade_decisions "
+                "WHERE id = :decision_id"
+            ),
+            {"decision_id": fixture.decision_id},
+        ).one()
+        claim_state = connection.execute(
+            text(
+                "SELECT state FROM trade_decision_submission_claims "
+                "WHERE trade_decision_id = :decision_id"
+            ),
+            {"decision_id": fixture.decision_id},
+        ).scalar_one()
+        receipt = connection.execute(
+            text(
+                "SELECT state, settlement_source, settlement_outcome, execution_id "
+                "FROM broker_mutation_receipt_events "
+                "WHERE receipt_id = :receipt_id "
+                "ORDER BY sequence_no DESC LIMIT 1"
+            ),
+            {"receipt_id": acquired.receipt.receipt_id},
+        ).one()
+        execution_count = connection.execute(
+            text(
+                "SELECT count(*) FROM executions WHERE trade_decision_id = :decision_id"
+            ),
+            {"decision_id": fixture.decision_id},
+        ).scalar_one()
+    assert decision.status == "rejected"
+    assert decision.decision_json["submission_stage"] == "rejected"
+    assert decision.decision_json["risk_reasons"] == ["broker_rejected"]
+    assert decision.decision_json["reject_reason_atomic"] == ["broker_rejected"]
+    assert decision.decision_json["reject_class"] == "runtime"
+    assert decision.decision_json["reject_origin"] == "scheduler"
+    assert claim_state == "rejected"
+    assert tuple(receipt[:3]) == ("settled", "recovery", "rejected")
+    assert receipt.execution_id is None
+    assert execution_count == 0

--- a/services/torghut/tests/execution/test_order_executor_existing_order_recovery.py
+++ b/services/torghut/tests/execution/test_order_executor_existing_order_recovery.py
@@ -1,0 +1,380 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from decimal import Decimal
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.models import Execution, TradeDecision
+from app.trading.broker_mutation_receipts import BrokerMutationReceiptSnapshot
+from app.trading.broker_mutation_coordinator import BrokerMutationDeferred
+from app.trading.execution import OrderExecutor
+from app.trading.execution.durable_existing_order_recovery import (
+    DurableExistingOrderRecoveryRequest,
+    DurableExistingOrderRecoveryResult,
+    recover_durable_linked_existing_order,
+)
+from app.trading.firewall import OrderFirewall
+from app.trading.models import StrategyDecision
+
+
+class _ExistingOrderClient:
+    def __init__(self, client_order_id: str) -> None:
+        self.lookup_calls = 0
+        self._order = {
+            "id": "existing-linked-order",
+            "client_order_id": client_order_id,
+            "symbol": "AAPL",
+            "side": "buy",
+            "qty": "1",
+            "type": "market",
+            "time_in_force": "day",
+            "limit_price": None,
+            "stop_price": None,
+            "status": "accepted",
+        }
+
+    def get_order_by_client_order_id(
+        self, client_order_id: str
+    ) -> dict[str, object] | None:
+        self.lookup_calls += 1
+        if client_order_id != self._order["client_order_id"]:
+            return None
+        return dict(self._order)
+
+
+def _recovery_firewall() -> OrderFirewall:
+    return cast(
+        OrderFirewall,
+        SimpleNamespace(
+            broker_endpoint_url="https://paper-api.alpaca.markets",
+        ),
+    )
+
+
+def _durable_recovery_request(
+    session: Session,
+    decision_row: TradeDecision,
+    *,
+    existing_orders: tuple[dict[str, object], ...],
+) -> DurableExistingOrderRecoveryRequest:
+    return DurableExistingOrderRecoveryRequest(
+        executor=OrderExecutor(),
+        session=session,
+        firewall=_recovery_firewall(),
+        decision_row=decision_row,
+        account_label="paper",
+        existing_orders=existing_orders,
+    )
+
+
+def test_existing_order_without_durable_receipt_uses_legacy_fallback() -> None:
+    decision_row = cast(
+        TradeDecision,
+        SimpleNamespace(
+            id=uuid.uuid4(),
+            decision_hash="a" * 64,
+            alpaca_account_label="paper",
+        ),
+    )
+    session = MagicMock(spec=Session)
+    session.execute.return_value.scalar_one_or_none.return_value = None
+
+    result = recover_durable_linked_existing_order(
+        _durable_recovery_request(
+            session,
+            decision_row,
+            existing_orders=({"id": "legacy-order"},),
+        )
+    )
+
+    assert not result.handled
+    assert result.execution is None
+    assert session.rollback.call_count == 2
+
+
+def test_durable_recovery_rejects_ambiguous_existing_order_count() -> None:
+    decision_row = cast(
+        TradeDecision,
+        SimpleNamespace(
+            id=uuid.uuid4(),
+            decision_hash="b" * 64,
+            alpaca_account_label="paper",
+        ),
+    )
+    session = MagicMock(spec=Session)
+    session.execute.return_value.scalar_one_or_none.return_value = uuid.uuid4()
+
+    with pytest.raises(
+        RuntimeError,
+        match="linked_submission_recovery_existing_order_count_invalid:.*:0",
+    ):
+        recover_durable_linked_existing_order(
+            _durable_recovery_request(session, decision_row, existing_orders=())
+        )
+
+    session.rollback.assert_called_once_with()
+
+
+def test_existing_order_path_uses_durable_recovery_before_legacy_backfill() -> None:
+    client_order_id = "d" * 64
+    decision = StrategyDecision(
+        strategy_id=str(uuid.uuid4()),
+        symbol="AAPL",
+        event_ts=datetime(2026, 7, 15, 6, 0, tzinfo=timezone.utc),
+        timeframe="1Min",
+        action="buy",
+        qty=Decimal("1"),
+    )
+    decision_row = cast(
+        TradeDecision,
+        SimpleNamespace(
+            id=uuid.uuid4(),
+            decision_hash=client_order_id,
+            alpaca_account_label="paper",
+        ),
+    )
+    session = MagicMock(spec=Session)
+    client = _ExistingOrderClient(client_order_id)
+    firewall = OrderFirewall(cast(object, client), account_label="paper")
+    executor = OrderExecutor()
+    recovered_execution = cast(
+        Execution,
+        SimpleNamespace(id=uuid.uuid4(), status="accepted"),
+    )
+
+    with (
+        patch(
+            "app.trading.execution.order_executor_core_methods.durable_recovery."
+            "recover_durable_linked_existing_order",
+            return_value=DurableExistingOrderRecoveryResult(
+                handled=True,
+                execution=recovered_execution,
+            ),
+        ) as recover,
+        patch.object(executor, "_sync_execution_payload") as legacy_backfill,
+    ):
+        handled, execution = executor._sync_existing_order_if_present(
+            session=session,
+            execution_client=firewall,
+            decision=decision,
+            decision_row=decision_row,
+            account_label="paper",
+            execution_expected_adapter="alpaca",
+            execution_policy_context={},
+        )
+
+    assert handled
+    assert execution is recovered_execution
+    assert client.lookup_calls == 1
+    recover.assert_called_once()
+    assert recover.call_args.args == (
+        DurableExistingOrderRecoveryRequest(
+            executor=executor,
+            session=session,
+            firewall=firewall,
+            decision_row=decision_row,
+            account_label="paper",
+            existing_orders=[client._order],
+        ),
+    )
+    legacy_backfill.assert_not_called()
+
+
+def test_submit_order_returns_recovered_terminal_execution() -> None:
+    decision = StrategyDecision(
+        strategy_id=str(uuid.uuid4()),
+        symbol="AAPL",
+        event_ts=datetime(2026, 7, 15, 6, 15, tzinfo=timezone.utc),
+        timeframe="1Min",
+        action="buy",
+        qty=Decimal("1"),
+    )
+    decision_row = cast(
+        TradeDecision,
+        SimpleNamespace(
+            id=uuid.uuid4(),
+            decision_hash="e" * 64,
+            alpaca_account_label="paper",
+            decision_json={},
+            status="planned",
+        ),
+    )
+    terminal_execution = cast(
+        Execution,
+        SimpleNamespace(id=uuid.uuid4(), status="canceled", filled_qty=Decimal("0")),
+    )
+    session = MagicMock(spec=Session)
+    executor = OrderExecutor()
+
+    with (
+        patch.object(executor, "_fetch_execution", return_value=None),
+        patch.object(
+            executor,
+            "_sync_existing_order_if_present",
+            return_value=(True, terminal_execution),
+        ),
+    ):
+        result = executor.submit_order(
+            session,
+            object(),
+            decision,
+            decision_row,
+            "paper",
+        )
+
+    assert result is terminal_execution
+
+
+def test_settled_rejected_receipt_restores_rejected_decision_state() -> None:
+    decision_id = uuid.uuid4()
+    client_order_id = "e" * 64
+    receipt_id = uuid.uuid4()
+    decision_row = cast(
+        TradeDecision,
+        SimpleNamespace(
+            id=decision_id,
+            decision_hash=client_order_id,
+            alpaca_account_label="paper",
+            decision_json={},
+            status="planned",
+        ),
+    )
+    session = MagicMock(spec=Session)
+    session.execute.return_value.scalar_one_or_none.return_value = receipt_id
+    settled_receipt = cast(
+        BrokerMutationReceiptSnapshot,
+        SimpleNamespace(
+            state="settled",
+            settlement=SimpleNamespace(outcome="rejected"),
+        ),
+    )
+
+    with patch(
+        "app.trading.execution.durable_existing_order_recovery."
+        "get_broker_mutation_receipt",
+        return_value=settled_receipt,
+    ):
+        result = recover_durable_linked_existing_order(
+            DurableExistingOrderRecoveryRequest(
+                executor=OrderExecutor(),
+                session=session,
+                firewall=_recovery_firewall(),
+                decision_row=decision_row,
+                account_label="paper",
+                existing_orders=({"id": "rejected-order"},),
+            )
+        )
+
+    assert result.handled
+    assert result.execution is None
+    assert decision_row.status == "rejected"
+    assert decision_row.decision_json["submission_stage"] == "rejected"
+    assert decision_row.decision_json["risk_reasons"] == ["broker_rejected"]
+    assert decision_row.decision_json["reject_reason_atomic"] == ["broker_rejected"]
+    assert decision_row.decision_json["reject_class"] == "runtime"
+    assert decision_row.decision_json["reject_origin"] == "scheduler"
+    session.add.assert_called_once_with(decision_row)
+    session.commit.assert_called_once_with()
+
+
+def test_existing_order_path_propagates_deferred_recovery_lease() -> None:
+    client_order_id = "f" * 64
+    receipt_id = uuid.uuid4()
+    decision = StrategyDecision(
+        strategy_id=str(uuid.uuid4()),
+        symbol="AAPL",
+        event_ts=datetime(2026, 7, 15, 6, 30, tzinfo=timezone.utc),
+        timeframe="1Min",
+        action="buy",
+        qty=Decimal("1"),
+    )
+    decision_row = cast(
+        TradeDecision,
+        SimpleNamespace(
+            id=uuid.uuid4(),
+            decision_hash=client_order_id,
+            alpaca_account_label="paper",
+            decision_json={},
+            status="planned",
+        ),
+    )
+    session = MagicMock(spec=Session)
+    session.execute.return_value.scalar_one_or_none.return_value = receipt_id
+    client = _ExistingOrderClient(client_order_id)
+    firewall = OrderFirewall(cast(object, client), account_label="paper")
+    executor = OrderExecutor()
+    broker_io_receipt = cast(
+        BrokerMutationReceiptSnapshot,
+        SimpleNamespace(state="broker_io"),
+    )
+
+    with (
+        patch(
+            "app.trading.execution.durable_existing_order_recovery."
+            "get_broker_mutation_receipt",
+            return_value=broker_io_receipt,
+        ),
+        patch(
+            "app.trading.execution.durable_existing_order_recovery."
+            "acquire_broker_mutation_recovery",
+            return_value=SimpleNamespace(
+                acquired=False,
+                receipt=None,
+                outcome="busy",
+            ),
+        ),
+        patch.object(executor, "_sync_execution_payload") as legacy_backfill,
+        pytest.raises(
+            BrokerMutationDeferred,
+            match="linked_submission_existing_order_recovery_deferred:.*:receipt:busy",
+        ),
+    ):
+        executor._sync_existing_order_if_present(
+            session=session,
+            execution_client=firewall,
+            decision=decision,
+            decision_row=decision_row,
+            account_label="paper",
+            execution_expected_adapter="alpaca",
+            execution_policy_context={},
+        )
+
+    assert client.lookup_calls == 1
+    legacy_backfill.assert_not_called()
+
+
+def test_durable_recovery_rejects_foreign_endpoint_receipt() -> None:
+    decision_row = cast(
+        TradeDecision,
+        SimpleNamespace(
+            id=uuid.uuid4(),
+            decision_hash="c" * 64,
+            alpaca_account_label="paper",
+        ),
+    )
+    session = MagicMock(spec=Session)
+    session.execute.side_effect = (
+        SimpleNamespace(scalar_one_or_none=lambda: None),
+        SimpleNamespace(scalar_one_or_none=lambda: uuid.uuid4()),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="linked_submission_recovery_endpoint_mismatch",
+    ):
+        recover_durable_linked_existing_order(
+            _durable_recovery_request(
+                session,
+                decision_row,
+                existing_orders=({"id": "foreign-endpoint-order"},),
+            )
+        )
+
+    assert session.rollback.call_count == 2
+    assert "endpoint_fingerprint" in str(session.execute.call_args_list[0].args[0])

--- a/services/torghut/tests/execution/test_order_executor_existing_order_recovery.py
+++ b/services/torghut/tests/execution/test_order_executor_existing_order_recovery.py
@@ -187,6 +187,82 @@ def test_existing_order_path_uses_durable_recovery_before_legacy_backfill() -> N
     legacy_backfill.assert_not_called()
 
 
+def test_legacy_backfill_prefers_filled_attempt_over_later_terminal_retry() -> None:
+    decision = StrategyDecision(
+        strategy_id=str(uuid.uuid4()),
+        symbol="AAPL",
+        event_ts=datetime(2026, 7, 15, 6, 10, tzinfo=timezone.utc),
+        timeframe="1Min",
+        action="buy",
+        qty=Decimal("1"),
+    )
+    decision_row = cast(
+        TradeDecision,
+        SimpleNamespace(
+            id=uuid.uuid4(),
+            decision_hash="5" * 64,
+            alpaca_account_label="paper",
+        ),
+    )
+    partial_execution = cast(
+        Execution,
+        SimpleNamespace(
+            id=uuid.uuid4(), status="partially_filled", filled_qty=Decimal("0.4")
+        ),
+    )
+    canceled_execution = cast(
+        Execution,
+        SimpleNamespace(id=uuid.uuid4(), status="canceled", filled_qty=Decimal("0")),
+    )
+    session = MagicMock(spec=Session)
+    executor = OrderExecutor()
+    existing_orders = [
+        {"id": "base-order", "filled_qty": "0.4", "status": "partially_filled"},
+        {"id": "retry-order", "filled_qty": "0", "status": "canceled"},
+    ]
+
+    with (
+        patch(
+            "app.trading.execution.order_executor_core_methods.fetch_existing_orders",
+            return_value=existing_orders,
+        ),
+        patch.object(
+            executor,
+            "_sync_execution_payload",
+            side_effect=(partial_execution, canceled_execution),
+        ),
+        patch(
+            "app.trading.execution.order_executor_core_methods."
+            "_order_payload_with_execution_metadata",
+            side_effect=lambda order, *_args, **_kwargs: order,
+        ),
+        patch(
+            "app.trading.execution.order_executor_core_methods."
+            "_attach_execution_policy_context"
+        ),
+        patch(
+            "app.trading.execution.order_executor_core_methods."
+            "upsert_execution_tca_metric"
+        ),
+        patch(
+            "app.trading.execution.order_executor_core_methods._apply_execution_status"
+        ),
+    ):
+        handled, execution = executor._sync_existing_order_if_present(
+            session=session,
+            execution_client=object(),
+            decision=decision,
+            decision_row=decision_row,
+            account_label="paper",
+            execution_expected_adapter="alpaca",
+            execution_policy_context={},
+        )
+
+    assert handled
+    assert execution is partial_execution
+    session.commit.assert_called_once_with()
+
+
 def test_submit_order_returns_recovered_terminal_execution() -> None:
     decision = StrategyDecision(
         strategy_id=str(uuid.uuid4()),

--- a/services/torghut/tests/execution/test_order_executor_existing_order_recovery.py
+++ b/services/torghut/tests/execution/test_order_executor_existing_order_recovery.py
@@ -14,6 +14,7 @@ from app.models import Execution, TradeDecision
 from app.trading.broker_mutation_receipts import BrokerMutationReceiptSnapshot
 from app.trading.broker_mutation_coordinator import BrokerMutationDeferred
 from app.trading.execution import OrderExecutor
+from app.trading.execution import durable_existing_order_recovery as durable_recovery
 from app.trading.execution.durable_existing_order_recovery import (
     DurableExistingOrderRecoveryRequest,
     DurableExistingOrderRecoveryResult,
@@ -378,3 +379,148 @@ def test_durable_recovery_rejects_foreign_endpoint_receipt() -> None:
 
     assert session.rollback.call_count == 2
     assert "endpoint_fingerprint" in str(session.execute.call_args_list[0].args[0])
+
+
+def test_durable_recovery_rejects_nonterminal_non_io_receipt() -> None:
+    decision_row = cast(
+        TradeDecision,
+        SimpleNamespace(
+            id=uuid.uuid4(),
+            decision_hash="3" * 64,
+            alpaca_account_label="paper",
+        ),
+    )
+    session = MagicMock(spec=Session)
+    session.execute.return_value.scalar_one_or_none.return_value = uuid.uuid4()
+    claimed_receipt = cast(
+        BrokerMutationReceiptSnapshot,
+        SimpleNamespace(state="claimed"),
+    )
+
+    with (
+        patch(
+            "app.trading.execution.durable_existing_order_recovery."
+            "get_broker_mutation_receipt",
+            return_value=claimed_receipt,
+        ),
+        pytest.raises(
+            RuntimeError,
+            match="linked_submission_existing_order_without_broker_io",
+        ),
+    ):
+        recover_durable_linked_existing_order(
+            _durable_recovery_request(
+                session,
+                decision_row,
+                existing_orders=({"id": "claimed-order"},),
+            )
+        )
+
+
+def test_settled_reconciled_receipt_loads_recovered_execution() -> None:
+    execution_id = uuid.uuid4()
+    recovered_execution = cast(
+        Execution,
+        SimpleNamespace(id=execution_id, status="accepted"),
+    )
+    decision_row = cast(
+        TradeDecision,
+        SimpleNamespace(
+            id=uuid.uuid4(),
+            decision_hash="4" * 64,
+            alpaca_account_label="paper",
+        ),
+    )
+    session = MagicMock(spec=Session)
+    session.execute.return_value.scalar_one_or_none.return_value = uuid.uuid4()
+    settled_receipt = cast(
+        BrokerMutationReceiptSnapshot,
+        SimpleNamespace(
+            state="settled",
+            settlement=SimpleNamespace(
+                outcome="reconciled",
+                execution_id=execution_id,
+            ),
+        ),
+    )
+
+    with (
+        patch(
+            "app.trading.execution.durable_existing_order_recovery."
+            "get_broker_mutation_receipt",
+            return_value=settled_receipt,
+        ),
+        patch.object(
+            durable_recovery,
+            "_load_recovered_execution",
+            return_value=recovered_execution,
+        ) as load_execution,
+    ):
+        result = recover_durable_linked_existing_order(
+            _durable_recovery_request(
+                session,
+                decision_row,
+                existing_orders=({"id": "reconciled-order"},),
+            )
+        )
+
+    assert result.handled
+    assert result.execution is recovered_execution
+    load_execution.assert_called_once_with(
+        session,
+        execution_id=execution_id,
+        required=True,
+    )
+
+
+def test_load_recovered_execution_requires_execution_id() -> None:
+    session = MagicMock(spec=Session)
+
+    with pytest.raises(
+        RuntimeError,
+        match="linked_submission_recovery_execution_missing",
+    ):
+        durable_recovery._load_recovered_execution(
+            session,
+            execution_id=None,
+            required=True,
+        )
+
+
+def test_load_recovered_execution_reuses_identity_map() -> None:
+    execution_id = uuid.uuid4()
+    recovered_execution = cast(
+        Execution,
+        SimpleNamespace(id=execution_id, status="expired"),
+    )
+    session = MagicMock()
+    identity_key = (Execution, (execution_id,), None)
+    session.identity_key.return_value = identity_key
+    session.identity_map.get.return_value = recovered_execution
+
+    result = durable_recovery._load_recovered_execution(
+        session,
+        execution_id=execution_id,
+        required=True,
+    )
+
+    assert result is recovered_execution
+    session.identity_key.assert_called_once_with(Execution, execution_id)
+    session.identity_map.get.assert_called_once_with(identity_key)
+    session.execute.assert_not_called()
+
+
+def test_load_recovered_execution_rejects_missing_execution_schema() -> None:
+    session = MagicMock()
+    session.identity_map.get.return_value = None
+    session.execute.return_value.scalars.return_value = ()
+
+    with pytest.raises(
+        RuntimeError,
+        match="linked_submission_recovery_execution_schema_missing",
+    ):
+        durable_recovery._load_recovered_execution(
+            session,
+            execution_id=uuid.uuid4(),
+            required=True,
+        )

--- a/services/torghut/tests/execution/test_order_executor_existing_order_recovery_postgres.py
+++ b/services/torghut/tests/execution/test_order_executor_existing_order_recovery_postgres.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+from sqlalchemy import text
+
+from app.trading.alpaca_mutation_recovery import LinkedSubmissionRecoveryExecutor
+from app.trading.execution.durable_existing_order_recovery import (
+    DurableExistingOrderRecoveryRequest,
+    recover_durable_linked_existing_order,
+)
+from tests.execution.test_linked_submission_recovery_postgres import (
+    _ObservedOrderExecutor,
+    _force_linked_recovery_due,
+    _observed_order,
+    _recovery_decision,
+    _recovery_firewall,
+    _upgrade_to_strict_submit_recovery,
+)
+from tests.execution.test_linked_submission_terminal_postgres import (
+    _TerminalHarness,
+    _enter_linked_io,
+    terminal_harness,
+)
+
+__all__ = ("terminal_harness",)
+
+
+def test_order_executor_existing_order_recovery_returns_terminal_execution(
+    terminal_harness: _TerminalHarness,
+) -> None:
+    _upgrade_to_strict_submit_recovery(terminal_harness)
+    fixture, acquired = _enter_linked_io(terminal_harness)
+    _force_linked_recovery_due(
+        terminal_harness,
+        fixture=fixture,
+        receipt_id=acquired.receipt.receipt_id,
+    )
+    executor = _ObservedOrderExecutor()
+    order = _observed_order(fixture)
+    order["status"] = "canceled"
+
+    with terminal_harness.sessions() as session:
+        result = recover_durable_linked_existing_order(
+            DurableExistingOrderRecoveryRequest(
+                executor=cast(LinkedSubmissionRecoveryExecutor, executor),
+                session=session,
+                firewall=_recovery_firewall(),
+                decision_row=_recovery_decision(session, fixture),
+                account_label="paper",
+                existing_orders=(order,),
+            )
+        )
+
+    assert result.handled
+    assert result.execution is not None
+    assert result.execution.status == "canceled"
+    assert executor.calls == 1
+
+
+def test_order_executor_existing_order_recovery_rolls_back_partial_execution(
+    terminal_harness: _TerminalHarness,
+) -> None:
+    _upgrade_to_strict_submit_recovery(terminal_harness)
+    fixture, acquired = _enter_linked_io(terminal_harness)
+    _force_linked_recovery_due(
+        terminal_harness,
+        fixture=fixture,
+        receipt_id=acquired.receipt.receipt_id,
+    )
+    executor = _ObservedOrderExecutor(fail_after_insert=True)
+    with (
+        terminal_harness.sessions() as session,
+        pytest.raises(RuntimeError, match="injected_after_execution_insert"),
+    ):
+        recover_durable_linked_existing_order(
+            DurableExistingOrderRecoveryRequest(
+                executor=cast(LinkedSubmissionRecoveryExecutor, executor),
+                session=session,
+                firewall=_recovery_firewall(),
+                decision_row=_recovery_decision(session, fixture),
+                account_label="paper",
+                existing_orders=(_observed_order(fixture),),
+            )
+        )
+
+    assert executor.calls == 1
+    with terminal_harness.engine.connect() as connection:
+        claim_state = connection.execute(
+            text(
+                "SELECT state FROM trade_decision_submission_claims "
+                "WHERE trade_decision_id = :decision_id"
+            ),
+            {"decision_id": fixture.decision_id},
+        ).scalar_one()
+        receipt_state = connection.execute(
+            text(
+                "SELECT state FROM broker_mutation_receipt_events "
+                "WHERE receipt_id = :receipt_id "
+                "ORDER BY sequence_no DESC LIMIT 1"
+            ),
+            {"receipt_id": acquired.receipt.receipt_id},
+        ).scalar_one()
+        execution_count = connection.execute(
+            text(
+                "SELECT count(*) FROM executions WHERE trade_decision_id = :decision_id"
+            ),
+            {"decision_id": fixture.decision_id},
+        ).scalar_one()
+    assert (claim_state, receipt_state, execution_count) == (
+        "broker_io",
+        "broker_io",
+        0,
+    )

--- a/services/torghut/tests/order_idempotency/test_decision_hash_stable_for_same_intent.py
+++ b/services/torghut/tests/order_idempotency/test_decision_hash_stable_for_same_intent.py
@@ -470,10 +470,14 @@ class TestDecisionHashStableForSameIntent(_TestOrderIdempotencyBase):
                 "paper",
             )
 
-            self.assertIsNone(execution)
+            self.assertIsNotNone(execution)
+            assert execution is not None
+            self.assertEqual(execution.client_order_id, retry_client_order_id)
+            self.assertEqual(execution.alpaca_order_id, "order-retry-3")
             self.assertEqual(len(alpaca_client.submitted), 1)
             persisted = session.execute(select(Execution)).scalars().all()
             self.assertEqual(len(persisted), 1)
+            self.assertEqual(persisted[0].id, execution.id)
             self.assertEqual(persisted[0].client_order_id, retry_client_order_id)
             self.assertEqual(persisted[0].alpaca_order_id, "order-retry-3")
 

--- a/services/torghut/tests/pipeline/test_trading_pipeline_execution_llm_a.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_execution_llm_a.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 from app.models import (
     BrokerMutationReceipt,
     BrokerMutationReceiptEvent,
@@ -708,6 +710,182 @@ class TestTradingPipelineExecutionLlmA(TradingPipelineTestCaseBase):
                 "precheck_sell_qty_exceeds_available",
             )
             self.assertNotIn("broker_precheck_recovery", decision_row.decision_json)
+
+    def test_recovered_broker_rejection_is_not_reported_as_submitted(self) -> None:
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="recovered-rejection",
+                description="recovered broker rejection",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+                max_notional_per_trade=Decimal("1000"),
+            )
+            session.add(strategy)
+            session.commit()
+            session.refresh(strategy)
+
+            decision = StrategyDecision(
+                strategy_id=str(strategy.id),
+                symbol="AAPL",
+                event_ts=datetime.now(timezone.utc),
+                timeframe="1Min",
+                action="buy",
+                qty=Decimal("1"),
+                params={"price": Decimal("100")},
+            )
+            executor = OrderExecutor()
+            decision_row = executor.ensure_decision(
+                session,
+                decision,
+                strategy,
+                "paper",
+            )
+            alpaca = FakeAlpacaClient()
+            state = TradingState()
+            pipeline = TradingPipeline(
+                alpaca_client=alpaca,
+                order_firewall=OrderFirewall(alpaca),
+                ingestor=FakeIngestor([]),
+                decision_engine=DecisionEngine(),
+                risk_engine=RiskEngine(),
+                executor=executor,
+                execution_adapter=alpaca,
+                reconciler=Reconciler(),
+                universe_resolver=UniverseResolver(),
+                state=state,
+                account_label="paper",
+                session_factory=self.session_local,
+            )
+
+            def recover_rejected_order(*_args: object, **_kwargs: object) -> None:
+                decision_json = dict(decision_row.decision_json)
+                decision_json["submission_stage"] = "rejected"
+                decision_row.status = "rejected"
+                decision_row.decision_json = decision_json
+                session.add(decision_row)
+                session.commit()
+                return None
+
+            with patch.object(
+                executor,
+                "submit_order",
+                side_effect=recover_rejected_order,
+            ):
+                execution, rejected = pipeline._submit_order_with_handling(
+                    OrderSubmissionRequest(
+                        session=session,
+                        execution_client=alpaca,
+                        decision=decision,
+                        decision_row=decision_row,
+                        selected_adapter_name="alpaca",
+                    )
+                )
+
+            self.assertIsNone(execution)
+            self.assertTrue(rejected)
+            self.assertEqual(decision_row.status, "rejected")
+            self.assertEqual(
+                decision_row.decision_json.get("submission_stage"),
+                "rejected",
+            )
+            self.assertEqual(state.metrics.orders_submitted_total, 0)
+            self.assertEqual(state.metrics.orders_rejected_total, 1)
+            self.assertEqual(
+                state.metrics.decision_reject_reason_total.get("broker_rejected"),
+                1,
+            )
+
+    def test_recovered_terminal_order_is_not_reported_as_submitted(self) -> None:
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="recovered-terminal",
+                description="recovered terminal broker order",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+                max_notional_per_trade=Decimal("1000"),
+            )
+            session.add(strategy)
+            session.commit()
+            session.refresh(strategy)
+
+            decision = StrategyDecision(
+                strategy_id=str(strategy.id),
+                symbol="AAPL",
+                event_ts=datetime.now(timezone.utc),
+                timeframe="1Min",
+                action="buy",
+                qty=Decimal("1"),
+                params={"price": Decimal("100")},
+            )
+            executor = OrderExecutor()
+            decision_row = executor.ensure_decision(
+                session,
+                decision,
+                strategy,
+                "paper",
+            )
+            alpaca = FakeAlpacaClient()
+            state = TradingState()
+            pipeline = TradingPipeline(
+                alpaca_client=alpaca,
+                order_firewall=OrderFirewall(alpaca),
+                ingestor=FakeIngestor([]),
+                decision_engine=DecisionEngine(),
+                risk_engine=RiskEngine(),
+                executor=executor,
+                execution_adapter=alpaca,
+                reconciler=Reconciler(),
+                universe_resolver=UniverseResolver(),
+                state=state,
+                account_label="paper",
+                session_factory=self.session_local,
+            )
+            terminal_execution = SimpleNamespace(
+                id="recovered-terminal-execution",
+                status="canceled",
+                filled_qty=Decimal("0"),
+                raw_order={},
+                execution_audit_json={},
+                execution_correlation_id=None,
+                execution_idempotency_key=None,
+                execution_fallback_reason=None,
+            )
+
+            with patch.object(
+                executor,
+                "submit_order",
+                return_value=terminal_execution,
+            ):
+                execution, rejected = pipeline._submit_order_with_handling(
+                    OrderSubmissionRequest(
+                        session=session,
+                        execution_client=alpaca,
+                        decision=decision,
+                        decision_row=decision_row,
+                        selected_adapter_name="alpaca",
+                    )
+                )
+
+            self.assertIs(execution, terminal_execution)
+            self.assertTrue(rejected)
+            self.assertEqual(state.metrics.orders_submitted_total, 0)
+            self.assertEqual(state.metrics.orders_rejected_total, 1)
+            self.assertEqual(
+                state.metrics.decision_reject_reason_total.get(
+                    "order_terminal_unfilled_canceled"
+                ),
+                1,
+            )
+            session.refresh(decision_row)
+            self.assertEqual(decision_row.status, "rejected")
+            self.assertEqual(
+                decision_row.decision_json.get("submission_stage"),
+                "rejected_unfilled",
+            )
 
     def test_pipeline_llm_veto(self) -> None:
         from app import config

--- a/services/torghut/tests/test_broker_mutation_wiring.py
+++ b/services/torghut/tests/test_broker_mutation_wiring.py
@@ -227,13 +227,20 @@ def test_runtime_status_claims_only_the_entry_capability_now_wired() -> None:
     assert status["recovery_degraded"] is False
 
 
-def test_scheduler_singleton_replica_contract_remains_enabled() -> None:
+def test_scheduler_writer_is_singleton_or_explicitly_quiesced() -> None:
     manifest = (
         SERVICE_ROOT.parents[1]
         / "argocd/applications/torghut/scheduler-deployment.yaml"
     ).read_text(encoding="utf-8")
 
-    assert "replicas: 1" in manifest
+    if "replicas: 0" in manifest:
+        assert (
+            "Temporarily quiesced for the bounded Alpaca-paper lifecycle proof"
+            in manifest
+        )
+        assert "Restore the single scheduler writer after readback" in manifest
+    else:
+        assert "replicas: 1" in manifest
 
 
 def test_receipt_postgres_races_are_a_required_ci_gate() -> None:

--- a/services/torghut/tests/test_order_lifecycle.py
+++ b/services/torghut/tests/test_order_lifecycle.py
@@ -68,6 +68,19 @@ def test_terminal_zero_fill_is_rejected_but_partial_fill_remains_actionable() ->
     assert terminal_unfilled_execution_reason(execution) is None
 
 
+def test_done_for_day_zero_fill_is_terminal() -> None:
+    execution = type(
+        "Execution",
+        (),
+        {"status": "done_for_day", "filled_qty": Decimal("0")},
+    )()
+
+    assert (
+        terminal_unfilled_execution_reason(execution)
+        == "order_terminal_unfilled_done_for_day"
+    )
+
+
 def test_historical_lifecycle_fill_metadata_remains_readable() -> None:
     execution = type(
         "Execution",


### PR DESCRIPTION
## Summary

- recover broker-observed existing orders through the durable linked receipt and submission-claim lifecycle before legacy backfill
- persist the recovered execution and terminal receipt/claim transitions in one transaction using fenced recovery handles
- retain legacy execution backfill only when no durable linked submit receipt exists
- share the validated Alpaca found-settlement builder between the recovery worker and the executor existing-order path

## Regression coverage

- successful process-death recovery creates one execution and atomically settles both linked records without another broker mutation
- an injected failure after execution insertion rolls back the execution and leaves receipt and claim unresolved in `broker_io`
- repeated recovery does not duplicate the execution or broker mutation
- the real `OrderExecutor` existing-order branch is exercised and bypasses legacy backfill for durable linked submissions

## Validation

- 56 related tests passed against PostgreSQL 16
- Ruff check and format check passed
- Pyright main, alpha, and scripts profiles: 0 errors
- `git diff --check` passed

Historical source: merged PR #12485, Codex comment 3581679825, thread `PRRT_kwDOLkRLus6SIiJ5`.
