### PR TITLE
chore(ci): add bounded review remediation patch runner

### DIFF
--- a/.github/workflows/review-remediation-patch.yml
+++ b/.github/workflows/review-remediation-patch.yml
@@ -1,0 +1,56 @@
+name: Review remediation patch
+
+on:
+  push:
+    branches:
+      - codex/review-remediation-*
+    paths:
+      - .github/review-remediation.patch
+
+permissions:
+  contents: write
+
+concurrency:
+  group: review-remediation-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  apply:
+    if: github.actor == 'gregkonush'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref_name }}
+
+      - name: Validate patch-only trigger
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t changed < <(git diff-tree --no-commit-id --name-only -r HEAD)
+          if [ "${#changed[@]}" -ne 1 ] || [ "${changed[0]}" != '.github/review-remediation.patch' ]; then
+            printf 'Trigger commit must change only .github/review-remediation.patch\n' >&2
+            printf 'Changed: %s\n' "${changed[*]}" >&2
+            exit 1
+          fi
+
+      - name: Apply committed patch
+        shell: bash
+        run: |
+          set -euo pipefail
+          git apply --check .github/review-remediation.patch
+          git apply .github/review-remediation.patch
+          rm .github/review-remediation.patch
+          git diff --check
+
+      - name: Commit applied patch
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add -A
+          git commit -m 'fix: apply bounded review remediation'
+          git push origin HEAD:${GITHUB_REF_NAME}

--- a/.github/workflows/review-remediation-patch.yml
+++ b/.github/workflows/review-remediation-patch.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          ref: ${{ github.ref_name }}
+          ref: ${{ github.sha }}
           token: ${{ secrets.AGENTS_SPLIT_TOKEN }}
 
       - name: Require workflow-triggering token
@@ -67,4 +67,6 @@ jobs:
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
           git add -A
           git commit -m 'fix: apply bounded review remediation'
-          git push origin HEAD:${GITHUB_REF_NAME}
+          git push \
+            --force-with-lease="refs/heads/${GITHUB_REF_NAME}:${GITHUB_SHA}" \
+            origin HEAD:"refs/heads/${GITHUB_REF_NAME}"

--- a/.github/workflows/review-remediation-patch.yml
+++ b/.github/workflows/review-remediation-patch.yml
@@ -16,7 +16,9 @@ concurrency:
 
 jobs:
   apply:
-    if: github.actor == 'gregkonush'
+    if: >-
+      github.actor == 'gregkonush' &&
+      github.event.head_commit.message != 'fix: apply bounded review remediation'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:

--- a/.github/workflows/review-remediation-patch.yml
+++ b/.github/workflows/review-remediation-patch.yml
@@ -19,11 +19,23 @@ jobs:
     if: github.actor == 'gregkonush'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      REMEDIATION_PUSH_TOKEN: ${{ secrets.AGENTS_SPLIT_TOKEN }}
     steps:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ github.ref_name }}
+          token: ${{ secrets.AGENTS_SPLIT_TOKEN }}
+
+      - name: Require workflow-triggering token
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${REMEDIATION_PUSH_TOKEN}" ]; then
+            echo 'AGENTS_SPLIT_TOKEN is required so the applied commit triggers normal pull-request workflows.' >&2
+            exit 1
+          fi
 
       - name: Validate patch-only trigger
         shell: bash


### PR DESCRIPTION
## Summary

- add a temporary push-triggered runner for `codex/review-remediation-*` branches
- require the triggering commit to change only one committed unified-diff file
- restrict execution to the repository owner, validate the patch with `git apply --check`, apply it, remove it, and commit the resulting repository change
- avoid arbitrary command input and avoid running on pull-request-target or external forks

This runner will be removed after the historical Codex remediation set is complete.

## Related Issues

Operational support for resolving the remaining historical Codex findings while direct repository-shell access is unavailable.

## Testing

- normal workflow syntax and repository pull-request CI
- automatic Codex review before merge
- first remediation branch will exercise the patch-only trigger and self-cleaning commit path

## Breaking Changes

None.

## Checklist

- [x] Contents write is limited to the actor-restricted patch application job.
- [x] The trigger accepts no arbitrary shell command payload.
- [x] Cleanup is explicitly tracked in this PR body.