### PR TITLE
refactor(bayn): simplify runtime API

### DIFF
--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -24,8 +24,7 @@ and journals the resulting simulation to TigerBeetle. It contains no broker clie
 
 - `GET /livez`: process liveness.
 - `GET /readyz`: dependency/evaluation/accounting readiness.
-- `GET /v1/status` and `GET /v1/evidence/latest`: authority boundary, input manifest, metrics, verdict, and
-  reconciliation receipt.
+- `GET /v1/status`: authority boundary, input manifest, metrics, verdict, and reconciliation receipt.
 
 ## Validation
 

--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -3,9 +3,9 @@ import { describe, expect, test } from 'bun:test'
 import { Cause, Context, Effect, Exit, Layer, Redacted, Ref } from 'effect'
 import { HttpServer } from 'effect/unstable/http'
 
-import { initializeBayn, makeHttpLayer, runBayn, type RuntimeState } from './app'
-import type { BaynConfig } from './config'
-import { baynError } from './errors'
+import { initialize, makeHttpLayer, run, type RuntimeState } from './app'
+import type { RuntimeConfig } from './config'
+import { operationalError } from './errors'
 import { Journal, type JournalService } from './ledger'
 import { MarketData, type MarketDataService } from './market-data'
 import { defaultProtocol } from './protocol'
@@ -13,7 +13,7 @@ import { evaluateTsmom } from './strategy'
 import { Strategy, TsmomStrategyLive, type StrategyService } from './strategy-service'
 import { makeSnapshot } from './test-fixtures'
 
-const config: BaynConfig = {
+const config: RuntimeConfig = {
   host: '127.0.0.1',
   port: 0,
   codeRevision: 'test-revision',
@@ -146,7 +146,7 @@ describe('Bayn startup lifecycle', () => {
     }
 
     await Effect.runPromise(
-      initializeBayn(config, state).pipe(
+      initialize(config, state).pipe(
         Effect.provideService(MarketData, { load: Effect.succeed(snapshot) }),
         Effect.provideService(Journal, successfulJournal),
         Effect.provideService(Strategy, strategy),
@@ -163,7 +163,7 @@ describe('Bayn startup lifecycle', () => {
     const marketData: MarketDataService = { load: Effect.succeed(snapshot) }
 
     await Effect.runPromise(
-      initializeBayn(config, state).pipe(
+      initialize(config, state).pipe(
         Effect.provideService(MarketData, marketData),
         Effect.provideService(Journal, successfulJournal),
         Effect.provide(TsmomStrategyLive),
@@ -183,7 +183,7 @@ describe('Bayn startup lifecycle', () => {
     const marketData: MarketDataService = { load: Effect.succeed(makeSnapshot(700)) }
 
     await Effect.runPromise(
-      initializeBayn(config, state).pipe(
+      initialize(config, state).pipe(
         Effect.provideService(MarketData, marketData),
         Effect.provideService(Journal, successfulJournal),
         Effect.provide(TsmomStrategyLive),
@@ -209,7 +209,7 @@ describe('Bayn startup lifecycle', () => {
     }
 
     await Effect.runPromise(
-      initializeBayn({ ...config, runOnStartup: false }, state).pipe(
+      initialize({ ...config, runOnStartup: false }, state).pipe(
         Effect.provideService(MarketData, marketData),
         Effect.provideService(Journal, journal),
         Effect.provide(TsmomStrategyLive),
@@ -231,7 +231,7 @@ describe('Bayn startup lifecycle', () => {
     }
 
     await Effect.runPromise(
-      initializeBayn({ ...config, operationTimeoutMs: 10 }, state).pipe(
+      initialize({ ...config, operationTimeoutMs: 10 }, state).pipe(
         Effect.provideService(MarketData, marketData),
         Effect.provideService(Journal, successfulJournal),
         Effect.provide(TsmomStrategyLive),
@@ -248,13 +248,14 @@ describe('Bayn startup lifecycle', () => {
   test('propagates an unexpected defect instead of leaving a detached STARTING worker', async () => {
     const marketData: MarketDataService = { load: Effect.die(new Error('unexpected startup defect')) }
     const exit = await Effect.runPromiseExit(
-      runBayn(config).pipe(
+      run(config).pipe(
         Effect.provideService(MarketData, marketData),
         Effect.provideService(Journal, successfulJournal),
         Effect.provide(TsmomStrategyLive),
         Effect.timeoutOrElse({
           duration: 250,
-          orElse: () => Effect.fail(baynError('http', 'test', 'runBayn remained alive after its startup worker died')),
+          orElse: () =>
+            Effect.fail(operationalError('http', 'test', 'run remained alive after its startup worker died')),
         }),
       ),
     )

--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -99,11 +99,6 @@ describe('Bayn HTTP probes', () => {
               authority: { brokerOrders: false, capitalPromotion: false },
             },
           })
-          expect(yield* Effect.promise(() => fetchJson(port, '/v1/evidence/latest'))).toMatchObject({
-            status: 200,
-            body: { service: 'bayn', status: 'READY' },
-          })
-
           yield* Ref.set(state, { status: 'FAIL_CLOSED', evidence: null, error: 'test failure' })
           expect(yield* Effect.promise(() => fetchJson(port, '/readyz'))).toMatchObject({
             status: 503,
@@ -113,7 +108,7 @@ describe('Bayn HTTP probes', () => {
             status: 200,
             body: { status: 'FAIL_CLOSED', error: 'test failure' },
           })
-          expect(yield* Effect.promise(() => fetchJson(port, '/missing'))).toMatchObject({
+          expect(yield* Effect.promise(() => fetchJson(port, '/v1/evidence/latest'))).toMatchObject({
             status: 404,
             body: { error: 'not_found' },
           })

--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -58,7 +58,6 @@ export const makeHttpLayer = (
     HttpRouter.route<never, never>('GET', '/livez', jsonResponse({ service: 'bayn', live: true })),
     HttpRouter.route<never, never>('GET', '/readyz', ready),
     HttpRouter.route<never, never>('GET', '/v1/status', status),
-    HttpRouter.route<never, never>('GET', '/v1/evidence/latest', status),
     HttpRouter.route<never, never>('*', '*', fallback),
   ] as const)
 

--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -4,8 +4,8 @@ import { NodeHttpServer } from '@effect/platform-node'
 import { Effect, Layer, Ref } from 'effect'
 import { HttpRouter, HttpServerRequest, HttpServerResponse } from 'effect/unstable/http'
 
-import type { BaynConfig } from './config'
-import { baynError, formatBaynError, type BaynComponent, type BaynError } from './errors'
+import type { RuntimeConfig } from './config'
+import { formatError, operationalError, type Component, type OperationalError } from './errors'
 import { Journal } from './ledger'
 import { MarketData } from './market-data'
 import { Strategy } from './strategy-service'
@@ -36,7 +36,7 @@ const jsonResponse = (body: unknown, status = 200, headers?: Readonly<Record<str
   HttpServerResponse.text(json(body), { status, contentType: 'application/json', headers })
 
 export const makeHttpLayer = (
-  config: Pick<BaynConfig, 'host' | 'port'>,
+  config: Pick<RuntimeConfig, 'host' | 'port'>,
   state: Ref.Ref<RuntimeState>,
 ): ReturnType<typeof NodeHttpServer.layer> => {
   const ready = Ref.get(state).pipe(
@@ -67,19 +67,19 @@ export const makeHttpLayer = (
 }
 
 const withinDeadline = <A, R>(
-  effect: Effect.Effect<A, BaynError, R>,
+  effect: Effect.Effect<A, OperationalError, R>,
   timeoutMs: number,
-  component: BaynComponent,
+  component: Component,
   operation: string,
-): Effect.Effect<A, BaynError, R> =>
+): Effect.Effect<A, OperationalError, R> =>
   effect.pipe(
     Effect.timeoutOrElse({
       duration: timeoutMs,
-      orElse: () => Effect.fail(baynError(component, operation, `${operation} timed out after ${timeoutMs}ms`)),
+      orElse: () => Effect.fail(operationalError(component, operation, `${operation} timed out after ${timeoutMs}ms`)),
     }),
   )
 
-const failClosed = (state: Ref.Ref<RuntimeState>, error: BaynError): Effect.Effect<void> =>
+const failClosed = (state: Ref.Ref<RuntimeState>, error: OperationalError): Effect.Effect<void> =>
   Effect.logError('Bayn startup failed closed').pipe(
     Effect.annotateLogs({
       service: 'bayn',
@@ -91,15 +91,15 @@ const failClosed = (state: Ref.Ref<RuntimeState>, error: BaynError): Effect.Effe
       Ref.set(state, {
         status: 'FAIL_CLOSED',
         evidence: null,
-        error: formatBaynError(error),
+        error: formatError(error),
       }),
     ),
   )
 
 const evaluateAndJournal = (
-  config: BaynConfig,
+  config: RuntimeConfig,
   state: Ref.Ref<RuntimeState>,
-): Effect.Effect<void, BaynError, MarketData | Journal | Strategy> =>
+): Effect.Effect<void, OperationalError, MarketData | Journal | Strategy> =>
   Effect.gen(function* () {
     const marketData = yield* MarketData
     const journal = yield* Journal
@@ -122,7 +122,7 @@ const evaluateAndJournal = (
     )
     const evaluation = yield* Effect.try({
       try: () => strategy.evaluate(snapshot.bars, snapshot.manifest, config.codeRevision),
-      catch: (cause) => baynError('strategy', 'evaluate', `${strategy.name} evaluation failed`, cause),
+      catch: (cause) => operationalError('strategy', 'evaluate', `${strategy.name} evaluation failed`, cause),
     })
     yield* Effect.logInfo('Bayn strategy evaluation completed').pipe(
       Effect.annotateLogs({
@@ -156,9 +156,9 @@ const evaluateAndJournal = (
   }).pipe(Effect.withLogSpan('startup'))
 
 const checkWithoutJournal = (
-  config: BaynConfig,
+  config: RuntimeConfig,
   state: Ref.Ref<RuntimeState>,
-): Effect.Effect<void, BaynError, MarketData | Journal> =>
+): Effect.Effect<void, OperationalError, MarketData | Journal> =>
   Effect.gen(function* () {
     const marketData = yield* MarketData
     const journal = yield* Journal
@@ -171,22 +171,22 @@ const checkWithoutJournal = (
     })
   })
 
-export const initializeBayn = (
-  config: BaynConfig,
+export const initialize = (
+  config: RuntimeConfig,
   state: Ref.Ref<RuntimeState>,
 ): Effect.Effect<void, never, MarketData | Journal | Strategy> =>
   (config.runOnStartup ? evaluateAndJournal(config, state) : checkWithoutJournal(config, state)).pipe(
     Effect.catch((error) => failClosed(state, error)),
   )
 
-export const runBayn = (config: BaynConfig): Effect.Effect<never, BaynError, MarketData | Journal | Strategy> =>
+export const run = (config: RuntimeConfig): Effect.Effect<never, OperationalError, MarketData | Journal | Strategy> =>
   Effect.scoped(
     Effect.gen(function* () {
       const state = yield* Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null })
       yield* Layer.build(makeHttpLayer(config, state)).pipe(
-        Effect.mapError((cause) => baynError('http', 'listen', 'Bayn HTTP server failed to listen', cause)),
+        Effect.mapError((cause) => operationalError('http', 'listen', 'HTTP server failed to listen', cause)),
       )
-      yield* initializeBayn(config, state)
+      yield* initialize(config, state)
       return yield* Effect.never
     }),
   )

--- a/services/bayn/src/config.test.ts
+++ b/services/bayn/src/config.test.ts
@@ -49,7 +49,7 @@ describe('Effect configuration', () => {
 
     const error = await Effect.runPromise(Effect.flip(provideEnvironment(loadConfig, invalid)))
     expect(error).toMatchObject({
-      _tag: 'BaynError',
+      _tag: 'OperationalError',
       component: 'config',
       operation: 'load',
     })

--- a/services/bayn/src/config.ts
+++ b/services/bayn/src/config.ts
@@ -1,8 +1,8 @@
 import { Config, Effect, Redacted, Schema, SchemaTransformation } from 'effect'
 
-import { baynError, type BaynError } from './errors'
+import { operationalError, type OperationalError } from './errors'
 
-export interface BaynConfig {
+export interface RuntimeConfig {
   readonly host: string
   readonly port: number
   readonly codeRevision: string
@@ -50,7 +50,7 @@ const positiveInteger = (name: string, fallback: number) =>
 const clickhouseIdentifier = (name: string, fallback: string) =>
   Config.schema(ClickHouseIdentifier, name).pipe(Config.withDefault(fallback))
 
-const baynConfig = Config.all({
+const runtimeConfig = Config.all({
   host: nonEmptyString('BAYN_HTTP_HOST').pipe(Config.withDefault('0.0.0.0')),
   port: Config.port('BAYN_HTTP_PORT').pipe(Config.withDefault(8080)),
   codeRevision: nonEmptyString('BAYN_CODE_REVISION'),
@@ -69,7 +69,7 @@ const baynConfig = Config.all({
   tigerBeetleLedger: positiveInteger('BAYN_TIGERBEETLE_LEDGER', 7001),
 }).pipe(
   Config.map(
-    (config): BaynConfig => ({
+    (config): RuntimeConfig => ({
       host: config.host,
       port: config.port,
       codeRevision: config.codeRevision,
@@ -92,6 +92,6 @@ const baynConfig = Config.all({
   ),
 )
 
-export const loadConfig: Effect.Effect<BaynConfig, BaynError> = baynConfig.pipe(
-  Effect.mapError((cause) => baynError('config', 'load', 'invalid Bayn configuration', cause)),
+export const loadConfig: Effect.Effect<RuntimeConfig, OperationalError> = runtimeConfig.pipe(
+  Effect.mapError((cause) => operationalError('config', 'load', 'invalid runtime configuration', cause)),
 )

--- a/services/bayn/src/errors.ts
+++ b/services/bayn/src/errors.ts
@@ -1,9 +1,9 @@
 import { Data } from 'effect'
 
-export type BaynComponent = 'config' | 'http' | 'market-data' | 'strategy' | 'journal'
+export type Component = 'config' | 'http' | 'market-data' | 'strategy' | 'journal'
 
-export class BaynError extends Data.TaggedError('BaynError')<{
-  readonly component: BaynComponent
+export class OperationalError extends Data.TaggedError('OperationalError')<{
+  readonly component: Component
   readonly operation: string
   readonly message: string
   readonly cause?: unknown
@@ -11,12 +11,18 @@ export class BaynError extends Data.TaggedError('BaynError')<{
 
 const causeMessage = (cause: unknown): string => (cause instanceof Error ? cause.message : String(cause))
 
-export const baynError = (component: BaynComponent, operation: string, message: string, cause?: unknown): BaynError =>
-  new BaynError({
+export const operationalError = (
+  component: Component,
+  operation: string,
+  message: string,
+  cause?: unknown,
+): OperationalError =>
+  new OperationalError({
     component,
     operation,
     message: cause === undefined ? message : `${message}: ${causeMessage(cause)}`,
     cause,
   })
 
-export const formatBaynError = (error: BaynError): string => `${error.component}.${error.operation}: ${error.message}`
+export const formatError = (error: OperationalError): string =>
+  `${error.component}.${error.operation}: ${error.message}`

--- a/services/bayn/src/index.ts
+++ b/services/bayn/src/index.ts
@@ -1,7 +1,7 @@
 import { NodeRuntime } from '@effect/platform-node'
 import { Cause, Effect, Layer, Logger } from 'effect'
 
-import { runBayn } from './app'
+import { run } from './app'
 import { loadConfig } from './config'
 import { JournalLive } from './ledger'
 import { MarketDataLive } from './market-data'
@@ -14,7 +14,7 @@ const main = Effect.gen(function* () {
     JournalLive(config),
     TsmomStrategyLive,
   )
-  return yield* runBayn(config).pipe(Effect.provide(dependencies))
+  return yield* run(config).pipe(Effect.provide(dependencies))
 })
 
 const program = main.pipe(

--- a/services/bayn/src/ledger.test.ts
+++ b/services/bayn/src/ledger.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test'
+import { Effect } from 'effect'
 import type { Account, Transfer } from 'tigerbeetle-node'
 
 import { assertReconciled, buildLedgerPlan, resolveReplicaAddresses } from './ledger'
@@ -57,12 +58,15 @@ describe('TigerBeetle simulation journal', () => {
 describe('TigerBeetle replica addresses', () => {
   test('resolves service hostnames once at startup and preserves numeric addresses', async () => {
     const lookups: string[] = []
-    const addresses = await resolveReplicaAddresses(
-      ['torghut-tigerbeetle.torghut.svc.cluster.local:3000', '10.244.5.234:3000', '3001'],
-      async (hostname) => {
-        lookups.push(hostname)
-        return ['10.244.5.234', '10.244.5.235']
-      },
+    const addresses = await Effect.runPromise(
+      resolveReplicaAddresses(
+        ['torghut-tigerbeetle.torghut.svc.cluster.local:3000', '10.244.5.234:3000', '3001'],
+        (hostname) =>
+          Effect.sync(() => {
+            lookups.push(hostname)
+            return ['10.244.5.234', '10.244.5.235']
+          }),
+      ),
     )
 
     expect(lookups).toEqual(['torghut-tigerbeetle.torghut.svc.cluster.local'])
@@ -70,12 +74,14 @@ describe('TigerBeetle replica addresses', () => {
   })
 
   test('rejects malformed, out-of-range, and IPv6-only endpoints', async () => {
-    expect(resolveReplicaAddresses(['missing-port'], async () => ['10.0.0.1'])).rejects.toThrow(
-      'invalid TigerBeetle replica address',
+    expect(
+      Effect.runPromise(resolveReplicaAddresses(['missing-port'], () => Effect.succeed(['10.0.0.1']))),
+    ).rejects.toThrow('invalid TigerBeetle replica address')
+    expect(
+      Effect.runPromise(resolveReplicaAddresses(['replica:70000'], () => Effect.succeed(['10.0.0.1']))),
+    ).rejects.toThrow('invalid TigerBeetle replica port')
+    expect(Effect.runPromise(resolveReplicaAddresses(['replica:3000'], () => Effect.succeed(['::1'])))).rejects.toThrow(
+      'has no IPv4 address',
     )
-    expect(resolveReplicaAddresses(['replica:70000'], async () => ['10.0.0.1'])).rejects.toThrow(
-      'invalid TigerBeetle replica port',
-    )
-    expect(resolveReplicaAddresses(['replica:3000'], async () => ['::1'])).rejects.toThrow('has no IPv4 address')
   })
 })

--- a/services/bayn/src/ledger.ts
+++ b/services/bayn/src/ledger.ts
@@ -24,22 +24,18 @@ const BATCH_MAX = 8_189
 type ResolveHostname = (hostname: string) => Effect.Effect<readonly string[], OperationalError>
 
 const lookupIpv4: ResolveHostname = (hostname) =>
-  Effect.tryPromise({
-    try: (signal) => {
-      const resolver = new Resolver()
-      const cancel = () => resolver.cancel()
-      signal.addEventListener('abort', cancel, { once: true })
-      const request = resolver.resolve4(hostname)
-      if (signal.aborted) cancel()
-      return request.finally(() => signal.removeEventListener('abort', cancel))
-    },
-    catch: (cause) =>
-      operationalError(
-        'journal',
-        'resolve-replica-addresses',
-        `failed to resolve TigerBeetle hostname ${hostname}`,
-        cause,
-      ),
+  Effect.suspend(() => {
+    const resolver = new Resolver()
+    return Effect.tryPromise({
+      try: () => resolver.resolve4(hostname),
+      catch: (cause) =>
+        operationalError(
+          'journal',
+          'resolve-replica-addresses',
+          `failed to resolve TigerBeetle hostname ${hostname}`,
+          cause,
+        ),
+    }).pipe(Effect.onInterrupt(() => Effect.sync(() => resolver.cancel())))
   })
 
 const parsePort = (value: string, address: string): Effect.Effect<number, OperationalError> => {
@@ -407,15 +403,9 @@ export const assertReconciled = (
 
 const request = <A>(client: Client, operation: string, execute: () => Promise<A>): Effect.Effect<A, OperationalError> =>
   Effect.tryPromise({
-    try: (signal) => {
-      const cancel = () => client.destroy()
-      signal.addEventListener('abort', cancel, { once: true })
-      const pending = execute()
-      if (signal.aborted) cancel()
-      return pending.finally(() => signal.removeEventListener('abort', cancel))
-    },
+    try: execute,
     catch: (cause) => operationalError('journal', operation, `TigerBeetle ${operation} failed`, cause),
-  })
+  }).pipe(Effect.onInterrupt(() => Effect.sync(() => client.destroy())))
 
 const validate = <A>(operation: string, evaluate: () => A): Effect.Effect<A, OperationalError> =>
   Effect.try({

--- a/services/bayn/src/ledger.ts
+++ b/services/bayn/src/ledger.ts
@@ -13,8 +13,8 @@ import {
 } from 'tigerbeetle-node'
 import { Context, Effect, Layer } from 'effect'
 
-import type { BaynConfig } from './config'
-import { baynError, type BaynError } from './errors'
+import type { RuntimeConfig } from './config'
+import { operationalError, type OperationalError } from './errors'
 import { hashObject, stableU128, stableU64 } from './hash'
 import type { EvaluationResult, FillEvent, ReconciliationResult } from './types'
 
@@ -94,8 +94,8 @@ export interface LedgerPlan {
 }
 
 export interface JournalService {
-  readonly journalAndReconcile: (result: EvaluationResult) => Effect.Effect<ReconciliationResult, BaynError>
-  readonly check: Effect.Effect<void, BaynError>
+  readonly journalAndReconcile: (result: EvaluationResult) => Effect.Effect<ReconciliationResult, OperationalError>
+  readonly check: Effect.Effect<void, OperationalError>
 }
 
 export class Journal extends Context.Service<Journal, JournalService>()('bayn/Journal') {}
@@ -408,7 +408,7 @@ const journalAndReconcile = (
   client: Client,
   ledger: number,
   result: EvaluationResult,
-): Effect.Effect<ReconciliationResult, BaynError> =>
+): Effect.Effect<ReconciliationResult, OperationalError> =>
   tigerBeetleRequest(client, 'journal-and-reconcile', async () => {
     const plan = buildLedgerPlan(result, ledger)
     await createAndVerifyAccounts(client, plan.accounts)
@@ -427,7 +427,7 @@ const tigerBeetleRequest = <A>(
   client: Client,
   operation: string,
   request: () => Promise<A>,
-): Effect.Effect<A, BaynError> =>
+): Effect.Effect<A, OperationalError> =>
   Effect.tryPromise({
     try: async (signal) => {
       const cancel = () => client.destroy()
@@ -439,7 +439,7 @@ const tigerBeetleRequest = <A>(
         signal.removeEventListener('abort', cancel)
       }
     },
-    catch: (cause) => baynError('journal', operation, `TigerBeetle ${operation} failed`, cause),
+    catch: (cause) => operationalError('journal', operation, `TigerBeetle ${operation} failed`, cause),
   })
 
 export interface JournalDependencies {
@@ -450,9 +450,9 @@ export interface JournalDependencies {
 const defaultDependencies: JournalDependencies = { createClient, resolveReplicaAddresses }
 
 export const JournalLive = (
-  config: BaynConfig,
+  config: RuntimeConfig,
   dependencies: JournalDependencies = defaultDependencies,
-): Layer.Layer<Journal, BaynError> =>
+): Layer.Layer<Journal, OperationalError> =>
   Layer.effect(
     Journal,
     Effect.acquireRelease(
@@ -465,13 +465,13 @@ export const JournalLive = (
             replica_addresses: replicaAddresses,
           })
         },
-        catch: (cause) => baynError('journal', 'connect', 'failed to create TigerBeetle client', cause),
+        catch: (cause) => operationalError('journal', 'connect', 'failed to create TigerBeetle client', cause),
       }).pipe(
         Effect.timeoutOrElse({
           duration: config.operationTimeoutMs,
           orElse: () =>
             Effect.fail(
-              baynError(
+              operationalError(
                 'journal',
                 'connect',
                 `TigerBeetle client creation timed out after ${config.operationTimeoutMs}ms`,
@@ -482,7 +482,7 @@ export const JournalLive = (
       (client) =>
         Effect.try({
           try: () => client.destroy(),
-          catch: (cause) => baynError('journal', 'close', 'failed to close TigerBeetle client', cause),
+          catch: (cause) => operationalError('journal', 'close', 'failed to close TigerBeetle client', cause),
         }).pipe(
           Effect.catch((error) =>
             Effect.logWarning('TigerBeetle client close failed').pipe(

--- a/services/bayn/src/ledger.ts
+++ b/services/bayn/src/ledger.ts
@@ -1,4 +1,4 @@
-import { lookup } from 'node:dns/promises'
+import { Resolver } from 'node:dns/promises'
 import { isIP } from 'node:net'
 
 import {
@@ -21,52 +21,105 @@ import type { EvaluationResult, FillEvent, ReconciliationResult } from './types'
 const SCHEMA_VERSION = 1
 const BATCH_MAX = 8_189
 
-type ResolveHostname = (hostname: string) => Promise<readonly string[]>
+type ResolveHostname = (hostname: string) => Effect.Effect<readonly string[], OperationalError>
 
-const lookupIpv4: ResolveHostname = async (hostname) =>
-  (await lookup(hostname, { all: true, family: 4, verbatim: true })).map(({ address }) => address)
+const lookupIpv4: ResolveHostname = (hostname) =>
+  Effect.tryPromise({
+    try: (signal) => {
+      const resolver = new Resolver()
+      const cancel = () => resolver.cancel()
+      signal.addEventListener('abort', cancel, { once: true })
+      const request = resolver.resolve4(hostname)
+      if (signal.aborted) cancel()
+      return request.finally(() => signal.removeEventListener('abort', cancel))
+    },
+    catch: (cause) =>
+      operationalError(
+        'journal',
+        'resolve-replica-addresses',
+        `failed to resolve TigerBeetle hostname ${hostname}`,
+        cause,
+      ),
+  })
 
-const parsePort = (value: string, address: string): number => {
-  if (!/^\d+$/.test(value)) throw new Error(`invalid TigerBeetle replica address: ${address}`)
+const parsePort = (value: string, address: string): Effect.Effect<number, OperationalError> => {
+  if (!/^\d+$/.test(value)) {
+    return Effect.fail(
+      operationalError('journal', 'resolve-replica-addresses', `invalid TigerBeetle replica address: ${address}`),
+    )
+  }
   const port = Number(value)
   if (!Number.isInteger(port) || port < 1 || port > 65_535) {
-    throw new Error(`invalid TigerBeetle replica port: ${address}`)
+    return Effect.fail(
+      operationalError('journal', 'resolve-replica-addresses', `invalid TigerBeetle replica port: ${address}`),
+    )
   }
-  return port
+  return Effect.succeed(port)
 }
 
-export const resolveReplicaAddresses = async (
+const resolveReplicaAddress = (
+  configuredAddress: string,
+  resolveHostname: ResolveHostname,
+): Effect.Effect<readonly string[], OperationalError> =>
+  Effect.gen(function* () {
+    const address = configuredAddress.trim()
+    if (/^\d+$/.test(address)) {
+      yield* parsePort(address, address)
+      return [address]
+    }
+
+    const separator = address.lastIndexOf(':')
+    if (separator <= 0 || separator !== address.indexOf(':')) {
+      return yield* Effect.fail(
+        operationalError(
+          'journal',
+          'resolve-replica-addresses',
+          `invalid TigerBeetle replica address: ${configuredAddress}`,
+        ),
+      )
+    }
+    const hostname = address.slice(0, separator)
+    const port = yield* parsePort(address.slice(separator + 1), address)
+    const addressFamily = isIP(hostname)
+    if (addressFamily === 4) return [`${hostname}:${port}`]
+    if (addressFamily === 6) {
+      return yield* Effect.fail(
+        operationalError(
+          'journal',
+          'resolve-replica-addresses',
+          `IPv6 TigerBeetle replica addresses are not supported: ${address}`,
+        ),
+      )
+    }
+
+    const ipv4Addresses = (yield* resolveHostname(hostname)).filter((value) => isIP(value) === 4)
+    if (ipv4Addresses.length === 0) {
+      return yield* Effect.fail(
+        operationalError(
+          'journal',
+          'resolve-replica-addresses',
+          `TigerBeetle replica hostname has no IPv4 address: ${hostname}`,
+        ),
+      )
+    }
+    return ipv4Addresses.map((ipv4Address) => `${ipv4Address}:${port}`)
+  })
+
+export const resolveReplicaAddresses = (
   configuredAddresses: readonly string[],
   resolveHostname: ResolveHostname = lookupIpv4,
-): Promise<string[]> => {
-  if (configuredAddresses.length === 0) throw new Error('at least one TigerBeetle replica address is required')
-
-  const resolved = await Promise.all(
-    configuredAddresses.map(async (configuredAddress) => {
-      const address = configuredAddress.trim()
-      if (/^\d+$/.test(address)) {
-        parsePort(address, address)
-        return [address]
-      }
-
-      const separator = address.lastIndexOf(':')
-      if (separator <= 0 || separator !== address.indexOf(':')) {
-        throw new Error(`invalid TigerBeetle replica address: ${configuredAddress}`)
-      }
-      const hostname = address.slice(0, separator)
-      const port = parsePort(address.slice(separator + 1), address)
-      const addressFamily = isIP(hostname)
-      if (addressFamily === 4) return [`${hostname}:${port}`]
-      if (addressFamily === 6) throw new Error(`IPv6 TigerBeetle replica addresses are not supported: ${address}`)
-
-      const ipv4Addresses = (await resolveHostname(hostname)).filter((value) => isIP(value) === 4)
-      if (ipv4Addresses.length === 0) throw new Error(`TigerBeetle replica hostname has no IPv4 address: ${hostname}`)
-      return ipv4Addresses.map((ipv4Address) => `${ipv4Address}:${port}`)
-    }),
-  )
-
-  return [...new Set(resolved.flat())]
-}
+): Effect.Effect<string[], OperationalError> =>
+  configuredAddresses.length === 0
+    ? Effect.fail(
+        operationalError(
+          'journal',
+          'resolve-replica-addresses',
+          'at least one TigerBeetle replica address is required',
+        ),
+      )
+    : Effect.forEach(configuredAddresses, (address) => resolveReplicaAddress(address, resolveHostname), {
+        concurrency: 'unbounded',
+      }).pipe(Effect.map((resolved) => [...new Set(resolved.flat())]))
 
 const AccountCode = {
   cash: 110,
@@ -352,45 +405,82 @@ export const assertReconciled = (
   }
 }
 
-const createAndVerifyAccounts = async (client: Client, accounts: readonly Account[]): Promise<void> => {
-  const results = await client.createAccounts([...accounts])
-  if (results.length !== accounts.length) throw new Error('TigerBeetle returned an incomplete account result batch')
-  const existingIds: bigint[] = []
-  for (let index = 0; index < results.length; index += 1) {
-    const status = results[index].status
-    if (status === CreateAccountStatus.created) continue
-    if (status === CreateAccountStatus.exists) {
-      existingIds.push(accounts[index].id)
-      continue
-    }
-    throw new Error(`TigerBeetle rejected account ${accounts[index].id} with status ${status}`)
-  }
-  if (existingIds.length > 0) {
-    const existing = await client.lookupAccounts(existingIds)
-    const expected = accounts.filter((value) => existingIds.includes(value.id))
-    assertUniqueExact('existing account', existing, expected, accountMetadataMatches)
-  }
-}
+const request = <A>(client: Client, operation: string, execute: () => Promise<A>): Effect.Effect<A, OperationalError> =>
+  Effect.tryPromise({
+    try: (signal) => {
+      const cancel = () => client.destroy()
+      signal.addEventListener('abort', cancel, { once: true })
+      const pending = execute()
+      if (signal.aborted) cancel()
+      return pending.finally(() => signal.removeEventListener('abort', cancel))
+    },
+    catch: (cause) => operationalError('journal', operation, `TigerBeetle ${operation} failed`, cause),
+  })
 
-const createAndVerifyTransfers = async (client: Client, transfers: readonly Transfer[]): Promise<void> => {
-  const results = await client.createTransfers([...transfers])
-  if (results.length !== transfers.length) throw new Error('TigerBeetle returned an incomplete transfer result batch')
-  const existingIds: bigint[] = []
-  for (let index = 0; index < results.length; index += 1) {
-    const status = results[index].status
-    if (status === CreateTransferStatus.created) continue
-    if (status === CreateTransferStatus.exists) {
-      existingIds.push(transfers[index].id)
-      continue
-    }
-    throw new Error(`TigerBeetle rejected transfer ${transfers[index].id} with status ${status}`)
-  }
-  if (existingIds.length > 0) {
-    const existing = await client.lookupTransfers(existingIds)
+const validate = <A>(operation: string, evaluate: () => A): Effect.Effect<A, OperationalError> =>
+  Effect.try({
+    try: evaluate,
+    catch: (cause) => operationalError('journal', operation, `TigerBeetle ${operation} failed`, cause),
+  })
+
+const createAndVerifyAccounts = (client: Client, accounts: readonly Account[]): Effect.Effect<void, OperationalError> =>
+  Effect.gen(function* () {
+    const results = yield* request(client, 'create-accounts', () => client.createAccounts([...accounts]))
+    const existingIds = yield* validate('verify-account-results', () => {
+      if (results.length !== accounts.length) {
+        throw new Error('TigerBeetle returned an incomplete account result batch')
+      }
+      const ids: bigint[] = []
+      for (let index = 0; index < results.length; index += 1) {
+        const status = results[index].status
+        if (status === CreateAccountStatus.created) continue
+        if (status === CreateAccountStatus.exists) {
+          ids.push(accounts[index].id)
+          continue
+        }
+        throw new Error(`TigerBeetle rejected account ${accounts[index].id} with status ${status}`)
+      }
+      return ids
+    })
+    if (existingIds.length === 0) return
+
+    const existing = yield* request(client, 'lookup-existing-accounts', () => client.lookupAccounts(existingIds))
+    const expected = accounts.filter((value) => existingIds.includes(value.id))
+    yield* validate('verify-existing-accounts', () =>
+      assertUniqueExact('existing account', existing, expected, accountMetadataMatches),
+    )
+  })
+
+const createAndVerifyTransfers = (
+  client: Client,
+  transfers: readonly Transfer[],
+): Effect.Effect<void, OperationalError> =>
+  Effect.gen(function* () {
+    const results = yield* request(client, 'create-transfers', () => client.createTransfers([...transfers]))
+    const existingIds = yield* validate('verify-transfer-results', () => {
+      if (results.length !== transfers.length) {
+        throw new Error('TigerBeetle returned an incomplete transfer result batch')
+      }
+      const ids: bigint[] = []
+      for (let index = 0; index < results.length; index += 1) {
+        const status = results[index].status
+        if (status === CreateTransferStatus.created) continue
+        if (status === CreateTransferStatus.exists) {
+          ids.push(transfers[index].id)
+          continue
+        }
+        throw new Error(`TigerBeetle rejected transfer ${transfers[index].id} with status ${status}`)
+      }
+      return ids
+    })
+    if (existingIds.length === 0) return
+
+    const existing = yield* request(client, 'lookup-existing-transfers', () => client.lookupTransfers(existingIds))
     const expected = transfers.filter((value) => existingIds.includes(value.id))
-    assertUniqueExact('existing transfer', existing, expected, transferMatches)
-  }
-}
+    yield* validate('verify-existing-transfers', () =>
+      assertUniqueExact('existing transfer', existing, expected, transferMatches),
+    )
+  })
 
 const queryFilter = (ledger: number): QueryFilter => ({
   user_data_128: 0n,
@@ -409,42 +499,28 @@ const journalAndReconcile = (
   ledger: number,
   result: EvaluationResult,
 ): Effect.Effect<ReconciliationResult, OperationalError> =>
-  tigerBeetleRequest(client, 'journal-and-reconcile', async () => {
-    const plan = buildLedgerPlan(result, ledger)
-    await createAndVerifyAccounts(client, plan.accounts)
-    await createAndVerifyTransfers(client, plan.transfers)
+  Effect.gen(function* () {
+    const plan = yield* validate('build-plan', () => buildLedgerPlan(result, ledger))
+    yield* createAndVerifyAccounts(client, plan.accounts)
+    yield* createAndVerifyTransfers(client, plan.transfers)
     const accountQuery = { ...queryFilter(ledger), user_data_128: plan.runKey, limit: plan.accounts.length + 1 }
     const transferQuery = { ...queryFilter(ledger), user_data_64: plan.runTag, limit: plan.transfers.length + 1 }
-    const [accounts, transfers] = await Promise.all([
-      client.queryAccounts(accountQuery),
-      client.queryTransfers(transferQuery),
-    ])
-    assertReconciled(plan, accounts, transfers)
+    const [accounts, transfers] = yield* Effect.all(
+      [
+        request(client, 'query-accounts', () => client.queryAccounts(accountQuery)),
+        request(client, 'query-transfers', () => client.queryTransfers(transferQuery)),
+      ],
+      { concurrency: 'unbounded' },
+    )
+    yield* validate('reconcile', () => assertReconciled(plan, accounts, transfers))
     return { runId: result.runId, accountCount: accounts.length, transferCount: transfers.length, exact: true }
-  })
-
-const tigerBeetleRequest = <A>(
-  client: Client,
-  operation: string,
-  request: () => Promise<A>,
-): Effect.Effect<A, OperationalError> =>
-  Effect.tryPromise({
-    try: async (signal) => {
-      const cancel = () => client.destroy()
-      signal.addEventListener('abort', cancel, { once: true })
-      if (signal.aborted) cancel()
-      try {
-        return await request()
-      } finally {
-        signal.removeEventListener('abort', cancel)
-      }
-    },
-    catch: (cause) => operationalError('journal', operation, `TigerBeetle ${operation} failed`, cause),
   })
 
 export interface JournalDependencies {
   readonly createClient: typeof createClient
-  readonly resolveReplicaAddresses: (configuredAddresses: readonly string[]) => Promise<string[]>
+  readonly resolveReplicaAddresses: (
+    configuredAddresses: readonly string[],
+  ) => Effect.Effect<string[], OperationalError>
 }
 
 const defaultDependencies: JournalDependencies = { createClient, resolveReplicaAddresses }
@@ -456,17 +532,17 @@ export const JournalLive = (
   Layer.effect(
     Journal,
     Effect.acquireRelease(
-      Effect.tryPromise({
-        try: async (signal) => {
-          const replicaAddresses = await dependencies.resolveReplicaAddresses(config.tigerBeetle.replicaAddresses)
-          signal.throwIfAborted()
-          return dependencies.createClient({
-            cluster_id: config.tigerBeetle.clusterId,
-            replica_addresses: replicaAddresses,
-          })
-        },
-        catch: (cause) => operationalError('journal', 'connect', 'failed to create TigerBeetle client', cause),
-      }).pipe(
+      dependencies.resolveReplicaAddresses(config.tigerBeetle.replicaAddresses).pipe(
+        Effect.flatMap((replicaAddresses) =>
+          Effect.try({
+            try: () =>
+              dependencies.createClient({
+                cluster_id: config.tigerBeetle.clusterId,
+                replica_addresses: replicaAddresses,
+              }),
+            catch: (cause) => operationalError('journal', 'connect', 'failed to create TigerBeetle client', cause),
+          }),
+        ),
         Effect.timeoutOrElse({
           duration: config.operationTimeoutMs,
           orElse: () =>
@@ -492,9 +568,9 @@ export const JournalLive = (
         ),
     ).pipe(
       Effect.map((client) => ({
-        check: tigerBeetleRequest(client, 'connectivity-check', async () => {
-          await client.lookupAccounts([stableU128('bayn-connectivity-probe')])
-        }),
+        check: request(client, 'connectivity-check', () =>
+          client.lookupAccounts([stableU128('bayn-connectivity-probe')]),
+        ).pipe(Effect.asVoid),
         journalAndReconcile: (result) => journalAndReconcile(client, config.tigerBeetle.ledger, result),
       })),
     ),

--- a/services/bayn/src/market-data.ts
+++ b/services/bayn/src/market-data.ts
@@ -1,8 +1,8 @@
 import { createClient, type ClickHouseClient } from '@clickhouse/client'
 import { Context, Effect, Layer, Redacted, Schema } from 'effect'
 
-import type { BaynConfig } from './config'
-import { baynError, type BaynError } from './errors'
+import type { RuntimeConfig } from './config'
+import { operationalError, type OperationalError } from './errors'
 import { hashObject } from './hash'
 import type { DailyBar, InputManifest, IsoDate, SymbolCoverage } from './types'
 
@@ -30,7 +30,7 @@ export interface MarketDataSnapshot {
 }
 
 export interface MarketDataService {
-  readonly load: Effect.Effect<MarketDataSnapshot, BaynError>
+  readonly load: Effect.Effect<MarketDataSnapshot, OperationalError>
 }
 
 export class MarketData extends Context.Service<MarketData, MarketDataService>()('bayn/MarketData') {}
@@ -172,9 +172,9 @@ export const buildInputManifest = (
 
 const loadSnapshot = (
   client: ClickHouseClient,
-  config: BaynConfig['clickhouse'],
+  config: RuntimeConfig['clickhouse'],
   universe: readonly string[],
-): Effect.Effect<MarketDataSnapshot, BaynError> =>
+): Effect.Effect<MarketDataSnapshot, OperationalError> =>
   Effect.tryPromise({
     try: async (signal) => {
       const database = identifier(config.database, 'database')
@@ -207,7 +207,7 @@ const loadSnapshot = (
       const manifest = buildInputManifest(bars, database, table, universe, config.datasetVersion)
       return { bars, manifest }
     },
-    catch: (cause) => baynError('market-data', 'load', 'failed to load Signal ClickHouse input', cause),
+    catch: (cause) => operationalError('market-data', 'load', 'failed to load Signal ClickHouse input', cause),
   })
 
 export interface MarketDataDependencies {
@@ -217,10 +217,10 @@ export interface MarketDataDependencies {
 const defaultDependencies: MarketDataDependencies = { createClient }
 
 export const MarketDataLive = (
-  config: BaynConfig,
+  config: RuntimeConfig,
   universe: readonly string[],
   dependencies: MarketDataDependencies = defaultDependencies,
-): Layer.Layer<MarketData, BaynError> =>
+): Layer.Layer<MarketData, OperationalError> =>
   Layer.effect(
     MarketData,
     Effect.acquireRelease(
@@ -234,12 +234,12 @@ export const MarketDataLive = (
             application: 'bayn',
             request_timeout: config.operationTimeoutMs,
           }),
-        catch: (cause) => baynError('market-data', 'connect', 'failed to create ClickHouse client', cause),
+        catch: (cause) => operationalError('market-data', 'connect', 'failed to create ClickHouse client', cause),
       }),
       (client) =>
         Effect.tryPromise({
           try: () => client.close(),
-          catch: (cause) => baynError('market-data', 'close', 'failed to close ClickHouse client', cause),
+          catch: (cause) => operationalError('market-data', 'close', 'failed to close ClickHouse client', cause),
         }).pipe(
           Effect.catch((error) =>
             Effect.logWarning('ClickHouse client close failed').pipe(

--- a/services/bayn/src/resources.test.ts
+++ b/services/bayn/src/resources.test.ts
@@ -4,15 +4,15 @@ import { createClient as createClickHouseClient, type ClickHouseClient } from '@
 import { Effect, Layer, Redacted, Ref } from 'effect'
 import { createClient as createTigerBeetleClient, type Client } from 'tigerbeetle-node'
 
-import { initializeBayn, type RuntimeState } from './app'
-import type { BaynConfig } from './config'
+import { initialize, type RuntimeState } from './app'
+import type { RuntimeConfig } from './config'
 import { Journal, JournalLive, type JournalService } from './ledger'
 import { MarketData, MarketDataLive, type MarketDataService } from './market-data'
 import { defaultProtocol } from './protocol'
 import { TsmomStrategyLive } from './strategy-service'
 import { makeSnapshot } from './test-fixtures'
 
-const config: BaynConfig = {
+const config: RuntimeConfig = {
   host: '127.0.0.1',
   port: 0,
   codeRevision: 'test-revision',
@@ -92,7 +92,7 @@ describe('Bayn resource lifecycle', () => {
 
     await Effect.runPromise(
       Effect.scoped(
-        initializeBayn(config, state).pipe(
+        initialize(config, state).pipe(
           Effect.provideService(Journal, successfulJournal),
           Effect.provide(TsmomStrategyLive),
           Effect.provide(
@@ -122,7 +122,7 @@ describe('Bayn resource lifecycle', () => {
 
     await Effect.runPromise(
       Effect.scoped(
-        initializeBayn(config, state).pipe(
+        initialize(config, state).pipe(
           Effect.provideService(Journal, successfulJournal),
           Effect.provide(TsmomStrategyLive),
           Effect.provide(
@@ -160,7 +160,7 @@ describe('Bayn resource lifecycle', () => {
 
     await Effect.runPromise(
       Effect.scoped(
-        initializeBayn(config, state).pipe(
+        initialize(config, state).pipe(
           Effect.provideService(MarketData, marketData),
           Effect.provide(TsmomStrategyLive),
           Effect.provide(

--- a/services/bayn/src/resources.test.ts
+++ b/services/bayn/src/resources.test.ts
@@ -59,7 +59,7 @@ describe('Bayn resource lifecycle', () => {
               }),
               JournalLive(config, {
                 createClient: (() => tigerBeetleClient) as unknown as typeof createTigerBeetleClient,
-                resolveReplicaAddresses: async () => ['3000'],
+                resolveReplicaAddresses: () => Effect.succeed(['3000']),
               }),
             ),
           ),
@@ -166,7 +166,7 @@ describe('Bayn resource lifecycle', () => {
           Effect.provide(
             JournalLive(config, {
               createClient: (() => tigerBeetleClient) as unknown as typeof createTigerBeetleClient,
-              resolveReplicaAddresses: async () => ['3000'],
+              resolveReplicaAddresses: () => Effect.succeed(['3000']),
             }),
           ),
         ),


### PR DESCRIPTION
## Summary

- Remove `/v1/evidence/latest`, which duplicated `/v1/status` with the same handler and payload.
- Rename app exports to `initialize` and `run`; replace service-branded types with `RuntimeConfig` and `OperationalError`.
- Make ledger I/O Effect-native: cancellable DNS, typed address failures, structured TigerBeetle requests, and Effect-based acquisition.
- Keep pure deterministic ledger planning and reconciliation as plain TypeScript.

## Related Issues

None

## Testing

- `bun run --filter @proompteng/bayn test` (25 passed)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`

## Breaking Changes

`GET /v1/evidence/latest` now returns 404. Repository search found no caller; use `GET /v1/status`. Exported internal names changed from `initializeBayn`/`runBayn`/`BaynConfig`/`BaynError` to role-based names; all repository callers are updated.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation is updated and no separate follow-up is required.