### PR TITLE
fix(platform): verify kube-router runtime image IDs

### DIFF
--- a/docs/runbooks/kube-router-network-policy-rollout.md
+++ b/docs/runbooks/kube-router-network-policy-rollout.md
@@ -67,8 +67,10 @@ kubectl -n kube-system rollout status daemonset/kube-router --timeout=10m
 The sync hook must print `All existing NetworkPolicy namespaces have a traffic-neutral activation policy.` If it fails,
 the DaemonSet wave is not applied. Update the declared safety coverage through Git and rerun CI; do not bypass the hook.
 
-Verify every desired node has one ready controller, the pinned platform image is running, health is green, and policy
-metrics exist:
+Verify every desired node has one ready controller, the pinned image index or its architecture-specific child manifest
+is running, the process architecture matches the node, health is green, and policy metrics exist. Container runtimes
+may report either the index digest or the selected child manifest as `imageID`, so the check deliberately accepts both
+forms while still rejecting any unpinned digest:
 
 ```bash
 set -euo pipefail
@@ -77,25 +79,46 @@ ready=$(kubectl -n kube-system get daemonset kube-router -o jsonpath='{.status.n
 test "$desired" -gt 0
 test "$ready" = "$desired"
 
-kubectl -n kube-system get pods -l app.kubernetes.io/name=kube-router -o json |
-  jq -e '
-    all(.items[];
-      .status.containerStatuses[0].ready == true and
-      (.status.containerStatuses[0].imageID |
-        endswith("sha256:81619a698b981a5c4fd6c89ae015d0faadce5d7a5270df7562c1743e58e3283f") or
-        endswith("sha256:b8df3247641d5f4e84e14d30b673b6362a0e3d56901218a1e1ee38a40f37afd8")))'
-
-while IFS= read -r pod; do
+kube_router_index_digest=sha256:0991f2cc7aaabe107b51c0c554d6b843f0483fd319b94f437fab638470c47c22
+while IFS=$'\t' read -r pod node pod_ready restart_count image_id; do
+  test "$pod_ready" = true
+  test "$restart_count" = 0
+  node_arch=$(kubectl get node "$node" -o jsonpath='{.status.nodeInfo.architecture}')
+  case "$node_arch" in
+    amd64)
+      platform_digest=sha256:81619a698b981a5c4fd6c89ae015d0faadce5d7a5270df7562c1743e58e3283f
+      expected_runtime_arch=x86_64
+      ;;
+    arm64)
+      platform_digest=sha256:b8df3247641d5f4e84e14d30b673b6362a0e3d56901218a1e1ee38a40f37afd8
+      expected_runtime_arch=aarch64
+      ;;
+    *)
+      echo "unsupported node architecture: $node_arch" >&2
+      exit 1
+      ;;
+  esac
+  case "$image_id" in
+    *"@$kube_router_index_digest"|*"@$platform_digest") ;;
+    *)
+      echo "unexpected kube-router imageID on $pod: $image_id" >&2
+      exit 1
+      ;;
+  esac
+  test "$(kubectl -n kube-system exec "$pod" -c kube-router -- uname -m)" = "$expected_runtime_arch"
   kubectl -n kube-system exec "$pod" -c kube-router -- wget -qO- http://127.0.0.1:20244/healthz
-  kubectl -n kube-system exec "$pod" -c kube-router -- wget -qO- http://127.0.0.1:20241/metrics |
-    grep -Eq '^kube_router_controller_policy_(chains|ipsets) '
-done < <(kubectl -n kube-system get pods -l app.kubernetes.io/name=kube-router -o name)
+  metrics=$(kubectl -n kube-system exec "$pod" -c kube-router -- wget -qO- http://127.0.0.1:20241/metrics)
+  grep -Eq '^kube_router_controller_policy_(chains|ipsets) ' <<< "$metrics"
+done < <(
+  kubectl -n kube-system get pods -l app.kubernetes.io/name=kube-router -o json |
+    jq -r '.items[] | [.metadata.name,.spec.nodeName,.status.containerStatuses[0].ready,.status.containerStatuses[0].restartCount,.status.containerStatuses[0].imageID] | @tsv'
+)
+unset expected_runtime_arch image_id kube_router_index_digest metrics node node_arch platform_digest pod pod_ready restart_count
 
-kubectl -n kube-system logs -l app.kubernetes.io/name=kube-router -c kube-router --prefix --tail=500 |
-  tee /tmp/kube-router-rollout.log
+controller_logs=$(kubectl -n kube-system logs -l app.kubernetes.io/name=kube-router -c kube-router --prefix --tail=500)
 ! grep -Eiq 'panic|fatal|permission denied|operation not permitted|failed to (sync|restore|create)' \
-  /tmp/kube-router-rollout.log
-rm -f /tmp/kube-router-rollout.log
+  <<< "$controller_logs"
+unset controller_logs
 ```
 
 ## 3. Enforcement and regression proof

--- a/docs/runbooks/kube-router-network-policy-rollout.md
+++ b/docs/runbooks/kube-router-network-policy-rollout.md
@@ -80,6 +80,21 @@ test "$desired" -gt 0
 test "$ready" = "$desired"
 
 kube_router_index_digest=sha256:0991f2cc7aaabe107b51c0c554d6b843f0483fd319b94f437fab638470c47c22
+pod_rows=$(
+  kubectl -n kube-system get pods -l app.kubernetes.io/name=kube-router -o json |
+    jq -er '
+      .items as $pods
+      | if ($pods | length) == 0 then error("no kube-router pods found") else $pods[] end
+      | [.metadata.name,.spec.nodeName,.status.containerStatuses[0].ready,.status.containerStatuses[0].restartCount,.status.containerStatuses[0].imageID]
+      | @tsv'
+)
+pod_count=$(awk 'NF { count += 1 } END { print count + 0 }' <<< "$pod_rows")
+if [ "$pod_count" -ne "$desired" ]; then
+  echo "expected $desired kube-router pods, found $pod_count" >&2
+  exit 1
+fi
+
+controller_logs=
 while IFS=$'\t' read -r pod node pod_ready restart_count image_id; do
   test "$pod_ready" = true
   test "$restart_count" = 0
@@ -109,16 +124,12 @@ while IFS=$'\t' read -r pod node pod_ready restart_count image_id; do
   kubectl -n kube-system exec "$pod" -c kube-router -- wget -qO- http://127.0.0.1:20244/healthz
   metrics=$(kubectl -n kube-system exec "$pod" -c kube-router -- wget -qO- http://127.0.0.1:20241/metrics)
   grep -Eq '^kube_router_controller_policy_(chains|ipsets) ' <<< "$metrics"
-done < <(
-  kubectl -n kube-system get pods -l app.kubernetes.io/name=kube-router -o json |
-    jq -r '.items[] | [.metadata.name,.spec.nodeName,.status.containerStatuses[0].ready,.status.containerStatuses[0].restartCount,.status.containerStatuses[0].imageID] | @tsv'
-)
-unset expected_runtime_arch image_id kube_router_index_digest metrics node node_arch platform_digest pod pod_ready restart_count
-
-controller_logs=$(kubectl -n kube-system logs -l app.kubernetes.io/name=kube-router -c kube-router --prefix --tail=500)
+  pod_logs=$(kubectl -n kube-system logs "$pod" -c kube-router --prefix --tail=500)
+  controller_logs+=$'\n'"$pod_logs"
+done <<< "$pod_rows"
 ! grep -Eiq 'panic|fatal|permission denied|operation not permitted|failed to (sync|restore|create)' \
   <<< "$controller_logs"
-unset controller_logs
+unset controller_logs expected_runtime_arch image_id kube_router_index_digest metrics node node_arch platform_digest pod pod_count pod_logs pod_ready pod_rows restart_count
 ```
 
 ## 3. Enforcement and regression proof

--- a/scripts/kube-router/validate-production.test.ts
+++ b/scripts/kube-router/validate-production.test.ts
@@ -156,3 +156,22 @@ test('rejects enforcement testing before controller activation', async () => {
     `${productionPaths.runbook}: coverage, activation, and enforcement proof are out of order`,
   )
 })
+
+test('rejects runtime verification that ignores the reported multi-architecture index digest', async () => {
+  const files = copy(await loadProductionFiles())
+  files.runbook = files.runbook.replace('*"@$kube_router_index_digest"|*"@$platform_digest")', '*"@$platform_digest")')
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.runbook}: missing production invariant "*\\\"@$kube_router_index_digest\\\"|*\\\"@$platform_digest\\\")"`,
+  )
+})
+
+test('rejects a policy metrics probe that can fail from SIGPIPE under pipefail', async () => {
+  const files = copy(await loadProductionFiles())
+  files.runbook = files.runbook.replace(
+    'metrics=$(kubectl -n kube-system exec "$pod" -c kube-router -- wget -qO- http://127.0.0.1:20241/metrics)',
+    'kubectl -n kube-system exec "$pod" -c kube-router -- wget -qO- http://127.0.0.1:20241/metrics |',
+  )
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.runbook}: missing production invariant "metrics=$(kubectl -n kube-system exec \\\"$pod\\\" -c kube-router -- wget -qO- http://127.0.0.1:20241/metrics)"`,
+  )
+})

--- a/scripts/kube-router/validate-production.test.ts
+++ b/scripts/kube-router/validate-production.test.ts
@@ -165,6 +165,14 @@ test('rejects runtime verification that ignores the reported multi-architecture 
   )
 })
 
+test('rejects runtime verification that can accept an empty pod list', async () => {
+  const files = copy(await loadProductionFiles())
+  files.runbook = files.runbook.replace('if [ "$pod_count" -ne "$desired" ]; then', 'if false; then')
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.runbook}: missing production invariant "if [ \\"$pod_count\\" -ne \\"$desired\\" ]; then"`,
+  )
+})
+
 test('rejects a policy metrics probe that can fail from SIGPIPE under pipefail', async () => {
   const files = copy(await loadProductionFiles())
   files.runbook = files.runbook.replace(

--- a/scripts/kube-router/validate-production.ts
+++ b/scripts/kube-router/validate-production.ts
@@ -339,6 +339,8 @@ export function validateProductionContent(files: ProductionFiles): string[] {
   requireTerms(failures, productionPaths.runbook, files.runbook, [
     'kubectl -n kube-system rollout status daemonset/kube-router',
     'kube_router_index_digest=sha256:0991f2cc7aaabe107b51c0c554d6b843f0483fd319b94f437fab638470c47c22',
+    'pod_rows=$(',
+    'if [ "$pod_count" -ne "$desired" ]; then',
     "while IFS=$'\\t' read -r pod node pod_ready restart_count image_id",
     'test "$restart_count" = 0',
     'node_arch=$(kubectl get node "$node" -o jsonpath=\'{.status.nodeInfo.architecture}\')',
@@ -346,6 +348,8 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'test "$(kubectl -n kube-system exec "$pod" -c kube-router -- uname -m)" = "$expected_runtime_arch"',
     'metrics=$(kubectl -n kube-system exec "$pod" -c kube-router -- wget -qO- http://127.0.0.1:20241/metrics)',
     'grep -Eq \'^kube_router_controller_policy_(chains|ipsets) \' <<< "$metrics"',
+    'pod_logs=$(kubectl -n kube-system logs "$pod" -c kube-router --prefix --tail=500)',
+    'done <<< "$pod_rows"',
     'operations/cleanup',
     'kubectl -n kube-system delete daemonset kube-router --wait=true',
     'KUBE-ROUTER-*',

--- a/scripts/kube-router/validate-production.ts
+++ b/scripts/kube-router/validate-production.ts
@@ -338,6 +338,14 @@ export function validateProductionContent(files: ProductionFiles): string[] {
   }
   requireTerms(failures, productionPaths.runbook, files.runbook, [
     'kubectl -n kube-system rollout status daemonset/kube-router',
+    'kube_router_index_digest=sha256:0991f2cc7aaabe107b51c0c554d6b843f0483fd319b94f437fab638470c47c22',
+    "while IFS=$'\\t' read -r pod node pod_ready restart_count image_id",
+    'test "$restart_count" = 0',
+    'node_arch=$(kubectl get node "$node" -o jsonpath=\'{.status.nodeInfo.architecture}\')',
+    '*"@$kube_router_index_digest"|*"@$platform_digest")',
+    'test "$(kubectl -n kube-system exec "$pod" -c kube-router -- uname -m)" = "$expected_runtime_arch"',
+    'metrics=$(kubectl -n kube-system exec "$pod" -c kube-router -- wget -qO- http://127.0.0.1:20241/metrics)',
+    'grep -Eq \'^kube_router_controller_policy_(chains|ipsets) \' <<< "$metrics"',
     'operations/cleanup',
     'kubectl -n kube-system delete daemonset kube-router --wait=true',
     'KUBE-ROUTER-*',


### PR DESCRIPTION
## Summary

- accept either the pinned multi-architecture index digest or the correct architecture-specific child digest reported by the CRI
- verify each running kube-router process architecture matches its node and require zero restarts
- avoid a `pipefail`-induced false failure by capturing metrics before matching them, with regression coverage for both defects

## Related Issues

None

## Testing

- `bun test scripts/kube-router/*.test.ts` (18 passing)
- `bun run scripts/kube-router/validate-production.ts`
- `bunx oxfmt --check scripts/kube-router/validate-production.ts scripts/kube-router/validate-production.test.ts`
- `shellcheck` on the extracted runtime-verification runbook block
- executed the exact runbook block against the live three-node mixed-architecture cluster; all three health checks returned `OK` and image, architecture, restart, metrics, and log gates passed

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
