### PR TITLE
fix(torghut): repair empty TigerBeetle stable refs

### DIFF
--- a/services/torghut/app/trading/tigerbeetle_journal/stable_ref_backfill.py
+++ b/services/torghut/app/trading/tigerbeetle_journal/stable_ref_backfill.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from typing import cast
 
+from sqlalchemy import cast as sa_cast
 from sqlalchemy import func, or_, select
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Session
 from sqlalchemy.sql.elements import ColumnElement
 
@@ -30,19 +32,30 @@ from .journal_payloads import (
 def _missing_stable_ref_clause(session: Session) -> ColumnElement[bool]:
     dialect_name = session.get_bind().dialect.name
     if dialect_name == "postgresql":
-        stable_ref_type = func.jsonb_typeof(
-            TigerBeetleTransferRef.payload_json["stable_ref"]
-        )
+        stable_ref = TigerBeetleTransferRef.payload_json["stable_ref"]
+        stable_ref_type = func.jsonb_typeof(stable_ref)
+        empty_object = stable_ref == sa_cast({}, JSONB)
     elif dialect_name == "sqlite":
         stable_ref_type = func.json_type(
             TigerBeetleTransferRef.payload_json,
             "$.stable_ref",
         )
+        empty_object = (
+            func.json_extract(
+                TigerBeetleTransferRef.payload_json,
+                "$.stable_ref",
+            )
+            == "{}"
+        )
     else:
         raise RuntimeError(
             f"tigerbeetle_stable_ref_backfill_dialect_unsupported:{dialect_name}"
         )
-    return or_(stable_ref_type.is_(None), stable_ref_type != "object")
+    return or_(
+        stable_ref_type.is_(None),
+        stable_ref_type != "object",
+        empty_object,
+    )
 
 
 def _required_payload_account_id(
@@ -192,7 +205,8 @@ def _backfill_ref(
     payload: Mapping[str, object],
     account_specs_by_id: Mapping[str, TigerBeetleAccountSpec],
 ) -> bool:
-    if isinstance(payload.get("stable_ref"), Mapping):
+    stable_ref = payload.get("stable_ref")
+    if isinstance(stable_ref, Mapping) and stable_ref:
         return False
     source_type = str(ref.source_type or "").strip()
     source_id = str(ref.source_id or "").strip()

--- a/services/torghut/tests/test_backfill_tigerbeetle_stable_refs.py
+++ b/services/torghut/tests/test_backfill_tigerbeetle_stable_refs.py
@@ -200,7 +200,7 @@ class TestBackfillTigerBeetleStableRefs(TestCase):
             with self.assertRaisesRegex(SystemExit, "missing DSN env var: CUSTOM_DSN"):
                 main(["--dsn-env", "CUSTOM_DSN"])
 
-    def test_postgresql_missing_predicate_uses_a_text_json_key(self) -> None:
+    def test_postgresql_missing_predicate_uses_supported_jsonb_operations(self) -> None:
         engine = create_engine("postgresql+psycopg://", future=True)
         try:
             with Session(engine) as session:
@@ -211,9 +211,39 @@ class TestBackfillTigerBeetleStableRefs(TestCase):
 
         self.assertIn("payload_json ->", str(compiled))
         self.assertIn("::TEXT", str(compiled))
-        self.assertNotIn("::JSONB", str(compiled))
+        self.assertIn("AS JSONB", str(compiled))
+        self.assertNotIn("jsonb_object_length", str(compiled))
         self.assertEqual(compiled.params["payload_json_1"], "stable_ref")
         self.assertEqual(compiled.params["jsonb_typeof_1"], "object")
+
+    def test_apply_replaces_empty_stable_ref_object_and_drains_missing_count(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            _seed_refs(session, count=1)
+            ref = session.scalar(select(TigerBeetleTransferRef))
+            assert ref is not None
+            ref.payload_json = {**ref.payload_json, "stable_ref": {}}
+            session.commit()
+            journal = TigerBeetleLedgerJournal(
+                settings_obj=_settings(),
+                client=FakeTigerBeetleClient(),
+            )
+
+            result = run_stable_ref_backfill(
+                session,
+                journal,
+                batch_size=1,
+                max_batches=1,
+                apply=True,
+            )
+            payload = session.scalar(select(TigerBeetleTransferRef.payload_json))
+
+        self.assertTrue(result["complete"])
+        self.assertEqual(result["missing_before"], 1)
+        self.assertEqual(result["missing_after"], 0)
+        self.assertEqual(result["postgres_rows_updated"], 1)
+        self.assertTrue(payload["stable_ref"])
 
     def test_apply_drains_multiple_batches_without_tigerbeetle_writes(self) -> None:
         with Session(self.engine) as session:


### PR DESCRIPTION
## Summary

- classify missing, non-object, and exactly empty `{}` stable-reference payloads without unsupported PostgreSQL JSONB functions
- use PostgreSQL JSONB equality and SQLite exact-object extraction rather than array-length semantics
- replace empty Python mappings while preserving already-populated stable references
- add a regression proving an empty stable reference is repaired and the missing count drains to zero
- replace the prior patch-runner head with direct source commits rebased onto current `main`

## Related Issues

Remediates the unresolved Codex finding on #12818 and the actionable findings introduced on this remediation PR.

## Testing

- `env LD_LIBRARY_PATH=/workspace/runtime-libs .venv/bin/pytest tests/test_backfill_tigerbeetle_stable_refs.py -q` (`14 passed`)
- `.venv/bin/ruff format --check app/trading/tigerbeetle_journal/stable_ref_backfill.py tests/test_backfill_tigerbeetle_stable_refs.py`
- `.venv/bin/ruff check app/trading/tigerbeetle_journal/stable_ref_backfill.py tests/test_backfill_tigerbeetle_stable_refs.py`
- complete required GitHub CI remains blocking before merge

## Rollout

This changes the Torghut runtime image. After merge, the multi-architecture image build, digest promotion PRs, Argo sync, migration and TigerBeetle smoke hooks, workload readiness, restarts, logs, and health endpoints must be verified before review threads are resolved.

## Breaking Changes

None. Existing non-empty stable references remain immutable.

## Checklist

- [x] Testing section documents exact commands and results.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Rollout requirements are documented.
