### PR TITLE
refactor(jangar): remove quant rollback fallback

### DIFF
--- a/services/jangar/src/server/__tests__/kysely-migrations.test.ts
+++ b/services/jangar/src/server/__tests__/kysely-migrations.test.ts
@@ -99,7 +99,7 @@ describe('migration registration', () => {
     expect(normalized).not.toContain('quant_pipeline_health;')
   })
 
-  it('keeps the no-copy quant-series active-store migration rollback-compatible', () => {
+  it('keeps the no-copy quant-series active-store transition forward-only', () => {
     const migrationPath = new URL('../migrations/20260715_torghut_quant_series_active.ts', import.meta.url)
     const normalized = readFileSync(fileURLToPath(migrationPath), 'utf8').toLowerCase().replace(/\s+/g, ' ')
 
@@ -108,10 +108,8 @@ describe('migration registration', () => {
     expect(normalized).toContain('using brin (as_of)')
     expect(normalized).toContain('create view torghut_control_plane.quant_metrics_series as')
     expect(normalized).toContain('instead of insert on torghut_control_plane.quant_metrics_series')
-    expect(normalized).toContain('on conflict (id) do nothing')
-    expect(normalized).toContain(
-      'lock table torghut_control_plane.quant_metrics_series, torghut_control_plane.quant_metrics_series_active in access exclusive mode',
-    )
+    expect(normalized).not.toContain('export const down')
+    expect(normalized).not.toContain('on conflict (id) do nothing')
     expect(normalized).not.toContain('vacuum full')
     expect(normalized).not.toContain('reindex')
     expect(normalized).not.toContain('unlogged')

--- a/services/jangar/src/server/__tests__/torghut-quant-metrics-store.test.ts
+++ b/services/jangar/src/server/__tests__/torghut-quant-metrics-store.test.ts
@@ -151,26 +151,6 @@ describe('torghut quant metrics store', () => {
     expect(normalized.join(' ')).not.toContain('create table as select')
   })
 
-  it('blocks compatibility-view writes before copying rollback rows', async () => {
-    const { db, calls } = makeFakeDb()
-    const { down } = await import('../migrations/20260715_torghut_quant_series_active')
-
-    await down(db)
-
-    expect(calls).toHaveLength(8)
-    const normalized = calls.map((call) => call.sql.toLowerCase().replace(/\s+/g, ' '))
-    expect(normalized[0]).toContain("set local lock_timeout = '5s'")
-    expect(normalized[1]).toContain(
-      'lock table torghut_control_plane.quant_metrics_series, torghut_control_plane.quant_metrics_series_active in access exclusive mode',
-    )
-    expect(normalized[1].indexOf('quant_metrics_series,')).toBeLessThan(
-      normalized[1].indexOf('quant_metrics_series_active'),
-    )
-    expect(normalized[2]).toContain('insert into torghut_control_plane.quant_metrics_series_legacy')
-    expect(normalized[2]).toContain('from torghut_control_plane.quant_metrics_series_active')
-    expect(normalized[3]).toContain('drop trigger if exists quant_metrics_series_active_insert')
-  })
-
   it('drops the unused series API stores without cascading into unrelated relations', async () => {
     const { db, calls } = makeFakeDb()
     const { up } = await import('../migrations/20260715_torghut_quant_series_remove')

--- a/services/jangar/src/server/migrations/20260715_torghut_quant_series_active.ts
+++ b/services/jangar/src/server/migrations/20260715_torghut_quant_series_active.ts
@@ -132,37 +132,5 @@ export const up = async (db: Kysely<Database>) => {
   `.execute(db)
 }
 
-export const down = async (db: Kysely<Database>) => {
-  await sql`SET LOCAL lock_timeout = '5s';`.execute(db)
-  await sql`
-    LOCK TABLE
-      torghut_control_plane.quant_metrics_series,
-      torghut_control_plane.quant_metrics_series_active
-    IN ACCESS EXCLUSIVE MODE;
-  `.execute(db)
-
-  // Preserve rows written after cutover before restoring the physical legacy
-  // table. Lock the compatibility view first so no writer can hold its lock
-  // while blocking inside the trigger on the active table; both locks remain
-  // held through the destructive rollback steps.
-  await sql
-    .raw(`
-    INSERT INTO torghut_control_plane.quant_metrics_series_legacy (${SERIES_COLUMNS})
-    SELECT ${SERIES_COLUMNS}
-    FROM torghut_control_plane.quant_metrics_series_active
-    ON CONFLICT (id) DO NOTHING;
-  `)
-    .execute(db)
-
-  await sql`
-    DROP TRIGGER IF EXISTS quant_metrics_series_active_insert
-    ON torghut_control_plane.quant_metrics_series;
-  `.execute(db)
-  await sql`DROP VIEW torghut_control_plane.quant_metrics_series;`.execute(db)
-  await sql`DROP FUNCTION torghut_control_plane.insert_quant_metrics_series_active();`.execute(db)
-  await sql`DROP TABLE ${sql.table(ACTIVE_TABLE)} CASCADE;`.execute(db)
-  await sql`
-    ALTER TABLE torghut_control_plane.quant_metrics_series_legacy
-    RENAME TO quant_metrics_series;
-  `.execute(db)
-}
+// Intentionally forward-only. The later quant-series removal migration hard-deletes
+// every series relation, so restoring the compatibility view is unsupported.


### PR DESCRIPTION
## Summary

- Remove the obsolete `down` migration that rebuilt the retired quant-series compatibility view and legacy table.
- Keep the quant-series transition forward-only; the later removal migration remains the sole supported schema outcome.
- Replace rollback-specific regressions with a source contract that rejects any restored rollback export or copy path.

## Related Issues

None

## Testing

- `/nix/var/nix/profiles/default/bin/nix develop -c bunx vitest run --config vitest.config.ts src/server/__tests__/kysely-migrations.test.ts src/server/__tests__/torghut-quant-metrics-store.test.ts` (24 passed)
- `/nix/var/nix/profiles/default/bin/nix develop -c bun run tsc`
- `/nix/var/nix/profiles/default/bin/nix develop -c bun run test` (698 passed, 4 skipped)
- `/nix/var/nix/profiles/default/bin/nix develop -c bunx oxfmt --check services/jangar/src/server/migrations/20260715_torghut_quant_series_active.ts services/jangar/src/server/__tests__/kysely-migrations.test.ts services/jangar/src/server/__tests__/torghut-quant-metrics-store.test.ts`
- `/nix/var/nix/profiles/default/bin/nix develop -c bunx oxlint services/jangar/src/server/migrations/20260715_torghut_quant_series_active.ts services/jangar/src/server/__tests__/kysely-migrations.test.ts services/jangar/src/server/__tests__/torghut-quant-metrics-store.test.ts` (0 warnings, 0 errors)
- `git diff --check`

## Breaking Changes

Rollback of `20260715_torghut_quant_series_active` is intentionally unsupported. The applied forward sequence already hard-deletes every quant-series relation, and no live schema or API changes in this PR.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation changes are not needed because the existing rollout evidence already records the irreversible hard deletion.
