### PR TITLE
fix(torghut): roll Alloy on config changes

### DIFF
--- a/.github/workflows/torghut-ci.yml
+++ b/.github/workflows/torghut-ci.yml
@@ -170,6 +170,33 @@ jobs:
         with:
           require-preinstalled: 'true'
 
+      - name: Verify Torghut Alloy config rollout digest
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          config_manifest='argocd/applications/torghut/alloy-configmap.yaml'
+          deployment_manifest='argocd/applications/torghut/alloy-deployment.yaml'
+          annotation='torghut.proompteng.ai/alloy-config-sha256'
+          expected="$(yq -r ".spec.template.metadata.annotations.\"${annotation}\"" "${deployment_manifest}")"
+          actual="$(
+            yq -o=json -I=0 '.data."config.river"' "${config_manifest}" \
+              | jq -jr . \
+              | sha256sum \
+              | awk '{print $1}'
+          )"
+
+          if ! [[ "${expected}" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "${deployment_manifest} is missing a valid ${annotation} annotation" >&2
+            exit 1
+          fi
+          if [ "${actual}" != "${expected}" ]; then
+            echo "Alloy config digest mismatch: update ${annotation} to ${actual}" >&2
+            exit 1
+          fi
+
+          echo "Torghut Alloy Deployment digest matches config.river."
+
       - name: Verify source image digest contract
         shell: bash
         env:

--- a/argocd/applications/torghut/alloy-deployment.yaml
+++ b/argocd/applications/torghut/alloy-deployment.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/restartedAt: "2026-03-19T06:31:00Z"
+        torghut.proompteng.ai/alloy-config-sha256: be2adb039b3b684c22547158b61e1903100df42fb7ea797401a49bfbfd6ff01c
       labels:
         app.kubernetes.io/name: torghut-alloy
         app.kubernetes.io/component: observability

--- a/services/torghut/tests/live_config_manifest_contract/test_scheduler_observability_manifest.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_scheduler_observability_manifest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 from typing import Mapping, cast
@@ -134,3 +135,20 @@ class SchedulerObservabilityManifestTests(TestCase):
             alloy_config,
         )
         self.assertNotIn("torghut-[0-9]{5}-private", alloy_config)
+
+    def test_alloy_config_digest_rolls_deployment(self) -> None:
+        alloy_config = _configmap_data(
+            "argocd/applications/torghut/alloy-configmap.yaml",
+            "config.river",
+        )
+        deployment = safe_load(
+            (
+                _repo_root() / "argocd/applications/torghut/alloy-deployment.yaml"
+            ).read_text(encoding="utf-8")
+        )
+        annotations = deployment["spec"]["template"]["metadata"]["annotations"]
+
+        self.assertEqual(
+            annotations.get("torghut.proompteng.ai/alloy-config-sha256"),
+            hashlib.sha256(alloy_config.encode()).hexdigest(),
+        )


### PR DESCRIPTION
## Summary

- bind the Torghut Alloy pod template to the exact SHA-256 of its embedded configuration so GitOps config changes trigger a rollout
- add a manifest contract that recomputes the digest and fails CI if the ConfigMap changes without the Deployment annotation
- prevent future silent operation on stale scrape targets after Argo reports the ConfigMap synced

## Related Issues

None

## Testing

- `services/torghut/.venv/bin/pytest tests/live_config_manifest_contract/test_scheduler_observability_manifest.py -q` (6 passed)
- Ruff format and lint on the changed manifest contract
- all five Torghut Pyright profiles (0 errors, 0 warnings)
- Torghut changed-line quality and file-length Pylint gates
- `alloy validate` on the rendered Torghut Alloy configuration
- Kustomize render for Torghut
- `bun run lint:argocd` (0 invalid resources)
- live manual reload of the already-synced config reported `config reloaded` and all Alloy components healthy; five inactive Knative revisions then reported desired/actual scale 0

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
