### PR TITLE
fix(agents): unblock Linear release publication

### DIFF
--- a/charts/agents/Chart.yaml
+++ b/charts/agents/Chart.yaml
@@ -6,7 +6,7 @@ sources:
   - https://github.com/proompteng/charts/tree/main/charts/agents
 type: application
 kubeVersion: '>=1.25.0-0'
-version: 0.9.28
+version: 0.9.29
 appVersion: '0.9.0'
 icon: https://avatars.githubusercontent.com/u/234536857
 keywords:

--- a/charts/agents/artifacthub-pkg.yml
+++ b/charts/agents/artifacthub-pkg.yml
@@ -1,4 +1,4 @@
-version: 0.9.28
+version: 0.9.29
 name: agents
 displayName: Agents Control Plane
 description: Minimal Agents control plane with CRDs and native workflow runtime.

--- a/nix/images/froussard.nix
+++ b/nix/images/froussard.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "froussard";
   packageName = "froussard";
   depsHash = {
-    x86_64-linux = "sha256-aUl+STPhASYBn9SjCz8uxqw3xE/YG+u/56uM689fi2E=";
-    aarch64-linux = "sha256-FeUEun3xfKfr8QnLkUvYmyblWWfdnib0gv1xGN0/rb8=";
+    x86_64-linux = "sha256-NM/bGVinQ7tlCqGwYBAvgixN4+VJ3MAlHN6+91nNw7Q=";
+    aarch64-linux = "sha256-f5UbFMOiJbHYEsGwUdoowjLJYUWa1AwKjKeAhma1Mvk=";
   };
   installFilters = [
     "@proompteng/agent-contracts"


### PR DESCRIPTION
## Summary

- bump the Agents Helm chart from `0.9.28` to `0.9.29` so the changed Linear CRDs and gateway chart can be published immutably
- keep `artifacthub-pkg.yml` aligned with `Chart.yaml`
- refresh both architecture-specific Froussard Bun dependency hashes from the authoritative failed Nix builds
- unblock `agents-sync` and the Froussard image publication triggered by #12888

## Related Issues

Follow-up to #12888.

## Testing

- `helm lint charts/agents`
- `bun packages/scripts/src/agents/publish-chart.ts --chart-dir charts/agents --dry-run` — packaged `agents-0.9.29.tgz`
- `nix-instantiate --parse nix/images/froussard.nix`
- the prior main-branch Nix build produced the exact replacement hashes independently on amd64 and arm64
- `git diff --check`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation and follow-up context are updated.
