### PR TITLE
fix(temporal): remove nonexistent workflow runtime export

### DIFF
--- a/packages/temporal-bun-sdk/package.json
+++ b/packages/temporal-bun-sdk/package.json
@@ -58,10 +58,6 @@
       "types": "./dist/src/workflow/index.d.ts",
       "default": "./dist/src/workflow/index.js"
     },
-    "./workflow/runtime": {
-      "types": "./dist/src/workflow/runtime/index.d.ts",
-      "default": "./dist/src/workflow/runtime/index.js"
-    },
     "./worker": {
       "types": "./dist/src/worker.d.ts",
       "default": "./dist/src/worker.js"

--- a/packages/temporal-bun-sdk/tests/packaging/manifest-packaging.test.ts
+++ b/packages/temporal-bun-sdk/tests/packaging/manifest-packaging.test.ts
@@ -7,6 +7,7 @@ import { join } from 'node:path'
 type TemporalSdkPackageJson = {
   dependencies?: Record<string, string>
   devDependencies?: Record<string, string>
+  exports?: Record<string, string | Record<string, string>>
   bin?: Record<string, string>
   files?: string[]
   scripts?: Record<string, string>
@@ -92,6 +93,23 @@ describe('temporal-bun-sdk packaging manifest', () => {
     expect(bins['temporal-bun']).toBe('./dist/src/bin/temporal-bun.js')
     expect(bins['temporal-bun-skill']).toBe('./dist/src/bin/temporal-bun-skill.js')
     expect(bins['temporal-bun-worker']).toBe('./dist/src/bin/start-worker.js')
+  })
+
+  test('declares only export targets backed by source modules', async () => {
+    const packageJson = await loadPackageJson()
+    const exports = packageJson.exports ?? {}
+
+    for (const [subpath, target] of Object.entries(exports)) {
+      const targets = typeof target === 'string' ? [target] : Object.values(target)
+      for (const exportTarget of targets) {
+        if (!exportTarget.startsWith('./dist/src/') || !exportTarget.endsWith('.js')) {
+          continue
+        }
+
+        const sourcePath = exportTarget.replace('./dist/src/', './src/').replace(/\.js$/, '.ts')
+        expect(existsSync(join(packageRoot, sourcePath)), `${subpath} -> ${sourcePath}`).toBeTrue()
+      }
+    }
   })
 
   test('exposes adoption metadata for npm and agent discovery', async () => {


### PR DESCRIPTION
## Summary

- remove the nonexistent `./workflow/runtime` package export
- add a packaging regression that verifies every declared `dist/src/*.js` export has a corresponding source module

## Related Codex finding

Historical PR #1845, discussion `r2551910542`.

## Testing

- TypeScript build passed
- 48 focused runtime, observability, TLS, shutdown, worker, and packaging tests passed
- Oxfmt passed
- normal and type-aware Oxlint completed with no errors
- `git diff --check` passed

## Breaking Changes

Removes a package subpath that never resolved to a shipped module.
