### PR TITLE
fix(torghut): raise writer memory headroom

### DIFF
--- a/argocd/applications/torghut-hyperliquid-feed/writer-deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/writer-deployment.yaml
@@ -82,10 +82,10 @@ spec:
           resources:
             requests:
               cpu: 250m
-              memory: 512Mi
+              memory: 1Gi
             limits:
               cpu: "1"
-              memory: 1Gi
+              memory: 2Gi
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/services/torghut/tests/live_config_manifest_contract/test_hyperliquid_kafka_clickhouse_staging_manifests.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_hyperliquid_kafka_clickhouse_staging_manifests.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from tests.live_config_manifest_contract.support import (
     Mapping,
+    _load_knative_container,
     _load_yaml_mapping,
     cast,
 )
@@ -14,6 +15,13 @@ def test_kafka_clickhouse_writer_is_active_only_against_staging_tables() -> None
     spec = cast(Mapping[str, object], deployment.get("spec", {}))
     assert spec.get("replicas") == 1
     assert spec.get("strategy") == {"type": "Recreate"}
+
+    container = _load_knative_container(
+        "argocd/applications/torghut-hyperliquid-feed/writer-deployment.yaml"
+    )
+    resources = cast(Mapping[str, object], container.get("resources", {}))
+    assert resources.get("requests") == {"cpu": "250m", "memory": "1Gi"}
+    assert resources.get("limits") == {"cpu": "1", "memory": "2Gi"}
 
     config = _load_yaml_mapping(
         "argocd/applications/torghut-hyperliquid-feed/configmap.yaml"


### PR DESCRIPTION
## Summary

- Raise the staging Kafka ClickHouse writer memory request from 512 MiB to 1 GiB and limit from 1 GiB to 2 GiB after retained-history replay repeatedly exhausted the 1 GiB JVM heap.
- Preserve the single-replica, staging-only replay contract and existing batch, buffer, and Kafka offset behavior.
- Lock the production memory reservation and limit into the live manifest contract test.

## Related Issues

None.

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest -q tests/live_config_manifest_contract/test_hyperliquid_kafka_clickhouse_staging_manifests.py`
- `uv run --frozen ruff check tests/live_config_manifest_contract/test_hyperliquid_kafka_clickhouse_staging_manifests.py`
- `uv run --frozen ruff format --check tests/live_config_manifest_contract/test_hyperliquid_kafka_clickhouse_staging_manifests.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`
- `kustomize build --enable-helm argocd/applications/torghut-hyperliquid-feed`
- Server-side dry-run of the rendered application with `--force-conflicts`; no Namespace objects rendered.
- Live evidence before the change: the writer reached approximately 900 MiB RSS, exited twice with `java.lang.OutOfMemoryError: Java heap space`, and resumed from committed Kafka offsets without unresolved writer errors.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] No documentation or release-note change is required for this resource correction; live evidence will be recorded in the rollout document.
