### PR TITLE
chore(torghut): promote image sha-04f7cce2f7042772c4f485a02a647d0da1c74371

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -54,7 +54,7 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: 79152bcf8e9c2bb74ef5b4059774bfb58a0eecbd
+              value: 04f7cce2f7042772c4f485a02a647d0da1c74371
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:5bad4a41c045fd00ea9ce014f5e49f5249bed686657e137fade783542da9e181
             - name: PYTHONPATH

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -46,7 +46,7 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: 79152bcf8e9c2bb74ef5b4059774bfb58a0eecbd
+              value: 04f7cce2f7042772c4f485a02a647d0da1c74371
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:5bad4a41c045fd00ea9ce014f5e49f5249bed686657e137fade783542da9e181
             - name: DB_DSN

--- a/argocd/applications/torghut-options/archive/deployment.yaml
+++ b/argocd/applications/torghut-options/archive/deployment.yaml
@@ -100,9 +100,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2294-g79152bcf8
+              value: v0.596.0-2350-g04f7cce2f
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 79152bcf8e9c2bb74ef5b4059774bfb58a0eecbd
+              value: 04f7cce2f7042772c4f485a02a647d0da1c74371
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -110,9 +110,9 @@ spec:
                   name: torghut-ws-config
                   key: SYMBOLS_ALLOWLIST
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2294-g79152bcf8
+              value: v0.596.0-2350-g04f7cce2f
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 79152bcf8e9c2bb74ef5b4059774bfb58a0eecbd
+              value: 04f7cce2f7042772c4f485a02a647d0da1c74371
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -106,9 +106,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2294-g79152bcf8
+              value: v0.596.0-2350-g04f7cce2f
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 79152bcf8e9c2bb74ef5b4059774bfb58a0eecbd
+              value: 04f7cce2f7042772c4f485a02a647d0da1c74371
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/broker-economic-ledger-reconciliation-cronjob.yaml
+++ b/argocd/applications/torghut/broker-economic-ledger-reconciliation-cronjob.yaml
@@ -92,9 +92,9 @@ spec:
                 - name: TRADING_ACCOUNT_LABEL
                   value: PA3SX7FYNUTF
                 - name: TORGHUT_VERSION
-                  value: v0.596.0-2294-g79152bcf8
+                  value: v0.596.0-2350-g04f7cce2f
                 - name: TORGHUT_COMMIT
-                  value: 79152bcf8e9c2bb74ef5b4059774bfb58a0eecbd
+                  value: 04f7cce2f7042772c4f485a02a647d0da1c74371
                 - name: TORGHUT_IMAGE_DIGEST
                   value: sha256:5bad4a41c045fd00ea9ce014f5e49f5249bed686657e137fade783542da9e181
                 - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-20T09:03:05Z"
+        client.knative.dev/updateTimestamp: "2026-07-21T05:10:03Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -528,9 +528,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2294-g79152bcf8
+              value: v0.596.0-2350-g04f7cce2f
             - name: TORGHUT_COMMIT
-              value: 79152bcf8e9c2bb74ef5b4059774bfb58a0eecbd
+              value: 04f7cce2f7042772c4f485a02a647d0da1c74371
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:5bad4a41c045fd00ea9ce014f5e49f5249bed686657e137fade783542da9e181
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-20T09:03:05Z"
+        client.knative.dev/updateTimestamp: "2026-07-21T05:10:03Z"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
     spec:
@@ -453,9 +453,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2294-g79152bcf8
+              value: v0.596.0-2350-g04f7cce2f
             - name: TORGHUT_COMMIT
-              value: 79152bcf8e9c2bb74ef5b4059774bfb58a0eecbd
+              value: 04f7cce2f7042772c4f485a02a647d0da1c74371
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:5bad4a41c045fd00ea9ce014f5e49f5249bed686657e137fade783542da9e181
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/order-lineage-reconciliation-cronjob.yaml
+++ b/argocd/applications/torghut/order-lineage-reconciliation-cronjob.yaml
@@ -88,9 +88,9 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_VERSION
-                  value: v0.596.0-2294-g79152bcf8
+                  value: v0.596.0-2350-g04f7cce2f
                 - name: TORGHUT_COMMIT
-                  value: 79152bcf8e9c2bb74ef5b4059774bfb58a0eecbd
+                  value: 04f7cce2f7042772c4f485a02a647d0da1c74371
                 - name: TORGHUT_IMAGE_DIGEST
                   value: sha256:5bad4a41c045fd00ea9ce014f5e49f5249bed686657e137fade783542da9e181
                 - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -470,9 +470,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2294-g79152bcf8
+              value: v0.596.0-2350-g04f7cce2f
             - name: TORGHUT_COMMIT
-              value: 79152bcf8e9c2bb74ef5b4059774bfb58a0eecbd
+              value: 04f7cce2f7042772c4f485a02a647d0da1c74371
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:5bad4a41c045fd00ea9ce014f5e49f5249bed686657e137fade783542da9e181
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `04f7cce2f7042772c4f485a02a647d0da1c74371`
- Image tag: `sha-04f7cce2f7042772c4f485a02a647d0da1c74371`
- Image digest: `sha256:5bad4a41c045fd00ea9ce014f5e49f5249bed686657e137fade783542da9e181`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher