### PR TITLE
fix(torghut): bound sequential migration index builds

### DIFF
--- a/.github/workflows/torghut-post-deploy-verify.yml
+++ b/.github/workflows/torghut-post-deploy-verify.yml
@@ -163,9 +163,9 @@ jobs:
             request_argocd_sync "${app}" "${EXPECTED_REVISION}"
           done
 
-          # The PreSync database migration may run for up to one hour. Keep the verifier
+          # The PreSync database migration may run for up to 90 minutes. Keep the verifier
           # alive for that deadline plus five minutes of Argo reconciliation headroom.
-          ARGO_SYNC_TIMEOUT_SECONDS=3900
+          ARGO_SYNC_TIMEOUT_SECONDS=5700
           ARGO_SYNC_POLL_INTERVAL_SECONDS=2
           ARGO_SYNC_POLL_ATTEMPTS=$((ARGO_SYNC_TIMEOUT_SECONDS / ARGO_SYNC_POLL_INTERVAL_SECONDS))
 

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -11,9 +11,10 @@ metadata:
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
 spec:
   backoffLimit: 6
-  # Online index builds cover the live 6+ GiB options catalog; keep this above
-  # the migration's 45-minute statement timeout so Kubernetes does not kill a healthy build.
-  activeDeadlineSeconds: 3600
+  # Migration 0083 can run two sequential 30-minute concurrent index builds.
+  # Include both 300-second database waits and remaining migration work so
+  # Kubernetes cannot kill a healthy PreSync hook before Alembic stamps it.
+  activeDeadlineSeconds: 5400
   ttlSecondsAfterFinished: 600
   template:
     metadata:

--- a/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
+++ b/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
@@ -281,8 +281,9 @@ describe('update-manifests', () => {
     const migrationManifest = readFileSync(join(repoRoot, 'argocd/applications/torghut/db-migrations-job.yaml'), 'utf8')
 
     expect(migrationManifest).toContain('backoffLimit: 6')
-    expect(migrationManifest).toContain('activeDeadlineSeconds: 3600')
-    expect(migrationManifest).toContain("migration's 45-minute statement timeout")
+    expect(migrationManifest).toContain('activeDeadlineSeconds: 5400')
+    expect(migrationManifest).toContain('two sequential 30-minute concurrent index builds')
+    expect(migrationManifest).toContain('both 300-second database waits')
     expect(migrationManifest).toContain('wait_for_database()')
     expect(migrationManifest).toContain("connection.execute(text('select 1'))")
     expect(migrationManifest).toContain('wait_for_database "torghut app database" "${DB_DSN}" 300')

--- a/services/torghut/tests/live_config_manifest_contract/test_db_migrations_deadline.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_db_migrations_deadline.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Mapping, cast
+from unittest import TestCase
+
+from tests.live_config_manifest_contract.support import _load_yaml_mapping
+
+
+_MANIFEST_PATH = "argocd/applications/torghut/db-migrations-job.yaml"
+_MIGRATION_PATH = Path(
+    "services/torghut/migrations/versions/"
+    "0083_hyperliquid_execution_order_read_indexes.py"
+)
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+class DatabaseMigrationDeadlineTests(TestCase):
+    def test_deadline_covers_both_online_index_builds_and_database_waits(self) -> None:
+        manifest = _load_yaml_mapping(_MANIFEST_PATH)
+        spec = cast(Mapping[str, object], manifest["spec"])
+        deadline_seconds = cast(int, spec["activeDeadlineSeconds"])
+        migration = (_REPO_ROOT / _MIGRATION_PATH).read_text()
+
+        index_build_count = migration.count("CREATE INDEX CONCURRENTLY")
+        self.assertEqual(index_build_count, 2)
+        self.assertIn("SET statement_timeout = '30min'", migration)
+
+        index_build_budget_seconds = index_build_count * 30 * 60
+        database_wait_budget_seconds = 2 * 300
+        remaining_migration_budget_seconds = 600
+        required_deadline_seconds = (
+            index_build_budget_seconds
+            + database_wait_budget_seconds
+            + remaining_migration_budget_seconds
+        )
+        self.assertGreaterEqual(deadline_seconds, required_deadline_seconds)


### PR DESCRIPTION
## Summary

- raise the Torghut migration hook deadline from 3,600 to 5,400 seconds so two sequential 30-minute concurrent index builds, two 300-second database waits, and remaining Alembic work fit inside the Kubernetes deadline
- raise the post-deploy Argo convergence timeout to 5,700 seconds so verification cannot time out before the migration hook plus reconciliation headroom
- add a Python manifest contract derived from migration 0083 and update the existing TypeScript manifest/workflow contracts
- replace the prior patch-runner head with direct source commits rebased onto current `main`

## Related Issues

Remediates the unresolved Codex finding on #12808 and the actionable review finding introduced on this remediation PR.

## Testing

- `uv run --frozen --extra dev pytest tests/live_config_manifest_contract/test_db_migrations_deadline.py -q` (`1 passed` before the final CI head)
- `bun test ./packages/scripts/src/torghut/__tests__/update-manifests.test.ts` (`5 passed`)
- `bun test ./packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts` (`24 passed`)
- complete Torghut CI run `29802249755` passed: bytecode/Ruff/migration guard, Pyright, PostgreSQL CAS, quality gates, both autoresearch runners, all four pytest shards, and aggregate coverage
- scripts run `29802249805` passed; workflow/Argo/kubeconform validation run `29802249841` passed
- final-head Codex review remains the only pre-merge gate

## Rollout

After merge, Argo CD must apply `activeDeadlineSeconds: 5400`, the live PreSync migration hook must complete successfully, and the live Job definition must expose the new deadline. The post-deploy verification workflow must execute successfully with `ARGO_SYNC_TIMEOUT_SECONDS=5700`. Review threads will only be resolved after that evidence is captured.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents exact commands and results.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Rollout requirements are documented.
