### PR TITLE
fix(torghut): honor notebook image entrypoint

### DIFF
--- a/argocd/applications/torghut/notebooks/values.yaml
+++ b/argocd/applications/torghut/notebooks/values.yaml
@@ -91,6 +91,7 @@ proxy:
         memory: 512Mi
 
 singleuser:
+  cmd: null
   image:
     name: registry.ide-newton.ts.net/lab/torghut-notebook@sha256
     tag: '30e85c4d868f8206cd5b3087c31e00dd5c19d282c940b4594753ace5fffe0d9f'

--- a/services/torghut/tests/notebook_data/test_entrypoint_values_contract.py
+++ b/services/torghut/tests/notebook_data/test_entrypoint_values_contract.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+def test_singleuser_runs_the_digest_pinned_image_entrypoint() -> None:
+    values = yaml.safe_load(
+        (REPO_ROOT / "argocd/applications/torghut/notebooks/values.yaml").read_text()
+    )
+
+    assert "cmd" in values["singleuser"]
+    assert values["singleuser"]["cmd"] is None


### PR DESCRIPTION
Superseded before merge. The existing `test_manifest_contract.py` still asserts that `singleuser.cmd` is absent, so the values change and that established contract must be updated atomically. The corrected change will be recreated through the bounded remediation patch workflow with the existing test changed in the same commit.