### PR TITLE
chore(product): promote nix product images

### DIFF
--- a/argocd/applications/app/kustomization.yaml
+++ b/argocd/applications/app/kustomization.yaml
@@ -8,5 +8,5 @@ resources:
   - secret.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/app
-    digest: sha256:4c14c4b5ac47f28485d3cd23d625b2d279fdb7656882e72504b4181af885c897
+    digest: sha256:29f56d83d14dc2fde39f25d3353d6bbf2cf6507d7034d7ba04da3912e51f6d24
     newName: registry.ide-newton.ts.net/lab/app

--- a/argocd/applications/docs/kustomization.yaml
+++ b/argocd/applications/docs/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
   - generated
 images:
   - name: registry.ide-newton.ts.net/lab/docs
-    digest: sha256:0098e452442eef1ff65d36a6bd03a9add43cd199e6b80e075a8f47b3787c1127
+    digest: sha256:2ee172f51787268c428cb4d19165625bc56bb778137480556dc0a38e331e3f0b
     newName: registry.ide-newton.ts.net/lab/docs

--- a/argocd/applications/proompteng/kustomization.yaml
+++ b/argocd/applications/proompteng/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
 - ingressroute.yaml
 images:
 - name: registry.ide-newton.ts.net/lab/proompteng
-  digest: sha256:c2b17249e80a6319f25179ac6f78d32e79a4b531ca78e0eb627094abffddc19e
+  digest: sha256:f4380b4b857cf39176107b36c98f468c3191b45a44f1d39ddbaff4b2b348b04c
   newName: registry.ide-newton.ts.net/lab/proompteng

--- a/argocd/applications/synthesis/kustomization.yaml
+++ b/argocd/applications/synthesis/kustomization.yaml
@@ -11,5 +11,5 @@ resources:
   - agents-domain
 images:
   - name: registry.ide-newton.ts.net/lab/synthesis
-    digest: sha256:35562eefe6b156ad1c34091b1c352a28caff339e88ba9b132f32ad9281444e49
+    digest: sha256:8e63384605068a59c480f427cc1272f739c760e6963659618c314184a7a12012
     newName: registry.ide-newton.ts.net/lab/synthesis


### PR DESCRIPTION
## Summary

- Promote enabled product app image digests built by the shared Nix OCI workflow.
- `app`: `registry.ide-newton.ts.net/lab/app@sha256:29f56d83d14dc2fde39f25d3353d6bbf2cf6507d7034d7ba04da3912e51f6d24` from `0eabcb6bcdcd442d618703b785b169fa417828c1`
- `docs`: `registry.ide-newton.ts.net/lab/docs@sha256:2ee172f51787268c428cb4d19165625bc56bb778137480556dc0a38e331e3f0b` from `0eabcb6bcdcd442d618703b785b169fa417828c1`
- `proompteng`: `registry.ide-newton.ts.net/lab/proompteng@sha256:f4380b4b857cf39176107b36c98f468c3191b45a44f1d39ddbaff4b2b348b04c` from `0eabcb6bcdcd442d618703b785b169fa417828c1`
- `synthesis`: `registry.ide-newton.ts.net/lab/synthesis@sha256:8e63384605068a59c480f427cc1272f739c760e6963659618c314184a7a12012` from `0eabcb6bcdcd442d618703b785b169fa417828c1`

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- <image>@<digest> linux/amd64 linux/arm64` for each promoted image.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.