### PR TITLE
chore(torghut): promote image sha-f7188d51681f1b413db079e6146dbf7dffa4f490

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -54,7 +54,7 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: ace302ab72c5b36d044ee98cc8f93bc00633197f
+              value: f7188d51681f1b413db079e6146dbf7dffa4f490
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:cbf784dfdfa5b34c634c8bd538ffed84f5b5dc74888cb08a7d6de7884a1909b8
             - name: PYTHONPATH

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -46,7 +46,7 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: ace302ab72c5b36d044ee98cc8f93bc00633197f
+              value: f7188d51681f1b413db079e6146dbf7dffa4f490
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:cbf784dfdfa5b34c634c8bd538ffed84f5b5dc74888cb08a7d6de7884a1909b8
             - name: DB_DSN

--- a/argocd/applications/torghut-options/archive/deployment.yaml
+++ b/argocd/applications/torghut-options/archive/deployment.yaml
@@ -101,9 +101,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2006-gace302ab7
+              value: v0.596.0-2014-gf7188d516
             - name: TORGHUT_OPTIONS_COMMIT
-              value: ace302ab72c5b36d044ee98cc8f93bc00633197f
+              value: f7188d51681f1b413db079e6146dbf7dffa4f490
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -110,9 +110,9 @@ spec:
                   name: torghut-ws-config
                   key: SYMBOLS_ALLOWLIST
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2006-gace302ab7
+              value: v0.596.0-2014-gf7188d516
             - name: TORGHUT_OPTIONS_COMMIT
-              value: ace302ab72c5b36d044ee98cc8f93bc00633197f
+              value: f7188d51681f1b413db079e6146dbf7dffa4f490
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -106,9 +106,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2006-gace302ab7
+              value: v0.596.0-2014-gf7188d516
             - name: TORGHUT_OPTIONS_COMMIT
-              value: ace302ab72c5b36d044ee98cc8f93bc00633197f
+              value: f7188d51681f1b413db079e6146dbf7dffa4f490
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-15T08:56:01Z"
+        client.knative.dev/updateTimestamp: "2026-07-15T09:55:00Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -507,9 +507,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2006-gace302ab7
+              value: v0.596.0-2014-gf7188d516
             - name: TORGHUT_COMMIT
-              value: ace302ab72c5b36d044ee98cc8f93bc00633197f
+              value: f7188d51681f1b413db079e6146dbf7dffa4f490
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:cbf784dfdfa5b34c634c8bd538ffed84f5b5dc74888cb08a7d6de7884a1909b8
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-15T08:56:01Z"
+        client.knative.dev/updateTimestamp: "2026-07-15T09:55:00Z"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
     spec:
@@ -446,9 +446,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2006-gace302ab7
+              value: v0.596.0-2014-gf7188d516
             - name: TORGHUT_COMMIT
-              value: ace302ab72c5b36d044ee98cc8f93bc00633197f
+              value: f7188d51681f1b413db079e6146dbf7dffa4f490
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:cbf784dfdfa5b34c634c8bd538ffed84f5b5dc74888cb08a7d6de7884a1909b8
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -462,9 +462,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2006-gace302ab7
+              value: v0.596.0-2014-gf7188d516
             - name: TORGHUT_COMMIT
-              value: ace302ab72c5b36d044ee98cc8f93bc00633197f
+              value: f7188d51681f1b413db079e6146dbf7dffa4f490
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:cbf784dfdfa5b34c634c8bd538ffed84f5b5dc74888cb08a7d6de7884a1909b8
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `f7188d51681f1b413db079e6146dbf7dffa4f490`
- Image tag: `sha-f7188d51681f1b413db079e6146dbf7dffa4f490`
- Image digest: `sha256:cbf784dfdfa5b34c634c8bd538ffed84f5b5dc74888cb08a7d6de7884a1909b8`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher