### PR TITLE
fix(agents): expire workspaces before pvc apply

### DIFF
--- a/services/agents/src/server/supporting-primitives-controller.test.ts
+++ b/services/agents/src/server/supporting-primitives-controller.test.ts
@@ -7,6 +7,7 @@ import { __test__ as scheduleRunnerTest } from './supporting-schedule-runner'
 const originalSwarmPrimitiveEnabled = process.env.AGENTS_SWARM_PRIMITIVE_ENABLED
 
 afterEach(() => {
+  vi.useRealTimers()
   if (originalSwarmPrimitiveEnabled === undefined) {
     delete process.env.AGENTS_SWARM_PRIMITIVE_ENABLED
   } else {
@@ -178,6 +179,74 @@ describe('supporting primitives controller', () => {
     expect(statuses.at(-1)).toMatchObject({
       kind: 'Workspace',
       status: { phase: 'Pending' },
+    })
+  })
+
+  it('expires Workspace resources before applying a PVC', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-16T08:00:00.000Z'))
+    const { kube, applied, deleted, statuses } = createKubeMock({
+      [`${RESOURCE_MAP.PersistentVolumeClaim}:agents:work-expired`]: {
+        spec: { volumeName: 'pvc-volume-a' },
+      },
+    })
+
+    await __test__.reconcileWorkspace(
+      kube,
+      {
+        apiVersion: 'workspaces.proompteng.ai/v1alpha1',
+        kind: 'Workspace',
+        metadata: {
+          name: 'work-expired',
+          namespace: 'agents',
+          generation: 2,
+          creationTimestamp: '2026-07-16T07:00:00.000Z',
+        },
+        spec: { size: '20Gi', ttlSeconds: 60 },
+      },
+      'agents',
+    )
+
+    expect(applied).toHaveLength(0)
+    expect(deleted).toEqual([
+      { resource: RESOURCE_MAP.PersistentVolumeClaim, name: 'work-expired', namespace: 'agents' },
+    ])
+    expect(statuses.at(-1)).toMatchObject({
+      kind: 'Workspace',
+      status: {
+        phase: 'Expired',
+        volumeName: 'pvc-volume-a',
+        conditions: [expect.objectContaining({ reason: 'Expired', status: 'False' })],
+      },
+    })
+  })
+
+  it('marks an expired Workspace without a PVC as expired without deleting', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-16T08:00:00.000Z'))
+    const { kube, applied, deleted, statuses } = createKubeMock()
+
+    await __test__.reconcileWorkspace(
+      kube,
+      {
+        apiVersion: 'workspaces.proompteng.ai/v1alpha1',
+        kind: 'Workspace',
+        metadata: {
+          name: 'work-never-provisioned',
+          namespace: 'agents',
+          generation: 1,
+          creationTimestamp: '2026-07-16T07:00:00.000Z',
+        },
+        spec: { size: '20Gi', ttlSeconds: 60 },
+      },
+      'agents',
+    )
+
+    expect(applied).toHaveLength(0)
+    expect(deleted).toHaveLength(0)
+    expect(statuses.at(-1)).toMatchObject({
+      kind: 'Workspace',
+      status: { phase: 'Expired', volumeName: undefined },
     })
   })
 

--- a/services/agents/src/server/supporting-primitives-controller.ts
+++ b/services/agents/src/server/supporting-primitives-controller.ts
@@ -809,6 +809,32 @@ const reconcileWorkspace = async (
   const workspaceName = asString(readNested(workspace, ['metadata', 'name'])) ?? 'workspace'
   const ownerReferences = buildOwnerRefs(workspace)
   const labels = { 'workspaces.proompteng.ai/workspace': workspaceName }
+
+  if (ttlSeconds && ttlSeconds > 0) {
+    const createdAt = asString(readNested(workspace, ['metadata', 'creationTimestamp']))
+    if (createdAt) {
+      const expiresAt = new Date(createdAt).getTime() + ttlSeconds * 1000
+      if (Number.isFinite(expiresAt) && Date.now() > expiresAt) {
+        const pvcResource = await kube.get(RESOURCE_MAP.PersistentVolumeClaim, workspaceName, namespace)
+        const pvcVolumeName = asString(readNested(pvcResource ?? {}, ['spec', 'volumeName'])) ?? undefined
+        if (pvcResource) {
+          await kube.delete(RESOURCE_MAP.PersistentVolumeClaim, workspaceName, namespace)
+        }
+        const conditions = upsertCondition(
+          normalizeConditions(status.conditions),
+          buildReadyCondition(false, 'Expired', 'workspace TTL expired'),
+        )
+        await setStatus(kube, workspace, {
+          observedGeneration: asRecord(workspace.metadata)?.generation ?? 0,
+          phase: 'Expired',
+          volumeName: pvcVolumeName,
+          conditions,
+        })
+        return
+      }
+    }
+  }
+
   await applyResourceIfChanged(kube, {
     apiVersion: 'v1',
     kind: 'PersistentVolumeClaim',
@@ -828,27 +854,6 @@ const reconcileWorkspace = async (
   const pvcResource = await kube.get(RESOURCE_MAP.PersistentVolumeClaim, workspaceName, namespace)
   const pvcPhase = asString(readNested(pvcResource ?? {}, ['status', 'phase'])) ?? 'Pending'
   const pvcVolumeName = asString(readNested(pvcResource ?? {}, ['spec', 'volumeName'])) ?? undefined
-
-  if (ttlSeconds && ttlSeconds > 0) {
-    const createdAt = asString(readNested(workspace, ['metadata', 'creationTimestamp']))
-    if (createdAt) {
-      const expiresAt = new Date(createdAt).getTime() + ttlSeconds * 1000
-      if (Number.isFinite(expiresAt) && Date.now() > expiresAt) {
-        await kube.delete(RESOURCE_MAP.PersistentVolumeClaim, workspaceName, namespace)
-        const conditions = upsertCondition(
-          normalizeConditions(status.conditions),
-          buildReadyCondition(false, 'Expired', 'workspace TTL expired'),
-        )
-        await setStatus(kube, workspace, {
-          observedGeneration: asRecord(workspace.metadata)?.generation ?? 0,
-          phase: 'Expired',
-          volumeName: pvcVolumeName,
-          conditions,
-        })
-        return
-      }
-    }
-  }
 
   const phase = pvcPhase === 'Bound' ? 'Ready' : pvcPhase === 'Lost' ? 'Failed' : 'Pending'
   const conditions = upsertCondition(


### PR DESCRIPTION
## Summary

- evaluate Workspace TTL before creating or updating its PVC
- delete an existing PVC only when one is present, then persist terminal `Expired` status
- add regressions for both provisioned and never-provisioned expired workspaces

## Related Issues

Historical Codex finding: PR #2546 comment `2706821647`.

## Testing

- focused Agents Vitest suite: 12 passed
- targeted Oxfmt and Oxlint: zero warnings or errors
- `git diff --check` passed on the rebased head

## Breaking Changes

None.

## Checklist

- [x] Testing section documents exact validation.
- [x] Screenshots are not applicable.
- [x] Documentation and release notes are not required.
