### PR TITLE
fix(torghut): execute notebook image arguments

### DIFF
--- a/services/torghut/scripts/start_torghut_notebook.sh
+++ b/services/torghut/scripts/start_torghut_notebook.sh
@@ -15,4 +15,8 @@ for notebook in \
   fi
 done
 
-exec jupyterhub-singleuser "$@"
+if [[ "$#" -eq 0 ]]; then
+  set -- jupyterhub-singleuser
+fi
+
+exec "$@"

--- a/services/torghut/tests/notebook_data/test_manifest_contract.py
+++ b/services/torghut/tests/notebook_data/test_manifest_contract.py
@@ -169,6 +169,10 @@ def test_notebook_entrypoint_seeds_only_absent_canonical_notebooks() -> None:
     assert 'cp "${canonical_dir}/${notebook}" "${workspace_dir}/${notebook}"' in source
     assert "cp -f" not in source
     assert "rm " not in source
+    assert 'if [[ "$#" -eq 0 ]]; then' in source
+    assert "set -- jupyterhub-singleuser" in source
+    assert 'exec "$@"' in source
+    assert 'exec jupyterhub-singleuser "$@"' not in source
 
 
 def test_chart_and_digest_contracts_are_pinned() -> None:


### PR DESCRIPTION
## Summary

- seed canonical notebooks, then execute the command and arguments supplied by KubeSpawner
- retain a standalone fallback to `jupyterhub-singleuser` when the image is launched without arguments
- add a regression contract preventing the wrapper from prepending a second single-user command

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/notebook_data/test_manifest_contract.py -q`
- `cd services/torghut && uv run --frozen ruff format --check tests/notebook_data/test_manifest_contract.py scripts/validate_notebook_render.py`
- `cd services/torghut && uv run --frozen ruff check tests/notebook_data/test_manifest_contract.py scripts/validate_notebook_render.py`
- `bash -n services/torghut/scripts/start_torghut_notebook.sh`
- `nix develop -c kustomize build --enable-helm argocd/applications/torghut/notebooks`
- `services/torghut/.venv/bin/python services/torghut/scripts/validate_notebook_render.py <rendered.yaml>`
- `nix develop -c scripts/kubeconform.sh <rendered.yaml>`
- live cluster evidence: KubeSpawner rendered the chart default and runtime arguments in `pod.spec.containers[0].args`; the old wrapper prepended another `jupyterhub-singleuser`, causing the single-user process to parse its executable name as a subcommand and crash

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.