### PR TITLE
fix(torghut): version paper lifecycle validation

### DIFF
--- a/services/torghut/app/models/entities/broker_mutation_validation_contract.py
+++ b/services/torghut/app/models/entities/broker_mutation_validation_contract.py
@@ -50,22 +50,22 @@ purpose <> 'control_plane_validation' OR COALESCE((
       > 0
   AND (canonical_intent_json::jsonb #>>
        '{request,infrastructure_validation,permit,max_notional_usd}')::numeric
-      <= CASE
-          WHEN canonical_intent_json::jsonb #>>
-               '{request,infrastructure_validation,test_plan,schema_version}' =
-               'torghut.infrastructure-validation-lifecycle-plan.v1'
-          THEN 30 ELSE 1
+      <= CASE canonical_intent_json::jsonb #>>
+              '{request,infrastructure_validation,test_plan,schema_version}'
+          WHEN 'torghut.infrastructure-validation-lifecycle-plan.v1' THEN 5
+          WHEN 'torghut.infrastructure-validation-lifecycle-plan.v2' THEN 30
+          ELSE 1
          END
   AND (canonical_intent_json::jsonb #>>
        '{request,infrastructure_validation,permit,max_loss_usd}')::numeric
       > 0
   AND (canonical_intent_json::jsonb #>>
        '{request,infrastructure_validation,permit,max_loss_usd}')::numeric
-      <= CASE
-          WHEN canonical_intent_json::jsonb #>>
-               '{request,infrastructure_validation,test_plan,schema_version}' =
-               'torghut.infrastructure-validation-lifecycle-plan.v1'
-          THEN 30 ELSE 1
+      <= CASE canonical_intent_json::jsonb #>>
+              '{request,infrastructure_validation,test_plan,schema_version}'
+          WHEN 'torghut.infrastructure-validation-lifecycle-plan.v1' THEN 5
+          WHEN 'torghut.infrastructure-validation-lifecycle-plan.v2' THEN 30
+          ELSE 1
          END
   AND (canonical_intent_json::jsonb #>>
        '{request,infrastructure_validation,permit,max_loss_usd}')::numeric
@@ -117,7 +117,8 @@ purpose <> 'control_plane_validation' OR COALESCE((
   AND canonical_intent_json::jsonb #>>
       '{request,infrastructure_validation,test_plan,schema_version}' IN (
       'torghut.infrastructure-validation-order-plan.v1',
-      'torghut.infrastructure-validation-lifecycle-plan.v1')
+      'torghut.infrastructure-validation-lifecycle-plan.v1',
+      'torghut.infrastructure-validation-lifecycle-plan.v2')
   AND canonical_intent_json::jsonb #>>
       '{request,infrastructure_validation,test_plan,venue}' = 'alpaca'
   AND canonical_intent_json::jsonb #>>
@@ -181,8 +182,9 @@ purpose <> 'control_plane_validation' OR COALESCE((
       '{request,infrastructure_validation,test_plan,stop_price}' = 'null'::jsonb
   AND (
       canonical_intent_json::jsonb #>>
-          '{request,infrastructure_validation,test_plan,schema_version}' <>
-          'torghut.infrastructure-validation-lifecycle-plan.v1'
+          '{request,infrastructure_validation,test_plan,schema_version}' NOT IN (
+          'torghut.infrastructure-validation-lifecycle-plan.v1',
+          'torghut.infrastructure-validation-lifecycle-plan.v2')
       OR COALESCE((
         ((canonical_intent_json::jsonb #>
           '{request,infrastructure_validation,test_plan}') - ARRAY[
@@ -198,18 +200,25 @@ purpose <> 'control_plane_validation' OR COALESCE((
              '{request,infrastructure_validation,test_plan,partial_close_qty}')::numeric
             < (canonical_intent_json::jsonb #>>
                '{request,infrastructure_validation,test_plan,qty}')::numeric
-        AND (canonical_intent_json::jsonb #>>
+        AND (
+          canonical_intent_json::jsonb #>>
+              '{request,infrastructure_validation,test_plan,schema_version}' <>
+              'torghut.infrastructure-validation-lifecycle-plan.v2'
+          OR (
+            (canonical_intent_json::jsonb #>>
              '{request,infrastructure_validation,test_plan,partial_close_qty}')::numeric *
-            (canonical_intent_json::jsonb #>>
-             '{request,infrastructure_validation,test_plan,limit_price}')::numeric
-            >= 12
-        AND ((canonical_intent_json::jsonb #>>
-              '{request,infrastructure_validation,test_plan,qty}')::numeric -
-             (canonical_intent_json::jsonb #>>
-              '{request,infrastructure_validation,test_plan,partial_close_qty}')::numeric) *
-            (canonical_intent_json::jsonb #>>
-             '{request,infrastructure_validation,test_plan,limit_price}')::numeric
-            >= 12
+                (canonical_intent_json::jsonb #>>
+                 '{request,infrastructure_validation,test_plan,limit_price}')::numeric
+                >= 12
+            AND ((canonical_intent_json::jsonb #>>
+                  '{request,infrastructure_validation,test_plan,qty}')::numeric -
+                 (canonical_intent_json::jsonb #>>
+                  '{request,infrastructure_validation,test_plan,partial_close_qty}')::numeric) *
+                (canonical_intent_json::jsonb #>>
+                 '{request,infrastructure_validation,test_plan,limit_price}')::numeric
+                >= 12
+          )
+        )
         AND (canonical_intent_json::jsonb #>>
              '{request,infrastructure_validation,test_plan,resting_close_limit_price}')::numeric
             > (canonical_intent_json::jsonb #>>

--- a/services/torghut/app/trading/alpaca_reduction_mutations.py
+++ b/services/torghut/app/trading/alpaca_reduction_mutations.py
@@ -37,6 +37,9 @@ from .broker_mutation_receipts import (
     fingerprint_broker_endpoint,
 )
 from .firewall import OrderFirewall
+from .infrastructure_validation import (
+    is_infrastructure_validation_lifecycle_plan_schema,
+)
 from .infrastructure_validation_records import (
     InfrastructureValidationEvidence,
     infrastructure_validation_lineage_payload,
@@ -643,8 +646,9 @@ class AlpacaReductionMutationExecutor:
             raise RuntimeError("infrastructure_validation_lineage_scope_mismatch")
         if (
             require_position_ancestry
-            and evidence.root_plan_schema
-            != "torghut.infrastructure-validation-lifecycle-plan.v1"
+            and not is_infrastructure_validation_lifecycle_plan_schema(
+                evidence.root_plan_schema
+            )
         ):
             raise RuntimeError("infrastructure_validation_position_ancestry_missing")
 

--- a/services/torghut/app/trading/infrastructure_validation.py
+++ b/services/torghut/app/trading/infrastructure_validation.py
@@ -23,6 +23,15 @@ _MAX_PERMIT_LIFETIME = timedelta(minutes=15)
 _MAX_SUBMIT_PROOF_NOTIONAL_USD = Decimal("1")
 _MAX_LIFECYCLE_NOTIONAL_USD = Decimal("30")
 _MIN_LIFECYCLE_LEG_PLAN_NOTIONAL_USD = Decimal("12")
+INFRASTRUCTURE_VALIDATION_LIFECYCLE_PLAN_SCHEMA_VERSION = (
+    "torghut.infrastructure-validation-lifecycle-plan.v2"
+)
+_INFRASTRUCTURE_VALIDATION_LIFECYCLE_PLAN_SCHEMA_VERSIONS = frozenset(
+    {
+        "torghut.infrastructure-validation-lifecycle-plan.v1",
+        INFRASTRUCTURE_VALIDATION_LIFECYCLE_PLAN_SCHEMA_VERSION,
+    }
+)
 _VALIDATION_HOSTS = {
     "alpaca": "paper-api.alpaca.markets",
     "hyperliquid": "api.hyperliquid-testnet.xyz",
@@ -179,7 +188,7 @@ class InfrastructureValidationOrderPlan(_InfrastructureValidationPlanBase):
 class InfrastructureValidationLifecyclePlan(_InfrastructureValidationPlanBase):
     """One bounded fill followed only by independently authorized reductions."""
 
-    schema_version: Literal["torghut.infrastructure-validation-lifecycle-plan.v1"]
+    schema_version: Literal["torghut.infrastructure-validation-lifecycle-plan.v2"]
     resting_close_limit_price: Decimal = Field(gt=0)
     replacement_close_limit_price: Decimal = Field(gt=0)
     partial_close_qty: Decimal = Field(gt=0)
@@ -324,6 +333,15 @@ def infrastructure_validation_lifecycle_plan_sha256(
     return infrastructure_validation_plan_sha256(plan)
 
 
+def is_infrastructure_validation_lifecycle_plan_schema(value: object) -> bool:
+    """Recognize both immutable historical v1 and current floor-enforced v2."""
+
+    return (
+        isinstance(value, str)
+        and value in _INFRASTRUCTURE_VALIDATION_LIFECYCLE_PLAN_SCHEMA_VERSIONS
+    )
+
+
 def infrastructure_validation_plan_sha256(
     plan: InfrastructureValidationSubmitPlan,
 ) -> str:
@@ -446,6 +464,7 @@ def _canonical_json(payload: Mapping[str, object]) -> str:
 
 
 __all__ = [
+    "INFRASTRUCTURE_VALIDATION_LIFECYCLE_PLAN_SCHEMA_VERSION",
     "InfrastructureValidationLifecyclePlan",
     "InfrastructureValidationPermit",
     "InfrastructureValidationOrderPlan",
@@ -460,4 +479,5 @@ __all__ = [
     "infrastructure_validation_request_payload",
     "infrastructure_validation_terminal_state_payload",
     "infrastructure_validation_terminal_state_sha256",
+    "is_infrastructure_validation_lifecycle_plan_schema",
 ]

--- a/services/torghut/app/trading/infrastructure_validation_lifecycle_proof.py
+++ b/services/torghut/app/trading/infrastructure_validation_lifecycle_proof.py
@@ -23,6 +23,9 @@ from ..models import (
     TradeDecisionSubmissionClaim,
 )
 from .broker_mutation_receipts import fingerprint_broker_endpoint
+from .infrastructure_validation import (
+    INFRASTRUCTURE_VALIDATION_LIFECYCLE_PLAN_SCHEMA_VERSION,
+)
 from .infrastructure_validation_lifecycle_broker import (
     InfrastructureValidationLifecycleContext,
 )
@@ -109,7 +112,7 @@ class InfrastructureValidationLifecycleProof:
                     )
                 if (
                     evidence.root_plan_schema
-                    != "torghut.infrastructure-validation-lifecycle-plan.v1"
+                    != INFRASTRUCTURE_VALIDATION_LIFECYCLE_PLAN_SCHEMA_VERSION
                 ):
                     raise RuntimeError(
                         "infrastructure_validation_position_ancestry_missing"

--- a/services/torghut/app/trading/infrastructure_validation_records.py
+++ b/services/torghut/app/trading/infrastructure_validation_records.py
@@ -25,6 +25,9 @@ from .evidence_contracts import (
     EvidenceMaturity,
     evidence_contract_payload,
 )
+from .infrastructure_validation import (
+    is_infrastructure_validation_lifecycle_plan_schema,
+)
 
 
 _EVIDENCE_KEY = "_torghut_evidence_contract"
@@ -229,9 +232,8 @@ def _require_infrastructure_validation_position_event(
     expected_position_quantity: Decimal,
     require_positive_position: bool,
 ) -> InfrastructureValidationPositionEvidence:
-    if (
+    if not is_infrastructure_validation_lifecycle_plan_schema(
         evidence.root_plan_schema
-        != "torghut.infrastructure-validation-lifecycle-plan.v1"
     ):
         raise RuntimeError("infrastructure_validation_position_ancestry_missing")
     normalized_symbol = symbol.strip().upper()
@@ -601,18 +603,17 @@ def _require_lineage_target(
         raise RuntimeError(
             "infrastructure_validation_receipt_evidence_invalid"
         ) from exc
+    lifecycle_root = is_infrastructure_validation_lifecycle_plan_schema(
+        root_plan_schema
+    )
     target_matches = {
-        "submit_order": root_plan_schema
-        == "torghut.infrastructure-validation-lifecycle-plan.v1"
+        "submit_order": lifecycle_root
         and receipt.target_key == root_symbol
         and request.get("symbol") == root_symbol,
         "replace_order": receipt.target_key == parent_broker_order_id,
         "cancel_order": receipt.target_key == parent_broker_order_id,
-        "close_position": root_plan_schema
-        == "torghut.infrastructure-validation-lifecycle-plan.v1"
-        and receipt.target_key == root_symbol,
-        "close_all_positions": root_plan_schema
-        == "torghut.infrastructure-validation-lifecycle-plan.v1"
+        "close_position": lifecycle_root and receipt.target_key == root_symbol,
+        "close_all_positions": lifecycle_root
         and request.get("symbols") == [root_symbol],
     }.get(receipt.operation, False)
     if not target_matches:

--- a/services/torghut/migrations/versions/0073_live_paper_lifecycle_bounds.py
+++ b/services/torghut/migrations/versions/0073_live_paper_lifecycle_bounds.py
@@ -7,6 +7,8 @@ Create Date: 2026-07-15 20:00:00.000000
 
 from __future__ import annotations
 
+import re
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.schema import conv
@@ -22,7 +24,15 @@ _CONSTRAINT = "ck_bm_receipt_validation_authority"
 _OLD_CAP = 5
 _NEW_CAP = 30
 _MIN_LEG_NOTIONAL = 12
-_LIFECYCLE_SCHEMA = "torghut.infrastructure-validation-lifecycle-plan.v1"
+_LEGACY_LIFECYCLE_SCHEMA = "torghut.infrastructure-validation-lifecycle-plan.v1"
+_LIFECYCLE_SCHEMA = "torghut.infrastructure-validation-lifecycle-plan.v2"
+_LINEAGE_FUNCTION = "torghut_guard_bm_validation_lineage_0072"
+_LINEAGE_SCHEMA_GUARD_COUNT = 3
+_LEGACY_ROOT_FUNCTION = "torghut_reject_bm_validation_lifecycle_v1_0073"
+_LEGACY_ROOT_TRIGGER = "trg_reject_bm_validation_lifecycle_v1_0073"
+_LEGACY_ROOT_RETIREMENT_ERROR = (
+    "infrastructure validation lifecycle v1 receipts are read-only"
+)
 
 
 def _numeric_plan_field(field: str) -> str:
@@ -39,12 +49,41 @@ def _numeric_permit_field(field: str) -> str:
     )
 
 
+def _plan_schema_value() -> str:
+    return (
+        "canonical_intent_json::jsonb #>> "
+        "'{request,infrastructure_validation,test_plan,schema_version}'::text[]"
+    )
+
+
+def _plan_schema_field() -> str:
+    return f"({_plan_schema_value()})"
+
+
 def _cap_fragment(field: str, cap: int) -> str:
     return f"{_numeric_permit_field(field)} <= {cap}::numeric"
 
 
+def _versioned_cap_fragment(field: str) -> str:
+    return (
+        f"{_numeric_permit_field(field)} <=\n"
+        f"CASE {_plan_schema_value()}\n"
+        f"    WHEN '{_LEGACY_LIFECYCLE_SCHEMA}'::text THEN {_OLD_CAP}::numeric\n"
+        f"    WHEN '{_LIFECYCLE_SCHEMA}'::text THEN {_NEW_CAP}::numeric\n"
+        "    ELSE NULL::numeric\n"
+        "END"
+    )
+
+
 def _partial_close_bound_fragment() -> str:
     return f"{_numeric_plan_field('partial_close_qty')} < {_numeric_plan_field('qty')}"
+
+
+def _resting_close_bound_fragment() -> str:
+    return (
+        f"{_numeric_plan_field('resting_close_limit_price')} > "
+        f"{_numeric_plan_field('limit_price')}"
+    )
 
 
 def _leg_floor_fragments() -> tuple[str, str]:
@@ -59,44 +98,125 @@ def _leg_floor_fragments() -> tuple[str, str]:
     )
 
 
+def _schema_predicate(schema: str) -> str:
+    return f"{_plan_schema_field()} = '{schema}'::text"
+
+
+def _schema_pair_predicate() -> str:
+    return (
+        f"{_plan_schema_field()} = ANY (ARRAY["
+        f"'{_LEGACY_LIFECYCLE_SCHEMA}'::text, '{_LIFECYCLE_SCHEMA}'::text])"
+    )
+
+
+def _floor_guard_fragment() -> str:
+    return (
+        f"{_plan_schema_field()} <> '{_LIFECYCLE_SCHEMA}'::text OR ("
+        f"{' AND '.join(_leg_floor_fragments())})"
+    )
+
+
 def _rewrite_lifecycle_authority(
     definition: str,
     *,
-    old_cap: int,
-    new_cap: int,
-    add_leg_floors: bool,
+    upgrade: bool,
 ) -> str:
     prefix = "CHECK ("
     if not definition.startswith(prefix) or not definition.endswith(")"):
         raise RuntimeError("validation_authority_constraint_shape_invalid")
     condition = definition[len(prefix) : -1]
-    if condition.count(_LIFECYCLE_SCHEMA) != 1:
-        raise RuntimeError("validation_authority_lifecycle_schema_invalid")
-    for field in ("max_notional_usd", "max_loss_usd"):
-        old_fragment = _cap_fragment(field, old_cap)
-        if condition.count(old_fragment) != 1:
-            raise RuntimeError(f"validation_authority_{field}_cap_invalid")
-        condition = condition.replace(
-            old_fragment,
-            _cap_fragment(field, new_cap),
-            1,
-        )
     partial_bound = _partial_close_bound_fragment()
-    floor_clause = " AND ".join(_leg_floor_fragments())
-    if add_leg_floors:
-        if condition.count(partial_bound) != 1 or floor_clause in condition:
+    bounded_floor_clause = f"{partial_bound} AND ({_floor_guard_fragment()})"
+    if upgrade:
+        legacy_schema = _schema_predicate(_LEGACY_LIFECYCLE_SCHEMA)
+        if condition.count(legacy_schema) != 1 or _LIFECYCLE_SCHEMA in condition:
+            raise RuntimeError("validation_authority_lifecycle_schema_invalid")
+        condition = condition.replace(legacy_schema, _schema_pair_predicate(), 1)
+        for field in ("max_notional_usd", "max_loss_usd"):
+            legacy_cap = _cap_fragment(field, _OLD_CAP)
+            if condition.count(legacy_cap) != 1:
+                raise RuntimeError(f"validation_authority_{field}_cap_invalid")
+            condition = condition.replace(
+                legacy_cap,
+                _versioned_cap_fragment(field),
+                1,
+            )
+        if condition.count(partial_bound) != 1 or any(
+            fragment in condition for fragment in _leg_floor_fragments()
+        ):
             raise RuntimeError("validation_authority_leg_floor_shape_invalid")
         condition = condition.replace(
             partial_bound,
-            f"{partial_bound} AND {floor_clause}",
+            bounded_floor_clause,
             1,
         )
     else:
-        bounded_floor_clause = f"{partial_bound} AND {floor_clause}"
-        if condition.count(bounded_floor_clause) != 1:
+        if condition.count(_schema_pair_predicate()) != 1:
+            raise RuntimeError("validation_authority_lifecycle_schema_invalid")
+        condition = condition.replace(
+            _schema_pair_predicate(),
+            _schema_predicate(_LEGACY_LIFECYCLE_SCHEMA),
+            1,
+        )
+        for field in ("max_notional_usd", "max_loss_usd"):
+            versioned_cap = _versioned_cap_fragment(field)
+            if condition.count(versioned_cap) != 1:
+                raise RuntimeError(f"validation_authority_{field}_cap_invalid")
+            condition = condition.replace(
+                versioned_cap,
+                _cap_fragment(field, _OLD_CAP),
+                1,
+            )
+        floor_guard_start = (
+            f" AND ({_plan_schema_field()} <> '{_LIFECYCLE_SCHEMA}'::text OR "
+        )
+        floor_guard_end = f" AND {_resting_close_bound_fragment()}"
+        if condition.count(floor_guard_start) != 1:
             raise RuntimeError("validation_authority_leg_floor_shape_invalid")
-        condition = condition.replace(bounded_floor_clause, partial_bound, 1)
+        start = condition.index(floor_guard_start)
+        end = condition.find(floor_guard_end, start)
+        if end < 0:
+            raise RuntimeError("validation_authority_leg_floor_shape_invalid")
+        floor_guard = condition[start:end]
+        if (
+            floor_guard.count(f">= {_MIN_LEG_NOTIONAL}::numeric") != 2
+            or "partial_close_qty" not in floor_guard
+            or "limit_price" not in floor_guard
+        ):
+            raise RuntimeError("validation_authority_leg_floor_shape_invalid")
+        condition = f"{condition[:start]}{condition[end:]}"
     return condition
+
+
+def _rewrite_lineage_function(definition: str, *, upgrade: bool) -> str:
+    legacy_guard = (
+        r"root_plan_schema\s+IS\s+DISTINCT\s+FROM\s+"
+        f"'{re.escape(_LEGACY_LIFECYCLE_SCHEMA)}'"
+    )
+    versioned_guard = (
+        r"\(\s*root_plan_schema\s+IS\s+DISTINCT\s+FROM\s+"
+        rf"'{re.escape(_LEGACY_LIFECYCLE_SCHEMA)}'\s+AND\s+"
+        r"root_plan_schema\s+IS\s+DISTINCT\s+FROM\s+"
+        rf"'{re.escape(_LIFECYCLE_SCHEMA)}'\s*\)"
+    )
+    old_guard, new_guard = (
+        (
+            legacy_guard,
+            "(root_plan_schema IS DISTINCT FROM "
+            f"'{_LEGACY_LIFECYCLE_SCHEMA}' AND "
+            "root_plan_schema IS DISTINCT FROM "
+            f"'{_LIFECYCLE_SCHEMA}')",
+        )
+        if upgrade
+        else (
+            versioned_guard,
+            f"root_plan_schema IS DISTINCT FROM '{_LEGACY_LIFECYCLE_SCHEMA}'",
+        )
+    )
+    rewritten, count = re.subn(old_guard, new_guard, definition)
+    if count != _LINEAGE_SCHEMA_GUARD_COUNT:
+        raise RuntimeError("validation_lineage_function_schema_invalid")
+    return rewritten
 
 
 def _current_constraint_definition() -> str:
@@ -120,6 +240,20 @@ def _current_constraint_definition() -> str:
     return definition
 
 
+def _current_lineage_function_definition() -> str:
+    definition = (
+        op.get_bind()
+        .execute(
+            sa.text("SELECT pg_get_functiondef(to_regprocedure(:signature))"),
+            {"signature": f"{_LINEAGE_FUNCTION}()"},
+        )
+        .scalar_one_or_none()
+    )
+    if not isinstance(definition, str):
+        raise RuntimeError("validation_lineage_function_missing")
+    return definition
+
+
 def _install_constraint(condition: str) -> None:
     op.drop_constraint(conv(_CONSTRAINT), "broker_mutation_receipts", type_="check")
     op.execute(
@@ -140,17 +274,58 @@ def _install_constraint(condition: str) -> None:
     )
 
 
+def _install_lineage_function(definition: str) -> None:
+    op.execute(sa.text(definition))
+
+
+def _install_legacy_root_retirement_guard() -> None:
+    op.execute(
+        sa.text(
+            f"""
+            CREATE FUNCTION {_LEGACY_ROOT_FUNCTION}() RETURNS trigger AS $torghut$
+            BEGIN
+                RAISE EXCEPTION '{_LEGACY_ROOT_RETIREMENT_ERROR}'
+                    USING ERRCODE = '23514';
+            END;
+            $torghut$ LANGUAGE plpgsql
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            f"""
+            CREATE TRIGGER {_LEGACY_ROOT_TRIGGER}
+            BEFORE INSERT ON broker_mutation_receipts
+            FOR EACH ROW
+            WHEN ((NEW.canonical_intent_json::jsonb #>>
+                '{{request,infrastructure_validation,test_plan,schema_version}}') =
+                '{_LEGACY_LIFECYCLE_SCHEMA}')
+            EXECUTE FUNCTION {_LEGACY_ROOT_FUNCTION}()
+            """
+        )
+    )
+
+
+def _remove_legacy_root_retirement_guard() -> None:
+    op.execute(
+        sa.text(f"DROP TRIGGER {_LEGACY_ROOT_TRIGGER} ON broker_mutation_receipts")
+    )
+    op.execute(sa.text(f"DROP FUNCTION {_LEGACY_ROOT_FUNCTION}()"))
+
+
 def upgrade() -> None:
     op.execute(
         sa.text("LOCK TABLE broker_mutation_receipts IN ACCESS EXCLUSIVE MODE NOWAIT")
     )
     condition = _rewrite_lifecycle_authority(
-        _current_constraint_definition(),
-        old_cap=_OLD_CAP,
-        new_cap=_NEW_CAP,
-        add_leg_floors=True,
+        _current_constraint_definition(), upgrade=True
+    )
+    lineage_function = _rewrite_lineage_function(
+        _current_lineage_function_definition(), upgrade=True
     )
     _install_constraint(condition)
+    _install_lineage_function(lineage_function)
+    _install_legacy_root_retirement_guard()
 
 
 def downgrade() -> None:
@@ -169,18 +344,9 @@ def downgrade() -> None:
                        AND canonical_intent_json::jsonb #>>
                            '{{request,infrastructure_validation,test_plan,schema_version}}' =
                            '{_LIFECYCLE_SCHEMA}'
-                       AND (
-                           (canonical_intent_json::jsonb #>>
-                            '{{request,infrastructure_validation,permit,max_notional_usd}}')::numeric
-                           > {_OLD_CAP}
-                           OR
-                           (canonical_intent_json::jsonb #>>
-                            '{{request,infrastructure_validation,permit,max_loss_usd}}')::numeric
-                           > {_OLD_CAP}
-                       )
                 ) THEN
                     RAISE EXCEPTION
-                        'cannot downgrade with lifecycle receipts above the old cap';
+                        'cannot downgrade with lifecycle v2 receipts';
                 END IF;
             END
             $torghut$;
@@ -188,9 +354,11 @@ def downgrade() -> None:
         )
     )
     condition = _rewrite_lifecycle_authority(
-        _current_constraint_definition(),
-        old_cap=_NEW_CAP,
-        new_cap=_OLD_CAP,
-        add_leg_floors=False,
+        _current_constraint_definition(), upgrade=False
     )
+    lineage_function = _rewrite_lineage_function(
+        _current_lineage_function_definition(), upgrade=False
+    )
+    _remove_legacy_root_retirement_guard()
     _install_constraint(condition)
+    _install_lineage_function(lineage_function)

--- a/services/torghut/tests/execution/infrastructure_validation_postgres_support.py
+++ b/services/torghut/tests/execution/infrastructure_validation_postgres_support.py
@@ -46,6 +46,67 @@ def upgrade_validation_submit_schema(
     command.upgrade(alembic, "0068_validation_submit")
 
 
+def upgrade_reduction_schema(
+    alembic: AlembicConfig,
+    schema_engine: Engine,
+    *,
+    target: str = "0071_validation_lineage",
+) -> None:
+    """Apply the accelerated reduction lineage and its catalog prerequisites."""
+
+    command.stamp(alembic, "0057_generic_multifactor_machine")
+    command.upgrade(alembic, "0061_linked_submission_terminal")
+    command.stamp(alembic, "0065_strategy_capital_compat")
+    with schema_engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                CREATE TABLE torghut_options_contract_catalog (
+                    contract_symbol TEXT PRIMARY KEY,
+                    status TEXT NOT NULL
+                )
+                """
+            )
+        )
+        if target in {
+            "0072_validation_lifecycle",
+            "0073_live_paper_bounds",
+        }:
+            connection.execute(
+                text(
+                    """
+                    CREATE TABLE execution_order_events (
+                        id UUID PRIMARY KEY,
+                        event_fingerprint VARCHAR(64) NOT NULL UNIQUE,
+                        source_topic VARCHAR(128) NOT NULL,
+                        source_partition INTEGER,
+                        source_offset BIGINT,
+                        alpaca_account_label VARCHAR(64) NOT NULL,
+                        feed_seq BIGINT,
+                        event_ts TIMESTAMPTZ,
+                        symbol VARCHAR(64),
+                        alpaca_order_id VARCHAR(128),
+                        client_order_id VARCHAR(128),
+                        event_type VARCHAR(64),
+                        status VARCHAR(32),
+                        qty NUMERIC(20, 8),
+                        filled_qty NUMERIC(20, 8),
+                        filled_qty_delta NUMERIC(20, 8),
+                        avg_fill_price NUMERIC(20, 8),
+                        filled_notional_delta NUMERIC(20, 8),
+                        fill_quantity_basis VARCHAR(32),
+                        raw_event JSONB NOT NULL,
+                        execution_id UUID,
+                        trade_decision_id UUID,
+                        source_window_id UUID,
+                        created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+                    )
+                    """
+                )
+            )
+    command.upgrade(alembic, target)
+
+
 def validation_fixture(
     now: datetime,
     *,
@@ -108,7 +169,7 @@ def validation_lifecycle_fixture(
 ) -> tuple[InfrastructureValidationPermit, InfrastructureValidationLifecyclePlan]:
     plan = InfrastructureValidationLifecyclePlan.model_validate(
         {
-            "schema_version": "torghut.infrastructure-validation-lifecycle-plan.v1",
+            "schema_version": "torghut.infrastructure-validation-lifecycle-plan.v2",
             "venue": "alpaca",
             "asset_class": "crypto",
             "symbol": "BTC/USD",

--- a/services/torghut/tests/execution/test_broker_reduction_coordinator_postgres.py
+++ b/services/torghut/tests/execution/test_broker_reduction_coordinator_postgres.py
@@ -9,7 +9,6 @@ import pytest
 from alembic import command
 from alembic.config import Config as AlembicConfig
 from sqlalchemy import select, text
-from sqlalchemy.engine import Engine
 from sqlalchemy.exc import DBAPIError, IntegrityError
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -61,67 +60,9 @@ from tests.execution.decision_submission_claims_postgres_support import (
     drop_schema,
 )
 from tests.execution.infrastructure_validation_postgres_support import (
+    upgrade_reduction_schema as _upgrade_reduction_schema,
     validation_lifecycle_fixture,
 )
-
-
-def _upgrade_reduction_schema(
-    alembic: AlembicConfig,
-    schema_engine: Engine,
-    *,
-    target: str = "0071_validation_lineage",
-) -> None:
-    command.stamp(alembic, "0057_generic_multifactor_machine")
-    command.upgrade(alembic, "0061_linked_submission_terminal")
-    command.stamp(alembic, "0065_strategy_capital_compat")
-    with schema_engine.begin() as connection:
-        connection.execute(
-            text(
-                """
-                CREATE TABLE torghut_options_contract_catalog (
-                    contract_symbol TEXT PRIMARY KEY,
-                    status TEXT NOT NULL
-                )
-                """
-            )
-        )
-        if target in {
-            "0072_validation_lifecycle",
-            "0073_live_paper_bounds",
-        }:
-            connection.execute(
-                text(
-                    """
-                    CREATE TABLE execution_order_events (
-                        id UUID PRIMARY KEY,
-                        event_fingerprint VARCHAR(64) NOT NULL UNIQUE,
-                        source_topic VARCHAR(128) NOT NULL,
-                        source_partition INTEGER,
-                        source_offset BIGINT,
-                        alpaca_account_label VARCHAR(64) NOT NULL,
-                        feed_seq BIGINT,
-                        event_ts TIMESTAMPTZ,
-                        symbol VARCHAR(64),
-                        alpaca_order_id VARCHAR(128),
-                        client_order_id VARCHAR(128),
-                        event_type VARCHAR(64),
-                        status VARCHAR(32),
-                        qty NUMERIC(20, 8),
-                        filled_qty NUMERIC(20, 8),
-                        filled_qty_delta NUMERIC(20, 8),
-                        avg_fill_price NUMERIC(20, 8),
-                        filled_notional_delta NUMERIC(20, 8),
-                        fill_quantity_basis VARCHAR(32),
-                        raw_event JSONB NOT NULL,
-                        execution_id UUID,
-                        trade_decision_id UUID,
-                        source_window_id UUID,
-                        created_at TIMESTAMPTZ NOT NULL DEFAULT now()
-                    )
-                    """
-                )
-            )
-    command.upgrade(alembic, target)
 
 
 @pytest.mark.skipif(

--- a/services/torghut/tests/execution/test_infrastructure_validation_lifecycle_bounds_postgres.py
+++ b/services/torghut/tests/execution/test_infrastructure_validation_lifecycle_bounds_postgres.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import copy
+from datetime import datetime, timezone
+from typing import cast
+
+import pytest
+from alembic import command
+from alembic.config import Config as AlembicConfig
+from sqlalchemy import select, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.config import settings
+from app.models import BrokerMutationReceipt
+from app.trading.broker_mutation_receipts import (
+    BrokerMutationIntent,
+    BrokerMutationIntentRequest,
+    BrokerMutationTarget,
+    acquire_broker_mutation_receipt,
+    build_broker_mutation_intent,
+    fingerprint_broker_endpoint,
+)
+from app.trading.infrastructure_validation import (
+    infrastructure_validation_client_order_id,
+    infrastructure_validation_request_payload,
+)
+from tests.execution.decision_submission_claims_postgres_support import (
+    POSTGRES_DSN,
+    SERVICE_ROOT,
+    create_schema_engines,
+    drop_schema,
+)
+from tests.execution.infrastructure_validation_postgres_support import (
+    upgrade_reduction_schema,
+    validation_lifecycle_fixture,
+)
+
+
+@pytest.mark.skipif(
+    not POSTGRES_DSN,
+    reason="set TORGHUT_TEST_POSTGRES_DSN for lifecycle migration compatibility",
+)
+def test_postgres_lifecycle_v2_preserves_released_v1_receipts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    schema, admin_engine, schema_engine, schema_dsn = create_schema_engines(
+        "lifecycle_v2_compatibility"
+    )
+    sessions = sessionmaker(
+        bind=schema_engine,
+        class_=Session,
+        autoflush=False,
+        expire_on_commit=False,
+        future=True,
+    )
+    try:
+        monkeypatch.setattr(settings, "db_dsn", schema_dsn)
+        alembic = AlembicConfig(str(SERVICE_ROOT / "alembic.ini"))
+        upgrade_reduction_schema(
+            alembic,
+            schema_engine,
+            target="0072_validation_lifecycle",
+        )
+        legacy_intent = _legacy_lifecycle_intent(
+            datetime.now(timezone.utc),
+            permit_suffix="released-v1",
+        )
+        with sessions() as session:
+            acquire_broker_mutation_receipt(
+                session,
+                intent=legacy_intent,
+                primary_owner="released-v1-regression",
+                writer_generation=1,
+            )
+
+        command.upgrade(alembic, "0073_live_paper_bounds")
+        with schema_engine.connect() as connection:
+            assert (
+                connection.scalar(
+                    text(
+                        "SELECT convalidated FROM pg_constraint "
+                        "WHERE conrelid = 'broker_mutation_receipts'::regclass "
+                        "AND conname = 'ck_bm_receipt_validation_authority'"
+                    )
+                )
+                is True
+            )
+            upgraded_constraint = str(
+                connection.scalar(
+                    text(
+                        "SELECT pg_get_constraintdef(oid, true) "
+                        "FROM pg_constraint "
+                        "WHERE conrelid = 'broker_mutation_receipts'::regclass "
+                        "AND conname = 'ck_bm_receipt_validation_authority'"
+                    )
+                )
+            )
+            upgraded_lineage = str(
+                connection.scalar(
+                    text(
+                        "SELECT pg_get_functiondef(to_regprocedure("
+                        "'torghut_guard_bm_validation_lineage_0072()'))"
+                    )
+                )
+            )
+            upgraded_retirement_trigger_count = connection.scalar(
+                text(
+                    "SELECT count(*) FROM pg_trigger WHERE tgname = "
+                    "'trg_reject_bm_validation_lifecycle_v1_0073'"
+                )
+            )
+        assert (
+            upgraded_lineage.count(
+                "torghut.infrastructure-validation-lifecycle-plan.v2"
+            )
+            == 3
+        )
+        assert "root_plan_schema NOT IN" not in upgraded_lineage
+        assert upgraded_retirement_trigger_count == 1
+        assert (
+            "WHEN 'torghut.infrastructure-validation-lifecycle-plan.v1'::text "
+            "THEN 5::numeric"
+        ) in upgraded_constraint
+        assert (
+            "WHEN 'torghut.infrastructure-validation-lifecycle-plan.v2'::text "
+            "THEN 30::numeric"
+        ) in upgraded_constraint
+        with sessions() as session:
+            assert (
+                session.scalar(
+                    select(BrokerMutationReceipt.id).where(
+                        BrokerMutationReceipt.client_request_id
+                        == legacy_intent.client_request_id
+                    )
+                )
+                is not None
+            )
+
+        retired_v1 = _legacy_lifecycle_intent(
+            datetime.now(timezone.utc),
+            permit_suffix="retired-v1",
+        )
+        with sessions() as session:
+            with pytest.raises(
+                IntegrityError,
+                match="lifecycle v1 receipts are read-only",
+            ):
+                acquire_broker_mutation_receipt(
+                    session,
+                    intent=retired_v1,
+                    primary_owner="retired-v1-regression",
+                    writer_generation=1,
+                )
+
+        command.downgrade(alembic, "0072_validation_lifecycle")
+        with schema_engine.connect() as connection:
+            downgraded_constraint = str(
+                connection.scalar(
+                    text(
+                        "SELECT pg_get_constraintdef(oid, true) "
+                        "FROM pg_constraint "
+                        "WHERE conrelid = 'broker_mutation_receipts'::regclass "
+                        "AND conname = 'ck_bm_receipt_validation_authority'"
+                    )
+                )
+            )
+            downgraded_lineage = str(
+                connection.scalar(
+                    text(
+                        "SELECT pg_get_functiondef(to_regprocedure("
+                        "'torghut_guard_bm_validation_lineage_0072()'))"
+                    )
+                )
+            )
+            downgraded_retirement_trigger_count = connection.scalar(
+                text(
+                    "SELECT count(*) FROM pg_trigger WHERE tgname = "
+                    "'trg_reject_bm_validation_lifecycle_v1_0073'"
+                )
+            )
+        assert "torghut.infrastructure-validation-lifecycle-plan.v1" in (
+            downgraded_constraint
+        )
+        assert "torghut.infrastructure-validation-lifecycle-plan.v2" not in (
+            downgraded_constraint
+        )
+        assert downgraded_lineage.count("root_plan_schema IS DISTINCT FROM") == 3
+        assert downgraded_retirement_trigger_count == 0
+
+        command.upgrade(alembic, "0073_live_paper_bounds")
+    finally:
+        drop_schema(schema, admin_engine, schema_engine)
+
+
+def _legacy_lifecycle_intent(
+    now: datetime,
+    *,
+    permit_suffix: str,
+) -> BrokerMutationIntent:
+    permit, plan = validation_lifecycle_fixture(
+        now,
+        permit_id=f"ivp-postgres-lifecycle-{permit_suffix}",
+    )
+    client_order_id = infrastructure_validation_client_order_id(permit, plan)
+    request_payload = copy.deepcopy(
+        infrastructure_validation_request_payload(permit, plan)
+    )
+    broker_request = cast(dict[str, object], request_payload["broker_request"])
+    validation = cast(dict[str, object], request_payload["infrastructure_validation"])
+    permit_payload = cast(dict[str, object], validation["permit"])
+    plan_payload = cast(dict[str, object], validation["test_plan"])
+
+    broker_request.update(qty="0.00004", limit_price="67000")
+    plan_payload.update(
+        schema_version="torghut.infrastructure-validation-lifecycle-plan.v1",
+        qty="0.00004",
+        limit_price="67000",
+        resting_close_limit_price="68000",
+        replacement_close_limit_price="69000",
+        partial_close_qty="0.00002",
+    )
+    permit_payload.update(
+        max_notional_usd="5",
+        max_loss_usd="5",
+        test_plan_digest="a" * 64,
+    )
+    validation["test_plan_sha256"] = "a" * 64
+
+    return build_broker_mutation_intent(
+        BrokerMutationIntentRequest(
+            broker_route="alpaca",
+            account_label=permit.account_label,
+            endpoint_fingerprint=fingerprint_broker_endpoint(
+                str(permit.broker_base_url)
+            ),
+            operation="submit_order",
+            risk_class="risk_neutral",
+            purpose="control_plane_validation",
+            workflow_id=client_order_id,
+            client_request_id=client_order_id,
+            target=BrokerMutationTarget(kind="order", key=client_order_id),
+            request_payload=request_payload,
+        )
+    )

--- a/services/torghut/tests/test_broker_mutation_receipt_models.py
+++ b/services/torghut/tests/test_broker_mutation_receipt_models.py
@@ -41,13 +41,16 @@ def _normalized_sql(sql: str) -> str:
 def _assert_lifecycle_validation_invariants(
     sql: str,
     *,
-    lifecycle_cap: int,
+    legacy_cap: int,
+    current_cap: int | None,
     leg_floor: int | None,
 ) -> None:
     normalized = _normalized_sql(sql)
 
     assert "torghut.infrastructure-validation-order-plan.v1" in normalized
     assert "torghut.infrastructure-validation-lifecycle-plan.v1" in normalized
+    if current_cap is not None:
+        assert "torghut.infrastructure-validation-lifecycle-plan.v2" in normalized
     assert "https://paper-api.alpaca.markets" in normalized
     assert "non_promotable_validation" in normalized
     assert "'{request,infrastructure_validation,permit,max_orders}' = '1'" in normalized
@@ -80,14 +83,26 @@ def _assert_lifecycle_validation_invariants(
             "'{request,infrastructure_validation,test_plan,partial_close_qty}')::numeric"
             in normalized
         )
-    assert normalized.count(f"THEN {lifecycle_cap} ELSE 1") == 2 or (
-        normalized.count(f"permit,max_notional_usd}}')::numeric <= {lifecycle_cap}")
-        == 1
-        and normalized.count(f"permit,max_loss_usd}}')::numeric <= {lifecycle_cap}")
-        == 1
-        and normalized.count("permit,max_notional_usd}')::numeric <= 1") == 1
-        and normalized.count("permit,max_loss_usd}')::numeric <= 1") == 1
-    )
+    if current_cap is None:
+        assert (
+            normalized.count(f"permit,max_notional_usd}}')::numeric <= {legacy_cap}")
+            == 1
+        )
+        assert (
+            normalized.count(f"permit,max_loss_usd}}')::numeric <= {legacy_cap}") == 1
+        )
+    else:
+        legacy_case = (
+            "WHEN 'torghut.infrastructure-validation-lifecycle-plan.v1' "
+            f"THEN {legacy_cap}"
+        )
+        current_case = (
+            "WHEN 'torghut.infrastructure-validation-lifecycle-plan.v2' "
+            f"THEN {current_cap}"
+        )
+        assert normalized.count(legacy_case) == 2
+        assert normalized.count(current_case) == 2
+        assert normalized.count("ELSE 1 END") == 2
 
 
 def _assert_lifecycle_lineage_invariants(sql: str) -> None:
@@ -204,17 +219,20 @@ def test_receipt_header_mirrors_validation_authority_and_permit_guards() -> None
     migration_lineage_sql = str(getattr(migration, "_LINEAGE_CONTRACT_0072"))
     _assert_lifecycle_validation_invariants(
         BROKER_MUTATION_VALIDATION_AUTHORITY_SQL,
-        lifecycle_cap=30,
+        legacy_cap=5,
+        current_cap=30,
         leg_floor=12,
     )
     _assert_lifecycle_validation_invariants(
         migration_validation_sql,
-        lifecycle_cap=5,
+        legacy_cap=5,
+        current_cap=None,
         leg_floor=None,
     )
     _assert_lifecycle_lineage_invariants(BROKER_MUTATION_VALIDATION_LINEAGE_SQL)
     _assert_lifecycle_lineage_invariants(migration_lineage_sql)
     assert "torghut.infrastructure-validation-lifecycle-plan.v1" in ddl
+    assert "torghut.infrastructure-validation-lifecycle-plan.v2" in ddl
     assert "operation IN ('submit_order', 'replace_order'" in ddl
 
 

--- a/services/torghut/tests/test_infrastructure_validation_lifecycle.py
+++ b/services/torghut/tests/test_infrastructure_validation_lifecycle.py
@@ -394,7 +394,7 @@ def lifecycle_runtime(
     monkeypatch.setattr(settings, "trading_kill_switch_enabled", False)
     plan = InfrastructureValidationLifecyclePlan.model_validate(
         {
-            "schema_version": "torghut.infrastructure-validation-lifecycle-plan.v1",
+            "schema_version": "torghut.infrastructure-validation-lifecycle-plan.v2",
             "venue": "alpaca",
             "asset_class": "crypto",
             "symbol": "BTC/USD",

--- a/services/torghut/tests/test_infrastructure_validation_lifecycle_bounds_migration.py
+++ b/services/torghut/tests/test_infrastructure_validation_lifecycle_bounds_migration.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -10,21 +10,51 @@ from tests.migration_testing import load_migration_module
 MIGRATION_FILENAME = "0073_live_paper_lifecycle_bounds.py"
 
 
-def _definition(module: object, cap: int, *, leg_floors: bool = False) -> str:
-    cap_fragment = getattr(module, "_cap_fragment")
-    partial_close_bound = getattr(module, "_partial_close_bound_fragment")()
-    floor_clause = " AND ".join(getattr(module, "_leg_floor_fragments")())
-    lifecycle_bounds = partial_close_bound
-    if leg_floors:
-        lifecycle_bounds = f"{lifecycle_bounds} AND {floor_clause}"
-    schema = getattr(module, "_LIFECYCLE_SCHEMA")
+def _definition(module: object, *, upgraded: bool = False) -> str:
+    resting_bound = getattr(module, "_resting_close_bound_fragment")()
+    if upgraded:
+        schema_predicate = getattr(module, "_schema_pair_predicate")()
+        cap_notional = getattr(module, "_versioned_cap_fragment")("max_notional_usd")
+        cap_loss = getattr(module, "_versioned_cap_fragment")("max_loss_usd")
+        lifecycle_bounds = (
+            f"{getattr(module, '_partial_close_bound_fragment')()} AND "
+            f"({getattr(module, '_floor_guard_fragment')()}) AND {resting_bound}"
+        )
+    else:
+        schema_predicate = getattr(module, "_schema_predicate")(
+            getattr(module, "_LEGACY_LIFECYCLE_SCHEMA")
+        )
+        cap = getattr(module, "_OLD_CAP")
+        raw_cap_fragment = getattr(module, "_cap_fragment")
+        cap_notional = raw_cap_fragment("max_notional_usd", cap)
+        cap_loss = raw_cap_fragment("max_loss_usd", cap)
+        lifecycle_bounds = (
+            f"{getattr(module, '_partial_close_bound_fragment')()} AND {resting_bound}"
+        )
     return (
         "CHECK (purpose <> 'control_plane_validation' OR ("
-        f"plan_schema = '{schema}' AND "
-        f"{cap_fragment('max_notional_usd', cap)} AND "
-        f"{cap_fragment('max_loss_usd', cap)} AND "
+        f"{schema_predicate} AND "
+        f"{cap_notional} AND "
+        f"{cap_loss} AND "
         f"{lifecycle_bounds}))"
     )
+
+
+def _lineage_definition(module: object, *, upgraded: bool = False) -> str:
+    legacy = getattr(module, "_LEGACY_LIFECYCLE_SCHEMA")
+    guard = f"root_plan_schema IS DISTINCT FROM\n    '{legacy}'"
+    assignment = (
+        "BEGIN\n"
+        "    lineage := NEW.canonical_intent_json::jsonb #>\n"
+        "        '{request,infrastructure_validation_lineage}';\n"
+    )
+    definition = assignment + "\n".join(f"IF {guard} THEN" for _ in range(3))
+    if upgraded:
+        return getattr(module, "_rewrite_lineage_function")(
+            definition,
+            upgrade=True,
+        )
+    return definition
 
 
 def test_revision_extends_the_released_lifecycle_schema() -> None:
@@ -34,22 +64,43 @@ def test_revision_extends_the_released_lifecycle_schema() -> None:
     assert module.down_revision == "0072_validation_lifecycle"
 
 
-def test_upgrade_rewrite_changes_caps_and_installs_both_leg_floors() -> None:
+def test_upgrade_rewrite_versions_caps_and_leg_floors() -> None:
     module = load_migration_module(MIGRATION_FILENAME)
-    definition = _definition(module, 5)
 
     condition = module._rewrite_lifecycle_authority(
-        definition,
-        old_cap=5,
-        new_cap=30,
-        add_leg_floors=True,
+        _definition(module),
+        upgrade=True,
     )
 
-    assert module._cap_fragment("max_notional_usd", 30) in condition
-    assert module._cap_fragment("max_loss_usd", 30) in condition
-    assert all(fragment in condition for fragment in module._leg_floor_fragments())
-    assert "purpose <> 'control_plane_validation'" in condition
-    assert "<= 5::numeric" not in condition
+    assert module._schema_pair_predicate() in condition
+    assert module._versioned_cap_fragment("max_notional_usd") in condition
+    assert module._versioned_cap_fragment("max_loss_usd") in condition
+    assert module._floor_guard_fragment() in condition
+    assert module._cap_fragment("max_notional_usd", 5) not in condition
+
+
+def test_authority_rewrite_round_trips_to_the_released_contract() -> None:
+    module = load_migration_module(MIGRATION_FILENAME)
+
+    downgraded = module._rewrite_lifecycle_authority(
+        _definition(module, upgraded=True),
+        upgrade=False,
+    )
+
+    assert f"CHECK ({downgraded})" == _definition(module)
+
+
+def test_lineage_rewrite_accepts_catalog_whitespace_and_round_trips() -> None:
+    module = load_migration_module(MIGRATION_FILENAME)
+    legacy_definition = _lineage_definition(module)
+
+    upgraded = module._rewrite_lineage_function(legacy_definition, upgrade=True)
+
+    assert upgraded.count(module._LIFECYCLE_SCHEMA) == 3
+    assert "NOT IN" not in upgraded
+    assert module._rewrite_lineage_function(upgraded, upgrade=False) == (
+        legacy_definition.replace("\n    '", " '")
+    )
 
 
 @pytest.mark.parametrize(
@@ -59,28 +110,34 @@ def test_upgrade_rewrite_changes_caps_and_installs_both_leg_floors() -> None:
         "CHECK (missing lifecycle schema)",
     ),
 )
-def test_cap_rewrite_fails_closed_on_catalog_drift(definition: str) -> None:
+def test_authority_rewrite_fails_closed_on_catalog_drift(definition: str) -> None:
     module = load_migration_module(MIGRATION_FILENAME)
 
     with pytest.raises(RuntimeError, match="validation_authority"):
-        module._rewrite_lifecycle_authority(
-            definition,
-            old_cap=5,
-            new_cap=30,
-            add_leg_floors=True,
-        )
+        module._rewrite_lifecycle_authority(definition, upgrade=True)
 
 
-def test_upgrade_locks_and_validates_the_rewritten_constraint() -> None:
+def test_lineage_rewrite_fails_closed_on_catalog_drift() -> None:
     module = load_migration_module(MIGRATION_FILENAME)
-    connection = Mock()
-    connection.execute.return_value.scalar_one_or_none.return_value = _definition(
-        module,
-        5,
-    )
+
+    with pytest.raises(RuntimeError, match="validation_lineage"):
+        module._rewrite_lineage_function("SELECT 1", upgrade=True)
+
+
+def test_upgrade_locks_and_validates_versioned_contracts() -> None:
+    module = load_migration_module(MIGRATION_FILENAME)
 
     with (
-        patch.object(module.op, "get_bind", return_value=connection),
+        patch.object(
+            module,
+            "_current_constraint_definition",
+            return_value=_definition(module),
+        ),
+        patch.object(
+            module,
+            "_current_lineage_function_definition",
+            return_value=_lineage_definition(module),
+        ),
         patch.object(module.op, "execute") as execute,
         patch.object(module.op, "drop_constraint") as drop_constraint,
     ):
@@ -88,11 +145,15 @@ def test_upgrade_locks_and_validates_the_rewritten_constraint() -> None:
 
     sql = "\n".join(str(call.args[0]) for call in execute.call_args_list)
     assert "ACCESS EXCLUSIVE MODE NOWAIT" in sql
-    assert module._cap_fragment("max_notional_usd", 30) in sql
-    assert module._cap_fragment("max_loss_usd", 30) in sql
-    assert all(fragment in sql for fragment in module._leg_floor_fragments())
+    assert module._versioned_cap_fragment("max_notional_usd") in sql
+    assert module._versioned_cap_fragment("max_loss_usd") in sql
+    assert module._floor_guard_fragment() in sql
+    assert sql.count(module._LIFECYCLE_SCHEMA) >= 6
     assert "NOT VALID" in sql
     assert "VALIDATE CONSTRAINT ck_bm_receipt_validation_authority" in sql
+    assert f"CREATE FUNCTION {module._LEGACY_ROOT_FUNCTION}()" in sql
+    assert f"CREATE TRIGGER {module._LEGACY_ROOT_TRIGGER}" in sql
+    assert module._LEGACY_ROOT_RETIREMENT_ERROR in sql
     drop_constraint.assert_called_once_with(
         "ck_bm_receipt_validation_authority",
         "broker_mutation_receipts",
@@ -100,24 +161,29 @@ def test_upgrade_locks_and_validates_the_rewritten_constraint() -> None:
     )
 
 
-def test_downgrade_refuses_incompatible_evidence_before_restoring_cap() -> None:
+def test_downgrade_refuses_v2_evidence_before_restoring_v1() -> None:
     module = load_migration_module(MIGRATION_FILENAME)
-    connection = Mock()
-    connection.execute.return_value.scalar_one_or_none.return_value = _definition(
-        module,
-        30,
-        leg_floors=True,
-    )
 
     with (
-        patch.object(module.op, "get_bind", return_value=connection),
+        patch.object(
+            module,
+            "_current_constraint_definition",
+            return_value=_definition(module, upgraded=True),
+        ),
+        patch.object(
+            module,
+            "_current_lineage_function_definition",
+            return_value=_lineage_definition(module, upgraded=True),
+        ),
         patch.object(module.op, "execute") as execute,
         patch.object(module.op, "drop_constraint"),
     ):
         module.downgrade()
 
     sql = "\n".join(str(call.args[0]) for call in execute.call_args_list)
-    assert "cannot downgrade with lifecycle receipts above the old cap" in sql
+    assert "cannot downgrade with lifecycle v2 receipts" in sql
     assert module._cap_fragment("max_notional_usd", 5) in sql
     assert module._cap_fragment("max_loss_usd", 5) in sql
     assert all(fragment not in sql for fragment in module._leg_floor_fragments())
+    assert f"DROP TRIGGER {module._LEGACY_ROOT_TRIGGER}" in sql
+    assert f"DROP FUNCTION {module._LEGACY_ROOT_FUNCTION}()" in sql

--- a/services/torghut/tests/test_infrastructure_validation_permit.py
+++ b/services/torghut/tests/test_infrastructure_validation_permit.py
@@ -22,10 +22,30 @@ from app.trading.infrastructure_validation import (
     infrastructure_validation_order_plan_sha256,
     infrastructure_validation_request_payload,
     infrastructure_validation_terminal_state_sha256,
+    is_infrastructure_validation_lifecycle_plan_schema,
 )
 
 
 _NOW = datetime(2026, 7, 14, 12, 0, tzinfo=timezone.utc)
+
+
+@pytest.mark.parametrize(
+    ("schema_version", "expected"),
+    (
+        ("torghut.infrastructure-validation-lifecycle-plan.v1", True),
+        ("torghut.infrastructure-validation-lifecycle-plan.v2", True),
+        ("torghut.infrastructure-validation-lifecycle-plan.v3", False),
+        (" torghut.infrastructure-validation-lifecycle-plan.v2", False),
+        (None, False),
+    ),
+)
+def test_lifecycle_schema_recognizer_is_explicitly_version_bounded(
+    schema_version: object,
+    expected: bool,
+) -> None:
+    assert (
+        is_infrastructure_validation_lifecycle_plan_schema(schema_version) is expected
+    )
 
 
 def _permit_payload(**overrides: object) -> dict[str, object]:
@@ -190,7 +210,7 @@ def test_crypto_ioc_plan_is_immutably_bound_to_one_non_promotable_identity() -> 
 def test_lifecycle_plan_allows_one_bounded_fill_and_only_resting_reductions() -> None:
     plan = InfrastructureValidationLifecyclePlan.model_validate(
         {
-            "schema_version": "torghut.infrastructure-validation-lifecycle-plan.v1",
+            "schema_version": "torghut.infrastructure-validation-lifecycle-plan.v2",
             "venue": "alpaca",
             "asset_class": "crypto",
             "symbol": "BTC/USD",
@@ -249,7 +269,7 @@ def test_lifecycle_authority_requires_two_broker_valid_close_legs(
 ) -> None:
     plan = InfrastructureValidationLifecyclePlan.model_validate(
         {
-            "schema_version": "torghut.infrastructure-validation-lifecycle-plan.v1",
+            "schema_version": "torghut.infrastructure-validation-lifecycle-plan.v2",
             "venue": "alpaca",
             "asset_class": "crypto",
             "symbol": "BTC/USD",
@@ -304,7 +324,7 @@ def test_lifecycle_plan_rejects_nonreducing_schedule(
     error: str,
 ) -> None:
     payload: dict[str, object] = {
-        "schema_version": "torghut.infrastructure-validation-lifecycle-plan.v1",
+        "schema_version": "torghut.infrastructure-validation-lifecycle-plan.v2",
         "venue": "alpaca",
         "asset_class": "crypto",
         "symbol": "BTC/USD",

--- a/services/torghut/tests/test_infrastructure_validation_position_evidence.py
+++ b/services/torghut/tests/test_infrastructure_validation_position_evidence.py
@@ -151,7 +151,7 @@ def _seed_lifecycle_root(session: Session) -> InfrastructureValidationEvidence:
     now = datetime.now(timezone.utc)
     plan = InfrastructureValidationLifecyclePlan.model_validate(
         {
-            "schema_version": "torghut.infrastructure-validation-lifecycle-plan.v1",
+            "schema_version": "torghut.infrastructure-validation-lifecycle-plan.v2",
             "venue": "alpaca",
             "asset_class": "crypto",
             "symbol": "BTC/USD",


### PR DESCRIPTION
## Summary\n\n- version lifecycle validation plans so historical v1 receipts retain their released  contract while current v2 plans enforce the  cap and  minimum notional on both close legs\n- retire new v1 root writes at the database boundary while preserving v1 risk-reducing descendants and require live lifecycle proof to originate from v2\n- rewrite migration 0073 and its lineage function from live PostgreSQL catalog definitions, including NULL-safe version checks and reversible upgrade behavior\n- move duplicated PostgreSQL schema setup into focused test support and add a production-shaped 0072 to 0073 to 0072 to 0073 regression without increasing the tech-debt ratchet\n\n## Related Issues\n\nNone\n\n## Testing\n\n- uv sync --frozen --extra dev\n- uv run --frozen ruff format and ruff check on all changed Torghut Python files\n- uv run --frozen pytest -q on lifecycle, permit, position-evidence, reduction, broker-wiring, model, migration, and exclusion tests: 95 passed\n- disposable postgres:18-alpine run of test_infrastructure_validation_lifecycle_bounds_postgres.py and test_broker_reduction_coordinator_postgres.py: 4 passed\n- uv run --frozen pyright --project pyrightconfig.json\n- uv run --frozen pyright --project pyrightconfig.alpha.json\n- uv run --frozen pyright --project pyrightconfig.scripts.json\n- uv run --frozen python scripts/check_migration_graph.py\n- uv run --frozen python scripts/measure_torghut_tech_debt.py --baseline config/quality/tech-debt-baseline.json --enforce-ratchet --format markdown\n- uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main on every changed Python file\n\n## Breaking Changes\n\nLifecycle plan v1 becomes read-only after migration 0073. Existing v1 receipts remain valid and reducible; every new lifecycle producer must emit v2.\n\n## Checklist\n\n- [x] Testing section documents the exact validation performed.\n- [x] Screenshots are not applicable and the section was removed; Breaking Changes is filled in.\n- [x] Documentation and follow-up behavior are captured in the versioned schema, migration contract, and regression tests.