### PR TITLE
fix(atlas): require empty absent-path results

### DIFF
--- a/packages/scripts/src/atlas/verify.test.ts
+++ b/packages/scripts/src/atlas/verify.test.ts
@@ -29,4 +29,11 @@ describe('atlas verify', () => {
     expect(performanceQueries.filter((query) => query.startsWith('exact identifier\n'))).toHaveLength(3)
     expect(performanceQueries.every((query) => query.includes('Atlas latency probe proof-'))).toBe(true)
   })
+
+  it('requires every absent-path search to return zero results', () => {
+    expect(__private.absentPathSearchError('src/deleted.ts', [])).toBeUndefined()
+    expect(__private.absentPathSearchError('src/deleted.ts', ['src/live.ts'])).toBe(
+      'deleted path search returned 1 result(s) for src/deleted.ts: src/live.ts',
+    )
+  })
 })

--- a/packages/scripts/src/atlas/verify.ts
+++ b/packages/scripts/src/atlas/verify.ts
@@ -294,6 +294,11 @@ const buildColdPerformanceQueries = (queries: GoldQuery[], runs: number, nonce: 
     queries.map((fixture, index) => `${fixture.query}\nAtlas latency probe ${nonce}-${run}-${index}`),
   ).flat()
 
+const absentPathSearchError = (path: string, paths: string[]) =>
+  paths.length === 0
+    ? undefined
+    : `deleted path search returned ${paths.length} result(s) for ${path}: ${paths.join(', ')}`
+
 const activeAtlasQueryCount = async (db: SQL) => {
   const rows = (await db`
     SELECT count(DISTINCT activity.pid)::bigint AS active
@@ -381,7 +386,7 @@ const runCancellationProbe = async (input: {
   return { reachedDatabase, observedBlockedQueries, lingeringQueries }
 }
 
-export const __private = { activeAtlasQueryCount, buildColdPerformanceQueries }
+export const __private = { absentPathSearchError, activeAtlasQueryCount, buildColdPerformanceQueries }
 
 const main = async () => {
   const options = parseArgs(Bun.argv.slice(2))
@@ -639,7 +644,8 @@ const main = async () => {
     for (const path of gold.absentPaths) {
       const result = await search(options.baseUrl, options.repository, options.ref, path)
       const paths = validateSearchPayload(path, result.payload)
-      if (paths.includes(path)) errors.push(`deleted path was returned by search: ${path}`)
+      const absentPathError = absentPathSearchError(path, paths)
+      if (absentPathError) errors.push(absentPathError)
       deletedPathResults.push({ query: path, paths, durationMs: result.durationMs })
     }
 


### PR DESCRIPTION
## Summary

- require every Atlas absent-path gold query to return zero search results
- report unrelated live-path hits instead of accepting them
- add a focused regression for nonempty and empty absent-path results

## Related Issues

- Historical Codex review on PR #12484, discussion `3582466774`

## Testing

- `bun test packages/scripts/src/atlas/verify.test.ts` (3 passed)
- `bun node_modules/oxlint/bin/oxlint --config .oxlintrc.json packages/scripts/src/atlas/verify.ts packages/scripts/src/atlas/verify.test.ts`
- `bun node_modules/oxfmt/bin/oxfmt --check packages/scripts/src/atlas/verify.ts packages/scripts/src/atlas/verify.test.ts`
- `git diff --check origin/main...HEAD`
- Local full Atlas TypeScript project check was unavailable because the isolated install cannot resolve the unbuilt `@proompteng/temporal-bun-sdk` workspace package; authoritative CI is required for that gate.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
