### PR TITLE
chore(jangar): promote image sha-444f59dc1e7bb26a48631bbe84e1896698a961f6

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/part-of: lab
   annotations:
     argocd.argoproj.io/sync-wave: "0"
-    deploy.knative.dev/rollout: 2026-07-15T08:41:43Z
+    deploy.knative.dev/rollout: 2026-07-15T08:58:02Z
 spec:
   replicas: 1
   strategy:
@@ -58,9 +58,9 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 294eeb147a3be05f96735b5a2da6bcc1dfdf97dd
+              value: 444f59dc1e7bb26a48631bbe84e1896698a961f6
             - name: JANGAR_GITOPS_REVISION
-              value: 294eeb147a3be05f96735b5a2da6bcc1dfdf97dd
+              value: 444f59dc1e7bb26a48631bbe84e1896698a961f6
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -360,15 +360,15 @@ spec:
             - name: ATLAS_CODE_SEARCH_STATEMENT_TIMEOUT_MS
               value: "750"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "29400847894"
+              value: "29401780062"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:12f3c76bb48f7e1a942293aaa23a32a5eba8cb2e2b9c87a08600adcd23ba82e5
+              value: sha256:1eccc6bcf5f2bcf1cc321d66fdafaec998a43d957ca75861f8906944056944f1
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: 294eeb147a3be05f96735b5a2da6bcc1dfdf97dd
+              value: 444f59dc1e7bb26a48631bbe84e1896698a961f6
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:12f3c76bb48f7e1a942293aaa23a32a5eba8cb2e2b9c87a08600adcd23ba82e5
+              value: sha256:1eccc6bcf5f2bcf1cc321d66fdafaec998a43d957ca75861f8906944056944f1
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -37,5 +37,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: sha-294eeb147a3be05f96735b5a2da6bcc1dfdf97dd
-    digest: sha256:12f3c76bb48f7e1a942293aaa23a32a5eba8cb2e2b9c87a08600adcd23ba82e5
+    newTag: sha-444f59dc1e7bb26a48631bbe84e1896698a961f6
+    digest: sha256:1eccc6bcf5f2bcf1cc321d66fdafaec998a43d957ca75861f8906944056944f1


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `444f59dc1e7bb26a48631bbe84e1896698a961f6`
- Image tag: `sha-444f59dc1e7bb26a48631bbe84e1896698a961f6`
- Image digest: `sha256:1eccc6bcf5f2bcf1cc321d66fdafaec998a43d957ca75861f8906944056944f1`
- Source CI run: `29401780062`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates