### PR TITLE
fix(talos): preserve flannel pod mtu

### DIFF
--- a/devices/altra/manifests/README.md
+++ b/devices/altra/manifests/README.md
@@ -14,6 +14,7 @@ Files:
 - `devices/altra/manifests/nvidia-kernel-modules.patch.yaml`
 - `devices/altra/manifests/node-labels.patch.yaml`
 - `devices/altra/manifests/kubelet-maxpods.patch.yaml` (set kubelet `maxPods` to 500)
+- `devices/altra/manifests/network-mtu.patch.yaml` (set the Flannel underlay to 1450 so VXLAN pod MTU is 1400)
 - `devices/altra/manifests/tailscale-extension-service.template.yaml`
 - `devices/altra/manifests/tailscale-dns.patch.yaml`
 - `devices/altra/manifests/altra-tailscale-nvidia-lts-schematic.yaml`

--- a/devices/altra/manifests/network-mtu.patch.yaml
+++ b/devices/altra/manifests/network-mtu.patch.yaml
@@ -1,0 +1,5 @@
+machine:
+  network:
+    interfaces:
+      - interface: enP5p1s0
+        mtu: 1450

--- a/devices/galactic/docs/troubleshooting-networking.md
+++ b/devices/galactic/docs/troubleshooting-networking.md
@@ -4,8 +4,31 @@ This cluster uses Talos-managed Flannel in VXLAN mode. Talos owns the Flannel Co
 and RBAC resources. Do not manage only a subset of those resources through Argo CD; split ownership causes Talos
 Kubernetes upgrades and Argo reconciliation to overwrite each other.
 
-If a future network requires a custom Flannel backend or MTU, either use Talos-supported Flannel configuration or
-disable Talos CNI management and move the complete Flannel installation to one GitOps application.
+The physical underlay interfaces use MTU 1450 so Flannel derives MTU 1400 after VXLAN overhead. Keep the node-specific
+Talos patches in sync with the active interface names:
+
+- Ryzen (`eno1`): `devices/ryzen/manifests/network-mtu.patch.yaml`
+- Altra (`enP5p1s0`): `devices/altra/manifests/network-mtu.patch.yaml`
+- Turin (`eno2np1`): `devices/turin/manifests/network-mtu.patch.yaml`
+
+This is required for GitHub Actions runner traffic. A fresh ARC runner at MTU 1450 repeatedly timed out while fetching
+GitHub pipeline connection data; lowering the same pod to MTU 1400 made it connect and claim a queued job immediately.
+Keeping the constraint in Talos machine configuration lets Talos remain the sole owner of the complete Flannel
+installation instead of maintaining a competing Argo-managed ConfigMap.
+
+Apply the patches without rebooting, one healthy node at a time:
+
+```bash
+talosctl -e 100.100.244.141 -n 100.100.244.141 patch machineconfig \
+  --patch @devices/ryzen/manifests/network-mtu.patch.yaml --mode=no-reboot
+talosctl -e 100.100.244.141 -n 100.100.244.142 patch machineconfig \
+  --patch @devices/altra/manifests/network-mtu.patch.yaml --mode=no-reboot
+talosctl -e 100.100.244.141 -n 100.100.244.190 patch machineconfig \
+  --patch @devices/turin/manifests/network-mtu.patch.yaml --mode=no-reboot
+```
+
+After restarting each Flannel pod, `/run/flannel/subnet.env` must report `FLANNEL_MTU=1400`. The Talos-managed
+`kube-flannel-cfg` ConfigMap should not contain an explicit CNI `mtu` field or Argo tracking annotations.
 
 Before every Kubernetes upgrade, inspect the Talos manifest plan:
 
@@ -14,7 +37,11 @@ talosctl -e <control-plane-ip> -n <control-plane-ip> upgrade-k8s --to <target-ve
 ```
 
 The plan must show Talos as the single manager of all Flannel resources and must not conflict with an Argo tracking
-annotation on `kube-system/kube-flannel-cfg`.
+annotation on `kube-system/kube-flannel-cfg`. Also verify the derived MTU before and after the upgrade:
+
+```bash
+talosctl -e <control-plane-ip> -n <node-ip> read /run/flannel/subnet.env
+```
 
 If VXLAN forwarding breaks, pods on one node cannot reach pods on another node, even though nodes may still appear
 `Ready`.

--- a/devices/ryzen/docs/cluster-bootstrap.md
+++ b/devices/ryzen/docs/cluster-bootstrap.md
@@ -18,6 +18,7 @@ Node-level patches:
 - `devices/ryzen/manifests/hostname.patch.yaml` (set Talos hostname to `ryzen`, optional if the generated config already sets it)
 - `devices/ryzen/manifests/node-labels.patch.yaml` (labels for KubeVirt scheduling)
 - `devices/ryzen/manifests/kubelet-maxpods.patch.yaml` (set kubelet `maxPods` to 500)
+- `devices/ryzen/manifests/network-mtu.patch.yaml` (set the Flannel underlay to 1450 so VXLAN pod MTU is 1400)
 - `devices/ryzen/manifests/tailscale-extension-service.template.yaml` (Tailscale extension service template)
 - `devices/ryzen/manifests/tailscale-extension-service.yaml` (generated from template; gitignored)
 - `devices/ryzen/manifests/tailscale-dns.patch.yaml` (prefer MagicDNS for tailnet hostnames)
@@ -92,6 +93,7 @@ If you need to re-layout these volumes on an already-installed node, follow:
 - `devices/ryzen/manifests/hostname.patch.yaml`
 - `devices/ryzen/manifests/node-labels.patch.yaml`
 - `devices/ryzen/manifests/kubelet-maxpods.patch.yaml`
+- `devices/ryzen/manifests/network-mtu.patch.yaml`
 - `devices/ryzen/manifests/tailscale-extension-service.yaml` (generate via `bun run packages/scripts/src/tailscale/generate-ryzen-extension-service.ts`)
 - `devices/ryzen/manifests/tailscale-dns.patch.yaml`
 

--- a/devices/ryzen/manifests/network-mtu.patch.yaml
+++ b/devices/ryzen/manifests/network-mtu.patch.yaml
@@ -1,0 +1,5 @@
+machine:
+  network:
+    interfaces:
+      - interface: eno1
+        mtu: 1450

--- a/devices/turin/README.md
+++ b/devices/turin/README.md
@@ -42,6 +42,7 @@ Manifests:
 - `devices/turin/manifests/etcd-lan-subnet.patch.yaml` (pin etcd peer/client addressing to the Turin LAN subnet)
 - `devices/turin/manifests/kubelet-node-ip-lan-subnet.patch.yaml` (pin kubelet node IP selection to the Turin LAN subnet)
 - `devices/turin/manifests/kubelet-maxpods.patch.yaml` (set kubelet `maxPods` to 500)
+- `devices/turin/manifests/network-mtu.patch.yaml` (set the Flannel underlay to 1450 so VXLAN pod MTU is 1400)
 - `devices/turin/manifests/nvidia-kernel-modules.patch.yaml` (load the NVIDIA kernel modules from the Talos system extension)
 - `devices/turin/manifests/time-servers.patch.yaml` (match the working control-plane nodes' explicit NTP servers)
 - `devices/turin/manifests/tailscale-dns.patch.yaml` (Talos DNS settings for node-level Tailscale)

--- a/devices/turin/manifests/network-mtu.patch.yaml
+++ b/devices/turin/manifests/network-mtu.patch.yaml
@@ -1,0 +1,5 @@
+machine:
+  network:
+    interfaces:
+      - interface: eno2np1
+        mtu: 1450


### PR DESCRIPTION
## Summary

- add node-specific Talos machine-config patches that set the physical Flannel underlay MTU to 1450
- keep Talos as the sole Flannel owner while VXLAN derives the required 1400 pod MTU
- document the live ARC MTU regression, recovery evidence, application order, and upgrade checks

## Related Issues

None

## Testing

- `talosctl -e 100.100.244.141 -n 100.100.244.141 patch machineconfig --patch @devices/ryzen/manifests/network-mtu.patch.yaml --mode=no-reboot --dry-run`
- `talosctl -e 100.100.244.141 -n 100.100.244.142 patch machineconfig --patch @devices/altra/manifests/network-mtu.patch.yaml --mode=no-reboot --dry-run`
- `talosctl -e 100.100.244.141 -n 100.100.244.190 patch machineconfig --patch @devices/turin/manifests/network-mtu.patch.yaml --mode=no-reboot --dry-run`
- `git diff --check`

## Breaking Changes

Apply each patch to one healthy node at a time before removing the temporary live ConfigMap MTU override or running `talosctl upgrade-k8s`.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
