### PR TITLE
refactor(bayn): clean runtime and database boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 - For requests to change, build, or fix, make the requested in-scope local changes and run relevant non-destructive validation without asking first. Safe local actions include reading and searching files, inspecting logs and repository state, editing in-scope code, and running tests.
 - Require confirmation before external writes not explicitly requested, destructive actions, purchases, credential or permission changes, or a material expansion of scope.
 - Complete the requested outcome before yielding. For multi-step work, keep a short plan, update it only at meaningful milestones, and avoid narrating routine tool use.
+- Use the provided current working directory for all repository work. Do not create or use alternate worktrees or temporary repository copies unless the user explicitly requests one.
 - Start from concrete evidence and reproduce defects when practical. Gather context until you can name the files or resources to change and the validation path, then act without repeating equivalent searches or reads.
 - Lead final responses with the result, evidence, validation commands and outcomes, material caveats or blockers, and the next required action. Omit repeated background and generic reassurance.
 - Check the nearest `README` or nested `AGENTS.md` for component-specific rules.

--- a/services/bayn/AGENTS.md
+++ b/services/bayn/AGENTS.md
@@ -46,6 +46,9 @@
   service modules. Validate once at startup and keep secrets `Redacted` until the third-party client boundary.
 - Decode every external payload with `Schema` or `SqlSchema`. A TypeScript assertion such as `json<Row>()` is not
   runtime validation. Pure domain code accepts decoded values only.
+- Model closed external vocabularies with TypeScript enums and `Schema.Enum`; do not repeat magic strings. Namespace
+  and version durable wire-contract identifiers, but keep internal names domain-oriented.
+- Do not use non-null assertions in production code. Narrow or validate the value and fail with a useful invariant.
 - Use `Effect.log*`, `Effect.annotateLogs`, and log spans. Production logs use `Logger.consoleJson`. Do not call `console.*`
   inside an Effect; direct console output is only an emergency before the runtime exists. Never log credentials.
 - Effect 4 HTTP lives under `effect/unstable/http`; use it with `@effect/platform-node` instead of hand-written Node
@@ -63,6 +66,8 @@
   record, and readiness requires exact account, transfer, and balance reconciliation.
 - Select one `Strategy` capability at the composition root; the strategy owns its protocol and universe. Do not add a
   runtime registry, scheduler, event bus, repository layer, or generic retry framework without a current requirement.
+- Define strategies and protocols in TypeScript. Do not add JSON strategy files, legacy loaders, or fallback paths;
+  make contract changes explicit and migrate callers directly.
 
 ## Tests and validation
 
@@ -70,6 +75,8 @@
   `Effect.runPromiseExit`; test layers replace external systems. Unit tests never require the live cluster.
 - Cover success, typed failure, defect propagation, interruption, timeout cancellation, and exactly-once finalization
   for changed Effectful code. Use deterministic fixtures and `TestClock` for time-dependent behavior.
+- Test observable behavior and durable contracts. Do not add tests that scan source text, filenames, or the absence of
+  old implementation details.
 - Run the focused test first, then before completing a code change run:
 
 ```sh

--- a/services/bayn/migrations/0006_domain_names.ts
+++ b/services/bayn/migrations/0006_domain_names.ts
@@ -1,0 +1,124 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+const tables = [
+  ['bayn_protocol_locks', 'protocol_locks'],
+  ['bayn_snapshot_references', 'snapshot_references'],
+  ['bayn_evaluation_runs', 'evaluation_runs'],
+  ['bayn_evaluation_artifacts', 'evaluation_artifacts'],
+  ['bayn_evaluation_events', 'evaluation_events'],
+  ['bayn_gate_outcomes', 'gate_outcomes'],
+  ['bayn_status_history', 'status_history'],
+  ['bayn_qualification_trials', 'qualification_trials'],
+  ['bayn_qualification_locks', 'qualification_locks'],
+  ['bayn_qualification_results', 'qualification_results'],
+] as const
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient
+
+  for (const [legacyName, domainName] of tables) {
+    yield* sql`ALTER TABLE ${sql(legacyName)} RENAME TO ${sql(domainName)}`
+  }
+
+  yield* sql`
+    DO $block$
+    DECLARE
+      item record;
+    BEGIN
+      FOR item IN
+        SELECT constraint_row.conrelid, constraint_row.conname
+        FROM pg_catalog.pg_constraint AS constraint_row
+        WHERE constraint_row.connamespace = 'public'::regnamespace
+          AND constraint_row.conrelid <> 0
+          AND constraint_row.conname LIKE 'bayn\_%' ESCAPE '\'
+        ORDER BY constraint_row.conrelid, constraint_row.conname
+      LOOP
+        EXECUTE format(
+          'ALTER TABLE %s RENAME CONSTRAINT %I TO %I',
+          item.conrelid::regclass,
+          item.conname,
+          substring(item.conname FROM 6)
+        );
+      END LOOP;
+    END
+    $block$
+  `
+
+  yield* sql`
+    ALTER INDEX bayn_status_history_run_sequence_idx
+      RENAME TO status_history_run_sequence_idx
+  `
+
+  yield* sql`ALTER FUNCTION bayn_reject_evidence_mutation() RENAME TO reject_evidence_mutation`
+  yield* sql`ALTER FUNCTION bayn_reject_qualification_mutation() RENAME TO reject_qualification_mutation`
+  yield* sql`ALTER FUNCTION bayn_allow_evaluation_completion_only() RENAME TO allow_evaluation_completion_only`
+  yield* sql`ALTER FUNCTION bayn_burn_completed_evaluation() RENAME TO burn_completed_evaluation`
+
+  yield* sql`
+    CREATE OR REPLACE FUNCTION burn_completed_evaluation()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+    DECLARE
+      reasons text[] := ARRAY['PRE_LOCK_RESULT_OBSERVED'];
+    BEGIN
+      IF EXISTS (
+        SELECT 1 FROM qualification_locks WHERE candidate_run_id = NEW.run_id
+      ) THEN
+        RETURN NEW;
+      END IF;
+
+      IF EXISTS (
+        SELECT 1
+        FROM gate_outcomes
+        WHERE run_id = NEW.run_id
+          AND gate_name = 'benchmark_sharpe_improvement'
+          AND passed = false
+      ) THEN
+        reasons := array_append(reasons, 'FAILED_BENCHMARK_GATE');
+      END IF;
+
+      INSERT INTO qualification_trials (
+        run_id,
+        schema_version,
+        disposition,
+        reason_codes,
+        observed_at
+      ) VALUES (
+        NEW.run_id,
+        'bayn.qualification-trial.v1',
+        'BURNED',
+        reasons,
+        COALESCE(NEW.completed_at, transaction_timestamp())
+      )
+      ON CONFLICT (run_id) DO NOTHING;
+
+      RETURN NEW;
+    END
+    $function$
+  `
+
+  yield* sql`
+    DO $block$
+    DECLARE
+      item record;
+    BEGIN
+      FOR item IN
+        SELECT trigger_row.tgrelid, trigger_row.tgname
+        FROM pg_catalog.pg_trigger AS trigger_row
+        WHERE NOT trigger_row.tgisinternal
+          AND trigger_row.tgname LIKE 'bayn\_%' ESCAPE '\'
+        ORDER BY trigger_row.tgrelid, trigger_row.tgname
+      LOOP
+        EXECUTE format(
+          'ALTER TRIGGER %I ON %s RENAME TO %I',
+          item.tgname,
+          item.tgrelid::regclass,
+          substring(item.tgname FROM 6)
+        );
+      END LOOP;
+    END
+    $block$
+  `
+})

--- a/services/bayn/src/contracts.test.ts
+++ b/services/bayn/src/contracts.test.ts
@@ -12,6 +12,7 @@ import {
   makeRunIdentity,
   makeRuntimeProvenance,
 } from './contracts'
+import { DataFeed, DataSource, PriceAdjustment, PublicationSchema } from './types'
 
 const sha = (character: string): string => character.repeat(64)
 
@@ -19,10 +20,10 @@ const snapshot = {
   schemaVersion: 'bayn.finalized-snapshot.v2' as const,
   snapshotId: sha('a'),
   publicationId: sha('b'),
-  publicationSchemaVersion: 'signal.adjusted-daily-snapshot.v1',
-  source: 'alpaca',
-  sourceFeed: 'sip',
-  adjustment: 'all',
+  publicationSchemaVersion: PublicationSchema.AdjustedDailySnapshotV1,
+  source: DataSource.Alpaca,
+  sourceFeed: DataFeed.Sip,
+  adjustment: PriceAdjustment.All,
   calendarVersion: 'XNYS-2025a',
   publisherSourceRevision: '1'.repeat(40),
   publisherImage: {

--- a/services/bayn/src/contracts.ts
+++ b/services/bayn/src/contracts.ts
@@ -1,6 +1,7 @@
 import { Schema } from 'effect'
 
-import { canonicalHashV1, canonicalJsonV1 } from './hash'
+import { canonicalHashV1 } from './hash'
+import { DataFeed, DataSource, PriceAdjustment, PublicationSchema } from './types'
 
 const StrictParseOptions = { onExcessProperty: 'error' } as const
 
@@ -18,15 +19,6 @@ const isUtcInstant = (value: string): boolean => {
   return !Number.isNaN(date.getTime()) && date.toISOString() === value
 }
 
-const canCanonicalize = (value: unknown): boolean => {
-  try {
-    canonicalJsonV1(value)
-    return true
-  } catch {
-    return false
-  }
-}
-
 const NonEmptyString = Schema.String.check(
   Schema.makeFilter((value: string) => value.length > 0 && value.trim() === value, {
     expected: 'a non-empty string without surrounding whitespace',
@@ -41,16 +33,16 @@ const ImageDigest = Schema.String.check(Schema.isPattern(/^sha256:[a-f0-9]{64}$/
 const SourceRevision = Schema.String.check(Schema.isPattern(/^(?:[a-f0-9]{40}|[a-f0-9]{64})$/))
 const PositiveInteger = Schema.Int.check(Schema.isGreaterThan(0))
 const SymbolName = Schema.String.check(Schema.isPattern(/^[A-Z][A-Z0-9.-]{0,15}$/))
-const CanonicalJson = Schema.Unknown.check(Schema.makeFilter(canCanonicalize, { expected: 'a canonical JSON value' }))
+const CanonicalJson = Schema.Unknown.check(Schema.makeFilter(Schema.is(Schema.Json), { expected: 'a JSON value' }))
 
 const FinalizedSnapshotBase = Schema.Struct({
   schemaVersion: Schema.Literal('bayn.finalized-snapshot.v2'),
   snapshotId: Sha256Schema,
   publicationId: Sha256Schema,
-  publicationSchemaVersion: NonEmptyString,
-  source: NonEmptyString,
-  sourceFeed: NonEmptyString,
-  adjustment: NonEmptyString,
+  publicationSchemaVersion: Schema.Enum(PublicationSchema),
+  source: Schema.Enum(DataSource),
+  sourceFeed: Schema.Enum(DataFeed),
+  adjustment: Schema.Enum(PriceAdjustment),
   calendarVersion: NonEmptyString,
   publisherSourceRevision: SourceRevision,
   publisherImage: Schema.Struct({

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test'
 
 import { NodeServices } from '@effect/platform-node'
-import { PgClient } from '@effect/sql-pg'
+import { PgClient, PgMigrator } from '@effect/sql-pg'
 import { Cause, Effect, Exit, Fiber, Layer, ManagedRuntime, Option, Redacted } from 'effect'
 
 import type { RuntimeConfig } from '../config'
@@ -19,6 +19,7 @@ import {
   PostgresClientLive,
   type PersistEvaluationInput,
 } from './evidence-store'
+import { migrationLoader } from './migrations'
 
 const postgresUrl = process.env.BAYN_TEST_POSTGRES_URL
 const testUrl = postgresUrl ?? 'postgresql://bayn:bayn@127.0.0.1:5432/bayn_test'
@@ -143,32 +144,94 @@ describePostgres('PostgreSQL evaluation evidence', () => {
         return yield* sql<{ table_name: string }>`
           SELECT table_name
           FROM information_schema.tables
-          WHERE table_schema = 'public' AND table_name LIKE 'bayn_%'
+          WHERE table_schema = 'public' AND table_type = 'BASE TABLE'
           ORDER BY table_name
         `
       }),
     )
 
     expect(tables.map((row) => row.table_name)).toEqual([
-      'bayn_evaluation_artifacts',
-      'bayn_evaluation_events',
-      'bayn_evaluation_runs',
-      'bayn_gate_outcomes',
-      'bayn_protocol_locks',
-      'bayn_qualification_locks',
-      'bayn_qualification_results',
-      'bayn_qualification_trials',
-      'bayn_schema_migrations',
-      'bayn_snapshot_references',
-      'bayn_status_history',
+      'evaluation_artifacts',
+      'evaluation_events',
+      'evaluation_runs',
+      'gate_outcomes',
+      'protocol_locks',
+      'qualification_locks',
+      'qualification_results',
+      'qualification_trials',
+      'schema_migrations',
+      'snapshot_references',
+      'status_history',
     ])
+  })
+
+  test('hard-migrates the deployed schema without losing data or migration history', async () => {
+    const runId = '9'.repeat(64)
+    await runtime.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* PgClient.PgClient
+        yield* sql`DROP SCHEMA public CASCADE`
+        yield* sql`CREATE SCHEMA public`
+        const deployedMigrations = migrationLoader.pipe(
+          Effect.map((migrations) => migrations.filter(([id]) => id <= 5)),
+        )
+        yield* PgMigrator.run({ loader: deployedMigrations, table: 'bayn_schema_migrations' }).pipe(
+          Effect.provide(NodeServices.layer),
+        )
+        yield* sql`
+          INSERT INTO bayn_protocol_locks (
+            protocol_hash,
+            schema_version,
+            strategy_name,
+            behavior_hash,
+            parameter_hash,
+            parameters
+          ) VALUES (
+            ${runId},
+            'bayn.tsmom.protocol.v2',
+            'tsmom',
+            ${'8'.repeat(64)},
+            ${'7'.repeat(64)},
+            '{}'::jsonb
+          )
+        `
+      }),
+    )
+
+    await runtime.dispose()
+    runtime = makeEvidenceRuntime()
+    await runtime.runPromise(Effect.flatMap(EvidenceStore, (store) => store.check))
+
+    const migrated = await runtime.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* PgClient.PgClient
+        const legacyTables = yield* sql<{ count: number }>`
+          SELECT count(*)::integer AS count
+          FROM pg_catalog.pg_tables
+          WHERE schemaname = 'public' AND tablename LIKE 'bayn\_%' ESCAPE '\'
+        `
+        const migrations = yield* sql<{ count: number }>`
+          SELECT count(*)::integer AS count FROM schema_migrations
+        `
+        const protocols = yield* sql<{ count: number }>`
+          SELECT count(*)::integer AS count FROM protocol_locks WHERE protocol_hash = ${runId}
+        `
+        return {
+          legacyTableCount: legacyTables[0]?.count,
+          migrationCount: migrations[0]?.count,
+          protocolCount: protocols[0]?.count,
+        }
+      }),
+    )
+
+    expect(migrated).toEqual({ legacyTableCount: 0, migrationCount: 6, protocolCount: 1 })
   })
 
   test('keeps the audit snapshot repeatable-read and rejects writes', async () => {
     const observed = await runtime.runPromise(
       Effect.gen(function* () {
         const sql = yield* PgClient.PgClient
-        yield* sql`CREATE TABLE bayn_audit_read_only_probe (id integer PRIMARY KEY)`
+        yield* sql`CREATE TABLE audit_read_only_probe (id integer PRIMARY KEY)`
         const transaction = yield* sql.withTransaction(
           Effect.gen(function* () {
             yield* sql`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY`
@@ -177,12 +240,12 @@ describePostgres('PostgreSQL evaluation evidence', () => {
                 current_setting('transaction_isolation') AS isolation,
                 current_setting('transaction_read_only') = 'on' AS read_only
             `
-            const write = yield* Effect.exit(sql`INSERT INTO bayn_audit_read_only_probe (id) VALUES (1)`)
+            const write = yield* Effect.exit(sql`INSERT INTO audit_read_only_probe (id) VALUES (1)`)
             return { mode: mode[0], write }
           }),
         )
         const rows = yield* sql<{ count: number }>`
-          SELECT count(*)::integer AS count FROM bayn_audit_read_only_probe
+          SELECT count(*)::integer AS count FROM audit_read_only_probe
         `
         return { ...transaction, rows }
       }),
@@ -209,10 +272,10 @@ describePostgres('PostgreSQL evaluation evidence', () => {
         }>`
           SELECT
             run.status,
-            (SELECT count(*)::integer FROM bayn_evaluation_artifacts WHERE run_id = run.run_id) AS artifact_count,
-            (SELECT count(*)::integer FROM bayn_evaluation_events WHERE run_id = run.run_id) AS event_count,
-            (SELECT count(*)::integer FROM bayn_gate_outcomes WHERE run_id = run.run_id) AS gate_count
-          FROM bayn_evaluation_runs AS run
+            (SELECT count(*)::integer FROM evaluation_artifacts WHERE run_id = run.run_id) AS artifact_count,
+            (SELECT count(*)::integer FROM evaluation_events WHERE run_id = run.run_id) AS event_count,
+            (SELECT count(*)::integer FROM gate_outcomes WHERE run_id = run.run_id) AS gate_count
+          FROM evaluation_runs AS run
         `
         const gates = yield* sql<{
           gate_name: string
@@ -227,7 +290,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
             required,
             jsonb_typeof(actual) AS actual_type,
             jsonb_typeof(required) AS required_type
-          FROM bayn_gate_outcomes
+          FROM gate_outcomes
           WHERE run_id = ${input.evaluation.runId}
           ORDER BY ordinal
         `
@@ -281,10 +344,10 @@ describePostgres('PostgreSQL evaluation evidence', () => {
           trials: number
         }>`
           SELECT
-            (SELECT count(*)::integer FROM bayn_qualification_locks) AS locks,
-            (SELECT count(*)::integer FROM bayn_qualification_results) AS results,
-            (SELECT count(*)::integer FROM bayn_evaluation_runs) AS runs,
-            (SELECT count(*)::integer FROM bayn_qualification_trials) AS trials
+            (SELECT count(*)::integer FROM qualification_locks) AS locks,
+            (SELECT count(*)::integer FROM qualification_results) AS results,
+            (SELECT count(*)::integer FROM evaluation_runs) AS runs,
+            (SELECT count(*)::integer FROM qualification_trials) AS trials
         `
         return { before, bypass, counts: counts[0], opened, receipt, reopened, terminal, trials }
       }),
@@ -326,7 +389,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
         `
         yield* sql`
           CREATE TRIGGER bayn_test_reject_qualification_result
-          BEFORE INSERT ON bayn_qualification_results
+          BEFORE INSERT ON qualification_results
           FOR EACH ROW EXECUTE FUNCTION bayn_test_reject_qualification_result()
         `
         const failure = yield* store.persist(qualification.persist).pipe(Effect.flip)
@@ -341,13 +404,13 @@ describePostgres('PostgreSQL evaluation evidence', () => {
           statuses: number
         }>`
           SELECT
-            (SELECT count(*)::integer FROM bayn_qualification_locks) AS locks,
-            (SELECT count(*)::integer FROM bayn_qualification_results) AS results,
-            (SELECT count(*)::integer FROM bayn_evaluation_runs) AS runs,
-            (SELECT count(*)::integer FROM bayn_evaluation_artifacts) AS artifacts,
-            (SELECT count(*)::integer FROM bayn_evaluation_events) AS events,
-            (SELECT count(*)::integer FROM bayn_gate_outcomes) AS gates,
-            (SELECT count(*)::integer FROM bayn_status_history) AS statuses
+            (SELECT count(*)::integer FROM qualification_locks) AS locks,
+            (SELECT count(*)::integer FROM qualification_results) AS results,
+            (SELECT count(*)::integer FROM evaluation_runs) AS runs,
+            (SELECT count(*)::integer FROM evaluation_artifacts) AS artifacts,
+            (SELECT count(*)::integer FROM evaluation_events) AS events,
+            (SELECT count(*)::integer FROM gate_outcomes) AS gates,
+            (SELECT count(*)::integer FROM status_history) AS statuses
         `
         return { counts: counts[0], failure, record }
       }),
@@ -442,7 +505,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
         })
 
         yield* sql`
-          INSERT INTO bayn_qualification_locks (
+          INSERT INTO qualification_locks (
             lock_id,
             schema_version,
             candidate_run_id,
@@ -476,28 +539,28 @@ describePostgres('PostgreSQL evaluation evidence', () => {
             disposition,
             'PRE_LOCK_RESULT_OBSERVED' = ANY(reason_codes) AS prelock_observed,
             'FAILED_BENCHMARK_GATE' = ANY(reason_codes) AS failed_benchmark
-          FROM bayn_qualification_trials
+          FROM qualification_trials
         `
         const locks = yield* sql<{ lock_id: string; payload: unknown }>`
-          SELECT lock_id, payload FROM bayn_qualification_locks
+          SELECT lock_id, payload FROM qualification_locks
         `
         const results = yield* sql<{ count: number }>`
-          SELECT count(*)::integer AS count FROM bayn_qualification_results
+          SELECT count(*)::integer AS count FROM qualification_results
         `
         const trialUpdate = yield* Effect.exit(sql`
-          UPDATE bayn_qualification_trials SET disposition = 'BURNED' WHERE run_id = ${input.evaluation.runId}
+          UPDATE qualification_trials SET disposition = 'BURNED' WHERE run_id = ${input.evaluation.runId}
         `)
         const trialDelete = yield* Effect.exit(sql`
-          DELETE FROM bayn_qualification_trials WHERE run_id = ${input.evaluation.runId}
+          DELETE FROM qualification_trials WHERE run_id = ${input.evaluation.runId}
         `)
         const lockUpdate = yield* Effect.exit(sql`
-          UPDATE bayn_qualification_locks SET payload = payload WHERE lock_id = ${lock.lockId}
+          UPDATE qualification_locks SET payload = payload WHERE lock_id = ${lock.lockId}
         `)
         const lockDelete = yield* Effect.exit(sql`
-          DELETE FROM bayn_qualification_locks WHERE lock_id = ${lock.lockId}
+          DELETE FROM qualification_locks WHERE lock_id = ${lock.lockId}
         `)
         const divergentLock = yield* Effect.exit(sql`
-          INSERT INTO bayn_qualification_locks (
+          INSERT INTO qualification_locks (
             lock_id,
             schema_version,
             candidate_run_id,
@@ -734,7 +797,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
         yield* store.persist(second)
         return yield* sql<{ protocol_hash: string; behavior_hash: string; parameter_hash: string }>`
           SELECT protocol_hash, behavior_hash, parameter_hash
-          FROM bayn_protocol_locks
+          FROM protocol_locks
           ORDER BY behavior_hash
         `
       }),
@@ -763,36 +826,36 @@ describePostgres('PostgreSQL evaluation evidence', () => {
         const sql = yield* PgClient.PgClient
         yield* store.persist(input)
         const artifactUpdate = yield* Effect.exit(sql`
-          UPDATE bayn_evaluation_artifacts
+          UPDATE evaluation_artifacts
           SET payload = ${sql.json({ corrupted: true })}
           WHERE run_id = ${input.evaluation.runId} AND artifact_name = 'strategy'
         `)
         const snapshotUpdate = yield* Effect.exit(sql`
-          UPDATE bayn_snapshot_references
+          UPDATE snapshot_references
           SET first_session = first_session + 1
           WHERE snapshot_id = ${input.evaluation.inputManifest.finalizedSnapshot.snapshotId}
         `)
         const runUpdate = yield* Effect.exit(sql`
-          UPDATE bayn_evaluation_runs
+          UPDATE evaluation_runs
           SET initial_capital_micros = initial_capital_micros + 1
           WHERE run_id = ${input.evaluation.runId}
         `)
         const statusUpdate = yield* Effect.exit(sql`
-          UPDATE bayn_status_history
+          UPDATE status_history
           SET detail = ${sql.json({ corrupted: true })}
           WHERE run_id = ${input.evaluation.runId} AND status = 'COMPLETE'
         `)
         const eventDelete = yield* Effect.exit(sql`
-          DELETE FROM bayn_evaluation_events WHERE run_id = ${input.evaluation.runId}
+          DELETE FROM evaluation_events WHERE run_id = ${input.evaluation.runId}
         `)
         const gateDelete = yield* Effect.exit(sql`
-          DELETE FROM bayn_gate_outcomes WHERE run_id = ${input.evaluation.runId}
+          DELETE FROM gate_outcomes WHERE run_id = ${input.evaluation.runId}
         `)
         const protocolDelete = yield* Effect.exit(sql`
-          DELETE FROM bayn_protocol_locks WHERE protocol_hash = ${input.evaluation.protocolHash}
+          DELETE FROM protocol_locks WHERE protocol_hash = ${input.evaluation.protocolHash}
         `)
         const runDelete = yield* Effect.exit(sql`
-          DELETE FROM bayn_evaluation_runs WHERE run_id = ${input.evaluation.runId}
+          DELETE FROM evaluation_runs WHERE run_id = ${input.evaluation.runId}
         `)
         const read = yield* store.read(input.evaluation.runId)
         return {
@@ -821,11 +884,11 @@ describePostgres('PostgreSQL evaluation evidence', () => {
         const sql = yield* PgClient.PgClient
         return yield* Effect.forEach(
           [
-            sql`TRUNCATE bayn_evaluation_runs CASCADE`,
-            sql`TRUNCATE bayn_evaluation_artifacts`,
-            sql`TRUNCATE bayn_qualification_trials`,
-            sql`TRUNCATE bayn_qualification_locks CASCADE`,
-            sql`TRUNCATE bayn_qualification_results`,
+            sql`TRUNCATE evaluation_runs CASCADE`,
+            sql`TRUNCATE evaluation_artifacts`,
+            sql`TRUNCATE qualification_trials`,
+            sql`TRUNCATE qualification_locks CASCADE`,
+            sql`TRUNCATE qualification_results`,
           ],
           Effect.exit,
         )
@@ -859,10 +922,10 @@ describePostgres('PostgreSQL evaluation evidence', () => {
           events: number
         }>`
           SELECT
-            (SELECT count(*)::integer FROM bayn_evaluation_runs) AS runs,
-            (SELECT count(*)::integer FROM bayn_protocol_locks) AS protocols,
-            (SELECT count(*)::integer FROM bayn_snapshot_references) AS snapshots,
-            (SELECT count(*)::integer FROM bayn_evaluation_events) AS events
+            (SELECT count(*)::integer FROM evaluation_runs) AS runs,
+            (SELECT count(*)::integer FROM protocol_locks) AS protocols,
+            (SELECT count(*)::integer FROM snapshot_references) AS snapshots,
+            (SELECT count(*)::integer FROM evaluation_events) AS events
         `
         return { error, counts: counts[0] }
       }),

--- a/services/bayn/src/db/evidence-store.ts
+++ b/services/bayn/src/db/evidence-store.ts
@@ -1,7 +1,7 @@
 import { PgClient, PgMigrator } from '@effect/sql-pg'
-import { Context, Data, Effect, FileSystem, Layer, Option, Schema } from 'effect'
+import { Context, Data, Effect, FileSystem, Layer, Match, Option, Schema } from 'effect'
 import { SqlSchema } from 'effect/unstable/sql'
-import { isSqlError } from 'effect/unstable/sql/SqlError'
+import { isSqlError, type SqlErrorReason } from 'effect/unstable/sql/SqlError'
 
 import type { RuntimeConfig } from '../config'
 import { makeRunIdentity, makeStrategyProtocolHash, type RuntimeProvenance } from '../contracts'
@@ -286,6 +286,10 @@ const QualificationRow = Schema.Struct({
 const CandidateRunCountRow = Schema.Struct({ count: NonNegativeInteger })
 const InsertedLockRow = Schema.Struct({ lock_id: Sha256 })
 const InsertedResultRow = Schema.Struct({ lock_id: Sha256 })
+const MigrationTablesRow = Schema.Struct({
+  current_exists: Schema.Boolean,
+  legacy_exists: Schema.Boolean,
+})
 
 const StrictParseOptions = { onExcessProperty: 'error' } as const
 const decodeQualificationLock = Schema.decodeUnknownSync(QualificationLockSchema, StrictParseOptions)
@@ -293,11 +297,25 @@ const decodeQualificationResult = Schema.decodeUnknownSync(QualificationResultSc
 
 const messageOf = (cause: unknown): string => (cause instanceof Error ? cause.message : String(cause))
 
-const errorCodeOf = (cause: unknown, depth = 0): string | undefined => {
-  if (depth > 4 || typeof cause !== 'object' || cause === null) return undefined
-  if ('code' in cause && typeof cause.code === 'string') return cause.code
-  return 'cause' in cause ? errorCodeOf(cause.cause, depth + 1) : undefined
-}
+const unavailable = (): DatabaseFailure => 'unavailable'
+const constraint = (): DatabaseFailure => 'constraint'
+const query = (): DatabaseFailure => 'query'
+
+const classifySqlReason: (reason: SqlErrorReason) => DatabaseFailure = Match.type<SqlErrorReason>().pipe(
+  Match.tagsExhaustive({
+    AuthenticationError: unavailable,
+    AuthorizationError: unavailable,
+    ConnectionError: unavailable,
+    ConstraintError: constraint,
+    DeadlockError: unavailable,
+    LockTimeoutError: unavailable,
+    SerializationError: unavailable,
+    SqlSyntaxError: query,
+    StatementTimeoutError: unavailable,
+    UniqueViolation: constraint,
+    UnknownError: unavailable,
+  }),
+)
 
 const databaseError = (failure: DatabaseFailure, operation: string, message: string, cause?: unknown): DatabaseError =>
   new DatabaseError({
@@ -311,18 +329,7 @@ const classifyDatabaseError = (operation: string, cause: unknown): DatabaseError
   if (cause instanceof DatabaseError) return cause
   if (Schema.isSchemaError(cause)) return databaseError('decode', operation, 'database row decoding failed', cause)
   if (isSqlError(cause)) {
-    const code = errorCodeOf(cause.reason)
-    const failure: DatabaseFailure =
-      cause.reason._tag === 'UniqueViolation' || cause.reason._tag === 'ConstraintError'
-        ? 'constraint'
-        : cause.reason._tag === 'SqlSyntaxError' ||
-            (cause.reason._tag === 'UnknownError' &&
-              code !== undefined &&
-              !code.startsWith('E') &&
-              !code.startsWith('08'))
-          ? 'query'
-          : 'unavailable'
-    return databaseError(failure, operation, 'PostgreSQL operation failed', cause)
+    return databaseError(classifySqlReason(cause.reason), operation, 'PostgreSQL operation failed', cause)
   }
   return databaseError('invariant', operation, 'unexpected database result', cause)
 }
@@ -686,7 +693,7 @@ const makeEvidenceStore = Effect.gen(function* () {
   const getProtocol = SqlSchema.findOne({
     Request: Schema.Struct({ protocolHash: Sha256 }),
     Result: ProtocolRow,
-    execute: ({ protocolHash }) => sql`SELECT * FROM bayn_protocol_locks WHERE protocol_hash = ${protocolHash}`,
+    execute: ({ protocolHash }) => sql`SELECT * FROM protocol_locks WHERE protocol_hash = ${protocolHash}`,
   })
   const getSnapshot = SqlSchema.findOne({
     Request: Schema.Struct({ snapshotId: Sha256 }),
@@ -706,7 +713,7 @@ const makeEvidenceStore = Effect.gen(function* () {
         first_session::text,
         last_session::text,
         manifest
-      FROM bayn_snapshot_references
+      FROM snapshot_references
       WHERE snapshot_id = ${snapshotId}
     `,
   })
@@ -727,7 +734,7 @@ const makeEvidenceStore = Effect.gen(function* () {
     }),
     Result: InsertedRun,
     execute: (request) => sql`
-      INSERT INTO bayn_evaluation_runs (
+      INSERT INTO evaluation_runs (
         run_id,
         protocol_hash,
         snapshot_id,
@@ -764,18 +771,18 @@ const makeEvidenceStore = Effect.gen(function* () {
     Request: RunRequest,
     Result: InsertedRun,
     execute: ({ runId }) => sql`
-      UPDATE bayn_evaluation_runs AS run
+      UPDATE evaluation_runs AS run
       SET status = 'COMPLETE', completed_at = transaction_timestamp()
       WHERE run.run_id = ${runId}
         AND run.status = 'WRITING'
         AND run.expected_artifact_count = (
-          SELECT count(*)::integer FROM bayn_evaluation_artifacts WHERE run_id = ${runId}
+          SELECT count(*)::integer FROM evaluation_artifacts WHERE run_id = ${runId}
         )
         AND run.expected_event_count = (
-          SELECT count(*)::integer FROM bayn_evaluation_events WHERE run_id = ${runId}
+          SELECT count(*)::integer FROM evaluation_events WHERE run_id = ${runId}
         )
         AND run.expected_gate_count = (
-          SELECT count(*)::integer FROM bayn_gate_outcomes WHERE run_id = ${runId}
+          SELECT count(*)::integer FROM gate_outcomes WHERE run_id = ${runId}
         )
       RETURNING run.run_id
     `,
@@ -798,10 +805,10 @@ const makeEvidenceStore = Effect.gen(function* () {
         run.expected_artifact_count,
         run.expected_event_count,
         run.expected_gate_count,
-        (SELECT count(*)::integer FROM bayn_evaluation_artifacts WHERE run_id = run.run_id) AS artifact_count,
-        (SELECT count(*)::integer FROM bayn_evaluation_events WHERE run_id = run.run_id) AS event_count,
-        (SELECT count(*)::integer FROM bayn_gate_outcomes WHERE run_id = run.run_id) AS gate_count
-      FROM bayn_evaluation_runs AS run
+        (SELECT count(*)::integer FROM evaluation_artifacts WHERE run_id = run.run_id) AS artifact_count,
+        (SELECT count(*)::integer FROM evaluation_events WHERE run_id = run.run_id) AS event_count,
+        (SELECT count(*)::integer FROM gate_outcomes WHERE run_id = run.run_id) AS gate_count
+      FROM evaluation_runs AS run
       WHERE run.run_id = ${runId}
     `,
   })
@@ -810,7 +817,7 @@ const makeEvidenceStore = Effect.gen(function* () {
     Result: ArtifactReferenceRow,
     execute: ({ runId }) => sql`
       SELECT artifact_name, schema_version, content_hash, payload
-      FROM bayn_evaluation_artifacts
+      FROM evaluation_artifacts
       WHERE run_id = ${runId}
       ORDER BY artifact_name
     `,
@@ -823,8 +830,8 @@ const makeEvidenceStore = Effect.gen(function* () {
         artifact.schema_version,
         artifact.content_hash,
         jsonb_array_length(artifact.payload -> 'items')::integer AS item_count
-      FROM bayn_evaluation_artifacts AS artifact
-      JOIN bayn_evaluation_runs AS run USING (run_id)
+      FROM evaluation_artifacts AS artifact
+      JOIN evaluation_runs AS run USING (run_id)
       WHERE artifact.run_id = ${runId}
         AND artifact.artifact_name = ${artifactName}
         AND run.status = 'COMPLETE'
@@ -841,7 +848,7 @@ const makeEvidenceStore = Effect.gen(function* () {
     Result: ArtifactItemRow,
     execute: ({ runId, artifactName, afterOrdinal, limit }) => sql`
       SELECT (item.ordinality - 1)::integer AS ordinal, item.payload
-      FROM bayn_evaluation_artifacts AS artifact
+      FROM evaluation_artifacts AS artifact
       CROSS JOIN LATERAL jsonb_array_elements(artifact.payload -> 'items')
         WITH ORDINALITY AS item(payload, ordinality)
       WHERE artifact.run_id = ${runId}
@@ -856,7 +863,7 @@ const makeEvidenceStore = Effect.gen(function* () {
     Result: EventReferenceRow,
     execute: ({ runId }) => sql`
       SELECT ordinal, event_id, event_kind, content_hash, payload
-      FROM bayn_evaluation_events
+      FROM evaluation_events
       WHERE run_id = ${runId}
       ORDER BY ordinal
     `,
@@ -866,7 +873,7 @@ const makeEvidenceStore = Effect.gen(function* () {
     Result: GateReferenceRow,
     execute: ({ runId }) => sql`
       SELECT ordinal, gate_name, passed, actual, required, content_hash
-      FROM bayn_gate_outcomes
+      FROM gate_outcomes
       WHERE run_id = ${runId}
       ORDER BY ordinal
     `,
@@ -875,7 +882,7 @@ const makeEvidenceStore = Effect.gen(function* () {
     Request: RunRequest,
     Result: StatusReferenceRow,
     execute: ({ runId }) => sql`
-      SELECT status, detail FROM bayn_status_history WHERE run_id = ${runId} ORDER BY sequence
+      SELECT status, detail FROM status_history WHERE run_id = ${runId} ORDER BY sequence
     `,
   })
   const getPriorTrials = SqlSchema.findAll({
@@ -884,9 +891,9 @@ const makeEvidenceStore = Effect.gen(function* () {
     execute: () => sql`
       SELECT run_id
       FROM (
-        SELECT run_id FROM bayn_qualification_trials
+        SELECT run_id FROM qualification_trials
         UNION
-        SELECT run_id FROM bayn_qualification_results
+        SELECT run_id FROM qualification_results
       ) AS trials
       ORDER BY run_id
     `,
@@ -896,8 +903,8 @@ const makeEvidenceStore = Effect.gen(function* () {
     Result: QualificationRow,
     execute: ({ candidateRunId }) => sql`
       SELECT lock.payload AS lock_payload, result.payload AS result_payload
-      FROM bayn_qualification_locks AS lock
-      LEFT JOIN bayn_qualification_results AS result USING (lock_id)
+      FROM qualification_locks AS lock
+      LEFT JOIN qualification_results AS result USING (lock_id)
       WHERE lock.candidate_run_id = ${candidateRunId}
     `,
   })
@@ -906,8 +913,8 @@ const makeEvidenceStore = Effect.gen(function* () {
     Result: QualificationRow,
     execute: ({ candidateRunId, snapshotId }) => sql`
       SELECT lock.payload AS lock_payload, result.payload AS result_payload
-      FROM bayn_qualification_locks AS lock
-      LEFT JOIN bayn_qualification_results AS result USING (lock_id)
+      FROM qualification_locks AS lock
+      LEFT JOIN qualification_results AS result USING (lock_id)
       WHERE lock.candidate_run_id = ${candidateRunId} OR lock.snapshot_id = ${snapshotId}
       ORDER BY lock.lock_id
     `,
@@ -926,7 +933,7 @@ const makeEvidenceStore = Effect.gen(function* () {
     }),
     Result: InsertedLockRow,
     execute: (request) => sql`
-      INSERT INTO bayn_qualification_locks (
+      INSERT INTO qualification_locks (
         lock_id,
         schema_version,
         candidate_run_id,
@@ -963,7 +970,7 @@ const makeEvidenceStore = Effect.gen(function* () {
     }),
     Result: InsertedResultRow,
     execute: (request) => sql`
-      INSERT INTO bayn_qualification_results (
+      INSERT INTO qualification_results (
         lock_id,
         schema_version,
         run_id,
@@ -988,7 +995,7 @@ const makeEvidenceStore = Effect.gen(function* () {
     Request: Schema.Struct({ candidateRunId: Sha256 }),
     Result: CandidateRunCountRow,
     execute: ({ candidateRunId }) => sql`
-      SELECT count(*)::integer AS count FROM bayn_evaluation_runs WHERE run_id = ${candidateRunId}
+      SELECT count(*)::integer AS count FROM evaluation_runs WHERE run_id = ${candidateRunId}
     `,
   })
   const getIncompleteQualificationCount = SqlSchema.findOne({
@@ -996,8 +1003,8 @@ const makeEvidenceStore = Effect.gen(function* () {
     Result: CandidateRunCountRow,
     execute: () => sql`
       SELECT count(*)::integer AS count
-      FROM bayn_qualification_locks AS lock
-      LEFT JOIN bayn_qualification_results AS result USING (lock_id)
+      FROM qualification_locks AS lock
+      LEFT JOIN qualification_results AS result USING (lock_id)
       WHERE result.lock_id IS NULL
     `,
   })
@@ -1032,7 +1039,7 @@ const makeEvidenceStore = Effect.gen(function* () {
   }) =>
     Effect.gen(function* () {
       yield* sql`
-        INSERT INTO bayn_protocol_locks (
+        INSERT INTO protocol_locks (
           protocol_hash,
           schema_version,
           strategy_name,
@@ -1071,7 +1078,7 @@ const makeEvidenceStore = Effect.gen(function* () {
     Effect.gen(function* () {
       const snapshot = inputManifest.finalizedSnapshot
       yield* sql`
-        INSERT INTO bayn_snapshot_references (
+        INSERT INTO snapshot_references (
           snapshot_id,
           schema_version,
           database_name,
@@ -1384,8 +1391,8 @@ const makeEvidenceStore = Effect.gen(function* () {
               parameters: plan.parameters,
             })
             yield* ensureSnapshotReference(plan.inputManifest)
-            yield* sql`LOCK TABLE bayn_qualification_trials IN SHARE MODE`
-            yield* sql`LOCK TABLE bayn_qualification_locks IN SHARE ROW EXCLUSIVE MODE`
+            yield* sql`LOCK TABLE qualification_trials IN SHARE MODE`
+            yield* sql`LOCK TABLE qualification_locks IN SHARE ROW EXCLUSIVE MODE`
 
             const existingRows = yield* getQualificationByIdentity({
               candidateRunId: lock.candidateRunId,
@@ -1531,6 +1538,11 @@ const makeEvidenceStore = Effect.gen(function* () {
           ['tsmom-signal-decisions', 'bayn.tsmom-signal-decisions.v1'],
         ])
         const artifacts = new Map(stored.artifacts.map((artifact) => [artifact.name, artifact]))
+        const requiredValue = <A>(value: A | undefined, description: string): Effect.Effect<A, DatabaseError> =>
+          value === undefined
+            ? Effect.fail(databaseError('invariant', 'recover-evidence', `stored run is missing ${description}`))
+            : Effect.succeed(value)
+        const requiredArtifact = (name: string) => requiredValue(artifacts.get(name), `artifact ${name}`)
         yield* ensure(
           artifacts.size === requiredArtifacts.size &&
             [...requiredArtifacts].every(
@@ -1550,29 +1562,56 @@ const makeEvidenceStore = Effect.gen(function* () {
           'recover-evidence',
           'stored run does not match the current runtime identity',
         )
-        const evaluation = yield* decodeEvaluationSummary(artifacts.get('evaluation-summary')!.payload)
-        const reconciliation = yield* decodeReconciliationResult(artifacts.get('reconciliation')!.payload)
-        const markedEquity = yield* decodeMarkedEquityReconciliation(
-          artifacts.get('marked-equity-reconciliation')!.payload,
-        )
-        const equitySeries = yield* decodeEquitySeriesArtifact(artifacts.get('equity-series')!.payload)
+        const [
+          evaluationArtifact,
+          reconciliationArtifact,
+          markedEquityArtifact,
+          equitySeriesArtifact,
+          ordersArtifact,
+          signalDecisionsArtifact,
+          buyAndHoldSeriesArtifact,
+          directVolatilitySeriesArtifact,
+          doubleCostSeriesArtifact,
+          artifactManifestArtifact,
+          cashChangesArtifact,
+          dailyMarksArtifact,
+          inputManifestArtifact,
+          strategyArtifact,
+          buyAndHoldArtifact,
+          directVolatilityArtifact,
+          doubleCostArtifact,
+        ] = yield* Effect.all([
+          requiredArtifact('evaluation-summary'),
+          requiredArtifact('reconciliation'),
+          requiredArtifact('marked-equity-reconciliation'),
+          requiredArtifact('equity-series'),
+          requiredArtifact('simulated-orders'),
+          requiredArtifact('tsmom-signal-decisions'),
+          requiredArtifact('buy-and-hold-series'),
+          requiredArtifact('direct-volatility-timing-series'),
+          requiredArtifact('double-cost-strategy-series'),
+          requiredArtifact('qualification-artifact-manifest'),
+          requiredArtifact('cash-changes'),
+          requiredArtifact('daily-position-marks'),
+          requiredArtifact('input-manifest'),
+          requiredArtifact('strategy'),
+          requiredArtifact('buy-and-hold'),
+          requiredArtifact('direct-volatility-timing'),
+          requiredArtifact('double-cost-strategy'),
+        ])
+        const evaluation = yield* decodeEvaluationSummary(evaluationArtifact.payload)
+        const reconciliation = yield* decodeReconciliationResult(reconciliationArtifact.payload)
+        const markedEquity = yield* decodeMarkedEquityReconciliation(markedEquityArtifact.payload)
+        const equitySeries = yield* decodeEquitySeriesArtifact(equitySeriesArtifact.payload)
         const events = yield* decodeEvaluationEvents(stored.events.map((event) => event.payload))
-        const orders = yield* decodeSimulatedOrdersArtifact(artifacts.get('simulated-orders')!.payload)
-        const signalDecisions = yield* decodeTsmomSignalDecisionsArtifact(
-          artifacts.get('tsmom-signal-decisions')!.payload,
-        )
-        const buyAndHoldSeries = yield* decodeDailyPerformanceSeriesArtifact(
-          artifacts.get('buy-and-hold-series')!.payload,
-        )
+        const orders = yield* decodeSimulatedOrdersArtifact(ordersArtifact.payload)
+        const signalDecisions = yield* decodeTsmomSignalDecisionsArtifact(signalDecisionsArtifact.payload)
+        const buyAndHoldSeries = yield* decodeDailyPerformanceSeriesArtifact(buyAndHoldSeriesArtifact.payload)
         const directVolatilitySeries = yield* decodeDailyPerformanceSeriesArtifact(
-          artifacts.get('direct-volatility-timing-series')!.payload,
+          directVolatilitySeriesArtifact.payload,
         )
-        const doubleCostSeries = yield* decodeDailyPerformanceSeriesArtifact(
-          artifacts.get('double-cost-strategy-series')!.payload,
-        )
-        const artifactManifest = yield* decodeQualificationArtifactManifest(
-          artifacts.get('qualification-artifact-manifest')!.payload,
-        )
+        const doubleCostSeries = yield* decodeDailyPerformanceSeriesArtifact(doubleCostSeriesArtifact.payload)
+        const artifactManifest = yield* decodeQualificationArtifactManifest(artifactManifestArtifact.payload)
         const storedExecutionModel = yield* Effect.try({
           try: () => protocolExecutionModel(stored.protocol.parameters),
           catch: (cause) => databaseError('invariant', 'recover-evidence', 'stored execution model is invalid', cause),
@@ -1588,9 +1627,9 @@ const makeEvidenceStore = Effect.gen(function* () {
           'recover-evidence',
           'stored protocol lock or execution model diverged',
         )
-        const cashChanges = yield* decodeCashChangesArtifact(artifacts.get('cash-changes')!.payload)
-        const dailyMarks = yield* decodeDailyPositionMarksArtifact(artifacts.get('daily-position-marks')!.payload)
-        const inputManifest = yield* decodeInputManifestArtifact(artifacts.get('input-manifest')!.payload)
+        const cashChanges = yield* decodeCashChangesArtifact(cashChangesArtifact.payload)
+        const dailyMarks = yield* decodeDailyPositionMarksArtifact(dailyMarksArtifact.payload)
+        const inputManifest = yield* decodeInputManifestArtifact(inputManifestArtifact.payload)
         const expectedArtifactManifest = {
           schemaVersion: 'bayn.qualification-artifact-manifest.v1',
           identity: {
@@ -1660,7 +1699,7 @@ const makeEvidenceStore = Effect.gen(function* () {
           catch: (cause) =>
             databaseError('invariant', 'recover-evidence', 'stored marked-equity reconstruction failed', cause),
         })
-        const finalPoint = equitySeries.items.at(-1)!
+        const finalPoint = yield* requiredValue(equitySeries.items.at(-1), 'final equity-series point')
         const decisionEvents = events.filter((event) => event.kind === 'decision')
         const candidateDates = dailyMarks.items.map((point) => point.sessionDate)
         yield* ensure(
@@ -1702,10 +1741,10 @@ const makeEvidenceStore = Effect.gen(function* () {
             ) &&
             evaluation.markedEquityReconciliation.runId === runId &&
             canonicalHashV1(evaluation.markedEquityReconciliation) === canonicalHashV1(markedEquity) &&
-            canonicalHashV1(evaluation.strategy) === artifacts.get('strategy')!.contentHash &&
-            canonicalHashV1(evaluation.buyAndHold) === artifacts.get('buy-and-hold')!.contentHash &&
-            canonicalHashV1(evaluation.directVolTiming) === artifacts.get('direct-volatility-timing')!.contentHash &&
-            canonicalHashV1(evaluation.doubleCostStrategy) === artifacts.get('double-cost-strategy')!.contentHash &&
+            canonicalHashV1(evaluation.strategy) === strategyArtifact.contentHash &&
+            canonicalHashV1(evaluation.buyAndHold) === buyAndHoldArtifact.contentHash &&
+            canonicalHashV1(evaluation.directVolTiming) === directVolatilityArtifact.contentHash &&
+            canonicalHashV1(evaluation.doubleCostStrategy) === doubleCostArtifact.contentHash &&
             stored.gates.length === evaluation.verdict.gates.length &&
             stored.gates.every(
               (gate, index) =>
@@ -1816,7 +1855,7 @@ const makeEvidenceStore = Effect.gen(function* () {
             }
 
             yield* sql`
-            INSERT INTO bayn_status_history (run_id, status, detail)
+            INSERT INTO status_history (run_id, status, detail)
             VALUES (
               ${plan.evaluation.runId},
               'WRITING',
@@ -1830,7 +1869,7 @@ const makeEvidenceStore = Effect.gen(function* () {
             yield* Effect.forEach(
               plan.artifacts,
               (artifact) => sql`
-              INSERT INTO bayn_evaluation_artifacts (
+              INSERT INTO evaluation_artifacts (
                 run_id,
                 artifact_name,
                 schema_version,
@@ -1849,7 +1888,7 @@ const makeEvidenceStore = Effect.gen(function* () {
             yield* Effect.forEach(
               plan.events,
               (event) => sql`
-              INSERT INTO bayn_evaluation_events (
+              INSERT INTO evaluation_events (
                 run_id,
                 ordinal,
                 event_id,
@@ -1870,7 +1909,7 @@ const makeEvidenceStore = Effect.gen(function* () {
             yield* Effect.forEach(
               plan.gates,
               (gate) => sql`
-              INSERT INTO bayn_gate_outcomes (
+              INSERT INTO gate_outcomes (
                 run_id,
                 ordinal,
                 gate_name,
@@ -1897,7 +1936,7 @@ const makeEvidenceStore = Effect.gen(function* () {
               'run could not be completed with exact evidence counts',
             )
             yield* sql`
-            INSERT INTO bayn_status_history (run_id, status, detail)
+            INSERT INTO status_history (run_id, status, detail)
             VALUES (
               ${plan.evaluation.runId},
               'COMPLETE',
@@ -1968,11 +2007,36 @@ export const PostgresClientLive = (config: RuntimeConfig) => {
   )
 }
 
-const migrations = PgMigrator.run({ loader: migrationLoader, table: 'bayn_schema_migrations' }).pipe(
+const migrate = Effect.gen(function* () {
+  const sql = yield* PgClient.PgClient
+  const inspectMigrationTables = SqlSchema.findOne({
+    Request: Schema.Void,
+    Result: MigrationTablesRow,
+    execute: () => sql`
+      SELECT
+        to_regclass('public.schema_migrations') IS NOT NULL AS current_exists,
+        to_regclass('public.bayn_schema_migrations') IS NOT NULL AS legacy_exists
+    `,
+  })
+  const state = yield* inspectMigrationTables(undefined)
+  if (state.current_exists && state.legacy_exists) {
+    return yield* Effect.fail(databaseError('migration', 'migrate', 'both current and legacy migration tables exist'))
+  }
+
+  const table = state.legacy_exists ? 'bayn_schema_migrations' : 'schema_migrations'
+  yield* PgMigrator.run({ loader: migrationLoader, table })
+  if (state.legacy_exists) {
+    yield* sql`ALTER TABLE bayn_schema_migrations RENAME TO schema_migrations`
+  }
+})
+
+const migrations = migrate.pipe(
   Effect.mapError((cause) =>
-    isSqlError(cause)
-      ? classifyDatabaseError('migrate', cause)
-      : databaseError('migration', 'migrate', 'PostgreSQL migration failed', cause),
+    cause instanceof DatabaseError
+      ? cause
+      : isSqlError(cause)
+        ? classifyDatabaseError('migrate', cause)
+        : databaseError('migration', 'migrate', 'PostgreSQL migration failed', cause),
   ),
   Effect.asVoid,
 )

--- a/services/bayn/src/db/migrations.ts
+++ b/services/bayn/src/db/migrations.ts
@@ -5,6 +5,7 @@ import qualificationLock from '../../migrations/0002_qualification_lock'
 import evidenceImmutability from '../../migrations/0003_evidence_immutability'
 import executionEvents from '../../migrations/0004_execution_events'
 import lockedQualification from '../../migrations/0005_locked_qualification'
+import domainNames from '../../migrations/0006_domain_names'
 
 export const migrationLoader = PgMigrator.fromRecord({
   '1_evaluation_evidence': evaluationEvidence,
@@ -12,4 +13,5 @@ export const migrationLoader = PgMigrator.fromRecord({
   '3_evidence_immutability': evidenceImmutability,
   '4_execution_events': executionEvents,
   '5_locked_qualification': lockedQualification,
+  '6_domain_names': domainNames,
 })

--- a/services/bayn/src/hash.ts
+++ b/services/bayn/src/hash.ts
@@ -22,25 +22,11 @@ export const hashObject = (value: unknown): string => sha256(canonicalJson(value
 
 const compareUtf16 = (left: string, right: string): number => (left < right ? -1 : left > right ? 1 : 0)
 
-const hasLoneSurrogate = (value: string): boolean => {
-  for (let index = 0; index < value.length; index += 1) {
-    const code = value.charCodeAt(index)
-    if (code >= 0xd800 && code <= 0xdbff) {
-      const next = value.charCodeAt(index + 1)
-      if (next < 0xdc00 || next > 0xdfff) return true
-      index += 1
-    } else if (code >= 0xdc00 && code <= 0xdfff) {
-      return true
-    }
-  }
-  return false
-}
-
 const serializeCanonicalValue = (value: unknown, ancestors: Set<object>, path: string): string => {
   if (value === null) return 'null'
   if (typeof value === 'boolean') return value ? 'true' : 'false'
   if (typeof value === 'string') {
-    if (hasLoneSurrogate(value)) throw new TypeError(`${path} contains an invalid Unicode surrogate`)
+    if (!value.isWellFormed()) throw new TypeError(`${path} contains an invalid Unicode surrogate`)
     return JSON.stringify(value)
   }
   if (typeof value === 'number') {
@@ -86,7 +72,7 @@ const serializeCanonicalValue = (value: unknown, ancestors: Set<object>, path: s
     const keys = Reflect.ownKeys(value)
     if (keys.some((key) => typeof key !== 'string')) throw new TypeError(`${path} contains a symbol key`)
     const entries = (keys as string[]).map((key) => {
-      if (hasLoneSurrogate(key)) throw new TypeError(`${path} contains an invalid Unicode key`)
+      if (!key.isWellFormed()) throw new TypeError(`${path} contains an invalid Unicode key`)
       const descriptor = Object.getOwnPropertyDescriptor(value, key)
       if (!descriptor?.enumerable || !('value' in descriptor)) {
         throw new TypeError(`${path}.${key} must be an enumerable data property`)

--- a/services/bayn/src/index.ts
+++ b/services/bayn/src/index.ts
@@ -1,6 +1,6 @@
 import { NodeHttpClient, NodeRuntime, NodeServices } from '@effect/platform-node'
 import { ClickhouseClient } from '@effect/sql-clickhouse'
-import { Cause, Effect, Layer, Logger, Redacted } from 'effect'
+import { Effect, Layer, Logger, Redacted } from 'effect'
 
 import { run } from './app'
 import { loadConfig } from './config'
@@ -50,15 +50,6 @@ const main = Effect.gen(function* () {
   return yield* run(config).pipe(Effect.provide(dependencies))
 })
 
-const program = main.pipe(
-  Effect.tapCause((cause) =>
-    Cause.hasInterruptsOnly(cause)
-      ? Effect.void
-      : Effect.logError('Bayn process failed').pipe(
-          Effect.annotateLogs({ service: 'bayn', event: 'process_failed', cause: Cause.pretty(cause) }),
-        ),
-  ),
-  Effect.provide(Logger.layer([Logger.consoleJson])),
-)
+const program = main.pipe(Effect.annotateLogs({ service: 'bayn' }), Effect.provide(Logger.layer([Logger.consoleJson])))
 
-NodeRuntime.runMain(program, { disableErrorReporting: true })
+NodeRuntime.runMain(program)

--- a/services/bayn/src/ledger.ts
+++ b/services/bayn/src/ledger.ts
@@ -423,11 +423,17 @@ export const assertReconciled = (
 
   const expectedBalances = new Map(plan.accounts.map((value) => [value.id, { debits: 0n, credits: 0n }]))
   for (const value of plan.transfers) {
-    expectedBalances.get(value.debit_account_id)!.debits += value.amount
-    expectedBalances.get(value.credit_account_id)!.credits += value.amount
+    const debit = expectedBalances.get(value.debit_account_id)
+    const credit = expectedBalances.get(value.credit_account_id)
+    if (debit === undefined || credit === undefined) {
+      throw new Error(`transfer ${value.id} references an unknown account`)
+    }
+    debit.debits += value.amount
+    credit.credits += value.amount
   }
   for (const value of actualAccounts) {
-    const balance = expectedBalances.get(value.id)!
+    const balance = expectedBalances.get(value.id)
+    if (balance === undefined) throw new Error(`unexpected account ${value.id}`)
     if (
       value.debits_pending !== 0n ||
       value.credits_pending !== 0n ||
@@ -575,7 +581,8 @@ const assertPersistedRun = (
   }
 
   for (const value of accounts) {
-    const balance = balances.get(value.id)!
+    const balance = balances.get(value.id)
+    if (balance === undefined) throw new Error(`run ${result.runId} has no balance for account ${value.id}`)
     if (
       value.debits_pending !== 0n ||
       value.credits_pending !== 0n ||

--- a/services/bayn/src/market-data.test.ts
+++ b/services/bayn/src/market-data.test.ts
@@ -7,6 +7,7 @@ import {
   type SnapshotRequest,
   type SnapshotRows,
 } from './market-data'
+import { DataFeed, DataSource, PriceAdjustment, PublicationSchema } from './types'
 
 const symbols = ['EEM', 'SPY'] as const
 const snapshotId = '2fb38a01471d5a6bb6c5aa08a49b6ff844a5a9ee1c6e7bb9ff7786ecdac01bba'
@@ -25,9 +26,9 @@ const producerRows = {
       adjusted_volume: '1000010.00000000',
       trade_count: '1010',
       vwap: '109.90000000',
-      provider: 'alpaca',
-      source_feed: 'sip',
-      adjustment: 'all',
+      provider: DataSource.Alpaca,
+      source_feed: DataFeed.Sip,
+      adjustment: PriceAdjustment.All,
       publication_asof: '2025-01-03',
     },
     {
@@ -41,9 +42,9 @@ const producerRows = {
       adjusted_volume: '1000020.00000000',
       trade_count: '1020',
       vwap: '119.90000000',
-      provider: 'alpaca',
-      source_feed: 'sip',
-      adjustment: 'all',
+      provider: DataSource.Alpaca,
+      source_feed: DataFeed.Sip,
+      adjustment: PriceAdjustment.All,
       publication_asof: '2025-01-03',
     },
     {
@@ -57,9 +58,9 @@ const producerRows = {
       adjusted_volume: '1000011.00000000',
       trade_count: '1011',
       vwap: '110.90000000',
-      provider: 'alpaca',
-      source_feed: 'sip',
-      adjustment: 'all',
+      provider: DataSource.Alpaca,
+      source_feed: DataFeed.Sip,
+      adjustment: PriceAdjustment.All,
       publication_asof: '2025-01-03',
     },
     {
@@ -73,9 +74,9 @@ const producerRows = {
       adjusted_volume: '1000021.00000000',
       trade_count: '1021',
       vwap: '120.90000000',
-      provider: 'alpaca',
-      source_feed: 'sip',
-      adjustment: 'all',
+      provider: DataSource.Alpaca,
+      source_feed: DataFeed.Sip,
+      adjustment: PriceAdjustment.All,
       publication_asof: '2025-01-03',
     },
   ],
@@ -87,7 +88,7 @@ const producerRows = {
       open_time: '09:30',
       close_time: '16:00',
       timezone: 'America/New_York',
-      provider: 'alpaca',
+      provider: DataSource.Alpaca,
     },
     {
       snapshot_id: snapshotId,
@@ -96,19 +97,19 @@ const producerRows = {
       open_time: '09:30',
       close_time: '16:00',
       timezone: 'America/New_York',
-      provider: 'alpaca',
+      provider: DataSource.Alpaca,
     },
   ],
   manifests: [
     {
       snapshot_id: snapshotId,
-      schema_version: 'signal.adjusted-daily-snapshot.v1',
+      schema_version: PublicationSchema.AdjustedDailySnapshotV1,
       publisher_source_revision: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
       publisher_image_repository: 'registry.ide-newton.ts.net/lab/signal-publisher',
       publisher_image_digest: `sha256:${'b'.repeat(64)}`,
-      provider: 'alpaca',
-      source_feed: 'sip',
-      adjustment: 'all',
+      provider: DataSource.Alpaca,
+      source_feed: DataFeed.Sip,
+      adjustment: PriceAdjustment.All,
       calendar_version: 'alpaca-us-equity-calendar-v1',
       requested_start: '2025-01-02',
       publication_asof: '2025-01-03',
@@ -167,7 +168,7 @@ describe('finalized Signal snapshot reader', () => {
         publicationId: source.manifest_content_hash,
         contentHash: source.bars_content_hash,
         sessionsContentHash: source.sessions_content_hash,
-        sourceFeed: 'sip',
+        sourceFeed: DataFeed.Sip,
         symbols,
       },
     })

--- a/services/bayn/src/market-data.ts
+++ b/services/bayn/src/market-data.ts
@@ -5,7 +5,16 @@ import type { RuntimeConfig } from './config'
 import { FinalizedSnapshotProvenanceSchema, type EvaluationBounds, type FinalizedSnapshotProvenance } from './contracts'
 import { OperationalError, operationalError } from './errors'
 import { canonicalHashV1 } from './hash'
-import type { DailyBar, InputManifest, IsoDate, SymbolCoverage } from './types'
+import {
+  DataFeed,
+  DataSource,
+  PriceAdjustment,
+  PublicationSchema,
+  type DailyBar,
+  type InputManifest,
+  type IsoDate,
+  type SymbolCoverage,
+} from './types'
 
 const database = 'signal' as const
 const tables = {
@@ -13,17 +22,15 @@ const tables = {
   sessions: 'exchange_sessions_v1',
   manifests: 'snapshot_manifests_v1',
 } as const
-const signalSchemaVersion = 'signal.adjusted-daily-snapshot.v1' as const
 const calendarTimeZone = 'America/New_York' as const
 const StrictParseOptions = { onExcessProperty: 'error' } as const
 
-const IsoDateSchema = Schema.String.check(
-  Schema.isPattern(/^\d{4}-\d{2}-\d{2}$/),
-  Schema.makeFilter((value: string) => {
-    const parsed = new Date(`${value}T00:00:00.000Z`)
-    return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value
-  }),
-)
+const isIsoDate = (value: string): value is IsoDate => {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false
+  const parsed = new Date(`${value}T00:00:00.000Z`)
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value
+}
+const IsoDateSchema = Schema.String.pipe(Schema.refine(isIsoDate, { expected: 'a valid ISO date (YYYY-MM-DD)' }))
 const SnapshotIdSchema = Schema.String.check(Schema.isPattern(/^[a-f0-9]{64}$/))
 const HashSchema = Schema.String.check(Schema.isPattern(/^[a-f0-9]{64}$/))
 const SourceRevisionSchema = Schema.String.check(Schema.isPattern(/^[a-f0-9]{40}$/))
@@ -49,9 +56,9 @@ const SignalBarRowSchema = Schema.Struct({
   adjusted_volume: FixedDecimalSchema,
   trade_count: DigitsSchema,
   vwap: Schema.NullOr(FixedDecimalSchema),
-  provider: Schema.Literal('alpaca'),
-  source_feed: Schema.Literal('sip'),
-  adjustment: Schema.Literal('all'),
+  provider: Schema.Enum(DataSource),
+  source_feed: Schema.Enum(DataFeed),
+  adjustment: Schema.Enum(PriceAdjustment),
   publication_asof: IsoDateSchema,
 })
 const SignalSessionRowSchema = Schema.Struct({
@@ -61,17 +68,17 @@ const SignalSessionRowSchema = Schema.Struct({
   open_time: MarketTimeSchema,
   close_time: MarketTimeSchema,
   timezone: Schema.Literal(calendarTimeZone),
-  provider: Schema.Literal('alpaca'),
+  provider: Schema.Enum(DataSource),
 })
 const SignalManifestRowSchema = Schema.Struct({
   snapshot_id: SnapshotIdSchema,
-  schema_version: Schema.Literal(signalSchemaVersion),
+  schema_version: Schema.Enum(PublicationSchema),
   publisher_source_revision: SourceRevisionSchema,
   publisher_image_repository: ImageRepositorySchema,
   publisher_image_digest: ImageDigestSchema,
-  provider: Schema.Literal('alpaca'),
-  source_feed: Schema.Literal('sip'),
-  adjustment: Schema.Literal('all'),
+  provider: Schema.Enum(DataSource),
+  source_feed: Schema.Enum(DataFeed),
+  adjustment: Schema.Enum(PriceAdjustment),
   calendar_version: Schema.Trim.check(Schema.isMinLength(1)),
   requested_start: IsoDateSchema,
   publication_asof: IsoDateSchema,
@@ -163,10 +170,10 @@ const toNumber = (value: string, name: string, positive: boolean): number => {
   return parsed
 }
 
-const toDailyBar = (row: SignalBarRow, publicationSchemaVersion: string): DailyBar => {
+const toDailyBar = (row: SignalBarRow, publicationSchemaVersion: PublicationSchema): DailyBar => {
   const bar: DailyBar = {
     symbol: row.symbol,
-    sessionDate: row.session_date as IsoDate,
+    sessionDate: row.session_date,
     open: toNumber(row.adjusted_open, 'adjusted_open', true),
     high: toNumber(row.adjusted_high, 'adjusted_high', true),
     low: toNumber(row.adjusted_low, 'adjusted_low', true),
@@ -299,11 +306,11 @@ const verifyCalendar = (
   }
   if (orderedSessions.length !== manifest.session_count)
     throw new Error('exchange-session count does not match manifest')
-  if (orderedSessions.length === 0) throw new Error('snapshot has no exchange sessions')
-  if (orderedSessions[0].session_date !== manifest.first_session)
-    throw new Error('first exchange session does not match')
-  if (orderedSessions.at(-1)!.session_date !== manifest.last_session)
-    throw new Error('last exchange session does not match')
+  const firstSession = orderedSessions.at(0)
+  const lastSession = orderedSessions.at(-1)
+  if (firstSession === undefined || lastSession === undefined) throw new Error('snapshot has no exchange sessions')
+  if (firstSession.session_date !== manifest.first_session) throw new Error('first exchange session does not match')
+  if (lastSession.session_date !== manifest.last_session) throw new Error('last exchange session does not match')
   if (canonicalHashV1(orderedSessions.map(withoutSnapshot)) !== manifest.sessions_content_hash) {
     throw new Error('exchange-session content hash is invalid')
   }
@@ -311,11 +318,16 @@ const verifyCalendar = (
   const boundedSessions = orderedSessions.filter(
     (session) => session.session_date >= request.bounds.dataStart && session.session_date <= request.bounds.dataEnd,
   )
+  const firstBoundedSession = boundedSessions.at(0)
+  const lastBoundedSession = boundedSessions.at(-1)
+  if (firstBoundedSession === undefined || lastBoundedSession === undefined) {
+    throw new Error('evaluation bounds contain no exchange sessions')
+  }
   const symbols: SymbolCoverage[] = universe.map((symbol) => ({
     symbol,
     rows: boundedSessions.length,
-    firstSession: boundedSessions[0].session_date as IsoDate,
-    lastSession: boundedSessions.at(-1)!.session_date as IsoDate,
+    firstSession: firstBoundedSession.session_date,
+    lastSession: lastBoundedSession.session_date,
   }))
   const manifestMaterial: Omit<InputManifest, 'hash'> = {
     schemaVersion: 'bayn.input-manifest.v2',
@@ -325,8 +337,8 @@ const verifyCalendar = (
     bounds: request.bounds,
     rowCount: boundedSessions.length * universe.length,
     sessionCount: boundedSessions.length,
-    firstSession: boundedSessions[0].session_date as IsoDate,
-    lastSession: boundedSessions.at(-1)!.session_date as IsoDate,
+    firstSession: firstBoundedSession.session_date,
+    lastSession: lastBoundedSession.session_date,
     symbols,
   }
   return {
@@ -344,7 +356,7 @@ export const verifyFinalizedCalendar = (
   const calendar = verifyCalendar(rows.sessions, rows.manifests, request)
   return {
     manifest: calendar.inputManifest,
-    sessionDates: calendar.boundedSessions.map((session) => session.session_date as IsoDate),
+    sessionDates: calendar.boundedSessions.map((session) => session.session_date),
   }
 }
 

--- a/services/bayn/src/qualification-audit-command.ts
+++ b/services/bayn/src/qualification-audit-command.ts
@@ -169,15 +169,15 @@ const readDatabase = (runId: string): Effect.Effect<AuditDatabaseSnapshot, unkno
                 run.strategy_name,
                 run.initial_capital_micros::text AS initial_capital_micros,
                 run.status,
-                (SELECT count(*)::integer FROM bayn_evaluation_artifacts WHERE run_id = run.run_id) AS artifact_count,
-                (SELECT count(*)::integer FROM bayn_evaluation_events WHERE run_id = run.run_id) AS event_count,
-                (SELECT count(*)::integer FROM bayn_gate_outcomes WHERE run_id = run.run_id) AS gate_count,
+                (SELECT count(*)::integer FROM evaluation_artifacts WHERE run_id = run.run_id) AS artifact_count,
+                (SELECT count(*)::integer FROM evaluation_events WHERE run_id = run.run_id) AS event_count,
+                (SELECT count(*)::integer FROM gate_outcomes WHERE run_id = run.run_id) AS gate_count,
                 protocol.schema_version,
                 protocol.behavior_hash,
                 protocol.parameter_hash,
                 protocol.parameters
-              FROM bayn_evaluation_runs AS run
-              JOIN bayn_protocol_locks AS protocol USING (protocol_hash)
+              FROM evaluation_runs AS run
+              JOIN protocol_locks AS protocol USING (protocol_hash)
               WHERE run.run_id = ${runId}
             `,
           ),
@@ -186,7 +186,7 @@ const readDatabase = (runId: string): Effect.Effect<AuditDatabaseSnapshot, unkno
         const artifacts = decodeArtifactRows(
           yield* sql`
             SELECT artifact_name, schema_version, content_hash, payload
-            FROM bayn_evaluation_artifacts
+            FROM evaluation_artifacts
             WHERE run_id = ${runId}
             ORDER BY artifact_name
           `,
@@ -194,7 +194,7 @@ const readDatabase = (runId: string): Effect.Effect<AuditDatabaseSnapshot, unkno
         const events = decodeEventRows(
           yield* sql`
             SELECT ordinal, event_id, event_kind, content_hash, payload
-            FROM bayn_evaluation_events
+            FROM evaluation_events
             WHERE run_id = ${runId}
             ORDER BY ordinal
           `,
@@ -202,7 +202,7 @@ const readDatabase = (runId: string): Effect.Effect<AuditDatabaseSnapshot, unkno
         const gates = decodeGateRows(
           yield* sql`
             SELECT ordinal, gate_name, passed, actual, required, content_hash
-            FROM bayn_gate_outcomes
+            FROM gate_outcomes
             WHERE run_id = ${runId}
             ORDER BY ordinal
           `,
@@ -210,7 +210,7 @@ const readDatabase = (runId: string): Effect.Effect<AuditDatabaseSnapshot, unkno
         const statuses = decodeStatusRows(
           yield* sql`
             SELECT status, detail
-            FROM bayn_status_history
+            FROM status_history
             WHERE run_id = ${runId}
             ORDER BY sequence
           `,
@@ -218,9 +218,9 @@ const readDatabase = (runId: string): Effect.Effect<AuditDatabaseSnapshot, unkno
         const trials = decodeTrialRows(
           yield* sql`
             SELECT run_id
-            FROM bayn_qualification_trials
+            FROM qualification_trials
             WHERE observed_at < (
-              SELECT created_at FROM bayn_qualification_locks WHERE candidate_run_id = ${runId}
+              SELECT created_at FROM qualification_locks WHERE candidate_run_id = ${runId}
             )
             ORDER BY run_id
           `,
@@ -237,8 +237,8 @@ const readDatabase = (runId: string): Effect.Effect<AuditDatabaseSnapshot, unkno
                 result.verdict,
                 lock.payload AS lock_payload,
                 result.payload AS result_payload
-              FROM bayn_qualification_locks AS lock
-              JOIN bayn_qualification_results AS result USING (lock_id)
+              FROM qualification_locks AS lock
+              JOIN qualification_results AS result USING (lock_id)
               WHERE lock.candidate_run_id = ${runId}
             `,
           ),

--- a/services/bayn/src/qualification-audit.ts
+++ b/services/bayn/src/qualification-audit.ts
@@ -2,7 +2,7 @@ import { canonicalHashV1 } from './hash'
 import { evaluateReferenceTsmom } from './qualification-reference'
 import { reconcileMarkedEquity } from './simulation-reconciliation'
 import { makeRuntimeProvenance } from './contracts'
-import type { DailyBar, InputManifest, TsmomProtocol } from './types'
+import { ContractVersion, type DailyBar, type InputManifest, type SimulationTrace, type TsmomProtocol } from './types'
 
 export interface StoredArtifact {
   readonly name: string
@@ -178,11 +178,12 @@ const expectedResultReason = (gateName: string): string =>
 const makeSummary = (
   input: QualificationAuditInput,
   reference: ReturnType<typeof evaluateReferenceTsmom>,
+  trace: SimulationTrace,
   markedEquity: ReturnType<typeof reconcileMarkedEquity>['reconciliation'],
 ) => ({
-  schemaVersion: 'bayn.evaluation-summary.v3',
+  schemaVersion: ContractVersion.EvaluationSummary,
   runId: reference.runId,
-  evaluationSchemaVersion: 'bayn.evaluation.v4',
+  evaluationSchemaVersion: ContractVersion.Evaluation,
   codeRevision: input.database.run.sourceRevision,
   protocolHash: reference.protocolHash,
   initialCapitalMicros: input.protocol.initialCapitalMicros,
@@ -202,9 +203,9 @@ const makeSummary = (
   verdict: reference.verdict,
   eventCount: reference.strategy.events.length,
   signalDecisionCount: reference.strategy.decisions.length,
-  orderCount: reference.strategy.trace!.orders.length,
-  cashChangeCount: reference.strategy.trace!.cashChanges.length,
-  dailyMarkCount: reference.strategy.trace!.dailyMarks.length,
+  orderCount: trace.orders.length,
+  cashChangeCount: trace.cashChanges.length,
+  dailyMarkCount: trace.dailyMarks.length,
   benchmarkSeriesCounts: {
     buyAndHold: reference.buyAndHold.daily.length,
     directVolTiming: reference.directVolTiming.daily.length,
@@ -336,7 +337,7 @@ export const auditQualification = (input: QualificationAuditInput): Qualificatio
   )
 
   const expectedArtifacts = new Map<string, unknown>([
-    ['evaluation-summary', makeSummary(input, reference, markedEquity.reconciliation)],
+    ['evaluation-summary', makeSummary(input, reference, reference.strategy.trace, markedEquity.reconciliation)],
     ['input-manifest', input.manifest],
     ['strategy', reference.strategy.metrics],
     ['buy-and-hold', reference.buyAndHold.metrics],

--- a/services/bayn/src/qualification-reference.ts
+++ b/services/bayn/src/qualification-reference.ts
@@ -103,7 +103,14 @@ const align = (bars: readonly DailyBar[], manifest: InputManifest, universe: rea
       if (day.size !== universe.length || universe.some((symbol) => !day.has(symbol))) {
         throw new Error(`reference input session ${date} is incomplete`)
       }
-      return { date, bars: Object.fromEntries(universe.map((symbol) => [symbol, day.get(symbol)!])) }
+      const sessionBars = Object.fromEntries(
+        universe.map((symbol) => {
+          const bar = day.get(symbol)
+          if (bar === undefined) throw new Error(`reference input session ${date} is missing ${symbol}`)
+          return [symbol, bar]
+        }),
+      )
+      return { date, bars: sessionBars }
     })
   if (
     sessions.length !== manifest.sessionCount ||
@@ -188,11 +195,14 @@ const metrics = (
   if (equityMicros.length < 2 || equityMicros.some((value) => value <= 0n)) {
     throw new Error('reference replay produced an invalid equity curve')
   }
+  const endingEquityMicros = equityMicros.at(-1)
+  if (endingEquityMicros === undefined) throw new Error('reference replay produced an empty equity curve')
   const equity = equityMicros.map(microsToNumber)
   const initial = microsToNumber(initialMicros)
+  const endingEquity = microsToNumber(endingEquityMicros)
   const returns = equity.map((value, index) => value / (index === 0 ? initial : equity[index - 1]) - 1)
-  const totalReturn = equity.at(-1)! / initial - 1
-  const annualizedReturn = Math.pow(equity.at(-1)! / initial, tradingDays / equity.length) - 1
+  const totalReturn = endingEquity / initial - 1
+  const annualizedReturn = Math.pow(endingEquity / initial, tradingDays / equity.length) - 1
   const annualizedVolatility = sampleDeviation(returns) * Math.sqrt(tradingDays)
   const sharpe = annualizedVolatility === 0 ? 0 : (average(returns) * tradingDays) / annualizedVolatility
   let peak = initial
@@ -213,7 +223,7 @@ const metrics = (
     totalSpreadCostMicros: spreadMicros.toString(),
     totalSlippageCostMicros: slippageMicros.toString(),
     totalCashYieldMicros: yieldMicros.toString(),
-    endingEquityMicros: equityMicros.at(-1)!.toString(),
+    endingEquityMicros: endingEquityMicros.toString(),
   }
 }
 

--- a/services/bayn/src/qualification-statistics.ts
+++ b/services/bayn/src/qualification-statistics.ts
@@ -416,11 +416,13 @@ const buildCompleteBlocks = (series: QualificationSeries): readonly BlockWork[] 
       (observation) => observation.sessionDate >= startSession && observation.sessionDate < nextRebalanceSession,
     )
     if (observations.length === 0 || observations[0].sessionDate !== startSession) continue
+    const lastObservation = observations.at(-1)
+    if (lastObservation === undefined) continue
     const material = {
       schemaVersion: 'bayn.qualification-block.v1',
       ordinal: blocks.length,
       startSession,
-      endSession: observations.at(-1)!.sessionDate,
+      endSession: lastObservation.sessionDate,
       nextRebalanceSession,
       observations,
     }
@@ -586,13 +588,15 @@ const runWalkForward = (
     const drawdown = maximumDrawdown(strategyReturns)
     const positiveExcess = excessReturn > 0
     const drawdownWithinLimit = drawdown <= policy.walkForward.maximumFoldDrawdown
+    const lastTestObservation = test.at(-1)
+    if (lastTestObservation === undefined) throw new Error('walk-forward fold has no test observations')
     const material = {
       schemaVersion: 'bayn.walk-forward-fold.v1' as const,
       ordinal: folds.length,
       trainingStart: series.observations[0].sessionDate,
       trainingEnd: series.observations[testStart - 1].sessionDate,
       testStart: test[0].sessionDate,
-      testEnd: test.at(-1)!.sessionDate,
+      testEnd: lastTestObservation.sessionDate,
       testObservationCount: test.length,
       strategyReturn: roundStatistic(strategyReturn),
       cashReturn: roundStatistic(cashReturn),

--- a/services/bayn/src/qualification.ts
+++ b/services/bayn/src/qualification.ts
@@ -1,7 +1,7 @@
 import { Schema } from 'effect'
 
 import { EvaluationBoundsSchema, IsoDateSchema, Sha256Schema } from './contracts'
-import { canonicalHashV1, canonicalJsonV1 } from './hash'
+import { canonicalHashV1 } from './hash'
 import {
   QualificationAnalysisSchema,
   defaultQualificationStatisticsPolicy,
@@ -20,19 +20,7 @@ const ImageDigest = Schema.String.check(Schema.isPattern(/^sha256:[a-f0-9]{64}$/
 const SymbolName = Schema.String.check(Schema.isPattern(/^[A-Z][A-Z0-9.-]{0,15}$/))
 const MinimumSessions = Schema.Int.check(Schema.isGreaterThanOrEqualTo(504))
 const MinimumRebalances = Schema.Int.check(Schema.isGreaterThanOrEqualTo(24))
-const CanonicalJson = Schema.Unknown.check(
-  Schema.makeFilter(
-    (value: unknown) => {
-      try {
-        canonicalJsonV1(value)
-        return true
-      } catch {
-        return false
-      }
-    },
-    { expected: 'a canonical JSON value' },
-  ),
-)
+const CanonicalJson = Schema.Unknown.check(Schema.makeFilter(Schema.is(Schema.Json), { expected: 'a JSON value' }))
 
 const PolicyDocumentBase = Schema.Struct({
   schemaVersion: NonEmptyString,

--- a/services/bayn/src/simulation-reconciliation.ts
+++ b/services/bayn/src/simulation-reconciliation.ts
@@ -300,7 +300,9 @@ export const reconcileMarkedEquity = (input: {
       }
       cash += amount
       ensure(cash >= -tolerance, `event ${event.id} spends unavailable reconstructed cash`)
-      validateCashChange(input.runId, changesBySource.get(event.id)!, event, amount, cash)
+      const change = changesBySource.get(event.id)
+      if (change === undefined) throw new Error(`event ${event.id} has no cash change`)
+      validateCashChange(input.runId, change, event, amount, cash)
       eventIndex += 1
     }
 

--- a/services/bayn/src/strategy.ts
+++ b/services/bayn/src/strategy.ts
@@ -19,27 +19,28 @@ import {
 import { canonicalHashV1, hashObject } from './hash'
 import { hashTsmomParameters } from './protocol'
 import { reconcileMarkedEquity } from './simulation-reconciliation'
-import type {
-  CashChange,
-  DailyBar,
-  DailyPerformancePoint,
-  DailyPositionMark,
-  DecisionEvent,
-  EconomicVerdict,
-  EvaluationEvent,
-  EvaluationResult,
-  EvaluationSummary,
-  FeeEvent,
-  FillEvent,
-  GateResult,
-  InputManifest,
-  IsoDate,
-  PerformanceMetrics,
-  SimulatedOrder,
-  SimulationTrace,
-  TsmomDecisionPlan,
-  TsmomProtocol,
-  TsmomSignalDecision,
+import {
+  ContractVersion,
+  type CashChange,
+  type DailyBar,
+  type DailyPerformancePoint,
+  type DailyPositionMark,
+  type DecisionEvent,
+  type EconomicVerdict,
+  type EvaluationEvent,
+  type EvaluationResult,
+  type EvaluationSummary,
+  type FeeEvent,
+  type FillEvent,
+  type GateResult,
+  type InputManifest,
+  type IsoDate,
+  type PerformanceMetrics,
+  type SimulatedOrder,
+  type SimulationTrace,
+  type TsmomDecisionPlan,
+  type TsmomProtocol,
+  type TsmomSignalDecision,
 } from './types'
 
 interface AlignedSession {
@@ -108,10 +109,14 @@ const alignBars = (
     if (actualSymbols.join(',') !== universe.join(',')) {
       throw new Error(`strategy input session ${date} is incomplete`)
     }
-    return {
-      date,
-      bars: Object.fromEntries(universe.map((symbol) => [symbol, session.get(symbol)!])),
-    }
+    const sessionBars = Object.fromEntries(
+      universe.map((symbol) => {
+        const bar = session.get(symbol)
+        if (bar === undefined) throw new Error(`strategy input session ${date} is missing ${symbol}`)
+        return [symbol, bar]
+      }),
+    )
+    return { date, bars: sessionBars }
   })
   if (aligned[0]?.date !== inputManifest.firstSession || aligned.at(-1)?.date !== inputManifest.lastSession) {
     throw new Error('strategy input bounds do not match manifest')
@@ -139,9 +144,11 @@ export const makeTsmomDecision = (
     if (history.some((price) => !Number.isFinite(price) || price <= 0)) {
       throw new Error(`TSMOM decision contains an invalid close for ${symbol}`)
     }
-    const current = history.at(-1)!
+    const current = history.at(-1)
+    if (current === undefined) throw new Error(`TSMOM decision has no current close for ${symbol}`)
     const lookbacks = protocol.lookbacks.map((lookbackSessions) => {
       const prior = history[maximumLookback - lookbackSessions]
+      if (prior === undefined) throw new Error(`TSMOM decision has no ${lookbackSessions}-session close for ${symbol}`)
       const value = current / prior - 1
       return {
         lookbackSessions,
@@ -159,7 +166,7 @@ export const makeTsmomDecision = (
     targetWeight: signal.active ? activeWeight : 0,
   }))
   return {
-    schemaVersion: 'bayn.tsmom-decision-plan.v1',
+    schemaVersion: ContractVersion.TsmomDecisionPlan,
     signalDate,
     targetWeights: Object.fromEntries(signals.map((signal) => [signal.symbol, signal.targetWeight])),
     signals,
@@ -197,9 +204,11 @@ export const calculatePerformanceMetrics = (
   if (equity.length < 2 || equity.some((value) => !Number.isFinite(value) || value <= 0)) {
     throw new Error('evaluation produced an invalid equity curve')
   }
+  const endingEquity = equity.at(-1)
+  if (endingEquity === undefined) throw new Error('evaluation produced an empty equity curve')
   const returns = [equity[0] / initialCapital - 1, ...equity.slice(1).map((value, index) => value / equity[index] - 1)]
-  const totalReturn = equity.at(-1)! / initialCapital - 1
-  const annualizedReturn = Math.pow(equity.at(-1)! / initialCapital, TRADING_DAYS / equity.length) - 1
+  const totalReturn = endingEquity / initialCapital - 1
+  const annualizedReturn = Math.pow(endingEquity / initialCapital, TRADING_DAYS / equity.length) - 1
   const volatility = sampleStandardDeviation(returns) * Math.sqrt(TRADING_DAYS)
   const sharpe = volatility === 0 ? 0 : (mean(returns) * TRADING_DAYS) / volatility
   let peak = initialCapital
@@ -221,7 +230,7 @@ export const calculatePerformanceMetrics = (
     totalSpreadCostMicros: '0',
     totalSlippageCostMicros: '0',
     totalCashYieldMicros: '0',
-    endingEquityMicros: toMicros(equity.at(-1)!),
+    endingEquityMicros: toMicros(endingEquity),
   }
 }
 
@@ -242,13 +251,15 @@ const calculateExactPerformanceMetrics = (
     microsToNumber(totalFeesMicros),
     initialCapital,
   )
+  const endingEquity = equityMicros.at(-1)
+  if (endingEquity === undefined) throw new Error('evaluation produced an empty exact equity curve')
   return {
     ...metrics,
     totalFeesMicros: totalFeesMicros.toString(),
     totalSpreadCostMicros: totalSpreadCostMicros.toString(),
     totalSlippageCostMicros: totalSlippageCostMicros.toString(),
     totalCashYieldMicros: totalCashYieldMicros.toString(),
-    endingEquityMicros: equityMicros.at(-1)!.toString(),
+    endingEquityMicros: endingEquity.toString(),
   }
 }
 
@@ -264,7 +275,7 @@ const makeOrder = (
 ): SimulatedOrder => {
   const outcome = makeOrderOutcome({
     identity: {
-      schemaVersion: 'bayn.partial-fill-seed.v1',
+      schemaVersion: ContractVersion.PartialFillSeed,
       signalDate: decision.signalDate,
       executionDate: decision.executionDate,
       symbol,
@@ -676,7 +687,7 @@ const simulate = (
     dailyPerformance,
     simulation: recordEvents
       ? {
-          schemaVersion: 'bayn.simulation-trace.v3',
+          schemaVersion: ContractVersion.SimulationTrace,
           executionModel: protocol.executionModel,
           costMultiplierMicros: costMultiplierMicros.toString(),
           orders,
@@ -764,7 +775,7 @@ const makeTsmomEvaluationIdentity = (
     throw new Error('input manifest hash does not match its content')
   }
   const runId = makeRunIdentity({
-    schemaVersion: 'bayn.run-identity.v1',
+    schemaVersion: ContractVersion.RunIdentity,
     sourceRevision: provenance.sourceRevision,
     image: provenance.image,
     strategy: {
@@ -917,7 +928,7 @@ export const evaluateTsmom = (
   })
 
   return {
-    schemaVersion: 'bayn.evaluation.v4',
+    schemaVersion: ContractVersion.Evaluation,
     runId,
     codeRevision: provenance.sourceRevision,
     protocolHash,
@@ -942,7 +953,7 @@ export const evaluateTsmom = (
 }
 
 export const summarizeEvaluation = (evaluation: EvaluationResult): EvaluationSummary => ({
-  schemaVersion: 'bayn.evaluation-summary.v3',
+  schemaVersion: ContractVersion.EvaluationSummary,
   runId: evaluation.runId,
   evaluationSchemaVersion: evaluation.schemaVersion,
   codeRevision: evaluation.codeRevision,

--- a/services/bayn/src/test-fixtures.ts
+++ b/services/bayn/src/test-fixtures.ts
@@ -3,7 +3,16 @@ import { Effect } from 'effect'
 import { makeRuntimeProvenance, type RuntimeProvenance } from './contracts'
 import { canonicalHashV1 } from './hash'
 import { hashTsmomParameters, loadDefaultProtocol } from './protocol'
-import type { DailyBar, InputManifest, IsoDate, TsmomProtocol } from './types'
+import {
+  DataFeed,
+  DataSource,
+  PriceAdjustment,
+  PublicationSchema,
+  type DailyBar,
+  type InputManifest,
+  type IsoDate,
+  type TsmomProtocol,
+} from './types'
 
 export const fixtureProtocol = Effect.runSync(loadDefaultProtocol)
 
@@ -50,10 +59,10 @@ export const makeBars = (sessionCount = 900): readonly DailyBar[] => {
           low: Math.min(open, close) * 0.997,
           close,
           volume: 1_000_000 + session * 10 + symbolIndex,
-          source: 'alpaca',
-          sourceFeed: 'sip',
-          adjustment: 'all',
-          publicationSchemaVersion: 'signal.adjusted-daily-snapshot.v1',
+          source: DataSource.Alpaca,
+          sourceFeed: DataFeed.Sip,
+          adjustment: PriceAdjustment.All,
+          publicationSchemaVersion: PublicationSchema.AdjustedDailySnapshotV1,
         })
       }
       session += 1
@@ -68,9 +77,12 @@ export const makeSnapshot = (
 ): { readonly bars: readonly DailyBar[]; readonly manifest: InputManifest } => {
   const bars = makeBars(sessionCount)
   const sessionDates = [...new Set(bars.map((bar) => bar.sessionDate))].sort()
-  const firstSession = sessionDates[0]
-  const lastSession = sessionDates.at(-1)!
+  const firstSession = sessionDates.at(0)
+  const lastSession = sessionDates.at(-1)
   const evaluationStart = sessionDates[Math.max(...fixtureProtocol.lookbacks)]
+  if (firstSession === undefined || lastSession === undefined || evaluationStart === undefined) {
+    throw new RangeError('fixture session count must cover the strategy lookback')
+  }
   const material: Omit<InputManifest, 'hash'> = {
     schemaVersion: 'bayn.input-manifest.v2',
     database: 'signal',
@@ -83,10 +95,10 @@ export const makeSnapshot = (
       schemaVersion: 'bayn.finalized-snapshot.v2',
       snapshotId: '1'.repeat(64),
       publicationId: '2'.repeat(64),
-      publicationSchemaVersion: 'signal.adjusted-daily-snapshot.v1',
-      source: 'alpaca',
-      sourceFeed: 'sip',
-      adjustment: 'all',
+      publicationSchemaVersion: PublicationSchema.AdjustedDailySnapshotV1,
+      source: DataSource.Alpaca,
+      sourceFeed: DataFeed.Sip,
+      adjustment: PriceAdjustment.All,
       calendarVersion: 'fixture-calendar-v1',
       publisherSourceRevision: '3'.repeat(40),
       publisherImage: {

--- a/services/bayn/src/types.ts
+++ b/services/bayn/src/types.ts
@@ -2,6 +2,31 @@ import type { EvaluationBounds, FinalizedSnapshotProvenance } from './contracts'
 
 export type IsoDate = `${number}-${number}-${number}`
 
+export enum DataSource {
+  Alpaca = 'alpaca',
+}
+
+export enum DataFeed {
+  Sip = 'sip',
+}
+
+export enum PriceAdjustment {
+  All = 'all',
+}
+
+export enum PublicationSchema {
+  AdjustedDailySnapshotV1 = 'signal.adjusted-daily-snapshot.v1',
+}
+
+export enum ContractVersion {
+  Evaluation = 'bayn.evaluation.v4',
+  EvaluationSummary = 'bayn.evaluation-summary.v3',
+  PartialFillSeed = 'bayn.partial-fill-seed.v1',
+  RunIdentity = 'bayn.run-identity.v1',
+  SimulationTrace = 'bayn.simulation-trace.v3',
+  TsmomDecisionPlan = 'bayn.tsmom-decision-plan.v1',
+}
+
 export interface DailyBar {
   readonly symbol: string
   readonly sessionDate: IsoDate
@@ -10,10 +35,10 @@ export interface DailyBar {
   readonly low: number
   readonly close: number
   readonly volume: number
-  readonly source: string
-  readonly sourceFeed: string
-  readonly adjustment: string
-  readonly publicationSchemaVersion: string
+  readonly source: DataSource
+  readonly sourceFeed: DataFeed
+  readonly adjustment: PriceAdjustment
+  readonly publicationSchemaVersion: PublicationSchema
 }
 
 export interface SymbolCoverage {


### PR DESCRIPTION
## Summary

- Hard-migrate the dedicated Bayn PostgreSQL database from redundant `bayn_*` object names to domain names while preserving rows, foreign keys, constraints, triggers, functions, and migration history.
- Replace manual SQL error-code traversal and unchecked external values with exhaustive Effect SQL reason matching, Effect Schema decoding, and closed provenance enums.
- Remove production non-null assertions, the custom Unicode surrogate scanner, and disabled runtime error reporting; document the CWD-only and Bayn implementation rules.

## Related Issues

[PROOMPT-395](https://linear.app/proompteng/issue/PROOMPT-395/normalize-bayn-database-names-and-effect-sql-error-handling)

## Testing

- `bun run --filter @proompteng/bayn test` — 109 passed, 21 PostgreSQL tests skipped by the unit command, 0 failed.
- `BAYN_TEST_POSTGRES_URL=postgresql://gregkonush@127.0.0.1:5432/bayn_test bun test services/bayn/src/db/evidence-store.integration.test.ts` — 19 passed, including fresh install, deployed-schema hard migration, data preservation, append-only enforcement, rollback, cancellation, and pool disposal.
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- Read-only live check: Bayn Deployment is 1/1 with `maxSurge: 0`; CNPG `bayn-db` is healthy with 2/2 instances; the five deployed migrations and row counts for all eleven legacy tables were captured; the latest scheduled backup is completed.

## Breaking Changes

Migration 6 renames the PostgreSQL tables, migration table, constraints, indexes, triggers, and functions without compatibility views. The previous image cannot query the renamed schema. The current single-replica `maxSurge: 0` rollout prevents mixed-version writers; rollback after migration requires a forward-compatible binary or database restore.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and the section is removed; Breaking Changes is filled in.
- [x] Documentation and operational follow-ups are updated or tracked.