### PR TITLE
chore(signal): promote publisher sha-4000b49f4435a9b8b27a6cc2b368258ace30e4e7

### DIFF
--- a/argocd/applications/torghut/clickhouse/kustomization.yaml
+++ b/argocd/applications/torghut/clickhouse/kustomization.yaml
@@ -17,5 +17,5 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/signal-publisher
     newName: registry.ide-newton.ts.net/lab/signal-publisher
-    newTag: "sha-01ac72aafca390609885c2093236f4a10dd14a32"
-    digest: sha256:8f573122837bdc97ee90c3054b266606fcb2a269ea4edee0ff1e81bb641bebda
+    newTag: "sha-4000b49f4435a9b8b27a6cc2b368258ace30e4e7"
+    digest: sha256:0e34134cbca3d13cf0682320762eebe302c9b930f8d1f0a6a70d7d9bde02d440

--- a/argocd/applications/torghut/clickhouse/signal-publisher-cronjob.yaml
+++ b/argocd/applications/torghut/clickhouse/signal-publisher-cronjob.yaml
@@ -47,11 +47,11 @@ spec:
                 - daily
               env:
                 - name: SIGNAL_CODE_REVISION
-                  value: "01ac72aafca390609885c2093236f4a10dd14a32"
+                  value: "4000b49f4435a9b8b27a6cc2b368258ace30e4e7"
                 - name: SIGNAL_IMAGE_REPOSITORY
                   value: registry.ide-newton.ts.net/lab/signal-publisher
                 - name: SIGNAL_IMAGE_DIGEST
-                  value: sha256:8f573122837bdc97ee90c3054b266606fcb2a269ea4edee0ff1e81bb641bebda
+                  value: sha256:0e34134cbca3d13cf0682320762eebe302c9b930f8d1f0a6a70d7d9bde02d440
                 - name: SIGNAL_CLICKHOUSE_URL
                   value: http://torghut-clickhouse.torghut.svc.cluster.local:8123
                 - name: SIGNAL_CLICKHOUSE_USERNAME


### PR DESCRIPTION
## Summary

Promote the immutable Signal adjusted-daily publisher image and activate its GitOps CronJob.

- Source commit: `4000b49f4435a9b8b27a6cc2b368258ace30e4e7`
- Image tag: `sha-4000b49f4435a9b8b27a6cc2b368258ace30e4e7`
- Image digest: `sha256:0e34134cbca3d13cf0682320762eebe302c9b930f8d1f0a6a70d7d9bde02d440`

## Related Issues

PROOMPT-357

## Testing

- OCI index contains `linux/amd64` and `linux/arm64`.

## Screenshots (if applicable)

N/A

## Breaking Changes

Adds a bounded, idempotent daily publisher. It has no broker or capital authority.

## Checklist

- [x] Testing section documents exact validation.
- [x] Runtime source revision and image digest are immutable.
- [x] No broker or capital-promotion authority is introduced.