### PR TITLE
fix(dorvud): preserve updated bar corrections

### DIFF
--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
@@ -186,6 +186,13 @@ internal fun alpacaTradesBackfillQuery(
 
 internal fun alpacaMarketDataChannels(config: ForwarderConfig): List<String> = config.alpacaMarketDataChannels
 
+internal fun barDedupKey(message: AlpacaMessage): String? =
+  when (message) {
+    is AlpacaBar -> "bars:${message.timestamp}-${message.symbol}"
+    is AlpacaUpdatedBar -> "updatedBars:${message.timestamp}-${message.symbol}"
+    else -> null
+  }
+
 @Serializable
 internal data class AlpacaBarsResponse(
   val bars: JsonElement? = null,
@@ -1383,17 +1390,8 @@ class ForwarderApp(
         }
       }
       is AlpacaBar, is AlpacaUpdatedBar -> {
-        val symbol =
-          when (msg) {
-            is AlpacaBar -> msg.symbol
-            is AlpacaUpdatedBar -> msg.symbol
-          }
-        val ts =
-          when (msg) {
-            is AlpacaBar -> msg.timestamp
-            is AlpacaUpdatedBar -> msg.timestamp
-          }
-        if (barsDedup.isDuplicate("$ts-$symbol")) {
+        val dedupKey = requireNotNull(barDedupKey(msg))
+        if (barsDedup.isDuplicate(dedupKey)) {
           metrics.recordDedup("bars")
           return null
         }

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderBarDedupTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderBarDedupTest.kt
@@ -1,0 +1,52 @@
+package ai.proompteng.dorvud.ws
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class ForwarderBarDedupTest {
+  @Test
+  fun `updated bar correction does not collide with regular bar`() {
+    val regular =
+      AlpacaBar(
+        symbol = "AAPL",
+        open = 100.0,
+        high = 101.0,
+        low = 99.0,
+        close = 100.5,
+        volume = 10.0,
+        timestamp = "2026-07-18T20:00:00Z",
+      )
+    val updated =
+      AlpacaUpdatedBar(
+        symbol = "AAPL",
+        open = 100.0,
+        high = 101.5,
+        low = 99.0,
+        close = 101.0,
+        volume = 12.0,
+        timestamp = "2026-07-18T20:00:00Z",
+      )
+
+    assertEquals("bars:2026-07-18T20:00:00Z-AAPL", barDedupKey(regular))
+    assertEquals("updatedBars:2026-07-18T20:00:00Z-AAPL", barDedupKey(updated))
+    assertNotEquals(barDedupKey(regular), barDedupKey(updated))
+  }
+
+  @Test
+  fun `duplicate updates retain the same dedup key`() {
+    val first =
+      AlpacaUpdatedBar(
+        symbol = "AAPL",
+        open = 100.0,
+        high = 101.5,
+        low = 99.0,
+        close = 101.0,
+        volume = 12.0,
+        timestamp = "2026-07-18T20:00:00Z",
+      )
+    val duplicate = first.copy(close = 101.25)
+
+    assertEquals(barDedupKey(first), barDedupKey(duplicate))
+  }
+}


### PR DESCRIPTION
## Summary

- separate regular-bar and updated-bar deduplication keys
- preserve updated/final correction events at the same symbol and timestamp
- keep duplicate corrections deduplicated within the updated-bars channel
- add focused regression coverage

## Related Codex finding

Historical PR #1917, discussion `r2584064885`.

## Testing

- source contract validates channel-separated keys and cancellation-aware reconnect loops
- `git diff --check`
- Dorvud Gradle compile/test is delegated to CI because this executor has no JDK

## Breaking Changes

None.
