### PR TITLE
fix(torghut): stabilize empty reduction receipts

### DIFF
--- a/services/torghut/app/hyperliquid_execution/reduction_mutations.py
+++ b/services/torghut/app/hyperliquid_execution/reduction_mutations.py
@@ -301,6 +301,7 @@ class HyperliquidReductionMutationExecutor:
             spec.request_payload,
             target_kind=spec.target_kind,
             target_key=spec.target_key,
+            purpose=spec.purpose,
         )
         return build_broker_mutation_intent(
             BrokerMutationIntentRequest(

--- a/services/torghut/app/trading/alpaca_reduction_mutations.py
+++ b/services/torghut/app/trading/alpaca_reduction_mutations.py
@@ -350,6 +350,23 @@ class AlpacaReductionMutationExecutor:
             CancelAllOrdersPlan(),
             now=observed_at,
         )
+        if not any(order.open for order in snapshot.orders):
+            observation: Mapping[str, object] = {
+                "complete": snapshot.complete,
+                "orders": [],
+            }
+            self._settle_already_satisfied(
+                _MutationSpec(
+                    operation="cancel_all_orders",
+                    risk_class="risk_neutral",
+                    purpose=purpose,
+                    target_kind="account",
+                    target_key=self._account_label,
+                    request_payload=_already_satisfied_request(observation),
+                ),
+                observation=observation,
+            )
+            return []
         request_payload = _request_payload(
             authorization,
             broker_request={
@@ -358,18 +375,6 @@ class AlpacaReductionMutationExecutor:
                 )
             },
         )
-        if not any(order.open for order in snapshot.orders):
-            self._settle_authorized_preflight(
-                _MutationSpec(
-                    operation="cancel_all_orders",
-                    risk_class="risk_neutral",
-                    purpose=purpose,
-                    target_kind="account",
-                    target_key=self._account_label,
-                    request_payload=request_payload,
-                )
-            )
-            return []
         return self._execute(
             _MutationSpec(
                 operation="cancel_all_orders",
@@ -695,6 +700,7 @@ class AlpacaReductionMutationExecutor:
             spec.request_payload,
             target_kind=spec.target_kind,
             target_key=spec.target_key,
+            purpose=spec.purpose,
         )
         return build_broker_mutation_intent(
             BrokerMutationIntentRequest(
@@ -712,15 +718,6 @@ class AlpacaReductionMutationExecutor:
                 ),
                 request_payload=spec.request_payload,
             )
-        )
-
-    def _settle_authorized_preflight(
-        self,
-        spec: _MutationSpec,
-    ) -> None:
-        self._settle_preflight_intent(
-            self._intent(spec),
-            observation={"reason": "empty_complete_snapshot"},
         )
 
     def _settle_already_satisfied(

--- a/services/torghut/app/trading/risk_reduction_mutation_authority.py
+++ b/services/torghut/app/trading/risk_reduction_mutation_authority.py
@@ -11,6 +11,7 @@ from .broker_mutation_receipts import (
     BrokerMutationIoPermit,
     BrokerMutationIoPermitExpectation,
     BrokerMutationOperation,
+    BrokerMutationPurpose,
     BrokerMutationRiskClass,
     BrokerMutationRoute,
     BrokerMutationTargetKind,
@@ -53,6 +54,7 @@ def risk_reduction_request_id(
     *,
     target_kind: BrokerMutationTargetKind,
     target_key: str,
+    purpose: BrokerMutationPurpose | None = None,
 ) -> str:
     """Derive one stable economic identity while retaining full observation evidence."""
 
@@ -77,7 +79,12 @@ def risk_reduction_request_id(
             },
         }
     elif request_payload.get("already_satisfied") is True:
-        identity = {"already_satisfied": True}
+        if purpose is None:
+            raise RiskReductionPermitError("risk_reduction_preflight_purpose_required")
+        identity = {
+            "already_satisfied": True,
+            "purpose": purpose,
+        }
     else:
         raise RiskReductionPermitError("risk_reduction_evidence_required")
     canonical_json, _ = canonicalize_broker_mutation_evidence(

--- a/services/torghut/tests/test_alpaca_reduction_preflight.py
+++ b/services/torghut/tests/test_alpaca_reduction_preflight.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import cast
+from unittest.mock import patch
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.alpaca_client import TorghutAlpacaClient
+from app.models import Base, BrokerMutationReceipt
+from app.trading.execution_adapters import AlpacaExecutionAdapter
+from app.trading.firewall import OrderFirewall
+
+
+class _EmptyOrderBroker:
+    endpoint_url = "https://paper-api.alpaca.markets"
+
+    def __init__(self) -> None:
+        self.cancel_all_calls = 0
+
+    def list_orders(
+        self,
+        status: str = "all",
+        *,
+        limit: int | None = None,
+    ) -> list[dict[str, object]]:
+        del status, limit
+        return []
+
+    def cancel_all_orders(self, **_kwargs: object) -> list[dict[str, object]]:
+        self.cancel_all_calls += 1
+        return []
+
+
+def test_empty_cancel_all_preflight_survives_restart_and_scopes_purpose() -> None:
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    sessions = sessionmaker(
+        bind=engine,
+        class_=Session,
+        autoflush=False,
+        expire_on_commit=False,
+        future=True,
+    )
+    broker = _EmptyOrderBroker()
+
+    def adapter() -> AlpacaExecutionAdapter:
+        return AlpacaExecutionAdapter(
+            firewall=OrderFirewall(broker, account_label="paper"),
+            read_client=cast(TorghutAlpacaClient, broker),
+            session_factory=sessions,
+            account_label="paper",
+            endpoint_url=broker.endpoint_url,
+        )
+
+    with patch("app.trading.alpaca_reduction_mutations.datetime") as clock:
+        clock.now.side_effect = [
+            datetime(2026, 7, 15, 19, 45, tzinfo=timezone.utc),
+            datetime(2026, 7, 15, 19, 57, tzinfo=timezone.utc),
+            datetime(2026, 7, 15, 20, 0, tzinfo=timezone.utc),
+        ]
+        assert adapter().cancel_all_orders(purpose="closeout") == []
+        assert adapter().cancel_all_orders(purpose="closeout") == []
+        assert adapter().cancel_all_orders(purpose="kill_switch") == []
+
+    assert broker.cancel_all_calls == 0
+    with sessions() as session:
+        receipts = session.execute(select(BrokerMutationReceipt)).scalars().all()
+    assert len(receipts) == 2
+    assert {receipt.purpose for receipt in receipts} == {"closeout", "kill_switch"}
+    for receipt in receipts:
+        request = json.loads(receipt.canonical_intent_json)["request"]
+        assert request == {
+            "already_satisfied": True,
+            "observation": {"complete": True, "orders": []},
+            "schema_version": "torghut.alpaca-reduction-preflight.v1",
+        }
+    engine.dispose()

--- a/services/torghut/tests/test_risk_reduction.py
+++ b/services/torghut/tests/test_risk_reduction.py
@@ -309,22 +309,33 @@ def test_already_satisfied_identity_is_stable_and_target_bound() -> None:
         request,
         target_kind="position",
         target_key="AAPL",
+        purpose="closeout",
     )
     repeated = risk_reduction_request_id(
         "close_position",
         {**request, "observation": {"positions": [], "read": "repeated"}},
         target_kind="position",
         target_key="AAPL",
+        purpose="closeout",
     )
     other_target = risk_reduction_request_id(
         "close_position",
         request,
         target_kind="position",
         target_key="MSFT",
+        purpose="closeout",
+    )
+    other_purpose = risk_reduction_request_id(
+        "close_position",
+        request,
+        target_kind="position",
+        target_key="AAPL",
+        purpose="operator",
     )
 
     assert first == repeated
     assert first != other_target
+    assert first != other_purpose
 
 
 def test_single_leg_of_balanced_book_is_blocked_when_net_exposure_would_increase() -> (


### PR DESCRIPTION
## Summary

- record empty cancel-all observations as stable already-satisfied preflight receipts instead of timestamp-bearing mutation intents
- bind already-satisfied receipt identities to mutation purpose across Alpaca and Hyperliquid
- remove the obsolete authorized-preflight helper and add restart and purpose-collision regression coverage in a focused test module

## Related Issues

None

## Testing

- `./.venv/bin/pytest -q tests/test_alpaca_reduction_preflight.py tests/test_alpaca_reduction_coordinator.py tests/test_alpaca_mutation_recovery.py tests/test_capital_controls.py tests/test_trading_scheduler_safety.py tests/test_risk_reduction.py tests/hyperliquid_execution` (269 passed, 1 skipped: PostgreSQL DSN not configured)
- `./.venv/bin/ruff check app/trading/alpaca_reduction_mutations.py app/hyperliquid_execution/reduction_mutations.py app/trading/risk_reduction_mutation_authority.py tests/test_alpaca_reduction_coordinator.py tests/test_alpaca_reduction_preflight.py tests/test_risk_reduction.py`
- `TORGHUT_DIFF_BASE=origin/main ./.venv/bin/python scripts/run_pylint_torghut_file_length_gate.py --base origin/main app/hyperliquid_execution/reduction_mutations.py app/trading/alpaca_reduction_mutations.py app/trading/risk_reduction_mutation_authority.py tests/test_alpaca_reduction_coordinator.py tests/test_alpaca_reduction_preflight.py tests/test_risk_reduction.py`
- `./.venv/bin/pyright --project pyrightconfig.json`
- `./.venv/bin/pyright --project pyrightconfig.alpha.json`
- `./.venv/bin/pyright --project pyrightconfig.scripts.json`
- reproduced against the live persisted receipt identity conflict `rr-cancel-all-orders-dd05b238...`; no database records were altered or deleted

## Breaking Changes

None. Existing settled receipts remain immutable; the corrected empty-preflight identity creates a separate purpose-scoped no-op receipt. A new Torghut image and GitOps promotion are required.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked. Runtime rollout and independent broker/CNPG proof remain tracked in the active Torghut profitability execution goal.