### PR TITLE
feat(torghut): add CNPG standby resilience

### DIFF
--- a/argocd/applications/torghut/postgres-cluster.yaml
+++ b/argocd/applications/torghut/postgres-cluster.yaml
@@ -4,8 +4,32 @@ metadata:
   name: torghut-db
   namespace: torghut
 spec:
-  instances: 1
+  # Avoid unproved cross-architecture physical replication. The lab has two
+  # amd64 workers, so run one instance on each instead of retaining the legacy
+  # single-host pin.
+  instances: 2
   primaryUpdateStrategy: unsupervised
+  affinity:
+    # Explicit null removes the legacy kubectl-owned hostname selector through
+    # server-side apply. Architecture placement is expressed below instead.
+    nodeSelector: null
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64
+    podAntiAffinityType: required
+    topologyKey: kubernetes.io/hostname
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: "4"
+      memory: 8Gi
   managed:
     roles:
       - name: torghut_notebook
@@ -33,6 +57,7 @@ spec:
       encoding: "UTF8"
       dataChecksums: true
   backup:
+    target: prefer-standby
     barmanObjectStore:
       destinationPath: s3://cnpg-torghut
       serverName: torghut-db-live

--- a/docs/torghut/profitability/README.md
+++ b/docs/torghut/profitability/README.md
@@ -45,6 +45,8 @@ readback. The audit snapshot records what was observed at its stated time.
   explicit residual classifications, and a permanent non-promotion boundary.
 - [Full broker-economic TigerBeetle parity](tigerbeetle-economic-parity.md): exact versioned projection, linked-chain
   materialization, full readback, sealed evidence, entry-only enforcement, and rollout proof.
+- [CNPG evidence storage and recovery](cnpg-evidence-storage-recovery.md): production database placement, resource,
+  backup, failover, restore, and evidence-preservation contract.
 - [Implementation roadmap](implementation-roadmap.md): ordered PR-sized delivery slices, tests, rollout proof,
   dependencies, and rollback posture.
 - [Slice 3 production evidence](evidence/slice-03-autoresearch-completion-2026-07-14.md): committed revision, CI and

--- a/docs/torghut/profitability/cnpg-evidence-storage-recovery.md
+++ b/docs/torghut/profitability/cnpg-evidence-storage-recovery.md
@@ -1,0 +1,72 @@
+# CNPG Evidence Storage And Recovery
+
+Status: Slice 11 implementation contract. The high-availability rollout and isolated restore drill are not yet
+production-proven.
+
+## Observed Baseline
+
+The live readback on `2026-07-18` found a healthy 21 GB PostgreSQL 17 database with data checksums, continuous WAL
+archiving, a 14-day recovery window, and successful daily object-store backups. The latest base backup completed in
+about 15 minutes. It also found three material gaps:
+
+- the cluster had one instance, so there was no failover replica;
+- an old `kubectl-patch` manager still pinned the pod to one hostname even though that selector was absent from Git;
+- no isolated restore or measured recovery-time proof existed.
+
+Backup success is not restore proof. One healthy pod and one Ceph-backed PVC are not database high availability.
+
+## Decision
+
+Run one primary and one hot standby on the two amd64 workers, with required hostname anti-affinity. Do not place a
+physical replica on the arm64 worker until mixed-architecture compatibility is deliberately proven with the exact
+PostgreSQL image and data types. The current two-instance topology is asynchronous: it improves availability but does
+not claim zero-loss synchronous failover.
+
+Each instance has a `500m` CPU and `1Gi` memory request plus a `4` CPU and `8Gi` memory limit. Those bounds are above
+the observed primary use of roughly `379m` CPU and `453Mi` memory while preventing an unbounded database pod from
+consuming a worker. Base backups prefer the standby and fall back to the primary when no standby is available.
+
+CloudNativePG manages `instances - 1` replicas and automated failover whenever `instances` is greater than one. Its
+backup guidance states that WAL archiving provides a default disaster-recovery RPO of at most five minutes and that
+restore time must be measured regularly. See the official
+[capability-level contract](https://cloudnative-pg.io/docs/current/operator_capability_levels/) and
+[backup guidance](https://cloudnative-pg.io/docs/current/backup/).
+
+## Ownership Migration
+
+Argo CD uses server-side apply with forced conflict resolution, but omitting a map entry does not delete a value still
+owned by another field manager. The rollout therefore has one explicit operational migration after the Git change is
+merged and before judging replica placement:
+
+```sh
+kubectl -n torghut patch cluster torghut-db --type=json \
+  -p='[{"op":"remove","path":"/spec/affinity/nodeSelector"}]'
+```
+
+This removes only the stale scheduling pin. It does not restart, delete, or recreate the primary. The committed
+architecture affinity and required hostname anti-affinity then become the only scheduling contract. Verify the result
+through `metadata.managedFields`, the live Cluster spec, and pod node placement; do not retain a cleanup Job or second
+configuration writer.
+
+## Production Proof Sequence
+
+Slice 11 is complete only after all of these pass:
+
+1. focused manifest tests, Kustomize rendering, CRD server dry-run, and CI pass at the merged source;
+2. the operator reports two ready instances on distinct amd64 hosts, streaming replication is healthy, and the standby
+   lag is measured rather than assumed;
+3. a controlled weekend switchover preserves database identity and immutable evidence counts, the read-write Service
+   follows the new primary, and the scheduler reconnects without duplicate broker mutation;
+4. a base backup completes from the standby and continuous WAL archiving remains healthy;
+5. a new isolated CNPG cluster restores the selected backup, verifies database/schema and immutable evidence
+   fingerprints, records recovery duration, and is then removed without touching the source cluster.
+
+The isolated restore follows CloudNativePG's rule that recovery bootstraps a new cluster rather than overwriting the
+source. See the official [recovery contract](https://cloudnative-pg.io/docs/current/recovery/).
+
+The installed CloudNativePG `1.30.0` operator warns that native Barman object-store support is removed in `1.31`.
+Migration to the supported Barman Cloud CNPG-I plugin is therefore a blocking follow-up before the next operator
+upgrade; backup availability must not be silently lost during that upgrade.
+
+None of these storage proofs establishes strategy profitability or capital authority. Risk-increasing real-capital
+submission remains blocked.

--- a/services/torghut/tests/live_config_manifest_contract/test_postgres_cluster_resilience.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_postgres_cluster_resilience.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import Mapping, cast
+from unittest import TestCase
+
+from .support import load_yaml_mapping
+
+
+class PostgresClusterResilienceManifestTests(TestCase):
+    def setUp(self) -> None:
+        self.cluster = load_yaml_mapping(
+            "argocd/applications/torghut/postgres-cluster.yaml"
+        )
+        self.cluster_spec = cast(Mapping[str, object], self.cluster["spec"])
+
+    def test_cluster_has_one_cross_host_amd64_standby(self) -> None:
+        self.assertEqual(self.cluster_spec["instances"], 2)
+
+        affinity = cast(Mapping[str, object], self.cluster_spec["affinity"])
+        self.assertIsNone(affinity["nodeSelector"])
+        self.assertEqual(affinity["podAntiAffinityType"], "required")
+        self.assertEqual(affinity["topologyKey"], "kubernetes.io/hostname")
+        self.assertEqual(
+            affinity["nodeAffinity"],
+            {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "kubernetes.io/arch",
+                                    "operator": "In",
+                                    "values": ["amd64"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+        )
+
+    def test_cluster_resources_are_bounded(self) -> None:
+        self.assertEqual(
+            self.cluster_spec["resources"],
+            {
+                "requests": {"cpu": "500m", "memory": "1Gi"},
+                "limits": {"cpu": "4", "memory": "8Gi"},
+            },
+        )
+
+    def test_continuous_backup_prefers_the_standby(self) -> None:
+        backup = cast(Mapping[str, object], self.cluster_spec["backup"])
+        object_store = cast(Mapping[str, object], backup["barmanObjectStore"])
+        wal = cast(Mapping[str, object], object_store["wal"])
+
+        self.assertEqual(backup["target"], "prefer-standby")
+        self.assertEqual(backup["retentionPolicy"], "14d")
+        self.assertEqual(object_store["destinationPath"], "s3://cnpg-torghut")
+        self.assertEqual(object_store["serverName"], "torghut-db-live")
+        self.assertEqual(wal["maxParallel"], 8)
+
+        schedule = load_yaml_mapping(
+            "argocd/applications/torghut/postgres-scheduled-backup.yaml"
+        )
+        schedule_spec = cast(Mapping[str, object], schedule["spec"])
+        self.assertEqual(schedule_spec["schedule"], "0 0 2 * * *")
+        self.assertEqual(schedule_spec["method"], "barmanObjectStore")
+        self.assertEqual(schedule_spec["backupOwnerReference"], "self")
+        self.assertEqual(schedule_spec["cluster"], {"name": "torghut-db"})


### PR DESCRIPTION
## Summary

- replace the single-instance, legacy host-pinned Torghut CNPG topology with one primary and one cross-host amd64 standby
- add required hostname anti-affinity, measured resource bounds, and standby-preferred base backups
- document the Slice 11 failover/restore proof contract and the one-time removal of the stale `kubectl-patch` hostname field
- add focused manifest contracts for topology, resources, and continuous backup

## Related Issues

None

## Testing

- `uv run --frozen --extra dev pytest tests/live_config_manifest_contract/test_postgres_cluster_resilience.py tests/notebook_data/test_manifest_contract.py -q` (`15 passed`)
- `uv run --frozen --extra dev pytest tests/live_config_manifest_contract -q` (`70 passed`)
- `uv run --frozen --extra dev ruff check tests/live_config_manifest_contract/test_postgres_cluster_resilience.py`
- `bunx oxfmt --check docs/torghut/profitability/README.md docs/torghut/profitability/cnpg-evidence-storage-recovery.md`
- `kustomize build --enable-helm argocd/applications/torghut`
- `./scripts/kubeconform.sh argocd/applications/torghut/postgres-cluster.yaml argocd/applications/torghut/postgres-scheduled-backup.yaml` (`2 skipped CRDs; 0 invalid/errors`)
- server-side apply dry-run with forced conflicts accepted the desired Cluster; JSON-patch server dry-run proved the legacy hostname selector can be removed without replacing the Cluster

## Breaking Changes

The Cluster scales from one to two instances. After merge, remove the stale `kubectl-patch`-owned `/spec/affinity/nodeSelector` exactly once as documented; Argo then owns the architecture and anti-affinity contract. No database or PVC is deleted. Native Barman backup support must migrate to the CNPG-I plugin before CloudNativePG 1.31.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.