### PR TITLE
fix(torghut): encode crypto position close paths

### DIFF
--- a/services/torghut/app/alpaca_client.py
+++ b/services/torghut/app/alpaca_client.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from enum import Enum
 from typing import Any, Dict, List, Optional, Protocol, cast
-from urllib.parse import urlsplit
+from urllib.parse import quote, urlsplit
 from uuid import UUID
 
 from alpaca.common.exceptions import APIError
@@ -570,8 +570,9 @@ class TorghutAlpacaClient:
         firewall_token: OrderFirewallToken,
     ) -> Dict[str, Any]:
         self._require_firewall_token(firewall_token)
+        position_path_segment = quote(symbol_or_asset_id, safe="")
         order = self._trading.close_position(
-            symbol_or_asset_id,
+            position_path_segment,
             ClosePositionRequest(qty=str(qty)),
         )
         return self._model_to_dict(order)

--- a/services/torghut/tests/test_alpaca_reduction_client.py
+++ b/services/torghut/tests/test_alpaca_reduction_client.py
@@ -88,3 +88,22 @@ class TestAlpacaReductionClient(TestCase):
         self.assertEqual(close_all[0]["status"], 200)
         self.assertEqual(close_all[0]["body"]["id"], "close-1")
         self.assertEqual(trading_client.close_all_cancel_orders, [False])
+
+    def test_close_position_encodes_crypto_symbol_as_one_path_segment(self) -> None:
+        trading_client = _ReductionTradingClient()
+        client = TorghutAlpacaClient(
+            api_key="k",
+            secret_key="s",
+            base_url="https://paper-api.alpaca.markets",
+            trading_client=trading_client,
+            data_client=Mock(),
+        )
+
+        client.close_position(
+            "BTC/USD",
+            qty=Decimal("0.0002"),
+            firewall_token=issue_order_firewall_token(),
+        )
+
+        self.assertEqual(trading_client.closed[0][0], "BTC%2FUSD")
+        self.assertEqual(trading_client.closed[0][1].qty, "0.0002")


### PR DESCRIPTION
## Summary

- Encode Alpaca position identifiers as one URL path segment before close-position mutations.
- Preserve ordinary equity and asset-ID behavior while making crypto symbols such as BTC/USD reach Alpaca as BTC%2FUSD.
- Add a regression test for the exact crypto close request that failed during the production paper lifecycle proof.

## Related Issues

None

## Testing

- `pytest -q tests/test_alpaca_client.py tests/test_alpaca_reduction_client.py tests/test_order_firewall.py tests/test_alpaca_reduction_coordinator.py tests/test_infrastructure_validation_lifecycle.py` (66 passed)
- `ruff check app/alpaca_client.py tests/test_alpaca_reduction_client.py`
- `ruff format --check app/alpaca_client.py tests/test_alpaca_reduction_client.py`
- `pyright --project pyrightconfig.json`
- `pyright --project pyrightconfig.alpha.json`
- `pyright --project pyrightconfig.scripts.json`
- `git diff --check`
- Independent Alpaca paper read after the failed lifecycle: zero positions and zero open orders.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
