### PR TITLE
fix(torghut): keep completed activity source current during overlap scan

### DIFF
--- a/services/torghut/app/trading/broker_account_activities.py
+++ b/services/torghut/app/trading/broker_account_activities.py
@@ -531,9 +531,24 @@ def load_broker_account_activity_status(
         }
     observed = as_utc(observed_at)
     updated_at = as_utc(cursor.updated_at)
-    age_seconds = max(0, int((observed - updated_at).total_seconds()))
+    last_completed_at = (
+        as_utc(cursor.last_completed_at)
+        if cursor.last_completed_at is not None
+        else None
+    )
+    freshness_at = (
+        last_completed_at
+        if cursor.status in {"complete", "scanning"} and last_completed_at is not None
+        else updated_at
+    )
+    age_seconds = max(0, int((observed - freshness_at).total_seconds()))
     reasons: list[str] = []
-    if cursor.status != "complete":
+    has_completed_scan = (
+        last_completed_at is not None and cursor.last_completed_scan_until is not None
+    )
+    if cursor.status != "complete" and not (
+        cursor.status == "scanning" and has_completed_scan
+    ):
         reasons.append(f"broker_account_activity_{cursor.status}")
     if age_seconds > _FRESHNESS_MAX_AGE_SECONDS:
         reasons.append("broker_account_activity_cursor_stale")

--- a/services/torghut/tests/test_broker_account_activities.py
+++ b/services/torghut/tests/test_broker_account_activities.py
@@ -674,9 +674,24 @@ def test_status_distinguishes_complete_fresh_cursor_from_stale_source() -> None:
             environment="paper",
             observed_at=clock.value + timedelta(seconds=61),
         )
+        cursor = session.scalar(select(BrokerAccountActivityCursor))
+        assert cursor is not None
+        cursor.status = "scanning"
+        cursor.scan_until = clock.value + timedelta(minutes=1)
+        cursor.updated_at = clock.value + timedelta(seconds=30)
+        session.commit()
+        overlap_scan = load_broker_account_activity_status(
+            session,
+            account_label="paper-account",
+            environment="paper",
+            observed_at=clock.value + timedelta(seconds=30),
+        )
 
     assert current["state"] == "current"
     assert current["current"] is True
     assert current["activities_inserted"] == 1
     assert stale["current"] is False
     assert stale["reason_codes"] == ["broker_account_activity_cursor_stale"]
+    assert overlap_scan["state"] == "current"
+    assert overlap_scan["current"] is True
+    assert overlap_scan["reason_codes"] == []

--- a/services/torghut/tests/test_broker_account_activity_overlap_status.py
+++ b/services/torghut/tests/test_broker_account_activity_overlap_status.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import cast
+
+from sqlalchemy import Table, create_engine
+from sqlalchemy.orm import Session
+
+from app.models import Base, BrokerAccountActivityCursor
+from app.trading.broker_account_activities import (
+    ACCOUNT_ACTIVITIES_REST_SOURCE,
+    ALPACA_PROVIDER,
+    load_broker_account_activity_status,
+)
+
+
+_OBSERVED_AT = datetime(2026, 7, 20, 14, 0, tzinfo=timezone.utc)
+
+
+def _status_for_completed_age(completed_age: timedelta) -> dict[str, object]:
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    Base.metadata.create_all(
+        engine,
+        tables=[cast(Table, BrokerAccountActivityCursor.__table__)],
+    )
+    try:
+        with Session(engine) as session:
+            completed_at = _OBSERVED_AT - completed_age
+            session.add(
+                BrokerAccountActivityCursor(
+                    provider=ALPACA_PROVIDER,
+                    source=ACCOUNT_ACTIVITIES_REST_SOURCE,
+                    environment="paper",
+                    account_label="paper-account",
+                    endpoint_fingerprint="a" * 64,
+                    status="scanning",
+                    scan_after=completed_at - timedelta(days=2),
+                    scan_until=_OBSERVED_AT + timedelta(minutes=1),
+                    scan_started_at=_OBSERVED_AT - timedelta(seconds=5),
+                    last_completed_at=completed_at,
+                    last_completed_scan_until=completed_at,
+                    updated_at=_OBSERVED_AT,
+                )
+            )
+            session.commit()
+            return load_broker_account_activity_status(
+                session,
+                account_label="paper-account",
+                environment="paper",
+                observed_at=_OBSERVED_AT,
+            )
+    finally:
+        engine.dispose()
+
+
+def test_overlap_scan_reuses_a_fresh_completed_watermark() -> None:
+    status = _status_for_completed_age(timedelta(seconds=30))
+
+    assert status["state"] == "current"
+    assert status["current"] is True
+    assert status["reason_codes"] == []
+    assert status["age_seconds"] == 30
+
+
+def test_overlap_scan_rejects_a_stale_completed_watermark() -> None:
+    status = _status_for_completed_age(timedelta(hours=2))
+
+    assert status["current"] is False
+    assert status["reason_codes"] == ["broker_account_activity_cursor_stale"]
+    assert status["age_seconds"] == 7200


### PR DESCRIPTION
## Summary

- preserve a recently completed broker-account-activity watermark while a bounded overlap scan is running
- calculate freshness from `last_completed_at` during overlap scans instead of the scan-start `updated_at`
- keep stale historical watermarks fail-closed even when a new scan refreshes the cursor row
- add focused fresh and stale overlap-scan regressions
- replace the prior patch-runner head with a direct source commit rebased onto current `main`

## Related Issues

Remediates the unresolved Codex finding on #12764 and the actionable findings introduced on this remediation PR.

## Testing

- `env LD_LIBRARY_PATH=/workspace/runtime-libs .venv/bin/pytest tests/test_broker_account_activities.py tests/test_broker_account_activity_overlap_status.py -q` (`18 passed`)
- Ruff format and lint passed on all three changed Python files
- complete required GitHub CI remains blocking before merge

## Rollout

This changes the Torghut runtime image and readiness/status semantics. After merge, the image build, immutable digest promotion, Argo sync, migration/smoke hooks, workload readiness, restarts, logs, status endpoints, and post-deploy verification must be checked before original review threads are resolved.

## Breaking Changes

None. Stale completed activity watermarks remain fail-closed.

## Checklist

- [x] Testing section documents exact commands and results.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Rollout requirements are documented.
