### PR TITLE
fix(torghut): persist order events before reconciliation

### DIFF
--- a/services/torghut/app/trading/infrastructure_validation_lifecycle_broker.py
+++ b/services/torghut/app/trading/infrastructure_validation_lifecycle_broker.py
@@ -123,7 +123,10 @@ class InfrastructureValidationLifecycleContext:
     configured_account_label: str
     evaluated_at: datetime | None = None
     order_timeout_seconds: float = 30.0
-    evidence_timeout_seconds: float = 30.0
+    # The single order-feed consumer may be finishing one bounded reconciliation
+    # cycle when a later lifecycle fill arrives. Keep the broker exposure finite
+    # while allowing that already-running cycle plus Kafka poll jitter to finish.
+    evidence_timeout_seconds: float = 60.0
     cleanup_timeout_seconds: float = 30.0
     poll_interval_seconds: float = 0.5
 

--- a/services/torghut/app/trading/order_feed/order_feed_ingestor.py
+++ b/services/torghut/app/trading/order_feed/order_feed_ingestor.py
@@ -99,8 +99,11 @@ class OrderFeedIngestor:
                 break
 
         if durable_any:
-            self._reconcile_tigerbeetle_if_enabled(session)
+            # The broker event is the primary fact. Make it visible before the
+            # optional cross-store audit performs network I/O; otherwise a slow
+            # TigerBeetle lookup can hide a fill from risk and lifecycle readers.
             session.commit()
+            self._reconcile_tigerbeetle_if_enabled(session)
         if durable_any and commit_allowed:
             if _consumer_commit_enabled():
                 if _commit_consumer(consumer):
@@ -118,7 +121,12 @@ class OrderFeedIngestor:
             return
         try:
             _shared_context.reconcile_tigerbeetle_transfers(session)
+            session.commit()
         except Exception as exc:
+            # SQLAlchemy requires an explicit rollback after a database error.
+            # Leaving the scheduler session failed poisons the rest of the
+            # current cycle even when reconciliation is configured as optional.
+            session.rollback()
             if settings.tigerbeetle_reconcile_required:
                 raise
             logger.warning(

--- a/services/torghut/tests/order_feed/test_order_feed_core.py
+++ b/services/torghut/tests/order_feed/test_order_feed_core.py
@@ -349,6 +349,48 @@ class TestOrderFeedCore(OrderFeedTestCase):
             self.assertEqual(len(runs), 1)
             self.assertEqual(runs[0].status, "ok")
 
+    def test_order_feed_event_survives_optional_reconciliation_rollback(self) -> None:
+        payload = (
+            b'{"channel":"trade_updates","payload":{"event":"fill","timestamp":"2026-02-01T10:00:00Z",'
+            b'"order":{"id":"order-1","client_order_id":"client-1","symbol":"AAPL","status":"filled",'
+            b'"qty":"1","filled_qty":"1","filled_avg_price":"190.25"}},"seq":10}'
+        )
+        record = FakeRecord(value=payload, offset=22)
+        client = FakeTigerBeetleClient()
+        settings.tigerbeetle_enabled = True
+        settings.tigerbeetle_journal_enabled = True
+
+        with Session(self.engine) as session:
+            self._seed_execution(session)
+            ingestor = OrderFeedIngestor(
+                consumer_factory=lambda: FakeConsumer([record]),
+                default_account_label="paper",
+            )
+
+            def fail_reconciliation(reconciliation_session: Session) -> None:
+                # Model a failed PostgreSQL transaction from the optional audit.
+                # The already-committed broker event must not be rolled back with it.
+                reconciliation_session.rollback()
+                raise RuntimeError("reconcile failed")
+
+            with (
+                patch(
+                    "app.trading.tigerbeetle_journal.ledger_journal.create_tigerbeetle_client",
+                    return_value=client,
+                ),
+                patch(
+                    "app.trading.order_feed.shared_context.reconcile_tigerbeetle_transfers",
+                    side_effect=fail_reconciliation,
+                ),
+                self.assertLogs(logger, level="WARNING"),
+            ):
+                counters = ingestor.ingest_once(session)
+
+            self.assertEqual(counters["events_persisted_total"], 1)
+            event = session.execute(select(ExecutionOrderEvent)).scalar_one()
+            self.assertEqual(event.alpaca_order_id, "order-1")
+            self.assertTrue(session.is_active)
+
     def test_order_feed_reconciliation_failure_respects_required_flag(self) -> None:
         settings.tigerbeetle_enabled = True
         settings.tigerbeetle_journal_enabled = True
@@ -358,19 +400,24 @@ class TestOrderFeedCore(OrderFeedTestCase):
                 consumer_factory=lambda: FakeConsumer([]),
                 default_account_label="paper",
             )
-            with patch(
-                (
-                    "app.trading.order_feed.shared_context"
-                    ".reconcile_tigerbeetle_transfers"
+            with (
+                patch(
+                    (
+                        "app.trading.order_feed.shared_context"
+                        ".reconcile_tigerbeetle_transfers"
+                    ),
+                    side_effect=RuntimeError("reconcile failed"),
                 ),
-                side_effect=RuntimeError("reconcile failed"),
+                patch.object(session, "rollback", wraps=session.rollback) as rollback,
             ):
                 with self.assertLogs(logger, level="WARNING"):
                     ingestor._reconcile_tigerbeetle_if_enabled(session)
+                self.assertEqual(rollback.call_count, 1)
 
                 settings.tigerbeetle_reconcile_required = True
                 with self.assertRaisesRegex(RuntimeError, "reconcile failed"):
                     ingestor._reconcile_tigerbeetle_if_enabled(session)
+                self.assertEqual(rollback.call_count, 2)
 
     def test_optional_tigerbeetle_journal_failure_does_not_drop_order_event(
         self,


### PR DESCRIPTION
## Summary

- Commit normalized broker order events before starting optional TigerBeetle reconciliation so risk and lifecycle readers can observe fills immediately.
- Commit successful reconciliation records independently and roll back failed reconciliation transactions so the shared scheduler session remains usable.
- Extend the bounded paper lifecycle evidence wait to 60 seconds, covering one already-running reconciliation cycle plus Kafka polling jitter.
- Add regression coverage proving an optional reconciliation rollback cannot erase an already-durable order event.

## Related Issues

None

## Testing

- `git diff --check`
- `python3 -c <compile changed Python sources>` — compiled all 3 changed Python files successfully without writing bytecode.
- Live reproduction on the currently deployed prior image: BTC/USD paper entry filled; the tagged order event remained invisible until optional TigerBeetle reconciliation completed, causing `infrastructure_validation_position_evidence_timeout`; cleanup independently verified zero broker positions and zero open orders.
- Full focused pytest, Ruff, Pyright, and changed-area validation are delegated to PR CI because the local Nix volume is at 100% capacity.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.