### PR TITLE
chore(torghut): upgrade TigerBeetle to 0.17.9

### DIFF
--- a/argocd/applications/torghut/tigerbeetle-cluster.yaml
+++ b/argocd/applications/torghut/tigerbeetle-cluster.yaml
@@ -11,7 +11,7 @@ spec:
   replicas: 1
   image:
     repository: ghcr.io/tigerbeetle/tigerbeetle
-    tag: "0.17.5"
+    tag: "0.17.9"
     pullPolicy: IfNotPresent
   storage:
     className: rook-ceph-block


### PR DESCRIPTION
## Summary

- Upgrade the Torghut TigerBeetle replica from the live, healthy 0.17.5 bridge to 0.17.9.
- Preserve the existing cluster ID, single replica, retained PVC, resources, and health configuration.
- Match the Bayn Node client at 0.17.9 while retaining compatibility with Torghut client 0.17.4.

## Related Issues

None

## Testing

- `kustomize build --enable-helm argocd/applications/torghut` rendered TigerBeetle tag 0.17.9.
- `bun run lint:argocd` passed: 0 invalid resources and 0 errors.
- Verified live 0.17.5 replica Ready and ClientProtocolHealthy with the original PVC UID and volume.
- Verified the official 0.17.9 release supports upgrades from 0.17.5, clients back to 0.16.4, and linux/arm64.

## Breaking Changes

The single-replica ledger can be briefly unavailable while the StatefulSet rolls. Persistent storage, cluster ID, broker authority, and capital authority are unchanged.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] No additional documentation or follow-up is required for this version hop.