### PR TITLE
feat(bayn): persist evaluation evidence

### DIFF
--- a/.github/workflows/bayn-ci.yml
+++ b/.github/workflows/bayn-ci.yml
@@ -32,3 +32,36 @@ jobs:
       test-command: bun run --cwd services/bayn tsc && bun run --cwd services/bayn test && bun test packages/scripts/src/bayn
       build-command: bun run --cwd services/bayn build
     secrets: inherit
+
+  postgres-integration:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    services:
+      postgres:
+        image: postgres:18-alpine
+        env:
+          POSTGRES_USER: bayn
+          POSTGRES_PASSWORD: bayn
+          POSTGRES_DB: bayn_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U bayn -d bayn_test"
+          --health-interval 1s
+          --health-timeout 5s
+          --health-retries 30
+    env:
+      BAYN_TEST_POSTGRES_URL: postgresql://bayn:bayn@127.0.0.1:5432/bayn_test
+    steps:
+      - uses: actions/checkout@v5
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+      - name: Install focused dependencies
+        run: >-
+          bun install --frozen-lockfile --ignore-scripts
+          --filter @proompteng/source
+          --filter @proompteng/bayn
+      - name: Verify durable evidence on PostgreSQL 18
+        run: bun test services/bayn/src/db/evidence-store.integration.test.ts

--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -74,6 +74,15 @@ spec:
               value: adjusted_daily_bars_v1
             - name: BAYN_DATASET_VERSION
               value: alpaca-all-iex-2017-01-01-2026-07-18-v1
+            - name: BAYN_POSTGRES_URL
+              valueFrom:
+                secretKeyRef:
+                  name: bayn-db-app
+                  key: fqdn-uri
+            - name: BAYN_POSTGRES_TLS
+              value: "true"
+            - name: BAYN_POSTGRES_CA_PATH
+              value: /var/run/secrets/bayn/postgres/ca.crt
             - name: BAYN_TIGERBEETLE_CLUSTER_ID
               value: "2001"
             - name: BAYN_TIGERBEETLE_ADDRESSES
@@ -122,7 +131,17 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            - name: postgres-ca
+              mountPath: /var/run/secrets/bayn/postgres
+              readOnly: true
       volumes:
         - name: tmp
           emptyDir:
             sizeLimit: 256Mi
+        - name: postgres-ca
+          secret:
+            secretName: bayn-db-ca
+            defaultMode: 0444
+            items:
+              - key: ca.crt
+                path: ca.crt

--- a/bun.lock
+++ b/bun.lock
@@ -719,6 +719,7 @@
       "dependencies": {
         "@clickhouse/client": "1.23.1",
         "@effect/platform-node": "4.0.0-beta.99",
+        "@effect/sql-pg": "4.0.0-beta.99",
         "effect": "4.0.0-beta.99",
         "tigerbeetle-node": "0.17.9",
       },
@@ -1400,6 +1401,8 @@
     "@effect/sql": ["@effect/sql@0.51.1", "", { "dependencies": { "uuid": "^11.0.3" }, "peerDependencies": { "@effect/experimental": "^0.60.0", "@effect/platform": "^0.96.1", "effect": "^3.21.2" } }, "sha512-iPDAefrJcI0HcTk9keP9Gq8Pg08K1HmpnmZZt85AqyTcvorhoNsXDFiKBbPldfV2CortwVkacX8KjO9GPpSYCA=="],
 
     "@effect/sql-clickhouse": ["@effect/sql-clickhouse@4.0.0-beta.99", "", { "dependencies": { "@clickhouse/client": "^1.23.1" }, "peerDependencies": { "@effect/platform-node": "^4.0.0-beta.99", "effect": "^4.0.0-beta.99" } }, "sha512-krsAI8L5ORdR/g4CXYTaGdKwekvdHXfXrJfrJbv9HRDFvAu9Q8DYVqk2Wl232sbfANm0Xqz3seeeYDn1OKWonQ=="],
+
+    "@effect/sql-pg": ["@effect/sql-pg@4.0.0-beta.99", "", { "dependencies": { "pg": "^8.22.0", "pg-connection-string": "2.14.0", "pg-cursor": "^2.21.0", "pg-pool": "^3.14.0", "pg-types": "^4.1.0" }, "peerDependencies": { "effect": "^4.0.0-beta.99" } }, "sha512-ZZCKdArioVX29YcH+0HjiYeZiTAEnngU8ao3cBGZXrUOZwcvzknGWNOS7aGzES7hSK/HDBKPu2t14LGgtSgsCA=="],
 
     "@effect/typeclass": ["@effect/typeclass@0.38.0", "", { "peerDependencies": { "effect": "^3.19.0" } }, "sha512-lMUcJTRtG8KXhXoczapZDxbLK5os7M6rn0zkvOgncJW++A0UyelZfMVMKdT5R+fgpZcsAU/1diaqw3uqLJwGxA=="],
 
@@ -4763,6 +4766,8 @@
 
     "object.assign": ["object.assign@4.1.7", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0", "has-symbols": "^1.1.0", "object-keys": "^1.1.1" } }, "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw=="],
 
+    "obuf": ["obuf@1.1.2", "", {}, "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="],
+
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
 
     "ocache": ["ocache@0.1.4", "", { "dependencies": { "ohash": "^2.0.11" } }, "sha512-e7geNdWjxSnvsSgvLuPvgKgu7ubM10ZmTPOgpr7mz2BXYtvjMKTiLhjFi/gWU8chkuP6hNkZBsa9LzOusyaqkQ=="],
@@ -4885,7 +4890,11 @@
 
     "pg-connection-string": ["pg-connection-string@2.12.0", "", {}, "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ=="],
 
+    "pg-cursor": ["pg-cursor@2.21.0", "", { "peerDependencies": { "pg": "^8" } }, "sha512-IYvk/j+Suhtbo/C3uOf4JLsLK/gWxOTUOmYbDsbKnLaVJDq+KwhwK6ngpRfiCk8eDMS3AmGQABZCv0cREEzHQw=="],
+
     "pg-int8": ["pg-int8@1.0.1", "", {}, "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="],
+
+    "pg-numeric": ["pg-numeric@1.0.2", "", {}, "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw=="],
 
     "pg-pool": ["pg-pool@3.13.0", "", { "peerDependencies": { "pg": ">=8.0" } }, "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA=="],
 
@@ -4942,6 +4951,8 @@
     "postgres-date": ["postgres-date@1.0.7", "", {}, "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="],
 
     "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
+
+    "postgres-range": ["postgres-range@1.1.4", "", {}, "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w=="],
 
     "posthog-node": ["posthog-node@5.17.2", "", { "dependencies": { "@posthog/core": "1.7.1" } }, "sha512-lz3YJOr0Nmiz0yHASaINEDHqoV+0bC3eD8aZAG+Ky292dAnVYul+ga/dMX8KCBXg8hHfKdxw0SztYD5j6dgUqQ=="],
 
@@ -5950,6 +5961,16 @@
     "@effect/sql-clickhouse/@effect/platform-node": ["@effect/platform-node@4.0.0-beta.99", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.99", "mime": "^4.1.0", "undici": "^8.7.0" }, "peerDependencies": { "effect": "^4.0.0-beta.99", "ioredis": "^5.7.0" } }, "sha512-jnK2KMW4W50AEOKK+Tgvab3YPHBxa3ApLQE8BCad+LH57JOziKzOjqtEpAgJgmao3t77x1UESK4JraaHJDHaYA=="],
 
     "@effect/sql-clickhouse/effect": ["effect@4.0.0-beta.99", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-hP1C61uzINfLl/4kKMwcqksxd34s4sQ3VSjsWjhGrkx9CRlXaqnfOK9dpTEKynQ6rA7wU9rb3c+48eDYw7uzxA=="],
+
+    "@effect/sql-pg/effect": ["effect@4.0.0-beta.99", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-hP1C61uzINfLl/4kKMwcqksxd34s4sQ3VSjsWjhGrkx9CRlXaqnfOK9dpTEKynQ6rA7wU9rb3c+48eDYw7uzxA=="],
+
+    "@effect/sql-pg/pg": ["pg@8.22.0", "", { "dependencies": { "pg-connection-string": "^2.14.0", "pg-pool": "^3.14.0", "pg-protocol": "^1.15.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.4.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA=="],
+
+    "@effect/sql-pg/pg-connection-string": ["pg-connection-string@2.14.0", "", {}, "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg=="],
+
+    "@effect/sql-pg/pg-pool": ["pg-pool@3.14.0", "", { "peerDependencies": { "pg": ">=8.0" } }, "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw=="],
+
+    "@effect/sql-pg/pg-types": ["pg-types@4.1.0", "", { "dependencies": { "pg-int8": "1.0.1", "pg-numeric": "1.0.2", "postgres-array": "~3.0.1", "postgres-bytea": "~3.0.0", "postgres-date": "~2.1.0", "postgres-interval": "^3.0.0", "postgres-range": "^1.1.1" } }, "sha512-o2XFanIMy/3+mThw69O8d4n1E5zsLhdO+OPqswezu7Z5ekP4hYDqlDjlmOpYMbzY2Br0ufCwJLdDIXeNVwcWFg=="],
 
     "@electron/get/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 
@@ -7172,6 +7193,34 @@
     "@effect/sql-clickhouse/effect/uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
 
     "@effect/sql-clickhouse/effect/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "@effect/sql-pg/effect/fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
+
+    "@effect/sql-pg/effect/ini": ["ini@7.0.0", "", {}, "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w=="],
+
+    "@effect/sql-pg/effect/msgpackr": ["msgpackr@2.0.4", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.4" } }, "sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA=="],
+
+    "@effect/sql-pg/effect/multipasta": ["multipasta@0.2.8", "", {}, "sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q=="],
+
+    "@effect/sql-pg/effect/toml": ["toml@4.3.0", "", {}, "sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A=="],
+
+    "@effect/sql-pg/effect/uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
+
+    "@effect/sql-pg/effect/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "@effect/sql-pg/pg/pg-cloudflare": ["pg-cloudflare@1.4.0", "", {}, "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A=="],
+
+    "@effect/sql-pg/pg/pg-protocol": ["pg-protocol@1.15.0", "", {}, "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ=="],
+
+    "@effect/sql-pg/pg/pg-types": ["pg-types@2.2.0", "", { "dependencies": { "pg-int8": "1.0.1", "postgres-array": "~2.0.0", "postgres-bytea": "~1.0.0", "postgres-date": "~1.0.4", "postgres-interval": "^1.1.0" } }, "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="],
+
+    "@effect/sql-pg/pg-types/postgres-array": ["postgres-array@3.0.4", "", {}, "sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ=="],
+
+    "@effect/sql-pg/pg-types/postgres-bytea": ["postgres-bytea@3.0.0", "", { "dependencies": { "obuf": "~1.1.2" } }, "sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw=="],
+
+    "@effect/sql-pg/pg-types/postgres-date": ["postgres-date@2.1.0", "", {}, "sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA=="],
+
+    "@effect/sql-pg/pg-types/postgres-interval": ["postgres-interval@3.0.0", "", {}, "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw=="],
 
     "@electron/get/fs-extra/jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
@@ -8417,6 +8466,10 @@
 
     "@effect/sql-clickhouse/effect/msgpackr/msgpackr-extract": ["msgpackr-extract@3.0.4", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw=="],
 
+    "@effect/sql-pg/effect/fast-check/pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
+
+    "@effect/sql-pg/effect/msgpackr/msgpackr-extract": ["msgpackr-extract@3.0.4", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw=="],
+
     "@floating-ui/react/@floating-ui/react-dom/@floating-ui/dom/@floating-ui/core": ["@floating-ui/core@1.7.4", "", { "dependencies": { "@floating-ui/utils": "^0.2.10" } }, "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg=="],
 
     "@grpc/proto-loader/protobufjs/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
@@ -9200,6 +9253,18 @@
     "@effect/sql-clickhouse/effect/msgpackr/msgpackr-extract/@msgpackr-extract/msgpackr-extract-linux-x64": ["@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ=="],
 
     "@effect/sql-clickhouse/effect/msgpackr/msgpackr-extract/@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4", "", { "os": "win32", "cpu": "x64" }, "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ=="],
+
+    "@effect/sql-pg/effect/msgpackr/msgpackr-extract/@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="],
+
+    "@effect/sql-pg/effect/msgpackr/msgpackr-extract/@msgpackr-extract/msgpackr-extract-darwin-x64": ["@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w=="],
+
+    "@effect/sql-pg/effect/msgpackr/msgpackr-extract/@msgpackr-extract/msgpackr-extract-linux-arm": ["@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4", "", { "os": "linux", "cpu": "arm" }, "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw=="],
+
+    "@effect/sql-pg/effect/msgpackr/msgpackr-extract/@msgpackr-extract/msgpackr-extract-linux-arm64": ["@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw=="],
+
+    "@effect/sql-pg/effect/msgpackr/msgpackr-extract/@msgpackr-extract/msgpackr-extract-linux-x64": ["@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ=="],
+
+    "@effect/sql-pg/effect/msgpackr/msgpackr-extract/@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4", "", { "os": "win32", "cpu": "x64" }, "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ=="],
 
     "@inquirer/core/wrap-ansi/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 

--- a/docs/bayn/architecture.md
+++ b/docs/bayn/architecture.md
@@ -7,9 +7,9 @@ adjusted-ETF time-series momentum. The deployed runtime currently stops at evalu
 not call a broker, submit an order, or promote capital. Later authority is unlocked only by the roadmap's economic,
 recovery, reconciliation, and observation gates.
 
-The current TigerBeetle-backed startup path described below is legacy production state, not the target architecture.
-The active roadmap replaces it incrementally with finalized Signal publications and Bayn-owned PostgreSQL evidence
-before any paper mutation work begins.
+The current deployment retains TigerBeetle as the deterministic simulation journal while Bayn-owned PostgreSQL stores
+the durable evaluation evidence. The roadmap replaces the transitional Signal read and simulation accounting
+incrementally before any paper mutation work begins.
 
 ## Critical path
 
@@ -22,7 +22,11 @@ before any paper mutation work begins.
 5. One evaluator produces strategy, buy-and-hold, direct-volatility, and doubled-cost results on comparable dates.
 6. Deterministic events become double-entry transfers in a Bayn-owned TigerBeetle ledger. Existing IDs are accepted
    only after object lookup and field comparison; accounts, transfers, and posted balances must reconcile exactly.
-7. Kubernetes readiness opens only after data validation, evaluation, journaling, and reconciliation complete.
+7. After exact reconciliation, a single PostgreSQL transaction records the immutable protocol and snapshot references,
+   run identity, metrics, reconciliation receipt, ordered events, gate outcomes, and status history. The transaction
+   changes the run from `WRITING` to `COMPLETE` only after exact child-row counts match.
+8. Kubernetes readiness opens only after data validation, evaluation, journaling, reconciliation, and the durable
+   PostgreSQL commit complete.
 
 There is one `apps/v1 Deployment`, one replica, and one container. It has no scheduler, CronJob, Knative revision,
 broker secret, or Kubernetes API token. `maxSurge: 0` prevents overlapping runtime writers during rollout.
@@ -49,6 +53,12 @@ Decision and fill IDs derive from canonical event payloads. TigerBeetle account 
 event ID, and journal leg. Repeating the same run is idempotent; a changed price, protocol, or source revision creates a
 different run namespace.
 
+PostgreSQL uses the same run ID as its primary idempotency key. Exact replay returns the existing `COMPLETE` receipt
+only after verifying its protocol, snapshot, source revision, image, strategy, status sequence, child-row counts, and
+every stored payload against its content hash. A collision, partial run, altered payload, or divergent immutable
+reference fails closed. Protocol locks and snapshot references are inserted and read back inside the same transaction
+as the run, so no partial evidence survives a failed write.
+
 This transitional identity is deliberately not `bayn.run-identity.v1`: the current ClickHouse table does not yet
 provide finalized publication provenance, an exchange-calendar version, or explicit evaluation bounds. The finalized
 snapshot and bounded-read roadmap slices must supply those facts before the target identity is used.
@@ -61,9 +71,9 @@ authority. Unknown versions and excess fields fail closed. Run identity binds th
 digest, compiled strategy behavior hash, decoded strategy parameters, finalized snapshot, exchange-calendar version,
 and explicit bounds through canonical JSON and SHA-256.
 
-Runtime provenance and strict TSMOM parameter decoding are the first adopted contract slice. Finalized-snapshot
-identity, bounded reads, persistence, continuous health, and removal of the legacy TigerBeetle dependency remain
-separate roadmap tickets with their own rollout evidence.
+Runtime provenance, strict TSMOM parameter decoding, and transactional evaluation persistence are adopted contract
+slices. Finalized-snapshot identity, bounded reads, continuous health, and removal of the legacy TigerBeetle dependency
+remain separate roadmap tickets with their own rollout evidence.
 
 ## Economic test
 
@@ -83,7 +93,8 @@ separate realized gain or loss. Fees move cash to fee expense. Quantities and pr
 event payload hash.
 
 TigerBeetle is currently a single-replica shared dependency. Exact Bayn reconciliation is an accounting-integrity gate;
-it does not make that dependency highly available and does not grant trading authority.
+it does not make that dependency highly available and does not grant trading authority. PostgreSQL durably records the
+result and receipt, but does not replace the double-entry ledger in this slice.
 
 ## Deployment and recovery
 
@@ -92,6 +103,12 @@ CD owns the `bayn` namespace and Deployment. The ClickHouse credential is separa
 Bayn namespace, and granted table-level `SELECT`. Alpaca credentials and the insert/select-only Signal writer identity
 are mounted only into the Signal publisher CronJob and are never mounted into the Bayn runtime.
 
+Bayn connects to `bayn-db-rw` with the CNPG-generated `bayn-db-app` URI and a read-only mount containing only
+`bayn-db-ca/ca.crt`; the CA private key is not mounted. TLS hostname and certificate verification are mandatory in a
+production artifact. Effect SQL owns the scoped two-connection pool and additive migrations. CNPG backup, retention,
+and isolated restore evidence are defined in [`cnpg-backup-restore.md`](cnpg-backup-restore.md).
+
 On restart, Bayn recomputes the deterministic run, verifies any existing TigerBeetle objects, and reconciles the full
-run again before becoming ready. If ClickHouse, TigerBeetle, data validation, evaluation, or reconciliation fails, the
-process remains live for diagnosis but readiness stays closed.
+run again before reading or writing the matching PostgreSQL receipt. If ClickHouse, TigerBeetle, PostgreSQL, data
+validation, evaluation, reconciliation, migration, or persistence fails, the process remains live for diagnosis but
+readiness stays closed.

--- a/nix/images/bayn.nix
+++ b/nix/images/bayn.nix
@@ -22,8 +22,8 @@ import ./bun-workspace-service.nix {
   serviceName = "bayn";
   packageName = "@proompteng/bayn";
   depsHash = {
-    x86_64-linux = "sha256-Ws9+JspLkyoPOaodc/xvJdz/ERHSbf1Mo1KatGv/T7Y=";
-    aarch64-linux = "sha256-H9QzprjNct0lMHUp5O3avguvBSIwgjtRhLPJXhrARb4=";
+    x86_64-linux = "sha256-2/2NUQ6SkNbdAGIcoelN56omrjjnSBO4agHGfG+R9D0=";
+    aarch64-linux = "sha256-sKDCdKuzIB7v6TiSp5DTnLSiSrulyFRW76qyudZLZbg=";
   };
   installFilters = [
     "@proompteng/bayn"

--- a/nix/images/signal-publisher.nix
+++ b/nix/images/signal-publisher.nix
@@ -16,8 +16,8 @@ import ./bun-workspace-service.nix {
   serviceName = "signal-publisher";
   packageName = "@proompteng/signal-publisher";
   depsHash = {
-    x86_64-linux = "sha256-zFGivgeMbIxb4g2X9BHechjkuWGUgUWB644eAuElSfA=";
-    aarch64-linux = "sha256-UzUes+aIh5ilPQ6N3t/sh7t+XuIMuEgBYikvjGnifps=";
+    x86_64-linux = "sha256-Qll8gIKENUGPCA7qH4ogRsxHhczfDGWKTtAMIAW1cTY=";
+    aarch64-linux = "sha256-/6c9pNb28HXphR0MtnU4atNqXNd6R4fWyvuk+9Hupjg=";
   };
   installFilters = [
     "@proompteng/signal-publisher"

--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -11,6 +11,9 @@ and journals the resulting simulation to TigerBeetle. It contains no broker clie
   startup operation (30 seconds by default).
 - Signal ClickHouse is read-only at runtime. Data publication and provider credentials are owned by the separate Signal
   adjusted-daily publisher; Bayn contains no DDL or backfill command.
+- Bayn owns a two-instance CloudNativePG cluster. The runtime uses the generated application URI over verified TLS,
+  runs additive Effect SQL migrations at startup, and keeps a two-connection pool for its single-writer operation plus
+  query cancellation.
 - The composition root selects one strategy capability. TSMOM is the first implementation and owns its protocol and
   universe; the HTTP and startup lifecycle do not depend on TSMOM directly.
 - The protocol is committed at `protocols/tsmom-v1.json` and runtime-decoded with Effect Schema before use. JSON holds
@@ -24,9 +27,13 @@ and journals the resulting simulation to TigerBeetle. It contains no broker clie
 - The transitional run ID binds runtime provenance and the exact ClickHouse input-manifest hash. It remains distinct
   from the target finalized-snapshot run identity until bounded Signal publications are adopted.
 - Signals are formed at a month-end close and may execute only at the next common session open.
-- A run becomes ready only after ClickHouse validation, evaluation, TigerBeetle journal creation, and exact
-  reconciliation. Strategy rejection is an auditable economic `FAIL_CLOSED`; dependency or accounting failure keeps
-  the Kubernetes readiness probe closed.
+- After exact TigerBeetle reconciliation, one PostgreSQL transaction records the immutable protocol lock, input
+  snapshot reference, run identity, metrics, reconciliation receipt, ordered events, gate outcomes, and status
+  history. An exact replay returns the existing complete receipt only after every stored payload and content hash is
+  revalidated; conflicting, altered, or partial evidence fails closed.
+- A run becomes ready only after ClickHouse validation, evaluation, TigerBeetle journal creation, exact reconciliation,
+  and the PostgreSQL commit. Strategy rejection is an auditable economic `FAIL_CLOSED`; dependency, accounting, or
+  persistence failure keeps the Kubernetes readiness probe closed.
 
 ## Endpoints
 
@@ -41,6 +48,13 @@ bun run --filter @proompteng/bayn test
 bun run --filter @proompteng/bayn tsc
 bun run --filter @proompteng/bayn build
 bun run --filter @proompteng/bayn lint:oxlint
+```
+
+The PostgreSQL integration suite requires an isolated local database whose name ends in `_test`:
+
+```sh
+BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:5432/bayn_test \
+  bun test services/bayn/src/db/evidence-store.integration.test.ts
 ```
 
 The legacy `adjusted_daily_bars_v1` read remains transitional until the bounded finalized-snapshot reader is adopted.

--- a/services/bayn/migrations/0001_evaluation_evidence.ts
+++ b/services/bayn/migrations/0001_evaluation_evidence.ts
@@ -1,0 +1,116 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient
+
+  yield* sql`
+    CREATE TABLE bayn_protocol_locks (
+      protocol_hash text PRIMARY KEY CHECK (protocol_hash ~ '^[0-9a-f]{64}$'),
+      schema_version text NOT NULL CHECK (length(schema_version) > 0),
+      strategy_name text NOT NULL CHECK (length(strategy_name) > 0),
+      behavior_hash text NOT NULL CHECK (behavior_hash ~ '^[0-9a-f]{64}$'),
+      parameter_hash text NOT NULL CHECK (parameter_hash ~ '^[0-9a-f]{64}$'),
+      parameters jsonb NOT NULL,
+      created_at timestamptz NOT NULL DEFAULT transaction_timestamp()
+    )
+  `
+
+  yield* sql`
+    CREATE TABLE bayn_snapshot_references (
+      snapshot_id text PRIMARY KEY CHECK (snapshot_id ~ '^[0-9a-f]{64}$'),
+      schema_version text NOT NULL CHECK (length(schema_version) > 0),
+      database_name text NOT NULL CHECK (length(database_name) > 0),
+      table_name text NOT NULL CHECK (length(table_name) > 0),
+      dataset_version text NOT NULL CHECK (length(dataset_version) > 0),
+      source text NOT NULL CHECK (length(source) > 0),
+      source_feed text NOT NULL CHECK (length(source_feed) > 0),
+      adjustment text NOT NULL CHECK (length(adjustment) > 0),
+      content_hash text NOT NULL CHECK (content_hash ~ '^[0-9a-f]{64}$'),
+      row_count bigint NOT NULL CHECK (row_count > 0),
+      first_session date NOT NULL,
+      last_session date NOT NULL,
+      manifest jsonb NOT NULL,
+      created_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+      CHECK (first_session <= last_session)
+    )
+  `
+
+  yield* sql`
+    CREATE TABLE bayn_evaluation_runs (
+      run_id text PRIMARY KEY CHECK (run_id ~ '^[0-9a-f]{64}$'),
+      protocol_hash text NOT NULL REFERENCES bayn_protocol_locks(protocol_hash) ON DELETE RESTRICT,
+      snapshot_id text NOT NULL REFERENCES bayn_snapshot_references(snapshot_id) ON DELETE RESTRICT,
+      evaluation_schema_version text NOT NULL CHECK (length(evaluation_schema_version) > 0),
+      source_revision text NOT NULL CHECK (source_revision ~ '^([0-9a-f]{40}|[0-9a-f]{64})$'),
+      image_repository text NOT NULL CHECK (length(image_repository) > 0),
+      image_digest text NOT NULL CHECK (image_digest ~ '^sha256:[0-9a-f]{64}$'),
+      strategy_name text NOT NULL CHECK (length(strategy_name) > 0),
+      initial_capital_micros numeric(38, 0) NOT NULL CHECK (initial_capital_micros > 0),
+      expected_artifact_count integer NOT NULL CHECK (expected_artifact_count > 0),
+      expected_event_count integer NOT NULL CHECK (expected_event_count >= 0),
+      expected_gate_count integer NOT NULL CHECK (expected_gate_count > 0),
+      status text NOT NULL CHECK (status IN ('WRITING', 'COMPLETE')),
+      created_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+      completed_at timestamptz,
+      CHECK (
+        (status = 'WRITING' AND completed_at IS NULL)
+        OR (status = 'COMPLETE' AND completed_at IS NOT NULL)
+      )
+    )
+  `
+
+  yield* sql`
+    CREATE TABLE bayn_evaluation_artifacts (
+      run_id text NOT NULL REFERENCES bayn_evaluation_runs(run_id) ON DELETE RESTRICT,
+      artifact_name text NOT NULL CHECK (length(artifact_name) > 0),
+      schema_version text NOT NULL CHECK (length(schema_version) > 0),
+      content_hash text NOT NULL CHECK (content_hash ~ '^[0-9a-f]{64}$'),
+      payload jsonb NOT NULL,
+      created_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+      PRIMARY KEY (run_id, artifact_name)
+    )
+  `
+
+  yield* sql`
+    CREATE TABLE bayn_evaluation_events (
+      run_id text NOT NULL REFERENCES bayn_evaluation_runs(run_id) ON DELETE RESTRICT,
+      ordinal integer NOT NULL CHECK (ordinal >= 0),
+      event_id text NOT NULL CHECK (event_id ~ '^[0-9a-f]{64}$'),
+      event_kind text NOT NULL CHECK (event_kind IN ('decision', 'fill')),
+      content_hash text NOT NULL CHECK (content_hash ~ '^[0-9a-f]{64}$'),
+      payload jsonb NOT NULL,
+      created_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+      PRIMARY KEY (run_id, ordinal),
+      UNIQUE (run_id, event_id)
+    )
+  `
+
+  yield* sql`
+    CREATE TABLE bayn_gate_outcomes (
+      run_id text NOT NULL REFERENCES bayn_evaluation_runs(run_id) ON DELETE RESTRICT,
+      ordinal integer NOT NULL CHECK (ordinal >= 0),
+      gate_name text NOT NULL CHECK (length(gate_name) > 0),
+      passed boolean NOT NULL,
+      actual jsonb NOT NULL,
+      required jsonb NOT NULL,
+      content_hash text NOT NULL CHECK (content_hash ~ '^[0-9a-f]{64}$'),
+      created_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+      PRIMARY KEY (run_id, ordinal),
+      UNIQUE (run_id, gate_name)
+    )
+  `
+
+  yield* sql`
+    CREATE TABLE bayn_status_history (
+      sequence bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+      run_id text NOT NULL REFERENCES bayn_evaluation_runs(run_id) ON DELETE RESTRICT,
+      status text NOT NULL CHECK (status IN ('WRITING', 'COMPLETE')),
+      detail jsonb NOT NULL,
+      recorded_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+      UNIQUE (run_id, status)
+    )
+  `
+
+  yield* sql`CREATE INDEX bayn_status_history_run_sequence_idx ON bayn_status_history(run_id, sequence)`
+})

--- a/services/bayn/package.json
+++ b/services/bayn/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@clickhouse/client": "1.23.1",
     "@effect/platform-node": "4.0.0-beta.99",
+    "@effect/sql-pg": "4.0.0-beta.99",
     "effect": "4.0.0-beta.99",
     "tigerbeetle-node": "0.17.9"
   },

--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -5,6 +5,7 @@ import { HttpServer } from 'effect/unstable/http'
 
 import { initialize, makeHttpLayer, run, type RuntimeState } from './app'
 import type { RuntimeConfig } from './config'
+import { DatabaseError, EvidenceStore, type EvidenceStoreService } from './db/evidence-store'
 import { operationalError } from './errors'
 import { Journal, type JournalService } from './ledger'
 import { MarketData, type MarketDataService } from './market-data'
@@ -34,6 +35,11 @@ const config: RuntimeConfig = {
     table: 'adjusted_daily_bars_v1',
     datasetVersion: 'fixture-v1',
   },
+  postgres: {
+    url: Redacted.make('postgresql://bayn:secret@postgres.test:5432/bayn'),
+    tls: false,
+    caPath: '/tmp/test-postgres-ca.crt',
+  },
   tigerBeetle: { clusterId: 2001n, replicaAddresses: ['3000'], ledger: 7001 },
 }
 
@@ -45,6 +51,18 @@ const successfulJournal: JournalService = {
       accountCount: evaluation.inputManifest.symbols.length + 5,
       transferCount: evaluation.events.length,
       exact: true,
+    }),
+}
+
+const successfulEvidenceStore: EvidenceStoreService = {
+  check: Effect.void,
+  persist: ({ evaluation }) =>
+    Effect.succeed({
+      runId: evaluation.runId,
+      deduplicated: false,
+      artifactCount: 5,
+      eventCount: evaluation.events.length,
+      gateCount: evaluation.verdict.gates.length,
     }),
 }
 
@@ -67,6 +85,13 @@ const readyState = (): RuntimeState => {
       provenance,
       evaluation: { ...evaluationWithoutEvents, eventCount: events.length },
       reconciliation: { runId: evaluation.runId, accountCount: 13, transferCount: events.length, exact: true },
+      persistence: {
+        runId: evaluation.runId,
+        deduplicated: false,
+        artifactCount: 5,
+        eventCount: events.length,
+        gateCount: evaluation.verdict.gates.length,
+      },
     },
     error: null,
   }
@@ -152,6 +177,7 @@ describe('Bayn startup lifecycle', () => {
     const strategy: StrategyService = {
       name: 'test-strategy',
       universe: fixtureProtocol.universe,
+      parameters: fixtureProtocol,
       provenance,
       evaluate: (bars, manifest) => {
         calls += 1
@@ -163,6 +189,7 @@ describe('Bayn startup lifecycle', () => {
       initialize(config, state).pipe(
         Effect.provideService(MarketData, { load: Effect.succeed(snapshot) }),
         Effect.provideService(Journal, successfulJournal),
+        Effect.provideService(EvidenceStore, successfulEvidenceStore),
         Effect.provideService(Strategy, strategy),
       ),
     )
@@ -180,6 +207,7 @@ describe('Bayn startup lifecycle', () => {
       initialize(config, state).pipe(
         Effect.provideService(MarketData, marketData),
         Effect.provideService(Journal, successfulJournal),
+        Effect.provideService(EvidenceStore, successfulEvidenceStore),
         Effect.provide(TsmomStrategyLayer(fixtureProtocol, provenance)),
       ),
     )
@@ -200,6 +228,7 @@ describe('Bayn startup lifecycle', () => {
       initialize(config, state).pipe(
         Effect.provideService(MarketData, marketData),
         Effect.provideService(Journal, successfulJournal),
+        Effect.provideService(EvidenceStore, successfulEvidenceStore),
         Effect.provide(TsmomStrategyLayer(fixtureProtocol, provenance)),
       ),
     )
@@ -226,6 +255,7 @@ describe('Bayn startup lifecycle', () => {
       initialize({ ...config, runOnStartup: false }, state).pipe(
         Effect.provideService(MarketData, marketData),
         Effect.provideService(Journal, journal),
+        Effect.provideService(EvidenceStore, successfulEvidenceStore),
         Effect.provide(TsmomStrategyLayer(fixtureProtocol, provenance)),
       ),
     )
@@ -248,6 +278,7 @@ describe('Bayn startup lifecycle', () => {
       initialize({ ...config, operationTimeoutMs: 10 }, state).pipe(
         Effect.provideService(MarketData, marketData),
         Effect.provideService(Journal, successfulJournal),
+        Effect.provideService(EvidenceStore, successfulEvidenceStore),
         Effect.provide(TsmomStrategyLayer(fixtureProtocol, provenance)),
       ),
     )
@@ -265,6 +296,7 @@ describe('Bayn startup lifecycle', () => {
       run(config).pipe(
         Effect.provideService(MarketData, marketData),
         Effect.provideService(Journal, successfulJournal),
+        Effect.provideService(EvidenceStore, successfulEvidenceStore),
         Effect.provide(TsmomStrategyLayer(fixtureProtocol, provenance)),
         Effect.timeoutOrElse({
           duration: 250,
@@ -279,5 +311,35 @@ describe('Bayn startup lifecycle', () => {
       expect(Cause.pretty(exit.cause)).toContain('unexpected startup defect')
       expect(Cause.pretty(exit.cause)).not.toContain('remained alive')
     }
+  })
+
+  test('keeps readiness closed when durable evidence cannot be committed', async () => {
+    const state = await Effect.runPromise(Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null }))
+    const unavailable: EvidenceStoreService = {
+      check: Effect.void,
+      persist: () =>
+        Effect.fail(
+          new DatabaseError({
+            failure: 'unavailable',
+            operation: 'persist',
+            message: 'database unavailable',
+          }),
+        ),
+    }
+
+    await Effect.runPromise(
+      initialize(config, state).pipe(
+        Effect.provideService(MarketData, { load: Effect.succeed(makeSnapshot()) }),
+        Effect.provideService(Journal, successfulJournal),
+        Effect.provideService(EvidenceStore, unavailable),
+        Effect.provide(TsmomStrategyLayer(fixtureProtocol, provenance)),
+      ),
+    )
+
+    expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
+      status: 'FAIL_CLOSED',
+      evidence: null,
+      error: expect.stringContaining('database.persist-evaluation'),
+    })
   })
 })

--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, test } from 'bun:test'
+import { randomUUID } from 'node:crypto'
+import { createServer } from 'node:http'
 
-import { Cause, Context, Effect, Exit, Layer, Redacted, Ref } from 'effect'
+import { NodeServices } from '@effect/platform-node'
+import { Cause, Context, Effect, Exit, Fiber, Layer, Redacted, Ref } from 'effect'
 import { HttpServer } from 'effect/unstable/http'
 
 import { initialize, makeHttpLayer, run, type RuntimeState } from './app'
 import type { RuntimeConfig } from './config'
-import { DatabaseError, EvidenceStore, type EvidenceStoreService } from './db/evidence-store'
+import { DatabaseError, EvidenceStore, EvidenceStoreRuntimeLive, type EvidenceStoreService } from './db/evidence-store'
 import { operationalError } from './errors'
 import { Journal, type JournalService } from './ledger'
 import { MarketData, type MarketDataService } from './market-data'
@@ -73,6 +76,36 @@ const fetchJson = async (port: number, path: string, method = 'GET') => {
     allow: response.headers.get('allow'),
     body: (await response.json()) as Record<string, unknown>,
   }
+}
+
+const unusedPort = () =>
+  new Promise<number>((resolve, reject) => {
+    const server = createServer()
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      if (address === null || typeof address === 'string') {
+        server.close()
+        reject(new Error('test server did not bind a TCP port'))
+        return
+      }
+      server.close((error) => (error === undefined ? resolve(address.port) : reject(error)))
+    })
+  })
+
+const waitForStatus = async (port: number, expectedStatus: string) => {
+  const deadline = Date.now() + 2_000
+  let lastError: unknown
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetchJson(port, '/v1/status')
+      if (response.body.status === expectedStatus) return response
+    } catch (error) {
+      lastError = error
+    }
+    await Bun.sleep(20)
+  }
+  throw new Error(`Bayn did not reach ${expectedStatus}`, { cause: lastError })
 }
 
 const readyState = (): RuntimeState => {
@@ -341,5 +374,43 @@ describe('Bayn startup lifecycle', () => {
       evidence: null,
       error: expect.stringContaining('database.persist-evaluation'),
     })
+  })
+
+  test('keeps HTTP live and readiness closed when database layer setup fails', async () => {
+    const port = await unusedPort()
+    const unavailableDatabase = {
+      ...config,
+      port,
+      postgres: {
+        ...config.postgres,
+        tls: true,
+        caPath: `/tmp/bayn-missing-ca-${randomUUID()}.crt`,
+      },
+    }
+    const dependencies = Layer.mergeAll(
+      Layer.succeed(MarketData, { load: Effect.succeed(makeSnapshot()) }),
+      Layer.succeed(Journal, successfulJournal),
+      EvidenceStoreRuntimeLive(unavailableDatabase).pipe(Layer.provide(NodeServices.layer)),
+      TsmomStrategyLayer(fixtureProtocol, provenance),
+    )
+    const fiber = Effect.runFork(run(unavailableDatabase).pipe(Effect.provide(dependencies)))
+
+    try {
+      const status = await waitForStatus(port, 'FAIL_CLOSED')
+      expect(status).toMatchObject({
+        status: 200,
+        body: {
+          status: 'FAIL_CLOSED',
+          error: expect.stringContaining('database.health-check'),
+        },
+      })
+      expect(await fetchJson(port, '/livez')).toMatchObject({ status: 200, body: { live: true } })
+      expect(await fetchJson(port, '/readyz')).toMatchObject({
+        status: 503,
+        body: { ready: false, status: 'FAIL_CLOSED' },
+      })
+    } finally {
+      await Effect.runPromise(Fiber.interrupt(fiber))
+    }
   })
 })

--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -6,6 +6,7 @@ import { HttpRouter, HttpServerRequest, HttpServerResponse } from 'effect/unstab
 
 import type { RuntimeBuildMetadata, RuntimeConfig } from './config'
 import type { RuntimeProvenance } from './contracts'
+import { EvidenceStore, type PersistenceReceipt } from './db/evidence-store'
 import { formatError, operationalError, type Component, type OperationalError } from './errors'
 import { Journal } from './ledger'
 import { MarketData } from './market-data'
@@ -16,6 +17,7 @@ interface RuntimeEvidence {
   readonly provenance: RuntimeProvenance
   readonly evaluation: Omit<EvaluationResult, 'events'> & { readonly eventCount: number }
   readonly reconciliation: ReconciliationResult
+  readonly persistence: PersistenceReceipt
 }
 
 export type RuntimeState =
@@ -108,14 +110,20 @@ const failClosed = (state: Ref.Ref<RuntimeState>, error: OperationalError): Effe
     ),
   )
 
+const databaseOperation = <A, R>(effect: Effect.Effect<A, { readonly message: string }, R>, operation: string) =>
+  effect.pipe(
+    Effect.mapError((cause) => operationalError('database', operation, `PostgreSQL ${operation} failed`, cause)),
+  )
+
 const evaluateAndJournal = (
   config: RuntimeConfig,
   state: Ref.Ref<RuntimeState>,
-): Effect.Effect<void, OperationalError, MarketData | Journal | Strategy> =>
+): Effect.Effect<void, OperationalError, MarketData | Journal | Strategy | EvidenceStore> =>
   Effect.gen(function* () {
     const marketData = yield* MarketData
     const journal = yield* Journal
     const strategy = yield* Strategy
+    const evidenceStore = yield* EvidenceStore
     yield* Effect.logInfo('Bayn startup evaluation started').pipe(
       Effect.annotateLogs({
         service: 'bayn',
@@ -127,6 +135,12 @@ const evaluateAndJournal = (
       }),
     )
     yield* withinDeadline(journal.check, config.operationTimeoutMs, 'journal', 'connectivity-check')
+    yield* withinDeadline(
+      databaseOperation(evidenceStore.check, 'health-check'),
+      config.operationTimeoutMs,
+      'database',
+      'health-check',
+    )
     const snapshot = yield* withinDeadline(marketData.load, config.operationTimeoutMs, 'market-data', 'load')
     yield* Effect.logInfo('Bayn signal snapshot loaded').pipe(
       Effect.annotateLogs({
@@ -154,6 +168,20 @@ const evaluateAndJournal = (
       'journal',
       'journal-and-reconcile',
     )
+    const persistence = yield* withinDeadline(
+      databaseOperation(
+        evidenceStore.persist({
+          provenance: strategy.provenance,
+          parameters: strategy.parameters,
+          evaluation,
+          reconciliation,
+        }),
+        'persist-evaluation',
+      ),
+      config.operationTimeoutMs,
+      'database',
+      'persist-evaluation',
+    )
     const { events, ...evaluationWithoutEvents } = evaluation
     yield* Ref.set(state, {
       status: 'READY',
@@ -161,6 +189,7 @@ const evaluateAndJournal = (
         provenance: strategy.provenance,
         evaluation: { ...evaluationWithoutEvents, eventCount: events.length },
         reconciliation,
+        persistence,
       },
       error: null,
     })
@@ -170,6 +199,7 @@ const evaluateAndJournal = (
         runId: evaluation.runId,
         accountCount: reconciliation.accountCount,
         transferCount: reconciliation.transferCount,
+        persistenceDeduplicated: persistence.deduplicated,
       }),
     )
   }).pipe(Effect.withLogSpan('startup'))
@@ -177,11 +207,18 @@ const evaluateAndJournal = (
 const checkWithoutJournal = (
   config: RuntimeConfig,
   state: Ref.Ref<RuntimeState>,
-): Effect.Effect<void, OperationalError, MarketData | Journal> =>
+): Effect.Effect<void, OperationalError, MarketData | Journal | EvidenceStore> =>
   Effect.gen(function* () {
     const marketData = yield* MarketData
     const journal = yield* Journal
+    const evidenceStore = yield* EvidenceStore
     yield* withinDeadline(journal.check, config.operationTimeoutMs, 'journal', 'connectivity-check')
+    yield* withinDeadline(
+      databaseOperation(evidenceStore.check, 'health-check'),
+      config.operationTimeoutMs,
+      'database',
+      'health-check',
+    )
     yield* withinDeadline(marketData.load, config.operationTimeoutMs, 'market-data', 'load')
     yield* Ref.set(state, {
       status: 'FAIL_CLOSED',
@@ -193,12 +230,14 @@ const checkWithoutJournal = (
 export const initialize = (
   config: RuntimeConfig,
   state: Ref.Ref<RuntimeState>,
-): Effect.Effect<void, never, MarketData | Journal | Strategy> =>
+): Effect.Effect<void, never, MarketData | Journal | Strategy | EvidenceStore> =>
   (config.runOnStartup ? evaluateAndJournal(config, state) : checkWithoutJournal(config, state)).pipe(
     Effect.catch((error) => failClosed(state, error)),
   )
 
-export const run = (config: RuntimeConfig): Effect.Effect<never, OperationalError, MarketData | Journal | Strategy> =>
+export const run = (
+  config: RuntimeConfig,
+): Effect.Effect<never, OperationalError, MarketData | Journal | Strategy | EvidenceStore> =>
   Effect.scoped(
     Effect.gen(function* () {
       const strategy = yield* Strategy

--- a/services/bayn/src/config.test.ts
+++ b/services/bayn/src/config.test.ts
@@ -22,6 +22,7 @@ const runtimeEnvironment = new Map([
   ['BAYN_CLICKHOUSE_USERNAME', 'bayn'],
   ['BAYN_CLICKHOUSE_PASSWORD', 'secret'],
   ['BAYN_DATASET_VERSION', 'fixture-v1'],
+  ['BAYN_POSTGRES_URL', 'postgresql://bayn:secret@postgres.test:5432/bayn'],
   ['BAYN_TIGERBEETLE_ADDRESSES', 'tigerbeetle.test:3000'],
 ])
 
@@ -39,6 +40,11 @@ describe('Effect configuration', () => {
     expect(config.operationTimeoutMs).toBe(30_000)
     expect(config.clickhouse.database).toBe('signal')
     expect(Redacted.isRedacted(config.clickhouse.password)).toBe(true)
+    expect(Redacted.isRedacted(config.postgres.url)).toBe(true)
+    expect(config.postgres).toMatchObject({
+      tls: true,
+      caPath: '/var/run/secrets/bayn/postgres/ca.crt',
+    })
     expect(config.tigerBeetle.clusterId).toBe(2001n)
     expect(config.tigerBeetle.replicaAddresses).toEqual(['tigerbeetle.test:3000'])
     expect(config.build).toEqual({ ...buildMetadata, imageDigest, verification: 'embedded' })
@@ -87,6 +93,18 @@ describe('Effect configuration', () => {
       _tag: 'OperationalError',
       component: 'config',
       operation: 'load',
+    })
+  })
+
+  test('does not permit plaintext PostgreSQL in a production artifact', async () => {
+    const invalid = new Map(runtimeEnvironment)
+    invalid.set('BAYN_POSTGRES_TLS', 'false')
+
+    const error = await Effect.runPromise(Effect.flip(provideEnvironment(loadConfig(buildMetadata), invalid)))
+    expect(error).toMatchObject({
+      _tag: 'OperationalError',
+      component: 'config',
+      operation: 'provenance',
     })
   })
 

--- a/services/bayn/src/config.ts
+++ b/services/bayn/src/config.ts
@@ -23,6 +23,11 @@ export interface RuntimeConfig {
     readonly table: string
     readonly datasetVersion: string
   }
+  readonly postgres: {
+    readonly url: Redacted.Redacted<string>
+    readonly tls: boolean
+    readonly caPath: string
+  }
   readonly tigerBeetle: {
     readonly clusterId: bigint
     readonly replicaAddresses: readonly string[]
@@ -77,6 +82,11 @@ const runtimeConfig = Config.all({
   clickhouseDatabase: clickhouseIdentifier('BAYN_CLICKHOUSE_DATABASE', 'signal'),
   clickhouseTable: clickhouseIdentifier('BAYN_CLICKHOUSE_TABLE', 'adjusted_daily_bars_v1'),
   datasetVersion: nonEmptyString('BAYN_DATASET_VERSION'),
+  postgresUrl: Config.redacted('BAYN_POSTGRES_URL'),
+  postgresTls: Config.boolean('BAYN_POSTGRES_TLS').pipe(Config.withDefault(true)),
+  postgresCaPath: nonEmptyString('BAYN_POSTGRES_CA_PATH').pipe(
+    Config.withDefault('/var/run/secrets/bayn/postgres/ca.crt'),
+  ),
   tigerBeetleClusterId: Config.schema(Schema.BigIntFromString, 'BAYN_TIGERBEETLE_CLUSTER_ID').pipe(
     Config.withDefault(2001n),
   ),
@@ -102,6 +112,11 @@ const runtimeConfig = Config.all({
       table: config.clickhouseTable,
       datasetVersion: config.datasetVersion,
     },
+    postgres: {
+      url: config.postgresUrl,
+      tls: config.postgresTls,
+      caPath: config.postgresCaPath,
+    },
     tigerBeetle: {
       clusterId: config.tigerBeetleClusterId,
       replicaAddresses: config.tigerBeetleReplicaAddresses,
@@ -126,6 +141,9 @@ export const loadConfig = (
           }
           if (embedded !== undefined && config.provenanceMode !== 'production') {
             throw new Error('development provenance cannot override embedded production metadata')
+          }
+          if (embedded !== undefined && !config.postgres.tls) {
+            throw new Error('production PostgreSQL connections require verified TLS')
           }
 
           const decodedBuild =

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -146,7 +146,24 @@ describePostgres('PostgreSQL evaluation evidence', () => {
             (SELECT count(*)::integer FROM bayn_gate_outcomes WHERE run_id = run.run_id) AS gate_count
           FROM bayn_evaluation_runs AS run
         `
-        return { first, second, runs }
+        const gates = yield* sql<{
+          gate_name: string
+          actual: unknown
+          required: unknown
+          actual_type: string
+          required_type: string
+        }>`
+          SELECT
+            gate_name,
+            actual,
+            required,
+            jsonb_typeof(actual) AS actual_type,
+            jsonb_typeof(required) AS required_type
+          FROM bayn_gate_outcomes
+          WHERE run_id = ${input.evaluation.runId}
+          ORDER BY ordinal
+        `
+        return { first, second, runs, gates }
       }),
     )
 
@@ -160,6 +177,15 @@ describePostgres('PostgreSQL evaluation evidence', () => {
         gate_count: result.first.gateCount,
       },
     ])
+    expect(result.gates).toEqual(
+      input.evaluation.verdict.gates.map((gate) => ({
+        gate_name: gate.name,
+        actual: gate.actual,
+        required: gate.required,
+        actual_type: typeof gate.actual,
+        required_type: typeof gate.required,
+      })),
+    )
   })
 
   test('creates distinct runs when bound runtime provenance changes', async () => {
@@ -195,6 +221,28 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     expect(error).toBeInstanceOf(DatabaseError)
     expect(error.failure).toBe('invariant')
     expect(error.operation).toBe('read-receipt')
+  })
+
+  test('rejects a replay whose normalized snapshot bounds were altered', async () => {
+    const input = makeInput()
+    const error = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* EvidenceStore
+        const sql = yield* PgClient.PgClient
+        yield* store.persist(input)
+        yield* sql`
+          UPDATE bayn_snapshot_references
+          SET first_session = first_session + 1
+          WHERE snapshot_id = ${input.evaluation.inputManifest.hash}
+        `
+        return yield* store.persist(input).pipe(Effect.flip)
+      }),
+    )
+
+    expect(error).toBeInstanceOf(DatabaseError)
+    expect(error.failure).toBe('invariant')
+    expect(error.operation).toBe('snapshot-reference')
+    expect(error.message).toContain('stored snapshot reference diverged')
   })
 
   test('rolls back every table when an event constraint fails', async () => {

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -245,6 +245,50 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     expect(error.message).toContain('stored snapshot reference diverged')
   })
 
+  test('rejects a replay whose initial capital was altered', async () => {
+    const input = makeInput()
+    const error = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* EvidenceStore
+        const sql = yield* PgClient.PgClient
+        yield* store.persist(input)
+        yield* sql`
+          UPDATE bayn_evaluation_runs
+          SET initial_capital_micros = initial_capital_micros + 1
+          WHERE run_id = ${input.evaluation.runId}
+        `
+        return yield* store.persist(input).pipe(Effect.flip)
+      }),
+    )
+
+    expect(error).toBeInstanceOf(DatabaseError)
+    expect(error.failure).toBe('invariant')
+    expect(error.operation).toBe('read-receipt')
+    expect(error.message).toContain('stored run identity diverged')
+  })
+
+  test('rejects a replay whose status detail was altered', async () => {
+    const input = makeInput()
+    const error = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* EvidenceStore
+        const sql = yield* PgClient.PgClient
+        yield* store.persist(input)
+        yield* sql`
+          UPDATE bayn_status_history
+          SET detail = ${sql.json({ reconciliationExact: false, verdict: 'corrupted' })}
+          WHERE run_id = ${input.evaluation.runId} AND status = 'COMPLETE'
+        `
+        return yield* store.persist(input).pipe(Effect.flip)
+      }),
+    )
+
+    expect(error).toBeInstanceOf(DatabaseError)
+    expect(error.failure).toBe('invariant')
+    expect(error.operation).toBe('read-receipt')
+    expect(error.message).toContain('stored status history diverged')
+  })
+
   test('rolls back every table when an event constraint fails', async () => {
     const input = makeInput()
     const duplicateId = input.evaluation.events[0].id

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -1,0 +1,292 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test'
+
+import { NodeServices } from '@effect/platform-node'
+import { PgClient } from '@effect/sql-pg'
+import { Cause, Effect, Exit, Fiber, Layer, ManagedRuntime, Option, Redacted } from 'effect'
+
+import type { RuntimeConfig } from '../config'
+import { buildLedgerPlan } from '../ledger'
+import { evaluateTsmom } from '../strategy'
+import { fixtureProtocol, makeSnapshot, makeTestProvenance } from '../test-fixtures'
+import {
+  DatabaseError,
+  EvidenceStore,
+  EvidenceStoreLive,
+  PostgresClientLive,
+  type PersistEvaluationInput,
+} from './evidence-store'
+
+const postgresUrl = process.env.BAYN_TEST_POSTGRES_URL
+const testUrl = postgresUrl ?? 'postgresql://bayn:bayn@127.0.0.1:5432/bayn_test'
+const describePostgres = postgresUrl === undefined ? describe.skip : describe
+
+const makeConfig = (url = testUrl): RuntimeConfig => ({
+  host: '127.0.0.1',
+  port: 8080,
+  build: {
+    sourceRevision: 'a'.repeat(40),
+    imageRepository: 'registry.ide-newton.ts.net/lab/bayn',
+    imageDigest: `sha256:${'b'.repeat(64)}`,
+    strategyBehaviorHash: 'c'.repeat(64),
+    verification: 'embedded',
+  },
+  runOnStartup: true,
+  operationTimeoutMs: 1_000,
+  clickhouse: {
+    url: 'http://clickhouse.invalid',
+    username: 'bayn',
+    password: Redacted.make('unused'),
+    database: 'signal',
+    table: 'adjusted_daily_bars_v1',
+    datasetVersion: 'fixture-v1',
+  },
+  postgres: { url: Redacted.make(url), tls: false, caPath: '/unused' },
+  tigerBeetle: { clusterId: 2_001n, replicaAddresses: ['127.0.0.1:3000'], ledger: 7_001 },
+})
+
+const makeEvidenceRuntime = (config = makeConfig()) =>
+  ManagedRuntime.make(EvidenceStoreLive(config).pipe(Layer.provide(NodeServices.layer)))
+
+const makeClientRuntime = (config = makeConfig()) =>
+  ManagedRuntime.make(PostgresClientLive(config).pipe(Layer.provide(NodeServices.layer)))
+
+const snapshot = makeSnapshot(800)
+
+const makeInput = (sourceRevision = 'a'.repeat(40)): PersistEvaluationInput => {
+  const provenance = makeTestProvenance(fixtureProtocol, { sourceRevision })
+  const evaluation = evaluateTsmom(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance)
+  const ledger = buildLedgerPlan(evaluation, 7_001)
+  return {
+    provenance,
+    parameters: fixtureProtocol,
+    evaluation,
+    reconciliation: {
+      runId: evaluation.runId,
+      accountCount: ledger.accounts.length,
+      transferCount: ledger.transfers.length,
+      exact: true,
+    },
+  }
+}
+
+describePostgres('PostgreSQL evaluation evidence', () => {
+  let runtime: ReturnType<typeof makeEvidenceRuntime>
+
+  beforeAll(async () => {
+    const parsed = new URL(testUrl)
+    if (!['127.0.0.1', 'localhost', '[::1]'].includes(parsed.hostname) || !parsed.pathname.endsWith('_test')) {
+      throw new Error('BAYN_TEST_POSTGRES_URL must target a local database whose name ends in _test')
+    }
+    runtime = makeEvidenceRuntime()
+    await runtime.runPromise(Effect.flatMap(EvidenceStore, (store) => store.check))
+  })
+
+  beforeEach(async () => {
+    await runtime.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* PgClient.PgClient
+        yield* sql`
+          TRUNCATE
+            bayn_evaluation_runs,
+            bayn_protocol_locks,
+            bayn_snapshot_references
+          RESTART IDENTITY CASCADE
+        `
+      }),
+    )
+  })
+
+  afterAll(async () => {
+    await runtime?.dispose()
+  })
+
+  test('migrates the complete evidence schema', async () => {
+    const tables = await runtime.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* PgClient.PgClient
+        return yield* sql<{ table_name: string }>`
+          SELECT table_name
+          FROM information_schema.tables
+          WHERE table_schema = 'public' AND table_name LIKE 'bayn_%'
+          ORDER BY table_name
+        `
+      }),
+    )
+
+    expect(tables.map((row) => row.table_name)).toEqual([
+      'bayn_evaluation_artifacts',
+      'bayn_evaluation_events',
+      'bayn_evaluation_runs',
+      'bayn_gate_outcomes',
+      'bayn_protocol_locks',
+      'bayn_schema_migrations',
+      'bayn_snapshot_references',
+      'bayn_status_history',
+    ])
+  })
+
+  test('commits one complete run and deduplicates an exact replay', async () => {
+    const input = makeInput()
+    const result = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* EvidenceStore
+        const sql = yield* PgClient.PgClient
+        const first = yield* store.persist(input)
+        const second = yield* store.persist(input)
+        const runs = yield* sql<{
+          status: string
+          artifact_count: number
+          event_count: number
+          gate_count: number
+        }>`
+          SELECT
+            run.status,
+            (SELECT count(*)::integer FROM bayn_evaluation_artifacts WHERE run_id = run.run_id) AS artifact_count,
+            (SELECT count(*)::integer FROM bayn_evaluation_events WHERE run_id = run.run_id) AS event_count,
+            (SELECT count(*)::integer FROM bayn_gate_outcomes WHERE run_id = run.run_id) AS gate_count
+          FROM bayn_evaluation_runs AS run
+        `
+        return { first, second, runs }
+      }),
+    )
+
+    expect(result.first).toMatchObject({ runId: input.evaluation.runId, deduplicated: false })
+    expect(result.second).toEqual({ ...result.first, deduplicated: true })
+    expect(result.runs).toEqual([
+      {
+        status: 'COMPLETE',
+        artifact_count: result.first.artifactCount,
+        event_count: result.first.eventCount,
+        gate_count: result.first.gateCount,
+      },
+    ])
+  })
+
+  test('creates distinct runs when bound runtime provenance changes', async () => {
+    const first = makeInput('a'.repeat(40))
+    const second = makeInput('d'.repeat(40))
+    const receipts = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* EvidenceStore
+        return [yield* store.persist(first), yield* store.persist(second)] as const
+      }),
+    )
+
+    expect(first.evaluation.runId).not.toBe(second.evaluation.runId)
+    expect(receipts.map((receipt) => receipt.runId)).toEqual([first.evaluation.runId, second.evaluation.runId])
+  })
+
+  test('rejects a complete receipt whose stored evidence was altered', async () => {
+    const input = makeInput()
+    const error = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* EvidenceStore
+        const sql = yield* PgClient.PgClient
+        yield* store.persist(input)
+        yield* sql`
+          UPDATE bayn_evaluation_artifacts
+          SET payload = ${sql.json({ corrupted: true })}
+          WHERE run_id = ${input.evaluation.runId} AND artifact_name = 'strategy'
+        `
+        return yield* store.persist(input).pipe(Effect.flip)
+      }),
+    )
+
+    expect(error).toBeInstanceOf(DatabaseError)
+    expect(error.failure).toBe('invariant')
+    expect(error.operation).toBe('read-receipt')
+  })
+
+  test('rolls back every table when an event constraint fails', async () => {
+    const input = makeInput()
+    const duplicateId = input.evaluation.events[0].id
+    const invalid: PersistEvaluationInput = {
+      ...input,
+      evaluation: {
+        ...input.evaluation,
+        events: input.evaluation.events.map((event, index) => (index === 1 ? { ...event, id: duplicateId } : event)),
+      },
+    }
+    const result = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* EvidenceStore
+        const error = yield* store.persist(invalid).pipe(Effect.flip)
+        const sql = yield* PgClient.PgClient
+        const counts = yield* sql<{
+          runs: number
+          protocols: number
+          snapshots: number
+          events: number
+        }>`
+          SELECT
+            (SELECT count(*)::integer FROM bayn_evaluation_runs) AS runs,
+            (SELECT count(*)::integer FROM bayn_protocol_locks) AS protocols,
+            (SELECT count(*)::integer FROM bayn_snapshot_references) AS snapshots,
+            (SELECT count(*)::integer FROM bayn_evaluation_events) AS events
+        `
+        return { error, counts: counts[0] }
+      }),
+    )
+
+    expect(result.error).toBeInstanceOf(DatabaseError)
+    expect(result.error.failure).toBe('constraint')
+    expect(result.counts).toEqual({ runs: 0, protocols: 0, snapshots: 0, events: 0 })
+  })
+
+  test('cancels an interrupted query and returns its pooled connection', async () => {
+    const rows = await runtime.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* PgClient.PgClient
+        const sleeper = yield* Effect.forkChild(sql`SELECT pg_sleep(30)`)
+        yield* Effect.sleep('250 millis')
+        yield* Fiber.interrupt(sleeper)
+        return yield* sql<{ value: number }>`SELECT 1::integer AS value`.pipe(
+          Effect.timeoutOrElse({
+            duration: '2 seconds',
+            orElse: () => Effect.fail(new Error('PostgreSQL pool did not recover')),
+          }),
+        )
+      }),
+    )
+
+    expect(rows).toEqual([{ value: 1 }])
+  })
+
+  test('closes the PostgreSQL pool when its managed scope is disposed', async () => {
+    const scoped = makeClientRuntime()
+    const pid = await scoped.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* PgClient.PgClient
+        const rows = yield* sql<{ pid: number }>`SELECT pg_backend_pid()::integer AS pid`
+        return rows[0].pid
+      }),
+    )
+    await scoped.dispose()
+
+    const rows = await runtime.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* PgClient.PgClient
+        return yield* sql<{ count: number }>`
+          SELECT count(*)::integer AS count FROM pg_stat_activity WHERE pid = ${pid}
+        `
+      }),
+    )
+    expect(rows).toEqual([{ count: 0 }])
+  })
+
+  test('reports an unreachable database as a typed availability failure', async () => {
+    const invalid = makeEvidenceRuntime(makeConfig('postgresql://bayn:bayn@127.0.0.1:1/bayn_test'))
+    try {
+      const exit = await invalid.runPromiseExit(Effect.void)
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isSuccess(exit)) throw new Error('unreachable PostgreSQL unexpectedly initialized')
+      const failure = Cause.findErrorOption(exit.cause)
+      expect(Option.isSome(failure)).toBe(true)
+      if (Option.isNone(failure)) throw new Error(Cause.pretty(exit.cause))
+      expect(failure.value).toBeInstanceOf(DatabaseError)
+      expect((failure.value as DatabaseError).failure).toBe('unavailable')
+    } finally {
+      await invalid.dispose()
+    }
+  })
+})

--- a/services/bayn/src/db/evidence-store.ts
+++ b/services/bayn/src/db/evidence-store.ts
@@ -100,6 +100,8 @@ const SnapshotRow = Schema.Struct({
   adjustment: Schema.String,
   content_hash: Sha256,
   row_count: PositiveInteger,
+  first_session: Schema.String,
+  last_session: Schema.String,
   manifest: Schema.Unknown,
 })
 const ReceiptRow = Schema.Struct({
@@ -241,6 +243,8 @@ const makePersistencePlan = (input: PersistEvaluationInput): PersistencePlan => 
 
 const makeEvidenceStore = Effect.gen(function* () {
   const sql = yield* PgClient.PgClient
+  const jsonScalar = (value: number | boolean | string) =>
+    sql.json(typeof value === 'string' ? JSON.stringify(value) : value)
 
   const health = SqlSchema.findOne({
     Request: Schema.Void,
@@ -267,6 +271,8 @@ const makeEvidenceStore = Effect.gen(function* () {
         adjustment,
         content_hash,
         row_count::integer AS row_count,
+        first_session::text,
+        last_session::text,
         manifest
       FROM bayn_snapshot_references
       WHERE snapshot_id = ${snapshotId}
@@ -585,6 +591,8 @@ const makeEvidenceStore = Effect.gen(function* () {
                 snapshot.adjustment === manifest.adjustment &&
                 snapshot.content_hash === manifest.contentHash &&
                 snapshot.row_count === manifest.rowCount &&
+                snapshot.first_session === manifest.firstSession &&
+                snapshot.last_session === manifest.lastSession &&
                 canonicalHashV1(snapshot.manifest) === canonicalHashV1(manifest),
               'snapshot-reference',
               'stored snapshot reference diverged from the evaluated input manifest',
@@ -674,8 +682,8 @@ const makeEvidenceStore = Effect.gen(function* () {
                 ${gate.ordinal},
                 ${gate.name},
                 ${gate.passed},
-                ${sql.json(JSON.stringify(gate.actual))},
-                ${sql.json(JSON.stringify(gate.required))},
+                ${jsonScalar(gate.actual)},
+                ${jsonScalar(gate.required)},
                 ${gate.contentHash}
               )
             `,

--- a/services/bayn/src/db/evidence-store.ts
+++ b/services/bayn/src/db/evidence-store.ts
@@ -1,0 +1,752 @@
+import { PgClient, PgMigrator } from '@effect/sql-pg'
+import { Context, Data, Effect, FileSystem, Layer, Schema } from 'effect'
+import { SqlSchema } from 'effect/unstable/sql'
+import { isSqlError } from 'effect/unstable/sql/SqlError'
+
+import type { RuntimeConfig } from '../config'
+import type { RuntimeProvenance } from '../contracts'
+import { canonicalHashV1, hashObject } from '../hash'
+import type { EvaluationResult, ReconciliationResult } from '../types'
+import { migrationLoader } from './migrations'
+
+export type DatabaseFailure = 'constraint' | 'decode' | 'invariant' | 'migration' | 'query' | 'unavailable'
+
+export class DatabaseError extends Data.TaggedError('DatabaseError')<{
+  readonly failure: DatabaseFailure
+  readonly operation: string
+  readonly message: string
+  readonly cause?: unknown
+}> {}
+
+export interface PersistenceReceipt {
+  readonly runId: string
+  readonly deduplicated: boolean
+  readonly artifactCount: number
+  readonly eventCount: number
+  readonly gateCount: number
+}
+
+export interface PersistEvaluationInput {
+  readonly provenance: RuntimeProvenance
+  readonly parameters: unknown
+  readonly evaluation: EvaluationResult
+  readonly reconciliation: ReconciliationResult
+}
+
+export interface EvidenceStoreService {
+  readonly check: Effect.Effect<void, DatabaseError>
+  readonly persist: (input: PersistEvaluationInput) => Effect.Effect<PersistenceReceipt, DatabaseError>
+}
+
+export class EvidenceStore extends Context.Service<EvidenceStore, EvidenceStoreService>()('bayn/EvidenceStore') {}
+
+interface ArtifactPlan {
+  readonly name: string
+  readonly schemaVersion: string
+  readonly contentHash: string
+  readonly payload: unknown
+}
+
+interface EventPlan {
+  readonly ordinal: number
+  readonly id: string
+  readonly kind: 'decision' | 'fill'
+  readonly contentHash: string
+  readonly payload: unknown
+}
+
+interface GatePlan {
+  readonly ordinal: number
+  readonly name: string
+  readonly passed: boolean
+  readonly actual: number | boolean | string
+  readonly required: number | boolean | string
+  readonly contentHash: string
+}
+
+interface PersistencePlan extends PersistEvaluationInput {
+  readonly strategyName: string
+  readonly protocolHash: string
+  readonly snapshotId: string
+  readonly artifacts: readonly ArtifactPlan[]
+  readonly events: readonly EventPlan[]
+  readonly gates: readonly GatePlan[]
+}
+
+const Sha256 = Schema.String.check(Schema.isPattern(/^[0-9a-f]{64}$/))
+const GitRevision = Schema.String.check(Schema.isPattern(/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/))
+const ImageDigest = Schema.String.check(Schema.isPattern(/^sha256:[0-9a-f]{64}$/))
+const PositiveInteger = Schema.Int.check(Schema.isGreaterThan(0))
+const NonNegativeInteger = Schema.Int.check(Schema.isGreaterThanOrEqualTo(0))
+const RunRequest = Schema.Struct({ runId: Sha256 })
+const InsertedRun = Schema.Struct({ run_id: Sha256 })
+const HealthRow = Schema.Struct({ value: Schema.Literal(1) })
+const ProtocolRow = Schema.Struct({
+  protocol_hash: Sha256,
+  schema_version: Schema.String,
+  strategy_name: Schema.String,
+  behavior_hash: Sha256,
+  parameter_hash: Sha256,
+  parameters: Schema.Unknown,
+})
+const SnapshotRow = Schema.Struct({
+  snapshot_id: Sha256,
+  schema_version: Schema.String,
+  database_name: Schema.String,
+  table_name: Schema.String,
+  dataset_version: Schema.String,
+  source: Schema.String,
+  source_feed: Schema.String,
+  adjustment: Schema.String,
+  content_hash: Sha256,
+  row_count: PositiveInteger,
+  manifest: Schema.Unknown,
+})
+const ReceiptRow = Schema.Struct({
+  run_id: Sha256,
+  protocol_hash: Sha256,
+  snapshot_id: Sha256,
+  evaluation_schema_version: Schema.String,
+  source_revision: GitRevision,
+  image_repository: Schema.String,
+  image_digest: ImageDigest,
+  strategy_name: Schema.String,
+  status: Schema.Literal('COMPLETE'),
+  expected_artifact_count: PositiveInteger,
+  expected_event_count: NonNegativeInteger,
+  expected_gate_count: PositiveInteger,
+  artifact_count: NonNegativeInteger,
+  event_count: NonNegativeInteger,
+  gate_count: NonNegativeInteger,
+})
+const ArtifactReferenceRow = Schema.Struct({
+  artifact_name: Schema.String,
+  schema_version: Schema.String,
+  content_hash: Sha256,
+  payload: Schema.Unknown,
+})
+const EventReferenceRow = Schema.Struct({
+  ordinal: NonNegativeInteger,
+  event_id: Sha256,
+  event_kind: Schema.Literals(['decision', 'fill']),
+  content_hash: Sha256,
+  payload: Schema.Unknown,
+})
+const GateReferenceRow = Schema.Struct({
+  ordinal: NonNegativeInteger,
+  gate_name: Schema.String,
+  passed: Schema.Boolean,
+  actual: Schema.Unknown,
+  required: Schema.Unknown,
+  content_hash: Sha256,
+})
+const StatusReferenceRow = Schema.Struct({ status: Schema.Literals(['WRITING', 'COMPLETE']) })
+
+const messageOf = (cause: unknown): string => (cause instanceof Error ? cause.message : String(cause))
+
+const errorCodeOf = (cause: unknown, depth = 0): string | undefined => {
+  if (depth > 4 || typeof cause !== 'object' || cause === null) return undefined
+  if ('code' in cause && typeof cause.code === 'string') return cause.code
+  return 'cause' in cause ? errorCodeOf(cause.cause, depth + 1) : undefined
+}
+
+const databaseError = (failure: DatabaseFailure, operation: string, message: string, cause?: unknown): DatabaseError =>
+  new DatabaseError({
+    failure,
+    operation,
+    message: cause === undefined ? message : `${message}: ${messageOf(cause)}`,
+    cause,
+  })
+
+const classifyDatabaseError = (operation: string, cause: unknown): DatabaseError => {
+  if (cause instanceof DatabaseError) return cause
+  if (Schema.isSchemaError(cause)) return databaseError('decode', operation, 'database row decoding failed', cause)
+  if (isSqlError(cause)) {
+    const code = errorCodeOf(cause.reason)
+    const failure: DatabaseFailure =
+      cause.reason._tag === 'UniqueViolation' || cause.reason._tag === 'ConstraintError'
+        ? 'constraint'
+        : cause.reason._tag === 'SqlSyntaxError' ||
+            (cause.reason._tag === 'UnknownError' &&
+              code !== undefined &&
+              !code.startsWith('E') &&
+              !code.startsWith('08'))
+          ? 'query'
+          : 'unavailable'
+    return databaseError(failure, operation, 'PostgreSQL operation failed', cause)
+  }
+  return databaseError('invariant', operation, 'unexpected database result', cause)
+}
+
+const runDatabase = <A, E, R>(operation: string, effect: Effect.Effect<A, E, R>): Effect.Effect<A, DatabaseError, R> =>
+  effect.pipe(Effect.mapError((cause) => classifyDatabaseError(operation, cause)))
+
+const ensure = (condition: boolean, operation: string, message: string): Effect.Effect<void, DatabaseError> =>
+  condition ? Effect.void : Effect.fail(databaseError('invariant', operation, message))
+
+const makePersistencePlan = (input: PersistEvaluationInput): PersistencePlan => {
+  const { evaluation, parameters, provenance, reconciliation } = input
+  const strategyName = provenance.strategy.name
+  const protocolHash = canonicalHashV1(parameters)
+  if (protocolHash !== evaluation.protocolHash || protocolHash !== provenance.strategy.parameterHash) {
+    throw new TypeError('evaluation, strategy parameters, and provenance disagree on protocol hash')
+  }
+  if (evaluation.codeRevision !== provenance.sourceRevision) {
+    throw new TypeError('evaluation code revision does not match runtime provenance')
+  }
+  if (reconciliation.runId !== evaluation.runId || reconciliation.exact !== true) {
+    throw new TypeError('reconciliation does not exactly match the evaluation run')
+  }
+  const { hash: snapshotId, ...manifestMaterial } = evaluation.inputManifest
+  if (hashObject(manifestMaterial) !== snapshotId) throw new TypeError('input manifest hash does not match its content')
+  const expectedRunId = canonicalHashV1({
+    schemaVersion: 'bayn.transitional-run-identity.v1',
+    provenance,
+    inputManifestHash: snapshotId,
+  })
+  if (evaluation.runId !== expectedRunId) throw new TypeError('run ID does not match runtime and input provenance')
+
+  const artifacts = [
+    ['strategy', 'bayn.performance-metrics.v1', evaluation.strategy],
+    ['buy-and-hold', 'bayn.performance-metrics.v1', evaluation.buyAndHold],
+    ['direct-volatility-timing', 'bayn.performance-metrics.v1', evaluation.directVolTiming],
+    ['double-cost-strategy', 'bayn.performance-metrics.v1', evaluation.doubleCostStrategy],
+    ['reconciliation', 'bayn.reconciliation.v1', reconciliation],
+  ].map(([name, schemaVersion, payload]) => ({
+    name: name as string,
+    schemaVersion: schemaVersion as string,
+    contentHash: canonicalHashV1(payload),
+    payload,
+  }))
+  const events = evaluation.events.map((event, ordinal) => ({
+    ordinal,
+    id: event.id,
+    kind: event.kind,
+    contentHash: canonicalHashV1(event),
+    payload: event,
+  }))
+  const gates = evaluation.verdict.gates.map((gate, ordinal) => ({
+    ordinal,
+    name: gate.name,
+    passed: gate.passed,
+    actual: gate.actual,
+    required: gate.required,
+    contentHash: canonicalHashV1(gate),
+  }))
+  if (events.length === 0) throw new TypeError('evaluation produced no durable events')
+  if (gates.length === 0) throw new TypeError('evaluation produced no economic gate outcomes')
+
+  return { ...input, strategyName, protocolHash, snapshotId, artifacts, events, gates }
+}
+
+const makeEvidenceStore = Effect.gen(function* () {
+  const sql = yield* PgClient.PgClient
+
+  const health = SqlSchema.findOne({
+    Request: Schema.Void,
+    Result: HealthRow,
+    execute: () => sql`SELECT 1::integer AS value`,
+  })
+  const getProtocol = SqlSchema.findOne({
+    Request: Schema.Struct({ protocolHash: Sha256 }),
+    Result: ProtocolRow,
+    execute: ({ protocolHash }) => sql`SELECT * FROM bayn_protocol_locks WHERE protocol_hash = ${protocolHash}`,
+  })
+  const getSnapshot = SqlSchema.findOne({
+    Request: Schema.Struct({ snapshotId: Sha256 }),
+    Result: SnapshotRow,
+    execute: ({ snapshotId }) => sql`
+      SELECT
+        snapshot_id,
+        schema_version,
+        database_name,
+        table_name,
+        dataset_version,
+        source,
+        source_feed,
+        adjustment,
+        content_hash,
+        row_count::integer AS row_count,
+        manifest
+      FROM bayn_snapshot_references
+      WHERE snapshot_id = ${snapshotId}
+    `,
+  })
+  const insertRun = SqlSchema.findAll({
+    Request: Schema.Struct({
+      runId: Sha256,
+      protocolHash: Sha256,
+      snapshotId: Sha256,
+      evaluationSchemaVersion: Schema.String,
+      sourceRevision: Schema.String,
+      imageRepository: Schema.String,
+      imageDigest: Schema.String,
+      strategyName: Schema.String,
+      initialCapitalMicros: Schema.String,
+      artifactCount: PositiveInteger,
+      eventCount: NonNegativeInteger,
+      gateCount: PositiveInteger,
+    }),
+    Result: InsertedRun,
+    execute: (request) => sql`
+      INSERT INTO bayn_evaluation_runs (
+        run_id,
+        protocol_hash,
+        snapshot_id,
+        evaluation_schema_version,
+        source_revision,
+        image_repository,
+        image_digest,
+        strategy_name,
+        initial_capital_micros,
+        expected_artifact_count,
+        expected_event_count,
+        expected_gate_count,
+        status
+      ) VALUES (
+        ${request.runId},
+        ${request.protocolHash},
+        ${request.snapshotId},
+        ${request.evaluationSchemaVersion},
+        ${request.sourceRevision},
+        ${request.imageRepository},
+        ${request.imageDigest},
+        ${request.strategyName},
+        ${request.initialCapitalMicros},
+        ${request.artifactCount},
+        ${request.eventCount},
+        ${request.gateCount},
+        'WRITING'
+      )
+      ON CONFLICT (run_id) DO NOTHING
+      RETURNING run_id
+    `,
+  })
+  const completeRun = SqlSchema.findAll({
+    Request: RunRequest,
+    Result: InsertedRun,
+    execute: ({ runId }) => sql`
+      UPDATE bayn_evaluation_runs AS run
+      SET status = 'COMPLETE', completed_at = transaction_timestamp()
+      WHERE run.run_id = ${runId}
+        AND run.status = 'WRITING'
+        AND run.expected_artifact_count = (
+          SELECT count(*)::integer FROM bayn_evaluation_artifacts WHERE run_id = ${runId}
+        )
+        AND run.expected_event_count = (
+          SELECT count(*)::integer FROM bayn_evaluation_events WHERE run_id = ${runId}
+        )
+        AND run.expected_gate_count = (
+          SELECT count(*)::integer FROM bayn_gate_outcomes WHERE run_id = ${runId}
+        )
+      RETURNING run.run_id
+    `,
+  })
+  const getReceipt = SqlSchema.findOne({
+    Request: RunRequest,
+    Result: ReceiptRow,
+    execute: ({ runId }) => sql`
+      SELECT
+        run.run_id,
+        run.protocol_hash,
+        run.snapshot_id,
+        run.evaluation_schema_version,
+        run.source_revision,
+        run.image_repository,
+        run.image_digest,
+        run.strategy_name,
+        run.status,
+        run.expected_artifact_count,
+        run.expected_event_count,
+        run.expected_gate_count,
+        (SELECT count(*)::integer FROM bayn_evaluation_artifacts WHERE run_id = run.run_id) AS artifact_count,
+        (SELECT count(*)::integer FROM bayn_evaluation_events WHERE run_id = run.run_id) AS event_count,
+        (SELECT count(*)::integer FROM bayn_gate_outcomes WHERE run_id = run.run_id) AS gate_count
+      FROM bayn_evaluation_runs AS run
+      WHERE run.run_id = ${runId}
+    `,
+  })
+  const getArtifactReferences = SqlSchema.findAll({
+    Request: RunRequest,
+    Result: ArtifactReferenceRow,
+    execute: ({ runId }) => sql`
+      SELECT artifact_name, schema_version, content_hash, payload
+      FROM bayn_evaluation_artifacts
+      WHERE run_id = ${runId}
+      ORDER BY artifact_name
+    `,
+  })
+  const getEventReferences = SqlSchema.findAll({
+    Request: RunRequest,
+    Result: EventReferenceRow,
+    execute: ({ runId }) => sql`
+      SELECT ordinal, event_id, event_kind, content_hash, payload
+      FROM bayn_evaluation_events
+      WHERE run_id = ${runId}
+      ORDER BY ordinal
+    `,
+  })
+  const getGateReferences = SqlSchema.findAll({
+    Request: RunRequest,
+    Result: GateReferenceRow,
+    execute: ({ runId }) => sql`
+      SELECT ordinal, gate_name, passed, actual, required, content_hash
+      FROM bayn_gate_outcomes
+      WHERE run_id = ${runId}
+      ORDER BY ordinal
+    `,
+  })
+  const getStatusReferences = SqlSchema.findAll({
+    Request: RunRequest,
+    Result: StatusReferenceRow,
+    execute: ({ runId }) => sql`
+      SELECT status FROM bayn_status_history WHERE run_id = ${runId} ORDER BY sequence
+    `,
+  })
+
+  const readReceipt = (plan: PersistencePlan, deduplicated: boolean) =>
+    Effect.gen(function* () {
+      const row = yield* getReceipt({ runId: plan.evaluation.runId })
+      yield* ensure(row.protocol_hash === plan.protocolHash, 'read-receipt', 'stored protocol reference diverged')
+      yield* ensure(row.snapshot_id === plan.snapshotId, 'read-receipt', 'stored snapshot reference diverged')
+      yield* ensure(
+        row.evaluation_schema_version === plan.evaluation.schemaVersion &&
+          row.source_revision === plan.provenance.sourceRevision &&
+          row.image_repository === plan.provenance.image.repository &&
+          row.image_digest === plan.provenance.image.digest &&
+          row.strategy_name === plan.strategyName,
+        'read-receipt',
+        'stored run identity diverged from the evaluated runtime',
+      )
+      yield* ensure(
+        row.expected_artifact_count === plan.artifacts.length && row.artifact_count === plan.artifacts.length,
+        'read-receipt',
+        'stored artifact count is incomplete',
+      )
+      yield* ensure(
+        row.expected_event_count === plan.events.length && row.event_count === plan.events.length,
+        'read-receipt',
+        'stored event count is incomplete',
+      )
+      yield* ensure(
+        row.expected_gate_count === plan.gates.length && row.gate_count === plan.gates.length,
+        'read-receipt',
+        'stored gate count is incomplete',
+      )
+      const artifacts = yield* getArtifactReferences({ runId: plan.evaluation.runId })
+      const events = yield* getEventReferences({ runId: plan.evaluation.runId })
+      const gates = yield* getGateReferences({ runId: plan.evaluation.runId })
+      const statuses = yield* getStatusReferences({ runId: plan.evaluation.runId })
+      const expectedArtifacts = [...plan.artifacts].sort((left, right) => left.name.localeCompare(right.name))
+      yield* ensure(
+        artifacts.every((artifact, index) => {
+          const expected = expectedArtifacts[index]
+          return (
+            expected !== undefined &&
+            artifact.artifact_name === expected.name &&
+            artifact.schema_version === expected.schemaVersion &&
+            artifact.content_hash === expected.contentHash &&
+            canonicalHashV1(artifact.payload) === expected.contentHash
+          )
+        }),
+        'read-receipt',
+        'stored artifact content diverged',
+      )
+      yield* ensure(
+        events.every((event, index) => {
+          const expected = plan.events[index]
+          return (
+            expected !== undefined &&
+            event.ordinal === expected.ordinal &&
+            event.event_id === expected.id &&
+            event.event_kind === expected.kind &&
+            event.content_hash === expected.contentHash &&
+            canonicalHashV1(event.payload) === expected.contentHash
+          )
+        }),
+        'read-receipt',
+        'stored event content diverged',
+      )
+      yield* ensure(
+        gates.every((gate, index) => {
+          const expected = plan.gates[index]
+          return (
+            expected !== undefined &&
+            gate.ordinal === expected.ordinal &&
+            gate.gate_name === expected.name &&
+            gate.passed === expected.passed &&
+            gate.content_hash === expected.contentHash &&
+            canonicalHashV1({
+              name: gate.gate_name,
+              passed: gate.passed,
+              actual: gate.actual,
+              required: gate.required,
+            }) === expected.contentHash
+          )
+        }),
+        'read-receipt',
+        'stored gate content diverged',
+      )
+      yield* ensure(
+        statuses.length === 2 && statuses[0].status === 'WRITING' && statuses[1].status === 'COMPLETE',
+        'read-receipt',
+        'stored status history is incomplete',
+      )
+      return {
+        runId: row.run_id,
+        deduplicated,
+        artifactCount: row.artifact_count,
+        eventCount: row.event_count,
+        gateCount: row.gate_count,
+      }
+    })
+
+  const persist = (input: PersistEvaluationInput) =>
+    runDatabase(
+      'persist',
+      Effect.gen(function* () {
+        const plan = yield* Effect.try({
+          try: () => makePersistencePlan(input),
+          catch: (cause) => databaseError('invariant', 'plan', 'invalid evaluation persistence input', cause),
+        })
+
+        return yield* sql.withTransaction(
+          Effect.gen(function* () {
+            yield* sql`
+            INSERT INTO bayn_protocol_locks (
+              protocol_hash,
+              schema_version,
+              strategy_name,
+              behavior_hash,
+              parameter_hash,
+              parameters
+            ) VALUES (
+              ${plan.protocolHash},
+              ${plan.provenance.strategy.parameterSchemaVersion},
+              ${plan.strategyName},
+              ${plan.provenance.strategy.behaviorHash},
+              ${plan.provenance.strategy.parameterHash},
+              ${sql.json(plan.parameters)}
+            )
+            ON CONFLICT (protocol_hash) DO NOTHING
+          `
+            const protocol = yield* getProtocol({ protocolHash: plan.protocolHash })
+            yield* ensure(
+              protocol.schema_version === plan.provenance.strategy.parameterSchemaVersion &&
+                protocol.strategy_name === plan.strategyName &&
+                protocol.behavior_hash === plan.provenance.strategy.behaviorHash &&
+                protocol.parameter_hash === plan.provenance.strategy.parameterHash &&
+                canonicalHashV1(protocol.parameters) === plan.protocolHash,
+              'protocol-lock',
+              'stored protocol lock diverged from the evaluated protocol',
+            )
+
+            const manifest = plan.evaluation.inputManifest
+            yield* sql`
+            INSERT INTO bayn_snapshot_references (
+              snapshot_id,
+              schema_version,
+              database_name,
+              table_name,
+              dataset_version,
+              source,
+              source_feed,
+              adjustment,
+              content_hash,
+              row_count,
+              first_session,
+              last_session,
+              manifest
+            ) VALUES (
+              ${plan.snapshotId},
+              ${manifest.schemaVersion},
+              ${manifest.database},
+              ${manifest.table},
+              ${manifest.datasetVersion},
+              ${manifest.source},
+              ${manifest.sourceFeed},
+              ${manifest.adjustment},
+              ${manifest.contentHash},
+              ${manifest.rowCount},
+              ${manifest.firstSession},
+              ${manifest.lastSession},
+              ${sql.json(manifest)}
+            )
+            ON CONFLICT (snapshot_id) DO NOTHING
+          `
+            const snapshot = yield* getSnapshot({ snapshotId: plan.snapshotId })
+            yield* ensure(
+              snapshot.schema_version === manifest.schemaVersion &&
+                snapshot.database_name === manifest.database &&
+                snapshot.table_name === manifest.table &&
+                snapshot.dataset_version === manifest.datasetVersion &&
+                snapshot.source === manifest.source &&
+                snapshot.source_feed === manifest.sourceFeed &&
+                snapshot.adjustment === manifest.adjustment &&
+                snapshot.content_hash === manifest.contentHash &&
+                snapshot.row_count === manifest.rowCount &&
+                canonicalHashV1(snapshot.manifest) === canonicalHashV1(manifest),
+              'snapshot-reference',
+              'stored snapshot reference diverged from the evaluated input manifest',
+            )
+
+            const inserted = yield* insertRun({
+              runId: plan.evaluation.runId,
+              protocolHash: plan.protocolHash,
+              snapshotId: plan.snapshotId,
+              evaluationSchemaVersion: plan.evaluation.schemaVersion,
+              sourceRevision: plan.provenance.sourceRevision,
+              imageRepository: plan.provenance.image.repository,
+              imageDigest: plan.provenance.image.digest,
+              strategyName: plan.strategyName,
+              initialCapitalMicros: plan.evaluation.initialCapitalMicros,
+              artifactCount: plan.artifacts.length,
+              eventCount: plan.events.length,
+              gateCount: plan.gates.length,
+            })
+            if (inserted.length === 0) return yield* readReceipt(plan, true)
+
+            yield* sql`
+            INSERT INTO bayn_status_history (run_id, status, detail)
+            VALUES (
+              ${plan.evaluation.runId},
+              'WRITING',
+              ${sql.json({
+                artifactCount: plan.artifacts.length,
+                eventCount: plan.events.length,
+                gateCount: plan.gates.length,
+              })}
+            )
+          `
+            yield* Effect.forEach(
+              plan.artifacts,
+              (artifact) => sql`
+              INSERT INTO bayn_evaluation_artifacts (
+                run_id,
+                artifact_name,
+                schema_version,
+                content_hash,
+                payload
+              ) VALUES (
+                ${plan.evaluation.runId},
+                ${artifact.name},
+                ${artifact.schemaVersion},
+                ${artifact.contentHash},
+                ${sql.json(artifact.payload)}
+              )
+            `,
+              { discard: true },
+            )
+            yield* Effect.forEach(
+              plan.events,
+              (event) => sql`
+              INSERT INTO bayn_evaluation_events (
+                run_id,
+                ordinal,
+                event_id,
+                event_kind,
+                content_hash,
+                payload
+              ) VALUES (
+                ${plan.evaluation.runId},
+                ${event.ordinal},
+                ${event.id},
+                ${event.kind},
+                ${event.contentHash},
+                ${sql.json(event.payload)}
+              )
+            `,
+              { discard: true },
+            )
+            yield* Effect.forEach(
+              plan.gates,
+              (gate) => sql`
+              INSERT INTO bayn_gate_outcomes (
+                run_id,
+                ordinal,
+                gate_name,
+                passed,
+                actual,
+                required,
+                content_hash
+              ) VALUES (
+                ${plan.evaluation.runId},
+                ${gate.ordinal},
+                ${gate.name},
+                ${gate.passed},
+                ${sql.json(JSON.stringify(gate.actual))},
+                ${sql.json(JSON.stringify(gate.required))},
+                ${gate.contentHash}
+              )
+            `,
+              { discard: true },
+            )
+            const completed = yield* completeRun({ runId: plan.evaluation.runId })
+            yield* ensure(
+              completed.length === 1,
+              'complete-run',
+              'run could not be completed with exact evidence counts',
+            )
+            yield* sql`
+            INSERT INTO bayn_status_history (run_id, status, detail)
+            VALUES (
+              ${plan.evaluation.runId},
+              'COMPLETE',
+              ${sql.json({ reconciliationExact: true, verdict: plan.evaluation.verdict.status })}
+            )
+          `
+            return yield* readReceipt(plan, false)
+          }),
+        )
+      }),
+    )
+
+  return {
+    check: runDatabase('health', health(undefined).pipe(Effect.asVoid)),
+    persist,
+  } satisfies EvidenceStoreService
+})
+
+export const PostgresClientLive = (config: RuntimeConfig) => {
+  const readCertificate = Effect.gen(function* () {
+    if (!config.postgres.tls) return undefined
+    const fileSystem = yield* FileSystem.FileSystem
+    return yield* fileSystem.readFileString(config.postgres.caPath)
+  })
+  return Layer.unwrap(
+    readCertificate.pipe(
+      Effect.mapError((cause) =>
+        databaseError('unavailable', 'tls', 'failed to read PostgreSQL CA certificate', cause),
+      ),
+      Effect.map((ca) =>
+        PgClient.layerFrom(
+          PgClient.make({
+            url: config.postgres.url,
+            ssl: ca === undefined ? undefined : { ca, rejectUnauthorized: true },
+            applicationName: 'bayn',
+            connectTimeout: config.operationTimeoutMs,
+            idleTimeout: '30 seconds',
+            maxConnections: 2,
+            minConnections: 0,
+            transformJson: false,
+          }).pipe(Effect.mapError((cause) => classifyDatabaseError('connect', cause))),
+        ),
+      ),
+    ),
+  )
+}
+
+const migrations = PgMigrator.run({ loader: migrationLoader, table: 'bayn_schema_migrations' }).pipe(
+  Effect.mapError((cause) =>
+    isSqlError(cause)
+      ? classifyDatabaseError('migrate', cause)
+      : databaseError('migration', 'migrate', 'PostgreSQL migration failed', cause),
+  ),
+  Effect.asVoid,
+)
+
+const MigrationLive = Layer.effectDiscard(migrations)
+const EvidenceStoreLayer = Layer.effect(EvidenceStore, makeEvidenceStore)
+
+export const EvidenceStoreLive = (config: RuntimeConfig) =>
+  Layer.merge(MigrationLive, EvidenceStoreLayer).pipe(Layer.provideMerge(PostgresClientLive(config)))

--- a/services/bayn/src/db/evidence-store.ts
+++ b/services/bayn/src/db/evidence-store.ts
@@ -113,6 +113,7 @@ const ReceiptRow = Schema.Struct({
   image_repository: Schema.String,
   image_digest: ImageDigest,
   strategy_name: Schema.String,
+  initial_capital_micros: Schema.String,
   status: Schema.Literal('COMPLETE'),
   expected_artifact_count: PositiveInteger,
   expected_event_count: NonNegativeInteger,
@@ -142,7 +143,10 @@ const GateReferenceRow = Schema.Struct({
   required: Schema.Unknown,
   content_hash: Sha256,
 })
-const StatusReferenceRow = Schema.Struct({ status: Schema.Literals(['WRITING', 'COMPLETE']) })
+const StatusReferenceRow = Schema.Struct({
+  status: Schema.Literals(['WRITING', 'COMPLETE']),
+  detail: Schema.Unknown,
+})
 
 const messageOf = (cause: unknown): string => (cause instanceof Error ? cause.message : String(cause))
 
@@ -361,6 +365,7 @@ const makeEvidenceStore = Effect.gen(function* () {
         run.image_repository,
         run.image_digest,
         run.strategy_name,
+        run.initial_capital_micros::text AS initial_capital_micros,
         run.status,
         run.expected_artifact_count,
         run.expected_event_count,
@@ -406,7 +411,7 @@ const makeEvidenceStore = Effect.gen(function* () {
     Request: RunRequest,
     Result: StatusReferenceRow,
     execute: ({ runId }) => sql`
-      SELECT status FROM bayn_status_history WHERE run_id = ${runId} ORDER BY sequence
+      SELECT status, detail FROM bayn_status_history WHERE run_id = ${runId} ORDER BY sequence
     `,
   })
 
@@ -420,7 +425,8 @@ const makeEvidenceStore = Effect.gen(function* () {
           row.source_revision === plan.provenance.sourceRevision &&
           row.image_repository === plan.provenance.image.repository &&
           row.image_digest === plan.provenance.image.digest &&
-          row.strategy_name === plan.strategyName,
+          row.strategy_name === plan.strategyName &&
+          row.initial_capital_micros === plan.evaluation.initialCapitalMicros,
         'read-receipt',
         'stored run identity diverged from the evaluated runtime',
       )
@@ -494,9 +500,19 @@ const makeEvidenceStore = Effect.gen(function* () {
         'stored gate content diverged',
       )
       yield* ensure(
-        statuses.length === 2 && statuses[0].status === 'WRITING' && statuses[1].status === 'COMPLETE',
+        statuses.length === 2 &&
+          statuses[0].status === 'WRITING' &&
+          canonicalHashV1(statuses[0].detail) ===
+            canonicalHashV1({
+              artifactCount: plan.artifacts.length,
+              eventCount: plan.events.length,
+              gateCount: plan.gates.length,
+            }) &&
+          statuses[1].status === 'COMPLETE' &&
+          canonicalHashV1(statuses[1].detail) ===
+            canonicalHashV1({ reconciliationExact: true, verdict: plan.evaluation.verdict.status }),
         'read-receipt',
-        'stored status history is incomplete',
+        'stored status history diverged',
       )
       return {
         runId: row.run_id,
@@ -755,6 +771,18 @@ const migrations = PgMigrator.run({ loader: migrationLoader, table: 'bayn_schema
 
 const MigrationLive = Layer.effectDiscard(migrations)
 const EvidenceStoreLayer = Layer.effect(EvidenceStore, makeEvidenceStore)
+const EvidenceStoreDatabaseLayer = Layer.merge(MigrationLive, EvidenceStoreLayer)
 
 export const EvidenceStoreLive = (config: RuntimeConfig) =>
-  Layer.merge(MigrationLive, EvidenceStoreLayer).pipe(Layer.provideMerge(PostgresClientLive(config)))
+  EvidenceStoreDatabaseLayer.pipe(Layer.provideMerge(PostgresClientLive(config)))
+
+export const EvidenceStoreRuntimeLive = (config: RuntimeConfig) =>
+  EvidenceStoreDatabaseLayer.pipe(
+    Layer.provide(PostgresClientLive(config)),
+    Layer.catch((error) =>
+      Layer.succeed(EvidenceStore, {
+        check: Effect.fail(error),
+        persist: () => Effect.fail(error),
+      }),
+    ),
+  )

--- a/services/bayn/src/db/migrations.ts
+++ b/services/bayn/src/db/migrations.ts
@@ -1,0 +1,7 @@
+import { PgMigrator } from '@effect/sql-pg'
+
+import evaluationEvidence from '../../migrations/0001_evaluation_evidence'
+
+export const migrationLoader = PgMigrator.fromRecord({
+  '1_evaluation_evidence': evaluationEvidence,
+})

--- a/services/bayn/src/errors.ts
+++ b/services/bayn/src/errors.ts
@@ -1,6 +1,6 @@
 import { Data } from 'effect'
 
-export type Component = 'config' | 'http' | 'market-data' | 'strategy' | 'journal'
+export type Component = 'config' | 'database' | 'http' | 'market-data' | 'strategy' | 'journal'
 
 export class OperationalError extends Data.TaggedError('OperationalError')<{
   readonly component: Component

--- a/services/bayn/src/index.ts
+++ b/services/bayn/src/index.ts
@@ -1,9 +1,10 @@
-import { NodeRuntime } from '@effect/platform-node'
+import { NodeRuntime, NodeServices } from '@effect/platform-node'
 import { Cause, Effect, Layer, Logger } from 'effect'
 
 import { run } from './app'
 import { loadConfig } from './config'
 import { makeRuntimeProvenance } from './contracts'
+import { EvidenceStoreLive } from './db/evidence-store'
 import { JournalLive } from './ledger'
 import { MarketDataLive } from './market-data'
 import { hashTsmomParameters, loadDefaultProtocol } from './protocol'
@@ -29,6 +30,7 @@ const main = Effect.gen(function* () {
   const dependencies = Layer.mergeAll(
     MarketDataLive(config, strategy.universe),
     JournalLive(config),
+    EvidenceStoreLive(config).pipe(Layer.provide(NodeServices.layer)),
     Layer.succeed(Strategy, strategy),
   )
   return yield* run(config).pipe(Effect.provide(dependencies))

--- a/services/bayn/src/index.ts
+++ b/services/bayn/src/index.ts
@@ -4,7 +4,7 @@ import { Cause, Effect, Layer, Logger } from 'effect'
 import { run } from './app'
 import { loadConfig } from './config'
 import { makeRuntimeProvenance } from './contracts'
-import { EvidenceStoreLive } from './db/evidence-store'
+import { EvidenceStoreRuntimeLive } from './db/evidence-store'
 import { JournalLive } from './ledger'
 import { MarketDataLive } from './market-data'
 import { hashTsmomParameters, loadDefaultProtocol } from './protocol'
@@ -30,7 +30,7 @@ const main = Effect.gen(function* () {
   const dependencies = Layer.mergeAll(
     MarketDataLive(config, strategy.universe),
     JournalLive(config),
-    EvidenceStoreLive(config).pipe(Layer.provide(NodeServices.layer)),
+    EvidenceStoreRuntimeLive(config).pipe(Layer.provide(NodeServices.layer)),
     Layer.succeed(Strategy, strategy),
   )
   return yield* run(config).pipe(Effect.provide(dependencies))

--- a/services/bayn/src/resources.test.ts
+++ b/services/bayn/src/resources.test.ts
@@ -6,6 +6,7 @@ import { createClient as createTigerBeetleClient, type Client } from 'tigerbeetl
 
 import { initialize, type RuntimeState } from './app'
 import type { RuntimeConfig } from './config'
+import { EvidenceStore, type EvidenceStoreService } from './db/evidence-store'
 import { Journal, JournalLive, type JournalService } from './ledger'
 import { MarketData, MarketDataLive, type MarketDataService } from './market-data'
 import { TsmomStrategyLayer } from './strategy-service'
@@ -33,6 +34,11 @@ const config: RuntimeConfig = {
     table: 'adjusted_daily_bars_v1',
     datasetVersion: 'fixture-v1',
   },
+  postgres: {
+    url: Redacted.make('postgresql://bayn:secret@postgres.test:5432/bayn'),
+    tls: false,
+    caPath: '/tmp/test-postgres-ca.crt',
+  },
   tigerBeetle: { clusterId: 2001n, replicaAddresses: ['3000'], ledger: 7001 },
 }
 
@@ -40,6 +46,18 @@ const successfulJournal: JournalService = {
   check: Effect.void,
   journalAndReconcile: (evaluation) =>
     Effect.succeed({ runId: evaluation.runId, accountCount: 1, transferCount: 1, exact: true }),
+}
+
+const successfulEvidenceStore: EvidenceStoreService = {
+  check: Effect.void,
+  persist: ({ evaluation }) =>
+    Effect.succeed({
+      runId: evaluation.runId,
+      deduplicated: false,
+      artifactCount: 5,
+      eventCount: evaluation.events.length,
+      gateCount: evaluation.verdict.gates.length,
+    }),
 }
 
 describe('Bayn resource lifecycle', () => {
@@ -101,6 +119,7 @@ describe('Bayn resource lifecycle', () => {
       Effect.scoped(
         initialize(config, state).pipe(
           Effect.provideService(Journal, successfulJournal),
+          Effect.provideService(EvidenceStore, successfulEvidenceStore),
           Effect.provide(TsmomStrategyLayer(fixtureProtocol, provenance)),
           Effect.provide(
             MarketDataLive(config, fixtureProtocol.universe, {
@@ -131,6 +150,7 @@ describe('Bayn resource lifecycle', () => {
       Effect.scoped(
         initialize(config, state).pipe(
           Effect.provideService(Journal, successfulJournal),
+          Effect.provideService(EvidenceStore, successfulEvidenceStore),
           Effect.provide(TsmomStrategyLayer(fixtureProtocol, provenance)),
           Effect.provide(
             MarketDataLive(config, fixtureProtocol.universe, {
@@ -169,6 +189,7 @@ describe('Bayn resource lifecycle', () => {
       Effect.scoped(
         initialize(config, state).pipe(
           Effect.provideService(MarketData, marketData),
+          Effect.provideService(EvidenceStore, successfulEvidenceStore),
           Effect.provide(TsmomStrategyLayer(fixtureProtocol, provenance)),
           Effect.provide(
             JournalLive(config, {

--- a/services/bayn/src/strategy-service.ts
+++ b/services/bayn/src/strategy-service.ts
@@ -7,6 +7,7 @@ import type { DailyBar, EvaluationResult, InputManifest, TsmomProtocol } from '.
 export interface StrategyService {
   readonly name: string
   readonly universe: readonly string[]
+  readonly parameters: unknown
   readonly provenance: RuntimeProvenance
   readonly evaluate: (bars: readonly DailyBar[], manifest: InputManifest) => EvaluationResult
 }
@@ -16,6 +17,7 @@ export class Strategy extends Context.Service<Strategy, StrategyService>()('bayn
 export const makeTsmomStrategy = (protocol: TsmomProtocol, provenance: RuntimeProvenance): StrategyService => ({
   name: 'tsmom',
   universe: protocol.universe,
+  parameters: protocol,
   provenance,
   evaluate: (bars, manifest) => evaluateTsmom(bars, manifest, protocol, provenance),
 })

--- a/services/bayn/tsconfig.json
+++ b/services/bayn/tsconfig.json
@@ -5,5 +5,5 @@
     "strict": true,
     "types": ["bun", "node"]
   },
-  "include": ["src"]
+  "include": ["src", "migrations"]
 }


### PR DESCRIPTION
## Summary

- Add a Bayn-owned Effect SQL PostgreSQL store and additive migration for immutable protocol, snapshot, run, artifact, event, gate, reconciliation, and status evidence.
- Keep readiness closed until exact TigerBeetle reconciliation is committed atomically; exact replay revalidates every stored payload, status detail, initial-capital value, and content hash.
- Recover typed CA, PostgreSQL connection, and migration setup failures into the fail-closed runtime state so liveness remains available while readiness stays closed.
- Connect the deployment to its CNPG application credential over verified TLS and add a real PostgreSQL 18 integration gate.

## Related Issues

PROOMPT-359

## Testing

- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:55432/bayn_test bun run --cwd services/bayn test` (57 passed)
- `bun run --cwd services/bayn tsc`
- `bun run --cwd services/bayn lint:oxlint`
- `bun run --cwd services/bayn lint:oxlint:type`
- `bun run --cwd services/bayn build`
- `bun test packages/scripts/src/bayn` (2 passed)
- `bunx oxfmt --check services/bayn argocd/applications/bayn argocd/applications/torghut/clickhouse/bayn-sealed-secret.yaml argocd/applications/torghut/clickhouse/clickhouse-cluster.yaml`
- `kustomize build --enable-helm argocd/applications/bayn`
- `kustomize build --enable-helm argocd/applications/torghut`
- `nix-instantiate --parse nix/images/bayn.nix`
- `nix-instantiate --parse nix/images/signal-publisher.nix`

## Breaking Changes

The Bayn runtime now requires `BAYN_POSTGRES_URL` and the CNPG CA certificate and runs an additive startup migration. Readiness depends on a successful durable evidence commit. No broker, order, or capital authority is introduced.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes are documented.
- [x] Runtime and architecture documentation are updated; rollout evidence remains tracked in PROOMPT-359.