### PR TITLE
fix(registry): expire abandoned uploads

### DIFF
--- a/argocd/applications/registry/haproxy.cfg
+++ b/argocd/applications/registry/haproxy.cfg
@@ -8,8 +8,9 @@ defaults
   option httplog
   option dontlognull
   timeout connect 5s
-  timeout client 2h
-  timeout server 2h
+  # Healthy shaped uploads continuously transfer data; bound inactivity so a canceled upload cannot retain the writer.
+  timeout client 5m
+  timeout server 5m
   timeout queue 2h
   timeout http-request 30s
   timeout http-keep-alive 1m

--- a/docs/torghut/storage-write-pressure-remediation-design.md
+++ b/docs/torghut/storage-write-pressure-remediation-design.md
@@ -372,10 +372,12 @@ for a registry-wide write boundary.
 The definitive boundary is therefore attached to the singleton registry itself. Its Service terminates at an HAProxy
 sidecar that routes `POST`, `PUT`, `PATCH`, and `DELETE` requests through one backend connection while preserving a
 separate concurrent path for `GET` and `HEAD` image pulls. The write backend closes its server connection after each
-response so the single slot cannot remain captured by an idle publisher, and queues at most 128 write requests for up
-to two hours. A generated ConfigMap name forces a pod rollout on proxy-policy changes, and `Recreate` prevents two
-registry pods from competing for the RWO filesystem during that rollout. This covers Docker, BuildKit, and direct OCI
-publishers at the same shared choke point without reducing pull concurrency.
+response. Client and server inactivity are bounded at five minutes so a canceled or stalled request body cannot retain
+the single write slot; healthy shaped uploads continuously transfer data and therefore reset the inactivity timer. The
+proxy queues at most 128 write requests for up to two hours. A generated ConfigMap name forces a pod rollout on
+proxy-policy changes, and `Recreate` prevents two registry pods from competing for the RWO filesystem during that
+rollout. This covers Docker, BuildKit, and direct OCI publishers at the same shared choke point without reducing pull
+concurrency.
 
 The first post-proxy Analysis run, `29411750432` at source revision `89a019b4`, proved that the proxy serialized all 12
 mutation requests, with a maximum queue time of 10.211 seconds. It also exposed a second-order limit: one

--- a/packages/scripts/src/shared/__tests__/registry.test.ts
+++ b/packages/scripts/src/shared/__tests__/registry.test.ts
@@ -31,6 +31,9 @@ describe('private registry write-pressure boundary', () => {
     expect(haproxyConfig).toContain('use_backend registry_manifest_write if manifest_write manifest_path')
     expect(haproxyConfig).toContain('use_backend registry_write if write_request')
     expect(haproxyConfig).toContain('default_backend registry_read')
+    expect(haproxyConfig).toContain('timeout client 5m')
+    expect(haproxyConfig).toContain('timeout server 5m')
+    expect(haproxyConfig).toContain('timeout queue 2h')
     expect(haproxyConfig.indexOf('use_backend registry_manifest_write')).toBeLessThan(
       haproxyConfig.indexOf('use_backend registry_write'),
     )


### PR DESCRIPTION
## Summary

- bound registry client/server inactivity at five minutes so canceled uploads cannot retain the singleton write slot for two hours
- preserve the one-writer queue and 1 MiB/s request-body shaping that protect the shared Ceph pool
- add focused configuration assertions and document the cancellation behavior

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/registry.test.ts` (4 passed)
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/registry.test.ts docs/torghut/storage-write-pressure-remediation-design.md`
- `nix shell nixpkgs#haproxy --command haproxy -c -V -f argocd/applications/registry/haproxy.cfg`
- `nix develop --command bun run lint:argocd` (all rendered resource groups, 0 invalid)
- `git diff --check`

## Breaking Changes

None. Healthy uploads continuously transfer data and reset the inactivity timer; the two-hour queue deadline is unchanged.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
