### PR TITLE
fix(bayn): expose locked audit policies

### DIFF
--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -97,6 +97,7 @@ BAYN_AUDIT_RUN_ID=<run-id> \
 BAYN_AUDIT_POSTGRES_URL=<authenticated-postgres-uri> \
 BAYN_AUDIT_SIGNAL_URL=<signal-clickhouse-url> \
 BAYN_AUDIT_SIGNAL_USERNAME=<readonly-bayn-user> \
+BAYN_AUDIT_SIGNAL_PUBLISHER_USERNAME=<signal-publisher-user> \
 BAYN_AUDIT_SIGNAL_PASSWORD=<readonly-bayn-password> \
 BAYN_AUDIT_CLICKHOUSE_URL=<clickhouse-audit-url> \
 BAYN_AUDIT_CLICKHOUSE_USERNAME=<query-log-audit-user> \

--- a/services/bayn/src/qualification-audit-command.ts
+++ b/services/bayn/src/qualification-audit-command.ts
@@ -103,6 +103,7 @@ const config = Config.all({
   postgresCaPath: Config.string('BAYN_AUDIT_POSTGRES_CA_PATH').pipe(Config.withDefault('')),
   signalUrl: Config.string('BAYN_AUDIT_SIGNAL_URL'),
   signalUsername: Config.string('BAYN_AUDIT_SIGNAL_USERNAME'),
+  signalPublisherUsername: Config.string('BAYN_AUDIT_SIGNAL_PUBLISHER_USERNAME'),
   signalPassword: Config.redacted('BAYN_AUDIT_SIGNAL_PASSWORD'),
   auditClickhouseUrl: Config.string('BAYN_AUDIT_CLICKHOUSE_URL'),
   auditClickhouseUsername: Config.string('BAYN_AUDIT_CLICKHOUSE_USERNAME'),
@@ -362,7 +363,6 @@ const readSignalAccess = (
         ) AS kind
       FROM system.query_log
       WHERE type = 'QueryStart'
-        AND user = 'bayn'
         AND query_start_time_microseconds >= parseDateTime64BestEffort(${sql.param('String', finalizedAt)}, 6)
         AND query_start_time_microseconds <= parseDateTime64BestEffort(
           ${sql.param('String', database.qualification.resultCommittedAt)},
@@ -458,6 +458,7 @@ const main = Effect.gen(function* () {
     protocol,
     database,
     signalAccess,
+    signalPrincipals: { candidate: input.signalUsername, publishers: [input.signalPublisherUsername] },
     repository,
   })
   const stdio = yield* Stdio.Stdio

--- a/services/bayn/src/qualification-audit.test.ts
+++ b/services/bayn/src/qualification-audit.test.ts
@@ -216,12 +216,50 @@ const fixture = (): QualificationAuditInput => {
     protocol: fixtureProtocol,
     database,
     signalAccess: [
+      {
+        queryId: 'publisher',
+        queryStartTime: '2026-07-20T11:59:58.000000Z',
+        user: 'signal-publisher',
+        kind: 'bars',
+      },
       { queryId: 'manifest', queryStartTime: '2026-07-20T11:59:59.000000Z', user: 'bayn', kind: 'manifest' },
       { queryId: 'sessions', queryStartTime: '2026-07-20T12:00:01.000000Z', user: 'bayn', kind: 'sessions' },
       { queryId: 'bars', queryStartTime: '2026-07-20T12:00:01.100000Z', user: 'bayn', kind: 'bars' },
     ],
+    signalPrincipals: { candidate: 'bayn', publishers: ['signal-publisher'] },
     repository: { sourceCommitExists: true, sourceCommitAncestorOfMain: true, preLockResultReferences: [] },
   }
+}
+
+const replaceArtifact = (
+  input: QualificationAuditInput,
+  name: string,
+  mutate: (payload: Readonly<Record<string, unknown>>) => unknown,
+): QualificationAuditInput => {
+  const source = input.database.artifacts.find((artifact) => artifact.name === name)
+  if (source === undefined || typeof source.payload !== 'object' || source.payload === null) {
+    throw new Error(`fixture artifact ${name} is missing or malformed`)
+  }
+  const payload = mutate(structuredClone(source.payload) as Readonly<Record<string, unknown>>)
+  return {
+    ...input,
+    database: {
+      ...input.database,
+      artifacts: input.database.artifacts.map((artifact) =>
+        artifact.name === name ? { ...artifact, payload, contentHash: canonicalHashV1(payload) } : artifact,
+      ),
+    },
+  }
+}
+
+const replaceFirstItem = (
+  payload: Readonly<Record<string, unknown>>,
+  patch: Readonly<Record<string, unknown>>,
+): unknown => {
+  if (!Array.isArray(payload.items) || typeof payload.items[0] !== 'object' || payload.items[0] === null) {
+    throw new Error('fixture artifact has no object item')
+  }
+  return { ...payload, items: [{ ...payload.items[0], ...patch }, ...payload.items.slice(1)] }
 }
 
 describe('qualification audit', () => {
@@ -231,6 +269,14 @@ describe('qualification audit', () => {
 
     expect(first.status).toBe('PASS')
     expect(first.checks.every((check) => check.passed)).toBe(true)
+    expect(first.policies.declaredAt).toBe(first.contamination.lockCreatedAt)
+    expect(first.policies.documents.map((policy) => policy.name)).toEqual([
+      'benchmark',
+      'execution',
+      'thresholds',
+      'uncertainty',
+    ])
+    expect(first.policies.policySetHash).toBe(canonicalHashV1(first.policies.documents))
     expect(second.auditHash).toBe(first.auditHash)
   })
 
@@ -255,11 +301,135 @@ describe('qualification audit', () => {
   test('fails closed when candidate data was read before the lock', () => {
     const input = fixture()
     const signalAccess = input.signalAccess.map((record) =>
-      record.kind === 'bars' ? { ...record, queryStartTime: '2026-07-20T11:59:58.000000Z' } : record,
+      record.user === 'bayn' && record.kind === 'bars'
+        ? { ...record, queryStartTime: '2026-07-20T11:59:58.000000Z' }
+        : record,
     )
     const report = auditQualification({ ...input, signalAccess })
 
     expect(report.status).toBe('FAIL')
     expect(report.checks.find((check) => check.name === 'signal-lock-before-candidate-data')?.passed).toBe(false)
+  })
+
+  test.each([
+    ['strategy', 'reference-strategy', (payload: Readonly<Record<string, unknown>>) => ({ ...payload, sharpe: 99 })],
+    [
+      'tsmom-signal-decisions',
+      'reference-tsmom-signal-decisions',
+      (payload: Readonly<Record<string, unknown>>) => replaceFirstItem(payload, { decisionId: '0'.repeat(64) }),
+    ],
+    [
+      'daily-position-marks',
+      'reference-daily-position-marks',
+      (payload: Readonly<Record<string, unknown>>) => replaceFirstItem(payload, { equityMicros: '1' }),
+    ],
+    [
+      'buy-and-hold-series',
+      'reference-buy-and-hold-series',
+      (payload: Readonly<Record<string, unknown>>) => replaceFirstItem(payload, { netReturn: 99 }),
+    ],
+    [
+      'simulated-orders',
+      'reference-simulated-orders',
+      (payload: Readonly<Record<string, unknown>>) => replaceFirstItem(payload, { filledQuantityMicros: '1' }),
+    ],
+  ])('fails closed on internally rehashed %s drift', (artifactName, checkName, mutate) => {
+    const report = auditQualification(replaceArtifact(fixture(), artifactName, mutate))
+
+    expect(report.status).toBe('FAIL')
+    expect(report.checks.find((check) => check.name === 'artifact-hashes')?.passed).toBe(true)
+    expect(report.checks.find((check) => check.name === checkName)?.passed).toBe(false)
+  })
+
+  test('fails closed on a rehashed gate that diverges from the independent result', () => {
+    const input = fixture()
+    const gate = input.database.gates[0]
+    const changed = { ...gate, passed: !gate.passed }
+    const contentHash = canonicalHashV1({
+      name: changed.name,
+      passed: changed.passed,
+      actual: changed.actual,
+      required: changed.required,
+    })
+    const database = { ...input.database, gates: [{ ...changed, contentHash }, ...input.database.gates.slice(1)] }
+    const report = auditQualification({ ...input, database })
+
+    expect(report.status).toBe('FAIL')
+    expect(report.checks.find((check) => check.name === 'gate-hashes-and-order')?.passed).toBe(true)
+    expect(report.checks.find((check) => check.name === 'reference-gates')?.passed).toBe(false)
+  })
+
+  test('fails closed on policy, trial-lineage, repository, access-coverage, and principal defects', () => {
+    const cases: readonly [string, QualificationAuditInput, string][] = [
+      [
+        'policy',
+        (() => {
+          const input = fixture()
+          const lock = structuredClone(input.database.qualification.lock) as Record<string, unknown>
+          const policies = lock.policies as Record<string, Record<string, unknown>>
+          lock.policies = {
+            ...policies,
+            thresholds: { ...policies.thresholds, content: { schemaVersion: 'tampered' } },
+          }
+          return {
+            ...input,
+            database: {
+              ...input.database,
+              qualification: { ...input.database.qualification, lock },
+            },
+          }
+        })(),
+        'lock-policy-hashes',
+      ],
+      [
+        'trial-lineage',
+        (() => {
+          const input = fixture()
+          return { ...input, database: { ...input.database, priorTrialRunIds: ['0'.repeat(64)] } }
+        })(),
+        'locked-prior-trial-lineage',
+      ],
+      [
+        'repository',
+        {
+          ...fixture(),
+          repository: { sourceCommitExists: true, sourceCommitAncestorOfMain: false, preLockResultReferences: [] },
+        },
+        'source-revision-in-repository',
+      ],
+      [
+        'access-coverage',
+        (() => {
+          const input = fixture()
+          return { ...input, signalAccess: input.signalAccess.filter((record) => record.queryId !== 'bars') }
+        })(),
+        'signal-lock-before-candidate-data',
+      ],
+      [
+        'principal',
+        (() => {
+          const input = fixture()
+          return {
+            ...input,
+            signalAccess: [
+              ...input.signalAccess,
+              {
+                queryId: 'unknown',
+                queryStartTime: '2026-07-20T11:59:59.500000Z',
+                user: 'notebook',
+                kind: 'manifest' as const,
+              },
+            ],
+          }
+        })(),
+        'signal-read-principals',
+      ],
+    ]
+
+    for (const [name, input, checkName] of cases) {
+      const report = auditQualification(input)
+      expect(report.status, name).toBe('FAIL')
+      expect(report.checks.find((check) => check.name === checkName)?.passed, name).toBe(false)
+    }
   })
 })

--- a/services/bayn/src/qualification-audit.ts
+++ b/services/bayn/src/qualification-audit.ts
@@ -77,6 +77,11 @@ export interface SignalAccessRecord {
   readonly kind: 'manifest' | 'sessions' | 'bars'
 }
 
+export interface SignalPrincipals {
+  readonly candidate: string
+  readonly publishers: readonly string[]
+}
+
 export interface RepositoryAudit {
   readonly sourceCommitExists: boolean
   readonly sourceCommitAncestorOfMain: boolean
@@ -89,6 +94,7 @@ export interface QualificationAuditInput {
   readonly protocol: TsmomProtocol
   readonly database: AuditDatabaseSnapshot
   readonly signalAccess: readonly SignalAccessRecord[]
+  readonly signalPrincipals: SignalPrincipals
   readonly repository: RepositoryAudit
 }
 
@@ -114,9 +120,21 @@ export interface QualificationAuditReport {
     readonly lockId: string
     readonly resultHash: string
   }
+  readonly policies: {
+    readonly declaredAt: string
+    readonly lockId: string
+    readonly policySetHash: string
+    readonly documents: readonly {
+      readonly name: string
+      readonly schemaVersion: string
+      readonly contentHash: string
+      readonly content: unknown
+    }[]
+  }
   readonly contamination: {
     readonly lockCreatedAt: string
     readonly resultCommittedAt: string
+    readonly principals: SignalPrincipals
     readonly access: readonly SignalAccessRecord[]
   }
   readonly repository: RepositoryAudit & { readonly sourceRevision: string }
@@ -456,6 +474,17 @@ export const auditQualification = (input: QualificationAuditInput): Qualificatio
   )
   const lockData = object(lock.data, 'qualification lock data')
   const lockPolicies = object(lock.policies, 'qualification lock policies')
+  const policyDocuments = Object.entries(lockPolicies)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([name, value]) => {
+      const policy = object(value, `qualification policy ${name}`)
+      return {
+        name,
+        schemaVersion: string(policy.schemaVersion, `qualification policy ${name} schema version`),
+        contentHash: string(policy.contentHash, `qualification policy ${name} content hash`),
+        content: policy.content,
+      }
+    })
   check(
     'lock-candidate-binding',
     lock.candidateRunId === database.run.runId &&
@@ -478,11 +507,11 @@ export const auditQualification = (input: QualificationAuditInput): Qualificatio
   )
   check(
     'lock-policy-hashes',
-    Object.values(lockPolicies).every((value) => {
-      const policy = object(value, 'qualification policy')
-      return policy.contentHash === canonicalHashV1(policy.content)
-    }),
-    `${Object.keys(lockPolicies).length} policies`,
+    same(
+      policyDocuments.map((policy) => policy.name),
+      ['benchmark', 'execution', 'thresholds', 'uncertainty'],
+    ) && policyDocuments.every((policy) => policy.contentHash === canonicalHashV1(policy.content)),
+    `${policyDocuments.length} policies policySetHash=${canonicalHashV1(policyDocuments)}`,
   )
   check(
     'locked-prior-trial-lineage',
@@ -533,8 +562,9 @@ export const auditQualification = (input: QualificationAuditInput): Qualificatio
       ? left.queryId.localeCompare(right.queryId)
       : left.queryStartTime.localeCompare(right.queryStartTime),
   )
-  const candidateReads = sortedAccess.filter((value) => value.kind === 'sessions' || value.kind === 'bars')
-  const manifestReads = sortedAccess.filter((value) => value.kind === 'manifest')
+  const candidateAccess = sortedAccess.filter((value) => value.user === input.signalPrincipals.candidate)
+  const candidateReads = candidateAccess.filter((value) => value.kind === 'sessions' || value.kind === 'bars')
+  const manifestReads = candidateAccess.filter((value) => value.kind === 'manifest')
   const preLockCandidateReads = candidateReads.filter(
     (value) => value.queryStartTime < database.qualification.lockCreatedAt,
   )
@@ -557,8 +587,15 @@ export const auditQualification = (input: QualificationAuditInput): Qualificatio
     `${manifestReads.length} manifest reads`,
   )
   check(
-    'signal-read-principal',
-    sortedAccess.every((value) => value.user === 'bayn'),
+    'signal-read-principals',
+    input.signalPrincipals.candidate.length > 0 &&
+      input.signalPrincipals.publishers.length > 0 &&
+      new Set([input.signalPrincipals.candidate, ...input.signalPrincipals.publishers]).size ===
+        input.signalPrincipals.publishers.length + 1 &&
+      sortedAccess.every(
+        (value) =>
+          value.user === input.signalPrincipals.candidate || input.signalPrincipals.publishers.includes(value.user),
+      ),
     [...new Set(sortedAccess.map((value) => value.user))].join(','),
   )
   check(
@@ -588,9 +625,16 @@ export const auditQualification = (input: QualificationAuditInput): Qualificatio
       lockId,
       resultHash,
     },
+    policies: {
+      declaredAt: database.qualification.lockCreatedAt,
+      lockId,
+      policySetHash: canonicalHashV1(policyDocuments),
+      documents: policyDocuments,
+    },
     contamination: {
       lockCreatedAt: database.qualification.lockCreatedAt,
       resultCommittedAt: database.qualification.resultCommittedAt,
+      principals: input.signalPrincipals,
       access: sortedAccess,
     },
     repository: { ...input.repository, sourceRevision: database.run.sourceRevision },


### PR DESCRIPTION
## Summary

- emit all four locked qualification policy documents, their declaration timestamp, lock binding, and deterministic policy-set hash in `bayn.qualification-audit.v1`
- inspect every matching Signal query-log principal and fail on identities other than the configured candidate and publisher users
- distinguish publisher validation reads from candidate data reads while preserving the lock-before-candidate-data invariant
- add focused internally rehashed artifact, gate, policy, lineage, repository, coverage, and principal regression tests

## Related Issues

[PROOMPT-368](https://linear.app/proompteng/issue/PROOMPT-368)

## Testing

- `bun run --filter @proompteng/bayn test` — 102 passed, 20 isolated-database tests skipped, 0 failed
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- production operator audit against run `42d8bbfaf1a2ce7759b2283384e8f41298fe3a354ba7c0e1756bb8a3e64af177` — PASS, 43/43 checks, policy-set hash `74cee92ac44af5a382c5f3826843b3b22e00edd60aae0d6105ee168322f439e0`, audit hash `21ded64c957fbc72bc650665387ecc15ae1298f0504c19832690a49e896fcfaf`

## Breaking Changes

None. The operator command adds one required Signal publisher username; the deployed runtime, database schema, broker authority, and capital authority are unchanged.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
