### PR TITLE
fix(torghut): align storage gate with archive worker

### DIFF
--- a/packages/scripts/src/torghut/__tests__/storage-stability-gate.test.ts
+++ b/packages/scripts/src/torghut/__tests__/storage-stability-gate.test.ts
@@ -232,12 +232,12 @@ const healthySnapshot = (): StorageStabilitySnapshot => ({
   workloads: [
     {
       name: 'torghut-options-archive',
-      desiredReplicas: 0,
-      actualReplicas: 0,
-      readyReplicas: 0,
-      availableReplicas: 0,
+      desiredReplicas: 1,
+      actualReplicas: 1,
+      readyReplicas: 1,
+      availableReplicas: 1,
       terminatingReplicas: 0,
-      podNames: [],
+      podNames: ['torghut-options-archive-7d9f8f6f65-abcde'],
     },
   ],
   argoApplications: [
@@ -507,7 +507,7 @@ describe('Torghut storage stability gate', () => {
     snapshot.jangarPostgres.settings.synchronousCommit = 'off'
     snapshot.jangarPostgres.walBytesPerSecond = 400_000
     snapshot.jangarPostgres.walSampleSeconds = 29
-    snapshot.workloads[0].desiredReplicas = 1
+    snapshot.workloads[0].readyReplicas = 0
     snapshot.argoApplications.find(({ name }) => name === 'rook-ceph')!.health = 'Degraded'
 
     const result = evaluateStorageStabilityGate(snapshot)
@@ -518,20 +518,20 @@ describe('Torghut storage stability gate', () => {
     expect(result.failures.join('\n')).toContain('Jangar PostgreSQL synchronous_commit is off')
     expect(result.failures.join('\n')).toContain('limit is 0.3015 MiB/s (50% of the 0.603 MiB/s pre-change baseline)')
     expect(result.failures.join('\n')).toContain('at least 30 seconds is required')
-    expect(result.failures.join('\n')).toContain('torghut-options-archive must remain contained')
+    expect(result.failures.join('\n')).toContain('torghut-options-archive must match the active replica contract')
     expect(result.failures.join('\n')).toContain('rook-ceph is sync=Synced health=Degraded')
   })
 
-  it('fails containment while any unready or terminating workload pod still exists', () => {
+  it('fails while the active archive worker is unready or terminating', () => {
     const snapshot = healthySnapshot()
-    snapshot.workloads[0].actualReplicas = 1
+    snapshot.workloads[0].readyReplicas = 0
+    snapshot.workloads[0].availableReplicas = 0
     snapshot.workloads[0].terminatingReplicas = 1
-    snapshot.workloads[0].podNames = ['torghut-options-archive-7d9f8f6f65-abcde']
 
     const result = evaluateStorageStabilityGate(snapshot)
 
     expect(result.ok).toBe(false)
-    expect(result.failures.join('\n')).toContain('observed desired=0 actual=1 ready=0 available=0 terminating=1')
+    expect(result.failures.join('\n')).toContain('observed desired=1 actual=1 ready=0 available=0 terminating=1')
     expect(result.failures.join('\n')).toContain('pods=[torghut-options-archive-7d9f8f6f65-abcde]')
   })
 
@@ -557,14 +557,14 @@ describe('Torghut storage stability gate', () => {
     expect(result.failures.join('\n')).toContain('pods=[torghut-hyperliquid-clickhouse-writer-75dd7d9ddc-abcde]')
   })
 
-  it('collects the contained workload from list-shaped deployment output', () => {
+  it('collects the active archive workload from list-shaped deployment output', () => {
     const workloads = __private.collectWorkloadEvidenceFromValues(
       {
         items: [
           {
             metadata: { name: 'torghut-options-archive' },
-            spec: { replicas: 0, selector: { matchLabels: { app: 'torghut-options-archive' } } },
-            status: {},
+            spec: { replicas: 1, selector: { matchLabels: { app: 'torghut-options-archive' } } },
+            status: { replicas: 1, readyReplicas: 1, availableReplicas: 1 },
           },
           {
             metadata: { name: 'torghut-scheduler' },
@@ -577,7 +577,6 @@ describe('Torghut storage stability gate', () => {
             metadata: {
               name: 'torghut-options-archive-7d9f8f6f65-abcde',
               labels: { app: 'torghut-options-archive' },
-              deletionTimestamp: '2026-07-15T17:00:00Z',
             },
           },
         ],
@@ -587,11 +586,11 @@ describe('Torghut storage stability gate', () => {
     expect(workloads).toEqual([
       {
         name: 'torghut-options-archive',
-        desiredReplicas: 0,
-        actualReplicas: 0,
-        readyReplicas: 0,
-        availableReplicas: 0,
-        terminatingReplicas: 1,
+        desiredReplicas: 1,
+        actualReplicas: 1,
+        readyReplicas: 1,
+        availableReplicas: 1,
+        terminatingReplicas: 0,
         podNames: ['torghut-options-archive-7d9f8f6f65-abcde'],
       },
     ])
@@ -603,8 +602,8 @@ describe('Torghut storage stability gate', () => {
         items: [
           {
             metadata: { name: 'torghut-options-archive' },
-            spec: { replicas: 0, selector: { matchLabels: { app: 'torghut-options-archive' } } },
-            status: {},
+            spec: { replicas: 1, selector: { matchLabels: { app: 'torghut-options-archive' } } },
+            status: { replicas: 1, readyReplicas: 1, availableReplicas: 1 },
           },
         ],
       },
@@ -624,10 +623,10 @@ describe('Torghut storage stability gate', () => {
     expect(workloads).toEqual([
       {
         name: 'torghut-options-archive',
-        desiredReplicas: 0,
-        actualReplicas: 0,
-        readyReplicas: 0,
-        availableReplicas: 0,
+        desiredReplicas: 1,
+        actualReplicas: 1,
+        readyReplicas: 1,
+        availableReplicas: 1,
         terminatingReplicas: 0,
         podNames: [],
       },

--- a/packages/scripts/src/torghut/storage-stability-gate.ts
+++ b/packages/scripts/src/torghut/storage-stability-gate.ts
@@ -34,9 +34,11 @@ const EXPECTED_ARGO_APPLICATIONS = [
   'torghut-hyperliquid-runtime',
   'torghut-options',
 ] as const
-const CONTAINED_WORKLOAD_NAMES = ['torghut-options-archive'] as const
+const ACTIVE_WORKLOAD_REPLICA_CONTRACTS = {
+  'torghut-options-archive': 1,
+} as const
 const REMOVED_WORKLOAD_NAMES = ['torghut-hyperliquid-clickhouse-writer'] as const
-const OBSERVED_WORKLOAD_NAMES = new Set([...CONTAINED_WORKLOAD_NAMES, ...REMOVED_WORKLOAD_NAMES])
+const OBSERVED_WORKLOAD_NAMES = new Set([...Object.keys(ACTIVE_WORKLOAD_REPLICA_CONTRACTS), ...REMOVED_WORKLOAD_NAMES])
 
 type OutputFormat = 'json' | 'text'
 
@@ -801,22 +803,22 @@ export const evaluateStorageStabilityGate = (snapshot: StorageStabilitySnapshot)
     )
   }
 
-  for (const expectedWorkload of CONTAINED_WORKLOAD_NAMES) {
+  for (const [expectedWorkload, expectedReplicas] of Object.entries(ACTIVE_WORKLOAD_REPLICA_CONTRACTS)) {
     const workload = snapshot.workloads.find(({ name }) => name === expectedWorkload)
     if (!workload) {
-      failures.push(`containment workload evidence is missing for ${expectedWorkload}`)
+      failures.push(`active workload evidence is missing for ${expectedWorkload}`)
       continue
     }
-    const isContained =
-      workload.desiredReplicas === 0 &&
-      workload.actualReplicas === 0 &&
-      workload.readyReplicas === 0 &&
-      workload.availableReplicas === 0 &&
+    const matchesReplicaContract =
+      workload.desiredReplicas === expectedReplicas &&
+      workload.actualReplicas === expectedReplicas &&
+      workload.readyReplicas === expectedReplicas &&
+      workload.availableReplicas === expectedReplicas &&
       workload.terminatingReplicas === 0 &&
-      workload.podNames.length === 0
-    if (!isContained) {
+      workload.podNames.length === expectedReplicas
+    if (!matchesReplicaContract) {
       failures.push(
-        `${expectedWorkload} must remain contained at desired=0 actual=0 ready=0 available=0 terminating=0 pods=[]; observed desired=${workload.desiredReplicas} actual=${workload.actualReplicas} ready=${workload.readyReplicas} available=${workload.availableReplicas} terminating=${workload.terminatingReplicas} pods=[${workload.podNames.join(', ')}]`,
+        `${expectedWorkload} must match the active replica contract desired=${expectedReplicas} actual=${expectedReplicas} ready=${expectedReplicas} available=${expectedReplicas} terminating=0 podCount=${expectedReplicas}; observed desired=${workload.desiredReplicas} actual=${workload.actualReplicas} ready=${workload.readyReplicas} available=${workload.availableReplicas} terminating=${workload.terminatingReplicas} podCount=${workload.podNames.length} pods=[${workload.podNames.join(', ')}]`,
       )
     }
   }


### PR DESCRIPTION
## Summary

- replace the obsolete zero-replica archive containment assumption with an explicit active workload replica contract
- require `torghut-options-archive` to have exactly one desired, actual, ready, and available replica, no terminating replicas, and one observed pod
- keep `torghut-hyperliquid-clickhouse-writer` under the existing removed-workload zero-presence contract
- update healthy, degraded, collection, and orphaned-pod regression fixtures

## Related Issues

Historical Codex review thread: #12572 discussion `3587329140`.

## Testing

- `bun test packages/scripts/src/torghut/__tests__` — 214 passed
- focused storage gate suite — 36 passed
- Oxfmt and Oxlint on both changed files
- focused strict TypeScript compilation on both changed files
- type-aware Oxlint — zero errors; one pre-existing warning on an unchanged test line
- repository-wide package-scripts TypeScript config remains red on unrelated pre-existing files; no diagnostic references either changed file

## Breaking Changes

The storage gate now treats the GitOps-required single archive worker as the healthy state instead of requiring it to be scaled to zero. The removed Hyperliquid shadow writer remains fail-closed at zero presence.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed because this is a CLI storage-gate contract fix.
- [x] Breaking Changes section is filled in.
- [x] Documentation and release notes are not required; the gate error text and regression suite describe the updated contract.