### PR TITLE
chore(torghut): promote image sha-d785a4f399047c1df717a5906ce3c494b5ca3e68

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -54,7 +54,7 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: 240795bf6c3344f75f622498d086b429d9c59f22
+              value: d785a4f399047c1df717a5906ce3c494b5ca3e68
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:451f6d40fc4882a5b13467e62c36ebc7a3a56518874d1d547fea7d00960e9f4c
             - name: PYTHONPATH

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -46,7 +46,7 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: 240795bf6c3344f75f622498d086b429d9c59f22
+              value: d785a4f399047c1df717a5906ce3c494b5ca3e68
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:451f6d40fc4882a5b13467e62c36ebc7a3a56518874d1d547fea7d00960e9f4c
             - name: DB_DSN

--- a/argocd/applications/torghut-options/archive/deployment.yaml
+++ b/argocd/applications/torghut-options/archive/deployment.yaml
@@ -100,9 +100,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2220-g240795bf6
+              value: v0.596.0-2222-gd785a4f39
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 240795bf6c3344f75f622498d086b429d9c59f22
+              value: d785a4f399047c1df717a5906ce3c494b5ca3e68
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -110,9 +110,9 @@ spec:
                   name: torghut-ws-config
                   key: SYMBOLS_ALLOWLIST
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2220-g240795bf6
+              value: v0.596.0-2222-gd785a4f39
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 240795bf6c3344f75f622498d086b429d9c59f22
+              value: d785a4f399047c1df717a5906ce3c494b5ca3e68
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -106,9 +106,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2220-g240795bf6
+              value: v0.596.0-2222-gd785a4f39
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 240795bf6c3344f75f622498d086b429d9c59f22
+              value: d785a4f399047c1df717a5906ce3c494b5ca3e68
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/broker-economic-ledger-reconciliation-cronjob.yaml
+++ b/argocd/applications/torghut/broker-economic-ledger-reconciliation-cronjob.yaml
@@ -92,9 +92,9 @@ spec:
                 - name: TRADING_ACCOUNT_LABEL
                   value: PA3SX7FYNUTF
                 - name: TORGHUT_VERSION
-                  value: v0.596.0-2220-g240795bf6
+                  value: v0.596.0-2222-gd785a4f39
                 - name: TORGHUT_COMMIT
-                  value: 240795bf6c3344f75f622498d086b429d9c59f22
+                  value: d785a4f399047c1df717a5906ce3c494b5ca3e68
                 - name: TORGHUT_IMAGE_DIGEST
                   value: sha256:451f6d40fc4882a5b13467e62c36ebc7a3a56518874d1d547fea7d00960e9f4c
                 - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-18T10:53:56Z"
+        client.knative.dev/updateTimestamp: "2026-07-18T11:08:08Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -509,9 +509,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2220-g240795bf6
+              value: v0.596.0-2222-gd785a4f39
             - name: TORGHUT_COMMIT
-              value: 240795bf6c3344f75f622498d086b429d9c59f22
+              value: d785a4f399047c1df717a5906ce3c494b5ca3e68
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:451f6d40fc4882a5b13467e62c36ebc7a3a56518874d1d547fea7d00960e9f4c
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-18T10:53:56Z"
+        client.knative.dev/updateTimestamp: "2026-07-18T11:08:08Z"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
     spec:
@@ -446,9 +446,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2220-g240795bf6
+              value: v0.596.0-2222-gd785a4f39
             - name: TORGHUT_COMMIT
-              value: 240795bf6c3344f75f622498d086b429d9c59f22
+              value: d785a4f399047c1df717a5906ce3c494b5ca3e68
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:451f6d40fc4882a5b13467e62c36ebc7a3a56518874d1d547fea7d00960e9f4c
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/order-lineage-reconciliation-cronjob.yaml
+++ b/argocd/applications/torghut/order-lineage-reconciliation-cronjob.yaml
@@ -88,9 +88,9 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_VERSION
-                  value: v0.596.0-2220-g240795bf6
+                  value: v0.596.0-2222-gd785a4f39
                 - name: TORGHUT_COMMIT
-                  value: 240795bf6c3344f75f622498d086b429d9c59f22
+                  value: d785a4f399047c1df717a5906ce3c494b5ca3e68
                 - name: TORGHUT_IMAGE_DIGEST
                   value: sha256:451f6d40fc4882a5b13467e62c36ebc7a3a56518874d1d547fea7d00960e9f4c
                 - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -462,9 +462,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2220-g240795bf6
+              value: v0.596.0-2222-gd785a4f39
             - name: TORGHUT_COMMIT
-              value: 240795bf6c3344f75f622498d086b429d9c59f22
+              value: d785a4f399047c1df717a5906ce3c494b5ca3e68
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:451f6d40fc4882a5b13467e62c36ebc7a3a56518874d1d547fea7d00960e9f4c
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `d785a4f399047c1df717a5906ce3c494b5ca3e68`
- Image tag: `sha-d785a4f399047c1df717a5906ce3c494b5ca3e68`
- Image digest: `sha256:451f6d40fc4882a5b13467e62c36ebc7a3a56518874d1d547fea7d00960e9f4c`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher