### PR TITLE
ci(torghut): coalesce image builds without starvation

### DIFF
--- a/.github/workflows/torghut-build-push.yaml
+++ b/.github/workflows/torghut-build-push.yaml
@@ -18,7 +18,9 @@ on:
 
 concurrency:
   group: torghut-build-${{ github.ref }}
-  cancel-in-progress: true
+  # Finish the active registry publish; GitHub's single pending slot still
+  # coalesces later pushes to the newest source revision.
+  cancel-in-progress: false
 
 jobs:
   nix-image:

--- a/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
@@ -112,6 +112,12 @@ describe('torghut build-push workflow', () => {
     expect(workflow).not.toContain('uses: actions/cache@v4')
   })
 
+  it('finishes the active publish while coalescing later pushes', () => {
+    expect(workflow).toContain('group: torghut-build-${{ github.ref }}')
+    expect(workflow).toContain('cancel-in-progress: false')
+    expect(workflow).not.toContain('cancel-in-progress: true')
+  })
+
   it('routes the core Torghut image through the shared Nix OCI workflow', () => {
     expect(workflow).toContain('uses: ./.github/workflows/nix-oci-build-common.yml')
     expect(workflow).toContain('image_name: torghut')


### PR DESCRIPTION
## Summary

- let an active Torghut multi-arch image publish finish instead of canceling its registry uploads on every main push
- retain GitHub's default single pending concurrency slot so later pushes coalesce to only the newest source revision
- lock the non-starving concurrency contract with a focused workflow regression test

## Related Issues

None

## Testing

- bun test packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts (26 passed)
- /Users/gregkonush/go/bin/actionlint -shellcheck '' -pyflakes '' .github/workflows/torghut-build-push.yaml
- /Users/gregkonush/.codex/worktrees/4e48/lab/node_modules/.bin/oxfmt --check packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
- observed production evidence: five Torghut source builds were canceled between 07:39 and 08:11 UTC while OCI publication uses a single shaped registry writer; one canceled run discarded more than five minutes of active upload work
- official GitHub concurrency contract: cancel-in-progress false preserves the running workflow while the default single pending slot replaces older pending runs with the newest

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed because this is a workflow scheduling change.
- [x] Breaking Changes is filled in.
- [x] The operational invariant and its regression test document the follow-up behavior.