### PR TITLE
chore(symphony): promote image sha-e32f125fc3d1fdf4e2c98d46eb7c46133d3c93a6

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-15T05:29:00Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-18T08:39:21Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -22,5 +22,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-2b4b9a368e5821c77ae960b8df65b95685e81d25"
-    digest: sha256:918f06ae507ea6453296cb16f533e1e1e912ccb30dcf64bccdf2a41d4912ae1b
+    newTag: "sha-e32f125fc3d1fdf4e2c98d46eb7c46133d3c93a6"
+    digest: sha256:b0ccfbd2dbc4d37af4a36d2cbd583bf5bf93e524247430b1dc261f324a696d6c

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-15T05:29:00Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-18T08:39:21Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-2b4b9a368e5821c77ae960b8df65b95685e81d25"
-    digest: sha256:918f06ae507ea6453296cb16f533e1e1e912ccb30dcf64bccdf2a41d4912ae1b
+    newTag: "sha-e32f125fc3d1fdf4e2c98d46eb7c46133d3c93a6"
+    digest: sha256:b0ccfbd2dbc4d37af4a36d2cbd583bf5bf93e524247430b1dc261f324a696d6c

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-15T05:29:00Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-18T08:39:21Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -16,5 +16,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-2b4b9a368e5821c77ae960b8df65b95685e81d25"
-    digest: sha256:918f06ae507ea6453296cb16f533e1e1e912ccb30dcf64bccdf2a41d4912ae1b
+    newTag: "sha-e32f125fc3d1fdf4e2c98d46eb7c46133d3c93a6"
+    digest: sha256:b0ccfbd2dbc4d37af4a36d2cbd583bf5bf93e524247430b1dc261f324a696d6c


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `e32f125fc3d1fdf4e2c98d46eb7c46133d3c93a6`
- Image tag: `sha-e32f125fc3d1fdf4e2c98d46eb7c46133d3c93a6`
- Image digest: `sha256:b0ccfbd2dbc4d37af4a36d2cbd583bf5bf93e524247430b1dc261f324a696d6c`