### PR TITLE
fix(atlas): verify cancellation before timeout

### DIFF
--- a/packages/scripts/src/atlas/verify.test.ts
+++ b/packages/scripts/src/atlas/verify.test.ts
@@ -30,6 +30,36 @@ describe('atlas verify', () => {
     expect(performanceQueries.every((query) => query.includes('Atlas latency probe proof-'))).toBe(true)
   })
 
+  it('requires canceled queries to drain before the statement-timeout fallback', async () => {
+    let now = 0
+    const lingering = await __private.waitForAtlasQueryDrain({
+      activeQueryCount: async () => 2,
+      now: () => now,
+      sleep: async (milliseconds) => {
+        now += milliseconds
+      },
+    })
+
+    expect(lingering).toBe(2)
+    expect(now).toBe(__private.cancellationDrainDeadlineMs)
+    expect(now).toBeLessThan(750)
+  })
+
+  it('accepts client cancellation that drains blocked queries promptly', async () => {
+    let now = 0
+    const activeCounts = [2, 1, 0]
+    const lingering = await __private.waitForAtlasQueryDrain({
+      activeQueryCount: async () => activeCounts.shift() ?? 0,
+      now: () => now,
+      sleep: async (milliseconds) => {
+        now += milliseconds
+      },
+    })
+
+    expect(lingering).toBe(0)
+    expect(now).toBeLessThan(__private.cancellationDrainDeadlineMs)
+  })
+
   it('requires every absent-path search to return zero results', () => {
     expect(__private.absentPathSearchError('src/deleted.ts', [])).toBeUndefined()
     expect(__private.absentPathSearchError('src/deleted.ts', ['src/live.ts'])).toBe(

--- a/packages/scripts/src/atlas/verify.ts
+++ b/packages/scripts/src/atlas/verify.ts
@@ -72,6 +72,8 @@ type CodeSearchResponse = {
 }
 
 const DEFAULT_GOLD_SET = resolve(defaultRepoRoot, 'docs/atlas/query-gold-set.json')
+const CANCELLATION_DRAIN_DEADLINE_MS = 500
+const CANCELLATION_DRAIN_POLL_MS = 25
 
 const usage = () =>
   `
@@ -312,6 +314,26 @@ const activeAtlasQueryCount = async (db: SQL) => {
   return count(rows[0]?.active)
 }
 
+const waitForAtlasQueryDrain = async (input: {
+  activeQueryCount: () => Promise<number>
+  now?: () => number
+  sleep?: (milliseconds: number) => Promise<void>
+  deadlineMs?: number
+  pollMs?: number
+}) => {
+  const now = input.now ?? Date.now
+  const sleep = input.sleep ?? Bun.sleep
+  const deadlineMs = input.deadlineMs ?? CANCELLATION_DRAIN_DEADLINE_MS
+  const pollMs = input.pollMs ?? CANCELLATION_DRAIN_POLL_MS
+  const deadline = now() + deadlineMs
+  let activeQueries = await input.activeQueryCount()
+  while (activeQueries > 0 && now() < deadline) {
+    await sleep(pollMs)
+    activeQueries = await input.activeQueryCount()
+  }
+  return activeQueries
+}
+
 const runCancellationProbe = async (input: {
   db: SQL
   baseUrl: string
@@ -376,8 +398,9 @@ const runCancellationProbe = async (input: {
 
     for (const controller of controllers) controller.abort(new Error('Atlas live cancellation probe'))
     await Promise.all(requests)
-    await Bun.sleep(1_000)
-    lingeringQueries = await activeAtlasQueryCount(input.db)
+    lingeringQueries = await waitForAtlasQueryDrain({
+      activeQueryCount: () => activeAtlasQueryCount(input.db),
+    })
   } finally {
     releaseLock()
     await lockTask
@@ -386,7 +409,13 @@ const runCancellationProbe = async (input: {
   return { reachedDatabase, observedBlockedQueries, lingeringQueries }
 }
 
-export const __private = { absentPathSearchError, activeAtlasQueryCount, buildColdPerformanceQueries }
+export const __private = {
+  absentPathSearchError,
+  activeAtlasQueryCount,
+  buildColdPerformanceQueries,
+  cancellationDrainDeadlineMs: CANCELLATION_DRAIN_DEADLINE_MS,
+  waitForAtlasQueryDrain,
+}
 
 const main = async () => {
   const options = parseArgs(Bun.argv.slice(2))


### PR DESCRIPTION
## Summary

- require the live Atlas cancellation probe to observe blocked SQL draining within 500 ms after client abort
- keep the drain deadline below Jangar statement timeout so timeout-only cleanup cannot pass
- poll active Atlas relation-lock holders until drain or deadline instead of sleeping 1 second
- add prompt-cancellation and timeout-only regressions

## Related Issues

Historical Codex review: #12483 discussion 3582437946.

## Testing

- Atlas verifier tests: 5 passed
- Oxfmt and Oxlint: clean
- focused strict TypeScript compilation: clean
- type-aware Oxlint: zero errors; two pre-existing warnings on unchanged lines
- diff and file-length checks

## Breaking Changes

The live Atlas verification gate is stricter: canceled queries must disappear before the statement-timeout fallback.