### PR TITLE
docs(torghut): prevent lifecycle scheduler races

### DIFF
--- a/docs/torghut/profitability/implementation-roadmap.md
+++ b/docs/torghut/profitability/implementation-roadmap.md
@@ -193,10 +193,11 @@ recoverable.
   cross-scope validation ancestry, descendant order-feed exclusion, and broker outage during emergency reduction.
 - Runtime proof: an infrastructure-validation paper/sandbox lifecycle exercises each mutation, reconciles a single
   causal chain, and remains excluded from every promotion/trial query.
-- Lifecycle shape: preserve the original maximum-$1 known-null submit proof and use one separate maximum-$5 Alpaca
+- Lifecycle shape: preserve the original maximum-$1 known-null submit proof and use one separate maximum-$30 Alpaca
   paper lifecycle: filled limit IOC entry, zero-fill GTC close, replacement with rotated order ID, cancellation,
-  partial broker close, and final flatten. Current broker asset minima and increments are runtime preconditions; cancel
-  never becomes an order-identity parent, and an ambiguous mutation is never retried from the old observation.
+  partial broker close, and final flatten. Both planned reduction legs must remain at least $12 at the entry limit.
+  Current broker asset minima and increments are runtime preconditions; cancel never becomes an order-identity parent,
+  and an ambiguous mutation is never retried from the old observation.
 - Dependency: slices 4-5. Effort: `L`.
 - Rollback: keep submit blocked; preserve the already-fenced reduce-only closeout path and disable replace.
 

--- a/docs/torghut/profitability/infrastructure-validation-runbook.md
+++ b/docs/torghut/profitability/infrastructure-validation-runbook.md
@@ -39,10 +39,21 @@ Before issuing a permit, record and independently verify:
 5. Alpaca returns the expected paper `account_number`, active account status, and active crypto status when applicable;
 6. the account has zero positions and zero open orders;
 7. the selected asset is active, tradable, and has the requested asset class;
-8. no earlier receipt uses the proposed `permit_id` or deterministic client-order ID.
+8. no earlier receipt uses the proposed `permit_id` or deterministic client-order ID;
+9. the scheduler cannot race the exercise: it is healthy and outside every scheduled/emergency closeout window, or it
+   has first been proven healthy on the promoted image and then quiesced through a reviewed GitOps change.
 
 Stop if any identity is missing, aliased, or contradictory. Never infer paper safety from `TRADING_MODE`; the endpoint
-and broker account response are authoritative.
+and broker account response are authoritative. Kubernetes readiness does not prove scheduler non-interference: after
+`TRADING_FLATTEN_START_TIME_ET`, or while an emergency stop is latched, the scheduler will correctly cancel and flatten
+broker state and therefore cannot share the account with this exercise.
+
+If the scheduler must be quiesced, do not patch or scale the live Deployment directly. Merge a temporary GitOps change
+to zero replicas, wait for Argo CD to reconcile it, and independently reconfirm the paper account is flat. Run the
+exercise only from the promoted API revision after proving its container image ID equals the promoted scheduler image
+digest. Whether the exercise succeeds or fails, independently read the broker account, restore one scheduler replica
+through GitOps, and require `/scheduler/readyz` to recover before ending the operation. A validation runner, permit, or
+API pod is never a replacement scheduler.
 
 ## Build The Input
 
@@ -213,6 +224,11 @@ This migration is necessary but is not the lifecycle proof. Do not manually comp
 Slice 6 is proven from migration presence. The bounded Alpaca-paper lifecycle runner, immutable image promotion, broker
 readback, CNPG receipt chain, and independent absence from candidate/PnL/ledger evidence must all pass before
 `reduction_fencing_proven` can become true.
+
+The lifecycle creates a real transient paper position and resting order. Do not start it while the scheduler is in a
+scheduled or emergency flatten state: the scheduler is supposed to cancel and close that state, which would split the
+causal chain and invalidate the proof. Use the non-interference precondition above; never rely on timing the mutations
+between scheduler polls.
 
 ### Live broker minimum correction
 


### PR DESCRIPTION
## Summary

- Correct the Slice 6 lifecycle cap from the obsolete $5 assumption to the broker-proven $30 cap with two $12 reduction legs.
- Require proof that the scheduler cannot race an infrastructure-validation order lifecycle.
- Document the reviewed GitOps quiesce, exact-image verification, independent broker readback, and scheduler restoration sequence.

## Related Issues

None

## Testing

- `git diff --check`
- Reviewed the operator contract against the live post-15:45 ET scheduler flatten behavior and current `$30`/`$12` v2 validation bounds.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.