### PR TITLE
chore(torghut): reactivate options archive worker

### DIFF
--- a/argocd/applications/torghut-options/archive/deployment.yaml
+++ b/argocd/applications/torghut-options/archive/deployment.yaml
@@ -6,9 +6,8 @@ metadata:
   labels:
     app: torghut-options-archive
 spec:
-  # Keep the worker disabled until the fixed image is promoted and a separate
-  # activation change can prove a complete archive shard against production.
-  replicas: 0
+  # Run exactly one fenced worker so archive finalization has a single writer.
+  replicas: 1
   revisionHistoryLimit: 2
   strategy:
     type: Recreate

--- a/docs/torghut/rollouts/2026-07-14-storage-write-pressure-remediation.md
+++ b/docs/torghut/rollouts/2026-07-14-storage-write-pressure-remediation.md
@@ -1,6 +1,6 @@
 # Torghut and Ceph Write-Pressure Remediation Rollout
 
-Last updated: **2026-07-15 04:29 UTC**
+Last updated: **2026-07-15 13:45 UTC**
 
 Status: **write-heavy activation contained; Jangar write-pressure fix and clean storage observation pending**
 
@@ -270,6 +270,16 @@ occurred at `04:28:57 UTC`, and maximum follower-lag time was 14,449 ms. Ceph re
 up and in, SMART current health passed on all three expected disks, and every Torghut runtime check passed. Concurrent
 WAL samples measured Torghut at 0.0048 MiB/s and Jangar at 0.3624 MiB/s; Jangar remains above the 0.3015 MiB/s gate.
 This is a real failed baseline, not a timeout-setting problem.
+
+After the Jangar write-pressure cleanup and registry mutation rate limit were live, the schema-v4 gate passed at
+`2026-07-15 12:41:51 UTC` against an observation start of `12:05:26 UTC`. The 36.42-minute window returned no failures:
+Ceph was `HEALTH_OK` with all six OSDs up and in; all three SMART devices passed current/baseline health, zero-media, and
+no-new-CRC checks; Kafka 4.3.0 / metadata `4.3-IV0` had all six broker/controller pods ready; and the archive worker and
+Kafka ClickHouse writer remained declaratively and actually at zero replicas. Concurrent WAL samples measured Torghut
+at 0.0096 MiB/s and Jangar at 0.0027 MiB/s over 30.6 seconds. The feed, scheduler, and Knative API revision
+`torghut-01477` were ready. The only warnings were the already-documented interrupted historical SMART self-tests and
+the still-active Kafka controller timeout overrides. This `PASS` authorizes the one-replica archive activation below;
+it does not authorize the Kafka writer or timeout-removal stages.
 
 The superseded repair-gate collection completed at `2026-07-15 01:38 UTC`, using `2026-07-14T20:12:00Z` as the start
 of the incident window. It correctly returned `FAIL` because that window intentionally contained the incident itself;

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -109,12 +109,12 @@ describe('Torghut manifest scheduling', () => {
     })
   })
 
-  it('keeps the fenced options archive worker disabled pending production proof', () => {
+  it('runs exactly one fenced options archive worker for production proof', () => {
     const deployment = parseManifest('argocd/applications/torghut-options/archive/deployment.yaml')
     const spec = getAtPath(deployment, ['spec'])
     const podSpec = getAtPath(deployment, ['spec', 'template', 'spec'])
 
-    expect(spec.replicas).toBe(0)
+    expect(spec.replicas).toBe(1)
     expect(spec.strategy).toMatchObject({ type: 'Recreate' })
     expect(podSpec.nodeSelector).toMatchObject({ 'kubernetes.io/arch': 'arm64' })
     expect(podSpec.serviceAccountName).toBe('torghut-runtime')


### PR DESCRIPTION
## Summary

- Reactivate exactly one fenced Torghut options archive worker after the corrected finalization image was promoted.
- Preserve the `Recreate` strategy so Kubernetes never overlaps side-effecting archive workers.
- Update the manifest regression test to require the single-writer production topology.
- Record the successful 36.42-minute pre-activation storage gate and its exact runtime/WAL evidence.

## Related Issues

None.

## Testing

- `/nix/var/nix/profiles/default/bin/nix develop --command bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts` (17 passed)
- `/nix/var/nix/profiles/default/bin/nix develop --command bunx oxfmt --check argocd/applications/torghut-options/archive/deployment.yaml packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `/nix/var/nix/profiles/default/bin/nix develop --command kustomize build --enable-helm argocd/applications/torghut-options`
- `/opt/homebrew/bin/kubectl apply -n torghut --dry-run=server --field-manager=argocd-controller -f /tmp/torghut-options-archive-reactivate-render.yaml`
- `/nix/var/nix/profiles/default/bin/nix develop --command bun run lint:argocd`
- `/nix/var/nix/profiles/default/bin/nix develop --command bunx oxfmt --check docs/torghut/rollouts/2026-07-14-storage-write-pressure-remediation.md`
- `git diff --check`

## Screenshots (if applicable)

N/A. This is a Kubernetes worker activation with no UI change.

## Breaking Changes

None. The worker uses the already-promoted fixed image and existing schema; rollout impact is one bounded archive writer becoming active.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked; the existing remediation design already defines this activation stage.
