### PR TITLE
chore(oirat): promote nix image sha-4000b49f4435a9b8b27a6cc2b368258ace30e4e7

### DIFF
--- a/argocd/applications/oirat/kustomization.yaml
+++ b/argocd/applications/oirat/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
   - alloy-deployment.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/oirat
-    digest: sha256:63751bf7bd03b19e61a32fd689bc3c50861a820d5929da629ed118ef0da70cd4
+    digest: sha256:01e5f0ea021d4f37b4164cfe9807c6ed13d2afe873b00a3ab2c0717950ec72bf


### PR DESCRIPTION
## Summary

- Promote `oirat` to `registry.ide-newton.ts.net/lab/oirat@sha256:01e5f0ea021d4f37b4164cfe9807c6ed13d2afe873b00a3ab2c0717950ec72bf`.
- Source commit: `4000b49f4435a9b8b27a6cc2b368258ace30e4e7`.
- Built by the shared Nix OCI workflow without Docker Buildx.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/oirat@sha256:01e5f0ea021d4f37b4164cfe9807c6ed13d2afe873b00a3ab2c0717950ec72bf" linux/amd64 linux/arm64`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.