### PR TITLE
chore(torghut): promote image sha-6681473258789a8cf62237817cf307767636c40e

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -54,7 +54,7 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: 5f884334e20d6a464dcca808dac064d00227270e
+              value: 6681473258789a8cf62237817cf307767636c40e
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:78660b3db72dd7479aeb6b4be29bb2818352f122dbf461f4c6c25014f54798d9
             - name: PYTHONPATH

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -46,7 +46,7 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: 5f884334e20d6a464dcca808dac064d00227270e
+              value: 6681473258789a8cf62237817cf307767636c40e
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:78660b3db72dd7479aeb6b4be29bb2818352f122dbf461f4c6c25014f54798d9
             - name: DB_DSN

--- a/argocd/applications/torghut-options/archive/deployment.yaml
+++ b/argocd/applications/torghut-options/archive/deployment.yaml
@@ -100,9 +100,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2243-g5f884334e
+              value: v0.596.0-2245-g668147325
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 5f884334e20d6a464dcca808dac064d00227270e
+              value: 6681473258789a8cf62237817cf307767636c40e
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -110,9 +110,9 @@ spec:
                   name: torghut-ws-config
                   key: SYMBOLS_ALLOWLIST
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2243-g5f884334e
+              value: v0.596.0-2245-g668147325
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 5f884334e20d6a464dcca808dac064d00227270e
+              value: 6681473258789a8cf62237817cf307767636c40e
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -106,9 +106,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2243-g5f884334e
+              value: v0.596.0-2245-g668147325
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 5f884334e20d6a464dcca808dac064d00227270e
+              value: 6681473258789a8cf62237817cf307767636c40e
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/broker-economic-ledger-reconciliation-cronjob.yaml
+++ b/argocd/applications/torghut/broker-economic-ledger-reconciliation-cronjob.yaml
@@ -92,9 +92,9 @@ spec:
                 - name: TRADING_ACCOUNT_LABEL
                   value: PA3SX7FYNUTF
                 - name: TORGHUT_VERSION
-                  value: v0.596.0-2243-g5f884334e
+                  value: v0.596.0-2245-g668147325
                 - name: TORGHUT_COMMIT
-                  value: 5f884334e20d6a464dcca808dac064d00227270e
+                  value: 6681473258789a8cf62237817cf307767636c40e
                 - name: TORGHUT_IMAGE_DIGEST
                   value: sha256:78660b3db72dd7479aeb6b4be29bb2818352f122dbf461f4c6c25014f54798d9
                 - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-18T18:19:55Z"
+        client.knative.dev/updateTimestamp: "2026-07-18T18:50:48Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -528,9 +528,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2243-g5f884334e
+              value: v0.596.0-2245-g668147325
             - name: TORGHUT_COMMIT
-              value: 5f884334e20d6a464dcca808dac064d00227270e
+              value: 6681473258789a8cf62237817cf307767636c40e
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:78660b3db72dd7479aeb6b4be29bb2818352f122dbf461f4c6c25014f54798d9
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-18T18:19:55Z"
+        client.knative.dev/updateTimestamp: "2026-07-18T18:50:48Z"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
     spec:
@@ -453,9 +453,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2243-g5f884334e
+              value: v0.596.0-2245-g668147325
             - name: TORGHUT_COMMIT
-              value: 5f884334e20d6a464dcca808dac064d00227270e
+              value: 6681473258789a8cf62237817cf307767636c40e
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:78660b3db72dd7479aeb6b4be29bb2818352f122dbf461f4c6c25014f54798d9
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/order-lineage-reconciliation-cronjob.yaml
+++ b/argocd/applications/torghut/order-lineage-reconciliation-cronjob.yaml
@@ -88,9 +88,9 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_VERSION
-                  value: v0.596.0-2243-g5f884334e
+                  value: v0.596.0-2245-g668147325
                 - name: TORGHUT_COMMIT
-                  value: 5f884334e20d6a464dcca808dac064d00227270e
+                  value: 6681473258789a8cf62237817cf307767636c40e
                 - name: TORGHUT_IMAGE_DIGEST
                   value: sha256:78660b3db72dd7479aeb6b4be29bb2818352f122dbf461f4c6c25014f54798d9
                 - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -470,9 +470,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2243-g5f884334e
+              value: v0.596.0-2245-g668147325
             - name: TORGHUT_COMMIT
-              value: 5f884334e20d6a464dcca808dac064d00227270e
+              value: 6681473258789a8cf62237817cf307767636c40e
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:78660b3db72dd7479aeb6b4be29bb2818352f122dbf461f4c6c25014f54798d9
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `6681473258789a8cf62237817cf307767636c40e`
- Image tag: `sha-6681473258789a8cf62237817cf307767636c40e`
- Image digest: `sha256:78660b3db72dd7479aeb6b4be29bb2818352f122dbf461f4c6c25014f54798d9`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher