### PR TITLE
chore(bayn): promote image sha-c9b4395e1f205eb512825d2b0445614490224557

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: bayn
         app.kubernetes.io/part-of: bayn
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-20T04:40:36Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-20T08:36:14Z"
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
@@ -47,7 +47,7 @@ spec:
               protocol: TCP
           env:
             - name: BAYN_CODE_REVISION
-              value: 43b4201272832a381ab50d87da9e1715d68f06a7
+              value: c9b4395e1f205eb512825d2b0445614490224557
             - name: BAYN_RUN_ON_STARTUP
               value: "true"
             - name: BAYN_OPERATION_TIMEOUT_MS

--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -10,5 +10,5 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/bayn
     newName: registry.ide-newton.ts.net/lab/bayn
-    newTag: "sha-43b4201272832a381ab50d87da9e1715d68f06a7"
-    digest: sha256:3571b730a2f21e10a488c397b6718a9dd05ab3eba3568aa099a617d6d5c6c67e
+    newTag: "sha-c9b4395e1f205eb512825d2b0445614490224557"
+    digest: sha256:43b4b5ad4c625d66b79cede0dd0e67598ac09fe4922b4262aa7afc615881ce52


### PR DESCRIPTION
## Summary

Promote the immutable Bayn image, activate the Bayn Argo application, and bind runtime evidence to its
source commit.

- Source commit: `c9b4395e1f205eb512825d2b0445614490224557`
- Image tag: `sha-c9b4395e1f205eb512825d2b0445614490224557`
- Image digest: `sha256:43b4b5ad4c625d66b79cede0dd0e67598ac09fe4922b4262aa7afc615881ce52`

## Related Issues

PROOMPT-353

## Testing

- OCI index contains `linux/amd64` and `linux/arm64`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents exact validation.
- [x] Runtime source revision and image digest are immutable.
- [x] No broker or capital-promotion authority is introduced.