### PR TITLE
fix(torghut): revalidate closeouts at broker boundary

### DIFF
--- a/services/torghut/app/trading/firewall.py
+++ b/services/torghut/app/trading/firewall.py
@@ -20,6 +20,10 @@ from ..alpaca_client import (
     issue_order_firewall_token,
 )
 from ..config import settings
+from .alpaca_observations import (
+    alpaca_order_observation,
+    alpaca_position_observation,
+)
 from .broker_mutation_receipts import (
     BrokerMutationBrokerIoError,
     BrokerMutationExplicitRejection,
@@ -39,7 +43,13 @@ from .risk_reduction_mutation_authority import (
     RiskReductionMutationAuthority,
     RiskReductionMutationExpectation,
     consume_risk_reduction_mutation_authority,
+    validate_risk_reduction_mutation_authority,
 )
+from .risk_reduction import (
+    BrokerReductionSnapshot,
+    RiskReductionPermitError,
+)
+from .risk_reduction_boundary import validate_submit_close_order_boundary
 
 logger = logging.getLogger(__name__)
 _MutationResult = TypeVar("_MutationResult")
@@ -57,6 +67,7 @@ _ALPACA_MUTATION_ERRORS = (
     ValueError,
 )
 _EXPLICIT_ALPACA_REJECTION_STATUSES = frozenset({400, 401, 403, 404, 422})
+_RISK_REDUCTION_OPEN_ORDER_LIMIT = 500
 
 
 def _raise_alpaca_mutation_error(exc: Exception) -> NoReturn:
@@ -380,20 +391,48 @@ class OrderFirewall:
         broker_request = alpaca_submit_request_payload(request)
         _require_submit_request_match(authority.request_payload, broker_request)
         normalized_symbol = str(broker_request["symbol"])
+        expectation = RiskReductionMutationExpectation(
+            broker_route="alpaca",
+            account_label=self.account_label,
+            endpoint_fingerprint=fingerprint_broker_endpoint(self.broker_endpoint_url),
+            operation="submit_order",
+            risk_class="risk_reducing",
+            target_key=normalized_symbol,
+        )
+        validate_risk_reduction_mutation_authority(authority, expectation)
+        reduction_evidence = authority.request_payload.get("risk_reduction")
+        if not isinstance(reduction_evidence, Mapping):
+            raise RiskReductionPermitError("risk_reduction_evidence_required")
+        validate_submit_close_order_boundary(
+            cast(Mapping[str, object], reduction_evidence),
+            self._current_risk_reduction_snapshot(),
+            target_key=normalized_symbol,
+        )
         consume_risk_reduction_mutation_authority(
             authority,
-            RiskReductionMutationExpectation(
-                broker_route="alpaca",
-                account_label=self.account_label,
-                endpoint_fingerprint=fingerprint_broker_endpoint(
-                    self.broker_endpoint_url
-                ),
-                operation="submit_order",
-                risk_class="risk_reducing",
-                target_key=normalized_symbol,
-            ),
+            expectation,
         )
         return self._submit_payload(broker_request, request.extra_params)
+
+    def _current_risk_reduction_snapshot(self) -> BrokerReductionSnapshot:
+        raw_positions = self._client.list_positions()
+        if raw_positions is None:
+            raise RiskReductionPermitError("alpaca_positions_unavailable")
+        raw_orders = self._client.list_orders(
+            status="open",
+            limit=_RISK_REDUCTION_OPEN_ORDER_LIMIT,
+        )
+        return BrokerReductionSnapshot(
+            broker_route="alpaca",
+            account_label=self.account_label,
+            endpoint_fingerprint=fingerprint_broker_endpoint(self.broker_endpoint_url),
+            observed_at=datetime.now(timezone.utc),
+            complete=len(raw_orders) < _RISK_REDUCTION_OPEN_ORDER_LIMIT,
+            orders=tuple(alpaca_order_observation(order) for order in raw_orders),
+            positions=tuple(
+                alpaca_position_observation(position) for position in raw_positions
+            ),
+        )
 
     def cancel_all_orders(
         self,

--- a/services/torghut/app/trading/risk_reduction_boundary.py
+++ b/services/torghut/app/trading/risk_reduction_boundary.py
@@ -1,0 +1,73 @@
+"""Broker-boundary revalidation for sealed risk-reduction actions."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from decimal import Decimal
+from typing import cast
+
+from .risk_reduction import (
+    RISK_REDUCTION_EVIDENCE_SCHEMA_VERSION,
+    BrokerReductionSnapshot,
+    OrderSide,
+    PositionCloseLeg,
+    RiskReductionPermitError,
+    SubmitCloseOrderPlan,
+    authorize_risk_reduction,
+)
+
+
+def validate_submit_close_order_boundary(
+    evidence: Mapping[str, object],
+    snapshot: BrokerReductionSnapshot,
+    *,
+    target_key: str,
+) -> None:
+    """Re-evaluate one sealed close order against broker state at I/O time."""
+
+    normalized_target = target_key.strip().upper()
+    if evidence.get("schema_version") != RISK_REDUCTION_EVIDENCE_SCHEMA_VERSION:
+        raise RiskReductionPermitError("risk_reduction_evidence_schema_invalid")
+    if evidence.get("target_key") != normalized_target:
+        raise RiskReductionPermitError("risk_reduction_target_mismatch")
+    raw_action = evidence.get("action")
+    if not isinstance(raw_action, Mapping):
+        raise RiskReductionPermitError("risk_reduction_action_invalid")
+    action = cast(Mapping[str, object], raw_action)
+    if action.get("type") != "submit_close_order":
+        raise RiskReductionPermitError("risk_reduction_action_invalid")
+    raw_leg = action.get("leg")
+    if not isinstance(raw_leg, Mapping):
+        raise RiskReductionPermitError("risk_reduction_action_invalid")
+    leg_payload = cast(Mapping[str, object], raw_leg)
+    side = str(leg_payload.get("side") or "").strip().lower()
+    if side not in {"buy", "sell"}:
+        raise RiskReductionPermitError("risk_reduction_action_invalid")
+    try:
+        quantity = Decimal(str(leg_payload.get("quantity")))
+        limit_price = Decimal(str(action.get("limit_price")))
+    except (ArithmeticError, ValueError) as exc:
+        raise RiskReductionPermitError("risk_reduction_action_invalid") from exc
+    if str(action.get("time_in_force") or "").strip().lower() != "gtc":
+        raise RiskReductionPermitError("risk_reduction_action_invalid")
+    authorization = authorize_risk_reduction(
+        snapshot,
+        SubmitCloseOrderPlan(
+            leg=PositionCloseLeg(
+                symbol=str(leg_payload.get("symbol") or ""),
+                side=cast(OrderSide, side),
+                quantity=quantity,
+            ),
+            limit_price=limit_price,
+            time_in_force="gtc",
+        ),
+        now=snapshot.observed_at,
+    )
+    if (
+        authorization.permit.operation != "submit_order"
+        or authorization.permit.target_key != normalized_target
+    ):
+        raise RiskReductionPermitError("risk_reduction_boundary_mismatch")
+
+
+__all__ = ["validate_submit_close_order_boundary"]

--- a/services/torghut/app/trading/risk_reduction_mutation_authority.py
+++ b/services/torghut/app/trading/risk_reduction_mutation_authority.py
@@ -111,21 +111,9 @@ def consume_risk_reduction_mutation_authority(
     consumed, but it always fails before the broker call.
     """
 
-    io_expectation = BrokerMutationIoPermitExpectation(
-        broker_route=expectation.broker_route,
-        operation=expectation.operation,
-        risk_class=expectation.risk_class,
-        account_label=expectation.account_label,
-        endpoint_fingerprint=expectation.endpoint_fingerprint,
-        request_payload=authority.request_payload,
-    )
-    reduction_expectation = RiskReductionPermitExpectation(
-        broker_route=expectation.broker_route,
-        account_label=expectation.account_label,
-        endpoint_fingerprint=expectation.endpoint_fingerprint,
-        operation=expectation.operation,
-        target_key=expectation.target_key,
-        request_payload=authority.request_payload,
+    io_expectation, reduction_expectation = _authority_expectations(
+        authority,
+        expectation,
     )
     validate_broker_mutation_io_permit(
         authority.mutation_permit,
@@ -145,9 +133,53 @@ def consume_risk_reduction_mutation_authority(
     )
 
 
+def validate_risk_reduction_mutation_authority(
+    authority: RiskReductionMutationAuthority,
+    expectation: RiskReductionMutationExpectation,
+) -> None:
+    """Validate both capabilities without consuming them."""
+
+    io_expectation, reduction_expectation = _authority_expectations(
+        authority,
+        expectation,
+    )
+    validate_broker_mutation_io_permit(
+        authority.mutation_permit,
+        expectation=io_expectation,
+    )
+    validate_risk_reduction_permit(
+        authority.reduction_permit,
+        expectation=reduction_expectation,
+    )
+
+
+def _authority_expectations(
+    authority: RiskReductionMutationAuthority,
+    expectation: RiskReductionMutationExpectation,
+) -> tuple[BrokerMutationIoPermitExpectation, RiskReductionPermitExpectation]:
+    io_expectation = BrokerMutationIoPermitExpectation(
+        broker_route=expectation.broker_route,
+        operation=expectation.operation,
+        risk_class=expectation.risk_class,
+        account_label=expectation.account_label,
+        endpoint_fingerprint=expectation.endpoint_fingerprint,
+        request_payload=authority.request_payload,
+    )
+    reduction_expectation = RiskReductionPermitExpectation(
+        broker_route=expectation.broker_route,
+        account_label=expectation.account_label,
+        endpoint_fingerprint=expectation.endpoint_fingerprint,
+        operation=expectation.operation,
+        target_key=expectation.target_key,
+        request_payload=authority.request_payload,
+    )
+    return io_expectation, reduction_expectation
+
+
 __all__ = [
     "RiskReductionMutationAuthority",
     "RiskReductionMutationExpectation",
     "consume_risk_reduction_mutation_authority",
     "risk_reduction_request_id",
+    "validate_risk_reduction_mutation_authority",
 ]

--- a/services/torghut/tests/test_order_firewall.py
+++ b/services/torghut/tests/test_order_firewall.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 from typing import Any
 from unittest import TestCase
 
+from app.alpaca_client import AlpacaSubmitRequest
 from app.config import settings
 from app.trading.broker_mutation_receipts import BrokerMutationReceiptValidationError
 from app.trading.firewall import (
@@ -27,6 +28,8 @@ from app.trading.risk_reduction import (
     CancelOrderPlan,
     ClosePositionPlan,
     PositionCloseLeg,
+    RiskReductionPermitError,
+    SubmitCloseOrderPlan,
     authorize_risk_reduction,
 )
 from app.trading.risk_reduction_mutation_authority import (
@@ -130,6 +133,34 @@ class FakeAlpacaClient:
     def get_asset(self, symbol_or_asset_id: str) -> dict[str, Any]:
         self.asset_calls.append(symbol_or_asset_id)
         return {"symbol": symbol_or_asset_id, "tradable": True}
+
+
+class BoundaryPositionAlpacaClient(FakeAlpacaClient):
+    def __init__(self, *, quantity: str, side: str = "long") -> None:
+        super().__init__()
+        self.quantity = quantity
+        self.side = side
+
+    def list_orders(
+        self,
+        status: str = "all",
+        *,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        _ = limit
+        self.order_list_calls.append(status)
+        return []
+
+    def list_positions(self) -> list[dict[str, Any]]:
+        self.position_calls += 1
+        return [
+            {
+                "symbol": "AAPL",
+                "qty": self.quantity,
+                "side": self.side,
+                "current_price": "100",
+            }
+        ]
 
 
 class TestOrderFirewall(TestCase):
@@ -433,6 +464,101 @@ class TestOrderFirewall(TestCase):
         )
 
         self.assertEqual(response["id"], "close-1")
+
+    def test_risk_reducing_submit_revalidates_position_at_broker_boundary(
+        self,
+    ) -> None:
+        for quantity, side, expected_error in (
+            ("1", "long", None),
+            ("0.5", "long", "close_order_would_cross_position_zero"),
+            ("1", "short", "close_side_does_not_reduce_position"),
+        ):
+            with self.subTest(quantity=quantity, side=side):
+                client = BoundaryPositionAlpacaClient(quantity=quantity, side=side)
+                firewall = OrderFirewall(client)
+                observed_at = datetime.now(timezone.utc)
+                authorization = authorize_risk_reduction(
+                    BrokerReductionSnapshot(
+                        broker_route="alpaca",
+                        account_label=firewall.account_label,
+                        endpoint_fingerprint=fingerprint_broker_endpoint(
+                            firewall.broker_endpoint_url
+                        ),
+                        observed_at=observed_at,
+                        complete=True,
+                        positions=(
+                            BrokerPositionObservation(
+                                symbol="AAPL",
+                                signed_quantity=Decimal("1"),
+                                unit_notional=Decimal("100"),
+                            ),
+                        ),
+                    ),
+                    SubmitCloseOrderPlan(
+                        leg=PositionCloseLeg(
+                            symbol="AAPL",
+                            side="sell",
+                            quantity=Decimal("1"),
+                        ),
+                        limit_price=Decimal("100"),
+                    ),
+                    now=observed_at,
+                )
+                request_payload = {
+                    "extra_params": {},
+                    "limit_price": "100",
+                    "order_type": "limit",
+                    "qty": "1",
+                    "risk_reduction": authorization.evidence_payload,
+                    "schema_version": "torghut.alpaca-reduction-request.v1",
+                    "side": "sell",
+                    "stop_price": None,
+                    "symbol": "AAPL",
+                    "time_in_force": "gtc",
+                }
+                mutation_permit = broker_mutation_test_permit(
+                    request_payload=request_payload,
+                    broker_route="alpaca",
+                    risk_class="risk_reducing",
+                    account_label=firewall.account_label,
+                    endpoint_url=firewall.broker_endpoint_url,
+                    operation="submit_order",
+                )
+                authority = RiskReductionMutationAuthority(
+                    request_payload=request_payload,
+                    mutation_permit=mutation_permit,
+                    reduction_permit=authorization.permit,
+                )
+                request = AlpacaSubmitRequest(
+                    symbol="AAPL",
+                    side="sell",
+                    qty=Decimal("1"),
+                    order_type="limit",
+                    time_in_force="gtc",
+                    limit_price=Decimal("100"),
+                    stop_price=None,
+                    extra_params={},
+                )
+
+                if expected_error is None:
+                    response = firewall.submit_risk_reducing_order(
+                        request,
+                        authority=authority,
+                    )
+                    self.assertEqual(response["id"], "order-1")
+                    self.assertEqual(len(client.submissions), 1)
+                else:
+                    with self.assertRaisesRegex(
+                        RiskReductionPermitError,
+                        expected_error,
+                    ):
+                        firewall.submit_risk_reducing_order(
+                            request,
+                            authority=authority,
+                        )
+                    self.assertEqual(client.submissions, [])
+                self.assertEqual(client.position_calls, 1)
+                self.assertEqual(client.order_list_calls, ["open"])
 
     def test_permit_is_request_bound_and_single_use(self) -> None:
         settings.trading_kill_switch_enabled = False


### PR DESCRIPTION
## Summary
- revalidate each sealed close-order plan against a fresh complete Alpaca position/open-order snapshot immediately before broker I/O
- validate mutation and reduction capabilities before the refresh, then consume both only after the boundary check passes
- reject shrink/side-flip races before any broker mutation while preserving the existing durable unresolved-receipt path

## Validation
- 49 focused firewall/risk-reduction/coordinator/property tests
- all five Torghut Pyright profiles
- compileall and repository-wide Ruff
- structural, changed-line design, and file-length Pylint gates
- tech-debt ratchet, migration graph, and diff checks

Historical source: #12543 discussion 3584994347.