### PR TITLE
fix(torghut): use valid notebook memory units

### DIFF
--- a/argocd/applications/torghut/notebooks/values.yaml
+++ b/argocd/applications/torghut/notebooks/values.yaml
@@ -104,8 +104,8 @@ singleuser:
     guarantee: 2
     limit: 8
   memory:
-    guarantee: 8Gi
-    limit: 16Gi
+    guarantee: 8G
+    limit: 16G
   storage:
     type: dynamic
     capacity: 50Gi

--- a/services/torghut/scripts/validate_notebook_render.py
+++ b/services/torghut/scripts/validate_notebook_render.py
@@ -218,7 +218,7 @@ def _validate_singleuser_values(values: YamlObject) -> None:
     )
     assert re.fullmatch(r"[0-9a-f]{64}", str(_at(singleuser, "image", "tag")))
     assert singleuser["cpu"] == {"guarantee": 2, "limit": 8}
-    assert singleuser["memory"] == {"guarantee": "8Gi", "limit": "16Gi"}
+    assert singleuser["memory"] == {"guarantee": "8G", "limit": "16G"}
     assert _at(singleuser, "storage", "capacity") == "50Gi"
     assert _at(singleuser, "storage", "dynamic", "storageClass") == "rook-ceph-block"
     assert _at(singleuser, "extraPodConfig", "automountServiceAccountToken") is False

--- a/services/torghut/tests/notebook_data/test_manifest_contract.py
+++ b/services/torghut/tests/notebook_data/test_manifest_contract.py
@@ -187,6 +187,13 @@ def test_chart_and_digest_contracts_are_pinned() -> None:
     assert re.fullmatch(r"[0-9a-f]{64}", values["singleuser"]["image"]["tag"])
 
 
+def test_singleuser_memory_uses_jupyterhub_byte_specifications() -> None:
+    values = yaml.safe_load((NOTEBOOKS_DIR / "values.yaml").read_text())
+    memory = values["singleuser"]["memory"]
+    assert memory == {"guarantee": "8G", "limit": "16G"}
+    assert all(re.fullmatch(r"[1-9][0-9]*[KMGT]", value) for value in memory.values())
+
+
 def test_render_validator_accepts_the_complete_production_contract(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- use JupyterHub ByteSpecification-compatible `8G` and `16G` values for the single-user server
- keep the intended 8 GB request and 16 GB limit while allowing KubeSpawner construction
- add a regression contract and update render validation

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/notebook_data/test_manifest_contract.py -q`
- `cd services/torghut && uv run --frozen ruff format --check tests/notebook_data/test_manifest_contract.py scripts/validate_notebook_render.py`
- `cd services/torghut && uv run --frozen ruff check tests/notebook_data/test_manifest_contract.py scripts/validate_notebook_render.py`
- `nix develop -c kustomize build --enable-helm argocd/applications/torghut/notebooks`
- `services/torghut/.venv/bin/python services/torghut/scripts/validate_notebook_render.py <rendered.yaml>`
- `nix develop -c scripts/kubeconform.sh <rendered.yaml>`
- live browser reproduction before the fix: Hub returned `500` with `TraitError: 16Gi is not a valid memory specification`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.