### PR TITLE
fix(torghut): quantize broker fill cash

### DIFF
--- a/docs/torghut/profitability/independent-economic-ledger.md
+++ b/docs/torghut/profitability/independent-economic-ledger.md
@@ -43,6 +43,9 @@ account data:
 - the latest 100 fills contained both equities and crypto, buys and sells, and no broker-provided `net_amount`.
 - the full REST history contained 31 historical equity fills with `side=sell_short`, despite the current Alpaca
   activity documentation describing only `buy` and `sell`.
+- all 309,552 broker cash snapshots retained at audit time were cent-denominated. Time-aligned crypto round trips showed
+  that each broker cash movement equaled the sum of per-fill USD amounts rounded to cents plus separately accrued fees,
+  while a contemporaneous open position retained sub-cent `quantity * average_entry_price` cost basis.
 
 Therefore a credible projection must calculate fill notionals, account for order-independent regulatory fees, handle
 crypto fees charged in the received asset, and retain external cash journals. A fill-only realized-PnL counter is not
@@ -91,6 +94,12 @@ fractional digits or at least 20 integer digits fail closed instead of being sil
 an 80-digit local decimal context and persist every derived notional, released cost, carrying value, fee, and realized
 amount at 18 fractional digits using decimal `ROUND_HALF_UP`, matching Torghut's existing TigerBeetle conversion rule.
 
+Derived USD fill cash is the one narrower boundary: Alpaca books it at the currency quantum, so each fill is rounded
+with decimal `ROUND_HALF_UP` to `$0.01` after quantity, price, and any option multiplier are applied. The exact
+18-decimal notional remains the position-cost and realized-PnL input. Their difference is an explicit signed
+`cash_rounding` expense rather than hidden in cost basis or labeled as trading PnL. Unsupported quote currencies fail
+closed until their broker precision is established from authoritative evidence.
+
 Weighted-average partial closes round the released cost once. The retained position receives the exact residual carrying
 cost; a full close releases the complete remaining carrying cost without division. Realized PnL is the exact balancing
 residual of fixed-point cash and carrying-cost deltas. This keeps every commodity transaction exactly balanced and makes
@@ -109,6 +118,7 @@ USD accounts:
 - `asset:position_cost:<symbol>` for long inventory or a credit balance for short inventory;
 - `equity:external_flow` for deposits, withdrawals, and cash journals;
 - `income:realized_pnl`;
+- `expense:cash_rounding` for the signed difference between exact fill notional and broker-booked USD cash;
 - `income:dividend` and `income:interest`;
 - `expense:broker_fee`, `expense:regulatory_fee`, and `expense:withholding`;
 - `equity:corporate_action` only for an explicitly broker-reported cash or basis adjustment.
@@ -127,7 +137,8 @@ a derived mark, not historical cost and not a source mutation.
 ### Fills
 
 For each `FILL`, quantity and price must be positive, and side must be `buy`, `sell`, or the empirically observed
-historical `sell_short` alias. USD notional is `quantity * price * multiplier` with no binary floating point. The
+historical `sell_short` alias. Exact USD notional is `quantity * price * multiplier` with no binary floating point;
+the cash leg is then rounded once to the observed USD cent quantum, while cost basis retains exact notional. The
 OCC symbol shape identifies option activities, but it does not determine their multiplier. The exact contract size is
 copied under a share lock from Torghut's persisted Alpaca contract catalog and bound into every affected immutable input
 manifest; missing catalog metadata or a size change between dry run and publication fails closed. Alpaca exposes this
@@ -199,6 +210,7 @@ Each reducer emits the same immutable result shape:
 - cash by currency;
 - signed quantity, signed cost, and average cost by symbol;
 - realized PnL, fees, dividends, interest, external flows, and other supported adjustments;
+- signed cash rounding, separate from realized trading PnL and broker-reported fees;
 - optional marks, market value, unrealized PnL, and equity;
 - unsupported, corrected, duplicate, and contradiction counts;
 - deterministic transaction/result digests.
@@ -308,6 +320,7 @@ the audit path into an uncontrolled evidence writer.
 
 - balanced entries for every commodity and every supported activity;
 - partial fills, long and short reductions, side flips, and full round trips;
+- broker-cent cash rounding with exact sub-cent position cost, half-cent boundaries, and fractional randomized fills;
 - USD fees, regulatory fees, crypto asset fees, deposits, withdrawals, journals, dividends, and interest;
 - splits, symbol changes, corrections, correction chains, missing predecessors, and cycles;
 - duplicate-identical and duplicate-contradictory source identities;

--- a/docs/torghut/profitability/independent-economic-ledger.md
+++ b/docs/torghut/profitability/independent-economic-ledger.md
@@ -100,13 +100,17 @@ with decimal `ROUND_HALF_UP` to `$0.01` after quantity, price, and any option mu
 `cash_rounding` expense rather than hidden in cost basis or labeled as trading PnL. Unsupported quote currencies fail
 closed until their broker precision is established from authoritative evidence.
 
+A nonzero exact fill whose broker cash rounds to zero remains admissible: it omits the zero cash line and balances exact
+position cost against signed cash rounding. Only an exact notional below the 18-decimal ledger quantum fails closed.
+
 Weighted-average partial closes round the released cost once. The retained position receives the exact residual carrying
 cost; a full close releases the complete remaining carrying cost without division. Realized PnL is the exact balancing
 residual of fixed-point cash and carrying-cost deltas. This keeps every commodity transaction exactly balanced and makes
 the two reducers comparable without an epsilon while avoiding context-dependent repeating-decimal dust.
 
 A nonzero fill notional or asset-fee fair value that rounds below the 18-decimal ledger quantum is rejected before any
-position mutation. Nonzero units can never enter the projection with zero cash, zero cost, or zero fee economics.
+position mutation. Nonzero units can never enter the projection without exact cost and explicit rounding or fee
+economics.
 
 ## Chart Of Accounts And Commodities
 

--- a/services/torghut/app/trading/economic_ledger/comparison.py
+++ b/services/torghut/app/trading/economic_ledger/comparison.py
@@ -127,6 +127,7 @@ def compare_projections(
 
     for field_name in (
         "realized_pnl",
+        "cash_rounding",
         "fees",
         "dividends",
         "interest",

--- a/services/torghut/app/trading/economic_ledger/journal_reducer.py
+++ b/services/torghut/app/trading/economic_ledger/journal_reducer.py
@@ -19,12 +19,13 @@ from .types import (
     balances_tuple,
     positions_tuple,
     prepare_activities,
+    quantize_broker_cash,
     quantize_ledger_decimal,
 )
 
 
 JOURNAL_REDUCER_NAME = "balanced_journal"
-JOURNAL_REDUCER_VERSION = "torghut.broker-economic-journal.v2"
+JOURNAL_REDUCER_VERSION = "torghut.broker-economic-journal.v3"
 
 _MAX_TRANSACTION_ID_LENGTH = 512
 _REVERSAL_TRANSACTION_ID_PREFIX = "correction-reversal:sha256:"
@@ -56,6 +57,7 @@ class _Position:
 class _FillPosting:
     delta_quantity: Decimal
     cash_delta: Decimal
+    cash_rounding: Decimal
     position_cost_delta: Decimal
     realized: Decimal
     new_quantity: Decimal
@@ -169,6 +171,7 @@ class _JournalWriter:
             position,
             delta_quantity,
             price * activity.notional_multiplier,
+            quote_currency=self.prepared.scope.quote_currency,
         )
         if posting.cash_delta == ZERO:
             raise EconomicLedgerError("economic_fill_notional_below_ledger_quantum")
@@ -194,6 +197,11 @@ class _JournalWriter:
                     "income:realized_pnl",
                     self.prepared.scope.quote_currency,
                     -posting.realized,
+                ),
+                _line(
+                    "expense:cash_rounding",
+                    self.prepared.scope.quote_currency,
+                    posting.cash_rounding,
                 ),
                 _line(
                     f"asset:position_units:{symbol}",
@@ -343,13 +351,24 @@ def _build_fill_posting(
     position: _Position,
     delta_quantity: Decimal,
     price: Decimal,
+    *,
+    quote_currency: str,
 ) -> _FillPosting:
-    cash_delta = quantize_ledger_decimal(
+    economic_cash_delta = quantize_ledger_decimal(
         -delta_quantity * price,
+        field_name="fill_economic_cash_delta",
+    )
+    cash_delta = quantize_broker_cash(
+        economic_cash_delta,
+        currency=quote_currency,
         field_name="fill_cash_delta",
     )
+    cash_rounding = quantize_ledger_decimal(
+        economic_cash_delta - cash_delta,
+        field_name="fill_cash_rounding",
+    )
     if position.quantity == ZERO or position.quantity * delta_quantity > ZERO:
-        position_cost_delta = -cash_delta
+        position_cost_delta = -economic_cash_delta
     else:
         position_cost_delta = _opposite_fill_position_cost_delta(
             position,
@@ -357,7 +376,7 @@ def _build_fill_posting(
             price,
         )
     realized = quantize_ledger_decimal(
-        cash_delta + position_cost_delta,
+        economic_cash_delta + position_cost_delta,
         field_name="fill_realized_pnl",
     )
     new_quantity = quantize_ledger_decimal(
@@ -375,6 +394,7 @@ def _build_fill_posting(
     return _FillPosting(
         delta_quantity=delta_quantity,
         cash_delta=cash_delta,
+        cash_rounding=cash_rounding,
         position_cost_delta=position_cost_delta,
         realized=realized,
         new_quantity=new_quantity,
@@ -436,6 +456,7 @@ def _projection_from_journal(
     quantities: dict[str, Decimal] = {}
     costs: dict[str, Decimal] = {}
     realized_pnl = ZERO
+    cash_rounding = ZERO
     fees = ZERO
     dividends = ZERO
     interest = ZERO
@@ -452,6 +473,8 @@ def _projection_from_journal(
                 quantities[symbol] = quantities.get(symbol, ZERO) + line.amount
             elif line.account == "income:realized_pnl":
                 realized_pnl -= line.amount
+            elif line.account == "expense:cash_rounding":
+                cash_rounding += line.amount
             elif line.account in {
                 "expense:broker_fee",
                 "expense:regulatory_fee",
@@ -475,6 +498,7 @@ def _projection_from_journal(
         cash=balances_tuple(cash),
         positions=positions_tuple(quantities, costs),
         realized_pnl=realized_pnl,
+        cash_rounding=cash_rounding,
         fees=fees,
         dividends=dividends,
         interest=interest,

--- a/services/torghut/app/trading/economic_ledger/journal_reducer.py
+++ b/services/torghut/app/trading/economic_ledger/journal_reducer.py
@@ -173,8 +173,6 @@ class _JournalWriter:
             price * activity.notional_multiplier,
             quote_currency=self.prepared.scope.quote_currency,
         )
-        if posting.cash_delta == ZERO:
-            raise EconomicLedgerError("economic_fill_notional_below_ledger_quantum")
         if posting.new_quantity != ZERO and posting.new_cost == ZERO:
             raise EconomicLedgerError(
                 "economic_fill_position_cost_below_ledger_quantum"
@@ -358,6 +356,8 @@ def _build_fill_posting(
         -delta_quantity * price,
         field_name="fill_economic_cash_delta",
     )
+    if economic_cash_delta == ZERO:
+        raise EconomicLedgerError("economic_fill_notional_below_ledger_quantum")
     cash_delta = quantize_broker_cash(
         economic_cash_delta,
         currency=quote_currency,

--- a/services/torghut/app/trading/economic_ledger/state_reducer.py
+++ b/services/torghut/app/trading/economic_ledger/state_reducer.py
@@ -15,12 +15,13 @@ from .types import (
     balances_tuple,
     positions_tuple,
     prepare_activities,
+    quantize_broker_cash,
     quantize_ledger_decimal,
 )
 
 
 STATE_REDUCER_NAME = "independent_position_state"
-STATE_REDUCER_VERSION = "torghut.broker-economic-state.v2"
+STATE_REDUCER_VERSION = "torghut.broker-economic-state.v3"
 
 _EXTERNAL_FLOW_TYPES = frozenset({"ACATC", "CSD", "CSW", "JNLC", "TRANS"})
 _DIVIDEND_ACTIVITY_TYPES = frozenset(
@@ -50,6 +51,7 @@ class _StateReducer:
         self.cash: dict[str, Decimal] = {}
         self.holdings: dict[str, _Holding] = {}
         self.realized_pnl = ZERO
+        self.cash_rounding = ZERO
         self.fees = ZERO
         self.dividends = ZERO
         self.interest = ZERO
@@ -81,6 +83,7 @@ class _StateReducer:
                 },
             ),
             realized_pnl=self.realized_pnl,
+            cash_rounding=self.cash_rounding,
             fees=self.fees,
             dividends=self.dividends,
             interest=self.interest,
@@ -165,8 +168,13 @@ class _StateReducer:
 
         holding = self.holdings.setdefault(symbol, _Holding())
         previous_value = holding.carrying_value
-        cash_change = quantize_ledger_decimal(
+        economic_cash_change = quantize_ledger_decimal(
             -order_units * price * activity.notional_multiplier,
+            field_name="fill_economic_cash_delta",
+        )
+        cash_change = quantize_broker_cash(
+            economic_cash_change,
+            currency=self.prepared.scope.quote_currency,
             field_name="fill_cash_delta",
         )
         if cash_change == ZERO:
@@ -175,7 +183,7 @@ class _StateReducer:
             holding,
             order_units,
             price * activity.notional_multiplier,
-            cash_change,
+            economic_cash_change,
         )
         if next_units != ZERO and next_value == ZERO:
             raise EconomicLedgerError(
@@ -185,8 +193,14 @@ class _StateReducer:
         holding.units = next_units
         holding.carrying_value = next_value
         self.realized_pnl = quantize_ledger_decimal(
-            self.realized_pnl + cash_change + (holding.carrying_value - previous_value),
+            self.realized_pnl
+            + economic_cash_change
+            + (holding.carrying_value - previous_value),
             field_name="realized_pnl",
+        )
+        self.cash_rounding = quantize_ledger_decimal(
+            self.cash_rounding + economic_cash_change - cash_change,
+            field_name="cash_rounding",
         )
 
     def _crypto_fee(self, activity: EconomicActivity) -> None:

--- a/services/torghut/app/trading/economic_ledger/state_reducer.py
+++ b/services/torghut/app/trading/economic_ledger/state_reducer.py
@@ -172,13 +172,13 @@ class _StateReducer:
             -order_units * price * activity.notional_multiplier,
             field_name="fill_economic_cash_delta",
         )
+        if economic_cash_change == ZERO:
+            raise EconomicLedgerError("economic_fill_notional_below_ledger_quantum")
         cash_change = quantize_broker_cash(
             economic_cash_change,
             currency=self.prepared.scope.quote_currency,
             field_name="fill_cash_delta",
         )
-        if cash_change == ZERO:
-            raise EconomicLedgerError("economic_fill_notional_below_ledger_quantum")
         next_units, next_value = _next_holding(
             holding,
             order_units,
@@ -189,7 +189,8 @@ class _StateReducer:
             raise EconomicLedgerError(
                 "economic_fill_position_cost_below_ledger_quantum"
             )
-        self._add_cash(activity, cash_change)
+        if cash_change != ZERO:
+            self._add_cash(activity, cash_change)
         holding.units = next_units
         holding.carrying_value = next_value
         self.realized_pnl = quantize_ledger_decimal(

--- a/services/torghut/app/trading/economic_ledger/types.py
+++ b/services/torghut/app/trading/economic_ledger/types.py
@@ -15,6 +15,7 @@ ZERO = Decimal("0")
 LEDGER_DECIMAL_PRECISION = 80
 LEDGER_DECIMAL_SCALE = 18
 LEDGER_QUANTUM = Decimal("0.000000000000000001")
+_USD_CASH_QUANTUM = Decimal("0.01")
 _LEDGER_ABSOLUTE_LIMIT = Decimal("100000000000000000000")
 _UNIT_NOTIONAL_MULTIPLIER = Decimal("1")
 _OCC_OPTION_SYMBOL = re.compile(r"^[A-Z0-9]{1,6}[0-9]{6}[CP][0-9]{8}$")
@@ -384,6 +385,7 @@ class EconomicProjection:
     cash: tuple[CommodityBalance, ...]
     positions: tuple[PositionBalance, ...]
     realized_pnl: Decimal
+    cash_rounding: Decimal
     fees: Decimal
     dividends: Decimal
     interest: Decimal
@@ -394,6 +396,7 @@ class EconomicProjection:
     def __post_init__(self) -> None:
         for field_name in (
             "realized_pnl",
+            "cash_rounding",
             "fees",
             "dividends",
             "interest",
@@ -420,6 +423,7 @@ class EconomicProjection:
             "cash": {
                 balance.commodity: decimal_text(balance.amount) for balance in self.cash
             },
+            "cash_rounding": decimal_text(self.cash_rounding),
             "corrected_count": self.corrected_count,
             "dividends": decimal_text(self.dividends),
             "duplicate_count": self.duplicate_count,
@@ -599,12 +603,34 @@ def quantize_ledger_decimal(
 ) -> Decimal:
     """Round one derived value to the durable NUMERIC(38, 18) contract."""
 
+    return _quantize_decimal(value, quantum=LEDGER_QUANTUM, field_name=field_name)
+
+
+def quantize_broker_cash(
+    value: Decimal,
+    *,
+    currency: str,
+    field_name: str = "broker_cash",
+) -> Decimal:
+    """Round a derived broker cash movement to the observed currency precision."""
+
+    if currency != "USD":
+        raise EconomicLedgerError("economic_broker_cash_currency_unsupported")
+    return _quantize_decimal(value, quantum=_USD_CASH_QUANTUM, field_name=field_name)
+
+
+def _quantize_decimal(
+    value: Decimal,
+    *,
+    quantum: Decimal,
+    field_name: str,
+) -> Decimal:
     if not value.is_finite():
         raise EconomicLedgerError(f"economic_ledger_{field_name}_invalid")
     with localcontext() as context:
         context.prec = LEDGER_DECIMAL_PRECISION
         try:
-            quantized = value.quantize(LEDGER_QUANTUM, rounding=ROUND_HALF_UP)
+            quantized = value.quantize(quantum, rounding=ROUND_HALF_UP)
         except InvalidOperation as exc:
             raise EconomicLedgerError(
                 f"economic_ledger_{field_name}_out_of_range"

--- a/services/torghut/tests/economic_ledger/test_cash_quantization.py
+++ b/services/torghut/tests/economic_ledger/test_cash_quantization.py
@@ -95,6 +95,40 @@ def test_fill_cash_half_cent_rounds_away_from_zero(
     assert abs(aapl.signed_cost) == Decimal("1.005")
 
 
+def test_subcent_fill_with_zero_booked_cash_remains_balanced() -> None:
+    result = reduce_and_compare(
+        [
+            activity(
+                "subcent-fill",
+                "FILL",
+                symbol="AAPL",
+                side="buy",
+                quantity="1",
+                price="0.004",
+                net_amount=None,
+            )
+        ]
+    )
+
+    assert result.admissible
+    assert result.comparison.equivalent
+    assert cash(result.journal.projection) == Decimal("0")
+    assert result.journal.projection.cash_rounding == Decimal("-0.004")
+    aapl = position(result.journal.projection, "AAPL")
+    assert aapl is not None
+    assert aapl.signed_cost == Decimal("0.004")
+    transaction = result.journal.transactions[0]
+    assert all(line.account != "asset:cash" for line in transaction.lines)
+    assert all(
+        sum(
+            (line.amount for line in transaction.lines if line.commodity == commodity),
+            start=Decimal("0"),
+        )
+        == Decimal("0")
+        for commodity in {line.commodity for line in transaction.lines}
+    )
+
+
 def test_fill_cash_rejects_unproved_quote_currency_precision() -> None:
     unsupported_scope = LedgerScope(
         provider=SCOPE.provider,

--- a/services/torghut/tests/economic_ledger/test_cash_quantization.py
+++ b/services/torghut/tests/economic_ledger/test_cash_quantization.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from decimal import Decimal
+
+import pytest
+
+from app.trading.economic_ledger import (
+    EconomicLedgerError,
+    LedgerScope,
+    reduce_and_compare,
+    reduce_balanced_journal,
+    reduce_independent_state,
+)
+from tests.economic_ledger.support import SCOPE, activity, cash, position
+
+
+def test_fill_cash_uses_broker_cents_without_rounding_position_cost() -> None:
+    result = reduce_and_compare(
+        [
+            activity(
+                "crypto-buy",
+                "FILL",
+                symbol="BTCUSD",
+                side="buy",
+                quantity="1",
+                price="29.21760773",
+                net_amount=None,
+            ),
+            activity(
+                "crypto-sell",
+                "FILL",
+                event_offset_seconds=1,
+                symbol="BTCUSD",
+                side="sell",
+                quantity="1",
+                price="29.12097393",
+                net_amount=None,
+            ),
+        ]
+    )
+
+    assert result.admissible
+    assert result.comparison.equivalent
+    assert cash(result.journal.projection) == Decimal("-0.10")
+    assert result.journal.projection.realized_pnl == Decimal("-0.0966338")
+    assert result.journal.projection.cash_rounding == Decimal("0.0033662")
+    assert position(result.journal.projection, "BTCUSD") is None
+    assert [
+        line.amount
+        for transaction in result.journal.transactions
+        for line in transaction.lines
+        if line.account == "asset:cash"
+    ] == [Decimal("-29.22"), Decimal("29.12")]
+    assert [
+        line.amount
+        for transaction in result.journal.transactions
+        for line in transaction.lines
+        if line.account == "expense:cash_rounding"
+    ] == [Decimal("0.00239227"), Decimal("0.00097393")]
+
+
+@pytest.mark.parametrize(
+    ("side", "expected_cash", "expected_rounding"),
+    [
+        ("buy", Decimal("-1.01"), Decimal("0.005")),
+        ("sell", Decimal("1.01"), Decimal("-0.005")),
+    ],
+)
+def test_fill_cash_half_cent_rounds_away_from_zero(
+    side: str,
+    expected_cash: Decimal,
+    expected_rounding: Decimal,
+) -> None:
+    result = reduce_and_compare(
+        [
+            activity(
+                f"half-cent-{side}",
+                "FILL",
+                symbol="AAPL",
+                side=side,
+                quantity="1",
+                price="1.005",
+                net_amount=None,
+            )
+        ]
+    )
+
+    assert result.admissible
+    assert result.comparison.equivalent
+    assert cash(result.journal.projection) == expected_cash
+    assert result.journal.projection.cash_rounding == expected_rounding
+    aapl = position(result.journal.projection, "AAPL")
+    assert aapl is not None
+    assert abs(aapl.signed_cost) == Decimal("1.005")
+
+
+def test_fill_cash_rejects_unproved_quote_currency_precision() -> None:
+    unsupported_scope = LedgerScope(
+        provider=SCOPE.provider,
+        environment=SCOPE.environment,
+        account_label=SCOPE.account_label,
+        endpoint_fingerprint=SCOPE.endpoint_fingerprint,
+        quote_currency="BTC",
+    )
+    fill = replace(
+        activity(
+            "unsupported-cash-precision",
+            "FILL",
+            symbol="ETH/BTC",
+            side="buy",
+            quantity="1",
+            price="0.1",
+            currency="BTC",
+            net_amount=None,
+        ),
+        scope=unsupported_scope,
+    )
+
+    for reducer in (reduce_balanced_journal, reduce_independent_state):
+        with pytest.raises(
+            EconomicLedgerError,
+            match="economic_broker_cash_currency_unsupported",
+        ):
+            reducer([fill])

--- a/services/torghut/tests/economic_ledger/test_differential_properties.py
+++ b/services/torghut/tests/economic_ledger/test_differential_properties.py
@@ -52,3 +52,48 @@ def test_random_fill_sequences_have_zero_differential(
         for transaction in result.journal.transactions
         for commodity in {line.commodity for line in transaction.lines}
     )
+
+
+@settings(max_examples=100, deadline=None)
+@given(
+    fills=st.lists(
+        st.tuples(
+            st.sampled_from(("buy", "sell")),
+            st.integers(min_value=1, max_value=2_500),
+            st.integers(min_value=1_000, max_value=500_000),
+        ),
+        min_size=1,
+        max_size=40,
+    )
+)
+def test_fractional_fill_cash_rounding_has_zero_differential(
+    fills: list[tuple[str, int, int]],
+) -> None:
+    rows = [activity("capital", "JNLC", net_amount="1000000")]
+    rows.extend(
+        activity(
+            f"fractional-fill-{index}",
+            "FILL",
+            event_offset_seconds=index + 1,
+            symbol="BTCUSD",
+            side=side,
+            quantity=str(Decimal(quantity_hundredths) / Decimal("100")),
+            price=str(Decimal(price_thousandths) / Decimal("1000")),
+            net_amount=None,
+        )
+        for index, (side, quantity_hundredths, price_thousandths) in enumerate(fills)
+    )
+
+    result = reduce_and_compare(rows)
+
+    assert result.admissible
+    assert result.comparison.equivalent
+    assert all(
+        sum(
+            (line.amount for line in transaction.lines if line.commodity == commodity),
+            start=Decimal("0"),
+        )
+        == Decimal("0")
+        for transaction in result.journal.transactions
+        for commodity in {line.commodity for line in transaction.lines}
+    )

--- a/services/torghut/tests/economic_ledger/test_dual_reducers.py
+++ b/services/torghut/tests/economic_ledger/test_dual_reducers.py
@@ -151,7 +151,7 @@ def test_side_flip_cannot_open_nonzero_units_with_zero_cost() -> None:
             symbol="AAPL",
             side="buy",
             quantity="1.000000000000000001",
-            price="0.000000000000000001",
+            price="0.4",
             net_amount=None,
         ),
     ]

--- a/services/torghut/tests/economic_ledger/test_option_multiplier.py
+++ b/services/torghut/tests/economic_ledger/test_option_multiplier.py
@@ -42,8 +42,8 @@ def test_option_fill_cash_and_cost_use_the_explicit_contract_size() -> None:
     )
 
     assert buy.manifest_payload()["notional_multiplier"] == "10"
-    assert JOURNAL_REDUCER_VERSION == "torghut.broker-economic-journal.v2"
-    assert STATE_REDUCER_VERSION == "torghut.broker-economic-state.v2"
+    assert JOURNAL_REDUCER_VERSION == "torghut.broker-economic-journal.v3"
+    assert STATE_REDUCER_VERSION == "torghut.broker-economic-state.v3"
     assert result.admissible
     assert result.comparison.equivalent
     assert cash(result.journal.projection) == Decimal("3")


### PR DESCRIPTION
## Summary

- Quantize derived Alpaca USD fill cash to broker-booked cents while retaining exact sub-cent position cost and realized trading PnL.
- Record the signed difference in an explicit `expense:cash_rounding` projection field and bump both immutable reducers to v3.
- Add live-derived, half-cent, unsupported-currency, and randomized fractional regression coverage; document the audited broker precision contract.

## Related Issues

None

## Testing

- `.venv/bin/pytest tests/economic_ledger -q` — 74 passed.
- `.venv/bin/ruff check app/trading/economic_ledger tests/economic_ledger`
- `.venv/bin/ruff format --check app/trading/economic_ledger tests/economic_ledger`
- All five Pyright project profiles — 0 errors.
- Pylint structural, changed-line, design, and file-length gates.
- Torghut tech-debt ratchet, migration graph, Vulture, compileall, and `git diff --check`.
- Read-only production-size replay over 40,161 immutable activities: 195,170 balanced entries, zero unsupported activities, exact dual-reducer equality, and broker cash difference reduced to the exact $0.40 accrued-fee timing bucket.

## Breaking Changes

Reducer identities advance from v2 to v3. Existing immutable v1/v2 evidence remains unchanged; production must publish a new v3 run pair before v3 observation. No database migration, broker mutation, order-path change, or capital-gate relaxation is included.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation and operational follow-up are updated.