### PR TITLE
chore(bayn): promote image sha-948a8bb8f4a635ca7612319ca950e3b9b5930eba

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: bayn
         app.kubernetes.io/part-of: bayn
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-20T09:26:27Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-20T18:56:39Z"
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
@@ -47,11 +47,11 @@ spec:
               protocol: TCP
           env:
             - name: BAYN_CODE_REVISION
-              value: 2ffb7c4966dd1cb05011143a46fecc871366224d
+              value: 948a8bb8f4a635ca7612319ca950e3b9b5930eba
             - name: BAYN_IMAGE_REPOSITORY
               value: registry.ide-newton.ts.net/lab/bayn
             - name: BAYN_IMAGE_DIGEST
-              value: sha256:ab5127d50acb3f13bd30e27f1f4b7ee047b0c113dddfb12c8b2fee3ce16c8cce
+              value: sha256:418840c185016cdee2ef74029c8a243924d30d7188bbc717d06d08a77c9ecb79
             - name: BAYN_RUN_ON_STARTUP
               value: "true"
             - name: BAYN_OPERATION_TIMEOUT_MS

--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -16,5 +16,5 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/bayn
     newName: registry.ide-newton.ts.net/lab/bayn
-    newTag: "sha-2ffb7c4966dd1cb05011143a46fecc871366224d"
-    digest: sha256:ab5127d50acb3f13bd30e27f1f4b7ee047b0c113dddfb12c8b2fee3ce16c8cce
+    newTag: "sha-948a8bb8f4a635ca7612319ca950e3b9b5930eba"
+    digest: sha256:418840c185016cdee2ef74029c8a243924d30d7188bbc717d06d08a77c9ecb79


### PR DESCRIPTION
## Summary

Promote the immutable Bayn durable-evidence runtime through GitOps.

- Source commit: `948a8bb8f4a635ca7612319ca950e3b9b5930eba`
- Image tag: `sha-948a8bb8f4a635ca7612319ca950e3b9b5930eba`
- Image digest: `sha256:418840c185016cdee2ef74029c8a243924d30d7188bbc717d06d08a77c9ecb79`
- Runtime authority remains observe-only: broker orders and capital promotion are disabled.

## Related Issues

PROOMPT-359

## Testing

- Source PR validation: 57 Bayn tests, including 11 PostgreSQL 18 integration tests.
- OCI index contains `linux/amd64` and `linux/arm64`.
- Promotion PR re-runs Bayn, PostgreSQL integration, Argo, and Kubernetes validation.
- Post-merge acceptance requires Argo rollout, CNPG durable readback, and restart/deduplication proof.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents exact validation.
- [x] Runtime source revision and image digest are immutable.
- [x] No broker or capital-promotion authority is introduced.
