### PR TITLE
docs(talos): record live flannel mtu handoff

### DIFF
--- a/devices/galactic/docs/troubleshooting-networking.md
+++ b/devices/galactic/docs/troubleshooting-networking.md
@@ -27,8 +27,20 @@ talosctl -e 100.100.244.141 -n 100.100.244.190 patch machineconfig \
   --patch @devices/turin/manifests/network-mtu.patch.yaml --mode=no-reboot
 ```
 
-After restarting each Flannel pod, `/run/flannel/subnet.env` must report `FLANNEL_MTU=1400`. The Talos-managed
-`kube-flannel-cfg` ConfigMap should not contain an explicit CNI `mtu` field or Argo tracking annotations.
+On an already-running node, `flannel.1` survives a Flannel pod restart and retains its previous MTU. Complete the
+live handoff on each node before removing any temporary ConfigMap override:
+
+```bash
+FLANNEL_POD=$(kubectl -n kube-system get pods -l k8s-app=flannel \
+  --field-selector spec.nodeName=<node-name> -o jsonpath='{.items[0].metadata.name}')
+kubectl -n kube-system exec "$FLANNEL_POD" -c kube-flannel -- ip link set dev flannel.1 mtu 1400
+kubectl -n kube-system delete pod "$FLANNEL_POD" --wait=true
+kubectl -n kube-system rollout status daemonset/kube-flannel --timeout=180s
+talosctl -e 100.100.244.141 -n <node-ip> read /run/flannel/subnet.env
+```
+
+`/run/flannel/subnet.env` must report `FLANNEL_MTU=1400`. The Talos-managed `kube-flannel-cfg` ConfigMap should not
+contain an explicit CNI `mtu` field or Argo tracking annotations after all three nodes have completed the handoff.
 
 Before every Kubernetes upgrade, inspect the Talos manifest plan:
 


### PR DESCRIPTION
## Summary

- document that the live `flannel.1` device retains its old MTU across a Flannel pod restart
- add the exact one-node-at-a-time handoff that sets `flannel.1` to 1400 before restart
- retain the final checks for Talos-derived MTU and absence of Argo ownership

## Related Issues

None

## Testing

- executed the documented sequence on `talos-192-168-1-194`
- verified physical `eno1` MTU 1450, `flannel.1` MTU 1400, and `FLANNEL_MTU=1400`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
