### PR TITLE
feat(bayn): provision durable CNPG evidence store

### DIFF
--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - serviceaccount.yaml
   - clickhouse-secret.yaml
   - objectbucketclaim.yaml
+  - postgres-objectstore.yaml
   - postgres-cluster.yaml
   - postgres-scheduled-backup.yaml
   - deployment.yaml

--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -4,6 +4,9 @@ namespace: bayn
 resources:
   - serviceaccount.yaml
   - clickhouse-secret.yaml
+  - objectbucketclaim.yaml
+  - postgres-cluster.yaml
+  - postgres-scheduled-backup.yaml
   - deployment.yaml
   - service.yaml
   - networkpolicy.yaml

--- a/argocd/applications/bayn/networkpolicy.yaml
+++ b/argocd/applications/bayn/networkpolicy.yaml
@@ -51,3 +51,61 @@ spec:
       ports:
         - port: 3000
           protocol: TCP
+    - to:
+        - podSelector:
+            matchLabels:
+              cnpg.io/cluster: bayn-db
+      ports:
+        - port: 5432
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: bayn-db
+  labels:
+    app.kubernetes.io/name: bayn-db
+    app.kubernetes.io/part-of: bayn
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: bayn-db
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: bayn
+      ports:
+        - port: 5432
+          protocol: TCP
+    - from:
+        - podSelector:
+            matchLabels:
+              cnpg.io/cluster: bayn-db
+      ports:
+        - port: 5432
+          protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: cloudnative-pg
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: cloudnative-pg
+      ports:
+        - port: 5432
+          protocol: TCP
+        - port: 8000
+          protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: observability-cluster-metrics-alloy
+      ports:
+        - port: 9187
+          protocol: TCP

--- a/argocd/applications/bayn/objectbucketclaim.yaml
+++ b/argocd/applications/bayn/objectbucketclaim.yaml
@@ -1,0 +1,10 @@
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: cnpg-bayn-db
+  annotations:
+    argocd.argoproj.io/sync-wave: "-10"
+    argocd.argoproj.io/sync-options: Prune=false,Delete=false
+spec:
+  bucketName: cnpg-bayn
+  storageClassName: rook-ceph-bucket

--- a/argocd/applications/bayn/postgres-cluster.yaml
+++ b/argocd/applications/bayn/postgres-cluster.yaml
@@ -1,0 +1,76 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: bayn-db
+  labels:
+    app.kubernetes.io/name: bayn-db
+    app.kubernetes.io/part-of: bayn
+  annotations:
+    argocd.argoproj.io/sync-wave: "-5"
+    argocd.argoproj.io/sync-options: Prune=false,Delete=false
+spec:
+  description: Bayn control and evaluation evidence
+  instances: 2
+  imageName: ghcr.io/cloudnative-pg/postgresql:18.4-system-trixie@sha256:9287ce030c6f3ce822e383b019ae4aaf1e8370bff3b39f9c51dc10d69dc97219
+  imagePullPolicy: IfNotPresent
+  enablePDB: true
+  enableSuperuserAccess: false
+  minSyncReplicas: 1
+  maxSyncReplicas: 1
+  primaryUpdateStrategy: unsupervised
+  primaryUpdateMethod: switchover
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64
+    podAntiAffinityType: required
+    topologyKey: kubernetes.io/hostname
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: "2"
+      memory: 2Gi
+  storage:
+    storageClass: rook-ceph-block
+    size: 10Gi
+    resizeInUseVolumes: true
+  bootstrap:
+    initdb:
+      database: bayn
+      owner: bayn_app
+      encoding: UTF8
+      dataChecksums: true
+  postgresql:
+    parameters:
+      password_encryption: scram-sha-256
+      ssl_min_protocol_version: TLSv1.3
+  backup:
+    target: prefer-standby
+    barmanObjectStore:
+      destinationPath: s3://cnpg-bayn
+      serverName: bayn-db-live
+      endpointURL: http://rook-ceph-rgw-objectstore.rook-ceph.svc.cluster.local:80
+      s3Credentials:
+        accessKeyId:
+          name: cnpg-bayn-db
+          key: AWS_ACCESS_KEY_ID
+        secretAccessKey:
+          name: cnpg-bayn-db
+          key: AWS_SECRET_ACCESS_KEY
+      data:
+        compression: snappy
+        jobs: 1
+        additionalCommandArgs:
+          - --max-bandwidth
+          - 8MB
+      wal:
+        compression: snappy
+        maxParallel: 2
+    retentionPolicy: 14d

--- a/argocd/applications/bayn/postgres-cluster.yaml
+++ b/argocd/applications/bayn/postgres-cluster.yaml
@@ -51,26 +51,9 @@ spec:
     parameters:
       password_encryption: scram-sha-256
       ssl_min_protocol_version: TLSv1.3
-  backup:
-    target: prefer-standby
-    barmanObjectStore:
-      destinationPath: s3://cnpg-bayn
-      serverName: bayn-db-live
-      endpointURL: http://rook-ceph-rgw-objectstore.rook-ceph.svc.cluster.local:80
-      s3Credentials:
-        accessKeyId:
-          name: cnpg-bayn-db
-          key: AWS_ACCESS_KEY_ID
-        secretAccessKey:
-          name: cnpg-bayn-db
-          key: AWS_SECRET_ACCESS_KEY
-      data:
-        compression: snappy
-        jobs: 1
-        additionalCommandArgs:
-          - --max-bandwidth
-          - 8MB
-      wal:
-        compression: snappy
-        maxParallel: 2
-    retentionPolicy: 14d
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: bayn-db
+        serverName: bayn-db-live

--- a/argocd/applications/bayn/postgres-objectstore.yaml
+++ b/argocd/applications/bayn/postgres-objectstore.yaml
@@ -1,0 +1,41 @@
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: bayn-db
+  labels:
+    app.kubernetes.io/name: bayn-db
+    app.kubernetes.io/part-of: bayn
+  annotations:
+    argocd.argoproj.io/sync-wave: "-8"
+    argocd.argoproj.io/sync-options: Prune=false,Delete=false,SkipDryRunOnMissingResource=true
+spec:
+  retentionPolicy: 14d
+  instanceSidecarConfiguration:
+    logLevel: info
+    retentionPolicyIntervalSeconds: 1800
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+  configuration:
+    destinationPath: s3://cnpg-bayn/
+    endpointURL: http://rook-ceph-rgw-objectstore.rook-ceph.svc.cluster.local:80
+    s3Credentials:
+      accessKeyId:
+        name: cnpg-bayn-db
+        key: AWS_ACCESS_KEY_ID
+      secretAccessKey:
+        name: cnpg-bayn-db
+        key: AWS_SECRET_ACCESS_KEY
+    data:
+      compression: snappy
+      jobs: 1
+      additionalCommandArgs:
+        - --max-bandwidth
+        - 8MB
+    wal:
+      compression: snappy
+      maxParallel: 2

--- a/argocd/applications/bayn/postgres-scheduled-backup.yaml
+++ b/argocd/applications/bayn/postgres-scheduled-backup.yaml
@@ -11,6 +11,9 @@ spec:
   schedule: "0 0 3 * * *"
   immediate: true
   backupOwnerReference: cluster
-  method: barmanObjectStore
+  target: prefer-standby
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
   cluster:
     name: bayn-db

--- a/argocd/applications/bayn/postgres-scheduled-backup.yaml
+++ b/argocd/applications/bayn/postgres-scheduled-backup.yaml
@@ -1,0 +1,16 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: bayn-db-daily
+  labels:
+    app.kubernetes.io/name: bayn-db
+    app.kubernetes.io/part-of: bayn
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  schedule: "0 0 3 * * *"
+  immediate: true
+  backupOwnerReference: cluster
+  method: barmanObjectStore
+  cluster:
+    name: bayn-db

--- a/argocd/applications/cloudnative-pg/kustomization.yaml
+++ b/argocd/applications/cloudnative-pg/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: cloudnative-pg
+resources:
+  - https://github.com/cloudnative-pg/plugin-barman-cloud/releases/download/v0.13.0/manifest.yaml
 helmCharts:
   - name: cloudnative-pg
     repo: https://cloudnative-pg.io/charts
@@ -8,3 +10,40 @@ helmCharts:
     releaseName: cloudnative-pg
     namespace: cloudnative-pg
     includeCRDs: true
+patches:
+  - target:
+      kind: Deployment
+      name: barman-cloud
+    patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: barman-cloud
+      spec:
+        template:
+          spec:
+            containers:
+              - name: barman-cloud
+                image: ghcr.io/cloudnative-pg/plugin-barman-cloud@sha256:71589dbac582333442812b07b31f7ea4d00324a8358aac7ca507dabf9f4b6c96
+                args:
+                  - operator
+                  - --server-cert=/server/tls.crt
+                  - --server-key=/server/tls.key
+                  - --client-cert=/client/tls.crt
+                  - --server-address=:9090
+                  - --leader-elect
+                  - --log-level=info
+                resources:
+                  requests:
+                    cpu: 100m
+                    memory: 128Mi
+                  limits:
+                    cpu: 500m
+                    memory: 512Mi
+  - target:
+      kind: Secret
+      name: plugin-barman-cloud-m5m67kfh8f
+    patch: |-
+      - op: replace
+        path: /data/SIDECAR_IMAGE
+        value: Z2hjci5pby9jbG91ZG5hdGl2ZS1wZy9wbHVnaW4tYmFybWFuLWNsb3VkLXNpZGVjYXJAc2hhMjU2Ojk5MDM2MWFmMzMxOWY5ZTIzYWFmYTBmNmQ3OTgxZjk5YmYxZjY5YjRlNmE4NWNmMWJjN2Q3MWQ2ZjA5YmIyODg=

--- a/docs/bayn/cnpg-backup-restore.md
+++ b/docs/bayn/cnpg-backup-restore.md
@@ -1,22 +1,25 @@
 # Bayn CNPG backup and restore
 
-Bayn owns `Cluster/bayn-db` and `ObjectBucketClaim/cnpg-bayn-db` in namespace `bayn`. Both are protected from
-ordinary Argo prune/delete operations. They must only be removed through an explicitly approved evidence-retention
-change. The database has two synchronous amd64 instances; loss of the standby blocks writes instead of acknowledging
-unreplicated evidence.
+Bayn owns `Cluster/bayn-db`, `ObjectStore/bayn-db`, and `ObjectBucketClaim/cnpg-bayn-db` in namespace `bayn`. All three
+are protected from ordinary Argo prune/delete operations. They must only be removed through an explicitly approved
+evidence-retention change. The database has two synchronous amd64 instances; loss of the standby blocks writes instead
+of acknowledging unreplicated evidence.
 
-CloudNativePG 1.30 still supports native Barman Cloud, and the installed cluster does not yet run the Barman Cloud
-Plugin. Bayn therefore uses the pinned PostgreSQL 18.4 `system-trixie` image and the existing native object-store path.
-Migrating the shared platform to the plugin is a separate change before CloudNativePG 1.31 removes native support.
+The platform app installs Barman Cloud Plugin 0.13.0 in the same namespace as the CloudNativePG 1.30 operator. Its
+manager and injected sidecar images are pinned by multi-architecture digest. Bayn uses the plugin API from its first
+backup, avoiding the native Barman API that CloudNativePG removes in 1.31.
 
 Upstream contracts: [CloudNativePG 1.30 release notes](https://cloudnative-pg.io/docs/1.30/release_notes/v1.30/),
-[native Barman backup and recovery](https://cloudnative-pg.io/docs/1.30/appendixes/backup_barmanobjectstore/), and
+[Barman Cloud Plugin installation](https://cloudnative-pg.io/plugin-barman-cloud/docs/installation/),
+[Barman Cloud Plugin usage](https://cloudnative-pg.io/plugin-barman-cloud/docs/usage/), and
 [required CNPG network ports](https://cloudnative-pg.io/docs/1.30/security/#exposed-ports).
 
 ## Primary checks
 
 ```sh
+kubectl -n cloudnative-pg rollout status deployment/barman-cloud
 kubectl -n bayn get objectbucketclaim cnpg-bayn-db
+kubectl -n bayn get objectstore.barmancloud.cnpg.io bayn-db
 kubectl -n bayn get cluster bayn-db
 kubectl -n bayn get pods -l cnpg.io/cluster=bayn-db -o wide
 kubectl -n bayn get scheduledbackup bayn-db-daily
@@ -27,7 +30,9 @@ kubectl cnpg psql -n bayn bayn-db -- -d bayn -Atqc \
   "select rolname, rolsuper, rolcreatedb, rolcreaterole from pg_roles where rolname = 'bayn_app'"
 ```
 
-The expected role row is `bayn_app|f|f|f`. Never print Secret data. In Mimir, both instances must be present and healthy:
+The expected role row is `bayn_app|f|f|f`. `kubectl cnpg status` must report
+`barman-cloud.cloudnative-pg.io` under Plugins status and successful WAL archiving. Never print Secret data. In Mimir,
+both instances must be present and healthy:
 
 ```promql
 count(up{cluster="bayn-db",job="cnpg-postgres"} == 1) == 2
@@ -48,7 +53,8 @@ the recovery Cluster has no backup stanza and only reads that archive.
 2. Request and wait for a named backup:
 
    ```sh
-   kubectl cnpg backup -n bayn bayn-db --backup-name bayn-db-proof-UTC_SUFFIX --backup-target prefer-standby
+   kubectl cnpg backup -n bayn bayn-db --backup-name bayn-db-proof-UTC_SUFFIX --backup-target prefer-standby \
+     --method=plugin --plugin-name=barman-cloud.cloudnative-pg.io
    kubectl -n bayn wait --for=jsonpath='{.status.phase}'=completed backup/bayn-db-proof-UTC_SUFFIX --timeout=30m
    ```
 
@@ -64,19 +70,11 @@ the recovery Cluster has no backup stanza and only reads that archive.
        owner: bayn_app
    externalClusters:
      - name: bayn-db-source
-       barmanObjectStore:
-         destinationPath: s3://cnpg-bayn
-         serverName: bayn-db-live
-         endpointURL: http://rook-ceph-rgw-objectstore.rook-ceph.svc.cluster.local:80
-         s3Credentials:
-           accessKeyId:
-             name: cnpg-bayn-db
-             key: AWS_ACCESS_KEY_ID
-           secretAccessKey:
-             name: cnpg-bayn-db
-             key: AWS_SECRET_ACCESS_KEY
-         wal:
-           maxParallel: 2
+       plugin:
+         name: barman-cloud.cloudnative-pg.io
+         parameters:
+           barmanObjectName: bayn-db
+           serverName: bayn-db-live
    ```
 
 4. After Argo reports the recovery Cluster healthy, query the exact proof row through `kubectl cnpg psql`. Record the

--- a/docs/bayn/cnpg-backup-restore.md
+++ b/docs/bayn/cnpg-backup-restore.md
@@ -66,6 +66,8 @@ the recovery Cluster has no backup stanza and only reads that archive.
    bootstrap:
      recovery:
        source: bayn-db-source
+       backup:
+         name: bayn-db-proof-UTC_SUFFIX
        database: bayn
        owner: bayn_app
    externalClusters:

--- a/docs/bayn/cnpg-backup-restore.md
+++ b/docs/bayn/cnpg-backup-restore.md
@@ -1,0 +1,88 @@
+# Bayn CNPG backup and restore
+
+Bayn owns `Cluster/bayn-db` and `ObjectBucketClaim/cnpg-bayn-db` in namespace `bayn`. Both are protected from
+ordinary Argo prune/delete operations. They must only be removed through an explicitly approved evidence-retention
+change. The database has two synchronous amd64 instances; loss of the standby blocks writes instead of acknowledging
+unreplicated evidence.
+
+CloudNativePG 1.30 still supports native Barman Cloud, and the installed cluster does not yet run the Barman Cloud
+Plugin. Bayn therefore uses the pinned PostgreSQL 18.4 `system-trixie` image and the existing native object-store path.
+Migrating the shared platform to the plugin is a separate change before CloudNativePG 1.31 removes native support.
+
+Upstream contracts: [CloudNativePG 1.30 release notes](https://cloudnative-pg.io/docs/1.30/release_notes/v1.30/),
+[native Barman backup and recovery](https://cloudnative-pg.io/docs/1.30/appendixes/backup_barmanobjectstore/), and
+[required CNPG network ports](https://cloudnative-pg.io/docs/1.30/security/#exposed-ports).
+
+## Primary checks
+
+```sh
+kubectl -n bayn get objectbucketclaim cnpg-bayn-db
+kubectl -n bayn get cluster bayn-db
+kubectl -n bayn get pods -l cnpg.io/cluster=bayn-db -o wide
+kubectl -n bayn get scheduledbackup bayn-db-daily
+kubectl -n bayn get backup -l cnpg.io/cluster=bayn-db
+kubectl -n bayn get secret bayn-db-app -o go-template='{{.metadata.name}}{{"\\t"}}{{.type}}{{"\\n"}}'
+kubectl cnpg status -n bayn bayn-db
+kubectl cnpg psql -n bayn bayn-db -- -d bayn -Atqc \
+  "select rolname, rolsuper, rolcreatedb, rolcreaterole from pg_roles where rolname = 'bayn_app'"
+```
+
+The expected role row is `bayn_app|f|f|f`. Never print Secret data. In Mimir, both instances must be present and healthy:
+
+```promql
+count(up{cluster="bayn-db",job="cnpg-postgres"} == 1) == 2
+```
+
+## Isolated restore drill
+
+Use a unique UTC suffix for every drill. Never point a recovery Cluster at `serverName: bayn-db-live` for new backups;
+the recovery Cluster has no backup stanza and only reads that archive.
+
+1. Seed one non-application proof row on the primary:
+
+   ```sh
+   kubectl cnpg psql -n bayn bayn-db -- -d bayn -v ON_ERROR_STOP=1 -c \
+     "create schema if not exists restore_probe; create table if not exists restore_probe.evidence (proof_id text primary key, proof_value text not null); insert into restore_probe.evidence values ('PROOF_ID', 'PROOF_VALUE') on conflict (proof_id) do update set proof_value = excluded.proof_value;"
+   ```
+
+2. Request and wait for a named backup:
+
+   ```sh
+   kubectl cnpg backup -n bayn bayn-db --backup-name bayn-db-proof-UTC_SUFFIX --backup-target prefer-standby
+   kubectl -n bayn wait --for=jsonpath='{.status.phase}'=completed backup/bayn-db-proof-UTC_SUFFIX --timeout=30m
+   ```
+
+3. Add a temporary, uniquely named recovery `Cluster` and matching ingress-only `NetworkPolicy` to a reviewed GitOps
+   change. The policy permits only its own peers, the CNPG operator on ports 5432/8000, and Alloy on 9187. Use one
+   instance, the same pinned image and storage class, and this recovery source:
+
+   ```yaml
+   bootstrap:
+     recovery:
+       source: bayn-db-source
+       database: bayn
+       owner: bayn_app
+   externalClusters:
+     - name: bayn-db-source
+       barmanObjectStore:
+         destinationPath: s3://cnpg-bayn
+         serverName: bayn-db-live
+         endpointURL: http://rook-ceph-rgw-objectstore.rook-ceph.svc.cluster.local:80
+         s3Credentials:
+           accessKeyId:
+             name: cnpg-bayn-db
+             key: AWS_ACCESS_KEY_ID
+           secretAccessKey:
+             name: cnpg-bayn-db
+             key: AWS_SECRET_ACCESS_KEY
+         wal:
+           maxParallel: 2
+   ```
+
+4. After Argo reports the recovery Cluster healthy, query the exact proof row through `kubectl cnpg psql`. Record the
+   primary and recovery Cluster UIDs, backup name/ID, start/end timestamps, source image digest, proof row, and recovery
+   duration in PROOMPT-358.
+
+5. Remove the temporary manifest through GitOps only after the evidence is recorded. Deleting the recovery Cluster or
+   its PVC requires explicit approval. Never alter or delete `bayn-db`, `cnpg-bayn-db`, or another service's storage as
+   part of the drill.

--- a/packages/scripts/src/shared/__tests__/bayn-cnpg-contract.test.ts
+++ b/packages/scripts/src/shared/__tests__/bayn-cnpg-contract.test.ts
@@ -56,8 +56,24 @@ test('Bayn owns a protected two-instance synchronous CNPG cluster', () => {
   )
 })
 
-test('Bayn backups use an isolated protected bucket and bounded schedule', () => {
+test('the CNPG platform installs the pinned Barman Cloud plugin', () => {
+  const platform = readManifest('argocd/applications/cloudnative-pg/kustomization.yaml')
+  const patches = platform.patches.map((patch: { patch: string }) => patch.patch).join('\n')
+
+  expect(platform.resources).toContain(
+    'https://github.com/cloudnative-pg/plugin-barman-cloud/releases/download/v0.13.0/manifest.yaml',
+  )
+  expect(patches).toContain(
+    'ghcr.io/cloudnative-pg/plugin-barman-cloud@sha256:71589dbac582333442812b07b31f7ea4d00324a8358aac7ca507dabf9f4b6c96',
+  )
+  expect(patches).toContain(
+    'Z2hjci5pby9jbG91ZG5hdGl2ZS1wZy9wbHVnaW4tYmFybWFuLWNsb3VkLXNpZGVjYXJAc2hhMjU2Ojk5MDM2MWFmMzMxOWY5ZTIzYWFmYTBmNmQ3OTgxZjk5YmYxZjY5YjRlNmE4NWNmMWJjN2Q3MWQ2ZjA5YmIyODg=',
+  )
+})
+
+test('Bayn backups use an isolated protected plugin object store and bounded schedule', () => {
   const bucket = readManifest('argocd/applications/bayn/objectbucketclaim.yaml')
+  const objectStore = readManifest('argocd/applications/bayn/postgres-objectstore.yaml')
   const cluster = readManifest('argocd/applications/bayn/postgres-cluster.yaml')
   const schedule = readManifest('argocd/applications/bayn/postgres-scheduled-backup.yaml')
   const kustomization = readManifest('argocd/applications/bayn/kustomization.yaml')
@@ -65,11 +81,22 @@ test('Bayn backups use an isolated protected bucket and bounded schedule', () =>
   expect(bucket.metadata.name).toBe('cnpg-bayn-db')
   expect(bucket.metadata.annotations['argocd.argoproj.io/sync-options']).toBe('Prune=false,Delete=false')
   expect(bucket.spec).toEqual({ bucketName: 'cnpg-bayn', storageClassName: 'rook-ceph-bucket' })
-  expect(cluster.spec.backup).toMatchObject({
-    target: 'prefer-standby',
-    barmanObjectStore: {
-      destinationPath: 's3://cnpg-bayn',
-      serverName: 'bayn-db-live',
+  expect(objectStore.metadata.name).toBe('bayn-db')
+  expect(objectStore.metadata.annotations['argocd.argoproj.io/sync-options']).toBe(
+    'Prune=false,Delete=false,SkipDryRunOnMissingResource=true',
+  )
+  expect(objectStore.spec).toMatchObject({
+    retentionPolicy: '14d',
+    instanceSidecarConfiguration: {
+      logLevel: 'info',
+      retentionPolicyIntervalSeconds: 1800,
+      resources: {
+        requests: { cpu: '100m', memory: '128Mi' },
+        limits: { cpu: '500m', memory: '512Mi' },
+      },
+    },
+    configuration: {
+      destinationPath: 's3://cnpg-bayn/',
       endpointURL: 'http://rook-ceph-rgw-objectstore.rook-ceph.svc.cluster.local:80',
       s3Credentials: {
         accessKeyId: { name: 'cnpg-bayn-db', key: 'AWS_ACCESS_KEY_ID' },
@@ -78,17 +105,31 @@ test('Bayn backups use an isolated protected bucket and bounded schedule', () =>
       data: { compression: 'snappy', jobs: 1, additionalCommandArgs: ['--max-bandwidth', '8MB'] },
       wal: { compression: 'snappy', maxParallel: 2 },
     },
-    retentionPolicy: '14d',
   })
+  expect(cluster.spec.backup).toBeUndefined()
+  expect(cluster.spec.plugins).toEqual([
+    {
+      name: 'barman-cloud.cloudnative-pg.io',
+      isWALArchiver: true,
+      parameters: { barmanObjectName: 'bayn-db', serverName: 'bayn-db-live' },
+    },
+  ])
   expect(schedule.spec).toEqual({
     schedule: '0 0 3 * * *',
     immediate: true,
     backupOwnerReference: 'cluster',
-    method: 'barmanObjectStore',
+    target: 'prefer-standby',
+    method: 'plugin',
+    pluginConfiguration: { name: 'barman-cloud.cloudnative-pg.io' },
     cluster: { name: 'bayn-db' },
   })
   expect(kustomization.resources).toEqual(
-    expect.arrayContaining(['objectbucketclaim.yaml', 'postgres-cluster.yaml', 'postgres-scheduled-backup.yaml']),
+    expect.arrayContaining([
+      'objectbucketclaim.yaml',
+      'postgres-objectstore.yaml',
+      'postgres-cluster.yaml',
+      'postgres-scheduled-backup.yaml',
+    ]),
   )
 })
 

--- a/packages/scripts/src/shared/__tests__/bayn-cnpg-contract.test.ts
+++ b/packages/scripts/src/shared/__tests__/bayn-cnpg-contract.test.ts
@@ -77,6 +77,7 @@ test('Bayn backups use an isolated protected plugin object store and bounded sch
   const cluster = readManifest('argocd/applications/bayn/postgres-cluster.yaml')
   const schedule = readManifest('argocd/applications/bayn/postgres-scheduled-backup.yaml')
   const kustomization = readManifest('argocd/applications/bayn/kustomization.yaml')
+  const restoreRunbook = readRepoFile('docs/bayn/cnpg-backup-restore.md')
 
   expect(bucket.metadata.name).toBe('cnpg-bayn-db')
   expect(bucket.metadata.annotations['argocd.argoproj.io/sync-options']).toBe('Prune=false,Delete=false')
@@ -131,6 +132,7 @@ test('Bayn backups use an isolated protected plugin object store and bounded sch
       'postgres-scheduled-backup.yaml',
     ]),
   )
+  expect(restoreRunbook).toContain('name: bayn-db-proof-UTC_SUFFIX')
 })
 
 test('Bayn and its database have explicit network paths and existing CNPG telemetry', () => {

--- a/packages/scripts/src/shared/__tests__/bayn-cnpg-contract.test.ts
+++ b/packages/scripts/src/shared/__tests__/bayn-cnpg-contract.test.ts
@@ -1,0 +1,145 @@
+import { readFileSync } from 'node:fs'
+
+import { expect, test } from 'bun:test'
+import YAML from 'yaml'
+
+const repoRoot = new URL('../../../../../', import.meta.url)
+const readRepoFile = (path: string): string => readFileSync(new URL(path, repoRoot), 'utf8')
+const readManifest = (path: string): Record<string, any> => YAML.parse(readRepoFile(path))
+
+test('Bayn owns a protected two-instance synchronous CNPG cluster', () => {
+  const cluster = readManifest('argocd/applications/bayn/postgres-cluster.yaml')
+
+  expect(cluster.metadata.name).toBe('bayn-db')
+  expect(cluster.metadata.annotations['argocd.argoproj.io/sync-options']).toBe('Prune=false,Delete=false')
+  expect(cluster.spec).toMatchObject({
+    instances: 2,
+    enablePDB: true,
+    enableSuperuserAccess: false,
+    minSyncReplicas: 1,
+    maxSyncReplicas: 1,
+    primaryUpdateMethod: 'switchover',
+    primaryUpdateStrategy: 'unsupervised',
+    affinity: {
+      nodeAffinity: {
+        requiredDuringSchedulingIgnoredDuringExecution: {
+          nodeSelectorTerms: [
+            {
+              matchExpressions: [{ key: 'kubernetes.io/arch', operator: 'In', values: ['amd64'] }],
+            },
+          ],
+        },
+      },
+      podAntiAffinityType: 'required',
+      topologyKey: 'kubernetes.io/hostname',
+    },
+    storage: {
+      storageClass: 'rook-ceph-block',
+      size: '10Gi',
+      resizeInUseVolumes: true,
+    },
+    resources: {
+      requests: { cpu: '250m', memory: '512Mi' },
+      limits: { cpu: '2', memory: '2Gi' },
+    },
+    bootstrap: {
+      initdb: {
+        database: 'bayn',
+        owner: 'bayn_app',
+        encoding: 'UTF8',
+        dataChecksums: true,
+      },
+    },
+  })
+  expect(cluster.spec.imageName).toBe(
+    'ghcr.io/cloudnative-pg/postgresql:18.4-system-trixie@sha256:9287ce030c6f3ce822e383b019ae4aaf1e8370bff3b39f9c51dc10d69dc97219',
+  )
+})
+
+test('Bayn backups use an isolated protected bucket and bounded schedule', () => {
+  const bucket = readManifest('argocd/applications/bayn/objectbucketclaim.yaml')
+  const cluster = readManifest('argocd/applications/bayn/postgres-cluster.yaml')
+  const schedule = readManifest('argocd/applications/bayn/postgres-scheduled-backup.yaml')
+  const kustomization = readManifest('argocd/applications/bayn/kustomization.yaml')
+
+  expect(bucket.metadata.name).toBe('cnpg-bayn-db')
+  expect(bucket.metadata.annotations['argocd.argoproj.io/sync-options']).toBe('Prune=false,Delete=false')
+  expect(bucket.spec).toEqual({ bucketName: 'cnpg-bayn', storageClassName: 'rook-ceph-bucket' })
+  expect(cluster.spec.backup).toMatchObject({
+    target: 'prefer-standby',
+    barmanObjectStore: {
+      destinationPath: 's3://cnpg-bayn',
+      serverName: 'bayn-db-live',
+      endpointURL: 'http://rook-ceph-rgw-objectstore.rook-ceph.svc.cluster.local:80',
+      s3Credentials: {
+        accessKeyId: { name: 'cnpg-bayn-db', key: 'AWS_ACCESS_KEY_ID' },
+        secretAccessKey: { name: 'cnpg-bayn-db', key: 'AWS_SECRET_ACCESS_KEY' },
+      },
+      data: { compression: 'snappy', jobs: 1, additionalCommandArgs: ['--max-bandwidth', '8MB'] },
+      wal: { compression: 'snappy', maxParallel: 2 },
+    },
+    retentionPolicy: '14d',
+  })
+  expect(schedule.spec).toEqual({
+    schedule: '0 0 3 * * *',
+    immediate: true,
+    backupOwnerReference: 'cluster',
+    method: 'barmanObjectStore',
+    cluster: { name: 'bayn-db' },
+  })
+  expect(kustomization.resources).toEqual(
+    expect.arrayContaining(['objectbucketclaim.yaml', 'postgres-cluster.yaml', 'postgres-scheduled-backup.yaml']),
+  )
+})
+
+test('Bayn and its database have explicit network paths and existing CNPG telemetry', () => {
+  const policies = YAML.parseAllDocuments(readRepoFile('argocd/applications/bayn/networkpolicy.yaml')).map((document) =>
+    document.toJSON(),
+  )
+  const applicationPolicy = policies.find((policy) => policy.metadata.name === 'bayn')
+  const databasePolicy = policies.find((policy) => policy.metadata.name === 'bayn-db')
+  const alloy = readRepoFile('argocd/applications/observability/cluster-metrics-alloy-config.river')
+
+  expect(applicationPolicy.spec.egress).toContainEqual({
+    to: [{ podSelector: { matchLabels: { 'cnpg.io/cluster': 'bayn-db' } } }],
+    ports: [{ port: 5432, protocol: 'TCP' }],
+  })
+  expect(databasePolicy.spec.podSelector.matchLabels).toEqual({ 'cnpg.io/cluster': 'bayn-db' })
+  expect(databasePolicy.spec.policyTypes).toEqual(['Ingress'])
+  expect(databasePolicy.spec.ingress).toHaveLength(4)
+  expect(databasePolicy.spec.ingress).toEqual(
+    expect.arrayContaining([
+      {
+        from: [{ podSelector: { matchLabels: { 'app.kubernetes.io/name': 'bayn' } } }],
+        ports: [{ port: 5432, protocol: 'TCP' }],
+      },
+      {
+        from: [{ podSelector: { matchLabels: { 'cnpg.io/cluster': 'bayn-db' } } }],
+        ports: [{ port: 5432, protocol: 'TCP' }],
+      },
+      {
+        from: [
+          {
+            namespaceSelector: { matchLabels: { 'kubernetes.io/metadata.name': 'cloudnative-pg' } },
+            podSelector: { matchLabels: { 'app.kubernetes.io/name': 'cloudnative-pg' } },
+          },
+        ],
+        ports: [
+          { port: 5432, protocol: 'TCP' },
+          { port: 8000, protocol: 'TCP' },
+        ],
+      },
+      {
+        from: [
+          {
+            namespaceSelector: { matchLabels: { 'kubernetes.io/metadata.name': 'observability' } },
+            podSelector: { matchLabels: { 'app.kubernetes.io/name': 'observability-cluster-metrics-alloy' } },
+          },
+        ],
+        ports: [{ port: 9187, protocol: 'TCP' }],
+      },
+    ]),
+  )
+  expect(alloy).toContain('label = "cnpg.io/cluster"')
+  expect(alloy).toContain('job_name        = "cnpg-postgres"')
+})


### PR DESCRIPTION
## Summary

- provision an isolated two-instance synchronous CloudNativePG cluster for Bayn with protected Ceph block storage
- install Barman Cloud Plugin 0.13.0 through the existing CNPG platform app with digest-pinned manager and sidecar images, bounded resources, and production logging
- add a Bayn-owned protected object bucket, plugin ObjectStore, daily plugin backup, and an explicit restore-evidence runbook
- restrict PostgreSQL ingress to Bayn, CNPG peers/operator, and the existing Alloy collector while preserving current application egress paths
- add contract tests for plugin supply, durability, backup, scheduling, network, and telemetry invariants

## Related Issues

[PROOMPT-358](https://linear.app/proompteng/issue/PROOMPT-358/provision-bayn-cnpg-backups-monitoring-and-restore-path)

## Testing

- `bun test packages/scripts/src/shared/__tests__/bayn-cnpg-contract.test.ts` — 4 tests, 25 assertions passed
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/bayn-cnpg-contract.test.ts` — passed
- `bunx oxlint --config .oxlintrc.json packages/scripts/src/shared/__tests__/bayn-cnpg-contract.test.ts` — passed with zero warnings and errors
- `kustomize build --enable-helm argocd/applications/cloudnative-pg` and `kustomize build argocd/applications/bayn` — passed
- `bun run lint:argocd` — all rendered manifest batches passed with zero invalid resources and errors
- targeted server-side dry-run of every new plugin CRD/RBAC/Secret/Service/Deployment/Certificate/Issuer — accepted by the live API
- server-side dry-run of all Bayn resources except the not-yet-installed ObjectStore CRD — accepted; the new ObjectStore is validated by the pinned upstream CRD and will receive a live server validation after the platform app installs it
- `git diff --check` — passed
- the broader `packages/scripts` TypeScript build remains red on unrelated pre-existing files; the new test has no diagnostics and passes focused lint/test validation

## Breaking Changes

None. This installs a new backup plugin and provisions a new database/backup target, but it does not switch existing CNPG clusters, move Bayn runtime state, or remove the transitional TigerBeetle path. Bayn uses the plugin API from its first backup instead of creating native Barman configuration that CNPG 1.31 removes.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.