### PR TITLE
fix(torghut): build notebook ownership with fakeroot

### DIFF
--- a/nix/images/torghut-notebook.nix
+++ b/nix/images/torghut-notebook.nix
@@ -160,9 +160,11 @@ pkgs.dockerTools.buildLayeredImage {
     mkdir -p etc home/jovyan tmp var/tmp
     echo 'jovyan:x:1000:100:Torghut Notebook:/home/jovyan:/bin/bash' > etc/passwd
     echo 'users:x:100:jovyan' > etc/group
-    chown 1000:100 home/jovyan
     chmod 0750 home/jovyan
     chmod 1777 tmp var/tmp
+  '';
+  fakeRootCommands = ''
+    chown 1000:100 ./home/jovyan
   '';
   config = {
     Entrypoint = [ "${startNotebook}/bin/start-torghut-notebook" ];

--- a/services/torghut/tests/notebook_data/test_manifest_contract.py
+++ b/services/torghut/tests/notebook_data/test_manifest_contract.py
@@ -148,6 +148,14 @@ def test_notebook_image_uses_a_dedicated_minimal_locked_dependency_group() -> No
     nix_source = (REPO_ROOT / "nix/images/torghut-notebook.nix").read_text()
     assert "--only-group notebook-runtime" in nix_source
     assert "--no-install-project" in nix_source
+    extra_commands = nix_source.split("extraCommands = ''", maxsplit=1)[1].split(
+        "'';", maxsplit=1
+    )[0]
+    fake_root_commands = nix_source.split("fakeRootCommands = ''", maxsplit=1)[1].split(
+        "'';", maxsplit=1
+    )[0]
+    assert "chown" not in extra_commands
+    assert "chown 1000:100 ./home/jovyan" in fake_root_commands
 
 
 def test_notebook_entrypoint_seeds_only_absent_canonical_notebooks() -> None:


### PR DESCRIPTION
## Summary

- Move the notebook home-directory ownership change from unprivileged `extraCommands` into Docker Tools `fakeRootCommands`.
- Preserve the runtime `1000:100` ownership and existing directory modes on both image architectures.
- Add a manifest contract regression test that forbids `chown` in `extraCommands` and requires the fakeroot ownership step.

## Related Issues

None.

## Testing

- `uv run --frozen ruff format --check tests/notebook_data/test_manifest_contract.py`
- `uv run --frozen ruff check tests/notebook_data/test_manifest_contract.py`
- `uv run --frozen pytest tests/notebook_data/test_manifest_contract.py -q` (11 passed)
- `nix-instantiate --parse nix/images/torghut-notebook.nix`
- `nix eval --raw .#packages.aarch64-linux.torghut-notebook-image.drvPath`
- `nix eval --raw .#packages.x86_64-linux.torghut-notebook-image.drvPath`
- The pre-fix main build failed identically on amd64 and arm64 with `chown: changing ownership of home/jovyan: Operation not permitted`.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] No documentation or release-note change is required for this build-only correction.