### PR TITLE
fix(bayn): expose the required liveness endpoint

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -78,7 +78,7 @@ spec:
               value: production
           startupProbe:
             httpGet:
-              path: /healthz
+              path: /livez
               port: http
             periodSeconds: 2
             failureThreshold: 30
@@ -91,7 +91,7 @@ spec:
             failureThreshold: 2
           livenessProbe:
             httpGet:
-              path: /healthz
+              path: /livez
               port: http
             periodSeconds: 10
             timeoutSeconds: 2

--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -18,7 +18,7 @@ and journals the resulting simulation to TigerBeetle. It contains no broker clie
 
 ## Endpoints
 
-- `GET /healthz`: process liveness.
+- `GET /livez`: process liveness.
 - `GET /readyz`: dependency/evaluation/accounting readiness.
 - `GET /v1/status` and `GET /v1/evidence/latest`: authority boundary, input manifest, metrics, verdict, and
   reconciliation receipt.

--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Effect, Ref } from 'effect'
+
+import { makeHttpServer, type RuntimeState } from './app'
+
+describe('Bayn HTTP probes', () => {
+  test('serves process liveness at /livez', async () => {
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const state = yield* Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null })
+          const server = yield* makeHttpServer({ host: '127.0.0.1', port: 0 }, state)
+          const address = server.address()
+          if (!address || typeof address === 'string') throw new Error('test server did not bind a TCP port')
+
+          const result = yield* Effect.promise(async () => {
+            const response = await fetch(`http://127.0.0.1:${address.port}/livez`)
+            return { status: response.status, body: await response.json() }
+          })
+          expect(result).toEqual({ status: 200, body: { service: 'bayn', live: true } })
+        }),
+      ),
+    )
+  })
+})

--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -14,7 +14,7 @@ interface RuntimeEvidence {
   readonly reconciliation: ReconciliationResult
 }
 
-type RuntimeState =
+export type RuntimeState =
   | { readonly status: 'STARTING'; readonly evidence: null; readonly error: null }
   | { readonly status: 'READY'; readonly evidence: RuntimeEvidence; readonly error: null }
   | { readonly status: 'FAIL_CLOSED'; readonly evidence: null; readonly error: string }
@@ -30,7 +30,7 @@ const publicState = (state: RuntimeState) => ({
   error: state.error,
 })
 
-const makeHttpServer = (config: BaynConfig, state: Ref.Ref<RuntimeState>) =>
+export const makeHttpServer = (config: Pick<BaynConfig, 'host' | 'port'>, state: Ref.Ref<RuntimeState>) =>
   Effect.acquireRelease(
     Effect.async<Server, Error>((resume) => {
       const server = createServer((request, response) => {
@@ -41,7 +41,7 @@ const makeHttpServer = (config: BaynConfig, state: Ref.Ref<RuntimeState>) =>
             response.end(json({ error: 'method_not_allowed' }))
             return
           }
-          if (path === '/healthz') {
+          if (path === '/livez') {
             response.writeHead(200, { 'content-type': 'application/json' })
             response.end(json({ service: 'bayn', live: true }))
             return


### PR DESCRIPTION
## Summary

- Expose the milestone-required process liveness contract at `GET /livez`.
- Point startup and liveness probes at `/livez` and update service documentation.
- Add a real HTTP regression test that binds an ephemeral port and verifies the response.

## Related Issues

PROOMPT-348

## Testing

- `bunx oxfmt --check services/bayn/src/app.ts services/bayn/src/app.test.ts services/bayn/README.md argocd/applications/bayn/deployment.yaml`
- `bun run --cwd services/bayn tsc`
- `bun run --cwd services/bayn test`
- `bun run --cwd services/bayn lint:oxlint`
- `bun run --cwd services/bayn lint:oxlint:type`
- `bun run --cwd services/bayn build`
- `kustomize build argocd/applications/bayn` plus rendered probe assertions

## Breaking Changes

None. Bayn has not been activated in Argo CD yet.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.