### PR TITLE
chore(product): promote nix product images

### DIFF
--- a/argocd/applications/app/kustomization.yaml
+++ b/argocd/applications/app/kustomization.yaml
@@ -8,5 +8,5 @@ resources:
   - secret.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/app
-    digest: sha256:29f56d83d14dc2fde39f25d3353d6bbf2cf6507d7034d7ba04da3912e51f6d24
+    digest: sha256:747fc3e090e60fb88442f334d509de412a038e41f6365ed4513003ce5af9dd6f
     newName: registry.ide-newton.ts.net/lab/app

--- a/argocd/applications/docs/kustomization.yaml
+++ b/argocd/applications/docs/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
   - generated
 images:
   - name: registry.ide-newton.ts.net/lab/docs
-    digest: sha256:2ee172f51787268c428cb4d19165625bc56bb778137480556dc0a38e331e3f0b
+    digest: sha256:7263e801c1511fda59800fc8269608d6f55f7bbf083bc5df5fe00de13aa2603c
     newName: registry.ide-newton.ts.net/lab/docs

--- a/argocd/applications/proompteng/kustomization.yaml
+++ b/argocd/applications/proompteng/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
 - ingressroute.yaml
 images:
 - name: registry.ide-newton.ts.net/lab/proompteng
-  digest: sha256:f4380b4b857cf39176107b36c98f468c3191b45a44f1d39ddbaff4b2b348b04c
+  digest: sha256:c92d8c09675bd1894781a820857f938053d01af4d2ed65a2bc25af15e8a341ea
   newName: registry.ide-newton.ts.net/lab/proompteng

--- a/argocd/applications/synthesis/kustomization.yaml
+++ b/argocd/applications/synthesis/kustomization.yaml
@@ -11,5 +11,5 @@ resources:
   - agents-domain
 images:
   - name: registry.ide-newton.ts.net/lab/synthesis
-    digest: sha256:8e63384605068a59c480f427cc1272f739c760e6963659618c314184a7a12012
+    digest: sha256:470f7350e496a7fb9af045403cfcdf55441da33a02a8a7dfb8ec37d2b423c2a6
     newName: registry.ide-newton.ts.net/lab/synthesis


### PR DESCRIPTION
## Summary

- Promote enabled product app image digests built by the shared Nix OCI workflow.
- `app`: `registry.ide-newton.ts.net/lab/app@sha256:747fc3e090e60fb88442f334d509de412a038e41f6365ed4513003ce5af9dd6f` from `2ffb7c4966dd1cb05011143a46fecc871366224d`
- `docs`: `registry.ide-newton.ts.net/lab/docs@sha256:7263e801c1511fda59800fc8269608d6f55f7bbf083bc5df5fe00de13aa2603c` from `2ffb7c4966dd1cb05011143a46fecc871366224d`
- `proompteng`: `registry.ide-newton.ts.net/lab/proompteng@sha256:c92d8c09675bd1894781a820857f938053d01af4d2ed65a2bc25af15e8a341ea` from `2ffb7c4966dd1cb05011143a46fecc871366224d`
- `synthesis`: `registry.ide-newton.ts.net/lab/synthesis@sha256:470f7350e496a7fb9af045403cfcdf55441da33a02a8a7dfb8ec37d2b423c2a6` from `2ffb7c4966dd1cb05011143a46fecc871366224d`

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- <image>@<digest> linux/amd64 linux/arm64` for each promoted image.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.