### PR TITLE
fix(agents): validate empty workflow step names

### DIFF
--- a/services/agents/src/server/agents-controller/workflow.test.ts
+++ b/services/agents/src/server/agents-controller/workflow.test.ts
@@ -55,7 +55,24 @@ describe('agents controller workflow module', () => {
         timeoutSeconds: 11,
         loop: null,
       },
+      {
+        name: '',
+        implementationSpecRefName: 'missing-name',
+        implementationInline: null,
+        parameters: {},
+        workload: null,
+        retries: 0,
+        retryBackoffSeconds: 0,
+        timeoutSeconds: 0,
+        loop: null,
+      },
     ])
+
+    expect(validateWorkflowSteps(parsed)).toEqual({
+      ok: false,
+      reason: 'WorkflowStepMissingName',
+      message: 'workflow steps must include a name',
+    })
   })
 
   it('validates run parameters bounds and types', () => {

--- a/services/agents/src/server/agents-controller/workflow.ts
+++ b/services/agents/src/server/agents-controller/workflow.ts
@@ -189,33 +189,29 @@ const parseWorkflowStepLoop = (step: Record<string, unknown>): WorkflowLoopSpec 
 export const parseWorkflowSteps = (agentRun: Record<string, unknown>): WorkflowStepSpec[] => {
   const workflow = asRecord(readNested(agentRun, ['spec', 'workflow'])) ?? {}
   const steps = Array.isArray(workflow.steps) ? (workflow.steps as Record<string, unknown>[]) : []
-  return steps
-    .map((step) => {
-      const name = asString(step.name) ?? ''
-      const parameters = asRecord(step.parameters) ?? {}
-      const parsedParameters: Record<string, string> = {}
-      for (const [key, value] of Object.entries(parameters)) {
-        if (typeof value !== 'string') continue
-        parsedParameters[key] = value
-      }
-      const retries = parseOptionalNumber(step.retries)
-      const retryBackoffSeconds = parseOptionalNumber(step.retryBackoffSeconds)
-      const timeoutSeconds = parseOptionalNumber(step.timeoutSeconds)
-      return {
-        name,
-        implementationSpecRefName: asString(readNested(step, ['implementationSpecRef', 'name'])) ?? null,
-        implementationInline: asRecord(readNested(step, ['implementation', 'inline'])) ?? null,
-        parameters: parsedParameters,
-        workload: asRecord(step.workload) ?? null,
-        retries: Number.isFinite(retries) ? Math.max(0, Math.trunc(retries ?? 0)) : 0,
-        retryBackoffSeconds: Number.isFinite(retryBackoffSeconds)
-          ? Math.max(0, Math.trunc(retryBackoffSeconds ?? 0))
-          : 0,
-        timeoutSeconds: Number.isFinite(timeoutSeconds) ? Math.max(0, Math.trunc(timeoutSeconds ?? 0)) : 0,
-        loop: parseWorkflowStepLoop(step),
-      }
-    })
-    .filter((step) => step.name.length > 0)
+  return steps.map((step) => {
+    const name = asString(step.name) ?? ''
+    const parameters = asRecord(step.parameters) ?? {}
+    const parsedParameters: Record<string, string> = {}
+    for (const [key, value] of Object.entries(parameters)) {
+      if (typeof value !== 'string') continue
+      parsedParameters[key] = value
+    }
+    const retries = parseOptionalNumber(step.retries)
+    const retryBackoffSeconds = parseOptionalNumber(step.retryBackoffSeconds)
+    const timeoutSeconds = parseOptionalNumber(step.timeoutSeconds)
+    return {
+      name,
+      implementationSpecRefName: asString(readNested(step, ['implementationSpecRef', 'name'])) ?? null,
+      implementationInline: asRecord(readNested(step, ['implementation', 'inline'])) ?? null,
+      parameters: parsedParameters,
+      workload: asRecord(step.workload) ?? null,
+      retries: Number.isFinite(retries) ? Math.max(0, Math.trunc(retries ?? 0)) : 0,
+      retryBackoffSeconds: Number.isFinite(retryBackoffSeconds) ? Math.max(0, Math.trunc(retryBackoffSeconds ?? 0)) : 0,
+      timeoutSeconds: Number.isFinite(timeoutSeconds) ? Math.max(0, Math.trunc(timeoutSeconds ?? 0)) : 0,
+      loop: parseWorkflowStepLoop(step),
+    }
+  })
 }
 
 const resolveEffectiveWorkflowVolumes = (step: WorkflowStepSpec, baseWorkload: Record<string, unknown> | null) => {


### PR DESCRIPTION
## Summary

- retain empty-name workflow steps during parsing so validation can reject them
- preserve the existing `WorkflowStepMissingName` fail-closed result instead of silently dropping work
- extend the workflow parser regression to cover a valid step alongside an empty-name step

## Related Issues

Historical Codex finding: PR #2534 comment `2706612463`.

## Testing

- focused Agents Vitest suite: 9 passed
- targeted Oxfmt and Oxlint: zero warnings or errors
- `git diff --check` passed on the rebased head

## Breaking Changes

None.

## Checklist

- [x] Testing section documents exact validation.
- [x] Screenshots are not applicable.
- [x] Documentation and release notes are not required.
