### PR TITLE
fix(ci): guarantee Torghut manifest tools

### DIFF
--- a/.github/workflows/torghut-ci.yml
+++ b/.github/workflows/torghut-ci.yml
@@ -168,6 +168,7 @@ jobs:
       - name: Set up Nix toolchain
         uses: ./.github/actions/setup-nix-toolchain
         with:
+          install-ci-toolchain: 'true'
           require-preinstalled: 'true'
 
       - name: Verify Torghut Alloy config rollout digest

--- a/packages/scripts/src/torghut/__tests__/ci-toolchain-contract.test.ts
+++ b/packages/scripts/src/torghut/__tests__/ci-toolchain-contract.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs'
+
+import { describe, expect, it } from 'bun:test'
+
+const workflow = readFileSync(new URL('../../../../../.github/workflows/torghut-ci.yml', import.meta.url), 'utf8')
+
+describe('Torghut CI toolchain contract', () => {
+  it('guarantees jq and yq before manifest digest validation', () => {
+    const setupStart = workflow.indexOf('- name: Set up Nix toolchain')
+    const verificationStart = workflow.indexOf('- name: Verify Torghut Alloy config rollout digest')
+
+    expect(setupStart).toBeGreaterThanOrEqual(0)
+    expect(verificationStart).toBeGreaterThan(setupStart)
+
+    const setup = workflow.slice(setupStart, verificationStart)
+    expect(setup).toContain("install-ci-toolchain: 'true'")
+    expect(setup).toContain("require-preinstalled: 'true'")
+    expect(workflow.slice(verificationStart)).toContain('yq -r')
+    expect(workflow.slice(verificationStart)).toContain('jq -jr')
+  })
+})


### PR DESCRIPTION
## Summary

- install the repository CI toolchain in Torghut's manifest-only release job before requiring preinstalled `jq` and `yq`
- keep the job fail-closed when either tool is absent
- add a focused workflow contract proving the setup/action inputs and digest verification remain wired together
- replace the earlier patch-runner head with a direct source commit rebased onto current `main`

## Related Issues

Remediates the unresolved Codex finding on #12777.

## Testing

- `node node_modules/oxfmt/bin/oxfmt --check packages/scripts/src/torghut/__tests__/ci-toolchain-contract.test.ts`
- `node node_modules/oxlint/bin/oxlint --config .oxlintrc.json packages/scripts/src/torghut/__tests__/ci-toolchain-contract.test.ts` (`0 warnings`, `0 errors`)
- `bun test packages/scripts/src/torghut/__tests__/ci-toolchain-contract.test.ts` (`1 pass`)
- final required GitHub CI remains blocking before merge

## Rollout

After merge, a real Torghut manifest-only pull request will exercise the corrected `Release manifest changes` job. The source thread will not be resolved until that actual job proves `jq`/`yq` setup and digest verification execute successfully.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents exact commands and results.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] No runtime or documentation change is required.
