### PR TITLE
fix(bayn): adopt Effect 4 fail-closed runtime

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -50,6 +50,8 @@ spec:
               value: 4c6ae65cf7aa3dd8e1d99b41adffd558399d212b
             - name: BAYN_RUN_ON_STARTUP
               value: "true"
+            - name: BAYN_OPERATION_TIMEOUT_MS
+              value: "30000"
             - name: BAYN_CLICKHOUSE_URL
               value: http://torghut-clickhouse.torghut.svc.cluster.local:8123
             - name: BAYN_CLICKHOUSE_USERNAME

--- a/bun.lock
+++ b/bun.lock
@@ -717,8 +717,9 @@
       "name": "@proompteng/bayn",
       "version": "0.1.0",
       "dependencies": {
-        "@clickhouse/client": "^1.23.1",
-        "effect": "^3.21.2",
+        "@clickhouse/client": "1.23.1",
+        "@effect/platform-node": "4.0.0-beta.99",
+        "effect": "4.0.0-beta.99",
         "tigerbeetle-node": "0.17.9",
       },
       "devDependencies": {
@@ -6190,6 +6191,10 @@
 
     "@proompteng/agents/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
+    "@proompteng/bayn/@effect/platform-node": ["@effect/platform-node@4.0.0-beta.99", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.99", "mime": "^4.1.0", "undici": "^8.7.0" }, "peerDependencies": { "effect": "^4.0.0-beta.99", "ioredis": "^5.7.0" } }, "sha512-jnK2KMW4W50AEOKK+Tgvab3YPHBxa3ApLQE8BCad+LH57JOziKzOjqtEpAgJgmao3t77x1UESK4JraaHJDHaYA=="],
+
+    "@proompteng/bayn/effect": ["effect@4.0.0-beta.99", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-hP1C61uzINfLl/4kKMwcqksxd34s4sQ3VSjsWjhGrkx9CRlXaqnfOK9dpTEKynQ6rA7wU9rb3c+48eDYw7uzxA=="],
+
     "@proompteng/bumba/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "@proompteng/design/react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
@@ -7404,6 +7409,26 @@
 
     "@proompteng/agents/nitro/rolldown": ["rolldown@1.0.2", "", { "dependencies": { "@oxc-project/types": "=0.132.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.2", "@rolldown/binding-darwin-arm64": "1.0.2", "@rolldown/binding-darwin-x64": "1.0.2", "@rolldown/binding-freebsd-x64": "1.0.2", "@rolldown/binding-linux-arm-gnueabihf": "1.0.2", "@rolldown/binding-linux-arm64-gnu": "1.0.2", "@rolldown/binding-linux-arm64-musl": "1.0.2", "@rolldown/binding-linux-ppc64-gnu": "1.0.2", "@rolldown/binding-linux-s390x-gnu": "1.0.2", "@rolldown/binding-linux-x64-gnu": "1.0.2", "@rolldown/binding-linux-x64-musl": "1.0.2", "@rolldown/binding-openharmony-arm64": "1.0.2", "@rolldown/binding-wasm32-wasi": "1.0.2", "@rolldown/binding-win32-arm64-msvc": "1.0.2", "@rolldown/binding-win32-x64-msvc": "1.0.2" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g=="],
 
+    "@proompteng/bayn/@effect/platform-node/@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.99", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.0" }, "peerDependencies": { "effect": "^4.0.0-beta.99" } }, "sha512-POBAowafsAAb3bH1x1rJlWnv32yMAazFgEuRW5LhkW/JJA5VGoEk9OnuoUkIH1OW6K/X6IrdNpqcO+5e9lPQJA=="],
+
+    "@proompteng/bayn/@effect/platform-node/mime": ["mime@4.1.0", "", { "bin": { "mime": "bin/cli.js" } }, "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw=="],
+
+    "@proompteng/bayn/@effect/platform-node/undici": ["undici@8.7.0", "", {}, "sha512-N7iQtfyLhIMOFgQubvmLV26svHpO0bqKnAiWotTQCVKCmWrcGbBotPuW1x+xwYZ2VHdSTVUfPQQnlEt1/LouTQ=="],
+
+    "@proompteng/bayn/effect/fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
+
+    "@proompteng/bayn/effect/ini": ["ini@7.0.0", "", {}, "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w=="],
+
+    "@proompteng/bayn/effect/msgpackr": ["msgpackr@2.0.4", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.4" } }, "sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA=="],
+
+    "@proompteng/bayn/effect/multipasta": ["multipasta@0.2.8", "", {}, "sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q=="],
+
+    "@proompteng/bayn/effect/toml": ["toml@4.3.0", "", {}, "sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A=="],
+
+    "@proompteng/bayn/effect/uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
+
+    "@proompteng/bayn/effect/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
     "@proompteng/golink/nitro/crossws": ["crossws@0.4.10", "", { "peerDependencies": { "srvx": ">=0.11.5" }, "optionalPeers": ["srvx"] }, "sha512-pz3oubH/dt12KjqsUB0IuXW4nwRDQ583iDsP4555Cpdqx0NoU7pGlWBcayyFI8f/l/idRpgjMEfwuOxSWJYlIA=="],
 
     "@proompteng/golink/nitro/env-runner": ["env-runner@0.1.16", "", { "dependencies": { "crossws": "^0.4.8", "exsolve": "^1.1.0", "httpxy": "^0.5.4", "srvx": "^0.11.19" }, "peerDependencies": { "@netlify/runtime": "^4.1.23", "@vercel/queue": ">=0.2.0", "miniflare": "^4.20260515.0", "wrangler": "^4.0.0" }, "optionalPeers": ["@netlify/runtime", "@vercel/queue", "miniflare", "wrangler"], "bin": { "env-runner": "dist/cli.mjs" } }, "sha512-2LRJM4P2KLX6J83QZZrMqvgCDt/D5ea7wPcI3yYiy5cG/9rX5QwdwZFx0D7ktWnjdRyZxYjttGGorb5nFqb1CA=="],
@@ -8442,6 +8467,12 @@
 
     "@proompteng/agents/nitro/rolldown/@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ=="],
 
+    "@proompteng/bayn/@effect/platform-node/@effect/platform-node-shared/ws": ["ws@8.21.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw=="],
+
+    "@proompteng/bayn/effect/fast-check/pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
+
+    "@proompteng/bayn/effect/msgpackr/msgpackr-extract": ["msgpackr-extract@3.0.4", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw=="],
+
     "@proompteng/golink/nitro/env-runner/exsolve": ["exsolve@1.1.0", "", {}, "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw=="],
 
     "@proompteng/golink/nitro/env-runner/httpxy": ["httpxy@0.5.5", "", {}, "sha512-uDjmnPyp1q4Sgzf3w+J/Fc6UqcCEj0x4Wjp7OqK5dGhNeDgpyrAmnS6ey8QWrX3SWDon2DMKf9sBa5X9+CVyMA=="],
@@ -9101,6 +9132,18 @@
     "@lexical/react/@floating-ui/react/@floating-ui/react-dom/@floating-ui/dom/@floating-ui/core": ["@floating-ui/core@1.7.4", "", { "dependencies": { "@floating-ui/utils": "^0.2.10" } }, "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg=="],
 
     "@proompteng/agents/nitro/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+
+    "@proompteng/bayn/effect/msgpackr/msgpackr-extract/@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="],
+
+    "@proompteng/bayn/effect/msgpackr/msgpackr-extract/@msgpackr-extract/msgpackr-extract-darwin-x64": ["@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w=="],
+
+    "@proompteng/bayn/effect/msgpackr/msgpackr-extract/@msgpackr-extract/msgpackr-extract-linux-arm": ["@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4", "", { "os": "linux", "cpu": "arm" }, "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw=="],
+
+    "@proompteng/bayn/effect/msgpackr/msgpackr-extract/@msgpackr-extract/msgpackr-extract-linux-arm64": ["@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw=="],
+
+    "@proompteng/bayn/effect/msgpackr/msgpackr-extract/@msgpackr-extract/msgpackr-extract-linux-x64": ["@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ=="],
+
+    "@proompteng/bayn/effect/msgpackr/msgpackr-extract/@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4", "", { "os": "win32", "cpu": "x64" }, "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ=="],
 
     "@proompteng/golink/nitro/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -719,7 +719,7 @@
       "dependencies": {
         "@clickhouse/client": "^1.23.1",
         "effect": "^3.21.2",
-        "tigerbeetle-node": "0.17.4",
+        "tigerbeetle-node": "0.17.9",
       },
       "devDependencies": {
         "@types/bun": "1.3.14",
@@ -5414,7 +5414,7 @@
 
     "thread-stream": ["thread-stream@4.0.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA=="],
 
-    "tigerbeetle-node": ["tigerbeetle-node@0.17.4", "", {}, "sha512-qrqx5aHiWlLbrzD/QtueqLtPzwroA3AMkEQZxZL5dlFZE9E+SW6VMZ1sUeSGQgtZpyFArUY+fQfTAPu0DGfQcQ=="],
+    "tigerbeetle-node": ["tigerbeetle-node@0.17.9", "", {}, "sha512-jx2V8WtY1IKndEGhNWsUYHh7Sc9uYLylkJUIXwkskUm/q/ziqS3VyKzBCSTkfU4nZxkAXHeVzzbG30ENzGj68w=="],
 
     "tiny-inflate": ["tiny-inflate@1.0.3", "", {}, "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="],
 

--- a/nix/images/bayn.nix
+++ b/nix/images/bayn.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "bayn";
   packageName = "@proompteng/bayn";
   depsHash = {
-    x86_64-linux = "sha256-PBr4Y0Rbp46sFbyzBwxifHCrHbJyVDZ1GpSouTy2YlI=";
-    aarch64-linux = "sha256-nCx2hzMO0DEyX2hqay6/aVRk8GD/1CNKVY36BJgJ/DY=";
+    x86_64-linux = "sha256-Q7q40NR0JwN5VZDrEI+zmST24o26kEVfXAEpOC98KBs=";
+    aarch64-linux = "sha256-iLYAqp+YJOcc08awthTnFvHTgwNMlFy5M9OsKYdh1so=";
   };
   installFilters = [
     "@proompteng/bayn"

--- a/services/bayn/AGENTS.md
+++ b/services/bayn/AGENTS.md
@@ -11,8 +11,9 @@
 
 ## Effect baseline
 
-- `package.json` is authoritative for the Effect version. Bayn currently uses Effect 3; verify APIs against installed
-  sources or `~/github.com/effect` at `origin/v3`. That checkout's `main` is Effect 4 beta—do not copy v4-only APIs.
+- `package.json` is authoritative for the Effect version. Bayn uses the exact Effect 4 beta cohort; keep `effect` and
+  `@effect/platform-node` on the same version. Verify APIs against installed sources and `~/github.com/effect` only when
+  its package versions match. APIs under `effect/unstable/**` may change between betas, so never use floating ranges.
 - Use Effect at I/O and application boundaries, not as a wrapper around pure functions or constants.
 - Prefer official Effect integrations when they remove hand-written lifecycle, interruption, or decoding code. Add them
   as direct, peer-compatible dependencies; never rely on another workspace's transitive dependency.
@@ -21,9 +22,9 @@
 
 - Use `NodeRuntime.runMain` at the entry point. Do not build a second runtime with `runPromise(...).catch(...)`, manual
   exit codes, or process signal handlers. Let interruption unwind scopes and finalizers.
-- Define a `Context.Tag` or `Context.GenericTag` only for a real replaceable capability. Build live implementations with
-  `Layer`; assemble them once at the composition root. Do not create tags for pure helpers or single-use values.
-- Own every long-lived client, server, or background fiber with `Layer.scoped`, `Effect.acquireRelease`, or
+- Define a `Context.Service` only for a real replaceable capability. Build live implementations with `Layer`; assemble
+  them once at the composition root. Do not create services for pure helpers or single-use values.
+- Own every long-lived client, server, or background fiber with a scoped `Layer`, `Effect.acquireRelease`, or
   `Effect.forkScoped`. Acquisition, interruption, and release must have tests. Never detach a Promise or fiber.
 - Use `Effect.gen` for readable orchestration. Use `Effect.fn` for a meaningful traced operation and `Effect.fnUntraced`
   only for a reusable or measured hot helper; do not mechanically wrap one-line effects.
@@ -45,11 +46,12 @@
   service modules. Validate once at startup and keep secrets `Redacted` until the third-party client boundary.
 - Decode every external payload with `Schema` or `SqlSchema`. A TypeScript assertion such as `json<Row>()` is not
   runtime validation. Pure domain code accepts decoded values only.
-- Use `Effect.log*`, `Effect.annotateLogs`, and log spans. Production logs use `Logger.json`. Do not call `console.*`
+- Use `Effect.log*`, `Effect.annotateLogs`, and log spans. Production logs use `Logger.consoleJson`. Do not call `console.*`
   inside an Effect; direct console output is only an emergency before the runtime exists. Never log credentials.
-- For HTTP and ClickHouse, prefer `@effect/platform-node` and `@effect/sql-clickhouse` over local lifecycle wrappers.
-  Keep SQL explicit and parameterized; Effect SQL replaces plumbing, not SQL. Use a thin scoped adapter only when no
-  official integration exists, as with TigerBeetle.
+- Effect 4 HTTP lives under `effect/unstable/http`; use it with `@effect/platform-node` instead of hand-written Node
+  request, signal, or shutdown plumbing. For ClickHouse, prefer `@effect/sql-clickhouse` when its exact Effect cohort is
+  compatible. Keep SQL explicit and parameterized; Effect SQL replaces plumbing, not SQL. Use a thin scoped adapter
+  only when no official integration exists, as with TigerBeetle.
 
 ## Trading and accounting invariants
 
@@ -57,8 +59,8 @@
   evaluation. Missing, stale, malformed, or mixed-contract data fails closed.
 - TigerBeetle writes remain deterministic and idempotent. Existing IDs must be verified against the complete expected
   record, and readiness requires exact account, transfer, and balance reconciliation.
-- Do not introduce a scheduler, event bus, repository layer, generic retry framework, or abstraction for hypothetical
-  strategies. Add a boundary only when current code needs independent lifecycle, substitution, or validation.
+- Select one `Strategy` capability at the composition root; the strategy owns its protocol and universe. Do not add a
+  runtime registry, scheduler, event bus, repository layer, or generic retry framework without a current requirement.
 
 ## Tests and validation
 

--- a/services/bayn/AGENTS.md
+++ b/services/bayn/AGENTS.md
@@ -1,0 +1,78 @@
+# Bayn Service Guide
+
+## Service contract
+
+- Bayn is a fail-closed quantitative evaluation service. Keep strategy and accounting evidence separate from broker or
+  capital authority; a `PASS`, healthy pod, or reconciled ledger never grants either.
+- Signal ClickHouse is read-only at runtime. Do not add DDL, backfill, administrative credentials, or dataset ownership
+  to the deployed service.
+- Keep strategy math, deterministic identifiers, manifests, and reconciliation plans as pure TypeScript. Given the same
+  code revision, protocol, and data, they must produce the same result.
+
+## Effect baseline
+
+- `package.json` is authoritative for the Effect version. Bayn currently uses Effect 3; verify APIs against installed
+  sources or `~/github.com/effect` at `origin/v3`. That checkout's `main` is Effect 4 beta—do not copy v4-only APIs.
+- Use Effect at I/O and application boundaries, not as a wrapper around pure functions or constants.
+- Prefer official Effect integrations when they remove hand-written lifecycle, interruption, or decoding code. Add them
+  as direct, peer-compatible dependencies; never rely on another workspace's transitive dependency.
+
+## Runtime and composition
+
+- Use `NodeRuntime.runMain` at the entry point. Do not build a second runtime with `runPromise(...).catch(...)`, manual
+  exit codes, or process signal handlers. Let interruption unwind scopes and finalizers.
+- Define a `Context.Tag` or `Context.GenericTag` only for a real replaceable capability. Build live implementations with
+  `Layer`; assemble them once at the composition root. Do not create tags for pure helpers or single-use values.
+- Own every long-lived client, server, or background fiber with `Layer.scoped`, `Effect.acquireRelease`, or
+  `Effect.forkScoped`. Acquisition, interruption, and release must have tests. Never detach a Promise or fiber.
+- Use `Effect.gen` for readable orchestration. Use `Effect.fn` for a meaningful traced operation and `Effect.fnUntraced`
+  only for a reusable or measured hot helper; do not mechanically wrap one-line effects.
+
+## Failures, cancellation, and time
+
+- Expected operational failures use the typed error channel and domain `Data.TaggedError` values that retain the cause.
+  Defects are reserved for violated invariants and programming bugs. Do not erase causes into generic strings.
+- Never use JavaScript `try/catch` to handle a yielded Effect. Use `Effect.try` for throwing synchronous APIs,
+  `Effect.tryPromise` for rejecting Promise APIs, and `catchTag`, `mapError`, or `tapErrorCause` for recovery/reporting.
+- A Promise adapter must forward Effect's `AbortSignal` when supported. Otherwise supply an explicit cancellation action
+  that actually stops the operation. A timeout without cancellation is not complete.
+- Use `Clock`, `Duration`, `Schedule`, and `TestClock` instead of ambient time and hand-written timers. Retries must be
+  bounded and must not turn an unknown outcome into a duplicate accounting or trading mutation.
+
+## Configuration, data, and observability
+
+- Read environment values through `Config` and test with `ConfigProvider`; do not read `process.env` in domain or
+  service modules. Validate once at startup and keep secrets `Redacted` until the third-party client boundary.
+- Decode every external payload with `Schema` or `SqlSchema`. A TypeScript assertion such as `json<Row>()` is not
+  runtime validation. Pure domain code accepts decoded values only.
+- Use `Effect.log*`, `Effect.annotateLogs`, and log spans. Production logs use `Logger.json`. Do not call `console.*`
+  inside an Effect; direct console output is only an emergency before the runtime exists. Never log credentials.
+- For HTTP and ClickHouse, prefer `@effect/platform-node` and `@effect/sql-clickhouse` over local lifecycle wrappers.
+  Keep SQL explicit and parameterized; Effect SQL replaces plumbing, not SQL. Use a thin scoped adapter only when no
+  official integration exists, as with TigerBeetle.
+
+## Trading and accounting invariants
+
+- Market-data snapshots must prove dataset version, universe, uniqueness, ordering, and content identity before
+  evaluation. Missing, stale, malformed, or mixed-contract data fails closed.
+- TigerBeetle writes remain deterministic and idempotent. Existing IDs must be verified against the complete expected
+  record, and readiness requires exact account, transfer, and balance reconciliation.
+- Do not introduce a scheduler, event bus, repository layer, generic retry framework, or abstraction for hypothetical
+  strategies. Add a boundary only when current code needs independent lifecycle, substitution, or validation.
+
+## Tests and validation
+
+- Keep pure tests synchronous. Run Effects only at the outer test boundary with `Effect.runPromise` or
+  `Effect.runPromiseExit`; test layers replace external systems. Unit tests never require the live cluster.
+- Cover success, typed failure, defect propagation, interruption, timeout cancellation, and exactly-once finalization
+  for changed Effectful code. Use deterministic fixtures and `TestClock` for time-dependent behavior.
+- Run the focused test first, then before completing a code change run:
+
+```sh
+bun run --filter @proompteng/bayn test
+bun run --filter @proompteng/bayn tsc
+bun run --filter @proompteng/bayn lint
+bun run --filter @proompteng/bayn lint:oxlint
+bun run --filter @proompteng/bayn lint:oxlint:type
+bun run --filter @proompteng/bayn build
+```

--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -11,6 +11,8 @@ and journals the resulting simulation to TigerBeetle. It contains no broker clie
   startup operation (30 seconds by default).
 - Signal ClickHouse is read-only at runtime. `backfill.ts` is an operator-only data preparation command and is not part
   of the Deployment.
+- The composition root selects one strategy capability. TSMOM is the first implementation and owns its protocol and
+  universe; the HTTP and startup lifecycle do not depend on TSMOM directly.
 - The protocol is committed at `protocols/tsmom-v1.json`. A run ID binds the code revision, protocol hash, and exact
   ClickHouse input-manifest hash.
 - Signals are formed at a month-end close and may execute only at the next common session open.

--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -7,6 +7,8 @@ and journals the resulting simulation to TigerBeetle. It contains no broker clie
 ## Runtime contract
 
 - Node.js is the production runtime; Effect owns dependency acquisition, failure handling, and shutdown.
+- Effect Config validates environment input, and `BAYN_OPERATION_TIMEOUT_MS` bounds each ClickHouse or TigerBeetle
+  startup operation (30 seconds by default).
 - Signal ClickHouse is read-only at runtime. `backfill.ts` is an operator-only data preparation command and is not part
   of the Deployment.
 - The protocol is committed at `protocols/tsmom-v1.json`. A run ID binds the code revision, protocol hash, and exact

--- a/services/bayn/package.json
+++ b/services/bayn/package.json
@@ -15,8 +15,9 @@
     "tsc": "bunx tsc --noEmit"
   },
   "dependencies": {
-    "@clickhouse/client": "^1.23.1",
-    "effect": "^3.21.2",
+    "@clickhouse/client": "1.23.1",
+    "@effect/platform-node": "4.0.0-beta.99",
+    "effect": "4.0.0-beta.99",
     "tigerbeetle-node": "0.17.9"
   },
   "devDependencies": {

--- a/services/bayn/package.json
+++ b/services/bayn/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@clickhouse/client": "^1.23.1",
     "effect": "^3.21.2",
-    "tigerbeetle-node": "0.17.4"
+    "tigerbeetle-node": "0.17.9"
   },
   "devDependencies": {
     "@types/bun": "1.3.14",

--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -1,14 +1,16 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Cause, Effect, Exit, Ref } from 'effect'
+import { Cause, Context, Effect, Exit, Layer, Redacted, Ref } from 'effect'
+import { HttpServer } from 'effect/unstable/http'
 
-import { initializeBayn, makeHttpServer, runBayn, type RuntimeState } from './app'
+import { initializeBayn, makeHttpLayer, runBayn, type RuntimeState } from './app'
 import type { BaynConfig } from './config'
 import { baynError } from './errors'
 import { Journal, type JournalService } from './ledger'
 import { MarketData, type MarketDataService } from './market-data'
 import { defaultProtocol } from './protocol'
 import { evaluateTsmom } from './strategy'
+import { Strategy, TsmomStrategyLive, type StrategyService } from './strategy-service'
 import { makeSnapshot } from './test-fixtures'
 
 const config: BaynConfig = {
@@ -20,13 +22,12 @@ const config: BaynConfig = {
   clickhouse: {
     url: 'http://clickhouse.test:8123',
     username: 'bayn',
-    password: 'secret',
+    password: Redacted.make('secret'),
     database: 'signal',
     table: 'adjusted_daily_bars_v1',
     datasetVersion: 'fixture-v1',
   },
   tigerBeetle: { clusterId: 2001n, replicaAddresses: ['3000'], ledger: 7001 },
-  protocol: defaultProtocol,
 }
 
 const successfulJournal: JournalService = {
@@ -70,9 +71,9 @@ describe('Bayn HTTP probes', () => {
       Effect.scoped(
         Effect.gen(function* () {
           const state = yield* Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null })
-          const server = yield* makeHttpServer({ host: '127.0.0.1', port: 0 }, state)
-          const address = server.address()
-          if (!address || typeof address === 'string') throw new Error('test server did not bind a TCP port')
+          const context = yield* Layer.build(makeHttpLayer({ host: '127.0.0.1', port: 0 }, state))
+          const address = Context.get(context, HttpServer.HttpServer).address
+          if (address._tag !== 'TcpAddress') throw new Error('test server did not bind a TCP port')
           port = address.port
 
           expect(yield* Effect.promise(() => fetchJson(port, '/livez'))).toEqual({
@@ -136,6 +137,31 @@ describe('Bayn HTTP probes', () => {
 })
 
 describe('Bayn startup lifecycle', () => {
+  test('evaluates through the provided strategy capability', async () => {
+    let calls = 0
+    const snapshot = makeSnapshot()
+    const state = await Effect.runPromise(Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null }))
+    const strategy: StrategyService = {
+      name: 'test-strategy',
+      universe: defaultProtocol.universe,
+      evaluate: (bars, manifest, codeRevision) => {
+        calls += 1
+        return evaluateTsmom(bars, manifest, defaultProtocol, codeRevision)
+      },
+    }
+
+    await Effect.runPromise(
+      initializeBayn(config, state).pipe(
+        Effect.provideService(MarketData, { load: Effect.succeed(snapshot) }),
+        Effect.provideService(Journal, successfulJournal),
+        Effect.provideService(Strategy, strategy),
+      ),
+    )
+
+    expect(calls).toBe(1)
+    expect(await Effect.runPromise(Ref.get(state))).toMatchObject({ status: 'READY' })
+  })
+
   test('transitions from STARTING to READY after evaluation and reconciliation', async () => {
     const snapshot = makeSnapshot()
     const state = await Effect.runPromise(Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null }))
@@ -145,6 +171,7 @@ describe('Bayn startup lifecycle', () => {
       initializeBayn(config, state).pipe(
         Effect.provideService(MarketData, marketData),
         Effect.provideService(Journal, successfulJournal),
+        Effect.provide(TsmomStrategyLive),
       ),
     )
 
@@ -164,6 +191,7 @@ describe('Bayn startup lifecycle', () => {
       initializeBayn(config, state).pipe(
         Effect.provideService(MarketData, marketData),
         Effect.provideService(Journal, successfulJournal),
+        Effect.provide(TsmomStrategyLive),
       ),
     )
 
@@ -181,7 +209,7 @@ describe('Bayn startup lifecycle', () => {
       check: Effect.void,
       journalAndReconcile: () => {
         journaled = true
-        return Effect.dieMessage('journal should not run')
+        return Effect.die(new Error('journal should not run'))
       },
     }
 
@@ -189,6 +217,7 @@ describe('Bayn startup lifecycle', () => {
       initializeBayn({ ...config, runOnStartup: false }, state).pipe(
         Effect.provideService(MarketData, marketData),
         Effect.provideService(Journal, journal),
+        Effect.provide(TsmomStrategyLive),
       ),
     )
 
@@ -210,6 +239,7 @@ describe('Bayn startup lifecycle', () => {
       initializeBayn({ ...config, operationTimeoutMs: 10 }, state).pipe(
         Effect.provideService(MarketData, marketData),
         Effect.provideService(Journal, successfulJournal),
+        Effect.provide(TsmomStrategyLive),
       ),
     )
 
@@ -221,14 +251,15 @@ describe('Bayn startup lifecycle', () => {
   })
 
   test('propagates an unexpected defect instead of leaving a detached STARTING worker', async () => {
-    const marketData: MarketDataService = { load: Effect.dieMessage('unexpected startup defect') }
+    const marketData: MarketDataService = { load: Effect.die(new Error('unexpected startup defect')) }
     const exit = await Effect.runPromiseExit(
       runBayn(config).pipe(
         Effect.provideService(MarketData, marketData),
         Effect.provideService(Journal, successfulJournal),
-        Effect.timeoutFail({
+        Effect.provide(TsmomStrategyLive),
+        Effect.timeoutOrElse({
           duration: 250,
-          onTimeout: () => baynError('http', 'test', 'runBayn remained alive after its startup worker died'),
+          orElse: () => Effect.fail(baynError('http', 'test', 'runBayn remained alive after its startup worker died')),
         }),
       ),
     )

--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -1,11 +1,71 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Effect, Ref } from 'effect'
+import { Cause, Effect, Exit, Ref } from 'effect'
 
-import { makeHttpServer, type RuntimeState } from './app'
+import { initializeBayn, makeHttpServer, runBayn, type RuntimeState } from './app'
+import type { BaynConfig } from './config'
+import { baynError } from './errors'
+import { Journal, type JournalService } from './ledger'
+import { MarketData, type MarketDataService } from './market-data'
+import { defaultProtocol } from './protocol'
+import { evaluateTsmom } from './strategy'
+import { makeSnapshot } from './test-fixtures'
+
+const config: BaynConfig = {
+  host: '127.0.0.1',
+  port: 0,
+  codeRevision: 'test-revision',
+  runOnStartup: true,
+  operationTimeoutMs: 250,
+  clickhouse: {
+    url: 'http://clickhouse.test:8123',
+    username: 'bayn',
+    password: 'secret',
+    database: 'signal',
+    table: 'adjusted_daily_bars_v1',
+    datasetVersion: 'fixture-v1',
+  },
+  tigerBeetle: { clusterId: 2001n, replicaAddresses: ['3000'], ledger: 7001 },
+  protocol: defaultProtocol,
+}
+
+const successfulJournal: JournalService = {
+  check: Effect.void,
+  journalAndReconcile: (evaluation) =>
+    Effect.succeed({
+      runId: evaluation.runId,
+      accountCount: evaluation.inputManifest.symbols.length + 5,
+      transferCount: evaluation.events.length,
+      exact: true,
+    }),
+}
+
+const fetchJson = async (port: number, path: string, method = 'GET') => {
+  const response = await fetch(`http://127.0.0.1:${port}${path}`, { method })
+  return {
+    status: response.status,
+    allow: response.headers.get('allow'),
+    body: (await response.json()) as Record<string, unknown>,
+  }
+}
+
+const readyState = (): RuntimeState => {
+  const snapshot = makeSnapshot()
+  const evaluation = evaluateTsmom(snapshot.bars, snapshot.manifest, defaultProtocol, 'test-revision')
+  const { events, ...evaluationWithoutEvents } = evaluation
+  return {
+    status: 'READY',
+    evidence: {
+      evaluation: { ...evaluationWithoutEvents, eventCount: events.length },
+      reconciliation: { runId: evaluation.runId, accountCount: 13, transferCount: events.length, exact: true },
+    },
+    error: null,
+  }
+}
 
 describe('Bayn HTTP probes', () => {
-  test('serves process liveness at /livez', async () => {
+  test('serves every route from the current runtime state and closes its socket', async () => {
+    let port = 0
     await Effect.runPromise(
       Effect.scoped(
         Effect.gen(function* () {
@@ -13,14 +73,170 @@ describe('Bayn HTTP probes', () => {
           const server = yield* makeHttpServer({ host: '127.0.0.1', port: 0 }, state)
           const address = server.address()
           if (!address || typeof address === 'string') throw new Error('test server did not bind a TCP port')
+          port = address.port
 
-          const result = yield* Effect.promise(async () => {
-            const response = await fetch(`http://127.0.0.1:${address.port}/livez`)
-            return { status: response.status, body: await response.json() }
+          expect(yield* Effect.promise(() => fetchJson(port, '/livez'))).toEqual({
+            status: 200,
+            allow: null,
+            body: { service: 'bayn', live: true },
           })
-          expect(result).toEqual({ status: 200, body: { service: 'bayn', live: true } })
+          expect(yield* Effect.promise(() => fetchJson(port, '/readyz'))).toMatchObject({
+            status: 503,
+            body: { ready: false, status: 'STARTING' },
+          })
+
+          yield* Ref.set(state, readyState())
+          expect(yield* Effect.promise(() => fetchJson(port, '/readyz'))).toMatchObject({
+            status: 200,
+            body: { ready: true, status: 'READY' },
+          })
+          expect(yield* Effect.promise(() => fetchJson(port, '/v1/status'))).toMatchObject({
+            status: 200,
+            body: {
+              service: 'bayn',
+              status: 'READY',
+              authority: { brokerOrders: false, capitalPromotion: false },
+            },
+          })
+          expect(yield* Effect.promise(() => fetchJson(port, '/v1/evidence/latest'))).toMatchObject({
+            status: 200,
+            body: { service: 'bayn', status: 'READY' },
+          })
+
+          yield* Ref.set(state, { status: 'FAIL_CLOSED', evidence: null, error: 'test failure' })
+          expect(yield* Effect.promise(() => fetchJson(port, '/readyz'))).toMatchObject({
+            status: 503,
+            body: { ready: false, status: 'FAIL_CLOSED' },
+          })
+          expect(yield* Effect.promise(() => fetchJson(port, '/v1/status'))).toMatchObject({
+            status: 200,
+            body: { status: 'FAIL_CLOSED', error: 'test failure' },
+          })
+          expect(yield* Effect.promise(() => fetchJson(port, '/missing'))).toMatchObject({
+            status: 404,
+            body: { error: 'not_found' },
+          })
+          expect(yield* Effect.promise(() => fetchJson(port, '/livez', 'POST'))).toEqual({
+            status: 405,
+            allow: 'GET',
+            body: { error: 'method_not_allowed' },
+          })
         }),
       ),
     )
+
+    let rejected = false
+    try {
+      await fetch(`http://127.0.0.1:${port}/livez`)
+    } catch {
+      rejected = true
+    }
+    expect(rejected).toBe(true)
+  })
+})
+
+describe('Bayn startup lifecycle', () => {
+  test('transitions from STARTING to READY after evaluation and reconciliation', async () => {
+    const snapshot = makeSnapshot()
+    const state = await Effect.runPromise(Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null }))
+    const marketData: MarketDataService = { load: Effect.succeed(snapshot) }
+
+    await Effect.runPromise(
+      initializeBayn(config, state).pipe(
+        Effect.provideService(MarketData, marketData),
+        Effect.provideService(Journal, successfulJournal),
+      ),
+    )
+
+    const current = await Effect.runPromise(Ref.get(state))
+    expect(current.status).toBe('READY')
+    if (current.status === 'READY') {
+      expect(current.evidence.reconciliation.exact).toBe(true)
+      expect(current.evidence.evaluation.eventCount).toBeGreaterThan(0)
+    }
+  })
+
+  test('turns strategy exceptions into an operational FAIL_CLOSED result', async () => {
+    const state = await Effect.runPromise(Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null }))
+    const marketData: MarketDataService = { load: Effect.succeed(makeSnapshot(700)) }
+
+    await Effect.runPromise(
+      initializeBayn(config, state).pipe(
+        Effect.provideService(MarketData, marketData),
+        Effect.provideService(Journal, successfulJournal),
+      ),
+    )
+
+    expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
+      status: 'FAIL_CLOSED',
+      error: expect.stringContaining('strategy.evaluate'),
+    })
+  })
+
+  test('keeps readiness closed when startup evaluation is explicitly disabled', async () => {
+    let journaled = false
+    const state = await Effect.runPromise(Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null }))
+    const marketData: MarketDataService = { load: Effect.succeed(makeSnapshot()) }
+    const journal: JournalService = {
+      check: Effect.void,
+      journalAndReconcile: () => {
+        journaled = true
+        return Effect.dieMessage('journal should not run')
+      },
+    }
+
+    await Effect.runPromise(
+      initializeBayn({ ...config, runOnStartup: false }, state).pipe(
+        Effect.provideService(MarketData, marketData),
+        Effect.provideService(Journal, journal),
+      ),
+    )
+
+    expect(journaled).toBe(false)
+    expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
+      status: 'FAIL_CLOSED',
+      error: expect.stringContaining('BAYN_RUN_ON_STARTUP=false'),
+    })
+  })
+
+  test('interrupts a stalled dependency and fails closed within the configured deadline', async () => {
+    let interrupted = false
+    const state = await Effect.runPromise(Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null }))
+    const marketData: MarketDataService = {
+      load: Effect.never.pipe(Effect.onInterrupt(() => Effect.sync(() => void (interrupted = true)))),
+    }
+
+    await Effect.runPromise(
+      initializeBayn({ ...config, operationTimeoutMs: 10 }, state).pipe(
+        Effect.provideService(MarketData, marketData),
+        Effect.provideService(Journal, successfulJournal),
+      ),
+    )
+
+    expect(interrupted).toBe(true)
+    expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
+      status: 'FAIL_CLOSED',
+      error: expect.stringContaining('market-data.load: load timed out'),
+    })
+  })
+
+  test('propagates an unexpected defect instead of leaving a detached STARTING worker', async () => {
+    const marketData: MarketDataService = { load: Effect.dieMessage('unexpected startup defect') }
+    const exit = await Effect.runPromiseExit(
+      runBayn(config).pipe(
+        Effect.provideService(MarketData, marketData),
+        Effect.provideService(Journal, successfulJournal),
+        Effect.timeoutFail({
+          duration: 250,
+          onTimeout: () => baynError('http', 'test', 'runBayn remained alive after its startup worker died'),
+        }),
+      ),
+    )
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) {
+      expect(Cause.pretty(exit.cause)).toContain('unexpected startup defect')
+      expect(Cause.pretty(exit.cause)).not.toContain('remained alive')
+    }
   })
 })

--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -1,9 +1,10 @@
 import { createServer, type Server } from 'node:http'
 import process from 'node:process'
 
-import { Deferred, Effect, Fiber, Ref } from 'effect'
+import { Deferred, Effect, Ref, Runtime } from 'effect'
 
 import type { BaynConfig } from './config'
+import { baynError, formatBaynError, type BaynComponent, type BaynError } from './errors'
 import { Journal, type JournalService } from './ledger'
 import { MarketData, type MarketDataService } from './market-data'
 import { evaluateTsmom } from './strategy'
@@ -19,6 +20,12 @@ export type RuntimeState =
   | { readonly status: 'READY'; readonly evidence: RuntimeEvidence; readonly error: null }
   | { readonly status: 'FAIL_CLOSED'; readonly evidence: null; readonly error: string }
 
+interface HttpResult {
+  readonly status: number
+  readonly headers?: Readonly<Record<string, string>>
+  readonly body: unknown
+}
+
 const json = (value: unknown): string =>
   JSON.stringify(value, (_, nested) => (typeof nested === 'bigint' ? nested.toString() : nested))
 
@@ -30,111 +37,196 @@ const publicState = (state: RuntimeState) => ({
   error: state.error,
 })
 
+const routeRequest = (method: string | undefined, url: string | undefined, state: RuntimeState): HttpResult => {
+  const path = url?.split('?')[0] ?? '/'
+  if (method !== 'GET') {
+    return { status: 405, headers: { allow: 'GET' }, body: { error: 'method_not_allowed' } }
+  }
+  if (path === '/livez') {
+    return { status: 200, body: { service: 'bayn', live: true } }
+  }
+  if (path === '/readyz') {
+    const ready = state.status === 'READY'
+    return { status: ready ? 200 : 503, body: { ready, status: state.status } }
+  }
+  if (path === '/v1/status' || path === '/v1/evidence/latest') {
+    return { status: 200, body: publicState(state) }
+  }
+  return { status: 404, body: { error: 'not_found' } }
+}
+
 export const makeHttpServer = (config: Pick<BaynConfig, 'host' | 'port'>, state: Ref.Ref<RuntimeState>) =>
-  Effect.acquireRelease(
-    Effect.async<Server, Error>((resume) => {
-      const server = createServer((request, response) => {
-        void Effect.runPromise(Ref.get(state)).then((current) => {
-          const path = request.url?.split('?')[0] ?? '/'
-          if (request.method !== 'GET') {
-            response.writeHead(405, { 'content-type': 'application/json', allow: 'GET' })
-            response.end(json({ error: 'method_not_allowed' }))
-            return
+  Effect.gen(function* () {
+    const runtime = yield* Effect.runtime<never>()
+    const runSync = Runtime.runSync(runtime)
+    const logCloseFailure = (cause: unknown) =>
+      runSync(
+        Effect.logWarning('Bayn HTTP server close failed').pipe(
+          Effect.annotateLogs({ service: 'bayn', component: 'http', operation: 'close', error: String(cause) }),
+        ),
+      )
+
+    return yield* Effect.acquireRelease(
+      Effect.async<Server, BaynError>((resume) => {
+        const server = createServer((request, response) => {
+          let result: HttpResult
+          try {
+            result = routeRequest(request.method, request.url, runSync(Ref.get(state)))
+          } catch {
+            result = { status: 500, body: { error: 'internal_server_error' } }
           }
-          if (path === '/livez') {
-            response.writeHead(200, { 'content-type': 'application/json' })
-            response.end(json({ service: 'bayn', live: true }))
-            return
-          }
-          if (path === '/readyz') {
-            const ready = current.status === 'READY'
-            response.writeHead(ready ? 200 : 503, { 'content-type': 'application/json' })
-            response.end(json({ ready, status: current.status }))
-            return
-          }
-          if (path === '/v1/status' || path === '/v1/evidence/latest') {
-            response.writeHead(200, { 'content-type': 'application/json' })
-            response.end(json(publicState(current)))
-            return
-          }
-          response.writeHead(404, { 'content-type': 'application/json' })
-          response.end(json({ error: 'not_found' }))
+          response.writeHead(result.status, { 'content-type': 'application/json', ...result.headers })
+          response.end(json(result.body))
         })
-      })
-      const onError = (cause: Error) => resume(Effect.fail(new Error(`Bayn HTTP server failed: ${cause.message}`)))
-      server.once('error', onError)
-      server.listen(config.port, config.host, () => {
-        server.off('error', onError)
-        resume(Effect.succeed(server))
-      })
-    }),
-    (server) =>
-      Effect.async<void>((resume) => {
-        server.close(() => resume(Effect.void))
+        const onError = (cause: Error) =>
+          resume(Effect.fail(baynError('http', 'listen', 'Bayn HTTP server failed to listen', cause)))
+        server.once('error', onError)
+        server.listen(config.port, config.host, () => {
+          server.off('error', onError)
+          resume(Effect.succeed(server))
+        })
       }),
+      (server) =>
+        Effect.async<void>((resume) => {
+          if (!server.listening) {
+            resume(Effect.void)
+            return
+          }
+          try {
+            server.close((cause) => {
+              if (cause) logCloseFailure(cause)
+              resume(Effect.void)
+            })
+          } catch (cause) {
+            logCloseFailure(cause)
+            resume(Effect.void)
+          }
+        }),
+    )
+  })
+
+const withinDeadline = <A, R>(
+  effect: Effect.Effect<A, BaynError, R>,
+  timeoutMs: number,
+  component: BaynComponent,
+  operation: string,
+): Effect.Effect<A, BaynError, R> =>
+  effect.pipe(
+    Effect.timeoutFail({
+      duration: timeoutMs,
+      onTimeout: () => baynError(component, operation, `${operation} timed out after ${timeoutMs}ms`),
+    }),
+  )
+
+const failClosed = (state: Ref.Ref<RuntimeState>, error: BaynError): Effect.Effect<void> =>
+  Effect.logError('Bayn startup failed closed').pipe(
+    Effect.annotateLogs({
+      service: 'bayn',
+      component: error.component,
+      operation: error.operation,
+      error: error.message,
+    }),
+    Effect.zipRight(
+      Ref.set(state, {
+        status: 'FAIL_CLOSED',
+        evidence: null,
+        error: formatBaynError(error),
+      }),
+    ),
   )
 
 const evaluateAndJournal = (
   config: BaynConfig,
   state: Ref.Ref<RuntimeState>,
-): Effect.Effect<void, never, MarketDataService | JournalService> =>
+): Effect.Effect<void, BaynError, MarketDataService | JournalService> =>
   Effect.gen(function* () {
     const marketData = yield* MarketData
     const journal = yield* Journal
-    yield* journal.check
-    const snapshot = yield* marketData.load
-    const evaluation = evaluateTsmom(snapshot.bars, snapshot.manifest, config.protocol, config.codeRevision)
-    const reconciliation = yield* journal.journalAndReconcile(evaluation)
+    yield* Effect.logInfo('Bayn startup evaluation started').pipe(
+      Effect.annotateLogs({
+        service: 'bayn',
+        codeRevision: config.codeRevision,
+        datasetVersion: config.clickhouse.datasetVersion,
+      }),
+    )
+    yield* withinDeadline(journal.check, config.operationTimeoutMs, 'journal', 'connectivity-check')
+    const snapshot = yield* withinDeadline(marketData.load, config.operationTimeoutMs, 'market-data', 'load')
+    yield* Effect.logInfo('Bayn signal snapshot loaded').pipe(
+      Effect.annotateLogs({
+        service: 'bayn',
+        inputManifestHash: snapshot.manifest.hash,
+        rowCount: snapshot.manifest.rowCount,
+      }),
+    )
+    const evaluation = yield* Effect.try({
+      try: () => evaluateTsmom(snapshot.bars, snapshot.manifest, config.protocol, config.codeRevision),
+      catch: (cause) => baynError('strategy', 'evaluate', 'TSMOM evaluation failed', cause),
+    })
+    yield* Effect.logInfo('Bayn TSMOM evaluation completed').pipe(
+      Effect.annotateLogs({
+        service: 'bayn',
+        runId: evaluation.runId,
+        verdict: evaluation.verdict.status,
+        eventCount: evaluation.events.length,
+      }),
+    )
+    const reconciliation = yield* withinDeadline(
+      journal.journalAndReconcile(evaluation),
+      config.operationTimeoutMs,
+      'journal',
+      'journal-and-reconcile',
+    )
     const { events, ...evaluationWithoutEvents } = evaluation
     yield* Ref.set(state, {
       status: 'READY',
       evidence: { evaluation: { ...evaluationWithoutEvents, eventCount: events.length }, reconciliation },
       error: null,
     })
-  }).pipe(
-    Effect.catchAll((cause) =>
-      Ref.set(state, {
-        status: 'FAIL_CLOSED',
-        evidence: null,
-        error: cause instanceof Error ? cause.message : String(cause),
+    yield* Effect.logInfo('Bayn startup proof is ready').pipe(
+      Effect.annotateLogs({
+        service: 'bayn',
+        runId: evaluation.runId,
+        accountCount: reconciliation.accountCount,
+        transferCount: reconciliation.transferCount,
       }),
-    ),
-  )
+    )
+  }).pipe(Effect.withLogSpan('startup'))
 
 const checkWithoutJournal = (
+  config: BaynConfig,
   state: Ref.Ref<RuntimeState>,
-): Effect.Effect<void, never, MarketDataService | JournalService> =>
+): Effect.Effect<void, BaynError, MarketDataService | JournalService> =>
   Effect.gen(function* () {
     const marketData = yield* MarketData
     const journal = yield* Journal
-    yield* journal.check
-    yield* marketData.load
+    yield* withinDeadline(journal.check, config.operationTimeoutMs, 'journal', 'connectivity-check')
+    yield* withinDeadline(marketData.load, config.operationTimeoutMs, 'market-data', 'load')
     yield* Ref.set(state, {
       status: 'FAIL_CLOSED',
       evidence: null,
       error: 'BAYN_RUN_ON_STARTUP=false; evaluation and accounting proof were not executed',
     })
-  }).pipe(
-    Effect.catchAll((cause) =>
-      Ref.set(state, {
-        status: 'FAIL_CLOSED',
-        evidence: null,
-        error: cause instanceof Error ? cause.message : String(cause),
-      }),
-    ),
+  })
+
+export const initializeBayn = (
+  config: BaynConfig,
+  state: Ref.Ref<RuntimeState>,
+): Effect.Effect<void, never, MarketDataService | JournalService> =>
+  (config.runOnStartup ? evaluateAndJournal(config, state) : checkWithoutJournal(config, state)).pipe(
+    Effect.catchAll((error) => failClosed(state, error)),
   )
 
-export const runBayn = (config: BaynConfig): Effect.Effect<void, Error, MarketDataService | JournalService> =>
+export const runBayn = (config: BaynConfig): Effect.Effect<void, BaynError, MarketDataService | JournalService> =>
   Effect.scoped(
     Effect.gen(function* () {
       const state = yield* Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null })
       yield* makeHttpServer(config, state)
-      const work = config.runOnStartup ? evaluateAndJournal(config, state) : checkWithoutJournal(state)
-      const worker = yield* Effect.forkScoped(work)
 
       const shutdown = yield* Deferred.make<void>()
+      const runtime = yield* Effect.runtime<never>()
+      const signalShutdown = Runtime.runSync(runtime)
       const onSignal = () => {
-        Effect.runFork(Deferred.succeed(shutdown, undefined))
+        signalShutdown(Deferred.succeed(shutdown, undefined))
       }
       process.once('SIGINT', onSignal)
       process.once('SIGTERM', onSignal)
@@ -144,7 +236,10 @@ export const runBayn = (config: BaynConfig): Effect.Effect<void, Error, MarketDa
           process.off('SIGTERM', onSignal)
         }),
       )
-      yield* Deferred.await(shutdown)
-      yield* Fiber.interrupt(worker)
+
+      yield* Effect.raceFirst(
+        initializeBayn(config, state).pipe(Effect.zipRight(Deferred.await(shutdown))),
+        Deferred.await(shutdown),
+      )
     }),
   )

--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -1,13 +1,14 @@
-import { createServer, type Server } from 'node:http'
-import process from 'node:process'
+import { createServer } from 'node:http'
 
-import { Deferred, Effect, Ref, Runtime } from 'effect'
+import { NodeHttpServer } from '@effect/platform-node'
+import { Effect, Layer, Ref } from 'effect'
+import { HttpRouter, HttpServerRequest, HttpServerResponse } from 'effect/unstable/http'
 
 import type { BaynConfig } from './config'
 import { baynError, formatBaynError, type BaynComponent, type BaynError } from './errors'
-import { Journal, type JournalService } from './ledger'
-import { MarketData, type MarketDataService } from './market-data'
-import { evaluateTsmom } from './strategy'
+import { Journal } from './ledger'
+import { MarketData } from './market-data'
+import { Strategy } from './strategy-service'
 import type { EvaluationResult, ReconciliationResult } from './types'
 
 interface RuntimeEvidence {
@@ -20,12 +21,6 @@ export type RuntimeState =
   | { readonly status: 'READY'; readonly evidence: RuntimeEvidence; readonly error: null }
   | { readonly status: 'FAIL_CLOSED'; readonly evidence: null; readonly error: string }
 
-interface HttpResult {
-  readonly status: number
-  readonly headers?: Readonly<Record<string, string>>
-  readonly body: unknown
-}
-
 const json = (value: unknown): string =>
   JSON.stringify(value, (_, nested) => (typeof nested === 'bigint' ? nested.toString() : nested))
 
@@ -37,73 +32,40 @@ const publicState = (state: RuntimeState) => ({
   error: state.error,
 })
 
-const routeRequest = (method: string | undefined, url: string | undefined, state: RuntimeState): HttpResult => {
-  const path = url?.split('?')[0] ?? '/'
-  if (method !== 'GET') {
-    return { status: 405, headers: { allow: 'GET' }, body: { error: 'method_not_allowed' } }
-  }
-  if (path === '/livez') {
-    return { status: 200, body: { service: 'bayn', live: true } }
-  }
-  if (path === '/readyz') {
-    const ready = state.status === 'READY'
-    return { status: ready ? 200 : 503, body: { ready, status: state.status } }
-  }
-  if (path === '/v1/status' || path === '/v1/evidence/latest') {
-    return { status: 200, body: publicState(state) }
-  }
-  return { status: 404, body: { error: 'not_found' } }
-}
+const jsonResponse = (body: unknown, status = 200, headers?: Readonly<Record<string, string>>) =>
+  HttpServerResponse.text(json(body), { status, contentType: 'application/json', headers })
 
-export const makeHttpServer = (config: Pick<BaynConfig, 'host' | 'port'>, state: Ref.Ref<RuntimeState>) =>
-  Effect.gen(function* () {
-    const runtime = yield* Effect.runtime<never>()
-    const runSync = Runtime.runSync(runtime)
-    const logCloseFailure = (cause: unknown) =>
-      runSync(
-        Effect.logWarning('Bayn HTTP server close failed').pipe(
-          Effect.annotateLogs({ service: 'bayn', component: 'http', operation: 'close', error: String(cause) }),
-        ),
-      )
-
-    return yield* Effect.acquireRelease(
-      Effect.async<Server, BaynError>((resume) => {
-        const server = createServer((request, response) => {
-          let result: HttpResult
-          try {
-            result = routeRequest(request.method, request.url, runSync(Ref.get(state)))
-          } catch {
-            result = { status: 500, body: { error: 'internal_server_error' } }
-          }
-          response.writeHead(result.status, { 'content-type': 'application/json', ...result.headers })
-          response.end(json(result.body))
-        })
-        const onError = (cause: Error) =>
-          resume(Effect.fail(baynError('http', 'listen', 'Bayn HTTP server failed to listen', cause)))
-        server.once('error', onError)
-        server.listen(config.port, config.host, () => {
-          server.off('error', onError)
-          resume(Effect.succeed(server))
-        })
-      }),
-      (server) =>
-        Effect.async<void>((resume) => {
-          if (!server.listening) {
-            resume(Effect.void)
-            return
-          }
-          try {
-            server.close((cause) => {
-              if (cause) logCloseFailure(cause)
-              resume(Effect.void)
-            })
-          } catch (cause) {
-            logCloseFailure(cause)
-            resume(Effect.void)
-          }
-        }),
+export const makeHttpLayer = (
+  config: Pick<BaynConfig, 'host' | 'port'>,
+  state: Ref.Ref<RuntimeState>,
+): ReturnType<typeof NodeHttpServer.layer> => {
+  const ready = Ref.get(state).pipe(
+    Effect.map((current) => {
+      const isReady = current.status === 'READY'
+      return jsonResponse({ ready: isReady, status: current.status }, isReady ? 200 : 503)
+    }),
+  )
+  const status = Ref.get(state).pipe(Effect.map((current) => jsonResponse(publicState(current))))
+  const fallback = (
+    request: HttpServerRequest.HttpServerRequest,
+  ): Effect.Effect<HttpServerResponse.HttpServerResponse> =>
+    Effect.succeed(
+      request.method === 'GET'
+        ? jsonResponse({ error: 'not_found' }, 404)
+        : jsonResponse({ error: 'method_not_allowed' }, 405, { allow: 'GET' }),
     )
-  })
+  const routes: Layer.Layer<never, never, HttpRouter.HttpRouter> = HttpRouter.addAll([
+    HttpRouter.route<never, never>('GET', '/livez', jsonResponse({ service: 'bayn', live: true })),
+    HttpRouter.route<never, never>('GET', '/readyz', ready),
+    HttpRouter.route<never, never>('GET', '/v1/status', status),
+    HttpRouter.route<never, never>('GET', '/v1/evidence/latest', status),
+    HttpRouter.route<never, never>('*', '*', fallback),
+  ] as const)
+
+  return HttpRouter.serve(routes, { disableLogger: true }).pipe(
+    Layer.provideMerge(NodeHttpServer.layer(() => createServer(), { host: config.host, port: config.port })),
+  )
+}
 
 const withinDeadline = <A, R>(
   effect: Effect.Effect<A, BaynError, R>,
@@ -112,9 +74,9 @@ const withinDeadline = <A, R>(
   operation: string,
 ): Effect.Effect<A, BaynError, R> =>
   effect.pipe(
-    Effect.timeoutFail({
+    Effect.timeoutOrElse({
       duration: timeoutMs,
-      onTimeout: () => baynError(component, operation, `${operation} timed out after ${timeoutMs}ms`),
+      orElse: () => Effect.fail(baynError(component, operation, `${operation} timed out after ${timeoutMs}ms`)),
     }),
   )
 
@@ -126,7 +88,7 @@ const failClosed = (state: Ref.Ref<RuntimeState>, error: BaynError): Effect.Effe
       operation: error.operation,
       error: error.message,
     }),
-    Effect.zipRight(
+    Effect.andThen(
       Ref.set(state, {
         status: 'FAIL_CLOSED',
         evidence: null,
@@ -138,10 +100,11 @@ const failClosed = (state: Ref.Ref<RuntimeState>, error: BaynError): Effect.Effe
 const evaluateAndJournal = (
   config: BaynConfig,
   state: Ref.Ref<RuntimeState>,
-): Effect.Effect<void, BaynError, MarketDataService | JournalService> =>
+): Effect.Effect<void, BaynError, MarketData | Journal | Strategy> =>
   Effect.gen(function* () {
     const marketData = yield* MarketData
     const journal = yield* Journal
+    const strategy = yield* Strategy
     yield* Effect.logInfo('Bayn startup evaluation started').pipe(
       Effect.annotateLogs({
         service: 'bayn',
@@ -159,13 +122,14 @@ const evaluateAndJournal = (
       }),
     )
     const evaluation = yield* Effect.try({
-      try: () => evaluateTsmom(snapshot.bars, snapshot.manifest, config.protocol, config.codeRevision),
-      catch: (cause) => baynError('strategy', 'evaluate', 'TSMOM evaluation failed', cause),
+      try: () => strategy.evaluate(snapshot.bars, snapshot.manifest, config.codeRevision),
+      catch: (cause) => baynError('strategy', 'evaluate', `${strategy.name} evaluation failed`, cause),
     })
-    yield* Effect.logInfo('Bayn TSMOM evaluation completed').pipe(
+    yield* Effect.logInfo('Bayn strategy evaluation completed').pipe(
       Effect.annotateLogs({
         service: 'bayn',
         runId: evaluation.runId,
+        strategy: strategy.name,
         verdict: evaluation.verdict.status,
         eventCount: evaluation.events.length,
       }),
@@ -195,7 +159,7 @@ const evaluateAndJournal = (
 const checkWithoutJournal = (
   config: BaynConfig,
   state: Ref.Ref<RuntimeState>,
-): Effect.Effect<void, BaynError, MarketDataService | JournalService> =>
+): Effect.Effect<void, BaynError, MarketData | Journal> =>
   Effect.gen(function* () {
     const marketData = yield* MarketData
     const journal = yield* Journal
@@ -211,35 +175,19 @@ const checkWithoutJournal = (
 export const initializeBayn = (
   config: BaynConfig,
   state: Ref.Ref<RuntimeState>,
-): Effect.Effect<void, never, MarketDataService | JournalService> =>
+): Effect.Effect<void, never, MarketData | Journal | Strategy> =>
   (config.runOnStartup ? evaluateAndJournal(config, state) : checkWithoutJournal(config, state)).pipe(
-    Effect.catchAll((error) => failClosed(state, error)),
+    Effect.catch((error) => failClosed(state, error)),
   )
 
-export const runBayn = (config: BaynConfig): Effect.Effect<void, BaynError, MarketDataService | JournalService> =>
+export const runBayn = (config: BaynConfig): Effect.Effect<never, BaynError, MarketData | Journal | Strategy> =>
   Effect.scoped(
     Effect.gen(function* () {
       const state = yield* Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null })
-      yield* makeHttpServer(config, state)
-
-      const shutdown = yield* Deferred.make<void>()
-      const runtime = yield* Effect.runtime<never>()
-      const signalShutdown = Runtime.runSync(runtime)
-      const onSignal = () => {
-        signalShutdown(Deferred.succeed(shutdown, undefined))
-      }
-      process.once('SIGINT', onSignal)
-      process.once('SIGTERM', onSignal)
-      yield* Effect.addFinalizer(() =>
-        Effect.sync(() => {
-          process.off('SIGINT', onSignal)
-          process.off('SIGTERM', onSignal)
-        }),
+      yield* Layer.build(makeHttpLayer(config, state)).pipe(
+        Effect.mapError((cause) => baynError('http', 'listen', 'Bayn HTTP server failed to listen', cause)),
       )
-
-      yield* Effect.raceFirst(
-        initializeBayn(config, state).pipe(Effect.zipRight(Deferred.await(shutdown))),
-        Deferred.await(shutdown),
-      )
+      yield* initializeBayn(config, state)
+      return yield* Effect.never
     }),
   )

--- a/services/bayn/src/backfill-config.ts
+++ b/services/bayn/src/backfill-config.ts
@@ -1,11 +1,11 @@
-import { Config, ConfigError, Effect, Redacted } from 'effect'
+import { Config, Effect, Redacted, Schema } from 'effect'
 
 export interface BackfillConfig {
   readonly clickhouseUrl: string
   readonly clickhouseUsername: string
-  readonly clickhousePassword: string
-  readonly alpacaKey: string
-  readonly alpacaSecret: string
+  readonly clickhousePassword: Redacted.Redacted<string>
+  readonly alpacaKey: Redacted.Redacted<string>
+  readonly alpacaSecret: Redacted.Redacted<string>
   readonly database: string
   readonly table: string
   readonly cluster: string
@@ -15,47 +15,35 @@ export interface BackfillConfig {
   readonly datasetVersion: string
 }
 
-const nonEmptyString = (name: string) =>
-  Config.string(name).pipe(
-    Config.map((value) => value.trim()),
-    Config.validate({ message: `${name} is required`, validation: (value) => value.length > 0 }),
-  )
+const NonEmptyString = Schema.Trim.check(Schema.isMinLength(1))
+const Identifier = NonEmptyString.check(Schema.isPattern(/^[a-zA-Z_][a-zA-Z0-9_]*$/))
+const IsoDate = NonEmptyString.check(
+  Schema.isPattern(/^\d{4}-\d{2}-\d{2}$/),
+  Schema.makeFilter((value: string) => !Number.isNaN(Date.parse(`${value}T00:00:00Z`)), {
+    expected: 'a valid ISO date (YYYY-MM-DD)',
+  }),
+)
+
+const nonEmptyString = (name: string) => Config.schema(NonEmptyString, name)
+
+const secretString = (name: string) => nonEmptyString(name).pipe(Config.map((value) => Redacted.make(value)))
 
 const identifier = (name: string, fallback: string) =>
-  nonEmptyString(name).pipe(
-    Config.withDefault(fallback),
-    Config.validate({
-      message: `${name} must be a ClickHouse identifier`,
-      validation: (value) => /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(value),
-    }),
-  )
+  Config.schema(Identifier, name).pipe(Config.withDefault(fallback))
 
-const isoDate = (name: string) =>
-  nonEmptyString(name).pipe(
-    Config.validate({
-      message: `${name} must be an ISO date`,
-      validation: (value) => /^\d{4}-\d{2}-\d{2}$/.test(value) && !Number.isNaN(Date.parse(`${value}T00:00:00Z`)),
-    }),
-  )
+const isoDate = (name: string) => Config.schema(IsoDate, name)
 
-export const loadBackfillConfig: Effect.Effect<BackfillConfig, ConfigError.ConfigError> = Config.all({
+export const loadBackfillConfig: Effect.Effect<BackfillConfig, Config.ConfigError> = Config.all({
   clickhouseUrl: nonEmptyString('BAYN_CLICKHOUSE_URL'),
   clickhouseUsername: nonEmptyString('BAYN_CLICKHOUSE_USERNAME'),
-  clickhousePassword: Config.redacted(nonEmptyString('BAYN_CLICKHOUSE_PASSWORD')),
-  alpacaKey: Config.redacted(nonEmptyString('APCA_API_KEY_ID')),
-  alpacaSecret: Config.redacted(nonEmptyString('APCA_API_SECRET_KEY')),
+  clickhousePassword: secretString('BAYN_CLICKHOUSE_PASSWORD'),
+  alpacaKey: secretString('APCA_API_KEY_ID'),
+  alpacaSecret: secretString('APCA_API_SECRET_KEY'),
   database: identifier('BAYN_CLICKHOUSE_DATABASE', 'signal'),
   table: identifier('BAYN_CLICKHOUSE_TABLE', 'adjusted_daily_bars_v1'),
   cluster: identifier('BAYN_CLICKHOUSE_CLUSTER', 'default'),
   start: isoDate('BAYN_DATASET_START'),
   end: isoDate('BAYN_DATASET_END'),
-  feed: Config.literal('iex', 'sip')('BAYN_ALPACA_FEED').pipe(Config.withDefault('iex')),
+  feed: Config.literals(['iex', 'sip'], 'BAYN_ALPACA_FEED').pipe(Config.withDefault('iex')),
   datasetVersion: nonEmptyString('BAYN_DATASET_VERSION'),
-}).pipe(
-  Effect.map((config) => ({
-    ...config,
-    clickhousePassword: Redacted.value(config.clickhousePassword),
-    alpacaKey: Redacted.value(config.alpacaKey),
-    alpacaSecret: Redacted.value(config.alpacaSecret),
-  })),
-)
+})

--- a/services/bayn/src/backfill-config.ts
+++ b/services/bayn/src/backfill-config.ts
@@ -1,0 +1,61 @@
+import { Config, ConfigError, Effect, Redacted } from 'effect'
+
+export interface BackfillConfig {
+  readonly clickhouseUrl: string
+  readonly clickhouseUsername: string
+  readonly clickhousePassword: string
+  readonly alpacaKey: string
+  readonly alpacaSecret: string
+  readonly database: string
+  readonly table: string
+  readonly cluster: string
+  readonly start: string
+  readonly end: string
+  readonly feed: 'iex' | 'sip'
+  readonly datasetVersion: string
+}
+
+const nonEmptyString = (name: string) =>
+  Config.string(name).pipe(
+    Config.map((value) => value.trim()),
+    Config.validate({ message: `${name} is required`, validation: (value) => value.length > 0 }),
+  )
+
+const identifier = (name: string, fallback: string) =>
+  nonEmptyString(name).pipe(
+    Config.withDefault(fallback),
+    Config.validate({
+      message: `${name} must be a ClickHouse identifier`,
+      validation: (value) => /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(value),
+    }),
+  )
+
+const isoDate = (name: string) =>
+  nonEmptyString(name).pipe(
+    Config.validate({
+      message: `${name} must be an ISO date`,
+      validation: (value) => /^\d{4}-\d{2}-\d{2}$/.test(value) && !Number.isNaN(Date.parse(`${value}T00:00:00Z`)),
+    }),
+  )
+
+export const loadBackfillConfig: Effect.Effect<BackfillConfig, ConfigError.ConfigError> = Config.all({
+  clickhouseUrl: nonEmptyString('BAYN_CLICKHOUSE_URL'),
+  clickhouseUsername: nonEmptyString('BAYN_CLICKHOUSE_USERNAME'),
+  clickhousePassword: Config.redacted(nonEmptyString('BAYN_CLICKHOUSE_PASSWORD')),
+  alpacaKey: Config.redacted(nonEmptyString('APCA_API_KEY_ID')),
+  alpacaSecret: Config.redacted(nonEmptyString('APCA_API_SECRET_KEY')),
+  database: identifier('BAYN_CLICKHOUSE_DATABASE', 'signal'),
+  table: identifier('BAYN_CLICKHOUSE_TABLE', 'adjusted_daily_bars_v1'),
+  cluster: identifier('BAYN_CLICKHOUSE_CLUSTER', 'default'),
+  start: isoDate('BAYN_DATASET_START'),
+  end: isoDate('BAYN_DATASET_END'),
+  feed: Config.literal('iex', 'sip')('BAYN_ALPACA_FEED').pipe(Config.withDefault('iex')),
+  datasetVersion: nonEmptyString('BAYN_DATASET_VERSION'),
+}).pipe(
+  Effect.map((config) => ({
+    ...config,
+    clickhousePassword: Redacted.value(config.clickhousePassword),
+    alpacaKey: Redacted.value(config.alpacaKey),
+    alpacaSecret: Redacted.value(config.alpacaSecret),
+  })),
+)

--- a/services/bayn/src/backfill.ts
+++ b/services/bayn/src/backfill.ts
@@ -1,7 +1,7 @@
 import process from 'node:process'
 
 import { createClient } from '@clickhouse/client'
-import { Effect } from 'effect'
+import { Effect, Redacted } from 'effect'
 
 import { loadBackfillConfig } from './backfill-config'
 import { defaultProtocol } from './protocol'
@@ -59,7 +59,7 @@ const main = async (): Promise<void> => {
   const client = createClient({
     url: clickhouseUrl,
     username: clickhouseUsername,
-    password: clickhousePassword,
+    password: Redacted.value(clickhousePassword),
     application: 'bayn-backfill',
   })
 
@@ -111,8 +111,8 @@ const main = async (): Promise<void> => {
       if (pageToken) parameters.set('page_token', pageToken)
       const response = await fetch(`https://data.alpaca.markets/v2/stocks/bars?${parameters.toString()}`, {
         headers: {
-          'APCA-API-KEY-ID': alpacaKey,
-          'APCA-API-SECRET-KEY': alpacaSecret,
+          'APCA-API-KEY-ID': Redacted.value(alpacaKey),
+          'APCA-API-SECRET-KEY': Redacted.value(alpacaSecret),
           accept: 'application/json',
         },
       })

--- a/services/bayn/src/backfill.ts
+++ b/services/bayn/src/backfill.ts
@@ -1,7 +1,9 @@
 import process from 'node:process'
 
 import { createClient } from '@clickhouse/client'
+import { Effect } from 'effect'
 
+import { loadBackfillConfig } from './backfill-config'
 import { defaultProtocol } from './protocol'
 
 interface AlpacaBar {
@@ -38,38 +40,21 @@ interface BackfillRow {
   readonly ingested_at: string
 }
 
-const required = (name: string): string => {
-  const value = process.env[name]?.trim()
-  if (!value) throw new Error(`${name} is required`)
-  return value
-}
-
-const identifier = (value: string, name: string): string => {
-  if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(value)) throw new Error(`${name} is not a valid ClickHouse identifier`)
-  return value
-}
-
-const date = (value: string, name: string): string => {
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(value) || Number.isNaN(Date.parse(`${value}T00:00:00Z`))) {
-    throw new Error(`${name} must be an ISO date`)
-  }
-  return value
-}
-
 const main = async (): Promise<void> => {
-  const clickhouseUrl = required('BAYN_CLICKHOUSE_URL')
-  const clickhouseUsername = required('BAYN_CLICKHOUSE_USERNAME')
-  const clickhousePassword = required('BAYN_CLICKHOUSE_PASSWORD')
-  const alpacaKey = required('APCA_API_KEY_ID')
-  const alpacaSecret = required('APCA_API_SECRET_KEY')
-  const database = identifier(process.env.BAYN_CLICKHOUSE_DATABASE?.trim() || 'signal', 'database')
-  const table = identifier(process.env.BAYN_CLICKHOUSE_TABLE?.trim() || 'adjusted_daily_bars_v1', 'table')
-  const cluster = identifier(process.env.BAYN_CLICKHOUSE_CLUSTER?.trim() || 'default', 'cluster')
-  const start = date(required('BAYN_DATASET_START'), 'BAYN_DATASET_START')
-  const end = date(required('BAYN_DATASET_END'), 'BAYN_DATASET_END')
-  const feed = process.env.BAYN_ALPACA_FEED?.trim() || 'iex'
-  if (!['iex', 'sip'].includes(feed)) throw new Error('BAYN_ALPACA_FEED must be iex or sip')
-  const datasetVersion = required('BAYN_DATASET_VERSION')
+  const {
+    clickhouseUrl,
+    clickhouseUsername,
+    clickhousePassword,
+    alpacaKey,
+    alpacaSecret,
+    database,
+    table,
+    cluster,
+    start,
+    end,
+    feed,
+    datasetVersion,
+  } = await Effect.runPromise(loadBackfillConfig)
   const universe = [...defaultProtocol.universe]
   const client = createClient({
     url: clickhouseUrl,

--- a/services/bayn/src/config.test.ts
+++ b/services/bayn/src/config.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'bun:test'
+
+import { ConfigProvider, Effect, Exit } from 'effect'
+
+import { loadBackfillConfig } from './backfill-config'
+import { loadConfig } from './config'
+
+const runtimeEnvironment = new Map([
+  ['BAYN_CODE_REVISION', 'test-revision'],
+  ['BAYN_CLICKHOUSE_URL', 'http://clickhouse.test:8123'],
+  ['BAYN_CLICKHOUSE_USERNAME', 'bayn'],
+  ['BAYN_CLICKHOUSE_PASSWORD', 'secret'],
+  ['BAYN_DATASET_VERSION', 'fixture-v1'],
+  ['BAYN_TIGERBEETLE_ADDRESSES', 'tigerbeetle.test:3000'],
+])
+
+const backfillEnvironment = new Map([
+  ['BAYN_CLICKHOUSE_URL', 'http://clickhouse.test:8123'],
+  ['BAYN_CLICKHOUSE_USERNAME', 'operator'],
+  ['BAYN_CLICKHOUSE_PASSWORD', 'secret'],
+  ['APCA_API_KEY_ID', 'alpaca-key'],
+  ['APCA_API_SECRET_KEY', 'alpaca-secret'],
+  ['BAYN_DATASET_START', '2025-01-01'],
+  ['BAYN_DATASET_END', '2025-12-31'],
+  ['BAYN_DATASET_VERSION', 'fixture-v1'],
+])
+
+const provideEnvironment = <A, E>(effect: Effect.Effect<A, E>, environment: Map<string, string>) =>
+  effect.pipe(Effect.withConfigProvider(ConfigProvider.fromMap(environment)))
+
+describe('Effect configuration', () => {
+  test('loads runtime configuration with validated defaults', async () => {
+    const config = await Effect.runPromise(provideEnvironment(loadConfig, runtimeEnvironment))
+
+    expect(config.host).toBe('0.0.0.0')
+    expect(config.port).toBe(8080)
+    expect(config.operationTimeoutMs).toBe(30_000)
+    expect(config.clickhouse.database).toBe('signal')
+    expect(config.tigerBeetle.clusterId).toBe(2001n)
+    expect(config.tigerBeetle.replicaAddresses).toEqual(['tigerbeetle.test:3000'])
+  })
+
+  test('returns a typed configuration failure for invalid values', async () => {
+    const invalid = new Map(runtimeEnvironment)
+    invalid.set('BAYN_OPERATION_TIMEOUT_MS', '0')
+
+    const error = await Effect.runPromise(Effect.flip(provideEnvironment(loadConfig, invalid)))
+    expect(error).toMatchObject({
+      _tag: 'BaynError',
+      component: 'config',
+      operation: 'load',
+    })
+  })
+
+  test('loads and validates backfill configuration without reading process.env directly', async () => {
+    const config = await Effect.runPromise(provideEnvironment(loadBackfillConfig, backfillEnvironment))
+
+    expect(config.database).toBe('signal')
+    expect(config.table).toBe('adjusted_daily_bars_v1')
+    expect(config.cluster).toBe('default')
+    expect(config.feed).toBe('iex')
+
+    const invalid = new Map(backfillEnvironment)
+    invalid.set('BAYN_ALPACA_FEED', 'invalid')
+    const exit = await Effect.runPromiseExit(provideEnvironment(loadBackfillConfig, invalid))
+    expect(Exit.isFailure(exit)).toBe(true)
+  })
+})

--- a/services/bayn/src/config.test.ts
+++ b/services/bayn/src/config.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { ConfigProvider, Effect, Exit } from 'effect'
+import { ConfigProvider, Effect, Exit, Redacted } from 'effect'
 
 import { loadBackfillConfig } from './backfill-config'
 import { loadConfig } from './config'
@@ -26,7 +26,9 @@ const backfillEnvironment = new Map([
 ])
 
 const provideEnvironment = <A, E>(effect: Effect.Effect<A, E>, environment: Map<string, string>) =>
-  effect.pipe(Effect.withConfigProvider(ConfigProvider.fromMap(environment)))
+  effect.pipe(
+    Effect.provideService(ConfigProvider.ConfigProvider, ConfigProvider.fromUnknown(Object.fromEntries(environment))),
+  )
 
 describe('Effect configuration', () => {
   test('loads runtime configuration with validated defaults', async () => {
@@ -36,6 +38,7 @@ describe('Effect configuration', () => {
     expect(config.port).toBe(8080)
     expect(config.operationTimeoutMs).toBe(30_000)
     expect(config.clickhouse.database).toBe('signal')
+    expect(Redacted.isRedacted(config.clickhouse.password)).toBe(true)
     expect(config.tigerBeetle.clusterId).toBe(2001n)
     expect(config.tigerBeetle.replicaAddresses).toEqual(['tigerbeetle.test:3000'])
   })
@@ -59,6 +62,9 @@ describe('Effect configuration', () => {
     expect(config.table).toBe('adjusted_daily_bars_v1')
     expect(config.cluster).toBe('default')
     expect(config.feed).toBe('iex')
+    expect(Redacted.isRedacted(config.clickhousePassword)).toBe(true)
+    expect(Redacted.isRedacted(config.alpacaKey)).toBe(true)
+    expect(Redacted.isRedacted(config.alpacaSecret)).toBe(true)
 
     const invalid = new Map(backfillEnvironment)
     invalid.set('BAYN_ALPACA_FEED', 'invalid')

--- a/services/bayn/src/config.ts
+++ b/services/bayn/src/config.ts
@@ -1,7 +1,6 @@
-import process from 'node:process'
+import { Config, Effect, Redacted } from 'effect'
 
-import { Effect } from 'effect'
-
+import { baynError, type BaynError } from './errors'
 import { defaultProtocol } from './protocol'
 import type { TsmomProtocol } from './types'
 
@@ -10,6 +9,7 @@ export interface BaynConfig {
   readonly port: number
   readonly codeRevision: string
   readonly runOnStartup: boolean
+  readonly operationTimeoutMs: number
   readonly clickhouse: {
     readonly url: string
     readonly username: string
@@ -26,54 +26,82 @@ export interface BaynConfig {
   readonly protocol: TsmomProtocol
 }
 
-const required = (environment: NodeJS.ProcessEnv, name: string): string => {
-  const value = environment[name]?.trim()
-  if (!value) {
-    throw new Error(`${name} is required`)
-  }
-  return value
-}
+const nonEmptyString = (name: string) =>
+  Config.string(name).pipe(
+    Config.map((value) => value.trim()),
+    Config.validate({ message: `${name} is required`, validation: (value) => value.length > 0 }),
+  )
 
-const positiveInteger = (value: string, name: string): number => {
-  const parsed = Number.parseInt(value, 10)
-  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
-    throw new Error(`${name} must be a positive integer`)
-  }
-  return parsed
-}
+const positiveInteger = (name: string, fallback: number) =>
+  Config.integer(name).pipe(
+    Config.withDefault(fallback),
+    Config.validate({ message: `${name} must be a positive integer`, validation: (value) => value > 0 }),
+  )
 
-const parseBoolean = (value: string | undefined, fallback: boolean): boolean => {
-  if (value === undefined) return fallback
-  if (value === 'true') return true
-  if (value === 'false') return false
-  throw new Error(`invalid boolean: ${value}`)
-}
+const clickhouseIdentifier = (name: string, fallback: string) =>
+  nonEmptyString(name).pipe(
+    Config.withDefault(fallback),
+    Config.validate({
+      message: `${name} must be a ClickHouse identifier`,
+      validation: (value) => /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(value),
+    }),
+  )
 
-export const parseConfig = (environment: NodeJS.ProcessEnv): BaynConfig => ({
-  host: environment.BAYN_HTTP_HOST?.trim() || '0.0.0.0',
-  port: positiveInteger(environment.BAYN_HTTP_PORT || '8080', 'BAYN_HTTP_PORT'),
-  codeRevision: required(environment, 'BAYN_CODE_REVISION'),
-  runOnStartup: parseBoolean(environment.BAYN_RUN_ON_STARTUP, true),
-  clickhouse: {
-    url: required(environment, 'BAYN_CLICKHOUSE_URL'),
-    username: required(environment, 'BAYN_CLICKHOUSE_USERNAME'),
-    password: required(environment, 'BAYN_CLICKHOUSE_PASSWORD'),
-    database: environment.BAYN_CLICKHOUSE_DATABASE?.trim() || 'signal',
-    table: environment.BAYN_CLICKHOUSE_TABLE?.trim() || 'adjusted_daily_bars_v1',
-    datasetVersion: required(environment, 'BAYN_DATASET_VERSION'),
-  },
-  tigerBeetle: {
-    clusterId: BigInt(environment.BAYN_TIGERBEETLE_CLUSTER_ID || '2001'),
-    replicaAddresses: required(environment, 'BAYN_TIGERBEETLE_ADDRESSES')
-      .split(',')
-      .map((address) => address.trim())
-      .filter(Boolean),
-    ledger: positiveInteger(environment.BAYN_TIGERBEETLE_LEDGER || '7001', 'BAYN_TIGERBEETLE_LEDGER'),
-  },
-  protocol: defaultProtocol,
-})
+const baynConfig = Config.all({
+  host: nonEmptyString('BAYN_HTTP_HOST').pipe(Config.withDefault('0.0.0.0')),
+  port: Config.port('BAYN_HTTP_PORT').pipe(Config.withDefault(8080)),
+  codeRevision: nonEmptyString('BAYN_CODE_REVISION'),
+  runOnStartup: Config.boolean('BAYN_RUN_ON_STARTUP').pipe(Config.withDefault(true)),
+  operationTimeoutMs: positiveInteger('BAYN_OPERATION_TIMEOUT_MS', 30_000),
+  clickhouseUrl: nonEmptyString('BAYN_CLICKHOUSE_URL'),
+  clickhouseUsername: nonEmptyString('BAYN_CLICKHOUSE_USERNAME'),
+  clickhousePassword: Config.redacted(nonEmptyString('BAYN_CLICKHOUSE_PASSWORD')),
+  clickhouseDatabase: clickhouseIdentifier('BAYN_CLICKHOUSE_DATABASE', 'signal'),
+  clickhouseTable: clickhouseIdentifier('BAYN_CLICKHOUSE_TABLE', 'adjusted_daily_bars_v1'),
+  datasetVersion: nonEmptyString('BAYN_DATASET_VERSION'),
+  tigerBeetleClusterId: nonEmptyString('BAYN_TIGERBEETLE_CLUSTER_ID').pipe(
+    Config.withDefault('2001'),
+    Config.mapAttempt((value) => BigInt(value)),
+  ),
+  tigerBeetleReplicaAddresses: nonEmptyString('BAYN_TIGERBEETLE_ADDRESSES').pipe(
+    Config.map((value) =>
+      value
+        .split(',')
+        .map((address) => address.trim())
+        .filter(Boolean),
+    ),
+    Config.validate({
+      message: 'BAYN_TIGERBEETLE_ADDRESSES must contain at least one address',
+      validation: (addresses) => addresses.length > 0,
+    }),
+  ),
+  tigerBeetleLedger: positiveInteger('BAYN_TIGERBEETLE_LEDGER', 7001),
+}).pipe(
+  Config.map(
+    (config): BaynConfig => ({
+      host: config.host,
+      port: config.port,
+      codeRevision: config.codeRevision,
+      runOnStartup: config.runOnStartup,
+      operationTimeoutMs: config.operationTimeoutMs,
+      clickhouse: {
+        url: config.clickhouseUrl,
+        username: config.clickhouseUsername,
+        password: Redacted.value(config.clickhousePassword),
+        database: config.clickhouseDatabase,
+        table: config.clickhouseTable,
+        datasetVersion: config.datasetVersion,
+      },
+      tigerBeetle: {
+        clusterId: config.tigerBeetleClusterId,
+        replicaAddresses: config.tigerBeetleReplicaAddresses,
+        ledger: config.tigerBeetleLedger,
+      },
+      protocol: defaultProtocol,
+    }),
+  ),
+)
 
-export const loadConfig = Effect.try({
-  try: () => parseConfig(process.env),
-  catch: (cause) => new Error(`invalid Bayn configuration: ${String(cause)}`),
-})
+export const loadConfig: Effect.Effect<BaynConfig, BaynError> = baynConfig.pipe(
+  Effect.mapError((cause) => baynError('config', 'load', 'invalid Bayn configuration', cause)),
+)

--- a/services/bayn/src/config.ts
+++ b/services/bayn/src/config.ts
@@ -1,8 +1,6 @@
-import { Config, Effect, Redacted } from 'effect'
+import { Config, Effect, Redacted, Schema, SchemaTransformation } from 'effect'
 
 import { baynError, type BaynError } from './errors'
-import { defaultProtocol } from './protocol'
-import type { TsmomProtocol } from './types'
 
 export interface BaynConfig {
   readonly host: string
@@ -13,7 +11,7 @@ export interface BaynConfig {
   readonly clickhouse: {
     readonly url: string
     readonly username: string
-    readonly password: string
+    readonly password: Redacted.Redacted<string>
     readonly database: string
     readonly table: string
     readonly datasetVersion: string
@@ -23,29 +21,34 @@ export interface BaynConfig {
     readonly replicaAddresses: readonly string[]
     readonly ledger: number
   }
-  readonly protocol: TsmomProtocol
 }
 
-const nonEmptyString = (name: string) =>
-  Config.string(name).pipe(
-    Config.map((value) => value.trim()),
-    Config.validate({ message: `${name} is required`, validation: (value) => value.length > 0 }),
-  )
+const NonEmptyString = Schema.Trim.check(Schema.isMinLength(1))
+const PositiveInteger = Schema.Int.check(Schema.isGreaterThan(0))
+const ClickHouseIdentifier = NonEmptyString.check(Schema.isPattern(/^[a-zA-Z_][a-zA-Z0-9_]*$/))
+const ReplicaAddresses = Schema.Trim.pipe(
+  Schema.decodeTo(
+    Schema.Array(NonEmptyString).check(Schema.isMinLength(1)),
+    SchemaTransformation.transform<readonly string[], string>({
+      decode: (value) =>
+        value
+          .split(',')
+          .map((address) => address.trim())
+          .filter(Boolean),
+      encode: (addresses) => addresses.join(','),
+    }),
+  ),
+)
+
+const nonEmptyString = (name: string) => Config.schema(NonEmptyString, name)
+
+const secretString = (name: string) => nonEmptyString(name).pipe(Config.map((value) => Redacted.make(value)))
 
 const positiveInteger = (name: string, fallback: number) =>
-  Config.integer(name).pipe(
-    Config.withDefault(fallback),
-    Config.validate({ message: `${name} must be a positive integer`, validation: (value) => value > 0 }),
-  )
+  Config.schema(PositiveInteger, name).pipe(Config.withDefault(fallback))
 
 const clickhouseIdentifier = (name: string, fallback: string) =>
-  nonEmptyString(name).pipe(
-    Config.withDefault(fallback),
-    Config.validate({
-      message: `${name} must be a ClickHouse identifier`,
-      validation: (value) => /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(value),
-    }),
-  )
+  Config.schema(ClickHouseIdentifier, name).pipe(Config.withDefault(fallback))
 
 const baynConfig = Config.all({
   host: nonEmptyString('BAYN_HTTP_HOST').pipe(Config.withDefault('0.0.0.0')),
@@ -55,26 +58,14 @@ const baynConfig = Config.all({
   operationTimeoutMs: positiveInteger('BAYN_OPERATION_TIMEOUT_MS', 30_000),
   clickhouseUrl: nonEmptyString('BAYN_CLICKHOUSE_URL'),
   clickhouseUsername: nonEmptyString('BAYN_CLICKHOUSE_USERNAME'),
-  clickhousePassword: Config.redacted(nonEmptyString('BAYN_CLICKHOUSE_PASSWORD')),
+  clickhousePassword: secretString('BAYN_CLICKHOUSE_PASSWORD'),
   clickhouseDatabase: clickhouseIdentifier('BAYN_CLICKHOUSE_DATABASE', 'signal'),
   clickhouseTable: clickhouseIdentifier('BAYN_CLICKHOUSE_TABLE', 'adjusted_daily_bars_v1'),
   datasetVersion: nonEmptyString('BAYN_DATASET_VERSION'),
-  tigerBeetleClusterId: nonEmptyString('BAYN_TIGERBEETLE_CLUSTER_ID').pipe(
-    Config.withDefault('2001'),
-    Config.mapAttempt((value) => BigInt(value)),
+  tigerBeetleClusterId: Config.schema(Schema.BigIntFromString, 'BAYN_TIGERBEETLE_CLUSTER_ID').pipe(
+    Config.withDefault(2001n),
   ),
-  tigerBeetleReplicaAddresses: nonEmptyString('BAYN_TIGERBEETLE_ADDRESSES').pipe(
-    Config.map((value) =>
-      value
-        .split(',')
-        .map((address) => address.trim())
-        .filter(Boolean),
-    ),
-    Config.validate({
-      message: 'BAYN_TIGERBEETLE_ADDRESSES must contain at least one address',
-      validation: (addresses) => addresses.length > 0,
-    }),
-  ),
+  tigerBeetleReplicaAddresses: Config.schema(ReplicaAddresses, 'BAYN_TIGERBEETLE_ADDRESSES'),
   tigerBeetleLedger: positiveInteger('BAYN_TIGERBEETLE_LEDGER', 7001),
 }).pipe(
   Config.map(
@@ -87,7 +78,7 @@ const baynConfig = Config.all({
       clickhouse: {
         url: config.clickhouseUrl,
         username: config.clickhouseUsername,
-        password: Redacted.value(config.clickhousePassword),
+        password: config.clickhousePassword,
         database: config.clickhouseDatabase,
         table: config.clickhouseTable,
         datasetVersion: config.datasetVersion,
@@ -97,7 +88,6 @@ const baynConfig = Config.all({
         replicaAddresses: config.tigerBeetleReplicaAddresses,
         ledger: config.tigerBeetleLedger,
       },
-      protocol: defaultProtocol,
     }),
   ),
 )

--- a/services/bayn/src/errors.ts
+++ b/services/bayn/src/errors.ts
@@ -6,6 +6,7 @@ export class BaynError extends Data.TaggedError('BaynError')<{
   readonly component: BaynComponent
   readonly operation: string
   readonly message: string
+  readonly cause?: unknown
 }> {}
 
 const causeMessage = (cause: unknown): string => (cause instanceof Error ? cause.message : String(cause))
@@ -15,6 +16,7 @@ export const baynError = (component: BaynComponent, operation: string, message: 
     component,
     operation,
     message: cause === undefined ? message : `${message}: ${causeMessage(cause)}`,
+    cause,
   })
 
 export const formatBaynError = (error: BaynError): string => `${error.component}.${error.operation}: ${error.message}`

--- a/services/bayn/src/errors.ts
+++ b/services/bayn/src/errors.ts
@@ -1,0 +1,20 @@
+import { Data } from 'effect'
+
+export type BaynComponent = 'config' | 'http' | 'market-data' | 'strategy' | 'journal'
+
+export class BaynError extends Data.TaggedError('BaynError')<{
+  readonly component: BaynComponent
+  readonly operation: string
+  readonly message: string
+}> {}
+
+const causeMessage = (cause: unknown): string => (cause instanceof Error ? cause.message : String(cause))
+
+export const baynError = (component: BaynComponent, operation: string, message: string, cause?: unknown): BaynError =>
+  new BaynError({
+    component,
+    operation,
+    message: cause === undefined ? message : `${message}: ${causeMessage(cause)}`,
+  })
+
+export const formatBaynError = (error: BaynError): string => `${error.component}.${error.operation}: ${error.message}`

--- a/services/bayn/src/index.ts
+++ b/services/bayn/src/index.ts
@@ -1,40 +1,31 @@
-import process from 'node:process'
-
-import { Effect, Layer } from 'effect'
+import { NodeRuntime } from '@effect/platform-node'
+import { Cause, Effect, Layer, Logger } from 'effect'
 
 import { runBayn } from './app'
 import { loadConfig } from './config'
 import { JournalLive } from './ledger'
 import { MarketDataLive } from './market-data'
+import { TsmomStrategyLive, tsmomStrategy } from './strategy-service'
 
 const main = Effect.gen(function* () {
   const config = yield* loadConfig
-  const dependencies = Layer.mergeAll(MarketDataLive(config), JournalLive(config))
-  yield* runBayn(config).pipe(Effect.provide(dependencies))
+  const dependencies = Layer.mergeAll(
+    MarketDataLive(config, tsmomStrategy.universe),
+    JournalLive(config),
+    TsmomStrategyLive,
+  )
+  return yield* runBayn(config).pipe(Effect.provide(dependencies))
 })
 
-const handledMain = main.pipe(
-  Effect.catchAll((error) =>
-    Effect.sync(() => {
-      console.error(
-        JSON.stringify({
-          service: 'bayn',
-          event: 'startup_failed',
-          error: { component: error.component, operation: error.operation, message: error.message },
-        }),
-      )
-      process.exitCode = 1
-    }),
+const program = main.pipe(
+  Effect.tapCause((cause) =>
+    Cause.hasInterruptsOnly(cause)
+      ? Effect.void
+      : Effect.logError('Bayn process failed').pipe(
+          Effect.annotateLogs({ service: 'bayn', event: 'process_failed', cause: Cause.pretty(cause) }),
+        ),
   ),
+  Effect.provide(Logger.layer([Logger.consoleJson])),
 )
 
-Effect.runPromise(handledMain).catch((cause) => {
-  console.error(
-    JSON.stringify({
-      service: 'bayn',
-      event: 'startup_defect',
-      error: cause instanceof Error ? cause.message : String(cause),
-    }),
-  )
-  process.exitCode = 1
-})
+NodeRuntime.runMain(program, { disableErrorReporting: true })

--- a/services/bayn/src/index.ts
+++ b/services/bayn/src/index.ts
@@ -13,11 +13,26 @@ const main = Effect.gen(function* () {
   yield* runBayn(config).pipe(Effect.provide(dependencies))
 })
 
-Effect.runPromise(main).catch((cause) => {
+const handledMain = main.pipe(
+  Effect.catchAll((error) =>
+    Effect.sync(() => {
+      console.error(
+        JSON.stringify({
+          service: 'bayn',
+          event: 'startup_failed',
+          error: { component: error.component, operation: error.operation, message: error.message },
+        }),
+      )
+      process.exitCode = 1
+    }),
+  ),
+)
+
+Effect.runPromise(handledMain).catch((cause) => {
   console.error(
     JSON.stringify({
       service: 'bayn',
-      event: 'startup_failed',
+      event: 'startup_defect',
       error: cause instanceof Error ? cause.message : String(cause),
     }),
   )

--- a/services/bayn/src/ledger.ts
+++ b/services/bayn/src/ledger.ts
@@ -14,6 +14,7 @@ import {
 import { Context, Effect, Layer } from 'effect'
 
 import type { BaynConfig } from './config'
+import { baynError, type BaynError } from './errors'
 import { hashObject, stableU128, stableU64 } from './hash'
 import type { EvaluationResult, FillEvent, ReconciliationResult } from './types'
 
@@ -93,8 +94,8 @@ export interface LedgerPlan {
 }
 
 export interface JournalService {
-  readonly journalAndReconcile: (result: EvaluationResult) => Effect.Effect<ReconciliationResult, Error>
-  readonly check: Effect.Effect<void, Error>
+  readonly journalAndReconcile: (result: EvaluationResult) => Effect.Effect<ReconciliationResult, BaynError>
+  readonly check: Effect.Effect<void, BaynError>
 }
 
 export const Journal = Context.GenericTag<JournalService>('bayn/Journal')
@@ -407,44 +408,90 @@ const journalAndReconcile = (
   client: Client,
   ledger: number,
   result: EvaluationResult,
-): Effect.Effect<ReconciliationResult, Error> =>
-  Effect.tryPromise({
-    try: async () => {
-      const plan = buildLedgerPlan(result, ledger)
-      await createAndVerifyAccounts(client, plan.accounts)
-      await createAndVerifyTransfers(client, plan.transfers)
-      const accountQuery = { ...queryFilter(ledger), user_data_128: plan.runKey, limit: plan.accounts.length + 1 }
-      const transferQuery = { ...queryFilter(ledger), user_data_64: plan.runTag, limit: plan.transfers.length + 1 }
-      const [accounts, transfers] = await Promise.all([
-        client.queryAccounts(accountQuery),
-        client.queryTransfers(transferQuery),
-      ])
-      assertReconciled(plan, accounts, transfers)
-      return { runId: result.runId, accountCount: accounts.length, transferCount: transfers.length, exact: true }
-    },
-    catch: (cause) => new Error(`TigerBeetle journal or reconciliation failed: ${String(cause)}`),
+): Effect.Effect<ReconciliationResult, BaynError> =>
+  tigerBeetleRequest(client, 'journal-and-reconcile', async () => {
+    const plan = buildLedgerPlan(result, ledger)
+    await createAndVerifyAccounts(client, plan.accounts)
+    await createAndVerifyTransfers(client, plan.transfers)
+    const accountQuery = { ...queryFilter(ledger), user_data_128: plan.runKey, limit: plan.accounts.length + 1 }
+    const transferQuery = { ...queryFilter(ledger), user_data_64: plan.runTag, limit: plan.transfers.length + 1 }
+    const [accounts, transfers] = await Promise.all([
+      client.queryAccounts(accountQuery),
+      client.queryTransfers(transferQuery),
+    ])
+    assertReconciled(plan, accounts, transfers)
+    return { runId: result.runId, accountCount: accounts.length, transferCount: transfers.length, exact: true }
   })
 
-export const JournalLive = (config: BaynConfig): Layer.Layer<JournalService, Error> =>
+const tigerBeetleRequest = <A>(
+  client: Client,
+  operation: string,
+  request: () => Promise<A>,
+): Effect.Effect<A, BaynError> =>
+  Effect.tryPromise({
+    try: async (signal) => {
+      const cancel = () => client.destroy()
+      signal.addEventListener('abort', cancel, { once: true })
+      if (signal.aborted) cancel()
+      try {
+        return await request()
+      } finally {
+        signal.removeEventListener('abort', cancel)
+      }
+    },
+    catch: (cause) => baynError('journal', operation, `TigerBeetle ${operation} failed`, cause),
+  })
+
+export interface JournalDependencies {
+  readonly createClient: typeof createClient
+  readonly resolveReplicaAddresses: (configuredAddresses: readonly string[]) => Promise<string[]>
+}
+
+const defaultDependencies: JournalDependencies = { createClient, resolveReplicaAddresses }
+
+export const JournalLive = (
+  config: BaynConfig,
+  dependencies: JournalDependencies = defaultDependencies,
+): Layer.Layer<JournalService, BaynError> =>
   Layer.scoped(
     Journal,
     Effect.acquireRelease(
       Effect.tryPromise({
-        try: async () =>
-          createClient({
+        try: async (signal) => {
+          const replicaAddresses = await dependencies.resolveReplicaAddresses(config.tigerBeetle.replicaAddresses)
+          signal.throwIfAborted()
+          return dependencies.createClient({
             cluster_id: config.tigerBeetle.clusterId,
-            replica_addresses: await resolveReplicaAddresses(config.tigerBeetle.replicaAddresses),
-          }),
-        catch: (cause) => new Error(`failed to create TigerBeetle client: ${String(cause)}`),
-      }),
-      (client) => Effect.sync(() => client.destroy()),
+            replica_addresses: replicaAddresses,
+          })
+        },
+        catch: (cause) => baynError('journal', 'connect', 'failed to create TigerBeetle client', cause),
+      }).pipe(
+        Effect.timeoutFail({
+          duration: config.operationTimeoutMs,
+          onTimeout: () =>
+            baynError(
+              'journal',
+              'connect',
+              `TigerBeetle client creation timed out after ${config.operationTimeoutMs}ms`,
+            ),
+        }),
+      ),
+      (client) =>
+        Effect.try({
+          try: () => client.destroy(),
+          catch: (cause) => baynError('journal', 'close', 'failed to close TigerBeetle client', cause),
+        }).pipe(
+          Effect.catchAll((error) =>
+            Effect.logWarning('TigerBeetle client close failed').pipe(
+              Effect.annotateLogs({ component: error.component, operation: error.operation, error: error.message }),
+            ),
+          ),
+        ),
     ).pipe(
       Effect.map((client) => ({
-        check: Effect.tryPromise({
-          try: async () => {
-            await client.lookupAccounts([stableU128('bayn-connectivity-probe')])
-          },
-          catch: (cause) => new Error(`TigerBeetle connectivity check failed: ${String(cause)}`),
+        check: tigerBeetleRequest(client, 'connectivity-check', async () => {
+          await client.lookupAccounts([stableU128('bayn-connectivity-probe')])
         }),
         journalAndReconcile: (result) => journalAndReconcile(client, config.tigerBeetle.ledger, result),
       })),

--- a/services/bayn/src/ledger.ts
+++ b/services/bayn/src/ledger.ts
@@ -98,7 +98,7 @@ export interface JournalService {
   readonly check: Effect.Effect<void, BaynError>
 }
 
-export const Journal = Context.GenericTag<JournalService>('bayn/Journal')
+export class Journal extends Context.Service<Journal, JournalService>()('bayn/Journal') {}
 
 const account = (
   runId: string,
@@ -452,8 +452,8 @@ const defaultDependencies: JournalDependencies = { createClient, resolveReplicaA
 export const JournalLive = (
   config: BaynConfig,
   dependencies: JournalDependencies = defaultDependencies,
-): Layer.Layer<JournalService, BaynError> =>
-  Layer.scoped(
+): Layer.Layer<Journal, BaynError> =>
+  Layer.effect(
     Journal,
     Effect.acquireRelease(
       Effect.tryPromise({
@@ -467,13 +467,15 @@ export const JournalLive = (
         },
         catch: (cause) => baynError('journal', 'connect', 'failed to create TigerBeetle client', cause),
       }).pipe(
-        Effect.timeoutFail({
+        Effect.timeoutOrElse({
           duration: config.operationTimeoutMs,
-          onTimeout: () =>
-            baynError(
-              'journal',
-              'connect',
-              `TigerBeetle client creation timed out after ${config.operationTimeoutMs}ms`,
+          orElse: () =>
+            Effect.fail(
+              baynError(
+                'journal',
+                'connect',
+                `TigerBeetle client creation timed out after ${config.operationTimeoutMs}ms`,
+              ),
             ),
         }),
       ),
@@ -482,7 +484,7 @@ export const JournalLive = (
           try: () => client.destroy(),
           catch: (cause) => baynError('journal', 'close', 'failed to close TigerBeetle client', cause),
         }).pipe(
-          Effect.catchAll((error) =>
+          Effect.catch((error) =>
             Effect.logWarning('TigerBeetle client close failed').pipe(
               Effect.annotateLogs({ component: error.component, operation: error.operation, error: error.message }),
             ),

--- a/services/bayn/src/market-data.ts
+++ b/services/bayn/src/market-data.ts
@@ -2,6 +2,7 @@ import { createClient, type ClickHouseClient } from '@clickhouse/client'
 import { Context, Effect, Layer } from 'effect'
 
 import type { BaynConfig } from './config'
+import { baynError, type BaynError } from './errors'
 import { hashObject } from './hash'
 import type { DailyBar, InputManifest, IsoDate, SymbolCoverage } from './types'
 
@@ -25,7 +26,7 @@ export interface MarketDataSnapshot {
 }
 
 export interface MarketDataService {
-  readonly load: Effect.Effect<MarketDataSnapshot, Error>
+  readonly load: Effect.Effect<MarketDataSnapshot, BaynError>
 }
 
 export const MarketData = Context.GenericTag<MarketDataService>('bayn/MarketData')
@@ -169,9 +170,9 @@ const loadSnapshot = (
   client: ClickHouseClient,
   config: BaynConfig['clickhouse'],
   universe: readonly string[],
-): Effect.Effect<MarketDataSnapshot, Error> =>
+): Effect.Effect<MarketDataSnapshot, BaynError> =>
   Effect.tryPromise({
-    try: async () => {
+    try: async (signal) => {
       const database = identifier(config.database, 'database')
       const table = identifier(config.table, 'table')
       const result = await client.query({
@@ -195,30 +196,51 @@ const loadSnapshot = (
         `,
         query_params: { datasetVersion: config.datasetVersion, universe: [...universe] },
         format: 'JSONEachRow',
+        abort_signal: signal,
       })
       const rows = await result.json<ClickHouseBarRow>()
       const bars = rows.map(toBar)
       const manifest = buildInputManifest(bars, database, table, universe, config.datasetVersion)
       return { bars, manifest }
     },
-    catch: (cause) => new Error(`failed to load Signal ClickHouse input: ${String(cause)}`),
+    catch: (cause) => baynError('market-data', 'load', 'failed to load Signal ClickHouse input', cause),
   })
 
-export const MarketDataLive = (config: BaynConfig): Layer.Layer<MarketDataService, Error> =>
+export interface MarketDataDependencies {
+  readonly createClient: typeof createClient
+}
+
+const defaultDependencies: MarketDataDependencies = { createClient }
+
+export const MarketDataLive = (
+  config: BaynConfig,
+  dependencies: MarketDataDependencies = defaultDependencies,
+): Layer.Layer<MarketDataService, BaynError> =>
   Layer.scoped(
     MarketData,
     Effect.acquireRelease(
       Effect.try({
         try: () =>
-          createClient({
+          dependencies.createClient({
             url: config.clickhouse.url,
             username: config.clickhouse.username,
             password: config.clickhouse.password,
             database: config.clickhouse.database,
             application: 'bayn',
+            request_timeout: config.operationTimeoutMs,
           }),
-        catch: (cause) => new Error(`failed to create ClickHouse client: ${String(cause)}`),
+        catch: (cause) => baynError('market-data', 'connect', 'failed to create ClickHouse client', cause),
       }),
-      (client) => Effect.promise(() => client.close()),
+      (client) =>
+        Effect.tryPromise({
+          try: () => client.close(),
+          catch: (cause) => baynError('market-data', 'close', 'failed to close ClickHouse client', cause),
+        }).pipe(
+          Effect.catchAll((error) =>
+            Effect.logWarning('ClickHouse client close failed').pipe(
+              Effect.annotateLogs({ component: error.component, operation: error.operation, error: error.message }),
+            ),
+          ),
+        ),
     ).pipe(Effect.map((client) => ({ load: loadSnapshot(client, config.clickhouse, config.protocol.universe) }))),
   )

--- a/services/bayn/src/market-data.ts
+++ b/services/bayn/src/market-data.ts
@@ -1,24 +1,28 @@
 import { createClient, type ClickHouseClient } from '@clickhouse/client'
-import { Context, Effect, Layer } from 'effect'
+import { Context, Effect, Layer, Redacted, Schema } from 'effect'
 
 import type { BaynConfig } from './config'
 import { baynError, type BaynError } from './errors'
 import { hashObject } from './hash'
 import type { DailyBar, InputManifest, IsoDate, SymbolCoverage } from './types'
 
-interface ClickHouseBarRow {
-  readonly symbol: string
-  readonly session_date: string
-  readonly adjusted_open: number | string
-  readonly adjusted_high: number | string
-  readonly adjusted_low: number | string
-  readonly adjusted_close: number | string
-  readonly adjusted_volume: number | string
-  readonly source: string
-  readonly source_feed: string
-  readonly adjustment: string
-  readonly dataset_version: string
-}
+const ClickHouseNumber = Schema.Union([Schema.Number, Schema.String])
+const ClickHouseBarRow = Schema.Struct({
+  symbol: Schema.String,
+  session_date: Schema.String,
+  adjusted_open: ClickHouseNumber,
+  adjusted_high: ClickHouseNumber,
+  adjusted_low: ClickHouseNumber,
+  adjusted_close: ClickHouseNumber,
+  adjusted_volume: ClickHouseNumber,
+  source: Schema.String,
+  source_feed: Schema.String,
+  adjustment: Schema.String,
+  dataset_version: Schema.String,
+})
+type ClickHouseBarRow = typeof ClickHouseBarRow.Type
+
+const decodeClickHouseBarRows = Schema.decodeUnknownSync(Schema.Array(ClickHouseBarRow))
 
 export interface MarketDataSnapshot {
   readonly bars: readonly DailyBar[]
@@ -29,7 +33,7 @@ export interface MarketDataService {
   readonly load: Effect.Effect<MarketDataSnapshot, BaynError>
 }
 
-export const MarketData = Context.GenericTag<MarketDataService>('bayn/MarketData')
+export class MarketData extends Context.Service<MarketData, MarketDataService>()('bayn/MarketData') {}
 
 const identifier = (value: string, name: string): string => {
   if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(value)) {
@@ -198,7 +202,7 @@ const loadSnapshot = (
         format: 'JSONEachRow',
         abort_signal: signal,
       })
-      const rows = await result.json<ClickHouseBarRow>()
+      const rows = decodeClickHouseBarRows(await result.json<unknown>())
       const bars = rows.map(toBar)
       const manifest = buildInputManifest(bars, database, table, universe, config.datasetVersion)
       return { bars, manifest }
@@ -214,9 +218,10 @@ const defaultDependencies: MarketDataDependencies = { createClient }
 
 export const MarketDataLive = (
   config: BaynConfig,
+  universe: readonly string[],
   dependencies: MarketDataDependencies = defaultDependencies,
-): Layer.Layer<MarketDataService, BaynError> =>
-  Layer.scoped(
+): Layer.Layer<MarketData, BaynError> =>
+  Layer.effect(
     MarketData,
     Effect.acquireRelease(
       Effect.try({
@@ -224,7 +229,7 @@ export const MarketDataLive = (
           dependencies.createClient({
             url: config.clickhouse.url,
             username: config.clickhouse.username,
-            password: config.clickhouse.password,
+            password: Redacted.value(config.clickhouse.password),
             database: config.clickhouse.database,
             application: 'bayn',
             request_timeout: config.operationTimeoutMs,
@@ -236,11 +241,11 @@ export const MarketDataLive = (
           try: () => client.close(),
           catch: (cause) => baynError('market-data', 'close', 'failed to close ClickHouse client', cause),
         }).pipe(
-          Effect.catchAll((error) =>
+          Effect.catch((error) =>
             Effect.logWarning('ClickHouse client close failed').pipe(
               Effect.annotateLogs({ component: error.component, operation: error.operation, error: error.message }),
             ),
           ),
         ),
-    ).pipe(Effect.map((client) => ({ load: loadSnapshot(client, config.clickhouse, config.protocol.universe) }))),
+    ).pipe(Effect.map((client) => ({ load: loadSnapshot(client, config.clickhouse, universe) }))),
   )

--- a/services/bayn/src/resources.test.ts
+++ b/services/bayn/src/resources.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 
 import { createClient as createClickHouseClient, type ClickHouseClient } from '@clickhouse/client'
-import { Effect, Layer, Ref } from 'effect'
+import { Effect, Layer, Redacted, Ref } from 'effect'
 import { createClient as createTigerBeetleClient, type Client } from 'tigerbeetle-node'
 
 import { initializeBayn, type RuntimeState } from './app'
@@ -9,6 +9,7 @@ import type { BaynConfig } from './config'
 import { Journal, JournalLive, type JournalService } from './ledger'
 import { MarketData, MarketDataLive, type MarketDataService } from './market-data'
 import { defaultProtocol } from './protocol'
+import { TsmomStrategyLive } from './strategy-service'
 import { makeSnapshot } from './test-fixtures'
 
 const config: BaynConfig = {
@@ -20,13 +21,12 @@ const config: BaynConfig = {
   clickhouse: {
     url: 'http://clickhouse.test:8123',
     username: 'bayn',
-    password: 'secret',
+    password: Redacted.make('secret'),
     database: 'signal',
     table: 'adjusted_daily_bars_v1',
     datasetVersion: 'fixture-v1',
   },
   tigerBeetle: { clusterId: 2001n, replicaAddresses: ['3000'], ledger: 7001 },
-  protocol: defaultProtocol,
 }
 
 const successfulJournal: JournalService = {
@@ -54,7 +54,7 @@ describe('Bayn resource lifecycle', () => {
         }).pipe(
           Effect.provide(
             Layer.mergeAll(
-              MarketDataLive(config, {
+              MarketDataLive(config, defaultProtocol.universe, {
                 createClient: (() => clickHouseClient) as unknown as typeof createClickHouseClient,
               }),
               JournalLive(config, {
@@ -94,8 +94,9 @@ describe('Bayn resource lifecycle', () => {
       Effect.scoped(
         initializeBayn(config, state).pipe(
           Effect.provideService(Journal, successfulJournal),
+          Effect.provide(TsmomStrategyLive),
           Effect.provide(
-            MarketDataLive(config, {
+            MarketDataLive(config, defaultProtocol.universe, {
               createClient: (() => clickHouseClient) as unknown as typeof createClickHouseClient,
             }),
           ),
@@ -108,6 +109,35 @@ describe('Bayn resource lifecycle', () => {
     expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
       status: 'FAIL_CLOSED',
       error: expect.stringContaining('market-data.load: load timed out'),
+    })
+  })
+
+  test('fails closed when ClickHouse returns a malformed row', async () => {
+    let closed = false
+    const clickHouseClient = {
+      query: async () => ({ json: async () => [{ symbol: 42 }] }),
+      close: async () => void (closed = true),
+    } as unknown as ClickHouseClient
+    const state = await Effect.runPromise(Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null }))
+
+    await Effect.runPromise(
+      Effect.scoped(
+        initializeBayn(config, state).pipe(
+          Effect.provideService(Journal, successfulJournal),
+          Effect.provide(TsmomStrategyLive),
+          Effect.provide(
+            MarketDataLive(config, defaultProtocol.universe, {
+              createClient: (() => clickHouseClient) as unknown as typeof createClickHouseClient,
+            }),
+          ),
+        ),
+      ),
+    )
+
+    expect(closed).toBe(true)
+    expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
+      status: 'FAIL_CLOSED',
+      error: expect.stringContaining('market-data.load'),
     })
   })
 
@@ -132,6 +162,7 @@ describe('Bayn resource lifecycle', () => {
       Effect.scoped(
         initializeBayn(config, state).pipe(
           Effect.provideService(MarketData, marketData),
+          Effect.provide(TsmomStrategyLive),
           Effect.provide(
             JournalLive(config, {
               createClient: (() => tigerBeetleClient) as unknown as typeof createTigerBeetleClient,

--- a/services/bayn/src/resources.test.ts
+++ b/services/bayn/src/resources.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createClient as createClickHouseClient, type ClickHouseClient } from '@clickhouse/client'
+import { Effect, Layer, Ref } from 'effect'
+import { createClient as createTigerBeetleClient, type Client } from 'tigerbeetle-node'
+
+import { initializeBayn, type RuntimeState } from './app'
+import type { BaynConfig } from './config'
+import { Journal, JournalLive, type JournalService } from './ledger'
+import { MarketData, MarketDataLive, type MarketDataService } from './market-data'
+import { defaultProtocol } from './protocol'
+import { makeSnapshot } from './test-fixtures'
+
+const config: BaynConfig = {
+  host: '127.0.0.1',
+  port: 0,
+  codeRevision: 'test-revision',
+  runOnStartup: true,
+  operationTimeoutMs: 20,
+  clickhouse: {
+    url: 'http://clickhouse.test:8123',
+    username: 'bayn',
+    password: 'secret',
+    database: 'signal',
+    table: 'adjusted_daily_bars_v1',
+    datasetVersion: 'fixture-v1',
+  },
+  tigerBeetle: { clusterId: 2001n, replicaAddresses: ['3000'], ledger: 7001 },
+  protocol: defaultProtocol,
+}
+
+const successfulJournal: JournalService = {
+  check: Effect.void,
+  journalAndReconcile: (evaluation) =>
+    Effect.succeed({ runId: evaluation.runId, accountCount: 1, transferCount: 1, exact: true }),
+}
+
+describe('Bayn resource lifecycle', () => {
+  test('closes ClickHouse and TigerBeetle clients exactly once when their scope exits', async () => {
+    let clickHouseCloseCount = 0
+    let tigerBeetleCloseCount = 0
+    const clickHouseClient = {
+      close: async () => void (clickHouseCloseCount += 1),
+    } as unknown as ClickHouseClient
+    const tigerBeetleClient = {
+      destroy: () => void (tigerBeetleCloseCount += 1),
+    } as unknown as Client
+
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          yield* MarketData
+          yield* Journal
+        }).pipe(
+          Effect.provide(
+            Layer.mergeAll(
+              MarketDataLive(config, {
+                createClient: (() => clickHouseClient) as unknown as typeof createClickHouseClient,
+              }),
+              JournalLive(config, {
+                createClient: (() => tigerBeetleClient) as unknown as typeof createTigerBeetleClient,
+                resolveReplicaAddresses: async () => ['3000'],
+              }),
+            ),
+          ),
+        ),
+      ),
+    )
+
+    expect(clickHouseCloseCount).toBe(1)
+    expect(tigerBeetleCloseCount).toBe(1)
+  })
+
+  test('aborts an in-flight ClickHouse query when the startup deadline expires', async () => {
+    let aborted = false
+    let closed = false
+    const clickHouseClient = {
+      query: ({ abort_signal: signal }: { abort_signal?: AbortSignal }) =>
+        new Promise<never>((_, reject) => {
+          signal?.addEventListener(
+            'abort',
+            () => {
+              aborted = true
+              reject(new Error('query aborted'))
+            },
+            { once: true },
+          )
+        }),
+      close: async () => void (closed = true),
+    } as unknown as ClickHouseClient
+    const state = await Effect.runPromise(Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null }))
+
+    await Effect.runPromise(
+      Effect.scoped(
+        initializeBayn(config, state).pipe(
+          Effect.provideService(Journal, successfulJournal),
+          Effect.provide(
+            MarketDataLive(config, {
+              createClient: (() => clickHouseClient) as unknown as typeof createClickHouseClient,
+            }),
+          ),
+        ),
+      ),
+    )
+
+    expect(aborted).toBe(true)
+    expect(closed).toBe(true)
+    expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
+      status: 'FAIL_CLOSED',
+      error: expect.stringContaining('market-data.load: load timed out'),
+    })
+  })
+
+  test('destroys TigerBeetle to cancel its indefinite retry when the startup deadline expires', async () => {
+    let destroyed = false
+    let rejectLookup: ((cause: Error) => void) | undefined
+    const tigerBeetleClient = {
+      lookupAccounts: () =>
+        new Promise<never>((_, reject) => {
+          rejectLookup = reject
+        }),
+      destroy: () => {
+        if (destroyed) return
+        destroyed = true
+        rejectLookup?.(new Error('client closed'))
+      },
+    } as unknown as Client
+    const marketData: MarketDataService = { load: Effect.succeed(makeSnapshot()) }
+    const state = await Effect.runPromise(Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null }))
+
+    await Effect.runPromise(
+      Effect.scoped(
+        initializeBayn(config, state).pipe(
+          Effect.provideService(MarketData, marketData),
+          Effect.provide(
+            JournalLive(config, {
+              createClient: (() => tigerBeetleClient) as unknown as typeof createTigerBeetleClient,
+              resolveReplicaAddresses: async () => ['3000'],
+            }),
+          ),
+        ),
+      ),
+    )
+
+    expect(destroyed).toBe(true)
+    expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
+      status: 'FAIL_CLOSED',
+      error: expect.stringContaining('journal.connectivity-check: connectivity-check timed out'),
+    })
+  })
+})

--- a/services/bayn/src/strategy-service.ts
+++ b/services/bayn/src/strategy-service.ts
@@ -1,0 +1,23 @@
+import { Context, Layer } from 'effect'
+
+import { defaultProtocol } from './protocol'
+import { evaluateTsmom } from './strategy'
+import type { DailyBar, EvaluationResult, InputManifest, TsmomProtocol } from './types'
+
+export interface StrategyService {
+  readonly name: string
+  readonly universe: readonly string[]
+  readonly evaluate: (bars: readonly DailyBar[], manifest: InputManifest, codeRevision: string) => EvaluationResult
+}
+
+export class Strategy extends Context.Service<Strategy, StrategyService>()('bayn/Strategy') {}
+
+export const makeTsmomStrategy = (protocol: TsmomProtocol): StrategyService => ({
+  name: 'tsmom',
+  universe: protocol.universe,
+  evaluate: (bars, manifest, codeRevision) => evaluateTsmom(bars, manifest, protocol, codeRevision),
+})
+
+export const tsmomStrategy = makeTsmomStrategy(defaultProtocol)
+
+export const TsmomStrategyLive = Layer.succeed(Strategy, tsmomStrategy)


### PR DESCRIPTION
## Summary

- migrate Bayn to the exact Effect 4 beta.99 cohort and `@effect/platform-node`; `NodeRuntime` and Effect HTTP now own process signals, server scope, shutdown, and structured JSON logging
- keep startup fail closed with typed causes, bounded and interruption-safe ClickHouse/TigerBeetle operations, exact resource finalization, and defect propagation instead of a detached `STARTING` worker
- validate runtime configuration and ClickHouse rows with Effect Schema while keeping credentials `Redacted` until the client/request boundary
- inject one minimal strategy capability at the composition root; TSMOM remains the first implementation and owns its protocol and universe without a registry or scheduler
- pin `@clickhouse/client` 1.23.1, `effect`/`@effect/platform-node` 4.0.0-beta.99, and `tigerbeetle-node` 0.17.9

## Related Issues

None

## Testing

- `bun run --filter @proompteng/bayn test` (25 passing)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- `bun test packages/scripts/src/bayn` (2 passing)
- `kustomize build argocd/applications/bayn`
- `kubectl apply --dry-run=client -n bayn -f /tmp/bayn-rendered.yaml`
- launched the built bundle with an empty environment and verified exit 1 with a structured configuration failure

## Breaking Changes

None. `BAYN_OPERATION_TIMEOUT_MS` still defaults to 30000 and is set explicitly in the Deployment.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; this is a backend runtime change.
- [x] Documentation and deployment follow-ups are updated.