### PR TITLE
chore(product): promote nix product images

### DIFF
--- a/argocd/applications/proompteng/kustomization.yaml
+++ b/argocd/applications/proompteng/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
 - ingressroute.yaml
 images:
 - name: registry.ide-newton.ts.net/lab/proompteng
-  digest: sha256:1a5a5902dab138094df9de846762dbb37adbce99bcff8d53a670a86c66714d0f
+  digest: sha256:552f9d8a9c0a18cbd6e9d33847bef0da4bcdbe1c4bc59adfd425643fa1694fa2
   newName: registry.ide-newton.ts.net/lab/proompteng


### PR DESCRIPTION
## Summary

- Promote enabled product app image digests built by the shared Nix OCI workflow.
- `proompteng`: `registry.ide-newton.ts.net/lab/proompteng@sha256:552f9d8a9c0a18cbd6e9d33847bef0da4bcdbe1c4bc59adfd425643fa1694fa2` from `88b7a38a12ab344c7190829ae01304a4c387a61f`

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- <image>@<digest> linux/amd64 linux/arm64` for each promoted image.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.