### PR TITLE
fix(torghut): align rollout contract with economic policy

### DIFF
--- a/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
@@ -56,7 +56,7 @@ const tradingStatus = (gate: typeof activeGate | typeof marketClosedGate = activ
     buying_power_reserve_bps: 1_000,
     daily_loss_limit: 0.01,
     drawdown_limit: 0.05,
-    gross_limit: 4,
+    gross_limit: 1,
     net_limit: 0.5,
     symbol_limit: 0.5,
   },
@@ -151,7 +151,7 @@ describe('Torghut post-deploy evidence', () => {
     expect(result.simulationContract).toBe('simulation_active')
     expect(result.apiReadyzStatusCode).toBe(200)
     expect(result.schedulerReadyzStatusCode).toBe(200)
-    expect(result.summaryLines.join('\n')).toContain('4x gross')
+    expect(result.summaryLines.join('\n')).toContain('1x gross')
     expect(result.summaryLines.join('\n')).toContain('Simulation runtime: `simulation_active`')
   })
 
@@ -239,10 +239,10 @@ describe('Torghut post-deploy evidence', () => {
 
   it('rejects a drifted capital limit', () => {
     const status = tradingStatus()
-    status.capital_controls.gross_limit = 1
+    status.capital_controls.gross_limit = 4
 
     expect(() => validatePostDeployEvidence(activeEvidence({ tradingStatus: status }))).toThrow(
-      'capital_controls.gross_limit must be 4',
+      'capital_controls.gross_limit must be 1',
     )
   })
 

--- a/packages/scripts/src/torghut/post-deploy-evidence.ts
+++ b/packages/scripts/src/torghut/post-deploy-evidence.ts
@@ -38,7 +38,7 @@ const EXPECTED_CAPITAL_LIMITS = {
   buying_power_reserve_bps: 1_000,
   daily_loss_limit: 0.01,
   drawdown_limit: 0.05,
-  gross_limit: 4,
+  gross_limit: 1,
   net_limit: 0.5,
   symbol_limit: 0.5,
 } as const
@@ -369,7 +369,7 @@ export const validatePostDeployEvidence = (input: PostDeployEvidenceInput): Post
       '- API readiness: `process-local` (external scheduler owner)',
       `- Live gate: \`${statusGate.reason}\``,
       `- Execution route: \`${statusGate.route}\``,
-      '- Capital limits: `4x gross`, `0.5x net`, `0.5x symbol`, `10% buying-power reserve`',
+      '- Capital limits: `1x gross`, `0.5x net`, `0.5x symbol`, `10% buying-power reserve`',
       '- TigerBeetle reconciliation: `current`',
       simulationSummaryLine(simulationContract),
     ],


### PR DESCRIPTION
## Summary

- Align the post-deploy gross-exposure assertion with the promoted 1x economic policy.
- Report the enforced 1x gross limit in rollout evidence.
- Keep a regression proving the retired 4x limit is rejected as drift.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/post-deploy-evidence.ts packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts`
- `bun run --cwd packages/scripts lint:oxlint`
- `bun run --cwd packages/scripts lint:oxlint:type`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] The executable rollout summary is updated; no separate documentation change is required.