### PR TITLE
fix(agents): count only terminal job failures

### DIFF
--- a/services/agents/src/server/control-plane-runtime-evidence.test.ts
+++ b/services/agents/src/server/control-plane-runtime-evidence.test.ts
@@ -129,6 +129,42 @@ describe('control-plane runtime evidence', () => {
     })
   })
 
+  it('does not count failed pods on an active retrying Job as a terminal workflow failure', async () => {
+    const listJobs = vi.fn(async () => [
+      job({
+        status: {
+          active: 1,
+          failed: 1,
+          startTime: '2026-05-20T11:55:00.000Z',
+          completionTime: null,
+          conditions: [
+            {
+              type: 'FailureTarget',
+              status: 'True',
+              reason: 'FailedCreate',
+              lastTransitionTime: '2026-05-20T11:56:00.000Z',
+            },
+          ],
+        },
+      }),
+    ])
+    const service = createControlPlaneRuntimeEvidenceService({
+      kubeGateway: {
+        listJobs,
+        listDeployments: vi.fn(async () => [deployment('agents'), deployment('agents-controllers')]),
+      },
+    })
+
+    const result = await Effect.runPromise(service.collect({ namespace: 'agents', now }))
+
+    expect(result.workflows).toMatchObject({
+      active_job_runs: 1,
+      recent_failed_jobs: 0,
+      backoff_limit_exceeded_jobs: 0,
+      top_failure_reasons: [],
+    })
+  })
+
   it('downgrades workflow confidence when a namespace collection fails', async () => {
     const service = createControlPlaneRuntimeEvidenceService({
       env: { AGENTS_WORKFLOW_RELIABILITY_NAMESPACES: 'agents,agents-ci' },

--- a/services/agents/src/server/control-plane-runtime-evidence.ts
+++ b/services/agents/src/server/control-plane-runtime-evidence.ts
@@ -130,6 +130,20 @@ const parseIsoMs = (value: string | null | undefined): number | null => {
   return Number.isFinite(parsed) ? parsed : null
 }
 
+const terminalFailedCondition = (conditions: KubeGatewayCondition[]) => {
+  let selected: KubeGatewayCondition | null = null
+  let selectedAt = Number.MIN_SAFE_INTEGER
+  for (const condition of conditions) {
+    if (condition.type !== 'Failed' || condition.status?.toLowerCase() !== 'true') continue
+    const occurredAt = parseIsoMs(condition.lastTransitionTime)
+    if (selected === null || (occurredAt !== null && occurredAt > selectedAt)) {
+      selected = condition
+      selectedAt = occurredAt ?? selectedAt
+    }
+  }
+  return selected
+}
+
 const isBackoffLimitExceededCondition = (condition: KubeGatewayCondition) => condition.reason === 'BackoffLimitExceeded'
 
 const collectWorkflows = async ({
@@ -163,35 +177,26 @@ const collectWorkflows = async ({
         const active = safeNumber(job.status.active)
         if (active > 0) activeJobRuns += 1
 
-        const failed = safeNumber(job.status.failed)
-        const referenceMs =
-          parseIsoMs(job.status.completionTime) ??
-          parseIsoMs(job.status.startTime) ??
-          parseIsoMs(job.metadata.creationTimestamp)
+        const failedCondition = terminalFailedCondition(job.status.conditions)
+        const referenceMs = failedCondition
+          ? (parseIsoMs(failedCondition.lastTransitionTime) ??
+            parseIsoMs(job.status.completionTime) ??
+            parseIsoMs(job.status.startTime) ??
+            parseIsoMs(job.metadata.creationTimestamp))
+          : null
         const failedInWindow =
-          failed > 0 && referenceMs !== null && referenceMs >= windowStartMs && referenceMs <= nowMs
+          failedCondition !== null && referenceMs !== null && referenceMs >= windowStartMs && referenceMs <= nowMs
 
         if (failedInWindow) {
           recentFailedJobs += 1
         }
 
-        const conditionReasons = new Set<string>()
-        let hasBackoffLimitExceeded = false
-        for (const condition of job.status.conditions) {
-          const reason = condition.reason?.trim()
-          const eventMs = parseIsoMs(condition.lastTransitionTime) ?? referenceMs
-          if (!reason || eventMs === null || eventMs < windowStartMs || eventMs > nowMs) continue
-          conditionReasons.add(reason)
-          if (isBackoffLimitExceededCondition(condition)) {
-            hasBackoffLimitExceeded = true
-          }
-        }
-
         if (failedInWindow) {
-          for (const reason of conditionReasons) {
+          const reason = failedCondition.reason?.trim()
+          if (reason) {
             reasonsMap.set(reason, (reasonsMap.get(reason) ?? 0) + 1)
           }
-          if (hasBackoffLimitExceeded) {
+          if (isBackoffLimitExceededCondition(failedCondition)) {
             backoffLimitExceededJobs += 1
           }
         }


### PR DESCRIPTION
## Summary

- move the historical reliability fix to the current agents-service runtime-evidence producer
- count a Job as failed only when it has a terminal Failed condition inside the reliability window
- derive failure reasons and backoff metrics only from that terminal condition
- add an active retry regression with a failed pod count and no terminal failure

## Related Issues

Historical Codex finding: PR #4011 comment `2882663458`.

## Testing

- agents TypeScript compiler passed
- 9 runtime-evidence, control-plane status, and status-route tests passed
- targeted Oxfmt and Oxlint passed
- `git diff --check` passed

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section is not applicable.
- [x] Documentation, release notes, and follow-ups are updated or tracked.