### PR TITLE
fix(torghut): account for option contract notional

### DIFF
--- a/docs/torghut/profitability/independent-economic-ledger.md
+++ b/docs/torghut/profitability/independent-economic-ledger.md
@@ -128,14 +128,16 @@ a derived mark, not historical cost and not a source mutation.
 
 For each `FILL`, quantity and price must be positive, and side must be `buy`, `sell`, or the empirically observed
 historical `sell_short` alias. USD notional is `quantity * price * multiplier` with no binary floating point. The
-multiplier is `100` only when the canonical symbol matches Alpaca's OCC option-symbol shape; it is `1` otherwise.
-Position quantity remains contracts rather than underlying shares. Alpaca's option examples explicitly price one
-contract as premium times 100 shares: [Options Orders](https://docs.alpaca.markets/us/v1.1/docs/options-orders).
+OCC symbol shape identifies option activities, but it does not determine their multiplier. The exact contract size is
+copied under a share lock from Torghut's persisted Alpaca contract catalog and bound into every affected immutable input
+manifest; missing catalog metadata or a size change between dry run and publication fails closed. Alpaca exposes this
+per-contract `size` field in the [Options Trading](https://docs.alpaca.markets/us/docs/options-trading) contract response.
+Non-option fills use multiplier `1`.
 `sell_short` has sell direction but remains unchanged in the immutable manifest; no other undocumented side is
 inferred.
 
-The same derived multiplier applies when reconciling broker average entry price and current-price marks. Broker option
-quantities remain contracts while signed cost, market value, equity, and unrealized P&L remain USD amounts.
+The same manifest-bound multiplier applies when reconciling broker average entry price and current-price marks. Broker
+option quantities remain contracts while signed cost, market value, equity, and unrealized P&L remain USD amounts.
 
 A `FILL` with nonzero `net_amount` is not silently treated as quantity-times-price cash. It remains unsupported until
 a golden broker fixture establishes whether that field is gross, fee-inclusive, or net settlement and a sourced
@@ -244,8 +246,9 @@ The deterministic replay CLI is read-only until publication:
 
 1. share-lock the one mutable REST cursor while leaving immutable source rows unlocked; because backfill appends facts and
    advances that cursor in one transaction, the lock freezes one closed source set without locking its history;
-2. require the completed REST cursor and fetch only the source columns needed by the reducers; do not adapt rows, parse
-   canonical JSON, sort activities, build the manifest, hash payloads, or reduce while the transaction is open;
+2. require the completed REST cursor, fetch only the source columns needed by the reducers, and share-lock contract-size
+   rows for OCC option symbols; do not adapt rows, parse canonical JSON, sort activities, build the manifest, hash
+   payloads, or reduce while the transaction is open;
 3. close the read transaction immediately after the detached database values and cursor metadata have been copied;
 4. validate source hashes, adapt and sort activities, and build the ordered manifest in memory;
 5. run both pure reducers and validate accounting identities and exact differential equality in memory;

--- a/docs/torghut/profitability/independent-economic-ledger.md
+++ b/docs/torghut/profitability/independent-economic-ledger.md
@@ -78,7 +78,7 @@ The pure reducer accepts bounded decimal and identifier values only:
 
 - external activity ID, raw payload hash, type, subtype, correction reference;
 - event timestamp, settlement date, first-observed timestamp;
-- symbol, side, quantity, price, net cash amount, and currency;
+- symbol, side, quantity, price, derived notional multiplier, net cash amount, and currency;
 - provider/account/environment/endpoint scope.
 
 The SQLAlchemy model is adapted into this value object at the boundary. The reducer never reads mutable strategy,
@@ -126,9 +126,16 @@ a derived mark, not historical cost and not a source mutation.
 
 ### Fills
 
-For each `FILL`, quantity and price must be positive, side must be `buy`, `sell`, or the empirically observed historical
-`sell_short` alias, and USD notional is `quantity * price` with no binary floating point. `sell_short` has sell direction
-but remains unchanged in the immutable manifest; no other undocumented side is inferred.
+For each `FILL`, quantity and price must be positive, and side must be `buy`, `sell`, or the empirically observed
+historical `sell_short` alias. USD notional is `quantity * price * multiplier` with no binary floating point. The
+multiplier is `100` only when the canonical symbol matches Alpaca's OCC option-symbol shape; it is `1` otherwise.
+Position quantity remains contracts rather than underlying shares. Alpaca's option examples explicitly price one
+contract as premium times 100 shares: [Options Orders](https://docs.alpaca.markets/us/v1.1/docs/options-orders).
+`sell_short` has sell direction but remains unchanged in the immutable manifest; no other undocumented side is
+inferred.
+
+The same derived multiplier applies when reconciling broker average entry price and current-price marks. Broker option
+quantities remain contracts while signed cost, market value, equity, and unrealized P&L remain USD amounts.
 
 A `FILL` with nonzero `net_amount` is not silently treated as quantity-times-price cash. It remains unsupported until
 a golden broker fixture establishes whether that field is gross, fee-inclusive, or net settlement and a sourced

--- a/services/torghut/app/trading/economic_ledger/journal_reducer.py
+++ b/services/torghut/app/trading/economic_ledger/journal_reducer.py
@@ -24,7 +24,7 @@ from .types import (
 
 
 JOURNAL_REDUCER_NAME = "balanced_journal"
-JOURNAL_REDUCER_VERSION = "torghut.broker-economic-journal.v1"
+JOURNAL_REDUCER_VERSION = "torghut.broker-economic-journal.v2"
 
 _MAX_TRANSACTION_ID_LENGTH = 512
 _REVERSAL_TRANSACTION_ID_PREFIX = "correction-reversal:sha256:"
@@ -165,7 +165,11 @@ class _JournalWriter:
         _require_quote_currency(activity)
 
         position = self.positions.setdefault(symbol, _Position())
-        posting = _build_fill_posting(position, delta_quantity, price)
+        posting = _build_fill_posting(
+            position,
+            delta_quantity,
+            price * activity.notional_multiplier,
+        )
         if posting.cash_delta == ZERO:
             raise EconomicLedgerError("economic_fill_notional_below_ledger_quantum")
         if posting.new_quantity != ZERO and posting.new_cost == ZERO:

--- a/services/torghut/app/trading/economic_ledger/persistence.py
+++ b/services/torghut/app/trading/economic_ledger/persistence.py
@@ -9,9 +9,20 @@ import uuid
 from dataclasses import dataclass
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Iterable, TypeAlias
+from typing import Iterable, TypeAlias, cast
 
-from sqlalchemy import and_, func, insert, or_, select, text
+from sqlalchemy import (
+    Integer,
+    Text,
+    and_,
+    column,
+    func,
+    insert,
+    or_,
+    select,
+    table,
+    text,
+)
 from sqlalchemy.engine import Row
 from sqlalchemy.orm import Session
 
@@ -36,6 +47,7 @@ from .types import (
     LedgerScope,
     PreparedActivities,
     canonical_sha256,
+    is_occ_option_symbol,
     prepare_activities,
 )
 
@@ -44,6 +56,11 @@ _RESULT_SCHEMA_VERSION = "torghut.broker-economic-ledger-result.v1"
 _REPLAY_SCHEMA_VERSION = "torghut.broker-economic-ledger-replay.v1"
 _PUBLICATION_TOKEN_SCHEMA_VERSION = "torghut.broker-economic-ledger-publication.v1"
 _ENTRY_INSERT_BATCH_SIZE = 2_000
+_OPTION_CONTRACT_CATALOG = table(
+    "torghut_options_contract_catalog",
+    column("contract_symbol", Text),
+    column("contract_size", Integer),
+)
 
 
 BrokerEconomicLedgerSourceRecord: TypeAlias = tuple[
@@ -76,6 +93,7 @@ class BrokerEconomicLedgerSourceRows:
     scope: LedgerScope
     activities_inserted: int
     rows: tuple[Row[BrokerEconomicLedgerSourceRecord], ...]
+    option_contract_sizes: tuple[tuple[str, int], ...]
 
 
 @dataclass(frozen=True, slots=True)
@@ -87,6 +105,7 @@ class BrokerEconomicLedgerSnapshot:
     prepared: PreparedActivities
     activities: tuple[EconomicActivity, ...]
     input_manifest_canonical_json: str
+    option_contract_sizes: tuple[tuple[str, int], ...]
 
 
 @dataclass(frozen=True, slots=True)
@@ -230,13 +249,49 @@ def load_broker_economic_ledger_source_rows(
             .order_by(BrokerAccountActivity.external_activity_id)
         ).tuples()
     )
+    option_contract_sizes = _load_locked_option_contract_sizes(
+        session,
+        symbols=_option_symbols(rows),
+    )
     return BrokerEconomicLedgerSourceRows(
         cursor_id=cursor.id,
         source_watermark=as_utc(cursor.last_completed_scan_until),
         scope=scope,
         activities_inserted=cursor.activities_inserted,
         rows=rows,
+        option_contract_sizes=option_contract_sizes,
     )
+
+
+def _option_symbols(
+    rows: Iterable[Row[BrokerEconomicLedgerSourceRecord]],
+) -> tuple[str, ...]:
+    symbols = {
+        symbol.replace("/", "").upper()
+        for row in rows
+        if (symbol := cast(str | None, row.symbol)) is not None
+        and is_occ_option_symbol(symbol.replace("/", "").upper())
+    }
+    return tuple(sorted(symbols))
+
+
+def _load_locked_option_contract_sizes(
+    session: Session,
+    *,
+    symbols: tuple[str, ...],
+) -> tuple[tuple[str, int], ...]:
+    if not symbols:
+        return ()
+    rows = session.execute(
+        select(
+            _OPTION_CONTRACT_CATALOG.c.contract_symbol,
+            _OPTION_CONTRACT_CATALOG.c.contract_size,
+        )
+        .where(_OPTION_CONTRACT_CATALOG.c.contract_symbol.in_(symbols))
+        .order_by(_OPTION_CONTRACT_CATALOG.c.contract_symbol)
+        .with_for_update(read=True)
+    ).tuples()
+    return tuple((str(symbol), int(contract_size)) for symbol, contract_size in rows)
 
 
 def prepare_broker_economic_ledger_snapshot(
@@ -246,8 +301,14 @@ def prepare_broker_economic_ledger_snapshot(
 
     if len(source_rows.rows) != source_rows.activities_inserted:
         raise EconomicLedgerError("economic_ledger_source_count_mismatch")
+    option_contract_sizes = dict(source_rows.option_contract_sizes)
     activities = tuple(
-        _adapt_source_activity(row, scope=source_rows.scope) for row in source_rows.rows
+        _adapt_source_activity(
+            row,
+            scope=source_rows.scope,
+            option_contract_sizes=option_contract_sizes,
+        )
+        for row in source_rows.rows
     )
     prepared = prepare_activities(activities)
     manifest = tuple(
@@ -263,6 +324,7 @@ def prepare_broker_economic_ledger_snapshot(
         prepared=prepared,
         activities=activities,
         input_manifest_canonical_json=manifest_canonical_json,
+        option_contract_sizes=source_rows.option_contract_sizes,
     )
 
 
@@ -388,6 +450,12 @@ def _require_current_source_snapshot(
     )
     if current_count != len(snapshot.activities):
         raise EconomicLedgerError("economic_ledger_source_rows_changed")
+    current_contract_sizes = _load_locked_option_contract_sizes(
+        session,
+        symbols=tuple(symbol for symbol, _ in snapshot.option_contract_sizes),
+    )
+    if current_contract_sizes != snapshot.option_contract_sizes:
+        raise EconomicLedgerError("economic_ledger_option_contract_sizes_changed")
 
 
 def _load_or_create_input(
@@ -475,6 +543,7 @@ def _adapt_source_activity(
     row: Row[BrokerEconomicLedgerSourceRecord],
     *,
     scope: LedgerScope,
+    option_contract_sizes: dict[str, int],
 ) -> EconomicActivity:
     (
         source,
@@ -507,6 +576,8 @@ def _adapt_source_activity(
         or _sha256(raw_payload_canonical_json) != raw_payload_sha256
     ):
         raise EconomicLedgerError("economic_ledger_source_hash_mismatch")
+    canonical_symbol = symbol.replace("/", "").upper() if symbol is not None else None
+    contract_size = option_contract_sizes.get(canonical_symbol or "")
     return EconomicActivity(
         scope=scope,
         external_activity_id=external_activity_id,
@@ -521,6 +592,7 @@ def _adapt_source_activity(
         side=side,
         quantity=quantity,
         price=price,
+        contract_size=(Decimal(contract_size) if contract_size is not None else None),
         net_amount=net_amount,
         currency=currency,
     )

--- a/services/torghut/app/trading/economic_ledger/reconciliation.py
+++ b/services/torghut/app/trading/economic_ledger/reconciliation.py
@@ -33,7 +33,7 @@ from .types import (
     LedgerScope,
     canonical_sha256,
     decimal_text,
-    notional_multiplier_for_symbol,
+    is_occ_option_symbol,
     quantize_ledger_decimal,
 )
 
@@ -255,9 +255,14 @@ def reconcile_broker_economic_ledger(
         raise EconomicLedgerError("economic_reconciliation_snapshot_before_watermark")
     source_age_seconds = int((snapshot.observed_at - watermark).total_seconds())
     projection = replay.reduction.journal.projection
+    option_contract_sizes = {
+        symbol: Decimal(contract_size)
+        for symbol, contract_size in replay.snapshot.option_contract_sizes
+    }
     residuals = _economic_residuals(
         projection,
         snapshot=snapshot,
+        option_contract_sizes=option_contract_sizes,
         source_age_seconds=source_age_seconds,
         max_source_age_seconds=max_source_age_seconds,
     )
@@ -267,7 +272,11 @@ def reconcile_broker_economic_ledger(
     if not replay.reduction.admissible:
         reason_codes.add("economic_projection_not_admissible")
     reconciled = not reason_codes
-    ledger_values = _marked_ledger_values(projection, snapshot=snapshot)
+    ledger_values = _marked_ledger_values(
+        projection,
+        snapshot=snapshot,
+        option_contract_sizes=option_contract_sizes,
+    )
     broker_unrealized = _sum_decimal(
         position.unrealized_pnl for position in snapshot.positions
     )
@@ -487,6 +496,7 @@ def _economic_residuals(
     projection: EconomicProjection,
     *,
     snapshot: BrokerEconomicSnapshot,
+    option_contract_sizes: Mapping[str, Decimal],
     source_age_seconds: int,
     max_source_age_seconds: int,
 ) -> tuple[BrokerEconomicResidual, ...]:
@@ -498,11 +508,17 @@ def _economic_residuals(
         max_source_age_seconds=max_source_age_seconds,
     )
     _append_cash_residuals(residuals, projection=projection, snapshot=snapshot)
-    _append_position_residuals(residuals, projection=projection, snapshot=snapshot)
+    _append_position_residuals(
+        residuals,
+        projection=projection,
+        snapshot=snapshot,
+        option_contract_sizes=option_contract_sizes,
+    )
     _append_mark_to_market_residuals(
         residuals,
         projection=projection,
         snapshot=snapshot,
+        option_contract_sizes=option_contract_sizes,
     )
     return tuple(residuals)
 
@@ -570,6 +586,7 @@ def _append_position_residuals(
     *,
     projection: EconomicProjection,
     snapshot: BrokerEconomicSnapshot,
+    option_contract_sizes: Mapping[str, Decimal],
 ) -> None:
     ledger_positions = {position.symbol: position for position in projection.positions}
     broker_positions = {position.symbol: position for position in snapshot.positions}
@@ -609,7 +626,7 @@ def _append_position_residuals(
                 broker_position.average_entry_price,
                 "broker_signed_cost",
             ),
-            notional_multiplier_for_symbol(symbol),
+            _contract_multiplier(symbol, option_contract_sizes),
             "broker_signed_cost",
         )
         _append_decimal_residual(
@@ -626,9 +643,14 @@ def _append_mark_to_market_residuals(
     *,
     projection: EconomicProjection,
     snapshot: BrokerEconomicSnapshot,
+    option_contract_sizes: Mapping[str, Decimal],
 ) -> None:
     ledger_positions = {position.symbol: position for position in projection.positions}
-    marked = _marked_ledger_values(projection, snapshot=snapshot)
+    marked = _marked_ledger_values(
+        projection,
+        snapshot=snapshot,
+        option_contract_sizes=option_contract_sizes,
+    )
     if marked.equity is None or marked.unrealized_pnl is None:
         marks = {position.symbol for position in snapshot.positions}
         for symbol in sorted(set(ledger_positions) - marks):
@@ -665,6 +687,7 @@ def _marked_ledger_values(
     projection: EconomicProjection,
     *,
     snapshot: BrokerEconomicSnapshot,
+    option_contract_sizes: Mapping[str, Decimal],
 ) -> _MarkedLedgerValues:
     cash_by_commodity = {item.commodity: item.amount for item in projection.cash}
     cash = cash_by_commodity.get(projection.scope.quote_currency, ZERO)
@@ -678,7 +701,7 @@ def _marked_ledger_values(
                 marks[position.symbol],
                 "ledger_market_value",
             ),
-            notional_multiplier_for_symbol(position.symbol),
+            _contract_multiplier(position.symbol, option_contract_sizes),
             "ledger_market_value",
         )
         for position in projection.positions
@@ -691,6 +714,18 @@ def _marked_ledger_values(
         equity=_add(cash, market_value, "ledger_equity"),
         unrealized_pnl=_add(market_value, -carrying_value, "ledger_unrealized_pnl"),
     )
+
+
+def _contract_multiplier(
+    symbol: str,
+    option_contract_sizes: Mapping[str, Decimal],
+) -> Decimal:
+    contract_size = option_contract_sizes.get(symbol)
+    if contract_size is not None:
+        return contract_size
+    if is_occ_option_symbol(symbol):
+        raise EconomicLedgerError("economic_option_contract_size_missing")
+    return Decimal("1")
 
 
 def _normalize_position(value: object) -> BrokerEconomicPosition:

--- a/services/torghut/app/trading/economic_ledger/reconciliation.py
+++ b/services/torghut/app/trading/economic_ledger/reconciliation.py
@@ -33,6 +33,7 @@ from .types import (
     LedgerScope,
     canonical_sha256,
     decimal_text,
+    notional_multiplier_for_symbol,
     quantize_ledger_decimal,
 )
 
@@ -603,7 +604,13 @@ def _append_position_residuals(
         ):
             continue
         broker_signed_cost = _multiply(
-            broker_quantity, broker_position.average_entry_price, "broker_signed_cost"
+            _multiply(
+                broker_quantity,
+                broker_position.average_entry_price,
+                "broker_signed_cost",
+            ),
+            notional_multiplier_for_symbol(symbol),
+            "broker_signed_cost",
         )
         _append_decimal_residual(
             residuals,
@@ -665,7 +672,15 @@ def _marked_ledger_values(
     if any(position.symbol not in marks for position in projection.positions):
         return _MarkedLedgerValues(cash=cash, equity=None, unrealized_pnl=None)
     market_value = _sum_decimal(
-        _multiply(position.quantity, marks[position.symbol], "ledger_market_value")
+        _multiply(
+            _multiply(
+                position.quantity,
+                marks[position.symbol],
+                "ledger_market_value",
+            ),
+            notional_multiplier_for_symbol(position.symbol),
+            "ledger_market_value",
+        )
         for position in projection.positions
     )
     carrying_value = _sum_decimal(

--- a/services/torghut/app/trading/economic_ledger/state_reducer.py
+++ b/services/torghut/app/trading/economic_ledger/state_reducer.py
@@ -20,7 +20,7 @@ from .types import (
 
 
 STATE_REDUCER_NAME = "independent_position_state"
-STATE_REDUCER_VERSION = "torghut.broker-economic-state.v1"
+STATE_REDUCER_VERSION = "torghut.broker-economic-state.v2"
 
 _EXTERNAL_FLOW_TYPES = frozenset({"ACATC", "CSD", "CSW", "JNLC", "TRANS"})
 _DIVIDEND_ACTIVITY_TYPES = frozenset(
@@ -166,7 +166,7 @@ class _StateReducer:
         holding = self.holdings.setdefault(symbol, _Holding())
         previous_value = holding.carrying_value
         cash_change = quantize_ledger_decimal(
-            -order_units * price,
+            -order_units * price * activity.notional_multiplier,
             field_name="fill_cash_delta",
         )
         if cash_change == ZERO:
@@ -174,7 +174,7 @@ class _StateReducer:
         next_units, next_value = _next_holding(
             holding,
             order_units,
-            price,
+            price * activity.notional_multiplier,
             cash_change,
         )
         if next_units != ZERO and next_value == ZERO:

--- a/services/torghut/app/trading/economic_ledger/types.py
+++ b/services/torghut/app/trading/economic_ledger/types.py
@@ -16,7 +16,6 @@ LEDGER_DECIMAL_PRECISION = 80
 LEDGER_DECIMAL_SCALE = 18
 LEDGER_QUANTUM = Decimal("0.000000000000000001")
 _LEDGER_ABSOLUTE_LIMIT = Decimal("100000000000000000000")
-_OPTION_CONTRACT_MULTIPLIER = Decimal("100")
 _UNIT_NOTIONAL_MULTIPLIER = Decimal("1")
 _OCC_OPTION_SYMBOL = re.compile(r"^[A-Z0-9]{1,6}[0-9]{6}[CP][0-9]{8}$")
 
@@ -84,6 +83,7 @@ class EconomicActivity:
     side: str | None = None
     quantity: Decimal | None = None
     price: Decimal | None = None
+    contract_size: Decimal | None = None
     net_amount: Decimal | None = None
     currency: str | None = None
 
@@ -139,10 +139,17 @@ class EconomicActivity:
         )
         if self.event_at is not None:
             object.__setattr__(self, "event_at", _aware_utc(self.event_at, "event_at"))
-        for field_name in ("quantity", "price", "net_amount"):
+        for field_name in ("quantity", "price", "contract_size", "net_amount"):
             value = getattr(self, field_name)
             if value is not None:
                 object.__setattr__(self, field_name, _finite_decimal(value, field_name))
+        if self.contract_size is not None and self.contract_size <= ZERO:
+            raise EconomicLedgerError("economic_option_contract_size_invalid")
+        option_symbol = is_occ_option_symbol(self.canonical_symbol)
+        if option_symbol and self.contract_size is None:
+            raise EconomicLedgerError("economic_option_contract_size_missing")
+        if not option_symbol and self.contract_size is not None:
+            raise EconomicLedgerError("economic_non_option_contract_size_present")
         if self.correction_of_external_id == self.external_activity_id:
             raise EconomicLedgerCorrectionError(
                 "economic_activity_cannot_correct_itself"
@@ -171,7 +178,9 @@ class EconomicActivity:
 
     @property
     def notional_multiplier(self) -> Decimal:
-        return notional_multiplier_for_symbol(self.canonical_symbol)
+        if self.contract_size is not None:
+            return self.contract_size
+        return _UNIT_NOTIONAL_MULTIPLIER
 
     @property
     def sort_key(self) -> tuple[datetime, date, str, str]:
@@ -628,11 +637,9 @@ def positions_tuple(
     )
 
 
-def notional_multiplier_for_symbol(symbol: str | None) -> Decimal:
-    """Return the broker notional multiplier encoded by a canonical symbol."""
-    if symbol is not None and _OCC_OPTION_SYMBOL.fullmatch(symbol) is not None:
-        return _OPTION_CONTRACT_MULTIPLIER
-    return _UNIT_NOTIONAL_MULTIPLIER
+def is_occ_option_symbol(symbol: str | None) -> bool:
+    """Return whether a canonical symbol has Alpaca's OCC option shape."""
+    return symbol is not None and _OCC_OPTION_SYMBOL.fullmatch(symbol) is not None
 
 
 def _required_text(value: object, field_name: str, maximum: int) -> str:
@@ -729,7 +736,7 @@ __all__ = (
     "balances_tuple",
     "canonical_sha256",
     "decimal_text",
-    "notional_multiplier_for_symbol",
+    "is_occ_option_symbol",
     "positions_tuple",
     "prepare_activities",
     "quantize_ledger_decimal",

--- a/services/torghut/app/trading/economic_ledger/types.py
+++ b/services/torghut/app/trading/economic_ledger/types.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from datetime import date, datetime, time, timezone
@@ -15,6 +16,9 @@ LEDGER_DECIMAL_PRECISION = 80
 LEDGER_DECIMAL_SCALE = 18
 LEDGER_QUANTUM = Decimal("0.000000000000000001")
 _LEDGER_ABSOLUTE_LIMIT = Decimal("100000000000000000000")
+_OPTION_CONTRACT_MULTIPLIER = Decimal("100")
+_UNIT_NOTIONAL_MULTIPLIER = Decimal("1")
+_OCC_OPTION_SYMBOL = re.compile(r"^[A-Z0-9]{1,6}[0-9]{6}[CP][0-9]{8}$")
 
 
 class EconomicLedgerError(RuntimeError):
@@ -166,6 +170,10 @@ class EconomicActivity:
         return self.symbol.replace("/", "")
 
     @property
+    def notional_multiplier(self) -> Decimal:
+        return notional_multiplier_for_symbol(self.canonical_symbol)
+
+    @property
     def sort_key(self) -> tuple[datetime, date, str, str]:
         return (
             self.economic_at,
@@ -184,6 +192,7 @@ class EconomicActivity:
             "external_activity_id": self.external_activity_id,
             "first_observed_at": _datetime_text(self.first_observed_at),
             "net_amount": decimal_text(self.net_amount),
+            "notional_multiplier": decimal_text(self.notional_multiplier),
             "price": decimal_text(self.price),
             "quantity": decimal_text(self.quantity),
             "raw_payload_sha256": self.raw_payload_sha256,
@@ -619,6 +628,13 @@ def positions_tuple(
     )
 
 
+def notional_multiplier_for_symbol(symbol: str | None) -> Decimal:
+    """Return the broker notional multiplier encoded by a canonical symbol."""
+    if symbol is not None and _OCC_OPTION_SYMBOL.fullmatch(symbol) is not None:
+        return _OPTION_CONTRACT_MULTIPLIER
+    return _UNIT_NOTIONAL_MULTIPLIER
+
+
 def _required_text(value: object, field_name: str, maximum: int) -> str:
     if not isinstance(value, str):
         raise EconomicLedgerError(f"economic_ledger_{field_name}_must_be_string")
@@ -713,6 +729,7 @@ __all__ = (
     "balances_tuple",
     "canonical_sha256",
     "decimal_text",
+    "notional_multiplier_for_symbol",
     "positions_tuple",
     "prepare_activities",
     "quantize_ledger_decimal",

--- a/services/torghut/tests/economic_ledger/support.py
+++ b/services/torghut/tests/economic_ledger/support.py
@@ -28,6 +28,7 @@ def activity(
     side: str | None = None,
     quantity: str | None = None,
     price: str | None = None,
+    contract_size: str | None = None,
     net_amount: str | None = None,
     currency: str | None = "USD",
     raw_payload_sha256: str | None = None,
@@ -49,6 +50,7 @@ def activity(
         side=side,
         quantity=Decimal(quantity) if quantity is not None else None,
         price=Decimal(price) if price is not None else None,
+        contract_size=(Decimal(contract_size) if contract_size is not None else None),
         net_amount=Decimal(net_amount) if net_amount is not None else None,
         currency=currency,
     )

--- a/services/torghut/tests/economic_ledger/test_dual_reducers.py
+++ b/services/torghut/tests/economic_ledger/test_dual_reducers.py
@@ -856,7 +856,14 @@ def test_correction_graph_rejects_missing_fork_and_cycle() -> None:
 
 def test_unknown_activity_is_visible_and_non_admissible() -> None:
     result = reduce_and_compare(
-        [activity("assignment", "OPASN", symbol="AAPL260117C00100000")]
+        [
+            activity(
+                "assignment",
+                "OPASN",
+                symbol="AAPL260117C00100000",
+                contract_size="100",
+            )
+        ]
     )
     assert result.comparison.equivalent
     assert not result.admissible

--- a/services/torghut/tests/economic_ledger/test_option_multiplier.py
+++ b/services/torghut/tests/economic_ledger/test_option_multiplier.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from app.trading.economic_ledger import (
+    JOURNAL_REDUCER_VERSION,
+    STATE_REDUCER_VERSION,
+    reduce_and_compare,
+)
+from tests.economic_ledger.support import activity, cash, position
+
+
+def test_option_fill_cash_and_cost_use_the_contract_multiplier() -> None:
+    buy = activity(
+        "option-buy",
+        "FILL",
+        symbol="AMZN260529P00270000",
+        side="buy",
+        quantity="2",
+        price="1.05",
+        net_amount=None,
+    )
+    result = reduce_and_compare(
+        [
+            buy,
+            activity(
+                "option-sell",
+                "FILL",
+                event_offset_seconds=1,
+                symbol="AMZN260529P00270000",
+                side="sell",
+                quantity="2",
+                price="1.20",
+                net_amount=None,
+            ),
+        ]
+    )
+
+    assert buy.manifest_payload()["notional_multiplier"] == "100"
+    assert JOURNAL_REDUCER_VERSION == "torghut.broker-economic-journal.v2"
+    assert STATE_REDUCER_VERSION == "torghut.broker-economic-state.v2"
+    assert result.admissible
+    assert result.comparison.equivalent
+    assert cash(result.journal.projection) == Decimal("30")
+    assert result.journal.projection.realized_pnl == Decimal("30")
+    assert position(result.journal.projection, "AMZN260529P00270000") is None
+    assert [
+        line.amount
+        for transaction in result.journal.transactions
+        for line in transaction.lines
+        if line.account == "asset:cash"
+    ] == [Decimal("-210"), Decimal("240")]
+
+
+def test_non_option_fill_keeps_unit_notional_multiplier() -> None:
+    stock_fill = activity(
+        "stock-buy",
+        "FILL",
+        symbol="AAPL",
+        side="buy",
+        quantity="2",
+        price="10",
+        net_amount=None,
+    )
+
+    result = reduce_and_compare([stock_fill])
+
+    assert stock_fill.manifest_payload()["notional_multiplier"] == "1"
+    assert cash(result.journal.projection) == Decimal("-20")

--- a/services/torghut/tests/economic_ledger/test_option_multiplier.py
+++ b/services/torghut/tests/economic_ledger/test_option_multiplier.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from decimal import Decimal
 
+import pytest
+
 from app.trading.economic_ledger import (
+    EconomicLedgerError,
     JOURNAL_REDUCER_VERSION,
     STATE_REDUCER_VERSION,
     reduce_and_compare,
@@ -10,7 +13,7 @@ from app.trading.economic_ledger import (
 from tests.economic_ledger.support import activity, cash, position
 
 
-def test_option_fill_cash_and_cost_use_the_contract_multiplier() -> None:
+def test_option_fill_cash_and_cost_use_the_explicit_contract_size() -> None:
     buy = activity(
         "option-buy",
         "FILL",
@@ -18,6 +21,7 @@ def test_option_fill_cash_and_cost_use_the_contract_multiplier() -> None:
         side="buy",
         quantity="2",
         price="1.05",
+        contract_size="10",
         net_amount=None,
     )
     result = reduce_and_compare(
@@ -31,25 +35,59 @@ def test_option_fill_cash_and_cost_use_the_contract_multiplier() -> None:
                 side="sell",
                 quantity="2",
                 price="1.20",
+                contract_size="10",
                 net_amount=None,
             ),
         ]
     )
 
-    assert buy.manifest_payload()["notional_multiplier"] == "100"
+    assert buy.manifest_payload()["notional_multiplier"] == "10"
     assert JOURNAL_REDUCER_VERSION == "torghut.broker-economic-journal.v2"
     assert STATE_REDUCER_VERSION == "torghut.broker-economic-state.v2"
     assert result.admissible
     assert result.comparison.equivalent
-    assert cash(result.journal.projection) == Decimal("30")
-    assert result.journal.projection.realized_pnl == Decimal("30")
+    assert cash(result.journal.projection) == Decimal("3")
+    assert result.journal.projection.realized_pnl == Decimal("3")
     assert position(result.journal.projection, "AMZN260529P00270000") is None
     assert [
         line.amount
         for transaction in result.journal.transactions
         for line in transaction.lines
         if line.account == "asset:cash"
-    ] == [Decimal("-210"), Decimal("240")]
+    ] == [Decimal("-21"), Decimal("24")]
+
+
+def test_option_activity_requires_catalog_contract_size() -> None:
+    with pytest.raises(
+        EconomicLedgerError,
+        match="economic_option_contract_size_missing",
+    ):
+        activity(
+            "option-without-catalog",
+            "FILL",
+            symbol="AMZN260529P00270000",
+            side="buy",
+            quantity="1",
+            price="1.05",
+            net_amount=None,
+        )
+
+
+def test_non_option_activity_rejects_contract_size() -> None:
+    with pytest.raises(
+        EconomicLedgerError,
+        match="economic_non_option_contract_size_present",
+    ):
+        activity(
+            "stock-with-contract-size",
+            "FILL",
+            symbol="AAPL",
+            side="buy",
+            quantity="1",
+            price="10",
+            contract_size="100",
+            net_amount=None,
+        )
 
 
 def test_non_option_fill_keeps_unit_notional_multiplier() -> None:

--- a/services/torghut/tests/economic_ledger/test_persistence.py
+++ b/services/torghut/tests/economic_ledger/test_persistence.py
@@ -8,7 +8,19 @@ from decimal import Decimal
 from typing import cast
 
 import pytest
-from sqlalchemy import Table, create_engine, event, func, select
+from sqlalchemy import (
+    Column,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    create_engine,
+    event,
+    func,
+    insert,
+    select,
+    update,
+)
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
@@ -47,6 +59,12 @@ _SCOPE = LedgerScope(
     account_label="paper-account",
     endpoint_fingerprint="a" * 64,
 )
+_OPTION_CATALOG = Table(
+    "torghut_options_contract_catalog",
+    MetaData(),
+    Column("contract_symbol", String, primary_key=True),
+    Column("contract_size", Integer, nullable=False),
+)
 
 
 def _session_factory() -> sessionmaker[Session]:
@@ -72,6 +90,7 @@ def _session_factory() -> sessionmaker[Session]:
             cast(Table, BrokerEconomicLedgerReconciliation.__table__),
         ],
     )
+    _OPTION_CATALOG.create(engine)
     return sessionmaker(bind=engine, expire_on_commit=False, future=True)
 
 
@@ -362,6 +381,103 @@ def test_replay_rejects_source_hash_mismatch() -> None:
             match="economic_ledger_source_hash_mismatch",
         ):
             _replay(session)
+
+
+def test_replay_requires_option_contract_size_from_catalog() -> None:
+    sessions = _session_factory()
+    _seed_source(
+        sessions,
+        [
+            _activity("cash", "CSD", offset=0, net_amount="1000"),
+            _activity(
+                "option-buy",
+                "FILL",
+                offset=1,
+                symbol="AMZN260529P00270000",
+                side="buy",
+                quantity="1",
+                price="1.05",
+                net_amount=None,
+            ),
+        ],
+    )
+
+    with sessions.begin() as session:
+        with pytest.raises(
+            EconomicLedgerError,
+            match="economic_option_contract_size_missing",
+        ):
+            _replay(session)
+
+
+def test_adjusted_option_contract_size_is_manifest_bound_and_publish_fenced() -> None:
+    sessions = _session_factory()
+    symbol = "AMZN260529P00270000"
+    _seed_source(
+        sessions,
+        [
+            _activity("cash", "CSD", offset=0, net_amount="1000"),
+            _activity(
+                "option-buy",
+                "FILL",
+                offset=1,
+                symbol=symbol,
+                side="buy",
+                quantity="2",
+                price="1",
+                net_amount=None,
+            ),
+            _activity(
+                "option-sell",
+                "FILL",
+                offset=2,
+                symbol=symbol,
+                side="sell",
+                quantity="2",
+                price="2",
+                net_amount=None,
+            ),
+        ],
+    )
+    with sessions.begin() as session:
+        session.execute(
+            insert(_OPTION_CATALOG).values(
+                contract_symbol=symbol,
+                contract_size=10,
+            )
+        )
+
+    with sessions.begin() as session:
+        replay = _replay(session)
+    option_activities = [
+        item for item in replay.snapshot.activities if item.canonical_symbol == symbol
+    ]
+    projection_cash = {
+        item.commodity: item.amount for item in replay.reduction.journal.projection.cash
+    }
+    assert replay.snapshot.option_contract_sizes == ((symbol, 10),)
+    assert {item.notional_multiplier for item in option_activities} == {Decimal("10")}
+    assert {
+        item.manifest_payload()["notional_multiplier"] for item in option_activities
+    } == {"10"}
+    assert projection_cash["USD"] == Decimal("1020")
+
+    with sessions.begin() as session:
+        session.execute(
+            update(_OPTION_CATALOG)
+            .where(_OPTION_CATALOG.c.contract_symbol == symbol)
+            .values(contract_size=20)
+        )
+    with sessions.begin() as session:
+        with pytest.raises(
+            EconomicLedgerError,
+            match="economic_ledger_option_contract_sizes_changed",
+        ):
+            publish_broker_economic_ledger(
+                session,
+                replay,
+                confirmation_token=replay.publication_token,
+            )
 
 
 def test_unsupported_dry_run_cannot_publish_partial_projection() -> None:

--- a/services/torghut/tests/economic_ledger/test_reconciliation.py
+++ b/services/torghut/tests/economic_ledger/test_reconciliation.py
@@ -53,6 +53,7 @@ def _activity(
     side: str | None = None,
     quantity: str | None = None,
     price: str | None = None,
+    contract_size: str | None = None,
     net_amount: str | None = None,
 ) -> EconomicActivity:
     return EconomicActivity(
@@ -66,6 +67,7 @@ def _activity(
         side=side,
         quantity=Decimal(quantity) if quantity is not None else None,
         price=Decimal(price) if price is not None else None,
+        contract_size=(Decimal(contract_size) if contract_size is not None else None),
         net_amount=Decimal(net_amount) if net_amount is not None else None,
         currency="USD",
     )
@@ -84,6 +86,16 @@ def _replay(*activities: EconomicActivity) -> BrokerEconomicLedgerReplay:
         activities=activities,
         input_manifest_canonical_json=json.dumps(
             ordered_manifest, sort_keys=True, separators=(",", ":")
+        ),
+        option_contract_sizes=tuple(
+            sorted(
+                {
+                    (item.canonical_symbol, int(item.notional_multiplier))
+                    for item in activities
+                    if item.contract_size is not None
+                    and item.canonical_symbol is not None
+                }
+            )
         ),
     )
     return BrokerEconomicLedgerReplay(
@@ -280,11 +292,12 @@ def test_option_position_reconciliation_uses_contract_notional() -> None:
             side="buy",
             quantity="2",
             price="1.05",
+            contract_size="50",
         ),
     )
     snapshot = _snapshot(
-        cash="790",
-        equity="1030",
+        cash="895",
+        equity="1015",
         positions=[
             {
                 "symbol": symbol,
@@ -292,8 +305,8 @@ def test_option_position_reconciliation_uses_contract_notional() -> None:
                 "qty": "2",
                 "avg_entry_price": "1.05",
                 "current_price": "1.20",
-                "market_value": "240",
-                "unrealized_pl": "30",
+                "market_value": "120",
+                "unrealized_pl": "15",
             }
         ],
     )

--- a/services/torghut/tests/economic_ledger/test_reconciliation.py
+++ b/services/torghut/tests/economic_ledger/test_reconciliation.py
@@ -268,6 +268,42 @@ def test_position_cost_and_unrealized_differences_are_not_tolerated() -> None:
     }
 
 
+def test_option_position_reconciliation_uses_contract_notional() -> None:
+    symbol = "AMZN260529P00270000"
+    replay = _replay(
+        _activity("cash", "CSD", offset=0, net_amount="1000"),
+        _activity(
+            "buy",
+            "FILL",
+            offset=1,
+            symbol=symbol,
+            side="buy",
+            quantity="2",
+            price="1.05",
+        ),
+    )
+    snapshot = _snapshot(
+        cash="790",
+        equity="1030",
+        positions=[
+            {
+                "symbol": symbol,
+                "side": "long",
+                "qty": "2",
+                "avg_entry_price": "1.05",
+                "current_price": "1.20",
+                "market_value": "240",
+                "unrealized_pl": "30",
+            }
+        ],
+    )
+
+    result = _result(replay, snapshot)
+
+    assert result.reconciled is True
+    assert result.residual_count == 0
+
+
 def test_broker_snapshot_rejects_duplicate_positions_and_incomplete_orders() -> None:
     position = {
         "symbol": "AAPL",


### PR DESCRIPTION
## Summary

- classify OCC option activities, then share-lock their exact per-contract size from Torghut's persisted Alpaca catalog and bind it into the immutable activity manifest
- apply option notional consistently in both independent reducers, then advance both reducer identities to v2 so prior v1 runs remain immutable
- apply the same manifest-bound size to broker cost-basis and mark-to-market reconciliation for open option positions
- fail closed on missing catalog metadata or a catalog-size change before publication; cover adjusted contracts, stock non-regression, manifest identity, versioning, and live-position reconciliation

## Related Issues

None.

## Testing

- `uv run --frozen pytest tests/economic_ledger -q` (69 passed)
- `uv run --frozen ruff format --check app/trading/economic_ledger tests/economic_ledger`
- `uv run --frozen ruff check app/trading/economic_ledger tests/economic_ledger`
- all five repository Pyright profiles (0 errors)
- Torghut structural, changed-line quality, changed-file design, file-length, tech-debt-ratchet, Vulture, compileall, and migration-lineage gates
- two read-only replays of all 40,161 production paper-account activity rows resolved both historical option symbols from CNPG at contract size 100 and produced 180,067 balanced entries with exact differential equivalence and identical digests; no rows were persisted
- the corrected dry replay reduces the current flat-account cash gap to $0.42329955898458; live deployment, v2 publication, and resolution of that remaining residual remain post-merge proof steps

## Breaking Changes

None. Existing v1 inputs and runs remain immutable; the changed input manifest and v2 reducer identities intentionally publish a new run pair.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
