### PR TITLE
chore(signal): promote publisher sha-948a8bb8f4a635ca7612319ca950e3b9b5930eba

### DIFF
--- a/argocd/applications/torghut/clickhouse/kustomization.yaml
+++ b/argocd/applications/torghut/clickhouse/kustomization.yaml
@@ -17,5 +17,5 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/signal-publisher
     newName: registry.ide-newton.ts.net/lab/signal-publisher
-    newTag: "sha-01ac72aafca390609885c2093236f4a10dd14a32"
-    digest: sha256:8f573122837bdc97ee90c3054b266606fcb2a269ea4edee0ff1e81bb641bebda
+    newTag: "sha-948a8bb8f4a635ca7612319ca950e3b9b5930eba"
+    digest: sha256:3e9b6acf05c02735fe07744899cf38392f4ea91bc67cf993d2fc931f8e487f53

--- a/argocd/applications/torghut/clickhouse/signal-publisher-cronjob.yaml
+++ b/argocd/applications/torghut/clickhouse/signal-publisher-cronjob.yaml
@@ -47,11 +47,11 @@ spec:
                 - daily
               env:
                 - name: SIGNAL_CODE_REVISION
-                  value: "01ac72aafca390609885c2093236f4a10dd14a32"
+                  value: "948a8bb8f4a635ca7612319ca950e3b9b5930eba"
                 - name: SIGNAL_IMAGE_REPOSITORY
                   value: registry.ide-newton.ts.net/lab/signal-publisher
                 - name: SIGNAL_IMAGE_DIGEST
-                  value: sha256:8f573122837bdc97ee90c3054b266606fcb2a269ea4edee0ff1e81bb641bebda
+                  value: sha256:3e9b6acf05c02735fe07744899cf38392f4ea91bc67cf993d2fc931f8e487f53
                 - name: SIGNAL_CLICKHOUSE_URL
                   value: http://torghut-clickhouse.torghut.svc.cluster.local:8123
                 - name: SIGNAL_CLICKHOUSE_USERNAME


### PR DESCRIPTION
## Summary

Promote the immutable Signal adjusted-daily publisher image and activate its GitOps CronJob.

- Source commit: `948a8bb8f4a635ca7612319ca950e3b9b5930eba`
- Image tag: `sha-948a8bb8f4a635ca7612319ca950e3b9b5930eba`
- Image digest: `sha256:3e9b6acf05c02735fe07744899cf38392f4ea91bc67cf993d2fc931f8e487f53`

## Related Issues

PROOMPT-357

## Testing

- OCI index contains `linux/amd64` and `linux/arm64`.

## Screenshots (if applicable)

N/A

## Breaking Changes

Adds a bounded, idempotent daily publisher. It has no broker or capital authority.

## Checklist

- [x] Testing section documents exact validation.
- [x] Runtime source revision and image digest are immutable.
- [x] No broker or capital-promotion authority is introduced.