### PR TITLE
feat(torghut): enforce broker economic TigerBeetle parity

### DIFF
--- a/argocd/applications/torghut/broker-economic-ledger-reconciliation-cronjob.yaml
+++ b/argocd/applications/torghut/broker-economic-ledger-reconciliation-cronjob.yaml
@@ -57,6 +57,14 @@ spec:
                   value: "1"
                 - name: APP_ENV
                   value: prod
+                - name: TORGHUT_TIGERBEETLE_ENABLED
+                  value: "true"
+                - name: TORGHUT_TIGERBEETLE_CLUSTER_ID
+                  value: "2001"
+                - name: TORGHUT_TIGERBEETLE_REPLICA_ADDRESSES
+                  value: torghut-tigerbeetle.torghut.svc.cluster.local:3000
+                - name: TORGHUT_TIGERBEETLE_RPC_TIMEOUT_SECONDS
+                  value: "30"
                 - name: DB_DSN
                   valueFrom:
                     secretKeyRef:
@@ -96,5 +104,6 @@ spec:
                 - scripts/replay_broker_economic_ledger.py
               args:
                 - --observe
+                - --tigerbeetle-parity
                 - --max-source-age-seconds
                 - "300"

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -90,6 +90,8 @@ spec:
               value: "true"
             - name: TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED
               value: "false"
+            - name: TORGHUT_TIGERBEETLE_ECONOMIC_PARITY_REQUIRED
+              value: "false"
             - name: APCA_API_KEY_ID
               valueFrom:
                 secretKeyRef:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -101,6 +101,8 @@ spec:
               value: "true"
             - name: TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED
               value: "false"
+            - name: TORGHUT_TIGERBEETLE_ECONOMIC_PARITY_REQUIRED
+              value: "true"
             - name: APCA_API_KEY_ID
               valueFrom:
                 secretKeyRef:

--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -119,6 +119,8 @@ spec:
               value: "true"
             - name: TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED
               value: "false"
+            - name: TORGHUT_TIGERBEETLE_ECONOMIC_PARITY_REQUIRED
+              value: "true"
             - name: APCA_API_KEY_ID
               valueFrom:
                 secretKeyRef:

--- a/docs/torghut/profitability/README.md
+++ b/docs/torghut/profitability/README.md
@@ -43,6 +43,8 @@ readback. The audit snapshot records what was observed at its stated time.
   permits, cancel/replace/close invariants, causal identity, fault schedules, and live proof contract.
 - [Order and fill lineage repair receipts](order-lineage-repair-receipts.md): append-only order-level repair evidence,
   explicit residual classifications, and a permanent non-promotion boundary.
+- [Full broker-economic TigerBeetle parity](tigerbeetle-economic-parity.md): exact versioned projection, linked-chain
+  materialization, full readback, sealed evidence, entry-only enforcement, and rollout proof.
 - [Implementation roadmap](implementation-roadmap.md): ordered PR-sized delivery slices, tests, rollout proof,
   dependencies, and rollback posture.
 - [Slice 3 production evidence](evidence/slice-03-autoresearch-completion-2026-07-14.md): committed revision, CI and

--- a/docs/torghut/profitability/implementation-roadmap.md
+++ b/docs/torghut/profitability/implementation-roadmap.md
@@ -257,12 +257,15 @@ rather than silently excluded.
 
 **Invariant:** protocol health and journal writes are not accepted as proof of economic parity.
 
+Detailed design: [Full Broker-Economic TigerBeetle Parity](tigerbeetle-economic-parity.md).
+
 - Deliverable: reconcile the full broker-derived economic projection against TigerBeetle balances/transfers, publish
   source watermark and age, and make freshness plus zero unexplained settled delta blocking dependencies for
   `entry_allowed`, accounting authority, and promotion. They must not make `service_healthy` or Kubernetes readiness
   false while the control/recovery endpoint can still serve safely.
-- Primary surfaces: `services/torghut/scripts/audit_tigerbeetle_runtime_ledger_parity.py`, verification scripts,
-  `argocd/applications/torghut/tigerbeetle-smoke-job.yaml`, scheduler entry/status projections, and GitOps schedules.
+- Primary surfaces: the broker-economic ledger package and replay/observation CLI, the existing append-only
+  reconciliation result, scheduler entry/status projections, strategy-capital pre-broker checks, and the existing
+  broker-economic GitOps schedule.
 - Tests: missing transfers, duplicate transfers, stale watermark, source lag, correction events, and protocol-up/parity-
   down behavior.
 - Runtime proof: scheduled parity completes from the broker event watermark through both ledgers and fails closed when a

--- a/docs/torghut/profitability/independent-economic-ledger.md
+++ b/docs/torghut/profitability/independent-economic-ledger.md
@@ -296,10 +296,10 @@ are then inserted atomically. Any trigger failure rolls back the input, entries,
 ## Status And Capital Boundary
 
 Slice 8 exposes freshness, input watermark, immutable run IDs, reducer versions, build identity, admissibility, broker
-snapshot digest, and classified residuals in the trading status response. The surface is diagnostic-only: no value from
-it is consulted by order submission or capital authority. It does not by itself enable entry or promotion. Slice 10
-will make fresh zero-unexplained-delta parity blocking for risk increase while leaving service health and reduce-only
-recovery available.
+snapshot digest, and classified residuals in the trading status response. Slice 10 composes that broker result with a
+sealed full TigerBeetle projection and consumes the combined status as a blocking dependency for risk increase and
+promotion. The combined result is not a capital grant. Service health and reduce-only recovery remain separate and
+available under their existing contracts.
 
 The existing runtime ledger remains visible as a legacy decision-lineage projection until Slice 9 completes repair. It
 is never silently relabeled as the broker-economic ledger.

--- a/docs/torghut/profitability/tigerbeetle-economic-parity.md
+++ b/docs/torghut/profitability/tigerbeetle-economic-parity.md
@@ -1,0 +1,262 @@
+# Full Broker-Economic TigerBeetle Parity
+
+Status: normative Slice 10 design; implementation must still complete CI, image promotion, GitOps reconciliation, and
+production proof before this slice is complete.
+
+## Decision
+
+Torghut projects the immutable, independently reduced broker-economic journal into TigerBeetle and proves the entire
+projection by exact account and transfer readback. Protocol reachability, successful journal calls, legacy runtime-ledger
+samples, and bounded recent rows are not economic parity.
+
+The implementation extends the existing broker-economic observation path. It does not add another service, queue,
+cursor, approval system, generic accounting framework, or per-transfer PostgreSQL shadow index. The immutable journal is
+already the complete source of expected TigerBeetle identities, so a second mutable reference store would add another
+authority and another reconciliation problem.
+
+Full, fresh, zero-residual parity is a necessary dependency for risk-increasing Alpaca entry and later promotion. It is
+not a capital grant. It never makes Kubernetes readiness or `service_healthy` false, never disables strictly
+exposure-reducing actions, and never disables recovery.
+
+## Upstream Semantics
+
+The design follows TigerBeetle's native contracts:
+
+- [Requests](https://docs.tigerbeetle.com/coding/requests/) are committed as batches, create events are idempotent, and
+  the default create/lookup batch limit is 8,189 events.
+- [Accounts](https://docs.tigerbeetle.com/reference/account/) are immutable except for cumulative debit and credit
+  balances; account IDs are cluster-wide and ledgers partition which accounts may transact.
+- [Transfers](https://docs.tigerbeetle.com/reference/transfer/) are immutable, cluster-wide identities between one debit
+  and one credit account on the same ledger.
+- [Multi-debit, multi-credit transfers](https://docs.tigerbeetle.com/coding/recipes/multi-debit-credit-transfers/) use
+  linked transfer chains so one broker-economic journal transaction is atomic.
+- [Currency exchange](https://docs.tigerbeetle.com/coding/recipes/currency-exchange/) requires distinct ledgers for
+  distinct commodities. Torghut therefore never mixes USD, an equity unit, a crypto unit, or another commodity in one
+  TigerBeetle ledger.
+
+## Authority Chain
+
+The exact dependency chain is:
+
+1. the broker account-activity REST cursor closes a source watermark;
+2. raw immutable activity bytes and hashes define one manifest;
+3. the canonical journal reducer and independent state reducer are admissible and exactly equivalent;
+4. the exact reducer pair has already been published as immutable CNPG runs;
+5. the journal projection is materialized in TigerBeetle using deterministic versioned IDs;
+6. every expected account and transfer is read back and compared exactly;
+7. the parity payload is bound to the source watermark, manifest, reducer, journal, published run IDs, cluster, and
+   observation time;
+8. broker-state reconciliation and TigerBeetle parity are sealed together in one append-only reconciliation result;
+9. only a current observation with broker reconciliation and TigerBeetle parity both true satisfies the entry and
+   promotion dependencies;
+10. a separate valid strategy-capital authority and every other runtime gate are still required before broker I/O.
+
+No step infers a later step. In particular, `parity=true` does not mean the strategy is profitable, statistically valid,
+approved for capital, or presently allowed to submit.
+
+## Deterministic Projection
+
+### Versioning and scope
+
+Projection identity is namespaced by a projection version and a SHA-256 scope digest over provider, broker environment,
+configured account label, endpoint fingerprint, and projection version. Raw account labels are not written into the
+TigerBeetle parity payload.
+
+Changing any economic encoding rule requires a new projection version. Versioned IDs prevent a revised projection from
+silently inheriting balances from an older encoding.
+
+### Amounts
+
+Every broker-economic ledger amount is already bounded to 18 decimal places. TigerBeetle amounts use the exact absolute
+integer value at scale `10^18`. There is no float conversion, tolerance, cent rounding, or nearest-integer fallback.
+Zero, precision loss, and unsigned 128-bit overflow are hard failures.
+
+### Ledgers
+
+Each normalized commodity maps deterministically to one nonzero unsigned 32-bit ledger ID. The projection reserves the
+high-bit ledger range to avoid the legacy Torghut ledgers. Before any write, the full journal is scanned for a hash
+collision between distinct commodities. A collision is a hard failure; the implementation never silently remaps one
+commodity.
+
+### Accounts
+
+An account ID is a deterministic 128-bit hash of projection version, scope digest, commodity, and canonical journal
+account. Account codes distinguish assets, clearing, expenses, income, equity, and liabilities. Expected account proof
+includes:
+
+- ID, ledger, code, flags, and zero user-data fields;
+- exact cumulative posted debits and credits;
+- zero pending debits and credits.
+
+Account identity is verified after creation and before any transfer write. A pre-existing ID with different immutable
+fields blocks all transfer materialization for that run.
+
+### Transfers and journal atomicity
+
+Positive journal lines are debits and negative journal lines are credits. Within each commodity, deterministic
+debit-credit matching decomposes a balanced journal transaction into the minimum ordered sequence of one-debit,
+one-credit TigerBeetle transfers. Transfer identity binds:
+
+- projection version and scope digest;
+- immutable journal transaction digest;
+- commodity;
+- debit and credit journal line numbers;
+- split segment and exact amount.
+
+All transfers for one journal transaction form one linked chain. The last transfer clears the linked flag. A journal
+transaction that would exceed TigerBeetle's 8,189-event request limit is rejected rather than split across atomic
+boundaries.
+
+Posting-rule-specific transfer codes preserve whether the source was a fill, external cash flow, dividend, interest,
+cash fee, crypto asset fee, or correction reversal.
+
+## Idempotent Materialization
+
+Blindly resubmitting a linked chain is unsafe: an existing event can cause later linked events to report dependent
+failure even when an earlier run already committed the full chain. Each request batch therefore follows this sequence:
+
+1. look up all deterministic transfer IDs;
+2. skip a chain when every member exists;
+3. create a chain only when no member exists;
+4. never write a partially present chain;
+5. after all writes, look up the complete projection again and verify it independently of create results.
+
+A partially present chain is an irreversible contradiction requiring investigation or a new versioned projection. The
+auditor does not guess, delete, overwrite, or manufacture a compensating transfer.
+
+## Full Parity Proof
+
+The auditor makes bounded 8,189-event requests and performs four checks:
+
+1. recompute expected account and transfer manifests from the immutable journal;
+2. create only missing accounts and wholly missing transfer chains;
+3. read every expected account and compare immutable fields plus cumulative balances;
+4. read every expected transfer and compare all economic and protocol fields.
+
+Expected and actual manifests are canonical newline-delimited JSON SHA-256 digests in deterministic order. Parity is
+true only when:
+
+- source age is within the configured bound;
+- the projection contains at least one transaction, account, and transfer;
+- expected and actual counts match;
+- account and transfer manifest digests match;
+- no create, lookup, missing, mismatch, or partial-chain error occurred;
+- no blocker remains.
+
+Mismatch evidence contains only object-ID hashes, field names, counts, digests, and exception class names. It does not
+persist broker credentials, endpoint URLs, account labels, account values, or arbitrary exception text.
+
+## Sealed CNPG Evidence
+
+The parity payload is nested inside the existing append-only `BrokerEconomicLedgerReconciliation.result`. This reuses
+the existing canonical JSON, SHA-256, and database immutability trigger. No migration or second result table is needed.
+
+Before insert, application code recomputes the full expected projection and validates exact bindings to:
+
+- TigerBeetle cluster and projection version;
+- scope digest;
+- current and published-input source watermarks;
+- observation time and source-age bound;
+- input, journal-run, and state-run IDs;
+- input-manifest, reducer-comparison, and journal digests;
+- reducer version.
+
+Status readback first validates the parent result's canonical bytes and hash, then validates every nested binding. A
+missing or malformed payload fails closed.
+
+## Runtime Semantics
+
+`GET /trading/status` exposes these additive fields on `broker_economic_ledger`:
+
+- `accounting_parity_satisfied`;
+- `entry_dependency_satisfied`;
+- `promotion_dependency_satisfied`;
+- `tigerbeetle_economic_parity`;
+- combined broker and TigerBeetle reason codes.
+
+`capital_authority` remains false. `diagnostic_only` becomes false because the result is an operational dependency, but
+it still grants no action by itself.
+
+When `TORGHUT_TIGERBEETLE_ECONOMIC_PARITY_REQUIRED=true`:
+
+- the runtime action projection adds parity blockers only to `entry`;
+- immediate strategy-capital evaluation reloads the latest sealed status before risk-increasing Alpaca authority;
+- the final transaction-held revalidation reloads it again immediately before the broker boundary;
+- read or validation failure denies entry;
+- Hyperliquid authority is not incorrectly coupled to the Alpaca economic scope;
+- reduce-only, closeout, cancel, recovery, `service_healthy`, liveness, and readiness retain their existing contracts.
+
+This double read prevents a stale passing observation from being relied on after it expires between decision evaluation
+and submission.
+
+## Scheduled Operation and Logging
+
+The existing hourly broker-economic reconciliation CronJob owns parity. It runs observation-only mode with
+`--tigerbeetle-parity`, `Forbid` concurrency, no retry, a bounded deadline, the exact deployed build identity, and no
+publication token.
+
+Observation output is deliberately compact. It omits the publication token, raw scope, broker cash/equity, positions,
+residual values, and journal economic values. Durable detailed evidence remains in sealed CNPG rows and the bounded
+status surface.
+
+The job exits nonzero when requested TigerBeetle parity is false. Broker-economic residuals remain visible and block the
+combined dependency, but preserve the existing distinction between an observation with economic residuals and a
+technical TigerBeetle audit failure.
+
+## Failure Matrix
+
+| Condition                                    | Entry                    | Reduce-only / recovery | Readiness                     | Scheduled job         |
+| -------------------------------------------- | ------------------------ | ---------------------- | ----------------------------- | --------------------- |
+| Fresh broker reconciliation and exact parity | Other gates decide       | Available              | Unchanged                     | Success               |
+| Broker residual                              | Blocked                  | Available              | Unchanged                     | Observation completes |
+| Source stale                                 | Blocked                  | Available              | Unchanged                     | Nonzero parity result |
+| Missing or mismatched account/transfer       | Blocked                  | Available              | Unchanged                     | Nonzero parity result |
+| Partial linked chain                         | Blocked; no repair write | Available              | Unchanged                     | Nonzero parity result |
+| TigerBeetle protocol/lookup failure          | Blocked                  | Available              | Existing protocol policy only | Nonzero parity result |
+| Missing/malformed sealed evidence            | Blocked                  | Available              | Unchanged                     | Not applicable        |
+
+## Tests
+
+Required focused coverage includes:
+
+- deterministic exact projection and idempotent rerun;
+- linked multi-debit/multi-credit atomic chains;
+- missing and partially present transfers;
+- duplicate-ID transfer payload mismatch;
+- missing or mismatched accounts and cumulative balances;
+- correction reversal plus replacement;
+- stale source watermark and source lag;
+- protocol-up/parity-down behavior;
+- forged expected digest or row binding rejection;
+- broker reconciliation plus parity status composition;
+- entry-only action-authority gating;
+- both pre-broker strategy-capital checks;
+- safe observation logging and client closure;
+- live GitOps environment and CronJob contracts.
+
+## Production Acceptance
+
+Slice 10 is complete only after all of the following are recorded in a dated evidence document:
+
+1. focused and broad local validation passes, including all five Pyright profiles;
+2. PR checks pass and the change is squash-merged;
+3. the exact merged image digest is published and promoted through GitOps;
+4. Argo reports the intended revision and child resources are healthy;
+5. the first explicit parity run materializes the full production projection without partial chains;
+6. an exact rerun creates zero accounts and zero transfers and reproduces both manifests;
+7. a natural scheduled run completes from a fresh source watermark;
+8. CNPG readback proves the nested payload is sealed and bound to the expected runs and build;
+9. direct scheduler status shows the combined entry dependency truth while service health and reduce-only remain
+   separate;
+10. a controlled discrepancy is demonstrated without corrupting production: a read-only wrapper changes one lookup
+    field in memory, forbids all create calls, does not persist the synthetic result, and proves parity plus entry fail
+    closed;
+11. subsequent unmodified scheduled parity returns to exact success;
+12. existing Slice 8 broker residuals are reported independently; parity does not erase or relabel them.
+
+## Rollback
+
+TigerBeetle accounts and transfers are immutable and are never deleted during rollback. Before reverting enforcement,
+operators must explicitly keep global new exposure blocked. The application and schedule may then be reverted while
+retaining the last sealed result for inspection only. A prior passing result is never treated as fresh proof after the
+new observer stops.

--- a/services/torghut/app/api/trading_status.py
+++ b/services/torghut/app/api/trading_status.py
@@ -12,18 +12,21 @@ from fastapi.responses import Response
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
-from app.alpaca_client import classify_alpaca_trading_endpoint
 from app.api.build_metadata import BUILD_COMMIT, BUILD_IMAGE_DIGEST, BUILD_VERSION
 from app.config import settings
 from app.db import SessionLocal
 from app.trading.action_authority import reduce_runtime_action_authority
 from app.trading.broker_account_activities import load_broker_account_activity_status
-from app.trading.broker_mutation_receipts import fingerprint_broker_endpoint
 from app.trading.broker_mutation_receipts.runtime_status import (
     load_broker_mutation_runtime_status,
     unavailable_broker_mutation_runtime_status,
 )
-from app.trading.economic_ledger import LedgerScope, load_broker_economic_ledger_status
+from app.trading.economic_ledger import (
+    EconomicLedgerError,
+    configured_broker_economic_scope,
+    configured_broker_environment,
+    load_broker_economic_ledger_status,
+)
 from app.trading.execution_runtime import build_execution_status_payload
 from app.trading.order_lineage_runs import load_order_lineage_repair_status
 from app.trading.scheduler import TradingScheduler
@@ -64,28 +67,8 @@ def _read_with_session(
     try:
         with SessionLocal() as session:
             return reader(session)
-    except SQLAlchemyError:
+    except (EconomicLedgerError, SQLAlchemyError):
         return unavailable
-
-
-def _configured_broker_endpoint() -> str:
-    endpoint = str(settings.apca_api_base_url or "").strip().rstrip("/")
-    if endpoint.endswith("/v2"):
-        endpoint = endpoint[:-3]
-    if endpoint:
-        return endpoint
-    return (
-        "https://api.alpaca.markets"
-        if settings.trading_mode == "live"
-        else "https://paper-api.alpaca.markets"
-    )
-
-
-def configured_broker_environment() -> str:
-    try:
-        return classify_alpaca_trading_endpoint(_configured_broker_endpoint())
-    except ValueError:
-        return "unknown"
 
 
 def _capital_controls(state: object) -> dict[str, object]:
@@ -167,12 +150,6 @@ def trading_status() -> dict[str, object] | Response:
         load_broker_mutation_runtime_status,
         unavailable=unavailable_broker_mutation_runtime_status(),
     )
-    action_authority = reduce_runtime_action_authority(
-        service_status=scheduler_readiness_payload(scheduler),
-        live_submission_gate=live_gate,
-        broker_mutation_status=broker_mutation,
-        state=state,
-    )
     tigerbeetle = _read_with_session(
         build_tigerbeetle_ledger_status,
         unavailable={"ok": False, "reason_codes": ["tigerbeetle_status_unavailable"]},
@@ -214,25 +191,31 @@ def trading_status() -> dict[str, object] | Response:
     broker_economic_ledger = _read_with_session(
         lambda session: load_broker_economic_ledger_status(
             session,
-            scope=LedgerScope(
-                provider="alpaca",
-                environment=configured_broker_environment(),
-                account_label=settings.trading_account_label,
-                endpoint_fingerprint=fingerprint_broker_endpoint(
-                    _configured_broker_endpoint()
-                ),
-            ),
+            scope=configured_broker_economic_scope(),
             observed_at=datetime.now(timezone.utc),
+            expected_tigerbeetle_cluster_id=settings.tigerbeetle_cluster_id,
         ),
         unavailable={
             "schema_version": "torghut.broker-economic-ledger-status.v1",
             "state": "unavailable",
             "current": False,
             "reconciled": False,
-            "diagnostic_only": True,
+            "diagnostic_only": False,
             "capital_authority": False,
+            "accounting_parity_satisfied": False,
+            "entry_dependency_satisfied": False,
+            "promotion_dependency_satisfied": False,
             "reason_codes": ["economic_reconciliation_status_unavailable"],
+            "tigerbeetle_economic_parity": None,
         },
+    )
+    action_authority = reduce_runtime_action_authority(
+        service_status=scheduler_readiness_payload(scheduler),
+        live_submission_gate=live_gate,
+        broker_mutation_status=broker_mutation,
+        state=state,
+        broker_economic_ledger_status=broker_economic_ledger,
+        accounting_parity_required=settings.tigerbeetle_economic_parity_required,
     )
     order_lineage = _read_with_session(
         lambda session: load_order_lineage_repair_status(

--- a/services/torghut/app/config/service_fields.py
+++ b/services/torghut/app/config/service_fields.py
@@ -176,6 +176,15 @@ class CoreSettingsFields(BaseSettings):
         description="Fail readiness when TigerBeetle reconciliation has blockers.",
     )
 
+    tigerbeetle_economic_parity_required: bool = Field(
+        default=False,
+        alias="TORGHUT_TIGERBEETLE_ECONOMIC_PARITY_REQUIRED",
+        description=(
+            "Require a fresh sealed broker-economic TigerBeetle parity result "
+            "before new broker exposure; never changes readiness or reduction access."
+        ),
+    )
+
     tigerbeetle_reconcile_max_age_seconds: int = Field(
         default=3600,
         alias="TORGHUT_TIGERBEETLE_RECONCILE_MAX_AGE_SECONDS",

--- a/services/torghut/app/config/settings.py
+++ b/services/torghut/app/config/settings.py
@@ -43,6 +43,10 @@ class SettingsAccessorsMixin(SettingsNormalizationMixin):
             raise ValueError(
                 "TORGHUT_TIGERBEETLE_REPLICA_ADDRESSES is required when TigerBeetle is enabled"
             )
+        if self.tigerbeetle_economic_parity_required and not self.tigerbeetle_enabled:
+            raise ValueError(
+                "TORGHUT_TIGERBEETLE_ENABLED is required when economic parity is required"
+            )
 
     def model_post_init(self, __context: Any) -> None:
         del __context

--- a/services/torghut/app/trading/action_authority.py
+++ b/services/torghut/app/trading/action_authority.py
@@ -12,7 +12,7 @@ BROKER_MUTATION_RUNTIME_STATUS_SCHEMA_VERSION = (
     "torghut.broker-mutation-runtime-status.v1"
 )
 RUNTIME_ACTION_AUTHORITY_SCHEMA_VERSION = "torghut.runtime-action-authority.v1"
-RUNTIME_ACTION_AUTHORITY_POLICY_REVISION = "p0-capital-freeze.v1"
+RUNTIME_ACTION_AUTHORITY_POLICY_REVISION = "p0-capital-freeze-economic-parity.v2"
 
 _REDUCTION_BLOCKERS = frozenset(
     {
@@ -131,6 +131,8 @@ def reduce_runtime_action_authority(
     live_submission_gate: Mapping[str, object],
     broker_mutation_status: Mapping[str, object],
     state: object,
+    broker_economic_ledger_status: Mapping[str, object] | None = None,
+    accounting_parity_required: bool = False,
     evaluated_at: datetime | None = None,
 ) -> RuntimeActionAuthority:
     """Combine process health with action-specific submission authority."""
@@ -156,12 +158,17 @@ def reduce_runtime_action_authority(
         fallback_reason="broker_mutation_reduction_fencing_unproven",
     )
     mutation_recovery_reasons = _mutation_recovery_reasons(broker_mutation_status)
+    accounting_entry_reasons = _accounting_parity_reasons(
+        broker_economic_ledger_status,
+        required=accounting_parity_required,
+    )
     entry_reasons = _unique(
         (
             *service_reasons,
             *submission.reason_codes["entry"],
             *mutation_entry_reasons,
             *mutation_recovery_reasons,
+            *accounting_entry_reasons,
         )
     )
     reduction_reasons = _unique(
@@ -191,6 +198,38 @@ def reduce_runtime_action_authority(
         },
         evaluated_at=observed_at,
     )
+
+
+def _accounting_parity_reasons(
+    status: Mapping[str, object] | None,
+    *,
+    required: bool,
+) -> tuple[str, ...]:
+    if not required:
+        return ()
+    invalid = ("broker_economic_accounting_parity_status_invalid",)
+    if status is None or status.get("schema_version") != (
+        "torghut.broker-economic-ledger-status.v1"
+    ):
+        return invalid
+    satisfied = status.get("entry_dependency_satisfied")
+    reason_codes = status.get("reason_codes")
+    if (
+        not isinstance(satisfied, bool)
+        or not isinstance(reason_codes, Sequence)
+        or isinstance(
+            reason_codes,
+            (str, bytes, bytearray),
+        )
+    ):
+        return invalid
+    reason_items = cast(Sequence[object], reason_codes)
+    if any(not isinstance(item, str) for item in reason_items):
+        return invalid
+    if satisfied:
+        return ()
+    reasons = _strings(reason_items)
+    return reasons or ("broker_economic_accounting_parity_unproven",)
 
 
 def _valid_gate_contract(gate: Mapping[str, object]) -> bool:

--- a/services/torghut/app/trading/economic_ledger/__init__.py
+++ b/services/torghut/app/trading/economic_ledger/__init__.py
@@ -7,6 +7,11 @@ from .comparison import (
     compare_projections,
     reduce_and_compare,
 )
+from .configured_scope import (
+    configured_broker_economic_scope,
+    configured_broker_endpoint,
+    configured_broker_environment,
+)
 from .journal_reducer import (
     JOURNAL_REDUCER_NAME,
     JOURNAL_REDUCER_VERSION,
@@ -40,6 +45,10 @@ from .state_reducer import (
     STATE_REDUCER_NAME,
     STATE_REDUCER_VERSION,
     reduce_independent_state,
+)
+from .tigerbeetle_parity import (
+    TigerBeetleEconomicParityObservation,
+    audit_broker_economic_tigerbeetle_parity,
 )
 from .types import (
     ZERO,
@@ -91,7 +100,12 @@ __all__ = (
     "ProjectionDelta",
     "STATE_REDUCER_NAME",
     "STATE_REDUCER_VERSION",
+    "TigerBeetleEconomicParityObservation",
+    "audit_broker_economic_tigerbeetle_parity",
     "compare_projections",
+    "configured_broker_economic_scope",
+    "configured_broker_endpoint",
+    "configured_broker_environment",
     "capture_broker_economic_snapshot",
     "load_broker_economic_ledger_source_rows",
     "load_broker_economic_ledger_status",

--- a/services/torghut/app/trading/economic_ledger/configured_scope.py
+++ b/services/torghut/app/trading/economic_ledger/configured_scope.py
@@ -1,0 +1,52 @@
+"""Single configured broker-economic scope shared by status and execution gates."""
+
+from __future__ import annotations
+
+from app.alpaca_client import classify_alpaca_trading_endpoint
+from app.config import Settings, settings
+from app.trading.broker_mutation_receipts import fingerprint_broker_endpoint
+
+from .types import LedgerScope
+
+
+def configured_broker_endpoint(settings_obj: Settings = settings) -> str:
+    endpoint = str(settings_obj.apca_api_base_url or "").strip().rstrip("/")
+    if endpoint.endswith("/v2"):
+        endpoint = endpoint[:-3]
+    if endpoint:
+        return endpoint
+    return (
+        "https://api.alpaca.markets"
+        if settings_obj.trading_mode == "live"
+        else "https://paper-api.alpaca.markets"
+    )
+
+
+def configured_broker_environment(settings_obj: Settings = settings) -> str:
+    try:
+        return classify_alpaca_trading_endpoint(
+            configured_broker_endpoint(settings_obj)
+        )
+    except ValueError:
+        return "unknown"
+
+
+def configured_broker_economic_scope(
+    *,
+    account_label: str | None = None,
+    settings_obj: Settings = settings,
+) -> LedgerScope:
+    endpoint = configured_broker_endpoint(settings_obj)
+    return LedgerScope(
+        provider="alpaca",
+        environment=configured_broker_environment(settings_obj),
+        account_label=account_label or settings_obj.trading_account_label,
+        endpoint_fingerprint=fingerprint_broker_endpoint(endpoint),
+    )
+
+
+__all__ = (
+    "configured_broker_economic_scope",
+    "configured_broker_endpoint",
+    "configured_broker_environment",
+)

--- a/services/torghut/app/trading/economic_ledger/reconciliation.py
+++ b/services/torghut/app/trading/economic_ledger/reconciliation.py
@@ -7,7 +7,7 @@ import json
 import re
 import uuid
 from collections.abc import Iterable, Mapping, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from decimal import Decimal, localcontext
 from typing import Protocol, cast
@@ -24,6 +24,11 @@ from .persistence import (
     BrokerEconomicLedgerReplay,
     PublishedBrokerEconomicLedgerRuns,
     require_published_broker_economic_ledger_runs,
+)
+from .tigerbeetle_parity import (
+    BrokerEconomicTigerBeetleParityResult,
+    load_persisted_tigerbeetle_economic_parity,
+    validated_tigerbeetle_parity_attachment,
 )
 from .types import (
     LEDGER_DECIMAL_PRECISION,
@@ -246,8 +251,6 @@ def reconcile_broker_economic_ledger(
     build: BrokerEconomicReconciliationBuild,
     max_source_age_seconds: int = DEFAULT_SOURCE_MAX_AGE_SECONDS,
 ) -> BrokerEconomicReconciliationResult:
-    """Compare a published reducer pair with one fresh read-only broker snapshot."""
-
     if max_source_age_seconds <= 0:
         raise ValueError("economic_reconciliation_max_source_age_invalid")
     watermark = as_utc(replay.snapshot.source_watermark)
@@ -344,6 +347,7 @@ def persist_broker_economic_ledger_reconciliation(
     *,
     build: BrokerEconomicReconciliationBuild,
     max_source_age_seconds: int = DEFAULT_SOURCE_MAX_AGE_SECONDS,
+    tigerbeetle_parity: BrokerEconomicTigerBeetleParityResult | None = None,
 ) -> PersistedBrokerEconomicReconciliation:
     """Append one observation only after resolving the exact published run pair."""
 
@@ -355,6 +359,20 @@ def persist_broker_economic_ledger_reconciliation(
         build=build,
         max_source_age_seconds=max_source_age_seconds,
     )
+    if tigerbeetle_parity is not None:
+        result = replace(
+            result,
+            payload={
+                **result.payload,
+                "tigerbeetle_economic_parity": validated_tigerbeetle_parity_attachment(
+                    tigerbeetle_parity,
+                    replay,
+                    runs,
+                    snapshot.observed_at,
+                    max_source_age_seconds,
+                ),
+            },
+        )
     observation_id = uuid.uuid4()
     snapshot_canonical_json = _canonical_json(snapshot.payload)
     result_canonical_json = _canonical_json(result.payload)
@@ -400,8 +418,9 @@ def load_broker_economic_ledger_status(
     scope: LedgerScope,
     observed_at: datetime,
     max_observation_age_seconds: int = DEFAULT_OBSERVATION_MAX_AGE_SECONDS,
+    expected_tigerbeetle_cluster_id: int | None = None,
 ) -> dict[str, object]:
-    """Load the latest bounded Slice 8 observation; it has no capital authority."""
+    """Load the latest sealed broker and TigerBeetle accounting dependencies."""
 
     if max_observation_age_seconds <= 0:
         raise ValueError("economic_status_max_observation_age_invalid")
@@ -422,7 +441,7 @@ def load_broker_economic_ledger_status(
         .limit(1)
     )
     if row is None:
-        return _missing_status(scope, max_observation_age_seconds)
+        return _missing_status(max_observation_age_seconds)
     if (
         _sha256(row.broker_snapshot_canonical_json) != row.broker_snapshot_sha256
         or _sha256(row.result_canonical_json) != row.result_sha256
@@ -444,19 +463,33 @@ def load_broker_economic_ledger_status(
         raise EconomicLedgerError(
             "economic_reconciliation_persisted_manifest_digest_invalid"
         )
+    (
+        tigerbeetle_parity,
+        tigerbeetle_parity_satisfied,
+        tigerbeetle_reason_codes,
+    ) = load_persisted_tigerbeetle_economic_parity(
+        row,
+        scope=scope,
+        expected_cluster_id=expected_tigerbeetle_cluster_id,
+    )
     now = as_utc(observed_at)
     age_seconds = max(0, int((now - as_utc(row.observed_at)).total_seconds()))
     stale = age_seconds > max_observation_age_seconds
     reason_codes = list(_string_sequence(row.result.get("reason_codes")))
+    reason_codes.extend(tigerbeetle_reason_codes)
     if stale:
         reason_codes.append("economic_reconciliation_observation_stale")
+    dependency_satisfied = row.reconciled and not stale and tigerbeetle_parity_satisfied
     return {
         "schema_version": _STATUS_SCHEMA_VERSION,
         "state": "stale" if stale else ("reconciled" if row.reconciled else "residual"),
         "current": not stale,
         "reconciled": row.reconciled and not stale,
-        "diagnostic_only": True,
+        "diagnostic_only": False,
         "capital_authority": False,
+        "accounting_parity_satisfied": dependency_satisfied,
+        "entry_dependency_satisfied": dependency_satisfied,
+        "promotion_dependency_satisfied": dependency_satisfied,
         "reason_codes": sorted(set(reason_codes)),
         "observation_id": str(row.id),
         "observed_at": as_utc(row.observed_at).isoformat(),
@@ -482,6 +515,9 @@ def load_broker_economic_ledger_status(
         "open_order_count": row.open_order_count,
         "residuals": row.result.get("residuals", []),
         "economics": row.result.get("economics", {}),
+        "tigerbeetle_economic_parity": (
+            dict(tigerbeetle_parity) if tigerbeetle_parity is not None else None
+        ),
     }
 
 
@@ -899,20 +935,25 @@ def _require_build_identity(*, source_commit: str, image_digest: str) -> None:
         raise EconomicLedgerError("economic_reconciliation_image_digest_invalid")
 
 
-def _missing_status(scope: LedgerScope, max_age_seconds: int) -> dict[str, object]:
+def _missing_status(max_age_seconds: int) -> dict[str, object]:
     return {
         "schema_version": _STATUS_SCHEMA_VERSION,
         "state": "missing",
         "current": False,
         "reconciled": False,
-        "diagnostic_only": True,
+        "diagnostic_only": False,
         "capital_authority": False,
-        "reason_codes": ["economic_reconciliation_missing"],
-        "account_label": scope.account_label,
-        "environment": scope.environment,
+        "accounting_parity_satisfied": False,
+        "entry_dependency_satisfied": False,
+        "promotion_dependency_satisfied": False,
+        "reason_codes": [
+            "economic_reconciliation_missing",
+            "tigerbeetle_economic_parity_missing",
+        ],
         "max_age_seconds": max_age_seconds,
         "residual_count": None,
         "open_order_count": None,
+        "tigerbeetle_economic_parity": None,
     }
 
 

--- a/services/torghut/app/trading/economic_ledger/tigerbeetle_parity.py
+++ b/services/torghut/app/trading/economic_ledger/tigerbeetle_parity.py
@@ -1,0 +1,969 @@
+"""Materialize and audit the broker-economic TigerBeetle projection."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, cast
+
+from app.trading.tigerbeetle_client import TigerBeetleClientProtocol
+from app.trading.tigerbeetle_journal.journal_payloads import result_statuses_by_index
+from app.trading.tigerbeetle_ledger_model import TigerBeetleTransferSpec
+
+from ..broker_account_activities import as_utc
+from . import tigerbeetle_projection as projection
+from .types import EconomicLedgerError, LedgerScope
+
+if TYPE_CHECKING:
+    from app.models import BrokerEconomicLedgerReconciliation
+
+    from .persistence import (
+        BrokerEconomicLedgerReplay,
+        PublishedBrokerEconomicLedgerRuns,
+    )
+
+
+TIGERBEETLE_ECONOMIC_PARITY_SCHEMA_VERSION = (
+    "torghut.broker-economic-tigerbeetle-parity.v1"
+)
+_SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+_MISMATCH_SAMPLE_LIMIT = 20
+_AUDIT_OPERATION_ERRORS = (
+    EconomicLedgerError,
+    RuntimeError,
+    TypeError,
+    ValueError,
+    AttributeError,
+)
+
+_BLOCKER_ACCOUNT_CREATE = "tigerbeetle_economic_account_create_failed"
+_BLOCKER_ACCOUNT_LOOKUP = "tigerbeetle_economic_account_lookup_failed"
+_BLOCKER_ACCOUNT_MISSING = "tigerbeetle_economic_account_missing"
+_BLOCKER_ACCOUNT_MISMATCH = "tigerbeetle_economic_account_mismatch"
+_BLOCKER_TRANSFER_CREATE = "tigerbeetle_economic_transfer_create_failed"
+_BLOCKER_TRANSFER_LOOKUP = "tigerbeetle_economic_transfer_lookup_failed"
+_BLOCKER_TRANSFER_MISSING = "tigerbeetle_economic_transfer_missing"
+_BLOCKER_TRANSFER_MISMATCH = "tigerbeetle_economic_transfer_mismatch"
+_BLOCKER_TRANSFER_PARTIAL = "tigerbeetle_economic_transfer_chain_partial"
+_BLOCKER_PROJECTION_EMPTY = "tigerbeetle_economic_projection_empty"
+_BLOCKER_SOURCE_STALE = "tigerbeetle_economic_source_watermark_stale"
+
+
+@dataclass(frozen=True, slots=True)
+class BrokerEconomicTigerBeetleParityResult:
+    payload: dict[str, object]
+    parity: bool
+    observation: TigerBeetleEconomicParityObservation
+
+
+@dataclass(frozen=True, slots=True)
+class TigerBeetleEconomicParityObservation:
+    cluster_id: int
+    observed_at: datetime
+    max_source_age_seconds: int
+
+
+def _add_blocker(blockers: list[str], blocker: str) -> None:
+    if blocker not in blockers:
+        blockers.append(blocker)
+
+
+@dataclass(slots=True)
+class _AuditState:
+    blockers: list[str]
+    errors: dict[str, int]
+    operations: dict[str, int]
+    mismatch_samples: list[dict[str, object]]
+    exceptions: list[dict[str, str]]
+
+
+def _record_exception(state: _AuditState, *, stage: str, exc: Exception) -> None:
+    if len(state.exceptions) >= _MISMATCH_SAMPLE_LIMIT:
+        return
+    state.exceptions.append({"stage": stage, "type": type(exc).__name__})
+
+
+def _sample_id(value: int) -> str:
+    return hashlib.sha256(str(value).encode("ascii")).hexdigest()
+
+
+def _record_mismatch(
+    state: _AuditState,
+    *,
+    kind: str,
+    object_id: int,
+    fields: Sequence[str],
+) -> None:
+    if len(state.mismatch_samples) >= _MISMATCH_SAMPLE_LIMIT:
+        return
+    state.mismatch_samples.append(
+        {
+            "fields": sorted(set(fields)),
+            "id_sha256": _sample_id(object_id),
+            "kind": kind,
+        }
+    )
+
+
+def _increment(state: _AuditState, key: str, count: int = 1) -> None:
+    state.errors[key] += count
+
+
+def _create_missing_accounts(
+    client: TigerBeetleClientProtocol,
+    summary: projection.ProjectionSummary,
+    state: _AuditState,
+) -> None:
+    accounts = [summary.accounts[item] for item in sorted(summary.accounts)]
+    for chunk in projection.chunked(accounts, projection.TIGERBEETLE_MAX_BATCH_SIZE):
+        ids = [item.spec.account_id for item in chunk]
+        try:
+            existing = projection.account_objects_by_id(
+                client.lookup_accounts(ids),
+                requested_ids=ids,
+            )
+        except _AUDIT_OPERATION_ERRORS as exc:
+            _increment(state, "account_lookup")
+            _add_blocker(state.blockers, _BLOCKER_ACCOUNT_LOOKUP)
+            _record_exception(state, stage="account_prewrite_lookup", exc=exc)
+            continue
+        missing = [item.spec for item in chunk if item.spec.account_id not in existing]
+        state.operations["account_existing_count"] += len(existing)
+        state.operations["account_create_selected_count"] += len(missing)
+        if not missing:
+            continue
+        try:
+            statuses = result_statuses_by_index(
+                client.create_accounts(missing),
+                count=len(missing),
+                default_status="created",
+                status_type_names=("CreateAccountStatus",),
+            )
+        except _AUDIT_OPERATION_ERRORS as exc:
+            _increment(state, "account_create", len(missing))
+            _add_blocker(state.blockers, _BLOCKER_ACCOUNT_CREATE)
+            _record_exception(state, stage="account_create", exc=exc)
+            continue
+        failures = sum(
+            status not in {"created", "exists"} for status in statuses.values()
+        )
+        if failures:
+            _increment(state, "account_create", failures)
+            _add_blocker(state.blockers, _BLOCKER_ACCOUNT_CREATE)
+
+
+def _accounts_are_safe_for_transfers(
+    client: TigerBeetleClientProtocol,
+    summary: projection.ProjectionSummary,
+    state: _AuditState,
+) -> bool:
+    safe = True
+    accounts = [summary.accounts[item] for item in sorted(summary.accounts)]
+    for chunk in projection.chunked(accounts, projection.TIGERBEETLE_MAX_BATCH_SIZE):
+        ids = [item.spec.account_id for item in chunk]
+        try:
+            actual_by_id = projection.account_objects_by_id(
+                client.lookup_accounts(ids),
+                requested_ids=ids,
+            )
+        except _AUDIT_OPERATION_ERRORS as exc:
+            _increment(state, "account_lookup")
+            _add_blocker(state.blockers, _BLOCKER_ACCOUNT_LOOKUP)
+            _record_exception(state, stage="account_identity_lookup", exc=exc)
+            safe = False
+            continue
+        for expected in chunk:
+            actual = actual_by_id.get(expected.spec.account_id)
+            if actual is None:
+                _increment(state, "account_missing")
+                _add_blocker(state.blockers, _BLOCKER_ACCOUNT_MISSING)
+                _record_mismatch(
+                    state,
+                    kind="account",
+                    object_id=expected.spec.account_id,
+                    fields=("missing_before_transfer",),
+                )
+                safe = False
+                continue
+            try:
+                actual_payload = projection.actual_account_payload(actual)
+            except (AttributeError, TypeError, ValueError) as exc:
+                _increment(state, "account_mismatch")
+                _add_blocker(state.blockers, _BLOCKER_ACCOUNT_MISMATCH)
+                _record_exception(state, stage="account_identity_payload", exc=exc)
+                safe = False
+                continue
+            expected_identity = projection.account_identity_payload(expected)
+            actual_identity = {
+                key: actual_payload.get(key) for key in expected_identity
+            }
+            mismatches = projection.mismatch_fields(expected_identity, actual_identity)
+            if mismatches:
+                _increment(state, "account_mismatch")
+                _add_blocker(state.blockers, _BLOCKER_ACCOUNT_MISMATCH)
+                _record_mismatch(
+                    state,
+                    kind="account",
+                    object_id=expected.spec.account_id,
+                    fields=mismatches,
+                )
+                safe = False
+    return safe
+
+
+def _create_missing_transfer_chains(
+    client: TigerBeetleClientProtocol,
+    summary: projection.ProjectionSummary,
+    state: _AuditState,
+) -> None:
+    for groups in projection.iter_group_batches(summary):
+        specs = tuple(spec for group in groups for spec in group)
+        ids = [spec.transfer_id for spec in specs]
+        try:
+            existing = projection.transfer_objects_by_id(
+                client.lookup_transfers(ids),
+                requested_ids=ids,
+            )
+        except _AUDIT_OPERATION_ERRORS as exc:
+            _increment(state, "transfer_lookup")
+            _add_blocker(state.blockers, _BLOCKER_TRANSFER_LOOKUP)
+            _record_exception(state, stage="transfer_prewrite_lookup", exc=exc)
+            continue
+
+        missing_groups: list[tuple[TigerBeetleTransferSpec, ...]] = []
+        for group in groups:
+            existing_count = sum(spec.transfer_id in existing for spec in group)
+            if existing_count == len(group):
+                state.operations["transfer_existing_chain_count"] += 1
+            elif existing_count == 0:
+                missing_groups.append(group)
+            else:
+                _increment(state, "transfer_chain_partial")
+                _add_blocker(state.blockers, _BLOCKER_TRANSFER_PARTIAL)
+                _record_mismatch(
+                    state,
+                    kind="transfer_chain",
+                    object_id=group[0].transfer_id,
+                    fields=("partial_chain",),
+                )
+
+        missing = tuple(spec for group in missing_groups for spec in group)
+        state.operations["transfer_create_selected_count"] += len(missing)
+        if not missing:
+            continue
+        try:
+            statuses = result_statuses_by_index(
+                client.create_transfers(missing),
+                count=len(missing),
+                default_status="created",
+                status_type_names=("CreateTransferStatus",),
+            )
+        except _AUDIT_OPERATION_ERRORS as exc:
+            _increment(state, "transfer_create", len(missing))
+            _add_blocker(state.blockers, _BLOCKER_TRANSFER_CREATE)
+            _record_exception(state, stage="transfer_create", exc=exc)
+            continue
+        failures = sum(
+            status not in {"created", "exists"} for status in statuses.values()
+        )
+        if failures:
+            _increment(state, "transfer_create", failures)
+            _add_blocker(state.blockers, _BLOCKER_TRANSFER_CREATE)
+
+
+def _verify_accounts(
+    client: TigerBeetleClientProtocol,
+    summary: projection.ProjectionSummary,
+    state: _AuditState,
+) -> tuple[int, str]:
+    accounts = [summary.accounts[item] for item in sorted(summary.accounts)]
+    actual_count = 0
+    actual_hasher = hashlib.sha256()
+    for chunk in projection.chunked(accounts, projection.TIGERBEETLE_MAX_BATCH_SIZE):
+        ids = [item.spec.account_id for item in chunk]
+        try:
+            actual_by_id = projection.account_objects_by_id(
+                client.lookup_accounts(ids),
+                requested_ids=ids,
+            )
+        except _AUDIT_OPERATION_ERRORS as exc:
+            _increment(state, "account_lookup")
+            _add_blocker(state.blockers, _BLOCKER_ACCOUNT_LOOKUP)
+            _record_exception(state, stage="account_verify_lookup", exc=exc)
+            continue
+        actual_count += len(actual_by_id)
+        for expected in chunk:
+            actual = actual_by_id.get(expected.spec.account_id)
+            if actual is None:
+                _increment(state, "account_missing")
+                _add_blocker(state.blockers, _BLOCKER_ACCOUNT_MISSING)
+                _record_mismatch(
+                    state,
+                    kind="account",
+                    object_id=expected.spec.account_id,
+                    fields=("missing",),
+                )
+                continue
+            expected_payload = projection.account_payload(expected)
+            try:
+                actual_payload = projection.actual_account_payload(actual)
+            except (AttributeError, TypeError, ValueError) as exc:
+                _increment(state, "account_mismatch")
+                _add_blocker(state.blockers, _BLOCKER_ACCOUNT_MISMATCH)
+                _record_exception(state, stage="account_verify_payload", exc=exc)
+                _record_mismatch(
+                    state,
+                    kind="account",
+                    object_id=expected.spec.account_id,
+                    fields=("payload_invalid",),
+                )
+                continue
+            actual_hasher.update(projection.canonical_line(actual_payload))
+            mismatches = projection.mismatch_fields(expected_payload, actual_payload)
+            if mismatches:
+                _increment(state, "account_mismatch")
+                _add_blocker(state.blockers, _BLOCKER_ACCOUNT_MISMATCH)
+                _record_mismatch(
+                    state,
+                    kind="account",
+                    object_id=expected.spec.account_id,
+                    fields=mismatches,
+                )
+    return actual_count, actual_hasher.hexdigest()
+
+
+def _verify_transfers(
+    client: TigerBeetleClientProtocol,
+    summary: projection.ProjectionSummary,
+    state: _AuditState,
+) -> tuple[int, str]:
+    actual_count = 0
+    actual_hasher = hashlib.sha256()
+    for specs in projection.iter_transfer_batches(summary):
+        ids = [spec.transfer_id for spec in specs]
+        try:
+            actual_by_id = projection.transfer_objects_by_id(
+                client.lookup_transfers(ids),
+                requested_ids=ids,
+            )
+        except _AUDIT_OPERATION_ERRORS as exc:
+            _increment(state, "transfer_lookup")
+            _add_blocker(state.blockers, _BLOCKER_TRANSFER_LOOKUP)
+            _record_exception(state, stage="transfer_verify_lookup", exc=exc)
+            continue
+        actual_count += len(actual_by_id)
+        for expected in specs:
+            actual = actual_by_id.get(expected.transfer_id)
+            if actual is None:
+                _increment(state, "transfer_missing")
+                _add_blocker(state.blockers, _BLOCKER_TRANSFER_MISSING)
+                _record_mismatch(
+                    state,
+                    kind="transfer",
+                    object_id=expected.transfer_id,
+                    fields=("missing",),
+                )
+                continue
+            expected_payload = projection.transfer_payload(expected)
+            try:
+                actual_payload = projection.actual_transfer_payload(actual)
+            except (AttributeError, TypeError, ValueError) as exc:
+                _increment(state, "transfer_mismatch")
+                _add_blocker(state.blockers, _BLOCKER_TRANSFER_MISMATCH)
+                _record_exception(state, stage="transfer_verify_payload", exc=exc)
+                _record_mismatch(
+                    state,
+                    kind="transfer",
+                    object_id=expected.transfer_id,
+                    fields=("payload_invalid",),
+                )
+                continue
+            actual_hasher.update(projection.canonical_line(actual_payload))
+            mismatches = projection.mismatch_fields(expected_payload, actual_payload)
+            if mismatches:
+                _increment(state, "transfer_mismatch")
+                _add_blocker(state.blockers, _BLOCKER_TRANSFER_MISMATCH)
+                _record_mismatch(
+                    state,
+                    kind="transfer",
+                    object_id=expected.transfer_id,
+                    fields=mismatches,
+                )
+    return actual_count, actual_hasher.hexdigest()
+
+
+def _utc(value: datetime, reason: str) -> datetime:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise EconomicLedgerError(reason)
+    return value.astimezone(timezone.utc)
+
+
+def _new_audit_state() -> _AuditState:
+    return _AuditState(
+        blockers=[],
+        errors={
+            "account_create": 0,
+            "account_lookup": 0,
+            "account_mismatch": 0,
+            "account_missing": 0,
+            "transfer_chain_partial": 0,
+            "transfer_create": 0,
+            "transfer_lookup": 0,
+            "transfer_mismatch": 0,
+            "transfer_missing": 0,
+        },
+        operations={
+            "account_create_selected_count": 0,
+            "account_existing_count": 0,
+            "transfer_create_selected_count": 0,
+            "transfer_existing_chain_count": 0,
+        },
+        mismatch_samples=[],
+        exceptions=[],
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class _AuditResult:
+    observed_at: datetime
+    source_watermark: datetime
+    source_age_seconds: int
+    summary: projection.ProjectionSummary
+    state: _AuditState
+    actual: dict[str, object]
+
+
+@dataclass(frozen=True, slots=True)
+class _ValidatedParityPayload:
+    bindings: Mapping[str, object]
+    expected: Mapping[str, object]
+    actual: Mapping[str, object]
+    errors: Mapping[str, object]
+    blockers: tuple[str, ...]
+    source_age_seconds: int
+    max_source_age_seconds: int
+    parity: bool
+
+
+def _validated_observation(
+    observation: TigerBeetleEconomicParityObservation,
+) -> datetime:
+    if observation.cluster_id <= 0:
+        raise ValueError("tigerbeetle_economic_cluster_id_invalid")
+    if observation.max_source_age_seconds <= 0:
+        raise ValueError("tigerbeetle_economic_max_source_age_invalid")
+    return _utc(
+        observation.observed_at,
+        "tigerbeetle_economic_observed_at_invalid",
+    )
+
+
+def _read_actual_projection(
+    client: TigerBeetleClientProtocol,
+    summary: projection.ProjectionSummary,
+    state: _AuditState,
+) -> dict[str, object]:
+    _create_missing_accounts(client, summary, state)
+    if _accounts_are_safe_for_transfers(client, summary, state):
+        _create_missing_transfer_chains(client, summary, state)
+    account_count, account_digest = _verify_accounts(client, summary, state)
+    transfer_count, transfer_digest = _verify_transfers(client, summary, state)
+    return {
+        "account_count": account_count,
+        "account_manifest_sha256": account_digest,
+        "transfer_count": transfer_count,
+        "transfer_manifest_sha256": transfer_digest,
+    }
+
+
+def _run_audit(
+    client: TigerBeetleClientProtocol,
+    replay: BrokerEconomicLedgerReplay,
+    observation: TigerBeetleEconomicParityObservation,
+) -> _AuditResult:
+    observed_at = _validated_observation(observation)
+    source_watermark = _utc(
+        replay.snapshot.source_watermark,
+        "tigerbeetle_economic_source_watermark_invalid",
+    )
+    if observed_at < source_watermark:
+        raise EconomicLedgerError("tigerbeetle_economic_observed_before_watermark")
+    source_age_seconds = int((observed_at - source_watermark).total_seconds())
+    summary = projection.build_projection_summary(replay)
+    state = _new_audit_state()
+    if not replay.reduction.admissible:
+        _add_blocker(state.blockers, "tigerbeetle_economic_projection_inadmissible")
+    if summary.transfer_count == 0:
+        _add_blocker(state.blockers, _BLOCKER_PROJECTION_EMPTY)
+    if source_age_seconds > observation.max_source_age_seconds:
+        _add_blocker(state.blockers, _BLOCKER_SOURCE_STALE)
+    return _AuditResult(
+        observed_at=observed_at,
+        source_watermark=source_watermark,
+        source_age_seconds=source_age_seconds,
+        summary=summary,
+        state=state,
+        actual=_read_actual_projection(client, summary, state),
+    )
+
+
+def _parity_from_sections(
+    expected: Mapping[str, object],
+    actual: Mapping[str, object],
+    errors: Mapping[str, object],
+    blockers: Sequence[str],
+    *,
+    source_fresh: bool,
+) -> bool:
+    return (
+        not blockers
+        and source_fresh
+        and _required_nonnegative_int(expected.get("account_count"), "account_count")
+        > 0
+        and _required_nonnegative_int(
+            expected.get("transaction_count"), "transaction_count"
+        )
+        > 0
+        and _required_nonnegative_int(expected.get("transfer_count"), "transfer_count")
+        > 0
+        and actual.get("account_count") == expected.get("account_count")
+        and actual.get("transfer_count") == expected.get("transfer_count")
+        and actual.get("account_manifest_sha256")
+        == expected.get("account_manifest_sha256")
+        and actual.get("transfer_manifest_sha256")
+        == expected.get("transfer_manifest_sha256")
+        and all(value == 0 for value in errors.values())
+    )
+
+
+def _replay_bindings(
+    replay: BrokerEconomicLedgerReplay,
+    runs: PublishedBrokerEconomicLedgerRuns,
+    source_watermark: datetime,
+) -> dict[str, object]:
+    return {
+        "comparison_sha256": replay.reduction.comparison.comparison_digest,
+        "current_source_watermark": source_watermark.isoformat(),
+        "input_id": str(runs.input_id),
+        "input_manifest_sha256": replay.snapshot.prepared.manifest_digest,
+        "input_source_watermark": _utc(
+            runs.source_watermark,
+            "tigerbeetle_economic_input_watermark_invalid",
+        ).isoformat(),
+        "journal_run_id": str(runs.journal_run_id),
+        "journal_sha256": replay.reduction.journal.journal_digest,
+        "reducer_version": replay.reduction.journal.projection.reducer_version,
+        "state_run_id": str(runs.state_run_id),
+    }
+
+
+def _build_payload(
+    replay: BrokerEconomicLedgerReplay,
+    runs: PublishedBrokerEconomicLedgerRuns,
+    observation: TigerBeetleEconomicParityObservation,
+    audit: _AuditResult,
+) -> dict[str, object]:
+    expected = audit.summary.payload()
+    blockers = tuple(sorted(audit.state.blockers))
+    parity = _parity_from_sections(
+        expected,
+        audit.actual,
+        audit.state.errors,
+        blockers,
+        source_fresh=(audit.source_age_seconds <= observation.max_source_age_seconds),
+    )
+    return {
+        "schema_version": TIGERBEETLE_ECONOMIC_PARITY_SCHEMA_VERSION,
+        "projection_version": projection.TIGERBEETLE_ECONOMIC_PROJECTION_VERSION,
+        "cluster_id": observation.cluster_id,
+        "scope_sha256": projection.scope_digest(replay.snapshot.prepared.scope),
+        "observed_at": audit.observed_at.isoformat(),
+        "source_age_seconds": audit.source_age_seconds,
+        "max_source_age_seconds": observation.max_source_age_seconds,
+        "bindings": _replay_bindings(replay, runs, audit.source_watermark),
+        "expected": expected,
+        "actual": audit.actual,
+        "errors": dict(audit.state.errors),
+        "operations": dict(audit.state.operations),
+        "mismatch_samples": audit.state.mismatch_samples,
+        "exceptions": audit.state.exceptions,
+        "blockers": list(blockers),
+        "parity": parity,
+        "capital_authority": False,
+        "promotion_authority": False,
+    }
+
+
+def audit_broker_economic_tigerbeetle_parity(
+    client: TigerBeetleClientProtocol,
+    replay: BrokerEconomicLedgerReplay,
+    *,
+    runs: PublishedBrokerEconomicLedgerRuns,
+    observation: TigerBeetleEconomicParityObservation,
+) -> BrokerEconomicTigerBeetleParityResult:
+    """Materialize missing immutable chains, then prove the complete projection."""
+
+    audit = _run_audit(client, replay, observation)
+    payload = _build_payload(replay, runs, observation, audit)
+    validate_tigerbeetle_economic_parity_payload(
+        payload,
+        replay=replay,
+        runs=runs,
+        observation=observation,
+    )
+    return BrokerEconomicTigerBeetleParityResult(
+        payload=payload,
+        parity=payload["parity"] is True,
+        observation=observation,
+    )
+
+
+def _required_mapping(value: object, reason: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise EconomicLedgerError(reason)
+    return cast(Mapping[str, object], value)
+
+
+def _required_nonnegative_int(value: object, field_name: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise EconomicLedgerError(f"tigerbeetle_economic_parity_{field_name}_invalid")
+    return value
+
+
+def _required_digest(value: object, field_name: str) -> str:
+    resolved = str(value or "")
+    if _SHA256_PATTERN.fullmatch(resolved) is None:
+        raise EconomicLedgerError(f"tigerbeetle_economic_parity_{field_name}_invalid")
+    return resolved
+
+
+def _required_aware_timestamp(value: object, field_name: str) -> str:
+    resolved = str(value or "")
+    try:
+        parsed = datetime.fromisoformat(resolved.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise EconomicLedgerError(
+            f"tigerbeetle_economic_parity_{field_name}_invalid"
+        ) from exc
+    _utc(parsed, f"tigerbeetle_economic_parity_{field_name}_invalid")
+    return resolved
+
+
+def _validate_projection_sections(
+    expected: Mapping[str, object],
+    actual: Mapping[str, object],
+    errors: Mapping[str, object],
+) -> None:
+    for field_name in ("account_count", "transaction_count", "transfer_count"):
+        _required_nonnegative_int(expected.get(field_name), f"expected_{field_name}")
+    for field_name in ("account_count", "transfer_count"):
+        _required_nonnegative_int(actual.get(field_name), f"actual_{field_name}")
+    for field_name in ("account_manifest_sha256", "transfer_manifest_sha256"):
+        _required_digest(expected.get(field_name), f"expected_{field_name}")
+        _required_digest(actual.get(field_name), f"actual_{field_name}")
+    expected_error_fields = {
+        "account_create",
+        "account_lookup",
+        "account_mismatch",
+        "account_missing",
+        "transfer_chain_partial",
+        "transfer_create",
+        "transfer_lookup",
+        "transfer_mismatch",
+        "transfer_missing",
+    }
+    if set(errors) != expected_error_fields:
+        raise EconomicLedgerError("tigerbeetle_economic_parity_errors_invalid")
+    for field_name, value in errors.items():
+        _required_nonnegative_int(value, f"errors_{field_name}")
+
+
+def _validated_blockers(payload: Mapping[str, object]) -> tuple[str, ...]:
+    blockers_raw = payload.get("blockers")
+    if not isinstance(blockers_raw, list):
+        raise EconomicLedgerError("tigerbeetle_economic_parity_blockers_invalid")
+    blocker_items = cast(list[object], blockers_raw)
+    if any(not isinstance(item, str) or not item for item in blocker_items):
+        raise EconomicLedgerError("tigerbeetle_economic_parity_blockers_invalid")
+    blockers = tuple(cast(list[str], blocker_items))
+    if blockers != tuple(sorted(set(blockers))):
+        raise EconomicLedgerError("tigerbeetle_economic_parity_blockers_invalid")
+    return blockers
+
+
+def _validate_diagnostics(payload: Mapping[str, object]) -> None:
+    operations = _required_mapping(
+        payload.get("operations"),
+        "tigerbeetle_economic_parity_operations_invalid",
+    )
+    for field_name, value in operations.items():
+        _required_nonnegative_int(value, f"operations_{field_name}")
+    for collection_name in ("mismatch_samples", "exceptions"):
+        collection = payload.get(collection_name)
+        if not isinstance(collection, list):
+            raise EconomicLedgerError(
+                f"tigerbeetle_economic_parity_{collection_name}_invalid"
+            )
+        collection_items = cast(list[object], collection)
+        if len(collection_items) > _MISMATCH_SAMPLE_LIMIT or any(
+            not isinstance(item, Mapping) for item in collection_items
+        ):
+            raise EconomicLedgerError(
+                f"tigerbeetle_economic_parity_{collection_name}_invalid"
+            )
+
+
+def _validated_payload_sections(
+    payload: Mapping[str, object],
+    *,
+    expected_cluster_id: int | None,
+) -> _ValidatedParityPayload:
+    if payload.get("schema_version") != TIGERBEETLE_ECONOMIC_PARITY_SCHEMA_VERSION:
+        raise EconomicLedgerError("tigerbeetle_economic_parity_schema_invalid")
+    if payload.get("projection_version") != (
+        projection.TIGERBEETLE_ECONOMIC_PROJECTION_VERSION
+    ):
+        raise EconomicLedgerError("tigerbeetle_economic_projection_version_invalid")
+    cluster_id = _required_nonnegative_int(payload.get("cluster_id"), "cluster_id")
+    if cluster_id == 0 or (
+        expected_cluster_id is not None and cluster_id != expected_cluster_id
+    ):
+        raise EconomicLedgerError("tigerbeetle_economic_parity_cluster_id_invalid")
+    _required_digest(payload.get("scope_sha256"), "scope_sha256")
+    _required_aware_timestamp(payload.get("observed_at"), "observed_at")
+    source_age = _required_nonnegative_int(
+        payload.get("source_age_seconds"),
+        "source_age_seconds",
+    )
+    max_source_age = _required_nonnegative_int(
+        payload.get("max_source_age_seconds"),
+        "max_source_age_seconds",
+    )
+    if max_source_age == 0:
+        raise EconomicLedgerError(
+            "tigerbeetle_economic_parity_max_source_age_seconds_invalid"
+        )
+    bindings = _required_mapping(
+        payload.get("bindings"),
+        "tigerbeetle_economic_parity_bindings_invalid",
+    )
+    expected = _required_mapping(
+        payload.get("expected"),
+        "tigerbeetle_economic_parity_expected_invalid",
+    )
+    actual = _required_mapping(
+        payload.get("actual"),
+        "tigerbeetle_economic_parity_actual_invalid",
+    )
+    errors = _required_mapping(
+        payload.get("errors"),
+        "tigerbeetle_economic_parity_errors_invalid",
+    )
+    _validate_projection_sections(expected, actual, errors)
+    blockers = _validated_blockers(payload)
+    parity = payload.get("parity")
+    if not isinstance(parity, bool):
+        raise EconomicLedgerError("tigerbeetle_economic_parity_value_invalid")
+    calculated = _parity_from_sections(
+        expected,
+        actual,
+        errors,
+        blockers,
+        source_fresh=source_age <= max_source_age,
+    )
+    if parity is not calculated:
+        raise EconomicLedgerError("tigerbeetle_economic_parity_value_contradiction")
+    if not parity and not blockers:
+        raise EconomicLedgerError("tigerbeetle_economic_parity_blocker_missing")
+    if payload.get("capital_authority") is not False:
+        raise EconomicLedgerError("tigerbeetle_economic_capital_authority_invalid")
+    if payload.get("promotion_authority") is not False:
+        raise EconomicLedgerError("tigerbeetle_economic_promotion_authority_invalid")
+    _validate_diagnostics(payload)
+    return _ValidatedParityPayload(
+        bindings=bindings,
+        expected=expected,
+        actual=actual,
+        errors=errors,
+        blockers=blockers,
+        source_age_seconds=source_age,
+        max_source_age_seconds=max_source_age,
+        parity=parity,
+    )
+
+
+def _require_bindings(
+    bindings: Mapping[str, object],
+    expected: Mapping[str, object],
+) -> None:
+    if set(bindings) != set(expected):
+        raise EconomicLedgerError("tigerbeetle_economic_parity_bindings_invalid")
+    for field_name, expected_value in expected.items():
+        if bindings.get(field_name) != expected_value:
+            raise EconomicLedgerError(
+                f"tigerbeetle_economic_parity_{field_name}_binding_invalid"
+            )
+
+
+def validate_tigerbeetle_economic_parity_payload(
+    payload: Mapping[str, object],
+    *,
+    replay: BrokerEconomicLedgerReplay,
+    runs: PublishedBrokerEconomicLedgerRuns,
+    observation: TigerBeetleEconomicParityObservation,
+) -> None:
+    """Recompute immutable expectations before sealing parity into PostgreSQL."""
+
+    sections = _validated_payload_sections(
+        payload,
+        expected_cluster_id=observation.cluster_id,
+    )
+    observed_at = _validated_observation(observation)
+    source_watermark = _utc(
+        replay.snapshot.source_watermark,
+        "tigerbeetle_economic_source_watermark_invalid",
+    )
+    if payload.get("scope_sha256") != projection.scope_digest(
+        replay.snapshot.prepared.scope
+    ):
+        raise EconomicLedgerError("tigerbeetle_economic_parity_scope_binding_invalid")
+    if payload.get("observed_at") != observed_at.isoformat():
+        raise EconomicLedgerError(
+            "tigerbeetle_economic_parity_observed_at_binding_invalid"
+        )
+    source_age_seconds = int((observed_at - source_watermark).total_seconds())
+    if source_age_seconds < 0:
+        raise EconomicLedgerError("tigerbeetle_economic_observed_before_watermark")
+    if sections.source_age_seconds != source_age_seconds:
+        raise EconomicLedgerError(
+            "tigerbeetle_economic_parity_source_age_binding_invalid"
+        )
+    if sections.max_source_age_seconds != observation.max_source_age_seconds:
+        raise EconomicLedgerError(
+            "tigerbeetle_economic_parity_max_source_age_binding_invalid"
+        )
+    _require_bindings(
+        sections.bindings,
+        _replay_bindings(replay, runs, source_watermark),
+    )
+    if dict(sections.expected) != projection.build_projection_summary(replay).payload():
+        raise EconomicLedgerError(
+            "tigerbeetle_economic_parity_expected_projection_invalid"
+        )
+
+
+def validated_tigerbeetle_parity_attachment(
+    parity: BrokerEconomicTigerBeetleParityResult,
+    replay: BrokerEconomicLedgerReplay,
+    runs: PublishedBrokerEconomicLedgerRuns,
+    observed_at: datetime,
+    max_source_age_seconds: int,
+) -> dict[str, object]:
+    """Validate the audit result against the reconciliation observation."""
+
+    expected_observed_at = _utc(
+        observed_at,
+        "economic_reconciliation_tigerbeetle_observation_binding_invalid",
+    )
+    if (
+        _validated_observation(parity.observation) != expected_observed_at
+        or parity.observation.max_source_age_seconds != max_source_age_seconds
+    ):
+        raise EconomicLedgerError(
+            "economic_reconciliation_tigerbeetle_observation_binding_invalid"
+        )
+    validate_tigerbeetle_economic_parity_payload(
+        parity.payload,
+        replay=replay,
+        runs=runs,
+        observation=parity.observation,
+    )
+    return dict(parity.payload)
+
+
+def _persisted_bindings(
+    row: BrokerEconomicLedgerReconciliation,
+    *,
+    input_manifest_sha256: str,
+    reducer_version: str,
+) -> dict[str, object]:
+    return {
+        "comparison_sha256": row.comparison_sha256,
+        "current_source_watermark": as_utc(row.source_watermark).isoformat(),
+        "input_id": str(row.input_id),
+        "input_manifest_sha256": input_manifest_sha256,
+        "input_source_watermark": as_utc(row.input_source_watermark).isoformat(),
+        "journal_run_id": str(row.journal_run_id),
+        "journal_sha256": row.journal_sha256,
+        "reducer_version": reducer_version,
+        "state_run_id": str(row.state_run_id),
+    }
+
+
+def load_persisted_tigerbeetle_economic_parity(
+    row: BrokerEconomicLedgerReconciliation,
+    *,
+    scope: LedgerScope,
+    expected_cluster_id: int | None,
+) -> tuple[Mapping[str, object] | None, bool, tuple[str, ...]]:
+    """Validate the optional sealed parity payload and its row bindings."""
+
+    raw_payload = row.result.get("tigerbeetle_economic_parity")
+    if raw_payload is None:
+        return None, False, ("tigerbeetle_economic_parity_missing",)
+    payload = _required_mapping(
+        raw_payload,
+        "economic_reconciliation_persisted_tigerbeetle_parity_invalid",
+    )
+    sections = _validated_payload_sections(
+        payload,
+        expected_cluster_id=expected_cluster_id,
+    )
+    if payload.get("scope_sha256") != projection.scope_digest(scope):
+        raise EconomicLedgerError("tigerbeetle_economic_parity_scope_binding_invalid")
+    if payload.get("observed_at") != as_utc(row.observed_at).isoformat():
+        raise EconomicLedgerError(
+            "tigerbeetle_economic_parity_observed_at_binding_invalid"
+        )
+    if sections.source_age_seconds != row.source_age_seconds:
+        raise EconomicLedgerError(
+            "tigerbeetle_economic_parity_source_age_binding_invalid"
+        )
+    if sections.max_source_age_seconds != row.max_source_age_seconds:
+        raise EconomicLedgerError(
+            "tigerbeetle_economic_parity_max_source_age_binding_invalid"
+        )
+    reducers = _required_mapping(
+        row.result.get("reducers"),
+        "economic_reconciliation_persisted_reducers_invalid",
+    )
+    reducer_version = str(reducers.get("journal") or "")
+    if not reducer_version:
+        raise EconomicLedgerError(
+            "economic_reconciliation_persisted_journal_reducer_invalid"
+        )
+    input_manifest_sha256 = _required_digest(
+        row.result.get("input_manifest_sha256"),
+        "input_manifest_sha256",
+    )
+    _require_bindings(
+        sections.bindings,
+        _persisted_bindings(
+            row,
+            input_manifest_sha256=input_manifest_sha256,
+            reducer_version=reducer_version,
+        ),
+    )
+    return payload, sections.parity, sections.blockers
+
+
+__all__ = (
+    "TIGERBEETLE_ECONOMIC_PARITY_SCHEMA_VERSION",
+    "BrokerEconomicTigerBeetleParityResult",
+    "TigerBeetleEconomicParityObservation",
+    "audit_broker_economic_tigerbeetle_parity",
+    "validate_tigerbeetle_economic_parity_payload",
+)

--- a/services/torghut/app/trading/economic_ledger/tigerbeetle_projection.py
+++ b/services/torghut/app/trading/economic_ledger/tigerbeetle_projection.py
@@ -1,0 +1,628 @@
+"""Deterministic TigerBeetle projection for the broker-economic journal."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, replace
+from decimal import Decimal
+from typing import TYPE_CHECKING, TypeVar, cast
+
+from app.trading.tigerbeetle_ids import U128_MAX, stable_u128, u128_decimal
+from app.trading.tigerbeetle_journal.journal_payloads import transfer_attr
+from app.trading.tigerbeetle_ledger_model import (
+    TigerBeetleAccountSpec,
+    TigerBeetleTransferSpec,
+)
+
+from .types import (
+    EconomicLedgerError,
+    LedgerScope,
+    LedgerTransaction,
+    canonical_sha256,
+)
+
+if TYPE_CHECKING:
+    from .persistence import BrokerEconomicLedgerReplay
+
+
+TIGERBEETLE_ECONOMIC_PROJECTION_VERSION = (
+    "torghut.broker-economic-tigerbeetle-projection.v1"
+)
+TIGERBEETLE_MAX_BATCH_SIZE = 8_189
+
+_AMOUNT_SCALE = Decimal("1000000000000000000")
+_LEDGER_HIGH_BIT = 1 << 31
+_LEDGER_LOW_MASK = _LEDGER_HIGH_BIT - 1
+
+_ACCOUNT_CODE_BY_TYPE = {
+    "asset": 1_601,
+    "clearing": 1_602,
+    "expense": 1_603,
+    "income": 1_604,
+    "equity": 1_605,
+    "liability": 1_606,
+}
+_TRANSFER_CODE_BY_RULE = {
+    "fill_weighted_average": 2_101,
+    "external_cash_flow": 2_102,
+    "dividend": 2_103,
+    "interest": 2_104,
+    "cash_fee": 2_105,
+    "crypto_asset_fee": 2_106,
+    "correction_reversal": 2_107,
+}
+_TRANSFER_KIND = "broker_economic_journal"
+_TRANSFER_FLAG_LINKED = 1
+
+_T = TypeVar("_T")
+
+
+@dataclass(slots=True)
+class ExpectedAccount:
+    spec: TigerBeetleAccountSpec
+    debits_posted: int = 0
+    credits_posted: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectionSummary:
+    accounts: dict[int, ExpectedAccount]
+    transfer_groups: tuple[tuple[TigerBeetleTransferSpec, ...], ...]
+    account_manifest_sha256: str
+    transfer_manifest_sha256: str
+
+    @property
+    def transaction_count(self) -> int:
+        return len(self.transfer_groups)
+
+    @property
+    def transfer_count(self) -> int:
+        return sum(len(group) for group in self.transfer_groups)
+
+    def payload(self) -> dict[str, object]:
+        return {
+            "account_count": len(self.accounts),
+            "account_manifest_sha256": self.account_manifest_sha256,
+            "transaction_count": self.transaction_count,
+            "transfer_count": self.transfer_count,
+            "transfer_manifest_sha256": self.transfer_manifest_sha256,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class _ProjectionContext:
+    scope_sha256: str
+    account_scope_key: str
+
+
+def canonical_line(value: Mapping[str, object]) -> bytes:
+    return (
+        json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        ).encode("utf-8")
+        + b"\n"
+    )
+
+
+def _scope_context(scope: LedgerScope) -> _ProjectionContext:
+    scope_payload = {
+        "account_label": scope.account_label,
+        "endpoint_fingerprint": scope.endpoint_fingerprint,
+        "environment": scope.environment,
+        "provider": scope.provider,
+        "projection_version": TIGERBEETLE_ECONOMIC_PROJECTION_VERSION,
+    }
+    scope_sha256 = canonical_sha256(scope_payload)
+    return _ProjectionContext(
+        scope_sha256=scope_sha256,
+        account_scope_key=scope_sha256[:32],
+    )
+
+
+def scope_digest(scope: LedgerScope) -> str:
+    return _scope_context(scope).scope_sha256
+
+
+def _commodity_ledger(commodity: str) -> int:
+    digest = hashlib.sha256(
+        (
+            f"{TIGERBEETLE_ECONOMIC_PROJECTION_VERSION}\0{commodity.strip().upper()}"
+        ).encode("utf-8")
+    ).digest()
+    return _LEDGER_HIGH_BIT | (int.from_bytes(digest[:4], "big") & _LEDGER_LOW_MASK)
+
+
+def _scaled_amount(value: Decimal) -> int:
+    scaled = abs(value) * _AMOUNT_SCALE
+    if scaled != scaled.to_integral_value():
+        raise EconomicLedgerError("tigerbeetle_economic_amount_precision_exceeded")
+    amount = int(scaled)
+    if amount <= 0 or amount > U128_MAX:
+        raise EconomicLedgerError("tigerbeetle_economic_amount_out_of_range")
+    return amount
+
+
+def _account_code(account: str) -> int:
+    account_type = account.split(":", 1)[0]
+    try:
+        return _ACCOUNT_CODE_BY_TYPE[account_type]
+    except KeyError as exc:
+        raise EconomicLedgerError(
+            f"tigerbeetle_economic_account_type_unsupported:{account_type}"
+        ) from exc
+
+
+def _projection_id(namespace: str, identity: str) -> int:
+    value = stable_u128(namespace, identity)
+    if value == U128_MAX:
+        raise EconomicLedgerError("tigerbeetle_economic_id_out_of_range")
+    return value
+
+
+def _transfer_code(posting_rule: str) -> int:
+    try:
+        return _TRANSFER_CODE_BY_RULE[posting_rule]
+    except KeyError as exc:
+        raise EconomicLedgerError(
+            f"tigerbeetle_economic_posting_rule_unsupported:{posting_rule}"
+        ) from exc
+
+
+def _account_spec(
+    *,
+    context: _ProjectionContext,
+    account: str,
+    commodity: str,
+) -> TigerBeetleAccountSpec:
+    identity = "\0".join(
+        (
+            TIGERBEETLE_ECONOMIC_PROJECTION_VERSION,
+            context.scope_sha256,
+            commodity,
+            account,
+        )
+    )
+    account_digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()
+    return TigerBeetleAccountSpec(
+        account_id=_projection_id(
+            "torghut.tigerbeetle.broker_economic.account",
+            identity,
+        ),
+        account_key=(
+            f"broker_economic:{context.account_scope_key}:{account_digest[:32]}"
+        ),
+        ledger=_commodity_ledger(commodity),
+        code=_account_code(account),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class _TransferProjectionContext:
+    projection: _ProjectionContext
+    transaction: LedgerTransaction
+    commodity: str
+
+
+@dataclass(slots=True)
+class _Posting:
+    line_number: int
+    account: TigerBeetleAccountSpec
+    remaining: int
+
+
+def _posting(
+    context: _TransferProjectionContext,
+    line_number: int,
+    account: str,
+    amount: Decimal,
+) -> _Posting:
+    return _Posting(
+        line_number=line_number,
+        account=_account_spec(
+            context=context.projection,
+            account=account,
+            commodity=context.commodity,
+        ),
+        remaining=_scaled_amount(amount),
+    )
+
+
+def _transfer_spec(
+    context: _TransferProjectionContext,
+    debit: _Posting,
+    credit: _Posting,
+    segment: int,
+    amount: int,
+) -> TigerBeetleTransferSpec:
+    identity = "\0".join(
+        (
+            TIGERBEETLE_ECONOMIC_PROJECTION_VERSION,
+            context.projection.scope_sha256,
+            context.transaction.digest,
+            context.commodity,
+            str(debit.line_number),
+            str(credit.line_number),
+            str(segment),
+            str(amount),
+        )
+    )
+    return TigerBeetleTransferSpec(
+        transfer_id=_projection_id(
+            "torghut.tigerbeetle.broker_economic.transfer",
+            identity,
+        ),
+        transfer_kind=_TRANSFER_KIND,
+        debit_account_id=debit.account.account_id,
+        credit_account_id=credit.account.account_id,
+        amount=amount,
+        ledger=debit.account.ledger,
+        code=_transfer_code(context.transaction.posting_rule),
+    )
+
+
+def _project_commodity(
+    context: _TransferProjectionContext,
+    lines: Sequence[tuple[int, str, Decimal]],
+) -> list[TigerBeetleTransferSpec]:
+    debits = [
+        _posting(context, line_number, account, amount)
+        for line_number, account, amount in lines
+        if amount > 0
+    ]
+    credits = [
+        _posting(context, line_number, account, amount)
+        for line_number, account, amount in lines
+        if amount < 0
+    ]
+    if not debits or not credits:
+        raise EconomicLedgerError("tigerbeetle_economic_transaction_unbalanced")
+
+    transfers: list[TigerBeetleTransferSpec] = []
+    debit_index = 0
+    credit_index = 0
+    segment = 0
+    while debit_index < len(debits) and credit_index < len(credits):
+        debit = debits[debit_index]
+        credit = credits[credit_index]
+        amount = min(debit.remaining, credit.remaining)
+        transfers.append(_transfer_spec(context, debit, credit, segment, amount))
+        debit.remaining -= amount
+        credit.remaining -= amount
+        if debit.remaining == 0:
+            debit_index += 1
+        if credit.remaining == 0:
+            credit_index += 1
+        segment += 1
+    if debit_index != len(debits) or credit_index != len(credits):
+        raise EconomicLedgerError("tigerbeetle_economic_transaction_unbalanced")
+    return transfers
+
+
+def project_broker_economic_transaction(
+    transaction: LedgerTransaction,
+    *,
+    scope: LedgerScope,
+) -> tuple[TigerBeetleTransferSpec, ...]:
+    """Decompose one balanced journal transaction into one linked TB chain."""
+
+    projection_context = _scope_context(scope)
+    by_commodity: dict[str, list[tuple[int, str, Decimal]]] = {}
+    ledger_by_commodity: dict[int, str] = {}
+    for line_number, line in enumerate(transaction.lines):
+        commodity = line.commodity.strip().upper()
+        ledger = _commodity_ledger(commodity)
+        existing_commodity = ledger_by_commodity.get(ledger)
+        if existing_commodity is not None and existing_commodity != commodity:
+            raise EconomicLedgerError("tigerbeetle_economic_commodity_ledger_collision")
+        ledger_by_commodity[ledger] = commodity
+        by_commodity.setdefault(commodity, []).append(
+            (line_number, line.account, line.amount)
+        )
+
+    transfers: list[TigerBeetleTransferSpec] = []
+    for commodity in sorted(by_commodity):
+        context = _TransferProjectionContext(
+            projection=projection_context,
+            transaction=transaction,
+            commodity=commodity,
+        )
+        transfers.extend(_project_commodity(context, by_commodity[commodity]))
+    return tuple(
+        replace(spec, flags=_TRANSFER_FLAG_LINKED if index < len(transfers) - 1 else 0)
+        for index, spec in enumerate(transfers)
+    )
+
+
+def _expected_accounts(
+    replay: BrokerEconomicLedgerReplay,
+    context: _ProjectionContext,
+) -> dict[int, ExpectedAccount]:
+    accounts: dict[int, ExpectedAccount] = {}
+    commodity_by_ledger: dict[int, str] = {}
+    for transaction in replay.reduction.journal.transactions:
+        for line in transaction.lines:
+            commodity = line.commodity.strip().upper()
+            ledger = _commodity_ledger(commodity)
+            existing_commodity = commodity_by_ledger.get(ledger)
+            if existing_commodity is not None and existing_commodity != commodity:
+                raise EconomicLedgerError(
+                    "tigerbeetle_economic_commodity_ledger_collision"
+                )
+            commodity_by_ledger[ledger] = commodity
+            spec = _account_spec(
+                context=context,
+                account=line.account,
+                commodity=commodity,
+            )
+            expected = accounts.get(spec.account_id)
+            if expected is None:
+                expected = ExpectedAccount(spec=spec)
+                accounts[spec.account_id] = expected
+            elif expected.spec != spec:
+                raise EconomicLedgerError("tigerbeetle_economic_account_id_collision")
+            amount = _scaled_amount(line.amount)
+            if line.amount > 0:
+                expected.debits_posted += amount
+                total = expected.debits_posted
+            else:
+                expected.credits_posted += amount
+                total = expected.credits_posted
+            if total > U128_MAX:
+                raise EconomicLedgerError(
+                    "tigerbeetle_economic_account_balance_out_of_range"
+                )
+    return accounts
+
+
+def _project_transfer_groups(
+    replay: BrokerEconomicLedgerReplay,
+) -> tuple[tuple[tuple[TigerBeetleTransferSpec, ...], ...], str]:
+    groups: list[tuple[TigerBeetleTransferSpec, ...]] = []
+    transfer_ids: set[int] = set()
+    transfer_hasher = hashlib.sha256()
+    for transaction in replay.reduction.journal.transactions:
+        group = project_broker_economic_transaction(
+            transaction,
+            scope=replay.snapshot.prepared.scope,
+        )
+        if not group:
+            raise EconomicLedgerError("tigerbeetle_economic_transaction_empty")
+        if len(group) > TIGERBEETLE_MAX_BATCH_SIZE:
+            raise EconomicLedgerError("tigerbeetle_economic_transaction_batch_exceeded")
+        for spec in group:
+            if spec.transfer_id in transfer_ids:
+                raise EconomicLedgerError("tigerbeetle_economic_transfer_id_collision")
+            transfer_ids.add(spec.transfer_id)
+            transfer_hasher.update(canonical_line(transfer_payload(spec)))
+        groups.append(group)
+    return tuple(groups), transfer_hasher.hexdigest()
+
+
+def _account_manifest(accounts: Mapping[int, ExpectedAccount]) -> str:
+    account_hasher = hashlib.sha256()
+    for account_id in sorted(accounts):
+        account_hasher.update(canonical_line(account_payload(accounts[account_id])))
+    return account_hasher.hexdigest()
+
+
+def build_projection_summary(replay: BrokerEconomicLedgerReplay) -> ProjectionSummary:
+    context = _scope_context(replay.snapshot.prepared.scope)
+    accounts = _expected_accounts(replay, context)
+    transfer_groups, transfer_manifest_sha256 = _project_transfer_groups(replay)
+    return ProjectionSummary(
+        accounts=accounts,
+        transfer_groups=transfer_groups,
+        account_manifest_sha256=_account_manifest(accounts),
+        transfer_manifest_sha256=transfer_manifest_sha256,
+    )
+
+
+def iter_transfer_batches(
+    summary: ProjectionSummary,
+) -> Iterable[tuple[TigerBeetleTransferSpec, ...]]:
+    batch: list[TigerBeetleTransferSpec] = []
+    for group in summary.transfer_groups:
+        if batch and len(batch) + len(group) > TIGERBEETLE_MAX_BATCH_SIZE:
+            yield tuple(batch)
+            batch = []
+        batch.extend(group)
+    if batch:
+        yield tuple(batch)
+
+
+def iter_group_batches(
+    summary: ProjectionSummary,
+) -> Iterable[tuple[tuple[TigerBeetleTransferSpec, ...], ...]]:
+    groups: list[tuple[TigerBeetleTransferSpec, ...]] = []
+    size = 0
+    for group in summary.transfer_groups:
+        if groups and size + len(group) > TIGERBEETLE_MAX_BATCH_SIZE:
+            yield tuple(groups)
+            groups = []
+            size = 0
+        groups.append(group)
+        size += len(group)
+    if groups:
+        yield tuple(groups)
+
+
+def chunked(values: Sequence[_T], size: int) -> Iterable[Sequence[_T]]:
+    for index in range(0, len(values), size):
+        yield values[index : index + size]
+
+
+def transfer_payload(spec: TigerBeetleTransferSpec) -> dict[str, object]:
+    return {
+        "amount": str(spec.amount),
+        "code": spec.code,
+        "credit_account_id": u128_decimal(spec.credit_account_id),
+        "debit_account_id": u128_decimal(spec.debit_account_id),
+        "flags": spec.flags,
+        "id": u128_decimal(spec.transfer_id),
+        "ledger": spec.ledger,
+        "pending_id": u128_decimal(spec.pending_id) if spec.pending_id else "0",
+        "timeout": spec.timeout,
+        "user_data_128": "0",
+        "user_data_32": 0,
+        "user_data_64": "0",
+    }
+
+
+def account_payload(expected: ExpectedAccount) -> dict[str, object]:
+    return {
+        "code": expected.spec.code,
+        "credits_pending": "0",
+        "credits_posted": str(expected.credits_posted),
+        "debits_pending": "0",
+        "debits_posted": str(expected.debits_posted),
+        "flags": 0,
+        "id": u128_decimal(expected.spec.account_id),
+        "ledger": expected.spec.ledger,
+        "user_data_128": "0",
+        "user_data_32": 0,
+        "user_data_64": "0",
+    }
+
+
+def account_identity_payload(expected: ExpectedAccount) -> dict[str, object]:
+    payload = account_payload(expected)
+    return {
+        key: payload[key]
+        for key in (
+            "code",
+            "flags",
+            "id",
+            "ledger",
+            "user_data_128",
+            "user_data_32",
+            "user_data_64",
+        )
+    }
+
+
+def _object_attr(value: object, name: str) -> object | None:
+    if isinstance(value, Mapping):
+        mapping = cast(Mapping[str, object], value)
+        resolved = mapping.get(name)
+        if resolved is None and name == "id":
+            resolved = mapping.get("account_id")
+        return resolved
+    if name == "id" and not hasattr(value, name) and hasattr(value, "account_id"):
+        return getattr(value, "account_id")
+    return getattr(value, name, None)
+
+
+def _required_int(value: object | None) -> int:
+    if not isinstance(value, (int, str)):
+        raise TypeError("tigerbeetle_integer_field_invalid")
+    return int(value)
+
+
+def _optional_int(value: object | None) -> int:
+    return 0 if value is None else _required_int(value)
+
+
+def _optional_transfer_int(value: object, name: str) -> int:
+    try:
+        return _optional_int(transfer_attr(value, name))
+    except AttributeError:
+        return 0
+
+
+def actual_transfer_payload(value: object) -> dict[str, object]:
+    pending_id = _optional_transfer_int(value, "pending_id")
+    return {
+        "amount": str(_required_int(transfer_attr(value, "amount"))),
+        "code": _required_int(transfer_attr(value, "code")),
+        "credit_account_id": u128_decimal(
+            _required_int(transfer_attr(value, "credit_account_id"))
+        ),
+        "debit_account_id": u128_decimal(
+            _required_int(transfer_attr(value, "debit_account_id"))
+        ),
+        "flags": _optional_transfer_int(value, "flags"),
+        "id": u128_decimal(_required_int(transfer_attr(value, "id"))),
+        "ledger": _required_int(transfer_attr(value, "ledger")),
+        "pending_id": u128_decimal(pending_id) if pending_id else "0",
+        "timeout": _optional_transfer_int(value, "timeout"),
+        "user_data_128": str(_optional_transfer_int(value, "user_data_128")),
+        "user_data_32": _optional_transfer_int(value, "user_data_32"),
+        "user_data_64": str(_optional_transfer_int(value, "user_data_64")),
+    }
+
+
+def actual_account_payload(value: object) -> dict[str, object]:
+    return {
+        "code": _required_int(_object_attr(value, "code")),
+        "credits_pending": str(_optional_int(_object_attr(value, "credits_pending"))),
+        "credits_posted": str(_optional_int(_object_attr(value, "credits_posted"))),
+        "debits_pending": str(_optional_int(_object_attr(value, "debits_pending"))),
+        "debits_posted": str(_optional_int(_object_attr(value, "debits_posted"))),
+        "flags": _optional_int(_object_attr(value, "flags")),
+        "id": u128_decimal(_required_int(_object_attr(value, "id"))),
+        "ledger": _required_int(_object_attr(value, "ledger")),
+        "user_data_128": str(_optional_int(_object_attr(value, "user_data_128"))),
+        "user_data_32": _optional_int(_object_attr(value, "user_data_32")),
+        "user_data_64": str(_optional_int(_object_attr(value, "user_data_64"))),
+    }
+
+
+def mismatch_fields(
+    expected: Mapping[str, object],
+    actual: Mapping[str, object],
+) -> list[str]:
+    return sorted(
+        key
+        for key, expected_value in expected.items()
+        if actual.get(key) != expected_value
+    )
+
+
+def account_objects_by_id(
+    values: Sequence[object],
+    *,
+    requested_ids: Sequence[int],
+) -> dict[int, object]:
+    requested = set(requested_ids)
+    resolved: dict[int, object] = {}
+    for value in values:
+        try:
+            account_id = _required_int(_object_attr(value, "id"))
+        except (TypeError, ValueError) as exc:
+            raise EconomicLedgerError(
+                "tigerbeetle_economic_account_lookup_payload_invalid"
+            ) from exc
+        if account_id not in requested or account_id in resolved:
+            raise EconomicLedgerError(
+                "tigerbeetle_economic_account_lookup_payload_invalid"
+            )
+        resolved[account_id] = value
+    return resolved
+
+
+def transfer_objects_by_id(
+    values: Sequence[object],
+    *,
+    requested_ids: Sequence[int],
+) -> dict[int, object]:
+    requested = set(requested_ids)
+    resolved: dict[int, object] = {}
+    for value in values:
+        try:
+            transfer_id = _required_int(transfer_attr(value, "id"))
+        except (AttributeError, TypeError, ValueError) as exc:
+            raise EconomicLedgerError(
+                "tigerbeetle_economic_transfer_lookup_payload_invalid"
+            ) from exc
+        if transfer_id not in requested or transfer_id in resolved:
+            raise EconomicLedgerError(
+                "tigerbeetle_economic_transfer_lookup_payload_invalid"
+            )
+        resolved[transfer_id] = value
+    return resolved

--- a/services/torghut/app/trading/strategy_capital_runtime.py
+++ b/services/torghut/app/trading/strategy_capital_runtime.py
@@ -6,12 +6,14 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from decimal import Decimal
+from typing import cast
 from uuid import UUID
 
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from ..api.build_metadata import BUILD_COMMIT, BUILD_IMAGE_DIGEST
+from ..config import settings
 from ..models import Strategy, StrategyCapitalAuthorityRecord
 from ..strategies.catalog import extract_catalog_metadata
 from .strategy_capital_authority import (
@@ -34,6 +36,11 @@ from .strategy_capital_authority_store import (
     load_active_strategy_capital_authority,
     load_strategy_capital_evidence_binding,
     validate_strategy_capital_authority_record,
+)
+from .economic_ledger import (
+    EconomicLedgerError,
+    configured_broker_economic_scope,
+    load_broker_economic_ledger_status,
 )
 
 
@@ -320,6 +327,41 @@ def _load_runtime_usage(
     return usage, None
 
 
+def _economic_parity_reasons(
+    session: Session,
+    *,
+    account_label: str,
+    observed_at: datetime,
+) -> tuple[str, ...]:
+    if not settings.tigerbeetle_economic_parity_required:
+        return ()
+    try:
+        status = load_broker_economic_ledger_status(
+            session,
+            scope=configured_broker_economic_scope(account_label=account_label),
+            observed_at=observed_at,
+            expected_tigerbeetle_cluster_id=settings.tigerbeetle_cluster_id,
+        )
+    except (EconomicLedgerError, SQLAlchemyError, TypeError, ValueError):
+        _rollback_read_failure(session)
+        return ("broker_economic_accounting_parity_read_failed",)
+    if status.get("entry_dependency_satisfied") is True:
+        return ()
+    reason_codes = status.get("reason_codes")
+    if not isinstance(reason_codes, Sequence) or isinstance(
+        reason_codes, (str, bytes, bytearray)
+    ):
+        return ("broker_economic_accounting_parity_status_invalid",)
+    reason_items = cast(Sequence[object], reason_codes)
+    if any(not isinstance(reason, str) for reason in reason_items):
+        return ("broker_economic_accounting_parity_status_invalid",)
+    typed_reasons = cast(Sequence[str], reason_items)
+    reasons = tuple(
+        dict.fromkeys(reason.strip() for reason in typed_reasons if reason.strip())
+    )
+    return reasons or ("broker_economic_accounting_parity_unproven",)
+
+
 def evaluate_runtime_strategy_capital_authority(
     session: Session,
     *,
@@ -334,6 +376,14 @@ def evaluate_runtime_strategy_capital_authority(
         return denied
     if context.authority.stage not in BROKER_RISK_STAGES:
         return _evaluate_context(context, _capital_request(context, request))
+    if context.venue is CapitalVenue.ALPACA:
+        parity_reasons = _economic_parity_reasons(
+            session,
+            account_label=request.account_label,
+            observed_at=request.observed_at,
+        )
+        if parity_reasons:
+            return context.verdict.denied(parity_reasons)
     evidence_binding, denied = _load_runtime_evidence(session, context, request)
     if evidence_binding is None:
         assert denied is not None
@@ -375,6 +425,17 @@ def _active_submission_authority_reasons(
     if authority.reduce_only:
         reasons.append("authority_reduce_only")
     reasons.extend(f"authority_blocker:{blocker}" for blocker in authority.blockers)
+    if authority.venue is CapitalVenue.ALPACA:
+        if authority.account_label is None:
+            reasons.append("authority_account_label_missing")
+        else:
+            reasons.extend(
+                _economic_parity_reasons(
+                    session,
+                    account_label=authority.account_label,
+                    observed_at=observed_at,
+                )
+            )
     reasons.extend(
         runtime_artifact_binding_reasons(
             authority=authority,

--- a/services/torghut/app/trading/tigerbeetle_client.py
+++ b/services/torghut/app/trading/tigerbeetle_client.py
@@ -32,7 +32,11 @@ class TigerBeetleClientProtocol(Protocol):
     def lookup_transfers(self, ids: Sequence[int]) -> Sequence[object]: ...
 
 
-class TigerBeetleClientTimeoutError(TimeoutError):
+class TigerBeetleClientError(RuntimeError):
+    """Normalized ordinary failure from the official TigerBeetle client."""
+
+
+class TigerBeetleClientTimeoutError(TigerBeetleClientError, TimeoutError):
     """Raised when the synchronous TigerBeetle client exceeds its RPC deadline."""
 
 
@@ -64,6 +68,12 @@ def _run_with_timeout(
         ) from exc
     if ok:
         return cast(_T, value)
+    if isinstance(value, TigerBeetleClientError):
+        raise value
+    if isinstance(value, Exception):
+        raise TigerBeetleClientError(
+            f"tigerbeetle_{operation_name}_failed:{type(value).__name__}"
+        ) from value
     if isinstance(value, BaseException):
         raise value
     raise RuntimeError(f"tigerbeetle_{operation_name}_failed")  # pragma: no cover

--- a/services/torghut/scripts/replay_broker_economic_ledger.py
+++ b/services/torghut/scripts/replay_broker_economic_ledger.py
@@ -13,15 +13,21 @@ from app.db import SessionLocal
 from app.trading.broker_mutation_receipts import fingerprint_broker_endpoint
 from app.trading.economic_ledger import (
     DEFAULT_SOURCE_MAX_AGE_SECONDS,
+    BrokerEconomicLedgerReplay,
     BrokerEconomicReconciliationBuild,
     LedgerScope,
+    PersistedBrokerEconomicReconciliation,
+    TigerBeetleEconomicParityObservation,
+    audit_broker_economic_tigerbeetle_parity,
     capture_broker_economic_snapshot,
     load_broker_economic_ledger_source_rows,
     persist_broker_economic_ledger_reconciliation,
     prepare_broker_economic_ledger_snapshot,
     publish_broker_economic_ledger,
+    require_published_broker_economic_ledger_runs,
     replay_broker_economic_ledger_snapshot,
 )
+from app.trading.tigerbeetle_client import create_tigerbeetle_client
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -55,27 +61,100 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=DEFAULT_SOURCE_MAX_AGE_SECONDS,
         help="Maximum closed-source age accepted by the reconciliation result.",
     )
-    return parser.parse_args(argv)
+    parser.add_argument(
+        "--tigerbeetle-parity",
+        action="store_true",
+        help=(
+            "With --observe, materialize missing immutable journal chains and "
+            "require exact full TigerBeetle parity."
+        ),
+    )
+    args = parser.parse_args(argv)
+    if args.tigerbeetle_parity and not args.observe:
+        parser.error("--tigerbeetle-parity requires --observe")
+    return args
+
+
+def _observation_output(
+    replay: BrokerEconomicLedgerReplay,
+    observation: PersistedBrokerEconomicReconciliation,
+) -> dict[str, object]:
+    result_payload = observation.result.payload
+    journal = replay.reduction.journal
+    runs = observation.runs
+    return {
+        "schema_version": "torghut.broker-economic-observation-log.v1",
+        "input": {
+            "count": replay.snapshot.prepared.input_count,
+            "manifest_sha256": replay.snapshot.prepared.manifest_digest,
+            "watermark": replay.snapshot.source_watermark.isoformat(),
+        },
+        "journal": {
+            "entry_count": sum(len(item.lines) for item in journal.transactions),
+            "journal_sha256": journal.journal_digest,
+            "reducer_version": journal.projection.reducer_version,
+            "transaction_count": len(journal.transactions),
+        },
+        "publication": {
+            "input_id": str(runs.input_id),
+            "journal_run_id": str(runs.journal_run_id),
+            "reused_existing": runs.reused_existing,
+            "state_run_id": str(runs.state_run_id),
+        },
+        "reconciliation": {
+            "observation_id": str(observation.observation_id),
+            "open_order_count": observation.result.open_order_count,
+            "reason_codes": result_payload["reason_codes"],
+            "reconciled": observation.result.reconciled,
+            "residual_count": observation.result.residual_count,
+            "result_sha256": observation.result.result_sha256,
+            "source_age_seconds": observation.result.source_age_seconds,
+            "tigerbeetle_economic_parity": result_payload.get(
+                "tigerbeetle_economic_parity"
+            ),
+        },
+    }
 
 
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
-    client = TorghutAlpacaClient()
-    if client.endpoint_class != "paper":
+    broker_client = TorghutAlpacaClient()
+    if broker_client.endpoint_class != "paper":
         raise RuntimeError("economic_ledger_replay_requires_paper_endpoint")
     if args.observe and (BUILD_COMMIT == "unknown" or BUILD_IMAGE_DIGEST is None):
         raise RuntimeError("economic_ledger_observation_build_identity_missing")
     scope = LedgerScope(
         provider="alpaca",
-        environment=client.endpoint_class,
+        environment=broker_client.endpoint_class,
         account_label=str(args.account_label),
-        endpoint_fingerprint=fingerprint_broker_endpoint(client.endpoint_url),
+        endpoint_fingerprint=fingerprint_broker_endpoint(broker_client.endpoint_url),
     )
-    snapshot = capture_broker_economic_snapshot(client) if args.observe else None
     with SessionLocal() as session, session.begin():
         source_rows = load_broker_economic_ledger_source_rows(session, scope=scope)
     ledger_snapshot = prepare_broker_economic_ledger_snapshot(source_rows)
     replay = replay_broker_economic_ledger_snapshot(ledger_snapshot)
+    snapshot = capture_broker_economic_snapshot(broker_client) if args.observe else None
+    tigerbeetle_parity = None
+    if args.tigerbeetle_parity:
+        if not settings.tigerbeetle_enabled:
+            raise RuntimeError("economic_ledger_tigerbeetle_parity_requires_enabled")
+        assert snapshot is not None
+        with SessionLocal() as session, session.begin():
+            runs = require_published_broker_economic_ledger_runs(session, replay)
+        tigerbeetle_client = create_tigerbeetle_client(settings)
+        try:
+            tigerbeetle_parity = audit_broker_economic_tigerbeetle_parity(
+                tigerbeetle_client,
+                replay,
+                runs=runs,
+                observation=TigerBeetleEconomicParityObservation(
+                    cluster_id=settings.tigerbeetle_cluster_id,
+                    observed_at=snapshot.observed_at,
+                    max_source_age_seconds=args.max_source_age_seconds,
+                ),
+            )
+        finally:
+            tigerbeetle_client.close()
     published = None
     observation = None
     if args.publish_token is not None or snapshot is not None:
@@ -99,23 +178,18 @@ def main(argv: list[str] | None = None) -> int:
                         image_digest=BUILD_IMAGE_DIGEST or "",
                     ),
                     max_source_age_seconds=args.max_source_age_seconds,
+                    tigerbeetle_parity=tigerbeetle_parity,
                 )
                 if snapshot is not None
                 else None
             )
-    payload = replay.to_payload(
-        published=published or (observation.runs if observation is not None else None)
-    )
-    payload["reconciliation"] = (
-        {
-            "observation_id": str(observation.observation_id),
-            **observation.result.payload,
-        }
-        if observation is not None
-        else None
-    )
+    if observation is not None:
+        payload = _observation_output(replay, observation)
+    else:
+        payload = replay.to_payload(published=published)
+        payload["reconciliation"] = None
     print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
-    return 0
+    return 1 if tigerbeetle_parity is not None and not tigerbeetle_parity.parity else 0
 
 
 if __name__ == "__main__":

--- a/services/torghut/tests/config/test_parses_signal_staleness_critical_reasons.py
+++ b/services/torghut/tests/config/test_parses_signal_staleness_critical_reasons.py
@@ -304,6 +304,7 @@ class TestParsesSignalStalenessCriticalReasons(_TestConfigBase):
             "tigerbeetle_required",
             "tigerbeetle_journal_enabled",
             "tigerbeetle_reconcile_required",
+            "tigerbeetle_economic_parity_required",
         }
         self.assertEqual(
             set(FEATURE_FLAG_BOOLEAN_KEY_BY_FIELD),

--- a/services/torghut/tests/config/test_tigerbeetle_settings_are_normalized.py
+++ b/services/torghut/tests/config/test_tigerbeetle_settings_are_normalized.py
@@ -21,6 +21,7 @@ class TestTigerbeetleSettingsAreNormalized(_TestConfigBase):
             TORGHUT_TIGERBEETLE_RPC_TIMEOUT_SECONDS=7.5,
             TORGHUT_TIGERBEETLE_JOURNAL_ENABLED=True,
             TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED=True,
+            TORGHUT_TIGERBEETLE_ECONOMIC_PARITY_REQUIRED=True,
         )
 
         self.assertTrue(settings.tigerbeetle_enabled)
@@ -31,6 +32,7 @@ class TestTigerbeetleSettingsAreNormalized(_TestConfigBase):
         self.assertEqual(settings.tigerbeetle_rpc_timeout_seconds, 7.5)
         self.assertTrue(settings.tigerbeetle_journal_enabled)
         self.assertTrue(settings.tigerbeetle_reconcile_required)
+        self.assertTrue(settings.tigerbeetle_economic_parity_required)
 
     def test_tigerbeetle_settings_reject_enabled_empty_addresses(self) -> None:
         with self.assertRaises(ValidationError):
@@ -44,6 +46,13 @@ class TestTigerbeetleSettingsAreNormalized(_TestConfigBase):
             ValidationError, "TORGHUT_TIGERBEETLE_CLUSTER_ID must be > 0"
         ):
             Settings(TORGHUT_TIGERBEETLE_CLUSTER_ID=0)
+
+    def test_economic_parity_requirement_requires_tigerbeetle_enabled(self) -> None:
+        with self.assertRaisesRegex(
+            ValidationError,
+            "TORGHUT_TIGERBEETLE_ENABLED is required when economic parity is required",
+        ):
+            Settings(TORGHUT_TIGERBEETLE_ECONOMIC_PARITY_REQUIRED=True)
 
     def test_tigerbeetle_settings_reject_invalid_health_timeout(self) -> None:
         with self.assertRaisesRegex(

--- a/services/torghut/tests/economic_ledger/test_persistence.py
+++ b/services/torghut/tests/economic_ledger/test_persistence.py
@@ -38,6 +38,8 @@ from app.trading.economic_ledger import (
     BrokerEconomicReconciliationBuild,
     EconomicLedgerError,
     LedgerScope,
+    TigerBeetleEconomicParityObservation,
+    audit_broker_economic_tigerbeetle_parity,
     load_broker_economic_ledger_source_rows,
     load_broker_economic_ledger_status,
     normalize_broker_economic_snapshot,
@@ -46,6 +48,7 @@ from app.trading.economic_ledger import (
     publish_broker_economic_ledger,
     replay_broker_economic_ledger_snapshot,
 )
+from tests.economic_ledger.test_tigerbeetle_parity import ExactTigerBeetleClient
 
 
 _OBSERVED_AT = datetime(2026, 7, 16, 13, 0, tzinfo=timezone.utc)
@@ -601,8 +604,10 @@ def test_reconciliation_observations_reuse_runs_across_newer_closed_watermarks()
         replay.snapshot.source_watermark.isoformat()
     )
     assert status["source_watermark"] == advanced.snapshot.source_watermark.isoformat()
-    assert status["diagnostic_only"] is True
+    assert status["diagnostic_only"] is False
     assert status["capital_authority"] is False
+    assert status["entry_dependency_satisfied"] is False
+    assert "tigerbeetle_economic_parity_missing" in status["reason_codes"]
     assert status["admissible"] is True
     assert status["input_manifest_sha256"] == replay.snapshot.prepared.manifest_digest
     assert status["reducers"] == {
@@ -669,4 +674,81 @@ def test_reconciliation_status_is_explicitly_missing_before_first_observation() 
             max_observation_age_seconds=60,
         )
     assert status["state"] == "missing"
-    assert status["reason_codes"] == ["economic_reconciliation_missing"]
+    assert status["reason_codes"] == [
+        "economic_reconciliation_missing",
+        "tigerbeetle_economic_parity_missing",
+    ]
+
+
+def test_sealed_full_parity_satisfies_entry_and_promotion_dependencies() -> None:
+    sessions = _session_factory()
+    _seed_source(sessions, _supported_history())
+    with sessions.begin() as session:
+        replay = _replay(session)
+        published = publish_broker_economic_ledger(
+            session,
+            replay,
+            confirmation_token=replay.publication_token,
+        )
+    snapshot = normalize_broker_economic_snapshot(
+        account={"status": "ACTIVE", "cash": "1009", "equity": "1009"},
+        positions=[],
+        open_orders=[],
+        observed_at=_OBSERVED_AT + timedelta(minutes=3),
+    )
+    parity = audit_broker_economic_tigerbeetle_parity(
+        ExactTigerBeetleClient(),
+        replay,
+        runs=published,
+        observation=TigerBeetleEconomicParityObservation(
+            cluster_id=2001,
+            observed_at=snapshot.observed_at,
+            max_source_age_seconds=300,
+        ),
+    )
+    mismatched = replace(
+        parity,
+        observation=replace(
+            parity.observation,
+            observed_at=snapshot.observed_at + timedelta(seconds=1),
+        ),
+    )
+
+    with (
+        pytest.raises(
+            EconomicLedgerError,
+            match="economic_reconciliation_tigerbeetle_observation_binding_invalid",
+        ),
+        sessions.begin() as session,
+    ):
+        persist_broker_economic_ledger_reconciliation(
+            session,
+            replay,
+            snapshot,
+            build=_BUILD,
+            tigerbeetle_parity=mismatched,
+        )
+
+    with sessions.begin() as session:
+        observation = persist_broker_economic_ledger_reconciliation(
+            session,
+            replay,
+            snapshot,
+            build=_BUILD,
+            tigerbeetle_parity=parity,
+        )
+    with sessions() as session:
+        status = load_broker_economic_ledger_status(
+            session,
+            scope=_SCOPE,
+            observed_at=_OBSERVED_AT + timedelta(minutes=4),
+            expected_tigerbeetle_cluster_id=2001,
+        )
+
+    assert observation.result.reconciled is True
+    assert observation.result.payload["tigerbeetle_economic_parity"] == parity.payload
+    assert status["accounting_parity_satisfied"] is True
+    assert status["entry_dependency_satisfied"] is True
+    assert status["promotion_dependency_satisfied"] is True
+    assert status["capital_authority"] is False
+    assert status["reason_codes"] == []

--- a/services/torghut/tests/economic_ledger/test_replay_cli.py
+++ b/services/torghut/tests/economic_ledger/test_replay_cli.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import json
+import uuid
+from datetime import datetime, timezone
 from types import SimpleNamespace
 
 import pytest
 
 from scripts import replay_broker_economic_ledger as replay_cli
+from tests.economic_ledger.test_tigerbeetle_parity import _flat_replay, _runs
 
 
 def test_observation_and_publication_modes_are_mutually_exclusive() -> None:
@@ -23,6 +27,158 @@ def test_default_mode_is_read_only_replay() -> None:
 
     assert args.observe is False
     assert args.publish_token is None
+
+
+def test_tigerbeetle_parity_requires_observation_mode() -> None:
+    with pytest.raises(SystemExit):
+        replay_cli._parse_args(["--tigerbeetle-parity"])
+
+
+def test_observation_log_excludes_token_scope_and_broker_economics() -> None:
+    replay = _flat_replay()
+    observation = SimpleNamespace(
+        observation_id=uuid.uuid4(),
+        runs=_runs(replay),
+        result=SimpleNamespace(
+            payload={
+                "reason_codes": [],
+                "economics": {"broker": {"cash": "sensitive"}},
+                "tigerbeetle_economic_parity": {
+                    "parity": True,
+                    "expected": {"transfer_count": 4},
+                },
+            },
+            open_order_count=0,
+            reconciled=True,
+            residual_count=0,
+            result_sha256="e" * 64,
+            source_age_seconds=1,
+        ),
+    )
+
+    payload = replay_cli._observation_output(replay, observation)
+    encoded = json.dumps(payload, sort_keys=True)
+
+    assert "publish:" not in encoded
+    assert _flat_replay().snapshot.prepared.scope.account_label not in encoded
+    assert "sensitive" not in encoded
+    assert "economics" not in encoded
+
+
+def test_parity_observation_closes_client_persists_evidence_and_exits_nonzero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    replay = _flat_replay()
+    runs = _runs(replay)
+    broker_snapshot = SimpleNamespace(
+        observed_at=datetime(2026, 7, 16, 14, 2, tzinfo=timezone.utc)
+    )
+    parity = SimpleNamespace(
+        parity=False,
+        payload={"schema_version": "test-parity", "parity": False},
+    )
+    persisted_kwargs: dict[str, object] = {}
+
+    class Transaction:
+        def __enter__(self) -> None:
+            return None
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+    class Session:
+        def __enter__(self) -> Session:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def begin(self) -> Transaction:
+            return Transaction()
+
+    class TigerBeetleClient:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    tigerbeetle_client = TigerBeetleClient()
+    observation = SimpleNamespace(
+        observation_id=uuid.uuid4(),
+        runs=runs,
+        result=SimpleNamespace(
+            payload={
+                "reason_codes": ["tigerbeetle_economic_transfer_missing"],
+                "tigerbeetle_economic_parity": parity.payload,
+            },
+            open_order_count=0,
+            reconciled=False,
+            residual_count=1,
+            result_sha256="e" * 64,
+            source_age_seconds=1,
+        ),
+    )
+
+    def persist(*_args: object, **kwargs: object) -> SimpleNamespace:
+        persisted_kwargs.update(kwargs)
+        return observation
+
+    monkeypatch.setattr(
+        replay_cli,
+        "TorghutAlpacaClient",
+        lambda: SimpleNamespace(
+            endpoint_class="paper",
+            endpoint_url="https://paper-api.alpaca.markets",
+        ),
+    )
+    monkeypatch.setattr(
+        replay_cli, "capture_broker_economic_snapshot", lambda *_: broker_snapshot
+    )
+    monkeypatch.setattr(replay_cli, "SessionLocal", Session)
+    monkeypatch.setattr(
+        replay_cli,
+        "load_broker_economic_ledger_source_rows",
+        lambda *_args, **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        replay_cli,
+        "prepare_broker_economic_ledger_snapshot",
+        lambda *_: replay.snapshot,
+    )
+    monkeypatch.setattr(
+        replay_cli,
+        "replay_broker_economic_ledger_snapshot",
+        lambda *_: replay,
+    )
+    monkeypatch.setattr(
+        replay_cli,
+        "require_published_broker_economic_ledger_runs",
+        lambda *_args, **_kwargs: runs,
+    )
+    monkeypatch.setattr(
+        replay_cli,
+        "create_tigerbeetle_client",
+        lambda *_: tigerbeetle_client,
+    )
+    monkeypatch.setattr(
+        replay_cli,
+        "audit_broker_economic_tigerbeetle_parity",
+        lambda *_args, **_kwargs: parity,
+    )
+    monkeypatch.setattr(
+        replay_cli,
+        "persist_broker_economic_ledger_reconciliation",
+        persist,
+    )
+    monkeypatch.setattr(replay_cli, "BUILD_COMMIT", "a" * 40)
+    monkeypatch.setattr(replay_cli, "BUILD_IMAGE_DIGEST", f"sha256:{'b' * 64}")
+    monkeypatch.setattr(replay_cli.settings, "tigerbeetle_enabled", True)
+    monkeypatch.setattr(replay_cli.settings, "tigerbeetle_cluster_id", 2001)
+
+    assert replay_cli.main(["--observe", "--tigerbeetle-parity"]) == 1
+    assert tigerbeetle_client.closed is True
+    assert persisted_kwargs["tigerbeetle_parity"] is parity
+    assert "tigerbeetle_cluster_id" not in persisted_kwargs
 
 
 def test_dry_run_closes_database_transaction_before_preparation_and_reduction(

--- a/services/torghut/tests/economic_ledger/test_tigerbeetle_parity.py
+++ b/services/torghut/tests/economic_ledger/test_tigerbeetle_parity.py
@@ -1,0 +1,437 @@
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from typing import cast
+
+import pytest
+
+from app.trading.economic_ledger import (
+    BrokerEconomicLedgerReplay,
+    BrokerEconomicLedgerSnapshot,
+    EconomicActivity,
+    EconomicLedgerError,
+    LedgerScope,
+    PublishedBrokerEconomicLedgerRuns,
+    TigerBeetleEconomicParityObservation,
+    audit_broker_economic_tigerbeetle_parity,
+    prepare_activities,
+    reduce_and_compare,
+)
+from app.trading.economic_ledger.tigerbeetle_parity import (
+    validate_tigerbeetle_economic_parity_payload,
+)
+from app.trading.economic_ledger.tigerbeetle_projection import (
+    project_broker_economic_transaction,
+)
+from app.trading.tigerbeetle_ledger_model import (
+    TigerBeetleAccountSpec,
+    TigerBeetleTransferSpec,
+)
+
+
+_AT = datetime(2026, 7, 16, 14, 0, tzinfo=timezone.utc)
+_SCOPE = LedgerScope(
+    provider="alpaca",
+    environment="paper",
+    account_label="parity-test",
+    endpoint_fingerprint="c" * 64,
+)
+
+
+class ExactTigerBeetleClient:
+    """Small protocol-faithful ledger used to test exact cumulative parity."""
+
+    def __init__(self) -> None:
+        self.accounts: dict[int, dict[str, int]] = {}
+        self.transfers: dict[int, dict[str, int]] = {}
+        self.account_create_calls = 0
+        self.transfer_create_calls = 0
+
+    def nop(self) -> None:
+        return None
+
+    def create_accounts(self, accounts: list[object]) -> list[object]:
+        self.account_create_calls += 1
+        results: list[object] = []
+        for index, value in enumerate(accounts):
+            spec = cast(TigerBeetleAccountSpec, value)
+            if spec.account_id in self.accounts:
+                results.append({"index": index, "status": "exists"})
+                continue
+            self.accounts[spec.account_id] = {
+                "id": spec.account_id,
+                "debits_pending": 0,
+                "debits_posted": 0,
+                "credits_pending": 0,
+                "credits_posted": 0,
+                "user_data_128": 0,
+                "user_data_64": 0,
+                "user_data_32": 0,
+                "ledger": spec.ledger,
+                "code": spec.code,
+                "flags": 0,
+            }
+        return results
+
+    def lookup_accounts(self, ids: list[int]) -> list[object]:
+        return [dict(self.accounts[item]) for item in ids if item in self.accounts]
+
+    def create_transfers(self, transfers: list[object]) -> list[object]:
+        self.transfer_create_calls += 1
+        results: list[object] = []
+        for index, value in enumerate(transfers):
+            spec = cast(TigerBeetleTransferSpec, value)
+            if spec.transfer_id in self.transfers:
+                results.append({"index": index, "status": "exists"})
+                continue
+            debit = self.accounts[spec.debit_account_id]
+            credit = self.accounts[spec.credit_account_id]
+            assert debit["ledger"] == credit["ledger"] == spec.ledger
+            self.transfers[spec.transfer_id] = {
+                "id": spec.transfer_id,
+                "debit_account_id": spec.debit_account_id,
+                "credit_account_id": spec.credit_account_id,
+                "amount": spec.amount,
+                "pending_id": spec.pending_id,
+                "user_data_128": 0,
+                "user_data_64": 0,
+                "user_data_32": 0,
+                "timeout": spec.timeout,
+                "ledger": spec.ledger,
+                "code": spec.code,
+                "flags": spec.flags,
+            }
+            debit["debits_posted"] += spec.amount
+            credit["credits_posted"] += spec.amount
+        return results
+
+    def lookup_transfers(self, ids: list[int]) -> list[object]:
+        return [dict(self.transfers[item]) for item in ids if item in self.transfers]
+
+    def remove_transfer(self, transfer_id: int) -> None:
+        transfer = self.transfers.pop(transfer_id)
+        self.accounts[transfer["debit_account_id"]]["debits_posted"] -= transfer[
+            "amount"
+        ]
+        self.accounts[transfer["credit_account_id"]]["credits_posted"] -= transfer[
+            "amount"
+        ]
+
+
+def _activity(
+    external_id: str,
+    activity_type: str,
+    *,
+    offset: int,
+    symbol: str | None = None,
+    side: str | None = None,
+    quantity: str | None = None,
+    price: str | None = None,
+    net_amount: str | None = None,
+    correction_of: str | None = None,
+) -> EconomicActivity:
+    return EconomicActivity(
+        scope=_SCOPE,
+        external_activity_id=external_id,
+        raw_payload_sha256=f"{offset + 1:064x}",
+        activity_type=activity_type,
+        first_observed_at=_AT + timedelta(seconds=offset),
+        event_at=_AT + timedelta(seconds=offset),
+        symbol=symbol,
+        side=side,
+        quantity=Decimal(quantity) if quantity is not None else None,
+        price=Decimal(price) if price is not None else None,
+        net_amount=Decimal(net_amount) if net_amount is not None else None,
+        currency="USD",
+        correction_of_external_id=correction_of,
+    )
+
+
+def _replay(*activities: EconomicActivity) -> BrokerEconomicLedgerReplay:
+    prepared = prepare_activities(activities)
+    manifest = [
+        activity.manifest_payload()
+        for activity in sorted(activities, key=lambda item: item.sort_key)
+    ]
+    snapshot = BrokerEconomicLedgerSnapshot(
+        cursor_id=uuid.uuid4(),
+        source_watermark=_AT + timedelta(minutes=1),
+        prepared=prepared,
+        activities=activities,
+        input_manifest_canonical_json=json.dumps(
+            manifest,
+            sort_keys=True,
+            separators=(",", ":"),
+        ),
+        option_contract_sizes=(),
+    )
+    return BrokerEconomicLedgerReplay(
+        snapshot=snapshot,
+        reduction=reduce_and_compare(prepared),
+        publication_token=f"publish:{'d' * 64}",
+    )
+
+
+def _flat_replay() -> BrokerEconomicLedgerReplay:
+    return _replay(
+        _activity("cash", "CSD", offset=0, net_amount="1000"),
+        _activity(
+            "buy",
+            "FILL",
+            offset=1,
+            symbol="AAPL",
+            side="buy",
+            quantity="1",
+            price="100",
+        ),
+        _activity(
+            "sell",
+            "FILL",
+            offset=2,
+            symbol="AAPL",
+            side="sell",
+            quantity="1",
+            price="110",
+        ),
+        _activity("fee", "FEE", offset=3, net_amount="-1"),
+    )
+
+
+def _runs(replay: BrokerEconomicLedgerReplay) -> PublishedBrokerEconomicLedgerRuns:
+    return PublishedBrokerEconomicLedgerRuns(
+        input_id=uuid.uuid4(),
+        journal_run_id=uuid.uuid4(),
+        state_run_id=uuid.uuid4(),
+        source_watermark=replay.snapshot.source_watermark,
+        reused_existing=True,
+    )
+
+
+def _audit(
+    client: ExactTigerBeetleClient,
+    replay: BrokerEconomicLedgerReplay,
+    *,
+    runs: PublishedBrokerEconomicLedgerRuns,
+    observed_at: datetime | None = None,
+    max_age: int = 300,
+):
+    return audit_broker_economic_tigerbeetle_parity(
+        client,
+        replay,
+        runs=runs,
+        observation=TigerBeetleEconomicParityObservation(
+            cluster_id=2001,
+            observed_at=observed_at or _AT + timedelta(minutes=2),
+            max_source_age_seconds=max_age,
+        ),
+    )
+
+
+def test_full_projection_is_exact_idempotent_and_bound_to_immutable_runs() -> None:
+    replay = _flat_replay()
+    runs = _runs(replay)
+    client = ExactTigerBeetleClient()
+
+    first = _audit(client, replay, runs=runs)
+    second = _audit(client, replay, runs=runs)
+
+    assert first.parity is True
+    assert first.payload["blockers"] == []
+    assert first.payload["expected"] == first.payload["actual"] | {
+        "transaction_count": len(replay.reduction.journal.transactions)
+    }
+    assert (
+        cast(dict[str, int], first.payload["operations"])[
+            "transfer_create_selected_count"
+        ]
+        > 0
+    )
+    assert second.parity is True
+    assert (
+        cast(dict[str, int], second.payload["operations"])[
+            "account_create_selected_count"
+        ]
+        == 0
+    )
+    assert (
+        cast(dict[str, int], second.payload["operations"])[
+            "transfer_create_selected_count"
+        ]
+        == 0
+    )
+    assert first.payload["expected"] == second.payload["expected"]
+    assert first.payload["actual"] == second.payload["actual"]
+
+
+def test_linked_transaction_projection_is_deterministic_and_atomic() -> None:
+    replay = _flat_replay()
+    transaction = replay.reduction.journal.transactions[1]
+
+    first = project_broker_economic_transaction(transaction, scope=_SCOPE)
+    second = project_broker_economic_transaction(transaction, scope=_SCOPE)
+
+    assert first == second
+    assert len(first) > 1
+    assert all(spec.flags == 1 for spec in first[:-1])
+    assert first[-1].flags == 0
+    assert all(spec.debit_account_id != spec.credit_account_id for spec in first)
+
+
+def test_partial_chain_is_not_blindly_replayed_and_blocks_parity() -> None:
+    replay = _flat_replay()
+    runs = _runs(replay)
+    client = ExactTigerBeetleClient()
+    first = _audit(client, replay, runs=runs)
+    assert first.parity is True
+    multi_transfer = next(
+        project_broker_economic_transaction(transaction, scope=_SCOPE)
+        for transaction in replay.reduction.journal.transactions
+        if len(project_broker_economic_transaction(transaction, scope=_SCOPE)) > 1
+    )
+    client.remove_transfer(multi_transfer[0].transfer_id)
+
+    result = _audit(client, replay, runs=runs)
+
+    assert result.parity is False
+    assert "tigerbeetle_economic_transfer_chain_partial" in result.payload["blockers"]
+    assert "tigerbeetle_economic_transfer_missing" in result.payload["blockers"]
+    assert (
+        cast(dict[str, int], result.payload["operations"])[
+            "transfer_create_selected_count"
+        ]
+        == 0
+    )
+
+
+def test_protocol_can_be_up_while_exact_transfer_parity_is_down() -> None:
+    replay = _flat_replay()
+    runs = _runs(replay)
+    client = ExactTigerBeetleClient()
+    assert _audit(client, replay, runs=runs).parity is True
+    transfer = next(iter(client.transfers.values()))
+    transfer["amount"] += 1
+
+    result = _audit(client, replay, runs=runs)
+
+    assert result.parity is False
+    assert "tigerbeetle_economic_transfer_mismatch" in result.payload["blockers"]
+    assert cast(dict[str, int], result.payload["errors"])["transfer_lookup"] == 0
+
+
+def test_preexisting_account_identity_mismatch_prevents_transfer_writes() -> None:
+    replay = _flat_replay()
+    runs = _runs(replay)
+    seeded = ExactTigerBeetleClient()
+    assert _audit(seeded, replay, runs=runs).parity is True
+    account_id, account = next(iter(seeded.accounts.items()))
+    client = ExactTigerBeetleClient()
+    client.accounts[account_id] = {
+        **account,
+        "code": account["code"] + 1,
+        "credits_posted": 0,
+        "debits_posted": 0,
+    }
+
+    result = _audit(client, replay, runs=runs)
+
+    assert result.parity is False
+    assert "tigerbeetle_economic_account_mismatch" in result.payload["blockers"]
+    assert "tigerbeetle_economic_transfer_missing" in result.payload["blockers"]
+    assert client.transfer_create_calls == 0
+
+
+def test_exact_account_balance_mismatch_blocks_parity() -> None:
+    replay = _flat_replay()
+    runs = _runs(replay)
+    client = ExactTigerBeetleClient()
+    assert _audit(client, replay, runs=runs).parity is True
+    next(iter(client.accounts.values()))["debits_posted"] += 1
+
+    result = _audit(client, replay, runs=runs)
+
+    assert result.parity is False
+    assert "tigerbeetle_economic_account_mismatch" in result.payload["blockers"]
+    assert cast(dict[str, int], result.payload["errors"])["account_lookup"] == 0
+
+
+def test_duplicate_lookup_payload_fails_closed() -> None:
+    class DuplicateLookupClient(ExactTigerBeetleClient):
+        def lookup_transfers(self, ids: list[int]) -> list[object]:
+            values = super().lookup_transfers(ids)
+            return values + values[:1]
+
+    replay = _flat_replay()
+    result = _audit(DuplicateLookupClient(), replay, runs=_runs(replay))
+
+    assert result.parity is False
+    assert "tigerbeetle_economic_transfer_lookup_failed" in result.payload["blockers"]
+    assert cast(dict[str, int], result.payload["errors"])["transfer_lookup"] > 0
+
+
+def test_stale_source_watermark_blocks_authority_without_hiding_exact_ledger() -> None:
+    replay = _flat_replay()
+    runs = _runs(replay)
+    result = _audit(
+        ExactTigerBeetleClient(),
+        replay,
+        runs=runs,
+        observed_at=_AT + timedelta(minutes=10),
+        max_age=300,
+    )
+
+    assert result.parity is False
+    assert result.payload["capital_authority"] is False
+    assert "tigerbeetle_economic_source_watermark_stale" in result.payload["blockers"]
+    assert (
+        cast(dict[str, object], result.payload["expected"])["account_manifest_sha256"]
+        == cast(dict[str, object], result.payload["actual"])["account_manifest_sha256"]
+    )
+
+
+def test_correction_reversal_and_replacement_project_without_delta() -> None:
+    replay = _replay(
+        _activity("cash-original", "CSD", offset=0, net_amount="100"),
+        _activity(
+            "cash-correction",
+            "CSD",
+            offset=1,
+            net_amount="120",
+            correction_of="cash-original",
+        ),
+    )
+    result = _audit(ExactTigerBeetleClient(), replay, runs=_runs(replay))
+
+    assert result.parity is True
+    assert [
+        transaction.posting_rule
+        for transaction in replay.reduction.journal.transactions
+    ] == ["external_cash_flow", "correction_reversal", "external_cash_flow"]
+
+
+def test_forged_expected_digest_is_rejected_before_persistence() -> None:
+    replay = _flat_replay()
+    runs = _runs(replay)
+    result = _audit(ExactTigerBeetleClient(), replay, runs=runs)
+    forged = dict(result.payload)
+    forged["expected"] = {
+        **cast(dict[str, object], result.payload["expected"]),
+        "transfer_manifest_sha256": "0" * 64,
+    }
+
+    with pytest.raises(
+        EconomicLedgerError,
+        match="tigerbeetle_economic_parity_value_contradiction",
+    ):
+        validate_tigerbeetle_economic_parity_payload(
+            forged,
+            replay=replay,
+            runs=runs,
+            observation=TigerBeetleEconomicParityObservation(
+                cluster_id=2001,
+                observed_at=_AT + timedelta(minutes=2),
+                max_source_age_seconds=300,
+            ),
+        )

--- a/services/torghut/tests/live_config_manifest_contract/test_broker_economic_ledger_reconciliation_cronjob.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_broker_economic_ledger_reconciliation_cronjob.py
@@ -77,7 +77,12 @@ class BrokerEconomicLedgerReconciliationCronJobTests(TestCase):
         )
         self.assertEqual(
             container["args"],
-            ["--observe", "--max-source-age-seconds", "300"],
+            [
+                "--observe",
+                "--tigerbeetle-parity",
+                "--max-source-age-seconds",
+                "300",
+            ],
         )
         invocation = " ".join(
             str(item)
@@ -119,6 +124,16 @@ class BrokerEconomicLedgerReconciliationCronJobTests(TestCase):
         self.assertGreaterEqual(len(described_commit), 7)
         self.assertTrue(commit.startswith(described_commit))
         self.assertEqual(env["TRADING_MODE"]["value"], "live")
+        self.assertEqual(env["TORGHUT_TIGERBEETLE_ENABLED"]["value"], "true")
+        self.assertEqual(env["TORGHUT_TIGERBEETLE_CLUSTER_ID"]["value"], "2001")
+        self.assertEqual(
+            env["TORGHUT_TIGERBEETLE_REPLICA_ADDRESSES"]["value"],
+            "torghut-tigerbeetle.torghut.svc.cluster.local:3000",
+        )
+        self.assertEqual(
+            env["TORGHUT_TIGERBEETLE_RPC_TIMEOUT_SECONDS"]["value"],
+            "30",
+        )
         self.assertNotIn("BROKER_ECONOMIC_LEDGER_PUBLISH_TOKEN", env)
 
     def test_cronjob_is_rendered_by_torghut_kustomization(self) -> None:

--- a/services/torghut/tests/live_config_manifest_contract/test_knative_env_wiring_is_safe_live_defaults.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_knative_env_wiring_is_safe_live_defaults.py
@@ -652,10 +652,22 @@ class TestKnativeEnvWiringIsSafeLiveDefaults(_TestLiveConfigManifestContractBase
             "TORGHUT_TIGERBEETLE_JOURNAL_ENABLED": "true",
         }
         requirements = {
-            "argocd/applications/torghut/knative-service.yaml": ("true", "false"),
-            "argocd/applications/torghut/knative-service-sim.yaml": ("false", "false"),
+            "argocd/applications/torghut/knative-service.yaml": (
+                "true",
+                "false",
+                "true",
+            ),
+            "argocd/applications/torghut/knative-service-sim.yaml": (
+                "false",
+                "false",
+                "false",
+            ),
         }
-        for relative_path, (required, reconcile_required) in requirements.items():
+        for relative_path, (
+            required,
+            reconcile_required,
+            economic_parity_required,
+        ) in requirements.items():
             env = _load_knative_env(relative_path)
             for key, value in common_expected.items():
                 self.assertEqual(env.get(key), value, f"{relative_path} {key}")
@@ -663,6 +675,10 @@ class TestKnativeEnvWiringIsSafeLiveDefaults(_TestLiveConfigManifestContractBase
             self.assertEqual(
                 env.get("TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED"),
                 reconcile_required,
+            )
+            self.assertEqual(
+                env.get("TORGHUT_TIGERBEETLE_ECONOMIC_PARITY_REQUIRED"),
+                economic_parity_required,
             )
 
     def test_torghut_tigerbeetle_client_pods_allow_io_uring(self) -> None:

--- a/services/torghut/tests/test_runtime_action_authority.py
+++ b/services/torghut/tests/test_runtime_action_authority.py
@@ -54,6 +54,70 @@ def _mutation_status(**overrides: object) -> dict[str, object]:
     return payload
 
 
+def _economic_ledger_status(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_version": "torghut.broker-economic-ledger-status.v1",
+        "entry_dependency_satisfied": True,
+        "reason_codes": [],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_required_accounting_parity_blocks_entry_only() -> None:
+    authority = reduce_runtime_action_authority(
+        service_status=_service(),
+        live_submission_gate=_gate(),
+        broker_mutation_status=_mutation_status(),
+        broker_economic_ledger_status=_economic_ledger_status(
+            entry_dependency_satisfied=False,
+            reason_codes=["tigerbeetle_economic_transfer_missing"],
+        ),
+        accounting_parity_required=True,
+        state=_state(),
+        evaluated_at=_NOW,
+    )
+
+    assert authority.service_healthy is True
+    assert authority.entry_allowed is False
+    assert authority.reduce_only_allowed is True
+    assert authority.recovery_degraded is False
+    assert authority.reason_codes["entry"] == ("tigerbeetle_economic_transfer_missing",)
+    assert authority.reason_codes["reduce_only"] == ()
+
+
+def test_current_accounting_parity_satisfies_required_entry_dependency() -> None:
+    authority = reduce_runtime_action_authority(
+        service_status=_service(),
+        live_submission_gate=_gate(),
+        broker_mutation_status=_mutation_status(),
+        broker_economic_ledger_status=_economic_ledger_status(),
+        accounting_parity_required=True,
+        state=_state(),
+        evaluated_at=_NOW,
+    )
+
+    assert authority.entry_allowed is True
+
+
+def test_required_accounting_parity_fails_closed_on_malformed_status() -> None:
+    authority = reduce_runtime_action_authority(
+        service_status=_service(),
+        live_submission_gate=_gate(),
+        broker_mutation_status=_mutation_status(),
+        broker_economic_ledger_status={"entry_dependency_satisfied": True},
+        accounting_parity_required=True,
+        state=_state(),
+        evaluated_at=_NOW,
+    )
+
+    assert authority.entry_allowed is False
+    assert authority.reduce_only_allowed is True
+    assert authority.reason_codes["entry"] == (
+        "broker_economic_accounting_parity_status_invalid",
+    )
+
+
 def test_capital_freeze_separates_service_entry_and_reduction_authority() -> None:
     authority = reduce_runtime_action_authority(
         service_status=_service(),

--- a/services/torghut/tests/test_tigerbeetle_client.py
+++ b/services/torghut/tests/test_tigerbeetle_client.py
@@ -12,6 +12,7 @@ from app.trading.tigerbeetle_client import (
     FakeTigerBeetleClient,
     HEALTH_PROBE_ACCOUNT_ID,
     RealTigerBeetleClient,
+    TigerBeetleClientError,
     TigerBeetleClientTimeoutError,
     _run_with_timeout,
     check_tigerbeetle_health,
@@ -167,13 +168,17 @@ class TestTigerBeetleClient(TestCase):
             rpc_timeout_seconds=settings.tigerbeetle_rpc_timeout_seconds,
         )
 
-    def test_timeout_helper_propagates_operation_errors(self) -> None:
-        with self.assertRaisesRegex(RuntimeError, "rpc failed"):
+    def test_timeout_helper_normalizes_operation_errors(self) -> None:
+        with self.assertRaisesRegex(
+            TigerBeetleClientError,
+            "tigerbeetle_lookup_accounts_failed:RuntimeError",
+        ) as raised:
             _run_with_timeout(
                 operation_name="lookup_accounts",
                 timeout_seconds=1.0,
                 operation=lambda: (_ for _ in ()).throw(RuntimeError("rpc failed")),
             )
+        self.assertIsInstance(raised.exception.__cause__, RuntimeError)
 
     def test_real_client_times_out_blocked_account_rpc(self) -> None:
         class _BlockingSync:

--- a/services/torghut/tests/trading/test_strategy_capital_authority_store.py
+++ b/services/torghut/tests/trading/test_strategy_capital_authority_store.py
@@ -9,6 +9,7 @@ import pytest
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session
 
+from app.config import settings
 from app.models import Base, EvidenceEpochRecord, Strategy, TradeDecision
 from app.trading.strategy_capital_authority import (
     AuthorityProofBindings,
@@ -547,6 +548,45 @@ def test_final_submission_hold_rejects_authority_that_expired_after_evaluation()
                 verdict=verdict,
                 observed_at=evaluated_at + timedelta(milliseconds=500),
             )
+            with (
+                patch.object(
+                    settings,
+                    "tigerbeetle_economic_parity_required",
+                    True,
+                ),
+                patch(
+                    "app.trading.strategy_capital_runtime.load_broker_economic_ledger_status",
+                    return_value={
+                        "schema_version": ("torghut.broker-economic-ledger-status.v1"),
+                        "entry_dependency_satisfied": False,
+                        "reason_codes": ["tigerbeetle_economic_transfer_missing"],
+                    },
+                ),
+            ):
+                parity_blocked_verdict = evaluate_runtime_strategy_capital_authority(
+                    session,
+                    strategy=strategy,
+                    request=RuntimeStrategyCapitalRequest(
+                        decision_id=uuid.uuid4(),
+                        account_label="paper",
+                        account_mode="paper",
+                        adapter_name="alpaca",
+                        symbol="NVDA",
+                        side="buy",
+                        order_notional=Decimal("100"),
+                        positions=[],
+                        capital_loss=Decimal("0"),
+                        observed_at=evaluated_at,
+                    ),
+                )
+                parity_blocked_hold = (
+                    hold_runtime_strategy_capital_authority_for_submission(
+                        session,
+                        strategy=strategy,
+                        verdict=verdict,
+                        observed_at=evaluated_at + timedelta(milliseconds=750),
+                    )
+                )
             final_verdict = hold_runtime_strategy_capital_authority_for_submission(
                 session,
                 strategy=strategy,
@@ -557,5 +597,13 @@ def test_final_submission_hold_rejects_authority_that_expired_after_evaluation()
     assert verdict.allowed is True
     assert held_verdict.allowed is True
     assert held_verdict.evaluated_at == evaluated_at + timedelta(milliseconds=500)
+    assert parity_blocked_verdict.allowed is False
+    assert parity_blocked_verdict.reason_codes == (
+        "tigerbeetle_economic_transfer_missing",
+    )
+    assert parity_blocked_hold.allowed is False
+    assert parity_blocked_hold.reason_codes == (
+        "tigerbeetle_economic_transfer_missing",
+    )
     assert final_verdict.allowed is False
     assert final_verdict.reason_codes == ("authority_expired",)


### PR DESCRIPTION
## Summary

- Project the immutable broker-economic journal into TigerBeetle with deterministic per-commodity ledgers, accounts, transfer IDs, exact fixed-point amounts, and atomic linked transfer chains.
- Verify complete account balances and transfer payloads on every replay, reject partial or conflicting chains, and seal the resulting parity observation into the existing append-only broker reconciliation record.
- Fail closed for new entry and capital promotion when broker reconciliation or fresh TigerBeetle parity is absent or mismatched, while leaving reduce-only, recovery, health, and readiness paths available; real-capital authority remains disabled.
- Wire the existing observer CronJob, live API, simulation API, and scheduler with explicit parity policy and sanitized operational output; add the production contract and roadmap documentation.
- Add regression coverage for idempotent replay, collision handling, partial writes, duplicate lookups, cumulative-balance drift, wrong account identity, stale/missing observations, runtime holds, and manifest defaults.

## Related Issues

None.

## Testing

- `uv run --frozen pytest -q tests/economic_ledger tests/test_runtime_action_authority.py tests/test_tigerbeetle_client.py tests/trading/test_strategy_capital_authority_store.py tests/live_config_manifest_contract/test_broker_economic_ledger_reconciliation_cronjob.py tests/live_config_manifest_contract/test_knative_env_wiring_is_safe_live_defaults.py tests/config/test_tigerbeetle_settings_are_normalized.py tests/config/test_parses_signal_staleness_critical_reasons.py` (209 passed)
- Repository-exact Pylint changed-line refactor gate, changed-file design gate, and file-length gate (all passed)
- `uv run --frozen python scripts/measure_torghut_tech_debt.py --baseline config/quality/tech-debt-baseline.json --enforce-ratchet --format markdown`
- `uv run --frozen python scripts/check_migration_graph.py`
- `uv run --frozen ruff format --check app tests scripts migrations`
- `uv run --frozen ruff check app tests scripts migrations`
- `uv run --frozen python -m compileall -q app tests scripts migrations`
- `uv run --frozen python scripts/run_pylint_torghut_structural_gate.py`
- All five Pyright profiles: base, alpha, scripts, alpha strict, and scripts strict (0 errors)
- `bun run lint:argocd` (0 invalid resources, 0 errors)
- `bunx oxfmt --check docs/torghut/profitability/README.md docs/torghut/profitability/implementation-roadmap.md docs/torghut/profitability/independent-economic-ledger.md docs/torghut/profitability/tigerbeetle-economic-parity.md`
- `git diff --check origin/main...HEAD`

## Breaking Changes

Operational behavior change: live risk-increasing entry and capital promotion now fail closed until both broker reconciliation and a fresh exact TigerBeetle parity observation pass. Reduce-only and recovery behavior remain available. No API or database migration is required.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
