### PR TITLE
fix(bayn): bind protocol locks to strategy behavior

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: bayn
         app.kubernetes.io/part-of: bayn
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-20T20:17:50Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-20T18:56:39Z"
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
@@ -47,11 +47,11 @@ spec:
               protocol: TCP
           env:
             - name: BAYN_CODE_REVISION
-              value: 627ad33f9ca9623c2055d53515026abb36ed016a
+              value: 948a8bb8f4a635ca7612319ca950e3b9b5930eba
             - name: BAYN_IMAGE_REPOSITORY
               value: registry.ide-newton.ts.net/lab/bayn
             - name: BAYN_IMAGE_DIGEST
-              value: sha256:fcc3d5245aa78e8bea5476dc3724ee29a8031ed9cc23f38cd58d75af3d38e124
+              value: sha256:418840c185016cdee2ef74029c8a243924d30d7188bbc717d06d08a77c9ecb79
             - name: BAYN_RUN_ON_STARTUP
               value: "true"
             - name: BAYN_OPERATION_TIMEOUT_MS
@@ -68,6 +68,13 @@ spec:
                 secretKeyRef:
                   name: bayn-clickhouse-auth
                   key: password
+            # Remove these legacy values atomically with the bounded-reader image promotion.
+            - name: BAYN_CLICKHOUSE_DATABASE
+              value: signal
+            - name: BAYN_CLICKHOUSE_TABLE
+              value: adjusted_daily_bars_v1
+            - name: BAYN_DATASET_VERSION
+              value: alpaca-all-iex-2017-01-01-2026-07-18-v1
             - name: BAYN_SIGNAL_SNAPSHOT_ID
               value: e6ff31d2b08ec246876c4b45937838f0e3b4f5167c682afd6c2f10c46acaab20
             - name: BAYN_SIGNAL_PUBLICATION_ASOF

--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -16,5 +16,5 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/bayn
     newName: registry.ide-newton.ts.net/lab/bayn
-    newTag: "sha-627ad33f9ca9623c2055d53515026abb36ed016a"
-    digest: sha256:fcc3d5245aa78e8bea5476dc3724ee29a8031ed9cc23f38cd58d75af3d38e124
+    newTag: "sha-948a8bb8f4a635ca7612319ca950e3b9b5930eba"
+    digest: sha256:418840c185016cdee2ef74029c8a243924d30d7188bbc717d06d08a77c9ecb79

--- a/services/bayn/src/contracts.ts
+++ b/services/bayn/src/contracts.ts
@@ -199,6 +199,15 @@ export const RuntimeProvenanceSchema = Schema.Struct({
 export type RuntimeProvenance = typeof RuntimeProvenanceSchema.Type
 export type RuntimeProvenanceInput = Omit<RuntimeProvenance, 'schemaVersion' | 'contractVersions'>
 
+export const makeStrategyProtocolHash = (strategy: RuntimeProvenance['strategy']): string =>
+  canonicalHashV1({
+    schemaVersion: 'bayn.strategy-protocol.v1',
+    name: strategy.name,
+    behaviorHash: strategy.behaviorHash,
+    parameterHash: strategy.parameterHash,
+    parameterSchemaVersion: strategy.parameterSchemaVersion,
+  })
+
 const EvidenceFreshnessBase = Schema.Struct({
   schemaVersion: Schema.Literal('bayn.evidence-freshness.v1'),
   observedAt: UtcInstant,

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -60,8 +60,8 @@ const makeClientRuntime = (config = makeConfig()) =>
 
 const snapshot = makeSnapshot(800)
 
-const makeInput = (sourceRevision = 'a'.repeat(40)): PersistEvaluationInput => {
-  const provenance = makeTestProvenance(fixtureProtocol, { sourceRevision })
+const makeInput = (sourceRevision = 'a'.repeat(40), behaviorHash = 'c'.repeat(64)): PersistEvaluationInput => {
+  const provenance = makeTestProvenance(fixtureProtocol, { sourceRevision, behaviorHash })
   const evaluation = evaluateTsmom(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance)
   const ledger = buildLedgerPlan(evaluation, 7_001)
   return {
@@ -209,6 +209,38 @@ describePostgres('PostgreSQL evaluation evidence', () => {
 
     expect(first.evaluation.runId).not.toBe(second.evaluation.runId)
     expect(receipts.map((receipt) => receipt.runId)).toEqual([first.evaluation.runId, second.evaluation.runId])
+  })
+
+  test('locks strategy behavior and parameters under a composite protocol identity', async () => {
+    const first = makeInput('a'.repeat(40), 'c'.repeat(64))
+    const second = makeInput('a'.repeat(40), 'd'.repeat(64))
+    const protocols = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* EvidenceStore
+        const sql = yield* PgClient.PgClient
+        yield* store.persist(first)
+        yield* store.persist(second)
+        return yield* sql<{ protocol_hash: string; behavior_hash: string; parameter_hash: string }>`
+          SELECT protocol_hash, behavior_hash, parameter_hash
+          FROM bayn_protocol_locks
+          ORDER BY behavior_hash
+        `
+      }),
+    )
+
+    expect(first.evaluation.protocolHash).not.toBe(second.evaluation.protocolHash)
+    expect(protocols).toEqual([
+      {
+        protocol_hash: first.evaluation.protocolHash,
+        behavior_hash: first.provenance.strategy.behaviorHash,
+        parameter_hash: first.provenance.strategy.parameterHash,
+      },
+      {
+        protocol_hash: second.evaluation.protocolHash,
+        behavior_hash: second.provenance.strategy.behaviorHash,
+        parameter_hash: second.provenance.strategy.parameterHash,
+      },
+    ])
   })
 
   test('rejects a complete receipt whose stored evidence was altered', async () => {

--- a/services/bayn/src/db/evidence-store.ts
+++ b/services/bayn/src/db/evidence-store.ts
@@ -4,7 +4,7 @@ import { SqlSchema } from 'effect/unstable/sql'
 import { isSqlError } from 'effect/unstable/sql/SqlError'
 
 import type { RuntimeConfig } from '../config'
-import { makeRunIdentity, type RuntimeProvenance } from '../contracts'
+import { makeRunIdentity, makeStrategyProtocolHash, type RuntimeProvenance } from '../contracts'
 import { canonicalHashV1 } from '../hash'
 import type { EvaluationResult, ReconciliationResult } from '../types'
 import { migrationLoader } from './migrations'
@@ -193,10 +193,13 @@ const ensure = (condition: boolean, operation: string, message: string): Effect.
 const makePersistencePlan = (input: PersistEvaluationInput): PersistencePlan => {
   const { evaluation, parameters, provenance, reconciliation } = input
   const strategyName = provenance.strategy.name
-  const protocolHash = canonicalHashV1(parameters)
-  if (protocolHash !== evaluation.protocolHash || protocolHash !== provenance.strategy.parameterHash) {
-    throw new TypeError('evaluation, strategy parameters, and provenance disagree on protocol hash')
+  const parameterHash = canonicalHashV1(parameters)
+  if (parameterHash !== provenance.strategy.parameterHash) {
+    throw new TypeError('strategy parameters and provenance disagree on parameter hash')
   }
+  const protocolHash = makeStrategyProtocolHash(provenance.strategy)
+  if (protocolHash !== evaluation.protocolHash)
+    throw new TypeError('evaluation and provenance disagree on protocol hash')
   if (evaluation.codeRevision !== provenance.sourceRevision) {
     throw new TypeError('evaluation code revision does not match runtime provenance')
   }
@@ -570,7 +573,13 @@ const makeEvidenceStore = Effect.gen(function* () {
                 protocol.strategy_name === plan.strategyName &&
                 protocol.behavior_hash === plan.provenance.strategy.behaviorHash &&
                 protocol.parameter_hash === plan.provenance.strategy.parameterHash &&
-                canonicalHashV1(protocol.parameters) === plan.protocolHash,
+                canonicalHashV1(protocol.parameters) === plan.provenance.strategy.parameterHash &&
+                makeStrategyProtocolHash({
+                  name: protocol.strategy_name,
+                  behaviorHash: protocol.behavior_hash,
+                  parameterHash: protocol.parameter_hash,
+                  parameterSchemaVersion: protocol.schema_version,
+                }) === plan.protocolHash,
               'protocol-lock',
               'stored protocol lock diverged from the evaluated protocol',
             )

--- a/services/bayn/src/index.ts
+++ b/services/bayn/src/index.ts
@@ -6,9 +6,8 @@ import { run } from './app'
 import { loadConfig } from './config'
 import { makeRuntimeProvenance } from './contracts'
 import { EvidenceStoreRuntimeLive } from './db/evidence-store'
-import { operationalError } from './errors'
 import { JournalLive } from './ledger'
-import { MarketData, MarketDataLive } from './market-data'
+import { MarketDataLive } from './market-data'
 import { hashTsmomParameters, loadDefaultProtocol } from './protocol'
 import { makeTsmomStrategy, Strategy } from './strategy-service'
 
@@ -41,13 +40,6 @@ const main = Effect.gen(function* () {
       }),
     ),
     Layer.provide(NodeHttpClient.layerNodeHttp),
-    Layer.catch((cause) =>
-      Layer.succeed(MarketData, {
-        load: Effect.fail(
-          operationalError('market-data', 'connect', 'failed to initialize Signal ClickHouse client', cause),
-        ),
-      }),
-    ),
   )
   const dependencies = Layer.mergeAll(
     marketData,

--- a/services/bayn/src/strategy.test.ts
+++ b/services/bayn/src/strategy.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
+import { makeStrategyProtocolHash } from './contracts'
 import { calculatePerformanceMetrics, evaluateTsmom } from './strategy'
 import { canonicalHashV1 } from './hash'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
@@ -20,7 +21,7 @@ describe('TSMOM economic evaluator', () => {
     const second = evaluateTsmom(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance)
     expect(first).toEqual(second)
     expect(first.codeRevision).toBe(provenance.sourceRevision)
-    expect(first.protocolHash).toBe(provenance.strategy.parameterHash)
+    expect(first.protocolHash).toBe(makeStrategyProtocolHash(provenance.strategy))
     expect(first.strategy.observations).toBeGreaterThanOrEqual(fixtureProtocol.thresholds.minimumObservations)
     expect(BigInt(first.strategy.totalFeesMicros)).toBeGreaterThan(0n)
     expect(first.doubleCostStrategy.endingEquityMicros).not.toBe(first.strategy.endingEquityMicros)
@@ -80,7 +81,9 @@ describe('TSMOM economic evaluator', () => {
     expect(sourceChanged.runId).not.toBe(baseline.runId)
     expect(imageChanged.runId).not.toBe(baseline.runId)
     expect(behaviorChanged.runId).not.toBe(baseline.runId)
+    expect(behaviorChanged.protocolHash).not.toBe(baseline.protocolHash)
     expect(protocolChanged.runId).not.toBe(baseline.runId)
+    expect(protocolChanged.protocolHash).not.toBe(baseline.protocolHash)
     expect(inputChanged.runId).not.toBe(baseline.runId)
   })
 

--- a/services/bayn/src/strategy.ts
+++ b/services/bayn/src/strategy.ts
@@ -1,4 +1,4 @@
-import { makeRunIdentity, type RuntimeProvenance } from './contracts'
+import { makeRunIdentity, makeStrategyProtocolHash, type RuntimeProvenance } from './contracts'
 import { canonicalHashV1, hashObject } from './hash'
 import { hashTsmomParameters } from './protocol'
 import type {
@@ -365,14 +365,15 @@ export const evaluateTsmom = (
   protocol: TsmomProtocol,
   provenance: RuntimeProvenance,
 ): EvaluationResult => {
-  const protocolHash = hashTsmomParameters(protocol)
+  const parameterHash = hashTsmomParameters(protocol)
   if (provenance.strategy.name !== 'tsmom') throw new Error('runtime provenance strategy must be tsmom')
   if (provenance.strategy.parameterSchemaVersion !== protocol.schemaVersion) {
     throw new Error('runtime provenance parameter schema does not match decoded TSMOM parameters')
   }
-  if (provenance.strategy.parameterHash !== protocolHash) {
+  if (provenance.strategy.parameterHash !== parameterHash) {
     throw new Error('runtime provenance parameter hash does not match decoded TSMOM parameters')
   }
+  const protocolHash = makeStrategyProtocolHash(provenance.strategy)
   const { hash: inputManifestHash, ...inputManifestMaterial } = inputManifest
   if (canonicalHashV1(inputManifestMaterial) !== inputManifestHash) {
     throw new Error('input manifest hash does not match its content')


### PR DESCRIPTION
## Summary

- bind immutable strategy protocol locks to strategy name, compiled behavior hash, parameter hash, and parameter schema instead of parameters alone
- preserve existing evidence without migration while allowing a new binary behavior with unchanged TSMOM parameters to create a distinct protocol lock
- propagate transient ClickHouse layer-construction failures so the process exits and Kubernetes can construct a clean runtime
- restore the last-known-ready Bayn image in GitOps while this corrected image is built and qualified

## Related Issues

PROOMPT-360

## Testing

- bun run --filter @proompteng/bayn test
- BAYN_TEST_POSTGRES_URL=postgresql://postgres:bayn-test@127.0.0.1:55432/bayn_test bun run --filter @proompteng/bayn test
- bun run --filter @proompteng/bayn tsc
- bun run --filter @proompteng/bayn lint
- bun run --filter @proompteng/bayn lint:oxlint
- bun run --filter @proompteng/bayn lint:oxlint:type
- bun run --filter @proompteng/bayn build
- kustomize build argocd/applications/bayn | kubectl apply --dry-run=client -n bayn -f -
- production CNPG readback remained 1 complete run, 5 artifacts, 367 events, 7 gates, and 2 status rows after the rejected v2 attempt

## Breaking Changes

No database migration or destructive rewrite. Protocol identities created by this binary use the behavior-bound contract; existing protocol locks and evidence remain immutable. The deployment is temporarily restored to the last-known-ready image and requires a digest-pinned follow-up promotion after CI publishes this fix.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed because this is a runtime and GitOps fix.
- [x] Breaking Changes and rollout follow-up are documented.