### PR TITLE
chore(signal): promote publisher sha-ad796a1b66c3cf92fea060ceb3750570831ac80b

### DIFF
--- a/argocd/applications/torghut/clickhouse/kustomization.yaml
+++ b/argocd/applications/torghut/clickhouse/kustomization.yaml
@@ -17,5 +17,5 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/signal-publisher
     newName: registry.ide-newton.ts.net/lab/signal-publisher
-    newTag: "sha-ed782f302385ee143f46490ce69159bf70ece547"
-    digest: sha256:4c02c9cd33a04da68b4d1b62cc222f4d037dc3fbb8c4cb32d78bbade23673d55
+    newTag: "sha-ad796a1b66c3cf92fea060ceb3750570831ac80b"
+    digest: sha256:7f848d36e34c5cb2c9a74053db29bab65a5e3c9ec19e5ce997c72955b0fc01c6

--- a/argocd/applications/torghut/clickhouse/signal-publisher-cronjob.yaml
+++ b/argocd/applications/torghut/clickhouse/signal-publisher-cronjob.yaml
@@ -13,7 +13,7 @@ spec:
   timeZone: America/New_York
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 3600
-  suspend: true
+  suspend: false
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   jobTemplate:
@@ -47,11 +47,11 @@ spec:
                 - daily
               env:
                 - name: SIGNAL_CODE_REVISION
-                  value: "ed782f302385ee143f46490ce69159bf70ece547"
+                  value: "ad796a1b66c3cf92fea060ceb3750570831ac80b"
                 - name: SIGNAL_IMAGE_REPOSITORY
                   value: registry.ide-newton.ts.net/lab/signal-publisher
                 - name: SIGNAL_IMAGE_DIGEST
-                  value: sha256:4c02c9cd33a04da68b4d1b62cc222f4d037dc3fbb8c4cb32d78bbade23673d55
+                  value: sha256:7f848d36e34c5cb2c9a74053db29bab65a5e3c9ec19e5ce997c72955b0fc01c6
                 - name: SIGNAL_CLICKHOUSE_URL
                   value: http://torghut-clickhouse.torghut.svc.cluster.local:8123
                 - name: SIGNAL_CLICKHOUSE_USERNAME


### PR DESCRIPTION
## Summary

Promote the immutable Signal adjusted-daily publisher image and activate its GitOps CronJob.

- Source commit: `ad796a1b66c3cf92fea060ceb3750570831ac80b`
- Image tag: `sha-ad796a1b66c3cf92fea060ceb3750570831ac80b`
- Image digest: `sha256:7f848d36e34c5cb2c9a74053db29bab65a5e3c9ec19e5ce997c72955b0fc01c6`

## Related Issues

PROOMPT-357

## Testing

- OCI index contains `linux/amd64` and `linux/arm64`.

## Screenshots (if applicable)

N/A

## Breaking Changes

Adds a bounded, idempotent daily publisher. It has no broker or capital authority.

## Checklist

- [x] Testing section documents exact validation.
- [x] Runtime source revision and image digest are immutable.
- [x] No broker or capital-promotion authority is introduced.