### PR TITLE
chore(torghut): promote image sha-eb9ebfa9e7b5230ea0961215c39da1bd204278fa

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -54,7 +54,7 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: 89e9c4e8ab4975f305dad586723b166ba7f1836a
+              value: eb9ebfa9e7b5230ea0961215c39da1bd204278fa
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:14dad3547c734cd97dc971d2a80122903e9ecfa3bcf1120275e13600da2674b0
             - name: PYTHONPATH

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -46,7 +46,7 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: 89e9c4e8ab4975f305dad586723b166ba7f1836a
+              value: eb9ebfa9e7b5230ea0961215c39da1bd204278fa
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:14dad3547c734cd97dc971d2a80122903e9ecfa3bcf1120275e13600da2674b0
             - name: DB_DSN

--- a/argocd/applications/torghut-options/archive/deployment.yaml
+++ b/argocd/applications/torghut-options/archive/deployment.yaml
@@ -100,9 +100,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2031-g89e9c4e8a
+              value: v0.596.0-2037-geb9ebfa9e
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 89e9c4e8ab4975f305dad586723b166ba7f1836a
+              value: eb9ebfa9e7b5230ea0961215c39da1bd204278fa
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -110,9 +110,9 @@ spec:
                   name: torghut-ws-config
                   key: SYMBOLS_ALLOWLIST
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2031-g89e9c4e8a
+              value: v0.596.0-2037-geb9ebfa9e
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 89e9c4e8ab4975f305dad586723b166ba7f1836a
+              value: eb9ebfa9e7b5230ea0961215c39da1bd204278fa
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -106,9 +106,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2031-g89e9c4e8a
+              value: v0.596.0-2037-geb9ebfa9e
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 89e9c4e8ab4975f305dad586723b166ba7f1836a
+              value: eb9ebfa9e7b5230ea0961215c39da1bd204278fa
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-15T14:55:39Z"
+        client.knative.dev/updateTimestamp: "2026-07-15T16:17:34Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -507,9 +507,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2031-g89e9c4e8a
+              value: v0.596.0-2037-geb9ebfa9e
             - name: TORGHUT_COMMIT
-              value: 89e9c4e8ab4975f305dad586723b166ba7f1836a
+              value: eb9ebfa9e7b5230ea0961215c39da1bd204278fa
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:14dad3547c734cd97dc971d2a80122903e9ecfa3bcf1120275e13600da2674b0
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-15T14:55:39Z"
+        client.knative.dev/updateTimestamp: "2026-07-15T16:17:34Z"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
     spec:
@@ -446,9 +446,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2031-g89e9c4e8a
+              value: v0.596.0-2037-geb9ebfa9e
             - name: TORGHUT_COMMIT
-              value: 89e9c4e8ab4975f305dad586723b166ba7f1836a
+              value: eb9ebfa9e7b5230ea0961215c39da1bd204278fa
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:14dad3547c734cd97dc971d2a80122903e9ecfa3bcf1120275e13600da2674b0
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -462,9 +462,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2031-g89e9c4e8a
+              value: v0.596.0-2037-geb9ebfa9e
             - name: TORGHUT_COMMIT
-              value: 89e9c4e8ab4975f305dad586723b166ba7f1836a
+              value: eb9ebfa9e7b5230ea0961215c39da1bd204278fa
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:14dad3547c734cd97dc971d2a80122903e9ecfa3bcf1120275e13600da2674b0
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `eb9ebfa9e7b5230ea0961215c39da1bd204278fa`
- Image tag: `sha-eb9ebfa9e7b5230ea0961215c39da1bd204278fa`
- Image digest: `sha256:14dad3547c734cd97dc971d2a80122903e9ecfa3bcf1120275e13600da2674b0`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher