### PR TITLE
docs(talos): validate guarded pod MTU

### DIFF
--- a/.github/workflows/scripts-ci.yml
+++ b/.github/workflows/scripts-ci.yml
@@ -14,6 +14,7 @@ on:
       - 'docs/agents/designs/handoff-common.md'
       - 'docs/runbooks/rook-ceph-client-ops-performance.md'
       - 'docs/nix-enabled-app-build-performance-rollout-plan.md'
+      - 'devices/galactic/docs/troubleshooting-networking.md'
       - '.github/workflows/scripts-ci.yml'
   pull_request:
     paths:
@@ -26,6 +27,7 @@ on:
       - 'docs/agents/designs/handoff-common.md'
       - 'docs/runbooks/rook-ceph-client-ops-performance.md'
       - 'docs/nix-enabled-app-build-performance-rollout-plan.md'
+      - 'devices/galactic/docs/troubleshooting-networking.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/devices/galactic/docs/troubleshooting-networking.md
+++ b/devices/galactic/docs/troubleshooting-networking.md
@@ -21,7 +21,7 @@ talosctl -e <control-plane-ip> -n <control-plane-ip> upgrade-k8s --to <target-ve
 ```
 
 The dry run must keep the VXLAN backend on UDP 4789. Immediately after the upgrade, sync `flannel-cni`, verify the
-guarded ConfigMap, restart the Flannel DaemonSet one node at a time, and confirm the derived MTU:
+guarded ConfigMap, restart the Flannel DaemonSet, and validate a newly-created pod on every node:
 
 ```bash
 argocd app sync flannel-cni
@@ -29,11 +29,13 @@ kubectl -n kube-system get configmap kube-flannel-cfg \
   -o jsonpath='{.data.cni-conf\.json}' | jq -e '.plugins[0].delegate.mtu == 1400'
 kubectl -n kube-system rollout restart daemonset/kube-flannel
 kubectl -n kube-system rollout status daemonset/kube-flannel --timeout=180s
-talosctl -e <control-plane-ip> -n <node-ip> read /run/flannel/subnet.env
+kubectl -n <workload-namespace> exec <fresh-pod-on-each-node> -- \
+  sh -c "ip -o link show eth0 | grep -q 'mtu 1400'"
 ```
 
-Do not continue workload validation unless every node reports `FLANNEL_MTU=1400` and fresh pods have interface MTU
-1400.
+The guard does not set Flannel's backend MTU, and `/run/flannel/subnet.env` may still report `FLANNEL_MTU=1450` on a
+normal 1500-byte underlay. Do not continue workload validation unless the guarded CNI value is 1400 and fresh pod
+interfaces on every node report MTU 1400.
 
 If VXLAN forwarding breaks, pods on one node cannot reach pods on another node, even though nodes may still appear
 `Ready`.
@@ -52,7 +54,6 @@ If a `Service` is `type: LoadBalancer`, shows an `EXTERNAL-IP`, but nothing on y
 ### Cause (Talos default node label)
 
 Talos commonly sets the node label `node.kubernetes.io/exclude-from-external-load-balancers` on control-plane nodes.
-
 MetalLB treats nodes with that label as ineligible for external load balancers, so speakers will not advertise VIPs from those nodes.
 
 ### Fix

--- a/devices/galactic/docs/troubleshooting-networking.md
+++ b/devices/galactic/docs/troubleshooting-networking.md
@@ -54,6 +54,7 @@ If a `Service` is `type: LoadBalancer`, shows an `EXTERNAL-IP`, but nothing on y
 ### Cause (Talos default node label)
 
 Talos commonly sets the node label `node.kubernetes.io/exclude-from-external-load-balancers` on control-plane nodes.
+
 MetalLB treats nodes with that label as ineligible for external load balancers, so speakers will not advertise VIPs from those nodes.
 
 ### Fix

--- a/packages/scripts/src/docs/__tests__/flannel-mtu-runbook.test.ts
+++ b/packages/scripts/src/docs/__tests__/flannel-mtu-runbook.test.ts
@@ -1,0 +1,20 @@
+import { expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { repoRoot } from '../../shared/cli'
+
+const runbookPath = 'devices/galactic/docs/troubleshooting-networking.md'
+const runbook = readFileSync(join(repoRoot, runbookPath), 'utf8')
+const scriptsWorkflow = readFileSync(join(repoRoot, '.github/workflows/scripts-ci.yml'), 'utf8')
+
+it('validates the MTU value controlled by the Flannel CNI guard', () => {
+  expect(runbook).toContain("jq -e '.plugins[0].delegate.mtu == 1400'")
+  expect(runbook).toContain("ip -o link show eth0 | grep -q 'mtu 1400'")
+  expect(runbook).toContain('may still report `FLANNEL_MTU=1450`')
+  expect(runbook).not.toContain('unless every node reports `FLANNEL_MTU=1400`')
+})
+
+it('runs the scripts regression suite when the protected runbook changes', () => {
+  expect(scriptsWorkflow.split(`'${runbookPath}'`)).toHaveLength(3)
+})


### PR DESCRIPTION
## Summary

- stop requiring `FLANNEL_MTU=1400` when the guard controls only CNI delegate and pod MTU
- document that the backend may correctly derive `FLANNEL_MTU=1450` on a normal 1500-byte underlay
- require the guarded CNI value and fresh pod interfaces to report MTU 1400
- add a docs contract regression and run it whenever the networking runbook changes

## Related Issues

Codex finding on PR #12750: https://github.com/proompteng/lab/pull/12750#discussion_r3601972362

## Testing

- regression contract added at `packages/scripts/src/docs/__tests__/flannel-mtu-runbook.test.ts`
- authoritative packages-scripts CI is required because the agents-shell runner is temporarily unavailable
- `git diff --check` remains a merge gate

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.