### PR TITLE
build(bumba): refresh Nix dependency hashes

### DIFF
--- a/nix/images/bumba.nix
+++ b/nix/images/bumba.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "bumba";
   packageName = "@proompteng/bumba";
   depsHash = {
-    x86_64-linux = "sha256-UahTkwRO669+IQpk7gyKK/8Fy7YAbHshT1BbcQ1O8R4=";
-    aarch64-linux = "sha256-eidimz6P4IdohNW/uIQu5AXDQqnxq+piV0C/rS4UiCk=";
+    x86_64-linux = "sha256-94ofrftDj9Qqt2XSV3t20OOm/VChZyW+s0j31IM/ZCc=";
+    aarch64-linux = "sha256-4dgPU4BNl5rgVdE0Sc4RkAmaTr3tjaStdNqD0g/4kUg=";
   };
   installFilters = [
     "@proompteng/bumba"


### PR DESCRIPTION
## Summary

- Refresh the Bumba x86_64-linux fixed-output dependency hash from the failed production image build.
- Refresh the matching aarch64-linux dependency hash from the same source revision.
- Restore multi-architecture Bumba image publication without changing runtime behavior.

## Related Issues

None

## Testing

- `nix eval --raw .#packages.x86_64-linux.bumba-image.name`
- `nix eval --raw .#packages.aarch64-linux.bumba-image.name`
- `git diff --check`
- Confirmed both replacement hashes from the failed native CI builders in run 29396470063.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.