### PR TITLE
perf(bayn): minimize runtime image

### DIFF
--- a/nix/images/bayn.nix
+++ b/nix/images/bayn.nix
@@ -10,7 +10,10 @@ import ./bun-workspace-service.nix {
   inherit pkgs lib repoRoot bun nodejs;
   serviceName = "bayn";
   packageName = "@proompteng/bayn";
-  depsHash = lib.fakeHash;
+  depsHash = {
+    x86_64-linux = "sha256-PBr4Y0Rbp46sFbyzBwxifHCrHbJyVDZ1GpSouTy2YlI=";
+    aarch64-linux = "sha256-nCx2hzMO0DEyX2hqay6/aVRk8GD/1CNKVY36BJgJ/DY=";
+  };
   installFilters = [
     "@proompteng/bayn"
   ];

--- a/nix/images/bayn.nix
+++ b/nix/images/bayn.nix
@@ -10,10 +10,7 @@ import ./bun-workspace-service.nix {
   inherit pkgs lib repoRoot bun nodejs;
   serviceName = "bayn";
   packageName = "@proompteng/bayn";
-  depsHash = {
-    x86_64-linux = "sha256-IvtIdhCRXFARgVPK8cYVFfhzRP8Wf02qSnYPAIu9crI=";
-    aarch64-linux = "sha256-xYEerzc3xv94pMQNn/wuxUGy0cMCffMkty3hoCYGkhw=";
-  };
+  depsHash = lib.fakeHash;
   installFilters = [
     "@proompteng/bayn"
   ];
@@ -24,11 +21,19 @@ import ./bun-workspace-service.nix {
     "bun --cwd=services/bayn run tsc"
     "bun --cwd=services/bayn run build"
   ];
+  runtimeInstallPhase = ''
+    mkdir -p "$out/app/services/bayn/dist" "$out/app/services/bayn/node_modules/tigerbeetle-node"
+    cp "$TMPDIR/work/services/bayn/dist/index.js" "$out/app/services/bayn/dist/index.js"
+    cp "$TMPDIR/work/services/bayn/package.json" "$out/app/services/bayn/package.json"
+    cp -R -L "$TMPDIR/work/services/bayn/node_modules/tigerbeetle-node/." \
+      "$out/app/services/bayn/node_modules/tigerbeetle-node/"
+  '';
   command = [
     "node"
     "dist/index.js"
   ];
   workingDir = "/app/services/bayn";
+  includeBunRuntime = false;
   extraContents = [
     nodejs
   ];

--- a/nix/images/bun-workspace-service.nix
+++ b/nix/images/bun-workspace-service.nix
@@ -261,7 +261,6 @@ if returnRuntimeRoot then builtRuntimeRoot else pkgs.dockerTools.buildLayeredIma
   inherit maxLayers;
   contents = [
     resolvedRuntimeRoot
-    bun
     pkgs.busybox
     pkgs.cacert
     pkgs.coreutils

--- a/nix/images/bun-workspace-service.nix
+++ b/nix/images/bun-workspace-service.nix
@@ -23,6 +23,7 @@
   maxLayers ? 24,
   runtimeRoot ? null,
   returnRuntimeRoot ? false,
+  includeBunRuntime ? true,
 }:
 
 let
@@ -248,11 +249,11 @@ let
 
   resolvedRuntimeRoot = if runtimeRoot == null then builtRuntimeRoot else runtimeRoot;
 
-  runtimePath = lib.makeBinPath ([
-    bun
+  runtimeTools = (lib.optionals includeBunRuntime [ bun ]) ++ [
     pkgs.busybox
     pkgs.coreutils
-  ] ++ extraContents);
+  ] ++ extraContents;
+  runtimePath = lib.makeBinPath runtimeTools;
 in
 if returnRuntimeRoot then builtRuntimeRoot else pkgs.dockerTools.buildLayeredImage {
   name = "registry.ide-newton.ts.net/lab/${imageName}";
@@ -264,7 +265,7 @@ if returnRuntimeRoot then builtRuntimeRoot else pkgs.dockerTools.buildLayeredIma
     pkgs.busybox
     pkgs.cacert
     pkgs.coreutils
-  ] ++ extraContents;
+  ] ++ (lib.optionals includeBunRuntime [ bun ]) ++ extraContents;
   extraCommands = ''
     mkdir -p tmp var/tmp
     chmod 1777 tmp var/tmp

--- a/services/bayn/package.json
+++ b/services/bayn/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "bun build src/index.ts src/backfill.ts --target=node --packages=external --outdir=dist",
+    "build": "bun build src/index.ts src/backfill.ts --target=node --external tigerbeetle-node --outdir=dist",
     "dev": "bun --watch src/index.ts",
     "start": "node dist/index.js",
     "backfill": "bun src/backfill.ts",


### PR DESCRIPTION
## Summary

- Bundle the Effect and ClickHouse JavaScript dependencies into the Bayn entrypoint.
- Ship only the production entrypoint and TigerBeetle native client instead of the workspace dependency closure.
- Make Bun optional in the shared runtime image helper and omit it from the Node-based Bayn image.

## Related Issues

PROOMPT-348, PROOMPT-353

## Testing

- `bun --cwd=services/bayn run tsc`
- `bun --cwd=services/bayn run build`
- `bun --cwd=services/bayn run lint:oxlint:type`
- `bun --cwd=services/bayn test` (9 passing)
- `nix-instantiate --parse nix/images/bun-workspace-service.nix`
- `nix-instantiate --parse nix/images/bayn.nix`
- Assembled the production layout locally (5.3 MiB application payload) and ran it against live Signal ClickHouse and TigerBeetle: `/healthz` and `/readyz` passed, the deterministic evaluation completed, and reconciliation was exact (13 accounts, 767 transfers).

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
