### PR TITLE
perf(arc): move analysis runner scratch off Ceph

### DIFF
--- a/argocd/applications/arc/README.md
+++ b/argocd/applications/arc/README.md
@@ -6,7 +6,8 @@ These runners are not pinned to any specific node by default.
 - Upgrading from ≤0.9.x requires deleting the legacy `actions.github.com` CRDs and reinstalling the controller/runner charts before letting Argo CD reconcile.
 - Keep the custom template (init container + privileged `docker:dind` sidecar with `DOCKER_HOST=unix:///var/run/docker.sock`) when reapplying so Docker builds continue to work under Kubernetes mode.
 - The runner container intentionally waits for `docker version` before starting `run.sh`; without this guard, ARC can register a runner before the dind socket is ready.
-- Runner workspace storage uses dynamic PVCs (20Gi) and must target an existing RWO StorageClass (currently `local-path`).
+- Runner workspaces use bounded node-local `emptyDir` volumes; analysis is hard-capped at one 20Gi workspace on the
+  Altra node while local kubelet capacity is constrained. No ephemeral runner work directory uses replicated Ceph RBD.
 - Tailscale connectivity now comes from the node-level installation managed by OpenTofu (`tofu/harvester/main.tf`) and Ansible (`ansible/playbooks/install_tailscale.yml`); no sidecar or additional secret is required in the runner pods.
 - ARC runner and listener pods append the tailnet search suffix `ide-newton.ts.net` via `dnsConfig.searches`, so bare tailnet hosts such as `temporal-grpc` resolve from GitHub Actions jobs without hardcoding the full `*.ts.net` name.
 - Generate the `github-token` SealedSecret with `scripts/generate-arc-github-token-secret.sh`. The script reads the token from 1Password via `${ARC_GITHUB_TOKEN_OP_PATH}` (defaults to `op://infra/github personal token/token`) and writes the sealed manifest to `argocd/applications/arc/github-token.yaml`.

--- a/argocd/applications/arc/application.yaml
+++ b/argocd/applications/arc/application.yaml
@@ -274,7 +274,9 @@ spec:
           scaleSetLabels:
             - arc-arm64
           minRunners: 1
-          maxRunners: 5
+          # The Altra node currently has about 94Gi of kubelet-local free space. Keep one hard-capped analysis
+          # workspace until additional local capacity is provisioned instead of letting concurrent jobs evict pods.
+          maxRunners: 1
           listenerTemplate:
             spec:
               dnsConfig:
@@ -292,7 +294,7 @@ spec:
               securityContext:
                 runAsNonRoot: false
                 # ARC runners need a writable tool cache under /home/runner/_work/_tool.
-                # With PVC-backed work dirs, the volume is root-owned by default; set an fsGroup so the
+                # The analysis work directory is a disposable node-local emptyDir; set an fsGroup so the
                 # non-root runner user can create directories before any workflow steps run.
                 fsGroup: 1001
                 fsGroupChangePolicy: OnRootMismatch
@@ -376,14 +378,8 @@ spec:
                       mountPath: /home/runner/externals
               volumes:
                 - name: work
-                  ephemeral:
-                    volumeClaimTemplate:
-                      spec:
-                        accessModes: ["ReadWriteOnce"]
-                        storageClassName: "rook-ceph-block"
-                        resources:
-                          requests:
-                            storage: 20Gi
+                  emptyDir:
+                    sizeLimit: 20Gi
                 - name: dind-sock
                   emptyDir: {}
                 - name: dind-externals

--- a/packages/scripts/src/shared/__tests__/arc-runner.test.ts
+++ b/packages/scripts/src/shared/__tests__/arc-runner.test.ts
@@ -48,7 +48,7 @@ const releaseGuardFragmentForPath = (path: string): string => {
 }
 
 describe('ARC Nix runner toolchain', () => {
-  it('keeps lab ARC runners on local work dirs while making runner images releasable by digest', () => {
+  it('keeps ARC runner scratch writes off shared Ceph while making runner images releasable by digest', () => {
     expect(arcApplication).toContain('runnerScaleSetName: arc-arm64')
     expect(arcApplication).toContain('runnerScaleSetName: arc-amd64')
     expect(arcApplication).toContain('runnerScaleSetName: analysis-arm64')
@@ -60,7 +60,11 @@ describe('ARC Nix runner toolchain', () => {
       expect(block).not.toContain('storageClassName: "rook-ceph-block"')
       expect(block).not.toContain('volumeClaimTemplate:')
     }
-    expect(runnerScaleSetBlock('analysis-arm64')).toContain('storageClassName: "rook-ceph-block"')
+    const analysisBlock = runnerScaleSetBlock('analysis-arm64')
+    expect(analysisBlock).toContain('emptyDir:')
+    expect(analysisBlock).toContain('sizeLimit: 20Gi')
+    expect(analysisBlock).not.toContain('volumeClaimTemplate:')
+    expect(analysisBlock).not.toContain('storageClassName: "rook-ceph-block"')
     expect(arcRunnerReleaseWorkflow).toContain('registry.ide-newton.ts.net/lab/arc-runner')
     expect(arcRunnerReleaseWorkflow).toContain('arc-runner\\@sha256')
     expect(arcRunnerReleaseWorkflow).toContain('test "$(grep -cF "image: ${IMAGE_REF}"')
@@ -75,7 +79,7 @@ describe('ARC Nix runner toolchain', () => {
     expect(runnerScaleSetBlock('arc-arm64')).toContain('minRunners: 1')
     expect(runnerScaleSetBlock('arc-amd64')).toContain('maxRunners: 5')
     expect(runnerScaleSetBlock('arc-amd64')).toContain('minRunners: 1')
-    expect(runnerScaleSetBlock('analysis-arm64')).toContain('maxRunners: 5')
+    expect(runnerScaleSetBlock('analysis-arm64')).toContain('maxRunners: 1')
     expect(runnerScaleSetBlock('analysis-arm64')).toContain('minRunners: 1')
   })
 
@@ -88,8 +92,8 @@ describe('ARC Nix runner toolchain', () => {
       expect(block).not.toContain('storage: 20Gi')
     }
 
-    expect(runnerScaleSetBlock('analysis-arm64')).toContain('storageClassName: "rook-ceph-block"')
-    expect(runnerScaleSetBlock('analysis-arm64')).toContain('storage: 20Gi')
+    expect(runnerScaleSetBlock('analysis-arm64')).toContain('sizeLimit: 20Gi')
+    expect(runnerScaleSetBlock('analysis-arm64')).not.toContain('volumeClaimTemplate:')
   })
 
   it('builds a custom actions runner image with pinned Nix CI tools preinstalled', () => {


### PR DESCRIPTION
## Summary

- Move the disposable `analysis-arm64` ARC runner workspace from replicated Ceph RBD to a node-local `emptyDir` with an enforced 20Gi size limit.
- Cap analysis concurrency at one runner while the Altra node has about 94Gi of kubelet-local free space, preventing local-disk overcommit.
- Add a regression assertion and document the distinct lab and analysis runner storage policies.

## Related Issues

None

## Testing

- `nix develop -c bun test packages/scripts/src/shared/__tests__/arc-runner.test.ts`
- `nix develop -c bun run --cwd packages/scripts lint:oxlint:type`
- `nix develop -c bunx tsc --noEmit --project packages/scripts/tsconfig.atlas.json`
- `nix develop -c bun test packages/scripts/src` (579 passed)
- `nix develop -c bun run lint:argocd`
- `kubectl apply -n argocd --server-side --dry-run=server --force-conflicts -f argocd/applications/arc/application.yaml`
- Live kubelet stats readback confirmed 93,746,810,880 available bytes on the sole ARM64 node before selecting the one-runner cap.

## Screenshots (if applicable)

N/A; this changes runner storage placement only.

## Breaking Changes

Analysis concurrency is reduced from five runners to one while local kubelet capacity is constrained. Existing jobs retain their current volume until completion; newly created analysis runners receive the hard-capped node-local workspace.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
