### PR TITLE
fix(torghut): drain legacy TigerBeetle stable refs

### DIFF
--- a/services/torghut/app/trading/tigerbeetle_journal/ledger_journal.py
+++ b/services/torghut/app/trading/tigerbeetle_journal/ledger_journal.py
@@ -8,7 +8,6 @@ from decimal import Decimal
 from types import TracebackType
 from typing import Any, Self, cast
 
-from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -38,7 +37,6 @@ from .journal_payloads import (
     SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
     PreparedTigerBeetleTransferWrite,
     StableRefPayloadInput,
-    nested_mapping,
     result_statuses_by_index,
     tigerbeetle_stable_ref_payload,
     transfer_attr,
@@ -47,6 +45,10 @@ from .source_transfer_plans import (
     build_execution_tca_metric_transfer_plan,
     build_execution_transfer_plan,
     build_runtime_ledger_bucket_transfer_plan,
+)
+from .stable_ref_backfill import (
+    backfill_stable_ref_payloads as backfill_stable_ref_payloads_in_postgres,
+    count_missing_stable_ref_payloads as count_missing_stable_ref_payloads_in_postgres,
 )
 from .transfer_refs import (
     build_order_event_transfer_plan,
@@ -80,6 +82,10 @@ class TigerBeetleLedgerJournal:
         self._settings = settings_obj
         self._client = client
         self._owns_client = client is None
+
+    @property
+    def cluster_id(self) -> int:
+        return self._settings.tigerbeetle_cluster_id
 
     def __enter__(self) -> Self:
         return self
@@ -367,64 +373,24 @@ class TigerBeetleLedgerJournal:
             or not self._settings.tigerbeetle_journal_enabled
         ):
             return {"selected": 0, "updated": 0, "skipped": 0}
-
-        refs = (
-            session.execute(
-                select(TigerBeetleTransferRef)
-                .where(
-                    TigerBeetleTransferRef.cluster_id
-                    == self._settings.tigerbeetle_cluster_id,
-                    TigerBeetleTransferRef.source_type.is_not(None),
-                    TigerBeetleTransferRef.source_id.is_not(None),
-                )
-                .order_by(TigerBeetleTransferRef.created_at.desc())
-                .limit(max(1, int(limit)))
-            )
-            .scalars()
-            .all()
+        return backfill_stable_ref_payloads_in_postgres(
+            session,
+            cluster_id=self.cluster_id,
+            limit=limit,
         )
-        updated = 0
-        skipped = 0
-        for ref in refs:
-            existing_payload = nested_mapping(ref.payload_json)
-            if isinstance(existing_payload.get("stable_ref"), Mapping):
-                skipped += 1
-                continue
-            source_type = str(ref.source_type or "").strip()
-            source_id = str(ref.source_id or "").strip()
-            if not source_type or not source_id:
-                skipped += 1
-                continue
-            transfer_spec = TigerBeetleTransferSpec(
-                transfer_id=int(ref.transfer_id),
-                transfer_kind=ref.transfer_kind,
-                debit_account_id=0,
-                credit_account_id=0,
-                amount=int(ref.amount),
-                ledger=ref.ledger,
-                code=ref.code,
-            )
-            ref.payload_json = coerce_json_payload(
-                {
-                    **existing_payload,
-                    **tigerbeetle_stable_ref_payload(
-                        StableRefPayloadInput(
-                            cluster_id=ref.cluster_id,
-                            account_specs=(),
-                            transfer_spec=transfer_spec,
-                            source_type=source_type,
-                            source_id=source_id,
-                            payload_json=existing_payload,
-                            event_fingerprint=ref.event_fingerprint,
-                        )
-                    ),
-                }
-            )
-            session.add(ref)
-            updated += 1
-        if updated:
-            session.flush()
-        return {"selected": len(refs), "updated": updated, "skipped": skipped}
+
+    def count_missing_stable_ref_payloads(self, session: Session) -> int:
+        """Count repairable PostgreSQL transfer refs without a stable-ref object."""
+
+        if (
+            not self._settings.tigerbeetle_enabled
+            or not self._settings.tigerbeetle_journal_enabled
+        ):
+            return 0
+        return count_missing_stable_ref_payloads_in_postgres(
+            session,
+            cluster_id=self.cluster_id,
+        )
 
     def journal_order_events(
         self,

--- a/services/torghut/app/trading/tigerbeetle_journal/stable_ref_backfill.py
+++ b/services/torghut/app/trading/tigerbeetle_journal/stable_ref_backfill.py
@@ -1,0 +1,276 @@
+"""Bounded, deterministic repair of legacy TigerBeetle stable-ref payloads."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import cast
+
+from sqlalchemy import func, or_, select
+from sqlalchemy.orm import Session
+from sqlalchemy.sql.elements import ColumnElement
+
+from app.models import (
+    TigerBeetleAccountRef,
+    TigerBeetleTransferRef,
+    coerce_json_payload,
+)
+from app.trading.tigerbeetle_ids import u128_decimal
+from app.trading.tigerbeetle_ledger_model import (
+    TigerBeetleAccountSpec,
+    TigerBeetleTransferSpec,
+)
+
+from .journal_payloads import (
+    StableRefPayloadInput,
+    nested_mapping,
+    tigerbeetle_stable_ref_payload,
+)
+
+
+def _missing_stable_ref_clause(session: Session) -> ColumnElement[bool]:
+    dialect_name = session.get_bind().dialect.name
+    if dialect_name == "postgresql":
+        stable_ref_type = func.jsonb_typeof(
+            TigerBeetleTransferRef.payload_json["stable_ref"]
+        )
+    elif dialect_name == "sqlite":
+        stable_ref_type = func.json_type(
+            TigerBeetleTransferRef.payload_json,
+            "$.stable_ref",
+        )
+    else:
+        raise RuntimeError(
+            f"tigerbeetle_stable_ref_backfill_dialect_unsupported:{dialect_name}"
+        )
+    return or_(stable_ref_type.is_(None), stable_ref_type != "object")
+
+
+def _required_payload_account_id(
+    payload: Mapping[str, object],
+    key: str,
+) -> str:
+    value = payload.get(key)
+    if value is None or not str(value).strip():
+        raise RuntimeError(f"tigerbeetle_stable_ref_backfill_{key}_missing")
+    try:
+        return u128_decimal(int(str(value).strip()))
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError(f"tigerbeetle_stable_ref_backfill_{key}_invalid") from exc
+
+
+def _payload_account_id_texts(payload: Mapping[str, object]) -> tuple[str, ...]:
+    values: list[object] = [
+        _required_payload_account_id(payload, "debit_account_id"),
+        _required_payload_account_id(payload, "credit_account_id"),
+    ]
+    raw_account_ids = payload.get("account_ids")
+    if isinstance(raw_account_ids, Sequence) and not isinstance(
+        raw_account_ids,
+        (str, bytes, bytearray),
+    ):
+        values.extend(cast(Sequence[object], raw_account_ids))
+
+    account_ids: list[str] = []
+    for value in values:
+        if value is None:
+            continue
+        try:
+            account_id = u128_decimal(int(str(value).strip()))
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError(
+                "tigerbeetle_stable_ref_backfill_account_id_invalid"
+            ) from exc
+        if account_id not in account_ids:
+            account_ids.append(account_id)
+    return tuple(sorted(account_ids))
+
+
+def _repairable_ref_predicates(
+    session: Session,
+    *,
+    cluster_id: int,
+) -> tuple[ColumnElement[bool], ...]:
+    return (
+        TigerBeetleTransferRef.cluster_id == cluster_id,
+        TigerBeetleTransferRef.source_type.is_not(None),
+        TigerBeetleTransferRef.source_id.is_not(None),
+        func.length(func.trim(TigerBeetleTransferRef.source_type)) > 0,
+        func.length(func.trim(TigerBeetleTransferRef.source_id)) > 0,
+        _missing_stable_ref_clause(session),
+    )
+
+
+def _select_missing_refs(
+    session: Session,
+    *,
+    cluster_id: int,
+    limit: int,
+) -> Sequence[TigerBeetleTransferRef]:
+    return session.scalars(
+        select(TigerBeetleTransferRef)
+        .where(*_repairable_ref_predicates(session, cluster_id=cluster_id))
+        .order_by(
+            TigerBeetleTransferRef.created_at.asc(),
+            TigerBeetleTransferRef.id.asc(),
+        )
+        .limit(max(1, int(limit)))
+        .with_for_update(skip_locked=True)
+    ).all()
+
+
+def _load_account_specs(
+    session: Session,
+    *,
+    cluster_id: int,
+    payloads: Sequence[Mapping[str, object]],
+) -> dict[str, TigerBeetleAccountSpec]:
+    account_ids = sorted(
+        {
+            account_id
+            for payload in payloads
+            for account_id in _payload_account_id_texts(payload)
+        }
+    )
+    account_refs = session.scalars(
+        select(TigerBeetleAccountRef).where(
+            TigerBeetleAccountRef.cluster_id == cluster_id,
+            TigerBeetleAccountRef.account_id.in_(account_ids),
+        )
+    ).all()
+    return {
+        account_ref.account_id: TigerBeetleAccountSpec(
+            account_id=int(account_ref.account_id),
+            account_key=account_ref.account_key,
+            ledger=account_ref.ledger,
+            code=account_ref.code,
+            account_label=account_ref.account_label,
+            symbol=account_ref.symbol,
+            strategy_id=account_ref.strategy_id,
+        )
+        for account_ref in account_refs
+    }
+
+
+def _account_specs_for_ref(
+    ref: TigerBeetleTransferRef,
+    payload: Mapping[str, object],
+    account_specs_by_id: Mapping[str, TigerBeetleAccountSpec],
+) -> tuple[TigerBeetleAccountSpec, ...]:
+    account_ids = _payload_account_id_texts(payload)
+    if any(account_id not in account_specs_by_id for account_id in account_ids):
+        raise RuntimeError("tigerbeetle_stable_ref_backfill_account_ref_missing")
+    account_specs = tuple(account_specs_by_id[account_id] for account_id in account_ids)
+    if any(spec.ledger != ref.ledger for spec in account_specs):
+        raise RuntimeError("tigerbeetle_stable_ref_backfill_account_ledger_mismatch")
+    if any(not spec.account_key.strip() for spec in account_specs):
+        raise RuntimeError("tigerbeetle_stable_ref_backfill_account_key_missing")
+    return account_specs
+
+
+def _validate_account_label(
+    payload: Mapping[str, object],
+    account_specs: Sequence[TigerBeetleAccountSpec],
+) -> None:
+    labels = [str(spec.account_label or "").strip() for spec in account_specs]
+    if not labels or any(not label for label in labels):
+        raise RuntimeError("tigerbeetle_stable_ref_backfill_account_label_missing")
+    account_labels = set(labels)
+    payload_account_label = str(payload.get("account_label") or "").strip()
+    if len(account_labels) != 1 or (
+        payload_account_label and payload_account_label not in account_labels
+    ):
+        raise RuntimeError("tigerbeetle_stable_ref_backfill_account_label_mismatch")
+
+
+def _backfill_ref(
+    session: Session,
+    ref: TigerBeetleTransferRef,
+    payload: Mapping[str, object],
+    account_specs_by_id: Mapping[str, TigerBeetleAccountSpec],
+) -> bool:
+    if isinstance(payload.get("stable_ref"), Mapping):
+        return False
+    source_type = str(ref.source_type or "").strip()
+    source_id = str(ref.source_id or "").strip()
+    if not source_type or not source_id:
+        return False
+
+    account_specs = _account_specs_for_ref(ref, payload, account_specs_by_id)
+    _validate_account_label(payload, account_specs)
+    transfer_spec = TigerBeetleTransferSpec(
+        transfer_id=int(ref.transfer_id),
+        transfer_kind=ref.transfer_kind,
+        debit_account_id=int(_required_payload_account_id(payload, "debit_account_id")),
+        credit_account_id=int(
+            _required_payload_account_id(payload, "credit_account_id")
+        ),
+        amount=int(ref.amount),
+        ledger=ref.ledger,
+        code=ref.code,
+    )
+    ref.payload_json = coerce_json_payload(
+        {
+            **payload,
+            **tigerbeetle_stable_ref_payload(
+                StableRefPayloadInput(
+                    cluster_id=ref.cluster_id,
+                    account_specs=account_specs,
+                    transfer_spec=transfer_spec,
+                    source_type=source_type,
+                    source_id=source_id,
+                    payload_json=payload,
+                    event_fingerprint=ref.event_fingerprint,
+                )
+            ),
+        }
+    )
+    session.add(ref)
+    return True
+
+
+def backfill_stable_ref_payloads(
+    session: Session,
+    *,
+    cluster_id: int,
+    limit: int,
+) -> dict[str, object]:
+    """Backfill one locked batch without contacting TigerBeetle."""
+
+    refs = _select_missing_refs(session, cluster_id=cluster_id, limit=limit)
+    payloads_by_ref_id = {ref.id: nested_mapping(ref.payload_json) for ref in refs}
+    account_specs_by_id = _load_account_specs(
+        session,
+        cluster_id=cluster_id,
+        payloads=list(payloads_by_ref_id.values()),
+    )
+    updated = sum(
+        _backfill_ref(
+            session,
+            ref,
+            payloads_by_ref_id[ref.id],
+            account_specs_by_id,
+        )
+        for ref in refs
+    )
+    if updated:
+        session.flush()
+    return {
+        "selected": len(refs),
+        "updated": updated,
+        "skipped": len(refs) - updated,
+    }
+
+
+def count_missing_stable_ref_payloads(
+    session: Session,
+    *,
+    cluster_id: int,
+) -> int:
+    """Count source-linked transfer refs without a stable-ref object."""
+
+    count = session.scalar(
+        select(func.count())
+        .select_from(TigerBeetleTransferRef)
+        .where(*_repairable_ref_predicates(session, cluster_id=cluster_id))
+    )
+    return int(count or 0)

--- a/services/torghut/app/trading/tigerbeetle_journal/stable_ref_backfill.py
+++ b/services/torghut/app/trading/tigerbeetle_journal/stable_ref_backfill.py
@@ -172,7 +172,11 @@ def _validate_account_label(
     account_specs: Sequence[TigerBeetleAccountSpec],
 ) -> None:
     labels = [str(spec.account_label or "").strip() for spec in account_specs]
-    if not labels or any(not label for label in labels):
+    if not labels:
+        raise RuntimeError("tigerbeetle_stable_ref_backfill_account_label_missing")
+    if all(not label for label in labels):
+        return
+    if any(not label for label in labels):
         raise RuntimeError("tigerbeetle_stable_ref_backfill_account_label_missing")
     account_labels = set(labels)
     payload_account_label = str(payload.get("account_label") or "").strip()

--- a/services/torghut/scripts/backfill_tigerbeetle_stable_refs.py
+++ b/services/torghut/scripts/backfill_tigerbeetle_stable_refs.py
@@ -184,7 +184,8 @@ def _print_payload(payload: Mapping[str, object], *, as_json: bool) -> None:
         f"apply={payload['apply']} complete={payload['complete']} "
         f"missing_before={payload['missing_before']} "
         f"missing_after={payload['missing_after']} "
-        f"updated={payload['postgres_rows_updated']}"
+        f"updated={payload['postgres_rows_updated']} "
+        f"would_update={payload['postgres_rows_would_update']}"
     )
 
 

--- a/services/torghut/scripts/backfill_tigerbeetle_stable_refs.py
+++ b/services/torghut/scripts/backfill_tigerbeetle_stable_refs.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Backfill deterministic TigerBeetle stable refs in bounded PostgreSQL batches."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.config import Settings
+from app.trading.tigerbeetle_journal import TigerBeetleLedgerJournal
+from app.trading.tigerbeetle_reconcile import tigerbeetle_ref_counts
+
+
+SCHEMA_VERSION = "torghut.tigerbeetle-stable-ref-backfill.v1"
+MAX_BATCH_SIZE = 5_000
+
+
+@dataclass(frozen=True)
+class _BatchSummary:
+    results: tuple[dict[str, int], ...]
+    selected_count: int
+    updated_count: int
+
+
+@dataclass(frozen=True)
+class _VerificationSummary:
+    missing_count: int
+    mismatch_count: int
+    stable_ref_count: int
+    transfer_ref_count: int
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Backfill deterministic stable-ref payloads without writing to "
+            "TigerBeetle or changing source rows."
+        )
+    )
+    parser.add_argument("--dsn-env", default="DB_DSN")
+    parser.add_argument("--batch-size", type=int, default=1_000)
+    parser.add_argument("--max-batches", type=int, default=25)
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Commit each bounded PostgreSQL batch; the default is a rolled-back preview.",
+    )
+    parser.add_argument(
+        "--require-complete",
+        action="store_true",
+        help="Exit nonzero unless the full stable-ref scan has zero missing or mismatched refs.",
+    )
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+    if not 1 <= int(args.batch_size) <= MAX_BATCH_SIZE:
+        parser.error(f"--batch-size must be between 1 and {MAX_BATCH_SIZE}")
+    if not 1 <= int(args.max_batches) <= 1_000:
+        parser.error("--max-batches must be between 1 and 1000")
+    if bool(args.require_complete) and not bool(args.apply):
+        parser.error("--require-complete requires --apply")
+    return args
+
+
+def _result_int(result: Mapping[str, object], key: str) -> int:
+    value = result.get(key)
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise RuntimeError(f"tigerbeetle_stable_ref_backfill_{key}_invalid")
+    return value
+
+
+def _run_batches(
+    session: Session,
+    journal: TigerBeetleLedgerJournal,
+    *,
+    batch_size: int,
+    max_batches: int,
+    apply: bool,
+) -> _BatchSummary:
+    batch_results: list[dict[str, int]] = []
+    selected_total = 0
+    updated_total = 0
+    for batch_index in range(max_batches):
+        raw_result = journal.backfill_stable_ref_payloads(session, limit=batch_size)
+        selected = _result_int(raw_result, "selected")
+        updated = _result_int(raw_result, "updated")
+        skipped = _result_int(raw_result, "skipped")
+        if skipped or selected != updated:
+            raise RuntimeError("tigerbeetle_stable_ref_backfill_batch_incomplete")
+        batch_results.append(
+            {
+                "batch": batch_index + 1,
+                "selected": selected,
+                "updated": updated,
+            }
+        )
+        selected_total += selected
+        updated_total += updated
+
+        if not apply:
+            session.rollback()
+            session.expire_all()
+            break
+        session.commit()
+        if selected < batch_size:
+            break
+    return _BatchSummary(
+        results=tuple(batch_results),
+        selected_count=selected_total,
+        updated_count=updated_total,
+    )
+
+
+def _verify_full_scan(
+    session: Session,
+    journal: TigerBeetleLedgerJournal,
+) -> _VerificationSummary:
+    verification = tigerbeetle_ref_counts(
+        session,
+        cluster_id=journal.cluster_id,
+        full_ref_scan=True,
+    )
+    return _VerificationSummary(
+        missing_count=_result_int(verification, "stable_ref_missing_count"),
+        mismatch_count=_result_int(verification, "stable_ref_mismatch_count"),
+        stable_ref_count=_result_int(verification, "stable_ref_count"),
+        transfer_ref_count=_result_int(verification, "transfer_ref_count"),
+    )
+
+
+def run_stable_ref_backfill(
+    session: Session,
+    journal: TigerBeetleLedgerJournal,
+    *,
+    batch_size: int,
+    max_batches: int,
+    apply: bool,
+) -> dict[str, object]:
+    """Preview or persist a bounded stable-ref repair and verify the full result."""
+
+    missing_before = journal.count_missing_stable_ref_payloads(session)
+    batch_summary = _run_batches(
+        session,
+        journal,
+        batch_size=batch_size,
+        max_batches=max_batches,
+        apply=apply,
+    )
+    verification = _verify_full_scan(session, journal)
+    complete = (
+        apply and verification.missing_count == 0 and verification.mismatch_count == 0
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "cluster_id": journal.cluster_id,
+        "apply": apply,
+        "complete": complete,
+        "missing_before": missing_before,
+        "missing_after": verification.missing_count,
+        "stable_ref_mismatch_count": verification.mismatch_count,
+        "stable_ref_count": verification.stable_ref_count,
+        "transfer_ref_count": verification.transfer_ref_count,
+        "selected_count": batch_summary.selected_count,
+        "postgres_rows_updated": batch_summary.updated_count if apply else 0,
+        "postgres_rows_would_update": batch_summary.updated_count if not apply else 0,
+        "tigerbeetle_writes": 0,
+        "capital_authority": False,
+        "promotion_authority": False,
+        "batches": list(batch_summary.results),
+    }
+
+
+def _print_payload(payload: Mapping[str, object], *, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+        return
+    print(
+        "TigerBeetle stable-ref backfill "
+        f"apply={payload['apply']} complete={payload['complete']} "
+        f"missing_before={payload['missing_before']} "
+        f"missing_after={payload['missing_after']} "
+        f"updated={payload['postgres_rows_updated']}"
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    dsn_env = str(args.dsn_env).strip()
+    dsn = os.environ.get(dsn_env)
+    if not dsn:
+        raise SystemExit(f"missing DSN env var: {dsn_env}")
+
+    settings_obj = Settings(
+        DB_DSN=dsn,
+        TORGHUT_TIGERBEETLE_ENABLED=True,
+        TORGHUT_TIGERBEETLE_JOURNAL_ENABLED=True,
+    )
+    engine = create_engine(settings_obj.sqlalchemy_dsn, pool_pre_ping=True, future=True)
+    session_factory = sessionmaker(
+        bind=engine,
+        autoflush=False,
+        autocommit=False,
+        expire_on_commit=False,
+        future=True,
+    )
+    try:
+        with (
+            session_factory() as session,
+            TigerBeetleLedgerJournal(settings_obj=settings_obj) as journal,
+        ):
+            payload = run_stable_ref_backfill(
+                session,
+                journal,
+                batch_size=int(args.batch_size),
+                max_batches=int(args.max_batches),
+                apply=bool(args.apply),
+            )
+    finally:
+        engine.dispose()
+
+    _print_payload(payload, as_json=bool(args.json))
+    if bool(args.require_complete) and payload["complete"] is not True:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/torghut/tests/test_backfill_tigerbeetle_stable_refs.py
+++ b/services/torghut/tests/test_backfill_tigerbeetle_stable_refs.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import io
+import os
+from contextlib import redirect_stdout
 from decimal import Decimal
 from unittest import TestCase
+from unittest.mock import patch
 
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session
@@ -18,7 +22,13 @@ from app.trading.tigerbeetle_ledger_model import (
     TRANSFER_CODE_FILL_POST,
     TRANSFER_KIND_FILL_POST,
 )
-from scripts.backfill_tigerbeetle_stable_refs import run_stable_ref_backfill
+from scripts.backfill_tigerbeetle_stable_refs import (
+    _parse_args,
+    _print_payload,
+    _result_int,
+    main,
+    run_stable_ref_backfill,
+)
 
 
 DEBIT_ACCOUNT_ID = "101"
@@ -94,6 +104,80 @@ class TestBackfillTigerBeetleStableRefs(TestCase):
 
     def tearDown(self) -> None:
         self.engine.dispose()
+
+    def test_cli_accepts_bounded_apply_configuration(self) -> None:
+        args = _parse_args(
+            [
+                "--dsn-env",
+                "CUSTOM_DSN",
+                "--batch-size",
+                "5000",
+                "--max-batches",
+                "1000",
+                "--apply",
+                "--require-complete",
+                "--json",
+            ]
+        )
+
+        self.assertEqual(args.dsn_env, "CUSTOM_DSN")
+        self.assertEqual(args.batch_size, 5_000)
+        self.assertEqual(args.max_batches, 1_000)
+        self.assertTrue(args.apply)
+        self.assertTrue(args.require_complete)
+        self.assertTrue(args.json)
+
+    def test_cli_rejects_unsafe_bounds_and_uncommitted_completion(self) -> None:
+        invalid_argv = (
+            ["--batch-size", "0"],
+            ["--batch-size", "5001"],
+            ["--max-batches", "0"],
+            ["--max-batches", "1001"],
+            ["--require-complete"],
+        )
+        for argv in invalid_argv:
+            with self.subTest(argv=argv), patch("sys.stderr", new=io.StringIO()):
+                with self.assertRaises(SystemExit) as raised:
+                    _parse_args(argv)
+                self.assertEqual(raised.exception.code, 2)
+
+    def test_result_counts_reject_bool_negative_and_non_integer_values(self) -> None:
+        for value in (True, -1, "1", None):
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "tigerbeetle_stable_ref_backfill_selected_invalid",
+                ):
+                    _result_int({"selected": value}, "selected")
+
+    def test_receipt_prints_json_and_human_formats(self) -> None:
+        payload = {
+            "apply": True,
+            "complete": True,
+            "missing_before": 3,
+            "missing_after": 0,
+            "postgres_rows_updated": 3,
+        }
+        json_output = io.StringIO()
+        human_output = io.StringIO()
+
+        with redirect_stdout(json_output):
+            _print_payload(payload, as_json=True)
+        with redirect_stdout(human_output):
+            _print_payload(payload, as_json=False)
+
+        self.assertEqual(
+            json_output.getvalue().strip(),
+            '{"apply":true,"complete":true,"missing_after":0,'
+            '"missing_before":3,"postgres_rows_updated":3}',
+        )
+        self.assertIn("apply=True complete=True", human_output.getvalue())
+        self.assertIn("missing_before=3 missing_after=0", human_output.getvalue())
+
+    def test_main_requires_the_selected_dsn_environment_variable(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaisesRegex(SystemExit, "missing DSN env var: CUSTOM_DSN"):
+                main(["--dsn-env", "CUSTOM_DSN"])
 
     def test_postgresql_missing_predicate_uses_a_text_json_key(self) -> None:
         engine = create_engine("postgresql+psycopg://", future=True)

--- a/services/torghut/tests/test_backfill_tigerbeetle_stable_refs.py
+++ b/services/torghut/tests/test_backfill_tigerbeetle_stable_refs.py
@@ -47,7 +47,9 @@ def _seed_refs(
     *,
     count: int,
     include_credit_account_ref: bool = True,
+    debit_account_label: str | None = "paper",
     credit_account_label: str | None = "paper",
+    payload_account_label: str | None = "paper",
 ) -> None:
     account_refs = [
         TigerBeetleAccountRef(
@@ -56,7 +58,7 @@ def _seed_refs(
             account_key="cash:paper:usd",
             ledger=LEDGER_USD_MICRO,
             code=1001,
-            account_label="paper",
+            account_label=debit_account_label,
         )
     ]
     if include_credit_account_ref:
@@ -86,7 +88,7 @@ def _seed_refs(
                 source_id=f"event-{index}",
                 event_fingerprint=f"fingerprint-{index}",
                 payload_json={
-                    "account_label": "paper",
+                    "account_label": payload_account_label,
                     "debit_account_id": DEBIT_ACCOUNT_ID,
                     "credit_account_id": CREDIT_ACCOUNT_ID,
                 },
@@ -157,6 +159,7 @@ class TestBackfillTigerBeetleStableRefs(TestCase):
             "missing_before": 3,
             "missing_after": 0,
             "postgres_rows_updated": 3,
+            "postgres_rows_would_update": 0,
         }
         json_output = io.StringIO()
         human_output = io.StringIO()
@@ -169,10 +172,28 @@ class TestBackfillTigerBeetleStableRefs(TestCase):
         self.assertEqual(
             json_output.getvalue().strip(),
             '{"apply":true,"complete":true,"missing_after":0,'
-            '"missing_before":3,"postgres_rows_updated":3}',
+            '"missing_before":3,"postgres_rows_updated":3,'
+            '"postgres_rows_would_update":0}',
         )
         self.assertIn("apply=True complete=True", human_output.getvalue())
         self.assertIn("missing_before=3 missing_after=0", human_output.getvalue())
+        self.assertIn("updated=3 would_update=0", human_output.getvalue())
+
+    def test_preview_receipt_shows_rows_that_would_be_updated(self) -> None:
+        output = io.StringIO()
+        payload = {
+            "apply": False,
+            "complete": False,
+            "missing_before": 3,
+            "missing_after": 3,
+            "postgres_rows_updated": 0,
+            "postgres_rows_would_update": 2,
+        }
+
+        with redirect_stdout(output):
+            _print_payload(payload, as_json=False)
+
+        self.assertIn("updated=0 would_update=2", output.getvalue())
 
     def test_main_requires_the_selected_dsn_environment_variable(self) -> None:
         with patch.dict(os.environ, {}, clear=True):
@@ -317,7 +338,35 @@ class TestBackfillTigerBeetleStableRefs(TestCase):
 
         self.assertNotIn("stable_ref", payload)
 
-    def test_missing_account_label_fails_closed(self) -> None:
+    def test_unknown_account_labels_use_stable_ref_fallback(self) -> None:
+        with Session(self.engine) as session:
+            _seed_refs(
+                session,
+                count=1,
+                debit_account_label=None,
+                credit_account_label=None,
+                payload_account_label=None,
+            )
+            journal = TigerBeetleLedgerJournal(
+                settings_obj=_settings(),
+                client=FakeTigerBeetleClient(),
+            )
+
+            result = run_stable_ref_backfill(
+                session,
+                journal,
+                batch_size=1,
+                max_batches=1,
+                apply=True,
+            )
+            payload = session.scalar(select(TigerBeetleTransferRef.payload_json))
+
+        self.assertTrue(result["complete"])
+        self.assertEqual(
+            payload["stable_ref"]["components"]["account_label"], "unknown"
+        )
+
+    def test_partial_account_label_metadata_fails_closed(self) -> None:
         with Session(self.engine) as session:
             _seed_refs(session, count=1, credit_account_label=None)
             journal = TigerBeetleLedgerJournal(

--- a/services/torghut/tests/test_backfill_tigerbeetle_stable_refs.py
+++ b/services/torghut/tests/test_backfill_tigerbeetle_stable_refs.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest import TestCase
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+
+from app.config import Settings
+from app.models import Base, TigerBeetleAccountRef, TigerBeetleTransferRef
+from app.trading.tigerbeetle_client import FakeTigerBeetleClient
+from app.trading.tigerbeetle_journal import TigerBeetleLedgerJournal
+from app.trading.tigerbeetle_journal.stable_ref_backfill import (
+    _missing_stable_ref_clause,
+)
+from app.trading.tigerbeetle_ledger_model import (
+    LEDGER_USD_MICRO,
+    TRANSFER_CODE_FILL_POST,
+    TRANSFER_KIND_FILL_POST,
+)
+from scripts.backfill_tigerbeetle_stable_refs import run_stable_ref_backfill
+
+
+DEBIT_ACCOUNT_ID = "101"
+CREDIT_ACCOUNT_ID = "102"
+
+
+def _settings() -> Settings:
+    return Settings(
+        TORGHUT_TIGERBEETLE_ENABLED=True,
+        TORGHUT_TIGERBEETLE_JOURNAL_ENABLED=True,
+    )
+
+
+def _seed_refs(
+    session: Session,
+    *,
+    count: int,
+    include_credit_account_ref: bool = True,
+    credit_account_label: str | None = "paper",
+) -> None:
+    account_refs = [
+        TigerBeetleAccountRef(
+            cluster_id=2001,
+            account_id=DEBIT_ACCOUNT_ID,
+            account_key="cash:paper:usd",
+            ledger=LEDGER_USD_MICRO,
+            code=1001,
+            account_label="paper",
+        )
+    ]
+    if include_credit_account_ref:
+        account_refs.append(
+            TigerBeetleAccountRef(
+                cluster_id=2001,
+                account_id=CREDIT_ACCOUNT_ID,
+                account_key="execution:paper:aapl",
+                ledger=LEDGER_USD_MICRO,
+                code=1502,
+                account_label=credit_account_label,
+                symbol="AAPL",
+            )
+        )
+    session.add_all(account_refs)
+    session.add_all(
+        [
+            TigerBeetleTransferRef(
+                cluster_id=2001,
+                transfer_id=str(201 + index),
+                transfer_kind=TRANSFER_KIND_FILL_POST,
+                ledger=LEDGER_USD_MICRO,
+                code=TRANSFER_CODE_FILL_POST,
+                amount=Decimal("2500000"),
+                status="created",
+                source_type="execution_order_event",
+                source_id=f"event-{index}",
+                event_fingerprint=f"fingerprint-{index}",
+                payload_json={
+                    "account_label": "paper",
+                    "debit_account_id": DEBIT_ACCOUNT_ID,
+                    "credit_account_id": CREDIT_ACCOUNT_ID,
+                },
+            )
+            for index in range(count)
+        ]
+    )
+    session.commit()
+
+
+class TestBackfillTigerBeetleStableRefs(TestCase):
+    def setUp(self) -> None:
+        self.engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        Base.metadata.create_all(self.engine)
+
+    def tearDown(self) -> None:
+        self.engine.dispose()
+
+    def test_postgresql_missing_predicate_uses_a_text_json_key(self) -> None:
+        engine = create_engine("postgresql+psycopg://", future=True)
+        try:
+            with Session(engine) as session:
+                clause = _missing_stable_ref_clause(session)
+                compiled = clause.compile(dialect=engine.dialect)
+        finally:
+            engine.dispose()
+
+        self.assertIn("payload_json ->", str(compiled))
+        self.assertIn("::TEXT", str(compiled))
+        self.assertNotIn("::JSONB", str(compiled))
+        self.assertEqual(compiled.params["payload_json_1"], "stable_ref")
+        self.assertEqual(compiled.params["jsonb_typeof_1"], "object")
+
+    def test_apply_drains_multiple_batches_without_tigerbeetle_writes(self) -> None:
+        with Session(self.engine) as session:
+            _seed_refs(session, count=3)
+            client = FakeTigerBeetleClient()
+            journal = TigerBeetleLedgerJournal(
+                settings_obj=_settings(),
+                client=client,
+            )
+
+            result = run_stable_ref_backfill(
+                session,
+                journal,
+                batch_size=2,
+                max_batches=2,
+                apply=True,
+            )
+
+            refs = session.execute(
+                select(TigerBeetleTransferRef).order_by(
+                    TigerBeetleTransferRef.transfer_id
+                )
+            ).scalars()
+            payloads = [ref.payload_json for ref in refs]
+
+        self.assertTrue(result["complete"])
+        self.assertEqual(result["missing_before"], 3)
+        self.assertEqual(result["missing_after"], 0)
+        self.assertEqual(result["stable_ref_mismatch_count"], 0)
+        self.assertEqual(result["stable_ref_count"], 3)
+        self.assertEqual(result["transfer_ref_count"], 3)
+        self.assertEqual(result["selected_count"], 3)
+        self.assertEqual(result["postgres_rows_updated"], 3)
+        self.assertEqual(result["postgres_rows_would_update"], 0)
+        self.assertEqual(result["tigerbeetle_writes"], 0)
+        self.assertFalse(result["capital_authority"])
+        self.assertFalse(result["promotion_authority"])
+        self.assertEqual(
+            result["batches"],
+            [
+                {"batch": 1, "selected": 2, "updated": 2},
+                {"batch": 2, "selected": 1, "updated": 1},
+            ],
+        )
+        self.assertEqual(client.transfers, {})
+        for payload in payloads:
+            stable_ref = payload["stable_ref"]
+            self.assertEqual(stable_ref["components"]["account_label"], "paper")
+            self.assertEqual(
+                stable_ref["account_keys"],
+                ["cash:paper:usd", "execution:paper:aapl"],
+            )
+
+    def test_preview_rolls_back_the_bounded_batch(self) -> None:
+        with Session(self.engine) as session:
+            _seed_refs(session, count=3)
+            journal = TigerBeetleLedgerJournal(
+                settings_obj=_settings(),
+                client=FakeTigerBeetleClient(),
+            )
+
+            result = run_stable_ref_backfill(
+                session,
+                journal,
+                batch_size=2,
+                max_batches=10,
+                apply=False,
+            )
+            payloads = session.scalars(
+                select(TigerBeetleTransferRef.payload_json)
+            ).all()
+
+        self.assertFalse(result["complete"])
+        self.assertEqual(result["missing_before"], 3)
+        self.assertEqual(result["missing_after"], 3)
+        self.assertEqual(result["selected_count"], 2)
+        self.assertEqual(result["postgres_rows_updated"], 0)
+        self.assertEqual(result["postgres_rows_would_update"], 2)
+        self.assertTrue(all("stable_ref" not in payload for payload in payloads))
+
+    def test_apply_reports_incomplete_when_batch_bound_is_exhausted(self) -> None:
+        with Session(self.engine) as session:
+            _seed_refs(session, count=3)
+            journal = TigerBeetleLedgerJournal(
+                settings_obj=_settings(),
+                client=FakeTigerBeetleClient(),
+            )
+
+            result = run_stable_ref_backfill(
+                session,
+                journal,
+                batch_size=1,
+                max_batches=1,
+                apply=True,
+            )
+
+        self.assertFalse(result["complete"])
+        self.assertEqual(result["postgres_rows_updated"], 1)
+        self.assertEqual(result["missing_after"], 2)
+
+    def test_missing_account_metadata_fails_closed(self) -> None:
+        with Session(self.engine) as session:
+            _seed_refs(session, count=1, include_credit_account_ref=False)
+            journal = TigerBeetleLedgerJournal(
+                settings_obj=_settings(),
+                client=FakeTigerBeetleClient(),
+            )
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "tigerbeetle_stable_ref_backfill_account_ref_missing",
+            ):
+                run_stable_ref_backfill(
+                    session,
+                    journal,
+                    batch_size=1,
+                    max_batches=1,
+                    apply=True,
+                )
+            session.rollback()
+            payload = session.scalar(select(TigerBeetleTransferRef.payload_json))
+
+        self.assertNotIn("stable_ref", payload)
+
+    def test_missing_account_label_fails_closed(self) -> None:
+        with Session(self.engine) as session:
+            _seed_refs(session, count=1, credit_account_label=None)
+            journal = TigerBeetleLedgerJournal(
+                settings_obj=_settings(),
+                client=FakeTigerBeetleClient(),
+            )
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "tigerbeetle_stable_ref_backfill_account_label_missing",
+            ):
+                run_stable_ref_backfill(
+                    session,
+                    journal,
+                    batch_size=1,
+                    max_batches=1,
+                    apply=True,
+                )
+            session.rollback()
+            payload = session.scalar(select(TigerBeetleTransferRef.payload_json))
+
+        self.assertNotIn("stable_ref", payload)

--- a/services/torghut/tests/tigerbeetle_journal/test_transfer_refs.py
+++ b/services/torghut/tests/tigerbeetle_journal/test_transfer_refs.py
@@ -53,10 +53,85 @@ from tests.tigerbeetle_journal.support import (
 
 
 class TestTigerBeetleLedgerJournalTransferRefs(_TestTigerBeetleLedgerJournalBase):
+    @staticmethod
+    def _add_stable_ref_account_refs(session: Session) -> None:
+        session.add_all(
+            [
+                TigerBeetleAccountRef(
+                    cluster_id=2001,
+                    account_id="100100100100100100100100100100100101",
+                    account_key="cash:paper:usd",
+                    ledger=LEDGER_USD_MICRO,
+                    code=1001,
+                    account_label="paper",
+                ),
+                TigerBeetleAccountRef(
+                    cluster_id=2001,
+                    account_id="100100100100100100100100100100100102",
+                    account_key="runtime_ledger:paper:hypothesis-1",
+                    ledger=LEDGER_USD_MICRO,
+                    code=1503,
+                    account_label="paper",
+                ),
+            ]
+        )
+
+    def test_stable_ref_backfill_selects_missing_ref_before_newer_complete_ref(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            self._add_stable_ref_account_refs(session)
+            missing = TigerBeetleTransferRef(
+                cluster_id=2001,
+                transfer_id="100100100100100100100100100100100201",
+                transfer_kind=TRANSFER_KIND_RUNTIME_NET_PNL,
+                ledger=LEDGER_USD_MICRO,
+                code=2012,
+                amount=Decimal("2500000"),
+                status="created",
+                source_type="strategy_runtime_ledger_bucket",
+                source_id="00000000-0000-4000-8000-000000000001",
+                payload_json={
+                    "debit_account_id": "100100100100100100100100100100100101",
+                    "credit_account_id": "100100100100100100100100100100100102",
+                    "runtime_key": "hypothesis-1:runtime-run-1:source-window",
+                },
+                created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+            )
+            complete = TigerBeetleTransferRef(
+                cluster_id=2001,
+                transfer_id="100100100100100100100100100100100202",
+                transfer_kind=TRANSFER_KIND_RUNTIME_NET_PNL,
+                ledger=LEDGER_USD_MICRO,
+                code=2012,
+                amount=Decimal("2500000"),
+                status="created",
+                source_type="strategy_runtime_ledger_bucket",
+                source_id="00000000-0000-4000-8000-000000000002",
+                payload_json={"stable_ref": {"schema_version": "already-present"}},
+                created_at=datetime(2026, 6, 2, tzinfo=timezone.utc),
+            )
+            session.add_all([missing, complete])
+            session.flush()
+            journal = TigerBeetleLedgerJournal(
+                settings_obj=_settings(),
+                client=FakeTigerBeetleClient(),
+            )
+
+            result = journal.backfill_stable_ref_payloads(session, limit=1)
+
+            self.assertEqual(result, {"selected": 1, "updated": 1, "skipped": 0})
+            self.assertIn("stable_ref", missing.payload_json)
+            self.assertEqual(
+                complete.payload_json,
+                {"stable_ref": {"schema_version": "already-present"}},
+            )
+
     def test_stable_ref_payload_backfill_is_idempotent_without_tigerbeetle_write(
         self,
     ) -> None:
         with Session(self.engine) as session:
+            self._add_stable_ref_account_refs(session)
             bucket = _runtime_bucket()
             session.add(bucket)
             session.flush()
@@ -90,10 +165,19 @@ class TestTigerBeetleLedgerJournalTransferRefs(_TestTigerBeetleLedgerJournalBase
             second = journal.backfill_stable_ref_payloads(session)
 
             self.assertEqual(first, {"selected": 1, "updated": 1, "skipped": 0})
-            self.assertEqual(second, {"selected": 1, "updated": 0, "skipped": 1})
+            self.assertEqual(second, {"selected": 0, "updated": 0, "skipped": 0})
             self.assertEqual(client.transfers, {})
             self.assertEqual(ref.payload_json, first_payload)
             self.assertIn("stable_ref", ref.payload_json)
+            stable_ref = ref.payload_json["stable_ref"]
+            self.assertEqual(
+                stable_ref["components"]["account_label"],
+                "paper",
+            )
+            self.assertEqual(
+                stable_ref["account_keys"],
+                ["cash:paper:usd", "runtime_ledger:paper:hypothesis-1"],
+            )
 
     def test_runtime_bucket_journal_payload_marks_aggregate_only_non_authority(
         self,


### PR DESCRIPTION
## Summary

- Fix legacy stable-ref starvation by selecting only missing refs in deterministic oldest-first locked batches.
- Reconstruct full account IDs, keys, labels, and ledger metadata from persisted TigerBeetle account refs and fail closed on disagreement.
- Add a preview-by-default, bounded, idempotent PostgreSQL repair command with full stable-ref verification and zero TigerBeetle or capital authority.
- Cover PostgreSQL predicate generation, rollback preview, multi-batch drain, bounded incompleteness, idempotence, and missing metadata failures.

## Related Issues

None

## Testing

- uv run --frozen pytest -q tests/tigerbeetle_journal tests/tigerbeetle_reconcile tests/journal_tigerbeetle_order_events tests/test_tigerbeetle_*.py tests/test_audit_tigerbeetle_runtime_ledger_parity.py tests/test_backfill_tigerbeetle_stable_refs.py (230 passed)
- uv run --frozen pyright --project pyrightconfig.json
- uv run --frozen pyright --project pyrightconfig.alpha.json
- uv run --frozen pyright --project pyrightconfig.scripts.json
- uv run --frozen pyright --project pyrightconfig.alpha.strict.json
- uv run --frozen pyright --project pyrightconfig.scripts.strict.json
- uv run --frozen ruff format --check app tests scripts migrations
- uv run --frozen ruff check app tests scripts migrations
- uv run --frozen python -m compileall -q app scripts
- uv run --frozen python scripts/run_pylint_torghut_structural_gate.py
- uv run --frozen python scripts/measure_torghut_tech_debt.py --baseline config/quality/tech-debt-baseline.json --enforce-ratchet --format markdown
- Read-only production preflight: 42,899 transfer refs, 22,342 missing stable refs, every affected source and debit/credit account ref resolves, zero stable mismatches, zero unlinked evidence, and economic parity passes.

## Breaking Changes

None. The repair command is not activated by this PR; it must run from the promoted image through a separate one-shot GitOps Job.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] Documentation is not required; the image-promotion and one-shot GitOps activation follow-up is explicit.
