### PR TITLE
chore(signal): promote publisher sha-ed782f302385ee143f46490ce69159bf70ece547

### DIFF
--- a/argocd/applications/torghut/clickhouse/kustomization.yaml
+++ b/argocd/applications/torghut/clickhouse/kustomization.yaml
@@ -17,4 +17,5 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/signal-publisher
     newName: registry.ide-newton.ts.net/lab/signal-publisher
-    newTag: bootstrap
+    newTag: "sha-ed782f302385ee143f46490ce69159bf70ece547"
+    digest: sha256:4c02c9cd33a04da68b4d1b62cc222f4d037dc3fbb8c4cb32d78bbade23673d55

--- a/argocd/applications/torghut/clickhouse/signal-publisher-cronjob.yaml
+++ b/argocd/applications/torghut/clickhouse/signal-publisher-cronjob.yaml
@@ -13,7 +13,7 @@ spec:
   timeZone: America/New_York
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 3600
-  suspend: true
+  suspend: false
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   jobTemplate:
@@ -47,11 +47,11 @@ spec:
                 - daily
               env:
                 - name: SIGNAL_CODE_REVISION
-                  value: "0000000000000000000000000000000000000000"
+                  value: "ed782f302385ee143f46490ce69159bf70ece547"
                 - name: SIGNAL_IMAGE_REPOSITORY
                   value: registry.ide-newton.ts.net/lab/signal-publisher
                 - name: SIGNAL_IMAGE_DIGEST
-                  value: sha256:0000000000000000000000000000000000000000000000000000000000000000
+                  value: sha256:4c02c9cd33a04da68b4d1b62cc222f4d037dc3fbb8c4cb32d78bbade23673d55
                 - name: SIGNAL_CLICKHOUSE_URL
                   value: http://torghut-clickhouse.torghut.svc.cluster.local:8123
                 - name: SIGNAL_CLICKHOUSE_USERNAME

--- a/packages/scripts/src/signal/gitops-contract.test.ts
+++ b/packages/scripts/src/signal/gitops-contract.test.ts
@@ -9,28 +9,35 @@ const root = resolve(import.meta.dir, '../../../..')
 const clickhouseDirectory = resolve(root, 'argocd/applications/torghut/clickhouse')
 const read = (path: string) => readFileSync(resolve(clickhouseDirectory, path), 'utf8')
 
+const assertActivationProvenance = (cronJob: ReturnType<typeof parse>, kustomization: ReturnType<typeof parse>) => {
+  if (cronJob.spec.suspend) return
+  const container = cronJob.spec.jobTemplate.spec.template.spec.containers[0]
+  const environment = new Map(container.env.map((entry: { name: string; value?: string }) => [entry.name, entry]))
+  const image = kustomization.images.find(
+    (entry: { name: string }) => entry.name === 'registry.ide-newton.ts.net/lab/signal-publisher',
+  )
+  expect(image.newTag).toMatch(/^sha-[0-9a-f]{40}$/)
+  expect(image.digest).toMatch(/^sha256:[0-9a-f]{64}$/)
+  expect(environment.get('SIGNAL_CODE_REVISION')).toMatchObject({ value: image.newTag.slice(4) })
+  expect(environment.get('SIGNAL_IMAGE_REPOSITORY')).toMatchObject({ value: image.newName })
+  expect(environment.get('SIGNAL_IMAGE_DIGEST')).toMatchObject({ value: image.digest })
+}
+
 describe('Signal publisher GitOps authority contract', () => {
-  test('activates only an immutable image with matching runtime provenance', () => {
+  test('requires immutable image provenance whenever the publisher is active', () => {
     const cronJob = parse(read('signal-publisher-cronjob.yaml'))
     const kustomization = parse(read('kustomization.yaml'))
     const container = cronJob.spec.jobTemplate.spec.template.spec.containers[0]
     const environment = new Map(container.env.map((entry: { name: string; value?: string }) => [entry.name, entry]))
-    const image = kustomization.images.find(
-      (entry: { name: string }) => entry.name === 'registry.ide-newton.ts.net/lab/signal-publisher',
-    )
 
     expect(cronJob.spec).toMatchObject({
       schedule: '30 18 * * 1-5',
       timeZone: 'America/New_York',
       concurrencyPolicy: 'Forbid',
-      suspend: false,
     })
-    expect(image.newTag).toMatch(/^sha-[0-9a-f]{40}$/)
-    expect(image.digest).toMatch(/^sha256:[0-9a-f]{64}$/)
+    expect(typeof cronJob.spec.suspend).toBe('boolean')
     expect(container.args).toEqual(['daily'])
-    expect(environment.get('SIGNAL_CODE_REVISION')).toMatchObject({ value: image.newTag.slice(4) })
-    expect(environment.get('SIGNAL_IMAGE_REPOSITORY')).toMatchObject({ value: image.newName })
-    expect(environment.get('SIGNAL_IMAGE_DIGEST')).toMatchObject({ value: image.digest })
+    assertActivationProvenance(cronJob, kustomization)
     expect(environment.get('SIGNAL_CLICKHOUSE_USERNAME')).toMatchObject({
       valueFrom: { secretKeyRef: { name: 'signal-publisher-clickhouse-auth', key: 'username' } },
     })
@@ -39,6 +46,15 @@ describe('Signal publisher GitOps authority contract', () => {
     })
     expect(environment.get('SIGNAL_ALPACA_FEED')).toMatchObject({ value: 'sip' })
     expect([...environment.keys()].filter((name) => /BROKER|TIGERBEETLE|CAPITAL/.test(name))).toEqual([])
+  })
+
+  test('always permits a fail-closed suspension', () => {
+    const cronJob = structuredClone(parse(read('signal-publisher-cronjob.yaml')))
+    const kustomization = structuredClone(parse(read('kustomization.yaml')))
+    cronJob.spec.suspend = true
+    kustomization.images[0].newTag = 'bootstrap'
+    delete kustomization.images[0].digest
+    expect(() => assertActivationProvenance(cronJob, kustomization)).not.toThrow()
   })
 
   test('limits database authority to the three append-only publication tables', () => {

--- a/packages/scripts/src/signal/gitops-contract.test.ts
+++ b/packages/scripts/src/signal/gitops-contract.test.ts
@@ -10,18 +10,27 @@ const clickhouseDirectory = resolve(root, 'argocd/applications/torghut/clickhous
 const read = (path: string) => readFileSync(resolve(clickhouseDirectory, path), 'utf8')
 
 describe('Signal publisher GitOps authority contract', () => {
-  test('keeps the publisher suspended until immutable image promotion', () => {
+  test('activates only an immutable image with matching runtime provenance', () => {
     const cronJob = parse(read('signal-publisher-cronjob.yaml'))
+    const kustomization = parse(read('kustomization.yaml'))
     const container = cronJob.spec.jobTemplate.spec.template.spec.containers[0]
     const environment = new Map(container.env.map((entry: { name: string; value?: string }) => [entry.name, entry]))
+    const image = kustomization.images.find(
+      (entry: { name: string }) => entry.name === 'registry.ide-newton.ts.net/lab/signal-publisher',
+    )
 
     expect(cronJob.spec).toMatchObject({
       schedule: '30 18 * * 1-5',
       timeZone: 'America/New_York',
       concurrencyPolicy: 'Forbid',
-      suspend: true,
+      suspend: false,
     })
+    expect(image.newTag).toMatch(/^sha-[0-9a-f]{40}$/)
+    expect(image.digest).toMatch(/^sha256:[0-9a-f]{64}$/)
     expect(container.args).toEqual(['daily'])
+    expect(environment.get('SIGNAL_CODE_REVISION')).toMatchObject({ value: image.newTag.slice(4) })
+    expect(environment.get('SIGNAL_IMAGE_REPOSITORY')).toMatchObject({ value: image.newName })
+    expect(environment.get('SIGNAL_IMAGE_DIGEST')).toMatchObject({ value: image.digest })
     expect(environment.get('SIGNAL_CLICKHOUSE_USERNAME')).toMatchObject({
       valueFrom: { secretKeyRef: { name: 'signal-publisher-clickhouse-auth', key: 'username' } },
     })


### PR DESCRIPTION
## Summary

Promote the immutable Signal adjusted-daily publisher image and activate its GitOps CronJob.

- Source commit: `ed782f302385ee143f46490ce69159bf70ece547`
- Image tag: `sha-ed782f302385ee143f46490ce69159bf70ece547`
- Image digest: `sha256:4c02c9cd33a04da68b4d1b62cc222f4d037dc3fbb8c4cb32d78bbade23673d55`

## Related Issues

PROOMPT-357

## Testing

- OCI index contains `linux/amd64` and `linux/arm64`.

## Screenshots (if applicable)

N/A

## Breaking Changes

Adds a bounded, idempotent daily publisher. It has no broker or capital authority.

## Checklist

- [x] Testing section documents exact validation.
- [x] Runtime source revision and image digest are immutable.
- [x] No broker or capital-promotion authority is introduced.