### PR TITLE
chore(product): promote nix product images

### DIFF
--- a/argocd/applications/app/kustomization.yaml
+++ b/argocd/applications/app/kustomization.yaml
@@ -8,5 +8,5 @@ resources:
   - secret.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/app
-    digest: sha256:9396212ca4ea6127b66a226820d26ee2aedb0e5b0a03df172495390c17b94e7b
+    digest: sha256:155a6293f4eebf70f49bc62ae7a9f2fc3c77aaa42917b0e8f387dadb19a862df
     newName: registry.ide-newton.ts.net/lab/app

--- a/argocd/applications/docs/kustomization.yaml
+++ b/argocd/applications/docs/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
   - generated
 images:
   - name: registry.ide-newton.ts.net/lab/docs
-    digest: sha256:0dcaf9b4fe648af7d286dccc76a8e9e7b5830da5408a5351840d2e6281cd0134
+    digest: sha256:ce3a68ead8a175fb0eb6fa24e2bedf3800fcdadffd3fc62b01c520e384ff9713
     newName: registry.ide-newton.ts.net/lab/docs

--- a/argocd/applications/proompteng/kustomization.yaml
+++ b/argocd/applications/proompteng/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
 - ingressroute.yaml
 images:
 - name: registry.ide-newton.ts.net/lab/proompteng
-  digest: sha256:26d739e9085c7dd343f4c777db25db07e4a9d839cad4a4963a99364e14118ff9
+  digest: sha256:4063cb561e82e7342bd43559d7f53ca80bcb4c6b2d4df29f6917aea713562174
   newName: registry.ide-newton.ts.net/lab/proompteng

--- a/argocd/applications/synthesis/kustomization.yaml
+++ b/argocd/applications/synthesis/kustomization.yaml
@@ -11,5 +11,5 @@ resources:
   - agents-domain
 images:
   - name: registry.ide-newton.ts.net/lab/synthesis
-    digest: sha256:17dcc016f8f23749f6b5a27ee55e0b92aaeeca913d108bcd692d79556616ce62
+    digest: sha256:3a960d06a4441b446d03e7c1632ba2a2006fd6c5c4ac779c479e43c5e0a56814
     newName: registry.ide-newton.ts.net/lab/synthesis


### PR DESCRIPTION
## Summary

- Promote enabled product app image digests built by the shared Nix OCI workflow.
- `app`: `registry.ide-newton.ts.net/lab/app@sha256:155a6293f4eebf70f49bc62ae7a9f2fc3c77aaa42917b0e8f387dadb19a862df` from `0551276e132e06efb30c92bd860b5a6fb8f0e26f`
- `docs`: `registry.ide-newton.ts.net/lab/docs@sha256:ce3a68ead8a175fb0eb6fa24e2bedf3800fcdadffd3fc62b01c520e384ff9713` from `0551276e132e06efb30c92bd860b5a6fb8f0e26f`
- `proompteng`: `registry.ide-newton.ts.net/lab/proompteng@sha256:4063cb561e82e7342bd43559d7f53ca80bcb4c6b2d4df29f6917aea713562174` from `0551276e132e06efb30c92bd860b5a6fb8f0e26f`
- `synthesis`: `registry.ide-newton.ts.net/lab/synthesis@sha256:3a960d06a4441b446d03e7c1632ba2a2006fd6c5c4ac779c479e43c5e0a56814` from `0551276e132e06efb30c92bd860b5a6fb8f0e26f`

## Rollout and impact

This is a simultaneous digest-only rollout of four production Deployments and their existing Services:

- `app/app`: the main product application Service and Deployment. Its CloudNativePG cluster is not changed.
- `docs/docs`: the documentation Service and Deployment.
- `proompteng/proompteng`: the public product-site Service and Deployment.
- `synthesis/synthesis`: the Synthesis Service and Deployment. Its database and `synthesis-tailscale` Service are not changed.

Argo CD applies each digest through its existing application independently. Kubernetes performs the normal Deployment rolling update, keeping the previous ReplicaSet available until the replacement pod becomes Ready. No schema, Secret, Service, route, database, or storage changes are included.

## Monitoring and verification

For each application:

1. Confirm Argo CD reaches `Synced` and `Healthy` at a revision containing this promotion.
2. Confirm the Deployment has its desired, updated, Ready, and Available replica counts.
3. Confirm the running pod reports the promoted immutable image digest and has no rollout restarts.
4. Inspect pod events and application logs for image-pull, startup, readiness, HTTP, or database errors.
5. Verify the existing Service endpoint through its normal health/readiness or public HTTP check.

Post-merge verification performed on 2026-07-21:

- `app`, `docs`, `proompteng`, and `synthesis` are all `Synced/Healthy` after later image promotions.
- Their current target application pods are Running and Ready with zero restarts.
- The current application images remain immutable digest references.
- A historical failed autonomous-trader scorecard Job in the `synthesis` namespace is unrelated to the `synthesis` Deployment image promotion and is not part of this rollout.

## Rollback

Revert the affected digest line in the corresponding `argocd/applications/<app>/kustomization.yaml` to the last known-good digest and merge that narrow GitOps change. Argo CD will roll the Deployment back through the same readiness-gated path. If only one product is unhealthy, revert only that product rather than rolling back all four.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- <image>@<digest> linux/amd64 linux/arm64` for each promoted image.
- Live Argo CD, Deployment, pod image, readiness, and restart verification for all four applications.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, rollout impact, monitoring, rollback, and follow-ups are updated or tracked.
