### PR TITLE
fix(agents): fail log streams on kube errors

### DIFF
--- a/services/agents/src/server/agentctl-grpc-logging.test.ts
+++ b/services/agents/src/server/agentctl-grpc-logging.test.ts
@@ -1,6 +1,7 @@
+import { status as GrpcStatus, type ServerWritableStream } from '@grpc/grpc-js'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { startAgentctlGrpcServer } from './agentctl-grpc'
+import { startAgentctlGrpcServer, streamAgentRunLogs } from './agentctl-grpc'
 
 const ORIGINAL_ENV = { ...process.env }
 
@@ -32,5 +33,29 @@ describe('agentctl gRPC runtime logging', () => {
     expect(startAgentctlGrpcServer()).toBeNull()
 
     expect(info).toHaveBeenCalledWith('[agents] agentctl grpc disabled for control plane')
+  })
+
+  it('returns INTERNAL when AgentRun lookup fails before log streaming starts', async () => {
+    const destroy = vi.fn()
+    const call = {
+      request: { namespace: 'agents', name: 'run-a', follow: false },
+      metadata: { get: () => [] },
+      destroy,
+    } as unknown as ServerWritableStream<{ namespace?: string; name?: string; follow?: boolean }, unknown>
+    const kube = {
+      get: vi.fn(async () => {
+        throw new Error('kubernetes API unavailable')
+      }),
+    }
+
+    await streamAgentRunLogs(call, kube as never)
+
+    expect(destroy).toHaveBeenCalledTimes(1)
+    expect(destroy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'kubernetes API unavailable',
+        code: GrpcStatus.INTERNAL,
+      }),
+    )
   })
 })

--- a/services/agents/src/server/agentctl-grpc.ts
+++ b/services/agents/src/server/agentctl-grpc.ts
@@ -410,6 +410,82 @@ const resolveComponent = () => {
   return 'control plane'
 }
 
+export const streamAgentRunLogs = async (call: ServerWritableStream<LogsRequest, unknown>, kube: KubernetesClient) => {
+  const authError = requireAuth(call)
+  if (authError) {
+    call.destroy(Object.assign(new Error(authError.message), { code: authError.code }))
+    return
+  }
+
+  try {
+    const namespace = normalizeNamespace(call.request?.namespace)
+    const name = call.request?.name ?? ''
+    const resource = await kube.get(RESOURCE_MAP.AgentRun, name, namespace)
+    if (!resource) {
+      call.destroy(Object.assign(new Error('AgentRun not found'), { code: GrpcStatus.NOT_FOUND }))
+      return
+    }
+    const { runtimeType, runtimeName } = resolveAgentRunRuntime(resource)
+    const pod = await selectAgentRunPod(kube, name, namespace, runtimeType, runtimeName)
+    if (!pod) {
+      call.end()
+      return
+    }
+    if (!call.request?.follow) {
+      const logs = await kube.logs({
+        pod: pod.podName,
+        namespace,
+        container: pod.containerName,
+      })
+      if (logs.length > 0) {
+        call.write({ stream: 'stdout', message: logs })
+      }
+      call.end()
+      return
+    }
+
+    const stream = new PassThrough()
+    stream.on('data', (chunk) => {
+      call.write({
+        stream: 'stdout',
+        message: Buffer.isBuffer(chunk) ? chunk.toString('utf8') : String(chunk),
+      })
+    })
+    stream.on('end', () => {
+      call.end()
+    })
+    stream.on('error', (error) => {
+      call.destroy(Object.assign(new Error(error.message), { code: GrpcStatus.INTERNAL }))
+    })
+    void getGrpcLogHelper()
+      .log(namespace, pod.podName, pod.containerName ?? '', stream, {
+        follow: true,
+        pretty: false,
+        timestamps: false,
+      })
+      .catch((error) => {
+        call.destroy(
+          Object.assign(new Error(error instanceof Error ? error.message : String(error)), {
+            code: GrpcStatus.INTERNAL,
+          }),
+        )
+      })
+
+    call.on('cancelled', () => {
+      stream.destroy()
+    })
+    call.on('close', () => {
+      stream.destroy()
+    })
+  } catch (error) {
+    call.destroy(
+      Object.assign(new Error(error instanceof Error ? error.message : String(error)), {
+        code: GrpcStatus.INTERNAL,
+      }),
+    )
+  }
+}
+
 export const startAgentctlGrpcServer = (): AgentctlServer | null => {
   const component = resolveComponent()
   const config = resolveAgentctlGrpcConfig()
@@ -986,72 +1062,7 @@ export const startAgentctlGrpcServer = (): AgentctlServer | null => {
       }
     },
 
-    StreamAgentRunLogs: async (call: ServerWritableStream<LogsRequest, unknown>) => {
-      const authError = requireAuth(call)
-      if (authError) {
-        call.destroy(Object.assign(new Error(authError.message), { code: authError.code }))
-        return
-      }
-      const namespace = normalizeNamespace(call.request?.namespace)
-      const name = call.request?.name ?? ''
-      const resource = await kube.get(RESOURCE_MAP.AgentRun, name, namespace)
-      if (!resource) {
-        call.destroy(Object.assign(new Error('AgentRun not found'), { code: GrpcStatus.NOT_FOUND }))
-        return
-      }
-      const { runtimeType, runtimeName } = resolveAgentRunRuntime(resource)
-      const pod = await selectAgentRunPod(kube, name, namespace, runtimeType, runtimeName)
-      if (!pod) {
-        call.end()
-        return
-      }
-      if (!call.request?.follow) {
-        const logs = await kube.logs({
-          pod: pod.podName,
-          namespace,
-          container: pod.containerName,
-        })
-        if (logs.length > 0) {
-          call.write({ stream: 'stdout', message: logs })
-        }
-        call.end()
-        return
-      }
-
-      const stream = new PassThrough()
-      stream.on('data', (chunk) => {
-        call.write({
-          stream: 'stdout',
-          message: Buffer.isBuffer(chunk) ? chunk.toString('utf8') : String(chunk),
-        })
-      })
-      stream.on('end', () => {
-        call.end()
-      })
-      stream.on('error', (error) => {
-        call.destroy(Object.assign(new Error(error.message), { code: GrpcStatus.INTERNAL }))
-      })
-      void getGrpcLogHelper()
-        .log(namespace, pod.podName, pod.containerName ?? '', stream, {
-          follow: true,
-          pretty: false,
-          timestamps: false,
-        })
-        .catch((error) => {
-          call.destroy(
-            Object.assign(new Error(error instanceof Error ? error.message : String(error)), {
-              code: GrpcStatus.INTERNAL,
-            }),
-          )
-        })
-
-      call.on('cancelled', () => {
-        stream.destroy()
-      })
-      call.on('close', () => {
-        stream.destroy()
-      })
-    },
+    StreamAgentRunLogs: (call: ServerWritableStream<LogsRequest, unknown>) => streamAgentRunLogs(call, kube),
 
     StreamAgentRunStatus: async (call: ServerWritableStream<StatusStreamRequest, unknown>) => {
       const authError = requireAuth(call)


### PR DESCRIPTION
## Summary

- route AgentRun log streaming through a testable handler
- convert Kubernetes lookup, pod-selection, and non-follow log failures into deterministic gRPC `INTERNAL` errors
- add a regression for an AgentRun lookup failure before streaming starts

## Related Issues

Historical Codex finding: PR #2524 comment `2706345554`.

## Testing

- focused Agents Vitest suite: 3 passed
- targeted Oxfmt and Oxlint: zero warnings or errors
- `git diff --check` passed on the rebased head

## Breaking Changes

None.

## Checklist

- [x] Testing section documents exact validation.
- [x] Screenshots are not applicable.
- [x] Documentation and release notes are not required.
