### PR TITLE
test(torghut): freeze options catalog clock

### DIFF
--- a/services/torghut/tests/test_options_lane.py
+++ b/services/torghut/tests/test_options_lane.py
@@ -579,10 +579,15 @@ class TestOptionsServiceStatusHeartbeat(TestCase):
         service._repository = repository
         service._client = _PartialCatalogClient()
 
-        with self.assertRaisesRegex(
-            RuntimeError, "provider interrupted after first page"
+        with patch.object(
+            service,
+            "utc_now",
+            return_value=datetime(2026, 7, 13, 15, 0, tzinfo=timezone.utc),
         ):
-            service._run_discovery_cycle()
+            with self.assertRaisesRegex(
+                RuntimeError, "provider interrupted after first page"
+            ):
+                service._run_discovery_cycle()
 
         self.assertEqual(len(repository.reconciliations), 1)
         desired_symbols, deactivate_symbols = repository.reconciliations[0]
@@ -608,7 +613,12 @@ class TestOptionsServiceStatusHeartbeat(TestCase):
         client = _CompleteCatalogClient()
         service._client = client
 
-        service._run_discovery_cycle()
+        with patch.object(
+            service,
+            "utc_now",
+            return_value=datetime(2026, 7, 13, 15, 0, tzinfo=timezone.utc),
+        ):
+            service._run_discovery_cycle()
 
         self.assertEqual(len(repository.reconciliations), 1)
         final_symbols, final_deactivations = repository.reconciliations[0]


### PR DESCRIPTION
## Summary

- Freeze both options-catalog discovery-cycle tests at the date encoded by their contract fixtures.
- Remove the wall-clock dependency that made current `main` fail after the fixtures expired at midnight UTC.
- Preserve the production expiration-scope behavior; this changes tests only.

## Related Issues

None

## Testing

- `uv run pytest tests/test_options_lane.py -q` (20 passed)
- `uv run ruff check tests/test_options_lane.py`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.