### PR TITLE
feat(bayn): lock qualification before evaluation

### DIFF
--- a/services/bayn/AGENTS.md
+++ b/services/bayn/AGENTS.md
@@ -57,6 +57,8 @@
 
 - Market-data snapshots must prove dataset version, universe, uniqueness, ordering, and content identity before
   evaluation. Missing, stale, malformed, or mixed-contract data fails closed.
+- Inspect finalized manifest and calendar before candidate bars, then acquire the immutable qualification lock. Commit
+  the evaluation graph and terminal result together; never retry or bypass an opened-incomplete lock.
 - TigerBeetle writes remain deterministic and idempotent. Existing IDs must be verified against the complete expected
   record, and readiness requires exact account, transfer, and balance reconciliation.
 - Select one `Strategy` capability at the composition root; the strategy owns its protocol and universe. Do not add a

--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -24,9 +24,10 @@ and journals the resulting simulation to TigerBeetle. It contains no broker clie
   not OCI production builds. That mode is visible in status and cannot override an executable with embedded metadata;
   it does not change lifecycle or authority. The Nix image starts in the default production mode and fails closed if
   embedded facts are absent.
-- The reader selects one configured finalized Signal snapshot by content-addressed ID. It verifies the publisher
-  manifest, sessions, every bar, exact SIP/all provenance, the canonical universe, content hashes, and explicit data,
-  lookback, and evaluation bounds before exposing numeric bars.
+- The reader selects one configured finalized Signal snapshot by content-addressed ID. Before reading bars, it verifies
+  the publisher manifest and exact exchange calendar and derives the candidate identity and evaluation window. After
+  lock acquisition it verifies every bar, SIP/all provenance, the canonical universe, content hashes, and explicit
+  data, lookback, and evaluation bounds before exposing numeric bars.
 - The run ID binds source and image identity, compiled strategy behavior and decoded parameters, complete finalized
   snapshot provenance, calendar version, and explicit bounds.
 - One pure compiled TSMOM decision function records each lookback return, direction vote, score, active symbol, and
@@ -39,18 +40,26 @@ and journals the resulting simulation to TigerBeetle. It contains no broker clie
   artifact, event, and gate hash to the exact source, image, protocol, snapshot, calendar, and execution contract.
 - Ordered artifacts can be read internally through contiguous pages capped at 256 items. PostgreSQL triggers make the
   complete evidence graph append-only and permit an evaluation row only its exact `WRITING` to `COMPLETE` transition.
-- Every completed pre-qualification run is recorded once as a burned trial. Observed results cannot later be presented
-  as an untouched qualification window, and the trial record cannot be updated or deleted.
-- A future qualification lock must bind the exact protocol, source and image, finalized snapshot and bounds, universe
-  rationale, prior trials, and content-hashed benchmark, threshold, uncertainty, and execution policies. Lock rows are
-  append-only, and the result table permits exactly one immutable `QUALIFIED` or `REJECTED` run per lock. No active
-  lock or qualification result exists until the remaining M2 policies are complete.
+- Every completed evaluation without a qualification lock is recorded once as a burned trial. Observed results cannot
+  later be presented as untouched evidence, and the trial record cannot be updated, deleted, or truncated.
+- Before reading candidate bars, Bayn atomically opens one immutable lock for the exact candidate run and snapshot. The
+  lock binds the protocol, source and image, finalized data and bounds, universe rationale, every prior burned trial,
+  every prior terminal qualification attempt, and content-hashed benchmark, threshold, statistical, and execution
+  policies. Concurrent attempts converge on that same lock; a different lock for the candidate or snapshot fails
+  closed.
+- Qualification uses deterministic paired complete-rebalance-block bootstrap inference, Bonferroni-adjusted one-sided
+  bounds, an explicit power requirement, and expanding-origin walk-forward gates. `QUALIFIED` requires both the
+  economic evaluation and every statistical gate to pass; every other terminal outcome is `REJECTED`.
+- The complete evaluation graph and its single terminal qualification result commit in one PostgreSQL transaction.
+  Any terminal-result failure rolls the evaluation graph back and leaves the lock visibly incomplete. An incomplete
+  lock is never silently retried and blocks every new candidate; a locked candidate cannot bypass the terminal result
+  through the ordinary persistence path.
 - The execution path and independent reducer use integer micros for cash, quantity, prices, spread, slippage, fees,
   cash yield, positions, and every marked-equity point. Full, partial, and rejected orders are durable. Evaluation and
   recovery require exact zero-difference cash, fee, position, and equity reconstruction.
-- On restart, Bayn derives the expected run ID from the verified Signal manifest and current executable identity. It
-  resumes only an exact, complete, runtime-decoded PostgreSQL record; missing evidence triggers one evaluation, while
-  partial, altered, or incompatible evidence fails closed without another TigerBeetle mutation.
+- On restart, Bayn derives the expected run ID from the verified Signal manifest and current executable identity. An
+  exact terminal lock recovers the complete runtime-decoded PostgreSQL record without reading bars or mutating
+  TigerBeetle. An opened lock without a terminal result, or altered or incompatible evidence, fails closed.
 - After startup, one scoped Effect loop continuously checks PostgreSQL, the configured Signal manifest, the active
   TigerBeetle run, and the complete durable evidence record without loading bars or writing accounting state. Readiness
   closes on any defect and reopens only after every check succeeds; the last valid evidence remains observable.
@@ -62,8 +71,8 @@ and journals the resulting simulation to TigerBeetle. It contains no broker clie
 
 - `GET /livez`: process liveness.
 - `GET /readyz`: current dependency, evidence, and accounting readiness.
-- `GET /v1/status`: operational dependencies, data and evidence identity, economic verdict, accounting, build
-  provenance, and fixed observe-only authority.
+- `GET /v1/status`: operational dependencies, data and evidence identity, terminal qualification, economic verdict,
+  accounting, build provenance, and fixed observe-only authority.
 - `GET /v1/evaluations/:runId`: complete content-hashed evidence for one exact run ID. The service is ClusterIP-only
   and the Bayn network policy limits HTTP ingress to the namespace.
 

--- a/services/bayn/migrations/0005_locked_qualification.ts
+++ b/services/bayn/migrations/0005_locked_qualification.ts
@@ -1,0 +1,130 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient
+
+  yield* sql`
+    ALTER TABLE bayn_qualification_locks
+      DROP CONSTRAINT bayn_qualification_locks_schema_version_check,
+      ADD COLUMN candidate_run_id text NOT NULL UNIQUE CHECK (candidate_run_id ~ '^[0-9a-f]{64}$'),
+      ADD CONSTRAINT bayn_qualification_locks_schema_version_check
+        CHECK (schema_version = 'bayn.qualification-lock.v2'),
+      ADD CONSTRAINT bayn_qualification_locks_snapshot_id_key UNIQUE (snapshot_id),
+      ADD CONSTRAINT bayn_qualification_locks_candidate_payload_check
+        CHECK (payload ->> 'candidateRunId' = candidate_run_id)
+  `
+
+  yield* sql`
+    ALTER TABLE bayn_qualification_results
+      DROP CONSTRAINT bayn_qualification_results_schema_version_check,
+      ADD COLUMN analysis_hash text NOT NULL CHECK (analysis_hash ~ '^[0-9a-f]{64}$'),
+      ADD COLUMN result_hash text NOT NULL UNIQUE CHECK (result_hash ~ '^[0-9a-f]{64}$'),
+      ADD COLUMN payload jsonb NOT NULL CHECK (jsonb_typeof(payload) = 'object'),
+      ADD CONSTRAINT bayn_qualification_results_schema_version_check
+        CHECK (schema_version = 'bayn.qualification-result.v2'),
+      ADD CONSTRAINT bayn_qualification_results_payload_binding_check CHECK (
+        payload ->> 'schemaVersion' = schema_version
+        AND payload ->> 'lockId' = lock_id
+        AND payload ->> 'runId' = run_id
+        AND payload ->> 'verdict' = verdict
+        AND payload #>> '{analysis,analysisHash}' = analysis_hash
+        AND payload ->> 'resultHash' = result_hash
+      )
+  `
+
+  yield* sql`
+    CREATE OR REPLACE FUNCTION bayn_burn_completed_evaluation()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+    DECLARE
+      reasons text[] := ARRAY['PRE_LOCK_RESULT_OBSERVED'];
+    BEGIN
+      IF EXISTS (
+        SELECT 1 FROM bayn_qualification_locks WHERE candidate_run_id = NEW.run_id
+      ) THEN
+        RETURN NEW;
+      END IF;
+
+      IF EXISTS (
+        SELECT 1
+        FROM bayn_gate_outcomes
+        WHERE run_id = NEW.run_id
+          AND gate_name = 'benchmark_sharpe_improvement'
+          AND passed = false
+      ) THEN
+        reasons := array_append(reasons, 'FAILED_BENCHMARK_GATE');
+      END IF;
+
+      INSERT INTO bayn_qualification_trials (
+        run_id,
+        schema_version,
+        disposition,
+        reason_codes,
+        observed_at
+      ) VALUES (
+        NEW.run_id,
+        'bayn.qualification-trial.v1',
+        'BURNED',
+        reasons,
+        COALESCE(NEW.completed_at, transaction_timestamp())
+      )
+      ON CONFLICT (run_id) DO NOTHING;
+
+      RETURN NEW;
+    END
+    $function$
+  `
+
+  yield* sql`
+    CREATE TRIGGER bayn_evaluation_runs_reject_truncate
+    BEFORE TRUNCATE ON bayn_evaluation_runs
+    FOR EACH STATEMENT EXECUTE FUNCTION bayn_reject_evidence_mutation()
+  `
+  yield* sql`
+    CREATE TRIGGER bayn_protocol_locks_reject_truncate
+    BEFORE TRUNCATE ON bayn_protocol_locks
+    FOR EACH STATEMENT EXECUTE FUNCTION bayn_reject_evidence_mutation()
+  `
+  yield* sql`
+    CREATE TRIGGER bayn_snapshot_references_reject_truncate
+    BEFORE TRUNCATE ON bayn_snapshot_references
+    FOR EACH STATEMENT EXECUTE FUNCTION bayn_reject_evidence_mutation()
+  `
+  yield* sql`
+    CREATE TRIGGER bayn_evaluation_artifacts_reject_truncate
+    BEFORE TRUNCATE ON bayn_evaluation_artifacts
+    FOR EACH STATEMENT EXECUTE FUNCTION bayn_reject_evidence_mutation()
+  `
+  yield* sql`
+    CREATE TRIGGER bayn_evaluation_events_reject_truncate
+    BEFORE TRUNCATE ON bayn_evaluation_events
+    FOR EACH STATEMENT EXECUTE FUNCTION bayn_reject_evidence_mutation()
+  `
+  yield* sql`
+    CREATE TRIGGER bayn_gate_outcomes_reject_truncate
+    BEFORE TRUNCATE ON bayn_gate_outcomes
+    FOR EACH STATEMENT EXECUTE FUNCTION bayn_reject_evidence_mutation()
+  `
+  yield* sql`
+    CREATE TRIGGER bayn_status_history_reject_truncate
+    BEFORE TRUNCATE ON bayn_status_history
+    FOR EACH STATEMENT EXECUTE FUNCTION bayn_reject_evidence_mutation()
+  `
+  yield* sql`
+    CREATE TRIGGER bayn_qualification_trials_reject_truncate
+    BEFORE TRUNCATE ON bayn_qualification_trials
+    FOR EACH STATEMENT EXECUTE FUNCTION bayn_reject_qualification_mutation()
+  `
+  yield* sql`
+    CREATE TRIGGER bayn_qualification_locks_reject_truncate
+    BEFORE TRUNCATE ON bayn_qualification_locks
+    FOR EACH STATEMENT EXECUTE FUNCTION bayn_reject_qualification_mutation()
+  `
+  yield* sql`
+    CREATE TRIGGER bayn_qualification_results_reject_truncate
+    BEFORE TRUNCATE ON bayn_qualification_results
+    FOR EACH STATEMENT EXECUTE FUNCTION bayn_reject_qualification_mutation()
+  `
+})

--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -19,8 +19,9 @@ import {
 import { operationalError } from './errors'
 import { Journal, type JournalService } from './ledger'
 import { MarketData, type MarketDataService } from './market-data'
-import { evaluateTsmom, identifyTsmomRun, summarizeEvaluation } from './strategy'
-import { Strategy, TsmomStrategyLayer, type StrategyService } from './strategy-service'
+import { makeQualificationResult } from './qualification'
+import { evaluateTsmom, summarizeEvaluation } from './strategy'
+import { Strategy, TsmomStrategyLayer, makeTsmomStrategy, type StrategyService } from './strategy-service'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
 
 const provenance = makeTestProvenance()
@@ -102,8 +103,12 @@ const successfulJournal: JournalService = {
     }),
 }
 
-const marketDataService = (load: MarketDataService['load']): MarketDataService => ({
-  check: Effect.sync(() => makeSnapshot().manifest.finalizedSnapshot),
+const marketDataService = (load: MarketDataService['load'], inspectedSnapshot = makeSnapshot()): MarketDataService => ({
+  check: Effect.sync(() => inspectedSnapshot.manifest.finalizedSnapshot),
+  inspect: Effect.sync(() => ({
+    manifest: inspectedSnapshot.manifest,
+    sessionDates: [...new Set(inspectedSnapshot.bars.map((bar) => bar.sessionDate))].sort(),
+  })),
   load,
 })
 
@@ -112,6 +117,9 @@ const successfulEvidenceStore: EvidenceStoreService = {
   read: (runId) => Effect.succeed(runId === historicalRunId ? Option.some(historicalEvidence) : Option.none()),
   readArtifactItems: () => Effect.succeed(Option.none()),
   recover: () => Effect.succeed(Option.none()),
+  listPriorTrials: Effect.succeed([]),
+  openQualification: ({ lock }) => Effect.succeed({ state: 'ACQUIRED', lock }),
+  readQualification: () => Effect.succeed(Option.none()),
   persist: ({ evaluation }) =>
     Effect.succeed({
       runId: evaluation.runId,
@@ -121,6 +129,20 @@ const successfulEvidenceStore: EvidenceStoreService = {
       gateCount: evaluation.verdict.gates.length,
     }),
 }
+
+const fixtureSnapshot = makeSnapshot()
+const fixtureStrategy = makeTsmomStrategy(fixtureProtocol, provenance)
+const fixtureEvaluation = fixtureStrategy.evaluate(fixtureSnapshot.bars, fixtureSnapshot.manifest)
+const fixtureLock = fixtureStrategy.prepareLock(
+  fixtureSnapshot.manifest,
+  [...new Set(fixtureSnapshot.bars.map((bar) => bar.sessionDate))].sort(),
+  [],
+)
+const fixtureQualification = makeQualificationResult(
+  fixtureLock,
+  fixtureEvaluation.verdict,
+  fixtureStrategy.analyze(fixtureEvaluation, []),
+)
 
 const fetchJson = async (port: number, path: string, method = 'GET') => {
   const response = await fetch(`http://127.0.0.1:${port}${path}`, { method })
@@ -163,8 +185,7 @@ const waitForStatus = async (port: number, expectedStatus: string) => {
 }
 
 const readyState = (): RuntimeState => {
-  const snapshot = makeSnapshot()
-  const evaluation = evaluateTsmom(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance)
+  const evaluation = fixtureEvaluation
   return {
     status: 'READY',
     evidence: {
@@ -184,6 +205,7 @@ const readyState = (): RuntimeState => {
         eventCount: evaluation.events.length,
         gateCount: evaluation.verdict.gates.length,
       },
+      qualification: fixtureQualification,
     },
     health: {
       sequence: 1,
@@ -211,6 +233,8 @@ const recoveringStore = (state: RuntimeState): EvidenceStoreService => {
           persistence: { ...state.evidence!.persistence, deduplicated: true },
         }),
       ),
+    readQualification: () =>
+      Effect.succeed(Option.some({ state: 'TERMINAL', lock: fixtureLock, result: state.evidence!.qualification })),
     persist: () => Effect.die(new Error('health probes must not persist')),
   }
 }
@@ -260,6 +284,11 @@ describe('Bayn HTTP probes', () => {
               data: { status: 'CURRENT' },
               evidence: { status: 'CURRENT' },
               economic: { status: 'REJECTED' },
+              qualification: {
+                status: 'REJECTED',
+                lockId: fixtureQualification.lockId,
+                resultHash: fixtureQualification.resultHash,
+              },
               accounting: { status: 'EXACT' },
             },
           })
@@ -356,6 +385,7 @@ describe('Bayn continuous health', () => {
           ? Effect.succeed(makeSnapshot().manifest.finalizedSnapshot)
           : Effect.die(new Error('Signal connection defect')),
       ),
+      inspect: Effect.die(new Error('health probes must not inspect sessions')),
       load: Effect.die(new Error('health probes must not load bars')),
     }
     const journal: JournalService = {
@@ -412,6 +442,7 @@ describe('Bayn continuous health', () => {
         checks += 1
         return makeSnapshot().manifest.finalizedSnapshot
       }),
+      inspect: Effect.die(new Error('health monitor must not inspect sessions')),
       load: Effect.die(new Error('health monitor must not load bars')),
     }
     const journal: JournalService = { ...successfulJournal, checkRun: () => Effect.void }
@@ -442,6 +473,7 @@ describe('Bayn continuous health', () => {
     let interrupted = false
     const marketData: MarketDataService = {
       check: Effect.never.pipe(Effect.onInterrupt(() => Effect.sync(() => void (interrupted = true)))),
+      inspect: Effect.die(new Error('health monitor must not inspect sessions')),
       load: Effect.die(new Error('health monitor must not load bars')),
     }
     const fiber = Effect.runFork(
@@ -465,11 +497,7 @@ describe('Bayn startup lifecycle', () => {
     let journalWrites = 0
     let persistenceWrites = 0
     const strategy: StrategyService = {
-      name: 'tsmom',
-      universe: fixtureProtocol.universe,
-      parameters: fixtureProtocol,
-      provenance,
-      identify: () => evaluation.runId,
+      ...fixtureStrategy,
       evaluate: () => {
         evaluations += 1
         return evaluation
@@ -485,6 +513,7 @@ describe('Bayn startup lifecycle', () => {
     }
     const store: EvidenceStoreService = {
       ...successfulEvidenceStore,
+      openQualification: () => Effect.succeed({ state: 'TERMINAL', lock: fixtureLock, result: fixtureQualification }),
       recover: () =>
         Effect.succeed(
           Option.some({
@@ -508,7 +537,10 @@ describe('Bayn startup lifecycle', () => {
 
     await Effect.runPromise(
       initialize(config, state).pipe(
-        Effect.provideService(MarketData, marketDataService(Effect.succeed(snapshot))),
+        Effect.provideService(
+          MarketData,
+          marketDataService(Effect.die(new Error('terminal recovery must not load bars')), snapshot),
+        ),
         Effect.provideService(Journal, journal),
         Effect.provideService(EvidenceStore, store),
         Effect.provideService(Strategy, strategy),
@@ -530,16 +562,66 @@ describe('Bayn startup lifecycle', () => {
     })
   })
 
+  test('fails closed on an opened qualification without reading bars or mutating evidence', async () => {
+    const snapshot = makeSnapshot()
+    let evaluations = 0
+    let journalWrites = 0
+    let persistenceWrites = 0
+    const strategy: StrategyService = {
+      ...fixtureStrategy,
+      evaluate: () => {
+        evaluations += 1
+        throw new Error('incomplete qualification must not evaluate')
+      },
+    }
+    const journal: JournalService = {
+      check: Effect.void,
+      checkRun: () => Effect.void,
+      journalAndReconcile: () => {
+        journalWrites += 1
+        return Effect.die(new Error('incomplete qualification must not journal'))
+      },
+    }
+    const store: EvidenceStoreService = {
+      ...successfulEvidenceStore,
+      openQualification: () => Effect.succeed({ state: 'OPENED_INCOMPLETE', lock: fixtureLock }),
+      persist: () => {
+        persistenceWrites += 1
+        return Effect.die(new Error('incomplete qualification must not persist'))
+      },
+    }
+    const state = await Effect.runPromise(Ref.make(initialState()))
+
+    await Effect.runPromise(
+      initialize(config, state).pipe(
+        Effect.provideService(
+          MarketData,
+          marketDataService(Effect.die(new Error('incomplete qualification must not load bars')), snapshot),
+        ),
+        Effect.provideService(Journal, journal),
+        Effect.provideService(EvidenceStore, store),
+        Effect.provideService(Strategy, strategy),
+      ),
+    )
+
+    expect({ evaluations, journalWrites, persistenceWrites }).toEqual({
+      evaluations: 0,
+      journalWrites: 0,
+      persistenceWrites: 0,
+    })
+    expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
+      status: 'FAILED',
+      evidence: null,
+      error: expect.stringContaining('database.open-qualification'),
+    })
+  })
+
   test('fails closed instead of re-evaluating a corrupt matching durable run', async () => {
     const snapshot = makeSnapshot()
     let evaluations = 0
     let journalWrites = 0
     const strategy: StrategyService = {
-      name: 'tsmom',
-      universe: fixtureProtocol.universe,
-      parameters: fixtureProtocol,
-      provenance,
-      identify: (manifest) => identifyTsmomRun(manifest, fixtureProtocol, provenance),
+      ...fixtureStrategy,
       evaluate: () => {
         evaluations += 1
         throw new Error('corrupt recovery must not fall back to evaluation')
@@ -547,6 +629,7 @@ describe('Bayn startup lifecycle', () => {
     }
     const store: EvidenceStoreService = {
       ...successfulEvidenceStore,
+      openQualification: () => Effect.succeed({ state: 'TERMINAL', lock: fixtureLock, result: fixtureQualification }),
       recover: () =>
         Effect.fail(
           new DatabaseError({
@@ -568,7 +651,10 @@ describe('Bayn startup lifecycle', () => {
 
     await Effect.runPromise(
       initialize(config, state).pipe(
-        Effect.provideService(MarketData, marketDataService(Effect.succeed(snapshot))),
+        Effect.provideService(
+          MarketData,
+          marketDataService(Effect.die(new Error('corrupt recovery must not load bars')), snapshot),
+        ),
         Effect.provideService(Journal, journal),
         Effect.provideService(EvidenceStore, store),
         Effect.provideService(Strategy, strategy),
@@ -588,11 +674,8 @@ describe('Bayn startup lifecycle', () => {
     const snapshot = makeSnapshot()
     const state = await Effect.runPromise(Ref.make(initialState()))
     const strategy: StrategyService = {
+      ...fixtureStrategy,
       name: 'test-strategy',
-      universe: fixtureProtocol.universe,
-      parameters: fixtureProtocol,
-      provenance,
-      identify: (manifest) => identifyTsmomRun(manifest, fixtureProtocol, provenance),
       evaluate: (bars, manifest) => {
         calls += 1
         return evaluateTsmom(bars, manifest, fixtureProtocol, provenance)
@@ -634,9 +717,10 @@ describe('Bayn startup lifecycle', () => {
     }
   })
 
-  test('turns strategy exceptions into an operational failure', async () => {
+  test('rejects an underpowered calendar before opening a qualification lock', async () => {
     const state = await Effect.runPromise(Ref.make(initialState()))
-    const marketData = marketDataService(Effect.succeed(makeSnapshot(700)))
+    const shortSnapshot = makeSnapshot(700)
+    const marketData = marketDataService(Effect.succeed(shortSnapshot), shortSnapshot)
 
     await Effect.runPromise(
       initialize(config, state).pipe(
@@ -649,7 +733,7 @@ describe('Bayn startup lifecycle', () => {
 
     expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
       status: 'FAILED',
-      error: expect.stringContaining('strategy.evaluate'),
+      error: expect.stringContaining('strategy.prepare-lock'),
     })
   })
 
@@ -706,6 +790,9 @@ describe('Bayn startup lifecycle', () => {
       read: () => Effect.succeed(Option.none()),
       readArtifactItems: () => Effect.succeed(Option.none()),
       recover: () => Effect.succeed(Option.none()),
+      listPriorTrials: Effect.succeed([]),
+      openQualification: ({ lock }) => Effect.succeed({ state: 'ACQUIRED', lock }),
+      readQualification: () => Effect.succeed(Option.none()),
       persist: () =>
         Effect.fail(
           new DatabaseError({

--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -10,12 +10,14 @@ import {
   EvidenceStore,
   type EvidenceStoreService,
   type PersistenceReceipt,
+  type QualificationRecord,
   type RecoveredEvaluationEvidence,
 } from './db/evidence-store'
 import { formatError, operationalError, type Component, type OperationalError } from './errors'
 import { canonicalHashV1 } from './hash'
 import { Journal } from './ledger'
 import { MarketData } from './market-data'
+import { makeQualificationResult, type QualificationResult } from './qualification'
 import { summarizeEvaluation } from './strategy'
 import { Strategy } from './strategy-service'
 import type { EvaluationSummary, ReconciliationResult } from './types'
@@ -26,6 +28,7 @@ export interface RuntimeEvidence {
   readonly evaluation: EvaluationSummary
   readonly reconciliation: ReconciliationResult
   readonly persistence: PersistenceReceipt
+  readonly qualification: QualificationResult
 }
 
 export interface DependencyHealth {
@@ -92,7 +95,7 @@ const publicState = (
   let economic = 'UNKNOWN'
   let accounting = 'UNKNOWN'
   if (state.evidence !== null) {
-    economic = state.evidence.evaluation.verdict.status === 'PASS' ? 'QUALIFIED' : 'REJECTED'
+    economic = state.evidence.qualification.verdict
     if (state.health.dependencies.tigerBeetle.status === 'AVAILABLE') accounting = 'EXACT'
     if (state.health.dependencies.tigerBeetle.status === 'UNAVAILABLE') accounting = 'UNAVAILABLE'
   }
@@ -118,7 +121,15 @@ const publicState = (
     },
     economic: {
       status: economic,
-      verdict: state.evidence?.evaluation.verdict ?? null,
+      verdict: state.evidence?.qualification.evaluationVerdict ?? null,
+    },
+    qualification: {
+      status: state.evidence?.qualification.verdict ?? 'UNKNOWN',
+      lockId: state.evidence?.qualification.lockId ?? null,
+      resultHash: state.evidence?.qualification.resultHash ?? null,
+      analysisHash: state.evidence?.qualification.analysis.analysisHash ?? null,
+      candidateOrdinal: state.evidence?.qualification.analysis.candidateOrdinal ?? null,
+      reasonCodes: state.evidence?.qualification.reasonCodes ?? [],
     },
     accounting: {
       status: accounting,
@@ -282,25 +293,74 @@ const evaluateAndJournal = (
       'database',
       'health-check',
     )
-    const snapshot = yield* withinDeadline(marketData.load, config.operationTimeoutMs, 'market-data', 'load')
-    yield* Effect.logInfo('Bayn signal snapshot loaded').pipe(
+    const inspection = yield* withinDeadline(marketData.inspect, config.operationTimeoutMs, 'market-data', 'inspect')
+    yield* Effect.logInfo('Bayn signal snapshot inspected').pipe(
       Effect.annotateLogs({
         service: 'bayn',
-        inputManifestHash: snapshot.manifest.hash,
-        rowCount: snapshot.manifest.rowCount,
+        inputManifestHash: inspection.manifest.hash,
+        rowCount: inspection.manifest.rowCount,
       }),
     )
-    const expectedRunId = yield* Effect.try({
-      try: () => strategy.identify(snapshot.manifest),
-      catch: (cause) => operationalError('strategy', 'identify', `${strategy.name} run identity failed`, cause),
-    })
-    const recovered = yield* withinDeadline(
-      databaseOperation(evidenceStore.recover(expectedRunId, strategy.provenance), 'recover-evaluation'),
+    const priorTrialRunIds = yield* withinDeadline(
+      databaseOperation(evidenceStore.listPriorTrials, 'list-prior-trials'),
       config.operationTimeoutMs,
       'database',
-      'recover-evaluation',
+      'list-prior-trials',
     )
-    if (Option.isSome(recovered)) {
+    const lock = yield* Effect.try({
+      try: () => strategy.prepareLock(inspection.manifest, inspection.sessionDates, priorTrialRunIds),
+      catch: (cause) => operationalError('strategy', 'prepare-lock', `${strategy.name} lock preparation failed`, cause),
+    })
+    const opened = yield* withinDeadline(
+      databaseOperation(
+        evidenceStore.openQualification({
+          lock,
+          inputManifest: inspection.manifest,
+          parameters: strategy.parameters,
+          provenance: strategy.provenance,
+        }),
+        'open-qualification',
+      ),
+      config.operationTimeoutMs,
+      'database',
+      'open-qualification',
+    )
+    if (opened.state === 'OPENED_INCOMPLETE') {
+      return yield* Effect.fail(
+        operationalError(
+          'database',
+          'open-qualification',
+          `qualification ${opened.lock.lockId} was opened without a terminal result`,
+        ),
+      )
+    }
+    if (opened.state === 'TERMINAL') {
+      const recovered = yield* withinDeadline(
+        databaseOperation(evidenceStore.recover(lock.candidateRunId, strategy.provenance), 'recover-evaluation'),
+        config.operationTimeoutMs,
+        'database',
+        'recover-evaluation',
+      )
+      if (Option.isNone(recovered)) {
+        return yield* Effect.fail(
+          operationalError(
+            'database',
+            'recover-evaluation',
+            `terminal qualification run ${lock.candidateRunId} is missing`,
+          ),
+        )
+      }
+      yield* Effect.try({
+        try: () => {
+          if (
+            opened.result.runId !== recovered.value.evaluation.runId ||
+            canonicalHashV1(opened.result.evaluationVerdict) !== canonicalHashV1(recovered.value.evaluation.verdict)
+          ) {
+            throw new Error('terminal qualification differs from the recovered evaluation')
+          }
+        },
+        catch: (cause) => operationalError('database', 'recover-qualification', 'qualification recovery failed', cause),
+      })
       yield* Ref.update(
         state,
         (current): RuntimeState => ({
@@ -311,6 +371,7 @@ const evaluateAndJournal = (
             evaluation: recovered.value.evaluation,
             reconciliation: recovered.value.reconciliation,
             persistence: recovered.value.persistence,
+            qualification: opened.result,
           },
           error: null,
         }),
@@ -318,7 +379,8 @@ const evaluateAndJournal = (
       yield* Effect.logInfo('Bayn startup proof recovered').pipe(
         Effect.annotateLogs({
           service: 'bayn',
-          runId: expectedRunId,
+          runId: lock.candidateRunId,
+          qualification: opened.result.verdict,
           artifactCount: recovered.value.persistence.artifactCount,
           eventCount: recovered.value.persistence.eventCount,
           gateCount: recovered.value.persistence.gateCount,
@@ -326,10 +388,24 @@ const evaluateAndJournal = (
       )
       return
     }
+    const snapshot = yield* withinDeadline(marketData.load, config.operationTimeoutMs, 'market-data', 'load')
+    yield* Effect.try({
+      try: () => {
+        if (canonicalHashV1(snapshot.manifest) !== canonicalHashV1(inspection.manifest)) {
+          throw new Error('loaded Signal manifest differs from the locked inspection')
+        }
+      },
+      catch: (cause) => operationalError('market-data', 'load-locked', 'locked Signal load failed', cause),
+    })
     const evaluation = yield* Effect.try({
       try: () => strategy.evaluate(snapshot.bars, snapshot.manifest),
       catch: (cause) => operationalError('strategy', 'evaluate', `${strategy.name} evaluation failed`, cause),
     })
+    if (evaluation.runId !== lock.candidateRunId) {
+      return yield* Effect.fail(
+        operationalError('strategy', 'evaluate', 'evaluation run identity differs from the qualification lock'),
+      )
+    }
     yield* Effect.logInfo('Bayn strategy evaluation completed').pipe(
       Effect.annotateLogs({
         service: 'bayn',
@@ -345,6 +421,14 @@ const evaluateAndJournal = (
       'journal',
       'journal-and-reconcile',
     )
+    const analysis = yield* Effect.try({
+      try: () => strategy.analyze(evaluation, lock.priorTrialRunIds),
+      catch: (cause) => operationalError('strategy', 'analyze', `${strategy.name} analysis failed`, cause),
+    })
+    const qualification = yield* Effect.try({
+      try: () => makeQualificationResult(lock, evaluation.verdict, analysis),
+      catch: (cause) => operationalError('strategy', 'qualify', `${strategy.name} qualification failed`, cause),
+    })
     const persistence = yield* withinDeadline(
       databaseOperation(
         evidenceStore.persist({
@@ -352,6 +436,7 @@ const evaluateAndJournal = (
           parameters: strategy.parameters,
           evaluation,
           reconciliation,
+          qualification: { lock, result: qualification },
         }),
         'persist-evaluation',
       ),
@@ -369,6 +454,7 @@ const evaluateAndJournal = (
           evaluation: summarizeEvaluation(evaluation),
           reconciliation,
           persistence,
+          qualification,
         },
         error: null,
       }),
@@ -380,6 +466,8 @@ const evaluateAndJournal = (
         accountCount: reconciliation.accountCount,
         transferCount: reconciliation.transferCount,
         persistenceDeduplicated: persistence.deduplicated,
+        qualification: qualification.verdict,
+        qualificationResultHash: qualification.resultHash,
         markedEquityDifferenceMicros: evaluation.markedEquityReconciliation.differenceMicros,
       }),
     )
@@ -435,14 +523,21 @@ const durableMaterial = (evidence: RuntimeEvidence | RecoveredEvaluationEvidence
 
 const ensureDurableEvidence = (
   recovered: Option.Option<RecoveredEvaluationEvidence>,
+  qualification: Option.Option<QualificationRecord>,
   evidence: RuntimeEvidence | null,
 ): Effect.Effect<void, OperationalError> =>
   Effect.try({
     try: () => {
       if (evidence === null) throw new Error('startup evidence is unavailable')
       if (Option.isNone(recovered)) throw new Error(`durable run ${evidence.evaluation.runId} is missing`)
+      if (Option.isNone(qualification) || qualification.value.state !== 'TERMINAL') {
+        throw new Error(`terminal qualification ${evidence.evaluation.runId} is missing`)
+      }
       if (canonicalHashV1(durableMaterial(recovered.value)) !== canonicalHashV1(durableMaterial(evidence))) {
         throw new Error(`durable run ${evidence.evaluation.runId} differs from the active proof`)
+      }
+      if (canonicalHashV1(qualification.value.result) !== canonicalHashV1(evidence.qualification)) {
+        throw new Error(`terminal qualification ${evidence.evaluation.runId} differs from the active proof`)
       }
     },
     catch: (cause) => operationalError('database', 'verify-evidence', 'durable evidence verification failed', cause),
@@ -491,14 +586,24 @@ export const probe = (
           evidence === null
             ? Effect.fail(operationalError('database', 'verify-evidence', 'startup evidence is unavailable'))
             : withinDeadline(
-                databaseOperation(
-                  evidenceStore.recover(evidence.evaluation.runId, evidence.provenance),
-                  'continuous-recovery',
-                ),
+                Effect.all([
+                  databaseOperation(
+                    evidenceStore.recover(evidence.evaluation.runId, evidence.provenance),
+                    'continuous-recovery',
+                  ),
+                  databaseOperation(
+                    evidenceStore.readQualification(evidence.evaluation.runId),
+                    'continuous-qualification',
+                  ),
+                ]),
                 config.operationTimeoutMs,
                 'database',
                 'continuous-recovery',
-              ).pipe(Effect.flatMap((recovered) => ensureDurableEvidence(recovered, evidence))),
+              ).pipe(
+                Effect.flatMap(([recovered, qualification]) =>
+                  ensureDurableEvidence(recovered, qualification, evidence),
+                ),
+              ),
         ),
       ],
       { concurrency: 'unbounded' },

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -7,8 +7,9 @@ import { Cause, Effect, Exit, Fiber, Layer, ManagedRuntime, Option, Redacted } f
 import type { RuntimeConfig } from '../config'
 import { canonicalHashV1 } from '../hash'
 import { buildLedgerPlan } from '../ledger'
-import { makeQualificationLock, makeQualificationPolicyDocument } from '../qualification'
+import { makeQualificationLock, makeQualificationPolicyDocument, makeQualificationResult } from '../qualification'
 import { evaluateTsmom } from '../strategy'
+import { makeTsmomStrategy } from '../strategy-service'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from '../test-fixtures'
 import type { TsmomProtocol } from '../types'
 import {
@@ -84,6 +85,28 @@ const makeInput = (
   }
 }
 
+const makeLockedInput = (input: PersistEvaluationInput, priorTrialRunIds: readonly string[] = []) => {
+  const strategy = makeTsmomStrategy(fixtureProtocol, input.provenance)
+  const sessionDates = [...new Set(snapshot.bars.map((bar) => bar.sessionDate))].sort()
+  const lock = strategy.prepareLock(input.evaluation.inputManifest, sessionDates, priorTrialRunIds)
+  const result = makeQualificationResult(
+    lock,
+    input.evaluation.verdict,
+    strategy.analyze(input.evaluation, priorTrialRunIds),
+  )
+  return {
+    open: {
+      lock,
+      inputManifest: input.evaluation.inputManifest,
+      parameters: input.parameters,
+      provenance: input.provenance,
+    },
+    persist: { ...input, qualification: { lock, result } },
+    lock,
+    result,
+  }
+}
+
 describePostgres('PostgreSQL evaluation evidence', () => {
   let runtime: ReturnType<typeof makeEvidenceRuntime>
 
@@ -100,15 +123,13 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     await runtime.runPromise(
       Effect.gen(function* () {
         const sql = yield* PgClient.PgClient
-        yield* sql`
-          TRUNCATE
-            bayn_evaluation_runs,
-            bayn_protocol_locks,
-            bayn_snapshot_references
-          RESTART IDENTITY CASCADE
-        `
+        yield* sql`DROP SCHEMA public CASCADE`
+        yield* sql`CREATE SCHEMA public`
       }),
     )
+    await runtime.dispose()
+    runtime = makeEvidenceRuntime()
+    await runtime.runPromise(Effect.flatMap(EvidenceStore, (store) => store.check))
   })
 
   afterAll(async () => {
@@ -207,6 +228,115 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     )
   })
 
+  test('opens one concurrent lock and commits one terminal qualification result', async () => {
+    const input = makeInput()
+    const qualification = makeLockedInput(input)
+    const observed = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* EvidenceStore
+        const sql = yield* PgClient.PgClient
+        const opened = yield* Effect.all(
+          [store.openQualification(qualification.open), store.openQualification(qualification.open)],
+          { concurrency: 'unbounded' },
+        )
+        const before = yield* store.readQualification(input.evaluation.runId)
+        const bypass = yield* store.persist(input).pipe(Effect.flip)
+        const receipt = yield* store.persist(qualification.persist)
+        const terminal = yield* store.readQualification(input.evaluation.runId)
+        const reopened = yield* store.openQualification(qualification.open)
+        const trials = yield* store.listPriorTrials
+        const counts = yield* sql<{
+          locks: number
+          results: number
+          runs: number
+          trials: number
+        }>`
+          SELECT
+            (SELECT count(*)::integer FROM bayn_qualification_locks) AS locks,
+            (SELECT count(*)::integer FROM bayn_qualification_results) AS results,
+            (SELECT count(*)::integer FROM bayn_evaluation_runs) AS runs,
+            (SELECT count(*)::integer FROM bayn_qualification_trials) AS trials
+        `
+        return { before, bypass, counts: counts[0], opened, receipt, reopened, terminal, trials }
+      }),
+    )
+
+    expect(observed.opened.map((result) => result.state).sort()).toEqual(['ACQUIRED', 'OPENED_INCOMPLETE'])
+    expect(observed.before).toEqual(Option.some({ state: 'OPENED_INCOMPLETE', lock: qualification.lock }))
+    expect(observed.bypass).toMatchObject({ failure: 'invariant', operation: 'persist-qualification' })
+    expect(observed.receipt).toMatchObject({ runId: input.evaluation.runId, deduplicated: false })
+    expect(observed.terminal).toEqual(
+      Option.some({ state: 'TERMINAL', lock: qualification.lock, result: qualification.result }),
+    )
+    expect(observed.reopened).toEqual({
+      state: 'TERMINAL',
+      lock: qualification.lock,
+      result: qualification.result,
+    })
+    expect(observed.trials).toEqual([input.evaluation.runId])
+    expect(observed.counts).toEqual({ locks: 1, results: 1, runs: 1, trials: 0 })
+  })
+
+  test('rolls back the evaluation graph when terminal qualification insertion fails', async () => {
+    const input = makeInput()
+    const qualification = makeLockedInput(input)
+    const observed = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* EvidenceStore
+        const sql = yield* PgClient.PgClient
+        yield* store.openQualification(qualification.open)
+        yield* sql`
+          CREATE FUNCTION bayn_test_reject_qualification_result()
+          RETURNS trigger
+          LANGUAGE plpgsql
+          AS $function$
+          BEGIN
+            RAISE EXCEPTION 'injected terminal result failure' USING ERRCODE = 'P0001';
+          END
+          $function$
+        `
+        yield* sql`
+          CREATE TRIGGER bayn_test_reject_qualification_result
+          BEFORE INSERT ON bayn_qualification_results
+          FOR EACH ROW EXECUTE FUNCTION bayn_test_reject_qualification_result()
+        `
+        const failure = yield* store.persist(qualification.persist).pipe(Effect.flip)
+        const record = yield* store.readQualification(input.evaluation.runId)
+        const counts = yield* sql<{
+          locks: number
+          results: number
+          runs: number
+          artifacts: number
+          events: number
+          gates: number
+          statuses: number
+        }>`
+          SELECT
+            (SELECT count(*)::integer FROM bayn_qualification_locks) AS locks,
+            (SELECT count(*)::integer FROM bayn_qualification_results) AS results,
+            (SELECT count(*)::integer FROM bayn_evaluation_runs) AS runs,
+            (SELECT count(*)::integer FROM bayn_evaluation_artifacts) AS artifacts,
+            (SELECT count(*)::integer FROM bayn_evaluation_events) AS events,
+            (SELECT count(*)::integer FROM bayn_gate_outcomes) AS gates,
+            (SELECT count(*)::integer FROM bayn_status_history) AS statuses
+        `
+        return { counts: counts[0], failure, record }
+      }),
+    )
+
+    expect(observed.failure).toBeInstanceOf(DatabaseError)
+    expect(observed.record).toEqual(Option.some({ state: 'OPENED_INCOMPLETE', lock: qualification.lock }))
+    expect(observed.counts).toEqual({
+      locks: 1,
+      results: 0,
+      runs: 0,
+      artifacts: 0,
+      events: 0,
+      gates: 0,
+      statuses: 0,
+    })
+  })
+
   test('persists and recovers fee, partial-fill, and nonzero cash-yield evidence', async () => {
     const protocol: TsmomProtocol = {
       ...fixtureProtocol,
@@ -251,7 +381,8 @@ describePostgres('PostgreSQL evaluation evidence', () => {
         const manifest = input.evaluation.inputManifest
         const decisionCount = input.evaluation.events.filter((event) => event.kind === 'decision').length
         const lock = makeQualificationLock({
-          schemaVersion: 'bayn.qualification-lock.v1',
+          schemaVersion: 'bayn.qualification-lock.v2',
+          candidateRunId: input.evaluation.runId,
           protocolHash: input.evaluation.protocolHash,
           sourceRevision: input.provenance.sourceRevision,
           image: input.provenance.image,
@@ -285,6 +416,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
           INSERT INTO bayn_qualification_locks (
             lock_id,
             schema_version,
+            candidate_run_id,
             protocol_hash,
             snapshot_id,
             source_revision,
@@ -294,6 +426,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
           ) VALUES (
             ${lock.lockId},
             ${lock.schemaVersion},
+            ${lock.candidateRunId},
             ${lock.protocolHash},
             ${lock.data.snapshotId},
             ${lock.sourceRevision},
@@ -338,6 +471,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
           INSERT INTO bayn_qualification_locks (
             lock_id,
             schema_version,
+            candidate_run_id,
             protocol_hash,
             snapshot_id,
             source_revision,
@@ -347,6 +481,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
           ) VALUES (
             ${'f'.repeat(64)},
             ${lock.schemaVersion},
+            ${lock.candidateRunId},
             ${lock.protocolHash},
             ${lock.data.snapshotId},
             ${lock.sourceRevision},
@@ -649,6 +784,26 @@ describePostgres('PostgreSQL evaluation evidence', () => {
 
     expect(result.exits.every(Exit.isFailure)).toBe(true)
     expect(Option.isSome(result.read)).toBe(true)
+  })
+
+  test('rejects truncation of evidence and qualification tables', async () => {
+    const exits = await runtime.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* PgClient.PgClient
+        return yield* Effect.forEach(
+          [
+            sql`TRUNCATE bayn_evaluation_runs CASCADE`,
+            sql`TRUNCATE bayn_evaluation_artifacts`,
+            sql`TRUNCATE bayn_qualification_trials`,
+            sql`TRUNCATE bayn_qualification_locks CASCADE`,
+            sql`TRUNCATE bayn_qualification_results`,
+          ],
+          Effect.exit,
+        )
+      }),
+    )
+
+    expect(exits.every(Exit.isFailure)).toBe(true)
   })
 
   test('rolls back every table when a terminal evidence constraint fails', async () => {

--- a/services/bayn/src/db/evidence-store.ts
+++ b/services/bayn/src/db/evidence-store.ts
@@ -21,6 +21,12 @@ import {
   makeEquitySeriesArtifact,
 } from '../evidence-contracts'
 import { canonicalHashV1 } from '../hash'
+import {
+  QualificationLockSchema,
+  QualificationResultSchema,
+  type QualificationLock,
+  type QualificationResult,
+} from '../qualification'
 import { reconcileMarkedEquity } from '../simulation-reconciliation'
 import { summarizeEvaluation } from '../strategy'
 import type { EvaluationResult, EvaluationSummary, InputManifest, ReconciliationResult } from '../types'
@@ -48,6 +54,23 @@ export interface PersistEvaluationInput {
   readonly parameters: unknown
   readonly evaluation: EvaluationResult
   readonly reconciliation: ReconciliationResult
+  readonly qualification?: {
+    readonly lock: QualificationLock
+    readonly result: QualificationResult
+  }
+}
+
+export type QualificationRecord =
+  | { readonly state: 'OPENED_INCOMPLETE'; readonly lock: QualificationLock }
+  | { readonly state: 'TERMINAL'; readonly lock: QualificationLock; readonly result: QualificationResult }
+
+export type QualificationOpen = { readonly state: 'ACQUIRED'; readonly lock: QualificationLock } | QualificationRecord
+
+export interface OpenQualificationInput {
+  readonly lock: QualificationLock
+  readonly inputManifest: InputManifest
+  readonly parameters: unknown
+  readonly provenance: RuntimeProvenance
 }
 
 export interface ArtifactItemPage {
@@ -74,6 +97,11 @@ export interface EvidenceStoreService {
     runId: string,
     provenance: RuntimeProvenance,
   ) => Effect.Effect<Option.Option<RecoveredEvaluationEvidence>, DatabaseError>
+  readonly listPriorTrials: Effect.Effect<readonly string[], DatabaseError>
+  readonly openQualification: (input: OpenQualificationInput) => Effect.Effect<QualificationOpen, DatabaseError>
+  readonly readQualification: (
+    candidateRunId: string,
+  ) => Effect.Effect<Option.Option<QualificationRecord>, DatabaseError>
 }
 
 export class EvidenceStore extends Context.Service<EvidenceStore, EvidenceStoreService>()('bayn/EvidenceStore') {}
@@ -250,6 +278,18 @@ const StatusReferenceRow = Schema.Struct({
   status: Schema.Literals(['WRITING', 'COMPLETE']),
   detail: Schema.Unknown,
 })
+const QualificationTrialRow = Schema.Struct({ run_id: Sha256 })
+const QualificationRow = Schema.Struct({
+  lock_payload: Schema.Unknown,
+  result_payload: Schema.NullOr(Schema.Unknown),
+})
+const CandidateRunCountRow = Schema.Struct({ count: NonNegativeInteger })
+const InsertedLockRow = Schema.Struct({ lock_id: Sha256 })
+const InsertedResultRow = Schema.Struct({ lock_id: Sha256 })
+
+const StrictParseOptions = { onExcessProperty: 'error' } as const
+const decodeQualificationLock = Schema.decodeUnknownSync(QualificationLockSchema, StrictParseOptions)
+const decodeQualificationResult = Schema.decodeUnknownSync(QualificationResultSchema, StrictParseOptions)
 
 const messageOf = (cause: unknown): string => (cause instanceof Error ? cause.message : String(cause))
 
@@ -328,6 +368,57 @@ const protocolExecutionModel = (parameters: unknown): unknown => {
 const artifactItemCount = (payload: unknown): number => {
   if (typeof payload !== 'object' || payload === null || !('items' in payload)) return 0
   return Array.isArray(payload.items) ? payload.items.length : 0
+}
+
+const validateQualificationOpenInput = (input: OpenQualificationInput): OpenQualificationInput => {
+  const lock = decodeQualificationLock(input.lock)
+  const { inputManifest, parameters, provenance } = input
+  if (canonicalHashV1(parameters) !== provenance.strategy.parameterHash) {
+    throw new TypeError('qualification parameters and provenance disagree')
+  }
+  const protocolHash = makeStrategyProtocolHash(provenance.strategy)
+  const { hash: manifestHash, ...manifestMaterial } = inputManifest
+  if (manifestHash !== canonicalHashV1(manifestMaterial)) {
+    throw new TypeError('qualification input manifest hash does not match its content')
+  }
+  const expectedRunId = makeRunIdentity({
+    schemaVersion: 'bayn.run-identity.v1',
+    sourceRevision: provenance.sourceRevision,
+    image: provenance.image,
+    strategy: {
+      name: provenance.strategy.name,
+      behaviorHash: provenance.strategy.behaviorHash,
+      parameters,
+    },
+    finalizedSnapshot: inputManifest.finalizedSnapshot,
+    calendarVersion: inputManifest.finalizedSnapshot.calendarVersion,
+    bounds: inputManifest.bounds,
+  }).runId
+  const snapshot = inputManifest.finalizedSnapshot
+  const dataMatches =
+    lock.data.snapshotId === snapshot.snapshotId &&
+    lock.data.publicationId === snapshot.publicationId &&
+    lock.data.contentHash === snapshot.contentHash &&
+    lock.data.sessionsContentHash === snapshot.sessionsContentHash &&
+    lock.data.provider === snapshot.source &&
+    lock.data.sourceFeed === snapshot.sourceFeed &&
+    lock.data.adjustment === snapshot.adjustment &&
+    lock.data.calendarVersion === snapshot.calendarVersion &&
+    lock.data.firstSession === snapshot.firstSession &&
+    lock.data.lastSession === snapshot.lastSession &&
+    canonicalHashV1(lock.data.bounds) === canonicalHashV1(inputManifest.bounds)
+  if (
+    lock.candidateRunId !== expectedRunId ||
+    lock.protocolHash !== protocolHash ||
+    lock.sourceRevision !== provenance.sourceRevision ||
+    canonicalHashV1(lock.image) !== canonicalHashV1(provenance.image) ||
+    canonicalHashV1(lock.universe) !== canonicalHashV1(snapshot.symbols) ||
+    !dataMatches ||
+    canonicalHashV1(lock.policies.execution.content) !== canonicalHashV1(protocolExecutionModel(parameters))
+  ) {
+    throw new TypeError('qualification lock diverges from the candidate runtime or finalized snapshot')
+  }
+  return { ...input, lock }
 }
 
 const makePersistencePlan = (input: PersistEvaluationInput): PersistencePlan => {
@@ -503,6 +594,30 @@ const makePersistencePlan = (input: PersistEvaluationInput): PersistencePlan => 
   if (events.length === 0) throw new TypeError('evaluation produced no durable events')
   if (gates.length === 0) throw new TypeError('evaluation produced no economic gate outcomes')
 
+  let qualification = input.qualification
+  if (qualification !== undefined) {
+    const lock = validateQualificationOpenInput({
+      lock: qualification.lock,
+      inputManifest: evaluation.inputManifest,
+      parameters,
+      provenance,
+    }).lock
+    const result = decodeQualificationResult(qualification.result)
+    if (
+      lock.candidateRunId !== evaluation.runId ||
+      lock.data.selectedSessionCount !== evaluation.strategy.observations ||
+      lock.data.selectedSessionCount !== evaluation.simulation.dailyMarks.length ||
+      lock.data.selectedRebalanceCount !== evaluation.signalDecisions.length ||
+      result.lockId !== lock.lockId ||
+      result.runId !== evaluation.runId ||
+      canonicalHashV1(result.evaluationVerdict) !== canonicalHashV1(evaluation.verdict) ||
+      canonicalHashV1(result.analysis.priorTrialRunIds) !== canonicalHashV1(lock.priorTrialRunIds)
+    ) {
+      throw new TypeError('qualification result diverges from the locked evaluation')
+    }
+    qualification = { lock, result }
+  }
+
   const artifactManifest = {
     schemaVersion: 'bayn.qualification-artifact-manifest.v1',
     identity: {
@@ -555,7 +670,7 @@ const makePersistencePlan = (input: PersistEvaluationInput): PersistencePlan => 
     },
   ]
 
-  return { ...input, strategyName, protocolHash, snapshotId, artifacts, events, gates }
+  return { ...input, qualification, strategyName, protocolHash, snapshotId, artifacts, events, gates }
 }
 
 const makeEvidenceStore = Effect.gen(function* () {
@@ -763,6 +878,237 @@ const makeEvidenceStore = Effect.gen(function* () {
       SELECT status, detail FROM bayn_status_history WHERE run_id = ${runId} ORDER BY sequence
     `,
   })
+  const getPriorTrials = SqlSchema.findAll({
+    Request: Schema.Void,
+    Result: QualificationTrialRow,
+    execute: () => sql`
+      SELECT run_id
+      FROM (
+        SELECT run_id FROM bayn_qualification_trials
+        UNION
+        SELECT run_id FROM bayn_qualification_results
+      ) AS trials
+      ORDER BY run_id
+    `,
+  })
+  const getQualificationByCandidate = SqlSchema.findAll({
+    Request: Schema.Struct({ candidateRunId: Sha256 }),
+    Result: QualificationRow,
+    execute: ({ candidateRunId }) => sql`
+      SELECT lock.payload AS lock_payload, result.payload AS result_payload
+      FROM bayn_qualification_locks AS lock
+      LEFT JOIN bayn_qualification_results AS result USING (lock_id)
+      WHERE lock.candidate_run_id = ${candidateRunId}
+    `,
+  })
+  const getQualificationByIdentity = SqlSchema.findAll({
+    Request: Schema.Struct({ candidateRunId: Sha256, snapshotId: Sha256 }),
+    Result: QualificationRow,
+    execute: ({ candidateRunId, snapshotId }) => sql`
+      SELECT lock.payload AS lock_payload, result.payload AS result_payload
+      FROM bayn_qualification_locks AS lock
+      LEFT JOIN bayn_qualification_results AS result USING (lock_id)
+      WHERE lock.candidate_run_id = ${candidateRunId} OR lock.snapshot_id = ${snapshotId}
+      ORDER BY lock.lock_id
+    `,
+  })
+  const insertQualificationLock = SqlSchema.findAll({
+    Request: Schema.Struct({
+      lockId: Sha256,
+      schemaVersion: Schema.Literal('bayn.qualification-lock.v2'),
+      candidateRunId: Sha256,
+      protocolHash: Sha256,
+      snapshotId: Sha256,
+      sourceRevision: GitRevision,
+      imageRepository: Schema.String,
+      imageDigest: ImageDigest,
+      payload: Schema.Unknown,
+    }),
+    Result: InsertedLockRow,
+    execute: (request) => sql`
+      INSERT INTO bayn_qualification_locks (
+        lock_id,
+        schema_version,
+        candidate_run_id,
+        protocol_hash,
+        snapshot_id,
+        source_revision,
+        image_repository,
+        image_digest,
+        payload
+      ) VALUES (
+        ${request.lockId},
+        ${request.schemaVersion},
+        ${request.candidateRunId},
+        ${request.protocolHash},
+        ${request.snapshotId},
+        ${request.sourceRevision},
+        ${request.imageRepository},
+        ${request.imageDigest},
+        ${sql.json(request.payload)}
+      )
+      ON CONFLICT DO NOTHING
+      RETURNING lock_id
+    `,
+  })
+  const insertQualificationResult = SqlSchema.findAll({
+    Request: Schema.Struct({
+      lockId: Sha256,
+      schemaVersion: Schema.Literal('bayn.qualification-result.v2'),
+      runId: Sha256,
+      verdict: Schema.Literals(['QUALIFIED', 'REJECTED']),
+      analysisHash: Sha256,
+      resultHash: Sha256,
+      payload: Schema.Unknown,
+    }),
+    Result: InsertedResultRow,
+    execute: (request) => sql`
+      INSERT INTO bayn_qualification_results (
+        lock_id,
+        schema_version,
+        run_id,
+        verdict,
+        analysis_hash,
+        result_hash,
+        payload
+      ) VALUES (
+        ${request.lockId},
+        ${request.schemaVersion},
+        ${request.runId},
+        ${request.verdict},
+        ${request.analysisHash},
+        ${request.resultHash},
+        ${sql.json(request.payload)}
+      )
+      ON CONFLICT DO NOTHING
+      RETURNING lock_id
+    `,
+  })
+  const getCandidateRunCount = SqlSchema.findOne({
+    Request: Schema.Struct({ candidateRunId: Sha256 }),
+    Result: CandidateRunCountRow,
+    execute: ({ candidateRunId }) => sql`
+      SELECT count(*)::integer AS count FROM bayn_evaluation_runs WHERE run_id = ${candidateRunId}
+    `,
+  })
+  const getIncompleteQualificationCount = SqlSchema.findOne({
+    Request: Schema.Void,
+    Result: CandidateRunCountRow,
+    execute: () => sql`
+      SELECT count(*)::integer AS count
+      FROM bayn_qualification_locks AS lock
+      LEFT JOIN bayn_qualification_results AS result USING (lock_id)
+      WHERE result.lock_id IS NULL
+    `,
+  })
+
+  const decodeQualificationRecord = (row: typeof QualificationRow.Type): QualificationRecord => {
+    const lock = decodeQualificationLock(row.lock_payload)
+    if (row.result_payload === null) return { state: 'OPENED_INCOMPLETE', lock }
+    const result = decodeQualificationResult(row.result_payload)
+    if (result.lockId !== lock.lockId || result.runId !== lock.candidateRunId) {
+      throw new TypeError('stored qualification result diverges from its lock')
+    }
+    return { state: 'TERMINAL', lock, result }
+  }
+
+  const decodeSingleQualification = (
+    rows: readonly (typeof QualificationRow.Type)[],
+    operation: string,
+  ): Effect.Effect<Option.Option<QualificationRecord>, DatabaseError> =>
+    Effect.gen(function* () {
+      if (rows.length === 0) return Option.none<QualificationRecord>()
+      yield* ensure(rows.length === 1, operation, 'qualification identity is duplicated or divergent')
+      return yield* Effect.try({
+        try: () => Option.some(decodeQualificationRecord(rows[0])),
+        catch: (cause) => databaseError('invariant', operation, 'stored qualification evidence is invalid', cause),
+      })
+    })
+
+  const ensureProtocolReference = (input: {
+    readonly protocolHash: string
+    readonly provenance: RuntimeProvenance
+    readonly parameters: unknown
+  }) =>
+    Effect.gen(function* () {
+      yield* sql`
+        INSERT INTO bayn_protocol_locks (
+          protocol_hash,
+          schema_version,
+          strategy_name,
+          behavior_hash,
+          parameter_hash,
+          parameters
+        ) VALUES (
+          ${input.protocolHash},
+          ${input.provenance.strategy.parameterSchemaVersion},
+          ${input.provenance.strategy.name},
+          ${input.provenance.strategy.behaviorHash},
+          ${input.provenance.strategy.parameterHash},
+          ${sql.json(input.parameters)}
+        )
+        ON CONFLICT (protocol_hash) DO NOTHING
+      `
+      const protocol = yield* getProtocol({ protocolHash: input.protocolHash })
+      yield* ensure(
+        protocol.schema_version === input.provenance.strategy.parameterSchemaVersion &&
+          protocol.strategy_name === input.provenance.strategy.name &&
+          protocol.behavior_hash === input.provenance.strategy.behaviorHash &&
+          protocol.parameter_hash === input.provenance.strategy.parameterHash &&
+          canonicalHashV1(protocol.parameters) === input.provenance.strategy.parameterHash &&
+          makeStrategyProtocolHash({
+            name: protocol.strategy_name,
+            behaviorHash: protocol.behavior_hash,
+            parameterHash: protocol.parameter_hash,
+            parameterSchemaVersion: protocol.schema_version,
+          }) === input.protocolHash,
+        'protocol-lock',
+        'stored protocol lock diverged from the evaluated protocol',
+      )
+    })
+
+  const ensureSnapshotReference = (inputManifest: InputManifest) =>
+    Effect.gen(function* () {
+      const snapshot = inputManifest.finalizedSnapshot
+      yield* sql`
+        INSERT INTO bayn_snapshot_references (
+          snapshot_id,
+          schema_version,
+          database_name,
+          table_name,
+          dataset_version,
+          source,
+          source_feed,
+          adjustment,
+          content_hash,
+          row_count,
+          first_session,
+          last_session,
+          manifest
+        ) VALUES (
+          ${snapshot.snapshotId},
+          ${snapshot.schemaVersion},
+          ${inputManifest.database},
+          ${inputManifest.tables.bars},
+          ${snapshot.publicationSchemaVersion},
+          ${snapshot.source},
+          ${snapshot.sourceFeed},
+          ${snapshot.adjustment},
+          ${snapshot.contentHash},
+          ${snapshot.rowCount},
+          ${snapshot.firstSession},
+          ${snapshot.lastSession},
+          ${sql.json(snapshot)}
+        )
+        ON CONFLICT (snapshot_id) DO NOTHING
+      `
+      const storedSnapshot = yield* getSnapshot({ snapshotId: snapshot.snapshotId })
+      yield* ensure(
+        snapshotReferenceMatches(storedSnapshot, inputManifest),
+        'snapshot-reference',
+        'stored snapshot reference diverged from the evaluated input manifest',
+      )
+    })
 
   const readReceipt = (plan: PersistencePlan, deduplicated: boolean) =>
     Effect.gen(function* () {
@@ -1006,6 +1352,110 @@ const makeEvidenceStore = Effect.gen(function* () {
     })
 
   const read = (runId: string) => runDatabase('read-evidence', readStored(runId))
+
+  const listPriorTrials = runDatabase(
+    'list-prior-trials',
+    getPriorTrials(undefined).pipe(Effect.map((rows) => rows.map((row) => row.run_id))),
+  )
+
+  const readQualification: EvidenceStoreService['readQualification'] = (candidateRunId) =>
+    runDatabase(
+      'read-qualification',
+      Effect.gen(function* () {
+        const rows = yield* getQualificationByCandidate({ candidateRunId })
+        return yield* decodeSingleQualification(rows, 'read-qualification')
+      }),
+    )
+
+  const openQualification: EvidenceStoreService['openQualification'] = (input) =>
+    runDatabase(
+      'open-qualification',
+      Effect.gen(function* () {
+        const plan = yield* Effect.try({
+          try: () => validateQualificationOpenInput(input),
+          catch: (cause) => databaseError('invariant', 'open-qualification', 'invalid qualification lock input', cause),
+        })
+        const lock = plan.lock
+        return yield* sql.withTransaction(
+          Effect.gen(function* () {
+            yield* ensureProtocolReference({
+              protocolHash: lock.protocolHash,
+              provenance: plan.provenance,
+              parameters: plan.parameters,
+            })
+            yield* ensureSnapshotReference(plan.inputManifest)
+            yield* sql`LOCK TABLE bayn_qualification_trials IN SHARE MODE`
+            yield* sql`LOCK TABLE bayn_qualification_locks IN SHARE ROW EXCLUSIVE MODE`
+
+            const existingRows = yield* getQualificationByIdentity({
+              candidateRunId: lock.candidateRunId,
+              snapshotId: lock.data.snapshotId,
+            })
+            const existing = yield* decodeSingleQualification(existingRows, 'open-qualification')
+            if (Option.isSome(existing)) {
+              yield* ensure(
+                existing.value.lock.lockId === lock.lockId &&
+                  canonicalHashV1(existing.value.lock) === canonicalHashV1(lock),
+                'open-qualification',
+                'candidate or snapshot is already bound to a different qualification lock',
+              )
+              return existing.value
+            }
+
+            const incompleteCount = yield* getIncompleteQualificationCount(undefined)
+            yield* ensure(
+              incompleteCount.count === 0,
+              'open-qualification',
+              'another qualification lock is opened without a terminal result',
+            )
+
+            const priorTrialRunIds = (yield* getPriorTrials(undefined)).map((row) => row.run_id)
+            yield* ensure(
+              canonicalHashV1(priorTrialRunIds) === canonicalHashV1(lock.priorTrialRunIds),
+              'open-qualification',
+              'qualification prior-trial lineage changed before lock acquisition',
+            )
+            const candidateRunCount = yield* getCandidateRunCount({ candidateRunId: lock.candidateRunId })
+            yield* ensure(
+              candidateRunCount.count === 0,
+              'open-qualification',
+              'candidate evaluation was observed before qualification lock acquisition',
+            )
+
+            const inserted = yield* insertQualificationLock({
+              lockId: lock.lockId,
+              schemaVersion: lock.schemaVersion,
+              candidateRunId: lock.candidateRunId,
+              protocolHash: lock.protocolHash,
+              snapshotId: lock.data.snapshotId,
+              sourceRevision: lock.sourceRevision,
+              imageRepository: lock.image.repository,
+              imageDigest: lock.image.digest,
+              payload: lock,
+            })
+            if (inserted.length === 1) return { state: 'ACQUIRED', lock } as const
+            yield* ensure(inserted.length === 0, 'open-qualification', 'qualification lock insert was duplicated')
+
+            const rows = yield* getQualificationByIdentity({
+              candidateRunId: lock.candidateRunId,
+              snapshotId: lock.data.snapshotId,
+            })
+            const stored = yield* decodeSingleQualification(rows, 'open-qualification')
+            if (Option.isNone(stored)) {
+              return yield* Effect.fail(
+                databaseError('invariant', 'open-qualification', 'conflicting qualification lock is missing'),
+              )
+            }
+            yield* ensure(
+              stored.value.lock.lockId === lock.lockId && canonicalHashV1(stored.value.lock) === canonicalHashV1(lock),
+              'open-qualification',
+              'qualification lock conflict diverges from the requested identity',
+            )
+            return stored.value
+          }),
+        )
+      }),
+    )
 
   const readArtifactItems: EvidenceStoreService['readArtifactItems'] = ({
     runId,
@@ -1307,81 +1757,36 @@ const makeEvidenceStore = Effect.gen(function* () {
 
         return yield* sql.withTransaction(
           Effect.gen(function* () {
-            yield* sql`
-            INSERT INTO bayn_protocol_locks (
-              protocol_hash,
-              schema_version,
-              strategy_name,
-              behavior_hash,
-              parameter_hash,
-              parameters
-            ) VALUES (
-              ${plan.protocolHash},
-              ${plan.provenance.strategy.parameterSchemaVersion},
-              ${plan.strategyName},
-              ${plan.provenance.strategy.behaviorHash},
-              ${plan.provenance.strategy.parameterHash},
-              ${sql.json(plan.parameters)}
-            )
-            ON CONFLICT (protocol_hash) DO NOTHING
-          `
-            const protocol = yield* getProtocol({ protocolHash: plan.protocolHash })
-            yield* ensure(
-              protocol.schema_version === plan.provenance.strategy.parameterSchemaVersion &&
-                protocol.strategy_name === plan.strategyName &&
-                protocol.behavior_hash === plan.provenance.strategy.behaviorHash &&
-                protocol.parameter_hash === plan.provenance.strategy.parameterHash &&
-                canonicalHashV1(protocol.parameters) === plan.provenance.strategy.parameterHash &&
-                makeStrategyProtocolHash({
-                  name: protocol.strategy_name,
-                  behaviorHash: protocol.behavior_hash,
-                  parameterHash: protocol.parameter_hash,
-                  parameterSchemaVersion: protocol.schema_version,
-                }) === plan.protocolHash,
-              'protocol-lock',
-              'stored protocol lock diverged from the evaluated protocol',
-            )
-
-            const inputManifest = plan.evaluation.inputManifest
-            const finalizedSnapshot = inputManifest.finalizedSnapshot
-            yield* sql`
-            INSERT INTO bayn_snapshot_references (
-              snapshot_id,
-              schema_version,
-              database_name,
-              table_name,
-              dataset_version,
-              source,
-              source_feed,
-              adjustment,
-              content_hash,
-              row_count,
-              first_session,
-              last_session,
-              manifest
-            ) VALUES (
-              ${plan.snapshotId},
-              ${finalizedSnapshot.schemaVersion},
-              ${inputManifest.database},
-              ${inputManifest.tables.bars},
-              ${finalizedSnapshot.publicationSchemaVersion},
-              ${finalizedSnapshot.source},
-              ${finalizedSnapshot.sourceFeed},
-              ${finalizedSnapshot.adjustment},
-              ${finalizedSnapshot.contentHash},
-              ${finalizedSnapshot.rowCount},
-              ${finalizedSnapshot.firstSession},
-              ${finalizedSnapshot.lastSession},
-              ${sql.json(finalizedSnapshot)}
-            )
-            ON CONFLICT (snapshot_id) DO NOTHING
-          `
-            const storedSnapshot = yield* getSnapshot({ snapshotId: plan.snapshotId })
-            yield* ensure(
-              snapshotReferenceMatches(storedSnapshot, inputManifest),
-              'snapshot-reference',
-              'stored snapshot reference diverged from the evaluated input manifest',
-            )
+            const qualificationRows = yield* getQualificationByCandidate({
+              candidateRunId: plan.evaluation.runId,
+            })
+            const storedQualification = yield* decodeSingleQualification(qualificationRows, 'persist-qualification')
+            if (plan.qualification !== undefined) {
+              if (Option.isNone(storedQualification)) {
+                return yield* Effect.fail(
+                  databaseError('invariant', 'persist-qualification', 'qualification lock was not opened'),
+                )
+              }
+              yield* ensure(
+                storedQualification.value.state === 'OPENED_INCOMPLETE' &&
+                  storedQualification.value.lock.lockId === plan.qualification.lock.lockId &&
+                  canonicalHashV1(storedQualification.value.lock) === canonicalHashV1(plan.qualification.lock),
+                'persist-qualification',
+                'qualification lock is terminal or diverges from the evaluation',
+              )
+            } else {
+              yield* ensure(
+                Option.isNone(storedQualification),
+                'persist-qualification',
+                'locked qualification candidate requires its terminal result in the same transaction',
+              )
+            }
+            yield* ensureProtocolReference({
+              protocolHash: plan.protocolHash,
+              provenance: plan.provenance,
+              parameters: plan.parameters,
+            })
+            yield* ensureSnapshotReference(plan.evaluation.inputManifest)
 
             const inserted = yield* insertRun({
               runId: plan.evaluation.runId,
@@ -1397,7 +1802,18 @@ const makeEvidenceStore = Effect.gen(function* () {
               eventCount: plan.events.length,
               gateCount: plan.gates.length,
             })
-            if (inserted.length === 0) return yield* readReceipt(plan, true)
+            if (inserted.length === 0) {
+              if (plan.qualification !== undefined) {
+                return yield* Effect.fail(
+                  databaseError(
+                    'invariant',
+                    'persist-qualification',
+                    'locked qualification candidate was already evaluated without a terminal result',
+                  ),
+                )
+              }
+              return yield* readReceipt(plan, true)
+            }
 
             yield* sql`
             INSERT INTO bayn_status_history (run_id, status, detail)
@@ -1488,6 +1904,23 @@ const makeEvidenceStore = Effect.gen(function* () {
               ${sql.json({ reconciliationExact: true, verdict: plan.evaluation.verdict.status })}
             )
           `
+            if (plan.qualification !== undefined) {
+              const result = plan.qualification.result
+              const resultRows = yield* insertQualificationResult({
+                lockId: result.lockId,
+                schemaVersion: result.schemaVersion,
+                runId: result.runId,
+                verdict: result.verdict,
+                analysisHash: result.analysis.analysisHash,
+                resultHash: result.resultHash,
+                payload: result,
+              })
+              yield* ensure(
+                resultRows.length === 1 && resultRows[0].lock_id === result.lockId,
+                'persist-qualification',
+                'terminal qualification result was not inserted exactly once',
+              )
+            }
             return yield* readReceipt(plan, false)
           }),
         )
@@ -1500,6 +1933,9 @@ const makeEvidenceStore = Effect.gen(function* () {
     read,
     readArtifactItems,
     recover,
+    listPriorTrials,
+    openQualification,
+    readQualification,
   } satisfies EvidenceStoreService
 })
 
@@ -1558,6 +1994,9 @@ export const EvidenceStoreRuntimeLive = (config: RuntimeConfig) =>
         read: () => Effect.fail(error),
         readArtifactItems: () => Effect.fail(error),
         recover: () => Effect.fail(error),
+        listPriorTrials: Effect.fail(error),
+        openQualification: () => Effect.fail(error),
+        readQualification: () => Effect.fail(error),
       }),
     ),
   )

--- a/services/bayn/src/db/migrations.ts
+++ b/services/bayn/src/db/migrations.ts
@@ -4,10 +4,12 @@ import evaluationEvidence from '../../migrations/0001_evaluation_evidence'
 import qualificationLock from '../../migrations/0002_qualification_lock'
 import evidenceImmutability from '../../migrations/0003_evidence_immutability'
 import executionEvents from '../../migrations/0004_execution_events'
+import lockedQualification from '../../migrations/0005_locked_qualification'
 
 export const migrationLoader = PgMigrator.fromRecord({
   '1_evaluation_evidence': evaluationEvidence,
   '2_qualification_lock': qualificationLock,
   '3_evidence_immutability': evidenceImmutability,
   '4_execution_events': executionEvents,
+  '5_locked_qualification': lockedQualification,
 })

--- a/services/bayn/src/market-data.test.ts
+++ b/services/bayn/src/market-data.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 
 import {
+  verifyFinalizedCalendar,
   verifyFinalizedManifest,
   verifyFinalizedSnapshot,
   type SnapshotRequest,
@@ -188,6 +189,18 @@ describe('finalized Signal snapshot reader', () => {
       sessionCount: 2,
     })
     expect(() => verifyFinalizedManifest([], fixture.request)).toThrow('0 manifests; expected exactly one')
+  })
+
+  test('precommits the exact input manifest from manifest and calendar rows without bars', () => {
+    const fixture = makeFixture()
+    const inspection = verifyFinalizedCalendar(
+      { manifests: fixture.rows.manifests, sessions: fixture.rows.sessions },
+      fixture.request,
+    )
+    const snapshot = verifyFinalizedSnapshot(fixture.rows, fixture.request)
+
+    expect(inspection.manifest).toEqual(snapshot.manifest)
+    expect(inspection.sessionDates).toEqual(['2025-01-02', '2025-01-03'])
   })
 
   test('rejects duplicate manifests, sessions, and bars', () => {

--- a/services/bayn/src/market-data.ts
+++ b/services/bayn/src/market-data.ts
@@ -115,8 +115,14 @@ export interface MarketDataSnapshot {
   readonly manifest: InputManifest
 }
 
+export interface MarketDataInspection {
+  readonly manifest: InputManifest
+  readonly sessionDates: readonly IsoDate[]
+}
+
 export interface MarketDataService {
   readonly check: Effect.Effect<FinalizedSnapshotProvenance, OperationalError>
+  readonly inspect: Effect.Effect<MarketDataInspection, OperationalError>
   readonly load: Effect.Effect<MarketDataSnapshot, OperationalError>
 }
 
@@ -265,10 +271,21 @@ export const verifyFinalizedManifest = (
   request: SnapshotRequest,
 ): FinalizedSnapshotProvenance => verifyManifest(manifests, request).finalizedSnapshot
 
-export const verifyFinalizedSnapshot = (rows: SnapshotRows, request: SnapshotRequest): MarketDataSnapshot => {
-  const { finalizedSnapshot, manifest, universe } = verifyManifest(rows.manifests, request)
+interface VerifiedCalendar {
+  readonly verifiedManifest: VerifiedManifest
+  readonly orderedSessions: readonly SignalSessionRow[]
+  readonly boundedSessions: readonly SignalSessionRow[]
+  readonly inputManifest: InputManifest
+}
 
-  const orderedSessions = [...rows.sessions].sort((left, right) => left.session_date.localeCompare(right.session_date))
+const verifyCalendar = (
+  sessions: readonly SignalSessionRow[],
+  manifests: readonly SignalManifestRow[],
+  request: SnapshotRequest,
+): VerifiedCalendar => {
+  const verifiedManifest = verifyManifest(manifests, request)
+  const { finalizedSnapshot, manifest, universe } = verifiedManifest
+  const orderedSessions = [...sessions].sort((left, right) => left.session_date.localeCompare(right.session_date))
   const sessionDates = new Set<string>()
   for (const session of orderedSessions) {
     if (session.snapshot_id !== request.snapshotId) throw new Error('exchange session has a mixed snapshot ID')
@@ -290,7 +307,51 @@ export const verifyFinalizedSnapshot = (rows: SnapshotRows, request: SnapshotReq
   if (canonicalHashV1(orderedSessions.map(withoutSnapshot)) !== manifest.sessions_content_hash) {
     throw new Error('exchange-session content hash is invalid')
   }
+  assertBoundSessions(sessionDates, request.bounds)
+  const boundedSessions = orderedSessions.filter(
+    (session) => session.session_date >= request.bounds.dataStart && session.session_date <= request.bounds.dataEnd,
+  )
+  const symbols: SymbolCoverage[] = universe.map((symbol) => ({
+    symbol,
+    rows: boundedSessions.length,
+    firstSession: boundedSessions[0].session_date as IsoDate,
+    lastSession: boundedSessions.at(-1)!.session_date as IsoDate,
+  }))
+  const manifestMaterial: Omit<InputManifest, 'hash'> = {
+    schemaVersion: 'bayn.input-manifest.v2',
+    database,
+    tables,
+    finalizedSnapshot,
+    bounds: request.bounds,
+    rowCount: boundedSessions.length * universe.length,
+    sessionCount: boundedSessions.length,
+    firstSession: boundedSessions[0].session_date as IsoDate,
+    lastSession: boundedSessions.at(-1)!.session_date as IsoDate,
+    symbols,
+  }
+  return {
+    verifiedManifest,
+    orderedSessions,
+    boundedSessions,
+    inputManifest: { ...manifestMaterial, hash: canonicalHashV1(manifestMaterial) },
+  }
+}
 
+export const verifyFinalizedCalendar = (
+  rows: Pick<SnapshotRows, 'sessions' | 'manifests'>,
+  request: SnapshotRequest,
+): MarketDataInspection => {
+  const calendar = verifyCalendar(rows.sessions, rows.manifests, request)
+  return {
+    manifest: calendar.inputManifest,
+    sessionDates: calendar.boundedSessions.map((session) => session.session_date as IsoDate),
+  }
+}
+
+export const verifyFinalizedSnapshot = (rows: SnapshotRows, request: SnapshotRequest): MarketDataSnapshot => {
+  const calendar = verifyCalendar(rows.sessions, rows.manifests, request)
+  const { manifest, universe } = calendar.verifiedManifest
+  const sessionDates = new Set(calendar.orderedSessions.map((session) => session.session_date))
   const orderedBars = [...rows.bars].sort((left, right) =>
     left.session_date === right.session_date
       ? left.symbol.localeCompare(right.symbol)
@@ -318,7 +379,7 @@ export const verifyFinalizedSnapshot = (rows: SnapshotRows, request: SnapshotReq
   if (orderedBars.length !== manifest.bar_count) throw new Error('adjusted-bar count does not match manifest')
   if ([...actualSymbols].sort().join(',') !== universe.join(','))
     throw new Error('snapshot universe does not match request')
-  for (const session of orderedSessions) {
+  for (const session of calendar.orderedSessions) {
     for (const symbol of universe) {
       if (!barKeys.has(`${symbol}\u001f${session.session_date}`)) {
         throw new Error(`incomplete snapshot: missing ${symbol} ${session.session_date}`)
@@ -328,40 +389,14 @@ export const verifyFinalizedSnapshot = (rows: SnapshotRows, request: SnapshotReq
   if (canonicalHashV1(orderedBars.map(withoutSnapshot)) !== manifest.bars_content_hash) {
     throw new Error('adjusted-bar content hash is invalid')
   }
-  assertBoundSessions(sessionDates, request.bounds)
-  const boundedSessions = orderedSessions.filter(
-    (session) => session.session_date >= request.bounds.dataStart && session.session_date <= request.bounds.dataEnd,
-  )
-  const boundedSessionDates = new Set(boundedSessions.map((session) => session.session_date))
+  const boundedSessionDates = new Set(calendar.boundedSessions.map((session) => session.session_date))
   const boundedRows = orderedBars.filter((bar) => boundedSessionDates.has(bar.session_date))
-  if (boundedRows.length !== boundedSessions.length * universe.length) {
+  if (boundedRows.length !== calendar.inputManifest.rowCount) {
     throw new Error('bounded snapshot is not a complete symbol-session product')
-  }
-
-  const symbols: SymbolCoverage[] = universe.map((symbol) => {
-    const symbolRows = boundedRows.filter((bar) => bar.symbol === symbol)
-    return {
-      symbol,
-      rows: symbolRows.length,
-      firstSession: symbolRows[0].session_date as IsoDate,
-      lastSession: symbolRows.at(-1)!.session_date as IsoDate,
-    }
-  })
-  const manifestMaterial: Omit<InputManifest, 'hash'> = {
-    schemaVersion: 'bayn.input-manifest.v2',
-    database,
-    tables,
-    finalizedSnapshot,
-    bounds: request.bounds,
-    rowCount: boundedRows.length,
-    sessionCount: boundedSessions.length,
-    firstSession: boundedSessions[0].session_date as IsoDate,
-    lastSession: boundedSessions.at(-1)!.session_date as IsoDate,
-    symbols,
   }
   return {
     bars: boundedRows.map((row) => toDailyBar(row, manifest.schema_version)),
-    manifest: { ...manifestMaterial, hash: canonicalHashV1(manifestMaterial) },
+    manifest: calendar.inputManifest,
   }
 }
 
@@ -414,11 +449,7 @@ const makeMarketData = (
         WHERE snapshot_id = ${sql.param('String', config.clickhouse.snapshotId)}
         ORDER BY finalized_at
       `.pipe(sql.withQueryId(`bayn-manifest-${config.clickhouse.snapshotId.slice(-32)}`))
-    const loadRows = Effect.gen(function* () {
-      const manifests = yield* loadManifests
-      const [sessions, bars] = yield* Effect.all(
-        [
-          sql`
+    const loadSessions = sql`
             SELECT
               snapshot_id,
               calendar_version,
@@ -430,8 +461,8 @@ const makeMarketData = (
             FROM signal.exchange_sessions_v1
             WHERE snapshot_id = ${sql.param('String', config.clickhouse.snapshotId)}
             ORDER BY session_date
-          `.pipe(sql.withQueryId(`bayn-sessions-${config.clickhouse.snapshotId.slice(-32)}`)),
-          sql`
+          `.pipe(sql.withQueryId(`bayn-sessions-${config.clickhouse.snapshotId.slice(-32)}`))
+    const loadBars = sql`
             SELECT
               snapshot_id,
               symbol,
@@ -450,12 +481,7 @@ const makeMarketData = (
             FROM signal.adjusted_daily_bars_v2
             WHERE snapshot_id = ${sql.param('String', config.clickhouse.snapshotId)}
             ORDER BY session_date, symbol
-          `.pipe(sql.withQueryId(`bayn-bars-${config.clickhouse.snapshotId.slice(-32)}`)),
-        ],
-        { concurrency: 2 },
-      )
-      return { bars, sessions, manifests }
-    })
+          `.pipe(sql.withQueryId(`bayn-bars-${config.clickhouse.snapshotId.slice(-32)}`))
 
     const request = (observedAt: string): SnapshotRequest => ({
       snapshotId: config.clickhouse.snapshotId,
@@ -485,11 +511,25 @@ const makeMarketData = (
             : operationalError('market-data', 'check', 'failed to check finalized Signal snapshot', cause),
         ),
       ),
+      inspect: Effect.gen(function* () {
+        const observedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
+        const [manifests, sessions] = yield* Effect.all([loadManifests, loadSessions], { concurrency: 2 })
+        const rows = decodeSnapshotRows([], sessions, manifests)
+        return yield* verify('inspect', () => verifyFinalizedCalendar(rows, request(observedAt)))
+      }).pipe(
+        Effect.mapError((cause) =>
+          cause instanceof OperationalError
+            ? cause
+            : operationalError('market-data', 'inspect', 'failed to inspect finalized Signal calendar', cause),
+        ),
+      ),
       load: Effect.gen(function* () {
         const observedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
-        const raw = yield* loadRows
+        const [manifests, sessions, bars] = yield* Effect.all([loadManifests, loadSessions, loadBars], {
+          concurrency: 3,
+        })
         return yield* verify('verify', () =>
-          verifyFinalizedSnapshot(decodeSnapshotRows(raw.bars, raw.sessions, raw.manifests), request(observedAt)),
+          verifyFinalizedSnapshot(decodeSnapshotRows(bars, sessions, manifests), request(observedAt)),
         )
       }).pipe(
         Effect.mapError((cause) =>

--- a/services/bayn/src/qualification.test.ts
+++ b/services/bayn/src/qualification.test.ts
@@ -6,14 +6,21 @@ import {
   defaultQualificationStatisticsPolicyDocument,
   makeQualificationLock,
   makeQualificationPolicyDocument,
+  makeQualificationResult,
   QualificationLockSchema,
   type QualificationLockMaterial,
 } from './qualification'
+import {
+  analyzeQualification,
+  defaultQualificationStatisticsPolicy,
+  type QualificationSeries,
+} from './qualification-statistics'
 
 const policy = (name: string) => makeQualificationPolicyDocument(`bayn.${name}.v1`, { name, enabled: true })
 
 const material: QualificationLockMaterial = {
-  schemaVersion: 'bayn.qualification-lock.v1' as const,
+  schemaVersion: 'bayn.qualification-lock.v2' as const,
+  candidateRunId: 'a'.repeat(64),
   protocolHash: '1'.repeat(64),
   sourceRevision: '2'.repeat(40),
   image: {
@@ -76,6 +83,7 @@ describe('qualification lock', () => {
     const baseline = makeQualificationLock(material).lockId
     const variants = [
       { ...material, sourceRevision: 'a'.repeat(40) },
+      { ...material, candidateRunId: 'b'.repeat(64) },
       { ...material, protocolHash: 'b'.repeat(64) },
       { ...material, image: { ...material.image, digest: `sha256:${'c'.repeat(64)}` } },
       { ...material, universeRationale: `${material.universeRationale} No substitutions.` },
@@ -115,5 +123,81 @@ describe('qualification lock', () => {
 
     const lock = makeQualificationLock(material)
     expect(() => Schema.decodeUnknownSync(QualificationLockSchema)({ ...lock, lockId: '0'.repeat(64) })).toThrow()
+  })
+})
+
+const qualificationSeries = (): QualificationSeries => {
+  const sessionDate = (index: number): `${number}-${number}-${number}` => {
+    const date = new Date('2000-01-01T00:00:00.000Z')
+    date.setUTCDate(date.getUTCDate() + index)
+    return date.toISOString().slice(0, 10) as `${number}-${number}-${number}`
+  }
+  const blockCount = 90
+  return {
+    schemaVersion: 'bayn.qualification-series.v1',
+    runId: material.candidateRunId,
+    observations: Array.from({ length: blockCount * 21 + 10 }, (_, index) => {
+      const noise = (((index * 17) % 23) - 11) / 100_000
+      return {
+        sessionDate: sessionDate(index),
+        strategyReturn: 0.0005 + noise,
+        cashReturn: 0,
+        buyAndHoldReturn: 0.00015 + noise * 1.1,
+        directVolatilityReturn: 0.0001 + noise * 0.8,
+      }
+    }),
+    rebalanceExecutionDates: Array.from({ length: blockCount + 1 }, (_, index) => sessionDate(index * 21)),
+  }
+}
+
+describe('qualification result', () => {
+  test('qualifies only when both locked economic and statistical gates pass', () => {
+    const lock = makeQualificationLock(material)
+    const analysis = analyzeQualification(
+      qualificationSeries(),
+      defaultQualificationStatisticsPolicy,
+      material.priorTrialRunIds,
+    )
+    const passingVerdict = {
+      status: 'PASS' as const,
+      gates: [{ name: 'benchmark_sharpe_improvement', passed: true, actual: 0.1, required: '>0' }],
+    }
+    const qualified = makeQualificationResult(lock, passingVerdict, analysis)
+    const rejected = makeQualificationResult(
+      lock,
+      {
+        status: 'FAIL_CLOSED',
+        gates: [{ name: 'benchmark_sharpe_improvement', passed: false, actual: -0.1, required: '>0' }],
+      },
+      analysis,
+    )
+
+    expect(analysis.status).toBe('PASS')
+    expect(qualified).toMatchObject({ verdict: 'QUALIFIED', reasonCodes: [] })
+    expect(rejected).toMatchObject({
+      verdict: 'REJECTED',
+      reasonCodes: ['EVALUATION_BENCHMARK_SHARPE_IMPROVEMENT_FAILED'],
+    })
+    expect(qualified.resultHash).toMatch(/^[0-9a-f]{64}$/)
+    expect(() => makeQualificationResult(lock, { ...passingVerdict, status: 'FAIL_CLOSED' }, analysis)).toThrow(
+      'must match every economic gate outcome',
+    )
+  })
+
+  test('rejects analysis from a different candidate or prior-trial lineage', () => {
+    const lock = makeQualificationLock(material)
+    const wrongLineage = analyzeQualification(qualificationSeries(), defaultQualificationStatisticsPolicy, [])
+    const wrongCandidate = analyzeQualification(
+      { ...qualificationSeries(), runId: 'b'.repeat(64) },
+      defaultQualificationStatisticsPolicy,
+      material.priorTrialRunIds,
+    )
+
+    const passingVerdict = {
+      status: 'PASS' as const,
+      gates: [{ name: 'benchmark_sharpe_improvement', passed: true, actual: 0.1, required: '>0' }],
+    }
+    expect(() => makeQualificationResult(lock, passingVerdict, wrongLineage)).toThrow('prior-trial lineage')
+    expect(() => makeQualificationResult(lock, passingVerdict, wrongCandidate)).toThrow('run IDs must match')
   })
 })

--- a/services/bayn/src/qualification.ts
+++ b/services/bayn/src/qualification.ts
@@ -2,7 +2,12 @@ import { Schema } from 'effect'
 
 import { EvaluationBoundsSchema, IsoDateSchema, Sha256Schema } from './contracts'
 import { canonicalHashV1, canonicalJsonV1 } from './hash'
-import { defaultQualificationStatisticsPolicy } from './qualification-statistics'
+import {
+  QualificationAnalysisSchema,
+  defaultQualificationStatisticsPolicy,
+  type QualificationAnalysis,
+} from './qualification-statistics'
+import type { EconomicVerdict } from './types'
 
 const StrictParseOptions = { onExcessProperty: 'error' } as const
 const NonEmptyString = Schema.String.check(
@@ -74,7 +79,8 @@ export const QualificationDataSchema = QualificationDataBase.check(
 )
 
 const QualificationLockMaterialBase = Schema.Struct({
-  schemaVersion: Schema.Literal('bayn.qualification-lock.v1'),
+  schemaVersion: Schema.Literal('bayn.qualification-lock.v2'),
+  candidateRunId: Sha256Schema,
   protocolHash: Sha256Schema,
   sourceRevision: SourceRevision,
   image: Schema.Struct({
@@ -150,3 +156,93 @@ export const defaultQualificationStatisticsPolicyDocument = makeQualificationPol
   defaultQualificationStatisticsPolicy.schemaVersion,
   defaultQualificationStatisticsPolicy,
 )
+
+const GateScalar = Schema.Union([Schema.Finite, Schema.Boolean, Schema.String])
+const EconomicVerdictSchema = Schema.Struct({
+  status: Schema.Literals(['PASS', 'FAIL_CLOSED']),
+  gates: Schema.Array(
+    Schema.Struct({
+      name: NonEmptyString,
+      passed: Schema.Boolean,
+      actual: GateScalar,
+      required: GateScalar,
+    }),
+  ).check(Schema.isMinLength(1)),
+})
+
+const QualificationResultMaterial = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.qualification-result.v2'),
+  lockId: Sha256Schema,
+  runId: Sha256Schema,
+  verdict: Schema.Literals(['QUALIFIED', 'REJECTED']),
+  evaluationVerdict: EconomicVerdictSchema,
+  analysis: QualificationAnalysisSchema,
+  reasonCodes: Schema.Array(NonEmptyString),
+})
+
+const QualificationResultBase = Schema.Struct({
+  ...QualificationResultMaterial.fields,
+  resultHash: Sha256Schema,
+})
+
+export const QualificationResultSchema = QualificationResultBase.check(
+  Schema.makeFilter((result: typeof QualificationResultBase.Type) => {
+    const { resultHash, ...material } = result
+    const economicPass = result.evaluationVerdict.gates.every((gate) => gate.passed)
+    const shouldQualify = economicPass && result.analysis.status === 'PASS'
+    const issues: Schema.FilterIssue[] = [...canonicalListIssues('reasonCodes', result.reasonCodes)]
+    if (result.runId !== result.analysis.runId) {
+      issues.push({ path: ['runId'], issue: 'must match the statistical analysis run ID' })
+    }
+    if (result.verdict !== (shouldQualify ? 'QUALIFIED' : 'REJECTED')) {
+      issues.push({ path: ['verdict'], issue: 'must match the economic and statistical gates' })
+    }
+    if (result.evaluationVerdict.status !== (economicPass ? 'PASS' : 'FAIL_CLOSED')) {
+      issues.push({ path: ['evaluationVerdict', 'status'], issue: 'must match every economic gate outcome' })
+    }
+    if ((shouldQualify && result.reasonCodes.length !== 0) || (!shouldQualify && result.reasonCodes.length === 0)) {
+      issues.push({ path: ['reasonCodes'], issue: 'must explain every rejection and be empty only when qualified' })
+    }
+    if (resultHash !== canonicalHashV1(material)) {
+      issues.push({ path: ['resultHash'], issue: 'must match the canonical result content hash' })
+    }
+    return issues
+  }),
+)
+export type QualificationResult = typeof QualificationResultSchema.Type
+
+const resultReason = (name: string): string =>
+  `EVALUATION_${name
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')}_FAILED`
+
+const decodeResultSync = Schema.decodeUnknownSync(QualificationResultSchema, StrictParseOptions)
+
+export const makeQualificationResult = (
+  lock: QualificationLock,
+  evaluationVerdict: EconomicVerdict,
+  analysis: QualificationAnalysis,
+): QualificationResult => {
+  if (lock.candidateRunId !== analysis.runId) {
+    throw new TypeError('qualification lock, candidate, and analysis run IDs must match')
+  }
+  if (canonicalHashV1(lock.priorTrialRunIds) !== canonicalHashV1(analysis.priorTrialRunIds)) {
+    throw new TypeError('qualification analysis must use the locked prior-trial lineage')
+  }
+  const economicReasons = evaluationVerdict.gates.filter((gate) => !gate.passed).map((gate) => resultReason(gate.name))
+  const reasonCodes = [...new Set([...economicReasons, ...analysis.reasonCodes])].sort()
+  const material = {
+    schemaVersion: 'bayn.qualification-result.v2' as const,
+    lockId: lock.lockId,
+    runId: lock.candidateRunId,
+    verdict:
+      evaluationVerdict.status === 'PASS' && analysis.status === 'PASS'
+        ? ('QUALIFIED' as const)
+        : ('REJECTED' as const),
+    evaluationVerdict,
+    analysis,
+    reasonCodes,
+  }
+  return decodeResultSync({ ...material, resultHash: canonicalHashV1(material) })
+}

--- a/services/bayn/src/resources.test.ts
+++ b/services/bayn/src/resources.test.ts
@@ -59,6 +59,13 @@ const successfulJournal: JournalService = {
 
 const marketDataService = (load: MarketDataService['load']): MarketDataService => ({
   check: Effect.sync(() => makeSnapshot().manifest.finalizedSnapshot),
+  inspect: Effect.sync(() => {
+    const snapshot = makeSnapshot()
+    return {
+      manifest: snapshot.manifest,
+      sessionDates: [...new Set(snapshot.bars.map((bar) => bar.sessionDate))].sort(),
+    }
+  }),
   load,
 })
 
@@ -67,6 +74,9 @@ const successfulEvidenceStore: EvidenceStoreService = {
   read: () => Effect.succeed(Option.none()),
   readArtifactItems: () => Effect.succeed(Option.none()),
   recover: () => Effect.succeed(Option.none()),
+  listPriorTrials: Effect.succeed([]),
+  openQualification: ({ lock }) => Effect.succeed({ state: 'ACQUIRED', lock }),
+  readQualification: () => Effect.succeed(Option.none()),
   persist: ({ evaluation }) =>
     Effect.succeed({
       runId: evaluation.runId,

--- a/services/bayn/src/strategy-service.ts
+++ b/services/bayn/src/strategy-service.ts
@@ -1,28 +1,104 @@
 import { Context, Layer } from 'effect'
 
 import type { RuntimeProvenance } from './contracts'
-import { evaluateTsmom, identifyTsmomRun } from './strategy'
-import type { DailyBar, EvaluationResult, InputManifest, TsmomProtocol } from './types'
+import {
+  defaultQualificationStatisticsPolicyDocument,
+  makeQualificationLock,
+  makeQualificationPolicyDocument,
+  type QualificationLock,
+} from './qualification'
+import {
+  analyzeQualification,
+  defaultQualificationStatisticsPolicy,
+  prepareQualificationSeries,
+  type QualificationAnalysis,
+} from './qualification-statistics'
+import { evaluateTsmom, prepareTsmomQualification } from './strategy'
+import type { DailyBar, EvaluationResult, InputManifest, IsoDate, TsmomProtocol } from './types'
 
 export interface StrategyService {
   readonly name: string
   readonly universe: readonly string[]
   readonly parameters: unknown
   readonly provenance: RuntimeProvenance
-  readonly identify: (manifest: InputManifest) => string
   readonly evaluate: (bars: readonly DailyBar[], manifest: InputManifest) => EvaluationResult
+  readonly prepareLock: (
+    manifest: InputManifest,
+    sessionDates: readonly IsoDate[],
+    priorTrialRunIds: readonly string[],
+  ) => QualificationLock
+  readonly analyze: (evaluation: EvaluationResult, priorTrialRunIds: readonly string[]) => QualificationAnalysis
 }
 
 export class Strategy extends Context.Service<Strategy, StrategyService>()('bayn/Strategy') {}
 
-export const makeTsmomStrategy = (protocol: TsmomProtocol, provenance: RuntimeProvenance): StrategyService => ({
-  name: 'tsmom',
-  universe: protocol.universe,
-  parameters: protocol,
-  provenance,
-  identify: (manifest) => identifyTsmomRun(manifest, protocol, provenance),
-  evaluate: (bars, manifest) => evaluateTsmom(bars, manifest, protocol, provenance),
-})
+export const makeTsmomStrategy = (protocol: TsmomProtocol, provenance: RuntimeProvenance): StrategyService => {
+  const benchmarkPolicy = makeQualificationPolicyDocument('bayn.tsmom-benchmark-policy.v1', {
+    schemaVersion: 'bayn.tsmom-benchmark-policy.v1',
+    comparison: 'stronger-of-buy-and-hold-or-direct-volatility-timing',
+    excessReturnBasis: 'after-cost-over-cash',
+    sharpeBasis: 'daily-excess-over-cash',
+    alignment: 'candidate-sessions-and-exposure-rules',
+  })
+  const thresholdPolicy = makeQualificationPolicyDocument('bayn.tsmom-threshold-policy.v1', {
+    schemaVersion: 'bayn.tsmom-threshold-policy.v1',
+    thresholds: protocol.thresholds,
+  })
+  const executionPolicy = makeQualificationPolicyDocument(
+    protocol.executionModel.schemaVersion,
+    protocol.executionModel,
+  )
+
+  return {
+    name: 'tsmom',
+    universe: protocol.universe,
+    parameters: protocol,
+    provenance,
+    evaluate: (bars, manifest) => evaluateTsmom(bars, manifest, protocol, provenance),
+    prepareLock: (manifest, sessionDates, priorTrialRunIds) => {
+      const precommit = prepareTsmomQualification(sessionDates, manifest, protocol, provenance)
+      const snapshot = manifest.finalizedSnapshot
+      return makeQualificationLock({
+        schemaVersion: 'bayn.qualification-lock.v2',
+        candidateRunId: precommit.candidateRunId,
+        protocolHash: precommit.protocolHash,
+        sourceRevision: provenance.sourceRevision,
+        image: provenance.image,
+        universe: protocol.universe,
+        universeRationale:
+          'Committed cross-asset ETF universe from bayn.tsmom.protocol.v2 with complete finalized SIP/all adjusted daily coverage.',
+        data: {
+          snapshotId: snapshot.snapshotId,
+          publicationId: snapshot.publicationId,
+          contentHash: snapshot.contentHash,
+          sessionsContentHash: snapshot.sessionsContentHash,
+          provider: snapshot.source,
+          sourceFeed: snapshot.sourceFeed,
+          adjustment: snapshot.adjustment,
+          calendarVersion: snapshot.calendarVersion,
+          firstSession: snapshot.firstSession,
+          lastSession: snapshot.lastSession,
+          selectedSessionCount: precommit.selectedSessionCount,
+          selectedRebalanceCount: precommit.selectedRebalanceCount,
+          bounds: manifest.bounds,
+        },
+        policies: {
+          benchmark: benchmarkPolicy,
+          thresholds: thresholdPolicy,
+          uncertainty: defaultQualificationStatisticsPolicyDocument,
+          execution: executionPolicy,
+        },
+        priorTrialRunIds,
+      })
+    },
+    analyze: (evaluation, priorTrialRunIds) =>
+      analyzeQualification(
+        prepareQualificationSeries(evaluation),
+        defaultQualificationStatisticsPolicy,
+        priorTrialRunIds,
+      ),
+  }
+}
 
 export const TsmomStrategyLayer = (protocol: TsmomProtocol, provenance: RuntimeProvenance) =>
   Layer.succeed(Strategy, makeTsmomStrategy(protocol, provenance))

--- a/services/bayn/src/strategy.test.ts
+++ b/services/bayn/src/strategy.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 
 import { makeStrategyProtocolHash } from './contracts'
-import { calculatePerformanceMetrics, evaluateTsmom, makeTsmomDecision } from './strategy'
+import { calculatePerformanceMetrics, evaluateTsmom, makeTsmomDecision, prepareTsmomQualification } from './strategy'
 import { canonicalHashV1 } from './hash'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
 import type { FillEvent } from './types'
@@ -61,6 +61,21 @@ describe('TSMOM economic evaluator', () => {
         targetWeights: firstDecision.targetWeights,
       })
     }
+  })
+
+  test('precommits the exact evaluation window from calendar dates without price access', () => {
+    const snapshot = makeSnapshot()
+    const provenance = makeTestProvenance()
+    const sessionDates = [...new Set(snapshot.bars.map((bar) => bar.sessionDate))].sort()
+    const precommit = prepareTsmomQualification(sessionDates, snapshot.manifest, fixtureProtocol, provenance)
+    const evaluation = evaluateTsmom(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance)
+
+    expect(precommit.candidateRunId).toBe(evaluation.runId)
+    expect(precommit.protocolHash).toBe(evaluation.protocolHash)
+    expect(precommit.selectedSessionCount).toBe(evaluation.simulation.dailyMarks.length)
+    expect(precommit.selectedRebalanceCount).toBe(evaluation.signalDecisions.length)
+    expect(precommit.signalDates).toEqual(evaluation.signalDecisions.map((decision) => decision.signalDate))
+    expect(precommit.executionDates).toEqual(evaluation.signalDecisions.map((decision) => decision.executionDate))
   })
 
   test('changes run identity when source, image, behavior, input, or parameters change', () => {

--- a/services/bayn/src/strategy.ts
+++ b/services/bayn/src/strategy.ts
@@ -119,9 +119,9 @@ const alignBars = (
   return aligned
 }
 
-const isMonthEnd = (sessions: readonly AlignedSession[], index: number): boolean => {
-  const currentMonth = sessions[index].date.slice(0, 7)
-  const nextMonth = sessions[index + 1]?.date.slice(0, 7)
+const isMonthEnd = (sessionDates: readonly IsoDate[], index: number): boolean => {
+  const currentMonth = sessionDates[index].slice(0, 7)
+  const nextMonth = sessionDates[index + 1]?.slice(0, 7)
   return nextMonth !== undefined && currentMonth !== nextMonth
 }
 
@@ -779,11 +779,78 @@ const makeTsmomEvaluationIdentity = (
   return { runId, protocolHash }
 }
 
-export const identifyTsmomRun = (
+interface TsmomEvaluationWindow {
+  readonly signalIndices: readonly number[]
+  readonly startIndex: number
+  readonly evaluationEndExclusive: number
+}
+
+export interface TsmomQualificationPrecommit {
+  readonly candidateRunId: string
+  readonly protocolHash: string
+  readonly selectedSessionCount: number
+  readonly selectedRebalanceCount: number
+  readonly signalDates: readonly IsoDate[]
+  readonly executionDates: readonly IsoDate[]
+}
+
+const selectTsmomEvaluationWindow = (
+  sessionDates: readonly IsoDate[],
+  inputManifest: InputManifest,
+  protocol: TsmomProtocol,
+): TsmomEvaluationWindow => {
+  if (
+    sessionDates.length !== inputManifest.sessionCount ||
+    sessionDates[0] !== inputManifest.firstSession ||
+    sessionDates.at(-1) !== inputManifest.lastSession ||
+    sessionDates.some((date, index) => index > 0 && date <= sessionDates[index - 1])
+  ) {
+    throw new Error('qualification calendar does not match the input manifest')
+  }
+  const maximumLookback = Math.max(...protocol.lookbacks)
+  const signalIndices = sessionDates
+    .map((_, index) => index)
+    .filter(
+      (index) =>
+        index >= maximumLookback &&
+        index < sessionDates.length - 1 &&
+        isMonthEnd(sessionDates, index) &&
+        sessionDates[index - maximumLookback] >= inputManifest.bounds.lookbackStart &&
+        sessionDates[index + 1] >= inputManifest.bounds.evaluationStart &&
+        sessionDates[index + 1] <= inputManifest.bounds.evaluationEnd,
+    )
+  if (signalIndices.length === 0) {
+    throw new Error('dataset has no eligible month-end signal followed by an execution session')
+  }
+  const startIndex = signalIndices[0] + 1
+  const evaluationEndExclusive = sessionDates.findIndex((date) => date > inputManifest.bounds.evaluationEnd)
+  const boundedEnd = evaluationEndExclusive === -1 ? sessionDates.length : evaluationEndExclusive
+  const selectedSessionCount = boundedEnd - startIndex
+  if (selectedSessionCount < protocol.thresholds.minimumObservations) {
+    throw new Error(
+      `dataset has ${selectedSessionCount} comparable observations; ${protocol.thresholds.minimumObservations} required`,
+    )
+  }
+  return { signalIndices, startIndex, evaluationEndExclusive: boundedEnd }
+}
+
+export const prepareTsmomQualification = (
+  sessionDates: readonly IsoDate[],
   inputManifest: InputManifest,
   protocol: TsmomProtocol,
   provenance: RuntimeProvenance,
-): string => makeTsmomEvaluationIdentity(inputManifest, protocol, provenance).runId
+): TsmomQualificationPrecommit => {
+  const { runId, protocolHash } = makeTsmomEvaluationIdentity(inputManifest, protocol, provenance)
+  const window = selectTsmomEvaluationWindow(sessionDates, inputManifest, protocol)
+  return {
+    candidateRunId: runId,
+    protocolHash,
+    selectedSessionCount: window.evaluationEndExclusive - window.startIndex,
+    selectedRebalanceCount: window.signalIndices.length,
+    signalDates: window.signalIndices.map((index) => sessionDates[index]),
+    executionDates: window.signalIndices.map((index) => sessionDates[index + 1]),
+  }
+}
 
 export const evaluateTsmom = (
   bars: readonly DailyBar[],
@@ -793,27 +860,11 @@ export const evaluateTsmom = (
 ): EvaluationResult => {
   const { runId, protocolHash } = makeTsmomEvaluationIdentity(inputManifest, protocol, provenance)
   const sessions = alignBars(bars, protocol.universe, inputManifest)
+  const sessionDates = sessions.map((session) => session.date)
+  const window = selectTsmomEvaluationWindow(sessionDates, inputManifest, protocol)
   const maximumLookback = Math.max(...protocol.lookbacks)
-  const signalIndices = sessions
-    .map((_, index) => index)
-    .filter(
-      (index) =>
-        index >= maximumLookback &&
-        index < sessions.length - 1 &&
-        isMonthEnd(sessions, index) &&
-        sessions[index - maximumLookback].date >= inputManifest.bounds.lookbackStart &&
-        sessions[index + 1].date >= inputManifest.bounds.evaluationStart &&
-        sessions[index + 1].date <= inputManifest.bounds.evaluationEnd,
-    )
-  if (signalIndices.length === 0)
-    throw new Error('dataset has no eligible month-end signal followed by an execution session')
-  const startIndex = signalIndices[0] + 1
-  const evaluationSessions = sessions.filter((session) => session.date <= inputManifest.bounds.evaluationEnd)
-  if (evaluationSessions.length - startIndex < protocol.thresholds.minimumObservations) {
-    throw new Error(
-      `dataset has ${evaluationSessions.length - startIndex} comparable observations; ${protocol.thresholds.minimumObservations} required`,
-    )
-  }
+  const { signalIndices, startIndex } = window
+  const evaluationSessions = sessions.slice(0, window.evaluationEndExclusive)
 
   const strategyTargets: Target[] = signalIndices.map((signalIndex) => {
     const closes = Object.fromEntries(


### PR DESCRIPTION
## Summary

- inspects the finalized Signal manifest and calendar before any candidate bar read, then opens one immutable candidate and snapshot lock
- commits the full evaluation graph and one deterministic statistical qualification result atomically; incomplete locks fail closed and block bypass or later candidates
- carries burned and terminal attempts into multiplicity lineage, prevents evidence truncation, and exposes the terminal result through status and continuous health verification
- removes the now-unused strategy identity method and keeps the runtime to one strategy capability, one startup path, and the existing observe-only HTTP surface

## Related Issues

PROOMPT-367

## Testing

- `bun run tsc`
- `bun run lint:oxlint`
- `bun run lint:oxlint:type`
- `bun run build`
- `bun test` (90 passed, 19 PostgreSQL tests skipped by the default isolated-database guard)
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:55432/bayn_test bun test src/db/evidence-store.integration.test.ts` (17 passed)

## Breaking Changes

The qualification lock and result contracts advance from v1 to v2. Migration 0005 adds candidate and result bindings and assumes the existing qualification lock and result tables are empty, matching the verified production state. Deployment must promote the qualification-aware image and the new finalized Signal snapshot in the same GitOps commit so the old runtime cannot observe that snapshot first.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; breaking and rollout implications are documented.
- [x] Service documentation and path-specific agent guidance are updated.
