### PR TITLE
fix(torghut): block inadmissible TigerBeetle writes

### DIFF
--- a/services/torghut/app/trading/economic_ledger/tigerbeetle_parity.py
+++ b/services/torghut/app/trading/economic_ledger/tigerbeetle_parity.py
@@ -465,10 +465,13 @@ def _read_actual_projection(
     client: TigerBeetleClientProtocol,
     summary: projection.ProjectionSummary,
     state: _AuditState,
+    *,
+    materialize: bool,
 ) -> dict[str, object]:
-    _create_missing_accounts(client, summary, state)
-    if _accounts_are_safe_for_transfers(client, summary, state):
-        _create_missing_transfer_chains(client, summary, state)
+    if materialize:
+        _create_missing_accounts(client, summary, state)
+        if _accounts_are_safe_for_transfers(client, summary, state):
+            _create_missing_transfer_chains(client, summary, state)
     account_count, account_digest = _verify_accounts(client, summary, state)
     transfer_count, transfer_digest = _verify_transfers(client, summary, state)
     return {
@@ -506,7 +509,12 @@ def _run_audit(
         source_age_seconds=source_age_seconds,
         summary=summary,
         state=state,
-        actual=_read_actual_projection(client, summary, state),
+        actual=_read_actual_projection(
+            client,
+            summary,
+            state,
+            materialize=replay.reduction.admissible,
+        ),
     )
 
 

--- a/services/torghut/tests/economic_ledger/test_tigerbeetle_parity.py
+++ b/services/torghut/tests/economic_ledger/test_tigerbeetle_parity.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import uuid
+from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from typing import cast
@@ -264,6 +265,31 @@ def test_full_projection_is_exact_idempotent_and_bound_to_immutable_runs() -> No
     )
     assert first.payload["expected"] == second.payload["expected"]
     assert first.payload["actual"] == second.payload["actual"]
+
+
+def test_inadmissible_projection_never_materializes_tigerbeetle_entries() -> None:
+    replay = _flat_replay()
+    inadmissible_independent = replace(
+        replay.reduction.independent,
+        unsupported_activity_ids=("unsupported-activity",),
+    )
+    inadmissible_replay = replace(
+        replay,
+        reduction=replace(
+            replay.reduction,
+            independent=inadmissible_independent,
+        ),
+    )
+    client = ExactTigerBeetleClient()
+
+    result = _audit(client, inadmissible_replay, runs=_runs(inadmissible_replay))
+
+    assert result.parity is False
+    assert "tigerbeetle_economic_projection_inadmissible" in result.payload["blockers"]
+    assert client.account_create_calls == 0
+    assert client.transfer_create_calls == 0
+    assert client.accounts == {}
+    assert client.transfers == {}
 
 
 def test_linked_transaction_projection_is_deterministic_and_atomic() -> None:


### PR DESCRIPTION
## Summary

- prevent inadmissible economic reductions from creating TigerBeetle accounts or transfers
- retain read-only verification so parity evidence still reports existing ledger state
- add a regression proving inadmissible projections perform zero immutable writes

## Related Issues

Historical Codex finding: PR #12727 discussion `r3601261609`.

## Testing

- `uv run --frozen pytest -q tests/economic_ledger/test_tigerbeetle_parity.py` (11 passed)
- Ruff format and lint on the changed Python files
- `git diff --check`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
