### PR TITLE
chore(torghut): promote hyperliquid feed image sha-7a49af3cd6fcb462e2030ba82d8f1a7d70e276aa

### DIFF
--- a/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
@@ -32,18 +32,18 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-hyperliquid-feed
-          image: registry.ide-newton.ts.net/lab/torghut-hyperliquid-feed@sha256:068f5f2f97eee3d7bdcd1b8a942cc7128408f97bcad2da7c5309f8da636620d4
+          image: registry.ide-newton.ts.net/lab/torghut-hyperliquid-feed@sha256:c357c2aefdc99809682b47d86cb892a1dc51a9f49f6bdb14a64a5c00dc727789
           imagePullPolicy: Always
           envFrom:
             - configMapRef:
                 name: torghut-hyperliquid-feed-config
           env:
             - name: TORGHUT_HYPERLIQUID_FEED_VERSION
-              value: main-sha-9abb853c837fd369e1d96e70f0d54c5576f86277
+              value: main-sha-7a49af3cd6fcb462e2030ba82d8f1a7d70e276aa
             - name: TORGHUT_HYPERLIQUID_FEED_COMMIT
-              value: 9abb853c837fd369e1d96e70f0d54c5576f86277
+              value: 7a49af3cd6fcb462e2030ba82d8f1a7d70e276aa
             - name: TORGHUT_HYPERLIQUID_FEED_IMAGE_DIGEST
-              value: sha256:068f5f2f97eee3d7bdcd1b8a942cc7128408f97bcad2da7c5309f8da636620d4
+              value: sha256:c357c2aefdc99809682b47d86cb892a1dc51a9f49f6bdb14a64a5c00dc727789
             - name: KAFKA_SASL_USER
               value: torghut-hyperliquid-feed
             - name: KAFKA_SASL_PASSWORD


### PR DESCRIPTION
## Summary

- Promote the immutable Torghut Hyperliquid feed image built from `7a49af3cd6fcb462e2030ba82d8f1a7d70e276aa`.
- Pin the single direct feed runtime to `sha256:c357c2aefdc99809682b47d86cb892a1dc51a9f49f6bdb14a64a5c00dc727789`.
- Preserve one source commit and image digest for the production feed.

## Related Issues

None.

## Testing

- The source commit passed its required CI before merge to `main`.
- The release workflow verified the multi-architecture image contract before creating this PR.
- The deploy gate validates the manifest against source `7a49af3cd6fcb462e2030ba82d8f1a7d70e276aa` and tag `sha-7a49af3cd6fcb462e2030ba82d8f1a7d70e276aa`.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact automated release validation.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] The production feed manifest carries the immutable source and image identity.