### PR TITLE
feat(bayn): verify runtime provenance

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -48,6 +48,10 @@ spec:
           env:
             - name: BAYN_CODE_REVISION
               value: 43b4201272832a381ab50d87da9e1715d68f06a7
+            - name: BAYN_IMAGE_REPOSITORY
+              value: registry.ide-newton.ts.net/lab/bayn
+            - name: BAYN_IMAGE_DIGEST
+              value: sha256:3571b730a2f21e10a488c397b6718a9dd05ab3eba3568aa099a617d6d5c6c67e
             - name: BAYN_RUN_ON_STARTUP
               value: "true"
             - name: BAYN_OPERATION_TIMEOUT_MS

--- a/docs/bayn/architecture.md
+++ b/docs/bayn/architecture.md
@@ -27,15 +27,24 @@ broker secret, or Kubernetes API token. `maxSurge: 0` prevents overlapping runti
 
 ## Reproducibility
 
-The run ID is the SHA-256 hash of:
+The executable embeds its full source revision, OCI repository, and a behavior hash derived from the reviewed strategy
+and hashing sources. Startup strictly decodes the committed TSMOM parameter JSON, hashes the decoded value with
+canonical JSON, and refuses to run when configured source/repository attribution differs from the embedded build.
+GitOps supplies the immutable image-index digest after publication. Status and the in-memory evidence envelope expose
+all of those facts and their contract versions.
 
-- the immutable image source revision;
-- the canonical protocol hash; and
+The current transitional run ID is the SHA-256 hash of:
+
+- the runtime-provenance envelope; and
 - the exact ClickHouse input-manifest hash, including an ordered content hash of all bars.
 
 Decision and fill IDs derive from canonical event payloads. TigerBeetle account and transfer IDs derive from the run ID,
 event ID, and journal leg. Repeating the same run is idempotent; a changed price, protocol, or source revision creates a
 different run namespace.
+
+This transitional identity is deliberately not `bayn.run-identity.v1`: the current ClickHouse table does not yet
+provide finalized publication provenance, an exchange-calendar version, or explicit evaluation bounds. The finalized
+snapshot and bounded-read roadmap slices must supply those facts before the target identity is used.
 
 ## Versioned contract boundary
 
@@ -45,8 +54,9 @@ authority. Unknown versions and excess fields fail closed. Run identity binds th
 digest, compiled strategy behavior hash, decoded strategy parameters, finalized snapshot, exchange-calendar version,
 and explicit bounds through canonical JSON and SHA-256.
 
-Contract availability does not mean the deployed runtime has adopted the target path. Adoption, persistence, continuous
-health, and removal of the legacy TigerBeetle dependency are separate roadmap tickets with their own rollout evidence.
+Runtime provenance and strict TSMOM parameter decoding are the first adopted contract slice. Finalized-snapshot
+identity, bounded reads, persistence, continuous health, and removal of the legacy TigerBeetle dependency remain
+separate roadmap tickets with their own rollout evidence.
 
 ## Economic test
 

--- a/docs/bayn/architecture.md
+++ b/docs/bayn/architecture.md
@@ -33,6 +33,11 @@ canonical JSON, and refuses to run when configured source/repository attribution
 GitOps supplies the immutable image-index digest after publication. Status and the in-memory evidence envelope expose
 all of those facts and their contract versions.
 
+Local package entry points remain usable through an explicit `development-configured` provenance mode. It is reported
+in HTTP status with an unverified behavior marker, forces evaluation and journaling off, and cannot override embedded
+build facts. The production Nix image does not enable that mode: absent, partial, or mismatched embedded attribution
+prevents startup.
+
 The current transitional run ID is the SHA-256 hash of:
 
 - the runtime-provenance envelope; and

--- a/docs/bayn/contracts/v1.md
+++ b/docs/bayn/contracts/v1.md
@@ -70,6 +70,12 @@ a configured source revision that differs from the executable, or a configured r
 executable. The digest is necessarily supplied after the image index is published; the release writer copies the exact
 published digest into GitOps, and rollout evidence compares the status value with the pod image reference.
 
+The standard package `dev` and `start` entry points opt into `development-configured` provenance because they do not
+produce the Nix OCI artifact. In that mode source and repository attribution come from validated Effect Config, the
+behavior hash is an explicit unverified marker, and startup evaluation and journaling are forced off. HTTP status
+reports `provenanceVerification: development-configured` outside this versioned envelope. Production is the default:
+missing or partial embedded facts fail closed, and development mode is rejected when embedded production facts exist.
+
 Runtime provenance is not the full `bayn.run-identity.v1` contract. Until finalized Signal provenance,
 exchange-calendar identity, and explicit evaluation bounds are present, Bayn labels its internal hash material as
 transitional and must not present it as completed target run identity.

--- a/docs/bayn/contracts/v1.md
+++ b/docs/bayn/contracts/v1.md
@@ -54,6 +54,26 @@ The top-level calendar version must match the snapshot. A persisted identity is 
 produces the stored run ID. Equivalent object insertion order produces the same identity; changing any bound component
 produces a different identity.
 
+## `bayn.runtime-provenance.v1`
+
+Runtime provenance is the deploy identity available before finalized snapshots and explicit evaluation bounds are
+adopted. It contains:
+
+- the full source revision embedded in the executable;
+- the configured OCI repository and immutable index digest;
+- the selected compiled strategy name and source-derived behavior hash;
+- the canonical hash and schema version of the already-decoded strategy parameters; and
+- the runtime-provenance, input-manifest, and evaluation contract versions.
+
+The build also carries the source revision and behavior hash as OCI labels. Startup rejects a malformed embedded value,
+a configured source revision that differs from the executable, or a configured repository that differs from the
+executable. The digest is necessarily supplied after the image index is published; the release writer copies the exact
+published digest into GitOps, and rollout evidence compares the status value with the pod image reference.
+
+Runtime provenance is not the full `bayn.run-identity.v1` contract. Until finalized Signal provenance,
+exchange-calendar identity, and explicit evaluation bounds are present, Bayn labels its internal hash material as
+transitional and must not present it as completed target run identity.
+
 ## `bayn.evidence-freshness.v1`
 
 Freshness contains `observedAt` and `validThrough`, with `observedAt <= validThrough`. Classification receives an

--- a/flake.nix
+++ b/flake.nix
@@ -259,7 +259,7 @@
               bun = exact.bun;
             };
             "bayn-image" = import ./nix/images/bayn.nix {
-              inherit pkgs lib nodejs;
+              inherit pkgs lib nodejs repoRevision;
               repoRoot = ./.;
               bun = exact.bun;
             };

--- a/nix/images/bayn.nix
+++ b/nix/images/bayn.nix
@@ -22,8 +22,8 @@ import ./bun-workspace-service.nix {
   serviceName = "bayn";
   packageName = "@proompteng/bayn";
   depsHash = {
-    x86_64-linux = "sha256-ahQym6RTy0Kx+7kJC1C2sI/BuOuu3TYE9ko5Ma1b8QA=";
-    aarch64-linux = "sha256-sJEUf14J+py5SXOhwRcFnng2+SPwyH0lxRdMYD1Gbvk=";
+    x86_64-linux = "sha256-ETTh/mPfj5MlszjVfMCQMDlrowBvKgbmoBTgSPLxeto=";
+    aarch64-linux = "sha256-3IQVR5Z/bsqZEnV6lxPwPeLrQTWhFx+doLGtWeci3uc=";
   };
   installFilters = [
     "@proompteng/bayn"

--- a/nix/images/bayn.nix
+++ b/nix/images/bayn.nix
@@ -2,10 +2,21 @@
   pkgs,
   lib,
   repoRoot,
+  repoRevision ? "dirty",
   bun,
   nodejs,
 }:
 
+let
+  imageRepository = "registry.ide-newton.ts.net/lab/bayn";
+  strategyBehaviorHash = builtins.hashString "sha256" (
+    "services/bayn/src/hash.ts\n"
+    + builtins.readFile ../../services/bayn/src/hash.ts
+    + "\nservices/bayn/src/strategy.ts\n"
+    + builtins.readFile ../../services/bayn/src/strategy.ts
+  );
+  buildDefine = name: value: "--define ${name}=${lib.escapeShellArg (builtins.toJSON value)}";
+in
 import ./bun-workspace-service.nix {
   inherit pkgs lib repoRoot bun nodejs;
   serviceName = "bayn";
@@ -22,7 +33,17 @@ import ./bun-workspace-service.nix {
   ];
   buildCommands = [
     "bun --cwd=services/bayn run tsc"
-    "bun --cwd=services/bayn run build"
+    (
+      "bun --cwd=services/bayn build src/index.ts src/backfill.ts --target=node "
+      + "--external tigerbeetle-node --outdir=dist "
+      + buildDefine "__BAYN_BUILD_SOURCE_REVISION__" repoRevision
+      + " "
+      + buildDefine "__BAYN_BUILD_IMAGE_REPOSITORY__" imageRepository
+      + " "
+      + buildDefine "__BAYN_BUILD_STRATEGY_BEHAVIOR_HASH__" strategyBehaviorHash
+    )
+    "grep -F -- ${lib.escapeShellArg repoRevision} services/bayn/dist/index.js"
+    "grep -F -- ${lib.escapeShellArg strategyBehaviorHash} services/bayn/dist/index.js"
   ];
   runtimeInstallPhase = ''
     mkdir -p "$out/app/services/bayn/dist" "$out/app/services/bayn/node_modules/tigerbeetle-node"
@@ -42,5 +63,9 @@ import ./bun-workspace-service.nix {
   ];
   exposedPorts = {
     "8080/tcp" = { };
+  };
+  labels = {
+    "org.opencontainers.image.revision" = repoRevision;
+    "proompteng.ai/bayn.strategy-behavior-hash" = strategyBehaviorHash;
   };
 }

--- a/nix/images/bun-workspace-service.nix
+++ b/nix/images/bun-workspace-service.nix
@@ -17,6 +17,7 @@
   dependencyClosure ? "nodeModules",
   command,
   env ? [ ],
+  labels ? { },
   extraContents ? [ ],
   exposedPorts ? { },
   workingDir ? "/app",
@@ -283,6 +284,6 @@ if returnRuntimeRoot then builtRuntimeRoot else pkgs.dockerTools.buildLayeredIma
       "org.opencontainers.image.title" = packageName;
       "org.opencontainers.image.source" = "https://github.com/proompteng/lab";
       "proompteng.ai/nix-package-attr" = "${serviceName}-image";
-    };
+    } // labels;
   };
 }

--- a/packages/scripts/src/bayn/update-manifests.test.ts
+++ b/packages/scripts/src/bayn/update-manifests.test.ts
@@ -24,7 +24,7 @@ describe('Bayn manifest promotion', () => {
     )
     writeFileSync(
       deploymentPath,
-      `metadata:\n  template:\n    metadata:\n      annotations:\n        kubectl.kubernetes.io/restartedAt: "old"\n    spec:\n      containers:\n        - env:\n            - name: BAYN_CODE_REVISION\n              value: bootstrap\n`,
+      `metadata:\n  template:\n    metadata:\n      annotations:\n        kubectl.kubernetes.io/restartedAt: "old"\n    spec:\n      containers:\n        - env:\n            - name: BAYN_CODE_REVISION\n              value: bootstrap\n            - name: BAYN_IMAGE_REPOSITORY\n              value: registry.ide-newton.ts.net/lab/bayn\n            - name: BAYN_IMAGE_DIGEST\n              value: sha256:old\n`,
     )
     writeFileSync(
       applicationSetPath,
@@ -43,6 +43,10 @@ describe('Bayn manifest promotion', () => {
     })
     expect(readFileSync(kustomizationPath, 'utf8')).toContain(`newTag: "sha-${sourceSha}"\n    digest: ${digest}`)
     expect(readFileSync(deploymentPath, 'utf8')).toContain(`value: ${sourceSha}`)
+    expect(readFileSync(deploymentPath, 'utf8')).toContain(
+      `- name: BAYN_IMAGE_REPOSITORY\n              value: registry.ide-newton.ts.net/lab/bayn`,
+    )
+    expect(readFileSync(deploymentPath, 'utf8')).toContain(`- name: BAYN_IMAGE_DIGEST\n              value: ${digest}`)
     expect(readFileSync(deploymentPath, 'utf8')).toContain('restartedAt: "2026-07-19T10:00:00Z"')
     expect(readFileSync(applicationSetPath, 'utf8')).toContain(
       '- name: bayn\n                path: argocd/applications/bayn\n                enabled: "true"',

--- a/packages/scripts/src/bayn/update-manifests.ts
+++ b/packages/scripts/src/bayn/update-manifests.ts
@@ -51,6 +51,12 @@ export const updateBaynManifests = (options: UpdateBaynManifestOptions): void =>
   )
   updatedDeployment = replaceExactlyOnce(
     updatedDeployment,
+    /(            - name: BAYN_IMAGE_DIGEST\n              value: )[^\n]+/,
+    `$1${options.digest}`,
+    'BAYN_IMAGE_DIGEST value',
+  )
+  updatedDeployment = replaceExactlyOnce(
+    updatedDeployment,
     /(        kubectl\.kubernetes\.io\/restartedAt: )[^\n]+/,
     `$1${JSON.stringify(options.rolloutTimestamp)}`,
     'Bayn rollout annotation',

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -1450,11 +1450,14 @@ describe('native OCI build workflows', () => {
   })
 
   it('keeps Bumba image content independent from GitOps-only release commits', () => {
+    const bumbaFlakeBlock = flake.match(
+      /"bumba-image"\s*=\s*import \.\/nix\/images\/bumba\.nix \{([\s\S]*?)\n\s*\};/m,
+    )?.[1]
+
     expect(bumbaImageModule).not.toContain('repoRevision')
     expect(bumbaImageModule).not.toContain('TEMPORAL_WORKER_BUILD_ID')
-    expect(flake).not.toContain(
-      'inherit pkgs lib nodejs repoRevision;\n              repoRoot = ./.;\n              bun = exact.bun;',
-    )
+    expect(bumbaFlakeBlock).toBeDefined()
+    expect(bumbaFlakeBlock).not.toContain('repoRevision')
     expect(readRepoFile('argocd/applications/bumba/deployment.yaml')).toContain('TEMPORAL_WORKER_BUILD_ID')
   })
 

--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -13,8 +13,12 @@ and journals the resulting simulation to TigerBeetle. It contains no broker clie
   of the Deployment.
 - The composition root selects one strategy capability. TSMOM is the first implementation and owns its protocol and
   universe; the HTTP and startup lifecycle do not depend on TSMOM directly.
-- The protocol is committed at `protocols/tsmom-v1.json`. A run ID binds the code revision, protocol hash, and exact
-  ClickHouse input-manifest hash.
+- The protocol is committed at `protocols/tsmom-v1.json` and runtime-decoded with Effect Schema before use. JSON holds
+  immutable parameters only; the reviewed TypeScript implementation remains compiled into the image.
+- The executable embeds source, repository, and strategy-behavior identity. Startup verifies configured attribution,
+  and status exposes the promoted image digest, parameter hash, and contract versions.
+- The transitional run ID binds runtime provenance and the exact ClickHouse input-manifest hash. It remains distinct
+  from the target finalized-snapshot run identity until bounded Signal publications are adopted.
 - Signals are formed at a month-end close and may execute only at the next common session open.
 - A run becomes ready only after ClickHouse validation, evaluation, TigerBeetle journal creation, and exact
   reconciliation. Strategy rejection is an auditable economic `FAIL_CLOSED`; dependency or accounting failure keeps

--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -17,6 +17,10 @@ and journals the resulting simulation to TigerBeetle. It contains no broker clie
   immutable parameters only; the reviewed TypeScript implementation remains compiled into the image.
 - The executable embeds source, repository, and strategy-behavior identity. Startup verifies configured attribution,
   and status exposes the promoted image digest, parameter hash, and contract versions.
+- The package `dev` and `start` scripts use explicit `development-configured` provenance because their artifacts are
+  not OCI production builds. That mode is visible in status and cannot override an executable with embedded metadata;
+  it also forces startup evaluation and journaling off. The Nix image starts in the default production mode and fails
+  closed if embedded facts are absent.
 - The transitional run ID binds runtime provenance and the exact ClickHouse input-manifest hash. It remains distinct
   from the target finalized-snapshot run identity until bounded Signal publications are adopted.
 - Signals are formed at a month-end close and may execute only at the next common session open.

--- a/services/bayn/package.json
+++ b/services/bayn/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "build": "bun build src/index.ts src/backfill.ts --target=node --external tigerbeetle-node --outdir=dist",
-    "dev": "bun --watch src/index.ts",
-    "start": "node dist/index.js",
+    "dev": "BAYN_PROVENANCE_MODE=development bun --watch src/index.ts",
+    "start": "BAYN_PROVENANCE_MODE=development node dist/index.js",
     "backfill": "bun src/backfill.ts",
     "lint": "bunx oxfmt --check src",
     "lint:oxlint": "oxlint --config ../../.oxlintrc.json .",

--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -8,15 +8,21 @@ import type { RuntimeConfig } from './config'
 import { operationalError } from './errors'
 import { Journal, type JournalService } from './ledger'
 import { MarketData, type MarketDataService } from './market-data'
-import { defaultProtocol } from './protocol'
 import { evaluateTsmom } from './strategy'
-import { Strategy, TsmomStrategyLive, type StrategyService } from './strategy-service'
-import { makeSnapshot } from './test-fixtures'
+import { Strategy, TsmomStrategyLayer, type StrategyService } from './strategy-service'
+import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
+
+const provenance = makeTestProvenance()
 
 const config: RuntimeConfig = {
   host: '127.0.0.1',
   port: 0,
-  codeRevision: 'test-revision',
+  build: {
+    sourceRevision: provenance.sourceRevision,
+    imageRepository: provenance.image.repository,
+    imageDigest: provenance.image.digest,
+    strategyBehaviorHash: provenance.strategy.behaviorHash,
+  },
   runOnStartup: true,
   operationTimeoutMs: 250,
   clickhouse: {
@@ -52,11 +58,12 @@ const fetchJson = async (port: number, path: string, method = 'GET') => {
 
 const readyState = (): RuntimeState => {
   const snapshot = makeSnapshot()
-  const evaluation = evaluateTsmom(snapshot.bars, snapshot.manifest, defaultProtocol, 'test-revision')
+  const evaluation = evaluateTsmom(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance)
   const { events, ...evaluationWithoutEvents } = evaluation
   return {
     status: 'READY',
     evidence: {
+      provenance,
       evaluation: { ...evaluationWithoutEvents, eventCount: events.length },
       reconciliation: { runId: evaluation.runId, accountCount: 13, transferCount: events.length, exact: true },
     },
@@ -71,7 +78,7 @@ describe('Bayn HTTP probes', () => {
       Effect.scoped(
         Effect.gen(function* () {
           const state = yield* Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null })
-          const context = yield* Layer.build(makeHttpLayer({ host: '127.0.0.1', port: 0 }, state))
+          const context = yield* Layer.build(makeHttpLayer({ host: '127.0.0.1', port: 0 }, state, provenance))
           const address = Context.get(context, HttpServer.HttpServer).address
           if (address._tag !== 'TcpAddress') throw new Error('test server did not bind a TCP port')
           port = address.port
@@ -97,6 +104,8 @@ describe('Bayn HTTP probes', () => {
               service: 'bayn',
               status: 'READY',
               authority: { brokerOrders: false, capitalPromotion: false },
+              provenance,
+              evidence: { provenance },
             },
           })
           yield* Ref.set(state, { status: 'FAIL_CLOSED', evidence: null, error: 'test failure' })
@@ -138,10 +147,11 @@ describe('Bayn startup lifecycle', () => {
     const state = await Effect.runPromise(Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null }))
     const strategy: StrategyService = {
       name: 'test-strategy',
-      universe: defaultProtocol.universe,
-      evaluate: (bars, manifest, codeRevision) => {
+      universe: fixtureProtocol.universe,
+      provenance,
+      evaluate: (bars, manifest) => {
         calls += 1
-        return evaluateTsmom(bars, manifest, defaultProtocol, codeRevision)
+        return evaluateTsmom(bars, manifest, fixtureProtocol, provenance)
       },
     }
 
@@ -166,7 +176,7 @@ describe('Bayn startup lifecycle', () => {
       initialize(config, state).pipe(
         Effect.provideService(MarketData, marketData),
         Effect.provideService(Journal, successfulJournal),
-        Effect.provide(TsmomStrategyLive),
+        Effect.provide(TsmomStrategyLayer(fixtureProtocol, provenance)),
       ),
     )
 
@@ -186,7 +196,7 @@ describe('Bayn startup lifecycle', () => {
       initialize(config, state).pipe(
         Effect.provideService(MarketData, marketData),
         Effect.provideService(Journal, successfulJournal),
-        Effect.provide(TsmomStrategyLive),
+        Effect.provide(TsmomStrategyLayer(fixtureProtocol, provenance)),
       ),
     )
 
@@ -212,7 +222,7 @@ describe('Bayn startup lifecycle', () => {
       initialize({ ...config, runOnStartup: false }, state).pipe(
         Effect.provideService(MarketData, marketData),
         Effect.provideService(Journal, journal),
-        Effect.provide(TsmomStrategyLive),
+        Effect.provide(TsmomStrategyLayer(fixtureProtocol, provenance)),
       ),
     )
 
@@ -234,7 +244,7 @@ describe('Bayn startup lifecycle', () => {
       initialize({ ...config, operationTimeoutMs: 10 }, state).pipe(
         Effect.provideService(MarketData, marketData),
         Effect.provideService(Journal, successfulJournal),
-        Effect.provide(TsmomStrategyLive),
+        Effect.provide(TsmomStrategyLayer(fixtureProtocol, provenance)),
       ),
     )
 
@@ -251,7 +261,7 @@ describe('Bayn startup lifecycle', () => {
       run(config).pipe(
         Effect.provideService(MarketData, marketData),
         Effect.provideService(Journal, successfulJournal),
-        Effect.provide(TsmomStrategyLive),
+        Effect.provide(TsmomStrategyLayer(fixtureProtocol, provenance)),
         Effect.timeoutOrElse({
           duration: 250,
           orElse: () =>

--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -22,6 +22,7 @@ const config: RuntimeConfig = {
     imageRepository: provenance.image.repository,
     imageDigest: provenance.image.digest,
     strategyBehaviorHash: provenance.strategy.behaviorHash,
+    verification: 'embedded',
   },
   runOnStartup: true,
   operationTimeoutMs: 250,
@@ -78,7 +79,9 @@ describe('Bayn HTTP probes', () => {
       Effect.scoped(
         Effect.gen(function* () {
           const state = yield* Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null })
-          const context = yield* Layer.build(makeHttpLayer({ host: '127.0.0.1', port: 0 }, state, provenance))
+          const context = yield* Layer.build(
+            makeHttpLayer({ host: '127.0.0.1', port: 0 }, state, provenance, 'embedded'),
+          )
           const address = Context.get(context, HttpServer.HttpServer).address
           if (address._tag !== 'TcpAddress') throw new Error('test server did not bind a TCP port')
           port = address.port
@@ -104,6 +107,7 @@ describe('Bayn HTTP probes', () => {
               service: 'bayn',
               status: 'READY',
               authority: { brokerOrders: false, capitalPromotion: false },
+              provenanceVerification: 'embedded',
               provenance,
               evidence: { provenance },
             },

--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -4,7 +4,7 @@ import { NodeHttpServer } from '@effect/platform-node'
 import { Effect, Layer, Ref } from 'effect'
 import { HttpRouter, HttpServerRequest, HttpServerResponse } from 'effect/unstable/http'
 
-import type { RuntimeConfig } from './config'
+import type { RuntimeBuildMetadata, RuntimeConfig } from './config'
 import type { RuntimeProvenance } from './contracts'
 import { formatError, operationalError, type Component, type OperationalError } from './errors'
 import { Journal } from './ledger'
@@ -26,10 +26,15 @@ export type RuntimeState =
 const json = (value: unknown): string =>
   JSON.stringify(value, (_, nested) => (typeof nested === 'bigint' ? nested.toString() : nested))
 
-const publicState = (state: RuntimeState, provenance: RuntimeProvenance) => ({
+const publicState = (
+  state: RuntimeState,
+  provenance: RuntimeProvenance,
+  provenanceVerification: RuntimeBuildMetadata['verification'],
+) => ({
   service: 'bayn',
   status: state.status,
   authority: { brokerOrders: false, capitalPromotion: false },
+  provenanceVerification,
   provenance,
   evidence: state.evidence,
   error: state.error,
@@ -42,6 +47,7 @@ export const makeHttpLayer = (
   config: Pick<RuntimeConfig, 'host' | 'port'>,
   state: Ref.Ref<RuntimeState>,
   provenance: RuntimeProvenance,
+  provenanceVerification: RuntimeBuildMetadata['verification'],
 ): ReturnType<typeof NodeHttpServer.layer> => {
   const ready = Ref.get(state).pipe(
     Effect.map((current) => {
@@ -49,7 +55,9 @@ export const makeHttpLayer = (
       return jsonResponse({ ready: isReady, status: current.status }, isReady ? 200 : 503)
     }),
   )
-  const status = Ref.get(state).pipe(Effect.map((current) => jsonResponse(publicState(current, provenance))))
+  const status = Ref.get(state).pipe(
+    Effect.map((current) => jsonResponse(publicState(current, provenance, provenanceVerification))),
+  )
   const fallback = (
     request: HttpServerRequest.HttpServerRequest,
   ): Effect.Effect<HttpServerResponse.HttpServerResponse> =>
@@ -195,7 +203,7 @@ export const run = (config: RuntimeConfig): Effect.Effect<never, OperationalErro
     Effect.gen(function* () {
       const strategy = yield* Strategy
       const state = yield* Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null })
-      yield* Layer.build(makeHttpLayer(config, state, strategy.provenance)).pipe(
+      yield* Layer.build(makeHttpLayer(config, state, strategy.provenance, config.build.verification)).pipe(
         Effect.mapError((cause) => operationalError('http', 'listen', 'HTTP server failed to listen', cause)),
       )
       yield* initialize(config, state)

--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -5,6 +5,7 @@ import { Effect, Layer, Ref } from 'effect'
 import { HttpRouter, HttpServerRequest, HttpServerResponse } from 'effect/unstable/http'
 
 import type { RuntimeConfig } from './config'
+import type { RuntimeProvenance } from './contracts'
 import { formatError, operationalError, type Component, type OperationalError } from './errors'
 import { Journal } from './ledger'
 import { MarketData } from './market-data'
@@ -12,6 +13,7 @@ import { Strategy } from './strategy-service'
 import type { EvaluationResult, ReconciliationResult } from './types'
 
 interface RuntimeEvidence {
+  readonly provenance: RuntimeProvenance
   readonly evaluation: Omit<EvaluationResult, 'events'> & { readonly eventCount: number }
   readonly reconciliation: ReconciliationResult
 }
@@ -24,10 +26,11 @@ export type RuntimeState =
 const json = (value: unknown): string =>
   JSON.stringify(value, (_, nested) => (typeof nested === 'bigint' ? nested.toString() : nested))
 
-const publicState = (state: RuntimeState) => ({
+const publicState = (state: RuntimeState, provenance: RuntimeProvenance) => ({
   service: 'bayn',
   status: state.status,
   authority: { brokerOrders: false, capitalPromotion: false },
+  provenance,
   evidence: state.evidence,
   error: state.error,
 })
@@ -38,6 +41,7 @@ const jsonResponse = (body: unknown, status = 200, headers?: Readonly<Record<str
 export const makeHttpLayer = (
   config: Pick<RuntimeConfig, 'host' | 'port'>,
   state: Ref.Ref<RuntimeState>,
+  provenance: RuntimeProvenance,
 ): ReturnType<typeof NodeHttpServer.layer> => {
   const ready = Ref.get(state).pipe(
     Effect.map((current) => {
@@ -45,7 +49,7 @@ export const makeHttpLayer = (
       return jsonResponse({ ready: isReady, status: current.status }, isReady ? 200 : 503)
     }),
   )
-  const status = Ref.get(state).pipe(Effect.map((current) => jsonResponse(publicState(current))))
+  const status = Ref.get(state).pipe(Effect.map((current) => jsonResponse(publicState(current, provenance))))
   const fallback = (
     request: HttpServerRequest.HttpServerRequest,
   ): Effect.Effect<HttpServerResponse.HttpServerResponse> =>
@@ -107,7 +111,10 @@ const evaluateAndJournal = (
     yield* Effect.logInfo('Bayn startup evaluation started').pipe(
       Effect.annotateLogs({
         service: 'bayn',
-        codeRevision: config.codeRevision,
+        sourceRevision: config.build.sourceRevision,
+        imageDigest: config.build.imageDigest,
+        strategyBehaviorHash: strategy.provenance.strategy.behaviorHash,
+        parameterHash: strategy.provenance.strategy.parameterHash,
         datasetVersion: config.clickhouse.datasetVersion,
       }),
     )
@@ -121,7 +128,7 @@ const evaluateAndJournal = (
       }),
     )
     const evaluation = yield* Effect.try({
-      try: () => strategy.evaluate(snapshot.bars, snapshot.manifest, config.codeRevision),
+      try: () => strategy.evaluate(snapshot.bars, snapshot.manifest),
       catch: (cause) => operationalError('strategy', 'evaluate', `${strategy.name} evaluation failed`, cause),
     })
     yield* Effect.logInfo('Bayn strategy evaluation completed').pipe(
@@ -142,7 +149,11 @@ const evaluateAndJournal = (
     const { events, ...evaluationWithoutEvents } = evaluation
     yield* Ref.set(state, {
       status: 'READY',
-      evidence: { evaluation: { ...evaluationWithoutEvents, eventCount: events.length }, reconciliation },
+      evidence: {
+        provenance: strategy.provenance,
+        evaluation: { ...evaluationWithoutEvents, eventCount: events.length },
+        reconciliation,
+      },
       error: null,
     })
     yield* Effect.logInfo('Bayn startup proof is ready').pipe(
@@ -182,8 +193,9 @@ export const initialize = (
 export const run = (config: RuntimeConfig): Effect.Effect<never, OperationalError, MarketData | Journal | Strategy> =>
   Effect.scoped(
     Effect.gen(function* () {
+      const strategy = yield* Strategy
       const state = yield* Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null })
-      yield* Layer.build(makeHttpLayer(config, state)).pipe(
+      yield* Layer.build(makeHttpLayer(config, state, strategy.provenance)).pipe(
         Effect.mapError((cause) => operationalError('http', 'listen', 'HTTP server failed to listen', cause)),
       )
       yield* initialize(config, state)

--- a/services/bayn/src/backfill.ts
+++ b/services/bayn/src/backfill.ts
@@ -4,7 +4,7 @@ import { createClient } from '@clickhouse/client'
 import { Effect, Redacted } from 'effect'
 
 import { loadBackfillConfig } from './backfill-config'
-import { defaultProtocol } from './protocol'
+import { loadDefaultProtocol } from './protocol'
 
 interface AlpacaBar {
   readonly t: string
@@ -55,7 +55,8 @@ const main = async (): Promise<void> => {
     feed,
     datasetVersion,
   } = await Effect.runPromise(loadBackfillConfig)
-  const universe = [...defaultProtocol.universe]
+  const protocol = await Effect.runPromise(loadDefaultProtocol)
+  const universe = [...protocol.universe]
   const client = createClient({
     url: clickhouseUrl,
     username: clickhouseUsername,

--- a/services/bayn/src/build.ts
+++ b/services/bayn/src/build.ts
@@ -15,9 +15,20 @@ export const EmbeddedBuildMetadataSchema = Schema.Struct({
 })
 export type EmbeddedBuildMetadata = typeof EmbeddedBuildMetadataSchema.Type
 
-export const embeddedBuildMetadata = {
-  sourceRevision: typeof __BAYN_BUILD_SOURCE_REVISION__ === 'undefined' ? 'unbuilt' : __BAYN_BUILD_SOURCE_REVISION__,
-  imageRepository: typeof __BAYN_BUILD_IMAGE_REPOSITORY__ === 'undefined' ? 'unbuilt' : __BAYN_BUILD_IMAGE_REPOSITORY__,
-  strategyBehaviorHash:
-    typeof __BAYN_BUILD_STRATEGY_BEHAVIOR_HASH__ === 'undefined' ? 'unbuilt' : __BAYN_BUILD_STRATEGY_BEHAVIOR_HASH__,
-} as const
+const sourceRevision =
+  typeof __BAYN_BUILD_SOURCE_REVISION__ === 'undefined' ? undefined : __BAYN_BUILD_SOURCE_REVISION__
+const imageRepository =
+  typeof __BAYN_BUILD_IMAGE_REPOSITORY__ === 'undefined' ? undefined : __BAYN_BUILD_IMAGE_REPOSITORY__
+const strategyBehaviorHash =
+  typeof __BAYN_BUILD_STRATEGY_BEHAVIOR_HASH__ === 'undefined' ? undefined : __BAYN_BUILD_STRATEGY_BEHAVIOR_HASH__
+
+const hasNoEmbeddedMetadata =
+  sourceRevision === undefined && imageRepository === undefined && strategyBehaviorHash === undefined
+
+export const embeddedBuildMetadata: EmbeddedBuildMetadata | undefined = hasNoEmbeddedMetadata
+  ? undefined
+  : {
+      sourceRevision: sourceRevision ?? 'incomplete',
+      imageRepository: imageRepository ?? 'incomplete',
+      strategyBehaviorHash: strategyBehaviorHash ?? 'incomplete',
+    }

--- a/services/bayn/src/build.ts
+++ b/services/bayn/src/build.ts
@@ -1,0 +1,23 @@
+import { Schema } from 'effect'
+
+declare const __BAYN_BUILD_SOURCE_REVISION__: string
+declare const __BAYN_BUILD_IMAGE_REPOSITORY__: string
+declare const __BAYN_BUILD_STRATEGY_BEHAVIOR_HASH__: string
+
+const SourceRevision = Schema.String.check(Schema.isPattern(/^[a-f0-9]{40}$/))
+const ImageRepository = Schema.String.check(Schema.isPattern(/^[a-z0-9.-]+(?::[0-9]+)?\/[a-z0-9._/-]+$/))
+const Sha256 = Schema.String.check(Schema.isPattern(/^[a-f0-9]{64}$/))
+
+export const EmbeddedBuildMetadataSchema = Schema.Struct({
+  sourceRevision: SourceRevision,
+  imageRepository: ImageRepository,
+  strategyBehaviorHash: Sha256,
+})
+export type EmbeddedBuildMetadata = typeof EmbeddedBuildMetadataSchema.Type
+
+export const embeddedBuildMetadata = {
+  sourceRevision: typeof __BAYN_BUILD_SOURCE_REVISION__ === 'undefined' ? 'unbuilt' : __BAYN_BUILD_SOURCE_REVISION__,
+  imageRepository: typeof __BAYN_BUILD_IMAGE_REPOSITORY__ === 'undefined' ? 'unbuilt' : __BAYN_BUILD_IMAGE_REPOSITORY__,
+  strategyBehaviorHash:
+    typeof __BAYN_BUILD_STRATEGY_BEHAVIOR_HASH__ === 'undefined' ? 'unbuilt' : __BAYN_BUILD_STRATEGY_BEHAVIOR_HASH__,
+} as const

--- a/services/bayn/src/config.test.ts
+++ b/services/bayn/src/config.test.ts
@@ -53,7 +53,41 @@ describe('Effect configuration', () => {
     expect(Redacted.isRedacted(config.clickhouse.password)).toBe(true)
     expect(config.tigerBeetle.clusterId).toBe(2001n)
     expect(config.tigerBeetle.replicaAddresses).toEqual(['tigerbeetle.test:3000'])
-    expect(config.build).toEqual({ ...buildMetadata, imageDigest })
+    expect(config.build).toEqual({ ...buildMetadata, imageDigest, verification: 'embedded' })
+  })
+
+  test('supports an explicit, visibly unverified development provenance path', async () => {
+    const development = new Map(runtimeEnvironment)
+    development.set('BAYN_PROVENANCE_MODE', 'development')
+
+    const config = await Effect.runPromise(provideEnvironment(loadConfig(undefined), development))
+
+    expect(config.build).toMatchObject({
+      sourceRevision,
+      imageRepository,
+      imageDigest,
+      verification: 'development-configured',
+    })
+    expect(config.build.strategyBehaviorHash).toMatch(/^[a-f0-9]{64}$/)
+    expect(config.runOnStartup).toBe(false)
+  })
+
+  test('does not let missing build facts or development mode bypass production verification', async () => {
+    const missing = await Effect.runPromise(Effect.flip(provideEnvironment(loadConfig(undefined), runtimeEnvironment)))
+    expect(missing).toMatchObject({
+      _tag: 'OperationalError',
+      component: 'config',
+      operation: 'provenance',
+    })
+
+    const bypass = new Map(runtimeEnvironment)
+    bypass.set('BAYN_PROVENANCE_MODE', 'development')
+    const mismatch = await Effect.runPromise(Effect.flip(provideEnvironment(loadConfig(buildMetadata), bypass)))
+    expect(mismatch).toMatchObject({
+      _tag: 'OperationalError',
+      component: 'config',
+      operation: 'provenance',
+    })
   })
 
   test('returns a typed configuration failure for invalid values', async () => {

--- a/services/bayn/src/config.test.ts
+++ b/services/bayn/src/config.test.ts
@@ -3,10 +3,22 @@ import { describe, expect, test } from 'bun:test'
 import { ConfigProvider, Effect, Exit, Redacted } from 'effect'
 
 import { loadBackfillConfig } from './backfill-config'
+import type { EmbeddedBuildMetadata } from './build'
 import { loadConfig } from './config'
 
+const sourceRevision = 'a'.repeat(40)
+const imageRepository = 'registry.ide-newton.ts.net/lab/bayn'
+const imageDigest = `sha256:${'b'.repeat(64)}`
+const buildMetadata: EmbeddedBuildMetadata = {
+  sourceRevision,
+  imageRepository,
+  strategyBehaviorHash: 'c'.repeat(64),
+}
+
 const runtimeEnvironment = new Map([
-  ['BAYN_CODE_REVISION', 'test-revision'],
+  ['BAYN_CODE_REVISION', sourceRevision],
+  ['BAYN_IMAGE_REPOSITORY', imageRepository],
+  ['BAYN_IMAGE_DIGEST', imageDigest],
   ['BAYN_CLICKHOUSE_URL', 'http://clickhouse.test:8123'],
   ['BAYN_CLICKHOUSE_USERNAME', 'bayn'],
   ['BAYN_CLICKHOUSE_PASSWORD', 'secret'],
@@ -32,7 +44,7 @@ const provideEnvironment = <A, E>(effect: Effect.Effect<A, E>, environment: Map<
 
 describe('Effect configuration', () => {
   test('loads runtime configuration with validated defaults', async () => {
-    const config = await Effect.runPromise(provideEnvironment(loadConfig, runtimeEnvironment))
+    const config = await Effect.runPromise(provideEnvironment(loadConfig(buildMetadata), runtimeEnvironment))
 
     expect(config.host).toBe('0.0.0.0')
     expect(config.port).toBe(8080)
@@ -41,18 +53,36 @@ describe('Effect configuration', () => {
     expect(Redacted.isRedacted(config.clickhouse.password)).toBe(true)
     expect(config.tigerBeetle.clusterId).toBe(2001n)
     expect(config.tigerBeetle.replicaAddresses).toEqual(['tigerbeetle.test:3000'])
+    expect(config.build).toEqual({ ...buildMetadata, imageDigest })
   })
 
   test('returns a typed configuration failure for invalid values', async () => {
     const invalid = new Map(runtimeEnvironment)
     invalid.set('BAYN_OPERATION_TIMEOUT_MS', '0')
 
-    const error = await Effect.runPromise(Effect.flip(provideEnvironment(loadConfig, invalid)))
+    const error = await Effect.runPromise(Effect.flip(provideEnvironment(loadConfig(buildMetadata), invalid)))
     expect(error).toMatchObject({
       _tag: 'OperationalError',
       component: 'config',
       operation: 'load',
     })
+  })
+
+  test('fails closed when configured and embedded provenance diverge', async () => {
+    for (const [name, value] of [
+      ['BAYN_CODE_REVISION', 'd'.repeat(40)],
+      ['BAYN_IMAGE_REPOSITORY', 'registry.example.invalid/bayn'],
+    ] as const) {
+      const invalid = new Map(runtimeEnvironment)
+      invalid.set(name, value)
+
+      const error = await Effect.runPromise(Effect.flip(provideEnvironment(loadConfig(buildMetadata), invalid)))
+      expect(error).toMatchObject({
+        _tag: 'OperationalError',
+        component: 'config',
+        operation: 'provenance',
+      })
+    }
   })
 
   test('loads and validates backfill configuration without reading process.env directly', async () => {

--- a/services/bayn/src/config.ts
+++ b/services/bayn/src/config.ts
@@ -1,11 +1,16 @@
 import { Config, Effect, Redacted, Schema, SchemaTransformation } from 'effect'
 
+import { EmbeddedBuildMetadataSchema, embeddedBuildMetadata, type EmbeddedBuildMetadata } from './build'
 import { operationalError, type OperationalError } from './errors'
+
+export interface RuntimeBuildMetadata extends EmbeddedBuildMetadata {
+  readonly imageDigest: string
+}
 
 export interface RuntimeConfig {
   readonly host: string
   readonly port: number
-  readonly codeRevision: string
+  readonly build: RuntimeBuildMetadata
   readonly runOnStartup: boolean
   readonly operationTimeoutMs: number
   readonly clickhouse: {
@@ -26,6 +31,9 @@ export interface RuntimeConfig {
 const NonEmptyString = Schema.Trim.check(Schema.isMinLength(1))
 const PositiveInteger = Schema.Int.check(Schema.isGreaterThan(0))
 const ClickHouseIdentifier = NonEmptyString.check(Schema.isPattern(/^[a-zA-Z_][a-zA-Z0-9_]*$/))
+const SourceRevision = Schema.String.check(Schema.isPattern(/^[a-f0-9]{40}$/))
+const ImageRepository = Schema.String.check(Schema.isPattern(/^[a-z0-9.-]+(?::[0-9]+)?\/[a-z0-9._/-]+$/))
+const ImageDigest = Schema.String.check(Schema.isPattern(/^sha256:[a-f0-9]{64}$/))
 const ReplicaAddresses = Schema.Trim.pipe(
   Schema.decodeTo(
     Schema.Array(NonEmptyString).check(Schema.isMinLength(1)),
@@ -53,7 +61,9 @@ const clickhouseIdentifier = (name: string, fallback: string) =>
 const runtimeConfig = Config.all({
   host: nonEmptyString('BAYN_HTTP_HOST').pipe(Config.withDefault('0.0.0.0')),
   port: Config.port('BAYN_HTTP_PORT').pipe(Config.withDefault(8080)),
-  codeRevision: nonEmptyString('BAYN_CODE_REVISION'),
+  sourceRevision: Config.schema(SourceRevision, 'BAYN_CODE_REVISION'),
+  imageRepository: Config.schema(ImageRepository, 'BAYN_IMAGE_REPOSITORY'),
+  imageDigest: Config.schema(ImageDigest, 'BAYN_IMAGE_DIGEST'),
   runOnStartup: Config.boolean('BAYN_RUN_ON_STARTUP').pipe(Config.withDefault(true)),
   operationTimeoutMs: positiveInteger('BAYN_OPERATION_TIMEOUT_MS', 30_000),
   clickhouseUrl: nonEmptyString('BAYN_CLICKHOUSE_URL'),
@@ -68,30 +78,61 @@ const runtimeConfig = Config.all({
   tigerBeetleReplicaAddresses: Config.schema(ReplicaAddresses, 'BAYN_TIGERBEETLE_ADDRESSES'),
   tigerBeetleLedger: positiveInteger('BAYN_TIGERBEETLE_LEDGER', 7001),
 }).pipe(
-  Config.map(
-    (config): RuntimeConfig => ({
-      host: config.host,
-      port: config.port,
-      codeRevision: config.codeRevision,
-      runOnStartup: config.runOnStartup,
-      operationTimeoutMs: config.operationTimeoutMs,
-      clickhouse: {
-        url: config.clickhouseUrl,
-        username: config.clickhouseUsername,
-        password: config.clickhousePassword,
-        database: config.clickhouseDatabase,
-        table: config.clickhouseTable,
-        datasetVersion: config.datasetVersion,
-      },
-      tigerBeetle: {
-        clusterId: config.tigerBeetleClusterId,
-        replicaAddresses: config.tigerBeetleReplicaAddresses,
-        ledger: config.tigerBeetleLedger,
-      },
-    }),
-  ),
+  Config.map((config) => ({
+    host: config.host,
+    port: config.port,
+    configuredBuild: {
+      sourceRevision: config.sourceRevision,
+      imageRepository: config.imageRepository,
+      imageDigest: config.imageDigest,
+    },
+    runOnStartup: config.runOnStartup,
+    operationTimeoutMs: config.operationTimeoutMs,
+    clickhouse: {
+      url: config.clickhouseUrl,
+      username: config.clickhouseUsername,
+      password: config.clickhousePassword,
+      database: config.clickhouseDatabase,
+      table: config.clickhouseTable,
+      datasetVersion: config.datasetVersion,
+    },
+    tigerBeetle: {
+      clusterId: config.tigerBeetleClusterId,
+      replicaAddresses: config.tigerBeetleReplicaAddresses,
+      ledger: config.tigerBeetleLedger,
+    },
+  })),
 )
 
-export const loadConfig: Effect.Effect<RuntimeConfig, OperationalError> = runtimeConfig.pipe(
-  Effect.mapError((cause) => operationalError('config', 'load', 'invalid runtime configuration', cause)),
-)
+const StrictParseOptions = { onExcessProperty: 'error' } as const
+const decodeEmbeddedBuildMetadata = Schema.decodeUnknownSync(EmbeddedBuildMetadataSchema, StrictParseOptions)
+
+export const loadConfig = (
+  embedded: EmbeddedBuildMetadata = embeddedBuildMetadata,
+): Effect.Effect<RuntimeConfig, OperationalError> =>
+  runtimeConfig.pipe(
+    Effect.mapError((cause) => operationalError('config', 'load', 'invalid runtime configuration', cause)),
+    Effect.flatMap((config) =>
+      Effect.try({
+        try: (): RuntimeConfig => {
+          const decodedBuild = decodeEmbeddedBuildMetadata(embedded)
+          if (config.configuredBuild.sourceRevision !== decodedBuild.sourceRevision) {
+            throw new Error(
+              `configured source revision ${config.configuredBuild.sourceRevision} does not match embedded revision ${decodedBuild.sourceRevision}`,
+            )
+          }
+          if (config.configuredBuild.imageRepository !== decodedBuild.imageRepository) {
+            throw new Error(
+              `configured image repository ${config.configuredBuild.imageRepository} does not match embedded repository ${decodedBuild.imageRepository}`,
+            )
+          }
+          const { configuredBuild, ...runtime } = config
+          return {
+            ...runtime,
+            build: { ...decodedBuild, imageDigest: configuredBuild.imageDigest },
+          }
+        },
+        catch: (cause) => operationalError('config', 'provenance', 'invalid build provenance', cause),
+      }),
+    ),
+  )

--- a/services/bayn/src/config.ts
+++ b/services/bayn/src/config.ts
@@ -2,9 +2,11 @@ import { Config, Effect, Redacted, Schema, SchemaTransformation } from 'effect'
 
 import { EmbeddedBuildMetadataSchema, embeddedBuildMetadata, type EmbeddedBuildMetadata } from './build'
 import { operationalError, type OperationalError } from './errors'
+import { sha256 } from './hash'
 
 export interface RuntimeBuildMetadata extends EmbeddedBuildMetadata {
   readonly imageDigest: string
+  readonly verification: 'embedded' | 'development-configured'
 }
 
 export interface RuntimeConfig {
@@ -34,6 +36,8 @@ const ClickHouseIdentifier = NonEmptyString.check(Schema.isPattern(/^[a-zA-Z_][a
 const SourceRevision = Schema.String.check(Schema.isPattern(/^[a-f0-9]{40}$/))
 const ImageRepository = Schema.String.check(Schema.isPattern(/^[a-z0-9.-]+(?::[0-9]+)?\/[a-z0-9._/-]+$/))
 const ImageDigest = Schema.String.check(Schema.isPattern(/^sha256:[a-f0-9]{64}$/))
+const ProvenanceMode = Schema.Literals(['production', 'development'])
+const developmentBehaviorHash = sha256('bayn.development-configured-behavior.v1')
 const ReplicaAddresses = Schema.Trim.pipe(
   Schema.decodeTo(
     Schema.Array(NonEmptyString).check(Schema.isMinLength(1)),
@@ -64,6 +68,7 @@ const runtimeConfig = Config.all({
   sourceRevision: Config.schema(SourceRevision, 'BAYN_CODE_REVISION'),
   imageRepository: Config.schema(ImageRepository, 'BAYN_IMAGE_REPOSITORY'),
   imageDigest: Config.schema(ImageDigest, 'BAYN_IMAGE_DIGEST'),
+  provenanceMode: Config.schema(ProvenanceMode, 'BAYN_PROVENANCE_MODE').pipe(Config.withDefault('production')),
   runOnStartup: Config.boolean('BAYN_RUN_ON_STARTUP').pipe(Config.withDefault(true)),
   operationTimeoutMs: positiveInteger('BAYN_OPERATION_TIMEOUT_MS', 30_000),
   clickhouseUrl: nonEmptyString('BAYN_CLICKHOUSE_URL'),
@@ -86,6 +91,7 @@ const runtimeConfig = Config.all({
       imageRepository: config.imageRepository,
       imageDigest: config.imageDigest,
     },
+    provenanceMode: config.provenanceMode,
     runOnStartup: config.runOnStartup,
     operationTimeoutMs: config.operationTimeoutMs,
     clickhouse: {
@@ -108,28 +114,49 @@ const StrictParseOptions = { onExcessProperty: 'error' } as const
 const decodeEmbeddedBuildMetadata = Schema.decodeUnknownSync(EmbeddedBuildMetadataSchema, StrictParseOptions)
 
 export const loadConfig = (
-  embedded: EmbeddedBuildMetadata = embeddedBuildMetadata,
+  embedded: EmbeddedBuildMetadata | undefined = embeddedBuildMetadata,
 ): Effect.Effect<RuntimeConfig, OperationalError> =>
   runtimeConfig.pipe(
     Effect.mapError((cause) => operationalError('config', 'load', 'invalid runtime configuration', cause)),
     Effect.flatMap((config) =>
       Effect.try({
         try: (): RuntimeConfig => {
-          const decodedBuild = decodeEmbeddedBuildMetadata(embedded)
-          if (config.configuredBuild.sourceRevision !== decodedBuild.sourceRevision) {
-            throw new Error(
-              `configured source revision ${config.configuredBuild.sourceRevision} does not match embedded revision ${decodedBuild.sourceRevision}`,
-            )
+          if (embedded === undefined && config.provenanceMode !== 'development') {
+            throw new Error('production provenance requires compile-time build metadata')
           }
-          if (config.configuredBuild.imageRepository !== decodedBuild.imageRepository) {
-            throw new Error(
-              `configured image repository ${config.configuredBuild.imageRepository} does not match embedded repository ${decodedBuild.imageRepository}`,
-            )
+          if (embedded !== undefined && config.provenanceMode !== 'production') {
+            throw new Error('development provenance cannot override embedded production metadata')
           }
-          const { configuredBuild, ...runtime } = config
+
+          const decodedBuild =
+            embedded === undefined
+              ? {
+                  sourceRevision: config.configuredBuild.sourceRevision,
+                  imageRepository: config.configuredBuild.imageRepository,
+                  strategyBehaviorHash: developmentBehaviorHash,
+                }
+              : decodeEmbeddedBuildMetadata(embedded)
+          if (embedded !== undefined) {
+            if (config.configuredBuild.sourceRevision !== decodedBuild.sourceRevision) {
+              throw new Error(
+                `configured source revision ${config.configuredBuild.sourceRevision} does not match embedded revision ${decodedBuild.sourceRevision}`,
+              )
+            }
+            if (config.configuredBuild.imageRepository !== decodedBuild.imageRepository) {
+              throw new Error(
+                `configured image repository ${config.configuredBuild.imageRepository} does not match embedded repository ${decodedBuild.imageRepository}`,
+              )
+            }
+          }
+          const { configuredBuild, provenanceMode, ...runtime } = config
           return {
             ...runtime,
-            build: { ...decodedBuild, imageDigest: configuredBuild.imageDigest },
+            runOnStartup: provenanceMode === 'production' ? runtime.runOnStartup : false,
+            build: {
+              ...decodedBuild,
+              imageDigest: configuredBuild.imageDigest,
+              verification: provenanceMode === 'production' ? 'embedded' : 'development-configured',
+            },
           }
         },
         catch: (cause) => operationalError('config', 'provenance', 'invalid build provenance', cause),

--- a/services/bayn/src/contracts.test.ts
+++ b/services/bayn/src/contracts.test.ts
@@ -11,8 +11,10 @@ import {
   decodeEvidenceFreshness,
   decodeFinalizedSnapshot,
   decodeRunIdentity,
+  decodeRuntimeProvenance,
   decodeStatusSnapshot,
   makeRunIdentity,
+  makeRuntimeProvenance,
   makeStatusSnapshot,
 } from './contracts'
 
@@ -162,6 +164,36 @@ describe('Bayn run identity', () => {
         strategy: { ...material.strategy, parameters: { unsupported: undefined } },
       }),
     ).toThrow()
+  })
+})
+
+describe('Bayn runtime provenance', () => {
+  test('binds deploy identity, compiled behavior, parameters, and contract versions', async () => {
+    const provenance = makeRuntimeProvenance({
+      sourceRevision: 'c'.repeat(40),
+      image: {
+        repository: 'registry.ide-newton.ts.net/lab/bayn',
+        digest: `sha256:${sha('d')}`,
+      },
+      strategy: {
+        name: 'tsmom',
+        behaviorHash: sha('e'),
+        parameterHash: sha('f'),
+        parameterSchemaVersion: 'bayn.tsmom.protocol.v1',
+      },
+    })
+
+    expect(provenance).toMatchObject({
+      schemaVersion: 'bayn.runtime-provenance.v1',
+      contractVersions: {
+        runtimeProvenance: 'bayn.runtime-provenance.v1',
+        inputManifest: 'bayn.input-manifest.v1',
+        evaluation: 'bayn.evaluation.v1',
+      },
+    })
+    expect(await Effect.runPromise(decodeRuntimeProvenance(provenance))).toEqual(provenance)
+    await expectFailure(decodeRuntimeProvenance({ ...provenance, futureField: true }))
+    await expectFailure(decodeRuntimeProvenance({ ...provenance, schemaVersion: 'bayn.runtime-provenance.v2' }))
   })
 })
 

--- a/services/bayn/src/contracts.ts
+++ b/services/bayn/src/contracts.ts
@@ -168,6 +168,28 @@ export const RunIdentitySchema = RunIdentityBase.check(
 )
 export type RunIdentity = typeof RunIdentitySchema.Type
 
+export const RuntimeProvenanceSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.runtime-provenance.v1'),
+  sourceRevision: SourceRevision,
+  image: Schema.Struct({
+    repository: NonEmptyString,
+    digest: ImageDigest,
+  }),
+  strategy: Schema.Struct({
+    name: NonEmptyString,
+    behaviorHash: Sha256,
+    parameterHash: Sha256,
+    parameterSchemaVersion: NonEmptyString,
+  }),
+  contractVersions: Schema.Struct({
+    runtimeProvenance: Schema.Literal('bayn.runtime-provenance.v1'),
+    inputManifest: Schema.Literal('bayn.input-manifest.v1'),
+    evaluation: Schema.Literal('bayn.evaluation.v1'),
+  }),
+})
+export type RuntimeProvenance = typeof RuntimeProvenanceSchema.Type
+export type RuntimeProvenanceInput = Omit<RuntimeProvenance, 'schemaVersion' | 'contractVersions'>
+
 const EvidenceFreshnessBase = Schema.Struct({
   schemaVersion: Schema.Literal('bayn.evidence-freshness.v1'),
   observedAt: UtcInstant,
@@ -258,17 +280,30 @@ export type StatusSnapshotInput = Omit<StatusSnapshot, 'schemaVersion' | 'exerci
 export const decodeFinalizedSnapshot = Schema.decodeUnknownEffect(FinalizedSnapshotProvenanceSchema, StrictParseOptions)
 export const decodeEvaluationBounds = Schema.decodeUnknownEffect(EvaluationBoundsSchema, StrictParseOptions)
 export const decodeRunIdentity = Schema.decodeUnknownEffect(RunIdentitySchema, StrictParseOptions)
+export const decodeRuntimeProvenance = Schema.decodeUnknownEffect(RuntimeProvenanceSchema, StrictParseOptions)
 export const decodeEvidenceFreshness = Schema.decodeUnknownEffect(EvidenceFreshnessSchema, StrictParseOptions)
 export const decodeStatusSnapshot = Schema.decodeUnknownEffect(StatusSnapshotSchema, StrictParseOptions)
 
 const decodeRunIdentityMaterialSync = Schema.decodeUnknownSync(RunIdentityMaterialSchema, StrictParseOptions)
 const decodeRunIdentitySync = Schema.decodeUnknownSync(RunIdentitySchema, StrictParseOptions)
+const decodeRuntimeProvenanceSync = Schema.decodeUnknownSync(RuntimeProvenanceSchema, StrictParseOptions)
 const decodeStatusSnapshotSync = Schema.decodeUnknownSync(StatusSnapshotSchema, StrictParseOptions)
 
 export const makeRunIdentity = (input: RunIdentityMaterial): RunIdentity => {
   const material = decodeRunIdentityMaterialSync(input)
   return decodeRunIdentitySync({ ...material, runId: canonicalHashV1(material) })
 }
+
+export const makeRuntimeProvenance = (input: RuntimeProvenanceInput): RuntimeProvenance =>
+  decodeRuntimeProvenanceSync({
+    schemaVersion: 'bayn.runtime-provenance.v1',
+    ...input,
+    contractVersions: {
+      runtimeProvenance: 'bayn.runtime-provenance.v1',
+      inputManifest: 'bayn.input-manifest.v1',
+      evaluation: 'bayn.evaluation.v1',
+    },
+  })
 
 export const classifyEvidenceFreshness = (freshness: EvidenceFreshness, now: string): EvidenceState => {
   if (!isUtcInstant(now)) throw new TypeError('now must be a canonical UTC instant')

--- a/services/bayn/src/index.ts
+++ b/services/bayn/src/index.ts
@@ -3,16 +3,33 @@ import { Cause, Effect, Layer, Logger } from 'effect'
 
 import { run } from './app'
 import { loadConfig } from './config'
+import { makeRuntimeProvenance } from './contracts'
 import { JournalLive } from './ledger'
 import { MarketDataLive } from './market-data'
-import { TsmomStrategyLive, tsmomStrategy } from './strategy-service'
+import { hashTsmomParameters, loadDefaultProtocol } from './protocol'
+import { makeTsmomStrategy, Strategy } from './strategy-service'
 
 const main = Effect.gen(function* () {
-  const config = yield* loadConfig
+  const config = yield* loadConfig()
+  const protocol = yield* loadDefaultProtocol
+  const provenance = makeRuntimeProvenance({
+    sourceRevision: config.build.sourceRevision,
+    image: {
+      repository: config.build.imageRepository,
+      digest: config.build.imageDigest,
+    },
+    strategy: {
+      name: 'tsmom',
+      behaviorHash: config.build.strategyBehaviorHash,
+      parameterHash: hashTsmomParameters(protocol),
+      parameterSchemaVersion: protocol.schemaVersion,
+    },
+  })
+  const strategy = makeTsmomStrategy(protocol, provenance)
   const dependencies = Layer.mergeAll(
-    MarketDataLive(config, tsmomStrategy.universe),
+    MarketDataLive(config, strategy.universe),
     JournalLive(config),
-    TsmomStrategyLive,
+    Layer.succeed(Strategy, strategy),
   )
   return yield* run(config).pipe(Effect.provide(dependencies))
 })

--- a/services/bayn/src/ledger.test.ts
+++ b/services/bayn/src/ledger.test.ts
@@ -3,9 +3,8 @@ import { Effect } from 'effect'
 import type { Account, Transfer } from 'tigerbeetle-node'
 
 import { assertReconciled, buildLedgerPlan, resolveReplicaAddresses } from './ledger'
-import { defaultProtocol } from './protocol'
 import { evaluateTsmom } from './strategy'
-import { makeSnapshot } from './test-fixtures'
+import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
 
 const materializeAccounts = (plan: ReturnType<typeof buildLedgerPlan>): Account[] => {
   const balances = new Map(plan.accounts.map((account) => [account.id, { debits: 0n, credits: 0n }]))
@@ -27,18 +26,18 @@ const materializeTransfers = (plan: ReturnType<typeof buildLedgerPlan>): Transfe
 describe('TigerBeetle simulation journal', () => {
   test('plans deterministic double-entry transfers and reconciles exact sets and balances', () => {
     const snapshot = makeSnapshot()
-    const result = evaluateTsmom(snapshot.bars, snapshot.manifest, defaultProtocol, 'test-revision')
+    const result = evaluateTsmom(snapshot.bars, snapshot.manifest, fixtureProtocol, makeTestProvenance())
     const first = buildLedgerPlan(result, 7001)
     const second = buildLedgerPlan(result, 7001)
     expect(first).toEqual(second)
-    expect(first.accounts).toHaveLength(defaultProtocol.universe.length + 5)
+    expect(first.accounts).toHaveLength(fixtureProtocol.universe.length + 5)
     expect(first.transfers.length).toBeGreaterThan(1)
     expect(() => assertReconciled(first, materializeAccounts(first), materializeTransfers(first))).not.toThrow()
   })
 
   test('fails closed on extra transfers or mismatched balances', () => {
     const snapshot = makeSnapshot()
-    const result = evaluateTsmom(snapshot.bars, snapshot.manifest, defaultProtocol, 'test-revision')
+    const result = evaluateTsmom(snapshot.bars, snapshot.manifest, fixtureProtocol, makeTestProvenance())
     const plan = buildLedgerPlan(result, 7001)
     const accounts = materializeAccounts(plan)
     const transfers = materializeTransfers(plan)

--- a/services/bayn/src/market-data.test.ts
+++ b/services/bayn/src/market-data.test.ts
@@ -1,18 +1,17 @@
 import { describe, expect, test } from 'bun:test'
 
 import { buildInputManifest } from './market-data'
-import { defaultProtocol } from './protocol'
-import { makeBars } from './test-fixtures'
+import { fixtureProtocol, makeBars } from './test-fixtures'
 
 describe('Signal input manifest', () => {
   test('is deterministic and records exact coverage', () => {
     const bars = makeBars(10)
-    const first = buildInputManifest(bars, 'signal', 'adjusted_daily_bars_v1', defaultProtocol.universe, 'fixture-v1')
+    const first = buildInputManifest(bars, 'signal', 'adjusted_daily_bars_v1', fixtureProtocol.universe, 'fixture-v1')
     const second = buildInputManifest(
       [...bars].reverse(),
       'signal',
       'adjusted_daily_bars_v1',
-      defaultProtocol.universe,
+      fixtureProtocol.universe,
       'fixture-v1',
     )
     expect(first.hash).toBe(second.hash)
@@ -24,7 +23,7 @@ describe('Signal input manifest', () => {
       changedBars,
       'signal',
       'adjusted_daily_bars_v1',
-      defaultProtocol.universe,
+      fixtureProtocol.universe,
       'fixture-v1',
     )
     expect(changed.contentHash).not.toBe(first.contentHash)
@@ -38,7 +37,7 @@ describe('Signal input manifest', () => {
         [...bars, bars[0]],
         'signal',
         'adjusted_daily_bars_v1',
-        defaultProtocol.universe,
+        fixtureProtocol.universe,
         'fixture-v1',
       ),
     ).toThrow('duplicate adjusted bar')
@@ -47,7 +46,7 @@ describe('Signal input manifest', () => {
         bars.filter((bar) => bar.symbol !== 'SPY'),
         'signal',
         'adjusted_daily_bars_v1',
-        defaultProtocol.universe,
+        fixtureProtocol.universe,
         'fixture-v1',
       ),
     ).toThrow('universe mismatch')

--- a/services/bayn/src/protocol.test.ts
+++ b/services/bayn/src/protocol.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Effect, Exit } from 'effect'
+
+import { defaultProtocolDocument, hashTsmomParameters, loadDefaultProtocol, loadTsmomProtocol } from './protocol'
+
+describe('TSMOM parameter contract', () => {
+  test('runtime-decodes the committed immutable parameters', async () => {
+    const protocol = await Effect.runPromise(loadDefaultProtocol)
+
+    expect(protocol.schemaVersion).toBe('bayn.tsmom.protocol.v1')
+    expect(protocol.universe).toEqual(['DBC', 'EEM', 'EFA', 'GLD', 'IEF', 'SPY', 'TLT', 'VNQ'])
+    expect(hashTsmomParameters(protocol)).toMatch(/^[a-f0-9]{64}$/)
+  })
+
+  test('fails with a typed reason for malformed or non-canonical parameters', async () => {
+    const invalidDocuments: readonly unknown[] = [
+      { ...defaultProtocolDocument, universe: [...defaultProtocolDocument.universe, 'SPY'] },
+      { ...defaultProtocolDocument, universe: [...defaultProtocolDocument.universe].reverse() },
+      { ...defaultProtocolDocument, lookbacks: [] },
+      { ...defaultProtocolDocument, lookbacks: [63, 21] },
+      {
+        ...defaultProtocolDocument,
+        thresholds: { ...defaultProtocolDocument.thresholds, minimumObservations: 0 },
+      },
+      { ...defaultProtocolDocument, futureField: true },
+    ]
+
+    for (const document of invalidDocuments) {
+      const exit = await Effect.runPromiseExit(loadTsmomProtocol(document))
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit)) {
+        expect(exit.cause.toString()).toContain('invalid TSMOM parameters')
+      }
+    }
+  })
+})

--- a/services/bayn/src/protocol.ts
+++ b/services/bayn/src/protocol.ts
@@ -1,5 +1,69 @@
+import { Effect, Schema } from 'effect'
+
+import { operationalError, type OperationalError } from './errors'
+import { canonicalHashV1 } from './hash'
 import type { TsmomProtocol } from './types'
 
-import protocol from '../protocols/tsmom-v1.json' with { type: 'json' }
+import protocolDocument from '../protocols/tsmom-v1.json' with { type: 'json' }
 
-export const defaultProtocol = protocol as TsmomProtocol
+const StrictParseOptions = { onExcessProperty: 'error' } as const
+const PositiveInteger = Schema.Int.check(Schema.isGreaterThan(0))
+const NonNegativeFinite = Schema.Finite.check(Schema.isGreaterThanOrEqualTo(0))
+const PositiveFinite = Schema.Finite.check(Schema.isGreaterThan(0))
+const UnitInterval = Schema.Finite.check(Schema.isBetween({ minimum: 0, maximum: 1 }))
+const PositiveUnitInterval = Schema.Finite.check(Schema.isGreaterThan(0), Schema.isLessThanOrEqualTo(1))
+const SymbolName = Schema.String.check(Schema.isPattern(/^[A-Z][A-Z0-9.-]{0,15}$/))
+const PositiveMicros = Schema.String.check(Schema.isPattern(/^[1-9][0-9]*$/))
+
+const TsmomProtocolBase = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.tsmom.protocol.v1'),
+  universe: Schema.Array(SymbolName).check(Schema.isMinLength(1)),
+  lookbacks: Schema.Array(PositiveInteger).check(Schema.isMinLength(1)),
+  rebalance: Schema.Literal('month-end'),
+  execution: Schema.Literal('next-session-open'),
+  positionPolicy: Schema.Literal('long-or-cash'),
+  directVolatilityTarget: PositiveUnitInterval,
+  initialCapitalMicros: PositiveMicros,
+  transactionCostBps: NonNegativeFinite.check(Schema.isLessThanOrEqualTo(10_000)),
+  thresholds: Schema.Struct({
+    minimumObservations: PositiveInteger,
+    minimumAnnualizedReturn: Schema.Finite.check(Schema.isGreaterThan(-1)),
+    minimumSharpeImprovement: Schema.Finite,
+    maximumDrawdown: UnitInterval,
+    maximumAnnualTurnover: PositiveFinite,
+    requirePositiveDoubleCostReturn: Schema.Boolean,
+  }),
+})
+
+export const TsmomProtocolSchema = TsmomProtocolBase.check(
+  Schema.makeFilter((parameters: typeof TsmomProtocolBase.Type) => {
+    const issues: Schema.FilterIssue[] = []
+    const sortedUniverse = [...new Set(parameters.universe)].sort()
+    if (sortedUniverse.length !== parameters.universe.length) {
+      issues.push({ path: ['universe'], issue: 'must not contain duplicate symbols' })
+    } else if (sortedUniverse.some((symbol, index) => symbol !== parameters.universe[index])) {
+      issues.push({ path: ['universe'], issue: 'must be sorted in canonical order' })
+    }
+    for (let index = 1; index < parameters.lookbacks.length; index += 1) {
+      if (parameters.lookbacks[index] <= parameters.lookbacks[index - 1]) {
+        issues.push({ path: ['lookbacks', index], issue: 'must be unique and strictly increasing' })
+        break
+      }
+    }
+    return issues
+  }),
+)
+
+export const defaultProtocolDocument = protocolDocument
+
+export const loadTsmomProtocol = (input: unknown): Effect.Effect<TsmomProtocol, OperationalError> =>
+  Schema.decodeUnknownEffect(
+    TsmomProtocolSchema,
+    StrictParseOptions,
+  )(input).pipe(
+    Effect.mapError((cause) => operationalError('strategy', 'parameters', 'invalid TSMOM parameters', cause)),
+  )
+
+export const loadDefaultProtocol = loadTsmomProtocol(defaultProtocolDocument)
+
+export const hashTsmomParameters = (parameters: TsmomProtocol): string => canonicalHashV1(parameters)

--- a/services/bayn/src/resources.test.ts
+++ b/services/bayn/src/resources.test.ts
@@ -21,6 +21,7 @@ const config: RuntimeConfig = {
     imageRepository: provenance.image.repository,
     imageDigest: provenance.image.digest,
     strategyBehaviorHash: provenance.strategy.behaviorHash,
+    verification: 'embedded',
   },
   runOnStartup: true,
   operationTimeoutMs: 20,

--- a/services/bayn/src/resources.test.ts
+++ b/services/bayn/src/resources.test.ts
@@ -8,14 +8,20 @@ import { initialize, type RuntimeState } from './app'
 import type { RuntimeConfig } from './config'
 import { Journal, JournalLive, type JournalService } from './ledger'
 import { MarketData, MarketDataLive, type MarketDataService } from './market-data'
-import { defaultProtocol } from './protocol'
-import { TsmomStrategyLive } from './strategy-service'
-import { makeSnapshot } from './test-fixtures'
+import { TsmomStrategyLayer } from './strategy-service'
+import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
+
+const provenance = makeTestProvenance()
 
 const config: RuntimeConfig = {
   host: '127.0.0.1',
   port: 0,
-  codeRevision: 'test-revision',
+  build: {
+    sourceRevision: provenance.sourceRevision,
+    imageRepository: provenance.image.repository,
+    imageDigest: provenance.image.digest,
+    strategyBehaviorHash: provenance.strategy.behaviorHash,
+  },
   runOnStartup: true,
   operationTimeoutMs: 20,
   clickhouse: {
@@ -54,7 +60,7 @@ describe('Bayn resource lifecycle', () => {
         }).pipe(
           Effect.provide(
             Layer.mergeAll(
-              MarketDataLive(config, defaultProtocol.universe, {
+              MarketDataLive(config, fixtureProtocol.universe, {
                 createClient: (() => clickHouseClient) as unknown as typeof createClickHouseClient,
               }),
               JournalLive(config, {
@@ -94,9 +100,9 @@ describe('Bayn resource lifecycle', () => {
       Effect.scoped(
         initialize(config, state).pipe(
           Effect.provideService(Journal, successfulJournal),
-          Effect.provide(TsmomStrategyLive),
+          Effect.provide(TsmomStrategyLayer(fixtureProtocol, provenance)),
           Effect.provide(
-            MarketDataLive(config, defaultProtocol.universe, {
+            MarketDataLive(config, fixtureProtocol.universe, {
               createClient: (() => clickHouseClient) as unknown as typeof createClickHouseClient,
             }),
           ),
@@ -124,9 +130,9 @@ describe('Bayn resource lifecycle', () => {
       Effect.scoped(
         initialize(config, state).pipe(
           Effect.provideService(Journal, successfulJournal),
-          Effect.provide(TsmomStrategyLive),
+          Effect.provide(TsmomStrategyLayer(fixtureProtocol, provenance)),
           Effect.provide(
-            MarketDataLive(config, defaultProtocol.universe, {
+            MarketDataLive(config, fixtureProtocol.universe, {
               createClient: (() => clickHouseClient) as unknown as typeof createClickHouseClient,
             }),
           ),
@@ -162,7 +168,7 @@ describe('Bayn resource lifecycle', () => {
       Effect.scoped(
         initialize(config, state).pipe(
           Effect.provideService(MarketData, marketData),
-          Effect.provide(TsmomStrategyLive),
+          Effect.provide(TsmomStrategyLayer(fixtureProtocol, provenance)),
           Effect.provide(
             JournalLive(config, {
               createClient: (() => tigerBeetleClient) as unknown as typeof createTigerBeetleClient,

--- a/services/bayn/src/strategy-service.ts
+++ b/services/bayn/src/strategy-service.ts
@@ -1,23 +1,24 @@
 import { Context, Layer } from 'effect'
 
-import { defaultProtocol } from './protocol'
+import type { RuntimeProvenance } from './contracts'
 import { evaluateTsmom } from './strategy'
 import type { DailyBar, EvaluationResult, InputManifest, TsmomProtocol } from './types'
 
 export interface StrategyService {
   readonly name: string
   readonly universe: readonly string[]
-  readonly evaluate: (bars: readonly DailyBar[], manifest: InputManifest, codeRevision: string) => EvaluationResult
+  readonly provenance: RuntimeProvenance
+  readonly evaluate: (bars: readonly DailyBar[], manifest: InputManifest) => EvaluationResult
 }
 
 export class Strategy extends Context.Service<Strategy, StrategyService>()('bayn/Strategy') {}
 
-export const makeTsmomStrategy = (protocol: TsmomProtocol): StrategyService => ({
+export const makeTsmomStrategy = (protocol: TsmomProtocol, provenance: RuntimeProvenance): StrategyService => ({
   name: 'tsmom',
   universe: protocol.universe,
-  evaluate: (bars, manifest, codeRevision) => evaluateTsmom(bars, manifest, protocol, codeRevision),
+  provenance,
+  evaluate: (bars, manifest) => evaluateTsmom(bars, manifest, protocol, provenance),
 })
 
-export const tsmomStrategy = makeTsmomStrategy(defaultProtocol)
-
-export const TsmomStrategyLive = Layer.succeed(Strategy, tsmomStrategy)
+export const TsmomStrategyLayer = (protocol: TsmomProtocol, provenance: RuntimeProvenance) =>
+  Layer.succeed(Strategy, makeTsmomStrategy(protocol, provenance))

--- a/services/bayn/src/strategy.test.ts
+++ b/services/bayn/src/strategy.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 
-import { defaultProtocol } from './protocol'
 import { calculatePerformanceMetrics, evaluateTsmom } from './strategy'
-import { makeSnapshot } from './test-fixtures'
+import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
 import type { FillEvent } from './types'
 
 describe('TSMOM economic evaluator', () => {
@@ -15,10 +14,13 @@ describe('TSMOM economic evaluator', () => {
 
   test('is deterministic, costed, and executes after the signal session', () => {
     const snapshot = makeSnapshot()
-    const first = evaluateTsmom(snapshot.bars, snapshot.manifest, defaultProtocol, 'test-revision')
-    const second = evaluateTsmom(snapshot.bars, snapshot.manifest, defaultProtocol, 'test-revision')
+    const provenance = makeTestProvenance()
+    const first = evaluateTsmom(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance)
+    const second = evaluateTsmom(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance)
     expect(first).toEqual(second)
-    expect(first.strategy.observations).toBeGreaterThanOrEqual(defaultProtocol.thresholds.minimumObservations)
+    expect(first.codeRevision).toBe(provenance.sourceRevision)
+    expect(first.protocolHash).toBe(provenance.strategy.parameterHash)
+    expect(first.strategy.observations).toBeGreaterThanOrEqual(fixtureProtocol.thresholds.minimumObservations)
     expect(BigInt(first.strategy.totalFeesMicros)).toBeGreaterThan(0n)
     expect(first.doubleCostStrategy.endingEquityMicros).not.toBe(first.strategy.endingEquityMicros)
     const firstDecision = first.events.find((event) => event.kind === 'decision')
@@ -33,23 +35,52 @@ describe('TSMOM economic evaluator', () => {
     }
   })
 
-  test('changes run identity when code, input, or protocol changes', () => {
+  test('changes run identity when source, image, behavior, input, or parameters change', () => {
     const snapshot = makeSnapshot()
-    const baseline = evaluateTsmom(snapshot.bars, snapshot.manifest, defaultProtocol, 'revision-a')
-    const codeChanged = evaluateTsmom(snapshot.bars, snapshot.manifest, defaultProtocol, 'revision-b')
+    const baseline = evaluateTsmom(snapshot.bars, snapshot.manifest, fixtureProtocol, makeTestProvenance())
+    const sourceChanged = evaluateTsmom(
+      snapshot.bars,
+      snapshot.manifest,
+      fixtureProtocol,
+      makeTestProvenance(fixtureProtocol, { sourceRevision: 'd'.repeat(40) }),
+    )
+    const imageChanged = evaluateTsmom(
+      snapshot.bars,
+      snapshot.manifest,
+      fixtureProtocol,
+      makeTestProvenance(fixtureProtocol, { imageDigest: `sha256:${'e'.repeat(64)}` }),
+    )
+    const behaviorChanged = evaluateTsmom(
+      snapshot.bars,
+      snapshot.manifest,
+      fixtureProtocol,
+      makeTestProvenance(fixtureProtocol, { behaviorHash: 'f'.repeat(64) }),
+    )
+    const changedProtocol = { ...fixtureProtocol, transactionCostBps: fixtureProtocol.transactionCostBps + 1 }
     const protocolChanged = evaluateTsmom(
       snapshot.bars,
       snapshot.manifest,
-      { ...defaultProtocol, transactionCostBps: defaultProtocol.transactionCostBps + 1 },
-      'revision-a',
+      changedProtocol,
+      makeTestProvenance(changedProtocol),
     )
-    expect(codeChanged.runId).not.toBe(baseline.runId)
+    expect(sourceChanged.runId).not.toBe(baseline.runId)
+    expect(imageChanged.runId).not.toBe(baseline.runId)
+    expect(behaviorChanged.runId).not.toBe(baseline.runId)
     expect(protocolChanged.runId).not.toBe(baseline.runId)
+  })
+
+  test('rejects a false parameter attribution before evaluation', () => {
+    const snapshot = makeSnapshot()
+    const changedProtocol = { ...fixtureProtocol, transactionCostBps: fixtureProtocol.transactionCostBps + 1 }
+
+    expect(() => evaluateTsmom(snapshot.bars, snapshot.manifest, changedProtocol, makeTestProvenance())).toThrow(
+      'parameter hash does not match',
+    )
   })
 
   test('fails before evaluation when comparable history is insufficient', () => {
     const snapshot = makeSnapshot(700)
-    expect(() => evaluateTsmom(snapshot.bars, snapshot.manifest, defaultProtocol, 'test-revision')).toThrow(
+    expect(() => evaluateTsmom(snapshot.bars, snapshot.manifest, fixtureProtocol, makeTestProvenance())).toThrow(
       'comparable observations',
     )
   })

--- a/services/bayn/src/strategy.ts
+++ b/services/bayn/src/strategy.ts
@@ -1,4 +1,6 @@
-import { hashObject } from './hash'
+import type { RuntimeProvenance } from './contracts'
+import { canonicalHashV1, hashObject } from './hash'
+import { hashTsmomParameters } from './protocol'
 import type {
   DailyBar,
   DecisionEvent,
@@ -342,10 +344,21 @@ export const evaluateTsmom = (
   bars: readonly DailyBar[],
   inputManifest: InputManifest,
   protocol: TsmomProtocol,
-  codeRevision: string,
+  provenance: RuntimeProvenance,
 ): EvaluationResult => {
-  const protocolHash = hashObject(protocol)
-  const runId = hashObject({ codeRevision, inputManifestHash: inputManifest.hash, protocolHash })
+  const protocolHash = hashTsmomParameters(protocol)
+  if (provenance.strategy.name !== 'tsmom') throw new Error('runtime provenance strategy must be tsmom')
+  if (provenance.strategy.parameterSchemaVersion !== protocol.schemaVersion) {
+    throw new Error('runtime provenance parameter schema does not match decoded TSMOM parameters')
+  }
+  if (provenance.strategy.parameterHash !== protocolHash) {
+    throw new Error('runtime provenance parameter hash does not match decoded TSMOM parameters')
+  }
+  const runId = canonicalHashV1({
+    schemaVersion: 'bayn.transitional-run-identity.v1',
+    provenance,
+    inputManifestHash: inputManifest.hash,
+  })
   const sessions = alignBars(bars, protocol.universe)
   const maximumLookback = Math.max(...protocol.lookbacks)
   const signalIndices = sessions
@@ -420,7 +433,7 @@ export const evaluateTsmom = (
   return {
     schemaVersion: 'bayn.evaluation.v1',
     runId,
-    codeRevision,
+    codeRevision: provenance.sourceRevision,
     protocolHash,
     initialCapitalMicros: protocol.initialCapitalMicros,
     inputManifest,

--- a/services/bayn/src/test-fixtures.ts
+++ b/services/bayn/src/test-fixtures.ts
@@ -1,6 +1,33 @@
+import { Effect } from 'effect'
+
+import { makeRuntimeProvenance, type RuntimeProvenance } from './contracts'
 import { buildInputManifest } from './market-data'
-import { defaultProtocol } from './protocol'
-import type { DailyBar, InputManifest, IsoDate } from './types'
+import { hashTsmomParameters, loadDefaultProtocol } from './protocol'
+import type { DailyBar, InputManifest, IsoDate, TsmomProtocol } from './types'
+
+export const fixtureProtocol = Effect.runSync(loadDefaultProtocol)
+
+export const makeTestProvenance = (
+  protocol: TsmomProtocol = fixtureProtocol,
+  overrides: {
+    readonly sourceRevision?: string
+    readonly imageDigest?: string
+    readonly behaviorHash?: string
+  } = {},
+): RuntimeProvenance =>
+  makeRuntimeProvenance({
+    sourceRevision: overrides.sourceRevision ?? 'a'.repeat(40),
+    image: {
+      repository: 'registry.ide-newton.ts.net/lab/bayn',
+      digest: overrides.imageDigest ?? `sha256:${'b'.repeat(64)}`,
+    },
+    strategy: {
+      name: 'tsmom',
+      behaviorHash: overrides.behaviorHash ?? 'c'.repeat(64),
+      parameterHash: hashTsmomParameters(protocol),
+      parameterSchemaVersion: protocol.schemaVersion,
+    },
+  })
 
 export const makeBars = (sessionCount = 900): readonly DailyBar[] => {
   const bars: DailyBar[] = []
@@ -9,8 +36,8 @@ export const makeBars = (sessionCount = 900): readonly DailyBar[] => {
   while (session < sessionCount) {
     const day = cursor.getUTCDay()
     if (day !== 0 && day !== 6) {
-      for (let symbolIndex = 0; symbolIndex < defaultProtocol.universe.length; symbolIndex += 1) {
-        const symbol = defaultProtocol.universe[symbolIndex]
+      for (let symbolIndex = 0; symbolIndex < fixtureProtocol.universe.length; symbolIndex += 1) {
+        const symbol = fixtureProtocol.universe[symbolIndex]
         const trend = symbolIndex % 3 === 0 ? -0.00005 : 0.00025 + symbolIndex * 0.00001
         const close =
           (50 + symbolIndex * 10) * (1 + trend * session) * (1 + 0.025 * Math.sin(session / 18 + symbolIndex))
@@ -42,6 +69,6 @@ export const makeSnapshot = (
   const bars = makeBars(sessionCount)
   return {
     bars,
-    manifest: buildInputManifest(bars, 'signal', 'adjusted_daily_bars_v1', defaultProtocol.universe, 'fixture-v1'),
+    manifest: buildInputManifest(bars, 'signal', 'adjusted_daily_bars_v1', fixtureProtocol.universe, 'fixture-v1'),
   }
 }


### PR DESCRIPTION
## Summary

- runtime-decode the immutable TSMOM parameter contract with Effect Schema and reject malformed or excess configuration
- embed source revision, image repository, and strategy behavior identity into the production Bun artifact, then expose verified runtime provenance in status and evidence
- require GitOps to supply the promoted OCI index digest and update Bayn release automation atomically with the image tag and source revision
- keep package `dev`/`start` usable through visibly unverified development provenance that cannot override embedded builds and cannot evaluate or journal
- bind transitional evaluation run identity to the verified provenance and input manifest while leaving the final run-identity contract to its dedicated roadmap ticket

## Related Issues

PROOMPT-356

## Testing

- `bun run --filter @proompteng/bayn test` — 44 tests, 172 assertions, 0 failures
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- `bun test packages/scripts/src` — 607 tests, 4669 assertions, 0 failures
- `bun test packages/scripts/src/bayn/update-manifests.test.ts` — 2 tests, 7 assertions
- `nix-instantiate --parse nix/images/bayn.nix`
- `nix-instantiate --parse nix/images/bun-workspace-service.nix`
- `nix-instantiate --parse flake.nix`
- `kustomize build argocd/applications/bayn | kubeconform -strict -summary -ignore-missing-schemas` — 5 valid, 0 invalid
- `git diff --check`
- compiled a real Bun artifact with immutable build defines and verified a configured/embedded revision mismatch exits before external resource acquisition with a typed provenance error
- started the standard local built bundle, observed `provenanceVerification: development-configured`, `FAIL_CLOSED`, no evidence, and no evaluation/journaling despite `BAYN_RUN_ON_STARTUP=true`
- full Nix evaluation was unavailable locally because the Nix daemon socket refused the connection; the repository's dual-architecture image CI is the authoritative production image build

## Breaking Changes

Bayn now requires `BAYN_IMAGE_REPOSITORY` and `BAYN_IMAGE_DIGEST`, and refuses startup when `BAYN_CODE_REVISION` or the configured repository differs from the immutable facts embedded by the Nix production build. The Deployment and Bayn release writer are updated in this pull request so promotion supplies the complete contract. Package `dev` and `start` explicitly select non-production provenance; that mode is visible in status and forces evaluation and journaling off.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
