### PR TITLE
chore(signal): promote publisher sha-0551276e132e06efb30c92bd860b5a6fb8f0e26f

### DIFF
--- a/argocd/applications/torghut/clickhouse/kustomization.yaml
+++ b/argocd/applications/torghut/clickhouse/kustomization.yaml
@@ -17,5 +17,5 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/signal-publisher
     newName: registry.ide-newton.ts.net/lab/signal-publisher
-    newTag: "sha-01ac72aafca390609885c2093236f4a10dd14a32"
-    digest: sha256:8f573122837bdc97ee90c3054b266606fcb2a269ea4edee0ff1e81bb641bebda
+    newTag: "sha-0551276e132e06efb30c92bd860b5a6fb8f0e26f"
+    digest: sha256:77a8615b2623cb1895cf13d9d0c63b570ee79999280688ad3d9a181a1e10562b

--- a/argocd/applications/torghut/clickhouse/signal-publisher-cronjob.yaml
+++ b/argocd/applications/torghut/clickhouse/signal-publisher-cronjob.yaml
@@ -47,11 +47,11 @@ spec:
                 - daily
               env:
                 - name: SIGNAL_CODE_REVISION
-                  value: "01ac72aafca390609885c2093236f4a10dd14a32"
+                  value: "0551276e132e06efb30c92bd860b5a6fb8f0e26f"
                 - name: SIGNAL_IMAGE_REPOSITORY
                   value: registry.ide-newton.ts.net/lab/signal-publisher
                 - name: SIGNAL_IMAGE_DIGEST
-                  value: sha256:8f573122837bdc97ee90c3054b266606fcb2a269ea4edee0ff1e81bb641bebda
+                  value: sha256:77a8615b2623cb1895cf13d9d0c63b570ee79999280688ad3d9a181a1e10562b
                 - name: SIGNAL_CLICKHOUSE_URL
                   value: http://torghut-clickhouse.torghut.svc.cluster.local:8123
                 - name: SIGNAL_CLICKHOUSE_USERNAME


### PR DESCRIPTION
## Summary

Promote the immutable Signal adjusted-daily publisher image and activate its GitOps CronJob.

- Source commit: `0551276e132e06efb30c92bd860b5a6fb8f0e26f`
- Image tag: `sha-0551276e132e06efb30c92bd860b5a6fb8f0e26f`
- Image digest: `sha256:77a8615b2623cb1895cf13d9d0c63b570ee79999280688ad3d9a181a1e10562b`

## Related Issues

PROOMPT-357

## Testing

- OCI index contains `linux/amd64` and `linux/arm64`.

## Screenshots (if applicable)

N/A

## Breaking Changes

Adds a bounded, idempotent daily publisher. It has no broker or capital authority.

## Checklist

- [x] Testing section documents exact validation.
- [x] Runtime source revision and image digest are immutable.
- [x] No broker or capital-promotion authority is introduced.