### PR TITLE
chore(torghut): promote image sha-6709bc4349f7810d2ba7e2add1780ba42325e9de

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -54,7 +54,7 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: 98b1f0966ffa6707f02d336119c34754bd565fe1
+              value: 6709bc4349f7810d2ba7e2add1780ba42325e9de
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:6e1d65a31f7c4657ef8140ec4ed92bc521738099fdd07844246d41ccafe86b5a
             - name: PYTHONPATH

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -46,7 +46,7 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: 98b1f0966ffa6707f02d336119c34754bd565fe1
+              value: 6709bc4349f7810d2ba7e2add1780ba42325e9de
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:6e1d65a31f7c4657ef8140ec4ed92bc521738099fdd07844246d41ccafe86b5a
             - name: DB_DSN

--- a/argocd/applications/torghut-options/archive/deployment.yaml
+++ b/argocd/applications/torghut-options/archive/deployment.yaml
@@ -100,9 +100,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2181-g98b1f0966
+              value: v0.596.0-2185-g6709bc434
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 98b1f0966ffa6707f02d336119c34754bd565fe1
+              value: 6709bc4349f7810d2ba7e2add1780ba42325e9de
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -110,9 +110,9 @@ spec:
                   name: torghut-ws-config
                   key: SYMBOLS_ALLOWLIST
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2181-g98b1f0966
+              value: v0.596.0-2185-g6709bc434
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 98b1f0966ffa6707f02d336119c34754bd565fe1
+              value: 6709bc4349f7810d2ba7e2add1780ba42325e9de
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -106,9 +106,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2181-g98b1f0966
+              value: v0.596.0-2185-g6709bc434
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 98b1f0966ffa6707f02d336119c34754bd565fe1
+              value: 6709bc4349f7810d2ba7e2add1780ba42325e9de
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/broker-economic-ledger-reconciliation-cronjob.yaml
+++ b/argocd/applications/torghut/broker-economic-ledger-reconciliation-cronjob.yaml
@@ -92,9 +92,9 @@ spec:
                 - name: TRADING_ACCOUNT_LABEL
                   value: PA3SX7FYNUTF
                 - name: TORGHUT_VERSION
-                  value: v0.596.0-2181-g98b1f0966
+                  value: v0.596.0-2185-g6709bc434
                 - name: TORGHUT_COMMIT
-                  value: 98b1f0966ffa6707f02d336119c34754bd565fe1
+                  value: 6709bc4349f7810d2ba7e2add1780ba42325e9de
                 - name: TORGHUT_IMAGE_DIGEST
                   value: sha256:6e1d65a31f7c4657ef8140ec4ed92bc521738099fdd07844246d41ccafe86b5a
                 - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-18T03:06:03Z"
+        client.knative.dev/updateTimestamp: "2026-07-18T03:36:24Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -509,9 +509,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2181-g98b1f0966
+              value: v0.596.0-2185-g6709bc434
             - name: TORGHUT_COMMIT
-              value: 98b1f0966ffa6707f02d336119c34754bd565fe1
+              value: 6709bc4349f7810d2ba7e2add1780ba42325e9de
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:6e1d65a31f7c4657ef8140ec4ed92bc521738099fdd07844246d41ccafe86b5a
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-18T03:06:03Z"
+        client.knative.dev/updateTimestamp: "2026-07-18T03:36:24Z"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
     spec:
@@ -446,9 +446,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2181-g98b1f0966
+              value: v0.596.0-2185-g6709bc434
             - name: TORGHUT_COMMIT
-              value: 98b1f0966ffa6707f02d336119c34754bd565fe1
+              value: 6709bc4349f7810d2ba7e2add1780ba42325e9de
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:6e1d65a31f7c4657ef8140ec4ed92bc521738099fdd07844246d41ccafe86b5a
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/order-lineage-reconciliation-cronjob.yaml
+++ b/argocd/applications/torghut/order-lineage-reconciliation-cronjob.yaml
@@ -88,9 +88,9 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_VERSION
-                  value: v0.596.0-2181-g98b1f0966
+                  value: v0.596.0-2185-g6709bc434
                 - name: TORGHUT_COMMIT
-                  value: 98b1f0966ffa6707f02d336119c34754bd565fe1
+                  value: 6709bc4349f7810d2ba7e2add1780ba42325e9de
                 - name: TORGHUT_IMAGE_DIGEST
                   value: sha256:6e1d65a31f7c4657ef8140ec4ed92bc521738099fdd07844246d41ccafe86b5a
                 - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -462,9 +462,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2181-g98b1f0966
+              value: v0.596.0-2185-g6709bc434
             - name: TORGHUT_COMMIT
-              value: 98b1f0966ffa6707f02d336119c34754bd565fe1
+              value: 6709bc4349f7810d2ba7e2add1780ba42325e9de
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:6e1d65a31f7c4657ef8140ec4ed92bc521738099fdd07844246d41ccafe86b5a
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `6709bc4349f7810d2ba7e2add1780ba42325e9de`
- Image tag: `sha-6709bc4349f7810d2ba7e2add1780ba42325e9de`
- Image digest: `sha256:6e1d65a31f7c4657ef8140ec4ed92bc521738099fdd07844246d41ccafe86b5a`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher