### PR TITLE
fix(torghut): preserve cross-date fee identities

### DIFF
--- a/services/torghut/app/trading/economic_ledger/journal_reducer.py
+++ b/services/torghut/app/trading/economic_ledger/journal_reducer.py
@@ -25,7 +25,7 @@ from .types import (
 
 
 JOURNAL_REDUCER_NAME = "balanced_journal"
-JOURNAL_REDUCER_VERSION = "torghut.broker-economic-journal.v4"
+JOURNAL_REDUCER_VERSION = "torghut.broker-economic-journal.v5"
 
 _MAX_TRANSACTION_ID_LENGTH = 512
 _REVERSAL_TRANSACTION_ID_PREFIX = "correction-reversal:sha256:"
@@ -295,6 +295,10 @@ class _JournalWriter:
                 "economic_crypto_fee_fair_value_below_ledger_quantum"
             )
         if position.quantity <= ZERO or abs(quantity) > position.quantity:
+            if activity.external_activity_id in self.prepared.retroactive_append_ids:
+                raise EconomicLedgerError(
+                    "economic_ledger_unappendable_late_fee_requires_new_version"
+                )
             raise EconomicLedgerError("economic_crypto_fee_position_insufficient")
         if abs(quantity) == position.quantity:
             position_cost_delta = -position.signed_cost

--- a/services/torghut/app/trading/economic_ledger/persistence.py
+++ b/services/torghut/app/trading/economic_ledger/persistence.py
@@ -39,6 +39,7 @@ from ..broker_account_activities import (
 )
 from .comparison import DualReduction, reduce_and_compare
 from .journal_reducer import JOURNAL_REDUCER_NAME, JOURNAL_REDUCER_VERSION
+from .published_order import load_published_activity_order
 from .state_reducer import STATE_REDUCER_NAME, STATE_REDUCER_VERSION
 from .types import (
     EconomicActivity,
@@ -94,6 +95,7 @@ class BrokerEconomicLedgerSourceRows:
     activities_inserted: int
     rows: tuple[Row[BrokerEconomicLedgerSourceRecord], ...]
     option_contract_sizes: tuple[tuple[str, int], ...]
+    published_activity_order: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -198,12 +200,47 @@ def replay_broker_economic_ledger_snapshot(
     """Run both pure reducers from an already closed immutable source snapshot."""
 
     reduction = reduce_and_compare(snapshot.prepared)
+    _require_retroactive_append_equivalence(snapshot, reduction=reduction)
     token = _publication_token(snapshot, reduction)
     return BrokerEconomicLedgerReplay(
         snapshot=snapshot,
         reduction=reduction,
         publication_token=token,
     )
+
+
+def _require_retroactive_append_equivalence(
+    snapshot: BrokerEconomicLedgerSnapshot,
+    *,
+    reduction: DualReduction,
+) -> None:
+    if not snapshot.prepared.retroactive_append_ids:
+        return
+
+    economic_order = reduce_and_compare(prepare_activities(snapshot.activities))
+    anchored_transactions = tuple(
+        sorted(
+            (transaction.transaction_id, transaction.digest)
+            for transaction in reduction.journal.transactions
+        )
+    )
+    economic_transactions = tuple(
+        sorted(
+            (transaction.transaction_id, transaction.digest)
+            for transaction in economic_order.journal.transactions
+        )
+    )
+    anchored_projection = reduction.journal.projection.economic_payload()
+    economic_projection = economic_order.journal.projection.economic_payload()
+    anchored_projection.pop("input_manifest_digest")
+    economic_projection.pop("input_manifest_digest")
+    if (
+        anchored_transactions != economic_transactions
+        or anchored_projection != economic_projection
+    ):
+        raise EconomicLedgerError(
+            "economic_ledger_unappendable_late_fee_requires_new_version"
+        )
 
 
 def load_broker_economic_ledger_source_rows(
@@ -253,6 +290,7 @@ def load_broker_economic_ledger_source_rows(
         session,
         symbols=_option_symbols(rows),
     )
+    published_activity_order = load_published_activity_order(session, scope=scope)
     return BrokerEconomicLedgerSourceRows(
         cursor_id=cursor.id,
         source_watermark=as_utc(cursor.last_completed_scan_until),
@@ -260,6 +298,7 @@ def load_broker_economic_ledger_source_rows(
         activities_inserted=cursor.activities_inserted,
         rows=rows,
         option_contract_sizes=option_contract_sizes,
+        published_activity_order=published_activity_order,
     )
 
 
@@ -310,10 +349,16 @@ def prepare_broker_economic_ledger_snapshot(
         )
         for row in source_rows.rows
     )
-    prepared = prepare_activities(activities)
+    prepared = prepare_activities(
+        activities,
+        prior_activity_order=source_rows.published_activity_order,
+    )
+    activities_by_id = {
+        activity.external_activity_id: activity for activity in activities
+    }
     manifest = tuple(
-        activity.manifest_payload()
-        for activity in sorted(activities, key=lambda item: item.sort_key)
+        activities_by_id[external_id].manifest_payload()
+        for external_id in prepared.activity_order
     )
     manifest_canonical_json = _canonical_json(manifest)
     if _sha256(manifest_canonical_json) != prepared.manifest_digest:

--- a/services/torghut/app/trading/economic_ledger/published_order.py
+++ b/services/torghut/app/trading/economic_ledger/published_order.py
@@ -1,0 +1,114 @@
+"""Load and validate the immutable order anchor from a published reducer pair."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import cast
+
+from sqlalchemy import and_, select
+from sqlalchemy.orm import Session, aliased
+
+from ...models import BrokerEconomicLedgerInput, BrokerEconomicLedgerRun
+from ..broker_account_activities import ACCOUNT_ACTIVITIES_REST_SOURCE
+from .journal_reducer import JOURNAL_REDUCER_NAME, JOURNAL_REDUCER_VERSION
+from .state_reducer import STATE_REDUCER_NAME, STATE_REDUCER_VERSION
+from .types import EconomicLedgerError, LedgerScope
+
+
+def load_published_activity_order(
+    session: Session,
+    *,
+    scope: LedgerScope,
+) -> tuple[str, ...]:
+    journal_run = aliased(BrokerEconomicLedgerRun)
+    state_run = aliased(BrokerEconomicLedgerRun)
+    input_row = session.scalar(
+        select(BrokerEconomicLedgerInput)
+        .join(
+            journal_run,
+            and_(
+                journal_run.input_id == BrokerEconomicLedgerInput.id,
+                journal_run.reducer_name == JOURNAL_REDUCER_NAME,
+                journal_run.reducer_version == JOURNAL_REDUCER_VERSION,
+            ),
+        )
+        .join(
+            state_run,
+            and_(
+                state_run.input_id == BrokerEconomicLedgerInput.id,
+                state_run.reducer_name == STATE_REDUCER_NAME,
+                state_run.reducer_version == STATE_REDUCER_VERSION,
+            ),
+        )
+        .where(
+            BrokerEconomicLedgerInput.provider == scope.provider,
+            BrokerEconomicLedgerInput.source == ACCOUNT_ACTIVITIES_REST_SOURCE,
+            BrokerEconomicLedgerInput.environment == scope.environment,
+            BrokerEconomicLedgerInput.account_label == scope.account_label,
+            BrokerEconomicLedgerInput.endpoint_fingerprint
+            == scope.endpoint_fingerprint,
+            BrokerEconomicLedgerInput.quote_currency == scope.quote_currency,
+        )
+        .order_by(
+            BrokerEconomicLedgerInput.source_watermark.desc(),
+            BrokerEconomicLedgerInput.created_at.desc(),
+            BrokerEconomicLedgerInput.id.desc(),
+        )
+        .limit(1)
+    )
+    if input_row is None:
+        return ()
+    return _manifest_activity_order(input_row)
+
+
+def _manifest_activity_order(
+    input_row: BrokerEconomicLedgerInput,
+) -> tuple[str, ...]:
+    manifest_json = input_row.manifest_canonical_json
+    if _sha256(manifest_json) != input_row.manifest_sha256:
+        raise EconomicLedgerError("economic_ledger_published_manifest_hash_mismatch")
+    try:
+        parsed_manifest = cast(object, json.loads(manifest_json))
+    except json.JSONDecodeError as exc:
+        raise EconomicLedgerError("economic_ledger_published_manifest_invalid") from exc
+    if not isinstance(parsed_manifest, list):
+        raise EconomicLedgerError("economic_ledger_published_manifest_invalid")
+    manifest = cast(list[object], parsed_manifest)
+    if _canonical_json(manifest) != manifest_json:
+        raise EconomicLedgerError("economic_ledger_published_manifest_invalid")
+    if len(manifest) != input_row.input_count:
+        raise EconomicLedgerError("economic_ledger_published_manifest_count_mismatch")
+
+    activity_order: list[str] = []
+    for payload in manifest:
+        if not isinstance(payload, dict):
+            raise EconomicLedgerError("economic_ledger_published_manifest_invalid")
+        payload = cast(dict[str, object], payload)
+        external_id = payload.get("external_activity_id")
+        if not isinstance(external_id, str) or not external_id.strip():
+            raise EconomicLedgerError("economic_ledger_published_manifest_invalid")
+        activity_order.append(external_id)
+    if len(set(activity_order)) != len(activity_order):
+        raise EconomicLedgerError("economic_ledger_published_manifest_duplicate")
+    return tuple(activity_order)
+
+
+def _canonical_json(value: object) -> str:
+    try:
+        return json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        )
+    except (TypeError, ValueError) as exc:
+        raise EconomicLedgerError("economic_ledger_published_manifest_invalid") from exc
+
+
+def _sha256(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+__all__ = ("load_published_activity_order",)

--- a/services/torghut/app/trading/economic_ledger/state_reducer.py
+++ b/services/torghut/app/trading/economic_ledger/state_reducer.py
@@ -21,7 +21,7 @@ from .types import (
 
 
 STATE_REDUCER_NAME = "independent_position_state"
-STATE_REDUCER_VERSION = "torghut.broker-economic-state.v4"
+STATE_REDUCER_VERSION = "torghut.broker-economic-state.v5"
 
 _EXTERNAL_FLOW_TYPES = frozenset({"ACATC", "CSD", "CSW", "JNLC", "TRANS"})
 _DIVIDEND_ACTIVITY_TYPES = frozenset(
@@ -231,6 +231,10 @@ class _StateReducer:
                 "economic_crypto_fee_fair_value_below_ledger_quantum"
             )
         if holding.units <= ZERO or abs(units) > holding.units:
+            if activity.external_activity_id in self.prepared.retroactive_append_ids:
+                raise EconomicLedgerError(
+                    "economic_ledger_unappendable_late_fee_requires_new_version"
+                )
             raise EconomicLedgerError("economic_crypto_fee_position_insufficient")
         if abs(units) == holding.units:
             released_cost = holding.carrying_value

--- a/services/torghut/app/trading/economic_ledger/tigerbeetle_projection.py
+++ b/services/torghut/app/trading/economic_ledger/tigerbeetle_projection.py
@@ -27,10 +27,12 @@ if TYPE_CHECKING:
     from .persistence import BrokerEconomicLedgerReplay
 
 
-# The v1 namespace contains immutable transfer chains from the pre-monotonic
-# date-only CFEE ordering and must never be reused for current parity.
+# The v1 namespace orders date-only fees by external ID. The v2 namespace only
+# preserves observation order within one settlement date. Both contain
+# immutable transfers and must never be reused after the cross-date ordering
+# correction.
 TIGERBEETLE_ECONOMIC_PROJECTION_VERSION = (
-    "torghut.broker-economic-tigerbeetle-projection.v2"
+    "torghut.broker-economic-tigerbeetle-projection.v3"
 )
 TIGERBEETLE_MAX_BATCH_SIZE = 8_189
 

--- a/services/torghut/app/trading/economic_ledger/types.py
+++ b/services/torghut/app/trading/economic_ledger/types.py
@@ -186,9 +186,9 @@ class EconomicActivity:
 
     @property
     def sort_key(self) -> tuple[datetime, date, datetime, str, str]:
-        # Alpaca can publish date-only crypto fees after their economic date.
-        # Preserve observation order so a late append cannot rewrite an earlier
-        # state-dependent fee transaction and its immutable ledger identity.
+        # Alpaca can publish multiple date-only crypto fees for one settlement
+        # date. Preserve their broker observation order inside that economic
+        # date; cross-scan append stability is enforced by prepare_activities.
         observation_order = (
             self.first_observed_at
             if self.activity_type == "CFEE"
@@ -243,6 +243,8 @@ class ActivityChain:
 class PreparedActivities:
     scope: LedgerScope
     chains: tuple[ActivityChain, ...]
+    activity_order: tuple[str, ...]
+    retroactive_append_ids: tuple[str, ...]
     manifest_digest: str
     input_count: int
     duplicate_count: int
@@ -477,23 +479,90 @@ class JournalReduction:
         )
 
 
-def prepare_activities(activities: Iterable[EconomicActivity]) -> PreparedActivities:
-    """Deduplicate immutable identities and resolve correction chains."""
+def prepare_activities(
+    activities: Iterable[EconomicActivity],
+    *,
+    prior_activity_order: tuple[str, ...] = (),
+) -> PreparedActivities:
+    """Deduplicate identities and preserve an immutable published order anchor."""
 
     unique, duplicate_count = _deduplicate_activities(activities)
     scope = _single_scope(unique.values())
-    chains = _activity_chains(unique)
-    manifest = [
-        activity.manifest_payload()
-        for activity in sorted(unique.values(), key=lambda activity: activity.sort_key)
-    ]
+    ordered, retroactive_append_ids = _ordered_activities(
+        unique,
+        prior_activity_order=prior_activity_order,
+    )
+    activity_order = tuple(activity.external_activity_id for activity in ordered)
+    order_rank = {
+        external_activity_id: index
+        for index, external_activity_id in enumerate(activity_order)
+    }
+    chains = _activity_chains(unique, order_rank=order_rank)
+    manifest = [activity.manifest_payload() for activity in ordered]
     return PreparedActivities(
         scope=scope,
         chains=chains,
+        activity_order=activity_order,
+        retroactive_append_ids=retroactive_append_ids,
         manifest_digest=canonical_sha256(manifest),
         input_count=len(unique),
         duplicate_count=duplicate_count,
         corrected_count=sum(len(chain.activities) - 1 for chain in chains),
+    )
+
+
+def _ordered_activities(
+    unique: Mapping[str, EconomicActivity],
+    *,
+    prior_activity_order: tuple[str, ...],
+) -> tuple[tuple[EconomicActivity, ...], tuple[str, ...]]:
+    if len(set(prior_activity_order)) != len(prior_activity_order):
+        raise EconomicLedgerError("economic_ledger_prior_activity_order_duplicate")
+    if any(external_id not in unique for external_id in prior_activity_order):
+        raise EconomicLedgerError("economic_ledger_prior_activity_missing")
+
+    anchored_ids = set(prior_activity_order)
+    new_activities = tuple(
+        activity
+        for external_id, activity in unique.items()
+        if external_id not in anchored_ids
+    )
+    retroactive_append_ids: tuple[str, ...] = ()
+    if prior_activity_order:
+        frontier = max(unique[external_id].sort_key for external_id in anchored_ids)
+        if any(
+            activity.correction_of_external_id in anchored_ids
+            for activity in new_activities
+        ):
+            raise EconomicLedgerError(
+                "economic_ledger_retroactive_correction_requires_new_version"
+            )
+        if any(
+            activity.sort_key < frontier and not _is_late_date_only_fee(activity)
+            for activity in new_activities
+        ):
+            raise EconomicLedgerError(
+                "economic_ledger_retroactive_activity_requires_new_version"
+            )
+        retroactive_append_ids = tuple(
+            activity.external_activity_id
+            for activity in new_activities
+            if activity.sort_key < frontier
+        )
+    appended = sorted(new_activities, key=lambda activity: activity.sort_key)
+    return (
+        tuple(unique[external_id] for external_id in prior_activity_order)
+        + tuple(appended),
+        retroactive_append_ids,
+    )
+
+
+def _is_late_date_only_fee(activity: EconomicActivity) -> bool:
+    return (
+        activity.activity_type == "CFEE"
+        and activity.event_at is None
+        and activity.settle_date is not None
+        and activity.correction_of_external_id is None
     )
 
 
@@ -529,6 +598,8 @@ def _single_scope(activities: Iterable[EconomicActivity]) -> LedgerScope:
 
 def _activity_chains(
     unique: Mapping[str, EconomicActivity],
+    *,
+    order_rank: Mapping[str, int],
 ) -> tuple[ActivityChain, ...]:
     successor = _correction_successors(unique)
     roots = sorted(
@@ -537,7 +608,7 @@ def _activity_chains(
             for activity in unique.values()
             if activity.correction_of_external_id is None
         ),
-        key=lambda activity: activity.sort_key,
+        key=lambda activity: order_rank[activity.external_activity_id],
     )
     visited: set[str] = set()
     chains = tuple(_walk_correction_chain(root, successor, visited) for root in roots)

--- a/services/torghut/tests/economic_ledger/test_late_fee_ordering.py
+++ b/services/torghut/tests/economic_ledger/test_late_fee_ordering.py
@@ -3,11 +3,19 @@ from __future__ import annotations
 from dataclasses import replace
 from datetime import timedelta
 
-from app.trading.economic_ledger import reduce_and_compare
-from tests.economic_ledger.support import activity
+import pytest
+
+from app.trading.economic_ledger import (
+    EconomicLedgerError,
+    prepare_activities,
+    reduce_balanced_journal,
+    reduce_and_compare,
+    reduce_independent_state,
+)
+from tests.economic_ledger.support import BASE_TIME, activity
 
 
-def test_late_date_only_crypto_fee_preserves_existing_transaction_digest() -> None:
+def test_late_date_only_crypto_fee_preserves_existing_transaction_digests() -> None:
     fills = [
         activity(
             "fill-1",
@@ -54,21 +62,262 @@ def test_late_date_only_crypto_fee_preserves_existing_transaction_digest() -> No
         first_observed_at=existing_fee.first_observed_at + timedelta(minutes=1),
     )
 
-    before = reduce_and_compare([*fills, existing_fee])
-    after = reduce_and_compare([*fills, existing_fee, late_fee])
-    before_digest = next(
-        transaction.digest
+    before_prepared = prepare_activities([*fills, existing_fee])
+    after_prepared = prepare_activities(
+        [*fills, existing_fee, late_fee],
+        prior_activity_order=before_prepared.activity_order,
+    )
+    before = reduce_and_compare(before_prepared)
+    after = reduce_and_compare(after_prepared)
+    before_digests = {
+        transaction.transaction_id: transaction.digest
         for transaction in before.journal.transactions
-        if transaction.source_activity_id == existing_fee.external_activity_id
-    )
-    after_digest = next(
-        transaction.digest
+    }
+    after_digests = {
+        transaction.transaction_id: transaction.digest
         for transaction in after.journal.transactions
-        if transaction.source_activity_id == existing_fee.external_activity_id
-    )
+    }
 
     assert existing_fee.external_activity_id > late_fee.external_activity_id
     assert existing_fee.sort_key < late_fee.sort_key
     assert before.admissible and after.admissible
     assert before.comparison.equivalent and after.comparison.equivalent
-    assert after_digest == before_digest
+    assert before_digests.items() <= after_digests.items()
+
+
+def test_late_prior_date_crypto_fee_preserves_existing_transaction_digests() -> None:
+    prior_day = BASE_TIME - timedelta(days=1)
+    fills = [
+        replace(
+            activity(
+                "fill-1",
+                "FILL",
+                symbol="BTCUSD",
+                side="buy",
+                quantity="0.1",
+                price="1",
+                net_amount=None,
+            ),
+            event_at=prior_day + timedelta(seconds=1),
+            settle_date=prior_day.date(),
+        ),
+        replace(
+            activity(
+                "fill-2",
+                "FILL",
+                symbol="BTCUSD",
+                side="buy",
+                quantity="0.1",
+                price="3.333333333333333333",
+                net_amount=None,
+            ),
+            event_at=prior_day + timedelta(seconds=2),
+            settle_date=prior_day.date(),
+        ),
+    ]
+    existing_fee = replace(
+        activity(
+            "existing-later-date-fee",
+            "CFEE",
+            symbol="BTCUSD",
+            quantity="-0.07",
+            price="3",
+            net_amount="0",
+        ),
+        event_at=None,
+        first_observed_at=BASE_TIME + timedelta(days=1),
+    )
+    late_prior_date_fee = replace(
+        activity(
+            "late-prior-date-fee",
+            "CFEE",
+            symbol="BTCUSD",
+            quantity="-0.01",
+            price="4",
+            net_amount="0",
+        ),
+        event_at=None,
+        settle_date=prior_day.date(),
+        first_observed_at=BASE_TIME + timedelta(days=2),
+    )
+
+    before_prepared = prepare_activities([*fills, existing_fee])
+    after_prepared = prepare_activities(
+        [*fills, existing_fee, late_prior_date_fee],
+        prior_activity_order=before_prepared.activity_order,
+    )
+    before = reduce_and_compare(before_prepared)
+    after = reduce_and_compare(after_prepared)
+    before_digests = {
+        transaction.transaction_id: transaction.digest
+        for transaction in before.journal.transactions
+    }
+    after_digests = {
+        transaction.transaction_id: transaction.digest
+        for transaction in after.journal.transactions
+    }
+
+    assert late_prior_date_fee.sort_key < existing_fee.sort_key
+    assert after_prepared.activity_order[-1] == late_prior_date_fee.external_activity_id
+    assert before.admissible and after.admissible
+    assert before.comparison.equivalent and after.comparison.equivalent
+    assert before_digests.items() <= after_digests.items()
+
+
+def test_initial_backfill_keeps_new_rows_in_economic_order() -> None:
+    prior_day = BASE_TIME - timedelta(days=1)
+    prior_fill = replace(
+        activity(
+            "prior-fill",
+            "FILL",
+            symbol="BTCUSD",
+            side="buy",
+            quantity="0.1",
+            price="10",
+            net_amount=None,
+        ),
+        event_at=prior_day + timedelta(seconds=1),
+        settle_date=prior_day.date(),
+    )
+    historical_fee = replace(
+        activity(
+            "historical-fee",
+            "CFEE",
+            symbol="BTCUSD",
+            quantity="-0.01",
+            price="10",
+            net_amount="0",
+        ),
+        event_at=None,
+        settle_date=prior_day.date(),
+        first_observed_at=BASE_TIME + timedelta(days=2),
+    )
+    later_fill = activity(
+        "later-fill",
+        "FILL",
+        event_offset_seconds=1,
+        symbol="BTCUSD",
+        side="buy",
+        quantity="0.1",
+        price="11",
+        net_amount=None,
+    )
+
+    prepared = prepare_activities([later_fill, historical_fee, prior_fill])
+    reduction = reduce_and_compare(prepared)
+
+    assert prepared.activity_order == (
+        prior_fill.external_activity_id,
+        historical_fee.external_activity_id,
+        later_fill.external_activity_id,
+    )
+    assert reduction.admissible
+    assert reduction.comparison.equivalent
+
+
+def test_published_order_anchor_fails_closed_when_duplicate_or_missing() -> None:
+    only = activity("only", "CSD", net_amount="1")
+
+    with pytest.raises(
+        EconomicLedgerError,
+        match="economic_ledger_prior_activity_order_duplicate",
+    ):
+        prepare_activities([only], prior_activity_order=("only", "only"))
+    with pytest.raises(
+        EconomicLedgerError,
+        match="economic_ledger_prior_activity_missing",
+    ):
+        prepare_activities([only], prior_activity_order=("missing",))
+
+
+def test_published_order_anchor_rejects_unsafe_retroactive_facts() -> None:
+    existing = activity("existing", "CSD", net_amount="1")
+    retroactive_fill = replace(
+        activity(
+            "retroactive-fill",
+            "FILL",
+            symbol="BTCUSD",
+            side="buy",
+            quantity="0.1",
+            price="1",
+            net_amount=None,
+        ),
+        event_at=BASE_TIME - timedelta(days=1),
+        settle_date=(BASE_TIME - timedelta(days=1)).date(),
+    )
+    correction = activity(
+        "correction",
+        "CSD",
+        correction_of="existing",
+        net_amount="2",
+    )
+
+    with pytest.raises(
+        EconomicLedgerError,
+        match="economic_ledger_retroactive_activity_requires_new_version",
+    ):
+        prepare_activities(
+            [existing, retroactive_fill],
+            prior_activity_order=("existing",),
+        )
+    with pytest.raises(
+        EconomicLedgerError,
+        match="economic_ledger_retroactive_correction_requires_new_version",
+    ):
+        prepare_activities(
+            [existing, correction],
+            prior_activity_order=("existing",),
+        )
+
+
+def test_unappendable_late_fee_requires_new_projection_version() -> None:
+    prior_day = BASE_TIME - timedelta(days=1)
+    buy = replace(
+        activity(
+            "buy",
+            "FILL",
+            symbol="BTCUSD",
+            side="buy",
+            quantity="0.1",
+            price="10",
+            net_amount=None,
+        ),
+        event_at=prior_day + timedelta(seconds=1),
+        settle_date=prior_day.date(),
+    )
+    sell = activity(
+        "sell",
+        "FILL",
+        event_offset_seconds=1,
+        symbol="BTCUSD",
+        side="sell",
+        quantity="0.1",
+        price="11",
+        net_amount=None,
+    )
+    late_fee = replace(
+        activity(
+            "late-fee",
+            "CFEE",
+            symbol="BTCUSD",
+            quantity="-0.01",
+            price="10",
+            net_amount="0",
+        ),
+        event_at=None,
+        settle_date=prior_day.date(),
+        first_observed_at=BASE_TIME + timedelta(days=1),
+    )
+    published = prepare_activities([buy, sell])
+    replay = prepare_activities(
+        [buy, sell, late_fee],
+        prior_activity_order=published.activity_order,
+    )
+
+    assert replay.retroactive_append_ids == (late_fee.external_activity_id,)
+    for reducer in (reduce_balanced_journal, reduce_independent_state):
+        with pytest.raises(
+            EconomicLedgerError,
+            match="economic_ledger_unappendable_late_fee_requires_new_version",
+        ):
+            reducer(replay)

--- a/services/torghut/tests/economic_ledger/test_option_multiplier.py
+++ b/services/torghut/tests/economic_ledger/test_option_multiplier.py
@@ -42,8 +42,8 @@ def test_option_fill_cash_and_cost_use_the_explicit_contract_size() -> None:
     )
 
     assert buy.manifest_payload()["notional_multiplier"] == "10"
-    assert JOURNAL_REDUCER_VERSION == "torghut.broker-economic-journal.v4"
-    assert STATE_REDUCER_VERSION == "torghut.broker-economic-state.v4"
+    assert JOURNAL_REDUCER_VERSION == "torghut.broker-economic-journal.v5"
+    assert STATE_REDUCER_VERSION == "torghut.broker-economic-state.v5"
     assert result.admissible
     assert result.comparison.equivalent
     assert cash(result.journal.projection) == Decimal("3")

--- a/services/torghut/tests/economic_ledger/test_persistence.py
+++ b/services/torghut/tests/economic_ledger/test_persistence.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import replace
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 from typing import cast
 
@@ -109,6 +109,9 @@ def _activity(
     net_amount: str | None = None,
     currency: str | None = "USD",
     payload_sha256: str | None = None,
+    date_only: bool = False,
+    settle_date: date | None = None,
+    first_observed_at: datetime | None = None,
 ) -> BrokerAccountActivity:
     payload = {"activity_type": activity_type, "id": external_id}
     canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
@@ -120,7 +123,8 @@ def _activity(
         endpoint_fingerprint="a" * 64,
         external_activity_id=external_id,
         activity_type=activity_type,
-        event_at=_OBSERVED_AT + timedelta(seconds=offset),
+        event_at=None if date_only else _OBSERVED_AT + timedelta(seconds=offset),
+        settle_date=settle_date,
         symbol=symbol,
         side=side,
         quantity=Decimal(quantity) if quantity is not None else None,
@@ -135,7 +139,7 @@ def _activity(
         normalized_economic_sha256=hashlib.sha256(
             f"economic:{external_id}".encode("utf-8")
         ).hexdigest(),
-        first_observed_at=_OBSERVED_AT + timedelta(minutes=1),
+        first_observed_at=(first_observed_at or _OBSERVED_AT + timedelta(minutes=1)),
     )
 
 
@@ -278,6 +282,214 @@ def test_replay_publishes_one_atomic_idempotent_run_pair() -> None:
     assert {run.input_id for run in runs} == {inputs[0].id}
     assert inputs[0].manifest_sha256 == replay.snapshot.prepared.manifest_digest
     assert len({run.comparison_sha256 for run in runs}) == 1
+
+
+def test_late_prior_date_fee_appends_to_published_manifest_order() -> None:
+    sessions = _session_factory()
+    prior_date = (_OBSERVED_AT - timedelta(days=1)).date()
+    later_date = _OBSERVED_AT.date()
+    initial = [
+        _activity(
+            "fill-1",
+            "FILL",
+            offset=-86_399,
+            symbol="BTCUSD",
+            side="buy",
+            quantity="0.1",
+            price="1",
+            net_amount=None,
+            settle_date=prior_date,
+        ),
+        _activity(
+            "fill-2",
+            "FILL",
+            offset=-86_398,
+            symbol="BTCUSD",
+            side="buy",
+            quantity="0.1",
+            price="3.333333333333333333",
+            net_amount=None,
+            settle_date=prior_date,
+        ),
+        _activity(
+            "existing-later-date-fee",
+            "CFEE",
+            offset=0,
+            symbol="BTCUSD",
+            quantity="-0.07",
+            price="3",
+            net_amount="0",
+            date_only=True,
+            settle_date=later_date,
+            first_observed_at=_OBSERVED_AT + timedelta(days=1),
+        ),
+    ]
+    _seed_source(sessions, initial)
+
+    with sessions.begin() as session:
+        before = _replay(session)
+        published_before = publish_broker_economic_ledger(
+            session,
+            before,
+            confirmation_token=before.publication_token,
+        )
+    before_digests = {
+        transaction.transaction_id: transaction.digest
+        for transaction in before.reduction.journal.transactions
+    }
+
+    late_fee = _activity(
+        "late-prior-date-fee",
+        "CFEE",
+        offset=0,
+        symbol="BTCUSD",
+        quantity="-0.01",
+        price="4",
+        net_amount="0",
+        date_only=True,
+        settle_date=prior_date,
+        first_observed_at=_OBSERVED_AT + timedelta(days=2),
+    )
+    with sessions.begin() as session:
+        session.add(late_fee)
+        cursor = session.scalar(select(BrokerAccountActivityCursor))
+        assert cursor is not None
+        assert cursor.last_completed_at is not None
+        assert cursor.last_completed_scan_until is not None
+        cursor.activities_seen += 1
+        cursor.activities_inserted += 1
+        cursor.last_completed_at += timedelta(minutes=1)
+        cursor.last_completed_scan_until += timedelta(minutes=1)
+
+    with sessions.begin() as session:
+        after = _replay(session)
+        published_after = publish_broker_economic_ledger(
+            session,
+            after,
+            confirmation_token=after.publication_token,
+        )
+    after_digests = {
+        transaction.transaction_id: transaction.digest
+        for transaction in after.reduction.journal.transactions
+    }
+
+    assert late_fee.settle_date is not None
+    assert before.snapshot.prepared.activity_order == (
+        "fill-1",
+        "fill-2",
+        "existing-later-date-fee",
+    )
+    assert after.snapshot.prepared.activity_order == (
+        *before.snapshot.prepared.activity_order,
+        late_fee.external_activity_id,
+    )
+    assert before_digests.items() <= after_digests.items()
+    assert after.reduction.admissible
+    assert published_after.reused_existing is False
+    assert published_after.journal_run_id != published_before.journal_run_id
+
+
+def test_late_fee_with_different_append_cost_basis_requires_new_version() -> None:
+    sessions = _session_factory()
+    prior_date = (_OBSERVED_AT - timedelta(days=1)).date()
+    initial = [
+        _activity(
+            "prior-buy",
+            "FILL",
+            offset=-86_399,
+            symbol="BTCUSD",
+            side="buy",
+            quantity="0.1",
+            price="10",
+            net_amount=None,
+            settle_date=prior_date,
+        ),
+        _activity(
+            "later-buy",
+            "FILL",
+            offset=1,
+            symbol="BTCUSD",
+            side="buy",
+            quantity="0.1",
+            price="20",
+            net_amount=None,
+            settle_date=_OBSERVED_AT.date(),
+        ),
+    ]
+    _seed_source(sessions, initial)
+    with sessions.begin() as session:
+        before = _replay(session)
+        publish_broker_economic_ledger(
+            session,
+            before,
+            confirmation_token=before.publication_token,
+        )
+
+    late_fee = _activity(
+        "late-prior-date-fee",
+        "CFEE",
+        offset=0,
+        symbol="BTCUSD",
+        quantity="-0.05",
+        price="10",
+        net_amount="0",
+        date_only=True,
+        settle_date=prior_date,
+        first_observed_at=_OBSERVED_AT + timedelta(days=1),
+    )
+    with sessions.begin() as session:
+        session.add(late_fee)
+        cursor = session.scalar(select(BrokerAccountActivityCursor))
+        assert cursor is not None
+        assert cursor.last_completed_at is not None
+        assert cursor.last_completed_scan_until is not None
+        cursor.activities_seen += 1
+        cursor.activities_inserted += 1
+        cursor.last_completed_at += timedelta(minutes=1)
+        cursor.last_completed_scan_until += timedelta(minutes=1)
+
+    with sessions.begin() as session:
+        with pytest.raises(
+            EconomicLedgerError,
+            match="economic_ledger_unappendable_late_fee_requires_new_version",
+        ):
+            _replay(session)
+
+
+@pytest.mark.parametrize(
+    ("manifest_json", "manifest_sha256", "error"),
+    [
+        ("{", hashlib.sha256(b"{").hexdigest(), "published_manifest_invalid"),
+        (
+            "[]",
+            hashlib.sha256(b"[]").hexdigest(),
+            "published_manifest_count_mismatch",
+        ),
+        ("[]", "0" * 64, "published_manifest_hash_mismatch"),
+    ],
+)
+def test_replay_fails_closed_on_corrupt_published_manifest_anchor(
+    manifest_json: str,
+    manifest_sha256: str,
+    error: str,
+) -> None:
+    sessions = _session_factory()
+    _seed_source(sessions, _supported_history())
+    with sessions.begin() as session:
+        replay = _replay(session)
+        publish_broker_economic_ledger(
+            session,
+            replay,
+            confirmation_token=replay.publication_token,
+        )
+    with sessions.begin() as session:
+        input_row = session.scalar(select(BrokerEconomicLedgerInput))
+        assert input_row is not None
+        input_row.manifest_canonical_json = manifest_json
+        input_row.manifest_sha256 = manifest_sha256
+    with sessions.begin() as session:
+        with pytest.raises(EconomicLedgerError, match=error):
+            _replay(session)
 
 
 def test_publication_rejects_forged_replay_token() -> None:

--- a/services/torghut/tests/economic_ledger/test_tigerbeetle_parity.py
+++ b/services/torghut/tests/economic_ledger/test_tigerbeetle_parity.py
@@ -241,7 +241,7 @@ def test_full_projection_is_exact_idempotent_and_bound_to_immutable_runs() -> No
     second = _audit(client, replay, runs=runs)
 
     assert TIGERBEETLE_ECONOMIC_PROJECTION_VERSION == (
-        "torghut.broker-economic-tigerbeetle-projection.v2"
+        "torghut.broker-economic-tigerbeetle-projection.v3"
     )
     assert first.payload["projection_version"] == (
         TIGERBEETLE_ECONOMIC_PROJECTION_VERSION


### PR DESCRIPTION
## Summary

- Preserve the exact activity order from the latest complete v5 published manifest, then append newly observed activities in economic order as one cohort.
- Permit only documented late date-only CFEE facts to cross the published frontier; old missing trades and corrections of published history require a new projection version.
- For every retroactive fee candidate, run the same dual reducers once in economic order and accept the anchored append only when all transaction IDs/digests and the final economic state are identical. A flat position or different later cost basis explicitly requires a new immutable namespace.
- Reject missing, duplicate, malformed, or hash-invalid published anchors. Advance reducers to v5 and TigerBeetle projection to v3; add no schema, service, queue, or second accounting engine.

## Related Issues

Follow-up to the actionable accounting review on #12778.

## Design Basis

- [Alpaca Crypto Spot Trading](https://docs.alpaca.markets/us/docs/crypto-trading) documents CFEE records as end-of-day activities that may not be available on the trade day.
- [TigerBeetle Transfer](https://docs.tigerbeetle.com/reference/transfer/) documents transfers as immutable and non-deletable; corrections require new transfers.
- [TigerBeetle Data Modeling](https://docs.tigerbeetle.com/coding/data-modeling/) defines transfer IDs as idempotency keys unique within the cluster.

## Testing

- Rejected-design regression proves global first-observed ordering puts a historical fee after later trades from the same backfill.
- Fail-closed regressions cover retroactive non-CFEE facts, corrections of published history, a fee after a full sell, and a fee after a later buy changed average cost. Safe cross-date fees prove the immutable prefix and every prior transaction digest remain unchanged.
- `pytest -q tests/economic_ledger tests/execution/test_broker_economic_ledger_postgres.py`: 109 passed, 1 expected local-Postgres skip.
- Read-only replay of all 40,172 live CNPG REST rows: admissible, dual reducers equivalent, zero deltas, 40,172 transactions, 195,207 entries, and 14 date-only CFEE rows.
- The v5 replay manifest and economic projection exactly match the currently published v4 production evidence for the same 40,172-row source.
- All five Pyright profiles passed with zero errors/warnings. Full compileall, Ruff, structural/changed-line/design/file-length Pylint, tech-debt ratchet, and migration graph checks passed.

## Breaking Changes

None. The version change intentionally creates a new immutable projection namespace; existing v1/v2 TigerBeetle objects are retained.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation follow-up remains tracked in #12778 and will be corrected after production proof.
