### PR TITLE
chore(bayn): promote image sha-b0dfaac26c8e55c39c55aa75c7b7f3686e784543

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: bayn
         app.kubernetes.io/part-of: bayn
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-21T01:44:20Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-21T03:06:24Z"
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
@@ -47,11 +47,11 @@ spec:
               protocol: TCP
           env:
             - name: BAYN_CODE_REVISION
-              value: 0fc400af4fff32109d4009e74e5700b47df64992
+              value: b0dfaac26c8e55c39c55aa75c7b7f3686e784543
             - name: BAYN_IMAGE_REPOSITORY
               value: registry.ide-newton.ts.net/lab/bayn
             - name: BAYN_IMAGE_DIGEST
-              value: sha256:07562aa643834b3b2a4458b69234c5b3093fc8bb97de574af9c40e6b4de64b54
+              value: sha256:e225540b24f749bb8a1743948c9c01768b443b3d51e42c12f1f4f617a67c9819
             - name: BAYN_HEALTH_INTERVAL_MS
               value: "30000"
             - name: BAYN_OPERATION_TIMEOUT_MS

--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -18,5 +18,5 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/bayn
     newName: registry.ide-newton.ts.net/lab/bayn
-    newTag: "sha-0fc400af4fff32109d4009e74e5700b47df64992"
-    digest: sha256:07562aa643834b3b2a4458b69234c5b3093fc8bb97de574af9c40e6b4de64b54
+    newTag: "sha-b0dfaac26c8e55c39c55aa75c7b7f3686e784543"
+    digest: sha256:e225540b24f749bb8a1743948c9c01768b443b3d51e42c12f1f4f617a67c9819


### PR DESCRIPTION
## Summary

Promote the immutable Bayn image, activate the Bayn Argo application, and bind runtime evidence to its
source commit.

- Source commit: `b0dfaac26c8e55c39c55aa75c7b7f3686e784543`
- Image tag: `sha-b0dfaac26c8e55c39c55aa75c7b7f3686e784543`
- Image digest: `sha256:e225540b24f749bb8a1743948c9c01768b443b3d51e42c12f1f4f617a67c9819`

## Related Issues

PROOMPT-353

## Testing

- OCI index contains `linux/amd64` and `linux/arm64`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents exact validation.
- [x] Runtime source revision and image digest are immutable.
- [x] No broker or capital-promotion authority is introduced.