### PR TITLE
fix(nix): serialize OCI layer uploads

### DIFF
--- a/nix/oci-push.sh
+++ b/nix/oci-push.sh
@@ -79,7 +79,10 @@ EOF
 
 reference="${image}:${tag}"
 echo "Pushing Nix-built OCI image tar to ${reference}."
-skopeo --policy "${policy_json}" copy --format oci "docker-archive:${resolved_tar_path}" "docker://${reference}"
+# The lab registry deliberately admits one shaped bulk writer. Keep each publisher
+# to one layer so concurrent releases queue images fairly instead of six layers each.
+skopeo --policy "${policy_json}" copy --image-parallel-copies 1 --format oci \
+  "docker-archive:${resolved_tar_path}" "docker://${reference}"
 
 if [[ -n "${latest_tag}" ]]; then
   latest_reference="${image}:${latest_tag}"

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -775,12 +775,18 @@ describe('native OCI build workflows', () => {
   it('gives Skopeo an explicit containers policy on ARC runners', () => {
     expect(ociPushScript).toContain('policy_json="$(mktemp)"')
     expect(ociPushScript).toContain('"type": "insecureAcceptAnything"')
-    expect(ociPushScript).toContain('skopeo --policy "${policy_json}" copy --format oci')
+    expect(ociPushScript).toContain('skopeo --policy "${policy_json}" copy')
+  })
+
+  it('serializes layer uploads against the shaped registry writer', () => {
+    expect(ociPushScript).toContain('copy --image-parallel-copies 1 --format oci')
   })
 
   it('tags platform latest refs without re-copying image layers', () => {
     expect(ociPushScript).toContain('crane tag "${reference}" "${latest_tag}"')
-    expect(ociPushScript).not.toContain('skopeo --policy "${policy_json}" copy --format oci "docker://${reference}"')
+    expect(ociPushScript).not.toContain(
+      'skopeo --policy "${policy_json}" copy --image-parallel-copies 1 --format oci "docker://${reference}"',
+    )
   })
 
   it('does not use Docker Buildx or docker daemon commands in migrated workflows', () => {


### PR DESCRIPTION
## Summary

- Serialize Skopeo layer uploads per publisher to match the private registry single blob-writer boundary.
- Prevent concurrent publishers from each flooding the two-hour registry queue with parallel layer requests.
- Add focused regression coverage for the explicit Skopeo concurrency contract.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/oci.test.ts` (49 passed)
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/oci.test.ts`
- `bash -n nix/oci-push.sh`
- `git diff --check origin/main...HEAD`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.