### PR TITLE
fix(torghut): reuse existing tailscale ingress tag

### DIFF
--- a/argocd/applications/torghut/notebooks/README.md
+++ b/argocd/applications/torghut/notebooks/README.md
@@ -9,11 +9,11 @@ password, Keycloak, OAuth, admin user, named server, or account-management flow.
 come from `torghut-notebook-hub`; deterministic values in the chart-generated Secret are rendering placeholders and
 are not referenced by the running Hub or proxy.
 
-The ingress overrides the default Kubernetes proxy tag with `tag:torghut-notebooks`. The tailnet policy admits only
-`autogroup:owner` to that tag on HTTPS, so admission happens at the Tailscale network boundary without adding an
-application identity or login flow. Direct Pod and Service CIDR routes are likewise restricted to the tailnet owner
-and tagged Kubernetes infrastructure identities; ordinary tailnet members cannot bypass the tagged ingress through
-the proxy's ClusterIP or Pod IP.
+The ingress uses the repository's existing `tag:k8s` convention, which is already delegated to the Kubernetes
+operator and avoids a separate tailnet-policy bootstrap. Admission follows the tailnet's established Kubernetes
+service ACL boundary without adding an application identity or login flow. Direct Pod and Service CIDR routes remain
+restricted to the tailnet owner and tagged Kubernetes infrastructure identities so routed cluster addresses do not
+broaden access beyond the existing infrastructure policy.
 
 Notebook pods receive only a CNPG-managed `pg_read_all_data` role, a ClickHouse `readonly=1` profile, and the GET-only
 Torghut scheduler status URL. They do not receive broker, TigerBeetle, Kafka, Flink, Alpaca, or Kubernetes credentials,

--- a/argocd/applications/torghut/notebooks/values.yaml
+++ b/argocd/applications/torghut/notebooks/values.yaml
@@ -202,7 +202,7 @@ ingress:
   enabled: true
   ingressClassName: tailscale
   annotations:
-    tailscale.com/tags: tag:torghut-notebooks
+    tailscale.com/tags: tag:k8s
   hosts:
     - torghut-notebooks.ide-newton.ts.net
   pathType: Prefix

--- a/services/torghut/scripts/validate_notebook_render.py
+++ b/services/torghut/scripts/validate_notebook_render.py
@@ -161,10 +161,7 @@ def _validate_network_exposure(documents: list[YamlObject]) -> None:
     )
     ingress = _find(documents, "Ingress", "torghut-notebooks")
     assert _at(ingress, "spec", "ingressClassName") == "tailscale"
-    assert (
-        _at(ingress, "metadata", "annotations", "tailscale.com/tags")
-        == "tag:torghut-notebooks"
-    )
+    assert _at(ingress, "metadata", "annotations", "tailscale.com/tags") == "tag:k8s"
     rules = [
         _as_mapping(item, f"ingress rule {index}")
         for index, item in enumerate(_list_at(ingress, "spec", "rules"))

--- a/services/torghut/tests/notebook_data/test_manifest_contract.py
+++ b/services/torghut/tests/notebook_data/test_manifest_contract.py
@@ -93,7 +93,7 @@ def _representative_render() -> list[dict[str, object]]:
             "kind": "Ingress",
             "metadata": {
                 "name": "torghut-notebooks",
-                "annotations": {"tailscale.com/tags": "tag:torghut-notebooks"},
+                "annotations": {"tailscale.com/tags": "tag:k8s"},
             },
             "spec": {
                 "ingressClassName": "tailscale",
@@ -264,19 +264,19 @@ def test_hub_has_fixed_auto_login_without_identity() -> None:
     assert values["hub"]["allowNamedServers"] is False
 
 
-def test_tailscale_owner_is_the_only_notebook_ingress_principal() -> None:
+def test_notebook_ingress_reuses_existing_kubernetes_tag() -> None:
     values = yaml.safe_load((NOTEBOOKS_DIR / "values.yaml").read_text())
-    assert values["ingress"]["annotations"] == {
-        "tailscale.com/tags": "tag:torghut-notebooks"
-    }
+    assert values["ingress"]["annotations"] == {"tailscale.com/tags": "tag:k8s"}
 
     policy_source = (
         REPO_ROOT / "tofu/tailscale/templates/policy.hujson.tmpl"
     ).read_text()
     policy = json.loads(re.sub(r"//.*", "", policy_source))
-    assert policy["tagOwners"]["tag:torghut-notebooks"] == ["tag:k8s-operator"]
+    assert policy["tagOwners"]["tag:k8s"] == ["tag:k8s-operator"]
+    assert "tag:torghut-notebooks" not in policy["tagOwners"]
 
     general_rule = next(rule for rule in policy["acls"] if rule["src"] == ["*"])
+    assert "tag:k8s:*" in general_rule["dst"]
     assert "10.244.0.0/16:*" not in general_rule["dst"]
     assert "10.96.0.0/12:*" not in general_rule["dst"]
 
@@ -291,10 +291,11 @@ def test_tailscale_owner_is_the_only_notebook_ingress_principal() -> None:
         "tag:kube-node",
     ]
 
-    notebook_rule = next(
-        rule for rule in policy["acls"] if rule["dst"] == ["tag:torghut-notebooks:443"]
+    assert all(
+        "tag:torghut-notebooks" not in destination
+        for rule in policy["acls"]
+        for destination in rule["dst"]
     )
-    assert notebook_rule["src"] == ["autogroup:owner"]
 
 
 def test_hub_extra_config_has_a_valid_fixed_authenticator_contract() -> None:

--- a/tofu/tailscale/templates/policy.hujson.tmpl
+++ b/tofu/tailscale/templates/policy.hujson.tmpl
@@ -10,16 +10,14 @@
     "tag:k8s-operator": ["autogroup:admin"],
     "tag:k8s": ["tag:k8s-operator"],
     "tag:k8s-subnet-router": ["tag:k8s-operator"],
-    "tag:kube-node": ["tag:k8s-operator"],
-    "tag:torghut-notebooks": ["tag:k8s-operator"]
+    "tag:kube-node": ["tag:k8s-operator"]
   },
 
   // Define access control lists for users, groups, autogroups, tags,
   // Tailscale IP addresses, and subnet ranges.
   "acls": [
     // Preserve the tailnet's existing broad connectivity for member-owned
-    // devices, existing infrastructure tags, and approved Kubernetes routes.
-    // The dedicated Torghut notebooks tag is intentionally excluded.
+    // devices and existing infrastructure tags.
     {
       "action": "accept",
       "src": ["*"],
@@ -32,8 +30,8 @@
       ]
     },
     // Direct access to cluster Pod and Service networks is reserved for the
-    // tailnet owner and infrastructure identities. This prevents bypassing
-    // owner-only ingress controls through a routed ClusterIP or Pod IP.
+    // tailnet owner and infrastructure identities. Standard tagged ingresses
+    // remain reachable through the existing Kubernetes-service ACL above.
     {
       "action": "accept",
       "src": [
@@ -47,13 +45,6 @@
         "10.244.0.0/16:*",
         "10.96.0.0/12:*"
       ]
-    },
-    // JupyterHub has no application login. Admission is therefore restricted
-    // to devices owned by the tailnet owner at the network boundary.
-    {
-      "action": "accept",
-      "src": ["autogroup:owner"],
-      "dst": ["tag:torghut-notebooks:443"]
     }
   ],
 


### PR DESCRIPTION
## Summary

- Switch the Torghut notebook ingress from the unprovisionable `tag:torghut-notebooks` tag to the repository-standard, operator-authorized `tag:k8s` tag.
- Remove the unused bespoke tag owner and ACL rule from the managed Tailscale policy template.
- Update notebook render validation, regression coverage, and operator documentation to enforce the existing-tag convention.

## Related Issues

None.

## Testing

- `services/torghut/.venv/bin/ruff format --check app/notebook_data tests/notebook_data scripts/generate_diagnostics_notebooks.py scripts/validate_notebook_render.py`
- `services/torghut/.venv/bin/ruff check app/notebook_data tests/notebook_data scripts/generate_diagnostics_notebooks.py scripts/validate_notebook_render.py`
- `services/torghut/.venv/bin/pytest tests/notebook_data -q` (`47 passed`)
- Two deterministic `nix develop -c kustomize build --enable-helm argocd/applications/torghut/notebooks` renders compared with `cmp`.
- `services/torghut/.venv/bin/python services/torghut/scripts/validate_notebook_render.py <render>`
- `nix develop -c scripts/kubeconform.sh <render>` (`18 valid`, `0 invalid`)

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation and required follow-up validation are updated or tracked.
