### PR TITLE
feat(platform): enforce network policies with kube-router

### DIFF
--- a/.github/ci/impact-map.yml
+++ b/.github/ci/impact-map.yml
@@ -61,12 +61,14 @@ targets:
       - .github/ci/impact-map.yml
       - .github/workflows/pull-request.yml
       - argocd/applications/hermes/**
+      - argocd/applications/kube-router/**
       - argocd/applications/observability/cluster-metrics-alloy-config.river
       - argocd/applications/observability/cluster-metrics-alloy-deployment.yaml
       - argocd/applications/observability/graf-mimir-rules.yaml
       - argocd/applications/observability/kube-state-metrics-values.yaml
       - argocd/applicationsets/platform.yaml
       - docs/runbooks/hermes-production-rollout.md
+      - docs/runbooks/kube-router-network-policy-rollout.md
       - scripts/**
 
   sag:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -203,6 +203,8 @@ jobs:
               bun run lint:flamingo-hard-migration
               bun run scripts/hermes/validate-production.ts
               bun test scripts/hermes/*.test.ts
+              bun run scripts/kube-router/validate-production.ts
+              bun test scripts/kube-router/*.test.ts
               ;;
             sag)
               bun install --frozen-lockfile --ignore-scripts --filter @proompteng/source --filter @proompteng/sag

--- a/argocd/applications/kube-router/README.md
+++ b/argocd/applications/kube-router/README.md
@@ -1,0 +1,24 @@
+# kube-router NetworkPolicy controller
+
+This manual Argo CD application runs kube-router v2.10.0 only as a Kubernetes NetworkPolicy controller. Flannel remains
+the CNI and kube-proxy remains the nftables service proxy. Routing, service proxying, load-balancer allocation, CNI
+installation, and IPv6 are explicitly disabled.
+
+The image is pinned to the multi-architecture index
+`sha256:0991f2cc7aaabe107b51c0c554d6b843f0483fd319b94f437fab638470c47c22`. Its expected Linux platform manifests are:
+
+- amd64: `sha256:81619a698b981a5c4fd6c89ae015d0faadce5d7a5270df7562c1743e58e3283f`
+- arm64: `sha256:b8df3247641d5f4e84e14d30b673b6362a0e3d56901218a1e1ee38a40f37afd8`
+
+## Activation safety
+
+The application is manual. Sync wave `-3` installs temporary allow-all policies in every namespace that already has a
+NetworkPolicy. A bounded wave `-2` hook compares that declared namespace set to the live cluster and validates every
+safety policy. Any mismatch stops the sync before the DaemonSet is applied at wave `0`.
+
+The safety policies use `Prune=false`. Do not remove them as part of controller activation or rollback. Replace them only
+through namespace-specific policy tests that prove all required ingress and egress before enforcement.
+
+Follow [the production rollout runbook](../../../docs/runbooks/kube-router-network-policy-rollout.md) for activation,
+live enforcement proof, workload comparison, and cleanup. The emergency cleanup overlay is intentionally excluded from
+the production kustomization.

--- a/argocd/applications/kube-router/daemonset.yaml
+++ b/argocd/applications/kube-router/daemonset.yaml
@@ -1,0 +1,120 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-router
+  namespace: kube-system
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  labels:
+    app.kubernetes.io/name: kube-router
+    app.kubernetes.io/component: network-policy
+    app.kubernetes.io/version: v2.10.0
+spec:
+  minReadySeconds: 15
+  revisionHistoryLimit: 3
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-router
+      app.kubernetes.io/component: network-policy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kube-router
+        app.kubernetes.io/component: network-policy
+        app.kubernetes.io/version: v2.10.0
+    spec:
+      serviceAccountName: kube-router
+      automountServiceAccountToken: true
+      priorityClassName: system-node-critical
+      hostNetwork: true
+      hostPID: true
+      dnsPolicy: ClusterFirstWithHostNet
+      terminationGracePeriodSeconds: 30
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: kube-router
+          image: docker.io/cloudnativelabs/kube-router@sha256:0991f2cc7aaabe107b51c0c554d6b843f0483fd319b94f437fab638470c47c22
+          imagePullPolicy: IfNotPresent
+          args:
+            - --run-router=false
+            - --run-service-proxy=false
+            - --run-firewall=true
+            - --run-loadbalancer=false
+            - --enable-cni=false
+            - --enable-ipv4=true
+            - --enable-ipv6=false
+            - --hostname-override=$(NODE_NAME)
+            - --service-cluster-ip-range=10.96.0.0/12
+            - --cache-sync-timeout=1m
+            - --iptables-sync-period=30s
+            - --health-port=20244
+            - --metrics-port=20241
+            - --v=2
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          ports:
+            - name: metrics
+              containerPort: 20241
+              protocol: TCP
+            - name: health
+              containerPort: 20244
+              protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 24
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: "1"
+              memory: 512Mi
+          securityContext:
+            privileged: true
+            allowPrivilegeEscalation: true
+            readOnlyRootFilesystem: true
+            runAsUser: 0
+          volumeMounts:
+            - name: lib-modules
+              mountPath: /lib/modules
+              readOnly: true
+            - name: xtables-lock
+              mountPath: /run/xtables.lock
+      volumes:
+        - name: lib-modules
+          hostPath:
+            path: /usr/lib/modules
+            type: Directory
+        - name: xtables-lock
+          hostPath:
+            path: /run/xtables.lock
+            type: FileOrCreate

--- a/argocd/applications/kube-router/kustomization.yaml
+++ b/argocd/applications/kube-router/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - service-account.yaml
+  - rbac.yaml
+  - safety-policies.yaml
+  - preflight-hook.yaml
+  - service.yaml
+  - daemonset.yaml

--- a/argocd/applications/kube-router/operations/cleanup/cleanup-daemonset.yaml
+++ b/argocd/applications/kube-router/operations/cleanup/cleanup-daemonset.yaml
@@ -1,0 +1,152 @@
+# Emergency-only cleanup. This manifest is intentionally excluded from the
+# production kustomization and must never run while the active controller runs.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-router-cleanup
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: kube-router-cleanup
+    app.kubernetes.io/component: emergency-cleanup
+spec:
+  minReadySeconds: 5
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-router-cleanup
+      app.kubernetes.io/component: emergency-cleanup
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kube-router-cleanup
+        app.kubernetes.io/component: emergency-cleanup
+    spec:
+      automountServiceAccountToken: false
+      priorityClassName: system-node-critical
+      hostNetwork: true
+      hostPID: true
+      dnsPolicy: ClusterFirstWithHostNet
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - operator: Exists
+      initContainers:
+        - name: cleanup
+          image: docker.io/cloudnativelabs/kube-router@sha256:0991f2cc7aaabe107b51c0c554d6b843f0483fd319b94f437fab638470c47c22
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+            - -ec
+          args:
+            - |
+              set -o pipefail
+
+              cleanup_filter_family() {
+                table_command=$1
+                save_command=$2
+
+                if ! "$save_command" -t filter >/dev/null 2>&1; then
+                  return
+                fi
+
+                for builtin_chain in INPUT FORWARD OUTPUT; do
+                  kube_router_chain="KUBE-ROUTER-$builtin_chain"
+                  while true; do
+                    rule_number=$(
+                      "$table_command" -w 10 -t filter -L "$builtin_chain" --line-numbers -n |
+                        awk -v target="$kube_router_chain" '$2 == target { print $1; exit }'
+                    )
+                    if [ -z "$rule_number" ]; then
+                      break
+                    fi
+                    "$table_command" -w 10 -t filter -D "$builtin_chain" "$rule_number"
+                  done
+                done
+
+                "$save_command" -t filter |
+                  awk '/^:KUBE-(ROUTER|NWPLCY|POD-FW)-/ { sub(/^:/, "", $1); print $1 }' |
+                  while IFS= read -r chain; do
+                    "$table_command" -w 10 -t filter -F "$chain"
+                  done
+                "$save_command" -t filter |
+                  awk '/^:KUBE-(ROUTER|NWPLCY|POD-FW)-/ { sub(/^:/, "", $1); print $1 }' |
+                  while IFS= read -r chain; do
+                    "$table_command" -w 10 -t filter -X "$chain"
+                  done
+
+                if "$save_command" -t filter | grep -Eq 'KUBE-(ROUTER|NWPLCY|POD-FW)-'; then
+                  echo "targeted kube-router cleanup left rules in $save_command" >&2
+                  exit 1
+                fi
+              }
+
+              cleanup_filter_family /usr/sbin/iptables /usr/sbin/iptables-save
+              cleanup_filter_family /usr/sbin/ip6tables /usr/sbin/ip6tables-save
+
+              /usr/sbin/ipset list -name |
+                awk '/^(inet6:)?KUBE-(SRC|DST)-|^(inet6:)?kube-router-local-pods$/ { print }' |
+                while IFS= read -r set_name; do
+                  /usr/sbin/ipset destroy "$set_name"
+                done
+              if /usr/sbin/ipset list -name |
+                grep -Eq '^(inet6:)?KUBE-(SRC|DST)-|^(inet6:)?kube-router-local-pods$'; then
+                echo 'targeted kube-router cleanup left NetworkPolicy ipsets' >&2
+                exit 1
+              fi
+          securityContext:
+            privileged: true
+            allowPrivilegeEscalation: true
+            readOnlyRootFilesystem: true
+            runAsUser: 0
+          volumeMounts:
+            - name: lib-modules
+              mountPath: /lib/modules
+              readOnly: true
+            - name: xtables-lock
+              mountPath: /run/xtables.lock
+      containers:
+        - name: verifier
+          image: docker.io/cloudnativelabs/kube-router@sha256:0991f2cc7aaabe107b51c0c554d6b843f0483fd319b94f437fab638470c47c22
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -ec
+          args:
+            - |
+              trap 'exit 0' TERM INT
+              while true; do sleep 3600; done
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -ec
+                - iptables-save >/dev/null
+            periodSeconds: 5
+            timeoutSeconds: 2
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+          securityContext:
+            privileged: true
+            allowPrivilegeEscalation: true
+            readOnlyRootFilesystem: true
+            runAsUser: 0
+          volumeMounts:
+            - name: lib-modules
+              mountPath: /lib/modules
+              readOnly: true
+            - name: xtables-lock
+              mountPath: /run/xtables.lock
+      terminationGracePeriodSeconds: 10
+      volumes:
+        - name: lib-modules
+          hostPath:
+            path: /usr/lib/modules
+            type: Directory
+        - name: xtables-lock
+          hostPath:
+            path: /run/xtables.lock
+            type: FileOrCreate

--- a/argocd/applications/kube-router/operations/cleanup/kustomization.yaml
+++ b/argocd/applications/kube-router/operations/cleanup/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kube-system
+resources:
+  - cleanup-daemonset.yaml

--- a/argocd/applications/kube-router/preflight-hook.yaml
+++ b/argocd/applications/kube-router/preflight-hook.yaml
@@ -1,0 +1,88 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kube-router-policy-preflight
+  namespace: kube-system
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+    argocd.argoproj.io/sync-wave: "-2"
+spec:
+  activeDeadlineSeconds: 120
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kube-router
+        app.kubernetes.io/component: policy-preflight
+    spec:
+      serviceAccountName: kube-router-policy-preflight
+      automountServiceAccountToken: true
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/os: linux
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: verify-policy-safety
+          image: docker.io/bitnami/kubectl@sha256:a67b11e95e953f550f020a41970185ccc5f83d78b86b8c575d02c904aa0f9cd7
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: HOME
+              value: /tmp
+          command:
+            - /bin/bash
+            - -ec
+          args:
+            - |
+              set -o pipefail
+              expected_namespaces=$(
+                printf '%s\n' agents argocd bayn bilig kafka media pgadmin synthesis torghut | sort -u
+              )
+              actual_namespaces=$(
+                kubectl get networkpolicies.networking.k8s.io --all-namespaces -o json |
+                  jq -r '.items[].metadata.namespace' |
+                  sort -u
+              )
+
+              if [[ "$actual_namespaces" != "$expected_namespaces" ]]; then
+                echo 'NetworkPolicy namespace coverage changed; refusing to activate kube-router.' >&2
+                diff -u <(printf '%s\n' "$expected_namespaces") <(printf '%s\n' "$actual_namespaces") >&2 || true
+                exit 1
+              fi
+
+              while IFS= read -r namespace; do
+                kubectl -n "$namespace" get networkpolicy kube-router-rollout-allow-all -o json |
+                  jq -e '
+                    .spec.podSelector == {} and
+                    (.spec.policyTypes | sort) == ["Egress", "Ingress"] and
+                    .spec.ingress == [{}] and
+                    .spec.egress == [{}]
+                  ' >/dev/null
+              done <<< "$expected_namespaces"
+
+              echo 'All existing NetworkPolicy namespaces have a traffic-neutral activation policy.'
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/argocd/applications/kube-router/rbac.yaml
+++ b/argocd/applications/kube-router/rbac.yaml
@@ -1,0 +1,79 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-router
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - nodes
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-router
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-router
+subjects:
+  - kind: ServiceAccount
+    name: kube-router
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-router-policy-preflight
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+rules:
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-router-policy-preflight
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-router-policy-preflight
+subjects:
+  - kind: ServiceAccount
+    name: kube-router-policy-preflight
+    namespace: kube-system

--- a/argocd/applications/kube-router/safety-policies.yaml
+++ b/argocd/applications/kube-router/safety-policies.yaml
@@ -1,0 +1,164 @@
+# These temporary policies make enforcement activation traffic-neutral in every
+# namespace that already has a NetworkPolicy. Removal requires a separate,
+# namespace-by-namespace policy validation rollout.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kube-router-rollout-allow-all
+  namespace: agents
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+    argocd.argoproj.io/sync-options: Prune=false
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - {}
+  egress:
+    - {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kube-router-rollout-allow-all
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+    argocd.argoproj.io/sync-options: Prune=false
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - {}
+  egress:
+    - {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kube-router-rollout-allow-all
+  namespace: bayn
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+    argocd.argoproj.io/sync-options: Prune=false
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - {}
+  egress:
+    - {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kube-router-rollout-allow-all
+  namespace: bilig
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+    argocd.argoproj.io/sync-options: Prune=false
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - {}
+  egress:
+    - {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kube-router-rollout-allow-all
+  namespace: kafka
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+    argocd.argoproj.io/sync-options: Prune=false
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - {}
+  egress:
+    - {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kube-router-rollout-allow-all
+  namespace: media
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+    argocd.argoproj.io/sync-options: Prune=false
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - {}
+  egress:
+    - {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kube-router-rollout-allow-all
+  namespace: pgadmin
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+    argocd.argoproj.io/sync-options: Prune=false
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - {}
+  egress:
+    - {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kube-router-rollout-allow-all
+  namespace: synthesis
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+    argocd.argoproj.io/sync-options: Prune=false
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - {}
+  egress:
+    - {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kube-router-rollout-allow-all
+  namespace: torghut
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+    argocd.argoproj.io/sync-options: Prune=false
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - {}
+  egress:
+    - {}

--- a/argocd/applications/kube-router/service-account.yaml
+++ b/argocd/applications/kube-router/service-account.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-router
+  namespace: kube-system
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+automountServiceAccountToken: true
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-router-policy-preflight
+  namespace: kube-system
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+automountServiceAccountToken: true

--- a/argocd/applications/kube-router/service.yaml
+++ b/argocd/applications/kube-router/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-router-metrics
+  namespace: kube-system
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  labels:
+    app.kubernetes.io/name: kube-router
+    app.kubernetes.io/component: network-policy
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: kube-router
+    app.kubernetes.io/component: network-policy
+  ports:
+    - name: metrics
+      port: 20241
+      targetPort: metrics
+    - name: health
+      port: 20244
+      targetPort: health

--- a/argocd/applications/observability/cluster-metrics-alloy-config.river
+++ b/argocd/applications/observability/cluster-metrics-alloy-config.river
@@ -96,8 +96,60 @@ prometheus.relabel "arc_resource_metrics" {
   rule {
     action        = "keep"
     source_labels = ["__name__"]
-    regex         = "up|container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|kube_argocd_application_deployment_history_info|kube_cronjob_created|kube_cronjob_status_last_successful_time|kube_deployment_spec_replicas|kube_deployment_status_replicas_available|kube_node_status_allocatable|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_restarts_total|kube_pod_info|kube_pod_labels|kube_pod_status_phase|kube_service_info|kube_statefulset_status_replicas_ready|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes"
+    regex         = "up|container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|kube_argocd_application_deployment_history_info|kube_cronjob_created|kube_cronjob_status_last_successful_time|kube_daemonset_status_desired_number_scheduled|kube_daemonset_status_number_ready|kube_daemonset_status_number_unavailable|kube_deployment_spec_replicas|kube_deployment_status_replicas_available|kube_node_status_allocatable|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_restarts_total|kube_pod_info|kube_pod_labels|kube_pod_status_phase|kube_service_info|kube_statefulset_status_replicas_ready|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes"
   }
+}
+
+discovery.kubernetes "kube_router_pods" {
+  role = "pod"
+
+  selectors {
+    role  = "pod"
+    label = "app.kubernetes.io/name=kube-router,app.kubernetes.io/component=network-policy"
+  }
+}
+
+discovery.relabel "kube_router_metrics" {
+  targets = discovery.kubernetes.kube_router_pods.targets
+
+  rule {
+    action        = "keep"
+    source_labels = ["__meta_kubernetes_pod_container_port_name"]
+    regex         = "metrics"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_namespace"]
+    target_label  = "namespace"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_pod_name"]
+    target_label  = "pod"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_pod_node_name"]
+    target_label  = "node"
+  }
+}
+
+prometheus.relabel "kube_router_metrics" {
+  forward_to = [prometheus.remote_write.mimir.receiver]
+
+  rule {
+    action        = "keep"
+    source_labels = ["__name__"]
+    regex         = "up|kube_router_build_info|kube_router_controller_(iptables|policy)_.*"
+  }
+}
+
+prometheus.scrape "kube_router" {
+  job_name        = "kube-router"
+  targets         = discovery.relabel.kube_router_metrics.output
+  scrape_interval = "30s"
+  scrape_timeout  = "10s"
+  forward_to      = [prometheus.relabel.kube_router_metrics.receiver]
 }
 
 prometheus.relabel "rbd_client_metrics" {

--- a/argocd/applications/observability/cluster-metrics-alloy-deployment.yaml
+++ b/argocd/applications/observability/cluster-metrics-alloy-deployment.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        observability.proompteng.ai/config-sha256: 2bc953061d4d94e453cbdbc083200d669550ae34d6b3aa4356f69b1850b2ce89
+        observability.proompteng.ai/config-sha256: f3721c207575c9703d317edb7547015d8f798348bf1f193e9946a50d5d71541c
       labels:
         app.kubernetes.io/name: observability-cluster-metrics-alloy
         app.kubernetes.io/component: cluster-metrics

--- a/argocd/applications/observability/graf-mimir-rules.yaml
+++ b/argocd/applications/observability/graf-mimir-rules.yaml
@@ -133,6 +133,96 @@ data:
               summary: Hermes backup is stale
               description: The Hermes backup CronJob is missing or has no successful completion within its 26-hour freshness window; inspect its Job logs and verified archives.
               runbook_url: docs/runbooks/hermes-production-rollout.md
+      - name: kube-router-network-policy.rules
+        rules:
+          - record: kube_router_rollout_enabled
+            expr: |
+              max(
+                kube_argocd_application_deployment_history_info{
+                  namespace="argocd",
+                  application="kube-router"
+                }
+              )
+          - alert: KubeRouterDaemonSetUnavailable
+            expr: |
+              (
+                (
+                  kube_daemonset_status_number_ready{
+                    namespace="kube-system",
+                    daemonset="kube-router"
+                  }
+                  <
+                  kube_daemonset_status_desired_number_scheduled{
+                    namespace="kube-system",
+                    daemonset="kube-router"
+                  }
+                )
+                or
+                absent(
+                  kube_daemonset_status_number_ready{
+                    namespace="kube-system",
+                    daemonset="kube-router"
+                  }
+                )
+              )
+              and on()
+              (kube_router_rollout_enabled == 1)
+            for: 5m
+            labels:
+              severity: critical
+              team: platform
+              service: kube-router
+            annotations:
+              summary: kube-router is unavailable on one or more nodes
+              description: The NetworkPolicy controller is not ready on every desired Linux node for five minutes.
+              runbook_url: docs/runbooks/kube-router-network-policy-rollout.md
+          - alert: KubeRouterMetricsMissing
+            expr: |
+              (
+                max(up{job="kube-router"} == 0) == 1
+                or
+                count(up{job="kube-router"})
+                  <
+                max(
+                  kube_daemonset_status_desired_number_scheduled{
+                    namespace="kube-system",
+                    daemonset="kube-router"
+                  }
+                )
+                or
+                absent(up{job="kube-router"})
+              )
+              and on()
+              (kube_router_rollout_enabled == 1)
+            for: 5m
+            labels:
+              severity: critical
+              team: platform
+              service: kube-router
+            annotations:
+              summary: kube-router policy metrics are incomplete
+              description: At least one desired kube-router controller is not being scraped successfully.
+              runbook_url: docs/runbooks/kube-router-network-policy-rollout.md
+          - alert: KubeRouterContainerRestarting
+            expr: |
+              sum by (pod) (
+                increase(
+                  kube_pod_container_status_restarts_total{
+                    namespace="kube-system",
+                    pod=~"kube-router-.*",
+                    container="kube-router"
+                  }[15m]
+                )
+              ) > 0
+            for: 5m
+            labels:
+              severity: warning
+              team: platform
+              service: kube-router
+            annotations:
+              summary: kube-router is restarting
+              description: NetworkPolicy controller Pod {{ $labels.pod }} restarted in the last 15 minutes.
+              runbook_url: docs/runbooks/kube-router-network-policy-rollout.md
       - name: graf-telemetry.rules
         rules:
           - alert: GrafHigh5xxRate

--- a/argocd/applications/observability/kube-state-metrics-values.yaml
+++ b/argocd/applications/observability/kube-state-metrics-values.yaml
@@ -4,6 +4,7 @@ replicas: 1
 
 collectors:
   - cronjobs
+  - daemonsets
   - deployments
   - namespaces
   - nodes

--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -83,6 +83,13 @@ spec:
                   argocd.argoproj.io/sync-wave: "-1"
                 automation: auto
                 enabled: "true"
+              - name: kube-router
+                path: argocd/applications/kube-router
+                namespace: kube-system
+                annotations:
+                  argocd.argoproj.io/sync-wave: "-1"
+                automation: manual
+                enabled: "true"
               - name: volume-snapshot-controller
                 path: argocd/applications/volume-snapshot-controller
                 namespace: kube-system

--- a/docs/runbooks/kube-router-network-policy-rollout.md
+++ b/docs/runbooks/kube-router-network-policy-rollout.md
@@ -1,0 +1,175 @@
+# kube-router NetworkPolicy production rollout
+
+This runbook activates enforcement for `networking.k8s.io/v1` NetworkPolicies without replacing Flannel or kube-proxy.
+The application is manual and must be rolled out only from merged `main`.
+
+## Invariants
+
+- Keep Flannel as the CNI and kube-proxy in nftables mode.
+- Keep kube-router routing, service proxy, load-balancer allocation, CNI installation, and IPv6 disabled.
+- Never activate the DaemonSet unless every namespace with an existing NetworkPolicy has the temporary allow-all policy.
+- Never remove the temporary safety policies during activation or rollback.
+- Never delete the active DaemonSet without subsequently running the pinned cleanup DaemonSet on every node; kube-router
+  rules persist after the controller exits.
+- Stop immediately on node, workload, DNS, service routing, or policy-probe regression.
+
+## 1. Release and cluster preflight
+
+Run from the repository root and retain the non-secret output:
+
+```bash
+set -euo pipefail
+git fetch --quiet origin main
+main_revision=$(git rev-parse origin/main)
+test "$(git rev-parse HEAD)" = "$main_revision"
+test "$(crane digest docker.io/cloudnativelabs/kube-router:v2.10.0)" = \
+  sha256:0991f2cc7aaabe107b51c0c554d6b843f0483fd319b94f437fab638470c47c22
+test "$(kubectl -n default get service kubernetes -o jsonpath='{.spec.clusterIP}')" = 10.96.0.1
+kubectl -n kube-system get daemonset kube-proxy -o json |
+  jq -e '.spec.template.spec.containers[0].command | any(. == "--proxy-mode=nftables")'
+kubectl get nodes -o json |
+  jq -e 'all(.items[]; any(.status.conditions[]; .type == "Ready" and .status == "True"))'
+bash scripts/kube-router/verify-safety-coverage.sh
+kustomize build argocd/applications/kube-router |
+  kubeconform -strict -summary -ignore-missing-schemas
+printf 'main=%s\n' "$main_revision"
+```
+
+Record a baseline before activation:
+
+```bash
+kubectl get nodes -o wide
+kubectl get pods --all-namespaces -o json |
+  jq -r '.items[] | select(any(.status.containerStatuses[]?; .ready != true)) | [.metadata.namespace,.metadata.name,.status.phase] | @tsv'
+kubectl -n argocd get applications -o json |
+  jq -r '.items[] | [.metadata.name,.status.sync.status,.status.health.status,.status.sync.revision] | @tsv' |
+  sort
+kubectl -n openclaw get virtualmachine,virtualmachineinstance,pvc -o wide
+kubectl -n flamingo get deployment,pod,service -o wide
+```
+
+Expected image platform digests are
+`sha256:81619a698b981a5c4fd6c89ae015d0faadce5d7a5270df7562c1743e58e3283f` for amd64 and
+`sha256:b8df3247641d5f4e84e14d30b673b6362a0e3d56901218a1e1ee38a40f37afd8` for arm64.
+
+## 2. Manual activation
+
+Refresh the manual application and require it to target the exact merged revision:
+
+```bash
+set -euo pipefail
+argocd app get kube-router --refresh
+test "$(kubectl -n argocd get application kube-router -o jsonpath='{.status.sync.revision}')" = "$main_revision"
+argocd app sync kube-router --revision "$main_revision" --prune=false --timeout 600
+kubectl -n kube-system rollout status daemonset/kube-router --timeout=10m
+```
+
+The sync hook must print `All existing NetworkPolicy namespaces have a traffic-neutral activation policy.` If it fails,
+the DaemonSet wave is not applied. Update the declared safety coverage through Git and rerun CI; do not bypass the hook.
+
+Verify every desired node has one ready controller, the pinned platform image is running, health is green, and policy
+metrics exist:
+
+```bash
+set -euo pipefail
+desired=$(kubectl -n kube-system get daemonset kube-router -o jsonpath='{.status.desiredNumberScheduled}')
+ready=$(kubectl -n kube-system get daemonset kube-router -o jsonpath='{.status.numberReady}')
+test "$desired" -gt 0
+test "$ready" = "$desired"
+
+kubectl -n kube-system get pods -l app.kubernetes.io/name=kube-router -o json |
+  jq -e '
+    all(.items[];
+      .status.containerStatuses[0].ready == true and
+      (.status.containerStatuses[0].imageID |
+        endswith("sha256:81619a698b981a5c4fd6c89ae015d0faadce5d7a5270df7562c1743e58e3283f") or
+        endswith("sha256:b8df3247641d5f4e84e14d30b673b6362a0e3d56901218a1e1ee38a40f37afd8")))'
+
+while IFS= read -r pod; do
+  kubectl -n kube-system exec "$pod" -c kube-router -- wget -qO- http://127.0.0.1:20244/healthz
+  kubectl -n kube-system exec "$pod" -c kube-router -- wget -qO- http://127.0.0.1:20241/metrics |
+    grep -Eq '^kube_router_controller_policy_(chains|ipsets) '
+done < <(kubectl -n kube-system get pods -l app.kubernetes.io/name=kube-router -o name)
+
+kubectl -n kube-system logs -l app.kubernetes.io/name=kube-router -c kube-router --prefix --tail=500 |
+  tee /tmp/kube-router-rollout.log
+! grep -Eiq 'panic|fatal|permission denied|operation not permitted|failed to (sync|restore|create)' \
+  /tmp/kube-router-rollout.log
+rm -f /tmp/kube-router-rollout.log
+```
+
+## 3. Enforcement and regression proof
+
+The first disposable probe schedules a client and server on every Linux node, checks each client against a server on a
+different node, proves an egress-deny policy blocks every one of those flows, and proves removal restores them. The
+second probe repeats the contract using the exact amd64 Hermes runtime image. Both delete their namespace on exit:
+
+```bash
+set -euo pipefail
+bash scripts/kube-router/verify-all-node-enforcement.sh
+bash scripts/hermes/verify-network-policy-enforcement.sh
+probe_namespaces=$(kubectl get namespaces -o name)
+test -z "$(grep -E '(kube-router|hermes)-network-policy-probe' <<< "$probe_namespaces" || true)"
+unset probe_namespaces
+```
+
+Compare the post-activation state with the baseline and prove OpenClaw and Flamingo remain healthy:
+
+```bash
+kubectl get nodes -o wide
+kubectl get pods --all-namespaces -o json |
+  jq -r '.items[] | select(any(.status.containerStatuses[]?; .ready != true)) | [.metadata.namespace,.metadata.name,.status.phase] | @tsv'
+kubectl -n argocd get applications -o json |
+  jq -r '.items[] | [.metadata.name,.status.sync.status,.status.health.status,.status.sync.revision] | @tsv' |
+  sort
+kubectl -n openclaw get virtualmachine,virtualmachineinstance,pvc -o wide
+kubectl -n flamingo rollout status deployment/flamingo --timeout=10m
+```
+
+Do not sync Hermes unless the policy probe passes and there is no new workload regression.
+
+## Emergency rollback and cleanup
+
+This is the documented emergency exception to GitOps. Keep every safety policy in place. First stop reconciliation and
+the active controller, then run the pinned targeted cleanup init container once on every Linux node. The cleanup removes
+only `KUBE-ROUTER-*`, `KUBE-NWPLCY-*`, and `KUBE-POD-FW-*` filter chains plus their NetworkPolicy ipsets. It deliberately
+does not use kube-router's generic cleanup mode, which can flush unrelated IPVS state:
+
+```bash
+set -euo pipefail
+argocd app terminate-op kube-router || true
+kubectl -n kube-system delete daemonset kube-router --wait=true
+kustomize build argocd/applications/kube-router/operations/cleanup |
+  kubectl -n kube-system apply -f -
+kubectl -n kube-system rollout status daemonset/kube-router-cleanup --timeout=5m
+
+kubectl -n kube-system get pods -l app.kubernetes.io/name=kube-router-cleanup -o json |
+  jq -e 'all(.items[]; .status.initContainerStatuses[0].state.terminated.exitCode == 0)'
+while IFS= read -r pod; do
+  iptables_state=$(kubectl -n kube-system exec "$pod" -c verifier -- iptables-save)
+  ipset_state=$(kubectl -n kube-system exec "$pod" -c verifier -- ipset list -name)
+  if grep -Eq 'KUBE-(ROUTER|NWPLCY|POD-FW)-' <<< "$iptables_state"; then
+    echo "targeted kube-router chains remain on $pod" >&2
+    exit 1
+  fi
+  if grep -Eq '^(inet6:)?KUBE-(SRC|DST)-|^(inet6:)?kube-router-local-pods$' <<< "$ipset_state"; then
+    echo "targeted kube-router ipsets remain on $pod" >&2
+    exit 1
+  fi
+done < <(kubectl -n kube-system get pods -l app.kubernetes.io/name=kube-router-cleanup -o name)
+unset iptables_state ipset_state
+
+kubectl -n kube-system delete daemonset kube-router-cleanup --wait=true
+set +e
+rollback_probe_output=$(bash scripts/hermes/verify-network-policy-enforcement.sh 2>&1)
+rollback_probe_status=$?
+set -e
+test "$rollback_probe_status" -ne 0
+grep -q 'NetworkPolicy is not enforced' <<< "$rollback_probe_output"
+unset rollback_probe_output rollback_probe_status
+```
+
+The final probe is expected to fail with `NetworkPolicy is not enforced`; it must still clean its disposable namespace.
+Recheck node, DNS, service routing, OpenClaw, and Flamingo health. Revert the Git commit through the normal PR path so
+Argo no longer desires the controller. Do not remove the safety policies until a separate policy rollout proves each
+namespace's required traffic.

--- a/scripts/hermes/validate-production.ts
+++ b/scripts/hermes/validate-production.ts
@@ -603,7 +603,9 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     failures.push(`${productionPaths.runbook}: final reconciliation must happen after the OpenClaw gateway is stopped`)
   }
 
-  requireTerms(failures, productionPaths.mimirRules, files.mimirRules, [
+  const hermesRuleGroup =
+    files.mimirRules.match(/      - name: hermes-production\.rules[\s\S]*?(?=\n      - name:)/)?.[0] ?? ''
+  requireTerms(failures, productionPaths.mimirRules, hermesRuleGroup, [
     'alert: HermesGatewayUnavailable',
     'alert: HermesEgressProxyUnavailable',
     'alert: HermesBackupStale',
@@ -618,11 +620,9 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'unless on (namespace, cronjob)',
     'absent(\n                  kube_cronjob_created{',
   ])
-  if (count(files.mimirRules, '(hermes_rollout_enabled == 1)') !== 3) {
+  if (count(hermesRuleGroup, '(hermes_rollout_enabled == 1)') !== 3) {
     failures.push(`${productionPaths.mimirRules}: all absent-series alerts must be gated on rollout enablement`)
   }
-  const hermesRuleGroup =
-    files.mimirRules.match(/- name: hermes-production\.rules[\s\S]*?- name: graf-telemetry\.rules/)?.[0] ?? ''
   forbidTerms(failures, productionPaths.mimirRules, hermesRuleGroup, [
     '[30d]',
     'or\n                hermes_rollout_enabled',

--- a/scripts/kube-router/validate-production.test.ts
+++ b/scripts/kube-router/validate-production.test.ts
@@ -1,0 +1,158 @@
+import { expect, test } from 'bun:test'
+
+import {
+  loadProductionFiles,
+  productionPaths,
+  validateProductionContent,
+  type ProductionFiles,
+} from './validate-production'
+
+function copy(files: ProductionFiles): ProductionFiles {
+  return { ...files }
+}
+
+test('accepts the production kube-router rollout', async () => {
+  expect(validateProductionContent(await loadProductionFiles())).toEqual([])
+})
+
+test('rejects a mutable controller image', async () => {
+  const files = copy(await loadProductionFiles())
+  files.daemonSet = files.daemonSet.replace(
+    /docker\.io\/cloudnativelabs\/kube-router@sha256:[a-f0-9]+/,
+    'docker.io/cloudnativelabs/kube-router:v2.10.0',
+  )
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.daemonSet}: kube-router must use the immutable multi-architecture v2.10.0 index`,
+  )
+})
+
+test('rejects enabling kube-router routing', async () => {
+  const files = copy(await loadProductionFiles())
+  files.daemonSet = files.daemonSet.replace('--run-router=false', '--run-router=true')
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.daemonSet}: controller flags must select firewall-only Flannel coexistence`,
+  )
+})
+
+test('rejects architecture pinning that misses a cluster node', async () => {
+  const files = copy(await loadProductionFiles())
+  files.daemonSet = files.daemonSet.replace(
+    '        kubernetes.io/os: linux',
+    '        kubernetes.io/os: linux\n        kubernetes.io/arch: amd64',
+  )
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.daemonSet}: controller must cover every Linux architecture in the cluster`,
+  )
+})
+
+test('rejects an enforcement probe that skips arm64', async () => {
+  const files = copy(await loadProductionFiles())
+  files.allNodeProbe = files.allNodeProbe.replace(
+    '  nodeName: PROBE_NODE',
+    '  nodeName: PROBE_NODE\n  nodeSelector:\n    kubernetes.io/arch: amd64',
+  )
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.allNodeProbe}: contains forbidden production term "kubernetes.io/arch"`,
+  )
+})
+
+test('rejects incomplete safety namespace coverage', async () => {
+  const files = copy(await loadProductionFiles())
+  files.safetyPolicies = files.safetyPolicies.replace(
+    /---\napiVersion: networking\.k8s\.io\/v1\nkind: NetworkPolicy\nmetadata:\n  name: kube-router-rollout-allow-all\n  namespace: torghut[\s\S]*$/,
+    '',
+  )
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.safetyPolicies}: safety policy namespace coverage must match the audited live set`,
+  )
+})
+
+test('rejects a safety policy that can deny traffic', async () => {
+  const files = copy(await loadProductionFiles())
+  files.safetyPolicies = files.safetyPolicies.replace('  ingress:\n    - {}', '  ingress: []')
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.safetyPolicies}: agents is not a retained traffic-neutral safety policy`,
+  )
+})
+
+test('rejects bypassing the live namespace preflight', async () => {
+  const files = copy(await loadProductionFiles())
+  files.preflightHook = files.preflightHook.replace(
+    'if [[ "$actual_namespaces" != "$expected_namespaces" ]]',
+    'if false',
+  )
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.preflightHook}: missing production invariant "if [[ \\"$actual_namespaces\\" != \\"$expected_namespaces\\" ]]"`,
+  )
+})
+
+test('rejects automatic controller activation', async () => {
+  const files = copy(await loadProductionFiles())
+  files.platform = files.platform.replace(/(\n\s+- name: kube-router\n[\s\S]*?automation:) manual/, '$1 auto')
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.platform}: missing production invariant "automation: manual"`,
+  )
+})
+
+test('rejects production CNI host mutation', async () => {
+  const files = copy(await loadProductionFiles())
+  files.daemonSet += '\n# /etc/cni/net.d\n'
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.daemonSet}: contains forbidden production term "/etc/cni/net.d"`,
+  )
+})
+
+test('rejects running emergency cleanup during normal reconciliation', async () => {
+  const files = copy(await loadProductionFiles())
+  files.kustomization = files.kustomization.replace('  - daemonset.yaml', '  - daemonset.yaml\n  - operations/cleanup')
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.kustomization}: contains forbidden production term "operations/cleanup"`,
+  )
+})
+
+test('rejects kube-router global cleanup that can flush unrelated node state', async () => {
+  const files = copy(await loadProductionFiles())
+  files.cleanupDaemonSet = files.cleanupDaemonSet.replace(
+    '              set -o pipefail',
+    '              /usr/local/bin/kube-router --cleanup-config\n              set -o pipefail',
+  )
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.cleanupDaemonSet}: contains forbidden production term "--cleanup-config"`,
+  )
+})
+
+test('rejects write-capable controller RBAC', async () => {
+  const files = copy(await loadProductionFiles())
+  files.rbac = files.rbac.replace('      - watch', '      - watch\n      - update')
+  expect(validateProductionContent(files)).toContain(`${productionPaths.rbac}: kube-router must remain read-only`)
+})
+
+test('rejects telemetry that drops DaemonSet readiness', async () => {
+  const files = copy(await loadProductionFiles())
+  files.kubeStateMetrics = files.kubeStateMetrics.replace('  - daemonsets\n', '')
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.kubeStateMetrics}: missing production invariant "  - daemonsets"`,
+  )
+})
+
+test('rejects a stale Alloy rollout checksum', async () => {
+  const files = copy(await loadProductionFiles())
+  files.clusterMetricsDeployment = files.clusterMetricsDeployment.replace(
+    /observability\.proompteng\.ai\/config-sha256: [a-f0-9]+/,
+    'observability.proompteng.ai/config-sha256: stale',
+  )
+  expect(validateProductionContent(files)).toContainEqual(
+    expect.stringContaining(`${productionPaths.clusterMetricsDeployment}: missing production invariant`),
+  )
+})
+
+test('rejects enforcement testing before controller activation', async () => {
+  const files = copy(await loadProductionFiles())
+  files.runbook = files.runbook.replace(
+    'argocd app sync kube-router --revision "$main_revision" --prune=false --timeout 600',
+    'bash scripts/hermes/verify-network-policy-enforcement.sh\nargocd app sync kube-router --revision "$main_revision" --prune=false --timeout 600',
+  )
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.runbook}: coverage, activation, and enforcement proof are out of order`,
+  )
+})

--- a/scripts/kube-router/validate-production.ts
+++ b/scripts/kube-router/validate-production.ts
@@ -1,0 +1,372 @@
+import { createHash } from 'node:crypto'
+import { readFile } from 'node:fs/promises'
+
+const kubeRouterImage =
+  'docker.io/cloudnativelabs/kube-router@sha256:0991f2cc7aaabe107b51c0c554d6b843f0483fd319b94f437fab638470c47c22'
+const kubectlImage = 'docker.io/bitnami/kubectl@sha256:a67b11e95e953f550f020a41970185ccc5f83d78b86b8c575d02c904aa0f9cd7'
+const safetyNamespaces = ['agents', 'argocd', 'bayn', 'bilig', 'kafka', 'media', 'pgadmin', 'synthesis', 'torghut']
+
+export const productionPaths = {
+  kustomization: 'argocd/applications/kube-router/kustomization.yaml',
+  serviceAccounts: 'argocd/applications/kube-router/service-account.yaml',
+  rbac: 'argocd/applications/kube-router/rbac.yaml',
+  safetyPolicies: 'argocd/applications/kube-router/safety-policies.yaml',
+  preflightHook: 'argocd/applications/kube-router/preflight-hook.yaml',
+  service: 'argocd/applications/kube-router/service.yaml',
+  daemonSet: 'argocd/applications/kube-router/daemonset.yaml',
+  readme: 'argocd/applications/kube-router/README.md',
+  cleanupKustomization: 'argocd/applications/kube-router/operations/cleanup/kustomization.yaml',
+  cleanupDaemonSet: 'argocd/applications/kube-router/operations/cleanup/cleanup-daemonset.yaml',
+  coverageProbe: 'scripts/kube-router/verify-safety-coverage.sh',
+  allNodeProbe: 'scripts/kube-router/verify-all-node-enforcement.sh',
+  platform: 'argocd/applicationsets/platform.yaml',
+  clusterMetrics: 'argocd/applications/observability/cluster-metrics-alloy-config.river',
+  clusterMetricsDeployment: 'argocd/applications/observability/cluster-metrics-alloy-deployment.yaml',
+  kubeStateMetrics: 'argocd/applications/observability/kube-state-metrics-values.yaml',
+  mimirRules: 'argocd/applications/observability/graf-mimir-rules.yaml',
+  runbook: 'docs/runbooks/kube-router-network-policy-rollout.md',
+  impactMap: '.github/ci/impact-map.yml',
+  pullRequestWorkflow: '.github/workflows/pull-request.yml',
+} as const
+
+export type ProductionPath = keyof typeof productionPaths
+export type ProductionFiles = Record<ProductionPath, string>
+
+type YamlObject = Record<string, any>
+
+function requireTerms(failures: string[], path: string, content: string, terms: string[]): void {
+  for (const term of terms) {
+    if (!content.includes(term)) {
+      failures.push(`${path}: missing production invariant ${JSON.stringify(term)}`)
+    }
+  }
+}
+
+function forbidTerms(failures: string[], path: string, content: string, terms: string[]): void {
+  for (const term of terms) {
+    if (content.includes(term)) {
+      failures.push(`${path}: contains forbidden production term ${JSON.stringify(term)}`)
+    }
+  }
+}
+
+function yamlDocuments(content: string): YamlObject[] {
+  const parsed = Bun.YAML.parse(content)
+  if (Array.isArray(parsed)) {
+    return parsed as YamlObject[]
+  }
+  return [parsed as YamlObject]
+}
+
+function resource(documents: YamlObject[], kind: string, name: string): YamlObject | undefined {
+  return documents.find((document) => document.kind === kind && document.metadata?.name === name)
+}
+
+function sortedStrings(value: unknown): string[] {
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== 'string')) {
+    return []
+  }
+  return [...value].sort()
+}
+
+export async function loadProductionFiles(): Promise<ProductionFiles> {
+  const entries = await Promise.all(
+    Object.entries(productionPaths).map(async ([name, path]) => [name, await readFile(path, 'utf8')] as const),
+  )
+  return Object.fromEntries(entries) as ProductionFiles
+}
+
+export function validateProductionContent(files: ProductionFiles): string[] {
+  const failures: string[] = []
+
+  const kustomization = yamlDocuments(files.kustomization)[0]
+  const expectedResources = [
+    'service-account.yaml',
+    'rbac.yaml',
+    'safety-policies.yaml',
+    'preflight-hook.yaml',
+    'service.yaml',
+    'daemonset.yaml',
+  ]
+  if (kustomization.kind !== 'Kustomization' || kustomization.namespace !== undefined) {
+    failures.push(
+      `${productionPaths.kustomization}: must be a cross-namespace Kustomization without namespace override`,
+    )
+  }
+  if (JSON.stringify(kustomization.resources) !== JSON.stringify(expectedResources)) {
+    failures.push(`${productionPaths.kustomization}: production resources are incomplete or reordered`)
+  }
+  forbidTerms(failures, productionPaths.kustomization, files.kustomization, ['operations/cleanup', 'kind: Namespace'])
+
+  const daemonSet = resource(yamlDocuments(files.daemonSet), 'DaemonSet', 'kube-router')
+  const podSpec = daemonSet?.spec?.template?.spec
+  const container = podSpec?.containers?.find((entry: YamlObject) => entry.name === 'kube-router')
+  const args = sortedStrings(container?.args)
+  const requiredArgs = [
+    '--cache-sync-timeout=1m',
+    '--enable-cni=false',
+    '--enable-ipv4=true',
+    '--enable-ipv6=false',
+    '--health-port=20244',
+    '--hostname-override=$(NODE_NAME)',
+    '--iptables-sync-period=30s',
+    '--metrics-port=20241',
+    '--run-firewall=true',
+    '--run-loadbalancer=false',
+    '--run-router=false',
+    '--run-service-proxy=false',
+    '--service-cluster-ip-range=10.96.0.0/12',
+    '--v=2',
+  ].sort()
+  if (daemonSet?.metadata?.namespace !== 'kube-system') {
+    failures.push(`${productionPaths.daemonSet}: DaemonSet must run in kube-system`)
+  }
+  if (container?.image !== kubeRouterImage) {
+    failures.push(`${productionPaths.daemonSet}: kube-router must use the immutable multi-architecture v2.10.0 index`)
+  }
+  if (JSON.stringify(args) !== JSON.stringify(requiredArgs)) {
+    failures.push(`${productionPaths.daemonSet}: controller flags must select firewall-only Flannel coexistence`)
+  }
+  if (
+    podSpec?.hostNetwork !== true ||
+    podSpec?.hostPID !== true ||
+    podSpec?.priorityClassName !== 'system-node-critical' ||
+    podSpec?.nodeSelector?.['kubernetes.io/os'] !== 'linux' ||
+    podSpec?.nodeSelector?.['kubernetes.io/arch'] !== undefined
+  ) {
+    failures.push(`${productionPaths.daemonSet}: controller must cover every Linux architecture in the cluster`)
+  }
+  if (
+    daemonSet?.spec?.updateStrategy?.rollingUpdate?.maxUnavailable !== 1 ||
+    daemonSet?.spec?.updateStrategy?.rollingUpdate?.maxSurge !== 0 ||
+    daemonSet?.spec?.minReadySeconds !== 15
+  ) {
+    failures.push(`${productionPaths.daemonSet}: rolling availability controls are not production-safe`)
+  }
+  if (
+    container?.securityContext?.privileged !== true ||
+    container?.securityContext?.runAsUser !== 0 ||
+    container?.securityContext?.readOnlyRootFilesystem !== true
+  ) {
+    failures.push(`${productionPaths.daemonSet}: required host-firewall privilege must be explicit and bounded`)
+  }
+  const volumes = podSpec?.volumes ?? []
+  const moduleVolume = volumes.find((entry: YamlObject) => entry.name === 'lib-modules')
+  const xtablesVolume = volumes.find((entry: YamlObject) => entry.name === 'xtables-lock')
+  if (moduleVolume?.hostPath?.path !== '/usr/lib/modules' || moduleVolume?.hostPath?.type !== 'Directory') {
+    failures.push(`${productionPaths.daemonSet}: Talos modules must be mounted from /usr/lib/modules`)
+  }
+  if (xtablesVolume?.hostPath?.path !== '/run/xtables.lock' || xtablesVolume?.hostPath?.type !== 'FileOrCreate') {
+    failures.push(`${productionPaths.daemonSet}: kube-router and host firewall writers must share xtables.lock`)
+  }
+  forbidTerms(failures, productionPaths.daemonSet, files.daemonSet, [
+    ':latest',
+    '/etc/cni/net.d',
+    '/opt/cni/bin',
+    '--run-router=true',
+    '--run-service-proxy=true',
+    '--enable-cni=true',
+  ])
+
+  const safetyPolicies = yamlDocuments(files.safetyPolicies)
+  const actualSafetyNamespaces = safetyPolicies.map((policy) => policy.metadata?.namespace).sort()
+  if (JSON.stringify(actualSafetyNamespaces) !== JSON.stringify([...safetyNamespaces].sort())) {
+    failures.push(`${productionPaths.safetyPolicies}: safety policy namespace coverage must match the audited live set`)
+  }
+  for (const policy of safetyPolicies) {
+    const namespace = policy.metadata?.namespace ?? '<missing>'
+    if (
+      policy.apiVersion !== 'networking.k8s.io/v1' ||
+      policy.kind !== 'NetworkPolicy' ||
+      policy.metadata?.name !== 'kube-router-rollout-allow-all' ||
+      JSON.stringify(policy.spec?.podSelector) !== '{}' ||
+      JSON.stringify(sortedStrings(policy.spec?.policyTypes)) !== JSON.stringify(['Egress', 'Ingress']) ||
+      JSON.stringify(policy.spec?.ingress) !== '[{}]' ||
+      JSON.stringify(policy.spec?.egress) !== '[{}]' ||
+      policy.metadata?.annotations?.['argocd.argoproj.io/sync-wave'] !== '-3' ||
+      policy.metadata?.annotations?.['argocd.argoproj.io/sync-options'] !== 'Prune=false'
+    ) {
+      failures.push(`${productionPaths.safetyPolicies}: ${namespace} is not a retained traffic-neutral safety policy`)
+    }
+  }
+
+  const hook = resource(yamlDocuments(files.preflightHook), 'Job', 'kube-router-policy-preflight')
+  const hookContainer = hook?.spec?.template?.spec?.containers?.[0]
+  if (
+    hook?.metadata?.annotations?.['argocd.argoproj.io/hook'] !== 'Sync' ||
+    hook?.metadata?.annotations?.['argocd.argoproj.io/sync-wave'] !== '-2' ||
+    hook?.spec?.backoffLimit !== 0 ||
+    hook?.spec?.activeDeadlineSeconds !== 120 ||
+    hookContainer?.image !== kubectlImage ||
+    hookContainer?.env?.find((entry: YamlObject) => entry.name === 'HOME')?.value !== '/tmp'
+  ) {
+    failures.push(`${productionPaths.preflightHook}: the bounded pre-DaemonSet coverage gate is incomplete`)
+  }
+  requireTerms(failures, productionPaths.preflightHook, files.preflightHook, [
+    "printf '%s\\n' agents argocd bayn bilig kafka media pgadmin synthesis torghut | sort -u",
+    'kubectl get networkpolicies.networking.k8s.io --all-namespaces -o json',
+    'if [[ "$actual_namespaces" != "$expected_namespaces" ]]',
+    'kubectl -n "$namespace" get networkpolicy kube-router-rollout-allow-all -o json',
+    '.spec.podSelector == {}',
+    '.spec.ingress == [{}]',
+    '.spec.egress == [{}]',
+  ])
+
+  const roles = yamlDocuments(files.rbac).filter((document) => document.kind === 'ClusterRole')
+  for (const role of roles) {
+    const verbs = (role.rules ?? []).flatMap((rule: YamlObject) => rule.verbs ?? [])
+    if (verbs.some((verb: string) => ['*', 'create', 'delete', 'deletecollection', 'patch', 'update'].includes(verb))) {
+      failures.push(`${productionPaths.rbac}: ${role.metadata?.name} must remain read-only`)
+    }
+  }
+  requireTerms(failures, productionPaths.rbac, files.rbac, [
+    '- endpointslices',
+    '- networkpolicies',
+    'name: kube-router-policy-preflight',
+  ])
+  forbidTerms(failures, productionPaths.rbac, files.rbac, ['services/status', 'resources:\n      - "*"'])
+
+  requireTerms(failures, productionPaths.serviceAccounts, files.serviceAccounts, [
+    'name: kube-router',
+    'name: kube-router-policy-preflight',
+    'namespace: kube-system',
+  ])
+  requireTerms(failures, productionPaths.service, files.service, [
+    'name: kube-router-metrics',
+    'clusterIP: None',
+    'port: 20241',
+    'port: 20244',
+  ])
+
+  const cleanupKustomization = yamlDocuments(files.cleanupKustomization)[0]
+  const cleanupDaemonSet = resource(yamlDocuments(files.cleanupDaemonSet), 'DaemonSet', 'kube-router-cleanup')
+  const cleanupInit = cleanupDaemonSet?.spec?.template?.spec?.initContainers?.[0]
+  if (
+    cleanupKustomization.namespace !== 'kube-system' ||
+    JSON.stringify(cleanupKustomization.resources) !== JSON.stringify(['cleanup-daemonset.yaml']) ||
+    cleanupInit?.image !== kubeRouterImage ||
+    JSON.stringify(cleanupInit?.command) !== JSON.stringify(['/bin/bash', '-ec']) ||
+    cleanupInit?.securityContext?.privileged !== true ||
+    cleanupDaemonSet?.spec?.template?.spec?.automountServiceAccountToken !== false
+  ) {
+    failures.push(`${productionPaths.cleanupDaemonSet}: pinned all-node emergency cleanup is incomplete`)
+  }
+  requireTerms(failures, productionPaths.cleanupDaemonSet, files.cleanupDaemonSet, [
+    'cleanup_filter_family /usr/sbin/iptables /usr/sbin/iptables-save',
+    'cleanup_filter_family /usr/sbin/ip6tables /usr/sbin/ip6tables-save',
+    "awk '/^:KUBE-(ROUTER|NWPLCY|POD-FW)-/",
+    "awk '/^(inet6:)?KUBE-(SRC|DST)-|^(inet6:)?kube-router-local-pods$/",
+  ])
+  forbidTerms(failures, productionPaths.cleanupDaemonSet, files.cleanupDaemonSet, ['--cleanup-config'])
+  requireTerms(failures, productionPaths.readme, files.readme, [
+    'manual Argo CD application',
+    'amd64: `sha256:81619a698b981a5c4fd6c89ae015d0faadce5d7a5270df7562c1743e58e3283f`',
+    'arm64: `sha256:b8df3247641d5f4e84e14d30b673b6362a0e3d56901218a1e1ee38a40f37afd8`',
+    'Prune=false',
+  ])
+
+  const kubeRouterEntry =
+    /\n\s+- name: kube-router\n[\s\S]*?\n\s+- name: volume-snapshot-controller/.exec(files.platform)?.[0] ?? ''
+  requireTerms(failures, productionPaths.platform, kubeRouterEntry, [
+    'path: argocd/applications/kube-router',
+    'namespace: kube-system',
+    'automation: manual',
+    'enabled: "true"',
+  ])
+
+  requireTerms(failures, productionPaths.clusterMetrics, files.clusterMetrics, [
+    'discovery.kubernetes "kube_router_pods"',
+    'prometheus.scrape "kube_router"',
+    'job_name        = "kube-router"',
+    'kube_router_controller_(iptables|policy)_.*',
+    'kube_daemonset_status_desired_number_scheduled',
+    'kube_daemonset_status_number_ready',
+  ])
+  const metricsHash = createHash('sha256').update(files.clusterMetrics).digest('hex')
+  requireTerms(failures, productionPaths.clusterMetricsDeployment, files.clusterMetricsDeployment, [
+    `observability.proompteng.ai/config-sha256: ${metricsHash}`,
+  ])
+  requireTerms(failures, productionPaths.kubeStateMetrics, files.kubeStateMetrics, ['  - daemonsets'])
+  requireTerms(failures, productionPaths.mimirRules, files.mimirRules, [
+    '- name: kube-router-network-policy.rules',
+    'record: kube_router_rollout_enabled',
+    'alert: KubeRouterDaemonSetUnavailable',
+    'alert: KubeRouterMetricsMissing',
+    'alert: KubeRouterContainerRestarting',
+    '(kube_router_rollout_enabled == 1)',
+    'runbook_url: docs/runbooks/kube-router-network-policy-rollout.md',
+  ])
+
+  requireTerms(failures, productionPaths.coverageProbe, files.coverageProbe, [
+    'set -euo pipefail',
+    'kubectl get networkpolicies.networking.k8s.io --all-namespaces -o json',
+    'if [[ "$actual_namespaces" != "$desired_namespaces" ]]',
+  ])
+  requireTerms(failures, productionPaths.allNodeProbe, files.allNodeProbe, [
+    kubeRouterImage,
+    'kind: Pod',
+    'activeDeadlineSeconds: 900',
+    'nodeName: PROBE_NODE',
+    'wait pod -l app.kubernetes.io/component=server',
+    'wait pod -l app.kubernetes.io/component=client',
+    'test "$client_count" = "$linux_node_count"',
+    'test "$server_count" = "$linux_node_count"',
+    'index($client_node)',
+    '$servers[(($client_index + 1) % ($servers | length))].status.podIP',
+    'name: deny-client-egress',
+    'egress: []',
+    'name: deny-server-ingress',
+    'ingress: []',
+    'if [[ "$policy_enforced" != true ]]',
+    'if [[ "$policy_released" != true ]]',
+    'network_policy_ingress_and_egress_enforced_on_all_linux_nodes=true',
+  ])
+  forbidTerms(failures, productionPaths.allNodeProbe, files.allNodeProbe, ['kubernetes.io/arch'])
+  const safetyCheckPosition = files.runbook.indexOf('bash scripts/kube-router/verify-safety-coverage.sh')
+  const syncPosition = files.runbook.indexOf('argocd app sync kube-router')
+  const allNodeEnforcementPosition = files.runbook.indexOf('bash scripts/kube-router/verify-all-node-enforcement.sh')
+  const enforcementPosition = files.runbook.indexOf('bash scripts/hermes/verify-network-policy-enforcement.sh')
+  if (
+    !(
+      safetyCheckPosition >= 0 &&
+      safetyCheckPosition < syncPosition &&
+      syncPosition < allNodeEnforcementPosition &&
+      allNodeEnforcementPosition < enforcementPosition
+    )
+  ) {
+    failures.push(`${productionPaths.runbook}: coverage, activation, and enforcement proof are out of order`)
+  }
+  requireTerms(failures, productionPaths.runbook, files.runbook, [
+    'kubectl -n kube-system rollout status daemonset/kube-router',
+    'operations/cleanup',
+    'kubectl -n kube-system delete daemonset kube-router --wait=true',
+    'KUBE-ROUTER-*',
+    "does not use kube-router's generic cleanup mode",
+    'iptables_state=$(kubectl -n kube-system exec "$pod" -c verifier -- iptables-save)',
+    'ipset_state=$(kubectl -n kube-system exec "$pod" -c verifier -- ipset list -name)',
+    'Do not sync Hermes unless the policy probe passes',
+  ])
+
+  requireTerms(failures, productionPaths.impactMap, files.impactMap, [
+    '- argocd/applications/kube-router/**',
+    '- docs/runbooks/kube-router-network-policy-rollout.md',
+  ])
+  requireTerms(failures, productionPaths.pullRequestWorkflow, files.pullRequestWorkflow, [
+    'bun run scripts/kube-router/validate-production.ts',
+    'bun test scripts/kube-router/*.test.ts',
+  ])
+
+  return failures
+}
+
+if (import.meta.main) {
+  const failures = validateProductionContent(await loadProductionFiles())
+  if (failures.length > 0) {
+    for (const failure of failures) {
+      console.error(failure)
+    }
+    process.exitCode = 1
+  } else {
+    console.log('kube-router production validation passed')
+  }
+}

--- a/scripts/kube-router/verify-all-node-enforcement.sh
+++ b/scripts/kube-router/verify-all-node-enforcement.sh
@@ -1,0 +1,378 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly probe_image='docker.io/cloudnativelabs/kube-router@sha256:0991f2cc7aaabe107b51c0c554d6b843f0483fd319b94f437fab638470c47c22'
+probe_namespace="kube-router-network-policy-probe-$(openssl rand -hex 4)"
+readonly probe_namespace
+probe_namespace_created=false
+
+cleanup_probe() {
+  if [[ "$probe_namespace_created" == true ]]; then
+    kubectl -n default delete namespace "$probe_namespace" --ignore-not-found --wait=true --timeout=5m >/dev/null
+    probe_namespace_created=false
+  fi
+}
+
+abort_probe() {
+  trap - EXIT HUP INT TERM
+  cleanup_probe
+  exit 130
+}
+
+trap cleanup_probe EXIT
+trap abort_probe HUP INT TERM
+
+kubectl -n default create namespace "$probe_namespace" >/dev/null
+probe_namespace_created=true
+kubectl -n default label namespace "$probe_namespace" --overwrite \
+  pod-security.kubernetes.io/enforce=restricted \
+  pod-security.kubernetes.io/audit=restricted \
+  pod-security.kubernetes.io/warn=restricted >/dev/null
+
+linux_nodes=$(
+  kubectl get nodes -l kubernetes.io/os=linux -o json |
+    jq -r '.items | sort_by(.metadata.name)[] | .metadata.name'
+)
+linux_node_count=$(wc -l <<< "$linux_nodes" | tr -d '[:space:]')
+test "$linux_node_count" -gt 1
+kubectl get nodes -l kubernetes.io/os=linux -o json |
+  jq -e 'all(.items[]; any(.status.conditions[]; .type == "Ready" and .status == "True"))' >/dev/null
+
+probe_index=0
+while IFS= read -r probe_node; do
+  sed \
+    -e "s|PROBE_IMAGE|$probe_image|g" \
+    -e "s|PROBE_NODE|$probe_node|g" \
+    -e "s|PROBE_INDEX|$probe_index|g" <<'EOF' | kubectl -n "$probe_namespace" apply -f - >/dev/null
+apiVersion: v1
+kind: Pod
+metadata:
+  name: policy-server-PROBE_INDEX
+  labels:
+    app.kubernetes.io/name: kube-router-network-policy-probe
+    app.kubernetes.io/component: server
+spec:
+  activeDeadlineSeconds: 900
+  automountServiceAccountToken: false
+  enableServiceLinks: false
+  nodeName: PROBE_NODE
+  tolerations:
+    - operator: Exists
+  restartPolicy: Never
+  terminationGracePeriodSeconds: 5
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 10000
+    runAsGroup: 10000
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: server
+      image: PROBE_IMAGE
+      imagePullPolicy: IfNotPresent
+      command:
+        - /bin/busybox
+        - nc
+        - -lk
+        - -p
+        - "8080"
+        - -e
+        - /bin/cat
+      ports:
+        - name: tcp
+          containerPort: 8080
+      readinessProbe:
+        tcpSocket:
+          port: tcp
+        periodSeconds: 1
+        failureThreshold: 30
+      resources:
+        requests:
+          cpu: 5m
+          memory: 8Mi
+          ephemeral-storage: 8Mi
+        limits:
+          cpu: 100m
+          memory: 32Mi
+          ephemeral-storage: 32Mi
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: policy-client-PROBE_INDEX
+  labels:
+    app.kubernetes.io/name: kube-router-network-policy-probe
+    app.kubernetes.io/component: client
+spec:
+  activeDeadlineSeconds: 900
+  automountServiceAccountToken: false
+  enableServiceLinks: false
+  nodeName: PROBE_NODE
+  tolerations:
+    - operator: Exists
+  restartPolicy: Never
+  terminationGracePeriodSeconds: 5
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 10000
+    runAsGroup: 10000
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: client
+      image: PROBE_IMAGE
+      imagePullPolicy: IfNotPresent
+      command:
+        - /bin/sleep
+        - "900"
+      resources:
+        requests:
+          cpu: 5m
+          memory: 8Mi
+          ephemeral-storage: 8Mi
+        limits:
+          cpu: 100m
+          memory: 32Mi
+          ephemeral-storage: 32Mi
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+EOF
+  probe_index=$((probe_index + 1))
+done <<< "$linux_nodes"
+
+kubectl -n "$probe_namespace" wait pod -l app.kubernetes.io/component=server \
+  --for=condition=Ready --timeout=5m >/dev/null
+kubectl -n "$probe_namespace" wait pod -l app.kubernetes.io/component=client \
+  --for=condition=Ready --timeout=5m >/dev/null
+
+client_count=$(
+  kubectl -n "$probe_namespace" get pods -l app.kubernetes.io/component=client -o name |
+    wc -l |
+    tr -d '[:space:]'
+)
+server_count=$(
+  kubectl -n "$probe_namespace" get pods -l app.kubernetes.io/component=server -o name |
+    wc -l |
+    tr -d '[:space:]'
+)
+test "$client_count" = "$linux_node_count"
+test "$server_count" = "$linux_node_count"
+
+cross_node_server_ip() {
+  local client_pod=$1
+  local client_node
+  local server_ip
+
+  client_node=$(kubectl -n "$probe_namespace" get "$client_pod" -o jsonpath='{.spec.nodeName}')
+  server_ip=$(
+    kubectl -n "$probe_namespace" get pods -l app.kubernetes.io/component=server -o json |
+      jq -r --arg client_node "$client_node" \
+        '[.items[] | select(.status.phase == "Running")] | sort_by(.spec.nodeName) as $servers |
+        ($servers | map(.spec.nodeName) | index($client_node)) as $client_index |
+        if $client_index == null or ($servers | length) < 2 then
+          empty
+        else
+          $servers[(($client_index + 1) % ($servers | length))].status.podIP
+        end'
+  )
+  test -n "$server_ip"
+  printf '%s\n' "$server_ip"
+}
+
+probe_request() {
+  local client_pod=$1
+  local server_ip=$2
+
+  # The single-quoted program expands inside the probe container, not in the operator shell.
+  # shellcheck disable=SC2016
+  kubectl -n "$probe_namespace" exec "$client_pod" -c client -- /bin/sh -ec '
+    /bin/busybox nc -z -w 2 "$1" 8080 && exit 0
+    status=$?
+    if [ "$status" -eq 1 ]; then
+      exit 42
+    fi
+    exit 43
+  ' probe "$server_ip" >/dev/null 2>&1
+}
+
+verify_probe_health() {
+  kubectl -n "$probe_namespace" wait pod -l app.kubernetes.io/component=server \
+    --for=condition=Ready --timeout=10s >/dev/null
+  kubectl -n "$probe_namespace" wait pod -l app.kubernetes.io/component=client \
+    --for=condition=Ready --timeout=10s >/dev/null
+  while IFS= read -r server_pod; do
+    kubectl -n "$probe_namespace" exec "$server_pod" -c server -- \
+      /bin/busybox nc -z -w 2 127.0.0.1 8080 >/dev/null 2>&1
+  done < <(kubectl -n "$probe_namespace" get pods -l app.kubernetes.io/component=server -o name)
+}
+
+while IFS= read -r client_pod; do
+  server_ip=$(cross_node_server_ip "$client_pod")
+  baseline_reachable=false
+  for _ in $(seq 1 30); do
+    if probe_request "$client_pod" "$server_ip"; then
+      baseline_reachable=true
+      break
+    else
+      request_status=$?
+    fi
+    if [[ "$request_status" -ne 42 ]]; then
+      echo "baseline probe execution failed from $client_pod with status $request_status" >&2
+      exit 1
+    fi
+    sleep 1
+  done
+  if [[ "$baseline_reachable" != true ]]; then
+    echo "cross-node baseline connectivity failed from $client_pod" >&2
+    exit 1
+  fi
+done < <(kubectl -n "$probe_namespace" get pods -l app.kubernetes.io/component=client -o name)
+
+kubectl -n "$probe_namespace" apply -f - >/dev/null <<'EOF'
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: deny-client-egress
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: kube-router-network-policy-probe
+      app.kubernetes.io/component: client
+  policyTypes:
+    - Egress
+  egress: []
+EOF
+
+while IFS= read -r client_pod; do
+  server_ip=$(cross_node_server_ip "$client_pod")
+  policy_enforced=false
+  for _ in $(seq 1 60); do
+    if probe_request "$client_pod" "$server_ip"; then
+      sleep 1
+      continue
+    else
+      request_status=$?
+    fi
+    if [[ "$request_status" -eq 42 ]]; then
+      verify_probe_health
+      policy_enforced=true
+      break
+    fi
+    echo "denial probe execution failed from $client_pod with status $request_status" >&2
+    exit 1
+  done
+  if [[ "$policy_enforced" != true ]]; then
+    client_node=$(kubectl -n "$probe_namespace" get "$client_pod" -o jsonpath='{.spec.nodeName}')
+    echo "NetworkPolicy is not enforced on node $client_node" >&2
+    exit 1
+  fi
+done < <(kubectl -n "$probe_namespace" get pods -l app.kubernetes.io/component=client -o name)
+
+kubectl -n "$probe_namespace" delete networkpolicy deny-client-egress --wait=true --timeout=1m >/dev/null
+while IFS= read -r client_pod; do
+  server_ip=$(cross_node_server_ip "$client_pod")
+  policy_released=false
+  for _ in $(seq 1 60); do
+    if probe_request "$client_pod" "$server_ip"; then
+      policy_released=true
+      break
+    else
+      request_status=$?
+    fi
+    if [[ "$request_status" -ne 42 ]]; then
+      echo "release probe execution failed from $client_pod with status $request_status" >&2
+      exit 1
+    fi
+    sleep 1
+  done
+  if [[ "$policy_released" != true ]]; then
+    client_node=$(kubectl -n "$probe_namespace" get "$client_pod" -o jsonpath='{.spec.nodeName}')
+    echo "NetworkPolicy removal did not restore connectivity on node $client_node" >&2
+    exit 1
+  fi
+done < <(kubectl -n "$probe_namespace" get pods -l app.kubernetes.io/component=client -o name)
+
+kubectl -n "$probe_namespace" apply -f - >/dev/null <<'EOF'
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: deny-server-ingress
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: kube-router-network-policy-probe
+      app.kubernetes.io/component: server
+  policyTypes:
+    - Ingress
+  ingress: []
+EOF
+
+while IFS= read -r client_pod; do
+  server_ip=$(cross_node_server_ip "$client_pod")
+  policy_enforced=false
+  for _ in $(seq 1 60); do
+    if probe_request "$client_pod" "$server_ip"; then
+      sleep 1
+      continue
+    else
+      request_status=$?
+    fi
+    if [[ "$request_status" -eq 42 ]]; then
+      verify_probe_health
+      policy_enforced=true
+      break
+    fi
+    echo "ingress denial probe execution failed from $client_pod with status $request_status" >&2
+    exit 1
+  done
+  if [[ "$policy_enforced" != true ]]; then
+    server_node=$(
+      kubectl -n "$probe_namespace" get pods -l app.kubernetes.io/component=server -o json |
+        jq -r --arg server_ip "$server_ip" '.items[] | select(.status.podIP == $server_ip) | .spec.nodeName'
+    )
+    echo "NetworkPolicy ingress is not enforced on node $server_node" >&2
+    exit 1
+  fi
+done < <(kubectl -n "$probe_namespace" get pods -l app.kubernetes.io/component=client -o name)
+
+kubectl -n "$probe_namespace" delete networkpolicy deny-server-ingress --wait=true --timeout=1m >/dev/null
+while IFS= read -r client_pod; do
+  server_ip=$(cross_node_server_ip "$client_pod")
+  policy_released=false
+  for _ in $(seq 1 60); do
+    if probe_request "$client_pod" "$server_ip"; then
+      policy_released=true
+      break
+    else
+      request_status=$?
+    fi
+    if [[ "$request_status" -ne 42 ]]; then
+      echo "ingress release probe execution failed from $client_pod with status $request_status" >&2
+      exit 1
+    fi
+    sleep 1
+  done
+  if [[ "$policy_released" != true ]]; then
+    server_node=$(
+      kubectl -n "$probe_namespace" get pods -l app.kubernetes.io/component=server -o json |
+        jq -r --arg server_ip "$server_ip" '.items[] | select(.status.podIP == $server_ip) | .spec.nodeName'
+    )
+    echo "NetworkPolicy ingress removal did not restore connectivity on node $server_node" >&2
+    exit 1
+  fi
+done < <(kubectl -n "$probe_namespace" get pods -l app.kubernetes.io/component=client -o name)
+
+printf 'network_policy_ingress_and_egress_enforced_on_all_linux_nodes=true nodes=%s\n' "$linux_node_count"
+cleanup_probe
+trap - EXIT HUP INT TERM

--- a/scripts/kube-router/verify-safety-coverage.sh
+++ b/scripts/kube-router/verify-safety-coverage.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+safety_manifest="$repo_root/argocd/applications/kube-router/safety-policies.yaml"
+
+desired_namespaces=$(
+  yq eval-all --no-doc --unwrapScalar 'select(.kind == "NetworkPolicy") | .metadata.namespace' "$safety_manifest" |
+    sort -u
+)
+actual_namespaces=$(
+  kubectl get networkpolicies.networking.k8s.io --all-namespaces -o json |
+    jq -r '.items[].metadata.namespace' |
+    sort -u
+)
+
+if [[ "$actual_namespaces" != "$desired_namespaces" ]]; then
+  echo 'NetworkPolicy namespace coverage changed; update and revalidate the kube-router safety policies.' >&2
+  diff -u <(printf '%s\n' "$desired_namespaces") <(printf '%s\n' "$actual_namespaces") >&2 || true
+  exit 1
+fi
+
+printf 'Safety coverage matches live NetworkPolicy namespaces:\n%s\n' "$desired_namespaces"


### PR DESCRIPTION
## Summary

- add a manual, digest-pinned kube-router v2.10.0 firewall-only DaemonSet for the mixed amd64/arm64 Talos cluster while preserving Flannel and nftables kube-proxy ownership
- stage retained allow-all policies ahead of activation and fail the sync if live NetworkPolicy namespace coverage differs from the audited nine-namespace set
- add bounded all-node ingress/egress enforcement probes plus a targeted rollback overlay that never invokes kube-router's global IPVS/routing cleanup
- add kube-router readiness, scrape, and restart telemetry with rollout-gated alerts, production validation, CI routing, and an operator runbook

## Related Issues

None

## Testing

- `bash scripts/kube-router/verify-safety-coverage.sh` (matched all live NetworkPolicy namespaces)
- `bun run scripts/kube-router/validate-production.ts`
- `bun run scripts/hermes/validate-production.ts`
- `bun test scripts/kube-router/*.test.ts scripts/hermes/*.test.ts` (75 passed)
- `kustomize build` and strict `kubeconform` for the production and cleanup overlays (19 resources valid)
- server-side apply dry-run for kube-system, all nine safety-policy namespaces, the cleanup overlay, and the bounded probe Pods
- `shellcheck` for operator scripts and the embedded targeted-cleanup program
- Alloy syntax validation on formatted output and Prometheus `promtool check rules` (131 rules)
- isolated privileged-container test proving targeted cleanup removes kube-router NetworkPolicy chains/ipsets while preserving unrelated chains/ipsets
- non-root, read-only-rootfs container test proving the pinned multi-arch probe client/server commands work without capabilities

## Breaking Changes

None at merge. The application remains manual; its first sync activates NetworkPolicy enforcement only after traffic-neutral safety policies and the live coverage hook succeed.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
