### PR TITLE
chore(torghut): promote image sha-9b87cb6f7e6d847ab13dcc2523ad9e7a51cc1c39

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -54,7 +54,7 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: b8cc2db09a31798f86884e9e71479c21bb3a9a07
+              value: 9b87cb6f7e6d847ab13dcc2523ad9e7a51cc1c39
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:66ac029b53896d28e9d2f64dcf2599b2fef13ac2c2fac1d97d934ac7b6c09dc6
             - name: PYTHONPATH

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -46,7 +46,7 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: b8cc2db09a31798f86884e9e71479c21bb3a9a07
+              value: 9b87cb6f7e6d847ab13dcc2523ad9e7a51cc1c39
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:66ac029b53896d28e9d2f64dcf2599b2fef13ac2c2fac1d97d934ac7b6c09dc6
             - name: DB_DSN

--- a/argocd/applications/torghut-options/archive/deployment.yaml
+++ b/argocd/applications/torghut-options/archive/deployment.yaml
@@ -100,9 +100,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2224-gb8cc2db09
+              value: v0.596.0-2225-g9b87cb6f7
             - name: TORGHUT_OPTIONS_COMMIT
-              value: b8cc2db09a31798f86884e9e71479c21bb3a9a07
+              value: 9b87cb6f7e6d847ab13dcc2523ad9e7a51cc1c39
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -110,9 +110,9 @@ spec:
                   name: torghut-ws-config
                   key: SYMBOLS_ALLOWLIST
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2224-gb8cc2db09
+              value: v0.596.0-2225-g9b87cb6f7
             - name: TORGHUT_OPTIONS_COMMIT
-              value: b8cc2db09a31798f86884e9e71479c21bb3a9a07
+              value: 9b87cb6f7e6d847ab13dcc2523ad9e7a51cc1c39
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -106,9 +106,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2224-gb8cc2db09
+              value: v0.596.0-2225-g9b87cb6f7
             - name: TORGHUT_OPTIONS_COMMIT
-              value: b8cc2db09a31798f86884e9e71479c21bb3a9a07
+              value: 9b87cb6f7e6d847ab13dcc2523ad9e7a51cc1c39
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/broker-economic-ledger-reconciliation-cronjob.yaml
+++ b/argocd/applications/torghut/broker-economic-ledger-reconciliation-cronjob.yaml
@@ -92,9 +92,9 @@ spec:
                 - name: TRADING_ACCOUNT_LABEL
                   value: PA3SX7FYNUTF
                 - name: TORGHUT_VERSION
-                  value: v0.596.0-2224-gb8cc2db09
+                  value: v0.596.0-2225-g9b87cb6f7
                 - name: TORGHUT_COMMIT
-                  value: b8cc2db09a31798f86884e9e71479c21bb3a9a07
+                  value: 9b87cb6f7e6d847ab13dcc2523ad9e7a51cc1c39
                 - name: TORGHUT_IMAGE_DIGEST
                   value: sha256:66ac029b53896d28e9d2f64dcf2599b2fef13ac2c2fac1d97d934ac7b6c09dc6
                 - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-18T11:24:27Z"
+        client.knative.dev/updateTimestamp: "2026-07-18T11:27:36Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -509,9 +509,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2224-gb8cc2db09
+              value: v0.596.0-2225-g9b87cb6f7
             - name: TORGHUT_COMMIT
-              value: b8cc2db09a31798f86884e9e71479c21bb3a9a07
+              value: 9b87cb6f7e6d847ab13dcc2523ad9e7a51cc1c39
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:66ac029b53896d28e9d2f64dcf2599b2fef13ac2c2fac1d97d934ac7b6c09dc6
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-18T11:24:27Z"
+        client.knative.dev/updateTimestamp: "2026-07-18T11:27:36Z"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
     spec:
@@ -446,9 +446,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2224-gb8cc2db09
+              value: v0.596.0-2225-g9b87cb6f7
             - name: TORGHUT_COMMIT
-              value: b8cc2db09a31798f86884e9e71479c21bb3a9a07
+              value: 9b87cb6f7e6d847ab13dcc2523ad9e7a51cc1c39
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:66ac029b53896d28e9d2f64dcf2599b2fef13ac2c2fac1d97d934ac7b6c09dc6
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/order-lineage-reconciliation-cronjob.yaml
+++ b/argocd/applications/torghut/order-lineage-reconciliation-cronjob.yaml
@@ -88,9 +88,9 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_VERSION
-                  value: v0.596.0-2224-gb8cc2db09
+                  value: v0.596.0-2225-g9b87cb6f7
                 - name: TORGHUT_COMMIT
-                  value: b8cc2db09a31798f86884e9e71479c21bb3a9a07
+                  value: 9b87cb6f7e6d847ab13dcc2523ad9e7a51cc1c39
                 - name: TORGHUT_IMAGE_DIGEST
                   value: sha256:66ac029b53896d28e9d2f64dcf2599b2fef13ac2c2fac1d97d934ac7b6c09dc6
                 - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -462,9 +462,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2224-gb8cc2db09
+              value: v0.596.0-2225-g9b87cb6f7
             - name: TORGHUT_COMMIT
-              value: b8cc2db09a31798f86884e9e71479c21bb3a9a07
+              value: 9b87cb6f7e6d847ab13dcc2523ad9e7a51cc1c39
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:66ac029b53896d28e9d2f64dcf2599b2fef13ac2c2fac1d97d934ac7b6c09dc6
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `9b87cb6f7e6d847ab13dcc2523ad9e7a51cc1c39`
- Image tag: `sha-9b87cb6f7e6d847ab13dcc2523ad9e7a51cc1c39`
- Image digest: `sha256:66ac029b53896d28e9d2f64dcf2599b2fef13ac2c2fac1d97d934ac7b6c09dc6`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher