### PR TITLE
fix(landing): align fullscreen minimize origin

### DIFF
--- a/apps/landing/src/components/terminal-window-motion.test.ts
+++ b/apps/landing/src/components/terminal-window-motion.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+
+import { resolveTerminalWindowCenter } from './terminal-window-motion'
+
+void describe('terminal window motion', () => {
+  void test('uses the rendered fullscreen center when targeting the dock', () => {
+    assert.deepEqual(
+      resolveTerminalWindowCenter({
+        fixedViewport: { width: 1280, height: 720 },
+        offset: { x: 120, y: 80 },
+        fullscreen: true,
+        fullscreenOffsetY: 44 / 2 - 96 / 2,
+      }),
+      { x: 640, y: 334 },
+    )
+  })
+
+  void test('keeps the dragged center for a normal window', () => {
+    assert.deepEqual(
+      resolveTerminalWindowCenter({
+        fixedViewport: { width: 1320, height: 720 },
+        offset: { x: 120, y: 80 },
+        fullscreen: false,
+        fullscreenOffsetY: 44 / 2 - 96 / 2,
+      }),
+      { x: 780, y: 440 },
+    )
+  })
+})

--- a/apps/landing/src/components/terminal-window-motion.ts
+++ b/apps/landing/src/components/terminal-window-motion.ts
@@ -1,0 +1,19 @@
+export type FixedViewportSize = {
+  width: number
+  height: number
+}
+
+export type TerminalWindowOffset = {
+  x: number
+  y: number
+}
+
+export const resolveTerminalWindowCenter = (input: {
+  fixedViewport: FixedViewportSize
+  offset: TerminalWindowOffset
+  fullscreen: boolean
+  fullscreenOffsetY: number
+}) => ({
+  x: input.fixedViewport.width / 2 + (input.fullscreen ? 0 : input.offset.x),
+  y: input.fixedViewport.height / 2 + (input.fullscreen ? input.fullscreenOffsetY : input.offset.y),
+})

--- a/apps/landing/src/components/terminal-window.tsx
+++ b/apps/landing/src/components/terminal-window.tsx
@@ -3,6 +3,7 @@
 import { motion } from 'motion/react'
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
 import LiveOnlineCounter from '@/components/live-online-counter'
+import { resolveTerminalWindowCenter } from '@/components/terminal-window-motion'
 import { cn } from '@/lib/utils'
 
 const AGENTRUN_FILE = 'charts/agents/examples/agentrun-workflow-smoke.yaml'
@@ -337,11 +338,15 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
       const menuBarRect = menuBarButtonRef.current.getBoundingClientRect()
       const topInsetPx = desktopBoundsRef?.current ? viewport.top : TOP_MENU_BAR_HEIGHT_PX
       const isFullscreenLike = fullscreenMode === 'fullscreen'
-      const windowCenterX = viewport.left + viewport.width / 2 + (isFullscreenLike ? 0 : offset.x)
-      const windowCenterY = viewport.top + viewport.height / 2 + (isFullscreenLike ? topInsetPx / 2 : offset.y)
+      const windowCenter = resolveTerminalWindowCenter({
+        fixedViewport: { width: window.innerWidth, height: window.innerHeight },
+        offset,
+        fullscreen: isFullscreenLike,
+        fullscreenOffsetY: topInsetPx / 2 - DOCK_SAFE_AREA_PX / 2,
+      })
       return {
-        x: menuBarRect.left + menuBarRect.width / 2 - windowCenterX,
-        y: menuBarRect.top + menuBarRect.height / 2 - windowCenterY,
+        x: menuBarRect.left + menuBarRect.width / 2 - windowCenter.x,
+        y: menuBarRect.top + menuBarRect.height / 2 - windowCenter.y,
       }
     }, [
       desktopBoundsRef,
@@ -360,14 +365,18 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
       // This avoids "minimize does nothing" when refs aren't available yet (SSR/fast interactions).
       const topInsetPx = desktopBoundsRef?.current ? viewport.top : TOP_MENU_BAR_HEIGHT_PX
       const isFullscreenLike = fullscreenMode === 'fullscreen'
-      const windowCenterX = viewport.left + viewport.width / 2 + (isFullscreenLike ? 0 : offset.x)
-      const windowCenterY = viewport.top + viewport.height / 2 + (isFullscreenLike ? topInsetPx / 2 : offset.y)
+      const windowCenter = resolveTerminalWindowCenter({
+        fixedViewport: { width: window.innerWidth, height: window.innerHeight },
+        offset,
+        fullscreen: isFullscreenLike,
+        fullscreenOffsetY: topInsetPx / 2 - DOCK_SAFE_AREA_PX / 2,
+      })
 
       const dockCenterX = viewport.left + viewport.width / 2
       const dockCenterY = viewport.top + viewport.height - 38
       return {
-        x: dockCenterX - windowCenterX,
-        y: dockCenterY - windowCenterY,
+        x: dockCenterX - windowCenter.x,
+        y: dockCenterY - windowCenter.y,
       }
     }, [
       desktopBoundsRef,


### PR DESCRIPTION
## Summary

- use the rendered fullscreen window center when computing measured and fallback dock minimize targets
- include the fullscreen dock-safe-area offset in the animation origin
- add a focused regression for fullscreen and normal-window center calculations

## Related Issues

Historical Codex finding: PR #3216 comment `2821137655`.

## Testing

- 2 focused motion tests passed
- landing TypeScript, Oxfmt, Oxlint, and type-aware Oxlint passed
- Next.js Turbopack production build completed successfully on the exact rebased head
