### PR TITLE
test(torghut): align linked recovery status coverage

### DIFF
--- a/services/torghut/tests/execution/test_linked_submission_recovery_postgres.py
+++ b/services/torghut/tests/execution/test_linked_submission_recovery_postgres.py
@@ -486,6 +486,7 @@ def test_postgres_0069_negative_observation_commits_and_releases_pair(
         "rejected": 0,
         "expired": 0,
         "manual_review": 1,
+        "validation_quarantine_closed": 0,
     }
     with terminal_harness.engine.connect() as connection:
         event_types = tuple(


### PR DESCRIPTION
## Summary

- Update the linked-submission PostgreSQL recovery assertion for the validation-quarantine terminal status added in #12687.
- Keep the test exhaustive over every runtime recovery-resolution bucket, including an explicit zero count for unrelated recovery flows.
- Restore the focused linked-recovery PostgreSQL verification needed for the historical Codex remediation audit.

## Related Issues

None

## Testing

- `TORGHUT_TEST_POSTGRES_DSN=postgresql+psycopg://postgres@<test-postgres>:5432/postgres uv run --frozen --extra dev pytest tests/execution/test_linked_submission_recovery_postgres.py tests/execution/test_order_executor_existing_order_recovery_postgres.py tests/test_infrastructure_validation_quarantine.py -q` (23 passed)
- `uv run --frozen --extra dev ruff check tests/execution/test_linked_submission_recovery_postgres.py`
- `uv run --frozen --extra dev ruff format --check tests/execution/test_linked_submission_recovery_postgres.py`
- `uv run --frozen --extra dev python -m compileall -q tests/execution/test_linked_submission_recovery_postgres.py`
- `uv run --frozen --extra dev pyright --project pyrightconfig.json`
- `uv run --frozen --extra dev pyright --project pyrightconfig.alpha.json`
- `uv run --frozen --extra dev pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
