### PR TITLE
chore(bayn): promote image sha-33ff3a688fdc01e8e3e63c9eb80ee9f91bdd64cb

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: bayn
         app.kubernetes.io/part-of: bayn
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-21T01:44:20Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-21T02:25:18Z"
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
@@ -47,11 +47,11 @@ spec:
               protocol: TCP
           env:
             - name: BAYN_CODE_REVISION
-              value: 0fc400af4fff32109d4009e74e5700b47df64992
+              value: 33ff3a688fdc01e8e3e63c9eb80ee9f91bdd64cb
             - name: BAYN_IMAGE_REPOSITORY
               value: registry.ide-newton.ts.net/lab/bayn
             - name: BAYN_IMAGE_DIGEST
-              value: sha256:07562aa643834b3b2a4458b69234c5b3093fc8bb97de574af9c40e6b4de64b54
+              value: sha256:d7cd6f52f8f06d314d84f899e62daa81a11c224f78797178e71ab534c8d1fbaa
             - name: BAYN_HEALTH_INTERVAL_MS
               value: "30000"
             - name: BAYN_OPERATION_TIMEOUT_MS

--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -18,5 +18,5 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/bayn
     newName: registry.ide-newton.ts.net/lab/bayn
-    newTag: "sha-0fc400af4fff32109d4009e74e5700b47df64992"
-    digest: sha256:07562aa643834b3b2a4458b69234c5b3093fc8bb97de574af9c40e6b4de64b54
+    newTag: "sha-33ff3a688fdc01e8e3e63c9eb80ee9f91bdd64cb"
+    digest: sha256:d7cd6f52f8f06d314d84f899e62daa81a11c224f78797178e71ab534c8d1fbaa


### PR DESCRIPTION
## Summary

Promote the immutable Bayn image, activate the Bayn Argo application, and bind runtime evidence to its
source commit.

- Source commit: `33ff3a688fdc01e8e3e63c9eb80ee9f91bdd64cb`
- Image tag: `sha-33ff3a688fdc01e8e3e63c9eb80ee9f91bdd64cb`
- Image digest: `sha256:d7cd6f52f8f06d314d84f899e62daa81a11c224f78797178e71ab534c8d1fbaa`

## Related Issues

PROOMPT-353

## Testing

- OCI index contains `linux/amd64` and `linux/arm64`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents exact validation.
- [x] Runtime source revision and image digest are immutable.
- [x] No broker or capital-promotion authority is introduced.