### PR TITLE
chore(torghut): promote notebook image sha-8b539d3b449c81bee479a6168301077231dc40be

### DIFF
--- a/argocd/applications/torghut/notebooks/values.yaml
+++ b/argocd/applications/torghut/notebooks/values.yaml
@@ -93,7 +93,7 @@ proxy:
 singleuser:
   image:
     name: registry.ide-newton.ts.net/lab/torghut-notebook@sha256
-    tag: '0000000000000000000000000000000000000000000000000000000000000000'
+    tag: 'd6dc573a9df115480fc81773beb60bcf90c37bf189f31195f88f1ad3afd288ad'
     pullPolicy: IfNotPresent
   cmd: start-torghut-notebook
   defaultUrl: /lab/tree/work/00-system-flow.ipynb


### PR DESCRIPTION
## Summary

- Promote the immutable multi-architecture Torghut notebook image built from `8b539d3b449c81bee479a6168301077231dc40be`.
- Update only the digest-pinned JupyterHub single-user image.

## Related Issues

None.

## Testing

- The source commit passed notebook fixture execution and manifest contracts.
- The release workflow verified `linux/amd64` and `linux/arm64` for `sha256:d6dc573a9df115480fc81773beb60bcf90c37bf189f31195f88f1ad3afd288ad`.

## Breaking Changes

None.

## Checklist

- [x] The single-user image is immutable and multi-architecture.
- [x] Promotion changes only the notebook image digest.
- [x] PVCs and read-only credentials are unchanged.