### PR TITLE
fix(jangar): lock quant rollback snapshot

### DIFF
--- a/services/jangar/src/server/__tests__/kysely-migrations.test.ts
+++ b/services/jangar/src/server/__tests__/kysely-migrations.test.ts
@@ -109,6 +109,9 @@ describe('migration registration', () => {
     expect(normalized).toContain('create view torghut_control_plane.quant_metrics_series as')
     expect(normalized).toContain('instead of insert on torghut_control_plane.quant_metrics_series')
     expect(normalized).toContain('on conflict (id) do nothing')
+    expect(normalized).toContain(
+      'lock table torghut_control_plane.quant_metrics_series_active in access exclusive mode',
+    )
     expect(normalized).not.toContain('vacuum full')
     expect(normalized).not.toContain('reindex')
     expect(normalized).not.toContain('unlogged')

--- a/services/jangar/src/server/__tests__/kysely-migrations.test.ts
+++ b/services/jangar/src/server/__tests__/kysely-migrations.test.ts
@@ -110,7 +110,7 @@ describe('migration registration', () => {
     expect(normalized).toContain('instead of insert on torghut_control_plane.quant_metrics_series')
     expect(normalized).toContain('on conflict (id) do nothing')
     expect(normalized).toContain(
-      'lock table torghut_control_plane.quant_metrics_series_active in access exclusive mode',
+      'lock table torghut_control_plane.quant_metrics_series, torghut_control_plane.quant_metrics_series_active in access exclusive mode',
     )
     expect(normalized).not.toContain('vacuum full')
     expect(normalized).not.toContain('reindex')

--- a/services/jangar/src/server/__tests__/torghut-quant-metrics-store.test.ts
+++ b/services/jangar/src/server/__tests__/torghut-quant-metrics-store.test.ts
@@ -151,6 +151,23 @@ describe('torghut quant metrics store', () => {
     expect(normalized.join(' ')).not.toContain('create table as select')
   })
 
+  it('blocks compatibility-view writes before copying rollback rows', async () => {
+    const { db, calls } = makeFakeDb()
+    const { down } = await import('../migrations/20260715_torghut_quant_series_active')
+
+    await down(db)
+
+    expect(calls).toHaveLength(8)
+    const normalized = calls.map((call) => call.sql.toLowerCase().replace(/\s+/g, ' '))
+    expect(normalized[0]).toContain("set local lock_timeout = '5s'")
+    expect(normalized[1]).toContain(
+      'lock table torghut_control_plane.quant_metrics_series_active in access exclusive mode',
+    )
+    expect(normalized[2]).toContain('insert into torghut_control_plane.quant_metrics_series_legacy')
+    expect(normalized[2]).toContain('from torghut_control_plane.quant_metrics_series_active')
+    expect(normalized[3]).toContain('drop trigger if exists quant_metrics_series_active_insert')
+  })
+
   it('drops the unused series API stores without cascading into unrelated relations', async () => {
     const { db, calls } = makeFakeDb()
     const { up } = await import('../migrations/20260715_torghut_quant_series_remove')

--- a/services/jangar/src/server/__tests__/torghut-quant-metrics-store.test.ts
+++ b/services/jangar/src/server/__tests__/torghut-quant-metrics-store.test.ts
@@ -161,7 +161,10 @@ describe('torghut quant metrics store', () => {
     const normalized = calls.map((call) => call.sql.toLowerCase().replace(/\s+/g, ' '))
     expect(normalized[0]).toContain("set local lock_timeout = '5s'")
     expect(normalized[1]).toContain(
-      'lock table torghut_control_plane.quant_metrics_series_active in access exclusive mode',
+      'lock table torghut_control_plane.quant_metrics_series, torghut_control_plane.quant_metrics_series_active in access exclusive mode',
+    )
+    expect(normalized[1].indexOf('quant_metrics_series,')).toBeLessThan(
+      normalized[1].indexOf('quant_metrics_series_active'),
     )
     expect(normalized[2]).toContain('insert into torghut_control_plane.quant_metrics_series_legacy')
     expect(normalized[2]).toContain('from torghut_control_plane.quant_metrics_series_active')

--- a/services/jangar/src/server/migrations/20260715_torghut_quant_series_active.ts
+++ b/services/jangar/src/server/migrations/20260715_torghut_quant_series_active.ts
@@ -135,13 +135,16 @@ export const up = async (db: Kysely<Database>) => {
 export const down = async (db: Kysely<Database>) => {
   await sql`SET LOCAL lock_timeout = '5s';`.execute(db)
   await sql`
-    LOCK TABLE torghut_control_plane.quant_metrics_series_active
+    LOCK TABLE
+      torghut_control_plane.quant_metrics_series,
+      torghut_control_plane.quant_metrics_series_active
     IN ACCESS EXCLUSIVE MODE;
   `.execute(db)
 
   // Preserve rows written after cutover before restoring the physical legacy
-  // table. The active-table lock blocks the compatibility-view trigger before
-  // the snapshot and remains held through the destructive rollback steps.
+  // table. Lock the compatibility view first so no writer can hold its lock
+  // while blocking inside the trigger on the active table; both locks remain
+  // held through the destructive rollback steps.
   await sql
     .raw(`
     INSERT INTO torghut_control_plane.quant_metrics_series_legacy (${SERIES_COLUMNS})

--- a/services/jangar/src/server/migrations/20260715_torghut_quant_series_active.ts
+++ b/services/jangar/src/server/migrations/20260715_torghut_quant_series_active.ts
@@ -133,8 +133,15 @@ export const up = async (db: Kysely<Database>) => {
 }
 
 export const down = async (db: Kysely<Database>) => {
+  await sql`SET LOCAL lock_timeout = '5s';`.execute(db)
+  await sql`
+    LOCK TABLE torghut_control_plane.quant_metrics_series_active
+    IN ACCESS EXCLUSIVE MODE;
+  `.execute(db)
+
   // Preserve rows written after cutover before restoring the physical legacy
-  // table. This is intentionally the only data-copying path.
+  // table. The active-table lock blocks the compatibility-view trigger before
+  // the snapshot and remains held through the destructive rollback steps.
   await sql
     .raw(`
     INSERT INTO torghut_control_plane.quant_metrics_series_legacy (${SERIES_COLUMNS})


### PR DESCRIPTION
## Summary

- block compatibility-view inserts before the rollback snapshot is copied
- hold an `ACCESS EXCLUSIVE` lock on the active partitioned table through destructive rollback
- add migration-source and call-order regressions proving lock-before-copy behavior

## Related review

- PR #12534, Codex discussion `3584770170`

## Testing

- focused Vitest migration tests (25 passed)
- Oxfmt check on changed files
- Oxlint on changed files (0 warnings, 0 errors)
- `git diff --check`
- Full local Jangar TypeScript validation was unavailable because the reusable workspace install lacks unrelated Temporal/Bumba dependencies; authoritative CI is required for the full type gate.

## Breaking Changes

Rollback now waits for an `ACCESS EXCLUSIVE` lock on the active series table and fails within the existing five-second lock timeout rather than taking a lossy snapshot under live writes.

## Checklist

- [x] Testing section documents exact validation
- [x] Breaking Changes is filled in
- [x] Regression coverage added