### PR TITLE
fix(torghut): reuse captured quote containers

### DIFF
--- a/services/torghut/app/trading/scheduler/pipeline/signal_processing.py
+++ b/services/torghut/app/trading/scheduler/pipeline/signal_processing.py
@@ -730,23 +730,13 @@ class TradingPipelineSignalProcessingMixin(TradingPipelineRuntime):
     def _captured_rejected_signal_entry_snapshot(
         signal: SignalEnvelope,
     ) -> MarketSnapshot | None:
-        price = extract_executable_price(signal.payload)
-        bid = scheduler_optional_decimal(
-            payload_value(
-                signal.payload,
-                "imbalance_bid_px",
-                block="imbalance",
-                nested_key="bid_px",
-            )
+        quote_status = assess_signal_quote_quality(
+            signal=signal,
+            previous_price=None,
         )
-        ask = scheduler_optional_decimal(
-            payload_value(
-                signal.payload,
-                "imbalance_ask_px",
-                block="imbalance",
-                nested_key="ask_px",
-            )
-        )
+        price = quote_status.price
+        bid = quote_status.bid
+        ask = quote_status.ask
         if (
             price is None
             or bid is None

--- a/services/torghut/tests/pipeline/test_trading_pipeline_quote_outcome.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_quote_outcome.py
@@ -635,9 +635,12 @@ class TestTradingPipelineQuoteOutcome(TradingPipelineTestCaseBase):
                     event_payload_json={
                         "event_id": "reject-event-captured-entry-quote",
                         "signal_payload": {
-                            "price": "100.00",
-                            "imbalance_bid_px": "99.99",
-                            "imbalance_ask_px": "100.01",
+                            "executable_quote": {
+                                "bid_px": "99.99",
+                                "ask_px": "100.01",
+                                "mid_price": "100.00",
+                                "source": "captured-nbbo",
+                            },
                         },
                     },
                     outcome_payload_json=None,


### PR DESCRIPTION
## Summary

- reuse `assess_signal_quote_quality()` when reconstructing rejected-signal entry snapshots
- preserve the same quote aliases and nested `executable_quote` container semantics used by the accepted-signal path
- add regression coverage using a captured nested NBBO quote rather than legacy top-level fields
- replace the prior patch-runner head with a direct source commit rebased onto current `main`

## Related Issues

Remediates the unresolved Codex finding on #12772.

## Testing

- `env LD_LIBRARY_PATH=/workspace/runtime-libs .venv/bin/pytest tests/pipeline/test_trading_pipeline_quote_outcome.py -q` (`17 passed`)
- Ruff format and lint passed on both changed files
- complete required GitHub CI remains blocking before merge

## Rollout

This changes the Torghut runtime image. After merge, the image build, immutable digest promotion, Argo sync, migration/smoke hooks, current workloads, readiness, restarts, logs, and health endpoints must be verified before review threads are resolved.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents exact commands and results.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Rollout requirements are documented.
