### PR TITLE
chore(torghut): promote image sha-a2b232bf47ebadb398a4c5b8ab8b26e40901376c

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -24,7 +24,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: migrate
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a5e4bf7442f80de5ca61630a300fd0b53817f5c67f8a13d94dc3414b81e57065
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e8cb1281ba90f29462e0fedc04c8c1271609f3cf416db1c4862c71a8f64ce9c9
           imagePullPolicy: Always
           workingDir: /app
           command:
@@ -54,9 +54,9 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: 7266722998cca1893ed68b8f98423ebf1b22026d
+              value: a2b232bf47ebadb398a4c5b8ab8b26e40901376c
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:a5e4bf7442f80de5ca61630a300fd0b53817f5c67f8a13d94dc3414b81e57065
+              value: sha256:e8cb1281ba90f29462e0fedc04c8c1271609f3cf416db1c4862c71a8f64ce9c9
             - name: PYTHONPATH
               value: /app
             - name: DB_DSN

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-hyperliquid-runtime
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a5e4bf7442f80de5ca61630a300fd0b53817f5c67f8a13d94dc3414b81e57065
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e8cb1281ba90f29462e0fedc04c8c1271609f3cf416db1c4862c71a8f64ce9c9
           imagePullPolicy: Always
           command:
             - uvicorn
@@ -46,9 +46,9 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: 7266722998cca1893ed68b8f98423ebf1b22026d
+              value: a2b232bf47ebadb398a4c5b8ab8b26e40901376c
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:a5e4bf7442f80de5ca61630a300fd0b53817f5c67f8a13d94dc3414b81e57065
+              value: sha256:e8cb1281ba90f29462e0fedc04c8c1271609f3cf416db1c4862c71a8f64ce9c9
             - name: DB_DSN
               valueFrom:
                 secretKeyRef:

--- a/argocd/applications/torghut-options/archive/deployment.yaml
+++ b/argocd/applications/torghut-options/archive/deployment.yaml
@@ -35,7 +35,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: await-options-schema
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a5e4bf7442f80de5ca61630a300fd0b53817f5c67f8a13d94dc3414b81e57065
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e8cb1281ba90f29462e0fedc04c8c1271609f3cf416db1c4862c71a8f64ce9c9
           imagePullPolicy: IfNotPresent
           command:
             - python
@@ -64,7 +64,7 @@ spec:
                 - ALL
       containers:
         - name: torghut-options-archive
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a5e4bf7442f80de5ca61630a300fd0b53817f5c67f8a13d94dc3414b81e57065
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e8cb1281ba90f29462e0fedc04c8c1271609f3cf416db1c4862c71a8f64ce9c9
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -100,9 +100,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2352-g726672299
+              value: v0.596.0-2355-ga2b232bf4
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 7266722998cca1893ed68b8f98423ebf1b22026d
+              value: a2b232bf47ebadb398a4c5b8ab8b26e40901376c
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -33,7 +33,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: await-options-schema
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a5e4bf7442f80de5ca61630a300fd0b53817f5c67f8a13d94dc3414b81e57065
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e8cb1281ba90f29462e0fedc04c8c1271609f3cf416db1c4862c71a8f64ce9c9
           imagePullPolicy: IfNotPresent
           command:
             - python
@@ -62,7 +62,7 @@ spec:
                 - ALL
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a5e4bf7442f80de5ca61630a300fd0b53817f5c67f8a13d94dc3414b81e57065
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e8cb1281ba90f29462e0fedc04c8c1271609f3cf416db1c4862c71a8f64ce9c9
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -110,9 +110,9 @@ spec:
                   name: torghut-ws-config
                   key: SYMBOLS_ALLOWLIST
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2352-g726672299
+              value: v0.596.0-2355-ga2b232bf4
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 7266722998cca1893ed68b8f98423ebf1b22026d
+              value: a2b232bf47ebadb398a4c5b8ab8b26e40901376c
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: await-options-schema
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a5e4bf7442f80de5ca61630a300fd0b53817f5c67f8a13d94dc3414b81e57065
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e8cb1281ba90f29462e0fedc04c8c1271609f3cf416db1c4862c71a8f64ce9c9
           imagePullPolicy: IfNotPresent
           command:
             - python
@@ -63,7 +63,7 @@ spec:
                 - ALL
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a5e4bf7442f80de5ca61630a300fd0b53817f5c67f8a13d94dc3414b81e57065
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e8cb1281ba90f29462e0fedc04c8c1271609f3cf416db1c4862c71a8f64ce9c9
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -106,9 +106,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2352-g726672299
+              value: v0.596.0-2355-ga2b232bf4
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 7266722998cca1893ed68b8f98423ebf1b22026d
+              value: a2b232bf47ebadb398a4c5b8ab8b26e40901376c
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:a5e4bf7442f80de5ca61630a300fd0b53817f5c67f8a13d94dc3414b81e57065
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e8cb1281ba90f29462e0fedc04c8c1271609f3cf416db1c4862c71a8f64ce9c9
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:a5e4bf7442f80de5ca61630a300fd0b53817f5c67f8a13d94dc3414b81e57065
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e8cb1281ba90f29462e0fedc04c8c1271609f3cf416db1c4862c71a8f64ce9c9
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:a5e4bf7442f80de5ca61630a300fd0b53817f5c67f8a13d94dc3414b81e57065
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e8cb1281ba90f29462e0fedc04c8c1271609f3cf416db1c4862c71a8f64ce9c9
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:a5e4bf7442f80de5ca61630a300fd0b53817f5c67f8a13d94dc3414b81e57065
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e8cb1281ba90f29462e0fedc04c8c1271609f3cf416db1c4862c71a8f64ce9c9
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/broker-economic-ledger-reconciliation-cronjob.yaml
+++ b/argocd/applications/torghut/broker-economic-ledger-reconciliation-cronjob.yaml
@@ -36,7 +36,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: reconcile
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:a5e4bf7442f80de5ca61630a300fd0b53817f5c67f8a13d94dc3414b81e57065
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:e8cb1281ba90f29462e0fedc04c8c1271609f3cf416db1c4862c71a8f64ce9c9
               imagePullPolicy: IfNotPresent
               securityContext:
                 seccompProfile:
@@ -92,11 +92,11 @@ spec:
                 - name: TRADING_ACCOUNT_LABEL
                   value: PA3SX7FYNUTF
                 - name: TORGHUT_VERSION
-                  value: v0.596.0-2352-g726672299
+                  value: v0.596.0-2355-ga2b232bf4
                 - name: TORGHUT_COMMIT
-                  value: 7266722998cca1893ed68b8f98423ebf1b22026d
+                  value: a2b232bf47ebadb398a4c5b8ab8b26e40901376c
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:a5e4bf7442f80de5ca61630a300fd0b53817f5c67f8a13d94dc3414b81e57065
+                  value: sha256:e8cb1281ba90f29462e0fedc04c8c1271609f3cf416db1c4862c71a8f64ce9c9
                 - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
                   value: linux/amd64,linux/arm64
                 - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a5e4bf7442f80de5ca61630a300fd0b53817f5c67f8a13d94dc3414b81e57065
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e8cb1281ba90f29462e0fedc04c8c1271609f3cf416db1c4862c71a8f64ce9c9
           workingDir: /app
           command:
             - /bin/sh

--- a/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
+++ b/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-generated-resource-retention
           containers:
             - name: prune-generated-residue
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:a5e4bf7442f80de5ca61630a300fd0b53817f5c67f8a13d94dc3414b81e57065
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:e8cb1281ba90f29462e0fedc04c8c1271609f3cf416db1c4862c71a8f64ce9c9
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:a5e4bf7442f80de5ca61630a300fd0b53817f5c67f8a13d94dc3414b81e57065
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:e8cb1281ba90f29462e0fedc04c8c1271609f3cf416db1c4862c71a8f64ce9c9
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-21T05:19:03Z"
+        client.knative.dev/updateTimestamp: "2026-07-21T05:40:46Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -34,7 +34,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a5e4bf7442f80de5ca61630a300fd0b53817f5c67f8a13d94dc3414b81e57065
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e8cb1281ba90f29462e0fedc04c8c1271609f3cf416db1c4862c71a8f64ce9c9
           ports:
             - name: http1
               containerPort: 8181
@@ -528,11 +528,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2352-g726672299
+              value: v0.596.0-2355-ga2b232bf4
             - name: TORGHUT_COMMIT
-              value: 7266722998cca1893ed68b8f98423ebf1b22026d
+              value: a2b232bf47ebadb398a4c5b8ab8b26e40901376c
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:a5e4bf7442f80de5ca61630a300fd0b53817f5c67f8a13d94dc3414b81e57065
+              value: sha256:e8cb1281ba90f29462e0fedc04c8c1271609f3cf416db1c4862c71a8f64ce9c9
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-21T05:19:03Z"
+        client.knative.dev/updateTimestamp: "2026-07-21T05:40:46Z"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
     spec:
@@ -30,7 +30,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a5e4bf7442f80de5ca61630a300fd0b53817f5c67f8a13d94dc3414b81e57065
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e8cb1281ba90f29462e0fedc04c8c1271609f3cf416db1c4862c71a8f64ce9c9
           ports:
             - name: http1
               containerPort: 8181
@@ -453,11 +453,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2352-g726672299
+              value: v0.596.0-2355-ga2b232bf4
             - name: TORGHUT_COMMIT
-              value: 7266722998cca1893ed68b8f98423ebf1b22026d
+              value: a2b232bf47ebadb398a4c5b8ab8b26e40901376c
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:a5e4bf7442f80de5ca61630a300fd0b53817f5c67f8a13d94dc3414b81e57065
+              value: sha256:e8cb1281ba90f29462e0fedc04c8c1271609f3cf416db1c4862c71a8f64ce9c9
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/order-lineage-reconciliation-cronjob.yaml
+++ b/argocd/applications/torghut/order-lineage-reconciliation-cronjob.yaml
@@ -39,7 +39,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: reconcile
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:a5e4bf7442f80de5ca61630a300fd0b53817f5c67f8a13d94dc3414b81e57065
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:e8cb1281ba90f29462e0fedc04c8c1271609f3cf416db1c4862c71a8f64ce9c9
               imagePullPolicy: IfNotPresent
               securityContext:
                 allowPrivilegeEscalation: false
@@ -88,11 +88,11 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_VERSION
-                  value: v0.596.0-2352-g726672299
+                  value: v0.596.0-2355-ga2b232bf4
                 - name: TORGHUT_COMMIT
-                  value: 7266722998cca1893ed68b8f98423ebf1b22026d
+                  value: a2b232bf47ebadb398a4c5b8ab8b26e40901376c
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:a5e4bf7442f80de5ca61630a300fd0b53817f5c67f8a13d94dc3414b81e57065
+                  value: sha256:e8cb1281ba90f29462e0fedc04c8c1271609f3cf416db1c4862c71a8f64ce9c9
                 - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
                   value: linux/amd64,linux/arm64
                 - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -37,7 +37,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a5e4bf7442f80de5ca61630a300fd0b53817f5c67f8a13d94dc3414b81e57065
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e8cb1281ba90f29462e0fedc04c8c1271609f3cf416db1c4862c71a8f64ce9c9
           command:
             - uvicorn
           args:
@@ -470,11 +470,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2352-g726672299
+              value: v0.596.0-2355-ga2b232bf4
             - name: TORGHUT_COMMIT
-              value: 7266722998cca1893ed68b8f98423ebf1b22026d
+              value: a2b232bf47ebadb398a4c5b8ab8b26e40901376c
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:a5e4bf7442f80de5ca61630a300fd0b53817f5c67f8a13d94dc3414b81e57065
+              value: sha256:e8cb1281ba90f29462e0fedc04c8c1271609f3cf416db1c4862c71a8f64ce9c9
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: smoke
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a5e4bf7442f80de5ca61630a300fd0b53817f5c67f8a13d94dc3414b81e57065
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e8cb1281ba90f29462e0fedc04c8c1271609f3cf416db1c4862c71a8f64ce9c9
           imagePullPolicy: IfNotPresent
           securityContext:
             seccompProfile:


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `a2b232bf47ebadb398a4c5b8ab8b26e40901376c`
- Image tag: `sha-a2b232bf47ebadb398a4c5b8ab8b26e40901376c`
- Image digest: `sha256:e8cb1281ba90f29462e0fedc04c8c1271609f3cf416db1c4862c71a8f64ce9c9`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher