### PR TITLE
fix(torghut): preserve omitted whitepaper outputs

### DIFF
--- a/services/torghut/app/whitepapers/workflow/whitepaper_workflow_api_methods.py
+++ b/services/torghut/app/whitepapers/workflow/whitepaper_workflow_api_methods.py
@@ -63,10 +63,13 @@ class WhitepaperWorkflowApiMethods(_WhitepaperWorkflowApiBase):
             "experiment_specs",
             "contradiction_events",
         )
-        if any(key in payload for key in keys):
+        if any(isinstance(payload.get(key), list) for key in keys):
             return True
         synthesis = payload.get("synthesis")
-        return isinstance(synthesis, Mapping) and any(key in synthesis for key in keys)
+        if not isinstance(synthesis, Mapping):
+            return False
+        structured_synthesis = cast(Mapping[str, Any], synthesis)
+        return any(isinstance(structured_synthesis.get(key), list) for key in keys)
 
     def _compiled_experiment_specs_from_templates(
         self,

--- a/services/torghut/tests/whitepaper_workflow/test_structured_output_presence.py
+++ b/services/torghut/tests/whitepaper_workflow/test_structured_output_presence.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pytest
+
+from app.whitepapers.workflow.whitepaper_workflow_api_methods import (
+    WhitepaperWorkflowApiMethods,
+)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    (
+        {"status": "completed", "claims": None},
+        {"status": "completed", "claims": {}},
+        {"status": "completed", "synthesis": {"claims": None}},
+        {"status": "completed", "synthesis": {"claims": "omitted"}},
+    ),
+)
+def test_non_list_structured_values_do_not_replace_persisted_outputs(
+    payload: dict[str, object],
+) -> None:
+    assert not WhitepaperWorkflowApiMethods._has_structured_research_outputs(payload)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    (
+        {"claims": []},
+        {"synthesis": {"claims": []}},
+        {"claim_relations": [{"source": "a", "target": "b"}]},
+        {"synthesis": {"strategy_templates": [{"template_id": "t1"}]}},
+    ),
+)
+def test_list_structured_values_authorize_replace_or_explicit_clear(
+    payload: dict[str, object],
+) -> None:
+    assert WhitepaperWorkflowApiMethods._has_structured_research_outputs(payload)


### PR DESCRIPTION
## Summary

- require structured whitepaper sections to contain lists before replacing persisted outputs
- preserve prior outputs when retries serialize omitted sections as null, mappings, or scalars
- retain explicit empty-list clears and non-empty-list replacements

## Related Issues

Historical Codex review: #12539 discussion 3585158296.

## Testing

- 43 whitepaper workflow tests passed
- 8 direct regressions passed
- 100% changed-line coverage
- all five Pyright profiles, Ruff, Pylint, file-length, tech-debt, migration graph, and diff checks

## Breaking Changes

Non-list structured values no longer clear persisted outputs. Explicit empty lists still clear them.