### PR TITLE
feat(torghut): preserve validation descendant lineage

### DIFF
--- a/docs/torghut/profitability/implementation-roadmap.md
+++ b/docs/torghut/profitability/implementation-roadmap.md
@@ -183,11 +183,14 @@ recoverable.
 - Deliverable: extend the coordinator to cancel, cancel-all, replace, multi-leg unwind, reduce-only closeout, and
   emergency liquidation, including causal links to the original order. Add a per-action `RiskReductionPermit` derived
   from broker-observed orders/positions that forbids new symbols, side flips, and any gross/net exposure increase; it
-  must remain issuable when candidate authority or profitability evidence is missing or expired.
+  must remain issuable when candidate authority or profitability evidence is missing or expired. Validation descendants
+  carry an exact-key root-and-parent lineage envelope enforced by PostgreSQL; mixed ordinary/validation account-wide
+  cancellation remains live without relabeling ordinary activity, and each proven validation event remains outside
+  candidate, trial, PnL, promotion, and ledger evidence.
 - Primary surfaces: all broker mutation adapters, closeout/kill-switch paths, claim schema, and emergency runbooks.
 - Tests: cancel/replace races with fills, partial-fill closeout, duplicate cancel, multi-leg partial failure, stale
-  candidate authority, stale profitability/reconciliation evidence, no-side-flip and no-increase properties, and broker
-  outage during emergency reduction.
+  candidate authority, stale profitability/reconciliation evidence, no-side-flip and no-increase properties, forged or
+  cross-scope validation ancestry, descendant order-feed exclusion, and broker outage during emergency reduction.
 - Runtime proof: an infrastructure-validation paper/sandbox lifecycle exercises each mutation, reconciles a single
   causal chain, and remains excluded from every promotion/trial query.
 - Dependency: slices 4-5. Effort: `L`.

--- a/docs/torghut/profitability/infrastructure-validation-runbook.md
+++ b/docs/torghut/profitability/infrastructure-validation-runbook.md
@@ -185,3 +185,31 @@ This implementation was checked on 2026-07-14 against Alpaca's official document
 - [client-order-ID lookup](https://docs.alpaca.markets/us/reference/getorderbyclientorderid) is the recovery identity.
 
 Recheck these primary sources before changing the order envelope or interpreting a new broker response.
+
+## Slice 6 Lifecycle Boundary
+
+Migration `0071_validation_lineage` adds the database contract for non-promotable replace and targeted cancel, and
+establishes the still-blocked boundary for targeted close and flatten descendants. Each descendant must name a terminal
+immediate parent and broker-terminal validation root; the database independently checks account, endpoint, root permit
+identity and submit-time window, broker order target, and root symbol.
+Order-feed events from a settled descendant are excluded by broker order ID even when the broker client-order ID no
+longer has the `ivp-` prefix.
+
+Permit expiry prevents another validation submit; it does not strand an existing order or position. A descendant uses
+the normal short-lived `RiskReductionPermit`, so cancel, monotonic replace, close, and flatten remain available after
+the root permit expires. A root recovered from an ambiguous broker-I/O window is eligible once broker readback settles
+it as `reconciled` with the exact broker order ID.
+
+The known-null IOC plan in this runbook may parent cancel or replace, but never close. Because it requires zero fill, it
+cannot prove position ancestry. Migration `0071` keeps close lineage blocked until the lifecycle runner's separate,
+position-producing plan schema is installed.
+
+The follow-up migration must not unlock close merely by accepting that schema name. It must bind the root broker order
+to persisted non-promotable fill evidence, prove positive bounded cumulative fill on the sole symbol, and reconcile the
+paper account's before/after position against that fill. Missing, zero, stale, cross-account, or cross-endpoint fill
+evidence keeps close and flatten blocked.
+
+This migration is necessary but is not the lifecycle proof. Do not manually compose descendant intents or infer that
+Slice 6 is proven from migration presence. The bounded Alpaca-paper lifecycle runner, immutable image promotion, broker
+readback, CNPG receipt chain, and independent absence from candidate/PnL/ledger evidence must all pass before
+`reduction_fencing_proven` can become true.

--- a/docs/torghut/profitability/risk-reduction-mutation-fencing.md
+++ b/docs/torghut/profitability/risk-reduction-mutation-fencing.md
@@ -136,8 +136,44 @@ receipt for an aggregate broker position or an external order, and it does not a
 Torghut order ancestry remains recoverable from the sealed client order ID and existing receipt or submission-claim
 records.
 
-Infrastructure-validation mutations retain their non-promotable marker and validation workflow identity throughout the
-causal chain. Candidate, trial, PnL, and promotion queries must exclude every descendant, not only the initial submit.
+Order-targeted and position-targeted infrastructure-validation mutations retain their non-promotable marker and
+validation workflow identity throughout the causal chain. Account-wide cancellation events are classified per order.
+Candidate, trial, PnL, and promotion queries must exclude every validation descendant, not only the initial submit.
+
+### Validation-Descendant Lineage
+
+Validation lineage is carried inside the existing canonical mutation intent; it is not a second coordinator, claim
+table, or evidence authority. The envelope names the immutable validation root, the immediately preceding receipt and
+broker order, the exact permit identity, and `promotable=false`. PostgreSQL accepts it only when all of these are true:
+
+- the root is an acknowledged or broker-reconciled, risk-neutral Alpaca paper validation submit in the same account
+  and endpoint;
+- the root permit ID and digest match; the root was created inside that permit's validity window, while later
+  risk-reducing descendants remain available after it expires;
+- the immediate parent is terminal, belongs to the same root chain, produced the named broker order ID, and is either
+  the root submit or an order-creating replace/close descendant; cancel receipts never become order identity;
+- cancel or replace targets that parent order, while close targets the root plan's sole symbol; and
+- the envelope has exactly the documented keys, with no caller-supplied extensions.
+
+The existing known-null IOC submit plan can parent cancel or replace only. It can never parent a close: it proves zero
+fill and therefore has no position ancestry. Close lineage remains database-blocked until the dedicated lifecycle plan
+schema and runner establish a bounded fill on the sole symbol. The follow-up guard must verify persisted tagged fill
+and reconciled position evidence; recognizing a plan-schema string alone is not position proof.
+
+Account-wide cancel remains available for every complete snapshot because it is a safety operation whose broker scope
+can race beyond the observed order set. Its receipt is never relabeled wholesale as validation. Each validation
+cancellation event is excluded independently from the existing root or replacement order ancestry. Cancel receipts
+never become order-identity parents because cancellation creates no broker order. Order-feed ingestion resolves
+order-creating descendants by settled broker order ID as well as the root `ivp-...` client ID. The same database-proven
+marker prevents execution/decision linkage and TigerBeetle journaling for every validation event.
+
+A broker trade update can race ahead of local receipt settlement. The order feed may classify the root update from the
+exact validation client ID plus the broker-observed order ID so ingestion continues and the event remains excluded, but
+that provisional evidence cannot authorize a descendant. Lineage construction remains blocked until the durable root
+receipt is acknowledged or broker-reconciled with an order reference.
+
+These checks prove evidence isolation and causal ancestry. They do not prove that the paper lifecycle runner exercised
+replace, cancel, partial close, or flatten. That remains a separate runtime gate below.
 
 ## State And Recovery
 
@@ -162,7 +198,8 @@ Broker-specific terminal evidence:
 
 - Alpaca cancel uses the exact order ID; cancel-all is only terminal after all sealed IDs are absent from a complete
   open-order snapshot. Replace is terminal when the desired replacement fields and causal order relationship are
-  observed. Close is terminal when the exact position is reduced or flat without a side flip.
+  observed. Close is terminal when the exact position is reduced or flat without a side flip. A successful replace or
+  close response without its broker order ID remains unresolved; a generated request ID is not order identity.
 - Hyperliquid cancel uses the exact order ID and coin. Reduce-only close is terminal only after broker position
   observation proves the bounded reduction; the SDK's `reduce_only` flag is necessary but not sufficient evidence.
 

--- a/services/torghut/app/models/entities/broker_mutation_records.py
+++ b/services/torghut/app/models/entities/broker_mutation_records.py
@@ -24,6 +24,7 @@ from sqlalchemy.schema import conv
 from ..base import Base, GUID
 from .broker_mutation_validation_contract import (
     BROKER_MUTATION_VALIDATION_AUTHORITY_SQL,
+    BROKER_MUTATION_VALIDATION_LINEAGE_SQL,
     BROKER_MUTATION_VALIDATION_PERMIT_ID_SQL,
 )
 
@@ -146,6 +147,10 @@ class BrokerMutationReceipt(Base):
         CheckConstraint(
             BROKER_MUTATION_VALIDATION_AUTHORITY_SQL,
             name=conv("ck_bm_receipt_validation_authority"),
+        ).ddl_if(dialect="postgresql"),
+        CheckConstraint(
+            BROKER_MUTATION_VALIDATION_LINEAGE_SQL,
+            name=conv("ck_bm_receipt_validation_lineage"),
         ).ddl_if(dialect="postgresql"),
         CheckConstraint("length(endpoint_fingerprint) = 64", name="endpoint_hash"),
         CheckConstraint(
@@ -535,6 +540,13 @@ class BrokerMutationReceiptEvent(Base):
             "recovery_lease_expires_at",
             "receipt_id",
             "sequence_no",
+        ),
+        Index(
+            "ix_bm_receipt_event_broker_reference",
+            "broker_reference",
+            "receipt_id",
+            postgresql_where=text("state = 'settled' AND broker_reference IS NOT NULL"),
+            sqlite_where=text("state = 'settled' AND broker_reference IS NOT NULL"),
         ),
     )
 

--- a/services/torghut/app/models/entities/broker_mutation_validation_contract.py
+++ b/services/torghut/app/models/entities/broker_mutation_validation_contract.py
@@ -176,7 +176,58 @@ BROKER_MUTATION_VALIDATION_PERMIT_ID_SQL = (
     "'{request,infrastructure_validation,permit,permit_id}')"
 )
 
+BROKER_MUTATION_VALIDATION_LINEAGE_SQL = r"""
+(canonical_intent_json::jsonb #>
+  '{request,infrastructure_validation_lineage}') IS NULL
+OR COALESCE((
+  broker_route = 'alpaca'
+  AND submission_claim_id IS NULL
+  AND operation IN ('replace_order', 'cancel_order',
+                    'close_position', 'close_all_positions')
+  AND jsonb_typeof(canonical_intent_json::jsonb #>
+      '{request,infrastructure_validation_lineage}') = 'object'
+  AND (canonical_intent_json::jsonb #>
+      '{request,infrastructure_validation_lineage}') ?& ARRAY[
+        'schema_version', 'root_receipt_id', 'root_client_order_id',
+        'parent_receipt_id', 'parent_broker_order_id', 'permit_id',
+        'permit_sha256', 'evidence_tag', 'promotable'
+      ]
+  AND ((canonical_intent_json::jsonb #>
+      '{request,infrastructure_validation_lineage}') - ARRAY[
+        'schema_version', 'root_receipt_id', 'root_client_order_id',
+        'parent_receipt_id', 'parent_broker_order_id', 'permit_id',
+        'permit_sha256', 'evidence_tag', 'promotable'
+      ]) = '{}'::jsonb
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation_lineage,schema_version}' =
+      'torghut.infrastructure-validation-lineage.v1'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation_lineage,root_receipt_id}' ~
+      '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation_lineage,root_client_order_id}' ~
+      '^ivp-[0-9a-f]{44}$'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation_lineage,parent_receipt_id}' ~
+      '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+  AND length(canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation_lineage,parent_broker_order_id}')
+      BETWEEN 1 AND 256
+  AND length(canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation_lineage,permit_id}') BETWEEN 1 AND 128
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation_lineage,permit_sha256}' ~
+      '^[0-9a-f]{64}$'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation_lineage,evidence_tag}' =
+      'non_promotable_validation'
+  AND canonical_intent_json::jsonb #>
+      '{request,infrastructure_validation_lineage,promotable}' = 'false'::jsonb
+), FALSE)
+"""
+
 __all__ = [
     "BROKER_MUTATION_VALIDATION_AUTHORITY_SQL",
+    "BROKER_MUTATION_VALIDATION_LINEAGE_SQL",
     "BROKER_MUTATION_VALIDATION_PERMIT_ID_SQL",
 ]

--- a/services/torghut/app/trading/alpaca_reduction_mutations.py
+++ b/services/torghut/app/trading/alpaca_reduction_mutations.py
@@ -37,6 +37,11 @@ from .broker_mutation_receipts import (
     fingerprint_broker_endpoint,
 )
 from .firewall import OrderFirewall
+from .infrastructure_validation_records import (
+    InfrastructureValidationEvidence,
+    infrastructure_validation_lineage_payload,
+    load_infrastructure_validation_evidence,
+)
 from .risk_reduction import (
     BrokerOrderObservation,
     BrokerPositionObservation,
@@ -61,6 +66,9 @@ _Result = TypeVar("_Result")
 _OPEN_ORDER_LIMIT = 500
 _REQUEST_SCHEMA_VERSION = "torghut.alpaca-reduction-request.v1"
 _PREFLIGHT_SCHEMA_VERSION = "torghut.alpaca-reduction-preflight.v1"
+_ORDER_CREATING_OPERATIONS = frozenset(
+    {"replace_order", "close_position", "close_all_positions"}
+)
 _ACCEPTED_ORDER_STATUSES = frozenset(
     {
         "accepted",
@@ -144,6 +152,7 @@ class AlpacaReductionMutationExecutor:
             raise RiskReductionPermitError("alpaca_cancel_order_identity_mismatch")
         if not order.open:
             observation = {"order": dict(raw_order)}
+            validation_evidence = self._validation_evidence_for_order(order)
             self._settle_already_satisfied(
                 _MutationSpec(
                     operation="cancel_order",
@@ -151,7 +160,10 @@ class AlpacaReductionMutationExecutor:
                     purpose=purpose,
                     target_kind="order",
                     target_key=order_id,
-                    request_payload=_already_satisfied_request(observation),
+                    request_payload=_already_satisfied_request(
+                        observation,
+                        validation_evidence=validation_evidence,
+                    ),
                 ),
                 observation=observation,
             )
@@ -164,6 +176,7 @@ class AlpacaReductionMutationExecutor:
         request_payload = _request_payload(
             authorization,
             broker_request={"order_id": order_id},
+            validation_evidence=self._validation_evidence_for_order(order),
         )
         return self._execute(
             _MutationSpec(
@@ -274,6 +287,7 @@ class AlpacaReductionMutationExecutor:
                 "limit_price": _decimal_text(limit_price),
                 "order_id": order_id,
             },
+            validation_evidence=self._validation_evidence_for_order(order),
         )
         return self._execute(
             _MutationSpec(
@@ -301,7 +315,12 @@ class AlpacaReductionMutationExecutor:
         quantity: Decimal,
         *,
         purpose: BrokerMutationPurpose = "closeout",
+        validation_evidence: InfrastructureValidationEvidence | None = None,
     ) -> dict[str, object]:
+        self._require_validation_evidence_scope(
+            validation_evidence,
+            require_position_ancestry=True,
+        )
         observed_at = datetime.now(timezone.utc)
         positions = tuple(
             alpaca_position_observation(position)
@@ -321,7 +340,10 @@ class AlpacaReductionMutationExecutor:
                     purpose=purpose,
                     target_kind="position",
                     target_key=normalized_symbol,
-                    request_payload=_already_satisfied_request(observation),
+                    request_payload=_already_satisfied_request(
+                        observation,
+                        validation_evidence=validation_evidence,
+                    ),
                 ),
                 observation=observation,
             )
@@ -346,6 +368,7 @@ class AlpacaReductionMutationExecutor:
                 "quantity": _decimal_text(quantity),
                 "symbol": normalized_symbol,
             },
+            validation_evidence=validation_evidence,
         )
         return self._execute(
             _MutationSpec(
@@ -371,7 +394,12 @@ class AlpacaReductionMutationExecutor:
         self,
         *,
         purpose: BrokerMutationPurpose = "flatten",
+        validation_evidence: InfrastructureValidationEvidence | None = None,
     ) -> list[dict[str, object]]:
+        self._require_validation_evidence_scope(
+            validation_evidence,
+            require_position_ancestry=True,
+        )
         observed_at = datetime.now(timezone.utc)
         positions = tuple(
             alpaca_position_observation(position)
@@ -386,7 +414,10 @@ class AlpacaReductionMutationExecutor:
                     purpose=purpose,
                     target_kind="account",
                     target_key=self._account_label,
-                    request_payload=_already_satisfied_request(observation),
+                    request_payload=_already_satisfied_request(
+                        observation,
+                        validation_evidence=validation_evidence,
+                    ),
                 ),
                 observation=observation,
             )
@@ -406,6 +437,7 @@ class AlpacaReductionMutationExecutor:
             broker_request={
                 "symbols": sorted(position.symbol for position in positions),
             },
+            validation_evidence=validation_evidence,
         )
         return self._execute(
             _MutationSpec(
@@ -442,6 +474,43 @@ class AlpacaReductionMutationExecutor:
             orders=orders,
             positions=positions,
         )
+
+    def _validation_evidence_for_order(
+        self,
+        order: BrokerOrderObservation,
+    ) -> InfrastructureValidationEvidence | None:
+        client_order_id = str(order.client_order_id or "").strip()
+        with self._session_factory() as session:
+            evidence = load_infrastructure_validation_evidence(
+                session,
+                account_label=self._account_label,
+                client_order_id=client_order_id,
+                alpaca_order_id=order.order_id,
+                endpoint_fingerprint=self._endpoint_fingerprint,
+            )
+        if evidence is None and client_order_id.startswith("ivp-"):
+            raise RuntimeError("infrastructure_validation_order_lineage_missing")
+        return evidence
+
+    def _require_validation_evidence_scope(
+        self,
+        evidence: InfrastructureValidationEvidence | None,
+        *,
+        require_position_ancestry: bool = False,
+    ) -> None:
+        if evidence is None:
+            return
+        if (
+            evidence.account_label != self._account_label
+            or evidence.endpoint_fingerprint != self._endpoint_fingerprint
+        ):
+            raise RuntimeError("infrastructure_validation_lineage_scope_mismatch")
+        if (
+            require_position_ancestry
+            and evidence.root_plan_schema
+            != "torghut.infrastructure-validation-lifecycle-plan.v1"
+        ):
+            raise RuntimeError("infrastructure_validation_position_ancestry_missing")
 
     def _execute(
         self,
@@ -544,22 +613,35 @@ def _request_payload(
     authorization: RiskReductionAuthorization,
     *,
     broker_request: Mapping[str, object],
+    validation_evidence: InfrastructureValidationEvidence | None = None,
 ) -> Mapping[str, object]:
-    return {
+    payload: dict[str, object] = {
         **broker_request,
         "risk_reduction": authorization.evidence_payload,
         "schema_version": _REQUEST_SCHEMA_VERSION,
     }
+    if validation_evidence is not None:
+        payload["infrastructure_validation_lineage"] = (
+            infrastructure_validation_lineage_payload(validation_evidence)
+        )
+    return payload
 
 
 def _already_satisfied_request(
     observation: Mapping[str, object],
+    *,
+    validation_evidence: InfrastructureValidationEvidence | None = None,
 ) -> Mapping[str, object]:
-    return {
+    payload: dict[str, object] = {
         "already_satisfied": True,
         "observation": observation,
         "schema_version": _PREFLIGHT_SCHEMA_VERSION,
     }
+    if validation_evidence is not None:
+        payload["infrastructure_validation_lineage"] = (
+            infrastructure_validation_lineage_payload(validation_evidence)
+        )
+    return payload
 
 
 def _terminal_settlement(
@@ -569,7 +651,15 @@ def _terminal_settlement(
     response: object,
 ) -> BrokerMutationSettlement:
     rejected = _response_rejected(response)
-    broker_reference = _broker_reference(response) or client_request_id
+    broker_reference = _broker_reference(response)
+    if (
+        not rejected
+        and operation in _ORDER_CREATING_OPERATIONS
+        and not broker_reference
+    ):
+        raise ValueError("alpaca_reduction_broker_reference_missing")
+    if not broker_reference:
+        broker_reference = client_request_id
     return build_broker_mutation_settlement(
         BrokerMutationSettlementRequest(
             source="primary",

--- a/services/torghut/app/trading/infrastructure_validation_records.py
+++ b/services/torghut/app/trading/infrastructure_validation_records.py
@@ -6,13 +6,18 @@ import json
 import re
 import uuid
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import cast
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from ..models import BrokerMutationReceipt, coerce_json_payload
+from ..models import (
+    BrokerMutationReceipt,
+    BrokerMutationReceiptEvent,
+    coerce_json_payload,
+)
 from .evidence_contracts import (
     ArtifactProvenance,
     EvidenceMaturity,
@@ -23,11 +28,55 @@ from .evidence_contracts import (
 _EVIDENCE_KEY = "_torghut_evidence_contract"
 _EVIDENCE_SCHEMA_VERSION = "torghut.order-event-evidence-contract.v1"
 _EVIDENCE_TAG = ArtifactProvenance.NON_PROMOTABLE_VALIDATION.value
+_EVIDENCE_SEAL = object()
+_LINEAGE_SCHEMA_VERSION = "torghut.infrastructure-validation-lineage.v1"
+_ORDER_CREATING_LINEAGE_OPERATIONS = (
+    "replace_order",
+    "close_position",
+    "close_all_positions",
+)
+_LINEAGE_KEYS = frozenset(
+    {
+        "schema_version",
+        "root_receipt_id",
+        "root_client_order_id",
+        "parent_receipt_id",
+        "parent_broker_order_id",
+        "permit_id",
+        "permit_sha256",
+        "evidence_tag",
+        "promotable",
+    }
+)
 
 
 @dataclass(frozen=True, slots=True)
 class InfrastructureValidationEvidence:
+    """Database-proven validation ancestry for one broker mutation."""
+
     receipt_id: uuid.UUID
+    broker_order_id: str
+    root_receipt_id: uuid.UUID
+    root_client_order_id: str
+    root_plan_schema: str
+    permit_id: str
+    permit_sha256: str
+    account_label: str
+    endpoint_fingerprint: str
+    lineage_parent_terminal: bool
+    _seal: object = field(repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if self._seal is not _EVIDENCE_SEAL:
+            raise PermissionError("infrastructure_validation_evidence_issuer_invalid")
+
+
+@dataclass(frozen=True, slots=True)
+class _ValidationLineage:
+    root_receipt_id: uuid.UUID
+    root_client_order_id: str
+    parent_receipt_id: uuid.UUID
+    parent_broker_order_id: str
     permit_id: str
     permit_sha256: str
 
@@ -37,32 +86,288 @@ def load_infrastructure_validation_evidence(
     *,
     account_label: str,
     client_order_id: str | None,
+    alpaca_order_id: str | None = None,
+    endpoint_fingerprint: str | None = None,
 ) -> InfrastructureValidationEvidence | None:
-    """Resolve a broker order identity to its immutable validation receipt."""
+    """Resolve broker client/order identities to immutable validation ancestry."""
 
     normalized_client_order_id = str(client_order_id or "").strip()
-    if not normalized_client_order_id.startswith("ivp-"):
-        return None
-    receipts = (
-        session.execute(
-            select(BrokerMutationReceipt).where(
-                BrokerMutationReceipt.account_label == account_label,
-                BrokerMutationReceipt.client_request_id == normalized_client_order_id,
-                BrokerMutationReceipt.purpose == "control_plane_validation",
-            )
+    normalized_order_id = str(alpaca_order_id or "").strip()
+    normalized_endpoint = str(endpoint_fingerprint or "").strip()
+    evidence: list[InfrastructureValidationEvidence] = []
+    if normalized_client_order_id.startswith("ivp-"):
+        root_receipts = _root_receipts(
+            session,
+            account_label=account_label,
+            client_order_id=normalized_client_order_id,
+            endpoint_fingerprint=normalized_endpoint,
         )
-        .scalars()
-        .all()
-    )
-    if not receipts:
+        for receipt in root_receipts:
+            root_evidence = _root_evidence(
+                session,
+                receipt,
+                expected_client_order_id=normalized_client_order_id,
+                observed_broker_order_id=normalized_order_id,
+            )
+            if root_evidence is not None:
+                evidence.append(root_evidence)
+    if normalized_order_id:
+        descendant_receipts = _descendant_receipts(
+            session,
+            account_label=account_label,
+            alpaca_order_id=normalized_order_id,
+            endpoint_fingerprint=normalized_endpoint,
+        )
+        if len(descendant_receipts) > 1:
+            raise RuntimeError("infrastructure_validation_lineage_parent_split")
+        evidence.extend(
+            _descendant_evidence(session, receipt) for receipt in descendant_receipts
+        )
+    if not evidence:
         return None
-    if len(receipts) != 1:
+    roots = {
+        (
+            item.root_receipt_id,
+            item.root_client_order_id,
+            item.root_plan_schema,
+            item.permit_id,
+            item.permit_sha256,
+        )
+        for item in evidence
+    }
+    if len(roots) != 1:
         raise RuntimeError("infrastructure_validation_receipt_identity_split")
-    receipt = receipts[0]
+    # Prefer the receipt that created the observed broker order. Root client-ID
+    # evidence remains the fallback for cancel/reject events on the setup order.
+    return evidence[-1]
+
+
+def infrastructure_validation_lineage_payload(
+    evidence: InfrastructureValidationEvidence,
+) -> dict[str, object]:
+    """Build the exact parent proof sealed into a descendant mutation intent."""
+
+    if not evidence.lineage_parent_terminal:
+        raise RuntimeError("infrastructure_validation_lineage_parent_not_terminal")
+    return {
+        "schema_version": _LINEAGE_SCHEMA_VERSION,
+        "root_receipt_id": str(evidence.root_receipt_id),
+        "root_client_order_id": evidence.root_client_order_id,
+        "parent_receipt_id": str(evidence.receipt_id),
+        "parent_broker_order_id": evidence.broker_order_id,
+        "permit_id": evidence.permit_id,
+        "permit_sha256": evidence.permit_sha256,
+        "evidence_tag": _EVIDENCE_TAG,
+        "promotable": False,
+    }
+
+
+def _root_receipts(
+    session: Session,
+    *,
+    account_label: str,
+    client_order_id: str,
+    endpoint_fingerprint: str,
+) -> list[BrokerMutationReceipt]:
+    statement = select(BrokerMutationReceipt).where(
+        BrokerMutationReceipt.account_label == account_label,
+        BrokerMutationReceipt.client_request_id == client_order_id,
+        BrokerMutationReceipt.purpose == "control_plane_validation",
+    )
+    if endpoint_fingerprint:
+        statement = statement.where(
+            BrokerMutationReceipt.endpoint_fingerprint == endpoint_fingerprint
+        )
+    receipts = session.execute(statement).scalars().all()
+    if len(receipts) > 1:
+        raise RuntimeError("infrastructure_validation_receipt_identity_split")
+    return list(receipts)
+
+
+def _descendant_receipts(
+    session: Session,
+    *,
+    account_label: str,
+    alpaca_order_id: str,
+    endpoint_fingerprint: str,
+) -> list[BrokerMutationReceipt]:
+    statement = (
+        select(BrokerMutationReceipt)
+        .join(
+            BrokerMutationReceiptEvent,
+            BrokerMutationReceiptEvent.receipt_id == BrokerMutationReceipt.id,
+        )
+        .where(
+            BrokerMutationReceipt.account_label == account_label,
+            BrokerMutationReceipt.broker_route == "alpaca",
+            BrokerMutationReceipt.operation.in_(_ORDER_CREATING_LINEAGE_OPERATIONS),
+            BrokerMutationReceiptEvent.state == "settled",
+            BrokerMutationReceiptEvent.broker_reference == alpaca_order_id,
+        )
+        .distinct()
+    )
+    if endpoint_fingerprint:
+        statement = statement.where(
+            BrokerMutationReceipt.endpoint_fingerprint == endpoint_fingerprint
+        )
+    return [
+        receipt
+        for receipt in session.execute(statement).scalars().all()
+        if _has_validation_lineage(receipt)
+    ]
+
+
+def _has_validation_lineage(receipt: BrokerMutationReceipt) -> bool:
     try:
-        intent = json.loads(receipt.canonical_intent_json)
-        validation = intent["request"]["infrastructure_validation"]
-        permit = validation["permit"]
+        intent = _parse_json_object(receipt.canonical_intent_json)
+        request = _required_object(intent, "request")
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+        return False
+    return "infrastructure_validation_lineage" in request
+
+
+def _root_evidence(
+    session: Session,
+    receipt: BrokerMutationReceipt,
+    *,
+    expected_client_order_id: str,
+    observed_broker_order_id: str,
+) -> InfrastructureValidationEvidence | None:
+    permit_id, permit_sha256 = _root_permit_identity(receipt)
+    if receipt.client_request_id != expected_client_order_id:
+        raise RuntimeError("infrastructure_validation_receipt_identity_split")
+    terminal = _lineage_parent_terminal(
+        session,
+        receipt.id,
+        allowed_outcomes=frozenset({"acknowledged", "reconciled"}),
+    )
+    broker_order_id = (
+        _required_broker_reference(terminal)
+        if terminal is not None
+        else observed_broker_order_id
+    )
+    if not broker_order_id:
+        return None
+    return InfrastructureValidationEvidence(
+        receipt_id=receipt.id,
+        broker_order_id=broker_order_id,
+        root_receipt_id=receipt.id,
+        root_client_order_id=receipt.client_request_id,
+        root_plan_schema=_root_plan_schema(receipt),
+        permit_id=permit_id,
+        permit_sha256=permit_sha256,
+        account_label=receipt.account_label,
+        endpoint_fingerprint=receipt.endpoint_fingerprint,
+        lineage_parent_terminal=terminal is not None,
+        _seal=_EVIDENCE_SEAL,
+    )
+
+
+def _descendant_evidence(
+    session: Session,
+    receipt: BrokerMutationReceipt,
+) -> InfrastructureValidationEvidence:
+    intent, lineage = _parse_validation_lineage(receipt)
+    root = session.get(BrokerMutationReceipt, lineage.root_receipt_id)
+    if root is None:
+        raise RuntimeError("infrastructure_validation_lineage_root_missing")
+    root_permit = _root_permit_identity(root)
+    if (
+        root.account_label != receipt.account_label
+        or root.endpoint_fingerprint != receipt.endpoint_fingerprint
+        or root.client_request_id != lineage.root_client_order_id
+        or root_permit != (lineage.permit_id, lineage.permit_sha256)
+    ):
+        raise RuntimeError("infrastructure_validation_lineage_root_mismatch")
+    _require_lineage_parent_terminal(
+        session,
+        root.id,
+        allowed_outcomes=frozenset({"acknowledged", "reconciled"}),
+    )
+    parent = session.get(BrokerMutationReceipt, lineage.parent_receipt_id)
+    if parent is None:
+        raise RuntimeError("infrastructure_validation_lineage_parent_missing")
+    if (
+        parent.account_label != receipt.account_label
+        or parent.endpoint_fingerprint != receipt.endpoint_fingerprint
+        or _utc(parent.created_at) > _utc(receipt.created_at)
+        or parent.operation not in ("submit_order", *_ORDER_CREATING_LINEAGE_OPERATIONS)
+        or not _belongs_to_validation_root(parent, lineage.root_receipt_id)
+    ):
+        raise RuntimeError("infrastructure_validation_lineage_parent_mismatch")
+    parent_terminal = _require_lineage_parent_terminal(
+        session,
+        parent.id,
+        allowed_outcomes=frozenset({"acknowledged", "reconciled"}),
+    )
+    if _required_broker_reference(parent_terminal) != lineage.parent_broker_order_id:
+        raise RuntimeError("infrastructure_validation_lineage_parent_mismatch")
+    _require_lineage_target(
+        receipt,
+        intent=intent,
+        root=root,
+        parent_broker_order_id=lineage.parent_broker_order_id,
+    )
+    terminal = _require_lineage_parent_terminal(
+        session,
+        receipt.id,
+        allowed_outcomes=frozenset({"acknowledged", "reconciled"}),
+    )
+    return InfrastructureValidationEvidence(
+        receipt_id=receipt.id,
+        broker_order_id=_required_broker_reference(terminal),
+        root_receipt_id=lineage.root_receipt_id,
+        root_client_order_id=lineage.root_client_order_id,
+        root_plan_schema=_root_plan_schema(root),
+        permit_id=lineage.permit_id,
+        permit_sha256=lineage.permit_sha256,
+        account_label=receipt.account_label,
+        endpoint_fingerprint=receipt.endpoint_fingerprint,
+        lineage_parent_terminal=True,
+        _seal=_EVIDENCE_SEAL,
+    )
+
+
+def _parse_validation_lineage(
+    receipt: BrokerMutationReceipt,
+) -> tuple[dict[str, object], _ValidationLineage]:
+    try:
+        intent = _parse_json_object(receipt.canonical_intent_json)
+        request = _required_object(intent, "request")
+        raw = _required_object(request, "infrastructure_validation_lineage")
+        if frozenset(raw) != _LINEAGE_KEYS:
+            raise ValueError("validation_lineage_shape_invalid")
+        lineage = _ValidationLineage(
+            root_receipt_id=uuid.UUID(str(raw["root_receipt_id"])),
+            root_client_order_id=str(raw["root_client_order_id"]).strip(),
+            parent_receipt_id=uuid.UUID(str(raw["parent_receipt_id"])),
+            parent_broker_order_id=str(raw["parent_broker_order_id"]).strip(),
+            permit_id=str(raw["permit_id"]).strip(),
+            permit_sha256=str(raw["permit_sha256"]).strip(),
+        )
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise RuntimeError(
+            "infrastructure_validation_receipt_evidence_invalid"
+        ) from exc
+    if (
+        raw["schema_version"] != _LINEAGE_SCHEMA_VERSION
+        or re.fullmatch(r"ivp-[0-9a-f]{44}", lineage.root_client_order_id) is None
+        or not lineage.parent_broker_order_id
+        or not lineage.permit_id
+        or re.fullmatch(r"[0-9a-f]{64}", lineage.permit_sha256) is None
+        or raw["evidence_tag"] != _EVIDENCE_TAG
+        or raw["promotable"] is not False
+    ):
+        raise RuntimeError("infrastructure_validation_receipt_evidence_invalid")
+    return intent, lineage
+
+
+def _root_permit_identity(receipt: BrokerMutationReceipt) -> tuple[str, str]:
+    try:
+        intent = _parse_json_object(receipt.canonical_intent_json)
+        request = _required_object(intent, "request")
+        validation = _required_object(request, "infrastructure_validation")
+        permit = _required_object(validation, "permit")
         permit_id = str(permit["permit_id"]).strip()
         permit_sha256 = str(validation["permit_sha256"]).strip()
         evidence_tag = permit["evidence_tag"]
@@ -72,17 +377,151 @@ def load_infrastructure_validation_evidence(
             "infrastructure_validation_receipt_evidence_invalid"
         ) from exc
     if (
-        not permit_id
+        receipt.purpose != "control_plane_validation"
+        or receipt.operation != "submit_order"
+        or re.fullmatch(r"ivp-[0-9a-f]{44}", receipt.client_request_id) is None
+        or not permit_id
         or re.fullmatch(r"[0-9a-f]{64}", permit_sha256) is None
         or evidence_tag != _EVIDENCE_TAG
         or promotable is not False
     ):
         raise RuntimeError("infrastructure_validation_receipt_evidence_invalid")
-    return InfrastructureValidationEvidence(
-        receipt_id=receipt.id,
-        permit_id=permit_id,
-        permit_sha256=permit_sha256,
+    return permit_id, permit_sha256
+
+
+def _root_plan_schema(receipt: BrokerMutationReceipt) -> str:
+    try:
+        intent = _parse_json_object(receipt.canonical_intent_json)
+        request = _required_object(intent, "request")
+        validation = _required_object(request, "infrastructure_validation")
+        test_plan = _required_object(validation, "test_plan")
+        schema_version = str(test_plan["schema_version"]).strip()
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise RuntimeError(
+            "infrastructure_validation_receipt_evidence_invalid"
+        ) from exc
+    if not schema_version:
+        raise RuntimeError("infrastructure_validation_receipt_evidence_invalid")
+    return schema_version
+
+
+def _belongs_to_validation_root(
+    receipt: BrokerMutationReceipt,
+    root_receipt_id: uuid.UUID,
+) -> bool:
+    if receipt.id == root_receipt_id:
+        return True
+    try:
+        intent = _parse_json_object(receipt.canonical_intent_json)
+        request = _required_object(intent, "request")
+        lineage = _required_object(request, "infrastructure_validation_lineage")
+        lineage_root = uuid.UUID(str(lineage["root_receipt_id"]))
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+        return False
+    return lineage_root == root_receipt_id
+
+
+def _utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _require_lineage_target(
+    receipt: BrokerMutationReceipt,
+    *,
+    intent: Mapping[str, object],
+    root: BrokerMutationReceipt,
+    parent_broker_order_id: str,
+) -> None:
+    try:
+        request = _required_object(intent, "request")
+        root_intent = _parse_json_object(root.canonical_intent_json)
+        root_request = _required_object(root_intent, "request")
+        validation = _required_object(root_request, "infrastructure_validation")
+        test_plan = _required_object(validation, "test_plan")
+        root_symbol = str(test_plan["symbol"]).strip()
+        root_plan_schema = str(test_plan["schema_version"]).strip()
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise RuntimeError(
+            "infrastructure_validation_receipt_evidence_invalid"
+        ) from exc
+    target_matches = {
+        "replace_order": receipt.target_key == parent_broker_order_id,
+        "cancel_order": receipt.target_key == parent_broker_order_id,
+        "close_position": root_plan_schema
+        == "torghut.infrastructure-validation-lifecycle-plan.v1"
+        and receipt.target_key == root_symbol,
+        "close_all_positions": root_plan_schema
+        == "torghut.infrastructure-validation-lifecycle-plan.v1"
+        and request.get("symbols") == [root_symbol],
+    }.get(receipt.operation, False)
+    if not target_matches:
+        raise RuntimeError("infrastructure_validation_lineage_target_mismatch")
+
+
+def _require_lineage_parent_terminal(
+    session: Session,
+    receipt_id: uuid.UUID,
+    *,
+    allowed_outcomes: frozenset[str],
+) -> BrokerMutationReceiptEvent:
+    latest = _lineage_parent_terminal(
+        session,
+        receipt_id,
+        allowed_outcomes=allowed_outcomes,
     )
+    if latest is None:
+        raise RuntimeError("infrastructure_validation_lineage_parent_not_terminal")
+    return latest
+
+
+def _lineage_parent_terminal(
+    session: Session,
+    receipt_id: uuid.UUID,
+    *,
+    allowed_outcomes: frozenset[str],
+) -> BrokerMutationReceiptEvent | None:
+    latest = session.execute(
+        select(BrokerMutationReceiptEvent)
+        .where(BrokerMutationReceiptEvent.receipt_id == receipt_id)
+        .order_by(BrokerMutationReceiptEvent.sequence_no.desc())
+        .limit(1)
+    ).scalar_one_or_none()
+    if (
+        latest is None
+        or latest.state != "settled"
+        or latest.settlement_outcome not in allowed_outcomes
+    ):
+        return None
+    return latest
+
+
+def _required_broker_reference(event: BrokerMutationReceiptEvent) -> str:
+    broker_reference = str(event.broker_reference or "").strip()
+    if not broker_reference:
+        raise RuntimeError("infrastructure_validation_lineage_parent_reference_missing")
+    return broker_reference
+
+
+def _parse_json_object(raw_document: str) -> dict[str, object]:
+    raw_value: object = json.loads(raw_document)
+    return _object_mapping(raw_value)
+
+
+def _required_object(
+    document: Mapping[str, object],
+    key: str,
+) -> dict[str, object]:
+    return _object_mapping(document[key])
+
+
+def _object_mapping(value: object) -> dict[str, object]:
+    if not isinstance(value, Mapping):
+        raise TypeError("infrastructure_validation_json_object_required")
+    return {
+        str(key): item for key, item in cast(Mapping[object, object], value).items()
+    }
 
 
 def tag_infrastructure_validation_event(
@@ -108,6 +547,8 @@ def tag_infrastructure_validation_event(
         ),
         "promotable": False,
         "broker_mutation_receipt_id": str(evidence.receipt_id),
+        "validation_root_receipt_id": str(evidence.root_receipt_id),
+        "validation_root_client_order_id": evidence.root_client_order_id,
         "permit_id": evidence.permit_id,
         "permit_sha256": evidence.permit_sha256,
     }
@@ -157,6 +598,7 @@ def is_non_promotable_validation_event(raw_event: object) -> bool:
 
 __all__ = [
     "InfrastructureValidationEvidence",
+    "infrastructure_validation_lineage_payload",
     "is_non_promotable_validation_event",
     "load_infrastructure_validation_evidence",
     "strip_unproven_infrastructure_validation_evidence",

--- a/services/torghut/app/trading/order_feed/normalize_order_feed_record.py
+++ b/services/torghut/app/trading/order_feed/normalize_order_feed_record.py
@@ -369,6 +369,7 @@ def persist_order_event(
         session,
         account_label=event.alpaca_account_label,
         client_order_id=event.client_order_id,
+        alpaca_order_id=event.alpaca_order_id,
     )
     existing = session.execute(
         select(ExecutionOrderEvent).where(
@@ -759,6 +760,7 @@ def link_order_events_to_execution(
                 session,
                 account_label=event.alpaca_account_label,
                 client_order_id=event.client_order_id,
+                alpaca_order_id=event.alpaca_order_id,
             )
             is not None
         ):

--- a/services/torghut/app/trading/order_feed/repair_order_feed_execution_links.py
+++ b/services/torghut/app/trading/order_feed/repair_order_feed_execution_links.py
@@ -223,6 +223,7 @@ def repair_order_feed_execution_links(
                 session,
                 account_label=event.alpaca_account_label,
                 client_order_id=event.client_order_id,
+                alpaca_order_id=event.alpaca_order_id,
             )
             is not None
         ):

--- a/services/torghut/app/trading/tigerbeetle_journal/transfer_refs.py
+++ b/services/torghut/app/trading/tigerbeetle_journal/transfer_refs.py
@@ -435,6 +435,7 @@ def build_order_event_transfer_plan(
             session,
             account_label=event.alpaca_account_label,
             client_order_id=event.client_order_id,
+            alpaca_order_id=event.alpaca_order_id,
         )
         is not None
     ):

--- a/services/torghut/migrations/versions/0071_infrastructure_validation_lineage.py
+++ b/services/torghut/migrations/versions/0071_infrastructure_validation_lineage.py
@@ -1,0 +1,298 @@
+"""Bind reduction receipts to database-proven validation ancestry.
+
+Revision ID: 0071_validation_lineage
+Revises: 0070_reduction_fencing
+Create Date: 2026-07-15 13:00:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.schema import conv
+
+
+revision = "0071_validation_lineage"
+down_revision = "0070_reduction_fencing"
+branch_labels = None
+depends_on = None
+
+
+_CONSTRAINT = "ck_bm_receipt_validation_lineage"
+_BROKER_REFERENCE_INDEX = "ix_bm_receipt_event_broker_reference"
+_TRIGGER = "trg_guard_bm_validation_lineage_0071"
+_FUNCTION = "torghut_guard_bm_validation_lineage_0071"
+_LINEAGE_CONTRACT = r"""
+(canonical_intent_json::jsonb #>
+  '{request,infrastructure_validation_lineage}') IS NULL
+OR COALESCE((
+  broker_route = 'alpaca'
+  AND submission_claim_id IS NULL
+  AND operation IN ('replace_order', 'cancel_order',
+                    'close_position', 'close_all_positions')
+  AND jsonb_typeof(canonical_intent_json::jsonb #>
+      '{request,infrastructure_validation_lineage}') = 'object'
+  AND (canonical_intent_json::jsonb #>
+      '{request,infrastructure_validation_lineage}') ?& ARRAY[
+        'schema_version', 'root_receipt_id', 'root_client_order_id',
+        'parent_receipt_id', 'parent_broker_order_id', 'permit_id',
+        'permit_sha256', 'evidence_tag', 'promotable'
+      ]
+  AND ((canonical_intent_json::jsonb #>
+      '{request,infrastructure_validation_lineage}') - ARRAY[
+        'schema_version', 'root_receipt_id', 'root_client_order_id',
+        'parent_receipt_id', 'parent_broker_order_id', 'permit_id',
+        'permit_sha256', 'evidence_tag', 'promotable'
+      ]) = '{}'::jsonb
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation_lineage,schema_version}' =
+      'torghut.infrastructure-validation-lineage.v1'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation_lineage,root_receipt_id}' ~
+      '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation_lineage,root_client_order_id}' ~
+      '^ivp-[0-9a-f]{44}$'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation_lineage,parent_receipt_id}' ~
+      '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+  AND length(canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation_lineage,parent_broker_order_id}')
+      BETWEEN 1 AND 256
+  AND length(canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation_lineage,permit_id}') BETWEEN 1 AND 128
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation_lineage,permit_sha256}' ~
+      '^[0-9a-f]{64}$'
+  AND canonical_intent_json::jsonb #>>
+      '{request,infrastructure_validation_lineage,evidence_tag}' =
+      'non_promotable_validation'
+  AND canonical_intent_json::jsonb #>
+      '{request,infrastructure_validation_lineage,promotable}' = 'false'::jsonb
+), FALSE)
+"""
+
+
+def _install_lineage_guard() -> None:
+    op.execute(
+        sa.text(
+            f"""
+            CREATE OR REPLACE FUNCTION {_FUNCTION}()
+            RETURNS trigger LANGUAGE plpgsql AS $$
+            DECLARE
+                lineage jsonb;
+                root broker_mutation_receipts%ROWTYPE;
+                ancestor broker_mutation_receipts%ROWTYPE;
+                root_state text;
+                root_outcome text;
+                root_reference text;
+                root_symbol text;
+                root_plan_schema text;
+                ancestor_state text;
+                ancestor_outcome text;
+                ancestor_reference text;
+            BEGIN
+                lineage := NEW.canonical_intent_json::jsonb #>
+                    '{{request,infrastructure_validation_lineage}}';
+                IF lineage IS NULL THEN
+                    RETURN NEW;
+                END IF;
+
+                SELECT * INTO root
+                  FROM broker_mutation_receipts
+                 WHERE id = (lineage #>> '{{root_receipt_id}}')::uuid
+                   FOR KEY SHARE;
+                IF NOT FOUND THEN
+                    RAISE EXCEPTION
+                        'infrastructure validation lineage root missing'
+                        USING ERRCODE = '23514';
+                END IF;
+                IF root.broker_route IS DISTINCT FROM 'alpaca'
+                   OR root.operation IS DISTINCT FROM 'submit_order'
+                   OR root.risk_class IS DISTINCT FROM 'risk_neutral'
+                   OR root.purpose IS DISTINCT FROM 'control_plane_validation'
+                   OR root.submission_claim_id IS NOT NULL
+                   OR root.account_label IS DISTINCT FROM NEW.account_label
+                   OR root.endpoint_fingerprint IS DISTINCT FROM NEW.endpoint_fingerprint
+                   OR root.client_request_id IS DISTINCT FROM
+                      lineage #>> '{{root_client_order_id}}'
+                   OR root.canonical_intent_json::jsonb #>>
+                      '{{request,infrastructure_validation,permit,permit_id}}'
+                      IS DISTINCT FROM lineage #>> '{{permit_id}}'
+                   OR root.canonical_intent_json::jsonb #>>
+                      '{{request,infrastructure_validation,permit_sha256}}'
+                      IS DISTINCT FROM lineage #>> '{{permit_sha256}}' THEN
+                    RAISE EXCEPTION
+                        'infrastructure validation lineage root mismatch'
+                        USING ERRCODE = '23514';
+                END IF;
+
+                SELECT event.state, event.settlement_outcome,
+                       event.broker_reference
+                  INTO root_state, root_outcome, root_reference
+                  FROM broker_mutation_receipt_events AS event
+                 WHERE event.receipt_id = root.id
+                 ORDER BY event.sequence_no DESC
+                 LIMIT 1;
+                IF NOT FOUND
+                   OR root_state IS DISTINCT FROM 'settled'
+                   OR root_outcome IS NULL
+                   OR root_outcome NOT IN ('acknowledged', 'reconciled')
+                   OR NULLIF(root_reference, '') IS NULL THEN
+                    RAISE EXCEPTION
+                        'infrastructure validation lineage root is not broker-terminal'
+                        USING ERRCODE = '23514';
+                END IF;
+
+                root_symbol := root.canonical_intent_json::jsonb #>>
+                    '{{request,infrastructure_validation,test_plan,symbol}}';
+                root_plan_schema := root.canonical_intent_json::jsonb #>>
+                    '{{request,infrastructure_validation,test_plan,schema_version}}';
+                SELECT * INTO ancestor
+                  FROM broker_mutation_receipts
+                 WHERE id = (lineage #>> '{{parent_receipt_id}}')::uuid
+                   FOR KEY SHARE;
+                IF NOT FOUND THEN
+                    RAISE EXCEPTION
+                        'infrastructure validation lineage parent missing'
+                        USING ERRCODE = '23514';
+                END IF;
+                IF ancestor.account_label IS DISTINCT FROM NEW.account_label
+                   OR ancestor.endpoint_fingerprint IS DISTINCT FROM
+                      NEW.endpoint_fingerprint
+                   OR ancestor.created_at >= NEW.created_at
+                   OR ancestor.operation NOT IN (
+                        'submit_order', 'replace_order',
+                        'close_position', 'close_all_positions'
+                   )
+                   OR (
+                        ancestor.id IS DISTINCT FROM root.id
+                        AND ancestor.canonical_intent_json::jsonb #>>
+                            '{{request,infrastructure_validation_lineage,root_receipt_id}}'
+                            IS DISTINCT FROM root.id::text
+                   ) THEN
+                    RAISE EXCEPTION
+                        'infrastructure validation lineage parent mismatch'
+                        USING ERRCODE = '23514';
+                END IF;
+
+                SELECT event.state, event.settlement_outcome,
+                       event.broker_reference
+                  INTO ancestor_state, ancestor_outcome, ancestor_reference
+                  FROM broker_mutation_receipt_events AS event
+                 WHERE event.receipt_id = ancestor.id
+                 ORDER BY event.sequence_no DESC
+                 LIMIT 1;
+                IF NOT FOUND
+                   OR ancestor_state IS DISTINCT FROM 'settled'
+                   OR ancestor_outcome IS NULL
+                   OR ancestor_outcome NOT IN ('acknowledged', 'reconciled')
+                   OR ancestor_reference IS DISTINCT FROM
+                      lineage #>> '{{parent_broker_order_id}}' THEN
+                    RAISE EXCEPTION
+                        'infrastructure validation lineage parent is not terminal'
+                        USING ERRCODE = '23514';
+                END IF;
+
+                IF (
+                       NEW.operation IN ('close_position', 'close_all_positions')
+                       AND root_plan_schema IS DISTINCT FROM
+                           'torghut.infrastructure-validation-lifecycle-plan.v1'
+                   ) OR (
+                       NEW.operation IN ('replace_order', 'cancel_order')
+                       AND NEW.target_key IS DISTINCT FROM ancestor_reference
+                   ) OR (
+                       NEW.operation = 'close_position'
+                       AND NEW.target_key IS DISTINCT FROM root_symbol
+                   ) OR (
+                       NEW.operation = 'close_all_positions'
+                       AND NEW.canonical_intent_json::jsonb #>
+                           '{{request,symbols}}'
+                           IS DISTINCT FROM jsonb_build_array(root_symbol)
+                   ) THEN
+                    RAISE EXCEPTION
+                        'infrastructure validation lineage target mismatch'
+                        USING ERRCODE = '23514';
+                END IF;
+                RETURN NEW;
+            END;
+            $$
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            f"""
+            CREATE TRIGGER {_TRIGGER}
+            BEFORE INSERT ON broker_mutation_receipts
+            FOR EACH ROW EXECUTE FUNCTION {_FUNCTION}()
+            """
+        )
+    )
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text("LOCK TABLE broker_mutation_receipts IN ACCESS EXCLUSIVE MODE NOWAIT")
+    )
+    op.execute(
+        sa.text(
+            f"""
+            ALTER TABLE broker_mutation_receipts
+              ADD CONSTRAINT {_CONSTRAINT}
+              CHECK ({_LINEAGE_CONTRACT}) NOT VALID
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            f"""
+            ALTER TABLE broker_mutation_receipts
+              VALIDATE CONSTRAINT {_CONSTRAINT}
+            """
+        )
+    )
+    op.create_index(
+        _BROKER_REFERENCE_INDEX,
+        "broker_mutation_receipt_events",
+        ["broker_reference", "receipt_id"],
+        unique=False,
+        postgresql_where=sa.text("state = 'settled' AND broker_reference IS NOT NULL"),
+    )
+    _install_lineage_guard()
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text("LOCK TABLE broker_mutation_receipts IN ACCESS EXCLUSIVE MODE NOWAIT")
+    )
+    op.execute(
+        sa.text(
+            """
+            DO $torghut$
+            BEGIN
+                IF EXISTS (
+                    SELECT 1
+                      FROM broker_mutation_receipts
+                     WHERE canonical_intent_json::jsonb #>
+                           '{request,infrastructure_validation_lineage}' IS NOT NULL
+                ) THEN
+                    RAISE EXCEPTION
+                        'cannot downgrade with validation-lineage receipts';
+                END IF;
+            END
+            $torghut$;
+            """
+        )
+    )
+    op.execute(sa.text(f"DROP TRIGGER {_TRIGGER} ON broker_mutation_receipts"))
+    op.execute(sa.text(f"DROP FUNCTION {_FUNCTION}()"))
+    op.drop_index(
+        _BROKER_REFERENCE_INDEX,
+        table_name="broker_mutation_receipt_events",
+    )
+    op.drop_constraint(
+        conv(_CONSTRAINT),
+        "broker_mutation_receipts",
+        type_="check",
+    )

--- a/services/torghut/tests/execution/test_broker_reduction_coordinator_postgres.py
+++ b/services/torghut/tests/execution/test_broker_reduction_coordinator_postgres.py
@@ -1,25 +1,41 @@
 from __future__ import annotations
 
+import uuid
+from datetime import datetime, timedelta, timezone
+
 import pytest
 from alembic import command
 from alembic.config import Config as AlembicConfig
 from sqlalchemy import select, text
 from sqlalchemy.engine import Engine
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import DBAPIError, IntegrityError
 from sqlalchemy.orm import Session, sessionmaker
 
 from app.config import settings
-from app.models import BrokerMutationReceipt
+from app.models import BrokerMutationReceipt, BrokerMutationReceiptEvent
 from app.trading.broker_mutation_coordinator import (
     BrokerMutationCoordinator,
+    InfrastructureValidationOrderSubmission,
     UnlinkedMutationCallbacks,
 )
 from app.trading.broker_mutation_receipts import (
+    BrokerMutationIntent,
     BrokerMutationIntentRequest,
     BrokerMutationSettlementRequest,
     BrokerMutationTarget,
     build_broker_mutation_intent,
     build_broker_mutation_settlement,
+)
+from app.trading.infrastructure_validation import (
+    InfrastructureValidationOrderPlan,
+    InfrastructureValidationPermit,
+    infrastructure_validation_client_order_id,
+    infrastructure_validation_order_plan_sha256,
+    infrastructure_validation_terminal_state_sha256,
+)
+from app.trading.infrastructure_validation_records import (
+    infrastructure_validation_lineage_payload,
+    load_infrastructure_validation_evidence,
 )
 from tests.execution.decision_submission_claims_postgres_support import (
     POSTGRES_DSN,
@@ -47,7 +63,7 @@ def _upgrade_reduction_schema(
                 """
             )
         )
-    command.upgrade(alembic, "0070_reduction_fencing")
+    command.upgrade(alembic, "0071_validation_lineage")
 
 
 @pytest.mark.skipif(
@@ -144,5 +160,401 @@ def test_postgres_unlinked_replacement_requires_exact_reduction_contract(
             "risk_neutral",
             "repricing",
         )
+        command.downgrade(alembic, "0070_reduction_fencing")
+        with schema_engine.connect() as connection:
+            guard_count = connection.scalar(
+                text(
+                    "SELECT count(*) FROM pg_trigger "
+                    "WHERE tgname = 'trg_guard_bm_validation_lineage_0071'"
+                )
+            )
+        assert guard_count == 0
     finally:
         drop_schema(schema, admin_engine, schema_engine)
+
+
+@pytest.mark.skipif(
+    not POSTGRES_DSN,
+    reason="set TORGHUT_TEST_POSTGRES_DSN for the validation lineage test",
+)
+def test_postgres_validation_descendant_requires_exact_root_parent_and_target(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    schema, admin_engine, schema_engine, schema_dsn = create_schema_engines(
+        "validation_lineage"
+    )
+    sessions = sessionmaker(
+        bind=schema_engine,
+        class_=Session,
+        autoflush=False,
+        expire_on_commit=False,
+        future=True,
+    )
+    try:
+        monkeypatch.setattr(settings, "db_dsn", schema_dsn)
+        alembic = AlembicConfig(str(SERVICE_ROOT / "alembic.ini"))
+        _upgrade_reduction_schema(alembic, schema_engine)
+        client_order_id = _seed_validation_root(sessions)
+        with sessions() as session:
+            evidence = load_infrastructure_validation_evidence(
+                session,
+                account_label="paper",
+                client_order_id=client_order_id,
+            )
+        assert evidence is not None
+        lineage = infrastructure_validation_lineage_payload(evidence)
+        expired_intent = _replacement_intent(
+            lineage=lineage,
+            endpoint_fingerprint=evidence.endpoint_fingerprint,
+            client_request_id="validation-replace-after-permit-expiry",
+            order_id="validation-root-order-1",
+        )
+        with schema_engine.begin() as connection:
+            connection.execute(
+                text(
+                    "ALTER TABLE broker_mutation_receipts ALTER COLUMN created_at "
+                    "SET DEFAULT (clock_timestamp() + interval '10 minutes')"
+                )
+            )
+        try:
+            with sessions() as session:
+                BrokerMutationCoordinator(
+                    "validation-expired-lineage-pg"
+                ).execute_unlinked_mutation(
+                    session,
+                    intent=expired_intent,
+                    callbacks=UnlinkedMutationCallbacks(
+                        broker_call=lambda _permit: {
+                            "id": "validation-expired-replacement-1",
+                            "status": "accepted",
+                        },
+                        persist_terminal=lambda _result: None,
+                        build_settlement=lambda result: (
+                            build_broker_mutation_settlement(
+                                BrokerMutationSettlementRequest(
+                                    source="primary",
+                                    outcome="acknowledged",
+                                    broker_reference=str(result["id"]),
+                                    execution_id=None,
+                                    evidence_payload={"status": result["status"]},
+                                )
+                            )
+                        ),
+                    ),
+                )
+        finally:
+            with schema_engine.begin() as connection:
+                connection.execute(
+                    text(
+                        "ALTER TABLE broker_mutation_receipts "
+                        "ALTER COLUMN created_at SET DEFAULT now()"
+                    )
+                )
+        valid_intent = _replacement_intent(
+            lineage=lineage,
+            endpoint_fingerprint=evidence.endpoint_fingerprint,
+            client_request_id="validation-replace-valid",
+            order_id="validation-root-order-1",
+        )
+        with sessions() as session:
+            BrokerMutationCoordinator(
+                "validation-lineage-pg"
+            ).execute_unlinked_mutation(
+                session,
+                intent=valid_intent,
+                callbacks=UnlinkedMutationCallbacks(
+                    broker_call=lambda _permit: {
+                        "id": "validation-replacement-1",
+                        "status": "accepted",
+                    },
+                    persist_terminal=lambda _result: None,
+                    build_settlement=lambda result: build_broker_mutation_settlement(
+                        BrokerMutationSettlementRequest(
+                            source="primary",
+                            outcome="acknowledged",
+                            broker_reference=str(result["id"]),
+                            execution_id=None,
+                            evidence_payload={"status": result["status"]},
+                        )
+                    ),
+                ),
+            )
+
+        with sessions() as session:
+            descendant = load_infrastructure_validation_evidence(
+                session,
+                account_label="paper",
+                client_order_id=None,
+                alpaca_order_id="validation-replacement-1",
+            )
+        assert descendant is not None
+        assert descendant.root_receipt_id == evidence.root_receipt_id
+        assert descendant.receipt_id != evidence.receipt_id
+        assert descendant.broker_order_id == "validation-replacement-1"
+        cancel_intent = _cancel_intent(
+            lineage=infrastructure_validation_lineage_payload(descendant),
+            endpoint_fingerprint=evidence.endpoint_fingerprint,
+            client_request_id="validation-cancel-valid",
+            order_id="validation-replacement-1",
+        )
+        with sessions() as session:
+            BrokerMutationCoordinator("validation-cancel-pg").execute_unlinked_mutation(
+                session,
+                intent=cancel_intent,
+                callbacks=UnlinkedMutationCallbacks(
+                    broker_call=lambda _permit: True,
+                    persist_terminal=lambda _result: None,
+                    build_settlement=lambda _result: build_broker_mutation_settlement(
+                        BrokerMutationSettlementRequest(
+                            source="primary",
+                            outcome="acknowledged",
+                            broker_reference="validation-cancel-valid",
+                            execution_id=None,
+                            evidence_payload={"canceled": True},
+                        )
+                    ),
+                ),
+            )
+        with sessions() as session:
+            cancel_receipt = session.execute(
+                select(BrokerMutationReceipt).where(
+                    BrokerMutationReceipt.client_request_id == "validation-cancel-valid"
+                )
+            ).scalar_one()
+            cancel_terminal = session.execute(
+                select(BrokerMutationReceiptEvent)
+                .where(BrokerMutationReceiptEvent.receipt_id == cancel_receipt.id)
+                .order_by(BrokerMutationReceiptEvent.sequence_no.desc())
+                .limit(1)
+            ).scalar_one()
+        cancel_reference = str(cancel_terminal.broker_reference or "")
+        assert cancel_reference
+        cancel_parent_lineage = {
+            **infrastructure_validation_lineage_payload(descendant),
+            "parent_receipt_id": str(cancel_receipt.id),
+            "parent_broker_order_id": cancel_reference,
+        }
+
+        forged_cases = (
+            (
+                "missing-root",
+                {**lineage, "root_receipt_id": str(uuid.uuid4())},
+                "validation-root-order-1",
+            ),
+            (
+                "wrong-parent-reference",
+                {**lineage, "parent_broker_order_id": "other-order"},
+                "validation-root-order-1",
+            ),
+            ("cancel-parent", cancel_parent_lineage, cancel_reference),
+            ("wrong-target", lineage, "other-order"),
+            ("extra-key", {**lineage, "forged": True}, "validation-root-order-1"),
+        )
+        for name, forged_lineage, order_id in forged_cases:
+            intent = _replacement_intent(
+                lineage=forged_lineage,
+                endpoint_fingerprint=evidence.endpoint_fingerprint,
+                client_request_id=f"validation-replace-{name}",
+                order_id=order_id,
+            )
+            with sessions() as session:
+                session.add(_receipt_from_intent(intent))
+                with pytest.raises(IntegrityError):
+                    session.commit()
+        with sessions() as session:
+            session.add(
+                _receipt_from_intent(
+                    _close_intent(
+                        lineage=lineage,
+                        endpoint_fingerprint=evidence.endpoint_fingerprint,
+                    )
+                )
+            )
+            with pytest.raises(IntegrityError):
+                session.commit()
+        with pytest.raises(
+            DBAPIError,
+            match="cannot downgrade with validation-lineage receipts",
+        ):
+            command.downgrade(alembic, "0070_reduction_fencing")
+    finally:
+        drop_schema(schema, admin_engine, schema_engine)
+
+
+def _seed_validation_root(sessions: sessionmaker[Session]) -> str:
+    now = datetime.now(timezone.utc)
+    plan = InfrastructureValidationOrderPlan.model_validate(
+        {
+            "schema_version": "torghut.infrastructure-validation-order-plan.v1",
+            "venue": "alpaca",
+            "asset_class": "crypto",
+            "symbol": "BTC/USD",
+            "side": "buy",
+            "qty": "1",
+            "order_type": "limit",
+            "time_in_force": "ioc",
+            "limit_price": "1",
+            "stop_price": None,
+        }
+    )
+    permit = InfrastructureValidationPermit.model_validate(
+        {
+            "schema_version": "torghut.infrastructure-validation-permit.v2",
+            "permit_id": "ivp-postgres-lineage",
+            "purpose": "control_plane_validation",
+            "venue": "alpaca",
+            "asset_class": "crypto",
+            "account_mode": "paper",
+            "market_session": "continuous",
+            "account_label": "paper",
+            "broker_base_url": "https://paper-api.alpaca.markets",
+            "symbols": ["BTC/USD"],
+            "sides": ["buy"],
+            "order_types": ["limit"],
+            "max_orders": 1,
+            "max_outstanding_intents": 1,
+            "max_notional_usd": "1",
+            "max_loss_usd": "1",
+            "issued_by": "infrastructure-owner",
+            "approved_by": "independent-infrastructure-owner",
+            "issued_at": now - timedelta(seconds=1),
+            "expires_at": now + timedelta(minutes=5),
+            "test_plan_digest": infrastructure_validation_order_plan_sha256(plan),
+            "expected_terminal_state": "no_open_orders_no_positions_no_unsettled_claims",
+            "expected_terminal_state_digest": infrastructure_validation_terminal_state_sha256(),
+            "evidence_tag": "non_promotable_validation",
+            "promotable": False,
+        }
+    )
+    with sessions() as session:
+        BrokerMutationCoordinator(
+            "validation-root-pg"
+        ).submit_infrastructure_validation_order(
+            session,
+            request=InfrastructureValidationOrderSubmission(
+                permit=permit,
+                plan=plan,
+                account_label="paper",
+                endpoint_url="https://paper-api.alpaca.markets",
+            ),
+            callbacks=UnlinkedMutationCallbacks(
+                broker_call=lambda _permit: {
+                    "id": "validation-root-order-1",
+                    "status": "accepted",
+                },
+                persist_terminal=lambda _result: None,
+                build_settlement=lambda result: build_broker_mutation_settlement(
+                    BrokerMutationSettlementRequest(
+                        source="primary",
+                        outcome="reconciled",
+                        broker_reference=str(result["id"]),
+                        execution_id=None,
+                        evidence_payload={"status": result["status"]},
+                    )
+                ),
+            ),
+            now=now,
+        )
+    return infrastructure_validation_client_order_id(permit, plan)
+
+
+def _replacement_intent(
+    *,
+    lineage: dict[str, object],
+    endpoint_fingerprint: str,
+    client_request_id: str,
+    order_id: str,
+) -> BrokerMutationIntent:
+    return build_broker_mutation_intent(
+        BrokerMutationIntentRequest(
+            broker_route="alpaca",
+            account_label="paper",
+            endpoint_fingerprint=endpoint_fingerprint,
+            operation="replace_order",
+            risk_class="risk_neutral",
+            purpose="repricing",
+            workflow_id=client_request_id,
+            client_request_id=client_request_id,
+            target=BrokerMutationTarget(kind="order", key=order_id),
+            request_payload={
+                "schema_version": "torghut.alpaca-reduction-request.v1",
+                "order_id": order_id,
+                "limit_price": "0.9",
+                "infrastructure_validation_lineage": lineage,
+            },
+        )
+    )
+
+
+def _cancel_intent(
+    *,
+    lineage: dict[str, object],
+    endpoint_fingerprint: str,
+    client_request_id: str,
+    order_id: str,
+) -> BrokerMutationIntent:
+    return build_broker_mutation_intent(
+        BrokerMutationIntentRequest(
+            broker_route="alpaca",
+            account_label="paper",
+            endpoint_fingerprint=endpoint_fingerprint,
+            operation="cancel_order",
+            risk_class="risk_neutral",
+            purpose="operator",
+            workflow_id=client_request_id,
+            client_request_id=client_request_id,
+            target=BrokerMutationTarget(kind="order", key=order_id),
+            request_payload={
+                "schema_version": "torghut.alpaca-reduction-request.v1",
+                "order_id": order_id,
+                "infrastructure_validation_lineage": lineage,
+            },
+        )
+    )
+
+
+def _close_intent(
+    *,
+    lineage: dict[str, object],
+    endpoint_fingerprint: str,
+) -> BrokerMutationIntent:
+    return build_broker_mutation_intent(
+        BrokerMutationIntentRequest(
+            broker_route="alpaca",
+            account_label="paper",
+            endpoint_fingerprint=endpoint_fingerprint,
+            operation="close_position",
+            risk_class="risk_reducing",
+            purpose="closeout",
+            workflow_id="validation-close-forged",
+            client_request_id="validation-close-forged",
+            target=BrokerMutationTarget(kind="position", key="BTC/USD"),
+            request_payload={
+                "schema_version": "torghut.alpaca-reduction-request.v1",
+                "symbol": "BTC/USD",
+                "quantity": "1",
+                "infrastructure_validation_lineage": lineage,
+            },
+        )
+    )
+
+
+def _receipt_from_intent(intent: BrokerMutationIntent) -> BrokerMutationReceipt:
+    return BrokerMutationReceipt(
+        broker_route=intent.broker_route,
+        account_label=intent.account_label,
+        endpoint_fingerprint=intent.endpoint_fingerprint,
+        operation=intent.operation,
+        risk_class=intent.risk_class,
+        purpose=intent.purpose,
+        submission_claim_id=intent.submission_claim_id,
+        workflow_id=intent.workflow_id,
+        client_request_id=intent.client_request_id,
+        target_kind=intent.target.kind,
+        target_key=intent.target.key,
+        intent_schema_version=intent.intent_schema_version,
+        canonical_intent_json=intent.canonical_intent_json,
+        canonical_intent_sha256=intent.canonical_intent_sha256,
+        creator_owner="validation-lineage-forgery-test",
+        origin_writer_generation=1,
+    )

--- a/services/torghut/tests/order_feed/test_infrastructure_validation_exclusion.py
+++ b/services/torghut/tests/order_feed/test_infrastructure_validation_exclusion.py
@@ -3,23 +3,30 @@ from __future__ import annotations
 import json
 import uuid
 
-from app.models import BrokerMutationReceipt, SimulationRunProgress
+from app.models import ExecutionOrderEvent, SimulationRunProgress
+from app.trading.broker_mutation_coordinator import (
+    BrokerMutationCoordinator,
+    InfrastructureValidationOrderSubmission,
+    UnlinkedMutationCallbacks,
+)
 from app.trading.broker_mutation_receipts import (
     BrokerMutationIntentRequest,
+    BrokerMutationSettlementRequest,
     BrokerMutationTarget,
     build_broker_mutation_intent,
-    fingerprint_broker_endpoint,
+    build_broker_mutation_settlement,
 )
 from app.trading.infrastructure_validation import (
     InfrastructureValidationOrderPlan,
     InfrastructureValidationPermit,
     infrastructure_validation_client_order_id,
     infrastructure_validation_order_plan_sha256,
-    infrastructure_validation_request_payload,
     infrastructure_validation_terminal_state_sha256,
 )
 from app.trading.infrastructure_validation_records import (
+    infrastructure_validation_lineage_payload,
     is_non_promotable_validation_event,
+    load_infrastructure_validation_evidence,
     strip_unproven_infrastructure_validation_evidence,
 )
 
@@ -187,25 +194,6 @@ class TestInfrastructureValidationExclusion(OrderFeedTestCase):
             }
         )
         client_order_id = infrastructure_validation_client_order_id(permit, plan)
-        intent = build_broker_mutation_intent(
-            BrokerMutationIntentRequest(
-                broker_route="alpaca",
-                account_label="paper",
-                endpoint_fingerprint=fingerprint_broker_endpoint(
-                    "https://paper-api.alpaca.markets"
-                ),
-                operation="submit_order",
-                risk_class="risk_neutral",
-                purpose="control_plane_validation",
-                workflow_id=client_order_id,
-                client_request_id=client_order_id,
-                target=BrokerMutationTarget(kind="order", key=client_order_id),
-                request_payload=infrastructure_validation_request_payload(
-                    permit,
-                    plan,
-                ),
-            )
-        )
         payload = (
             '{"channel":"trade_updates","payload":{"event":"fill",'
             '"timestamp":"2026-07-14T10:00:00Z","order":{'
@@ -215,29 +203,14 @@ class TestInfrastructureValidationExclusion(OrderFeedTestCase):
         ).encode()
         settings.tigerbeetle_enabled = True
         settings.tigerbeetle_journal_enabled = True
+        normalized = normalize_order_feed_record(
+            FakeRecord(value=payload, offset=91),
+            default_topic="torghut.trade-updates.v1",
+            default_account_label="paper",
+        )
+        assert normalized.event is not None
 
         with Session(self.engine) as session:
-            session.add(
-                BrokerMutationReceipt(
-                    id=uuid.uuid4(),
-                    broker_route=intent.broker_route,
-                    account_label=intent.account_label,
-                    endpoint_fingerprint=intent.endpoint_fingerprint,
-                    operation=intent.operation,
-                    risk_class=intent.risk_class,
-                    purpose=intent.purpose,
-                    submission_claim_id=None,
-                    workflow_id=intent.workflow_id,
-                    client_request_id=intent.client_request_id,
-                    target_kind=intent.target.kind,
-                    target_key=intent.target.key,
-                    intent_schema_version=intent.intent_schema_version,
-                    canonical_intent_json=intent.canonical_intent_json,
-                    canonical_intent_sha256=intent.canonical_intent_sha256,
-                    creator_owner="validation-test",
-                    origin_writer_generation=1,
-                )
-            )
             execution = self._seed_execution(
                 session,
                 account_label="paper",
@@ -245,17 +218,65 @@ class TestInfrastructureValidationExclusion(OrderFeedTestCase):
                 client_order_id=client_order_id,
             )
             session.flush()
-            normalized = normalize_order_feed_record(
-                FakeRecord(value=payload, offset=91),
-                default_topic="torghut.trade-updates.v1",
-                default_account_label="paper",
-            )
-            assert normalized.event is not None
+            persisted_during_broker_io: tuple[ExecutionOrderEvent, bool] | None = None
+
+            def broker_call(_permit: object) -> dict[str, str]:
+                nonlocal persisted_during_broker_io
+                persisted_during_broker_io = persist_order_event(
+                    session,
+                    normalized.event,
+                )
+                race_evidence = load_infrastructure_validation_evidence(
+                    session,
+                    account_label="paper",
+                    client_order_id=client_order_id,
+                    alpaca_order_id="validation-order-1",
+                )
+                assert race_evidence is not None
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "infrastructure_validation_lineage_parent_not_terminal",
+                ):
+                    infrastructure_validation_lineage_payload(race_evidence)
+                return {"id": "validation-order-1", "status": "accepted"}
+
             with patch(
                 "app.trading.tigerbeetle_journal.ledger_journal.create_tigerbeetle_client",
                 return_value=FakeTigerBeetleClient(),
             ):
-                persisted, duplicate = persist_order_event(session, normalized.event)
+                BrokerMutationCoordinator(
+                    "validation-order-feed-test"
+                ).submit_infrastructure_validation_order(
+                    session,
+                    request=InfrastructureValidationOrderSubmission(
+                        permit=permit,
+                        plan=plan,
+                        account_label="paper",
+                        endpoint_url="https://paper-api.alpaca.markets",
+                    ),
+                    callbacks=UnlinkedMutationCallbacks(
+                        broker_call=broker_call,
+                        persist_terminal=lambda _result: None,
+                        build_settlement=lambda result: (
+                            build_broker_mutation_settlement(
+                                BrokerMutationSettlementRequest(
+                                    source="primary",
+                                    outcome="acknowledged",
+                                    broker_reference=str(result["id"]),
+                                    execution_id=None,
+                                    evidence_payload={
+                                        "evidence_tag": "non_promotable_validation",
+                                        "promotable": False,
+                                        "status": result["status"],
+                                    },
+                                )
+                            )
+                        ),
+                    ),
+                    now=now,
+                )
+            assert persisted_during_broker_io is not None
+            persisted, duplicate = persisted_during_broker_io
             session.commit()
 
             self.assertFalse(duplicate)
@@ -268,6 +289,89 @@ class TestInfrastructureValidationExclusion(OrderFeedTestCase):
             session.refresh(persisted)
             self.assertIsNone(persisted.execution_id)
             self.assertIsNone(persisted.trade_decision_id)
+            self.assertEqual(
+                session.execute(select(TigerBeetleTransferRef)).scalars().all(),
+                [],
+            )
+
+            evidence = load_infrastructure_validation_evidence(
+                session,
+                account_label="paper",
+                client_order_id=client_order_id,
+            )
+            assert evidence is not None
+            replacement_intent = build_broker_mutation_intent(
+                BrokerMutationIntentRequest(
+                    broker_route="alpaca",
+                    account_label="paper",
+                    endpoint_fingerprint=evidence.endpoint_fingerprint,
+                    operation="replace_order",
+                    risk_class="risk_neutral",
+                    purpose="repricing",
+                    workflow_id="validation-replace-1",
+                    client_request_id="validation-replace-1",
+                    target=BrokerMutationTarget(
+                        kind="order",
+                        key="validation-order-1",
+                    ),
+                    request_payload={
+                        "schema_version": "torghut.alpaca-reduction-request.v1",
+                        "order_id": "validation-order-1",
+                        "limit_price": "0.9",
+                        "infrastructure_validation_lineage": (
+                            infrastructure_validation_lineage_payload(evidence)
+                        ),
+                    },
+                )
+            )
+            BrokerMutationCoordinator(
+                "validation-descendant-test"
+            ).execute_unlinked_mutation(
+                session,
+                intent=replacement_intent,
+                callbacks=UnlinkedMutationCallbacks(
+                    broker_call=lambda _permit: {
+                        "id": "validation-replacement-1",
+                        "status": "accepted",
+                    },
+                    persist_terminal=lambda _result: None,
+                    build_settlement=lambda result: build_broker_mutation_settlement(
+                        BrokerMutationSettlementRequest(
+                            source="primary",
+                            outcome="acknowledged",
+                            broker_reference=str(result["id"]),
+                            execution_id=None,
+                            evidence_payload={"status": result["status"]},
+                        )
+                    ),
+                ),
+            )
+            descendant_payload = (
+                '{"channel":"trade_updates","payload":{"event":"fill",'
+                '"timestamp":"2026-07-14T10:01:00Z","order":{'
+                '"id":"validation-replacement-1",'
+                '"client_order_id":"broker-replacement-client",'
+                '"symbol":"BTC/USD","status":"filled","qty":"1",'
+                '"filled_qty":"1","filled_avg_price":"1"}},"seq":11}'
+            ).encode()
+            descendant = normalize_order_feed_record(
+                FakeRecord(value=descendant_payload, offset=92),
+                default_topic="torghut.trade-updates.v1",
+                default_account_label="paper",
+            )
+            assert descendant.event is not None
+            descendant_event, descendant_duplicate = persist_order_event(
+                session,
+                descendant.event,
+            )
+            session.commit()
+
+            self.assertFalse(descendant_duplicate)
+            self.assertIsNone(descendant_event.execution_id)
+            self.assertIsNone(descendant_event.trade_decision_id)
+            self.assertTrue(
+                is_non_promotable_validation_event(descendant_event.raw_event)
+            )
             self.assertEqual(
                 session.execute(select(TigerBeetleTransferRef)).scalars().all(),
                 [],

--- a/services/torghut/tests/test_alpaca_reduction_coordinator.py
+++ b/services/torghut/tests/test_alpaca_reduction_coordinator.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import json
 from collections.abc import Iterator
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from typing import cast
 from unittest.mock import patch
@@ -13,14 +15,33 @@ from app.alpaca_client import TorghutAlpacaClient
 from app.config import settings
 from app.models import Base, BrokerMutationReceipt, BrokerMutationReceiptEvent
 from app.trading.broker_mutation_coordinator import (
+    BrokerMutationCoordinator,
     BrokerMutationDeferred,
     BrokerMutationUnresolved,
+    InfrastructureValidationOrderSubmission,
+    UnlinkedMutationCallbacks,
 )
 from app.trading.broker_mutation_receipts import (
+    BrokerMutationIntentRequest,
+    BrokerMutationSettlementRequest,
     BrokerMutationReceiptValidationError,
+    BrokerMutationTarget,
+    build_broker_mutation_intent,
+    build_broker_mutation_settlement,
 )
+from app.trading.alpaca_reduction_mutations import AlpacaReductionMutationExecutor
 from app.trading.execution_adapters import AlpacaExecutionAdapter, OrderSubmission
 from app.trading.firewall import OrderFirewall
+from app.trading.infrastructure_validation import (
+    InfrastructureValidationOrderPlan,
+    InfrastructureValidationPermit,
+    infrastructure_validation_client_order_id,
+    infrastructure_validation_order_plan_sha256,
+    infrastructure_validation_terminal_state_sha256,
+)
+from app.trading.infrastructure_validation_records import (
+    load_infrastructure_validation_evidence,
+)
 
 
 class _CloseoutBroker:
@@ -100,16 +121,26 @@ class _UnchangedCloseBroker:
 class _ReplaceBroker:
     endpoint_url = "https://paper-api.alpaca.markets"
 
-    def __init__(self, *, side: str = "buy") -> None:
+    def __init__(
+        self,
+        *,
+        side: str = "buy",
+        symbol: str = "AAPL",
+        client_order_id: str = "client-order-1",
+        order_id: str = "order-1",
+    ) -> None:
         self.side = side
+        self.symbol = symbol
+        self.client_order_id = client_order_id
+        self.order_id = order_id
         self.replace_calls: list[tuple[str, float]] = []
         self.positions: list[dict[str, object]] = []
 
     def get_order_by_id_strict(self, order_id: str) -> dict[str, object]:
         return {
             "id": order_id,
-            "client_order_id": "client-order-1",
-            "symbol": "AAPL",
+            "client_order_id": self.client_order_id,
+            "symbol": self.symbol,
             "side": self.side,
             "qty": "10",
             "filled_qty": "4",
@@ -131,6 +162,70 @@ class _ReplaceBroker:
         return {"id": "replacement-1", "status": "accepted"}
 
 
+class _ReferenceLessReplaceBroker(_ReplaceBroker):
+    def replace_order(
+        self,
+        order_id: str,
+        *,
+        limit_price: float,
+        **_kwargs: object,
+    ) -> dict[str, object]:
+        self.replace_calls.append((order_id, limit_price))
+        return {"status": "accepted"}
+
+
+class _CancelBroker:
+    endpoint_url = "https://paper-api.alpaca.markets"
+
+    def __init__(self, *, client_order_id: str, order_id: str) -> None:
+        self.client_order_id = client_order_id
+        self.order_id = order_id
+        self.cancel_calls: list[str] = []
+
+    def get_order_by_id_strict(self, order_id: str) -> dict[str, object]:
+        return {
+            "id": order_id,
+            "client_order_id": self.client_order_id,
+            "symbol": "BTC/USD",
+            "side": "buy",
+            "qty": "1",
+            "filled_qty": "0",
+            "status": "new",
+            "limit_price": "1",
+        }
+
+    def cancel_order(self, order_id: str, **_kwargs: object) -> bool:
+        self.cancel_calls.append(order_id)
+        return True
+
+
+class _CancelAllBroker:
+    endpoint_url = "https://paper-api.alpaca.markets"
+
+    def __init__(
+        self,
+        orders: list[dict[str, object]],
+        *,
+        responses: list[dict[str, object]] | None = None,
+    ) -> None:
+        self.orders = orders
+        self.responses = list(responses or [])
+        self.cancel_all_calls = 0
+
+    def list_orders(
+        self,
+        status: str = "all",
+        *,
+        limit: int | None = None,
+    ) -> list[dict[str, object]]:
+        del status, limit
+        return list(self.orders)
+
+    def cancel_all_orders(self, **_kwargs: object) -> list[dict[str, object]]:
+        self.cancel_all_calls += 1
+        return list(self.responses)
+
+
 @pytest.fixture
 def sessions() -> Iterator[sessionmaker[Session]]:
     engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
@@ -146,6 +241,99 @@ def sessions() -> Iterator[sessionmaker[Session]]:
         yield factory
     finally:
         engine.dispose()
+
+
+def _seed_validation_root(
+    sessions: sessionmaker[Session],
+    *,
+    broker_order_id: str = "validation-order-1",
+    settlement_outcome: str = "acknowledged",
+) -> tuple[str, BrokerMutationReceipt]:
+    now = datetime.now(timezone.utc)
+    plan = InfrastructureValidationOrderPlan.model_validate(
+        {
+            "schema_version": "torghut.infrastructure-validation-order-plan.v1",
+            "venue": "alpaca",
+            "asset_class": "crypto",
+            "symbol": "BTC/USD",
+            "side": "buy",
+            "qty": "1",
+            "order_type": "limit",
+            "time_in_force": "ioc",
+            "limit_price": "1",
+            "stop_price": None,
+        }
+    )
+    permit = InfrastructureValidationPermit.model_validate(
+        {
+            "schema_version": "torghut.infrastructure-validation-permit.v2",
+            "permit_id": f"ivp-lineage-{broker_order_id}",
+            "purpose": "control_plane_validation",
+            "venue": "alpaca",
+            "asset_class": "crypto",
+            "account_mode": "paper",
+            "market_session": "continuous",
+            "account_label": "paper",
+            "broker_base_url": "https://paper-api.alpaca.markets",
+            "symbols": ["BTC/USD"],
+            "sides": ["buy"],
+            "order_types": ["limit"],
+            "max_orders": 1,
+            "max_outstanding_intents": 1,
+            "max_notional_usd": "1",
+            "max_loss_usd": "1",
+            "issued_by": "infrastructure-owner",
+            "approved_by": "independent-infrastructure-owner",
+            "issued_at": now - timedelta(seconds=1),
+            "expires_at": now + timedelta(minutes=5),
+            "test_plan_digest": infrastructure_validation_order_plan_sha256(plan),
+            "expected_terminal_state": "no_open_orders_no_positions_no_unsettled_claims",
+            "expected_terminal_state_digest": infrastructure_validation_terminal_state_sha256(),
+            "evidence_tag": "non_promotable_validation",
+            "promotable": False,
+        }
+    )
+    client_order_id = infrastructure_validation_client_order_id(permit, plan)
+    with sessions() as session:
+        BrokerMutationCoordinator(
+            "validation-lineage-test"
+        ).submit_infrastructure_validation_order(
+            session,
+            request=InfrastructureValidationOrderSubmission(
+                permit=permit,
+                plan=plan,
+                account_label="paper",
+                endpoint_url="https://paper-api.alpaca.markets",
+            ),
+            callbacks=UnlinkedMutationCallbacks(
+                broker_call=lambda _permit: {
+                    "id": broker_order_id,
+                    "status": "accepted",
+                },
+                persist_terminal=lambda _result: None,
+                build_settlement=lambda result: build_broker_mutation_settlement(
+                    BrokerMutationSettlementRequest(
+                        source="primary",
+                        outcome=settlement_outcome,
+                        broker_reference=str(result["id"]),
+                        execution_id=None,
+                        evidence_payload={
+                            "evidence_tag": "non_promotable_validation",
+                            "promotable": False,
+                            "status": result["status"],
+                        },
+                    )
+                ),
+            ),
+            now=now,
+        )
+        root = session.execute(
+            select(BrokerMutationReceipt).where(
+                BrokerMutationReceipt.client_request_id == client_order_id
+            )
+        ).scalar_one()
+        session.expunge(root)
+    return client_order_id, root
 
 
 def test_broker_enforced_close_is_receipted_and_preflight_deduplicated(
@@ -260,6 +448,378 @@ def test_repricing_uses_complete_observation_and_exact_broker_request(
     assert receipt.purpose == "repricing"
     assert latest.state == "settled"
     assert latest.settlement_outcome == "acknowledged"
+    with sessions() as session:
+        assert (
+            load_infrastructure_validation_evidence(
+                session,
+                account_label="paper",
+                client_order_id="client-order-1",
+                alpaca_order_id="replacement-1",
+            )
+            is None
+        )
+
+
+def test_repricing_without_a_broker_order_reference_remains_unresolved(
+    sessions: sessionmaker[Session],
+) -> None:
+    broker = _ReferenceLessReplaceBroker()
+    adapter = AlpacaExecutionAdapter(
+        firewall=OrderFirewall(broker, account_label="paper"),
+        read_client=cast(TorghutAlpacaClient, broker),
+        session_factory=sessions,
+        account_label="paper",
+        endpoint_url=broker.endpoint_url,
+    )
+
+    with pytest.raises(BrokerMutationUnresolved, match="terminal_unresolved"):
+        adapter.replace_order("order-1", limit_price=Decimal("190.25"))
+
+    assert broker.replace_calls == [("order-1", 190.25)]
+    with sessions() as session:
+        latest = session.execute(
+            select(BrokerMutationReceiptEvent)
+            .order_by(BrokerMutationReceiptEvent.sequence_no.desc())
+            .limit(1)
+        ).scalar_one()
+    assert latest.state == "broker_io"
+    assert latest.settlement_outcome is None
+
+
+def test_validation_replacement_seals_database_proven_parent_lineage(
+    sessions: sessionmaker[Session],
+) -> None:
+    client_order_id, root = _seed_validation_root(sessions)
+    broker = _ReplaceBroker(
+        symbol="BTC/USD",
+        client_order_id=client_order_id,
+        order_id="validation-order-1",
+    )
+    adapter = AlpacaExecutionAdapter(
+        firewall=OrderFirewall(broker, account_label="paper"),
+        read_client=cast(TorghutAlpacaClient, broker),
+        session_factory=sessions,
+        account_label="paper",
+        endpoint_url=broker.endpoint_url,
+    )
+
+    result = adapter.replace_order(
+        "validation-order-1",
+        limit_price=Decimal("0.9"),
+    )
+
+    assert result == {"id": "replacement-1", "status": "accepted"}
+    with sessions() as session:
+        receipt = session.execute(
+            select(BrokerMutationReceipt).where(
+                BrokerMutationReceipt.operation == "replace_order"
+            )
+        ).scalar_one()
+    lineage = json.loads(receipt.canonical_intent_json)["request"][
+        "infrastructure_validation_lineage"
+    ]
+    assert lineage == {
+        "schema_version": "torghut.infrastructure-validation-lineage.v1",
+        "root_receipt_id": str(root.id),
+        "root_client_order_id": client_order_id,
+        "parent_receipt_id": str(root.id),
+        "parent_broker_order_id": "validation-order-1",
+        "permit_id": "ivp-lineage-validation-order-1",
+        "permit_sha256": lineage["permit_sha256"],
+        "evidence_tag": "non_promotable_validation",
+        "promotable": False,
+    }
+    assert len(lineage["permit_sha256"]) == 64
+
+    replacement_cancel = _CancelBroker(
+        client_order_id="broker-replacement-client",
+        order_id="replacement-1",
+    )
+    replacement_adapter = AlpacaExecutionAdapter(
+        firewall=OrderFirewall(replacement_cancel, account_label="paper"),
+        read_client=cast(TorghutAlpacaClient, replacement_cancel),
+        session_factory=sessions,
+        account_label="paper",
+        endpoint_url=replacement_cancel.endpoint_url,
+    )
+    assert replacement_adapter.cancel_order("replacement-1") is True
+    with sessions() as session:
+        cancel_receipt = session.execute(
+            select(BrokerMutationReceipt).where(
+                BrokerMutationReceipt.operation == "cancel_order"
+            )
+        ).scalar_one()
+        cancel_terminal = session.execute(
+            select(BrokerMutationReceiptEvent)
+            .where(BrokerMutationReceiptEvent.receipt_id == cancel_receipt.id)
+            .order_by(BrokerMutationReceiptEvent.sequence_no.desc())
+            .limit(1)
+        ).scalar_one()
+    cancel_lineage = json.loads(cancel_receipt.canonical_intent_json)["request"][
+        "infrastructure_validation_lineage"
+    ]
+    assert cancel_lineage["root_receipt_id"] == str(root.id)
+    assert cancel_lineage["parent_receipt_id"] == str(receipt.id)
+    assert cancel_lineage["parent_broker_order_id"] == "replacement-1"
+    with sessions() as session:
+        order_evidence = load_infrastructure_validation_evidence(
+            session,
+            account_label="paper",
+            client_order_id="broker-replacement-client",
+            alpaca_order_id="replacement-1",
+        )
+    assert order_evidence is not None
+    assert order_evidence.receipt_id == receipt.id
+
+    cancel_reference = str(cancel_terminal.broker_reference or "")
+    assert cancel_reference
+    forged_lineage = {
+        **cancel_lineage,
+        "parent_receipt_id": str(cancel_receipt.id),
+        "parent_broker_order_id": cancel_reference,
+    }
+    forged_intent = build_broker_mutation_intent(
+        BrokerMutationIntentRequest(
+            broker_route="alpaca",
+            account_label="paper",
+            endpoint_fingerprint=receipt.endpoint_fingerprint,
+            operation="replace_order",
+            risk_class="risk_neutral",
+            purpose="repricing",
+            workflow_id="forged-cancel-parent",
+            client_request_id="forged-cancel-parent",
+            target=BrokerMutationTarget(kind="order", key=cancel_reference),
+            request_payload={
+                "schema_version": "torghut.alpaca-reduction-request.v1",
+                "order_id": cancel_reference,
+                "limit_price": "0.8",
+                "infrastructure_validation_lineage": forged_lineage,
+            },
+        )
+    )
+    with sessions() as session:
+        BrokerMutationCoordinator("forged-cancel-parent").execute_unlinked_mutation(
+            session,
+            intent=forged_intent,
+            callbacks=UnlinkedMutationCallbacks(
+                broker_call=lambda _permit: {
+                    "id": "forged-descendant-order",
+                    "status": "accepted",
+                },
+                persist_terminal=lambda _result: None,
+                build_settlement=lambda result: build_broker_mutation_settlement(
+                    BrokerMutationSettlementRequest(
+                        source="primary",
+                        outcome="acknowledged",
+                        broker_reference=str(result["id"]),
+                        execution_id=None,
+                        evidence_payload={"status": result["status"]},
+                    )
+                ),
+            ),
+        )
+    with sessions() as session:
+        with pytest.raises(
+            RuntimeError,
+            match="infrastructure_validation_lineage_parent_mismatch",
+        ):
+            load_infrastructure_validation_evidence(
+                session,
+                account_label="paper",
+                client_order_id=None,
+                alpaca_order_id="forged-descendant-order",
+            )
+
+
+@pytest.mark.parametrize("root_outcome", ("acknowledged", "reconciled"))
+def test_validation_cancel_seals_the_same_proven_parent(
+    sessions: sessionmaker[Session],
+    root_outcome: str,
+) -> None:
+    client_order_id, root = _seed_validation_root(
+        sessions,
+        settlement_outcome=root_outcome,
+    )
+    broker = _CancelBroker(
+        client_order_id=client_order_id,
+        order_id="validation-order-1",
+    )
+    adapter = AlpacaExecutionAdapter(
+        firewall=OrderFirewall(broker, account_label="paper"),
+        read_client=cast(TorghutAlpacaClient, broker),
+        session_factory=sessions,
+        account_label="paper",
+        endpoint_url=broker.endpoint_url,
+    )
+
+    assert adapter.cancel_order("validation-order-1") is True
+    assert broker.cancel_calls == ["validation-order-1"]
+    with sessions() as session:
+        receipt = session.execute(
+            select(BrokerMutationReceipt).where(
+                BrokerMutationReceipt.operation == "cancel_order"
+            )
+        ).scalar_one()
+    lineage = json.loads(receipt.canonical_intent_json)["request"][
+        "infrastructure_validation_lineage"
+    ]
+    assert lineage["root_receipt_id"] == str(root.id)
+    assert lineage["parent_receipt_id"] == str(root.id)
+    assert lineage["parent_broker_order_id"] == "validation-order-1"
+    assert lineage["promotable"] is False
+
+
+def test_validation_identity_without_a_terminal_root_fails_before_broker_io(
+    sessions: sessionmaker[Session],
+) -> None:
+    broker = _ReplaceBroker(
+        symbol="BTC/USD",
+        client_order_id="ivp-" + "a" * 44,
+        order_id="validation-order-1",
+    )
+    adapter = AlpacaExecutionAdapter(
+        firewall=OrderFirewall(broker, account_label="paper"),
+        read_client=cast(TorghutAlpacaClient, broker),
+        session_factory=sessions,
+        account_label="paper",
+        endpoint_url=broker.endpoint_url,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="infrastructure_validation_order_lineage_missing",
+    ):
+        adapter.replace_order("validation-order-1", limit_price=Decimal("0.9"))
+
+    assert broker.replace_calls == []
+    with sessions() as session:
+        assert (
+            session.execute(select(BrokerMutationReceipt)).scalar_one_or_none() is None
+        )
+
+
+def test_validation_evidence_cannot_cross_an_endpoint_scope(
+    sessions: sessionmaker[Session],
+) -> None:
+    client_order_id, _root = _seed_validation_root(sessions)
+    with sessions() as session:
+        evidence = load_infrastructure_validation_evidence(
+            session,
+            account_label="paper",
+            client_order_id=client_order_id,
+        )
+    assert evidence is not None
+    broker = _CloseoutBroker()
+    executor = AlpacaReductionMutationExecutor(
+        firewall=OrderFirewall(broker, account_label="paper"),
+        read_client=cast(TorghutAlpacaClient, broker),
+        session_factory=sessions,
+        account_label="paper",
+        endpoint_url="https://paper-api.alpaca.markets/other",
+        coordinator=BrokerMutationCoordinator("validation-scope-test"),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="infrastructure_validation_lineage_scope_mismatch",
+    ):
+        executor.close_position(
+            "AAPL",
+            Decimal("1"),
+            validation_evidence=evidence,
+        )
+
+    assert broker.close_calls == 0
+    same_scope = AlpacaReductionMutationExecutor(
+        firewall=OrderFirewall(broker, account_label="paper"),
+        read_client=cast(TorghutAlpacaClient, broker),
+        session_factory=sessions,
+        account_label="paper",
+        endpoint_url=broker.endpoint_url,
+        coordinator=BrokerMutationCoordinator("validation-position-test"),
+    )
+    with pytest.raises(
+        RuntimeError,
+        match="infrastructure_validation_position_ancestry_missing",
+    ):
+        same_scope.close_position(
+            "BTC/USD",
+            Decimal("1"),
+            validation_evidence=evidence,
+        )
+    assert broker.close_calls == 0
+
+
+def test_cancel_all_preserves_liveness_for_mixed_validation_and_ordinary_orders(
+    sessions: sessionmaker[Session],
+) -> None:
+    client_order_id, _root = _seed_validation_root(sessions)
+    replacement_broker = _ReplaceBroker(
+        symbol="BTC/USD",
+        client_order_id=client_order_id,
+        order_id="validation-order-1",
+    )
+    replacement_adapter = AlpacaExecutionAdapter(
+        firewall=OrderFirewall(replacement_broker, account_label="paper"),
+        read_client=cast(TorghutAlpacaClient, replacement_broker),
+        session_factory=sessions,
+        account_label="paper",
+        endpoint_url=replacement_broker.endpoint_url,
+    )
+    replacement_adapter.replace_order(
+        "validation-order-1",
+        limit_price=Decimal("0.9"),
+    )
+    broker = _CancelAllBroker(
+        [
+            {
+                "id": "replacement-1",
+                "client_order_id": "broker-replacement-client",
+                "symbol": "BTC/USD",
+                "side": "buy",
+                "qty": "1",
+                "filled_qty": "0",
+                "status": "new",
+                "limit_price": "0.9",
+            },
+            {
+                "id": "ordinary-order-1",
+                "client_order_id": "ordinary-client-1",
+                "symbol": "ETH/USD",
+                "side": "buy",
+                "qty": "1",
+                "filled_qty": "0",
+                "status": "new",
+                "limit_price": "1",
+            },
+        ],
+        responses=[
+            {"id": "replacement-1", "status": 200},
+            {"id": "ordinary-order-1", "status": 200},
+        ],
+    )
+    adapter = AlpacaExecutionAdapter(
+        firewall=OrderFirewall(broker, account_label="paper"),
+        read_client=cast(TorghutAlpacaClient, broker),
+        session_factory=sessions,
+        account_label="paper",
+        endpoint_url=broker.endpoint_url,
+    )
+
+    assert adapter.cancel_all_orders() == [
+        {"id": "replacement-1", "status": 200},
+        {"id": "ordinary-order-1", "status": 200},
+    ]
+
+    assert broker.cancel_all_calls == 1
+    with sessions() as session:
+        receipts = session.execute(select(BrokerMutationReceipt)).scalars().all()
+    assert len(receipts) == 3
+    cancel_receipt = next(
+        receipt for receipt in receipts if receipt.operation == "cancel_all_orders"
+    )
+    request = json.loads(cancel_receipt.canonical_intent_json)["request"]
+    assert "infrastructure_validation_lineage" not in request
 
 
 def test_repricing_cannot_cross_an_observed_position(

--- a/services/torghut/tests/test_broker_mutation_receipt_models.py
+++ b/services/torghut/tests/test_broker_mutation_receipt_models.py
@@ -12,6 +12,7 @@ from sqlalchemy import (
 from app.models import BrokerMutationReceipt, BrokerMutationReceiptEvent
 from app.models.entities.broker_mutation_validation_contract import (
     BROKER_MUTATION_VALIDATION_AUTHORITY_SQL,
+    BROKER_MUTATION_VALIDATION_LINEAGE_SQL,
 )
 from tests.migration_testing import load_migration_module
 
@@ -82,6 +83,15 @@ def test_receipt_header_mirrors_validation_authority_and_permit_guards() -> None
     assert str(validation_check.sqltext).strip() == (
         BROKER_MUTATION_VALIDATION_AUTHORITY_SQL.strip()
     )
+    lineage_check = next(
+        constraint
+        for constraint in table.constraints
+        if isinstance(constraint, CheckConstraint)
+        and constraint.name == "ck_bm_receipt_validation_lineage"
+    )
+    assert str(lineage_check.sqltext).strip() == (
+        BROKER_MUTATION_VALIDATION_LINEAGE_SQL.strip()
+    )
 
     validation_permit = next(
         index
@@ -104,12 +114,19 @@ def test_receipt_header_mirrors_validation_authority_and_permit_guards() -> None
     table.create(engine)
     ddl = "\n".join(statements)
     assert "CONSTRAINT ck_bm_receipt_validation_authority" in ddl
+    assert "CONSTRAINT ck_bm_receipt_validation_lineage" in ddl
     assert "CREATE UNIQUE INDEX uq_bm_receipt_validation_permit" in ddl
     assert "non_promotable_validation" in ddl
 
     migration = load_migration_module("0068_infrastructure_validation_submit.py")
     assert str(getattr(migration, "_VALIDATION_AUTHORITY")).strip() == (
         BROKER_MUTATION_VALIDATION_AUTHORITY_SQL.strip()
+    )
+    lineage_migration = load_migration_module(
+        "0071_infrastructure_validation_lineage.py"
+    )
+    assert str(getattr(lineage_migration, "_LINEAGE_CONTRACT")).strip() == (
+        BROKER_MUTATION_VALIDATION_LINEAGE_SQL.strip()
     )
 
 
@@ -138,7 +155,21 @@ def test_event_model_keeps_recovery_and_settlement_evidence_separate() -> None:
     assert {
         "ix_broker_mutation_receipt_latest",
         "ix_broker_mutation_receipt_recovery_due",
+        "ix_bm_receipt_event_broker_reference",
     }.issubset(index_names)
+    broker_reference_index = next(
+        index
+        for index in table.indexes
+        if index.name == "ix_bm_receipt_event_broker_reference"
+    )
+    assert tuple(column.name for column in broker_reference_index.columns) == (
+        "broker_reference",
+        "receipt_id",
+    )
+    assert (
+        str(broker_reference_index.dialect_options["postgresql"]["where"])
+        == "state = 'settled' AND broker_reference IS NOT NULL"
+    )
 
 
 def test_event_model_enforces_the_exact_settlement_contract() -> None:

--- a/services/torghut/tests/test_infrastructure_validation_lineage_migration.py
+++ b/services/torghut/tests/test_infrastructure_validation_lineage_migration.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from tests.migration_testing import load_migration_module
+
+
+MIGRATION_FILENAME = "0071_infrastructure_validation_lineage.py"
+
+
+def test_revision_extends_reduction_fencing_without_rewriting_history() -> None:
+    module = load_migration_module(MIGRATION_FILENAME)
+
+    assert module.revision == "0071_validation_lineage"
+    assert module.down_revision == "0070_reduction_fencing"
+    assert len(module.revision) <= 32
+    assert (
+        len(Path(module.__file__ or "").read_text(encoding="utf-8").splitlines())
+        <= 1000
+    )
+
+
+def test_upgrade_binds_each_descendant_to_a_terminal_parent_and_root() -> None:
+    module = load_migration_module(MIGRATION_FILENAME)
+
+    with (
+        patch.object(module.op, "execute") as execute,
+        patch.object(module.op, "create_index") as create_index,
+    ):
+        module.upgrade()
+
+    sql = "\n".join(str(call.args[0]) for call in execute.call_args_list)
+    assert "ACCESS EXCLUSIVE MODE NOWAIT" in sql
+    assert "ADD CONSTRAINT ck_bm_receipt_validation_lineage" in sql
+    assert "VALIDATE CONSTRAINT ck_bm_receipt_validation_lineage" in sql
+    assert "jsonb_object_length" not in sql
+    for required_key in (
+        "root_receipt_id",
+        "root_client_order_id",
+        "parent_receipt_id",
+        "parent_broker_order_id",
+        "permit_id",
+        "permit_sha256",
+        "evidence_tag",
+        "promotable",
+    ):
+        assert required_key in sql
+    assert "CREATE TRIGGER trg_guard_bm_validation_lineage_0071" in sql
+    assert "root is not broker-terminal" in sql
+    assert "lineage parent missing" in sql
+    assert "ancestor_reference" in sql
+    assert "ancestor.operation NOT IN" in sql
+    assert "'submit_order', 'replace_order'" in sql
+    assert "torghut.infrastructure-validation-lifecycle-plan.v1" in sql
+    assert "lineage target mismatch" in sql
+    assert "cancel_all_orders" not in sql
+    assert "jsonb_build_array(root_symbol)" in sql
+    create_index.assert_called_once()
+    index_call = create_index.call_args
+    assert index_call.args == (
+        "ix_bm_receipt_event_broker_reference",
+        "broker_mutation_receipt_events",
+        ["broker_reference", "receipt_id"],
+    )
+    assert index_call.kwargs["unique"] is False
+    assert str(index_call.kwargs["postgresql_where"]) == (
+        "state = 'settled' AND broker_reference IS NOT NULL"
+    )
+
+
+def test_downgrade_refuses_to_erase_lineage_history() -> None:
+    module = load_migration_module(MIGRATION_FILENAME)
+
+    with (
+        patch.object(module.op, "execute") as execute,
+        patch.object(module.op, "drop_index") as drop_index,
+        patch.object(module.op, "drop_constraint") as drop_constraint,
+    ):
+        module.downgrade()
+
+    statements = [str(call.args[0]) for call in execute.call_args_list]
+    assert "ACCESS EXCLUSIVE MODE NOWAIT" in statements[0]
+    assert "cannot downgrade with validation-lineage receipts" in statements[1]
+    assert "DROP TRIGGER trg_guard_bm_validation_lineage_0071" in statements[2]
+    assert "DROP FUNCTION torghut_guard_bm_validation_lineage_0071" in statements[3]
+    drop_index.assert_called_once_with(
+        "ix_bm_receipt_event_broker_reference",
+        table_name="broker_mutation_receipt_events",
+    )
+    drop_constraint.assert_called_once_with(
+        "ck_bm_receipt_validation_lineage",
+        "broker_mutation_receipts",
+        type_="check",
+    )

--- a/services/torghut/tests/test_strategy_capital_authority_migration_compat.py
+++ b/services/torghut/tests/test_strategy_capital_authority_migration_compat.py
@@ -28,7 +28,7 @@ def test_migration_graph_has_one_merged_head_and_knows_the_released_revision() -
     config = AlembicConfig(str(SERVICE_ROOT / "alembic.ini"))
     scripts = ScriptDirectory.from_config(config)
 
-    assert scripts.get_heads() == ["0070_reduction_fencing"]
+    assert scripts.get_heads() == ["0071_validation_lineage"]
     assert scripts.get_revision("0063_strategy_capital_authority") is not None
     assert scripts.get_revision("0064_strategy_capital_authority") is not None
     assert scripts.get_revision("0065_strategy_capital_compat") is not None
@@ -37,3 +37,4 @@ def test_migration_graph_has_one_merged_head_and_knows_the_released_revision() -
     assert scripts.get_revision("0068_validation_submit") is not None
     assert scripts.get_revision("0069_strict_submit_recovery") is not None
     assert scripts.get_revision("0070_reduction_fencing") is not None
+    assert scripts.get_revision("0071_validation_lineage") is not None


### PR DESCRIPTION
## Summary

- Preserve exact non-promotable Alpaca-paper validation ancestry inside the existing broker-mutation receipt protocol; this adds no route, coordinator, claim table, or execution authority.
- Enforce root, parent, broker-order, account, endpoint, permit, and operation invariants in both application parsing and PostgreSQL so a malformed or ambiguous descendant fails closed.
- Exclude tagged descendant events from strategy execution, trade-decision, and TigerBeetle economic evidence while retaining their durable audit trail; account-wide cancel-all remains unclassified because its scope can race.
- Keep exposure-reduction liveness after the root submit permit expires, require actual broker order IDs for order-creating mutations, and document the bounded paper-runner and combined-image proof still required before Slice 6 can be promoted.

## Related Issues

None.

## Testing

- `uv run --frozen pytest -q` with a disposable local PostgreSQL 16 listener: 5,310 passed, 46 skipped, 0 failed.
- Real PostgreSQL 16 opt-in CAS/migration suite with `TORGHUT_TEST_POSTGRES_DSN` set to the disposable cluster: 36 passed.
- `uv run --frozen pytest -q tests/test_alpaca_reduction_coordinator.py tests/order_feed/test_infrastructure_validation_exclusion.py tests/test_broker_mutation_receipt_models.py tests/test_infrastructure_validation_lineage_migration.py tests/test_strategy_capital_authority_migration_compat.py`: 28 passed after rebasing onto current main.
- `uv run --frozen ruff check <13 changed Python files>` and `uv run --frozen ruff format --check <13 changed Python files>`: passed.
- Five Torghut Pyright profiles, changed-line Pylint plus design checks, migration single-head validation, file-length gate, compileall, and the tech-debt ratchet: passed; design findings decreased from 1,220 to 1,219.

## Breaking Changes

No API break. Migration `0071_validation_lineage` adds a partial receipt-event lookup index plus lineage constraints/trigger checks. The live preflight measured 23 receipt-event rows (128 KiB), so a regular transactional index is appropriate; downgrade refuses to erase existing lineage. Risk-increasing submission remains blocked, and this PR must not be promoted alone—the bounded lifecycle runner and a combined immutable image are still required.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
