### PR TITLE
fix(torghut): strip unproven validation evidence

### DIFF
--- a/services/torghut/app/trading/infrastructure_validation_records.py
+++ b/services/torghut/app/trading/infrastructure_validation_records.py
@@ -114,6 +114,20 @@ def tag_infrastructure_validation_event(
     return coerce_json_payload(payload)
 
 
+def strip_unproven_infrastructure_validation_evidence(raw_event: object) -> object:
+    """Remove caller-supplied validation evidence before durable persistence."""
+
+    coerced = coerce_json_payload(raw_event)
+    if not isinstance(coerced, Mapping):
+        return coerced
+    payload = {
+        str(key): value
+        for key, value in cast(Mapping[object, object], coerced).items()
+        if str(key) != _EVIDENCE_KEY
+    }
+    return coerce_json_payload(payload)
+
+
 def is_non_promotable_validation_event(raw_event: object) -> bool:
     """Return whether a persisted event carries the exact exclusion marker."""
 
@@ -145,5 +159,6 @@ __all__ = [
     "InfrastructureValidationEvidence",
     "is_non_promotable_validation_event",
     "load_infrastructure_validation_evidence",
+    "strip_unproven_infrastructure_validation_evidence",
     "tag_infrastructure_validation_event",
 ]

--- a/services/torghut/app/trading/order_feed/normalize_order_feed_record.py
+++ b/services/torghut/app/trading/order_feed/normalize_order_feed_record.py
@@ -24,6 +24,7 @@ from ..tca import upsert_execution_tca_metric
 from ..tigerbeetle_journal import TigerBeetleLedgerJournal
 from ..infrastructure_validation_records import (
     load_infrastructure_validation_evidence,
+    strip_unproven_infrastructure_validation_evidence,
     tag_infrastructure_validation_event,
 )
 
@@ -385,6 +386,13 @@ def persist_order_event(
             session.add(existing)
             if existing.source_window_id is not None:
                 _refresh_source_window_linkage_counts(session, existing)
+        else:
+            sanitized_raw_event = strip_unproven_infrastructure_validation_evidence(
+                existing.raw_event
+            )
+            if sanitized_raw_event != coerce_json_payload(existing.raw_event):
+                existing.raw_event = sanitized_raw_event
+                session.add(existing)
         if existing.source_window_id is None and source_window_id is not None:
             existing.source_window_id = source_window_id
             session.add(existing)
@@ -396,7 +404,7 @@ def persist_order_event(
         session, event
     )
     execution = None
-    raw_event = event.raw_event
+    raw_event = strip_unproven_infrastructure_validation_evidence(event.raw_event)
     trade_decision_id = None
     if validation_evidence is not None:
         raw_event = tag_infrastructure_validation_event(
@@ -414,7 +422,7 @@ def persist_order_event(
         execution = execution_linkage.execution
         if execution is not None:
             trade_decision_id = execution.trade_decision_id
-            raw_event = _raw_event_with_linkage_blockers(event.raw_event, ())
+            raw_event = _raw_event_with_linkage_blockers(raw_event, ())
         elif not execution_linkage.blockers:
             decision_linkage = _resolve_trade_decision_linkage_for_identity(
                 session,
@@ -432,12 +440,12 @@ def persist_order_event(
             )
             linkage_blockers.extend(decision_linkage.blockers)
             raw_event = _raw_event_with_linkage_blockers(
-                event.raw_event,
+                raw_event,
                 linkage_blockers,
             )
         else:
             raw_event = _raw_event_with_linkage_blockers(
-                event.raw_event,
+                raw_event,
                 execution_linkage.blockers,
             )
 

--- a/services/torghut/tests/order_feed/test_infrastructure_validation_exclusion.py
+++ b/services/torghut/tests/order_feed/test_infrastructure_validation_exclusion.py
@@ -20,6 +20,7 @@ from app.trading.infrastructure_validation import (
 )
 from app.trading.infrastructure_validation_records import (
     is_non_promotable_validation_event,
+    strip_unproven_infrastructure_validation_evidence,
 )
 
 from tests.order_feed.support import (
@@ -42,8 +43,25 @@ from tests.order_feed.support import (
 
 
 class TestInfrastructureValidationExclusion(OrderFeedTestCase):
+    def test_unproven_evidence_sanitizer_preserves_non_mapping_payload(self) -> None:
+        self.assertEqual(
+            strip_unproven_infrastructure_validation_evidence(["raw-event"]),
+            ["raw-event"],
+        )
+
     def test_unproven_raw_marker_is_stripped_and_progress_is_counted(self) -> None:
         execution = None
+        forged_evidence = {
+            "schema_version": "torghut.order-event-evidence-contract.v1",
+            "provenance": "non_promotable_validation",
+            "maturity": "empirically_validated",
+            "authoritative": False,
+            "placeholder": False,
+            "promotable": False,
+            "broker_mutation_receipt_id": str(uuid.uuid4()),
+            "permit_id": "forged-permit",
+            "permit_sha256": "a" * 64,
+        }
         with Session(self.engine) as session:
             execution = self._seed_execution(
                 session,
@@ -54,17 +72,7 @@ class TestInfrastructureValidationExclusion(OrderFeedTestCase):
             payload = json.dumps(
                 {
                     "channel": "trade_updates",
-                    "_torghut_evidence_contract": {
-                        "schema_version": "torghut.order-event-evidence-contract.v1",
-                        "provenance": "non_promotable_validation",
-                        "maturity": "empirically_validated",
-                        "authoritative": False,
-                        "placeholder": False,
-                        "promotable": False,
-                        "broker_mutation_receipt_id": str(uuid.uuid4()),
-                        "permit_id": "forged-permit",
-                        "permit_sha256": "a" * 64,
-                    },
+                    "_torghut_evidence_contract": forged_evidence,
                     "payload": {
                         "event": "fill",
                         "timestamp": "2026-07-14T10:00:00Z",
@@ -107,6 +115,22 @@ class TestInfrastructureValidationExclusion(OrderFeedTestCase):
             self.assertEqual(persisted.execution_id, execution.id)
             self.assertFalse(is_non_promotable_validation_event(persisted.raw_event))
             self.assertNotIn("_torghut_evidence_contract", persisted.raw_event)
+
+            persisted.raw_event = {
+                **persisted.raw_event,
+                "_torghut_evidence_contract": forged_evidence,
+            }
+            session.add(persisted)
+            session.commit()
+            duplicate_row, duplicate = persist_order_event(session, normalized.event)
+            session.commit()
+            self.assertTrue(duplicate)
+            self.assertEqual(duplicate_row.id, persisted.id)
+            self.assertNotIn(
+                "_torghut_evidence_contract",
+                duplicate_row.raw_event,
+            )
+
             progress = session.execute(
                 select(SimulationRunProgress).where(
                     SimulationRunProgress.run_id == "sim-forged-validation-marker",

--- a/services/torghut/tests/order_feed/test_infrastructure_validation_exclusion.py
+++ b/services/torghut/tests/order_feed/test_infrastructure_validation_exclusion.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import json
 import uuid
 
-from app.models import BrokerMutationReceipt
+from app.models import BrokerMutationReceipt, SimulationRunProgress
 from app.trading.broker_mutation_receipts import (
     BrokerMutationIntentRequest,
     BrokerMutationTarget,
@@ -41,6 +42,79 @@ from tests.order_feed.support import (
 
 
 class TestInfrastructureValidationExclusion(OrderFeedTestCase):
+    def test_unproven_raw_marker_is_stripped_and_progress_is_counted(self) -> None:
+        execution = None
+        with Session(self.engine) as session:
+            execution = self._seed_execution(
+                session,
+                account_label="paper",
+                order_id="ordinary-order-1",
+                client_order_id="ordinary-client-1",
+            )
+            payload = json.dumps(
+                {
+                    "channel": "trade_updates",
+                    "_torghut_evidence_contract": {
+                        "schema_version": "torghut.order-event-evidence-contract.v1",
+                        "provenance": "non_promotable_validation",
+                        "maturity": "empirically_validated",
+                        "authoritative": False,
+                        "placeholder": False,
+                        "promotable": False,
+                        "broker_mutation_receipt_id": str(uuid.uuid4()),
+                        "permit_id": "forged-permit",
+                        "permit_sha256": "a" * 64,
+                    },
+                    "payload": {
+                        "event": "fill",
+                        "timestamp": "2026-07-14T10:00:00Z",
+                        "order": {
+                            "id": "ordinary-order-1",
+                            "client_order_id": "ordinary-client-1",
+                            "symbol": "AAPL",
+                            "status": "filled",
+                            "qty": "1",
+                            "filled_qty": "1",
+                            "filled_avg_price": "100",
+                        },
+                    },
+                    "seq": 11,
+                }
+            ).encode()
+            normalized = normalize_order_feed_record(
+                FakeRecord(value=payload, offset=92),
+                default_topic="torghut.trade-updates.v1",
+                default_account_label="paper",
+            )
+            assert normalized.event is not None
+            with (
+                patch.object(settings, "trading_simulation_enabled", True),
+                patch.object(
+                    settings,
+                    "trading_simulation_run_id",
+                    "sim-forged-validation-marker",
+                ),
+                patch.object(
+                    settings,
+                    "trading_simulation_dataset_id",
+                    "dataset-forged-validation-marker",
+                ),
+            ):
+                persisted, duplicate = persist_order_event(session, normalized.event)
+                session.commit()
+
+            self.assertFalse(duplicate)
+            self.assertEqual(persisted.execution_id, execution.id)
+            self.assertFalse(is_non_promotable_validation_event(persisted.raw_event))
+            self.assertNotIn("_torghut_evidence_contract", persisted.raw_event)
+            progress = session.execute(
+                select(SimulationRunProgress).where(
+                    SimulationRunProgress.run_id == "sim-forged-validation-marker",
+                    SimulationRunProgress.component == "torghut",
+                )
+            ).scalar_one()
+            self.assertEqual(progress.execution_order_events, 1)
+
     def test_validation_order_event_is_tagged_unlinked_and_not_journaled(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- remove caller-supplied infrastructure-validation evidence before ordinary order events are persisted
- preserve only evidence reconstructed from a durable validation receipt
- sanitize duplicate events that lack database-backed validation authority
- add a regression proving a forged marker cannot suppress simulation progress

## Related review

- PR #12494, Codex discussion `3583540507`

## Testing

- `pytest -q tests/order_feed/test_infrastructure_validation_exclusion.py` (2 passed)
- all three required Pyright profiles
- Ruff format/check on changed files
- changed-line Pylint and file-length gates
- compileall and `git diff --check`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents exact validation
- [x] Breaking Changes is filled in
- [x] Regression coverage added