### PR TITLE
fix(torghut): deduplicate TA heartbeat timers

### DIFF
--- a/services/dorvud/technical-analysis-flink/src/main/kotlin/ai/proompteng/dorvud/ta/flink/FlinkTechnicalAnalysisJob.kt
+++ b/services/dorvud/technical-analysis-flink/src/main/kotlin/ai/proompteng/dorvud/ta/flink/FlinkTechnicalAnalysisJob.kt
@@ -1216,12 +1216,12 @@ private class StatusHeartbeatProcessFunction(
     ctx: OnTimerContext,
     out: Collector<Envelope<TaStatusPayload>>,
   ) {
+    val next = nextStatusHeartbeatTimer(timestamp, nextTimerState.value(), intervalMs) ?: return
     emitHeartbeat(
       now = Instant.now(),
       watermark = ctx.timerService().currentWatermark(),
       out = out,
     )
-    val next = timestamp + intervalMs
     ctx.timerService().registerProcessingTimeTimer(next)
     nextTimerState.update(next)
   }
@@ -1290,6 +1290,17 @@ private class StatusHeartbeatProcessFunction(
     }
   }
 }
+
+internal fun nextStatusHeartbeatTimer(
+  firedTimestamp: Long,
+  scheduledTimestamp: Long?,
+  intervalMs: Long,
+): Long? =
+  if (firedTimestamp == scheduledTimestamp) {
+    firedTimestamp + intervalMs
+  } else {
+    null
+  }
 
 internal fun taStatusPayload(
   now: Instant,

--- a/services/dorvud/technical-analysis-flink/src/test/kotlin/ai/proompteng/dorvud/ta/flink/FlinkTechnicalAnalysisStatusHeartbeatTest.kt
+++ b/services/dorvud/technical-analysis-flink/src/test/kotlin/ai/proompteng/dorvud/ta/flink/FlinkTechnicalAnalysisStatusHeartbeatTest.kt
@@ -16,6 +16,29 @@ import kotlin.test.assertNull
 
 class FlinkTechnicalAnalysisStatusHeartbeatTest {
   @Test
+  fun `stale restored heartbeat timer is ignored instead of creating a duplicate timer chain`() {
+    assertNull(
+      nextStatusHeartbeatTimer(
+        firedTimestamp = 1_000,
+        scheduledTimestamp = 1_001,
+        intervalMs = 60_000,
+      ),
+    )
+  }
+
+  @Test
+  fun `current heartbeat timer advances exactly one interval`() {
+    assertEquals(
+      61_000,
+      nextStatusHeartbeatTimer(
+        firedTimestamp = 1_000,
+        scheduledTimestamp = 1_000,
+        intervalMs = 60_000,
+      ),
+    )
+  }
+
+  @Test
   fun `startup heartbeat payload is explicit when no input event has arrived`() {
     val payload =
       taStatusPayload(


### PR DESCRIPTION
## Summary

- Stop stale restored processing-time callbacks from emitting a second TA status heartbeat for the same interval.
- Advance only the timer timestamp persisted in `nextTimerState`, preventing duplicate timer chains from surviving Flink recovery.
- Add regression coverage for rejecting a stale timer and advancing the current timer exactly once.

## Related Issues

None.

## Testing

- `/nix/var/nix/profiles/default/bin/nix shell nixpkgs#jdk21_headless --command ./gradlew :technical-analysis-flink:test --tests ai.proompteng.dorvud.ta.flink.FlinkTechnicalAnalysisStatusHeartbeatTest :technical-analysis-flink:ktlintCheck`
- `/nix/var/nix/profiles/default/bin/nix shell nixpkgs#jdk21_headless --command ./gradlew :technical-analysis-flink:test`
- `git diff --check`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] No documentation, release-note, or follow-up change is required for this corrective timer-state guard.
