### PR TITLE
perf(registry): shape shared-pool uploads

### DIFF
--- a/argocd/applications/registry/haproxy.cfg
+++ b/argocd/applications/registry/haproxy.cfg
@@ -16,7 +16,9 @@ defaults
 
 frontend registry
   bind :8080
+  filter bwlim-in registry_upload default-limit 1m default-period 1s
   acl write_request method POST PUT PATCH DELETE
+  http-request set-bandwidth-limit registry_upload if write_request
   use_backend registry_write if write_request
   default_backend registry_read
 

--- a/docs/torghut/storage-write-pressure-remediation-design.md
+++ b/docs/torghut/storage-write-pressure-remediation-design.md
@@ -371,10 +371,17 @@ to two hours. A generated ConfigMap name forces a pod rollout on proxy-policy ch
 registry pods from competing for the RWO filesystem during that rollout. This covers Docker, BuildKit, and direct OCI
 publishers at the same shared choke point without reducing pull concurrency.
 
-The cancelled analysis image workflow must be rerun through build and push after this boundary rolls out, and a new
-30-minute storage gate must show no controller event above two seconds. If the real BuildKit workload still fails that
-gate, stop the rollout and design a retained local-registry migration with explicit copy, outage, recovery, and
-digest-inventory proof rather than masking the failure with Kafka timeouts.
+The first post-proxy Analysis run, `29411750432` at source revision `89a019b4`, proved that the proxy serialized all 12
+mutation requests, with a maximum queue time of 10.211 seconds. It also exposed a second-order limit: one
+519,231,697-byte blob was still committed at roughly 51.53 MiB/s, and Kafka recorded a 2,423.56 ms controller event
+immediately afterward. That exceeds the two-second storage gate even though request fan-out was eliminated. The
+registry boundary must therefore also shape mutation request bodies to 1 MiB/s. This keeps the shared Ceph write path
+bounded independently of publisher implementation while leaving `GET` and `HEAD` image pulls unthrottled.
+
+After request-body shaping rolls out, dispatch the current Analysis `main` workflow through build and push, then start
+a new 30-minute observation from a fresh SMART baseline. The gate must show no controller event above two seconds. If
+the shaped workload still fails that gate, stop the rollout and investigate the remaining measured writer instead of
+masking the failure with Kafka timeouts.
 
 ## Talos local-storage feasibility and boundary
 

--- a/packages/scripts/src/shared/__tests__/registry.test.ts
+++ b/packages/scripts/src/shared/__tests__/registry.test.ts
@@ -22,8 +22,10 @@ const backendBlock = (name: string): string => {
 }
 
 describe('private registry write-pressure boundary', () => {
-  it('routes every registry mutation through one shared backend connection', () => {
+  it('rate-limits every registry mutation through one shared backend connection', () => {
+    expect(haproxyConfig).toContain('filter bwlim-in registry_upload default-limit 1m default-period 1s')
     expect(haproxyConfig).toContain('acl write_request method POST PUT PATCH DELETE')
+    expect(haproxyConfig).toContain('http-request set-bandwidth-limit registry_upload if write_request')
     expect(haproxyConfig).toContain('use_backend registry_write if write_request')
     expect(haproxyConfig).toContain('default_backend registry_read')
 
@@ -33,9 +35,12 @@ describe('private registry write-pressure boundary', () => {
   })
 
   it('keeps image pulls concurrent and separate from the write queue', () => {
+    expect(haproxyConfig).not.toContain('http-request set-bandwidth-limit registry_upload unless write_request')
+
     const readBackend = backendBlock('registry_read')
     expect(readBackend).toContain('127.0.0.1:5000 maxconn 100 check')
     expect(readBackend).not.toContain('maxconn 1 ')
+    expect(readBackend).not.toContain('set-bandwidth-limit')
   })
 
   it('serves traffic through the pinned non-root proxy and rolls config changes', () => {


### PR DESCRIPTION
## Summary

- Cap registry mutation request bodies at 1 MiB/s while preserving the existing global single-writer queue.
- Keep GET and HEAD image pulls on the separate unthrottled concurrent backend.
- Record the failed post-serialization Analysis proof and the measured 519 MB Ceph write burst in the remediation design.

## Related Issues

None

## Testing

- `docker run ... haproxy -c -f /usr/local/etc/haproxy/haproxy.cfg`
- Local Distribution and HAProxy protocol proof: a 4 MiB PATCH completed in 4.013 seconds while a concurrent `/v2/` GET completed in 1.352 milliseconds.
- `nix develop -c bun test packages/scripts/src/shared/__tests__/arc-runner.test.ts packages/scripts/src/shared/__tests__/registry.test.ts` (12 tests, 256 assertions)
- `nix develop -c bunx oxfmt --check packages/scripts/src/shared/__tests__/registry.test.ts docs/torghut/storage-write-pressure-remediation-design.md`
- `nix develop -c bun run lint:argocd`
- `nix develop -c sh -c 'kustomize build --enable-helm argocd/applications/registry | kubectl apply --server-side --dry-run=server --force-conflicts -n registry -f -'`

## Breaking Changes

None. Registry image pushes intentionally take longer; image pulls remain unthrottled.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] The storage remediation design documents the live failure evidence and rollout gate.
