### PR TITLE
fix(atlas): allow cold exact search headroom

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -357,8 +357,9 @@ spec:
               value: qwen3-embedding-saigak:8b
             - name: ATLAS_CODE_SEARCH_EMBEDDING_DIMENSION
               value: "1024"
+            # Exact and lexical SQL retain cold-cache headroom while staying below the 1s p95 acceptance gate.
             - name: ATLAS_CODE_SEARCH_STATEMENT_TIMEOUT_MS
-              value: "750"
+              value: "900"
             - name: JANGAR_SOURCE_CI_RUN_ID
               value: "29465487509"
             - name: JANGAR_SOURCE_CI_CONCLUSION


### PR DESCRIPTION
## Summary

- Raise the live Atlas exact/lexical PostgreSQL statement budget from 750ms to the existing supported 900ms ceiling.
- Preserve the separate 20s semantic budget and client-driven PostgreSQL cancellation contract.
- Keep the hard SQL cap below the 1s p95 acceptance gate without changing the schema, model, corpus, or image.

## Related Issues

None

## Testing

- `git diff --check`
- `kustomize build --enable-helm argocd/applications/jangar`
- `bun run atlas:verify --repository proompteng/lab --ref main --json` reproduced HTTP 504 at the 750ms exact/lexical cap; PostgreSQL logged the indexed exact-candidate statement as the timed-out query.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
