### PR TITLE
docs: supersede duplicate design contracts

### DIFF
--- a/docs/agents/designs/61-jangar-runtime-kit-ledger-and-execution-class-admission-contract-2026-03-20.md
+++ b/docs/agents/designs/61-jangar-runtime-kit-ledger-and-execution-class-admission-contract-2026-03-20.md
@@ -1,6 +1,12 @@
 # 61. Jangar Runtime Kit Ledger and Execution-Class Admission Contract (2026-03-20)
 
-Status: Approved for implementation (`plan`)
+Status: Superseded; non-authoritative historical variant
+Superseded by:
+[`61-jangar-runtime-kits-and-admission-passports-contract-2026-03-20.md`](61-jangar-runtime-kits-and-admission-passports-contract-2026-03-20.md)
+
+Do not use this document as an implementation contract. It is retained only for historical context; the linked
+runtime-kits and admission-passports contract is the authoritative `# 61` design.
+
 Date: `2026-03-20`
 Owner: Victor Chen (Jangar Engineering)
 Mission: `codex/swarm-jangar-control-plane-plan`

--- a/docs/torghut/design-system/v6/60-torghut-hypothesis-passports-and-profit-guardrail-admission-contract-2026-03-20.md
+++ b/docs/torghut/design-system/v6/60-torghut-hypothesis-passports-and-profit-guardrail-admission-contract-2026-03-20.md
@@ -1,6 +1,11 @@
 # 60. Torghut Hypothesis Passports and Profit Guardrail Admission Contract (2026-03-20)
 
-Status: Approved for implementation (`plan`)
+Status: Superseded; non-authoritative historical variant
+Superseded by:
+[`60-torghut-hypothesis-passports-and-capability-quote-auction-contract-2026-03-20.md`](60-torghut-hypothesis-passports-and-capability-quote-auction-contract-2026-03-20.md)
+
+Do not use this document as an implementation contract. It is retained only for historical context; the linked
+hypothesis-passports and capability-quote-auction contract is the authoritative `# 60` design.
 
 ## Source Implementation Audit (2026-07-04)
 
@@ -13,7 +18,6 @@ Status: Approved for implementation (`plan`)
   - `argocd/applications/torghut/clickhouse/clickhouse-guardrails-exporter.yaml`
   - `docs/torghut/production-readiness-proof-runbook.md`
 - Design drift note: Operational docs need runtime status and alerting readback before being treated as complete.
-
 
 ## Executive summary
 


### PR DESCRIPTION
## Summary

- mark the duplicate Jangar `# 61` runtime-kit-ledger contract as a non-authoritative historical variant
- mark the duplicate Torghut `# 60` profit-guardrail contract as a non-authoritative historical variant
- link each retained document directly to the indexed authoritative contract

## Related Issues

Historical Codex findings: PR #4694 comments `2968295840` and `2968295843`.

## Testing

- Oxfmt check passed for both Markdown files
- both superseding link targets exist in the current tree
- `git diff --check` passed

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section is not applicable.
- [x] Documentation, release notes, and follow-ups are updated or tracked.