### PR TITLE
fix(torghut): prevent stale revision overlap

### DIFF
--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -10,7 +10,6 @@ metadata:
     networking.knative.dev/visibility: cluster-local
   annotations:
     serving.knative.dev/creator: system:serviceaccount:argocd:argocd-application-controller
-    serving.knative.dev/rollout-duration: 10s
     argocd.argoproj.io/tracking-id: torghut:serving.knative.dev/Service:torghut/torghut-sim
 spec:
   template:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -11,7 +11,6 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "0"
     serving.knative.dev/creator: system:serviceaccount:argocd:argocd-application-controller
-    serving.knative.dev/rollout-duration: 10s
     argocd.argoproj.io/tracking-id: torghut:serving.knative.dev/Service:torghut/torghut
 spec:
   template:

--- a/services/torghut/tests/live_config_manifest_contract/test_product_applicationset_renders_torghut_namespace_security_metadata.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_product_applicationset_renders_torghut_namespace_security_metadata.py
@@ -97,6 +97,17 @@ class TestProductApplicationsetRendersTorghutNamespaceSecurityMetadata(
             )
         )
 
+    def test_torghut_knative_services_use_immediate_revision_cutover(self) -> None:
+        for path in (
+            "argocd/applications/torghut/knative-service.yaml",
+            "argocd/applications/torghut/knative-service-sim.yaml",
+        ):
+            manifest = _load_yaml_mapping(path)
+            metadata = cast(Mapping[str, object], manifest.get("metadata", {}))
+            annotations = cast(Mapping[str, object], metadata.get("annotations", {}))
+
+            self.assertNotIn("serving.knative.dev/rollout-duration", annotations)
+
     def test_options_ta_uses_primary_clickhouse_auth_secret(self) -> None:
         manifest = _load_yaml_mapping(
             "argocd/applications/torghut-options/ta/flinkdeployment.yaml"


### PR DESCRIPTION
## Summary

- remove the 10-second gradual traffic rollout from the singleton Torghut API and simulation Knative services
- use Knative readiness followed by immediate latest-revision cutover so completed revisions can scale to zero promptly
- lock the immediate-cutover contract with a focused manifest regression test

## Related Issues

None

## Testing

- `uv run --directory services/torghut --frozen pytest tests/live_config_manifest_contract/test_product_applicationset_renders_torghut_namespace_security_metadata.py -q` (16 passed)
- `uv run --directory services/torghut --frozen ruff format --check tests/live_config_manifest_contract/test_product_applicationset_renders_torghut_namespace_security_metadata.py`
- `uv run --directory services/torghut --frozen ruff check tests/live_config_manifest_contract/test_product_applicationset_renders_torghut_namespace_security_metadata.py`
- `kustomize build --enable-helm argocd/applications/torghut` followed by `./scripts/kubeconform.sh` (84 valid, 0 invalid, 0 errors, 10 skipped CRDs)
- live pre-change readback: one active production revision and one active simulation revision; all retained prior deployments at zero replicas

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.