### PR TITLE
perf(registry): serialize shared-pool writes

### DIFF
--- a/argocd/applications/arc/application.yaml
+++ b/argocd/applications/arc/application.yaml
@@ -103,11 +103,14 @@ spec:
                       mountPath: /var/run
                 - name: dind
                   image: docker:dind
+                  # The private registry is a single filesystem writer on shared Ceph RBD.
+                  # Serialize daemon-driven uploads so direct Docker pushes cannot burst
+                  # fsync traffic into Kafka's pool.
                   args:
                     - dockerd
                     - --host=unix:///var/run/docker.sock
                     - --group=$(DOCKER_GROUP_GID)
-                    - --max-concurrent-uploads=8
+                    - --max-concurrent-uploads=1
                   resources:
                     requests:
                       cpu: "2"
@@ -224,11 +227,14 @@ spec:
                       mountPath: /var/run
                 - name: dind
                   image: docker:dind
+                  # The private registry is a single filesystem writer on shared Ceph RBD.
+                  # Serialize daemon-driven uploads so direct Docker pushes cannot burst
+                  # fsync traffic into Kafka's pool.
                   args:
                     - dockerd
                     - --host=unix:///var/run/docker.sock
                     - --group=$(DOCKER_GROUP_GID)
-                    - --max-concurrent-uploads=8
+                    - --max-concurrent-uploads=1
                   resources:
                     requests:
                       cpu: "2"
@@ -350,11 +356,14 @@ spec:
                       mountPath: /var/run
                 - name: dind
                   image: docker:dind
+                  # The private registry is a single filesystem writer on shared Ceph RBD.
+                  # Serialize daemon-driven uploads so direct Docker pushes cannot burst
+                  # fsync traffic into Kafka's pool.
                   args:
                     - dockerd
                     - --host=unix:///var/run/docker.sock
                     - --group=$(DOCKER_GROUP_GID)
-                    - --max-concurrent-uploads=8
+                    - --max-concurrent-uploads=1
                   resources:
                     requests:
                       cpu: "1"

--- a/argocd/applications/registry/deployment.yaml
+++ b/argocd/applications/registry/deployment.yaml
@@ -7,6 +7,8 @@ metadata:
   namespace: registry
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: registry
@@ -15,12 +17,21 @@ spec:
       labels:
         app: registry
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: registry
-          image: registry:3
+          image: registry:3@sha256:1be55279f18a2fe1a74edf2664cac61c1bea305b7b4642dab412e7affdcb3e33
           env:
             - name: REGISTRY_CONFIGURATION_PATH
               value: /etc/docker/registry/config.yml
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
           resources:
             limits:
               cpu: "1"
@@ -29,12 +40,56 @@ spec:
               cpu: "200m"
               memory: "64Mi"
           ports:
-            - containerPort: 5000
+            - name: registry-api
+              containerPort: 5000
           volumeMounts:
             - name: registry-config
               mountPath: /etc/docker/registry
             - name: registry-data
               mountPath: /var/lib/registry
+        - name: registry-proxy
+          image: haproxy:3.2.21-alpine@sha256:66e25cc9a8332635f4e897f7f4b1e5622c25f09f0ee23cddc6ce9bdb3a24772a
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 99
+            runAsNonRoot: true
+            runAsUser: 99
+          resources:
+            limits:
+              cpu: "250m"
+              memory: "256Mi"
+            requests:
+              cpu: "50m"
+              memory: "64Mi"
+          ports:
+            - name: registry-http
+              containerPort: 8080
+          startupProbe:
+            httpGet:
+              path: /v2/
+              port: registry-http
+            failureThreshold: 30
+            periodSeconds: 2
+          readinessProbe:
+            httpGet:
+              path: /v2/
+              port: registry-http
+            failureThreshold: 3
+            periodSeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: registry-http
+            failureThreshold: 3
+            periodSeconds: 10
+          volumeMounts:
+            - name: registry-proxy-config
+              mountPath: /usr/local/etc/haproxy/haproxy.cfg
+              subPath: haproxy.cfg
+              readOnly: true
       volumes:
         - name: registry-config
           configMap:
@@ -42,3 +97,6 @@ spec:
         - name: registry-data
           persistentVolumeClaim:
             claimName: registry-data
+        - name: registry-proxy-config
+          configMap:
+            name: registry-proxy

--- a/argocd/applications/registry/haproxy.cfg
+++ b/argocd/applications/registry/haproxy.cfg
@@ -1,0 +1,28 @@
+global
+  log stdout format raw local0 info
+  maxconn 1024
+
+defaults
+  log global
+  mode http
+  option httplog
+  option dontlognull
+  timeout connect 5s
+  timeout client 2h
+  timeout server 2h
+  timeout queue 2h
+  timeout http-request 30s
+  timeout http-keep-alive 1m
+
+frontend registry
+  bind :8080
+  acl write_request method POST PUT PATCH DELETE
+  use_backend registry_write if write_request
+  default_backend registry_read
+
+backend registry_write
+  option http-server-close
+  server registry 127.0.0.1:5000 maxconn 1 maxqueue 128 check
+
+backend registry_read
+  server registry 127.0.0.1:5000 maxconn 100 check

--- a/argocd/applications/registry/kustomization.yaml
+++ b/argocd/applications/registry/kustomization.yaml
@@ -8,3 +8,7 @@ resources:
   - registry-configmap.yaml
   - tailscale-ingress.yaml
   - ingressroute-registry-k8s-private.yaml
+configMapGenerator:
+  - name: registry-proxy
+    files:
+      - haproxy.cfg=haproxy.cfg

--- a/argocd/applications/registry/service.yaml
+++ b/argocd/applications/registry/service.yaml
@@ -8,4 +8,4 @@ spec:
     app: registry
   ports:
     - port: 80
-      targetPort: 5000
+      targetPort: registry-http

--- a/docs/torghut/storage-write-pressure-remediation-design.md
+++ b/docs/torghut/storage-write-pressure-remediation-design.md
@@ -342,6 +342,23 @@ stalls. Jangar quant persistence must therefore switch from append-only pipeline
 state, suppress no-op latest-metric updates, and reduce one-minute analytical-series sampling from five seconds to one
 minute before the storage-stability observation can start. Compute, alerting, and trading semantics remain unchanged.
 
+## Post-implementation registry addendum
+
+A later clean-observation attempt isolated another shared-pool writer. Analysis ARC scratch had already moved from an
+RBD PVC to a bounded node-local `emptyDir`, but its image publication still drove the single Distribution registry.
+That registry stores its filesystem on `rook-ceph-block`; during the push Kafka controller 2 recorded twelve controller
+events above two seconds, with a 3.288-second maximum. The DinD daemon was configured for eight concurrent uploads,
+above Docker's default of five, but the observed workflow used the `docker-container` BuildKit driver. Its exporter runs
+inside the BuildKit container and does not inherit the Docker daemon's upload limit.
+
+The Analysis workflow now removes its duplicate `mode=max` registry-cache export, keeps only inline cache metadata, and
+sets BuildKit's OCI worker `max-parallelism` to one. This removes publication of every intermediate build layer while
+preserving final-image cache reuse. All ARC DinD daemons also use `--max-concurrent-uploads=1` as a secondary boundary
+for direct Docker daemon pushes; that flag is not treated as BuildKit proof. The cancelled analysis image workflow must
+be rerun through build and push, and a new 30-minute storage gate must show no controller event above two seconds. If
+the real BuildKit workload still fails that gate, stop the rollout and design a retained local-registry migration with
+explicit copy, outage, recovery, and digest-inventory proof rather than masking the failure with Kafka timeouts.
+
 ## Talos local-storage feasibility and boundary
 
 Talos user volumes already expose sufficient local capacity:

--- a/docs/torghut/storage-write-pressure-remediation-design.md
+++ b/docs/torghut/storage-write-pressure-remediation-design.md
@@ -354,10 +354,21 @@ inside the BuildKit container and does not inherit the Docker daemon's upload li
 The Analysis workflow now removes its duplicate `mode=max` registry-cache export, keeps only inline cache metadata, and
 sets BuildKit's OCI worker `max-parallelism` to one. This removes publication of every intermediate build layer while
 preserving final-image cache reuse. All ARC DinD daemons also use `--max-concurrent-uploads=1` as a secondary boundary
-for direct Docker daemon pushes; that flag is not treated as BuildKit proof. The cancelled analysis image workflow must
-be rerun through build and push, and a new 30-minute storage gate must show no controller event above two seconds. If
-the real BuildKit workload still fails that gate, stop the rollout and design a retained local-registry migration with
-explicit copy, outage, recovery, and digest-inventory proof rather than masking the failure with Kafka timeouts.
+for direct Docker daemon pushes; that per-daemon flag is not treated as a global limit and does not govern direct
+`skopeo` publication.
+
+The definitive boundary is therefore attached to the singleton registry itself. Its Service terminates at an HAProxy
+sidecar that routes `POST`, `PUT`, `PATCH`, and `DELETE` requests through one backend connection while preserving a
+separate concurrent path for `GET` and `HEAD` image pulls. The write backend closes its server connection after each
+response so the single slot cannot remain captured by an idle publisher, and queues at most 128 write requests for up
+to two hours. A generated ConfigMap name forces a pod rollout on proxy-policy changes, and `Recreate` prevents two
+registry pods from competing for the RWO filesystem during that rollout. This covers Docker, BuildKit, and direct OCI
+publishers at the same shared choke point without reducing pull concurrency.
+
+The cancelled analysis image workflow must be rerun through build and push after this boundary rolls out, and a new
+30-minute storage gate must show no controller event above two seconds. If the real BuildKit workload still fails that
+gate, stop the rollout and design a retained local-registry migration with explicit copy, outage, recovery, and
+digest-inventory proof rather than masking the failure with Kafka timeouts.
 
 ## Talos local-storage feasibility and boundary
 

--- a/docs/torghut/storage-write-pressure-remediation-design.md
+++ b/docs/torghut/storage-write-pressure-remediation-design.md
@@ -357,6 +357,12 @@ preserving final-image cache reuse. All ARC DinD daemons also use `--max-concurr
 for direct Docker daemon pushes; that per-daemon flag is not treated as a global limit and does not govern direct
 `skopeo` publication.
 
+The pre-proxy Analysis rerun `29408081703` completed successfully after removing the registry-cache export, but its
+Distribution request log still showed simultaneous blob initiation and finalization from the BuildKit exporter. Kafka
+remained below the hard gate with no fencing or timeout, but the maximum controller event reached 1,854.48 ms. This is
+live proof that OCI worker `max-parallelism` bounds build execution, not exporter request fan-out; it cannot substitute
+for a registry-wide write boundary.
+
 The definitive boundary is therefore attached to the singleton registry itself. Its Service terminates at an HAProxy
 sidecar that routes `POST`, `PUT`, `PATCH`, and `DELETE` requests through one backend connection while preserving a
 separate concurrent path for `GET` and `HEAD` image pulls. The write backend closes its server connection after each

--- a/packages/scripts/src/shared/__tests__/arc-runner.test.ts
+++ b/packages/scripts/src/shared/__tests__/arc-runner.test.ts
@@ -83,6 +83,14 @@ describe('ARC Nix runner toolchain', () => {
     expect(runnerScaleSetBlock('analysis-arm64')).toContain('minRunners: 1')
   })
 
+  it('serializes registry uploads from every runner scale set', () => {
+    for (const scaleSet of ['arc-arm64', 'arc-amd64', 'analysis-arm64']) {
+      const block = runnerScaleSetBlock(scaleSet)
+      expect(block).toContain('--max-concurrent-uploads=1')
+      expect(block).not.toContain('--max-concurrent-uploads=8')
+    }
+  })
+
   it('keeps lab ARC ephemeral-storage requests small enough for the configured runner scale', () => {
     for (const scaleSet of ['arc-arm64', 'arc-amd64']) {
       const block = runnerScaleSetBlock(scaleSet)

--- a/packages/scripts/src/shared/__tests__/registry.test.ts
+++ b/packages/scripts/src/shared/__tests__/registry.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from 'node:fs'
+
+import { describe, expect, it } from 'bun:test'
+
+const repoRoot = new URL('../../../../../', import.meta.url)
+const readRepoFile = (path: string): string => readFileSync(new URL(path, repoRoot), 'utf8')
+
+const deployment = readRepoFile('argocd/applications/registry/deployment.yaml')
+const haproxyConfig = readRepoFile('argocd/applications/registry/haproxy.cfg')
+const kustomization = readRepoFile('argocd/applications/registry/kustomization.yaml')
+const pvc = readRepoFile('argocd/applications/registry/pvc.yaml')
+const service = readRepoFile('argocd/applications/registry/service.yaml')
+
+const backendBlock = (name: string): string => {
+  const marker = `\nbackend ${name}\n`
+  const start = haproxyConfig.indexOf(marker)
+  expect(start).toBeGreaterThan(-1)
+
+  const contentStart = start + 1
+  const next = haproxyConfig.indexOf('\nbackend ', contentStart + marker.length)
+  return haproxyConfig.slice(contentStart, next === -1 ? haproxyConfig.length : next)
+}
+
+describe('private registry write-pressure boundary', () => {
+  it('routes every registry mutation through one shared backend connection', () => {
+    expect(haproxyConfig).toContain('acl write_request method POST PUT PATCH DELETE')
+    expect(haproxyConfig).toContain('use_backend registry_write if write_request')
+    expect(haproxyConfig).toContain('default_backend registry_read')
+
+    const writeBackend = backendBlock('registry_write')
+    expect(writeBackend).toContain('option http-server-close')
+    expect(writeBackend).toContain('127.0.0.1:5000 maxconn 1 maxqueue 128 check')
+  })
+
+  it('keeps image pulls concurrent and separate from the write queue', () => {
+    const readBackend = backendBlock('registry_read')
+    expect(readBackend).toContain('127.0.0.1:5000 maxconn 100 check')
+    expect(readBackend).not.toContain('maxconn 1 ')
+  })
+
+  it('serves traffic through the pinned non-root proxy and rolls config changes', () => {
+    expect(service).toContain('targetPort: registry-http')
+    expect(deployment).toContain('type: Recreate')
+    expect(deployment).toContain(
+      'haproxy:3.2.21-alpine@sha256:66e25cc9a8332635f4e897f7f4b1e5622c25f09f0ee23cddc6ce9bdb3a24772a',
+    )
+    expect(deployment).toContain('runAsNonRoot: true')
+    expect(deployment).toContain('readOnlyRootFilesystem: true')
+    expect(deployment).toContain('containerPort: 8080')
+    expect(haproxyConfig).toContain('bind :8080')
+    expect(deployment).toContain('path: /v2/')
+    expect(kustomization).toContain('configMapGenerator:')
+    expect(kustomization).toContain('haproxy.cfg=haproxy.cfg')
+  })
+
+  it('preserves the single Ceph filesystem store and its existing claim', () => {
+    expect(deployment).toContain('claimName: registry-data')
+    expect(pvc).toContain('storageClassName: rook-ceph-block')
+    expect(pvc).toContain('storage: 2Ti')
+  })
+})


### PR DESCRIPTION
## Summary

- enforce one shared registry write request across Docker, BuildKit, and direct OCI publishers while keeping image pulls concurrent
- serialize each ARC Docker daemon as a secondary boundary and pin the registry/proxy images used by the singleton deployment
- document the observed Analysis write pressure and add regression coverage for the runner and registry-wide controls

## Related Issues

None.

## Testing

- `nix develop -c bun test packages/scripts/src/shared/__tests__/arc-runner.test.ts packages/scripts/src/shared/__tests__/registry.test.ts` (12 passed, 252 assertions)
- `nix develop -c bunx oxfmt --check packages/scripts/src/shared/__tests__/arc-runner.test.ts packages/scripts/src/shared/__tests__/registry.test.ts docs/torghut/storage-write-pressure-remediation-design.md`
- `nix develop -c bun run lint:argocd` (all rendered resources valid)
- `nix develop -c sh -c 'kustomize build --enable-helm argocd/applications/registry | kubectl apply --dry-run=server -f -'`
- `docker run --rm --read-only --user 99:99 --cap-drop ALL --security-opt no-new-privileges -v "$PWD/argocd/applications/registry/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro" docker.io/library/haproxy:3.2.21-alpine haproxy -c -f /usr/local/etc/haproxy/haproxy.cfg`
- restricted Distribution write test with a read-only root filesystem, dropped capabilities, and writable data mount (`POST` and `PATCH` returned 202)
- local Distribution protocol tests with two simultaneous `PATCH` uploads (one active, one queued for 2.953 seconds) and a concurrent `GET` completing in 1.384 ms during a 9.958-second write
- `git diff --check`

## Screenshots (if applicable)

N/A. This changes registry and runner runtime policy only.

## Breaking Changes

None. The singleton registry has one brief `Recreate` rollout; write requests may queue while image pulls remain concurrent.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation and regression coverage are updated.
