### PR TITLE
perf(registry): skip existing OCI blobs

### DIFF
--- a/docs/torghut/storage-write-pressure-remediation-design.md
+++ b/docs/torghut/storage-write-pressure-remediation-design.md
@@ -376,6 +376,17 @@ safe because an image manifest or index is only a few KiB and Distribution rejec
 already present. This restores publication liveness without reopening the large-blob fan-out that caused the Ceph write
 burst.
 
+The next Torghut rollout exposed avoidable work ahead of that boundary. Runs `29482560820` and `29485437093` each fed
+roughly 200 MiB per architecture through the shaped writer even though most Nix store layers were unchanged. A
+`dockerTools` Docker archive identifies uncompressed layers, while Skopeo compresses them for the OCI destination; the
+publisher therefore cannot perform the destination-digest existence check before streaming unless explicitly asked to
+precompute it. Live registry logs showed repeated blob misses followed by the same compressed layer commits, eight
+queued writers, and upload-initiation waits above two minutes. The safe correction is Skopeo's
+`--dest-precompute-digests`: compute the compressed digest locally, issue the registry existence check, and upload only
+missing blobs. This does not raise registry bandwidth or concurrency, weaken durability, or change image content. The
+next production build must retain the one-layer publisher limit and prove fewer uploaded bytes plus the same published
+platform/index digests before the optimization is considered effective.
+
 After request-body shaping rolls out, dispatch the current Analysis `main` workflow through build and push, then start
 a new 30-minute observation from a fresh SMART baseline. The gate must show no controller event above two seconds. If
 the shaped workload still fails that gate, stop the rollout and investigate the remaining measured writer instead of

--- a/nix/oci-push.sh
+++ b/nix/oci-push.sh
@@ -81,7 +81,10 @@ reference="${image}:${tag}"
 echo "Pushing Nix-built OCI image tar to ${reference}."
 # The lab registry deliberately admits one shaped bulk writer. Keep each publisher
 # to one layer so concurrent releases queue images fairly instead of six layers each.
-skopeo --policy "${policy_json}" copy --image-parallel-copies 1 --format oci \
+# dockerTools archives contain uncompressed layers; precompute their destination
+# digests so Skopeo can skip blobs already present instead of uploading them again.
+skopeo --policy "${policy_json}" copy --dest-precompute-digests \
+  --image-parallel-copies 1 --format oci \
   "docker-archive:${resolved_tar_path}" "docker://${reference}"
 
 if [[ -n "${latest_tag}" ]]; then

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -779,13 +779,17 @@ describe('native OCI build workflows', () => {
   })
 
   it('serializes layer uploads against the shaped registry writer', () => {
-    expect(ociPushScript).toContain('copy --image-parallel-copies 1 --format oci')
+    expect(ociPushScript).toContain('--image-parallel-copies 1 --format oci')
+  })
+
+  it('precomputes destination digests to avoid redundant registry writes', () => {
+    expect(ociPushScript).toContain('copy --dest-precompute-digests')
   })
 
   it('tags platform latest refs without re-copying image layers', () => {
     expect(ociPushScript).toContain('crane tag "${reference}" "${latest_tag}"')
     expect(ociPushScript).not.toContain(
-      'skopeo --policy "${policy_json}" copy --image-parallel-copies 1 --format oci "docker://${reference}"',
+      'skopeo --policy "${policy_json}" copy --dest-precompute-digests --image-parallel-copies 1 --format oci "docker://${reference}"',
     )
   })
 


### PR DESCRIPTION
## Summary

- Precompute destination layer digests before Nix OCI pushes so Skopeo skips blobs already present in Distribution.
- Preserve the registry one-writer, 1 MiB/s Ceph safety boundary and one-layer publisher limit.
- Record the measured Torghut re-upload/queue evidence and add a regression assertion for the push contract.

## Related Issues

None

## Testing

- bash -n nix/oci-push.sh
- shellcheck nix/oci-push.sh
- bun test packages/scripts/src/shared/__tests__/oci.test.ts (50 passed, 1,314 assertions)
- bunx oxfmt --check packages/scripts/src/shared/__tests__/oci.test.ts docs/torghut/storage-write-pressure-remediation-design.md
- git diff --check

## Breaking Changes

None. Registry concurrency, bandwidth shaping, image content, tags, and digest publication remain unchanged.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is handled above.
- [x] Documentation and regression coverage are updated.