### PR TITLE
chore(torghut): promote image sha-ad2daaf242192aea34364e36caaf1cdb6da20da1

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -54,7 +54,7 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: e2b3dbd1d3dbf091fb2cd8e33201235915b8f115
+              value: ad2daaf242192aea34364e36caaf1cdb6da20da1
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:238f79c2fc0af35b7cd87b8765a426345905aa68ee77ab364ab7358b3ed0e2aa
             - name: PYTHONPATH

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -46,7 +46,7 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: e2b3dbd1d3dbf091fb2cd8e33201235915b8f115
+              value: ad2daaf242192aea34364e36caaf1cdb6da20da1
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:238f79c2fc0af35b7cd87b8765a426345905aa68ee77ab364ab7358b3ed0e2aa
             - name: DB_DSN

--- a/argocd/applications/torghut-options/archive/deployment.yaml
+++ b/argocd/applications/torghut-options/archive/deployment.yaml
@@ -100,9 +100,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2135-ge2b3dbd1d
+              value: v0.596.0-2136-gad2daaf24
             - name: TORGHUT_OPTIONS_COMMIT
-              value: e2b3dbd1d3dbf091fb2cd8e33201235915b8f115
+              value: ad2daaf242192aea34364e36caaf1cdb6da20da1
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -110,9 +110,9 @@ spec:
                   name: torghut-ws-config
                   key: SYMBOLS_ALLOWLIST
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2135-ge2b3dbd1d
+              value: v0.596.0-2136-gad2daaf24
             - name: TORGHUT_OPTIONS_COMMIT
-              value: e2b3dbd1d3dbf091fb2cd8e33201235915b8f115
+              value: ad2daaf242192aea34364e36caaf1cdb6da20da1
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -106,9 +106,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2135-ge2b3dbd1d
+              value: v0.596.0-2136-gad2daaf24
             - name: TORGHUT_OPTIONS_COMMIT
-              value: e2b3dbd1d3dbf091fb2cd8e33201235915b8f115
+              value: ad2daaf242192aea34364e36caaf1cdb6da20da1
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/broker-economic-ledger-reconciliation-cronjob.yaml
+++ b/argocd/applications/torghut/broker-economic-ledger-reconciliation-cronjob.yaml
@@ -82,9 +82,9 @@ spec:
                 - name: TRADING_ACCOUNT_LABEL
                   value: PA3SX7FYNUTF
                 - name: TORGHUT_VERSION
-                  value: v0.596.0-2135-ge2b3dbd1d
+                  value: v0.596.0-2136-gad2daaf24
                 - name: TORGHUT_COMMIT
-                  value: e2b3dbd1d3dbf091fb2cd8e33201235915b8f115
+                  value: ad2daaf242192aea34364e36caaf1cdb6da20da1
                 - name: TORGHUT_IMAGE_DIGEST
                   value: sha256:238f79c2fc0af35b7cd87b8765a426345905aa68ee77ab364ab7358b3ed0e2aa
                 - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-16T16:47:27Z"
+        client.knative.dev/updateTimestamp: "2026-07-16T17:15:37Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -507,9 +507,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2135-ge2b3dbd1d
+              value: v0.596.0-2136-gad2daaf24
             - name: TORGHUT_COMMIT
-              value: e2b3dbd1d3dbf091fb2cd8e33201235915b8f115
+              value: ad2daaf242192aea34364e36caaf1cdb6da20da1
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:238f79c2fc0af35b7cd87b8765a426345905aa68ee77ab364ab7358b3ed0e2aa
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-16T16:47:27Z"
+        client.knative.dev/updateTimestamp: "2026-07-16T17:15:37Z"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
     spec:
@@ -444,9 +444,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2135-ge2b3dbd1d
+              value: v0.596.0-2136-gad2daaf24
             - name: TORGHUT_COMMIT
-              value: e2b3dbd1d3dbf091fb2cd8e33201235915b8f115
+              value: ad2daaf242192aea34364e36caaf1cdb6da20da1
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:238f79c2fc0af35b7cd87b8765a426345905aa68ee77ab364ab7358b3ed0e2aa
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -460,9 +460,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2135-ge2b3dbd1d
+              value: v0.596.0-2136-gad2daaf24
             - name: TORGHUT_COMMIT
-              value: e2b3dbd1d3dbf091fb2cd8e33201235915b8f115
+              value: ad2daaf242192aea34364e36caaf1cdb6da20da1
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:238f79c2fc0af35b7cd87b8765a426345905aa68ee77ab364ab7358b3ed0e2aa
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `ad2daaf242192aea34364e36caaf1cdb6da20da1`
- Image tag: `sha-ad2daaf242192aea34364e36caaf1cdb6da20da1`
- Image digest: `sha256:238f79c2fc0af35b7cd87b8765a426345905aa68ee77ab364ab7358b3ed0e2aa`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher