### PR TITLE
fix(signal): suspend broken publisher

### DIFF
--- a/argocd/applications/torghut/clickhouse/signal-publisher-cronjob.yaml
+++ b/argocd/applications/torghut/clickhouse/signal-publisher-cronjob.yaml
@@ -13,7 +13,7 @@ spec:
   timeZone: America/New_York
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 3600
-  suspend: false
+  suspend: true
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   jobTemplate:


### PR DESCRIPTION
## Summary

- suspend the Signal adjusted-daily CronJob after the first bounded production Job failed during Node bundle startup
- preserve the immutable promoted image and provenance for diagnosis and a later fixed-image promotion
- keep the existing no-broker/no-capital authority boundary unchanged

## Related Issues

PROOMPT-357

## Testing

- `bun test packages/scripts/src/signal/gitops-contract.test.ts` (4 passed)
- `kustomize build --enable-helm argocd/applications/torghut`
- Production Job `signal-publisher-manual-20260720t174744z` failed before publication with `exports_Undici is not defined`; both ClickHouse replicas retained zero manifest rows.

## Breaking Changes

The publisher schedule is fail-closed until a corrected immutable image is promoted. No other Torghut workload is changed.

## Checklist

- [x] Testing section documents exact validation and production evidence.
- [x] Screenshots are not applicable; Breaking Changes are documented.
- [x] The runtime defect and follow-up remain tracked in PROOMPT-357.
