### PR TITLE
chore(bumba): promote nix image sha-4000b49f4435a9b8b27a6cc2b368258ace30e4e7

### DIFF
--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -73,7 +73,7 @@ spec:
             - name: TEMPORAL_TASK_QUEUE
               value: bumba
             - name: TEMPORAL_WORKER_BUILD_ID
-              value: bumba@302e46b9e7dd6973933034742717b2de47c8f788
+              value: bumba@4000b49f4435a9b8b27a6cc2b368258ace30e4e7
             - name: TEMPORAL_WORKFLOW_CONCURRENCY
               value: "12"
             - name: TEMPORAL_ACTIVITY_CONCURRENCY

--- a/argocd/applications/bumba/kustomization.yaml
+++ b/argocd/applications/bumba/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
   - deployment.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/bumba
-    digest: sha256:f3a31ade59190cebb9a8c7818b71aa9a55c8c9631851980cb5e917b9e2240a32
+    digest: sha256:cb12e8bf2ea5915eb74286be0710ee77fbf6ab67eab0da2b20551c9206b3780e
     newName: registry.ide-newton.ts.net/lab/bumba


### PR DESCRIPTION
## Summary

- Promote `bumba` to `registry.ide-newton.ts.net/lab/bumba@sha256:cb12e8bf2ea5915eb74286be0710ee77fbf6ab67eab0da2b20551c9206b3780e`.
- Source commit: `4000b49f4435a9b8b27a6cc2b368258ace30e4e7`.
- Built by the shared Nix OCI workflow without Docker Buildx.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/bumba@sha256:cb12e8bf2ea5915eb74286be0710ee77fbf6ab67eab0da2b20551c9206b3780e" linux/amd64 linux/arm64`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.