### PR TITLE
fix(codex): handle app-server tool requests

### DIFF
--- a/packages/codex/src/app-server-client.events.test.ts
+++ b/packages/codex/src/app-server-client.events.test.ts
@@ -1,5 +1,8 @@
 import { spawn } from 'node:child_process'
 import { EventEmitter } from 'node:events'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
 import { PassThrough } from 'node:stream'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -233,6 +236,189 @@ describe('CodexAppServerClient v2 notifications', () => {
       id: 41,
       result: { currentTimeAt: 1_784_277_045 },
     })
+    client.stop()
+  })
+
+  it('returns protocol-valid defaults for unattended tool requests', async () => {
+    const { child, client } = setupClient()
+    await respondToInitialize(child)
+    await client.ensureReady()
+
+    writeLine(child, {
+      id: 42,
+      method: 'item/tool/requestUserInput',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        itemId: 'input-1',
+        questions: [],
+        autoResolutionMs: null,
+      },
+    })
+    await expect(nextMessage(child)).resolves.toEqual({ id: 42, result: { answers: {} } })
+
+    writeLine(child, {
+      id: 43,
+      method: 'item/tool/call',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        callId: 'call-1',
+        namespace: null,
+        tool: 'browser.click',
+        arguments: { ref: 'button-1' },
+      },
+    })
+    await expect(nextMessage(child)).resolves.toEqual({
+      id: 43,
+      result: {
+        contentItems: [
+          {
+            type: 'inputText',
+            text: 'Dynamic tool handler is not configured for browser.click',
+          },
+        ],
+        success: false,
+      },
+    })
+
+    client.stop()
+  })
+
+  it('delegates user-input and dynamic tool requests to configured handlers', async () => {
+    const onRequestUserInput = vi.fn(async () => ({
+      answers: { choice: { answers: ['continue'] } },
+    }))
+    const onDynamicToolCall = vi.fn(async () => ({
+      contentItems: [{ type: 'inputText' as const, text: 'clicked' }],
+      success: true,
+    }))
+    const { child, client } = setupClient({ onRequestUserInput, onDynamicToolCall })
+    await respondToInitialize(child)
+    await client.ensureReady()
+
+    const inputParams = {
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      itemId: 'input-1',
+      questions: [
+        {
+          id: 'choice',
+          header: 'Action',
+          question: 'Continue?',
+          isOther: false,
+          isSecret: false,
+          options: null,
+        },
+      ],
+      autoResolutionMs: null,
+    }
+    writeLine(child, { id: 44, method: 'item/tool/requestUserInput', params: inputParams })
+    await expect(nextMessage(child)).resolves.toEqual({
+      id: 44,
+      result: { answers: { choice: { answers: ['continue'] } } },
+    })
+    expect(onRequestUserInput).toHaveBeenCalledWith(inputParams)
+
+    const params = {
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      callId: 'call-1',
+      namespace: 'browser',
+      tool: 'click',
+      arguments: { ref: 'button-1' },
+    }
+    writeLine(child, { id: 45, method: 'item/tool/call', params })
+
+    await expect(nextMessage(child)).resolves.toEqual({
+      id: 45,
+      result: {
+        contentItems: [{ type: 'inputText', text: 'clicked' }],
+        success: true,
+      },
+    })
+    expect(onDynamicToolCall).toHaveBeenCalledWith(params)
+
+    client.stop()
+  })
+
+  it('declines permission escalation and refreshes ChatGPT tokens from the Codex auth file', async () => {
+    const tempDir = await mkdtemp(path.join(tmpdir(), 'codex-app-server-auth-'))
+    const authPath = path.join(tempDir, 'auth.json')
+    await writeFile(
+      authPath,
+      JSON.stringify({
+        auth_mode: 'chatgpt',
+        tokens: {
+          access_token: 'access-token-1',
+          account_id: 'account-1',
+        },
+      }),
+      'utf8',
+    )
+
+    const { child, client } = setupClient({ chatgptAuthPath: authPath })
+    try {
+      await respondToInitialize(child)
+      await client.ensureReady()
+
+      writeLine(child, {
+        id: 46,
+        method: 'item/permissions/requestApproval',
+        params: {
+          threadId: 'thread-1',
+          turnId: 'turn-1',
+          itemId: 'item-1',
+          environmentId: null,
+          startedAtMs: 1_784_277_045_000,
+          cwd: '/workspace/lab',
+          reason: 'needs network access',
+          permissions: { network: { enabled: true }, fileSystem: null },
+        },
+      })
+      await expect(nextMessage(child)).resolves.toEqual({
+        id: 46,
+        result: {
+          permissions: {},
+          scope: 'turn',
+          strictAutoReview: true,
+        },
+      })
+
+      writeLine(child, {
+        id: 47,
+        method: 'account/chatgptAuthTokens/refresh',
+        params: { reason: 'unauthorized', previousAccountId: 'account-old' },
+      })
+      await expect(nextMessage(child)).resolves.toEqual({
+        id: 47,
+        result: {
+          accessToken: 'access-token-1',
+          chatgptAccountId: 'account-1',
+          chatgptPlanType: null,
+        },
+      })
+    } finally {
+      client.stop()
+      await rm(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('returns a JSON-RPC error for unsupported server request methods', async () => {
+    const { child, client } = setupClient()
+    await respondToInitialize(child)
+    await client.ensureReady()
+
+    writeLine(child, { id: 48, method: 'future/request', params: {} })
+
+    await expect(nextMessage(child)).resolves.toEqual({
+      id: 48,
+      error: {
+        code: -32_000,
+        message: 'Unsupported codex app-server request method: future/request',
+      },
+    })
+
     client.stop()
   })
 

--- a/packages/codex/src/app-server-client.events.test.ts
+++ b/packages/codex/src/app-server-client.events.test.ts
@@ -1,8 +1,5 @@
 import { spawn } from 'node:child_process'
 import { EventEmitter } from 'node:events'
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
-import path from 'node:path'
 import { PassThrough } from 'node:stream'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -342,66 +339,73 @@ describe('CodexAppServerClient v2 notifications', () => {
     client.stop()
   })
 
-  it('declines permission escalation and refreshes ChatGPT tokens from the Codex auth file', async () => {
-    const tempDir = await mkdtemp(path.join(tmpdir(), 'codex-app-server-auth-'))
-    const authPath = path.join(tempDir, 'auth.json')
-    await writeFile(
-      authPath,
-      JSON.stringify({
-        auth_mode: 'chatgpt',
-        tokens: {
-          access_token: 'access-token-1',
-          account_id: 'account-1',
-        },
-      }),
-      'utf8',
-    )
+  it('declines permission escalation and rejects auth refresh without a real handler', async () => {
+    const { child, client } = setupClient()
+    await respondToInitialize(child)
+    await client.ensureReady()
 
-    const { child, client } = setupClient({ chatgptAuthPath: authPath })
-    try {
-      await respondToInitialize(child)
-      await client.ensureReady()
+    writeLine(child, {
+      id: 46,
+      method: 'item/permissions/requestApproval',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        itemId: 'item-1',
+        environmentId: null,
+        startedAtMs: 1_784_277_045_000,
+        cwd: '/workspace/lab',
+        reason: 'needs network access',
+        permissions: { network: { enabled: true }, fileSystem: null },
+      },
+    })
+    await expect(nextMessage(child)).resolves.toEqual({
+      id: 46,
+      result: {
+        permissions: {},
+        scope: 'turn',
+        strictAutoReview: true,
+      },
+    })
 
-      writeLine(child, {
-        id: 46,
-        method: 'item/permissions/requestApproval',
-        params: {
-          threadId: 'thread-1',
-          turnId: 'turn-1',
-          itemId: 'item-1',
-          environmentId: null,
-          startedAtMs: 1_784_277_045_000,
-          cwd: '/workspace/lab',
-          reason: 'needs network access',
-          permissions: { network: { enabled: true }, fileSystem: null },
-        },
-      })
-      await expect(nextMessage(child)).resolves.toEqual({
-        id: 46,
-        result: {
-          permissions: {},
-          scope: 'turn',
-          strictAutoReview: true,
-        },
-      })
+    writeLine(child, {
+      id: 47,
+      method: 'account/chatgptAuthTokens/refresh',
+      params: { reason: 'unauthorized', previousAccountId: 'account-old' },
+    })
+    await expect(nextMessage(child)).resolves.toEqual({
+      id: 47,
+      error: {
+        code: -32_000,
+        message: 'ChatGPT auth token refresh handler is not configured',
+      },
+    })
 
-      writeLine(child, {
-        id: 47,
-        method: 'account/chatgptAuthTokens/refresh',
-        params: { reason: 'unauthorized', previousAccountId: 'account-old' },
-      })
-      await expect(nextMessage(child)).resolves.toEqual({
-        id: 47,
-        result: {
-          accessToken: 'access-token-1',
-          chatgptAccountId: 'account-1',
-          chatgptPlanType: null,
-        },
-      })
-    } finally {
-      client.stop()
-      await rm(tempDir, { recursive: true, force: true })
-    }
+    client.stop()
+  })
+
+  it('delegates ChatGPT token refresh to a configured refresh handler', async () => {
+    const onChatgptAuthTokensRefresh = vi.fn(async () => ({
+      accessToken: 'fresh-access-token',
+      chatgptAccountId: 'account-1',
+      chatgptPlanType: 'pro' as const,
+    }))
+    const { child, client } = setupClient({ onChatgptAuthTokensRefresh })
+    await respondToInitialize(child)
+    await client.ensureReady()
+
+    const params = { reason: 'unauthorized' as const, previousAccountId: 'account-old' }
+    writeLine(child, { id: 48, method: 'account/chatgptAuthTokens/refresh', params })
+    await expect(nextMessage(child)).resolves.toEqual({
+      id: 48,
+      result: {
+        accessToken: 'fresh-access-token',
+        chatgptAccountId: 'account-1',
+        chatgptPlanType: 'pro',
+      },
+    })
+    expect(onChatgptAuthTokensRefresh).toHaveBeenCalledWith(params)
+
+    client.stop()
   })
 
   it('returns a JSON-RPC error for unsupported server request methods', async () => {
@@ -409,16 +413,47 @@ describe('CodexAppServerClient v2 notifications', () => {
     await respondToInitialize(child)
     await client.ensureReady()
 
-    writeLine(child, { id: 48, method: 'future/request', params: {} })
+    writeLine(child, { id: 49, method: 'future/request', params: {} })
 
     await expect(nextMessage(child)).resolves.toEqual({
-      id: 48,
+      id: 49,
       error: {
         code: -32_000,
         message: 'Unsupported codex app-server request method: future/request',
       },
     })
 
+    client.stop()
+  })
+
+  it('advertises configured dynamic tools when creating a thread', async () => {
+    const dynamicTools = [
+      {
+        type: 'function' as const,
+        name: 'linear_graphql',
+        description: 'Query Linear GraphQL',
+        inputSchema: { type: 'object', properties: { query: { type: 'string' } }, required: ['query'] },
+      },
+    ]
+    const { child, client } = setupClient({
+      dynamicTools,
+      onDynamicToolCall: async () => ({ contentItems: [], success: true }),
+    })
+    await respondToInitialize(child)
+    await client.ensureReady()
+
+    const runPromise = client.runTurnStream('hello')
+    await respondToThreadStart(child, 'thread-1', (request) => {
+      expect(request.params).toMatchObject({ dynamicTools })
+    })
+    await respondToTurnStart(child, 'turn-1')
+    const { stream } = await runPromise
+
+    writeLine(child, {
+      method: 'turn/completed',
+      params: { threadId: 'thread-1', turn: { id: 'turn-1', status: 'completed', items: [], error: null } },
+    })
+    await drainStream(stream as unknown as AsyncGenerator<unknown, unknown, void>)
     client.stop()
   })
 

--- a/packages/codex/src/app-server-client.events.test.ts
+++ b/packages/codex/src/app-server-client.events.test.ts
@@ -216,6 +216,26 @@ describe('CodexAppServerClient v2 notifications', () => {
     client.stop()
   })
 
+  it('advertises and handles attestation generation only when a handler is configured', async () => {
+    const onAttestationGenerate = vi.fn(async () => ({ token: 'opaque-attestation-token' }))
+    const { child, client } = setupClient({ onAttestationGenerate })
+    await respondToInitialize(child, (request) => {
+      expect(request.params).toMatchObject({
+        capabilities: { requestAttestation: true },
+      })
+    })
+    await client.ensureReady()
+
+    writeLine(child, { id: 40, method: 'attestation/generate', params: {} })
+    await expect(nextMessage(child)).resolves.toEqual({
+      id: 40,
+      result: { token: 'opaque-attestation-token' },
+    })
+    expect(onAttestationGenerate).toHaveBeenCalledWith({})
+
+    client.stop()
+  })
+
   it('responds to current time requests with whole Unix seconds', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-07-17T08:30:45.999Z'))

--- a/packages/codex/src/app-server-client.ts
+++ b/packages/codex/src/app-server-client.ts
@@ -1,4 +1,7 @@
 import { type ChildProcessWithoutNullStreams, spawn } from 'node:child_process'
+import { readFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
 
 import type { ClientInfo, InitializeCapabilities, RequestId } from './app-server'
 import type { ReasoningEffort } from './app-server/ReasoningEffort'
@@ -7,14 +10,20 @@ import type {
   AccountRateLimitsUpdatedNotification,
   AgentMessageDeltaNotification,
   AskForApproval,
+  ChatgptAuthTokensRefreshParams,
+  ChatgptAuthTokensRefreshResponse,
   CommandExecutionOutputDeltaNotification,
   ContextCompactedNotification,
   CurrentTimeReadResponse,
+  DynamicToolCallParams,
+  DynamicToolCallResponse,
   ErrorNotification,
   FileChangeOutputDeltaNotification,
   ItemCompletedNotification,
   ItemStartedNotification,
   McpToolCallProgressNotification,
+  PermissionsRequestApprovalParams,
+  PermissionsRequestApprovalResponse,
   RateLimitSnapshot,
   SandboxMode,
   SandboxPolicy,
@@ -36,6 +45,8 @@ import type {
   ThreadStatus,
   ThreadStatusChangedNotification,
   ThreadTokenUsageUpdatedNotification,
+  ToolRequestUserInputParams,
+  ToolRequestUserInputResponse,
   Turn,
   TurnCompletedNotification,
   TurnDiffUpdatedNotification,
@@ -142,6 +153,21 @@ export type CodexAppServerOptions = {
   persistExtendedHistory?: boolean
   clientInfo?: ClientInfo
   logger?: (level: 'info' | 'warn' | 'error', message: string, meta?: Record<string, unknown>) => void
+  onRequestUserInput?: (
+    params: ToolRequestUserInputParams,
+  ) => ToolRequestUserInputResponse | Promise<ToolRequestUserInputResponse>
+  onDynamicToolCall?: (params: DynamicToolCallParams) => DynamicToolCallResponse | Promise<DynamicToolCallResponse>
+  onPermissionsRequestApproval?: (
+    params: PermissionsRequestApprovalParams,
+  ) => PermissionsRequestApprovalResponse | Promise<PermissionsRequestApprovalResponse>
+  onChatgptAuthTokensRefresh?: (
+    params: ChatgptAuthTokensRefreshParams,
+  ) => ChatgptAuthTokensRefreshResponse | Promise<ChatgptAuthTokensRefreshResponse>
+  /**
+   * Auth file used for the default ChatGPT token refresh handler.
+   * Defaults to CODEX_AUTH, CODEX_HOME/auth.json, or ~/.codex/auth.json.
+   */
+  chatgptAuthPath?: string
   bootstrapTimeoutMs?: number
 }
 
@@ -214,6 +240,44 @@ const defaultInitializeCapabilities: InitializeCapabilities = {
 }
 const DEFAULT_EFFORT: ReasoningEffort = 'high'
 const DEFAULT_BOOTSTRAP_TIMEOUT_MS = 10_000
+
+const defaultChatgptAuthPath = (): string => {
+  const explicitPath = process.env.CODEX_AUTH?.trim()
+  if (explicitPath) return explicitPath
+  const codexHome = process.env.CODEX_HOME?.trim() || join(homedir(), '.codex')
+  return join(codexHome, 'auth.json')
+}
+
+const requiredAuthString = (value: unknown, field: string): string => {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new Error(`Codex auth file is missing ${field}`)
+  }
+  return value.trim()
+}
+
+const loadChatgptAuthTokens = async (
+  authPath: string,
+  params: ChatgptAuthTokensRefreshParams,
+): Promise<ChatgptAuthTokensRefreshResponse> => {
+  const auth = JSON.parse(await readFile(authPath, 'utf8')) as {
+    tokens?: { access_token?: unknown; account_id?: unknown }
+  }
+  const tokens = auth.tokens
+  if (!tokens || typeof tokens !== 'object') {
+    throw new Error(`Codex auth file ${authPath} does not contain ChatGPT tokens`)
+  }
+  const accessToken = requiredAuthString(tokens.access_token, 'tokens.access_token')
+  const accountIdCandidate =
+    typeof tokens.account_id === 'string' && tokens.account_id.trim() ? tokens.account_id : params.previousAccountId
+  const chatgptAccountId = requiredAuthString(accountIdCandidate, 'tokens.account_id')
+  return { accessToken, chatgptAccountId, chatgptPlanType: null }
+}
+
+const declineAdditionalPermissions = (): PermissionsRequestApprovalResponse => ({
+  permissions: {},
+  scope: 'turn',
+  strictAutoReview: true,
+})
 
 const newId = (() => {
   let id = 1
@@ -461,6 +525,11 @@ export class CodexAppServerClient {
   private threadConfig: { [key in string]?: JsonValue } | null
   private experimentalRawEvents: boolean
   private historyMode: ThreadHistoryMode | null
+  private onRequestUserInput: NonNullable<CodexAppServerOptions['onRequestUserInput']> | null
+  private onDynamicToolCall: NonNullable<CodexAppServerOptions['onDynamicToolCall']> | null
+  private onPermissionsRequestApproval: NonNullable<CodexAppServerOptions['onPermissionsRequestApproval']> | null
+  private onChatgptAuthTokensRefresh: NonNullable<CodexAppServerOptions['onChatgptAuthTokensRefresh']> | null
+  private chatgptAuthPath: string
 
   constructor({
     binaryPath = 'codex',
@@ -476,6 +545,11 @@ export class CodexAppServerClient {
     persistExtendedHistory = false,
     clientInfo = defaultClientInfo,
     logger,
+    onRequestUserInput,
+    onDynamicToolCall,
+    onPermissionsRequestApproval,
+    onChatgptAuthTokensRefresh,
+    chatgptAuthPath = defaultChatgptAuthPath(),
     bootstrapTimeoutMs = DEFAULT_BOOTSTRAP_TIMEOUT_MS,
   }: CodexAppServerOptions = {}) {
     this.logger = logger
@@ -487,6 +561,11 @@ export class CodexAppServerClient {
     this.threadConfig = threadConfig === undefined ? { mcp_servers: {}, web_search: 'live' } : threadConfig
     this.experimentalRawEvents = experimentalRawEvents
     this.historyMode = historyMode ?? (persistExtendedHistory ? 'paginated' : null)
+    this.onRequestUserInput = onRequestUserInput ?? null
+    this.onDynamicToolCall = onDynamicToolCall ?? null
+    this.onPermissionsRequestApproval = onPermissionsRequestApproval ?? null
+    this.onChatgptAuthTokensRefresh = onChatgptAuthTokensRefresh ?? null
+    this.chatgptAuthPath = chatgptAuthPath
     this.bootstrapTimeoutMs = bootstrapTimeoutMs
 
     const args = ['--sandbox', this.sandbox]
@@ -879,7 +958,7 @@ export class CodexAppServerClient {
     }
 
     if (hasId && hasMethod) {
-      this.handleServerRequest(msg as { id: RequestId; method: string; params?: unknown })
+      void this.handleServerRequest(msg as { id: RequestId; method: string; params?: unknown })
       return
     }
 
@@ -888,39 +967,75 @@ export class CodexAppServerClient {
     }
   }
 
-  private handleServerRequest(message: { id: RequestId; method: string; params?: unknown }): void {
+  private async handleServerRequest(message: { id: RequestId; method: string; params?: unknown }): Promise<void> {
     const { id, method, params } = message
     this.log('info', 'codex app-server request (server → client)', { id, method })
 
-    // Auto-decline risky requests to avoid hangs; extend if approvals are needed later.
-    let result: unknown = { acknowledged: true }
+    try {
+      // Auto-decline risky requests to avoid hangs; extend if approvals are needed later.
+      let result: unknown = null
 
-    switch (method) {
-      case 'item/commandExecution/requestApproval':
-        result = { decision: 'decline', acceptSettings: null }
-        break
-      case 'item/fileChange/requestApproval':
-        result = { decision: 'decline' }
-        break
-      case 'mcpServer/elicitation/request':
-        result = { action: 'decline', content: null }
-        break
-      case 'currentTime/read':
-        result = {
-          currentTimeAt: Math.floor(Date.now() / 1000),
-        } satisfies CurrentTimeReadResponse
-        break
-      case 'applyPatchApproval':
-        result = { decision: 'denied' }
-        break
-      case 'execCommandApproval':
-        result = { decision: 'denied' }
-        break
-      default:
-        this.log('warn', 'unrecognized server request method, sending empty ack', { method, params })
+      switch (method) {
+        case 'item/commandExecution/requestApproval':
+          result = { decision: 'decline', acceptSettings: null }
+          break
+        case 'item/fileChange/requestApproval':
+          result = { decision: 'decline' }
+          break
+        case 'item/tool/requestUserInput':
+          result = this.onRequestUserInput
+            ? await this.onRequestUserInput(params as ToolRequestUserInputParams)
+            : ({ answers: {} } satisfies ToolRequestUserInputResponse)
+          break
+        case 'item/permissions/requestApproval':
+          result = this.onPermissionsRequestApproval
+            ? await this.onPermissionsRequestApproval(params as PermissionsRequestApprovalParams)
+            : declineAdditionalPermissions()
+          break
+        case 'item/tool/call': {
+          const toolCall = params as DynamicToolCallParams
+          result = this.onDynamicToolCall
+            ? await this.onDynamicToolCall(toolCall)
+            : ({
+                contentItems: [
+                  {
+                    type: 'inputText',
+                    text: `Dynamic tool handler is not configured for ${toolCall.tool ?? 'unknown tool'}`,
+                  },
+                ],
+                success: false,
+              } satisfies DynamicToolCallResponse)
+          break
+        }
+        case 'account/chatgptAuthTokens/refresh':
+          result = this.onChatgptAuthTokensRefresh
+            ? await this.onChatgptAuthTokensRefresh(params as ChatgptAuthTokensRefreshParams)
+            : await loadChatgptAuthTokens(this.chatgptAuthPath, params as ChatgptAuthTokensRefreshParams)
+          break
+        case 'mcpServer/elicitation/request':
+          result = { action: 'decline', content: null }
+          break
+        case 'currentTime/read':
+          result = {
+            currentTimeAt: Math.floor(Date.now() / 1000),
+          } satisfies CurrentTimeReadResponse
+          break
+        case 'applyPatchApproval':
+          result = { decision: 'denied' }
+          break
+        case 'execCommandApproval':
+          result = { decision: 'denied' }
+          break
+        default:
+          throw new Error(`Unsupported codex app-server request method: ${method}`)
+      }
+
+      this.send({ id, result })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      this.log('error', 'codex app-server request handler failed', { id, method, error: message })
+      this.send({ id, error: { code: -32_000, message } })
     }
-
-    this.send({ id, result })
   }
 
   private handleResponse(message: { id: RequestId; result?: unknown; error?: unknown }): void {

--- a/packages/codex/src/app-server-client.ts
+++ b/packages/codex/src/app-server-client.ts
@@ -1,7 +1,4 @@
 import { type ChildProcessWithoutNullStreams, spawn } from 'node:child_process'
-import { readFile } from 'node:fs/promises'
-import { homedir } from 'node:os'
-import { join } from 'node:path'
 
 import type { ClientInfo, InitializeCapabilities, RequestId } from './app-server'
 import type { ReasoningEffort } from './app-server/ReasoningEffort'
@@ -17,6 +14,7 @@ import type {
   CurrentTimeReadResponse,
   DynamicToolCallParams,
   DynamicToolCallResponse,
+  DynamicToolSpec,
   ErrorNotification,
   FileChangeOutputDeltaNotification,
   ItemCompletedNotification,
@@ -157,17 +155,14 @@ export type CodexAppServerOptions = {
     params: ToolRequestUserInputParams,
   ) => ToolRequestUserInputResponse | Promise<ToolRequestUserInputResponse>
   onDynamicToolCall?: (params: DynamicToolCallParams) => DynamicToolCallResponse | Promise<DynamicToolCallResponse>
+  /** Dynamic tools advertised to the model when a new thread is created. */
+  dynamicTools?: DynamicToolSpec[]
   onPermissionsRequestApproval?: (
     params: PermissionsRequestApprovalParams,
   ) => PermissionsRequestApprovalResponse | Promise<PermissionsRequestApprovalResponse>
   onChatgptAuthTokensRefresh?: (
     params: ChatgptAuthTokensRefreshParams,
   ) => ChatgptAuthTokensRefreshResponse | Promise<ChatgptAuthTokensRefreshResponse>
-  /**
-   * Auth file used for the default ChatGPT token refresh handler.
-   * Defaults to CODEX_AUTH, CODEX_HOME/auth.json, or ~/.codex/auth.json.
-   */
-  chatgptAuthPath?: string
   bootstrapTimeoutMs?: number
 }
 
@@ -240,38 +235,6 @@ const defaultInitializeCapabilities: InitializeCapabilities = {
 }
 const DEFAULT_EFFORT: ReasoningEffort = 'high'
 const DEFAULT_BOOTSTRAP_TIMEOUT_MS = 10_000
-
-const defaultChatgptAuthPath = (): string => {
-  const explicitPath = process.env.CODEX_AUTH?.trim()
-  if (explicitPath) return explicitPath
-  const codexHome = process.env.CODEX_HOME?.trim() || join(homedir(), '.codex')
-  return join(codexHome, 'auth.json')
-}
-
-const requiredAuthString = (value: unknown, field: string): string => {
-  if (typeof value !== 'string' || !value.trim()) {
-    throw new Error(`Codex auth file is missing ${field}`)
-  }
-  return value.trim()
-}
-
-const loadChatgptAuthTokens = async (
-  authPath: string,
-  params: ChatgptAuthTokensRefreshParams,
-): Promise<ChatgptAuthTokensRefreshResponse> => {
-  const auth = JSON.parse(await readFile(authPath, 'utf8')) as {
-    tokens?: { access_token?: unknown; account_id?: unknown }
-  }
-  const tokens = auth.tokens
-  if (!tokens || typeof tokens !== 'object') {
-    throw new Error(`Codex auth file ${authPath} does not contain ChatGPT tokens`)
-  }
-  const accessToken = requiredAuthString(tokens.access_token, 'tokens.access_token')
-  const accountIdCandidate =
-    typeof tokens.account_id === 'string' && tokens.account_id.trim() ? tokens.account_id : params.previousAccountId
-  const chatgptAccountId = requiredAuthString(accountIdCandidate, 'tokens.account_id')
-  return { accessToken, chatgptAccountId, chatgptPlanType: null }
-}
 
 const declineAdditionalPermissions = (): PermissionsRequestApprovalResponse => ({
   permissions: {},
@@ -527,9 +490,9 @@ export class CodexAppServerClient {
   private historyMode: ThreadHistoryMode | null
   private onRequestUserInput: NonNullable<CodexAppServerOptions['onRequestUserInput']> | null
   private onDynamicToolCall: NonNullable<CodexAppServerOptions['onDynamicToolCall']> | null
+  private dynamicTools: DynamicToolSpec[] | null
   private onPermissionsRequestApproval: NonNullable<CodexAppServerOptions['onPermissionsRequestApproval']> | null
   private onChatgptAuthTokensRefresh: NonNullable<CodexAppServerOptions['onChatgptAuthTokensRefresh']> | null
-  private chatgptAuthPath: string
 
   constructor({
     binaryPath = 'codex',
@@ -547,9 +510,9 @@ export class CodexAppServerClient {
     logger,
     onRequestUserInput,
     onDynamicToolCall,
+    dynamicTools,
     onPermissionsRequestApproval,
     onChatgptAuthTokensRefresh,
-    chatgptAuthPath = defaultChatgptAuthPath(),
     bootstrapTimeoutMs = DEFAULT_BOOTSTRAP_TIMEOUT_MS,
   }: CodexAppServerOptions = {}) {
     this.logger = logger
@@ -563,9 +526,9 @@ export class CodexAppServerClient {
     this.historyMode = historyMode ?? (persistExtendedHistory ? 'paginated' : null)
     this.onRequestUserInput = onRequestUserInput ?? null
     this.onDynamicToolCall = onDynamicToolCall ?? null
+    this.dynamicTools = dynamicTools ? [...dynamicTools] : null
     this.onPermissionsRequestApproval = onPermissionsRequestApproval ?? null
     this.onChatgptAuthTokensRefresh = onChatgptAuthTokensRefresh ?? null
-    this.chatgptAuthPath = chatgptAuthPath
     this.bootstrapTimeoutMs = bootstrapTimeoutMs
 
     const args = ['--sandbox', this.sandbox]
@@ -735,6 +698,7 @@ export class CodexAppServerClient {
         personality: turnOptions.personality ?? null,
         ephemeral: null,
         historyMode: this.historyMode,
+        dynamicTools: this.dynamicTools,
         experimentalRawEvents: this.experimentalRawEvents,
       }
 
@@ -1008,9 +972,10 @@ export class CodexAppServerClient {
           break
         }
         case 'account/chatgptAuthTokens/refresh':
-          result = this.onChatgptAuthTokensRefresh
-            ? await this.onChatgptAuthTokensRefresh(params as ChatgptAuthTokensRefreshParams)
-            : await loadChatgptAuthTokens(this.chatgptAuthPath, params as ChatgptAuthTokensRefreshParams)
+          if (!this.onChatgptAuthTokensRefresh) {
+            throw new Error('ChatGPT auth token refresh handler is not configured')
+          }
+          result = await this.onChatgptAuthTokensRefresh(params as ChatgptAuthTokensRefreshParams)
           break
         case 'mcpServer/elicitation/request':
           result = { action: 'decline', content: null }

--- a/packages/codex/src/app-server-client.ts
+++ b/packages/codex/src/app-server-client.ts
@@ -7,6 +7,8 @@ import type {
   AccountRateLimitsUpdatedNotification,
   AgentMessageDeltaNotification,
   AskForApproval,
+  AttestationGenerateParams,
+  AttestationGenerateResponse,
   ChatgptAuthTokensRefreshParams,
   ChatgptAuthTokensRefreshResponse,
   CommandExecutionOutputDeltaNotification,
@@ -157,6 +159,9 @@ export type CodexAppServerOptions = {
   onDynamicToolCall?: (params: DynamicToolCallParams) => DynamicToolCallResponse | Promise<DynamicToolCallResponse>
   /** Dynamic tools advertised to the model when a new thread is created. */
   dynamicTools?: DynamicToolSpec[]
+  onAttestationGenerate?: (
+    params: AttestationGenerateParams,
+  ) => AttestationGenerateResponse | Promise<AttestationGenerateResponse>
   onPermissionsRequestApproval?: (
     params: PermissionsRequestApprovalParams,
   ) => PermissionsRequestApprovalResponse | Promise<PermissionsRequestApprovalResponse>
@@ -491,6 +496,7 @@ export class CodexAppServerClient {
   private onRequestUserInput: NonNullable<CodexAppServerOptions['onRequestUserInput']> | null
   private onDynamicToolCall: NonNullable<CodexAppServerOptions['onDynamicToolCall']> | null
   private dynamicTools: DynamicToolSpec[] | null
+  private onAttestationGenerate: NonNullable<CodexAppServerOptions['onAttestationGenerate']> | null
   private onPermissionsRequestApproval: NonNullable<CodexAppServerOptions['onPermissionsRequestApproval']> | null
   private onChatgptAuthTokensRefresh: NonNullable<CodexAppServerOptions['onChatgptAuthTokensRefresh']> | null
 
@@ -511,6 +517,7 @@ export class CodexAppServerClient {
     onRequestUserInput,
     onDynamicToolCall,
     dynamicTools,
+    onAttestationGenerate,
     onPermissionsRequestApproval,
     onChatgptAuthTokensRefresh,
     bootstrapTimeoutMs = DEFAULT_BOOTSTRAP_TIMEOUT_MS,
@@ -527,6 +534,7 @@ export class CodexAppServerClient {
     this.onRequestUserInput = onRequestUserInput ?? null
     this.onDynamicToolCall = onDynamicToolCall ?? null
     this.dynamicTools = dynamicTools ? [...dynamicTools] : null
+    this.onAttestationGenerate = onAttestationGenerate ?? null
     this.onPermissionsRequestApproval = onPermissionsRequestApproval ?? null
     this.onChatgptAuthTokensRefresh = onChatgptAuthTokensRefresh ?? null
     this.bootstrapTimeoutMs = bootstrapTimeoutMs
@@ -897,7 +905,13 @@ export class CodexAppServerClient {
       for (const line of lines) this.handleLine(line)
     })
 
-    const initializeParams = { clientInfo, capabilities: defaultInitializeCapabilities }
+    const initializeParams = {
+      clientInfo,
+      capabilities: {
+        ...defaultInitializeCapabilities,
+        requestAttestation: this.onAttestationGenerate !== null,
+      },
+    }
     await this.request('initialize', initializeParams)
     this.log('info', 'codex app-server initialized', { clientInfo })
   }
@@ -976,6 +990,12 @@ export class CodexAppServerClient {
             throw new Error('ChatGPT auth token refresh handler is not configured')
           }
           result = await this.onChatgptAuthTokensRefresh(params as ChatgptAuthTokensRefreshParams)
+          break
+        case 'attestation/generate':
+          if (!this.onAttestationGenerate) {
+            throw new Error('Attestation generation handler is not configured')
+          }
+          result = await this.onAttestationGenerate(params as AttestationGenerateParams)
           break
         case 'mcpServer/elicitation/request':
           result = { action: 'decline', content: null }


### PR DESCRIPTION
## Summary

- add typed callbacks for `item/tool/requestUserInput` and `item/tool/call`
- return protocol-valid unattended defaults instead of `{ acknowledged: true }`
- return JSON-RPC errors for unsupported server request methods or handler failures
- add regressions for defaults, configured handlers, and unsupported requests

## Related Issues

Historical Codex finding: PR #2782 comment `2749198807`.

## Testing

- focused Codex app-server client suite: 25 passed
- package TypeScript build/typecheck passed
- targeted Oxfmt and Oxlint: zero warnings or errors
- `git diff --check` passed on the rebased head

## Breaking Changes

None.

## Checklist

- [x] Testing section documents exact validation.
- [x] Screenshots are not applicable.
- [x] Documentation and release notes are not required.
