### PR TITLE
fix(torghut): scope expert router policy checks

### DIFF
--- a/services/torghut/app/trading/autonomy/policy_check/profitability_manifest.py
+++ b/services/torghut/app/trading/autonomy/policy_check/profitability_manifest.py
@@ -27,6 +27,7 @@ from .requirements import (
     load_json_if_exists as _load_json_if_exists,
     normalize_artifact_path as _normalize_artifact_path,
     regime_slice_count as _regime_slice_count,
+    requires_expert_router_registry as _requires_expert_router_registry,
     sha256_json as _sha256_json,
     sha256_path as _sha256_path,
 )
@@ -170,6 +171,7 @@ def _validate_stages(
     manifest_path: Path,
     policy_payload: dict[str, Any],
     artifact_root: Path,
+    promotion_target: str,
 ) -> dict[str, Any] | None:
     """Validate stages presence, order, status, checks, and artifacts. Returns stages dict."""
     stages_raw = manifest_payload.get("stages")
@@ -182,7 +184,13 @@ def _validate_stages(
 
     _validate_stage_names(ctx, stages, manifest_path)
     _validate_stage_payloads(ctx, stages, manifest_path)
-    _validate_stage_checks(ctx, stages, manifest_path, policy_payload)
+    _validate_stage_checks(
+        ctx,
+        stages,
+        manifest_path,
+        policy_payload,
+        promotion_target=promotion_target,
+    )
     _validate_stage_artifacts(ctx, stages, manifest_path, policy_payload, artifact_root)
     return stages
 
@@ -248,6 +256,8 @@ def _validate_stage_checks(
     stages: dict[str, Any],
     manifest_path: Path,
     policy_payload: dict[str, Any],
+    *,
+    promotion_target: str,
 ) -> None:
     for stage_name in _PROFITABILITY_STAGE_ORDER:
         stage_payload = _as_dict(stages.get(stage_name))
@@ -255,8 +265,9 @@ def _validate_stage_checks(
             continue
 
         required_checks = list(_PROFITABILITY_STAGE_REQUIRED_CHECKS.get(stage_name, ()))
-        if stage_name == "execution" and not bool(
-            policy_payload.get("promotion_require_expert_router_registry", False)
+        if stage_name == "execution" and not _requires_expert_router_registry(
+            policy_payload=policy_payload,
+            promotion_target=promotion_target,
         ):
             required_checks = [
                 check
@@ -649,6 +660,7 @@ def append_profitability_stage_manifest_reasons(
     reason_details: list[dict[str, object]],
     policy_payload: dict[str, Any],
     artifact_root: Path,
+    promotion_target: str = "paper",
 ) -> None:
     manifest_relpath = str(
         policy_payload.get(
@@ -672,7 +684,12 @@ def append_profitability_stage_manifest_reasons(
     ctx = _ValidationContext(reasons=reasons, reason_details=reason_details)
     _validate_manifest_top_level(ctx, manifest_payload, manifest_path)
     stages = _validate_stages(
-        ctx, manifest_payload, manifest_path, policy_payload, artifact_root
+        ctx,
+        manifest_payload,
+        manifest_path,
+        policy_payload,
+        artifact_root,
+        promotion_target,
     )
 
     if bool(

--- a/services/torghut/app/trading/autonomy/policy_checks.py
+++ b/services/torghut/app/trading/autonomy/policy_checks.py
@@ -246,6 +246,7 @@ def evaluate_promotion_prerequisites(
             reason_details=reason_details,
             policy_payload=policy_payload,
             artifact_root=artifact_root,
+            promotion_target=promotion_target,
         )
     if bool(
         policy_payload.get("promotion_require_portfolio_optimizer_evidence", False)

--- a/services/torghut/scripts/run_governance_policy_dry_run.py
+++ b/services/torghut/scripts/run_governance_policy_dry_run.py
@@ -89,6 +89,15 @@ def _stable_hash(payload: object) -> str:
     return hashlib.sha256(payload_json.encode("utf-8")).hexdigest()
 
 
+def _int_field_or_default(
+    payload: dict[str, Any],
+    key: str,
+    default: int,
+) -> int:
+    value = payload.get(key)
+    return default if value is None else int(value)
+
+
 def main() -> int:
     from app.trading.autonomy.policy_checks import (
         evaluate_promotion_prerequisites,
@@ -390,7 +399,11 @@ def main() -> int:
             "router_version": str(
                 expert_router_payload.get("router_version") or "router-v1"
             ),
-            "route_count": int(expert_router_payload.get("route_count") or 10),
+            "route_count": _int_field_or_default(
+                expert_router_payload,
+                "route_count",
+                10,
+            ),
             "fallback_count": int(expert_router_payload.get("fallback_count") or 0),
             "fallback_rate": str(expert_router_payload.get("fallback_rate") or "0"),
             "max_expert_weight": str(

--- a/services/torghut/tests/policy_checks/test_policy_checks_expert_router_scope.py
+++ b/services/torghut/tests/policy_checks/test_policy_checks_expert_router_scope.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.trading.autonomy.policy_check.common import (
+    PROFITABILITY_STAGE_REQUIRED_CHECKS,
+)
+from app.trading.autonomy.policy_check.profitability_manifest import (
+    _ValidationContext,
+    _validate_stage_checks,
+)
+
+
+def _execution_stage_without_expert_router() -> dict[str, object]:
+    checks = [
+        {"check": check, "status": "pass"}
+        for check in PROFITABILITY_STAGE_REQUIRED_CHECKS["execution"]
+        if check != "expert_router_registry_present"
+    ]
+    return {"execution": {"checks": checks}}
+
+
+def test_profitability_manifest_expert_router_check_respects_target_scope() -> None:
+    policy = {
+        "promotion_require_expert_router_registry": True,
+        "promotion_expert_router_required_targets": ["live"],
+    }
+    stages = _execution_stage_without_expert_router()
+    manifest_path = Path("profitability-stage-manifest-v1.json")
+
+    paper_context = _ValidationContext(reasons=[], reason_details=[])
+    _validate_stage_checks(
+        paper_context,
+        stages,
+        manifest_path,
+        policy,
+        promotion_target="paper",
+    )
+    assert (
+        "profitability_stage_manifest_required_check_missing"
+        not in paper_context.reasons
+    )
+
+    live_context = _ValidationContext(reasons=[], reason_details=[])
+    _validate_stage_checks(
+        live_context,
+        stages,
+        manifest_path,
+        policy,
+        promotion_target="live",
+    )
+    assert "profitability_stage_manifest_required_check_missing" in live_context.reasons
+    assert any(
+        detail.get("check") == "expert_router_registry_present"
+        for detail in live_context.reason_details
+    )

--- a/services/torghut/tests/test_governance_policy_dry_run.py
+++ b/services/torghut/tests/test_governance_policy_dry_run.py
@@ -7,6 +7,8 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest import TestCase
 
+from scripts import run_governance_policy_dry_run as script
+
 
 def _default_gate_report(now: datetime) -> dict[str, object]:
     return {
@@ -118,6 +120,13 @@ def _default_gate_report(now: datetime) -> dict[str, object]:
 
 
 class TestGovernancePolicyDryRun(TestCase):
+    def test_int_field_or_default_preserves_explicit_zero(self) -> None:
+        self.assertEqual(script._int_field_or_default({}, "route_count", 10), 10)
+        self.assertEqual(
+            script._int_field_or_default({"route_count": 0}, "route_count", 10),
+            0,
+        )
+
     def test_dry_run_blocks_progression_when_artifact_missing(self) -> None:
         output = self._run_harness("--simulate-missing-artifact")
         self.assertFalse(output["promotion_progression_allowed"])
@@ -167,7 +176,18 @@ class TestGovernancePolicyDryRun(TestCase):
         output = self._run_harness()
         self.assertTrue(output["promotion_progression_allowed"])
 
-    def _run_harness(self, *extra_args: str) -> dict[str, object]:
+    def test_dry_run_preserves_zero_expert_router_route_count(self) -> None:
+        output = self._run_harness(expert_router_route_count=0)
+
+        self.assertFalse(output["promotion_progression_allowed"])
+        reasons = output["promotion_prerequisites"]["reasons"]
+        self.assertIn("expert_router_registry_route_count_below_minimum", reasons)
+
+    def _run_harness(
+        self,
+        *extra_args: str,
+        expert_router_route_count: int | None = None,
+    ) -> dict[str, object]:
         now = datetime.now(timezone.utc)
         repo_root = Path(__file__).resolve().parents[3]
         service_root = repo_root / "services" / "torghut"
@@ -175,6 +195,12 @@ class TestGovernancePolicyDryRun(TestCase):
         source_policy = service_root / "config" / "autonomy-gates-v3.json"
 
         gate_report = _default_gate_report(now)
+        if expert_router_route_count is not None:
+            promotion_evidence = gate_report.get("promotion_evidence")
+            if isinstance(promotion_evidence, dict):
+                expert_router = promotion_evidence.get("expert_router_registry")
+                if isinstance(expert_router, dict):
+                    expert_router["route_count"] = expert_router_route_count
         if "--simulate-stress-metrics-stale" in extra_args:
             stress_metrics = gate_report["promotion_evidence"]["stress_metrics"]
             if isinstance(stress_metrics, dict):


### PR DESCRIPTION
## Summary

- make profitability-stage expert-router checks use the same promotion-target predicate as artifact requirements
- preserve explicit `route_count=0` in the governance dry-run artifact so minimum-route enforcement can fail closed
- add direct target-scope and zero-route dry-run regressions

## Related Issues

Historical Codex findings: PR #3939 comments `2878106459` and `2878106466`.

## Testing

- 30 profitability-manifest and governance dry-run tests passed
- all required Pyright profiles passed: default, alpha, and scripts
- full Ruff format/check, compileall, structural Pylint, changed-line quality/design, file-length, tech-debt ratchet, migration graph, and `git diff --check` passed

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section is not applicable.
- [x] Documentation, release notes, and follow-ups are updated or tracked.