### PR TITLE
chore(bayn): promote image sha-0551276e132e06efb30c92bd860b5a6fb8f0e26f

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -68,13 +68,6 @@ spec:
                 secretKeyRef:
                   name: bayn-clickhouse-auth
                   key: password
-            # Remove these legacy values atomically with the bounded-reader image promotion.
-            - name: BAYN_CLICKHOUSE_DATABASE
-              value: signal
-            - name: BAYN_CLICKHOUSE_TABLE
-              value: adjusted_daily_bars_v1
-            - name: BAYN_DATASET_VERSION
-              value: alpaca-all-iex-2017-01-01-2026-07-18-v1
             - name: BAYN_SIGNAL_SNAPSHOT_ID
               value: e6ff31d2b08ec246876c4b45937838f0e3b4f5167c682afd6c2f10c46acaab20
             - name: BAYN_SIGNAL_PUBLICATION_ASOF

--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: bayn
         app.kubernetes.io/part-of: bayn
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-20T18:56:39Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-20T19:53:03Z"
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
@@ -47,11 +47,11 @@ spec:
               protocol: TCP
           env:
             - name: BAYN_CODE_REVISION
-              value: 948a8bb8f4a635ca7612319ca950e3b9b5930eba
+              value: 0551276e132e06efb30c92bd860b5a6fb8f0e26f
             - name: BAYN_IMAGE_REPOSITORY
               value: registry.ide-newton.ts.net/lab/bayn
             - name: BAYN_IMAGE_DIGEST
-              value: sha256:418840c185016cdee2ef74029c8a243924d30d7188bbc717d06d08a77c9ecb79
+              value: sha256:397bfe247806a823541842241dc157f3b4f33d868e31c4f39cc7e2df1665c750
             - name: BAYN_RUN_ON_STARTUP
               value: "true"
             - name: BAYN_OPERATION_TIMEOUT_MS

--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -16,5 +16,5 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/bayn
     newName: registry.ide-newton.ts.net/lab/bayn
-    newTag: "sha-948a8bb8f4a635ca7612319ca950e3b9b5930eba"
-    digest: sha256:418840c185016cdee2ef74029c8a243924d30d7188bbc717d06d08a77c9ecb79
+    newTag: "sha-0551276e132e06efb30c92bd860b5a6fb8f0e26f"
+    digest: sha256:397bfe247806a823541842241dc157f3b4f33d868e31c4f39cc7e2df1665c750


### PR DESCRIPTION
## Summary

Promote the immutable Bayn bounded-snapshot reader and bind runtime evidence to its source and image identity.

- Source commit: `0551276e132e06efb30c92bd860b5a6fb8f0e26f`
- Image tag: `sha-0551276e132e06efb30c92bd860b5a6fb8f0e26f`
- Image digest: `sha256:397bfe247806a823541842241dc157f3b4f33d868e31c4f39cc7e2df1665c750`
- Remove the three legacy v1 reader variables atomically with the compatible image promotion.

## Related Issues

PROOMPT-360

## Testing

- The release contract binds the image to source commit `0551276e132e06efb30c92bd860b5a6fb8f0e26f`.
- The OCI index contains `linux/amd64` and `linux/arm64`.
- `kustomize build --enable-helm argocd/applications/bayn` renders successfully.
- The rendered resources pass `kubectl apply --dry-run=client --validate=false`.
- Source PR #12911 passed unit, PostgreSQL integration, lint, typecheck, dual-architecture Nix image, Argo, kubeconform, and compatibility checks.

## Screenshots (if applicable)

N/A

## Breaking Changes

The deployment no longer supplies the legacy v1 ClickHouse table and dataset variables. The promoted image requires the exact finalized-snapshot contract already present in GitOps. No broker-order or capital-promotion authority is introduced.

## Checklist

- [x] Testing section documents exact validation.
- [x] Runtime source revision and image digest are immutable.
- [x] Legacy configuration is removed in the same rollout as the compatible image.
- [x] No broker or capital-promotion authority is introduced.
