### PR TITLE
fix(torghut): close paper IOC validation quarantine

### DIFF
--- a/.github/workflows/torghut-ci.yml
+++ b/.github/workflows/torghut-ci.yml
@@ -685,6 +685,7 @@ jobs:
             tests/execution/test_broker_mutation_coordinator_postgres.py \
             tests/execution/test_broker_reduction_coordinator_postgres.py \
             tests/execution/test_broker_account_activities_postgres.py \
+            tests/execution/test_validation_quarantine_postgres.py \
             tests/execution/test_linked_submission_terminal_postgres.py \
             tests/execution/test_validation_observation_timestamp_postgres.py \
             tests/trading/test_strategy_capital_authority_postgres.py

--- a/docs/torghut/profitability/implementation-roadmap.md
+++ b/docs/torghut/profitability/implementation-roadmap.md
@@ -174,6 +174,9 @@ receipt or unresolved state afterward.
 - Runtime proof: injected response loss recovers the original paper order without producing a second order.
 - Dependency: slice 4. Effort: `M`.
 - Rollback: stop recovery retries, retain unresolved claims, and require manual broker reconciliation.
+- Operator action: the only local terminal for absent evidence is the reviewed
+  [paper-IOC validation quarantine closure](validation-quarantine-closure.md). It cannot settle linked, ordinary,
+  promotable, non-IOC, or live-account submissions and does not claim broker rejection.
 
 ### Slice 6 - Fence Cancel, Replace, And Closeout Mutations
 

--- a/docs/torghut/profitability/strict-submit-recovery.md
+++ b/docs/torghut/profitability/strict-submit-recovery.md
@@ -58,8 +58,10 @@ The public six-state projection is intentionally distinct from the four durable 
 automatic negative terminal.
 
 An `expired` or `manual_review` receipt remains due on a long retry interval so later broker truth can reconcile it. It
-continues to block entry. Slice 5 deliberately provides no operator endpoint that can manufacture a terminal outcome;
-until a separately reviewed confirmation workflow exists, the receipt remains unresolved.
+continues to block entry. The only reviewed operator terminal is the narrow
+[infrastructure-validation quarantine closure](validation-quarantine-closure.md): an unlinked, non-promotable
+Alpaca-paper IOC may close its future-exposure quarantine after fresh exact-order, history, open-order, position, and
+account proof. That outcome preserves order existence as unresolved and is unavailable to ordinary or live submits.
 
 ## Recovery Algorithm
 
@@ -176,7 +178,8 @@ and zero additional submit attempts. Broker readback and CNPG history are both r
 
 For a pre-existing unresolved receipt, production validation is observation-only: query the exact original ID and let
 the deployed worker append evidence. Do not create a new client ID or another broker mutation merely to make the proof
-terminal.
+terminal. If and only if the receipt satisfies the paper-IOC validation boundary, use the separately reviewed operator
+procedure; never relabel it broker-rejected.
 
 ## Rollback
 

--- a/docs/torghut/profitability/validation-quarantine-closure.md
+++ b/docs/torghut/profitability/validation-quarantine-closure.md
@@ -1,0 +1,95 @@
+# Infrastructure-Validation Quarantine Closure
+
+Status: normative operator-action contract for the narrow unresolved-paper-IOC case in profitability roadmap Slice 5.
+
+## Decision
+
+Torghut may close an unresolved submit quarantine without asserting broker rejection only when the receipt is an
+unlinked, non-promotable, Alpaca-paper `control_plane_validation` order with `time_in_force=ioc`. The terminal outcome
+is `validation_quarantine_closed`, the source is `operator_confirmation`, and the evidence keeps
+`order_existence_resolution=unresolved`.
+
+This terminal says only that the receipt can no longer create future exposure and the paper account is freshly flat. It
+does not say that Alpaca rejected the order, that the order never existed, or that its economics are admissible for
+profitability, trials, promotion, or accounting parity.
+
+Alpaca warns that a timed-out submit may have reached the market and must not be resent or marked canceled before
+confirmation. Torghut preserves that ambiguity and never retries the client order ID. Alpaca also defines IOC as an
+order whose unfilled portion is canceled immediately, so an old IOC cannot remain resting. The operator still must
+prove the current account has zero open orders and zero positions. Sources:
+[Working with orders](https://docs.alpaca.markets/us/v1.1/docs/working-with-orders),
+[Get order by client order ID](https://docs.alpaca.markets/us/reference/getorderbyclientorderid), and
+[Get all orders](https://docs.alpaca.markets/us/v1.1/reference/getallorders-1).
+
+## Exact Eligibility Boundary
+
+All conditions are mandatory in application code and PostgreSQL:
+
+- broker route `alpaca`, endpoint fingerprint for `https://paper-api.alpaca.markets`;
+- operation `submit_order`, risk class `risk_neutral`, purpose `control_plane_validation`;
+- no linked decision-submission claim;
+- sealed validation permit says `account_mode=paper`, `promotable=false`, and
+  `evidence_tag=non_promotable_validation`;
+- sealed broker request is `time_in_force=ioc`;
+- broker I/O started at least one minute earlier;
+- latest recovery is a complete `not_found` observation projected as `expired`, with automatic resubmission false;
+- caller supplies the exact receipt ID and exact sealed intent SHA-256;
+- fresh exact client-order lookup is absent;
+- a bounded all-status history page is complete and contains no matching client order ID;
+- broker account identity is exact and active, with no account/trading/transfer block;
+- the entire account has zero open orders and zero positions.
+
+Ordinary strategy submits, live endpoints, linked claims, GTC/DAY orders, partial evidence, a found order, a full
+500-row history page, any open order, or any position fail closed. The workflow exposes no submit, cancel, replace, or
+close method.
+
+## State And Concurrency
+
+The append-only receipt stream remains the only authority:
+
+`broker_io(expired) -> settled(validation_quarantine_closed)`
+
+The operator transition locks the receipt identity, requires a contiguous next sequence, rejects a previously settled
+receipt, and records its own writer generation. Concurrent recovery either commits first and causes the operator's
+prior-evidence hash to fail, or observes the terminal state and stops. No recovery row, approval queue, parallel status
+table, or mutable override is introduced.
+
+PostgreSQL independently checks the receipt class, paper endpoint, IOC policy, prior recovery evidence hash, account
+snapshot claims, zero counts, non-promotable marker, operator identity, and evidence freshness. The settlement envelope
+is hashed and append-only. Downgrade refuses while this outcome exists.
+
+## Operator Procedure
+
+Run from the exact deployed Torghut image. Dry-run first:
+
+```bash
+python -m app.trading.infrastructure_validation_quarantine \
+  --receipt-id "$RECEIPT_ID" \
+  --expected-intent-sha256 "$INTENT_SHA256" \
+  --operator-id "$OPERATOR_ID"
+```
+
+Apply only when the dry-run returns the expected receipt, intent hash, and evidence hash:
+
+```bash
+python -m app.trading.infrastructure_validation_quarantine \
+  --receipt-id "$RECEIPT_ID" \
+  --expected-intent-sha256 "$INTENT_SHA256" \
+  --operator-id "$OPERATOR_ID" \
+  --apply \
+  --confirm CLOSE_PAPER_IOC_VALIDATION_QUARANTINE
+```
+
+If Alpaca Support supplied a reference, add `--support-confirmation-reference`; it is recorded but never used to turn
+the outcome into broker rejection.
+
+After each apply, read the broker account again, query the exact receipt history through CNPG, and verify
+`/trading/status` reports no unresolved submit receipt. A fresh controlled validation lifecycle and normal strategy
+entry proof remain separate gates.
+
+## Rollback
+
+Remove the CLI/operator transition through a forward application change. Existing terminal evidence remains immutable.
+Do not rewrite it to `rejected`, delete it, or re-open the client order ID. If the terminal is later contradicted by
+broker activity, append a correction/incident record and keep entry blocked until the account and independent economic
+ledger reconcile.

--- a/services/torghut/app/models/entities/broker_mutation_records.py
+++ b/services/torghut/app/models/entities/broker_mutation_records.py
@@ -454,12 +454,14 @@ class BrokerMutationReceiptEvent(Base):
         ),
         CheckConstraint(
             "settlement_outcome IS NULL OR settlement_outcome IN "
-            "('acknowledged', 'reconciled', 'rejected', 'already_satisfied')",
+            "('acknowledged', 'reconciled', 'rejected', 'already_satisfied', "
+            "'validation_quarantine_closed')",
             name="settlement_outcome",
         ),
         CheckConstraint(
             "settlement_source IS NULL OR "
-            "settlement_source IN ('primary', 'recovery', 'preflight')",
+            "settlement_source IN "
+            "('primary', 'recovery', 'preflight', 'operator_confirmation')",
             name="settlement_source",
         ),
         CheckConstraint(
@@ -469,7 +471,9 @@ class BrokerMutationReceiptEvent(Base):
             "(settlement_outcome = 'acknowledged' "
             "AND settlement_source = 'primary') OR "
             "(settlement_outcome IN ('reconciled', 'rejected') "
-            "AND settlement_source IN ('primary', 'recovery'))",
+            "AND settlement_source IN ('primary', 'recovery')) OR "
+            "(settlement_outcome = 'validation_quarantine_closed' "
+            "AND settlement_source = 'operator_confirmation')",
             name="settlement_source_outcome",
         ),
         CheckConstraint(

--- a/services/torghut/app/trading/broker_mutation_receipts/__init__.py
+++ b/services/torghut/app/trading/broker_mutation_receipts/__init__.py
@@ -39,6 +39,7 @@ from .transitions import (
     renew_broker_mutation_receipt,
     settle_broker_mutation_preflight,
     settle_broker_mutation_primary,
+    settle_broker_mutation_operator_confirmation,
 )
 from .types import (
     BrokerMutationIntent,
@@ -150,6 +151,7 @@ __all__ = [
     "renew_broker_mutation_recovery",
     "settle_broker_mutation_preflight",
     "settle_broker_mutation_primary",
+    "settle_broker_mutation_operator_confirmation",
     "settle_linked_submission_primary",
     "settle_linked_submission_recovery",
     "settle_broker_mutation_recovery",

--- a/services/torghut/app/trading/broker_mutation_receipts/canonicalization.py
+++ b/services/torghut/app/trading/broker_mutation_receipts/canonicalization.py
@@ -84,12 +84,14 @@ _SETTLEMENT_SOURCES: tuple[BrokerMutationSettlementSource, ...] = (
     "primary",
     "recovery",
     "preflight",
+    "operator_confirmation",
 )
 _SETTLEMENT_OUTCOMES: tuple[BrokerMutationSettlementOutcome, ...] = (
     "acknowledged",
     "reconciled",
     "rejected",
     "already_satisfied",
+    "validation_quarantine_closed",
 )
 
 
@@ -574,6 +576,14 @@ def _validate_settlement_contract(
     if source == "recovery" and outcome == "acknowledged":
         raise BrokerMutationReceiptValidationError(
             "recovery_cannot_acknowledge_new_broker_io"
+        )
+    if outcome == "validation_quarantine_closed" and source != "operator_confirmation":
+        raise BrokerMutationReceiptValidationError(
+            "validation_quarantine_closed_requires_operator_confirmation"
+        )
+    if source == "operator_confirmation" and outcome != "validation_quarantine_closed":
+        raise BrokerMutationReceiptValidationError(
+            "operator_confirmation_requires_validation_quarantine_closed"
         )
 
 

--- a/services/torghut/app/trading/broker_mutation_receipts/lifecycle_helpers.py
+++ b/services/torghut/app/trading/broker_mutation_receipts/lifecycle_helpers.py
@@ -239,6 +239,7 @@ def normalized_settlement(
         "reconciled",
         "rejected",
         "already_satisfied",
+        "validation_quarantine_closed",
     }:
         raise BrokerMutationReceiptValidationError("settlement_outcome_invalid")
     if expected_source == "preflight" and settlement.outcome != "already_satisfied":

--- a/services/torghut/app/trading/broker_mutation_receipts/runtime_status.py
+++ b/services/torghut/app/trading/broker_mutation_receipts/runtime_status.py
@@ -127,6 +127,9 @@ def load_broker_mutation_runtime_status(session: Session) -> dict[str, object]:
     manual_review_count = unresolved_resolution_counts.get("manual_review", 0)
     expired_count = unresolved_resolution_counts.get("expired", 0)
     rejected_count = settlement_counts.get("rejected", 0)
+    validation_quarantine_closed_count = settlement_counts.get(
+        "validation_quarantine_closed", 0
+    )
     acknowledged_count = sum(
         settlement_counts.get(outcome, 0)
         for outcome in ("acknowledged", "reconciled", "already_satisfied")
@@ -138,7 +141,8 @@ def load_broker_mutation_runtime_status(session: Session) -> dict[str, object]:
         0,
         state_counts.get("settled", 0)
         - acknowledged_count
-        - settlement_counts.get("rejected", 0),
+        - rejected_count
+        - validation_quarantine_closed_count,
     )
     resolution_state_counts: Counter[str] = Counter(
         {
@@ -148,6 +152,7 @@ def load_broker_mutation_runtime_status(session: Session) -> dict[str, object]:
             "rejected": rejected_count,
             "expired": expired_count,
             "manual_review": manual_review_count,
+            "validation_quarantine_closed": validation_quarantine_closed_count,
         }
     )
     recovery_due_count = int(
@@ -238,6 +243,7 @@ def load_broker_mutation_runtime_status(session: Session) -> dict[str, object]:
                 "rejected",
                 "expired",
                 "manual_review",
+                "validation_quarantine_closed",
             )
         },
         pre_io_receipt_count=(

--- a/services/torghut/app/trading/broker_mutation_receipts/transitions.py
+++ b/services/torghut/app/trading/broker_mutation_receipts/transitions.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import json
+import uuid
 from dataclasses import dataclass
 from datetime import timedelta
+from typing import cast
 
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
@@ -48,7 +51,9 @@ from .validation import (
     BrokerMutationReceiptConflictError,
     BrokerMutationReceiptFenceError,
     BrokerMutationReceiptValidationError,
+    as_uuid,
     bounded_seconds,
+    positive_integer,
     required_text,
 )
 
@@ -297,6 +302,154 @@ def settle_broker_mutation_primary(
     )
 
 
+def settle_broker_mutation_operator_confirmation(
+    session: Session,
+    *,
+    receipt_id: uuid.UUID | str,
+    writer_generation: int,
+    settlement: BrokerMutationSettlement,
+) -> BrokerMutationReceiptSnapshot:
+    """Append one explicit operator terminal for an eligible validation receipt."""
+
+    try:
+        normalized_receipt_id = as_uuid(receipt_id, field="receipt_id")
+        normalized_writer_generation = positive_integer(
+            writer_generation,
+            field="writer_generation",
+        )
+        normalized_terminal = normalized_settlement(
+            settlement,
+            expected_source="operator_confirmation",
+        )
+        if normalized_terminal.outcome != "validation_quarantine_closed":
+            raise BrokerMutationReceiptValidationError(
+                "operator_confirmation_outcome_invalid"
+            )
+        current = lock_current_receipt(session, normalized_receipt_id)
+        if current is None:
+            raise BrokerMutationReceiptFenceError(
+                f"broker_mutation_receipt_not_found:{normalized_receipt_id}"
+            )
+        require_unlinked_terminal(current.snapshot)
+        if current.snapshot.state == "settled":
+            compatible = require_compatible_terminal(
+                current.snapshot,
+                normalized_terminal,
+            )
+            return read_and_close(session, compatible)
+        _require_validation_quarantine_eligible(current, normalized_terminal)
+        values = full_state_values_from_event(current.event)
+        values.update(
+            sequence_no=current.event.sequence_no + 1,
+            event_type="settled",
+            state="settled",
+            event_writer_generation=normalized_writer_generation,
+            settlement_source=normalized_terminal.source,
+            settlement_outcome=normalized_terminal.outcome,
+            broker_reference=None,
+            execution_id=None,
+            settlement_evidence_json=normalized_terminal.evidence_json,
+            settlement_evidence_sha256=normalized_terminal.evidence_sha256,
+            settled_at=current.now,
+        )
+        return append_and_commit(
+            session,
+            receipt_id=normalized_receipt_id,
+            values=values,
+        )
+    except (BrokerMutationReceiptError, SQLAlchemyError):
+        session.rollback()
+        raise
+
+
+def _require_validation_quarantine_eligible(
+    current: LockedReceipt,
+    settlement: BrokerMutationSettlement,
+) -> None:
+    receipt = current.snapshot
+    intent = receipt.intent
+    if (
+        receipt.state != "broker_io"
+        or intent.broker_route != "alpaca"
+        or intent.operation != "submit_order"
+        or intent.risk_class != "risk_neutral"
+        or intent.purpose != "control_plane_validation"
+        or intent.submission_claim_id is not None
+        or receipt.recovery.outcome != "not_found"
+        or receipt.recovery.evidence_json is None
+        or receipt.recovery.evidence_sha256 is None
+        or receipt.lifecycle.broker_io_started_at is None
+        or (current.now - receipt.lifecycle.broker_io_started_at).total_seconds() < 60
+        or settlement.broker_reference is not None
+        or settlement.execution_id is not None
+    ):
+        raise BrokerMutationReceiptValidationError(
+            "validation_quarantine_receipt_ineligible"
+        )
+    try:
+        document = json.loads(receipt.recovery.evidence_json)
+    except (TypeError, ValueError) as exc:
+        raise BrokerMutationReceiptValidationError(
+            "validation_quarantine_recovery_evidence_invalid"
+        ) from exc
+    if not isinstance(document, dict):
+        raise BrokerMutationReceiptValidationError(
+            "validation_quarantine_recovery_evidence_invalid"
+        )
+    raw_observation = cast(dict[str, object], document).get("observation")
+    if not isinstance(raw_observation, dict):
+        raise BrokerMutationReceiptValidationError(
+            "validation_quarantine_recovery_evidence_ineligible"
+        )
+    observation = cast(dict[str, object], raw_observation)
+    if (
+        observation.get("resolution_state") != "expired"
+        or observation.get("absence_proof_complete") is not True
+        or observation.get("operator_confirmation_required") is not True
+        or observation.get("automatic_resubmission_attempted") is not False
+    ):
+        raise BrokerMutationReceiptValidationError(
+            "validation_quarantine_recovery_evidence_ineligible"
+        )
+    try:
+        terminal = json.loads(settlement.evidence_json)
+    except (TypeError, ValueError) as exc:
+        raise BrokerMutationReceiptValidationError(
+            "validation_quarantine_settlement_evidence_invalid"
+        ) from exc
+    if not isinstance(terminal, dict):
+        raise BrokerMutationReceiptValidationError(
+            "validation_quarantine_settlement_evidence_invalid"
+        )
+    raw_evidence = cast(dict[str, object], terminal).get("evidence")
+    if not isinstance(raw_evidence, dict):
+        raise BrokerMutationReceiptValidationError(
+            "validation_quarantine_settlement_evidence_ineligible"
+        )
+    evidence = cast(dict[str, object], raw_evidence)
+    if (
+        evidence.get("schema_version")
+        != "torghut.infrastructure-validation-quarantine-closure.v1"
+        or evidence.get("receipt_id") != str(receipt.receipt_id)
+        or evidence.get("client_order_id") != intent.client_request_id
+        or evidence.get("intent_sha256") != intent.canonical_intent_sha256
+        or evidence.get("prior_recovery_evidence_sha256")
+        != receipt.recovery.evidence_sha256
+        or evidence.get("order_existence_resolution") != "unresolved"
+        or evidence.get("time_in_force") != "ioc"
+        or evidence.get("history_complete") is not True
+        or evidence.get("history_match_count") != 0
+        or evidence.get("open_order_count") != 0
+        or evidence.get("position_count") != 0
+        or evidence.get("promotable") is not False
+        or evidence.get("automatic_resubmission_attempted") is not False
+        or evidence.get("broker_mutation_attempted") is not False
+    ):
+        raise BrokerMutationReceiptValidationError(
+            "validation_quarantine_settlement_evidence_ineligible"
+        )
+
+
 def _settle_primary_path(
     session: Session,
     path: _PrimarySettlementPath,
@@ -369,4 +522,5 @@ __all__ = [
     "renew_broker_mutation_receipt",
     "settle_broker_mutation_preflight",
     "settle_broker_mutation_primary",
+    "settle_broker_mutation_operator_confirmation",
 ]

--- a/services/torghut/app/trading/broker_mutation_receipts/types.py
+++ b/services/torghut/app/trading/broker_mutation_receipts/types.py
@@ -67,8 +67,14 @@ BrokerMutationSettlementOutcome = Literal[
     "reconciled",
     "rejected",
     "already_satisfied",
+    "validation_quarantine_closed",
 ]
-BrokerMutationSettlementSource = Literal["primary", "recovery", "preflight"]
+BrokerMutationSettlementSource = Literal[
+    "primary",
+    "recovery",
+    "preflight",
+    "operator_confirmation",
+]
 BrokerMutationRecoveryObservationOutcome = Literal["not_found", "indeterminate"]
 BrokerMutationReceiptAcquireOutcome = Literal[
     "acquired",
@@ -595,6 +601,8 @@ def broker_mutation_runtime_result(
     if settlement_outcome == "reconciled":
         return "reconciled"
     if settlement_outcome == "already_satisfied":
+        return "already_processed"
+    if settlement_outcome == "validation_quarantine_closed":
         return "already_processed"
     if settlement_outcome == "rejected":
         return "rejected"

--- a/services/torghut/app/trading/infrastructure_validation_quarantine.py
+++ b/services/torghut/app/trading/infrastructure_validation_quarantine.py
@@ -1,0 +1,528 @@
+"""Close only paper-IOC validation quarantines without inventing broker truth."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+import uuid
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Protocol, cast
+
+from sqlalchemy.orm import Session
+
+from ..alpaca_client import AlpacaRecoveryOrderHistoryPage, TorghutAlpacaClient
+from ..db import SessionLocal
+from .broker_mutation_receipts import (
+    BrokerMutationReceiptSnapshot,
+    BrokerMutationSettlement,
+    BrokerMutationSettlementRequest,
+    build_broker_mutation_settlement,
+    fingerprint_broker_endpoint,
+    get_broker_mutation_receipt,
+    settle_broker_mutation_operator_confirmation,
+)
+
+
+VALIDATION_QUARANTINE_CONFIRMATION = "CLOSE_PAPER_IOC_VALIDATION_QUARANTINE"
+VALIDATION_QUARANTINE_SCHEMA_VERSION = (
+    "torghut.infrastructure-validation-quarantine-closure.v1"
+)
+_PAPER_ENDPOINT = "https://paper-api.alpaca.markets"
+_PAPER_ENDPOINT_FINGERPRINT = fingerprint_broker_endpoint(_PAPER_ENDPOINT)
+_HISTORY_LIMIT = 500
+_HISTORY_MARGIN = timedelta(minutes=5)
+_MINIMUM_IO_AGE = timedelta(minutes=1)
+_WRITER_GENERATION = max(1, time.time_ns())
+
+
+class InfrastructureValidationQuarantineError(RuntimeError):
+    """A validation receipt or fresh broker read is not safe to close."""
+
+
+class _ValidationBrokerReader(Protocol):
+    endpoint_url: str
+    endpoint_class: str
+
+    def get_account(self) -> dict[str, object]: ...
+
+    def get_order_by_client_order_id_strict(
+        self, client_order_id: str
+    ) -> dict[str, object] | None: ...
+
+    def list_orders_recovery_window(
+        self,
+        *,
+        after: datetime,
+        until: datetime,
+        limit: int = _HISTORY_LIMIT,
+    ) -> AlpacaRecoveryOrderHistoryPage: ...
+
+    def list_open_orders(self) -> list[dict[str, object]]: ...
+
+    def list_positions(self) -> list[dict[str, object]]: ...
+
+
+SessionFactory = Callable[[], Session]
+
+
+@dataclass(frozen=True, slots=True)
+class InfrastructureValidationQuarantineRequest:
+    receipt_id: uuid.UUID | str
+    expected_intent_sha256: str
+    operator_id: str
+    support_confirmation_reference: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class InfrastructureValidationQuarantineContext:
+    client: _ValidationBrokerReader
+    session_factory: SessionFactory
+    evaluated_at: datetime | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class InfrastructureValidationQuarantineReport:
+    receipt_id: uuid.UUID
+    client_order_id: str
+    intent_sha256: str
+    applied: bool
+    receipt_state: str
+    settlement_outcome: str | None
+    evidence_sha256: str
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "schema_version": VALIDATION_QUARANTINE_SCHEMA_VERSION,
+            "receipt_id": str(self.receipt_id),
+            "client_order_id": self.client_order_id,
+            "intent_sha256": self.intent_sha256,
+            "applied": self.applied,
+            "receipt_state": self.receipt_state,
+            "settlement_outcome": self.settlement_outcome,
+            "evidence_sha256": self.evidence_sha256,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class _NormalizedRequest:
+    receipt_id: uuid.UUID
+    expected_intent_sha256: str
+    operator_id: str
+    support_confirmation_reference: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class _BrokerProof:
+    observed_at: datetime
+    account_number: str
+    account_status: str
+    history_count: int
+
+
+def run_infrastructure_validation_quarantine_close(
+    *,
+    request: InfrastructureValidationQuarantineRequest,
+    context: InfrastructureValidationQuarantineContext,
+    apply: bool = False,
+) -> InfrastructureValidationQuarantineReport:
+    """Inspect or close one exact non-promotable paper-IOC quarantine."""
+
+    normalized = _normalize_request(request)
+    observed_at = _evaluated_at(context.evaluated_at)
+    with context.session_factory() as session:
+        receipt = get_broker_mutation_receipt(session, normalized.receipt_id)
+    if receipt is None:
+        raise InfrastructureValidationQuarantineError(
+            f"validation_quarantine_receipt_not_found:{normalized.receipt_id}"
+        )
+    document = _require_eligible_receipt(
+        receipt,
+        expected_intent_sha256=normalized.expected_intent_sha256,
+        observed_at=observed_at,
+    )
+    proof = _read_broker_proof(
+        context.client,
+        receipt=receipt,
+        observed_at=observed_at,
+    )
+    settlement = _build_quarantine_settlement(
+        receipt,
+        document=document,
+        request=normalized,
+        proof=proof,
+    )
+    if not apply:
+        return _report(
+            receipt,
+            settlement=settlement,
+            applied=False,
+        )
+    with context.session_factory() as session:
+        settled = settle_broker_mutation_operator_confirmation(
+            session,
+            receipt_id=receipt.receipt_id,
+            writer_generation=_WRITER_GENERATION,
+            settlement=settlement,
+        )
+    return _report(settled, settlement=settlement, applied=True)
+
+
+def _normalize_request(
+    request: InfrastructureValidationQuarantineRequest,
+) -> _NormalizedRequest:
+    try:
+        receipt_id = uuid.UUID(str(request.receipt_id))
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise ValueError("validation_quarantine_receipt_id_invalid") from exc
+    intent_sha256 = _sha256(request.expected_intent_sha256, field="intent_sha256")
+    operator_id = _required_text(request.operator_id, field="operator_id", maximum=128)
+    support_reference = _optional_text(
+        request.support_confirmation_reference,
+        field="support_confirmation_reference",
+        maximum=256,
+    )
+    return _NormalizedRequest(
+        receipt_id=receipt_id,
+        expected_intent_sha256=intent_sha256,
+        operator_id=operator_id,
+        support_confirmation_reference=support_reference,
+    )
+
+
+def _evaluated_at(value: datetime | None) -> datetime:
+    observed_at = value or datetime.now(timezone.utc)
+    if observed_at.tzinfo is None:
+        raise ValueError("validation_quarantine_evaluated_at_timezone_required")
+    return observed_at.astimezone(timezone.utc)
+
+
+def _require_eligible_receipt(
+    receipt: BrokerMutationReceiptSnapshot,
+    *,
+    expected_intent_sha256: str,
+    observed_at: datetime,
+) -> dict[str, object]:
+    intent = receipt.intent
+    started_at = receipt.lifecycle.broker_io_started_at
+    if (
+        intent.canonical_intent_sha256 != expected_intent_sha256
+        or receipt.state != "broker_io"
+        or intent.broker_route != "alpaca"
+        or intent.endpoint_fingerprint != _PAPER_ENDPOINT_FINGERPRINT
+        or intent.operation != "submit_order"
+        or intent.risk_class != "risk_neutral"
+        or intent.purpose != "control_plane_validation"
+        or intent.submission_claim_id is not None
+        or started_at is None
+        or observed_at - started_at < _MINIMUM_IO_AGE
+    ):
+        raise InfrastructureValidationQuarantineError(
+            "validation_quarantine_receipt_ineligible"
+        )
+    document = _json_object(
+        intent.canonical_intent_json,
+        error="validation_quarantine_intent_invalid",
+    )
+    request = _mapping(
+        document.get("request"), error="validation_quarantine_intent_invalid"
+    )
+    broker_request = _mapping(
+        request.get("broker_request"),
+        error="validation_quarantine_intent_invalid",
+    )
+    validation = _mapping(
+        request.get("infrastructure_validation"),
+        error="validation_quarantine_intent_invalid",
+    )
+    permit = _mapping(
+        validation.get("permit"),
+        error="validation_quarantine_intent_invalid",
+    )
+    if (
+        _text(broker_request.get("time_in_force")).lower() != "ioc"
+        or _text(permit.get("account_mode")).lower() != "paper"
+        or permit.get("promotable") is not False
+        or permit.get("evidence_tag") != "non_promotable_validation"
+        or broker_request.get("extra_params")
+        != {"client_order_id": intent.client_request_id}
+    ):
+        raise InfrastructureValidationQuarantineError(
+            "validation_quarantine_intent_ineligible"
+        )
+    _require_expired_absence_evidence(receipt)
+    return document
+
+
+def _require_expired_absence_evidence(
+    receipt: BrokerMutationReceiptSnapshot,
+) -> None:
+    if receipt.recovery.outcome != "not_found" or not receipt.recovery.evidence_json:
+        raise InfrastructureValidationQuarantineError(
+            "validation_quarantine_absence_evidence_required"
+        )
+    evidence = _json_object(
+        receipt.recovery.evidence_json,
+        error="validation_quarantine_absence_evidence_invalid",
+    )
+    observation = _mapping(
+        evidence.get("observation"),
+        error="validation_quarantine_absence_evidence_invalid",
+    )
+    if (
+        observation.get("resolution_state") != "expired"
+        or observation.get("absence_proof_complete") is not True
+        or observation.get("operator_confirmation_required") is not True
+        or observation.get("automatic_resubmission_attempted") is not False
+    ):
+        raise InfrastructureValidationQuarantineError(
+            "validation_quarantine_absence_evidence_ineligible"
+        )
+
+
+def _read_broker_proof(
+    client: _ValidationBrokerReader,
+    *,
+    receipt: BrokerMutationReceiptSnapshot,
+    observed_at: datetime,
+) -> _BrokerProof:
+    if (
+        client.endpoint_class != "paper"
+        or fingerprint_broker_endpoint(client.endpoint_url)
+        != receipt.intent.endpoint_fingerprint
+    ):
+        raise InfrastructureValidationQuarantineError(
+            "validation_quarantine_broker_endpoint_mismatch"
+        )
+    account = client.get_account()
+    account_number = _text(account.get("account_number"))
+    account_status = _text(account.get("status")).upper()
+    if account_number != receipt.intent.account_label or account_status != "ACTIVE":
+        raise InfrastructureValidationQuarantineError(
+            "validation_quarantine_broker_account_mismatch"
+        )
+    if any(
+        account.get(field) is True
+        for field in (
+            "account_blocked",
+            "trading_blocked",
+            "trade_suspended_by_user",
+            "transfers_blocked",
+        )
+    ):
+        raise InfrastructureValidationQuarantineError(
+            "validation_quarantine_broker_account_blocked"
+        )
+    if (
+        client.get_order_by_client_order_id_strict(receipt.intent.client_request_id)
+        is not None
+    ):
+        raise InfrastructureValidationQuarantineError(
+            "validation_quarantine_exact_order_found"
+        )
+    started_at = receipt.lifecycle.broker_io_started_at
+    if started_at is None:  # pragma: no cover - eligibility checked above
+        raise InfrastructureValidationQuarantineError(
+            "validation_quarantine_broker_io_timestamp_missing"
+        )
+    history = client.list_orders_recovery_window(
+        after=started_at - _HISTORY_MARGIN,
+        until=observed_at,
+        limit=_HISTORY_LIMIT,
+    )
+    matches = tuple(
+        order
+        for order in history.orders
+        if _text(order.get("client_order_id")) == receipt.intent.client_request_id
+    )
+    if not history.complete or matches:
+        raise InfrastructureValidationQuarantineError(
+            "validation_quarantine_order_history_incomplete_or_matched"
+        )
+    open_orders = client.list_open_orders()
+    positions = client.list_positions()
+    if open_orders or positions:
+        raise InfrastructureValidationQuarantineError(
+            "validation_quarantine_account_not_flat"
+        )
+    return _BrokerProof(
+        observed_at=observed_at,
+        account_number=account_number,
+        account_status=account_status,
+        history_count=len(history.orders),
+    )
+
+
+def _build_quarantine_settlement(
+    receipt: BrokerMutationReceiptSnapshot,
+    *,
+    document: Mapping[str, object],
+    request: _NormalizedRequest,
+    proof: _BrokerProof,
+) -> BrokerMutationSettlement:
+    intent_request = _mapping(
+        document.get("request"),
+        error="validation_quarantine_intent_invalid",
+    )
+    validation = _mapping(
+        intent_request.get("infrastructure_validation"),
+        error="validation_quarantine_intent_invalid",
+    )
+    permit = _mapping(
+        validation.get("permit"),
+        error="validation_quarantine_intent_invalid",
+    )
+    evidence_payload: dict[str, object] = {
+        "schema_version": VALIDATION_QUARANTINE_SCHEMA_VERSION,
+        "receipt_id": str(receipt.receipt_id),
+        "client_order_id": receipt.intent.client_request_id,
+        "intent_sha256": receipt.intent.canonical_intent_sha256,
+        "account_label": receipt.intent.account_label,
+        "endpoint_fingerprint": receipt.intent.endpoint_fingerprint,
+        "operator_id": request.operator_id,
+        "support_confirmation_reference": request.support_confirmation_reference,
+        "confirmation_reason": "paper_ioc_future_exposure_impossible",
+        "order_existence_resolution": "unresolved",
+        "prior_recovery_evidence_sha256": receipt.recovery.evidence_sha256,
+        "exact_client_order_lookup": "not_found",
+        "history_complete": True,
+        "history_count": proof.history_count,
+        "history_match_count": 0,
+        "open_order_count": 0,
+        "position_count": 0,
+        "account_number": proof.account_number,
+        "account_status": proof.account_status,
+        "account_blocked": False,
+        "trading_blocked": False,
+        "transfers_blocked": False,
+        "time_in_force": "ioc",
+        "evidence_tag": permit.get("evidence_tag"),
+        "promotable": False,
+        "automatic_resubmission_attempted": False,
+        "broker_mutation_attempted": False,
+        "observed_at": proof.observed_at.isoformat().replace("+00:00", "Z"),
+    }
+    return build_broker_mutation_settlement(
+        BrokerMutationSettlementRequest(
+            source="operator_confirmation",
+            outcome="validation_quarantine_closed",
+            broker_reference=None,
+            execution_id=None,
+            evidence_payload=evidence_payload,
+        )
+    )
+
+
+def _report(
+    receipt: BrokerMutationReceiptSnapshot,
+    *,
+    settlement: BrokerMutationSettlement,
+    applied: bool,
+) -> InfrastructureValidationQuarantineReport:
+    return InfrastructureValidationQuarantineReport(
+        receipt_id=receipt.receipt_id,
+        client_order_id=receipt.intent.client_request_id,
+        intent_sha256=receipt.intent.canonical_intent_sha256,
+        applied=applied,
+        receipt_state=receipt.state,
+        settlement_outcome=(
+            receipt.settlement.outcome if applied else settlement.outcome
+        ),
+        evidence_sha256=settlement.evidence_sha256,
+    )
+
+
+def _json_object(value: str, *, error: str) -> dict[str, object]:
+    try:
+        parsed = json.loads(value)
+    except (TypeError, ValueError) as exc:
+        raise InfrastructureValidationQuarantineError(error) from exc
+    if not isinstance(parsed, dict):
+        raise InfrastructureValidationQuarantineError(error)
+    return cast(dict[str, object], parsed)
+
+
+def _mapping(value: object, *, error: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise InfrastructureValidationQuarantineError(error)
+    raw = cast(Mapping[object, object], value)
+    if any(not isinstance(key, str) for key in raw):
+        raise InfrastructureValidationQuarantineError(error)
+    return {cast(str, key): item for key, item in raw.items()}
+
+
+def _required_text(value: object, *, field: str, maximum: int) -> str:
+    normalized = _text(value)
+    if not normalized or len(normalized) > maximum:
+        raise ValueError(f"validation_quarantine_{field}_invalid")
+    return normalized
+
+
+def _optional_text(value: object, *, field: str, maximum: int) -> str | None:
+    if value is None:
+        return None
+    return _required_text(value, field=field, maximum=maximum)
+
+
+def _sha256(value: object, *, field: str) -> str:
+    normalized = _required_text(value, field=field, maximum=64).lower()
+    if len(normalized) != 64 or any(
+        character not in "0123456789abcdef" for character in normalized
+    ):
+        raise ValueError(f"validation_quarantine_{field}_invalid")
+    return normalized
+
+
+def _text(value: object) -> str:
+    enum_value = getattr(value, "value", value)
+    return "" if enum_value is None else str(enum_value).strip()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Inspect or close one exact paper-IOC validation quarantine."
+    )
+    parser.add_argument("--receipt-id", required=True)
+    parser.add_argument("--expected-intent-sha256", required=True)
+    parser.add_argument("--operator-id", required=True)
+    parser.add_argument("--support-confirmation-reference")
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--confirm")
+    args = parser.parse_args(argv)
+    if args.apply and args.confirm != VALIDATION_QUARANTINE_CONFIRMATION:
+        raise SystemExit(
+            "--apply requires --confirm " + VALIDATION_QUARANTINE_CONFIRMATION
+        )
+    report = run_infrastructure_validation_quarantine_close(
+        request=InfrastructureValidationQuarantineRequest(
+            receipt_id=args.receipt_id,
+            expected_intent_sha256=args.expected_intent_sha256,
+            operator_id=args.operator_id,
+            support_confirmation_reference=args.support_confirmation_reference,
+        ),
+        context=InfrastructureValidationQuarantineContext(
+            client=TorghutAlpacaClient(),
+            session_factory=SessionLocal,
+        ),
+        apply=bool(args.apply),
+    )
+    print(json.dumps(report.to_payload(), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised from the deployed image
+    raise SystemExit(main())
+
+
+__all__ = [
+    "VALIDATION_QUARANTINE_CONFIRMATION",
+    "VALIDATION_QUARANTINE_SCHEMA_VERSION",
+    "InfrastructureValidationQuarantineContext",
+    "InfrastructureValidationQuarantineError",
+    "InfrastructureValidationQuarantineReport",
+    "InfrastructureValidationQuarantineRequest",
+    "main",
+    "run_infrastructure_validation_quarantine_close",
+]

--- a/services/torghut/migrations/versions/0077_validation_quarantine_closure.py
+++ b/services/torghut/migrations/versions/0077_validation_quarantine_closure.py
@@ -1,0 +1,314 @@
+"""Add an honest terminal for non-promotable paper-IOC validation debt.
+
+Revision ID: 0077_validation_quarantine
+Revises: 0076_broker_account_activities
+Create Date: 2026-07-16 03:30:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0077_validation_quarantine"
+down_revision = "0076_broker_account_activities"
+branch_labels = None
+depends_on = None
+
+
+_TABLE = "broker_mutation_receipt_events"
+_SOURCE_CHECK = "ck_bm_event_settlement_source"
+_OUTCOME_CHECK = "ck_bm_event_settlement_outcome"
+_PAIR_CHECK = "ck_bm_event_settlement_pair"
+
+
+_OPERATOR_GUARD_SQL = r"""
+CREATE FUNCTION torghut_guard_validation_quarantine_terminal_0077()
+RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE
+    evidence jsonb;
+    intent jsonb;
+    now_at timestamptz;
+    previous broker_mutation_receipt_events%ROWTYPE;
+    receipt broker_mutation_receipts%ROWTYPE;
+    recovery_observation jsonb;
+BEGIN
+    now_at := clock_timestamp();
+    NEW.recorded_at := now_at;
+    NEW.settled_at := now_at;
+    IF NEW.settlement_evidence_json IS NULL
+       OR NEW.settlement_evidence_sha256 IS DISTINCT FROM encode(
+           digest(convert_to(NEW.settlement_evidence_json, 'UTF8'), 'sha256'),
+           'hex'
+       ) THEN
+        RAISE EXCEPTION 'validation quarantine settlement hash mismatch'
+            USING ERRCODE = '23514';
+    END IF;
+    PERFORM torghut_lock_submission_identities(ARRAY[
+        'torghut:broker-mutation:receipt:' || NEW.receipt_id::text
+    ]);
+    SELECT * INTO receipt
+      FROM broker_mutation_receipts
+     WHERE id = NEW.receipt_id
+       FOR UPDATE;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'validation quarantine receipt not found'
+            USING ERRCODE = '23503';
+    END IF;
+    SELECT * INTO previous
+      FROM broker_mutation_receipt_events
+     WHERE receipt_id = NEW.receipt_id
+     ORDER BY sequence_no DESC
+     LIMIT 1
+       FOR UPDATE;
+    IF NOT FOUND
+       OR NEW.sequence_no <> previous.sequence_no + 1
+       OR previous.state <> 'broker_io'
+       OR NEW.event_type <> 'settled'
+       OR NEW.state <> 'settled'
+       OR NEW.settlement_source <> 'operator_confirmation'
+       OR NEW.settlement_outcome <> 'validation_quarantine_closed'
+       OR NEW.broker_reference IS NOT NULL
+       OR NEW.execution_id IS NOT NULL
+       OR NEW.event_writer_generation <= 0
+       OR NOT torghut_bm_events_equal_except(
+           NEW, previous, ARRAY[
+               'id', 'sequence_no', 'event_type', 'state',
+               'event_writer_generation', 'recorded_at', 'settlement_source',
+               'settlement_outcome', 'broker_reference', 'execution_id',
+               'settlement_evidence_json', 'settlement_evidence_sha256',
+               'settled_at'
+           ]
+       ) THEN
+        RAISE EXCEPTION 'invalid validation quarantine transition'
+            USING ERRCODE = '23514';
+    END IF;
+    intent := receipt.canonical_intent_json::jsonb;
+    recovery_observation := previous.recovery_evidence_json::jsonb -> 'observation';
+    IF receipt.broker_route <> 'alpaca'
+       OR receipt.endpoint_fingerprint <>
+          'e7ce2f426f96cfc1606a46bc494cdfff68192ac2de4529bf406007d11d059ad7'
+       OR receipt.operation <> 'submit_order'
+       OR receipt.risk_class <> 'risk_neutral'
+       OR receipt.purpose <> 'control_plane_validation'
+       OR receipt.submission_claim_id IS NOT NULL
+       OR intent #>> '{request,broker_request,time_in_force}' IS DISTINCT FROM 'ioc'
+       OR intent #>> '{request,infrastructure_validation,permit,account_mode}'
+          IS DISTINCT FROM 'paper'
+       OR intent #>> '{request,infrastructure_validation,permit,evidence_tag}'
+          IS DISTINCT FROM 'non_promotable_validation'
+       OR intent #> '{request,infrastructure_validation,permit,promotable}'
+          IS DISTINCT FROM 'false'::jsonb
+       OR previous.broker_io_started_at IS NULL
+       OR previous.broker_io_started_at > now_at - interval '1 minute'
+       OR previous.recovery_outcome IS DISTINCT FROM 'not_found'
+       OR previous.recovery_evidence_sha256 IS NULL
+       OR recovery_observation ->> 'resolution_state' IS DISTINCT FROM 'expired'
+       OR recovery_observation -> 'absence_proof_complete'
+          IS DISTINCT FROM 'true'::jsonb
+       OR recovery_observation -> 'operator_confirmation_required'
+          IS DISTINCT FROM 'true'::jsonb
+       OR recovery_observation -> 'automatic_resubmission_attempted'
+          IS DISTINCT FROM 'false'::jsonb
+    THEN
+        RAISE EXCEPTION 'validation quarantine receipt is ineligible'
+            USING ERRCODE = '23514';
+    END IF;
+    evidence := NEW.settlement_evidence_json::jsonb -> 'evidence';
+    IF jsonb_typeof(evidence) <> 'object'
+       OR NOT evidence ?& ARRAY[
+          'schema_version', 'receipt_id', 'client_order_id', 'intent_sha256',
+          'account_label', 'endpoint_fingerprint', 'operator_id',
+          'support_confirmation_reference', 'confirmation_reason',
+          'order_existence_resolution', 'prior_recovery_evidence_sha256',
+          'exact_client_order_lookup', 'history_complete', 'history_count',
+          'history_match_count', 'open_order_count', 'position_count',
+          'account_number', 'account_status', 'account_blocked',
+          'trading_blocked', 'transfers_blocked', 'time_in_force',
+          'evidence_tag', 'promotable', 'automatic_resubmission_attempted',
+          'broker_mutation_attempted', 'observed_at'
+       ]
+       OR evidence ->> 'schema_version' IS DISTINCT FROM
+          'torghut.infrastructure-validation-quarantine-closure.v1'
+       OR evidence ->> 'receipt_id' IS DISTINCT FROM receipt.id::text
+       OR evidence ->> 'client_order_id' IS DISTINCT FROM receipt.client_request_id
+       OR evidence ->> 'intent_sha256' IS DISTINCT FROM receipt.canonical_intent_sha256
+       OR evidence ->> 'account_label' IS DISTINCT FROM receipt.account_label
+       OR evidence ->> 'endpoint_fingerprint' IS DISTINCT FROM receipt.endpoint_fingerprint
+       OR jsonb_typeof(evidence -> 'operator_id') IS DISTINCT FROM 'string'
+       OR length(btrim(evidence ->> 'operator_id')) NOT BETWEEN 1 AND 128
+       OR evidence ->> 'confirmation_reason' IS DISTINCT FROM
+          'paper_ioc_future_exposure_impossible'
+       OR evidence ->> 'order_existence_resolution' IS DISTINCT FROM 'unresolved'
+       OR evidence ->> 'prior_recovery_evidence_sha256'
+          IS DISTINCT FROM previous.recovery_evidence_sha256
+       OR evidence ->> 'exact_client_order_lookup' IS DISTINCT FROM 'not_found'
+       OR evidence -> 'history_complete' IS DISTINCT FROM 'true'::jsonb
+       OR (evidence ->> 'history_count') IS NULL
+       OR (evidence ->> 'history_count')::integer < 0
+       OR (evidence ->> 'history_match_count')::integer IS DISTINCT FROM 0
+       OR (evidence ->> 'open_order_count')::integer IS DISTINCT FROM 0
+       OR (evidence ->> 'position_count')::integer IS DISTINCT FROM 0
+       OR evidence ->> 'account_number' IS DISTINCT FROM receipt.account_label
+       OR evidence ->> 'account_status' IS DISTINCT FROM 'ACTIVE'
+       OR evidence -> 'account_blocked' IS DISTINCT FROM 'false'::jsonb
+       OR evidence -> 'trading_blocked' IS DISTINCT FROM 'false'::jsonb
+       OR evidence -> 'transfers_blocked' IS DISTINCT FROM 'false'::jsonb
+       OR evidence ->> 'time_in_force' IS DISTINCT FROM 'ioc'
+       OR evidence ->> 'evidence_tag' IS DISTINCT FROM 'non_promotable_validation'
+       OR evidence -> 'promotable' IS DISTINCT FROM 'false'::jsonb
+       OR evidence -> 'automatic_resubmission_attempted'
+          IS DISTINCT FROM 'false'::jsonb
+       OR evidence -> 'broker_mutation_attempted' IS DISTINCT FROM 'false'::jsonb
+       OR jsonb_typeof(evidence -> 'observed_at') IS DISTINCT FROM 'string'
+       OR (evidence ->> 'observed_at')::timestamptz < now_at - interval '5 minutes'
+       OR (evidence ->> 'observed_at')::timestamptz > now_at + interval '5 seconds'
+       OR (
+           evidence -> 'support_confirmation_reference' <> 'null'::jsonb
+           AND (
+               jsonb_typeof(evidence -> 'support_confirmation_reference') <> 'string'
+               OR length(evidence ->> 'support_confirmation_reference') > 256
+           )
+       )
+    THEN
+        RAISE EXCEPTION 'validation quarantine evidence is invalid'
+            USING ERRCODE = '23514';
+    END IF;
+    RETURN NEW;
+END;
+$$
+"""
+
+
+def _drop_settlement_checks() -> None:
+    for constraint in (_SOURCE_CHECK, _OUTCOME_CHECK, _PAIR_CHECK):
+        op.drop_constraint(constraint, _TABLE, type_="check")
+
+
+def _create_0077_settlement_checks() -> None:
+    op.create_check_constraint(
+        _SOURCE_CHECK,
+        _TABLE,
+        "settlement_source IS NULL OR settlement_source IN "
+        "('primary', 'recovery', 'preflight', 'operator_confirmation')",
+    )
+    op.create_check_constraint(
+        _OUTCOME_CHECK,
+        _TABLE,
+        "settlement_outcome IS NULL OR settlement_outcome IN "
+        "('acknowledged', 'reconciled', 'rejected', 'already_satisfied', "
+        "'validation_quarantine_closed')",
+    )
+    op.create_check_constraint(
+        _PAIR_CHECK,
+        _TABLE,
+        "settlement_outcome IS NULL OR "
+        "(settlement_outcome = 'already_satisfied' "
+        "AND settlement_source = 'preflight') OR "
+        "(settlement_outcome = 'acknowledged' "
+        "AND settlement_source = 'primary') OR "
+        "(settlement_outcome IN ('reconciled', 'rejected') "
+        "AND settlement_source IN ('primary', 'recovery')) OR "
+        "(settlement_outcome = 'validation_quarantine_closed' "
+        "AND settlement_source = 'operator_confirmation')",
+    )
+
+
+def _create_0059_settlement_checks() -> None:
+    op.create_check_constraint(
+        _SOURCE_CHECK,
+        _TABLE,
+        "settlement_source IS NULL OR "
+        "settlement_source IN ('primary', 'recovery', 'preflight')",
+    )
+    op.create_check_constraint(
+        _OUTCOME_CHECK,
+        _TABLE,
+        "settlement_outcome IS NULL OR settlement_outcome IN "
+        "('acknowledged', 'reconciled', 'rejected', 'already_satisfied')",
+    )
+    op.create_check_constraint(
+        _PAIR_CHECK,
+        _TABLE,
+        "settlement_outcome IS NULL OR "
+        "(settlement_outcome = 'already_satisfied' "
+        "AND settlement_source = 'preflight') OR "
+        "(settlement_outcome = 'acknowledged' "
+        "AND settlement_source = 'primary') OR "
+        "(settlement_outcome IN ('reconciled', 'rejected') "
+        "AND settlement_source IN ('primary', 'recovery'))",
+    )
+
+
+def _split_event_guard() -> None:
+    op.execute(sa.text("DROP TRIGGER trg_guard_bm_receipt_event ON " + _TABLE))
+    op.execute(sa.text(_OPERATOR_GUARD_SQL))
+    statements = (
+        "CREATE TRIGGER trg_guard_bm_receipt_event_insert "
+        "BEFORE INSERT ON broker_mutation_receipt_events FOR EACH ROW "
+        "WHEN (NEW.settlement_source IS DISTINCT FROM 'operator_confirmation') "
+        "EXECUTE FUNCTION torghut_guard_broker_mutation_event()",
+        "CREATE TRIGGER trg_guard_bm_receipt_event_update_delete "
+        "BEFORE UPDATE OR DELETE ON broker_mutation_receipt_events FOR EACH ROW "
+        "EXECUTE FUNCTION torghut_guard_broker_mutation_event()",
+        "CREATE TRIGGER trg_guard_bm_receipt_event_operator_confirmation "
+        "BEFORE INSERT ON broker_mutation_receipt_events FOR EACH ROW "
+        "WHEN (NEW.settlement_source = 'operator_confirmation') "
+        "EXECUTE FUNCTION torghut_guard_validation_quarantine_terminal_0077()",
+    )
+    for statement in statements:
+        op.execute(sa.text(statement))
+
+
+def _restore_event_guard() -> None:
+    for trigger in (
+        "trg_guard_bm_receipt_event_operator_confirmation",
+        "trg_guard_bm_receipt_event_update_delete",
+        "trg_guard_bm_receipt_event_insert",
+    ):
+        op.execute(sa.text(f"DROP TRIGGER {trigger} ON {_TABLE}"))
+    op.execute(
+        sa.text("DROP FUNCTION torghut_guard_validation_quarantine_terminal_0077()")
+    )
+    op.execute(
+        sa.text(
+            "CREATE TRIGGER trg_guard_bm_receipt_event "
+            "BEFORE INSERT OR UPDATE OR DELETE ON broker_mutation_receipt_events "
+            "FOR EACH ROW EXECUTE FUNCTION torghut_guard_broker_mutation_event()"
+        )
+    )
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            "LOCK TABLE broker_mutation_receipts, "
+            + _TABLE
+            + " IN ACCESS EXCLUSIVE MODE"
+        )
+    )
+    _drop_settlement_checks()
+    _create_0077_settlement_checks()
+    _split_event_guard()
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text(
+            "LOCK TABLE broker_mutation_receipts, "
+            + _TABLE
+            + " IN ACCESS EXCLUSIVE MODE"
+        )
+    )
+    op.execute(
+        sa.text(
+            "DO $$ BEGIN IF EXISTS (SELECT 1 FROM broker_mutation_receipt_events "
+            "WHERE settlement_outcome = 'validation_quarantine_closed') THEN "
+            "RAISE EXCEPTION 'refusing to downgrade validation quarantine evidence' "
+            "USING ERRCODE = '55000'; END IF; END; $$"
+        )
+    )
+    _restore_event_guard()
+    _drop_settlement_checks()
+    _create_0059_settlement_checks()

--- a/services/torghut/tests/execution/infrastructure_validation_postgres_support.py
+++ b/services/torghut/tests/execution/infrastructure_validation_postgres_support.py
@@ -73,6 +73,8 @@ def upgrade_reduction_schema(
             "0073_live_paper_bounds",
             "0074_crypto_qty_precision",
             "0075_validation_observed_at",
+            "0076_broker_account_activities",
+            "0077_validation_quarantine",
         }:
             connection.execute(
                 text(

--- a/services/torghut/tests/execution/test_validation_quarantine_postgres.py
+++ b/services/torghut/tests/execution/test_validation_quarantine_postgres.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import Mapping
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from alembic.config import Config as AlembicConfig
+from sqlalchemy import select, text
+from sqlalchemy.exc import DBAPIError
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.config import settings
+from app.models import BrokerMutationReceiptEvent
+from app.trading.broker_mutation_receipts import (
+    BrokerMutationIntentRequest,
+    BrokerMutationRecoveryAcquireOptions,
+    BrokerMutationRecoveryObservationRequest,
+    BrokerMutationSettlementRequest,
+    BrokerMutationSettlement,
+    BrokerMutationTarget,
+    acquire_broker_mutation_receipt,
+    acquire_broker_mutation_recovery,
+    build_broker_mutation_intent,
+    build_broker_mutation_recovery_observation,
+    build_broker_mutation_settlement,
+    fingerprint_broker_endpoint,
+    mark_broker_mutation_io_started,
+    record_broker_mutation_recovery_observation,
+    release_broker_mutation_recovery,
+    settle_broker_mutation_operator_confirmation,
+)
+from app.trading.broker_mutation_receipts.persistence import (
+    append_full_state_event,
+    database_now,
+    full_state_values_from_event,
+)
+from app.trading.infrastructure_validation import (
+    infrastructure_validation_client_order_id,
+    infrastructure_validation_request_payload,
+)
+from tests.execution.decision_submission_claims_postgres_support import (
+    POSTGRES_DSN,
+    SERVICE_ROOT,
+    create_schema_engines,
+    drop_schema,
+)
+from tests.execution.infrastructure_validation_postgres_support import (
+    upgrade_reduction_schema,
+    validation_fixture,
+)
+
+
+def _age_latest_event(
+    sessions: sessionmaker[Session],
+    receipt_id: uuid.UUID,
+    *,
+    recovery_due: bool,
+) -> None:
+    with sessions() as session:
+        session.execute(
+            text(
+                "ALTER TABLE broker_mutation_receipt_events DISABLE TRIGGER "
+                "trg_guard_bm_receipt_event_update_delete"
+            )
+        )
+        latest = session.execute(
+            select(BrokerMutationReceiptEvent)
+            .where(BrokerMutationReceiptEvent.receipt_id == receipt_id)
+            .order_by(BrokerMutationReceiptEvent.sequence_no.desc())
+            .limit(1)
+        ).scalar_one()
+        latest.broker_io_started_at = database_now(session) - timedelta(minutes=2)
+        if recovery_due:
+            latest.recovery_after = database_now(session) - timedelta(seconds=1)
+            if latest.recovery_lease_expires_at is not None:
+                latest.recovery_lease_started_at = database_now(session) - timedelta(
+                    minutes=2
+                )
+                latest.recovery_lease_expires_at = database_now(session) - timedelta(
+                    minutes=1
+                )
+        session.flush()
+        session.execute(
+            text(
+                "ALTER TABLE broker_mutation_receipt_events ENABLE TRIGGER "
+                "trg_guard_bm_receipt_event_update_delete"
+            )
+        )
+        session.commit()
+
+
+def _seed_expired_validation_receipt(
+    sessions: sessionmaker[Session],
+) -> tuple[uuid.UUID, str, str]:
+    now = datetime.now(timezone.utc)
+    permit, plan = validation_fixture(now, permit_id=f"ivp-{uuid.uuid4().hex}")
+    client_order_id = infrastructure_validation_client_order_id(permit, plan)
+    intent = build_broker_mutation_intent(
+        BrokerMutationIntentRequest(
+            broker_route="alpaca",
+            account_label=permit.account_label,
+            endpoint_fingerprint=fingerprint_broker_endpoint(permit.broker_base_url),
+            operation="submit_order",
+            risk_class="risk_neutral",
+            purpose="control_plane_validation",
+            workflow_id=client_order_id,
+            client_request_id=client_order_id,
+            target=BrokerMutationTarget(kind="order", key=client_order_id),
+            request_payload=infrastructure_validation_request_payload(permit, plan),
+        )
+    )
+    with sessions() as session:
+        acquired = acquire_broker_mutation_receipt(
+            session,
+            intent=intent,
+            primary_owner="validation-writer",
+            writer_generation=1,
+        )
+        started = mark_broker_mutation_io_started(
+            session,
+            handle=acquired.receipt.primary_handle,
+            recovery_seconds=30,
+        )
+    receipt_id = started.receipt.receipt_id
+    _age_latest_event(sessions, receipt_id, recovery_due=True)
+    with sessions() as session:
+        recovery = acquire_broker_mutation_recovery(
+            session,
+            receipt_id=receipt_id,
+            recovery_owner="recovery-reader",
+            writer_generation=2,
+            options=BrokerMutationRecoveryAcquireOptions(lease_seconds=30),
+        )
+    assert recovery.receipt is not None and recovery.receipt.recovery_handle is not None
+    handle = recovery.receipt.recovery_handle
+    observation = build_broker_mutation_recovery_observation(
+        BrokerMutationRecoveryObservationRequest(
+            checked_client_request_id=client_order_id,
+            checked_target_key=client_order_id,
+            outcome="not_found",
+            evidence_payload={
+                "schema_version": "torghut.broker-submit-recovery-observation.v1",
+                "resolution_state": "expired",
+                "absence_proof_complete": True,
+                "operator_confirmation_required": True,
+                "automatic_resubmission_attempted": False,
+            },
+        )
+    )
+    with sessions() as session:
+        record_broker_mutation_recovery_observation(
+            session,
+            handle=handle,
+            observation=observation,
+            retry_seconds=3600,
+        )
+    with sessions() as session:
+        released = release_broker_mutation_recovery(session, handle=handle)
+    _age_latest_event(sessions, receipt_id, recovery_due=False)
+    assert released.recovery.evidence_sha256 is not None
+    return receipt_id, intent.canonical_intent_sha256, released.recovery.evidence_sha256
+
+
+def _settlement(
+    *,
+    receipt_id: uuid.UUID,
+    client_order_id: str,
+    intent_sha256: str,
+    recovery_sha256: str,
+    include_history_complete: bool = True,
+    evidence_overrides: Mapping[str, object] | None = None,
+) -> BrokerMutationSettlement:
+    payload: dict[str, object] = {
+        "schema_version": "torghut.infrastructure-validation-quarantine-closure.v1",
+        "receipt_id": str(receipt_id),
+        "client_order_id": client_order_id,
+        "intent_sha256": intent_sha256,
+        "account_label": "dedicated-validation-paper",
+        "endpoint_fingerprint": fingerprint_broker_endpoint(
+            "https://paper-api.alpaca.markets"
+        ),
+        "operator_id": "postgres-test-operator",
+        "support_confirmation_reference": None,
+        "confirmation_reason": "paper_ioc_future_exposure_impossible",
+        "order_existence_resolution": "unresolved",
+        "prior_recovery_evidence_sha256": recovery_sha256,
+        "exact_client_order_lookup": "not_found",
+        "history_count": 0,
+        "history_match_count": 0,
+        "open_order_count": 0,
+        "position_count": 0,
+        "account_number": "dedicated-validation-paper",
+        "account_status": "ACTIVE",
+        "account_blocked": False,
+        "trading_blocked": False,
+        "transfers_blocked": False,
+        "time_in_force": "ioc",
+        "evidence_tag": "non_promotable_validation",
+        "promotable": False,
+        "automatic_resubmission_attempted": False,
+        "broker_mutation_attempted": False,
+        "observed_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }
+    if include_history_complete:
+        payload["history_complete"] = True
+    if evidence_overrides:
+        payload.update(evidence_overrides)
+    return build_broker_mutation_settlement(
+        BrokerMutationSettlementRequest(
+            source="operator_confirmation",
+            outcome="validation_quarantine_closed",
+            broker_reference=None,
+            execution_id=None,
+            evidence_payload=payload,
+        )
+    )
+
+
+@pytest.mark.skipif(
+    not POSTGRES_DSN,
+    reason="set TORGHUT_TEST_POSTGRES_DSN for the validation quarantine test",
+)
+def test_postgres_validation_quarantine_requires_complete_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    schema, admin_engine, schema_engine, schema_dsn = create_schema_engines(
+        "validation_quarantine"
+    )
+    sessions = sessionmaker(
+        bind=schema_engine,
+        class_=Session,
+        autoflush=False,
+        expire_on_commit=False,
+        future=True,
+    )
+    try:
+        monkeypatch.setattr(settings, "db_dsn", schema_dsn)
+        alembic = AlembicConfig(str(SERVICE_ROOT / "alembic.ini"))
+        upgrade_reduction_schema(
+            alembic,
+            schema_engine,
+            target="0077_validation_quarantine",
+        )
+        receipt_id, intent_sha256, recovery_sha256 = _seed_expired_validation_receipt(
+            sessions
+        )
+        with sessions() as session:
+            latest = session.execute(
+                select(BrokerMutationReceiptEvent)
+                .where(BrokerMutationReceiptEvent.receipt_id == receipt_id)
+                .order_by(BrokerMutationReceiptEvent.sequence_no.desc())
+                .limit(1)
+            ).scalar_one()
+            invalid = _settlement(
+                receipt_id=receipt_id,
+                client_order_id=latest.receipt.client_request_id,
+                intent_sha256=intent_sha256,
+                recovery_sha256=recovery_sha256,
+                include_history_complete=False,
+            )
+            values = full_state_values_from_event(latest)
+            values.update(
+                sequence_no=latest.sequence_no + 1,
+                event_type="settled",
+                state="settled",
+                event_writer_generation=99,
+                settlement_source=invalid.source,
+                settlement_outcome=invalid.outcome,
+                broker_reference=None,
+                execution_id=None,
+                settlement_evidence_json=invalid.evidence_json,
+                settlement_evidence_sha256=invalid.evidence_sha256,
+                settled_at=database_now(session),
+            )
+            with pytest.raises(DBAPIError, match="evidence is invalid"):
+                append_full_state_event(session, receipt_id=receipt_id, values=values)
+            session.rollback()
+
+        for evidence_overrides in (
+            {"operator_id": None},
+            {"history_count": None},
+            {"history_match_count": None},
+            {"open_order_count": None},
+            {"position_count": None},
+            {"observed_at": None},
+        ):
+            with sessions() as session:
+                latest = session.execute(
+                    select(BrokerMutationReceiptEvent)
+                    .where(BrokerMutationReceiptEvent.receipt_id == receipt_id)
+                    .order_by(BrokerMutationReceiptEvent.sequence_no.desc())
+                    .limit(1)
+                ).scalar_one()
+                invalid = _settlement(
+                    receipt_id=receipt_id,
+                    client_order_id=latest.receipt.client_request_id,
+                    intent_sha256=intent_sha256,
+                    recovery_sha256=recovery_sha256,
+                    evidence_overrides=evidence_overrides,
+                )
+                values = full_state_values_from_event(latest)
+                values.update(
+                    sequence_no=latest.sequence_no + 1,
+                    event_type="settled",
+                    state="settled",
+                    event_writer_generation=99,
+                    settlement_source=invalid.source,
+                    settlement_outcome=invalid.outcome,
+                    broker_reference=None,
+                    execution_id=None,
+                    settlement_evidence_json=invalid.evidence_json,
+                    settlement_evidence_sha256=invalid.evidence_sha256,
+                    settled_at=database_now(session),
+                )
+                with pytest.raises(DBAPIError, match="evidence is invalid"):
+                    append_full_state_event(
+                        session,
+                        receipt_id=receipt_id,
+                        values=values,
+                    )
+                session.rollback()
+
+        with sessions() as session:
+            latest = session.execute(
+                select(BrokerMutationReceiptEvent)
+                .where(BrokerMutationReceiptEvent.receipt_id == receipt_id)
+                .order_by(BrokerMutationReceiptEvent.sequence_no.desc())
+                .limit(1)
+            ).scalar_one()
+            valid = _settlement(
+                receipt_id=receipt_id,
+                client_order_id=latest.receipt.client_request_id,
+                intent_sha256=intent_sha256,
+                recovery_sha256=recovery_sha256,
+            )
+            settled = settle_broker_mutation_operator_confirmation(
+                session,
+                receipt_id=receipt_id,
+                writer_generation=100,
+                settlement=valid,
+            )
+        assert settled.state == "settled"
+        assert settled.settlement.source == "operator_confirmation"
+        assert settled.settlement.outcome == "validation_quarantine_closed"
+        assert settled.settlement.broker_reference is None
+        assert settled.settlement.execution_id is None
+    finally:
+        drop_schema(schema, admin_engine, schema_engine)

--- a/services/torghut/tests/execution/test_validation_quarantine_postgres.py
+++ b/services/torghut/tests/execution/test_validation_quarantine_postgres.py
@@ -100,7 +100,9 @@ def _seed_expired_validation_receipt(
         BrokerMutationIntentRequest(
             broker_route="alpaca",
             account_label=permit.account_label,
-            endpoint_fingerprint=fingerprint_broker_endpoint(permit.broker_base_url),
+            endpoint_fingerprint=fingerprint_broker_endpoint(
+                str(permit.broker_base_url)
+            ),
             operation="submit_order",
             risk_class="risk_neutral",
             purpose="control_plane_validation",

--- a/services/torghut/tests/test_broker_mutation_wiring.py
+++ b/services/torghut/tests/test_broker_mutation_wiring.py
@@ -258,4 +258,5 @@ def test_receipt_postgres_races_are_a_required_ci_gate() -> None:
         in workflow
     )
     assert "tests/execution/test_broker_mutation_coordinator_postgres.py" in workflow
+    assert "tests/execution/test_validation_quarantine_postgres.py" in workflow
     assert "tests/execution/test_linked_submission_terminal_postgres.py" in workflow

--- a/services/torghut/tests/test_infrastructure_validation_quarantine.py
+++ b/services/torghut/tests/test_infrastructure_validation_quarantine.py
@@ -1,0 +1,347 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.alpaca_client import AlpacaRecoveryOrderHistoryPage
+from app.models import Base, BrokerMutationReceiptEvent
+from app.trading.broker_mutation_receipts import (
+    BrokerMutationIntent,
+    BrokerMutationIntentRequest,
+    BrokerMutationReceiptAcquireOptions,
+    BrokerMutationRecoveryAcquireOptions,
+    BrokerMutationRecoveryObservationRequest,
+    BrokerMutationTarget,
+    acquire_broker_mutation_receipt,
+    acquire_broker_mutation_recovery,
+    build_broker_mutation_intent,
+    build_broker_mutation_recovery_observation,
+    fingerprint_broker_endpoint,
+    mark_broker_mutation_io_started,
+    record_broker_mutation_recovery_observation,
+    release_broker_mutation_recovery,
+)
+from app.trading.broker_mutation_receipts.runtime_status import (
+    load_broker_mutation_runtime_status,
+)
+from app.trading.infrastructure_validation_quarantine import (
+    VALIDATION_QUARANTINE_CONFIRMATION,
+    InfrastructureValidationQuarantineContext,
+    InfrastructureValidationQuarantineError,
+    InfrastructureValidationQuarantineRequest,
+    main,
+    run_infrastructure_validation_quarantine_close,
+)
+
+
+_PAPER_ENDPOINT = "https://paper-api.alpaca.markets"
+
+
+@dataclass
+class _FakeClient:
+    endpoint_url: str = _PAPER_ENDPOINT
+    endpoint_class: str = "paper"
+    exact_order: dict[str, object] | None = None
+    history_complete: bool = True
+    history_orders: tuple[dict[str, object], ...] = ()
+    open_orders: tuple[dict[str, object], ...] = ()
+    positions: tuple[dict[str, object], ...] = ()
+
+    def get_account(self) -> dict[str, object]:
+        return {
+            "account_number": "paper-account",
+            "status": "ACTIVE",
+            "account_blocked": False,
+            "trading_blocked": False,
+            "trade_suspended_by_user": False,
+            "transfers_blocked": False,
+        }
+
+    def get_order_by_client_order_id_strict(
+        self, client_order_id: str
+    ) -> dict[str, object] | None:
+        del client_order_id
+        return self.exact_order
+
+    def list_orders_recovery_window(
+        self,
+        *,
+        after: datetime,
+        until: datetime,
+        limit: int = 500,
+    ) -> AlpacaRecoveryOrderHistoryPage:
+        return AlpacaRecoveryOrderHistoryPage(
+            orders=self.history_orders,
+            complete=self.history_complete,
+            limit=limit,
+            after=after,
+            until=until,
+        )
+
+    def list_open_orders(self) -> list[dict[str, object]]:
+        return list(self.open_orders)
+
+    def list_positions(self) -> list[dict[str, object]]:
+        return list(self.positions)
+
+
+def _sessions(path: Path) -> sessionmaker[Session]:
+    engine = create_engine(f"sqlite+pysqlite:///{path}", future=True)
+    Base.metadata.create_all(engine)
+    return sessionmaker(
+        bind=engine,
+        class_=Session,
+        autoflush=False,
+        expire_on_commit=False,
+        future=True,
+    )
+
+
+def _validation_intent(client_order_id: str) -> BrokerMutationIntent:
+    return build_broker_mutation_intent(
+        BrokerMutationIntentRequest(
+            broker_route="alpaca",
+            account_label="paper-account",
+            endpoint_fingerprint=fingerprint_broker_endpoint(_PAPER_ENDPOINT),
+            operation="submit_order",
+            risk_class="risk_neutral",
+            purpose="control_plane_validation",
+            workflow_id=client_order_id,
+            client_request_id=client_order_id,
+            target=BrokerMutationTarget(kind="order", key=client_order_id),
+            request_payload={
+                "broker_request": {
+                    "symbol": "BTC/USD",
+                    "side": "buy",
+                    "qty": "0.00004",
+                    "order_type": "limit",
+                    "time_in_force": "ioc",
+                    "limit_price": "67000",
+                    "stop_price": None,
+                    "extra_params": {"client_order_id": client_order_id},
+                },
+                "infrastructure_validation": {
+                    "permit": {
+                        "account_mode": "paper",
+                        "evidence_tag": "non_promotable_validation",
+                        "promotable": False,
+                    }
+                },
+            },
+        )
+    )
+
+
+def _seed_expired_receipt(
+    sessions: sessionmaker[Session],
+) -> tuple[uuid.UUID, BrokerMutationIntent]:
+    client_order_id = "ivp-" + "a" * 44
+    intent = _validation_intent(client_order_id)
+    with sessions() as session:
+        acquired = acquire_broker_mutation_receipt(
+            session,
+            intent=intent,
+            primary_owner="validation-writer",
+            writer_generation=1,
+            options=BrokerMutationReceiptAcquireOptions(lease_seconds=30),
+        )
+        started = mark_broker_mutation_io_started(
+            session,
+            handle=acquired.receipt.primary_handle,
+            recovery_seconds=30,
+        )
+    receipt_id = started.receipt.receipt_id
+    _force_recovery_due(sessions, receipt_id)
+    with sessions() as session:
+        recovery = acquire_broker_mutation_recovery(
+            session,
+            receipt_id=receipt_id,
+            recovery_owner="recovery-reader",
+            writer_generation=2,
+            options=BrokerMutationRecoveryAcquireOptions(lease_seconds=30),
+        )
+    assert recovery.receipt is not None and recovery.receipt.recovery_handle is not None
+    handle = recovery.receipt.recovery_handle
+    observation = build_broker_mutation_recovery_observation(
+        BrokerMutationRecoveryObservationRequest(
+            checked_client_request_id=client_order_id,
+            checked_target_key=client_order_id,
+            outcome="not_found",
+            evidence_payload={
+                "schema_version": "torghut.broker-submit-recovery-observation.v1",
+                "resolution_state": "expired",
+                "absence_proof_complete": True,
+                "operator_confirmation_required": True,
+                "automatic_resubmission_attempted": False,
+            },
+        )
+    )
+    with sessions() as session:
+        record_broker_mutation_recovery_observation(
+            session,
+            handle=handle,
+            observation=observation,
+            retry_seconds=3600,
+        )
+    with sessions() as session:
+        release_broker_mutation_recovery(session, handle=handle)
+    _age_latest_receipt(sessions, receipt_id)
+    return receipt_id, intent
+
+
+def _force_recovery_due(sessions: sessionmaker[Session], receipt_id: uuid.UUID) -> None:
+    with sessions() as session:
+        latest = session.execute(
+            select(BrokerMutationReceiptEvent)
+            .where(BrokerMutationReceiptEvent.receipt_id == receipt_id)
+            .order_by(BrokerMutationReceiptEvent.sequence_no.desc())
+            .limit(1)
+        ).scalar_one()
+        latest.recovery_after = datetime(2000, 1, 1, tzinfo=timezone.utc)
+        session.commit()
+
+
+def _age_latest_receipt(sessions: sessionmaker[Session], receipt_id: uuid.UUID) -> None:
+    with sessions() as session:
+        latest = session.execute(
+            select(BrokerMutationReceiptEvent)
+            .where(BrokerMutationReceiptEvent.receipt_id == receipt_id)
+            .order_by(BrokerMutationReceiptEvent.sequence_no.desc())
+            .limit(1)
+        ).scalar_one()
+        latest.broker_io_started_at = datetime.now(timezone.utc) - timedelta(minutes=2)
+        session.commit()
+
+
+def _request(
+    receipt_id: uuid.UUID,
+    intent_sha256: str,
+) -> InfrastructureValidationQuarantineRequest:
+    return InfrastructureValidationQuarantineRequest(
+        receipt_id=receipt_id,
+        expected_intent_sha256=intent_sha256,
+        operator_id="codex-runtime-operator",
+    )
+
+
+def test_dry_run_then_apply_closes_only_the_validation_quarantine(
+    tmp_path: Path,
+) -> None:
+    sessions = _sessions(tmp_path / "quarantine.sqlite")
+    receipt_id, intent = _seed_expired_receipt(sessions)
+    context = InfrastructureValidationQuarantineContext(
+        client=_FakeClient(),
+        session_factory=sessions,
+        evaluated_at=datetime.now(timezone.utc),
+    )
+
+    dry_run = run_infrastructure_validation_quarantine_close(
+        request=_request(receipt_id, intent.canonical_intent_sha256),
+        context=context,
+    )
+    assert not dry_run.applied
+    assert dry_run.receipt_state == "broker_io"
+    assert dry_run.settlement_outcome == "validation_quarantine_closed"
+
+    applied = run_infrastructure_validation_quarantine_close(
+        request=_request(receipt_id, intent.canonical_intent_sha256),
+        context=context,
+        apply=True,
+    )
+    assert applied.applied
+    assert applied.receipt_state == "settled"
+    assert applied.settlement_outcome == "validation_quarantine_closed"
+    assert applied.evidence_sha256 == dry_run.evidence_sha256
+
+    with sessions() as session:
+        status = load_broker_mutation_runtime_status(session)
+    assert status["unresolved_receipt_count"] == 0
+    assert status["recovery_resolution_state_counts"] == {
+        "claimed": 0,
+        "submitted_unknown": 0,
+        "acknowledged": 0,
+        "rejected": 0,
+        "expired": 0,
+        "manual_review": 0,
+        "validation_quarantine_closed": 1,
+    }
+
+
+@pytest.mark.parametrize(
+    "client,error",
+    [
+        (_FakeClient(exact_order={"id": "found"}), "exact_order_found"),
+        (_FakeClient(history_complete=False), "history_incomplete_or_matched"),
+        (
+            _FakeClient(history_orders=({"client_order_id": "ivp-" + "a" * 44},)),
+            "history_incomplete_or_matched",
+        ),
+        (_FakeClient(open_orders=({"id": "open"},)), "account_not_flat"),
+        (_FakeClient(positions=({"symbol": "BTC/USD"},)), "account_not_flat"),
+        (
+            _FakeClient(
+                endpoint_url="https://api.alpaca.markets",
+                endpoint_class="live",
+            ),
+            "broker_endpoint_mismatch",
+        ),
+    ],
+)
+def test_fresh_broker_evidence_fails_closed(
+    tmp_path: Path,
+    client: _FakeClient,
+    error: str,
+) -> None:
+    sessions = _sessions(tmp_path / f"{error}.sqlite")
+    receipt_id, intent = _seed_expired_receipt(sessions)
+
+    with pytest.raises(InfrastructureValidationQuarantineError, match=error):
+        run_infrastructure_validation_quarantine_close(
+            request=_request(receipt_id, intent.canonical_intent_sha256),
+            context=InfrastructureValidationQuarantineContext(
+                client=client,
+                session_factory=sessions,
+            ),
+            apply=True,
+        )
+
+
+def test_wrong_intent_digest_cannot_close_receipt(tmp_path: Path) -> None:
+    sessions = _sessions(tmp_path / "wrong-digest.sqlite")
+    receipt_id, _ = _seed_expired_receipt(sessions)
+
+    with pytest.raises(
+        InfrastructureValidationQuarantineError,
+        match="receipt_ineligible",
+    ):
+        run_infrastructure_validation_quarantine_close(
+            request=_request(receipt_id, "b" * 64),
+            context=InfrastructureValidationQuarantineContext(
+                client=_FakeClient(),
+                session_factory=sessions,
+            ),
+            apply=True,
+        )
+
+
+def test_apply_requires_explicit_confirmation_before_client_construction() -> None:
+    with pytest.raises(SystemExit, match=VALIDATION_QUARANTINE_CONFIRMATION):
+        main(
+            [
+                "--receipt-id",
+                str(uuid.uuid4()),
+                "--expected-intent-sha256",
+                "a" * 64,
+                "--operator-id",
+                "operator",
+                "--apply",
+                "--confirm",
+                "WRONG",
+            ]
+        )

--- a/services/torghut/tests/test_strategy_capital_authority_migration_compat.py
+++ b/services/torghut/tests/test_strategy_capital_authority_migration_compat.py
@@ -28,7 +28,7 @@ def test_migration_graph_has_one_merged_head_and_knows_the_released_revision() -
     config = AlembicConfig(str(SERVICE_ROOT / "alembic.ini"))
     scripts = ScriptDirectory.from_config(config)
 
-    assert scripts.get_heads() == ["0076_broker_account_activities"]
+    assert scripts.get_heads() == ["0077_validation_quarantine"]
     assert scripts.get_revision("0063_strategy_capital_authority") is not None
     assert scripts.get_revision("0064_strategy_capital_authority") is not None
     assert scripts.get_revision("0065_strategy_capital_compat") is not None
@@ -43,3 +43,4 @@ def test_migration_graph_has_one_merged_head_and_knows_the_released_revision() -
     assert scripts.get_revision("0074_crypto_qty_precision") is not None
     assert scripts.get_revision("0075_validation_observed_at") is not None
     assert scripts.get_revision("0076_broker_account_activities") is not None
+    assert scripts.get_revision("0077_validation_quarantine") is not None

--- a/services/torghut/tests/test_validation_quarantine_migration.py
+++ b/services/torghut/tests/test_validation_quarantine_migration.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+
+SERVICE_ROOT = Path(__file__).resolve().parents[1]
+MIGRATION = (
+    SERVICE_ROOT / "migrations" / "versions" / "0077_validation_quarantine_closure.py"
+)
+
+
+def _load_migration() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "validation_quarantine_migration", MIGRATION
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_validation_quarantine_migration_has_one_linear_parent() -> None:
+    module = _load_migration()
+
+    assert module.revision == "0077_validation_quarantine"
+    assert module.down_revision == "0076_broker_account_activities"
+    assert module.branch_labels is None
+    assert module.depends_on is None
+
+
+def test_validation_quarantine_migration_is_narrow_and_fail_closed() -> None:
+    text = MIGRATION.read_text(encoding="utf-8")
+
+    assert "operator_confirmation" in text
+    assert "validation_quarantine_closed" in text
+    assert "control_plane_validation" in text
+    assert "time_in_force}' IS DISTINCT FROM 'ioc'" in text
+    assert "non_promotable_validation" in text
+    assert "order_existence_resolution' IS DISTINCT FROM 'unresolved'" in text
+    assert "refusing to downgrade validation quarantine evidence" in text
+    assert "DELETE FROM broker_mutation" not in text


### PR DESCRIPTION
## Summary

- Add one append-only operator settlement for unlinked, non-promotable Alpaca-paper IOC validation receipts only after expired complete absence evidence and fresh exact-order, complete-history, active-account, zero-order, and zero-position proof.
- Preserve `order_existence_resolution=unresolved`; report the closure separately from broker acknowledgements and reject linked, live, promotable, ordinary, non-IOC, malformed, or stale evidence in PostgreSQL.
- Add a dry-run-first deployed-image CLI, the normative operator contract, and required PostgreSQL regression coverage without a second authority table, queue, or broker-mutation path.

## Related Issues

None

## Testing

- `uv run --frozen pytest -q tests/test_validation_quarantine_migration.py tests/test_strategy_capital_authority_migration_compat.py tests/test_broker_mutation_wiring.py tests/test_infrastructure_validation_quarantine.py tests/execution/test_validation_quarantine_postgres.py` — 25 passed, 1 skipped because the local Postgres DSN is absent; the skipped test is added to the required CI PostgreSQL fencing job.
- `uv run --frozen ruff format app tests scripts migrations`
- `uv run --frozen ruff check app tests scripts migrations`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- Pylint changed-line refactor, design-complexity, and file-length gates.
- `git diff --check origin/main...HEAD`

## Breaking Changes

Adds Alembic revision `0077_validation_quarantine`. Downgrade deliberately refuses after immutable validation-quarantine closure evidence exists; no existing receipt is rewritten.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] Documentation, release notes, and follow-ups are updated or tracked.