### PR TITLE
fix(torghut): honor notebook image entrypoint

### DIFF
--- a/argocd/applications/torghut/notebooks/values.yaml
+++ b/argocd/applications/torghut/notebooks/values.yaml
@@ -91,6 +91,7 @@ proxy:
         memory: 512Mi
 
 singleuser:
+  cmd: null
   image:
     name: registry.ide-newton.ts.net/lab/torghut-notebook@sha256
     tag: '97c8c88b6a6b97b647986ee85f438feb68edcd61bad1fbdd79251a1d076b9de1'

--- a/services/torghut/tests/notebook_data/test_manifest_contract.py
+++ b/services/torghut/tests/notebook_data/test_manifest_contract.py
@@ -200,7 +200,7 @@ def test_chart_and_digest_contracts_are_pinned() -> None:
     values = yaml.safe_load((NOTEBOOKS_DIR / "values.yaml").read_text())
     assert values["hub"]["image"]["tag"] == "4.4.0"
     assert values["proxy"]["chp"]["image"]["tag"] == "5.2.0"
-    assert "cmd" not in values["singleuser"]
+    assert values["singleuser"]["cmd"] is None
     assert values["singleuser"]["image"]["name"].endswith("@sha256")
     assert re.fullmatch(r"[0-9a-f]{64}", values["singleuser"]["image"]["tag"])
 


### PR DESCRIPTION
## Summary

- set `singleuser.cmd: null` so JupyterHub uses the promoted notebook image entrypoint instead of overriding it with the chart default
- keep the manifest contract explicit about the null command
- replace the prior patch-runner head with a direct source commit rebased onto current `main`

## Related Issues

Remediates the unresolved Codex finding on #12793 and supersedes the closed remediation attempt #12869.

## Testing

- `uv run --frozen --extra dev pytest tests/notebook_data/test_manifest_contract.py -q` (`12 passed`)
- final required GitHub CI, including the real Torghut manifest-only release job, remains blocking before merge

## Rollout

After merge, Argo CD must sync the changed notebook values and the live JupyterHub Secret must contain `singleuser.cmd: null` while retaining the promoted immutable notebook digest. The original and remediation review threads will only be resolved after that live verification.

## Breaking Changes

None. This restores the image's intended entrypoint.

## Checklist

- [x] Testing section documents exact commands and results.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Rollout evidence requirements are documented.
