### PR TITLE
fix(metallb): advertise Plex from Turin

### DIFF
--- a/argocd/applications/metallb-system/ipaddresspool.yaml
+++ b/argocd/applications/metallb-system/ipaddresspool.yaml
@@ -5,7 +5,8 @@ metadata:
   namespace: metallb-system
 spec:
   addresses:
-    - 100.100.244.181-100.100.244.190
+    # .190 is Turin's node address and must never be allocated to a Service.
+    - 100.100.244.181-100.100.244.189
 ---
 apiVersion: metallb.io/v1beta1
 kind: IPAddressPool

--- a/argocd/applications/metallb-system/kustomization.yaml
+++ b/argocd/applications/metallb-system/kustomization.yaml
@@ -5,3 +5,13 @@ resources:
   - github.com/metallb/metallb//config/native?ref=v0.15.3
   - ipaddresspool.yaml
   - l2advertisement.yaml
+patches:
+  - target:
+      group: apps
+      version: v1
+      kind: DaemonSet
+      name: speaker
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --ignore-exclude-lb

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -64,7 +64,7 @@ Notes:
 
 - Edit `argocd/applications/metallb-system/ipaddresspool.yaml` to match your LAN range and avoid static IPs. Current pools:
   - `metallb-plex-pool`: `100.100.244.180/32`, reserved for Plex LAN access.
-  - `metallb-ip-pool`: `100.100.244.181-100.100.244.190`, shared platform services.
+  - `metallb-ip-pool`: `100.100.244.181-100.100.244.189`, shared platform services (`.190` is Turin).
 - Traefik and Forgejo SSH share `100.100.244.181`; Istio ingress uses `100.100.244.182`.
 
 4. Apply the root Application (ApplicationSet) to sync the rest of the stack:


### PR DESCRIPTION
## Summary

- allow MetalLB speakers to advertise from control-plane nodes when explicitly required
- exclude Turin node address `100.100.244.190` from the generic Service pool
- document the corrected allocatable range

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `kubectl kustomize argocd/applications/metallb-system`
- `kubectl --context galactic-lan apply --dry-run=server -f /tmp/metallb-render.yaml`
- `git diff --check`

## Breaking Changes

None. The generic pool loses only the node-owned `.190` address; no Service currently uses it.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed because this is infrastructure-only.
- [x] Documentation and rollout impact are updated.