### PR TITLE
fix(torghut): default invalid route counts

### DIFF
--- a/services/torghut/scripts/run_governance_policy_dry_run.py
+++ b/services/torghut/scripts/run_governance_policy_dry_run.py
@@ -274,7 +274,12 @@ def _int_field_or_default(
     default: int,
 ) -> int:
     value = payload.get(key)
-    return default if value is None else int(value)
+    if value is None or (isinstance(value, str) and not value.strip()):
+        return default
+    try:
+        return int(value)
+    except (OverflowError, TypeError, ValueError):
+        return default
 
 
 def main() -> int:

--- a/services/torghut/tests/test_governance_policy_dry_run.py
+++ b/services/torghut/tests/test_governance_policy_dry_run.py
@@ -336,10 +336,25 @@ class TestGovernancePolicyDryRun(TestCase):
         reasons = output["promotion_prerequisites"]["reasons"]
         self.assertIn("expert_router_registry_route_count_below_minimum", reasons)
 
+    def test_dry_run_defaults_blank_expert_router_route_count(self) -> None:
+        output = self._run_harness(expert_router_route_count="")
+
+        self.assertTrue(output["promotion_progression_allowed"])
+
+    def test_dry_run_defaults_invalid_expert_router_route_count(self) -> None:
+        output = self._run_harness(expert_router_route_count="not-an-integer")
+
+        self.assertTrue(output["promotion_progression_allowed"])
+
+    def test_dry_run_defaults_infinite_expert_router_route_count(self) -> None:
+        output = self._run_harness(expert_router_route_count=float("inf"))
+
+        self.assertTrue(output["promotion_progression_allowed"])
+
     def _run_harness(
         self,
         *extra_args: str,
-        expert_router_route_count: int | None = None,
+        expert_router_route_count: object | None = None,
     ) -> dict[str, object]:
         now = datetime.now(timezone.utc)
         repo_root = Path(__file__).resolve().parents[3]


### PR DESCRIPTION
## Summary

- treat blank and malformed expert-router route counts as missing input
- preserve explicit zero so the minimum-route gate still fails correctly
- add regressions for blank and non-integer report values

## Related Issues

Historical Codex finding: PR #12668 discussion `r3593612000`.

## Testing

- `uv run --frozen pytest -q tests/test_governance_policy_dry_run.py` (21 passed)
- Ruff format and lint on the changed Python files
- `git diff --check`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.