### PR TITLE
fix(torghut): finalize whitepaper AgentRun state

### DIFF
--- a/services/torghut/app/whitepapers/workflow/whitepaper_workflow_api_methods.py
+++ b/services/torghut/app/whitepapers/workflow/whitepaper_workflow_api_methods.py
@@ -20,6 +20,7 @@ from ...models import (
     WhitepaperArtifact,
     WhitepaperClaim,
     WhitepaperClaimRelation,
+    WhitepaperCodexAgentRun,
     WhitepaperContradictionEvent,
     WhitepaperDesignPullRequest,
     WhitepaperExperimentSpec,
@@ -32,6 +33,7 @@ from ...trading.discovery.whitepaper_candidate_compiler import (
 
 
 from .shared_context import (
+    RETRYABLE_AGENTRUN_STATUSES,
     http_request_bytes as _http_request_bytes,
     int_env as _int_env,
     normalize_identifier as _normalize_identifier,
@@ -54,6 +56,10 @@ else:
 
 
 class WhitepaperWorkflowApiMethods(_WhitepaperWorkflowApiBase):
+    _TERMINAL_AGENTRUN_STATUSES = frozenset(
+        {*RETRYABLE_AGENTRUN_STATUSES, "completed", "terminated", "succeeded"}
+    )
+
     @staticmethod
     def _has_structured_research_outputs(payload: Mapping[str, Any]) -> bool:
         keys = (
@@ -620,18 +626,36 @@ class WhitepaperWorkflowApiMethods(_WhitepaperWorkflowApiBase):
         payload: Mapping[str, Any],
     ) -> None:
         target_status = _optional_text(payload.get("status")) or "completed"
-        run.status = target_status
-        run.result_payload_json = coerce_json_payload(cast(dict[str, Any], payload))
-        run.completed_at = datetime.now(timezone.utc)
-        run.failure_reason = (
+        completed_at = datetime.now(timezone.utc)
+        failure_reason = (
             None
             if target_status == "completed"
             else _optional_text(payload.get("failure_reason"))
         )
+        run.status = target_status
+        run.result_payload_json = coerce_json_payload(cast(dict[str, Any], payload))
+        run.completed_at = completed_at
+        run.failure_reason = failure_reason
         session.add(run)
 
+        agentruns = session.execute(
+            select(WhitepaperCodexAgentRun).where(
+                WhitepaperCodexAgentRun.analysis_run_id == run.id,
+                WhitepaperCodexAgentRun.execution_mode == "workflow",
+            )
+        ).scalars()
+        output_context = coerce_json_payload(cast(dict[str, Any], payload))
+        for agentrun in agentruns:
+            if agentrun.status.strip().lower() in self._TERMINAL_AGENTRUN_STATUSES:
+                continue
+            agentrun.status = target_status
+            agentrun.completed_at = completed_at
+            agentrun.failure_reason = failure_reason
+            agentrun.output_context_json = output_context
+            session.add(agentrun)
+
         run.document.status = "analyzed" if target_status == "completed" else "failed"
-        run.document.last_processed_at = datetime.now(timezone.utc)
+        run.document.last_processed_at = completed_at
         session.add(run.document)
 
     @staticmethod

--- a/services/torghut/tests/whitepaper_workflow/test_agentrun_finalization.py
+++ b/services/torghut/tests/whitepaper_workflow/test_agentrun_finalization.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models import WhitepaperAnalysisRun, WhitepaperCodexAgentRun
+from tests.whitepaper_workflow.support import (
+    _FakeCephClient,
+    _TestWhitepaperWorkflowBase,
+    _TestWhitepaperWorkflowService,
+)
+
+
+class TestAgentRunFinalization(_TestWhitepaperWorkflowBase):
+    def _seed_dispatched_run(
+        self, session: Session
+    ) -> tuple[_TestWhitepaperWorkflowService, WhitepaperAnalysisRun]:
+        service = _TestWhitepaperWorkflowService()
+        service.ceph_client = _FakeCephClient()
+        kickoff = service.ingest_github_issue_event(
+            session,
+            self._issue_payload(),
+            source="api",
+        )
+        self.assertTrue(kickoff.accepted)
+        session.flush()
+        run = session.execute(select(WhitepaperAnalysisRun)).scalar_one()
+        return service, run
+
+    def test_complete_run_terminalizes_only_active_workflow_agentruns(self) -> None:
+        with Session(self.engine) as session:
+            service, run = self._seed_dispatched_run(session)
+            active = session.execute(select(WhitepaperCodexAgentRun)).scalar_one()
+            active.status = "Running"
+            session.add(active)
+
+            prior_completed_at = datetime.now(timezone.utc) - timedelta(hours=1)
+            prior_attempts = [
+                WhitepaperCodexAgentRun(
+                    analysis_run_id=run.id,
+                    agentrun_name=f"agentrun-prior-{status}",
+                    status=status,
+                    execution_mode="workflow",
+                    completed_at=prior_completed_at,
+                    failure_reason=f"prior_{status}",
+                )
+                for status in ("failed", "error", "timeout", "timed_out")
+            ]
+            engineering = WhitepaperCodexAgentRun(
+                analysis_run_id=run.id,
+                agentrun_name="agentrun-engineering",
+                status="Pending",
+                execution_mode="engineering_candidate",
+            )
+            session.add_all([*prior_attempts, engineering])
+            session.flush()
+
+            payload = {"status": "completed", "synthesis": {"summary": "done"}}
+            service._complete_run(session, run, payload)
+            session.flush()
+
+            self.assertEqual(active.status, "completed")
+            self.assertIsNotNone(active.completed_at)
+            self.assertIsNone(active.failure_reason)
+            self.assertEqual(active.output_context_json, payload)
+            self.assertEqual(active.completed_at, run.completed_at)
+
+            for prior in prior_attempts:
+                self.assertIn(prior.status, {"failed", "error", "timeout", "timed_out"})
+                self.assertEqual(prior.completed_at, prior_completed_at)
+                self.assertEqual(prior.failure_reason, f"prior_{prior.status}")
+            self.assertEqual(engineering.status, "Pending")
+            self.assertIsNone(engineering.completed_at)
+
+    def test_failed_run_propagates_failure_to_active_workflow_agentrun(self) -> None:
+        with Session(self.engine) as session:
+            service, run = self._seed_dispatched_run(session)
+            agentrun = session.execute(select(WhitepaperCodexAgentRun)).scalar_one()
+            payload = {
+                "status": "failed",
+                "failure_reason": "analysis_failed",
+            }
+
+            service._complete_run(session, run, payload)
+            session.flush()
+
+            self.assertEqual(run.status, "failed")
+            self.assertEqual(agentrun.status, "failed")
+            self.assertEqual(agentrun.failure_reason, "analysis_failed")
+            self.assertEqual(agentrun.output_context_json, payload)
+            self.assertEqual(agentrun.completed_at, run.completed_at)


### PR DESCRIPTION
## Summary

- terminalize active workflow AgentRuns when the analysis run is finalized
- propagate the same completion timestamp, output payload, and failure reason
- preserve already terminal attempts and engineering-candidate AgentRuns

## Related Issues

Historical Codex finding: PR #3553 comment `2844182504`.

## Testing

45 whitepaper workflow tests passed. Changed-line coverage is 100%. All five Pyright profiles, Ruff, Pylint, file-length, tech-debt, migration graph, and diff checks passed.
