### PR TITLE
chore(torghut): promote image sha-789efe793641b1e1819e5b419065eda2662756f1

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -54,7 +54,7 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: 31ccf69134d57ddd3cf33d2f600783f0fc392536
+              value: 789efe793641b1e1819e5b419065eda2662756f1
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:b0d22e4e4c4f5ec5fbbe0fe94d7259292d8b1712e75dc7a61d3a22b554fcaf02
             - name: PYTHONPATH

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -46,7 +46,7 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: 31ccf69134d57ddd3cf33d2f600783f0fc392536
+              value: 789efe793641b1e1819e5b419065eda2662756f1
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:b0d22e4e4c4f5ec5fbbe0fe94d7259292d8b1712e75dc7a61d3a22b554fcaf02
             - name: DB_DSN

--- a/argocd/applications/torghut-options/archive/deployment.yaml
+++ b/argocd/applications/torghut-options/archive/deployment.yaml
@@ -100,9 +100,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2149-g31ccf6913
+              value: v0.596.0-2151-g789efe793
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 31ccf69134d57ddd3cf33d2f600783f0fc392536
+              value: 789efe793641b1e1819e5b419065eda2662756f1
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -110,9 +110,9 @@ spec:
                   name: torghut-ws-config
                   key: SYMBOLS_ALLOWLIST
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2149-g31ccf6913
+              value: v0.596.0-2151-g789efe793
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 31ccf69134d57ddd3cf33d2f600783f0fc392536
+              value: 789efe793641b1e1819e5b419065eda2662756f1
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -106,9 +106,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2149-g31ccf6913
+              value: v0.596.0-2151-g789efe793
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 31ccf69134d57ddd3cf33d2f600783f0fc392536
+              value: 789efe793641b1e1819e5b419065eda2662756f1
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/broker-economic-ledger-reconciliation-cronjob.yaml
+++ b/argocd/applications/torghut/broker-economic-ledger-reconciliation-cronjob.yaml
@@ -82,9 +82,9 @@ spec:
                 - name: TRADING_ACCOUNT_LABEL
                   value: PA3SX7FYNUTF
                 - name: TORGHUT_VERSION
-                  value: v0.596.0-2149-g31ccf6913
+                  value: v0.596.0-2151-g789efe793
                 - name: TORGHUT_COMMIT
-                  value: 31ccf69134d57ddd3cf33d2f600783f0fc392536
+                  value: 789efe793641b1e1819e5b419065eda2662756f1
                 - name: TORGHUT_IMAGE_DIGEST
                   value: sha256:b0d22e4e4c4f5ec5fbbe0fe94d7259292d8b1712e75dc7a61d3a22b554fcaf02
                 - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-17T04:57:11Z"
+        client.knative.dev/updateTimestamp: "2026-07-17T05:20:24Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -507,9 +507,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2149-g31ccf6913
+              value: v0.596.0-2151-g789efe793
             - name: TORGHUT_COMMIT
-              value: 31ccf69134d57ddd3cf33d2f600783f0fc392536
+              value: 789efe793641b1e1819e5b419065eda2662756f1
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:b0d22e4e4c4f5ec5fbbe0fe94d7259292d8b1712e75dc7a61d3a22b554fcaf02
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-17T04:57:11Z"
+        client.knative.dev/updateTimestamp: "2026-07-17T05:20:24Z"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
     spec:
@@ -444,9 +444,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2149-g31ccf6913
+              value: v0.596.0-2151-g789efe793
             - name: TORGHUT_COMMIT
-              value: 31ccf69134d57ddd3cf33d2f600783f0fc392536
+              value: 789efe793641b1e1819e5b419065eda2662756f1
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:b0d22e4e4c4f5ec5fbbe0fe94d7259292d8b1712e75dc7a61d3a22b554fcaf02
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/order-lineage-reconciliation-cronjob.yaml
+++ b/argocd/applications/torghut/order-lineage-reconciliation-cronjob.yaml
@@ -88,9 +88,9 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_VERSION
-                  value: v0.596.0-2149-g31ccf6913
+                  value: v0.596.0-2151-g789efe793
                 - name: TORGHUT_COMMIT
-                  value: 31ccf69134d57ddd3cf33d2f600783f0fc392536
+                  value: 789efe793641b1e1819e5b419065eda2662756f1
                 - name: TORGHUT_IMAGE_DIGEST
                   value: sha256:b0d22e4e4c4f5ec5fbbe0fe94d7259292d8b1712e75dc7a61d3a22b554fcaf02
                 - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -460,9 +460,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2149-g31ccf6913
+              value: v0.596.0-2151-g789efe793
             - name: TORGHUT_COMMIT
-              value: 31ccf69134d57ddd3cf33d2f600783f0fc392536
+              value: 789efe793641b1e1819e5b419065eda2662756f1
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:b0d22e4e4c4f5ec5fbbe0fe94d7259292d8b1712e75dc7a61d3a22b554fcaf02
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `789efe793641b1e1819e5b419065eda2662756f1`
- Image tag: `sha-789efe793641b1e1819e5b419065eda2662756f1`
- Image digest: `sha256:b0d22e4e4c4f5ec5fbbe0fe94d7259292d8b1712e75dc7a61d3a22b554fcaf02`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher