### PR TITLE
fix(torghut): honor notebook image entrypoint

### DIFF
--- a/argocd/applications/torghut/notebooks/values.yaml
+++ b/argocd/applications/torghut/notebooks/values.yaml
@@ -95,7 +95,6 @@ singleuser:
     name: registry.ide-newton.ts.net/lab/torghut-notebook@sha256
     tag: 'd6dc573a9df115480fc81773beb60bcf90c37bf189f31195f88f1ad3afd288ad'
     pullPolicy: IfNotPresent
-  cmd: start-torghut-notebook
   defaultUrl: /lab/tree/work/00-system-flow.ipynb
   startTimeout: 600
   uid: 1000

--- a/services/torghut/tests/notebook_data/test_manifest_contract.py
+++ b/services/torghut/tests/notebook_data/test_manifest_contract.py
@@ -156,6 +156,9 @@ def test_notebook_image_uses_a_dedicated_minimal_locked_dependency_group() -> No
     )[0]
     assert "chown" not in extra_commands
     assert "chown 1000:100 ./home/jovyan" in fake_root_commands
+    assert (
+        'Entrypoint = [ "${startNotebook}/bin/start-torghut-notebook" ];' in nix_source
+    )
 
 
 def test_notebook_entrypoint_seeds_only_absent_canonical_notebooks() -> None:
@@ -183,6 +186,7 @@ def test_chart_and_digest_contracts_are_pinned() -> None:
     values = yaml.safe_load((NOTEBOOKS_DIR / "values.yaml").read_text())
     assert values["hub"]["image"]["tag"] == "4.4.0"
     assert values["proxy"]["chp"]["image"]["tag"] == "5.2.0"
+    assert "cmd" not in values["singleuser"]
     assert values["singleuser"]["image"]["name"].endswith("@sha256")
     assert re.fullmatch(r"[0-9a-f]{64}", values["singleuser"]["image"]["tag"])
 


### PR DESCRIPTION
## Summary

- remove the duplicate `singleuser.cmd` value so KubeSpawner does not pass the launcher name as a positional argument
- rely on the digest-pinned image entrypoint to seed notebooks and launch `jupyterhub-singleuser`
- add a regression contract covering both sides of the entrypoint configuration

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/notebook_data/test_manifest_contract.py -q`
- `cd services/torghut && uv run --frozen ruff format --check tests/notebook_data/test_manifest_contract.py`
- `cd services/torghut && uv run --frozen ruff check tests/notebook_data/test_manifest_contract.py`
- `nix develop -c kustomize build --enable-helm argocd/applications/torghut/notebooks`
- `services/torghut/.venv/bin/python services/torghut/scripts/validate_notebook_render.py <rendered.yaml>`
- `nix develop -c scripts/kubeconform.sh <rendered.yaml>`
- live browser reproduction before the fix: single-user pod repeatedly exited with `TypeError: argument of type Dict is not iterable`; pod spec rendered `args=[start-torghut-notebook]` while the image already used that launcher as its entrypoint

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.