### PR TITLE
fix(torghut): normalize broker fill timestamp precision

### DIFF
--- a/docs/torghut/profitability/broker-economic-source-ingestion.md
+++ b/docs/torghut/profitability/broker-economic-source-ingestion.md
@@ -87,6 +87,11 @@ currency, and correction reference. It deliberately excludes source-specific IDs
 For fills, the stream normalizer uses event-level `qty` and `price`, not cumulative order quantity or average order
 price. This makes the normalized multiset comparable to REST `FILL` activities across partial fills.
 
+Alpaca stream timestamps can carry nanoseconds while the REST activity for the same execution is rounded to six
+fractional digits. Torghut applies the broker-compatible half-up microsecond conversion before persisting `event_at` or
+computing the normalized digest; Python's default nanosecond truncation is not an equivalence rule. Raw payload bytes
+and their source hashes remain unchanged.
+
 `scripts/verify_broker_economic_source_equivalence.py` compares the two fill multisets over an explicit UTC window. A
 proof is complete only when both sources contain the same nonempty multiset. The report retains both sources' raw
 payload hashes and reports every missing normalized hash.

--- a/services/torghut/app/trading/broker_account_activities.py
+++ b/services/torghut/app/trading/broker_account_activities.py
@@ -7,7 +7,7 @@ import json
 from collections import Counter
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal, InvalidOperation
 from typing import cast
 
@@ -136,7 +136,24 @@ def _optional_datetime(payload: Mapping[str, object], key: str) -> datetime | No
         raise BrokerAccountActivityPayloadError(
             f"broker_account_activity_{key}_timezone_required"
         )
-    return parsed.astimezone(timezone.utc)
+    return _round_to_broker_microseconds(value, parsed).astimezone(timezone.utc)
+
+
+def _round_to_broker_microseconds(value: str, parsed: datetime) -> datetime:
+    """Match Alpaca REST's half-up conversion of stream nanoseconds."""
+
+    fraction_start = value.find(".", 10)
+    if fraction_start < 0:
+        return parsed
+    fraction_end = len(value)
+    for separator in ("Z", "+", "-"):
+        separator_at = value.find(separator, fraction_start + 1)
+        if separator_at >= 0:
+            fraction_end = min(fraction_end, separator_at)
+    fraction = value[fraction_start + 1 : fraction_end]
+    if len(fraction) > 6 and fraction[6] >= "5":
+        return parsed + timedelta(microseconds=1)
+    return parsed
 
 
 def _canonical_payload(payload: Mapping[str, object]) -> tuple[str, str]:

--- a/services/torghut/tests/property/test_broker_account_activity_properties.py
+++ b/services/torghut/tests/property/test_broker_account_activity_properties.py
@@ -77,7 +77,7 @@ def test_equivalent_fill_shapes_have_one_digest_across_decimal_encodings(
                 },
                 "price": f"{price_text}0",
                 "qty": f"{quantity_text}0",
-                "timestamp": "2026-07-16T07:39:00.123456789Z",
+                "timestamp": "2026-07-16T07:39:00.123456499Z",
             },
         },
         event_fingerprint="b" * 64,

--- a/services/torghut/tests/test_broker_account_activities.py
+++ b/services/torghut/tests/test_broker_account_activities.py
@@ -172,8 +172,10 @@ def test_normalization_preserves_nontrade_economic_fields_and_hash() -> None:
 
 def test_stream_and_backfill_fill_share_one_normalized_economic_hash() -> None:
     observed_at = datetime(2026, 7, 16, tzinfo=timezone.utc)
+    rest_payload = _fill("activity-fill")
+    rest_payload["transaction_time"] = "2026-07-16T11:50:40.401907Z"
     rest = normalize_broker_account_activity(
-        _fill("activity-fill"),
+        rest_payload,
         observation=_observation(observed_at),
         source_page_token=None,
     )
@@ -194,7 +196,7 @@ def test_stream_and_backfill_fill_share_one_normalized_economic_hash() -> None:
                 },
                 "price": "100.25",
                 "qty": "1",
-                "timestamp": "2026-07-15T18:07:02.759000027Z",
+                "timestamp": "2026-07-16T11:50:40.401906528Z",
             },
         },
         event_fingerprint="b" * 64,
@@ -206,6 +208,20 @@ def test_stream_and_backfill_fill_share_one_normalized_economic_hash() -> None:
         ),
     )
 
+    assert (
+        rest.event_at
+        == stream.event_at
+        == datetime(
+            2026,
+            7,
+            16,
+            11,
+            50,
+            40,
+            401907,
+            tzinfo=timezone.utc,
+        )
+    )
     assert rest.normalized_economic_sha256 == stream.normalized_economic_sha256
     assert rest.raw_payload_sha256 != stream.raw_payload_sha256
     assert stream.raw_payload.get("ingestTs") is None


### PR DESCRIPTION
## Summary

- round Alpaca nanosecond stream timestamps to broker-compatible microseconds before persistence and economic hashing
- add an exact regression for the live `401906528Z` stream versus `401907Z` REST representation of one execution
- document the cross-source timestamp contract while preserving immutable raw payload bytes and hashes

## Related Issues

None

## Testing

- `uv run --frozen pytest -q tests/test_broker_account_activities.py tests/test_verify_broker_economic_source_equivalence.py` (17 passed)
- `uv run --frozen ruff format --check app/trading/broker_account_activities.py tests/test_broker_account_activities.py`
- `uv run --frozen ruff check app/trading/broker_account_activities.py tests/test_broker_account_activities.py`
- all five Torghut Pyright profiles (0 errors)
- structural, changed-line refactor/design, file-length, and tech-debt ratchet gates
- `bunx oxfmt --check docs/torghut/profitability/broker-economic-source-ingestion.md`
- live deployed verifier reproduced one source mismatch where order, execution, side, quantity, and price matched but REST rounded the stream nanoseconds to the next microsecond

## Breaking Changes

None. Existing immutable rows are not rewritten; a fresh post-deployment lifecycle supplies corrected proof evidence.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
