### PR TITLE
fix(torghut): use lane ConfigMap source default

### DIFF
--- a/services/torghut/app/trading/scheduler/governance/governance_mixin_decision_methods.py
+++ b/services/torghut/app/trading/scheduler/governance/governance_mixin_decision_methods.py
@@ -601,7 +601,6 @@ class TradingSchedulerGovernanceDecisionMethods(
                 gate_policy_path=gate_policy_path,
                 output_dir=run_output_dir,
                 promotion_target=promotion_target,
-                strategy_configmap_path=Path("/etc/torghut/strategies.yaml"),
                 code_version="live",
                 approval_token=approval_token,
                 drift_promotion_evidence=dict(drift_gate_evidence),

--- a/services/torghut/tests/trading_scheduler_autonomy/test_run_autonomous_cycle_uses_live_promotion_when_token_present.py
+++ b/services/torghut/tests/trading_scheduler_autonomy/test_run_autonomous_cycle_uses_live_promotion_when_token_present.py
@@ -165,6 +165,7 @@ class TestRunAutonomousCycleUsesLivePromotionWhenTokenPresent(
                 deps.call_kwargs["gate_policy_path"],
                 Path(settings.trading_autonomy_gate_policy_path),
             )
+            self.assertNotIn("strategy_configmap_path", deps.call_kwargs)
 
     def test_run_autonomous_cycle_passes_persistence_inputs(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Superseded

Closed without merge as a duplicate of PR #12743. Both branches initially omitted `strategy_configmap_path`, which Codex correctly identified as invalid in the deployed scheduler image. The authoritative remediation is #12743 and must pass the configured `strategy_config_path` instead of relying on the unavailable repository default.