### PR TITLE
chore(froussard): promote nix image sha-e33cfb024520b4ce1a215d03552b8f9f3feb0725

### DIFF
--- a/argocd/applications/froussard/knative-service.yaml
+++ b/argocd/applications/froussard/knative-service.yaml
@@ -24,7 +24,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: app
-          image: registry.ide-newton.ts.net/lab/froussard@sha256:a302534b5266cbe975f9767731e5ea85f44318cb427b7702a8e1383895569db9
+          image: registry.ide-newton.ts.net/lab/froussard@sha256:3038f57a1616b3280d1f7a49f8d4519795a02dc81a630cae480100162e9ee5d4
           imagePullPolicy: Always
           ports:
             - containerPort: 8080
@@ -75,7 +75,7 @@ spec:
             - name: FROUSSARD_VERSION
               value: v0.571.1-491-ga931fba9e
             - name: FROUSSARD_COMMIT
-              value: d8d24cd01df091dedde7e32c262fea96cc3d7d11
+              value: e33cfb024520b4ce1a215d03552b8f9f3feb0725
             - name: LGTM_TEMPO_TRACES_ENDPOINT
               value: http://observability-tempo-gateway.observability.svc.cluster.local:4317
             - name: LGTM_MIMIR_METRICS_ENDPOINT


### PR DESCRIPTION
## Summary

- Promote `froussard` to `registry.ide-newton.ts.net/lab/froussard@sha256:3038f57a1616b3280d1f7a49f8d4519795a02dc81a630cae480100162e9ee5d4`.
- Source commit: `e33cfb024520b4ce1a215d03552b8f9f3feb0725`.
- Built by the shared Nix OCI workflow without Docker Buildx.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/froussard@sha256:3038f57a1616b3280d1f7a49f8d4519795a02dc81a630cae480100162e9ee5d4" linux/amd64 linux/arm64`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.