### PR TITLE
fix(bayn): refresh Nix dependency hashes

### DIFF
--- a/nix/images/bayn.nix
+++ b/nix/images/bayn.nix
@@ -24,8 +24,8 @@ import ./bun-workspace-service.nix {
   serviceName = "bayn";
   packageName = "@proompteng/bayn";
   depsHash = {
-    x86_64-linux = "sha256-CeOs78vla5p146UrjZeHkM6vEKYxwEPjVj81e9c8I9g=";
-    aarch64-linux = "sha256-JrQvA54yWRDbChXXtaJfx1foKMOHxYTA0mG9DOLzyj4=";
+    x86_64-linux = "sha256-PIrg1j+HNm1PUD9OHHdPYaVu2xdJ9SohAFxHsxSf9iM=";
+    aarch64-linux = "sha256-PwP+ISp9QUubnxee0JdDntGBpIUquiBXZXNTa29D8O0=";
   };
   installFilters = [
     "@proompteng/bayn"


### PR DESCRIPTION
## Summary

- Refresh the Bayn fixed-output Bun dependency hashes for both Linux architectures.
- Use the exact deterministic outputs reported by failed main build run `29806694123`.
- Unblock the immutable Bayn image build and GitOps promotion for merged PR #12956.

## Related Issues

[PROOMPT-395](https://linear.app/proompteng/issue/PROOMPT-395/normalize-bayn-database-names-and-effect-sql-error-handling)

## Testing

- `nix-instantiate --parse nix/images/bayn.nix`
- `git diff --check`
- Expected CI proof: rebuild `bayn-image` on both `linux/amd64` and `linux/arm64` with the reported fixed-output hashes.

## Breaking Changes

None. This changes only build-time fixed-output hashes and does not change runtime behavior, schema, broker authority, or capital authority.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and the section is removed; Breaking Changes is filled in.
- [x] Documentation and operational follow-ups are updated or tracked.