### PR TITLE
fix(torghut): keep inadmissible parity audits read-only

### DIFF
--- a/services/torghut/app/trading/economic_ledger/tigerbeetle_parity.py
+++ b/services/torghut/app/trading/economic_ledger/tigerbeetle_parity.py
@@ -469,6 +469,14 @@ def _read_actual_projection(
     _create_missing_accounts(client, summary, state)
     if _accounts_are_safe_for_transfers(client, summary, state):
         _create_missing_transfer_chains(client, summary, state)
+    return _verify_actual_projection(client, summary, state)
+
+
+def _verify_actual_projection(
+    client: TigerBeetleClientProtocol,
+    summary: projection.ProjectionSummary,
+    state: _AuditState,
+) -> dict[str, object]:
     account_count, account_digest = _verify_accounts(client, summary, state)
     transfer_count, transfer_digest = _verify_transfers(client, summary, state)
     return {
@@ -500,13 +508,18 @@ def _run_audit(
         _add_blocker(state.blockers, _BLOCKER_PROJECTION_EMPTY)
     if source_age_seconds > observation.max_source_age_seconds:
         _add_blocker(state.blockers, _BLOCKER_SOURCE_STALE)
+    actual = (
+        _read_actual_projection(client, summary, state)
+        if replay.reduction.admissible
+        else _verify_actual_projection(client, summary, state)
+    )
     return _AuditResult(
         observed_at=observed_at,
         source_watermark=source_watermark,
         source_age_seconds=source_age_seconds,
         summary=summary,
         state=state,
-        actual=_read_actual_projection(client, summary, state),
+        actual=actual,
     )
 
 

--- a/services/torghut/tests/economic_ledger/test_tigerbeetle_parity.py
+++ b/services/torghut/tests/economic_ledger/test_tigerbeetle_parity.py
@@ -266,6 +266,33 @@ def test_full_projection_is_exact_idempotent_and_bound_to_immutable_runs() -> No
     assert first.payload["actual"] == second.payload["actual"]
 
 
+def test_inadmissible_projection_is_a_read_only_parity_audit() -> None:
+    replay = _replay(
+        _activity("cash", "CSD", offset=0, net_amount="1000"),
+        _activity(
+            "buy",
+            "FILL",
+            offset=1,
+            symbol="AAPL",
+            side="buy",
+            quantity="1",
+            price="100",
+        ),
+        _activity("unsupported", "MA", offset=2),
+    )
+    assert replay.reduction.admissible is False
+    client = ExactTigerBeetleClient()
+
+    result = _audit(client, replay, runs=_runs(replay))
+
+    assert result.parity is False
+    assert "tigerbeetle_economic_projection_inadmissible" in result.payload["blockers"]
+    assert client.account_create_calls == 0
+    assert client.transfer_create_calls == 0
+    assert client.accounts == {}
+    assert client.transfers == {}
+
+
 def test_linked_transaction_projection_is_deterministic_and_atomic() -> None:
     replay = _flat_replay()
     transaction = replay.reduction.journal.transactions[1]


### PR DESCRIPTION
## Summary

- keep TigerBeetle parity audits read-only when either economic reduction is inadmissible
- retain exact account and transfer verification without creating immutable ledger objects
- add a regression proving unsupported source activity cannot trigger account or transfer writes

## Related Issues

Historical Codex finding on PR #12727: https://github.com/proompteng/lab/pull/12727#discussion_r3601261609

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/economic_ledger/test_tigerbeetle_parity.py -k inadmissible_projection_is_a_read_only_parity_audit -q`
- `uv run --frozen pytest tests/economic_ledger/test_tigerbeetle_parity.py -q`
- `.venv/bin/pyright --project pyrightconfig.json`
- `.venv/bin/pyright --project pyrightconfig.alpha.json`
- `.venv/bin/pyright --project pyrightconfig.scripts.json`
- `python3 -m compileall -q services/torghut/app/trading/economic_ledger/tigerbeetle_parity.py services/torghut/tests/economic_ledger/test_tigerbeetle_parity.py`
- `git diff --check`
- Local Ruff unavailable: the repository-pinned Ruff binary cannot execute in the agents-shell runtime; required CI lint remains a merge gate.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
