### PR TITLE
feat(torghut): graduate reduction mutation fencing

### DIFF
--- a/services/torghut/app/trading/action_authority.py
+++ b/services/torghut/app/trading/action_authority.py
@@ -238,9 +238,9 @@ def _mutation_authority_reasons(
 ) -> tuple[str, ...]:
     if not _valid_mutation_status(status):
         return ("broker_mutation_status_contract_invalid",)
+    if status.get("database_status") != "current":
+        return ("broker_mutation_database_status_not_current",)
     if required_field == "entry_fencing_proven":
-        if status.get("database_status") != "current":
-            return ("broker_mutation_database_status_not_current",)
         unresolved_count = status.get("unresolved_receipt_count")
         if (
             not isinstance(unresolved_count, int)

--- a/services/torghut/app/trading/broker_mutation_receipts/runtime_status.py
+++ b/services/torghut/app/trading/broker_mutation_receipts/runtime_status.py
@@ -15,11 +15,13 @@ from ...models import BrokerMutationReceipt, BrokerMutationReceiptEvent
 from ...config import settings
 from ..action_authority import BROKER_MUTATION_RUNTIME_STATUS_SCHEMA_VERSION
 
-# Entry submissions and observation-only submit recovery are wired through the
-# durable coordinator. Reduction mutations remain fail-closed until Slice 6.
+# Entry submissions, observation-only recovery, and every reachable reduction
+# mutation are wired through the durable coordinator. Slice 6 graduated only
+# after the promoted Alpaca-paper lifecycle exercised submit, replace, cancel,
+# targeted close, and final flatten as one excluded, fully settled causal chain.
 BROKER_MUTATION_RUNTIME_WIRED = True
 BROKER_MUTATION_ENTRY_FENCING_PROVEN = True
-BROKER_MUTATION_REDUCTION_FENCING_PROVEN = False
+BROKER_MUTATION_REDUCTION_FENCING_PROVEN = True
 BROKER_MUTATION_RECOVERY_WORKER_WIRED = True
 
 
@@ -27,7 +29,11 @@ def build_broker_mutation_runtime_status() -> dict[str, object]:
     """Return current code wiring truth without adding status-path database load."""
 
     recovery_enabled = settings.trading_broker_mutation_recovery_enabled
-    reason_codes = ["broker_mutation_reduction_fencing_unproven"]
+    reason_codes = (
+        []
+        if BROKER_MUTATION_REDUCTION_FENCING_PROVEN
+        else ["broker_mutation_reduction_fencing_unproven"]
+    )
     if not recovery_enabled:
         reason_codes.append("broker_mutation_recovery_disabled")
     return {

--- a/services/torghut/app/trading/broker_mutation_receipts/runtime_status.py
+++ b/services/torghut/app/trading/broker_mutation_receipts/runtime_status.py
@@ -285,6 +285,7 @@ def unavailable_broker_mutation_runtime_status() -> dict[str, object]:
     )
     payload.update(
         entry_fencing_proven=False,
+        reduction_fencing_proven=False,
         recovery_degraded=True,
         database_status="unavailable",
         receipt_state_counts=None,

--- a/services/torghut/tests/test_broker_mutation_runtime_status.py
+++ b/services/torghut/tests/test_broker_mutation_runtime_status.py
@@ -24,6 +24,7 @@ def test_database_status_unavailability_fails_entry_capability_closed() -> None:
 
     assert payload["runtime_wired"] is True
     assert payload["entry_fencing_proven"] is False
+    assert payload["reduction_fencing_proven"] is False
     assert payload["recovery_degraded"] is True
     assert payload["database_status"] == "unavailable"
     assert payload["reason_codes"][:2] == [

--- a/services/torghut/tests/test_broker_mutation_runtime_status.py
+++ b/services/torghut/tests/test_broker_mutation_runtime_status.py
@@ -6,19 +6,17 @@ from app.trading.broker_mutation_receipts.runtime_status import (
 )
 
 
-def test_entry_wiring_reports_code_truth_without_overclaim() -> None:
+def test_mutation_wiring_reports_proven_code_truth() -> None:
     payload = build_broker_mutation_runtime_status()
 
     assert payload["runtime_wired"] is True
     assert payload["entry_fencing_proven"] is True
-    assert payload["reduction_fencing_proven"] is False
+    assert payload["reduction_fencing_proven"] is True
     assert payload["recovery_degraded"] is False
     assert payload["schema_version"] == "torghut.broker-mutation-runtime-status.v1"
     assert payload["recovery_worker_wired"] is True
     assert payload["recovery_worker_enabled"] is True
-    assert payload["reason_codes"] == [
-        "broker_mutation_reduction_fencing_unproven",
-    ]
+    assert payload["reason_codes"] == []
 
 
 def test_database_status_unavailability_fails_entry_capability_closed() -> None:

--- a/services/torghut/tests/test_broker_mutation_wiring.py
+++ b/services/torghut/tests/test_broker_mutation_wiring.py
@@ -216,12 +216,12 @@ def test_recovery_routes_have_no_broker_mutation_calls() -> None:
     }
 
 
-def test_runtime_status_claims_only_the_entry_capability_now_wired() -> None:
+def test_runtime_status_claims_entry_and_reduction_capabilities() -> None:
     status = build_broker_mutation_runtime_status()
 
     assert status["runtime_wired"] is True
     assert status["entry_fencing_proven"] is True
-    assert status["reduction_fencing_proven"] is False
+    assert status["reduction_fencing_proven"] is True
     assert status["recovery_worker_wired"] is True
     assert status["recovery_worker_enabled"] is True
     assert status["recovery_degraded"] is False

--- a/services/torghut/tests/test_runtime_action_authority.py
+++ b/services/torghut/tests/test_runtime_action_authority.py
@@ -242,7 +242,7 @@ def test_disabled_recovery_blocks_new_entry_without_disabling_reduction() -> Non
     assert authority.reason_codes["recovery"] == ("broker_mutation_recovery_disabled",)
 
 
-def test_entry_requires_current_durable_receipt_readback() -> None:
+def test_mutations_require_current_durable_receipt_readback() -> None:
     authority = reduce_runtime_action_authority(
         service_status=_service(),
         live_submission_gate=_gate(),
@@ -255,8 +255,11 @@ def test_entry_requires_current_durable_receipt_readback() -> None:
     )
 
     assert authority.entry_allowed is False
-    assert authority.reduce_only_allowed is True
+    assert authority.reduce_only_allowed is False
     assert authority.reason_codes["entry"] == (
+        "broker_mutation_database_status_not_current",
+    )
+    assert authority.reason_codes["reduce_only"] == (
         "broker_mutation_database_status_not_current",
     )
 


### PR DESCRIPTION
## Summary

- Promote the Slice 6 reduction-mutation capability bit after the promoted Alpaca-paper lifecycle exercised submit, replace, cancel, targeted close, and final flatten as one fully settled chain.
- Remove the stale `broker_mutation_reduction_fencing_unproven` reason while explicitly requiring current durable receipt state for both entry and reduce-only authority while preserving recovery-degraded fail-closed behavior.
- Update the structural and runtime-status truth tests; no new coordinator, workflow layer, or dynamic proof inference was added.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest -q tests/test_broker_mutation_runtime_status.py tests/test_broker_mutation_wiring.py` (27 passed)
- `uv run --frozen ruff check app/trading/broker_mutation_receipts/runtime_status.py tests/test_broker_mutation_runtime_status.py tests/test_broker_mutation_wiring.py`
- All five Pyright profiles: default, alpha, alpha strict, scripts, and scripts strict (0 errors)
- Live source `55b5f7f6c2db1238e31e7f78b7455c6b0890d429`, image `sha256:2db81afe...`: exactly one root broker call, fenced replay, six settled receipts, zero unresolved receipts, zero positions/orders at terminal, zero claims/executions/decisions/TigerBeetle refs, and non-promotable evidence only.
- Independent broker-economic verifier: 3 REST fills = 3 WebSocket fills, identical normalized multiset digest, `proof_complete=true`.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
