### PR TITLE
fix(torghut): grant repair temp volume ownership

### DIFF
--- a/argocd/applications/torghut/tigerbeetle-stable-ref-backfill-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-stable-ref-backfill-job.yaml
@@ -28,6 +28,8 @@ spec:
         runAsNonRoot: true
         runAsUser: 999
         runAsGroup: 999
+        fsGroup: 999
+        fsGroupChangePolicy: OnRootMismatch
         seccompProfile:
           type: RuntimeDefault
       containers:


### PR DESCRIPTION
## Summary

- Set pod `fsGroup: 999` so the non-root stable-ref repair process can write to its size-limited `/tmp` emptyDir.
- Use `fsGroupChangePolicy: OnRootMismatch` to avoid unnecessary recursive permission changes.
- Preserve the read-only root filesystem and fail-closed repair contract; the second attempt also exited during import and live SQL confirms all 22,342 gaps remain unchanged.

## Related Issues

None

## Testing

- `nix develop -c scripts/kubeconform.sh argocd/applications/torghut/tigerbeetle-stable-ref-backfill-job.yaml`
- `nix develop -c sh -c 'kustomize build --enable-helm argocd/applications/torghut >/dev/null'`
- `yq '.metadata.name = "torghut-tigerbeetle-stable-ref-backfill-validate"' argocd/applications/torghut/tigerbeetle-stable-ref-backfill-job.yaml | kubectl create --dry-run=server -n torghut -f -`
- Live failure and SQL readback: the pod exited 1 during Python temp-dir detection; `stable_ref_missing_count=22342` remained unchanged.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.