### PR TITLE
fix(rook-ceph): persist CSI operator defaults

### DIFF
--- a/argocd/applications/rook-ceph/cluster-values.yaml
+++ b/argocd/applications/rook-ceph/cluster-values.yaml
@@ -146,6 +146,9 @@ cephClusterSpec:
         memory: 8Gi
 
   csi:
+    cephfs:
+      # The CSI-operator path sources per-cluster mount defaults from the CephCluster.
+      kernelMountOptions: "ms_mode=crc"
     readAffinity:
       enabled: true
       crushLocationLabels:

--- a/argocd/applications/rook-ceph/operator-values.yaml
+++ b/argocd/applications/rook-ceph/operator-values.yaml
@@ -48,6 +48,9 @@ csi:
   # FUSE mount processes live inside this pod. Roll nodes only after inventorying
   # and restarting the node's FUSE consumers through a controlled operation.
   cephFSPluginUpdateStrategy: OnDelete
+  # Rook v1.19.7's CSI-operator path reads the RBD strategy when constructing the
+  # CephFS Driver CR. Keep both OnDelete until that upstream mapping bug is fixed.
+  rbdPluginUpdateStrategy: OnDelete
   # A 1 GiB limit OOM-killed ceph-fuse and invalidated every FUSE mount on the node.
   # Media workloads use the kernel client, while this headroom protects compatibility clients.
   csiCephFSPluginResource: |

--- a/docs/runbooks/cephfs-fuse-on-talos.md
+++ b/docs/runbooks/cephfs-fuse-on-talos.md
@@ -14,9 +14,11 @@ The required defaults are:
 - `rook-cephfs` uses the kernel mounter with `noatime` and `ms_mode=crc`.
 - `rook-cephfs-fuse` explicitly sets `mounter: fuse`.
 - The CephFS CSI node plugin requests 1 GiB and is limited to 4 GiB.
-- The CephFS CSI node-plugin DaemonSet uses `OnDelete` so an operator must coordinate each node rollout with its FUSE consumers.
+- The CephFS and RBD CSI node-plugin DaemonSets use `OnDelete` so an operator must coordinate each node rollout with its consumers.
 
 `ms_mode=crc` is required for the kernel client to negotiate Ceph messenger v2 with the current cluster. Do not remove it from either the Rook CSI default or the kernel StorageClass without a mount canary.
+
+Rook v1.19.7's CSI-operator path incorrectly uses `CSI_RBD_PLUGIN_UPDATE_STRATEGY` when building the CephFS `Driver` CR. `operator-values.yaml` therefore sets both the RBD and CephFS strategies to `OnDelete`. Remove the RBD workaround only after an upgrade proves the live CephFS `Driver` independently reports `OnDelete`.
 
 ## Why Kernel Is The Default
 


### PR DESCRIPTION
## Summary

- Persist `ms_mode=crc` in the CephCluster CSI spec used by the CSI-operator path.
- Work around Rook v1.19.7 reading the RBD strategy while constructing the CephFS Driver CR by setting both node-plugin strategies to `OnDelete`.
- Document the workaround and the live-CR condition required before removing it.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kubectl kustomize --enable-helm argocd/applications/rook-ceph`
- `kubeconform -strict -ignore-missing-schemas -summary /tmp/rook-ceph-csi-defaults-render.yaml`
- `bun run lint:argocd`
- Render inspection confirmed both CSI plugin strategies are `OnDelete` and `CephCluster.spec.csi.cephfs.kernelMountOptions` is `ms_mode=crc`.

## Breaking Changes

None. Future CSI node-plugin updates require an explicit, consumer-aware pod replacement.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.