### PR TITLE
fix(signal): use Node HTTP runtime

### DIFF
--- a/nix/images/signal-publisher.nix
+++ b/nix/images/signal-publisher.nix
@@ -34,6 +34,13 @@ import ./bun-workspace-service.nix {
       + buildDefine "__SIGNAL_PUBLISHER_BUILD_IMAGE_REPOSITORY__" imageRepository
     )
     "grep -F -- ${lib.escapeShellArg repoRevision} services/signal-publisher/dist/main.js"
+    (
+      "bun services/signal-publisher/src/runtime-smoke.ts "
+      + "services/signal-publisher/dist/main.js "
+      + lib.escapeShellArg repoRevision
+      + " "
+      + lib.escapeShellArg imageRepository
+    )
   ];
   runtimeInstallPhase = ''
     mkdir -p "$out/app/services/signal-publisher/dist"

--- a/services/signal-publisher/src/main.ts
+++ b/services/signal-publisher/src/main.ts
@@ -29,7 +29,7 @@ const run = Effect.gen(function* () {
     const repository = yield* makeSnapshotRepository
     return yield* publish(config, args, repository)
   }).pipe(
-    Effect.provide([database, NodeHttpClient.layerUndici]),
+    Effect.provide([database, NodeHttpClient.layerNodeHttp]),
     Effect.mapError((cause) =>
       cause._tag === 'PublicationError'
         ? cause

--- a/services/signal-publisher/src/runtime-smoke.ts
+++ b/services/signal-publisher/src/runtime-smoke.ts
@@ -1,0 +1,44 @@
+import { spawnSync } from 'node:child_process'
+import process from 'node:process'
+
+const [entrypoint, sourceRevision, imageRepository] = process.argv.slice(2)
+
+if (!entrypoint || !sourceRevision || !imageRepository) {
+  throw new Error('usage: runtime-smoke ENTRYPOINT SOURCE_REVISION IMAGE_REPOSITORY')
+}
+
+const result = spawnSync('node', [entrypoint, 'daily'], {
+  encoding: 'utf8',
+  timeout: 10_000,
+  env: {
+    ...process.env,
+    SIGNAL_CLICKHOUSE_URL: 'http://127.0.0.1:1',
+    SIGNAL_CLICKHOUSE_USERNAME: 'runtime-smoke',
+    SIGNAL_CLICKHOUSE_PASSWORD: 'runtime-smoke',
+    SIGNAL_ALPACA_DATA_URL: 'http://127.0.0.1:1',
+    SIGNAL_ALPACA_TRADING_URL: 'http://127.0.0.1:1',
+    APCA_API_KEY_ID: 'runtime-smoke',
+    APCA_API_SECRET_KEY: 'runtime-smoke',
+    SIGNAL_SYMBOLS: 'SPY',
+    SIGNAL_START_DATE: '2026-07-17',
+    SIGNAL_CODE_REVISION: sourceRevision,
+    SIGNAL_IMAGE_REPOSITORY: imageRepository,
+    SIGNAL_IMAGE_DIGEST: `sha256:${'a'.repeat(64)}`,
+    SIGNAL_OPERATION_TIMEOUT_MS: '1000',
+  },
+})
+
+if (result.error) throw result.error
+
+const output = `${result.stdout}${result.stderr}`
+if (
+  result.status !== 1 ||
+  !output.includes('ECONNREFUSED') ||
+  !output.includes('"event":"publication_failed"') ||
+  !output.includes('"phase":"storage"')
+) {
+  throw new Error(`bundled publisher did not reach the expected closed local endpoint:\n${output}`)
+}
+if (output.includes('exports_Undici is not defined')) {
+  throw new Error(`bundled publisher loaded a broken Undici runtime:\n${output}`)
+}


### PR DESCRIPTION
## Summary

- replace the bundled Undici Effect HTTP layer with the official scoped `node:http` layer
- add a built-artifact smoke that boots the exact Node bundle through client initialization and asserts the expected typed storage failure
- run that smoke inside each Nix image build so an image cannot publish with this runtime regression

## Related Issues

PROOMPT-357

## Testing

- `bun run --cwd services/signal-publisher tsc`
- `bun run --cwd services/signal-publisher test` (18 passed)
- `bun run --cwd services/signal-publisher lint:oxlint`
- `bun run --cwd services/signal-publisher lint:oxlint:type`
- `bunx oxfmt --check services/signal-publisher/src/main.ts services/signal-publisher/src/runtime-smoke.ts nix/images/signal-publisher.nix`
- `nix-instantiate --parse nix/images/signal-publisher.nix`
- production-metadata `bun build` followed by `bun services/signal-publisher/src/runtime-smoke.ts services/signal-publisher/dist/main.js f2a38b4d8a9bdd8ac3e4f1ebcd06a3f01acef3d1 registry.ide-newton.ts.net/lab/signal-publisher`
- before the fix, the same bundled artifact reproduced `exports_Undici is not defined`; after the fix it exits only with the expected typed ClickHouse `ECONNREFUSED` storage failure

## Breaking Changes

None. The publisher remains GitOps-suspended until a fixed immutable image is built and promoted.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.