### PR TITLE
chore(torghut): promote image sha-5ccccb99414d0a60419dcc72f245b30a8b3b86cc

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -24,7 +24,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: migrate
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:14dad3547c734cd97dc971d2a80122903e9ecfa3bcf1120275e13600da2674b0
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4aea6cbccd6d97413d69a559f531f9dd45f965d8bc78480e7e721e63bf6d53ec
           imagePullPolicy: Always
           workingDir: /app
           command:
@@ -54,9 +54,9 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: 89e9c4e8ab4975f305dad586723b166ba7f1836a
+              value: 5ccccb99414d0a60419dcc72f245b30a8b3b86cc
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:14dad3547c734cd97dc971d2a80122903e9ecfa3bcf1120275e13600da2674b0
+              value: sha256:4aea6cbccd6d97413d69a559f531f9dd45f965d8bc78480e7e721e63bf6d53ec
             - name: PYTHONPATH
               value: /app
             - name: DB_DSN

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-hyperliquid-runtime
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:14dad3547c734cd97dc971d2a80122903e9ecfa3bcf1120275e13600da2674b0
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4aea6cbccd6d97413d69a559f531f9dd45f965d8bc78480e7e721e63bf6d53ec
           imagePullPolicy: Always
           command:
             - uvicorn
@@ -46,9 +46,9 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: 89e9c4e8ab4975f305dad586723b166ba7f1836a
+              value: 5ccccb99414d0a60419dcc72f245b30a8b3b86cc
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:14dad3547c734cd97dc971d2a80122903e9ecfa3bcf1120275e13600da2674b0
+              value: sha256:4aea6cbccd6d97413d69a559f531f9dd45f965d8bc78480e7e721e63bf6d53ec
             - name: DB_DSN
               valueFrom:
                 secretKeyRef:

--- a/argocd/applications/torghut-options/archive/deployment.yaml
+++ b/argocd/applications/torghut-options/archive/deployment.yaml
@@ -35,7 +35,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: await-options-schema
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:14dad3547c734cd97dc971d2a80122903e9ecfa3bcf1120275e13600da2674b0
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4aea6cbccd6d97413d69a559f531f9dd45f965d8bc78480e7e721e63bf6d53ec
           imagePullPolicy: IfNotPresent
           command:
             - python
@@ -64,7 +64,7 @@ spec:
                 - ALL
       containers:
         - name: torghut-options-archive
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:14dad3547c734cd97dc971d2a80122903e9ecfa3bcf1120275e13600da2674b0
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4aea6cbccd6d97413d69a559f531f9dd45f965d8bc78480e7e721e63bf6d53ec
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -100,9 +100,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2031-g89e9c4e8a
+              value: v0.596.0-2046-g5ccccb994
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 89e9c4e8ab4975f305dad586723b166ba7f1836a
+              value: 5ccccb99414d0a60419dcc72f245b30a8b3b86cc
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -33,7 +33,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: await-options-schema
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:14dad3547c734cd97dc971d2a80122903e9ecfa3bcf1120275e13600da2674b0
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4aea6cbccd6d97413d69a559f531f9dd45f965d8bc78480e7e721e63bf6d53ec
           imagePullPolicy: IfNotPresent
           command:
             - python
@@ -62,7 +62,7 @@ spec:
                 - ALL
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:14dad3547c734cd97dc971d2a80122903e9ecfa3bcf1120275e13600da2674b0
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4aea6cbccd6d97413d69a559f531f9dd45f965d8bc78480e7e721e63bf6d53ec
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -110,9 +110,9 @@ spec:
                   name: torghut-ws-config
                   key: SYMBOLS_ALLOWLIST
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2031-g89e9c4e8a
+              value: v0.596.0-2046-g5ccccb994
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 89e9c4e8ab4975f305dad586723b166ba7f1836a
+              value: 5ccccb99414d0a60419dcc72f245b30a8b3b86cc
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: await-options-schema
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:14dad3547c734cd97dc971d2a80122903e9ecfa3bcf1120275e13600da2674b0
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4aea6cbccd6d97413d69a559f531f9dd45f965d8bc78480e7e721e63bf6d53ec
           imagePullPolicy: IfNotPresent
           command:
             - python
@@ -63,7 +63,7 @@ spec:
                 - ALL
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:14dad3547c734cd97dc971d2a80122903e9ecfa3bcf1120275e13600da2674b0
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4aea6cbccd6d97413d69a559f531f9dd45f965d8bc78480e7e721e63bf6d53ec
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -106,9 +106,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2031-g89e9c4e8a
+              value: v0.596.0-2046-g5ccccb994
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 89e9c4e8ab4975f305dad586723b166ba7f1836a
+              value: 5ccccb99414d0a60419dcc72f245b30a8b3b86cc
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:14dad3547c734cd97dc971d2a80122903e9ecfa3bcf1120275e13600da2674b0
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:4aea6cbccd6d97413d69a559f531f9dd45f965d8bc78480e7e721e63bf6d53ec
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:14dad3547c734cd97dc971d2a80122903e9ecfa3bcf1120275e13600da2674b0
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:4aea6cbccd6d97413d69a559f531f9dd45f965d8bc78480e7e721e63bf6d53ec
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:14dad3547c734cd97dc971d2a80122903e9ecfa3bcf1120275e13600da2674b0
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:4aea6cbccd6d97413d69a559f531f9dd45f965d8bc78480e7e721e63bf6d53ec
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:14dad3547c734cd97dc971d2a80122903e9ecfa3bcf1120275e13600da2674b0
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:4aea6cbccd6d97413d69a559f531f9dd45f965d8bc78480e7e721e63bf6d53ec
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -27,7 +27,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:14dad3547c734cd97dc971d2a80122903e9ecfa3bcf1120275e13600da2674b0
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4aea6cbccd6d97413d69a559f531f9dd45f965d8bc78480e7e721e63bf6d53ec
           workingDir: /app
           command:
             - /bin/sh

--- a/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
+++ b/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-generated-resource-retention
           containers:
             - name: prune-generated-residue
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:14dad3547c734cd97dc971d2a80122903e9ecfa3bcf1120275e13600da2674b0
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:4aea6cbccd6d97413d69a559f531f9dd45f965d8bc78480e7e721e63bf6d53ec
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:14dad3547c734cd97dc971d2a80122903e9ecfa3bcf1120275e13600da2674b0
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:4aea6cbccd6d97413d69a559f531f9dd45f965d8bc78480e7e721e63bf6d53ec
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-15T14:55:39Z"
+        client.knative.dev/updateTimestamp: "2026-07-15T19:50:33Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:14dad3547c734cd97dc971d2a80122903e9ecfa3bcf1120275e13600da2674b0
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4aea6cbccd6d97413d69a559f531f9dd45f965d8bc78480e7e721e63bf6d53ec
           ports:
             - name: http1
               containerPort: 8181
@@ -507,11 +507,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2031-g89e9c4e8a
+              value: v0.596.0-2046-g5ccccb994
             - name: TORGHUT_COMMIT
-              value: 89e9c4e8ab4975f305dad586723b166ba7f1836a
+              value: 5ccccb99414d0a60419dcc72f245b30a8b3b86cc
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:14dad3547c734cd97dc971d2a80122903e9ecfa3bcf1120275e13600da2674b0
+              value: sha256:4aea6cbccd6d97413d69a559f531f9dd45f965d8bc78480e7e721e63bf6d53ec
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-15T14:55:39Z"
+        client.knative.dev/updateTimestamp: "2026-07-15T19:50:33Z"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
     spec:
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:14dad3547c734cd97dc971d2a80122903e9ecfa3bcf1120275e13600da2674b0
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4aea6cbccd6d97413d69a559f531f9dd45f965d8bc78480e7e721e63bf6d53ec
           ports:
             - name: http1
               containerPort: 8181
@@ -446,11 +446,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2031-g89e9c4e8a
+              value: v0.596.0-2046-g5ccccb994
             - name: TORGHUT_COMMIT
-              value: 89e9c4e8ab4975f305dad586723b166ba7f1836a
+              value: 5ccccb99414d0a60419dcc72f245b30a8b3b86cc
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:14dad3547c734cd97dc971d2a80122903e9ecfa3bcf1120275e13600da2674b0
+              value: sha256:4aea6cbccd6d97413d69a559f531f9dd45f965d8bc78480e7e721e63bf6d53ec
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -37,7 +37,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:14dad3547c734cd97dc971d2a80122903e9ecfa3bcf1120275e13600da2674b0
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4aea6cbccd6d97413d69a559f531f9dd45f965d8bc78480e7e721e63bf6d53ec
           command:
             - uvicorn
           args:
@@ -462,11 +462,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2031-g89e9c4e8a
+              value: v0.596.0-2046-g5ccccb994
             - name: TORGHUT_COMMIT
-              value: 89e9c4e8ab4975f305dad586723b166ba7f1836a
+              value: 5ccccb99414d0a60419dcc72f245b30a8b3b86cc
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:14dad3547c734cd97dc971d2a80122903e9ecfa3bcf1120275e13600da2674b0
+              value: sha256:4aea6cbccd6d97413d69a559f531f9dd45f965d8bc78480e7e721e63bf6d53ec
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: smoke
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:14dad3547c734cd97dc971d2a80122903e9ecfa3bcf1120275e13600da2674b0
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4aea6cbccd6d97413d69a559f531f9dd45f965d8bc78480e7e721e63bf6d53ec
           imagePullPolicy: IfNotPresent
           securityContext:
             seccompProfile:


### PR DESCRIPTION
## Summary

- Promote Torghut source `5ccccb99414d0a60419dcc72f245b30a8b3b86cc` to every owned runtime and migration manifest.
- Pin the immutable multi-architecture image index `sha256:4aea6cbccd6d97413d69a559f531f9dd45f965d8bc78480e7e721e63bf6d53ec` for `linux/amd64` and `linux/arm64`.
- Apply migration `0073_live_paper_bounds`, which preserves historical lifecycle v1 receipts, retires new v1 roots, and admits bounded lifecycle v2 roots with a $30 total cap and two at-least-$12 close legs.
- Keep this release manually gated until the migration diff, image contract, and manifest-only scope are reviewed.

## Related Issues

None.

## Testing

- `git diff --check origin/main..origin/codex/torghut-release-sha-5ccccb99414d0a60419dcc72f245b30a8b3b86cc`
- `crane digest registry.ide-newton.ts.net/lab/torghut:sha-5ccccb99414d0a60419dcc72f245b30a8b3b86cc`
- `skopeo inspect --raw docker://registry.ide-newton.ts.net/lab/torghut:sha-5ccccb99414d0a60419dcc72f245b30a8b3b86cc` (verified exactly `linux/amd64` and `linux/arm64`)
- `torghut-build-push` run 29438983551: passed
- `torghut-release` run 29445942870: passed migration detection, image-platform contract, and manifest generation
- Required PR checks must pass before merge.

## Breaking Changes

Migration `0073_live_paper_bounds` takes a fail-fast `ACCESS EXCLUSIVE ... NOWAIT` lock while replacing the validation constraint and lineage trigger. It rejects new lifecycle v1 roots while preserving existing v1 evidence. Downgrade is intentionally refused after a lifecycle v2 receipt exists.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed because this is a GitOps-only promotion.
- [x] Documentation and migration behavior are described above; no release-note follow-up is required for this internal control-plane release.
