### PR TITLE
fix(torghut): detach ledger snapshot preparation

### DIFF
--- a/docs/torghut/profitability/independent-economic-ledger.md
+++ b/docs/torghut/profitability/independent-economic-ledger.md
@@ -237,13 +237,14 @@ The deterministic replay CLI is read-only until publication:
 
 1. share-lock the one mutable REST cursor while leaving immutable source rows unlocked; because backfill appends facts and
    advances that cursor in one transaction, the lock freezes one closed source set without locking its history;
-2. require the completed REST cursor and build the ordered manifest;
-3. close the read transaction, then run both pure reducers in memory so production-size replay cannot hold an idle
-   database transaction or block cursor progress;
-4. validate accounting identities and exact differential equality;
-5. optionally fetch a read-only broker snapshot and calculate broker deltas;
-6. print the complete report in dry-run mode;
-7. publish only with an explicit confirmation token, in one database transaction, after the cursor is re-locked and the
+2. require the completed REST cursor and fetch only the source columns needed by the reducers; do not adapt rows, parse
+   canonical JSON, sort activities, build the manifest, hash payloads, or reduce while the transaction is open;
+3. close the read transaction immediately after the detached database values and cursor metadata have been copied;
+4. validate source hashes, adapt and sort activities, and build the ordered manifest in memory;
+5. run both pure reducers and validate accounting identities and exact differential equality in memory;
+6. optionally fetch a read-only broker snapshot and calculate broker deltas;
+7. print the complete report in dry-run mode;
+8. publish only with an explicit confirmation token, in one database transaction, after the cursor is re-locked and the
    immutable source set is still exact. A later closed scan watermark is valid only when the cursor identity and source
    row count are unchanged; regression or any appended row rejects publication.
 

--- a/services/torghut/app/trading/economic_ledger/__init__.py
+++ b/services/torghut/app/trading/economic_ledger/__init__.py
@@ -15,11 +15,12 @@ from .journal_reducer import (
 from .persistence import (
     BrokerEconomicLedgerReplay,
     BrokerEconomicLedgerSnapshot,
+    BrokerEconomicLedgerSourceRows,
     PublishedBrokerEconomicLedgerRuns,
-    load_broker_economic_ledger_snapshot,
+    load_broker_economic_ledger_source_rows,
+    prepare_broker_economic_ledger_snapshot,
     publish_broker_economic_ledger,
     require_published_broker_economic_ledger_runs,
-    replay_broker_economic_ledger,
     replay_broker_economic_ledger_snapshot,
 )
 from .reconciliation import (
@@ -63,6 +64,7 @@ __all__ = (
     "ActivityChain",
     "BrokerEconomicLedgerReplay",
     "BrokerEconomicLedgerSnapshot",
+    "BrokerEconomicLedgerSourceRows",
     "BrokerEconomicReconciliationBuild",
     "BrokerEconomicReconciliationResult",
     "BrokerEconomicSnapshot",
@@ -91,10 +93,11 @@ __all__ = (
     "STATE_REDUCER_VERSION",
     "compare_projections",
     "capture_broker_economic_snapshot",
-    "load_broker_economic_ledger_snapshot",
+    "load_broker_economic_ledger_source_rows",
     "load_broker_economic_ledger_status",
     "normalize_broker_economic_snapshot",
     "prepare_activities",
+    "prepare_broker_economic_ledger_snapshot",
     "publish_broker_economic_ledger",
     "persist_broker_economic_ledger_reconciliation",
     "reduce_and_compare",
@@ -102,6 +105,5 @@ __all__ = (
     "reduce_independent_state",
     "reconcile_broker_economic_ledger",
     "require_published_broker_economic_ledger_runs",
-    "replay_broker_economic_ledger",
     "replay_broker_economic_ledger_snapshot",
 )

--- a/services/torghut/app/trading/economic_ledger/persistence.py
+++ b/services/torghut/app/trading/economic_ledger/persistence.py
@@ -7,10 +7,12 @@ import hmac
 import json
 import uuid
 from dataclasses import dataclass
-from datetime import datetime
-from typing import Iterable
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Iterable, TypeAlias
 
 from sqlalchemy import and_, func, insert, or_, select, text
+from sqlalchemy.engine import Row
 from sqlalchemy.orm import Session
 
 from ...models import (
@@ -44,9 +46,41 @@ _PUBLICATION_TOKEN_SCHEMA_VERSION = "torghut.broker-economic-ledger-publication.
 _ENTRY_INSERT_BATCH_SIZE = 2_000
 
 
+BrokerEconomicLedgerSourceRecord: TypeAlias = tuple[
+    str,
+    str,
+    dict[str, object],
+    str,
+    str,
+    str,
+    str | None,
+    str | None,
+    datetime | None,
+    date | None,
+    datetime,
+    str | None,
+    str | None,
+    Decimal | None,
+    Decimal | None,
+    Decimal | None,
+    str | None,
+]
+
+
+@dataclass(frozen=True, slots=True)
+class BrokerEconomicLedgerSourceRows:
+    """Database values copied while the closed-source cursor is share-locked."""
+
+    cursor_id: uuid.UUID
+    source_watermark: datetime
+    scope: LedgerScope
+    activities_inserted: int
+    rows: tuple[Row[BrokerEconomicLedgerSourceRecord], ...]
+
+
 @dataclass(frozen=True, slots=True)
 class BrokerEconomicLedgerSnapshot:
-    """One complete immutable REST source set held behind its cursor lock."""
+    """One complete immutable REST source set prepared after lock release."""
 
     cursor_id: uuid.UUID
     source_watermark: datetime
@@ -139,17 +173,6 @@ class BrokerEconomicLedgerReplay:
         }
 
 
-def replay_broker_economic_ledger(
-    session: Session,
-    *,
-    scope: LedgerScope,
-) -> BrokerEconomicLedgerReplay:
-    """Load one closed REST source set and run both pure reducers exactly once."""
-
-    snapshot = load_broker_economic_ledger_snapshot(session, scope=scope)
-    return replay_broker_economic_ledger_snapshot(snapshot)
-
-
 def replay_broker_economic_ledger_snapshot(
     snapshot: BrokerEconomicLedgerSnapshot,
 ) -> BrokerEconomicLedgerReplay:
@@ -164,20 +187,38 @@ def replay_broker_economic_ledger_snapshot(
     )
 
 
-def load_broker_economic_ledger_snapshot(
+def load_broker_economic_ledger_source_rows(
     session: Session,
     *,
     scope: LedgerScope,
-) -> BrokerEconomicLedgerSnapshot:
-    """Share-lock the mutable cursor; immutable source rows remain unlocked."""
+) -> BrokerEconomicLedgerSourceRows:
+    """Read only database values while share-locking the mutable source cursor."""
 
     cursor = _load_locked_source_cursor(session, scope)
     _require_complete_cursor(cursor)
     assert cursor is not None
     assert cursor.last_completed_scan_until is not None
     rows = tuple(
-        session.scalars(
-            select(BrokerAccountActivity)
+        session.execute(
+            select(
+                BrokerAccountActivity.source,
+                BrokerAccountActivity.external_activity_id,
+                BrokerAccountActivity.raw_payload,
+                BrokerAccountActivity.raw_payload_canonical_json,
+                BrokerAccountActivity.raw_payload_sha256,
+                BrokerAccountActivity.activity_type,
+                BrokerAccountActivity.activity_subtype,
+                BrokerAccountActivity.correction_of_external_id,
+                BrokerAccountActivity.event_at,
+                BrokerAccountActivity.settle_date,
+                BrokerAccountActivity.first_observed_at,
+                BrokerAccountActivity.symbol,
+                BrokerAccountActivity.side,
+                BrokerAccountActivity.quantity,
+                BrokerAccountActivity.price,
+                BrokerAccountActivity.net_amount,
+                BrokerAccountActivity.currency,
+            )
             .where(
                 BrokerAccountActivity.provider == scope.provider,
                 BrokerAccountActivity.source == ACCOUNT_ACTIVITIES_REST_SOURCE,
@@ -187,11 +228,27 @@ def load_broker_economic_ledger_snapshot(
                 == scope.endpoint_fingerprint,
             )
             .order_by(BrokerAccountActivity.external_activity_id)
-        )
+        ).tuples()
     )
-    if len(rows) != cursor.activities_inserted:
+    return BrokerEconomicLedgerSourceRows(
+        cursor_id=cursor.id,
+        source_watermark=as_utc(cursor.last_completed_scan_until),
+        scope=scope,
+        activities_inserted=cursor.activities_inserted,
+        rows=rows,
+    )
+
+
+def prepare_broker_economic_ledger_snapshot(
+    source_rows: BrokerEconomicLedgerSourceRows,
+) -> BrokerEconomicLedgerSnapshot:
+    """Validate and canonicalize detached source values without a transaction."""
+
+    if len(source_rows.rows) != source_rows.activities_inserted:
         raise EconomicLedgerError("economic_ledger_source_count_mismatch")
-    activities = tuple(_adapt_source_activity(row, scope=scope) for row in rows)
+    activities = tuple(
+        _adapt_source_activity(row, scope=source_rows.scope) for row in source_rows.rows
+    )
     prepared = prepare_activities(activities)
     manifest = tuple(
         activity.manifest_payload()
@@ -201,8 +258,8 @@ def load_broker_economic_ledger_snapshot(
     if _sha256(manifest_canonical_json) != prepared.manifest_digest:
         raise EconomicLedgerError("economic_ledger_manifest_digest_mismatch")
     return BrokerEconomicLedgerSnapshot(
-        cursor_id=cursor.id,
-        source_watermark=as_utc(cursor.last_completed_scan_until),
+        cursor_id=source_rows.cursor_id,
+        source_watermark=source_rows.source_watermark,
         prepared=prepared,
         activities=activities,
         input_manifest_canonical_json=manifest_canonical_json,
@@ -415,38 +472,57 @@ def _input_values(
 
 
 def _adapt_source_activity(
-    row: BrokerAccountActivity,
+    row: Row[BrokerEconomicLedgerSourceRecord],
     *,
     scope: LedgerScope,
 ) -> EconomicActivity:
-    if row.source != ACCOUNT_ACTIVITIES_REST_SOURCE:
+    (
+        source,
+        external_activity_id,
+        raw_payload,
+        raw_payload_canonical_json,
+        raw_payload_sha256,
+        activity_type,
+        activity_subtype,
+        correction_of_external_id,
+        event_at,
+        settle_date,
+        first_observed_at,
+        symbol,
+        side,
+        quantity,
+        price,
+        net_amount,
+        currency,
+    ) = row
+    if source != ACCOUNT_ACTIVITIES_REST_SOURCE:
         raise EconomicLedgerError("economic_ledger_source_not_rest")
     try:
-        canonical_payload = json.loads(row.raw_payload_canonical_json)
+        canonical_payload = json.loads(raw_payload_canonical_json)
     except json.JSONDecodeError as exc:
         raise EconomicLedgerError("economic_ledger_source_json_invalid") from exc
     if (
         not isinstance(canonical_payload, dict)
-        or canonical_payload != row.raw_payload
-        or _sha256(row.raw_payload_canonical_json) != row.raw_payload_sha256
+        or canonical_payload != raw_payload
+        or _sha256(raw_payload_canonical_json) != raw_payload_sha256
     ):
         raise EconomicLedgerError("economic_ledger_source_hash_mismatch")
     return EconomicActivity(
         scope=scope,
-        external_activity_id=row.external_activity_id,
-        raw_payload_sha256=row.raw_payload_sha256,
-        activity_type=row.activity_type,
-        activity_subtype=row.activity_subtype,
-        correction_of_external_id=row.correction_of_external_id,
-        event_at=as_utc(row.event_at) if row.event_at is not None else None,
-        settle_date=row.settle_date,
-        first_observed_at=as_utc(row.first_observed_at),
-        symbol=row.symbol,
-        side=row.side,
-        quantity=row.quantity,
-        price=row.price,
-        net_amount=row.net_amount,
-        currency=row.currency,
+        external_activity_id=external_activity_id,
+        raw_payload_sha256=raw_payload_sha256,
+        activity_type=activity_type,
+        activity_subtype=activity_subtype,
+        correction_of_external_id=correction_of_external_id,
+        event_at=as_utc(event_at) if event_at is not None else None,
+        settle_date=settle_date,
+        first_observed_at=as_utc(first_observed_at),
+        symbol=symbol,
+        side=side,
+        quantity=quantity,
+        price=price,
+        net_amount=net_amount,
+        currency=currency,
     )
 
 
@@ -754,9 +830,11 @@ def _sha256(value: str) -> str:
 __all__ = (
     "BrokerEconomicLedgerReplay",
     "BrokerEconomicLedgerSnapshot",
+    "BrokerEconomicLedgerSourceRows",
     "PublishedBrokerEconomicLedgerRuns",
-    "load_broker_economic_ledger_snapshot",
+    "load_broker_economic_ledger_source_rows",
+    "prepare_broker_economic_ledger_snapshot",
     "publish_broker_economic_ledger",
     "require_published_broker_economic_ledger_runs",
-    "replay_broker_economic_ledger",
+    "replay_broker_economic_ledger_snapshot",
 )

--- a/services/torghut/scripts/replay_broker_economic_ledger.py
+++ b/services/torghut/scripts/replay_broker_economic_ledger.py
@@ -16,8 +16,9 @@ from app.trading.economic_ledger import (
     BrokerEconomicReconciliationBuild,
     LedgerScope,
     capture_broker_economic_snapshot,
-    load_broker_economic_ledger_snapshot,
+    load_broker_economic_ledger_source_rows,
     persist_broker_economic_ledger_reconciliation,
+    prepare_broker_economic_ledger_snapshot,
     publish_broker_economic_ledger,
     replay_broker_economic_ledger_snapshot,
 )
@@ -72,7 +73,8 @@ def main(argv: list[str] | None = None) -> int:
     )
     snapshot = capture_broker_economic_snapshot(client) if args.observe else None
     with SessionLocal() as session, session.begin():
-        ledger_snapshot = load_broker_economic_ledger_snapshot(session, scope=scope)
+        source_rows = load_broker_economic_ledger_source_rows(session, scope=scope)
+    ledger_snapshot = prepare_broker_economic_ledger_snapshot(source_rows)
     replay = replay_broker_economic_ledger_snapshot(ledger_snapshot)
     published = None
     observation = None

--- a/services/torghut/tests/economic_ledger/test_persistence.py
+++ b/services/torghut/tests/economic_ledger/test_persistence.py
@@ -22,14 +22,17 @@ from app.models import (
     BrokerEconomicLedgerRun,
 )
 from app.trading.economic_ledger import (
+    BrokerEconomicLedgerReplay,
     BrokerEconomicReconciliationBuild,
     EconomicLedgerError,
     LedgerScope,
+    load_broker_economic_ledger_source_rows,
     load_broker_economic_ledger_status,
     normalize_broker_economic_snapshot,
     persist_broker_economic_ledger_reconciliation,
+    prepare_broker_economic_ledger_snapshot,
     publish_broker_economic_ledger,
-    replay_broker_economic_ledger,
+    replay_broker_economic_ledger_snapshot,
 )
 
 
@@ -170,12 +173,18 @@ def _supported_history() -> list[BrokerAccountActivity]:
     ]
 
 
+def _replay(session: Session) -> BrokerEconomicLedgerReplay:
+    source_rows = load_broker_economic_ledger_source_rows(session, scope=_SCOPE)
+    snapshot = prepare_broker_economic_ledger_snapshot(source_rows)
+    return replay_broker_economic_ledger_snapshot(snapshot)
+
+
 def test_replay_publishes_one_atomic_idempotent_run_pair() -> None:
     sessions = _session_factory()
     _seed_source(sessions, _supported_history())
 
     with sessions.begin() as session:
-        replay = replay_broker_economic_ledger(session, scope=_SCOPE)
+        replay = _replay(session)
         assert replay.reduction.admissible
         assert replay.reduction.comparison.equivalent
         assert replay.publication_token.startswith("publish:")
@@ -202,7 +211,7 @@ def test_replay_publishes_one_atomic_idempotent_run_pair() -> None:
         assert published.reused_existing is False
 
     with sessions.begin() as session:
-        replay = replay_broker_economic_ledger(session, scope=_SCOPE)
+        replay = _replay(session)
         repeated = publish_broker_economic_ledger(
             session,
             replay,
@@ -220,7 +229,7 @@ def test_replay_publishes_one_atomic_idempotent_run_pair() -> None:
         cursor.last_completed_at += timedelta(minutes=1)
         cursor.last_completed_scan_until += timedelta(minutes=1)
     with sessions.begin() as session:
-        advanced = replay_broker_economic_ledger(session, scope=_SCOPE)
+        advanced = _replay(session)
         assert advanced.publication_token == replay.publication_token
         advanced_publication = publish_broker_economic_ledger(
             session,
@@ -254,7 +263,7 @@ def test_publication_rejects_forged_replay_token() -> None:
     _seed_source(sessions, _supported_history())
 
     with sessions.begin() as session:
-        replay = replay_broker_economic_ledger(session, scope=_SCOPE)
+        replay = _replay(session)
         forged = replace(replay, publication_token=f"publish:{'0' * 64}")
         with pytest.raises(
             EconomicLedgerError,
@@ -272,7 +281,7 @@ def test_publication_accepts_later_cursor_watermark_for_unchanged_source() -> No
     _seed_source(sessions, _supported_history())
 
     with sessions.begin() as session:
-        replay = replay_broker_economic_ledger(session, scope=_SCOPE)
+        replay = _replay(session)
     with sessions.begin() as session:
         cursor = session.scalar(select(BrokerAccountActivityCursor))
         assert cursor is not None and cursor.last_completed_scan_until is not None
@@ -292,7 +301,7 @@ def test_publication_rejects_cursor_watermark_regression() -> None:
     _seed_source(sessions, _supported_history())
 
     with sessions.begin() as session:
-        replay = replay_broker_economic_ledger(session, scope=_SCOPE)
+        replay = _replay(session)
     with sessions.begin() as session:
         cursor = session.scalar(select(BrokerAccountActivityCursor))
         assert cursor is not None and cursor.last_completed_scan_until is not None
@@ -314,7 +323,7 @@ def test_publication_rejects_source_append_without_cursor_advance() -> None:
     _seed_source(sessions, _supported_history())
 
     with sessions.begin() as session:
-        replay = replay_broker_economic_ledger(session, scope=_SCOPE)
+        replay = _replay(session)
     with sessions.begin() as session:
         session.add(_activity("untracked", "FEE", offset=4, net_amount="-0.1"))
     with sessions.begin() as session:
@@ -338,7 +347,7 @@ def test_replay_rejects_incomplete_cursor_before_reading_source() -> None:
             EconomicLedgerError,
             match="economic_ledger_source_cursor_incomplete",
         ):
-            replay_broker_economic_ledger(session, scope=_SCOPE)
+            _replay(session)
 
 
 def test_replay_rejects_source_hash_mismatch() -> None:
@@ -352,7 +361,7 @@ def test_replay_rejects_source_hash_mismatch() -> None:
             EconomicLedgerError,
             match="economic_ledger_source_hash_mismatch",
         ):
-            replay_broker_economic_ledger(session, scope=_SCOPE)
+            _replay(session)
 
 
 def test_unsupported_dry_run_cannot_publish_partial_projection() -> None:
@@ -360,7 +369,7 @@ def test_unsupported_dry_run_cannot_publish_partial_projection() -> None:
     _seed_source(sessions, [_activity("merger", "MA", offset=0)])
 
     with sessions.begin() as session:
-        replay = replay_broker_economic_ledger(session, scope=_SCOPE)
+        replay = _replay(session)
         assert replay.reduction.admissible is False
         with pytest.raises(
             EconomicLedgerError,
@@ -389,7 +398,7 @@ def test_reconciliation_observations_reuse_runs_across_newer_closed_watermarks()
     sessions = _session_factory()
     _seed_source(sessions, _supported_history())
     with sessions.begin() as session:
-        replay = replay_broker_economic_ledger(session, scope=_SCOPE)
+        replay = _replay(session)
         published = publish_broker_economic_ledger(
             session,
             replay,
@@ -425,7 +434,7 @@ def test_reconciliation_observations_reuse_runs_across_newer_closed_watermarks()
         observed_at=_OBSERVED_AT + timedelta(minutes=11),
     )
     with sessions.begin() as session:
-        advanced = replay_broker_economic_ledger(session, scope=_SCOPE)
+        advanced = _replay(session)
         second = persist_broker_economic_ledger_reconciliation(
             session,
             advanced,
@@ -497,7 +506,7 @@ def test_reconciliation_refuses_unpublished_changed_manifest() -> None:
     activities = _supported_history()
     _seed_source(sessions, activities)
     with sessions.begin() as session:
-        replay = replay_broker_economic_ledger(session, scope=_SCOPE)
+        replay = _replay(session)
         publish_broker_economic_ledger(
             session,
             replay,
@@ -520,7 +529,7 @@ def test_reconciliation_refuses_unpublished_changed_manifest() -> None:
         observed_at=_OBSERVED_AT + timedelta(minutes=4),
     )
     with sessions.begin() as session:
-        changed = replay_broker_economic_ledger(session, scope=_SCOPE)
+        changed = _replay(session)
         with pytest.raises(
             EconomicLedgerError,
             match="economic_ledger_published_input_missing",

--- a/services/torghut/tests/economic_ledger/test_replay_cli.py
+++ b/services/torghut/tests/economic_ledger/test_replay_cli.py
@@ -25,7 +25,7 @@ def test_default_mode_is_read_only_replay() -> None:
     assert args.publish_token is None
 
 
-def test_dry_run_closes_database_transaction_before_pure_reduction(
+def test_dry_run_closes_database_transaction_before_preparation_and_reduction(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -57,12 +57,19 @@ def test_dry_run_closes_database_transaction_before_pure_reduction(
             return Transaction(self)
 
     session = Session()
+    source_rows = object()
     ledger_snapshot = object()
 
-    def load_snapshot(loaded_session: Session, **_kwargs: object) -> object:
+    def load_source_rows(loaded_session: Session, **_kwargs: object) -> object:
         assert loaded_session is session
         assert loaded_session.transaction_active is True
-        events.append("load_snapshot")
+        events.append("load_source_rows")
+        return source_rows
+
+    def prepare_snapshot(loaded_source_rows: object) -> object:
+        assert loaded_source_rows is source_rows
+        assert session.transaction_active is False
+        events.append("prepare_snapshot")
         return ledger_snapshot
 
     def reduce_snapshot(loaded_snapshot: object) -> SimpleNamespace:
@@ -83,7 +90,10 @@ def test_dry_run_closes_database_transaction_before_pure_reduction(
     )
     monkeypatch.setattr(replay_cli, "SessionLocal", lambda: session)
     monkeypatch.setattr(
-        replay_cli, "load_broker_economic_ledger_snapshot", load_snapshot
+        replay_cli, "load_broker_economic_ledger_source_rows", load_source_rows
+    )
+    monkeypatch.setattr(
+        replay_cli, "prepare_broker_economic_ledger_snapshot", prepare_snapshot
     )
     monkeypatch.setattr(
         replay_cli, "replay_broker_economic_ledger_snapshot", reduce_snapshot
@@ -93,9 +103,10 @@ def test_dry_run_closes_database_transaction_before_pure_reduction(
     assert events == [
         "session_enter",
         "transaction_enter",
-        "load_snapshot",
+        "load_source_rows",
         "transaction_exit",
         "session_exit",
+        "prepare_snapshot",
         "reduce_snapshot",
     ]
     assert '"schema_version":"test-replay"' in capsys.readouterr().out

--- a/services/torghut/tests/execution/test_broker_economic_ledger_postgres.py
+++ b/services/torghut/tests/execution/test_broker_economic_ledger_postgres.py
@@ -27,12 +27,15 @@ from app.trading.broker_account_activities import (
     normalize_broker_account_activity,
 )
 from app.trading.economic_ledger import (
+    BrokerEconomicLedgerReplay,
     BrokerEconomicReconciliationBuild,
     LedgerScope,
+    load_broker_economic_ledger_source_rows,
     normalize_broker_economic_snapshot,
     persist_broker_economic_ledger_reconciliation,
+    prepare_broker_economic_ledger_snapshot,
     publish_broker_economic_ledger,
-    replay_broker_economic_ledger,
+    replay_broker_economic_ledger_snapshot,
 )
 from tests.execution.decision_submission_claims_postgres_support import (
     POSTGRES_DSN,
@@ -44,6 +47,17 @@ from tests.execution.decision_submission_claims_postgres_support import (
 from tests.execution.infrastructure_validation_postgres_support import (
     upgrade_reduction_schema,
 )
+
+
+def _load_replay(
+    sessions: sessionmaker[Session],
+    *,
+    scope: LedgerScope,
+) -> BrokerEconomicLedgerReplay:
+    with sessions.begin() as session:
+        source_rows = load_broker_economic_ledger_source_rows(session, scope=scope)
+    snapshot = prepare_broker_economic_ledger_snapshot(source_rows)
+    return replay_broker_economic_ledger_snapshot(snapshot)
 
 
 @pytest.mark.skipif(
@@ -77,9 +91,9 @@ def test_postgres_ledger_publication_is_atomic_balanced_and_immutable(
         barrier = threading.Barrier(2)
 
         def publish_once():
+            replay = _load_replay(sessions, scope=scope)
+            barrier.wait(timeout=10)
             with sessions() as session, session.begin():
-                replay = replay_broker_economic_ledger(session, scope=scope)
-                barrier.wait(timeout=10)
                 return publish_broker_economic_ledger(
                     session,
                     replay,
@@ -119,8 +133,8 @@ def test_postgres_ledger_publication_is_atomic_balanced_and_immutable(
             open_orders=[],
             observed_at=datetime(2026, 7, 16, 13, 2, tzinfo=timezone.utc),
         )
+        replay = _load_replay(sessions, scope=scope)
         with sessions.begin() as session:
-            replay = replay_broker_economic_ledger(session, scope=scope)
             observation = persist_broker_economic_ledger_reconciliation(
                 session,
                 replay,
@@ -152,8 +166,8 @@ def test_postgres_ledger_publication_is_atomic_balanced_and_immutable(
             open_orders=[],
             observed_at=datetime(2026, 7, 16, 13, 3, tzinfo=timezone.utc),
         )
+        advanced_replay = _load_replay(sessions, scope=scope)
         with sessions.begin() as session:
-            advanced_replay = replay_broker_economic_ledger(session, scope=scope)
             later_observation = persist_broker_economic_ledger_reconciliation(
                 session,
                 advanced_replay,


### PR DESCRIPTION
## Summary

- Split closed-source replay into a minimal cursor-locked database read and detached in-memory preparation/reduction phases.
- Remove the unsafe session-coupled replay convenience APIs so production callers cannot canonicalize 40,161 rows inside an idle transaction.
- Add transaction-order and PostgreSQL publication regressions and correct the Slice 8 replay contract.

## Related Issues

None

## Testing

- `.venv/bin/pytest -q tests/economic_ledger tests/api/test_trading_api_status_contract.py tests/live_config_manifest_contract/test_broker_economic_ledger_reconciliation_cronjob.py tests/execution/test_broker_economic_ledger_postgres.py` (72 passed, 1 PostgreSQL test skipped locally; CI owns the PostgreSQL run).
- All five Pyright profiles passed with zero errors; Ruff format/check, unused-import, compileall, structural/changed-line/design/file-length Pylint, Vulture, tech-debt ratchet, and migration graph passed.
- Sanitized production-scale read-only replay through the live CNPG app endpoint completed over 40,161 source events with `admissible=true`, exact reducer equivalence, 180,067 journal entries, and zero persisted input/run/entry/reconciliation rows.

## Breaking Changes

None. The removed convenience functions had no production callers; all repository callers now use the explicit three-phase API.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.