### PR TITLE
fix(torghut): retry broker source races

### DIFF
--- a/services/torghut/scripts/replay_broker_economic_ledger.py
+++ b/services/torghut/scripts/replay_broker_economic_ledger.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
+import time
 
 from app.alpaca_client import TorghutAlpacaClient
 from app.api.build_metadata import BUILD_COMMIT, BUILD_IMAGE_DIGEST
@@ -15,6 +17,7 @@ from app.trading.economic_ledger import (
     DEFAULT_SOURCE_MAX_AGE_SECONDS,
     BrokerEconomicLedgerReplay,
     BrokerEconomicReconciliationBuild,
+    EconomicLedgerError,
     LedgerScope,
     PersistedBrokerEconomicReconciliation,
     TigerBeetleEconomicParityObservation,
@@ -28,6 +31,17 @@ from app.trading.economic_ledger import (
     replay_broker_economic_ledger_snapshot,
 )
 from app.trading.tigerbeetle_client import create_tigerbeetle_client
+
+
+_SOURCE_CONSISTENCY_RETRY_REASONS = frozenset(
+    {
+        "economic_ledger_option_contract_sizes_changed",
+        "economic_ledger_source_cursor_incomplete",
+        "economic_ledger_source_rows_changed",
+        "economic_ledger_source_watermark_changed",
+    }
+)
+_SOURCE_CONSISTENCY_RETRY_DELAY_SECONDS = 5.0
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -69,9 +83,22 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "require exact full TigerBeetle parity."
         ),
     )
+    parser.add_argument(
+        "--source-consistency-timeout-seconds",
+        type=int,
+        default=0,
+        help=(
+            "With --observe, retry the complete observation when a concurrent "
+            "source scan changes or temporarily opens the source snapshot."
+        ),
+    )
     args = parser.parse_args(argv)
     if args.tigerbeetle_parity and not args.observe:
         parser.error("--tigerbeetle-parity requires --observe")
+    if args.source_consistency_timeout_seconds < 0:
+        parser.error("--source-consistency-timeout-seconds must be non-negative")
+    if args.source_consistency_timeout_seconds > 0 and not args.observe:
+        parser.error("--source-consistency-timeout-seconds requires --observe")
     return args
 
 
@@ -116,19 +143,12 @@ def _observation_output(
     }
 
 
-def main(argv: list[str] | None = None) -> int:
-    args = _parse_args(argv)
-    broker_client = TorghutAlpacaClient()
-    if broker_client.endpoint_class != "paper":
-        raise RuntimeError("economic_ledger_replay_requires_paper_endpoint")
-    if args.observe and (BUILD_COMMIT == "unknown" or BUILD_IMAGE_DIGEST is None):
-        raise RuntimeError("economic_ledger_observation_build_identity_missing")
-    scope = LedgerScope(
-        provider="alpaca",
-        environment=broker_client.endpoint_class,
-        account_label=str(args.account_label),
-        endpoint_fingerprint=fingerprint_broker_endpoint(broker_client.endpoint_url),
-    )
+def _execute_attempt(
+    args: argparse.Namespace,
+    *,
+    broker_client: TorghutAlpacaClient,
+    scope: LedgerScope,
+) -> tuple[dict[str, object], int]:
     with SessionLocal() as session, session.begin():
         source_rows = load_broker_economic_ledger_source_rows(session, scope=scope)
     ledger_snapshot = prepare_broker_economic_ledger_snapshot(source_rows)
@@ -188,8 +208,75 @@ def main(argv: list[str] | None = None) -> int:
     else:
         payload = replay.to_payload(published=published)
         payload["reconciliation"] = None
+    exit_code = (
+        1 if tigerbeetle_parity is not None and not tigerbeetle_parity.parity else 0
+    )
+    return payload, exit_code
+
+
+def _execute_with_source_consistency_retry(
+    args: argparse.Namespace,
+    *,
+    broker_client: TorghutAlpacaClient,
+    scope: LedgerScope,
+) -> tuple[dict[str, object], int]:
+    deadline = time.monotonic() + args.source_consistency_timeout_seconds
+    attempt = 1
+    while True:
+        try:
+            return _execute_attempt(args, broker_client=broker_client, scope=scope)
+        except EconomicLedgerError as exc:
+            reason = str(exc)
+            remaining_seconds = deadline - time.monotonic()
+            if (
+                reason not in _SOURCE_CONSISTENCY_RETRY_REASONS
+                or remaining_seconds <= 0
+            ):
+                raise
+            delay_seconds = min(
+                _SOURCE_CONSISTENCY_RETRY_DELAY_SECONDS,
+                remaining_seconds,
+            )
+            print(
+                json.dumps(
+                    {
+                        "attempt": attempt,
+                        "delay_seconds": delay_seconds,
+                        "reason": reason,
+                        "schema_version": (
+                            "torghut.broker-economic-source-retry-log.v1"
+                        ),
+                    },
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ),
+                file=sys.stderr,
+                flush=True,
+            )
+            time.sleep(delay_seconds)
+            attempt += 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    broker_client = TorghutAlpacaClient()
+    if broker_client.endpoint_class != "paper":
+        raise RuntimeError("economic_ledger_replay_requires_paper_endpoint")
+    if args.observe and (BUILD_COMMIT == "unknown" or BUILD_IMAGE_DIGEST is None):
+        raise RuntimeError("economic_ledger_observation_build_identity_missing")
+    scope = LedgerScope(
+        provider="alpaca",
+        environment=broker_client.endpoint_class,
+        account_label=str(args.account_label),
+        endpoint_fingerprint=fingerprint_broker_endpoint(broker_client.endpoint_url),
+    )
+    payload, exit_code = _execute_with_source_consistency_retry(
+        args,
+        broker_client=broker_client,
+        scope=scope,
+    )
     print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
-    return 1 if tigerbeetle_parity is not None and not tigerbeetle_parity.parity else 0
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/services/torghut/tests/economic_ledger/test_replay_cli.py
+++ b/services/torghut/tests/economic_ledger/test_replay_cli.py
@@ -27,11 +27,145 @@ def test_default_mode_is_read_only_replay() -> None:
 
     assert args.observe is False
     assert args.publish_token is None
+    assert args.source_consistency_timeout_seconds == 0
 
 
 def test_tigerbeetle_parity_requires_observation_mode() -> None:
     with pytest.raises(SystemExit):
         replay_cli._parse_args(["--tigerbeetle-parity"])
+
+
+def test_source_consistency_retry_requires_observation_mode() -> None:
+    with pytest.raises(SystemExit):
+        replay_cli._parse_args(["--source-consistency-timeout-seconds", "1"])
+
+
+def test_source_consistency_retry_rejects_negative_timeout() -> None:
+    with pytest.raises(SystemExit):
+        replay_cli._parse_args(
+            ["--observe", "--source-consistency-timeout-seconds", "-1"]
+        )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    sorted(replay_cli._SOURCE_CONSISTENCY_RETRY_REASONS),
+)
+def test_observation_retries_only_source_consistency_races(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    reason: str,
+) -> None:
+    attempts = 0
+    delays: list[float] = []
+
+    def execute_attempt(
+        *_args: object, **_kwargs: object
+    ) -> tuple[dict[str, object], int]:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise replay_cli.EconomicLedgerError(reason)
+        return {"schema_version": "test-observation"}, 0
+
+    monkeypatch.setattr(
+        replay_cli,
+        "TorghutAlpacaClient",
+        lambda: SimpleNamespace(
+            endpoint_class="paper",
+            endpoint_url="https://paper-api.alpaca.markets",
+        ),
+    )
+    monkeypatch.setattr(replay_cli, "_execute_attempt", execute_attempt)
+    monkeypatch.setattr(replay_cli.time, "sleep", delays.append)
+    monkeypatch.setattr(replay_cli, "BUILD_COMMIT", "a" * 40)
+    monkeypatch.setattr(replay_cli, "BUILD_IMAGE_DIGEST", f"sha256:{'b' * 64}")
+
+    assert (
+        replay_cli.main(["--observe", "--source-consistency-timeout-seconds", "30"])
+        == 0
+    )
+
+    captured = capsys.readouterr()
+    retry_log = json.loads(captured.err)
+    assert attempts == 2
+    assert delays == [replay_cli._SOURCE_CONSISTENCY_RETRY_DELAY_SECONDS]
+    assert retry_log["reason"] == reason
+    assert retry_log["schema_version"] == (
+        "torghut.broker-economic-source-retry-log.v1"
+    )
+    assert json.loads(captured.out)["schema_version"] == "test-observation"
+
+
+def test_observation_does_not_retry_non_source_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts = 0
+    delays: list[float] = []
+
+    def execute_attempt(
+        *_args: object, **_kwargs: object
+    ) -> tuple[dict[str, object], int]:
+        nonlocal attempts
+        attempts += 1
+        raise replay_cli.EconomicLedgerError("tigerbeetle_economic_account_mismatch")
+
+    monkeypatch.setattr(
+        replay_cli,
+        "TorghutAlpacaClient",
+        lambda: SimpleNamespace(
+            endpoint_class="paper",
+            endpoint_url="https://paper-api.alpaca.markets",
+        ),
+    )
+    monkeypatch.setattr(replay_cli, "_execute_attempt", execute_attempt)
+    monkeypatch.setattr(replay_cli.time, "sleep", delays.append)
+    monkeypatch.setattr(replay_cli, "BUILD_COMMIT", "a" * 40)
+    monkeypatch.setattr(replay_cli, "BUILD_IMAGE_DIGEST", f"sha256:{'b' * 64}")
+
+    with pytest.raises(
+        replay_cli.EconomicLedgerError,
+        match="tigerbeetle_economic_account_mismatch",
+    ):
+        replay_cli.main(["--observe", "--source-consistency-timeout-seconds", "30"])
+
+    assert attempts == 1
+    assert delays == []
+
+
+def test_observation_source_retry_timeout_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts = 0
+    monotonic_values = iter((10.0, 11.0))
+
+    def execute_attempt(
+        *_args: object, **_kwargs: object
+    ) -> tuple[dict[str, object], int]:
+        nonlocal attempts
+        attempts += 1
+        raise replay_cli.EconomicLedgerError("economic_ledger_source_cursor_incomplete")
+
+    monkeypatch.setattr(
+        replay_cli,
+        "TorghutAlpacaClient",
+        lambda: SimpleNamespace(
+            endpoint_class="paper",
+            endpoint_url="https://paper-api.alpaca.markets",
+        ),
+    )
+    monkeypatch.setattr(replay_cli, "_execute_attempt", execute_attempt)
+    monkeypatch.setattr(replay_cli.time, "monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr(replay_cli, "BUILD_COMMIT", "a" * 40)
+    monkeypatch.setattr(replay_cli, "BUILD_IMAGE_DIGEST", f"sha256:{'b' * 64}")
+
+    with pytest.raises(
+        replay_cli.EconomicLedgerError,
+        match="economic_ledger_source_cursor_incomplete",
+    ):
+        replay_cli.main(["--observe", "--source-consistency-timeout-seconds", "1"])
+
+    assert attempts == 1
 
 
 def test_observation_log_excludes_token_scope_and_broker_economics() -> None:


### PR DESCRIPTION
## Summary

- Add a bounded whole-observation retry for concurrent broker-source snapshot races.
- Retry only the four source-consistency errors; TigerBeetle mismatches, broker residuals, build-identity failures, timeout exhaustion, and every other error still fail immediately.
- Emit only a compact non-sensitive retry event and cover success, non-retry, timeout, and CLI validation paths.
- Deliberately defer CronJob activation until this code is built and its image is promoted, preventing a manifest-before-image incompatibility window.

## Related Issues

None

## Testing

- `uv run --frozen pytest -q tests/economic_ledger/test_replay_cli.py` (14 passed)
- `uv run --frozen pytest -q tests/economic_ledger tests/execution/test_broker_economic_ledger_postgres.py` (97 passed, 1 skipped because `TORGHUT_TEST_POSTGRES_DSN` was not set)
- all five Pyright profiles (0 errors, 0 warnings)
- Ruff format/check, Python compileall, structural Pylint, changed-line Pylint quality/design, file-length, migration graph, and tech-debt ratchet gates
- live cursor sampling confirmed normal scans complete in about 0.4 seconds with stable windows between scans

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed because this is a backend fix.
- [x] Documentation and GitOps activation are intentionally deferred until the retry-capable image is promoted.