### PR TITLE
fix(torghut): eliminate options catalog write churn

### DIFF
--- a/docs/torghut/storage-write-pressure-remediation-design.md
+++ b/docs/torghut/storage-write-pressure-remediation-design.md
@@ -160,6 +160,12 @@ The repository executes one transaction:
 
 The existing blanket `contract_symbol <> ALL(:symbols)` update is removed from provisional reconciliation.
 
+Ranking-input authority is disjoint. Catalog ranking owns `liquidity_score`, `underlying_activity_score`, `dte_score`,
+and `moneyness_score`; snapshot enrichment owns only `quote_recency_score` and `trade_recency_score`. Enrichment merges
+only its two keys and performs no subscription-row update when the merged JSON is unchanged. Catalog reconciliation
+carries the enrichment-owned values forward but does not replace them with a second interpretation. A ranking-input key
+must never have two writers because alternating values would turn every observation into a non-material index rewrite.
+
 ### Coalescing
 
 Ranking scores are normalized by the maximum observed open interest, which may change during a scan. Candidate changes

--- a/services/torghut/app/options_lane/alpaca.py
+++ b/services/torghut/app/options_lane/alpaca.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 import re
 from typing import cast
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
 _OCC_SYMBOL_RE = re.compile(r"^([A-Z]{1,6})\d{6}[CP]\d{8}$")
+_CONTRACT_PRICE_QUANTUM = Decimal("0.000001")
 JsonObject = dict[str, object]
 
 
@@ -64,6 +65,20 @@ def _to_float(value: object) -> float | None:
     try:
         return float(cast(Decimal | int | float | str, value))
     except (TypeError, ValueError, ArithmeticError):
+        return None
+
+
+def _to_contract_price(value: object) -> Decimal | None:
+    """Normalize provider prices to the catalog's NUMERIC(18, 6) domain."""
+
+    if value is None:
+        return None
+    try:
+        parsed = Decimal(str(value))
+        if not parsed.is_finite():
+            return None
+        return parsed.quantize(_CONTRACT_PRICE_QUANTUM, rounding=ROUND_HALF_UP)
+    except (InvalidOperation, ValueError):
         return None
 
 
@@ -328,11 +343,12 @@ def normalize_contract_record(
         or None,
         "option_type": option_type,
         "style": style,
-        "strike_price": _to_float(raw.get("strike_price")) or 0.0,
+        "strike_price": _to_contract_price(raw.get("strike_price"))
+        or Decimal("0.000000"),
         "contract_size": contract_size,
         "open_interest": _to_int(raw.get("open_interest")),
         "open_interest_date": _normalize_iso_date(raw.get("open_interest_date")),
-        "close_price": _to_float(raw.get("close_price")),
+        "close_price": _to_contract_price(raw.get("close_price")),
         "close_price_date": _normalize_iso_date(raw.get("close_price_date")),
         "provider_updated_ts": _normalize_iso_datetime(
             raw.get("updated_at") or raw.get("provider_updated_at")

--- a/services/torghut/app/options_lane/enricher_service.py
+++ b/services/torghut/app/options_lane/enricher_service.py
@@ -17,6 +17,7 @@ from .options_status import build_status_payload
 from .repository import OptionsRepository
 from .session import session_state, utc_now
 from .settings import get_options_lane_settings
+from .snapshot_ranking import snapshot_ranking_inputs
 
 logger = logging.getLogger(__name__)
 
@@ -133,22 +134,6 @@ def _publish_status(
     _producer.send(settings.topic_status, "enricher", envelope)
 
 
-def _ranking_inputs_from_snapshot(payload: dict[str, Any]) -> dict[str, Any]:
-    trade_recency_score = 1.0 if payload.get("latest_trade_ts") else 0.2
-    quote_recency_score = 1.0 if payload.get("latest_quote_ts") else 0.2
-    liquidity_score = 0.5
-    if payload.get("latest_bid_size") and payload.get("latest_ask_size"):
-        total_size = float(payload["latest_bid_size"]) + float(
-            payload["latest_ask_size"]
-        )
-        liquidity_score = min(total_size / 1000.0, 1.0)
-    return {
-        "trade_recency_score": trade_recency_score,
-        "quote_recency_score": quote_recency_score,
-        "liquidity_score": liquidity_score,
-    }
-
-
 def _process_tier(*, tier: str, interval_sec: int, bucket_name: str) -> int:
     due_rows = _repository.get_due_snapshot_contracts(
         tier=tier,
@@ -186,7 +171,7 @@ def _process_tier(*, tier: str, interval_sec: int, bucket_name: str) -> int:
             contract_symbol=symbol,
             snapshot_class=tier,
             observed_at=observed_at,
-            ranking_inputs=_ranking_inputs_from_snapshot(payload),
+            ranking_inputs=snapshot_ranking_inputs(payload),
         )
     return 0
 

--- a/services/torghut/app/options_lane/repository.py
+++ b/services/torghut/app/options_lane/repository.py
@@ -632,6 +632,11 @@ class OptionsRepository:
                     ON CONFLICT (contract_symbol) DO UPDATE
                     SET ranking_inputs = COALESCE(torghut_options_subscription_state.ranking_inputs, '{}'::JSONB)
                         || EXCLUDED.ranking_inputs
+                    WHERE COALESCE(torghut_options_subscription_state.ranking_inputs, '{}'::JSONB)
+                      IS DISTINCT FROM (
+                        COALESCE(torghut_options_subscription_state.ranking_inputs, '{}'::JSONB)
+                        || EXCLUDED.ranking_inputs
+                      )
                     """
                 ),
                 {

--- a/services/torghut/app/options_lane/snapshot_ranking.py
+++ b/services/torghut/app/options_lane/snapshot_ranking.py
@@ -1,0 +1,14 @@
+"""Snapshot-owned inputs for options subscription ranking."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+
+def snapshot_ranking_inputs(payload: Mapping[str, object]) -> dict[str, float]:
+    """Return only the recency inputs owned by snapshot enrichment."""
+
+    return {
+        "trade_recency_score": 1.0 if payload.get("latest_trade_ts") else 0.2,
+        "quote_recency_score": 1.0 if payload.get("latest_quote_ts") else 0.2,
+    }

--- a/services/torghut/tests/test_options_catalog_change_detection.py
+++ b/services/torghut/tests/test_options_catalog_change_detection.py
@@ -1,0 +1,44 @@
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from app.options_lane.alpaca import normalize_contract_record
+from app.options_lane.catalog_change_detection import contract_catalog_row_changed
+
+
+def _normalized_contract(*, close_price: str) -> dict[str, object]:
+    return normalize_contract_record(
+        {
+            "id": "contract-amd",
+            "symbol": "AMD260715C00300000",
+            "status": "active",
+            "tradable": True,
+            "expiration_date": "2026-07-15",
+            "root_symbol": "AMD",
+            "underlying_symbol": "AMD",
+            "type": "call",
+            "style": "american",
+            "strike_price": "300.125",
+            "size": "100",
+            "close_price": close_price,
+            "close_price_date": "2026-07-14",
+        },
+        observed_at=datetime(2026, 7, 15, 14, 0, tzinfo=UTC),
+    )
+
+
+def test_postgres_numeric_prices_do_not_create_false_catalog_changes() -> None:
+    payload = _normalized_contract(close_price="261.59")
+    current = dict(payload)
+    current["strike_price"] = Decimal("300.125000")
+    current["close_price"] = Decimal("261.590000")
+
+    assert payload["strike_price"] == Decimal("300.125000")
+    assert payload["close_price"] == Decimal("261.590000")
+    assert not contract_catalog_row_changed(current=current, payload=payload)
+
+
+def test_material_price_change_remains_visible() -> None:
+    current = _normalized_contract(close_price="261.59")
+    payload = _normalized_contract(close_price="261.60")
+
+    assert contract_catalog_row_changed(current=current, payload=payload)

--- a/services/torghut/tests/test_options_snapshot_persistence.py
+++ b/services/torghut/tests/test_options_snapshot_persistence.py
@@ -1,0 +1,79 @@
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager, nullcontext
+from datetime import UTC, datetime
+import json
+from types import SimpleNamespace
+from typing import cast
+
+from sqlalchemy.orm import Session
+
+from app.options_lane.repository import OptionsRepository
+from app.options_lane.snapshot_ranking import snapshot_ranking_inputs
+
+
+class _RecordingSession:
+    def __init__(self) -> None:
+        self.statements: list[tuple[str, Mapping[str, object]]] = []
+
+    def begin(self) -> nullcontext[None]:
+        return nullcontext()
+
+    def execute(
+        self,
+        statement: object,
+        parameters: Mapping[str, object],
+    ) -> SimpleNamespace:
+        self.statements.append((str(statement), parameters))
+        return SimpleNamespace(rowcount=1)
+
+
+class _RecordingRepository(OptionsRepository):
+    def __init__(self, session: _RecordingSession) -> None:
+        self._recording_session = session
+
+    @contextmanager
+    def session(self) -> Iterator[Session]:
+        yield cast(Session, self._recording_session)
+
+
+def test_snapshot_ranking_inputs_do_not_overwrite_catalog_liquidity() -> None:
+    inputs = snapshot_ranking_inputs(
+        {
+            "latest_trade_ts": datetime(2026, 7, 15, 14, 0, tzinfo=UTC),
+            "latest_quote_ts": datetime(2026, 7, 15, 14, 0, tzinfo=UTC),
+            "latest_bid_size": 20,
+            "latest_ask_size": 30,
+        }
+    )
+
+    assert inputs == {
+        "trade_recency_score": 1.0,
+        "quote_recency_score": 1.0,
+    }
+    assert "liquidity_score" not in inputs
+
+
+def test_snapshot_persistence_skips_unchanged_subscription_inputs() -> None:
+    session = _RecordingSession()
+    repository = _RecordingRepository(session)
+    ranking_inputs = {
+        "trade_recency_score": 1.0,
+        "quote_recency_score": 1.0,
+    }
+
+    repository.record_snapshot_success(
+        contract_symbol="AMD260715C00300000",
+        snapshot_class="hot",
+        observed_at=datetime(2026, 7, 15, 14, 0, tzinfo=UTC),
+        ranking_inputs=ranking_inputs,
+    )
+
+    assert len(session.statements) == 2
+    subscription_sql, subscription_parameters = session.statements[1]
+    assert "ON CONFLICT (contract_symbol) DO UPDATE" in subscription_sql
+    assert "IS DISTINCT FROM" in subscription_sql
+    assert "|| EXCLUDED.ranking_inputs" in subscription_sql
+    assert (
+        json.loads(cast(str, subscription_parameters["ranking_inputs"]))
+        == ranking_inputs
+    )


### PR DESCRIPTION
## Summary

- normalize contract prices to the catalog's exact PostgreSQL `NUMERIC(18,6)` domain so unchanged provider rows are neither upserted nor republished
- make ranking-input ownership disjoint: catalog owns liquidity and contract-derived scores, while snapshot enrichment owns quote/trade recency only
- make snapshot ranking-input persistence conditional and document the single-authority contract in the accepted storage remediation design

## Related Issues

None

## Testing

- `uv run --frozen pytest -q tests/test_options*.py` (91 passed)
- `uv run --frozen ruff check app tests scripts migrations`
- `uv run --frozen ruff format --check app tests scripts migrations`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python scripts/run_pylint_torghut_structural_gate.py`
- changed-line Pylint quality, design, and file-length gates against `origin/main`
- `uv run --frozen python scripts/measure_torghut_tech_debt.py --baseline config/quality/tech-debt-baseline.json --enforce-ratchet --format markdown`
- live read-only comparison of 10,000 provider rows against PostgreSQL proved all 6,307 false changes were equal `close_price` values represented as `float` versus `Decimal`
- live read-only comparison of the 960 desired subscription rows proved current repeated reconciliation differences were snapshot/catalog `liquidity_score` ownership conflicts

## Breaking Changes

None. Existing ranking inputs converge forward to the documented single-authority values during the next normal catalog cycle.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
