### PR TITLE
docs(torghut): fix clickhouse shell quoting

### DIFF
--- a/docs/torghut/design-system/v1/operations-clickhouse-replica-and-keeper.md
+++ b/docs/torghut/design-system/v1/operations-clickhouse-replica-and-keeper.md
@@ -18,7 +18,6 @@
   - `docs/torghut/production-readiness-proof-runbook.md`
 - Design drift note: Operational docs need runtime status and alerting readback before being treated as complete.
 
-
 ## Purpose
 
 Provide ClickHouse recovery procedures tailored to Torghut’s replicated tables and known operational incidents (keeper
@@ -70,9 +69,9 @@ CH_PASS="$(kubectl -n torghut get secret torghut-clickhouse-auth -o jsonpath='{.
 Example query:
 
 ```bash
-curl -fsS 'http://localhost:8123/?query=SELECT%201%20FORMAT%20JSONEachRow' \\
-  -H \"X-ClickHouse-User: ${CH_USER}\" \\
-  -H \"X-ClickHouse-Key: ${CH_PASS}\"
+curl -fsS 'http://localhost:8123/?query=SELECT%201%20FORMAT%20JSONEachRow' \
+  -H "X-ClickHouse-User: ${CH_USER}" \
+  -H "X-ClickHouse-Key: ${CH_PASS}"
 ```
 
 ## Procedure A: Replica is read-only


### PR DESCRIPTION
## Summary

- replace double-escaped shell continuations with executable line continuations
- use normal quoted ClickHouse HTTP headers
- keep the recovery query copy-pasteable in Bash

## Related Issues

Historical Codex finding: PR #2902 comment `2779793807`.

## Testing

- the Bash example passes `bash -n`
- assertions verify one continuation per continued line and normal header quoting
- targeted Oxfmt passed
- `git diff --check` passed

## Breaking Changes

None.

## Checklist

- [x] Testing section documents exact validation.
- [x] Screenshots are not applicable.
- [x] Documentation change is self-contained.
