### PR TITLE
chore(torghut): bridge TigerBeetle to 0.17.5

### DIFF
--- a/argocd/applications/torghut/tigerbeetle-cluster.yaml
+++ b/argocd/applications/torghut/tigerbeetle-cluster.yaml
@@ -11,7 +11,7 @@ spec:
   replicas: 1
   image:
     repository: ghcr.io/tigerbeetle/tigerbeetle
-    tag: "0.17.4"
+    tag: "0.17.5"
     pullPolicy: IfNotPresent
   storage:
     className: rook-ceph-block


### PR DESCRIPTION
## Summary

- Upgrade the Torghut TigerBeetle replica from 0.17.4 to the supported 0.17.5 bridge release.
- Preserve the existing cluster ID, single replica, retained PVC, resources, and health configuration.
- Prepare the required second hop to 0.17.9, whose oldest upgradable replica is 0.17.5.

## Related Issues

None

## Testing

- `kustomize build --enable-helm argocd/applications/torghut` rendered TigerBeetle tag 0.17.5.
- `bun run lint:argocd` passed: 0 invalid resources and 0 errors.
- Verified the official 0.17.5 release supports upgrades from replicas as old as 0.17.1 and publishes linux/arm64.

## Breaking Changes

The single-replica ledger can be briefly unavailable while the StatefulSet rolls. Persistent storage, cluster ID, and client/capital authority are unchanged. After live health proof, a separate GitOps change will perform the 0.17.9 hop.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Required follow-up is documented above.