### PR TITLE
fix(atlas): use exact scans for narrow scopes

### DIFF
--- a/services/jangar/src/server/__tests__/atlas-store.test.ts
+++ b/services/jangar/src/server/__tests__/atlas-store.test.ts
@@ -495,6 +495,37 @@ describe('atlas store', () => {
     expect(calls.some((call) => call.sql.toLowerCase().includes("set_config('hnsw.ef_search'"))).toBe(false)
   })
 
+  it('keeps broad language-only semantic searches on HNSW', async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
+      Response.json({
+        data: [{ embedding: [0.1, 0.2, 0.3] }],
+      }),
+    )
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const { db, calls } = makeFakeDb({ selectRows: [] })
+    const store = createPostgresAtlasStore({
+      url: 'postgresql://user:pass@localhost:5432/db',
+      createDb: () => db,
+    })
+
+    await store.codeSearch({
+      query: 'where is source search implemented',
+      repository: 'proompteng/lab',
+      language: 'typescript',
+      limit: 5,
+    })
+
+    const semanticSql = calls.find((call) =>
+      call.sql.toLowerCase().includes('from atlas.chunk_embeddings as chunk_embeddings'),
+    )
+    const normalized = String(semanticSql?.sql).toLowerCase().replace(/\s+/g, ' ')
+    expect(normalized).not.toContain('with scoped_semantic_candidates as materialized')
+    expect(normalized).toContain('file_versions.language =')
+    expect(normalized).toContain('order by chunk_embeddings.embedding <=> $')
+    expect(calls.some((call) => call.sql.toLowerCase().includes("set_config('hnsw.ef_search'"))).toBe(true)
+  })
+
   it('isolates exact-match candidates without whole-content similarity scans', async () => {
     const { db, calls } = makeFakeDb({ selectRows: [] })
     const store = createPostgresAtlasStore({

--- a/services/jangar/src/server/__tests__/atlas-store.test.ts
+++ b/services/jangar/src/server/__tests__/atlas-store.test.ts
@@ -22,6 +22,7 @@ type FakeDbOptions = {
   exactRows?: unknown[]
   lexicalRows?: unknown[]
   semanticRows?: unknown[]
+  scopedSemanticCandidateCount?: number
   repositoryRows?: unknown[]
 }
 
@@ -193,6 +194,10 @@ const makeFakeDb = (options: FakeDbOptions = {}) => {
 
       if (normalized.includes(' as lexical_rank')) {
         return { rows: (options.lexicalRows ?? options.selectRows ?? []) as R[] }
+      }
+
+      if (normalized.includes(' as candidate_count') && normalized.includes('scoped_semantic_probe')) {
+        return { rows: [{ candidate_count: options.scopedSemanticCandidateCount ?? 0 }] as R[] }
       }
 
       if (normalized.includes('from atlas.chunk_embeddings as chunk_embeddings')) {
@@ -449,8 +454,10 @@ describe('atlas store', () => {
 
     await store.codeSearch({ query: 'where is source search implemented', limit: 5 })
 
-    const semanticSql = calls.find((call) =>
-      call.sql.toLowerCase().includes('from atlas.chunk_embeddings as chunk_embeddings'),
+    const semanticSql = calls.find(
+      (call) =>
+        call.sql.toLowerCase().includes('from atlas.chunk_embeddings as chunk_embeddings') &&
+        call.sql.toLowerCase().includes(' as semantic_distance'),
     )
     expect(semanticSql).toBeDefined()
     expect(semanticSql?.sql.toLowerCase()).not.toContain('candidate_chunks')
@@ -469,7 +476,7 @@ describe('atlas store', () => {
     )
     globalThis.fetch = fetchMock as unknown as typeof fetch
 
-    const { db, calls } = makeFakeDb({ selectRows: [] })
+    const { db, calls } = makeFakeDb({ selectRows: [], scopedSemanticCandidateCount: 50 })
     const store = createPostgresAtlasStore({
       url: 'postgresql://user:pass@localhost:5432/db',
       createDb: () => db,
@@ -484,7 +491,7 @@ describe('atlas store', () => {
     })
 
     const semanticSql = calls.find((call) =>
-      call.sql.toLowerCase().includes('from atlas.chunk_embeddings as chunk_embeddings'),
+      call.sql.toLowerCase().includes('with scoped_semantic_candidates as materialized'),
     )
     const normalized = String(semanticSql?.sql).toLowerCase().replace(/\s+/g, ' ')
     expect(normalized).toContain('with scoped_semantic_candidates as materialized')
@@ -493,6 +500,33 @@ describe('atlas store', () => {
     expect(normalized).toContain('order by scoped_semantic_candidates.candidate_embedding <=> $')
     expect(normalized).not.toContain('order by chunk_embeddings.embedding <=> $')
     expect(calls.some((call) => call.sql.toLowerCase().includes("set_config('hnsw.ef_search'"))).toBe(false)
+  })
+
+  it('keeps broad path-prefix semantic searches on HNSW', async () => {
+    const { db, calls } = makeFakeDb({ selectRows: [], scopedSemanticCandidateCount: 501 })
+    const store = createPostgresAtlasStore({
+      url: 'postgresql://user:pass@localhost:5432/db',
+      createDb: () => db,
+    })
+
+    await store.codeSearch({
+      query: 'where is source search implemented',
+      repository: 'proompteng/lab',
+      pathPrefix: 'services/',
+      limit: 5,
+    })
+
+    const countSql = calls.find((call) => call.sql.toLowerCase().includes('scoped_semantic_probe'))
+    expect(countSql?.params.at(-1)).toBe(501)
+    const semanticSql = calls.find(
+      (call) =>
+        call.sql.toLowerCase().includes('from atlas.chunk_embeddings as chunk_embeddings') &&
+        call.sql.toLowerCase().includes(' as semantic_distance'),
+    )
+    const normalized = String(semanticSql?.sql).toLowerCase().replace(/\s+/g, ' ')
+    expect(normalized).not.toContain('with scoped_semantic_candidates as materialized')
+    expect(normalized).toContain('order by chunk_embeddings.embedding <=> $')
+    expect(calls.some((call) => call.sql.toLowerCase().includes("set_config('hnsw.ef_search'"))).toBe(true)
   })
 
   it('keeps broad language-only semantic searches on HNSW', async () => {

--- a/services/jangar/src/server/__tests__/atlas-store.test.ts
+++ b/services/jangar/src/server/__tests__/atlas-store.test.ts
@@ -461,6 +461,40 @@ describe('atlas store', () => {
     expect(hnswBudgetSql?.params).toContain('20')
   })
 
+  it('uses an exact materialized semantic scan for narrow caller scopes', async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
+      Response.json({
+        data: [{ embedding: [0.1, 0.2, 0.3] }],
+      }),
+    )
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const { db, calls } = makeFakeDb({ selectRows: [] })
+    const store = createPostgresAtlasStore({
+      url: 'postgresql://user:pass@localhost:5432/db',
+      createDb: () => db,
+    })
+
+    await store.codeSearch({
+      query: 'where is source search implemented',
+      repository: 'proompteng/lab',
+      pathPrefix: 'services/jangar',
+      language: 'typescript',
+      limit: 5,
+    })
+
+    const semanticSql = calls.find((call) =>
+      call.sql.toLowerCase().includes('from atlas.chunk_embeddings as chunk_embeddings'),
+    )
+    const normalized = String(semanticSql?.sql).toLowerCase().replace(/\s+/g, ' ')
+    expect(normalized).toContain('with scoped_semantic_candidates as materialized')
+    expect(normalized).toContain('file_keys.path like')
+    expect(normalized).toContain('file_versions.language =')
+    expect(normalized).toContain('order by scoped_semantic_candidates.candidate_embedding <=> $')
+    expect(normalized).not.toContain('order by chunk_embeddings.embedding <=> $')
+    expect(calls.some((call) => call.sql.toLowerCase().includes("set_config('hnsw.ef_search'"))).toBe(false)
+  })
+
   it('isolates exact-match candidates without whole-content similarity scans', async () => {
     const { db, calls } = makeFakeDb({ selectRows: [] })
     const store = createPostgresAtlasStore({

--- a/services/jangar/src/server/atlas-code-search.ts
+++ b/services/jangar/src/server/atlas-code-search.ts
@@ -521,6 +521,7 @@ export const createAtlasCodeSearchHandlers = ({
       MAX_SEARCH_LIMIT,
       Math.max(MIN_SEMANTIC_CANDIDATES, resolvedLimit * SEMANTIC_CANDIDATE_MULTIPLIER),
     )
+    const requiresExactScopedSemanticScan = Boolean(filters.pathPrefix || filters.language)
     const embeddingConfig = loadEmbeddingConfig()
     const vectorString = isPathQuery
       ? null
@@ -610,24 +611,49 @@ export const createAtlasCodeSearchHandlers = ({
 
       let semanticRows: AtlasCodeSearchRow[] = []
       if (vectorString !== null) {
-        await sql`SELECT set_config('hnsw.ef_search', ${String(semanticCandidateLimit)}, true);`.execute(trx)
+        if (requiresExactScopedSemanticScan) {
+          const semanticResult = await sql<AtlasCodeSearchRow>`
+            WITH scoped_semantic_candidates AS MATERIALIZED (
+              SELECT
+                ${sql.raw(codeSearchRawSelectColumns)},
+                chunk_embeddings.embedding AS candidate_embedding
+              FROM atlas.chunk_embeddings AS chunk_embeddings
+              INNER JOIN atlas.file_chunks AS file_chunks ON file_chunks.id = chunk_embeddings.chunk_id
+              INNER JOIN atlas.file_versions AS file_versions ON file_versions.id = file_chunks.file_version_id
+              INNER JOIN atlas.file_keys AS file_keys ON file_keys.id = file_versions.file_key_id
+              INNER JOIN atlas.repositories AS repositories ON repositories.id = file_keys.repository_id
+              ${whereClause}
+                AND chunk_embeddings.model = ${embeddingConfig.model}
+                AND chunk_embeddings.dimension = ${embeddingConfig.dimension}
+            )
+            SELECT
+              scoped_semantic_candidates.*,
+              scoped_semantic_candidates.candidate_embedding <=> ${vectorString}::vector AS semantic_distance
+            FROM scoped_semantic_candidates
+            ORDER BY scoped_semantic_candidates.candidate_embedding <=> ${vectorString}::vector
+            LIMIT ${semanticCandidateLimit};
+          `.execute(trx)
+          semanticRows = semanticResult.rows as AtlasCodeSearchRow[]
+        } else {
+          await sql`SELECT set_config('hnsw.ef_search', ${String(semanticCandidateLimit)}, true);`.execute(trx)
 
-        const semanticResult = await sql<AtlasCodeSearchRow>`
-          SELECT
-            ${sql.raw(codeSearchRawSelectColumns)},
-            chunk_embeddings.embedding <=> ${vectorString}::vector AS semantic_distance
-          FROM atlas.chunk_embeddings AS chunk_embeddings
-          INNER JOIN atlas.file_chunks AS file_chunks ON file_chunks.id = chunk_embeddings.chunk_id
-          INNER JOIN atlas.file_versions AS file_versions ON file_versions.id = file_chunks.file_version_id
-          INNER JOIN atlas.file_keys AS file_keys ON file_keys.id = file_versions.file_key_id
-          INNER JOIN atlas.repositories AS repositories ON repositories.id = file_keys.repository_id
-          ${whereClause}
-            AND chunk_embeddings.model = ${embeddingConfig.model}
-            AND chunk_embeddings.dimension = ${embeddingConfig.dimension}
-          ORDER BY chunk_embeddings.embedding <=> ${vectorString}::vector
-          LIMIT ${semanticCandidateLimit};
-        `.execute(trx)
-        semanticRows = semanticResult.rows as AtlasCodeSearchRow[]
+          const semanticResult = await sql<AtlasCodeSearchRow>`
+            SELECT
+              ${sql.raw(codeSearchRawSelectColumns)},
+              chunk_embeddings.embedding <=> ${vectorString}::vector AS semantic_distance
+            FROM atlas.chunk_embeddings AS chunk_embeddings
+            INNER JOIN atlas.file_chunks AS file_chunks ON file_chunks.id = chunk_embeddings.chunk_id
+            INNER JOIN atlas.file_versions AS file_versions ON file_versions.id = file_chunks.file_version_id
+            INNER JOIN atlas.file_keys AS file_keys ON file_keys.id = file_versions.file_key_id
+            INNER JOIN atlas.repositories AS repositories ON repositories.id = file_keys.repository_id
+            ${whereClause}
+              AND chunk_embeddings.model = ${embeddingConfig.model}
+              AND chunk_embeddings.dimension = ${embeddingConfig.dimension}
+            ORDER BY chunk_embeddings.embedding <=> ${vectorString}::vector
+            LIMIT ${semanticCandidateLimit};
+          `.execute(trx)
+          semanticRows = semanticResult.rows as AtlasCodeSearchRow[]
+        }
       }
 
       return {

--- a/services/jangar/src/server/atlas-code-search.ts
+++ b/services/jangar/src/server/atlas-code-search.ts
@@ -118,6 +118,7 @@ const DEFAULT_SEARCH_LIMIT = 10
 const MAX_SEARCH_LIMIT = 200
 const MIN_SEMANTIC_CANDIDATES = 20
 const SEMANTIC_CANDIDATE_MULTIPLIER = 2
+const MAX_EXACT_SCOPED_SEMANTIC_CANDIDATES = 500
 const DEFAULT_CODE_SEARCH_SEMANTIC_TIMEOUT_MS = 12_000
 const DEFAULT_CODE_SEARCH_STATEMENT_TIMEOUT_MS = 750
 const MAX_CODE_SEARCH_STATEMENT_TIMEOUT_MS = 900
@@ -521,7 +522,6 @@ export const createAtlasCodeSearchHandlers = ({
       MAX_SEARCH_LIMIT,
       Math.max(MIN_SEMANTIC_CANDIDATES, resolvedLimit * SEMANTIC_CANDIDATE_MULTIPLIER),
     )
-    const requiresExactScopedSemanticScan = Boolean(filters.pathPrefix)
     const embeddingConfig = loadEmbeddingConfig()
     const vectorString = isPathQuery
       ? null
@@ -611,6 +611,27 @@ export const createAtlasCodeSearchHandlers = ({
 
       let semanticRows: AtlasCodeSearchRow[] = []
       if (vectorString !== null) {
+        let requiresExactScopedSemanticScan = false
+        if (filters.pathPrefix) {
+          const scopedCount = await sql<{ candidate_count: number | string }>`
+            SELECT count(*)::int AS candidate_count
+            FROM (
+              SELECT chunk_embeddings.chunk_id
+              FROM atlas.chunk_embeddings AS chunk_embeddings
+              INNER JOIN atlas.file_chunks AS file_chunks ON file_chunks.id = chunk_embeddings.chunk_id
+              INNER JOIN atlas.file_versions AS file_versions ON file_versions.id = file_chunks.file_version_id
+              INNER JOIN atlas.file_keys AS file_keys ON file_keys.id = file_versions.file_key_id
+              INNER JOIN atlas.repositories AS repositories ON repositories.id = file_keys.repository_id
+              ${whereClause}
+                AND chunk_embeddings.model = ${embeddingConfig.model}
+                AND chunk_embeddings.dimension = ${embeddingConfig.dimension}
+              LIMIT ${MAX_EXACT_SCOPED_SEMANTIC_CANDIDATES + 1}
+            ) AS scoped_semantic_probe;
+          `.execute(trx)
+          const candidateCount = Number(scopedCount.rows[0]?.candidate_count)
+          requiresExactScopedSemanticScan =
+            Number.isFinite(candidateCount) && candidateCount <= MAX_EXACT_SCOPED_SEMANTIC_CANDIDATES
+        }
         if (requiresExactScopedSemanticScan) {
           const semanticResult = await sql<AtlasCodeSearchRow>`
             WITH scoped_semantic_candidates AS MATERIALIZED (

--- a/services/jangar/src/server/atlas-code-search.ts
+++ b/services/jangar/src/server/atlas-code-search.ts
@@ -521,7 +521,7 @@ export const createAtlasCodeSearchHandlers = ({
       MAX_SEARCH_LIMIT,
       Math.max(MIN_SEMANTIC_CANDIDATES, resolvedLimit * SEMANTIC_CANDIDATE_MULTIPLIER),
     )
-    const requiresExactScopedSemanticScan = Boolean(filters.pathPrefix || filters.language)
+    const requiresExactScopedSemanticScan = Boolean(filters.pathPrefix)
     const embeddingConfig = loadEmbeddingConfig()
     const vectorString = isPathQuery
       ? null


### PR DESCRIPTION
## Summary

- use a filtered materialized exact vector scan for narrow `pathPrefix` or `language` scopes
- retain HNSW and its bounded `ef_search` budget for broad semantic searches
- avoid relying on `hnsw.iterative_scan`, which the live Jangar PostgreSQL server does not expose despite pgvector 0.8.0 metadata
- add regression coverage proving narrow scopes filter before vector ordering and do not use the global HNSW candidate budget

## Related review

- PR #12524, Codex discussion `3584538284`

## Testing

- focused Atlas store Vitest suite (18 passed)
- Oxfmt check on changed files
- Oxlint on changed files (0 warnings, 0 errors)
- `git diff --check`
- live read-only verification: Jangar DB reports pgvector `0.8.0`, while `hnsw.iterative_scan` is unrecognized by the running server
- Full local Jangar TypeScript validation was unavailable because the reusable workspace install lacks unrelated Temporal/Bumba dependencies; authoritative CI is required for the full type gate.

## Breaking Changes

Narrow filtered semantic searches now trade ANN latency for exact scoped recall, still bounded by the existing statement timeout.

## Checklist

- [x] Testing section documents exact validation
- [x] Breaking Changes is filled in
- [x] Regression coverage added