### PR TITLE
fix(temporal): share OTEL API provider state

### DIFF
--- a/packages/otel/src/api.ts
+++ b/packages/otel/src/api.ts
@@ -23,8 +23,24 @@ type GlobalTracerProvider = {
   getTracer: (name: string, version?: string) => TracerLike
 }
 
+type SharedOtelApiState = {
+  tracerProvider?: unknown
+}
+
+const OTEL_TRACE_API_STATE_KEY = Symbol.for('proompteng.otel.trace-api.state.v1')
 let globalMeterProvider: GlobalMeterProvider = new NoopMeterProvider()
-let globalTracerProvider: GlobalTracerProvider = new NoopTracerProvider()
+const localTracerProvider = new NoopTracerProvider()
+
+const sharedState = (() => {
+  const registry = globalThis as typeof globalThis & { [key: symbol]: unknown }
+  const existing = registry[OTEL_TRACE_API_STATE_KEY]
+  if (typeof existing === 'object' && existing !== null) {
+    return existing as SharedOtelApiState
+  }
+  const created: SharedOtelApiState = {}
+  registry[OTEL_TRACE_API_STATE_KEY] = created
+  return created
+})()
 
 export const metrics = {
   setGlobalMeterProvider(provider: GlobalMeterProvider) {
@@ -37,10 +53,11 @@ export const metrics = {
 
 export const trace = {
   setGlobalTracerProvider(provider: GlobalTracerProvider) {
-    globalTracerProvider = provider
+    sharedState.tracerProvider = provider
   },
   getTracer(name: string, version?: string) {
-    return globalTracerProvider.getTracer(name, version)
+    const provider = (sharedState.tracerProvider as GlobalTracerProvider | undefined) ?? localTracerProvider
+    return provider.getTracer(name, version)
   },
 }
 

--- a/packages/temporal-bun-sdk/src/otel/api.ts
+++ b/packages/temporal-bun-sdk/src/otel/api.ts
@@ -19,8 +19,24 @@ type GlobalTracerProvider = {
   getTracer: (name: string, version?: string) => TracerLike
 }
 
+type SharedOtelApiState = {
+  tracerProvider?: unknown
+}
+
+const OTEL_TRACE_API_STATE_KEY = Symbol.for('proompteng.otel.trace-api.state.v1')
 let globalMeterProvider: GlobalMeterProvider = new NoopMeterProvider()
-let globalTracerProvider: GlobalTracerProvider = new NoopTracerProvider()
+const localTracerProvider = new NoopTracerProvider()
+
+const sharedState = (() => {
+  const registry = globalThis as typeof globalThis & { [key: symbol]: unknown }
+  const existing = registry[OTEL_TRACE_API_STATE_KEY]
+  if (typeof existing === 'object' && existing !== null) {
+    return existing as SharedOtelApiState
+  }
+  const created: SharedOtelApiState = {}
+  registry[OTEL_TRACE_API_STATE_KEY] = created
+  return created
+})()
 
 export const metrics = {
   setGlobalMeterProvider(provider: GlobalMeterProvider) {
@@ -33,10 +49,11 @@ export const metrics = {
 
 export const trace = {
   setGlobalTracerProvider(provider: GlobalTracerProvider) {
-    globalTracerProvider = provider
+    sharedState.tracerProvider = provider
   },
   getTracer(name: string, version?: string) {
-    return globalTracerProvider.getTracer(name, version)
+    const provider = (sharedState.tracerProvider as GlobalTracerProvider | undefined) ?? localTracerProvider
+    return provider.getTracer(name, version)
   },
 }
 

--- a/packages/temporal-bun-sdk/tests/client/operation-interceptors.test.ts
+++ b/packages/temporal-bun-sdk/tests/client/operation-interceptors.test.ts
@@ -1,6 +1,24 @@
-import { describe, expect, test } from 'bun:test'
+import { afterEach, describe, expect, test } from 'bun:test'
 import { Effect } from 'effect'
 
+import { metrics as sharedMetrics, trace as sharedTrace } from '../../../otel/src/api'
+import { ExportResultCode } from '../../../otel/src/core'
+import {
+  MeterProvider as SharedMeterProvider,
+  NoopMeterProvider as SharedNoopMeterProvider,
+} from '../../../otel/src/sdk-metrics'
+import {
+  createSimpleSpanProcessor,
+  NoopTracerProvider,
+  type SpanData,
+  type SpanExporter,
+  TracerProvider,
+} from '../../../otel/src/sdk-trace'
+import { metrics as temporalMetrics } from '../../src/otel/api'
+import {
+  MeterProvider as TemporalMeterProvider,
+  NoopMeterProvider as TemporalNoopMeterProvider,
+} from '../../src/otel/sdk-metrics'
 import { makeDefaultClientInterceptors, runClientInterceptors } from '../../src/interceptors/client'
 import type { TemporalInterceptor } from '../../src/interceptors/types'
 import type { Logger } from '../../src/observability/logger'
@@ -60,6 +78,12 @@ const createMetrics = () => {
 }
 
 describe('client operation interceptors', () => {
+  afterEach(() => {
+    sharedTrace.setGlobalTracerProvider(new NoopTracerProvider())
+    sharedMetrics.setGlobalMeterProvider(new SharedNoopMeterProvider())
+    temporalMetrics.setGlobalMeterProvider(new TemporalNoopMeterProvider())
+  })
+
   test('retries transient rpc and records attempt metadata', async () => {
     const { logger } = createLogger()
     const metrics = createMetrics()
@@ -138,5 +162,59 @@ describe('client operation interceptors', () => {
     expect(headers['temporal-namespace']).toBe('integration')
     expect(headers['temporal-client-identity']).toBe('client-2')
     expect(metrics.counters.get('temporal_client_interceptor_operation_total')).toBe(1)
+  })
+
+  test('uses the tracer provider registered by the shared OTEL API', async () => {
+    const exportedSpans: SpanData[] = []
+    const exporter: SpanExporter = {
+      export(spans, resultCallback) {
+        exportedSpans.push(...spans)
+        resultCallback({ code: ExportResultCode.SUCCESS })
+      },
+      async shutdown() {},
+    }
+    const provider = new TracerProvider()
+    provider.addSpanProcessor(createSimpleSpanProcessor(exporter))
+    sharedTrace.setGlobalTracerProvider(provider)
+
+    const { logger } = createLogger()
+    const metrics = createMetrics()
+    const interceptors = await run(
+      makeDefaultClientInterceptors({
+        namespace: 'integration',
+        taskQueue: 'demo',
+        identity: 'client-shared-otel',
+        logger,
+        metricsRegistry: metrics.registry,
+        metricsExporter: metrics.exporter,
+        tracingEnabled: true,
+      }),
+    )
+
+    await run(
+      runClientInterceptors(
+        interceptors as readonly TemporalInterceptor[],
+        {
+          kind: 'workflow.signal',
+          namespace: 'integration',
+          taskQueue: 'demo',
+          identity: 'client-shared-otel',
+          headers: {},
+        },
+        () => Effect.succeed('signalled'),
+      ),
+    )
+
+    expect(exportedSpans.map((span) => span.name)).toContain('temporal.client.workflow.signal')
+    await provider.shutdown()
+  })
+
+  test('keeps incompatible OTEL meter providers isolated', () => {
+    sharedMetrics.setGlobalMeterProvider(new SharedMeterProvider())
+    temporalMetrics.setGlobalMeterProvider(new TemporalMeterProvider())
+
+    const gauge = sharedMetrics.getMeter('shared-meter').createGauge('shared_gauge')
+
+    expect(() => gauge.set(1)).not.toThrow()
   })
 })


### PR DESCRIPTION
## Summary

- make the shared OTEL package and the published Temporal SDK API copies use one global provider registry
- keep local no-op providers out of global state so import order does not install incompatible defaults
- prove a tracer provider registered through the shared API receives Temporal client-interceptor spans
- preserve the published package's no-workspace-runtime-dependency contract

## Related Issues

Historical Codex finding: PR #3526 comment `2838739298`.

## Testing

- 311 OTEL/Temporal unit tests passed with 33 integration skips under NODE_ENV=test
- 3 client-interceptor tests and 12 packaging-manifest tests passed on the exact rebased head
- both package TypeScript builds, Oxfmt, Oxlint, and type-aware Oxlint passed
- the only excluded local test creates a `#!/usr/bin/env bash` fixture; this container lacks `/usr/bin/env`
