### PR TITLE
fix(torghut): provide temp space for stable-ref repair

### DIFF
--- a/argocd/applications/torghut/tigerbeetle-stable-ref-backfill-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-stable-ref-backfill-job.yaml
@@ -49,6 +49,8 @@ spec:
           env:
             - name: APP_ENV
               value: prod
+            - name: TMPDIR
+              value: /tmp
             - name: DB_DSN
               valueFrom:
                 secretKeyRef:
@@ -79,3 +81,10 @@ spec:
               cpu: "1"
               memory: 1Gi
               ephemeral-storage: 256Mi
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 64Mi


### PR DESCRIPTION
## Summary

- Mount a size-limited writable `emptyDir` at `/tmp` while preserving the stable-ref repair Job's read-only root filesystem.
- Set `TMPDIR=/tmp` explicitly so Python can initialize before the PostgreSQL-only repair starts.
- Replace the failed pre-database Job on the next Argo sync; live readback confirms both failed pods exited during import and all 22,342 gaps remain unchanged.

## Related Issues

None

## Testing

- `nix develop -c scripts/kubeconform.sh argocd/applications/torghut/tigerbeetle-stable-ref-backfill-job.yaml`
- `nix develop -c sh -c 'kustomize build --enable-helm argocd/applications/torghut >/dev/null'`
- `yq '.metadata.name = "torghut-tigerbeetle-stable-ref-backfill-validate"' argocd/applications/torghut/tigerbeetle-stable-ref-backfill-job.yaml | kubectl create --dry-run=server -n torghut -f -`
- Live failure readback: two pods exited 1 before database initialization; `stable_ref_missing_count=22342` remained unchanged.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.