### PR TITLE
chore(product): promote nix product images

### DIFF
--- a/argocd/applications/app/kustomization.yaml
+++ b/argocd/applications/app/kustomization.yaml
@@ -8,5 +8,5 @@ resources:
   - secret.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/app
-    digest: sha256:98dd8a7ca3c6e0ae274a309e95a41748becd68c1efe07bc7a59723bf1d116aab
+    digest: sha256:5f9fccd2e917c4438674b7865f454945b3b6343a3b0cd189ae96e7680d1ad3cc
     newName: registry.ide-newton.ts.net/lab/app

--- a/argocd/applications/synthesis/kustomization.yaml
+++ b/argocd/applications/synthesis/kustomization.yaml
@@ -11,5 +11,5 @@ resources:
   - agents-domain
 images:
   - name: registry.ide-newton.ts.net/lab/synthesis
-    digest: sha256:7cc3d8ca7b4cdb47f8b42762de9f6caf55a7312336089a1478f3227b8d0dd8a1
+    digest: sha256:08fd7deddd0b65e1bd1e53639e01aad4a7ad1a8a7e041493c0a37f19f78ae24c
     newName: registry.ide-newton.ts.net/lab/synthesis


### PR DESCRIPTION
## Summary

- Promote enabled product app image digests built by the shared Nix OCI workflow.
- `app`: `registry.ide-newton.ts.net/lab/app@sha256:5f9fccd2e917c4438674b7865f454945b3b6343a3b0cd189ae96e7680d1ad3cc` from `5a1d8dd766d3b90d3ef662b337e5e9c46687be78`
- `docs`: `registry.ide-newton.ts.net/lab/docs@sha256:00112453c5b20135b7aa461308a79082fb49c2420eaa30e5c6dcd6e4abdc0f6c` from `5a1d8dd766d3b90d3ef662b337e5e9c46687be78`
- `olden`: `registry.ide-newton.ts.net/lab/olden@sha256:a1ee64f469fe6521a430c0a3ba5e9fbdb3bb79cf9b88fa90f27e3111674c9d0f` from `5a1d8dd766d3b90d3ef662b337e5e9c46687be78`
- `proompteng`: `registry.ide-newton.ts.net/lab/proompteng@sha256:1a5a5902dab138094df9de846762dbb37adbce99bcff8d53a670a86c66714d0f` from `5a1d8dd766d3b90d3ef662b337e5e9c46687be78`
- `synthesis`: `registry.ide-newton.ts.net/lab/synthesis@sha256:08fd7deddd0b65e1bd1e53639e01aad4a7ad1a8a7e041493c0a37f19f78ae24c` from `5a1d8dd766d3b90d3ef662b337e5e9c46687be78`

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- <image>@<digest> linux/amd64 linux/arm64` for each promoted image.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.