### PR TITLE
fix(torghut): restore manifest dependency contracts

### DIFF
--- a/docs/torghut/tigerbeetle-ledger-design.md
+++ b/docs/torghut/tigerbeetle-ledger-design.md
@@ -119,4 +119,4 @@ The single-replica topology is not HA. Full production HA requires at least six 
 
 ## Version Contract
 
-TigerBeetle server and client versions are pinned together. The first rollout pins both to `0.17.4`, matching the latest verified upstream release at implementation start.
+TigerBeetle server and client versions are pinned together at `0.17.9`. A version change must update the cluster manifest, Python dependency and lockfile, manifest contract, and operational documentation in the same rollout.

--- a/docs/torghut/tigerbeetle-ledger-runbook.md
+++ b/docs/torghut/tigerbeetle-ledger-runbook.md
@@ -9,7 +9,7 @@ Torghut uses TigerBeetle as a durable double-entry ledger for execution/order li
 - Cluster: `TigerBeetleCluster/torghut-tigerbeetle`
 - Cluster ID: `2001`
 - Endpoint: `torghut-tigerbeetle.torghut.svc.cluster.local:3000`
-- Server/client version: `0.17.4`
+- Server/client version: `0.17.9`
 - Storage class: `rook-ceph-block`
 - Bootstrap replicas: `1`
 
@@ -101,7 +101,7 @@ The operator-driven journal runner emits stable JSON with schema version `torghu
 
 ## Rollout Checklist
 
-1. Confirm `0.17.4` is still the latest TigerBeetle release before changing pins.
+1. Confirm the intended TigerBeetle release is compatible with the live replica and update the server manifest, Python client dependency, lockfile, contract test, and version documentation together.
 2. Render manifests:
 
    ```bash

--- a/services/torghut/pyproject.toml
+++ b/services/torghut/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "inngest>=0.5.15,<1.0",
   "pypdf>=5.4.0,<6.0",
   "hyperliquid-python-sdk==0.24.0",
-  "tigerbeetle==0.17.4",
+  "tigerbeetle==0.17.9",
   "mlx>=0.29.2,<1.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
 ]
 

--- a/services/torghut/tests/live_config_manifest_contract/test_knative_env_wiring_is_safe_live_defaults.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_knative_env_wiring_is_safe_live_defaults.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import tomllib
+
 from tests.live_config_manifest_contract.support import (
     Decimal,
     Mapping,
@@ -582,6 +584,14 @@ class TestKnativeEnvWiringIsSafeLiveDefaults(_TestLiveConfigManifestContractBase
         manifest = _load_yaml_mapping(
             "argocd/applications/torghut/tigerbeetle-cluster.yaml"
         )
+        pyproject = tomllib.loads(
+            (_repo_root() / "services/torghut/pyproject.toml").read_text()
+        )
+        client_pin = next(
+            dependency.split("==", maxsplit=1)[1]
+            for dependency in pyproject["project"]["dependencies"]
+            if dependency.startswith("tigerbeetle==")
+        )
 
         self.assertEqual(manifest["apiVersion"], "tigerbeetle.proompteng.ai/v1alpha1")
         self.assertEqual(manifest["kind"], "TigerBeetleCluster")
@@ -605,10 +615,11 @@ class TestKnativeEnvWiringIsSafeLiveDefaults(_TestLiveConfigManifestContractBase
             spec_mapping["image"],
             {
                 "repository": "ghcr.io/tigerbeetle/tigerbeetle",
-                "tag": "0.17.4",
+                "tag": client_pin,
                 "pullPolicy": "IfNotPresent",
             },
         )
+        self.assertEqual(client_pin, "0.17.9")
         self.assertEqual(
             spec_mapping["storage"], {"className": "rook-ceph-block", "size": "100Gi"}
         )

--- a/services/torghut/tests/notebook_data/test_manifest_contract.py
+++ b/services/torghut/tests/notebook_data/test_manifest_contract.py
@@ -405,7 +405,10 @@ def test_database_principals_are_read_only_and_bounded() -> None:
         ).read_text()
     )
     profiles = clickhouse["spec"]["configuration"]["profiles"]
-    assert profiles == {
+    notebook_profiles = {
+        key: value for key, value in profiles.items() if key.startswith("notebook/")
+    }
+    assert notebook_profiles == {
         "notebook/readonly": 1,
         "notebook/max_execution_time": 30,
         "notebook/max_result_rows": 100000,

--- a/services/torghut/uv.lock
+++ b/services/torghut/uv.lock
@@ -3530,10 +3530,10 @@ wheels = [
 
 [[package]]
 name = "tigerbeetle"
-version = "0.17.4"
+version = "0.17.9"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/a8/3d5b80197493af4bd1c1454ad3737d58234af2cb86827fcfb141f0f4b8c2/tigerbeetle-0.17.4-py3-none-any.whl", hash = "sha256:b0b79a2a340e99598b3d5a9094a2c29325d3caf58045f45260fd065f82238f3a", size = 1644037, upload-time = "2026-05-11T09:25:00.321Z" },
+    { url = "https://files.pythonhosted.org/packages/98/ba/1819cb0023531fd8e45b89c1d223a937c837aac9b6c0d4ae6f9ce1565a50/tigerbeetle-0.17.9-py3-none-any.whl", hash = "sha256:405910bfdf74f169a27a282abfd6a124bee57ac2ef8cc50d247bb753e9a119ec", size = 1680410, upload-time = "2026-07-06T17:24:45.517Z" },
 ]
 
 [[package]]
@@ -3787,7 +3787,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.2,<7.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9.0,<1.0" },
     { name = "sqlalchemy", specifier = ">=2.0.36,<3.0" },
-    { name = "tigerbeetle", specifier = "==0.17.4" },
+    { name = "tigerbeetle", specifier = "==0.17.9" },
     { name = "torch", marker = "(sys_platform == 'linux' and extra == 'cuda-research') or (sys_platform == 'win32' and extra == 'cuda-research')", specifier = "==2.11.0+cu128", index = "https://download.pytorch.org/whl/cu128", conflict = { package = "torghut", extra = "cuda-research" } },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0,<1.0" },
     { name = "vulture", marker = "extra == 'dev'", specifier = ">=2.14,<3.0" },


### PR DESCRIPTION
## Summary

- scope the notebook ClickHouse manifest contract to the exact `notebook/` profile namespace so Bayn's separate read-only profile can coexist
- align the Torghut Python TigerBeetle client, lockfile, tests, and documentation with the live server pin `0.17.9`
- bind the server image tag to the Python dependency in the live manifest contract to prevent future client/server drift
- restore the required Torghut CI gates on current `main`; these two pre-existing contract regressions could not independently produce a green required test suite

## Related Issues

Historical Codex finding in #12857. The notebook contract regression was discovered while rebuilding the historical remediation PRs.

## Testing

- `uv lock --check`
- imported installed `tigerbeetle` version `0.17.9`
- `uv run --frozen --extra dev pytest tests/notebook_data/test_manifest_contract.py tests/live_config_manifest_contract/test_knative_env_wiring_is_safe_live_defaults.py::TestKnativeEnvWiringIsSafeLiveDefaults::test_torghut_declares_tigerbeetle_cluster tests/test_tigerbeetle_client.py tests/test_tigerbeetle_status.py -q` (`47 passed`)
- first CI run `29725719824` independently confirmed the remaining failure was the existing `0.17.4` test/client versus live `0.17.9` server mismatch; all other required static, Pyright, PostgreSQL CAS, autoresearch, and three pytest shards passed
- final required CI on the updated head remains blocking before merge

## Rollout

This changes Torghut runtime dependencies. After merge, the source image build must complete, its immutable digest must be promoted through GitOps, and the live Torghut workloads and TigerBeetle connectivity must be verified before the original review thread is resolved.

## Breaking Changes

None. Server and client are aligned to the server version already declared and running in GitOps.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Operational documentation and rollout requirements are updated.
