### PR TITLE
fix(torghut): close replay transaction before reduction

### DIFF
--- a/docs/torghut/profitability/independent-economic-ledger.md
+++ b/docs/torghut/profitability/independent-economic-ledger.md
@@ -238,11 +238,14 @@ The deterministic replay CLI is read-only until publication:
 1. share-lock the one mutable REST cursor while leaving immutable source rows unlocked; because backfill appends facts and
    advances that cursor in one transaction, the lock freezes one closed source set without locking its history;
 2. require the completed REST cursor and build the ordered manifest;
-3. run both reducers in memory;
+3. close the read transaction, then run both pure reducers in memory so production-size replay cannot hold an idle
+   database transaction or block cursor progress;
 4. validate accounting identities and exact differential equality;
 5. optionally fetch a read-only broker snapshot and calculate broker deltas;
 6. print the complete report in dry-run mode;
-7. publish only with an explicit confirmation token, in one database transaction, if the source watermark is unchanged.
+7. publish only with an explicit confirmation token, in one database transaction, after the cursor is re-locked and the
+   immutable source set is still exact. A later closed scan watermark is valid only when the cursor identity and source
+   row count are unchanged; regression or any appended row rejects publication.
 
 `--observe` is deliberately separate from publication. It requires an already published exact run pair, requires a
 real source commit and image digest from the deployed build, rejects any non-paper broker endpoint, and
@@ -252,15 +255,16 @@ no retry, a 20-minute deadline, and no publication token or broker-mutation comm
 
 Re-running the same reducer version and exact economic input (scope, cursor, and manifest digest) returns the existing
 immutable run. A later completed scan with the same manifest leaves the confirmation token stable and does not clone the
-manifest or 180,067 current journal entries; publication still verifies the current closed watermark, and Delivery 3
-reconciliation observations retain that newer watermark. A different result for the same economic identity is a hard
-contradiction.
+manifest or 180,067 current journal entries; publication verifies the current cursor has not regressed and that the
+source row set is unchanged. Delivery 3 observations remain attached to the input's first proving watermark, while the
+current cursor remains separately visible as source-freshness evidence. A different result for the same economic
+identity is a hard contradiction.
 
 The publication token commits the cursor identity, input manifest, admissibility, exact comparison, both projection
 digests, and the journal digest. Publication recomputes that token, serializes writers per account scope, re-locks the
-current cursor, and rejects a changed cursor, watermark, or source count before inserting either run. The input envelope
-is inserted once, balanced entries follow under a deferred foreign key, and both sealed run envelopes are then inserted
-atomically. Any trigger failure rolls back the input, entries, and both runs together.
+current cursor, and rejects a changed cursor, regressed watermark, or changed source count before inserting either run.
+The input envelope is inserted once, balanced entries follow under a deferred foreign key, and both sealed run envelopes
+are then inserted atomically. Any trigger failure rolls back the input, entries, and both runs together.
 
 ## Status And Capital Boundary
 

--- a/docs/torghut/profitability/independent-economic-ledger.md
+++ b/docs/torghut/profitability/independent-economic-ledger.md
@@ -211,8 +211,8 @@ append-only evidence tables:
 2. `broker_economic_ledger_runs` stores reducer identity, the shared input ID, result JSON, and result digests;
 3. `broker_economic_ledger_entries` stores balanced lines keyed by run, source activity, transaction, commodity, and line
    number;
-4. `broker_economic_reconciliations` stores the two run IDs, fresh broker snapshot digest, exact deltas, residuals, and
-   admissibility.
+4. `broker_economic_reconciliations` stores the two run IDs, immutable input watermark, current observation watermark,
+   fresh broker snapshot digest, exact deltas, residuals, and admissibility.
 
 The current 40,161-row source history measured about 21.4 MB as logical normalized JSON and about 5.7 MB as TOAST-
 compressed canonical text on production CNPG. Storing JSONB plus text in both reducer rows would consume about 23.7 MB
@@ -225,11 +225,11 @@ PostgreSQL rejects update/delete/truncate, verifies canonical JSON hashes, and i
 lines and per-transaction commodity balance. Rebuild creates a new versioned run; it never rewrites an old proof.
 
 Reconciliation evidence adds one more database-enforced boundary. A row must reference the exact canonical and
-independent run pair for one input, use that input's exact source watermark, and report the source age derived from its
-broker-observation and watermark timestamps. PostgreSQL also binds the canonical snapshot and result JSON to their
-SHA-256 digests, verifies the persisted build identity and residual counts, and rejects any later mutation. These
-checks prevent an application or ad hoc writer from making a stale or unrelated observation look attached to a valid
-projection.
+independent run pair for one input, name that input's exact immutable watermark, and report source age from the current
+completed scan watermark and broker-observation timestamp. PostgreSQL also binds both watermarks, the canonical snapshot,
+and result JSON to their SHA-256 digests, verifies the persisted build identity and residual counts, and rejects any later
+mutation. These checks prevent an application or ad hoc writer from making a stale or unrelated observation look attached
+to a valid projection.
 
 ## Replay And Publication
 
@@ -256,8 +256,8 @@ no retry, a 20-minute deadline, and no publication token or broker-mutation comm
 Re-running the same reducer version and exact economic input (scope, cursor, and manifest digest) returns the existing
 immutable run. A later completed scan with the same manifest leaves the confirmation token stable and does not clone the
 manifest or 180,067 current journal entries; publication verifies the current cursor has not regressed and that the
-source row set is unchanged. Delivery 3 observations remain attached to the input's first proving watermark, while the
-current cursor remains separately visible as source-freshness evidence. A different result for the same economic
+source row set is unchanged. Delivery 3 observations bind immutable identity to the input's first proving watermark and
+carry the later completed cursor watermark separately for truthful freshness. A different result for the same economic
 identity is a hard contradiction.
 
 The publication token commits the cursor identity, input manifest, admissibility, exact comparison, both projection

--- a/services/torghut/app/models/entities/broker_economic_ledger_records.py
+++ b/services/torghut/app/models/entities/broker_economic_ledger_records.py
@@ -164,6 +164,9 @@ class BrokerEconomicLedgerReconciliation(Base, CreatedAtMixin):
         ForeignKey("broker_economic_ledger_runs.id", ondelete="RESTRICT"),
         nullable=False,
     )
+    input_source_watermark: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
     source_watermark: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False
     )

--- a/services/torghut/app/trading/economic_ledger/__init__.py
+++ b/services/torghut/app/trading/economic_ledger/__init__.py
@@ -20,6 +20,7 @@ from .persistence import (
     publish_broker_economic_ledger,
     require_published_broker_economic_ledger_runs,
     replay_broker_economic_ledger,
+    replay_broker_economic_ledger_snapshot,
 )
 from .reconciliation import (
     DEFAULT_OBSERVATION_MAX_AGE_SECONDS,
@@ -102,4 +103,5 @@ __all__ = (
     "reconcile_broker_economic_ledger",
     "require_published_broker_economic_ledger_runs",
     "replay_broker_economic_ledger",
+    "replay_broker_economic_ledger_snapshot",
 )

--- a/services/torghut/app/trading/economic_ledger/persistence.py
+++ b/services/torghut/app/trading/economic_ledger/persistence.py
@@ -60,6 +60,7 @@ class PublishedBrokerEconomicLedgerRuns:
     input_id: uuid.UUID
     journal_run_id: uuid.UUID
     state_run_id: uuid.UUID
+    source_watermark: datetime
     reused_existing: bool
 
 
@@ -114,6 +115,11 @@ class BrokerEconomicLedgerReplay:
             },
             "publication": {
                 "input_id": str(published.input_id) if published is not None else None,
+                "input_source_watermark": (
+                    published.source_watermark.isoformat()
+                    if published is not None
+                    else None
+                ),
                 "journal_run_id": (
                     str(published.journal_run_id) if published is not None else None
                 ),
@@ -141,6 +147,14 @@ def replay_broker_economic_ledger(
     """Load one closed REST source set and run both pure reducers exactly once."""
 
     snapshot = load_broker_economic_ledger_snapshot(session, scope=scope)
+    return replay_broker_economic_ledger_snapshot(snapshot)
+
+
+def replay_broker_economic_ledger_snapshot(
+    snapshot: BrokerEconomicLedgerSnapshot,
+) -> BrokerEconomicLedgerReplay:
+    """Run both pure reducers from an already closed immutable source snapshot."""
+
     reduction = reduce_and_compare(snapshot.prepared)
     token = _publication_token(snapshot, reduction)
     return BrokerEconomicLedgerReplay(
@@ -213,8 +227,9 @@ def publish_broker_economic_ledger(
     _require_replay_identity(replay)
     _acquire_publication_lock(session, replay.snapshot.prepared.scope)
     _require_current_source_snapshot(session, replay.snapshot)
-    input_id = _load_or_create_input(session, replay.snapshot)
-    existing = _load_existing_runs(session, replay, input_id=input_id)
+    input_row = _load_or_create_input(session, replay.snapshot)
+    input_id = input_row.id
+    existing = _load_existing_runs(session, replay, input_row=input_row)
     if existing is not None:
         return existing
 
@@ -248,6 +263,7 @@ def publish_broker_economic_ledger(
         input_id=input_id,
         journal_run_id=journal_run_id,
         state_run_id=state_run_id,
+        source_watermark=as_utc(input_row.source_watermark),
         reused_existing=False,
     )
 
@@ -297,7 +313,7 @@ def _require_current_source_snapshot(
     assert cursor.last_completed_scan_until is not None
     if (
         cursor.id != snapshot.cursor_id
-        or as_utc(cursor.last_completed_scan_until) != snapshot.source_watermark
+        or as_utc(cursor.last_completed_scan_until) < snapshot.source_watermark
         or cursor.activities_inserted != len(snapshot.activities)
     ):
         raise EconomicLedgerError("economic_ledger_source_watermark_changed")
@@ -320,17 +336,20 @@ def _require_current_source_snapshot(
 def _load_or_create_input(
     session: Session,
     snapshot: BrokerEconomicLedgerSnapshot,
-) -> uuid.UUID:
+) -> BrokerEconomicLedgerInput:
     existing = _load_input(session, snapshot)
     if existing is not None:
         _require_existing_input(existing, snapshot)
-        return existing.id
+        return existing
     input_id = uuid.uuid4()
     session.execute(
         insert(BrokerEconomicLedgerInput),
         [_input_values(snapshot, input_id=input_id)],
     )
-    return input_id
+    created = _load_input(session, snapshot)
+    if created is None:
+        raise EconomicLedgerError("economic_ledger_input_insert_missing")
+    return created
 
 
 def _load_input(
@@ -519,8 +538,9 @@ def _load_existing_runs(
     session: Session,
     replay: BrokerEconomicLedgerReplay,
     *,
-    input_id: uuid.UUID,
+    input_row: BrokerEconomicLedgerInput,
 ) -> PublishedBrokerEconomicLedgerRuns | None:
+    input_id = input_row.id
     rows = tuple(
         session.scalars(
             select(BrokerEconomicLedgerRun).where(
@@ -563,6 +583,7 @@ def _load_existing_runs(
         input_id=input_id,
         journal_run_id=journal.id,
         state_run_id=state.id,
+        source_watermark=as_utc(input_row.source_watermark),
         reused_existing=True,
     )
 
@@ -580,7 +601,7 @@ def require_published_broker_economic_ledger_runs(
     if input_row is None:
         raise EconomicLedgerError("economic_ledger_published_input_missing")
     _require_existing_input(input_row, replay.snapshot)
-    runs = _load_existing_runs(session, replay, input_id=input_row.id)
+    runs = _load_existing_runs(session, replay, input_row=input_row)
     if runs is None:
         raise EconomicLedgerError("economic_ledger_published_run_pair_missing")
     return runs

--- a/services/torghut/app/trading/economic_ledger/reconciliation.py
+++ b/services/torghut/app/trading/economic_ledger/reconciliation.py
@@ -7,7 +7,7 @@ import json
 import re
 import uuid
 from collections.abc import Iterable, Mapping, Sequence
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from decimal import Decimal, localcontext
 from typing import Protocol, cast
@@ -278,6 +278,7 @@ def reconcile_broker_economic_ledger(
         "open_order_count": len(snapshot.open_orders),
         "source_age_seconds": source_age_seconds,
         "max_source_age_seconds": max_source_age_seconds,
+        "input_source_watermark": runs.source_watermark.isoformat(),
         "source_watermark": watermark.isoformat(),
         "observed_at": snapshot.observed_at.isoformat(),
         "source_commit": build.source_commit,
@@ -337,13 +338,6 @@ def persist_broker_economic_ledger_reconciliation(
     """Append one observation only after resolving the exact published run pair."""
 
     runs = require_published_broker_economic_ledger_runs(session, replay)
-    replay = replace(
-        replay,
-        snapshot=replace(
-            replay.snapshot,
-            source_watermark=runs.source_watermark,
-        ),
-    )
     result = reconcile_broker_economic_ledger(
         replay,
         snapshot,
@@ -362,6 +356,7 @@ def persist_broker_economic_ledger_reconciliation(
                 "input_id": runs.input_id,
                 "journal_run_id": runs.journal_run_id,
                 "state_run_id": runs.state_run_id,
+                "input_source_watermark": runs.source_watermark,
                 "source_watermark": replay.snapshot.source_watermark,
                 "observed_at": snapshot.observed_at,
                 "source_age_seconds": result.source_age_seconds,
@@ -457,6 +452,7 @@ def load_broker_economic_ledger_status(
         "observed_at": as_utc(row.observed_at).isoformat(),
         "age_seconds": age_seconds,
         "max_age_seconds": max_observation_age_seconds,
+        "input_source_watermark": as_utc(row.input_source_watermark).isoformat(),
         "source_watermark": as_utc(row.source_watermark).isoformat(),
         "source_age_seconds": row.source_age_seconds,
         "max_source_age_seconds": row.max_source_age_seconds,

--- a/services/torghut/app/trading/economic_ledger/reconciliation.py
+++ b/services/torghut/app/trading/economic_ledger/reconciliation.py
@@ -7,7 +7,7 @@ import json
 import re
 import uuid
 from collections.abc import Iterable, Mapping, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from decimal import Decimal, localcontext
 from typing import Protocol, cast
@@ -337,6 +337,13 @@ def persist_broker_economic_ledger_reconciliation(
     """Append one observation only after resolving the exact published run pair."""
 
     runs = require_published_broker_economic_ledger_runs(session, replay)
+    replay = replace(
+        replay,
+        snapshot=replace(
+            replay.snapshot,
+            source_watermark=runs.source_watermark,
+        ),
+    )
     result = reconcile_broker_economic_ledger(
         replay,
         snapshot,

--- a/services/torghut/migrations/versions/0080_broker_economic_reconciliation_freshness.py
+++ b/services/torghut/migrations/versions/0080_broker_economic_reconciliation_freshness.py
@@ -1,0 +1,267 @@
+"""Separate immutable input identity from reconciliation freshness.
+
+Revision ID: 0080_broker_econ_recon_freshness
+Revises: 0079_broker_econ_reconciliation
+Create Date: 2026-07-16 10:40:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.schema import conv
+
+
+revision = "0080_broker_econ_recon_freshness"
+down_revision = "0079_broker_econ_reconciliation"
+branch_labels = None
+depends_on = None
+
+
+_TABLE = "broker_economic_ledger_reconciliations"
+_INPUT_TABLE = "broker_economic_ledger_inputs"
+_RUN_TABLE = "broker_economic_ledger_runs"
+_OLD_GUARD = "torghut_guard_broker_economic_reconciliation_0079"
+_NEW_GUARD = "torghut_guard_broker_economic_reconciliation_0080"
+_ROW_TRIGGER = "trg_guard_broker_econ_recon"
+_TRUNCATE_TRIGGER = "trg_guard_broker_econ_recon_truncate"
+_WATERMARK_CONSTRAINT = "ck_broker_econ_recon_input_watermark_order"
+
+
+def _drop_guard(function_name: str) -> None:
+    op.execute(sa.text(f"DROP TRIGGER {_TRUNCATE_TRIGGER} ON {_TABLE}"))
+    op.execute(sa.text(f"DROP TRIGGER {_ROW_TRIGGER} ON {_TABLE}"))
+    op.execute(sa.text(f"DROP FUNCTION {function_name}()"))
+
+
+def _create_guard(function_name: str, *, separate_input_watermark: bool) -> None:
+    input_watermark = (
+        "NEW.input_source_watermark"
+        if separate_input_watermark
+        else "NEW.source_watermark"
+    )
+    result_input_watermark_guard = (
+        """
+                   OR (result_document->>'input_source_watermark')::timestamptz
+                       IS DISTINCT FROM NEW.input_source_watermark"""
+        if separate_input_watermark
+        else ""
+    )
+    op.execute(
+        sa.text(
+            f"""
+            CREATE FUNCTION {function_name}()
+            RETURNS trigger LANGUAGE plpgsql AS $$
+            DECLARE
+                snapshot_document jsonb;
+                result_document jsonb;
+                stored_input_manifest_sha text;
+                stored_input_watermark timestamptz;
+                journal_input uuid;
+                journal_reducer text;
+                journal_reducer_version text;
+                journal_admissible boolean;
+                journal_comparison text;
+                stored_journal_sha text;
+                state_input uuid;
+                state_reducer text;
+                state_reducer_version text;
+                state_admissible boolean;
+                state_comparison text;
+                stored_state_journal_sha text;
+            BEGIN
+                IF TG_OP IN ('UPDATE', 'DELETE', 'TRUNCATE') THEN
+                    RAISE EXCEPTION 'broker economic reconciliation is append-only'
+                        USING ERRCODE = '23514';
+                END IF;
+                BEGIN
+                    snapshot_document := NEW.broker_snapshot_canonical_json::jsonb;
+                    result_document := NEW.result_canonical_json::jsonb;
+                EXCEPTION WHEN invalid_text_representation THEN
+                    RAISE EXCEPTION 'broker economic reconciliation JSON is invalid'
+                        USING ERRCODE = '23514';
+                END;
+                IF snapshot_document IS DISTINCT FROM NEW.broker_snapshot
+                   OR result_document IS DISTINCT FROM NEW.result THEN
+                    RAISE EXCEPTION 'broker economic reconciliation JSON identity mismatch'
+                        USING ERRCODE = '23514';
+                END IF;
+                IF NEW.broker_snapshot_sha256 IS DISTINCT FROM encode(
+                    sha256(convert_to(NEW.broker_snapshot_canonical_json, 'UTF8')),
+                    'hex'
+                ) OR NEW.result_sha256 IS DISTINCT FROM encode(
+                    sha256(convert_to(NEW.result_canonical_json, 'UTF8')),
+                    'hex'
+                ) THEN
+                    RAISE EXCEPTION 'broker economic reconciliation hash mismatch'
+                        USING ERRCODE = '23514';
+                END IF;
+                IF snapshot_document->>'schema_version'
+                       IS DISTINCT FROM 'torghut.broker-economic-snapshot.v1'
+                   OR (snapshot_document->>'observed_at')::timestamptz
+                       IS DISTINCT FROM NEW.observed_at
+                   OR jsonb_typeof(snapshot_document->'open_orders')
+                       IS DISTINCT FROM 'array'
+                   OR jsonb_array_length(snapshot_document->'open_orders')
+                       IS DISTINCT FROM NEW.open_order_count THEN
+                    RAISE EXCEPTION 'broker economic reconciliation snapshot identity mismatch'
+                        USING ERRCODE = '23514';
+                END IF;
+
+                SELECT input_id, reducer_name, reducer_version, admissible,
+                       comparison_sha256, journal_sha256
+                INTO journal_input, journal_reducer, journal_reducer_version,
+                     journal_admissible, journal_comparison, stored_journal_sha
+                FROM {_RUN_TABLE} WHERE id = NEW.journal_run_id;
+                SELECT input_id, reducer_name, reducer_version, admissible,
+                       comparison_sha256, journal_sha256
+                INTO state_input, state_reducer, state_reducer_version,
+                     state_admissible, state_comparison, stored_state_journal_sha
+                FROM {_RUN_TABLE} WHERE id = NEW.state_run_id;
+                IF journal_input IS NULL OR state_input IS NULL
+                   OR journal_input <> NEW.input_id OR state_input <> NEW.input_id
+                   OR journal_reducer <> 'balanced_journal'
+                   OR state_reducer <> 'independent_position_state'
+                   OR journal_admissible IS DISTINCT FROM true
+                   OR state_admissible IS DISTINCT FROM true
+                   OR journal_comparison <> NEW.comparison_sha256
+                   OR state_comparison <> NEW.comparison_sha256
+                   OR stored_journal_sha <> NEW.journal_sha256
+                   OR stored_state_journal_sha IS NOT NULL THEN
+                    RAISE EXCEPTION 'broker economic reconciliation run identity mismatch'
+                        USING ERRCODE = '23514';
+                END IF;
+                SELECT manifest_sha256, source_watermark
+                INTO stored_input_manifest_sha, stored_input_watermark
+                FROM {_INPUT_TABLE} WHERE id = NEW.input_id;
+                IF stored_input_manifest_sha IS NULL
+                   OR stored_input_watermark IS DISTINCT FROM {input_watermark} THEN
+                    RAISE EXCEPTION 'broker economic reconciliation source identity mismatch'
+                        USING ERRCODE = '23514';
+                END IF;
+                IF FLOOR(EXTRACT(EPOCH FROM (
+                       NEW.observed_at - NEW.source_watermark
+                   )))::bigint IS DISTINCT FROM NEW.source_age_seconds THEN
+                    RAISE EXCEPTION 'broker economic reconciliation source age mismatch'
+                        USING ERRCODE = '23514';
+                END IF;
+                IF result_document->>'schema_version'
+                       IS DISTINCT FROM 'torghut.broker-economic-ledger-reconciliation.v1'
+                   OR result_document->>'input_id'
+                       IS DISTINCT FROM NEW.input_id::text
+                   OR result_document->>'journal_run_id'
+                       IS DISTINCT FROM NEW.journal_run_id::text
+                   OR result_document->>'state_run_id'
+                       IS DISTINCT FROM NEW.state_run_id::text
+                   OR result_document->>'comparison_sha256'
+                       IS DISTINCT FROM NEW.comparison_sha256
+                   OR result_document->>'journal_sha256'
+                       IS DISTINCT FROM NEW.journal_sha256
+                   OR result_document->>'broker_snapshot_sha256'
+                       IS DISTINCT FROM NEW.broker_snapshot_sha256
+                   OR result_document->>'input_manifest_sha256'
+                       IS DISTINCT FROM stored_input_manifest_sha
+                   OR result_document#>>'{{reducers,journal}}'
+                       IS DISTINCT FROM journal_reducer_version
+                   OR result_document#>>'{{reducers,state}}'
+                       IS DISTINCT FROM state_reducer_version
+                   OR (result_document#>>'{{reducers,admissible}}')::boolean
+                       IS DISTINCT FROM journal_admissible
+                   OR (result_document#>>'{{reducers,differential_equivalent}}')::boolean
+                       IS DISTINCT FROM true{result_input_watermark_guard}
+                   OR (result_document->>'source_watermark')::timestamptz
+                       IS DISTINCT FROM NEW.source_watermark
+                   OR (result_document->>'observed_at')::timestamptz
+                       IS DISTINCT FROM NEW.observed_at
+                   OR (result_document->>'source_age_seconds')::bigint
+                       IS DISTINCT FROM NEW.source_age_seconds
+                   OR (result_document->>'max_source_age_seconds')::bigint
+                       IS DISTINCT FROM NEW.max_source_age_seconds
+                   OR (result_document->>'reconciled')::boolean
+                       IS DISTINCT FROM NEW.reconciled
+                   OR (result_document->>'residual_count')::bigint
+                       IS DISTINCT FROM NEW.residual_count
+                   OR (result_document->>'open_order_count')::bigint
+                       IS DISTINCT FROM NEW.open_order_count
+                   OR jsonb_typeof(result_document->'residuals')
+                       IS DISTINCT FROM 'array'
+                   OR jsonb_array_length(result_document->'residuals')
+                       IS DISTINCT FROM NEW.residual_count
+                   OR jsonb_typeof(result_document->'reason_codes')
+                       IS DISTINCT FROM 'array'
+                   OR NEW.reconciled IS DISTINCT FROM (
+                       jsonb_array_length(result_document->'residuals') = 0
+                       AND jsonb_array_length(result_document->'reason_codes') = 0
+                   )
+                   OR result_document->>'source_commit'
+                       IS DISTINCT FROM NEW.source_commit
+                   OR result_document->>'image_digest'
+                       IS DISTINCT FROM NEW.image_digest THEN
+                    RAISE EXCEPTION 'broker economic reconciliation result identity mismatch'
+                        USING ERRCODE = '23514';
+                END IF;
+                NEW.created_at := clock_timestamp();
+                RETURN NEW;
+            END;
+            $$
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            f"""
+            CREATE TRIGGER {_ROW_TRIGGER}
+            BEFORE INSERT OR UPDATE OR DELETE ON {_TABLE}
+            FOR EACH ROW EXECUTE FUNCTION {function_name}()
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            f"""
+            CREATE TRIGGER {_TRUNCATE_TRIGGER}
+            BEFORE TRUNCATE ON {_TABLE}
+            FOR EACH STATEMENT EXECUTE FUNCTION {function_name}()
+            """
+        )
+    )
+
+
+def upgrade() -> None:
+    _drop_guard(_OLD_GUARD)
+    op.add_column(
+        _TABLE,
+        sa.Column("input_source_watermark", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.execute(
+        sa.text(
+            f"UPDATE {_TABLE} SET input_source_watermark = source_watermark "
+            "WHERE input_source_watermark IS NULL"
+        )
+    )
+    op.alter_column(_TABLE, "input_source_watermark", nullable=False)
+    op.create_check_constraint(
+        conv(_WATERMARK_CONSTRAINT),
+        _TABLE,
+        "source_watermark >= input_source_watermark",
+    )
+    _create_guard(_NEW_GUARD, separate_input_watermark=True)
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text(
+            f"""
+            DO $$ BEGIN
+                IF EXISTS (SELECT 1 FROM {_TABLE}) THEN
+                    RAISE EXCEPTION 'refusing to discard reconciliation watermark evidence'
+                        USING ERRCODE = '55000';
+                END IF;
+            END; $$
+            """
+        )
+    )
+    _drop_guard(_NEW_GUARD)
+    op.drop_constraint(conv(_WATERMARK_CONSTRAINT), _TABLE, type_="check")
+    op.drop_column(_TABLE, "input_source_watermark")
+    _create_guard(_OLD_GUARD, separate_input_watermark=False)

--- a/services/torghut/scripts/replay_broker_economic_ledger.py
+++ b/services/torghut/scripts/replay_broker_economic_ledger.py
@@ -16,9 +16,10 @@ from app.trading.economic_ledger import (
     BrokerEconomicReconciliationBuild,
     LedgerScope,
     capture_broker_economic_snapshot,
+    load_broker_economic_ledger_snapshot,
     persist_broker_economic_ledger_reconciliation,
     publish_broker_economic_ledger,
-    replay_broker_economic_ledger,
+    replay_broker_economic_ledger_snapshot,
 )
 
 
@@ -71,42 +72,46 @@ def main(argv: list[str] | None = None) -> int:
     )
     snapshot = capture_broker_economic_snapshot(client) if args.observe else None
     with SessionLocal() as session, session.begin():
-        replay = replay_broker_economic_ledger(session, scope=scope)
-        published = (
-            publish_broker_economic_ledger(
-                session,
-                replay,
-                confirmation_token=str(args.publish_token),
+        ledger_snapshot = load_broker_economic_ledger_snapshot(session, scope=scope)
+    replay = replay_broker_economic_ledger_snapshot(ledger_snapshot)
+    published = None
+    observation = None
+    if args.publish_token is not None or snapshot is not None:
+        with SessionLocal() as session, session.begin():
+            published = (
+                publish_broker_economic_ledger(
+                    session,
+                    replay,
+                    confirmation_token=str(args.publish_token),
+                )
+                if args.publish_token is not None
+                else None
             )
-            if args.publish_token is not None
-            else None
-        )
-        observation = (
-            persist_broker_economic_ledger_reconciliation(
-                session,
-                replay,
-                snapshot,
-                build=BrokerEconomicReconciliationBuild(
-                    source_commit=BUILD_COMMIT,
-                    image_digest=BUILD_IMAGE_DIGEST or "",
-                ),
-                max_source_age_seconds=args.max_source_age_seconds,
+            observation = (
+                persist_broker_economic_ledger_reconciliation(
+                    session,
+                    replay,
+                    snapshot,
+                    build=BrokerEconomicReconciliationBuild(
+                        source_commit=BUILD_COMMIT,
+                        image_digest=BUILD_IMAGE_DIGEST or "",
+                    ),
+                    max_source_age_seconds=args.max_source_age_seconds,
+                )
+                if snapshot is not None
+                else None
             )
-            if snapshot is not None
-            else None
-        )
-        payload = replay.to_payload(
-            published=published
-            or (observation.runs if observation is not None else None)
-        )
-        payload["reconciliation"] = (
-            {
-                "observation_id": str(observation.observation_id),
-                **observation.result.payload,
-            }
-            if observation is not None
-            else None
-        )
+    payload = replay.to_payload(
+        published=published or (observation.runs if observation is not None else None)
+    )
+    payload["reconciliation"] = (
+        {
+            "observation_id": str(observation.observation_id),
+            **observation.result.payload,
+        }
+        if observation is not None
+        else None
+    )
     print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
     return 0
 

--- a/services/torghut/tests/economic_ledger/test_persistence.py
+++ b/services/torghut/tests/economic_ledger/test_persistence.py
@@ -416,13 +416,13 @@ def test_reconciliation_observations_reuse_runs_across_newer_closed_watermarks()
         assert cursor is not None
         assert cursor.last_completed_scan_until is not None
         assert cursor.last_completed_at is not None
-        cursor.last_completed_scan_until += timedelta(minutes=1)
-        cursor.last_completed_at += timedelta(minutes=1)
+        cursor.last_completed_scan_until += timedelta(minutes=10)
+        cursor.last_completed_at += timedelta(minutes=10)
     later_snapshot = normalize_broker_economic_snapshot(
         account={"status": "ACTIVE", "cash": "1009", "equity": "1009"},
         positions=[],
         open_orders=[],
-        observed_at=_OBSERVED_AT + timedelta(minutes=4),
+        observed_at=_OBSERVED_AT + timedelta(minutes=11),
     )
     with sessions.begin() as session:
         advanced = replay_broker_economic_ledger(session, scope=_SCOPE)
@@ -435,9 +435,14 @@ def test_reconciliation_observations_reuse_runs_across_newer_closed_watermarks()
         assert second.runs.journal_run_id == published.journal_run_id
         assert second.runs.state_run_id == published.state_run_id
         assert second.runs.source_watermark == replay.snapshot.source_watermark
-        assert second.result.payload["source_watermark"] == (
+        assert second.result.payload["input_source_watermark"] == (
             replay.snapshot.source_watermark.isoformat()
         )
+        assert second.result.payload["source_watermark"] == (
+            advanced.snapshot.source_watermark.isoformat()
+        )
+        assert second.result.source_age_seconds == 60
+        assert second.result.reconciled is True
 
     with sessions() as session:
         assert (
@@ -457,16 +462,20 @@ def test_reconciliation_observations_reuse_runs_across_newer_closed_watermarks()
         status = load_broker_economic_ledger_status(
             session,
             scope=_SCOPE,
-            observed_at=_OBSERVED_AT + timedelta(minutes=5),
+            observed_at=_OBSERVED_AT + timedelta(minutes=12),
         )
         stale_status = load_broker_economic_ledger_status(
             session,
             scope=_SCOPE,
-            observed_at=_OBSERVED_AT + timedelta(minutes=6),
+            observed_at=_OBSERVED_AT + timedelta(minutes=13),
             max_observation_age_seconds=60,
         )
     assert status["state"] == "reconciled"
     assert status["reconciled"] is True
+    assert status["input_source_watermark"] == (
+        replay.snapshot.source_watermark.isoformat()
+    )
+    assert status["source_watermark"] == advanced.snapshot.source_watermark.isoformat()
     assert status["diagnostic_only"] is True
     assert status["capital_authority"] is False
     assert status["admissible"] is True

--- a/services/torghut/tests/economic_ledger/test_persistence.py
+++ b/services/torghut/tests/economic_ledger/test_persistence.py
@@ -267,7 +267,7 @@ def test_publication_rejects_forged_replay_token() -> None:
             )
 
 
-def test_publication_rejects_stale_source_watermark() -> None:
+def test_publication_accepts_later_cursor_watermark_for_unchanged_source() -> None:
     sessions = _session_factory()
     _seed_source(sessions, _supported_history())
 
@@ -277,6 +277,26 @@ def test_publication_rejects_stale_source_watermark() -> None:
         cursor = session.scalar(select(BrokerAccountActivityCursor))
         assert cursor is not None and cursor.last_completed_scan_until is not None
         cursor.last_completed_scan_until += timedelta(seconds=1)
+    with sessions.begin() as session:
+        published = publish_broker_economic_ledger(
+            session,
+            replay,
+            confirmation_token=replay.publication_token,
+        )
+
+    assert published.source_watermark == replay.snapshot.source_watermark
+
+
+def test_publication_rejects_cursor_watermark_regression() -> None:
+    sessions = _session_factory()
+    _seed_source(sessions, _supported_history())
+
+    with sessions.begin() as session:
+        replay = replay_broker_economic_ledger(session, scope=_SCOPE)
+    with sessions.begin() as session:
+        cursor = session.scalar(select(BrokerAccountActivityCursor))
+        assert cursor is not None and cursor.last_completed_scan_until is not None
+        cursor.last_completed_scan_until -= timedelta(seconds=1)
     with sessions.begin() as session:
         with pytest.raises(
             EconomicLedgerError,
@@ -414,6 +434,10 @@ def test_reconciliation_observations_reuse_runs_across_newer_closed_watermarks()
         )
         assert second.runs.journal_run_id == published.journal_run_id
         assert second.runs.state_run_id == published.state_run_id
+        assert second.runs.source_watermark == replay.snapshot.source_watermark
+        assert second.result.payload["source_watermark"] == (
+            replay.snapshot.source_watermark.isoformat()
+        )
 
     with sessions() as session:
         assert (

--- a/services/torghut/tests/economic_ledger/test_reconciliation.py
+++ b/services/torghut/tests/economic_ledger/test_reconciliation.py
@@ -39,6 +39,7 @@ _RUNS = PublishedBrokerEconomicLedgerRuns(
     input_id=uuid.uuid4(),
     journal_run_id=uuid.uuid4(),
     state_run_id=uuid.uuid4(),
+    source_watermark=_AT,
     reused_existing=True,
 )
 

--- a/services/torghut/tests/economic_ledger/test_reconciliation.py
+++ b/services/torghut/tests/economic_ledger/test_reconciliation.py
@@ -151,6 +151,10 @@ def test_flat_projection_reconciles_exactly_to_fresh_broker_snapshot() -> None:
     assert result.residual_count == 0
     assert result.open_order_count == 0
     assert result.payload["reason_codes"] == []
+    assert result.payload["input_source_watermark"] == _AT.isoformat()
+    assert (
+        result.payload["source_watermark"] == (_AT + timedelta(minutes=1)).isoformat()
+    )
     assert len(result.result_sha256) == 64
 
 

--- a/services/torghut/tests/economic_ledger/test_reconciliation_migration.py
+++ b/services/torghut/tests/economic_ledger/test_reconciliation_migration.py
@@ -9,6 +9,12 @@ SERVICE_ROOT = Path(__file__).resolve().parents[2]
 MIGRATION = (
     SERVICE_ROOT / "migrations" / "versions" / "0079_broker_economic_reconciliation.py"
 )
+FRESHNESS_MIGRATION = (
+    SERVICE_ROOT
+    / "migrations"
+    / "versions"
+    / "0080_broker_economic_reconciliation_freshness.py"
+)
 
 
 def test_reconciliation_migration_has_one_linear_parent() -> None:
@@ -34,3 +40,23 @@ def test_reconciliation_migration_enforces_append_only_run_bound_evidence() -> N
     assert "result_document#>>'{{reducers,journal}}'" in text
     assert "refusing to discard broker economic reconciliation evidence" in text
     assert "ON DELETE CASCADE" not in text
+
+
+def test_reconciliation_freshness_migration_has_one_linear_parent() -> None:
+    module = load_migration_module(FRESHNESS_MIGRATION.name)
+
+    assert module.revision == "0080_broker_econ_recon_freshness"
+    assert module.down_revision == "0079_broker_econ_reconciliation"
+    assert module.branch_labels is None
+    assert module.depends_on is None
+
+
+def test_reconciliation_freshness_migration_separates_identity_from_age() -> None:
+    text = FRESHNESS_MIGRATION.read_text(encoding="utf-8")
+
+    assert 'sa.Column("input_source_watermark"' in text
+    assert "source_watermark >= input_source_watermark" in text
+    assert '"NEW.input_source_watermark"' in text
+    assert "result_document->>'input_source_watermark'" in text
+    assert "NEW.observed_at - NEW.source_watermark" in text
+    assert "refusing to discard reconciliation watermark evidence" in text

--- a/services/torghut/tests/economic_ledger/test_replay_cli.py
+++ b/services/torghut/tests/economic_ledger/test_replay_cli.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from scripts import replay_broker_economic_ledger as replay_cli
@@ -21,3 +23,79 @@ def test_default_mode_is_read_only_replay() -> None:
 
     assert args.observe is False
     assert args.publish_token is None
+
+
+def test_dry_run_closes_database_transaction_before_pure_reduction(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    events: list[str] = []
+
+    class Transaction:
+        def __init__(self, session: Session) -> None:
+            self._session = session
+
+        def __enter__(self) -> None:
+            events.append("transaction_enter")
+            self._session.transaction_active = True
+
+        def __exit__(self, *_args: object) -> None:
+            self._session.transaction_active = False
+            events.append("transaction_exit")
+
+    class Session:
+        transaction_active = False
+
+        def __enter__(self) -> Session:
+            events.append("session_enter")
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            events.append("session_exit")
+
+        def begin(self) -> Transaction:
+            return Transaction(self)
+
+    session = Session()
+    ledger_snapshot = object()
+
+    def load_snapshot(loaded_session: Session, **_kwargs: object) -> object:
+        assert loaded_session is session
+        assert loaded_session.transaction_active is True
+        events.append("load_snapshot")
+        return ledger_snapshot
+
+    def reduce_snapshot(loaded_snapshot: object) -> SimpleNamespace:
+        assert loaded_snapshot is ledger_snapshot
+        assert session.transaction_active is False
+        events.append("reduce_snapshot")
+        return SimpleNamespace(
+            to_payload=lambda **_kwargs: {"schema_version": "test-replay"}
+        )
+
+    monkeypatch.setattr(
+        replay_cli,
+        "TorghutAlpacaClient",
+        lambda: SimpleNamespace(
+            endpoint_class="paper",
+            endpoint_url="https://paper-api.alpaca.markets",
+        ),
+    )
+    monkeypatch.setattr(replay_cli, "SessionLocal", lambda: session)
+    monkeypatch.setattr(
+        replay_cli, "load_broker_economic_ledger_snapshot", load_snapshot
+    )
+    monkeypatch.setattr(
+        replay_cli, "replay_broker_economic_ledger_snapshot", reduce_snapshot
+    )
+
+    assert replay_cli.main([]) == 0
+    assert events == [
+        "session_enter",
+        "transaction_enter",
+        "load_snapshot",
+        "transaction_exit",
+        "session_exit",
+        "reduce_snapshot",
+    ]
+    assert '"schema_version":"test-replay"' in capsys.readouterr().out

--- a/services/torghut/tests/execution/test_broker_economic_ledger_postgres.py
+++ b/services/torghut/tests/execution/test_broker_economic_ledger_postgres.py
@@ -137,6 +137,44 @@ def test_postgres_ledger_publication_is_atomic_balanced_and_immutable(
         assert reconciliation.journal_run_id == journal.id
         assert reconciliation.result_sha256 == observation.result.result_sha256
 
+        with sessions.begin() as session:
+            cursor = session.scalar(select(BrokerAccountActivityCursor))
+            assert cursor is not None
+            assert cursor.last_completed_at is not None
+            assert cursor.last_completed_scan_until is not None
+            cursor.last_completed_at = datetime(2026, 7, 16, 13, 3, tzinfo=timezone.utc)
+            cursor.last_completed_scan_until = datetime(
+                2026, 7, 16, 13, 2, tzinfo=timezone.utc
+            )
+        later_snapshot = normalize_broker_economic_snapshot(
+            account={"status": "ACTIVE", "cash": "1010", "equity": "1010"},
+            positions=[],
+            open_orders=[],
+            observed_at=datetime(2026, 7, 16, 13, 3, tzinfo=timezone.utc),
+        )
+        with sessions.begin() as session:
+            advanced_replay = replay_broker_economic_ledger(session, scope=scope)
+            later_observation = persist_broker_economic_ledger_reconciliation(
+                session,
+                advanced_replay,
+                later_snapshot,
+                build=BrokerEconomicReconciliationBuild(
+                    source_commit="a" * 40,
+                    image_digest=f"sha256:{'b' * 64}",
+                ),
+            )
+        assert later_observation.runs.source_watermark == input_row.source_watermark
+        assert later_observation.result.payload["source_watermark"] == (
+            input_row.source_watermark.isoformat()
+        )
+        with sessions() as session:
+            assert (
+                session.scalar(
+                    select(func.count()).select_from(BrokerEconomicLedgerReconciliation)
+                )
+                == 2
+            )
+
         _assert_manifest_hash_rejected(schema_engine, input_row)
         assert_rejected(
             schema_engine,

--- a/services/torghut/tests/execution/test_broker_economic_ledger_postgres.py
+++ b/services/torghut/tests/execution/test_broker_economic_ledger_postgres.py
@@ -65,12 +65,12 @@ def test_postgres_ledger_publication_is_atomic_balanced_and_immutable(
             schema_engine,
             target="0074_crypto_qty_precision",
         )
-        command.upgrade(alembic, "0079_broker_econ_reconciliation")
+        command.upgrade(alembic, "0080_broker_econ_recon_freshness")
         assert _public_alembic_revision(admin_engine) == public_revision_before
         with schema_engine.connect() as connection:
             assert connection.scalar(
                 text("SELECT version_num FROM alembic_version")
-            ) == ("0079_broker_econ_reconciliation")
+            ) == ("0080_broker_econ_recon_freshness")
         sessions = sessionmaker(bind=schema_engine, expire_on_commit=False, future=True)
         scope = _seed_source(sessions)
 
@@ -164,8 +164,11 @@ def test_postgres_ledger_publication_is_atomic_balanced_and_immutable(
                 ),
             )
         assert later_observation.runs.source_watermark == input_row.source_watermark
-        assert later_observation.result.payload["source_watermark"] == (
+        assert later_observation.result.payload["input_source_watermark"] == (
             input_row.source_watermark.isoformat()
+        )
+        assert later_observation.result.payload["source_watermark"] == (
+            advanced_replay.snapshot.source_watermark.isoformat()
         )
         with sessions() as session:
             assert (
@@ -374,7 +377,8 @@ def _assert_reconciliation_run_swap_rejected(
                     """
                     INSERT INTO broker_economic_ledger_reconciliations (
                         id, input_id, journal_run_id, state_run_id,
-                        source_watermark, observed_at, source_age_seconds,
+                        input_source_watermark, source_watermark,
+                        observed_at, source_age_seconds,
                         max_source_age_seconds, broker_snapshot,
                         broker_snapshot_canonical_json, broker_snapshot_sha256,
                         result, result_canonical_json, result_sha256,
@@ -382,7 +386,8 @@ def _assert_reconciliation_run_swap_rejected(
                         residual_count, open_order_count, source_commit, image_digest
                     ) VALUES (
                         :id, :input_id, :state_run_id, :journal_run_id,
-                        :source_watermark, :observed_at, :source_age_seconds,
+                        :input_source_watermark, :source_watermark,
+                        :observed_at, :source_age_seconds,
                         :max_source_age_seconds, CAST(:broker_snapshot AS jsonb),
                         :broker_snapshot, :broker_snapshot_sha256,
                         CAST(:result AS jsonb), :result, :result_sha256,
@@ -396,6 +401,7 @@ def _assert_reconciliation_run_swap_rejected(
                     "input_id": valid.input_id,
                     "journal_run_id": valid.journal_run_id,
                     "state_run_id": valid.state_run_id,
+                    "input_source_watermark": valid.input_source_watermark,
                     "source_watermark": valid.source_watermark,
                     "observed_at": valid.observed_at,
                     "source_age_seconds": valid.source_age_seconds,
@@ -421,17 +427,30 @@ def _assert_reconciliation_source_invariants_rejected(
 ) -> None:
     invalid_cases = (
         (
-            "source_watermark + INTERVAL '1 second'",
+            "input_source_watermark + INTERVAL '1 second'",
+            "source_watermark",
             "source_age_seconds",
             "broker economic reconciliation source identity mismatch",
         ),
         (
+            "input_source_watermark",
+            "source_watermark + INTERVAL '1 second'",
+            "source_age_seconds",
+            "broker economic reconciliation source age mismatch",
+        ),
+        (
+            "input_source_watermark",
             "source_watermark",
             "source_age_seconds + 1",
             "broker economic reconciliation source age mismatch",
         ),
     )
-    for source_watermark_sql, source_age_sql, expected_error in invalid_cases:
+    for (
+        input_watermark_sql,
+        source_watermark_sql,
+        source_age_sql,
+        expected_error,
+    ) in invalid_cases:
         with pytest.raises(DBAPIError, match=expected_error):
             with schema_engine.begin() as connection:
                 connection.execute(
@@ -439,7 +458,8 @@ def _assert_reconciliation_source_invariants_rejected(
                         f"""
                         INSERT INTO broker_economic_ledger_reconciliations (
                             id, input_id, journal_run_id, state_run_id,
-                            source_watermark, observed_at, source_age_seconds,
+                            input_source_watermark, source_watermark,
+                            observed_at, source_age_seconds,
                             max_source_age_seconds, broker_snapshot,
                             broker_snapshot_canonical_json, broker_snapshot_sha256,
                             result, result_canonical_json, result_sha256,
@@ -448,7 +468,8 @@ def _assert_reconciliation_source_invariants_rejected(
                         )
                         SELECT
                             :id, input_id, journal_run_id, state_run_id,
-                            {source_watermark_sql}, observed_at, {source_age_sql},
+                            {input_watermark_sql}, {source_watermark_sql},
+                            observed_at, {source_age_sql},
                             max_source_age_seconds, broker_snapshot,
                             broker_snapshot_canonical_json, broker_snapshot_sha256,
                             result, result_canonical_json, result_sha256,

--- a/services/torghut/tests/test_strategy_capital_authority_migration_compat.py
+++ b/services/torghut/tests/test_strategy_capital_authority_migration_compat.py
@@ -28,7 +28,7 @@ def test_migration_graph_has_one_merged_head_and_knows_the_released_revision() -
     config = AlembicConfig(str(SERVICE_ROOT / "alembic.ini"))
     scripts = ScriptDirectory.from_config(config)
 
-    assert scripts.get_heads() == ["0079_broker_econ_reconciliation"]
+    assert scripts.get_heads() == ["0080_broker_econ_recon_freshness"]
     assert scripts.get_revision("0063_strategy_capital_authority") is not None
     assert scripts.get_revision("0064_strategy_capital_authority") is not None
     assert scripts.get_revision("0065_strategy_capital_compat") is not None
@@ -46,3 +46,4 @@ def test_migration_graph_has_one_merged_head_and_knows_the_released_revision() -
     assert scripts.get_revision("0077_validation_quarantine") is not None
     assert scripts.get_revision("0078_broker_economic_ledger") is not None
     assert scripts.get_revision("0079_broker_econ_reconciliation") is not None
+    assert scripts.get_revision("0080_broker_econ_recon_freshness") is not None


### PR DESCRIPTION
## Summary

- Close the source-read transaction before CPU-only dual reduction so production-sized ledger replay cannot hit CNPG idle-in-transaction fencing.
- Re-lock and atomically validate the cursor after reduction, accepting only monotonic scan progress with the identical immutable source row set.
- Bind every later broker observation to the published input first proving watermark required by the PostgreSQL guard.
- Add unit and PostgreSQL regressions plus update the Slice 8 replay contract.

## Related Issues

None

## Testing

- uv run --frozen --extra dev pytest -q tests/economic_ledger tests/api/test_trading_api_status_contract.py tests/live_config_manifest_contract/test_broker_economic_ledger_reconciliation_cronjob.py tests/execution/test_broker_economic_ledger_postgres.py (74 passed, 1 PostgreSQL test skipped locally; CI owns the PostgreSQL run)
- uv run --frozen pyright --project pyrightconfig.json; repeated for alpha, scripts, alpha.strict, and scripts.strict (all zero errors)
- Ruff format/check, unused-import gate, structural and changed-line Pylint gates, file-length gate, tech-debt ratchet, migration graph, Vulture, and compileall all passed.
- Sanitized production-scale replay through the live CNPG app endpoint completed read-only over 40,161 events with admissible=true, exact reducer equivalence, and zero persisted rows. The deployed pre-fix command failed at commit with idle_in_transaction_session_timeout.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or N/A with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.