### PR TITLE
fix(bayn): resolve TigerBeetle service addresses

### DIFF
--- a/services/bayn/src/ledger.test.ts
+++ b/services/bayn/src/ledger.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 import type { Account, Transfer } from 'tigerbeetle-node'
 
-import { assertReconciled, buildLedgerPlan } from './ledger'
+import { assertReconciled, buildLedgerPlan, resolveReplicaAddresses } from './ledger'
 import { defaultProtocol } from './protocol'
 import { evaluateTsmom } from './strategy'
 import { makeSnapshot } from './test-fixtures'
@@ -51,5 +51,31 @@ describe('TigerBeetle simulation journal', () => {
         transfers,
       ),
     ).toThrow('balance does not reconcile exactly')
+  })
+})
+
+describe('TigerBeetle replica addresses', () => {
+  test('resolves service hostnames once at startup and preserves numeric addresses', async () => {
+    const lookups: string[] = []
+    const addresses = await resolveReplicaAddresses(
+      ['torghut-tigerbeetle.torghut.svc.cluster.local:3000', '10.244.5.234:3000', '3001'],
+      async (hostname) => {
+        lookups.push(hostname)
+        return ['10.244.5.234', '10.244.5.235']
+      },
+    )
+
+    expect(lookups).toEqual(['torghut-tigerbeetle.torghut.svc.cluster.local'])
+    expect(addresses).toEqual(['10.244.5.234:3000', '10.244.5.235:3000', '3001'])
+  })
+
+  test('rejects malformed, out-of-range, and IPv6-only endpoints', async () => {
+    expect(resolveReplicaAddresses(['missing-port'], async () => ['10.0.0.1'])).rejects.toThrow(
+      'invalid TigerBeetle replica address',
+    )
+    expect(resolveReplicaAddresses(['replica:70000'], async () => ['10.0.0.1'])).rejects.toThrow(
+      'invalid TigerBeetle replica port',
+    )
+    expect(resolveReplicaAddresses(['replica:3000'], async () => ['::1'])).rejects.toThrow('has no IPv4 address')
   })
 })

--- a/services/bayn/src/ledger.ts
+++ b/services/bayn/src/ledger.ts
@@ -1,3 +1,6 @@
+import { lookup } from 'node:dns/promises'
+import { isIP } from 'node:net'
+
 import {
   AccountFlags,
   type Account,
@@ -16,6 +19,53 @@ import type { EvaluationResult, FillEvent, ReconciliationResult } from './types'
 
 const SCHEMA_VERSION = 1
 const BATCH_MAX = 8_189
+
+type ResolveHostname = (hostname: string) => Promise<readonly string[]>
+
+const lookupIpv4: ResolveHostname = async (hostname) =>
+  (await lookup(hostname, { all: true, family: 4, verbatim: true })).map(({ address }) => address)
+
+const parsePort = (value: string, address: string): number => {
+  if (!/^\d+$/.test(value)) throw new Error(`invalid TigerBeetle replica address: ${address}`)
+  const port = Number(value)
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error(`invalid TigerBeetle replica port: ${address}`)
+  }
+  return port
+}
+
+export const resolveReplicaAddresses = async (
+  configuredAddresses: readonly string[],
+  resolveHostname: ResolveHostname = lookupIpv4,
+): Promise<string[]> => {
+  if (configuredAddresses.length === 0) throw new Error('at least one TigerBeetle replica address is required')
+
+  const resolved = await Promise.all(
+    configuredAddresses.map(async (configuredAddress) => {
+      const address = configuredAddress.trim()
+      if (/^\d+$/.test(address)) {
+        parsePort(address, address)
+        return [address]
+      }
+
+      const separator = address.lastIndexOf(':')
+      if (separator <= 0 || separator !== address.indexOf(':')) {
+        throw new Error(`invalid TigerBeetle replica address: ${configuredAddress}`)
+      }
+      const hostname = address.slice(0, separator)
+      const port = parsePort(address.slice(separator + 1), address)
+      const addressFamily = isIP(hostname)
+      if (addressFamily === 4) return [`${hostname}:${port}`]
+      if (addressFamily === 6) throw new Error(`IPv6 TigerBeetle replica addresses are not supported: ${address}`)
+
+      const ipv4Addresses = (await resolveHostname(hostname)).filter((value) => isIP(value) === 4)
+      if (ipv4Addresses.length === 0) throw new Error(`TigerBeetle replica hostname has no IPv4 address: ${hostname}`)
+      return ipv4Addresses.map((ipv4Address) => `${ipv4Address}:${port}`)
+    }),
+  )
+
+  return [...new Set(resolved.flat())]
+}
 
 const AccountCode = {
   cash: 110,
@@ -379,11 +429,11 @@ export const JournalLive = (config: BaynConfig): Layer.Layer<JournalService, Err
   Layer.scoped(
     Journal,
     Effect.acquireRelease(
-      Effect.try({
-        try: () =>
+      Effect.tryPromise({
+        try: async () =>
           createClient({
             cluster_id: config.tigerBeetle.clusterId,
-            replica_addresses: [...config.tigerBeetle.replicaAddresses],
+            replica_addresses: await resolveReplicaAddresses(config.tigerBeetle.replicaAddresses),
           }),
         catch: (cause) => new Error(`failed to create TigerBeetle client: ${String(cause)}`),
       }),


### PR DESCRIPTION
## Summary

- resolve configured TigerBeetle service hostnames to IPv4 addresses once during client startup
- preserve TigerBeetle numeric endpoint forms without pinning a Kubernetes ClusterIP in GitOps
- fail startup on malformed, unsupported, or unresolvable replica endpoints

## Related Issues

PROOMPT-351, PROOMPT-353

## Testing

- `bunx oxfmt --check services/bayn/src/ledger.ts services/bayn/src/ledger.test.ts`
- `bun run --cwd services/bayn tsc`
- `bun run --cwd services/bayn lint:oxlint`
- `bun run --cwd services/bayn lint:oxlint:type`
- `bun run --cwd services/bayn test` (12 passed)
- `bun run --cwd services/bayn build`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or not required.