### PR TITLE
fix(torghut): force immediate simulator cutover

### DIFF
--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -9,6 +9,10 @@ metadata:
     app.kubernetes.io/part-of: lab
     networking.knative.dev/visibility: cluster-local
   annotations:
+    # A legacy kubectl field manager still co-owns this key in production, so SSA
+    # cannot delete the old 10s value by omission. With no cluster rollout default,
+    # 0s preserves immediate cutover while keeping GitOps authoritative.
+    serving.knative.dev/rollout-duration: 0s
     serving.knative.dev/creator: system:serviceaccount:argocd:argocd-application-controller
     argocd.argoproj.io/tracking-id: torghut:serving.knative.dev/Service:torghut/torghut-sim
 spec:

--- a/services/torghut/tests/live_config_manifest_contract/test_product_applicationset_renders_torghut_namespace_security_metadata.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_product_applicationset_renders_torghut_namespace_security_metadata.py
@@ -98,15 +98,18 @@ class TestProductApplicationsetRendersTorghutNamespaceSecurityMetadata(
         )
 
     def test_torghut_knative_services_use_immediate_revision_cutover(self) -> None:
-        for path in (
-            "argocd/applications/torghut/knative-service.yaml",
-            "argocd/applications/torghut/knative-service-sim.yaml",
-        ):
+        expected_by_path = {
+            "argocd/applications/torghut/knative-service.yaml": None,
+            "argocd/applications/torghut/knative-service-sim.yaml": "0s",
+        }
+        for path, expected in expected_by_path.items():
             manifest = _load_yaml_mapping(path)
             metadata = cast(Mapping[str, object], manifest.get("metadata", {}))
             annotations = cast(Mapping[str, object], metadata.get("annotations", {}))
 
-            self.assertNotIn("serving.knative.dev/rollout-duration", annotations)
+            self.assertEqual(
+                annotations.get("serving.knative.dev/rollout-duration"), expected
+            )
 
     def test_options_ta_uses_primary_clickhouse_auth_secret(self) -> None:
         manifest = _load_yaml_mapping(


### PR DESCRIPTION
## Summary

- set the simulator rollout duration to `0s` so the legacy `kubectl` field owner cannot preserve the stale `10s` value
- keep production on the clean annotation-free immediate-cutover path
- extend the manifest contract to enforce both immediate-cutover representations

## Related Issues

None

## Testing

- `uv run --directory services/torghut pytest tests/live_config_manifest_contract/test_product_applicationset_renders_torghut_namespace_security_metadata.py -q` (17 passed)
- `uv run --directory services/torghut ruff format --check tests/live_config_manifest_contract/test_product_applicationset_renders_torghut_namespace_security_metadata.py`
- `uv run --directory services/torghut ruff check tests/live_config_manifest_contract/test_product_applicationset_renders_torghut_namespace_security_metadata.py`
- `kustomize build --enable-helm argocd/applications/torghut | kubeconform -strict -ignore-missing-schemas -summary` (69 valid, 0 invalid, 0 errors, 25 skipped CRDs)
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.