### PR TITLE
test(bayn): restore current M1 evidence backup

### DIFF
--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -10,6 +10,8 @@ resources:
   - postgres-scheduled-backup.yaml
   - postgres-restore-proof.yaml
   - postgres-restore-proof-networkpolicy.yaml
+  - postgres-m1-restore-proof.yaml
+  - postgres-m1-restore-proof-networkpolicy.yaml
   - deployment.yaml
   - service.yaml
   - networkpolicy.yaml

--- a/argocd/applications/bayn/postgres-m1-restore-proof-networkpolicy.yaml
+++ b/argocd/applications/bayn/postgres-m1-restore-proof-networkpolicy.yaml
@@ -1,0 +1,45 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: bayn-db-restore-m1-20260720t232623z
+  labels:
+    app.kubernetes.io/name: bayn-db-restore-proof
+    app.kubernetes.io/part-of: bayn
+  annotations:
+    argocd.argoproj.io/sync-wave: "-5"
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: bayn-db-restore-m1-20260720t232623z
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              cnpg.io/cluster: bayn-db-restore-m1-20260720t232623z
+      ports:
+        - port: 5432
+          protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: cloudnative-pg
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: cloudnative-pg
+      ports:
+        - port: 5432
+          protocol: TCP
+        - port: 8000
+          protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: observability-cluster-metrics-alloy
+      ports:
+        - port: 9187
+          protocol: TCP

--- a/argocd/applications/bayn/postgres-m1-restore-proof.yaml
+++ b/argocd/applications/bayn/postgres-m1-restore-proof.yaml
@@ -1,0 +1,55 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: bayn-db-restore-m1-20260720t232623z
+  labels:
+    app.kubernetes.io/name: bayn-db-restore-proof
+    app.kubernetes.io/part-of: bayn
+  annotations:
+    argocd.argoproj.io/sync-wave: "-4"
+    argocd.argoproj.io/sync-options: Prune=false,Delete=false
+spec:
+  description: Isolated PROOMPT-362 restore proof from bayn-db-m1-proof-20260720t232623z
+  instances: 1
+  imageName: ghcr.io/cloudnative-pg/postgresql:18.4-system-trixie@sha256:9287ce030c6f3ce822e383b019ae4aaf1e8370bff3b39f9c51dc10d69dc97219
+  imagePullPolicy: IfNotPresent
+  enablePDB: false
+  enableSuperuserAccess: false
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+  storage:
+    storageClass: rook-ceph-block
+    size: 10Gi
+    resizeInUseVolumes: true
+  bootstrap:
+    recovery:
+      source: bayn-db-source
+      database: bayn
+      owner: bayn_app
+      backup:
+        name: bayn-db-m1-proof-20260720t232623z
+  externalClusters:
+    - name: bayn-db-source
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: bayn-db
+          serverName: bayn-db-live
+  postgresql:
+    parameters:
+      password_encryption: scram-sha-256
+      ssl_min_protocol_version: TLSv1.3


### PR DESCRIPTION
## Summary

- Add an isolated CNPG recovery Cluster for completed backup `bayn-db-m1-proof-20260720t232623z` (UID `fc213050-2ccc-4590-8d1c-42838ff6dd4b`).
- Restore the current PROOMPT-362 evaluation schema and run evidence; the earlier retained restore predates those tables.
- Restrict ingress to the restore Cluster itself, the CNPG operator, and observability; retain the proof Cluster with `Prune=false,Delete=false`.

## Related Issues

PROOMPT-362

## Testing

- `kustomize build argocd/applications/bayn`
- `kubectl apply --dry-run=server -n bayn -f /tmp/bayn-m1-restore-rendered.yaml`
- `scripts/kubeconform.sh argocd/applications/bayn/postgres-m1-restore-proof.yaml argocd/applications/bayn/postgres-m1-restore-proof-networkpolicy.yaml argocd/applications/bayn/kustomization.yaml` (`2` resources, `1` valid, `0` invalid/errors, `1` custom resource skipped locally; server dry-run validated the CNPG Cluster)
- CNPG backup completed from preferred standby: `2026-07-20T23:26:52Z` to `2026-07-20T23:27:00Z`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None. The restore Cluster is isolated and does not mutate the primary database.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation and follow-up evidence are tracked in PROOMPT-362.