### PR TITLE
chore(torghut): quiesce scheduler for lifecycle proof

### DIFF
--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -10,9 +10,10 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "2"
 spec:
-  # Exactly one dedicated writer owns live trading. Knative API revisions run
-  # with TORGHUT_PROCESS_ROLE=api and TRADING_ENABLED=false.
-  replicas: 1
+  # Temporarily quiesced for the bounded Alpaca-paper lifecycle proof. The
+  # promoted API revision runs with TORGHUT_PROCESS_ROLE=api and cannot race
+  # the broker lifecycle. Restore the single scheduler writer after readback.
+  replicas: 0
   revisionHistoryLimit: 1
   strategy:
     type: Recreate


### PR DESCRIPTION
## Summary

- temporarily set the single Torghut scheduler Deployment to zero replicas
- prevent the scheduled closeout controller from racing the bounded Alpaca-paper lifecycle
- retain the promoted API revision as the identical-image, non-scheduler execution surface

## Related Issues

None

## Testing

- git diff --check
- kubectl apply --dry-run=client -f argocd/applications/torghut/scheduler-deployment.yaml -o name
- live precondition: promoted scheduler /scheduler/readyz returned 200 on digest sha256:b0a4ffe71482e2db2d20c773863204bf8a1d2526b9442941cabd9b80207c9163

## Breaking Changes

Temporary operational quiescence only. A follow-up GitOps change will restore exactly one scheduler replica after lifecycle execution and independent broker readback.

## Checklist

- [x] Testing section documents the exact validation performed (or N/A with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.