### PR TITLE
fix(torghut): trim notebook hub secret whitespace

### DIFF
--- a/argocd/applications/torghut/notebooks/values.yaml
+++ b/argocd/applications/torghut/notebooks/values.yaml
@@ -57,10 +57,10 @@ hub:
           async def authenticate(self, handler, data=None):
               return {"name": "torghut", "admin": False}
 
-      cookie_secret = os.environ.get("TORGHUT_HUB_COOKIE_SECRET", "")
+      cookie_secret = os.environ.get("TORGHUT_HUB_COOKIE_SECRET", "").strip()
       if len(cookie_secret) != 64:
           raise RuntimeError("TORGHUT_HUB_COOKIE_SECRET must be 64 hexadecimal characters")
-      crypt_key = os.environ.get("TORGHUT_HUB_CRYPT_KEY", "")
+      crypt_key = os.environ.get("TORGHUT_HUB_CRYPT_KEY", "").strip()
       if len(crypt_key) != 64:
           raise RuntimeError("TORGHUT_HUB_CRYPT_KEY must be 64 hexadecimal characters")
 

--- a/services/torghut/tests/notebook_data/test_manifest_contract.py
+++ b/services/torghut/tests/notebook_data/test_manifest_contract.py
@@ -306,6 +306,24 @@ def test_hub_extra_config_has_a_valid_fixed_authenticator_contract() -> None:
     result = next(node for node in authenticate.body if isinstance(node, ast.Return))
     assert ast.literal_eval(result.value) == {"name": "torghut", "admin": False}
 
+    assignments = {
+        target.id: node.value
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        if isinstance(target, ast.Name)
+    }
+    assert ast.dump(assignments["cookie_secret"]) == ast.dump(
+        ast.parse(
+            'os.environ.get("TORGHUT_HUB_COOKIE_SECRET", "").strip()', mode="eval"
+        ).body
+    )
+    assert ast.dump(assignments["crypt_key"]) == ast.dump(
+        ast.parse(
+            'os.environ.get("TORGHUT_HUB_CRYPT_KEY", "").strip()', mode="eval"
+        ).body
+    )
+
 
 def test_no_namespace_or_plaintext_secret_is_committed() -> None:
     yaml_sources = "\n".join(path.read_text() for path in NOTEBOOKS_DIR.glob("*.yaml"))


### PR DESCRIPTION
## Summary

- Normalize surrounding whitespace on JupyterHub cookie and crypt keys before enforcing the 64-hex-character contract.
- Preserve fail-closed length and hex validation while accepting the newline emitted by the sealed secret payload.
- Add an AST-level manifest contract regression test for both secret reads.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/notebook_data/test_manifest_contract.py -q` (11 passed)
- `uv run --frozen ruff format --check tests/notebook_data/test_manifest_contract.py`
- `uv run --frozen ruff check tests/notebook_data/test_manifest_contract.py`
- `nix develop -c kustomize build --enable-helm argocd/applications/torghut/notebooks`
- `services/torghut/.venv/bin/python services/torghut/scripts/validate_notebook_render.py <render>`
- `nix develop -c scripts/kubeconform.sh <render>`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation and release notes are not required for this parser-boundary fix.