### PR TITLE
chore(bayn): promote qualification dossier runtime

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -47,11 +47,13 @@ spec:
               protocol: TCP
           env:
             - name: BAYN_CODE_REVISION
-              value: b0dfaac26c8e55c39c55aa75c7b7f3686e784543
+              value: 02c18b7bbd4885a3cda73620e19319638a758fc7
             - name: BAYN_IMAGE_REPOSITORY
               value: registry.ide-newton.ts.net/lab/bayn
             - name: BAYN_IMAGE_DIGEST
-              value: sha256:e225540b24f749bb8a1743948c9c01768b443b3d51e42c12f1f4f617a67c9819
+              value: sha256:3079e8bf79c59254d5394a0bd3f2d5e269fd03cf083fab106bfbe423595ba6f9
+            - name: BAYN_QUALIFICATION_RUN_ID
+              value: 42d8bbfaf1a2ce7759b2283384e8f41298fe3a354ba7c0e1756bb8a3e64af177
             - name: BAYN_HEALTH_INTERVAL_MS
               value: "30000"
             - name: BAYN_OPERATION_TIMEOUT_MS

--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -22,5 +22,5 @@ configMapGenerator:
 images:
   - name: registry.ide-newton.ts.net/lab/bayn
     newName: registry.ide-newton.ts.net/lab/bayn
-    newTag: "sha-b0dfaac26c8e55c39c55aa75c7b7f3686e784543"
-    digest: sha256:e225540b24f749bb8a1743948c9c01768b443b3d51e42c12f1f4f617a67c9819
+    newTag: "sha-02c18b7bbd4885a3cda73620e19319638a758fc7"
+    digest: sha256:3079e8bf79c59254d5394a0bd3f2d5e269fd03cf083fab106bfbe423595ba6f9


### PR DESCRIPTION
## Summary

- Promote the merged Bayn image by immutable multi-architecture digest.
- Pin startup to qualification run `42d8bbfaf1a2ce7759b2283384e8f41298fe3a354ba7c0e1756bb8a3e64af177`.
- Keep the rejected production result fail-closed while exposing its deployment dossier.

## Related Issues

PROOMPT-369

## Testing

- Verified GitHub Actions release contract from successful main run `29802454781`: image digest `sha256:3079e8bf79c59254d5394a0bd3f2d5e269fd03cf083fab106bfbe423595ba6f9`.
- `bun run lint:argocd`
- `nix develop --command kustomize build --enable-helm argocd/applications/bayn`
- Rendered manifest piped to `kubectl apply --dry-run=client -n bayn -f -`.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed because this is a GitOps promotion.
- [x] Breaking Changes section is handled.
- [x] Documentation, release notes, and follow-ups are updated or tracked.