### PR TITLE
fix(rook-ceph): harden CephFS client defaults

### DIFF
--- a/argocd/applications/rook-ceph/operator-values.yaml
+++ b/argocd/applications/rook-ceph/operator-values.yaml
@@ -41,8 +41,36 @@ csi:
   enableRBDSnapshotter: true
   enableCephfsSnapshotter: true
   enableCSIHostNetwork: true
+  # The Talos kernel client requires explicit v2 CRC negotiation with this Ceph cluster.
+  cephFSKernelMountOptions: ms_mode=crc
   # Render `CSI_FORCE_CEPHFS_KERNEL_CLIENT: "false"` (Helm `with` blocks skip boolean false).
   forceCephFSKernelClient: "false"
+  cephFSPluginUpdateStrategy: RollingUpdate
+  cephFSPluginUpdateStrategyMaxUnavailable: 1
+  # A 1 GiB limit OOM-killed ceph-fuse and invalidated every FUSE mount on the node.
+  # Media workloads use the kernel client, while this headroom protects compatibility clients.
+  csiCephFSPluginResource: |
+    - name : driver-registrar
+      resource:
+        requests:
+          memory: 128Mi
+          cpu: 50m
+        limits:
+          memory: 256Mi
+    - name : csi-cephfsplugin
+      resource:
+        requests:
+          memory: 1Gi
+          cpu: 250m
+        limits:
+          memory: 4Gi
+    - name : liveness-prometheus
+      resource:
+        requests:
+          memory: 128Mi
+          cpu: 50m
+        limits:
+          memory: 256Mi
   topology:
     enabled: true
     domainLabels:

--- a/argocd/applications/rook-ceph/operator-values.yaml
+++ b/argocd/applications/rook-ceph/operator-values.yaml
@@ -45,8 +45,9 @@ csi:
   cephFSKernelMountOptions: ms_mode=crc
   # Render `CSI_FORCE_CEPHFS_KERNEL_CLIENT: "false"` (Helm `with` blocks skip boolean false).
   forceCephFSKernelClient: "false"
-  cephFSPluginUpdateStrategy: RollingUpdate
-  cephFSPluginUpdateStrategyMaxUnavailable: 1
+  # FUSE mount processes live inside this pod. Roll nodes only after inventorying
+  # and restarting the node's FUSE consumers through a controlled operation.
+  cephFSPluginUpdateStrategy: OnDelete
   # A 1 GiB limit OOM-killed ceph-fuse and invalidated every FUSE mount on the node.
   # Media workloads use the kernel client, while this headroom protects compatibility clients.
   csiCephFSPluginResource: |

--- a/argocd/applications/rook-ceph/storageclasses.yaml
+++ b/argocd/applications/rook-ceph/storageclasses.yaml
@@ -106,6 +106,7 @@ reclaimPolicy: Delete
 volumeBindingMode: Immediate
 mountOptions:
   - noatime
+  - ms_mode=crc
 parameters:
   clusterID: rook-ceph
   fsName: cephfs
@@ -129,7 +130,7 @@ mountOptions:
 parameters:
   clusterID: rook-ceph
   fsName: cephfs
-  # Talos nodes do not ship the kernel ceph module; force userspace mounts.
+  # Compatibility class for workloads that explicitly require the userspace client.
   mounter: fuse
   csi.storage.k8s.io/provisioner-secret-name: rook-csi-cephfs-provisioner
   csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph

--- a/docs/runbooks/cephfs-fuse-on-talos.md
+++ b/docs/runbooks/cephfs-fuse-on-talos.md
@@ -1,105 +1,78 @@
-# CephFS (FUSE) On Talos
+# CephFS On Talos
 
-This cluster runs Kubernetes on Talos Linux. Talos does not ship the in-kernel CephFS client module, so CephFS mounts must use the FUSE mounter.
+The `galactic` Talos nodes provide the in-kernel CephFS client. Use the kernel client for durable, high-churn RWX workloads. Keep `rook-cephfs-fuse` only as an explicit compatibility class.
 
-This runbook documents:
+## Cluster Configuration
 
-- How we configure Rook-Ceph / Ceph-CSI for CephFS FUSE on Talos.
-- How to migrate an existing CephFS PVC to the FUSE storage class.
-- How to treat `rook-cephfs-fuse` as the compatibility RWX class when benchmarking.
+Rook configuration is owned by GitOps:
 
-## Why FUSE
+- `argocd/applications/rook-ceph/operator-values.yaml`
+- `argocd/applications/rook-ceph/storageclasses.yaml`
 
-If the CephFS kernel module (`ceph`) is not present on nodes, CephFS CSI mounts that rely on the in-kernel client will fail (pods stuck in `ContainerCreating` with mount errors). Using the CephFS FUSE mounter avoids needing the kernel module.
+The required defaults are:
 
-## Cluster Configuration (GitOps)
+- `rook-cephfs` uses the kernel mounter with `noatime` and `ms_mode=crc`.
+- `rook-cephfs-fuse` explicitly sets `mounter: fuse`.
+- The CephFS CSI node plugin requests 1 GiB and is limited to 4 GiB.
+- The CephFS CSI node-plugin DaemonSet rolls one node at a time.
 
-1. Rook-Ceph operator chart values force CephFS kernel client off:
+`ms_mode=crc` is required for the kernel client to negotiate Ceph messenger v2 with the current cluster. Do not remove it from either the Rook CSI default or the kernel StorageClass without a mount canary.
 
-- File: `argocd/applications/rook-ceph/operator-values.yaml`
-- Key: `csi.forceCephFSKernelClient: "false"`
+## Why Kernel Is The Default
 
-Note: this is quoted as a string so Helm renders `CSI_FORCE_CEPHFS_KERNEL_CLIENT: "false"`. Helm `with` blocks skip boolean `false`.
+FUSE mount processes run inside the CephFS CSI node-plugin container. If that container is OOM-killed, each affected `ceph-fuse` process dies and existing workload mounts return `Transport endpoint is not connected`. Recreating an application pod can then reproduce the same broken node-local mount.
 
-2. A CephFS FUSE `StorageClass` exists:
+Kernel CephFS mount state is owned by the host kernel instead of a `ceph-fuse` process. A CSI node-plugin restart therefore does not invalidate an established kernel mount. The larger plugin limit still protects workloads that intentionally use the FUSE compatibility class.
 
-- File: `argocd/applications/rook-ceph/storageclasses.yaml`
-- Name: `rook-cephfs-fuse`
-- Key parameter: `parameters.mounter: fuse`
-- Conservative default mount option: `mountOptions: [noatime]`
+## New PVCs
 
-3. The live CephFS keeps a single active MDS and now sets explicit MDS resources:
-
-- File: `argocd/applications/rook-ceph/storageclasses.yaml`
-- Key path: `spec.metadataServer`
-- Default resources: requests `2 CPU / 8Gi`, limits `4 CPU / 16Gi`
-
-## Using CephFS FUSE In Apps
-
-Set PVCs to use:
-
-- `storageClassName: rook-cephfs-fuse`
-
-Use this class only when the workload genuinely needs shared POSIX semantics and the node image does not provide a working kernel CephFS client.
-If a kernel-capable worker pool exists, benchmark `rook-cephfs` against `rook-cephfs-fuse` before standardizing on FUSE for a performance-sensitive workload.
-
-Example:
+Use the kernel class unless a tested compatibility requirement says otherwise:
 
 ```yaml
 spec:
   accessModes:
     - ReadWriteMany
-  storageClassName: rook-cephfs-fuse
+  storageClassName: rook-cephfs
 ```
 
-## Migrating Existing PVCs (Wipe/Recreate)
+Use `rook-cephfs-fuse` only after documenting why the kernel client cannot be used.
 
-Ceph-CSI-backed PVCs cannot change `storageClassName` in-place. If a PVC was created with the wrong CephFS storage class, you must delete and recreate it.
+## Existing Data Migration
 
-This process is destructive: deleting the PVC deletes the CephFS subvolume, and the data is not recovered from other “members”.
+A PVC's storage class is immutable. Never delete a data-bearing dynamic CephFS PVC merely to change its mounter: with a `Delete` reclaim policy, that can delete the CephFS subvolume.
 
-1. Identify the workloads using the PVC:
+For an existing subvolume:
 
-```bash
-kubectl -n <ns> get pods -o wide
-kubectl -n <ns> describe pod <pod>
-```
-
-2. Scale down / delete workloads that mount the PVC.
-
-3. Delete the PVC and wait for the PV to be removed:
-
-```bash
-kubectl -n <ns> delete pvc <pvc-name>
-kubectl get pv | rg <pvc-name> -n || true
-```
-
-If the PV remains in `Terminating`, check for finalizers and confirm no pods still reference it.
-
-4. Recreate the PVC via GitOps:
-
-- Ensure the PVC manifest in the repo uses `storageClassName: rook-cephfs-fuse`.
-- Sync the owning Argo CD application.
-
-5. Verify the new PVC is bound to `rook-cephfs-fuse`:
-
-```bash
-kubectl -n <ns> get pvc <pvc-name> -o wide
-kubectl -n <ns> get pvc <pvc-name> -o yaml | rg storageClassName -n
-```
+1. Record the source PV's `rootPath`, `volumeHandle`, secret references, capacity, and claim UID.
+2. Patch the source PV reclaim policy to `Retain`.
+3. Create a static PV with `staticVolume: "true"`, the same `rootPath`, a new unique `volumeHandle`, `mounter: kernel`, and `persistentVolumeReclaimPolicy: Retain`.
+4. Bind a new PVC explicitly to that static PV.
+5. Mount the new PVC in a canary on every target node and prove read, write, hardlink, and remount behavior.
+6. Switch workloads through GitOps and verify their mount type is `ceph`.
+7. Remove the old PVC/PV objects only after no pod references them. Never delete the retained CephFS subvolume.
 
 ## Validation
 
-1. Confirm Rook-Ceph is healthy:
-
 ```bash
-argocd app get rook-ceph
-kubectl -n rook-ceph get pods
+kubectl -n rook-ceph get pods -l app=rook-ceph.cephfs.csi.ceph.com-nodeplugin -o wide
+kubectl -n rook-ceph get cephfilesystem cephfs
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph fs status cephfs
+kubectl -n <namespace> exec <pod> -- awk '$2 == "/data" { print }' /proc/mounts
 ```
 
-2. Confirm a pod mounting the PVC starts successfully (no CephFS mount errors) and that the app becomes `Healthy` in Argo CD.
+For a kernel mount, `/proc/mounts` must report filesystem type `ceph`, not `fuse.ceph-fuse`.
 
-## Performance Investigation
+Check CSI resource and restart history:
 
-The RWX-only performance workflow lives in `docs/runbooks/rook-ceph-rwx-performance.md`.
-Use that runbook before changing `activeCount`, changing hardware topology, or treating a FUSE result as representative of all CephFS RWX performance.
+```bash
+kubectl -n rook-ceph get pod -l app=rook-ceph.cephfs.csi.ceph.com-nodeplugin -o json \
+  | jq '.items[] | {node: .spec.nodeName, plugin: (.status.containerStatuses[] | select(.name == "csi-cephfsplugin") | {restartCount, lastState}), limits: (.spec.containers[] | select(.name == "csi-cephfsplugin") | .resources)}'
+```
+
+Any `OOMKilled` termination is a platform incident. Identify FUSE consumers on that node before restarting the node plugin. Kernel-mounted workloads do not need to be recreated after a CSI-only restart.
+
+References:
+
+- [CephFS kernel client](https://docs.ceph.com/en/latest/cephfs/mount-using-kernel-driver/)
+- [mount.ceph options](https://docs.ceph.com/en/latest/man/8/mount.ceph/)
+- [Ceph CSI static PVCs](https://github.com/ceph/ceph-csi/blob/devel/docs/static-pvc.md)

--- a/docs/runbooks/cephfs-fuse-on-talos.md
+++ b/docs/runbooks/cephfs-fuse-on-talos.md
@@ -14,7 +14,7 @@ The required defaults are:
 - `rook-cephfs` uses the kernel mounter with `noatime` and `ms_mode=crc`.
 - `rook-cephfs-fuse` explicitly sets `mounter: fuse`.
 - The CephFS CSI node plugin requests 1 GiB and is limited to 4 GiB.
-- The CephFS CSI node-plugin DaemonSet rolls one node at a time.
+- The CephFS CSI node-plugin DaemonSet uses `OnDelete` so an operator must coordinate each node rollout with its FUSE consumers.
 
 `ms_mode=crc` is required for the kernel client to negotiate Ceph messenger v2 with the current cluster. Do not remove it from either the Rook CSI default or the kernel StorageClass without a mount canary.
 
@@ -43,9 +43,9 @@ A PVC's storage class is immutable. Never delete a data-bearing dynamic CephFS P
 
 For an existing subvolume:
 
-1. Record the source PV's `rootPath`, `volumeHandle`, secret references, capacity, and claim UID.
+1. Record the source PV's `subvolumePath`, `volumeHandle`, secret references, capacity, and claim UID.
 2. Patch the source PV reclaim policy to `Retain`.
-3. Create a static PV with `staticVolume: "true"`, the same `rootPath`, a new unique `volumeHandle`, `mounter: kernel`, and `persistentVolumeReclaimPolicy: Retain`.
+3. Create a static PV with `staticVolume: "true"`, copy the dynamic PV's `subvolumePath` value into the static PV's `rootPath`, use a new unique `volumeHandle`, set `mounter: kernel`, and set `persistentVolumeReclaimPolicy: Retain`.
 4. Bind a new PVC explicitly to that static PV.
 5. Mount the new PVC in a canary on every target node and prove read, write, hardlink, and remount behavior.
 6. Switch workloads through GitOps and verify their mount type is `ceph`.

--- a/docs/runbooks/rook-ceph-rwx-performance.md
+++ b/docs/runbooks/rook-ceph-rwx-performance.md
@@ -9,19 +9,19 @@ Non-RWX classes such as `rook-ceph-block` and non-POSIX paths such as `rook-ceph
 
 ## Decision Matrix
 
-Use `rook-cephfs-fuse` when:
-
-1. The workload requires shared POSIX semantics.
-1. The workload must run on Talos nodes that do not ship the in-kernel CephFS client.
-1. Compatibility matters more than peak throughput.
-
 Use `rook-cephfs` when:
 
 1. The workload requires shared POSIX semantics.
-1. You have a worker pool with a working kernel CephFS client.
-1. The workload is performance-sensitive enough that FUSE overhead matters.
+1. The workload runs on the `galactic` Talos nodes.
+1. The workload is durable or performance-sensitive.
 
-Do not choose between the two classes based on anecdote. Run the same benchmark suite against both classes when a kernel-capable worker pool exists.
+Use `rook-cephfs-fuse` when:
+
+1. The workload requires shared POSIX semantics.
+1. A tested compatibility issue prevents the kernel client from working.
+1. The workload owner accepts that a CSI plugin restart invalidates active FUSE mounts.
+
+Do not choose between the two classes based on anecdote. Run the same benchmark suite against both classes when validating a compatibility exception.
 
 ## Current Cluster Defaults
 
@@ -30,7 +30,8 @@ Current GitOps defaults are tuned for safe first-pass RWX investigations:
 1. The Ceph mgr `stats` module is enabled so `ceph fs perf stats` is available.
 1. The live `CephFilesystem` keeps `activeCount: 1` and `activeStandby: true`.
 1. The MDS pods have explicit resources: requests `2 CPU / 8Gi`, limits `4 CPU / 16Gi`.
-1. Both RWX classes set `mountOptions: [noatime]`.
+1. Both RWX classes set `noatime`; the kernel class also sets `ms_mode=crc` for messenger v2 negotiation.
+1. The CephFS CSI node plugin requests 1 GiB and is limited to 4 GiB after a 1 GiB OOM invalidated node-local FUSE mounts.
 1. CSI read affinity is enabled with `kubernetes.io/hostname` CRUSH location labels so clients can prefer closer replicas when topology allows it.
 
 These defaults do not remove the known topology ceiling:
@@ -60,7 +61,7 @@ kubectl apply -f kubernetes/rook-ceph-rwx-benchmarks/job-rook-cephfs-fuse.yaml
 kubectl -n rook-ceph-benchmarks logs -f job/rook-cephfs-fuse-benchmark
 ```
 
-Run the kernel benchmark job only after labeling a kernel-capable worker pool:
+Run the kernel benchmark job after labeling the target worker pool:
 
 ```bash
 kubectl label node <node-name> storage.proompteng.ai/cephfs-kernel-client=true
@@ -97,7 +98,7 @@ If you are comparing kernel vs FUSE, collect the same evidence set for both runs
 If `rook-cephfs` materially outperforms `rook-cephfs-fuse`:
 
 1. Keep FUSE as the compatibility class.
-1. Migrate only the performance-sensitive RWX workloads to a kernel-capable worker pool.
+1. Keep durable and performance-sensitive RWX workloads on the kernel class.
 
 If both RWX classes are slow and `ceph osd perf` stays high:
 

--- a/docs/runbooks/rook-ceph-rwx-performance.md
+++ b/docs/runbooks/rook-ceph-rwx-performance.md
@@ -31,7 +31,7 @@ Current GitOps defaults are tuned for safe first-pass RWX investigations:
 1. The live `CephFilesystem` keeps `activeCount: 1` and `activeStandby: true`.
 1. The MDS pods have explicit resources: requests `2 CPU / 8Gi`, limits `4 CPU / 16Gi`.
 1. Both RWX classes set `noatime`; the kernel class also sets `ms_mode=crc` for messenger v2 negotiation.
-1. The CephFS CSI node plugin requests 1 GiB and is limited to 4 GiB after a 1 GiB OOM invalidated node-local FUSE mounts.
+1. The CephFS CSI node plugin requests 1 GiB and is limited to 4 GiB after a 1 GiB OOM invalidated node-local FUSE mounts; its `OnDelete` strategy requires a controlled node rollout.
 1. CSI read affinity is enabled with `kubernetes.io/hostname` CRUSH location labels so clients can prefer closer replicas when topology allows it.
 
 These defaults do not remove the known topology ceiling:


### PR DESCRIPTION
## Summary

- Make kernel CephFS the documented Talos default and negotiate messenger v2 with `ms_mode=crc`.
- Raise the CephFS CSI plugin from the OOM-prone 1 GiB limit to a 1 GiB request and 4 GiB limit.
- Keep FUSE as an explicit compatibility class and document the non-destructive static-PV migration procedure.
- Roll CephFS node plugins one node at a time.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kubectl kustomize --enable-helm argocd/applications/rook-ceph`
- `kubeconform -strict -ignore-missing-schemas -summary /tmp/rook-ceph-kernel-render.yaml`
- `bun run lint:argocd`
- Render inspection confirmed `CSI_CEPHFS_KERNEL_MOUNT_OPTIONS=ms_mode=crc`, a 4 GiB plugin limit, and `rook-cephfs` mount options.

## Breaking Changes

None. The CSI node-plugin DaemonSet will roll one node at a time after merge; existing kernel mounts remain valid.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.