### PR TITLE
fix(bayn): support readonly ClickHouse access

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: bayn
         app.kubernetes.io/part-of: bayn
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-20T19:53:03Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-20T18:56:39Z"
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
@@ -47,11 +47,11 @@ spec:
               protocol: TCP
           env:
             - name: BAYN_CODE_REVISION
-              value: 0551276e132e06efb30c92bd860b5a6fb8f0e26f
+              value: 948a8bb8f4a635ca7612319ca950e3b9b5930eba
             - name: BAYN_IMAGE_REPOSITORY
               value: registry.ide-newton.ts.net/lab/bayn
             - name: BAYN_IMAGE_DIGEST
-              value: sha256:397bfe247806a823541842241dc157f3b4f33d868e31c4f39cc7e2df1665c750
+              value: sha256:418840c185016cdee2ef74029c8a243924d30d7188bbc717d06d08a77c9ecb79
             - name: BAYN_RUN_ON_STARTUP
               value: "true"
             - name: BAYN_OPERATION_TIMEOUT_MS
@@ -68,6 +68,13 @@ spec:
                 secretKeyRef:
                   name: bayn-clickhouse-auth
                   key: password
+            # Remove these legacy values atomically with the bounded-reader image promotion.
+            - name: BAYN_CLICKHOUSE_DATABASE
+              value: signal
+            - name: BAYN_CLICKHOUSE_TABLE
+              value: adjusted_daily_bars_v1
+            - name: BAYN_DATASET_VERSION
+              value: alpaca-all-iex-2017-01-01-2026-07-18-v1
             - name: BAYN_SIGNAL_SNAPSHOT_ID
               value: e6ff31d2b08ec246876c4b45937838f0e3b4f5167c682afd6c2f10c46acaab20
             - name: BAYN_SIGNAL_PUBLICATION_ASOF

--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -16,5 +16,5 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/bayn
     newName: registry.ide-newton.ts.net/lab/bayn
-    newTag: "sha-0551276e132e06efb30c92bd860b5a6fb8f0e26f"
-    digest: sha256:397bfe247806a823541842241dc157f3b4f33d868e31c4f39cc7e2df1665c750
+    newTag: "sha-948a8bb8f4a635ca7612319ca950e3b9b5930eba"
+    digest: sha256:418840c185016cdee2ef74029c8a243924d30d7188bbc717d06d08a77c9ecb79

--- a/services/bayn/src/market-data.test.ts
+++ b/services/bayn/src/market-data.test.ts
@@ -188,8 +188,14 @@ describe('finalized Signal snapshot reader', () => {
     ).toThrow('duplicate adjusted bar')
   })
 
-  test('rejects a missing symbol-session row instead of silently shrinking history', () => {
+  test('rejects incomplete replica reads instead of silently shrinking history', () => {
     const fixture = makeFixture()
+    expect(() => verifyFinalizedSnapshot({ ...fixture.rows, manifests: [] }, fixture.request)).toThrow(
+      '0 manifests; expected exactly one',
+    )
+    expect(() =>
+      verifyFinalizedSnapshot({ ...fixture.rows, sessions: fixture.rows.sessions.slice(1) }, fixture.request),
+    ).toThrow('exchange-session count does not match manifest')
     expect(() =>
       verifyFinalizedSnapshot({ ...fixture.rows, bars: fixture.rows.bars.slice(1) }, fixture.request),
     ).toThrow('adjusted-bar count does not match manifest')

--- a/services/bayn/src/market-data.ts
+++ b/services/bayn/src/market-data.ts
@@ -366,6 +366,8 @@ const makeMarketData = (
 ): Effect.Effect<MarketDataService, never, ClickhouseClient.ClickhouseClient> =>
   Effect.gen(function* () {
     const sql = yield* ClickhouseClient.ClickhouseClient
+    // The Bayn principal is readonly=1, so query-level setting changes are forbidden. Snapshot counts and content
+    // hashes below make an incomplete or stale replica read fail closed.
     const loadRows = Effect.gen(function* () {
       const manifests = yield* sql`
         SELECT
@@ -432,7 +434,7 @@ const makeMarketData = (
         { concurrency: 2 },
       )
       return { bars, sessions, manifests }
-    }).pipe(sql.withClickhouseSettings({ select_sequential_consistency: '1' }))
+    })
 
     return {
       load: Effect.gen(function* () {


### PR DESCRIPTION
## Summary

Fix Bayn startup against its intentionally read-only ClickHouse principal and restore the last known Ready image while the corrected image is built.

- Remove the query-level `select_sequential_consistency` override rejected by `readonly=1`.
- Keep stale or incomplete replica reads fail-closed through exact manifest, count, completeness, and content-hash verification.
- Roll GitOps back to the previous immutable image until this source commit is built and promoted.
- Do not change ClickHouse grants, broker authority, or capital-promotion authority.

## Related Issues

PROOMPT-360

## Testing

- `bun run --filter @proompteng/bayn test` — 52 passed, 13 PostgreSQL tests skipped by the unit invocation.
- `BAYN_TEST_POSTGRES_URL=... bun test ./services/bayn/src/db/evidence-store.integration.test.ts` — 11 passed, 32 expectations.
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- `kustomize build --enable-helm argocd/applications/bayn`
- Rendered resources pass `kubectl apply --dry-run=client --validate=false`.
- Live failure reproduced with ClickHouse error code 164: the query attempted to change `select_sequential_consistency` under `readonly=1`.
- The same production credential successfully executes a read without the override and reports `readonly=1`, `select_sequential_consistency=0`.

## Screenshots (if applicable)

N/A

## Breaking Changes

The failed bounded-reader rollout is temporarily rolled back to the previous immutable image. A new immutable promotion will remove the legacy v1 variables atomically after this fix is built. No database permissions or trading authority are widened.

## Checklist

- [x] Regression coverage rejects missing manifest, session, and bar data.
- [x] The production failure and read-only compatibility path were reproduced live.
- [x] Rollback and forward-promotion boundaries are explicit.
- [x] No broker or capital-promotion authority is introduced.
