### PR TITLE
fix(hermes): require network policy enforcement

### DIFF
--- a/argocd/applications/hermes/README.md
+++ b/argocd/applications/hermes/README.md
@@ -1,8 +1,9 @@
 # Hermes production
 
-Hermes is the production runtime for the Tuslagch assistant. The initial GitOps state exposes only the authenticated
-cluster-local API. Discord remains disabled until migration and API canary gates pass; the cutover is a separate reviewed
-change so Hermes and OpenClaw never use the Discord token concurrently.
+Hermes is the planned production runtime for the Tuslagch assistant. The initial GitOps state exposes only the authenticated
+cluster-local API. Keep the manual application unsynced until the live NetworkPolicy enforcement probe passes. Discord
+remains disabled until migration and API canary gates pass; the cutover is a separate reviewed change so Hermes and OpenClaw
+never use the Discord token concurrently.
 
 ## Release and supply chain
 
@@ -21,7 +22,9 @@ smoke test, manifest change, and normal CI/Codex review.
 - Root filesystems are read-only, all Linux capabilities are dropped, seccomp is `RuntimeDefault`, and no pod receives a
   Kubernetes service-account token.
 - The namespace enforces the Kubernetes `restricted` Pod Security profile.
-- Default-deny network policy permits the gateway to reach only cluster DNS, Flamingo, and the allowlisted Squid proxy.
+- Default-deny NetworkPolicies permit the gateway to reach only cluster DNS, Flamingo, and the allowlisted Squid proxy once
+  a compatible policy engine is present. Flannel alone does not enforce these objects; the runbook's disposable live probe
+  must pass before the first sync.
 - Squid permits HTTPS `CONNECT` only to Discord-owned domains and blocks private, tailnet, metadata, and multicast ranges.
 - The API key comes from `onepassword-infra` through External Secrets. No secret is committed to Git.
 - API key rotation requires a bounded Secret refresh, gateway Pod restart, and old-key rejection/new-key acceptance proof.

--- a/docs/runbooks/hermes-production-rollout.md
+++ b/docs/runbooks/hermes-production-rollout.md
@@ -55,8 +55,9 @@ The expected mirrored amd64 manifest digest is
 
 2. Empirically prove the live CNI enforces `networking.k8s.io/v1` policies. The probe creates an isolated disposable
    namespace, schedules its bounded client and server on different nodes, first proves Pod-to-Pod connectivity, applies a
-   client egress deny, proves that same request fails, and then deletes the namespace. A rendered or accepted NetworkPolicy
-   object is not enforcement evidence:
+   client egress deny, proves that same request fails while both endpoints remain healthy, removes the policy, proves
+   connectivity returns, and then deletes the namespace. A rendered or accepted NetworkPolicy object is not enforcement
+   evidence:
 
    ```bash
    bash scripts/hermes/verify-network-policy-enforcement.sh

--- a/docs/runbooks/hermes-production-rollout.md
+++ b/docs/runbooks/hermes-production-rollout.md
@@ -12,6 +12,7 @@ channel without dual writers, and retains a tested rollback path. All `kubectl` 
 - Never start migration or restore until the backup CronJob is suspended and every active backup Job has finished.
 - Never create a migration or restore Job until every earlier Hermes maintenance Job is terminal.
 - Never enable Hermes Discord until a final audited migration is applied after the OpenClaw gateway is inactive.
+- Never sync Hermes until the disposable NetworkPolicy enforcement probe passes on the live cluster.
 - Every API key rotation must restart `hermes-0` and prove the old key is rejected and the new key is accepted.
 - A `Synced/Healthy` Argo application is not sufficient proof. Record authenticated inference, persistence, egress, backup,
   migration, and Discord lifecycle evidence.
@@ -52,7 +53,19 @@ The expected mirrored amd64 manifest digest is
    kubectl -n flamingo rollout status deployment/flamingo --timeout=10m
    ```
 
-2. Create a minimum 32-byte API key in the `infra` 1Password vault. Do this from a private shell with 1Password unlocked;
+2. Empirically prove the live CNI enforces `networking.k8s.io/v1` policies. The probe creates an isolated disposable
+   namespace, schedules its bounded client and server on different nodes, first proves Pod-to-Pod connectivity, applies a
+   client egress deny, proves that same request fails, and then deletes the namespace. A rendered or accepted NetworkPolicy
+   object is not enforcement evidence:
+
+   ```bash
+   bash scripts/hermes/verify-network-policy-enforcement.sh
+   ```
+
+   `NetworkPolicy is not enforced` is a hard rollout blocker. Do not sync Hermes or weaken the containment test; install
+   and validate a compatible policy engine first.
+
+3. Create a minimum 32-byte API key in the `infra` 1Password vault. Do this from a private shell with 1Password unlocked;
    do not echo the generated value:
 
    ```bash
@@ -63,7 +76,7 @@ The expected mirrored amd64 manifest digest is
    unset hermes_api_key
    ```
 
-3. Wait for the ApplicationSet to create the manual Hermes app, sync it, and verify the secret bridge without reading the
+4. Wait for the ApplicationSet to create the manual Hermes app, sync it, and verify the secret bridge without reading the
    value:
 
    ```bash

--- a/scripts/hermes/validate-production.test.ts
+++ b/scripts/hermes/validate-production.test.ts
@@ -75,6 +75,18 @@ test('rejects a network-policy probe without bounded Pods', async () => {
   )
 })
 
+test('rejects treating arbitrary probe failures as policy enforcement', async () => {
+  const files = await loadProductionFiles()
+  files.networkPolicyProbe = files.networkPolicyProbe.replace(
+    'if [[ "$request_status" -eq 42 ]]',
+    'if [[ "$request_status" -ne 0 ]]',
+  )
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.networkPolicyProbe}: missing production invariant "if [[ \\"$request_status\\" -eq 42 ]]"`,
+  )
+})
+
 test('rejects syncing Hermes before network-policy enforcement proof', async () => {
   const files = await loadProductionFiles()
   const probeCommand = '   bash scripts/hermes/verify-network-policy-enforcement.sh\n'

--- a/scripts/hermes/validate-production.test.ts
+++ b/scripts/hermes/validate-production.test.ts
@@ -87,6 +87,18 @@ test('rejects treating arbitrary probe failures as policy enforcement', async ()
   )
 })
 
+test('rejects policy enforcement proof without connectivity restoration', async () => {
+  const files = await loadProductionFiles()
+  files.networkPolicyProbe = files.networkPolicyProbe.replace(
+    'if [[ "$policy_released" != true ]]',
+    'if [[ "$policy_released" == true ]]',
+  )
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.networkPolicyProbe}: missing production invariant "if [[ \\"$policy_released\\" != true ]]"`,
+  )
+})
+
 test('rejects syncing Hermes before network-policy enforcement proof', async () => {
   const files = await loadProductionFiles()
   const probeCommand = '   bash scripts/hermes/verify-network-policy-enforcement.sh\n'

--- a/scripts/hermes/validate-production.test.ts
+++ b/scripts/hermes/validate-production.test.ts
@@ -57,6 +57,38 @@ test('rejects secret bridge verification that does not enforce key length', asyn
   )
 })
 
+test('rejects a network-policy probe without a deny rule', async () => {
+  const files = await loadProductionFiles()
+  files.networkPolicyProbe = files.networkPolicyProbe.replace('  egress: []\n', '  egress:\n    - {}\n')
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.networkPolicyProbe}: missing production invariant "egress: []"`,
+  )
+})
+
+test('rejects a network-policy probe without bounded Pods', async () => {
+  const files = await loadProductionFiles()
+  files.networkPolicyProbe = files.networkPolicyProbe.replace('  activeDeadlineSeconds: 600\n', '')
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.networkPolicyProbe}: both probe Pods must enforce "activeDeadlineSeconds: 600"`,
+  )
+})
+
+test('rejects syncing Hermes before network-policy enforcement proof', async () => {
+  const files = await loadProductionFiles()
+  const probeCommand = '   bash scripts/hermes/verify-network-policy-enforcement.sh\n'
+  files.runbook = files.runbook.replace(probeCommand, '')
+  files.runbook = files.runbook.replace(
+    '   argocd app sync hermes --prune=false\n',
+    `   argocd app sync hermes --prune=false\n${probeCommand}`,
+  )
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.runbook}: NetworkPolicy enforcement must be proven before the first Hermes sync`,
+  )
+})
+
 test('rejects automatic Argo reconciliation during the staged migration', async () => {
   const files = await loadProductionFiles()
   files.platform = files.platform.replace(/(\n\s+- name: hermes\n[\s\S]*?automation:) manual/, '$1 auto')

--- a/scripts/hermes/validate-production.test.ts
+++ b/scripts/hermes/validate-production.test.ts
@@ -87,6 +87,18 @@ test('rejects treating arbitrary probe failures as policy enforcement', async ()
   )
 })
 
+test('rejects treating HTTP error responses as policy enforcement', async () => {
+  const files = await loadProductionFiles()
+  files.networkPolicyProbe = files.networkPolicyProbe.replace(
+    'except urllib.error.HTTPError:\n    raise SystemExit(43)\nexcept (TimeoutError, OSError, urllib.error.URLError):',
+    'except (TimeoutError, OSError, urllib.error.URLError):\n    raise SystemExit(42)\nexcept urllib.error.HTTPError:',
+  )
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.networkPolicyProbe}: HTTP responses must not count as policy denials`,
+  )
+})
+
 test('rejects policy enforcement proof without connectivity restoration', async () => {
   const files = await loadProductionFiles()
   files.networkPolicyProbe = files.networkPolicyProbe.replace(

--- a/scripts/hermes/validate-production.ts
+++ b/scripts/hermes/validate-production.ts
@@ -289,6 +289,11 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'egress: []',
     'baseline_reachable=false',
     'policy_enforced=false',
+    'raise SystemExit(42)',
+    'raise SystemExit(43)',
+    'verify_probe_health() {',
+    'urllib.request.urlopen("http://127.0.0.1:8080/", timeout=2).read(1)',
+    'if [[ "$request_status" -eq 42 ]]',
     "echo 'NetworkPolicy is not enforced; do not sync Hermes' >&2",
     "printf 'network_policy_enforced=true\\n'",
   ])
@@ -308,6 +313,7 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'privileged: true',
     'hostNetwork: true',
     'serviceAccountName:',
+    'if ! probe_request',
   ])
   const probeBaselineIndex = files.networkPolicyProbe.indexOf('if [[ "$baseline_reachable" != true ]]')
   const probePolicyIndex = files.networkPolicyProbe.indexOf('name: deny-client-egress')

--- a/scripts/hermes/validate-production.ts
+++ b/scripts/hermes/validate-production.ts
@@ -289,6 +289,8 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'egress: []',
     'baseline_reachable=false',
     'policy_enforced=false',
+    'except urllib.error.HTTPError:',
+    'except (TimeoutError, OSError, urllib.error.URLError):',
     'raise SystemExit(42)',
     'raise SystemExit(43)',
     'verify_probe_health() {',
@@ -332,6 +334,13 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     failures.push(
       `${productionPaths.networkPolicyProbe}: baseline connectivity must pass before the deny policy is tested`,
     )
+  }
+  const probeHttpErrorIndex = files.networkPolicyProbe.indexOf('except urllib.error.HTTPError:')
+  const probeNetworkErrorIndex = files.networkPolicyProbe.indexOf(
+    'except (TimeoutError, OSError, urllib.error.URLError):',
+  )
+  if (probeHttpErrorIndex < 0 || probeNetworkErrorIndex <= probeHttpErrorIndex) {
+    failures.push(`${productionPaths.networkPolicyProbe}: HTTP responses must not count as policy denials`)
   }
   requireTerms(failures, productionPaths.maintenanceWait, files.maintenanceWait, [
     'set -euo pipefail',

--- a/scripts/hermes/validate-production.ts
+++ b/scripts/hermes/validate-production.ts
@@ -294,6 +294,10 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'verify_probe_health() {',
     'urllib.request.urlopen("http://127.0.0.1:8080/", timeout=2).read(1)',
     'if [[ "$request_status" -eq 42 ]]',
+    'delete networkpolicy deny-client-egress --wait=true --timeout=1m',
+    'policy_released=false',
+    'if [[ "$policy_released" != true ]]',
+    "echo 'NetworkPolicy removal did not restore baseline connectivity; do not sync Hermes' >&2",
     "echo 'NetworkPolicy is not enforced; do not sync Hermes' >&2",
     "printf 'network_policy_enforced=true\\n'",
   ])
@@ -318,7 +322,13 @@ export function validateProductionContent(files: ProductionFiles): string[] {
   const probeBaselineIndex = files.networkPolicyProbe.indexOf('if [[ "$baseline_reachable" != true ]]')
   const probePolicyIndex = files.networkPolicyProbe.indexOf('name: deny-client-egress')
   const probeEnforcementIndex = files.networkPolicyProbe.indexOf('if [[ "$policy_enforced" != true ]]')
-  if (probeBaselineIndex < 0 || probePolicyIndex <= probeBaselineIndex || probeEnforcementIndex <= probePolicyIndex) {
+  const probeReleaseIndex = files.networkPolicyProbe.indexOf('if [[ "$policy_released" != true ]]')
+  if (
+    probeBaselineIndex < 0 ||
+    probePolicyIndex <= probeBaselineIndex ||
+    probeEnforcementIndex <= probePolicyIndex ||
+    probeReleaseIndex <= probeEnforcementIndex
+  ) {
     failures.push(
       `${productionPaths.networkPolicyProbe}: baseline connectivity must pass before the deny policy is tested`,
     )

--- a/scripts/hermes/validate-production.ts
+++ b/scripts/hermes/validate-production.ts
@@ -21,6 +21,7 @@ export const productionPaths = {
   restoreStage: 'argocd/applications/hermes/operations/restore-stage-pod.yaml',
   restore: 'argocd/applications/hermes/operations/restore-job.yaml',
   migrationAudit: 'scripts/hermes/audit-migration-source.ts',
+  networkPolicyProbe: 'scripts/hermes/verify-network-policy-enforcement.sh',
   maintenanceWait: 'scripts/hermes/wait-for-maintenance.sh',
   maintenanceLock: 'scripts/hermes/maintenance-lock.sh',
   platform: 'argocd/applicationsets/platform.yaml',
@@ -270,6 +271,52 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'migration source audit failed',
     '${issue.path}: ${issue.reason}',
   ])
+  requireTerms(failures, productionPaths.networkPolicyProbe, files.networkPolicyProbe, [
+    'set -euo pipefail',
+    `readonly hermes_image='${hermesImage}'`,
+    'probe_namespace="hermes-network-policy-probe-$(openssl rand -hex 4)"',
+    'readonly probe_namespace',
+    'probe_namespace_created=false',
+    'cleanup_probe() {',
+    'if [[ "$probe_namespace_created" == true ]]',
+    'trap cleanup_probe EXIT',
+    'trap abort_probe HUP INT TERM',
+    'kubectl -n default create namespace "$probe_namespace"',
+    'kubectl -n default delete namespace "$probe_namespace" --ignore-not-found --wait=true --timeout=5m',
+    'pod-security.kubernetes.io/enforce=restricted',
+    'kind: NetworkPolicy',
+    'name: deny-client-egress',
+    'egress: []',
+    'baseline_reachable=false',
+    'policy_enforced=false',
+    "echo 'NetworkPolicy is not enforced; do not sync Hermes' >&2",
+    "printf 'network_policy_enforced=true\\n'",
+  ])
+  for (const term of [
+    'activeDeadlineSeconds: 600',
+    'automountServiceAccountToken: false',
+    'kubernetes.io/arch: amd64',
+    'readOnlyRootFilesystem: true',
+    'requiredDuringSchedulingIgnoredDuringExecution:',
+  ]) {
+    if (count(files.networkPolicyProbe, term) !== 2) {
+      failures.push(`${productionPaths.networkPolicyProbe}: both probe Pods must enforce ${JSON.stringify(term)}`)
+    }
+  }
+  forbidTerms(failures, productionPaths.networkPolicyProbe, files.networkPolicyProbe, [
+    ':latest',
+    'privileged: true',
+    'hostNetwork: true',
+    'serviceAccountName:',
+  ])
+  const probeBaselineIndex = files.networkPolicyProbe.indexOf('if [[ "$baseline_reachable" != true ]]')
+  const probePolicyIndex = files.networkPolicyProbe.indexOf('name: deny-client-egress')
+  const probeEnforcementIndex = files.networkPolicyProbe.indexOf('if [[ "$policy_enforced" != true ]]')
+  if (probeBaselineIndex < 0 || probePolicyIndex <= probeBaselineIndex || probeEnforcementIndex <= probePolicyIndex) {
+    failures.push(
+      `${productionPaths.networkPolicyProbe}: baseline connectivity must pass before the deny policy is tested`,
+    )
+  }
   requireTerms(failures, productionPaths.maintenanceWait, files.maintenanceWait, [
     'set -euo pipefail',
     'readonly namespace=hermes',
@@ -316,6 +363,7 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'Never run `hermes claw cleanup`',
     'Never create a migration or restore Job until every earlier Hermes maintenance Job is terminal.',
     'Never enable Hermes Discord until a final audited migration is applied after the OpenClaw gateway is inactive.',
+    'Never sync Hermes until the disposable NetworkPolicy enforcement probe passes on the live cluster.',
     "stale_maintenance_holder=$(kubectl -n hermes get lease hermes-maintenance -o jsonpath='{.spec.holderIdentity}')",
     'maintenance-lock.sh recover "$stale_maintenance_holder"',
     'A standalone Job does not update the CronJob',
@@ -360,11 +408,18 @@ export function validateProductionContent(files: ProductionFiles): string[] {
   ])
   const phaseZeroSection = files.runbook.match(/## Phase 0:[\s\S]*?## Phase 1:/)?.[0] ?? ''
   requireTerms(failures, productionPaths.runbook, phaseZeroSection, [
+    'bash scripts/hermes/verify-network-policy-enforcement.sh',
+    '`NetworkPolicy is not enforced` is a hard rollout blocker.',
     'test "$api_key_bytes" -ge 32',
     'printf \'%s\\n\' "$api_key_bytes"',
     "hermes_deployed_revision=$(kubectl -n argocd get application hermes -o json | jq -r '.status.history[-1].revision // empty')",
     'test "$hermes_deployed_revision" = "$(git rev-parse HEAD)"',
   ])
+  const networkPolicyProbeIndex = phaseZeroSection.indexOf('bash scripts/hermes/verify-network-policy-enforcement.sh')
+  const initialHermesSyncIndex = phaseZeroSection.indexOf('argocd app sync hermes --prune=false')
+  if (networkPolicyProbeIndex < 0 || initialHermesSyncIndex <= networkPolicyProbeIndex) {
+    failures.push(`${productionPaths.runbook}: NetworkPolicy enforcement must be proven before the first Hermes sync`)
+  }
   if (count(phaseZeroSection, 'set -euo pipefail') !== 2) {
     failures.push(`${productionPaths.runbook}: secret creation and bridge verification must both fail closed`)
   }

--- a/scripts/hermes/verify-network-policy-enforcement.sh
+++ b/scripts/hermes/verify-network-policy-enforcement.sh
@@ -184,8 +184,25 @@ test -n "$server_ip"
 probe_request() {
   kubectl -n "$probe_namespace" exec pod/policy-client -c client -- \
     /opt/hermes/.venv/bin/python -c \
-    'import sys, urllib.request; urllib.request.urlopen(sys.argv[1], timeout=2).read(1)' \
+    'import sys, urllib.error, urllib.request
+try:
+    urllib.request.urlopen(sys.argv[1], timeout=2).read(1)
+except (TimeoutError, OSError, urllib.error.URLError):
+    raise SystemExit(42)
+except BaseException:
+    raise SystemExit(43)' \
     "http://$server_ip:8080/" >/dev/null 2>&1
+}
+
+verify_probe_health() {
+  kubectl -n "$probe_namespace" wait pod/policy-server pod/policy-client \
+    --for=condition=Ready --timeout=5s >/dev/null
+  kubectl -n "$probe_namespace" exec pod/policy-client -c client -- \
+    /opt/hermes/.venv/bin/python -c 'raise SystemExit(0)' >/dev/null 2>&1
+  kubectl -n "$probe_namespace" exec pod/policy-server -c server -- \
+    /opt/hermes/.venv/bin/python -c \
+    'import urllib.request; urllib.request.urlopen("http://127.0.0.1:8080/", timeout=2).read(1)' \
+    >/dev/null 2>&1
 }
 
 baseline_reachable=false
@@ -193,6 +210,12 @@ for _ in $(seq 1 30); do
   if probe_request; then
     baseline_reachable=true
     break
+  else
+    request_status=$?
+  fi
+  if [[ "$request_status" -ne 42 ]]; then
+    echo "network-policy baseline probe execution failed with status $request_status" >&2
+    exit 1
   fi
   sleep 1
 done
@@ -219,11 +242,19 @@ EOF
 
 policy_enforced=false
 for _ in $(seq 1 30); do
-  if ! probe_request; then
+  if probe_request; then
+    sleep 1
+    continue
+  else
+    request_status=$?
+  fi
+  if [[ "$request_status" -eq 42 ]]; then
+    verify_probe_health
     policy_enforced=true
     break
   fi
-  sleep 1
+  echo "network-policy denial probe execution failed with status $request_status" >&2
+  exit 1
 done
 if [[ "$policy_enforced" != true ]]; then
   echo 'NetworkPolicy is not enforced; do not sync Hermes' >&2

--- a/scripts/hermes/verify-network-policy-enforcement.sh
+++ b/scripts/hermes/verify-network-policy-enforcement.sh
@@ -187,6 +187,8 @@ probe_request() {
     'import sys, urllib.error, urllib.request
 try:
     urllib.request.urlopen(sys.argv[1], timeout=2).read(1)
+except urllib.error.HTTPError:
+    raise SystemExit(43)
 except (TimeoutError, OSError, urllib.error.URLError):
     raise SystemExit(42)
 except BaseException:

--- a/scripts/hermes/verify-network-policy-enforcement.sh
+++ b/scripts/hermes/verify-network-policy-enforcement.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly hermes_image='registry.ide-newton.ts.net/lab/hermes-agent@sha256:3db34ce19adfa080736a2a3feb0316dbcccc588faa9afe7fd8ae1c03b4f1a53a'
+probe_namespace="hermes-network-policy-probe-$(openssl rand -hex 4)"
+readonly probe_namespace
+probe_namespace_created=false
+
+cleanup_probe() {
+  if [[ "$probe_namespace_created" == true ]]; then
+    kubectl -n default delete namespace "$probe_namespace" --ignore-not-found --wait=true --timeout=5m >/dev/null
+    probe_namespace_created=false
+  fi
+}
+
+abort_probe() {
+  trap - EXIT HUP INT TERM
+  cleanup_probe
+  exit 130
+}
+
+trap cleanup_probe EXIT
+trap abort_probe HUP INT TERM
+
+kubectl -n default create namespace "$probe_namespace" >/dev/null
+probe_namespace_created=true
+kubectl -n default label namespace "$probe_namespace" --overwrite \
+  pod-security.kubernetes.io/enforce=restricted \
+  pod-security.kubernetes.io/audit=restricted \
+  pod-security.kubernetes.io/warn=restricted >/dev/null
+
+sed "s|HERMES_IMAGE|$hermes_image|g" <<'EOF' | kubectl -n "$probe_namespace" apply -f - >/dev/null
+apiVersion: v1
+kind: Pod
+metadata:
+  name: policy-server
+  labels:
+    app.kubernetes.io/name: hermes-network-policy-probe
+    app.kubernetes.io/component: server
+spec:
+  activeDeadlineSeconds: 600
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: hermes-network-policy-probe
+          topologyKey: kubernetes.io/hostname
+  automountServiceAccountToken: false
+  enableServiceLinks: false
+  nodeSelector:
+    kubernetes.io/arch: amd64
+  restartPolicy: Never
+  terminationGracePeriodSeconds: 5
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 10000
+    runAsGroup: 10000
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: server
+      image: HERMES_IMAGE
+      imagePullPolicy: IfNotPresent
+      command:
+        - /opt/hermes/.venv/bin/python
+        - -m
+        - http.server
+        - "8080"
+        - --bind
+        - 0.0.0.0
+      env:
+        - name: HOME
+          value: /tmp
+        - name: PYTHONDONTWRITEBYTECODE
+          value: "1"
+      ports:
+        - name: http
+          containerPort: 8080
+      readinessProbe:
+        tcpSocket:
+          port: http
+        periodSeconds: 1
+        failureThreshold: 30
+      resources:
+        requests:
+          cpu: 10m
+          memory: 32Mi
+          ephemeral-storage: 16Mi
+        limits:
+          cpu: 250m
+          memory: 128Mi
+          ephemeral-storage: 128Mi
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 10000
+        runAsGroup: 10000
+      volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+  volumes:
+    - name: tmp
+      emptyDir:
+        sizeLimit: 16Mi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: policy-client
+  labels:
+    app.kubernetes.io/name: hermes-network-policy-probe
+    app.kubernetes.io/component: client
+spec:
+  activeDeadlineSeconds: 600
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: hermes-network-policy-probe
+          topologyKey: kubernetes.io/hostname
+  automountServiceAccountToken: false
+  enableServiceLinks: false
+  nodeSelector:
+    kubernetes.io/arch: amd64
+  restartPolicy: Never
+  terminationGracePeriodSeconds: 5
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 10000
+    runAsGroup: 10000
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: client
+      image: HERMES_IMAGE
+      imagePullPolicy: IfNotPresent
+      command:
+        - /bin/sh
+        - -c
+        - while :; do sleep 3600; done
+      env:
+        - name: HOME
+          value: /tmp
+        - name: PYTHONDONTWRITEBYTECODE
+          value: "1"
+      resources:
+        requests:
+          cpu: 10m
+          memory: 32Mi
+          ephemeral-storage: 16Mi
+        limits:
+          cpu: 250m
+          memory: 128Mi
+          ephemeral-storage: 128Mi
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 10000
+        runAsGroup: 10000
+      volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+  volumes:
+    - name: tmp
+      emptyDir:
+        sizeLimit: 16Mi
+EOF
+
+kubectl -n "$probe_namespace" wait pod/policy-server pod/policy-client --for=condition=Ready --timeout=5m >/dev/null
+server_ip=$(kubectl -n "$probe_namespace" get pod policy-server -o jsonpath='{.status.podIP}')
+test -n "$server_ip"
+
+probe_request() {
+  kubectl -n "$probe_namespace" exec pod/policy-client -c client -- \
+    /opt/hermes/.venv/bin/python -c \
+    'import sys, urllib.request; urllib.request.urlopen(sys.argv[1], timeout=2).read(1)' \
+    "http://$server_ip:8080/" >/dev/null 2>&1
+}
+
+baseline_reachable=false
+for _ in $(seq 1 30); do
+  if probe_request; then
+    baseline_reachable=true
+    break
+  fi
+  sleep 1
+done
+if [[ "$baseline_reachable" != true ]]; then
+  kubectl -n "$probe_namespace" logs pod/policy-server -c server >&2 || true
+  echo 'network-policy probe could not establish baseline Pod-to-Pod connectivity' >&2
+  exit 1
+fi
+
+kubectl -n "$probe_namespace" apply -f - >/dev/null <<'EOF'
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: deny-client-egress
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: hermes-network-policy-probe
+      app.kubernetes.io/component: client
+  policyTypes:
+    - Egress
+  egress: []
+EOF
+
+policy_enforced=false
+for _ in $(seq 1 30); do
+  if ! probe_request; then
+    policy_enforced=true
+    break
+  fi
+  sleep 1
+done
+if [[ "$policy_enforced" != true ]]; then
+  echo 'NetworkPolicy is not enforced; do not sync Hermes' >&2
+  exit 1
+fi
+
+printf 'network_policy_enforced=true\n'
+cleanup_probe
+trap - EXIT HUP INT TERM

--- a/scripts/hermes/verify-network-policy-enforcement.sh
+++ b/scripts/hermes/verify-network-policy-enforcement.sh
@@ -261,6 +261,26 @@ if [[ "$policy_enforced" != true ]]; then
   exit 1
 fi
 
+kubectl -n "$probe_namespace" delete networkpolicy deny-client-egress --wait=true --timeout=1m >/dev/null
+policy_released=false
+for _ in $(seq 1 30); do
+  if probe_request; then
+    policy_released=true
+    break
+  else
+    request_status=$?
+  fi
+  if [[ "$request_status" -ne 42 ]]; then
+    echo "network-policy release probe execution failed with status $request_status" >&2
+    exit 1
+  fi
+  sleep 1
+done
+if [[ "$policy_released" != true ]]; then
+  echo 'NetworkPolicy removal did not restore baseline connectivity; do not sync Hermes' >&2
+  exit 1
+fi
+
 printf 'network_policy_enforced=true\n'
 cleanup_probe
 trap - EXIT HUP INT TERM


### PR DESCRIPTION
## Summary

- Add a disposable cross-node A/B/A probe that proves baseline Pod connectivity, requires a standard egress-deny NetworkPolicy to stop the same request, then requires connectivity to recover after only that policy is removed.
- Bound both probe pods with immutable images, restricted security contexts, no service-account tokens, anti-affinity, deadlines, and signal-safe namespace cleanup.
- Distinguish an attributable connection denial from HTTP responses, transport, exec, client, server, or cross-node connectivity failures before the security gate can pass.
- Block the runbook before the first Hermes sync when live policy enforcement is absent, and correct the runtime documentation so Flannel objects are not presented as isolation.
- Extend the production validator and regression suite to keep the enforcement gate ordered before the manual Argo sync.

## Related Issues

None. Follow-up to #12896; blocks the runtime stages of #12920 until enforcement exists.

## Testing

- `bun run scripts/hermes/validate-production.ts` — validated 26 production surfaces.
- `bun test scripts/hermes/*.test.ts` — 59 passed, 0 failed.
- `bunx oxlint scripts/hermes/validate-production.ts scripts/hermes/validate-production.test.ts` — 0 warnings and 0 errors.
- `shellcheck scripts/hermes/*.sh` and `bash -n scripts/hermes/verify-network-policy-enforcement.sh` — passed.
- `bun run lint:argocd` — 0 invalid resources and 0 errors across all seven validation batches.
- Live `kubectl exec` remote-status check — exit code 42 was preserved end to end, supporting denial/transport discrimination.
- Live exact-head `bash scripts/hermes/verify-network-policy-enforcement.sh` — baseline traffic succeeded across nodes, the egress deny remained unenforced for the full 30-second gate, the script failed closed with `NetworkPolicy is not enforced; do not sync Hermes`, and zero probe namespaces remained afterward.

## Breaking Changes

Hermes rollout now intentionally stops before the first sync unless empirical NetworkPolicy enforcement succeeds. Merging this PR changes no running workload; the Hermes Argo application remains manual and unsynced. Installing a policy engine is a separate cluster-wide change because it can activate every existing NetworkPolicy.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
