### PR TITLE
fix(registry): unblock OCI manifest publication

### DIFF
--- a/argocd/applications/registry/haproxy.cfg
+++ b/argocd/applications/registry/haproxy.cfg
@@ -18,9 +18,16 @@ frontend registry
   bind :8080
   filter bwlim-in registry_upload default-limit 1m default-period 1s
   acl write_request method POST PUT PATCH DELETE
+  acl manifest_write method PUT
+  acl manifest_path path_reg ^/v2/.+/manifests/[^/]+$
   http-request set-bandwidth-limit registry_upload if write_request
+  use_backend registry_manifest_write if manifest_write manifest_path
   use_backend registry_write if write_request
   default_backend registry_read
+
+backend registry_manifest_write
+  option http-server-close
+  server registry 127.0.0.1:5000 maxconn 4 maxqueue 32 check
 
 backend registry_write
   option http-server-close

--- a/docs/torghut/storage-write-pressure-remediation-design.md
+++ b/docs/torghut/storage-write-pressure-remediation-design.md
@@ -384,6 +384,19 @@ immediately afterward. That exceeds the two-second storage gate even though requ
 registry boundary must therefore also shape mutation request bodies to 1 MiB/s. This keeps the shared Ceph write path
 bounded independently of publisher implementation while leaving `GET` and `HEAD` image pulls unthrottled.
 
+A later production build exposed a liveness defect in that first boundary. A large blob upload occupied the only write
+connection while completed multi-architecture builds queued their small image-manifest and index `PUT` requests behind
+it. The Torghut publisher spent more than ten minutes in `crane index append` without sending the index to Distribution;
+live HAProxy socket state showed full client receive queues waiting behind the single backend connection. Repeating the
+publisher reproduced the same head-of-line blocking.
+
+Manifest commits now have a separate, bounded four-connection backend selected only for `PUT
+/v2/<repository>/manifests/<reference>`. All mutation bodies remain subject to the 1 MiB/s frontend limit, while blob
+upload initiation, transfer, finalization, and deletion remain on the original single-connection queue. The exception is
+safe because an image manifest or index is only a few KiB and Distribution rejects references to blobs that are not
+already present. This restores publication liveness without reopening the large-blob fan-out that caused the Ceph write
+burst.
+
 After request-body shaping rolls out, dispatch the current Analysis `main` workflow through build and push, then start
 a new 30-minute observation from a fresh SMART baseline. The gate must show no controller event above two seconds. If
 the shaped workload still fails that gate, stop the rollout and investigate the remaining measured writer instead of

--- a/packages/scripts/src/shared/__tests__/registry.test.ts
+++ b/packages/scripts/src/shared/__tests__/registry.test.ts
@@ -22,12 +22,23 @@ const backendBlock = (name: string): string => {
 }
 
 describe('private registry write-pressure boundary', () => {
-  it('rate-limits every registry mutation through one shared backend connection', () => {
+  it('rate-limits every mutation while keeping tiny manifest commits out of the blob queue', () => {
     expect(haproxyConfig).toContain('filter bwlim-in registry_upload default-limit 1m default-period 1s')
     expect(haproxyConfig).toContain('acl write_request method POST PUT PATCH DELETE')
+    expect(haproxyConfig).toContain('acl manifest_write method PUT')
+    expect(haproxyConfig).toContain('acl manifest_path path_reg ^/v2/.+/manifests/[^/]+$')
     expect(haproxyConfig).toContain('http-request set-bandwidth-limit registry_upload if write_request')
+    expect(haproxyConfig).toContain('use_backend registry_manifest_write if manifest_write manifest_path')
     expect(haproxyConfig).toContain('use_backend registry_write if write_request')
     expect(haproxyConfig).toContain('default_backend registry_read')
+    expect(haproxyConfig.indexOf('use_backend registry_manifest_write')).toBeLessThan(
+      haproxyConfig.indexOf('use_backend registry_write'),
+    )
+
+    const manifestWriteBackend = backendBlock('registry_manifest_write')
+    expect(manifestWriteBackend).toContain('option http-server-close')
+    expect(manifestWriteBackend).toContain('127.0.0.1:5000 maxconn 4 maxqueue 32 check')
+    expect(manifestWriteBackend).not.toContain('maxconn 1 ')
 
     const writeBackend = backendBlock('registry_write')
     expect(writeBackend).toContain('option http-server-close')


### PR DESCRIPTION
## Summary

- route OCI manifest and index PUT requests through a separate bounded four-connection backend
- preserve the 1 MiB/s mutation limit and single-connection bulk blob queue that protect Ceph
- add regression coverage and document the reproduced Torghut publication liveness failure

## Related Issues

None.

## Testing

- `nix develop -c bun test packages/scripts/src/shared/__tests__/registry.test.ts` (4 passed, 34 assertions)
- `nix develop -c bunx oxfmt --check packages/scripts/src/shared/__tests__/registry.test.ts docs/torghut/storage-write-pressure-remediation-design.md`
- pinned HAProxy 3.2.21 config validation under the production non-root, read-only security context (exit 0)
- local Distribution plus HAProxy protocol proof: an empty OCI index PUT returned 201 in 0.049801 seconds while an 8 MiB blob PATCH held the serialized bulk-write lane
- `nix develop -c bun run lint:argocd` (all rendered resources valid)
- `nix develop -c sh -c "kustomize build --enable-helm argocd/applications/registry | kubectl apply --server-side --dry-run=server --force-conflicts -n registry -f -"`
- `git diff --check`

## Breaking Changes

One brief registry Recreate rollout is expected. In-flight image publishers may retry; image pulls resume after the replacement pod becomes ready.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] Documentation, release notes, and follow-ups are updated or tracked.