### PR TITLE
chore(bayn): promote image sha-ed782f302385ee143f46490ce69159bf70ece547

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: bayn
         app.kubernetes.io/part-of: bayn
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-20T09:26:27Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-20T17:08:30Z"
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
@@ -47,11 +47,11 @@ spec:
               protocol: TCP
           env:
             - name: BAYN_CODE_REVISION
-              value: 2ffb7c4966dd1cb05011143a46fecc871366224d
+              value: ed782f302385ee143f46490ce69159bf70ece547
             - name: BAYN_IMAGE_REPOSITORY
               value: registry.ide-newton.ts.net/lab/bayn
             - name: BAYN_IMAGE_DIGEST
-              value: sha256:ab5127d50acb3f13bd30e27f1f4b7ee047b0c113dddfb12c8b2fee3ce16c8cce
+              value: sha256:7dcad70d72a109fb973eed0ec0f6b0b803eafb854328c0c54b9edd6eac7f991d
             - name: BAYN_RUN_ON_STARTUP
               value: "true"
             - name: BAYN_OPERATION_TIMEOUT_MS

--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -16,5 +16,5 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/bayn
     newName: registry.ide-newton.ts.net/lab/bayn
-    newTag: "sha-2ffb7c4966dd1cb05011143a46fecc871366224d"
-    digest: sha256:ab5127d50acb3f13bd30e27f1f4b7ee047b0c113dddfb12c8b2fee3ce16c8cce
+    newTag: "sha-ed782f302385ee143f46490ce69159bf70ece547"
+    digest: sha256:7dcad70d72a109fb973eed0ec0f6b0b803eafb854328c0c54b9edd6eac7f991d


### PR DESCRIPTION
## Summary

Promote the immutable Bayn image, activate the Bayn Argo application, and bind runtime evidence to its
source commit.

- Source commit: `ed782f302385ee143f46490ce69159bf70ece547`
- Image tag: `sha-ed782f302385ee143f46490ce69159bf70ece547`
- Image digest: `sha256:7dcad70d72a109fb973eed0ec0f6b0b803eafb854328c0c54b9edd6eac7f991d`

## Related Issues

PROOMPT-353

## Testing

- OCI index contains `linux/amd64` and `linux/arm64`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents exact validation.
- [x] Runtime source revision and image digest are immutable.
- [x] No broker or capital-promotion authority is introduced.