### PR TITLE
chore(bayn): promote image sha-02c18b7bbd4885a3cda73620e19319638a758fc7

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: bayn
         app.kubernetes.io/part-of: bayn
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-21T01:44:20Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-21T04:58:14Z"
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
@@ -47,11 +47,11 @@ spec:
               protocol: TCP
           env:
             - name: BAYN_CODE_REVISION
-              value: b0dfaac26c8e55c39c55aa75c7b7f3686e784543
+              value: 02c18b7bbd4885a3cda73620e19319638a758fc7
             - name: BAYN_IMAGE_REPOSITORY
               value: registry.ide-newton.ts.net/lab/bayn
             - name: BAYN_IMAGE_DIGEST
-              value: sha256:e225540b24f749bb8a1743948c9c01768b443b3d51e42c12f1f4f617a67c9819
+              value: sha256:3079e8bf79c59254d5394a0bd3f2d5e269fd03cf083fab106bfbe423595ba6f9
             - name: BAYN_HEALTH_INTERVAL_MS
               value: "30000"
             - name: BAYN_OPERATION_TIMEOUT_MS

--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -22,5 +22,5 @@ configMapGenerator:
 images:
   - name: registry.ide-newton.ts.net/lab/bayn
     newName: registry.ide-newton.ts.net/lab/bayn
-    newTag: "sha-b0dfaac26c8e55c39c55aa75c7b7f3686e784543"
-    digest: sha256:e225540b24f749bb8a1743948c9c01768b443b3d51e42c12f1f4f617a67c9819
+    newTag: "sha-02c18b7bbd4885a3cda73620e19319638a758fc7"
+    digest: sha256:3079e8bf79c59254d5394a0bd3f2d5e269fd03cf083fab106bfbe423595ba6f9


### PR DESCRIPTION
## Summary

Promote the immutable Bayn image, activate the Bayn Argo application, and bind runtime evidence to its
source commit.

- Source commit: `02c18b7bbd4885a3cda73620e19319638a758fc7`
- Image tag: `sha-02c18b7bbd4885a3cda73620e19319638a758fc7`
- Image digest: `sha256:3079e8bf79c59254d5394a0bd3f2d5e269fd03cf083fab106bfbe423595ba6f9`

## Related Issues

PROOMPT-353

## Testing

- OCI index contains `linux/amd64` and `linux/arm64`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents exact validation.
- [x] Runtime source revision and image digest are immutable.
- [x] No broker or capital-promotion authority is introduced.