### PR TITLE
chore(torghut): promote notebook image sha-2ffb7c4966dd1cb05011143a46fecc871366224d

### DIFF
--- a/argocd/applications/torghut/notebooks/values.yaml
+++ b/argocd/applications/torghut/notebooks/values.yaml
@@ -94,7 +94,7 @@ singleuser:
   cmd: null
   image:
     name: registry.ide-newton.ts.net/lab/torghut-notebook@sha256
-    tag: '97c8c88b6a6b97b647986ee85f438feb68edcd61bad1fbdd79251a1d076b9de1'
+    tag: 'ebb67a85f333d3f9a67ba9556761c78cd68ade05cf502e6c39ceb9f89b10351b'
     pullPolicy: IfNotPresent
   defaultUrl: /lab/tree/work/00-system-flow.ipynb
   startTimeout: 600


### PR DESCRIPTION
## Summary

- Promote the immutable multi-architecture Torghut notebook image built from `2ffb7c4966dd1cb05011143a46fecc871366224d`.
- Update only the digest-pinned JupyterHub single-user image.

## Related Issues

None.

## Testing

- The source commit passed notebook fixture execution and manifest contracts.
- The release workflow verified `linux/amd64` and `linux/arm64` for `sha256:ebb67a85f333d3f9a67ba9556761c78cd68ade05cf502e6c39ceb9f89b10351b`.

## Breaking Changes

None.

## Checklist

- [x] The single-user image is immutable and multi-architecture.
- [x] Promotion changes only the notebook image digest.
- [x] PVCs and read-only credentials are unchanged.