### PR TITLE
fix(torghut): allow TigerBeetle observer io_uring

### DIFF
--- a/argocd/applications/torghut/broker-economic-ledger-reconciliation-cronjob.yaml
+++ b/argocd/applications/torghut/broker-economic-ledger-reconciliation-cronjob.yaml
@@ -39,6 +39,8 @@ spec:
               image: registry.ide-newton.ts.net/lab/torghut@sha256:5dd97b82ac388ea9d3815119881fc5802d627d8558b0408f03923b4197b9783b
               imagePullPolicy: IfNotPresent
               securityContext:
+                seccompProfile:
+                  type: Unconfined
                 allowPrivilegeEscalation: false
                 capabilities:
                   drop:

--- a/docs/torghut/profitability/tigerbeetle-economic-parity.md
+++ b/docs/torghut/profitability/tigerbeetle-economic-parity.md
@@ -195,6 +195,14 @@ The existing hourly broker-economic reconciliation CronJob owns parity. It runs 
 `--tigerbeetle-parity`, `Forbid` concurrency, no retry, a bounded deadline, the exact deployed build identity, and no
 publication token.
 
+The official TigerBeetle Linux client requires `io_uring`; the upstream project documents `PermissionDenied` under
+container seccomp defaults and recommends an unconfined seccomp profile. The reconciliation container therefore uses
+the same container-scoped `Unconfined` override as the existing TigerBeetle smoke job while remaining non-root, denying
+privilege escalation, dropping every Linux capability, and mounting no service-account token. The pod default remains
+`RuntimeDefault`, so the exception is limited to the one container that initializes the trusted TigerBeetle client.
+See TigerBeetle's [container troubleshooting](https://docs.tigerbeetle.com/operating/deploying/docker/) and the official
+[client io_uring report](https://github.com/tigerbeetle/tigerbeetle/issues/3295).
+
 Observation output is deliberately compact. It omits the publication token, raw scope, broker cash/equity, positions,
 residual values, and journal economic values. Durable detailed evidence remains in sealed CNPG rows and the bounded
 status surface.

--- a/services/torghut/tests/live_config_manifest_contract/test_broker_economic_ledger_reconciliation_cronjob.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_broker_economic_ledger_reconciliation_cronjob.py
@@ -68,7 +68,11 @@ class BrokerEconomicLedgerReconciliationCronJobTests(TestCase):
         seccomp = cast(Mapping[str, object], pod_security["seccompProfile"])
         self.assertEqual(seccomp["type"], "RuntimeDefault")
         container_security = cast(Mapping[str, object], container["securityContext"])
+        container_seccomp = cast(
+            Mapping[str, object], container_security["seccompProfile"]
+        )
         capabilities = cast(Mapping[str, object], container_security["capabilities"])
+        self.assertEqual(container_seccomp["type"], "Unconfined")
         self.assertFalse(container_security["allowPrivilegeEscalation"])
         self.assertEqual(capabilities["drop"], ["ALL"])
         self.assertEqual(


### PR DESCRIPTION
## Summary

- Fix the broker-economic parity observer's production startup failure: the official TigerBeetle Linux client requires `io_uring`, which the Kubernetes `RuntimeDefault` seccomp profile denied with a native `PermissionDenied` panic.
- Add the same container-scoped `Unconfined` seccomp override already used by the production TigerBeetle smoke job; keep the pod default at `RuntimeDefault` and preserve non-root execution, no privilege escalation, all capabilities dropped, and no service-account token.
- Lock the exception into the live manifest contract test and document the upstream runtime requirement and security boundary.

## Related Issues

None.

## Testing

- `uv run --frozen pytest -q tests/live_config_manifest_contract/test_broker_economic_ledger_reconciliation_cronjob.py` (3 passed)
- `bun run lint:argocd` (0 invalid resources, 0 errors)
- `bunx oxfmt --check docs/torghut/profitability/tigerbeetle-economic-parity.md`
- `git diff --check`

## Breaking Changes

Security-profile change: only the reconciliation container now overrides seccomp to `Unconfined` so the trusted TigerBeetle client can initialize `io_uring`. The pod default remains `RuntimeDefault`; all other container hardening remains enforced.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
