### PR TITLE
chore(torghut): promote notebook image sha-ed782f302385ee143f46490ce69159bf70ece547

### DIFF
--- a/argocd/applications/torghut/notebooks/values.yaml
+++ b/argocd/applications/torghut/notebooks/values.yaml
@@ -94,7 +94,7 @@ singleuser:
   cmd: null
   image:
     name: registry.ide-newton.ts.net/lab/torghut-notebook@sha256
-    tag: 'ebb67a85f333d3f9a67ba9556761c78cd68ade05cf502e6c39ceb9f89b10351b'
+    tag: '2e76ecf7d4bfaf9dba2c07440089441b7b5ad99a5064e18998ee489f5abb5b06'
     pullPolicy: IfNotPresent
   defaultUrl: /lab/tree/work/00-system-flow.ipynb
   startTimeout: 600


### PR DESCRIPTION
## Summary

- Promote the immutable multi-architecture Torghut notebook image built from `ed782f302385ee143f46490ce69159bf70ece547`.
- Update only the digest-pinned JupyterHub single-user image.

## Related Issues

None.

## Testing

- The source commit passed notebook fixture execution and manifest contracts.
- The release workflow verified `linux/amd64` and `linux/arm64` for `sha256:2e76ecf7d4bfaf9dba2c07440089441b7b5ad99a5064e18998ee489f5abb5b06`.

## Breaking Changes

None.

## Checklist

- [x] The single-user image is immutable and multi-architecture.
- [x] Promotion changes only the notebook image digest.
- [x] PVCs and read-only credentials are unchanged.