### PR TITLE
fix(torghut): require observed writer lag

### DIFF
--- a/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/KafkaClickHouseWriter.kt
+++ b/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/KafkaClickHouseWriter.kt
@@ -267,6 +267,8 @@ class KafkaClickHouseWriter(
   private fun rebalanceListener(): ConsumerRebalanceListener =
     object : ConsumerRebalanceListener {
       override fun onPartitionsRevoked(partitions: Collection<TopicPartition>) {
+        state.markConsumerLagPending()
+        lastLagRefreshMs = 0
         var remainingFlushes = config.maxFlushesPerPoll
         partitions.forEach { topicPartition ->
           val buffer = buffers[topicPartition] ?: return@forEach
@@ -282,6 +284,8 @@ class KafkaClickHouseWriter(
       }
 
       override fun onPartitionsAssigned(partitions: Collection<TopicPartition>) {
+        state.markConsumerLagPending()
+        lastLagRefreshMs = 0
         partitions.forEach { topicPartition ->
           buffers.getOrPut(topicPartition) { PartitionBuffer() }.requiresReconciliation = true
         }

--- a/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/KafkaClickHouseWriterState.kt
+++ b/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/KafkaClickHouseWriterState.kt
@@ -43,6 +43,7 @@ class KafkaClickHouseWriterState(
   private val pendingRecords = AtomicInteger(0)
   private val consumerLag = AtomicLong(0)
   private val maxPartitionLag = AtomicLong(0)
+  private val consumerLagObserved = AtomicBoolean(false)
   private val lastPollMs = AtomicLong(0)
   private val lastCommitMs = AtomicLong(0)
   private val failures = ConcurrentHashMap<String, WriterFailure>()
@@ -85,6 +86,11 @@ class KafkaClickHouseWriterState(
   ) {
     consumerLag.set(total.coerceAtLeast(0))
     maxPartitionLag.set(maximum.coerceAtLeast(0))
+    consumerLagObserved.set(true)
+  }
+
+  fun markConsumerLagPending() {
+    consumerLagObserved.set(false)
   }
 
   fun markStopped() {
@@ -107,7 +113,10 @@ class KafkaClickHouseWriterState(
         commitMs > 0 &&
         observedAt - pollMs <= readinessMaxAgeMs &&
         failures.isEmpty()
-    val isCaughtUp = isReady && maxPartitionLag.get() <= catchUpMaxPartitionLagRecords
+    val isCaughtUp =
+      isReady &&
+        consumerLagObserved.get() &&
+        maxPartitionLag.get() <= catchUpMaxPartitionLagRecords
     return KafkaClickHouseWriterSnapshot(
       status =
         when {

--- a/services/dorvud/hyperliquid-feed/src/test/kotlin/ai/proompteng/dorvud/hyperliquid/KafkaClickHouseWriterTest.kt
+++ b/services/dorvud/hyperliquid-feed/src/test/kotlin/ai/proompteng/dorvud/hyperliquid/KafkaClickHouseWriterTest.kt
@@ -125,7 +125,7 @@ class KafkaClickHouseWriterTest {
   }
 
   @Test
-  fun `writer state requires assignment polling and a successful commit`() {
+  fun `writer state requires assignment polling a successful commit and observed lag`() {
     var nowMs = 10_000L
     val state = KafkaClickHouseWriterState(readinessMaxAgeMs = 1_000, nowMs = { nowMs })
     state.markRunning(1)
@@ -135,13 +135,20 @@ class KafkaClickHouseWriterTest {
 
     state.markCommit("partition:a:0")
     assertTrue(state.snapshot().ready)
-    assertTrue(state.snapshot().caughtUp)
-    assertEquals("ready", state.snapshot().status)
+    assertFalse(state.snapshot().caughtUp)
+    assertEquals("backfilling", state.snapshot().status)
 
     state.markConsumerLag(total = 48_000, maximum = 1_000)
     assertTrue(state.snapshot().ready)
     assertTrue(state.snapshot().caughtUp)
     state.markConsumerLag(total = 1_001, maximum = 1_001)
+    assertTrue(state.snapshot().ready)
+    assertFalse(state.snapshot().caughtUp)
+    assertEquals("backfilling", state.snapshot().status)
+    state.markConsumerLag(total = 0, maximum = 0)
+    assertTrue(state.snapshot().caughtUp)
+
+    state.markConsumerLagPending()
     assertTrue(state.snapshot().ready)
     assertFalse(state.snapshot().caughtUp)
     assertEquals("backfilling", state.snapshot().status)


### PR DESCRIPTION
## Summary

- Require a real Kafka lag observation before the ClickHouse writer can report `caughtUp=true`.
- Invalidate the lag observation and force an immediate refresh whenever Kafka partitions are revoked or assigned.
- Cover startup, threshold, stale-observation, and readiness behavior with a regression test.

## Related Issues

None.

## Testing

- `env JAVA_HOME=/nix/store/adgxs4i9zn1v0wx3dxg1frqzdccdmdvj-zulu-ca-jdk-21.0.11 PATH=/nix/store/adgxs4i9zn1v0wx3dxg1frqzdccdmdvj-zulu-ca-jdk-21.0.11/bin:$PATH ./gradlew :hyperliquid-feed:test --tests 'ai.proompteng.dorvud.hyperliquid.KafkaClickHouseWriterTest'`
- `env JAVA_HOME=/nix/store/adgxs4i9zn1v0wx3dxg1frqzdccdmdvj-zulu-ca-jdk-21.0.11 PATH=/nix/store/adgxs4i9zn1v0wx3dxg1frqzdccdmdvj-zulu-ca-jdk-21.0.11/bin:$PATH ./gradlew :hyperliquid-feed:check`
- `git diff --check`

## Screenshots (if applicable)

N/A.

## Breaking Changes

None. `/readyz` remains operationally ready during replay, but `caughtUp` now stays false until lag has been measured for the current assignment.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
