### PR TITLE
fix(torghut): restore scheduled closeout window

### DIFF
--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -10,8 +10,8 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "2"
 spec:
-  # Keep the sole writer and order-feed ingestor online during the bounded
-  # Alpaca-paper lifecycle proof. Ordinary entry remains frozen below.
+  # Exactly one dedicated writer owns live trading. Knative API revisions run
+  # with TORGHUT_PROCESS_ROLE=api and TRADING_ENABLED=false.
   replicas: 1
   revisionHistoryLimit: 1
   strategy:
@@ -429,11 +429,9 @@ spec:
               # closeout, while every risk-increasing decision is rejected.
               value: "00:00:00"
             - name: TRADING_FLATTEN_START_TIME_ET
-              # Temporary paper-proof window. Restore 15:45 after broker and
-              # CNPG readback; emergency, equity, and ledger stops stay active.
-              value: "23:55:00"
+              value: "15:45:00"
             - name: TRADING_FLAT_CONFIRMATION_TIME_ET
-              value: "23:59:00"
+              value: "15:50:00"
             - name: TRADING_PAIR_DELTA_TOLERANCE_BPS
               value: "8"
             - name: TRADING_CLOSEOUT_REPRICE_SECONDS


### PR DESCRIPTION
## Summary

- Restore the scheduler closeout start to 15:45 ET after the bounded Alpaca paper lifecycle run.
- Restore flat confirmation to 15:50 ET.
- Keep the singleton writer and order-feed ingestor online while the independent new-exposure freeze remains active.

## Related Issues

None

## Testing

- git diff --check
- /opt/homebrew/bin/kubectl apply --dry-run=client -f argocd/applications/torghut/scheduler-deployment.yaml

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed; no UI change.
- [x] Documentation, release notes, and follow-ups are updated or tracked.