### PR TITLE
feat(bayn): persist recoverable simulation evidence

### DIFF
--- a/nix/images/bayn.nix
+++ b/nix/images/bayn.nix
@@ -22,8 +22,8 @@ import ./bun-workspace-service.nix {
   serviceName = "bayn";
   packageName = "@proompteng/bayn";
   depsHash = {
-    x86_64-linux = "sha256-I3WEbUlScbaonhE+tm8juu6LAoWzy4m0YokQnVRNV30=";
-    aarch64-linux = "sha256-S1/xNH45pfLBAg7wlVBrgrRn9OZm2gHxzm3H85Kck28=";
+    x86_64-linux = "sha256-vcBPDVDy9zfqEj+n4lJMkg8f6D7WwEC5IiyUylcKUhE=";
+    aarch64-linux = "sha256-uY5n3M01VfApaJXe4CYFtL6/5ZL8hZQTaHAGrv4mPRs=";
   };
   installFilters = [
     "@proompteng/bayn"

--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -31,9 +31,14 @@ and journals the resulting simulation to TigerBeetle. It contains no broker clie
   snapshot provenance, calendar version, and explicit bounds.
 - Signals are formed at a month-end close and may execute only at the next exchange session open.
 - After exact TigerBeetle reconciliation, one PostgreSQL transaction records the immutable protocol lock, input
-  snapshot reference, run identity, metrics, reconciliation receipt, ordered events, gate outcomes, and status
-  history. An exact replay returns the existing complete receipt only after every stored payload and content hash is
-  revalidated; conflicting, altered, or partial evidence fails closed.
+  snapshot reference, run identity, metrics, simulated orders, fills, cash changes, daily position marks, the full
+  equity series, independent marked-equity proof, reconciliation receipt, gate outcomes, and status history.
+- The independent reducer rebuilds protocol costs, cash, positions, and every marked-equity point with integer micros.
+  Evaluation and recovery fail if lineage diverges or fees or equity differ by more than one cent; the exact measured
+  differences remain part of the receipt.
+- On restart, Bayn derives the expected run ID from the verified Signal manifest and current executable identity. It
+  resumes only an exact, complete, runtime-decoded PostgreSQL record; missing evidence triggers one evaluation, while
+  partial, altered, or incompatible evidence fails closed without another TigerBeetle mutation.
 - A run becomes ready only after ClickHouse validation, evaluation, TigerBeetle journal creation, exact reconciliation,
   and the PostgreSQL commit. Strategy rejection is an auditable economic `FAIL_CLOSED`; dependency, accounting, or
   persistence failure keeps the Kubernetes readiness probe closed.
@@ -42,7 +47,9 @@ and journals the resulting simulation to TigerBeetle. It contains no broker clie
 
 - `GET /livez`: process liveness.
 - `GET /readyz`: dependency/evaluation/accounting readiness.
-- `GET /v1/status`: authority boundary, input manifest, metrics, verdict, and reconciliation receipt.
+- `GET /v1/status`: bounded authority, provenance, metrics, verdict, and reconciliation summary.
+- `GET /v1/evaluations/:runId`: complete content-hashed evidence for one exact run ID. The service is ClusterIP-only
+  and the Bayn network policy limits HTTP ingress to the namespace.
 
 ## Validation
 

--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -3,20 +3,55 @@ import { randomUUID } from 'node:crypto'
 import { createServer } from 'node:http'
 
 import { NodeServices } from '@effect/platform-node'
-import { Cause, Context, Effect, Exit, Fiber, Layer, Redacted, Ref } from 'effect'
+import { Cause, Context, Effect, Exit, Fiber, Layer, Option, Redacted, Ref } from 'effect'
 import { HttpServer } from 'effect/unstable/http'
 
 import { initialize, makeHttpLayer, run, type RuntimeState } from './app'
 import type { RuntimeConfig } from './config'
-import { DatabaseError, EvidenceStore, EvidenceStoreRuntimeLive, type EvidenceStoreService } from './db/evidence-store'
+import {
+  DatabaseError,
+  EvidenceStore,
+  EvidenceStoreRuntimeLive,
+  type EvidenceStoreService,
+  type StoredEvaluationEvidence,
+} from './db/evidence-store'
 import { operationalError } from './errors'
 import { Journal, type JournalService } from './ledger'
 import { MarketData, type MarketDataService } from './market-data'
-import { evaluateTsmom } from './strategy'
+import { evaluateTsmom, identifyTsmomRun, summarizeEvaluation } from './strategy'
 import { Strategy, TsmomStrategyLayer, type StrategyService } from './strategy-service'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
 
 const provenance = makeTestProvenance()
+const historicalRunId = '9'.repeat(64)
+const historicalEvidence: StoredEvaluationEvidence = {
+  protocol: {
+    protocolHash: '8'.repeat(64),
+    schemaVersion: fixtureProtocol.schemaVersion,
+    strategyName: 'tsmom',
+    behaviorHash: provenance.strategy.behaviorHash,
+    parameterHash: provenance.strategy.parameterHash,
+    parameters: fixtureProtocol,
+  },
+  run: {
+    runId: historicalRunId,
+    protocolHash: '8'.repeat(64),
+    snapshotId: '7'.repeat(64),
+    evaluationSchemaVersion: 'bayn.evaluation.v2',
+    sourceRevision: provenance.sourceRevision,
+    imageRepository: provenance.image.repository,
+    imageDigest: provenance.image.digest,
+    strategyName: 'tsmom',
+    initialCapitalMicros: '1000000000000',
+    artifactCount: 0,
+    eventCount: 0,
+    gateCount: 0,
+  },
+  artifacts: [],
+  events: [],
+  gates: [],
+  statuses: [],
+}
 
 const config: RuntimeConfig = {
   host: '127.0.0.1',
@@ -67,11 +102,13 @@ const successfulJournal: JournalService = {
 
 const successfulEvidenceStore: EvidenceStoreService = {
   check: Effect.void,
+  read: (runId) => Effect.succeed(runId === historicalRunId ? Option.some(historicalEvidence) : Option.none()),
+  recover: () => Effect.succeed(Option.none()),
   persist: ({ evaluation }) =>
     Effect.succeed({
       runId: evaluation.runId,
       deduplicated: false,
-      artifactCount: 6,
+      artifactCount: 12,
       eventCount: evaluation.events.length,
       gateCount: evaluation.verdict.gates.length,
     }),
@@ -119,18 +156,23 @@ const waitForStatus = async (port: number, expectedStatus: string) => {
 const readyState = (): RuntimeState => {
   const snapshot = makeSnapshot()
   const evaluation = evaluateTsmom(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance)
-  const { events, ...evaluationWithoutEvents } = evaluation
   return {
     status: 'READY',
     evidence: {
+      startupMode: 'evaluated',
       provenance,
-      evaluation: { ...evaluationWithoutEvents, eventCount: events.length },
-      reconciliation: { runId: evaluation.runId, accountCount: 13, transferCount: events.length, exact: true },
+      evaluation: summarizeEvaluation(evaluation),
+      reconciliation: {
+        runId: evaluation.runId,
+        accountCount: 13,
+        transferCount: evaluation.events.length,
+        exact: true,
+      },
       persistence: {
         runId: evaluation.runId,
         deduplicated: false,
-        artifactCount: 6,
-        eventCount: events.length,
+        artifactCount: 12,
+        eventCount: evaluation.events.length,
         gateCount: evaluation.verdict.gates.length,
       },
     },
@@ -146,7 +188,13 @@ describe('Bayn HTTP probes', () => {
         Effect.gen(function* () {
           const state = yield* Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null })
           const context = yield* Layer.build(
-            makeHttpLayer({ host: '127.0.0.1', port: 0 }, state, provenance, 'embedded'),
+            makeHttpLayer(
+              { host: '127.0.0.1', operationTimeoutMs: 250, port: 0 },
+              state,
+              provenance,
+              'embedded',
+              successfulEvidenceStore,
+            ),
           )
           const address = Context.get(context, HttpServer.HttpServer).address
           if (address._tag !== 'TcpAddress') throw new Error('test server did not bind a TCP port')
@@ -178,6 +226,18 @@ describe('Bayn HTTP probes', () => {
               evidence: { provenance },
             },
           })
+          expect(yield* Effect.promise(() => fetchJson(port, `/v1/evaluations/${historicalRunId}`))).toMatchObject({
+            status: 200,
+            body: { run: { runId: historicalRunId } },
+          })
+          expect(yield* Effect.promise(() => fetchJson(port, '/v1/evaluations/not-a-run'))).toMatchObject({
+            status: 400,
+            body: { error: 'invalid_run_id' },
+          })
+          expect(yield* Effect.promise(() => fetchJson(port, `/v1/evaluations/${'f'.repeat(64)}`))).toMatchObject({
+            status: 404,
+            body: { error: 'evaluation_not_found' },
+          })
           yield* Ref.set(state, { status: 'FAIL_CLOSED', evidence: null, error: 'test failure' })
           expect(yield* Effect.promise(() => fetchJson(port, '/readyz'))).toMatchObject({
             status: 503,
@@ -208,9 +268,169 @@ describe('Bayn HTTP probes', () => {
     }
     expect(rejected).toBe(true)
   })
+
+  test('returns service unavailable when durable evidence cannot be read', async () => {
+    const unavailableStore: EvidenceStoreService = {
+      ...successfulEvidenceStore,
+      read: () =>
+        Effect.fail(
+          new DatabaseError({
+            failure: 'unavailable',
+            operation: 'read-evidence',
+            message: 'database unavailable',
+          }),
+        ),
+    }
+
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const state = yield* Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null })
+          const context = yield* Layer.build(
+            makeHttpLayer(
+              { host: '127.0.0.1', operationTimeoutMs: 250, port: 0 },
+              state,
+              provenance,
+              'embedded',
+              unavailableStore,
+            ),
+          )
+          const address = Context.get(context, HttpServer.HttpServer).address
+          if (address._tag !== 'TcpAddress') throw new Error('test server did not bind a TCP port')
+
+          expect(
+            yield* Effect.promise(() => fetchJson(address.port, `/v1/evaluations/${historicalRunId}`)),
+          ).toMatchObject({ status: 503, body: { error: 'evidence_unavailable' } })
+        }),
+      ),
+    )
+  })
 })
 
 describe('Bayn startup lifecycle', () => {
+  test('recovers a complete run without evaluating, journaling, or persisting again', async () => {
+    const snapshot = makeSnapshot()
+    const evaluation = evaluateTsmom(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance)
+    let evaluations = 0
+    let journalWrites = 0
+    let persistenceWrites = 0
+    const strategy: StrategyService = {
+      name: 'tsmom',
+      universe: fixtureProtocol.universe,
+      parameters: fixtureProtocol,
+      provenance,
+      identify: () => evaluation.runId,
+      evaluate: () => {
+        evaluations += 1
+        return evaluation
+      },
+    }
+    const journal: JournalService = {
+      check: Effect.void,
+      journalAndReconcile: () => {
+        journalWrites += 1
+        return Effect.die(new Error('recovered startup must not journal'))
+      },
+    }
+    const store: EvidenceStoreService = {
+      ...successfulEvidenceStore,
+      recover: () =>
+        Effect.succeed(
+          Option.some({
+            evaluation: summarizeEvaluation(evaluation),
+            reconciliation: { runId: evaluation.runId, accountCount: 13, transferCount: 321, exact: true },
+            persistence: {
+              runId: evaluation.runId,
+              deduplicated: true,
+              artifactCount: 12,
+              eventCount: evaluation.events.length,
+              gateCount: evaluation.verdict.gates.length,
+            },
+          }),
+        ),
+      persist: () => {
+        persistenceWrites += 1
+        return Effect.die(new Error('recovered startup must not persist'))
+      },
+    }
+    const state = await Effect.runPromise(Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null }))
+
+    await Effect.runPromise(
+      initialize(config, state).pipe(
+        Effect.provideService(MarketData, { load: Effect.succeed(snapshot) }),
+        Effect.provideService(Journal, journal),
+        Effect.provideService(EvidenceStore, store),
+        Effect.provideService(Strategy, strategy),
+      ),
+    )
+
+    expect({ evaluations, journalWrites, persistenceWrites }).toEqual({
+      evaluations: 0,
+      journalWrites: 0,
+      persistenceWrites: 0,
+    })
+    expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
+      status: 'READY',
+      evidence: {
+        startupMode: 'recovered',
+        evaluation: { runId: evaluation.runId },
+        persistence: { deduplicated: true },
+      },
+    })
+  })
+
+  test('fails closed instead of re-evaluating a corrupt matching durable run', async () => {
+    const snapshot = makeSnapshot()
+    let evaluations = 0
+    let journalWrites = 0
+    const strategy: StrategyService = {
+      name: 'tsmom',
+      universe: fixtureProtocol.universe,
+      parameters: fixtureProtocol,
+      provenance,
+      identify: (manifest) => identifyTsmomRun(manifest, fixtureProtocol, provenance),
+      evaluate: () => {
+        evaluations += 1
+        throw new Error('corrupt recovery must not fall back to evaluation')
+      },
+    }
+    const store: EvidenceStoreService = {
+      ...successfulEvidenceStore,
+      recover: () =>
+        Effect.fail(
+          new DatabaseError({
+            failure: 'invariant',
+            operation: 'recover-evidence',
+            message: 'stored artifact hash diverged',
+          }),
+        ),
+    }
+    const journal: JournalService = {
+      check: Effect.void,
+      journalAndReconcile: () => {
+        journalWrites += 1
+        return Effect.die(new Error('corrupt recovery must not journal'))
+      },
+    }
+    const state = await Effect.runPromise(Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null }))
+
+    await Effect.runPromise(
+      initialize(config, state).pipe(
+        Effect.provideService(MarketData, { load: Effect.succeed(snapshot) }),
+        Effect.provideService(Journal, journal),
+        Effect.provideService(EvidenceStore, store),
+        Effect.provideService(Strategy, strategy),
+      ),
+    )
+
+    expect({ evaluations, journalWrites }).toEqual({ evaluations: 0, journalWrites: 0 })
+    expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
+      status: 'FAIL_CLOSED',
+      evidence: null,
+      error: expect.stringContaining('database.recover-evaluation'),
+    })
+  })
+
   test('evaluates through the provided strategy capability', async () => {
     let calls = 0
     const snapshot = makeSnapshot()
@@ -220,6 +440,7 @@ describe('Bayn startup lifecycle', () => {
       universe: fixtureProtocol.universe,
       parameters: fixtureProtocol,
       provenance,
+      identify: (manifest) => identifyTsmomRun(manifest, fixtureProtocol, provenance),
       evaluate: (bars, manifest) => {
         calls += 1
         return evaluateTsmom(bars, manifest, fixtureProtocol, provenance)
@@ -358,6 +579,8 @@ describe('Bayn startup lifecycle', () => {
     const state = await Effect.runPromise(Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null }))
     const unavailable: EvidenceStoreService = {
       check: Effect.void,
+      read: () => Effect.succeed(Option.none()),
+      recover: () => Effect.succeed(Option.none()),
       persist: () =>
         Effect.fail(
           new DatabaseError({

--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -1,21 +1,23 @@
 import { createServer } from 'node:http'
 
 import { NodeHttpServer } from '@effect/platform-node'
-import { Effect, Layer, Ref } from 'effect'
+import { Effect, Layer, Option, Ref } from 'effect'
 import { HttpRouter, HttpServerRequest, HttpServerResponse } from 'effect/unstable/http'
 
 import type { RuntimeBuildMetadata, RuntimeConfig } from './config'
 import type { RuntimeProvenance } from './contracts'
-import { EvidenceStore, type PersistenceReceipt } from './db/evidence-store'
+import { EvidenceStore, type EvidenceStoreService, type PersistenceReceipt } from './db/evidence-store'
 import { formatError, operationalError, type Component, type OperationalError } from './errors'
 import { Journal } from './ledger'
 import { MarketData } from './market-data'
+import { summarizeEvaluation } from './strategy'
 import { Strategy } from './strategy-service'
-import type { EvaluationResult, ReconciliationResult } from './types'
+import type { EvaluationSummary, ReconciliationResult } from './types'
 
 interface RuntimeEvidence {
+  readonly startupMode: 'evaluated' | 'recovered'
   readonly provenance: RuntimeProvenance
-  readonly evaluation: Omit<EvaluationResult, 'events'> & { readonly eventCount: number }
+  readonly evaluation: EvaluationSummary
   readonly reconciliation: ReconciliationResult
   readonly persistence: PersistenceReceipt
 }
@@ -46,10 +48,11 @@ const jsonResponse = (body: unknown, status = 200, headers?: Readonly<Record<str
   HttpServerResponse.text(json(body), { status, contentType: 'application/json', headers })
 
 export const makeHttpLayer = (
-  config: Pick<RuntimeConfig, 'host' | 'port'>,
+  config: Pick<RuntimeConfig, 'host' | 'operationTimeoutMs' | 'port'>,
   state: Ref.Ref<RuntimeState>,
   provenance: RuntimeProvenance,
   provenanceVerification: RuntimeBuildMetadata['verification'],
+  evidenceStore: EvidenceStoreService,
 ): ReturnType<typeof NodeHttpServer.layer> => {
   const ready = Ref.get(state).pipe(
     Effect.map((current) => {
@@ -59,6 +62,31 @@ export const makeHttpLayer = (
   )
   const status = Ref.get(state).pipe(
     Effect.map((current) => jsonResponse(publicState(current, provenance, provenanceVerification))),
+  )
+  const historicalEvaluation = HttpRouter.params.pipe(
+    Effect.flatMap(({ runId }) => {
+      if (runId === undefined || !/^[0-9a-f]{64}$/.test(runId)) {
+        return Effect.succeed(jsonResponse({ error: 'invalid_run_id' }, 400))
+      }
+      return evidenceStore.read(runId).pipe(
+        Effect.timeoutOrElse({
+          duration: config.operationTimeoutMs,
+          orElse: () => Effect.fail(new Error(`evidence read timed out after ${config.operationTimeoutMs}ms`)),
+        }),
+        Effect.map((stored) =>
+          Option.match(stored, {
+            onNone: () => jsonResponse({ error: 'evaluation_not_found' }, 404),
+            onSome: (evidence) => jsonResponse(evidence),
+          }),
+        ),
+        Effect.catch((error) =>
+          Effect.logError('Bayn historical evidence read failed').pipe(
+            Effect.annotateLogs({ service: 'bayn', runId, error: error.message }),
+            Effect.as(jsonResponse({ error: 'evidence_unavailable' }, 503)),
+          ),
+        ),
+      )
+    }),
   )
   const fallback = (
     request: HttpServerRequest.HttpServerRequest,
@@ -72,6 +100,7 @@ export const makeHttpLayer = (
     HttpRouter.route<never, never>('GET', '/livez', jsonResponse({ service: 'bayn', live: true })),
     HttpRouter.route<never, never>('GET', '/readyz', ready),
     HttpRouter.route<never, never>('GET', '/v1/status', status),
+    HttpRouter.route('GET', '/v1/evaluations/:runId', historicalEvaluation),
     HttpRouter.route<never, never>('*', '*', fallback),
   ] as const)
 
@@ -151,6 +180,39 @@ const evaluateAndJournal = (
         rowCount: snapshot.manifest.rowCount,
       }),
     )
+    const expectedRunId = yield* Effect.try({
+      try: () => strategy.identify(snapshot.manifest),
+      catch: (cause) => operationalError('strategy', 'identify', `${strategy.name} run identity failed`, cause),
+    })
+    const recovered = yield* withinDeadline(
+      databaseOperation(evidenceStore.recover(expectedRunId, strategy.provenance), 'recover-evaluation'),
+      config.operationTimeoutMs,
+      'database',
+      'recover-evaluation',
+    )
+    if (Option.isSome(recovered)) {
+      yield* Ref.set(state, {
+        status: 'READY',
+        evidence: {
+          startupMode: 'recovered',
+          provenance: strategy.provenance,
+          evaluation: recovered.value.evaluation,
+          reconciliation: recovered.value.reconciliation,
+          persistence: recovered.value.persistence,
+        },
+        error: null,
+      })
+      yield* Effect.logInfo('Bayn startup proof recovered').pipe(
+        Effect.annotateLogs({
+          service: 'bayn',
+          runId: expectedRunId,
+          artifactCount: recovered.value.persistence.artifactCount,
+          eventCount: recovered.value.persistence.eventCount,
+          gateCount: recovered.value.persistence.gateCount,
+        }),
+      )
+      return
+    }
     const evaluation = yield* Effect.try({
       try: () => strategy.evaluate(snapshot.bars, snapshot.manifest),
       catch: (cause) => operationalError('strategy', 'evaluate', `${strategy.name} evaluation failed`, cause),
@@ -184,12 +246,12 @@ const evaluateAndJournal = (
       'database',
       'persist-evaluation',
     )
-    const { events, ...evaluationWithoutEvents } = evaluation
     yield* Ref.set(state, {
       status: 'READY',
       evidence: {
+        startupMode: 'evaluated',
         provenance: strategy.provenance,
-        evaluation: { ...evaluationWithoutEvents, eventCount: events.length },
+        evaluation: summarizeEvaluation(evaluation),
         reconciliation,
         persistence,
       },
@@ -202,6 +264,7 @@ const evaluateAndJournal = (
         accountCount: reconciliation.accountCount,
         transferCount: reconciliation.transferCount,
         persistenceDeduplicated: persistence.deduplicated,
+        markedEquityDifferenceMicros: evaluation.markedEquityReconciliation.differenceMicros,
       }),
     )
   }).pipe(Effect.withLogSpan('startup'))
@@ -243,10 +306,11 @@ export const run = (
   Effect.scoped(
     Effect.gen(function* () {
       const strategy = yield* Strategy
+      const evidenceStore = yield* EvidenceStore
       const state = yield* Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null })
-      yield* Layer.build(makeHttpLayer(config, state, strategy.provenance, config.build.verification)).pipe(
-        Effect.mapError((cause) => operationalError('http', 'listen', 'HTTP server failed to listen', cause)),
-      )
+      yield* Layer.build(
+        makeHttpLayer(config, state, strategy.provenance, config.build.verification, evidenceStore),
+      ).pipe(Effect.mapError((cause) => operationalError('http', 'listen', 'HTTP server failed to listen', cause)))
       yield* initialize(config, state)
       return yield* Effect.never
     }),

--- a/services/bayn/src/contracts.test.ts
+++ b/services/bayn/src/contracts.test.ts
@@ -44,7 +44,7 @@ const snapshot = {
   sessionCount: 1_510,
   contentHash: sha('3'),
   sessionsContentHash: sha('4'),
-}
+} as const
 
 const bounds = {
   schemaVersion: 'bayn.evaluation-bounds.v1' as const,
@@ -53,7 +53,7 @@ const bounds = {
   lookbackStart: '2020-01-02',
   evaluationStart: '2021-01-04',
   evaluationEnd: '2025-12-31',
-}
+} as const
 
 const material = {
   schemaVersion: 'bayn.run-identity.v1' as const,
@@ -73,7 +73,7 @@ const material = {
   finalizedSnapshot: snapshot,
   calendarVersion: snapshot.calendarVersion,
   bounds,
-}
+} as const
 
 const expectFailure = async (effect: Effect.Effect<unknown, unknown>): Promise<void> => {
   expect(Exit.isFailure(await Effect.runPromiseExit(effect))).toBe(true)
@@ -196,7 +196,7 @@ describe('Bayn runtime provenance', () => {
       contractVersions: {
         runtimeProvenance: 'bayn.runtime-provenance.v1',
         inputManifest: 'bayn.input-manifest.v2',
-        evaluation: 'bayn.evaluation.v1',
+        evaluation: 'bayn.evaluation.v2',
       },
     })
     expect(await Effect.runPromise(decodeRuntimeProvenance(provenance))).toEqual(provenance)

--- a/services/bayn/src/contracts.ts
+++ b/services/bayn/src/contracts.ts
@@ -4,7 +4,9 @@ import { canonicalHashV1, canonicalJsonV1 } from './hash'
 
 const StrictParseOptions = { onExcessProperty: 'error' } as const
 
-const isIsoDate = (value: string): boolean => {
+type IsoDateValue = `${number}-${number}-${number}`
+
+const isIsoDate = (value: string): value is IsoDateValue => {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false
   const date = new Date(`${value}T00:00:00.000Z`)
   return !Number.isNaN(date.getTime()) && date.toISOString().slice(0, 10) === value
@@ -30,9 +32,7 @@ const NonEmptyString = Schema.String.check(
     expected: 'a non-empty string without surrounding whitespace',
   }),
 )
-export const IsoDateSchema = Schema.String.check(
-  Schema.makeFilter(isIsoDate, { expected: 'a valid ISO date (YYYY-MM-DD)' }),
-)
+export const IsoDateSchema = Schema.String.pipe(Schema.refine(isIsoDate, { expected: 'a valid ISO date (YYYY-MM-DD)' }))
 const UtcInstant = Schema.String.check(
   Schema.makeFilter(isUtcInstant, { expected: 'a canonical UTC instant (YYYY-MM-DDTHH:mm:ss.sssZ)' }),
 )
@@ -193,7 +193,7 @@ export const RuntimeProvenanceSchema = Schema.Struct({
   contractVersions: Schema.Struct({
     runtimeProvenance: Schema.Literal('bayn.runtime-provenance.v1'),
     inputManifest: Schema.Literal('bayn.input-manifest.v2'),
-    evaluation: Schema.Literal('bayn.evaluation.v1'),
+    evaluation: Schema.Literal('bayn.evaluation.v2'),
   }),
 })
 export type RuntimeProvenance = typeof RuntimeProvenanceSchema.Type
@@ -319,7 +319,7 @@ export const makeRuntimeProvenance = (input: RuntimeProvenanceInput): RuntimePro
     contractVersions: {
       runtimeProvenance: 'bayn.runtime-provenance.v1',
       inputManifest: 'bayn.input-manifest.v2',
-      evaluation: 'bayn.evaluation.v1',
+      evaluation: 'bayn.evaluation.v2',
     },
   })
 

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -176,7 +176,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     )
 
     expect(result.first).toMatchObject({ runId: input.evaluation.runId, deduplicated: false })
-    expect(result.first.artifactCount).toBe(6)
+    expect(result.first.artifactCount).toBe(12)
     expect(result.second).toEqual({ ...result.first, deduplicated: true })
     expect(result.runs).toEqual([
       {
@@ -195,6 +195,90 @@ describePostgres('PostgreSQL evaluation evidence', () => {
         required_type: typeof gate.required,
       })),
     )
+  })
+
+  test('reads and recovers the complete v2 evidence contract without evaluating it again', async () => {
+    const input = makeInput()
+    const result = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* EvidenceStore
+        yield* store.persist(input)
+        const stored = yield* store.read(input.evaluation.runId)
+        const recovered = yield* store.recover(input.evaluation.runId, input.provenance)
+        const missing = yield* store.read('f'.repeat(64))
+        return { stored, recovered, missing }
+      }),
+    )
+
+    expect(Option.isSome(result.stored)).toBe(true)
+    if (Option.isSome(result.stored)) {
+      expect(result.stored.value.protocol).toMatchObject({
+        protocolHash: input.evaluation.protocolHash,
+        schemaVersion: fixtureProtocol.schemaVersion,
+        strategyName: 'tsmom',
+        behaviorHash: input.provenance.strategy.behaviorHash,
+        parameterHash: input.provenance.strategy.parameterHash,
+        parameters: fixtureProtocol,
+      })
+      expect(result.stored.value.run).toMatchObject({
+        runId: input.evaluation.runId,
+        evaluationSchemaVersion: 'bayn.evaluation.v2',
+        artifactCount: 12,
+        eventCount: input.evaluation.events.length,
+      })
+      expect(result.stored.value.artifacts.map((artifact) => artifact.name)).toEqual([
+        'buy-and-hold',
+        'cash-changes',
+        'daily-position-marks',
+        'direct-volatility-timing',
+        'double-cost-strategy',
+        'equity-series',
+        'evaluation-summary',
+        'input-manifest',
+        'marked-equity-reconciliation',
+        'reconciliation',
+        'simulated-orders',
+        'strategy',
+      ])
+    }
+    expect(Option.isSome(result.recovered)).toBe(true)
+    if (Option.isSome(result.recovered)) {
+      expect(result.recovered.value).toMatchObject({
+        evaluation: {
+          runId: input.evaluation.runId,
+          markedEquityReconciliation: { withinTolerance: true },
+        },
+        reconciliation: { runId: input.evaluation.runId, exact: true },
+        persistence: { runId: input.evaluation.runId, deduplicated: true, artifactCount: 12 },
+      })
+    }
+    expect(Option.isNone(result.missing)).toBe(true)
+  })
+
+  test('rejects a simulation whose declared costs diverge from its locked protocol', async () => {
+    const input = makeInput()
+    const error = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* EvidenceStore
+        return yield* store
+          .persist({
+            ...input,
+            evaluation: {
+              ...input.evaluation,
+              simulation: {
+                ...input.evaluation.simulation,
+                transactionCostBpsMicros: '6000000',
+              },
+            },
+          })
+          .pipe(Effect.flip)
+      }),
+    )
+
+    expect(error).toBeInstanceOf(DatabaseError)
+    expect(error.failure).toBe('invariant')
+    expect(error.operation).toBe('plan')
+    expect(error.message).toContain('simulation transaction costs do not match')
   })
 
   test('creates distinct runs when bound runtime provenance changes', async () => {
@@ -245,7 +329,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
 
   test('rejects a complete receipt whose stored evidence was altered', async () => {
     const input = makeInput()
-    const error = await runtime.runPromise(
+    const errors = await runtime.runPromise(
       Effect.gen(function* () {
         const store = yield* EvidenceStore
         const sql = yield* PgClient.PgClient
@@ -255,13 +339,18 @@ describePostgres('PostgreSQL evaluation evidence', () => {
           SET payload = ${sql.json({ corrupted: true })}
           WHERE run_id = ${input.evaluation.runId} AND artifact_name = 'strategy'
         `
-        return yield* store.persist(input).pipe(Effect.flip)
+        const read = yield* store.read(input.evaluation.runId).pipe(Effect.flip)
+        const replay = yield* store.persist(input).pipe(Effect.flip)
+        return { read, replay }
       }),
     )
 
-    expect(error).toBeInstanceOf(DatabaseError)
-    expect(error.failure).toBe('invariant')
-    expect(error.operation).toBe('read-receipt')
+    expect(errors.read).toBeInstanceOf(DatabaseError)
+    expect(errors.read.failure).toBe('invariant')
+    expect(errors.read.operation).toBe('read-evidence')
+    expect(errors.replay).toBeInstanceOf(DatabaseError)
+    expect(errors.replay.failure).toBe('invariant')
+    expect(errors.replay.operation).toBe('read-receipt')
   })
 
   test('rejects a replay whose normalized snapshot bounds were altered', async () => {
@@ -330,14 +419,16 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     expect(error.message).toContain('stored status history diverged')
   })
 
-  test('rolls back every table when an event constraint fails', async () => {
+  test('rolls back every table when a terminal evidence constraint fails', async () => {
     const input = makeInput()
-    const duplicateId = input.evaluation.events[0].id
     const invalid: PersistEvaluationInput = {
       ...input,
       evaluation: {
         ...input.evaluation,
-        events: input.evaluation.events.map((event, index) => (index === 1 ? { ...event, id: duplicateId } : event)),
+        verdict: {
+          ...input.evaluation.verdict,
+          gates: input.evaluation.verdict.gates.map((gate, index) => (index === 0 ? { ...gate, name: '' } : gate)),
+        },
       },
     }
     const result = await runtime.runPromise(

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -375,6 +375,28 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     expect(error.message).toContain('stored snapshot reference diverged')
   })
 
+  test('fails recovery when the stored snapshot manifest was altered', async () => {
+    const input = makeInput()
+    const error = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* EvidenceStore
+        const sql = yield* PgClient.PgClient
+        yield* store.persist(input)
+        yield* sql`
+          UPDATE bayn_snapshot_references
+          SET manifest = ${sql.json({ corrupted: true })}
+          WHERE snapshot_id = ${input.evaluation.inputManifest.finalizedSnapshot.snapshotId}
+        `
+        return yield* store.recover(input.evaluation.runId, input.provenance).pipe(Effect.flip)
+      }),
+    )
+
+    expect(error).toBeInstanceOf(DatabaseError)
+    expect(error.failure).toBe('invariant')
+    expect(error.operation).toBe('recover-evidence')
+    expect(error.message).toContain('stored snapshot reference diverged')
+  })
+
   test('rejects a replay whose initial capital was altered', async () => {
     const input = makeInput()
     const error = await runtime.runPromise(

--- a/services/bayn/src/db/evidence-store.ts
+++ b/services/bayn/src/db/evidence-store.ts
@@ -1,12 +1,26 @@
 import { PgClient, PgMigrator } from '@effect/sql-pg'
-import { Context, Data, Effect, FileSystem, Layer, Schema } from 'effect'
+import { Context, Data, Effect, FileSystem, Layer, Option, Schema } from 'effect'
 import { SqlSchema } from 'effect/unstable/sql'
 import { isSqlError } from 'effect/unstable/sql/SqlError'
 
 import type { RuntimeConfig } from '../config'
 import { makeRunIdentity, makeStrategyProtocolHash, type RuntimeProvenance } from '../contracts'
+import {
+  decodeCashChangesArtifact,
+  decodeDailyPositionMarksArtifact,
+  decodeEquitySeriesArtifact,
+  decodeEvaluationEvents,
+  decodeEvaluationSummary,
+  decodeInputManifestArtifact,
+  decodeMarkedEquityReconciliation,
+  decodeReconciliationResult,
+  decodeSimulatedOrdersArtifact,
+  makeEquitySeriesArtifact,
+} from '../evidence-contracts'
 import { canonicalHashV1 } from '../hash'
-import type { EvaluationResult, ReconciliationResult } from '../types'
+import { reconcileMarkedEquity } from '../simulation-reconciliation'
+import { summarizeEvaluation } from '../strategy'
+import type { EvaluationResult, EvaluationSummary, ReconciliationResult } from '../types'
 import { migrationLoader } from './migrations'
 
 export type DatabaseFailure = 'constraint' | 'decode' | 'invariant' | 'migration' | 'query' | 'unavailable'
@@ -36,9 +50,70 @@ export interface PersistEvaluationInput {
 export interface EvidenceStoreService {
   readonly check: Effect.Effect<void, DatabaseError>
   readonly persist: (input: PersistEvaluationInput) => Effect.Effect<PersistenceReceipt, DatabaseError>
+  readonly read: (runId: string) => Effect.Effect<Option.Option<StoredEvaluationEvidence>, DatabaseError>
+  readonly recover: (
+    runId: string,
+    provenance: RuntimeProvenance,
+  ) => Effect.Effect<Option.Option<RecoveredEvaluationEvidence>, DatabaseError>
 }
 
 export class EvidenceStore extends Context.Service<EvidenceStore, EvidenceStoreService>()('bayn/EvidenceStore') {}
+
+export interface StoredEvaluationEvidence {
+  readonly protocol: {
+    readonly protocolHash: string
+    readonly schemaVersion: string
+    readonly strategyName: string
+    readonly behaviorHash: string
+    readonly parameterHash: string
+    readonly parameters: unknown
+  }
+  readonly run: {
+    readonly runId: string
+    readonly protocolHash: string
+    readonly snapshotId: string
+    readonly evaluationSchemaVersion: string
+    readonly sourceRevision: string
+    readonly imageRepository: string
+    readonly imageDigest: string
+    readonly strategyName: string
+    readonly initialCapitalMicros: string
+    readonly artifactCount: number
+    readonly eventCount: number
+    readonly gateCount: number
+  }
+  readonly artifacts: readonly {
+    readonly name: string
+    readonly schemaVersion: string
+    readonly contentHash: string
+    readonly payload: unknown
+  }[]
+  readonly events: readonly {
+    readonly ordinal: number
+    readonly id: string
+    readonly kind: 'decision' | 'fill'
+    readonly contentHash: string
+    readonly payload: unknown
+  }[]
+  readonly gates: readonly {
+    readonly ordinal: number
+    readonly name: string
+    readonly passed: boolean
+    readonly actual: unknown
+    readonly required: unknown
+    readonly contentHash: string
+  }[]
+  readonly statuses: readonly {
+    readonly status: 'WRITING' | 'COMPLETE'
+    readonly detail: unknown
+  }[]
+}
+
+export interface RecoveredEvaluationEvidence {
+  readonly evaluation: EvaluationSummary
+  readonly reconciliation: ReconciliationResult
+  readonly persistence: PersistenceReceipt
+}
 
 interface ArtifactPlan {
   readonly name: string
@@ -190,12 +265,32 @@ const runDatabase = <A, E, R>(operation: string, effect: Effect.Effect<A, E, R>)
 const ensure = (condition: boolean, operation: string, message: string): Effect.Effect<void, DatabaseError> =>
   condition ? Effect.void : Effect.fail(databaseError('invariant', operation, message))
 
+const protocolTransactionCostBpsMicros = (parameters: unknown): string => {
+  if (
+    typeof parameters !== 'object' ||
+    parameters === null ||
+    !('transactionCostBps' in parameters) ||
+    typeof parameters.transactionCostBps !== 'number' ||
+    !Number.isFinite(parameters.transactionCostBps) ||
+    parameters.transactionCostBps < 0 ||
+    parameters.transactionCostBps > 10_000
+  ) {
+    throw new TypeError('strategy parameters do not declare valid transaction costs')
+  }
+  const micros = parameters.transactionCostBps * 1_000_000
+  if (!Number.isSafeInteger(micros)) throw new TypeError('transaction costs exceed fixed-point precision')
+  return BigInt(micros).toString()
+}
+
 const makePersistencePlan = (input: PersistEvaluationInput): PersistencePlan => {
   const { evaluation, parameters, provenance, reconciliation } = input
   const strategyName = provenance.strategy.name
   const parameterHash = canonicalHashV1(parameters)
   if (parameterHash !== provenance.strategy.parameterHash) {
     throw new TypeError('strategy parameters and provenance disagree on parameter hash')
+  }
+  if (evaluation.simulation.transactionCostBpsMicros !== protocolTransactionCostBpsMicros(parameters)) {
+    throw new TypeError('simulation transaction costs do not match strategy parameters')
   }
   const protocolHash = makeStrategyProtocolHash(provenance.strategy)
   if (protocolHash !== evaluation.protocolHash)
@@ -226,12 +321,53 @@ const makePersistencePlan = (input: PersistEvaluationInput): PersistencePlan => 
   }).runId
   if (evaluation.runId !== expectedRunId) throw new TypeError('run ID does not match runtime and input provenance')
 
+  const equityProof = reconcileMarkedEquity({
+    runId: evaluation.runId,
+    initialCapitalMicros: evaluation.initialCapitalMicros,
+    evaluatorTotalFeesMicros: evaluation.strategy.totalFeesMicros,
+    evaluatorEndingEquityMicros: evaluation.strategy.endingEquityMicros,
+    events: evaluation.events,
+    simulation: evaluation.simulation,
+  })
+  if (
+    canonicalHashV1(equityProof.reconciliation) !== canonicalHashV1(evaluation.markedEquityReconciliation) ||
+    canonicalHashV1(equityProof.equitySeries) !== canonicalHashV1(evaluation.equitySeries)
+  ) {
+    throw new TypeError('independent marked-equity proof diverges from the evaluation evidence')
+  }
+
   const artifacts = [
+    ['evaluation-summary', 'bayn.evaluation-summary.v1', summarizeEvaluation(evaluation)],
     ['input-manifest', evaluation.inputManifest.schemaVersion, evaluation.inputManifest],
     ['strategy', 'bayn.performance-metrics.v1', evaluation.strategy],
     ['buy-and-hold', 'bayn.performance-metrics.v1', evaluation.buyAndHold],
     ['direct-volatility-timing', 'bayn.performance-metrics.v1', evaluation.directVolTiming],
     ['double-cost-strategy', 'bayn.performance-metrics.v1', evaluation.doubleCostStrategy],
+    [
+      'simulated-orders',
+      'bayn.simulated-orders.v1',
+      {
+        schemaVersion: 'bayn.simulated-orders.v1',
+        transactionCostBpsMicros: evaluation.simulation.transactionCostBpsMicros,
+        items: evaluation.simulation.orders,
+      },
+    ],
+    [
+      'cash-changes',
+      'bayn.cash-changes.v1',
+      { schemaVersion: 'bayn.cash-changes.v1', items: evaluation.simulation.cashChanges },
+    ],
+    [
+      'daily-position-marks',
+      'bayn.daily-position-marks.v1',
+      { schemaVersion: 'bayn.daily-position-marks.v1', items: evaluation.simulation.dailyMarks },
+    ],
+    ['equity-series', 'bayn.equity-series.v1', makeEquitySeriesArtifact(evaluation.equitySeries)],
+    [
+      'marked-equity-reconciliation',
+      evaluation.markedEquityReconciliation.schemaVersion,
+      evaluation.markedEquityReconciliation,
+    ],
     ['reconciliation', 'bayn.reconciliation.v1', reconciliation],
   ].map(([name, schemaVersion, payload]) => ({
     name: name as string,
@@ -367,7 +503,7 @@ const makeEvidenceStore = Effect.gen(function* () {
       RETURNING run.run_id
     `,
   })
-  const getReceipt = SqlSchema.findOne({
+  const getReceipt = SqlSchema.findAll({
     Request: RunRequest,
     Result: ReceiptRow,
     execute: ({ runId }) => sql`
@@ -432,7 +568,9 @@ const makeEvidenceStore = Effect.gen(function* () {
 
   const readReceipt = (plan: PersistencePlan, deduplicated: boolean) =>
     Effect.gen(function* () {
-      const row = yield* getReceipt({ runId: plan.evaluation.runId })
+      const rows = yield* getReceipt({ runId: plan.evaluation.runId })
+      yield* ensure(rows.length === 1, 'read-receipt', 'stored run receipt is missing or duplicated')
+      const row = rows[0]
       yield* ensure(row.protocol_hash === plan.protocolHash, 'read-receipt', 'stored protocol reference diverged')
       yield* ensure(row.snapshot_id === plan.snapshotId, 'read-receipt', 'stored snapshot reference diverged')
       yield* ensure(
@@ -537,6 +675,291 @@ const makeEvidenceStore = Effect.gen(function* () {
         gateCount: row.gate_count,
       }
     })
+
+  const readStored = (runId: string) =>
+    Effect.gen(function* () {
+      const rows = yield* getReceipt({ runId })
+      if (rows.length === 0) return Option.none<StoredEvaluationEvidence>()
+      yield* ensure(rows.length === 1, 'read-evidence', 'stored run receipt is duplicated')
+      const row = rows[0]
+      const protocol = yield* getProtocol({ protocolHash: row.protocol_hash })
+      const artifacts = yield* getArtifactReferences({ runId })
+      const events = yield* getEventReferences({ runId })
+      const gates = yield* getGateReferences({ runId })
+      const statuses = yield* getStatusReferences({ runId })
+
+      yield* ensure(
+        row.strategy_name === protocol.strategy_name &&
+          canonicalHashV1(protocol.parameters) === protocol.parameter_hash,
+        'read-evidence',
+        'stored protocol lock diverged',
+      )
+
+      yield* ensure(
+        artifacts.length === row.expected_artifact_count && artifacts.length === row.artifact_count,
+        'read-evidence',
+        'stored artifact count is incomplete',
+      )
+      yield* ensure(
+        events.length === row.expected_event_count && events.length === row.event_count,
+        'read-evidence',
+        'stored event count is incomplete',
+      )
+      yield* ensure(
+        gates.length === row.expected_gate_count && gates.length === row.gate_count,
+        'read-evidence',
+        'stored gate count is incomplete',
+      )
+      yield* ensure(
+        artifacts.every((artifact) => canonicalHashV1(artifact.payload) === artifact.content_hash),
+        'read-evidence',
+        'stored artifact content hash diverged',
+      )
+      yield* ensure(
+        events.every(
+          (event, index) => event.ordinal === index && canonicalHashV1(event.payload) === event.content_hash,
+        ),
+        'read-evidence',
+        'stored event content hash or ordering diverged',
+      )
+      yield* ensure(
+        gates.every(
+          (gate, index) =>
+            gate.ordinal === index &&
+            canonicalHashV1({
+              name: gate.gate_name,
+              passed: gate.passed,
+              actual: gate.actual,
+              required: gate.required,
+            }) === gate.content_hash,
+        ),
+        'read-evidence',
+        'stored gate content hash or ordering diverged',
+      )
+      const completeDetail = statuses[1]?.detail
+      const completeDetailValid =
+        typeof completeDetail === 'object' &&
+        completeDetail !== null &&
+        'reconciliationExact' in completeDetail &&
+        completeDetail.reconciliationExact === true &&
+        'verdict' in completeDetail &&
+        (completeDetail.verdict === 'PASS' || completeDetail.verdict === 'FAIL_CLOSED')
+      yield* ensure(
+        statuses.length === 2 &&
+          statuses[0].status === 'WRITING' &&
+          canonicalHashV1(statuses[0].detail) ===
+            canonicalHashV1({
+              artifactCount: row.artifact_count,
+              eventCount: row.event_count,
+              gateCount: row.gate_count,
+            }) &&
+          statuses[1].status === 'COMPLETE' &&
+          completeDetailValid,
+        'read-evidence',
+        'stored status history is incomplete or divergent',
+      )
+
+      return Option.some({
+        protocol: {
+          protocolHash: protocol.protocol_hash,
+          schemaVersion: protocol.schema_version,
+          strategyName: protocol.strategy_name,
+          behaviorHash: protocol.behavior_hash,
+          parameterHash: protocol.parameter_hash,
+          parameters: protocol.parameters,
+        },
+        run: {
+          runId: row.run_id,
+          protocolHash: row.protocol_hash,
+          snapshotId: row.snapshot_id,
+          evaluationSchemaVersion: row.evaluation_schema_version,
+          sourceRevision: row.source_revision,
+          imageRepository: row.image_repository,
+          imageDigest: row.image_digest,
+          strategyName: row.strategy_name,
+          initialCapitalMicros: row.initial_capital_micros,
+          artifactCount: row.artifact_count,
+          eventCount: row.event_count,
+          gateCount: row.gate_count,
+        },
+        artifacts: artifacts.map((artifact) => ({
+          name: artifact.artifact_name,
+          schemaVersion: artifact.schema_version,
+          contentHash: artifact.content_hash,
+          payload: artifact.payload,
+        })),
+        events: events.map((event) => ({
+          ordinal: event.ordinal,
+          id: event.event_id,
+          kind: event.event_kind,
+          contentHash: event.content_hash,
+          payload: event.payload,
+        })),
+        gates: gates.map((gate) => ({
+          ordinal: gate.ordinal,
+          name: gate.gate_name,
+          passed: gate.passed,
+          actual: gate.actual,
+          required: gate.required,
+          contentHash: gate.content_hash,
+        })),
+        statuses,
+      } satisfies StoredEvaluationEvidence)
+    })
+
+  const read = (runId: string) => runDatabase('read-evidence', readStored(runId))
+
+  const recover = (runId: string, provenance: RuntimeProvenance) =>
+    runDatabase(
+      'recover-evidence',
+      Effect.gen(function* () {
+        const storedOption = yield* readStored(runId)
+        if (Option.isNone(storedOption)) return Option.none<RecoveredEvaluationEvidence>()
+        const stored = storedOption.value
+        const requiredArtifacts = new Map([
+          ['buy-and-hold', 'bayn.performance-metrics.v1'],
+          ['cash-changes', 'bayn.cash-changes.v1'],
+          ['daily-position-marks', 'bayn.daily-position-marks.v1'],
+          ['direct-volatility-timing', 'bayn.performance-metrics.v1'],
+          ['double-cost-strategy', 'bayn.performance-metrics.v1'],
+          ['equity-series', 'bayn.equity-series.v1'],
+          ['evaluation-summary', 'bayn.evaluation-summary.v1'],
+          ['input-manifest', 'bayn.input-manifest.v2'],
+          ['marked-equity-reconciliation', 'bayn.marked-equity-reconciliation.v1'],
+          ['reconciliation', 'bayn.reconciliation.v1'],
+          ['simulated-orders', 'bayn.simulated-orders.v1'],
+          ['strategy', 'bayn.performance-metrics.v1'],
+        ])
+        const artifacts = new Map(stored.artifacts.map((artifact) => [artifact.name, artifact]))
+        yield* ensure(
+          artifacts.size === requiredArtifacts.size &&
+            [...requiredArtifacts].every(
+              ([name, schemaVersion]) => artifacts.get(name)?.schemaVersion === schemaVersion,
+            ),
+          'recover-evidence',
+          'stored run does not have the exact v2 artifact contract',
+        )
+        yield* ensure(
+          stored.run.runId === runId &&
+            stored.run.evaluationSchemaVersion === 'bayn.evaluation.v2' &&
+            stored.run.sourceRevision === provenance.sourceRevision &&
+            stored.run.imageRepository === provenance.image.repository &&
+            stored.run.imageDigest === provenance.image.digest &&
+            stored.run.strategyName === provenance.strategy.name &&
+            stored.run.protocolHash === makeStrategyProtocolHash(provenance.strategy),
+          'recover-evidence',
+          'stored run does not match the current runtime identity',
+        )
+        const evaluation = yield* decodeEvaluationSummary(artifacts.get('evaluation-summary')!.payload)
+        const reconciliation = yield* decodeReconciliationResult(artifacts.get('reconciliation')!.payload)
+        const markedEquity = yield* decodeMarkedEquityReconciliation(
+          artifacts.get('marked-equity-reconciliation')!.payload,
+        )
+        const equitySeries = yield* decodeEquitySeriesArtifact(artifacts.get('equity-series')!.payload)
+        const events = yield* decodeEvaluationEvents(stored.events.map((event) => event.payload))
+        const orders = yield* decodeSimulatedOrdersArtifact(artifacts.get('simulated-orders')!.payload)
+        const storedTransactionCostBpsMicros = yield* Effect.try({
+          try: () => protocolTransactionCostBpsMicros(stored.protocol.parameters),
+          catch: (cause) =>
+            databaseError('invariant', 'recover-evidence', 'stored transaction-cost model is invalid', cause),
+        })
+        yield* ensure(
+          stored.protocol.schemaVersion === provenance.strategy.parameterSchemaVersion &&
+            stored.protocol.strategyName === provenance.strategy.name &&
+            stored.protocol.behaviorHash === provenance.strategy.behaviorHash &&
+            stored.protocol.parameterHash === provenance.strategy.parameterHash &&
+            canonicalHashV1(stored.protocol.parameters) === provenance.strategy.parameterHash &&
+            storedTransactionCostBpsMicros === orders.transactionCostBpsMicros,
+          'recover-evidence',
+          'stored protocol lock or transaction-cost model diverged',
+        )
+        const cashChanges = yield* decodeCashChangesArtifact(artifacts.get('cash-changes')!.payload)
+        const dailyMarks = yield* decodeDailyPositionMarksArtifact(artifacts.get('daily-position-marks')!.payload)
+        const inputManifest = yield* decodeInputManifestArtifact(artifacts.get('input-manifest')!.payload)
+        const equityProof = yield* Effect.try({
+          try: () =>
+            reconcileMarkedEquity({
+              runId,
+              initialCapitalMicros: evaluation.initialCapitalMicros,
+              evaluatorTotalFeesMicros: evaluation.strategy.totalFeesMicros,
+              evaluatorEndingEquityMicros: evaluation.strategy.endingEquityMicros,
+              events,
+              simulation: {
+                schemaVersion: 'bayn.simulation-trace.v1',
+                transactionCostBpsMicros: orders.transactionCostBpsMicros,
+                orders: orders.items,
+                cashChanges: cashChanges.items,
+                dailyMarks: dailyMarks.items,
+              },
+            }),
+          catch: (cause) =>
+            databaseError('invariant', 'recover-evidence', 'stored marked-equity reconstruction failed', cause),
+        })
+        const finalPoint = equitySeries.items.at(-1)!
+        yield* ensure(
+          evaluation.runId === runId &&
+            evaluation.codeRevision === provenance.sourceRevision &&
+            evaluation.protocolHash === stored.run.protocolHash &&
+            evaluation.initialCapitalMicros === stored.run.initialCapitalMicros &&
+            evaluation.input.snapshotId === stored.run.snapshotId &&
+            evaluation.input.snapshotId === inputManifest.finalizedSnapshot.snapshotId &&
+            evaluation.input.publicationId === inputManifest.finalizedSnapshot.publicationId &&
+            evaluation.input.manifestHash === inputManifest.hash &&
+            canonicalHashV1(evaluation.input.bounds) === canonicalHashV1(inputManifest.bounds) &&
+            evaluation.input.rowCount === inputManifest.rowCount &&
+            evaluation.input.sessionCount === inputManifest.sessionCount &&
+            canonicalHashV1(evaluation.input.symbols) ===
+              canonicalHashV1(inputManifest.symbols.map((coverage) => coverage.symbol)) &&
+            evaluation.eventCount === stored.run.eventCount &&
+            evaluation.eventCount === events.length &&
+            evaluation.orderCount === orders.items.length &&
+            evaluation.cashChangeCount === cashChanges.items.length &&
+            evaluation.dailyMarkCount === dailyMarks.items.length &&
+            evaluation.dailyMarkCount === evaluation.strategy.observations &&
+            evaluation.markedEquityReconciliation.runId === runId &&
+            canonicalHashV1(evaluation.markedEquityReconciliation) === canonicalHashV1(markedEquity) &&
+            canonicalHashV1(evaluation.strategy) === artifacts.get('strategy')!.contentHash &&
+            canonicalHashV1(evaluation.buyAndHold) === artifacts.get('buy-and-hold')!.contentHash &&
+            canonicalHashV1(evaluation.directVolTiming) === artifacts.get('direct-volatility-timing')!.contentHash &&
+            canonicalHashV1(evaluation.doubleCostStrategy) === artifacts.get('double-cost-strategy')!.contentHash &&
+            stored.gates.length === evaluation.verdict.gates.length &&
+            stored.gates.every(
+              (gate, index) =>
+                canonicalHashV1({
+                  name: gate.name,
+                  passed: gate.passed,
+                  actual: gate.actual,
+                  required: gate.required,
+                }) === canonicalHashV1(evaluation.verdict.gates[index]),
+            ) &&
+            stored.events.every((event, index) => event.id === events[index].id && event.kind === events[index].kind) &&
+            reconciliation.runId === runId &&
+            markedEquity.runId === runId &&
+            equitySeries.items.length === evaluation.dailyMarkCount &&
+            canonicalHashV1(equityProof.reconciliation) === canonicalHashV1(markedEquity) &&
+            canonicalHashV1(equityProof.equitySeries) === canonicalHashV1(equitySeries.items) &&
+            finalPoint.evaluatorEquityMicros === markedEquity.evaluatorEndingEquityMicros &&
+            finalPoint.reconstructedEquityMicros === markedEquity.reconstructedEndingEquityMicros &&
+            finalPoint.differenceMicros === markedEquity.differenceMicros &&
+            canonicalHashV1(stored.statuses[1]?.detail) ===
+              canonicalHashV1({ reconciliationExact: true, verdict: evaluation.verdict.status }),
+          'recover-evidence',
+          'stored v2 evidence components diverge',
+        )
+
+        return Option.some({
+          evaluation,
+          reconciliation,
+          persistence: {
+            runId,
+            deduplicated: true,
+            artifactCount: stored.run.artifactCount,
+            eventCount: stored.run.eventCount,
+            gateCount: stored.run.gateCount,
+          },
+        } satisfies RecoveredEvaluationEvidence)
+      }),
+    )
 
   const persist = (input: PersistEvaluationInput) =>
     runDatabase(
@@ -750,6 +1173,8 @@ const makeEvidenceStore = Effect.gen(function* () {
   return {
     check: runDatabase('health', health(undefined).pipe(Effect.asVoid)),
     persist,
+    read,
+    recover,
   } satisfies EvidenceStoreService
 })
 
@@ -805,6 +1230,8 @@ export const EvidenceStoreRuntimeLive = (config: RuntimeConfig) =>
       Layer.succeed(EvidenceStore, {
         check: Effect.fail(error),
         persist: () => Effect.fail(error),
+        read: () => Effect.fail(error),
+        recover: () => Effect.fail(error),
       }),
     ),
   )

--- a/services/bayn/src/db/evidence-store.ts
+++ b/services/bayn/src/db/evidence-store.ts
@@ -20,7 +20,7 @@ import {
 import { canonicalHashV1 } from '../hash'
 import { reconcileMarkedEquity } from '../simulation-reconciliation'
 import { summarizeEvaluation } from '../strategy'
-import type { EvaluationResult, EvaluationSummary, ReconciliationResult } from '../types'
+import type { EvaluationResult, EvaluationSummary, InputManifest, ReconciliationResult } from '../types'
 import { migrationLoader } from './migrations'
 
 export type DatabaseFailure = 'constraint' | 'decode' | 'invariant' | 'migration' | 'query' | 'unavailable'
@@ -264,6 +264,25 @@ const runDatabase = <A, E, R>(operation: string, effect: Effect.Effect<A, E, R>)
 
 const ensure = (condition: boolean, operation: string, message: string): Effect.Effect<void, DatabaseError> =>
   condition ? Effect.void : Effect.fail(databaseError('invariant', operation, message))
+
+const snapshotReferenceMatches = (row: typeof SnapshotRow.Type, inputManifest: InputManifest): boolean => {
+  const snapshot = inputManifest.finalizedSnapshot
+  return (
+    row.snapshot_id === snapshot.snapshotId &&
+    row.schema_version === snapshot.schemaVersion &&
+    row.database_name === inputManifest.database &&
+    row.table_name === inputManifest.tables.bars &&
+    row.dataset_version === snapshot.publicationSchemaVersion &&
+    row.source === snapshot.source &&
+    row.source_feed === snapshot.sourceFeed &&
+    row.adjustment === snapshot.adjustment &&
+    row.content_hash === snapshot.contentHash &&
+    row.row_count === snapshot.rowCount &&
+    row.first_session === snapshot.firstSession &&
+    row.last_session === snapshot.lastSession &&
+    canonicalHashV1(row.manifest) === canonicalHashV1(snapshot)
+  )
+}
 
 const protocolTransactionCostBpsMicros = (parameters: unknown): string => {
   if (
@@ -876,6 +895,12 @@ const makeEvidenceStore = Effect.gen(function* () {
         const cashChanges = yield* decodeCashChangesArtifact(artifacts.get('cash-changes')!.payload)
         const dailyMarks = yield* decodeDailyPositionMarksArtifact(artifacts.get('daily-position-marks')!.payload)
         const inputManifest = yield* decodeInputManifestArtifact(artifacts.get('input-manifest')!.payload)
+        const storedSnapshot = yield* getSnapshot({ snapshotId: stored.run.snapshotId })
+        yield* ensure(
+          snapshotReferenceMatches(storedSnapshot, inputManifest),
+          'recover-evidence',
+          'stored snapshot reference diverged from the recovered input manifest',
+        )
         const equityProof = yield* Effect.try({
           try: () =>
             reconcileMarkedEquity({
@@ -1043,18 +1068,7 @@ const makeEvidenceStore = Effect.gen(function* () {
           `
             const storedSnapshot = yield* getSnapshot({ snapshotId: plan.snapshotId })
             yield* ensure(
-              storedSnapshot.schema_version === finalizedSnapshot.schemaVersion &&
-                storedSnapshot.database_name === inputManifest.database &&
-                storedSnapshot.table_name === inputManifest.tables.bars &&
-                storedSnapshot.dataset_version === finalizedSnapshot.publicationSchemaVersion &&
-                storedSnapshot.source === finalizedSnapshot.source &&
-                storedSnapshot.source_feed === finalizedSnapshot.sourceFeed &&
-                storedSnapshot.adjustment === finalizedSnapshot.adjustment &&
-                storedSnapshot.content_hash === finalizedSnapshot.contentHash &&
-                storedSnapshot.row_count === finalizedSnapshot.rowCount &&
-                storedSnapshot.first_session === finalizedSnapshot.firstSession &&
-                storedSnapshot.last_session === finalizedSnapshot.lastSession &&
-                canonicalHashV1(storedSnapshot.manifest) === canonicalHashV1(finalizedSnapshot),
+              snapshotReferenceMatches(storedSnapshot, inputManifest),
               'snapshot-reference',
               'stored snapshot reference diverged from the evaluated input manifest',
             )

--- a/services/bayn/src/evidence-contracts.ts
+++ b/services/bayn/src/evidence-contracts.ts
@@ -1,0 +1,255 @@
+import { Schema } from 'effect'
+
+import { EvaluationBoundsSchema, FinalizedSnapshotProvenanceSchema, IsoDateSchema, Sha256Schema } from './contracts'
+import { canonicalHashV1 } from './hash'
+import { MARKED_EQUITY_TOLERANCE_MICROS } from './simulation-reconciliation'
+
+const StrictParseOptions = { onExcessProperty: 'error' } as const
+const Micros = Schema.String.check(Schema.isPattern(/^\d+$/))
+const SignedMicros = Schema.String.check(Schema.isPattern(/^-?\d+$/))
+const SourceRevision = Schema.String.check(Schema.isPattern(/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/))
+const PositiveInteger = Schema.Int.check(Schema.isGreaterThan(0))
+const Scalar = Schema.Union([Schema.Finite, Schema.Boolean, Schema.String])
+const Symbol = Schema.String.check(Schema.isPattern(/^[A-Z][A-Z0-9.-]{0,15}$/))
+
+const InputManifestBase = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.input-manifest.v2'),
+  hash: Sha256Schema,
+  database: Schema.Literal('signal'),
+  tables: Schema.Struct({
+    bars: Schema.Literal('adjusted_daily_bars_v2'),
+    sessions: Schema.Literal('exchange_sessions_v1'),
+    manifests: Schema.Literal('snapshot_manifests_v1'),
+  }),
+  finalizedSnapshot: FinalizedSnapshotProvenanceSchema,
+  bounds: EvaluationBoundsSchema,
+  rowCount: PositiveInteger,
+  sessionCount: PositiveInteger,
+  firstSession: IsoDateSchema,
+  lastSession: IsoDateSchema,
+  symbols: Schema.Array(
+    Schema.Struct({
+      symbol: Symbol,
+      rows: PositiveInteger,
+      firstSession: IsoDateSchema,
+      lastSession: IsoDateSchema,
+    }),
+  ).check(Schema.isMinLength(1)),
+})
+
+export const InputManifestArtifactSchema = InputManifestBase.check(
+  Schema.makeFilter((manifest: typeof InputManifestBase.Type) => {
+    const { hash, ...material } = manifest
+    const symbolNames = manifest.symbols.map((coverage) => coverage.symbol)
+    const issues: Schema.FilterIssue[] = []
+    if (canonicalHashV1(material) !== hash) issues.push({ path: ['hash'], issue: 'does not match the manifest' })
+    if (manifest.firstSession !== manifest.bounds.dataStart) {
+      issues.push({ path: ['firstSession'], issue: 'must equal bounds.dataStart' })
+    }
+    if (manifest.lastSession !== manifest.bounds.dataEnd) {
+      issues.push({ path: ['lastSession'], issue: 'must equal bounds.dataEnd' })
+    }
+    if (manifest.rowCount !== manifest.sessionCount * manifest.symbols.length) {
+      issues.push({ path: ['rowCount'], issue: 'must equal sessionCount multiplied by symbol count' })
+    }
+    if (canonicalHashV1(symbolNames) !== canonicalHashV1(manifest.finalizedSnapshot.symbols)) {
+      issues.push({ path: ['symbols'], issue: 'must match the finalized snapshot universe' })
+    }
+    for (const [index, coverage] of manifest.symbols.entries()) {
+      if (
+        coverage.rows !== manifest.sessionCount ||
+        coverage.firstSession !== manifest.firstSession ||
+        coverage.lastSession !== manifest.lastSession
+      ) {
+        issues.push({ path: ['symbols', index], issue: 'coverage does not match the bounded manifest' })
+      }
+    }
+    return issues
+  }),
+)
+
+const PerformanceMetricsSchema = Schema.Struct({
+  observations: PositiveInteger,
+  totalReturn: Schema.Finite,
+  annualizedReturn: Schema.Finite,
+  annualizedVolatility: Schema.Finite,
+  sharpe: Schema.Finite,
+  maximumDrawdown: Schema.Finite,
+  annualTurnover: Schema.Finite,
+  totalFeesMicros: Micros,
+  endingEquityMicros: Micros,
+})
+
+const VerdictSchema = Schema.Struct({
+  status: Schema.Literals(['PASS', 'FAIL_CLOSED']),
+  gates: Schema.Array(
+    Schema.Struct({
+      name: Schema.String,
+      passed: Schema.Boolean,
+      actual: Scalar,
+      required: Scalar,
+    }),
+  ),
+})
+
+export const MarkedEquityReconciliationSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.marked-equity-reconciliation.v1'),
+  runId: Sha256Schema,
+  toleranceMicros: Schema.Literal(MARKED_EQUITY_TOLERANCE_MICROS.toString()),
+  maximumDailyDifferenceMicros: Micros,
+  reconstructedCashMicros: Schema.String.check(Schema.isPattern(/^-?\d+$/)),
+  reconstructedPositionValueMicros: Micros,
+  evaluatorTotalFeesMicros: Micros,
+  reconstructedTotalFeesMicros: Micros,
+  feeDifferenceMicros: Micros,
+  evaluatorEndingEquityMicros: Micros,
+  reconstructedEndingEquityMicros: Micros,
+  differenceMicros: Micros,
+  exact: Schema.Boolean,
+  withinTolerance: Schema.Literal(true),
+})
+
+export const EvaluationSummarySchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.evaluation-summary.v1'),
+  runId: Sha256Schema,
+  evaluationSchemaVersion: Schema.Literal('bayn.evaluation.v2'),
+  codeRevision: SourceRevision,
+  protocolHash: Sha256Schema,
+  initialCapitalMicros: Micros,
+  input: Schema.Struct({
+    snapshotId: Sha256Schema,
+    publicationId: Sha256Schema,
+    manifestHash: Sha256Schema,
+    bounds: EvaluationBoundsSchema,
+    rowCount: PositiveInteger,
+    sessionCount: PositiveInteger,
+    symbols: Schema.Array(Schema.String).check(Schema.isMinLength(1)),
+  }),
+  strategy: PerformanceMetricsSchema,
+  buyAndHold: PerformanceMetricsSchema,
+  directVolTiming: PerformanceMetricsSchema,
+  doubleCostStrategy: PerformanceMetricsSchema,
+  verdict: VerdictSchema,
+  eventCount: PositiveInteger,
+  orderCount: PositiveInteger,
+  cashChangeCount: PositiveInteger,
+  dailyMarkCount: PositiveInteger,
+  markedEquityReconciliation: MarkedEquityReconciliationSchema,
+})
+
+export const ReconciliationResultSchema = Schema.Struct({
+  runId: Sha256Schema,
+  accountCount: PositiveInteger,
+  transferCount: PositiveInteger,
+  exact: Schema.Literal(true),
+})
+
+const DecisionEventSchema = Schema.Struct({
+  kind: Schema.Literal('decision'),
+  id: Sha256Schema,
+  signalDate: IsoDateSchema,
+  executionDate: IsoDateSchema,
+  targetWeights: Schema.Record(Schema.String, Schema.Finite),
+})
+
+const FillEventSchema = Schema.Struct({
+  kind: Schema.Literal('fill'),
+  id: Sha256Schema,
+  orderId: Sha256Schema,
+  decisionId: Sha256Schema,
+  sessionDate: IsoDateSchema,
+  symbol: Schema.String,
+  side: Schema.Literals(['buy', 'sell']),
+  quantityMicros: Micros,
+  priceMicros: Micros,
+  notionalMicros: Micros,
+  feeMicros: Micros,
+  costBasisMicros: Micros,
+})
+
+export const EvaluationEventsSchema = Schema.Array(Schema.Union([DecisionEventSchema, FillEventSchema]))
+
+export const SimulatedOrdersArtifactSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.simulated-orders.v1'),
+  transactionCostBpsMicros: Micros,
+  items: Schema.Array(
+    Schema.Struct({
+      id: Sha256Schema,
+      decisionId: Sha256Schema,
+      sessionDate: IsoDateSchema,
+      symbol: Schema.String,
+      side: Schema.Literals(['buy', 'sell']),
+      requestedQuantityMicros: Micros,
+      filledQuantityMicros: Micros,
+    }),
+  ).check(Schema.isMinLength(1)),
+})
+
+export const CashChangesArtifactSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.cash-changes.v1'),
+  items: Schema.Array(
+    Schema.Struct({
+      id: Sha256Schema,
+      fillId: Sha256Schema,
+      sessionDate: IsoDateSchema,
+      amountMicros: SignedMicros,
+      cashAfterMicros: SignedMicros,
+    }),
+  ).check(Schema.isMinLength(1)),
+})
+
+export const DailyPositionMarksArtifactSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.daily-position-marks.v1'),
+  items: Schema.Array(
+    Schema.Struct({
+      sessionDate: IsoDateSchema,
+      cashMicros: Micros,
+      positions: Schema.Array(
+        Schema.Struct({
+          symbol: Schema.String,
+          quantityMicros: Micros,
+          costBasisMicros: Micros,
+          priceMicros: Micros,
+          marketValueMicros: Micros,
+        }),
+      ).check(Schema.isMinLength(1)),
+      equityMicros: Micros,
+    }),
+  ).check(Schema.isMinLength(1)),
+})
+
+export const EquitySeriesArtifactSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.equity-series.v1'),
+  items: Schema.Array(
+    Schema.Struct({
+      sessionDate: IsoDateSchema,
+      evaluatorEquityMicros: Micros,
+      reconstructedEquityMicros: Micros,
+      differenceMicros: Micros,
+    }),
+  ).check(Schema.isMinLength(1)),
+})
+
+export const decodeEvaluationSummary = Schema.decodeUnknownEffect(EvaluationSummarySchema, StrictParseOptions)
+export const decodeReconciliationResult = Schema.decodeUnknownEffect(ReconciliationResultSchema, StrictParseOptions)
+export const decodeMarkedEquityReconciliation = Schema.decodeUnknownEffect(
+  MarkedEquityReconciliationSchema,
+  StrictParseOptions,
+)
+export const decodeInputManifestArtifact = Schema.decodeUnknownEffect(InputManifestArtifactSchema, StrictParseOptions)
+export const decodeEquitySeriesArtifact = Schema.decodeUnknownEffect(EquitySeriesArtifactSchema, StrictParseOptions)
+export const decodeEvaluationEvents = Schema.decodeUnknownEffect(EvaluationEventsSchema, StrictParseOptions)
+export const decodeSimulatedOrdersArtifact = Schema.decodeUnknownEffect(
+  SimulatedOrdersArtifactSchema,
+  StrictParseOptions,
+)
+export const decodeCashChangesArtifact = Schema.decodeUnknownEffect(CashChangesArtifactSchema, StrictParseOptions)
+export const decodeDailyPositionMarksArtifact = Schema.decodeUnknownEffect(
+  DailyPositionMarksArtifactSchema,
+  StrictParseOptions,
+)
+
+export const makeEquitySeriesArtifact = (items: (typeof EquitySeriesArtifactSchema.Type)['items']) => ({
+  schemaVersion: 'bayn.equity-series.v1' as const,
+  items,
+})

--- a/services/bayn/src/resources.test.ts
+++ b/services/bayn/src/resources.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Effect, Redacted, Ref } from 'effect'
+import { Effect, Option, Redacted, Ref } from 'effect'
 import { createClient as createTigerBeetleClient, type Client } from 'tigerbeetle-node'
 
 import { initialize, type RuntimeState } from './app'
@@ -58,11 +58,13 @@ const successfulJournal: JournalService = {
 
 const successfulEvidenceStore: EvidenceStoreService = {
   check: Effect.void,
+  read: () => Effect.succeed(Option.none()),
+  recover: () => Effect.succeed(Option.none()),
   persist: ({ evaluation }) =>
     Effect.succeed({
       runId: evaluation.runId,
       deduplicated: false,
-      artifactCount: 6,
+      artifactCount: 12,
       eventCount: evaluation.events.length,
       gateCount: evaluation.verdict.gates.length,
     }),

--- a/services/bayn/src/simulation-reconciliation.test.ts
+++ b/services/bayn/src/simulation-reconciliation.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, test } from 'bun:test'
+
+import { MARKED_EQUITY_TOLERANCE_MICROS, reconcileMarkedEquity } from './simulation-reconciliation'
+import { hashObject } from './hash'
+import { evaluateTsmom } from './strategy'
+import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
+import type { EvaluationEvent, SimulationTrace } from './types'
+
+const evaluation = (() => {
+  const snapshot = makeSnapshot(800)
+  return evaluateTsmom(snapshot.bars, snapshot.manifest, fixtureProtocol, makeTestProvenance(fixtureProtocol))
+})()
+
+const reconcile = (
+  overrides: {
+    readonly events?: readonly EvaluationEvent[]
+    readonly simulation?: SimulationTrace
+    readonly evaluatorEndingEquityMicros?: string
+    readonly evaluatorTotalFeesMicros?: string
+  } = {},
+) =>
+  reconcileMarkedEquity({
+    runId: evaluation.runId,
+    initialCapitalMicros: evaluation.initialCapitalMicros,
+    evaluatorTotalFeesMicros: overrides.evaluatorTotalFeesMicros ?? evaluation.strategy.totalFeesMicros,
+    evaluatorEndingEquityMicros: overrides.evaluatorEndingEquityMicros ?? evaluation.strategy.endingEquityMicros,
+    events: overrides.events ?? evaluation.events,
+    simulation: overrides.simulation ?? evaluation.simulation,
+  })
+
+describe('independent marked-equity reconciliation', () => {
+  test('reconstructs every daily point from orders, fills, cash, positions, and close marks', () => {
+    const proof = reconcile()
+    const fills = evaluation.events.filter((event) => event.kind === 'fill')
+
+    expect(proof).toEqual({
+      reconciliation: evaluation.markedEquityReconciliation,
+      equitySeries: evaluation.equitySeries,
+    })
+    expect(proof.equitySeries).toHaveLength(evaluation.strategy.observations)
+    expect(evaluation.simulation.orders).toHaveLength(fills.length)
+    expect(evaluation.simulation.cashChanges).toHaveLength(fills.length)
+    expect(evaluation.simulation.dailyMarks).toHaveLength(evaluation.strategy.observations)
+    expect(proof.reconciliation.withinTolerance).toBe(true)
+    expect(BigInt(proof.reconciliation.maximumDailyDifferenceMicros)).toBeLessThanOrEqual(
+      MARKED_EQUITY_TOLERANCE_MICROS,
+    )
+  })
+
+  test('rejects cash, fill, mark, lineage, and completeness tampering', () => {
+    const firstChange = evaluation.simulation.cashChanges[0]
+    const badCash: SimulationTrace = {
+      ...evaluation.simulation,
+      cashChanges: evaluation.simulation.cashChanges.map((change, index) =>
+        index === 0 ? { ...change, amountMicros: (BigInt(firstChange.amountMicros) + 1n).toString() } : change,
+      ),
+    }
+    expect(() => reconcile({ simulation: badCash })).toThrow('cash change')
+
+    const firstFillIndex = evaluation.events.findIndex((event) => event.kind === 'fill')
+    const firstFill = evaluation.events[firstFillIndex]
+    if (firstFill.kind !== 'fill') throw new Error('fixture has no fill')
+    const badFill = evaluation.events.map((event, index) =>
+      index === firstFillIndex
+        ? { ...firstFill, quantityMicros: (BigInt(firstFill.quantityMicros) + 1n).toString() }
+        : event,
+    )
+    expect(() => reconcile({ events: badFill })).toThrow('order')
+
+    const secondFillIndex = evaluation.events.findIndex(
+      (event, index) => index > firstFillIndex && event.kind === 'fill',
+    )
+    const secondFill = evaluation.events[secondFillIndex]
+    if (secondFill.kind !== 'fill') throw new Error('fixture has only one fill')
+    const duplicateFillForOrder = evaluation.events.map((event, index) =>
+      index === secondFillIndex ? { ...secondFill, orderId: firstFill.orderId } : event,
+    )
+    expect(() => reconcile({ events: duplicateFillForOrder })).toThrow('multiple fills')
+
+    const changedNotionalPayload = {
+      ...firstFill,
+      notionalMicros: (BigInt(firstFill.notionalMicros) + 20_000n).toString(),
+    }
+    const { id: _, kind: __, ...fillIdentityPayload } = changedNotionalPayload
+    const badNotional = evaluation.events.map((event, index) =>
+      index === firstFillIndex
+        ? {
+            ...changedNotionalPayload,
+            id: hashObject({ runId: evaluation.runId, kind: 'fill', ...fillIdentityPayload }),
+          }
+        : event,
+    )
+    expect(() => reconcile({ events: badNotional })).toThrow('notional diverges')
+
+    const changedFeePayload = {
+      ...firstFill,
+      feeMicros: (BigInt(firstFill.feeMicros) + 20_000n).toString(),
+    }
+    const { id: ___, kind: ____, ...feeIdentityPayload } = changedFeePayload
+    const badFee = evaluation.events.map((event, index) =>
+      index === firstFillIndex
+        ? {
+            ...changedFeePayload,
+            id: hashObject({ runId: evaluation.runId, kind: 'fill', ...feeIdentityPayload }),
+          }
+        : event,
+    )
+    expect(() => reconcile({ events: badFee })).toThrow('fee diverges')
+
+    expect(() =>
+      reconcile({
+        evaluatorTotalFeesMicros: (
+          BigInt(evaluation.strategy.totalFeesMicros) +
+          MARKED_EQUITY_TOLERANCE_MICROS +
+          1n
+        ).toString(),
+      }),
+    ).toThrow('reconstructed fees exceed')
+
+    const duplicateOrder: SimulationTrace = {
+      ...evaluation.simulation,
+      orders: [...evaluation.simulation.orders, evaluation.simulation.orders[0]],
+    }
+    expect(() => reconcile({ simulation: duplicateOrder })).toThrow('duplicate ID')
+
+    const firstMarkedPosition = evaluation.simulation.dailyMarks.findIndex((mark) =>
+      mark.positions.some((position) => position.quantityMicros !== '0'),
+    )
+    const badMark: SimulationTrace = {
+      ...evaluation.simulation,
+      dailyMarks: evaluation.simulation.dailyMarks.map((mark, index) =>
+        index === firstMarkedPosition
+          ? {
+              ...mark,
+              positions: mark.positions.map((position, positionIndex) =>
+                positionIndex === 0
+                  ? { ...position, marketValueMicros: (BigInt(position.marketValueMicros) + 20_000n).toString() }
+                  : position,
+              ),
+            }
+          : mark,
+      ),
+    }
+    expect(() => reconcile({ simulation: badMark })).toThrow('position value')
+
+    const badQuantity: SimulationTrace = {
+      ...evaluation.simulation,
+      dailyMarks: evaluation.simulation.dailyMarks.map((mark, index) =>
+        index === firstMarkedPosition
+          ? {
+              ...mark,
+              positions: mark.positions.map((position, positionIndex) =>
+                positionIndex === 0
+                  ? { ...position, quantityMicros: (BigInt(position.quantityMicros) + 1_000n).toString() }
+                  : position,
+              ),
+            }
+          : mark,
+      ),
+    }
+    expect(() => reconcile({ simulation: badQuantity })).toThrow('position quantity')
+
+    const fillSession = firstFill.sessionDate
+    const missingMark: SimulationTrace = {
+      ...evaluation.simulation,
+      dailyMarks: evaluation.simulation.dailyMarks.filter((mark) => mark.sessionDate !== fillSession),
+    }
+    expect(() => reconcile({ simulation: missingMark })).toThrow('has no mark for its session')
+  })
+
+  test('enforces the declared final-equity tolerance at the micro boundary', () => {
+    const baseline = reconcile()
+    const reconstructed = BigInt(baseline.reconciliation.reconstructedEndingEquityMicros)
+    const atBoundary = reconcile({
+      evaluatorEndingEquityMicros: (reconstructed + MARKED_EQUITY_TOLERANCE_MICROS).toString(),
+    })
+    expect(atBoundary.reconciliation.differenceMicros).toBe(MARKED_EQUITY_TOLERANCE_MICROS.toString())
+    expect(() =>
+      reconcile({
+        evaluatorEndingEquityMicros: (reconstructed + MARKED_EQUITY_TOLERANCE_MICROS + 1n).toString(),
+      }),
+    ).toThrow('final marked equity exceeds')
+  })
+})

--- a/services/bayn/src/simulation-reconciliation.ts
+++ b/services/bayn/src/simulation-reconciliation.ts
@@ -1,0 +1,287 @@
+import type {
+  CashChange,
+  DailyPositionMark,
+  DecisionEvent,
+  EquityPoint,
+  EvaluationEvent,
+  FillEvent,
+  MarkedEquityReconciliation,
+  SimulatedOrder,
+  SimulationTrace,
+} from './types'
+import { hashObject } from './hash'
+
+const MICROS = 1_000_000n
+const BASIS_POINTS = 10_000n
+export const MARKED_EQUITY_TOLERANCE_MICROS = 10_000n
+const POSITION_QUANTITY_TOLERANCE_MICROS = 100n
+
+const ensure = (condition: boolean, message: string): void => {
+  if (!condition) throw new Error(message)
+}
+
+const unsigned = (value: string, name: string): bigint => {
+  ensure(/^\d+$/.test(value), `${name} must be an unsigned integer string`)
+  return BigInt(value)
+}
+
+const signed = (value: string, name: string): bigint => {
+  ensure(/^-?\d+$/.test(value), `${name} must be an integer string`)
+  return BigInt(value)
+}
+
+const absolute = (value: bigint): bigint => (value < 0n ? -value : value)
+
+const roundedMicrosProduct = (quantityMicros: bigint, priceMicros: bigint): bigint =>
+  (quantityMicros * priceMicros + MICROS / 2n) / MICROS
+
+const roundedFee = (notionalMicros: bigint, transactionCostBpsMicros: bigint): bigint => {
+  const denominator = BASIS_POINTS * MICROS
+  return (notionalMicros * transactionCostBpsMicros + denominator / 2n) / denominator
+}
+
+const uniqueById = <A extends { readonly id: string }>(values: readonly A[], name: string): Map<string, A> => {
+  const byId = new Map<string, A>()
+  for (const value of values) {
+    ensure(/^[0-9a-f]{64}$/.test(value.id), `${name} has an invalid ID`)
+    ensure(!byId.has(value.id), `${name} contains duplicate ID ${value.id}`)
+    byId.set(value.id, value)
+  }
+  return byId
+}
+
+const expectedCashAmount = (fill: FillEvent): bigint => {
+  const notional = unsigned(fill.notionalMicros, 'fill notional')
+  const fee = unsigned(fill.feeMicros, 'fill fee')
+  return fill.side === 'buy' ? -(notional + fee) : notional - fee
+}
+
+const validateDecisionIdentity = (runId: string, decision: DecisionEvent): void => {
+  const { id: _, kind: __, ...payload } = decision
+  ensure(
+    decision.id === hashObject({ runId, kind: 'decision', ...payload }),
+    `decision ${decision.id} has an invalid identity`,
+  )
+}
+
+const validateOrder = (
+  runId: string,
+  order: SimulatedOrder,
+  fill: FillEvent,
+  decisions: ReadonlyMap<string, DecisionEvent>,
+  transactionCostBpsMicros: bigint,
+): void => {
+  const decision = decisions.get(order.decisionId)
+  if (decision === undefined) throw new Error(`order ${order.id} references an unknown decision`)
+  ensure(fill.orderId === order.id, `fill ${fill.id} does not reference its order`)
+  ensure(fill.decisionId === order.decisionId, `fill ${fill.id} and order ${order.id} disagree on decision`)
+  ensure(fill.sessionDate === order.sessionDate, `fill ${fill.id} and order ${order.id} disagree on session`)
+  ensure(fill.symbol === order.symbol, `fill ${fill.id} and order ${order.id} disagree on symbol`)
+  ensure(fill.side === order.side, `fill ${fill.id} and order ${order.id} disagree on side`)
+  ensure(decision.executionDate === order.sessionDate, `order ${order.id} is outside its decision execution session`)
+  const requested = unsigned(order.requestedQuantityMicros, 'requested order quantity')
+  const filled = unsigned(order.filledQuantityMicros, 'filled order quantity')
+  ensure(filled > 0n, `order ${order.id} has no filled quantity`)
+  ensure(filled <= requested, `order ${order.id} filled more than requested`)
+  ensure(filled === unsigned(fill.quantityMicros, 'fill quantity'), `order ${order.id} and fill quantity diverge`)
+  const { id: _, ...orderPayload } = order
+  ensure(
+    order.id === hashObject({ runId, kind: 'order', ...orderPayload }),
+    `order ${order.id} has an invalid identity`,
+  )
+  const { id: __, kind: ___, ...fillPayload } = fill
+  ensure(fill.id === hashObject({ runId, kind: 'fill', ...fillPayload }), `fill ${fill.id} has an invalid identity`)
+  const reconstructedNotional = roundedMicrosProduct(filled, unsigned(fill.priceMicros, 'fill price'))
+  ensure(
+    absolute(reconstructedNotional - unsigned(fill.notionalMicros, 'fill notional')) <= MARKED_EQUITY_TOLERANCE_MICROS,
+    `fill ${fill.id} notional diverges from quantity and price`,
+  )
+  ensure(
+    absolute(unsigned(fill.feeMicros, 'fill fee') - roundedFee(reconstructedNotional, transactionCostBpsMicros)) <=
+      MARKED_EQUITY_TOLERANCE_MICROS,
+    `fill ${fill.id} fee diverges from the declared transaction-cost model`,
+  )
+}
+
+const validateCashChange = (runId: string, change: CashChange, fill: FillEvent, expectedCash: bigint): void => {
+  ensure(change.fillId === fill.id, `cash change ${change.id} references the wrong fill`)
+  ensure(change.sessionDate === fill.sessionDate, `cash change ${change.id} references the wrong session`)
+  ensure(
+    signed(change.amountMicros, 'cash change amount') === expectedCashAmount(fill),
+    `cash change ${change.id} diverges`,
+  )
+  ensure(
+    signed(change.cashAfterMicros, 'cash after fill') === expectedCash,
+    `cash change ${change.id} balance diverges`,
+  )
+  const { id: _, ...payload } = change
+  ensure(
+    change.id === hashObject({ runId, kind: 'cash-change', ...payload }),
+    `cash change ${change.id} has an invalid identity`,
+  )
+}
+
+const validateMarks = (marks: readonly DailyPositionMark[]): void => {
+  ensure(marks.length > 0, 'simulation has no daily marks')
+  for (let index = 0; index < marks.length; index += 1) {
+    const mark = marks[index]
+    if (index > 0) ensure(marks[index - 1].sessionDate < mark.sessionDate, 'daily marks are not strictly ordered')
+    const symbols = mark.positions.map((position) => position.symbol)
+    ensure(new Set(symbols).size === symbols.length, `daily mark ${mark.sessionDate} contains duplicate positions`)
+    ensure(
+      symbols.every((symbol, symbolIndex) => symbolIndex === 0 || symbols[symbolIndex - 1] < symbol),
+      `daily mark ${mark.sessionDate} positions are not sorted`,
+    )
+  }
+}
+
+export interface MarkedEquityProof {
+  readonly reconciliation: MarkedEquityReconciliation
+  readonly equitySeries: readonly EquityPoint[]
+}
+
+export const reconcileMarkedEquity = (input: {
+  readonly runId: string
+  readonly initialCapitalMicros: string
+  readonly evaluatorTotalFeesMicros: string
+  readonly evaluatorEndingEquityMicros: string
+  readonly events: readonly EvaluationEvent[]
+  readonly simulation: SimulationTrace
+  readonly toleranceMicros?: bigint
+}): MarkedEquityProof => {
+  const tolerance = input.toleranceMicros ?? MARKED_EQUITY_TOLERANCE_MICROS
+  ensure(tolerance >= 0n, 'marked-equity tolerance must not be negative')
+  ensure(/^[0-9a-f]{64}$/.test(input.runId), 'marked-equity run ID is invalid')
+  ensure(input.simulation.schemaVersion === 'bayn.simulation-trace.v1', 'simulation trace version is unsupported')
+  const transactionCostBpsMicros = unsigned(input.simulation.transactionCostBpsMicros, 'transaction cost basis points')
+  ensure(transactionCostBpsMicros <= BASIS_POINTS * MICROS, 'transaction cost basis points exceed 100%')
+
+  const decisions = uniqueById(
+    input.events.filter((event): event is DecisionEvent => event.kind === 'decision'),
+    'decision events',
+  )
+  for (const decision of decisions.values()) validateDecisionIdentity(input.runId, decision)
+  const fills = input.events.filter((event): event is FillEvent => event.kind === 'fill')
+  const fillsById = uniqueById(fills, 'fill events')
+  const orders = uniqueById(input.simulation.orders, 'simulated orders')
+  const changes = uniqueById(input.simulation.cashChanges, 'cash changes')
+  const changesByFill = new Map<string, CashChange>()
+  for (const change of changes.values()) {
+    ensure(!changesByFill.has(change.fillId), `fill ${change.fillId} has multiple cash changes`)
+    changesByFill.set(change.fillId, change)
+  }
+  ensure(orders.size === fills.length, 'simulated order count does not match fill count')
+  ensure(changes.size === fills.length, 'cash change count does not match fill count')
+  const filledOrderIds = new Set<string>()
+  for (const fill of fills) {
+    const order = orders.get(fill.orderId)
+    if (order === undefined) throw new Error(`fill ${fill.id} references an unknown order`)
+    ensure(!filledOrderIds.has(order.id), `order ${order.id} has multiple fills`)
+    filledOrderIds.add(order.id)
+    validateOrder(input.runId, order, fill, decisions, transactionCostBpsMicros)
+    ensure(changesByFill.has(fill.id), `fill ${fill.id} has no cash change`)
+  }
+  ensure(filledOrderIds.size === orders.size, 'simulation contains an unfilled order')
+  for (const change of changes.values()) ensure(fillsById.has(change.fillId), `cash change ${change.id} has no fill`)
+  validateMarks(input.simulation.dailyMarks)
+
+  let cash = unsigned(input.initialCapitalMicros, 'initial capital')
+  const quantities = new Map<string, bigint>()
+  let fillIndex = 0
+  let previousFillDate: string | undefined
+  let maximumDifference = 0n
+  let finalPositionValue = 0n
+  let reconstructedTotalFees = 0n
+  const equitySeries: EquityPoint[] = []
+
+  for (const mark of input.simulation.dailyMarks) {
+    while (fillIndex < fills.length && fills[fillIndex].sessionDate <= mark.sessionDate) {
+      const fill = fills[fillIndex]
+      if (previousFillDate !== undefined) ensure(previousFillDate <= fill.sessionDate, 'fill events are not ordered')
+      previousFillDate = fill.sessionDate
+      ensure(fill.sessionDate === mark.sessionDate, `fill ${fill.id} has no mark for its session`)
+      cash += expectedCashAmount(fill)
+      reconstructedTotalFees += unsigned(fill.feeMicros, 'fill fee')
+      ensure(cash >= -tolerance, `fill ${fill.id} spends unavailable reconstructed cash`)
+      const quantity = unsigned(fill.quantityMicros, 'fill quantity')
+      const current = quantities.get(fill.symbol) ?? 0n
+      const next = fill.side === 'buy' ? current + quantity : current - quantity
+      ensure(next >= -POSITION_QUANTITY_TOLERANCE_MICROS, `fill ${fill.id} creates a negative long-only position`)
+      quantities.set(fill.symbol, next < 0n ? 0n : next)
+      validateCashChange(input.runId, changesByFill.get(fill.id)!, fill, cash)
+      fillIndex += 1
+    }
+
+    const markCash = unsigned(mark.cashMicros, 'daily cash')
+    const cashDifference = absolute(markCash - cash)
+    ensure(cashDifference <= tolerance, `daily cash diverges on ${mark.sessionDate}`)
+    let reconstructedPositionValue = 0n
+    const markedSymbols = new Set<string>()
+    for (const position of mark.positions) {
+      markedSymbols.add(position.symbol)
+      const price = unsigned(position.priceMicros, 'position mark price')
+      const reconstructedQuantity = quantities.get(position.symbol) ?? 0n
+      const evaluatorQuantity = unsigned(position.quantityMicros, 'position quantity')
+      ensure(
+        absolute(evaluatorQuantity - reconstructedQuantity) <= POSITION_QUANTITY_TOLERANCE_MICROS,
+        `position quantity diverges for ${position.symbol} on ${mark.sessionDate}`,
+      )
+      unsigned(position.costBasisMicros, 'position cost basis')
+      const reconstructedValue = roundedMicrosProduct(reconstructedQuantity, price)
+      reconstructedPositionValue += reconstructedValue
+      const evaluatorValue = unsigned(position.marketValueMicros, 'position market value')
+      ensure(
+        absolute(evaluatorValue - reconstructedValue) <= tolerance,
+        `position value diverges for ${position.symbol} on ${mark.sessionDate}`,
+      )
+    }
+    for (const [symbol, quantity] of quantities) {
+      ensure(
+        quantity === 0n || markedSymbols.has(symbol),
+        `daily mark ${mark.sessionDate} omits open position ${symbol}`,
+      )
+    }
+    const reconstructedEquity = cash + reconstructedPositionValue
+    const evaluatorEquity = unsigned(mark.equityMicros, 'daily evaluator equity')
+    const difference = absolute(reconstructedEquity - evaluatorEquity)
+    ensure(difference <= tolerance, `daily marked equity diverges on ${mark.sessionDate}`)
+    maximumDifference = maximumDifference > difference ? maximumDifference : difference
+    finalPositionValue = reconstructedPositionValue
+    equitySeries.push({
+      sessionDate: mark.sessionDate,
+      evaluatorEquityMicros: evaluatorEquity.toString(),
+      reconstructedEquityMicros: reconstructedEquity.toString(),
+      differenceMicros: difference.toString(),
+    })
+  }
+  ensure(fillIndex === fills.length, 'simulation has fills after its final daily mark')
+
+  const evaluatorEnding = unsigned(input.evaluatorEndingEquityMicros, 'evaluator ending equity')
+  const evaluatorTotalFees = unsigned(input.evaluatorTotalFeesMicros, 'evaluator total fees')
+  const feeDifference = absolute(reconstructedTotalFees - evaluatorTotalFees)
+  ensure(feeDifference <= tolerance, 'reconstructed fees exceed the declared tolerance')
+  const reconstructedEnding = cash + finalPositionValue
+  const finalDifference = absolute(reconstructedEnding - evaluatorEnding)
+  ensure(finalDifference <= tolerance, 'final marked equity exceeds the declared tolerance')
+  maximumDifference = maximumDifference > finalDifference ? maximumDifference : finalDifference
+
+  return {
+    reconciliation: {
+      schemaVersion: 'bayn.marked-equity-reconciliation.v1',
+      runId: input.runId,
+      toleranceMicros: tolerance.toString(),
+      maximumDailyDifferenceMicros: maximumDifference.toString(),
+      reconstructedCashMicros: cash.toString(),
+      reconstructedPositionValueMicros: finalPositionValue.toString(),
+      evaluatorTotalFeesMicros: evaluatorTotalFees.toString(),
+      reconstructedTotalFeesMicros: reconstructedTotalFees.toString(),
+      feeDifferenceMicros: feeDifference.toString(),
+      evaluatorEndingEquityMicros: evaluatorEnding.toString(),
+      reconstructedEndingEquityMicros: reconstructedEnding.toString(),
+      differenceMicros: finalDifference.toString(),
+      exact: maximumDifference === 0n && feeDifference === 0n,
+      withinTolerance: true,
+    },
+    equitySeries,
+  }
+}

--- a/services/bayn/src/strategy-service.ts
+++ b/services/bayn/src/strategy-service.ts
@@ -1,7 +1,7 @@
 import { Context, Layer } from 'effect'
 
 import type { RuntimeProvenance } from './contracts'
-import { evaluateTsmom } from './strategy'
+import { evaluateTsmom, identifyTsmomRun } from './strategy'
 import type { DailyBar, EvaluationResult, InputManifest, TsmomProtocol } from './types'
 
 export interface StrategyService {
@@ -9,6 +9,7 @@ export interface StrategyService {
   readonly universe: readonly string[]
   readonly parameters: unknown
   readonly provenance: RuntimeProvenance
+  readonly identify: (manifest: InputManifest) => string
   readonly evaluate: (bars: readonly DailyBar[], manifest: InputManifest) => EvaluationResult
 }
 
@@ -19,6 +20,7 @@ export const makeTsmomStrategy = (protocol: TsmomProtocol, provenance: RuntimePr
   universe: protocol.universe,
   parameters: protocol,
   provenance,
+  identify: (manifest) => identifyTsmomRun(manifest, protocol, provenance),
   evaluate: (bars, manifest) => evaluateTsmom(bars, manifest, protocol, provenance),
 })
 

--- a/services/bayn/src/strategy.test.ts
+++ b/services/bayn/src/strategy.test.ts
@@ -112,4 +112,18 @@ describe('TSMOM economic evaluator', () => {
       'row count does not match manifest',
     )
   })
+
+  test('retains bounded complete evidence for a production-sized history', () => {
+    const snapshot = makeSnapshot(2_400)
+    const evaluation = evaluateTsmom(snapshot.bars, snapshot.manifest, fixtureProtocol, makeTestProvenance())
+    const serializedEvidence = JSON.stringify({
+      events: evaluation.events,
+      simulation: evaluation.simulation,
+      equitySeries: evaluation.equitySeries,
+    })
+
+    expect(evaluation.simulation.dailyMarks).toHaveLength(evaluation.strategy.observations)
+    expect(evaluation.equitySeries).toHaveLength(evaluation.strategy.observations)
+    expect(Buffer.byteLength(serializedEvidence)).toBeLessThan(10 * 1024 * 1024)
+  })
 })

--- a/services/bayn/src/strategy.ts
+++ b/services/bayn/src/strategy.ts
@@ -1,17 +1,23 @@
 import { makeRunIdentity, makeStrategyProtocolHash, type RuntimeProvenance } from './contracts'
 import { canonicalHashV1, hashObject } from './hash'
 import { hashTsmomParameters } from './protocol'
+import { reconcileMarkedEquity } from './simulation-reconciliation'
 import type {
+  CashChange,
   DailyBar,
+  DailyPositionMark,
   DecisionEvent,
   EconomicVerdict,
   EvaluationEvent,
   EvaluationResult,
+  EvaluationSummary,
   FillEvent,
   GateResult,
   InputManifest,
   IsoDate,
   PerformanceMetrics,
+  SimulatedOrder,
+  SimulationTrace,
   TsmomProtocol,
 } from './types'
 
@@ -34,6 +40,7 @@ interface Target {
 interface SimulationResult {
   readonly metrics: PerformanceMetrics
   readonly events: readonly EvaluationEvent[]
+  readonly simulation: SimulationTrace | null
 }
 
 const MICROS = 1_000_000
@@ -170,22 +177,41 @@ export const calculatePerformanceMetrics = (
   }
 }
 
-const makeFill = (
+const makeOrder = (
   runId: string,
   decision: DecisionEvent,
   sessionDate: IsoDate,
   symbol: string,
   side: 'buy' | 'sell',
-  quantity: number,
-  price: number,
-  fee: number,
-  costBasis: number,
-): FillEvent => {
+  requestedQuantity: number,
+  filledQuantity: number,
+): SimulatedOrder => {
   const payload = {
     decisionId: decision.id,
     sessionDate,
     symbol,
     side,
+    requestedQuantityMicros: toMicros(requestedQuantity),
+    filledQuantityMicros: toMicros(filledQuantity),
+  }
+  return { id: hashObject({ runId, kind: 'order', ...payload }), ...payload }
+}
+
+const makeFill = (
+  runId: string,
+  decision: DecisionEvent,
+  order: SimulatedOrder,
+  price: number,
+  fee: number,
+  costBasis: number,
+): FillEvent => {
+  const quantity = Number(BigInt(order.filledQuantityMicros)) / MICROS
+  const payload = {
+    orderId: order.id,
+    decisionId: decision.id,
+    sessionDate: order.sessionDate,
+    symbol: order.symbol,
+    side: order.side,
     quantityMicros: toMicros(quantity),
     priceMicros: toMicros(price),
     notionalMicros: toMicros(quantity * price),
@@ -193,6 +219,19 @@ const makeFill = (
     costBasisMicros: toMicros(costBasis),
   }
   return { kind: 'fill', id: hashObject({ runId, kind: 'fill', ...payload }), ...payload }
+}
+
+const makeCashChange = (runId: string, fill: FillEvent, cashAfterMicros: bigint): CashChange => {
+  const notional = BigInt(fill.notionalMicros)
+  const fee = BigInt(fill.feeMicros)
+  const amount = fill.side === 'buy' ? -(notional + fee) : notional - fee
+  const payload = {
+    fillId: fill.id,
+    sessionDate: fill.sessionDate,
+    amountMicros: amount.toString(),
+    cashAfterMicros: cashAfterMicros.toString(),
+  }
+  return { id: hashObject({ runId, kind: 'cash-change', ...payload }), ...payload }
 }
 
 const simulate = (
@@ -211,6 +250,10 @@ const simulate = (
   let totalFees = 0
   const equity: number[] = []
   const events: EvaluationEvent[] = []
+  const orders: SimulatedOrder[] = []
+  const cashChanges: CashChange[] = []
+  const dailyMarks: DailyPositionMark[] = []
+  let reconstructedCashMicros = BigInt(toMicros(initialCapital))
   const feeRate = costBps / 10_000
 
   for (let index = startIndex; index < sessions.length; index += 1) {
@@ -258,8 +301,14 @@ const simulate = (
         position.quantity = Math.max(0, desired)
         position.costBasis = Math.max(0, position.costBasis - costBasis)
         positions.set(symbol, position)
-        if (recordEvents)
-          events.push(makeFill(runId, decision, session.date, symbol, 'sell', quantity, price, fee, costBasis))
+        if (recordEvents) {
+          const order = makeOrder(runId, decision, session.date, symbol, 'sell', quantity, quantity)
+          const fill = makeFill(runId, decision, order, price, fee, costBasis)
+          orders.push(order)
+          events.push(fill)
+          reconstructedCashMicros += BigInt(fill.notionalMicros) - BigInt(fill.feeMicros)
+          cashChanges.push(makeCashChange(runId, fill, reconstructedCashMicros))
+        }
       }
 
       const proposedBuys = Object.keys(target.weights)
@@ -274,6 +323,7 @@ const simulate = (
       const scale = proposedNotional === 0 ? 0 : Math.min(1, cash / (proposedNotional * (1 + feeRate)))
       for (const buy of proposedBuys) {
         const quantity = buy.quantity * scale
+        if (quantity <= 1e-9) continue
         const notional = quantity * buy.price
         const fee = notional * feeRate
         cash -= notional + fee
@@ -283,7 +333,12 @@ const simulate = (
         buy.position.costBasis += notional
         positions.set(buy.symbol, buy.position)
         if (recordEvents) {
-          events.push(makeFill(runId, decision, session.date, buy.symbol, 'buy', quantity, buy.price, fee, notional))
+          const order = makeOrder(runId, decision, session.date, buy.symbol, 'buy', buy.quantity, quantity)
+          const fill = makeFill(runId, decision, order, buy.price, fee, notional)
+          orders.push(order)
+          events.push(fill)
+          reconstructedCashMicros -= BigInt(fill.notionalMicros) + BigInt(fill.feeMicros)
+          cashChanges.push(makeCashChange(runId, fill, reconstructedCashMicros))
         }
       }
       if (cash < -0.01) throw new Error(`simulation spent unavailable cash: ${cash}`)
@@ -296,9 +351,40 @@ const simulate = (
         0,
       )
     equity.push(closingEquity)
+    if (recordEvents) {
+      dailyMarks.push({
+        sessionDate: session.date,
+        cashMicros: toMicros(Math.max(0, cash)),
+        positions: Object.entries(session.bars)
+          .sort(([left], [right]) => left.localeCompare(right))
+          .map(([symbol, bar]) => {
+            const position = positions.get(symbol) ?? { quantity: 0, costBasis: 0 }
+            return {
+              symbol,
+              quantityMicros: toMicros(position.quantity),
+              costBasisMicros: toMicros(position.costBasis),
+              priceMicros: toMicros(bar.close),
+              marketValueMicros: toMicros(position.quantity * bar.close),
+            }
+          }),
+        equityMicros: toMicros(closingEquity),
+      })
+    }
   }
 
-  return { metrics: calculatePerformanceMetrics(equity, turnover, totalFees, initialCapital), events }
+  return {
+    metrics: calculatePerformanceMetrics(equity, turnover, totalFees, initialCapital),
+    events,
+    simulation: recordEvents
+      ? {
+          schemaVersion: 'bayn.simulation-trace.v1',
+          transactionCostBpsMicros: toMicros(costBps),
+          orders,
+          cashChanges,
+          dailyMarks,
+        }
+      : null,
+  }
 }
 
 const buildVerdict = (
@@ -359,12 +445,11 @@ const buildVerdict = (
   return { status: gates.every((gate) => gate.passed) ? 'PASS' : 'FAIL_CLOSED', gates }
 }
 
-export const evaluateTsmom = (
-  bars: readonly DailyBar[],
+const makeTsmomEvaluationIdentity = (
   inputManifest: InputManifest,
   protocol: TsmomProtocol,
   provenance: RuntimeProvenance,
-): EvaluationResult => {
+): { readonly runId: string; readonly protocolHash: string } => {
   const parameterHash = hashTsmomParameters(protocol)
   if (provenance.strategy.name !== 'tsmom') throw new Error('runtime provenance strategy must be tsmom')
   if (provenance.strategy.parameterSchemaVersion !== protocol.schemaVersion) {
@@ -391,6 +476,22 @@ export const evaluateTsmom = (
     calendarVersion: inputManifest.finalizedSnapshot.calendarVersion,
     bounds: inputManifest.bounds,
   }).runId
+  return { runId, protocolHash }
+}
+
+export const identifyTsmomRun = (
+  inputManifest: InputManifest,
+  protocol: TsmomProtocol,
+  provenance: RuntimeProvenance,
+): string => makeTsmomEvaluationIdentity(inputManifest, protocol, provenance).runId
+
+export const evaluateTsmom = (
+  bars: readonly DailyBar[],
+  inputManifest: InputManifest,
+  protocol: TsmomProtocol,
+  provenance: RuntimeProvenance,
+): EvaluationResult => {
+  const { runId, protocolHash } = makeTsmomEvaluationIdentity(inputManifest, protocol, provenance)
   const sessions = alignBars(bars, protocol.universe, inputManifest)
   const maximumLookback = Math.max(...protocol.lookbacks)
   const signalIndices = sessions
@@ -470,9 +571,18 @@ export const evaluateTsmom = (
     runId,
     false,
   )
+  if (strategy.simulation === null) throw new Error('candidate simulation did not retain its evidence trace')
+  const markedEquity = reconcileMarkedEquity({
+    runId,
+    initialCapitalMicros: protocol.initialCapitalMicros,
+    evaluatorTotalFeesMicros: strategy.metrics.totalFeesMicros,
+    evaluatorEndingEquityMicros: strategy.metrics.endingEquityMicros,
+    events: strategy.events,
+    simulation: strategy.simulation,
+  })
 
   return {
-    schemaVersion: 'bayn.evaluation.v1',
+    schemaVersion: 'bayn.evaluation.v2',
     runId,
     codeRevision: provenance.sourceRevision,
     protocolHash,
@@ -484,5 +594,36 @@ export const evaluateTsmom = (
     doubleCostStrategy: doubleCost.metrics,
     verdict: buildVerdict(strategy.metrics, buyAndHold.metrics, directVolTiming.metrics, doubleCost.metrics, protocol),
     events: strategy.events,
+    simulation: strategy.simulation,
+    equitySeries: markedEquity.equitySeries,
+    markedEquityReconciliation: markedEquity.reconciliation,
   }
 }
+
+export const summarizeEvaluation = (evaluation: EvaluationResult): EvaluationSummary => ({
+  schemaVersion: 'bayn.evaluation-summary.v1',
+  runId: evaluation.runId,
+  evaluationSchemaVersion: evaluation.schemaVersion,
+  codeRevision: evaluation.codeRevision,
+  protocolHash: evaluation.protocolHash,
+  initialCapitalMicros: evaluation.initialCapitalMicros,
+  input: {
+    snapshotId: evaluation.inputManifest.finalizedSnapshot.snapshotId,
+    publicationId: evaluation.inputManifest.finalizedSnapshot.publicationId,
+    manifestHash: evaluation.inputManifest.hash,
+    bounds: evaluation.inputManifest.bounds,
+    rowCount: evaluation.inputManifest.rowCount,
+    sessionCount: evaluation.inputManifest.sessionCount,
+    symbols: evaluation.inputManifest.symbols.map((coverage) => coverage.symbol),
+  },
+  strategy: evaluation.strategy,
+  buyAndHold: evaluation.buyAndHold,
+  directVolTiming: evaluation.directVolTiming,
+  doubleCostStrategy: evaluation.doubleCostStrategy,
+  verdict: evaluation.verdict,
+  eventCount: evaluation.events.length,
+  orderCount: evaluation.simulation.orders.length,
+  cashChangeCount: evaluation.simulation.cashChanges.length,
+  dailyMarkCount: evaluation.simulation.dailyMarks.length,
+  markedEquityReconciliation: evaluation.markedEquityReconciliation,
+})

--- a/services/bayn/src/types.ts
+++ b/services/bayn/src/types.ts
@@ -74,6 +74,7 @@ export interface DecisionEvent {
 export interface FillEvent {
   readonly kind: 'fill'
   readonly id: string
+  readonly orderId: string
   readonly decisionId: string
   readonly sessionDate: IsoDate
   readonly symbol: string
@@ -86,6 +87,71 @@ export interface FillEvent {
 }
 
 export type EvaluationEvent = DecisionEvent | FillEvent
+
+export interface SimulatedOrder {
+  readonly id: string
+  readonly decisionId: string
+  readonly sessionDate: IsoDate
+  readonly symbol: string
+  readonly side: 'buy' | 'sell'
+  readonly requestedQuantityMicros: string
+  readonly filledQuantityMicros: string
+}
+
+export interface CashChange {
+  readonly id: string
+  readonly fillId: string
+  readonly sessionDate: IsoDate
+  readonly amountMicros: string
+  readonly cashAfterMicros: string
+}
+
+export interface PositionMark {
+  readonly symbol: string
+  readonly quantityMicros: string
+  readonly costBasisMicros: string
+  readonly priceMicros: string
+  readonly marketValueMicros: string
+}
+
+export interface DailyPositionMark {
+  readonly sessionDate: IsoDate
+  readonly cashMicros: string
+  readonly positions: readonly PositionMark[]
+  readonly equityMicros: string
+}
+
+export interface SimulationTrace {
+  readonly schemaVersion: 'bayn.simulation-trace.v1'
+  readonly transactionCostBpsMicros: string
+  readonly orders: readonly SimulatedOrder[]
+  readonly cashChanges: readonly CashChange[]
+  readonly dailyMarks: readonly DailyPositionMark[]
+}
+
+export interface EquityPoint {
+  readonly sessionDate: IsoDate
+  readonly evaluatorEquityMicros: string
+  readonly reconstructedEquityMicros: string
+  readonly differenceMicros: string
+}
+
+export interface MarkedEquityReconciliation {
+  readonly schemaVersion: 'bayn.marked-equity-reconciliation.v1'
+  readonly runId: string
+  readonly toleranceMicros: string
+  readonly maximumDailyDifferenceMicros: string
+  readonly reconstructedCashMicros: string
+  readonly reconstructedPositionValueMicros: string
+  readonly evaluatorTotalFeesMicros: string
+  readonly reconstructedTotalFeesMicros: string
+  readonly feeDifferenceMicros: string
+  readonly evaluatorEndingEquityMicros: string
+  readonly reconstructedEndingEquityMicros: string
+  readonly differenceMicros: string
+  readonly exact: boolean
+  readonly withinTolerance: true
+}
 
 export interface PerformanceMetrics {
   readonly observations: number
@@ -112,7 +178,7 @@ export interface EconomicVerdict {
 }
 
 export interface EvaluationResult {
-  readonly schemaVersion: 'bayn.evaluation.v1'
+  readonly schemaVersion: 'bayn.evaluation.v2'
   readonly runId: string
   readonly codeRevision: string
   readonly protocolHash: string
@@ -124,6 +190,37 @@ export interface EvaluationResult {
   readonly doubleCostStrategy: PerformanceMetrics
   readonly verdict: EconomicVerdict
   readonly events: readonly EvaluationEvent[]
+  readonly simulation: SimulationTrace
+  readonly equitySeries: readonly EquityPoint[]
+  readonly markedEquityReconciliation: MarkedEquityReconciliation
+}
+
+export interface EvaluationSummary {
+  readonly schemaVersion: 'bayn.evaluation-summary.v1'
+  readonly runId: string
+  readonly evaluationSchemaVersion: 'bayn.evaluation.v2'
+  readonly codeRevision: string
+  readonly protocolHash: string
+  readonly initialCapitalMicros: string
+  readonly input: {
+    readonly snapshotId: string
+    readonly publicationId: string
+    readonly manifestHash: string
+    readonly bounds: EvaluationBounds
+    readonly rowCount: number
+    readonly sessionCount: number
+    readonly symbols: readonly string[]
+  }
+  readonly strategy: PerformanceMetrics
+  readonly buyAndHold: PerformanceMetrics
+  readonly directVolTiming: PerformanceMetrics
+  readonly doubleCostStrategy: PerformanceMetrics
+  readonly verdict: EconomicVerdict
+  readonly eventCount: number
+  readonly orderCount: number
+  readonly cashChangeCount: number
+  readonly dailyMarkCount: number
+  readonly markedEquityReconciliation: MarkedEquityReconciliation
 }
 
 export interface ReconciliationResult {


### PR DESCRIPTION
## Summary

- persist the complete Bayn simulation trace as 12 content-hashed CNPG artifacts, including the locked protocol, orders, fills, cash changes, daily marks, and equity series
- independently reconstruct transaction costs, cash, positions, and every marked-equity point with bigint micros and a fixed one-cent fail-closed tolerance
- recover an exact completed run on restart before any evaluation or TigerBeetle mutation, and fail closed on partial, corrupt, or runtime-incompatible evidence
- expose bounded runtime status plus an internal, exact-run historical evidence endpoint

## Related Issues

Related: PROOMPT-361

## Testing

- `bun run --filter @proompteng/bayn test` — 59 passed, 16 PostgreSQL-gated tests skipped
- `BAYN_TEST_POSTGRES_URL=postgresql://postgres:***@127.0.0.1:55432/bayn_test bun test services/bayn/src/db/evidence-store.integration.test.ts` — 14 passed
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- production-sized 2,400-session fixture — 3.17 MiB evidence, 729 events, 630 orders, 2,140 marks, fee difference 7 micros, maximum daily equity difference 6,315 micros

## Breaking Changes

The evaluation evidence contract advances from `bayn.evaluation.v1` to `bayn.evaluation.v2`. No database migration or destructive rewrite is required. Existing v1 runs remain immutable and readable; only exact v2 runs can satisfy restart recovery.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed because this is an internal runtime and evidence change.
- [x] Documentation and the PROOMPT-361 implementation plan are updated.