### PR TITLE
fix(signal): bound quorum inserts

### DIFF
--- a/argocd/applications/torghut/clickhouse/signal-publisher-cronjob.yaml
+++ b/argocd/applications/torghut/clickhouse/signal-publisher-cronjob.yaml
@@ -18,7 +18,7 @@ spec:
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
-      backoffLimit: 2
+      backoffLimit: 3
       activeDeadlineSeconds: 900
       ttlSecondsAfterFinished: 86400
       template:

--- a/services/signal-publisher/src/repository.test.ts
+++ b/services/signal-publisher/src/repository.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from 'bun:test'
 import { readFileSync } from 'node:fs'
 
+import { insertBatchSize, partitionInsertRows } from './repository'
+
 describe('ClickHouse readback contract', () => {
   test('preserves the Decimal64 scale used by snapshot content hashes', () => {
     const source = readFileSync(import.meta.dir + '/repository.ts', 'utf8')
@@ -10,5 +12,14 @@ describe('ClickHouse readback contract', () => {
     }
     expect(source).toContain('toDecimalString(vwap, 8)')
     expect(source).not.toMatch(/toString\(adjusted_(?:open|high|low|close|volume)\)/)
+  })
+
+  test('bounds quorum inserts without dropping or reordering rows', () => {
+    const rows = Array.from({ length: insertBatchSize * 2 + 17 }, (_, index) => index)
+    const batches = partitionInsertRows(rows)
+
+    expect(batches.map((batch) => batch.length)).toEqual([insertBatchSize, insertBatchSize, 17])
+    expect(batches.flat()).toEqual(rows)
+    expect(partitionInsertRows([])).toEqual([])
   })
 })

--- a/services/signal-publisher/src/repository.ts
+++ b/services/signal-publisher/src/repository.ts
@@ -98,6 +98,16 @@ const asCount = (value: string | number, name: string): number => {
 const storage = <A>(message: string) =>
   Effect.mapError<A, PublicationError>((cause: A) => publicationError('storage', message, cause))
 
+export const insertBatchSize = 5_000
+
+export const partitionInsertRows = <A>(rows: readonly A[]): readonly (readonly A[])[] => {
+  const batches: A[][] = []
+  for (let offset = 0; offset < rows.length; offset += insertBatchSize) {
+    batches.push(rows.slice(offset, offset + insertBatchSize))
+  }
+  return batches
+}
+
 const decodeReadback = <A>(name: string, parse: () => A): Effect.Effect<A, PublicationError> =>
   Effect.try({ try: parse, catch: (cause) => publicationError('storage', `invalid ${name} readback`, cause) })
 
@@ -193,19 +203,22 @@ export const makeSnapshotRepository: Effect.Effect<SnapshotRepository, never, Cl
       )
 
     const insert = <A>(table: string, snapshotId: string, kind: string, values: readonly A[]) =>
-      values.length === 0
-        ? Effect.void
-        : sql.insertQuery({ table, values: [...values], format: 'JSONEachRow' }).pipe(
-            sql.withQueryId(`signal-${kind}-${snapshotId.slice(-32)}`),
+      Effect.forEach(
+        partitionInsertRows(values),
+        (batch, index) =>
+          sql.insertQuery({ table, values: [...batch], format: 'JSONEachRow' }).pipe(
+            sql.withQueryId(`signal-${kind}-${snapshotId.slice(-32)}-${index}`),
             sql.withClickhouseSettings({
               insert_deduplicate: 1,
-              insert_deduplication_token: `${kind}-${snapshotId}-${createHash('sha256')
-                .update(JSON.stringify(values))
+              insert_deduplication_token: `${kind}-${snapshotId}-${index}-${createHash('sha256')
+                .update(JSON.stringify(batch))
                 .digest('hex')}`,
             }),
-            storage(`failed to insert ${kind}`),
+            storage(`failed to insert ${kind} batch ${index + 1}`),
             Effect.asVoid,
-          )
+          ),
+        { concurrency: 1, discard: true },
+      )
 
     return {
       loadBars,


### PR DESCRIPTION
## Summary

- Split synchronous ClickHouse quorum inserts into ordered 5,000-row batches after the 19,176-row production write exceeded the configured 60-second quorum timeout.
- Give every batch a deterministic query ID and content-derived deduplication token so Kubernetes retries can safely resume the append-only snapshot.
- Allow one additional Job retry while keeping the publisher suspended until the fixed immutable image is promoted and verified live.

## Related Issues

PROOMPT-357

## Testing

- `bun run --cwd services/signal-publisher tsc`
- `bun run --cwd services/signal-publisher test` (19 passed)
- `bun run --cwd services/signal-publisher lint:oxlint`
- `bun run --cwd services/signal-publisher lint:oxlint:type`
- `bunx oxfmt --check services/signal-publisher/src/repository.ts services/signal-publisher/src/repository.test.ts argocd/applications/torghut/clickhouse/signal-publisher-cronjob.yaml`
- `bun test packages/scripts/src/signal` (4 passed)
- `kustomize build --enable-helm argocd/applications/torghut`
- `nix-instantiate --parse nix/images/signal-publisher.nix`
- Built the production-metadata Node bundle and passed the built-artifact runtime smoke test.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.