### PR TITLE
fix(torghut): bound DSPy signature version storage

### DIFF
--- a/services/torghut/app/trading/llm/dspy_compile/workflow/shared_context.py
+++ b/services/torghut/app/trading/llm/dspy_compile/workflow/shared_context.py
@@ -37,6 +37,7 @@ DSPyWorkflowLane = Literal[
 DSPyWorkflowExecutionMode = Literal["agentrun", "local"]
 
 DEFAULT_DSPY_AGENT_NAME = "codex-spark-agent"
+SIGNATURE_VERSIONS_METADATA_KEY = "signature_versions"
 
 IMPLEMENTATION_SPEC_BY_LANE: dict[DSPyWorkflowLane, str] = {
     "dataset-build": "torghut-dspy-dataset-build-v1",
@@ -380,15 +381,17 @@ def upsert_workflow_artifact_record(
     metadata_payload = dict(metadata) if metadata is not None else {}
     if compile_result is not None and "executor" not in metadata_payload:
         metadata_payload["executor"] = "dspy_live"
-    row.metadata_json = (
-        coerce_json_payload(metadata_payload) if metadata_payload else None
-    )
 
     if compile_result is not None:
+        signature_versions = {
+            str(key).strip(): str(value).strip()
+            for key, value in compile_result.signature_versions.items()
+            if str(key).strip() and str(value).strip()
+        }
+        metadata_payload[SIGNATURE_VERSIONS_METADATA_KEY] = signature_versions
         row.program_name = compile_result.program_name
-        row.signature_version = ",".join(
-            f"{key}:{value}"
-            for key, value in sorted(compile_result.signature_versions.items())
+        row.signature_version = hash_payload(
+            {SIGNATURE_VERSIONS_METADATA_KEY: signature_versions}
         )
         row.optimizer = compile_result.optimizer
         row.artifact_uri = compile_result.compiled_artifact_uri
@@ -397,6 +400,10 @@ def upsert_workflow_artifact_record(
         row.compiled_prompt_hash = compile_result.compiled_prompt_hash
         row.reproducibility_hash = compile_result.reproducibility_hash
         row.metric_bundle = coerce_json_payload(compile_result.metric_bundle)
+
+    row.metadata_json = (
+        coerce_json_payload(metadata_payload) if metadata_payload else None
+    )
 
     if eval_report is not None:
         row.gate_compatibility = eval_report.gate_compatibility
@@ -414,13 +421,13 @@ def upsert_workflow_artifact_record(
         row.metric_bundle = coerce_json_payload(metric_bundle)
 
     resource = cast(dict[str, Any], (response_payload or {}).get("resource") or {})
-    metadata_payload = cast(dict[str, Any], resource.get("metadata") or {})
-    if metadata_payload:
-        row.agentrun_name = str(metadata_payload.get("name") or "").strip() or None
+    resource_metadata = cast(dict[str, Any], resource.get("metadata") or {})
+    if resource_metadata:
+        row.agentrun_name = str(resource_metadata.get("name") or "").strip() or None
         row.agentrun_namespace = (
-            str(metadata_payload.get("namespace") or "").strip() or None
+            str(resource_metadata.get("namespace") or "").strip() or None
         )
-        row.agentrun_uid = str(metadata_payload.get("uid") or "").strip() or None
+        row.agentrun_uid = str(resource_metadata.get("uid") or "").strip() or None
 
     session.add(row)
     session.flush()

--- a/services/torghut/app/trading/llm/dspy_programs/runtime.py
+++ b/services/torghut/app/trading/llm/dspy_programs/runtime.py
@@ -19,6 +19,7 @@ from .committee_programs import (
 )
 
 _HASH_LENGTH = 64
+_SIGNATURE_VERSIONS_METADATA_KEY = "signature_versions"
 _BOOTSTRAP_PROGRAM_NAME = "trade-review-committee-v1"
 _BOOTSTRAP_SIGNATURE_VERSION = "v1"
 _DSPY_OPENAI_BASE_PATH = "/openai/v1"
@@ -308,9 +309,16 @@ class DSPyReviewRuntime:
                 "dspy_artifact_gate_compatibility_failed"
             )
 
-        signature_versions = _parse_signature_versions(row.signature_version)
-        if not signature_versions:
-            signature_versions = {"trade_review": self.signature_version}
+        metadata = _artifact_metadata(row.metadata_json)
+        signature_versions = _resolve_signature_versions(
+            metadata=metadata,
+            legacy_signature_version=row.signature_version,
+            fallback_signature_version=self.signature_version,
+        )
+        _validate_signature_versions_identity(
+            persisted_identity=row.signature_version,
+            signature_versions=signature_versions,
+        )
 
         program_name = (row.program_name or "").strip()
         if not program_name:
@@ -351,12 +359,6 @@ class DSPyReviewRuntime:
         }
         if artifact_hash not in accepted_hashes:
             raise DSPyRuntimeUnsupportedStateError("dspy_artifact_hash_mismatch")
-
-        metadata: dict[str, Any] = {}
-        metadata_raw = row.metadata_json
-        if isinstance(metadata_raw, dict):
-            metadata_items = cast(dict[Any, Any], metadata_raw)
-            metadata = {str(key): value for key, value in metadata_items.items()}
 
         executor_value = metadata.get("executor")
         if not isinstance(executor_value, str):
@@ -457,6 +459,61 @@ def _parse_signature_versions(raw: str | None) -> dict[str, str]:
         elif item:
             parsed["trade_review"] = item
     return parsed
+
+
+def _artifact_metadata(raw: object) -> dict[str, Any]:
+    if not isinstance(raw, Mapping):
+        return {}
+    return {str(key): value for key, value in cast(Mapping[Any, Any], raw).items()}
+
+
+def _metadata_signature_versions(metadata: Mapping[str, Any]) -> dict[str, str]:
+    raw = metadata.get(_SIGNATURE_VERSIONS_METADATA_KEY)
+    if not isinstance(raw, Mapping):
+        return {}
+    normalized: dict[str, str] = {}
+    for key, value in cast(Mapping[Any, Any], raw).items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            continue
+        normalized_key = key.strip()
+        normalized_value = value.strip()
+        if normalized_key and normalized_value:
+            normalized[normalized_key] = normalized_value
+    return normalized
+
+
+def _resolve_signature_versions(
+    *,
+    metadata: Mapping[str, Any],
+    legacy_signature_version: str | None,
+    fallback_signature_version: str,
+) -> dict[str, str]:
+    signature_versions = _metadata_signature_versions(metadata)
+    if signature_versions:
+        return signature_versions
+    signature_versions = _parse_signature_versions(legacy_signature_version)
+    if signature_versions:
+        return signature_versions
+    return {"trade_review": fallback_signature_version}
+
+
+def _validate_signature_versions_identity(
+    *,
+    persisted_identity: str | None,
+    signature_versions: Mapping[str, str],
+) -> None:
+    normalized_identity = (persisted_identity or "").strip().lower()
+    if len(normalized_identity) != _HASH_LENGTH or any(
+        character not in string.hexdigits for character in normalized_identity
+    ):
+        return
+    expected_identity = hash_payload(
+        {_SIGNATURE_VERSIONS_METADATA_KEY: dict(signature_versions)}
+    )
+    if normalized_identity != expected_identity:
+        raise DSPyRuntimeUnsupportedStateError(
+            "dspy_signature_versions_identity_mismatch"
+        )
 
 
 def _pick_signature_version(

--- a/services/torghut/tests/llm_dspy_workflow/test_signature_version_storage.py
+++ b/services/torghut/tests/llm_dspy_workflow/test_signature_version_storage.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models import LLMDSPyWorkflowArtifact
+from app.trading.llm.dspy_compile import (
+    build_compile_result,
+    upsert_workflow_artifact_record,
+)
+from app.trading.llm.dspy_compile.hashing import hash_payload
+from app.trading.llm.dspy_programs.runtime import (
+    DSPyRuntimeUnsupportedStateError,
+    _resolve_signature_versions,
+    _validate_signature_versions_identity,
+)
+from tests.llm_dspy_workflow.support import _TestLLMDSPyWorkflowBase
+
+
+class TestSignatureVersionStorage(_TestLLMDSPyWorkflowBase):
+    def test_persists_bounded_identity_and_complete_mapping(self) -> None:
+        signature_versions = {
+            f"committee_{index}": f"version-{index}-{'x' * 24}" for index in range(8)
+        }
+        compile_result = build_compile_result(
+            program_name="trade-review-committee-v1",
+            signature_versions=signature_versions,
+            optimizer="miprov2",
+            dataset_payload={"rows": [{"a": 1}]},
+            metric_bundle={"schema_valid_rate": 1.0},
+            compiled_prompt_payload={"prompt": "json"},
+            compiled_artifact_uri="s3://bucket/compile.json",
+            seed="seed-1",
+        )
+
+        with Session(self.engine) as session:
+            upsert_workflow_artifact_record(
+                session,
+                run_key="torghut-dspy-signature-map-1",
+                lane="compile",
+                status="completed",
+                implementation_spec_ref="torghut-dspy-compile-mipro-v1",
+                idempotency_key="torghut-dspy-signature-map-1",
+                request_payload=None,
+                response_payload=None,
+                compile_result=compile_result,
+                eval_report=None,
+                promotion_record=None,
+                metadata={"source": "test"},
+            )
+            session.commit()
+
+            loaded = session.execute(select(LLMDSPyWorkflowArtifact)).scalar_one()
+            assert loaded.signature_version is not None
+            self.assertEqual(len(loaded.signature_version), 64)
+            self.assertEqual(
+                loaded.signature_version,
+                hash_payload({"signature_versions": signature_versions}),
+            )
+            self.assertIsInstance(loaded.metadata_json, dict)
+            assert isinstance(loaded.metadata_json, dict)
+            self.assertEqual(
+                loaded.metadata_json.get("signature_versions"),
+                signature_versions,
+            )
+            self.assertEqual(loaded.metadata_json.get("source"), "test")
+
+    def test_runtime_prefers_metadata_and_keeps_legacy_fallback(self) -> None:
+        signature_versions = {
+            "trade_review": "v7",
+            "risk_review": "v3",
+        }
+        identity = hash_payload({"signature_versions": signature_versions})
+
+        resolved = _resolve_signature_versions(
+            metadata={"signature_versions": signature_versions},
+            legacy_signature_version=identity,
+            fallback_signature_version="v1",
+        )
+        self.assertEqual(resolved, signature_versions)
+        _validate_signature_versions_identity(
+            persisted_identity=identity,
+            signature_versions=resolved,
+        )
+        self.assertEqual(
+            _resolve_signature_versions(
+                metadata={},
+                legacy_signature_version="trade_review:v2,risk_review:v4",
+                fallback_signature_version="v1",
+            ),
+            {"trade_review": "v2", "risk_review": "v4"},
+        )
+
+    def test_runtime_rejects_mapping_identity_mismatch(self) -> None:
+        with self.assertRaisesRegex(
+            DSPyRuntimeUnsupportedStateError,
+            "dspy_signature_versions_identity_mismatch",
+        ):
+            _validate_signature_versions_identity(
+                persisted_identity="a" * 64,
+                signature_versions={"trade_review": "v1"},
+            )


### PR DESCRIPTION
## Summary

- store a deterministic 64-character digest in the bounded DSPy signature-version column
- retain the complete signature-version mapping in artifact metadata
- make runtime loading prefer metadata while preserving legacy comma-encoded rows
- reject digest/metadata mismatches

## Related Issues

Historical Codex finding: PR #3653 comment `2852057824`.

## Testing

50 DSPy workflow/runtime tests passed. Changed-line coverage is 93.33%. All five Pyright profiles, Ruff, Pylint, file-length, tech-debt, migration graph, and diff checks passed.
