### PR TITLE
fix(jangar): keep routing sync optional without workers

### DIFF
--- a/.github/workflows/jangar-post-deploy-verify.yml
+++ b/.github/workflows/jangar-post-deploy-verify.yml
@@ -147,4 +147,5 @@ jobs:
           bun run packages/scripts/src/jangar/sync-temporal-routing.ts \
             --task-queue jangar \
             --deployment-name jangar-deployment \
-            --migrate-stale-running
+            --migrate-stale-running \
+            --allow-no-versioned-pollers

--- a/packages/scripts/src/jangar/__tests__/sync-temporal-routing.test.ts
+++ b/packages/scripts/src/jangar/__tests__/sync-temporal-routing.test.ts
@@ -26,6 +26,7 @@ describe('sync-temporal-routing', () => {
       'jangar@new',
       '--migrate-stale-running',
       '--migrate-unversioned-running',
+      '--allow-no-versioned-pollers',
       '--dry-run',
       '--reason',
       'test',
@@ -38,6 +39,7 @@ describe('sync-temporal-routing', () => {
     expect(parsed.buildId).toBe('jangar@new')
     expect(parsed.migrateStaleRunning).toBe(true)
     expect(parsed.migrateUnversionedRunning).toBe(true)
+    expect(parsed.allowNoVersionedPollers).toBe(true)
     expect(parsed.dryRun).toBe(true)
     expect(parsed.reason).toBe('test')
   })
@@ -204,6 +206,78 @@ describe('sync-temporal-routing', () => {
       previousBuildId: 'jangar@current',
       targetBuildId: 'jangar@current',
     })
+  })
+
+  it('skips routing when no worker build is registered and the deployment is explicitly optional', async () => {
+    const setRequests: unknown[] = []
+    const client = {
+      deployments: {
+        describeWorkerDeployment: async () =>
+          ({
+            workerDeploymentInfo: {
+              routingConfig: {},
+              routingConfigUpdateState: RoutingConfigUpdateState.UNSPECIFIED,
+              versionSummaries: [],
+            },
+          }) as never,
+        setWorkerDeploymentCurrentVersion: async (request: unknown) => {
+          setRequests.push(request)
+          return {} as never
+        },
+      },
+    }
+
+    const result = await __private.syncCurrentVersion(
+      __private.resolveOptions({
+        address: 'temporal.example:7233',
+        namespace: 'default',
+        taskQueue: 'jangar',
+        deploymentName: 'jangar-deployment',
+        allowNoVersionedPollers: true,
+      }),
+      client as never,
+    )
+
+    expect(result).toEqual({
+      changed: false,
+      previousBuildId: undefined,
+      deploymentBuildIds: [],
+      skippedReason: 'no_versioned_workflow_pollers',
+    })
+    expect(setRequests).toEqual([])
+  })
+
+  it('fails closed when no worker build is registered without the explicit optional guard', async () => {
+    const client = {
+      deployments: {
+        describeWorkerDeployment: async () =>
+          ({
+            workerDeploymentInfo: {
+              routingConfig: {},
+              routingConfigUpdateState: RoutingConfigUpdateState.UNSPECIFIED,
+              versionSummaries: [],
+            },
+          }) as never,
+      },
+    }
+
+    let failure: unknown
+    try {
+      await __private.syncCurrentVersion(
+        __private.resolveOptions({
+          address: 'temporal.example:7233',
+          namespace: 'default',
+          taskQueue: 'jangar',
+          deploymentName: 'jangar-deployment',
+        }),
+        client as never,
+      )
+    } catch (error) {
+      failure = error
+    }
+
+    expect(failure).toBeInstanceOf(Error)
+    expect((failure as Error).message).toContain("Temporal worker deployment 'jangar-deployment' has no current build")
   })
 
   it('normalizes legacy deployment versions before selecting stale builds', async () => {

--- a/packages/scripts/src/jangar/sync-temporal-routing.ts
+++ b/packages/scripts/src/jangar/sync-temporal-routing.ts
@@ -24,6 +24,7 @@ type CliOptions = {
   buildId?: string
   migrateStaleRunning?: boolean
   migrateUnversionedRunning?: boolean
+  allowNoVersionedPollers?: boolean
   reason?: string
   dryRun?: boolean
 }
@@ -36,6 +37,7 @@ type ResolvedOptions = {
   buildId?: string
   migrateStaleRunning: boolean
   migrateUnversionedRunning: boolean
+  allowNoVersionedPollers: boolean
   reason: string
   dryRun: boolean
 }
@@ -49,8 +51,9 @@ type CommandResult = {
 type SyncResult = {
   changed: boolean
   previousBuildId?: string
-  targetBuildId: string
+  targetBuildId?: string
   deploymentBuildIds: string[]
+  skippedReason?: 'no_versioned_workflow_pollers'
 }
 
 const defaultAddress = 'temporal-frontend.temporal.svc.cluster.local:7233'
@@ -108,6 +111,7 @@ Options:
   --build-id <id>                       Explicit build to select; otherwise verify the worker-selected current build
   --migrate-stale-running               Move stale pinned running workflows to auto_upgrade after routing update
   --migrate-unversioned-running         Move unversioned running workflows to auto_upgrade
+  --allow-no-versioned-pollers          Skip routing sync when the deployment has no registered worker build
   --reason <text>                       Reason recorded in workflow update-options
   --dry-run                             Print intended actions without mutating Temporal`)
       process.exit(0)
@@ -119,6 +123,10 @@ Options:
     }
     if (arg === '--migrate-unversioned-running') {
       options.migrateUnversionedRunning = true
+      continue
+    }
+    if (arg === '--allow-no-versioned-pollers') {
+      options.allowNoVersionedPollers = true
       continue
     }
     if (arg === '--dry-run') {
@@ -179,6 +187,7 @@ const resolveOptions = (options: CliOptions): ResolvedOptions => {
     buildId: options.buildId?.trim() || process.env.TEMPORAL_WORKER_BUILD_ID?.trim() || undefined,
     migrateStaleRunning: options.migrateStaleRunning ?? false,
     migrateUnversionedRunning: options.migrateUnversionedRunning ?? false,
+    allowNoVersionedPollers: options.allowNoVersionedPollers ?? false,
     reason: options.reason?.trim() || defaultReason,
     dryRun: options.dryRun ?? false,
   }
@@ -361,6 +370,17 @@ const syncCurrentVersion = async (options: ResolvedOptions, client: TemporalClie
   const targetBuildId = options.buildId ?? currentBuildId
   const deploymentBuildIds = extractDeploymentBuildIds(deployment, options.deploymentName)
   if (!targetBuildId) {
+    if (options.allowNoVersionedPollers && deploymentBuildIds.length === 0) {
+      console.log(
+        `Temporal worker deployment '${options.deploymentName}' has no registered build; skipping routing sync.`,
+      )
+      return {
+        changed: false,
+        previousBuildId: currentBuildId,
+        deploymentBuildIds,
+        skippedReason: 'no_versioned_workflow_pollers',
+      }
+    }
     throw new Error(
       `Temporal worker deployment '${options.deploymentName}' has no current build; wait for a healthy worker or pass --build-id explicitly.`,
     )
@@ -429,7 +449,7 @@ export const main = async (cliOptions?: CliOptions) => {
     let migratedStale = 0
     let migratedUnversioned = 0
 
-    if (options.migrateStaleRunning) {
+    if (options.migrateStaleRunning && sync.targetBuildId) {
       const staleBuildIds = [...new Set(sync.deploymentBuildIds)].filter((buildId) => buildId !== sync.targetBuildId)
       for (const buildId of staleBuildIds) {
         const query = `TaskQueue="${options.taskQueue}" and ExecutionStatus="Running" and TemporalWorkerDeploymentVersion="${options.deploymentName}:${buildId}"`
@@ -460,6 +480,7 @@ export const main = async (cliOptions?: CliOptions) => {
           previousBuildId: sync.previousBuildId,
           targetBuildId: sync.targetBuildId,
           changed: sync.changed,
+          skippedReason: sync.skippedReason,
           migratedStale,
           migratedUnversioned,
           dryRun: options.dryRun,

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -1074,6 +1074,7 @@ describe('native OCI build workflows', () => {
     expect(jangarPostDeployVerifyWorkflow).toContain('contents: read')
     expect(jangarPostDeployVerifyWorkflow).toContain('Verify deployment health and digest')
     expect(jangarPostDeployVerifyWorkflow).toContain('Sync Temporal routing after rollout')
+    expect(jangarPostDeployVerifyWorkflow).toContain('--allow-no-versioned-pollers')
     expect(jangarPostDeployVerifyWorkflow).toContain('bun install --frozen-lockfile --ignore-scripts')
     expect(jangarPostDeployVerifyWorkflow).toContain('--filter @proompteng/scripts')
     expect(jangarPostDeployVerifyWorkflow).toContain('--filter @proompteng/temporal-bun-sdk')


### PR DESCRIPTION
## Summary

- restore the explicit `--allow-no-versioned-pollers` contract in the SDK-based Jangar routing synchronizer
- skip only when the worker deployment has neither a current build nor registered versions; retain fail-closed behavior otherwise
- opt the app-only Jangar post-deploy workflow into the guard and add parser, skip, fail-closed, and workflow regressions

## Related Issues

Historical Codex finding: PR #12479 comment `3582092879`.

## Testing

- `bun test packages/scripts/src/jangar/__tests__/sync-temporal-routing.test.ts packages/scripts/src/shared/__tests__/oci.test.ts` — 58 passed
- narrow TypeScript project for `sync-temporal-routing.ts` and its test — passed
- targeted Oxlint — 0 errors; type-aware lint reports only one unchanged warning on a pre-existing test line
- `git diff --check`
- live verification: the `jangar` namespace has no Jangar worker Deployment/Pod; the live `jangar` Deployment contains only the app and Docker sidecar

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section is not applicable.
- [x] Documentation, release notes, and follow-ups are updated or tracked.