### PR TITLE
chore(torghut): promote hyperliquid feed image sha-cc325fe7716f9dc465e08485e8aa8e2b81f15fe5

### DIFF
--- a/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
@@ -32,18 +32,18 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-hyperliquid-feed
-          image: registry.ide-newton.ts.net/lab/torghut-hyperliquid-feed@sha256:068f5f2f97eee3d7bdcd1b8a942cc7128408f97bcad2da7c5309f8da636620d4
+          image: registry.ide-newton.ts.net/lab/torghut-hyperliquid-feed@sha256:aede6700c5b42c683263c17dbdd2526c970eb0bf58f8d0c357fb64789f8566c3
           imagePullPolicy: Always
           envFrom:
             - configMapRef:
                 name: torghut-hyperliquid-feed-config
           env:
             - name: TORGHUT_HYPERLIQUID_FEED_VERSION
-              value: main-sha-9abb853c837fd369e1d96e70f0d54c5576f86277
+              value: main-sha-cc325fe7716f9dc465e08485e8aa8e2b81f15fe5
             - name: TORGHUT_HYPERLIQUID_FEED_COMMIT
-              value: 9abb853c837fd369e1d96e70f0d54c5576f86277
+              value: cc325fe7716f9dc465e08485e8aa8e2b81f15fe5
             - name: TORGHUT_HYPERLIQUID_FEED_IMAGE_DIGEST
-              value: sha256:068f5f2f97eee3d7bdcd1b8a942cc7128408f97bcad2da7c5309f8da636620d4
+              value: sha256:aede6700c5b42c683263c17dbdd2526c970eb0bf58f8d0c357fb64789f8566c3
             - name: KAFKA_SASL_USER
               value: torghut-hyperliquid-feed
             - name: KAFKA_SASL_PASSWORD

--- a/argocd/applications/torghut-hyperliquid-feed/parity-cronjob.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/parity-cronjob.yaml
@@ -38,7 +38,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: torghut-hyperliquid-clickhouse-parity
-              image: registry.ide-newton.ts.net/lab/torghut-hyperliquid-feed@sha256:068f5f2f97eee3d7bdcd1b8a942cc7128408f97bcad2da7c5309f8da636620d4
+              image: registry.ide-newton.ts.net/lab/torghut-hyperliquid-feed@sha256:aede6700c5b42c683263c17dbdd2526c970eb0bf58f8d0c357fb64789f8566c3
               imagePullPolicy: Always
               envFrom:
                 - configMapRef:
@@ -47,11 +47,11 @@ spec:
                 - name: TORGHUT_HYPERLIQUID_MODE
                   value: clickhouse-parity
                 - name: TORGHUT_HYPERLIQUID_FEED_VERSION
-                  value: main-sha-9abb853c837fd369e1d96e70f0d54c5576f86277
+                  value: main-sha-cc325fe7716f9dc465e08485e8aa8e2b81f15fe5
                 - name: TORGHUT_HYPERLIQUID_FEED_COMMIT
-                  value: 9abb853c837fd369e1d96e70f0d54c5576f86277
+                  value: cc325fe7716f9dc465e08485e8aa8e2b81f15fe5
                 - name: TORGHUT_HYPERLIQUID_FEED_IMAGE_DIGEST
-                  value: sha256:068f5f2f97eee3d7bdcd1b8a942cc7128408f97bcad2da7c5309f8da636620d4
+                  value: sha256:aede6700c5b42c683263c17dbdd2526c970eb0bf58f8d0c357fb64789f8566c3
                 - name: KAFKA_SASL_USER
                   value: torghut-hyperliquid-feed
                 - name: KAFKA_SASL_PASSWORD

--- a/argocd/applications/torghut-hyperliquid-feed/writer-deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/writer-deployment.yaml
@@ -33,7 +33,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-hyperliquid-clickhouse-writer
-          image: registry.ide-newton.ts.net/lab/torghut-hyperliquid-feed@sha256:068f5f2f97eee3d7bdcd1b8a942cc7128408f97bcad2da7c5309f8da636620d4
+          image: registry.ide-newton.ts.net/lab/torghut-hyperliquid-feed@sha256:aede6700c5b42c683263c17dbdd2526c970eb0bf58f8d0c357fb64789f8566c3
           imagePullPolicy: Always
           envFrom:
             - configMapRef:
@@ -42,11 +42,11 @@ spec:
             - name: TORGHUT_HYPERLIQUID_MODE
               value: clickhouse-writer
             - name: TORGHUT_HYPERLIQUID_FEED_VERSION
-              value: main-sha-9abb853c837fd369e1d96e70f0d54c5576f86277
+              value: main-sha-cc325fe7716f9dc465e08485e8aa8e2b81f15fe5
             - name: TORGHUT_HYPERLIQUID_FEED_COMMIT
-              value: 9abb853c837fd369e1d96e70f0d54c5576f86277
+              value: cc325fe7716f9dc465e08485e8aa8e2b81f15fe5
             - name: TORGHUT_HYPERLIQUID_FEED_IMAGE_DIGEST
-              value: sha256:068f5f2f97eee3d7bdcd1b8a942cc7128408f97bcad2da7c5309f8da636620d4
+              value: sha256:aede6700c5b42c683263c17dbdd2526c970eb0bf58f8d0c357fb64789f8566c3
             - name: KAFKA_SASL_USER
               value: torghut-hyperliquid-feed
             - name: KAFKA_SASL_PASSWORD


### PR DESCRIPTION
## Summary

- Promote the immutable Torghut Hyperliquid feed image built from `cc325fe7716f9dc465e08485e8aa8e2b81f15fe5`.
- Pin the feed, Kafka-backed ClickHouse writer, and suspended parity gate to `sha256:aede6700c5b42c683263c17dbdd2526c970eb0bf58f8d0c357fb64789f8566c3`.
- Preserve one source commit and image digest across all runtime modes.

## Related Issues

None.

## Testing

- The source commit passed its required CI before merge to `main`.
- The release workflow verified the multi-architecture image contract before creating this PR.
- The deploy gate validates both manifests against source `cc325fe7716f9dc465e08485e8aa8e2b81f15fe5` and tag `sha-cc325fe7716f9dc465e08485e8aa8e2b81f15fe5`.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact automated release validation.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] All runtime manifests carry the same immutable source and image identity.