### PR TITLE
chore(torghut): promote notebook image sha-6bc70ab3b247f57c279ce52ac125a34dff68ddb2

### DIFF
--- a/argocd/applications/torghut/notebooks/values.yaml
+++ b/argocd/applications/torghut/notebooks/values.yaml
@@ -93,7 +93,7 @@ proxy:
 singleuser:
   image:
     name: registry.ide-newton.ts.net/lab/torghut-notebook@sha256
-    tag: '06c6c1c96a9e98761b697db1e0c3971a5159de0e480535a5396077bc3766c9c6'
+    tag: '30e85c4d868f8206cd5b3087c31e00dd5c19d282c940b4594753ace5fffe0d9f'
     pullPolicy: IfNotPresent
   defaultUrl: /lab/tree/work/00-system-flow.ipynb
   startTimeout: 600


### PR DESCRIPTION
## Summary

- Promote the immutable multi-architecture Torghut notebook image built from `6bc70ab3b247f57c279ce52ac125a34dff68ddb2`.
- Update only the digest-pinned JupyterHub single-user image.

## Related Issues

None.

## Testing

- The source commit passed notebook fixture execution and manifest contracts.
- The release workflow verified `linux/amd64` and `linux/arm64` for `sha256:30e85c4d868f8206cd5b3087c31e00dd5c19d282c940b4594753ace5fffe0d9f`.

## Breaking Changes

None.

## Checklist

- [x] The single-user image is immutable and multi-architecture.
- [x] Promotion changes only the notebook image digest.
- [x] PVCs and read-only credentials are unchanged.