### PR TITLE
fix(torghut): fail closed on legacy parity projections

### DIFF
--- a/docs/torghut/profitability/tigerbeetle-economic-parity.md
+++ b/docs/torghut/profitability/tigerbeetle-economic-parity.md
@@ -76,11 +76,15 @@ keeps every published activity in the same order, and economically sorts only th
 
 Crossing the published economic frontier is not a generic ingestion-time rule. A missing historical trade or a
 correction of published history requires a new reducer and projection version. A documented late date-only `CFEE` may
-append only after the canonical and independent reducers also replay the complete source in economic order and prove:
+append only after the normal dual reduction remains admissible and equivalent and the dedicated retroactive-append
+guard replays the complete source in economic order. That dedicated guard compares the canonical journal and proves:
 
 - the transaction ID and digest multiset is identical;
-- the final economic projection is identical, excluding only the order-dependent input-manifest digest; and
-- both reductions remain admissible and exactly equivalent.
+- the canonical journal's final economic projection is identical, excluding only the order-dependent input-manifest
+  digest.
+
+Independent-reducer equivalence is required by the normal replay boundary, but it is not an additional comparison made
+inside the retroactive-append guard.
 
 This rejects both obvious insufficient-position cases and sufficient-position cases where later trades changed the
 fee's average cost. The implementation never guesses that an append is safe from position quantity alone. A malformed,

--- a/services/torghut/app/trading/economic_ledger/tigerbeetle_parity.py
+++ b/services/torghut/app/trading/economic_ledger/tigerbeetle_parity.py
@@ -29,6 +29,12 @@ if TYPE_CHECKING:
 TIGERBEETLE_ECONOMIC_PARITY_SCHEMA_VERSION = (
     "torghut.broker-economic-tigerbeetle-parity.v1"
 )
+_HISTORICAL_PROJECTION_VERSIONS = frozenset(
+    {
+        "torghut.broker-economic-tigerbeetle-projection.v1",
+        "torghut.broker-economic-tigerbeetle-projection.v2",
+    }
+)
 _SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 _MISMATCH_SAMPLE_LIMIT = 20
 _AUDIT_OPERATION_ERRORS = (
@@ -926,6 +932,12 @@ def load_persisted_tigerbeetle_economic_parity(
         raw_payload,
         "economic_reconciliation_persisted_tigerbeetle_parity_invalid",
     )
+    projection_version = payload.get("projection_version")
+    if (
+        isinstance(projection_version, str)
+        and projection_version in _HISTORICAL_PROJECTION_VERSIONS
+    ):
+        return None, False, ("tigerbeetle_economic_projection_version_stale",)
     sections = _validated_payload_sections(
         payload,
         expected_cluster_id=expected_cluster_id,

--- a/services/torghut/tests/economic_ledger/test_legacy_parity_payload_version.py
+++ b/services/torghut/tests/economic_ledger/test_legacy_parity_payload_version.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from app.models import BrokerEconomicLedgerReconciliation
+from app.trading.economic_ledger import EconomicLedgerError, LedgerScope
+from app.trading.economic_ledger.tigerbeetle_parity import (
+    load_persisted_tigerbeetle_economic_parity,
+)
+
+
+_SCOPE = LedgerScope(
+    provider="alpaca",
+    environment="paper",
+    account_label="parity-test",
+    endpoint_fingerprint="c" * 64,
+)
+
+
+def test_non_scalar_projection_version_fails_with_economic_ledger_error() -> None:
+    row = cast(
+        BrokerEconomicLedgerReconciliation,
+        SimpleNamespace(
+            result={
+                "tigerbeetle_economic_parity": {
+                    "projection_version": [],
+                },
+            },
+        ),
+    )
+
+    with pytest.raises(EconomicLedgerError):
+        load_persisted_tigerbeetle_economic_parity(
+            row,
+            scope=_SCOPE,
+            expected_cluster_id=2001,
+        )

--- a/services/torghut/tests/economic_ledger/test_tigerbeetle_parity.py
+++ b/services/torghut/tests/economic_ledger/test_tigerbeetle_parity.py
@@ -5,10 +5,12 @@ import uuid
 from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
+from types import SimpleNamespace
 from typing import cast
 
 import pytest
 
+from app.models import BrokerEconomicLedgerReconciliation
 from app.trading.economic_ledger import (
     BrokerEconomicLedgerReplay,
     BrokerEconomicLedgerSnapshot,
@@ -22,6 +24,7 @@ from app.trading.economic_ledger import (
     reduce_and_compare,
 )
 from app.trading.economic_ledger.tigerbeetle_parity import (
+    load_persisted_tigerbeetle_economic_parity,
     validate_tigerbeetle_economic_parity_payload,
 )
 from app.trading.economic_ledger.tigerbeetle_projection import (
@@ -468,3 +471,35 @@ def test_forged_expected_digest_is_rejected_before_persistence() -> None:
                 max_source_age_seconds=300,
             ),
         )
+
+
+@pytest.mark.parametrize(
+    "projection_version",
+    [
+        "torghut.broker-economic-tigerbeetle-projection.v1",
+        "torghut.broker-economic-tigerbeetle-projection.v2",
+    ],
+)
+def test_load_persisted_legacy_projection_is_unsatisfied(
+    projection_version: str,
+) -> None:
+    row = cast(
+        BrokerEconomicLedgerReconciliation,
+        SimpleNamespace(
+            result={
+                "tigerbeetle_economic_parity": {
+                    "projection_version": projection_version,
+                },
+            },
+        ),
+    )
+
+    payload, satisfied, reasons = load_persisted_tigerbeetle_economic_parity(
+        row,
+        scope=_SCOPE,
+        expected_cluster_id=2001,
+    )
+
+    assert payload is None
+    assert satisfied is False
+    assert reasons == ("tigerbeetle_economic_projection_version_stale",)


### PR DESCRIPTION
## Summary

- treat persisted legacy TigerBeetle parity projections as stale and unsatisfied rather than as valid current evidence
- fail closed on malformed non-string `projection_version` values with `EconomicLedgerError` instead of an unhandled `TypeError`
- document that parity is derived from the same canonical economic reducer while independently validating persisted projection evidence
- add focused regressions for legacy versions, malformed versions, and current-version parity
- replace the prior patch-runner head with direct source commits rebased onto current `main`

## Related Issues

Remediates the unresolved Codex findings on #12766 and #12778 and the actionable findings introduced on this remediation PR.

## Testing

- `env LD_LIBRARY_PATH=/workspace/runtime-libs .venv/bin/pytest tests/economic_ledger/test_legacy_parity_payload_version.py tests/economic_ledger/test_tigerbeetle_parity.py -q` (`14 passed`)
- Ruff format and lint passed on all changed Python files
- complete required GitHub CI remains blocking before merge

## Rollout

This changes the Torghut runtime image and status semantics. After merge, the image build, immutable digest promotion, Argo sync, migration/smoke hooks, current workload readiness, restarts, logs, `/trading/status`, and post-deploy verification must be checked before source threads are resolved.

## Breaking Changes

Legacy or malformed persisted parity projections now fail closed as stale/unavailable instead of being accepted or raising an unhandled exception.

## Checklist

- [x] Testing section documents exact commands and results.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation and rollout requirements are updated.
