### PR TITLE
chore(product): promote nix product images

### DIFF
--- a/argocd/applications/app/kustomization.yaml
+++ b/argocd/applications/app/kustomization.yaml
@@ -8,5 +8,5 @@ resources:
   - secret.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/app
-    digest: sha256:d0644f712be33f370aeb1403a3254fd825a70231c132de41f373013046ff9f9e
+    digest: sha256:9396212ca4ea6127b66a226820d26ee2aedb0e5b0a03df172495390c17b94e7b
     newName: registry.ide-newton.ts.net/lab/app

--- a/argocd/applications/docs/kustomization.yaml
+++ b/argocd/applications/docs/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
   - generated
 images:
   - name: registry.ide-newton.ts.net/lab/docs
-    digest: sha256:1bf2e70c49012b4f60a6404aca12a52254559d700224fa3f574ea0a268f23cf1
+    digest: sha256:0dcaf9b4fe648af7d286dccc76a8e9e7b5830da5408a5351840d2e6281cd0134
     newName: registry.ide-newton.ts.net/lab/docs

--- a/argocd/applications/proompteng/kustomization.yaml
+++ b/argocd/applications/proompteng/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
 - ingressroute.yaml
 images:
 - name: registry.ide-newton.ts.net/lab/proompteng
-  digest: sha256:045022216ed4a287aba38759cae98ccb15aab511c7a98daf128757d39643c089
+  digest: sha256:26d739e9085c7dd343f4c777db25db07e4a9d839cad4a4963a99364e14118ff9
   newName: registry.ide-newton.ts.net/lab/proompteng

--- a/argocd/applications/synthesis/kustomization.yaml
+++ b/argocd/applications/synthesis/kustomization.yaml
@@ -11,5 +11,5 @@ resources:
   - agents-domain
 images:
   - name: registry.ide-newton.ts.net/lab/synthesis
-    digest: sha256:613a3b43ae618c383ac3bcc752db6691fae9798b9aa22207a4e1a7af7fdade07
+    digest: sha256:17dcc016f8f23749f6b5a27ee55e0b92aaeeca913d108bcd692d79556616ce62
     newName: registry.ide-newton.ts.net/lab/synthesis


### PR DESCRIPTION
## Summary

- Promote enabled product app image digests built by the shared Nix OCI workflow.
- `app`: `registry.ide-newton.ts.net/lab/app@sha256:9396212ca4ea6127b66a226820d26ee2aedb0e5b0a03df172495390c17b94e7b` from `948a8bb8f4a635ca7612319ca950e3b9b5930eba`
- `docs`: `registry.ide-newton.ts.net/lab/docs@sha256:0dcaf9b4fe648af7d286dccc76a8e9e7b5830da5408a5351840d2e6281cd0134` from `948a8bb8f4a635ca7612319ca950e3b9b5930eba`
- `proompteng`: `registry.ide-newton.ts.net/lab/proompteng@sha256:26d739e9085c7dd343f4c777db25db07e4a9d839cad4a4963a99364e14118ff9` from `948a8bb8f4a635ca7612319ca950e3b9b5930eba`
- `synthesis`: `registry.ide-newton.ts.net/lab/synthesis@sha256:17dcc016f8f23749f6b5a27ee55e0b92aaeeca913d108bcd692d79556616ce62` from `948a8bb8f4a635ca7612319ca950e3b9b5930eba`

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- <image>@<digest> linux/amd64 linux/arm64` for each promoted image.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.