### PR TITLE
fix(torghut): use configured simulation cache bucket

### DIFF
--- a/services/torghut/scripts/historical_simulation_startup/service_environment.py
+++ b/services/torghut/scripts/historical_simulation_startup/service_environment.py
@@ -607,8 +607,14 @@ def _derived_simulation_cache_key(manifest: Mapping[str, Any]) -> str:
     return hashlib.sha256(_stable_json_for_hash(payload).encode("utf-8")).hexdigest()
 
 
-def _derived_simulation_cache_paths(cache_key: str, dump_format: str) -> dict[str, str]:
+def _derived_simulation_cache_paths(
+    cache_key: str,
+    dump_format: str,
+    *,
+    bucket: str = DEFAULT_SIMULATION_CACHE_BUCKET,
+) -> dict[str, str]:
     normalized_prefix = DEFAULT_SIMULATION_CACHE_PREFIX.strip("/")
+    normalized_bucket = bucket.strip() or DEFAULT_SIMULATION_CACHE_BUCKET
     object_key = "/".join(
         part
         for part in (
@@ -618,7 +624,7 @@ def _derived_simulation_cache_paths(cache_key: str, dump_format: str) -> dict[st
         )
         if part
     )
-    artifact_path = f"s3://{DEFAULT_SIMULATION_CACHE_BUCKET}/{object_key}"
+    artifact_path = f"s3://{normalized_bucket}/{object_key}"
     return {
         "cache_artifact_path": artifact_path,
         "cache_manifest_path": f"{artifact_path}.manifest.json",

--- a/services/torghut/scripts/historical_simulation_startup/state_and_cache.py
+++ b/services/torghut/scripts/historical_simulation_startup/state_and_cache.py
@@ -251,6 +251,13 @@ def _write_dump_marker_from_manifest(
     )
 
 
+def _simulation_cache_bucket_from_env() -> str:
+    return (
+        os.getenv("TORGHUT_SIM_CACHE_CEPH_BUCKET", "").strip()
+        or DEFAULT_SIMULATION_CACHE_BUCKET
+    )
+
+
 def _simulation_cache_client_from_env(
     timeout_seconds: int | None = None,
 ) -> tuple[CephS3Client | None, str]:
@@ -262,10 +269,7 @@ def _simulation_cache_client_from_env(
         os.getenv("TORGHUT_SIM_CACHE_CEPH_SECRET_KEY", "").strip()
         or os.getenv("AWS_SECRET_ACCESS_KEY", "").strip()
     )
-    bucket = (
-        os.getenv("TORGHUT_SIM_CACHE_CEPH_BUCKET", "").strip()
-        or DEFAULT_SIMULATION_CACHE_BUCKET
-    )
+    bucket = _simulation_cache_bucket_from_env()
     endpoint = (
         os.getenv("TORGHUT_SIM_CACHE_CEPH_ENDPOINT", "").strip()
         or DEFAULT_SIMULATION_CACHE_ENDPOINT
@@ -388,6 +392,7 @@ def _cache_metadata(manifest: Mapping[str, Any]) -> dict[str, str]:
             cache_key,
             _as_text(performance_cfg.get("dump_format"))
             or DEFAULT_SIMULATION_DUMP_FORMAT,
+            bucket=_simulation_cache_bucket_from_env(),
         )
         if not cache_artifact_path:
             cache_artifact_path = derived_paths["cache_artifact_path"]

--- a/services/torghut/tests/historical_simulation/test_start_historical_simulation_dump_cache_a.py
+++ b/services/torghut/tests/historical_simulation/test_start_historical_simulation_dump_cache_a.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import os
 
 from tests.historical_simulation.start_historical_simulation_base import (
     Any,
@@ -371,6 +372,29 @@ class TestStartHistoricalSimulationDumpCacheA(StartHistoricalSimulationTestCaseB
             self.assertEqual(report["records"], 1)
             self.assertEqual(report["cache_artifact_path"], cache_artifact_path)
             self.assertTrue(dump_path.exists())
+
+    def test_cache_metadata_derives_paths_from_configured_ceph_bucket(self) -> None:
+        manifest = {
+            "dataset_id": "dataset-a",
+            "performance": {"dumpFormat": "ndjson"},
+            "metadata": {"cacheKey": "cache-key"},
+        }
+
+        with patch.dict(
+            os.environ,
+            {"TORGHUT_SIM_CACHE_CEPH_BUCKET": "custom-simulation-cache"},
+        ):
+            cache_metadata = historical_simulation_startup._cache_metadata(manifest)
+
+        expected_artifact_path = (
+            "s3://custom-simulation-cache/torghut-simulation-cache/"
+            "cache-key/source-dump.ndjson"
+        )
+        self.assertEqual(cache_metadata["cache_artifact_path"], expected_artifact_path)
+        self.assertEqual(
+            cache_metadata["cache_manifest_path"],
+            f"{expected_artifact_path}.manifest.json",
+        )
 
     def test_restore_cached_dump_rejects_lineage_mismatch(self) -> None:
         manifest = {


### PR DESCRIPTION
## Summary

- derive missing historical-simulation cache URIs from `TORGHUT_SIM_CACHE_CEPH_BUCKET`
- share one bucket resolver between path derivation and Ceph client construction
- add a custom-bucket regression for derived artifact and manifest paths

## Related Issues

Historical Codex finding: PR #4553 comment `2940020517`.

## Testing

- complete dump/cache test file passed: 12 tests
- all required Pyright profiles passed: default, alpha, and scripts
- full Ruff format/check, compileall, structural Pylint, changed-line quality/design, file-length, tech-debt ratchet, migration graph, and `git diff --check` passed

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section is not applicable.
- [x] Documentation, release notes, and follow-ups are updated or tracked.