### PR TITLE
fix(bayn): stop CNPG sync loop

### DIFF
--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -381,6 +381,7 @@ spec:
                 renderWithLovely: false
                 annotations:
                   argocd.argoproj.io/sync-wave: "7"
+                  argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
                 managedNamespaceMetadata:
                   labels:
                     # The TigerBeetle client requires an explicit io_uring seccomp exception.

--- a/packages/scripts/src/shared/__tests__/bayn-cnpg-contract.test.ts
+++ b/packages/scripts/src/shared/__tests__/bayn-cnpg-contract.test.ts
@@ -56,6 +56,14 @@ test('Bayn owns a protected two-instance synchronous CNPG cluster', () => {
   )
 })
 
+test('Bayn compares CNPG resources after admission defaulting', () => {
+  const applicationSet = readManifest('argocd/applicationsets/product.yaml')
+  const elements = applicationSet.spec.generators[0].matrix.generators[1].list.elements
+  const bayn = elements.find((element: { name: string }) => element.name === 'bayn')
+
+  expect(bayn.annotations['argocd.argoproj.io/compare-options']).toBe('ServerSideDiff=true,IncludeMutationWebhook=true')
+})
+
 test('the CNPG platform installs the pinned Barman Cloud plugin', () => {
   const platform = readManifest('argocd/applications/cloudnative-pg/kustomization.yaml')
   const patches = platform.patches.map((patch: { patch: string }) => patch.patch).join('\n')


### PR DESCRIPTION
## Summary

- Compare Bayn resources with Argo server-side diff so CNPG admission defaults do not create perpetual drift.
- Include mutating-webhook output because CNPG supplies the defaulted Cluster fields.
- Lock the ApplicationSet contract with a focused regression test.

## Related Issues

PROOMPT-358

## Testing

- bun test packages/scripts/src/shared/__tests__/bayn-cnpg-contract.test.ts (5 tests, 26 assertions)
- bunx oxfmt --check packages/scripts/src/shared/__tests__/bayn-cnpg-contract.test.ts
- bunx oxlint --config .oxlintrc.json packages/scripts/src/shared/__tests__/bayn-cnpg-contract.test.ts
- bun run lint:argocd (0 invalid resources)
- kubectl apply -n argocd --dry-run=server -f argocd/applicationsets/product.yaml

## Screenshots (if applicable)

N/A

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.