### PR TITLE
fix(torghut): close crypto positions by asset id

### DIFF
--- a/services/torghut/app/alpaca_client.py
+++ b/services/torghut/app/alpaca_client.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from enum import Enum
 from typing import Any, Dict, List, Optional, Protocol, cast
-from urllib.parse import quote, urlsplit
+from urllib.parse import urlsplit
 from uuid import UUID
 
 from alpaca.common.exceptions import APIError
@@ -570,9 +570,16 @@ class TorghutAlpacaClient:
         firewall_token: OrderFirewallToken,
     ) -> Dict[str, Any]:
         self._require_firewall_token(firewall_token)
-        position_path_segment = quote(symbol_or_asset_id, safe="")
+        position_target = symbol_or_asset_id
+        if "/" in position_target:
+            asset = self.get_asset(position_target)
+            asset_id = str((asset or {}).get("id") or "").strip()
+            try:
+                position_target = str(UUID(asset_id))
+            except ValueError as exc:
+                raise ValueError("alpaca_crypto_close_asset_id_invalid") from exc
         order = self._trading.close_position(
-            position_path_segment,
+            position_target,
             ClosePositionRequest(qty=str(qty)),
         )
         return self._model_to_dict(order)

--- a/services/torghut/tests/test_alpaca_reduction_client.py
+++ b/services/torghut/tests/test_alpaca_reduction_client.py
@@ -24,11 +24,12 @@ class _ReductionTradingClient:
         self.closed: list[tuple[str, ClosePositionRequest]] = []
         self.close_all_cancel_orders: list[bool] = []
         self.asset_lookups: list[str] = []
+        self.asset_id = "276e2673-764b-4ab6-a611-caf665ca6340"
 
     def get_asset(self, symbol_or_asset_id: str) -> _Model:
         self.asset_lookups.append(symbol_or_asset_id)
         return _Model(
-            id="276e2673-764b-4ab6-a611-caf665ca6340",
+            id=self.asset_id,
             symbol=symbol_or_asset_id,
         )
 
@@ -119,3 +120,27 @@ class TestAlpacaReductionClient(TestCase):
             "276e2673-764b-4ab6-a611-caf665ca6340",
         )
         self.assertEqual(trading_client.closed[0][1].qty, "0.0002")
+
+    def test_close_position_rejects_crypto_asset_without_uuid(self) -> None:
+        trading_client = _ReductionTradingClient()
+        trading_client.asset_id = ""
+        client = TorghutAlpacaClient(
+            api_key="k",
+            secret_key="s",
+            base_url="https://paper-api.alpaca.markets",
+            trading_client=trading_client,
+            data_client=Mock(),
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "alpaca_crypto_close_asset_id_invalid",
+        ):
+            client.close_position(
+                "BTC/USD",
+                qty=Decimal("0.0002"),
+                firewall_token=issue_order_firewall_token(),
+            )
+
+        self.assertEqual(trading_client.asset_lookups, ["BTC/USD"])
+        self.assertEqual(trading_client.closed, [])

--- a/services/torghut/tests/test_alpaca_reduction_client.py
+++ b/services/torghut/tests/test_alpaca_reduction_client.py
@@ -23,6 +23,14 @@ class _ReductionTradingClient:
         self.replaced: list[tuple[str, ReplaceOrderRequest]] = []
         self.closed: list[tuple[str, ClosePositionRequest]] = []
         self.close_all_cancel_orders: list[bool] = []
+        self.asset_lookups: list[str] = []
+
+    def get_asset(self, symbol_or_asset_id: str) -> _Model:
+        self.asset_lookups.append(symbol_or_asset_id)
+        return _Model(
+            id="276e2673-764b-4ab6-a611-caf665ca6340",
+            symbol=symbol_or_asset_id,
+        )
 
     def replace_order_by_id(
         self,
@@ -89,7 +97,7 @@ class TestAlpacaReductionClient(TestCase):
         self.assertEqual(close_all[0]["body"]["id"], "close-1")
         self.assertEqual(trading_client.close_all_cancel_orders, [False])
 
-    def test_close_position_encodes_crypto_symbol_as_one_path_segment(self) -> None:
+    def test_close_position_resolves_crypto_symbol_to_asset_id(self) -> None:
         trading_client = _ReductionTradingClient()
         client = TorghutAlpacaClient(
             api_key="k",
@@ -105,5 +113,9 @@ class TestAlpacaReductionClient(TestCase):
             firewall_token=issue_order_firewall_token(),
         )
 
-        self.assertEqual(trading_client.closed[0][0], "BTC%2FUSD")
+        self.assertEqual(trading_client.asset_lookups, ["BTC/USD"])
+        self.assertEqual(
+            trading_client.closed[0][0],
+            "276e2673-764b-4ab6-a611-caf665ca6340",
+        )
         self.assertEqual(trading_client.closed[0][1].qty, "0.0002")


### PR DESCRIPTION
## Summary

- resolve slash-delimited crypto symbols through Alpaca's asset read before closing a position
- submit the risk-reducing DELETE with Alpaca's UUID instead of a percent-encoded symbol that the paper broker rejects with HTTP 404
- replace the failed encoding regression with exact symbol-to-asset-ID and invalid-ID fail-closed coverage

## Related Issues

None

## Testing

- /Users/gregkonush/.codex/worktrees/4e48/lab/services/torghut/.venv/bin/pytest -q tests/test_alpaca_client.py tests/test_alpaca_reduction_client.py tests/test_order_firewall.py tests/test_alpaca_reduction_coordinator.py tests/test_infrastructure_validation_lifecycle.py (67 passed)
- /Users/gregkonush/.codex/worktrees/4e48/lab/services/torghut/.venv/bin/ruff check app/alpaca_client.py tests/test_alpaca_reduction_client.py
- /Users/gregkonush/.codex/worktrees/4e48/lab/services/torghut/.venv/bin/ruff format --check app/alpaca_client.py tests/test_alpaca_reduction_client.py
- .venv/bin/pyright --project pyrightconfig.json
- .venv/bin/pyright --project pyrightconfig.alpha.json
- .venv/bin/pyright --project pyrightconfig.scripts.json
- live Alpaca paper evidence: BTC/USD resolves to asset ID 276e2673-764b-4ab6-a611-caf665ca6340; the failed percent-encoded close returned HTTP 404; cleanup independently proved zero positions and zero open orders

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed because this is a broker-client fix.
- [x] Breaking Changes is filled in.
- [x] Documentation and release notes are not required for this narrow corrective change; production lifecycle proof follows image promotion.