### PR TITLE
chore(product): promote nix product images

### DIFF
--- a/argocd/applications/app/kustomization.yaml
+++ b/argocd/applications/app/kustomization.yaml
@@ -8,5 +8,5 @@ resources:
   - secret.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/app
-    digest: sha256:e8c53561712e9fb5ee336a9b5b88a2257ca117556c5cc707c23856dda8fcca49
+    digest: sha256:98dd8a7ca3c6e0ae274a309e95a41748becd68c1efe07bc7a59723bf1d116aab
     newName: registry.ide-newton.ts.net/lab/app

--- a/argocd/applications/docs/kustomization.yaml
+++ b/argocd/applications/docs/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
   - generated
 images:
   - name: registry.ide-newton.ts.net/lab/docs
-    digest: sha256:00bc193a1675fd3850e20504ff06b4d3b39a445691d55aa498874dcb686cfa2d
+    digest: sha256:00112453c5b20135b7aa461308a79082fb49c2420eaa30e5c6dcd6e4abdc0f6c
     newName: registry.ide-newton.ts.net/lab/docs

--- a/argocd/applications/olden/kustomization.yaml
+++ b/argocd/applications/olden/kustomization.yaml
@@ -5,5 +5,5 @@ resources:
   - service.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/olden
-    digest: sha256:17c826dda8f922d3be374e0a81c1321b232925aeb1ce97b8d1a67a769f8c0527
+    digest: sha256:a1ee64f469fe6521a430c0a3ba5e9fbdb3bb79cf9b88fa90f27e3111674c9d0f
     newName: registry.ide-newton.ts.net/lab/olden

--- a/argocd/applications/proompteng/kustomization.yaml
+++ b/argocd/applications/proompteng/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
 - ingressroute.yaml
 images:
 - name: registry.ide-newton.ts.net/lab/proompteng
-  digest: sha256:83b774c60f423a5415f57d06aea2bda9f90eb7673b3297ee64a16520497b5f10
+  digest: sha256:1a5a5902dab138094df9de846762dbb37adbce99bcff8d53a670a86c66714d0f
   newName: registry.ide-newton.ts.net/lab/proompteng

--- a/argocd/applications/synthesis/kustomization.yaml
+++ b/argocd/applications/synthesis/kustomization.yaml
@@ -11,5 +11,5 @@ resources:
   - agents-domain
 images:
   - name: registry.ide-newton.ts.net/lab/synthesis
-    digest: sha256:8f99b91c900a1006937041f1e7d3a6c0b6721c4ee96592e5b268cf3bd08d8572
+    digest: sha256:7cc3d8ca7b4cdb47f8b42762de9f6caf55a7312336089a1478f3227b8d0dd8a1
     newName: registry.ide-newton.ts.net/lab/synthesis


### PR DESCRIPTION
## Summary

- Promote enabled product app image digests built by the shared Nix OCI workflow.
- `app`: `registry.ide-newton.ts.net/lab/app@sha256:98dd8a7ca3c6e0ae274a309e95a41748becd68c1efe07bc7a59723bf1d116aab` from `31817d928fb57a7f68ff14259406ef15b7696614`
- `docs`: `registry.ide-newton.ts.net/lab/docs@sha256:00112453c5b20135b7aa461308a79082fb49c2420eaa30e5c6dcd6e4abdc0f6c` from `31817d928fb57a7f68ff14259406ef15b7696614`
- `olden`: `registry.ide-newton.ts.net/lab/olden@sha256:a1ee64f469fe6521a430c0a3ba5e9fbdb3bb79cf9b88fa90f27e3111674c9d0f` from `31817d928fb57a7f68ff14259406ef15b7696614`
- `proompteng`: `registry.ide-newton.ts.net/lab/proompteng@sha256:1a5a5902dab138094df9de846762dbb37adbce99bcff8d53a670a86c66714d0f` from `31817d928fb57a7f68ff14259406ef15b7696614`
- `synthesis`: `registry.ide-newton.ts.net/lab/synthesis@sha256:7cc3d8ca7b4cdb47f8b42762de9f6caf55a7312336089a1478f3227b8d0dd8a1` from `31817d928fb57a7f68ff14259406ef15b7696614`

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- <image>@<digest> linux/amd64 linux/arm64` for each promoted image.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.