### PR TITLE
chore(torghut): restore scheduled capital windows

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -409,15 +409,11 @@ spec:
             - name: TRADING_PERSISTENT_DRAWDOWN_STOP_PCT_EQUITY
               value: "0.05"
             - name: TRADING_NEW_EXPOSURE_CUTOFF_TIME_ET
-              # Mirror the scheduler's P0 capital-freeze policy so status and
-              # scheduler configuration cannot report different authority.
-              value: "00:00:00"
+              value: "15:30:00"
             - name: TRADING_FLATTEN_START_TIME_ET
-              # Temporary Slice 6 proof window; mirror the singleton scheduler
-              # and restore immediately after the bounded lifecycle completes.
-              value: "23:50:00"
+              value: "15:45:00"
             - name: TRADING_FLAT_CONFIRMATION_TIME_ET
-              value: "23:55:00"
+              value: "15:50:00"
             - name: TRADING_PAIR_DELTA_TOLERANCE_BPS
               value: "8"
             - name: TRADING_CLOSEOUT_REPRICE_SECONDS

--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -425,15 +425,11 @@ spec:
             - name: TRADING_PERSISTENT_DRAWDOWN_STOP_PCT_EQUITY
               value: "0.05"
             - name: TRADING_NEW_EXPOSURE_CUTOFF_TIME_ET
-              # P0 capital freeze: the scheduler stays healthy for recovery and
-              # closeout, while every risk-increasing decision is rejected.
-              value: "00:00:00"
+              value: "15:30:00"
             - name: TRADING_FLATTEN_START_TIME_ET
-              # Temporary Slice 6 proof window; restore immediately after the
-              # bounded continuous-session lifecycle reaches a known-null account.
-              value: "23:50:00"
+              value: "15:45:00"
             - name: TRADING_FLAT_CONFIRMATION_TIME_ET
-              value: "23:55:00"
+              value: "15:50:00"
             - name: TRADING_PAIR_DELTA_TOLERANCE_BPS
               value: "8"
             - name: TRADING_CLOSEOUT_REPRICE_SECONDS

--- a/services/torghut/tests/live_config_manifest_contract/test_single_writer_scheduler_manifest.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_single_writer_scheduler_manifest.py
@@ -92,7 +92,7 @@ class SingleWriterSchedulerManifestTests(TestCase):
         self.assertEqual(env["TRADING_ENABLED"].get("value"), "true")
         self.assertEqual(
             env["TRADING_NEW_EXPOSURE_CUTOFF_TIME_ET"].get("value"),
-            "00:00:00",
+            "15:30:00",
         )
         self.assertNotIn("TRADING_ORDER_MAX_ATTEMPTS", env)
         self.assertNotIn("TRADING_EXECUTION_MAX_RETRIES", env)


### PR DESCRIPTION
## Summary

- restore the production new-exposure cutoff from the temporary all-day P0 freeze to the documented 15:30 ET boundary
- restore flatten and flat-confirmation boundaries from the Slice 6 proof window to 15:45 ET and 15:50 ET
- keep the stateless API and singleton scheduler authority configuration identical and ratchet the manifest contract

## Related Issues

None.

## Testing

- `PYTHONPATH=services/torghut python3 -m unittest services.torghut.tests.live_config_manifest_contract.test_single_writer_scheduler_manifest` (8 tests passed)
- `git diff --check origin/main...HEAD`
- live CNPG audit for the July 15 regular session: 29 decisions, 29 `new_exposure_cutoff_active` rejections, zero submission claims, and zero order events
- live Alpaca paper audit: active account, zero positions, and zero open orders before rollout

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed because this is a backend GitOps configuration change; Breaking Changes is filled in.
- [x] Existing Torghut README already documents the restored 15:30/15:45/15:50 ET production boundaries; no release note is required.