### PR TITLE
chore(bayn): promote locked qualification snapshot

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -47,11 +47,11 @@ spec:
               protocol: TCP
           env:
             - name: BAYN_CODE_REVISION
-              value: 0fc400af4fff32109d4009e74e5700b47df64992
+              value: b0dfaac26c8e55c39c55aa75c7b7f3686e784543
             - name: BAYN_IMAGE_REPOSITORY
               value: registry.ide-newton.ts.net/lab/bayn
             - name: BAYN_IMAGE_DIGEST
-              value: sha256:07562aa643834b3b2a4458b69234c5b3093fc8bb97de574af9c40e6b4de64b54
+              value: sha256:e225540b24f749bb8a1743948c9c01768b443b3d51e42c12f1f4f617a67c9819
             - name: BAYN_HEALTH_INTERVAL_MS
               value: "30000"
             - name: BAYN_OPERATION_TIMEOUT_MS
@@ -69,21 +69,21 @@ spec:
                   name: bayn-clickhouse-auth
                   key: password
             - name: BAYN_SIGNAL_SNAPSHOT_ID
-              value: e6ff31d2b08ec246876c4b45937838f0e3b4f5167c682afd6c2f10c46acaab20
+              value: 0e3188062fb6781f9dfdc048b4bfe9846d8f4ce74c5e429e296e3ebcd75e93a5
             - name: BAYN_SIGNAL_PUBLICATION_ASOF
-              value: "2026-07-17"
+              value: "2026-07-20"
             - name: BAYN_SIGNAL_CALENDAR_VERSION
               value: alpaca-us-equity-calendar-v1
             - name: BAYN_SIGNAL_DATA_START
               value: "2017-01-03"
             - name: BAYN_SIGNAL_DATA_END
-              value: "2026-07-17"
+              value: "2026-07-20"
             - name: BAYN_SIGNAL_LOOKBACK_START
               value: "2017-01-03"
             - name: BAYN_SIGNAL_EVALUATION_START
               value: "2018-01-03"
             - name: BAYN_SIGNAL_EVALUATION_END
-              value: "2026-07-17"
+              value: "2026-07-20"
             - name: BAYN_POSTGRES_URL
               valueFrom:
                 secretKeyRef:

--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -18,5 +18,5 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/bayn
     newName: registry.ide-newton.ts.net/lab/bayn
-    newTag: "sha-0fc400af4fff32109d4009e74e5700b47df64992"
-    digest: sha256:07562aa643834b3b2a4458b69234c5b3093fc8bb97de574af9c40e6b4de64b54
+    newTag: "sha-b0dfaac26c8e55c39c55aa75c7b7f3686e784543"
+    digest: sha256:e225540b24f749bb8a1743948c9c01768b443b3d51e42c12f1f4f617a67c9819


### PR DESCRIPTION
## Summary

- Promote the multi-architecture Bayn image built from `b0dfaac26c8e55c39c55aa75c7b7f3686e784543`, pinned to OCI digest `sha256:e225540b24f749bb8a1743948c9c01768b443b3d51e42c12f1f4f617a67c9819`.
- Atomically bind that qualification-aware runtime to finalized Signal snapshot `0e3188062fb6781f9dfdc048b4bfe9846d8f4ce74c5e429e296e3ebcd75e93a5` and its July 20, 2026 data bounds.
- Preserve the single-replica, `maxSurge: 0` rollout and existing observe-only authority. On startup, the new runtime applies migration 0005, locks the snapshot before reading candidate bars, and writes one terminal qualification result or fails closed.
- Rollback is a Git revert to the previous image and snapshot. The immutable qualification lock/result remains retained as evidence and prevents the snapshot from being silently reused.

## Related Issues

PROOMPT-367

## Testing

- `bun run lint:argocd` — 0 invalid resources and 0 errors across all Argo validation batches.
- `kustomize build --enable-helm argocd/applications/bayn` — rendered the expected source revision, image digest, snapshot ID, July 20 bounds, and content-addressed image reference.
- `git diff --check`

## Breaking Changes

None. This is a controlled Bayn rollout with no broker or capital-authority expansion.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked in PROOMPT-367.
