### PR TITLE
chore(torghut): ratchet websocket config contract

### DIFF
--- a/argocd/applications/torghut/ws/configmap.yaml
+++ b/argocd/applications/torghut/ws/configmap.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: torghut
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
+    torghut.proompteng.ai/config-contract: stable-trade-updates-v1
 data:
   ALPACA_MARKET_TYPE: "equity"
   ALPACA_CRYPTO_LOCATION: "us"


### PR DESCRIPTION
## Summary

- Mark the Torghut websocket ConfigMap with the stable trade-update stream contract.
- Give Argo a declarative metadata delta so it reapplies the ConfigMap whose removed idle-timeout key was otherwise treated as unmanaged live data.
- Keep the source manifest free of the obsolete application-message timeout.

## Related Issues

Follow-up to #12634.

## Testing

- /opt/homebrew/bin/kubectl apply --dry-run=client -n torghut -f argocd/applications/torghut/ws/configmap.yaml
- git diff --check

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or N/A with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.