### PR TITLE
fix(temporal): retain schema job for Argo

### DIFF
--- a/argocd/applications/temporal/kustomization.yaml
+++ b/argocd/applications/temporal/kustomization.yaml
@@ -49,6 +49,8 @@ patches:
       - op: add
         path: /metadata/annotations/argocd.argoproj.io~1sync-wave
         value: "-1"
+      - op: remove
+        path: /spec/ttlSecondsAfterFinished
 
 helmCharts:
   - name: cassandra


### PR DESCRIPTION
## Summary

- remove the Temporal schema Job TTL from rendered manifests
- retain the completed idempotent schema Job so Argo does not report it permanently Missing after 24 hours
- preserve Force/Replace behavior for intentional schema reruns on future syncs

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/temporal`
- verified rendered `Job/temporal-schema` has no `ttlSecondsAfterFinished`
- `git diff --check origin/main...HEAD`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] No documentation or release-note update is required for this focused GitOps lifecycle fix.