### PR TITLE
chore(bayn): promote image sha-4c6ae65cf7aa3dd8e1d99b41adffd558399d212b

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: bayn
         app.kubernetes.io/part-of: bayn
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-19T10:23:41Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-19T10:44:17Z"
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
@@ -47,7 +47,7 @@ spec:
               protocol: TCP
           env:
             - name: BAYN_CODE_REVISION
-              value: b742eab5c3e46e93b6ae6811b8487058aa94cc2c
+              value: 4c6ae65cf7aa3dd8e1d99b41adffd558399d212b
             - name: BAYN_RUN_ON_STARTUP
               value: "true"
             - name: BAYN_CLICKHOUSE_URL

--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -10,5 +10,5 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/bayn
     newName: registry.ide-newton.ts.net/lab/bayn
-    newTag: "sha-b742eab5c3e46e93b6ae6811b8487058aa94cc2c"
-    digest: sha256:c042cfaafe323a9a91b48bc2227a5f849607851e941d1cab1fe85bd1d3b9d416
+    newTag: "sha-4c6ae65cf7aa3dd8e1d99b41adffd558399d212b"
+    digest: sha256:af149867c034fe3561fd2987439e7e925a3dc38d3f3f61010a46749334fd4d10


### PR DESCRIPTION
## Summary

Promote the immutable Bayn image, activate the Bayn Argo application, and bind runtime evidence to its
source commit.

- Source commit: `4c6ae65cf7aa3dd8e1d99b41adffd558399d212b`
- Image tag: `sha-4c6ae65cf7aa3dd8e1d99b41adffd558399d212b`
- Image digest: `sha256:af149867c034fe3561fd2987439e7e925a3dc38d3f3f61010a46749334fd4d10`

## Related Issues

PROOMPT-353

## Testing

- OCI index contains `linux/amd64` and `linux/arm64`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents exact validation.
- [x] Runtime source revision and image digest are immutable.
- [x] No broker or capital-promotion authority is introduced.