### PR TITLE
fix(torghut): use captured rejected-signal quotes

### DIFF
--- a/services/torghut/app/trading/scheduler/pipeline/signal_processing.py
+++ b/services/torghut/app/trading/scheduler/pipeline/signal_processing.py
@@ -27,6 +27,7 @@ from ...portfolio import (
     AllocationResult,
     allocator_from_settings,
 )
+from ...prices import MarketSnapshot
 from ..pair_execution import partition_pair_allocations, reserve_pair_allocations
 from ...quote_quality import (
     QuoteQualityStatus,
@@ -695,7 +696,9 @@ class TradingPipelineSignalProcessingMixin(TradingPipelineRuntime):
         followup_signal = entry_signal.model_copy(
             update={"event_ts": entry_signal.event_ts + followup_horizon}
         )
-        entry_snapshot = self.price_fetcher.fetch_market_snapshot(entry_signal)
+        entry_snapshot = self._captured_rejected_signal_entry_snapshot(entry_signal)
+        if entry_snapshot is None:
+            entry_snapshot = self.price_fetcher.fetch_market_snapshot(entry_signal)
         followup_snapshot = self.price_fetcher.fetch_market_snapshot(followup_signal)
         if (
             entry_snapshot is None
@@ -708,6 +711,49 @@ class TradingPipelineSignalProcessingMixin(TradingPipelineRuntime):
         ):
             return None
         return entry_snapshot, followup_snapshot
+
+    @staticmethod
+    def _captured_rejected_signal_entry_snapshot(
+        signal: SignalEnvelope,
+    ) -> MarketSnapshot | None:
+        price = extract_executable_price(signal.payload)
+        bid = scheduler_optional_decimal(
+            payload_value(
+                signal.payload,
+                "imbalance_bid_px",
+                block="imbalance",
+                nested_key="bid_px",
+            )
+        )
+        ask = scheduler_optional_decimal(
+            payload_value(
+                signal.payload,
+                "imbalance_ask_px",
+                block="imbalance",
+                nested_key="ask_px",
+            )
+        )
+        if (
+            price is None
+            or bid is None
+            or ask is None
+            or price <= 0
+            or bid <= 0
+            or ask <= 0
+            or ask < bid
+        ):
+            return None
+        return MarketSnapshot(
+            symbol=signal.symbol,
+            as_of=signal.event_ts,
+            price=price,
+            spread=ask - bid,
+            source="rejected_signal_event",
+            bid=bid,
+            ask=ask,
+            quote_as_of=signal.event_ts,
+            quote_source="rejected_signal_event",
+        )
 
     @staticmethod
     def _rejected_signal_route_metrics(

--- a/services/torghut/tests/pipeline/test_trading_pipeline_quote_outcome.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_quote_outcome.py
@@ -595,6 +595,70 @@ class TestTradingPipelineQuoteOutcome(TradingPipelineTestCaseBase):
             ).scalar_one()
         self.assertEqual(row.outcome_label_status, "labeled")
 
+    def test_rejected_signal_outcome_labeler_uses_captured_entry_quote(self) -> None:
+        event_ts = datetime(2026, 1, 1, 14, 31, tzinfo=timezone.utc)
+        followup_ts = event_ts + timedelta(minutes=5)
+        pipeline = self._build_rejected_outcome_pipeline(
+            price_fetcher=TimelinePriceFetcher(
+                {
+                    followup_ts: MarketSnapshot(
+                        symbol="AAPL",
+                        as_of=followup_ts,
+                        price=Decimal("101.00"),
+                        spread=None,
+                        source="test-followup",
+                    )
+                }
+            )
+        )
+        with self.session_local() as session:
+            session.add(
+                RejectedSignalOutcomeEvent(
+                    event_id="reject-event-captured-entry-quote",
+                    source="quote_quality_gate",
+                    paper_source="ssrn-6607301",
+                    paper_claim_id="post-rejection-follow-up-sampling",
+                    account_label="paper",
+                    symbol="AAPL",
+                    event_ts=event_ts,
+                    timeframe="1Min",
+                    seq="42",
+                    reject_reason="spread_too_wide",
+                    outcome_label_status="pending",
+                    counterfactual_required=True,
+                    required_outcome_fields_json=[
+                        "counterfactual_return",
+                        "route_tca",
+                        "post_cost_net_pnl",
+                        "executable_quote",
+                    ],
+                    event_payload_json={
+                        "event_id": "reject-event-captured-entry-quote",
+                        "signal_payload": {
+                            "price": "100.00",
+                            "imbalance_bid_px": "99.99",
+                            "imbalance_ask_px": "100.01",
+                        },
+                    },
+                    outcome_payload_json=None,
+                )
+            )
+            session.commit()
+
+        pipeline.label_mature_rejected_signal_outcomes(
+            now=followup_ts + timedelta(seconds=1)
+        )
+
+        with self.session_local() as session:
+            row = session.execute(select(RejectedSignalOutcomeEvent)).scalar_one()
+
+        self.assertEqual(row.outcome_label_status, "labeled")
+        self.assertEqual(row.outcome_payload_json["executable_quote"]["bid"], "99.99")
+        self.assertEqual(
+            row.outcome_payload_json["executable_quote"]["source"],
+            "rejected_signal_event",
+        )
+
     def test_rejected_signal_outcome_labeler_keeps_missing_quote_pending(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- use the immutable event-time bid and ask already stored with a rejected signal instead of re-fetching an often-incomplete historical entry quote
- retain the historical entry lookup as a compatibility fallback when older events lack a captured executable quote
- cover the live head-of-line starvation case where the follow-up price exists but the historical entry lookup has no bid or ask

## Related Issues

None

## Testing

- `services/torghut/.venv/bin/pytest services/torghut/tests/pipeline/test_trading_pipeline_quote_outcome.py -q` (16 passed)
- `services/torghut/.venv/bin/pytest services/torghut/tests/pipeline services/torghut/tests/test_scheduler_market_context_status.py services/torghut/tests/trading_scheduler_autonomy -q` (183 passed)
- `services/torghut/.venv/bin/ruff format --check services/torghut/app services/torghut/tests services/torghut/scripts services/torghut/migrations`
- `services/torghut/.venv/bin/ruff check services/torghut/app services/torghut/tests services/torghut/scripts services/torghut/migrations`
- all five Pyright profiles (0 errors)
- Torghut structural, changed-line quality, design-complexity, and file-length Pylint gates
- `services/torghut/.venv/bin/python -m compileall -q services/torghut/app services/torghut/scripts`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.