### PR TITLE
fix(torghut): keep reduction 4xx unresolved

### DIFF
--- a/services/torghut/app/trading/firewall.py
+++ b/services/torghut/app/trading/firewall.py
@@ -635,7 +635,9 @@ class OrderFirewall:
         try:
             return callback()
         except _ALPACA_MUTATION_ERRORS as exc:
-            _raise_alpaca_mutation_error(exc)
+            raise BrokerMutationBrokerIoError(
+                f"alpaca_broker_io_failed:{type(exc).__name__}"
+            ) from exc
 
     def get_order_by_client_order_id(
         self, client_order_id: str

--- a/services/torghut/tests/test_alpaca_reduction_ambiguity.py
+++ b/services/torghut/tests/test_alpaca_reduction_ambiguity.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+from alpaca.common.exceptions import APIError
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.alpaca_client import TorghutAlpacaClient
+from app.models import Base, BrokerMutationReceipt, BrokerMutationReceiptEvent
+from app.trading.broker_mutation_coordinator import BrokerMutationUnresolved
+from app.trading.execution_adapters import AlpacaExecutionAdapter
+from app.trading.firewall import OrderFirewall
+
+
+class _HttpErrorCancelBroker:
+    endpoint_url = "https://paper-api.alpaca.markets"
+
+    def __init__(self, *, status_code: int) -> None:
+        self.status_code = status_code
+        self.cancel_calls: list[str] = []
+
+    def get_order_by_id_strict(self, order_id: str) -> dict[str, object]:
+        return {
+            "id": order_id,
+            "client_order_id": "ordinary-client-1",
+            "symbol": "BTC/USD",
+            "side": "buy",
+            "qty": "1",
+            "filled_qty": "0",
+            "status": "new",
+            "limit_price": "1",
+        }
+
+    def cancel_order(self, order_id: str, **_kwargs: object) -> bool:
+        self.cancel_calls.append(order_id)
+        raise APIError(
+            json.dumps(
+                {
+                    "code": f"{self.status_code}10000",
+                    "message": "ambiguous reduction response",
+                }
+            ),
+            SimpleNamespace(
+                response=SimpleNamespace(status_code=self.status_code),
+                request=None,
+            ),
+        )
+
+
+@pytest.fixture
+def sessions() -> Iterator[sessionmaker[Session]]:
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(
+        bind=engine,
+        class_=Session,
+        autoflush=False,
+        expire_on_commit=False,
+        future=True,
+    )
+    try:
+        yield factory
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.parametrize("status_code", (404, 422))
+def test_cancel_http_rejection_keeps_receipt_unresolved(
+    sessions: sessionmaker[Session],
+    status_code: int,
+) -> None:
+    broker = _HttpErrorCancelBroker(status_code=status_code)
+    adapter = AlpacaExecutionAdapter(
+        firewall=OrderFirewall(broker, account_label="paper"),
+        read_client=cast(TorghutAlpacaClient, broker),
+        session_factory=sessions,
+        account_label="paper",
+        endpoint_url=broker.endpoint_url,
+    )
+
+    with pytest.raises(BrokerMutationUnresolved, match="broker_io_unresolved"):
+        adapter.cancel_order("order-1")
+
+    assert broker.cancel_calls == ["order-1"]
+    with sessions() as session:
+        receipt = session.execute(
+            select(BrokerMutationReceipt).where(
+                BrokerMutationReceipt.operation == "cancel_order"
+            )
+        ).scalar_one()
+        latest = session.execute(
+            select(BrokerMutationReceiptEvent)
+            .where(BrokerMutationReceiptEvent.receipt_id == receipt.id)
+            .order_by(BrokerMutationReceiptEvent.sequence_no.desc())
+            .limit(1)
+        ).scalar_one()
+    assert latest.state == "broker_io"
+    assert latest.settlement_outcome is None

--- a/services/torghut/tests/test_order_firewall.py
+++ b/services/torghut/tests/test_order_firewall.py
@@ -1,14 +1,21 @@
 from __future__ import annotations
 
+import json
 from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
+from types import SimpleNamespace
 from typing import Any
 from unittest import TestCase
 
+from alpaca.common.exceptions import APIError
+
 from app.alpaca_client import AlpacaSubmitRequest
 from app.config import settings
-from app.trading.broker_mutation_receipts import BrokerMutationReceiptValidationError
+from app.trading.broker_mutation_receipts import (
+    BrokerMutationBrokerIoError,
+    BrokerMutationReceiptValidationError,
+)
 from app.trading.firewall import (
     OrderFirewall,
     OrderFirewallBlocked,
@@ -464,6 +471,28 @@ class TestOrderFirewall(TestCase):
         )
 
         self.assertEqual(response["id"], "close-1")
+
+    def test_reduction_http_rejections_remain_broker_io_ambiguous(self) -> None:
+        for status_code in (404, 422):
+            with self.subTest(status_code=status_code):
+                error = APIError(
+                    json.dumps(
+                        {
+                            "code": f"{status_code}10000",
+                            "message": "broker reduction response",
+                        }
+                    ),
+                    SimpleNamespace(
+                        response=SimpleNamespace(status_code=status_code),
+                        request=None,
+                    ),
+                )
+
+                with self.assertRaisesRegex(
+                    BrokerMutationBrokerIoError,
+                    "alpaca_broker_io_failed:APIError",
+                ):
+                    OrderFirewall._broker_call(lambda: (_ for _ in ()).throw(error))
 
     def test_risk_reducing_submit_revalidates_position_at_broker_boundary(
         self,


### PR DESCRIPTION
## Summary

- Preserve definitive submit-order rejection handling for infrastructure validation.
- Treat errors returned after an authorized cancel, replace, close, or flatten mutation as unresolved broker I/O until read-only reconciliation establishes terminal broker truth.
- Add cancellation regressions for HTTP 404 and 422 and retain the single durable receipt in broker_io without false settlement.

## Related Issues

Follow-up to #12601 review feedback.

## Testing

- ./.venv/bin/pytest -q tests/test_alpaca_reduction_ambiguity.py tests/test_order_firewall.py (15 passed)
- ./.venv/bin/ruff check app/trading/firewall.py tests/test_alpaca_reduction_ambiguity.py tests/test_order_firewall.py
- ./.venv/bin/pyright --project pyrightconfig.json
- GitHub torghut-ci PostgreSQL mutation fencing, eight pytest shards, four autoresearch shards, static guards, Pyright, and coverage

## Breaking Changes

None. Reduction HTTP errors now remain unresolved until broker reconciliation instead of being prematurely settled as rejected.

## Checklist

- [x] Testing section documents the exact validation performed (or N/A with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.