### PR TITLE
fix(bayn): address merged Codex findings

### DIFF
--- a/services/bayn/src/config.test.ts
+++ b/services/bayn/src/config.test.ts
@@ -43,6 +43,14 @@ describe('Effect configuration', () => {
     expect(config.tigerBeetle.replicaAddresses).toEqual(['tigerbeetle.test:3000'])
   })
 
+  test('normalizes bare IPv4 TigerBeetle replicas to the default port', async () => {
+    const environment = new Map(runtimeEnvironment)
+    environment.set('BAYN_TIGERBEETLE_ADDRESSES', '127.0.0.1,replica.test:3000,3001')
+
+    const config = await Effect.runPromise(provideEnvironment(loadConfig, environment))
+    expect(config.tigerBeetle.replicaAddresses).toEqual(['127.0.0.1:3001', 'replica.test:3000', '3001'])
+  })
+
   test('returns a typed configuration failure for invalid values', async () => {
     const invalid = new Map(runtimeEnvironment)
     invalid.set('BAYN_OPERATION_TIMEOUT_MS', '0')

--- a/services/bayn/src/config.ts
+++ b/services/bayn/src/config.ts
@@ -1,3 +1,5 @@
+import { isIP } from 'node:net'
+
 import { Config, Effect, Redacted, Schema, SchemaTransformation } from 'effect'
 
 import { operationalError, type OperationalError } from './errors'
@@ -26,6 +28,7 @@ export interface RuntimeConfig {
 const NonEmptyString = Schema.Trim.check(Schema.isMinLength(1))
 const PositiveInteger = Schema.Int.check(Schema.isGreaterThan(0))
 const ClickHouseIdentifier = NonEmptyString.check(Schema.isPattern(/^[a-zA-Z_][a-zA-Z0-9_]*$/))
+const normalizeReplicaAddress = (address: string): string => (isIP(address) === 4 ? `${address}:3001` : address)
 const ReplicaAddresses = Schema.Trim.pipe(
   Schema.decodeTo(
     Schema.Array(NonEmptyString).check(Schema.isMinLength(1)),
@@ -34,7 +37,8 @@ const ReplicaAddresses = Schema.Trim.pipe(
         value
           .split(',')
           .map((address) => address.trim())
-          .filter(Boolean),
+          .filter(Boolean)
+          .map(normalizeReplicaAddress),
       encode: (addresses) => addresses.join(','),
     }),
   ),

--- a/services/bayn/src/strategy.test.ts
+++ b/services/bayn/src/strategy.test.ts
@@ -1,11 +1,18 @@
 import { describe, expect, test } from 'bun:test'
 
 import { defaultProtocol } from './protocol'
-import { evaluateTsmom } from './strategy'
+import { calculatePerformanceMetrics, evaluateTsmom } from './strategy'
 import { makeSnapshot } from './test-fixtures'
 import type { FillEvent } from './types'
 
 describe('TSMOM economic evaluator', () => {
+  test('includes the initial trading session in return statistics', () => {
+    const result = calculatePerformanceMetrics([90, 99], 0, 0, 100)
+    expect(result.totalReturn).toBeCloseTo(-0.01)
+    expect(result.annualizedVolatility).toBeCloseTo(Math.sqrt(0.02) * Math.sqrt(252))
+    expect(result.sharpe).toBeCloseTo(0)
+  })
+
   test('is deterministic, costed, and executes after the signal session', () => {
     const snapshot = makeSnapshot()
     const first = evaluateTsmom(snapshot.bars, snapshot.manifest, defaultProtocol, 'test-revision')

--- a/services/bayn/src/strategy.ts
+++ b/services/bayn/src/strategy.ts
@@ -115,7 +115,7 @@ const directVolatilityWeights = (
   return Object.fromEntries(protocol.universe.map((symbol) => [symbol, weight]))
 }
 
-const metrics = (
+export const calculatePerformanceMetrics = (
   equity: readonly number[],
   turnover: number,
   totalFees: number,
@@ -124,7 +124,7 @@ const metrics = (
   if (equity.length < 2 || equity.some((value) => !Number.isFinite(value) || value <= 0)) {
     throw new Error('evaluation produced an invalid equity curve')
   }
-  const returns = equity.slice(1).map((value, index) => value / equity[index] - 1)
+  const returns = [equity[0] / initialCapital - 1, ...equity.slice(1).map((value, index) => value / equity[index] - 1)]
   const totalReturn = equity.at(-1)! / initialCapital - 1
   const annualizedReturn = Math.pow(equity.at(-1)! / initialCapital, TRADING_DAYS / equity.length) - 1
   const volatility = sampleStandardDeviation(returns) * Math.sqrt(TRADING_DAYS)
@@ -277,7 +277,7 @@ const simulate = (
     equity.push(closingEquity)
   }
 
-  return { metrics: metrics(equity, turnover, totalFees, initialCapital), events }
+  return { metrics: calculatePerformanceMetrics(equity, turnover, totalFees, initialCapital), events }
 }
 
 const buildVerdict = (


### PR DESCRIPTION
## Summary

- normalize TigerBeetle bare IPv4 replica addresses to the supported default port without regressing the Effect-native ledger
- include the first simulated trading session in volatility and Sharpe return statistics
- add focused configuration and performance-metric regressions for both merged Codex findings

## Related Issues

Historical Codex findings in #12852 and #12845. Supersedes #12861.

## Testing

- `bunx oxfmt --check services/bayn/src/config.ts services/bayn/src/config.test.ts services/bayn/src/strategy.ts services/bayn/src/strategy.test.ts`
- `bun run --cwd services/bayn tsc`
- `bun run --cwd services/bayn lint:oxlint`
- `bun run --cwd services/bayn lint:oxlint:type`
- `bun run --cwd services/bayn test`
- `bun run --cwd services/bayn build`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or not required.