### PR TITLE
fix(torghut): defer unsettled validation descendants

### DIFF
--- a/services/torghut/app/trading/infrastructure_validation_records.py
+++ b/services/torghut/app/trading/infrastructure_validation_records.py
@@ -11,7 +11,7 @@ from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation
 from typing import cast
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from ..models import (
@@ -54,6 +54,10 @@ _LINEAGE_KEYS = frozenset(
         "promotable",
     }
 )
+
+
+class InfrastructureValidationLineagePending(RuntimeError):
+    """An order event may belong to a validation descendant still in broker I/O."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -164,6 +168,30 @@ def load_infrastructure_validation_evidence(
     # Prefer the receipt that created the observed broker order. Root client-ID
     # evidence remains the fallback for cancel/reject events on the setup order.
     return evidence[-1]
+
+
+def defer_pending_infrastructure_validation_descendant(
+    session: Session,
+    *,
+    account_label: str,
+    symbol: str | None,
+) -> None:
+    """Fail closed until an order-creating validation descendant is settled."""
+
+    normalized_symbol = str(symbol or "").strip().upper()
+    if not normalized_symbol:
+        return
+    for receipt in _pending_descendant_receipts(
+        session,
+        account_label=account_label,
+    ):
+        _intent, _lineage, root = _validated_descendant_ancestry(session, receipt)
+        if _root_symbol(root) != normalized_symbol:
+            continue
+        raise InfrastructureValidationLineagePending(
+            "infrastructure_validation_descendant_lineage_pending:"
+            f"{receipt.id}:{normalized_symbol}"
+        )
 
 
 def infrastructure_validation_lineage_payload(
@@ -358,6 +386,41 @@ def _descendant_receipts(
     ]
 
 
+def _pending_descendant_receipts(
+    session: Session,
+    *,
+    account_label: str,
+) -> list[BrokerMutationReceipt]:
+    latest = (
+        select(
+            BrokerMutationReceiptEvent.receipt_id.label("receipt_id"),
+            func.max(BrokerMutationReceiptEvent.sequence_no).label("sequence_no"),
+        )
+        .group_by(BrokerMutationReceiptEvent.receipt_id)
+        .subquery()
+    )
+    statement = (
+        select(BrokerMutationReceipt)
+        .join(latest, BrokerMutationReceipt.id == latest.c.receipt_id)
+        .join(
+            BrokerMutationReceiptEvent,
+            (BrokerMutationReceiptEvent.receipt_id == latest.c.receipt_id)
+            & (BrokerMutationReceiptEvent.sequence_no == latest.c.sequence_no),
+        )
+        .where(
+            BrokerMutationReceipt.account_label == account_label,
+            BrokerMutationReceipt.broker_route == "alpaca",
+            BrokerMutationReceipt.operation.in_(_ORDER_CREATING_LINEAGE_OPERATIONS),
+            BrokerMutationReceiptEvent.state == "broker_io",
+        )
+    )
+    return [
+        receipt
+        for receipt in session.execute(statement).scalars().all()
+        if _has_validation_lineage(receipt)
+    ]
+
+
 def _has_validation_lineage(receipt: BrokerMutationReceipt) -> bool:
     try:
         intent = _parse_json_object(receipt.canonical_intent_json)
@@ -408,6 +471,31 @@ def _descendant_evidence(
     session: Session,
     receipt: BrokerMutationReceipt,
 ) -> InfrastructureValidationEvidence:
+    _intent, lineage, root = _validated_descendant_ancestry(session, receipt)
+    terminal = _require_lineage_parent_terminal(
+        session,
+        receipt.id,
+        allowed_outcomes=frozenset({"acknowledged", "reconciled"}),
+    )
+    return InfrastructureValidationEvidence(
+        receipt_id=receipt.id,
+        broker_order_id=_required_broker_reference(terminal),
+        root_receipt_id=lineage.root_receipt_id,
+        root_client_order_id=lineage.root_client_order_id,
+        root_plan_schema=_root_plan_schema(root),
+        permit_id=lineage.permit_id,
+        permit_sha256=lineage.permit_sha256,
+        account_label=receipt.account_label,
+        endpoint_fingerprint=receipt.endpoint_fingerprint,
+        lineage_parent_terminal=True,
+        _seal=_EVIDENCE_SEAL,
+    )
+
+
+def _validated_descendant_ancestry(
+    session: Session,
+    receipt: BrokerMutationReceipt,
+) -> tuple[dict[str, object], _ValidationLineage, BrokerMutationReceipt]:
     intent, lineage = _parse_validation_lineage(receipt)
     root = session.get(BrokerMutationReceipt, lineage.root_receipt_id)
     if root is None:
@@ -449,24 +537,7 @@ def _descendant_evidence(
         root=root,
         parent_broker_order_id=lineage.parent_broker_order_id,
     )
-    terminal = _require_lineage_parent_terminal(
-        session,
-        receipt.id,
-        allowed_outcomes=frozenset({"acknowledged", "reconciled"}),
-    )
-    return InfrastructureValidationEvidence(
-        receipt_id=receipt.id,
-        broker_order_id=_required_broker_reference(terminal),
-        root_receipt_id=lineage.root_receipt_id,
-        root_client_order_id=lineage.root_client_order_id,
-        root_plan_schema=_root_plan_schema(root),
-        permit_id=lineage.permit_id,
-        permit_sha256=lineage.permit_sha256,
-        account_label=receipt.account_label,
-        endpoint_fingerprint=receipt.endpoint_fingerprint,
-        lineage_parent_terminal=True,
-        _seal=_EVIDENCE_SEAL,
-    )
+    return intent, lineage, root
 
 
 def _parse_validation_lineage(

--- a/services/torghut/app/trading/order_feed/normalize_order_feed_record.py
+++ b/services/torghut/app/trading/order_feed/normalize_order_feed_record.py
@@ -23,6 +23,7 @@ from ...models import (
 from ..tca import upsert_execution_tca_metric
 from ..tigerbeetle_journal import TigerBeetleLedgerJournal
 from ..infrastructure_validation_records import (
+    defer_pending_infrastructure_validation_descendant,
     load_infrastructure_validation_evidence,
     strip_unproven_infrastructure_validation_evidence,
     tag_infrastructure_validation_event,
@@ -376,6 +377,12 @@ def persist_order_event(
         client_order_id=event.client_order_id,
         alpaca_order_id=event.alpaca_order_id,
     )
+    if validation_evidence is None:
+        defer_pending_infrastructure_validation_descendant(
+            session,
+            account_label=event.alpaca_account_label,
+            symbol=event.symbol,
+        )
     existing = session.execute(
         select(ExecutionOrderEvent).where(
             ExecutionOrderEvent.event_fingerprint == event.event_fingerprint

--- a/services/torghut/tests/order_feed/test_infrastructure_validation_exclusion.py
+++ b/services/torghut/tests/order_feed/test_infrastructure_validation_exclusion.py
@@ -24,6 +24,8 @@ from app.trading.infrastructure_validation import (
     infrastructure_validation_terminal_state_sha256,
 )
 from app.trading.infrastructure_validation_records import (
+    InfrastructureValidationLineagePending,
+    defer_pending_infrastructure_validation_descendant,
     infrastructure_validation_lineage_payload,
     is_non_promotable_validation_event,
     load_infrastructure_validation_evidence,
@@ -324,28 +326,6 @@ class TestInfrastructureValidationExclusion(OrderFeedTestCase):
                     },
                 )
             )
-            BrokerMutationCoordinator(
-                "validation-descendant-test"
-            ).execute_unlinked_mutation(
-                session,
-                intent=replacement_intent,
-                callbacks=UnlinkedMutationCallbacks(
-                    broker_call=lambda _permit: {
-                        "id": "validation-replacement-1",
-                        "status": "accepted",
-                    },
-                    persist_terminal=lambda _result: None,
-                    build_settlement=lambda result: build_broker_mutation_settlement(
-                        BrokerMutationSettlementRequest(
-                            source="primary",
-                            outcome="acknowledged",
-                            broker_reference=str(result["id"]),
-                            execution_id=None,
-                            evidence_payload={"status": result["status"]},
-                        )
-                    ),
-                ),
-            )
             descendant_payload = (
                 '{"channel":"trade_updates","payload":{"event":"fill",'
                 '"timestamp":"2026-07-14T10:01:00Z","order":{'
@@ -360,6 +340,47 @@ class TestInfrastructureValidationExclusion(OrderFeedTestCase):
                 default_account_label="paper",
             )
             assert descendant.event is not None
+
+            def replace_broker_call(_permit: object) -> dict[str, str]:
+                defer_pending_infrastructure_validation_descendant(
+                    session,
+                    account_label="paper",
+                    symbol="ETH/USD",
+                )
+                with self.assertRaisesRegex(
+                    InfrastructureValidationLineagePending,
+                    "infrastructure_validation_descendant_lineage_pending",
+                ):
+                    persist_order_event(session, descendant.event)
+                self.assertIsNone(
+                    session.execute(
+                        select(ExecutionOrderEvent).where(
+                            ExecutionOrderEvent.event_fingerprint
+                            == descendant.event.event_fingerprint
+                        )
+                    ).scalar_one_or_none()
+                )
+                return {"id": "validation-replacement-1", "status": "accepted"}
+
+            BrokerMutationCoordinator(
+                "validation-descendant-test"
+            ).execute_unlinked_mutation(
+                session,
+                intent=replacement_intent,
+                callbacks=UnlinkedMutationCallbacks(
+                    broker_call=replace_broker_call,
+                    persist_terminal=lambda _result: None,
+                    build_settlement=lambda result: build_broker_mutation_settlement(
+                        BrokerMutationSettlementRequest(
+                            source="primary",
+                            outcome="acknowledged",
+                            broker_reference=str(result["id"]),
+                            execution_id=None,
+                            evidence_payload={"status": result["status"]},
+                        )
+                    ),
+                ),
+            )
             descendant_event, descendant_duplicate = persist_order_event(
                 session,
                 descendant.event,


### PR DESCRIPTION
## Summary

- detect order-creating infrastructure-validation descendants whose latest durable receipt state is still `broker_io`
- validate their sealed root, parent, scope, and target ancestry before using them as a fail-closed deferral signal
- defer only unclassified order-feed events on the same account and validation root symbol before any event row can be persisted or journaled
- allow unrelated symbols through and persist/tag the identical descendant event after the receipt settles

## Related Issues

Historical Codex review thread: #12584 discussion `3587194295`.

## Testing

- 142 order-feed, reduction, and infrastructure-validation tests passed
- changed-line coverage: 95.45%
- all five Torghut Pyright profiles on the implementation tree; exact rebased head rechecked with the primary profile
- compileall and repository-wide Ruff
- structural, changed-line design, and file-length Pylint gates
- Torghut tech-debt ratchet and migration graph
- exact-head diff checks

## Breaking Changes

Order-feed records that match an in-flight validation descendant are now retried rather than committed as ordinary broker events. The existing source-window failure path remains durable while Kafka offset commit is forbidden until the descendant receipt exposes terminal lineage.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed because this is an order-feed persistence correctness fix.
- [x] Breaking Changes section is filled in.
- [x] Documentation and release notes are not required; the historical review thread contains the failure scenario.