### PR TITLE
docs(torghut): clarify reduction error recovery

### DIFF
--- a/docs/torghut/profitability/infrastructure-validation-runbook.md
+++ b/docs/torghut/profitability/infrastructure-validation-runbook.md
@@ -258,12 +258,18 @@ For example, when BTC/USD is below `$70,000`, `qty=0.0004`, `limit_price=70000`,
 Resting and replacement close limits must remain strictly above the entry limit and each other. Recompute the immutable
 plan digest after every price or quantity change; never widen a signed permit in place.
 
-An Alpaca HTTP `400`, `401`, `403`, `404`, or `422` response definitively refuses the request and now settles the
-existing receipt as `rejected`, without a fabricated broker reference or success callback. Every other status,
-including conflict, timeout, rate-limit, transport, and server failures, remains ambiguous and stays in `broker_io` for
-read-only reconciliation. These are the synchronous failures documented by the official
+For the initial submit only, an Alpaca HTTP `400`, `401`, `403`, `404`, or `422` response definitively refuses the
+request and settles the receipt as `rejected`, without a fabricated broker reference or success callback. Every other
+submit status, including conflict, timeout, rate-limit, transport, and server failures, remains ambiguous and stays in
+`broker_io` for read-only reconciliation. These are the synchronous failures documented by the official
 [order endpoint](https://docs.alpaca.markets/us/reference/createorderforaccount); live broker behavior remains the
 authority when published minimum metadata and the order endpoint disagree.
+
+That submit rule does not apply after a cancel, replace, close, or flatten mutation has been authorized. A reduction
+endpoint can return `404` or `422` because its target filled, closed, disappeared, or otherwise became terminal while
+the request raced broker state. Any error after reduction I/O therefore preserves the receipt in `broker_io`. Recovery
+must re-read the sealed order or position identity and settle `acknowledged`, `already_satisfied`, `rejected`, or
+`manual_review` from observed broker truth; it must never retry the mutation blindly.
 
 ### Crypto fee and close-all response correction
 

--- a/docs/torghut/profitability/risk-reduction-mutation-fencing.md
+++ b/docs/torghut/profitability/risk-reduction-mutation-fencing.md
@@ -225,9 +225,10 @@ claimed --durable I/O fence--> broker_io --terminal response--> settled
 Safety rules:
 
 - a primary or recovery lease authorizes database transitions, never a second broker mutation;
-- an adapter must translate a definitive non-retryable broker refusal into the shared explicit-rejection contract, so
-  the coordinator atomically settles `rejected`; timeouts, rate limits, transport loss, and server failures remain
-  ambiguous `broker_io` rather than pretending success or rejection;
+- the initial submit adapter may translate a documented synchronous broker refusal into the shared explicit-rejection
+  contract so the coordinator atomically settles `rejected`;
+- after cancel, replace, close, or flatten I/O is authorized, every adapter error remains ambiguous `broker_io`,
+  including HTTP `404` and `422`, because the sealed target may have concurrently filled, closed, or become terminal;
 - recovery observes exact broker identities and sealed target sets; it never calls cancel, replace, or close;
 - an incomplete lookup records `indeterminate` and preserves `broker_io`;
 - side flip, increased quantity, conflicting replacement identity, or increased exposure requires manual review;


### PR DESCRIPTION
## Summary

- Scope synchronous Alpaca HTTP rejection settlement to the initial validation submit.
- Document why cancel, replace, close, and flatten errors remain unresolved after broker I/O authorization.
- Require read-only reconciliation of the sealed broker target and prohibit blind reduction retries.

## Related Issues

Follow-up to #12633.

## Testing

- /nix/var/nix/profiles/default/bin/nix shell nixpkgs#nodejs_24 nixpkgs#bun -c bunx oxfmt --check docs/torghut/profitability/infrastructure-validation-runbook.md docs/torghut/profitability/risk-reduction-mutation-fencing.md
- git diff --check

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or N/A with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.