### PR TITLE
test(bayn): restore CNPG proof backup

### DIFF
--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -8,6 +8,8 @@ resources:
   - postgres-objectstore.yaml
   - postgres-cluster.yaml
   - postgres-scheduled-backup.yaml
+  - postgres-restore-proof.yaml
+  - postgres-restore-proof-networkpolicy.yaml
   - deployment.yaml
   - service.yaml
   - networkpolicy.yaml

--- a/argocd/applications/bayn/postgres-restore-proof-networkpolicy.yaml
+++ b/argocd/applications/bayn/postgres-restore-proof-networkpolicy.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     app.kubernetes.io/name: bayn-db-restore-proof
     app.kubernetes.io/part-of: bayn
+  annotations:
+    argocd.argoproj.io/sync-wave: "-5"
 spec:
   podSelector:
     matchLabels:

--- a/argocd/applications/bayn/postgres-restore-proof-networkpolicy.yaml
+++ b/argocd/applications/bayn/postgres-restore-proof-networkpolicy.yaml
@@ -1,0 +1,43 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: bayn-db-restore-20260720t161329z
+  labels:
+    app.kubernetes.io/name: bayn-db-restore-proof
+    app.kubernetes.io/part-of: bayn
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: bayn-db-restore-20260720t161329z
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              cnpg.io/cluster: bayn-db-restore-20260720t161329z
+      ports:
+        - port: 5432
+          protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: cloudnative-pg
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: cloudnative-pg
+      ports:
+        - port: 5432
+          protocol: TCP
+        - port: 8000
+          protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: observability-cluster-metrics-alloy
+      ports:
+        - port: 9187
+          protocol: TCP

--- a/argocd/applications/bayn/postgres-restore-proof.yaml
+++ b/argocd/applications/bayn/postgres-restore-proof.yaml
@@ -1,0 +1,55 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: bayn-db-restore-20260720t161329z
+  labels:
+    app.kubernetes.io/name: bayn-db-restore-proof
+    app.kubernetes.io/part-of: bayn
+  annotations:
+    argocd.argoproj.io/sync-wave: "-4"
+    argocd.argoproj.io/sync-options: Prune=false,Delete=false
+spec:
+  description: Isolated PROOMPT-358 restore proof from bayn-db-proof-20260720t161329z
+  instances: 1
+  imageName: ghcr.io/cloudnative-pg/postgresql:18.4-system-trixie@sha256:9287ce030c6f3ce822e383b019ae4aaf1e8370bff3b39f9c51dc10d69dc97219
+  imagePullPolicy: IfNotPresent
+  enablePDB: false
+  enableSuperuserAccess: false
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+  storage:
+    storageClass: rook-ceph-block
+    size: 10Gi
+    resizeInUseVolumes: true
+  bootstrap:
+    recovery:
+      source: bayn-db-source
+      database: bayn
+      owner: bayn_app
+      backup:
+        name: bayn-db-proof-20260720t161329z
+  externalClusters:
+    - name: bayn-db-source
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: bayn-db
+          serverName: bayn-db-live
+  postgresql:
+    parameters:
+      password_encryption: scram-sha-256
+      ssl_min_protocol_version: TLSv1.3


### PR DESCRIPTION
## Summary

- add one isolated, single-instance CNPG recovery cluster bound to the completed named backup `bayn-db-proof-20260720t161329z`
- isolate recovery ingress to its own peer, the CNPG operator, and the shared Alloy scraper
- protect the temporary recovery cluster from automatic prune/delete until the exact proof row is read back and evidence is retained

## Related Issues

PROOMPT-358

## Testing

- `kustomize build argocd/applications/bayn`: 12 rendered resources
- `bun run lint:argocd`: zero invalid resources
- `kustomize build argocd/applications/bayn | kubectl apply -n bayn --dry-run=server -f -`: recovery Cluster and NetworkPolicy accepted by the live API server
- source proof row: `bayn-restore-proof-20260720T161329Z|26daf9d20ea9e707c2c41a601ffa330f3795320df8667928953ab7bf5fe34ef3`
- source backup: `bayn-db-proof-20260720t161329z`, UID `d414f095-9312-4a8d-8414-ad8ccc9aad6e`, completed from synchronous standby `bayn-db-2`

## Breaking Changes

Adds a temporary protected 10 GiB recovery PVC and one PostgreSQL pod. It does not alter `bayn-db`, publish a service, or grant application access. Removal requires a separate explicitly approved GitOps change after evidence capture.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Restore evidence and cleanup authority are documented in PROOMPT-358.

