### PR TITLE
docs(atlas): record production acceptance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,10 @@
 - For new GPT-5.6 integrations, start at `medium` reasoning, use `low` for measured latency-sensitive work, move to `high` or `xhigh` only for measured quality gains, and reserve `max` for the hardest quality-first workloads. Preserve an existing evaluated setting when migrating, then compare one level lower.
 - Use the Responses API for tool-using or multi-turn integrations and preserve response output items and applicable reasoning context across turns. Use programmatic tool calling only for bounded tool-heavy work that does not need fresh judgment between calls.
 
-Sources: [OpenAI GPT-5.6 model guidance](https://developers.openai.com/api/docs/guides/latest-model) and the [OpenAI GPT-5 prompting guide](https://developers.openai.com/cookbook/examples/gpt-5/gpt-5_prompting_guide).
+Sources: [OpenAI GPT-5.6 model guidance](https://developers.openai.com/api/docs/guides/latest-model), the current
+[GPT-5.6 Sol prompting guidance](https://developers.openai.com/api/docs/guides/prompt-guidance-gpt-5p6), and the
+[OpenAI GPT-5 Cookbook prompting guide](https://developers.openai.com/cookbook/examples/gpt-5/gpt-5_prompting_guide).
+Prefer the Sol-specific guidance when the sources differ.
 
 ## Repository Map
 

--- a/docs/atlas/README.md
+++ b/docs/atlas/README.md
@@ -46,7 +46,9 @@ of truth.
 5. If `origin/main` and the indexed commit differ, wait for the single reconcile workflow or run the operator verifier;
    do not start a duplicate reconcile.
 6. Do not infer corpus completeness from `atlas_stats`, sampled health, pod readiness, Argo health, or a few successful
-   queries. Only `atlas:verify` checks the complete contract.
+   queries. `atlas:verify` checks the complete Git, PostgreSQL, and Jangar corpus/search contract.
+7. For a complete rollout claim, also inspect the Definition of Done's Argo state, live image digest, single consumer,
+   and ten-minute convergence evidence; `atlas:verify` does not check those runtime gates.
 
 The dated execution record in the production design closed the initial rollout gate. Any later contradictory live
 evidence takes precedence and reopens it.

--- a/docs/atlas/README.md
+++ b/docs/atlas/README.md
@@ -1,8 +1,9 @@
 # Atlas Code Search
 
-Status: Current operating entrypoint. The in-place repair is implemented, but Atlas remains untrusted until the
-production images are deployed, the one corpus is rebuilt from the then-current `origin/main`, and every live acceptance
-gate passes.
+Status: Current operating entrypoint. Initial production acceptance passed on 2026-07-17. Atlas is trusted only while
+the live indexed commit matches the exact requested Git ref, search reports no degradation, and current behavior does not
+contradict the acceptance contract below. A mismatch, timeout, stale result, or irrelevant lexical fallback reopens the
+gate until reconciliation and `atlas:verify` pass again.
 
 Atlas is the repository ingestion, indexing, and search system used by Jangar, Bumba, Codex, and other agents. Its job
 is not merely to return plausible code. It must identify the exact indexed repository snapshot, search the complete
@@ -32,20 +33,23 @@ When sources disagree, use this order:
 The design describes required behavior. It must never be used to claim that behavior is already deployed. Every
 production claim needs current runtime proof against the active snapshot.
 
-## Agent Use Until Live Proof
+## Agent Trust and Reverification
 
-Atlas remains a navigation aid while the production acceptance gates are open.
+Atlas is a production navigation surface when its live index agrees with the requested Git ref. Git remains the source
+of truth.
 
 1. Search Atlas first when repository guidance requires it.
-2. Treat returned paths and line ranges as leads, not proof.
-3. Verify important results against the exact requested ref with `git show`, `rg`, or direct file reads.
+2. Check the returned commit and degradation fields before relying on a result.
+3. Verify high-impact findings against the returned exact commit with `git show`, `rg`, or direct file reads.
 4. If Atlas misses a known symbol, returns a deleted path, silently falls back from semantic search, or serves source
    from a different commit, report that contradiction rather than working around it invisibly.
-5. Do not infer corpus completeness from `atlas_stats`, sampled health, pod readiness, Argo health, or a few successful
-   queries.
+5. If `origin/main` and the indexed commit differ, wait for the single reconcile workflow or run the operator verifier;
+   do not start a duplicate reconcile.
+6. Do not infer corpus completeness from `atlas_stats`, sampled health, pod readiness, Argo health, or a few successful
+   queries. Only `atlas:verify` checks the complete contract.
 
-No agent should claim that Atlas works correctly until every gate in the production design's Definition of Done is
-proven on the live active snapshot.
+The dated execution record in the production design closed the initial rollout gate. Any later contradictory live
+evidence takes precedence and reopens it.
 
 ## Operator Commands
 
@@ -63,9 +67,10 @@ bun run atlas:verify \
   --base-url "$ATLAS_BASE_URL"
 ```
 
-The GitOps manifest intentionally sets `BUMBA_GITHUB_EVENT_CONSUMER_ENABLED=false` during cutover. Leave it disabled
-until `atlas:verify` exits zero against the live image and indexed commit. If `origin/main` advances, run rebuild and
-verification again. Re-enable the same consumer in Git only after the final verification passes.
+Production GitOps enables exactly one Bumba GitHub event consumer. During a future destructive rebuild, disable that
+same consumer through GitOps and leave it disabled until `atlas:verify` exits zero against the live image and indexed
+commit. If `origin/main` advances, let the existing reconcile finish and verify again. Re-enable the same consumer in Git
+only after the final verification passes; never add a second consumer or corpus.
 
 The rebuild writes bounded file batches while repository status is `building`, so all search surfaces return unavailable
 until the final complete-manifest transaction changes the status to `ready`. Temporal heartbeats detect a dead worker in

--- a/docs/atlas/production-code-search-design.md
+++ b/docs/atlas/production-code-search-design.md
@@ -258,8 +258,37 @@ There is nothing to restore.
   event callers share one repository-scoped workflow ID. Local PostgreSQL/pgvector tests prove forced post-batch failure,
   unavailable state, heartbeat resume, complete convergence, HNSW migration, hybrid search, and query cancellation. This
   is pre-merge evidence, not production proof.
-- The Definition of Done remains open until this hardening is merged, promoted, and used for a fresh rebuild of the then
-  current `origin/main`.
+- At this checkpoint the Definition of Done remained open pending merge, promotion, and a fresh rebuild. The accepted
+  2026-07-17 execution record below closes that initial rollout gate.
+
+### Execution record: 2026-07-17 — accepted
+
+- PR #12665 merged the bounded filtered-semantic and literal-search fix with PostgreSQL/pgvector regression coverage.
+  PR #12723 raised the exact/lexical PostgreSQL failure-isolation ceiling to five seconds while retaining verifier SLOs
+  of p95 below one second and p99 below two seconds. PR #12726 promoted the resulting Jangar image through GitOps.
+- The repair kept one existing Atlas schema and corpus, `vector(1024)`, and the configured
+  `qwen3-embedding-saigak:8b` model. It introduced no backup, shadow index, dual write, or fallback corpus.
+- On the accepted `b12191e4cff53a5266d4e289e43ecd9ea73620aa` snapshot, `atlas:verify` matched all 8,421 eligible
+  Git files and all 74,827 chunks/embeddings. Missing, stale, hash, object, commit, line-coverage, embedding, and chunk
+  metadata mismatches were all zero.
+- Exact identifier search ranked the definition first. The filtered cold semantic fixture ranked
+  `docs/atlas/production-code-search-design.md` first, returned ten results, and reported no degradation. Deleted paths
+  returned no results, and every sampled source preview matched the indexed commit and content hash.
+- The 24-request cold-unique-query performance probe passed below its one-second p95 and two-second p99 limits. The
+  cancellation probe reached PostgreSQL and left zero queries running after client cancellation.
+- Argo reported Jangar and Bumba `Synced` and `Healthy`; the running Jangar image matched the promoted digest. Exactly
+  one Bumba Deployment replica ran with `BUMBA_GITHUB_EVENT_CONSUMER_ENABLED=true`, and the accepted snapshot had no
+  running reconcile workflow, unprocessed event, or unfinished ingestion.
+- During the final audit, `origin/main` advanced to `d2ffb65c8b773e54189f6a6ff5fc924b0b2d7db3`. The existing
+  consumer started the single reconcile without operator duplication and completed in 1 minute 58 seconds. A fresh
+  verifier run then matched 8,426/8,426 files and 74,946/74,946 chunks/embeddings with zero integrity errors, p95
+  626 ms, p99 640 ms, and zero lingering canceled queries.
+- A separately issued cold semantic paraphrase that had no verbatim repository match returned
+  `services/bumba/src/atlas/file-eligibility.ts` first in 1.72 seconds with `retrievalMode=semantic` and
+  `degradation=null`. This proves the live non-fixture path without adding that query text to the indexed gold set.
+- This record closes initial production acceptance, not permanent trust. A later Git/index mismatch, timeout, stale
+  path, semantic degradation, or relevance contradiction reopens the gate until the single reconcile and full verifier
+  pass on the new active snapshot.
 
 ## Definition of Done
 
@@ -285,8 +314,10 @@ No percentage-based partial coverage is accepted. No fallback mode is called hea
 
 ## Agent Rule
 
-Until every Definition of Done item passes live, agents treat Atlas results only as navigation leads and verify material
-findings against Git. A miss, stale path, wrong commit, or fallback must be reported, not hidden with a narrower query.
+Agents may use Atlas as the production navigation surface only while the live indexed commit matches the requested Git
+ref and the response reports no degradation. Verify high-impact findings against the returned exact commit. A miss,
+stale path, wrong commit, timeout, or irrelevant lexical fallback is contradictory live evidence: report it and reopen
+the verification gate instead of hiding it with a narrower query.
 
 ## Code Map
 

--- a/docs/atlas/production-code-search-design.md
+++ b/docs/atlas/production-code-search-design.md
@@ -1,8 +1,8 @@
 # Atlas Code Search Repair Plan
 
-Status: The initial in-place repair merged in PR #12459. Production hardening is implemented in the codebase, but Atlas
-is not production-proven until the hardened images run, a fresh current-main rebuild completes, and the live Definition
-of Done passes.
+Status: Initial production acceptance passed on 2026-07-17 after the hardened images ran, fresh current-main
+reconciliation completed, and the live Definition of Done passed. The dated execution record below is the accepted
+baseline; any later contradictory live evidence reopens the gate.
 
 Evidence baseline: 2026-07-13, repository commit `9f6487ada0cf9222b65cbb1ee9b10d50a09b216e`.
 


### PR DESCRIPTION
## Summary

- Refresh AGENTS.md sources with current GPT-5.6 Sol-specific prompting guidance while retaining the official Cookbook reference.
- Record the accepted single-corpus Atlas rollout, verifier evidence, and a non-fixture cold semantic proof.
- Replace stale cutover-only instructions with the live one-consumer trust and reverification contract for agents.

## Related Issues

None

## Testing

- `bunx oxfmt --check AGENTS.md docs/atlas/README.md docs/atlas/production-code-search-design.md`
- `git diff --check`
- `bun run --filter @proompteng/jangar docs:inventory:check`
- `bun run --filter @proompteng/jangar check:module-sizes`
- Live `atlas:verify` against fresh `origin/main` d2ffb65c8b773e54189f6a6ff5fc924b0b2d7db3: 8,426/8,426 files, 74,946/74,946 embeddings, zero integrity errors, p95 626 ms, p99 640 ms, zero lingering canceled queries.
- Novel non-fixture cold semantic query: correct file ranked first, HTTP 200, `retrievalMode=semantic`, `degradation=null`.
- Single Bumba reconcile completed after main advanced; Temporal running workflows, unprocessed events, and unfinished ingestions all returned zero.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed; no visual change. Breaking Changes is filled in.
- [x] Documentation and operational follow-up state are updated.