### PR TITLE
feat(bayn): define versioned evaluation contracts

### DIFF
--- a/docs/bayn/architecture.md
+++ b/docs/bayn/architecture.md
@@ -2,10 +2,14 @@
 
 ## Purpose and boundary
 
-Bayn is an autonomous quantitative evaluation and accounting service. Its first production protocol is adjusted-ETF
-time-series momentum. The service may read market data, evaluate a frozen protocol, and journal simulation accounting.
-It may not call a broker, submit an order, or promote capital. A profitable live trading system is a later outcome; this
-boundary first makes research results reproducible and mechanically rejectable.
+Bayn is being built as an autonomous quantitative evaluation, execution, and accounting service. Its first strategy is
+adjusted-ETF time-series momentum. The deployed runtime currently stops at evaluation and simulation accounting: it may
+not call a broker, submit an order, or promote capital. Later authority is unlocked only by the roadmap's economic,
+recovery, reconciliation, and observation gates.
+
+The current TigerBeetle-backed startup path described below is legacy production state, not the target architecture.
+The active roadmap replaces it incrementally with finalized Signal publications and Bayn-owned PostgreSQL evidence
+before any paper mutation work begins.
 
 ## Critical path
 
@@ -32,6 +36,17 @@ The run ID is the SHA-256 hash of:
 Decision and fill IDs derive from canonical event payloads. TigerBeetle account and transfer IDs derive from the run ID,
 event ID, and journal leg. Repeating the same run is idempotent; a changed price, protocol, or source revision creates a
 different run namespace.
+
+## Versioned contract boundary
+
+The target evaluation path uses the executable v1 contracts in [`contracts/v1.md`](contracts/v1.md). They strictly
+decode finalized-snapshot provenance, evaluation bounds, run identity, evidence freshness, independent status axes, and
+authority. Unknown versions and excess fields fail closed. Run identity binds the full source revision, OCI image
+digest, compiled strategy behavior hash, decoded strategy parameters, finalized snapshot, exchange-calendar version,
+and explicit bounds through canonical JSON and SHA-256.
+
+Contract availability does not mean the deployed runtime has adopted the target path. Adoption, persistence, continuous
+health, and removal of the legacy TigerBeetle dependency are separate roadmap tickets with their own rollout evidence.
 
 ## Economic test
 

--- a/docs/bayn/contracts/v1.md
+++ b/docs/bayn/contracts/v1.md
@@ -1,0 +1,94 @@
+# Bayn v1 contracts
+
+These contracts are the shared boundary for Bayn evaluation evidence. The executable definitions live in
+`services/bayn/src/contracts.ts`; this document defines their meaning. Adding a field or enum value requires a new
+schema version. Decoders reject excess fields, unknown versions, malformed values, and cross-field invariant failures.
+
+This contract slice changes no deployed authority. Bayn remains observe-only and has no broker client or credential.
+
+## Canonical representation
+
+All hashes use canonical JSON with recursively sorted UTF-16 object keys. The encoder accepts only plain JSON values,
+normalizes negative zero, and rejects non-finite numbers, sparse arrays, cycles, accessors, non-enumerable state, symbols,
+`undefined`, `bigint`, class instances, and invalid Unicode surrogates. Digests are lowercase SHA-256 values.
+
+Dates use `YYYY-MM-DD`. Instants use the canonical UTC form `YYYY-MM-DDTHH:mm:ss.sssZ`; implicit time zones and
+normalized invalid dates are not accepted.
+
+## `bayn.finalized-snapshot.v1`
+
+A finalized snapshot identifies one immutable Signal publication. It binds the publication and dataset versions,
+source/feed/adjustment contract, exchange-calendar version, publication and finalization instants, covered sessions,
+canonical sorted symbol universe, row count, and ordered content hash.
+
+Required invariants:
+
+- `firstSession <= lastSession` and `asOfSession == lastSession`;
+- `finalizedAt <= publishedAt`;
+- symbols are non-empty, unique, uppercase, and sorted;
+- `rowCount` is positive and at least the symbol count;
+- snapshot and content identities are full SHA-256 hashes.
+
+## `bayn.evaluation-bounds.v1`
+
+The bounds distinguish loaded data from the lookback and scored evaluation windows:
+
+`dataStart <= lookbackStart <= evaluationStart <= evaluationEnd <= dataEnd`
+
+The finalized snapshot must cover `dataStart` through `dataEnd`. Bounds are part of run identity; changing any boundary
+creates a different run.
+
+## `bayn.run-identity.v1`
+
+The run ID is SHA-256 over the canonical object containing:
+
+- full Git source revision;
+- OCI repository and immutable image digest;
+- compiled strategy name and behavior hash;
+- the complete already-decoded strategy parameter value;
+- complete finalized-snapshot provenance;
+- exchange-calendar version; and
+- explicit evaluation bounds.
+
+The top-level calendar version must match the snapshot. A persisted identity is accepted only when recomputing its hash
+produces the stored run ID. Equivalent object insertion order produces the same identity; changing any bound component
+produces a different identity.
+
+## `bayn.evidence-freshness.v1`
+
+Freshness contains `observedAt` and `validThrough`, with `observedAt <= validThrough`. Classification receives an
+explicit clock value:
+
+- before `observedAt`: `INVALID`;
+- through `validThrough`: `CURRENT`;
+- after `validThrough`: `STALE`.
+
+No domain contract reads ambient wall-clock time.
+
+## `bayn.status.v1`
+
+Status keeps independent facts independent:
+
+| Axis | Values |
+| --- | --- |
+| operational | `STARTING`, `RUNNING`, `STOPPING`, `FAILED` |
+| dependency | `UNKNOWN`, `AVAILABLE`, `UNAVAILABLE` |
+| data | `UNKNOWN`, `FRESH`, `STALE`, `INVALID` |
+| evidence | `UNKNOWN`, `CURRENT`, `STALE`, `INVALID` |
+| economic | `UNKNOWN`, `QUALIFIED`, `REJECTED` |
+| reconciliation | `UNKNOWN`, `EXACT`, `DISCREPANCY` |
+| kill | `UNKNOWN`, `CLEAR`, `ENGAGED` |
+| maximum authority | `observe`, `paper`, `live-bounded` |
+| exercisable authority | `none`, `observe`, `paper`, `live-bounded` |
+
+Exercisable authority is derived, never trusted. Observation requires a running service, available dependencies, fresh
+data, current evidence, exact reconciliation, and a clear kill state. Any unknown, stale, invalid, unavailable,
+discrepant, failed, or engaged required fact yields `none`. Paper or bounded-live authority additionally requires
+`QUALIFIED`; otherwise the highest possible authority is `observe`. Exercisable authority can never exceed the GitOps
+maximum.
+
+## Verification fixtures
+
+Contract tests cover valid decode, invalid calendar dates, duplicate and non-canonical symbols, invalid bounds, stale
+and future evidence, provenance/calendar mismatch, authority escalation, stored-hash mismatch, unknown versions, excess
+fields, canonical insertion-order stability, and mutation of every run-identity component.

--- a/nix/images/bayn.nix
+++ b/nix/images/bayn.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "bayn";
   packageName = "@proompteng/bayn";
   depsHash = {
-    x86_64-linux = "sha256-Q7q40NR0JwN5VZDrEI+zmST24o26kEVfXAEpOC98KBs=";
-    aarch64-linux = "sha256-iLYAqp+YJOcc08awthTnFvHTgwNMlFy5M9OsKYdh1so=";
+    x86_64-linux = "sha256-ahQym6RTy0Kx+7kJC1C2sI/BuOuu3TYE9ko5Ma1b8QA=";
+    aarch64-linux = "sha256-sJEUf14J+py5SXOhwRcFnng2+SPwyH0lxRdMYD1Gbvk=";
   };
   installFilters = [
     "@proompteng/bayn"

--- a/services/bayn/src/contracts.test.ts
+++ b/services/bayn/src/contracts.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Effect, Exit, Schema } from 'effect'
+
+import {
+  FinalizedSnapshotProvenanceSchema,
+  RunIdentitySchema,
+  StatusSnapshotSchema,
+  classifyEvidenceFreshness,
+  decodeEvaluationBounds,
+  decodeEvidenceFreshness,
+  decodeFinalizedSnapshot,
+  decodeRunIdentity,
+  decodeStatusSnapshot,
+  makeRunIdentity,
+  makeStatusSnapshot,
+} from './contracts'
+
+const sha = (character: string): string => character.repeat(64)
+
+const snapshot = {
+  schemaVersion: 'bayn.finalized-snapshot.v1' as const,
+  snapshotId: sha('a'),
+  publicationId: 'signal-adjusted-etf-2025-12-31',
+  datasetVersion: 'adjusted-etf-v1',
+  source: 'alpaca',
+  sourceFeed: 'sip',
+  adjustment: 'all',
+  calendarVersion: 'XNYS-2025a',
+  publishedAt: '2026-01-01T01:05:00.000Z',
+  finalizedAt: '2026-01-01T01:00:00.000Z',
+  firstSession: '2020-01-02',
+  lastSession: '2025-12-31',
+  asOfSession: '2025-12-31',
+  symbols: ['EEM', 'SPY'],
+  rowCount: 3_020,
+  contentHash: sha('b'),
+}
+
+const bounds = {
+  schemaVersion: 'bayn.evaluation-bounds.v1' as const,
+  dataStart: '2020-01-02',
+  dataEnd: '2025-12-31',
+  lookbackStart: '2020-01-02',
+  evaluationStart: '2021-01-04',
+  evaluationEnd: '2025-12-31',
+}
+
+const material = {
+  schemaVersion: 'bayn.run-identity.v1' as const,
+  sourceRevision: 'c'.repeat(40),
+  image: {
+    repository: 'ghcr.io/proompteng/bayn',
+    digest: `sha256:${sha('d')}`,
+  },
+  strategy: {
+    name: 'tsmom',
+    behaviorHash: sha('e'),
+    parameters: {
+      lookbacks: [21, 63, 126, 252],
+      transactionCostBps: 5,
+    },
+  },
+  finalizedSnapshot: snapshot,
+  calendarVersion: snapshot.calendarVersion,
+  bounds,
+}
+
+const expectFailure = async (effect: Effect.Effect<unknown, unknown>): Promise<void> => {
+  expect(Exit.isFailure(await Effect.runPromiseExit(effect))).toBe(true)
+}
+
+describe('Bayn contract decoding', () => {
+  test('accepts the versioned valid fixtures', async () => {
+    const decodedSnapshot = await Effect.runPromise(decodeFinalizedSnapshot(snapshot))
+    expect(decodedSnapshot).toEqual(snapshot)
+    expect(Schema.encodeSync(FinalizedSnapshotProvenanceSchema)(decodedSnapshot)).toEqual(snapshot)
+    expect(await Effect.runPromise(decodeEvaluationBounds(bounds))).toEqual(bounds)
+
+    const freshness = {
+      schemaVersion: 'bayn.evidence-freshness.v1' as const,
+      observedAt: '2026-01-01T01:00:00.000Z',
+      validThrough: '2026-01-01T02:00:00.000Z',
+    }
+    expect(await Effect.runPromise(decodeEvidenceFreshness(freshness))).toEqual(freshness)
+    await expectFailure(
+      decodeEvidenceFreshness({
+        ...freshness,
+        observedAt: '2026-01-01T03:00:00.000Z',
+      }),
+    )
+  })
+
+  test('rejects malformed dates, duplicate symbols, and invalid bounds', async () => {
+    await expectFailure(decodeFinalizedSnapshot({ ...snapshot, firstSession: '2025-02-30' }))
+    await expectFailure(decodeFinalizedSnapshot({ ...snapshot, symbols: ['SPY', 'SPY'] }))
+    await expectFailure(decodeFinalizedSnapshot({ ...snapshot, symbols: ['SPY', 'EEM'] }))
+    await expectFailure(decodeFinalizedSnapshot({ ...snapshot, finalizedAt: '2026-01-01T01:10:00.000Z' }))
+    await expectFailure(decodeEvaluationBounds({ ...bounds, evaluationStart: '2019-12-31' }))
+    await expectFailure(decodeEvaluationBounds({ ...bounds, evaluationEnd: '2026-01-02' }))
+  })
+
+  test('rejects unknown versions and forward-incompatible fields', async () => {
+    await expectFailure(decodeFinalizedSnapshot({ ...snapshot, schemaVersion: 'bayn.finalized-snapshot.v2' }))
+    await expectFailure(decodeFinalizedSnapshot({ ...snapshot, futureField: true }))
+  })
+})
+
+describe('Bayn run identity', () => {
+  test('is stable across object insertion order', async () => {
+    const baseline = makeRunIdentity(material)
+    const reordered = makeRunIdentity({
+      ...material,
+      strategy: {
+        ...material.strategy,
+        parameters: {
+          transactionCostBps: 5,
+          lookbacks: [21, 63, 126, 252],
+        },
+      },
+    })
+
+    expect(reordered.runId).toBe(baseline.runId)
+    expect(await Effect.runPromise(decodeRunIdentity(baseline))).toEqual(baseline)
+    expect(Schema.encodeSync(RunIdentitySchema)(baseline)).toEqual(baseline)
+  })
+
+  test('binds every required identity component', () => {
+    const baseline = makeRunIdentity(material).runId
+    const variants = [
+      { ...material, sourceRevision: 'f'.repeat(40) },
+      { ...material, image: { ...material.image, digest: `sha256:${sha('1')}` } },
+      { ...material, strategy: { ...material.strategy, behaviorHash: sha('2') } },
+      { ...material, strategy: { ...material.strategy, parameters: { lookbacks: [21], transactionCostBps: 5 } } },
+      { ...material, finalizedSnapshot: { ...snapshot, contentHash: sha('3') } },
+      { ...material, bounds: { ...bounds, evaluationEnd: '2025-12-30' } },
+      {
+        ...material,
+        finalizedSnapshot: { ...snapshot, calendarVersion: 'XNYS-2025b' },
+        calendarVersion: 'XNYS-2025b',
+      },
+    ] as const
+
+    for (const variant of variants) expect(makeRunIdentity(variant).runId).not.toBe(baseline)
+  })
+
+  test('rejects snapshot, calendar, bound, and persisted-hash mismatches', async () => {
+    expect(() => makeRunIdentity({ ...material, calendarVersion: 'XNYS-2025b' })).toThrow()
+    expect(() =>
+      makeRunIdentity({
+        ...material,
+        bounds: { ...bounds, dataEnd: '2026-01-02', evaluationEnd: '2026-01-02' },
+      }),
+    ).toThrow()
+
+    const identity = makeRunIdentity(material)
+    await expectFailure(decodeRunIdentity({ ...identity, runId: sha('9') }))
+    await expectFailure(decodeRunIdentity({ ...identity, image: { ...identity.image, futureField: true } }))
+    expect(() =>
+      makeRunIdentity({
+        ...material,
+        strategy: { ...material.strategy, parameters: { unsupported: undefined } },
+      }),
+    ).toThrow()
+  })
+})
+
+describe('Bayn evidence and authority state', () => {
+  const healthy = {
+    observedAt: '2026-01-01T01:30:00.000Z',
+    operational: 'RUNNING' as const,
+    dependency: 'AVAILABLE' as const,
+    data: 'FRESH' as const,
+    evidence: 'CURRENT' as const,
+    economic: 'QUALIFIED' as const,
+    reconciliation: 'EXACT' as const,
+    kill: 'CLEAR' as const,
+  }
+
+  test('classifies freshness from an explicit clock value', () => {
+    const freshness = {
+      schemaVersion: 'bayn.evidence-freshness.v1' as const,
+      observedAt: '2026-01-01T01:00:00.000Z',
+      validThrough: '2026-01-01T02:00:00.000Z',
+    }
+
+    expect(classifyEvidenceFreshness(freshness, '2026-01-01T01:30:00.000Z')).toBe('CURRENT')
+    expect(classifyEvidenceFreshness(freshness, '2026-01-01T03:00:00.000Z')).toBe('STALE')
+    expect(classifyEvidenceFreshness(freshness, '2026-01-01T00:30:00.000Z')).toBe('INVALID')
+  })
+
+  test('derives exercisable authority and fails closed on stale or unknown facts', async () => {
+    const paper = makeStatusSnapshot({ ...healthy, maximumAuthority: 'paper' })
+    expect(paper.exercisableAuthority).toBe('paper')
+    expect(Schema.encodeSync(StatusSnapshotSchema)(paper)).toEqual(paper)
+
+    const stale = makeStatusSnapshot({ ...healthy, evidence: 'STALE', maximumAuthority: 'paper' })
+    const unknown = makeStatusSnapshot({ ...healthy, dependency: 'UNKNOWN', maximumAuthority: 'paper' })
+    const killed = makeStatusSnapshot({ ...healthy, kill: 'ENGAGED', maximumAuthority: 'paper' })
+    expect(stale.exercisableAuthority).toBe('none')
+    expect(unknown.exercisableAuthority).toBe('none')
+    expect(killed.exercisableAuthority).toBe('none')
+
+    await expectFailure(decodeStatusSnapshot({ ...stale, exercisableAuthority: 'paper' }))
+    await expectFailure(decodeStatusSnapshot({ ...paper, exercisableAuthority: 'live-bounded' }))
+    await expectFailure(decodeStatusSnapshot({ ...paper, dependency: 'PARTIAL' }))
+  })
+
+  test('keeps economic state separate from safe observation', () => {
+    const rejected = makeStatusSnapshot({
+      ...healthy,
+      economic: 'REJECTED',
+      maximumAuthority: 'paper',
+    })
+    expect(rejected.exercisableAuthority).toBe('observe')
+
+    const observeOnly = makeStatusSnapshot({
+      ...healthy,
+      maximumAuthority: 'observe',
+    })
+    expect(observeOnly.exercisableAuthority).toBe('observe')
+  })
+})

--- a/services/bayn/src/contracts.ts
+++ b/services/bayn/src/contracts.ts
@@ -1,0 +1,284 @@
+import { Schema } from 'effect'
+
+import { canonicalHashV1, canonicalJsonV1 } from './hash'
+
+const StrictParseOptions = { onExcessProperty: 'error' } as const
+
+const isIsoDate = (value: string): boolean => {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false
+  const date = new Date(`${value}T00:00:00.000Z`)
+  return !Number.isNaN(date.getTime()) && date.toISOString().slice(0, 10) === value
+}
+
+const isUtcInstant = (value: string): boolean => {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(value)) return false
+  const date = new Date(value)
+  return !Number.isNaN(date.getTime()) && date.toISOString() === value
+}
+
+const canCanonicalize = (value: unknown): boolean => {
+  try {
+    canonicalJsonV1(value)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const NonEmptyString = Schema.String.check(
+  Schema.makeFilter((value: string) => value.length > 0 && value.trim() === value, {
+    expected: 'a non-empty string without surrounding whitespace',
+  }),
+)
+const IsoDate = Schema.String.check(Schema.makeFilter(isIsoDate, { expected: 'a valid ISO date (YYYY-MM-DD)' }))
+const UtcInstant = Schema.String.check(
+  Schema.makeFilter(isUtcInstant, { expected: 'a canonical UTC instant (YYYY-MM-DDTHH:mm:ss.sssZ)' }),
+)
+const Sha256 = Schema.String.check(Schema.isPattern(/^[a-f0-9]{64}$/))
+const ImageDigest = Schema.String.check(Schema.isPattern(/^sha256:[a-f0-9]{64}$/))
+const SourceRevision = Schema.String.check(Schema.isPattern(/^(?:[a-f0-9]{40}|[a-f0-9]{64})$/))
+const PositiveInteger = Schema.Int.check(Schema.isGreaterThan(0))
+const SymbolName = Schema.String.check(Schema.isPattern(/^[A-Z][A-Z0-9.-]{0,15}$/))
+const CanonicalJson = Schema.Unknown.check(Schema.makeFilter(canCanonicalize, { expected: 'a canonical JSON value' }))
+
+const FinalizedSnapshotBase = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.finalized-snapshot.v1'),
+  snapshotId: Sha256,
+  publicationId: NonEmptyString,
+  datasetVersion: NonEmptyString,
+  source: NonEmptyString,
+  sourceFeed: NonEmptyString,
+  adjustment: NonEmptyString,
+  calendarVersion: NonEmptyString,
+  publishedAt: UtcInstant,
+  finalizedAt: UtcInstant,
+  firstSession: IsoDate,
+  lastSession: IsoDate,
+  asOfSession: IsoDate,
+  symbols: Schema.Array(SymbolName).check(Schema.isMinLength(1)),
+  rowCount: PositiveInteger,
+  contentHash: Sha256,
+})
+
+export const FinalizedSnapshotProvenanceSchema = FinalizedSnapshotBase.check(
+  Schema.makeFilter((snapshot: typeof FinalizedSnapshotBase.Type) => {
+    const issues: Schema.FilterIssue[] = []
+    if (snapshot.firstSession > snapshot.lastSession) {
+      issues.push({ path: ['firstSession'], issue: 'must not be after lastSession' })
+    }
+    if (snapshot.asOfSession !== snapshot.lastSession) {
+      issues.push({ path: ['asOfSession'], issue: 'must equal lastSession for a finalized snapshot' })
+    }
+    if (snapshot.finalizedAt > snapshot.publishedAt) {
+      issues.push({ path: ['finalizedAt'], issue: 'must not be after publishedAt' })
+    }
+    if (snapshot.rowCount < snapshot.symbols.length) {
+      issues.push({ path: ['rowCount'], issue: 'must contain at least one row per symbol' })
+    }
+    const canonicalSymbols = [...new Set(snapshot.symbols)].sort()
+    if (canonicalSymbols.length !== snapshot.symbols.length) {
+      issues.push({ path: ['symbols'], issue: 'must not contain duplicate symbols' })
+    } else if (canonicalSymbols.some((symbol, index) => symbol !== snapshot.symbols[index])) {
+      issues.push({ path: ['symbols'], issue: 'must be sorted in canonical order' })
+    }
+    return issues
+  }),
+)
+export type FinalizedSnapshotProvenance = typeof FinalizedSnapshotProvenanceSchema.Type
+
+const EvaluationBoundsBase = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.evaluation-bounds.v1'),
+  dataStart: IsoDate,
+  dataEnd: IsoDate,
+  lookbackStart: IsoDate,
+  evaluationStart: IsoDate,
+  evaluationEnd: IsoDate,
+})
+
+export const EvaluationBoundsSchema = EvaluationBoundsBase.check(
+  Schema.makeFilter((bounds: typeof EvaluationBoundsBase.Type) => {
+    const issues: Schema.FilterIssue[] = []
+    if (bounds.dataStart > bounds.dataEnd) {
+      issues.push({ path: ['dataStart'], issue: 'must not be after dataEnd' })
+    }
+    if (bounds.lookbackStart < bounds.dataStart) {
+      issues.push({ path: ['lookbackStart'], issue: 'must not precede dataStart' })
+    }
+    if (bounds.evaluationStart < bounds.lookbackStart) {
+      issues.push({ path: ['evaluationStart'], issue: 'must not precede lookbackStart' })
+    }
+    if (bounds.evaluationEnd < bounds.evaluationStart) {
+      issues.push({ path: ['evaluationEnd'], issue: 'must not precede evaluationStart' })
+    }
+    if (bounds.evaluationEnd > bounds.dataEnd) {
+      issues.push({ path: ['evaluationEnd'], issue: 'must not follow dataEnd' })
+    }
+    return issues
+  }),
+)
+export type EvaluationBounds = typeof EvaluationBoundsSchema.Type
+
+const RunIdentityFields = {
+  schemaVersion: Schema.Literal('bayn.run-identity.v1'),
+  sourceRevision: SourceRevision,
+  image: Schema.Struct({
+    repository: NonEmptyString,
+    digest: ImageDigest,
+  }),
+  strategy: Schema.Struct({
+    name: NonEmptyString,
+    behaviorHash: Sha256,
+    parameters: CanonicalJson,
+  }),
+  finalizedSnapshot: FinalizedSnapshotProvenanceSchema,
+  calendarVersion: NonEmptyString,
+  bounds: EvaluationBoundsSchema,
+} as const
+
+const RunIdentityMaterialBase = Schema.Struct(RunIdentityFields)
+
+const runIdentityMaterialIssues = (material: typeof RunIdentityMaterialBase.Type): readonly Schema.FilterIssue[] => {
+  const issues: Schema.FilterIssue[] = []
+  if (material.calendarVersion !== material.finalizedSnapshot.calendarVersion) {
+    issues.push({ path: ['calendarVersion'], issue: 'must match finalizedSnapshot.calendarVersion' })
+  }
+  if (material.bounds.dataStart < material.finalizedSnapshot.firstSession) {
+    issues.push({ path: ['bounds', 'dataStart'], issue: 'is outside the finalized snapshot' })
+  }
+  if (material.bounds.dataEnd > material.finalizedSnapshot.asOfSession) {
+    issues.push({ path: ['bounds', 'dataEnd'], issue: 'is outside the finalized snapshot' })
+  }
+  return issues
+}
+
+export const RunIdentityMaterialSchema = RunIdentityMaterialBase.check(Schema.makeFilter(runIdentityMaterialIssues))
+export type RunIdentityMaterial = typeof RunIdentityMaterialSchema.Type
+
+const RunIdentityBase = Schema.Struct({ ...RunIdentityFields, runId: Sha256 })
+
+export const RunIdentitySchema = RunIdentityBase.check(
+  Schema.makeFilter((identity: typeof RunIdentityBase.Type) => {
+    const { runId, ...material } = identity
+    const issues = [...runIdentityMaterialIssues(material)]
+    if (runId !== canonicalHashV1(material)) {
+      issues.push({ path: ['runId'], issue: 'does not match the identity material' })
+    }
+    return issues
+  }),
+)
+export type RunIdentity = typeof RunIdentitySchema.Type
+
+const EvidenceFreshnessBase = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.evidence-freshness.v1'),
+  observedAt: UtcInstant,
+  validThrough: UtcInstant,
+})
+
+export const EvidenceFreshnessSchema = EvidenceFreshnessBase.check(
+  Schema.makeFilter(
+    (freshness: typeof EvidenceFreshnessBase.Type) =>
+      freshness.observedAt <= freshness.validThrough ||
+      ({ path: ['validThrough'], issue: 'must not precede observedAt' } as const),
+  ),
+)
+export type EvidenceFreshness = typeof EvidenceFreshnessSchema.Type
+
+export const OperationalStateSchema = Schema.Literals(['STARTING', 'RUNNING', 'STOPPING', 'FAILED'])
+export const DependencyStateSchema = Schema.Literals(['UNKNOWN', 'AVAILABLE', 'UNAVAILABLE'])
+export const DataStateSchema = Schema.Literals(['UNKNOWN', 'FRESH', 'STALE', 'INVALID'])
+export const EvidenceStateSchema = Schema.Literals(['UNKNOWN', 'CURRENT', 'STALE', 'INVALID'])
+export const EconomicStateSchema = Schema.Literals(['UNKNOWN', 'QUALIFIED', 'REJECTED'])
+export const ReconciliationStateSchema = Schema.Literals(['UNKNOWN', 'EXACT', 'DISCREPANCY'])
+export const KillStateSchema = Schema.Literals(['UNKNOWN', 'CLEAR', 'ENGAGED'])
+export const MaximumAuthoritySchema = Schema.Literals(['observe', 'paper', 'live-bounded'])
+export const ExercisableAuthoritySchema = Schema.Literals(['none', 'observe', 'paper', 'live-bounded'])
+
+export type OperationalState = typeof OperationalStateSchema.Type
+export type DependencyState = typeof DependencyStateSchema.Type
+export type DataState = typeof DataStateSchema.Type
+export type EvidenceState = typeof EvidenceStateSchema.Type
+export type EconomicState = typeof EconomicStateSchema.Type
+export type ReconciliationState = typeof ReconciliationStateSchema.Type
+export type KillState = typeof KillStateSchema.Type
+export type MaximumAuthority = typeof MaximumAuthoritySchema.Type
+export type ExercisableAuthority = typeof ExercisableAuthoritySchema.Type
+
+export interface StatusAxes {
+  readonly operational: OperationalState
+  readonly dependency: DependencyState
+  readonly data: DataState
+  readonly evidence: EvidenceState
+  readonly economic: EconomicState
+  readonly reconciliation: ReconciliationState
+  readonly kill: KillState
+}
+
+const deriveExercisableAuthority = (
+  state: StatusAxes & { readonly maximumAuthority: MaximumAuthority },
+): ExercisableAuthority => {
+  const canObserve =
+    state.operational === 'RUNNING' &&
+    state.dependency === 'AVAILABLE' &&
+    state.data === 'FRESH' &&
+    state.evidence === 'CURRENT' &&
+    state.reconciliation === 'EXACT' &&
+    state.kill === 'CLEAR'
+  if (!canObserve) return 'none'
+  if (state.maximumAuthority === 'observe' || state.economic !== 'QUALIFIED') return 'observe'
+  return state.maximumAuthority
+}
+
+const StatusSnapshotBase = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.status.v1'),
+  observedAt: UtcInstant,
+  operational: OperationalStateSchema,
+  dependency: DependencyStateSchema,
+  data: DataStateSchema,
+  evidence: EvidenceStateSchema,
+  economic: EconomicStateSchema,
+  reconciliation: ReconciliationStateSchema,
+  kill: KillStateSchema,
+  maximumAuthority: MaximumAuthoritySchema,
+  exercisableAuthority: ExercisableAuthoritySchema,
+})
+
+export const StatusSnapshotSchema = StatusSnapshotBase.check(
+  Schema.makeFilter(
+    (state: typeof StatusSnapshotBase.Type) =>
+      state.exercisableAuthority === deriveExercisableAuthority(state) ||
+      ({
+        path: ['exercisableAuthority'],
+        issue: `must be ${deriveExercisableAuthority(state)} for the reported state`,
+      } as const),
+  ),
+)
+export type StatusSnapshot = typeof StatusSnapshotSchema.Type
+export type StatusSnapshotInput = Omit<StatusSnapshot, 'schemaVersion' | 'exercisableAuthority'>
+
+export const decodeFinalizedSnapshot = Schema.decodeUnknownEffect(FinalizedSnapshotProvenanceSchema, StrictParseOptions)
+export const decodeEvaluationBounds = Schema.decodeUnknownEffect(EvaluationBoundsSchema, StrictParseOptions)
+export const decodeRunIdentity = Schema.decodeUnknownEffect(RunIdentitySchema, StrictParseOptions)
+export const decodeEvidenceFreshness = Schema.decodeUnknownEffect(EvidenceFreshnessSchema, StrictParseOptions)
+export const decodeStatusSnapshot = Schema.decodeUnknownEffect(StatusSnapshotSchema, StrictParseOptions)
+
+const decodeRunIdentityMaterialSync = Schema.decodeUnknownSync(RunIdentityMaterialSchema, StrictParseOptions)
+const decodeRunIdentitySync = Schema.decodeUnknownSync(RunIdentitySchema, StrictParseOptions)
+const decodeStatusSnapshotSync = Schema.decodeUnknownSync(StatusSnapshotSchema, StrictParseOptions)
+
+export const makeRunIdentity = (input: RunIdentityMaterial): RunIdentity => {
+  const material = decodeRunIdentityMaterialSync(input)
+  return decodeRunIdentitySync({ ...material, runId: canonicalHashV1(material) })
+}
+
+export const classifyEvidenceFreshness = (freshness: EvidenceFreshness, now: string): EvidenceState => {
+  if (!isUtcInstant(now)) throw new TypeError('now must be a canonical UTC instant')
+  if (now < freshness.observedAt) return 'INVALID'
+  return now <= freshness.validThrough ? 'CURRENT' : 'STALE'
+}
+
+export const makeStatusSnapshot = (input: StatusSnapshotInput): StatusSnapshot =>
+  decodeStatusSnapshotSync({
+    schemaVersion: 'bayn.status.v1',
+    ...input,
+    exercisableAuthority: deriveExercisableAuthority(input),
+  })

--- a/services/bayn/src/hash.test.ts
+++ b/services/bayn/src/hash.test.ts
@@ -10,6 +10,7 @@ describe('canonical hashing', () => {
 
   test('uses deterministic UTF-16 key order and normalizes negative zero', () => {
     expect(canonicalJsonV1({ '\u20ac': 1, '\r': 2, a: -0, '\ud83d\ude00': 3 })).toBe('{"\\r":2,"a":0,"€":1,"😀":3}')
+    expect(canonicalJsonV1({ nested: { '2': 2, '10': 1 } })).toBe('{"nested":{"10":1,"2":2}}')
     expect(canonicalHashV1({ b: 2, a: 1 })).toBe(canonicalHashV1({ a: 1, b: 2 }))
   })
 

--- a/services/bayn/src/hash.test.ts
+++ b/services/bayn/src/hash.test.ts
@@ -1,11 +1,35 @@
 import { describe, expect, test } from 'bun:test'
 
-import { canonicalJson, hashObject, stableU128, stableU64 } from './hash'
+import { canonicalHashV1, canonicalJson, canonicalJsonV1, hashObject, stableU128, stableU64 } from './hash'
 
 describe('canonical hashing', () => {
   test('does not depend on object insertion order', () => {
     expect(canonicalJson({ z: 1, a: { y: 2, x: 3 } })).toBe(canonicalJson({ a: { x: 3, y: 2 }, z: 1 }))
     expect(hashObject({ b: 2, a: 1 })).toBe(hashObject({ a: 1, b: 2 }))
+  })
+
+  test('uses deterministic UTF-16 key order and normalizes negative zero', () => {
+    expect(canonicalJsonV1({ '\u20ac': 1, '\r': 2, a: -0, '\ud83d\ude00': 3 })).toBe('{"\\r":2,"a":0,"€":1,"😀":3}')
+    expect(canonicalHashV1({ b: 2, a: 1 })).toBe(canonicalHashV1({ a: 1, b: 2 }))
+  })
+
+  test('rejects values that JSON would silently discard or coerce', () => {
+    expect(() => canonicalJsonV1({ missing: undefined })).toThrow('non-JSON undefined')
+    expect(() => canonicalJsonV1({ invalid: Number.NaN })).toThrow('non-finite number')
+    expect(() => canonicalJsonV1({ invalid: Number.POSITIVE_INFINITY })).toThrow('non-finite number')
+    expect(() => canonicalJsonV1({ invalid: 1n })).toThrow('non-JSON bigint')
+    expect(() => canonicalJsonV1(new Date('2026-01-01T00:00:00.000Z'))).toThrow('plain JSON objects')
+    const sparse: unknown[] = []
+    sparse.length = 1
+    expect(() => canonicalJsonV1(sparse)).toThrow('dense array')
+
+    const accessor = [1]
+    Object.defineProperty(accessor, '0', { enumerable: true, get: () => 1 })
+    expect(() => canonicalJsonV1(accessor)).toThrow('enumerable data property')
+
+    const cyclic: Record<string, unknown> = {}
+    cyclic.self = cyclic
+    expect(() => canonicalJsonV1(cyclic)).toThrow('cycle')
   })
 
   test('produces stable non-zero TigerBeetle identifiers', () => {

--- a/services/bayn/src/hash.ts
+++ b/services/bayn/src/hash.ts
@@ -20,9 +20,6 @@ export const sha256 = (value: string): string => createHash('sha256').update(val
 
 export const hashObject = (value: unknown): string => sha256(canonicalJson(value))
 
-type JsonPrimitive = null | boolean | number | string
-type JsonValue = JsonPrimitive | readonly JsonValue[] | { readonly [key: string]: JsonValue }
-
 const compareUtf16 = (left: string, right: string): number => (left < right ? -1 : left > right ? 1 : 0)
 
 const hasLoneSurrogate = (value: string): boolean => {
@@ -39,15 +36,16 @@ const hasLoneSurrogate = (value: string): boolean => {
   return false
 }
 
-const canonicalizeValue = (value: unknown, ancestors: Set<object>, path: string): JsonValue => {
-  if (value === null || typeof value === 'boolean') return value
+const serializeCanonicalValue = (value: unknown, ancestors: Set<object>, path: string): string => {
+  if (value === null) return 'null'
+  if (typeof value === 'boolean') return value ? 'true' : 'false'
   if (typeof value === 'string') {
     if (hasLoneSurrogate(value)) throw new TypeError(`${path} contains an invalid Unicode surrogate`)
-    return value
+    return JSON.stringify(value)
   }
   if (typeof value === 'number') {
     if (!Number.isFinite(value)) throw new TypeError(`${path} contains a non-finite number`)
-    return Object.is(value, -0) ? 0 : value
+    return JSON.stringify(Object.is(value, -0) ? 0 : value)
   }
   if (Array.isArray(value)) {
     if (ancestors.has(value)) throw new TypeError(`${path} contains a cycle`)
@@ -63,16 +61,21 @@ const canonicalizeValue = (value: unknown, ancestors: Set<object>, path: string)
     ) {
       throw new TypeError(`${path} must be a dense array without custom properties`)
     }
-    for (const key of keys) {
+    const values = keys.map((key) => {
       const descriptor = Object.getOwnPropertyDescriptor(value, key)
       if (!descriptor?.enumerable || !('value' in descriptor)) {
         throw new TypeError(`${path}[${key}] must be an enumerable data property`)
       }
-    }
+      return descriptor.value
+    })
     ancestors.add(value)
-    const canonical = value.map((nested, index) => canonicalizeValue(nested, ancestors, `${path}[${index}]`))
-    ancestors.delete(value)
-    return canonical
+    try {
+      return `[${values
+        .map((nested, index) => serializeCanonicalValue(nested, ancestors, `${path}[${index}]`))
+        .join(',')}]`
+    } finally {
+      ancestors.delete(value)
+    }
   }
   if (typeof value === 'object') {
     if (ancestors.has(value)) throw new TypeError(`${path} contains a cycle`)
@@ -82,26 +85,30 @@ const canonicalizeValue = (value: unknown, ancestors: Set<object>, path: string)
     }
     const keys = Reflect.ownKeys(value)
     if (keys.some((key) => typeof key !== 'string')) throw new TypeError(`${path} contains a symbol key`)
-    for (const key of keys as string[]) {
+    const entries = (keys as string[]).map((key) => {
       if (hasLoneSurrogate(key)) throw new TypeError(`${path} contains an invalid Unicode key`)
       const descriptor = Object.getOwnPropertyDescriptor(value, key)
       if (!descriptor?.enumerable || !('value' in descriptor)) {
         throw new TypeError(`${path}.${key} must be an enumerable data property`)
       }
-    }
+      return [key, descriptor.value] as const
+    })
     ancestors.add(value)
-    const canonical = Object.fromEntries(
-      (keys as string[])
-        .sort(compareUtf16)
-        .map((key) => [key, canonicalizeValue((value as Record<string, unknown>)[key], ancestors, `${path}.${key}`)]),
-    )
-    ancestors.delete(value)
-    return canonical
+    try {
+      return `{${entries
+        .sort(([left], [right]) => compareUtf16(left, right))
+        .map(
+          ([key, nested]) => `${JSON.stringify(key)}:${serializeCanonicalValue(nested, ancestors, `${path}.${key}`)}`,
+        )
+        .join(',')}}`
+    } finally {
+      ancestors.delete(value)
+    }
   }
   throw new TypeError(`${path} contains a non-JSON ${typeof value} value`)
 }
 
-export const canonicalJsonV1 = (value: unknown): string => JSON.stringify(canonicalizeValue(value, new Set(), '$'))
+export const canonicalJsonV1 = (value: unknown): string => serializeCanonicalValue(value, new Set(), '$')
 
 export const canonicalHashV1 = (value: unknown): string => sha256(canonicalJsonV1(value))
 

--- a/services/bayn/src/hash.ts
+++ b/services/bayn/src/hash.ts
@@ -1,24 +1,109 @@
 import { createHash } from 'node:crypto'
 
-const canonicalizeValue = (value: unknown): unknown => {
+const canonicalizeLegacyValue = (value: unknown): unknown => {
   if (Array.isArray(value)) {
-    return value.map(canonicalizeValue)
+    return value.map(canonicalizeLegacyValue)
   }
   if (value !== null && typeof value === 'object') {
     return Object.fromEntries(
       Object.entries(value as Record<string, unknown>)
         .sort(([left], [right]) => left.localeCompare(right))
-        .map(([key, nested]) => [key, canonicalizeValue(nested)]),
+        .map(([key, nested]) => [key, canonicalizeLegacyValue(nested)]),
     )
   }
   return value
 }
 
-export const canonicalJson = (value: unknown): string => JSON.stringify(canonicalizeValue(value))
+export const canonicalJson = (value: unknown): string => JSON.stringify(canonicalizeLegacyValue(value))
 
 export const sha256 = (value: string): string => createHash('sha256').update(value).digest('hex')
 
 export const hashObject = (value: unknown): string => sha256(canonicalJson(value))
+
+type JsonPrimitive = null | boolean | number | string
+type JsonValue = JsonPrimitive | readonly JsonValue[] | { readonly [key: string]: JsonValue }
+
+const compareUtf16 = (left: string, right: string): number => (left < right ? -1 : left > right ? 1 : 0)
+
+const hasLoneSurrogate = (value: string): boolean => {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index)
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1)
+      if (next < 0xdc00 || next > 0xdfff) return true
+      index += 1
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return true
+    }
+  }
+  return false
+}
+
+const canonicalizeValue = (value: unknown, ancestors: Set<object>, path: string): JsonValue => {
+  if (value === null || typeof value === 'boolean') return value
+  if (typeof value === 'string') {
+    if (hasLoneSurrogate(value)) throw new TypeError(`${path} contains an invalid Unicode surrogate`)
+    return value
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new TypeError(`${path} contains a non-finite number`)
+    return Object.is(value, -0) ? 0 : value
+  }
+  if (Array.isArray(value)) {
+    if (ancestors.has(value)) throw new TypeError(`${path} contains a cycle`)
+    const keys = Object.keys(value)
+    if (keys.length !== value.length || keys.some((key, index) => key !== String(index))) {
+      throw new TypeError(`${path} must be a dense array without custom properties`)
+    }
+    if (
+      Reflect.ownKeys(value).some(
+        (key) =>
+          key !== 'length' && (typeof key !== 'string' || !/^(?:0|[1-9]\d*)$/.test(key) || Number(key) >= value.length),
+      )
+    ) {
+      throw new TypeError(`${path} must be a dense array without custom properties`)
+    }
+    for (const key of keys) {
+      const descriptor = Object.getOwnPropertyDescriptor(value, key)
+      if (!descriptor?.enumerable || !('value' in descriptor)) {
+        throw new TypeError(`${path}[${key}] must be an enumerable data property`)
+      }
+    }
+    ancestors.add(value)
+    const canonical = value.map((nested, index) => canonicalizeValue(nested, ancestors, `${path}[${index}]`))
+    ancestors.delete(value)
+    return canonical
+  }
+  if (typeof value === 'object') {
+    if (ancestors.has(value)) throw new TypeError(`${path} contains a cycle`)
+    const prototype = Object.getPrototypeOf(value)
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new TypeError(`${path} must contain only plain JSON objects`)
+    }
+    const keys = Reflect.ownKeys(value)
+    if (keys.some((key) => typeof key !== 'string')) throw new TypeError(`${path} contains a symbol key`)
+    for (const key of keys as string[]) {
+      if (hasLoneSurrogate(key)) throw new TypeError(`${path} contains an invalid Unicode key`)
+      const descriptor = Object.getOwnPropertyDescriptor(value, key)
+      if (!descriptor?.enumerable || !('value' in descriptor)) {
+        throw new TypeError(`${path}.${key} must be an enumerable data property`)
+      }
+    }
+    ancestors.add(value)
+    const canonical = Object.fromEntries(
+      (keys as string[])
+        .sort(compareUtf16)
+        .map((key) => [key, canonicalizeValue((value as Record<string, unknown>)[key], ancestors, `${path}.${key}`)]),
+    )
+    ancestors.delete(value)
+    return canonical
+  }
+  throw new TypeError(`${path} contains a non-JSON ${typeof value} value`)
+}
+
+export const canonicalJsonV1 = (value: unknown): string => JSON.stringify(canonicalizeValue(value, new Set(), '$'))
+
+export const canonicalHashV1 = (value: unknown): string => sha256(canonicalJsonV1(value))
 
 export const stableU128 = (...parts: readonly string[]): bigint => {
   const bytes = createHash('sha256').update(parts.join('\u001f')).digest().subarray(0, 16)


### PR DESCRIPTION
## Summary

- Add strict Effect Schema v1 contracts for finalized Signal snapshots, evaluation bounds, run identity, evidence freshness, independent status axes, and authority derivation.
- Add a versioned canonical JSON/SHA-256 identity path that rejects ambiguous JSON values while preserving all legacy Bayn hashes and runtime behavior.
- Document contract semantics, target architecture boundaries, failure rules, and adoption status.
- Refresh the architecture-specific Nix dependency hashes from the CI-produced fixed-output derivations.

## Related Issues

- [PROOMPT-355](https://linear.app/proompteng/issue/PROOMPT-355/define-bayn-evidence-status-provenance-and-finalized-snapshot)

## Testing

- `bun test src/contracts.test.ts src/hash.test.ts`
- `bun run --filter @proompteng/bayn test` — 37 tests, 139 assertions; run with localhost binding enabled for the existing HTTP lifecycle tests.
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- `git diff --check`
- Local Nix evaluation was unavailable because the desktop Nix daemon socket refused connections; the per-architecture image jobs are the authoritative Nix validation.

## Breaking Changes

None. The new contracts are not wired into the deployed runtime in this slice, and existing `canonicalJson` / `hashObject` behavior is unchanged.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation and follow-up adoption boundaries are updated.