### PR TITLE
fix(torghut): keep outcome learning off order path

### DIFF
--- a/services/torghut/app/trading/scheduler/pipeline/run_cycle.py
+++ b/services/torghut/app/trading/scheduler/pipeline/run_cycle.py
@@ -170,7 +170,6 @@ class TradingPipelineRunCycleMixin(TradingPipelinePositionExposureMixin):
             self.ingestor.commit_cursor(cursor_session, batch)
 
     def run_once(self) -> None:
-        self._label_mature_rejected_signal_outcome_events()
         with self.session_factory() as session:
             self.state.metrics.planned_decision_age_seconds = 0
             self._prepare_run_once(session)

--- a/services/torghut/app/trading/scheduler/pipeline/runtime_contract.py
+++ b/services/torghut/app/trading/scheduler/pipeline/runtime_contract.py
@@ -254,7 +254,7 @@ class TradingPipelineInteractions(Protocol):
         decision_row: TradeDecision,
     ) -> bool: ...
 
-    def _label_mature_rejected_signal_outcome_events(
+    def label_mature_rejected_signal_outcomes(
         self,
         *,
         now: datetime | None = None,

--- a/services/torghut/app/trading/scheduler/pipeline/signal_processing.py
+++ b/services/torghut/app/trading/scheduler/pipeline/signal_processing.py
@@ -9,6 +9,7 @@ import inspect
 from collections.abc import Mapping
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
+from http.client import HTTPException
 from typing import Any, cast
 
 from sqlalchemy import select
@@ -549,7 +550,7 @@ class TradingPipelineSignalProcessingMixin(TradingPipelineRuntime):
                 event_payload.get("symbol"),
             )
 
-    def _label_mature_rejected_signal_outcome_events(
+    def label_mature_rejected_signal_outcomes(
         self,
         *,
         now: datetime | None = None,
@@ -560,7 +561,7 @@ class TradingPipelineSignalProcessingMixin(TradingPipelineRuntime):
         mature_before = resolved_now - followup_horizon
         try:
             with self.session_factory() as session:
-                rows = (
+                candidates = (
                     session.execute(
                         select(RejectedSignalOutcomeEvent)
                         .where(
@@ -573,24 +574,53 @@ class TradingPipelineSignalProcessingMixin(TradingPipelineRuntime):
                     .scalars()
                     .all()
                 )
-                for row in rows:
-                    try:
-                        outcome = self._build_rejected_signal_outcome_payload(
-                            row=row,
-                            followup_horizon=followup_horizon,
+                session.expunge_all()
+
+            # Quote lookups can consume their full network timeout. End the read
+            # transaction before that I/O so PostgreSQL never sees an idle
+            # transaction while the labeler waits on a market-data provider.
+            outcomes: dict[str, dict[str, Any]] = {}
+            for candidate in candidates:
+                try:
+                    outcome = self._build_rejected_signal_outcome_payload(
+                        row=candidate,
+                        followup_horizon=followup_horizon,
+                    )
+                except (
+                    ArithmeticError,
+                    HTTPException,
+                    OSError,
+                    RuntimeError,
+                    TypeError,
+                    ValueError,
+                ):
+                    logger.exception(
+                        "Failed to build rejected signal outcome label event_id=%s",
+                        candidate.event_id,
+                    )
+                    continue
+                if outcome is not None:
+                    outcomes[candidate.event_id] = outcome
+
+            if not outcomes:
+                return
+            with self.session_factory() as session:
+                rows_to_label = (
+                    session.execute(
+                        select(RejectedSignalOutcomeEvent)
+                        .where(RejectedSignalOutcomeEvent.event_id.in_(tuple(outcomes)))
+                        .where(
+                            RejectedSignalOutcomeEvent.outcome_label_status == "pending"
                         )
-                    except Exception:
-                        logger.exception(
-                            "Failed to build rejected signal outcome label event_id=%s",
-                            row.event_id,
-                        )
-                        continue
-                    if outcome is None:
-                        continue
+                    )
+                    .scalars()
+                    .all()
+                )
+                for row in rows_to_label:
                     row.outcome_label_status = "labeled"
-                    row.outcome_payload_json = outcome
+                    row.outcome_payload_json = outcomes[row.event_id]
                     row.updated_at = resolved_now
-                if rows:
+                if rows_to_label:
                     session.commit()
         except (SQLAlchemyError, ValueError):
             logger.exception("Failed to label mature rejected signal outcome events")

--- a/services/torghut/app/trading/scheduler/rejected_outcome_runtime.py
+++ b/services/torghut/app/trading/scheduler/rejected_outcome_runtime.py
@@ -1,0 +1,45 @@
+"""Run rejected-signal outcome learning outside the order-execution path."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable, Sequence
+
+from .pipeline import TradingPipeline
+
+logger = logging.getLogger(__name__)
+
+
+async def run_rejected_signal_outcome_iteration(
+    pipelines: Sequence[TradingPipeline],
+) -> None:
+    calls: list[tuple[str, Callable[[], object]]] = []
+    for pipeline in pipelines:
+        label_outcomes = getattr(
+            pipeline,
+            "label_mature_rejected_signal_outcomes",
+            None,
+        )
+        if callable(label_outcomes):
+            calls.append((pipeline.account_label, label_outcomes))
+    if not calls:
+        return
+
+    outcomes = await asyncio.gather(
+        *(asyncio.to_thread(label_outcomes) for _, label_outcomes in calls),
+        return_exceptions=True,
+    )
+    for (account_label, _), outcome in zip(calls, outcomes, strict=True):
+        if isinstance(outcome, Exception):
+            logger.error(
+                "Rejected signal outcome lane failed account=%s error=%s",
+                account_label,
+                outcome,
+                exc_info=(type(outcome), outcome, outcome.__traceback__),
+            )
+        elif isinstance(outcome, BaseException):
+            raise outcome
+
+
+__all__ = ["run_rejected_signal_outcome_iteration"]

--- a/services/torghut/app/trading/scheduler/runtime.py
+++ b/services/torghut/app/trading/scheduler/runtime.py
@@ -54,6 +54,7 @@ from .broker_mutation_recovery_runtime import (
 )
 from .pipeline import TradingPipeline
 from .pipeline_helpers import build_llm_policy_resolution
+from .rejected_outcome_runtime import run_rejected_signal_outcome_iteration
 from .runtime_pipeline_factory import build_trading_pipeline_for_account
 from .simulation_state import sync_simulation_run_state
 from .state import TradingState
@@ -692,7 +693,9 @@ class TradingScheduler(
         last_autonomy = datetime.now(timezone.utc)
         last_evidence_check = datetime.now(timezone.utc)
         last_broker_activity = datetime.fromtimestamp(0, tz=timezone.utc)
+        last_rejected_outcome_label = datetime.fromtimestamp(0, tz=timezone.utc)
         broker_activity_task: asyncio.Task[None] | None = None
+        rejected_outcome_task: asyncio.Task[None] | None = None
         logger.info(
             "Trading scheduler loop running poll_interval_seconds=%s reconcile_interval_seconds=%s autonomy_interval_seconds=%s evidence_interval_seconds=%s",
             poll_interval,
@@ -708,6 +711,9 @@ class TradingScheduler(
                 if broker_activity_task is not None and broker_activity_task.done():
                     await broker_activity_task
                     broker_activity_task = None
+                if rejected_outcome_task is not None and rejected_outcome_task.done():
+                    await rejected_outcome_task
+                    rejected_outcome_task = None
                 if broker_activity_task is None and self._interval_elapsed(
                     last_broker_activity,
                     reconcile_interval,
@@ -719,6 +725,17 @@ class TradingScheduler(
                         self._run_broker_account_activity_iteration()
                     )
                     last_broker_activity = now
+                if rejected_outcome_task is None and self._interval_elapsed(
+                    last_rejected_outcome_label,
+                    reconcile_interval,
+                    now=now,
+                ):
+                    # Counterfactual learning is useful research evidence, but
+                    # quote backfills must never delay decisions or broker I/O.
+                    rejected_outcome_task = asyncio.create_task(
+                        self._run_rejected_signal_outcome_iteration()
+                    )
+                    last_rejected_outcome_label = now
                 if self._interval_elapsed(last_reconcile, reconcile_interval, now=now):
                     await self._run_reconcile_iteration()
                     last_reconcile = now
@@ -751,6 +768,8 @@ class TradingScheduler(
                 # through to_thread. Drain it before leadership can be released;
                 # stop() retains the writer fence and exits fatally on timeout.
                 await broker_activity_task
+            if rejected_outcome_task is not None:
+                await rejected_outcome_task
             self.state.running = False
             logger.info("Trading scheduler loop exited")
 
@@ -837,6 +856,12 @@ class TradingScheduler(
                 )
             elif isinstance(outcome, BaseException):
                 raise outcome
+
+    async def _run_rejected_signal_outcome_iteration(self) -> None:
+        active_pipelines = self._pipelines or (
+            [self._pipeline] if self._pipeline else []
+        )
+        await run_rejected_signal_outcome_iteration(active_pipelines)
 
     async def _run_reconcile_iteration(self) -> None:
         if self._pipeline is None:

--- a/services/torghut/tests/pipeline/test_trading_pipeline_capital_safety_ordering.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_capital_safety_ordering.py
@@ -17,7 +17,7 @@ def _pipeline() -> tuple[TradingPipeline, object]:
         metrics=SimpleNamespace(planned_decision_age_seconds=0),
     )
     pipeline.capital_safety = Mock()
-    pipeline._label_mature_rejected_signal_outcome_events = Mock()
+    pipeline.label_mature_rejected_signal_outcomes = Mock()
     pipeline._prepare_run_once = Mock()
     pipeline._get_account_snapshot = Mock(return_value=object())
     return pipeline, session
@@ -32,6 +32,15 @@ def test_capital_safety_runs_when_no_strategy_is_enabled() -> None:
     pipeline.capital_safety.evaluate.assert_called_once_with(
         session, pipeline._get_account_snapshot.return_value
     )
+
+
+def test_rejected_outcome_learning_is_not_on_order_execution_path() -> None:
+    pipeline, _ = _pipeline()
+    pipeline._load_strategies = Mock(return_value=[])
+
+    pipeline.run_once()
+
+    pipeline.label_mature_rejected_signal_outcomes.assert_not_called()
 
 
 def test_capital_safety_runs_before_empty_signal_exit() -> None:

--- a/services/torghut/tests/pipeline/test_trading_pipeline_quote_outcome.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_quote_outcome.py
@@ -492,7 +492,7 @@ class TestTradingPipelineQuoteOutcome(TradingPipelineTestCaseBase):
             )
             session.commit()
 
-        pipeline._label_mature_rejected_signal_outcome_events(
+        pipeline.label_mature_rejected_signal_outcomes(
             now=followup_ts + timedelta(seconds=1)
         )
 
@@ -507,6 +507,93 @@ class TestTradingPipelineQuoteOutcome(TradingPipelineTestCaseBase):
         self.assertEqual(outcome["route_tca"]["horizon_seconds"], "300")
         self.assertNotIn("promotion_readiness", outcome)
         self.assertEqual(outcome["candidate_spec_id"], "spec-feedback")
+
+    def test_rejected_signal_outcome_labeler_closes_read_transaction_before_quotes(
+        self,
+    ) -> None:
+        event_ts = datetime(2026, 1, 1, 14, 31, tzinfo=timezone.utc)
+        followup_ts = event_ts + timedelta(minutes=5)
+        sessions: list[Session] = []
+
+        def tracking_session_factory() -> Session:
+            session = self.session_local()
+            sessions.append(session)
+            return session
+
+        class TransactionCheckingPriceFetcher(TimelinePriceFetcher):
+            active_transaction_seen = False
+
+            def fetch_market_snapshot(
+                self, signal: SignalEnvelope
+            ) -> MarketSnapshot | None:
+                self.active_transaction_seen = self.active_transaction_seen or any(
+                    session.in_transaction() for session in sessions
+                )
+                return super().fetch_market_snapshot(signal)
+
+        price_fetcher = TransactionCheckingPriceFetcher(
+            {
+                event_ts: MarketSnapshot(
+                    symbol="AAPL",
+                    as_of=event_ts,
+                    price=Decimal("100.00"),
+                    spread=Decimal("0.02"),
+                    source="test-entry",
+                    bid=Decimal("99.99"),
+                    ask=Decimal("100.01"),
+                ),
+                followup_ts: MarketSnapshot(
+                    symbol="AAPL",
+                    as_of=followup_ts,
+                    price=Decimal("101.00"),
+                    spread=Decimal("0.02"),
+                    source="test-followup",
+                    bid=Decimal("100.99"),
+                    ask=Decimal("101.01"),
+                ),
+            }
+        )
+        pipeline = self._build_rejected_outcome_pipeline(
+            session_factory=tracking_session_factory,
+            price_fetcher=price_fetcher,
+        )
+        with self.session_local() as session:
+            session.add(
+                RejectedSignalOutcomeEvent(
+                    event_id="reject-event-transaction-boundary",
+                    source="quote_quality_gate",
+                    paper_source="ssrn-6607301",
+                    paper_claim_id="post-rejection-follow-up-sampling",
+                    account_label="paper",
+                    symbol="AAPL",
+                    event_ts=event_ts,
+                    timeframe="1Min",
+                    seq="42",
+                    reject_reason="missing_executable_quote",
+                    outcome_label_status="pending",
+                    counterfactual_required=True,
+                    required_outcome_fields_json=["counterfactual_return"],
+                    event_payload_json={
+                        "event_id": "reject-event-transaction-boundary"
+                    },
+                    outcome_payload_json=None,
+                )
+            )
+            session.commit()
+
+        pipeline.label_mature_rejected_signal_outcomes(
+            now=followup_ts + timedelta(seconds=1)
+        )
+
+        self.assertFalse(price_fetcher.active_transaction_seen)
+        with self.session_local() as session:
+            row = session.execute(
+                select(RejectedSignalOutcomeEvent).where(
+                    RejectedSignalOutcomeEvent.event_id
+                    == "reject-event-transaction-boundary"
+                )
+            ).scalar_one()
+        self.assertEqual(row.outcome_label_status, "labeled")
 
     def test_rejected_signal_outcome_labeler_keeps_missing_quote_pending(
         self,
@@ -542,7 +629,7 @@ class TestTradingPipelineQuoteOutcome(TradingPipelineTestCaseBase):
             )
             session.commit()
 
-        pipeline._label_mature_rejected_signal_outcome_events(
+        pipeline.label_mature_rejected_signal_outcomes(
             now=event_ts + timedelta(minutes=6)
         )
 

--- a/services/torghut/tests/test_scheduler_market_context_status.py
+++ b/services/torghut/tests/test_scheduler_market_context_status.py
@@ -504,7 +504,7 @@ class TestTradingSchedulerMarketContextStatus(TestCase):
         config.settings.trading_autonomy_enabled = False
         config.settings.trading_evidence_continuity_enabled = True
         scheduler = TradingScheduler()
-        calls = {"trading": 0, "reconcile": 0, "evidence": 0}
+        calls = {"trading": 0, "reconcile": 0, "evidence": 0, "outcomes": 0}
 
         async def fake_trading_iteration() -> None:
             calls["trading"] += 1
@@ -516,12 +516,18 @@ class TestTradingSchedulerMarketContextStatus(TestCase):
         async def fake_evidence_iteration() -> None:
             calls["evidence"] += 1
 
+        async def fake_rejected_outcome_iteration() -> None:
+            calls["outcomes"] += 1
+
         async def fake_sleep(_delay: float) -> None:
             return None
 
         cast(Any, scheduler)._run_trading_iteration = fake_trading_iteration
         cast(Any, scheduler)._run_reconcile_iteration = fake_reconcile_iteration
         cast(Any, scheduler)._run_evidence_iteration = fake_evidence_iteration
+        cast(
+            Any, scheduler
+        )._run_rejected_signal_outcome_iteration = fake_rejected_outcome_iteration
         cast(Any, scheduler)._sync_simulation_run_context = lambda: None
         cast(Any, scheduler)._interval_elapsed = lambda *_args, **_kwargs: True
 
@@ -530,5 +536,8 @@ class TestTradingSchedulerMarketContextStatus(TestCase):
         ):
             asyncio.run(scheduler._run_loop())
 
-        self.assertEqual(calls, {"trading": 1, "reconcile": 1, "evidence": 1})
+        self.assertEqual(
+            calls,
+            {"trading": 1, "reconcile": 1, "evidence": 1, "outcomes": 1},
+        )
         self.assertFalse(scheduler.state.running)

--- a/services/torghut/tests/trading_scheduler_autonomy/support.py
+++ b/services/torghut/tests/trading_scheduler_autonomy/support.py
@@ -152,15 +152,18 @@ class _PipelineIterationStub:
         reconcile_return: int = 0,
         reconcile_fail: bool = False,
         account_activity_fail: bool = False,
+        rejected_outcome_fail: bool = False,
     ) -> None:
         self.account_label = account_label
         self.run_once_fail = run_once_fail
         self.reconcile_fail = reconcile_fail
         self.reconcile_return = reconcile_return
         self.account_activity_fail = account_activity_fail
+        self.rejected_outcome_fail = rejected_outcome_fail
         self.run_once_calls = 0
         self.reconcile_calls = 0
         self.account_activity_calls = 0
+        self.rejected_outcome_calls = 0
         self.run_once_last_error: str | None = None
         self.reconcile_last_error: str | None = None
 
@@ -181,6 +184,11 @@ class _PipelineIterationStub:
         self.account_activity_calls += 1
         if self.account_activity_fail:
             raise RuntimeError("account_activity_failed")
+
+    def label_mature_rejected_signal_outcomes(self) -> None:
+        self.rejected_outcome_calls += 1
+        if self.rejected_outcome_fail:
+            raise RuntimeError("rejected_outcome_failed")
 
 
 class _SchedulerDependencies:

--- a/services/torghut/tests/trading_scheduler_autonomy/test_emergency_stop_incident_contains_hooks_and_provenance.py
+++ b/services/torghut/tests/trading_scheduler_autonomy/test_emergency_stop_incident_contains_hooks_and_provenance.py
@@ -326,6 +326,23 @@ class TestEmergencyStopIncidentContainsHooksAndProvenance(
         self.assertIsNone(scheduler.state.last_trading_error)
         self.assertIsNone(scheduler.state.last_reconcile_error)
 
+    def test_rejected_outcome_learning_isolated_per_lane(self) -> None:
+        scheduler = TradingScheduler()
+        failing_lane = _PipelineIterationStub(
+            account_label="paper-a",
+            rejected_outcome_fail=True,
+        )
+        healthy_lane = _PipelineIterationStub(account_label="paper-b")
+        scheduler._pipelines = [failing_lane, healthy_lane]
+        scheduler._pipeline = failing_lane
+
+        asyncio.run(scheduler._run_rejected_signal_outcome_iteration())
+
+        self.assertEqual(failing_lane.rejected_outcome_calls, 1)
+        self.assertEqual(healthy_lane.rejected_outcome_calls, 1)
+        self.assertIsNone(scheduler.state.last_trading_error)
+        self.assertIsNone(scheduler.state.last_reconcile_error)
+
     def test_recovery_worker_failure_is_counted_and_fails_reconciliation(self) -> None:
         class _FailingRecoveryWorker:
             def run_once(self) -> None:


### PR DESCRIPTION
## Summary

- remove rejected-signal outcome quote backfills from the strategy, risk, and broker execution cycle
- run one isolated background outcome-learning task per scheduler, with per-account failure isolation and shutdown draining
- close the PostgreSQL read transaction before external quote lookups, then persist completed labels in a short write transaction
- add regressions for the transaction boundary, critical-path isolation, scheduler dispatch, and per-lane failure containment

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/pipeline tests/test_scheduler_market_context_status.py tests/trading_scheduler_autonomy -q` (182 passed)
- `uv run --frozen ruff format --check app tests scripts migrations`
- `uv run --frozen ruff check app tests scripts migrations`
- `uv run --frozen python -m compileall -q app scripts`
- all five Pyright profiles: default, alpha, alpha strict, scripts, and scripts strict
- changed-line Pylint quality/design gates and file-length gate
- live diagnosis: 40,776 pending outcome rows, PostgreSQL 15-second idle-in-transaction timeout, and repeated scheduler labeler errors while core readiness remained green

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed because this is a backend runtime fix; Breaking Changes is filled in.
- [x] No documentation or release-note change is required; live rollout evidence will be recorded after promotion.
