### PR TITLE
perf(torghut): index measured order reads

### DIFF
--- a/docs/torghut/profitability/cnpg-evidence-storage-recovery.md
+++ b/docs/torghut/profitability/cnpg-evidence-storage-recovery.md
@@ -123,11 +123,23 @@ copy was analyzed and used to benchmark the exact SQL from `loop_status.py`, `re
 | orders in the last 24 hours |          283 / 0.469 ms |                  2 / 0.011 ms | 99% fewer buffers; about 43x faster |
 | exchange-order lookup       |          283 / 0.330 ms |                  3 / 0.018 ms | 99% fewer buffers; about 18x faster |
 
+The projected-volume check used the same PostgreSQL 17 image, production column types and status mix, and a 512-byte
+row-width pad in a disposable CNPG cluster. Its 1,000,000 rows were about 233 times the live order count and occupied a
+651 MB heap (780 MB including the pre-existing indexes).
+
+| Projected-volume query       | Baseline buffers / time | Measured index buffers / time |
+| ---------------------------- | ----------------------: | ----------------------------: |
+| latest acknowledged order    |     83,425 / 341.228 ms |                  9 / 0.024 ms |
+| orders in the last 24 hours  |     83,334 / 114.007 ms |              4,327 / 1.694 ms |
+| exchange-order lookup        |     83,334 / 108.565 ms |                  4 / 0.021 ms |
+| rejection cooldown (30 days) |      25,024 / 84.645 ms |             3,573 / 20.384 ms |
+
 Two B-tree indexes produced those results: `(execution_network, created_at DESC)` and the partial
 `(execution_network, exchange_order_id, created_at DESC) WHERE exchange_order_id IS NOT NULL`. Together they occupied
-336 KiB on the restored data. Stale-open-order, rejection-cooldown, and rejected-order-report plans did not improve,
-so no speculative indexes were added for them. Production creation uses `CREATE INDEX CONCURRENTLY` to avoid blocking
-writes, consistent with the PostgreSQL 17
+336 KiB on the restored data and 51 MB on the projected fixture. Stale-open-order latency remained below 0.1 ms, and
+the rejected-order operator report remained below 125 ms at projected volume; neither justified another index. The
+projected fixture and all of its resources were removed after measurement. Production creation uses
+`CREATE INDEX CONCURRENTLY` to avoid blocking writes, consistent with the PostgreSQL 17
 [index-build contract](https://www.postgresql.org/docs/17/sql-createindex.html#SQL-CREATEINDEX-CONCURRENTLY).
 
 None of these storage proofs establishes strategy profitability or capital authority. Risk-increasing real-capital

--- a/docs/torghut/profitability/cnpg-evidence-storage-recovery.md
+++ b/docs/torghut/profitability/cnpg-evidence-storage-recovery.md
@@ -1,7 +1,7 @@
 # CNPG Evidence Storage And Recovery
 
-Status: Slice 11 implementation contract. Cross-host replication is production-proven; standby backup, controlled
-switchover, query-envelope, and isolated-restore proofs remain open.
+Status: Slice 11 recovery and availability proof is production-complete. Two measured order-read indexes remain in the
+normal image-promotion path before the query envelope is closed on the live database.
 
 ## Observed Baseline
 
@@ -88,6 +88,47 @@ source. See the official [recovery contract](https://cloudnative-pg.io/docs/curr
 The installed CloudNativePG `1.30.0` operator warns that native Barman object-store support is removed in `1.31`.
 Migration to the supported Barman Cloud CNPG-I plugin is therefore a blocking follow-up before the next operator
 upgrade; backup availability must not be silently lost during that upgrade.
+
+## Standby Backup, Switchover, And Restore Evidence
+
+The controlled `2026-07-18` proof completed all destructive-risk work against isolated or redundant capacity:
+
+- `Backup/torghut-db-ha-proof-20260718` ran on standby `torghut-db-2` from `13:00:21Z` to `13:12:02Z` and completed
+  with end LSN `881/FE0A7450`;
+- a controlled promotion made that standby primary, moved the read-write endpoint, restored a healthy two-instance
+  topology with zero replay lag, and produced no duplicate trade decision or broker mutation;
+- an isolated one-instance cluster restored Barman backup ID `20260718T130021` with `targetImmediate: true`. The base
+  restore and WAL replay completed in 8 minutes 49 seconds, and the cluster became ready in 9 minutes 1 second;
+- recovery stopped at the backup-end LSN, with the last completed transaction at `13:11:38.162862Z`. The restored
+  database retained the source system identifier, 21 GB database size, data checksums, Alembic revision
+  `0082_order_lineage_runs`, and the 1,656-column schema fingerprint;
+- full-row canonical hashes and counts matched for `broker_economic_ledger_entries` (1,336,109),
+  `broker_mutation_receipt_events` (269), `broker_mutation_receipts` (34), `evidence_receipts` (56), and
+  `execution_order_events` (15,428).
+
+For a `targetImmediate` restore, use `Backup.status.backupId` (`20260718T130021` here), not
+`Backup.status.backupName`. The admission webhook requires that ID even when `bootstrap.recovery.backup.name` already
+references the exact Kubernetes Backup object. The restore cluster had no application route and no backup stanza, so
+it could neither receive Torghut traffic nor write into the source archive.
+
+## Measured Query Envelope
+
+The live statistics history showed repeated full scans of `hyperliquid_execution_orders`. The table held only 4,290
+rows, but the affected reads sit on status and fill-ingestion paths, so their cumulative work matters. The restored
+copy was analyzed and used to benchmark the exact SQL from `loop_status.py`, `reporting.py`, and `repository.py`.
+
+| Query                       | Baseline buffers / time | Measured index buffers / time | Result                              |
+| --------------------------- | ----------------------: | ----------------------------: | ----------------------------------- |
+| latest acknowledged order   |           59 / 0.147 ms |                  3 / 0.014 ms | 95% fewer buffers; about 10x faster |
+| orders in the last 24 hours |          283 / 0.469 ms |                  2 / 0.011 ms | 99% fewer buffers; about 43x faster |
+| exchange-order lookup       |          283 / 0.330 ms |                  3 / 0.018 ms | 99% fewer buffers; about 18x faster |
+
+Two B-tree indexes produced those results: `(execution_network, created_at DESC)` and the partial
+`(execution_network, exchange_order_id, created_at DESC) WHERE exchange_order_id IS NOT NULL`. Together they occupied
+336 KiB on the restored data. Stale-open-order, rejection-cooldown, and rejected-order-report plans did not improve,
+so no speculative indexes were added for them. Production creation uses `CREATE INDEX CONCURRENTLY` to avoid blocking
+writes, consistent with the PostgreSQL 17
+[index-build contract](https://www.postgresql.org/docs/17/sql-createindex.html#SQL-CREATEINDEX-CONCURRENTLY).
 
 None of these storage proofs establishes strategy profitability or capital authority. Risk-increasing real-capital
 submission remains blocked.

--- a/services/torghut/migrations/versions/0083_hyperliquid_execution_order_read_indexes.py
+++ b/services/torghut/migrations/versions/0083_hyperliquid_execution_order_read_indexes.py
@@ -1,0 +1,66 @@
+"""Add measured Hyperliquid execution order read indexes.
+
+Revision ID: 0083_hyperliquid_order_reads
+Revises: 0082_order_lineage_runs
+Create Date: 2026-07-18 06:40:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect
+
+
+revision = "0083_hyperliquid_order_reads"
+down_revision = "0082_order_lineage_runs"
+branch_labels = None
+depends_on = None
+
+
+TABLE_NAME = "hyperliquid_execution_orders"
+INDEXES: tuple[tuple[str, str], ...] = (
+    (
+        "ix_hyperliquid_execution_orders_network_created",
+        """
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+  ix_hyperliquid_execution_orders_network_created
+ON hyperliquid_execution_orders (execution_network, created_at DESC)
+""",
+    ),
+    (
+        "ix_hyperliquid_execution_orders_network_exchange_created",
+        """
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+  ix_hyperliquid_execution_orders_network_exchange_created
+ON hyperliquid_execution_orders (
+  execution_network,
+  exchange_order_id,
+  created_at DESC
+)
+WHERE exchange_order_id IS NOT NULL
+""",
+    ),
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if getattr(getattr(bind, "dialect", None), "name", "") != "postgresql":
+        return
+    if not inspect(bind).has_table(TABLE_NAME):
+        return
+    with op.get_context().autocommit_block():
+        for _index_name, create_sql in INDEXES:
+            op.execute(sa.text(create_sql))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if getattr(getattr(bind, "dialect", None), "name", "") != "postgresql":
+        return
+    if not inspect(bind).has_table(TABLE_NAME):
+        return
+    with op.get_context().autocommit_block():
+        for index_name, _create_sql in reversed(INDEXES):
+            op.execute(sa.text(f"DROP INDEX CONCURRENTLY IF EXISTS {index_name}"))

--- a/services/torghut/migrations/versions/0083_hyperliquid_execution_order_read_indexes.py
+++ b/services/torghut/migrations/versions/0083_hyperliquid_execution_order_read_indexes.py
@@ -23,7 +23,7 @@ INDEXES: tuple[tuple[str, str], ...] = (
     (
         "ix_hyperliquid_execution_orders_network_created",
         """
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   ix_hyperliquid_execution_orders_network_created
 ON hyperliquid_execution_orders (execution_network, created_at DESC)
 """,
@@ -31,7 +31,7 @@ ON hyperliquid_execution_orders (execution_network, created_at DESC)
     (
         "ix_hyperliquid_execution_orders_network_exchange_created",
         """
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   ix_hyperliquid_execution_orders_network_exchange_created
 ON hyperliquid_execution_orders (
   execution_network,
@@ -44,6 +44,26 @@ WHERE exchange_order_id IS NOT NULL
 )
 
 
+def _index_is_valid(index_name: str) -> bool | None:
+    value = (
+        op.get_bind()
+        .execute(
+            sa.text(
+                """
+                SELECT COALESCE(indisvalid AND indisready, false)
+                FROM pg_index
+                WHERE indexrelid = to_regclass(:index_name)
+                """
+            ),
+            {"index_name": index_name},
+        )
+        .scalar_one_or_none()
+    )
+    if value is None:
+        return None
+    return bool(value)
+
+
 def upgrade() -> None:
     bind = op.get_bind()
     if getattr(getattr(bind, "dialect", None), "name", "") != "postgresql":
@@ -51,8 +71,20 @@ def upgrade() -> None:
     if not inspect(bind).has_table(TABLE_NAME):
         return
     with op.get_context().autocommit_block():
-        for _index_name, create_sql in INDEXES:
-            op.execute(sa.text(create_sql))
+        op.execute(sa.text("SET lock_timeout = '5s'"))
+        op.execute(sa.text("SET statement_timeout = '30min'"))
+        try:
+            for index_name, create_sql in INDEXES:
+                # A cancelled concurrent build leaves a named but invalid index.
+                # Rebuild unconditionally so an invalid or mismatched definition
+                # cannot make IF NOT EXISTS silently stamp this migration.
+                op.execute(sa.text(f"DROP INDEX CONCURRENTLY IF EXISTS {index_name}"))
+                op.execute(sa.text(create_sql))
+                if _index_is_valid(index_name) is not True:
+                    raise RuntimeError(f"{index_name} was not created as a valid index")
+        finally:
+            op.execute(sa.text("RESET statement_timeout"))
+            op.execute(sa.text("RESET lock_timeout"))
 
 
 def downgrade() -> None:

--- a/services/torghut/tests/test_hyperliquid_execution_order_read_indexes_migration.py
+++ b/services/torghut/tests/test_hyperliquid_execution_order_read_indexes_migration.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from tests.migration_testing import load_migration_module
+
+
+MIGRATION_FILENAME = "0083_hyperliquid_execution_order_read_indexes.py"
+
+
+class TestHyperliquidExecutionOrderReadIndexesMigration(TestCase):
+    def test_revision_follows_current_head(self) -> None:
+        module = load_migration_module(MIGRATION_FILENAME)
+
+        self.assertEqual(module.revision, "0083_hyperliquid_order_reads")
+        self.assertEqual(module.down_revision, "0082_order_lineage_runs")
+
+    def test_index_contract_matches_measured_queries(self) -> None:
+        module = load_migration_module(MIGRATION_FILENAME)
+        sql = "\n".join(create_sql for _index_name, create_sql in module.INDEXES)
+
+        self.assertEqual(len(module.INDEXES), 2)
+        self.assertIn("(execution_network, created_at DESC)", sql)
+        self.assertIn("exchange_order_id", sql)
+        self.assertIn("WHERE exchange_order_id IS NOT NULL", sql)
+        for index_name, create_sql in module.INDEXES:
+            self.assertLessEqual(len(index_name), 63, index_name)
+            self.assertIn("CREATE INDEX CONCURRENTLY IF NOT EXISTS", create_sql)
+
+    def test_upgrade_creates_indexes_concurrently(self) -> None:
+        module = load_migration_module(MIGRATION_FILENAME)
+        bind = MagicMock()
+        bind.dialect.name = "postgresql"
+        inspector = MagicMock()
+        inspector.has_table.return_value = True
+
+        with (
+            patch.object(module.op, "get_bind", return_value=bind),
+            patch.object(module.op, "get_context") as get_context,
+            patch.object(module, "inspect", return_value=inspector),
+            patch.object(module.op, "execute") as execute,
+        ):
+            module.upgrade()
+
+        inspector.has_table.assert_called_once_with(module.TABLE_NAME)
+        get_context.return_value.autocommit_block.assert_called_once_with()
+        self.assertEqual(execute.call_count, 2)
+
+    def test_downgrade_drops_indexes_concurrently(self) -> None:
+        module = load_migration_module(MIGRATION_FILENAME)
+        bind = MagicMock()
+        bind.dialect.name = "postgresql"
+        inspector = MagicMock()
+        inspector.has_table.return_value = True
+
+        with (
+            patch.object(module.op, "get_bind", return_value=bind),
+            patch.object(module.op, "get_context") as get_context,
+            patch.object(module, "inspect", return_value=inspector),
+            patch.object(module.op, "execute") as execute,
+        ):
+            module.downgrade()
+
+        get_context.return_value.autocommit_block.assert_called_once_with()
+        executed_sql = "\n".join(str(call.args[0]) for call in execute.call_args_list)
+        self.assertEqual(execute.call_count, 2)
+        self.assertIn("DROP INDEX CONCURRENTLY IF EXISTS", executed_sql)

--- a/services/torghut/tests/test_hyperliquid_execution_order_read_indexes_migration.py
+++ b/services/torghut/tests/test_hyperliquid_execution_order_read_indexes_migration.py
@@ -1,12 +1,20 @@
 from __future__ import annotations
 
+from contextlib import nullcontext
+from types import SimpleNamespace
 from unittest import TestCase
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 from tests.migration_testing import load_migration_module
 
 
 MIGRATION_FILENAME = "0083_hyperliquid_execution_order_read_indexes.py"
+
+
+def _postgres_bind() -> MagicMock:
+    bind = MagicMock()
+    bind.dialect = SimpleNamespace(name="postgresql")
+    return bind
 
 
 class TestHyperliquidExecutionOrderReadIndexesMigration(TestCase):
@@ -26,31 +34,88 @@ class TestHyperliquidExecutionOrderReadIndexesMigration(TestCase):
         self.assertIn("WHERE exchange_order_id IS NOT NULL", sql)
         for index_name, create_sql in module.INDEXES:
             self.assertLessEqual(len(index_name), 63, index_name)
-            self.assertIn("CREATE INDEX CONCURRENTLY IF NOT EXISTS", create_sql)
+            self.assertIn("CREATE INDEX CONCURRENTLY", create_sql)
+            self.assertNotIn("IF NOT EXISTS", create_sql)
 
-    def test_upgrade_creates_indexes_concurrently(self) -> None:
+    def test_upgrade_rebuilds_and_validates_indexes_concurrently(self) -> None:
         module = load_migration_module(MIGRATION_FILENAME)
-        bind = MagicMock()
-        bind.dialect.name = "postgresql"
+        bind = _postgres_bind()
         inspector = MagicMock()
         inspector.has_table.return_value = True
+        context = MagicMock()
+        context.autocommit_block.return_value = nullcontext()
 
         with (
             patch.object(module.op, "get_bind", return_value=bind),
-            patch.object(module.op, "get_context") as get_context,
+            patch.object(module.op, "get_context", return_value=context),
             patch.object(module, "inspect", return_value=inspector),
             patch.object(module.op, "execute") as execute,
+            patch.object(
+                module, "_index_is_valid", side_effect=(True, True)
+            ) as is_valid,
         ):
             module.upgrade()
 
         inspector.has_table.assert_called_once_with(module.TABLE_NAME)
-        get_context.return_value.autocommit_block.assert_called_once_with()
-        self.assertEqual(execute.call_count, 2)
+        context.autocommit_block.assert_called_once_with()
+        is_valid.assert_has_calls(
+            [
+                call("ix_hyperliquid_execution_orders_network_created"),
+                call("ix_hyperliquid_execution_orders_network_exchange_created"),
+            ]
+        )
+        executed_sql = [str(call.args[0]) for call in execute.call_args_list]
+        self.assertEqual(
+            sum(sql.startswith("DROP INDEX CONCURRENTLY") for sql in executed_sql), 2
+        )
+        self.assertEqual(
+            sum("CREATE INDEX CONCURRENTLY" in sql for sql in executed_sql), 2
+        )
+        self.assertIn("SET lock_timeout = '5s'", executed_sql)
+        self.assertIn("SET statement_timeout = '30min'", executed_sql)
+        self.assertIn("RESET statement_timeout", executed_sql)
+        self.assertIn("RESET lock_timeout", executed_sql)
+
+    def test_upgrade_rejects_invalid_concurrent_index(self) -> None:
+        module = load_migration_module(MIGRATION_FILENAME)
+        bind = _postgres_bind()
+        inspector = MagicMock()
+        inspector.has_table.return_value = True
+        context = MagicMock()
+        context.autocommit_block.return_value = nullcontext()
+
+        with (
+            patch.object(module.op, "get_bind", return_value=bind),
+            patch.object(module.op, "get_context", return_value=context),
+            patch.object(module, "inspect", return_value=inspector),
+            patch.object(module.op, "execute") as execute,
+            patch.object(module, "_index_is_valid", return_value=False),
+            self.assertRaisesRegex(RuntimeError, "was not created as a valid index"),
+        ):
+            module.upgrade()
+
+        executed_sql = [str(call.args[0]) for call in execute.call_args_list]
+        self.assertTrue(
+            any(sql.startswith("DROP INDEX CONCURRENTLY") for sql in executed_sql)
+        )
+        self.assertIn("RESET statement_timeout", executed_sql)
+        self.assertIn("RESET lock_timeout", executed_sql)
+
+    def test_index_validation_requires_ready_and_valid_catalog_state(self) -> None:
+        module = load_migration_module(MIGRATION_FILENAME)
+        bind = _postgres_bind()
+        bind.execute.return_value.scalar_one_or_none.return_value = False
+
+        with patch.object(module.op, "get_bind", return_value=bind):
+            self.assertFalse(module._index_is_valid("ix_example"))
+
+        sql = str(bind.execute.call_args.args[0])
+        self.assertIn("indisvalid AND indisready", sql)
+        self.assertEqual(bind.execute.call_args.args[1], {"index_name": "ix_example"})
 
     def test_downgrade_drops_indexes_concurrently(self) -> None:
         module = load_migration_module(MIGRATION_FILENAME)
-        bind = MagicMock()
-        bind.dialect.name = "postgresql"
+        bind = _postgres_bind()
         inspector = MagicMock()
         inspector.has_table.return_value = True
 

--- a/services/torghut/tests/test_strategy_capital_authority_migration_compat.py
+++ b/services/torghut/tests/test_strategy_capital_authority_migration_compat.py
@@ -28,7 +28,7 @@ def test_migration_graph_has_one_merged_head_and_knows_the_released_revision() -
     config = AlembicConfig(str(SERVICE_ROOT / "alembic.ini"))
     scripts = ScriptDirectory.from_config(config)
 
-    assert scripts.get_heads() == ["0082_order_lineage_runs"]
+    assert scripts.get_heads() == ["0083_hyperliquid_order_reads"]
     assert scripts.get_revision("0063_strategy_capital_authority") is not None
     assert scripts.get_revision("0064_strategy_capital_authority") is not None
     assert scripts.get_revision("0065_strategy_capital_compat") is not None
@@ -49,3 +49,4 @@ def test_migration_graph_has_one_merged_head_and_knows_the_released_revision() -
     assert scripts.get_revision("0080_broker_econ_recon_freshness") is not None
     assert scripts.get_revision("0081_order_lineage_receipts") is not None
     assert scripts.get_revision("0082_order_lineage_runs") is not None
+    assert scripts.get_revision("0083_hyperliquid_order_reads") is not None


### PR DESCRIPTION
## Summary

- add two concurrent B-tree indexes proven against exact Hyperliquid order read paths on an isolated CNPG restore
- record standby backup, switchover, nine-minute restore, immutable fingerprint parity, and measured query plans
- advance the single Alembic head and cover migration creation, rollback, naming, and query-shape contracts

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff check migrations/versions/0083_hyperliquid_execution_order_read_indexes.py tests/test_hyperliquid_execution_order_read_indexes_migration.py tests/test_strategy_capital_authority_migration_compat.py`
- `uv run --frozen ruff format --check migrations/versions/0083_hyperliquid_execution_order_read_indexes.py tests/test_hyperliquid_execution_order_read_indexes_migration.py tests/test_strategy_capital_authority_migration_compat.py`
- `uv run --frozen pytest -q tests/test_*migration*.py` (122 passed)
- `uv run --frozen pytest -q tests/hyperliquid_execution` (165 passed, one existing DSN-gated test skipped)
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen alembic -c alembic.ini heads` (`0083_hyperliquid_order_reads`)
- `bunx oxfmt --check docs/torghut/profitability/cnpg-evidence-storage-recovery.md`
- restored `Backup/torghut-db-ha-proof-20260718` into an isolated CNPG cluster; system ID, checksums, schema, Alembic head, and five immutable table fingerprints matched; ephemeral resources were removed afterward
- ran `EXPLAIN (ANALYZE, BUFFERS)` before and after the candidate indexes on the restored copy; affected reads fell from 59/283/283 buffers to 3/2/3
- repeated the plan benchmark on a disposable 1,000,000-row PostgreSQL 17 fixture (~233x live volume); hot reads fell from 341/114/109 ms to 0.024/1.694/0.021 ms; all fixture resources were removed

## Breaking Changes

None. The migration builds both indexes concurrently and does not change table data or query semantics.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
