### PR TITLE
fix(torghut): charge initial tsmom turnover

### DIFF
--- a/services/torghut/app/trading/alpha/tsmom.py
+++ b/services/torghut/app/trading/alpha/tsmom.py
@@ -117,7 +117,8 @@ def _compute_portfolio_returns(
     cfg: TSMOMConfig,
 ) -> tuple[pd.Series, pd.Series, pd.Series, pd.Series]:
     port_ret_gross: pd.Series = (weights * rets).sum(axis=1).fillna(0.0)
-    turnover: pd.Series = weights.diff().abs().sum(axis=1).fillna(0.0)
+    weight_changes = weights.diff().fillna(weights)
+    turnover: pd.Series = weight_changes.abs().sum(axis=1)
     cost_ret: pd.Series = turnover * (cfg.cost_bps_per_turnover / 10000.0)
     port_ret_net: pd.Series = port_ret_gross - cost_ret
     return port_ret_gross, turnover, cost_ret, port_ret_net

--- a/services/torghut/tests/test_alpha_tsmom.py
+++ b/services/torghut/tests/test_alpha_tsmom.py
@@ -3,8 +3,13 @@ from __future__ import annotations
 from datetime import date
 
 import pandas as pd
+import pytest
 
-from app.trading.alpha.tsmom import TSMOMConfig, backtest_tsmom
+from app.trading.alpha.tsmom import (
+    TSMOMConfig,
+    _compute_portfolio_returns,
+    backtest_tsmom,
+)
 
 
 def test_backtest_tsmom_filters_dates_and_reports_debug_columns() -> None:
@@ -38,3 +43,25 @@ def test_backtest_tsmom_filters_dates_and_reports_debug_columns() -> None:
         "gross_leverage",
     }.issubset(debug.columns)
     assert debug["gross_leverage"].max() <= 1.0
+
+
+def test_portfolio_returns_charge_initial_rebalance_from_cash() -> None:
+    index = pd.date_range("2026-01-01", periods=2, freq="D", tz="UTC")
+    weights = pd.DataFrame(
+        {
+            "AAPL": [0.4, 0.1],
+            "MSFT": [-0.2, -0.1],
+        },
+        index=index,
+    )
+    rets = pd.DataFrame(0.0, index=index, columns=weights.columns)
+
+    _, turnover, cost_ret, port_ret_net = _compute_portfolio_returns(
+        weights,
+        rets,
+        TSMOMConfig(cost_bps_per_turnover=10.0),
+    )
+
+    assert turnover.tolist() == pytest.approx([0.6, 0.4])
+    assert cost_ret.tolist() == pytest.approx([0.0006, 0.0004])
+    assert port_ret_net.tolist() == pytest.approx([-0.0006, -0.0004])


### PR DESCRIPTION
## Summary

- treat the first weight row as a rebalance from cash when calculating TSMOM turnover
- preserve normal row-to-row turnover for subsequent dates
- add a regression proving initial gross exposure is charged transaction cost

## Related Issues

Historical Codex finding: PR #3015 comment `2791414590`.

## Testing

- focused Torghut regressions: 27 passed
- Ruff format and lint: passed
- Pyright main, alpha, and alpha-strict profiles: zero errors before the clean rebase
- exact-head `git diff --check`: passed

## Breaking Changes

None.

## Checklist

- [x] Testing section documents exact validation.
- [x] Screenshots are not applicable.
- [x] Documentation and release notes are not required.
