### PR TITLE
feat(bayn): lock qualification evidence

### DIFF
--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -37,7 +37,8 @@ and journals the resulting simulation to TigerBeetle. It contains no broker clie
   as an untouched qualification window, and the trial record cannot be updated or deleted.
 - A future qualification lock must bind the exact protocol, source and image, finalized snapshot and bounds, universe
   rationale, prior trials, and content-hashed benchmark, threshold, uncertainty, and execution policies. Lock rows are
-  append-only; no active lock or qualification result exists until the remaining M2 policies are complete.
+  append-only, and the result table permits exactly one immutable `QUALIFIED` or `REJECTED` run per lock. No active
+  lock or qualification result exists until the remaining M2 policies are complete.
 - The independent reducer rebuilds protocol costs, cash, positions, and every marked-equity point with integer micros.
   Evaluation and recovery fail if lineage diverges or fees or equity differ by more than one cent; the exact measured
   differences remain part of the receipt.

--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -33,6 +33,11 @@ and journals the resulting simulation to TigerBeetle. It contains no broker clie
 - After exact TigerBeetle reconciliation, one PostgreSQL transaction records the immutable protocol lock, input
   snapshot reference, run identity, metrics, simulated orders, fills, cash changes, daily position marks, the full
   equity series, independent marked-equity proof, reconciliation receipt, gate outcomes, and status history.
+- Every completed pre-qualification run is recorded once as a burned trial. Observed results cannot later be presented
+  as an untouched qualification window, and the trial record cannot be updated or deleted.
+- A future qualification lock must bind the exact protocol, source and image, finalized snapshot and bounds, universe
+  rationale, prior trials, and content-hashed benchmark, threshold, uncertainty, and execution policies. Lock rows are
+  append-only; no active lock or qualification result exists until the remaining M2 policies are complete.
 - The independent reducer rebuilds protocol costs, cash, positions, and every marked-equity point with integer micros.
   Evaluation and recovery fail if lineage diverges or fees or equity differ by more than one cent; the exact measured
   differences remain part of the receipt.

--- a/services/bayn/migrations/0002_qualification_lock.ts
+++ b/services/bayn/migrations/0002_qualification_lock.ts
@@ -1,0 +1,140 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient
+
+  yield* sql`
+    CREATE TABLE bayn_qualification_trials (
+      run_id text PRIMARY KEY REFERENCES bayn_evaluation_runs(run_id) ON DELETE RESTRICT,
+      schema_version text NOT NULL CHECK (schema_version = 'bayn.qualification-trial.v1'),
+      disposition text NOT NULL CHECK (disposition = 'BURNED'),
+      reason_codes text[] NOT NULL CHECK (
+        cardinality(reason_codes) > 0
+        AND array_position(reason_codes, '') IS NULL
+        AND array_position(reason_codes, NULL) IS NULL
+      ),
+      observed_at timestamptz NOT NULL,
+      recorded_at timestamptz NOT NULL DEFAULT transaction_timestamp()
+    )
+  `
+
+  yield* sql`
+    CREATE TABLE bayn_qualification_locks (
+      lock_id text PRIMARY KEY CHECK (lock_id ~ '^[0-9a-f]{64}$'),
+      schema_version text NOT NULL CHECK (schema_version = 'bayn.qualification-lock.v1'),
+      protocol_hash text NOT NULL REFERENCES bayn_protocol_locks(protocol_hash) ON DELETE RESTRICT,
+      snapshot_id text NOT NULL REFERENCES bayn_snapshot_references(snapshot_id) ON DELETE RESTRICT,
+      source_revision text NOT NULL CHECK (source_revision ~ '^([0-9a-f]{40}|[0-9a-f]{64})$'),
+      image_repository text NOT NULL CHECK (length(image_repository) > 0),
+      image_digest text NOT NULL CHECK (image_digest ~ '^sha256:[0-9a-f]{64}$'),
+      payload jsonb NOT NULL CHECK (jsonb_typeof(payload) = 'object'),
+      created_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+      CHECK (payload ->> 'lockId' = lock_id),
+      CHECK (payload ->> 'schemaVersion' = schema_version),
+      CHECK (payload ->> 'protocolHash' = protocol_hash),
+      CHECK (payload ->> 'sourceRevision' = source_revision),
+      CHECK (payload #>> '{image,repository}' = image_repository),
+      CHECK (payload #>> '{image,digest}' = image_digest),
+      CHECK (payload #>> '{data,snapshotId}' = snapshot_id)
+    )
+  `
+
+  yield* sql`
+    CREATE FUNCTION bayn_reject_qualification_mutation()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+    BEGIN
+      RAISE EXCEPTION '% is append-only', TG_TABLE_NAME USING ERRCODE = '55000';
+    END
+    $function$
+  `
+
+  yield* sql`
+    CREATE TRIGGER bayn_qualification_trials_append_only
+    BEFORE UPDATE OR DELETE ON bayn_qualification_trials
+    FOR EACH ROW EXECUTE FUNCTION bayn_reject_qualification_mutation()
+  `
+
+  yield* sql`
+    CREATE TRIGGER bayn_qualification_locks_append_only
+    BEFORE UPDATE OR DELETE ON bayn_qualification_locks
+    FOR EACH ROW EXECUTE FUNCTION bayn_reject_qualification_mutation()
+  `
+
+  yield* sql`
+    CREATE FUNCTION bayn_burn_completed_evaluation()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+    DECLARE
+      reasons text[] := ARRAY['PRE_LOCK_RESULT_OBSERVED'];
+    BEGIN
+      IF EXISTS (
+        SELECT 1
+        FROM bayn_gate_outcomes
+        WHERE run_id = NEW.run_id
+          AND gate_name = 'benchmark_sharpe_improvement'
+          AND passed = false
+      ) THEN
+        reasons := array_append(reasons, 'FAILED_BENCHMARK_GATE');
+      END IF;
+
+      INSERT INTO bayn_qualification_trials (
+        run_id,
+        schema_version,
+        disposition,
+        reason_codes,
+        observed_at
+      ) VALUES (
+        NEW.run_id,
+        'bayn.qualification-trial.v1',
+        'BURNED',
+        reasons,
+        COALESCE(NEW.completed_at, transaction_timestamp())
+      )
+      ON CONFLICT (run_id) DO NOTHING;
+
+      RETURN NEW;
+    END
+    $function$
+  `
+
+  yield* sql`
+    CREATE TRIGGER bayn_burn_completed_evaluation
+    AFTER UPDATE OF status ON bayn_evaluation_runs
+    FOR EACH ROW
+    WHEN (OLD.status IS DISTINCT FROM NEW.status AND NEW.status = 'COMPLETE')
+    EXECUTE FUNCTION bayn_burn_completed_evaluation()
+  `
+
+  yield* sql`
+    INSERT INTO bayn_qualification_trials (
+      run_id,
+      schema_version,
+      disposition,
+      reason_codes,
+      observed_at
+    )
+    SELECT
+      run.run_id,
+      'bayn.qualification-trial.v1',
+      'BURNED',
+      CASE
+        WHEN EXISTS (
+          SELECT 1
+          FROM bayn_gate_outcomes AS gate
+          WHERE gate.run_id = run.run_id
+            AND gate.gate_name = 'benchmark_sharpe_improvement'
+            AND gate.passed = false
+        )
+          THEN ARRAY['PRE_LOCK_RESULT_OBSERVED', 'FAILED_BENCHMARK_GATE']
+        ELSE ARRAY['PRE_LOCK_RESULT_OBSERVED']
+      END,
+      COALESCE(run.completed_at, run.created_at)
+    FROM bayn_evaluation_runs AS run
+    WHERE run.status = 'COMPLETE'
+    ON CONFLICT (run_id) DO NOTHING
+  `
+})

--- a/services/bayn/migrations/0002_qualification_lock.ts
+++ b/services/bayn/migrations/0002_qualification_lock.ts
@@ -41,6 +41,16 @@ export default Effect.gen(function* () {
   `
 
   yield* sql`
+    CREATE TABLE bayn_qualification_results (
+      lock_id text PRIMARY KEY REFERENCES bayn_qualification_locks(lock_id) ON DELETE RESTRICT,
+      schema_version text NOT NULL CHECK (schema_version = 'bayn.qualification-result.v1'),
+      run_id text NOT NULL UNIQUE REFERENCES bayn_evaluation_runs(run_id) ON DELETE RESTRICT,
+      verdict text NOT NULL CHECK (verdict IN ('QUALIFIED', 'REJECTED')),
+      committed_at timestamptz NOT NULL DEFAULT transaction_timestamp()
+    )
+  `
+
+  yield* sql`
     CREATE FUNCTION bayn_reject_qualification_mutation()
     RETURNS trigger
     LANGUAGE plpgsql
@@ -60,6 +70,12 @@ export default Effect.gen(function* () {
   yield* sql`
     CREATE TRIGGER bayn_qualification_locks_append_only
     BEFORE UPDATE OR DELETE ON bayn_qualification_locks
+    FOR EACH ROW EXECUTE FUNCTION bayn_reject_qualification_mutation()
+  `
+
+  yield* sql`
+    CREATE TRIGGER bayn_qualification_results_append_only
+    BEFORE UPDATE OR DELETE ON bayn_qualification_results
     FOR EACH ROW EXECUTE FUNCTION bayn_reject_qualification_mutation()
   `
 

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -129,6 +129,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       'bayn_gate_outcomes',
       'bayn_protocol_locks',
       'bayn_qualification_locks',
+      'bayn_qualification_results',
       'bayn_qualification_trials',
       'bayn_schema_migrations',
       'bayn_snapshot_references',
@@ -280,6 +281,9 @@ describePostgres('PostgreSQL evaluation evidence', () => {
         const locks = yield* sql<{ lock_id: string; payload: unknown }>`
           SELECT lock_id, payload FROM bayn_qualification_locks
         `
+        const results = yield* sql<{ count: number }>`
+          SELECT count(*)::integer AS count FROM bayn_qualification_results
+        `
         const trialUpdate = yield* Effect.exit(sql`
           UPDATE bayn_qualification_trials SET disposition = 'BURNED' WHERE run_id = ${input.evaluation.runId}
         `)
@@ -313,7 +317,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
             ${sql.json(lock)}
           )
         `)
-        return { lock, locks, trials, trialUpdate, trialDelete, lockUpdate, lockDelete, divergentLock }
+        return { lock, locks, results, trials, trialUpdate, trialDelete, lockUpdate, lockDelete, divergentLock }
       }),
     )
 
@@ -327,6 +331,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       },
     ])
     expect(result.locks).toEqual([{ lock_id: result.lock.lockId, payload: result.lock }])
+    expect(result.results).toEqual([{ count: 0 }])
     expect(Exit.isFailure(result.trialUpdate)).toBe(true)
     expect(Exit.isFailure(result.trialDelete)).toBe(true)
     expect(Exit.isFailure(result.lockUpdate)).toBe(true)

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -6,6 +6,7 @@ import { Cause, Effect, Exit, Fiber, Layer, ManagedRuntime, Option, Redacted } f
 
 import type { RuntimeConfig } from '../config'
 import { buildLedgerPlan } from '../ledger'
+import { makeQualificationLock, makeQualificationPolicyDocument } from '../qualification'
 import { evaluateTsmom } from '../strategy'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from '../test-fixtures'
 import {
@@ -127,6 +128,8 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       'bayn_evaluation_runs',
       'bayn_gate_outcomes',
       'bayn_protocol_locks',
+      'bayn_qualification_locks',
+      'bayn_qualification_trials',
       'bayn_schema_migrations',
       'bayn_snapshot_references',
       'bayn_status_history',
@@ -195,6 +198,140 @@ describePostgres('PostgreSQL evaluation evidence', () => {
         required_type: typeof gate.required,
       })),
     )
+  })
+
+  test('burns observed runs and preserves qualification state as append-only', async () => {
+    const input = makeInput()
+    const policy = (name: string) => makeQualificationPolicyDocument(`bayn.${name}.v1`, { name, enabled: true })
+    const result = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* EvidenceStore
+        const sql = yield* PgClient.PgClient
+        yield* store.persist(input)
+
+        const manifest = input.evaluation.inputManifest
+        const decisionCount = input.evaluation.events.filter((event) => event.kind === 'decision').length
+        const lock = makeQualificationLock({
+          schemaVersion: 'bayn.qualification-lock.v1',
+          protocolHash: input.evaluation.protocolHash,
+          sourceRevision: input.provenance.sourceRevision,
+          image: input.provenance.image,
+          universe: [...fixtureProtocol.universe],
+          universeRationale: 'Liquid cross-asset ETFs with complete fixture coverage.',
+          data: {
+            snapshotId: manifest.finalizedSnapshot.snapshotId,
+            publicationId: manifest.finalizedSnapshot.publicationId,
+            contentHash: manifest.finalizedSnapshot.contentHash,
+            sessionsContentHash: manifest.finalizedSnapshot.sessionsContentHash,
+            provider: manifest.finalizedSnapshot.source,
+            sourceFeed: manifest.finalizedSnapshot.sourceFeed,
+            adjustment: manifest.finalizedSnapshot.adjustment,
+            calendarVersion: manifest.finalizedSnapshot.calendarVersion,
+            firstSession: manifest.finalizedSnapshot.firstSession,
+            lastSession: manifest.finalizedSnapshot.lastSession,
+            selectedSessionCount: input.evaluation.strategy.observations,
+            selectedRebalanceCount: decisionCount,
+            bounds: manifest.bounds,
+          },
+          policies: {
+            benchmark: policy('benchmark-policy'),
+            thresholds: policy('threshold-policy'),
+            uncertainty: policy('uncertainty-policy'),
+            execution: policy('execution-policy'),
+          },
+          priorTrialRunIds: [input.evaluation.runId],
+        })
+
+        yield* sql`
+          INSERT INTO bayn_qualification_locks (
+            lock_id,
+            schema_version,
+            protocol_hash,
+            snapshot_id,
+            source_revision,
+            image_repository,
+            image_digest,
+            payload
+          ) VALUES (
+            ${lock.lockId},
+            ${lock.schemaVersion},
+            ${lock.protocolHash},
+            ${lock.data.snapshotId},
+            ${lock.sourceRevision},
+            ${lock.image.repository},
+            ${lock.image.digest},
+            ${sql.json(lock)}
+          )
+        `
+
+        const trials = yield* sql<{
+          run_id: string
+          disposition: string
+          prelock_observed: boolean
+          failed_benchmark: boolean
+        }>`
+          SELECT
+            run_id,
+            disposition,
+            'PRE_LOCK_RESULT_OBSERVED' = ANY(reason_codes) AS prelock_observed,
+            'FAILED_BENCHMARK_GATE' = ANY(reason_codes) AS failed_benchmark
+          FROM bayn_qualification_trials
+        `
+        const locks = yield* sql<{ lock_id: string; payload: unknown }>`
+          SELECT lock_id, payload FROM bayn_qualification_locks
+        `
+        const trialUpdate = yield* Effect.exit(sql`
+          UPDATE bayn_qualification_trials SET disposition = 'BURNED' WHERE run_id = ${input.evaluation.runId}
+        `)
+        const trialDelete = yield* Effect.exit(sql`
+          DELETE FROM bayn_qualification_trials WHERE run_id = ${input.evaluation.runId}
+        `)
+        const lockUpdate = yield* Effect.exit(sql`
+          UPDATE bayn_qualification_locks SET payload = payload WHERE lock_id = ${lock.lockId}
+        `)
+        const lockDelete = yield* Effect.exit(sql`
+          DELETE FROM bayn_qualification_locks WHERE lock_id = ${lock.lockId}
+        `)
+        const divergentLock = yield* Effect.exit(sql`
+          INSERT INTO bayn_qualification_locks (
+            lock_id,
+            schema_version,
+            protocol_hash,
+            snapshot_id,
+            source_revision,
+            image_repository,
+            image_digest,
+            payload
+          ) VALUES (
+            ${'f'.repeat(64)},
+            ${lock.schemaVersion},
+            ${lock.protocolHash},
+            ${lock.data.snapshotId},
+            ${lock.sourceRevision},
+            ${lock.image.repository},
+            ${lock.image.digest},
+            ${sql.json(lock)}
+          )
+        `)
+        return { lock, locks, trials, trialUpdate, trialDelete, lockUpdate, lockDelete, divergentLock }
+      }),
+    )
+
+    expect(result.trials).toEqual([
+      {
+        run_id: input.evaluation.runId,
+        disposition: 'BURNED',
+        prelock_observed: true,
+        failed_benchmark: !input.evaluation.verdict.gates.find((gate) => gate.name === 'benchmark_sharpe_improvement')!
+          .passed,
+      },
+    ])
+    expect(result.locks).toEqual([{ lock_id: result.lock.lockId, payload: result.lock }])
+    expect(Exit.isFailure(result.trialUpdate)).toBe(true)
+    expect(Exit.isFailure(result.trialDelete)).toBe(true)
+    expect(Exit.isFailure(result.lockUpdate)).toBe(true)
+    expect(Exit.isFailure(result.lockDelete)).toBe(true)
+    expect(Exit.isFailure(result.divergentLock)).toBe(true)
   })
 
   test('reads and recovers the complete v2 evidence contract without evaluating it again', async () => {

--- a/services/bayn/src/db/migrations.ts
+++ b/services/bayn/src/db/migrations.ts
@@ -1,7 +1,9 @@
 import { PgMigrator } from '@effect/sql-pg'
 
 import evaluationEvidence from '../../migrations/0001_evaluation_evidence'
+import qualificationLock from '../../migrations/0002_qualification_lock'
 
 export const migrationLoader = PgMigrator.fromRecord({
   '1_evaluation_evidence': evaluationEvidence,
+  '2_qualification_lock': qualificationLock,
 })

--- a/services/bayn/src/qualification.test.ts
+++ b/services/bayn/src/qualification.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Schema } from 'effect'
+
+import {
+  makeQualificationLock,
+  makeQualificationPolicyDocument,
+  QualificationLockSchema,
+  type QualificationLockMaterial,
+} from './qualification'
+
+const policy = (name: string) => makeQualificationPolicyDocument(`bayn.${name}.v1`, { name, enabled: true })
+
+const material: QualificationLockMaterial = {
+  schemaVersion: 'bayn.qualification-lock.v1' as const,
+  protocolHash: '1'.repeat(64),
+  sourceRevision: '2'.repeat(40),
+  image: {
+    repository: 'registry.example.test/lab/bayn',
+    digest: `sha256:${'3'.repeat(64)}`,
+  },
+  universe: ['DBC', 'EEM', 'EFA', 'GLD', 'IEF', 'SPY', 'TLT', 'VNQ'],
+  universeRationale: 'Liquid cross-asset ETFs with complete point-in-time coverage.',
+  data: {
+    snapshotId: '4'.repeat(64),
+    publicationId: '5'.repeat(64),
+    contentHash: '6'.repeat(64),
+    sessionsContentHash: '7'.repeat(64),
+    provider: 'alpaca',
+    sourceFeed: 'sip',
+    adjustment: 'all',
+    calendarVersion: 'alpaca-us-equity-calendar-v1',
+    firstSession: '2007-01-03',
+    lastSession: '2016-12-30',
+    selectedSessionCount: 2266,
+    selectedRebalanceCount: 108,
+    bounds: {
+      schemaVersion: 'bayn.evaluation-bounds.v1' as const,
+      dataStart: '2007-01-03',
+      dataEnd: '2016-12-30',
+      lookbackStart: '2007-01-03',
+      evaluationStart: '2008-01-03',
+      evaluationEnd: '2016-12-30',
+    },
+  },
+  policies: {
+    benchmark: policy('benchmark-policy'),
+    thresholds: policy('threshold-policy'),
+    uncertainty: policy('uncertainty-policy'),
+    execution: policy('execution-policy'),
+  },
+  priorTrialRunIds: ['8'.repeat(64), '9'.repeat(64)],
+}
+
+describe('qualification lock', () => {
+  test('builds a deterministic identity from the complete precommit', () => {
+    const first = makeQualificationLock(material)
+    const second = makeQualificationLock(structuredClone(material))
+
+    expect(second).toEqual(first)
+    expect(first.lockId).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  test('changes identity for every authority-bearing input group', () => {
+    const baseline = makeQualificationLock(material).lockId
+    const variants = [
+      { ...material, sourceRevision: 'a'.repeat(40) },
+      { ...material, protocolHash: 'b'.repeat(64) },
+      { ...material, image: { ...material.image, digest: `sha256:${'c'.repeat(64)}` } },
+      { ...material, universeRationale: `${material.universeRationale} No substitutions.` },
+      {
+        ...material,
+        data: { ...material.data, selectedSessionCount: material.data.selectedSessionCount + 1 },
+      },
+      {
+        ...material,
+        policies: { ...material.policies, execution: policy('execution-policy-v2') },
+      },
+      { ...material, priorTrialRunIds: [...material.priorTrialRunIds, 'a'.repeat(64)].sort() },
+    ]
+
+    for (const variant of variants) expect(makeQualificationLock(variant).lockId).not.toBe(baseline)
+  })
+
+  test('rejects weak windows, unordered lineage, divergent policy hashes, and forged lock ids', () => {
+    expect(() =>
+      makeQualificationLock({
+        ...material,
+        data: { ...material.data, selectedSessionCount: 503 },
+      }),
+    ).toThrow()
+    expect(() =>
+      makeQualificationLock({ ...material, priorTrialRunIds: [...material.priorTrialRunIds].reverse() }),
+    ).toThrow()
+    expect(() =>
+      makeQualificationLock({
+        ...material,
+        policies: {
+          ...material.policies,
+          benchmark: { ...material.policies.benchmark, contentHash: 'f'.repeat(64) },
+        },
+      }),
+    ).toThrow()
+
+    const lock = makeQualificationLock(material)
+    expect(() => Schema.decodeUnknownSync(QualificationLockSchema)({ ...lock, lockId: '0'.repeat(64) })).toThrow()
+  })
+})

--- a/services/bayn/src/qualification.ts
+++ b/services/bayn/src/qualification.ts
@@ -1,0 +1,146 @@
+import { Schema } from 'effect'
+
+import { EvaluationBoundsSchema, IsoDateSchema, Sha256Schema } from './contracts'
+import { canonicalHashV1, canonicalJsonV1 } from './hash'
+
+const StrictParseOptions = { onExcessProperty: 'error' } as const
+const NonEmptyString = Schema.String.check(
+  Schema.makeFilter((value: string) => value.length > 0 && value.trim() === value, {
+    expected: 'a non-empty string without surrounding whitespace',
+  }),
+)
+const SourceRevision = Schema.String.check(Schema.isPattern(/^(?:[a-f0-9]{40}|[a-f0-9]{64})$/))
+const ImageDigest = Schema.String.check(Schema.isPattern(/^sha256:[a-f0-9]{64}$/))
+const SymbolName = Schema.String.check(Schema.isPattern(/^[A-Z][A-Z0-9.-]{0,15}$/))
+const MinimumSessions = Schema.Int.check(Schema.isGreaterThanOrEqualTo(504))
+const MinimumRebalances = Schema.Int.check(Schema.isGreaterThanOrEqualTo(24))
+const CanonicalJson = Schema.Unknown.check(
+  Schema.makeFilter(
+    (value: unknown) => {
+      try {
+        canonicalJsonV1(value)
+        return true
+      } catch {
+        return false
+      }
+    },
+    { expected: 'a canonical JSON value' },
+  ),
+)
+
+const PolicyDocumentBase = Schema.Struct({
+  schemaVersion: NonEmptyString,
+  contentHash: Sha256Schema,
+  content: CanonicalJson,
+})
+
+export const QualificationPolicyDocumentSchema = PolicyDocumentBase.check(
+  Schema.makeFilter(
+    (document: typeof PolicyDocumentBase.Type) =>
+      document.contentHash === canonicalHashV1(document.content) ||
+      ({ path: ['contentHash'], issue: 'must match the canonical policy content hash' } as const),
+  ),
+)
+export type QualificationPolicyDocument = typeof QualificationPolicyDocumentSchema.Type
+
+const QualificationDataBase = Schema.Struct({
+  snapshotId: Sha256Schema,
+  publicationId: Sha256Schema,
+  contentHash: Sha256Schema,
+  sessionsContentHash: Sha256Schema,
+  provider: NonEmptyString,
+  sourceFeed: NonEmptyString,
+  adjustment: NonEmptyString,
+  calendarVersion: NonEmptyString,
+  firstSession: IsoDateSchema,
+  lastSession: IsoDateSchema,
+  selectedSessionCount: MinimumSessions,
+  selectedRebalanceCount: MinimumRebalances,
+  bounds: EvaluationBoundsSchema,
+})
+
+export const QualificationDataSchema = QualificationDataBase.check(
+  Schema.makeFilter((data: typeof QualificationDataBase.Type) => {
+    const issues: Schema.FilterIssue[] = []
+    if (data.firstSession > data.lastSession) {
+      issues.push({ path: ['firstSession'], issue: 'must not be after lastSession' })
+    }
+    if (data.bounds.dataStart < data.firstSession || data.bounds.dataEnd > data.lastSession) {
+      issues.push({ path: ['bounds'], issue: 'must be contained by the finalized snapshot' })
+    }
+    return issues
+  }),
+)
+
+const QualificationLockMaterialBase = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.qualification-lock.v1'),
+  protocolHash: Sha256Schema,
+  sourceRevision: SourceRevision,
+  image: Schema.Struct({
+    repository: NonEmptyString,
+    digest: ImageDigest,
+  }),
+  universe: Schema.Array(SymbolName).check(Schema.isMinLength(1)),
+  universeRationale: NonEmptyString,
+  data: QualificationDataSchema,
+  policies: Schema.Struct({
+    benchmark: QualificationPolicyDocumentSchema,
+    thresholds: QualificationPolicyDocumentSchema,
+    uncertainty: QualificationPolicyDocumentSchema,
+    execution: QualificationPolicyDocumentSchema,
+  }),
+  priorTrialRunIds: Schema.Array(Sha256Schema),
+})
+
+const canonicalListIssues = (path: string, values: readonly string[]): readonly Schema.FilterIssue[] => {
+  const canonical = [...new Set(values)].sort()
+  if (canonical.length !== values.length) return [{ path: [path], issue: 'must not contain duplicates' }]
+  if (canonical.some((value, index) => value !== values[index])) {
+    return [{ path: [path], issue: 'must be sorted in canonical order' }]
+  }
+  return []
+}
+
+export const QualificationLockMaterialSchema = QualificationLockMaterialBase.check(
+  Schema.makeFilter((lock: typeof QualificationLockMaterialBase.Type) => [
+    ...canonicalListIssues('universe', lock.universe),
+    ...canonicalListIssues('priorTrialRunIds', lock.priorTrialRunIds),
+  ]),
+)
+export type QualificationLockMaterial = typeof QualificationLockMaterialSchema.Type
+
+const QualificationLockBase = Schema.Struct({
+  ...QualificationLockMaterialBase.fields,
+  lockId: Sha256Schema,
+})
+
+export const QualificationLockSchema = QualificationLockBase.check(
+  Schema.makeFilter((lock: typeof QualificationLockBase.Type) => {
+    const { lockId, ...material } = lock
+    const issues = [
+      ...canonicalListIssues('universe', material.universe),
+      ...canonicalListIssues('priorTrialRunIds', material.priorTrialRunIds),
+    ]
+    if (lockId !== canonicalHashV1(material)) {
+      issues.push({ path: ['lockId'], issue: 'must match the canonical lock material hash' })
+    }
+    return issues
+  }),
+)
+export type QualificationLock = typeof QualificationLockSchema.Type
+
+const decodePolicyDocumentSync = Schema.decodeUnknownSync(QualificationPolicyDocumentSchema, StrictParseOptions)
+const decodeLockMaterialSync = Schema.decodeUnknownSync(QualificationLockMaterialSchema, StrictParseOptions)
+const decodeLockSync = Schema.decodeUnknownSync(QualificationLockSchema, StrictParseOptions)
+
+export const makeQualificationPolicyDocument = (schemaVersion: string, content: unknown): QualificationPolicyDocument =>
+  decodePolicyDocumentSync({
+    schemaVersion,
+    contentHash: canonicalHashV1(content),
+    content,
+  })
+
+export const makeQualificationLock = (input: QualificationLockMaterial): QualificationLock => {
+  const material = decodeLockMaterialSync(input)
+  return decodeLockSync({ ...material, lockId: canonicalHashV1(material) })
+}


### PR DESCRIPTION
## Summary

- classify every completed pre-lock evaluation as an append-only burned qualification trial
- add a strict, content-addressed Effect Schema contract for future qualification locks without opening one early
- enforce one immutable terminal result per lock while retaining protocol, snapshot, run, and artifact tables as the source of truth

## Related Issues

Related: [PROOMPT-363](https://linear.app/proompteng/issue/PROOMPT-363/define-immutable-tsmom-candidate-trial-ledger-and-qualification-lock)

## Testing

- `BAYN_TEST_POSTGRES_URL=postgresql://postgres:***@127.0.0.1:55432/bayn_test bun run --filter @proompteng/bayn test` — 80 passed
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- rehearsed the additive upgrade against a database containing one migration-v1 completed run; migration-v2 readback was one burned trial with `PRE_LOCK_RESULT_OBSERVED,FAILED_BENCHMARK_GATE`, zero locks, and zero results

## Breaking Changes

None. The migration is additive. It backfills existing complete evaluations and makes qualification trials, locks, and results append-only.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed because this is a database/domain-contract change.
- [x] Documentation and PROOMPT-363 implementation plan are updated.
