### PR TITLE
feat(bayn): add independent qualification audit

### DIFF
--- a/nix/images/bayn.nix
+++ b/nix/images/bayn.nix
@@ -24,8 +24,8 @@ import ./bun-workspace-service.nix {
   serviceName = "bayn";
   packageName = "@proompteng/bayn";
   depsHash = {
-    x86_64-linux = "sha256-oWH35nt1Tr6Qui/nR+KyRzYkPbbsdU9qLNgP9Tnj/VE=";
-    aarch64-linux = "sha256-vwq/G5KoemqzCPHdojueGrv9iUpK4ue2Pi18wHdV25c=";
+    x86_64-linux = "sha256-CeOs78vla5p146UrjZeHkM6vEKYxwEPjVj81e9c8I9g=";
+    aarch64-linux = "sha256-JrQvA54yWRDbChXXtaJfx1foKMOHxYTA0mG9DOLzyj4=";
   };
   installFilters = [
     "@proompteng/bayn"

--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -85,6 +85,30 @@ bun run --filter @proompteng/bayn build
 bun run --filter @proompteng/bayn lint:oxlint
 ```
 
+For a terminal locked candidate, `audit:qualification` performs an operator-side, read-only reproduction. It reads the
+evidence graph in one PostgreSQL `REPEATABLE READ, READ ONLY` transaction, reloads the finalized Signal snapshot,
+replays the candidate and all benchmarks without importing the production strategy, checks ClickHouse query-start
+chronology with a separately supplied audit principal, and checks authoritative `origin/main` history. It emits one
+`bayn.qualification-audit.v1` JSON report and exits nonzero on any failed check. Run it twice and require identical
+`auditHash` values.
+
+```sh
+BAYN_AUDIT_RUN_ID=<run-id> \
+BAYN_AUDIT_POSTGRES_URL=<authenticated-postgres-uri> \
+BAYN_AUDIT_SIGNAL_URL=<signal-clickhouse-url> \
+BAYN_AUDIT_SIGNAL_USERNAME=<readonly-bayn-user> \
+BAYN_AUDIT_SIGNAL_PASSWORD=<readonly-bayn-password> \
+BAYN_AUDIT_CLICKHOUSE_URL=<clickhouse-audit-url> \
+BAYN_AUDIT_CLICKHOUSE_USERNAME=<query-log-audit-user> \
+BAYN_AUDIT_CLICKHOUSE_PASSWORD=<query-log-audit-password> \
+BAYN_AUDIT_REPOSITORY_PATH=<lab-checkout> \
+  bun run --filter @proompteng/bayn audit:qualification
+```
+
+The audit command is not part of the deployed runtime and never calls TigerBeetle or a broker. Its privileged
+ClickHouse credential is operator-supplied only to read `system.query_log`; the service keeps its normal Signal
+read-only identity.
+
 The PostgreSQL integration suite requires an isolated local database whose name ends in `_test`:
 
 ```sh

--- a/services/bayn/package.json
+++ b/services/bayn/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "audit:qualification": "bun src/qualification-audit-command.ts",
     "build": "bun build src/index.ts --target=node --external tigerbeetle-node --outdir=dist",
     "dev": "BAYN_PROVENANCE_MODE=development bun --watch src/index.ts",
     "start": "BAYN_PROVENANCE_MODE=development node dist/index.js",

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -164,6 +164,35 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     ])
   })
 
+  test('keeps the audit snapshot repeatable-read and rejects writes', async () => {
+    const observed = await runtime.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* PgClient.PgClient
+        yield* sql`CREATE TABLE bayn_audit_read_only_probe (id integer PRIMARY KEY)`
+        const transaction = yield* sql.withTransaction(
+          Effect.gen(function* () {
+            yield* sql`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY`
+            const mode = yield* sql<{ isolation: string; read_only: boolean }>`
+              SELECT
+                current_setting('transaction_isolation') AS isolation,
+                current_setting('transaction_read_only') = 'on' AS read_only
+            `
+            const write = yield* Effect.exit(sql`INSERT INTO bayn_audit_read_only_probe (id) VALUES (1)`)
+            return { mode: mode[0], write }
+          }),
+        )
+        const rows = yield* sql<{ count: number }>`
+          SELECT count(*)::integer AS count FROM bayn_audit_read_only_probe
+        `
+        return { ...transaction, rows }
+      }),
+    )
+
+    expect(observed.mode).toEqual({ isolation: 'repeatable read', read_only: true })
+    expect(Exit.isFailure(observed.write)).toBe(true)
+    expect(observed.rows).toEqual([{ count: 0 }])
+  })
+
   test('commits one complete run and deduplicates an exact replay', async () => {
     const input = makeInput()
     const result = await runtime.runPromise(

--- a/services/bayn/src/market-data.ts
+++ b/services/bayn/src/market-data.ts
@@ -416,7 +416,7 @@ const decodeSnapshotRows = (
 })
 
 const makeMarketData = (
-  config: RuntimeConfig,
+  config: Pick<RuntimeConfig, 'clickhouse' | 'operationTimeoutMs'>,
   universe: readonly string[],
 ): Effect.Effect<MarketDataService, never, ClickhouseClient.ClickhouseClient> =>
   Effect.gen(function* () {
@@ -542,7 +542,7 @@ const makeMarketData = (
   })
 
 export const MarketDataLive = (
-  config: RuntimeConfig,
+  config: Pick<RuntimeConfig, 'clickhouse' | 'operationTimeoutMs'>,
   universe: readonly string[],
 ): Layer.Layer<MarketData, never, ClickhouseClient.ClickhouseClient> =>
   Layer.effect(MarketData, makeMarketData(config, universe))

--- a/services/bayn/src/qualification-audit-command.ts
+++ b/services/bayn/src/qualification-audit-command.ts
@@ -1,0 +1,480 @@
+import { NodeHttpClient, NodeRuntime, NodeServices } from '@effect/platform-node'
+import { ClickhouseClient } from '@effect/sql-clickhouse'
+import { PgClient } from '@effect/sql-pg'
+import { Cause, Config, Effect, FileSystem, Layer, Logger, Redacted, Schema, Stdio, Stream } from 'effect'
+import { ChildProcess, ChildProcessSpawner } from 'effect/unstable/process'
+
+import { decodeInputManifestArtifact } from './evidence-contracts'
+import { MarketData, MarketDataLive } from './market-data'
+import { TsmomProtocolSchema } from './protocol'
+import {
+  auditQualification,
+  type AuditDatabaseSnapshot,
+  type RepositoryAudit,
+  type SignalAccessRecord,
+} from './qualification-audit'
+import type { InputManifest, TsmomProtocol } from './types'
+
+const StrictParseOptions = { onExcessProperty: 'error' } as const
+const Sha256 = Schema.String.check(Schema.isPattern(/^[0-9a-f]{64}$/))
+const PositiveInteger = Schema.Int.check(Schema.isGreaterThan(0))
+const NonNegativeInteger = Schema.Int.check(Schema.isGreaterThanOrEqualTo(0))
+const IsoInstant = Schema.String.check(Schema.isPattern(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z$/))
+
+const RunRow = Schema.Struct({
+  run_id: Sha256,
+  protocol_hash: Sha256,
+  snapshot_id: Sha256,
+  evaluation_schema_version: Schema.String,
+  source_revision: Schema.String,
+  image_repository: Schema.String,
+  image_digest: Schema.String,
+  strategy_name: Schema.String,
+  initial_capital_micros: Schema.String,
+  status: Schema.String,
+  artifact_count: PositiveInteger,
+  event_count: NonNegativeInteger,
+  gate_count: PositiveInteger,
+  schema_version: Schema.String,
+  behavior_hash: Sha256,
+  parameter_hash: Sha256,
+  parameters: Schema.Unknown,
+})
+const ArtifactRow = Schema.Struct({
+  artifact_name: Schema.String,
+  schema_version: Schema.String,
+  content_hash: Sha256,
+  payload: Schema.Unknown,
+})
+const EventRow = Schema.Struct({
+  ordinal: NonNegativeInteger,
+  event_id: Sha256,
+  event_kind: Schema.String,
+  content_hash: Sha256,
+  payload: Schema.Unknown,
+})
+const GateRow = Schema.Struct({
+  ordinal: NonNegativeInteger,
+  gate_name: Schema.String,
+  passed: Schema.Boolean,
+  actual: Schema.Unknown,
+  required: Schema.Unknown,
+  content_hash: Sha256,
+})
+const StatusRow = Schema.Struct({ status: Schema.String, detail: Schema.Unknown })
+const TrialRow = Schema.Struct({ run_id: Sha256 })
+const QualificationRow = Schema.Struct({
+  lock_created_at: IsoInstant,
+  result_committed_at: IsoInstant,
+  lock_id: Sha256,
+  analysis_hash: Sha256,
+  result_hash: Sha256,
+  verdict: Schema.Literals(['QUALIFIED', 'REJECTED']),
+  lock_payload: Schema.Unknown,
+  result_payload: Schema.Unknown,
+})
+const ReadOnlyRow = Schema.Struct({ read_only: Schema.Boolean })
+const AccessRow = Schema.Struct({
+  query_id: Schema.String,
+  query_start_time: IsoInstant,
+  user: Schema.String,
+  kind: Schema.Literals(['manifest', 'sessions', 'bars']),
+})
+
+const decodeRunRows = Schema.decodeUnknownSync(Schema.Array(RunRow), StrictParseOptions)
+const decodeArtifactRows = Schema.decodeUnknownSync(Schema.Array(ArtifactRow), StrictParseOptions)
+const decodeEventRows = Schema.decodeUnknownSync(Schema.Array(EventRow), StrictParseOptions)
+const decodeGateRows = Schema.decodeUnknownSync(Schema.Array(GateRow), StrictParseOptions)
+const decodeStatusRows = Schema.decodeUnknownSync(Schema.Array(StatusRow), StrictParseOptions)
+const decodeTrialRows = Schema.decodeUnknownSync(Schema.Array(TrialRow), StrictParseOptions)
+const decodeQualificationRows = Schema.decodeUnknownSync(Schema.Array(QualificationRow), StrictParseOptions)
+const decodeReadOnlyRows = Schema.decodeUnknownSync(Schema.Array(ReadOnlyRow), StrictParseOptions)
+const decodeAccessRows = Schema.decodeUnknownSync(Schema.Array(AccessRow), StrictParseOptions)
+
+const exactlyOne = <A>(values: readonly A[], name: string): A => {
+  if (values.length !== 1) throw new Error(`${name} returned ${values.length} rows; expected exactly one`)
+  return values[0]
+}
+
+const config = Config.all({
+  runId: Config.schema(Sha256, 'BAYN_AUDIT_RUN_ID'),
+  postgresUrl: Config.redacted('BAYN_AUDIT_POSTGRES_URL'),
+  postgresTls: Config.boolean('BAYN_AUDIT_POSTGRES_TLS').pipe(Config.withDefault(false)),
+  postgresCaPath: Config.string('BAYN_AUDIT_POSTGRES_CA_PATH').pipe(Config.withDefault('')),
+  signalUrl: Config.string('BAYN_AUDIT_SIGNAL_URL'),
+  signalUsername: Config.string('BAYN_AUDIT_SIGNAL_USERNAME'),
+  signalPassword: Config.redacted('BAYN_AUDIT_SIGNAL_PASSWORD'),
+  auditClickhouseUrl: Config.string('BAYN_AUDIT_CLICKHOUSE_URL'),
+  auditClickhouseUsername: Config.string('BAYN_AUDIT_CLICKHOUSE_USERNAME'),
+  auditClickhousePassword: Config.redacted('BAYN_AUDIT_CLICKHOUSE_PASSWORD'),
+  repositoryPath: Config.string('BAYN_AUDIT_REPOSITORY_PATH').pipe(Config.withDefault('.')),
+  operationTimeoutMs: Config.schema(PositiveInteger, 'BAYN_AUDIT_OPERATION_TIMEOUT_MS').pipe(
+    Config.withDefault(60_000),
+  ),
+})
+
+type AuditConfig = Config.Success<typeof config>
+
+const postgresLayer = (input: AuditConfig) => {
+  const readCertificate = Effect.gen(function* () {
+    if (!input.postgresTls) return undefined
+    if (input.postgresCaPath.length === 0) throw new Error('BAYN_AUDIT_POSTGRES_CA_PATH is required with TLS')
+    const fileSystem = yield* FileSystem.FileSystem
+    return yield* fileSystem.readFileString(input.postgresCaPath)
+  })
+  return Layer.unwrap(
+    readCertificate.pipe(
+      Effect.map((ca) =>
+        PgClient.layerFrom(
+          PgClient.make({
+            url: input.postgresUrl,
+            ssl: ca === undefined ? undefined : { ca, rejectUnauthorized: true },
+            applicationName: 'bayn-qualification-audit',
+            connectTimeout: input.operationTimeoutMs,
+            idleTimeout: '30 seconds',
+            maxConnections: 1,
+            minConnections: 0,
+            transformJson: false,
+          }),
+        ),
+      ),
+    ),
+  )
+}
+
+const readDatabase = (runId: string): Effect.Effect<AuditDatabaseSnapshot, unknown, PgClient.PgClient> =>
+  Effect.gen(function* () {
+    const sql = yield* PgClient.PgClient
+    return yield* sql.withTransaction(
+      Effect.gen(function* () {
+        yield* sql`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY`
+        const readOnly = exactlyOne(
+          decodeReadOnlyRows(yield* sql`SELECT current_setting('transaction_read_only') = 'on' AS read_only`),
+          'transaction mode',
+        )
+        const run = exactlyOne(
+          decodeRunRows(
+            yield* sql`
+              SELECT
+                run.run_id,
+                run.protocol_hash,
+                run.snapshot_id,
+                run.evaluation_schema_version,
+                run.source_revision,
+                run.image_repository,
+                run.image_digest,
+                run.strategy_name,
+                run.initial_capital_micros::text AS initial_capital_micros,
+                run.status,
+                (SELECT count(*)::integer FROM bayn_evaluation_artifacts WHERE run_id = run.run_id) AS artifact_count,
+                (SELECT count(*)::integer FROM bayn_evaluation_events WHERE run_id = run.run_id) AS event_count,
+                (SELECT count(*)::integer FROM bayn_gate_outcomes WHERE run_id = run.run_id) AS gate_count,
+                protocol.schema_version,
+                protocol.behavior_hash,
+                protocol.parameter_hash,
+                protocol.parameters
+              FROM bayn_evaluation_runs AS run
+              JOIN bayn_protocol_locks AS protocol USING (protocol_hash)
+              WHERE run.run_id = ${runId}
+            `,
+          ),
+          'evaluation run',
+        )
+        const artifacts = decodeArtifactRows(
+          yield* sql`
+            SELECT artifact_name, schema_version, content_hash, payload
+            FROM bayn_evaluation_artifacts
+            WHERE run_id = ${runId}
+            ORDER BY artifact_name
+          `,
+        )
+        const events = decodeEventRows(
+          yield* sql`
+            SELECT ordinal, event_id, event_kind, content_hash, payload
+            FROM bayn_evaluation_events
+            WHERE run_id = ${runId}
+            ORDER BY ordinal
+          `,
+        )
+        const gates = decodeGateRows(
+          yield* sql`
+            SELECT ordinal, gate_name, passed, actual, required, content_hash
+            FROM bayn_gate_outcomes
+            WHERE run_id = ${runId}
+            ORDER BY ordinal
+          `,
+        )
+        const statuses = decodeStatusRows(
+          yield* sql`
+            SELECT status, detail
+            FROM bayn_status_history
+            WHERE run_id = ${runId}
+            ORDER BY sequence
+          `,
+        )
+        const trials = decodeTrialRows(
+          yield* sql`
+            SELECT run_id
+            FROM bayn_qualification_trials
+            WHERE observed_at < (
+              SELECT created_at FROM bayn_qualification_locks WHERE candidate_run_id = ${runId}
+            )
+            ORDER BY run_id
+          `,
+        )
+        const qualification = exactlyOne(
+          decodeQualificationRows(
+            yield* sql`
+              SELECT
+                to_char(lock.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"') AS lock_created_at,
+                to_char(result.committed_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"') AS result_committed_at,
+                lock.lock_id,
+                result.analysis_hash,
+                result.result_hash,
+                result.verdict,
+                lock.payload AS lock_payload,
+                result.payload AS result_payload
+              FROM bayn_qualification_locks AS lock
+              JOIN bayn_qualification_results AS result USING (lock_id)
+              WHERE lock.candidate_run_id = ${runId}
+            `,
+          ),
+          'terminal qualification',
+        )
+        return {
+          transactionReadOnly: readOnly.read_only,
+          protocol: {
+            protocolHash: run.protocol_hash,
+            schemaVersion: run.schema_version,
+            strategyName: run.strategy_name,
+            behaviorHash: run.behavior_hash,
+            parameterHash: run.parameter_hash,
+            parameters: run.parameters,
+          },
+          run: {
+            runId: run.run_id,
+            protocolHash: run.protocol_hash,
+            snapshotId: run.snapshot_id,
+            evaluationSchemaVersion: run.evaluation_schema_version,
+            sourceRevision: run.source_revision,
+            imageRepository: run.image_repository,
+            imageDigest: run.image_digest,
+            strategyName: run.strategy_name,
+            initialCapitalMicros: run.initial_capital_micros,
+            status: run.status,
+            artifactCount: run.artifact_count,
+            eventCount: run.event_count,
+            gateCount: run.gate_count,
+          },
+          artifacts: artifacts.map((row) => ({
+            name: row.artifact_name,
+            schemaVersion: row.schema_version,
+            contentHash: row.content_hash,
+            payload: row.payload,
+          })),
+          events: events.map((row) => ({
+            ordinal: row.ordinal,
+            id: row.event_id,
+            kind: row.event_kind,
+            contentHash: row.content_hash,
+            payload: row.payload,
+          })),
+          gates: gates.map((row) => ({
+            ordinal: row.ordinal,
+            name: row.gate_name,
+            passed: row.passed,
+            actual: row.actual,
+            required: row.required,
+            contentHash: row.content_hash,
+          })),
+          statuses,
+          priorTrialRunIds: trials.map((row) => row.run_id),
+          qualification: {
+            lockCreatedAt: qualification.lock_created_at,
+            resultCommittedAt: qualification.result_committed_at,
+            storedLockId: qualification.lock_id,
+            storedAnalysisHash: qualification.analysis_hash,
+            storedResultHash: qualification.result_hash,
+            storedVerdict: qualification.verdict,
+            lock: qualification.lock_payload,
+            result: qualification.result_payload,
+          },
+        }
+      }),
+    )
+  })
+
+const loadSignal = (
+  input: AuditConfig,
+  database: AuditDatabaseSnapshot,
+  manifest: InputManifest,
+  protocol: TsmomProtocol,
+) => {
+  const layer = MarketDataLive(
+    {
+      operationTimeoutMs: input.operationTimeoutMs,
+      clickhouse: {
+        url: input.signalUrl,
+        username: input.signalUsername,
+        password: input.signalPassword,
+        snapshotId: manifest.finalizedSnapshot.snapshotId,
+        publicationAsOf: manifest.finalizedSnapshot.asOfSession,
+        calendarVersion: manifest.finalizedSnapshot.calendarVersion,
+        bounds: manifest.bounds,
+      },
+    },
+    protocol.universe,
+  ).pipe(
+    Layer.provide(
+      ClickhouseClient.layer({
+        url: input.signalUrl,
+        username: input.signalUsername,
+        password: Redacted.value(input.signalPassword),
+        database: 'signal',
+        application: 'bayn-qualification-audit',
+        request_timeout: input.operationTimeoutMs,
+      }),
+    ),
+    Layer.provide(NodeHttpClient.layerNodeHttp),
+  )
+  return MarketData.pipe(
+    Effect.flatMap((marketData) => marketData.load),
+    Effect.provide(layer),
+  )
+}
+
+const readSignalAccess = (
+  input: AuditConfig,
+  database: AuditDatabaseSnapshot,
+  finalizedAt: string,
+): Effect.Effect<readonly SignalAccessRecord[], unknown> => {
+  const program = Effect.gen(function* () {
+    const sql = yield* ClickhouseClient.ClickhouseClient
+    const rows = yield* sql`
+      SELECT
+        query_id,
+        formatDateTime(toTimeZone(query_start_time_microseconds, 'UTC'), '%Y-%m-%dT%H:%i:%S.%fZ') AS query_start_time,
+        user,
+        multiIf(
+          positionCaseInsensitive(query, 'snapshot_manifests_v1') > 0, 'manifest',
+          positionCaseInsensitive(query, 'exchange_sessions_v1') > 0, 'sessions',
+          'bars'
+        ) AS kind
+      FROM system.query_log
+      WHERE type = 'QueryStart'
+        AND user = 'bayn'
+        AND query_start_time_microseconds >= parseDateTime64BestEffort(${sql.param('String', finalizedAt)}, 6)
+        AND query_start_time_microseconds <= parseDateTime64BestEffort(
+          ${sql.param('String', database.qualification.resultCommittedAt)},
+          6
+        )
+        AND position(query, ${sql.param('String', database.run.snapshotId)}) > 0
+        AND (
+          positionCaseInsensitive(query, 'snapshot_manifests_v1') > 0
+          OR positionCaseInsensitive(query, 'exchange_sessions_v1') > 0
+          OR positionCaseInsensitive(query, 'adjusted_daily_bars_v2') > 0
+        )
+      ORDER BY query_start_time_microseconds, query_id
+    `.pipe(sql.withQueryId(`bayn-audit-access-${database.run.runId.slice(-24)}`))
+    return decodeAccessRows(rows).map((row) => ({
+      queryId: row.query_id,
+      queryStartTime: row.query_start_time,
+      user: row.user,
+      kind: row.kind,
+    }))
+  })
+  return program.pipe(
+    Effect.provide(
+      ClickhouseClient.layer({
+        url: input.auditClickhouseUrl,
+        username: input.auditClickhouseUsername,
+        password: Redacted.value(input.auditClickhousePassword),
+        database: 'system',
+        application: 'bayn-qualification-audit',
+        request_timeout: input.operationTimeoutMs,
+      }),
+    ),
+    Effect.provide(NodeHttpClient.layerNodeHttp),
+  )
+}
+
+const repositoryAudit = (
+  repositoryPath: string,
+  sourceRevision: string,
+  lockCreatedAt: string,
+  resultIdentity: readonly string[],
+): Effect.Effect<RepositoryAudit, unknown, ChildProcessSpawner.ChildProcessSpawner> =>
+  Effect.gen(function* () {
+    const processes = yield* ChildProcessSpawner.ChildProcessSpawner
+    const exists = yield* processes.exitCode(
+      ChildProcess.make('git', ['-C', repositoryPath, 'cat-file', '-e', `${sourceRevision}^{commit}`]),
+    )
+    const ancestor = yield* processes.exitCode(
+      ChildProcess.make('git', ['-C', repositoryPath, 'merge-base', '--is-ancestor', sourceRevision, 'origin/main']),
+    )
+    const pattern = resultIdentity.join('|')
+    const lines = yield* processes.lines(
+      ChildProcess.make('git', [
+        '-C',
+        repositoryPath,
+        'log',
+        'origin/main',
+        `--before=${lockCreatedAt}`,
+        '--format=%H',
+        `-G${pattern}`,
+      ]),
+    )
+    const references = new Set(lines.filter((line) => /^[0-9a-f]{40}$/.test(line)))
+    return {
+      sourceCommitExists: Number(exists) === 0,
+      sourceCommitAncestorOfMain: Number(ancestor) === 0,
+      preLockResultReferences: [...references].sort(),
+    }
+  })
+
+const main = Effect.gen(function* () {
+  const input = yield* config
+  const database = yield* readDatabase(input.runId).pipe(Effect.provide(postgresLayer(input)))
+  const inputManifestArtifact = database.artifacts.find((artifact) => artifact.name === 'input-manifest')
+  if (inputManifestArtifact === undefined) throw new Error('input-manifest artifact is missing')
+  const manifest = yield* decodeInputManifestArtifact(inputManifestArtifact.payload)
+  const protocol = yield* Schema.decodeUnknownEffect(
+    TsmomProtocolSchema,
+    StrictParseOptions,
+  )(database.protocol.parameters)
+  const signal = yield* loadSignal(input, database, manifest, protocol)
+  const signalAccess = yield* readSignalAccess(input, database, manifest.finalizedSnapshot.finalizedAt)
+  const result = database.qualification.result as Readonly<Record<string, unknown>>
+  const analysis = result.analysis as Readonly<Record<string, unknown>>
+  const repository = yield* repositoryAudit(
+    input.repositoryPath,
+    database.run.sourceRevision,
+    database.qualification.lockCreatedAt,
+    [database.run.runId, String(result.resultHash), String(analysis.analysisHash)],
+  )
+  const report = auditQualification({
+    bars: signal.bars,
+    manifest: signal.manifest,
+    protocol,
+    database,
+    signalAccess,
+    repository,
+  })
+  const stdio = yield* Stdio.Stdio
+  yield* Stream.run(Stream.make(`${JSON.stringify(report)}\n`), stdio.stdout())
+  if (report.status !== 'PASS') return yield* Effect.fail(new Error('qualification audit failed'))
+})
+
+const program = main.pipe(
+  Effect.tapCause((cause) =>
+    Cause.hasInterruptsOnly(cause)
+      ? Effect.void
+      : Effect.logError('Bayn qualification audit failed').pipe(
+          Effect.annotateLogs({ service: 'bayn-qualification-audit', cause: Cause.pretty(cause) }),
+        ),
+  ),
+  Effect.provide(Logger.layer([Logger.consoleJson])),
+  Effect.provide(NodeServices.layer),
+)
+
+NodeRuntime.runMain(program, { disableErrorReporting: true })

--- a/services/bayn/src/qualification-audit.test.ts
+++ b/services/bayn/src/qualification-audit.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, test } from 'bun:test'
+
+import { makeEquitySeriesArtifact } from './evidence-contracts'
+import { canonicalHashV1 } from './hash'
+import { makeQualificationResult } from './qualification'
+import { auditQualification, type AuditDatabaseSnapshot, type QualificationAuditInput } from './qualification-audit'
+import { makeTsmomStrategy } from './strategy-service'
+import { evaluateTsmom, summarizeEvaluation } from './strategy'
+import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
+
+const fixture = (): QualificationAuditInput => {
+  const snapshot = makeSnapshot(900)
+  const provenance = makeTestProvenance()
+  const strategy = makeTsmomStrategy(fixtureProtocol, provenance)
+  const evaluation = evaluateTsmom(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance)
+  const sessionDates = [...new Set(snapshot.bars.map((bar) => bar.sessionDate))].sort()
+  const priorTrialRunIds: readonly string[] = []
+  const lock = strategy.prepareLock(snapshot.manifest, sessionDates, priorTrialRunIds)
+  const analysis = strategy.analyze(evaluation, priorTrialRunIds)
+  const result = makeQualificationResult(lock, evaluation.verdict, analysis)
+  const reconciliation = { runId: evaluation.runId, accountCount: 14, transferCount: 900, exact: true as const }
+  const base = [
+    ['evaluation-summary', 'bayn.evaluation-summary.v3', summarizeEvaluation(evaluation)],
+    ['input-manifest', snapshot.manifest.schemaVersion, snapshot.manifest],
+    ['strategy', 'bayn.performance-metrics.v2', evaluation.strategy],
+    ['buy-and-hold', 'bayn.performance-metrics.v2', evaluation.buyAndHold],
+    ['direct-volatility-timing', 'bayn.performance-metrics.v2', evaluation.directVolTiming],
+    ['double-cost-strategy', 'bayn.performance-metrics.v2', evaluation.doubleCostStrategy],
+    [
+      'simulated-orders',
+      'bayn.simulated-orders.v2',
+      {
+        schemaVersion: 'bayn.simulated-orders.v2',
+        executionModel: evaluation.simulation.executionModel,
+        costMultiplierMicros: evaluation.simulation.costMultiplierMicros,
+        items: evaluation.simulation.orders,
+      },
+    ],
+    [
+      'cash-changes',
+      'bayn.cash-changes.v2',
+      { schemaVersion: 'bayn.cash-changes.v2', items: evaluation.simulation.cashChanges },
+    ],
+    [
+      'daily-position-marks',
+      'bayn.daily-position-marks.v3',
+      { schemaVersion: 'bayn.daily-position-marks.v3', items: evaluation.simulation.dailyMarks },
+    ],
+    [
+      'tsmom-signal-decisions',
+      'bayn.tsmom-signal-decisions.v1',
+      { schemaVersion: 'bayn.tsmom-signal-decisions.v1', items: evaluation.signalDecisions },
+    ],
+    [
+      'buy-and-hold-series',
+      'bayn.daily-performance-series.v1',
+      {
+        schemaVersion: 'bayn.daily-performance-series.v1',
+        series: 'buy-and-hold',
+        items: evaluation.benchmarkSeries.buyAndHold,
+      },
+    ],
+    [
+      'direct-volatility-timing-series',
+      'bayn.daily-performance-series.v1',
+      {
+        schemaVersion: 'bayn.daily-performance-series.v1',
+        series: 'direct-volatility-timing',
+        items: evaluation.benchmarkSeries.directVolTiming,
+      },
+    ],
+    [
+      'double-cost-strategy-series',
+      'bayn.daily-performance-series.v1',
+      {
+        schemaVersion: 'bayn.daily-performance-series.v1',
+        series: 'double-cost-strategy',
+        items: evaluation.benchmarkSeries.doubleCostStrategy,
+      },
+    ],
+    ['equity-series', 'bayn.equity-series.v1', makeEquitySeriesArtifact(evaluation.equitySeries)],
+    [
+      'marked-equity-reconciliation',
+      evaluation.markedEquityReconciliation.schemaVersion,
+      evaluation.markedEquityReconciliation,
+    ],
+    ['reconciliation', 'bayn.reconciliation.v1', reconciliation],
+  ].map(([name, schemaVersion, payload]) => ({
+    name: name as string,
+    schemaVersion: schemaVersion as string,
+    payload,
+    contentHash: canonicalHashV1(payload),
+  }))
+  const events = evaluation.events.map((event, ordinal) => ({
+    ordinal,
+    id: event.id,
+    kind: event.kind,
+    payload: event,
+    contentHash: canonicalHashV1(event),
+  }))
+  const gates = evaluation.verdict.gates.map((gate, ordinal) => ({
+    ordinal,
+    name: gate.name,
+    passed: gate.passed,
+    actual: gate.actual,
+    required: gate.required,
+    contentHash: canonicalHashV1(gate),
+  }))
+  const artifactManifest = {
+    schemaVersion: 'bayn.qualification-artifact-manifest.v1',
+    identity: {
+      runId: evaluation.runId,
+      evaluationSchemaVersion: evaluation.schemaVersion,
+      protocolHash: evaluation.protocolHash,
+      sourceRevision: provenance.sourceRevision,
+      image: provenance.image,
+      snapshotId: snapshot.manifest.finalizedSnapshot.snapshotId,
+      publicationId: snapshot.manifest.finalizedSnapshot.publicationId,
+      inputManifestHash: snapshot.manifest.hash,
+      bounds: snapshot.manifest.bounds,
+      calendarVersion: snapshot.manifest.finalizedSnapshot.calendarVersion,
+    },
+    execution: {
+      parameterSchemaVersion: provenance.strategy.parameterSchemaVersion,
+      parameterHash: provenance.strategy.parameterHash,
+      simulationSchemaVersion: evaluation.simulation.schemaVersion,
+      executionModel: evaluation.simulation.executionModel,
+      costMultiplierMicros: evaluation.simulation.costMultiplierMicros,
+    },
+    artifacts: [...base]
+      .sort((left, right) => left.name.localeCompare(right.name))
+      .map((value) => ({
+        name: value.name,
+        schemaVersion: value.schemaVersion,
+        itemCount:
+          typeof value.payload === 'object' &&
+          value.payload !== null &&
+          'items' in value.payload &&
+          Array.isArray(value.payload.items)
+            ? value.payload.items.length
+            : 0,
+        contentHash: value.contentHash,
+      })),
+    events: {
+      count: events.length,
+      contentHash: canonicalHashV1(
+        events.map(({ ordinal, id, kind, contentHash }) => ({ ordinal, id, kind, contentHash })),
+      ),
+    },
+    gates: {
+      count: gates.length,
+      contentHash: canonicalHashV1(
+        gates.map(({ ordinal, name, passed, contentHash }) => ({ ordinal, name, passed, contentHash })),
+      ),
+    },
+  }
+  const artifacts = [
+    ...base,
+    {
+      name: 'qualification-artifact-manifest',
+      schemaVersion: artifactManifest.schemaVersion,
+      payload: artifactManifest,
+      contentHash: canonicalHashV1(artifactManifest),
+    },
+  ]
+  const database: AuditDatabaseSnapshot = {
+    transactionReadOnly: true,
+    protocol: {
+      protocolHash: evaluation.protocolHash,
+      schemaVersion: fixtureProtocol.schemaVersion,
+      strategyName: 'tsmom',
+      behaviorHash: provenance.strategy.behaviorHash,
+      parameterHash: provenance.strategy.parameterHash,
+      parameters: fixtureProtocol,
+    },
+    run: {
+      runId: evaluation.runId,
+      protocolHash: evaluation.protocolHash,
+      snapshotId: snapshot.manifest.finalizedSnapshot.snapshotId,
+      evaluationSchemaVersion: evaluation.schemaVersion,
+      sourceRevision: provenance.sourceRevision,
+      imageRepository: provenance.image.repository,
+      imageDigest: provenance.image.digest,
+      strategyName: 'tsmom',
+      initialCapitalMicros: evaluation.initialCapitalMicros,
+      status: 'COMPLETE',
+      artifactCount: artifacts.length,
+      eventCount: events.length,
+      gateCount: gates.length,
+    },
+    artifacts: [...artifacts].sort((left, right) => left.name.localeCompare(right.name)),
+    events,
+    gates,
+    statuses: [
+      {
+        status: 'WRITING',
+        detail: { artifactCount: artifacts.length, eventCount: events.length, gateCount: gates.length },
+      },
+      { status: 'COMPLETE', detail: { reconciliationExact: true, verdict: evaluation.verdict.status } },
+    ],
+    priorTrialRunIds,
+    qualification: {
+      lockCreatedAt: '2026-07-20T12:00:00.000000Z',
+      resultCommittedAt: '2026-07-20T12:00:10.000000Z',
+      storedLockId: lock.lockId,
+      storedAnalysisHash: result.analysis.analysisHash,
+      storedResultHash: result.resultHash,
+      storedVerdict: result.verdict,
+      lock,
+      result,
+    },
+  }
+  return {
+    bars: snapshot.bars,
+    manifest: snapshot.manifest,
+    protocol: fixtureProtocol,
+    database,
+    signalAccess: [
+      { queryId: 'manifest', queryStartTime: '2026-07-20T11:59:59.000000Z', user: 'bayn', kind: 'manifest' },
+      { queryId: 'sessions', queryStartTime: '2026-07-20T12:00:01.000000Z', user: 'bayn', kind: 'sessions' },
+      { queryId: 'bars', queryStartTime: '2026-07-20T12:00:01.100000Z', user: 'bayn', kind: 'bars' },
+    ],
+    repository: { sourceCommitExists: true, sourceCommitAncestorOfMain: true, preLockResultReferences: [] },
+  }
+}
+
+describe('qualification audit', () => {
+  test('passes only when independent replay, lineage, chronology, and immutable evidence agree', () => {
+    const first = auditQualification(fixture())
+    const second = auditQualification(fixture())
+
+    expect(first.status).toBe('PASS')
+    expect(first.checks.every((check) => check.passed)).toBe(true)
+    expect(second.auditHash).toBe(first.auditHash)
+  })
+
+  test('fails closed on stored evidence drift', () => {
+    const input = fixture()
+    const strategy = input.database.artifacts.find((artifact) => artifact.name === 'strategy')!
+    const database = {
+      ...input.database,
+      artifacts: input.database.artifacts.map((artifact) =>
+        artifact.name === 'strategy'
+          ? { ...artifact, payload: { ...(strategy.payload as object), annualizedReturn: 99 } }
+          : artifact,
+      ),
+    }
+    const report = auditQualification({ ...input, database })
+
+    expect(report.status).toBe('FAIL')
+    expect(report.checks.find((check) => check.name === 'artifact-hashes')?.passed).toBe(false)
+    expect(report.checks.find((check) => check.name === 'reference-strategy')?.passed).toBe(false)
+  })
+
+  test('fails closed when candidate data was read before the lock', () => {
+    const input = fixture()
+    const signalAccess = input.signalAccess.map((record) =>
+      record.kind === 'bars' ? { ...record, queryStartTime: '2026-07-20T11:59:58.000000Z' } : record,
+    )
+    const report = auditQualification({ ...input, signalAccess })
+
+    expect(report.status).toBe('FAIL')
+    expect(report.checks.find((check) => check.name === 'signal-lock-before-candidate-data')?.passed).toBe(false)
+  })
+})

--- a/services/bayn/src/qualification-audit.ts
+++ b/services/bayn/src/qualification-audit.ts
@@ -1,0 +1,602 @@
+import { canonicalHashV1 } from './hash'
+import { evaluateReferenceTsmom } from './qualification-reference'
+import { reconcileMarkedEquity } from './simulation-reconciliation'
+import { makeRuntimeProvenance } from './contracts'
+import type { DailyBar, InputManifest, TsmomProtocol } from './types'
+
+export interface StoredArtifact {
+  readonly name: string
+  readonly schemaVersion: string
+  readonly contentHash: string
+  readonly payload: unknown
+}
+
+export interface StoredEvent {
+  readonly ordinal: number
+  readonly id: string
+  readonly kind: string
+  readonly contentHash: string
+  readonly payload: unknown
+}
+
+export interface StoredGate {
+  readonly ordinal: number
+  readonly name: string
+  readonly passed: boolean
+  readonly actual: unknown
+  readonly required: unknown
+  readonly contentHash: string
+}
+
+export interface AuditDatabaseSnapshot {
+  readonly transactionReadOnly: boolean
+  readonly protocol: {
+    readonly protocolHash: string
+    readonly schemaVersion: string
+    readonly strategyName: string
+    readonly behaviorHash: string
+    readonly parameterHash: string
+    readonly parameters: unknown
+  }
+  readonly run: {
+    readonly runId: string
+    readonly protocolHash: string
+    readonly snapshotId: string
+    readonly evaluationSchemaVersion: string
+    readonly sourceRevision: string
+    readonly imageRepository: string
+    readonly imageDigest: string
+    readonly strategyName: string
+    readonly initialCapitalMicros: string
+    readonly status: string
+    readonly artifactCount: number
+    readonly eventCount: number
+    readonly gateCount: number
+  }
+  readonly artifacts: readonly StoredArtifact[]
+  readonly events: readonly StoredEvent[]
+  readonly gates: readonly StoredGate[]
+  readonly statuses: readonly { readonly status: string; readonly detail: unknown }[]
+  readonly priorTrialRunIds: readonly string[]
+  readonly qualification: {
+    readonly lockCreatedAt: string
+    readonly resultCommittedAt: string
+    readonly storedLockId: string
+    readonly storedAnalysisHash: string
+    readonly storedResultHash: string
+    readonly storedVerdict: string
+    readonly lock: unknown
+    readonly result: unknown
+  }
+}
+
+export interface SignalAccessRecord {
+  readonly queryId: string
+  readonly queryStartTime: string
+  readonly user: string
+  readonly kind: 'manifest' | 'sessions' | 'bars'
+}
+
+export interface RepositoryAudit {
+  readonly sourceCommitExists: boolean
+  readonly sourceCommitAncestorOfMain: boolean
+  readonly preLockResultReferences: readonly string[]
+}
+
+export interface QualificationAuditInput {
+  readonly bars: readonly DailyBar[]
+  readonly manifest: InputManifest
+  readonly protocol: TsmomProtocol
+  readonly database: AuditDatabaseSnapshot
+  readonly signalAccess: readonly SignalAccessRecord[]
+  readonly repository: RepositoryAudit
+}
+
+export interface AuditCheck {
+  readonly name: string
+  readonly passed: boolean
+  readonly evidence: string
+}
+
+export interface QualificationAuditReport {
+  readonly schemaVersion: 'bayn.qualification-audit.v1'
+  readonly runId: string
+  readonly status: 'PASS' | 'FAIL'
+  readonly reference: {
+    readonly economicStatus: 'PASS' | 'FAIL_CLOSED'
+    readonly observations: number
+    readonly rebalanceCount: number
+  }
+  readonly evidence: {
+    readonly artifactCount: number
+    readonly eventCount: number
+    readonly gateCount: number
+    readonly lockId: string
+    readonly resultHash: string
+  }
+  readonly contamination: {
+    readonly lockCreatedAt: string
+    readonly resultCommittedAt: string
+    readonly access: readonly SignalAccessRecord[]
+  }
+  readonly repository: RepositoryAudit & { readonly sourceRevision: string }
+  readonly checks: readonly AuditCheck[]
+  readonly auditHash: string
+}
+
+type JsonObject = Readonly<Record<string, unknown>>
+
+const object = (value: unknown, name: string): JsonObject => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) throw new Error(`${name} must be an object`)
+  return value as JsonObject
+}
+
+const array = (value: unknown, name: string): readonly unknown[] => {
+  if (!Array.isArray(value)) throw new Error(`${name} must be an array`)
+  return value
+}
+
+const string = (value: unknown, name: string): string => {
+  if (typeof value !== 'string' || value.length === 0) throw new Error(`${name} must be a non-empty string`)
+  return value
+}
+
+const without = (value: JsonObject, key: string): JsonObject =>
+  Object.fromEntries(Object.entries(value).filter(([name]) => name !== key))
+
+const same = (left: unknown, right: unknown): boolean => canonicalHashV1(left) === canonicalHashV1(right)
+
+const itemCount = (payload: unknown): number => {
+  if (typeof payload !== 'object' || payload === null || !('items' in payload)) return 0
+  return Array.isArray(payload.items) ? payload.items.length : 0
+}
+
+const expectedResultReason = (gateName: string): string =>
+  `EVALUATION_${gateName
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')}_FAILED`
+
+const makeSummary = (
+  input: QualificationAuditInput,
+  reference: ReturnType<typeof evaluateReferenceTsmom>,
+  markedEquity: ReturnType<typeof reconcileMarkedEquity>['reconciliation'],
+) => ({
+  schemaVersion: 'bayn.evaluation-summary.v3',
+  runId: reference.runId,
+  evaluationSchemaVersion: 'bayn.evaluation.v4',
+  codeRevision: input.database.run.sourceRevision,
+  protocolHash: reference.protocolHash,
+  initialCapitalMicros: input.protocol.initialCapitalMicros,
+  input: {
+    snapshotId: input.manifest.finalizedSnapshot.snapshotId,
+    publicationId: input.manifest.finalizedSnapshot.publicationId,
+    manifestHash: input.manifest.hash,
+    bounds: input.manifest.bounds,
+    rowCount: input.manifest.rowCount,
+    sessionCount: input.manifest.sessionCount,
+    symbols: input.manifest.symbols.map((coverage) => coverage.symbol),
+  },
+  strategy: reference.strategy.metrics,
+  buyAndHold: reference.buyAndHold.metrics,
+  directVolTiming: reference.directVolTiming.metrics,
+  doubleCostStrategy: reference.doubleCostStrategy.metrics,
+  verdict: reference.verdict,
+  eventCount: reference.strategy.events.length,
+  signalDecisionCount: reference.strategy.decisions.length,
+  orderCount: reference.strategy.trace!.orders.length,
+  cashChangeCount: reference.strategy.trace!.cashChanges.length,
+  dailyMarkCount: reference.strategy.trace!.dailyMarks.length,
+  benchmarkSeriesCounts: {
+    buyAndHold: reference.buyAndHold.daily.length,
+    directVolTiming: reference.directVolTiming.daily.length,
+    doubleCostStrategy: reference.doubleCostStrategy.daily.length,
+  },
+  markedEquityReconciliation: markedEquity,
+})
+
+export const auditQualification = (input: QualificationAuditInput): QualificationAuditReport => {
+  const checks: AuditCheck[] = []
+  const check = (name: string, passed: boolean, evidence: string): void => {
+    checks.push({ name, passed, evidence })
+  }
+  const database = input.database
+  const artifact = new Map(database.artifacts.map((value) => [value.name, value]))
+  const lock = object(database.qualification.lock, 'qualification lock')
+  const result = object(database.qualification.result, 'qualification result')
+  const lockId = string(lock.lockId, 'qualification lock ID')
+  const resultHash = string(result.resultHash, 'qualification result hash')
+  const provenance = makeRuntimeProvenance({
+    sourceRevision: database.run.sourceRevision,
+    image: { repository: database.run.imageRepository, digest: database.run.imageDigest },
+    strategy: {
+      name: database.protocol.strategyName,
+      behaviorHash: database.protocol.behaviorHash,
+      parameterHash: database.protocol.parameterHash,
+      parameterSchemaVersion: database.protocol.schemaVersion,
+    },
+  })
+  const reference = evaluateReferenceTsmom(input.bars, input.manifest, input.protocol, provenance)
+  if (reference.strategy.trace === null) throw new Error('reference evaluation omitted its candidate trace')
+  const markedEquity = reconcileMarkedEquity({
+    runId: reference.runId,
+    initialCapitalMicros: input.protocol.initialCapitalMicros,
+    evaluatorTotalFeesMicros: reference.strategy.metrics.totalFeesMicros,
+    evaluatorEndingEquityMicros: reference.strategy.metrics.endingEquityMicros,
+    events: reference.strategy.events,
+    simulation: reference.strategy.trace,
+  })
+
+  check('postgres-transaction-read-only', database.transactionReadOnly, 'transaction_read_only=on')
+  check(
+    'protocol-content',
+    same(input.protocol, database.protocol.parameters) &&
+      canonicalHashV1(input.protocol) === database.protocol.parameterHash &&
+      reference.protocolHash === database.protocol.protocolHash,
+    `parameterHash=${database.protocol.parameterHash}`,
+  )
+  check(
+    'run-identity',
+    reference.runId === database.run.runId &&
+      reference.protocolHash === database.run.protocolHash &&
+      input.manifest.finalizedSnapshot.snapshotId === database.run.snapshotId &&
+      database.run.status === 'COMPLETE',
+    `runId=${database.run.runId}`,
+  )
+  check(
+    'evidence-counts',
+    database.artifacts.length === database.run.artifactCount &&
+      database.events.length === database.run.eventCount &&
+      database.gates.length === database.run.gateCount,
+    `${database.artifacts.length}/${database.events.length}/${database.gates.length}`,
+  )
+  check(
+    'artifact-hashes',
+    database.artifacts.every((value) => canonicalHashV1(value.payload) === value.contentHash),
+    `${database.artifacts.length} artifacts`,
+  )
+  const expectedArtifactSchemas = new Map<string, string>([
+    ['evaluation-summary', 'bayn.evaluation-summary.v3'],
+    ['input-manifest', input.manifest.schemaVersion],
+    ['strategy', 'bayn.performance-metrics.v2'],
+    ['buy-and-hold', 'bayn.performance-metrics.v2'],
+    ['direct-volatility-timing', 'bayn.performance-metrics.v2'],
+    ['double-cost-strategy', 'bayn.performance-metrics.v2'],
+    ['simulated-orders', 'bayn.simulated-orders.v2'],
+    ['cash-changes', 'bayn.cash-changes.v2'],
+    ['daily-position-marks', 'bayn.daily-position-marks.v3'],
+    ['tsmom-signal-decisions', 'bayn.tsmom-signal-decisions.v1'],
+    ['buy-and-hold-series', 'bayn.daily-performance-series.v1'],
+    ['direct-volatility-timing-series', 'bayn.daily-performance-series.v1'],
+    ['double-cost-strategy-series', 'bayn.daily-performance-series.v1'],
+    ['equity-series', 'bayn.equity-series.v1'],
+    ['marked-equity-reconciliation', markedEquity.reconciliation.schemaVersion],
+    ['reconciliation', 'bayn.reconciliation.v1'],
+    ['qualification-artifact-manifest', 'bayn.qualification-artifact-manifest.v1'],
+  ])
+  check(
+    'artifact-schema-versions',
+    database.artifacts.length === expectedArtifactSchemas.size &&
+      database.artifacts.every((value) => expectedArtifactSchemas.get(value.name) === value.schemaVersion),
+    `${database.artifacts.length} versioned artifacts`,
+  )
+  check(
+    'event-hashes-and-order',
+    database.events.every((value, index) => {
+      const payload = object(value.payload, `event ${index}`)
+      return (
+        value.ordinal === index &&
+        value.id === payload.id &&
+        value.kind === payload.kind &&
+        canonicalHashV1(payload) === value.contentHash
+      )
+    }),
+    `${database.events.length} events`,
+  )
+  check(
+    'gate-hashes-and-order',
+    database.gates.every(
+      (value, index) =>
+        value.ordinal === index &&
+        canonicalHashV1({ name: value.name, passed: value.passed, actual: value.actual, required: value.required }) ===
+          value.contentHash,
+    ),
+    `${database.gates.length} gates`,
+  )
+  check(
+    'status-history',
+    database.statuses.length === 2 &&
+      database.statuses[0].status === 'WRITING' &&
+      database.statuses[1].status === 'COMPLETE' &&
+      same(database.statuses[0].detail, {
+        artifactCount: database.run.artifactCount,
+        eventCount: database.run.eventCount,
+        gateCount: database.run.gateCount,
+      }) &&
+      same(database.statuses[1].detail, { reconciliationExact: true, verdict: reference.verdict.status }),
+    database.statuses.map((status) => status.status).join(' -> '),
+  )
+
+  const expectedArtifacts = new Map<string, unknown>([
+    ['evaluation-summary', makeSummary(input, reference, markedEquity.reconciliation)],
+    ['input-manifest', input.manifest],
+    ['strategy', reference.strategy.metrics],
+    ['buy-and-hold', reference.buyAndHold.metrics],
+    ['direct-volatility-timing', reference.directVolTiming.metrics],
+    ['double-cost-strategy', reference.doubleCostStrategy.metrics],
+    [
+      'simulated-orders',
+      {
+        schemaVersion: 'bayn.simulated-orders.v2',
+        executionModel: input.protocol.executionModel,
+        costMultiplierMicros: MICROS_STRING,
+        items: reference.strategy.trace.orders,
+      },
+    ],
+    ['cash-changes', { schemaVersion: 'bayn.cash-changes.v2', items: reference.strategy.trace.cashChanges }],
+    [
+      'daily-position-marks',
+      { schemaVersion: 'bayn.daily-position-marks.v3', items: reference.strategy.trace.dailyMarks },
+    ],
+    [
+      'tsmom-signal-decisions',
+      { schemaVersion: 'bayn.tsmom-signal-decisions.v1', items: reference.strategy.decisions },
+    ],
+    [
+      'buy-and-hold-series',
+      {
+        schemaVersion: 'bayn.daily-performance-series.v1',
+        series: 'buy-and-hold',
+        items: reference.buyAndHold.daily,
+      },
+    ],
+    [
+      'direct-volatility-timing-series',
+      {
+        schemaVersion: 'bayn.daily-performance-series.v1',
+        series: 'direct-volatility-timing',
+        items: reference.directVolTiming.daily,
+      },
+    ],
+    [
+      'double-cost-strategy-series',
+      {
+        schemaVersion: 'bayn.daily-performance-series.v1',
+        series: 'double-cost-strategy',
+        items: reference.doubleCostStrategy.daily,
+      },
+    ],
+    ['equity-series', { schemaVersion: 'bayn.equity-series.v1', items: markedEquity.equitySeries }],
+    ['marked-equity-reconciliation', markedEquity.reconciliation],
+  ])
+  for (const [name, expected] of expectedArtifacts) {
+    check(`reference-${name}`, same(artifact.get(name)?.payload, expected), `contentHash=${canonicalHashV1(expected)}`)
+  }
+  check(
+    'reference-events',
+    same(
+      database.events.map((value) => value.payload),
+      reference.strategy.events,
+    ),
+    `contentHash=${canonicalHashV1(reference.strategy.events)}`,
+  )
+  check(
+    'reference-gates',
+    same(
+      database.gates.map(({ name, passed, actual, required }) => ({ name, passed, actual, required })),
+      reference.verdict.gates,
+    ),
+    `economicStatus=${reference.verdict.status}`,
+  )
+
+  const reconciliation = object(artifact.get('reconciliation')?.payload, 'TigerBeetle reconciliation artifact')
+  check(
+    'accounting-reconciliation-identity',
+    reconciliation.runId === database.run.runId && reconciliation.exact === true,
+    `runId=${String(reconciliation.runId)} exact=${String(reconciliation.exact)}`,
+  )
+  const baseArtifacts = database.artifacts.filter((value) => value.name !== 'qualification-artifact-manifest')
+  const qualificationManifest = {
+    schemaVersion: 'bayn.qualification-artifact-manifest.v1',
+    identity: {
+      runId: database.run.runId,
+      evaluationSchemaVersion: database.run.evaluationSchemaVersion,
+      protocolHash: database.run.protocolHash,
+      sourceRevision: database.run.sourceRevision,
+      image: { repository: database.run.imageRepository, digest: database.run.imageDigest },
+      snapshotId: database.run.snapshotId,
+      publicationId: input.manifest.finalizedSnapshot.publicationId,
+      inputManifestHash: input.manifest.hash,
+      bounds: input.manifest.bounds,
+      calendarVersion: input.manifest.finalizedSnapshot.calendarVersion,
+    },
+    execution: {
+      parameterSchemaVersion: database.protocol.schemaVersion,
+      parameterHash: database.protocol.parameterHash,
+      simulationSchemaVersion: 'bayn.simulation-trace.v3',
+      executionModel: input.protocol.executionModel,
+      costMultiplierMicros: MICROS_STRING,
+    },
+    artifacts: [...baseArtifacts]
+      .sort((left, right) => left.name.localeCompare(right.name))
+      .map((value) => ({
+        name: value.name,
+        schemaVersion: value.schemaVersion,
+        itemCount: itemCount(value.payload),
+        contentHash: value.contentHash,
+      })),
+    events: {
+      count: database.events.length,
+      contentHash: canonicalHashV1(
+        database.events.map(({ ordinal, id, kind, contentHash }) => ({ ordinal, id, kind, contentHash })),
+      ),
+    },
+    gates: {
+      count: database.gates.length,
+      contentHash: canonicalHashV1(
+        database.gates.map(({ ordinal, name, passed, contentHash }) => ({ ordinal, name, passed, contentHash })),
+      ),
+    },
+  }
+  check(
+    'qualification-artifact-manifest',
+    same(artifact.get('qualification-artifact-manifest')?.payload, qualificationManifest),
+    `contentHash=${canonicalHashV1(qualificationManifest)}`,
+  )
+
+  check('lock-hash', canonicalHashV1(without(lock, 'lockId')) === lockId, `lockId=${lockId}`)
+  check(
+    'qualification-row-binding',
+    database.qualification.storedLockId === lockId &&
+      database.qualification.storedAnalysisHash ===
+        string(object(result.analysis, 'qualification analysis').analysisHash, 'analysis hash') &&
+      database.qualification.storedResultHash === resultHash &&
+      database.qualification.storedVerdict === result.verdict,
+    `storedResultHash=${database.qualification.storedResultHash}`,
+  )
+  const lockData = object(lock.data, 'qualification lock data')
+  const lockPolicies = object(lock.policies, 'qualification lock policies')
+  check(
+    'lock-candidate-binding',
+    lock.candidateRunId === database.run.runId &&
+      lock.protocolHash === database.run.protocolHash &&
+      lock.sourceRevision === database.run.sourceRevision &&
+      same(lock.image, { repository: database.run.imageRepository, digest: database.run.imageDigest }) &&
+      same(lock.universe, input.protocol.universe),
+    `candidateRunId=${String(lock.candidateRunId)}`,
+  )
+  check(
+    'lock-data-binding',
+    lockData.snapshotId === input.manifest.finalizedSnapshot.snapshotId &&
+      lockData.publicationId === input.manifest.finalizedSnapshot.publicationId &&
+      lockData.contentHash === input.manifest.finalizedSnapshot.contentHash &&
+      lockData.sessionsContentHash === input.manifest.finalizedSnapshot.sessionsContentHash &&
+      lockData.selectedSessionCount === reference.strategy.metrics.observations &&
+      lockData.selectedRebalanceCount === reference.strategy.decisions.length &&
+      same(lockData.bounds, input.manifest.bounds),
+    `snapshotId=${String(lockData.snapshotId)}`,
+  )
+  check(
+    'lock-policy-hashes',
+    Object.values(lockPolicies).every((value) => {
+      const policy = object(value, 'qualification policy')
+      return policy.contentHash === canonicalHashV1(policy.content)
+    }),
+    `${Object.keys(lockPolicies).length} policies`,
+  )
+  check(
+    'locked-prior-trial-lineage',
+    same(lock.priorTrialRunIds, [...database.priorTrialRunIds].sort()),
+    `${database.priorTrialRunIds.length} prior trials`,
+  )
+
+  const analysis = object(result.analysis, 'qualification analysis')
+  const analysisHash = string(analysis.analysisHash, 'qualification analysis hash')
+  check(
+    'analysis-hash',
+    canonicalHashV1(without(analysis, 'analysisHash')) === analysisHash,
+    `analysisHash=${analysisHash}`,
+  )
+  check('result-hash', canonicalHashV1(without(result, 'resultHash')) === resultHash, `resultHash=${resultHash}`)
+  const economicPass = reference.verdict.gates.every((gate) => gate.passed)
+  const analysisPass = analysis.status === 'PASS'
+  const expectedQualification = economicPass && analysisPass ? 'QUALIFIED' : 'REJECTED'
+  const expectedEconomicReasons = reference.verdict.gates
+    .filter((gate) => !gate.passed)
+    .map((gate) => expectedResultReason(gate.name))
+  const reasonCodes = array(result.reasonCodes, 'qualification reason codes').map((value) =>
+    string(value, 'reason code'),
+  )
+  const analysisReasonCodes = array(analysis.reasonCodes, 'qualification analysis reason codes').map((value) =>
+    string(value, 'analysis reason code'),
+  )
+  const expectedReasonCodes = [...new Set([...expectedEconomicReasons, ...analysisReasonCodes])].sort()
+  check(
+    'analysis-lineage',
+    analysis.runId === database.run.runId &&
+      same(analysis.priorTrialRunIds, lock.priorTrialRunIds) &&
+      analysis.candidateOrdinal === database.priorTrialRunIds.length + 1,
+    `candidateOrdinal=${String(analysis.candidateOrdinal)}`,
+  )
+  check(
+    'terminal-result-binding',
+    result.lockId === lockId &&
+      result.runId === database.run.runId &&
+      result.verdict === expectedQualification &&
+      same(result.evaluationVerdict, reference.verdict) &&
+      same(reasonCodes, expectedReasonCodes),
+    `verdict=${String(result.verdict)} reasons=${reasonCodes.join(',')}`,
+  )
+
+  const sortedAccess = [...input.signalAccess].sort((left, right) =>
+    left.queryStartTime === right.queryStartTime
+      ? left.queryId.localeCompare(right.queryId)
+      : left.queryStartTime.localeCompare(right.queryStartTime),
+  )
+  const candidateReads = sortedAccess.filter((value) => value.kind === 'sessions' || value.kind === 'bars')
+  const manifestReads = sortedAccess.filter((value) => value.kind === 'manifest')
+  const preLockCandidateReads = candidateReads.filter(
+    (value) => value.queryStartTime < database.qualification.lockCreatedAt,
+  )
+  check(
+    'signal-lock-before-candidate-data',
+    preLockCandidateReads.length === 0 &&
+      candidateReads.length === 2 &&
+      candidateReads.every(
+        (value) =>
+          value.queryStartTime >= database.qualification.lockCreatedAt &&
+          value.queryStartTime <= database.qualification.resultCommittedAt,
+      ),
+    `lock=${database.qualification.lockCreatedAt} candidateReads=${candidateReads
+      .map((value) => `${value.kind}@${value.queryStartTime}`)
+      .join(',')}`,
+  )
+  check(
+    'signal-manifest-inspected-before-lock',
+    manifestReads.some((value) => value.queryStartTime < database.qualification.lockCreatedAt),
+    `${manifestReads.length} manifest reads`,
+  )
+  check(
+    'signal-read-principal',
+    sortedAccess.every((value) => value.user === 'bayn'),
+    [...new Set(sortedAccess.map((value) => value.user))].join(','),
+  )
+  check(
+    'source-revision-in-repository',
+    input.repository.sourceCommitExists && input.repository.sourceCommitAncestorOfMain,
+    `sourceRevision=${database.run.sourceRevision}`,
+  )
+  check(
+    'no-pre-lock-result-reference',
+    input.repository.preLockResultReferences.length === 0,
+    input.repository.preLockResultReferences.join(',') || 'none',
+  )
+
+  const material = {
+    schemaVersion: 'bayn.qualification-audit.v1' as const,
+    runId: database.run.runId,
+    status: checks.every((value) => value.passed) ? ('PASS' as const) : ('FAIL' as const),
+    reference: {
+      economicStatus: reference.verdict.status,
+      observations: reference.strategy.metrics.observations,
+      rebalanceCount: reference.strategy.decisions.length,
+    },
+    evidence: {
+      artifactCount: database.artifacts.length,
+      eventCount: database.events.length,
+      gateCount: database.gates.length,
+      lockId,
+      resultHash,
+    },
+    contamination: {
+      lockCreatedAt: database.qualification.lockCreatedAt,
+      resultCommittedAt: database.qualification.resultCommittedAt,
+      access: sortedAccess,
+    },
+    repository: { ...input.repository, sourceRevision: database.run.sourceRevision },
+    checks,
+  }
+  return { ...material, auditHash: canonicalHashV1(material) }
+}
+
+const MICROS_STRING = '1000000'

--- a/services/bayn/src/qualification-reference.test.ts
+++ b/services/bayn/src/qualification-reference.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'bun:test'
+
+import { canonicalHashV1 } from './hash'
+import { evaluateReferenceTsmom } from './qualification-reference'
+import { evaluateTsmom } from './strategy'
+import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
+
+describe('independent qualification reference', () => {
+  test('reproduces the production strategy, benchmarks, trace, and economic gates', () => {
+    const snapshot = makeSnapshot(900)
+    const provenance = makeTestProvenance()
+    const actual = evaluateTsmom(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance)
+    const reference = evaluateReferenceTsmom(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance)
+
+    expect(reference.runId).toBe(actual.runId)
+    expect(reference.protocolHash).toBe(actual.protocolHash)
+    expect(reference.strategy.metrics).toEqual(actual.strategy)
+    expect(reference.buyAndHold.metrics).toEqual(actual.buyAndHold)
+    expect(reference.directVolTiming.metrics).toEqual(actual.directVolTiming)
+    expect(reference.doubleCostStrategy.metrics).toEqual(actual.doubleCostStrategy)
+    expect(reference.verdict).toEqual(actual.verdict)
+    expect(reference.strategy.events).toEqual(actual.events)
+    expect(reference.strategy.decisions).toEqual(actual.signalDecisions)
+    expect(reference.strategy.trace).toEqual(actual.simulation)
+    expect(reference.buyAndHold.daily).toEqual(actual.benchmarkSeries.buyAndHold)
+    expect(reference.directVolTiming.daily).toEqual(actual.benchmarkSeries.directVolTiming)
+    expect(reference.doubleCostStrategy.daily).toEqual(actual.benchmarkSeries.doubleCostStrategy)
+  })
+
+  test('binds the result to raw market data instead of accepting stored output', () => {
+    const snapshot = makeSnapshot(900)
+    const provenance = makeTestProvenance()
+    const original = evaluateReferenceTsmom(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance)
+    const bars = snapshot.bars.map((bar, index) => (index === 4_000 ? { ...bar, close: bar.close * 1.5 } : bar))
+    const changed = evaluateReferenceTsmom(bars, snapshot.manifest, fixtureProtocol, provenance)
+
+    expect(canonicalHashV1(changed.strategy.decisions)).not.toBe(canonicalHashV1(original.strategy.decisions))
+  })
+})

--- a/services/bayn/src/qualification-reference.ts
+++ b/services/bayn/src/qualification-reference.ts
@@ -1,0 +1,774 @@
+import { makeRunIdentity, makeStrategyProtocolHash, type RuntimeProvenance } from './contracts'
+import {
+  MICROS,
+  accrueCashYield,
+  calculateSessionFees,
+  desiredQuantityMicros,
+  elapsedCalendarDays,
+  makeFillTerms,
+  makeOrderOutcome,
+  microsToNumber,
+  notionalMicros,
+  ppm,
+  referencePriceMicros,
+  saleCostBasisMicros,
+  scaleQuantityMicros,
+  type FeeInput,
+  type FillTerms,
+} from './execution-model'
+import { canonicalHashV1, hashObject } from './hash'
+import type {
+  CashChange,
+  DailyBar,
+  DailyPerformancePoint,
+  DailyPositionMark,
+  DecisionEvent,
+  EconomicVerdict,
+  EvaluationEvent,
+  FeeEvent,
+  FillEvent,
+  GateResult,
+  InputManifest,
+  IsoDate,
+  PerformanceMetrics,
+  SimulatedOrder,
+  SimulationTrace,
+  TsmomDecisionPlan,
+  TsmomProtocol,
+  TsmomSignalDecision,
+} from './types'
+
+interface Session {
+  readonly date: IsoDate
+  readonly bars: Readonly<Record<string, DailyBar>>
+}
+
+interface Target {
+  readonly signalIndex: number
+  readonly executionIndex: number
+  readonly weights: Readonly<Record<string, number>>
+  readonly plan?: TsmomDecisionPlan
+}
+
+interface Position {
+  quantityMicros: bigint
+  costBasisMicros: bigint
+}
+
+interface Replay {
+  readonly metrics: PerformanceMetrics
+  readonly events: readonly EvaluationEvent[]
+  readonly decisions: readonly TsmomSignalDecision[]
+  readonly daily: readonly DailyPerformancePoint[]
+  readonly trace: SimulationTrace | null
+}
+
+export interface ReferenceEvaluation {
+  readonly runId: string
+  readonly protocolHash: string
+  readonly strategy: Replay
+  readonly buyAndHold: Replay
+  readonly directVolTiming: Replay
+  readonly doubleCostStrategy: Replay
+  readonly verdict: EconomicVerdict
+}
+
+const tradingDays = 252
+
+const roundWeight = (value: number): number => Number.parseFloat(value.toFixed(12))
+
+const average = (values: readonly number[]): number => values.reduce((sum, value) => sum + value, 0) / values.length
+
+const sampleDeviation = (values: readonly number[]): number => {
+  if (values.length < 2) return 0
+  const center = average(values)
+  const variance = values.reduce((sum, value) => sum + (value - center) ** 2, 0) / (values.length - 1)
+  return Math.sqrt(variance)
+}
+
+const align = (bars: readonly DailyBar[], manifest: InputManifest, universe: readonly string[]): readonly Session[] => {
+  if (bars.length !== manifest.rowCount) throw new Error('reference input row count differs from the manifest')
+  const expected = new Set(universe)
+  const grouped = new Map<IsoDate, Map<string, DailyBar>>()
+  for (const bar of bars) {
+    if (!expected.has(bar.symbol)) throw new Error(`reference input has unexpected symbol ${bar.symbol}`)
+    const day = grouped.get(bar.sessionDate) ?? new Map<string, DailyBar>()
+    if (day.has(bar.symbol)) throw new Error(`reference input duplicates ${bar.symbol} ${bar.sessionDate}`)
+    day.set(bar.symbol, bar)
+    grouped.set(bar.sessionDate, day)
+  }
+  const sessions = [...grouped.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([date, day]): Session => {
+      if (day.size !== universe.length || universe.some((symbol) => !day.has(symbol))) {
+        throw new Error(`reference input session ${date} is incomplete`)
+      }
+      return { date, bars: Object.fromEntries(universe.map((symbol) => [symbol, day.get(symbol)!])) }
+    })
+  if (
+    sessions.length !== manifest.sessionCount ||
+    sessions[0]?.date !== manifest.firstSession ||
+    sessions.at(-1)?.date !== manifest.lastSession
+  ) {
+    throw new Error('reference input sessions differ from the manifest')
+  }
+  return sessions
+}
+
+const monthEnds = (dates: readonly IsoDate[]): readonly number[] => {
+  const result: number[] = []
+  for (let index = 0; index < dates.length - 1; index += 1) {
+    if (dates[index].slice(0, 7) !== dates[index + 1].slice(0, 7)) result.push(index)
+  }
+  return result
+}
+
+const decisionPlan = (
+  signalIndex: number,
+  sessions: readonly Session[],
+  protocol: TsmomProtocol,
+): TsmomDecisionPlan => {
+  const maximumLookback = Math.max(...protocol.lookbacks)
+  const signals = protocol.universe.map((symbol) => {
+    const current = sessions[signalIndex].bars[symbol].close
+    const lookbacks = protocol.lookbacks.map((lookbackSessions) => {
+      const prior = sessions[signalIndex - lookbackSessions].bars[symbol].close
+      if (![current, prior].every((price) => Number.isFinite(price) && price > 0)) {
+        throw new Error(`reference TSMOM decision has an invalid close for ${symbol}`)
+      }
+      const value = current / prior - 1
+      return {
+        lookbackSessions,
+        return: value,
+        direction: value > 0 ? ('positive' as const) : ('non-positive' as const),
+      }
+    })
+    const score = lookbacks.reduce((sum, lookback) => sum + (lookback.return > 0 ? 1 : -1), 0)
+    return { symbol, lookbacks, score, active: score > 0, targetWeight: 0 }
+  })
+  if (signalIndex < maximumLookback) throw new Error('reference TSMOM decision has insufficient history')
+  const activeCount = signals.filter((signal) => signal.active).length
+  const weight = activeCount === 0 ? 0 : roundWeight(1 / activeCount)
+  const weighted = signals.map((signal) => ({ ...signal, targetWeight: signal.active ? weight : 0 }))
+  return {
+    schemaVersion: 'bayn.tsmom-decision-plan.v1',
+    signalDate: sessions[signalIndex].date,
+    targetWeights: Object.fromEntries(weighted.map((signal) => [signal.symbol, signal.targetWeight])),
+    signals: weighted,
+  }
+}
+
+const directVolatilityTarget = (
+  sessions: readonly Session[],
+  signalIndex: number,
+  protocol: TsmomProtocol,
+): Readonly<Record<string, number>> => {
+  const portfolioReturns: number[] = []
+  for (let index = signalIndex - 62; index <= signalIndex; index += 1) {
+    const returns = protocol.universe.map(
+      (symbol) => sessions[index].bars[symbol].close / sessions[index - 1].bars[symbol].close - 1,
+    )
+    portfolioReturns.push(average(returns))
+  }
+  const volatility = sampleDeviation(portfolioReturns) * Math.sqrt(tradingDays)
+  const exposure = volatility <= 0 ? 0 : Math.min(1, protocol.directVolatilityTarget / volatility)
+  const weight = roundWeight(exposure / protocol.universe.length)
+  return Object.fromEntries(protocol.universe.map((symbol) => [symbol, weight]))
+}
+
+const metrics = (
+  equityMicros: readonly bigint[],
+  turnoverMicros: bigint,
+  feeMicros: bigint,
+  spreadMicros: bigint,
+  slippageMicros: bigint,
+  yieldMicros: bigint,
+  initialMicros: bigint,
+): PerformanceMetrics => {
+  if (equityMicros.length < 2 || equityMicros.some((value) => value <= 0n)) {
+    throw new Error('reference replay produced an invalid equity curve')
+  }
+  const equity = equityMicros.map(microsToNumber)
+  const initial = microsToNumber(initialMicros)
+  const returns = equity.map((value, index) => value / (index === 0 ? initial : equity[index - 1]) - 1)
+  const totalReturn = equity.at(-1)! / initial - 1
+  const annualizedReturn = Math.pow(equity.at(-1)! / initial, tradingDays / equity.length) - 1
+  const annualizedVolatility = sampleDeviation(returns) * Math.sqrt(tradingDays)
+  const sharpe = annualizedVolatility === 0 ? 0 : (average(returns) * tradingDays) / annualizedVolatility
+  let peak = initial
+  let maximumDrawdown = 0
+  for (const value of equity) {
+    peak = Math.max(peak, value)
+    maximumDrawdown = Math.max(maximumDrawdown, 1 - value / peak)
+  }
+  return {
+    observations: equity.length,
+    totalReturn,
+    annualizedReturn,
+    annualizedVolatility,
+    sharpe,
+    maximumDrawdown,
+    annualTurnover: microsToNumber(turnoverMicros) / initial / (equity.length / tradingDays),
+    totalFeesMicros: feeMicros.toString(),
+    totalSpreadCostMicros: spreadMicros.toString(),
+    totalSlippageCostMicros: slippageMicros.toString(),
+    totalCashYieldMicros: yieldMicros.toString(),
+    endingEquityMicros: equityMicros.at(-1)!.toString(),
+  }
+}
+
+const order = (
+  runId: string,
+  decision: DecisionEvent,
+  sessionDate: IsoDate,
+  symbol: string,
+  side: 'buy' | 'sell',
+  requestedQuantityMicros: bigint,
+  referencePrice: bigint,
+  protocol: TsmomProtocol,
+): SimulatedOrder => {
+  const outcome = makeOrderOutcome({
+    identity: {
+      schemaVersion: 'bayn.partial-fill-seed.v1',
+      signalDate: decision.signalDate,
+      executionDate: decision.executionDate,
+      symbol,
+      side,
+    },
+    side,
+    requestedQuantityMicros,
+    referencePriceMicros: referencePrice,
+    model: protocol.executionModel,
+  })
+  const material = {
+    decisionId: decision.id,
+    sessionDate,
+    symbol,
+    side,
+    requestedQuantityMicros: outcome.requestedQuantityMicros.toString(),
+    filledQuantityMicros: outcome.filledQuantityMicros.toString(),
+    status: outcome.status,
+    rejectionReason: outcome.rejectionReason,
+    unfilledRemainder: outcome.unfilledRemainder,
+  }
+  return { id: hashObject({ runId, kind: 'order', ...material }), ...material }
+}
+
+const fill = (
+  runId: string,
+  decision: DecisionEvent,
+  simulatedOrder: SimulatedOrder,
+  terms: FillTerms,
+  costBasisMicros: bigint,
+): FillEvent => {
+  const material = {
+    orderId: simulatedOrder.id,
+    decisionId: decision.id,
+    sessionDate: simulatedOrder.sessionDate,
+    symbol: simulatedOrder.symbol,
+    side: simulatedOrder.side,
+    quantityMicros: simulatedOrder.filledQuantityMicros,
+    referencePriceMicros: terms.referencePriceMicros.toString(),
+    priceMicros: terms.fillPriceMicros.toString(),
+    notionalMicros: terms.notionalMicros.toString(),
+    spreadCostMicros: terms.spreadCostMicros.toString(),
+    slippageCostMicros: terms.slippageCostMicros.toString(),
+    costBasisMicros: costBasisMicros.toString(),
+  }
+  return { kind: 'fill', id: hashObject({ runId, kind: 'fill', ...material }), ...material }
+}
+
+const cashChange = (
+  runId: string,
+  source:
+    | Pick<FillEvent | FeeEvent, 'kind' | 'id' | 'sessionDate'>
+    | { kind: 'cash-yield'; id: string; sessionDate: IsoDate },
+  amountMicros: bigint,
+  cashAfterMicros: bigint,
+): CashChange => {
+  const material = {
+    sourceKind: source.kind,
+    sourceId: source.id,
+    sessionDate: source.sessionDate,
+    amountMicros: amountMicros.toString(),
+    cashAfterMicros: cashAfterMicros.toString(),
+  }
+  return { id: hashObject({ runId, kind: 'cash-change', ...material }), ...material }
+}
+
+const replay = (
+  sessions: readonly Session[],
+  targets: readonly Target[],
+  startIndex: number,
+  protocol: TsmomProtocol,
+  costMultiplierMicros: bigint,
+  runId: string,
+  retainTrace: boolean,
+): Replay => {
+  const targetBySession = new Map(targets.map((target) => [target.executionIndex, target]))
+  const positions = new Map<string, Position>()
+  const initial = BigInt(protocol.initialCapitalMicros)
+  let cash = initial
+  let turnover = 0n
+  let fees = 0n
+  let spread = 0n
+  let slippage = 0n
+  let cashYield = 0n
+  let previousEquity = initial
+  let peakEquity = initial
+  let previousDate: IsoDate | undefined
+  const equity: bigint[] = []
+  const events: EvaluationEvent[] = []
+  const decisions: TsmomSignalDecision[] = []
+  const orders: SimulatedOrder[] = []
+  const changes: CashChange[] = []
+  const marks: DailyPositionMark[] = []
+  const daily: DailyPerformancePoint[] = []
+
+  for (let index = startIndex; index < sessions.length; index += 1) {
+    const session = sessions[index]
+    const target = targetBySession.get(index)
+    const beforeTurnover = turnover
+    const beforeFees = fees
+    const beforeSpread = spread
+    const beforeSlippage = slippage
+    const beforeYield = cashYield
+
+    if (previousDate !== undefined) {
+      const elapsedDays = elapsedCalendarDays(previousDate, session.date)
+      const accrued = accrueCashYield(cash, elapsedDays, protocol.executionModel)
+      if (accrued > 0n) {
+        cash += accrued
+        cashYield += accrued
+        if (retainTrace) {
+          const material = {
+            sessionDate: session.date,
+            elapsedDays,
+            annualYieldBps: protocol.executionModel.cash.annualYieldBps,
+            amountMicros: accrued.toString(),
+          }
+          const event = {
+            kind: 'cash-yield' as const,
+            id: hashObject({ runId, kind: 'cash-yield', ...material }),
+            ...material,
+          }
+          events.push(event)
+          changes.push(cashChange(runId, event, accrued, cash))
+        }
+      }
+    }
+    previousDate = session.date
+
+    if (target !== undefined) {
+      const decisionMaterial = {
+        signalDate: sessions[target.signalIndex].date,
+        executionDate: session.date,
+        targetWeights: target.weights,
+      }
+      const decision: DecisionEvent = {
+        kind: 'decision',
+        id: hashObject({ runId, kind: 'decision', ...decisionMaterial }),
+        ...decisionMaterial,
+      }
+      if (retainTrace) {
+        if (target.plan === undefined) throw new Error('reference candidate target lacks a signal plan')
+        events.push(decision)
+        decisions.push({ ...target.plan, decisionId: decision.id, executionDate: decision.executionDate })
+      }
+
+      const opens = Object.fromEntries(
+        protocol.universe.map((symbol) => [
+          symbol,
+          referencePriceMicros(session.bars[symbol].open, protocol.executionModel),
+        ]),
+      ) as Readonly<Record<string, bigint>>
+      const equityAtOpen =
+        cash +
+        protocol.universe.reduce(
+          (sum, symbol) => sum + notionalMicros(positions.get(symbol)?.quantityMicros ?? 0n, opens[symbol]),
+          0n,
+        )
+      const desired = Object.fromEntries(
+        protocol.universe.map((symbol) => [
+          symbol,
+          desiredQuantityMicros(equityAtOpen, target.weights[symbol], opens[symbol], protocol.executionModel),
+        ]),
+      ) as Readonly<Record<string, bigint>>
+      const sessionFills: FillEvent[] = []
+
+      for (const symbol of [...protocol.universe].sort()) {
+        const position = positions.get(symbol) ?? { quantityMicros: 0n, costBasisMicros: 0n }
+        if (desired[symbol] >= position.quantityMicros) continue
+        const simulatedOrder = order(
+          runId,
+          decision,
+          session.date,
+          symbol,
+          'sell',
+          position.quantityMicros - desired[symbol],
+          opens[symbol],
+          protocol,
+        )
+        if (retainTrace) orders.push(simulatedOrder)
+        const quantity = BigInt(simulatedOrder.filledQuantityMicros)
+        if (quantity === 0n) continue
+        const terms = makeFillTerms('sell', quantity, opens[symbol], protocol.executionModel, costMultiplierMicros)
+        const costBasis = saleCostBasisMicros(position.costBasisMicros, quantity, position.quantityMicros)
+        const event = fill(runId, decision, simulatedOrder, terms, costBasis)
+        cash += terms.notionalMicros
+        turnover += terms.notionalMicros
+        spread += terms.spreadCostMicros
+        slippage += terms.slippageCostMicros
+        position.quantityMicros -= quantity
+        position.costBasisMicros -= costBasis
+        positions.set(symbol, position)
+        sessionFills.push(event)
+        if (retainTrace) {
+          events.push(event)
+          changes.push(cashChange(runId, event, terms.notionalMicros, cash))
+        }
+      }
+
+      const buys = [...protocol.universe]
+        .sort()
+        .map((symbol) => {
+          const position = positions.get(symbol) ?? { quantityMicros: 0n, costBasisMicros: 0n }
+          return {
+            symbol,
+            position,
+            quantityMicros: desired[symbol] > position.quantityMicros ? desired[symbol] - position.quantityMicros : 0n,
+            referencePriceMicros: opens[symbol],
+          }
+        })
+        .filter((candidate) => candidate.quantityMicros > 0n)
+      const sellFees: FeeInput[] = sessionFills.map((event) => ({
+        side: event.side,
+        quantityMicros: BigInt(event.quantityMicros),
+        notionalMicros: BigInt(event.notionalMicros),
+      }))
+      const isAffordable = (scale: bigint): boolean => {
+        const buyFees: FeeInput[] = []
+        for (const candidate of buys) {
+          const quantity = scaleQuantityMicros(candidate.quantityMicros, scale, protocol.executionModel)
+          if (
+            quantity === 0n ||
+            notionalMicros(quantity, candidate.referencePriceMicros) <
+              BigInt(protocol.executionModel.precision.minimumBuyNotionalMicros)
+          ) {
+            continue
+          }
+          const terms = makeFillTerms(
+            'buy',
+            quantity,
+            candidate.referencePriceMicros,
+            protocol.executionModel,
+            costMultiplierMicros,
+          )
+          buyFees.push({ side: 'buy', quantityMicros: quantity, notionalMicros: terms.notionalMicros })
+        }
+        const fee = calculateSessionFees([...sellFees, ...buyFees], protocol.executionModel, costMultiplierMicros)
+        return buyFees.reduce((sum, value) => sum + value.notionalMicros, 0n) + fee.totalMicros <= cash
+      }
+      let minimum = 0n
+      let maximum = ppm
+      while (minimum < maximum) {
+        const candidate = (minimum + maximum + 1n) / 2n
+        if (isAffordable(candidate)) minimum = candidate
+        else maximum = candidate - 1n
+      }
+
+      for (const candidate of buys) {
+        const requested = scaleQuantityMicros(candidate.quantityMicros, minimum, protocol.executionModel)
+        if (requested === 0n) continue
+        const simulatedOrder = order(
+          runId,
+          decision,
+          session.date,
+          candidate.symbol,
+          'buy',
+          requested,
+          candidate.referencePriceMicros,
+          protocol,
+        )
+        if (retainTrace) orders.push(simulatedOrder)
+        const quantity = BigInt(simulatedOrder.filledQuantityMicros)
+        if (quantity === 0n) continue
+        const terms = makeFillTerms(
+          'buy',
+          quantity,
+          candidate.referencePriceMicros,
+          protocol.executionModel,
+          costMultiplierMicros,
+        )
+        const event = fill(runId, decision, simulatedOrder, terms, terms.notionalMicros)
+        cash -= terms.notionalMicros
+        turnover += terms.notionalMicros
+        spread += terms.spreadCostMicros
+        slippage += terms.slippageCostMicros
+        candidate.position.quantityMicros += quantity
+        candidate.position.costBasisMicros += terms.notionalMicros
+        positions.set(candidate.symbol, candidate.position)
+        sessionFills.push(event)
+        if (retainTrace) {
+          events.push(event)
+          changes.push(cashChange(runId, event, -terms.notionalMicros, cash))
+        }
+      }
+
+      const fee = calculateSessionFees(
+        sessionFills.map((event) => ({
+          side: event.side,
+          quantityMicros: BigInt(event.quantityMicros),
+          notionalMicros: BigInt(event.notionalMicros),
+        })),
+        protocol.executionModel,
+        costMultiplierMicros,
+      )
+      if (fee.totalMicros > 0n) {
+        cash -= fee.totalMicros
+        fees += fee.totalMicros
+        if (retainTrace) {
+          const material = {
+            sessionDate: session.date,
+            commissionMicros: fee.commissionMicros.toString(),
+            secMicros: fee.secMicros.toString(),
+            tafMicros: fee.tafMicros.toString(),
+            catMicros: fee.catMicros.toString(),
+            totalMicros: fee.totalMicros.toString(),
+          }
+          const event: FeeEvent = {
+            kind: 'fee',
+            id: hashObject({ runId, kind: 'fee', ...material }),
+            ...material,
+          }
+          events.push(event)
+          changes.push(cashChange(runId, event, -fee.totalMicros, cash))
+        }
+      }
+      if (cash < 0n) throw new Error('reference replay spent unavailable cash')
+    }
+
+    const closes = Object.fromEntries(
+      protocol.universe.map((symbol) => [
+        symbol,
+        referencePriceMicros(session.bars[symbol].close, protocol.executionModel),
+      ]),
+    ) as Readonly<Record<string, bigint>>
+    const closingEquity =
+      cash +
+      protocol.universe.reduce(
+        (sum, symbol) => sum + notionalMicros(positions.get(symbol)?.quantityMicros ?? 0n, closes[symbol]),
+        0n,
+      )
+    equity.push(closingEquity)
+    peakEquity = peakEquity > closingEquity ? peakEquity : closingEquity
+    const point: DailyPerformancePoint = {
+      sessionDate: session.date,
+      equityMicros: closingEquity.toString(),
+      netReturn: Number(closingEquity) / Number(previousEquity) - 1,
+      turnoverMicros: (turnover - beforeTurnover).toString(),
+      cumulativeTurnoverMicros: turnover.toString(),
+      feeMicros: (fees - beforeFees).toString(),
+      cumulativeFeesMicros: fees.toString(),
+      spreadCostMicros: (spread - beforeSpread).toString(),
+      cumulativeSpreadCostMicros: spread.toString(),
+      slippageCostMicros: (slippage - beforeSlippage).toString(),
+      cumulativeSlippageCostMicros: slippage.toString(),
+      cashYieldMicros: (cashYield - beforeYield).toString(),
+      cumulativeCashYieldMicros: cashYield.toString(),
+      peakEquityMicros: peakEquity.toString(),
+      drawdown: 1 - Number(closingEquity) / Number(peakEquity),
+    }
+    daily.push(point)
+    if (retainTrace) {
+      marks.push({
+        ...point,
+        cashMicros: cash.toString(),
+        positions: [...protocol.universe].sort().map((symbol) => {
+          const position = positions.get(symbol) ?? { quantityMicros: 0n, costBasisMicros: 0n }
+          return {
+            symbol,
+            quantityMicros: position.quantityMicros.toString(),
+            costBasisMicros: position.costBasisMicros.toString(),
+            priceMicros: closes[symbol].toString(),
+            marketValueMicros: notionalMicros(position.quantityMicros, closes[symbol]).toString(),
+          }
+        }),
+      })
+    }
+    previousEquity = closingEquity
+  }
+
+  return {
+    metrics: metrics(equity, turnover, fees, spread, slippage, cashYield, initial),
+    events,
+    decisions,
+    daily,
+    trace: retainTrace
+      ? {
+          schemaVersion: 'bayn.simulation-trace.v3',
+          executionModel: protocol.executionModel,
+          costMultiplierMicros: costMultiplierMicros.toString(),
+          orders,
+          cashChanges: changes,
+          dailyMarks: marks,
+        }
+      : null,
+  }
+}
+
+const verdict = (
+  strategy: PerformanceMetrics,
+  buyAndHold: PerformanceMetrics,
+  directVolTiming: PerformanceMetrics,
+  doubleCost: PerformanceMetrics,
+  protocol: TsmomProtocol,
+): EconomicVerdict => {
+  const threshold = protocol.thresholds
+  const benchmarkSharpe = Math.max(buyAndHold.sharpe, directVolTiming.sharpe)
+  const finite = [
+    strategy.annualizedReturn,
+    strategy.sharpe,
+    strategy.maximumDrawdown,
+    strategy.annualTurnover,
+    doubleCost.annualizedReturn,
+  ].every(Number.isFinite)
+  const gates: GateResult[] = [
+    { name: 'finite_metrics', passed: finite, actual: finite, required: true },
+    {
+      name: 'minimum_observations',
+      passed: strategy.observations >= threshold.minimumObservations,
+      actual: strategy.observations,
+      required: threshold.minimumObservations,
+    },
+    {
+      name: 'positive_net_return',
+      passed: strategy.annualizedReturn > threshold.minimumAnnualizedReturn,
+      actual: strategy.annualizedReturn,
+      required: `>${threshold.minimumAnnualizedReturn}`,
+    },
+    {
+      name: 'benchmark_sharpe_improvement',
+      passed: strategy.sharpe - benchmarkSharpe > threshold.minimumSharpeImprovement,
+      actual: strategy.sharpe - benchmarkSharpe,
+      required: `>${threshold.minimumSharpeImprovement}`,
+    },
+    {
+      name: 'maximum_drawdown',
+      passed: strategy.maximumDrawdown <= threshold.maximumDrawdown,
+      actual: strategy.maximumDrawdown,
+      required: `<=${threshold.maximumDrawdown}`,
+    },
+    {
+      name: 'maximum_turnover',
+      passed: strategy.annualTurnover <= threshold.maximumAnnualTurnover,
+      actual: strategy.annualTurnover,
+      required: `<=${threshold.maximumAnnualTurnover}`,
+    },
+    {
+      name: 'double_cost_return',
+      passed: !threshold.requirePositiveDoubleCostReturn || doubleCost.annualizedReturn > 0,
+      actual: doubleCost.annualizedReturn,
+      required: threshold.requirePositiveDoubleCostReturn ? '>0' : 'not-required',
+    },
+  ]
+  return { status: gates.every((gate) => gate.passed) ? 'PASS' : 'FAIL_CLOSED', gates }
+}
+
+export const evaluateReferenceTsmom = (
+  bars: readonly DailyBar[],
+  manifest: InputManifest,
+  protocol: TsmomProtocol,
+  provenance: RuntimeProvenance,
+): ReferenceEvaluation => {
+  const sessions = align(bars, manifest, protocol.universe)
+  const dates = sessions.map((session) => session.date)
+  const maximumLookback = Math.max(...protocol.lookbacks)
+  const eligibleSignals = monthEnds(dates).filter(
+    (index) =>
+      index >= maximumLookback &&
+      index < dates.length - 1 &&
+      dates[index - maximumLookback] >= manifest.bounds.lookbackStart &&
+      dates[index + 1] >= manifest.bounds.evaluationStart &&
+      dates[index + 1] <= manifest.bounds.evaluationEnd,
+  )
+  if (eligibleSignals.length === 0) throw new Error('reference dataset has no eligible signal session')
+  const startIndex = eligibleSignals[0] + 1
+  const firstAfterEnd = dates.findIndex((date) => date > manifest.bounds.evaluationEnd)
+  const endExclusive = firstAfterEnd === -1 ? dates.length : firstAfterEnd
+  const boundedSessions = sessions.slice(0, endExclusive)
+  if (endExclusive - startIndex < protocol.thresholds.minimumObservations) {
+    throw new Error('reference dataset has too few evaluation observations')
+  }
+
+  const parameterHash = canonicalHashV1(protocol)
+  const strategyIdentity = {
+    name: provenance.strategy.name,
+    behaviorHash: provenance.strategy.behaviorHash,
+    parameterHash,
+    parameterSchemaVersion: protocol.schemaVersion,
+  }
+  if (canonicalHashV1(protocol) !== provenance.strategy.parameterHash || provenance.strategy.name !== 'tsmom') {
+    throw new Error('reference protocol does not match runtime provenance')
+  }
+  const runId = makeRunIdentity({
+    schemaVersion: 'bayn.run-identity.v1',
+    sourceRevision: provenance.sourceRevision,
+    image: provenance.image,
+    strategy: {
+      name: provenance.strategy.name,
+      behaviorHash: provenance.strategy.behaviorHash,
+      parameters: protocol,
+    },
+    finalizedSnapshot: manifest.finalizedSnapshot,
+    calendarVersion: manifest.finalizedSnapshot.calendarVersion,
+    bounds: manifest.bounds,
+  }).runId
+  const protocolHash = makeStrategyProtocolHash(strategyIdentity)
+  const candidateTargets = eligibleSignals.map((signalIndex): Target => {
+    const plan = decisionPlan(signalIndex, sessions, protocol)
+    return { signalIndex, executionIndex: signalIndex + 1, weights: plan.targetWeights, plan }
+  })
+  const equalWeight = roundWeight(1 / protocol.universe.length)
+  const buyAndHoldTargets: readonly Target[] = [
+    {
+      signalIndex: startIndex - 1,
+      executionIndex: startIndex,
+      weights: Object.fromEntries(protocol.universe.map((symbol) => [symbol, equalWeight])),
+    },
+  ]
+  const directVolTargets = eligibleSignals.map(
+    (signalIndex): Target => ({
+      signalIndex,
+      executionIndex: signalIndex + 1,
+      weights: directVolatilityTarget(sessions, signalIndex, protocol),
+    }),
+  )
+  const strategy = replay(boundedSessions, candidateTargets, startIndex, protocol, MICROS, runId, true)
+  const buyAndHold = replay(boundedSessions, buyAndHoldTargets, startIndex, protocol, MICROS, runId, false)
+  const directVolTiming = replay(boundedSessions, directVolTargets, startIndex, protocol, MICROS, runId, false)
+  const doubleCostStrategy = replay(
+    boundedSessions,
+    candidateTargets,
+    startIndex,
+    protocol,
+    BigInt(protocol.executionModel.doubleCostMultiplier) * MICROS,
+    runId,
+    false,
+  )
+  return {
+    runId,
+    protocolHash,
+    strategy,
+    buyAndHold,
+    directVolTiming,
+    doubleCostStrategy,
+    verdict: verdict(
+      strategy.metrics,
+      buyAndHold.metrics,
+      directVolTiming.metrics,
+      doubleCostStrategy.metrics,
+      protocol,
+    ),
+  }
+}


### PR DESCRIPTION
## Summary

- add a pure independent TSMOM reference evaluator that does not import the production strategy, qualification statistics, or evidence store
- add an Effect-based operator command that reads one PostgreSQL repeatable-read/read-only snapshot, reloads finalized Signal data, inspects ClickHouse query chronology, and verifies authoritative `origin/main` history
- fail closed on any mismatch across replayed decisions, orders, cash, marks, benchmarks, metrics, gates, hashes, lineage, schema versions, qualification result, or pre-lock data access
- document the sequential two-run operator procedure; the command is not included in the deployed runtime and calls neither TigerBeetle nor a broker

## Related Issues

[PROOMPT-368](https://linear.app/proompteng/issue/PROOMPT-368)

## Testing

- `bun run --filter @proompteng/bayn test` — 95 passed, 20 isolated-database tests skipped, 0 failed
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- `BAYN_TEST_POSTGRES_URL=<isolated-postgresql-18-test-url> bun test src/db/evidence-store.integration.test.ts -t "keeps the audit snapshot repeatable-read and rejects writes"` — 1 passed, 0 failed
- live operator audit executed sequentially twice against run `42d8bbfaf1a2ce7759b2283384e8f41298fe3a354ba7c0e1756bb8a3e64af177` — both passed all 43 checks with identical audit hash `ff14c321314afe3fa7caaf464e94f15c9387992e5e8f5459df2a3965e54f0716`

## Breaking Changes

None. This adds an operator-side audit command and does not change the deployed Bayn runtime, database schema, broker authority, or capital authority.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
