### PR TITLE
chore(torghut): promote ws image sha-cb01577143f3245f6d2133f084385071fc125b22

### DIFF
--- a/argocd/applications/torghut-options/ws/deployment.yaml
+++ b/argocd/applications/torghut-options/ws/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws-options
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:b5c3b6cb48e19120ef845e8a7f87965a5e1d9b09d9e41f54397b33164a71e8cb
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:8fff8015205925954d8567b5084ae206d1dddf3ce89033222a6edaf04f5d6289
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -54,9 +54,9 @@ spec:
                   name: torghut-options
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-sha-47a3f7c9260daa924c57a4aafb8006fb80001c3a
+              value: main-sha-cb01577143f3245f6d2133f084385071fc125b22
             - name: TORGHUT_WS_COMMIT
-              value: 47a3f7c9260daa924c57a4aafb8006fb80001c3a
+              value: cb01577143f3245f6d2133f084385071fc125b22
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:

--- a/argocd/applications/torghut/ws/deployment.yaml
+++ b/argocd/applications/torghut/ws/deployment.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:b5c3b6cb48e19120ef845e8a7f87965a5e1d9b09d9e41f54397b33164a71e8cb
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:8fff8015205925954d8567b5084ae206d1dddf3ce89033222a6edaf04f5d6289
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -55,9 +55,9 @@ spec:
                   name: torghut-ws
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-sha-47a3f7c9260daa924c57a4aafb8006fb80001c3a
+              value: main-sha-cb01577143f3245f6d2133f084385071fc125b22
             - name: TORGHUT_WS_COMMIT
-              value: 47a3f7c9260daa924c57a4aafb8006fb80001c3a
+              value: cb01577143f3245f6d2133f084385071fc125b22
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:


### PR DESCRIPTION
## Summary
Promote the Torghut websocket image into GitOps manifests.

- Source commit: `cb01577143f3245f6d2133f084385071fc125b22`
- Image tag: `sha-cb01577143f3245f6d2133f084385071fc125b22`
- Image digest: `sha256:8fff8015205925954d8567b5084ae206d1dddf3ce89033222a6edaf04f5d6289`