### PR TITLE
chore(torghut): promote image sha-41b5d80e68d6cd6199db630c4c42bec2cb75146d

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -54,7 +54,7 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: 8f9bf697dec51117ee96c7fc3a93e140e111036f
+              value: 41b5d80e68d6cd6199db630c4c42bec2cb75146d
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:66ac029b53896d28e9d2f64dcf2599b2fef13ac2c2fac1d97d934ac7b6c09dc6
             - name: PYTHONPATH

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -46,7 +46,7 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: 8f9bf697dec51117ee96c7fc3a93e140e111036f
+              value: 41b5d80e68d6cd6199db630c4c42bec2cb75146d
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:66ac029b53896d28e9d2f64dcf2599b2fef13ac2c2fac1d97d934ac7b6c09dc6
             - name: DB_DSN

--- a/argocd/applications/torghut-options/archive/deployment.yaml
+++ b/argocd/applications/torghut-options/archive/deployment.yaml
@@ -100,9 +100,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2231-g8f9bf697d
+              value: v0.596.0-2234-g41b5d80e6
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 8f9bf697dec51117ee96c7fc3a93e140e111036f
+              value: 41b5d80e68d6cd6199db630c4c42bec2cb75146d
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -110,9 +110,9 @@ spec:
                   name: torghut-ws-config
                   key: SYMBOLS_ALLOWLIST
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2231-g8f9bf697d
+              value: v0.596.0-2234-g41b5d80e6
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 8f9bf697dec51117ee96c7fc3a93e140e111036f
+              value: 41b5d80e68d6cd6199db630c4c42bec2cb75146d
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -106,9 +106,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2231-g8f9bf697d
+              value: v0.596.0-2234-g41b5d80e6
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 8f9bf697dec51117ee96c7fc3a93e140e111036f
+              value: 41b5d80e68d6cd6199db630c4c42bec2cb75146d
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/broker-economic-ledger-reconciliation-cronjob.yaml
+++ b/argocd/applications/torghut/broker-economic-ledger-reconciliation-cronjob.yaml
@@ -92,9 +92,9 @@ spec:
                 - name: TRADING_ACCOUNT_LABEL
                   value: PA3SX7FYNUTF
                 - name: TORGHUT_VERSION
-                  value: v0.596.0-2231-g8f9bf697d
+                  value: v0.596.0-2234-g41b5d80e6
                 - name: TORGHUT_COMMIT
-                  value: 8f9bf697dec51117ee96c7fc3a93e140e111036f
+                  value: 41b5d80e68d6cd6199db630c4c42bec2cb75146d
                 - name: TORGHUT_IMAGE_DIGEST
                   value: sha256:66ac029b53896d28e9d2f64dcf2599b2fef13ac2c2fac1d97d934ac7b6c09dc6
                 - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-18T11:56:46Z"
+        client.knative.dev/updateTimestamp: "2026-07-18T12:34:14Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -512,9 +512,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2231-g8f9bf697d
+              value: v0.596.0-2234-g41b5d80e6
             - name: TORGHUT_COMMIT
-              value: 8f9bf697dec51117ee96c7fc3a93e140e111036f
+              value: 41b5d80e68d6cd6199db630c4c42bec2cb75146d
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:66ac029b53896d28e9d2f64dcf2599b2fef13ac2c2fac1d97d934ac7b6c09dc6
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-18T11:56:46Z"
+        client.knative.dev/updateTimestamp: "2026-07-18T12:34:14Z"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
     spec:
@@ -445,9 +445,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2231-g8f9bf697d
+              value: v0.596.0-2234-g41b5d80e6
             - name: TORGHUT_COMMIT
-              value: 8f9bf697dec51117ee96c7fc3a93e140e111036f
+              value: 41b5d80e68d6cd6199db630c4c42bec2cb75146d
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:66ac029b53896d28e9d2f64dcf2599b2fef13ac2c2fac1d97d934ac7b6c09dc6
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/order-lineage-reconciliation-cronjob.yaml
+++ b/argocd/applications/torghut/order-lineage-reconciliation-cronjob.yaml
@@ -88,9 +88,9 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_VERSION
-                  value: v0.596.0-2231-g8f9bf697d
+                  value: v0.596.0-2234-g41b5d80e6
                 - name: TORGHUT_COMMIT
-                  value: 8f9bf697dec51117ee96c7fc3a93e140e111036f
+                  value: 41b5d80e68d6cd6199db630c4c42bec2cb75146d
                 - name: TORGHUT_IMAGE_DIGEST
                   value: sha256:66ac029b53896d28e9d2f64dcf2599b2fef13ac2c2fac1d97d934ac7b6c09dc6
                 - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -462,9 +462,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2231-g8f9bf697d
+              value: v0.596.0-2234-g41b5d80e6
             - name: TORGHUT_COMMIT
-              value: 8f9bf697dec51117ee96c7fc3a93e140e111036f
+              value: 41b5d80e68d6cd6199db630c4c42bec2cb75146d
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:66ac029b53896d28e9d2f64dcf2599b2fef13ac2c2fac1d97d934ac7b6c09dc6
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `41b5d80e68d6cd6199db630c4c42bec2cb75146d`
- Image tag: `sha-41b5d80e68d6cd6199db630c4c42bec2cb75146d`
- Image digest: `sha256:66ac029b53896d28e9d2f64dcf2599b2fef13ac2c2fac1d97d934ac7b6c09dc6`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher