### PR TITLE
fix(torghut): repair archive finalization

### DIFF
--- a/argocd/applications/torghut-options/archive/deployment.yaml
+++ b/argocd/applications/torghut-options/archive/deployment.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     app: torghut-options-archive
 spec:
-  # Exactly one worker owns the PostgreSQL advisory lease. Recreate prevents
-  # Kubernetes from overlapping workers during image or configuration rollouts.
-  replicas: 1
+  # Keep the worker disabled until the fixed image is promoted and a separate
+  # activation change can prove a complete archive shard against production.
+  replicas: 0
   revisionHistoryLimit: 2
   strategy:
     type: Recreate

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -109,12 +109,12 @@ describe('Torghut manifest scheduling', () => {
     })
   })
 
-  it('runs exactly one fenced options archive worker without rollout overlap', () => {
+  it('keeps the fenced options archive worker disabled pending production proof', () => {
     const deployment = parseManifest('argocd/applications/torghut-options/archive/deployment.yaml')
     const spec = getAtPath(deployment, ['spec'])
     const podSpec = getAtPath(deployment, ['spec', 'template', 'spec'])
 
-    expect(spec.replicas).toBe(1)
+    expect(spec.replicas).toBe(0)
     expect(spec.strategy).toMatchObject({ type: 'Recreate' })
     expect(podSpec.nodeSelector).toMatchObject({ 'kubernetes.io/arch': 'arm64' })
     expect(podSpec.serviceAccountName).toBe('torghut-runtime')

--- a/services/torghut/app/options_lane/archive_repository.py
+++ b/services/torghut/app/options_lane/archive_repository.py
@@ -647,7 +647,13 @@ class OptionsArchiveRepository:
                     session,
                     text(
                         f"""
-                    WITH candidates AS (
+                    WITH archive_parameters AS (
+                      SELECT CAST(:query_fingerprint AS VARCHAR(64)) AS query_fingerprint,
+                             CAST(:shard_key AS TEXT) AS shard_key,
+                             CAST(:component AS TEXT) AS component,
+                             CAST(:finalize_snapshot_at AS TIMESTAMPTZ) AS finalize_snapshot_at
+                    ),
+                    candidates AS (
                       SELECT candidate.expiration_date,
                              candidate.contract_symbol
                       FROM unnest(
@@ -664,14 +670,15 @@ class OptionsArchiveRepository:
                     )
                     SELECT catalog.contract_symbol,
                            CASE
-                             WHEN catalog.expiration_date < CAST(:finalize_snapshot_at AS DATE)
+                             WHEN catalog.expiration_date < CAST(archive_parameters.finalize_snapshot_at AS DATE)
                                THEN 'expired'
                              ELSE 'inactive'
                            END,
-                           :query_fingerprint,
-                           :shard_key,
-                           :finalize_snapshot_at
+                           archive_parameters.query_fingerprint,
+                           archive_parameters.shard_key,
+                           archive_parameters.finalize_snapshot_at
                     FROM candidates
+                    CROSS JOIN archive_parameters
                     JOIN torghut_options_contract_catalog AS catalog
                       ON catalog.expiration_date = candidates.expiration_date
                       AND catalog.contract_symbol = candidates.contract_symbol
@@ -679,9 +686,9 @@ class OptionsArchiveRepository:
                       AND NOT EXISTS (
                         SELECT 1
                         FROM {ARCHIVE_MEMBERSHIP_TABLE} AS membership
-                        WHERE membership.component = :component
-                          AND membership.query_fingerprint = :query_fingerprint
-                          AND membership.shard_key = :shard_key
+                        WHERE membership.component = archive_parameters.component
+                          AND membership.query_fingerprint = archive_parameters.query_fingerprint
+                          AND membership.shard_key = archive_parameters.shard_key
                           AND membership.contract_symbol = catalog.contract_symbol
                       )
                       AND NOT EXISTS (
@@ -707,7 +714,6 @@ class OptionsArchiveRepository:
                         """
                     ),
                     {
-                        "observed_at": observed_at,
                         "finalize_snapshot_at": current.finalize_snapshot_at,
                         "candidate_expiration_dates": candidate_expiration_dates,
                         "candidate_symbols": candidate_symbols,

--- a/services/torghut/app/options_lane/archive_state.py
+++ b/services/torghut/app/options_lane/archive_state.py
@@ -70,8 +70,11 @@ class ArchiveRuntimeState:
                     self.last_success_ts = change.checkpoint.last_success_at.isoformat()
             if change.completed:
                 self.last_success_ts = change.observed_at.isoformat()
-            self.last_error_code = change.error_code
-            self.last_error_detail = change.error_detail
+                self.last_error_code = None
+                self.last_error_detail = None
+            elif change.error_code is not None:
+                self.last_error_code = change.error_code
+                self.last_error_detail = change.error_detail
 
     def snapshot(self) -> dict[str, object]:
         with self._lock:

--- a/services/torghut/tests/test_options_archive.py
+++ b/services/torghut/tests/test_options_archive.py
@@ -662,18 +662,25 @@ def test_finalize_scans_one_bounded_batch_and_persists_cursor() -> None:
         for sql, parameters in session.calls
         if "INSERT INTO torghut_options_contract_archive_status" in sql
     )
-    assert "WITH candidates AS" in transition_sql
+    assert "WITH archive_parameters AS" in transition_sql
+    assert "CAST(:query_fingerprint AS VARCHAR(64))" in transition_sql
+    assert "CAST(:shard_key AS TEXT)" in transition_sql
+    assert "CAST(:component AS TEXT)" in transition_sql
+    assert "CAST(:finalize_snapshot_at AS TIMESTAMPTZ)" in transition_sql
     assert "INSERT INTO torghut_options_contract_archive_status" in transition_sql
     assert "UPDATE torghut_options_contract_catalog" not in transition_sql
     assert "CAST(:candidate_expiration_dates AS DATE[])" in transition_sql
     assert "CAST(:candidate_symbols AS TEXT[])" in transition_sql
     assert "catalog.expiration_date = candidates.expiration_date" in transition_sql
     assert "catalog.contract_symbol = candidates.contract_symbol" in transition_sql
-    assert "membership.query_fingerprint = :query_fingerprint" in transition_sql
-    assert "membership.shard_key = :shard_key" in transition_sql
+    assert (
+        "membership.query_fingerprint = archive_parameters.query_fingerprint"
+        in transition_sql
+    )
+    assert "membership.shard_key = archive_parameters.shard_key" in transition_sql
     assert "subscription.tier IS DISTINCT FROM 'off'" in transition_sql
     assert "ON CONFLICT (contract_symbol) DO UPDATE" in transition_sql
-    assert "CAST(:finalize_snapshot_at AS DATE)" in transition_sql
+    assert "CAST(archive_parameters.finalize_snapshot_at AS DATE)" in transition_sql
     assert "CAST(:observed_at AS DATE)" not in transition_sql
     assert isinstance(transition_parameters, dict)
     assert transition_parameters["finalize_snapshot_at"] == finalize_snapshot_at
@@ -928,3 +935,38 @@ def test_archive_retry_remains_live_but_not_ready() -> None:
     )
 
     assert not archive_is_ready(runtime_state.snapshot())
+
+
+def test_archive_error_remains_not_ready_until_a_shard_completes() -> None:
+    runtime_state = ArchiveRuntimeState()
+    runtime_state.update(
+        ArchiveStateUpdate(
+            phase="retry",
+            observed_at=datetime(2026, 7, 14, 12, tzinfo=UTC),
+            lease_acquired=True,
+            error_code="archive_shard_failed",
+            error_detail="database statement failed",
+        )
+    )
+    runtime_state.update(
+        ArchiveStateUpdate(
+            phase="finalizing",
+            observed_at=datetime(2026, 7, 14, 12, 1, tzinfo=UTC),
+        )
+    )
+
+    failed_snapshot = runtime_state.snapshot()
+    assert failed_snapshot["last_error_code"] == "archive_shard_failed"
+    assert not archive_is_ready(failed_snapshot)
+
+    runtime_state.update(
+        ArchiveStateUpdate(
+            phase="complete",
+            observed_at=datetime(2026, 7, 14, 12, 2, tzinfo=UTC),
+            completed=True,
+        )
+    )
+
+    recovered_snapshot = runtime_state.snapshot()
+    assert recovered_snapshot["last_error_code"] is None
+    assert archive_is_ready(recovered_snapshot)


### PR DESCRIPTION
## Summary

- Fix archive finalization parameter inference by binding PostgreSQL values once with their schema-native types.
- Keep archive readiness failed across retries until a shard completes successfully.
- Set the archive worker to zero replicas until the fixed image is promoted and production activation is proven separately.

## Related Issues

None.

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_options_archive.py tests/test_options_archive_runtime.py` (43 passed)
- `uv run --frozen ruff check app/options_lane/archive_repository.py app/options_lane/archive_state.py tests/test_options_archive.py`
- `uv run --frozen ruff format --check app/options_lane/archive_repository.py app/options_lane/archive_state.py tests/test_options_archive.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts` (17 passed)
- `bunx oxfmt --check packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `kustomize build --enable-helm argocd/applications/torghut-options`
- `kustomize build --enable-helm argocd/applications/torghut-options | kubectl apply -n torghut --server-side --dry-run=server --field-manager=argocd-controller -f -`
- `bun run lint:argocd`
- Live rolled-back SQLAlchemy/psycopg execution against Torghut PostgreSQL returned `archive_finalize_parser_proof rowcount=0` without the prior `AmbiguousParameter` error.
- Live containment proof: the archive pod is fenced by the archive advisory lease, remains `0/1`, and `/readyz` returns 503 while Git still points at the affected image.

## Breaking Changes

None. The archive deployment is intentionally disabled in this PR; a separate activation change is required after the fixed image is promoted.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (screenshots are not applicable; breaking changes are documented above).
- [x] Documentation, release notes, and follow-ups are updated or tracked (production activation is explicitly separated from this containment fix).
