### PR TITLE
fix(torghut): recover TA after Kafka outages

### DIFF
--- a/argocd/applications/torghut/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta/flinkdeployment.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:158499b56e165329827be2fee52494484e1aa33736cdbc07a07aed2b243659dd
   imagePullPolicy: IfNotPresent
-  restartNonce: 32
+  restartNonce: 33
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   logConfiguration:
@@ -90,9 +90,7 @@ spec:
     execution.checkpointing.mode: EXACTLY_ONCE
     execution.checkpointing.externalized-checkpoint-retention: RETAIN_ON_CANCELLATION
     taskmanager.numberOfTaskSlots: "2"
-    restart-strategy.type: fixed-delay
-    restart-strategy.fixed-delay.attempts: "5"
-    restart-strategy.fixed-delay.delay: 5 s
+    restart-strategy.type: exponential-delay
     execution.checkpointing.unaligned: "true"
     execution.checkpointing.tolerable-failed-checkpoints: "3"
     metrics.reporter.prom.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory
@@ -187,5 +185,5 @@ spec:
     entryClass: ai.proompteng.dorvud.ta.flink.FlinkTechnicalAnalysisJobKt
     jarURI: local:///opt/flink/usrlib/app.jar
     parallelism: 8
-    upgradeMode: stateless
+    upgradeMode: last-state
     state: running

--- a/services/torghut/tests/live_config_manifest_contract/test_product_applicationset_renders_torghut_namespace_security_metadata.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_product_applicationset_renders_torghut_namespace_security_metadata.py
@@ -77,6 +77,26 @@ class TestProductApplicationsetRendersTorghutNamespaceSecurityMetadata(
             "1",
         )
 
+    def test_production_ta_recovers_transient_dependencies_without_losing_state(
+        self,
+    ) -> None:
+        manifest = _load_yaml_mapping(
+            "argocd/applications/torghut/ta/flinkdeployment.yaml"
+        )
+        spec = cast(Mapping[str, object], manifest.get("spec", {}))
+        flink_config = cast(Mapping[str, object], spec.get("flinkConfiguration", {}))
+        job = cast(Mapping[str, object], spec.get("job", {}))
+
+        self.assertGreaterEqual(int(str(spec.get("restartNonce"))), 33)
+        self.assertEqual(job.get("upgradeMode"), "last-state")
+        self.assertEqual(flink_config.get("restart-strategy.type"), "exponential-delay")
+        self.assertFalse(
+            any(
+                str(key).startswith("restart-strategy.fixed-delay.")
+                for key in flink_config
+            )
+        )
+
     def test_options_ta_uses_primary_clickhouse_auth_secret(self) -> None:
         manifest = _load_yaml_mapping(
             "argocd/applications/torghut-options/ta/flinkdeployment.yaml"


### PR DESCRIPTION
## Summary

- Replace the production TA job finite five-attempt restart budget with Flink 2.0 exponential-delay recovery.
- Bump `restartNonce` once to restart the currently failed job after Kafka connectivity recovered.
- Add a manifest contract that rejects finite fixed-delay recovery for the production strategy data plane.

The live job exhausted its retry budget during the Kafka outage and remained terminal even after the broker cluster recovered. The websocket producer currently proves metadata access for the trades, quotes, bars, and status topics. Flink 2.0 documents exponential delay as the checkpointed-job default with infinite attempts and recommends it for external-service failures: https://nightlies.apache.org/flink/flink-docs-release-2.0/docs/deployment/config/#fault-tolerance

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/live_config_manifest_contract/test_product_applicationset_renders_torghut_namespace_security_metadata.py -q` (16 passed)
- `uv run --frozen ruff format --check tests/live_config_manifest_contract/test_product_applicationset_renders_torghut_namespace_security_metadata.py`
- `uv run --frozen ruff check tests/live_config_manifest_contract/test_product_applicationset_renders_torghut_namespace_security_metadata.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `nix develop -c kustomize build --enable-helm argocd/applications/torghut`
- `nix develop -c scripts/kubeconform.sh <render>`
- Live precondition: Torghut websocket readiness reports Kafka metadata healthy for all required market-data topics.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] The operational rationale and upstream Flink behavior are documented in this PR.