### PR TITLE
fix(bayn): address historical review findings

### DIFF
--- a/services/bayn/src/ledger.test.ts
+++ b/services/bayn/src/ledger.test.ts
@@ -60,7 +60,7 @@ describe('TigerBeetle replica addresses', () => {
     const lookups: string[] = []
     const addresses = await Effect.runPromise(
       resolveReplicaAddresses(
-        ['torghut-tigerbeetle.torghut.svc.cluster.local:3000', '10.244.5.234:3000', '3001'],
+        ['torghut-tigerbeetle.torghut.svc.cluster.local:3000', '10.244.5.234:3000', '127.0.0.1', '3001'],
         (hostname) =>
           Effect.sync(() => {
             lookups.push(hostname)
@@ -70,7 +70,7 @@ describe('TigerBeetle replica addresses', () => {
     )
 
     expect(lookups).toEqual(['torghut-tigerbeetle.torghut.svc.cluster.local'])
-    expect(addresses).toEqual(['10.244.5.234:3000', '10.244.5.235:3000', '3001'])
+    expect(addresses).toEqual(['10.244.5.234:3000', '10.244.5.235:3000', '127.0.0.1', '3001'])
   })
 
   test('rejects malformed, out-of-range, and IPv6-only endpoints', async () => {
@@ -82,6 +82,9 @@ describe('TigerBeetle replica addresses', () => {
     ).rejects.toThrow('invalid TigerBeetle replica port')
     expect(Effect.runPromise(resolveReplicaAddresses(['replica:3000'], () => Effect.succeed(['::1'])))).rejects.toThrow(
       'has no IPv4 address',
+    )
+    expect(Effect.runPromise(resolveReplicaAddresses(['::1']))).rejects.toThrow(
+      'IPv6 TigerBeetle replica addresses are not supported',
     )
   })
 })

--- a/services/bayn/src/ledger.ts
+++ b/services/bayn/src/ledger.ts
@@ -59,6 +59,17 @@ const resolveReplicaAddress = (
 ): Effect.Effect<readonly string[], OperationalError> =>
   Effect.gen(function* () {
     const address = configuredAddress.trim()
+    const addressFamily = isIP(address)
+    if (addressFamily === 4) return [address]
+    if (addressFamily === 6) {
+      return yield* Effect.fail(
+        operationalError(
+          'journal',
+          'resolve-replica-addresses',
+          `IPv6 TigerBeetle replica addresses are not supported: ${address}`,
+        ),
+      )
+    }
     if (/^\d+$/.test(address)) {
       yield* parsePort(address, address)
       return [address]
@@ -76,9 +87,9 @@ const resolveReplicaAddress = (
     }
     const hostname = address.slice(0, separator)
     const port = yield* parsePort(address.slice(separator + 1), address)
-    const addressFamily = isIP(hostname)
-    if (addressFamily === 4) return [`${hostname}:${port}`]
-    if (addressFamily === 6) {
+    const hostnameFamily = isIP(hostname)
+    if (hostnameFamily === 4) return [`${hostname}:${port}`]
+    if (hostnameFamily === 6) {
       return yield* Effect.fail(
         operationalError(
           'journal',

--- a/services/bayn/src/strategy.test.ts
+++ b/services/bayn/src/strategy.test.ts
@@ -1,11 +1,18 @@
 import { describe, expect, test } from 'bun:test'
 
 import { defaultProtocol } from './protocol'
-import { evaluateTsmom } from './strategy'
+import { calculatePerformanceMetrics, evaluateTsmom } from './strategy'
 import { makeSnapshot } from './test-fixtures'
 import type { FillEvent } from './types'
 
 describe('TSMOM economic evaluator', () => {
+  test('includes the initial trading session in return statistics', () => {
+    const result = calculatePerformanceMetrics([90, 99], 0, 0, 100)
+    expect(result.totalReturn).toBeCloseTo(-0.01)
+    expect(result.annualizedVolatility).toBeCloseTo(Math.sqrt(0.02) * Math.sqrt(252))
+    expect(result.sharpe).toBeCloseTo(0)
+  })
+
   test('is deterministic, costed, and executes after the signal session', () => {
     const snapshot = makeSnapshot()
     const first = evaluateTsmom(snapshot.bars, snapshot.manifest, defaultProtocol, 'test-revision')

--- a/services/bayn/src/strategy.ts
+++ b/services/bayn/src/strategy.ts
@@ -115,7 +115,7 @@ const directVolatilityWeights = (
   return Object.fromEntries(protocol.universe.map((symbol) => [symbol, weight]))
 }
 
-const metrics = (
+export const calculatePerformanceMetrics = (
   equity: readonly number[],
   turnover: number,
   totalFees: number,
@@ -124,7 +124,7 @@ const metrics = (
   if (equity.length < 2 || equity.some((value) => !Number.isFinite(value) || value <= 0)) {
     throw new Error('evaluation produced an invalid equity curve')
   }
-  const returns = equity.slice(1).map((value, index) => value / equity[index] - 1)
+  const returns = [equity[0] / initialCapital - 1, ...equity.slice(1).map((value, index) => value / equity[index] - 1)]
   const totalReturn = equity.at(-1)! / initialCapital - 1
   const annualizedReturn = Math.pow(equity.at(-1)! / initialCapital, TRADING_DAYS / equity.length) - 1
   const volatility = sampleStandardDeviation(returns) * Math.sqrt(TRADING_DAYS)
@@ -277,7 +277,7 @@ const simulate = (
     equity.push(closingEquity)
   }
 
-  return { metrics: metrics(equity, turnover, totalFees, initialCapital), events }
+  return { metrics: calculatePerformanceMetrics(equity, turnover, totalFees, initialCapital), events }
 }
 
 const buildVerdict = (


### PR DESCRIPTION
## Summary

- Preserve TigerBeetle bare IPv4 replica addresses so the client can apply its documented default port.
- Include the first simulated trading session, including initial fees, in volatility and Sharpe returns.
- Add focused regressions on top of the current Effect-native ledger implementation.
- Supersede stale generated PR #12861 without restoring Promise-based ledger code.

## Related Issues

Historical Codex findings in #12852 and #12845.

## Testing

- `bun run --filter @proompteng/bayn test` (26 passed)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] No additional documentation or follow-up is required.