### PR TITLE
fix(atlas): scope exact candidates and rank content

### DIFF
--- a/services/jangar/src/server/__tests__/atlas-store.test.ts
+++ b/services/jangar/src/server/__tests__/atlas-store.test.ts
@@ -478,6 +478,31 @@ describe('atlas store', () => {
     expect(exactSql?.sql.toLowerCase()).not.toMatch(/file_chunks\.content\s+%\s+\$/)
   })
 
+  it('pushes corpus and caller filters into every materialized exact-candidate scan', async () => {
+    const { db, calls } = makeFakeDb({ selectRows: [] })
+    const store = createPostgresAtlasStore({
+      url: 'postgresql://user:pass@localhost:5432/db',
+      createDb: () => db,
+    })
+
+    await store.codeSearch({
+      query: 'source search implementation',
+      repository: 'proompteng/lab',
+      ref: 'main',
+      pathPrefix: 'services/jangar',
+      language: 'typescript',
+    })
+
+    const exactSql = calls.find((call) => call.sql.toLowerCase().includes(' as exact_rank'))
+    const normalized = String(exactSql?.sql).toLowerCase().replace(/\s+/g, ' ')
+    const candidates = normalized.slice(normalized.indexOf('with exact_candidates'), normalized.indexOf(') select'))
+    expect(candidates.match(/repositories\.name =/g)).toHaveLength(2)
+    expect(candidates.match(/file_versions\.repository_ref =/g)).toHaveLength(4)
+    expect(candidates.match(/file_keys\.path like/g)).toHaveLength(2)
+    expect(candidates.match(/file_versions\.language =/g)).toHaveLength(2)
+    expect(candidates.match(/repositories\.metadata->>'indexstatus' = 'ready'/g)).toHaveLength(2)
+  })
+
   it('relaxes natural-language lexical queries by one content term', async () => {
     const { db, calls } = makeFakeDb({ selectRows: [] })
     const store = createPostgresAtlasStore({
@@ -511,7 +536,8 @@ describe('atlas store', () => {
     })
 
     const exactSql = calls.find((call) => call.sql.toLowerCase().includes(' as exact_rank'))
-    expect(exactSql?.sql).not.toMatch(/FROM atlas\.file_chunks AS file_chunks\s+WHERE file_chunks\.content IS NOT NULL/)
+    const normalized = String(exactSql?.sql).toLowerCase().replace(/\s+/g, ' ')
+    expect(normalized).not.toContain('union select file_chunks.id as chunk_id from atlas.file_chunks as file_chunks')
     expect(calls.some((call) => call.sql.toLowerCase().includes('from atlas.chunk_embeddings'))).toBe(false)
   })
 
@@ -529,7 +555,8 @@ describe('atlas store', () => {
     })
 
     const exactSql = calls.find((call) => call.sql.toLowerCase().includes(' as exact_rank'))
-    expect(exactSql?.sql).toMatch(/FROM atlas\.file_chunks AS file_chunks\s+WHERE file_chunks\.content IS NOT NULL/)
+    const normalized = String(exactSql?.sql).toLowerCase().replace(/\s+/g, ' ')
+    expect(normalized).toContain('union select file_chunks.id as chunk_id from atlas.file_chunks as file_chunks')
     expect(calls.some((call) => call.sql.toLowerCase().includes('from atlas.chunk_embeddings'))).toBe(true)
   })
 
@@ -634,6 +661,27 @@ describe('atlas store', () => {
 
     expect(matches.map((match) => match.chunk.id)).toEqual(['exact-chunk', 'weak-chunk'])
     expect(matches[0]?.signals.matchedIdentifiers).toEqual(['BUMBA_ATLAS_CHUNK_INDEXING'])
+  })
+
+  it('keeps generic content substring matches on the RRF score scale', async () => {
+    const generic = makeCodeSearchRow({
+      chunk_id: 'generic-content-chunk',
+      chunk_content: 'source',
+      exact_rank: 0.75,
+      file_key_path: 'generic.ts',
+    })
+    const { db } = makeFakeDb({ exactRows: [generic], lexicalRows: [], semanticRows: [] })
+    const store = createPostgresAtlasStore({
+      url: 'postgresql://user:pass@localhost:5432/db',
+      createDb: () => db,
+    })
+
+    const matches = await store.codeSearch({ query: 'source', repository: 'proompteng/lab', limit: 1 })
+
+    expect(matches).toHaveLength(1)
+    expect(matches[0]?.signals.exactRank).toBe(0.75)
+    expect(matches[0]?.score).toBeCloseTo(3 / 61)
+    expect(matches[0]?.score).toBeLessThan(0.1)
   })
 
   it('queries only the ready current commit and requested filters', async () => {

--- a/services/jangar/src/server/atlas-code-search.ts
+++ b/services/jangar/src/server/atlas-code-search.ts
@@ -123,6 +123,7 @@ const DEFAULT_CODE_SEARCH_STATEMENT_TIMEOUT_MS = 750
 const MAX_CODE_SEARCH_STATEMENT_TIMEOUT_MS = 900
 const DEFAULT_CODE_SEARCH_QUERY_EMBEDDING_CACHE_TTL_MS = 60_000
 const RRF_K = 60
+const EXACT_SCORE_BOOST_MIN_RANK = 0.9
 const ATLAS_QUERY_INSTRUCTION = 'Given a query, retrieve relevant source-code chunks from the repository'
 const LEXICAL_STOP_WORDS = new Set([
   'a',
@@ -525,6 +526,7 @@ export const createAtlasCodeSearchHandlers = ({
       ? null
       : vectorToPgArray(await embedCodeSearchQuery(resolvedQuery, embeddingConfig))
     const containsPattern = `%${escapeLikePattern(resolvedQuery)}%`
+    const whereClause = searchWhereClause(filters)
     const contentCandidateUnion = isPathQuery
       ? sql``
       : sql`
@@ -532,7 +534,11 @@ export const createAtlasCodeSearchHandlers = ({
 
           SELECT file_chunks.id AS chunk_id
           FROM atlas.file_chunks AS file_chunks
-          WHERE file_chunks.content IS NOT NULL
+          INNER JOIN atlas.file_versions AS file_versions ON file_versions.id = file_chunks.file_version_id
+          INNER JOIN atlas.file_keys AS file_keys ON file_keys.id = file_versions.file_key_id
+          INNER JOIN atlas.repositories AS repositories ON repositories.id = file_keys.repository_id
+          ${whereClause}
+            AND file_chunks.content IS NOT NULL
             AND file_chunks.content ILIKE ${containsPattern} ESCAPE '\'
         `
     const definitionPattern = buildDefinitionPattern(resolvedQuery)
@@ -540,7 +546,6 @@ export const createAtlasCodeSearchHandlers = ({
       ? sql`WHEN file_chunks.content ~ ${definitionPattern} THEN 0.98`
       : sql``
     const lexicalQuery = buildLexicalQuery(resolvedQuery)
-    const whereClause = searchWhereClause(filters)
     const semanticTimeoutMs = parsePositiveIntEnv(
       'ATLAS_CODE_SEARCH_SEMANTIC_TIMEOUT_MS',
       DEFAULT_CODE_SEARCH_SEMANTIC_TIMEOUT_MS,
@@ -560,8 +565,12 @@ export const createAtlasCodeSearchHandlers = ({
           FROM atlas.file_keys AS file_keys
           INNER JOIN atlas.file_versions AS file_versions ON file_versions.file_key_id = file_keys.id
           INNER JOIN atlas.file_chunks AS file_chunks ON file_chunks.file_version_id = file_versions.id
-          WHERE file_keys.path ILIKE ${containsPattern} ESCAPE '\'
-             OR file_keys.path % ${resolvedQuery}::text
+          INNER JOIN atlas.repositories AS repositories ON repositories.id = file_keys.repository_id
+          ${whereClause}
+            AND (
+              file_keys.path ILIKE ${containsPattern} ESCAPE '\'
+              OR file_keys.path % ${resolvedQuery}::text
+            )
 
           ${contentCandidateUnion}
         )
@@ -650,8 +659,9 @@ export const createAtlasCodeSearchHandlers = ({
         entry.score += weight / (RRF_K + index + 1)
         entry.modes.add(mode)
         if (mode === 'exact') {
-          entry.exactRank = Number(row.exact_rank)
-          if (Number.isFinite(entry.exactRank)) entry.score += entry.exactRank
+          const exactRank = Number(row.exact_rank)
+          entry.exactRank = exactRank
+          if (Number.isFinite(exactRank) && exactRank >= EXACT_SCORE_BOOST_MIN_RANK) entry.score += exactRank
         }
         if (mode === 'lexical') entry.lexicalRank = Number(row.lexical_rank)
         if (mode === 'semantic') entry.semanticDistance = Number(row.semantic_distance)


### PR DESCRIPTION
## Summary

- push ready/current-corpus and caller filters into both materialized exact-candidate scans
- prevent scoped searches from scanning unrelated Atlas chunks before filtering
- reserve direct score boosts for path/definition-grade exact matches
- keep generic content substring matches on the RRF score scale

## Related reviews

- PR #12519, Codex discussion `3584375135`
- PR #12524, Codex discussion `3584538281`

## Testing

- focused Atlas store Vitest suite (19 passed)
- Oxfmt check on changed files
- Oxlint on changed files (0 warnings, 0 errors)
- `git diff --check`
- Full local Jangar TypeScript validation was unavailable because the reusable workspace install lacks unrelated Temporal/Bumba dependencies; authoritative CI is required for the full type gate.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents exact validation
- [x] Breaking Changes is filled in
- [x] Regression coverage added