### PR TITLE
chore(torghut): promote notebook image sha-e8cbb061811bf6c279581eab9bdfd1299fb5187a

### DIFF
--- a/argocd/applications/torghut/notebooks/values.yaml
+++ b/argocd/applications/torghut/notebooks/values.yaml
@@ -93,7 +93,7 @@ proxy:
 singleuser:
   image:
     name: registry.ide-newton.ts.net/lab/torghut-notebook@sha256
-    tag: '30e85c4d868f8206cd5b3087c31e00dd5c19d282c940b4594753ace5fffe0d9f'
+    tag: '97c8c88b6a6b97b647986ee85f438feb68edcd61bad1fbdd79251a1d076b9de1'
     pullPolicy: IfNotPresent
   defaultUrl: /lab/tree/work/00-system-flow.ipynb
   startTimeout: 600


### PR DESCRIPTION
## Summary

- Promote the immutable multi-architecture Torghut notebook image built from `e8cbb061811bf6c279581eab9bdfd1299fb5187a`.
- Update only the digest-pinned JupyterHub single-user image.

## Related Issues

None.

## Testing

- The source commit passed notebook fixture execution and manifest contracts.
- The release workflow verified `linux/amd64` and `linux/arm64` for `sha256:97c8c88b6a6b97b647986ee85f438feb68edcd61bad1fbdd79251a1d076b9de1`.

## Breaking Changes

None.

## Checklist

- [x] The single-user image is immutable and multi-architecture.
- [x] Promotion changes only the notebook image digest.
- [x] PVCs and read-only credentials are unchanged.