### PR TITLE
fix(agentctl): show grpc address for empty status

### DIFF
--- a/services/agents/agentctl/src/__tests__/status.test.ts
+++ b/services/agents/agentctl/src/__tests__/status.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { outputStatus } from '../runtime'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('agentctl status output', () => {
+  it('shows the gRPC address when the status message is empty', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    outputStatus(
+      {
+        service: 'agents',
+        generated_at: '2026-07-16T08:00:00.000Z',
+        grpc: {
+          enabled: true,
+          address: 'agents.example.test:50051',
+          status: 'healthy',
+          message: '',
+        },
+      },
+      'table',
+      'agents',
+    )
+
+    expect(log.mock.calls.flat().join('\n')).toContain('agents.example.test:50051')
+  })
+})

--- a/services/agents/agentctl/src/runtime.ts
+++ b/services/agents/agentctl/src/runtime.ts
@@ -1716,7 +1716,7 @@ const outputStatus = (status: ControlPlaneStatus, output: string, namespace: str
       component: 'grpc',
       namespace,
       status: status.grpc.status ?? '',
-      message: status.grpc.message ?? status.grpc.address ?? '',
+      message: status.grpc.message || status.grpc.address || '',
     })
   }
 


### PR DESCRIPTION
## Summary

- fall back to the configured gRPC address when the status message is an empty string
- keep non-empty status messages authoritative
- add a table-output regression proving the address is visible

## Related Issues

Historical Codex finding: PR #2567 comment `2707501027`.

## Testing

- focused agentctl Bun test: 1 passed
- targeted Oxfmt passed
- targeted Oxlint reported zero errors; its 22 warnings are pre-existing elsewhere in `runtime.ts`
- `git diff --check` passed on the rebased head

## Breaking Changes

None.

## Checklist

- [x] Testing section documents exact validation.
- [x] Screenshots are not applicable.
- [x] Documentation and release notes are not required.
