### PR TITLE
chore(torghut): promote image sha-9db22fb1ee8dc4af92e879736893a1770373dc35

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -24,7 +24,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: migrate
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:20099957a6cfe9545a9b2bed20a1dcbf034746a5e65d5cf71e347188f221bcd2
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1098d12a52edbc578baf41b685bf578f0de2dbfc969097ecac17ac6e92827b28
           imagePullPolicy: Always
           workingDir: /app
           command:
@@ -54,9 +54,9 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: 4218e0b632cd70c54e8b6690d2ef688979c88407
+              value: 9db22fb1ee8dc4af92e879736893a1770373dc35
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:20099957a6cfe9545a9b2bed20a1dcbf034746a5e65d5cf71e347188f221bcd2
+              value: sha256:1098d12a52edbc578baf41b685bf578f0de2dbfc969097ecac17ac6e92827b28
             - name: PYTHONPATH
               value: /app
             - name: DB_DSN

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-hyperliquid-runtime
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:20099957a6cfe9545a9b2bed20a1dcbf034746a5e65d5cf71e347188f221bcd2
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1098d12a52edbc578baf41b685bf578f0de2dbfc969097ecac17ac6e92827b28
           imagePullPolicy: Always
           command:
             - uvicorn
@@ -46,9 +46,9 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: 4218e0b632cd70c54e8b6690d2ef688979c88407
+              value: 9db22fb1ee8dc4af92e879736893a1770373dc35
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:20099957a6cfe9545a9b2bed20a1dcbf034746a5e65d5cf71e347188f221bcd2
+              value: sha256:1098d12a52edbc578baf41b685bf578f0de2dbfc969097ecac17ac6e92827b28
             - name: DB_DSN
               valueFrom:
                 secretKeyRef:

--- a/argocd/applications/torghut-options/archive/deployment.yaml
+++ b/argocd/applications/torghut-options/archive/deployment.yaml
@@ -35,7 +35,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: await-options-schema
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:20099957a6cfe9545a9b2bed20a1dcbf034746a5e65d5cf71e347188f221bcd2
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1098d12a52edbc578baf41b685bf578f0de2dbfc969097ecac17ac6e92827b28
           imagePullPolicy: IfNotPresent
           command:
             - python
@@ -64,7 +64,7 @@ spec:
                 - ALL
       containers:
         - name: torghut-options-archive
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:20099957a6cfe9545a9b2bed20a1dcbf034746a5e65d5cf71e347188f221bcd2
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1098d12a52edbc578baf41b685bf578f0de2dbfc969097ecac17ac6e92827b28
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -100,9 +100,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2118-g4218e0b63
+              value: v0.596.0-2120-g9db22fb1e
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 4218e0b632cd70c54e8b6690d2ef688979c88407
+              value: 9db22fb1ee8dc4af92e879736893a1770373dc35
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -33,7 +33,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: await-options-schema
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:20099957a6cfe9545a9b2bed20a1dcbf034746a5e65d5cf71e347188f221bcd2
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1098d12a52edbc578baf41b685bf578f0de2dbfc969097ecac17ac6e92827b28
           imagePullPolicy: IfNotPresent
           command:
             - python
@@ -62,7 +62,7 @@ spec:
                 - ALL
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:20099957a6cfe9545a9b2bed20a1dcbf034746a5e65d5cf71e347188f221bcd2
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1098d12a52edbc578baf41b685bf578f0de2dbfc969097ecac17ac6e92827b28
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -110,9 +110,9 @@ spec:
                   name: torghut-ws-config
                   key: SYMBOLS_ALLOWLIST
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2118-g4218e0b63
+              value: v0.596.0-2120-g9db22fb1e
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 4218e0b632cd70c54e8b6690d2ef688979c88407
+              value: 9db22fb1ee8dc4af92e879736893a1770373dc35
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: await-options-schema
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:20099957a6cfe9545a9b2bed20a1dcbf034746a5e65d5cf71e347188f221bcd2
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1098d12a52edbc578baf41b685bf578f0de2dbfc969097ecac17ac6e92827b28
           imagePullPolicy: IfNotPresent
           command:
             - python
@@ -63,7 +63,7 @@ spec:
                 - ALL
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:20099957a6cfe9545a9b2bed20a1dcbf034746a5e65d5cf71e347188f221bcd2
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1098d12a52edbc578baf41b685bf578f0de2dbfc969097ecac17ac6e92827b28
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -106,9 +106,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2118-g4218e0b63
+              value: v0.596.0-2120-g9db22fb1e
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 4218e0b632cd70c54e8b6690d2ef688979c88407
+              value: 9db22fb1ee8dc4af92e879736893a1770373dc35
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:20099957a6cfe9545a9b2bed20a1dcbf034746a5e65d5cf71e347188f221bcd2
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:1098d12a52edbc578baf41b685bf578f0de2dbfc969097ecac17ac6e92827b28
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:20099957a6cfe9545a9b2bed20a1dcbf034746a5e65d5cf71e347188f221bcd2
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:1098d12a52edbc578baf41b685bf578f0de2dbfc969097ecac17ac6e92827b28
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:20099957a6cfe9545a9b2bed20a1dcbf034746a5e65d5cf71e347188f221bcd2
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:1098d12a52edbc578baf41b685bf578f0de2dbfc969097ecac17ac6e92827b28
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:20099957a6cfe9545a9b2bed20a1dcbf034746a5e65d5cf71e347188f221bcd2
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:1098d12a52edbc578baf41b685bf578f0de2dbfc969097ecac17ac6e92827b28
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -27,7 +27,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:20099957a6cfe9545a9b2bed20a1dcbf034746a5e65d5cf71e347188f221bcd2
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1098d12a52edbc578baf41b685bf578f0de2dbfc969097ecac17ac6e92827b28
           workingDir: /app
           command:
             - /bin/sh

--- a/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
+++ b/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-generated-resource-retention
           containers:
             - name: prune-generated-residue
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:20099957a6cfe9545a9b2bed20a1dcbf034746a5e65d5cf71e347188f221bcd2
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:1098d12a52edbc578baf41b685bf578f0de2dbfc969097ecac17ac6e92827b28
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:20099957a6cfe9545a9b2bed20a1dcbf034746a5e65d5cf71e347188f221bcd2
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:1098d12a52edbc578baf41b685bf578f0de2dbfc969097ecac17ac6e92827b28
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-16T11:17:54Z"
+        client.knative.dev/updateTimestamp: "2026-07-16T11:33:17Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:20099957a6cfe9545a9b2bed20a1dcbf034746a5e65d5cf71e347188f221bcd2
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1098d12a52edbc578baf41b685bf578f0de2dbfc969097ecac17ac6e92827b28
           ports:
             - name: http1
               containerPort: 8181
@@ -507,11 +507,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2118-g4218e0b63
+              value: v0.596.0-2120-g9db22fb1e
             - name: TORGHUT_COMMIT
-              value: 4218e0b632cd70c54e8b6690d2ef688979c88407
+              value: 9db22fb1ee8dc4af92e879736893a1770373dc35
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:20099957a6cfe9545a9b2bed20a1dcbf034746a5e65d5cf71e347188f221bcd2
+              value: sha256:1098d12a52edbc578baf41b685bf578f0de2dbfc969097ecac17ac6e92827b28
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-16T11:17:54Z"
+        client.knative.dev/updateTimestamp: "2026-07-16T11:33:17Z"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
     spec:
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:20099957a6cfe9545a9b2bed20a1dcbf034746a5e65d5cf71e347188f221bcd2
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1098d12a52edbc578baf41b685bf578f0de2dbfc969097ecac17ac6e92827b28
           ports:
             - name: http1
               containerPort: 8181
@@ -448,11 +448,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2118-g4218e0b63
+              value: v0.596.0-2120-g9db22fb1e
             - name: TORGHUT_COMMIT
-              value: 4218e0b632cd70c54e8b6690d2ef688979c88407
+              value: 9db22fb1ee8dc4af92e879736893a1770373dc35
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:20099957a6cfe9545a9b2bed20a1dcbf034746a5e65d5cf71e347188f221bcd2
+              value: sha256:1098d12a52edbc578baf41b685bf578f0de2dbfc969097ecac17ac6e92827b28
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -37,7 +37,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:20099957a6cfe9545a9b2bed20a1dcbf034746a5e65d5cf71e347188f221bcd2
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1098d12a52edbc578baf41b685bf578f0de2dbfc969097ecac17ac6e92827b28
           command:
             - uvicorn
           args:
@@ -464,11 +464,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2118-g4218e0b63
+              value: v0.596.0-2120-g9db22fb1e
             - name: TORGHUT_COMMIT
-              value: 4218e0b632cd70c54e8b6690d2ef688979c88407
+              value: 9db22fb1ee8dc4af92e879736893a1770373dc35
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:20099957a6cfe9545a9b2bed20a1dcbf034746a5e65d5cf71e347188f221bcd2
+              value: sha256:1098d12a52edbc578baf41b685bf578f0de2dbfc969097ecac17ac6e92827b28
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: smoke
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:20099957a6cfe9545a9b2bed20a1dcbf034746a5e65d5cf71e347188f221bcd2
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1098d12a52edbc578baf41b685bf578f0de2dbfc969097ecac17ac6e92827b28
           imagePullPolicy: IfNotPresent
           securityContext:
             seccompProfile:


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `9db22fb1ee8dc4af92e879736893a1770373dc35`
- Image tag: `sha-9db22fb1ee8dc4af92e879736893a1770373dc35`
- Image digest: `sha256:1098d12a52edbc578baf41b685bf578f0de2dbfc969097ecac17ac6e92827b28`
- Migration change detected under `services/torghut/migrations/**`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher
- Added `do-not-automerge`; manual DB migration approval required before merge