### PR TITLE
fix(torghut): handle fee-adjusted crypto lifecycle

### DIFF
--- a/docs/torghut/profitability/infrastructure-validation-runbook.md
+++ b/docs/torghut/profitability/infrastructure-validation-runbook.md
@@ -264,3 +264,37 @@ including conflict, timeout, rate-limit, transport, and server failures, remains
 read-only reconciliation. These are the synchronous failures documented by the official
 [order endpoint](https://docs.alpaca.markets/us/reference/createorderforaccount); live broker behavior remains the
 authority when published minimum metadata and the order endpoint disagree.
+
+### Crypto fee and close-all response correction
+
+The next promoted attempt on 2026-07-15 UTC filled the exact `0.00045040` BTC/USD IOC, but the position became
+`0.000449274` BTC. This is the documented broker contract: Alpaca charges the crypto fee against the asset credited by
+a buy, and its current tier-one taker fee is `0.25%`. The fill was complete; treating gross fill quantity as net
+position quantity was incorrect. The historical root receipt, fill event, cleanup receipt, and broker orders must
+remain intact.
+
+Alpaca's position endpoint also reports the same pair as slashless `BTCUSD` while order and order-feed evidence use
+`BTC/USD`. Normalize that broker representation only when `asset_class=crypto`, and retain the original broker symbol
+in the risk-reduction observation. A string mismatch must never be interpreted as an absent position.
+
+The runner must therefore prove both quantities independently. The root order must still be terminal `filled` with
+`filled_qty` exactly equal to the signed plan quantity. The resulting sole long position may equal the gross fill or be
+smaller only within Alpaca's published maximum taker-fee bound plus one broker quantity increment for rounding. Every
+resting, replacement, partial-close, residual, lineage, and terminal check uses the observed net position. Both actual
+close legs must still exceed the `$12` observed-notional guard before the first reduction mutation. An increased
+position, a larger unexplained debit, an invalid increment, or a leg below the guard fails closed and triggers only the
+independently fenced cleanup path. See Alpaca's official
+[Crypto Spot Trading Fees](https://docs.alpaca.markets/us/docs/crypto-fees).
+
+Alpaca crypto quantities and fee-adjusted positions can contain nine fractional digits. Migration
+`0074_crypto_qty_precision` widens only the four order-feed quantity columns to `numeric(21,9)` while preserving the
+existing twelve integer digits; prices and notionals remain at their existing money precision. Do not round broker
+positions to fit the old schema or use the raw event as a substitute for normalized durable evidence.
+
+`DELETE /v2/positions` returns HTTP `207` with an array of close-position responses. A successful item can carry the
+created order under its nested `body` even when top-level `order_id` is null. Settlement and lifecycle readback must
+extract exactly one distinct order ID for this known-single-position proof and reject missing or ambiguous identities.
+See Alpaca's official [Close All Positions](https://docs.alpaca.markets/us/reference/deleteallopenpositions-1)
+contract. The 2026-07-15 cleanup did flatten the account; its initially unresolved receipt was later reconciled from
+flat-account broker truth. That recovery proves safety, not lifecycle success, so a fresh permit and complete receipt
+chain are still required.

--- a/services/torghut/app/models/entities/trading_records.py
+++ b/services/torghut/app/models/entities/trading_records.py
@@ -714,13 +714,13 @@ class ExecutionOrderEvent(Base, CreatedAtMixin):
     )
     event_type: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
     status: Mapped[Optional[str]] = mapped_column(String(length=32), nullable=True)
-    qty: Mapped[Optional[Decimal]] = mapped_column(Numeric(20, 8), nullable=True)
-    filled_qty: Mapped[Optional[Decimal]] = mapped_column(Numeric(20, 8), nullable=True)
+    qty: Mapped[Optional[Decimal]] = mapped_column(Numeric(21, 9), nullable=True)
+    filled_qty: Mapped[Optional[Decimal]] = mapped_column(Numeric(21, 9), nullable=True)
     position_qty: Mapped[Optional[Decimal]] = mapped_column(
-        Numeric(20, 8), nullable=True
+        Numeric(21, 9), nullable=True
     )
     filled_qty_delta: Mapped[Optional[Decimal]] = mapped_column(
-        Numeric(20, 8), nullable=True
+        Numeric(21, 9), nullable=True
     )
     avg_fill_price: Mapped[Optional[Decimal]] = mapped_column(
         Numeric(20, 8), nullable=True

--- a/services/torghut/app/trading/alpaca_observations.py
+++ b/services/torghut/app/trading/alpaca_observations.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from decimal import Decimal, InvalidOperation
 from typing import cast
 
@@ -59,11 +59,36 @@ def alpaca_position_observation(
     if unit_notional is None:
         raise RiskReductionPermitError("alpaca_position_unit_notional_unavailable")
     return BrokerPositionObservation(
-        symbol=str(raw.get("symbol") or ""),
+        symbol=_position_symbol(raw),
         signed_quantity=signed_quantity,
         unit_notional=unit_notional,
         broker_symbol=str(raw.get("symbol") or ""),
     )
+
+
+def alpaca_order_references(raw: object) -> tuple[str, ...]:
+    """Return distinct order IDs from an order or close-position response."""
+
+    references: list[str] = []
+
+    def collect(value: object) -> None:
+        if isinstance(value, Mapping):
+            response = cast(Mapping[object, object], value)
+            reference = str(
+                response.get("id") or response.get("order_id") or ""
+            ).strip()
+            if reference and reference not in references:
+                references.append(reference)
+            body = response.get("body")
+            if body is not None:
+                collect(body)
+            return
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+            for item in cast(Sequence[object], value):
+                collect(item)
+
+    collect(raw)
+    return tuple(references)
 
 
 def optional_decimal(value: object) -> Decimal | None:
@@ -72,6 +97,19 @@ def optional_decimal(value: object) -> Decimal | None:
     except (InvalidOperation, ValueError):
         return None
     return parsed if parsed.is_finite() else None
+
+
+def _position_symbol(raw: Mapping[str, object]) -> str:
+    broker_symbol = str(raw.get("symbol") or "").strip().upper()
+    asset_class = str(raw.get("asset_class") or "").strip().lower()
+    if asset_class != "crypto" or "/" in broker_symbol:
+        return broker_symbol
+    for quote_asset in ("USDT", "USDC", "USD", "BTC"):
+        if broker_symbol.endswith(quote_asset) and len(broker_symbol) > len(
+            quote_asset
+        ):
+            return f"{broker_symbol[: -len(quote_asset)]}/{quote_asset}"
+    raise RiskReductionPermitError("alpaca_crypto_position_symbol_invalid")
 
 
 def _required_decimal(value: object, *, field_name: str) -> Decimal:
@@ -88,6 +126,7 @@ def _optional_order_decimal(value: object, *, field_name: str) -> Decimal | None
 
 
 __all__ = [
+    "alpaca_order_references",
     "alpaca_order_observation",
     "alpaca_position_observation",
     "optional_decimal",

--- a/services/torghut/app/trading/alpaca_reduction_mutations.py
+++ b/services/torghut/app/trading/alpaca_reduction_mutations.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import Session
 from ..alpaca_client import AlpacaSubmitRequest
 from .alpaca_observations import (
     alpaca_order_observation,
+    alpaca_order_references,
     alpaca_position_observation,
 )
 from .broker_mutation_coordinator import (
@@ -872,16 +873,8 @@ def _mapping_response_rejected(response: Mapping[str, object]) -> bool:
 
 
 def _broker_reference(response: object) -> str | None:
-    response_map = _string_mapping(response)
-    if response_map is not None:
-        value = response_map.get("id") or response_map.get("order_id")
-        return str(value).strip() if value else None
-    if isinstance(response, Sequence) and not isinstance(response, (str, bytes)):
-        for item in cast(Sequence[object], response):
-            reference = _broker_reference(item)
-            if reference:
-                return reference
-    return None
+    references = alpaca_order_references(response)
+    return references[0] if references else None
 
 
 def _string_mapping(value: object) -> Mapping[str, object] | None:

--- a/services/torghut/app/trading/infrastructure_validation_lifecycle.py
+++ b/services/torghut/app/trading/infrastructure_validation_lifecycle.py
@@ -56,6 +56,8 @@ class InfrastructureValidationLifecycleReport:
     broker_account_number: str
     symbol: str
     entry_quantity: str
+    net_entry_quantity: str
+    entry_fee_quantity: str
     partial_close_quantity: str
     residual_quantity: str
     root_client_order_id: str
@@ -97,6 +99,7 @@ class _LifecycleState:
 class _EntryResult:
     client_order_id: str
     order_id: str
+    position_quantity: Decimal
     evidence: InfrastructureValidationEvidence
     replay_outcome: str
 
@@ -133,9 +136,16 @@ def run_infrastructure_validation_lifecycle(
     state = _LifecycleState()
     try:
         entry = _enter_position(permit, plan, broker, proof, state)
-        repricing = _exercise_repricing(plan, broker, proof, entry.evidence)
+        repricing = _exercise_repricing(
+            plan,
+            entry.position_quantity,
+            broker,
+            proof,
+            entry.evidence,
+        )
         closeout = _exercise_closeout(
             plan,
+            entry.position_quantity,
             broker,
             proof,
             repricing.replacement_evidence,
@@ -155,13 +165,15 @@ def run_infrastructure_validation_lifecycle(
         )
         terminal = broker.known_null_snapshot()
         report = InfrastructureValidationLifecycleReport(
-            schema_version="torghut.infrastructure-validation-lifecycle-report.v1",
+            schema_version="torghut.infrastructure-validation-lifecycle-report.v2",
             observed_at=datetime.now(timezone.utc).isoformat(),
             permit_id=permit.permit_id,
             permit_sha256=infrastructure_validation_permit_sha256(permit),
             broker_account_number=broker.broker_account_number,
             symbol=plan.symbol,
             entry_quantity=decimal_text(plan.qty),
+            net_entry_quantity=decimal_text(entry.position_quantity),
+            entry_fee_quantity=decimal_text(plan.qty - entry.position_quantity),
             partial_close_quantity=decimal_text(plan.partial_close_qty),
             residual_quantity=decimal_text(closeout.residual_quantity),
             root_client_order_id=entry.client_order_id,
@@ -216,7 +228,7 @@ def _enter_position(
     )
     if order_id(root_response) != order_id_value:
         raise RuntimeError("infrastructure_validation_root_response_mismatch")
-    broker.wait_position(symbol=plan.symbol, quantity=plan.qty)
+    position_quantity = broker.wait_entry_position(plan=plan)
     evidence = proof.wait_lineage(
         client_order_id=client_order_id,
         order_id=order_id_value,
@@ -225,12 +237,13 @@ def _enter_position(
     proof.wait_position(
         evidence=evidence,
         symbol=plan.symbol,
-        quantity=plan.qty,
+        quantity=position_quantity,
         expected_order_id=order_id_value,
     )
     return _EntryResult(
         client_order_id=client_order_id,
         order_id=order_id_value,
+        position_quantity=position_quantity,
         evidence=evidence,
         replay_outcome=replay_outcome,
     )
@@ -238,6 +251,7 @@ def _enter_position(
 
 def _exercise_repricing(
     plan: InfrastructureValidationLifecyclePlan,
+    position_quantity: Decimal,
     broker: AlpacaPaperLifecycleBroker,
     proof: InfrastructureValidationLifecycleProof,
     root_evidence: InfrastructureValidationEvidence,
@@ -246,7 +260,7 @@ def _exercise_repricing(
     resting_order_id = order_id(
         executor.submit_crypto_close_order(
             plan.symbol,
-            plan.qty,
+            position_quantity,
             limit_price=plan.resting_close_limit_price,
             validation_evidence=root_evidence,
         )
@@ -256,7 +270,7 @@ def _exercise_repricing(
         LifecycleOrderExpectation(
             symbol=plan.symbol,
             side="sell",
-            quantity=plan.qty,
+            quantity=position_quantity,
             order_id=resting_order_id,
             price_bound=plan.resting_close_limit_price,
         ),
@@ -279,7 +293,7 @@ def _exercise_repricing(
         LifecycleOrderExpectation(
             symbol=plan.symbol,
             side="sell",
-            quantity=plan.qty,
+            quantity=position_quantity,
             order_id=replacement_order_id,
             price_bound=plan.replacement_close_limit_price,
         ),
@@ -303,6 +317,7 @@ def _exercise_repricing(
 
 def _exercise_closeout(
     plan: InfrastructureValidationLifecyclePlan,
+    position_quantity: Decimal,
     broker: AlpacaPaperLifecycleBroker,
     proof: InfrastructureValidationLifecycleProof,
     replacement_evidence: InfrastructureValidationEvidence,
@@ -325,7 +340,7 @@ def _exercise_closeout(
             order_id=partial_order_id,
         ),
     )
-    residual_quantity = plan.qty - plan.partial_close_qty
+    residual_quantity = position_quantity - plan.partial_close_qty
     broker.wait_position(symbol=plan.symbol, quantity=residual_quantity)
     partial_evidence = proof.wait_lineage(
         client_order_id=None,

--- a/services/torghut/app/trading/infrastructure_validation_lifecycle_broker.py
+++ b/services/torghut/app/trading/infrastructure_validation_lifecycle_broker.py
@@ -17,7 +17,10 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from ..models import BrokerMutationReceipt, ExecutionOrderEvent
-from .alpaca_observations import alpaca_position_observation
+from .alpaca_observations import (
+    alpaca_order_references,
+    alpaca_position_observation,
+)
 from .alpaca_reduction_mutations import (
     AlpacaReductionMutationExecutor,
     AlpacaReductionReadClient,
@@ -73,6 +76,8 @@ _CLEANUP_ERRORS = (
     TypeError,
     ValueError,
 )
+_MAX_CRYPTO_TAKER_FEE_RATE = Decimal("0.0025")
+_MIN_LIFECYCLE_LEG_NOTIONAL_USD = Decimal("12")
 
 
 class InfrastructureValidationLifecycleClient(
@@ -135,6 +140,12 @@ class LifecycleOrderExpectation:
     price_bound: Decimal | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class _LifecycleAssetConstraints:
+    minimum_order_size: Decimal
+    quantity_increment: Decimal
+
+
 class AlpacaPaperLifecycleBroker:
     """Own all broker observations, response checks, waits, and cleanup."""
 
@@ -145,6 +156,7 @@ class AlpacaPaperLifecycleBroker:
         account_label: str,
         broker_account_number: str,
         evaluated_at: datetime,
+        asset_constraints: _LifecycleAssetConstraints,
         firewall: OrderFirewall,
         coordinator: BrokerMutationCoordinator,
     ) -> None:
@@ -152,6 +164,7 @@ class AlpacaPaperLifecycleBroker:
         self.account_label = account_label
         self.broker_account_number = broker_account_number
         self.evaluated_at = evaluated_at
+        self.asset_constraints = asset_constraints
         self.firewall = firewall
         self.coordinator = coordinator
 
@@ -187,7 +200,10 @@ class AlpacaPaperLifecycleBroker:
             context.client.get_account(),
             permit,
         )
-        _validate_lifecycle_asset(context.client.get_asset(plan.symbol), plan)
+        asset_constraints = _validate_lifecycle_asset(
+            context.client.get_asset(plan.symbol),
+            plan,
+        )
         positions, orders = _known_null_snapshot(context.client)
         if positions or orders:
             raise RuntimeError("infrastructure_validation_account_not_known_null")
@@ -214,6 +230,7 @@ class AlpacaPaperLifecycleBroker:
             account_label=account_label,
             broker_account_number=account_number,
             evaluated_at=evaluated_at,
+            asset_constraints=asset_constraints,
             firewall=firewall,
             coordinator=BrokerMutationCoordinator("validation-lifecycle"),
         )
@@ -364,6 +381,80 @@ class AlpacaPaperLifecycleBroker:
             raise RuntimeError("infrastructure_validation_fill_price_exceeds_limit")
         return order_id
 
+    def wait_entry_position(
+        self,
+        *,
+        plan: InfrastructureValidationLifecyclePlan,
+    ) -> Decimal:
+        """Return the fee-adjusted position created by the filled buy order."""
+
+        deadline = time.monotonic() + self.context.order_timeout_seconds
+        latest = "missing"
+        minimum_quantity = (
+            plan.qty * (Decimal("1") - _MAX_CRYPTO_TAKER_FEE_RATE)
+            - self.asset_constraints.quantity_increment
+        )
+        while time.monotonic() < deadline:
+            raw_positions = self.context.client.list_positions()
+            if len(raw_positions) == 1:
+                position = alpaca_position_observation(raw_positions[0])
+                latest = f"{position.symbol}:{position.signed_quantity}"
+                if (
+                    position.symbol == plan.symbol
+                    and minimum_quantity <= position.signed_quantity <= plan.qty
+                ):
+                    self._require_entry_reduction_quantities(
+                        plan=plan,
+                        position_quantity=position.signed_quantity,
+                        unit_notional=position.unit_notional,
+                    )
+                    return position.signed_quantity
+            else:
+                latest = f"count={len(raw_positions)}"
+            time.sleep(self.context.poll_interval_seconds)
+        raise RuntimeError(
+            f"infrastructure_validation_entry_position_wait_timeout:{latest}"
+        )
+
+    def _require_entry_reduction_quantities(
+        self,
+        *,
+        plan: InfrastructureValidationLifecyclePlan,
+        position_quantity: Decimal,
+        unit_notional: Decimal,
+    ) -> None:
+        residual_quantity = position_quantity - plan.partial_close_qty
+        if residual_quantity <= 0:
+            raise RuntimeError(
+                "infrastructure_validation_fee_adjusted_residual_not_positive"
+            )
+        for field, quantity in (
+            ("fee_adjusted_entry_quantity", position_quantity),
+            ("fee_adjusted_residual_quantity", residual_quantity),
+        ):
+            if quantity < self.asset_constraints.minimum_order_size:
+                raise RuntimeError(
+                    f"infrastructure_validation_{field}_below_broker_minimum"
+                )
+            try:
+                _require_increment(
+                    quantity,
+                    self.asset_constraints.quantity_increment,
+                    field,
+                )
+                _require_numeric_21_9(quantity, field)
+            except ValueError as exc:
+                raise RuntimeError(str(exc)) from exc
+        for field, quantity in (
+            ("partial_close", plan.partial_close_qty),
+            ("fee_adjusted_residual_close", residual_quantity),
+        ):
+            if quantity * unit_notional < _MIN_LIFECYCLE_LEG_NOTIONAL_USD:
+                raise RuntimeError(
+                    "infrastructure_validation_"
+                    f"{field}_observed_notional_below_broker_cost_basis_floor"
+                )
+
     def wait_position(self, *, symbol: str, quantity: Decimal) -> None:
         deadline = time.monotonic() + self.context.order_timeout_seconds
         latest = "missing"
@@ -441,18 +532,20 @@ class AlpacaPaperLifecycleBroker:
 
 
 def order_id(response: Mapping[str, object]) -> str:
-    value = str(response.get("id") or response.get("order_id") or "").strip()
-    if not value:
+    references = alpaca_order_references(response)
+    if len(references) != 1:
         raise RuntimeError("infrastructure_validation_broker_order_identity_missing")
-    return value
+    return references[0]
 
 
 def single_order_id(response: Sequence[Mapping[str, object]]) -> str:
-    if len(response) != 1:
+    references = alpaca_order_references(response)
+    if len(response) != 1 or len(references) != 1:
         raise RuntimeError(
-            f"infrastructure_validation_flatten_response_count_invalid:{len(response)}"
+            "infrastructure_validation_flatten_response_identity_invalid:"
+            f"responses={len(response)}:references={len(references)}"
         )
-    return order_id(response[0])
+    return references[0]
 
 
 def decimal_text(value: Decimal) -> str:
@@ -497,7 +590,7 @@ def _validate_broker_account(
 def _validate_lifecycle_asset(
     asset: Mapping[str, object] | None,
     plan: InfrastructureValidationLifecyclePlan,
-) -> None:
+) -> _LifecycleAssetConstraints:
     if not asset or not bool(asset.get("tradable")):
         raise RuntimeError("infrastructure_validation_asset_not_tradable")
     if str(asset.get("asset_class") or "").strip().lower() != "crypto":
@@ -525,7 +618,7 @@ def _validate_lifecycle_asset(
         if quantity < minimum_order_size:
             raise ValueError(f"infrastructure_validation_{field}_below_broker_minimum")
         _require_increment(quantity, quantity_increment, field)
-        _require_numeric_20_8(quantity, field)
+        _require_numeric_21_9(quantity, field)
     for field, price in (
         ("entry_limit_price", plan.limit_price),
         ("resting_close_limit_price", plan.resting_close_limit_price),
@@ -533,6 +626,10 @@ def _validate_lifecycle_asset(
     ):
         _require_increment(price, price_increment, field)
         _require_numeric_20_8(price, field)
+    return _LifecycleAssetConstraints(
+        minimum_order_size=minimum_order_size,
+        quantity_increment=quantity_increment,
+    )
 
 
 def _require_increment(value: Decimal, increment: Decimal, field: str) -> None:
@@ -541,7 +638,21 @@ def _require_increment(value: Decimal, increment: Decimal, field: str) -> None:
         raise ValueError(f"infrastructure_validation_{field}_increment_invalid")
 
 
+def _require_numeric_21_9(value: Decimal, field: str) -> None:
+    _require_numeric_precision(value, field=field, integer_digits=12, scale=9)
+
+
 def _require_numeric_20_8(value: Decimal, field: str) -> None:
+    _require_numeric_precision(value, field=field, integer_digits=12, scale=8)
+
+
+def _require_numeric_precision(
+    value: Decimal,
+    *,
+    field: str,
+    integer_digits: int,
+    scale: int,
+) -> None:
     normalized = value.copy_abs().normalize()
     exponent = normalized.as_tuple().exponent
     if not isinstance(exponent, int):  # finite values are guaranteed by the plan
@@ -549,8 +660,8 @@ def _require_numeric_20_8(value: Decimal, field: str) -> None:
             f"infrastructure_validation_{field}_database_precision_invalid"
         )
     fractional_digits = max(0, -exponent)
-    integer_digits = max(1, normalized.adjusted() + 1)
-    if fractional_digits > 8 or integer_digits > 12:
+    observed_integer_digits = max(1, normalized.adjusted() + 1)
+    if fractional_digits > scale or observed_integer_digits > integer_digits:
         raise ValueError(
             f"infrastructure_validation_{field}_database_precision_invalid"
         )

--- a/services/torghut/migrations/versions/0074_order_feed_crypto_quantity_precision.py
+++ b/services/torghut/migrations/versions/0074_order_feed_crypto_quantity_precision.py
@@ -1,0 +1,99 @@
+"""Preserve Alpaca crypto quantities at the broker's nine-decimal precision.
+
+Revision ID: 0074_crypto_qty_precision
+Revises: 0073_live_paper_bounds
+Create Date: 2026-07-15 22:30:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect
+
+
+revision = "0074_crypto_qty_precision"
+down_revision = "0073_live_paper_bounds"
+branch_labels = None
+depends_on = None
+
+
+_TABLE = "execution_order_events"
+_QUANTITY_COLUMNS = (
+    "qty",
+    "filled_qty",
+    "filled_qty_delta",
+    "position_qty",
+)
+_OLD_TYPE = sa.Numeric(20, 8)
+_NEW_TYPE = sa.Numeric(21, 9)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if getattr(getattr(bind, "dialect", None), "name", "") != "postgresql":
+        return
+    inspector = inspect(bind)
+    if not inspector.has_table(_TABLE):
+        return
+    columns = {column["name"]: column for column in inspector.get_columns(_TABLE)}
+    op.execute(sa.text(f"LOCK TABLE {_TABLE} IN ACCESS EXCLUSIVE MODE NOWAIT"))
+    for column_name in _QUANTITY_COLUMNS:
+        column = columns.get(column_name)
+        if column is None or _is_quantity_type(column["type"], precision=21, scale=9):
+            continue
+        op.alter_column(
+            _TABLE,
+            column_name,
+            existing_type=column["type"],
+            type_=_NEW_TYPE,
+            existing_nullable=True,
+            postgresql_using=f"{column_name}::numeric(21, 9)",
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if getattr(getattr(bind, "dialect", None), "name", "") != "postgresql":
+        return
+    inspector = inspect(bind)
+    if not inspector.has_table(_TABLE):
+        return
+    columns = {column["name"]: column for column in inspector.get_columns(_TABLE)}
+    op.execute(sa.text(f"LOCK TABLE {_TABLE} IN ACCESS EXCLUSIVE MODE NOWAIT"))
+    for column_name in _QUANTITY_COLUMNS:
+        column = columns.get(column_name)
+        if column is None or _is_quantity_type(column["type"], precision=20, scale=8):
+            continue
+        loses_precision = bind.execute(
+            sa.text(
+                f"SELECT EXISTS (SELECT 1 FROM {_TABLE} "
+                f"WHERE {column_name} IS NOT NULL "
+                f"AND {column_name} <> round({column_name}, 8))"
+            )
+        ).scalar_one()
+        if loses_precision:
+            raise RuntimeError(
+                f"cannot narrow {_TABLE}.{column_name}: nine-decimal values exist"
+            )
+        op.alter_column(
+            _TABLE,
+            column_name,
+            existing_type=column["type"],
+            type_=_OLD_TYPE,
+            existing_nullable=True,
+            postgresql_using=f"{column_name}::numeric(20, 8)",
+        )
+
+
+def _is_quantity_type(
+    column_type: object,
+    *,
+    precision: int,
+    scale: int,
+) -> bool:
+    return (
+        isinstance(column_type, sa.Numeric)
+        and column_type.precision == precision
+        and column_type.scale == scale
+    )

--- a/services/torghut/tests/execution/infrastructure_validation_postgres_support.py
+++ b/services/torghut/tests/execution/infrastructure_validation_postgres_support.py
@@ -71,6 +71,7 @@ def upgrade_reduction_schema(
         if target in {
             "0072_validation_lifecycle",
             "0073_live_paper_bounds",
+            "0074_crypto_qty_precision",
         }:
             connection.execute(
                 text(

--- a/services/torghut/tests/execution/test_order_feed_crypto_quantity_precision_postgres.py
+++ b/services/torghut/tests/execution/test_order_feed_crypto_quantity_precision_postgres.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+
+import pytest
+from alembic import command
+from alembic.config import Config as AlembicConfig
+from sqlalchemy import inspect, text
+
+from tests.execution.decision_submission_claims_postgres_support import (
+    POSTGRES_DSN,
+    SERVICE_ROOT,
+    create_schema_engines,
+    drop_schema,
+)
+from tests.execution.infrastructure_validation_postgres_support import (
+    upgrade_reduction_schema,
+)
+
+
+@pytest.mark.skipif(
+    not POSTGRES_DSN,
+    reason="set TORGHUT_TEST_POSTGRES_DSN for crypto quantity precision",
+)
+def test_postgres_preserves_nine_decimal_order_feed_quantities() -> None:
+    schema, admin_engine, schema_engine, _schema_dsn = create_schema_engines(
+        "crypto_quantity_precision"
+    )
+    try:
+        alembic = AlembicConfig(str(SERVICE_ROOT / "alembic.ini"))
+        upgrade_reduction_schema(
+            alembic,
+            schema_engine,
+            target="0074_crypto_qty_precision",
+        )
+
+        columns = {
+            column["name"]: column["type"]
+            for column in inspect(schema_engine).get_columns("execution_order_events")
+        }
+        for column_name in ("qty", "filled_qty", "filled_qty_delta", "position_qty"):
+            assert columns[column_name].precision == 21
+            assert columns[column_name].scale == 9
+
+        value = Decimal("0.000449274")
+        with schema_engine.begin() as connection:
+            connection.execute(
+                text(
+                    "INSERT INTO execution_order_events "
+                    "(id, event_fingerprint, source_topic, alpaca_account_label, "
+                    "qty, filled_qty, filled_qty_delta, position_qty, raw_event) "
+                    "VALUES (:id, :fingerprint, :topic, :account, :value, :value, "
+                    ":value, :value, CAST(:raw_event AS jsonb))"
+                ),
+                {
+                    "account": "paper",
+                    "fingerprint": "f" * 64,
+                    "id": uuid.uuid4(),
+                    "raw_event": "{}",
+                    "topic": "torghut.trade-updates.v1",
+                    "value": value,
+                },
+            )
+            observed = connection.scalar(
+                text(
+                    "SELECT position_qty FROM execution_order_events "
+                    "WHERE event_fingerprint = :fingerprint"
+                ),
+                {"fingerprint": "f" * 64},
+            )
+        assert observed == value
+
+        with pytest.raises(RuntimeError, match="nine-decimal values exist"):
+            command.downgrade(alembic, "0073_live_paper_bounds")
+    finally:
+        drop_schema(schema, admin_engine, schema_engine)

--- a/services/torghut/tests/test_alpaca_reduction_client.py
+++ b/services/torghut/tests/test_alpaca_reduction_client.py
@@ -42,7 +42,14 @@ class _ReductionTradingClient:
 
     def close_all_positions(self, cancel_orders: bool = False) -> list[_Model]:
         self.close_all_cancel_orders.append(cancel_orders)
-        return [_Model(order_id="close-1", status=200, symbol="AAPL")]
+        return [
+            _Model(
+                body={"id": "close-1", "status": "accepted"},
+                order_id=None,
+                status=200,
+                symbol="AAPL",
+            )
+        ]
 
 
 class TestAlpacaReductionClient(TestCase):
@@ -77,6 +84,7 @@ class TestAlpacaReductionClient(TestCase):
         self.assertEqual(close["id"], "close-1")
         self.assertEqual(trading_client.closed[0][0], "AAPL")
         self.assertEqual(trading_client.closed[0][1].qty, "0.5")
-        self.assertEqual(close_all[0]["order_id"], "close-1")
+        self.assertIsNone(close_all[0]["order_id"])
         self.assertEqual(close_all[0]["status"], 200)
+        self.assertEqual(close_all[0]["body"]["id"], "close-1")
         self.assertEqual(trading_client.close_all_cancel_orders, [False])

--- a/services/torghut/tests/test_infrastructure_validation_lifecycle.py
+++ b/services/torghut/tests/test_infrastructure_validation_lifecycle.py
@@ -27,6 +27,7 @@ from app.trading.infrastructure_validation_lifecycle import (
     InfrastructureValidationLifecycleContext,
     run_infrastructure_validation_lifecycle,
 )
+from app.trading.infrastructure_validation_lifecycle_broker import single_order_id
 from app.trading.infrastructure_validation_records import (
     load_infrastructure_validation_evidence,
     tag_infrastructure_validation_event,
@@ -41,10 +42,16 @@ class _LifecycleBroker:
         self,
         session_factory: Callable[[], Session],
         *,
+        broker_position_symbol: str = "BTC/USD",
+        entry_fee_quantity: Decimal = Decimal("0"),
         fail_mutation: str | None = None,
+        nested_close_all_response: bool = False,
     ) -> None:
         self._session_factory = session_factory
+        self._broker_position_symbol = broker_position_symbol
+        self._entry_fee_quantity = entry_fee_quantity
         self._fail_mutation = fail_mutation
+        self._nested_close_all_response = nested_close_all_response
         self._orders: dict[str, dict[str, object]] = {}
         self._position_quantity = Decimal("0")
         self._position_after_order: dict[str, Decimal] = {}
@@ -105,7 +112,8 @@ class _LifecycleBroker:
             return []
         return [
             {
-                "symbol": "BTC/USD",
+                "asset_class": "crypto",
+                "symbol": self._broker_position_symbol,
                 "qty": str(self._position_quantity),
                 "side": "long",
                 "market_value": str(self._position_quantity * Decimal("100000")),
@@ -151,7 +159,7 @@ class _LifecycleBroker:
         client_order_id = str((extra_params or {})["client_order_id"])
         if side == "buy":
             self._begin_mutation("root_submit")
-            self._position_quantity = quantity
+            self._position_quantity = quantity - self._entry_fee_quantity
             return self._add_order(
                 order_id="root-order-1",
                 client_order_id=client_order_id,
@@ -241,20 +249,28 @@ class _LifecycleBroker:
         self._begin_mutation("close_all_positions")
         quantity = self._position_quantity
         self._position_quantity = Decimal("0")
-        return [
-            self._add_order(
-                order_id="final-flatten-order-1",
-                client_order_id="final-flatten-client-1",
-                symbol="BTC/USD",
-                side="sell",
-                quantity=quantity,
-                order_type="market",
-                time_in_force="gtc",
-                limit_price=None,
-                status="filled",
-                filled_quantity=quantity,
-            )
-        ]
+        order = self._add_order(
+            order_id="final-flatten-order-1",
+            client_order_id="final-flatten-client-1",
+            symbol="BTC/USD",
+            side="sell",
+            quantity=quantity,
+            order_type="market",
+            time_in_force="gtc",
+            limit_price=None,
+            status="filled",
+            filled_quantity=quantity,
+        )
+        if self._nested_close_all_response:
+            return [
+                {
+                    "body": order,
+                    "order_id": None,
+                    "status": 200,
+                    "symbol": "BTC/USD",
+                }
+            ]
+        return [order]
 
     def _begin_mutation(self, name: str) -> None:
         self.mutations.append(name)
@@ -491,7 +507,90 @@ def test_runner_executes_one_bounded_lifecycle_and_proves_exclusion(
     assert report.terminal_position_count == 0
     assert report.terminal_open_order_count == 0
     assert report.promotable is False
+    assert (
+        report.schema_version == "torghut.infrastructure-validation-lifecycle-report.v2"
+    )
+    assert report.net_entry_quantity == "0.0004"
+    assert report.entry_fee_quantity == "0"
     assert report.to_payload()["evidence_tag"] == "non_promotable_validation"
+
+
+def test_runner_uses_fee_adjusted_position_and_nested_close_all_order(
+    lifecycle_runtime: tuple[
+        sessionmaker[Session],
+        InfrastructureValidationPermit,
+        InfrastructureValidationLifecyclePlan,
+    ],
+) -> None:
+    sessions, permit, plan = lifecycle_runtime
+    broker = _LifecycleBroker(
+        cast(Callable[[], Session], sessions),
+        broker_position_symbol="BTCUSD",
+        entry_fee_quantity=Decimal("0.000001"),
+        nested_close_all_response=True,
+    )
+
+    report = run_infrastructure_validation_lifecycle(
+        permit=permit,
+        plan=plan,
+        context=_context(broker, sessions),
+    )
+
+    orders = {str(order["id"]): order for order in broker.list_orders()}
+    assert report.entry_quantity == "0.0004"
+    assert report.net_entry_quantity == "0.000399"
+    assert report.entry_fee_quantity == "0.000001"
+    assert report.partial_close_quantity == "0.0002"
+    assert report.residual_quantity == "0.000199"
+    assert orders["resting-close-order-1"]["qty"] == "0.000399"
+    assert orders["replacement-close-order-1"]["qty"] == "0.000399"
+    assert orders["partial-close-order-1"]["qty"] == "0.0002"
+    assert orders["final-flatten-order-1"]["qty"] == "0.000199"
+    assert report.terminal_position_count == 0
+    assert report.terminal_open_order_count == 0
+
+
+def test_runner_rejects_position_below_documented_maximum_fee_bound(
+    lifecycle_runtime: tuple[
+        sessionmaker[Session],
+        InfrastructureValidationPermit,
+        InfrastructureValidationLifecyclePlan,
+    ],
+) -> None:
+    sessions, permit, plan = lifecycle_runtime
+    broker = _LifecycleBroker(
+        cast(Callable[[], Session], sessions),
+        entry_fee_quantity=Decimal("0.00000101"),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="infrastructure_validation_entry_position_wait_timeout",
+    ):
+        run_infrastructure_validation_lifecycle(
+            permit=permit,
+            plan=plan,
+            context=_context(broker, sessions),
+        )
+
+    assert broker.mutations == ["root_submit", "close_all_positions"]
+    assert broker.list_positions() == []
+
+
+def test_flatten_response_rejects_ambiguous_nested_order_identity() -> None:
+    with pytest.raises(
+        RuntimeError,
+        match="infrastructure_validation_flatten_response_identity_invalid",
+    ):
+        single_order_id(
+            [
+                {
+                    "body": {"id": "body-order"},
+                    "order_id": "wrapper-order",
+                    "status": 200,
+                }
+            ]
+        )
 
 
 @pytest.mark.parametrize(

--- a/services/torghut/tests/test_order_feed_crypto_quantity_precision_migration.py
+++ b/services/torghut/tests/test_order_feed_crypto_quantity_precision_migration.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from sqlalchemy import Numeric
+
+from app.models import ExecutionOrderEvent
+from tests.migration_testing import load_migration_module
+
+
+def test_revision_follows_live_paper_bounds() -> None:
+    module = load_migration_module("0074_order_feed_crypto_quantity_precision.py")
+
+    assert module.revision == "0074_crypto_qty_precision"
+    assert module.down_revision == "0073_live_paper_bounds"
+
+
+def test_order_feed_quantity_columns_preserve_alpaca_precision() -> None:
+    table = ExecutionOrderEvent.__table__
+
+    for column_name in ("qty", "filled_qty", "filled_qty_delta", "position_qty"):
+        column_type = table.c[column_name].type
+        assert isinstance(column_type, Numeric)
+        assert column_type.precision == 21
+        assert column_type.scale == 9

--- a/services/torghut/tests/test_strategy_capital_authority_migration_compat.py
+++ b/services/torghut/tests/test_strategy_capital_authority_migration_compat.py
@@ -28,7 +28,7 @@ def test_migration_graph_has_one_merged_head_and_knows_the_released_revision() -
     config = AlembicConfig(str(SERVICE_ROOT / "alembic.ini"))
     scripts = ScriptDirectory.from_config(config)
 
-    assert scripts.get_heads() == ["0073_live_paper_bounds"]
+    assert scripts.get_heads() == ["0074_crypto_qty_precision"]
     assert scripts.get_revision("0063_strategy_capital_authority") is not None
     assert scripts.get_revision("0064_strategy_capital_authority") is not None
     assert scripts.get_revision("0065_strategy_capital_compat") is not None
@@ -40,3 +40,4 @@ def test_migration_graph_has_one_merged_head_and_knows_the_released_revision() -
     assert scripts.get_revision("0071_validation_lineage") is not None
     assert scripts.get_revision("0072_validation_lifecycle") is not None
     assert scripts.get_revision("0073_live_paper_bounds") is not None
+    assert scripts.get_revision("0074_crypto_qty_precision") is not None


### PR DESCRIPTION
## Summary

- Use the filled gross order quantity for root proof and the observed fee-adjusted net crypto position for every reduction and position proof.
- Normalize Alpaca slashless crypto position symbols and read nested order IDs from close-all 207 responses without accepting ambiguous identities.
- Preserve nine-decimal Alpaca quantities in the normalized order feed with a backward-compatible PostgreSQL migration and guarded downgrade.
- Record gross, net, and inferred fee quantities in lifecycle report v2 and document the live broker corrections.

## Related Issues

None

## Testing

- uv sync --frozen --extra dev
- uv run --frozen pyright --project pyrightconfig.json
- uv run --frozen pyright --project pyrightconfig.alpha.json
- uv run --frozen pyright --project pyrightconfig.scripts.json
- ruff format --check on all changed Python files
- ruff check on all changed Python files
- pytest focused lifecycle, permit, position evidence, reduction, order-feed, and migration suites: 192 passed, 1 skipped because TORGHUT_TEST_POSTGRES_DSN is unavailable locally
- uv run --frozen python scripts/check_migration_graph.py
- git diff --check

## Breaking Changes

None. Migration 0074 widens four nullable order-feed quantity columns from numeric(20,8) to numeric(21,9), preserving twelve integer digits. Downgrade refuses to discard nine-decimal values.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed; no UI change.
- [x] Documentation and migration follow-up are included.