### PR TITLE
fix(atlas): restore semantic retrieval

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,17 @@
 - Check the nearest `README` or nested `AGENTS.md` for component-specific rules.
 - Keep this root guide repository-wide. Add new path-specific rules to the nearest nested `AGENTS.md` instead of expanding the global instruction chain.
 
+## GPT-5.6 Sol Usage
+
+- `gpt-5.6-sol` is this repository's frontier-capability default; the public `gpt-5.6` alias routes to Sol. Do not switch model families or raise reasoning effort merely as a substitute for missing evidence or tests.
+- Give the model the outcome, material domain context, hard constraints, approval boundaries, success criteria, required evidence, and output shape. Let it choose ordinary implementation steps instead of prescribing a brittle procedure.
+- Keep prompts and tool descriptions lean: state each durable rule once, expose only relevant tools, and retain examples only when they encode a product requirement or correct a measured failure.
+- Gather context in a bounded loop: search broadly once, focus on the converged files and contracts, deduplicate reads, stop when the change and validation path are known, and search again only when validation exposes a new unknown.
+- For new GPT-5.6 integrations, start at `medium` reasoning, use `low` for measured latency-sensitive work, move to `high` or `xhigh` only for measured quality gains, and reserve `max` for the hardest quality-first workloads. Preserve an existing evaluated setting when migrating, then compare one level lower.
+- Use the Responses API for tool-using or multi-turn integrations and preserve response output items and applicable reasoning context across turns. Use programmatic tool calling only for bounded tool-heavy work that does not need fresh judgment between calls.
+
+Sources: [OpenAI GPT-5.6 model guidance](https://developers.openai.com/api/docs/guides/latest-model) and the [OpenAI GPT-5 prompting guide](https://developers.openai.com/cookbook/examples/gpt-5/gpt-5_prompting_guide).
+
 ## Repository Map
 
 - `apps/`: Next.js and TanStack frontends; tests are co-located.

--- a/services/jangar/src/server/__tests__/atlas-code-search.integration.test.ts
+++ b/services/jangar/src/server/__tests__/atlas-code-search.integration.test.ts
@@ -37,7 +37,7 @@ integration('Atlas code search PostgreSQL integration', () => {
   beforeAll(async () => {
     if (!databaseUrl) throw new Error('integration database was not configured')
     process.env.ATLAS_CODE_SEARCH_STATEMENT_TIMEOUT_MS = '250'
-    process.env.ATLAS_CODE_SEARCH_SEMANTIC_TIMEOUT_MS = '1000'
+    process.env.ATLAS_CODE_SEARCH_SEMANTIC_TIMEOUT_MS = '300'
     db = createKyselyDb(databaseUrl)
     lockDb = createKyselyDb(databaseUrl)
     await sql`DROP SCHEMA IF EXISTS atlas CASCADE;`.execute(db)

--- a/services/jangar/src/server/__tests__/atlas-store.test.ts
+++ b/services/jangar/src/server/__tests__/atlas-store.test.ts
@@ -582,6 +582,22 @@ describe('atlas store', () => {
     expect(exactSql?.sql.toLowerCase()).not.toMatch(/file_chunks\.content\s+%\s+\$/)
   })
 
+  it('keeps exact content candidates for literal queries that are not declaration identifiers', async () => {
+    const { db, calls } = makeFakeDb({ selectRows: [] })
+    const store = createPostgresAtlasStore({
+      url: 'postgresql://user:pass@localhost:5432/db',
+      createDb: () => db,
+    })
+
+    await store.codeSearch({ query: 'docker:25.0-dind', repository: 'proompteng/lab', ref: 'main' })
+
+    const exactSql = calls.find((call) => call.sql.toLowerCase().includes(' as exact_rank'))
+    const normalized = String(exactSql?.sql).toLowerCase().replace(/\s+/g, ' ')
+    const candidates = normalized.slice(normalized.indexOf('with exact_candidates'), normalized.indexOf(') select'))
+    expect(candidates).toContain('union select file_chunks.id as chunk_id from atlas.file_chunks as file_chunks')
+    expect(candidates).toContain('file_chunks.content ilike')
+  })
+
   it('pushes corpus and caller filters into every materialized exact-candidate scan', async () => {
     const { db, calls } = makeFakeDb({ selectRows: [] })
     const store = createPostgresAtlasStore({
@@ -645,7 +661,7 @@ describe('atlas store', () => {
     expect(calls.some((call) => call.sql.toLowerCase().includes('from atlas.chunk_embeddings'))).toBe(false)
   })
 
-  it('skips whole-query content scans but keeps semantic retrieval for natural-language queries containing a path', async () => {
+  it('keeps content and semantic retrieval for natural-language queries containing a path', async () => {
     const { db, calls } = makeFakeDb({ selectRows: [] })
     const store = createPostgresAtlasStore({
       url: 'postgresql://user:pass@localhost:5432/db',
@@ -660,8 +676,7 @@ describe('atlas store', () => {
 
     const exactSql = calls.find((call) => call.sql.toLowerCase().includes(' as exact_rank'))
     const normalized = String(exactSql?.sql).toLowerCase().replace(/\s+/g, ' ')
-    const candidates = normalized.slice(normalized.indexOf('with exact_candidates'), normalized.indexOf(') select'))
-    expect(candidates).not.toContain('union select file_chunks.id as chunk_id from atlas.file_chunks as file_chunks')
+    expect(normalized).toContain('union select file_chunks.id as chunk_id from atlas.file_chunks as file_chunks')
     expect(calls.some((call) => call.sql.toLowerCase().includes('from atlas.chunk_embeddings'))).toBe(true)
   })
 
@@ -768,7 +783,7 @@ describe('atlas store', () => {
     expect(matches[0]?.signals.matchedIdentifiers).toEqual(['BUMBA_ATLAS_CHUNK_INDEXING'])
   })
 
-  it('does not let lexical-only matches crowd the best semantic result out of the first page', async () => {
+  it('breaks top-result RRF ties in favor of the best semantic result', async () => {
     const lexicalRows = Array.from({ length: 10 }, (_, index) =>
       makeCodeSearchRow({
         chunk_id: `lexical-${index}`,
@@ -791,13 +806,12 @@ describe('atlas store', () => {
       query: 'where are unsupported Git file modes and oversized files rejected before indexing',
       repository: 'proompteng/lab',
       ref: 'main',
-      limit: 10,
+      limit: 1,
     })
 
-    const semanticRank = matches.findIndex((match) => match.chunk.id === 'semantic-target')
-    expect(semanticRank).toBeGreaterThanOrEqual(0)
-    expect(semanticRank).toBeLessThan(3)
-    expect(matches[semanticRank]?.retrievalMode).toBe('semantic')
+    expect(matches).toHaveLength(1)
+    expect(matches[0]?.chunk.id).toBe('semantic-target')
+    expect(matches[0]?.retrievalMode).toBe('semantic')
   })
 
   it('keeps generic content substring matches on the RRF score scale', async () => {

--- a/services/jangar/src/server/__tests__/atlas-store.test.ts
+++ b/services/jangar/src/server/__tests__/atlas-store.test.ts
@@ -261,6 +261,7 @@ describe('atlas store', () => {
       'ATLAS_CODE_SEARCH_EMBEDDING_MODEL',
       'ATLAS_CODE_SEARCH_EMBEDDING_DIMENSION',
       'ATLAS_CODE_SEARCH_SEMANTIC_TIMEOUT_MS',
+      'ATLAS_CODE_SEARCH_STATEMENT_TIMEOUT_MS',
       'ATLAS_CODE_SEARCH_QUERY_EMBEDDING_CACHE_TTL_MS',
       'ATLAS_CODE_SEARCH_SEMANTIC_CANDIDATE_LIMIT',
       'ATLAS_CODE_SEARCH_HEALTH_SAMPLE_LIMIT',
@@ -275,6 +276,7 @@ describe('atlas store', () => {
     process.env.ATLAS_CODE_SEARCH_EMBEDDING_MODEL = 'test-embedding'
     process.env.ATLAS_CODE_SEARCH_EMBEDDING_DIMENSION = '3'
     process.env.ATLAS_CODE_SEARCH_SEMANTIC_TIMEOUT_MS = '1000'
+    process.env.ATLAS_CODE_SEARCH_STATEMENT_TIMEOUT_MS = '250'
     process.env.ATLAS_CODE_SEARCH_QUERY_EMBEDDING_CACHE_TTL_MS = '1'
     globalThis.fetch = vi.fn(async () =>
       Response.json({ data: [{ embedding: [0.1, 0.2, 0.3] }] }),
@@ -463,9 +465,12 @@ describe('atlas store', () => {
     expect(semanticSql?.sql.toLowerCase()).not.toContain('candidate_chunks')
     expect(semanticSql?.sql.toLowerCase()).toContain('order by chunk_embeddings.embedding <=> $')
     expect(semanticSql?.params.at(-1)).toBe(20)
-    expect(calls.some((call) => call.sql.toLowerCase().includes("set_config('statement_timeout'"))).toBe(true)
+    const statementTimeouts = calls
+      .filter((call) => call.sql.toLowerCase().includes("set_config('statement_timeout'"))
+      .flatMap((call) => call.params)
+    expect(statementTimeouts).toEqual(['250ms', '1000ms'])
     const hnswBudgetSql = calls.find((call) => call.sql.toLowerCase().includes("set_config('hnsw.ef_search'"))
-    expect(hnswBudgetSql?.params).toContain('20')
+    expect(hnswBudgetSql?.params).toContain('40')
   })
 
   it('uses an exact materialized semantic scan for narrow caller scopes', async () => {
@@ -585,7 +590,7 @@ describe('atlas store', () => {
     })
 
     await store.codeSearch({
-      query: 'source search implementation',
+      query: 'createAtlasCodeSearchHandlers',
       repository: 'proompteng/lab',
       ref: 'main',
       pathPrefix: 'services/jangar',
@@ -640,7 +645,7 @@ describe('atlas store', () => {
     expect(calls.some((call) => call.sql.toLowerCase().includes('from atlas.chunk_embeddings'))).toBe(false)
   })
 
-  it('keeps content and semantic retrieval for natural-language queries containing a path', async () => {
+  it('skips whole-query content scans but keeps semantic retrieval for natural-language queries containing a path', async () => {
     const { db, calls } = makeFakeDb({ selectRows: [] })
     const store = createPostgresAtlasStore({
       url: 'postgresql://user:pass@localhost:5432/db',
@@ -655,7 +660,8 @@ describe('atlas store', () => {
 
     const exactSql = calls.find((call) => call.sql.toLowerCase().includes(' as exact_rank'))
     const normalized = String(exactSql?.sql).toLowerCase().replace(/\s+/g, ' ')
-    expect(normalized).toContain('union select file_chunks.id as chunk_id from atlas.file_chunks as file_chunks')
+    const candidates = normalized.slice(normalized.indexOf('with exact_candidates'), normalized.indexOf(') select'))
+    expect(candidates).not.toContain('union select file_chunks.id as chunk_id from atlas.file_chunks as file_chunks')
     expect(calls.some((call) => call.sql.toLowerCase().includes('from atlas.chunk_embeddings'))).toBe(true)
   })
 
@@ -762,6 +768,38 @@ describe('atlas store', () => {
     expect(matches[0]?.signals.matchedIdentifiers).toEqual(['BUMBA_ATLAS_CHUNK_INDEXING'])
   })
 
+  it('does not let lexical-only matches crowd the best semantic result out of the first page', async () => {
+    const lexicalRows = Array.from({ length: 10 }, (_, index) =>
+      makeCodeSearchRow({
+        chunk_id: `lexical-${index}`,
+        file_key_path: `schemas/generated/lexical-${index}.json`,
+        lexical_rank: 1 - index / 100,
+      }),
+    )
+    const semantic = makeCodeSearchRow({
+      chunk_id: 'semantic-target',
+      file_key_path: 'services/bumba/src/atlas/file-eligibility.ts',
+      semantic_distance: 0.18,
+    })
+    const { db } = makeFakeDb({ exactRows: [], lexicalRows, semanticRows: [semantic] })
+    const store = createPostgresAtlasStore({
+      url: 'postgresql://user:pass@localhost:5432/db',
+      createDb: () => db,
+    })
+
+    const matches = await store.codeSearch({
+      query: 'where are unsupported Git file modes and oversized files rejected before indexing',
+      repository: 'proompteng/lab',
+      ref: 'main',
+      limit: 10,
+    })
+
+    const semanticRank = matches.findIndex((match) => match.chunk.id === 'semantic-target')
+    expect(semanticRank).toBeGreaterThanOrEqual(0)
+    expect(semanticRank).toBeLessThan(3)
+    expect(matches[semanticRank]?.retrievalMode).toBe('semantic')
+  })
+
   it('keeps generic content substring matches on the RRF score scale', async () => {
     const generic = makeCodeSearchRow({
       chunk_id: 'generic-content-chunk',
@@ -779,7 +817,7 @@ describe('atlas store', () => {
 
     expect(matches).toHaveLength(1)
     expect(matches[0]?.signals.exactRank).toBe(0.75)
-    expect(matches[0]?.score).toBeCloseTo(3 / 61)
+    expect(matches[0]?.score).toBeCloseTo(1 / 61)
     expect(matches[0]?.score).toBeLessThan(0.1)
   })
 

--- a/services/jangar/src/server/atlas-code-search.ts
+++ b/services/jangar/src/server/atlas-code-search.ts
@@ -119,6 +119,7 @@ const MAX_SEARCH_LIMIT = 200
 const MIN_SEMANTIC_CANDIDATES = 20
 const SEMANTIC_CANDIDATE_MULTIPLIER = 2
 const MAX_EXACT_SCOPED_SEMANTIC_CANDIDATES = 500
+const MIN_HNSW_EF_SEARCH = 40
 const DEFAULT_CODE_SEARCH_SEMANTIC_TIMEOUT_MS = 12_000
 const DEFAULT_CODE_SEARCH_STATEMENT_TIMEOUT_MS = 750
 const MAX_CODE_SEARCH_STATEMENT_TIMEOUT_MS = 900
@@ -528,9 +529,11 @@ export const createAtlasCodeSearchHandlers = ({
       : vectorToPgArray(await embedCodeSearchQuery(resolvedQuery, embeddingConfig))
     const containsPattern = `%${escapeLikePattern(resolvedQuery)}%`
     const whereClause = searchWhereClause(filters)
-    const contentCandidateUnion = isPathQuery
-      ? sql``
-      : sql`
+    const definitionPattern = buildDefinitionPattern(resolvedQuery)
+    const contentCandidateUnion =
+      isPathQuery || definitionPattern === null
+        ? sql``
+        : sql`
           UNION
 
           SELECT file_chunks.id AS chunk_id
@@ -542,7 +545,6 @@ export const createAtlasCodeSearchHandlers = ({
             AND file_chunks.content IS NOT NULL
             AND file_chunks.content ILIKE ${containsPattern} ESCAPE '\'
         `
-    const definitionPattern = buildDefinitionPattern(resolvedQuery)
     const definitionRankClause = definitionPattern
       ? sql`WHEN file_chunks.content ~ ${definitionPattern} THEN 0.98`
       : sql``
@@ -553,8 +555,8 @@ export const createAtlasCodeSearchHandlers = ({
     )
     const statementTimeoutMs = parsePositiveIntEnv(
       'ATLAS_CODE_SEARCH_STATEMENT_TIMEOUT_MS',
-      Math.min(DEFAULT_CODE_SEARCH_STATEMENT_TIMEOUT_MS, Math.max(250, semanticTimeoutMs - 250)),
-      Math.min(MAX_CODE_SEARCH_STATEMENT_TIMEOUT_MS, Math.max(250, semanticTimeoutMs - 250)),
+      DEFAULT_CODE_SEARCH_STATEMENT_TIMEOUT_MS,
+      MAX_CODE_SEARCH_STATEMENT_TIMEOUT_MS,
     )
 
     const { exactRows, lexicalRows, semanticRows } = await db.transaction().execute(async (trx) => {
@@ -611,6 +613,7 @@ export const createAtlasCodeSearchHandlers = ({
 
       let semanticRows: AtlasCodeSearchRow[] = []
       if (vectorString !== null) {
+        await sql`SELECT set_config('statement_timeout', ${`${semanticTimeoutMs}ms`}, true);`.execute(trx)
         let requiresExactScopedSemanticScan = false
         if (filters.pathPrefix) {
           const scopedCount = await sql<{ candidate_count: number | string }>`
@@ -656,7 +659,9 @@ export const createAtlasCodeSearchHandlers = ({
           `.execute(trx)
           semanticRows = semanticResult.rows as AtlasCodeSearchRow[]
         } else {
-          await sql`SELECT set_config('hnsw.ef_search', ${String(semanticCandidateLimit)}, true);`.execute(trx)
+          await sql`SELECT set_config('hnsw.ef_search', ${String(
+            Math.max(MIN_HNSW_EF_SEARCH, semanticCandidateLimit),
+          )}, true);`.execute(trx)
 
           const semanticResult = await sql<AtlasCodeSearchRow>`
             SELECT
@@ -715,9 +720,9 @@ export const createAtlasCodeSearchHandlers = ({
         merged.set(row.chunk_id, entry)
       })
     }
-    addRows(exactRows, 'exact', 3)
-    addRows(lexicalRows, 'lexical', 2)
+    addRows(exactRows, 'exact', 1)
     addRows(semanticRows, 'semantic', 1)
+    addRows(lexicalRows, 'lexical', 1)
 
     return [...merged.values()]
       .map((entry) => {

--- a/services/jangar/src/server/atlas-code-search.ts
+++ b/services/jangar/src/server/atlas-code-search.ts
@@ -529,11 +529,9 @@ export const createAtlasCodeSearchHandlers = ({
       : vectorToPgArray(await embedCodeSearchQuery(resolvedQuery, embeddingConfig))
     const containsPattern = `%${escapeLikePattern(resolvedQuery)}%`
     const whereClause = searchWhereClause(filters)
-    const definitionPattern = buildDefinitionPattern(resolvedQuery)
-    const contentCandidateUnion =
-      isPathQuery || definitionPattern === null
-        ? sql``
-        : sql`
+    const contentCandidateUnion = isPathQuery
+      ? sql``
+      : sql`
           UNION
 
           SELECT file_chunks.id AS chunk_id
@@ -545,6 +543,7 @@ export const createAtlasCodeSearchHandlers = ({
             AND file_chunks.content IS NOT NULL
             AND file_chunks.content ILIKE ${containsPattern} ESCAPE '\'
         `
+    const definitionPattern = buildDefinitionPattern(resolvedQuery)
     const definitionRankClause = definitionPattern
       ? sql`WHEN file_chunks.content ~ ${definitionPattern} THEN 0.98`
       : sql``
@@ -740,7 +739,12 @@ export const createAtlasCodeSearchHandlers = ({
           retrievalMode,
         )
       })
-      .sort((left, right) => right.score - left.score || left.fileKey.path.localeCompare(right.fileKey.path))
+      .sort(
+        (left, right) =>
+          right.score - left.score ||
+          Number(right.signals.semanticDistance !== null) - Number(left.signals.semanticDistance !== null) ||
+          left.fileKey.path.localeCompare(right.fileKey.path),
+      )
       .slice(0, resolvedLimit)
   }
 


### PR DESCRIPTION
## Summary

- give semantic vector SQL its explicit 12-second database budget while keeping exact and lexical statements tightly bounded, and restore the HNSW search floor to 40
- use equal-weight reciprocal-rank fusion with a semantic-aware top-result tie-breaker so weak lexical-only hits cannot evict the best semantic result, while preserving literal and high-confidence exact matches
- document concise GPT-5.6 Sol agent usage from official OpenAI guidance

## Related Issues

None.

## Testing

- `bunx vitest run --config vitest.config.ts src/server/__tests__/atlas-store.test.ts src/server/__tests__/atlas-rest.test.ts src/server/__tests__/atlas-code-search.integration.test.ts` from `services/jangar` (31 passed, 4 integration tests skipped without a disposable PostgreSQL URL before review fixes)
- focused post-review Atlas store suite (24 passed), including top-1 semantic tie-breaking and punctuated literal exact-search regressions
- `bunx tsc --noEmit -p services/jangar/tsconfig.app.json`
- `bunx oxfmt --check services/jangar/src/server/atlas-code-search.ts services/jangar/src/server/__tests__/atlas-store.test.ts services/jangar/src/server/__tests__/atlas-code-search.integration.test.ts`
- `bunx oxlint --config .oxlintrc.json services/jangar/src/server/atlas-code-search.ts services/jangar/src/server/__tests__/atlas-store.test.ts services/jangar/src/server/__tests__/atlas-code-search.integration.test.ts`
- `git diff origin/main...HEAD --check`
- live read-only evidence: the HNSW plan took 1.49 seconds cold, exceeding the old 750 ms budget; raw semantic rank 1 for the novel eligibility query was `services/bumba/src/atlas/file-eligibility.ts` at cosine distance `0.1889`

## Breaking Changes

Atlas hybrid result ordering changes to equal-weight reciprocal-rank fusion with semantic-first score tie-breaking. No schema migration, corpus rebuild, or API shape change is required.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
