### PR TITLE
chore(torghut): promote image sha-79152bcf8e9c2bb74ef5b4059774bfb58a0eecbd

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -54,7 +54,7 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: e8cbb061811bf6c279581eab9bdfd1299fb5187a
+              value: 79152bcf8e9c2bb74ef5b4059774bfb58a0eecbd
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:5bad4a41c045fd00ea9ce014f5e49f5249bed686657e137fade783542da9e181
             - name: PYTHONPATH

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -46,7 +46,7 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: e8cbb061811bf6c279581eab9bdfd1299fb5187a
+              value: 79152bcf8e9c2bb74ef5b4059774bfb58a0eecbd
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:5bad4a41c045fd00ea9ce014f5e49f5249bed686657e137fade783542da9e181
             - name: DB_DSN

--- a/argocd/applications/torghut-options/archive/deployment.yaml
+++ b/argocd/applications/torghut-options/archive/deployment.yaml
@@ -100,9 +100,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2289-ge8cbb0618
+              value: v0.596.0-2294-g79152bcf8
             - name: TORGHUT_OPTIONS_COMMIT
-              value: e8cbb061811bf6c279581eab9bdfd1299fb5187a
+              value: 79152bcf8e9c2bb74ef5b4059774bfb58a0eecbd
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -110,9 +110,9 @@ spec:
                   name: torghut-ws-config
                   key: SYMBOLS_ALLOWLIST
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2289-ge8cbb0618
+              value: v0.596.0-2294-g79152bcf8
             - name: TORGHUT_OPTIONS_COMMIT
-              value: e8cbb061811bf6c279581eab9bdfd1299fb5187a
+              value: 79152bcf8e9c2bb74ef5b4059774bfb58a0eecbd
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -106,9 +106,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2289-ge8cbb0618
+              value: v0.596.0-2294-g79152bcf8
             - name: TORGHUT_OPTIONS_COMMIT
-              value: e8cbb061811bf6c279581eab9bdfd1299fb5187a
+              value: 79152bcf8e9c2bb74ef5b4059774bfb58a0eecbd
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/broker-economic-ledger-reconciliation-cronjob.yaml
+++ b/argocd/applications/torghut/broker-economic-ledger-reconciliation-cronjob.yaml
@@ -92,9 +92,9 @@ spec:
                 - name: TRADING_ACCOUNT_LABEL
                   value: PA3SX7FYNUTF
                 - name: TORGHUT_VERSION
-                  value: v0.596.0-2289-ge8cbb0618
+                  value: v0.596.0-2294-g79152bcf8
                 - name: TORGHUT_COMMIT
-                  value: e8cbb061811bf6c279581eab9bdfd1299fb5187a
+                  value: 79152bcf8e9c2bb74ef5b4059774bfb58a0eecbd
                 - name: TORGHUT_IMAGE_DIGEST
                   value: sha256:5bad4a41c045fd00ea9ce014f5e49f5249bed686657e137fade783542da9e181
                 - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-20T08:27:30Z"
+        client.knative.dev/updateTimestamp: "2026-07-20T09:03:05Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -528,9 +528,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2289-ge8cbb0618
+              value: v0.596.0-2294-g79152bcf8
             - name: TORGHUT_COMMIT
-              value: e8cbb061811bf6c279581eab9bdfd1299fb5187a
+              value: 79152bcf8e9c2bb74ef5b4059774bfb58a0eecbd
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:5bad4a41c045fd00ea9ce014f5e49f5249bed686657e137fade783542da9e181
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-20T08:27:30Z"
+        client.knative.dev/updateTimestamp: "2026-07-20T09:03:05Z"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
     spec:
@@ -453,9 +453,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2289-ge8cbb0618
+              value: v0.596.0-2294-g79152bcf8
             - name: TORGHUT_COMMIT
-              value: e8cbb061811bf6c279581eab9bdfd1299fb5187a
+              value: 79152bcf8e9c2bb74ef5b4059774bfb58a0eecbd
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:5bad4a41c045fd00ea9ce014f5e49f5249bed686657e137fade783542da9e181
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/order-lineage-reconciliation-cronjob.yaml
+++ b/argocd/applications/torghut/order-lineage-reconciliation-cronjob.yaml
@@ -88,9 +88,9 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_VERSION
-                  value: v0.596.0-2289-ge8cbb0618
+                  value: v0.596.0-2294-g79152bcf8
                 - name: TORGHUT_COMMIT
-                  value: e8cbb061811bf6c279581eab9bdfd1299fb5187a
+                  value: 79152bcf8e9c2bb74ef5b4059774bfb58a0eecbd
                 - name: TORGHUT_IMAGE_DIGEST
                   value: sha256:5bad4a41c045fd00ea9ce014f5e49f5249bed686657e137fade783542da9e181
                 - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -470,9 +470,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2289-ge8cbb0618
+              value: v0.596.0-2294-g79152bcf8
             - name: TORGHUT_COMMIT
-              value: e8cbb061811bf6c279581eab9bdfd1299fb5187a
+              value: 79152bcf8e9c2bb74ef5b4059774bfb58a0eecbd
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:5bad4a41c045fd00ea9ce014f5e49f5249bed686657e137fade783542da9e181
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `79152bcf8e9c2bb74ef5b4059774bfb58a0eecbd`
- Image tag: `sha-79152bcf8e9c2bb74ef5b4059774bfb58a0eecbd`
- Image digest: `sha256:5bad4a41c045fd00ea9ce014f5e49f5249bed686657e137fade783542da9e181`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher