### PR TITLE
chore(bayn): promote image sha-11c9def250ec074ca8cdd020838054efe93af8b2

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: bayn
         app.kubernetes.io/part-of: bayn
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-21T00:07:35Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-21T00:47:09Z"
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
@@ -47,11 +47,11 @@ spec:
               protocol: TCP
           env:
             - name: BAYN_CODE_REVISION
-              value: 10605761cc9da2f5e466a90154730b6d17f7aefe
+              value: 11c9def250ec074ca8cdd020838054efe93af8b2
             - name: BAYN_IMAGE_REPOSITORY
               value: registry.ide-newton.ts.net/lab/bayn
             - name: BAYN_IMAGE_DIGEST
-              value: sha256:ab472293b1c6827be24f556778789d04aaf58d5ecec6afa357cb8c2cc2dc4f5d
+              value: sha256:a63e6d246938101f390918df6a39b390ec516b09cfc395099c9314438331c8cf
             - name: BAYN_HEALTH_INTERVAL_MS
               value: "30000"
             - name: BAYN_OPERATION_TIMEOUT_MS

--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -18,5 +18,5 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/bayn
     newName: registry.ide-newton.ts.net/lab/bayn
-    newTag: "sha-10605761cc9da2f5e466a90154730b6d17f7aefe"
-    digest: sha256:ab472293b1c6827be24f556778789d04aaf58d5ecec6afa357cb8c2cc2dc4f5d
+    newTag: "sha-11c9def250ec074ca8cdd020838054efe93af8b2"
+    digest: sha256:a63e6d246938101f390918df6a39b390ec516b09cfc395099c9314438331c8cf


### PR DESCRIPTION
## Summary

Promote the immutable Bayn image, activate the Bayn Argo application, and bind runtime evidence to its
source commit.

- Source commit: `11c9def250ec074ca8cdd020838054efe93af8b2`
- Image tag: `sha-11c9def250ec074ca8cdd020838054efe93af8b2`
- Image digest: `sha256:a63e6d246938101f390918df6a39b390ec516b09cfc395099c9314438331c8cf`

## Related Issues

PROOMPT-353

## Testing

- OCI index contains `linux/amd64` and `linux/arm64`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents exact validation.
- [x] Runtime source revision and image digest are immutable.
- [x] No broker or capital-promotion authority is introduced.