### PR TITLE
fix(torghut): restore scheduler progress and revision scaling

### DIFF
--- a/argocd/applications/observability/graf-mimir-rules.yaml
+++ b/argocd/applications/observability/graf-mimir-rules.yaml
@@ -862,7 +862,7 @@ data:
               summary: Torghut API service is missing
               description: |
                 The stable Knative API Service is absent from Kubernetes inventory.
-                Private revision metrics may be absent normally while the stateless API is scaled to zero.
+                The Torghut metrics scrape uses this Service to reach the current revision.
               runbook_url: docs/torghut/design-system/v1/operations-knative-revision-failures.md
           - alert: TorghutActiveApiRevisionMetricsDown
             expr: |
@@ -870,7 +870,7 @@ data:
                 up{
                   job="torghut",
                   namespace="torghut",
-                  service=~"torghut-[0-9]{5}-private"
+                  service="torghut"
                 }
               ) == 0
             for: 5m
@@ -879,8 +879,7 @@ data:
             annotations:
               summary: Active Torghut API revision metrics endpoint is down
               description: |
-                A currently active stateless Knative API revision is being scraped but up=0 for 5 minutes.
-                No alert is expected while Knative has intentionally scaled the API to zero.
+                The stable Knative route to the current stateless API revision has reported up=0 for 5 minutes.
               runbook_url: docs/torghut/design-system/v1/operations-knative-revision-failures.md
           - alert: TorghutSchedulerMetricsMissing
             expr: |

--- a/argocd/applications/torghut/alloy-configmap.yaml
+++ b/argocd/applications/torghut/alloy-configmap.yaml
@@ -70,7 +70,7 @@ data:
 
       rule {
         source_labels = ["__meta_kubernetes_endpoint_port_name", "__meta_kubernetes_service_name"]
-        regex         = "metric(s)?;.*|http;torghut-[0-9]{5}-private"
+        regex         = "metric(s)?;.*"
         action        = "keep"
       }
 
@@ -101,6 +101,19 @@ data:
       scrape_interval = "30s"
       targets         = discovery.relabel.torghut_metrics.output
       forward_to      = [prometheus.remote_write.mimir.receiver]
+    }
+
+    // Scraping every revision-private endpoint prevents Knative from scaling
+    // inactive revisions to zero. The stable route always targets the current revision.
+    prometheus.scrape "torghut_api" {
+      job_name        = "torghut"
+      scrape_interval = "30s"
+      targets = [{
+        "__address__" = "torghut.torghut.svc.cluster.local:80",
+        "namespace"   = "torghut",
+        "service"     = "torghut",
+      }]
+      forward_to = [prometheus.remote_write.mimir.receiver]
     }
 
     loki.write "default" {

--- a/services/torghut/app/trading/scheduler/pipeline/signal_processing.py
+++ b/services/torghut/app/trading/scheduler/pipeline/signal_processing.py
@@ -566,16 +566,25 @@ class TradingPipelineSignalProcessingMixin(TradingPipelineRuntime):
                     session.execute(
                         select(RejectedSignalOutcomeEvent)
                         .where(
-                            RejectedSignalOutcomeEvent.outcome_label_status == "pending"
+                            RejectedSignalOutcomeEvent.outcome_label_status
+                            == "pending",
+                            RejectedSignalOutcomeEvent.account_label
+                            == self.account_label,
+                            RejectedSignalOutcomeEvent.event_ts <= mature_before,
                         )
-                        .where(RejectedSignalOutcomeEvent.event_ts <= mature_before)
-                        .order_by(RejectedSignalOutcomeEvent.event_ts.asc())
+                        .order_by(
+                            RejectedSignalOutcomeEvent.updated_at.asc(),
+                            RejectedSignalOutcomeEvent.event_ts.asc(),
+                        )
                         .limit(max(0, limit))
                     )
                     .scalars()
                     .all()
                 )
                 session.expunge_all()
+
+            if not candidates:
+                return
 
             # Quote lookups can consume their full network timeout. End the read
             # transaction before that I/O so PostgreSQL never sees an idle
@@ -603,25 +612,30 @@ class TradingPipelineSignalProcessingMixin(TradingPipelineRuntime):
                 if outcome is not None:
                     outcomes[candidate.event_id] = outcome
 
-            if not outcomes:
-                return
+            candidate_event_ids = tuple(candidate.event_id for candidate in candidates)
             with self.session_factory() as session:
-                rows_to_label = (
+                rows_to_update = (
                     session.execute(
-                        select(RejectedSignalOutcomeEvent)
-                        .where(RejectedSignalOutcomeEvent.event_id.in_(tuple(outcomes)))
-                        .where(
-                            RejectedSignalOutcomeEvent.outcome_label_status == "pending"
+                        select(RejectedSignalOutcomeEvent).where(
+                            RejectedSignalOutcomeEvent.event_id.in_(
+                                candidate_event_ids
+                            ),
+                            RejectedSignalOutcomeEvent.account_label
+                            == self.account_label,
+                            RejectedSignalOutcomeEvent.outcome_label_status
+                            == "pending",
                         )
                     )
                     .scalars()
                     .all()
                 )
-                for row in rows_to_label:
-                    row.outcome_label_status = "labeled"
-                    row.outcome_payload_json = outcomes[row.event_id]
+                for row in rows_to_update:
+                    outcome = outcomes.get(row.event_id)
+                    if outcome is not None:
+                        row.outcome_label_status = "labeled"
+                        row.outcome_payload_json = outcome
                     row.updated_at = resolved_now
-                if rows_to_label:
+                if rows_to_update:
                     session.commit()
         except (SQLAlchemyError, ValueError):
             logger.exception("Failed to label mature rejected signal outcome events")

--- a/services/torghut/tests/live_config_manifest_contract/test_scheduler_observability_manifest.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_scheduler_observability_manifest.py
@@ -71,8 +71,10 @@ class SchedulerObservabilityManifestTests(TestCase):
         api_down = str(by_alert["TorghutActiveApiRevisionMetricsDown"]["expr"])
         self.assertIn("kube_service_info", api_missing)
         self.assertIn('service="torghut"', api_missing)
-        self.assertIn('service=~"torghut-[0-9]{5}-private"', api_down)
+        self.assertIn('service="torghut"', api_down)
+        self.assertNotIn("-private", api_down)
         self.assertNotIn('service="torghut-scheduler"', api_missing)
+        self.assertNotIn('service="torghut-scheduler"', api_down)
 
         for alert in ("TorghutSchedulerMetricsMissing", "TorghutSchedulerMetricsDown"):
             expr = str(by_alert[alert]["expr"])
@@ -120,12 +122,15 @@ class SchedulerObservabilityManifestTests(TestCase):
             self.assertIn('service="torghut-scheduler"', expression)
             self.assertNotIn('service="torghut"', expression)
 
-    def test_namespace_alloy_discovers_scheduler_metrics_port(self) -> None:
+    def test_namespace_alloy_scrapes_api_through_stable_route(self) -> None:
         alloy_config = _configmap_data(
             "argocd/applications/torghut/alloy-configmap.yaml",
             "config.river",
         )
+        self.assertIn('regex         = "metric(s)?;.*"', alloy_config)
+        self.assertIn('prometheus.scrape "torghut_api"', alloy_config)
         self.assertIn(
-            'regex         = "metric(s)?;.*|http;torghut-[0-9]{5}-private"',
+            '"__address__" = "torghut.torghut.svc.cluster.local:80"',
             alloy_config,
         )
+        self.assertNotIn("torghut-[0-9]{5}-private", alloy_config)

--- a/services/torghut/tests/pipeline/test_trading_pipeline_quote_outcome.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_quote_outcome.py
@@ -703,6 +703,144 @@ class TestTradingPipelineQuoteOutcome(TradingPipelineTestCaseBase):
         self.assertEqual(row.outcome_label_status, "pending")
         self.assertIsNone(row.outcome_payload_json)
 
+    def test_rejected_signal_outcome_labeler_retries_fairly_within_account(
+        self,
+    ) -> None:
+        foreign_event_ts = datetime(2026, 1, 1, 14, 28, tzinfo=timezone.utc)
+        incomplete_event_ts = datetime(2026, 1, 1, 14, 29, tzinfo=timezone.utc)
+        complete_event_ts = datetime(2026, 1, 1, 14, 30, tzinfo=timezone.utc)
+        followup_ts = complete_event_ts + timedelta(minutes=5)
+        first_attempt_at = datetime(2026, 1, 1, 14, 36, tzinfo=timezone.utc)
+        pipeline = self._build_rejected_outcome_pipeline(
+            price_fetcher=TimelinePriceFetcher(
+                {
+                    followup_ts: MarketSnapshot(
+                        symbol="MSFT",
+                        as_of=followup_ts,
+                        price=Decimal("201.00"),
+                        spread=None,
+                        source="test-followup",
+                    )
+                }
+            )
+        )
+        initial_updated_at = {
+            "foreign": datetime(2026, 1, 1, 13, 1, tzinfo=timezone.utc),
+            "incomplete": datetime(2026, 1, 1, 13, 2, tzinfo=timezone.utc),
+            "complete": datetime(2026, 1, 1, 13, 3, tzinfo=timezone.utc),
+        }
+        with self.session_local() as session:
+            session.add_all(
+                [
+                    RejectedSignalOutcomeEvent(
+                        event_id="reject-event-foreign-account",
+                        source="quote_quality_gate",
+                        paper_source="ssrn-6607301",
+                        paper_claim_id="post-rejection-follow-up-sampling",
+                        account_label="live",
+                        symbol="NVDA",
+                        event_ts=foreign_event_ts,
+                        timeframe="1Min",
+                        seq="40",
+                        reject_reason="missing_executable_quote",
+                        outcome_label_status="pending",
+                        counterfactual_required=True,
+                        required_outcome_fields_json=["counterfactual_return"],
+                        event_payload_json={"event_id": "reject-event-foreign-account"},
+                        outcome_payload_json=None,
+                        created_at=initial_updated_at["foreign"],
+                        updated_at=initial_updated_at["foreign"],
+                    ),
+                    RejectedSignalOutcomeEvent(
+                        event_id="reject-event-incomplete-oldest",
+                        source="quote_quality_gate",
+                        paper_source="ssrn-6607301",
+                        paper_claim_id="post-rejection-follow-up-sampling",
+                        account_label="paper",
+                        symbol="AAPL",
+                        event_ts=incomplete_event_ts,
+                        timeframe="1Min",
+                        seq="41",
+                        reject_reason="missing_executable_quote",
+                        outcome_label_status="pending",
+                        counterfactual_required=True,
+                        required_outcome_fields_json=["counterfactual_return"],
+                        event_payload_json={
+                            "event_id": "reject-event-incomplete-oldest"
+                        },
+                        outcome_payload_json=None,
+                        created_at=initial_updated_at["incomplete"],
+                        updated_at=initial_updated_at["incomplete"],
+                    ),
+                    RejectedSignalOutcomeEvent(
+                        event_id="reject-event-complete-next",
+                        source="quote_quality_gate",
+                        paper_source="ssrn-6607301",
+                        paper_claim_id="post-rejection-follow-up-sampling",
+                        account_label="paper",
+                        symbol="MSFT",
+                        event_ts=complete_event_ts,
+                        timeframe="1Min",
+                        seq="42",
+                        reject_reason="spread_too_wide",
+                        outcome_label_status="pending",
+                        counterfactual_required=True,
+                        required_outcome_fields_json=["counterfactual_return"],
+                        event_payload_json={
+                            "event_id": "reject-event-complete-next",
+                            "signal_payload": {
+                                "price": "200.00",
+                                "imbalance_bid_px": "199.99",
+                                "imbalance_ask_px": "200.01",
+                            },
+                        },
+                        outcome_payload_json=None,
+                        created_at=initial_updated_at["complete"],
+                        updated_at=initial_updated_at["complete"],
+                    ),
+                ]
+            )
+            session.commit()
+            foreign_initial_timestamp = session.execute(
+                select(RejectedSignalOutcomeEvent.updated_at).where(
+                    RejectedSignalOutcomeEvent.event_id
+                    == "reject-event-foreign-account"
+                )
+            ).scalar_one()
+            incomplete_initial_timestamp = session.execute(
+                select(RejectedSignalOutcomeEvent.updated_at).where(
+                    RejectedSignalOutcomeEvent.event_id
+                    == "reject-event-incomplete-oldest"
+                )
+            ).scalar_one()
+
+        pipeline.label_mature_rejected_signal_outcomes(
+            now=first_attempt_at,
+            limit=1,
+        )
+        pipeline.label_mature_rejected_signal_outcomes(
+            now=first_attempt_at + timedelta(seconds=1),
+            limit=1,
+        )
+
+        with self.session_local() as session:
+            rows = {
+                row.event_id: row
+                for row in session.execute(select(RejectedSignalOutcomeEvent)).scalars()
+            }
+
+        foreign = rows["reject-event-foreign-account"]
+        incomplete = rows["reject-event-incomplete-oldest"]
+        complete = rows["reject-event-complete-next"]
+        self.assertEqual(foreign.outcome_label_status, "pending")
+        self.assertEqual(foreign.updated_at, foreign_initial_timestamp)
+        self.assertEqual(incomplete.outcome_label_status, "pending")
+        self.assertGreater(incomplete.updated_at, incomplete_initial_timestamp)
+        self.assertEqual(complete.outcome_label_status, "labeled")
+        self.assertEqual(
+            complete.outcome_payload_json["counterfactual_return"], "0.005"
+        )
+
     def test_rejected_signal_outcome_persistence_logs_and_continues_on_db_error(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- rotate mature rejected-outcome retries by durable `updated_at` order within the scheduler account so incomplete rows cannot starve later learnable outcomes
- keep failed and incomplete outcomes pending while recording each attempt in a short write transaction after all quote I/O
- scrape Torghut API metrics through the stable Knative route instead of every retained revision-private endpoint, allowing inactive revisions to scale to zero
- preserve the live alert path by moving the Mimir target selector to the stable `torghut` service label

## Related Issues

None

## Testing

- regression first failed on `test_rejected_signal_outcome_labeler_retries_fairly_within_account`, then passed after the fix
- `services/torghut/.venv/bin/pytest services/torghut/tests/pipeline/test_trading_pipeline_quote_outcome.py -q` (17 passed)
- `services/torghut/.venv/bin/pytest services/torghut/tests/pipeline services/torghut/tests/test_scheduler_market_context_status.py services/torghut/tests/trading_scheduler_autonomy -q` (184 passed)
- Ruff format/lint, unused-import gate, and Python bytecode compilation across Torghut app/tests/scripts/migrations
- all five Torghut Pyright profiles (0 errors, 0 warnings)
- Torghut structural, changed-line quality, changed-file design, and file-length Pylint gates
- `alloy validate` on the rendered `config.river`
- Kustomize renders for Torghut and observability
- `bun run lint:argocd` (0 invalid resources)
- live stable-route request returned current Torghut API metrics through `knative-local-gateway`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
