### PR TITLE
perf(jangar): unlog derived quant state caches

### DIFF
--- a/docs/torghut/jangar-quant-write-pressure-remediation.md
+++ b/docs/torghut/jangar-quant-write-pressure-remediation.md
@@ -87,6 +87,31 @@ remain immediate. A process restart and an on-demand request both force a comple
 sampling clock resumes. The health payload records whether each frame persisted latest state so the write budget is
 observable rather than implicit.
 
+### Latest-state cache durability
+
+The destructive series-removal rollout completed at `2026-07-15T07:30Z`: the migration ledger recorded
+`20260715_torghut_quant_series_remove`, all series relations and the insert function were absent, the removed endpoint
+returned `404`, and Jangar health, readiness, quant health, and snapshot requests remained healthy.
+
+That hard deletion did not by itself clear the storage gate. A transaction-separated 60.119-second sample produced
+35.922 MiB of WAL, or **0.5975 MiB/s**, while `quant_metrics_latest` performed 18,252 updates and
+`quant_pipeline_health_latest` performed 2,628 updates. The primary and replica Jangar RBD images remained around
+18-38 and 20-51 writes per second in the corresponding sample, with periodic checkpoint-sized byte spikes. The
+remaining pressure is therefore the durability and replica replay cost of rebuildable latest-state projections, not
+historical-series persistence.
+
+Both latest-state tables are converted to `UNLOGGED` with `fillfactor=70`. PostgreSQL then retains the single
+database-backed Jangar read path without WAL-logging or replicating projection contents. A crash or standby promotion
+can empty the caches; the one-second quant loop repopulates active frames, and witness/health readers report explicit
+empty or stale state until repopulation completes. They do not read a legacy table or restore a compatibility path.
+This matches PostgreSQL 17's documented [unlogged-table semantics](https://www.postgresql.org/docs/17/sql-createtable.html)
+and uses its supported [`ALTER TABLE ... SET UNLOGGED`](https://www.postgresql.org/docs/17/sql-altertable.html) transition.
+
+The `quant_pipeline_health_latest` index containing `updated_at` is removed. The live table has only 378 rows, while the
+index prevented every five-second heartbeat update from using HOT. Account/window/freshness reads remain bounded by
+that compact cardinality, and the lower fillfactor reserves page space for HOT replacements on both latest-state
+tables.
+
 ## Implementation
 
 ### Latest metrics
@@ -117,17 +142,25 @@ unbounded PostgreSQL cache.
 1. Verify the migration creates the empty latest-state table without reading the legacy table.
 2. Verify Jangar becomes ready and active health scopes populate within five seconds.
 3. Verify the quant-series route returns 404 and all four series relations/functions are absent.
-4. Verify quant health and snapshot APIs preserve their response contracts.
-5. Compare Jangar WAL rate and both Jangar RBD image write rates with the 0.603 MiB/s pre-change WAL baseline.
-6. Require the shared RBD pool and Kafka controllers to complete a new 30-minute observation with no request timeout,
+4. Verify both latest-state tables report `relpersistence='u'`, `fillfactor=70`, and the update-hostile health freshness
+   index is absent.
+5. Verify quant health and snapshot APIs preserve their response contracts, including explicit empty/stale behavior
+   while a cleared cache repopulates.
+6. Compare Jangar WAL rate, HOT-update ratio, and both Jangar RBD image write rates with the 0.603 MiB/s pre-change WAL
+   baseline and require WAL below 0.3015 MiB/s.
+7. Require the shared RBD pool and Kafka controllers to complete a new 30-minute observation with no request timeout,
    broker fencing, slow controller event above two seconds, or sustained ISR loss.
-7. Only after the observation passes, proceed with the bounded Options archive activation.
+8. Only after the observation passes, proceed with the bounded Options archive activation.
 
 ## Rollback and cleanup
 
 The quant-series deletion is irreversible. After that migration applies, an image rollback to code that expects the
 series table is prohibited; recovery is roll-forward only. The legacy pipeline-health table remains available during
 this slice and is not dropped or truncated by the quant-series migration.
+
+The cache-persistence migration is also roll-forward only. Re-logging the derived tables would restore the measured WAL
+and asynchronous-replica amplification. Authoritative Torghut trading, order, execution, accounting, and market-data
+tables are not changed.
 
 After the new path soaks and repository/runtime searches prove no legacy pipeline-health readers or writers, a follow-up
 migration may drop `quant_pipeline_health`.

--- a/services/jangar/src/server/__tests__/kysely-migrations.test.ts
+++ b/services/jangar/src/server/__tests__/kysely-migrations.test.ts
@@ -127,6 +127,20 @@ describe('migration registration', () => {
     expect(normalized).not.toContain('export const down')
   })
 
+  it('makes rebuildable quant state unlogged without a compatibility path', () => {
+    const migrationPath = new URL('../migrations/20260715_torghut_quant_state_cache_unlogged.ts', import.meta.url)
+    const normalized = readFileSync(fileURLToPath(migrationPath), 'utf8').toLowerCase().replace(/\s+/g, ' ')
+
+    expect(normalized).toContain('drop index torghut_control_plane.torghut_quant_pipeline_health_latest_freshness_idx')
+    expect(normalized).toContain('alter table torghut_control_plane.quant_metrics_latest set (fillfactor = 70)')
+    expect(normalized).toContain('alter table torghut_control_plane.quant_metrics_latest set unlogged')
+    expect(normalized).toContain('alter table torghut_control_plane.quant_pipeline_health_latest set (fillfactor = 70)')
+    expect(normalized).toContain('alter table torghut_control_plane.quant_pipeline_health_latest set unlogged')
+    expect(normalized).not.toContain('if exists')
+    expect(normalized).not.toContain('set logged')
+    expect(normalized).not.toContain('export const down')
+  })
+
   it('keeps the Codex judge AgentRun column migration registered as a retired Agents backfill handoff', () => {
     expect(__test__.getRegisteredMigrations()).toContain('20260520_codex_judge_agentrun_columns')
     expect(__test__.getRetiredMigrationNames()).toContain('20260520_codex_judge_agentrun_columns')

--- a/services/jangar/src/server/__tests__/torghut-quant-metrics-store.test.ts
+++ b/services/jangar/src/server/__tests__/torghut-quant-metrics-store.test.ts
@@ -170,6 +170,29 @@ describe('torghut quant metrics store', () => {
     expect(normalized.join(' ')).not.toContain('insert into')
   })
 
+  it('converts rebuildable quant state to update-friendly unlogged caches', async () => {
+    const { db, calls } = makeFakeDb()
+    const { up } = await import('../migrations/20260715_torghut_quant_state_cache_unlogged')
+
+    await up(db)
+
+    expect(calls).toHaveLength(9)
+    const normalized = calls.map((call) => call.sql.toLowerCase().replace(/\s+/g, ' '))
+    expect(normalized[0]).toContain("set local lock_timeout = '5s'")
+    expect(normalized[1]).toContain("set local statement_timeout = '60s'")
+    expect(normalized[2]).toContain(
+      'drop index torghut_control_plane.torghut_quant_pipeline_health_latest_freshness_idx',
+    )
+    expect(normalized[3]).toContain('alter table torghut_control_plane.quant_metrics_latest set (fillfactor = 70)')
+    expect(normalized[4]).toContain('alter table torghut_control_plane.quant_metrics_latest set unlogged')
+    expect(normalized[5]).toContain(
+      'alter table torghut_control_plane.quant_pipeline_health_latest set (fillfactor = 70)',
+    )
+    expect(normalized[6]).toContain('alter table torghut_control_plane.quant_pipeline_health_latest set unlogged')
+    expect(normalized[7]).toContain('analyze torghut_control_plane.quant_metrics_latest')
+    expect(normalized[8]).toContain('analyze torghut_control_plane.quant_pipeline_health_latest')
+  })
+
   it('avoids physical latest-metric updates when every material value is unchanged', async () => {
     const { db, calls } = makeFakeDb()
     dbMocks.getDb.mockReturnValue(db)

--- a/services/jangar/src/server/kysely-migrations.ts
+++ b/services/jangar/src/server/kysely-migrations.ts
@@ -24,6 +24,7 @@ import * as atlasCurrentCorpusMigration from '~/server/migrations/20260714_atlas
 import * as torghutQuantPipelineHealthLatestMigration from '~/server/migrations/20260715_torghut_quant_pipeline_health_latest'
 import * as torghutQuantSeriesActiveMigration from '~/server/migrations/20260715_torghut_quant_series_active'
 import * as torghutQuantSeriesRemoveMigration from '~/server/migrations/20260715_torghut_quant_series_remove'
+import * as torghutQuantStateCacheUnloggedMigration from '~/server/migrations/20260715_torghut_quant_state_cache_unlogged'
 
 type MigrationMap = Record<string, Migration>
 
@@ -62,6 +63,7 @@ const migrations: MigrationMap = {
   '20260715_torghut_quant_pipeline_health_latest': torghutQuantPipelineHealthLatestMigration,
   '20260715_torghut_quant_series_active': torghutQuantSeriesActiveMigration,
   '20260715_torghut_quant_series_remove': torghutQuantSeriesRemoveMigration,
+  '20260715_torghut_quant_state_cache_unlogged': torghutQuantStateCacheUnloggedMigration,
 }
 
 export const getRegisteredMigrationNames = () => Object.keys(migrations).sort()

--- a/services/jangar/src/server/migrations/20260715_torghut_quant_state_cache_unlogged.ts
+++ b/services/jangar/src/server/migrations/20260715_torghut_quant_state_cache_unlogged.ts
@@ -1,0 +1,40 @@
+import { type Kysely, sql } from 'kysely'
+
+import type { Database } from '../db'
+
+export const up = async (db: Kysely<Database>) => {
+  await sql`SET LOCAL lock_timeout = '5s';`.execute(db)
+  await sql`SET LOCAL statement_timeout = '60s';`.execute(db)
+
+  // These tables are rebuildable Jangar projections, not authoritative trading data.
+  // Keep one database-backed read path while removing WAL replay from the asynchronous
+  // replica. After a crash or failover the quant loop repopulates them; readers report
+  // empty/stale state until that completes instead of falling back to legacy history.
+  await sql`
+    DROP INDEX torghut_control_plane.torghut_quant_pipeline_health_latest_freshness_idx;
+  `.execute(db)
+
+  await sql`
+    ALTER TABLE torghut_control_plane.quant_metrics_latest
+    SET (fillfactor = 70);
+  `.execute(db)
+  await sql`
+    ALTER TABLE torghut_control_plane.quant_metrics_latest
+    SET UNLOGGED;
+  `.execute(db)
+
+  await sql`
+    ALTER TABLE torghut_control_plane.quant_pipeline_health_latest
+    SET (fillfactor = 70);
+  `.execute(db)
+  await sql`
+    ALTER TABLE torghut_control_plane.quant_pipeline_health_latest
+    SET UNLOGGED;
+  `.execute(db)
+
+  await sql`ANALYZE torghut_control_plane.quant_metrics_latest;`.execute(db)
+  await sql`ANALYZE torghut_control_plane.quant_pipeline_health_latest;`.execute(db)
+}
+
+// Intentionally roll-forward only. Re-logging rebuildable cache rows would restore
+// the WAL and replica-write amplification this migration removes.


### PR DESCRIPTION
## Summary

- Convert Jangar's rebuildable quant latest-metric and pipeline-health projections to unlogged PostgreSQL tables.
- Reserve heap space for HOT updates and remove the compact health table's `updated_at` index that changed on every heartbeat.
- Record the live post-series-removal WAL/RBD evidence, failure semantics, and rollout gates in the remediation design.

## Related Issues

None.

## Testing

- `nix develop -c bun run test` from `services/jangar`: 698 passed, 4 skipped.
- `nix develop -c bun run tsc` from `services/jangar`.
- `nix develop -c bun run lint` from `services/jangar`.
- `nix develop -c bun run lint:oxlint` from `services/jangar`: 0 errors; pre-existing warnings only.
- `nix develop -c bun run lint:oxlint:type` from `services/jangar`: 0 errors; pre-existing warnings only.
- `nix develop -c bun run docs:inventory:check` from `services/jangar`.
- `nix develop -c bun run test -- src/server/__tests__/kysely-migrations.test.ts src/server/__tests__/torghut-quant-metrics-store.test.ts` from `services/jangar`: 24 passed.
- `git diff --check`.
- Live pre-change validation confirmed the two target tables are rebuildable 22.7 MiB/811 KiB projections with no foreign-key dependencies; a transaction-separated 60.119-second sample measured 0.5975 MiB/s WAL and 18,252/2,628 updates.

## Breaking Changes

The two derived cache tables no longer replicate their contents to the CNPG standby and can be empty after an unclean PostgreSQL restart or standby promotion. Jangar repopulates them from authoritative Torghut data; health and witness routes report empty/stale state until that completes. The migration is intentionally roll-forward only and adds no legacy read or write fallback.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
