### PR TITLE
fix(torghut): stabilize lifecycle replay proof

### DIFF
--- a/.github/workflows/torghut-ci.yml
+++ b/.github/workflows/torghut-ci.yml
@@ -685,6 +685,7 @@ jobs:
             tests/execution/test_broker_mutation_coordinator_postgres.py \
             tests/execution/test_broker_reduction_coordinator_postgres.py \
             tests/execution/test_linked_submission_terminal_postgres.py \
+            tests/execution/test_validation_observation_timestamp_postgres.py \
             tests/trading/test_strategy_capital_authority_postgres.py
 
       - name: Upload PostgreSQL coverage data

--- a/services/torghut/app/trading/order_feed/normalize_order_feed_record.py
+++ b/services/torghut/app/trading/order_feed/normalize_order_feed_record.py
@@ -207,7 +207,6 @@ def normalize_order_feed_record(
         "feed_seq": feed_seq,
         "qty": str(qty) if qty is not None else None,
         "filled_qty": str(filled_qty) if filled_qty is not None else None,
-        "position_qty": str(position_qty) if position_qty is not None else None,
         "avg_fill_price": str(avg_fill_price) if avg_fill_price is not None else None,
     }
     fingerprint = hashlib.sha256(

--- a/services/torghut/migrations/versions/0075_validation_observation_timestamp.py
+++ b/services/torghut/migrations/versions/0075_validation_observation_timestamp.py
@@ -1,0 +1,82 @@
+"""Reject lifecycle reductions without an observation timestamp.
+
+Revision ID: 0075_validation_observed_at
+Revises: 0074_crypto_qty_precision
+Create Date: 2026-07-16 00:30:00.000000
+"""
+
+from __future__ import annotations
+
+import re
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0075_validation_observed_at"
+down_revision = "0074_crypto_qty_precision"
+branch_labels = None
+depends_on = None
+
+
+_LINEAGE_FUNCTION = "torghut_guard_bm_validation_lineage_0072"
+_POSITION_GUARD = r"observed_position_qty\s+IS\s+DISTINCT\s+FROM\s+latest_position_qty"
+_NULL_POSITION_GUARD = r"observed_at\s+IS\s+NULL\s+OR\s+" + _POSITION_GUARD
+
+
+def _rewrite_lineage_function(definition: str, *, upgrade: bool) -> str:
+    old_guard, new_guard = (
+        (
+            rf"IF\s+{_POSITION_GUARD}",
+            "IF observed_at IS NULL\n"
+            "                   OR observed_position_qty IS DISTINCT FROM "
+            "latest_position_qty",
+        )
+        if upgrade
+        else (
+            rf"IF\s+{_NULL_POSITION_GUARD}",
+            "IF observed_position_qty IS DISTINCT FROM latest_position_qty",
+        )
+    )
+    rewritten, count = re.subn(old_guard, new_guard, definition, count=1)
+    if count != 1:
+        raise RuntimeError("validation_observation_timestamp_guard_shape_invalid")
+    return rewritten
+
+
+def _current_lineage_function_definition() -> str:
+    definition = (
+        op.get_bind()
+        .execute(
+            sa.text("SELECT pg_get_functiondef(to_regprocedure(:signature))"),
+            {"signature": f"{_LINEAGE_FUNCTION}()"},
+        )
+        .scalar_one_or_none()
+    )
+    if not isinstance(definition, str):
+        raise RuntimeError("validation_lineage_function_missing")
+    return definition
+
+
+def _install_lineage_function(definition: str) -> None:
+    op.execute(sa.text(definition))
+
+
+def _rewrite_live_function(*, upgrade: bool) -> None:
+    op.execute(
+        sa.text("LOCK TABLE broker_mutation_receipts IN ACCESS EXCLUSIVE MODE NOWAIT")
+    )
+    _install_lineage_function(
+        _rewrite_lineage_function(
+            _current_lineage_function_definition(),
+            upgrade=upgrade,
+        )
+    )
+
+
+def upgrade() -> None:
+    _rewrite_live_function(upgrade=True)
+
+
+def downgrade() -> None:
+    _rewrite_live_function(upgrade=False)

--- a/services/torghut/tests/execution/infrastructure_validation_postgres_support.py
+++ b/services/torghut/tests/execution/infrastructure_validation_postgres_support.py
@@ -72,6 +72,7 @@ def upgrade_reduction_schema(
             "0072_validation_lifecycle",
             "0073_live_paper_bounds",
             "0074_crypto_qty_precision",
+            "0075_validation_observed_at",
         }:
             connection.execute(
                 text(

--- a/services/torghut/tests/execution/test_validation_observation_timestamp_postgres.py
+++ b/services/torghut/tests/execution/test_validation_observation_timestamp_postgres.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import pytest
+from alembic import command
+from alembic.config import Config as AlembicConfig
+from sqlalchemy import text
+
+from app.config import settings
+from tests.execution.decision_submission_claims_postgres_support import (
+    POSTGRES_DSN,
+    SERVICE_ROOT,
+    create_schema_engines,
+    drop_schema,
+)
+from tests.execution.infrastructure_validation_postgres_support import (
+    upgrade_reduction_schema,
+)
+
+
+@pytest.mark.skipif(
+    not POSTGRES_DSN,
+    reason="set TORGHUT_TEST_POSTGRES_DSN for lifecycle timestamp migration",
+)
+def test_postgres_observation_timestamp_guard_upgrade_and_downgrade(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    schema, admin_engine, schema_engine, schema_dsn = create_schema_engines(
+        "validation_observed_at"
+    )
+    try:
+        monkeypatch.setattr(settings, "db_dsn", schema_dsn)
+        alembic = AlembicConfig(str(SERVICE_ROOT / "alembic.ini"))
+        upgrade_reduction_schema(
+            alembic,
+            schema_engine,
+            target="0074_crypto_qty_precision",
+        )
+
+        command.upgrade(alembic, "0075_validation_observed_at")
+        with schema_engine.connect() as connection:
+            upgraded = str(
+                connection.scalar(
+                    text(
+                        "SELECT pg_get_functiondef(to_regprocedure("
+                        "'torghut_guard_bm_validation_lineage_0072()'))"
+                    )
+                )
+            )
+        assert "observed_at IS NULL" in upgraded
+
+        command.downgrade(alembic, "0074_crypto_qty_precision")
+        with schema_engine.connect() as connection:
+            downgraded = str(
+                connection.scalar(
+                    text(
+                        "SELECT pg_get_functiondef(to_regprocedure("
+                        "'torghut_guard_bm_validation_lineage_0072()'))"
+                    )
+                )
+            )
+        assert "observed_at IS NULL" not in downgraded
+    finally:
+        drop_schema(schema, admin_engine, schema_engine)

--- a/services/torghut/tests/order_feed/test_order_feed_core.py
+++ b/services/torghut/tests/order_feed/test_order_feed_core.py
@@ -97,6 +97,20 @@ class TestOrderFeedCore(OrderFeedTestCase):
             )
             assert normalized.event is not None
             self.assertEqual(normalized.event.position_qty, Decimal("0.00003"))
+            replay_without_position = normalize_order_feed_record(
+                FakeRecord(
+                    value=payload.replace(b'"position_qty":"0.00003",', b""),
+                    offset=56,
+                ),
+                default_topic="torghut.trade-updates.v1",
+                default_account_label="paper",
+            )
+            assert replay_without_position.event is not None
+            self.assertIsNone(replay_without_position.event.position_qty)
+            self.assertEqual(
+                normalized.event.event_fingerprint,
+                replay_without_position.event.event_fingerprint,
+            )
 
             persisted, is_duplicate = persist_order_event(session, normalized.event)
             session.commit()

--- a/services/torghut/tests/test_strategy_capital_authority_migration_compat.py
+++ b/services/torghut/tests/test_strategy_capital_authority_migration_compat.py
@@ -28,7 +28,7 @@ def test_migration_graph_has_one_merged_head_and_knows_the_released_revision() -
     config = AlembicConfig(str(SERVICE_ROOT / "alembic.ini"))
     scripts = ScriptDirectory.from_config(config)
 
-    assert scripts.get_heads() == ["0074_crypto_qty_precision"]
+    assert scripts.get_heads() == ["0075_validation_observed_at"]
     assert scripts.get_revision("0063_strategy_capital_authority") is not None
     assert scripts.get_revision("0064_strategy_capital_authority") is not None
     assert scripts.get_revision("0065_strategy_capital_compat") is not None
@@ -41,3 +41,4 @@ def test_migration_graph_has_one_merged_head_and_knows_the_released_revision() -
     assert scripts.get_revision("0072_validation_lifecycle") is not None
     assert scripts.get_revision("0073_live_paper_bounds") is not None
     assert scripts.get_revision("0074_crypto_qty_precision") is not None
+    assert scripts.get_revision("0075_validation_observed_at") is not None

--- a/services/torghut/tests/test_validation_observation_timestamp_migration.py
+++ b/services/torghut/tests/test_validation_observation_timestamp_migration.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tests.migration_testing import load_migration_module
+
+
+MIGRATION_FILENAME = "0075_validation_observation_timestamp.py"
+_FUNCTION_DEFINITION = """
+CREATE OR REPLACE FUNCTION torghut_guard_bm_validation_lineage_0072()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $function$
+BEGIN
+    IF observed_position_qty IS DISTINCT FROM latest_position_qty
+       OR observed_at > NEW.created_at + interval '1 second'
+       OR NEW.created_at - observed_at > interval '5 seconds' THEN
+        RAISE EXCEPTION 'infrastructure validation position not reconciled';
+    END IF;
+    RETURN NEW;
+END;
+$function$
+"""
+
+
+def test_revision_extends_crypto_quantity_precision() -> None:
+    module = load_migration_module(MIGRATION_FILENAME)
+
+    assert module.revision == "0075_validation_observed_at"
+    assert module.down_revision == "0074_crypto_qty_precision"
+    assert len(module.revision) <= 32
+    assert (
+        len(Path(module.__file__ or "").read_text(encoding="utf-8").splitlines())
+        <= 1000
+    )
+
+
+def test_lineage_rewrite_requires_and_round_trips_observation_timestamp() -> None:
+    module = load_migration_module(MIGRATION_FILENAME)
+
+    upgraded = module._rewrite_lineage_function(_FUNCTION_DEFINITION, upgrade=True)
+
+    assert "IF observed_at IS NULL" in upgraded
+    assert "OR observed_position_qty IS DISTINCT FROM latest_position_qty" in upgraded
+    assert module._rewrite_lineage_function(upgraded, upgrade=False) == (
+        _FUNCTION_DEFINITION
+    )
+
+
+def test_upgrade_locks_and_replaces_the_live_lineage_function() -> None:
+    module = load_migration_module(MIGRATION_FILENAME)
+
+    with (
+        patch.object(
+            module,
+            "_current_lineage_function_definition",
+            return_value=_FUNCTION_DEFINITION,
+        ),
+        patch.object(module.op, "execute") as execute,
+    ):
+        module.upgrade()
+
+    sql = "\n".join(str(call.args[0]) for call in execute.call_args_list)
+    assert "ACCESS EXCLUSIVE MODE NOWAIT" in sql
+    assert "IF observed_at IS NULL" in sql
+    assert "observed_position_qty IS DISTINCT FROM latest_position_qty" in sql
+
+
+def test_rewrite_rejects_an_unrecognized_function_shape() -> None:
+    module = load_migration_module(MIGRATION_FILENAME)
+
+    with pytest.raises(
+        RuntimeError,
+        match="validation_observation_timestamp_guard_shape_invalid",
+    ):
+        module._rewrite_lineage_function("SELECT 1", upgrade=True)


### PR DESCRIPTION
## Summary

- keep broker `position_qty` persisted for lifecycle proof without changing the pre-existing order-event idempotency fingerprint
- add reversible migration `0075_validation_observed_at` that rewrites the deployed validation-lineage trigger to reject missing observation timestamps
- register the PostgreSQL upgrade/downgrade regression in the authoritative Postgres 17 CI job
- add replay, migration-shape, upgrade/downgrade, and malformed-shape regression coverage

## Related Issues

Historical Codex review threads: #12592 discussions `3587921118` and `3588209928`.

## Testing

- 131 order-feed and lifecycle tests passed; 1 opt-in PostgreSQL test skipped locally because no DSN is available
- PostgreSQL migration regression added to the Postgres 17 `PostgreSQL mutation fencing CAS` job
- all five Torghut Pyright profiles
- compileall and repository-wide Ruff
- structural, changed-line design, and file-length Pylint gates
- Torghut tech-debt ratchet
- migration graph guardrail with single head `0075_validation_observed_at`
- workflow YAML and diff checks
- changed-line coverage gate passed

## Breaking Changes

None. Existing event fingerprints remain compatible with records produced before `position_qty` was introduced. Migration `0075` only tightens malformed lifecycle proof rejection and has a reversible downgrade.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed because this is a backend and database correctness fix.
- [x] Breaking Changes section is filled in.
- [x] Documentation and release notes are not required; the historical review threads provide the operator-facing defect context.