### PR TITLE
fix(torghut): persist reduced fallback decisions

### DIFF
--- a/services/torghut/app/trading/scheduler/pipeline/llm_outcomes.py
+++ b/services/torghut/app/trading/scheduler/pipeline/llm_outcomes.py
@@ -449,26 +449,25 @@ class TradingPipelineReviewOutcomeMixin(TradingPipelineRuntime):
         }
         if request.response_payload_extra:
             response_payload.update(request.response_payload_extra)
-        decision_metadata_update: dict[str, Any] = {}
+        decision_state_update = dict(decision.model_dump(mode="json"))
         if request.response_payload_extra:
             llm_runtime_payload = request.response_payload_extra.get("llm_runtime")
             if isinstance(llm_runtime_payload, Mapping):
-                decision_metadata_update["llm_runtime"] = dict(
+                decision_state_update["llm_runtime"] = dict(
                     cast(Mapping[str, Any], llm_runtime_payload)
                 )
             market_context_payload = request.response_payload_extra.get(
                 "market_context"
             )
             if isinstance(market_context_payload, Mapping):
-                decision_metadata_update["market_context"] = dict(
+                decision_state_update["market_context"] = dict(
                     cast(Mapping[str, Any], market_context_payload)
                 )
-        if decision_metadata_update:
-            self.executor.update_decision_json(
-                context.session,
-                context.decision_row,
-                decision_metadata_update,
-            )
+        self.executor.update_decision_json(
+            context.session,
+            context.decision_row,
+            decision_state_update,
+        )
         response_payload["request_hash"] = hash_payload(request_payload)
         response_payload["response_hash"] = hash_payload(response_payload)
         self._persist_llm_review(

--- a/services/torghut/tests/pipeline/test_trading_pipeline_dspy_gate_c.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_dspy_gate_c.py
@@ -173,6 +173,25 @@ class TestTradingPipelineDspyGateC(TradingPipelineTestCaseBase):
                 self.assertEqual(len(executions), 1)
                 self.assertLess(executions[0].submitted_qty, Decimal("10"))
                 self.assertGreaterEqual(executions[0].submitted_qty, Decimal("1"))
+                decision_payload = decisions[0].decision_json
+                assert isinstance(decision_payload, dict)
+                params = decision_payload.get("params")
+                assert isinstance(params, dict)
+                degrade = params.get("llm_runtime_block_degrade")
+                assert isinstance(degrade, dict)
+                self.assertEqual(
+                    Decimal(str(decision_payload.get("qty"))),
+                    executions[0].submitted_qty,
+                )
+                self.assertEqual(
+                    Decimal(str(degrade.get("degraded_qty"))),
+                    executions[0].submitted_qty,
+                )
+                self.assertGreater(
+                    Decimal(str(degrade.get("original_qty"))),
+                    executions[0].submitted_qty,
+                )
+                self.assertEqual(degrade.get("qty_multiplier"), "0.5")
         finally:
             config.settings.trading_enabled = original["trading_enabled"]
             config.settings.trading_mode = original["trading_mode"]
@@ -552,6 +571,25 @@ class TestTradingPipelineDspyGateC(TradingPipelineTestCaseBase):
                 self.assertEqual(decisions[0].status, "submitted")
                 self.assertEqual(len(executions), 1)
                 self.assertLess(executions[0].submitted_qty, Decimal("1"))
+                decision_payload = decisions[0].decision_json
+                assert isinstance(decision_payload, dict)
+                params = decision_payload.get("params")
+                assert isinstance(params, dict)
+                degrade = params.get("llm_runtime_block_degrade")
+                assert isinstance(degrade, dict)
+                self.assertEqual(
+                    Decimal(str(decision_payload.get("qty"))),
+                    executions[0].submitted_qty,
+                )
+                self.assertEqual(
+                    Decimal(str(degrade.get("degraded_qty"))),
+                    executions[0].submitted_qty,
+                )
+                self.assertGreater(
+                    Decimal(str(degrade.get("original_qty"))),
+                    executions[0].submitted_qty,
+                )
+                self.assertEqual(degrade.get("qty_multiplier"), "0.5")
                 remaining_qty = Decimal(
                     str(execution_adapter.list_positions()[0]["qty"])
                 )


### PR DESCRIPTION
## Summary

- persist the full reduced `StrategyDecision` payload when DSPy runtime fallback uses `pass_through_reduced_size`
- merge runtime and market-context metadata without losing reduced quantity or degradation params
- extend buy and sell regressions to prove persisted decision quantity matches the submitted execution

## Related Issues

Historical Codex finding: PR #3962 comment `2881513668`.

## Testing

- complete DSPy gate C suite passed: 5 tests
- all required Pyright profiles passed: default, alpha, and scripts
- full Ruff format/check, compileall, structural Pylint, changed-line quality/design, file-length, tech-debt ratchet, migration graph, and `git diff --check` passed

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section is not applicable.
- [x] Documentation, release notes, and follow-ups are updated or tracked.