### PR TITLE
chore(infra): preserve flannel config during handoff

### DIFF
--- a/argocd/applications/flannel-cni/kube-flannel-cfg.yaml
+++ b/argocd/applications/flannel-cni/kube-flannel-cfg.yaml
@@ -3,6 +3,9 @@ kind: ConfigMap
 metadata:
   name: kube-flannel-cfg
   namespace: kube-system
+  annotations:
+    # Preserve live CNI configuration while ownership transfers from Argo CD to Talos.
+    argocd.argoproj.io/sync-options: Delete=false
   labels:
     k8s-app: flannel
     tier: node


### PR DESCRIPTION
## Summary

- Mark the Argo-managed Flannel ConfigMap with Delete=false before retiring the partial application.
- Preserve live CNI configuration during the ownership handoff to Talos.
- Make no runtime networking, MTU, or backend change in this phase.

## Related Issues

None

## Testing

- git diff --check
- kubectl kustomize argocd/applications/flannel-cni | kubectl apply --dry-run=server -n kube-system -f -
- bun run lint:argocd

## Breaking Changes

None. This is the preservation gate for a separately verified Talos ownership transition.

## Checklist

- [x] Testing section documents the exact validation performed (or N/A with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.