### PR TITLE
docs(talos): require bootstrap MTU patches

### DIFF
--- a/.github/workflows/scripts-ci.yml
+++ b/.github/workflows/scripts-ci.yml
@@ -14,6 +14,10 @@ on:
       - 'docs/agents/designs/handoff-common.md'
       - 'docs/runbooks/rook-ceph-client-ops-performance.md'
       - 'docs/nix-enabled-app-build-performance-rollout-plan.md'
+      - 'devices/altra/docs/cluster-bootstrap.md'
+      - 'devices/ryzen/docs/cluster-bootstrap.md'
+      - 'devices/turin/docs/nvidia-gpu-on-talos.md'
+      - 'devices/turin/docs/cluster-join-plan.md'
       - '.github/workflows/scripts-ci.yml'
   pull_request:
     paths:
@@ -26,6 +30,10 @@ on:
       - 'docs/agents/designs/handoff-common.md'
       - 'docs/runbooks/rook-ceph-client-ops-performance.md'
       - 'docs/nix-enabled-app-build-performance-rollout-plan.md'
+      - 'devices/altra/docs/cluster-bootstrap.md'
+      - 'devices/ryzen/docs/cluster-bootstrap.md'
+      - 'devices/turin/docs/nvidia-gpu-on-talos.md'
+      - 'devices/turin/docs/cluster-join-plan.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/scripts-ci.yml
+++ b/.github/workflows/scripts-ci.yml
@@ -18,6 +18,10 @@ on:
       - 'devices/ryzen/docs/cluster-bootstrap.md'
       - 'devices/turin/docs/nvidia-gpu-on-talos.md'
       - 'devices/turin/docs/cluster-join-plan.md'
+      - 'devices/galactic/docs/add-control-plane-node.md'
+      - 'devices/altra/manifests/network-mtu.patch.yaml'
+      - 'devices/ryzen/manifests/network-mtu.patch.yaml'
+      - 'devices/turin/manifests/network-mtu.patch.yaml'
       - '.github/workflows/scripts-ci.yml'
   pull_request:
     paths:
@@ -34,6 +38,10 @@ on:
       - 'devices/ryzen/docs/cluster-bootstrap.md'
       - 'devices/turin/docs/nvidia-gpu-on-talos.md'
       - 'devices/turin/docs/cluster-join-plan.md'
+      - 'devices/galactic/docs/add-control-plane-node.md'
+      - 'devices/altra/manifests/network-mtu.patch.yaml'
+      - 'devices/ryzen/manifests/network-mtu.patch.yaml'
+      - 'devices/turin/manifests/network-mtu.patch.yaml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/devices/altra/docs/cluster-bootstrap.md
+++ b/devices/altra/docs/cluster-bootstrap.md
@@ -84,6 +84,7 @@ talosctl apply-config --insecure -n "$ALTRA_IP" -e "$ALTRA_IP" \
   --config-patch @devices/altra/manifests/allow-scheduling-controlplane.patch.yaml \
   --config-patch @devices/altra/manifests/controlplane-endpoint-nuc.patch.yaml \
   --config-patch @devices/altra/manifests/kubelet-maxpods.patch.yaml \
+  --config-patch @devices/altra/manifests/network-mtu.patch.yaml \
   --mode=reboot
 ```
 

--- a/devices/galactic/docs/add-control-plane-node.md
+++ b/devices/galactic/docs/add-control-plane-node.md
@@ -10,6 +10,8 @@ Assumptions:
   - `ampone` (`192.168.1.203`)
 - NUC HAProxy endpoint is up: `https://nuc:6443` and `https://192.168.1.130:6443`
 - The new node is booted into Talos maintenance mode and you know its LAN IP.
+- `<device_dir>/manifests/network-mtu.patch.yaml` targets the new node's physical
+  underlay interface and keeps it at MTU 1450 so Flannel derives pod MTU 1400.
 
 ## 0) Update NUC HAProxy backends
 
@@ -88,11 +90,15 @@ talosctl apply-config --insecure -n <new_ip> -e <new_ip> \
   --config-patch @<device_dir>/manifests/allow-scheduling-controlplane.patch.yaml \
   --config-patch @<device_dir>/manifests/controlplane-endpoint-nuc.patch.yaml \
   --config-patch @<device_dir>/manifests/hostname.patch.yaml \
+  --config-patch @<device_dir>/manifests/network-mtu.patch.yaml \
   --mode=reboot
 ```
 
 Important:
 
+- The node-specific MTU patch is required on first install. Omitting it recreates
+  the Flannel/ARC timeout documented in
+  `devices/galactic/docs/troubleshooting-networking.md`.
 - The node IP may change after install/reboot (DHCP). Use console/KVM to confirm
   the post-install IP before troubleshooting.
 

--- a/devices/ryzen/docs/cluster-bootstrap.md
+++ b/devices/ryzen/docs/cluster-bootstrap.md
@@ -87,13 +87,23 @@ If you need to re-layout these volumes on an already-installed node, follow:
 
 - `devices/ryzen/docs/relayout-volumes.md`
 
+### 2.3 Required network MTU patch
+
+Keep the physical `eno1` underlay at MTU 1450 so Talos-managed Flannel derives
+the required VXLAN pod MTU of 1400:
+
+- `devices/ryzen/manifests/network-mtu.patch.yaml`
+
+This patch is required on the first install. Omitting it recreates the ARC
+runner connection timeouts documented in
+`devices/galactic/docs/troubleshooting-networking.md`.
+
 ### 2.4 Optional patches
 
 - `devices/ryzen/manifests/allow-scheduling-controlplane.patch.yaml` (single-node)
 - `devices/ryzen/manifests/hostname.patch.yaml`
 - `devices/ryzen/manifests/node-labels.patch.yaml`
 - `devices/ryzen/manifests/kubelet-maxpods.patch.yaml`
-- `devices/ryzen/manifests/network-mtu.patch.yaml`
 - `devices/ryzen/manifests/tailscale-extension-service.yaml` (generate via `bun run packages/scripts/src/tailscale/generate-ryzen-extension-service.ts`)
 - `devices/ryzen/manifests/tailscale-dns.patch.yaml`
 
@@ -128,7 +138,8 @@ export TALOSCONFIG=$PWD/devices/ryzen/talosconfig
 talosctl apply-config --insecure -n 192.168.1.194 -e 192.168.1.194 \
   -f devices/ryzen/controlplane.yaml \
   --config-patch @devices/ryzen/manifests/ephemeral-volume.patch.yaml \
-  --config-patch @devices/ryzen/manifests/local-path.patch.yaml
+  --config-patch @devices/ryzen/manifests/local-path.patch.yaml \
+  --config-patch @devices/ryzen/manifests/network-mtu.patch.yaml
 
 # Optional patches you can add at install time:
 #   --config-patch @devices/ryzen/manifests/allow-scheduling-controlplane.patch.yaml

--- a/devices/turin/docs/cluster-join-plan.md
+++ b/devices/turin/docs/cluster-join-plan.md
@@ -86,6 +86,8 @@ Preinstall the required Talos pieces in the machine config:
   `devices/turin/manifests/tailscale-dns.patch.yaml`
 - NVIDIA kernel module load patch:
   `devices/turin/manifests/nvidia-kernel-modules.patch.yaml`
+- Physical underlay MTU patch required for Flannel VXLAN traffic:
+  `devices/turin/manifests/network-mtu.patch.yaml`
 
 The installer-image patch is generated from
 `devices/turin/manifests/turin-talos-nvidia-lts-schematic.yaml`, which includes
@@ -104,6 +106,7 @@ Then include these patches with the first `talosctl apply-config`:
 ```bash
 --config-patch @devices/turin/manifests/installer-image.tailscale-nvidia-lts.patch.yaml \
 --config-patch @devices/turin/manifests/nvidia-kernel-modules.patch.yaml \
+--config-patch @devices/turin/manifests/network-mtu.patch.yaml \
 --config-patch @devices/turin/manifests/tailscale-extension-service.yaml \
 --config-patch @devices/turin/manifests/tailscale-dns.patch.yaml
 ```
@@ -270,6 +273,7 @@ talosctl apply-config --insecure -n 100.100.244.171 -e 100.100.244.171 \
   --config-patch @devices/turin/manifests/etcd-lan-subnet.patch.yaml \
   --config-patch @devices/turin/manifests/kubelet-node-ip-lan-subnet.patch.yaml \
   --config-patch @devices/turin/manifests/kubelet-maxpods.patch.yaml \
+  --config-patch @devices/turin/manifests/network-mtu.patch.yaml \
   --config-patch @devices/turin/manifests/nvidia-kernel-modules.patch.yaml \
   --config-patch @devices/turin/manifests/time-servers.patch.yaml \
   --config-patch @devices/turin/manifests/tailscale-extension-service.yaml \

--- a/devices/turin/docs/nvidia-gpu-on-talos.md
+++ b/devices/turin/docs/nvidia-gpu-on-talos.md
@@ -75,6 +75,7 @@ talosctl apply-config --insecure -n 100.100.244.171 -e 100.100.244.171 \
   --config-patch @devices/turin/manifests/etcd-lan-subnet.patch.yaml \
   --config-patch @devices/turin/manifests/kubelet-node-ip-lan-subnet.patch.yaml \
   --config-patch @devices/turin/manifests/kubelet-maxpods.patch.yaml \
+  --config-patch @devices/turin/manifests/network-mtu.patch.yaml \
   --config-patch @devices/turin/manifests/nvidia-kernel-modules.patch.yaml \
   --config-patch @devices/turin/manifests/time-servers.patch.yaml \
   --config-patch @devices/turin/manifests/tailscale-extension-service.yaml \

--- a/packages/scripts/src/docs/__tests__/talos-bootstrap-mtu.test.ts
+++ b/packages/scripts/src/docs/__tests__/talos-bootstrap-mtu.test.ts
@@ -23,6 +23,7 @@ describe('Talos bootstrap MTU contracts', () => {
     const ryzen = readRepoFile('devices/ryzen/docs/cluster-bootstrap.md')
     const turinJoin = readRepoFile('devices/turin/docs/cluster-join-plan.md')
     const turinGpu = readRepoFile('devices/turin/docs/nvidia-gpu-on-talos.md')
+    const canonicalJoin = readRepoFile('devices/galactic/docs/add-control-plane-node.md')
 
     expect(bashBlockAfter(altra, '## 2) Apply config to `altra` (first install)')).toContain(
       '--config-patch @devices/altra/manifests/network-mtu.patch.yaml',
@@ -38,6 +39,9 @@ describe('Talos bootstrap MTU contracts', () => {
     )
     expect(bashBlockAfter(turinGpu, '## Apply with first install')).toContain(
       '--config-patch @devices/turin/manifests/network-mtu.patch.yaml',
+    )
+    expect(bashBlockAfter(canonicalJoin, '## 3) Apply config (install + join)')).toContain(
+      '--config-patch @<device_dir>/manifests/network-mtu.patch.yaml',
     )
   })
 
@@ -55,16 +59,20 @@ describe('Talos bootstrap MTU contracts', () => {
     }
   })
 
-  test('runs the docs contract when an affected bootstrap runbook changes', () => {
+  test('runs the docs contract when an affected bootstrap input changes', () => {
     const workflow = readRepoFile('.github/workflows/scripts-ci.yml')
-    const protectedRunbooks = [
+    const protectedPaths = [
       'devices/altra/docs/cluster-bootstrap.md',
       'devices/ryzen/docs/cluster-bootstrap.md',
       'devices/turin/docs/nvidia-gpu-on-talos.md',
       'devices/turin/docs/cluster-join-plan.md',
+      'devices/galactic/docs/add-control-plane-node.md',
+      'devices/altra/manifests/network-mtu.patch.yaml',
+      'devices/ryzen/manifests/network-mtu.patch.yaml',
+      'devices/turin/manifests/network-mtu.patch.yaml',
     ]
 
-    for (const path of protectedRunbooks) {
+    for (const path of protectedPaths) {
       expect(workflow.split(`'${path}'`), path).toHaveLength(3)
     }
   })

--- a/packages/scripts/src/docs/__tests__/talos-bootstrap-mtu.test.ts
+++ b/packages/scripts/src/docs/__tests__/talos-bootstrap-mtu.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const repoRoot = join(import.meta.dir, '../../../../..')
+
+const readRepoFile = (path: string) => readFileSync(join(repoRoot, path), 'utf8')
+
+const bashBlockAfter = (document: string, marker: string): string => {
+  const markerIndex = document.indexOf(marker)
+  expect(markerIndex, `missing marker: ${marker}`).toBeGreaterThanOrEqual(0)
+  const blockStart = document.indexOf('```bash\n', markerIndex)
+  expect(blockStart, `missing bash block after: ${marker}`).toBeGreaterThanOrEqual(0)
+  const contentStart = blockStart + '```bash\n'.length
+  const blockEnd = document.indexOf('\n```', contentStart)
+  expect(blockEnd, `unterminated bash block after: ${marker}`).toBeGreaterThanOrEqual(0)
+  return document.slice(contentStart, blockEnd)
+}
+
+describe('Talos bootstrap MTU contracts', () => {
+  test('keeps the node-specific MTU patch in every first-install command', () => {
+    const altra = readRepoFile('devices/altra/docs/cluster-bootstrap.md')
+    const ryzen = readRepoFile('devices/ryzen/docs/cluster-bootstrap.md')
+    const turinJoin = readRepoFile('devices/turin/docs/cluster-join-plan.md')
+    const turinGpu = readRepoFile('devices/turin/docs/nvidia-gpu-on-talos.md')
+
+    expect(bashBlockAfter(altra, '## 2) Apply config to `altra` (first install)')).toContain(
+      '--config-patch @devices/altra/manifests/network-mtu.patch.yaml',
+    )
+    expect(bashBlockAfter(ryzen, '### 2.5 Apply config with patches')).toContain(
+      '--config-patch @devices/ryzen/manifests/network-mtu.patch.yaml',
+    )
+    expect(bashBlockAfter(turinJoin, 'Then include these patches with the first `talosctl apply-config`')).toContain(
+      '--config-patch @devices/turin/manifests/network-mtu.patch.yaml',
+    )
+    expect(bashBlockAfter(turinJoin, 'For a clean Turin install')).toContain(
+      '--config-patch @devices/turin/manifests/network-mtu.patch.yaml',
+    )
+    expect(bashBlockAfter(turinGpu, '## Apply with first install')).toContain(
+      '--config-patch @devices/turin/manifests/network-mtu.patch.yaml',
+    )
+  })
+
+  test('keeps each machine patch pinned to its physical interface and MTU', () => {
+    const patches = [
+      ['devices/altra/manifests/network-mtu.patch.yaml', 'interface: enP5p1s0'],
+      ['devices/ryzen/manifests/network-mtu.patch.yaml', 'interface: eno1'],
+      ['devices/turin/manifests/network-mtu.patch.yaml', 'interface: eno2np1'],
+    ] as const
+
+    for (const [path, interfaceLine] of patches) {
+      const patch = readRepoFile(path)
+      expect(patch, path).toContain(interfaceLine)
+      expect(patch, path).toContain('mtu: 1450')
+    }
+  })
+})

--- a/packages/scripts/src/docs/__tests__/talos-bootstrap-mtu.test.ts
+++ b/packages/scripts/src/docs/__tests__/talos-bootstrap-mtu.test.ts
@@ -54,4 +54,18 @@ describe('Talos bootstrap MTU contracts', () => {
       expect(patch, path).toContain('mtu: 1450')
     }
   })
+
+  test('runs the docs contract when an affected bootstrap runbook changes', () => {
+    const workflow = readRepoFile('.github/workflows/scripts-ci.yml')
+    const protectedRunbooks = [
+      'devices/altra/docs/cluster-bootstrap.md',
+      'devices/ryzen/docs/cluster-bootstrap.md',
+      'devices/turin/docs/nvidia-gpu-on-talos.md',
+      'devices/turin/docs/cluster-join-plan.md',
+    ]
+
+    for (const path of protectedRunbooks) {
+      expect(workflow.split(`'${path}'`), path).toHaveLength(3)
+    }
+  })
 })


### PR DESCRIPTION
## Superseded

Closed without merge. PR #12750 (`112f889ab518d6c399053e7fd4d999e02d91c583`) removed the unsafe physical-interface MTU patches and established the guarded Flannel CNI ConfigMap as the current design. This branch references files that no longer exist and would restore the rejected ownership strategy.

The remaining runbook validation defect from #12750 is handled by PR #12751.