### PR TITLE
feat(bayn): persist deterministic qualification artifacts

### DIFF
--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -29,10 +29,16 @@ and journals the resulting simulation to TigerBeetle. It contains no broker clie
   lookback, and evaluation bounds before exposing numeric bars.
 - The run ID binds source and image identity, compiled strategy behavior and decoded parameters, complete finalized
   snapshot provenance, calendar version, and explicit bounds.
-- Signals are formed at a month-end close and may execute only at the next exchange session open.
+- One pure compiled TSMOM decision function records each lookback return, direction vote, score, active symbol, and
+  target weight at a month-end close. Historical evaluation uses that function directly; any later paper planner must
+  reuse it. Decisions may execute only at the next exchange session open.
 - After exact TigerBeetle reconciliation, one PostgreSQL transaction records the immutable protocol lock, input
-  snapshot reference, run identity, metrics, simulated orders, fills, cash changes, daily position marks, the full
-  equity series, independent marked-equity proof, reconciliation receipt, gate outcomes, and status history.
+  snapshot reference, run identity, metrics, simulated orders, fills, cash changes, daily position marks, daily
+  returns, turnover, fees, drawdown, aligned benchmark series, the full equity series, independent marked-equity
+  proof, reconciliation receipt, gate outcomes, and status history. A content-addressed dossier manifest binds every
+  artifact, event, and gate hash to the exact source, image, protocol, snapshot, calendar, and execution contract.
+- Ordered artifacts can be read internally through contiguous pages capped at 256 items. PostgreSQL triggers make the
+  complete evidence graph append-only and permit an evaluation row only its exact `WRITING` to `COMPLETE` transition.
 - Every completed pre-qualification run is recorded once as a burned trial. Observed results cannot later be presented
   as an untouched qualification window, and the trial record cannot be updated or deleted.
 - A future qualification lock must bind the exact protocol, source and image, finalized snapshot and bounds, universe

--- a/services/bayn/migrations/0003_evidence_immutability.ts
+++ b/services/bayn/migrations/0003_evidence_immutability.ts
@@ -1,0 +1,76 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient
+
+  yield* sql`
+    CREATE FUNCTION bayn_reject_evidence_mutation()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+    BEGIN
+      RAISE EXCEPTION '% is append-only', TG_TABLE_NAME USING ERRCODE = '55000';
+    END
+    $function$
+  `
+
+  yield* sql`
+    CREATE TRIGGER bayn_protocol_locks_append_only
+    BEFORE UPDATE OR DELETE ON bayn_protocol_locks
+    FOR EACH ROW EXECUTE FUNCTION bayn_reject_evidence_mutation()
+  `
+  yield* sql`
+    CREATE TRIGGER bayn_snapshot_references_append_only
+    BEFORE UPDATE OR DELETE ON bayn_snapshot_references
+    FOR EACH ROW EXECUTE FUNCTION bayn_reject_evidence_mutation()
+  `
+  yield* sql`
+    CREATE TRIGGER bayn_evaluation_artifacts_append_only
+    BEFORE UPDATE OR DELETE ON bayn_evaluation_artifacts
+    FOR EACH ROW EXECUTE FUNCTION bayn_reject_evidence_mutation()
+  `
+  yield* sql`
+    CREATE TRIGGER bayn_evaluation_events_append_only
+    BEFORE UPDATE OR DELETE ON bayn_evaluation_events
+    FOR EACH ROW EXECUTE FUNCTION bayn_reject_evidence_mutation()
+  `
+  yield* sql`
+    CREATE TRIGGER bayn_gate_outcomes_append_only
+    BEFORE UPDATE OR DELETE ON bayn_gate_outcomes
+    FOR EACH ROW EXECUTE FUNCTION bayn_reject_evidence_mutation()
+  `
+  yield* sql`
+    CREATE TRIGGER bayn_status_history_append_only
+    BEFORE UPDATE OR DELETE ON bayn_status_history
+    FOR EACH ROW EXECUTE FUNCTION bayn_reject_evidence_mutation()
+  `
+
+  yield* sql`
+    CREATE FUNCTION bayn_allow_evaluation_completion_only()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+    BEGIN
+      IF TG_OP = 'UPDATE'
+        AND OLD.status = 'WRITING'
+        AND NEW.status = 'COMPLETE'
+        AND OLD.completed_at IS NULL
+        AND NEW.completed_at IS NOT NULL
+        AND (to_jsonb(OLD) - ARRAY['status', 'completed_at']) =
+            (to_jsonb(NEW) - ARRAY['status', 'completed_at'])
+      THEN
+        RETURN NEW;
+      END IF;
+
+      RAISE EXCEPTION '% is immutable except for WRITING to COMPLETE', TG_TABLE_NAME USING ERRCODE = '55000';
+    END
+    $function$
+  `
+
+  yield* sql`
+    CREATE TRIGGER bayn_evaluation_runs_completion_only
+    BEFORE UPDATE OR DELETE ON bayn_evaluation_runs
+    FOR EACH ROW EXECUTE FUNCTION bayn_allow_evaluation_completion_only()
+  `
+})

--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -110,12 +110,13 @@ const marketDataService = (load: MarketDataService['load']): MarketDataService =
 const successfulEvidenceStore: EvidenceStoreService = {
   check: Effect.void,
   read: (runId) => Effect.succeed(runId === historicalRunId ? Option.some(historicalEvidence) : Option.none()),
+  readArtifactItems: () => Effect.succeed(Option.none()),
   recover: () => Effect.succeed(Option.none()),
   persist: ({ evaluation }) =>
     Effect.succeed({
       runId: evaluation.runId,
       deduplicated: false,
-      artifactCount: 12,
+      artifactCount: 17,
       eventCount: evaluation.events.length,
       gateCount: evaluation.verdict.gates.length,
     }),
@@ -179,7 +180,7 @@ const readyState = (): RuntimeState => {
       persistence: {
         runId: evaluation.runId,
         deduplicated: false,
-        artifactCount: 12,
+        artifactCount: 17,
         eventCount: evaluation.events.length,
         gateCount: evaluation.verdict.gates.length,
       },
@@ -492,7 +493,7 @@ describe('Bayn startup lifecycle', () => {
             persistence: {
               runId: evaluation.runId,
               deduplicated: true,
-              artifactCount: 12,
+              artifactCount: 17,
               eventCount: evaluation.events.length,
               gateCount: evaluation.verdict.gates.length,
             },
@@ -703,6 +704,7 @@ describe('Bayn startup lifecycle', () => {
     const unavailable: EvidenceStoreService = {
       check: Effect.void,
       read: () => Effect.succeed(Option.none()),
+      readArtifactItems: () => Effect.succeed(Option.none()),
       recover: () => Effect.succeed(Option.none()),
       persist: () =>
         Effect.fail(

--- a/services/bayn/src/contracts.test.ts
+++ b/services/bayn/src/contracts.test.ts
@@ -174,15 +174,15 @@ describe('Bayn runtime provenance', () => {
     })
 
     expect(provenance).toMatchObject({
-      schemaVersion: 'bayn.runtime-provenance.v1',
+      schemaVersion: 'bayn.runtime-provenance.v2',
       contractVersions: {
-        runtimeProvenance: 'bayn.runtime-provenance.v1',
+        runtimeProvenance: 'bayn.runtime-provenance.v2',
         inputManifest: 'bayn.input-manifest.v2',
-        evaluation: 'bayn.evaluation.v2',
+        evaluation: 'bayn.evaluation.v3',
       },
     })
     expect(await Effect.runPromise(decodeRuntimeProvenance(provenance))).toEqual(provenance)
     await expectFailure(decodeRuntimeProvenance({ ...provenance, futureField: true }))
-    await expectFailure(decodeRuntimeProvenance({ ...provenance, schemaVersion: 'bayn.runtime-provenance.v2' }))
+    await expectFailure(decodeRuntimeProvenance({ ...provenance, schemaVersion: 'bayn.runtime-provenance.v1' }))
   })
 })

--- a/services/bayn/src/contracts.ts
+++ b/services/bayn/src/contracts.ts
@@ -178,7 +178,7 @@ export const RunIdentitySchema = RunIdentityBase.check(
 export type RunIdentity = typeof RunIdentitySchema.Type
 
 export const RuntimeProvenanceSchema = Schema.Struct({
-  schemaVersion: Schema.Literal('bayn.runtime-provenance.v1'),
+  schemaVersion: Schema.Literal('bayn.runtime-provenance.v2'),
   sourceRevision: SourceRevision,
   image: Schema.Struct({
     repository: NonEmptyString,
@@ -191,9 +191,9 @@ export const RuntimeProvenanceSchema = Schema.Struct({
     parameterSchemaVersion: NonEmptyString,
   }),
   contractVersions: Schema.Struct({
-    runtimeProvenance: Schema.Literal('bayn.runtime-provenance.v1'),
+    runtimeProvenance: Schema.Literal('bayn.runtime-provenance.v2'),
     inputManifest: Schema.Literal('bayn.input-manifest.v2'),
-    evaluation: Schema.Literal('bayn.evaluation.v2'),
+    evaluation: Schema.Literal('bayn.evaluation.v3'),
   }),
 })
 export type RuntimeProvenance = typeof RuntimeProvenanceSchema.Type
@@ -224,11 +224,11 @@ export const makeRunIdentity = (input: RunIdentityMaterial): RunIdentity => {
 
 export const makeRuntimeProvenance = (input: RuntimeProvenanceInput): RuntimeProvenance =>
   decodeRuntimeProvenanceSync({
-    schemaVersion: 'bayn.runtime-provenance.v1',
+    schemaVersion: 'bayn.runtime-provenance.v2',
     ...input,
     contractVersions: {
-      runtimeProvenance: 'bayn.runtime-provenance.v1',
+      runtimeProvenance: 'bayn.runtime-provenance.v2',
       inputManifest: 'bayn.input-manifest.v2',
-      evaluation: 'bayn.evaluation.v2',
+      evaluation: 'bayn.evaluation.v3',
     },
   })

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -5,6 +5,7 @@ import { PgClient } from '@effect/sql-pg'
 import { Cause, Effect, Exit, Fiber, Layer, ManagedRuntime, Option, Redacted } from 'effect'
 
 import type { RuntimeConfig } from '../config'
+import { canonicalHashV1 } from '../hash'
 import { buildLedgerPlan } from '../ledger'
 import { makeQualificationLock, makeQualificationPolicyDocument } from '../qualification'
 import { evaluateTsmom } from '../strategy'
@@ -180,7 +181,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     )
 
     expect(result.first).toMatchObject({ runId: input.evaluation.runId, deduplicated: false })
-    expect(result.first.artifactCount).toBe(12)
+    expect(result.first.artifactCount).toBe(17)
     expect(result.second).toEqual({ ...result.first, deduplicated: true })
     expect(result.runs).toEqual([
       {
@@ -339,7 +340,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     expect(Exit.isFailure(result.divergentLock)).toBe(true)
   })
 
-  test('reads and recovers the complete v2 evidence contract without evaluating it again', async () => {
+  test('reads and recovers the complete v3 evidence contract without evaluating it again', async () => {
     const input = makeInput()
     const result = await runtime.runPromise(
       Effect.gen(function* () {
@@ -364,24 +365,46 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       })
       expect(result.stored.value.run).toMatchObject({
         runId: input.evaluation.runId,
-        evaluationSchemaVersion: 'bayn.evaluation.v2',
-        artifactCount: 12,
+        evaluationSchemaVersion: 'bayn.evaluation.v3',
+        artifactCount: 17,
         eventCount: input.evaluation.events.length,
       })
       expect(result.stored.value.artifacts.map((artifact) => artifact.name)).toEqual([
         'buy-and-hold',
+        'buy-and-hold-series',
         'cash-changes',
         'daily-position-marks',
         'direct-volatility-timing',
+        'direct-volatility-timing-series',
         'double-cost-strategy',
+        'double-cost-strategy-series',
         'equity-series',
         'evaluation-summary',
         'input-manifest',
         'marked-equity-reconciliation',
+        'qualification-artifact-manifest',
         'reconciliation',
         'simulated-orders',
         'strategy',
+        'tsmom-signal-decisions',
       ])
+      const manifest = result.stored.value.artifacts.find(
+        (artifact) => artifact.name === 'qualification-artifact-manifest',
+      )
+      if (manifest === undefined) throw new Error('qualification artifact manifest is missing')
+      expect(manifest.payload).toMatchObject({
+        schemaVersion: 'bayn.qualification-artifact-manifest.v1',
+        identity: {
+          runId: input.evaluation.runId,
+          protocolHash: input.evaluation.protocolHash,
+          snapshotId: input.evaluation.inputManifest.finalizedSnapshot.snapshotId,
+          sourceRevision: input.provenance.sourceRevision,
+          image: input.provenance.image,
+        },
+        events: { count: input.evaluation.events.length },
+        gates: { count: input.evaluation.verdict.gates.length },
+      })
+      expect(canonicalHashV1(manifest.payload)).toBe(manifest.contentHash)
     }
     expect(Option.isSome(result.recovered)).toBe(true)
     if (Option.isSome(result.recovered)) {
@@ -391,10 +414,66 @@ describePostgres('PostgreSQL evaluation evidence', () => {
           markedEquityReconciliation: { withinTolerance: true },
         },
         reconciliation: { runId: input.evaluation.runId, exact: true },
-        persistence: { runId: input.evaluation.runId, deduplicated: true, artifactCount: 12 },
+        persistence: { runId: input.evaluation.runId, deduplicated: true, artifactCount: 17 },
       })
     }
     expect(Option.isNone(result.missing)).toBe(true)
+  })
+
+  test('retrieves ordered artifact items through bounded contiguous pages', async () => {
+    const input = makeInput()
+    const result = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* EvidenceStore
+        yield* store.persist(input)
+        const items: unknown[] = []
+        const pageSizes: number[] = []
+        let afterOrdinal = -1
+        let contentHash = ''
+        while (true) {
+          const page = yield* store.readArtifactItems({
+            runId: input.evaluation.runId,
+            artifactName: 'daily-position-marks',
+            afterOrdinal,
+            limit: 31,
+          })
+          if (Option.isNone(page)) throw new Error('daily-position-marks page is missing')
+          contentHash = page.value.contentHash
+          pageSizes.push(page.value.items.length)
+          items.push(...page.value.items.map((item) => item.payload))
+          if (page.value.nextAfterOrdinal === null) break
+          afterOrdinal = page.value.nextAfterOrdinal
+        }
+        const scalar = yield* store.readArtifactItems({
+          runId: input.evaluation.runId,
+          artifactName: 'strategy',
+          limit: 1,
+        })
+        const invalidLimit = yield* store
+          .readArtifactItems({
+            runId: input.evaluation.runId,
+            artifactName: 'daily-position-marks',
+            limit: 257,
+          })
+          .pipe(Effect.flip)
+        return { contentHash, invalidLimit, items, pageSizes, scalar }
+      }),
+    )
+
+    expect(result.items).toEqual([...input.evaluation.simulation.dailyMarks])
+    expect(result.contentHash).toBe(
+      canonicalHashV1({
+        schemaVersion: 'bayn.daily-position-marks.v2',
+        items: input.evaluation.simulation.dailyMarks,
+      }),
+    )
+    expect(result.pageSizes.length).toBeGreaterThan(2)
+    expect(result.pageSizes.every((size) => size > 0 && size <= 31)).toBe(true)
+    expect(Option.isNone(result.scalar)).toBe(true)
+    expect(result.invalidLimit).toMatchObject({
+      failure: 'invariant',
+      operation: 'read-artifact-items',
+    })
   })
 
   test('rejects a simulation whose declared costs diverge from its locked protocol', async () => {
@@ -469,118 +548,64 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     ])
   })
 
-  test('rejects a complete receipt whose stored evidence was altered', async () => {
+  test('rejects updates and deletes across the completed evidence graph', async () => {
     const input = makeInput()
-    const errors = await runtime.runPromise(
+    const result = await runtime.runPromise(
       Effect.gen(function* () {
         const store = yield* EvidenceStore
         const sql = yield* PgClient.PgClient
         yield* store.persist(input)
-        yield* sql`
+        const artifactUpdate = yield* Effect.exit(sql`
           UPDATE bayn_evaluation_artifacts
           SET payload = ${sql.json({ corrupted: true })}
           WHERE run_id = ${input.evaluation.runId} AND artifact_name = 'strategy'
-        `
-        const read = yield* store.read(input.evaluation.runId).pipe(Effect.flip)
-        const replay = yield* store.persist(input).pipe(Effect.flip)
-        return { read, replay }
-      }),
-    )
-
-    expect(errors.read).toBeInstanceOf(DatabaseError)
-    expect(errors.read.failure).toBe('invariant')
-    expect(errors.read.operation).toBe('read-evidence')
-    expect(errors.replay).toBeInstanceOf(DatabaseError)
-    expect(errors.replay.failure).toBe('invariant')
-    expect(errors.replay.operation).toBe('read-receipt')
-  })
-
-  test('rejects a replay whose normalized snapshot bounds were altered', async () => {
-    const input = makeInput()
-    const error = await runtime.runPromise(
-      Effect.gen(function* () {
-        const store = yield* EvidenceStore
-        const sql = yield* PgClient.PgClient
-        yield* store.persist(input)
-        yield* sql`
+        `)
+        const snapshotUpdate = yield* Effect.exit(sql`
           UPDATE bayn_snapshot_references
           SET first_session = first_session + 1
           WHERE snapshot_id = ${input.evaluation.inputManifest.finalizedSnapshot.snapshotId}
-        `
-        return yield* store.persist(input).pipe(Effect.flip)
-      }),
-    )
-
-    expect(error).toBeInstanceOf(DatabaseError)
-    expect(error.failure).toBe('invariant')
-    expect(error.operation).toBe('snapshot-reference')
-    expect(error.message).toContain('stored snapshot reference diverged')
-  })
-
-  test('fails recovery when the stored snapshot manifest was altered', async () => {
-    const input = makeInput()
-    const error = await runtime.runPromise(
-      Effect.gen(function* () {
-        const store = yield* EvidenceStore
-        const sql = yield* PgClient.PgClient
-        yield* store.persist(input)
-        yield* sql`
-          UPDATE bayn_snapshot_references
-          SET manifest = ${sql.json({ corrupted: true })}
-          WHERE snapshot_id = ${input.evaluation.inputManifest.finalizedSnapshot.snapshotId}
-        `
-        return yield* store.recover(input.evaluation.runId, input.provenance).pipe(Effect.flip)
-      }),
-    )
-
-    expect(error).toBeInstanceOf(DatabaseError)
-    expect(error.failure).toBe('invariant')
-    expect(error.operation).toBe('recover-evidence')
-    expect(error.message).toContain('stored snapshot reference diverged')
-  })
-
-  test('rejects a replay whose initial capital was altered', async () => {
-    const input = makeInput()
-    const error = await runtime.runPromise(
-      Effect.gen(function* () {
-        const store = yield* EvidenceStore
-        const sql = yield* PgClient.PgClient
-        yield* store.persist(input)
-        yield* sql`
+        `)
+        const runUpdate = yield* Effect.exit(sql`
           UPDATE bayn_evaluation_runs
           SET initial_capital_micros = initial_capital_micros + 1
           WHERE run_id = ${input.evaluation.runId}
-        `
-        return yield* store.persist(input).pipe(Effect.flip)
-      }),
-    )
-
-    expect(error).toBeInstanceOf(DatabaseError)
-    expect(error.failure).toBe('invariant')
-    expect(error.operation).toBe('read-receipt')
-    expect(error.message).toContain('stored run identity diverged')
-  })
-
-  test('rejects a replay whose status detail was altered', async () => {
-    const input = makeInput()
-    const error = await runtime.runPromise(
-      Effect.gen(function* () {
-        const store = yield* EvidenceStore
-        const sql = yield* PgClient.PgClient
-        yield* store.persist(input)
-        yield* sql`
+        `)
+        const statusUpdate = yield* Effect.exit(sql`
           UPDATE bayn_status_history
-          SET detail = ${sql.json({ reconciliationExact: false, verdict: 'corrupted' })}
+          SET detail = ${sql.json({ corrupted: true })}
           WHERE run_id = ${input.evaluation.runId} AND status = 'COMPLETE'
-        `
-        return yield* store.persist(input).pipe(Effect.flip)
+        `)
+        const eventDelete = yield* Effect.exit(sql`
+          DELETE FROM bayn_evaluation_events WHERE run_id = ${input.evaluation.runId}
+        `)
+        const gateDelete = yield* Effect.exit(sql`
+          DELETE FROM bayn_gate_outcomes WHERE run_id = ${input.evaluation.runId}
+        `)
+        const protocolDelete = yield* Effect.exit(sql`
+          DELETE FROM bayn_protocol_locks WHERE protocol_hash = ${input.evaluation.protocolHash}
+        `)
+        const runDelete = yield* Effect.exit(sql`
+          DELETE FROM bayn_evaluation_runs WHERE run_id = ${input.evaluation.runId}
+        `)
+        const read = yield* store.read(input.evaluation.runId)
+        return {
+          exits: [
+            artifactUpdate,
+            snapshotUpdate,
+            runUpdate,
+            statusUpdate,
+            eventDelete,
+            gateDelete,
+            protocolDelete,
+            runDelete,
+          ],
+          read,
+        }
       }),
     )
 
-    expect(error).toBeInstanceOf(DatabaseError)
-    expect(error.failure).toBe('invariant')
-    expect(error.operation).toBe('read-receipt')
-    expect(error.message).toContain('stored status history diverged')
+    expect(result.exits.every(Exit.isFailure)).toBe(true)
+    expect(Option.isSome(result.read)).toBe(true)
   })
 
   test('rolls back every table when a terminal evidence constraint fails', async () => {

--- a/services/bayn/src/db/evidence-store.ts
+++ b/services/bayn/src/db/evidence-store.ts
@@ -7,14 +7,17 @@ import type { RuntimeConfig } from '../config'
 import { makeRunIdentity, makeStrategyProtocolHash, type RuntimeProvenance } from '../contracts'
 import {
   decodeCashChangesArtifact,
+  decodeDailyPerformanceSeriesArtifact,
   decodeDailyPositionMarksArtifact,
   decodeEquitySeriesArtifact,
   decodeEvaluationEvents,
   decodeEvaluationSummary,
   decodeInputManifestArtifact,
   decodeMarkedEquityReconciliation,
+  decodeQualificationArtifactManifest,
   decodeReconciliationResult,
   decodeSimulatedOrdersArtifact,
+  decodeTsmomSignalDecisionsArtifact,
   makeEquitySeriesArtifact,
 } from '../evidence-contracts'
 import { canonicalHashV1 } from '../hash'
@@ -47,10 +50,26 @@ export interface PersistEvaluationInput {
   readonly reconciliation: ReconciliationResult
 }
 
+export interface ArtifactItemPage {
+  readonly runId: string
+  readonly artifactName: string
+  readonly schemaVersion: string
+  readonly contentHash: string
+  readonly itemCount: number
+  readonly items: readonly { readonly ordinal: number; readonly payload: unknown }[]
+  readonly nextAfterOrdinal: number | null
+}
+
 export interface EvidenceStoreService {
   readonly check: Effect.Effect<void, DatabaseError>
   readonly persist: (input: PersistEvaluationInput) => Effect.Effect<PersistenceReceipt, DatabaseError>
   readonly read: (runId: string) => Effect.Effect<Option.Option<StoredEvaluationEvidence>, DatabaseError>
+  readonly readArtifactItems: (input: {
+    readonly runId: string
+    readonly artifactName: string
+    readonly afterOrdinal?: number
+    readonly limit: number
+  }) => Effect.Effect<Option.Option<ArtifactItemPage>, DatabaseError>
   readonly recover: (
     runId: string,
     provenance: RuntimeProvenance,
@@ -203,6 +222,15 @@ const ArtifactReferenceRow = Schema.Struct({
   content_hash: Sha256,
   payload: Schema.Unknown,
 })
+const ArtifactSeriesMetadataRow = Schema.Struct({
+  schema_version: Schema.String,
+  content_hash: Sha256,
+  item_count: NonNegativeInteger,
+})
+const ArtifactItemRow = Schema.Struct({
+  ordinal: NonNegativeInteger,
+  payload: Schema.Unknown,
+})
 const EventReferenceRow = Schema.Struct({
   ordinal: NonNegativeInteger,
   event_id: Sha256,
@@ -301,6 +329,11 @@ const protocolTransactionCostBpsMicros = (parameters: unknown): string => {
   return BigInt(micros).toString()
 }
 
+const artifactItemCount = (payload: unknown): number => {
+  if (typeof payload !== 'object' || payload === null || !('items' in payload)) return 0
+  return Array.isArray(payload.items) ? payload.items.length : 0
+}
+
 const makePersistencePlan = (input: PersistEvaluationInput): PersistencePlan => {
   const { evaluation, parameters, provenance, reconciliation } = input
   const strategyName = provenance.strategy.name
@@ -355,8 +388,34 @@ const makePersistencePlan = (input: PersistEvaluationInput): PersistencePlan => 
     throw new TypeError('independent marked-equity proof diverges from the evaluation evidence')
   }
 
-  const artifacts = [
-    ['evaluation-summary', 'bayn.evaluation-summary.v1', summarizeEvaluation(evaluation)],
+  const decisionEvents = evaluation.events.filter((event) => event.kind === 'decision')
+  if (
+    evaluation.signalDecisions.length !== decisionEvents.length ||
+    evaluation.signalDecisions.some(
+      (decision, index) =>
+        decision.decisionId !== decisionEvents[index]?.id ||
+        decision.signalDate !== decisionEvents[index]?.signalDate ||
+        decision.executionDate !== decisionEvents[index]?.executionDate ||
+        canonicalHashV1(decision.targetWeights) !== canonicalHashV1(decisionEvents[index]?.targetWeights),
+    )
+  ) {
+    throw new TypeError('TSMOM signal decisions diverge from durable decision events')
+  }
+  const candidateDates = evaluation.simulation.dailyMarks.map((point) => point.sessionDate)
+  const benchmarkSeries = Object.values(evaluation.benchmarkSeries)
+  if (
+    candidateDates.length !== evaluation.strategy.observations ||
+    benchmarkSeries.some(
+      (series) =>
+        series.length !== candidateDates.length ||
+        series.some((point, index) => point.sessionDate !== candidateDates[index]),
+    )
+  ) {
+    throw new TypeError('candidate and benchmark daily series are not exactly aligned')
+  }
+
+  const baseArtifacts = [
+    ['evaluation-summary', 'bayn.evaluation-summary.v2', summarizeEvaluation(evaluation)],
     ['input-manifest', evaluation.inputManifest.schemaVersion, evaluation.inputManifest],
     ['strategy', 'bayn.performance-metrics.v1', evaluation.strategy],
     ['buy-and-hold', 'bayn.performance-metrics.v1', evaluation.buyAndHold],
@@ -378,8 +437,40 @@ const makePersistencePlan = (input: PersistEvaluationInput): PersistencePlan => 
     ],
     [
       'daily-position-marks',
-      'bayn.daily-position-marks.v1',
-      { schemaVersion: 'bayn.daily-position-marks.v1', items: evaluation.simulation.dailyMarks },
+      'bayn.daily-position-marks.v2',
+      { schemaVersion: 'bayn.daily-position-marks.v2', items: evaluation.simulation.dailyMarks },
+    ],
+    [
+      'tsmom-signal-decisions',
+      'bayn.tsmom-signal-decisions.v1',
+      { schemaVersion: 'bayn.tsmom-signal-decisions.v1', items: evaluation.signalDecisions },
+    ],
+    [
+      'buy-and-hold-series',
+      'bayn.daily-performance-series.v1',
+      {
+        schemaVersion: 'bayn.daily-performance-series.v1',
+        series: 'buy-and-hold',
+        items: evaluation.benchmarkSeries.buyAndHold,
+      },
+    ],
+    [
+      'direct-volatility-timing-series',
+      'bayn.daily-performance-series.v1',
+      {
+        schemaVersion: 'bayn.daily-performance-series.v1',
+        series: 'direct-volatility-timing',
+        items: evaluation.benchmarkSeries.directVolTiming,
+      },
+    ],
+    [
+      'double-cost-strategy-series',
+      'bayn.daily-performance-series.v1',
+      {
+        schemaVersion: 'bayn.daily-performance-series.v1',
+        series: 'double-cost-strategy',
+        items: evaluation.benchmarkSeries.doubleCostStrategy,
+      },
     ],
     ['equity-series', 'bayn.equity-series.v1', makeEquitySeriesArtifact(evaluation.equitySeries)],
     [
@@ -393,7 +484,7 @@ const makePersistencePlan = (input: PersistEvaluationInput): PersistencePlan => 
     schemaVersion: schemaVersion as string,
     contentHash: canonicalHashV1(payload),
     payload,
-  }))
+  })) satisfies ArtifactPlan[]
   const events = evaluation.events.map((event, ordinal) => ({
     ordinal,
     id: event.id,
@@ -411,6 +502,57 @@ const makePersistencePlan = (input: PersistEvaluationInput): PersistencePlan => 
   }))
   if (events.length === 0) throw new TypeError('evaluation produced no durable events')
   if (gates.length === 0) throw new TypeError('evaluation produced no economic gate outcomes')
+
+  const artifactManifest = {
+    schemaVersion: 'bayn.qualification-artifact-manifest.v1',
+    identity: {
+      runId: evaluation.runId,
+      evaluationSchemaVersion: evaluation.schemaVersion,
+      protocolHash,
+      sourceRevision: provenance.sourceRevision,
+      image: provenance.image,
+      snapshotId,
+      publicationId: evaluation.inputManifest.finalizedSnapshot.publicationId,
+      inputManifestHash: evaluation.inputManifest.hash,
+      bounds: evaluation.inputManifest.bounds,
+      calendarVersion: evaluation.inputManifest.finalizedSnapshot.calendarVersion,
+    },
+    execution: {
+      parameterSchemaVersion: provenance.strategy.parameterSchemaVersion,
+      parameterHash: provenance.strategy.parameterHash,
+      simulationSchemaVersion: evaluation.simulation.schemaVersion,
+      transactionCostBpsMicros: evaluation.simulation.transactionCostBpsMicros,
+    },
+    artifacts: [...baseArtifacts]
+      .sort((left, right) => left.name.localeCompare(right.name))
+      .map((artifact) => ({
+        name: artifact.name,
+        schemaVersion: artifact.schemaVersion,
+        itemCount: artifactItemCount(artifact.payload),
+        contentHash: artifact.contentHash,
+      })),
+    events: {
+      count: events.length,
+      contentHash: canonicalHashV1(
+        events.map(({ ordinal, id, kind, contentHash }) => ({ ordinal, id, kind, contentHash })),
+      ),
+    },
+    gates: {
+      count: gates.length,
+      contentHash: canonicalHashV1(
+        gates.map(({ ordinal, name, passed, contentHash }) => ({ ordinal, name, passed, contentHash })),
+      ),
+    },
+  }
+  const artifacts = [
+    ...baseArtifacts,
+    {
+      name: 'qualification-artifact-manifest',
+      schemaVersion: artifactManifest.schemaVersion,
+      contentHash: canonicalHashV1(artifactManifest),
+      payload: artifactManifest,
+    },
+  ]
 
   return { ...input, strategyName, protocolHash, snapshotId, artifacts, events, gates }
 }
@@ -555,6 +697,42 @@ const makeEvidenceStore = Effect.gen(function* () {
       FROM bayn_evaluation_artifacts
       WHERE run_id = ${runId}
       ORDER BY artifact_name
+    `,
+  })
+  const getArtifactSeriesMetadata = SqlSchema.findAll({
+    Request: Schema.Struct({ runId: Sha256, artifactName: Schema.String }),
+    Result: ArtifactSeriesMetadataRow,
+    execute: ({ runId, artifactName }) => sql`
+      SELECT
+        artifact.schema_version,
+        artifact.content_hash,
+        jsonb_array_length(artifact.payload -> 'items')::integer AS item_count
+      FROM bayn_evaluation_artifacts AS artifact
+      JOIN bayn_evaluation_runs AS run USING (run_id)
+      WHERE artifact.run_id = ${runId}
+        AND artifact.artifact_name = ${artifactName}
+        AND run.status = 'COMPLETE'
+        AND jsonb_typeof(artifact.payload -> 'items') = 'array'
+    `,
+  })
+  const getArtifactItems = SqlSchema.findAll({
+    Request: Schema.Struct({
+      runId: Sha256,
+      artifactName: Schema.String,
+      afterOrdinal: Schema.Int,
+      limit: PositiveInteger,
+    }),
+    Result: ArtifactItemRow,
+    execute: ({ runId, artifactName, afterOrdinal, limit }) => sql`
+      SELECT (item.ordinality - 1)::integer AS ordinal, item.payload
+      FROM bayn_evaluation_artifacts AS artifact
+      CROSS JOIN LATERAL jsonb_array_elements(artifact.payload -> 'items')
+        WITH ORDINALITY AS item(payload, ordinality)
+      WHERE artifact.run_id = ${runId}
+        AND artifact.artifact_name = ${artifactName}
+        AND (item.ordinality - 1) > ${afterOrdinal}
+      ORDER BY item.ordinality
+      LIMIT ${limit}
     `,
   })
   const getEventReferences = SqlSchema.findAll({
@@ -828,6 +1006,53 @@ const makeEvidenceStore = Effect.gen(function* () {
 
   const read = (runId: string) => runDatabase('read-evidence', readStored(runId))
 
+  const readArtifactItems: EvidenceStoreService['readArtifactItems'] = ({
+    runId,
+    artifactName,
+    afterOrdinal = -1,
+    limit,
+  }) =>
+    runDatabase(
+      'read-artifact-items',
+      Effect.gen(function* () {
+        yield* ensure(/^[0-9a-f]{64}$/.test(runId), 'read-artifact-items', 'run ID is invalid')
+        yield* ensure(
+          artifactName.length > 0 && artifactName.trim() === artifactName,
+          'read-artifact-items',
+          'artifact name is invalid',
+        )
+        yield* ensure(
+          Number.isInteger(afterOrdinal) && afterOrdinal >= -1,
+          'read-artifact-items',
+          'after ordinal must be an integer greater than or equal to -1',
+        )
+        yield* ensure(
+          Number.isInteger(limit) && limit > 0 && limit <= 256,
+          'read-artifact-items',
+          'page limit must be between 1 and 256',
+        )
+        const metadata = yield* getArtifactSeriesMetadata({ runId, artifactName })
+        if (metadata.length === 0) return Option.none<ArtifactItemPage>()
+        yield* ensure(metadata.length === 1, 'read-artifact-items', 'artifact series metadata is duplicated')
+        const rows = yield* getArtifactItems({ runId, artifactName, afterOrdinal, limit })
+        yield* ensure(
+          rows.every((row, index) => row.ordinal === afterOrdinal + index + 1),
+          'read-artifact-items',
+          'artifact page is not contiguous',
+        )
+        const last = rows.at(-1)?.ordinal
+        return Option.some({
+          runId,
+          artifactName,
+          schemaVersion: metadata[0].schema_version,
+          contentHash: metadata[0].content_hash,
+          itemCount: metadata[0].item_count,
+          items: rows,
+          nextAfterOrdinal: last !== undefined && last < metadata[0].item_count - 1 ? last : null,
+        } satisfies ArtifactItemPage)
+      }),
+    )
+
   const recover = (runId: string, provenance: RuntimeProvenance) =>
     runDatabase(
       'recover-evidence',
@@ -837,17 +1062,22 @@ const makeEvidenceStore = Effect.gen(function* () {
         const stored = storedOption.value
         const requiredArtifacts = new Map([
           ['buy-and-hold', 'bayn.performance-metrics.v1'],
+          ['buy-and-hold-series', 'bayn.daily-performance-series.v1'],
           ['cash-changes', 'bayn.cash-changes.v1'],
-          ['daily-position-marks', 'bayn.daily-position-marks.v1'],
+          ['daily-position-marks', 'bayn.daily-position-marks.v2'],
           ['direct-volatility-timing', 'bayn.performance-metrics.v1'],
+          ['direct-volatility-timing-series', 'bayn.daily-performance-series.v1'],
           ['double-cost-strategy', 'bayn.performance-metrics.v1'],
+          ['double-cost-strategy-series', 'bayn.daily-performance-series.v1'],
           ['equity-series', 'bayn.equity-series.v1'],
-          ['evaluation-summary', 'bayn.evaluation-summary.v1'],
+          ['evaluation-summary', 'bayn.evaluation-summary.v2'],
           ['input-manifest', 'bayn.input-manifest.v2'],
           ['marked-equity-reconciliation', 'bayn.marked-equity-reconciliation.v1'],
+          ['qualification-artifact-manifest', 'bayn.qualification-artifact-manifest.v1'],
           ['reconciliation', 'bayn.reconciliation.v1'],
           ['simulated-orders', 'bayn.simulated-orders.v1'],
           ['strategy', 'bayn.performance-metrics.v1'],
+          ['tsmom-signal-decisions', 'bayn.tsmom-signal-decisions.v1'],
         ])
         const artifacts = new Map(stored.artifacts.map((artifact) => [artifact.name, artifact]))
         yield* ensure(
@@ -856,11 +1086,11 @@ const makeEvidenceStore = Effect.gen(function* () {
               ([name, schemaVersion]) => artifacts.get(name)?.schemaVersion === schemaVersion,
             ),
           'recover-evidence',
-          'stored run does not have the exact v2 artifact contract',
+          'stored run does not have the exact v3 artifact contract',
         )
         yield* ensure(
           stored.run.runId === runId &&
-            stored.run.evaluationSchemaVersion === 'bayn.evaluation.v2' &&
+            stored.run.evaluationSchemaVersion === 'bayn.evaluation.v3' &&
             stored.run.sourceRevision === provenance.sourceRevision &&
             stored.run.imageRepository === provenance.image.repository &&
             stored.run.imageDigest === provenance.image.digest &&
@@ -877,6 +1107,21 @@ const makeEvidenceStore = Effect.gen(function* () {
         const equitySeries = yield* decodeEquitySeriesArtifact(artifacts.get('equity-series')!.payload)
         const events = yield* decodeEvaluationEvents(stored.events.map((event) => event.payload))
         const orders = yield* decodeSimulatedOrdersArtifact(artifacts.get('simulated-orders')!.payload)
+        const signalDecisions = yield* decodeTsmomSignalDecisionsArtifact(
+          artifacts.get('tsmom-signal-decisions')!.payload,
+        )
+        const buyAndHoldSeries = yield* decodeDailyPerformanceSeriesArtifact(
+          artifacts.get('buy-and-hold-series')!.payload,
+        )
+        const directVolatilitySeries = yield* decodeDailyPerformanceSeriesArtifact(
+          artifacts.get('direct-volatility-timing-series')!.payload,
+        )
+        const doubleCostSeries = yield* decodeDailyPerformanceSeriesArtifact(
+          artifacts.get('double-cost-strategy-series')!.payload,
+        )
+        const artifactManifest = yield* decodeQualificationArtifactManifest(
+          artifacts.get('qualification-artifact-manifest')!.payload,
+        )
         const storedTransactionCostBpsMicros = yield* Effect.try({
           try: () => protocolTransactionCostBpsMicros(stored.protocol.parameters),
           catch: (cause) =>
@@ -895,6 +1140,48 @@ const makeEvidenceStore = Effect.gen(function* () {
         const cashChanges = yield* decodeCashChangesArtifact(artifacts.get('cash-changes')!.payload)
         const dailyMarks = yield* decodeDailyPositionMarksArtifact(artifacts.get('daily-position-marks')!.payload)
         const inputManifest = yield* decodeInputManifestArtifact(artifacts.get('input-manifest')!.payload)
+        const expectedArtifactManifest = {
+          schemaVersion: 'bayn.qualification-artifact-manifest.v1',
+          identity: {
+            runId,
+            evaluationSchemaVersion: evaluation.evaluationSchemaVersion,
+            protocolHash: stored.run.protocolHash,
+            sourceRevision: stored.run.sourceRevision,
+            image: { repository: stored.run.imageRepository, digest: stored.run.imageDigest },
+            snapshotId: stored.run.snapshotId,
+            publicationId: inputManifest.finalizedSnapshot.publicationId,
+            inputManifestHash: inputManifest.hash,
+            bounds: inputManifest.bounds,
+            calendarVersion: inputManifest.finalizedSnapshot.calendarVersion,
+          },
+          execution: {
+            parameterSchemaVersion: stored.protocol.schemaVersion,
+            parameterHash: stored.protocol.parameterHash,
+            simulationSchemaVersion: 'bayn.simulation-trace.v2',
+            transactionCostBpsMicros: storedTransactionCostBpsMicros,
+          },
+          artifacts: stored.artifacts
+            .filter((artifact) => artifact.name !== 'qualification-artifact-manifest')
+            .sort((left, right) => left.name.localeCompare(right.name))
+            .map((artifact) => ({
+              name: artifact.name,
+              schemaVersion: artifact.schemaVersion,
+              itemCount: artifactItemCount(artifact.payload),
+              contentHash: artifact.contentHash,
+            })),
+          events: {
+            count: stored.events.length,
+            contentHash: canonicalHashV1(
+              stored.events.map(({ ordinal, id, kind, contentHash }) => ({ ordinal, id, kind, contentHash })),
+            ),
+          },
+          gates: {
+            count: stored.gates.length,
+            contentHash: canonicalHashV1(
+              stored.gates.map(({ ordinal, name, passed, contentHash }) => ({ ordinal, name, passed, contentHash })),
+            ),
+          },
+        }
         const storedSnapshot = yield* getSnapshot({ snapshotId: stored.run.snapshotId })
         yield* ensure(
           snapshotReferenceMatches(storedSnapshot, inputManifest),
@@ -910,7 +1197,7 @@ const makeEvidenceStore = Effect.gen(function* () {
               evaluatorEndingEquityMicros: evaluation.strategy.endingEquityMicros,
               events,
               simulation: {
-                schemaVersion: 'bayn.simulation-trace.v1',
+                schemaVersion: 'bayn.simulation-trace.v2',
                 transactionCostBpsMicros: orders.transactionCostBpsMicros,
                 orders: orders.items,
                 cashChanges: cashChanges.items,
@@ -921,6 +1208,8 @@ const makeEvidenceStore = Effect.gen(function* () {
             databaseError('invariant', 'recover-evidence', 'stored marked-equity reconstruction failed', cause),
         })
         const finalPoint = equitySeries.items.at(-1)!
+        const decisionEvents = events.filter((event) => event.kind === 'decision')
+        const candidateDates = dailyMarks.items.map((point) => point.sessionDate)
         yield* ensure(
           evaluation.runId === runId &&
             evaluation.codeRevision === provenance.sourceRevision &&
@@ -937,10 +1226,27 @@ const makeEvidenceStore = Effect.gen(function* () {
               canonicalHashV1(inputManifest.symbols.map((coverage) => coverage.symbol)) &&
             evaluation.eventCount === stored.run.eventCount &&
             evaluation.eventCount === events.length &&
+            evaluation.signalDecisionCount === signalDecisions.items.length &&
+            signalDecisions.items.length === decisionEvents.length &&
+            signalDecisions.items.every(
+              (decision, index) =>
+                decision.decisionId === decisionEvents[index]?.id &&
+                decision.signalDate === decisionEvents[index]?.signalDate &&
+                decision.executionDate === decisionEvents[index]?.executionDate &&
+                canonicalHashV1(decision.targetWeights) === canonicalHashV1(decisionEvents[index]?.targetWeights),
+            ) &&
             evaluation.orderCount === orders.items.length &&
             evaluation.cashChangeCount === cashChanges.items.length &&
             evaluation.dailyMarkCount === dailyMarks.items.length &&
             evaluation.dailyMarkCount === evaluation.strategy.observations &&
+            evaluation.benchmarkSeriesCounts.buyAndHold === buyAndHoldSeries.items.length &&
+            evaluation.benchmarkSeriesCounts.directVolTiming === directVolatilitySeries.items.length &&
+            evaluation.benchmarkSeriesCounts.doubleCostStrategy === doubleCostSeries.items.length &&
+            [buyAndHoldSeries.items, directVolatilitySeries.items, doubleCostSeries.items].every(
+              (series) =>
+                series.length === candidateDates.length &&
+                series.every((point, index) => point.sessionDate === candidateDates[index]),
+            ) &&
             evaluation.markedEquityReconciliation.runId === runId &&
             canonicalHashV1(evaluation.markedEquityReconciliation) === canonicalHashV1(markedEquity) &&
             canonicalHashV1(evaluation.strategy) === artifacts.get('strategy')!.contentHash &&
@@ -966,10 +1272,11 @@ const makeEvidenceStore = Effect.gen(function* () {
             finalPoint.evaluatorEquityMicros === markedEquity.evaluatorEndingEquityMicros &&
             finalPoint.reconstructedEquityMicros === markedEquity.reconstructedEndingEquityMicros &&
             finalPoint.differenceMicros === markedEquity.differenceMicros &&
+            canonicalHashV1(artifactManifest) === canonicalHashV1(expectedArtifactManifest) &&
             canonicalHashV1(stored.statuses[1]?.detail) ===
               canonicalHashV1({ reconciliationExact: true, verdict: evaluation.verdict.status }),
           'recover-evidence',
-          'stored v2 evidence components diverge',
+          'stored v3 evidence components diverge',
         )
 
         return Option.some({
@@ -1188,6 +1495,7 @@ const makeEvidenceStore = Effect.gen(function* () {
     check: runDatabase('health', health(undefined).pipe(Effect.asVoid)),
     persist,
     read,
+    readArtifactItems,
     recover,
   } satisfies EvidenceStoreService
 })
@@ -1245,6 +1553,7 @@ export const EvidenceStoreRuntimeLive = (config: RuntimeConfig) =>
         check: Effect.fail(error),
         persist: () => Effect.fail(error),
         read: () => Effect.fail(error),
+        readArtifactItems: () => Effect.fail(error),
         recover: () => Effect.fail(error),
       }),
     ),

--- a/services/bayn/src/db/migrations.ts
+++ b/services/bayn/src/db/migrations.ts
@@ -2,8 +2,10 @@ import { PgMigrator } from '@effect/sql-pg'
 
 import evaluationEvidence from '../../migrations/0001_evaluation_evidence'
 import qualificationLock from '../../migrations/0002_qualification_lock'
+import evidenceImmutability from '../../migrations/0003_evidence_immutability'
 
 export const migrationLoader = PgMigrator.fromRecord({
   '1_evaluation_evidence': evaluationEvidence,
   '2_qualification_lock': qualificationLock,
+  '3_evidence_immutability': evidenceImmutability,
 })

--- a/services/bayn/src/evidence-contracts.ts
+++ b/services/bayn/src/evidence-contracts.ts
@@ -8,7 +8,9 @@ const StrictParseOptions = { onExcessProperty: 'error' } as const
 const Micros = Schema.String.check(Schema.isPattern(/^\d+$/))
 const SignedMicros = Schema.String.check(Schema.isPattern(/^-?\d+$/))
 const SourceRevision = Schema.String.check(Schema.isPattern(/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/))
+const ImageDigest = Schema.String.check(Schema.isPattern(/^sha256:[0-9a-f]{64}$/))
 const PositiveInteger = Schema.Int.check(Schema.isGreaterThan(0))
+const NonNegativeInteger = Schema.Int.check(Schema.isGreaterThanOrEqualTo(0))
 const Scalar = Schema.Union([Schema.Finite, Schema.Boolean, Schema.String])
 const Symbol = Schema.String.check(Schema.isPattern(/^[A-Z][A-Z0-9.-]{0,15}$/))
 
@@ -110,9 +112,9 @@ export const MarkedEquityReconciliationSchema = Schema.Struct({
 })
 
 export const EvaluationSummarySchema = Schema.Struct({
-  schemaVersion: Schema.Literal('bayn.evaluation-summary.v1'),
+  schemaVersion: Schema.Literal('bayn.evaluation-summary.v2'),
   runId: Sha256Schema,
-  evaluationSchemaVersion: Schema.Literal('bayn.evaluation.v2'),
+  evaluationSchemaVersion: Schema.Literal('bayn.evaluation.v3'),
   codeRevision: SourceRevision,
   protocolHash: Sha256Schema,
   initialCapitalMicros: Micros,
@@ -131,9 +133,15 @@ export const EvaluationSummarySchema = Schema.Struct({
   doubleCostStrategy: PerformanceMetricsSchema,
   verdict: VerdictSchema,
   eventCount: PositiveInteger,
+  signalDecisionCount: PositiveInteger,
   orderCount: PositiveInteger,
   cashChangeCount: PositiveInteger,
   dailyMarkCount: PositiveInteger,
+  benchmarkSeriesCounts: Schema.Struct({
+    buyAndHold: PositiveInteger,
+    directVolTiming: PositiveInteger,
+    doubleCostStrategy: PositiveInteger,
+  }),
   markedEquityReconciliation: MarkedEquityReconciliationSchema,
 })
 
@@ -198,11 +206,25 @@ export const CashChangesArtifactSchema = Schema.Struct({
   ).check(Schema.isMinLength(1)),
 })
 
+const DailyPerformanceFields = {
+  sessionDate: IsoDateSchema,
+  equityMicros: Micros,
+  netReturn: Schema.Finite,
+  turnoverMicros: Micros,
+  cumulativeTurnoverMicros: Micros,
+  feeMicros: Micros,
+  cumulativeFeesMicros: Micros,
+  peakEquityMicros: Micros,
+  drawdown: Schema.Finite,
+} as const
+
+const DailyPerformancePointSchema = Schema.Struct(DailyPerformanceFields)
+
 export const DailyPositionMarksArtifactSchema = Schema.Struct({
-  schemaVersion: Schema.Literal('bayn.daily-position-marks.v1'),
+  schemaVersion: Schema.Literal('bayn.daily-position-marks.v2'),
   items: Schema.Array(
     Schema.Struct({
-      sessionDate: IsoDateSchema,
+      ...DailyPerformanceFields,
       cashMicros: Micros,
       positions: Schema.Array(
         Schema.Struct({
@@ -213,9 +235,74 @@ export const DailyPositionMarksArtifactSchema = Schema.Struct({
           marketValueMicros: Micros,
         }),
       ).check(Schema.isMinLength(1)),
-      equityMicros: Micros,
     }),
   ).check(Schema.isMinLength(1)),
+})
+
+export const TsmomSignalDecisionsArtifactSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.tsmom-signal-decisions.v1'),
+  items: Schema.Array(
+    Schema.Struct({
+      schemaVersion: Schema.Literal('bayn.tsmom-decision-plan.v1'),
+      decisionId: Sha256Schema,
+      signalDate: IsoDateSchema,
+      executionDate: IsoDateSchema,
+      targetWeights: Schema.Record(Symbol, Schema.Finite),
+      signals: Schema.Array(
+        Schema.Struct({
+          symbol: Symbol,
+          lookbacks: Schema.Array(
+            Schema.Struct({
+              lookbackSessions: PositiveInteger,
+              return: Schema.Finite,
+              direction: Schema.Literals(['positive', 'non-positive']),
+            }),
+          ).check(Schema.isMinLength(1)),
+          score: Schema.Int,
+          active: Schema.Boolean,
+          targetWeight: Schema.Finite,
+        }),
+      ).check(Schema.isMinLength(1)),
+    }),
+  ).check(Schema.isMinLength(1)),
+})
+
+export const DailyPerformanceSeriesArtifactSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.daily-performance-series.v1'),
+  series: Schema.Literals(['buy-and-hold', 'direct-volatility-timing', 'double-cost-strategy']),
+  items: Schema.Array(DailyPerformancePointSchema).check(Schema.isMinLength(1)),
+})
+
+export const QualificationArtifactManifestSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.qualification-artifact-manifest.v1'),
+  identity: Schema.Struct({
+    runId: Sha256Schema,
+    evaluationSchemaVersion: Schema.Literal('bayn.evaluation.v3'),
+    protocolHash: Sha256Schema,
+    sourceRevision: SourceRevision,
+    image: Schema.Struct({ repository: Schema.String, digest: ImageDigest }),
+    snapshotId: Sha256Schema,
+    publicationId: Sha256Schema,
+    inputManifestHash: Sha256Schema,
+    bounds: EvaluationBoundsSchema,
+    calendarVersion: Schema.String,
+  }),
+  execution: Schema.Struct({
+    parameterSchemaVersion: Schema.String,
+    parameterHash: Sha256Schema,
+    simulationSchemaVersion: Schema.Literal('bayn.simulation-trace.v2'),
+    transactionCostBpsMicros: Micros,
+  }),
+  artifacts: Schema.Array(
+    Schema.Struct({
+      name: Schema.String,
+      schemaVersion: Schema.String,
+      itemCount: NonNegativeInteger,
+      contentHash: Sha256Schema,
+    }),
+  ).check(Schema.isMinLength(1)),
+  events: Schema.Struct({ count: PositiveInteger, contentHash: Sha256Schema }),
+  gates: Schema.Struct({ count: PositiveInteger, contentHash: Sha256Schema }),
 })
 
 export const EquitySeriesArtifactSchema = Schema.Struct({
@@ -246,6 +333,18 @@ export const decodeSimulatedOrdersArtifact = Schema.decodeUnknownEffect(
 export const decodeCashChangesArtifact = Schema.decodeUnknownEffect(CashChangesArtifactSchema, StrictParseOptions)
 export const decodeDailyPositionMarksArtifact = Schema.decodeUnknownEffect(
   DailyPositionMarksArtifactSchema,
+  StrictParseOptions,
+)
+export const decodeTsmomSignalDecisionsArtifact = Schema.decodeUnknownEffect(
+  TsmomSignalDecisionsArtifactSchema,
+  StrictParseOptions,
+)
+export const decodeDailyPerformanceSeriesArtifact = Schema.decodeUnknownEffect(
+  DailyPerformanceSeriesArtifactSchema,
+  StrictParseOptions,
+)
+export const decodeQualificationArtifactManifest = Schema.decodeUnknownEffect(
+  QualificationArtifactManifestSchema,
   StrictParseOptions,
 )
 

--- a/services/bayn/src/resources.test.ts
+++ b/services/bayn/src/resources.test.ts
@@ -65,12 +65,13 @@ const marketDataService = (load: MarketDataService['load']): MarketDataService =
 const successfulEvidenceStore: EvidenceStoreService = {
   check: Effect.void,
   read: () => Effect.succeed(Option.none()),
+  readArtifactItems: () => Effect.succeed(Option.none()),
   recover: () => Effect.succeed(Option.none()),
   persist: ({ evaluation }) =>
     Effect.succeed({
       runId: evaluation.runId,
       deduplicated: false,
-      artifactCount: 12,
+      artifactCount: 17,
       eventCount: evaluation.events.length,
       gateCount: evaluation.verdict.gates.length,
     }),

--- a/services/bayn/src/simulation-reconciliation.ts
+++ b/services/bayn/src/simulation-reconciliation.ts
@@ -152,7 +152,7 @@ export const reconcileMarkedEquity = (input: {
   const tolerance = input.toleranceMicros ?? MARKED_EQUITY_TOLERANCE_MICROS
   ensure(tolerance >= 0n, 'marked-equity tolerance must not be negative')
   ensure(/^[0-9a-f]{64}$/.test(input.runId), 'marked-equity run ID is invalid')
-  ensure(input.simulation.schemaVersion === 'bayn.simulation-trace.v1', 'simulation trace version is unsupported')
+  ensure(input.simulation.schemaVersion === 'bayn.simulation-trace.v2', 'simulation trace version is unsupported')
   const transactionCostBpsMicros = unsigned(input.simulation.transactionCostBpsMicros, 'transaction cost basis points')
   ensure(transactionCostBpsMicros <= BASIS_POINTS * MICROS, 'transaction cost basis points exceed 100%')
 

--- a/services/bayn/src/strategy.test.ts
+++ b/services/bayn/src/strategy.test.ts
@@ -1,12 +1,28 @@
 import { describe, expect, test } from 'bun:test'
 
 import { makeStrategyProtocolHash } from './contracts'
-import { calculatePerformanceMetrics, evaluateTsmom } from './strategy'
+import { calculatePerformanceMetrics, evaluateTsmom, makeTsmomDecision } from './strategy'
 import { canonicalHashV1 } from './hash'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
 import type { FillEvent } from './types'
 
 describe('TSMOM economic evaluator', () => {
+  test('uses one pure content-addressed decision function', () => {
+    const protocol = { ...fixtureProtocol, lookbacks: [1, 2] }
+    const closes = Object.fromEntries(
+      protocol.universe.map((symbol, index) => [
+        symbol,
+        index === 0 ? [100, 90, 110] : index === 1 ? [100, 120, 110] : [120, 110, 100],
+      ]),
+    )
+    const decision = makeTsmomDecision('2026-07-17', closes, protocol)
+
+    expect(decision.signals[0]).toMatchObject({ symbol: 'DBC', score: 2, active: true, targetWeight: 1 })
+    expect(decision.signals[1]).toMatchObject({ symbol: 'EEM', score: 0, active: false, targetWeight: 0 })
+    expect(Object.values(decision.targetWeights).reduce((sum, weight) => sum + weight, 0)).toBe(1)
+    expect(canonicalHashV1(decision)).toBe('3f2a2f3484e66ee13e96fed0b88d9b03b4f1de3084a93a841bfa1a160db587b7')
+  })
+
   test('includes the initial trading session in return statistics', () => {
     const result = calculatePerformanceMetrics([90, 99], 0, 0, 100)
     expect(result.totalReturn).toBeCloseTo(-0.01)
@@ -20,6 +36,9 @@ describe('TSMOM economic evaluator', () => {
     const first = evaluateTsmom(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance)
     const second = evaluateTsmom(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance)
     expect(first).toEqual(second)
+    expect(canonicalHashV1(first.signalDecisions)).toBe(canonicalHashV1(second.signalDecisions))
+    expect(canonicalHashV1(first.simulation.dailyMarks)).toBe(canonicalHashV1(second.simulation.dailyMarks))
+    expect(canonicalHashV1(first.benchmarkSeries)).toBe(canonicalHashV1(second.benchmarkSeries))
     expect(first.codeRevision).toBe(provenance.sourceRevision)
     expect(first.protocolHash).toBe(makeStrategyProtocolHash(provenance.strategy))
     expect(first.strategy.observations).toBeGreaterThanOrEqual(fixtureProtocol.thresholds.minimumObservations)
@@ -34,6 +53,11 @@ describe('TSMOM economic evaluator', () => {
       )
       expect(fills.length).toBeGreaterThan(0)
       expect(fills.every((fill) => fill.sessionDate === firstDecision.executionDate)).toBe(true)
+      expect(first.signalDecisions.find((decision) => decision.decisionId === firstDecision.id)).toMatchObject({
+        signalDate: firstDecision.signalDate,
+        executionDate: firstDecision.executionDate,
+        targetWeights: firstDecision.targetWeights,
+      })
     }
   })
 
@@ -113,7 +137,7 @@ describe('TSMOM economic evaluator', () => {
     )
   })
 
-  test('retains bounded complete evidence for a production-sized history', () => {
+  test('retains complete aligned daily and rebalance evidence for a production-sized history', () => {
     const snapshot = makeSnapshot(2_400)
     const evaluation = evaluateTsmom(snapshot.bars, snapshot.manifest, fixtureProtocol, makeTestProvenance())
     const serializedEvidence = JSON.stringify({
@@ -124,6 +148,23 @@ describe('TSMOM economic evaluator', () => {
 
     expect(evaluation.simulation.dailyMarks).toHaveLength(evaluation.strategy.observations)
     expect(evaluation.equitySeries).toHaveLength(evaluation.strategy.observations)
+    expect(evaluation.signalDecisions).toHaveLength(
+      evaluation.events.filter((event) => event.kind === 'decision').length,
+    )
+    for (const series of Object.values(evaluation.benchmarkSeries)) {
+      expect(series.map((point) => point.sessionDate)).toEqual(
+        evaluation.simulation.dailyMarks.map((point) => point.sessionDate),
+      )
+    }
+    expect(
+      evaluation.simulation.dailyMarks.every(
+        (point) =>
+          Number.isFinite(point.netReturn) &&
+          Number.isFinite(point.drawdown) &&
+          BigInt(point.cumulativeTurnoverMicros) >= BigInt(point.turnoverMicros) &&
+          BigInt(point.cumulativeFeesMicros) >= BigInt(point.feeMicros),
+      ),
+    ).toBe(true)
     expect(Buffer.byteLength(serializedEvidence)).toBeLessThan(10 * 1024 * 1024)
   })
 })

--- a/services/bayn/src/strategy.ts
+++ b/services/bayn/src/strategy.ts
@@ -5,6 +5,7 @@ import { reconcileMarkedEquity } from './simulation-reconciliation'
 import type {
   CashChange,
   DailyBar,
+  DailyPerformancePoint,
   DailyPositionMark,
   DecisionEvent,
   EconomicVerdict,
@@ -18,7 +19,9 @@ import type {
   PerformanceMetrics,
   SimulatedOrder,
   SimulationTrace,
+  TsmomDecisionPlan,
   TsmomProtocol,
+  TsmomSignalDecision,
 } from './types'
 
 interface AlignedSession {
@@ -35,11 +38,14 @@ interface Target {
   readonly signalIndex: number
   readonly executionIndex: number
   readonly weights: Readonly<Record<string, number>>
+  readonly decision?: TsmomDecisionPlan
 }
 
 interface SimulationResult {
   readonly metrics: PerformanceMetrics
   readonly events: readonly EvaluationEvent[]
+  readonly signalDecisions: readonly TsmomSignalDecision[]
+  readonly dailyPerformance: readonly DailyPerformancePoint[]
   readonly simulation: SimulationTrace | null
 }
 
@@ -102,23 +108,45 @@ const isMonthEnd = (sessions: readonly AlignedSession[], index: number): boolean
   return nextMonth !== undefined && currentMonth !== nextMonth
 }
 
-const tsmomWeights = (
-  sessions: readonly AlignedSession[],
-  signalIndex: number,
+export const makeTsmomDecision = (
+  signalDate: IsoDate,
+  closes: Readonly<Record<string, readonly number[]>>,
   protocol: TsmomProtocol,
-): Readonly<Record<string, number>> => {
-  const active = protocol.universe.filter((symbol) => {
-    const current = sessions[signalIndex].bars[symbol].close
-    const signedMomentum = protocol.lookbacks.reduce((score, lookback) => {
-      const prior = sessions[signalIndex - lookback].bars[symbol].close
-      return score + (current / prior - 1 > 0 ? 1 : -1)
-    }, 0)
-    return signedMomentum > 0
+): TsmomDecisionPlan => {
+  const maximumLookback = Math.max(...protocol.lookbacks)
+  const rawSignals = protocol.universe.map((symbol) => {
+    const history = closes[symbol]
+    if (history === undefined || history.length !== maximumLookback + 1) {
+      throw new Error(`TSMOM decision requires ${maximumLookback + 1} ordered closes for ${symbol}`)
+    }
+    if (history.some((price) => !Number.isFinite(price) || price <= 0)) {
+      throw new Error(`TSMOM decision contains an invalid close for ${symbol}`)
+    }
+    const current = history.at(-1)!
+    const lookbacks = protocol.lookbacks.map((lookbackSessions) => {
+      const prior = history[maximumLookback - lookbackSessions]
+      const value = current / prior - 1
+      return {
+        lookbackSessions,
+        return: value,
+        direction: value > 0 ? ('positive' as const) : ('non-positive' as const),
+      }
+    })
+    const score = lookbacks.reduce((total, signal) => total + (signal.direction === 'positive' ? 1 : -1), 0)
+    return { symbol, lookbacks, score, active: score > 0 }
   })
-  const weight = active.length === 0 ? 0 : 1 / active.length
-  return Object.fromEntries(
-    protocol.universe.map((symbol) => [symbol, active.includes(symbol) ? roundWeight(weight) : 0]),
-  )
+  const activeCount = rawSignals.filter((signal) => signal.active).length
+  const activeWeight = activeCount === 0 ? 0 : roundWeight(1 / activeCount)
+  const signals = rawSignals.map((signal) => ({
+    ...signal,
+    targetWeight: signal.active ? activeWeight : 0,
+  }))
+  return {
+    schemaVersion: 'bayn.tsmom-decision-plan.v1',
+    signalDate,
+    targetWeights: Object.fromEntries(signals.map((signal) => [signal.symbol, signal.targetWeight])),
+    signals,
+  }
 }
 
 const directVolatilityWeights = (
@@ -250,15 +278,21 @@ const simulate = (
   let totalFees = 0
   const equity: number[] = []
   const events: EvaluationEvent[] = []
+  const signalDecisions: TsmomSignalDecision[] = []
   const orders: SimulatedOrder[] = []
   const cashChanges: CashChange[] = []
   const dailyMarks: DailyPositionMark[] = []
+  const dailyPerformance: DailyPerformancePoint[] = []
   let reconstructedCashMicros = BigInt(toMicros(initialCapital))
   const feeRate = costBps / 10_000
+  let previousEquity = initialCapital
+  let peakEquity = initialCapital
 
   for (let index = startIndex; index < sessions.length; index += 1) {
     const session = sessions[index]
     const target = targetsByExecution.get(index)
+    const turnoverBeforeSession = turnover
+    const feesBeforeSession = totalFees
     if (target) {
       const decisionPayload = {
         signalDate: sessions[target.signalIndex].date,
@@ -270,7 +304,17 @@ const simulate = (
         id: hashObject({ runId, kind: 'decision', ...decisionPayload }),
         ...decisionPayload,
       }
-      if (recordEvents) events.push(decision)
+      if (recordEvents) {
+        if (target.decision === undefined) throw new Error('candidate target is missing its TSMOM signal decision')
+        if (
+          target.decision.signalDate !== decision.signalDate ||
+          canonicalHashV1(target.decision.targetWeights) !== canonicalHashV1(decision.targetWeights)
+        ) {
+          throw new Error('TSMOM signal decision diverges from its execution target')
+        }
+        events.push(decision)
+        signalDecisions.push({ ...target.decision, decisionId: decision.id, executionDate: decision.executionDate })
+      }
 
       const preTradeEquity =
         cash +
@@ -351,9 +395,23 @@ const simulate = (
         0,
       )
     equity.push(closingEquity)
+    const netReturn = closingEquity / previousEquity - 1
+    peakEquity = Math.max(peakEquity, closingEquity)
+    const performance = {
+      sessionDate: session.date,
+      equityMicros: toMicros(closingEquity),
+      netReturn,
+      turnoverMicros: toMicros(Math.max(0, turnover - turnoverBeforeSession)),
+      cumulativeTurnoverMicros: toMicros(turnover),
+      feeMicros: toMicros(Math.max(0, totalFees - feesBeforeSession)),
+      cumulativeFeesMicros: toMicros(totalFees),
+      peakEquityMicros: toMicros(peakEquity),
+      drawdown: 1 - closingEquity / peakEquity,
+    } satisfies DailyPerformancePoint
+    dailyPerformance.push(performance)
     if (recordEvents) {
       dailyMarks.push({
-        sessionDate: session.date,
+        ...performance,
         cashMicros: toMicros(Math.max(0, cash)),
         positions: Object.entries(session.bars)
           .sort(([left], [right]) => left.localeCompare(right))
@@ -367,17 +425,19 @@ const simulate = (
               marketValueMicros: toMicros(position.quantity * bar.close),
             }
           }),
-        equityMicros: toMicros(closingEquity),
       })
     }
+    previousEquity = closingEquity
   }
 
   return {
     metrics: calculatePerformanceMetrics(equity, turnover, totalFees, initialCapital),
     events,
+    signalDecisions,
+    dailyPerformance,
     simulation: recordEvents
       ? {
-          schemaVersion: 'bayn.simulation-trace.v1',
+          schemaVersion: 'bayn.simulation-trace.v2',
           transactionCostBpsMicros: toMicros(costBps),
           orders,
           cashChanges,
@@ -515,11 +575,21 @@ export const evaluateTsmom = (
     )
   }
 
-  const strategyTargets: Target[] = signalIndices.map((signalIndex) => ({
-    signalIndex,
-    executionIndex: signalIndex + 1,
-    weights: tsmomWeights(sessions, signalIndex, protocol),
-  }))
+  const strategyTargets: Target[] = signalIndices.map((signalIndex) => {
+    const closes = Object.fromEntries(
+      protocol.universe.map((symbol) => [
+        symbol,
+        sessions.slice(signalIndex - maximumLookback, signalIndex + 1).map((session) => session.bars[symbol].close),
+      ]),
+    )
+    const decision = makeTsmomDecision(sessions[signalIndex].date, closes, protocol)
+    return {
+      signalIndex,
+      executionIndex: signalIndex + 1,
+      weights: decision.targetWeights,
+      decision,
+    }
+  })
   const equalWeight = roundWeight(1 / protocol.universe.length)
   const buyAndHoldTargets: Target[] = [
     {
@@ -582,7 +652,7 @@ export const evaluateTsmom = (
   })
 
   return {
-    schemaVersion: 'bayn.evaluation.v2',
+    schemaVersion: 'bayn.evaluation.v3',
     runId,
     codeRevision: provenance.sourceRevision,
     protocolHash,
@@ -594,14 +664,20 @@ export const evaluateTsmom = (
     doubleCostStrategy: doubleCost.metrics,
     verdict: buildVerdict(strategy.metrics, buyAndHold.metrics, directVolTiming.metrics, doubleCost.metrics, protocol),
     events: strategy.events,
+    signalDecisions: strategy.signalDecisions,
     simulation: strategy.simulation,
+    benchmarkSeries: {
+      buyAndHold: buyAndHold.dailyPerformance,
+      directVolTiming: directVolTiming.dailyPerformance,
+      doubleCostStrategy: doubleCost.dailyPerformance,
+    },
     equitySeries: markedEquity.equitySeries,
     markedEquityReconciliation: markedEquity.reconciliation,
   }
 }
 
 export const summarizeEvaluation = (evaluation: EvaluationResult): EvaluationSummary => ({
-  schemaVersion: 'bayn.evaluation-summary.v1',
+  schemaVersion: 'bayn.evaluation-summary.v2',
   runId: evaluation.runId,
   evaluationSchemaVersion: evaluation.schemaVersion,
   codeRevision: evaluation.codeRevision,
@@ -622,8 +698,14 @@ export const summarizeEvaluation = (evaluation: EvaluationResult): EvaluationSum
   doubleCostStrategy: evaluation.doubleCostStrategy,
   verdict: evaluation.verdict,
   eventCount: evaluation.events.length,
+  signalDecisionCount: evaluation.signalDecisions.length,
   orderCount: evaluation.simulation.orders.length,
   cashChangeCount: evaluation.simulation.cashChanges.length,
   dailyMarkCount: evaluation.simulation.dailyMarks.length,
+  benchmarkSeriesCounts: {
+    buyAndHold: evaluation.benchmarkSeries.buyAndHold.length,
+    directVolTiming: evaluation.benchmarkSeries.directVolTiming.length,
+    doubleCostStrategy: evaluation.benchmarkSeries.doubleCostStrategy.length,
+  },
   markedEquityReconciliation: evaluation.markedEquityReconciliation,
 })

--- a/services/bayn/src/types.ts
+++ b/services/bayn/src/types.ts
@@ -63,6 +63,32 @@ export interface TsmomProtocol {
   readonly thresholds: EconomicThresholds
 }
 
+export interface TsmomLookbackSignal {
+  readonly lookbackSessions: number
+  readonly return: number
+  readonly direction: 'positive' | 'non-positive'
+}
+
+export interface TsmomSymbolSignal {
+  readonly symbol: string
+  readonly lookbacks: readonly TsmomLookbackSignal[]
+  readonly score: number
+  readonly active: boolean
+  readonly targetWeight: number
+}
+
+export interface TsmomDecisionPlan {
+  readonly schemaVersion: 'bayn.tsmom-decision-plan.v1'
+  readonly signalDate: IsoDate
+  readonly targetWeights: Readonly<Record<string, number>>
+  readonly signals: readonly TsmomSymbolSignal[]
+}
+
+export interface TsmomSignalDecision extends TsmomDecisionPlan {
+  readonly decisionId: string
+  readonly executionDate: IsoDate
+}
+
 export interface DecisionEvent {
   readonly kind: 'decision'
   readonly id: string
@@ -119,10 +145,29 @@ export interface DailyPositionMark {
   readonly cashMicros: string
   readonly positions: readonly PositionMark[]
   readonly equityMicros: string
+  readonly netReturn: number
+  readonly turnoverMicros: string
+  readonly cumulativeTurnoverMicros: string
+  readonly feeMicros: string
+  readonly cumulativeFeesMicros: string
+  readonly peakEquityMicros: string
+  readonly drawdown: number
+}
+
+export interface DailyPerformancePoint {
+  readonly sessionDate: IsoDate
+  readonly equityMicros: string
+  readonly netReturn: number
+  readonly turnoverMicros: string
+  readonly cumulativeTurnoverMicros: string
+  readonly feeMicros: string
+  readonly cumulativeFeesMicros: string
+  readonly peakEquityMicros: string
+  readonly drawdown: number
 }
 
 export interface SimulationTrace {
-  readonly schemaVersion: 'bayn.simulation-trace.v1'
+  readonly schemaVersion: 'bayn.simulation-trace.v2'
   readonly transactionCostBpsMicros: string
   readonly orders: readonly SimulatedOrder[]
   readonly cashChanges: readonly CashChange[]
@@ -178,7 +223,7 @@ export interface EconomicVerdict {
 }
 
 export interface EvaluationResult {
-  readonly schemaVersion: 'bayn.evaluation.v2'
+  readonly schemaVersion: 'bayn.evaluation.v3'
   readonly runId: string
   readonly codeRevision: string
   readonly protocolHash: string
@@ -190,15 +235,21 @@ export interface EvaluationResult {
   readonly doubleCostStrategy: PerformanceMetrics
   readonly verdict: EconomicVerdict
   readonly events: readonly EvaluationEvent[]
+  readonly signalDecisions: readonly TsmomSignalDecision[]
   readonly simulation: SimulationTrace
+  readonly benchmarkSeries: {
+    readonly buyAndHold: readonly DailyPerformancePoint[]
+    readonly directVolTiming: readonly DailyPerformancePoint[]
+    readonly doubleCostStrategy: readonly DailyPerformancePoint[]
+  }
   readonly equitySeries: readonly EquityPoint[]
   readonly markedEquityReconciliation: MarkedEquityReconciliation
 }
 
 export interface EvaluationSummary {
-  readonly schemaVersion: 'bayn.evaluation-summary.v1'
+  readonly schemaVersion: 'bayn.evaluation-summary.v2'
   readonly runId: string
-  readonly evaluationSchemaVersion: 'bayn.evaluation.v2'
+  readonly evaluationSchemaVersion: 'bayn.evaluation.v3'
   readonly codeRevision: string
   readonly protocolHash: string
   readonly initialCapitalMicros: string
@@ -217,9 +268,15 @@ export interface EvaluationSummary {
   readonly doubleCostStrategy: PerformanceMetrics
   readonly verdict: EconomicVerdict
   readonly eventCount: number
+  readonly signalDecisionCount: number
   readonly orderCount: number
   readonly cashChangeCount: number
   readonly dailyMarkCount: number
+  readonly benchmarkSeriesCounts: {
+    readonly buyAndHold: number
+    readonly directVolTiming: number
+    readonly doubleCostStrategy: number
+  }
   readonly markedEquityReconciliation: MarkedEquityReconciliation
 }
 


### PR DESCRIPTION
## Summary

- emit deterministic raw TSMOM decisions plus aligned candidate and benchmark daily performance series
- persist a content-addressed 17-artifact qualification dossier with bounded contiguous item reads
- make the completed PostgreSQL evidence graph append-only while preserving the one WRITING-to-COMPLETE transition
- version the runtime provenance, evaluation, simulation trace, summary, and daily-mark contracts for the new evidence shape

## Related Issues

PROOMPT-364

## Testing

- BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:55432/bayn_test bun run --filter @proompteng/bayn test (78 passed)
- bun run --filter @proompteng/bayn tsc
- bunx oxfmt --check services/bayn
- bun run --filter @proompteng/bayn lint:oxlint
- bun run --filter @proompteng/bayn lint:oxlint:type
- bun run --filter @proompteng/bayn build
- upgrade rehearsal: migrations 1 and 2 retained a complete 12-artifact v2 run; migration 3 then wrote and recovered a separate complete 17-artifact v3 run with zero qualification locks/results
- identical fixture comparison against the prior evaluator preserved aggregate economics and execution-event hashes

## Breaking Changes

Runtime evidence contracts advance to evaluation v3, simulation trace v2, evaluation summary v2, daily position marks v2, and runtime provenance v2. Existing v2 database rows remain intact; new matching-run recovery requires the exact v3 artifact contract. Migration 3 makes evidence rows append-only.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] README and the PROOMPT-364 implementation plan are updated.