### PR TITLE
fix(ci): diff pull requests from merge base

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v5
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -40,8 +40,8 @@ jobs:
           changed_manifests="${RUNNER_TEMP}/changed-manifests.txt"
           git rev-parse --verify 'HEAD^1' >/dev/null
           git rev-parse --verify 'HEAD^2' >/dev/null
-          git diff --find-renames --name-only --diff-filter=ACDMRTUXB 'HEAD^1' 'HEAD^2' > "${changed_files}"
-          git diff --find-renames --name-only --diff-filter=ACMRTUXB 'HEAD^1' 'HEAD^2' > "${changed_manifests}"
+          git diff --merge-base --find-renames --name-only --diff-filter=ACDMRTUXB 'HEAD^1' 'HEAD^2' > "${changed_files}"
+          git diff --merge-base --find-renames --name-only --diff-filter=ACMRTUXB 'HEAD^1' 'HEAD^2' > "${changed_manifests}"
           printf 'changed_files=%s\n' "${changed_files}" >> "${GITHUB_OUTPUT}"
           printf 'changed_manifests=%s\n' "${changed_manifests}" >> "${GITHUB_OUTPUT}"
 

--- a/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
@@ -325,16 +325,20 @@ describe('torghut build-push workflow', () => {
     expect(compareCall).toBeGreaterThan(authHeader)
   })
 
-  it('derives pull-request changed files from the checked-out merge commit', () => {
+  it('derives pull-request changed files from the merge base to the PR head', () => {
+    const checkoutStep = pullRequestWorkflow.indexOf('name: Check out repository')
+    const fullHistory = pullRequestWorkflow.indexOf('fetch-depth: 0', checkoutStep)
     const deriveFilesStep = pullRequestWorkflow.indexOf('Derive changed files from Git')
     const firstParent = pullRequestWorkflow.indexOf("git rev-parse --verify 'HEAD^1'", deriveFilesStep)
     const secondParent = pullRequestWorkflow.indexOf("git rev-parse --verify 'HEAD^2'", firstParent)
     const diffCall = pullRequestWorkflow.indexOf(
-      "git diff --find-renames --name-only --diff-filter=ACDMRTUXB 'HEAD^1' 'HEAD^2'",
+      "git diff --merge-base --find-renames --name-only --diff-filter=ACDMRTUXB 'HEAD^1' 'HEAD^2'",
       secondParent,
     )
 
-    expect(deriveFilesStep).toBeGreaterThan(-1)
+    expect(checkoutStep).toBeGreaterThan(-1)
+    expect(fullHistory).toBeGreaterThan(checkoutStep)
+    expect(deriveFilesStep).toBeGreaterThan(fullHistory)
     expect(firstParent).toBeGreaterThan(deriveFilesStep)
     expect(secondParent).toBeGreaterThan(firstParent)
     expect(diffCall).toBeGreaterThan(secondParent)
@@ -345,7 +349,7 @@ describe('torghut build-push workflow', () => {
   it('keeps deleted manifests out of kubeconform inputs', () => {
     const deriveFilesStep = pullRequestWorkflow.indexOf('Derive changed files from Git')
     const activeManifestFilter = pullRequestWorkflow.indexOf(
-      "git diff --find-renames --name-only --diff-filter=ACMRTUXB 'HEAD^1' 'HEAD^2'",
+      "git diff --merge-base --find-renames --name-only --diff-filter=ACMRTUXB 'HEAD^1' 'HEAD^2'",
       deriveFilesStep,
     )
     const activeManifestOutput = pullRequestWorkflow.indexOf('changed_manifests=', activeManifestFilter)


### PR DESCRIPTION
## Summary

- derive pull-request changed files from the merge base to the PR head
- exclude base-only commits that landed after a pull request branch diverged
- update the workflow contract tests for both general files and active manifests

## Related Issues

Historical Codex finding: PR #12712 discussion `r3599410304`.

## Testing

- `bun test packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts` (26 passed)
- `git diff --check`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
