### PR TITLE
fix(torghut): honor live paper lifecycle bounds

### DIFF
--- a/docs/torghut/profitability/infrastructure-validation-runbook.md
+++ b/docs/torghut/profitability/infrastructure-validation-runbook.md
@@ -227,7 +227,8 @@ at `$1`. A lifecycle plan must keep the root order at or below `$30` and must al
 residual at a plan notional of at least `$12` each. The `$12` guard is a deterministic buffer over the observed `$10`
 broker floor, not permission to skip fresh quote readback. Immediately before issuance, independently verify that the
 entry limit is marketable and that both close quantities remain above the broker's current minimum cost basis. Stop if
-those conditions cannot coexist under the `$30` root cap.
+those conditions cannot coexist under the `$30` root cap. Application authorization and the PostgreSQL receipt
+authority constraint both enforce the two leg floors, including for direct forged-intent attempts.
 
 For example, when BTC/USD is below `$70,000`, `qty=0.0004`, `limit_price=70000`, and
 `partial_close_qty=0.0002` bind at most `$28` of paper exposure and give each planned close leg `$14` of plan notional.

--- a/docs/torghut/profitability/infrastructure-validation-runbook.md
+++ b/docs/torghut/profitability/infrastructure-validation-runbook.md
@@ -213,3 +213,30 @@ This migration is necessary but is not the lifecycle proof. Do not manually comp
 Slice 6 is proven from migration presence. The bounded Alpaca-paper lifecycle runner, immutable image promotion, broker
 readback, CNPG receipt chain, and independent absence from candidate/PnL/ledger evidence must all pass before
 `reduction_fencing_proven` can become true.
+
+### Live broker minimum correction
+
+The first promoted lifecycle attempt on 2026-07-15 UTC disproved the original `$5` assumption. Alpaca paper returned
+HTTP `403`, code `40310000`, and an explicit `$10` minimum-cost-basis rejection even though the Assets response's
+`min_order_size` allowed the requested quantity. The attempt created no broker order, position, open order, execution,
+or trade decision. The old adapter incorrectly collapsed that definitive response into ambiguous broker I/O; retain
+that historical receipt and its absence observations rather than rewriting it.
+
+Migration `0073_live_paper_bounds` raises only the lifecycle-plan ceiling to `$30`; the known-null submit proof remains
+at `$1`. A lifecycle plan must keep the root order at or below `$30` and must allocate both the partial close and final
+residual at a plan notional of at least `$12` each. The `$12` guard is a deterministic buffer over the observed `$10`
+broker floor, not permission to skip fresh quote readback. Immediately before issuance, independently verify that the
+entry limit is marketable and that both close quantities remain above the broker's current minimum cost basis. Stop if
+those conditions cannot coexist under the `$30` root cap.
+
+For example, when BTC/USD is below `$70,000`, `qty=0.0004`, `limit_price=70000`, and
+`partial_close_qty=0.0002` bind at most `$28` of paper exposure and give each planned close leg `$14` of plan notional.
+Resting and replacement close limits must remain strictly above the entry limit and each other. Recompute the immutable
+plan digest after every price or quantity change; never widen a signed permit in place.
+
+An Alpaca HTTP `400`, `401`, `403`, `404`, or `422` response definitively refuses the request and now settles the
+existing receipt as `rejected`, without a fabricated broker reference or success callback. Every other status,
+including conflict, timeout, rate-limit, transport, and server failures, remains ambiguous and stays in `broker_io` for
+read-only reconciliation. These are the synchronous failures documented by the official
+[order endpoint](https://docs.alpaca.markets/us/reference/createorderforaccount); live broker behavior remains the
+authority when published minimum metadata and the order endpoint disagree.

--- a/docs/torghut/profitability/risk-reduction-mutation-fencing.md
+++ b/docs/torghut/profitability/risk-reduction-mutation-fencing.md
@@ -225,6 +225,9 @@ claimed --durable I/O fence--> broker_io --terminal response--> settled
 Safety rules:
 
 - a primary or recovery lease authorizes database transitions, never a second broker mutation;
+- an adapter must translate a definitive non-retryable broker refusal into the shared explicit-rejection contract, so
+  the coordinator atomically settles `rejected`; timeouts, rate limits, transport loss, and server failures remain
+  ambiguous `broker_io` rather than pretending success or rejection;
 - recovery observes exact broker identities and sealed target sets; it never calls cancel, replace, or close;
 - an incomplete lookup records `indeterminate` and preserves `broker_io`;
 - side flip, increased quantity, conflicting replacement identity, or increased exposure requires manual review;

--- a/services/torghut/app/models/entities/broker_mutation_validation_contract.py
+++ b/services/torghut/app/models/entities/broker_mutation_validation_contract.py
@@ -54,7 +54,7 @@ purpose <> 'control_plane_validation' OR COALESCE((
           WHEN canonical_intent_json::jsonb #>>
                '{request,infrastructure_validation,test_plan,schema_version}' =
                'torghut.infrastructure-validation-lifecycle-plan.v1'
-          THEN 5 ELSE 1
+          THEN 30 ELSE 1
          END
   AND (canonical_intent_json::jsonb #>>
        '{request,infrastructure_validation,permit,max_loss_usd}')::numeric
@@ -65,7 +65,7 @@ purpose <> 'control_plane_validation' OR COALESCE((
           WHEN canonical_intent_json::jsonb #>>
                '{request,infrastructure_validation,test_plan,schema_version}' =
                'torghut.infrastructure-validation-lifecycle-plan.v1'
-          THEN 5 ELSE 1
+          THEN 30 ELSE 1
          END
   AND (canonical_intent_json::jsonb #>>
        '{request,infrastructure_validation,permit,max_loss_usd}')::numeric

--- a/services/torghut/app/models/entities/broker_mutation_validation_contract.py
+++ b/services/torghut/app/models/entities/broker_mutation_validation_contract.py
@@ -199,6 +199,18 @@ purpose <> 'control_plane_validation' OR COALESCE((
             < (canonical_intent_json::jsonb #>>
                '{request,infrastructure_validation,test_plan,qty}')::numeric
         AND (canonical_intent_json::jsonb #>>
+             '{request,infrastructure_validation,test_plan,partial_close_qty}')::numeric *
+            (canonical_intent_json::jsonb #>>
+             '{request,infrastructure_validation,test_plan,limit_price}')::numeric
+            >= 12
+        AND ((canonical_intent_json::jsonb #>>
+              '{request,infrastructure_validation,test_plan,qty}')::numeric -
+             (canonical_intent_json::jsonb #>>
+              '{request,infrastructure_validation,test_plan,partial_close_qty}')::numeric) *
+            (canonical_intent_json::jsonb #>>
+             '{request,infrastructure_validation,test_plan,limit_price}')::numeric
+            >= 12
+        AND (canonical_intent_json::jsonb #>>
              '{request,infrastructure_validation,test_plan,resting_close_limit_price}')::numeric
             > (canonical_intent_json::jsonb #>>
                '{request,infrastructure_validation,test_plan,limit_price}')::numeric

--- a/services/torghut/app/trading/broker_mutation_coordinator.py
+++ b/services/torghut/app/trading/broker_mutation_coordinator.py
@@ -19,6 +19,7 @@ from ..models import Execution
 from .broker_mutation_receipts import (
     BrokerMutationIntent,
     BrokerMutationIntentRequest,
+    BrokerMutationExplicitRejection,
     BrokerMutationIoPermit,
     BrokerMutationLinkedSubmissionSettlementRequest,
     BrokerMutationReceiptAcquireOptions,
@@ -26,9 +27,11 @@ from .broker_mutation_receipts import (
     BrokerMutationReceiptHandle,
     BrokerMutationReceiptSnapshot,
     BrokerMutationSettlement,
+    BrokerMutationSettlementRequest,
     BrokerMutationTarget,
     acquire_broker_mutation_receipt,
     build_broker_mutation_intent,
+    build_broker_mutation_settlement,
     build_linked_submission_terminal_settlement,
     fingerprint_broker_endpoint,
     mark_broker_mutation_io_started,
@@ -74,7 +77,7 @@ class BrokerMutationAlreadyProcessed(BrokerMutationError):
 
 
 class BrokerMutationRejected(BrokerMutationError):
-    """The linked decision is durably rejected or no longer claimable."""
+    """The mutation is durably rejected or no longer claimable."""
 
 
 class BrokerMutationPreflightFailed(BrokerMutationError):
@@ -174,12 +177,23 @@ class BrokerMutationCoordinator:
             submission_claim_handle=claim.handle,
             scope="linked_submission",
         )
-        broker_result = _call_broker(
-            callbacks.broker_call,
-            permit=permit,
-            receipt_id=handle.receipt_id,
-            scope="linked_submission",
-        )
+        try:
+            broker_result = _call_broker(
+                callbacks.broker_call,
+                permit=permit,
+                receipt_id=handle.receipt_id,
+                scope="linked_submission",
+            )
+        except BrokerMutationExplicitRejection as exc:
+            _settle_linked_broker_rejection(
+                session,
+                handle=handle,
+                claim=claim,
+                rejection=exc,
+            )
+            raise BrokerMutationRejected(
+                _broker_rejection_message("linked_submission", handle.receipt_id, exc)
+            ) from exc
         return _settle_linked_terminal(
             session,
             _LinkedTerminalContext(
@@ -307,12 +321,23 @@ class BrokerMutationCoordinator:
             submission_claim_handle=None,
             scope=scope,
         )
-        broker_result = _call_broker(
-            callbacks.broker_call,
-            permit=permit,
-            receipt_id=handle.receipt_id,
-            scope=scope,
-        )
+        try:
+            broker_result = _call_broker(
+                callbacks.broker_call,
+                permit=permit,
+                receipt_id=handle.receipt_id,
+                scope=scope,
+            )
+        except BrokerMutationExplicitRejection as exc:
+            _settle_unlinked_broker_rejection(
+                session,
+                handle=handle,
+                scope=scope,
+                rejection=exc,
+            )
+            raise BrokerMutationRejected(
+                _broker_rejection_message(scope, handle.receipt_id, exc)
+            ) from exc
         _settle_unlinked_terminal(
             session,
             _UnlinkedTerminalContext(
@@ -494,10 +519,90 @@ def _call_broker(
 ) -> _BrokerResult:
     try:
         return broker_call(permit)
+    except BrokerMutationExplicitRejection:
+        raise
     except _BROKER_CALLBACK_ERRORS as exc:
         raise BrokerMutationUnresolved(
             f"{scope}_broker_io_unresolved:{receipt_id}:{type(exc).__name__}"
         ) from exc
+
+
+def _settle_linked_broker_rejection(
+    session: Session,
+    *,
+    handle: BrokerMutationReceiptHandle,
+    claim: DecisionSubmissionClaimSnapshot,
+    rejection: BrokerMutationExplicitRejection,
+) -> None:
+    try:
+        settlement = build_linked_submission_terminal_settlement(
+            BrokerMutationLinkedSubmissionSettlementRequest(
+                source="primary",
+                outcome="rejected",
+                claim_handle=claim.handle,
+                broker_status=rejection.broker_status,
+                rejection_code=rejection.rejection_code,
+                broker_reference=None,
+                execution_id=None,
+            )
+        )
+        settle_linked_submission_primary(
+            session,
+            handle=handle,
+            submission_claim_handle=claim.handle,
+            settlement=settlement,
+        )
+    except _TERMINAL_CALLBACK_ERRORS as exc:
+        session.rollback()
+        raise BrokerMutationUnresolved(
+            f"linked_submission_rejection_unresolved:{handle.receipt_id}:"
+            f"{type(exc).__name__}"
+        ) from exc
+
+
+def _settle_unlinked_broker_rejection(
+    session: Session,
+    *,
+    handle: BrokerMutationReceiptHandle,
+    scope: str,
+    rejection: BrokerMutationExplicitRejection,
+) -> None:
+    try:
+        settlement = build_broker_mutation_settlement(
+            BrokerMutationSettlementRequest(
+                source="primary",
+                outcome="rejected",
+                broker_reference=None,
+                execution_id=None,
+                evidence_payload={
+                    "schema_version": ("torghut.broker-mutation-explicit-rejection.v1"),
+                    "broker_status": rejection.broker_status,
+                    "rejection_code": rejection.rejection_code,
+                    "detail": rejection.detail,
+                },
+            )
+        )
+        settle_broker_mutation_primary(
+            session,
+            handle=handle,
+            settlement=settlement,
+        )
+    except _TERMINAL_CALLBACK_ERRORS as exc:
+        session.rollback()
+        raise BrokerMutationUnresolved(
+            f"{scope}_rejection_unresolved:{handle.receipt_id}:{type(exc).__name__}"
+        ) from exc
+
+
+def _broker_rejection_message(
+    scope: str,
+    receipt_id: uuid.UUID,
+    rejection: BrokerMutationExplicitRejection,
+) -> str:
+    return (
+        f"{scope}_broker_rejected:{receipt_id}:"
+        f"{rejection.broker_status}:{rejection.rejection_code}"
+    )
 
 
 def _settle_linked_terminal(

--- a/services/torghut/app/trading/broker_mutation_receipts/__init__.py
+++ b/services/torghut/app/trading/broker_mutation_receipts/__init__.py
@@ -78,6 +78,7 @@ from .types import (
 )
 from .validation import (
     BrokerMutationBrokerIoError,
+    BrokerMutationExplicitRejection,
     BrokerMutationReceiptConflictError,
     BrokerMutationReceiptError,
     BrokerMutationReceiptFenceError,
@@ -101,6 +102,7 @@ __all__ = [
     "BrokerMutationOperation",
     "BrokerMutationPurpose",
     "BrokerMutationBrokerIoError",
+    "BrokerMutationExplicitRejection",
     "BrokerMutationReceiptConflictError",
     "BrokerMutationReceiptAcquireOptions",
     "BrokerMutationReceiptAcquireResult",

--- a/services/torghut/app/trading/broker_mutation_receipts/validation.py
+++ b/services/torghut/app/trading/broker_mutation_receipts/validation.py
@@ -28,6 +28,7 @@ MAX_CANONICAL_NESTING = 32
 
 _SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 _DNS_LABEL = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
+_BROKER_REJECTION_VALUE = re.compile(r"^[a-z0-9][a-z0-9_.:-]*$")
 _SECRET_BEARING_KEY_MARKERS = (
     "apikey",
     "authorization",
@@ -61,6 +62,49 @@ class BrokerMutationReceiptConflictError(BrokerMutationReceiptError):
 
 class BrokerMutationBrokerIoError(RuntimeError):
     """A known broker dependency failed after durable I/O authorization."""
+
+
+class BrokerMutationExplicitRejection(RuntimeError):
+    """The broker definitively refused a mutation without accepting it."""
+
+    def __init__(
+        self,
+        *,
+        broker_status: str,
+        rejection_code: str,
+        detail: str,
+    ) -> None:
+        self.broker_status = _stable_rejection_value(
+            broker_status,
+            field="broker_status",
+            maximum=64,
+        )
+        self.rejection_code = _stable_rejection_value(
+            rejection_code,
+            field="rejection_code",
+            maximum=128,
+        )
+        normalized_detail = " ".join(
+            "".join(
+                character if character.isprintable() else " " for character in detail
+            ).split()
+        )
+        self.detail = (normalized_detail or "broker_request_rejected")[:512]
+        super().__init__(
+            "broker_mutation_explicit_rejection:"
+            f"{self.broker_status}:{self.rejection_code}"
+        )
+
+
+def _stable_rejection_value(value: str, *, field: str, maximum: int) -> str:
+    normalized = str(value).strip().lower()
+    if (
+        not normalized
+        or len(normalized) > maximum
+        or _BROKER_REJECTION_VALUE.fullmatch(normalized) is None
+    ):
+        raise ValueError(f"broker_mutation_{field}_invalid")
+    return normalized
 
 
 def canonical_broker_request_sha256(payload: Mapping[str, object]) -> str:

--- a/services/torghut/app/trading/firewall.py
+++ b/services/torghut/app/trading/firewall.py
@@ -8,7 +8,7 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation
-from typing import Protocol, TypeVar, cast
+from typing import NoReturn, Protocol, TypeVar, cast
 
 from alpaca.common.exceptions import APIError, RetryException
 from requests.exceptions import RequestException
@@ -22,6 +22,7 @@ from ..alpaca_client import (
 from ..config import settings
 from .broker_mutation_receipts import (
     BrokerMutationBrokerIoError,
+    BrokerMutationExplicitRejection,
     BrokerMutationIoPermit,
     BrokerMutationIoPermitExpectation,
     consume_broker_mutation_io_permit,
@@ -55,6 +56,59 @@ _ALPACA_MUTATION_ERRORS = (
     TypeError,
     ValueError,
 )
+_EXPLICIT_ALPACA_REJECTION_STATUSES = frozenset({400, 401, 403, 404, 422})
+
+
+def _raise_alpaca_mutation_error(exc: Exception) -> NoReturn:
+    if isinstance(exc, BrokerMutationExplicitRejection):
+        raise exc
+    if isinstance(exc, APIError):
+        rejection = _explicit_alpaca_rejection(exc)
+        if rejection is not None:
+            raise rejection from exc
+    raise BrokerMutationBrokerIoError(
+        f"alpaca_broker_io_failed:{type(exc).__name__}"
+    ) from exc
+
+
+def _explicit_alpaca_rejection(
+    exc: APIError,
+) -> BrokerMutationExplicitRejection | None:
+    status_code: object = getattr(exc, "status_code", None)
+    if type(status_code) is not int:
+        return None
+    normalized_status = status_code
+    if normalized_status not in _EXPLICIT_ALPACA_REJECTION_STATUSES:
+        return None
+    try:
+        raw_payload: object = json.loads(str(exc))
+    except (TypeError, ValueError):
+        raw_payload = {}
+    payload: Mapping[object, object]
+    if isinstance(raw_payload, Mapping):
+        payload = cast(Mapping[object, object], raw_payload)
+    else:
+        payload = {}
+    return BrokerMutationExplicitRejection(
+        broker_status=f"http_{normalized_status}",
+        rejection_code=_stable_alpaca_rejection_code(
+            payload.get("code"),
+            status_code=normalized_status,
+        ),
+        detail=str(payload.get("message") or "broker_request_rejected"),
+    )
+
+
+def _stable_alpaca_rejection_code(value: object, *, status_code: int) -> str:
+    allowed = frozenset("abcdefghijklmnopqrstuvwxyz0123456789_.:-")
+    raw = str(value or "").strip().lower()
+    normalized = "".join(
+        character if character in allowed else "_" for character in raw
+    )
+    normalized = normalized.strip("_")[:128]
+    if not normalized or normalized[0] not in "abcdefghijklmnopqrstuvwxyz0123456789":
+        return f"http_{status_code}"
+    return normalized
 
 
 class OrderFirewallBlocked(RuntimeError):
@@ -535,18 +589,14 @@ class OrderFirewall:
                 firewall_token=self._token,
             )
         except _ALPACA_MUTATION_ERRORS as exc:
-            raise BrokerMutationBrokerIoError(
-                f"alpaca_broker_io_failed:{type(exc).__name__}"
-            ) from exc
+            _raise_alpaca_mutation_error(exc)
 
     @staticmethod
     def _broker_call(callback: Callable[[], _MutationResult]) -> _MutationResult:
         try:
             return callback()
         except _ALPACA_MUTATION_ERRORS as exc:
-            raise BrokerMutationBrokerIoError(
-                f"alpaca_broker_io_failed:{type(exc).__name__}"
-            ) from exc
+            _raise_alpaca_mutation_error(exc)
 
     def get_order_by_client_order_id(
         self, client_order_id: str

--- a/services/torghut/app/trading/infrastructure_validation.py
+++ b/services/torghut/app/trading/infrastructure_validation.py
@@ -21,7 +21,8 @@ from pydantic import (
 
 _MAX_PERMIT_LIFETIME = timedelta(minutes=15)
 _MAX_SUBMIT_PROOF_NOTIONAL_USD = Decimal("1")
-_MAX_LIFECYCLE_NOTIONAL_USD = Decimal("5")
+_MAX_LIFECYCLE_NOTIONAL_USD = Decimal("30")
+_MIN_LIFECYCLE_LEG_PLAN_NOTIONAL_USD = Decimal("12")
 _VALIDATION_HOSTS = {
     "alpaca": "paper-api.alpaca.markets",
     "hyperliquid": "api.hyperliquid-testnet.xyz",
@@ -284,6 +285,8 @@ def authorize_infrastructure_validation_order(
         or plan.notional_usd > absolute_cap
     ):
         raise ValueError("infrastructure_validation_submit_exceeds_absolute_cap")
+    if isinstance(plan, InfrastructureValidationLifecyclePlan):
+        _validate_lifecycle_leg_plan_notional(plan)
     if infrastructure_validation_plan_sha256(plan) != permit.test_plan_digest:
         raise ValueError("infrastructure_validation_order_plan_digest_mismatch")
     if (
@@ -292,6 +295,21 @@ def authorize_infrastructure_validation_order(
     ):
         raise ValueError("infrastructure_validation_terminal_digest_mismatch")
     return permit
+
+
+def _validate_lifecycle_leg_plan_notional(
+    plan: InfrastructureValidationLifecyclePlan,
+) -> None:
+    residual_quantity = plan.qty - plan.partial_close_qty
+    for field, quantity in (
+        ("partial_close", plan.partial_close_qty),
+        ("residual_close", residual_quantity),
+    ):
+        if quantity * plan.limit_price < _MIN_LIFECYCLE_LEG_PLAN_NOTIONAL_USD:
+            raise ValueError(
+                "infrastructure_validation_"
+                f"{field}_plan_notional_below_broker_cost_basis_floor"
+            )
 
 
 def infrastructure_validation_order_plan_sha256(

--- a/services/torghut/migrations/versions/0073_live_paper_lifecycle_bounds.py
+++ b/services/torghut/migrations/versions/0073_live_paper_lifecycle_bounds.py
@@ -1,0 +1,146 @@
+"""Align the paper lifecycle bound with Alpaca's enforced cost-basis floor.
+
+Revision ID: 0073_live_paper_bounds
+Revises: 0072_validation_lifecycle
+Create Date: 2026-07-15 20:00:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.schema import conv
+
+
+revision = "0073_live_paper_bounds"
+down_revision = "0072_validation_lifecycle"
+branch_labels = None
+depends_on = None
+
+
+_CONSTRAINT = "ck_bm_receipt_validation_authority"
+_OLD_CAP = 5
+_NEW_CAP = 30
+_LIFECYCLE_SCHEMA = "torghut.infrastructure-validation-lifecycle-plan.v1"
+
+
+def _cap_fragment(field: str, cap: int) -> str:
+    return (
+        "((canonical_intent_json::jsonb #>> "
+        f"'{{request,infrastructure_validation,permit,{field}}}'::text[])::numeric) "
+        f"<= {cap}::numeric"
+    )
+
+
+def _replace_lifecycle_cap(definition: str, *, old_cap: int, new_cap: int) -> str:
+    prefix = "CHECK ("
+    if not definition.startswith(prefix) or not definition.endswith(")"):
+        raise RuntimeError("validation_authority_constraint_shape_invalid")
+    condition = definition[len(prefix) : -1]
+    if condition.count(_LIFECYCLE_SCHEMA) != 1:
+        raise RuntimeError("validation_authority_lifecycle_schema_invalid")
+    for field in ("max_notional_usd", "max_loss_usd"):
+        old_fragment = _cap_fragment(field, old_cap)
+        if condition.count(old_fragment) != 1:
+            raise RuntimeError(f"validation_authority_{field}_cap_invalid")
+        condition = condition.replace(
+            old_fragment,
+            _cap_fragment(field, new_cap),
+            1,
+        )
+    return condition
+
+
+def _current_constraint_definition() -> str:
+    definition = (
+        op.get_bind()
+        .execute(
+            sa.text(
+                """
+            SELECT pg_get_constraintdef(oid, true)
+              FROM pg_constraint
+             WHERE conrelid = 'broker_mutation_receipts'::regclass
+               AND conname = :constraint_name
+            """
+            ),
+            {"constraint_name": _CONSTRAINT},
+        )
+        .scalar_one_or_none()
+    )
+    if not isinstance(definition, str):
+        raise RuntimeError("validation_authority_constraint_missing")
+    return definition
+
+
+def _install_constraint(condition: str) -> None:
+    op.drop_constraint(conv(_CONSTRAINT), "broker_mutation_receipts", type_="check")
+    op.execute(
+        sa.text(
+            f"""
+            ALTER TABLE broker_mutation_receipts
+              ADD CONSTRAINT {_CONSTRAINT} CHECK ({condition}) NOT VALID
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            f"""
+            ALTER TABLE broker_mutation_receipts
+              VALIDATE CONSTRAINT {_CONSTRAINT}
+            """
+        )
+    )
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text("LOCK TABLE broker_mutation_receipts IN ACCESS EXCLUSIVE MODE NOWAIT")
+    )
+    condition = _replace_lifecycle_cap(
+        _current_constraint_definition(),
+        old_cap=_OLD_CAP,
+        new_cap=_NEW_CAP,
+    )
+    _install_constraint(condition)
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text("LOCK TABLE broker_mutation_receipts IN ACCESS EXCLUSIVE MODE NOWAIT")
+    )
+    op.execute(
+        sa.text(
+            f"""
+            DO $torghut$
+            BEGIN
+                IF EXISTS (
+                    SELECT 1
+                      FROM broker_mutation_receipts
+                     WHERE purpose = 'control_plane_validation'
+                       AND canonical_intent_json::jsonb #>>
+                           '{{request,infrastructure_validation,test_plan,schema_version}}' =
+                           '{_LIFECYCLE_SCHEMA}'
+                       AND (
+                           (canonical_intent_json::jsonb #>>
+                            '{{request,infrastructure_validation,permit,max_notional_usd}}')::numeric
+                           > {_OLD_CAP}
+                           OR
+                           (canonical_intent_json::jsonb #>>
+                            '{{request,infrastructure_validation,permit,max_loss_usd}}')::numeric
+                           > {_OLD_CAP}
+                       )
+                ) THEN
+                    RAISE EXCEPTION
+                        'cannot downgrade with lifecycle receipts above the old cap';
+                END IF;
+            END
+            $torghut$;
+            """
+        )
+    )
+    condition = _replace_lifecycle_cap(
+        _current_constraint_definition(),
+        old_cap=_NEW_CAP,
+        new_cap=_OLD_CAP,
+    )
+    _install_constraint(condition)

--- a/services/torghut/migrations/versions/0073_live_paper_lifecycle_bounds.py
+++ b/services/torghut/migrations/versions/0073_live_paper_lifecycle_bounds.py
@@ -21,18 +21,51 @@ depends_on = None
 _CONSTRAINT = "ck_bm_receipt_validation_authority"
 _OLD_CAP = 5
 _NEW_CAP = 30
+_MIN_LEG_NOTIONAL = 12
 _LIFECYCLE_SCHEMA = "torghut.infrastructure-validation-lifecycle-plan.v1"
 
 
-def _cap_fragment(field: str, cap: int) -> str:
+def _numeric_plan_field(field: str) -> str:
     return (
         "((canonical_intent_json::jsonb #>> "
-        f"'{{request,infrastructure_validation,permit,{field}}}'::text[])::numeric) "
-        f"<= {cap}::numeric"
+        f"'{{request,infrastructure_validation,test_plan,{field}}}'::text[])::numeric)"
     )
 
 
-def _replace_lifecycle_cap(definition: str, *, old_cap: int, new_cap: int) -> str:
+def _numeric_permit_field(field: str) -> str:
+    return (
+        "((canonical_intent_json::jsonb #>> "
+        f"'{{request,infrastructure_validation,permit,{field}}}'::text[])::numeric)"
+    )
+
+
+def _cap_fragment(field: str, cap: int) -> str:
+    return f"{_numeric_permit_field(field)} <= {cap}::numeric"
+
+
+def _partial_close_bound_fragment() -> str:
+    return f"{_numeric_plan_field('partial_close_qty')} < {_numeric_plan_field('qty')}"
+
+
+def _leg_floor_fragments() -> tuple[str, str]:
+    limit_price = _numeric_plan_field("limit_price")
+    partial_close = _numeric_plan_field("partial_close_qty")
+    residual_close = (
+        f"({_numeric_plan_field('qty')} - {_numeric_plan_field('partial_close_qty')})"
+    )
+    return (
+        f"({partial_close} * {limit_price}) >= {_MIN_LEG_NOTIONAL}::numeric",
+        f"({residual_close} * {limit_price}) >= {_MIN_LEG_NOTIONAL}::numeric",
+    )
+
+
+def _rewrite_lifecycle_authority(
+    definition: str,
+    *,
+    old_cap: int,
+    new_cap: int,
+    add_leg_floors: bool,
+) -> str:
     prefix = "CHECK ("
     if not definition.startswith(prefix) or not definition.endswith(")"):
         raise RuntimeError("validation_authority_constraint_shape_invalid")
@@ -48,6 +81,21 @@ def _replace_lifecycle_cap(definition: str, *, old_cap: int, new_cap: int) -> st
             _cap_fragment(field, new_cap),
             1,
         )
+    partial_bound = _partial_close_bound_fragment()
+    floor_clause = " AND ".join(_leg_floor_fragments())
+    if add_leg_floors:
+        if condition.count(partial_bound) != 1 or floor_clause in condition:
+            raise RuntimeError("validation_authority_leg_floor_shape_invalid")
+        condition = condition.replace(
+            partial_bound,
+            f"{partial_bound} AND {floor_clause}",
+            1,
+        )
+    else:
+        bounded_floor_clause = f"{partial_bound} AND {floor_clause}"
+        if condition.count(bounded_floor_clause) != 1:
+            raise RuntimeError("validation_authority_leg_floor_shape_invalid")
+        condition = condition.replace(bounded_floor_clause, partial_bound, 1)
     return condition
 
 
@@ -96,10 +144,11 @@ def upgrade() -> None:
     op.execute(
         sa.text("LOCK TABLE broker_mutation_receipts IN ACCESS EXCLUSIVE MODE NOWAIT")
     )
-    condition = _replace_lifecycle_cap(
+    condition = _rewrite_lifecycle_authority(
         _current_constraint_definition(),
         old_cap=_OLD_CAP,
         new_cap=_NEW_CAP,
+        add_leg_floors=True,
     )
     _install_constraint(condition)
 
@@ -138,9 +187,10 @@ def downgrade() -> None:
             """
         )
     )
-    condition = _replace_lifecycle_cap(
+    condition = _rewrite_lifecycle_authority(
         _current_constraint_definition(),
         old_cap=_NEW_CAP,
         new_cap=_OLD_CAP,
+        add_leg_floors=False,
     )
     _install_constraint(condition)

--- a/services/torghut/tests/execution/infrastructure_validation_postgres_support.py
+++ b/services/torghut/tests/execution/infrastructure_validation_postgres_support.py
@@ -14,8 +14,10 @@ from app.trading.broker_mutation_receipts import (
     build_broker_mutation_settlement,
 )
 from app.trading.infrastructure_validation import (
+    InfrastructureValidationLifecyclePlan,
     InfrastructureValidationOrderPlan,
     InfrastructureValidationPermit,
+    infrastructure_validation_lifecycle_plan_sha256,
     infrastructure_validation_order_plan_sha256,
     infrastructure_validation_terminal_state_sha256,
 )
@@ -96,6 +98,65 @@ def validation_fixture(
         ),
         plan,
     )
+
+
+def validation_lifecycle_fixture(
+    now: datetime,
+    *,
+    permit_id: str = "ivp-postgres-lifecycle",
+    partial_close_qty: str = "0.0002",
+) -> tuple[InfrastructureValidationPermit, InfrastructureValidationLifecyclePlan]:
+    plan = InfrastructureValidationLifecyclePlan.model_validate(
+        {
+            "schema_version": "torghut.infrastructure-validation-lifecycle-plan.v1",
+            "venue": "alpaca",
+            "asset_class": "crypto",
+            "symbol": "BTC/USD",
+            "side": "buy",
+            "qty": "0.0004",
+            "order_type": "limit",
+            "time_in_force": "ioc",
+            "limit_price": "70000",
+            "stop_price": None,
+            "resting_close_limit_price": "130000",
+            "replacement_close_limit_price": "140000",
+            "partial_close_qty": partial_close_qty,
+        }
+    )
+    permit = InfrastructureValidationPermit.model_validate(
+        {
+            "schema_version": "torghut.infrastructure-validation-permit.v2",
+            "permit_id": permit_id,
+            "purpose": "control_plane_validation",
+            "venue": "alpaca",
+            "asset_class": "crypto",
+            "account_mode": "paper",
+            "market_session": "continuous",
+            "account_label": "paper",
+            "broker_base_url": "https://paper-api.alpaca.markets",
+            "symbols": ["BTC/USD"],
+            "sides": ["buy"],
+            "order_types": ["limit"],
+            "max_orders": 1,
+            "max_outstanding_intents": 1,
+            "max_notional_usd": "30",
+            "max_loss_usd": "30",
+            "issued_by": "infrastructure-owner",
+            "approved_by": "independent-infrastructure-owner",
+            "issued_at": now - timedelta(seconds=1),
+            "expires_at": now + timedelta(minutes=5),
+            "test_plan_digest": infrastructure_validation_lifecycle_plan_sha256(plan),
+            "expected_terminal_state": (
+                "no_open_orders_no_positions_no_unsettled_claims"
+            ),
+            "expected_terminal_state_digest": (
+                infrastructure_validation_terminal_state_sha256()
+            ),
+            "evidence_tag": "non_promotable_validation",
+            "promotable": False,
+        }
+    )
+    return permit, plan
 
 
 def validation_settlement(

--- a/services/torghut/tests/execution/infrastructure_validation_postgres_support.py
+++ b/services/torghut/tests/execution/infrastructure_validation_postgres_support.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime, timedelta
+
+from alembic import command
+from alembic.config import Config as AlembicConfig
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+from app.trading.broker_mutation_receipts import (
+    BrokerMutationSettlement,
+    BrokerMutationSettlementRequest,
+    build_broker_mutation_settlement,
+)
+from app.trading.infrastructure_validation import (
+    InfrastructureValidationOrderPlan,
+    InfrastructureValidationPermit,
+    infrastructure_validation_order_plan_sha256,
+    infrastructure_validation_terminal_state_sha256,
+)
+
+
+def upgrade_validation_submit_schema(
+    alembic: AlembicConfig,
+    schema_engine: Engine,
+) -> None:
+    """Apply the accelerated receipt lineage with its historical catalog prerequisite."""
+
+    command.stamp(alembic, "0057_generic_multifactor_machine")
+    command.upgrade(alembic, "0061_linked_submission_terminal")
+    command.stamp(alembic, "0065_strategy_capital_compat")
+    with schema_engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                CREATE TABLE torghut_options_contract_catalog (
+                    contract_symbol TEXT PRIMARY KEY,
+                    status TEXT NOT NULL
+                )
+                """
+            )
+        )
+    command.upgrade(alembic, "0068_validation_submit")
+
+
+def validation_fixture(
+    now: datetime,
+    *,
+    permit_id: str = "ivp-postgres-one",
+    symbol: str = "BTC/USD",
+) -> tuple[InfrastructureValidationPermit, InfrastructureValidationOrderPlan]:
+    plan = InfrastructureValidationOrderPlan.model_validate(
+        {
+            "schema_version": "torghut.infrastructure-validation-order-plan.v1",
+            "venue": "alpaca",
+            "asset_class": "crypto",
+            "symbol": symbol,
+            "side": "buy",
+            "qty": "1",
+            "order_type": "limit",
+            "time_in_force": "ioc",
+            "limit_price": "1",
+            "stop_price": None,
+        }
+    )
+    return (
+        InfrastructureValidationPermit.model_validate(
+            {
+                "schema_version": "torghut.infrastructure-validation-permit.v2",
+                "permit_id": permit_id,
+                "purpose": "control_plane_validation",
+                "venue": "alpaca",
+                "asset_class": "crypto",
+                "account_mode": "paper",
+                "market_session": "continuous",
+                "account_label": "dedicated-validation-paper",
+                "broker_base_url": "https://paper-api.alpaca.markets",
+                "symbols": [symbol],
+                "sides": ["buy"],
+                "order_types": ["limit"],
+                "max_orders": 1,
+                "max_outstanding_intents": 1,
+                "max_notional_usd": "1",
+                "max_loss_usd": "1",
+                "issued_by": "infrastructure-owner",
+                "approved_by": "independent-infrastructure-owner",
+                "issued_at": now - timedelta(seconds=1),
+                "expires_at": now + timedelta(minutes=5),
+                "test_plan_digest": infrastructure_validation_order_plan_sha256(plan),
+                "expected_terminal_state": "no_open_orders_no_positions_no_unsettled_claims",
+                "expected_terminal_state_digest": infrastructure_validation_terminal_state_sha256(),
+                "evidence_tag": "non_promotable_validation",
+                "promotable": False,
+            }
+        ),
+        plan,
+    )
+
+
+def validation_settlement(
+    result: Mapping[str, object],
+) -> BrokerMutationSettlement:
+    return build_broker_mutation_settlement(
+        BrokerMutationSettlementRequest(
+            source="primary",
+            outcome="acknowledged",
+            broker_reference=str(result.get("id") or "validation-rejected"),
+            execution_id=None,
+            evidence_payload={
+                "schema_version": "torghut.infrastructure-validation-submit-terminal.v1",
+                "evidence_tag": "non_promotable_validation",
+                "promotable": False,
+                "broker_status": str(result.get("status") or "unknown"),
+            },
+        )
+    )

--- a/services/torghut/tests/execution/test_broker_mutation_coordinator_postgres.py
+++ b/services/torghut/tests/execution/test_broker_mutation_coordinator_postgres.py
@@ -5,7 +5,7 @@ import json
 import uuid
 from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from decimal import Decimal
 from threading import Barrier, Event, Lock
 from typing import cast
@@ -14,7 +14,6 @@ import pytest
 from alembic import command
 from alembic.config import Config as AlembicConfig
 from sqlalchemy import select, text
-from sqlalchemy.engine import Engine
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -56,9 +55,7 @@ from app.trading.infrastructure_validation import (
     InfrastructureValidationPermit,
     authorize_infrastructure_validation_order,
     infrastructure_validation_client_order_id,
-    infrastructure_validation_order_plan_sha256,
     infrastructure_validation_request_payload,
-    infrastructure_validation_terminal_state_sha256,
 )
 from app.trading.infrastructure_validation_submit import (
     InfrastructureValidationSubmitContext,
@@ -71,29 +68,11 @@ from tests.execution.decision_submission_claims_postgres_support import (
     drop_schema,
     insert_decision,
 )
-
-
-def _upgrade_validation_submit_schema(
-    alembic: AlembicConfig,
-    schema_engine: Engine,
-) -> None:
-    """Apply the accelerated receipt lineage with its historical catalog prerequisite."""
-
-    command.stamp(alembic, "0057_generic_multifactor_machine")
-    command.upgrade(alembic, "0061_linked_submission_terminal")
-    command.stamp(alembic, "0065_strategy_capital_compat")
-    with schema_engine.begin() as connection:
-        connection.execute(
-            text(
-                """
-                CREATE TABLE torghut_options_contract_catalog (
-                    contract_symbol TEXT PRIMARY KEY,
-                    status TEXT NOT NULL
-                )
-                """
-            )
-        )
-    command.upgrade(alembic, "0068_validation_submit")
+from tests.execution.infrastructure_validation_postgres_support import (
+    upgrade_validation_submit_schema,
+    validation_fixture,
+    validation_settlement,
+)
 
 
 @pytest.mark.skipif(
@@ -383,7 +362,7 @@ def test_postgres_validation_permit_race_makes_one_non_promotable_broker_call(
         future=True,
     )
     now = datetime.now(timezone.utc)
-    permit, plan = _validation_fixture(now)
+    permit, plan = validation_fixture(now)
     request = InfrastructureValidationOrderSubmission(
         permit=permit,
         plan=plan,
@@ -418,13 +397,13 @@ def test_postgres_validation_permit_race_makes_one_non_promotable_broker_call(
     callbacks = UnlinkedMutationCallbacks(
         broker_call=broker_call,
         persist_terminal=lambda _result: None,
-        build_settlement=_validation_settlement,
+        build_settlement=validation_settlement,
     )
 
     try:
         monkeypatch.setattr(settings, "db_dsn", schema_dsn)
         alembic = AlembicConfig(str(SERVICE_ROOT / "alembic.ini"))
-        _upgrade_validation_submit_schema(alembic, schema_engine)
+        upgrade_validation_submit_schema(alembic, schema_engine)
 
         def run(component: str) -> str:
             with sessions() as session:
@@ -487,7 +466,7 @@ def test_postgres_validation_permit_race_makes_one_non_promotable_broker_call(
             "acknowledged",
         )
 
-        reused_permit, reused_plan = _validation_fixture(
+        reused_permit, reused_plan = validation_fixture(
             now,
             permit_id=permit.permit_id,
             symbol="ETH/USD",
@@ -514,7 +493,7 @@ def test_postgres_validation_permit_race_makes_one_non_promotable_broker_call(
 
 def test_control_plane_validation_cannot_use_generic_unlinked_entrypoint() -> None:
     now = datetime.now(timezone.utc)
-    permit, plan = _validation_fixture(now)
+    permit, plan = validation_fixture(now)
     request_payload = infrastructure_validation_request_payload(permit, plan)
     intent = build_broker_mutation_intent(
         BrokerMutationIntentRequest(
@@ -543,7 +522,7 @@ def test_control_plane_validation_cannot_use_generic_unlinked_entrypoint() -> No
             callbacks=UnlinkedMutationCallbacks(
                 broker_call=lambda _permit: {},
                 persist_terminal=lambda _result: None,
-                build_settlement=_validation_settlement,
+                build_settlement=validation_settlement,
             ),
         )
 
@@ -559,7 +538,7 @@ def test_postgres_validation_authority_rejects_forged_or_incomplete_intents(
         "validation_authority"
     )
     now = datetime.now(timezone.utc)
-    permit, plan = _validation_fixture(now, permit_id="ivp-authority-test")
+    permit, plan = validation_fixture(now, permit_id="ivp-authority-test")
     client_order_id = infrastructure_validation_client_order_id(permit, plan)
     intent = build_broker_mutation_intent(
         BrokerMutationIntentRequest(
@@ -578,7 +557,7 @@ def test_postgres_validation_authority_rejects_forged_or_incomplete_intents(
     try:
         monkeypatch.setattr(settings, "db_dsn", schema_dsn)
         alembic = AlembicConfig(str(SERVICE_ROOT / "alembic.ini"))
-        _upgrade_validation_submit_schema(alembic, schema_engine)
+        upgrade_validation_submit_schema(alembic, schema_engine)
 
         base_document = json.loads(intent.canonical_intent_json)
         forged_documents: list[dict[str, object]] = []
@@ -672,7 +651,7 @@ def test_postgres_validation_runner_proves_known_null_terminal_state(
         future=True,
     )
     now = datetime.now(timezone.utc)
-    permit, plan = _validation_fixture(now, permit_id="ivp-runner-one")
+    permit, plan = validation_fixture(now, permit_id="ivp-runner-one")
     client = _FakeValidationAlpacaClient()
     observed_authorization_times: list[datetime] = []
 
@@ -707,7 +686,7 @@ def test_postgres_validation_runner_proves_known_null_terminal_state(
         monkeypatch.setattr(settings, "db_dsn", schema_dsn)
         monkeypatch.setattr(settings, "trading_kill_switch_enabled", False)
         alembic = AlembicConfig(str(SERVICE_ROOT / "alembic.ini"))
-        _upgrade_validation_submit_schema(alembic, schema_engine)
+        upgrade_validation_submit_schema(alembic, schema_engine)
         with schema_engine.begin() as connection:
             connection.execute(
                 text(
@@ -824,79 +803,6 @@ class _FakeValidationAlpacaClient:
         }
         self.submissions.append(order)
         return order
-
-
-def _validation_fixture(
-    now: datetime,
-    *,
-    permit_id: str = "ivp-postgres-one",
-    symbol: str = "BTC/USD",
-) -> tuple[InfrastructureValidationPermit, InfrastructureValidationOrderPlan]:
-    plan = InfrastructureValidationOrderPlan.model_validate(
-        {
-            "schema_version": "torghut.infrastructure-validation-order-plan.v1",
-            "venue": "alpaca",
-            "asset_class": "crypto",
-            "symbol": symbol,
-            "side": "buy",
-            "qty": "1",
-            "order_type": "limit",
-            "time_in_force": "ioc",
-            "limit_price": "1",
-            "stop_price": None,
-        }
-    )
-    return (
-        InfrastructureValidationPermit.model_validate(
-            {
-                "schema_version": "torghut.infrastructure-validation-permit.v2",
-                "permit_id": permit_id,
-                "purpose": "control_plane_validation",
-                "venue": "alpaca",
-                "asset_class": "crypto",
-                "account_mode": "paper",
-                "market_session": "continuous",
-                "account_label": "dedicated-validation-paper",
-                "broker_base_url": "https://paper-api.alpaca.markets",
-                "symbols": [symbol],
-                "sides": ["buy"],
-                "order_types": ["limit"],
-                "max_orders": 1,
-                "max_outstanding_intents": 1,
-                "max_notional_usd": "1",
-                "max_loss_usd": "1",
-                "issued_by": "infrastructure-owner",
-                "approved_by": "independent-infrastructure-owner",
-                "issued_at": now - timedelta(seconds=1),
-                "expires_at": now + timedelta(minutes=5),
-                "test_plan_digest": infrastructure_validation_order_plan_sha256(plan),
-                "expected_terminal_state": "no_open_orders_no_positions_no_unsettled_claims",
-                "expected_terminal_state_digest": infrastructure_validation_terminal_state_sha256(),
-                "evidence_tag": "non_promotable_validation",
-                "promotable": False,
-            }
-        ),
-        plan,
-    )
-
-
-def _validation_settlement(
-    result: Mapping[str, object],
-) -> BrokerMutationSettlement:
-    return build_broker_mutation_settlement(
-        BrokerMutationSettlementRequest(
-            source="primary",
-            outcome="acknowledged",
-            broker_reference=str(result.get("id") or "validation-rejected"),
-            execution_id=None,
-            evidence_payload={
-                "schema_version": "torghut.infrastructure-validation-submit-terminal.v1",
-                "evidence_tag": "non_promotable_validation",
-                "promotable": False,
-                "broker_status": str(result.get("status") or "unknown"),
-            },
-        )
-    )
 
 
 def _persist_execution(

--- a/services/torghut/tests/execution/test_broker_mutation_rejection_postgres.py
+++ b/services/torghut/tests/execution/test_broker_mutation_rejection_postgres.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime, timezone
+
+import pytest
+from alembic.config import Config as AlembicConfig
+from sqlalchemy import select
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.config import settings
+from app.models import BrokerMutationReceiptEvent
+from app.trading.broker_mutation_receipts import (
+    BrokerMutationExplicitRejection,
+    BrokerMutationIoPermit,
+    BrokerMutationSettlement,
+    validate_broker_mutation_io_permit,
+)
+from app.trading.broker_mutation_coordinator import (
+    BrokerMutationAlreadyProcessed,
+    BrokerMutationCoordinator,
+    BrokerMutationRejected,
+    InfrastructureValidationOrderSubmission,
+    UnlinkedMutationCallbacks,
+)
+from tests.execution.decision_submission_claims_postgres_support import (
+    POSTGRES_DSN,
+    SERVICE_ROOT,
+    create_schema_engines,
+    drop_schema,
+)
+from tests.execution.infrastructure_validation_postgres_support import (
+    upgrade_validation_submit_schema,
+    validation_fixture,
+)
+
+
+@pytest.mark.skipif(
+    not POSTGRES_DSN,
+    reason="set TORGHUT_TEST_POSTGRES_DSN for explicit rejection settlement",
+)
+def test_postgres_validation_explicit_rejection_is_terminal_and_not_retried(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    schema, admin_engine, schema_engine, schema_dsn = create_schema_engines(
+        "validation_rejection"
+    )
+    sessions = sessionmaker(
+        bind=schema_engine,
+        class_=Session,
+        autoflush=False,
+        expire_on_commit=False,
+        future=True,
+    )
+    now = datetime.now(timezone.utc)
+    permit, plan = validation_fixture(now, permit_id="ivp-explicit-rejection")
+    request = InfrastructureValidationOrderSubmission(
+        permit=permit,
+        plan=plan,
+        account_label=permit.account_label,
+        endpoint_url="https://paper-api.alpaca.markets",
+    )
+    calls = 0
+
+    def broker_call(permit_to_consume: BrokerMutationIoPermit) -> Mapping[str, object]:
+        nonlocal calls
+        validate_broker_mutation_io_permit(permit_to_consume)
+        calls += 1
+        raise BrokerMutationExplicitRejection(
+            broker_status="http_403",
+            rejection_code="40310000",
+            detail="cost basis below broker minimum",
+        )
+
+    def forbidden_success(_result: Mapping[str, object]) -> None:
+        raise AssertionError("rejection must not run success persistence")
+
+    def forbidden_settlement(
+        _result: Mapping[str, object],
+    ) -> BrokerMutationSettlement:
+        raise AssertionError("rejection must use coordinator settlement")
+
+    callbacks = UnlinkedMutationCallbacks(
+        broker_call=broker_call,
+        persist_terminal=forbidden_success,
+        build_settlement=forbidden_settlement,
+    )
+    try:
+        monkeypatch.setattr(settings, "db_dsn", schema_dsn)
+        alembic = AlembicConfig(str(SERVICE_ROOT / "alembic.ini"))
+        upgrade_validation_submit_schema(alembic, schema_engine)
+
+        with (
+            sessions() as session,
+            pytest.raises(
+                BrokerMutationRejected,
+                match="unlinked_submission_broker_rejected.*40310000",
+            ),
+        ):
+            BrokerMutationCoordinator(
+                "validation-rejection"
+            ).submit_infrastructure_validation_order(
+                session,
+                request=request,
+                callbacks=callbacks,
+                now=now,
+            )
+
+        with sessions() as session, pytest.raises(BrokerMutationAlreadyProcessed):
+            BrokerMutationCoordinator(
+                "validation-rejection-replay"
+            ).submit_infrastructure_validation_order(
+                session,
+                request=request,
+                callbacks=callbacks,
+                now=now,
+            )
+
+        with sessions() as session:
+            latest = session.execute(
+                select(BrokerMutationReceiptEvent)
+                .order_by(BrokerMutationReceiptEvent.sequence_no.desc())
+                .limit(1)
+            ).scalar_one()
+        assert calls == 1
+        assert (
+            latest.state,
+            latest.settlement_source,
+            latest.settlement_outcome,
+            latest.broker_reference,
+        ) == ("settled", "primary", "rejected", None)
+    finally:
+        drop_schema(schema, admin_engine, schema_engine)

--- a/services/torghut/tests/execution/test_broker_reduction_coordinator_postgres.py
+++ b/services/torghut/tests/execution/test_broker_reduction_coordinator_postgres.py
@@ -82,7 +82,10 @@ def _upgrade_reduction_schema(
                 """
             )
         )
-        if target == "0072_validation_lifecycle":
+        if target in {
+            "0072_validation_lifecycle",
+            "0073_live_paper_bounds",
+        }:
             connection.execute(
                 text(
                     """
@@ -456,7 +459,7 @@ def test_postgres_lifecycle_close_requires_reconciled_position_and_fill_receipt(
         _upgrade_reduction_schema(
             alembic,
             schema_engine,
-            target="0072_validation_lifecycle",
+            target="0073_live_paper_bounds",
         )
         evidence = _seed_validation_lifecycle_root(sessions)
         lineage = infrastructure_validation_lineage_payload(evidence)
@@ -675,14 +678,14 @@ def _seed_validation_lifecycle_root(
             "asset_class": "crypto",
             "symbol": "BTC/USD",
             "side": "buy",
-            "qty": "0.00002",
+            "qty": "0.0004",
             "order_type": "limit",
             "time_in_force": "ioc",
-            "limit_price": "100000",
+            "limit_price": "70000",
             "stop_price": None,
-            "resting_close_limit_price": "200000",
-            "replacement_close_limit_price": "210000",
-            "partial_close_qty": "0.00001",
+            "resting_close_limit_price": "130000",
+            "replacement_close_limit_price": "140000",
+            "partial_close_qty": "0.0002",
         }
     )
     permit = InfrastructureValidationPermit.model_validate(
@@ -701,8 +704,8 @@ def _seed_validation_lifecycle_root(
             "order_types": ["limit"],
             "max_orders": 1,
             "max_outstanding_intents": 1,
-            "max_notional_usd": "5",
-            "max_loss_usd": "5",
+            "max_notional_usd": "30",
+            "max_loss_usd": "30",
             "issued_by": "infrastructure-owner",
             "approved_by": "independent-infrastructure-owner",
             "issued_at": now - timedelta(seconds=1),

--- a/services/torghut/tests/execution/test_broker_reduction_coordinator_postgres.py
+++ b/services/torghut/tests/execution/test_broker_reduction_coordinator_postgres.py
@@ -31,14 +31,14 @@ from app.trading.broker_mutation_receipts import (
     BrokerMutationTarget,
     build_broker_mutation_intent,
     build_broker_mutation_settlement,
+    fingerprint_broker_endpoint,
 )
 from app.trading.infrastructure_validation import (
-    InfrastructureValidationLifecyclePlan,
     InfrastructureValidationOrderPlan,
     InfrastructureValidationPermit,
     infrastructure_validation_client_order_id,
-    infrastructure_validation_lifecycle_plan_sha256,
     infrastructure_validation_order_plan_sha256,
+    infrastructure_validation_request_payload,
     infrastructure_validation_terminal_state_sha256,
 )
 from app.trading.infrastructure_validation_records import (
@@ -59,6 +59,9 @@ from tests.execution.decision_submission_claims_postgres_support import (
     SERVICE_ROOT,
     create_schema_engines,
     drop_schema,
+)
+from tests.execution.infrastructure_validation_postgres_support import (
+    validation_lifecycle_fixture,
 )
 
 
@@ -461,6 +464,50 @@ def test_postgres_lifecycle_close_requires_reconciled_position_and_fill_receipt(
             schema_engine,
             target="0073_live_paper_bounds",
         )
+        for permit_suffix, partial_close_qty in (
+            ("partial", "0.00001"),
+            ("residual", "0.00039"),
+        ):
+            invalid_permit, invalid_plan = validation_lifecycle_fixture(
+                datetime.now(timezone.utc),
+                permit_id=f"ivp-postgres-lifecycle-forged-{permit_suffix}",
+                partial_close_qty=partial_close_qty,
+            )
+            invalid_client_order_id = infrastructure_validation_client_order_id(
+                invalid_permit,
+                invalid_plan,
+            )
+            invalid_intent = build_broker_mutation_intent(
+                BrokerMutationIntentRequest(
+                    broker_route="alpaca",
+                    account_label=invalid_permit.account_label,
+                    endpoint_fingerprint=fingerprint_broker_endpoint(
+                        str(invalid_permit.broker_base_url)
+                    ),
+                    operation="submit_order",
+                    risk_class="risk_neutral",
+                    purpose="control_plane_validation",
+                    workflow_id=invalid_client_order_id,
+                    client_request_id=invalid_client_order_id,
+                    target=BrokerMutationTarget(
+                        kind="order",
+                        key=invalid_client_order_id,
+                    ),
+                    request_payload=infrastructure_validation_request_payload(
+                        invalid_permit,
+                        invalid_plan,
+                    ),
+                )
+            )
+            with sessions() as session:
+                session.add(_receipt_from_intent(invalid_intent))
+                with pytest.raises(IntegrityError) as captured:
+                    session.commit()
+            assert (
+                captured.value.orig.diag.constraint_name
+                == "ck_bm_receipt_validation_authority"
+            )
+
         evidence = _seed_validation_lifecycle_root(sessions)
         lineage = infrastructure_validation_lineage_payload(evidence)
         authorization = _submit_close_authorization(
@@ -671,56 +718,7 @@ def _seed_validation_lifecycle_root(
     sessions: sessionmaker[Session],
 ) -> object:
     now = datetime.now(timezone.utc)
-    plan = InfrastructureValidationLifecyclePlan.model_validate(
-        {
-            "schema_version": "torghut.infrastructure-validation-lifecycle-plan.v1",
-            "venue": "alpaca",
-            "asset_class": "crypto",
-            "symbol": "BTC/USD",
-            "side": "buy",
-            "qty": "0.0004",
-            "order_type": "limit",
-            "time_in_force": "ioc",
-            "limit_price": "70000",
-            "stop_price": None,
-            "resting_close_limit_price": "130000",
-            "replacement_close_limit_price": "140000",
-            "partial_close_qty": "0.0002",
-        }
-    )
-    permit = InfrastructureValidationPermit.model_validate(
-        {
-            "schema_version": "torghut.infrastructure-validation-permit.v2",
-            "permit_id": "ivp-postgres-lifecycle",
-            "purpose": "control_plane_validation",
-            "venue": "alpaca",
-            "asset_class": "crypto",
-            "account_mode": "paper",
-            "market_session": "continuous",
-            "account_label": "paper",
-            "broker_base_url": "https://paper-api.alpaca.markets",
-            "symbols": ["BTC/USD"],
-            "sides": ["buy"],
-            "order_types": ["limit"],
-            "max_orders": 1,
-            "max_outstanding_intents": 1,
-            "max_notional_usd": "30",
-            "max_loss_usd": "30",
-            "issued_by": "infrastructure-owner",
-            "approved_by": "independent-infrastructure-owner",
-            "issued_at": now - timedelta(seconds=1),
-            "expires_at": now + timedelta(minutes=5),
-            "test_plan_digest": infrastructure_validation_lifecycle_plan_sha256(plan),
-            "expected_terminal_state": (
-                "no_open_orders_no_positions_no_unsettled_claims"
-            ),
-            "expected_terminal_state_digest": (
-                infrastructure_validation_terminal_state_sha256()
-            ),
-            "evidence_tag": "non_promotable_validation",
-            "promotable": False,
-        }
-    )
+    permit, plan = validation_lifecycle_fixture(now)
     with sessions() as session:
         BrokerMutationCoordinator(
             "validation-lifecycle-pg"

--- a/services/torghut/tests/test_alpaca_client.py
+++ b/services/torghut/tests/test_alpaca_client.py
@@ -20,7 +20,10 @@ from app.alpaca_client import (
 from app.alpaca_client import OrderFirewallToken
 from app.config import settings
 from app.trading.firewall import OrderFirewall
-from app.trading.broker_mutation_receipts import BrokerMutationBrokerIoError
+from app.trading.broker_mutation_receipts import (
+    BrokerMutationBrokerIoError,
+    BrokerMutationExplicitRejection,
+)
 from tests.broker_mutation_test_support import alpaca_broker_mutation_test_permit
 
 
@@ -636,7 +639,7 @@ class TestAlpacaClient(TestCase):
     def test_service_created_trading_client_makes_one_broker_mutation_attempt(
         self,
     ) -> None:
-        for status_code in (429, 504):
+        for status_code in (409, 429, 504):
             with self.subTest(status_code=status_code):
                 client = TorghutAlpacaClient(
                     api_key="k",
@@ -677,6 +680,48 @@ class TestAlpacaClient(TestCase):
                 mock_request.assert_called_once()
                 self.assertEqual(mock_request.call_args.args[0], "POST")
                 mock_sleep.assert_not_called()
+
+    def test_explicit_http_403_is_a_terminal_broker_rejection(self) -> None:
+        client = TorghutAlpacaClient(
+            api_key="k",
+            secret_key="s",
+            base_url="https://paper-api.alpaca.markets",
+            data_client=DummyDataClient(),
+        )
+        response = Mock(spec=Response)
+        response.status_code = 403
+        response.text = (
+            '{"code":40310000,'
+            '"message":"cost basis must be >= minimal amount of order 10"}'
+        )
+        response.raise_for_status.side_effect = HTTPError(response=response)
+
+        with (
+            patch(
+                "alpaca.common.rest.Session.request", return_value=response
+            ) as request,
+            patch("alpaca.common.rest.time.sleep") as sleep,
+            self.assertRaises(BrokerMutationExplicitRejection) as raised,
+        ):
+            _fenced_submit(
+                OrderFirewall(client),
+                symbol="BTC/USD",
+                side="buy",
+                qty=0.00004,
+                order_type="limit",
+                time_in_force="ioc",
+                limit_price=67000,
+            )
+
+        self.assertEqual(raised.exception.broker_status, "http_403")
+        self.assertEqual(raised.exception.rejection_code, "40310000")
+        self.assertEqual(
+            raised.exception.detail,
+            "cost basis must be >= minimal amount of order 10",
+        )
+        self.assertIsInstance(raised.exception.__cause__, APIError)
+        request.assert_called_once()
+        sleep.assert_not_called()
 
     def test_service_created_read_client_keeps_sdk_retry_behavior(self) -> None:
         for status_code in (429, 504):

--- a/services/torghut/tests/test_broker_mutation_coordinator.py
+++ b/services/torghut/tests/test_broker_mutation_coordinator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import uuid
 from collections.abc import Callable, Iterator, Mapping
 from decimal import Decimal
@@ -21,6 +22,7 @@ from app.models import (
 from app.trading.broker_mutation_receipts import (
     BrokerMutationIntentRequest,
     BrokerMutationIntent,
+    BrokerMutationExplicitRejection,
     BrokerMutationIoPermit,
     BrokerMutationIoPermitExpectation,
     BrokerMutationReceiptValidationError,
@@ -36,6 +38,7 @@ from app.trading.broker_mutation_coordinator import (
     BrokerMutationAlreadyProcessed,
     BrokerMutationDeferred,
     BrokerMutationPreflightFailed,
+    BrokerMutationRejected,
     BrokerMutationUnresolved,
     BrokerMutationCoordinator,
     LinkedOrderSubmission,
@@ -220,6 +223,20 @@ def _states(factory: sessionmaker[Session]) -> tuple[str | None, str | None, int
         )
 
 
+def _latest_settlement(
+    factory: sessionmaker[Session],
+) -> tuple[str | None, dict[str, object]]:
+    with factory() as session:
+        latest = session.execute(
+            select(BrokerMutationReceiptEvent)
+            .order_by(BrokerMutationReceiptEvent.sequence_no.desc())
+            .limit(1)
+        ).scalar_one()
+    evidence = json.loads(str(latest.settlement_evidence_json))
+    assert isinstance(evidence, dict)
+    return latest.settlement_outcome, evidence
+
+
 def test_invalid_intent_fails_before_claim_or_broker_call(
     sessions: sessionmaker[Session],
 ) -> None:
@@ -396,6 +413,61 @@ def test_failure_after_io_boundary_is_unresolved_and_never_retried(
 
     assert _states(sessions) == ("broker_io", "broker_io", 0)
     with sessions() as session, pytest.raises(BrokerMutationDeferred):
+        coordinator.submit_linked_order(
+            session,
+            request=_request(decision),
+            callbacks=_linked_callbacks(session, decision, broker_call),
+        )
+    assert broker_calls == 1
+
+
+def test_explicit_linked_broker_rejection_settles_claim_and_receipt(
+    sessions: sessionmaker[Session],
+) -> None:
+    decision = _decision(sessions)
+    coordinator = _coordinator()
+    broker_calls = 0
+
+    def broker_call(_permit: object) -> Mapping[str, object]:
+        nonlocal broker_calls
+        broker_calls += 1
+        raise BrokerMutationExplicitRejection(
+            broker_status="http_403",
+            rejection_code="40310000",
+            detail="cost basis below broker minimum",
+        )
+
+    def forbidden_execution(_response: Mapping[str, object]) -> Execution:
+        raise AssertionError("rejection must not persist an execution")
+
+    with (
+        sessions() as session,
+        pytest.raises(
+            BrokerMutationRejected,
+            match="linked_submission_broker_rejected.*http_403:40310000",
+        ),
+    ):
+        coordinator.submit_linked_order(
+            session,
+            request=_request(decision),
+            callbacks=_linked_callbacks(
+                session,
+                decision,
+                broker_call,
+                persist_execution=forbidden_execution,
+            ),
+        )
+
+    assert broker_calls == 1
+    assert _states(sessions) == ("rejected", "settled", 0)
+    outcome, evidence = _latest_settlement(sessions)
+    assert outcome == "rejected"
+    broker_evidence = evidence["evidence"]
+    assert isinstance(broker_evidence, dict)
+    assert broker_evidence["broker_status"] == "http_403"
+    assert broker_evidence["rejection_code"] == "40310000"
+
+    with sessions() as session, pytest.raises(BrokerMutationRejected):
         coordinator.submit_linked_order(
             session,
             request=_request(decision),
@@ -687,6 +759,68 @@ def test_unlinked_timeout_stays_unresolved_and_is_not_retried(
     assert status["unresolved_submit_receipt_count"] == 1
     assert status["unresolved_reduction_receipt_count"] == 0
     assert status["settled_receipt_count"] == 0
+
+
+def test_explicit_unlinked_broker_rejection_settles_without_terminal_callback(
+    sessions: sessionmaker[Session],
+) -> None:
+    coordinator = _coordinator()
+    intent = _unlinked_intent()
+    broker_calls = 0
+
+    def broker_call(_permit: object) -> Mapping[str, object]:
+        nonlocal broker_calls
+        broker_calls += 1
+        raise BrokerMutationExplicitRejection(
+            broker_status="http_422",
+            rejection_code="42210000",
+            detail="order rejected",
+        )
+
+    def forbidden_terminal(_result: Mapping[str, object]) -> None:
+        raise AssertionError("rejection must not run the success callback")
+
+    def forbidden_settlement(
+        _result: Mapping[str, object],
+    ) -> BrokerMutationSettlement:
+        raise AssertionError("rejection must use the coordinator settlement")
+
+    callbacks = UnlinkedMutationCallbacks(
+        broker_call=broker_call,
+        persist_terminal=forbidden_terminal,
+        build_settlement=forbidden_settlement,
+    )
+    with (
+        sessions() as session,
+        pytest.raises(
+            BrokerMutationRejected,
+            match="unlinked_submission_broker_rejected.*http_422:42210000",
+        ),
+    ):
+        coordinator.execute_unlinked_mutation(
+            session,
+            intent=intent,
+            callbacks=callbacks,
+        )
+
+    assert broker_calls == 1
+    assert _states(sessions) == (None, "settled", 0)
+    outcome, evidence = _latest_settlement(sessions)
+    assert outcome == "rejected"
+    assert evidence["evidence"] == {
+        "broker_status": "http_422",
+        "detail": "order rejected",
+        "rejection_code": "42210000",
+        "schema_version": "torghut.broker-mutation-explicit-rejection.v1",
+    }
+
+    with sessions() as session, pytest.raises(BrokerMutationAlreadyProcessed):
+        coordinator.execute_unlinked_mutation(
+            session,
+            intent=intent,
+            callbacks=callbacks,
+        )
+    assert broker_calls == 1
 
 
 def test_reduction_timeout_uses_operation_specific_error_scope(

--- a/services/torghut/tests/test_broker_mutation_receipt_models.py
+++ b/services/torghut/tests/test_broker_mutation_receipt_models.py
@@ -42,6 +42,7 @@ def _assert_lifecycle_validation_invariants(
     sql: str,
     *,
     lifecycle_cap: int,
+    leg_floor: int | None,
 ) -> None:
     normalized = _normalized_sql(sql)
 
@@ -66,6 +67,19 @@ def _assert_lifecycle_validation_invariants(
     assert "test_plan,partial_close_qty}')::numeric <" in normalized
     assert "test_plan,replacement_close_limit_price}')::numeric >" in normalized
     assert "test_plan,resting_close_limit_price}')::numeric >" in normalized
+    if leg_floor is not None:
+        assert normalized.count(f">= {leg_floor}") == 2
+        assert (
+            "test_plan,partial_close_qty}')::numeric * "
+            "(canonical_intent_json::jsonb #>> "
+            "'{request,infrastructure_validation,test_plan,limit_price}')::numeric"
+            in normalized
+        )
+        assert (
+            "test_plan,qty}')::numeric - (canonical_intent_json::jsonb #>> "
+            "'{request,infrastructure_validation,test_plan,partial_close_qty}')::numeric"
+            in normalized
+        )
     assert normalized.count(f"THEN {lifecycle_cap} ELSE 1") == 2 or (
         normalized.count(f"permit,max_notional_usd}}')::numeric <= {lifecycle_cap}")
         == 1
@@ -191,10 +205,12 @@ def test_receipt_header_mirrors_validation_authority_and_permit_guards() -> None
     _assert_lifecycle_validation_invariants(
         BROKER_MUTATION_VALIDATION_AUTHORITY_SQL,
         lifecycle_cap=30,
+        leg_floor=12,
     )
     _assert_lifecycle_validation_invariants(
         migration_validation_sql,
         lifecycle_cap=5,
+        leg_floor=None,
     )
     _assert_lifecycle_lineage_invariants(BROKER_MUTATION_VALIDATION_LINEAGE_SQL)
     _assert_lifecycle_lineage_invariants(migration_lineage_sql)

--- a/services/torghut/tests/test_broker_mutation_receipt_models.py
+++ b/services/torghut/tests/test_broker_mutation_receipt_models.py
@@ -38,7 +38,11 @@ def _normalized_sql(sql: str) -> str:
     return " ".join(sql.split())
 
 
-def _assert_lifecycle_validation_invariants(sql: str) -> None:
+def _assert_lifecycle_validation_invariants(
+    sql: str,
+    *,
+    lifecycle_cap: int,
+) -> None:
     normalized = _normalized_sql(sql)
 
     assert "torghut.infrastructure-validation-order-plan.v1" in normalized
@@ -62,9 +66,11 @@ def _assert_lifecycle_validation_invariants(sql: str) -> None:
     assert "test_plan,partial_close_qty}')::numeric <" in normalized
     assert "test_plan,replacement_close_limit_price}')::numeric >" in normalized
     assert "test_plan,resting_close_limit_price}')::numeric >" in normalized
-    assert normalized.count("THEN 5 ELSE 1") == 2 or (
-        normalized.count("permit,max_notional_usd}')::numeric <= 5") == 1
-        and normalized.count("permit,max_loss_usd}')::numeric <= 5") == 1
+    assert normalized.count(f"THEN {lifecycle_cap} ELSE 1") == 2 or (
+        normalized.count(f"permit,max_notional_usd}}')::numeric <= {lifecycle_cap}")
+        == 1
+        and normalized.count(f"permit,max_loss_usd}}')::numeric <= {lifecycle_cap}")
+        == 1
         and normalized.count("permit,max_notional_usd}')::numeric <= 1") == 1
         and normalized.count("permit,max_loss_usd}')::numeric <= 1") == 1
     )
@@ -182,8 +188,14 @@ def test_receipt_header_mirrors_validation_authority_and_permit_guards() -> None
     migration = load_migration_module("0072_infrastructure_validation_lifecycle.py")
     migration_validation_sql = str(getattr(migration, "_VALIDATION_AUTHORITY_0072"))
     migration_lineage_sql = str(getattr(migration, "_LINEAGE_CONTRACT_0072"))
-    _assert_lifecycle_validation_invariants(BROKER_MUTATION_VALIDATION_AUTHORITY_SQL)
-    _assert_lifecycle_validation_invariants(migration_validation_sql)
+    _assert_lifecycle_validation_invariants(
+        BROKER_MUTATION_VALIDATION_AUTHORITY_SQL,
+        lifecycle_cap=30,
+    )
+    _assert_lifecycle_validation_invariants(
+        migration_validation_sql,
+        lifecycle_cap=5,
+    )
     _assert_lifecycle_lineage_invariants(BROKER_MUTATION_VALIDATION_LINEAGE_SQL)
     _assert_lifecycle_lineage_invariants(migration_lineage_sql)
     assert "torghut.infrastructure-validation-lifecycle-plan.v1" in ddl

--- a/services/torghut/tests/test_infrastructure_validation_lifecycle.py
+++ b/services/torghut/tests/test_infrastructure_validation_lifecycle.py
@@ -275,6 +275,9 @@ class _LifecycleBroker:
         status: str,
         filled_quantity: Decimal,
     ) -> dict[str, object]:
+        fill_price = (
+            limit_price - Decimal("1") if limit_price is not None else Decimal("65000")
+        )
         order = {
             "id": order_id,
             "client_order_id": client_order_id,
@@ -286,7 +289,7 @@ class _LifecycleBroker:
             "limit_price": str(limit_price) if limit_price is not None else None,
             "status": status,
             "filled_qty": str(filled_quantity),
-            "filled_avg_price": "99999" if filled_quantity else None,
+            "filled_avg_price": str(fill_price) if filled_quantity else None,
         }
         self._orders[order_id] = order
         self._position_after_order[order_id] = self._position_quantity
@@ -396,14 +399,14 @@ def lifecycle_runtime(
             "asset_class": "crypto",
             "symbol": "BTC/USD",
             "side": "buy",
-            "qty": "0.00004",
+            "qty": "0.0004",
             "order_type": "limit",
             "time_in_force": "ioc",
-            "limit_price": "100000",
+            "limit_price": "70000",
             "stop_price": None,
-            "resting_close_limit_price": "200000",
-            "replacement_close_limit_price": "210000",
-            "partial_close_qty": "0.00002",
+            "resting_close_limit_price": "130000",
+            "replacement_close_limit_price": "140000",
+            "partial_close_qty": "0.0002",
         }
     )
     now = datetime.now(timezone.utc)
@@ -423,8 +426,8 @@ def lifecycle_runtime(
             "order_types": ["limit"],
             "max_orders": 1,
             "max_outstanding_intents": 1,
-            "max_notional_usd": "5",
-            "max_loss_usd": "5",
+            "max_notional_usd": "30",
+            "max_loss_usd": "30",
             "issued_by": "infrastructure-owner",
             "approved_by": "independent-infrastructure-owner",
             "issued_at": now - timedelta(seconds=1),

--- a/services/torghut/tests/test_infrastructure_validation_lifecycle_bounds_migration.py
+++ b/services/torghut/tests/test_infrastructure_validation_lifecycle_bounds_migration.py
@@ -10,14 +10,20 @@ from tests.migration_testing import load_migration_module
 MIGRATION_FILENAME = "0073_live_paper_lifecycle_bounds.py"
 
 
-def _definition(module: object, cap: int) -> str:
+def _definition(module: object, cap: int, *, leg_floors: bool = False) -> str:
     cap_fragment = getattr(module, "_cap_fragment")
+    partial_close_bound = getattr(module, "_partial_close_bound_fragment")()
+    floor_clause = " AND ".join(getattr(module, "_leg_floor_fragments")())
+    lifecycle_bounds = partial_close_bound
+    if leg_floors:
+        lifecycle_bounds = f"{lifecycle_bounds} AND {floor_clause}"
     schema = getattr(module, "_LIFECYCLE_SCHEMA")
     return (
         "CHECK (purpose <> 'control_plane_validation' OR ("
         f"plan_schema = '{schema}' AND "
         f"{cap_fragment('max_notional_usd', cap)} AND "
-        f"{cap_fragment('max_loss_usd', cap)}))"
+        f"{cap_fragment('max_loss_usd', cap)} AND "
+        f"{lifecycle_bounds}))"
     )
 
 
@@ -28,18 +34,20 @@ def test_revision_extends_the_released_lifecycle_schema() -> None:
     assert module.down_revision == "0072_validation_lifecycle"
 
 
-def test_cap_rewrite_changes_only_the_two_lifecycle_money_bounds() -> None:
+def test_upgrade_rewrite_changes_caps_and_installs_both_leg_floors() -> None:
     module = load_migration_module(MIGRATION_FILENAME)
     definition = _definition(module, 5)
 
-    condition = module._replace_lifecycle_cap(
+    condition = module._rewrite_lifecycle_authority(
         definition,
         old_cap=5,
         new_cap=30,
+        add_leg_floors=True,
     )
 
     assert module._cap_fragment("max_notional_usd", 30) in condition
     assert module._cap_fragment("max_loss_usd", 30) in condition
+    assert all(fragment in condition for fragment in module._leg_floor_fragments())
     assert "purpose <> 'control_plane_validation'" in condition
     assert "<= 5::numeric" not in condition
 
@@ -55,7 +63,12 @@ def test_cap_rewrite_fails_closed_on_catalog_drift(definition: str) -> None:
     module = load_migration_module(MIGRATION_FILENAME)
 
     with pytest.raises(RuntimeError, match="validation_authority"):
-        module._replace_lifecycle_cap(definition, old_cap=5, new_cap=30)
+        module._rewrite_lifecycle_authority(
+            definition,
+            old_cap=5,
+            new_cap=30,
+            add_leg_floors=True,
+        )
 
 
 def test_upgrade_locks_and_validates_the_rewritten_constraint() -> None:
@@ -77,6 +90,7 @@ def test_upgrade_locks_and_validates_the_rewritten_constraint() -> None:
     assert "ACCESS EXCLUSIVE MODE NOWAIT" in sql
     assert module._cap_fragment("max_notional_usd", 30) in sql
     assert module._cap_fragment("max_loss_usd", 30) in sql
+    assert all(fragment in sql for fragment in module._leg_floor_fragments())
     assert "NOT VALID" in sql
     assert "VALIDATE CONSTRAINT ck_bm_receipt_validation_authority" in sql
     drop_constraint.assert_called_once_with(
@@ -92,6 +106,7 @@ def test_downgrade_refuses_incompatible_evidence_before_restoring_cap() -> None:
     connection.execute.return_value.scalar_one_or_none.return_value = _definition(
         module,
         30,
+        leg_floors=True,
     )
 
     with (
@@ -105,3 +120,4 @@ def test_downgrade_refuses_incompatible_evidence_before_restoring_cap() -> None:
     assert "cannot downgrade with lifecycle receipts above the old cap" in sql
     assert module._cap_fragment("max_notional_usd", 5) in sql
     assert module._cap_fragment("max_loss_usd", 5) in sql
+    assert all(fragment not in sql for fragment in module._leg_floor_fragments())

--- a/services/torghut/tests/test_infrastructure_validation_lifecycle_bounds_migration.py
+++ b/services/torghut/tests/test_infrastructure_validation_lifecycle_bounds_migration.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from tests.migration_testing import load_migration_module
+
+
+MIGRATION_FILENAME = "0073_live_paper_lifecycle_bounds.py"
+
+
+def _definition(module: object, cap: int) -> str:
+    cap_fragment = getattr(module, "_cap_fragment")
+    schema = getattr(module, "_LIFECYCLE_SCHEMA")
+    return (
+        "CHECK (purpose <> 'control_plane_validation' OR ("
+        f"plan_schema = '{schema}' AND "
+        f"{cap_fragment('max_notional_usd', cap)} AND "
+        f"{cap_fragment('max_loss_usd', cap)}))"
+    )
+
+
+def test_revision_extends_the_released_lifecycle_schema() -> None:
+    module = load_migration_module(MIGRATION_FILENAME)
+
+    assert module.revision == "0073_live_paper_bounds"
+    assert module.down_revision == "0072_validation_lifecycle"
+
+
+def test_cap_rewrite_changes_only_the_two_lifecycle_money_bounds() -> None:
+    module = load_migration_module(MIGRATION_FILENAME)
+    definition = _definition(module, 5)
+
+    condition = module._replace_lifecycle_cap(
+        definition,
+        old_cap=5,
+        new_cap=30,
+    )
+
+    assert module._cap_fragment("max_notional_usd", 30) in condition
+    assert module._cap_fragment("max_loss_usd", 30) in condition
+    assert "purpose <> 'control_plane_validation'" in condition
+    assert "<= 5::numeric" not in condition
+
+
+@pytest.mark.parametrize(
+    "definition",
+    (
+        "NOT A CHECK",
+        "CHECK (missing lifecycle schema)",
+    ),
+)
+def test_cap_rewrite_fails_closed_on_catalog_drift(definition: str) -> None:
+    module = load_migration_module(MIGRATION_FILENAME)
+
+    with pytest.raises(RuntimeError, match="validation_authority"):
+        module._replace_lifecycle_cap(definition, old_cap=5, new_cap=30)
+
+
+def test_upgrade_locks_and_validates_the_rewritten_constraint() -> None:
+    module = load_migration_module(MIGRATION_FILENAME)
+    connection = Mock()
+    connection.execute.return_value.scalar_one_or_none.return_value = _definition(
+        module,
+        5,
+    )
+
+    with (
+        patch.object(module.op, "get_bind", return_value=connection),
+        patch.object(module.op, "execute") as execute,
+        patch.object(module.op, "drop_constraint") as drop_constraint,
+    ):
+        module.upgrade()
+
+    sql = "\n".join(str(call.args[0]) for call in execute.call_args_list)
+    assert "ACCESS EXCLUSIVE MODE NOWAIT" in sql
+    assert module._cap_fragment("max_notional_usd", 30) in sql
+    assert module._cap_fragment("max_loss_usd", 30) in sql
+    assert "NOT VALID" in sql
+    assert "VALIDATE CONSTRAINT ck_bm_receipt_validation_authority" in sql
+    drop_constraint.assert_called_once_with(
+        "ck_bm_receipt_validation_authority",
+        "broker_mutation_receipts",
+        type_="check",
+    )
+
+
+def test_downgrade_refuses_incompatible_evidence_before_restoring_cap() -> None:
+    module = load_migration_module(MIGRATION_FILENAME)
+    connection = Mock()
+    connection.execute.return_value.scalar_one_or_none.return_value = _definition(
+        module,
+        30,
+    )
+
+    with (
+        patch.object(module.op, "get_bind", return_value=connection),
+        patch.object(module.op, "execute") as execute,
+        patch.object(module.op, "drop_constraint"),
+    ):
+        module.downgrade()
+
+    sql = "\n".join(str(call.args[0]) for call in execute.call_args_list)
+    assert "cannot downgrade with lifecycle receipts above the old cap" in sql
+    assert module._cap_fragment("max_notional_usd", 5) in sql
+    assert module._cap_fragment("max_loss_usd", 5) in sql

--- a/services/torghut/tests/test_infrastructure_validation_permit.py
+++ b/services/torghut/tests/test_infrastructure_validation_permit.py
@@ -195,14 +195,14 @@ def test_lifecycle_plan_allows_one_bounded_fill_and_only_resting_reductions() ->
             "asset_class": "crypto",
             "symbol": "BTC/USD",
             "side": "buy",
-            "qty": "0.00004",
+            "qty": "0.0004",
             "order_type": "limit",
             "time_in_force": "ioc",
-            "limit_price": "100000",
+            "limit_price": "70000",
             "stop_price": None,
-            "resting_close_limit_price": "125000",
-            "replacement_close_limit_price": "150000",
-            "partial_close_qty": "0.00002",
+            "resting_close_limit_price": "130000",
+            "replacement_close_limit_price": "140000",
+            "partial_close_qty": "0.0002",
         }
     )
     permit = InfrastructureValidationPermit.model_validate(
@@ -212,8 +212,8 @@ def test_lifecycle_plan_allows_one_bounded_fill_and_only_resting_reductions() ->
             symbols=["BTC/USD"],
             sides=["buy"],
             order_types=["limit"],
-            max_notional_usd="5",
-            max_loss_usd="5",
+            max_notional_usd="30",
+            max_loss_usd="30",
             test_plan_digest=infrastructure_validation_lifecycle_plan_sha256(plan),
             expected_terminal_state_digest=infrastructure_validation_terminal_state_sha256(),
         )
@@ -227,13 +227,65 @@ def test_lifecycle_plan_allows_one_bounded_fill_and_only_resting_reductions() ->
         now=_NOW,
     )
 
-    assert plan.notional_usd == 4
+    assert plan.notional_usd == 28
     assert (
         infrastructure_validation_request_payload(permit, plan)["broker_request"][
             "limit_price"
         ]
-        == "100000"
+        == "70000"
     )
+
+
+@pytest.mark.parametrize(
+    ("partial_close_qty", "error"),
+    [
+        ("0.0001", "partial_close_plan_notional_below_broker_cost_basis_floor"),
+        ("0.0003", "residual_close_plan_notional_below_broker_cost_basis_floor"),
+    ],
+)
+def test_lifecycle_authority_requires_two_broker_valid_close_legs(
+    partial_close_qty: str,
+    error: str,
+) -> None:
+    plan = InfrastructureValidationLifecyclePlan.model_validate(
+        {
+            "schema_version": "torghut.infrastructure-validation-lifecycle-plan.v1",
+            "venue": "alpaca",
+            "asset_class": "crypto",
+            "symbol": "BTC/USD",
+            "side": "buy",
+            "qty": "0.0004",
+            "order_type": "limit",
+            "time_in_force": "ioc",
+            "limit_price": "70000",
+            "stop_price": None,
+            "resting_close_limit_price": "130000",
+            "replacement_close_limit_price": "140000",
+            "partial_close_qty": partial_close_qty,
+        }
+    )
+    permit = InfrastructureValidationPermit.model_validate(
+        _permit_payload(
+            asset_class="crypto",
+            market_session="continuous",
+            symbols=["BTC/USD"],
+            sides=["buy"],
+            order_types=["limit"],
+            max_notional_usd="30",
+            max_loss_usd="30",
+            test_plan_digest=infrastructure_validation_lifecycle_plan_sha256(plan),
+            expected_terminal_state_digest=infrastructure_validation_terminal_state_sha256(),
+        )
+    )
+
+    with pytest.raises(ValueError, match=error):
+        authorize_infrastructure_validation_order(
+            permit,
+            plan,
+            account_label=permit.account_label,
+            broker_base_url="https://paper-api.alpaca.markets",
+            now=_NOW,
+        )
 
 
 @pytest.mark.parametrize(

--- a/services/torghut/tests/test_infrastructure_validation_position_evidence.py
+++ b/services/torghut/tests/test_infrastructure_validation_position_evidence.py
@@ -51,7 +51,7 @@ def test_position_evidence_requires_exact_tagged_fill_and_quantity(
     event = _position_event(
         evidence,
         fingerprint="a" * 64,
-        position_quantity=Decimal("0.00002000"),
+        position_quantity=Decimal("0.00040000"),
     )
     session.add(event)
     session.commit()
@@ -60,15 +60,15 @@ def test_position_evidence_requires_exact_tagged_fill_and_quantity(
         session,
         evidence=evidence,
         symbol="btc/usd",
-        signed_quantity=Decimal("0.00002"),
+        signed_quantity=Decimal("0.0004"),
     )
 
     assert proven.order_event_id == event.id
     assert proven.alpaca_order_id == "validation-root-order-1"
     assert proven.symbol == "BTC/USD"
-    assert proven.filled_quantity == Decimal("0.00002000")
-    assert proven.position_quantity == Decimal("0.00002000")
-    assert proven.average_fill_price == Decimal("100000.00000000")
+    assert proven.filled_quantity == Decimal("0.00040000")
+    assert proven.position_quantity == Decimal("0.00040000")
+    assert proven.average_fill_price == Decimal("70000.00000000")
     with pytest.raises(
         RuntimeError,
         match="infrastructure_validation_position_not_reconciled",
@@ -77,7 +77,7 @@ def test_position_evidence_requires_exact_tagged_fill_and_quantity(
             session,
             evidence=evidence,
             symbol="BTC/USD",
-            signed_quantity=Decimal("0.00003"),
+            signed_quantity=Decimal("0.0003"),
         )
 
 
@@ -88,7 +88,7 @@ def test_position_evidence_rejects_forged_receipt_and_linked_event(
     forged = _position_event(
         evidence,
         fingerprint="b" * 64,
-        position_quantity=Decimal("0.00002"),
+        position_quantity=Decimal("0.0004"),
     )
     forged.raw_event = copy.deepcopy(forged.raw_event)
     forged.raw_event["_torghut_evidence_contract"]["broker_mutation_receipt_id"] = str(
@@ -97,7 +97,7 @@ def test_position_evidence_rejects_forged_receipt_and_linked_event(
     linked = _position_event(
         evidence,
         fingerprint="c" * 64,
-        position_quantity=Decimal("0.00002"),
+        position_quantity=Decimal("0.0004"),
     )
     linked.trade_decision_id = uuid.uuid4()
     session.add_all((forged, linked))
@@ -111,7 +111,7 @@ def test_position_evidence_rejects_forged_receipt_and_linked_event(
             session,
             evidence=evidence,
             symbol="BTC/USD",
-            signed_quantity=Decimal("0.00002"),
+            signed_quantity=Decimal("0.0004"),
         )
 
 
@@ -136,7 +136,7 @@ def test_position_evidence_rejects_nonpositive_broker_position(
             session,
             evidence=evidence,
             symbol="BTC/USD",
-            signed_quantity=Decimal("0.00002"),
+            signed_quantity=Decimal("0.0004"),
         )
 
     flat = require_infrastructure_validation_flat_position_evidence(
@@ -156,14 +156,14 @@ def _seed_lifecycle_root(session: Session) -> InfrastructureValidationEvidence:
             "asset_class": "crypto",
             "symbol": "BTC/USD",
             "side": "buy",
-            "qty": "0.00002",
+            "qty": "0.0004",
             "order_type": "limit",
             "time_in_force": "ioc",
-            "limit_price": "100000",
+            "limit_price": "70000",
             "stop_price": None,
-            "resting_close_limit_price": "200000",
-            "replacement_close_limit_price": "210000",
-            "partial_close_qty": "0.00001",
+            "resting_close_limit_price": "130000",
+            "replacement_close_limit_price": "140000",
+            "partial_close_qty": "0.0002",
         }
     )
     permit = InfrastructureValidationPermit.model_validate(
@@ -182,8 +182,8 @@ def _seed_lifecycle_root(session: Session) -> InfrastructureValidationEvidence:
             "order_types": ["limit"],
             "max_orders": 1,
             "max_outstanding_intents": 1,
-            "max_notional_usd": "5",
-            "max_loss_usd": "5",
+            "max_notional_usd": "30",
+            "max_loss_usd": "30",
             "issued_by": "infrastructure-owner",
             "approved_by": "independent-infrastructure-owner",
             "issued_at": now - timedelta(seconds=1),
@@ -256,10 +256,10 @@ def _position_event(
         client_order_id=evidence.root_client_order_id,
         event_type="fill",
         status="filled",
-        qty=Decimal("0.00002"),
-        filled_qty=Decimal("0.00002"),
+        qty=Decimal("0.0004"),
+        filled_qty=Decimal("0.0004"),
         position_qty=position_quantity,
-        avg_fill_price=Decimal("100000"),
+        avg_fill_price=Decimal("70000"),
         raw_event=tag_infrastructure_validation_event(
             {"event": "fill"},
             evidence,

--- a/services/torghut/tests/test_strategy_capital_authority_migration_compat.py
+++ b/services/torghut/tests/test_strategy_capital_authority_migration_compat.py
@@ -28,7 +28,7 @@ def test_migration_graph_has_one_merged_head_and_knows_the_released_revision() -
     config = AlembicConfig(str(SERVICE_ROOT / "alembic.ini"))
     scripts = ScriptDirectory.from_config(config)
 
-    assert scripts.get_heads() == ["0072_validation_lifecycle"]
+    assert scripts.get_heads() == ["0073_live_paper_bounds"]
     assert scripts.get_revision("0063_strategy_capital_authority") is not None
     assert scripts.get_revision("0064_strategy_capital_authority") is not None
     assert scripts.get_revision("0065_strategy_capital_compat") is not None
@@ -39,3 +39,4 @@ def test_migration_graph_has_one_merged_head_and_knows_the_released_revision() -
     assert scripts.get_revision("0070_reduction_fencing") is not None
     assert scripts.get_revision("0071_validation_lineage") is not None
     assert scripts.get_revision("0072_validation_lifecycle") is not None
+    assert scripts.get_revision("0073_live_paper_bounds") is not None


### PR DESCRIPTION
## Summary

- Preserve the observed Alpaca `40310000` rejection as terminal evidence instead of stranding a definitive refusal in ambiguous `broker_io`.
- Raise only the bounded paper lifecycle ceiling from `$5` to `$30` and require both close legs to carry at least `$12` of plan notional; the known-null submit proof remains capped at `$1`.
- Enforce the lifecycle cap and both close-leg floors at application authorization and PostgreSQL receipt-authority boundaries, including direct forged-intent inserts.
- Add migration `0073_live_paper_bounds`, which fail-closes on unexpected catalog shape and changes only the released lifecycle authority predicates.
- Record the live broker contradiction and the exact safety/ambiguity contract needed before rerunning the non-promotable paper lifecycle.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format --check app tests scripts migrations`
- `uv run --frozen ruff check app tests scripts migrations`
- Focused Torghut suite covering the client, coordinator, receipts, lifecycle authority, migration compatibility, position evidence, and PostgreSQL coordinator paths (`104 passed`, `9 skipped` because no PostgreSQL DSN was supplied to that invocation).
- Disposable PostgreSQL 18: explicit rejection settlement and lifecycle reduction coverage passed; the final lifecycle test independently rejected forged intents with an undersized partial leg and an undersized residual leg while accepting the valid lifecycle.
- Disposable PostgreSQL 18: migration `0073` empty-schema upgrade/downgrade round trip installed both `$12` predicates, restored the `$5` predicates on downgrade, and failed closed on catalog-shape drift.
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.strict.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.strict.json`
- `uv run --frozen python scripts/check_migration_graph.py`
- `uv run --frozen python scripts/measure_torghut_tech_debt.py --baseline config/quality/tech-debt-baseline.json --enforce-ratchet --format markdown` (`files_ge_1000=1`, unchanged).
- `git diff --check`

## Breaking Changes

Migration `0073_live_paper_bounds` takes an immediate `ACCESS EXCLUSIVE ... NOWAIT` lock while replacing and validating the existing receipt authority constraint. It aborts rather than waiting or rewriting an unrecognized constraint. No API contract is removed.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
