### PR TITLE
chore(bayn): promote protocol identity fix

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: bayn
         app.kubernetes.io/part-of: bayn
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-20T18:56:39Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-20T20:40:22Z"
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
@@ -47,11 +47,11 @@ spec:
               protocol: TCP
           env:
             - name: BAYN_CODE_REVISION
-              value: 948a8bb8f4a635ca7612319ca950e3b9b5930eba
+              value: 471ef5152f18477b01ce3ce9d583af24cf12f458
             - name: BAYN_IMAGE_REPOSITORY
               value: registry.ide-newton.ts.net/lab/bayn
             - name: BAYN_IMAGE_DIGEST
-              value: sha256:418840c185016cdee2ef74029c8a243924d30d7188bbc717d06d08a77c9ecb79
+              value: sha256:86af6726eb4d80b931128d568c6efd1c4bec4826acf6349da9fdd5fcb78c0401
             - name: BAYN_RUN_ON_STARTUP
               value: "true"
             - name: BAYN_OPERATION_TIMEOUT_MS
@@ -68,13 +68,6 @@ spec:
                 secretKeyRef:
                   name: bayn-clickhouse-auth
                   key: password
-            # Remove these legacy values atomically with the bounded-reader image promotion.
-            - name: BAYN_CLICKHOUSE_DATABASE
-              value: signal
-            - name: BAYN_CLICKHOUSE_TABLE
-              value: adjusted_daily_bars_v1
-            - name: BAYN_DATASET_VERSION
-              value: alpaca-all-iex-2017-01-01-2026-07-18-v1
             - name: BAYN_SIGNAL_SNAPSHOT_ID
               value: e6ff31d2b08ec246876c4b45937838f0e3b4f5167c682afd6c2f10c46acaab20
             - name: BAYN_SIGNAL_PUBLICATION_ASOF

--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -16,5 +16,5 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/bayn
     newName: registry.ide-newton.ts.net/lab/bayn
-    newTag: "sha-948a8bb8f4a635ca7612319ca950e3b9b5930eba"
-    digest: sha256:418840c185016cdee2ef74029c8a243924d30d7188bbc717d06d08a77c9ecb79
+    newTag: "sha-471ef5152f18477b01ce3ce9d583af24cf12f458"
+    digest: sha256:86af6726eb4d80b931128d568c6efd1c4bec4826acf6349da9fdd5fcb78c0401


### PR DESCRIPTION
## Summary

- promote the multi-architecture Bayn image built from merged source commit 471ef5152f18477b01ce3ce9d583af24cf12f458
- pin registry.ide-newton.ts.net/lab/bayn by immutable digest sha256:86af6726eb4d80b931128d568c6efd1c4bec4826acf6349da9fdd5fcb78c0401
- remove the legacy database, table, and dataset environment variables atomically with the bounded finalized-snapshot reader
- restart the single Bayn deployment through the normal Argo CD GitOps path

## Related Issues

PROOMPT-360

## Testing

- source PR #12917 passed Bayn unit, PostgreSQL integration, TSC, Oxfmt, Oxlint, type-aware Oxlint, build, Argo lint, and kubeconform checks
- main image workflow 29776861440 published and verified linux/amd64 and linux/arm64 in one OCI index
- bun run lint:argocd
- kustomize build argocd/applications/bayn | kubectl apply --dry-run=client -n bayn -f -

## Breaking Changes

None. The deprecated ClickHouse database, table, and dataset variables are removed only when the image that no longer reads them is promoted.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed because this is a GitOps image promotion.
- [x] Breaking Changes and rollout behavior are documented.