### PR TITLE
chore(bayn): promote image sha-847efd76377d4c81eb6486d9d3baf6595617e0f3

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: bayn
         app.kubernetes.io/part-of: bayn
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-20T03:53:47Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-20T04:32:36Z"
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
@@ -47,7 +47,7 @@ spec:
               protocol: TCP
           env:
             - name: BAYN_CODE_REVISION
-              value: 0eabcb6bcdcd442d618703b785b169fa417828c1
+              value: 847efd76377d4c81eb6486d9d3baf6595617e0f3
             - name: BAYN_RUN_ON_STARTUP
               value: "true"
             - name: BAYN_OPERATION_TIMEOUT_MS

--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -10,5 +10,5 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/bayn
     newName: registry.ide-newton.ts.net/lab/bayn
-    newTag: "sha-0eabcb6bcdcd442d618703b785b169fa417828c1"
-    digest: sha256:6d1eca52c6a37e05fef85f73b60d5088eced8f9224c918d1f9644f786668ec3f
+    newTag: "sha-847efd76377d4c81eb6486d9d3baf6595617e0f3"
+    digest: sha256:1fec0ecf01f266c669b2ee90f97f24adf843a212b306ce97446adc2866232695


### PR DESCRIPTION
## Summary

Promote the immutable Bayn image, activate the Bayn Argo application, and bind runtime evidence to its
source commit.

- Source commit: `847efd76377d4c81eb6486d9d3baf6595617e0f3`
- Image tag: `sha-847efd76377d4c81eb6486d9d3baf6595617e0f3`
- Image digest: `sha256:1fec0ecf01f266c669b2ee90f97f24adf843a212b306ce97446adc2866232695`

## Related Issues

PROOMPT-353

## Testing

- OCI index contains `linux/amd64` and `linux/arm64`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents exact validation.
- [x] Runtime source revision and image digest are immutable.
- [x] No broker or capital-promotion authority is introduced.