### PR TITLE
chore(torghut): promote notebook image sha-cc502658668cf0c220dc1c2c0110b346f0504c8c

### DIFF
--- a/argocd/applications/torghut/notebooks/values.yaml
+++ b/argocd/applications/torghut/notebooks/values.yaml
@@ -93,7 +93,7 @@ proxy:
 singleuser:
   image:
     name: registry.ide-newton.ts.net/lab/torghut-notebook@sha256
-    tag: '30e85c4d868f8206cd5b3087c31e00dd5c19d282c940b4594753ace5fffe0d9f'
+    tag: 'e8104998625ee80b8231e79542df2e945fdf47af03b1be1d2230edbe8483a9a9'
     pullPolicy: IfNotPresent
   defaultUrl: /lab/tree/work/00-system-flow.ipynb
   startTimeout: 600


### PR DESCRIPTION
## Summary

- Promote the immutable multi-architecture Torghut notebook image built from `cc502658668cf0c220dc1c2c0110b346f0504c8c`.
- Update only the digest-pinned JupyterHub single-user image.

## Related Issues

None.

## Testing

- The source commit passed notebook fixture execution and manifest contracts.
- The release workflow verified `linux/amd64` and `linux/arm64` for `sha256:e8104998625ee80b8231e79542df2e945fdf47af03b1be1d2230edbe8483a9a9`.

## Breaking Changes

None.

## Checklist

- [x] The single-user image is immutable and multi-architecture.
- [x] Promotion changes only the notebook image digest.
- [x] PVCs and read-only credentials are unchanged.