### PR TITLE
feat(torghut): activate bounded options archive worker

### DIFF
--- a/argocd/applications/torghut-options/archive/deployment.yaml
+++ b/argocd/applications/torghut-options/archive/deployment.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     app: torghut-options-archive
 spec:
-  # Image promotion and schema migration must not activate this write workload.
-  # A separate gated Git change enables it after the shared storage path is healthy.
-  replicas: 0
+  # Exactly one worker owns the PostgreSQL advisory lease. Recreate prevents
+  # Kubernetes from overlapping workers during image or configuration rollouts.
+  replicas: 1
   revisionHistoryLimit: 2
   strategy:
     type: Recreate

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -85,6 +85,7 @@ describe('Torghut manifest scheduling', () => {
       'argocd/applications/symphony-torghut/deployment.patch.yaml',
       'argocd/applications/torghut-hyperliquid-feed/deployment.yaml',
       'argocd/applications/torghut-hyperliquid-runtime/deployment.yaml',
+      'argocd/applications/torghut-options/archive/deployment.yaml',
       'argocd/applications/torghut-options/catalog/deployment.yaml',
       'argocd/applications/torghut-options/enricher/deployment.yaml',
       'argocd/applications/torghut/ws/deployment.yaml',
@@ -106,6 +107,18 @@ describe('Torghut manifest scheduling', () => {
         maxUnavailable: 1,
       },
     })
+  })
+
+  it('runs exactly one fenced options archive worker without rollout overlap', () => {
+    const deployment = parseManifest('argocd/applications/torghut-options/archive/deployment.yaml')
+    const spec = getAtPath(deployment, ['spec'])
+    const podSpec = getAtPath(deployment, ['spec', 'template', 'spec'])
+
+    expect(spec.replicas).toBe(1)
+    expect(spec.strategy).toMatchObject({ type: 'Recreate' })
+    expect(podSpec.nodeSelector).toMatchObject({ 'kubernetes.io/arch': 'arm64' })
+    expect(podSpec.serviceAccountName).toBe('torghut-runtime')
+    expect(getAtPath(deployment, ['spec', 'template', 'spec', 'containers', 0]).name).toBe('torghut-options-archive')
   })
 
   it('pins arm64-only Torghut image consumers to arm64 nodes', () => {

--- a/packages/scripts/src/torghut/__tests__/options-schema-gate.test.ts
+++ b/packages/scripts/src/torghut/__tests__/options-schema-gate.test.ts
@@ -58,11 +58,3 @@ test('gates promoted options workloads on the complete migration 0067 schema', (
     })
   }
 })
-
-test('keeps archive activation separate from image promotion', () => {
-  const archive = YAML.parse(readFileSync(join(optionsRoot, 'archive', 'deployment.yaml'), 'utf8')) as {
-    spec?: { replicas?: number }
-  }
-
-  expect(archive.spec?.replicas).toBe(0)
-})


### PR DESCRIPTION
## Summary

- Scale the bounded options archive worker from zero to exactly one replica.
- Preserve `Recreate` rollout semantics and the PostgreSQL advisory-lease fence so workers cannot overlap.
- Add a manifest regression covering replica count, rollout strategy, architecture placement, service account, and container identity.

## Related Issues

None

## Testing

- `/nix/var/nix/profiles/default/bin/nix develop -c bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts` (17 passed)
- `/nix/var/nix/profiles/default/bin/nix develop -c bunx oxfmt --check packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `/nix/var/nix/profiles/default/bin/nix develop -c bun run lint:argocd` (0 invalid resources)
- `/nix/var/nix/profiles/default/bin/nix develop -c sh -o pipefail -c 'kustomize build --enable-helm argocd/applications/torghut-options | kubectl apply -n torghut --server-side --dry-run=server --field-manager=argocd-controller -f -'`
- Rendered output contains no `Namespace` resource.
- Live storage gate from `2026-07-15T12:05:26.312Z` passed after 36.42 minutes with zero failures: Ceph `HEALTH_OK`, OSDs 6/6/6, SMART 3/3 unchanged, Kafka 4.3.0 / `4.3-IV0` with 6/6 pods ready, and Torghut feed, scheduler, and API ready.
- The same observation included a successful 519,252,981-byte registry upload shaped to 0.998 MiB/s and concurrent Torghut image publication.

## Breaking Changes

None. This activates only the isolated, lease-fenced archive worker. Live discovery and subscription authority remain unchanged.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] The accepted design and live gate evidence authorize this bounded activation.
