### PR TITLE
fix(torghut): canonicalize replacement prices

### DIFF
--- a/services/torghut/app/trading/firewall.py
+++ b/services/torghut/app/trading/firewall.py
@@ -464,9 +464,13 @@ class OrderFirewall:
         authority: RiskReductionMutationAuthority,
     ) -> dict[str, object]:
         request_payload = authority.request_payload
-        if str(request_payload.get("order_id") or "").strip() != alpaca_order_id or str(
-            request_payload.get("limit_price") or ""
-        ) != str(limit_price):
+        payload_limit_price = _finite_decimal(request_payload.get("limit_price"))
+        normalized_limit_price = _finite_decimal(limit_price)
+        if str(request_payload.get("order_id") or "").strip() != alpaca_order_id or (
+            payload_limit_price is None
+            or normalized_limit_price is None
+            or payload_limit_price != normalized_limit_price
+        ):
             raise ValueError("alpaca_replace_order_request_mismatch")
         consume_risk_reduction_mutation_authority(
             authority,

--- a/services/torghut/tests/test_alpaca_reduction_coordinator.py
+++ b/services/torghut/tests/test_alpaca_reduction_coordinator.py
@@ -468,7 +468,7 @@ def test_repricing_uses_complete_observation_and_exact_broker_request(
         endpoint_url=broker.endpoint_url,
     )
 
-    result = adapter.replace_order("order-1", limit_price=Decimal("190.25"))
+    result = adapter.replace_order("order-1", limit_price=Decimal("190.2500"))
 
     assert result == {"id": "replacement-1", "status": "accepted"}
     assert broker.replace_calls == [("order-1", 190.25)]
@@ -482,6 +482,9 @@ def test_repricing_uses_complete_observation_and_exact_broker_request(
     assert receipt.operation == "replace_order"
     assert receipt.risk_class == "risk_neutral"
     assert receipt.purpose == "repricing"
+    assert (
+        json.loads(receipt.canonical_intent_json)["request"]["limit_price"] == "190.25"
+    )
     assert latest.state == "settled"
     assert latest.settlement_outcome == "acknowledged"
     with sessions() as session:


### PR DESCRIPTION
## Summary

- compare sealed and caller-supplied replacement prices as canonical finite Decimals rather than raw strings
- accept representation-equivalent prices such as `190.25` and `190.2500` before consuming the reduction capability
- preserve the existing mismatch rejection for invalid, non-finite, or genuinely different prices
- extend the end-to-end repricing test to prove canonical intent persistence and terminal receipt settlement

## Related Issues

Historical Codex review thread: #12573 discussion `3586337634`.

## Testing

- 50 focused firewall, coordinator, preflight, risk-reduction, and property tests
- all five Torghut Pyright profiles
- Ruff and compileall
- changed-line, design, and file-length Pylint gates
- Torghut tech-debt ratchet and migration graph
- diff checks

## Breaking Changes

None. Replacement prices remain request-bound; only numerically equivalent Decimal representations are accepted.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed because this is a broker-boundary correctness fix.
- [x] Breaking Changes section is filled in.
- [x] Documentation and release notes are not required; the historical review thread contains the defect context.