### PR TITLE
fix(torghut): mirror validation receipt guards

### DIFF
--- a/services/torghut/app/models/entities/broker_mutation_records.py
+++ b/services/torghut/app/models/entities/broker_mutation_records.py
@@ -19,8 +19,13 @@ from sqlalchemy import (
     text,
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.schema import conv
 
 from ..base import Base, GUID
+from .broker_mutation_validation_contract import (
+    BROKER_MUTATION_VALIDATION_AUTHORITY_SQL,
+    BROKER_MUTATION_VALIDATION_PERMIT_ID_SQL,
+)
 
 if TYPE_CHECKING:
     from .trading_records import TradeDecisionSubmissionClaim
@@ -136,6 +141,10 @@ class BrokerMutationReceipt(Base):
             "AND risk_class = 'risk_reducing'))",
             name="operation_contract",
         ),
+        CheckConstraint(
+            BROKER_MUTATION_VALIDATION_AUTHORITY_SQL,
+            name=conv("ck_bm_receipt_validation_authority"),
+        ).ddl_if(dialect="postgresql"),
         CheckConstraint("length(endpoint_fingerprint) = 64", name="endpoint_hash"),
         CheckConstraint(
             "intent_schema_version = 'torghut.broker-mutation-intent.v1'",
@@ -180,6 +189,12 @@ class BrokerMutationReceipt(Base):
                 "operation = 'submit_order' AND submission_claim_id IS NOT NULL"
             ),
         ),
+        Index(
+            "uq_bm_receipt_validation_permit",
+            text(BROKER_MUTATION_VALIDATION_PERMIT_ID_SQL),
+            unique=True,
+            postgresql_where=text("purpose = 'control_plane_validation'"),
+        ).ddl_if(dialect="postgresql"),
         Index("ix_broker_mutation_receipts_workflow", "workflow_id"),
         Index(
             "ix_broker_mutation_receipts_target",

--- a/services/torghut/app/models/entities/broker_mutation_validation_contract.py
+++ b/services/torghut/app/models/entities/broker_mutation_validation_contract.py
@@ -1,0 +1,182 @@
+"""PostgreSQL-only ORM guards for infrastructure-validation receipts."""
+
+from __future__ import annotations
+
+BROKER_MUTATION_VALIDATION_AUTHORITY_SQL = r"""
+purpose <> 'control_plane_validation' OR COALESCE((
+  broker_route = 'alpaca'
+  AND endpoint_fingerprint =
+      'e7ce2f426f96cfc1606a46bc494cdfff68192ac2de4529bf406007d11d059ad7'
+  AND operation = 'submit_order'
+  AND risk_class = 'risk_neutral'
+  AND submission_claim_id IS NULL
+  AND workflow_id = client_request_id
+  AND client_request_id ~ '^ivp-[0-9a-f]{44}$'
+  AND target_kind = 'order'
+  AND target_key = client_request_id
+  AND canonical_intent_json::jsonb #>>
+      '{request,broker_request,extra_params,client_order_id}' = client_request_id
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,schema_version}' =
+      'torghut.infrastructure-validation-permit.v2'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,purpose}' =
+      'control_plane_validation'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,venue}' = 'alpaca'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,account_mode}' = 'paper'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,account_label}' = account_label
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,broker_base_url}' IN
+      ('https://paper-api.alpaca.markets',
+       'https://paper-api.alpaca.markets/')
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,asset_class}' = 'crypto'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,market_session}' = 'continuous'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,evidence_tag}' =
+      'non_promotable_validation'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,promotable}' = 'false'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,max_orders}' = '1'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,max_outstanding_intents}' = '1'
+  AND (canonical_intent_json::jsonb #>>
+       '{request,infrastructure_validation,permit,max_notional_usd}')::numeric
+      > 0
+  AND (canonical_intent_json::jsonb #>>
+       '{request,infrastructure_validation,permit,max_notional_usd}')::numeric
+      <= 1
+  AND (canonical_intent_json::jsonb #>>
+       '{request,infrastructure_validation,permit,max_loss_usd}')::numeric
+      > 0
+  AND (canonical_intent_json::jsonb #>>
+       '{request,infrastructure_validation,permit,max_loss_usd}')::numeric
+      <= 1
+  AND (canonical_intent_json::jsonb #>>
+       '{request,infrastructure_validation,permit,max_loss_usd}')::numeric
+      <= (canonical_intent_json::jsonb #>>
+          '{request,infrastructure_validation,permit,max_notional_usd}')::numeric
+  AND lower(canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,issued_by}') <>
+      lower(canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,approved_by}')
+  AND length(canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,issued_by}') BETWEEN 1 AND 128
+  AND length(canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,approved_by}') BETWEEN 1 AND 128
+  AND length(canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,permit_id}') BETWEEN 1 AND 128
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit_sha256}' ~ '^[0-9a-f]{64}$'
+  AND created_at >= (canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,issued_at}')::timestamptz
+  AND created_at < (canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,expires_at}')::timestamptz
+  AND (canonical_intent_json::jsonb #>>
+       '{request,infrastructure_validation,permit,expires_at}')::timestamptz
+      - (canonical_intent_json::jsonb #>>
+         '{request,infrastructure_validation,permit,issued_at}')::timestamptz
+      <= interval '15 minutes'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,test_plan_digest}' =
+      canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,test_plan_sha256}'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,test_plan_sha256}' ~ '^[0-9a-f]{64}$'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,expected_terminal_state_digest}' =
+      canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,expected_terminal_state_sha256}'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,expected_terminal_state_sha256}' =
+      '796e64c0dfebb4e72c3c56990b7976a952ff772822b3b02104af024a5fefd03e'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,expected_terminal_state}' =
+      'no_open_orders_no_positions_no_unsettled_claims'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,expected_terminal_state,schema_version}' =
+      'torghut.infrastructure-validation-terminal.v1'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,expected_terminal_state,state}' =
+      'no_open_orders_no_positions_no_unsettled_claims'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,test_plan,schema_version}' =
+      'torghut.infrastructure-validation-order-plan.v1'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,test_plan,venue}' = 'alpaca'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,test_plan,asset_class}' =
+      canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,permit,asset_class}'
+  AND canonical_intent_json::jsonb #>>
+      '{request,broker_request,symbol}' =
+      canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,test_plan,symbol}'
+  AND canonical_intent_json::jsonb #>
+      '{request,infrastructure_validation,permit,symbols}' =
+      jsonb_build_array(canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,test_plan,symbol}')
+  AND canonical_intent_json::jsonb #>>
+      '{request,broker_request,side}' = 'buy'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,test_plan,side}' = 'buy'
+  AND canonical_intent_json::jsonb #>
+      '{request,infrastructure_validation,permit,sides}' = '["buy"]'::jsonb
+  AND canonical_intent_json::jsonb #>>
+      '{request,broker_request,order_type}' = 'limit'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,test_plan,order_type}' = 'limit'
+  AND canonical_intent_json::jsonb #>
+      '{request,infrastructure_validation,permit,order_types}' = '["limit"]'::jsonb
+  AND canonical_intent_json::jsonb #>>
+      '{request,broker_request,time_in_force}' = 'ioc'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation,test_plan,time_in_force}' = 'ioc'
+  AND (canonical_intent_json::jsonb #>>
+       '{request,infrastructure_validation,test_plan,qty}')::numeric > 0
+  AND (canonical_intent_json::jsonb #>>
+       '{request,infrastructure_validation,test_plan,limit_price}')::numeric > 0
+  AND (canonical_intent_json::jsonb #>>
+       '{request,broker_request,qty}')::numeric =
+      (canonical_intent_json::jsonb #>>
+       '{request,infrastructure_validation,test_plan,qty}')::numeric
+  AND (canonical_intent_json::jsonb #>>
+       '{request,broker_request,limit_price}')::numeric =
+      (canonical_intent_json::jsonb #>>
+       '{request,infrastructure_validation,test_plan,limit_price}')::numeric
+  AND (canonical_intent_json::jsonb #>>
+       '{request,infrastructure_validation,test_plan,qty}')::numeric *
+      (canonical_intent_json::jsonb #>>
+       '{request,infrastructure_validation,test_plan,limit_price}')::numeric
+      <= (canonical_intent_json::jsonb #>>
+          '{request,infrastructure_validation,permit,max_notional_usd}')::numeric
+  AND (canonical_intent_json::jsonb #>>
+       '{request,infrastructure_validation,test_plan,qty}')::numeric *
+      (canonical_intent_json::jsonb #>>
+       '{request,infrastructure_validation,test_plan,limit_price}')::numeric
+      <= (canonical_intent_json::jsonb #>>
+          '{request,infrastructure_validation,permit,max_loss_usd}')::numeric
+  AND canonical_intent_json::jsonb #>
+      '{request,broker_request,extra_params}' =
+      jsonb_build_object('client_order_id', client_request_id)
+  AND canonical_intent_json::jsonb #>
+      '{request,broker_request,stop_price}' = 'null'::jsonb
+  AND canonical_intent_json::jsonb #>
+      '{request,infrastructure_validation,test_plan,stop_price}' = 'null'::jsonb
+), FALSE)
+"""
+
+BROKER_MUTATION_VALIDATION_PERMIT_ID_SQL = (
+    "(canonical_intent_json::jsonb #>> "
+    "'{request,infrastructure_validation,permit,permit_id}')"
+)
+
+__all__ = [
+    "BROKER_MUTATION_VALIDATION_AUTHORITY_SQL",
+    "BROKER_MUTATION_VALIDATION_PERMIT_ID_SQL",
+]

--- a/services/torghut/tests/test_broker_mutation_receipt_models.py
+++ b/services/torghut/tests/test_broker_mutation_receipt_models.py
@@ -2,9 +2,18 @@ from __future__ import annotations
 
 from typing import cast
 
-from sqlalchemy import CheckConstraint, Table, UniqueConstraint
+from sqlalchemy import (
+    CheckConstraint,
+    Table,
+    UniqueConstraint,
+    create_mock_engine,
+)
 
 from app.models import BrokerMutationReceipt, BrokerMutationReceiptEvent
+from app.models.entities.broker_mutation_validation_contract import (
+    BROKER_MUTATION_VALIDATION_AUTHORITY_SQL,
+)
+from tests.migration_testing import load_migration_module
 
 
 def _table(
@@ -59,6 +68,48 @@ def test_receipt_header_encodes_the_exact_broker_mutation_contract() -> None:
     )
     assert "operation = 'submit_order'" in str(
         submit_claim.dialect_options["postgresql"]["where"]
+    )
+
+
+def test_receipt_header_mirrors_validation_authority_and_permit_guards() -> None:
+    table = _table(BrokerMutationReceipt)
+    validation_check = next(
+        constraint
+        for constraint in table.constraints
+        if isinstance(constraint, CheckConstraint)
+        and constraint.name == "ck_bm_receipt_validation_authority"
+    )
+    assert str(validation_check.sqltext).strip() == (
+        BROKER_MUTATION_VALIDATION_AUTHORITY_SQL.strip()
+    )
+
+    validation_permit = next(
+        index
+        for index in table.indexes
+        if index.name == "uq_bm_receipt_validation_permit"
+    )
+    assert validation_permit.unique
+    assert "permit,permit_id" in str(validation_permit.expressions[0])
+    assert "control_plane_validation" in str(
+        validation_permit.dialect_options["postgresql"]["where"]
+    )
+
+    statements: list[str] = []
+    engine = create_mock_engine(
+        "postgresql+psycopg://",
+        lambda statement, *_args, **_kwargs: statements.append(
+            str(statement.compile(dialect=engine.dialect))
+        ),
+    )
+    table.create(engine)
+    ddl = "\n".join(statements)
+    assert "CONSTRAINT ck_bm_receipt_validation_authority" in ddl
+    assert "CREATE UNIQUE INDEX uq_bm_receipt_validation_permit" in ddl
+    assert "non_promotable_validation" in ddl
+
+    migration = load_migration_module("0068_infrastructure_validation_submit.py")
+    assert str(getattr(migration, "_VALIDATION_AUTHORITY")).strip() == (
+        BROKER_MUTATION_VALIDATION_AUTHORITY_SQL.strip()
     )
 
 


### PR DESCRIPTION
## Summary

- mirror migration 0068's infrastructure-validation authority constraint in ORM metadata
- add the PostgreSQL-only unique validation-permit index for `Base.metadata.create_all` schemas
- keep the validation contract SQL in one model constant and assert exact parity with the migration

## Related review

- PR #12494, Codex discussion `3583540506`

## Testing

- `pytest -q tests/test_broker_mutation_receipt_models.py tests/test_infrastructure_validation_submit_migration.py` (8 passed)
- all three required Pyright profiles
- Ruff format/check on changed files
- changed-line Pylint and file-length gates
- compileall and `git diff --check`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents exact validation
- [x] Breaking Changes is filled in
- [x] Regression coverage added