### PR TITLE
feat(torghut): add independent economic ledger kernel

### DIFF
--- a/docs/torghut/profitability/implementation-roadmap.md
+++ b/docs/torghut/profitability/implementation-roadmap.md
@@ -225,6 +225,8 @@ Detailed design: [Broker Economic Source Ingestion](broker-economic-source-inges
 **Invariant:** profitability is reconstructed from broker economic events by a reducer independent of trading decisions
 and the existing runtime ledger.
 
+Detailed design: [Independent Broker-Economic Ledger](independent-economic-ledger.md).
+
 - Deliverable: deterministic double-entry projections for positions, cash, equity, realized/unrealized P&L, fees,
   dividends, corrections, and corporate actions; retain both canonical and independent reducers.
 - Primary surfaces: new isolated ledger package, CNPG migrations/views, reconciliation API, and deterministic replay CLI.

--- a/docs/torghut/profitability/independent-economic-ledger.md
+++ b/docs/torghut/profitability/independent-economic-ledger.md
@@ -66,6 +66,10 @@ The input manifest orders activities by economic timestamp, settlement date, ext
 `event_at` and `first_observed_at` are retained separately. Late and corrected facts therefore preserve both when the
 broker says they occurred and when Torghut learned them.
 
+An Alpaca asset `CFEE` row that has a settlement date but no event timestamp sorts at the end of that UTC date. This
+keeps a date-only fee behind the same-day timestamped fills whose received asset it charges. Other date-only activity
+retains the start-of-day convention until a documented broker shape requires a more specific rule.
+
 ## Shared Input Contract
 
 The pure reducer accepts bounded decimal and identifier values only:

--- a/docs/torghut/profitability/independent-economic-ledger.md
+++ b/docs/torghut/profitability/independent-economic-ledger.md
@@ -161,10 +161,9 @@ Fees remain separate from gross trade PnL so both gross and after-cost results a
 
 ### Corporate Actions And Corrections
 
-- a single-delta split row with no cash component changes units while preserving total signed cost. Paired reverse-split
-  `REMOVE`/`ADD` rows, a row that removes the current position, and any `SSP` row with nonzero `net_amount` remain
-  unsupported until a sourced golden fixture establishes the complete broker semantics; both reducers fail these
-  shapes closed instead of applying only part of the corporate action;
+- every `SSP` row remains unsupported until a sourced golden fixture establishes whether Alpaca reports a single delta,
+  paired `REMOVE`/`ADD` rows, cash in lieu, and basis changes. Both reducers fail the entire shape closed instead of
+  applying a speculative or partial corporate action;
 - symbol/name changes move both quantity and cost from old to new identity in one balanced transaction;
 - dividends, return of capital, assignments, exercises, expirations, mergers, spin-offs, and reorganizations require an
   explicit typed rule and a golden broker fixture before they become admissible;

--- a/docs/torghut/profitability/independent-economic-ledger.md
+++ b/docs/torghut/profitability/independent-economic-ledger.md
@@ -150,7 +150,9 @@ Fees remain separate from gross trade PnL so both gross and after-cost results a
 
 ### Corporate Actions And Corrections
 
-- split and reverse-split rows change units while preserving total signed cost;
+- split and reverse-split rows with no cash component change units while preserving total signed cost. An `SSP` row
+  with nonzero `net_amount` is an unsupported cash-in-lieu shape until a sourced posting rule and golden broker fixture
+  exist; both reducers fail it closed instead of dropping cash;
 - symbol/name changes move both quantity and cost from old to new identity in one balanced transaction;
 - dividends, return of capital, assignments, exercises, expirations, mergers, spin-offs, and reorganizations require an
   explicit typed rule and a golden broker fixture before they become admissible;

--- a/docs/torghut/profitability/independent-economic-ledger.md
+++ b/docs/torghut/profitability/independent-economic-ledger.md
@@ -1,0 +1,262 @@
+# Independent Broker-Economic Ledger
+
+Status: Slice 8 implementation design
+
+Last updated: 2026-07-16
+
+## Decision
+
+Torghut will reconstruct account economics from immutable Alpaca account activities with two separately implemented
+reducers:
+
+1. a canonical double-entry journal reducer; and
+2. an independent position-and-cash state reducer used only as a differential check.
+
+The reducers share the immutable input contract and comparison result, but they do not share posting, cost-basis, or
+position-transition logic. A common bug therefore cannot pass merely because both projections call the same accounting
+helper.
+
+Neither reducer is a broker, execution, capital, or mutation authority. Both are disposable projections. The only
+executed-economic source is `broker_account_activities` from
+`source=account_activities_rest`. `trade_updates_ws` remains a low-latency corroborating source for Slice 7 fill
+equivalence and is never counted a second time.
+
+This design follows Alpaca's official
+[account-activity contract](https://docs.alpaca.markets/us/docs/account-activities),
+[crypto fee contract](https://docs.alpaca.markets/us/docs/crypto-trading), and
+[position cost-basis behavior](https://docs.alpaca.markets/us/docs/position-average-entry-price-calculation). It uses
+immutable balanced entries and explicit reversals, consistent with
+[event-sourced accounting](https://martinfowler.com/eaaDev/EventSourcing.html) and
+[two-legged accounting transactions](https://martinfowler.com/eaaDev/AccountingTransaction.html). TigerBeetle remains
+the later independent durable ledger comparison in Slice 10, not an implementation dependency of this reducer.
+
+## Verified Production Shape
+
+Read-only Alpaca paper-account inspection on 2026-07-16 established the current input shape without retaining raw
+account data:
+
+- the first 2,000 ascending activities were incomplete and contained 1,981 fills, 18 fees, and one cash journal;
+- an activity-type-complete read contained 63 USD fees: 38 `TAF`, 18 `CAT`, four `OCC`, and three `ORF`, all negative
+  cash amounts;
+- seven `CFEE` rows contained quantity, price, and symbol; four had negative cash impact and three had zero cash impact;
+- one `JNLC` row had positive cash impact;
+- the latest 100 fills contained both equities and crypto, buys and sells, and no broker-provided `net_amount`.
+
+Therefore a credible projection must calculate fill notionals, account for order-independent regulatory fees, handle
+crypto fees charged in the received asset, and retain external cash journals. A fill-only realized-PnL counter is not
+acceptable.
+
+## Authority And Completeness Boundary
+
+A projection run is admissible only when all of these are true:
+
+- the scope is one provider, environment, account label, endpoint fingerprint, and quote currency;
+- the REST cursor exists, is `complete`, has no error, and names a closed scan watermark;
+- every selected source row is `account_activities_rest` and its database-verified raw hash is present;
+- source identities are unique; identical duplicates collapse and contradictory duplicate bytes fail;
+- the ordered input manifest and its SHA-256 digest are persisted with the reducer version;
+- every activity type is either supported by an explicit versioned posting rule or appears in the unsupported residual
+  set; any unsupported residual makes the run non-admissible;
+- every journal transaction balances to zero independently for each commodity;
+- canonical and independent cash, quantity, cost, realized PnL, fee, income, and equity outputs agree exactly at the
+  configured decimal scale;
+- reconciliation uses a fresh read-only broker account/position snapshot captured after the source watermark.
+
+The input manifest orders activities by economic timestamp, settlement date, external activity ID, and raw hash.
+`event_at` and `first_observed_at` are retained separately. Late and corrected facts therefore preserve both when the
+broker says they occurred and when Torghut learned them.
+
+## Shared Input Contract
+
+The pure reducer accepts bounded decimal and identifier values only:
+
+- external activity ID, raw payload hash, type, subtype, correction reference;
+- event timestamp, settlement date, first-observed timestamp;
+- symbol, side, quantity, price, net cash amount, and currency;
+- provider/account/environment/endpoint scope.
+
+The SQLAlchemy model is adapted into this value object at the boundary. The reducer never reads mutable strategy,
+execution, runtime-ledger, candidate, or TigerBeetle state.
+
+### Fixed-point contract
+
+All source quantity, price, and cash fields must fit PostgreSQL `NUMERIC(38, 18)` exactly; inputs with more than 18
+fractional digits or at least 20 integer digits fail closed instead of being silently rounded. Reducers calculate with
+an 80-digit local decimal context and persist every derived notional, released cost, carrying value, fee, and realized
+amount at 18 fractional digits using decimal `ROUND_HALF_UP`, matching Torghut's existing TigerBeetle conversion rule.
+
+Weighted-average partial closes round the released cost once. The retained position receives the exact residual carrying
+cost; a full close releases the complete remaining carrying cost without division. Realized PnL is the exact balancing
+residual of fixed-point cash and carrying-cost deltas. This keeps every commodity transaction exactly balanced and makes
+the two reducers comparable without an epsilon while avoiding context-dependent repeating-decimal dust.
+
+## Chart Of Accounts And Commodities
+
+Amounts use debit-positive signs. Each transaction balances separately by commodity.
+
+USD accounts:
+
+- `asset:cash`;
+- `asset:position_cost:<symbol>` for long inventory or a credit balance for short inventory;
+- `equity:external_flow` for deposits, withdrawals, and cash journals;
+- `income:realized_pnl`;
+- `income:dividend` and `income:interest`;
+- `expense:broker_fee`, `expense:regulatory_fee`, and `expense:withholding`;
+- `equity:corporate_action` only for an explicitly broker-reported cash or basis adjustment.
+
+Quantity accounts use the canonical asset symbol as their commodity:
+
+- `asset:position_units:<symbol>`; and
+- a transaction-specific clearing account such as `clearing:broker_fill`, `clearing:fee`, or
+  `clearing:corporate_action`.
+
+This separates monetary cost from security quantity while preserving double entry in both dimensions. Market value is
+a derived mark, not historical cost and not a source mutation.
+
+## Posting Rules
+
+### Fills
+
+For each `FILL`, quantity and price must be positive, side must be `buy` or `sell`, and USD notional is
+`quantity * price` with no binary floating point.
+
+- a buy credits cash and debits position cost for newly opened long quantity;
+- a sell debits cash and credits position cost for newly opened short quantity;
+- the portion that closes an existing position releases weighted-average signed cost and posts the difference between
+  proceeds/cost and released cost to realized PnL;
+- a side flip is split deterministically into a closing leg and an opening leg inside one balanced transaction;
+- quantity entries move units between broker clearing and the position account.
+
+The canonical reducer uses explicit signed weighted-average cost. The independent reducer computes the same terminal
+contract through a separately coded state transition. Alpaca can change displayed average entry price at its beginning-
+of-day compression, so broker average-entry-price differences are classified separately from quantity, cash, and total
+equity. A flat round trip must converge exactly regardless of lot-display method.
+
+### Cash, Fees, Dividends, And Interest
+
+- positive `CSD`, `JNLC`, `JNL`, or cash-transfer net amount debits cash and credits external flow;
+- negative cash flow reverses those legs;
+- USD `FEE`, `DIVFEE`, pass-through charge, and withholding debits the matching expense and credits cash;
+- positive dividend or interest net amount debits cash and credits income; negative adjustments reverse the original
+  economic category;
+- `CFEE` with nonzero `net_amount` posts as a cash fee;
+- `CFEE` with zero cash and nonzero asset quantity reduces the named asset units, releases their signed average cost,
+  posts fair-value fee expense from broker quantity times price, and records any cost/fair-value difference as realized
+  PnL. Crypto may not become short through a fee.
+
+Fees remain separate from gross trade PnL so both gross and after-cost results are reproducible.
+
+### Corporate Actions And Corrections
+
+- split and reverse-split rows change units while preserving total signed cost;
+- symbol/name changes move both quantity and cost from old to new identity in one balanced transaction;
+- dividends, return of capital, assignments, exercises, expirations, mergers, spin-offs, and reorganizations require an
+  explicit typed rule and a golden broker fixture before they become admissible;
+- `previous_id` never edits or deletes history. A correction creates exact reversing entries for the superseded
+  transaction and applies the replacement fact;
+- a correction chain occupies its root activity's original economic-order slot, so a late replacement rebuilds the
+  historical projection instead of being misclassified as a new trade at observation time; every replacement timestamp
+  remains in the immutable input manifest;
+- correction chains are resolved before replay, cycles and missing predecessors fail closed, and the manifest records
+  every source row even when its economic effect is reversed.
+
+Unknown activity types are residual evidence, not zero-value no-ops.
+
+## Projection Contract
+
+Each reducer emits the same immutable result shape:
+
+- ordered input count, first/last event, source manifest digest, and reducer version;
+- cash by currency;
+- signed quantity, signed cost, and average cost by symbol;
+- realized PnL, fees, dividends, interest, external flows, and other supported adjustments;
+- optional marks, market value, unrealized PnL, and equity;
+- unsupported, corrected, duplicate, and contradiction counts;
+- deterministic transaction/result digests.
+
+For a mark `m`, signed market value is `quantity * m`, unrealized PnL is `market_value - signed_cost`, and equity is
+cash plus signed market value. Marks carry their own source, timestamp, and digest and never alter historical entries.
+
+The comparison report enumerates every field delta. It has no tolerance for cash, source quantities, balanced entries,
+or realized values derived from identical decimals. Broker snapshot comparisons use explicit configured tolerances only
+for venue-displayed marks and timing differences.
+
+## Minimal Persistence
+
+Persistence will use the existing CNPG database and only three append-only projections:
+
+1. `broker_economic_ledger_runs` stores scope, reducer version, input manifest/watermark, result JSON, and result digest;
+2. `broker_economic_ledger_entries` stores balanced lines keyed by run, source activity, transaction, commodity, and line
+   number;
+3. `broker_economic_reconciliations` stores the two run IDs, fresh broker snapshot digest, exact deltas, residuals, and
+   admissibility.
+
+There is no mutable ledger cursor, approval row, order path, queue, or second account-activity table. A run and all of
+its entries commit atomically after pure reduction succeeds. Failed runs write no partial projection. PostgreSQL rejects
+update/delete/truncate, verifies canonical JSON hashes, and independently checks contiguous entry lines and per-
+transaction commodity balance. Rebuild creates a new versioned run; it never rewrites an old proof.
+
+## Replay And Publication
+
+The deterministic replay CLI is read-only until publication:
+
+1. lock no source rows and read one repeatable-read snapshot;
+2. require the completed REST cursor and build the ordered manifest;
+3. run both reducers in memory;
+4. validate accounting identities and exact differential equality;
+5. optionally fetch a read-only broker snapshot and calculate broker deltas;
+6. print the complete report in dry-run mode;
+7. publish only with an explicit confirmation token, in one database transaction, if the source watermark is unchanged.
+
+Re-running the same reducer version and input digest returns the existing immutable run. A different result for the same
+identity is a hard contradiction.
+
+## Status And Capital Boundary
+
+Slice 8 exposes freshness, input watermark, reducer versions, admissibility, and all residual counts in the trading
+status response. It does not by itself enable entry or promotion. Slice 10 will make fresh zero-unexplained-delta parity
+blocking for risk increase while leaving service health and reduce-only recovery available.
+
+The existing runtime ledger remains visible as a legacy decision-lineage projection until Slice 9 completes repair. It
+is never silently relabeled as the broker-economic ledger.
+
+## Delivery Sequence
+
+To keep review and rollback small, Slice 8 is delivered as three production changes:
+
+1. pure input contract, canonical journal reducer, independent state reducer, differential checker, and golden/property
+   tests;
+2. minimal append-only CNPG persistence plus dry-run-first replay/publication CLI;
+3. fresh broker snapshot reconciliation, status surface, GitOps schedule, and production replay proof.
+
+Each change is independently useful and removable. No framework or generic accounting DSL is introduced.
+
+## Required Tests
+
+- balanced entries for every commodity and every supported activity;
+- partial fills, long and short reductions, side flips, and full round trips;
+- USD fees, regulatory fees, crypto asset fees, deposits, withdrawals, journals, dividends, and interest;
+- splits, symbol changes, corrections, correction chains, missing predecessors, and cycles;
+- duplicate-identical and duplicate-contradictory source identities;
+- shuffled input, restart from serialized state, repeated replay, and digest determinism;
+- randomized differential fill sequences with no NaN, infinity, sign flip, or unbalanced counterexample;
+- database hash, immutability, transaction-balance, stale-watermark, and concurrent-publication races;
+- broker snapshot mismatch, stale mark, unsupported residual, incomplete cursor, and unknown activity type;
+- golden fixtures derived from documented Alpaca shapes with no production account values embedded in source control.
+
+## Production Proof
+
+Slice 8 is complete only when an exact deployed image:
+
+- replays the full completed paper-account REST activity history from the 2016 cursor boundary;
+- publishes two independently versioned runs with the same nonempty manifest digest;
+- reports every journal transaction balanced and zero canonical/independent differential;
+- reconciles current flat broker positions, open orders, cash, and equity at a fresh snapshot or classifies every timing
+  delta;
+- repeats after process restart with identical result and entry digests;
+- proves one injected source contradiction and one unsupported type fail closed without a partial run;
+- records source commit, image digest, Argo revision, migration, cursor watermark, run IDs, digests, and residuals in the
+  append-only Slice 8 evidence bundle.
+
+This proof establishes deterministic broker-economic reconstruction. It does not establish strategy profitability,
+TigerBeetle parity, decision lineage completeness, paper promotion, or live-capital authority.

--- a/docs/torghut/profitability/independent-economic-ledger.md
+++ b/docs/torghut/profitability/independent-economic-ledger.md
@@ -136,7 +136,9 @@ equity. A flat round trip must converge exactly regardless of lot-display method
 
 - positive `CSD`, `JNLC`, `JNL`, or cash-transfer net amount debits cash and credits external flow;
 - negative cash flow reverses those legs;
-- USD `FEE`, `DIVFEE`, pass-through charge, and withholding debits the matching expense and credits cash;
+- USD `FEE`, `DIVFEE`, pass-through charge, and withholding debits the matching expense and credits cash. Alpaca
+  `DIVFT`, `DIVNRA`, `DIVTW`, `INTNRA`, and `INTTW` rows are withholding expenses, never negative dividend or interest
+  income;
 - positive dividend or interest net amount debits cash and credits income; negative adjustments reverse the original
   economic category;
 - `CFEE` with nonzero `net_amount` posts as a cash fee;

--- a/docs/torghut/profitability/independent-economic-ledger.md
+++ b/docs/torghut/profitability/independent-economic-ledger.md
@@ -96,6 +96,9 @@ cost; a full close releases the complete remaining carrying cost without divisio
 residual of fixed-point cash and carrying-cost deltas. This keeps every commodity transaction exactly balanced and makes
 the two reducers comparable without an epsilon while avoiding context-dependent repeating-decimal dust.
 
+A nonzero fill notional or asset-fee fair value that rounds below the 18-decimal ledger quantum is rejected before any
+position mutation. Nonzero units can never enter the projection with zero cash, zero cost, or zero fee economics.
+
 ## Chart Of Accounts And Commodities
 
 Amounts use debit-positive signs. Each transaction balances separately by commodity.

--- a/docs/torghut/profitability/independent-economic-ledger.md
+++ b/docs/torghut/profitability/independent-economic-ledger.md
@@ -120,6 +120,10 @@ a derived mark, not historical cost and not a source mutation.
 For each `FILL`, quantity and price must be positive, side must be `buy` or `sell`, and USD notional is
 `quantity * price` with no binary floating point.
 
+A `FILL` with nonzero `net_amount` is not silently treated as quantity-times-price cash. It remains unsupported until
+a golden broker fixture establishes whether that field is gross, fee-inclusive, or net settlement and a sourced
+posting rule is implemented in both reducers.
+
 - a buy credits cash and debits position cost for newly opened long quantity;
 - a sell debits cash and credits position cost for newly opened short quantity;
 - the portion that closes an existing position releases weighted-average signed cost and posts the difference between

--- a/docs/torghut/profitability/independent-economic-ledger.md
+++ b/docs/torghut/profitability/independent-economic-ledger.md
@@ -161,9 +161,10 @@ Fees remain separate from gross trade PnL so both gross and after-cost results a
 
 ### Corporate Actions And Corrections
 
-- split and reverse-split rows with no cash component change units while preserving total signed cost. An `SSP` row
-  with nonzero `net_amount` is an unsupported cash-in-lieu shape until a sourced posting rule and golden broker fixture
-  exist; both reducers fail it closed instead of dropping cash;
+- a single-delta split row with no cash component changes units while preserving total signed cost. Paired reverse-split
+  `REMOVE`/`ADD` rows, a row that removes the current position, and any `SSP` row with nonzero `net_amount` remain
+  unsupported until a sourced golden fixture establishes the complete broker semantics; both reducers fail these
+  shapes closed instead of applying only part of the corporate action;
 - symbol/name changes move both quantity and cost from old to new identity in one balanced transaction;
 - dividends, return of capital, assignments, exercises, expirations, mergers, spin-offs, and reorganizations require an
   explicit typed rule and a golden broker fixture before they become admissible;

--- a/docs/torghut/profitability/independent-economic-ledger.md
+++ b/docs/torghut/profitability/independent-economic-ledger.md
@@ -41,6 +41,8 @@ account data:
 - seven `CFEE` rows contained quantity, price, and symbol; four had negative cash impact and three had zero cash impact;
 - one `JNLC` row had positive cash impact;
 - the latest 100 fills contained both equities and crypto, buys and sells, and no broker-provided `net_amount`.
+- the full REST history contained 31 historical equity fills with `side=sell_short`, despite the current Alpaca
+  activity documentation describing only `buy` and `sell`.
 
 Therefore a credible projection must calculate fill notionals, account for order-independent regulatory fees, handle
 crypto fees charged in the received asset, and retain external cash journals. A fill-only realized-PnL counter is not
@@ -121,8 +123,9 @@ a derived mark, not historical cost and not a source mutation.
 
 ### Fills
 
-For each `FILL`, quantity and price must be positive, side must be `buy` or `sell`, and USD notional is
-`quantity * price` with no binary floating point.
+For each `FILL`, quantity and price must be positive, side must be `buy`, `sell`, or the empirically observed historical
+`sell_short` alias, and USD notional is `quantity * price` with no binary floating point. `sell_short` has sell direction
+but remains unchanged in the immutable manifest; no other undocumented side is inferred.
 
 A `FILL` with nonzero `net_amount` is not silently treated as quantity-times-price cash. It remains unsupported until
 a golden broker fixture establishes whether that field is gross, fee-inclusive, or net settlement and a sourced

--- a/services/torghut/app/trading/economic_ledger/__init__.py
+++ b/services/torghut/app/trading/economic_ledger/__init__.py
@@ -1,0 +1,65 @@
+"""Independent broker-economic ledger reducers."""
+
+from .comparison import (
+    DualReduction,
+    ProjectionComparison,
+    ProjectionDelta,
+    compare_projections,
+    reduce_and_compare,
+)
+from .journal_reducer import (
+    JOURNAL_REDUCER_NAME,
+    JOURNAL_REDUCER_VERSION,
+    reduce_balanced_journal,
+)
+from .state_reducer import (
+    STATE_REDUCER_NAME,
+    STATE_REDUCER_VERSION,
+    reduce_independent_state,
+)
+from .types import (
+    ZERO,
+    ActivityChain,
+    CommodityBalance,
+    EconomicActivity,
+    EconomicLedgerCorrectionError,
+    EconomicLedgerError,
+    EconomicLedgerSourceContradiction,
+    EconomicProjection,
+    JournalReduction,
+    LedgerLine,
+    LedgerScope,
+    LedgerTransaction,
+    PositionBalance,
+    PreparedActivities,
+    prepare_activities,
+)
+
+__all__ = (
+    "ZERO",
+    "ActivityChain",
+    "CommodityBalance",
+    "DualReduction",
+    "EconomicActivity",
+    "EconomicLedgerCorrectionError",
+    "EconomicLedgerError",
+    "EconomicLedgerSourceContradiction",
+    "EconomicProjection",
+    "JOURNAL_REDUCER_NAME",
+    "JOURNAL_REDUCER_VERSION",
+    "JournalReduction",
+    "LedgerLine",
+    "LedgerScope",
+    "LedgerTransaction",
+    "PositionBalance",
+    "PreparedActivities",
+    "ProjectionComparison",
+    "ProjectionDelta",
+    "STATE_REDUCER_NAME",
+    "STATE_REDUCER_VERSION",
+    "compare_projections",
+    "prepare_activities",
+    "reduce_and_compare",
+    "reduce_balanced_journal",
+    "reduce_independent_state",
+)

--- a/services/torghut/app/trading/economic_ledger/comparison.py
+++ b/services/torghut/app/trading/economic_ledger/comparison.py
@@ -1,0 +1,207 @@
+"""Exact differential comparison between independent economic projections."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+
+from .journal_reducer import reduce_balanced_journal
+from .state_reducer import reduce_independent_state
+from .types import (
+    ZERO,
+    EconomicActivity,
+    EconomicLedgerError,
+    EconomicProjection,
+    JournalReduction,
+    PositionBalance,
+    PreparedActivities,
+    canonical_sha256,
+    decimal_text,
+    prepare_activities,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectionDelta:
+    path: str
+    canonical: str
+    independent: str
+    difference: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectionComparison:
+    canonical_reducer: str
+    independent_reducer: str
+    input_manifest_digest: str
+    deltas: tuple[ProjectionDelta, ...]
+    comparison_digest: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "comparison_digest",
+            canonical_sha256(
+                {
+                    "canonical_reducer": self.canonical_reducer,
+                    "deltas": [
+                        {
+                            "canonical": delta.canonical,
+                            "difference": delta.difference,
+                            "independent": delta.independent,
+                            "path": delta.path,
+                        }
+                        for delta in self.deltas
+                    ],
+                    "independent_reducer": self.independent_reducer,
+                    "input_manifest_digest": self.input_manifest_digest,
+                }
+            ),
+        )
+
+    @property
+    def equivalent(self) -> bool:
+        return not self.deltas
+
+
+@dataclass(frozen=True, slots=True)
+class DualReduction:
+    journal: JournalReduction
+    independent: EconomicProjection
+    comparison: ProjectionComparison
+
+    @property
+    def admissible(self) -> bool:
+        return (
+            self.journal.projection.admissible
+            and self.independent.admissible
+            and self.comparison.equivalent
+        )
+
+
+def compare_projections(
+    canonical: EconomicProjection,
+    independent: EconomicProjection,
+) -> ProjectionComparison:
+    """Compare two projections of the exact same immutable input with no tolerance."""
+
+    if (
+        canonical.scope != independent.scope
+        or canonical.input_manifest_digest != independent.input_manifest_digest
+        or canonical.input_count != independent.input_count
+        or canonical.duplicate_count != independent.duplicate_count
+        or canonical.corrected_count != independent.corrected_count
+    ):
+        raise EconomicLedgerError("economic_projection_inputs_do_not_match")
+
+    deltas: list[ProjectionDelta] = []
+    canonical_cash = {item.commodity: item.amount for item in canonical.cash}
+    independent_cash = {item.commodity: item.amount for item in independent.cash}
+    for commodity in sorted(set(canonical_cash) | set(independent_cash)):
+        _append_decimal_delta(
+            deltas,
+            path=f"cash.{commodity}",
+            canonical=canonical_cash.get(commodity, ZERO),
+            independent=independent_cash.get(commodity, ZERO),
+        )
+
+    canonical_positions = {item.symbol: item for item in canonical.positions}
+    independent_positions = {item.symbol: item for item in independent.positions}
+    for symbol in sorted(set(canonical_positions) | set(independent_positions)):
+        canonical_position = canonical_positions.get(symbol) or _zero_position(symbol)
+        independent_position = independent_positions.get(symbol) or _zero_position(
+            symbol
+        )
+        _append_decimal_delta(
+            deltas,
+            path=f"positions.{symbol}.quantity",
+            canonical=canonical_position.quantity,
+            independent=independent_position.quantity,
+        )
+        _append_decimal_delta(
+            deltas,
+            path=f"positions.{symbol}.signed_cost",
+            canonical=canonical_position.signed_cost,
+            independent=independent_position.signed_cost,
+        )
+
+    for field_name in (
+        "realized_pnl",
+        "fees",
+        "dividends",
+        "interest",
+        "external_flows",
+    ):
+        _append_decimal_delta(
+            deltas,
+            path=field_name,
+            canonical=getattr(canonical, field_name),
+            independent=getattr(independent, field_name),
+        )
+    if canonical.unsupported_activity_ids != independent.unsupported_activity_ids:
+        deltas.append(
+            ProjectionDelta(
+                path="unsupported_activity_ids",
+                canonical=",".join(canonical.unsupported_activity_ids),
+                independent=",".join(independent.unsupported_activity_ids),
+                difference=None,
+            )
+        )
+    return ProjectionComparison(
+        canonical_reducer=f"{canonical.reducer_name}:{canonical.reducer_version}",
+        independent_reducer=f"{independent.reducer_name}:{independent.reducer_version}",
+        input_manifest_digest=canonical.input_manifest_digest,
+        deltas=tuple(deltas),
+    )
+
+
+def reduce_and_compare(
+    activities: PreparedActivities
+    | tuple[EconomicActivity, ...]
+    | list[EconomicActivity],
+) -> DualReduction:
+    prepared = (
+        activities
+        if isinstance(activities, PreparedActivities)
+        else prepare_activities(activities)
+    )
+    journal = reduce_balanced_journal(prepared)
+    independent = reduce_independent_state(prepared)
+    return DualReduction(
+        journal=journal,
+        independent=independent,
+        comparison=compare_projections(journal.projection, independent),
+    )
+
+
+def _append_decimal_delta(
+    deltas: list[ProjectionDelta],
+    *,
+    path: str,
+    canonical: Decimal,
+    independent: Decimal,
+) -> None:
+    difference = canonical - independent
+    if difference == ZERO:
+        return
+    deltas.append(
+        ProjectionDelta(
+            path=path,
+            canonical=decimal_text(canonical) or "0",
+            independent=decimal_text(independent) or "0",
+            difference=decimal_text(difference),
+        )
+    )
+
+
+def _zero_position(symbol: str) -> PositionBalance:
+    return PositionBalance(symbol=symbol, quantity=ZERO, signed_cost=ZERO)
+
+
+__all__ = (
+    "DualReduction",
+    "ProjectionComparison",
+    "ProjectionDelta",
+    "compare_projections",
+    "reduce_and_compare",
+)

--- a/services/torghut/app/trading/economic_ledger/journal_reducer.py
+++ b/services/torghut/app/trading/economic_ledger/journal_reducer.py
@@ -166,6 +166,8 @@ class _JournalWriter:
 
         position = self.positions.setdefault(symbol, _Position())
         posting = _build_fill_posting(position, delta_quantity, price)
+        if posting.cash_delta == ZERO:
+            raise EconomicLedgerError("economic_fill_notional_below_ledger_quantum")
         transaction = _transaction(
             activity,
             posting_rule="fill_weighted_average",
@@ -274,6 +276,10 @@ class _JournalWriter:
             abs(quantity) * price,
             field_name="crypto_fee_fair_value",
         )
+        if fair_value == ZERO:
+            raise EconomicLedgerError(
+                "economic_crypto_fee_fair_value_below_ledger_quantum"
+            )
         if position.quantity <= ZERO or abs(quantity) > position.quantity:
             raise EconomicLedgerError("economic_crypto_fee_position_insufficient")
         if abs(quantity) == position.quantity:

--- a/services/torghut/app/trading/economic_ledger/journal_reducer.py
+++ b/services/torghut/app/trading/economic_ledger/journal_reducer.py
@@ -32,14 +32,13 @@ _DIVIDEND_TYPES = frozenset(
         "DIV",
         "DIVCGL",
         "DIVCGS",
-        "DIVFT",
-        "DIVNRA",
-        "DIVTW",
         "DIVTXEX",
     }
 )
-_INTEREST_TYPES = frozenset({"INT", "INTNRA", "INTTW"})
+_INTEREST_TYPES = frozenset({"INT"})
+_WITHHOLDING_TYPES = frozenset({"DIVFT", "DIVNRA", "DIVTW", "INTNRA", "INTTW"})
 _FEE_TYPES = frozenset({"DIVFEE", "FEE", "PTC"})
+_CASH_EXPENSE_TYPES = _FEE_TYPES | _WITHHOLDING_TYPES
 _REGULATORY_FEE_SUBTYPES = frozenset({"CAT", "OCC", "ORF", "REG", "TAF"})
 
 
@@ -123,7 +122,7 @@ class _JournalWriter:
                 account="income:interest",
                 rule="interest",
             )
-        elif activity_type in _FEE_TYPES:
+        elif activity_type in _CASH_EXPENSE_TYPES:
             transaction = self._cash_fee(activity)
         else:
             self.unsupported.add(activity.external_activity_id)
@@ -221,7 +220,9 @@ class _JournalWriter:
         if amount == ZERO:
             return None
         subtype = activity.activity_subtype or ""
-        if activity.activity_type == "DIVFEE":
+        if activity.activity_type == "DIVFEE" or (
+            activity.activity_type in _WITHHOLDING_TYPES
+        ):
             account = "expense:withholding"
         elif subtype.upper() in _REGULATORY_FEE_SUBTYPES:
             account = "expense:regulatory_fee"

--- a/services/torghut/app/trading/economic_ledger/journal_reducer.py
+++ b/services/torghut/app/trading/economic_ledger/journal_reducer.py
@@ -168,6 +168,10 @@ class _JournalWriter:
         posting = _build_fill_posting(position, delta_quantity, price)
         if posting.cash_delta == ZERO:
             raise EconomicLedgerError("economic_fill_notional_below_ledger_quantum")
+        if posting.new_quantity != ZERO and posting.new_cost == ZERO:
+            raise EconomicLedgerError(
+                "economic_fill_position_cost_below_ledger_quantum"
+            )
         transaction = _transaction(
             activity,
             posting_rule="fill_weighted_average",

--- a/services/torghut/app/trading/economic_ledger/journal_reducer.py
+++ b/services/torghut/app/trading/economic_ledger/journal_reducer.py
@@ -103,7 +103,11 @@ class _JournalWriter:
         elif activity_type == "CFEE":
             transaction = self._crypto_fee(activity)
         elif activity_type == "SSP":
-            transaction = self._split(activity)
+            if activity.net_amount not in {None, ZERO}:
+                self.unsupported.add(activity.external_activity_id)
+                transaction = None
+            else:
+                transaction = self._split(activity)
         elif activity_type in _CASH_TYPES or (
             activity_type == "JNL"
             and activity.symbol is None

--- a/services/torghut/app/trading/economic_ledger/journal_reducer.py
+++ b/services/torghut/app/trading/economic_ledger/journal_reducer.py
@@ -246,6 +246,7 @@ class _JournalWriter:
         price = activity.price
         if price is None or price <= ZERO:
             raise EconomicLedgerError("economic_crypto_fee_price_must_be_positive")
+        _require_quote_currency(activity)
         symbol = _required_symbol(activity)
         position = self.positions.setdefault(symbol, _Position())
         fair_value = quantize_ledger_decimal(
@@ -535,6 +536,8 @@ def _currency(activity: EconomicActivity, default: str) -> str:
 
 
 def _require_quote_currency(activity: EconomicActivity) -> None:
+    if activity.currency not in {None, activity.scope.quote_currency}:
+        raise EconomicLedgerError("economic_activity_currency_unsupported")
     symbol = activity.symbol or ""
     if "/" not in symbol:
         return

--- a/services/torghut/app/trading/economic_ledger/journal_reducer.py
+++ b/services/torghut/app/trading/economic_ledger/journal_reducer.py
@@ -1,0 +1,550 @@
+"""Canonical balanced-journal reducer for immutable broker activities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal, localcontext
+
+from .types import (
+    LEDGER_DECIMAL_PRECISION,
+    ZERO,
+    EconomicActivity,
+    EconomicLedgerError,
+    EconomicProjection,
+    JournalReduction,
+    LedgerLine,
+    LedgerTransaction,
+    PreparedActivities,
+    balances_tuple,
+    positions_tuple,
+    prepare_activities,
+    quantize_ledger_decimal,
+)
+
+
+JOURNAL_REDUCER_NAME = "balanced_journal"
+JOURNAL_REDUCER_VERSION = "torghut.broker-economic-journal.v1"
+
+_CASH_TYPES = frozenset({"ACATC", "CSD", "CSW", "JNLC", "TRANS"})
+_DIVIDEND_TYPES = frozenset(
+    {
+        "CGD",
+        "DIV",
+        "DIVCGL",
+        "DIVCGS",
+        "DIVFT",
+        "DIVNRA",
+        "DIVTW",
+        "DIVTXEX",
+    }
+)
+_INTEREST_TYPES = frozenset({"INT", "INTNRA", "INTTW"})
+_FEE_TYPES = frozenset({"DIVFEE", "FEE", "PTC"})
+_REGULATORY_FEE_SUBTYPES = frozenset({"CAT", "OCC", "ORF", "REG", "TAF"})
+
+
+@dataclass(slots=True)
+class _Position:
+    quantity: Decimal = ZERO
+    signed_cost: Decimal = ZERO
+
+
+@dataclass(frozen=True, slots=True)
+class _FillPosting:
+    delta_quantity: Decimal
+    cash_delta: Decimal
+    position_cost_delta: Decimal
+    realized: Decimal
+    new_quantity: Decimal
+    new_cost: Decimal
+
+
+class _JournalWriter:
+    def __init__(self, prepared: PreparedActivities) -> None:
+        self.prepared = prepared
+        self.positions: dict[str, _Position] = {}
+        self.transactions: list[LedgerTransaction] = []
+        self.unsupported: set[str] = set()
+
+    def reduce(self) -> JournalReduction:
+        for chain in self.prepared.chains:
+            for index, activity in enumerate(chain.activities):
+                position_snapshot = {
+                    symbol: _Position(position.quantity, position.signed_cost)
+                    for symbol, position in self.positions.items()
+                }
+                transaction = self._apply(activity)
+                if transaction is not None:
+                    self.transactions.append(transaction)
+                if index == len(chain.activities) - 1:
+                    continue
+                correction = chain.activities[index + 1]
+                if transaction is not None:
+                    self.transactions.append(
+                        _reversal_transaction(
+                            transaction,
+                            correction_activity_id=correction.external_activity_id,
+                        )
+                    )
+                self.positions = position_snapshot
+        projection = _projection_from_journal(
+            self.prepared,
+            transactions=tuple(self.transactions),
+            unsupported=tuple(sorted(self.unsupported)),
+        )
+        return JournalReduction(
+            projection=projection,
+            transactions=tuple(self.transactions),
+        )
+
+    def _apply(self, activity: EconomicActivity) -> LedgerTransaction | None:
+        activity_type = activity.activity_type
+        if activity_type == "FILL":
+            transaction = self._fill(activity)
+        elif activity_type == "CFEE":
+            transaction = self._crypto_fee(activity)
+        elif activity_type == "SSP":
+            transaction = self._split(activity)
+        elif activity_type in _CASH_TYPES or (
+            activity_type == "JNL"
+            and activity.symbol is None
+            and activity.quantity is None
+        ):
+            transaction = self._cash_flow(activity)
+        elif activity_type in _DIVIDEND_TYPES:
+            transaction = self._income(
+                activity,
+                account="income:dividend",
+                rule="dividend",
+            )
+        elif activity_type in _INTEREST_TYPES:
+            transaction = self._income(
+                activity,
+                account="income:interest",
+                rule="interest",
+            )
+        elif activity_type in _FEE_TYPES:
+            transaction = self._cash_fee(activity)
+        else:
+            self.unsupported.add(activity.external_activity_id)
+            transaction = None
+        return transaction
+
+    def _fill(self, activity: EconomicActivity) -> LedgerTransaction:
+        symbol = _required_symbol(activity)
+        quantity = activity.quantity
+        price = activity.price
+        if quantity is None or quantity <= ZERO:
+            raise EconomicLedgerError("economic_fill_quantity_must_be_positive")
+        if price is None or price <= ZERO:
+            raise EconomicLedgerError("economic_fill_price_must_be_positive")
+        if activity.side not in {"buy", "sell"}:
+            raise EconomicLedgerError("economic_fill_side_invalid")
+        _require_quote_currency(activity)
+
+        position = self.positions.setdefault(symbol, _Position())
+        delta_quantity = quantity if activity.side == "buy" else -quantity
+        posting = _build_fill_posting(position, delta_quantity, price)
+        transaction = _transaction(
+            activity,
+            posting_rule="fill_weighted_average",
+            lines=(
+                _line(
+                    "asset:cash",
+                    self.prepared.scope.quote_currency,
+                    posting.cash_delta,
+                ),
+                _line(
+                    f"asset:position_cost:{symbol}",
+                    self.prepared.scope.quote_currency,
+                    posting.position_cost_delta,
+                ),
+                _line(
+                    "income:realized_pnl",
+                    self.prepared.scope.quote_currency,
+                    -posting.realized,
+                ),
+                _line(
+                    f"asset:position_units:{symbol}",
+                    symbol,
+                    posting.delta_quantity,
+                ),
+                _line("clearing:broker_fill", symbol, -posting.delta_quantity),
+            ),
+        )
+        position.quantity = posting.new_quantity
+        position.signed_cost = posting.new_cost
+        return transaction
+
+    def _cash_flow(self, activity: EconomicActivity) -> LedgerTransaction | None:
+        amount = activity.net_amount
+        if amount is None:
+            raise EconomicLedgerError("economic_cash_flow_net_amount_required")
+        if amount == ZERO:
+            return None
+        currency = _currency(activity, self.prepared.scope.quote_currency)
+        return _transaction(
+            activity,
+            posting_rule="external_cash_flow",
+            lines=(
+                _line("asset:cash", currency, amount),
+                _line("equity:external_flow", currency, -amount),
+            ),
+        )
+
+    def _income(
+        self,
+        activity: EconomicActivity,
+        *,
+        account: str,
+        rule: str,
+    ) -> LedgerTransaction | None:
+        amount = activity.net_amount
+        if amount is None:
+            raise EconomicLedgerError(f"economic_{rule}_net_amount_required")
+        if amount == ZERO:
+            return None
+        currency = _currency(activity, self.prepared.scope.quote_currency)
+        return _transaction(
+            activity,
+            posting_rule=rule,
+            lines=(
+                _line("asset:cash", currency, amount),
+                _line(account, currency, -amount),
+            ),
+        )
+
+    def _cash_fee(self, activity: EconomicActivity) -> LedgerTransaction | None:
+        amount = activity.net_amount
+        if amount is None:
+            raise EconomicLedgerError("economic_fee_net_amount_required")
+        if amount == ZERO:
+            return None
+        subtype = activity.activity_subtype or ""
+        if activity.activity_type == "DIVFEE":
+            account = "expense:withholding"
+        elif subtype.upper() in _REGULATORY_FEE_SUBTYPES:
+            account = "expense:regulatory_fee"
+        else:
+            account = "expense:broker_fee"
+        currency = _currency(activity, self.prepared.scope.quote_currency)
+        return _transaction(
+            activity,
+            posting_rule="cash_fee",
+            lines=(
+                _line("asset:cash", currency, amount),
+                _line(account, currency, -amount),
+            ),
+        )
+
+    def _crypto_fee(self, activity: EconomicActivity) -> LedgerTransaction | None:
+        if activity.net_amount not in {None, ZERO}:
+            return self._cash_fee(activity)
+        quantity = activity.quantity
+        if quantity is None or quantity == ZERO:
+            return None
+        price = activity.price
+        if price is None or price <= ZERO:
+            raise EconomicLedgerError("economic_crypto_fee_price_must_be_positive")
+        symbol = _required_symbol(activity)
+        position = self.positions.setdefault(symbol, _Position())
+        fair_value = quantize_ledger_decimal(
+            abs(quantity) * price,
+            field_name="crypto_fee_fair_value",
+        )
+        if quantity < ZERO:
+            if position.quantity <= ZERO or abs(quantity) > position.quantity:
+                raise EconomicLedgerError("economic_crypto_fee_position_insufficient")
+            if abs(quantity) == position.quantity:
+                position_cost_delta = -position.signed_cost
+            else:
+                average_cost = position.signed_cost / position.quantity
+                position_cost_delta = quantize_ledger_decimal(
+                    quantity * average_cost,
+                    field_name="crypto_fee_position_cost_delta",
+                )
+            fee_amount = fair_value
+        else:
+            position_cost_delta = fair_value
+            fee_amount = -fair_value
+        realized = quantize_ledger_decimal(
+            position_cost_delta + fee_amount,
+            field_name="crypto_fee_realized_pnl",
+        )
+        transaction = _transaction(
+            activity,
+            posting_rule="crypto_asset_fee",
+            lines=(
+                _line(
+                    f"asset:position_cost:{symbol}",
+                    self.prepared.scope.quote_currency,
+                    position_cost_delta,
+                ),
+                _line(
+                    "expense:broker_fee",
+                    self.prepared.scope.quote_currency,
+                    fee_amount,
+                ),
+                _line(
+                    "income:realized_pnl",
+                    self.prepared.scope.quote_currency,
+                    -realized,
+                ),
+                _line(f"asset:position_units:{symbol}", symbol, quantity),
+                _line("clearing:fee", symbol, -quantity),
+            ),
+        )
+        position.quantity = quantize_ledger_decimal(
+            position.quantity + quantity,
+            field_name="crypto_fee_position_quantity",
+        )
+        position.signed_cost = quantize_ledger_decimal(
+            position.signed_cost + position_cost_delta,
+            field_name="crypto_fee_position_cost",
+        )
+        if position.quantity == ZERO:
+            position.signed_cost = ZERO
+        return transaction
+
+    def _split(self, activity: EconomicActivity) -> LedgerTransaction:
+        symbol = _required_symbol(activity)
+        quantity = activity.quantity
+        if quantity is None or quantity == ZERO:
+            raise EconomicLedgerError("economic_split_quantity_delta_required")
+        position = self.positions.setdefault(symbol, _Position())
+        new_quantity = quantize_ledger_decimal(
+            position.quantity + quantity,
+            field_name="split_position_quantity",
+        )
+        if (
+            position.quantity == ZERO
+            or new_quantity == ZERO
+            or position.quantity * new_quantity < ZERO
+        ):
+            raise EconomicLedgerError("economic_split_position_direction_invalid")
+        transaction = _transaction(
+            activity,
+            posting_rule="stock_split_quantity_delta",
+            lines=(
+                _line(f"asset:position_units:{symbol}", symbol, quantity),
+                _line("clearing:corporate_action", symbol, -quantity),
+            ),
+        )
+        position.quantity = new_quantity
+        return transaction
+
+
+def _build_fill_posting(
+    position: _Position,
+    delta_quantity: Decimal,
+    price: Decimal,
+) -> _FillPosting:
+    cash_delta = quantize_ledger_decimal(
+        -delta_quantity * price,
+        field_name="fill_cash_delta",
+    )
+    if position.quantity == ZERO or position.quantity * delta_quantity > ZERO:
+        position_cost_delta = -cash_delta
+    else:
+        position_cost_delta = _opposite_fill_position_cost_delta(
+            position,
+            delta_quantity,
+            price,
+        )
+    realized = quantize_ledger_decimal(
+        cash_delta + position_cost_delta,
+        field_name="fill_realized_pnl",
+    )
+    new_quantity = quantize_ledger_decimal(
+        position.quantity + delta_quantity,
+        field_name="fill_position_quantity",
+    )
+    new_cost = quantize_ledger_decimal(
+        position.signed_cost + position_cost_delta,
+        field_name="fill_position_cost",
+    )
+    if new_quantity == ZERO:
+        new_cost = ZERO
+    if new_quantity * new_cost < ZERO:
+        raise EconomicLedgerError("economic_fill_position_cost_sign_mismatch")
+    return _FillPosting(
+        delta_quantity=delta_quantity,
+        cash_delta=cash_delta,
+        position_cost_delta=position_cost_delta,
+        realized=realized,
+        new_quantity=new_quantity,
+        new_cost=new_cost,
+    )
+
+
+def _opposite_fill_position_cost_delta(
+    position: _Position,
+    delta_quantity: Decimal,
+    price: Decimal,
+) -> Decimal:
+    closing_quantity = min(abs(position.quantity), abs(delta_quantity))
+    current_direction = Decimal(1 if position.quantity > ZERO else -1)
+    closing_delta = -current_direction * closing_quantity
+    if closing_quantity == abs(position.quantity):
+        released_cost_delta = -position.signed_cost
+    else:
+        average_cost = position.signed_cost / position.quantity
+        released_cost_delta = quantize_ledger_decimal(
+            -current_direction * closing_quantity * average_cost,
+            field_name="fill_released_cost_delta",
+        )
+    opening_delta = delta_quantity - closing_delta
+    opening_cost_delta = quantize_ledger_decimal(
+        opening_delta * price,
+        field_name="fill_opening_cost_delta",
+    )
+    return quantize_ledger_decimal(
+        released_cost_delta + opening_cost_delta,
+        field_name="fill_position_cost_delta",
+    )
+
+
+def reduce_balanced_journal(
+    activities: PreparedActivities
+    | tuple[EconomicActivity, ...]
+    | list[EconomicActivity],
+) -> JournalReduction:
+    prepared = (
+        activities
+        if isinstance(activities, PreparedActivities)
+        else prepare_activities(activities)
+    )
+    with localcontext() as context:
+        context.prec = LEDGER_DECIMAL_PRECISION
+        return _JournalWriter(prepared).reduce()
+
+
+def _projection_from_journal(
+    prepared: PreparedActivities,
+    *,
+    transactions: tuple[LedgerTransaction, ...],
+    unsupported: tuple[str, ...],
+) -> EconomicProjection:
+    cash: dict[str, Decimal] = {}
+    quantities: dict[str, Decimal] = {}
+    costs: dict[str, Decimal] = {}
+    realized_pnl = ZERO
+    fees = ZERO
+    dividends = ZERO
+    interest = ZERO
+    external_flows = ZERO
+    for transaction in transactions:
+        for line in transaction.lines:
+            if line.account == "asset:cash":
+                cash[line.commodity] = cash.get(line.commodity, ZERO) + line.amount
+            elif line.account.startswith("asset:position_cost:"):
+                symbol = line.account.removeprefix("asset:position_cost:")
+                costs[symbol] = costs.get(symbol, ZERO) + line.amount
+            elif line.account.startswith("asset:position_units:"):
+                symbol = line.account.removeprefix("asset:position_units:")
+                quantities[symbol] = quantities.get(symbol, ZERO) + line.amount
+            elif line.account == "income:realized_pnl":
+                realized_pnl -= line.amount
+            elif line.account in {
+                "expense:broker_fee",
+                "expense:regulatory_fee",
+                "expense:withholding",
+            }:
+                fees += line.amount
+            elif line.account == "income:dividend":
+                dividends -= line.amount
+            elif line.account == "income:interest":
+                interest -= line.amount
+            elif line.account == "equity:external_flow":
+                external_flows -= line.amount
+    return EconomicProjection(
+        reducer_name=JOURNAL_REDUCER_NAME,
+        reducer_version=JOURNAL_REDUCER_VERSION,
+        scope=prepared.scope,
+        input_manifest_digest=prepared.manifest_digest,
+        input_count=prepared.input_count,
+        duplicate_count=prepared.duplicate_count,
+        corrected_count=prepared.corrected_count,
+        cash=balances_tuple(cash),
+        positions=positions_tuple(quantities, costs),
+        realized_pnl=realized_pnl,
+        fees=fees,
+        dividends=dividends,
+        interest=interest,
+        external_flows=external_flows,
+        unsupported_activity_ids=unsupported,
+    )
+
+
+def _reversal_transaction(
+    transaction: LedgerTransaction,
+    *,
+    correction_activity_id: str,
+) -> LedgerTransaction:
+    return LedgerTransaction(
+        transaction_id=(
+            f"{correction_activity_id}:reversal:{transaction.transaction_id}"
+        ),
+        source_activity_id=correction_activity_id,
+        posting_rule="correction_reversal",
+        reverses_transaction_id=transaction.transaction_id,
+        lines=tuple(
+            LedgerLine(
+                account=line.account,
+                commodity=line.commodity,
+                amount=-line.amount,
+            )
+            for line in transaction.lines
+        ),
+    )
+
+
+def _transaction(
+    activity: EconomicActivity,
+    *,
+    posting_rule: str,
+    lines: tuple[LedgerLine | None, ...],
+) -> LedgerTransaction:
+    present = tuple(line for line in lines if line is not None)
+    return LedgerTransaction(
+        transaction_id=activity.external_activity_id,
+        source_activity_id=activity.external_activity_id,
+        posting_rule=posting_rule,
+        lines=present,
+    )
+
+
+def _line(account: str, commodity: str, amount: Decimal) -> LedgerLine | None:
+    if amount == ZERO:
+        return None
+    return LedgerLine(account=account, commodity=commodity, amount=amount)
+
+
+def _required_symbol(activity: EconomicActivity) -> str:
+    symbol = activity.canonical_symbol
+    if symbol is None:
+        raise EconomicLedgerError("economic_activity_symbol_required")
+    return symbol
+
+
+def _currency(activity: EconomicActivity, default: str) -> str:
+    currency = activity.currency or default
+    if currency != default:
+        raise EconomicLedgerError("economic_activity_currency_unsupported")
+    return currency
+
+
+def _require_quote_currency(activity: EconomicActivity) -> None:
+    symbol = activity.symbol or ""
+    if "/" not in symbol:
+        return
+    quote = symbol.rsplit("/", maxsplit=1)[-1]
+    if quote != activity.scope.quote_currency:
+        raise EconomicLedgerError("economic_fill_quote_currency_unsupported")
+
+
+__all__ = (
+    "JOURNAL_REDUCER_NAME",
+    "JOURNAL_REDUCER_VERSION",
+    "reduce_balanced_journal",
+)

--- a/services/torghut/app/trading/economic_ledger/journal_reducer.py
+++ b/services/torghut/app/trading/economic_ledger/journal_reducer.py
@@ -247,9 +247,7 @@ class _JournalWriter:
         if amount == ZERO:
             return None
         subtype = activity.activity_subtype or ""
-        if activity.activity_type == "DIVFEE" or (
-            activity.activity_type in _WITHHOLDING_TYPES
-        ):
+        if activity.activity_type in _WITHHOLDING_TYPES:
             account = "expense:withholding"
         elif subtype.upper() in _REGULATORY_FEE_SUBTYPES:
             account = "expense:regulatory_fee"

--- a/services/torghut/app/trading/economic_ledger/journal_reducer.py
+++ b/services/torghut/app/trading/economic_ledger/journal_reducer.py
@@ -164,12 +164,15 @@ class _JournalWriter:
             raise EconomicLedgerError("economic_fill_quantity_must_be_positive")
         if price is None or price <= ZERO:
             raise EconomicLedgerError("economic_fill_price_must_be_positive")
-        if activity.side not in {"buy", "sell"}:
+        if activity.side == "buy":
+            delta_quantity = quantity
+        elif activity.side in {"sell", "sell_short"}:
+            delta_quantity = -quantity
+        else:
             raise EconomicLedgerError("economic_fill_side_invalid")
         _require_quote_currency(activity)
 
         position = self.positions.setdefault(symbol, _Position())
-        delta_quantity = quantity if activity.side == "buy" else -quantity
         posting = _build_fill_posting(position, delta_quantity, price)
         transaction = _transaction(
             activity,

--- a/services/torghut/app/trading/economic_ledger/journal_reducer.py
+++ b/services/torghut/app/trading/economic_ledger/journal_reducer.py
@@ -43,6 +43,7 @@ _INTEREST_TYPES = frozenset({"INT"})
 _WITHHOLDING_TYPES = frozenset({"DIVFT", "DIVNRA", "DIVTW", "INTNRA", "INTTW"})
 _FEE_TYPES = frozenset({"DIVFEE", "FEE", "PTC"})
 _CASH_EXPENSE_TYPES = _FEE_TYPES | _WITHHOLDING_TYPES
+_PAIRED_SPLIT_SUBTYPES = frozenset({"add", "remove"})
 _REGULATORY_FEE_SUBTYPES = frozenset({"CAT", "OCC", "ORF", "REG", "TAF"})
 
 
@@ -151,10 +152,26 @@ class _JournalWriter:
         return self._crypto_fee(activity)
 
     def _apply_split(self, activity: EconomicActivity) -> LedgerTransaction | None:
-        if activity.net_amount not in {None, ZERO}:
+        if (
+            activity.net_amount not in {None, ZERO}
+            or activity.activity_subtype in _PAIRED_SPLIT_SUBTYPES
+            or self._split_removes_or_flips_position(activity)
+        ):
             self.unsupported.add(activity.external_activity_id)
             return None
         return self._split(activity)
+
+    def _split_removes_or_flips_position(self, activity: EconomicActivity) -> bool:
+        symbol = activity.canonical_symbol
+        quantity = activity.quantity
+        position = self.positions.get(symbol) if symbol is not None else None
+        if quantity is None or quantity == ZERO or position is None:
+            return False
+        new_quantity = quantize_ledger_decimal(
+            position.quantity + quantity,
+            field_name="split_position_quantity",
+        )
+        return new_quantity == ZERO or position.quantity * new_quantity < ZERO
 
     def _fill(self, activity: EconomicActivity) -> LedgerTransaction:
         symbol = _required_symbol(activity)

--- a/services/torghut/app/trading/economic_ledger/journal_reducer.py
+++ b/services/torghut/app/trading/economic_ledger/journal_reducer.py
@@ -99,7 +99,11 @@ class _JournalWriter:
     def _apply(self, activity: EconomicActivity) -> LedgerTransaction | None:
         activity_type = activity.activity_type
         if activity_type == "FILL":
-            transaction = self._fill(activity)
+            if activity.net_amount not in {None, ZERO}:
+                self.unsupported.add(activity.external_activity_id)
+                transaction = None
+            else:
+                transaction = self._fill(activity)
         elif activity_type == "CFEE":
             transaction = self._crypto_fee(activity)
         elif activity_type == "SSP":

--- a/services/torghut/app/trading/economic_ledger/journal_reducer.py
+++ b/services/torghut/app/trading/economic_ledger/journal_reducer.py
@@ -109,7 +109,14 @@ class _JournalWriter:
             else:
                 transaction = self._fill(activity)
         elif activity_type == "CFEE":
-            transaction = self._crypto_fee(activity)
+            if activity.net_amount in {None, ZERO} and activity.quantity in {
+                None,
+                ZERO,
+            }:
+                self.unsupported.add(activity.external_activity_id)
+                transaction = None
+            else:
+                transaction = self._crypto_fee(activity)
         elif activity_type == "SSP":
             if activity.net_amount not in {None, ZERO}:
                 self.unsupported.add(activity.external_activity_id)

--- a/services/torghut/app/trading/economic_ledger/journal_reducer.py
+++ b/services/torghut/app/trading/economic_ledger/journal_reducer.py
@@ -143,7 +143,9 @@ class _JournalWriter:
         self,
         activity: EconomicActivity,
     ) -> LedgerTransaction | None:
-        if activity.net_amount in {None, ZERO} and activity.quantity in {None, ZERO}:
+        if activity.net_amount in {None, ZERO} and (
+            activity.quantity is None or activity.quantity >= ZERO
+        ):
             self.unsupported.add(activity.external_activity_id)
             return None
         return self._crypto_fee(activity)
@@ -267,8 +269,8 @@ class _JournalWriter:
         if activity.net_amount not in {None, ZERO}:
             return self._cash_fee(activity)
         quantity = activity.quantity
-        if quantity is None or quantity == ZERO:
-            return None
+        if quantity is None or quantity >= ZERO:
+            raise EconomicLedgerError("economic_crypto_fee_quantity_must_be_negative")
         price = activity.price
         if price is None or price <= ZERO:
             raise EconomicLedgerError("economic_crypto_fee_price_must_be_positive")
@@ -279,21 +281,17 @@ class _JournalWriter:
             abs(quantity) * price,
             field_name="crypto_fee_fair_value",
         )
-        if quantity < ZERO:
-            if position.quantity <= ZERO or abs(quantity) > position.quantity:
-                raise EconomicLedgerError("economic_crypto_fee_position_insufficient")
-            if abs(quantity) == position.quantity:
-                position_cost_delta = -position.signed_cost
-            else:
-                average_cost = position.signed_cost / position.quantity
-                position_cost_delta = quantize_ledger_decimal(
-                    quantity * average_cost,
-                    field_name="crypto_fee_position_cost_delta",
-                )
-            fee_amount = fair_value
+        if position.quantity <= ZERO or abs(quantity) > position.quantity:
+            raise EconomicLedgerError("economic_crypto_fee_position_insufficient")
+        if abs(quantity) == position.quantity:
+            position_cost_delta = -position.signed_cost
         else:
-            position_cost_delta = fair_value
-            fee_amount = -fair_value
+            average_cost = position.signed_cost / position.quantity
+            position_cost_delta = quantize_ledger_decimal(
+                quantity * average_cost,
+                field_name="crypto_fee_position_cost_delta",
+            )
+        fee_amount = fair_value
         realized = quantize_ledger_decimal(
             position_cost_delta + fee_amount,
             field_name="crypto_fee_realized_pnl",
@@ -415,9 +413,11 @@ def _opposite_fill_position_cost_delta(
     if closing_quantity == abs(position.quantity):
         released_cost_delta = -position.signed_cost
     else:
-        average_cost = position.signed_cost / position.quantity
         released_cost_delta = quantize_ledger_decimal(
-            -current_direction * closing_quantity * average_cost,
+            -current_direction
+            * closing_quantity
+            * abs(position.signed_cost)
+            / abs(position.quantity),
             field_name="fill_released_cost_delta",
         )
     opening_delta = delta_quantity - closing_delta

--- a/services/torghut/app/trading/economic_ledger/journal_reducer.py
+++ b/services/torghut/app/trading/economic_ledger/journal_reducer.py
@@ -43,7 +43,6 @@ _INTEREST_TYPES = frozenset({"INT"})
 _WITHHOLDING_TYPES = frozenset({"DIVFT", "DIVNRA", "DIVTW", "INTNRA", "INTTW"})
 _FEE_TYPES = frozenset({"DIVFEE", "FEE", "PTC"})
 _CASH_EXPENSE_TYPES = _FEE_TYPES | _WITHHOLDING_TYPES
-_PAIRED_SPLIT_SUBTYPES = frozenset({"add", "remove"})
 _REGULATORY_FEE_SUBTYPES = frozenset({"CAT", "OCC", "ORF", "REG", "TAF"})
 
 
@@ -107,8 +106,6 @@ class _JournalWriter:
             transaction = self._apply_fill(activity)
         elif activity_type == "CFEE":
             transaction = self._apply_crypto_fee(activity)
-        elif activity_type == "SSP":
-            transaction = self._apply_split(activity)
         elif activity_type in _CASH_TYPES or (
             activity_type == "JNL"
             and activity.symbol is None
@@ -150,28 +147,6 @@ class _JournalWriter:
             self.unsupported.add(activity.external_activity_id)
             return None
         return self._crypto_fee(activity)
-
-    def _apply_split(self, activity: EconomicActivity) -> LedgerTransaction | None:
-        if (
-            activity.net_amount not in {None, ZERO}
-            or activity.activity_subtype in _PAIRED_SPLIT_SUBTYPES
-            or self._split_removes_or_flips_position(activity)
-        ):
-            self.unsupported.add(activity.external_activity_id)
-            return None
-        return self._split(activity)
-
-    def _split_removes_or_flips_position(self, activity: EconomicActivity) -> bool:
-        symbol = activity.canonical_symbol
-        quantity = activity.quantity
-        position = self.positions.get(symbol) if symbol is not None else None
-        if quantity is None or quantity == ZERO or position is None:
-            return False
-        new_quantity = quantize_ledger_decimal(
-            position.quantity + quantity,
-            field_name="split_position_quantity",
-        )
-        return new_quantity == ZERO or position.quantity * new_quantity < ZERO
 
     def _fill(self, activity: EconomicActivity) -> LedgerTransaction:
         symbol = _required_symbol(activity)
@@ -347,33 +322,6 @@ class _JournalWriter:
         )
         if position.quantity == ZERO:
             position.signed_cost = ZERO
-        return transaction
-
-    def _split(self, activity: EconomicActivity) -> LedgerTransaction:
-        symbol = _required_symbol(activity)
-        quantity = activity.quantity
-        if quantity is None or quantity == ZERO:
-            raise EconomicLedgerError("economic_split_quantity_delta_required")
-        position = self.positions.setdefault(symbol, _Position())
-        new_quantity = quantize_ledger_decimal(
-            position.quantity + quantity,
-            field_name="split_position_quantity",
-        )
-        if (
-            position.quantity == ZERO
-            or new_quantity == ZERO
-            or position.quantity * new_quantity < ZERO
-        ):
-            raise EconomicLedgerError("economic_split_position_direction_invalid")
-        transaction = _transaction(
-            activity,
-            posting_rule="stock_split_quantity_delta",
-            lines=(
-                _line(f"asset:position_units:{symbol}", symbol, quantity),
-                _line("clearing:corporate_action", symbol, -quantity),
-            ),
-        )
-        position.quantity = new_quantity
         return transaction
 
 

--- a/services/torghut/app/trading/economic_ledger/journal_reducer.py
+++ b/services/torghut/app/trading/economic_ledger/journal_reducer.py
@@ -103,26 +103,11 @@ class _JournalWriter:
     def _apply(self, activity: EconomicActivity) -> LedgerTransaction | None:
         activity_type = activity.activity_type
         if activity_type == "FILL":
-            if activity.net_amount not in {None, ZERO}:
-                self.unsupported.add(activity.external_activity_id)
-                transaction = None
-            else:
-                transaction = self._fill(activity)
+            transaction = self._apply_fill(activity)
         elif activity_type == "CFEE":
-            if activity.net_amount in {None, ZERO} and activity.quantity in {
-                None,
-                ZERO,
-            }:
-                self.unsupported.add(activity.external_activity_id)
-                transaction = None
-            else:
-                transaction = self._crypto_fee(activity)
+            transaction = self._apply_crypto_fee(activity)
         elif activity_type == "SSP":
-            if activity.net_amount not in {None, ZERO}:
-                self.unsupported.add(activity.external_activity_id)
-                transaction = None
-            else:
-                transaction = self._split(activity)
+            transaction = self._apply_split(activity)
         elif activity_type in _CASH_TYPES or (
             activity_type == "JNL"
             and activity.symbol is None
@@ -147,6 +132,27 @@ class _JournalWriter:
             self.unsupported.add(activity.external_activity_id)
             transaction = None
         return transaction
+
+    def _apply_fill(self, activity: EconomicActivity) -> LedgerTransaction | None:
+        if activity.net_amount not in {None, ZERO}:
+            self.unsupported.add(activity.external_activity_id)
+            return None
+        return self._fill(activity)
+
+    def _apply_crypto_fee(
+        self,
+        activity: EconomicActivity,
+    ) -> LedgerTransaction | None:
+        if activity.net_amount in {None, ZERO} and activity.quantity in {None, ZERO}:
+            self.unsupported.add(activity.external_activity_id)
+            return None
+        return self._crypto_fee(activity)
+
+    def _apply_split(self, activity: EconomicActivity) -> LedgerTransaction | None:
+        if activity.net_amount not in {None, ZERO}:
+            self.unsupported.add(activity.external_activity_id)
+            return None
+        return self._split(activity)
 
     def _fill(self, activity: EconomicActivity) -> LedgerTransaction:
         symbol = _required_symbol(activity)

--- a/services/torghut/app/trading/economic_ledger/journal_reducer.py
+++ b/services/torghut/app/trading/economic_ledger/journal_reducer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass
 from decimal import Decimal, localcontext
 
@@ -24,6 +25,9 @@ from .types import (
 
 JOURNAL_REDUCER_NAME = "balanced_journal"
 JOURNAL_REDUCER_VERSION = "torghut.broker-economic-journal.v1"
+
+_MAX_TRANSACTION_ID_LENGTH = 512
+_REVERSAL_TRANSACTION_ID_PREFIX = "correction-reversal:sha256:"
 
 _CASH_TYPES = frozenset({"ACATC", "CSD", "CSW", "JNLC", "TRANS"})
 _DIVIDEND_TYPES = frozenset(
@@ -492,8 +496,9 @@ def _reversal_transaction(
     correction_activity_id: str,
 ) -> LedgerTransaction:
     return LedgerTransaction(
-        transaction_id=(
-            f"{correction_activity_id}:reversal:{transaction.transaction_id}"
+        transaction_id=_reversal_transaction_id(
+            correction_activity_id=correction_activity_id,
+            reversed_transaction_id=transaction.transaction_id,
         ),
         source_activity_id=correction_activity_id,
         posting_rule="correction_reversal",
@@ -507,6 +512,18 @@ def _reversal_transaction(
             for line in transaction.lines
         ),
     )
+
+
+def _reversal_transaction_id(
+    *,
+    correction_activity_id: str,
+    reversed_transaction_id: str,
+) -> str:
+    readable = f"{correction_activity_id}:reversal:{reversed_transaction_id}"
+    if len(readable) <= _MAX_TRANSACTION_ID_LENGTH:
+        return readable
+    digest = hashlib.sha256(readable.encode("utf-8")).hexdigest()
+    return f"{_REVERSAL_TRANSACTION_ID_PREFIX}{digest}"
 
 
 def _transaction(

--- a/services/torghut/app/trading/economic_ledger/state_reducer.py
+++ b/services/torghut/app/trading/economic_ledger/state_reducer.py
@@ -171,13 +171,19 @@ class _StateReducer:
         )
         if cash_change == ZERO:
             raise EconomicLedgerError("economic_fill_notional_below_ledger_quantum")
-        self._add_cash(activity, cash_change)
-        holding.units, holding.carrying_value = _next_holding(
+        next_units, next_value = _next_holding(
             holding,
             order_units,
             price,
             cash_change,
         )
+        if next_units != ZERO and next_value == ZERO:
+            raise EconomicLedgerError(
+                "economic_fill_position_cost_below_ledger_quantum"
+            )
+        self._add_cash(activity, cash_change)
+        holding.units = next_units
+        holding.carrying_value = next_value
         self.realized_pnl = quantize_ledger_decimal(
             self.realized_pnl + cash_change + (holding.carrying_value - previous_value),
             field_name="realized_pnl",

--- a/services/torghut/app/trading/economic_ledger/state_reducer.py
+++ b/services/torghut/app/trading/economic_ledger/state_reducer.py
@@ -36,6 +36,7 @@ _INTEREST_ACTIVITY_TYPES = frozenset({"INT"})
 _WITHHOLDING_ACTIVITY_TYPES = frozenset({"DIVFT", "DIVNRA", "DIVTW", "INTNRA", "INTTW"})
 _CASH_FEE_ACTIVITY_TYPES = frozenset({"DIVFEE", "FEE", "PTC"})
 _CASH_EXPENSE_ACTIVITY_TYPES = _CASH_FEE_ACTIVITY_TYPES | _WITHHOLDING_ACTIVITY_TYPES
+_PAIRED_SPLIT_SUBTYPES = frozenset({"add", "remove"})
 
 
 @dataclass(slots=True)
@@ -99,7 +100,11 @@ class _StateReducer:
                 )
             )
             or (activity_type == "FILL" and activity.net_amount in {None, ZERO})
-            or (activity_type == "SSP" and activity.net_amount in {None, ZERO})
+            or (
+                activity_type == "SSP"
+                and activity.net_amount in {None, ZERO}
+                and activity.activity_subtype not in _PAIRED_SPLIT_SUBTYPES
+            )
             or activity_type in _EXTERNAL_FLOW_TYPES
             or activity_type in _DIVIDEND_ACTIVITY_TYPES
             or activity_type in _INTEREST_ACTIVITY_TYPES
@@ -118,7 +123,10 @@ class _StateReducer:
         elif activity_type == "CFEE":
             self._crypto_fee(activity)
         elif activity_type == "SSP":
-            self._split(activity)
+            if self._split_removes_or_flips_holding(activity):
+                self.unsupported.add(activity.external_activity_id)
+            else:
+                self._split(activity)
         elif activity_type in _EXTERNAL_FLOW_TYPES or activity_type == "JNL":
             amount = _required_amount(activity, "cash_flow")
             self._add_cash(activity, amount)
@@ -251,6 +259,18 @@ class _StateReducer:
         ):
             raise EconomicLedgerError("economic_split_position_direction_invalid")
         holding.units = new_units
+
+    def _split_removes_or_flips_holding(self, activity: EconomicActivity) -> bool:
+        symbol = activity.canonical_symbol
+        units = activity.quantity
+        holding = self.holdings.get(symbol) if symbol is not None else None
+        if units is None or units == ZERO or holding is None:
+            return False
+        new_units = quantize_ledger_decimal(
+            holding.units + units,
+            field_name="split_position_quantity",
+        )
+        return new_units == ZERO or holding.units * new_units < ZERO
 
     def _add_cash(self, activity: EconomicActivity, amount: Decimal) -> None:
         currency = activity.currency or self.prepared.scope.quote_currency

--- a/services/torghut/app/trading/economic_ledger/state_reducer.py
+++ b/services/torghut/app/trading/economic_ledger/state_reducer.py
@@ -1,0 +1,375 @@
+"""Independent cash-and-position reducer for broker-economic differential proof."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal, localcontext
+
+from .types import (
+    LEDGER_DECIMAL_PRECISION,
+    ZERO,
+    EconomicActivity,
+    EconomicLedgerError,
+    EconomicProjection,
+    PreparedActivities,
+    balances_tuple,
+    positions_tuple,
+    prepare_activities,
+    quantize_ledger_decimal,
+)
+
+
+STATE_REDUCER_NAME = "independent_position_state"
+STATE_REDUCER_VERSION = "torghut.broker-economic-state.v1"
+
+_EXTERNAL_FLOW_TYPES = frozenset({"ACATC", "CSD", "CSW", "JNLC", "TRANS"})
+_DIVIDEND_ACTIVITY_TYPES = frozenset(
+    {
+        "CGD",
+        "DIV",
+        "DIVCGL",
+        "DIVCGS",
+        "DIVFT",
+        "DIVNRA",
+        "DIVTW",
+        "DIVTXEX",
+    }
+)
+_INTEREST_ACTIVITY_TYPES = frozenset({"INT", "INTNRA", "INTTW"})
+_CASH_FEE_ACTIVITY_TYPES = frozenset({"DIVFEE", "FEE", "PTC"})
+
+
+@dataclass(slots=True)
+class _Holding:
+    units: Decimal = ZERO
+    carrying_value: Decimal = ZERO
+
+
+class _StateReducer:
+    def __init__(self, prepared: PreparedActivities) -> None:
+        self.prepared = prepared
+        self.cash: dict[str, Decimal] = {}
+        self.holdings: dict[str, _Holding] = {}
+        self.realized_pnl = ZERO
+        self.fees = ZERO
+        self.dividends = ZERO
+        self.interest = ZERO
+        self.external_flows = ZERO
+        self.unsupported: set[str] = set()
+
+    def reduce(self) -> EconomicProjection:
+        for chain in self.prepared.chains:
+            for activity in chain.activities:
+                if not self._recognized(activity):
+                    self.unsupported.add(activity.external_activity_id)
+            effective = chain.effective
+            if effective.external_activity_id not in self.unsupported:
+                self._apply(effective)
+        return EconomicProjection(
+            reducer_name=STATE_REDUCER_NAME,
+            reducer_version=STATE_REDUCER_VERSION,
+            scope=self.prepared.scope,
+            input_manifest_digest=self.prepared.manifest_digest,
+            input_count=self.prepared.input_count,
+            duplicate_count=self.prepared.duplicate_count,
+            corrected_count=self.prepared.corrected_count,
+            cash=balances_tuple(self.cash),
+            positions=positions_tuple(
+                {symbol: holding.units for symbol, holding in self.holdings.items()},
+                {
+                    symbol: holding.carrying_value
+                    for symbol, holding in self.holdings.items()
+                },
+            ),
+            realized_pnl=self.realized_pnl,
+            fees=self.fees,
+            dividends=self.dividends,
+            interest=self.interest,
+            external_flows=self.external_flows,
+            unsupported_activity_ids=tuple(sorted(self.unsupported)),
+        )
+
+    def _recognized(self, activity: EconomicActivity) -> bool:
+        activity_type = activity.activity_type
+        return (
+            activity_type in {"CFEE", "FILL", "SSP"}
+            or activity_type in _EXTERNAL_FLOW_TYPES
+            or activity_type in _DIVIDEND_ACTIVITY_TYPES
+            or activity_type in _INTEREST_ACTIVITY_TYPES
+            or activity_type in _CASH_FEE_ACTIVITY_TYPES
+            or (
+                activity_type == "JNL"
+                and activity.symbol is None
+                and activity.quantity is None
+            )
+        )
+
+    def _apply(self, activity: EconomicActivity) -> None:
+        activity_type = activity.activity_type
+        if activity_type == "FILL":
+            self._fill(activity)
+        elif activity_type == "CFEE":
+            self._crypto_fee(activity)
+        elif activity_type == "SSP":
+            self._split(activity)
+        elif activity_type in _EXTERNAL_FLOW_TYPES or activity_type == "JNL":
+            amount = _required_amount(activity, "cash_flow")
+            self._add_cash(activity, amount)
+            self.external_flows = quantize_ledger_decimal(
+                self.external_flows + amount,
+                field_name="external_flows",
+            )
+        elif activity_type in _DIVIDEND_ACTIVITY_TYPES:
+            amount = _required_amount(activity, "dividend")
+            self._add_cash(activity, amount)
+            self.dividends = quantize_ledger_decimal(
+                self.dividends + amount,
+                field_name="dividends",
+            )
+        elif activity_type in _INTEREST_ACTIVITY_TYPES:
+            amount = _required_amount(activity, "interest")
+            self._add_cash(activity, amount)
+            self.interest = quantize_ledger_decimal(
+                self.interest + amount,
+                field_name="interest",
+            )
+        elif activity_type in _CASH_FEE_ACTIVITY_TYPES:
+            amount = _required_amount(activity, "fee")
+            self._add_cash(activity, amount)
+            self.fees = quantize_ledger_decimal(
+                self.fees - amount,
+                field_name="fees",
+            )
+        else:
+            raise EconomicLedgerError("independent_reducer_unrecognized_activity")
+
+    def _fill(self, activity: EconomicActivity) -> None:
+        symbol = _symbol(activity)
+        quantity = activity.quantity
+        price = activity.price
+        if quantity is None or quantity <= ZERO:
+            raise EconomicLedgerError("economic_fill_quantity_must_be_positive")
+        if price is None or price <= ZERO:
+            raise EconomicLedgerError("economic_fill_price_must_be_positive")
+        if activity.side == "buy":
+            order_units = quantity
+        elif activity.side == "sell":
+            order_units = -quantity
+        else:
+            raise EconomicLedgerError("economic_fill_side_invalid")
+        _validate_quote(activity)
+
+        holding = self.holdings.setdefault(symbol, _Holding())
+        previous_value = holding.carrying_value
+        cash_change = quantize_ledger_decimal(
+            -order_units * price,
+            field_name="fill_cash_delta",
+        )
+        self._add_cash(activity, cash_change)
+        holding.units, holding.carrying_value = _next_holding(
+            holding,
+            order_units,
+            price,
+            cash_change,
+        )
+        self.realized_pnl = quantize_ledger_decimal(
+            self.realized_pnl + cash_change + (holding.carrying_value - previous_value),
+            field_name="realized_pnl",
+        )
+
+    def _crypto_fee(self, activity: EconomicActivity) -> None:
+        if activity.net_amount not in {None, ZERO}:
+            amount = _required_amount(activity, "fee")
+            self._add_cash(activity, amount)
+            self.fees = quantize_ledger_decimal(
+                self.fees - amount,
+                field_name="fees",
+            )
+            return
+        units = activity.quantity
+        if units is None or units == ZERO:
+            return
+        price = activity.price
+        if price is None or price <= ZERO:
+            raise EconomicLedgerError("economic_crypto_fee_price_must_be_positive")
+        symbol = _symbol(activity)
+        holding = self.holdings.setdefault(symbol, _Holding())
+        fair_value = quantize_ledger_decimal(
+            abs(units) * price,
+            field_name="crypto_fee_fair_value",
+        )
+        if units < ZERO:
+            if holding.units <= ZERO or abs(units) > holding.units:
+                raise EconomicLedgerError("economic_crypto_fee_position_insufficient")
+            if abs(units) == holding.units:
+                released_cost = holding.carrying_value
+            else:
+                released_cost = quantize_ledger_decimal(
+                    abs(units) * holding.carrying_value / holding.units,
+                    field_name="crypto_fee_released_cost",
+                )
+            holding.units = quantize_ledger_decimal(
+                holding.units + units,
+                field_name="crypto_fee_position_quantity",
+            )
+            holding.carrying_value = quantize_ledger_decimal(
+                holding.carrying_value - released_cost,
+                field_name="crypto_fee_position_cost",
+            )
+            self.realized_pnl = quantize_ledger_decimal(
+                self.realized_pnl + fair_value - released_cost,
+                field_name="realized_pnl",
+            )
+            self.fees = quantize_ledger_decimal(
+                self.fees + fair_value,
+                field_name="fees",
+            )
+        else:
+            holding.units = quantize_ledger_decimal(
+                holding.units + units,
+                field_name="crypto_fee_position_quantity",
+            )
+            holding.carrying_value = quantize_ledger_decimal(
+                holding.carrying_value + fair_value,
+                field_name="crypto_fee_position_cost",
+            )
+            self.fees = quantize_ledger_decimal(
+                self.fees - fair_value,
+                field_name="fees",
+            )
+        if holding.units == ZERO:
+            holding.carrying_value = ZERO
+
+    def _split(self, activity: EconomicActivity) -> None:
+        units = activity.quantity
+        if units is None or units == ZERO:
+            raise EconomicLedgerError("economic_split_quantity_delta_required")
+        symbol = _symbol(activity)
+        holding = self.holdings.setdefault(symbol, _Holding())
+        new_units = quantize_ledger_decimal(
+            holding.units + units,
+            field_name="split_position_quantity",
+        )
+        if (
+            holding.units == ZERO
+            or new_units == ZERO
+            or holding.units * new_units < ZERO
+        ):
+            raise EconomicLedgerError("economic_split_position_direction_invalid")
+        holding.units = new_units
+
+    def _add_cash(self, activity: EconomicActivity, amount: Decimal) -> None:
+        currency = activity.currency or self.prepared.scope.quote_currency
+        if currency != self.prepared.scope.quote_currency:
+            raise EconomicLedgerError("economic_activity_currency_unsupported")
+        self.cash[currency] = quantize_ledger_decimal(
+            self.cash.get(currency, ZERO) + amount,
+            field_name="cash_balance",
+        )
+
+
+def _next_holding(
+    holding: _Holding,
+    order_units: Decimal,
+    price: Decimal,
+    cash_change: Decimal,
+) -> tuple[Decimal, Decimal]:
+    if holding.units == ZERO or holding.units * order_units > ZERO:
+        return (
+            quantize_ledger_decimal(
+                holding.units + order_units,
+                field_name="fill_position_quantity",
+            ),
+            quantize_ledger_decimal(
+                holding.carrying_value - cash_change,
+                field_name="fill_position_cost",
+            ),
+        )
+    return _opposite_holding(holding, order_units, price)
+
+
+def _opposite_holding(
+    holding: _Holding,
+    order_units: Decimal,
+    price: Decimal,
+) -> tuple[Decimal, Decimal]:
+    current_sign = Decimal(1 if holding.units > ZERO else -1)
+    order_sign = Decimal(1 if order_units > ZERO else -1)
+    units_closed = min(abs(holding.units), abs(order_units))
+    if units_closed == abs(holding.units):
+        released_value = abs(holding.carrying_value)
+    else:
+        released_value = quantize_ledger_decimal(
+            units_closed * abs(holding.carrying_value) / abs(holding.units),
+            field_name="fill_released_cost",
+        )
+
+    existing_remainder = abs(holding.units) - units_closed
+    order_remainder = abs(order_units) - units_closed
+    if existing_remainder > ZERO:
+        new_units = current_sign * existing_remainder
+        new_value = holding.carrying_value - current_sign * released_value
+    elif order_remainder > ZERO:
+        new_units = order_sign * order_remainder
+        new_value = order_sign * quantize_ledger_decimal(
+            order_remainder * price,
+            field_name="fill_opening_cost",
+        )
+    else:
+        new_units = ZERO
+        new_value = ZERO
+    return (
+        quantize_ledger_decimal(
+            new_units,
+            field_name="fill_position_quantity",
+        ),
+        quantize_ledger_decimal(
+            new_value,
+            field_name="fill_position_cost",
+        ),
+    )
+
+
+def reduce_independent_state(
+    activities: PreparedActivities
+    | tuple[EconomicActivity, ...]
+    | list[EconomicActivity],
+) -> EconomicProjection:
+    prepared = (
+        activities
+        if isinstance(activities, PreparedActivities)
+        else prepare_activities(activities)
+    )
+    with localcontext() as context:
+        context.prec = LEDGER_DECIMAL_PRECISION
+        return _StateReducer(prepared).reduce()
+
+
+def _required_amount(activity: EconomicActivity, kind: str) -> Decimal:
+    amount = activity.net_amount
+    if amount is None:
+        raise EconomicLedgerError(f"economic_{kind}_net_amount_required")
+    return amount
+
+
+def _symbol(activity: EconomicActivity) -> str:
+    symbol = activity.canonical_symbol
+    if symbol is None:
+        raise EconomicLedgerError("economic_activity_symbol_required")
+    return symbol
+
+
+def _validate_quote(activity: EconomicActivity) -> None:
+    raw_symbol = activity.symbol or ""
+    if (
+        "/" in raw_symbol
+        and raw_symbol.rsplit("/", maxsplit=1)[-1] != activity.scope.quote_currency
+    ):
+        raise EconomicLedgerError("economic_fill_quote_currency_unsupported")
+
+
+__all__ = (
+    "STATE_REDUCER_NAME",
+    "STATE_REDUCER_VERSION",
+    "reduce_independent_state",
+)

--- a/services/torghut/app/trading/economic_ledger/state_reducer.py
+++ b/services/torghut/app/trading/economic_ledger/state_reducer.py
@@ -160,7 +160,7 @@ class _StateReducer:
             raise EconomicLedgerError("economic_fill_price_must_be_positive")
         if activity.side == "buy":
             order_units = quantity
-        elif activity.side == "sell":
+        elif activity.side in {"sell", "sell_short"}:
             order_units = -quantity
         else:
             raise EconomicLedgerError("economic_fill_side_invalid")

--- a/services/torghut/app/trading/economic_ledger/state_reducer.py
+++ b/services/torghut/app/trading/economic_ledger/state_reducer.py
@@ -36,7 +36,6 @@ _INTEREST_ACTIVITY_TYPES = frozenset({"INT"})
 _WITHHOLDING_ACTIVITY_TYPES = frozenset({"DIVFT", "DIVNRA", "DIVTW", "INTNRA", "INTTW"})
 _CASH_FEE_ACTIVITY_TYPES = frozenset({"DIVFEE", "FEE", "PTC"})
 _CASH_EXPENSE_ACTIVITY_TYPES = _CASH_FEE_ACTIVITY_TYPES | _WITHHOLDING_ACTIVITY_TYPES
-_PAIRED_SPLIT_SUBTYPES = frozenset({"add", "remove"})
 
 
 @dataclass(slots=True)
@@ -100,11 +99,6 @@ class _StateReducer:
                 )
             )
             or (activity_type == "FILL" and activity.net_amount in {None, ZERO})
-            or (
-                activity_type == "SSP"
-                and activity.net_amount in {None, ZERO}
-                and activity.activity_subtype not in _PAIRED_SPLIT_SUBTYPES
-            )
             or activity_type in _EXTERNAL_FLOW_TYPES
             or activity_type in _DIVIDEND_ACTIVITY_TYPES
             or activity_type in _INTEREST_ACTIVITY_TYPES
@@ -122,11 +116,6 @@ class _StateReducer:
             self._fill(activity)
         elif activity_type == "CFEE":
             self._crypto_fee(activity)
-        elif activity_type == "SSP":
-            if self._split_removes_or_flips_holding(activity):
-                self.unsupported.add(activity.external_activity_id)
-            else:
-                self._split(activity)
         elif activity_type in _EXTERNAL_FLOW_TYPES or activity_type == "JNL":
             amount = _required_amount(activity, "cash_flow")
             self._add_cash(activity, amount)
@@ -241,36 +230,6 @@ class _StateReducer:
         )
         if holding.units == ZERO:
             holding.carrying_value = ZERO
-
-    def _split(self, activity: EconomicActivity) -> None:
-        units = activity.quantity
-        if units is None or units == ZERO:
-            raise EconomicLedgerError("economic_split_quantity_delta_required")
-        symbol = _symbol(activity)
-        holding = self.holdings.setdefault(symbol, _Holding())
-        new_units = quantize_ledger_decimal(
-            holding.units + units,
-            field_name="split_position_quantity",
-        )
-        if (
-            holding.units == ZERO
-            or new_units == ZERO
-            or holding.units * new_units < ZERO
-        ):
-            raise EconomicLedgerError("economic_split_position_direction_invalid")
-        holding.units = new_units
-
-    def _split_removes_or_flips_holding(self, activity: EconomicActivity) -> bool:
-        symbol = activity.canonical_symbol
-        units = activity.quantity
-        holding = self.holdings.get(symbol) if symbol is not None else None
-        if units is None or units == ZERO or holding is None:
-            return False
-        new_units = quantize_ledger_decimal(
-            holding.units + units,
-            field_name="split_position_quantity",
-        )
-        return new_units == ZERO or holding.units * new_units < ZERO
 
     def _add_cash(self, activity: EconomicActivity, amount: Decimal) -> None:
         currency = activity.currency or self.prepared.scope.quote_currency

--- a/services/torghut/app/trading/economic_ledger/state_reducer.py
+++ b/services/torghut/app/trading/economic_ledger/state_reducer.py
@@ -29,14 +29,13 @@ _DIVIDEND_ACTIVITY_TYPES = frozenset(
         "DIV",
         "DIVCGL",
         "DIVCGS",
-        "DIVFT",
-        "DIVNRA",
-        "DIVTW",
         "DIVTXEX",
     }
 )
-_INTEREST_ACTIVITY_TYPES = frozenset({"INT", "INTNRA", "INTTW"})
+_INTEREST_ACTIVITY_TYPES = frozenset({"INT"})
+_WITHHOLDING_ACTIVITY_TYPES = frozenset({"DIVFT", "DIVNRA", "DIVTW", "INTNRA", "INTTW"})
 _CASH_FEE_ACTIVITY_TYPES = frozenset({"DIVFEE", "FEE", "PTC"})
+_CASH_EXPENSE_ACTIVITY_TYPES = _CASH_FEE_ACTIVITY_TYPES | _WITHHOLDING_ACTIVITY_TYPES
 
 
 @dataclass(slots=True)
@@ -96,7 +95,7 @@ class _StateReducer:
             or activity_type in _EXTERNAL_FLOW_TYPES
             or activity_type in _DIVIDEND_ACTIVITY_TYPES
             or activity_type in _INTEREST_ACTIVITY_TYPES
-            or activity_type in _CASH_FEE_ACTIVITY_TYPES
+            or activity_type in _CASH_EXPENSE_ACTIVITY_TYPES
             or (
                 activity_type == "JNL"
                 and activity.symbol is None
@@ -133,7 +132,7 @@ class _StateReducer:
                 self.interest + amount,
                 field_name="interest",
             )
-        elif activity_type in _CASH_FEE_ACTIVITY_TYPES:
+        elif activity_type in _CASH_EXPENSE_ACTIVITY_TYPES:
             amount = _required_amount(activity, "fee")
             self._add_cash(activity, amount)
             self.fees = quantize_ledger_decimal(

--- a/services/torghut/app/trading/economic_ledger/state_reducer.py
+++ b/services/torghut/app/trading/economic_ledger/state_reducer.py
@@ -91,7 +91,8 @@ class _StateReducer:
     def _recognized(self, activity: EconomicActivity) -> bool:
         activity_type = activity.activity_type
         return (
-            activity_type in {"CFEE", "FILL", "SSP"}
+            activity_type in {"CFEE", "FILL"}
+            or (activity_type == "SSP" and activity.net_amount in {None, ZERO})
             or activity_type in _EXTERNAL_FLOW_TYPES
             or activity_type in _DIVIDEND_ACTIVITY_TYPES
             or activity_type in _INTEREST_ACTIVITY_TYPES

--- a/services/torghut/app/trading/economic_ledger/state_reducer.py
+++ b/services/torghut/app/trading/economic_ledger/state_reducer.py
@@ -91,7 +91,8 @@ class _StateReducer:
     def _recognized(self, activity: EconomicActivity) -> bool:
         activity_type = activity.activity_type
         return (
-            activity_type in {"CFEE", "FILL"}
+            activity_type == "CFEE"
+            or (activity_type == "FILL" and activity.net_amount in {None, ZERO})
             or (activity_type == "SSP" and activity.net_amount in {None, ZERO})
             or activity_type in _EXTERNAL_FLOW_TYPES
             or activity_type in _DIVIDEND_ACTIVITY_TYPES

--- a/services/torghut/app/trading/economic_ledger/state_reducer.py
+++ b/services/torghut/app/trading/economic_ledger/state_reducer.py
@@ -169,6 +169,8 @@ class _StateReducer:
             -order_units * price,
             field_name="fill_cash_delta",
         )
+        if cash_change == ZERO:
+            raise EconomicLedgerError("economic_fill_notional_below_ledger_quantum")
         self._add_cash(activity, cash_change)
         holding.units, holding.carrying_value = _next_holding(
             holding,
@@ -203,6 +205,10 @@ class _StateReducer:
             abs(units) * price,
             field_name="crypto_fee_fair_value",
         )
+        if fair_value == ZERO:
+            raise EconomicLedgerError(
+                "economic_crypto_fee_fair_value_below_ledger_quantum"
+            )
         if holding.units <= ZERO or abs(units) > holding.units:
             raise EconomicLedgerError("economic_crypto_fee_position_insufficient")
         if abs(units) == holding.units:

--- a/services/torghut/app/trading/economic_ledger/state_reducer.py
+++ b/services/torghut/app/trading/economic_ledger/state_reducer.py
@@ -95,7 +95,7 @@ class _StateReducer:
                 activity_type == "CFEE"
                 and (
                     activity.net_amount not in {None, ZERO}
-                    or activity.quantity not in {None, ZERO}
+                    or (activity.quantity is not None and activity.quantity < ZERO)
                 )
             )
             or (activity_type == "FILL" and activity.net_amount in {None, ZERO})
@@ -194,8 +194,8 @@ class _StateReducer:
             )
             return
         units = activity.quantity
-        if units is None or units == ZERO:
-            return
+        if units is None or units >= ZERO:
+            raise EconomicLedgerError("economic_crypto_fee_quantity_must_be_negative")
         price = activity.price
         if price is None or price <= ZERO:
             raise EconomicLedgerError("economic_crypto_fee_price_must_be_positive")
@@ -206,45 +206,31 @@ class _StateReducer:
             abs(units) * price,
             field_name="crypto_fee_fair_value",
         )
-        if units < ZERO:
-            if holding.units <= ZERO or abs(units) > holding.units:
-                raise EconomicLedgerError("economic_crypto_fee_position_insufficient")
-            if abs(units) == holding.units:
-                released_cost = holding.carrying_value
-            else:
-                released_cost = quantize_ledger_decimal(
-                    abs(units) * holding.carrying_value / holding.units,
-                    field_name="crypto_fee_released_cost",
-                )
-            holding.units = quantize_ledger_decimal(
-                holding.units + units,
-                field_name="crypto_fee_position_quantity",
-            )
-            holding.carrying_value = quantize_ledger_decimal(
-                holding.carrying_value - released_cost,
-                field_name="crypto_fee_position_cost",
-            )
-            self.realized_pnl = quantize_ledger_decimal(
-                self.realized_pnl + fair_value - released_cost,
-                field_name="realized_pnl",
-            )
-            self.fees = quantize_ledger_decimal(
-                self.fees + fair_value,
-                field_name="fees",
-            )
+        if holding.units <= ZERO or abs(units) > holding.units:
+            raise EconomicLedgerError("economic_crypto_fee_position_insufficient")
+        if abs(units) == holding.units:
+            released_cost = holding.carrying_value
         else:
-            holding.units = quantize_ledger_decimal(
-                holding.units + units,
-                field_name="crypto_fee_position_quantity",
+            released_cost = quantize_ledger_decimal(
+                abs(units) * holding.carrying_value / holding.units,
+                field_name="crypto_fee_released_cost",
             )
-            holding.carrying_value = quantize_ledger_decimal(
-                holding.carrying_value + fair_value,
-                field_name="crypto_fee_position_cost",
-            )
-            self.fees = quantize_ledger_decimal(
-                self.fees - fair_value,
-                field_name="fees",
-            )
+        holding.units = quantize_ledger_decimal(
+            holding.units + units,
+            field_name="crypto_fee_position_quantity",
+        )
+        holding.carrying_value = quantize_ledger_decimal(
+            holding.carrying_value - released_cost,
+            field_name="crypto_fee_position_cost",
+        )
+        self.realized_pnl = quantize_ledger_decimal(
+            self.realized_pnl + fair_value - released_cost,
+            field_name="realized_pnl",
+        )
+        self.fees = quantize_ledger_decimal(
+            self.fees + fair_value,
+            field_name="fees",
+        )
         if holding.units == ZERO:
             holding.carrying_value = ZERO
 

--- a/services/torghut/app/trading/economic_ledger/state_reducer.py
+++ b/services/torghut/app/trading/economic_ledger/state_reducer.py
@@ -91,7 +91,13 @@ class _StateReducer:
     def _recognized(self, activity: EconomicActivity) -> bool:
         activity_type = activity.activity_type
         return (
-            activity_type == "CFEE"
+            (
+                activity_type == "CFEE"
+                and (
+                    activity.net_amount not in {None, ZERO}
+                    or activity.quantity not in {None, ZERO}
+                )
+            )
             or (activity_type == "FILL" and activity.net_amount in {None, ZERO})
             or (activity_type == "SSP" and activity.net_amount in {None, ZERO})
             or activity_type in _EXTERNAL_FLOW_TYPES

--- a/services/torghut/app/trading/economic_ledger/state_reducer.py
+++ b/services/torghut/app/trading/economic_ledger/state_reducer.py
@@ -192,6 +192,7 @@ class _StateReducer:
         price = activity.price
         if price is None or price <= ZERO:
             raise EconomicLedgerError("economic_crypto_fee_price_must_be_positive")
+        _validate_quote(activity)
         symbol = _symbol(activity)
         holding = self.holdings.setdefault(symbol, _Holding())
         fair_value = quantize_ledger_decimal(
@@ -360,6 +361,8 @@ def _symbol(activity: EconomicActivity) -> str:
 
 
 def _validate_quote(activity: EconomicActivity) -> None:
+    if activity.currency not in {None, activity.scope.quote_currency}:
+        raise EconomicLedgerError("economic_activity_currency_unsupported")
     raw_symbol = activity.symbol or ""
     if (
         "/" in raw_symbol

--- a/services/torghut/app/trading/economic_ledger/types.py
+++ b/services/torghut/app/trading/economic_ledger/types.py
@@ -559,7 +559,10 @@ def decimal_text(value: Decimal | None) -> str | None:
         return None
     if value == ZERO:
         return "0"
-    return format(value.normalize(), "f")
+    exact = format(value, "f")
+    if "." not in exact:
+        return exact
+    return exact.rstrip("0").rstrip(".")
 
 
 def quantize_ledger_decimal(

--- a/services/torghut/app/trading/economic_ledger/types.py
+++ b/services/torghut/app/trading/economic_ledger/types.py
@@ -1,0 +1,707 @@
+"""Pure contracts for deterministic broker-economic ledger reduction."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from datetime import date, datetime, time, timezone
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP, localcontext
+
+
+ZERO = Decimal("0")
+LEDGER_DECIMAL_PRECISION = 80
+LEDGER_DECIMAL_SCALE = 18
+LEDGER_QUANTUM = Decimal("0.000000000000000001")
+_LEDGER_ABSOLUTE_LIMIT = Decimal("100000000000000000000")
+
+
+class EconomicLedgerError(RuntimeError):
+    """Base error for an inadmissible economic-ledger input or output."""
+
+
+class EconomicLedgerSourceContradiction(EconomicLedgerError):
+    """One broker identity was observed with contradictory immutable bytes."""
+
+
+class EconomicLedgerCorrectionError(EconomicLedgerError):
+    """A correction chain is missing, forked, or cyclic."""
+
+
+@dataclass(frozen=True, slots=True)
+class LedgerScope:
+    provider: str
+    environment: str
+    account_label: str
+    endpoint_fingerprint: str
+    quote_currency: str = "USD"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "provider", _required_text(self.provider, "provider", 32).lower()
+        )
+        object.__setattr__(
+            self,
+            "environment",
+            _required_text(self.environment, "environment", 16).lower(),
+        )
+        object.__setattr__(
+            self,
+            "account_label",
+            _required_text(self.account_label, "account_label", 64),
+        )
+        object.__setattr__(
+            self,
+            "endpoint_fingerprint",
+            _sha256(self.endpoint_fingerprint, field_name="endpoint_fingerprint"),
+        )
+        object.__setattr__(
+            self,
+            "quote_currency",
+            _required_text(self.quote_currency, "quote_currency", 16).upper(),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class EconomicActivity:
+    """One immutable REST broker activity adapted for pure reduction."""
+
+    scope: LedgerScope
+    external_activity_id: str
+    raw_payload_sha256: str
+    activity_type: str
+    first_observed_at: datetime
+    activity_subtype: str | None = None
+    correction_of_external_id: str | None = None
+    event_at: datetime | None = None
+    settle_date: date | None = None
+    symbol: str | None = None
+    side: str | None = None
+    quantity: Decimal | None = None
+    price: Decimal | None = None
+    net_amount: Decimal | None = None
+    currency: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "external_activity_id",
+            _required_text(self.external_activity_id, "external_activity_id", 256),
+        )
+        object.__setattr__(
+            self,
+            "raw_payload_sha256",
+            _sha256(self.raw_payload_sha256, field_name="raw_payload_sha256"),
+        )
+        object.__setattr__(
+            self,
+            "activity_type",
+            _required_text(self.activity_type, "activity_type", 32).upper(),
+        )
+        object.__setattr__(
+            self,
+            "activity_subtype",
+            _optional_text(self.activity_subtype, "activity_subtype", 32, lower=True),
+        )
+        object.__setattr__(
+            self,
+            "correction_of_external_id",
+            _optional_text(
+                self.correction_of_external_id,
+                "correction_of_external_id",
+                256,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "symbol",
+            _optional_text(self.symbol, "symbol", 64, upper=True),
+        )
+        object.__setattr__(
+            self,
+            "side",
+            _optional_text(self.side, "side", 16, lower=True),
+        )
+        object.__setattr__(
+            self,
+            "currency",
+            _optional_text(self.currency, "currency", 16, upper=True),
+        )
+        object.__setattr__(
+            self,
+            "first_observed_at",
+            _aware_utc(self.first_observed_at, "first_observed_at"),
+        )
+        if self.event_at is not None:
+            object.__setattr__(self, "event_at", _aware_utc(self.event_at, "event_at"))
+        for field_name in ("quantity", "price", "net_amount"):
+            value = getattr(self, field_name)
+            if value is not None:
+                object.__setattr__(self, field_name, _finite_decimal(value, field_name))
+        if self.correction_of_external_id == self.external_activity_id:
+            raise EconomicLedgerCorrectionError(
+                "economic_activity_cannot_correct_itself"
+            )
+
+    @property
+    def economic_at(self) -> datetime:
+        if self.event_at is not None:
+            return self.event_at
+        if self.settle_date is not None:
+            return datetime.combine(self.settle_date, time.min, tzinfo=timezone.utc)
+        return self.first_observed_at
+
+    @property
+    def canonical_symbol(self) -> str | None:
+        if self.symbol is None:
+            return None
+        return self.symbol.replace("/", "")
+
+    @property
+    def sort_key(self) -> tuple[datetime, date, str, str]:
+        return (
+            self.economic_at,
+            self.settle_date or date.min,
+            self.external_activity_id,
+            self.raw_payload_sha256,
+        )
+
+    def manifest_payload(self) -> dict[str, object]:
+        return {
+            "activity_subtype": self.activity_subtype,
+            "activity_type": self.activity_type,
+            "correction_of_external_id": self.correction_of_external_id,
+            "currency": self.currency,
+            "event_at": _datetime_text(self.event_at),
+            "external_activity_id": self.external_activity_id,
+            "first_observed_at": _datetime_text(self.first_observed_at),
+            "net_amount": decimal_text(self.net_amount),
+            "price": decimal_text(self.price),
+            "quantity": decimal_text(self.quantity),
+            "raw_payload_sha256": self.raw_payload_sha256,
+            "settle_date": self.settle_date.isoformat() if self.settle_date else None,
+            "side": self.side,
+            "symbol": self.symbol,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ActivityChain:
+    """One original activity followed by zero or more retroactive corrections."""
+
+    activities: tuple[EconomicActivity, ...]
+
+    @property
+    def effective(self) -> EconomicActivity:
+        return self.activities[-1]
+
+    @property
+    def root(self) -> EconomicActivity:
+        return self.activities[0]
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedActivities:
+    scope: LedgerScope
+    chains: tuple[ActivityChain, ...]
+    manifest_digest: str
+    input_count: int
+    duplicate_count: int
+    corrected_count: int
+
+    @property
+    def effective(self) -> tuple[EconomicActivity, ...]:
+        return tuple(chain.effective for chain in self.chains)
+
+
+@dataclass(frozen=True, slots=True)
+class LedgerLine:
+    account: str
+    commodity: str
+    amount: Decimal
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "account", _required_text(self.account, "account", 128)
+        )
+        object.__setattr__(
+            self,
+            "commodity",
+            _required_text(self.commodity, "commodity", 64).upper(),
+        )
+        amount = _finite_decimal(self.amount, "amount")
+        if amount == ZERO:
+            raise EconomicLedgerError("ledger_line_amount_must_be_nonzero")
+        object.__setattr__(self, "amount", amount)
+
+
+@dataclass(frozen=True, slots=True)
+class LedgerTransaction:
+    transaction_id: str
+    source_activity_id: str
+    posting_rule: str
+    lines: tuple[LedgerLine, ...]
+    reverses_transaction_id: str | None = None
+    digest: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "transaction_id",
+            _required_text(self.transaction_id, "transaction_id", 512),
+        )
+        object.__setattr__(
+            self,
+            "source_activity_id",
+            _required_text(self.source_activity_id, "source_activity_id", 256),
+        )
+        object.__setattr__(
+            self,
+            "posting_rule",
+            _required_text(self.posting_rule, "posting_rule", 128),
+        )
+        if self.reverses_transaction_id is not None:
+            object.__setattr__(
+                self,
+                "reverses_transaction_id",
+                _required_text(
+                    self.reverses_transaction_id,
+                    "reverses_transaction_id",
+                    512,
+                ),
+            )
+        if len(self.lines) < 2:
+            raise EconomicLedgerError("ledger_transaction_requires_two_lines")
+        balances: dict[str, Decimal] = {}
+        for line in self.lines:
+            balances[line.commodity] = balances.get(line.commodity, ZERO) + line.amount
+        unbalanced = {
+            commodity: amount
+            for commodity, amount in balances.items()
+            if amount != ZERO
+        }
+        if unbalanced:
+            raise EconomicLedgerError(f"ledger_transaction_unbalanced:{unbalanced}")
+        payload = {
+            "lines": [
+                {
+                    "account": line.account,
+                    "amount": decimal_text(line.amount),
+                    "commodity": line.commodity,
+                }
+                for line in self.lines
+            ],
+            "posting_rule": self.posting_rule,
+            "reverses_transaction_id": self.reverses_transaction_id,
+            "source_activity_id": self.source_activity_id,
+            "transaction_id": self.transaction_id,
+        }
+        object.__setattr__(self, "digest", canonical_sha256(payload))
+
+
+@dataclass(frozen=True, slots=True)
+class CommodityBalance:
+    commodity: str
+    amount: Decimal
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "commodity",
+            _required_text(self.commodity, "commodity", 64).upper(),
+        )
+        object.__setattr__(self, "amount", _finite_decimal(self.amount, "amount"))
+
+
+@dataclass(frozen=True, slots=True)
+class PositionBalance:
+    symbol: str
+    quantity: Decimal
+    signed_cost: Decimal
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "symbol", _required_text(self.symbol, "symbol", 64).upper()
+        )
+        object.__setattr__(self, "quantity", _finite_decimal(self.quantity, "quantity"))
+        object.__setattr__(
+            self, "signed_cost", _finite_decimal(self.signed_cost, "signed_cost")
+        )
+        if self.quantity == ZERO and self.signed_cost != ZERO:
+            raise EconomicLedgerError("economic_position_flat_cost_nonzero")
+        if self.quantity * self.signed_cost < ZERO:
+            raise EconomicLedgerError("economic_position_cost_sign_mismatch")
+
+    @property
+    def average_cost(self) -> Decimal | None:
+        if self.quantity == ZERO:
+            return None
+        with localcontext() as context:
+            context.prec = LEDGER_DECIMAL_PRECISION
+            return quantize_ledger_decimal(
+                self.signed_cost / self.quantity,
+                field_name="average_cost",
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class EconomicProjection:
+    reducer_name: str
+    reducer_version: str
+    scope: LedgerScope
+    input_manifest_digest: str
+    input_count: int
+    duplicate_count: int
+    corrected_count: int
+    cash: tuple[CommodityBalance, ...]
+    positions: tuple[PositionBalance, ...]
+    realized_pnl: Decimal
+    fees: Decimal
+    dividends: Decimal
+    interest: Decimal
+    external_flows: Decimal
+    unsupported_activity_ids: tuple[str, ...]
+    result_digest: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "realized_pnl",
+            "fees",
+            "dividends",
+            "interest",
+            "external_flows",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _finite_decimal(getattr(self, field_name), field_name),
+            )
+        payload = self.economic_payload()
+        payload.update(
+            reducer_name=self.reducer_name,
+            reducer_version=self.reducer_version,
+        )
+        object.__setattr__(self, "result_digest", canonical_sha256(payload))
+
+    @property
+    def admissible(self) -> bool:
+        return not self.unsupported_activity_ids
+
+    def economic_payload(self) -> dict[str, object]:
+        return {
+            "cash": {
+                balance.commodity: decimal_text(balance.amount) for balance in self.cash
+            },
+            "corrected_count": self.corrected_count,
+            "dividends": decimal_text(self.dividends),
+            "duplicate_count": self.duplicate_count,
+            "external_flows": decimal_text(self.external_flows),
+            "fees": decimal_text(self.fees),
+            "input_count": self.input_count,
+            "input_manifest_digest": self.input_manifest_digest,
+            "interest": decimal_text(self.interest),
+            "positions": {
+                position.symbol: {
+                    "quantity": decimal_text(position.quantity),
+                    "signed_cost": decimal_text(position.signed_cost),
+                }
+                for position in self.positions
+            },
+            "realized_pnl": decimal_text(self.realized_pnl),
+            "scope": {
+                "account_label": self.scope.account_label,
+                "endpoint_fingerprint": self.scope.endpoint_fingerprint,
+                "environment": self.scope.environment,
+                "provider": self.scope.provider,
+                "quote_currency": self.scope.quote_currency,
+            },
+            "unsupported_activity_ids": list(self.unsupported_activity_ids),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class JournalReduction:
+    projection: EconomicProjection
+    transactions: tuple[LedgerTransaction, ...]
+    journal_digest: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "journal_digest",
+            canonical_sha256([transaction.digest for transaction in self.transactions]),
+        )
+
+
+def prepare_activities(activities: Iterable[EconomicActivity]) -> PreparedActivities:
+    """Deduplicate immutable identities and resolve correction chains."""
+
+    unique, duplicate_count = _deduplicate_activities(activities)
+    scope = _single_scope(unique.values())
+    chains = _activity_chains(unique)
+    manifest = [
+        activity.manifest_payload()
+        for activity in sorted(unique.values(), key=lambda activity: activity.sort_key)
+    ]
+    return PreparedActivities(
+        scope=scope,
+        chains=chains,
+        manifest_digest=canonical_sha256(manifest),
+        input_count=len(unique),
+        duplicate_count=duplicate_count,
+        corrected_count=sum(len(chain.activities) - 1 for chain in chains),
+    )
+
+
+def _deduplicate_activities(
+    activities: Iterable[EconomicActivity],
+) -> tuple[dict[str, EconomicActivity], int]:
+    unique: dict[str, EconomicActivity] = {}
+    duplicate_count = 0
+    for activity in activities:
+        existing = unique.get(activity.external_activity_id)
+        if existing is None:
+            unique[activity.external_activity_id] = activity
+            continue
+        if (
+            existing.raw_payload_sha256 != activity.raw_payload_sha256
+            or existing != activity
+        ):
+            raise EconomicLedgerSourceContradiction(
+                f"economic_activity_payload_changed:{activity.external_activity_id}"
+            )
+        duplicate_count += 1
+    if not unique:
+        raise EconomicLedgerError("economic_ledger_input_empty")
+    return unique, duplicate_count
+
+
+def _single_scope(activities: Iterable[EconomicActivity]) -> LedgerScope:
+    scopes = {activity.scope for activity in activities}
+    if len(scopes) != 1:
+        raise EconomicLedgerError("economic_ledger_scope_mixed")
+    return next(iter(scopes))
+
+
+def _activity_chains(
+    unique: Mapping[str, EconomicActivity],
+) -> tuple[ActivityChain, ...]:
+    successor = _correction_successors(unique)
+    roots = sorted(
+        (
+            activity
+            for activity in unique.values()
+            if activity.correction_of_external_id is None
+        ),
+        key=lambda activity: activity.sort_key,
+    )
+    visited: set[str] = set()
+    chains = tuple(_walk_correction_chain(root, successor, visited) for root in roots)
+    if visited != set(unique):
+        raise EconomicLedgerCorrectionError("economic_activity_correction_cycle")
+    return chains
+
+
+def _correction_successors(
+    unique: Mapping[str, EconomicActivity],
+) -> dict[str, EconomicActivity]:
+    successor: dict[str, EconomicActivity] = {}
+    for activity in unique.values():
+        predecessor = activity.correction_of_external_id
+        if predecessor is None:
+            continue
+        if predecessor not in unique:
+            raise EconomicLedgerCorrectionError(
+                f"economic_activity_correction_predecessor_missing:{predecessor}"
+            )
+        if predecessor in successor:
+            raise EconomicLedgerCorrectionError(
+                f"economic_activity_correction_fork:{predecessor}"
+            )
+        successor[predecessor] = activity
+    return successor
+
+
+def _walk_correction_chain(
+    root: EconomicActivity,
+    successor: Mapping[str, EconomicActivity],
+    visited: set[str],
+) -> ActivityChain:
+    chain: list[EconomicActivity] = []
+    current = root
+    while current.external_activity_id not in visited:
+        visited.add(current.external_activity_id)
+        chain.append(current)
+        next_activity = successor.get(current.external_activity_id)
+        if next_activity is None:
+            return ActivityChain(tuple(chain))
+        current = next_activity
+    raise EconomicLedgerCorrectionError("economic_activity_correction_cycle")
+
+
+def canonical_sha256(value: object) -> str:
+    try:
+        encoded = json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise EconomicLedgerError("economic_ledger_value_not_canonical_json") from exc
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def decimal_text(value: Decimal | None) -> str | None:
+    if value is None:
+        return None
+    if value == ZERO:
+        return "0"
+    return format(value.normalize(), "f")
+
+
+def quantize_ledger_decimal(
+    value: Decimal,
+    *,
+    field_name: str = "derived_amount",
+) -> Decimal:
+    """Round one derived value to the durable NUMERIC(38, 18) contract."""
+
+    if not value.is_finite():
+        raise EconomicLedgerError(f"economic_ledger_{field_name}_invalid")
+    with localcontext() as context:
+        context.prec = LEDGER_DECIMAL_PRECISION
+        try:
+            quantized = value.quantize(LEDGER_QUANTUM, rounding=ROUND_HALF_UP)
+        except InvalidOperation as exc:
+            raise EconomicLedgerError(
+                f"economic_ledger_{field_name}_out_of_range"
+            ) from exc
+    if abs(quantized) >= _LEDGER_ABSOLUTE_LIMIT:
+        raise EconomicLedgerError(f"economic_ledger_{field_name}_out_of_range")
+    return ZERO if quantized == ZERO else quantized
+
+
+def balances_tuple(values: Mapping[str, Decimal]) -> tuple[CommodityBalance, ...]:
+    return tuple(
+        CommodityBalance(commodity=commodity, amount=amount)
+        for commodity, amount in sorted(values.items())
+        if amount != ZERO
+    )
+
+
+def positions_tuple(
+    quantities: Mapping[str, Decimal],
+    costs: Mapping[str, Decimal],
+) -> tuple[PositionBalance, ...]:
+    return tuple(
+        PositionBalance(
+            symbol=symbol,
+            quantity=quantities.get(symbol, ZERO),
+            signed_cost=costs.get(symbol, ZERO),
+        )
+        for symbol in sorted(set(quantities) | set(costs))
+        if quantities.get(symbol, ZERO) != ZERO or costs.get(symbol, ZERO) != ZERO
+    )
+
+
+def _required_text(value: object, field_name: str, maximum: int) -> str:
+    if not isinstance(value, str):
+        raise EconomicLedgerError(f"economic_ledger_{field_name}_must_be_string")
+    normalized = value.strip()
+    if (
+        not normalized
+        or len(normalized) > maximum
+        or any(ord(char) < 32 for char in normalized)
+    ):
+        raise EconomicLedgerError(f"economic_ledger_{field_name}_invalid")
+    return normalized
+
+
+def _optional_text(
+    value: object,
+    field_name: str,
+    maximum: int,
+    *,
+    lower: bool = False,
+    upper: bool = False,
+) -> str | None:
+    if value is None:
+        return None
+    normalized = _required_text(value, field_name, maximum)
+    if lower:
+        return normalized.lower()
+    if upper:
+        return normalized.upper()
+    return normalized
+
+
+def _sha256(value: object, *, field_name: str) -> str:
+    normalized = _required_text(value, field_name, 64).lower()
+    if len(normalized) != 64 or any(
+        char not in "0123456789abcdef" for char in normalized
+    ):
+        raise EconomicLedgerError(f"economic_ledger_{field_name}_invalid")
+    return normalized
+
+
+def _aware_utc(value: datetime, field_name: str) -> datetime:
+    if value.tzinfo is None:
+        raise EconomicLedgerError(f"economic_ledger_{field_name}_timezone_required")
+    return value.astimezone(timezone.utc)
+
+
+def _finite_decimal(value: object, field_name: str) -> Decimal:
+    if isinstance(value, bool):
+        raise EconomicLedgerError(f"economic_ledger_{field_name}_invalid")
+    try:
+        parsed = value if isinstance(value, Decimal) else Decimal(str(value))
+    except (InvalidOperation, ValueError, TypeError) as exc:
+        raise EconomicLedgerError(f"economic_ledger_{field_name}_invalid") from exc
+    if not parsed.is_finite():
+        raise EconomicLedgerError(f"economic_ledger_{field_name}_invalid")
+    quantized = quantize_ledger_decimal(parsed, field_name=field_name)
+    if parsed != quantized:
+        raise EconomicLedgerError(
+            f"economic_ledger_{field_name}_scale_exceeds_{LEDGER_DECIMAL_SCALE}"
+        )
+    return quantized
+
+
+def _datetime_text(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    return (
+        value.astimezone(timezone.utc)
+        .isoformat(timespec="microseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+__all__ = (
+    "LEDGER_DECIMAL_PRECISION",
+    "LEDGER_DECIMAL_SCALE",
+    "LEDGER_QUANTUM",
+    "ZERO",
+    "ActivityChain",
+    "CommodityBalance",
+    "EconomicActivity",
+    "EconomicLedgerCorrectionError",
+    "EconomicLedgerError",
+    "EconomicLedgerSourceContradiction",
+    "EconomicProjection",
+    "JournalReduction",
+    "LedgerLine",
+    "LedgerScope",
+    "LedgerTransaction",
+    "PositionBalance",
+    "PreparedActivities",
+    "balances_tuple",
+    "canonical_sha256",
+    "decimal_text",
+    "positions_tuple",
+    "prepare_activities",
+    "quantize_ledger_decimal",
+)

--- a/services/torghut/app/trading/economic_ledger/types.py
+++ b/services/torghut/app/trading/economic_ledger/types.py
@@ -149,7 +149,14 @@ class EconomicActivity:
         if self.event_at is not None:
             return self.event_at
         if self.settle_date is not None:
-            return datetime.combine(self.settle_date, time.min, tzinfo=timezone.utc)
+            # Alpaca can emit asset CFEE rows with only a date. The fee charges
+            # that day's fills, so it must not sort ahead of timestamped fills.
+            fallback_time = time.max if self.activity_type == "CFEE" else time.min
+            return datetime.combine(
+                self.settle_date,
+                fallback_time,
+                tzinfo=timezone.utc,
+            )
         return self.first_observed_at
 
     @property

--- a/services/torghut/app/trading/economic_ledger/types.py
+++ b/services/torghut/app/trading/economic_ledger/types.py
@@ -337,6 +337,8 @@ class PositionBalance:
         )
         if self.quantity == ZERO and self.signed_cost != ZERO:
             raise EconomicLedgerError("economic_position_flat_cost_nonzero")
+        if self.quantity != ZERO and self.signed_cost == ZERO:
+            raise EconomicLedgerError("economic_position_nonzero_quantity_zero_cost")
         if self.quantity * self.signed_cost < ZERO:
             raise EconomicLedgerError("economic_position_cost_sign_mismatch")
 

--- a/services/torghut/tests/economic_ledger/__init__.py
+++ b/services/torghut/tests/economic_ledger/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the independent broker-economic ledger."""

--- a/services/torghut/tests/economic_ledger/support.py
+++ b/services/torghut/tests/economic_ledger/support.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import hashlib
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal
+
+from app.trading.economic_ledger import EconomicActivity, LedgerScope
+
+
+SCOPE = LedgerScope(
+    provider="alpaca",
+    environment="paper",
+    account_label="paper-account",
+    endpoint_fingerprint="a" * 64,
+    quote_currency="USD",
+)
+BASE_TIME = datetime(2026, 7, 16, 9, 30, tzinfo=timezone.utc)
+
+
+def activity(
+    external_id: str,
+    activity_type: str,
+    *,
+    subtype: str | None = None,
+    correction_of: str | None = None,
+    event_offset_seconds: int = 0,
+    symbol: str | None = None,
+    side: str | None = None,
+    quantity: str | None = None,
+    price: str | None = None,
+    net_amount: str | None = None,
+    currency: str | None = "USD",
+    raw_payload_sha256: str | None = None,
+) -> EconomicActivity:
+    return EconomicActivity(
+        scope=SCOPE,
+        external_activity_id=external_id,
+        raw_payload_sha256=(
+            raw_payload_sha256
+            or hashlib.sha256(external_id.encode("utf-8")).hexdigest()
+        ),
+        activity_type=activity_type,
+        activity_subtype=subtype,
+        correction_of_external_id=correction_of,
+        event_at=BASE_TIME + timedelta(seconds=event_offset_seconds),
+        settle_date=date(2026, 7, 16),
+        first_observed_at=BASE_TIME + timedelta(minutes=1),
+        symbol=symbol,
+        side=side,
+        quantity=Decimal(quantity) if quantity is not None else None,
+        price=Decimal(price) if price is not None else None,
+        net_amount=Decimal(net_amount) if net_amount is not None else None,
+        currency=currency,
+    )
+
+
+def cash(projection, currency: str = "USD") -> Decimal:
+    return {balance.commodity: balance.amount for balance in projection.cash}.get(
+        currency,
+        Decimal("0"),
+    )
+
+
+def position(projection, symbol: str):
+    return {item.symbol: item for item in projection.positions}.get(symbol)

--- a/services/torghut/tests/economic_ledger/test_differential_properties.py
+++ b/services/torghut/tests/economic_ledger/test_differential_properties.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from app.trading.economic_ledger import reduce_and_compare
+from tests.economic_ledger.support import activity
+
+
+@settings(max_examples=150, deadline=None)
+@given(
+    fills=st.lists(
+        st.tuples(
+            st.sampled_from(("buy", "sell")),
+            st.integers(min_value=1, max_value=25),
+            st.integers(min_value=1, max_value=500),
+        ),
+        min_size=1,
+        max_size=60,
+    )
+)
+def test_random_fill_sequences_have_zero_differential(
+    fills: list[tuple[str, int, int]],
+) -> None:
+    rows = [activity("capital", "JNLC", net_amount="1000000")]
+    rows.extend(
+        activity(
+            f"fill-{index}",
+            "FILL",
+            event_offset_seconds=index + 1,
+            symbol="AAPL",
+            side=side,
+            quantity=str(quantity),
+            price=str(price),
+            net_amount=None,
+        )
+        for index, (side, quantity, price) in enumerate(fills)
+    )
+
+    result = reduce_and_compare(rows)
+
+    assert result.admissible
+    assert result.comparison.equivalent
+    assert all(
+        sum(
+            (line.amount for line in transaction.lines if line.commodity == commodity),
+            start=Decimal("0"),
+        )
+        == Decimal("0")
+        for transaction in result.journal.transactions
+        for commodity in {line.commodity for line in transaction.lines}
+    )

--- a/services/torghut/tests/economic_ledger/test_dual_reducers.py
+++ b/services/torghut/tests/economic_ledger/test_dual_reducers.py
@@ -1,0 +1,497 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.trading.economic_ledger import (
+    EconomicLedgerCorrectionError,
+    EconomicLedgerError,
+    EconomicLedgerSourceContradiction,
+    LedgerLine,
+    LedgerTransaction,
+    prepare_activities,
+    reduce_and_compare,
+)
+from tests.economic_ledger.support import activity, cash, position
+
+
+def test_partial_fills_and_full_round_trip_balance_exactly() -> None:
+    result = reduce_and_compare(
+        [
+            activity("cash", "JNLC", net_amount="1000"),
+            activity(
+                "buy",
+                "FILL",
+                event_offset_seconds=1,
+                symbol="AAPL",
+                side="buy",
+                quantity="10",
+                price="10",
+                net_amount=None,
+            ),
+            activity(
+                "partial-sell",
+                "FILL",
+                event_offset_seconds=2,
+                symbol="AAPL",
+                side="sell",
+                quantity="4",
+                price="12",
+                net_amount=None,
+            ),
+            activity(
+                "final-sell",
+                "FILL",
+                event_offset_seconds=3,
+                symbol="AAPL",
+                side="sell",
+                quantity="6",
+                price="8",
+                net_amount=None,
+            ),
+        ]
+    )
+
+    assert result.admissible
+    assert result.comparison.equivalent
+    assert cash(result.journal.projection) == Decimal("996")
+    assert position(result.journal.projection, "AAPL") is None
+    assert result.journal.projection.realized_pnl == Decimal("-4")
+    assert result.journal.projection.external_flows == Decimal("1000")
+
+
+def test_repeating_weighted_average_rounds_once_and_stays_exactly_balanced() -> None:
+    result = reduce_and_compare(
+        [
+            activity(
+                "short-one",
+                "FILL",
+                event_offset_seconds=1,
+                symbol="AAPL",
+                side="sell",
+                quantity="1",
+                price="1",
+                net_amount=None,
+            ),
+            activity(
+                "short-two",
+                "FILL",
+                event_offset_seconds=2,
+                symbol="AAPL",
+                side="sell",
+                quantity="1",
+                price="1",
+                net_amount=None,
+            ),
+            activity(
+                "short-three",
+                "FILL",
+                event_offset_seconds=3,
+                symbol="AAPL",
+                side="sell",
+                quantity="1",
+                price="2",
+                net_amount=None,
+            ),
+            activity(
+                "partial-cover",
+                "FILL",
+                event_offset_seconds=4,
+                symbol="AAPL",
+                side="buy",
+                quantity="1",
+                price="1",
+                net_amount=None,
+            ),
+            activity(
+                "flip-long",
+                "FILL",
+                event_offset_seconds=5,
+                symbol="AAPL",
+                side="buy",
+                quantity="5",
+                price="4",
+                net_amount=None,
+            ),
+        ]
+    )
+
+    assert result.comparison.equivalent
+    aapl = position(result.journal.projection, "AAPL")
+    assert aapl is not None
+    assert aapl.quantity == Decimal("3")
+    assert aapl.signed_cost == Decimal("12")
+    assert all(
+        sum(
+            (line.amount for line in transaction.lines if line.commodity == commodity),
+            start=Decimal("0"),
+        )
+        == Decimal("0")
+        for transaction in result.journal.transactions
+        for commodity in {line.commodity for line in transaction.lines}
+    )
+
+
+def test_source_decimal_precision_beyond_database_contract_fails_closed() -> None:
+    with pytest.raises(EconomicLedgerError, match="quantity_scale_exceeds_18"):
+        activity(
+            "over-precise",
+            "FILL",
+            symbol="AAPL",
+            side="buy",
+            quantity="0.0000000000000000001",
+            price="1",
+            net_amount=None,
+        )
+
+    with pytest.raises(EconomicLedgerError, match="price_out_of_range"):
+        activity(
+            "over-range",
+            "FILL",
+            symbol="AAPL",
+            side="buy",
+            quantity="1",
+            price="100000000000000000000",
+            net_amount=None,
+        )
+
+
+def test_short_cover_and_side_flip_use_signed_cost() -> None:
+    result = reduce_and_compare(
+        [
+            activity("cash", "CSD", net_amount="1000"),
+            activity(
+                "short",
+                "FILL",
+                event_offset_seconds=1,
+                symbol="AMD",
+                side="sell",
+                quantity="10",
+                price="20",
+                net_amount=None,
+            ),
+            activity(
+                "partial-cover",
+                "FILL",
+                event_offset_seconds=2,
+                symbol="AMD",
+                side="buy",
+                quantity="4",
+                price="15",
+                net_amount=None,
+            ),
+            activity(
+                "flip-long",
+                "FILL",
+                event_offset_seconds=3,
+                symbol="AMD",
+                side="buy",
+                quantity="8",
+                price="18",
+                net_amount=None,
+            ),
+        ]
+    )
+
+    assert result.comparison.equivalent
+    assert cash(result.independent) == Decimal("996")
+    amd = position(result.independent, "AMD")
+    assert amd is not None
+    assert amd.quantity == Decimal("2")
+    assert amd.signed_cost == Decimal("36")
+    assert result.independent.realized_pnl == Decimal("32")
+
+
+def test_cash_fees_dividends_interest_and_withdrawal_remain_separate() -> None:
+    result = reduce_and_compare(
+        [
+            activity("deposit", "JNLC", net_amount="1000"),
+            activity("fee", "FEE", subtype="TAF", net_amount="-1.5"),
+            activity("dividend", "DIV", net_amount="5"),
+            activity("interest", "INT", net_amount="2"),
+            activity("withdrawal", "CSW", net_amount="-100"),
+        ]
+    )
+
+    assert result.admissible
+    assert cash(result.journal.projection) == Decimal("905.5")
+    assert result.journal.projection.fees == Decimal("1.5")
+    assert result.journal.projection.dividends == Decimal("5")
+    assert result.journal.projection.interest == Decimal("2")
+    assert result.journal.projection.external_flows == Decimal("900")
+
+
+def test_occ_and_dividend_withholding_use_distinct_expense_accounts() -> None:
+    result = reduce_and_compare(
+        [
+            activity("deposit", "JNLC", net_amount="10"),
+            activity("occ-fee", "FEE", subtype="OCC", net_amount="-0.03"),
+            activity("withholding", "DIVFEE", net_amount="-0.50"),
+        ]
+    )
+
+    expense_accounts = {
+        line.account
+        for transaction in result.journal.transactions
+        for line in transaction.lines
+        if line.account.startswith("expense:")
+    }
+    assert expense_accounts == {"expense:regulatory_fee", "expense:withholding"}
+    assert result.comparison.equivalent
+    assert result.journal.projection.fees == Decimal("0.53")
+
+
+def test_crypto_asset_fee_reduces_units_and_records_after_cost_economics() -> None:
+    result = reduce_and_compare(
+        [
+            activity("deposit", "JNLC", net_amount="1000"),
+            activity(
+                "btc-buy",
+                "FILL",
+                event_offset_seconds=1,
+                symbol="BTC/USD",
+                side="buy",
+                quantity="1",
+                price="100",
+                net_amount=None,
+            ),
+            activity(
+                "btc-fee",
+                "CFEE",
+                event_offset_seconds=2,
+                symbol="BTCUSD",
+                quantity="-0.01",
+                price="110",
+                net_amount="0",
+            ),
+            activity(
+                "cash-crypto-fee",
+                "CFEE",
+                event_offset_seconds=3,
+                symbol="BTCUSD",
+                quantity="-0.02",
+                price="110",
+                net_amount="-0.25",
+            ),
+        ]
+    )
+
+    assert result.comparison.equivalent
+    assert cash(result.independent) == Decimal("899.75")
+    btc = position(result.independent, "BTCUSD")
+    assert btc is not None
+    assert btc.quantity == Decimal("0.99")
+    assert btc.signed_cost == Decimal("99")
+    assert result.independent.realized_pnl == Decimal("0.1")
+    assert result.independent.fees == Decimal("1.35")
+
+
+def test_split_changes_quantity_without_changing_total_cost() -> None:
+    result = reduce_and_compare(
+        [
+            activity("deposit", "JNLC", net_amount="1000"),
+            activity(
+                "buy",
+                "FILL",
+                symbol="MU",
+                side="buy",
+                quantity="10",
+                price="10",
+                net_amount=None,
+            ),
+            activity("split", "SSP", symbol="MU", quantity="10", net_amount="0"),
+        ]
+    )
+
+    assert result.comparison.equivalent
+    mu = position(result.independent, "MU")
+    assert mu is not None
+    assert mu.quantity == Decimal("20")
+    assert mu.signed_cost == Decimal("100")
+    assert mu.average_cost == Decimal("5")
+
+
+def test_retroactive_correction_reverses_original_then_applies_replacement() -> None:
+    original = activity(
+        "original-fill",
+        "FILL",
+        event_offset_seconds=1,
+        symbol="AVGO",
+        side="buy",
+        quantity="1",
+        price="100",
+        net_amount=None,
+    )
+    correction = activity(
+        "corrected-fill",
+        "FILL",
+        correction_of="original-fill",
+        event_offset_seconds=10,
+        symbol="AVGO",
+        side="buy",
+        quantity="1",
+        price="90",
+        net_amount=None,
+    )
+    result = reduce_and_compare(
+        [activity("deposit", "CSD", net_amount="1000"), original, correction]
+    )
+
+    assert result.comparison.equivalent
+    assert result.journal.projection.corrected_count == 1
+    assert cash(result.independent) == Decimal("910")
+    avgo = position(result.independent, "AVGO")
+    assert avgo is not None and avgo.signed_cost == Decimal("90")
+    reversal = next(
+        transaction
+        for transaction in result.journal.transactions
+        if transaction.posting_rule == "correction_reversal"
+    )
+    original_transaction = next(
+        transaction
+        for transaction in result.journal.transactions
+        if transaction.transaction_id == "original-fill"
+    )
+    assert reversal.reverses_transaction_id == original_transaction.transaction_id
+    assert tuple(line.amount for line in reversal.lines) == tuple(
+        -line.amount for line in original_transaction.lines
+    )
+
+
+def test_correction_replaces_the_root_at_its_original_economic_order_slot() -> None:
+    result = reduce_and_compare(
+        [
+            activity(
+                "original-buy",
+                "FILL",
+                event_offset_seconds=1,
+                symbol="AVGO",
+                side="buy",
+                quantity="1",
+                price="10",
+                net_amount=None,
+            ),
+            activity(
+                "interposed-sell",
+                "FILL",
+                event_offset_seconds=2,
+                symbol="AVGO",
+                side="sell",
+                quantity="1",
+                price="20",
+                net_amount=None,
+            ),
+            activity(
+                "corrected-buy",
+                "FILL",
+                correction_of="original-buy",
+                event_offset_seconds=3,
+                symbol="AVGO",
+                side="buy",
+                quantity="2",
+                price="10",
+                net_amount=None,
+            ),
+        ]
+    )
+
+    avgo = position(result.independent, "AVGO")
+    assert avgo is not None
+    assert avgo.quantity == Decimal("1")
+    assert avgo.signed_cost == Decimal("10")
+    assert result.independent.realized_pnl == Decimal("10")
+    assert [
+        transaction.transaction_id for transaction in result.journal.transactions
+    ] == [
+        "original-buy",
+        "corrected-buy:reversal:original-buy",
+        "corrected-buy",
+        "interposed-sell",
+    ]
+    assert result.comparison.equivalent
+
+
+def test_identical_duplicates_collapse_but_changed_bytes_fail() -> None:
+    fill = activity(
+        "fill",
+        "FILL",
+        symbol="AAPL",
+        side="buy",
+        quantity="1",
+        price="10",
+        net_amount=None,
+    )
+    result = reduce_and_compare([fill, fill])
+    assert result.journal.projection.input_count == 1
+    assert result.journal.projection.duplicate_count == 1
+
+    changed = activity(
+        "fill",
+        "FILL",
+        symbol="AAPL",
+        side="buy",
+        quantity="1",
+        price="10",
+        net_amount=None,
+        raw_payload_sha256="b" * 64,
+    )
+    with pytest.raises(EconomicLedgerSourceContradiction):
+        prepare_activities([fill, changed])
+
+
+def test_correction_graph_rejects_missing_fork_and_cycle() -> None:
+    root = activity("root", "DIV", net_amount="1")
+    missing = activity("missing", "DIV", correction_of="absent", net_amount="2")
+    with pytest.raises(EconomicLedgerCorrectionError, match="predecessor_missing"):
+        prepare_activities([root, missing])
+
+    left = activity("left", "DIV", correction_of="root", net_amount="2")
+    right = activity("right", "DIV", correction_of="root", net_amount="3")
+    with pytest.raises(EconomicLedgerCorrectionError, match="correction_fork"):
+        prepare_activities([root, left, right])
+
+    cycle_a = activity("cycle-a", "DIV", correction_of="cycle-b", net_amount="1")
+    cycle_b = activity("cycle-b", "DIV", correction_of="cycle-a", net_amount="2")
+    with pytest.raises(EconomicLedgerCorrectionError, match="correction_cycle"):
+        prepare_activities([cycle_a, cycle_b])
+
+
+def test_unknown_activity_is_visible_and_non_admissible() -> None:
+    result = reduce_and_compare(
+        [activity("assignment", "OPASN", symbol="AAPL260117C00100000")]
+    )
+    assert result.comparison.equivalent
+    assert not result.admissible
+    assert result.independent.unsupported_activity_ids == ("assignment",)
+
+
+def test_input_order_does_not_change_manifest_or_results() -> None:
+    rows = [
+        activity("deposit", "CSD", event_offset_seconds=0, net_amount="100"),
+        activity("fee", "FEE", event_offset_seconds=2, net_amount="-1"),
+        activity("dividend", "DIV", event_offset_seconds=1, net_amount="2"),
+    ]
+    ordered = reduce_and_compare(rows)
+    shuffled = reduce_and_compare([rows[2], rows[0], rows[1]])
+    assert (
+        ordered.journal.projection.result_digest
+        == shuffled.journal.projection.result_digest
+    )
+    assert ordered.independent.result_digest == shuffled.independent.result_digest
+    assert ordered.journal.journal_digest == shuffled.journal.journal_digest
+
+
+def test_transaction_constructor_rejects_an_unbalanced_commodity() -> None:
+    with pytest.raises(EconomicLedgerError, match="unbalanced"):
+        LedgerTransaction(
+            transaction_id="bad",
+            source_activity_id="bad",
+            posting_rule="bad",
+            lines=(
+                LedgerLine(account="asset:cash", commodity="USD", amount=Decimal("1")),
+                LedgerLine(
+                    account="income:test", commodity="USD", amount=Decimal("-0.5")
+                ),
+            ),
+        )

--- a/services/torghut/tests/economic_ledger/test_dual_reducers.py
+++ b/services/torghut/tests/economic_ledger/test_dual_reducers.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from decimal import Decimal
+from decimal import Decimal, localcontext
 
 import pytest
 
@@ -13,6 +13,7 @@ from app.trading.economic_ledger import (
     prepare_activities,
     reduce_and_compare,
 )
+from app.trading.economic_ledger.types import decimal_text
 from tests.economic_ledger.support import activity, cash, position
 
 
@@ -157,6 +158,20 @@ def test_source_decimal_precision_beyond_database_contract_fails_closed() -> Non
         )
 
 
+def test_decimal_serialization_preserves_all_38_digits_in_any_active_context() -> None:
+    maximum = Decimal("99999999999999999999.999999999999999999")
+    predecessor = Decimal("99999999999999999999.999999999999999998")
+
+    with localcontext() as context:
+        context.prec = 6
+        maximum_text = decimal_text(maximum)
+        predecessor_text = decimal_text(predecessor)
+
+    assert maximum_text == "99999999999999999999.999999999999999999"
+    assert predecessor_text == "99999999999999999999.999999999999999998"
+    assert maximum_text != predecessor_text
+
+
 def test_short_cover_and_side_flip_use_signed_cost() -> None:
     result = reduce_and_compare(
         [
@@ -285,6 +300,35 @@ def test_crypto_asset_fee_reduces_units_and_records_after_cost_economics() -> No
     assert btc.signed_cost == Decimal("99")
     assert result.independent.realized_pnl == Decimal("0.1")
     assert result.independent.fees == Decimal("1.35")
+
+
+@pytest.mark.parametrize("activity_type", ["FILL", "CFEE"])
+def test_trade_and_crypto_fee_reject_non_quote_currency(
+    activity_type: str,
+) -> None:
+    opening = activity(
+        "btc-buy",
+        "FILL",
+        symbol="BTCUSD",
+        side="buy",
+        quantity="1",
+        price="100",
+        net_amount=None,
+    )
+    contradictory = activity(
+        "contradictory-currency",
+        activity_type,
+        event_offset_seconds=1,
+        symbol="BTCUSD",
+        side="buy" if activity_type == "FILL" else None,
+        quantity="0.01" if activity_type == "FILL" else "-0.01",
+        price="100",
+        net_amount=None if activity_type == "FILL" else "0",
+        currency="EUR",
+    )
+
+    with pytest.raises(EconomicLedgerError, match="currency_unsupported"):
+        reduce_and_compare([opening, contradictory])
 
 
 def test_split_changes_quantity_without_changing_total_cost() -> None:

--- a/services/torghut/tests/economic_ledger/test_dual_reducers.py
+++ b/services/torghut/tests/economic_ledger/test_dual_reducers.py
@@ -257,6 +257,33 @@ def test_occ_and_dividend_withholding_use_distinct_expense_accounts() -> None:
     assert result.journal.projection.fees == Decimal("0.53")
 
 
+@pytest.mark.parametrize(
+    "activity_type",
+    ("DIVFT", "DIVNRA", "DIVTW", "INTNRA", "INTTW"),
+)
+def test_tax_withholding_is_expense_not_negative_income(
+    activity_type: str,
+) -> None:
+    result = reduce_and_compare(
+        [activity("withholding", activity_type, net_amount="-1.25")]
+    )
+
+    assert result.comparison.equivalent
+    assert cash(result.journal.projection) == Decimal("-1.25")
+    assert result.journal.projection.fees == Decimal("1.25")
+    assert result.journal.projection.dividends == Decimal("0")
+    assert result.journal.projection.interest == Decimal("0")
+    assert result.independent.fees == Decimal("1.25")
+    assert result.independent.dividends == Decimal("0")
+    assert result.independent.interest == Decimal("0")
+    assert {
+        line.account
+        for transaction in result.journal.transactions
+        for line in transaction.lines
+        if line.account.startswith("expense:")
+    } == {"expense:withholding"}
+
+
 def test_crypto_asset_fee_reduces_units_and_records_after_cost_economics() -> None:
     result = reduce_and_compare(
         [

--- a/services/torghut/tests/economic_ledger/test_dual_reducers.py
+++ b/services/torghut/tests/economic_ledger/test_dual_reducers.py
@@ -330,6 +330,16 @@ def test_crypto_asset_fee_reduces_units_and_records_after_cost_economics() -> No
     assert result.independent.fees == Decimal("1.35")
 
 
+def test_crypto_fee_without_cash_or_asset_quantity_fails_closed() -> None:
+    result = reduce_and_compare([activity("empty-crypto-fee", "CFEE", net_amount="0")])
+
+    assert result.comparison.equivalent
+    assert not result.admissible
+    assert result.journal.projection.unsupported_activity_ids == ("empty-crypto-fee",)
+    assert result.independent.unsupported_activity_ids == ("empty-crypto-fee",)
+    assert result.journal.transactions == ()
+
+
 @pytest.mark.parametrize("activity_type", ["FILL", "CFEE"])
 def test_trade_and_crypto_fee_reject_non_quote_currency(
     activity_type: str,

--- a/services/torghut/tests/economic_ledger/test_dual_reducers.py
+++ b/services/torghut/tests/economic_ledger/test_dual_reducers.py
@@ -572,6 +572,31 @@ def test_split_with_cash_component_fails_closed_in_both_reducers() -> None:
     assert aapl.quantity == Decimal("1")
 
 
+def test_fill_with_broker_cash_component_fails_closed_in_both_reducers() -> None:
+    result = reduce_and_compare(
+        [
+            activity("deposit", "CSD", net_amount="100"),
+            activity(
+                "net-fill",
+                "FILL",
+                event_offset_seconds=1,
+                symbol="AAPL",
+                side="buy",
+                quantity="1",
+                price="10",
+                net_amount="-11",
+            ),
+        ]
+    )
+
+    assert result.comparison.equivalent
+    assert not result.admissible
+    assert result.journal.projection.unsupported_activity_ids == ("net-fill",)
+    assert result.independent.unsupported_activity_ids == ("net-fill",)
+    assert cash(result.journal.projection) == Decimal("100")
+    assert position(result.journal.projection, "AAPL") is None
+
+
 def test_input_order_does_not_change_manifest_or_results() -> None:
     rows = [
         activity("deposit", "CSD", event_offset_seconds=0, net_amount="100"),

--- a/services/torghut/tests/economic_ledger/test_dual_reducers.py
+++ b/services/torghut/tests/economic_ledger/test_dual_reducers.py
@@ -520,6 +520,56 @@ def test_split_changes_quantity_without_changing_total_cost() -> None:
     assert mu.average_cost == Decimal("5")
 
 
+def test_paired_reverse_split_remove_and_add_rows_fail_closed() -> None:
+    result = reduce_and_compare(
+        [
+            activity(
+                "mu-buy",
+                "FILL",
+                symbol="MU",
+                side="buy",
+                quantity="10",
+                price="10",
+                net_amount=None,
+            ),
+            activity(
+                "reverse-split-remove",
+                "SSP",
+                subtype="remove",
+                event_offset_seconds=1,
+                symbol="MU",
+                quantity="-10",
+                net_amount="0",
+            ),
+            activity(
+                "reverse-split-add",
+                "SSP",
+                subtype="add",
+                event_offset_seconds=2,
+                symbol="MU",
+                quantity="1",
+                net_amount="0",
+            ),
+        ]
+    )
+
+    assert result.comparison.equivalent
+    assert result.admissible is False
+    assert result.journal.projection.unsupported_activity_ids == (
+        "reverse-split-add",
+        "reverse-split-remove",
+    )
+    assert result.independent.unsupported_activity_ids == (
+        "reverse-split-add",
+        "reverse-split-remove",
+    )
+    mu = position(result.independent, "MU")
+    assert mu is not None
+    assert mu.quantity == Decimal("10")
+    assert mu.signed_cost == Decimal("100")
+    assert mu.average_cost == Decimal("10")
+
+
 def test_retroactive_correction_reverses_original_then_applies_replacement() -> None:
     original = activity(
         "original-fill",

--- a/services/torghut/tests/economic_ledger/test_dual_reducers.py
+++ b/services/torghut/tests/economic_ledger/test_dual_reducers.py
@@ -14,6 +14,8 @@ from app.trading.economic_ledger import (
     LedgerTransaction,
     prepare_activities,
     reduce_and_compare,
+    reduce_balanced_journal,
+    reduce_independent_state,
 )
 from app.trading.economic_ledger.types import decimal_text
 from tests.economic_ledger.support import activity, cash, position
@@ -97,6 +99,25 @@ def test_historical_sell_short_fill_is_a_sell_direction_without_relabeling() -> 
     assert cash(result.independent) == Decimal("4")
     assert position(result.independent, "AAPL") is None
     assert result.independent.realized_pnl == Decimal("4")
+
+
+def test_fill_notional_below_ledger_quantum_is_rejected_by_both_reducers() -> None:
+    tiny_fill = activity(
+        "tiny-fill",
+        "FILL",
+        symbol="BTCUSD",
+        side="buy",
+        quantity="0.000000000000000001",
+        price="0.000000000000000001",
+        net_amount=None,
+    )
+
+    for reducer in (reduce_balanced_journal, reduce_independent_state):
+        with pytest.raises(
+            EconomicLedgerError,
+            match="economic_fill_notional_below_ledger_quantum",
+        ):
+            reducer([tiny_fill])
 
 
 def test_repeating_weighted_average_rounds_once_and_stays_exactly_balanced() -> None:
@@ -404,6 +425,36 @@ def test_date_only_crypto_fee_orders_after_same_day_timestamped_fill() -> None:
     assert btc.quantity == Decimal("0.99")
     assert btc.signed_cost == Decimal("99")
     assert result.independent.fees == Decimal("1.1")
+
+
+def test_crypto_fee_underflow_is_rejected_by_both_reducers() -> None:
+    activities = [
+        activity(
+            "btc-buy",
+            "FILL",
+            symbol="BTCUSD",
+            side="buy",
+            quantity="1",
+            price="1",
+            net_amount=None,
+        ),
+        activity(
+            "tiny-asset-fee",
+            "CFEE",
+            event_offset_seconds=1,
+            symbol="BTCUSD",
+            quantity="-0.000000000000000001",
+            price="0.000000000000000001",
+            net_amount="0",
+        ),
+    ]
+
+    for reducer in (reduce_balanced_journal, reduce_independent_state):
+        with pytest.raises(
+            EconomicLedgerError,
+            match="economic_crypto_fee_fair_value_below_ledger_quantum",
+        ):
+            reducer(activities)
 
 
 @pytest.mark.parametrize("quantity", [None, "0", "0.01"])

--- a/services/torghut/tests/economic_ledger/test_dual_reducers.py
+++ b/services/torghut/tests/economic_ledger/test_dual_reducers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 from decimal import Decimal, localcontext
 
 import pytest
@@ -428,6 +429,47 @@ def test_retroactive_correction_reverses_original_then_applies_replacement() -> 
     assert tuple(line.amount for line in reversal.lines) == tuple(
         -line.amount for line in original_transaction.lines
     )
+
+
+def test_correction_reversal_id_is_bounded_for_maximum_valid_broker_ids() -> None:
+    original_id = "o" * 256
+    correction_id = "c" * 256
+    result = reduce_and_compare(
+        [
+            activity(
+                original_id,
+                "FILL",
+                symbol="AVGO",
+                side="buy",
+                quantity="1",
+                price="100",
+                net_amount=None,
+            ),
+            activity(
+                correction_id,
+                "FILL",
+                correction_of=original_id,
+                event_offset_seconds=1,
+                symbol="AVGO",
+                side="buy",
+                quantity="1",
+                price="90",
+                net_amount=None,
+            ),
+        ]
+    )
+
+    reversal = next(
+        transaction
+        for transaction in result.journal.transactions
+        if transaction.posting_rule == "correction_reversal"
+    )
+    readable = f"{correction_id}:reversal:{original_id}"
+    expected_digest = hashlib.sha256(readable.encode("utf-8")).hexdigest()
+    assert reversal.transaction_id == f"correction-reversal:sha256:{expected_digest}"
+    assert len(reversal.transaction_id) <= 512
+    assert reversal.reverses_transaction_id == original_id
+    assert result.comparison.equivalent
 
 
 def test_correction_replaces_the_root_at_its_original_economic_order_slot() -> None:

--- a/services/torghut/tests/economic_ledger/test_dual_reducers.py
+++ b/services/torghut/tests/economic_ledger/test_dual_reducers.py
@@ -238,24 +238,29 @@ def test_cash_fees_dividends_interest_and_withdrawal_remain_separate() -> None:
     assert result.journal.projection.external_flows == Decimal("900")
 
 
-def test_occ_and_dividend_withholding_use_distinct_expense_accounts() -> None:
+def test_regulatory_dividend_and_withholding_fees_use_distinct_accounts() -> None:
     result = reduce_and_compare(
         [
             activity("deposit", "JNLC", net_amount="10"),
             activity("occ-fee", "FEE", subtype="OCC", net_amount="-0.03"),
-            activity("withholding", "DIVFEE", net_amount="-0.50"),
+            activity("dividend-fee", "DIVFEE", net_amount="-0.50"),
+            activity("withholding", "DIVFT", net_amount="-0.25"),
         ]
     )
 
-    expense_accounts = {
-        line.account
+    expense_accounts_by_activity = {
+        transaction.source_activity_id: line.account
         for transaction in result.journal.transactions
         for line in transaction.lines
         if line.account.startswith("expense:")
     }
-    assert expense_accounts == {"expense:regulatory_fee", "expense:withholding"}
+    assert expense_accounts_by_activity == {
+        "dividend-fee": "expense:broker_fee",
+        "occ-fee": "expense:regulatory_fee",
+        "withholding": "expense:withholding",
+    }
     assert result.comparison.equivalent
-    assert result.journal.projection.fees == Decimal("0.53")
+    assert result.journal.projection.fees == Decimal("0.78")
 
 
 @pytest.mark.parametrize(

--- a/services/torghut/tests/economic_ledger/test_dual_reducers.py
+++ b/services/torghut/tests/economic_ledger/test_dual_reducers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+from dataclasses import replace
 from decimal import Decimal, localcontext
 
 import pytest
@@ -333,6 +334,41 @@ def test_crypto_asset_fee_reduces_units_and_records_after_cost_economics() -> No
     assert btc.signed_cost == Decimal("99")
     assert result.independent.realized_pnl == Decimal("0.1")
     assert result.independent.fees == Decimal("1.35")
+
+
+def test_date_only_crypto_fee_orders_after_same_day_timestamped_fill() -> None:
+    fee = replace(
+        activity(
+            "date-only-fee",
+            "CFEE",
+            symbol="BTCUSD",
+            quantity="-0.01",
+            price="110",
+            net_amount="0",
+        ),
+        event_at=None,
+    )
+    fill = activity(
+        "timestamped-fill",
+        "FILL",
+        event_offset_seconds=1,
+        symbol="BTCUSD",
+        side="buy",
+        quantity="1",
+        price="100",
+        net_amount=None,
+    )
+
+    result = reduce_and_compare([fee, fill])
+
+    assert fee.economic_at > fill.economic_at
+    assert result.admissible
+    assert result.comparison.equivalent
+    btc = position(result.independent, "BTCUSD")
+    assert btc is not None
+    assert btc.quantity == Decimal("0.99")
+    assert btc.signed_cost == Decimal("99")
+    assert result.independent.fees == Decimal("1.1")
 
 
 @pytest.mark.parametrize("quantity", [None, "0", "0.01"])

--- a/services/torghut/tests/economic_ledger/test_dual_reducers.py
+++ b/services/torghut/tests/economic_ledger/test_dual_reducers.py
@@ -330,14 +330,64 @@ def test_crypto_asset_fee_reduces_units_and_records_after_cost_economics() -> No
     assert result.independent.fees == Decimal("1.35")
 
 
-def test_crypto_fee_without_cash_or_asset_quantity_fails_closed() -> None:
-    result = reduce_and_compare([activity("empty-crypto-fee", "CFEE", net_amount="0")])
+@pytest.mark.parametrize("quantity", [None, "0", "0.01"])
+def test_zero_cash_crypto_fee_without_negative_asset_charge_fails_closed(
+    quantity: str | None,
+) -> None:
+    result = reduce_and_compare(
+        [
+            activity(
+                "invalid-crypto-fee",
+                "CFEE",
+                quantity=quantity,
+                net_amount="0",
+            )
+        ]
+    )
 
     assert result.comparison.equivalent
     assert not result.admissible
-    assert result.journal.projection.unsupported_activity_ids == ("empty-crypto-fee",)
-    assert result.independent.unsupported_activity_ids == ("empty-crypto-fee",)
+    assert result.journal.projection.unsupported_activity_ids == ("invalid-crypto-fee",)
+    assert result.independent.unsupported_activity_ids == ("invalid-crypto-fee",)
     assert result.journal.transactions == ()
+
+
+def test_repeating_cost_side_flips_use_one_released_cost_rounding_order() -> None:
+    fills = (
+        ("buy", "1", "1"),
+        ("buy", "6", "1"),
+        ("sell", "25", "19"),
+        ("sell", "3", "8"),
+        ("sell", "16", "1"),
+        ("buy", "21", "1"),
+        ("sell", "1", "1"),
+        ("sell", "2", "1"),
+        ("sell", "25", "1"),
+        ("buy", "22", "2"),
+    )
+    rows = [activity("capital", "JNLC", net_amount="1000000")]
+    rows.extend(
+        activity(
+            f"rounding-fill-{index}",
+            "FILL",
+            event_offset_seconds=index + 1,
+            symbol="AAPL",
+            side=side,
+            quantity=quantity,
+            price=price,
+            net_amount=None,
+        )
+        for index, (side, quantity, price) in enumerate(fills)
+    )
+
+    result = reduce_and_compare(rows)
+
+    assert result.admissible
+    assert result.comparison.equivalent
+    aapl = position(result.independent, "AAPL")
+    assert aapl is not None
+    assert aapl.signed_cost == Decimal("-96.594594594594594594")
+    assert result.independent.realized_pnl == Decimal("374.405405405405405406")
 
 
 @pytest.mark.parametrize("activity_type", ["FILL", "CFEE"])

--- a/services/torghut/tests/economic_ledger/test_dual_reducers.py
+++ b/services/torghut/tests/economic_ledger/test_dual_reducers.py
@@ -537,6 +537,41 @@ def test_unknown_activity_is_visible_and_non_admissible() -> None:
     assert result.independent.unsupported_activity_ids == ("assignment",)
 
 
+def test_split_with_cash_component_fails_closed_in_both_reducers() -> None:
+    result = reduce_and_compare(
+        [
+            activity("deposit", "CSD", net_amount="100"),
+            activity(
+                "buy",
+                "FILL",
+                event_offset_seconds=1,
+                symbol="AAPL",
+                side="buy",
+                quantity="1",
+                price="100",
+                net_amount=None,
+            ),
+            activity(
+                "cash-in-lieu",
+                "SSP",
+                event_offset_seconds=2,
+                symbol="AAPL",
+                quantity="1",
+                net_amount="-0.25",
+            ),
+        ]
+    )
+
+    assert result.comparison.equivalent
+    assert not result.admissible
+    assert result.journal.projection.unsupported_activity_ids == ("cash-in-lieu",)
+    assert result.independent.unsupported_activity_ids == ("cash-in-lieu",)
+    assert cash(result.journal.projection) == Decimal("0")
+    aapl = position(result.journal.projection, "AAPL")
+    assert aapl is not None
+    assert aapl.quantity == Decimal("1")
+
+
 def test_input_order_does_not_change_manifest_or_results() -> None:
     rows = [
         activity("deposit", "CSD", event_offset_seconds=0, net_amount="100"),

--- a/services/torghut/tests/economic_ledger/test_dual_reducers.py
+++ b/services/torghut/tests/economic_ledger/test_dual_reducers.py
@@ -64,6 +64,41 @@ def test_partial_fills_and_full_round_trip_balance_exactly() -> None:
     assert result.journal.projection.external_flows == Decimal("1000")
 
 
+def test_historical_sell_short_fill_is_a_sell_direction_without_relabeling() -> None:
+    short_fill = activity(
+        "short-open",
+        "FILL",
+        event_offset_seconds=1,
+        symbol="AAPL",
+        side="sell_short",
+        quantity="2",
+        price="10",
+        net_amount=None,
+    )
+    result = reduce_and_compare(
+        [
+            short_fill,
+            activity(
+                "short-close",
+                "FILL",
+                event_offset_seconds=2,
+                symbol="AAPL",
+                side="buy",
+                quantity="2",
+                price="8",
+                net_amount=None,
+            ),
+        ]
+    )
+
+    assert short_fill.manifest_payload()["side"] == "sell_short"
+    assert result.admissible
+    assert result.comparison.equivalent
+    assert cash(result.independent) == Decimal("4")
+    assert position(result.independent, "AAPL") is None
+    assert result.independent.realized_pnl == Decimal("4")
+
+
 def test_repeating_weighted_average_rounds_once_and_stays_exactly_balanced() -> None:
     result = reduce_and_compare(
         [

--- a/services/torghut/tests/economic_ledger/test_dual_reducers.py
+++ b/services/torghut/tests/economic_ledger/test_dual_reducers.py
@@ -120,6 +120,37 @@ def test_fill_notional_below_ledger_quantum_is_rejected_by_both_reducers() -> No
             reducer([tiny_fill])
 
 
+def test_side_flip_cannot_open_nonzero_units_with_zero_cost() -> None:
+    activities = [
+        activity(
+            "short-open",
+            "FILL",
+            symbol="AAPL",
+            side="sell",
+            quantity="1",
+            price="1",
+            net_amount=None,
+        ),
+        activity(
+            "sub-quantum-flip",
+            "FILL",
+            event_offset_seconds=1,
+            symbol="AAPL",
+            side="buy",
+            quantity="1.000000000000000001",
+            price="0.000000000000000001",
+            net_amount=None,
+        ),
+    ]
+
+    for reducer in (reduce_balanced_journal, reduce_independent_state):
+        with pytest.raises(
+            EconomicLedgerError,
+            match="economic_fill_position_cost_below_ledger_quantum",
+        ):
+            reducer(activities)
+
+
 def test_repeating_weighted_average_rounds_once_and_stays_exactly_balanced() -> None:
     result = reduce_and_compare(
         [

--- a/services/torghut/tests/economic_ledger/test_dual_reducers.py
+++ b/services/torghut/tests/economic_ledger/test_dual_reducers.py
@@ -495,7 +495,7 @@ def test_trade_and_crypto_fee_reject_non_quote_currency(
         reduce_and_compare([opening, contradictory])
 
 
-def test_split_changes_quantity_without_changing_total_cost() -> None:
+def test_split_without_golden_broker_fixture_fails_closed() -> None:
     result = reduce_and_compare(
         [
             activity("deposit", "JNLC", net_amount="1000"),
@@ -513,11 +513,14 @@ def test_split_changes_quantity_without_changing_total_cost() -> None:
     )
 
     assert result.comparison.equivalent
+    assert result.admissible is False
+    assert result.journal.projection.unsupported_activity_ids == ("split",)
+    assert result.independent.unsupported_activity_ids == ("split",)
     mu = position(result.independent, "MU")
     assert mu is not None
-    assert mu.quantity == Decimal("20")
+    assert mu.quantity == Decimal("10")
     assert mu.signed_cost == Decimal("100")
-    assert mu.average_cost == Decimal("5")
+    assert mu.average_cost == Decimal("10")
 
 
 def test_paired_reverse_split_remove_and_add_rows_fail_closed() -> None:

--- a/services/torghut/tests/economic_ledger/test_dual_reducers.py
+++ b/services/torghut/tests/economic_ledger/test_dual_reducers.py
@@ -12,6 +12,7 @@ from app.trading.economic_ledger import (
     EconomicLedgerSourceContradiction,
     LedgerLine,
     LedgerTransaction,
+    PositionBalance,
     prepare_activities,
     reduce_and_compare,
     reduce_balanced_journal,
@@ -118,6 +119,18 @@ def test_fill_notional_below_ledger_quantum_is_rejected_by_both_reducers() -> No
             match="economic_fill_notional_below_ledger_quantum",
         ):
             reducer([tiny_fill])
+
+
+def test_nonzero_position_cannot_have_zero_carrying_cost() -> None:
+    with pytest.raises(
+        EconomicLedgerError,
+        match="economic_position_nonzero_quantity_zero_cost",
+    ):
+        PositionBalance(
+            symbol="AAPL",
+            quantity=Decimal("0.000000000000000001"),
+            signed_cost=Decimal("0"),
+        )
 
 
 def test_side_flip_cannot_open_nonzero_units_with_zero_cost() -> None:


### PR DESCRIPTION
## Summary

- add a pure canonical balanced-journal reducer and a separately coded cash-and-position reducer for immutable broker activities
- compare fixed-point cash, positions, cost basis, realized PnL, fees, income, and unsupported residuals exactly with no tolerance
- fail closed on contradictory identities, malformed correction graphs, unsupported facts, out-of-range decimals, and unbalanced transactions; bound maximum-length correction reversal identities with deterministic SHA-256 IDs
- document the verified Alpaca input shape, authority boundary, minimal persistence design, delivery sequence, and production proof contract for Slice 8
- cover long, short, side-flip, repeating weighted-average, crypto-fee, correction, duplicate, ordering, and randomized differential behavior

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest -q tests/economic_ledger` (38 passed)
- `uv run --frozen ruff format --check app/trading/economic_ledger tests/economic_ledger`
- `uv run --frozen ruff check app/trading/economic_ledger tests/economic_ledger`
- `uv run --frozen python -m compileall -q app/trading/economic_ledger tests/economic_ledger`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.strict.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.strict.json`
- `uv run --frozen python scripts/run_pylint_torghut_structural_gate.py --paths app/trading/economic_ledger tests/economic_ledger`
- `uv run --frozen pylint app/trading/economic_ledger tests/economic_ledger --disable=all --enable=too-many-lines --score=n`
- `uv run --frozen vulture app/trading/economic_ledger --min-confidence 100`
- `uv run --frozen python scripts/measure_torghut_tech_debt.py --baseline config/quality/tech-debt-baseline.json --enforce-ratchet`
- `bunx oxfmt --check docs/torghut/profitability/implementation-roadmap.md docs/torghut/profitability/independent-economic-ledger.md`

## Breaking Changes

None. This slice adds a pure, unused projection kernel; CNPG persistence and scheduled production replay remain explicit follow-up delivery steps.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.