### PR TITLE
fix(signal): suspend quorum-blocked publisher

### DIFF
--- a/argocd/applications/torghut/clickhouse/signal-publisher-cronjob.yaml
+++ b/argocd/applications/torghut/clickhouse/signal-publisher-cronjob.yaml
@@ -13,7 +13,7 @@ spec:
   timeZone: America/New_York
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 3600
-  suspend: false
+  suspend: true
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   jobTemplate:


### PR DESCRIPTION
## Summary

- suspend the production Signal publisher after its bounded activation exposed a ClickHouse quorum timeout
- preserve the immutable fixed image and provenance while preventing scheduled retries
- keep the partial staged snapshot unfinalized; no manifest exists and Bayn cannot consume it

## Related Issues

PROOMPT-357

## Testing

- `bun test packages/scripts/src/signal` (4 passed)
- `kustomize build --enable-helm argocd/applications/torghut`
- bounded Job `signal-publisher-manual-20260720t181122z` (UID `b11ff983-35b3-484e-8252-a116394ddf9a`) reproduced the quorum failure and was deleted after `BackoffLimitExceeded`
- both ClickHouse replicas show 18,096 staged bars, 0 sessions, and 0 manifests for snapshot `e6ff31d2b08ec246876c4b45937838f0e3b4f5167c682afd6c2f10c46acaab20`

## Breaking Changes

None. Publication remains fail-closed until the bounded write protocol is fixed and re-proven.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.