### PR TITLE
chore(torghut): promote image sha-03250c7c81fa4c765584f5b303cf9604ca5e4e12

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -54,7 +54,7 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: 55b5f7f6c2db1238e31e7f78b7455c6b0890d429
+              value: 03250c7c81fa4c765584f5b303cf9604ca5e4e12
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:2db81afe1bb55477f9a29e73e8235b9e25dbd5cd8cef4ef2ba00c7925ba6e25d
             - name: PYTHONPATH

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -46,7 +46,7 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: 55b5f7f6c2db1238e31e7f78b7455c6b0890d429
+              value: 03250c7c81fa4c765584f5b303cf9604ca5e4e12
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:2db81afe1bb55477f9a29e73e8235b9e25dbd5cd8cef4ef2ba00c7925ba6e25d
             - name: DB_DSN

--- a/argocd/applications/torghut-options/archive/deployment.yaml
+++ b/argocd/applications/torghut-options/archive/deployment.yaml
@@ -100,9 +100,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2124-g55b5f7f6c
+              value: v0.596.0-2127-g03250c7c8
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 55b5f7f6c2db1238e31e7f78b7455c6b0890d429
+              value: 03250c7c81fa4c765584f5b303cf9604ca5e4e12
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -110,9 +110,9 @@ spec:
                   name: torghut-ws-config
                   key: SYMBOLS_ALLOWLIST
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2124-g55b5f7f6c
+              value: v0.596.0-2127-g03250c7c8
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 55b5f7f6c2db1238e31e7f78b7455c6b0890d429
+              value: 03250c7c81fa4c765584f5b303cf9604ca5e4e12
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -106,9 +106,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2124-g55b5f7f6c
+              value: v0.596.0-2127-g03250c7c8
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 55b5f7f6c2db1238e31e7f78b7455c6b0890d429
+              value: 03250c7c81fa4c765584f5b303cf9604ca5e4e12
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-16T12:40:54Z"
+        client.knative.dev/updateTimestamp: "2026-07-16T13:00:44Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -507,9 +507,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2124-g55b5f7f6c
+              value: v0.596.0-2127-g03250c7c8
             - name: TORGHUT_COMMIT
-              value: 55b5f7f6c2db1238e31e7f78b7455c6b0890d429
+              value: 03250c7c81fa4c765584f5b303cf9604ca5e4e12
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:2db81afe1bb55477f9a29e73e8235b9e25dbd5cd8cef4ef2ba00c7925ba6e25d
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-16T12:40:54Z"
+        client.knative.dev/updateTimestamp: "2026-07-16T13:00:44Z"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
     spec:
@@ -444,9 +444,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2124-g55b5f7f6c
+              value: v0.596.0-2127-g03250c7c8
             - name: TORGHUT_COMMIT
-              value: 55b5f7f6c2db1238e31e7f78b7455c6b0890d429
+              value: 03250c7c81fa4c765584f5b303cf9604ca5e4e12
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:2db81afe1bb55477f9a29e73e8235b9e25dbd5cd8cef4ef2ba00c7925ba6e25d
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -460,9 +460,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2124-g55b5f7f6c
+              value: v0.596.0-2127-g03250c7c8
             - name: TORGHUT_COMMIT
-              value: 55b5f7f6c2db1238e31e7f78b7455c6b0890d429
+              value: 03250c7c81fa4c765584f5b303cf9604ca5e4e12
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:2db81afe1bb55477f9a29e73e8235b9e25dbd5cd8cef4ef2ba00c7925ba6e25d
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `03250c7c81fa4c765584f5b303cf9604ca5e4e12`
- Image tag: `sha-03250c7c81fa4c765584f5b303cf9604ca5e4e12`
- Image digest: `sha256:2db81afe1bb55477f9a29e73e8235b9e25dbd5cd8cef4ef2ba00c7925ba6e25d`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher