### PR TITLE
fix(atlas): use indexed exact candidates

### DIFF
--- a/services/jangar/src/server/__tests__/atlas-store.test.ts
+++ b/services/jangar/src/server/__tests__/atlas-store.test.ts
@@ -576,13 +576,16 @@ describe('atlas store', () => {
 
     const exactSql = calls.find((call) => call.sql.toLowerCase().includes(' as exact_rank'))
     expect(exactSql).toBeDefined()
-    expect(exactSql?.sql.toLowerCase()).toContain('with exact_candidates as materialized')
-    expect(exactSql?.sql.toLowerCase()).toContain('file_chunks.content ilike')
-    expect(exactSql?.sql.toLowerCase()).toContain('file_chunks.content ~ $')
-    expect(exactSql?.sql.toLowerCase()).not.toMatch(/file_chunks\.content\s+%\s+\$/)
+    const normalized = String(exactSql?.sql).toLowerCase().replace(/\s+/g, ' ')
+    const candidates = normalized.slice(normalized.indexOf('with exact_candidates'), normalized.indexOf(') select'))
+    expect(normalized).toContain('with exact_candidates as materialized')
+    expect(candidates).toContain("file_chunks.text_tsvector @@ websearch_to_tsquery('simple', $")
+    expect(candidates).not.toContain('file_chunks.content ilike')
+    expect(normalized).toContain('file_chunks.content ~ $')
+    expect(normalized).not.toMatch(/file_chunks\.content\s+%\s+\$/)
   })
 
-  it('keeps exact content candidates for literal queries that are not declaration identifiers', async () => {
+  it('keeps literal exact candidates through indexed text terms', async () => {
     const { db, calls } = makeFakeDb({ selectRows: [] })
     const store = createPostgresAtlasStore({
       url: 'postgresql://user:pass@localhost:5432/db',
@@ -595,7 +598,25 @@ describe('atlas store', () => {
     const normalized = String(exactSql?.sql).toLowerCase().replace(/\s+/g, ' ')
     const candidates = normalized.slice(normalized.indexOf('with exact_candidates'), normalized.indexOf(') select'))
     expect(candidates).toContain('union select file_chunks.id as chunk_id from atlas.file_chunks as file_chunks')
+    expect(candidates).toContain("file_chunks.text_tsvector @@ websearch_to_tsquery('simple', $")
+    expect(candidates).not.toContain('file_chunks.content ilike')
+    expect(normalized).toContain('file_chunks.content ilike')
+  })
+
+  it('falls back to exact content scanning only when a literal has no searchable text terms', async () => {
+    const { db, calls } = makeFakeDb({ selectRows: [] })
+    const store = createPostgresAtlasStore({
+      url: 'postgresql://user:pass@localhost:5432/db',
+      createDb: () => db,
+    })
+
+    await store.codeSearch({ query: '=>', repository: 'proompteng/lab', ref: 'main' })
+
+    const exactSql = calls.find((call) => call.sql.toLowerCase().includes(' as exact_rank'))
+    const normalized = String(exactSql?.sql).toLowerCase().replace(/\s+/g, ' ')
+    const candidates = normalized.slice(normalized.indexOf('with exact_candidates'), normalized.indexOf(') select'))
     expect(candidates).toContain('file_chunks.content ilike')
+    expect(candidates).not.toContain('file_chunks.text_tsvector')
   })
 
   it('pushes corpus and caller filters into every materialized exact-candidate scan', async () => {
@@ -661,7 +682,7 @@ describe('atlas store', () => {
     expect(calls.some((call) => call.sql.toLowerCase().includes('from atlas.chunk_embeddings'))).toBe(false)
   })
 
-  it('keeps content and semantic retrieval for natural-language queries containing a path', async () => {
+  it('keeps indexed content and semantic retrieval for natural-language queries containing a path', async () => {
     const { db, calls } = makeFakeDb({ selectRows: [] })
     const store = createPostgresAtlasStore({
       url: 'postgresql://user:pass@localhost:5432/db',
@@ -676,7 +697,10 @@ describe('atlas store', () => {
 
     const exactSql = calls.find((call) => call.sql.toLowerCase().includes(' as exact_rank'))
     const normalized = String(exactSql?.sql).toLowerCase().replace(/\s+/g, ' ')
-    expect(normalized).toContain('union select file_chunks.id as chunk_id from atlas.file_chunks as file_chunks')
+    const candidates = normalized.slice(normalized.indexOf('with exact_candidates'), normalized.indexOf(') select'))
+    expect(candidates).toContain('union select file_chunks.id as chunk_id from atlas.file_chunks as file_chunks')
+    expect(candidates).toContain("file_chunks.text_tsvector @@ websearch_to_tsquery('simple', $")
+    expect(candidates).not.toContain('file_chunks.content ilike')
     expect(calls.some((call) => call.sql.toLowerCase().includes('from atlas.chunk_embeddings'))).toBe(true)
   })
 

--- a/services/jangar/src/server/__tests__/atlas-store.test.ts
+++ b/services/jangar/src/server/__tests__/atlas-store.test.ts
@@ -579,13 +579,13 @@ describe('atlas store', () => {
     const normalized = String(exactSql?.sql).toLowerCase().replace(/\s+/g, ' ')
     const candidates = normalized.slice(normalized.indexOf('with exact_candidates'), normalized.indexOf(') select'))
     expect(normalized).toContain('with exact_candidates as materialized')
-    expect(candidates).toContain("file_chunks.text_tsvector @@ websearch_to_tsquery('simple', $")
+    expect(candidates).toContain("file_chunks.text_tsvector @@ plainto_tsquery('simple', $")
     expect(candidates).not.toContain('file_chunks.content ilike')
     expect(normalized).toContain('file_chunks.content ~ $')
     expect(normalized).not.toMatch(/file_chunks\.content\s+%\s+\$/)
   })
 
-  it('keeps literal exact candidates through indexed text terms', async () => {
+  it('keeps punctuation-bearing literals indexed without treating them as web-search operators', async () => {
     const { db, calls } = makeFakeDb({ selectRows: [] })
     const store = createPostgresAtlasStore({
       url: 'postgresql://user:pass@localhost:5432/db',
@@ -598,7 +598,8 @@ describe('atlas store', () => {
     const normalized = String(exactSql?.sql).toLowerCase().replace(/\s+/g, ' ')
     const candidates = normalized.slice(normalized.indexOf('with exact_candidates'), normalized.indexOf(') select'))
     expect(candidates).toContain('union select file_chunks.id as chunk_id from atlas.file_chunks as file_chunks')
-    expect(candidates).toContain("file_chunks.text_tsvector @@ websearch_to_tsquery('simple', $")
+    expect(candidates).toContain("file_chunks.text_tsvector @@ plainto_tsquery('simple', $")
+    expect(candidates).not.toContain('websearch_to_tsquery')
     expect(candidates).not.toContain('file_chunks.content ilike')
     expect(normalized).toContain('file_chunks.content ilike')
   })
@@ -699,7 +700,7 @@ describe('atlas store', () => {
     const normalized = String(exactSql?.sql).toLowerCase().replace(/\s+/g, ' ')
     const candidates = normalized.slice(normalized.indexOf('with exact_candidates'), normalized.indexOf(') select'))
     expect(candidates).toContain('union select file_chunks.id as chunk_id from atlas.file_chunks as file_chunks')
-    expect(candidates).toContain("file_chunks.text_tsvector @@ websearch_to_tsquery('simple', $")
+    expect(candidates).toContain("file_chunks.text_tsvector @@ plainto_tsquery('simple', $")
     expect(candidates).not.toContain('file_chunks.content ilike')
     expect(calls.some((call) => call.sql.toLowerCase().includes('from atlas.chunk_embeddings'))).toBe(true)
   })

--- a/services/jangar/src/server/atlas-code-search.ts
+++ b/services/jangar/src/server/atlas-code-search.ts
@@ -530,7 +530,7 @@ export const createAtlasCodeSearchHandlers = ({
     const containsPattern = `%${escapeLikePattern(resolvedQuery)}%`
     const whereClause = searchWhereClause(filters)
     const indexedContentCandidateClause = /[A-Za-z0-9_$]+/.test(resolvedQuery)
-      ? sql`file_chunks.text_tsvector @@ websearch_to_tsquery('simple', ${resolvedQuery}::text)`
+      ? sql`file_chunks.text_tsvector @@ plainto_tsquery('simple', ${resolvedQuery}::text)`
       : sql`file_chunks.content ILIKE ${containsPattern} ESCAPE '\'`
     const contentCandidateUnion = isPathQuery
       ? sql``

--- a/services/jangar/src/server/atlas-code-search.ts
+++ b/services/jangar/src/server/atlas-code-search.ts
@@ -529,6 +529,9 @@ export const createAtlasCodeSearchHandlers = ({
       : vectorToPgArray(await embedCodeSearchQuery(resolvedQuery, embeddingConfig))
     const containsPattern = `%${escapeLikePattern(resolvedQuery)}%`
     const whereClause = searchWhereClause(filters)
+    const indexedContentCandidateClause = /[A-Za-z0-9_$]+/.test(resolvedQuery)
+      ? sql`file_chunks.text_tsvector @@ websearch_to_tsquery('simple', ${resolvedQuery}::text)`
+      : sql`file_chunks.content ILIKE ${containsPattern} ESCAPE '\'`
     const contentCandidateUnion = isPathQuery
       ? sql``
       : sql`
@@ -541,7 +544,7 @@ export const createAtlasCodeSearchHandlers = ({
           INNER JOIN atlas.repositories AS repositories ON repositories.id = file_keys.repository_id
           ${whereClause}
             AND file_chunks.content IS NOT NULL
-            AND file_chunks.content ILIKE ${containsPattern} ESCAPE '\'
+            AND ${indexedContentCandidateClause}
         `
     const definitionPattern = buildDefinitionPattern(resolvedQuery)
     const definitionRankClause = definitionPattern


### PR DESCRIPTION
## Summary

- Bound exact-content candidates with the existing Atlas lexical GIN index before literal confirmation and ranking.
- Preserve exact literal matching for identifiers and punctuation-bearing strings, with a content-scan fallback for punctuation-only queries.
- Add regression coverage for identifiers, literals, punctuation-only queries, and natural-language semantic searches.

## Related Issues

None

## Testing

- `bun test services/jangar/src/server/__tests__/atlas-store.test.ts` (25 passed)
- `bun run --filter @proompteng/jangar test -- src/server/__tests__/atlas-store.test.ts` (25 passed, 4 integration tests skipped)
- `bun run --filter @proompteng/jangar tsc`
- `bunx oxfmt --check services/jangar/src/server/atlas-code-search.ts services/jangar/src/server/__tests__/atlas-store.test.ts`
- `bunx oxlint --config .oxlintrc.json services/jangar/src/server/atlas-code-search.ts services/jangar/src/server/__tests__/atlas-store.test.ts`
- Production-query read-only timing under the unchanged 750 ms exact-search budget: 11.5 ms for `createAtlasCodeSearchHandlers`, 1.0 ms for `docker:25.0-dind`.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
