### PR TITLE
chore(torghut): defer closeout for lifecycle proof

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -413,9 +413,11 @@ spec:
               # scheduler configuration cannot report different authority.
               value: "00:00:00"
             - name: TRADING_FLATTEN_START_TIME_ET
-              value: "15:45:00"
+              # Temporary Slice 6 proof window; mirror the singleton scheduler
+              # and restore immediately after the bounded lifecycle completes.
+              value: "23:50:00"
             - name: TRADING_FLAT_CONFIRMATION_TIME_ET
-              value: "15:50:00"
+              value: "23:55:00"
             - name: TRADING_PAIR_DELTA_TOLERANCE_BPS
               value: "8"
             - name: TRADING_CLOSEOUT_REPRICE_SECONDS

--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -429,9 +429,11 @@ spec:
               # closeout, while every risk-increasing decision is rejected.
               value: "00:00:00"
             - name: TRADING_FLATTEN_START_TIME_ET
-              value: "15:45:00"
+              # Temporary Slice 6 proof window; restore immediately after the
+              # bounded continuous-session lifecycle reaches a known-null account.
+              value: "23:50:00"
             - name: TRADING_FLAT_CONFIRMATION_TIME_ET
-              value: "15:50:00"
+              value: "23:55:00"
             - name: TRADING_PAIR_DELTA_TOLERANCE_BPS
               value: "8"
             - name: TRADING_CLOSEOUT_REPRICE_SECONDS


### PR DESCRIPTION
## Summary

- move only the scheduled paper flatten and flat-confirmation times to 23:50 and 23:55 ET for the bounded continuous-session Slice 6 exercise
- keep the 00:00 new-exposure cutoff, kill switch, emergency controls, loss stops, and singleton scheduler unchanged
- mark both runtime surfaces as temporary and require immediate GitOps restoration after a known-null terminal account

## Related Issues

None.

## Testing

- kubectl apply -n torghut --dry-run=server -f argocd/applications/torghut/scheduler-deployment.yaml
- kubectl apply -n torghut --dry-run=server -f argocd/applications/torghut/knative-service.yaml
- git diff --check

## Breaking Changes

None. This is a bounded temporary paper-account operations window and must be reverted immediately after the lifecycle proof.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] The required immediate restoration follow-up is documented in the manifests and this PR.