### PR TITLE
chore(bayn): promote image sha-cc739b2cf7cf3ac03f4ecc42f9538fe67fc959e7

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: bayn
         app.kubernetes.io/part-of: bayn
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-21T01:44:20Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-21T04:13:58Z"
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
@@ -47,11 +47,11 @@ spec:
               protocol: TCP
           env:
             - name: BAYN_CODE_REVISION
-              value: b0dfaac26c8e55c39c55aa75c7b7f3686e784543
+              value: cc739b2cf7cf3ac03f4ecc42f9538fe67fc959e7
             - name: BAYN_IMAGE_REPOSITORY
               value: registry.ide-newton.ts.net/lab/bayn
             - name: BAYN_IMAGE_DIGEST
-              value: sha256:e225540b24f749bb8a1743948c9c01768b443b3d51e42c12f1f4f617a67c9819
+              value: sha256:cc1e1cadddef8c179f0b45a4a1b8191491034032f097318a856e4d8278c67711
             - name: BAYN_HEALTH_INTERVAL_MS
               value: "30000"
             - name: BAYN_OPERATION_TIMEOUT_MS

--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -18,5 +18,5 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/bayn
     newName: registry.ide-newton.ts.net/lab/bayn
-    newTag: "sha-b0dfaac26c8e55c39c55aa75c7b7f3686e784543"
-    digest: sha256:e225540b24f749bb8a1743948c9c01768b443b3d51e42c12f1f4f617a67c9819
+    newTag: "sha-cc739b2cf7cf3ac03f4ecc42f9538fe67fc959e7"
+    digest: sha256:cc1e1cadddef8c179f0b45a4a1b8191491034032f097318a856e4d8278c67711


### PR DESCRIPTION
## Summary

Promote the immutable Bayn image, activate the Bayn Argo application, and bind runtime evidence to its
source commit.

- Source commit: `cc739b2cf7cf3ac03f4ecc42f9538fe67fc959e7`
- Image tag: `sha-cc739b2cf7cf3ac03f4ecc42f9538fe67fc959e7`
- Image digest: `sha256:cc1e1cadddef8c179f0b45a4a1b8191491034032f097318a856e4d8278c67711`

## Related Issues

PROOMPT-353

## Testing

- OCI index contains `linux/amd64` and `linux/arm64`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents exact validation.
- [x] Runtime source revision and image digest are immutable.
- [x] No broker or capital-promotion authority is introduced.