### PR TITLE
chore(torghut): promote notebook image sha-b8cc2db09a31798f86884e9e71479c21bb3a9a07

### DIFF
--- a/argocd/applications/torghut/notebooks/values.yaml
+++ b/argocd/applications/torghut/notebooks/values.yaml
@@ -93,7 +93,7 @@ proxy:
 singleuser:
   image:
     name: registry.ide-newton.ts.net/lab/torghut-notebook@sha256
-    tag: 'd6dc573a9df115480fc81773beb60bcf90c37bf189f31195f88f1ad3afd288ad'
+    tag: '06c6c1c96a9e98761b697db1e0c3971a5159de0e480535a5396077bc3766c9c6'
     pullPolicy: IfNotPresent
   defaultUrl: /lab/tree/work/00-system-flow.ipynb
   startTimeout: 600


### PR DESCRIPTION
## Summary

- Promote the immutable multi-architecture Torghut notebook image built from `b8cc2db09a31798f86884e9e71479c21bb3a9a07`.
- Update only the digest-pinned JupyterHub single-user image.

## Related Issues

None.

## Testing

- The source commit passed notebook fixture execution and manifest contracts.
- The release workflow verified `linux/amd64` and `linux/arm64` for `sha256:06c6c1c96a9e98761b697db1e0c3971a5159de0e480535a5396077bc3766c9c6`.

## Breaking Changes

None.

## Checklist

- [x] The single-user image is immutable and multi-architecture.
- [x] Promotion changes only the notebook image digest.
- [x] PVCs and read-only credentials are unchanged.