### PR TITLE
feat(hermes): stage single-writer Discord cutover

### DIFF
--- a/argocd/applications/hermes/config.yaml
+++ b/argocd/applications/hermes/config.yaml
@@ -75,7 +75,7 @@ platform_toolsets:
 
 platforms:
   discord:
-    enabled: false
+    enabled: true
     reply_to_mode: first
     gateway_restart_notification: false
     typing_indicator: true

--- a/argocd/applications/hermes/external-secret.yaml
+++ b/argocd/applications/hermes/external-secret.yaml
@@ -28,3 +28,17 @@ spec:
         key: hermes-runtime/API_SERVER_KEY
         metadataPolicy: None
         nullBytePolicy: Ignore
+    - secretKey: DISCORD_BOT_TOKEN
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: hermes-runtime/DISCORD_BOT_TOKEN
+        metadataPolicy: None
+        nullBytePolicy: Ignore
+    - secretKey: DISCORD_ALLOWED_USERS
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: hermes-runtime/DISCORD_ALLOWED_USERS
+        metadataPolicy: None
+        nullBytePolicy: Ignore

--- a/argocd/applications/hermes/statefulset.yaml
+++ b/argocd/applications/hermes/statefulset.yaml
@@ -129,6 +129,16 @@ spec:
                 secretKeyRef:
                   name: hermes-api-auth
                   key: API_SERVER_KEY
+            - name: DISCORD_BOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-api-auth
+                  key: DISCORD_BOT_TOKEN
+            - name: DISCORD_ALLOWED_USERS
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-api-auth
+                  key: DISCORD_ALLOWED_USERS
             - name: DISCORD_PROXY
               value: http://hermes-egress-proxy.hermes.svc.cluster.local:3128
             - name: HTTP_PROXY

--- a/argocd/applications/openclaw/openclaw-vm-rbac.yaml
+++ b/argocd/applications/openclaw/openclaw-vm-rbac.yaml
@@ -65,16 +65,3 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: openclaw-vm-agentruns
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: openclaw-vm-cluster-admin
-subjects:
-  - kind: ServiceAccount
-    name: openclaw-vm
-    namespace: openclaw
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin

--- a/argocd/applications/openclaw/virtualmachine.yaml
+++ b/argocd/applications/openclaw/virtualmachine.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
-  running: true
+  runStrategy: Halted
   template:
     metadata:
       labels:

--- a/docs/runbooks/hermes-production-rollout.md
+++ b/docs/runbooks/hermes-production-rollout.md
@@ -71,10 +71,23 @@ The expected mirrored amd64 manifest digest is
 
    ```bash
    set -euo pipefail
+   cleanup_api_key() { unset hermes_api_key; }
+   abort_api_key() { trap - EXIT HUP INT TERM; cleanup_api_key; exit 130; }
+   trap cleanup_api_key EXIT
+   trap abort_api_key HUP INT TERM
    hermes_api_key=$(openssl rand -hex 32)
-   op item create --vault infra --category login --title hermes-runtime \
-     "API_SERVER_KEY[password]=$hermes_api_key" >/dev/null
-   unset hermes_api_key
+   op item template get 'Secure Note' | \
+     jq --rawfile api_server_key <(printf '%s' "$hermes_api_key") '
+       .title = "hermes-runtime"
+       | .fields += [{
+           id: "API_SERVER_KEY",
+           type: "CONCEALED",
+           label: "API_SERVER_KEY",
+           value: $api_server_key
+         }]
+     ' | op item create --vault infra - >/dev/null
+   cleanup_api_key
+   trap - EXIT HUP INT TERM
    ```
 
 4. Wait for the ApplicationSet to create the manual Hermes app, sync it, and verify the secret bridge without reading the
@@ -248,7 +261,18 @@ trap 'exit 1' HUP INT TERM
 previous_secret_version=$(kubectl -n hermes get secret hermes-api-auth -o jsonpath='{.metadata.resourceVersion}')
 old_api_key=$(kubectl -n hermes get secret hermes-api-auth -o jsonpath='{.data.API_SERVER_KEY}' | base64 -d)
 new_api_key=$(openssl rand -hex 32)
-op item edit --vault infra hermes-runtime "API_SERVER_KEY[password]=$new_api_key" >/dev/null
+op item get --vault infra hermes-runtime --format json | \
+  jq --rawfile api_server_key <(printf '%s' "$new_api_key") '
+    ([.fields[] | select(.label == "API_SERVER_KEY")] | length) as $count
+    | if $count == 1 then
+        .fields |= map(if .label == "API_SERVER_KEY" then .type = "CONCEALED" | .value = $api_server_key else . end)
+      else
+        error("exactly one API_SERVER_KEY field is required")
+      end
+  ' | op item edit --vault infra hermes-runtime >/dev/null
+op item get --vault infra hermes-runtime --format json | \
+  jq -e --rawfile api_server_key <(printf '%s' "$new_api_key") \
+    '[.fields[] | select(.label == "API_SERVER_KEY" and .value == $api_server_key)] | length == 1' >/dev/null
 kubectl -n hermes annotate externalsecret hermes-api-auth force-sync="$(date +%s)" --overwrite
 current_secret_version=$previous_secret_version
 for _ in $(seq 1 72); do
@@ -460,29 +484,50 @@ Discord activation requires a second PR. That PR must:
 - add an ExternalSecret mapping `hermes-runtime/DISCORD_BOT_TOKEN` and `hermes-runtime/DISCORD_ALLOWED_USERS`;
 - inject both secret keys into the gateway container;
 - set `platforms.discord.enabled: true`;
-- set OpenClaw `spec.running: false` and remove the OpenClaw `cluster-admin` binding;
+- set OpenClaw `spec.runStrategy: Halted` and remove the OpenClaw `cluster-admin` binding;
 - retain the OpenClaw VM, root-disk PVC, cloud-init Secret, and scoped read-only rollback resources;
 - retain manual Argo automation so the token transfer and sync are ordered by the operator.
 
 Cutover sequence:
 
-1. Record the current OpenClaw Discord allowlist count. Quiesce its Discord writer while the VM remains reachable, and prove
-   the gateway process is inactive:
+1. In a dedicated private credential shell, capture the existing bot token and numeric allowlist without printing either
+   value. Keep this shell open through step 4. Record only the allowlist count, quiesce OpenClaw's Discord writer while the
+   VM remains reachable, and prove the gateway process is inactive:
 
    ```bash
    set -euo pipefail
+   cleanup_discord_credentials() {
+     unset discord_bot_token discord_allowed_users discord_allowed_user_count
+   }
+   abort_discord_credentials() { trap - EXIT HUP INT TERM; cleanup_discord_credentials; exit 130; }
+   trap cleanup_discord_credentials EXIT
+   trap abort_discord_credentials HUP INT TERM
+   discord_bot_token=$(virtctl ssh -n openclaw --username ubuntu --identity-file /Users/gregkonush/.ssh/id_ed25519 \
+     --local-ssh-opts='-o IdentityAgent=none' --local-ssh-opts='-o IdentitiesOnly=yes' \
+     --command='set -eu; jq -er '\''.channels.discord.token | select(type == "string" and length >= 20)'\'' /home/ubuntu/.openclaw/openclaw.json' \
+     vm/openclaw)
+   discord_allowed_users=$(virtctl ssh -n openclaw --username ubuntu --identity-file /Users/gregkonush/.ssh/id_ed25519 \
+     --local-ssh-opts='-o IdentityAgent=none' --local-ssh-opts='-o IdentitiesOnly=yes' \
+     --command='set -eu; jq -er '\''[.channels.discord.allowFrom[]?, .channels.discord.guilds[]?.users[]?] | if length > 0 and all(.[]; type == "string" and test("^[0-9]+$")) then unique | join(",") else error("numeric Discord allowlist required") end'\'' /home/ubuntu/.openclaw/openclaw.json' \
+     vm/openclaw)
+   test "${#discord_bot_token}" -ge 20
+   case "$discord_allowed_users" in ""|,*|*,|*,,*|*[!0-9,]*) exit 1 ;; esac
+   discord_allowed_user_count=$(printf '%s\n' "$discord_allowed_users" | awk -F, '{print NF}')
+   printf 'openclaw_discord_allowed_users=%s\n' "$discord_allowed_user_count"
    virtctl ssh -n openclaw --username ubuntu --identity-file /Users/gregkonush/.ssh/id_ed25519 \
      --local-ssh-opts='-o IdentityAgent=none' --local-ssh-opts='-o IdentitiesOnly=yes' \
      --command='set -eu; systemctl --user stop openclaw-gateway.service; test "$(systemctl --user is-active openclaw-gateway.service || true)" = inactive; if pgrep -f "[o]penclaw.*gateway" >/dev/null; then exit 1; fi; sync' \
      vm/openclaw
    ```
 
-2. With the source quiesced, repeat Phase 2 steps 1 through 4 from a fresh `hermes_stage_dir`. Preserve the new audit output,
-   dry-run Job, apply Job, and restore-point archive as the final reconciliation evidence. Do not reuse the earlier archive.
-   Leave the Hermes StatefulSet at zero and backups suspended; do not run Phase 2 step 5 because merged `main` now enables
-   Discord. Keep the same Phase 2 shell and Lease open through cutover step 5. If this final migration fails, keep Hermes
+2. In a separate maintenance shell, with the source quiesced, repeat Phase 2 steps 1 through 4 from a fresh
+   `hermes_stage_dir`. Preserve the new audit output, dry-run Job, apply Job, and restore-point archive as the final
+   reconciliation evidence. Do not reuse the earlier archive. Leave the Hermes StatefulSet at zero and backups suspended;
+   do not run Phase 2 step 5 because merged `main` now enables Discord. Keep the same Phase 2 shell and Lease open through
+   cutover step 5. Keep the credential shell from step 1 open through step 4. If this final migration fails, keep Hermes
    Discord disabled. If cutover is abandoned before the VMI is stopped, restart `openclaw-gateway.service`, resync the last
-   API-only Hermes revision, release the Lease, and repeat this final reconciliation before any later attempt.
+   API-only Hermes revision, release the Lease, clear the credential variables, and repeat this final reconciliation before
+   any later attempt.
 3. In the same shell, assert continued Lease ownership, sync the merged OpenClaw GitOps change, and prove its VMI is gone
    before provisioning Hermes with the shared token:
 
@@ -490,6 +535,9 @@ Cutover sequence:
    set -euo pipefail
    test -n "${maintenance_holder:-}"
    test "$(kubectl -n hermes get lease hermes-maintenance -o jsonpath='{.spec.holderIdentity}')" = "$maintenance_holder"
+   argocd app sync openclaw --prune \
+     --resource rbac.authorization.k8s.io:ClusterRoleBinding:openclaw-vm-cluster-admin
+   test -z "$(kubectl -n openclaw get clusterrolebinding openclaw-vm-cluster-admin --ignore-not-found -o name)"
    argocd app sync openclaw --prune=false
    openclaw_stop_deadline=$(( $(date +%s) + 600 ))
    while :; do
@@ -507,8 +555,43 @@ Cutover sequence:
    unset openclaw_vmi_name openclaw_stop_deadline
    ```
 
-4. In a second private shell, transfer the existing bot token and numeric allowlist directly into the `hermes-runtime`
-   1Password item, then unset local variables. Keep the Lease-owning shell open.
+4. Only after the OpenClaw VMI is absent, use the credential shell from step 1 to transfer the captured bot token and numeric
+   allowlist directly into the `hermes-runtime` 1Password item. Verify the fields without printing them, clear the variables,
+   and keep the Lease-owning shell open:
+
+   ```bash
+   set -euo pipefail
+   test -n "${discord_bot_token:-}"
+   test -n "${discord_allowed_users:-}"
+   op item get --vault infra hermes-runtime --format json | \
+     jq --rawfile discord_bot_token <(printf '%s' "$discord_bot_token") \
+       --rawfile discord_allowed_users <(printf '%s' "$discord_allowed_users") '
+       def upsert_field($id; $type; $label; $value):
+         ([.fields[] | select(.label == $label)] | length) as $count
+         | if $count == 0 then
+             .fields += [{id: $id, type: $type, label: $label, value: $value}]
+           elif $count == 1 then
+             .fields |= map(if .label == $label then .type = $type | .value = $value else . end)
+           else
+             error("duplicate field: " + $label)
+           end;
+       upsert_field("DISCORD_BOT_TOKEN"; "CONCEALED"; "DISCORD_BOT_TOKEN"; $discord_bot_token)
+       | upsert_field("DISCORD_ALLOWED_USERS"; "STRING"; "DISCORD_ALLOWED_USERS"; $discord_allowed_users)
+     ' | op item edit --vault infra hermes-runtime >/dev/null
+   op item get --vault infra hermes-runtime --format json | \
+     jq -e --rawfile expected_discord_bot_token <(printf '%s' "$discord_bot_token") \
+       --rawfile expected_discord_allowed_users <(printf '%s' "$discord_allowed_users") '
+       ([.fields[] | select(
+         .label == "DISCORD_BOT_TOKEN" and .value == $expected_discord_bot_token
+       )] | length == 1) and
+       ([.fields[] | select(
+         .label == "DISCORD_ALLOWED_USERS" and .value == $expected_discord_allowed_users
+       )] | length == 1)
+     ' >/dev/null
+   cleanup_discord_credentials
+   trap - EXIT HUP INT TERM
+   ```
+
 5. Keep the Lease-owning shell open. Sync Hermes from merged `main` only after the OpenClaw VMI is gone. Wait for the
    updated ExternalSecret and rollout, verify backups are enabled, then release the Lease. Prove only one Discord bot
    session is active. This sync restores the Hermes replicas and backups:
@@ -520,7 +603,13 @@ Cutover sequence:
    argocd app sync hermes --prune=false
    kubectl -n hermes wait externalsecret/hermes-api-auth --for=condition=Ready --timeout=5m
    kubectl -n hermes rollout status statefulset/hermes --timeout=15m
+   discord_secret_keys=$(kubectl -n hermes get secret hermes-api-auth -o json | jq -r '.data | keys | sort | join(",")')
+   test "$discord_secret_keys" = API_SERVER_KEY,DISCORD_ALLOWED_USERS,DISCORD_BOT_TOKEN
+   unset discord_secret_keys
    test "$(kubectl -n hermes get cronjob hermes-backup -o jsonpath='{.spec.suspend}')" = false
+   test -z "$(kubectl -n openclaw get virtualmachineinstance openclaw --ignore-not-found -o name)"
+   test "$(kubectl -n hermes get statefulset hermes -o jsonpath='{.status.readyReplicas}')" = 1
+   kubectl -n hermes logs statefulset/hermes -c hermes --since=15m | rg -m1 '\[discord\] Connected as '
    release_maintenance_lock
    trap - EXIT HUP INT TERM
    unset maintenance_holder
@@ -551,7 +640,8 @@ The OpenClaw runtime remains unchanged and authoritative.
 
 1. Disable Discord in Hermes and stop its pod through a reviewed GitOps rollback.
 2. Verify the Hermes VMI-equivalent workload is gone before restarting OpenClaw; never allow both runtimes to connect.
-3. Revert OpenClaw `spec.running` and scoped RBAC through GitOps. Restore the token to OpenClaw only after Hermes is stopped.
+3. Revert OpenClaw to `spec.runStrategy: Always` and restore only its scoped RBAC through GitOps. Restore the token to
+   OpenClaw only after Hermes is stopped.
 4. Verify OpenClaw's Discord lifecycle and retain Hermes PVCs/backups for investigation.
 
 ### Restore Hermes data from a verified backup

--- a/docs/runbooks/hermes-production-rollout.md
+++ b/docs/runbooks/hermes-production-rollout.md
@@ -66,26 +66,50 @@ The expected mirrored amd64 manifest digest is
    `NetworkPolicy is not enforced` is a hard rollout blocker. Do not sync Hermes or weaken the containment test; install
    and validate a compatible policy engine first.
 
-3. Create a minimum 32-byte API key in the `infra` 1Password vault. Do this from a private shell with 1Password unlocked;
-   do not echo the generated value:
+3. Ensure the `infra` 1Password vault contains exactly one `hermes-runtime` item with a minimum 32-byte API key. The
+   command is safe to rerun: it reuses and validates an existing item, and creates one only when none exists. Do this from
+   a private shell with 1Password unlocked; do not echo the generated value:
 
    ```bash
    set -euo pipefail
-   cleanup_api_key() { unset hermes_api_key; }
+   cleanup_api_key() {
+     unset hermes_api_key hermes_item_count hermes_item_id api_key_bytes
+   }
    abort_api_key() { trap - EXIT HUP INT TERM; cleanup_api_key; exit 130; }
    trap cleanup_api_key EXIT
    trap abort_api_key HUP INT TERM
-   hermes_api_key=$(openssl rand -hex 32)
-   op item template get 'Secure Note' | \
-     jq --rawfile api_server_key <(printf '%s' "$hermes_api_key") '
-       .title = "hermes-runtime"
-       | .fields += [{
-           id: "API_SERVER_KEY",
-           type: "CONCEALED",
-           label: "API_SERVER_KEY",
-           value: $api_server_key
-         }]
-     ' | op item create --vault infra - >/dev/null
+   hermes_item_count=$(op item list --vault infra --format json | \
+     jq -er '[.[] | select(.title == "hermes-runtime")] | length')
+   case "$hermes_item_count" in
+     0)
+       hermes_api_key=$(openssl rand -hex 32)
+       op item template get 'Secure Note' | \
+         jq --rawfile api_server_key <(printf '%s' "$hermes_api_key") '
+           .title = "hermes-runtime"
+           | .fields += [{
+               id: "API_SERVER_KEY",
+               type: "CONCEALED",
+               label: "API_SERVER_KEY",
+               value: $api_server_key
+             }]
+         ' | op item create --vault infra - >/dev/null
+       ;;
+     1) ;;
+     *)
+       echo 'multiple hermes-runtime items found; reconcile them before continuing' >&2
+       exit 1
+       ;;
+   esac
+   hermes_item_id=$(op item list --vault infra --format json | \
+     jq -er '[.[] | select(.title == "hermes-runtime") | .id] |
+       if length == 1 then .[0] else error("exactly one hermes-runtime item is required") end')
+   api_key_bytes=$(op item get --vault infra "$hermes_item_id" --format json | \
+     jq -er '[.fields[] | select(.label == "API_SERVER_KEY")] as $fields |
+       if ($fields | length) == 1 and $fields[0].type == "CONCEALED" and ($fields[0].value | type) == "string"
+       then ($fields[0].value | length)
+       else error("exactly one concealed API_SERVER_KEY field is required")
+       end')
+   test "$api_key_bytes" -ge 32
    cleanup_api_key
    trap - EXIT HUP INT TERM
    ```

--- a/scripts/hermes/validate-production.test.ts
+++ b/scripts/hermes/validate-production.test.ts
@@ -155,10 +155,13 @@ test('rejects a Discord credential transfer without exact-value verification', a
 
 test('rejects secret bridge verification that does not enforce key length', async () => {
   const files = await loadProductionFiles()
-  files.runbook = files.runbook.replace('test "$api_key_bytes" -ge 32', 'echo "$api_key_bytes"')
+  files.runbook = files.runbook.replace(
+    'test "$api_key_bytes" -ge 32\n   printf \'%s\\n\' "$api_key_bytes"',
+    'echo "$api_key_bytes"',
+  )
 
   expect(validateProductionContent(files)).toContain(
-    `${productionPaths.runbook}: missing production invariant "test \\"$api_key_bytes\\" -ge 32"`,
+    `${productionPaths.runbook}: 1Password and bridged API keys must both enforce the minimum length`,
   )
 })
 
@@ -592,6 +595,30 @@ test('rejects cutover instructions that fail when the OpenClaw VMI is already ab
 
   expect(validateProductionContent(files)).toContain(
     `${productionPaths.runbook}: missing production invariant "openclaw_vmi_name=$(kubectl -n openclaw get virtualmachineinstance openclaw --ignore-not-found -o name)"`,
+  )
+})
+
+test('rejects non-idempotent initial 1Password provisioning', async () => {
+  const files = await loadProductionFiles()
+  files.runbook = files.runbook.replace(
+    'hermes_item_count=$(op item list --vault infra --format json',
+    'hermes_item_count=0 # skip existing-item discovery',
+  )
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.runbook}: missing production invariant "hermes_item_count=$(op item list --vault infra --format json"`,
+  )
+})
+
+test('rejects initial 1Password provisioning that does not fail on duplicate items', async () => {
+  const files = await loadProductionFiles()
+  files.runbook = files.runbook.replace(
+    'multiple hermes-runtime items found; reconcile them before continuing',
+    'continuing with an arbitrary hermes-runtime item',
+  )
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.runbook}: missing production invariant "multiple hermes-runtime items found; reconcile them before continuing"`,
   )
 })
 

--- a/scripts/hermes/validate-production.test.ts
+++ b/scripts/hermes/validate-production.test.ts
@@ -39,12 +39,117 @@ test('rejects rollout evidence that permits an Argo revision mismatch', async ()
   )
 })
 
-test('rejects enabling Discord inside the API-only canary', async () => {
+test('rejects disabling Discord after the cutover', async () => {
   const files = await loadProductionFiles()
-  files.config = files.config.replace('discord:\n    enabled: false', 'discord:\n    enabled: true')
+  files.config = files.config.replace('discord:\n    enabled: true', 'discord:\n    enabled: false')
 
   expect(validateProductionContent(files)).toContain(
-    `${productionPaths.config}: missing production invariant "discord:\\n    enabled: false"`,
+    `${productionPaths.config}: missing production invariant "discord:\\n    enabled: true"`,
+  )
+})
+
+test('rejects a Discord token without a matching gateway SecretKeyRef', async () => {
+  const files = await loadProductionFiles()
+  files.statefulSet = files.statefulSet.replace('- name: DISCORD_BOT_TOKEN\n', '- name: DISCORD_BOT_TOKEN_DISABLED\n')
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.statefulSet}: DISCORD_BOT_TOKEN must have exactly one matching SecretKeyRef`,
+  )
+})
+
+test('rejects a Discord allowlist without a matching 1Password mapping', async () => {
+  const files = await loadProductionFiles()
+  files.externalSecret = files.externalSecret.replace(
+    '    - secretKey: DISCORD_ALLOWED_USERS\n',
+    '    - secretKey: DISCORD_ALLOWED_USERS_DISABLED\n',
+  )
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.externalSecret}: DISCORD_ALLOWED_USERS must have exactly one 1Password mapping`,
+  )
+})
+
+test('rejects a cutover that leaves the OpenClaw VM running', async () => {
+  const files = await loadProductionFiles()
+  files.openClawVirtualMachine = files.openClawVirtualMachine.replace('runStrategy: Halted', 'runStrategy: Always')
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.openClawVirtualMachine}: missing production invariant "runStrategy: Halted"`,
+  )
+})
+
+test('rejects the deprecated KubeVirt running field', async () => {
+  const files = await loadProductionFiles()
+  files.openClawVirtualMachine = files.openClawVirtualMachine.replace('runStrategy: Halted', 'running: false')
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.openClawVirtualMachine}: contains forbidden production term "running: false"`,
+  )
+})
+
+test('rejects retaining OpenClaw cluster-admin authority', async () => {
+  const files = await loadProductionFiles()
+  files.openClawRbac += '\nroleRef:\n  name: cluster-admin\n'
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.openClawRbac}: contains forbidden production term "name: cluster-admin"`,
+  )
+})
+
+test('rejects whole-application pruning during OpenClaw cutover', async () => {
+  const files = await loadProductionFiles()
+  files.runbook = files.runbook.replace(
+    'argocd app sync openclaw --prune \\\n     --resource rbac.authorization.k8s.io:ClusterRoleBinding:openclaw-vm-cluster-admin',
+    'argocd app sync openclaw --prune=true',
+  )
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.runbook}: contains forbidden production term "argocd app sync openclaw --prune=true"`,
+  )
+})
+
+test('rejects stopping the source before Discord credentials are captured', async () => {
+  const files = await loadProductionFiles()
+  files.runbook = files.runbook.replace(
+    '   discord_bot_token=$(virtctl ssh',
+    '   systemctl --user stop openclaw-gateway.service\n   discord_bot_token=$(virtctl ssh',
+  )
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.runbook}: Discord cutover operations are out of order`,
+  )
+})
+
+test('rejects transferring the Discord token before the OpenClaw VMI is absent', async () => {
+  const files = await loadProductionFiles()
+  files.runbook = files.runbook.replace(
+    '   argocd app sync openclaw --prune=false\n',
+    '   op item edit --vault infra hermes-runtime\n   argocd app sync openclaw --prune=false\n',
+  )
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.runbook}: Discord cutover operations are out of order`,
+  )
+})
+
+test('rejects exposing secrets through 1Password assignment arguments', async () => {
+  const files = await loadProductionFiles()
+  files.runbook += '\nop item edit --vault infra hermes-runtime "DISCORD_BOT_TOKEN[password]=$discord_bot_token"\n'
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.runbook}: contains forbidden production term "DISCORD_BOT_TOKEN[password]="`,
+  )
+})
+
+test('rejects a Discord credential transfer without exact-value verification', async () => {
+  const files = await loadProductionFiles()
+  files.runbook = files.runbook.replace(
+    '.value == $expected_discord_bot_token',
+    '(.value | type == "string" and length >= 20)',
+  )
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.runbook}: missing production invariant ".value == $expected_discord_bot_token"`,
   )
 })
 
@@ -128,6 +233,15 @@ test('rejects syncing Hermes before network-policy enforcement proof', async () 
 test('rejects automatic Argo reconciliation during the staged migration', async () => {
   const files = await loadProductionFiles()
   files.platform = files.platform.replace(/(\n\s+- name: hermes\n[\s\S]*?automation:) manual/, '$1 auto')
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.platform}: missing production invariant "automation: manual"`,
+  )
+})
+
+test('rejects automatic OpenClaw reconciliation during credential transfer', async () => {
+  const files = await loadProductionFiles()
+  files.platform = files.platform.replace(/(\n\s+- name: openclaw\n[\s\S]*?automation:) manual/, '$1 auto')
 
   expect(validateProductionContent(files)).toContain(
     `${productionPaths.platform}: missing production invariant "automation: manual"`,
@@ -308,11 +422,11 @@ test('rejects migration instructions that skip the content audit', async () => {
 test('rejects Discord cutover without a final stopped-source reconciliation', async () => {
   const files = await loadProductionFiles()
   files.runbook = files.runbook.replace(
-    'repeat Phase 2 steps 1 through 4 from a fresh `hermes_stage_dir`',
+    'repeat Phase 2 steps 1 through 4 from a fresh',
     'reuse the earlier migration archive',
   )
 
-  const invariant = 'repeat Phase 2 steps 1 through 4 from a fresh `hermes_stage_dir`'
+  const invariant = 'repeat Phase 2 steps 1 through 4 from a fresh'
   expect(validateProductionContent(files)).toContain(
     `${productionPaths.runbook}: missing production invariant ${JSON.stringify(invariant)}`,
   )

--- a/scripts/hermes/validate-production.ts
+++ b/scripts/hermes/validate-production.ts
@@ -556,11 +556,18 @@ export function validateProductionContent(files: ProductionFiles): string[] {
   requireTerms(failures, productionPaths.runbook, phaseZeroSection, [
     'bash scripts/hermes/verify-network-policy-enforcement.sh',
     '`NetworkPolicy is not enforced` is a hard rollout blocker.',
-    'cleanup_api_key() { unset hermes_api_key; }',
+    'unset hermes_api_key hermes_item_count hermes_item_id api_key_bytes',
     'trap cleanup_api_key EXIT',
+    'hermes_item_count=$(op item list --vault infra --format json',
+    '[.[] | select(.title == "hermes-runtime")] | length',
+    'multiple hermes-runtime items found; reconcile them before continuing',
     "op item template get 'Secure Note'",
     'jq --rawfile api_server_key <(printf \'%s\' "$hermes_api_key")',
     'op item create --vault infra -',
+    'hermes_item_id=$(op item list --vault infra --format json',
+    'if length == 1 then .[0] else error("exactly one hermes-runtime item is required") end',
+    'op item get --vault infra "$hermes_item_id" --format json',
+    'else error("exactly one concealed API_SERVER_KEY field is required")',
     'test "$api_key_bytes" -ge 32',
     'printf \'%s\\n\' "$api_key_bytes"',
     "hermes_deployed_revision=$(kubectl -n argocd get application hermes -o json | jq -r '.status.history[-1].revision // empty')",
@@ -573,6 +580,9 @@ export function validateProductionContent(files: ProductionFiles): string[] {
   }
   if (count(phaseZeroSection, 'set -euo pipefail') !== 2) {
     failures.push(`${productionPaths.runbook}: secret creation and bridge verification must both fail closed`)
+  }
+  if (count(phaseZeroSection, 'test "$api_key_bytes" -ge 32') !== 2) {
+    failures.push(`${productionPaths.runbook}: 1Password and bridged API keys must both enforce the minimum length`)
   }
   const rotationSection = files.runbook.match(/## API key rotation[\s\S]*?## Maintenance lock recovery/)?.[0] ?? ''
   requireTerms(failures, productionPaths.runbook, rotationSection, [

--- a/scripts/hermes/validate-production.ts
+++ b/scripts/hermes/validate-production.ts
@@ -28,6 +28,9 @@ export const productionPaths = {
   clusterMetrics: 'argocd/applications/observability/cluster-metrics-alloy-config.river',
   clusterMetricsDeployment: 'argocd/applications/observability/cluster-metrics-alloy-deployment.yaml',
   kubeStateMetrics: 'argocd/applications/observability/kube-state-metrics-values.yaml',
+  openClawKustomization: 'argocd/applications/openclaw/kustomization.yaml',
+  openClawVirtualMachine: 'argocd/applications/openclaw/virtualmachine.yaml',
+  openClawRbac: 'argocd/applications/openclaw/openclaw-vm-rbac.yaml',
   runbook: 'docs/runbooks/hermes-production-rollout.md',
   impactMap: '.github/ci/impact-map.yml',
   pullRequestWorkflow: '.github/workflows/pull-request.yml',
@@ -98,6 +101,8 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'capabilities:\n              drop:\n                - ALL',
     'seccompProfile:\n              type: RuntimeDefault',
     'API_SERVER_KEY',
+    'DISCORD_BOT_TOKEN',
+    'DISCORD_ALLOWED_USERS',
     'name: data',
     'name: backups',
     'mountPath: /opt/backups\n              readOnly: true',
@@ -111,6 +116,14 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'hostPID: true',
     '        - name: backup\n',
   ])
+  for (const key of ['DISCORD_BOT_TOKEN', 'DISCORD_ALLOWED_USERS']) {
+    if (
+      count(files.statefulSet, `            - name: ${key}\n`) !== 1 ||
+      count(files.statefulSet, `                  key: ${key}\n`) !== 1
+    ) {
+      failures.push(`${productionPaths.statefulSet}: ${key} must have exactly one matching SecretKeyRef`)
+    }
+  }
 
   if (count(files.backupCronJob, `image: ${hermesImage}`) !== 1) {
     failures.push(`${productionPaths.backupCronJob}: backup must use the immutable mirrored Hermes digest`)
@@ -164,7 +177,7 @@ export function validateProductionContent(files: ProductionFiles): string[] {
   requireTerms(failures, productionPaths.config, files.config, [
     '_config_version: 33',
     'base_url: http://flamingo.flamingo.svc.cluster.local/v1',
-    'discord:\n    enabled: false',
+    'discord:\n    enabled: true',
     'api_server:\n    enabled: true',
     'cron_mode: deny',
     'orchestrator_enabled: false',
@@ -179,8 +192,50 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'name: onepassword-infra',
     'deletionPolicy: Retain',
     'key: hermes-runtime/API_SERVER_KEY',
+    'secretKey: DISCORD_BOT_TOKEN',
+    'key: hermes-runtime/DISCORD_BOT_TOKEN',
+    'secretKey: DISCORD_ALLOWED_USERS',
+    'key: hermes-runtime/DISCORD_ALLOWED_USERS',
   ])
   forbidTerms(failures, productionPaths.externalSecret, files.externalSecret, ['dataFrom:', 'kind: Secret'])
+  for (const key of ['DISCORD_BOT_TOKEN', 'DISCORD_ALLOWED_USERS']) {
+    if (
+      count(files.externalSecret, `    - secretKey: ${key}\n`) !== 1 ||
+      count(files.externalSecret, `        key: hermes-runtime/${key}\n`) !== 1
+    ) {
+      failures.push(`${productionPaths.externalSecret}: ${key} must have exactly one 1Password mapping`)
+    }
+  }
+
+  requireTerms(failures, productionPaths.openClawKustomization, files.openClawKustomization, [
+    'namespace: openclaw',
+    '- cloud-init-secret.yaml',
+    '- datavolume-rootdisk-rbd.yaml',
+    '- virtualmachine.yaml',
+    '- service-ssh.yaml',
+    '- openclaw-vm-rbac.yaml',
+  ])
+  requireTerms(failures, productionPaths.openClawVirtualMachine, files.openClawVirtualMachine, [
+    'kind: VirtualMachine',
+    'name: openclaw',
+    'namespace: openclaw',
+    'runStrategy: Halted',
+    'name: openclaw-rootdisk-rbd',
+    'secretRef:\n              name: openclaw-cloud-init',
+  ])
+  forbidTerms(failures, productionPaths.openClawVirtualMachine, files.openClawVirtualMachine, [
+    'running: true',
+    'running: false',
+  ])
+  requireTerms(failures, productionPaths.openClawRbac, files.openClawRbac, [
+    'name: openclaw-vm-argocd-applications',
+    'name: openclaw-vm-agentruns',
+    'resourceNames: ["codex-github-token", "codex-openai-key"]',
+  ])
+  forbidTerms(failures, productionPaths.openClawRbac, files.openClawRbac, [
+    'name: openclaw-vm-cluster-admin',
+    'name: cluster-admin',
+  ])
 
   requireTerms(failures, productionPaths.networkPolicy, files.networkPolicy, [
     'name: hermes-default-deny',
@@ -410,6 +465,13 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'wait-for-maintenance.sh',
   ])
 
+  const openClawApplication = files.platform.match(/\n\s+- name: openclaw\n[\s\S]*?\n\s+- name: hermes\n/)?.[0] ?? ''
+  requireTerms(failures, productionPaths.platform, openClawApplication, [
+    'path: argocd/applications/openclaw',
+    'namespace: openclaw',
+    'automation: manual',
+  ])
+
   const hermesApplication = files.platform.match(/\n\s+- name: hermes\n[\s\S]*?\n\s+- name: workers\n/)?.[0] ?? ''
   requireTerms(failures, productionPaths.platform, hermesApplication, [
     'path: argocd/applications/hermes',
@@ -494,6 +556,11 @@ export function validateProductionContent(files: ProductionFiles): string[] {
   requireTerms(failures, productionPaths.runbook, phaseZeroSection, [
     'bash scripts/hermes/verify-network-policy-enforcement.sh',
     '`NetworkPolicy is not enforced` is a hard rollout blocker.',
+    'cleanup_api_key() { unset hermes_api_key; }',
+    'trap cleanup_api_key EXIT',
+    "op item template get 'Secure Note'",
+    'jq --rawfile api_server_key <(printf \'%s\' "$hermes_api_key")',
+    'op item create --vault infra -',
     'test "$api_key_bytes" -ge 32',
     'printf \'%s\\n\' "$api_key_bytes"',
     "hermes_deployed_revision=$(kubectl -n argocd get application hermes -o json | jq -r '.status.history[-1].revision // empty')",
@@ -511,6 +578,9 @@ export function validateProductionContent(files: ProductionFiles): string[] {
   requireTerms(failures, productionPaths.runbook, rotationSection, [
     'set -euo pipefail',
     'trap cleanup_rotation EXIT',
+    'jq --rawfile api_server_key <(printf \'%s\' "$new_api_key")',
+    'error("exactly one API_SERVER_KEY field is required")',
+    'op item edit --vault infra hermes-runtime',
     'kubectl -n hermes delete pod hermes-0',
     'kubectl -n hermes rollout status statefulset/hermes --timeout=15m',
     'rotation_port_forward_log=$(mktemp)',
@@ -522,6 +592,9 @@ export function validateProductionContent(files: ProductionFiles): string[] {
   ])
   forbidTerms(failures, productionPaths.runbook, files.runbook, [
     '--ignore-failed-read',
+    'API_SERVER_KEY[password]=',
+    'DISCORD_BOT_TOKEN[password]=',
+    'DISCORD_ALLOWED_USERS[text]=',
     'kubectl -n hermes exec hermes-0 -c hermes -- mkdir -p /opt/data/migration/openclaw',
     'for path in AGENTS.md SOUL.md IDENTITY.md USER.md TOOLS.md HEARTBEAT.md memory',
     "'rm -rf -- /opt/data/migration/openclaw && mkdir -p /opt/data/migration/openclaw'",
@@ -634,34 +707,91 @@ export function validateProductionContent(files: ProductionFiles): string[] {
   }
   const cutoverSection = files.runbook.match(/## Phase 3:[\s\S]*?## Rollback/)?.[0] ?? ''
   requireTerms(failures, productionPaths.runbook, cutoverSection, [
+    'cleanup_discord_credentials() {',
+    'trap cleanup_discord_credentials EXIT',
+    '.channels.discord.token | select(type == "string" and length >= 20)',
+    '.channels.discord.allowFrom[]?',
+    '.channels.discord.guilds[]?.users[]?',
+    'numeric Discord allowlist required',
+    'test "${#discord_bot_token}" -ge 20',
+    'case "$discord_allowed_users" in ""|,*|*,|*,,*|*[!0-9,]*) exit 1 ;; esac',
     'systemctl --user stop openclaw-gateway.service',
-    'repeat Phase 2 steps 1 through 4 from a fresh `hermes_stage_dir`',
+    'repeat Phase 2 steps 1 through 4 from a fresh',
+    '`hermes_stage_dir`',
     'Do not reuse the earlier archive.',
     'do not run Phase 2 step 5 because merged `main` now enables',
-    'Keep the same Phase 2 shell and Lease open through cutover step 5.',
+    'Keep the same Phase 2 shell and Lease open through',
+    'cutover step 5.',
+    'argocd app sync openclaw --prune \\\n     --resource rbac.authorization.k8s.io:ClusterRoleBinding:openclaw-vm-cluster-admin',
+    'get clusterrolebinding openclaw-vm-cluster-admin --ignore-not-found -o name',
     'argocd app sync openclaw --prune=false',
     'openclaw_vmi_name=$(kubectl -n openclaw get virtualmachineinstance openclaw --ignore-not-found -o name)',
+    'op item get --vault infra hermes-runtime --format json',
+    'jq --rawfile discord_bot_token <(printf \'%s\' "$discord_bot_token")',
+    '--rawfile discord_allowed_users <(printf \'%s\' "$discord_allowed_users")',
+    'def upsert_field($id; $type; $label; $value):',
+    'error("duplicate field: " + $label)',
+    'upsert_field("DISCORD_BOT_TOKEN"; "CONCEALED"; "DISCORD_BOT_TOKEN"; $discord_bot_token)',
+    'upsert_field("DISCORD_ALLOWED_USERS"; "STRING"; "DISCORD_ALLOWED_USERS"; $discord_allowed_users)',
+    'op item edit --vault infra hermes-runtime',
+    'jq -e --rawfile expected_discord_bot_token <(printf \'%s\' "$discord_bot_token")',
+    '--rawfile expected_discord_allowed_users <(printf \'%s\' "$discord_allowed_users")',
+    '.value == $expected_discord_bot_token',
+    '.value == $expected_discord_allowed_users',
+    '.label == "DISCORD_BOT_TOKEN"',
+    '.label == "DISCORD_ALLOWED_USERS"',
+    '| length == 1) and',
+    'cleanup_discord_credentials',
     'Sync Hermes from merged `main` only after the OpenClaw VMI is gone',
+    'test "$discord_secret_keys" = API_SERVER_KEY,DISCORD_ALLOWED_USERS,DISCORD_BOT_TOKEN',
+    "rg -m1 '\\[discord\\] Connected as '",
+  ])
+  forbidTerms(failures, productionPaths.runbook, cutoverSection, [
+    'argocd app sync openclaw --prune=true',
+    'allow_all_users: true',
   ])
   if (cutoverSection.includes('kubectl -n openclaw wait virtualmachineinstance/openclaw --for=delete')) {
     failures.push(`${productionPaths.runbook}: cutover must treat an already-absent OpenClaw VMI as stopped`)
   }
+  const credentialCaptureIndex = cutoverSection.indexOf('discord_bot_token=$(virtctl ssh')
+  const openClawGatewayStopIndex = cutoverSection.indexOf('systemctl --user stop openclaw-gateway.service')
+  const finalReconciliationIndex = cutoverSection.indexOf('repeat Phase 2 steps 1 through 4')
+  const clusterAdminPruneIndex = cutoverSection.indexOf('argocd app sync openclaw --prune \\')
+  const clusterAdminAbsentIndex = cutoverSection.indexOf(
+    'get clusterrolebinding openclaw-vm-cluster-admin --ignore-not-found -o name',
+  )
   const cutoverOpenClawSyncIndex = cutoverSection.indexOf('argocd app sync openclaw --prune=false')
+  const openClawVmiAbsentIndex = cutoverSection.indexOf('if [ -z "$openclaw_vmi_name" ]')
+  const credentialTransferIndex = cutoverSection.indexOf('op item edit --vault infra hermes-runtime')
+  const credentialCleanupIndex = cutoverSection.lastIndexOf('\n   cleanup_discord_credentials\n')
   const cutoverHermesSyncIndex = cutoverSection.indexOf('argocd app sync hermes --prune=false')
+  const discordConnectedIndex = cutoverSection.indexOf("rg -m1 '\\[discord\\] Connected as '")
   const cutoverReleaseIndex = cutoverSection.lastIndexOf('\n   release_maintenance_lock\n')
   if (
     count(cutoverSection, maintenanceOwnershipAssertion) !== 2 ||
     count(cutoverSection, '\n   release_maintenance_lock\n') !== 1 ||
     cutoverOpenClawSyncIndex < 0 ||
     cutoverHermesSyncIndex <= cutoverOpenClawSyncIndex ||
-    cutoverReleaseIndex <= cutoverHermesSyncIndex
+    cutoverReleaseIndex <= discordConnectedIndex
   ) {
     failures.push(`${productionPaths.runbook}: cutover must hold the migration Lease until Hermes is restored`)
   }
   if (
-    cutoverSection.indexOf('systemctl --user stop openclaw-gateway.service') >
-    cutoverSection.indexOf('repeat Phase 2 steps 1 through 4')
+    credentialCaptureIndex < 0 ||
+    openClawGatewayStopIndex <= credentialCaptureIndex ||
+    finalReconciliationIndex <= openClawGatewayStopIndex ||
+    clusterAdminPruneIndex <= finalReconciliationIndex ||
+    clusterAdminAbsentIndex <= clusterAdminPruneIndex ||
+    cutoverOpenClawSyncIndex <= clusterAdminAbsentIndex ||
+    openClawVmiAbsentIndex <= cutoverOpenClawSyncIndex ||
+    credentialTransferIndex <= openClawVmiAbsentIndex ||
+    credentialCleanupIndex <= credentialTransferIndex ||
+    cutoverHermesSyncIndex <= credentialCleanupIndex ||
+    discordConnectedIndex <= cutoverHermesSyncIndex
   ) {
+    failures.push(`${productionPaths.runbook}: Discord cutover operations are out of order`)
+  }
+  if (openClawGatewayStopIndex > finalReconciliationIndex) {
     failures.push(`${productionPaths.runbook}: final reconciliation must happen after the OpenClaw gateway is stopped`)
   }
 


### PR DESCRIPTION
## Summary

- Enable Hermes Discord through exact `DISCORD_BOT_TOKEN` and numeric `DISCORD_ALLOWED_USERS` ExternalSecret mappings.
- Halt OpenClaw with the supported `runStrategy: Halted`, remove its cluster-admin binding, and retain its VM, disk, cloud-init, SSH, and scoped rollback resources.
- Add a fail-closed single-writer cutover sequence with stopped-source reconciliation, maintenance Lease ownership, resource-scoped pruning, exact credential verification, and Discord lifecycle proof.
- Stream sensitive 1Password create, edit, and rotation templates over stdin so secret values never appear in command arguments or files; make initial API-key provisioning idempotent and fail on ambiguous items.
- Extend the production validator to 28 surfaces and 66 focused tests, including manual Argo gates for both runtimes.

## Related Issues

None. Follow-up to #12896 and dependent on the enforcement gate in #12922.

## Testing

- `bun run scripts/hermes/validate-production.ts` — validated 28 production surfaces.
- `bun test scripts/hermes/*.test.ts` — 66 passed, 0 failed.
- `bunx oxlint scripts/hermes/validate-production.ts scripts/hermes/validate-production.test.ts` — 0 warnings and 0 errors.
- `shellcheck argocd/applications/hermes/*.sh scripts/hermes/*.sh` — passed.
- Extracted the Phase 0, API-key rotation, and Phase 3 Bash fences with `awk` and piped each to `bash -n` — passed.
- `kustomize build --enable-helm argocd/applications/hermes` and `kustomize build --enable-helm argocd/applications/openclaw` — passed.
- `bun run lint:argocd` — 0 invalid resources and 0 errors across all seven validation batches.
- `kustomize build --enable-helm argocd/applications/openclaw | kubectl diff -n openclaw -f -` — only the intended VM run-state migration was present; no deprecated-field warning remains.
- Read-only live preflight verified the captured OpenClaw Discord token meets the length gate and its single allowlist entry is numeric; no values were printed.

## Breaking Changes

Operational cutover only: after this PR is merged and manually synced, OpenClaw is halted, its cluster-admin binding is removed, and Hermes becomes the sole Discord writer. Both Argo applications remain manual, so merge alone does not reconcile either runtime. Do not merge or sync this PR until #12922 is merged, the live enforcement probe passes, and the API-only canary plus stopped-source migration gates in the runbook pass.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
