### PR TITLE
fix(torghut): preserve late fee ledger identities

### DIFF
--- a/services/torghut/app/trading/economic_ledger/journal_reducer.py
+++ b/services/torghut/app/trading/economic_ledger/journal_reducer.py
@@ -25,7 +25,7 @@ from .types import (
 
 
 JOURNAL_REDUCER_NAME = "balanced_journal"
-JOURNAL_REDUCER_VERSION = "torghut.broker-economic-journal.v3"
+JOURNAL_REDUCER_VERSION = "torghut.broker-economic-journal.v4"
 
 _MAX_TRANSACTION_ID_LENGTH = 512
 _REVERSAL_TRANSACTION_ID_PREFIX = "correction-reversal:sha256:"

--- a/services/torghut/app/trading/economic_ledger/state_reducer.py
+++ b/services/torghut/app/trading/economic_ledger/state_reducer.py
@@ -21,7 +21,7 @@ from .types import (
 
 
 STATE_REDUCER_NAME = "independent_position_state"
-STATE_REDUCER_VERSION = "torghut.broker-economic-state.v3"
+STATE_REDUCER_VERSION = "torghut.broker-economic-state.v4"
 
 _EXTERNAL_FLOW_TYPES = frozenset({"ACATC", "CSD", "CSW", "JNLC", "TRANS"})
 _DIVIDEND_ACTIVITY_TYPES = frozenset(

--- a/services/torghut/app/trading/economic_ledger/tigerbeetle_projection.py
+++ b/services/torghut/app/trading/economic_ledger/tigerbeetle_projection.py
@@ -27,8 +27,10 @@ if TYPE_CHECKING:
     from .persistence import BrokerEconomicLedgerReplay
 
 
+# The v1 namespace contains immutable transfer chains from the pre-monotonic
+# date-only CFEE ordering and must never be reused for current parity.
 TIGERBEETLE_ECONOMIC_PROJECTION_VERSION = (
-    "torghut.broker-economic-tigerbeetle-projection.v1"
+    "torghut.broker-economic-tigerbeetle-projection.v2"
 )
 TIGERBEETLE_MAX_BATCH_SIZE = 8_189
 

--- a/services/torghut/app/trading/economic_ledger/types.py
+++ b/services/torghut/app/trading/economic_ledger/types.py
@@ -19,6 +19,7 @@ _USD_CASH_QUANTUM = Decimal("0.01")
 _LEDGER_ABSOLUTE_LIMIT = Decimal("100000000000000000000")
 _UNIT_NOTIONAL_MULTIPLIER = Decimal("1")
 _OCC_OPTION_SYMBOL = re.compile(r"^[A-Z0-9]{1,6}[0-9]{6}[CP][0-9]{8}$")
+_MIN_UTC_DATETIME = datetime.min.replace(tzinfo=timezone.utc)
 
 
 class EconomicLedgerError(RuntimeError):
@@ -184,10 +185,21 @@ class EconomicActivity:
         return _UNIT_NOTIONAL_MULTIPLIER
 
     @property
-    def sort_key(self) -> tuple[datetime, date, str, str]:
+    def sort_key(self) -> tuple[datetime, date, datetime, str, str]:
+        # Alpaca can publish date-only crypto fees after their economic date.
+        # Preserve observation order so a late append cannot rewrite an earlier
+        # state-dependent fee transaction and its immutable ledger identity.
+        observation_order = (
+            self.first_observed_at
+            if self.activity_type == "CFEE"
+            and self.event_at is None
+            and self.settle_date is not None
+            else _MIN_UTC_DATETIME
+        )
         return (
             self.economic_at,
             self.settle_date or date.min,
+            observation_order,
             self.external_activity_id,
             self.raw_payload_sha256,
         )

--- a/services/torghut/tests/economic_ledger/test_late_fee_ordering.py
+++ b/services/torghut/tests/economic_ledger/test_late_fee_ordering.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import timedelta
+
+from app.trading.economic_ledger import reduce_and_compare
+from tests.economic_ledger.support import activity
+
+
+def test_late_date_only_crypto_fee_preserves_existing_transaction_digest() -> None:
+    fills = [
+        activity(
+            "fill-1",
+            "FILL",
+            event_offset_seconds=1,
+            symbol="BTCUSD",
+            side="buy",
+            quantity="0.1",
+            price="1",
+            net_amount=None,
+        ),
+        activity(
+            "fill-2",
+            "FILL",
+            event_offset_seconds=2,
+            symbol="BTCUSD",
+            side="buy",
+            quantity="0.1",
+            price="3.333333333333333333",
+            net_amount=None,
+        ),
+    ]
+    existing_fee = replace(
+        activity(
+            "z-existing-fee",
+            "CFEE",
+            symbol="BTCUSD",
+            quantity="-0.07",
+            price="3",
+            net_amount="0",
+        ),
+        event_at=None,
+    )
+    late_fee = replace(
+        activity(
+            "a-late-fee",
+            "CFEE",
+            symbol="BTCUSD",
+            quantity="-0.01",
+            price="4",
+            net_amount="0",
+        ),
+        event_at=None,
+        first_observed_at=existing_fee.first_observed_at + timedelta(minutes=1),
+    )
+
+    before = reduce_and_compare([*fills, existing_fee])
+    after = reduce_and_compare([*fills, existing_fee, late_fee])
+    before_digest = next(
+        transaction.digest
+        for transaction in before.journal.transactions
+        if transaction.source_activity_id == existing_fee.external_activity_id
+    )
+    after_digest = next(
+        transaction.digest
+        for transaction in after.journal.transactions
+        if transaction.source_activity_id == existing_fee.external_activity_id
+    )
+
+    assert existing_fee.external_activity_id > late_fee.external_activity_id
+    assert existing_fee.sort_key < late_fee.sort_key
+    assert before.admissible and after.admissible
+    assert before.comparison.equivalent and after.comparison.equivalent
+    assert after_digest == before_digest

--- a/services/torghut/tests/economic_ledger/test_option_multiplier.py
+++ b/services/torghut/tests/economic_ledger/test_option_multiplier.py
@@ -42,8 +42,8 @@ def test_option_fill_cash_and_cost_use_the_explicit_contract_size() -> None:
     )
 
     assert buy.manifest_payload()["notional_multiplier"] == "10"
-    assert JOURNAL_REDUCER_VERSION == "torghut.broker-economic-journal.v3"
-    assert STATE_REDUCER_VERSION == "torghut.broker-economic-state.v3"
+    assert JOURNAL_REDUCER_VERSION == "torghut.broker-economic-journal.v4"
+    assert STATE_REDUCER_VERSION == "torghut.broker-economic-state.v4"
     assert result.admissible
     assert result.comparison.equivalent
     assert cash(result.journal.projection) == Decimal("3")

--- a/services/torghut/tests/economic_ledger/test_tigerbeetle_parity.py
+++ b/services/torghut/tests/economic_ledger/test_tigerbeetle_parity.py
@@ -25,6 +25,7 @@ from app.trading.economic_ledger.tigerbeetle_parity import (
     validate_tigerbeetle_economic_parity_payload,
 )
 from app.trading.economic_ledger.tigerbeetle_projection import (
+    TIGERBEETLE_ECONOMIC_PROJECTION_VERSION,
     project_broker_economic_transaction,
 )
 from app.trading.tigerbeetle_ledger_model import (
@@ -239,6 +240,12 @@ def test_full_projection_is_exact_idempotent_and_bound_to_immutable_runs() -> No
     first = _audit(client, replay, runs=runs)
     second = _audit(client, replay, runs=runs)
 
+    assert TIGERBEETLE_ECONOMIC_PROJECTION_VERSION == (
+        "torghut.broker-economic-tigerbeetle-projection.v2"
+    )
+    assert first.payload["projection_version"] == (
+        TIGERBEETLE_ECONOMIC_PROJECTION_VERSION
+    )
     assert first.parity is True
     assert first.payload["blockers"] == []
     assert first.payload["expected"] == first.payload["actual"] | {


### PR DESCRIPTION
## Summary

- Order date-only Alpaca crypto fees by immutable first-observed time so late arrivals append without changing earlier state-dependent transaction digests.
- Advance both economic reducers to v4 and isolate current TigerBeetle materialization in projection namespace v2 because the v1 namespace contains an obsolete immutable chain.
- Add a rounding-sensitive regression proving a lexically earlier late fee cannot rewrite an existing transaction, plus explicit reducer/projection version assertions.

## Related Issues

None.

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/economic_ledger/test_late_fee_ordering.py tests/economic_ledger/test_tigerbeetle_parity.py tests/economic_ledger/test_option_multiplier.py -q` (16 passed)
- `uv run --frozen pytest tests/economic_ledger -q` (99 passed)
- `uv run --frozen ruff check app/trading/economic_ledger tests/economic_ledger`
- `uv run --frozen ruff format --check app/trading/economic_ledger tests/economic_ledger`
- `uv run --frozen pylint tests/economic_ledger/test_dual_reducers.py tests/economic_ledger/test_late_fee_ordering.py --disable=all --enable=too-many-lines --score=n`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.strict.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.strict.json`
- `git diff --check`

## Breaking Changes

TigerBeetle broker-economic projection namespace advances from v1 to v2. The old immutable namespace remains intact for inspection; the first v2 parity observation must materialize the complete current projection before entry parity can pass. No database migration is required.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section was removed because this is a backend accounting repair; Breaking Changes is filled in.
- [x] The operational projection-version transition and required live proof are documented above; dated evidence will be recorded after GitOps rollout.
