### PR TITLE
fix(torghut): close crypto by observed broker symbol

### DIFF
--- a/docs/torghut/profitability/infrastructure-validation-runbook.md
+++ b/docs/torghut/profitability/infrastructure-validation-runbook.md
@@ -283,6 +283,13 @@ Alpaca's position endpoint also reports the same pair as slashless `BTCUSD` whil
 `BTC/USD`. Normalize that broker representation only when `asset_class=crypto`, and retain the original broker symbol
 in the risk-reduction observation. A string mismatch must never be interpreted as an absent position.
 
+A 2026-07-16 paper lifecycle then disproved asset-ID substitution for partial crypto closes: Alpaca resolved the UUID
+to `BTC/USD` but returned `404 position not found`, while the independently fenced account-wide close immediately found
+and flattened the same position. A targeted close must therefore keep canonical `BTC/USD` as its receipt and lineage
+identity but send the exact freshly observed position symbol, currently `BTCUSD`, as the broker path segment. The
+canonical and broker symbols are both sealed in the request evidence. A slash-delimited target reaching the SDK, a
+missing observed broker symbol, or any canonical/broker mismatch fails before broker I/O.
+
 The runner must therefore prove both quantities independently. The root order must still be terminal `filled` with
 `filled_qty` exactly equal to the signed plan quantity. The resulting sole long position may equal the gross fill or be
 smaller only within Alpaca's published maximum taker-fee bound plus one broker quantity increment for rounding. Every

--- a/services/torghut/app/alpaca_client.py
+++ b/services/torghut/app/alpaca_client.py
@@ -570,14 +570,9 @@ class TorghutAlpacaClient:
         firewall_token: OrderFirewallToken,
     ) -> Dict[str, Any]:
         self._require_firewall_token(firewall_token)
-        position_target = symbol_or_asset_id
-        if "/" in position_target:
-            asset = self.get_asset(position_target)
-            asset_id = str((asset or {}).get("id") or "").strip()
-            try:
-                position_target = str(UUID(asset_id))
-            except ValueError as exc:
-                raise ValueError("alpaca_crypto_close_asset_id_invalid") from exc
+        position_target = symbol_or_asset_id.strip()
+        if not position_target or "/" in position_target:
+            raise ValueError("alpaca_close_position_broker_symbol_required")
         order = self._trading.close_position(
             position_target,
             ClosePositionRequest(qty=str(qty)),

--- a/services/torghut/app/trading/alpaca_reduction_mutations.py
+++ b/services/torghut/app/trading/alpaca_reduction_mutations.py
@@ -503,9 +503,13 @@ class AlpacaReductionMutationExecutor:
             ClosePositionPlan(leg),
             now=observed_at,
         )
+        broker_symbol = str(position.broker_symbol or "").strip()
+        if not broker_symbol or "/" in broker_symbol:
+            raise RuntimeError("alpaca_close_position_broker_symbol_invalid")
         request_payload = _request_payload(
             authorization,
             broker_request={
+                "broker_symbol": broker_symbol,
                 "quantity": _decimal_text(quantity),
                 "symbol": normalized_symbol,
             },
@@ -523,6 +527,7 @@ class AlpacaReductionMutationExecutor:
             broker_call=lambda mutation_permit: self._firewall.close_position(
                 normalized_symbol,
                 quantity,
+                broker_symbol=broker_symbol,
                 authority=RiskReductionMutationAuthority(
                     request_payload=request_payload,
                     mutation_permit=mutation_permit,

--- a/services/torghut/app/trading/firewall.py
+++ b/services/torghut/app/trading/firewall.py
@@ -498,18 +498,25 @@ class OrderFirewall:
         symbol: str,
         quantity: Decimal,
         *,
+        broker_symbol: str | None = None,
         authority: RiskReductionMutationAuthority,
     ) -> dict[str, object]:
         request_payload = authority.request_payload
         normalized_symbol = symbol.strip().upper()
+        normalized_broker_symbol = str(broker_symbol or normalized_symbol).strip()
         payload_quantity = _positive_decimal(request_payload.get("quantity"))
         normalized_quantity = _positive_decimal(quantity)
-        if str(
-            request_payload.get("symbol") or ""
-        ).strip().upper() != normalized_symbol or (
-            payload_quantity is None
-            or normalized_quantity is None
-            or payload_quantity != normalized_quantity
+        if (
+            str(request_payload.get("symbol") or "").strip().upper()
+            != normalized_symbol
+            or str(request_payload.get("broker_symbol") or normalized_symbol).strip()
+            != normalized_broker_symbol
+            or not normalized_broker_symbol
+            or (
+                payload_quantity is None
+                or normalized_quantity is None
+                or payload_quantity != normalized_quantity
+            )
         ):
             raise ValueError("alpaca_close_position_request_mismatch")
         consume_risk_reduction_mutation_authority(
@@ -527,7 +534,7 @@ class OrderFirewall:
         )
         return self._broker_call(
             lambda: self._client.close_position(
-                normalized_symbol,
+                normalized_broker_symbol,
                 qty=quantity,
                 firewall_token=self._token,
             )

--- a/services/torghut/tests/test_alpaca_reduction_client.py
+++ b/services/torghut/tests/test_alpaca_reduction_client.py
@@ -23,15 +23,6 @@ class _ReductionTradingClient:
         self.replaced: list[tuple[str, ReplaceOrderRequest]] = []
         self.closed: list[tuple[str, ClosePositionRequest]] = []
         self.close_all_cancel_orders: list[bool] = []
-        self.asset_lookups: list[str] = []
-        self.asset_id = "276e2673-764b-4ab6-a611-caf665ca6340"
-
-    def get_asset(self, symbol_or_asset_id: str) -> _Model:
-        self.asset_lookups.append(symbol_or_asset_id)
-        return _Model(
-            id=self.asset_id,
-            symbol=symbol_or_asset_id,
-        )
 
     def replace_order_by_id(
         self,
@@ -98,7 +89,7 @@ class TestAlpacaReductionClient(TestCase):
         self.assertEqual(close_all[0]["body"]["id"], "close-1")
         self.assertEqual(trading_client.close_all_cancel_orders, [False])
 
-    def test_close_position_resolves_crypto_symbol_to_asset_id(self) -> None:
+    def test_close_position_uses_exact_broker_position_symbol(self) -> None:
         trading_client = _ReductionTradingClient()
         client = TorghutAlpacaClient(
             api_key="k",
@@ -109,21 +100,16 @@ class TestAlpacaReductionClient(TestCase):
         )
 
         client.close_position(
-            "BTC/USD",
+            "BTCUSD",
             qty=Decimal("0.0002"),
             firewall_token=issue_order_firewall_token(),
         )
 
-        self.assertEqual(trading_client.asset_lookups, ["BTC/USD"])
-        self.assertEqual(
-            trading_client.closed[0][0],
-            "276e2673-764b-4ab6-a611-caf665ca6340",
-        )
+        self.assertEqual(trading_client.closed[0][0], "BTCUSD")
         self.assertEqual(trading_client.closed[0][1].qty, "0.0002")
 
-    def test_close_position_rejects_crypto_asset_without_uuid(self) -> None:
+    def test_close_position_rejects_canonical_crypto_pair(self) -> None:
         trading_client = _ReductionTradingClient()
-        trading_client.asset_id = ""
         client = TorghutAlpacaClient(
             api_key="k",
             secret_key="s",
@@ -134,7 +120,7 @@ class TestAlpacaReductionClient(TestCase):
 
         with self.assertRaisesRegex(
             ValueError,
-            "alpaca_crypto_close_asset_id_invalid",
+            "alpaca_close_position_broker_symbol_required",
         ):
             client.close_position(
                 "BTC/USD",
@@ -142,5 +128,4 @@ class TestAlpacaReductionClient(TestCase):
                 firewall_token=issue_order_firewall_token(),
             )
 
-        self.assertEqual(trading_client.asset_lookups, ["BTC/USD"])
         self.assertEqual(trading_client.closed, [])

--- a/services/torghut/tests/test_alpaca_reduction_coordinator.py
+++ b/services/torghut/tests/test_alpaca_reduction_coordinator.py
@@ -49,6 +49,7 @@ class _CloseoutBroker:
 
     def __init__(self) -> None:
         self.close_calls = 0
+        self.close_targets: list[str] = []
         self.positions: list[dict[str, object]] = [
             {
                 "symbol": "AAPL",
@@ -61,8 +62,13 @@ class _CloseoutBroker:
     def list_positions(self) -> list[dict[str, object]]:
         return list(self.positions)
 
-    def close_position(self, *_args: object, **_kwargs: object) -> dict[str, object]:
+    def close_position(
+        self,
+        symbol_or_asset_id: str,
+        **_kwargs: object,
+    ) -> dict[str, object]:
         self.close_calls += 1
+        self.close_targets.append(symbol_or_asset_id)
         self.positions = []
         return {"id": "closeout-order-1", "status": "accepted"}
 
@@ -376,6 +382,15 @@ def test_broker_enforced_close_is_receipted_and_preflight_deduplicated(
     sessions: sessionmaker[Session],
 ) -> None:
     broker = _CloseoutBroker()
+    broker.positions = [
+        {
+            "asset_class": "crypto",
+            "market_value": "28",
+            "qty": "0.00044",
+            "side": "long",
+            "symbol": "BTCUSD",
+        }
+    ]
     firewall = OrderFirewall(broker, account_label="paper")
     adapter = AlpacaExecutionAdapter(
         firewall=firewall,
@@ -384,31 +399,18 @@ def test_broker_enforced_close_is_receipted_and_preflight_deduplicated(
         account_label="paper",
         endpoint_url=broker.endpoint_url,
     )
-    submission = OrderSubmission(
-        symbol="AAPL",
-        side="sell",
-        qty=1.0,
-        order_type="limit",
-        time_in_force="day",
-        limit_price=100.0,
-        stop_price=None,
-        extra_params=None,
-    )
-
     with patch.object(settings, "trading_kill_switch_enabled", False):
-        with pytest.raises(
-            RuntimeError,
-            match="alpaca_entry_submit_requires_durable_order_firewall",
-        ):
-            adapter.submit_order(submission)
-        result = adapter.close_position("AAPL", Decimal("1"))
-        duplicate = adapter.close_position("AAPL", Decimal("1"))
-        duplicate_again = adapter.close_position("AAPL", Decimal("1"))
+        with pytest.raises(RuntimeError, match="requires_durable_order_firewall"):
+            adapter.submit_order(
+                OrderSubmission("AAPL", "sell", 1.0, "limit", "day", 100.0, None, None)
+            )
+        result = adapter.close_position("BTC/USD", Decimal("0.00022"))
+        duplicate = adapter.close_position("BTC/USD", Decimal("0.00022"))
 
     assert result["id"] == "closeout-order-1"
     assert duplicate["status"] == "already_satisfied"
-    assert duplicate_again["status"] == "already_satisfied"
     assert broker.close_calls == 1
+    assert broker.close_targets == ["BTCUSD"]
     with sessions() as session:
         receipts = (
             session.execute(
@@ -430,6 +432,10 @@ def test_broker_enforced_close_is_receipted_and_preflight_deduplicated(
         assert receipt.risk_class == "risk_reducing"
         assert receipt.purpose == "closeout"
         assert receipt.submission_claim_id is None
+        assert receipt.target_key == "BTC/USD"
+        request = json.loads(receipt.canonical_intent_json)["request"]
+        assert request["symbol"] == "BTC/USD"
+        assert request["broker_symbol"] == "BTCUSD"
         assert latest.state == "settled"
         assert latest.settlement_outcome == "acknowledged"
 

--- a/services/torghut/tests/test_infrastructure_validation_lifecycle.py
+++ b/services/torghut/tests/test_infrastructure_validation_lifecycle.py
@@ -42,7 +42,7 @@ class _LifecycleBroker:
         self,
         session_factory: Callable[[], Session],
         *,
-        broker_position_symbol: str = "BTC/USD",
+        broker_position_symbol: str = "BTCUSD",
         entry_fee_quantity: Decimal = Decimal("0"),
         fail_mutation: str | None = None,
         nested_close_all_response: bool = False,
@@ -225,11 +225,12 @@ class _LifecycleBroker:
 
     def close_position(
         self,
-        _symbol: str,
+        symbol: str,
         *,
         qty: Decimal,
         **_kwargs: object,
     ) -> dict[str, object]:
+        assert symbol == self._broker_position_symbol
         self._begin_mutation("close_position")
         self._position_quantity -= qty
         return self._add_order(

--- a/services/torghut/tests/test_order_firewall.py
+++ b/services/torghut/tests/test_order_firewall.py
@@ -446,6 +446,7 @@ class TestOrderFirewall(TestCase):
             now=now,
         )
         request_payload = {
+            "broker_symbol": "AAPL",
             "quantity": "1",
             "risk_reduction": authorization.evidence_payload,
             "symbol": "AAPL",
@@ -464,9 +465,21 @@ class TestOrderFirewall(TestCase):
             reduction_permit=authorization.permit,
         )
 
+        with self.assertRaisesRegex(
+            ValueError,
+            "alpaca_close_position_request_mismatch",
+        ):
+            firewall.close_position(
+                "AAPL",
+                Decimal("1.0"),
+                broker_symbol="MSFT",
+                authority=authority,
+            )
+
         response = firewall.close_position(
             "AAPL",
             Decimal("1.0"),
+            broker_symbol="AAPL",
             authority=authority,
         )
 


### PR DESCRIPTION
## Summary

- close a targeted Alpaca crypto position with the exact symbol from the fresh broker position observation (`BTCUSD`)
- preserve canonical `BTC/USD` as the risk, receipt, and lineage identity while sealing both identities into mutation evidence
- reject missing, slash-delimited, or mismatched broker targets before authority consumption or broker I/O
- remove the disproved asset-ID lookup path and its dead test scaffolding

## Related Issues

None

## Testing

- `uv run --frozen pytest -q tests/test_alpaca_reduction_client.py tests/test_order_firewall.py tests/test_alpaca_reduction_coordinator.py tests/test_infrastructure_validation_lifecycle.py` (40 passed)
- focused Ruff format and lint checks
- all five Torghut Pyright profiles (0 errors)
- structural, changed-line refactor/design, file-length, and tech-debt ratchet gates
- `bunx oxfmt --check docs/torghut/profitability/infrastructure-validation-runbook.md`
- live Alpaca paper evidence: both percent-encoded `BTC/USD` and the asset UUID returned position-not-found, while the same fresh position was reported as `BTCUSD` and an independently fenced account-wide close flattened it

## Breaking Changes

None. Receipt identity remains canonical; only the broker path segment changes to the exact observed symbol.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
