### PR TITLE
chore(bayn): promote image sha-627ad33f9ca9623c2055d53515026abb36ed016a

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -68,13 +68,6 @@ spec:
                 secretKeyRef:
                   name: bayn-clickhouse-auth
                   key: password
-            # Remove these legacy values atomically with the bounded-reader image promotion.
-            - name: BAYN_CLICKHOUSE_DATABASE
-              value: signal
-            - name: BAYN_CLICKHOUSE_TABLE
-              value: adjusted_daily_bars_v1
-            - name: BAYN_DATASET_VERSION
-              value: alpaca-all-iex-2017-01-01-2026-07-18-v1
             - name: BAYN_SIGNAL_SNAPSHOT_ID
               value: e6ff31d2b08ec246876c4b45937838f0e3b4f5167c682afd6c2f10c46acaab20
             - name: BAYN_SIGNAL_PUBLICATION_ASOF

--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: bayn
         app.kubernetes.io/part-of: bayn
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-20T18:56:39Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-20T20:17:50Z"
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
@@ -47,11 +47,11 @@ spec:
               protocol: TCP
           env:
             - name: BAYN_CODE_REVISION
-              value: 948a8bb8f4a635ca7612319ca950e3b9b5930eba
+              value: 627ad33f9ca9623c2055d53515026abb36ed016a
             - name: BAYN_IMAGE_REPOSITORY
               value: registry.ide-newton.ts.net/lab/bayn
             - name: BAYN_IMAGE_DIGEST
-              value: sha256:418840c185016cdee2ef74029c8a243924d30d7188bbc717d06d08a77c9ecb79
+              value: sha256:fcc3d5245aa78e8bea5476dc3724ee29a8031ed9cc23f38cd58d75af3d38e124
             - name: BAYN_RUN_ON_STARTUP
               value: "true"
             - name: BAYN_OPERATION_TIMEOUT_MS

--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -16,5 +16,5 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/bayn
     newName: registry.ide-newton.ts.net/lab/bayn
-    newTag: "sha-948a8bb8f4a635ca7612319ca950e3b9b5930eba"
-    digest: sha256:418840c185016cdee2ef74029c8a243924d30d7188bbc717d06d08a77c9ecb79
+    newTag: "sha-627ad33f9ca9623c2055d53515026abb36ed016a"
+    digest: sha256:fcc3d5245aa78e8bea5476dc3724ee29a8031ed9cc23f38cd58d75af3d38e124


### PR DESCRIPTION
## Summary

Promote the corrected immutable Bayn finalized-snapshot reader after the read-only ClickHouse startup failure.

- Source commit: `627ad33f9ca9623c2055d53515026abb36ed016a`
- Image tag: `sha-627ad33f9ca9623c2055d53515026abb36ed016a`
- Image digest: `sha256:fcc3d5245aa78e8bea5476dc3724ee29a8031ed9cc23f38cd58d75af3d38e124`
- Remove the three legacy v1 reader variables atomically with the compatible image.
- Preserve the `readonly=1` ClickHouse principal and zero broker/capital authority.

## Related Issues

PROOMPT-360

## Testing

- Source PR #12914 passed 52 unit tests, 11 PostgreSQL integration tests, typecheck, formatting, Oxlint, type-aware Oxlint, build, Argo, kubeconform, and dual-architecture Nix image checks.
- Regression coverage rejects missing manifest, session, and bar rows from an incomplete replica read.
- The OCI release contract binds this image to source commit `627ad33f9ca9623c2055d53515026abb36ed016a`.
- The OCI index contains `linux/amd64` and `linux/arm64`.
- `kustomize build --enable-helm argocd/applications/bayn` renders successfully.
- The rendered resources pass `kubectl apply --dry-run=client --validate=false`.

## Screenshots (if applicable)

N/A

## Breaking Changes

The deployment no longer supplies legacy v1 ClickHouse table and dataset variables. The promoted image reads the exact finalized snapshot with the existing read-only credential. No database permissions or trading authority are widened.

## Checklist

- [x] Runtime source revision and image digest are immutable.
- [x] The production failure has focused regression coverage.
- [x] Legacy configuration is removed with the compatible image.
- [x] No broker or capital-promotion authority is introduced.
