### PR TITLE
chore(product): promote nix product images

### DIFF
--- a/argocd/applications/app/kustomization.yaml
+++ b/argocd/applications/app/kustomization.yaml
@@ -8,5 +8,5 @@ resources:
   - secret.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/app
-    digest: sha256:5f9fccd2e917c4438674b7865f454945b3b6343a3b0cd189ae96e7680d1ad3cc
+    digest: sha256:4c14c4b5ac47f28485d3cd23d625b2d279fdb7656882e72504b4181af885c897
     newName: registry.ide-newton.ts.net/lab/app

--- a/argocd/applications/docs/kustomization.yaml
+++ b/argocd/applications/docs/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
   - generated
 images:
   - name: registry.ide-newton.ts.net/lab/docs
-    digest: sha256:00112453c5b20135b7aa461308a79082fb49c2420eaa30e5c6dcd6e4abdc0f6c
+    digest: sha256:0098e452442eef1ff65d36a6bd03a9add43cd199e6b80e075a8f47b3787c1127
     newName: registry.ide-newton.ts.net/lab/docs

--- a/argocd/applications/proompteng/kustomization.yaml
+++ b/argocd/applications/proompteng/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
 - ingressroute.yaml
 images:
 - name: registry.ide-newton.ts.net/lab/proompteng
-  digest: sha256:552f9d8a9c0a18cbd6e9d33847bef0da4bcdbe1c4bc59adfd425643fa1694fa2
+  digest: sha256:c2b17249e80a6319f25179ac6f78d32e79a4b531ca78e0eb627094abffddc19e
   newName: registry.ide-newton.ts.net/lab/proompteng

--- a/argocd/applications/synthesis/kustomization.yaml
+++ b/argocd/applications/synthesis/kustomization.yaml
@@ -11,5 +11,5 @@ resources:
   - agents-domain
 images:
   - name: registry.ide-newton.ts.net/lab/synthesis
-    digest: sha256:08fd7deddd0b65e1bd1e53639e01aad4a7ad1a8a7e041493c0a37f19f78ae24c
+    digest: sha256:35562eefe6b156ad1c34091b1c352a28caff339e88ba9b132f32ad9281444e49
     newName: registry.ide-newton.ts.net/lab/synthesis


### PR DESCRIPTION
## Summary

- Promote enabled product app image digests built by the shared Nix OCI workflow.
- `app`: `registry.ide-newton.ts.net/lab/app@sha256:4c14c4b5ac47f28485d3cd23d625b2d279fdb7656882e72504b4181af885c897` from `6b302932f9881d02141c51ac2d215525841e3a8e`
- `docs`: `registry.ide-newton.ts.net/lab/docs@sha256:0098e452442eef1ff65d36a6bd03a9add43cd199e6b80e075a8f47b3787c1127` from `6b302932f9881d02141c51ac2d215525841e3a8e`
- `proompteng`: `registry.ide-newton.ts.net/lab/proompteng@sha256:c2b17249e80a6319f25179ac6f78d32e79a4b531ca78e0eb627094abffddc19e` from `6b302932f9881d02141c51ac2d215525841e3a8e`
- `synthesis`: `registry.ide-newton.ts.net/lab/synthesis@sha256:35562eefe6b156ad1c34091b1c352a28caff339e88ba9b132f32ad9281444e49` from `6b302932f9881d02141c51ac2d215525841e3a8e`

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- <image>@<digest> linux/amd64 linux/arm64` for each promoted image.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.