### PR TITLE
fix(torghut): activate broker source retries

### DIFF
--- a/argocd/applications/torghut/broker-economic-ledger-reconciliation-cronjob.yaml
+++ b/argocd/applications/torghut/broker-economic-ledger-reconciliation-cronjob.yaml
@@ -109,3 +109,5 @@ spec:
                 - --tigerbeetle-parity
                 - --max-source-age-seconds
                 - "300"
+                - --source-consistency-timeout-seconds
+                - "180"

--- a/docs/torghut/profitability/tigerbeetle-economic-parity.md
+++ b/docs/torghut/profitability/tigerbeetle-economic-parity.md
@@ -192,8 +192,11 @@ and submission.
 ## Scheduled Operation and Logging
 
 The existing hourly broker-economic reconciliation CronJob owns parity. It runs observation-only mode with
-`--tigerbeetle-parity`, `Forbid` concurrency, no retry, a bounded deadline, the exact deployed build identity, and no
-publication token.
+`--tigerbeetle-parity`, `Forbid` concurrency, zero Kubernetes backoff, a bounded deadline, the exact deployed build
+identity, and no publication token. The CLI retries the complete observation only when a concurrent broker-activity
+scan opens or changes the source snapshot, for at most three minutes. It never retries TigerBeetle mismatches, broker
+residuals, build-identity failures, or any other error; exhaustion remains a hard failure. Retrying the complete attempt
+ensures no partially stale reduction or broker snapshot can be reused.
 
 The official TigerBeetle Linux client requires `io_uring`; the upstream project documents `PermissionDenied` under
 container seccomp defaults and recommends an unconfined seccomp profile. The reconciliation container therefore uses

--- a/services/torghut/tests/live_config_manifest_contract/test_broker_economic_ledger_reconciliation_cronjob.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_broker_economic_ledger_reconciliation_cronjob.py
@@ -86,6 +86,8 @@ class BrokerEconomicLedgerReconciliationCronJobTests(TestCase):
                 "--tigerbeetle-parity",
                 "--max-source-age-seconds",
                 "300",
+                "--source-consistency-timeout-seconds",
+                "180",
             ],
         )
         invocation = " ".join(


### PR DESCRIPTION
## Summary

- Activate the already-promoted broker source-consistency retry with a three-minute bound on the hourly parity CronJob.
- Keep Kubernetes backoff at zero and retain hard failure for TigerBeetle mismatches, broker residuals, build identity failures, and unrelated errors.
- Extend the live-manifest contract and operating documentation for the exact production arguments.

## Related Issues

None

## Testing

- `uv run pytest tests/live_config_manifest_contract/test_broker_economic_ledger_reconciliation_cronjob.py -q` (3 passed)
- `uv run ruff check tests/live_config_manifest_contract/test_broker_economic_ledger_reconciliation_cronjob.py`
- `bunx oxfmt --check docs/torghut/profitability/tigerbeetle-economic-parity.md argocd/applications/torghut/broker-economic-ledger-reconciliation-cronjob.yaml`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.