### PR TITLE
fix(talos): restore guarded flannel pod mtu

### DIFF
--- a/argocd/applications/flannel-cni/kube-flannel-cfg.yaml
+++ b/argocd/applications/flannel-cni/kube-flannel-cfg.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-flannel-cfg
+  namespace: kube-system
+  annotations:
+    # Keep the last known-good CNI configuration if this guard application is removed.
+    argocd.argoproj.io/sync-options: Delete=false
+  labels:
+    k8s-app: flannel
+    tier: node
+data:
+  cni-conf.json: |-
+    {
+      "name": "cbr0",
+      "cniVersion": "1.0.0",
+      "plugins": [
+        {
+          "type": "flannel",
+          "delegate": {
+            "hairpinMode": true,
+            "isDefaultGateway": true,
+            "mtu": 1400
+          }
+        },
+        {
+          "type": "portmap",
+          "capabilities": {
+            "portMappings": true
+          }
+        }
+      ]
+    }
+  net-conf.json: |-
+    {
+      "Network": "10.244.0.0/16",
+      "Backend": {
+        "Type": "vxlan",
+        "Port": 4789
+      }
+    }

--- a/argocd/applications/flannel-cni/kustomization.yaml
+++ b/argocd/applications/flannel-cni/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - kube-flannel-cfg.yaml

--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -76,6 +76,13 @@ spec:
                   argocd.argoproj.io/sync-wave: "-1"
                 automation: auto
                 enabled: "true"
+              - name: flannel-cni
+                path: argocd/applications/flannel-cni
+                namespace: kube-system
+                annotations:
+                  argocd.argoproj.io/sync-wave: "-1"
+                automation: auto
+                enabled: "true"
               - name: volume-snapshot-controller
                 path: argocd/applications/volume-snapshot-controller
                 namespace: kube-system

--- a/devices/altra/manifests/README.md
+++ b/devices/altra/manifests/README.md
@@ -14,7 +14,6 @@ Files:
 - `devices/altra/manifests/nvidia-kernel-modules.patch.yaml`
 - `devices/altra/manifests/node-labels.patch.yaml`
 - `devices/altra/manifests/kubelet-maxpods.patch.yaml` (set kubelet `maxPods` to 500)
-- `devices/altra/manifests/network-mtu.patch.yaml` (set the Flannel underlay to 1450 so VXLAN pod MTU is 1400)
 - `devices/altra/manifests/tailscale-extension-service.template.yaml`
 - `devices/altra/manifests/tailscale-dns.patch.yaml`
 - `devices/altra/manifests/altra-tailscale-nvidia-lts-schematic.yaml`

--- a/devices/altra/manifests/network-mtu.patch.yaml
+++ b/devices/altra/manifests/network-mtu.patch.yaml
@@ -1,5 +1,0 @@
-machine:
-  network:
-    interfaces:
-      - interface: enP5p1s0
-        mtu: 1450

--- a/devices/galactic/docs/troubleshooting-networking.md
+++ b/devices/galactic/docs/troubleshooting-networking.md
@@ -1,46 +1,18 @@
-# Troubleshooting: pod networking (Talos-managed Flannel VXLAN)
+# Troubleshooting: pod networking (Talos Flannel VXLAN with MTU guard)
 
-This cluster uses Talos-managed Flannel in VXLAN mode. Talos owns the Flannel ConfigMap, DaemonSet, service account,
-and RBAC resources. Do not manage only a subset of those resources through Argo CD; split ownership causes Talos
-Kubernetes upgrades and Argo reconciliation to overwrite each other.
+Talos owns the Flannel DaemonSet, service account, and RBAC resources. The `flannel-cni` Argo application deliberately
+guards only `kube-flannel-cfg` so the CNI delegate keeps MTU 1400 while the backend remains Talos' default VXLAN on
+UDP 4789.
 
-The physical underlay interfaces use MTU 1450 so Flannel derives MTU 1400 after VXLAN overhead. Keep the node-specific
-Talos patches in sync with the active interface names:
+This is a temporary compatibility exception for stable Talos 1.13, which does not expose a Flannel MTU setting. Fresh
+ARC runners at pod MTU 1450 repeatedly timed out fetching GitHub pipeline connection data; changing the same pod to
+MTU 1400 made it register and claim work immediately. Do not reduce the physical underlay MTU to force Flannel's
+derived value: adding an otherwise-incomplete interface entry can displace platform-provided addressing and remove a
+control-plane node from the network.
 
-- Ryzen (`eno1`): `devices/ryzen/manifests/network-mtu.patch.yaml`
-- Altra (`enP5p1s0`): `devices/altra/manifests/network-mtu.patch.yaml`
-- Turin (`eno2np1`): `devices/turin/manifests/network-mtu.patch.yaml`
-
-This is required for GitHub Actions runner traffic. A fresh ARC runner at MTU 1450 repeatedly timed out while fetching
-GitHub pipeline connection data; lowering the same pod to MTU 1400 made it connect and claim a queued job immediately.
-Keeping the constraint in Talos machine configuration lets Talos remain the sole owner of the complete Flannel
-installation instead of maintaining a competing Argo-managed ConfigMap.
-
-Apply the patches without rebooting, one healthy node at a time:
-
-```bash
-talosctl -e 100.100.244.141 -n 100.100.244.141 patch machineconfig \
-  --patch @devices/ryzen/manifests/network-mtu.patch.yaml --mode=no-reboot
-talosctl -e 100.100.244.141 -n 100.100.244.142 patch machineconfig \
-  --patch @devices/altra/manifests/network-mtu.patch.yaml --mode=no-reboot
-talosctl -e 100.100.244.141 -n 100.100.244.190 patch machineconfig \
-  --patch @devices/turin/manifests/network-mtu.patch.yaml --mode=no-reboot
-```
-
-On an already-running node, `flannel.1` survives a Flannel pod restart and retains its previous MTU. Complete the
-live handoff on each node before removing any temporary ConfigMap override:
-
-```bash
-FLANNEL_POD=$(kubectl -n kube-system get pods -l k8s-app=flannel \
-  --field-selector spec.nodeName=<node-name> -o jsonpath='{.items[0].metadata.name}')
-kubectl -n kube-system exec "$FLANNEL_POD" -c kube-flannel -- ip link set dev flannel.1 mtu 1400
-kubectl -n kube-system delete pod "$FLANNEL_POD" --wait=true
-kubectl -n kube-system rollout status daemonset/kube-flannel --timeout=180s
-talosctl -e 100.100.244.141 -n <node-ip> read /run/flannel/subnet.env
-```
-
-`/run/flannel/subnet.env` must report `FLANNEL_MTU=1400`. The Talos-managed `kube-flannel-cfg` ConfigMap should not
-contain an explicit CNI `mtu` field or Argo tracking annotations after all three nodes have completed the handoff.
+The long-term fix is either a stable Talos release with native Flannel MTU configuration or a complete custom CNI
+manifest with one owner. Until then, preserve this narrowly-scoped guard and treat its reconciliation as part of every
+Kubernetes upgrade.
 
 Before every Kubernetes upgrade, inspect the Talos manifest plan:
 
@@ -48,12 +20,20 @@ Before every Kubernetes upgrade, inspect the Talos manifest plan:
 talosctl -e <control-plane-ip> -n <control-plane-ip> upgrade-k8s --to <target-version> --dry-run
 ```
 
-The plan must show Talos as the single manager of all Flannel resources and must not conflict with an Argo tracking
-annotation on `kube-system/kube-flannel-cfg`. Also verify the derived MTU before and after the upgrade:
+The dry run must keep the VXLAN backend on UDP 4789. Immediately after the upgrade, sync `flannel-cni`, verify the
+guarded ConfigMap, restart the Flannel DaemonSet one node at a time, and confirm the derived MTU:
 
 ```bash
+argocd app sync flannel-cni
+kubectl -n kube-system get configmap kube-flannel-cfg \
+  -o jsonpath='{.data.cni-conf\.json}' | jq -e '.plugins[0].delegate.mtu == 1400'
+kubectl -n kube-system rollout restart daemonset/kube-flannel
+kubectl -n kube-system rollout status daemonset/kube-flannel --timeout=180s
 talosctl -e <control-plane-ip> -n <node-ip> read /run/flannel/subnet.env
 ```
+
+Do not continue workload validation unless every node reports `FLANNEL_MTU=1400` and fresh pods have interface MTU
+1400.
 
 If VXLAN forwarding breaks, pods on one node cannot reach pods on another node, even though nodes may still appear
 `Ready`.

--- a/devices/ryzen/docs/cluster-bootstrap.md
+++ b/devices/ryzen/docs/cluster-bootstrap.md
@@ -18,7 +18,6 @@ Node-level patches:
 - `devices/ryzen/manifests/hostname.patch.yaml` (set Talos hostname to `ryzen`, optional if the generated config already sets it)
 - `devices/ryzen/manifests/node-labels.patch.yaml` (labels for KubeVirt scheduling)
 - `devices/ryzen/manifests/kubelet-maxpods.patch.yaml` (set kubelet `maxPods` to 500)
-- `devices/ryzen/manifests/network-mtu.patch.yaml` (set the Flannel underlay to 1450 so VXLAN pod MTU is 1400)
 - `devices/ryzen/manifests/tailscale-extension-service.template.yaml` (Tailscale extension service template)
 - `devices/ryzen/manifests/tailscale-extension-service.yaml` (generated from template; gitignored)
 - `devices/ryzen/manifests/tailscale-dns.patch.yaml` (prefer MagicDNS for tailnet hostnames)
@@ -93,7 +92,6 @@ If you need to re-layout these volumes on an already-installed node, follow:
 - `devices/ryzen/manifests/hostname.patch.yaml`
 - `devices/ryzen/manifests/node-labels.patch.yaml`
 - `devices/ryzen/manifests/kubelet-maxpods.patch.yaml`
-- `devices/ryzen/manifests/network-mtu.patch.yaml`
 - `devices/ryzen/manifests/tailscale-extension-service.yaml` (generate via `bun run packages/scripts/src/tailscale/generate-ryzen-extension-service.ts`)
 - `devices/ryzen/manifests/tailscale-dns.patch.yaml`
 

--- a/devices/ryzen/manifests/network-mtu.patch.yaml
+++ b/devices/ryzen/manifests/network-mtu.patch.yaml
@@ -1,5 +1,0 @@
-machine:
-  network:
-    interfaces:
-      - interface: eno1
-        mtu: 1450

--- a/devices/turin/README.md
+++ b/devices/turin/README.md
@@ -42,7 +42,6 @@ Manifests:
 - `devices/turin/manifests/etcd-lan-subnet.patch.yaml` (pin etcd peer/client addressing to the Turin LAN subnet)
 - `devices/turin/manifests/kubelet-node-ip-lan-subnet.patch.yaml` (pin kubelet node IP selection to the Turin LAN subnet)
 - `devices/turin/manifests/kubelet-maxpods.patch.yaml` (set kubelet `maxPods` to 500)
-- `devices/turin/manifests/network-mtu.patch.yaml` (set the Flannel underlay to 1450 so VXLAN pod MTU is 1400)
 - `devices/turin/manifests/nvidia-kernel-modules.patch.yaml` (load the NVIDIA kernel modules from the Talos system extension)
 - `devices/turin/manifests/time-servers.patch.yaml` (match the working control-plane nodes' explicit NTP servers)
 - `devices/turin/manifests/tailscale-dns.patch.yaml` (Talos DNS settings for node-level Tailscale)

--- a/devices/turin/manifests/network-mtu.patch.yaml
+++ b/devices/turin/manifests/network-mtu.patch.yaml
@@ -1,5 +1,0 @@
-machine:
-  network:
-    interfaces:
-      - interface: eno2np1
-        mtu: 1450

--- a/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
+++ b/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
@@ -21,6 +21,10 @@ const productApplicationSet = YAML.parse(readFileSync('argocd/applicationsets/pr
     templatePatch?: string
   }
 }
+const flannelConfigMap = YAML.parse(readFileSync('argocd/applications/flannel-cni/kube-flannel-cfg.yaml', 'utf8')) as {
+  metadata?: { annotations?: Record<string, string> }
+  data?: Record<string, string>
+}
 
 const entry = (name: string) => {
   const found = inventory.entries.find((candidate) => candidate.name === name)
@@ -30,21 +34,37 @@ const entry = (name: string) => {
 
 describe('enabled app inventory', () => {
   it('loads only root-enabled ApplicationSet entries plus direct root-managed Applications', () => {
-    expect(inventory.applicationSetEntryCount).toBe(67)
+    expect(inventory.applicationSetEntryCount).toBe(68)
     expect(inventory.directApplicationCount).toBe(1)
-    expect(inventory.entries).toHaveLength(68)
+    expect(inventory.entries).toHaveLength(69)
     expect(inventory.entries.some((candidate) => candidate.name === 'facteur')).toBe(false)
     expect(inventory.entries.some((candidate) => candidate.name === 'bonjour')).toBe(false)
     expect(inventory.entries.some((candidate) => candidate.name === 'olden')).toBe(false)
     expect(inventory.entries.some((candidate) => candidate.name === 'posthog')).toBe(false)
     expect(inventory.entries.some((candidate) => candidate.name === 'sag')).toBe(false)
-    expect(inventory.entries.some((candidate) => candidate.name === 'flannel-cni')).toBe(false)
+    expect(entry('flannel-cni')).toMatchObject({
+      class: 'vendor-manifest',
+      path: 'argocd/applications/flannel-cni',
+    })
   })
 
   it('records preservation intent when a product app is disabled', () => {
     expect(productApplicationSet.spec?.syncPolicy?.preserveResourcesOnDeletion).toBe(true)
     const productElements = productApplicationSet.spec?.generators?.[0]?.matrix?.generators?.[1]?.list?.elements ?? []
     expect(productElements.find((candidate) => candidate.name === 'sag')?.cascadeResourcesOnDeletion).not.toBe(true)
+  })
+
+  it('guards the required pod MTU without changing the Talos VXLAN backend', () => {
+    const cni = JSON.parse(flannelConfigMap.data?.['cni-conf.json'] ?? '{}') as {
+      plugins?: Array<{ delegate?: { mtu?: number } }>
+    }
+    const network = JSON.parse(flannelConfigMap.data?.['net-conf.json'] ?? '{}') as {
+      Backend?: { Type?: string; Port?: number }
+    }
+
+    expect(flannelConfigMap.metadata?.annotations?.['argocd.argoproj.io/sync-options']).toBe('Delete=false')
+    expect(cni.plugins?.[0]?.delegate?.mtu).toBe(1400)
+    expect(network.Backend).toEqual({ Type: 'vxlan', Port: 4789 })
   })
 
   it('cascades resources for generated Applications that are disabled destructively', () => {


### PR DESCRIPTION
## Summary

- restore the `flannel-cni` Argo application as a narrow ConfigMap guard for the required pod MTU 1400
- preserve Talos 1.13's VXLAN backend on UDP 4789 and remove the unsafe physical-interface MTU patches
- document the temporary ownership exception and the required post-upgrade reconciliation checks
- add regression coverage for application inventory, pod MTU, and VXLAN backend settings

## Related Issues

None

## Testing

- `kustomize build argocd/applications/flannel-cni` with parsed CNI and network JSON validation
- `bun test packages/scripts/src/shared/__tests__/enabled-apps.test.ts` (19 passed)
- `bun run lint:argocd` (all rendered resources valid)
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/enabled-apps.test.ts`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.