### PR TITLE
docs(agents): fix validation command quoting

### DIFF
--- a/docs/agents/designs/controller-condition-type-taxonomy.md
+++ b/docs/agents/designs/controller-condition-type-taxonomy.md
@@ -68,7 +68,7 @@ Rollback:
 
 ```bash
 kubectl -n agents get agentrun <name> -o jsonpath='{.status.conditions[*].type}'; echo
-kubectl -n agents get agentrun <name> -o jsonpath='{.status.conditions[?(@.type==\"Succeeded\")].status}'; echo
+kubectl -n agents get agentrun <name> -o jsonpath='{.status.conditions[?(@.type=="Succeeded")].status}'; echo
 ```
 
 ## Failure Modes and Mitigations

--- a/docs/agents/designs/crd-agentrun-spec-immutability.md
+++ b/docs/agents/designs/crd-agentrun-spec-immutability.md
@@ -69,8 +69,8 @@ Rollback:
 
 ```bash
 kubectl -n agents apply -f charts/agents/examples/agentrun-sample.yaml
-kubectl -n agents patch agentrun <name> --type=merge -p '{\"spec\":{\"parameters\":{\"x\":\"y\"}}}'
-kubectl -n agents get agentrun <name> -o yaml | rg -n \"SpecImmutableViolation|specHash|conditions\"
+kubectl -n agents patch agentrun <name> --type=merge -p '{"spec":{"parameters":{"x":"y"}}}'
+kubectl -n agents get agentrun <name> -o yaml | rg -n "SpecImmutableViolation|specHash|conditions"
 ```
 
 ## Failure Modes and Mitigations

--- a/docs/agents/designs/crd-orchestrationrun-cancel-propagation.md
+++ b/docs/agents/designs/crd-orchestrationrun-cancel-propagation.md
@@ -62,8 +62,8 @@ Rollback:
 ## Validation
 
 ```bash
-kubectl -n agents patch orchestrationrun <name> --type=merge -p '{\"spec\":{\"cancel\":true}}'
-kubectl -n agents get orchestrationrun <name> -o yaml | rg -n \"Cancelled|phase\"
+kubectl -n agents patch orchestrationrun <name> --type=merge -p '{"spec":{"cancel":true}}'
+kubectl -n agents get orchestrationrun <name> -o yaml | rg -n "Cancelled|phase"
 ```
 
 ## Failure Modes and Mitigations


### PR DESCRIPTION
## Summary

- remove invalid backslash escaping from AgentRun and OrchestrationRun JSON patch payloads
- use a valid single-quoted Kubernetes JSONPath filter for the `Succeeded` condition
- normalize adjacent `rg` command quoting in the same validation snippets

## Related Issues

Historical Codex findings: PR #2861 comments `2773741064` and `2773741071`.

## Testing

- both embedded patch payloads parse as JSON
- the JSONPath literal contains no shell-preserved quote escapes
- all three Bash validation blocks pass `bash -n`
- targeted Oxfmt passed
- `git diff --check` passed

## Breaking Changes

None.

## Checklist

- [x] Testing section documents exact validation.
- [x] Screenshots are not applicable.
- [x] Documentation change is self-contained.
