### PR TITLE
chore(bayn): promote image sha-b742eab5c3e46e93b6ae6811b8487058aa94cc2c

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: bayn
         app.kubernetes.io/part-of: bayn
       annotations:
-        kubectl.kubernetes.io/restartedAt: "1970-01-01T00:00:00Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-19T10:23:41Z"
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
@@ -47,7 +47,7 @@ spec:
               protocol: TCP
           env:
             - name: BAYN_CODE_REVISION
-              value: bootstrap
+              value: b742eab5c3e46e93b6ae6811b8487058aa94cc2c
             - name: BAYN_RUN_ON_STARTUP
               value: "true"
             - name: BAYN_CLICKHOUSE_URL

--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -10,4 +10,5 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/bayn
     newName: registry.ide-newton.ts.net/lab/bayn
-    newTag: bootstrap
+    newTag: "sha-b742eab5c3e46e93b6ae6811b8487058aa94cc2c"
+    digest: sha256:c042cfaafe323a9a91b48bc2227a5f849607851e941d1cab1fe85bd1d3b9d416

--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -387,7 +387,7 @@ spec:
                     pod-security.kubernetes.io/audit: restricted
                     pod-security.kubernetes.io/warn: restricted
                 automation: auto
-                enabled: "false"
+                enabled: "true"
               - name: torghut-options
                 path: argocd/applications/torghut-options
                 namespace: torghut


### PR DESCRIPTION
## Summary

Promote the immutable Bayn image, activate the Bayn Argo application, and bind runtime evidence to its
source commit.

- Source commit: `b742eab5c3e46e93b6ae6811b8487058aa94cc2c`
- Image tag: `sha-b742eab5c3e46e93b6ae6811b8487058aa94cc2c`
- Image digest: `sha256:c042cfaafe323a9a91b48bc2227a5f849607851e941d1cab1fe85bd1d3b9d416`

## Related Issues

PROOMPT-353

## Testing

- OCI index contains `linux/amd64` and `linux/arm64`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents exact validation.
- [x] Runtime source revision and image digest are immutable.
- [x] No broker or capital-promotion authority is introduced.