### PR TITLE
chore(product): promote nix product images

### DIFF
--- a/argocd/applications/app/kustomization.yaml
+++ b/argocd/applications/app/kustomization.yaml
@@ -8,5 +8,5 @@ resources:
   - secret.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/app
-    digest: sha256:747fc3e090e60fb88442f334d509de412a038e41f6365ed4513003ce5af9dd6f
+    digest: sha256:d0644f712be33f370aeb1403a3254fd825a70231c132de41f373013046ff9f9e
     newName: registry.ide-newton.ts.net/lab/app

--- a/argocd/applications/docs/kustomization.yaml
+++ b/argocd/applications/docs/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
   - generated
 images:
   - name: registry.ide-newton.ts.net/lab/docs
-    digest: sha256:7263e801c1511fda59800fc8269608d6f55f7bbf083bc5df5fe00de13aa2603c
+    digest: sha256:1bf2e70c49012b4f60a6404aca12a52254559d700224fa3f574ea0a268f23cf1
     newName: registry.ide-newton.ts.net/lab/docs

--- a/argocd/applications/proompteng/kustomization.yaml
+++ b/argocd/applications/proompteng/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
 - ingressroute.yaml
 images:
 - name: registry.ide-newton.ts.net/lab/proompteng
-  digest: sha256:c92d8c09675bd1894781a820857f938053d01af4d2ed65a2bc25af15e8a341ea
+  digest: sha256:045022216ed4a287aba38759cae98ccb15aab511c7a98daf128757d39643c089
   newName: registry.ide-newton.ts.net/lab/proompteng

--- a/argocd/applications/synthesis/kustomization.yaml
+++ b/argocd/applications/synthesis/kustomization.yaml
@@ -11,5 +11,5 @@ resources:
   - agents-domain
 images:
   - name: registry.ide-newton.ts.net/lab/synthesis
-    digest: sha256:470f7350e496a7fb9af045403cfcdf55441da33a02a8a7dfb8ec37d2b423c2a6
+    digest: sha256:613a3b43ae618c383ac3bcc752db6691fae9798b9aa22207a4e1a7af7fdade07
     newName: registry.ide-newton.ts.net/lab/synthesis


### PR DESCRIPTION
## Summary

- Promote enabled product app image digests built by the shared Nix OCI workflow.
- `app`: `registry.ide-newton.ts.net/lab/app@sha256:d0644f712be33f370aeb1403a3254fd825a70231c132de41f373013046ff9f9e` from `ed782f302385ee143f46490ce69159bf70ece547`
- `docs`: `registry.ide-newton.ts.net/lab/docs@sha256:1bf2e70c49012b4f60a6404aca12a52254559d700224fa3f574ea0a268f23cf1` from `ed782f302385ee143f46490ce69159bf70ece547`
- `proompteng`: `registry.ide-newton.ts.net/lab/proompteng@sha256:045022216ed4a287aba38759cae98ccb15aab511c7a98daf128757d39643c089` from `ed782f302385ee143f46490ce69159bf70ece547`
- `synthesis`: `registry.ide-newton.ts.net/lab/synthesis@sha256:613a3b43ae618c383ac3bcc752db6691fae9798b9aa22207a4e1a7af7fdade07` from `ed782f302385ee143f46490ce69159bf70ece547`

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- <image>@<digest> linux/amd64 linux/arm64` for each promoted image.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.