### PR TITLE
chore(product): promote nix product images

### DIFF
--- a/argocd/applications/app/kustomization.yaml
+++ b/argocd/applications/app/kustomization.yaml
@@ -8,5 +8,5 @@ resources:
   - secret.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/app
-    digest: sha256:155a6293f4eebf70f49bc62ae7a9f2fc3c77aaa42917b0e8f387dadb19a862df
+    digest: sha256:8c6a731c676256e39570389041ab4762245c27e0452a11998c3a11b21f8d310e
     newName: registry.ide-newton.ts.net/lab/app

--- a/argocd/applications/docs/kustomization.yaml
+++ b/argocd/applications/docs/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
   - generated
 images:
   - name: registry.ide-newton.ts.net/lab/docs
-    digest: sha256:ce3a68ead8a175fb0eb6fa24e2bedf3800fcdadffd3fc62b01c520e384ff9713
+    digest: sha256:edb3e93f3c61f865bbd34628e134b5be5206432618aac80eccd7dcdfc66d5a15
     newName: registry.ide-newton.ts.net/lab/docs

--- a/argocd/applications/proompteng/kustomization.yaml
+++ b/argocd/applications/proompteng/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
 - ingressroute.yaml
 images:
 - name: registry.ide-newton.ts.net/lab/proompteng
-  digest: sha256:4063cb561e82e7342bd43559d7f53ca80bcb4c6b2d4df29f6917aea713562174
+  digest: sha256:9c4bfd91efa4224f8b503c26d10985982ebfbf76c49e152276d6d92d10b04540
   newName: registry.ide-newton.ts.net/lab/proompteng

--- a/argocd/applications/synthesis/kustomization.yaml
+++ b/argocd/applications/synthesis/kustomization.yaml
@@ -11,5 +11,5 @@ resources:
   - agents-domain
 images:
   - name: registry.ide-newton.ts.net/lab/synthesis
-    digest: sha256:3a960d06a4441b446d03e7c1632ba2a2006fd6c5c4ac779c479e43c5e0a56814
+    digest: sha256:85d8bb25f7a358c81c695120827a72582754ed1789aa11f41d46ead11914a5b6
     newName: registry.ide-newton.ts.net/lab/synthesis


### PR DESCRIPTION
## Summary

- Promote enabled product app image digests built by the shared Nix OCI workflow.
- `app`: `registry.ide-newton.ts.net/lab/app@sha256:8c6a731c676256e39570389041ab4762245c27e0452a11998c3a11b21f8d310e` from `4000b49f4435a9b8b27a6cc2b368258ace30e4e7`
- `docs`: `registry.ide-newton.ts.net/lab/docs@sha256:edb3e93f3c61f865bbd34628e134b5be5206432618aac80eccd7dcdfc66d5a15` from `4000b49f4435a9b8b27a6cc2b368258ace30e4e7`
- `proompteng`: `registry.ide-newton.ts.net/lab/proompteng@sha256:9c4bfd91efa4224f8b503c26d10985982ebfbf76c49e152276d6d92d10b04540` from `4000b49f4435a9b8b27a6cc2b368258ace30e4e7`
- `synthesis`: `registry.ide-newton.ts.net/lab/synthesis@sha256:85d8bb25f7a358c81c695120827a72582754ed1789aa11f41d46ead11914a5b6` from `4000b49f4435a9b8b27a6cc2b368258ace30e4e7`

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- <image>@<digest> linux/amd64 linux/arm64` for each promoted image.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.