### PR TITLE
fix(torghut): backfill late crypto fee activities

### DIFF
--- a/services/torghut/app/trading/broker_account_activity_backfill.py
+++ b/services/torghut/app/trading/broker_account_activity_backfill.py
@@ -35,7 +35,10 @@ from .broker_mutation_receipts import fingerprint_broker_endpoint
 logger = logging.getLogger(__name__)
 
 _INITIAL_SCAN_AFTER = datetime(2016, 1, 1, tzinfo=timezone.utc)
-_SCAN_OVERLAP = timedelta(minutes=5)
+# Alpaca posts date-only crypto fee activities after the trading day closes.
+# Re-read two full UTC dates so those immutable late arrivals cannot fall behind
+# a cursor that already advanced past their settlement date.
+_SCAN_OVERLAP = timedelta(days=2)
 _PAGE_SIZE = 100
 _HTTP_TIMEOUT_SECONDS = 10.0
 _DEFAULT_PAGES_PER_RUN = 3

--- a/services/torghut/tests/test_broker_account_activities.py
+++ b/services/torghut/tests/test_broker_account_activities.py
@@ -511,6 +511,55 @@ def test_ingestor_drains_bounded_pages_then_deduplicates_overlap() -> None:
         )
 
 
+def test_completed_scan_rewinds_two_days_for_late_date_only_crypto_fees() -> None:
+    late_fee = {
+        "activity_type": "CFEE",
+        "date": "2026-07-15",
+        "description": "Coin Pair Transaction Fee (Non USD)",
+        "id": "late-crypto-fee",
+        "net_amount": "0",
+        "price": "100000",
+        "qty": "-0.000001",
+        "status": "executed",
+        "symbol": "BTCUSD",
+    }
+    pages: list[object] = [[], [late_fee]]
+    requested_after: list[object] = []
+
+    def get_json(**kwargs: object) -> object:
+        params = kwargs["params"]
+        assert isinstance(params, Mapping)
+        requested_after.append(cast(Mapping[str, object], params)["after"])
+        return pages.pop(0)
+
+    sessions = _session_factory()
+    ingestor = BrokerAccountActivityIngestor(
+        client=AlpacaAccountActivitiesClient(
+            api_key="key",
+            secret_key="secret",
+            endpoint_url="https://paper-api.alpaca.markets",
+            get_json=get_json,
+        ),
+        session_factory=sessions,
+        account_label="paper-account",
+        now=_Clock(),
+    )
+
+    first = ingestor.ingest_once()
+    second = ingestor.ingest_once()
+
+    assert first.complete is True
+    assert second.inserted == 1
+    assert requested_after == [
+        "2016-01-01T00:00:00Z",
+        "2026-07-14T01:00:00Z",
+    ]
+    with sessions() as session:
+        stored = session.scalar(select(BrokerAccountActivity))
+        assert stored is not None
+        assert stored.external_activity_id == "late-crypto-fee"
+
+
 def test_changed_payload_for_same_activity_is_hard_contradiction() -> None:
     pages: list[object] = [
         [_fill("activity-001")],


### PR DESCRIPTION
## Summary

- widen the Alpaca account-activity cursor overlap from five minutes to two days so late date-only crypto fees are re-read
- preserve append-only identity deduplication while recovering fee rows posted after their settlement date
- add a regression test proving a prior-day `CFEE` row is inserted on the next completed scan

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_broker_account_activities.py -q` (16 passed)
- `uv run --frozen ruff check app/trading/broker_account_activity_backfill.py tests/test_broker_account_activities.py`
- `uv run --frozen ruff format --check app/trading/broker_account_activity_backfill.py tests/test_broker_account_activities.py`
- all five Torghut Pyright profiles (0 errors)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Existing Torghut design documentation already records Alpaca's end-of-day `CFEE` posting behavior; no release note is required.
