### PR TITLE
fix(bayn): permit TigerBeetle io_uring

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -104,6 +104,10 @@ spec:
               cpu: "2"
               memory: 1Gi
           securityContext:
+            # TigerBeetle's native client requires io_uring, which containerd's
+            # RuntimeDefault seccomp profile blocks. Keep every other control.
+            seccompProfile:
+              type: Unconfined
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             capabilities:

--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -383,7 +383,9 @@ spec:
                   argocd.argoproj.io/sync-wave: "7"
                 managedNamespaceMetadata:
                   labels:
-                    pod-security.kubernetes.io/enforce: restricted
+                    # The TigerBeetle client requires an explicit io_uring seccomp exception.
+                    # The Bayn container remains non-root with no capabilities or privilege escalation.
+                    pod-security.kubernetes.io/enforce: privileged
                     pod-security.kubernetes.io/audit: restricted
                     pod-security.kubernetes.io/warn: restricted
                 automation: auto


### PR DESCRIPTION
## Summary

- allow the Bayn container to use the `io_uring` syscalls required by TigerBeetle
- make the namespace admission exception explicit while continuing to audit and warn against the restricted policy
- retain non-root execution, dropped capabilities, disabled privilege escalation, a read-only root filesystem, and network isolation

## Related Issues

PROOMPT-351, PROOMPT-353

## Testing

- `kustomize build argocd/applications/bayn | kubectl -n bayn apply --dry-run=server -f -`
- `bash scripts/kubeconform.sh argocd/applications/bayn argocd/applicationsets/product.yaml` (6 valid, 0 invalid)
- `kubectl -n argocd apply --dry-run=server -f argocd/applicationsets/product.yaml`
- `git diff --check`

## Breaking Changes

The Bayn namespace no longer enforces the restricted Pod Security Standard because TigerBeetle requires an explicit unconfined seccomp profile. Restricted-policy audit and warning remain enabled, and the container retains all other hardening controls.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or not required.