### PR TITLE
feat(bayn): verify runtime health continuously

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -54,6 +54,8 @@ spec:
               value: sha256:cb3508090afdc8f1cb1c5661266f79dc6a63e22f03e370b7d664eef4dd953036
             - name: BAYN_RUN_ON_STARTUP
               value: "true"
+            - name: BAYN_HEALTH_INTERVAL_MS
+              value: "30000"
             - name: BAYN_OPERATION_TIMEOUT_MS
               value: "30000"
             - name: BAYN_CLICKHOUSE_URL

--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -52,8 +52,6 @@ spec:
               value: registry.ide-newton.ts.net/lab/bayn
             - name: BAYN_IMAGE_DIGEST
               value: sha256:cb3508090afdc8f1cb1c5661266f79dc6a63e22f03e370b7d664eef4dd953036
-            - name: BAYN_RUN_ON_STARTUP
-              value: "true"
             - name: BAYN_HEALTH_INTERVAL_MS
               value: "30000"
             - name: BAYN_OPERATION_TIMEOUT_MS

--- a/bun.lock
+++ b/bun.lock
@@ -1028,6 +1028,9 @@
       },
     },
   },
+  "patchedDependencies": {
+    "@effect/sql-clickhouse@4.0.0-beta.99": "patches/@effect%2Fsql-clickhouse@4.0.0-beta.99.patch",
+  },
   "packages": {
     "@a2a-js/sdk": ["@a2a-js/sdk@0.3.13", "", { "dependencies": { "uuid": "^11.1.0" }, "peerDependencies": { "@bufbuild/protobuf": "^2.10.2", "@grpc/grpc-js": "^1.11.0", "express": "^4.21.2 || ^5.1.0" }, "optionalPeers": ["@bufbuild/protobuf", "@grpc/grpc-js", "express"] }, "sha512-BZr0f9JVNQs3GKOM9xINWCh6OKIJWZFPyqqVqTym5mxO2Eemc6I/0zL7zWnljHzGdaf5aZQyQN5xa6PSH62q+A=="],
 

--- a/nix/images/bayn.nix
+++ b/nix/images/bayn.nix
@@ -22,8 +22,8 @@ import ./bun-workspace-service.nix {
   serviceName = "bayn";
   packageName = "@proompteng/bayn";
   depsHash = {
-    x86_64-linux = "sha256-vcBPDVDy9zfqEj+n4lJMkg8f6D7WwEC5IiyUylcKUhE=";
-    aarch64-linux = "sha256-uY5n3M01VfApaJXe4CYFtL6/5ZL8hZQTaHAGrv4mPRs=";
+    x86_64-linux = "sha256-ipihvTFg7aAUkKYhfA95fGZ2LpVH7CaOQl/4oydTYUo=";
+    aarch64-linux = "sha256-Qa5/rwdZcb2aRWwCHlKj3u2VeaiL2LMOg21aXvUmpTU=";
   };
   installFilters = [
     "@proompteng/bayn"

--- a/nix/images/bumba.nix
+++ b/nix/images/bumba.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "bumba";
   packageName = "@proompteng/bumba";
   depsHash = {
-    x86_64-linux = "sha256-94ofrftDj9Qqt2XSV3t20OOm/VChZyW+s0j31IM/ZCc=";
-    aarch64-linux = "sha256-4dgPU4BNl5rgVdE0Sc4RkAmaTr3tjaStdNqD0g/4kUg=";
+    x86_64-linux = "sha256-NM+BPCnISkk2k1PauM49xSsGaaCP9p0sdUFq/gcolck=";
+    aarch64-linux = "sha256-bT36tSGaXh0nKCPWLJOve9P2EuWBAEJ2oWWsmou45Dg=";
   };
   installFilters = [
     "@proompteng/bumba"

--- a/nix/images/bun-workspace-service.nix
+++ b/nix/images/bun-workspace-service.nix
@@ -56,7 +56,7 @@ let
   depsSource = lib.cleanSourceWith {
     src = repoRoot;
     filter = path: type:
-      type == "directory" || isPackageManifest (relativePath path);
+      type == "directory" || isPackageManifest (relativePath path) || isUnder "patches" (relativePath path);
   };
 
   runtimeSource = lib.cleanSourceWith {

--- a/nix/images/froussard.nix
+++ b/nix/images/froussard.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "froussard";
   packageName = "froussard";
   depsHash = {
-    x86_64-linux = "sha256-NM/bGVinQ7tlCqGwYBAvgixN4+VJ3MAlHN6+91nNw7Q=";
-    aarch64-linux = "sha256-f5UbFMOiJbHYEsGwUdoowjLJYUWa1AwKjKeAhma1Mvk=";
+    x86_64-linux = "sha256-3MVjycp6fxdUgsqUeEJIeXQvOdyRZ8CG/wjAHT6IVlQ=";
+    aarch64-linux = "sha256-oKUEn057bF7SzVEioPrXlVA0r/0L19QLA404VHstt4A=";
   };
   installFilters = [
     "@proompteng/agent-contracts"

--- a/nix/images/oirat.nix
+++ b/nix/images/oirat.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "oirat";
   packageName = "@proompteng/oirat";
   depsHash = {
-    x86_64-linux = "sha256-kSt4OfRK8gX/VsNk3NGskDbjpRnoEn1E9/9cQGY/pCI=";
-    aarch64-linux = "sha256-1AdBQWWvjJuZfAzk8iN5QiFBRDnsJ+ljhTF/gai8nRo=";
+    x86_64-linux = "sha256-u3v9tkwhCCRO1UVIPk9N3EboACBt124Mr6ao7WpmWaw=";
+    aarch64-linux = "sha256-BHt13fiIkXK6vRAV+2zLOFZu5do/pn+hbIRz32hH8P8=";
   };
   installFilters = [
     "@proompteng/discord"

--- a/nix/images/signal-publisher.nix
+++ b/nix/images/signal-publisher.nix
@@ -16,8 +16,8 @@ import ./bun-workspace-service.nix {
   serviceName = "signal-publisher";
   packageName = "@proompteng/signal-publisher";
   depsHash = {
-    x86_64-linux = "sha256-LS/rTMkDAREqQ2O7DjpQbvaIggPP/16ZXzPgGwV03jc=";
-    aarch64-linux = "sha256-J/6TRKZyHUyEc5ctY7GjcxMUpuLJ3b8o8IuKHJCMnAY=";
+    x86_64-linux = "sha256-y/+b5uIyouOpJ7NPWOFCHd8Bkttg5rPgfLTaxQh34B8=";
+    aarch64-linux = "sha256-OewlYC0LzrdmDh53USwqJS0/2TiHUfUV1THTWxl4DbU=";
   };
   installFilters = [
     "@proompteng/signal-publisher"

--- a/package.json
+++ b/package.json
@@ -142,5 +142,8 @@
   "engines": {
     "node": "24.11.1"
   },
-  "packageManager": "bun@1.3.14"
+  "packageManager": "bun@1.3.14",
+  "patchedDependencies": {
+    "@effect/sql-clickhouse@4.0.0-beta.99": "patches/@effect%2Fsql-clickhouse@4.0.0-beta.99.patch"
+  }
 }

--- a/patches/@effect%2Fsql-clickhouse@4.0.0-beta.99.patch
+++ b/patches/@effect%2Fsql-clickhouse@4.0.0-beta.99.patch
@@ -1,0 +1,25 @@
+diff --git a/dist/ClickhouseClient.js b/dist/ClickhouseClient.js
+index c97676fc8913cfedc2c793bf9d4fed179a265f32..34a80630e4262f36f4c4b3f8bfa848271716b13c 100644
+--- a/dist/ClickhouseClient.js
++++ b/dist/ClickhouseClient.js
+@@ -97,7 +97,7 @@ export const make = options => Effect.gen(function* () {
+   const transformRows = options.transformResultNames ? Statement.defaultTransforms(options.transformResultNames).array : undefined;
+   const client = Clickhouse.createClient(options);
+   yield* Effect.acquireRelease(Effect.tryPromise({
+-    try: () => client.exec({
++    try: () => client.command({
+       query: "SELECT 1"
+     }),
+     catch: cause => new SqlError({
+diff --git a/src/ClickhouseClient.ts b/src/ClickhouseClient.ts
+index fb5883eb1201b651040b50059c4f991657a5252a..69350d70013a4bfc3268da4e6318c544ea0f5c54 100644
+--- a/src/ClickhouseClient.ts
++++ b/src/ClickhouseClient.ts
+@@ -180,6 +180,6 @@ export const make = (
+     yield* Effect.acquireRelease(
+       Effect.tryPromise({
+-        try: () => client.exec({ query: "SELECT 1" }),
++        try: () => client.command({ query: "SELECT 1" }),
+         catch: (cause) =>
+           new SqlError({ reason: classifyError(cause, "ClickhouseClient: Failed to connect", "connect", "connection") })
+       }),

--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -7,8 +7,8 @@ and journals the resulting simulation to TigerBeetle. It contains no broker clie
 ## Runtime contract
 
 - Node.js is the production runtime; Effect owns dependency acquisition, failure handling, and shutdown.
-- Effect Config validates environment input, and `BAYN_OPERATION_TIMEOUT_MS` bounds each ClickHouse or TigerBeetle
-  startup operation (30 seconds by default).
+- Effect Config validates environment input. `BAYN_OPERATION_TIMEOUT_MS` bounds dependency operations, and
+  `BAYN_HEALTH_INTERVAL_MS` controls the continuous health interval; both default to 30 seconds.
 - Signal ClickHouse is read-only at runtime. Data publication and provider credentials are owned by the separate Signal
   adjusted-daily publisher; Bayn contains no DDL or backfill command.
 - Bayn owns a two-instance CloudNativePG cluster. The runtime uses the generated application URI over verified TLS,
@@ -22,8 +22,8 @@ and journals the resulting simulation to TigerBeetle. It contains no broker clie
   and status exposes the promoted image digest, parameter hash, and contract versions.
 - The package `dev` and `start` scripts use explicit `development-configured` provenance because their artifacts are
   not OCI production builds. That mode is visible in status and cannot override an executable with embedded metadata;
-  it also forces startup evaluation and journaling off. The Nix image starts in the default production mode and fails
-  closed if embedded facts are absent.
+  it does not change lifecycle or authority. The Nix image starts in the default production mode and fails closed if
+  embedded facts are absent.
 - The reader selects one configured finalized Signal snapshot by content-addressed ID. It verifies the publisher
   manifest, sessions, every bar, exact SIP/all provenance, the canonical universe, content hashes, and explicit data,
   lookback, and evaluation bounds before exposing numeric bars.
@@ -39,15 +39,19 @@ and journals the resulting simulation to TigerBeetle. It contains no broker clie
 - On restart, Bayn derives the expected run ID from the verified Signal manifest and current executable identity. It
   resumes only an exact, complete, runtime-decoded PostgreSQL record; missing evidence triggers one evaluation, while
   partial, altered, or incompatible evidence fails closed without another TigerBeetle mutation.
+- After startup, one scoped Effect loop continuously checks PostgreSQL, the configured Signal manifest, the active
+  TigerBeetle run, and the complete durable evidence record without loading bars or writing accounting state. Readiness
+  closes on any defect and reopens only after every check succeeds; the last valid evidence remains observable.
 - A run becomes ready only after ClickHouse validation, evaluation, TigerBeetle journal creation, exact reconciliation,
-  and the PostgreSQL commit. Strategy rejection is an auditable economic `FAIL_CLOSED`; dependency, accounting, or
-  persistence failure keeps the Kubernetes readiness probe closed.
+  the PostgreSQL commit, and one successful continuous check. Strategy rejection is an auditable economic
+  `FAIL_CLOSED`; it remains separate from operational health and never expands authority.
 
 ## Endpoints
 
 - `GET /livez`: process liveness.
-- `GET /readyz`: dependency/evaluation/accounting readiness.
-- `GET /v1/status`: bounded authority, provenance, metrics, verdict, and reconciliation summary.
+- `GET /readyz`: current dependency, evidence, and accounting readiness.
+- `GET /v1/status`: operational dependencies, data and evidence identity, economic verdict, accounting, build
+  provenance, and fixed observe-only authority.
 - `GET /v1/evaluations/:runId`: complete content-hashed evidence for one exact run ID. The service is ClusterIP-only
   and the Bayn network policy limits HTTP ingress to the namespace.
 

--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -4,9 +4,10 @@ import { createServer } from 'node:http'
 
 import { NodeServices } from '@effect/platform-node'
 import { Cause, Context, Effect, Exit, Fiber, Layer, Option, Redacted, Ref } from 'effect'
+import { TestClock } from 'effect/testing'
 import { HttpServer } from 'effect/unstable/http'
 
-import { initialize, makeHttpLayer, run, type RuntimeState } from './app'
+import { initialState, initialize, makeHttpLayer, monitor, probe, run, type RuntimeState } from './app'
 import type { RuntimeConfig } from './config'
 import {
   DatabaseError,
@@ -63,7 +64,7 @@ const config: RuntimeConfig = {
     strategyBehaviorHash: provenance.strategy.behaviorHash,
     verification: 'embedded',
   },
-  runOnStartup: true,
+  healthIntervalMs: 100,
   operationTimeoutMs: 250,
   clickhouse: {
     url: 'http://clickhouse.test:8123',
@@ -91,6 +92,7 @@ const config: RuntimeConfig = {
 
 const successfulJournal: JournalService = {
   check: Effect.void,
+  checkRun: () => Effect.void,
   journalAndReconcile: (evaluation) =>
     Effect.succeed({
       runId: evaluation.runId,
@@ -99,6 +101,11 @@ const successfulJournal: JournalService = {
       exact: true,
     }),
 }
+
+const marketDataService = (load: MarketDataService['load']): MarketDataService => ({
+  check: Effect.sync(() => makeSnapshot().manifest.finalizedSnapshot),
+  load,
+})
 
 const successfulEvidenceStore: EvidenceStoreService = {
   check: Effect.void,
@@ -144,7 +151,8 @@ const waitForStatus = async (port: number, expectedStatus: string) => {
   while (Date.now() < deadline) {
     try {
       const response = await fetchJson(port, '/v1/status')
-      if (response.body.status === expectedStatus) return response
+      const operational = response.body.operational as { readonly status?: string } | undefined
+      if (operational?.status === expectedStatus) return response
     } catch (error) {
       lastError = error
     }
@@ -176,7 +184,33 @@ const readyState = (): RuntimeState => {
         gateCount: evaluation.verdict.gates.length,
       },
     },
+    health: {
+      sequence: 1,
+      checkedAt: '2026-07-20T00:00:00.000Z',
+      dependencies: {
+        postgresql: { status: 'AVAILABLE', checkedAt: '2026-07-20T00:00:00.000Z', error: null },
+        signal: { status: 'AVAILABLE', checkedAt: '2026-07-20T00:00:00.000Z', error: null },
+        tigerBeetle: { status: 'AVAILABLE', checkedAt: '2026-07-20T00:00:00.000Z', error: null },
+        evidence: { status: 'AVAILABLE', checkedAt: '2026-07-20T00:00:00.000Z', error: null },
+      },
+    },
     error: null,
+  }
+}
+
+const recoveringStore = (state: RuntimeState): EvidenceStoreService => {
+  if (state.evidence === null) throw new Error('test state must contain evidence')
+  return {
+    ...successfulEvidenceStore,
+    recover: () =>
+      Effect.succeed(
+        Option.some({
+          evaluation: state.evidence!.evaluation,
+          reconciliation: state.evidence!.reconciliation,
+          persistence: { ...state.evidence!.persistence, deduplicated: true },
+        }),
+      ),
+    persist: () => Effect.die(new Error('health probes must not persist')),
   }
 }
 
@@ -186,7 +220,7 @@ describe('Bayn HTTP probes', () => {
     await Effect.runPromise(
       Effect.scoped(
         Effect.gen(function* () {
-          const state = yield* Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null })
+          const state = yield* Ref.make(initialState())
           const context = yield* Layer.build(
             makeHttpLayer(
               { host: '127.0.0.1', operationTimeoutMs: 250, port: 0 },
@@ -219,11 +253,13 @@ describe('Bayn HTTP probes', () => {
             status: 200,
             body: {
               service: 'bayn',
-              status: 'READY',
-              authority: { brokerOrders: false, capitalPromotion: false },
-              provenanceVerification: 'embedded',
-              provenance,
-              evidence: { provenance },
+              operational: { status: 'READY', ready: true, probeSequence: 1 },
+              authority: { maximum: 'observe', brokerOrders: false, capitalPromotion: false },
+              build: { sourceRevision: provenance.sourceRevision, verification: 'embedded' },
+              data: { status: 'CURRENT' },
+              evidence: { status: 'CURRENT' },
+              economic: { status: 'REJECTED' },
+              accounting: { status: 'EXACT' },
             },
           })
           expect(yield* Effect.promise(() => fetchJson(port, `/v1/evaluations/${historicalRunId}`))).toMatchObject({
@@ -238,14 +274,14 @@ describe('Bayn HTTP probes', () => {
             status: 404,
             body: { error: 'evaluation_not_found' },
           })
-          yield* Ref.set(state, { status: 'FAIL_CLOSED', evidence: null, error: 'test failure' })
+          yield* Ref.set(state, { ...initialState(), status: 'FAILED', error: 'test failure' })
           expect(yield* Effect.promise(() => fetchJson(port, '/readyz'))).toMatchObject({
             status: 503,
-            body: { ready: false, status: 'FAIL_CLOSED' },
+            body: { ready: false, status: 'FAILED' },
           })
           expect(yield* Effect.promise(() => fetchJson(port, '/v1/status'))).toMatchObject({
             status: 200,
-            body: { status: 'FAIL_CLOSED', error: 'test failure' },
+            body: { operational: { status: 'FAILED' }, error: 'test failure' },
           })
           expect(yield* Effect.promise(() => fetchJson(port, '/v1/evidence/latest'))).toMatchObject({
             status: 404,
@@ -285,7 +321,7 @@ describe('Bayn HTTP probes', () => {
     await Effect.runPromise(
       Effect.scoped(
         Effect.gen(function* () {
-          const state = yield* Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null })
+          const state = yield* Ref.make(initialState())
           const context = yield* Layer.build(
             makeHttpLayer(
               { host: '127.0.0.1', operationTimeoutMs: 250, port: 0 },
@@ -304,6 +340,119 @@ describe('Bayn HTTP probes', () => {
         }),
       ),
     )
+  })
+})
+
+describe('Bayn continuous health', () => {
+  test('degrades on a probe defect, preserves evidence, and recovers only after a complete success', async () => {
+    const initial = readyState()
+    const state = await Effect.runPromise(Ref.make(initial))
+    let signalAvailable = false
+    let accountingChecks = 0
+    const marketData: MarketDataService = {
+      check: Effect.suspend(() =>
+        signalAvailable
+          ? Effect.succeed(makeSnapshot().manifest.finalizedSnapshot)
+          : Effect.die(new Error('Signal connection defect')),
+      ),
+      load: Effect.die(new Error('health probes must not load bars')),
+    }
+    const journal: JournalService = {
+      check: Effect.die(new Error('a durable run must use checkRun')),
+      checkRun: () => Effect.sync(() => void (accountingChecks += 1)),
+      journalAndReconcile: () => Effect.die(new Error('health probes must not write TigerBeetle')),
+    }
+    const dependencies = (effect: Effect.Effect<void, never, MarketData | Journal | EvidenceStore>) =>
+      effect.pipe(
+        Effect.provideService(MarketData, marketData),
+        Effect.provideService(Journal, journal),
+        Effect.provideService(EvidenceStore, recoveringStore(initial)),
+      )
+
+    await Effect.runPromise(dependencies(probe(config, state)))
+    expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
+      status: 'DEGRADED',
+      evidence: { evaluation: { runId: initial.evidence!.evaluation.runId } },
+      health: {
+        sequence: 2,
+        dependencies: {
+          postgresql: { status: 'AVAILABLE' },
+          signal: { status: 'UNAVAILABLE', error: 'Signal connection defect' },
+          tigerBeetle: { status: 'AVAILABLE' },
+          evidence: { status: 'AVAILABLE' },
+        },
+      },
+    })
+
+    signalAvailable = true
+    await Effect.runPromise(dependencies(probe(config, state)))
+    expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
+      status: 'READY',
+      error: null,
+      health: {
+        sequence: 3,
+        dependencies: {
+          postgresql: { status: 'AVAILABLE' },
+          signal: { status: 'AVAILABLE' },
+          tigerBeetle: { status: 'AVAILABLE' },
+          evidence: { status: 'AVAILABLE' },
+        },
+      },
+    })
+    expect(accountingChecks).toBe(2)
+  })
+
+  test('runs immediately and then on the configured Effect schedule', async () => {
+    const initial = readyState()
+    const state = await Effect.runPromise(Ref.make(initial))
+    let checks = 0
+    const marketData: MarketDataService = {
+      check: Effect.sync(() => {
+        checks += 1
+        return makeSnapshot().manifest.finalizedSnapshot
+      }),
+      load: Effect.die(new Error('health monitor must not load bars')),
+    }
+    const journal: JournalService = { ...successfulJournal, checkRun: () => Effect.void }
+    const program = Effect.scoped(
+      Effect.gen(function* () {
+        const fiber = yield* monitor({ ...config, healthIntervalMs: 100 }, state).pipe(
+          Effect.provideService(MarketData, marketData),
+          Effect.provideService(Journal, journal),
+          Effect.provideService(EvidenceStore, recoveringStore(initial)),
+          Effect.forkScoped({ startImmediately: true }),
+        )
+        yield* Effect.yieldNow
+        expect(checks).toBe(1)
+        yield* TestClock.adjust(99)
+        expect(checks).toBe(1)
+        yield* TestClock.adjust(1)
+        expect(checks).toBe(2)
+        yield* Fiber.interrupt(fiber)
+      }),
+    ).pipe(Effect.provide(TestClock.layer()))
+
+    await Effect.runPromise(program)
+  })
+
+  test('interrupts an in-flight probe when its scope closes', async () => {
+    const initial = readyState()
+    const state = await Effect.runPromise(Ref.make(initial))
+    let interrupted = false
+    const marketData: MarketDataService = {
+      check: Effect.never.pipe(Effect.onInterrupt(() => Effect.sync(() => void (interrupted = true)))),
+      load: Effect.die(new Error('health monitor must not load bars')),
+    }
+    const fiber = Effect.runFork(
+      monitor(config, state).pipe(
+        Effect.provideService(MarketData, marketData),
+        Effect.provideService(Journal, { ...successfulJournal, checkRun: () => Effect.void }),
+        Effect.provideService(EvidenceStore, recoveringStore(initial)),
+      ),
+    )
+    await Bun.sleep(10)
+    await Effect.runPromise(Fiber.interrupt(fiber))
+    expect(interrupted).toBe(true)
   })
 })
 
@@ -327,6 +476,7 @@ describe('Bayn startup lifecycle', () => {
     }
     const journal: JournalService = {
       check: Effect.void,
+      checkRun: () => Effect.void,
       journalAndReconcile: () => {
         journalWrites += 1
         return Effect.die(new Error('recovered startup must not journal'))
@@ -353,11 +503,11 @@ describe('Bayn startup lifecycle', () => {
         return Effect.die(new Error('recovered startup must not persist'))
       },
     }
-    const state = await Effect.runPromise(Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null }))
+    const state = await Effect.runPromise(Ref.make(initialState()))
 
     await Effect.runPromise(
       initialize(config, state).pipe(
-        Effect.provideService(MarketData, { load: Effect.succeed(snapshot) }),
+        Effect.provideService(MarketData, marketDataService(Effect.succeed(snapshot))),
         Effect.provideService(Journal, journal),
         Effect.provideService(EvidenceStore, store),
         Effect.provideService(Strategy, strategy),
@@ -370,7 +520,7 @@ describe('Bayn startup lifecycle', () => {
       persistenceWrites: 0,
     })
     expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
-      status: 'READY',
+      status: 'STARTING',
       evidence: {
         startupMode: 'recovered',
         evaluation: { runId: evaluation.runId },
@@ -407,16 +557,17 @@ describe('Bayn startup lifecycle', () => {
     }
     const journal: JournalService = {
       check: Effect.void,
+      checkRun: () => Effect.void,
       journalAndReconcile: () => {
         journalWrites += 1
         return Effect.die(new Error('corrupt recovery must not journal'))
       },
     }
-    const state = await Effect.runPromise(Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null }))
+    const state = await Effect.runPromise(Ref.make(initialState()))
 
     await Effect.runPromise(
       initialize(config, state).pipe(
-        Effect.provideService(MarketData, { load: Effect.succeed(snapshot) }),
+        Effect.provideService(MarketData, marketDataService(Effect.succeed(snapshot))),
         Effect.provideService(Journal, journal),
         Effect.provideService(EvidenceStore, store),
         Effect.provideService(Strategy, strategy),
@@ -425,7 +576,7 @@ describe('Bayn startup lifecycle', () => {
 
     expect({ evaluations, journalWrites }).toEqual({ evaluations: 0, journalWrites: 0 })
     expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
-      status: 'FAIL_CLOSED',
+      status: 'FAILED',
       evidence: null,
       error: expect.stringContaining('database.recover-evaluation'),
     })
@@ -434,7 +585,7 @@ describe('Bayn startup lifecycle', () => {
   test('evaluates through the provided strategy capability', async () => {
     let calls = 0
     const snapshot = makeSnapshot()
-    const state = await Effect.runPromise(Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null }))
+    const state = await Effect.runPromise(Ref.make(initialState()))
     const strategy: StrategyService = {
       name: 'test-strategy',
       universe: fixtureProtocol.universe,
@@ -449,7 +600,7 @@ describe('Bayn startup lifecycle', () => {
 
     await Effect.runPromise(
       initialize(config, state).pipe(
-        Effect.provideService(MarketData, { load: Effect.succeed(snapshot) }),
+        Effect.provideService(MarketData, marketDataService(Effect.succeed(snapshot))),
         Effect.provideService(Journal, successfulJournal),
         Effect.provideService(EvidenceStore, successfulEvidenceStore),
         Effect.provideService(Strategy, strategy),
@@ -457,13 +608,13 @@ describe('Bayn startup lifecycle', () => {
     )
 
     expect(calls).toBe(1)
-    expect(await Effect.runPromise(Ref.get(state))).toMatchObject({ status: 'READY' })
+    expect(await Effect.runPromise(Ref.get(state))).toMatchObject({ status: 'STARTING' })
   })
 
-  test('transitions from STARTING to READY after evaluation and reconciliation', async () => {
+  test('records durable evaluation and reconciliation before health opens readiness', async () => {
     const snapshot = makeSnapshot()
-    const state = await Effect.runPromise(Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null }))
-    const marketData: MarketDataService = { load: Effect.succeed(snapshot) }
+    const state = await Effect.runPromise(Ref.make(initialState()))
+    const marketData = marketDataService(Effect.succeed(snapshot))
 
     await Effect.runPromise(
       initialize(config, state).pipe(
@@ -475,16 +626,16 @@ describe('Bayn startup lifecycle', () => {
     )
 
     const current = await Effect.runPromise(Ref.get(state))
-    expect(current.status).toBe('READY')
-    if (current.status === 'READY') {
+    expect(current.status).toBe('STARTING')
+    if (current.evidence !== null) {
       expect(current.evidence.reconciliation.exact).toBe(true)
       expect(current.evidence.evaluation.eventCount).toBeGreaterThan(0)
     }
   })
 
-  test('turns strategy exceptions into an operational FAIL_CLOSED result', async () => {
-    const state = await Effect.runPromise(Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null }))
-    const marketData: MarketDataService = { load: Effect.succeed(makeSnapshot(700)) }
+  test('turns strategy exceptions into an operational failure', async () => {
+    const state = await Effect.runPromise(Ref.make(initialState()))
+    const marketData = marketDataService(Effect.succeed(makeSnapshot(700)))
 
     await Effect.runPromise(
       initialize(config, state).pipe(
@@ -496,45 +647,17 @@ describe('Bayn startup lifecycle', () => {
     )
 
     expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
-      status: 'FAIL_CLOSED',
+      status: 'FAILED',
       error: expect.stringContaining('strategy.evaluate'),
-    })
-  })
-
-  test('keeps readiness closed when startup evaluation is explicitly disabled', async () => {
-    let journaled = false
-    const state = await Effect.runPromise(Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null }))
-    const marketData: MarketDataService = { load: Effect.succeed(makeSnapshot()) }
-    const journal: JournalService = {
-      check: Effect.void,
-      journalAndReconcile: () => {
-        journaled = true
-        return Effect.die(new Error('journal should not run'))
-      },
-    }
-
-    await Effect.runPromise(
-      initialize({ ...config, runOnStartup: false }, state).pipe(
-        Effect.provideService(MarketData, marketData),
-        Effect.provideService(Journal, journal),
-        Effect.provideService(EvidenceStore, successfulEvidenceStore),
-        Effect.provide(TsmomStrategyLayer(fixtureProtocol, provenance)),
-      ),
-    )
-
-    expect(journaled).toBe(false)
-    expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
-      status: 'FAIL_CLOSED',
-      error: expect.stringContaining('BAYN_RUN_ON_STARTUP=false'),
     })
   })
 
   test('interrupts a stalled dependency and fails closed within the configured deadline', async () => {
     let interrupted = false
-    const state = await Effect.runPromise(Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null }))
-    const marketData: MarketDataService = {
-      load: Effect.never.pipe(Effect.onInterrupt(() => Effect.sync(() => void (interrupted = true)))),
-    }
+    const state = await Effect.runPromise(Ref.make(initialState()))
+    const marketData = marketDataService(
+      Effect.never.pipe(Effect.onInterrupt(() => Effect.sync(() => void (interrupted = true)))),
+    )
 
     await Effect.runPromise(
       initialize({ ...config, operationTimeoutMs: 10 }, state).pipe(
@@ -547,13 +670,13 @@ describe('Bayn startup lifecycle', () => {
 
     expect(interrupted).toBe(true)
     expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
-      status: 'FAIL_CLOSED',
+      status: 'FAILED',
       error: expect.stringContaining('market-data.load: load timed out'),
     })
   })
 
   test('propagates an unexpected defect instead of leaving a detached STARTING worker', async () => {
-    const marketData: MarketDataService = { load: Effect.die(new Error('unexpected startup defect')) }
+    const marketData = marketDataService(Effect.die(new Error('unexpected startup defect')))
     const exit = await Effect.runPromiseExit(
       run(config).pipe(
         Effect.provideService(MarketData, marketData),
@@ -576,7 +699,7 @@ describe('Bayn startup lifecycle', () => {
   })
 
   test('keeps readiness closed when durable evidence cannot be committed', async () => {
-    const state = await Effect.runPromise(Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null }))
+    const state = await Effect.runPromise(Ref.make(initialState()))
     const unavailable: EvidenceStoreService = {
       check: Effect.void,
       read: () => Effect.succeed(Option.none()),
@@ -593,7 +716,7 @@ describe('Bayn startup lifecycle', () => {
 
     await Effect.runPromise(
       initialize(config, state).pipe(
-        Effect.provideService(MarketData, { load: Effect.succeed(makeSnapshot()) }),
+        Effect.provideService(MarketData, marketDataService(Effect.succeed(makeSnapshot()))),
         Effect.provideService(Journal, successfulJournal),
         Effect.provideService(EvidenceStore, unavailable),
         Effect.provide(TsmomStrategyLayer(fixtureProtocol, provenance)),
@@ -601,7 +724,7 @@ describe('Bayn startup lifecycle', () => {
     )
 
     expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
-      status: 'FAIL_CLOSED',
+      status: 'FAILED',
       evidence: null,
       error: expect.stringContaining('database.persist-evaluation'),
     })
@@ -619,7 +742,7 @@ describe('Bayn startup lifecycle', () => {
       },
     }
     const dependencies = Layer.mergeAll(
-      Layer.succeed(MarketData, { load: Effect.succeed(makeSnapshot()) }),
+      Layer.succeed(MarketData, marketDataService(Effect.succeed(makeSnapshot()))),
       Layer.succeed(Journal, successfulJournal),
       EvidenceStoreRuntimeLive(unavailableDatabase).pipe(Layer.provide(NodeServices.layer)),
       TsmomStrategyLayer(fixtureProtocol, provenance),
@@ -627,18 +750,18 @@ describe('Bayn startup lifecycle', () => {
     const fiber = Effect.runFork(run(unavailableDatabase).pipe(Effect.provide(dependencies)))
 
     try {
-      const status = await waitForStatus(port, 'FAIL_CLOSED')
+      const status = await waitForStatus(port, 'FAILED')
       expect(status).toMatchObject({
         status: 200,
         body: {
-          status: 'FAIL_CLOSED',
+          operational: { status: 'FAILED' },
           error: expect.stringContaining('database.health-check'),
         },
       })
       expect(await fetchJson(port, '/livez')).toMatchObject({ status: 200, body: { live: true } })
       expect(await fetchJson(port, '/readyz')).toMatchObject({
         status: 503,
-        body: { ready: false, status: 'FAIL_CLOSED' },
+        body: { ready: false, status: 'FAILED' },
       })
     } finally {
       await Effect.runPromise(Fiber.interrupt(fiber))

--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -1,20 +1,26 @@
 import { createServer } from 'node:http'
 
 import { NodeHttpServer } from '@effect/platform-node'
-import { Effect, Layer, Option, Ref } from 'effect'
+import { Cause, Clock, Duration, Effect, Exit, Layer, Option, Ref, Schedule } from 'effect'
 import { HttpRouter, HttpServerRequest, HttpServerResponse } from 'effect/unstable/http'
 
 import type { RuntimeBuildMetadata, RuntimeConfig } from './config'
-import type { RuntimeProvenance } from './contracts'
-import { EvidenceStore, type EvidenceStoreService, type PersistenceReceipt } from './db/evidence-store'
+import type { FinalizedSnapshotProvenance, RuntimeProvenance } from './contracts'
+import {
+  EvidenceStore,
+  type EvidenceStoreService,
+  type PersistenceReceipt,
+  type RecoveredEvaluationEvidence,
+} from './db/evidence-store'
 import { formatError, operationalError, type Component, type OperationalError } from './errors'
+import { canonicalHashV1 } from './hash'
 import { Journal } from './ledger'
 import { MarketData } from './market-data'
 import { summarizeEvaluation } from './strategy'
 import { Strategy } from './strategy-service'
 import type { EvaluationSummary, ReconciliationResult } from './types'
 
-interface RuntimeEvidence {
+export interface RuntimeEvidence {
   readonly startupMode: 'evaluated' | 'recovered'
   readonly provenance: RuntimeProvenance
   readonly evaluation: EvaluationSummary
@@ -22,27 +28,115 @@ interface RuntimeEvidence {
   readonly persistence: PersistenceReceipt
 }
 
-export type RuntimeState =
-  | { readonly status: 'STARTING'; readonly evidence: null; readonly error: null }
-  | { readonly status: 'READY'; readonly evidence: RuntimeEvidence; readonly error: null }
-  | { readonly status: 'FAIL_CLOSED'; readonly evidence: null; readonly error: string }
+export interface DependencyHealth {
+  readonly status: 'UNKNOWN' | 'AVAILABLE' | 'UNAVAILABLE'
+  readonly checkedAt: string | null
+  readonly error: string | null
+}
+
+export interface RuntimeHealth {
+  readonly sequence: number
+  readonly checkedAt: string | null
+  readonly dependencies: {
+    readonly postgresql: DependencyHealth
+    readonly signal: DependencyHealth
+    readonly tigerBeetle: DependencyHealth
+    readonly evidence: DependencyHealth
+  }
+}
+
+export interface RuntimeState {
+  readonly status: 'STARTING' | 'READY' | 'DEGRADED' | 'FAILED'
+  readonly evidence: RuntimeEvidence | null
+  readonly health: RuntimeHealth
+  readonly error: string | null
+}
+
+const unknownDependency = (): DependencyHealth => ({ status: 'UNKNOWN', checkedAt: null, error: null })
+
+export const initialState = (): RuntimeState => ({
+  status: 'STARTING',
+  evidence: null,
+  health: {
+    sequence: 0,
+    checkedAt: null,
+    dependencies: {
+      postgresql: unknownDependency(),
+      signal: unknownDependency(),
+      tigerBeetle: unknownDependency(),
+      evidence: unknownDependency(),
+    },
+  },
+  error: null,
+})
+
+const allAvailable = (health: RuntimeHealth): boolean =>
+  Object.values(health.dependencies).every((dependency) => dependency.status === 'AVAILABLE')
+
+const isReady = (state: RuntimeState): boolean =>
+  state.status === 'READY' && state.evidence !== null && allAvailable(state.health)
 
 const json = (value: unknown): string =>
   JSON.stringify(value, (_, nested) => (typeof nested === 'bigint' ? nested.toString() : nested))
+
+const verifiedState = (evidence: RuntimeEvidence | null, dependency: DependencyHealth) => {
+  if (evidence === null || dependency.status === 'UNKNOWN') return 'UNKNOWN'
+  return dependency.status === 'AVAILABLE' ? 'CURRENT' : 'INVALID'
+}
 
 const publicState = (
   state: RuntimeState,
   provenance: RuntimeProvenance,
   provenanceVerification: RuntimeBuildMetadata['verification'],
-) => ({
-  service: 'bayn',
-  status: state.status,
-  authority: { brokerOrders: false, capitalPromotion: false },
-  provenanceVerification,
-  provenance,
-  evidence: state.evidence,
-  error: state.error,
-})
+) => {
+  let economic = 'UNKNOWN'
+  let accounting = 'UNKNOWN'
+  if (state.evidence !== null) {
+    economic = state.evidence.evaluation.verdict.status === 'PASS' ? 'QUALIFIED' : 'REJECTED'
+    if (state.health.dependencies.tigerBeetle.status === 'AVAILABLE') accounting = 'EXACT'
+    if (state.health.dependencies.tigerBeetle.status === 'UNAVAILABLE') accounting = 'UNAVAILABLE'
+  }
+
+  return {
+    service: 'bayn',
+    operational: {
+      status: state.status,
+      ready: isReady(state),
+      probeSequence: state.health.sequence,
+      checkedAt: state.health.checkedAt,
+    },
+    dependencies: state.health.dependencies,
+    data: {
+      status: verifiedState(state.evidence, state.health.dependencies.signal),
+      input: state.evidence?.evaluation.input ?? null,
+    },
+    evidence: {
+      status: verifiedState(state.evidence, state.health.dependencies.evidence),
+      runId: state.evidence?.evaluation.runId ?? null,
+      startupMode: state.evidence?.startupMode ?? null,
+      persistence: state.evidence?.persistence ?? null,
+    },
+    economic: {
+      status: economic,
+      verdict: state.evidence?.evaluation.verdict ?? null,
+    },
+    accounting: {
+      status: accounting,
+      reconciliation: state.evidence?.reconciliation ?? null,
+    },
+    authority: {
+      maximum: 'observe',
+      brokerOrders: false,
+      capitalPromotion: false,
+    },
+    build: {
+      sourceRevision: provenance.sourceRevision,
+      image: provenance.image,
+      verification: provenanceVerification,
+    },
+    error: state.error,
+  }
+}
 
 const jsonResponse = (body: unknown, status = 200, headers?: Readonly<Record<string, string>>) =>
   HttpServerResponse.text(json(body), { status, contentType: 'application/json', headers })
@@ -56,8 +150,20 @@ export const makeHttpLayer = (
 ): ReturnType<typeof NodeHttpServer.layer> => {
   const ready = Ref.get(state).pipe(
     Effect.map((current) => {
-      const isReady = current.status === 'READY'
-      return jsonResponse({ ready: isReady, status: current.status }, isReady ? 200 : 503)
+      const ready = isReady(current)
+      const failedDependencies = Object.entries(current.health.dependencies)
+        .filter(([, dependency]) => dependency.status !== 'AVAILABLE')
+        .map(([name]) => name)
+      return jsonResponse(
+        {
+          ready,
+          status: current.status,
+          checkedAt: current.health.checkedAt,
+          probeSequence: current.health.sequence,
+          failedDependencies,
+        },
+        ready ? 200 : 503,
+      )
     }),
   )
   const status = Ref.get(state).pipe(
@@ -122,8 +228,8 @@ const withinDeadline = <A, R>(
     }),
   )
 
-const failClosed = (state: Ref.Ref<RuntimeState>, error: OperationalError): Effect.Effect<void> =>
-  Effect.logError('Bayn startup failed closed').pipe(
+const failStartup = (state: Ref.Ref<RuntimeState>, error: OperationalError): Effect.Effect<void> =>
+  Effect.logError('Bayn startup failed').pipe(
     Effect.annotateLogs({
       service: 'bayn',
       component: error.component,
@@ -131,11 +237,15 @@ const failClosed = (state: Ref.Ref<RuntimeState>, error: OperationalError): Effe
       error: error.message,
     }),
     Effect.andThen(
-      Ref.set(state, {
-        status: 'FAIL_CLOSED',
-        evidence: null,
-        error: formatError(error),
-      }),
+      Ref.update(
+        state,
+        (current): RuntimeState => ({
+          ...current,
+          status: 'FAILED',
+          evidence: null,
+          error: formatError(error),
+        }),
+      ),
     ),
   )
 
@@ -191,17 +301,20 @@ const evaluateAndJournal = (
       'recover-evaluation',
     )
     if (Option.isSome(recovered)) {
-      yield* Ref.set(state, {
-        status: 'READY',
-        evidence: {
-          startupMode: 'recovered',
-          provenance: strategy.provenance,
-          evaluation: recovered.value.evaluation,
-          reconciliation: recovered.value.reconciliation,
-          persistence: recovered.value.persistence,
-        },
-        error: null,
-      })
+      yield* Ref.update(
+        state,
+        (current): RuntimeState => ({
+          ...current,
+          evidence: {
+            startupMode: 'recovered',
+            provenance: strategy.provenance,
+            evaluation: recovered.value.evaluation,
+            reconciliation: recovered.value.reconciliation,
+            persistence: recovered.value.persistence,
+          },
+          error: null,
+        }),
+      )
       yield* Effect.logInfo('Bayn startup proof recovered').pipe(
         Effect.annotateLogs({
           service: 'bayn',
@@ -246,18 +359,21 @@ const evaluateAndJournal = (
       'database',
       'persist-evaluation',
     )
-    yield* Ref.set(state, {
-      status: 'READY',
-      evidence: {
-        startupMode: 'evaluated',
-        provenance: strategy.provenance,
-        evaluation: summarizeEvaluation(evaluation),
-        reconciliation,
-        persistence,
-      },
-      error: null,
-    })
-    yield* Effect.logInfo('Bayn startup proof is ready').pipe(
+    yield* Ref.update(
+      state,
+      (current): RuntimeState => ({
+        ...current,
+        evidence: {
+          startupMode: 'evaluated',
+          provenance: strategy.provenance,
+          evaluation: summarizeEvaluation(evaluation),
+          reconciliation,
+          persistence,
+        },
+        error: null,
+      }),
+    )
+    yield* Effect.logInfo('Bayn startup proof is durable').pipe(
       Effect.annotateLogs({
         service: 'bayn',
         runId: evaluation.runId,
@@ -269,36 +385,167 @@ const evaluateAndJournal = (
     )
   }).pipe(Effect.withLogSpan('startup'))
 
-const checkWithoutJournal = (
-  config: RuntimeConfig,
-  state: Ref.Ref<RuntimeState>,
-): Effect.Effect<void, OperationalError, MarketData | Journal | EvidenceStore> =>
-  Effect.gen(function* () {
-    const marketData = yield* MarketData
-    const journal = yield* Journal
-    const evidenceStore = yield* EvidenceStore
-    yield* withinDeadline(journal.check, config.operationTimeoutMs, 'journal', 'connectivity-check')
-    yield* withinDeadline(
-      databaseOperation(evidenceStore.check, 'health-check'),
-      config.operationTimeoutMs,
-      'database',
-      'health-check',
-    )
-    yield* withinDeadline(marketData.load, config.operationTimeoutMs, 'market-data', 'load')
-    yield* Ref.set(state, {
-      status: 'FAIL_CLOSED',
-      evidence: null,
-      error: 'BAYN_RUN_ON_STARTUP=false; evaluation and accounting proof were not executed',
-    })
-  })
-
 export const initialize = (
   config: RuntimeConfig,
   state: Ref.Ref<RuntimeState>,
 ): Effect.Effect<void, never, MarketData | Journal | Strategy | EvidenceStore> =>
-  (config.runOnStartup ? evaluateAndJournal(config, state) : checkWithoutJournal(config, state)).pipe(
-    Effect.catch((error) => failClosed(state, error)),
-  )
+  evaluateAndJournal(config, state).pipe(Effect.catch((error) => failStartup(state, error)))
+
+interface ProbeResult<A> {
+  readonly value: A | null
+  readonly error: string | null
+}
+
+const observe = <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<ProbeResult<A>, never, R> =>
+  Effect.gen(function* () {
+    const exit = yield* Effect.exit(effect)
+    if (Exit.isSuccess(exit)) return { value: exit.value, error: null }
+    if (Cause.hasInterrupts(exit.cause)) return yield* Effect.interrupt
+    const errors = Cause.prettyErrors(exit.cause).map((error) => error.message)
+    return { value: null, error: errors.join('; ') || 'unknown probe failure' }
+  })
+
+const ensureSignalIdentity = (
+  snapshot: FinalizedSnapshotProvenance,
+  evidence: RuntimeEvidence | null,
+): Effect.Effect<void, OperationalError> =>
+  Effect.try({
+    try: () => {
+      if (evidence === null) throw new Error('startup evidence is unavailable')
+      if (snapshot.snapshotId !== evidence.evaluation.input.snapshotId) {
+        throw new Error('configured Signal snapshot differs from the active run')
+      }
+      if (snapshot.publicationId !== evidence.evaluation.input.publicationId) {
+        throw new Error('configured Signal publication differs from the active run')
+      }
+    },
+    catch: (cause) => operationalError('market-data', 'check-identity', 'Signal identity check failed', cause),
+  })
+
+const durableMaterial = (evidence: RuntimeEvidence | RecoveredEvaluationEvidence) => ({
+  evaluation: evidence.evaluation,
+  reconciliation: evidence.reconciliation,
+  persistence: {
+    runId: evidence.persistence.runId,
+    artifactCount: evidence.persistence.artifactCount,
+    eventCount: evidence.persistence.eventCount,
+    gateCount: evidence.persistence.gateCount,
+  },
+})
+
+const ensureDurableEvidence = (
+  recovered: Option.Option<RecoveredEvaluationEvidence>,
+  evidence: RuntimeEvidence | null,
+): Effect.Effect<void, OperationalError> =>
+  Effect.try({
+    try: () => {
+      if (evidence === null) throw new Error('startup evidence is unavailable')
+      if (Option.isNone(recovered)) throw new Error(`durable run ${evidence.evaluation.runId} is missing`)
+      if (canonicalHashV1(durableMaterial(recovered.value)) !== canonicalHashV1(durableMaterial(evidence))) {
+        throw new Error(`durable run ${evidence.evaluation.runId} differs from the active proof`)
+      }
+    },
+    catch: (cause) => operationalError('database', 'verify-evidence', 'durable evidence verification failed', cause),
+  })
+
+const dependencyHealth = (result: ProbeResult<unknown>, checkedAt: string): DependencyHealth => ({
+  status: result.error === null ? 'AVAILABLE' : 'UNAVAILABLE',
+  checkedAt,
+  error: result.error,
+})
+
+export const probe = (
+  config: RuntimeConfig,
+  state: Ref.Ref<RuntimeState>,
+): Effect.Effect<void, never, MarketData | Journal | EvidenceStore> =>
+  Effect.gen(function* () {
+    const marketData = yield* MarketData
+    const journal = yield* Journal
+    const evidenceStore = yield* EvidenceStore
+    const current = yield* Ref.get(state)
+    const evidence = current.evidence
+    const [postgresql, signal, tigerBeetle, durableEvidence] = yield* Effect.all(
+      [
+        observe(
+          withinDeadline(
+            databaseOperation(evidenceStore.check, 'continuous-health'),
+            config.operationTimeoutMs,
+            'database',
+            'continuous-health',
+          ),
+        ),
+        observe(
+          withinDeadline(marketData.check, config.operationTimeoutMs, 'market-data', 'continuous-health').pipe(
+            Effect.flatMap((snapshot) => ensureSignalIdentity(snapshot, evidence)),
+          ),
+        ),
+        observe(
+          withinDeadline(
+            evidence === null ? journal.check : journal.checkRun(evidence.reconciliation),
+            config.operationTimeoutMs,
+            'journal',
+            'continuous-health',
+          ),
+        ),
+        observe(
+          evidence === null
+            ? Effect.fail(operationalError('database', 'verify-evidence', 'startup evidence is unavailable'))
+            : withinDeadline(
+                databaseOperation(
+                  evidenceStore.recover(evidence.evaluation.runId, evidence.provenance),
+                  'continuous-recovery',
+                ),
+                config.operationTimeoutMs,
+                'database',
+                'continuous-recovery',
+              ).pipe(Effect.flatMap((recovered) => ensureDurableEvidence(recovered, evidence))),
+        ),
+      ],
+      { concurrency: 'unbounded' },
+    )
+    const checkedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
+    const health: RuntimeHealth = {
+      sequence: current.health.sequence + 1,
+      checkedAt,
+      dependencies: {
+        postgresql: dependencyHealth(postgresql, checkedAt),
+        signal: dependencyHealth(signal, checkedAt),
+        tigerBeetle: dependencyHealth(tigerBeetle, checkedAt),
+        evidence: dependencyHealth(durableEvidence, checkedAt),
+      },
+    }
+    const failures = Object.entries(health.dependencies).filter(([, dependency]) => dependency.error !== null)
+    let next: RuntimeState = { ...current, health }
+    if (evidence !== null && failures.length === 0) {
+      next = { ...current, status: 'READY', health, error: null }
+    } else if (evidence !== null) {
+      next = {
+        ...current,
+        status: 'DEGRADED',
+        health,
+        error: failures.map(([name, dependency]) => `${name}: ${dependency.error}`).join('; '),
+      }
+    }
+    yield* Ref.set(state, next)
+
+    if (next.status !== current.status) {
+      const log = next.status === 'READY' ? Effect.logInfo : Effect.logWarning
+      yield* log(`Bayn health changed to ${next.status}`).pipe(
+        Effect.annotateLogs({
+          service: 'bayn',
+          checkedAt,
+          probeSequence: health.sequence,
+          failedDependencies: failures.map(([name]) => name).join(','),
+        }),
+      )
+    }
+  }).pipe(Effect.withLogSpan('health'))
+
+export const monitor = (
+  config: RuntimeConfig,
+  state: Ref.Ref<RuntimeState>,
+): Effect.Effect<void, never, MarketData | Journal | EvidenceStore> =>
+  probe(config, state).pipe(Effect.repeat(Schedule.spaced(Duration.millis(config.healthIntervalMs))), Effect.asVoid)
 
 export const run = (
   config: RuntimeConfig,
@@ -307,11 +554,12 @@ export const run = (
     Effect.gen(function* () {
       const strategy = yield* Strategy
       const evidenceStore = yield* EvidenceStore
-      const state = yield* Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null })
+      const state = yield* Ref.make(initialState())
       yield* Layer.build(
         makeHttpLayer(config, state, strategy.provenance, config.build.verification, evidenceStore),
       ).pipe(Effect.mapError((cause) => operationalError('http', 'listen', 'HTTP server failed to listen', cause)))
       yield* initialize(config, state)
+      yield* monitor(config, state).pipe(Effect.forkScoped({ startImmediately: true }))
       return yield* Effect.never
     }),
   )

--- a/services/bayn/src/clickhouse-patch.test.ts
+++ b/services/bayn/src/clickhouse-patch.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from 'bun:test'
+import { createServer } from 'node:http'
+
+import { NodeHttpClient } from '@effect/platform-node'
+import { ClickhouseClient } from '@effect/sql-clickhouse'
+import { Effect, Layer } from 'effect'
+
+const listen = (server: ReturnType<typeof createServer>): Promise<number> =>
+  new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      if (address === null || typeof address === 'string') {
+        reject(new Error('ClickHouse test server did not bind a TCP port'))
+        return
+      }
+      resolve(address.port)
+    })
+  })
+
+test('Effect ClickHouse drains its connection check before exposing the client', async () => {
+  let responseFinished = false
+  let requests = 0
+  const server = createServer((_, response) => {
+    requests += 1
+    response.writeHead(200, { 'content-type': 'text/plain; charset=UTF-8', 'x-clickhouse-summary': '{}' })
+    response.flushHeaders()
+    response.write('1\n')
+    setTimeout(() => {
+      responseFinished = true
+      response.end()
+    }, 250)
+  })
+  const port = await listen(server)
+
+  try {
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          yield* ClickhouseClient.ClickhouseClient
+          expect(responseFinished).toBe(true)
+        }).pipe(
+          Effect.provide(
+            ClickhouseClient.layer({
+              url: `http://127.0.0.1:${port}`,
+              username: 'default',
+              password: '',
+              database: 'signal',
+              application: 'bayn-patch-test',
+              request_timeout: 1_000,
+            }).pipe(Layer.provide(NodeHttpClient.layerNodeHttp)),
+          ),
+        ),
+      ),
+    )
+    expect(requests).toBe(1)
+  } finally {
+    server.close()
+    server.closeAllConnections()
+  }
+})

--- a/services/bayn/src/config.test.ts
+++ b/services/bayn/src/config.test.ts
@@ -44,6 +44,7 @@ describe('Effect configuration', () => {
 
     expect(config.host).toBe('0.0.0.0')
     expect(config.port).toBe(8080)
+    expect(config.healthIntervalMs).toBe(30_000)
     expect(config.operationTimeoutMs).toBe(30_000)
     expect(config.clickhouse).toMatchObject({
       snapshotId: 'd'.repeat(64),
@@ -82,7 +83,6 @@ describe('Effect configuration', () => {
       verification: 'development-configured',
     })
     expect(config.build.strategyBehaviorHash).toMatch(/^[a-f0-9]{64}$/)
-    expect(config.runOnStartup).toBe(false)
   })
 
   test('does not let missing build facts or development mode bypass production verification', async () => {

--- a/services/bayn/src/config.ts
+++ b/services/bayn/src/config.ts
@@ -14,7 +14,7 @@ export interface RuntimeConfig {
   readonly host: string
   readonly port: number
   readonly build: RuntimeBuildMetadata
-  readonly runOnStartup: boolean
+  readonly healthIntervalMs: number
   readonly operationTimeoutMs: number
   readonly clickhouse: {
     readonly url: string
@@ -72,7 +72,7 @@ const runtimeConfig = Config.all({
   imageRepository: Config.schema(ImageRepository, 'BAYN_IMAGE_REPOSITORY'),
   imageDigest: Config.schema(ImageDigest, 'BAYN_IMAGE_DIGEST'),
   provenanceMode: Config.schema(ProvenanceMode, 'BAYN_PROVENANCE_MODE').pipe(Config.withDefault('production')),
-  runOnStartup: Config.boolean('BAYN_RUN_ON_STARTUP').pipe(Config.withDefault(true)),
+  healthIntervalMs: positiveInteger('BAYN_HEALTH_INTERVAL_MS', 30_000),
   operationTimeoutMs: positiveInteger('BAYN_OPERATION_TIMEOUT_MS', 30_000),
   clickhouseUrl: nonEmptyString('BAYN_CLICKHOUSE_URL'),
   clickhouseUsername: nonEmptyString('BAYN_CLICKHOUSE_USERNAME'),
@@ -105,7 +105,7 @@ const runtimeConfig = Config.all({
       imageDigest: config.imageDigest,
     },
     provenanceMode: config.provenanceMode,
-    runOnStartup: config.runOnStartup,
+    healthIntervalMs: config.healthIntervalMs,
     operationTimeoutMs: config.operationTimeoutMs,
     clickhouse: {
       url: config.clickhouseUrl,
@@ -192,7 +192,6 @@ export const loadConfig = (
           return {
             ...runtime,
             clickhouse: runtime.clickhouse,
-            runOnStartup: provenanceMode === 'production' ? runtime.runOnStartup : false,
             build: {
               ...decodedBuild,
               imageDigest: configuredBuild.imageDigest,

--- a/services/bayn/src/contracts.test.ts
+++ b/services/bayn/src/contracts.test.ts
@@ -5,17 +5,12 @@ import { Effect, Exit, Schema } from 'effect'
 import {
   FinalizedSnapshotProvenanceSchema,
   RunIdentitySchema,
-  StatusSnapshotSchema,
-  classifyEvidenceFreshness,
   decodeEvaluationBounds,
-  decodeEvidenceFreshness,
   decodeFinalizedSnapshot,
   decodeRunIdentity,
   decodeRuntimeProvenance,
-  decodeStatusSnapshot,
   makeRunIdentity,
   makeRuntimeProvenance,
-  makeStatusSnapshot,
 } from './contracts'
 
 const sha = (character: string): string => character.repeat(64)
@@ -85,19 +80,6 @@ describe('Bayn contract decoding', () => {
     expect(decodedSnapshot).toEqual(snapshot)
     expect(Schema.encodeSync(FinalizedSnapshotProvenanceSchema)(decodedSnapshot)).toEqual(snapshot)
     expect(await Effect.runPromise(decodeEvaluationBounds(bounds))).toEqual(bounds)
-
-    const freshness = {
-      schemaVersion: 'bayn.evidence-freshness.v1' as const,
-      observedAt: '2026-01-01T01:00:00.000Z',
-      validThrough: '2026-01-01T02:00:00.000Z',
-    }
-    expect(await Effect.runPromise(decodeEvidenceFreshness(freshness))).toEqual(freshness)
-    await expectFailure(
-      decodeEvidenceFreshness({
-        ...freshness,
-        observedAt: '2026-01-01T03:00:00.000Z',
-      }),
-    )
   })
 
   test('rejects malformed dates, duplicate symbols, and invalid bounds', async () => {
@@ -202,62 +184,5 @@ describe('Bayn runtime provenance', () => {
     expect(await Effect.runPromise(decodeRuntimeProvenance(provenance))).toEqual(provenance)
     await expectFailure(decodeRuntimeProvenance({ ...provenance, futureField: true }))
     await expectFailure(decodeRuntimeProvenance({ ...provenance, schemaVersion: 'bayn.runtime-provenance.v2' }))
-  })
-})
-
-describe('Bayn evidence and authority state', () => {
-  const healthy = {
-    observedAt: '2026-01-01T01:30:00.000Z',
-    operational: 'RUNNING' as const,
-    dependency: 'AVAILABLE' as const,
-    data: 'FRESH' as const,
-    evidence: 'CURRENT' as const,
-    economic: 'QUALIFIED' as const,
-    reconciliation: 'EXACT' as const,
-    kill: 'CLEAR' as const,
-  }
-
-  test('classifies freshness from an explicit clock value', () => {
-    const freshness = {
-      schemaVersion: 'bayn.evidence-freshness.v1' as const,
-      observedAt: '2026-01-01T01:00:00.000Z',
-      validThrough: '2026-01-01T02:00:00.000Z',
-    }
-
-    expect(classifyEvidenceFreshness(freshness, '2026-01-01T01:30:00.000Z')).toBe('CURRENT')
-    expect(classifyEvidenceFreshness(freshness, '2026-01-01T03:00:00.000Z')).toBe('STALE')
-    expect(classifyEvidenceFreshness(freshness, '2026-01-01T00:30:00.000Z')).toBe('INVALID')
-  })
-
-  test('derives exercisable authority and fails closed on stale or unknown facts', async () => {
-    const paper = makeStatusSnapshot({ ...healthy, maximumAuthority: 'paper' })
-    expect(paper.exercisableAuthority).toBe('paper')
-    expect(Schema.encodeSync(StatusSnapshotSchema)(paper)).toEqual(paper)
-
-    const stale = makeStatusSnapshot({ ...healthy, evidence: 'STALE', maximumAuthority: 'paper' })
-    const unknown = makeStatusSnapshot({ ...healthy, dependency: 'UNKNOWN', maximumAuthority: 'paper' })
-    const killed = makeStatusSnapshot({ ...healthy, kill: 'ENGAGED', maximumAuthority: 'paper' })
-    expect(stale.exercisableAuthority).toBe('none')
-    expect(unknown.exercisableAuthority).toBe('none')
-    expect(killed.exercisableAuthority).toBe('none')
-
-    await expectFailure(decodeStatusSnapshot({ ...stale, exercisableAuthority: 'paper' }))
-    await expectFailure(decodeStatusSnapshot({ ...paper, exercisableAuthority: 'live-bounded' }))
-    await expectFailure(decodeStatusSnapshot({ ...paper, dependency: 'PARTIAL' }))
-  })
-
-  test('keeps economic state separate from safe observation', () => {
-    const rejected = makeStatusSnapshot({
-      ...healthy,
-      economic: 'REJECTED',
-      maximumAuthority: 'paper',
-    })
-    expect(rejected.exercisableAuthority).toBe('observe')
-
-    const observeOnly = makeStatusSnapshot({
-      ...healthy,
-      maximumAuthority: 'observe',
-    })
-    expect(observeOnly.exercisableAuthority).toBe('observe')
   })
 })

--- a/services/bayn/src/contracts.ts
+++ b/services/bayn/src/contracts.ts
@@ -208,104 +208,14 @@ export const makeStrategyProtocolHash = (strategy: RuntimeProvenance['strategy']
     parameterSchemaVersion: strategy.parameterSchemaVersion,
   })
 
-const EvidenceFreshnessBase = Schema.Struct({
-  schemaVersion: Schema.Literal('bayn.evidence-freshness.v1'),
-  observedAt: UtcInstant,
-  validThrough: UtcInstant,
-})
-
-export const EvidenceFreshnessSchema = EvidenceFreshnessBase.check(
-  Schema.makeFilter(
-    (freshness: typeof EvidenceFreshnessBase.Type) =>
-      freshness.observedAt <= freshness.validThrough ||
-      ({ path: ['validThrough'], issue: 'must not precede observedAt' } as const),
-  ),
-)
-export type EvidenceFreshness = typeof EvidenceFreshnessSchema.Type
-
-export const OperationalStateSchema = Schema.Literals(['STARTING', 'RUNNING', 'STOPPING', 'FAILED'])
-export const DependencyStateSchema = Schema.Literals(['UNKNOWN', 'AVAILABLE', 'UNAVAILABLE'])
-export const DataStateSchema = Schema.Literals(['UNKNOWN', 'FRESH', 'STALE', 'INVALID'])
-export const EvidenceStateSchema = Schema.Literals(['UNKNOWN', 'CURRENT', 'STALE', 'INVALID'])
-export const EconomicStateSchema = Schema.Literals(['UNKNOWN', 'QUALIFIED', 'REJECTED'])
-export const ReconciliationStateSchema = Schema.Literals(['UNKNOWN', 'EXACT', 'DISCREPANCY'])
-export const KillStateSchema = Schema.Literals(['UNKNOWN', 'CLEAR', 'ENGAGED'])
-export const MaximumAuthoritySchema = Schema.Literals(['observe', 'paper', 'live-bounded'])
-export const ExercisableAuthoritySchema = Schema.Literals(['none', 'observe', 'paper', 'live-bounded'])
-
-export type OperationalState = typeof OperationalStateSchema.Type
-export type DependencyState = typeof DependencyStateSchema.Type
-export type DataState = typeof DataStateSchema.Type
-export type EvidenceState = typeof EvidenceStateSchema.Type
-export type EconomicState = typeof EconomicStateSchema.Type
-export type ReconciliationState = typeof ReconciliationStateSchema.Type
-export type KillState = typeof KillStateSchema.Type
-export type MaximumAuthority = typeof MaximumAuthoritySchema.Type
-export type ExercisableAuthority = typeof ExercisableAuthoritySchema.Type
-
-export interface StatusAxes {
-  readonly operational: OperationalState
-  readonly dependency: DependencyState
-  readonly data: DataState
-  readonly evidence: EvidenceState
-  readonly economic: EconomicState
-  readonly reconciliation: ReconciliationState
-  readonly kill: KillState
-}
-
-const deriveExercisableAuthority = (
-  state: StatusAxes & { readonly maximumAuthority: MaximumAuthority },
-): ExercisableAuthority => {
-  const canObserve =
-    state.operational === 'RUNNING' &&
-    state.dependency === 'AVAILABLE' &&
-    state.data === 'FRESH' &&
-    state.evidence === 'CURRENT' &&
-    state.reconciliation === 'EXACT' &&
-    state.kill === 'CLEAR'
-  if (!canObserve) return 'none'
-  if (state.maximumAuthority === 'observe' || state.economic !== 'QUALIFIED') return 'observe'
-  return state.maximumAuthority
-}
-
-const StatusSnapshotBase = Schema.Struct({
-  schemaVersion: Schema.Literal('bayn.status.v1'),
-  observedAt: UtcInstant,
-  operational: OperationalStateSchema,
-  dependency: DependencyStateSchema,
-  data: DataStateSchema,
-  evidence: EvidenceStateSchema,
-  economic: EconomicStateSchema,
-  reconciliation: ReconciliationStateSchema,
-  kill: KillStateSchema,
-  maximumAuthority: MaximumAuthoritySchema,
-  exercisableAuthority: ExercisableAuthoritySchema,
-})
-
-export const StatusSnapshotSchema = StatusSnapshotBase.check(
-  Schema.makeFilter(
-    (state: typeof StatusSnapshotBase.Type) =>
-      state.exercisableAuthority === deriveExercisableAuthority(state) ||
-      ({
-        path: ['exercisableAuthority'],
-        issue: `must be ${deriveExercisableAuthority(state)} for the reported state`,
-      } as const),
-  ),
-)
-export type StatusSnapshot = typeof StatusSnapshotSchema.Type
-export type StatusSnapshotInput = Omit<StatusSnapshot, 'schemaVersion' | 'exercisableAuthority'>
-
 export const decodeFinalizedSnapshot = Schema.decodeUnknownEffect(FinalizedSnapshotProvenanceSchema, StrictParseOptions)
 export const decodeEvaluationBounds = Schema.decodeUnknownEffect(EvaluationBoundsSchema, StrictParseOptions)
 export const decodeRunIdentity = Schema.decodeUnknownEffect(RunIdentitySchema, StrictParseOptions)
 export const decodeRuntimeProvenance = Schema.decodeUnknownEffect(RuntimeProvenanceSchema, StrictParseOptions)
-export const decodeEvidenceFreshness = Schema.decodeUnknownEffect(EvidenceFreshnessSchema, StrictParseOptions)
-export const decodeStatusSnapshot = Schema.decodeUnknownEffect(StatusSnapshotSchema, StrictParseOptions)
 
 const decodeRunIdentityMaterialSync = Schema.decodeUnknownSync(RunIdentityMaterialSchema, StrictParseOptions)
 const decodeRunIdentitySync = Schema.decodeUnknownSync(RunIdentitySchema, StrictParseOptions)
 const decodeRuntimeProvenanceSync = Schema.decodeUnknownSync(RuntimeProvenanceSchema, StrictParseOptions)
-const decodeStatusSnapshotSync = Schema.decodeUnknownSync(StatusSnapshotSchema, StrictParseOptions)
 
 export const makeRunIdentity = (input: RunIdentityMaterial): RunIdentity => {
   const material = decodeRunIdentityMaterialSync(input)
@@ -321,17 +231,4 @@ export const makeRuntimeProvenance = (input: RuntimeProvenanceInput): RuntimePro
       inputManifest: 'bayn.input-manifest.v2',
       evaluation: 'bayn.evaluation.v2',
     },
-  })
-
-export const classifyEvidenceFreshness = (freshness: EvidenceFreshness, now: string): EvidenceState => {
-  if (!isUtcInstant(now)) throw new TypeError('now must be a canonical UTC instant')
-  if (now < freshness.observedAt) return 'INVALID'
-  return now <= freshness.validThrough ? 'CURRENT' : 'STALE'
-}
-
-export const makeStatusSnapshot = (input: StatusSnapshotInput): StatusSnapshot =>
-  decodeStatusSnapshotSync({
-    schemaVersion: 'bayn.status.v1',
-    ...input,
-    exercisableAuthority: deriveExercisableAuthority(input),
   })

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -30,7 +30,7 @@ const makeConfig = (url = testUrl): RuntimeConfig => ({
     strategyBehaviorHash: 'c'.repeat(64),
     verification: 'embedded',
   },
-  runOnStartup: true,
+  healthIntervalMs: 30_000,
   operationTimeoutMs: 1_000,
   clickhouse: {
     url: 'http://clickhouse.invalid',

--- a/services/bayn/src/ledger.test.ts
+++ b/services/bayn/src/ledger.test.ts
@@ -1,8 +1,16 @@
 import { describe, expect, test } from 'bun:test'
-import { Effect } from 'effect'
-import type { Account, Transfer } from 'tigerbeetle-node'
+import { Effect, Redacted } from 'effect'
+import { createClient as createTigerBeetleClient, type Account, type Client, type Transfer } from 'tigerbeetle-node'
 
-import { assertReconciled, buildLedgerPlan, resolveReplicaAddresses } from './ledger'
+import type { RuntimeConfig } from './config'
+import {
+  assertReconciled,
+  buildLedgerPlan,
+  Journal,
+  JournalLive,
+  resolveReplicaAddresses,
+  type JournalService,
+} from './ledger'
 import { evaluateTsmom } from './strategy'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
 
@@ -51,6 +59,81 @@ describe('TigerBeetle simulation journal', () => {
         transfers,
       ),
     ).toThrow('balance does not reconcile exactly')
+  })
+
+  test('checks the persisted run read-only and rejects changed TigerBeetle balances', async () => {
+    const snapshot = makeSnapshot()
+    const provenance = makeTestProvenance()
+    const result = evaluateTsmom(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance)
+    const plan = buildLedgerPlan(result, 7001)
+    let accounts = materializeAccounts(plan)
+    const transfers = materializeTransfers(plan)
+    let writes = 0
+    const client = {
+      queryAccounts: async () => accounts,
+      queryTransfers: async () => transfers,
+      createAccounts: async () => {
+        writes += 1
+        return []
+      },
+      createTransfers: async () => {
+        writes += 1
+        return []
+      },
+      destroy: () => undefined,
+    } as unknown as Client
+    const config: RuntimeConfig = {
+      host: '127.0.0.1',
+      port: 0,
+      build: {
+        sourceRevision: provenance.sourceRevision,
+        imageRepository: provenance.image.repository,
+        imageDigest: provenance.image.digest,
+        strategyBehaviorHash: provenance.strategy.behaviorHash,
+        verification: 'embedded',
+      },
+      healthIntervalMs: 30_000,
+      operationTimeoutMs: 1_000,
+      clickhouse: {
+        url: 'http://clickhouse.test',
+        username: 'bayn',
+        password: Redacted.make('unused'),
+        snapshotId: snapshot.manifest.finalizedSnapshot.snapshotId,
+        publicationAsOf: snapshot.manifest.finalizedSnapshot.asOfSession,
+        calendarVersion: snapshot.manifest.finalizedSnapshot.calendarVersion,
+        bounds: snapshot.manifest.bounds,
+      },
+      postgres: { url: Redacted.make('postgresql://unused'), tls: false, caPath: '/unused' },
+      tigerBeetle: { clusterId: 2001n, replicaAddresses: ['3000'], ledger: 7001 },
+    }
+    const check = (journal: JournalService) =>
+      journal.checkRun({
+        runId: result.runId,
+        accountCount: accounts.length,
+        transferCount: transfers.length,
+        exact: true,
+      })
+    const useJournal = <A, E>(body: (journal: JournalService) => Effect.Effect<A, E>) =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          return yield* body(yield* Journal)
+        }).pipe(
+          Effect.provide(
+            JournalLive(config, {
+              createClient: (() => client) as unknown as typeof createTigerBeetleClient,
+              resolveReplicaAddresses: () => Effect.succeed(['3000']),
+            }),
+          ),
+        ),
+      )
+
+    await Effect.runPromise(useJournal(check))
+    expect(writes).toBe(0)
+
+    accounts = [{ ...accounts[0], debits_posted: accounts[0].debits_posted + 1n }, ...accounts.slice(1)]
+    const error = await Effect.runPromise(Effect.flip(useJournal(check)))
+    expect(error.message).toContain('balance does not reconcile exactly')
+    expect(writes).toBe(0)
   })
 })
 

--- a/services/bayn/src/ledger.ts
+++ b/services/bayn/src/ledger.ts
@@ -156,6 +156,7 @@ export interface LedgerPlan {
 export interface JournalService {
   readonly journalAndReconcile: (result: EvaluationResult) => Effect.Effect<ReconciliationResult, OperationalError>
   readonly check: Effect.Effect<void, OperationalError>
+  readonly checkRun: (result: ReconciliationResult) => Effect.Effect<void, OperationalError>
 }
 
 export class Journal extends Context.Service<Journal, JournalService>()('bayn/Journal') {}
@@ -495,6 +496,98 @@ const queryFilter = (ledger: number): QueryFilter => ({
   flags: 0,
 })
 
+const assertPersistedRun = (
+  result: ReconciliationResult,
+  ledger: number,
+  accounts: readonly Account[],
+  transfers: readonly Transfer[],
+): void => {
+  if (accounts.length !== result.accountCount) {
+    throw new Error(`run ${result.runId} has ${accounts.length} accounts; expected ${result.accountCount}`)
+  }
+  if (transfers.length !== result.transferCount) {
+    throw new Error(`run ${result.runId} has ${transfers.length} transfers; expected ${result.transferCount}`)
+  }
+
+  const runKey = stableU128('bayn-run-v1', result.runId)
+  const runTag = stableU64('bayn-run-v1', result.runId)
+  const accountIds = new Set<bigint>()
+  const balances = new Map<bigint, { debits: bigint; credits: bigint }>()
+  for (const value of accounts) {
+    if (accountIds.has(value.id)) throw new Error(`run ${result.runId} contains duplicate account ${value.id}`)
+    if (
+      value.user_data_128 !== runKey ||
+      value.user_data_64 !== runTag ||
+      value.user_data_32 !== SCHEMA_VERSION ||
+      value.ledger !== ledger
+    ) {
+      throw new Error(`run ${result.runId} account ${value.id} has invalid metadata`)
+    }
+    accountIds.add(value.id)
+    balances.set(value.id, { debits: 0n, credits: 0n })
+  }
+
+  const transferIds = new Set<bigint>()
+  for (const value of transfers) {
+    if (transferIds.has(value.id)) throw new Error(`run ${result.runId} contains duplicate transfer ${value.id}`)
+    if (
+      value.user_data_64 !== runTag ||
+      value.user_data_32 !== SCHEMA_VERSION ||
+      value.ledger !== ledger ||
+      value.amount <= 0n
+    ) {
+      throw new Error(`run ${result.runId} transfer ${value.id} has invalid metadata`)
+    }
+    const debit = balances.get(value.debit_account_id)
+    const credit = balances.get(value.credit_account_id)
+    if (debit === undefined || credit === undefined) {
+      throw new Error(`run ${result.runId} transfer ${value.id} references an account outside the run`)
+    }
+    transferIds.add(value.id)
+    debit.debits += value.amount
+    credit.credits += value.amount
+  }
+
+  for (const value of accounts) {
+    const balance = balances.get(value.id)!
+    if (
+      value.debits_pending !== 0n ||
+      value.credits_pending !== 0n ||
+      value.debits_posted !== balance.debits ||
+      value.credits_posted !== balance.credits
+    ) {
+      throw new Error(`run ${result.runId} account ${value.id} balance does not reconcile exactly`)
+    }
+  }
+}
+
+const checkRun = (
+  client: Client,
+  ledger: number,
+  result: ReconciliationResult,
+): Effect.Effect<void, OperationalError> =>
+  Effect.gen(function* () {
+    if (result.accountCount >= BATCH_MAX || result.transferCount >= BATCH_MAX) {
+      return yield* Effect.fail(
+        operationalError('journal', 'check-run', 'persisted TigerBeetle counts exceed the exact query limit'),
+      )
+    }
+    const runKey = stableU128('bayn-run-v1', result.runId)
+    const runTag = stableU64('bayn-run-v1', result.runId)
+    const [accounts, transfers] = yield* Effect.all(
+      [
+        request(client, 'check-run-accounts', () =>
+          client.queryAccounts({ ...queryFilter(ledger), user_data_128: runKey, limit: result.accountCount + 1 }),
+        ),
+        request(client, 'check-run-transfers', () =>
+          client.queryTransfers({ ...queryFilter(ledger), user_data_64: runTag, limit: result.transferCount + 1 }),
+        ),
+      ],
+      { concurrency: 'unbounded' },
+    )
+    yield* validate('check-run', () => assertPersistedRun(result, ledger, accounts, transfers))
+  })
+
 const journalAndReconcile = (
   client: Client,
   ledger: number,
@@ -572,6 +665,7 @@ export const JournalLive = (
         check: request(client, 'connectivity-check', () =>
           client.lookupAccounts([stableU128('bayn-connectivity-probe')]),
         ).pipe(Effect.asVoid),
+        checkRun: (result) => checkRun(client, config.tigerBeetle.ledger, result),
         journalAndReconcile: (result) => journalAndReconcile(client, config.tigerBeetle.ledger, result),
       })),
     ),

--- a/services/bayn/src/market-data.test.ts
+++ b/services/bayn/src/market-data.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from 'bun:test'
 
-import { verifyFinalizedSnapshot, type SnapshotRequest, type SnapshotRows } from './market-data'
+import {
+  verifyFinalizedManifest,
+  verifyFinalizedSnapshot,
+  type SnapshotRequest,
+  type SnapshotRows,
+} from './market-data'
 
 const symbols = ['EEM', 'SPY'] as const
 const snapshotId = '2fb38a01471d5a6bb6c5aa08a49b6ff844a5a9ee1c6e7bb9ff7786ecdac01bba'
@@ -167,6 +172,22 @@ describe('finalized Signal snapshot reader', () => {
     })
     expect(snapshot.manifest.hash).toMatch(/^[a-f0-9]{64}$/)
     expect(snapshot.bars.every((bar) => bar.open > 0 && bar.close > 0)).toBe(true)
+  })
+
+  test('checks the finalized publication identity without loading sessions or bars', () => {
+    const fixture = makeFixture()
+    const publication = verifyFinalizedManifest(fixture.rows.manifests, fixture.request)
+
+    expect(publication).toMatchObject({
+      snapshotId,
+      publicationId: fixture.rows.manifests[0].manifest_content_hash,
+      calendarVersion: fixture.request.calendarVersion,
+      asOfSession: fixture.request.publicationAsOf,
+      symbols,
+      rowCount: 4,
+      sessionCount: 2,
+    })
+    expect(() => verifyFinalizedManifest([], fixture.request)).toThrow('0 manifests; expected exactly one')
   })
 
   test('rejects duplicate manifests, sessions, and bars', () => {

--- a/services/bayn/src/market-data.ts
+++ b/services/bayn/src/market-data.ts
@@ -116,6 +116,7 @@ export interface MarketDataSnapshot {
 }
 
 export interface MarketDataService {
+  readonly check: Effect.Effect<FinalizedSnapshotProvenance, OperationalError>
   readonly load: Effect.Effect<MarketDataSnapshot, OperationalError>
 }
 
@@ -183,12 +184,18 @@ const assertBoundSessions = (sessions: ReadonlySet<string>, bounds: EvaluationBo
   }
 }
 
-export const verifyFinalizedSnapshot = (rows: SnapshotRows, request: SnapshotRequest): MarketDataSnapshot => {
+interface VerifiedManifest {
+  readonly manifest: SignalManifestRow
+  readonly finalizedSnapshot: FinalizedSnapshotProvenance
+  readonly universe: readonly string[]
+}
+
+const verifyManifest = (manifests: readonly SignalManifestRow[], request: SnapshotRequest): VerifiedManifest => {
   const universe = canonicalUniverse(request.universe)
-  if (rows.manifests.length !== 1) {
-    throw new Error(`snapshot ${request.snapshotId} has ${rows.manifests.length} manifests; expected exactly one`)
+  if (manifests.length !== 1) {
+    throw new Error(`snapshot ${request.snapshotId} has ${manifests.length} manifests; expected exactly one`)
   }
-  const manifest = rows.manifests[0]
+  const manifest = manifests[0]
   if (manifest.snapshot_id !== request.snapshotId) throw new Error('manifest snapshot ID does not match request')
   if (manifest.calendar_version !== request.calendarVersion) throw new Error('manifest calendar version does not match')
   if (manifest.publication_asof !== request.publicationAsOf) {
@@ -201,6 +208,65 @@ export const verifyFinalizedSnapshot = (rows: SnapshotRows, request: SnapshotReq
   if (manifest.manifest_content_hash !== canonicalHashV1(withoutManifestHash(manifest))) {
     throw new Error('snapshot manifest content hash is invalid')
   }
+  if (manifest.symbol_count !== universe.length) throw new Error('manifest symbol count does not match request')
+  if (manifest.bar_count !== manifest.session_count * manifest.symbol_count) {
+    throw new Error('manifest does not describe a complete symbol-session product')
+  }
+  const expectedSnapshotId = canonicalHashV1({
+    schemaVersion: manifest.schema_version,
+    provider: manifest.provider,
+    feed: manifest.source_feed,
+    adjustment: manifest.adjustment,
+    calendarVersion: manifest.calendar_version,
+    requestedStart: manifest.requested_start,
+    publicationAsOf: manifest.publication_asof,
+    symbols: universe,
+    barsContentHash: manifest.bars_content_hash,
+    sessionsContentHash: manifest.sessions_content_hash,
+  })
+  if (manifest.snapshot_id !== expectedSnapshotId) throw new Error('snapshot ID does not match finalized content')
+  if (request.bounds.dataStart < manifest.first_session || request.bounds.dataEnd > manifest.last_session) {
+    throw new Error('evaluation data bounds are outside the finalized snapshot')
+  }
+
+  return {
+    manifest,
+    universe,
+    finalizedSnapshot: decodeFinalizedSnapshot({
+      schemaVersion: 'bayn.finalized-snapshot.v2',
+      snapshotId: manifest.snapshot_id,
+      publicationId: manifest.manifest_content_hash,
+      publicationSchemaVersion: manifest.schema_version,
+      source: manifest.provider,
+      sourceFeed: manifest.source_feed,
+      adjustment: manifest.adjustment,
+      calendarVersion: manifest.calendar_version,
+      publisherSourceRevision: manifest.publisher_source_revision,
+      publisherImage: {
+        repository: manifest.publisher_image_repository,
+        digest: manifest.publisher_image_digest,
+      },
+      finalizedAt,
+      requestedStart: manifest.requested_start,
+      firstSession: manifest.first_session,
+      lastSession: manifest.last_session,
+      asOfSession: manifest.publication_asof,
+      symbols: universe,
+      rowCount: manifest.bar_count,
+      sessionCount: manifest.session_count,
+      contentHash: manifest.bars_content_hash,
+      sessionsContentHash: manifest.sessions_content_hash,
+    }),
+  }
+}
+
+export const verifyFinalizedManifest = (
+  manifests: readonly SignalManifestRow[],
+  request: SnapshotRequest,
+): FinalizedSnapshotProvenance => verifyManifest(manifests, request).finalizedSnapshot
+
+export const verifyFinalizedSnapshot = (rows: SnapshotRows, request: SnapshotRequest): MarketDataSnapshot => {
+  const { finalizedSnapshot, manifest, universe } = verifyManifest(rows.manifests, request)
 
   const orderedSessions = [...rows.sessions].sort((left, right) => left.session_date.localeCompare(right.session_date))
   const sessionDates = new Set<string>()
@@ -252,10 +318,6 @@ export const verifyFinalizedSnapshot = (rows: SnapshotRows, request: SnapshotReq
   if (orderedBars.length !== manifest.bar_count) throw new Error('adjusted-bar count does not match manifest')
   if ([...actualSymbols].sort().join(',') !== universe.join(','))
     throw new Error('snapshot universe does not match request')
-  if (manifest.symbol_count !== universe.length) throw new Error('manifest symbol count does not match request')
-  if (manifest.bar_count !== manifest.session_count * manifest.symbol_count) {
-    throw new Error('manifest does not describe a complete symbol-session product')
-  }
   for (const session of orderedSessions) {
     for (const symbol of universe) {
       if (!barKeys.has(`${symbol}\u001f${session.session_date}`)) {
@@ -265,23 +327,6 @@ export const verifyFinalizedSnapshot = (rows: SnapshotRows, request: SnapshotReq
   }
   if (canonicalHashV1(orderedBars.map(withoutSnapshot)) !== manifest.bars_content_hash) {
     throw new Error('adjusted-bar content hash is invalid')
-  }
-  const expectedSnapshotId = canonicalHashV1({
-    schemaVersion: manifest.schema_version,
-    provider: manifest.provider,
-    feed: manifest.source_feed,
-    adjustment: manifest.adjustment,
-    calendarVersion: manifest.calendar_version,
-    requestedStart: manifest.requested_start,
-    publicationAsOf: manifest.publication_asof,
-    symbols: universe,
-    barsContentHash: manifest.bars_content_hash,
-    sessionsContentHash: manifest.sessions_content_hash,
-  })
-  if (manifest.snapshot_id !== expectedSnapshotId) throw new Error('snapshot ID does not match finalized content')
-
-  if (request.bounds.dataStart < manifest.first_session || request.bounds.dataEnd > manifest.last_session) {
-    throw new Error('evaluation data bounds are outside the finalized snapshot')
   }
   assertBoundSessions(sessionDates, request.bounds)
   const boundedSessions = orderedSessions.filter(
@@ -301,31 +346,6 @@ export const verifyFinalizedSnapshot = (rows: SnapshotRows, request: SnapshotReq
       firstSession: symbolRows[0].session_date as IsoDate,
       lastSession: symbolRows.at(-1)!.session_date as IsoDate,
     }
-  })
-  const finalizedSnapshot: FinalizedSnapshotProvenance = decodeFinalizedSnapshot({
-    schemaVersion: 'bayn.finalized-snapshot.v2',
-    snapshotId: manifest.snapshot_id,
-    publicationId: manifest.manifest_content_hash,
-    publicationSchemaVersion: manifest.schema_version,
-    source: manifest.provider,
-    sourceFeed: manifest.source_feed,
-    adjustment: manifest.adjustment,
-    calendarVersion: manifest.calendar_version,
-    publisherSourceRevision: manifest.publisher_source_revision,
-    publisherImage: {
-      repository: manifest.publisher_image_repository,
-      digest: manifest.publisher_image_digest,
-    },
-    finalizedAt,
-    requestedStart: manifest.requested_start,
-    firstSession: manifest.first_session,
-    lastSession: manifest.last_session,
-    asOfSession: manifest.publication_asof,
-    symbols: universe,
-    rowCount: manifest.bar_count,
-    sessionCount: manifest.session_count,
-    contentHash: manifest.bars_content_hash,
-    sessionsContentHash: manifest.sessions_content_hash,
   })
   const manifestMaterial: Omit<InputManifest, 'hash'> = {
     schemaVersion: 'bayn.input-manifest.v2',
@@ -368,8 +388,7 @@ const makeMarketData = (
     const sql = yield* ClickhouseClient.ClickhouseClient
     // The Bayn principal is readonly=1, so query-level setting changes are forbidden. Snapshot counts and content
     // hashes below make an incomplete or stale replica read fail closed.
-    const loadRows = Effect.gen(function* () {
-      const manifests = yield* sql`
+    const loadManifests = sql`
         SELECT
           snapshot_id,
           schema_version,
@@ -395,6 +414,8 @@ const makeMarketData = (
         WHERE snapshot_id = ${sql.param('String', config.clickhouse.snapshotId)}
         ORDER BY finalized_at
       `.pipe(sql.withQueryId(`bayn-manifest-${config.clickhouse.snapshotId.slice(-32)}`))
+    const loadRows = Effect.gen(function* () {
+      const manifests = yield* loadManifests
       const [sessions, bars] = yield* Effect.all(
         [
           sql`
@@ -436,22 +457,40 @@ const makeMarketData = (
       return { bars, sessions, manifests }
     })
 
+    const request = (observedAt: string): SnapshotRequest => ({
+      snapshotId: config.clickhouse.snapshotId,
+      publicationAsOf: config.clickhouse.publicationAsOf,
+      calendarVersion: config.clickhouse.calendarVersion,
+      universe,
+      bounds: config.clickhouse.bounds,
+      observedAt,
+    })
+    const verify = <A>(operation: string, body: () => A): Effect.Effect<A, OperationalError> =>
+      Effect.try({
+        try: body,
+        catch: (cause) => operationalError('market-data', operation, 'Signal snapshot verification failed', cause),
+      })
+
     return {
+      check: Effect.gen(function* () {
+        const observedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
+        const manifests = yield* loadManifests
+        return yield* verify('check', () =>
+          verifyFinalizedManifest(decodeSnapshotRows([], [], manifests).manifests, request(observedAt)),
+        )
+      }).pipe(
+        Effect.mapError((cause) =>
+          cause instanceof OperationalError
+            ? cause
+            : operationalError('market-data', 'check', 'failed to check finalized Signal snapshot', cause),
+        ),
+      ),
       load: Effect.gen(function* () {
         const observedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
         const raw = yield* loadRows
-        return yield* Effect.try({
-          try: () =>
-            verifyFinalizedSnapshot(decodeSnapshotRows(raw.bars, raw.sessions, raw.manifests), {
-              snapshotId: config.clickhouse.snapshotId,
-              publicationAsOf: config.clickhouse.publicationAsOf,
-              calendarVersion: config.clickhouse.calendarVersion,
-              universe,
-              bounds: config.clickhouse.bounds,
-              observedAt,
-            }),
-          catch: (cause) => operationalError('market-data', 'verify', 'Signal snapshot verification failed', cause),
-        })
+        return yield* verify('verify', () =>
+          verifyFinalizedSnapshot(decodeSnapshotRows(raw.bars, raw.sessions, raw.manifests), request(observedAt)),
+        )
       }).pipe(
         Effect.mapError((cause) =>
           cause instanceof OperationalError

--- a/services/bayn/src/resources.test.ts
+++ b/services/bayn/src/resources.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'bun:test'
 import { Effect, Option, Redacted, Ref } from 'effect'
 import { createClient as createTigerBeetleClient, type Client } from 'tigerbeetle-node'
 
-import { initialize, type RuntimeState } from './app'
+import { initialState, initialize } from './app'
 import type { RuntimeConfig } from './config'
 import { EvidenceStore, type EvidenceStoreService } from './db/evidence-store'
 import { operationalError } from './errors'
@@ -24,7 +24,7 @@ const config: RuntimeConfig = {
     strategyBehaviorHash: provenance.strategy.behaviorHash,
     verification: 'embedded',
   },
-  runOnStartup: true,
+  healthIntervalMs: 100,
   operationTimeoutMs: 20,
   clickhouse: {
     url: 'http://clickhouse.test:8123',
@@ -52,9 +52,15 @@ const config: RuntimeConfig = {
 
 const successfulJournal: JournalService = {
   check: Effect.void,
+  checkRun: () => Effect.void,
   journalAndReconcile: (evaluation) =>
     Effect.succeed({ runId: evaluation.runId, accountCount: 1, transferCount: 1, exact: true }),
 }
+
+const marketDataService = (load: MarketDataService['load']): MarketDataService => ({
+  check: Effect.sync(() => makeSnapshot().manifest.finalizedSnapshot),
+  load,
+})
 
 const successfulEvidenceStore: EvidenceStoreService = {
   check: Effect.void,
@@ -97,10 +103,10 @@ describe('Bayn resource lifecycle', () => {
 
   test('interrupts an in-flight market-data read when the startup deadline expires', async () => {
     let interrupted = false
-    const marketData: MarketDataService = {
-      load: Effect.never.pipe(Effect.onInterrupt(() => Effect.sync(() => void (interrupted = true)))),
-    }
-    const state = await Effect.runPromise(Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null }))
+    const marketData = marketDataService(
+      Effect.never.pipe(Effect.onInterrupt(() => Effect.sync(() => void (interrupted = true)))),
+    )
+    const state = await Effect.runPromise(Ref.make(initialState()))
 
     await Effect.runPromise(
       Effect.scoped(
@@ -115,18 +121,18 @@ describe('Bayn resource lifecycle', () => {
 
     expect(interrupted).toBe(true)
     expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
-      status: 'FAIL_CLOSED',
+      status: 'FAILED',
       error: expect.stringContaining('market-data.load: load timed out'),
     })
   })
 
   test('fails closed when ClickHouse returns a malformed row', async () => {
-    const marketData: MarketDataService = {
-      load: Effect.fail(
+    const marketData = marketDataService(
+      Effect.fail(
         operationalError('market-data', 'verify', 'Signal snapshot verification failed', new Error('malformed row')),
       ),
-    }
-    const state = await Effect.runPromise(Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null }))
+    )
+    const state = await Effect.runPromise(Ref.make(initialState()))
 
     await Effect.runPromise(
       Effect.scoped(
@@ -140,7 +146,7 @@ describe('Bayn resource lifecycle', () => {
     )
 
     expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
-      status: 'FAIL_CLOSED',
+      status: 'FAILED',
       error: expect.stringContaining('market-data.verify'),
     })
   })
@@ -159,8 +165,8 @@ describe('Bayn resource lifecycle', () => {
         rejectLookup?.(new Error('client closed'))
       },
     } as unknown as Client
-    const marketData: MarketDataService = { load: Effect.succeed(makeSnapshot()) }
-    const state = await Effect.runPromise(Ref.make<RuntimeState>({ status: 'STARTING', evidence: null, error: null }))
+    const marketData = marketDataService(Effect.succeed(makeSnapshot()))
+    const state = await Effect.runPromise(Ref.make(initialState()))
 
     await Effect.runPromise(
       Effect.scoped(
@@ -180,7 +186,7 @@ describe('Bayn resource lifecycle', () => {
 
     expect(destroyed).toBe(true)
     expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
-      status: 'FAIL_CLOSED',
+      status: 'FAILED',
       error: expect.stringContaining('journal.connectivity-check: connectivity-check timed out'),
     })
   })


### PR DESCRIPTION
## Summary

- Run one scoped Effect health loop that continuously verifies PostgreSQL, the finalized Signal manifest, durable evidence, and the active TigerBeetle run.
- Keep readiness closed until every read-only check succeeds, preserve the last valid evidence while degraded, and expose operational, economic, accounting, authority, and build facts separately.
- Patch the pinned Effect ClickHouse client so its startup check drains the response, with a failing-before regression test.
- Remove the unused startup bypass and 178 lines of speculative status, kill, and authority contracts.
- Include Bun patch sources in reproducible Nix dependency closures and refresh every affected full-node_modules image hash.

## Related Issues

Closes PROOMPT-362

## Testing

- bun install --frozen-lockfile --ignore-scripts --filter @proompteng/bayn
- bun run --filter @proompteng/bayn tsc
- bun run --filter @proompteng/bayn test: 61 passed, 17 PostgreSQL-gated tests skipped
- Isolated bayn_test PostgreSQL integration suite: 15 passed
- Bayn format, Oxlint, type-aware Oxlint, build, script tests, Kustomize render, and kubeconform passed
- Bayn and Signal Publisher Nix OCI builds passed on linux/amd64 and linux/arm64 in required PR workflows
- Bumba Nix OCI closure passed on both architectures: https://github.com/proompteng/lab/actions/runs/29784954642
- Froussard Nix OCI closure passed on both architectures: https://github.com/proompteng/lab/actions/runs/29784956031
- Oirat Nix OCI closure passed on both architectures: https://github.com/proompteng/lab/actions/runs/29784957390

## Screenshots (if applicable)

N/A

## Breaking Changes

GET /v1/status now returns explicit status axes instead of the previous flat payload. BAYN_RUN_ON_STARTUP is removed; startup evaluation and exact recovery are unconditional.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes are handled.
- [x] Documentation and the PROOMPT-362 implementation plan are updated.