### PR TITLE
chore(torghut): promote ws image sha-7a49af3cd6fcb462e2030ba82d8f1a7d70e276aa

### DIFF
--- a/argocd/applications/torghut-options/ws/deployment.yaml
+++ b/argocd/applications/torghut-options/ws/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws-options
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:b5c3b6cb48e19120ef845e8a7f87965a5e1d9b09d9e41f54397b33164a71e8cb
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:3c71bd31714ce15b1e5fb1801b2442b2d084cc0a1a347ed28d0ba06a9b58e6ce
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -54,9 +54,9 @@ spec:
                   name: torghut-options
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-sha-47a3f7c9260daa924c57a4aafb8006fb80001c3a
+              value: main-sha-7a49af3cd6fcb462e2030ba82d8f1a7d70e276aa
             - name: TORGHUT_WS_COMMIT
-              value: 47a3f7c9260daa924c57a4aafb8006fb80001c3a
+              value: 7a49af3cd6fcb462e2030ba82d8f1a7d70e276aa
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:

--- a/argocd/applications/torghut/ws/deployment.yaml
+++ b/argocd/applications/torghut/ws/deployment.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:b5c3b6cb48e19120ef845e8a7f87965a5e1d9b09d9e41f54397b33164a71e8cb
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:3c71bd31714ce15b1e5fb1801b2442b2d084cc0a1a347ed28d0ba06a9b58e6ce
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -55,9 +55,9 @@ spec:
                   name: torghut-ws
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-sha-47a3f7c9260daa924c57a4aafb8006fb80001c3a
+              value: main-sha-7a49af3cd6fcb462e2030ba82d8f1a7d70e276aa
             - name: TORGHUT_WS_COMMIT
-              value: 47a3f7c9260daa924c57a4aafb8006fb80001c3a
+              value: 7a49af3cd6fcb462e2030ba82d8f1a7d70e276aa
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:


### PR DESCRIPTION
## Summary
Promote the Torghut websocket image into GitOps manifests.

- Source commit: `7a49af3cd6fcb462e2030ba82d8f1a7d70e276aa`
- Image tag: `sha-7a49af3cd6fcb462e2030ba82d8f1a7d70e276aa`
- Image digest: `sha256:3c71bd31714ce15b1e5fb1801b2442b2d084cc0a1a347ed28d0ba06a9b58e6ce`