### PR TITLE
fix(hermes): reconcile rollout state and locks

### DIFF
--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -231,6 +231,16 @@ spec:
                   argocd.argoproj.io/sync-wave: "2"
                 automation: manual
                 enabled: "true"
+                ignoreDifferences:
+                  - group: apps
+                    kind: StatefulSet
+                    namespace: hermes
+                    name: hermes
+                    jqPathExpressions:
+                      - .spec.volumeClaimTemplates[].apiVersion
+                      - .spec.volumeClaimTemplates[].kind
+                      - .spec.volumeClaimTemplates[].spec.volumeMode
+                      - .spec.volumeClaimTemplates[].status
                 managedNamespaceMetadata:
                   labels:
                     external-secrets.proompteng.ai/enabled: "true"

--- a/scripts/hermes/maintenance-lock.sh
+++ b/scripts/hermes/maintenance-lock.sh
@@ -16,7 +16,7 @@ patch_holder() {
   local expected_holder="$1"
   local replacement_holder="$2"
   local now patch
-  now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  now="$(date -u +%Y-%m-%dT%H:%M:%S.000000Z)"
   patch="$(
     jq -cn --arg expected "$expected_holder" --arg replacement "$replacement_holder" --arg now "$now" \
       '[

--- a/scripts/hermes/validate-production.test.ts
+++ b/scripts/hermes/validate-production.test.ts
@@ -336,6 +336,19 @@ test('rejects declaring the globally excluded maintenance Lease as an Argo resou
   )
 })
 
+test('rejects incomplete normalization of StatefulSet PVC template defaults', async () => {
+  const files = await loadProductionFiles()
+  const hermesApplication = files.platform.match(/\n\s+- name: hermes\n[\s\S]*?\n\s+- name: workers\n/)?.[0] ?? ''
+  files.platform = files.platform.replace(
+    hermesApplication,
+    hermesApplication.replace('                      - .spec.volumeClaimTemplates[].status\n', ''),
+  )
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.platform}: missing production invariant "- .spec.volumeClaimTemplates[].status"`,
+  )
+})
+
 test('rejects the invalid namespace name-plus-selector rollout check', async () => {
   const files = await loadProductionFiles()
   files.runbook = files.runbook.replace(

--- a/scripts/hermes/validate-production.test.ts
+++ b/scripts/hermes/validate-production.test.ts
@@ -324,6 +324,18 @@ test('rejects a maintenance lock that cannot bootstrap the Argo-excluded Lease',
   )
 })
 
+test('rejects a Lease renewTime without Kubernetes MicroTime precision', async () => {
+  const files = await loadProductionFiles()
+  files.maintenanceLock = files.maintenanceLock.replace(
+    'date -u +%Y-%m-%dT%H:%M:%S.000000Z',
+    'date -u +%Y-%m-%dT%H:%M:%SZ',
+  )
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.maintenanceLock}: missing production invariant "date -u +%Y-%m-%dT%H:%M:%S.000000Z"`,
+  )
+})
+
 test('rejects declaring the globally excluded maintenance Lease as an Argo resource', async () => {
   const files = await loadProductionFiles()
   files.kustomization = files.kustomization.replace(

--- a/scripts/hermes/validate-production.ts
+++ b/scripts/hermes/validate-production.ts
@@ -368,6 +368,13 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'path: argocd/applications/hermes',
     'namespace: hermes',
     'automation: manual',
+    'group: apps',
+    'kind: StatefulSet',
+    'name: hermes',
+    '- .spec.volumeClaimTemplates[].apiVersion',
+    '- .spec.volumeClaimTemplates[].kind',
+    '- .spec.volumeClaimTemplates[].spec.volumeMode',
+    '- .spec.volumeClaimTemplates[].status',
     'external-secrets.proompteng.ai/enabled: "true"',
     'observability.proompteng.ai/hermes-rollout-enabled: "true"',
     'pod-security.kubernetes.io/enforce: restricted',
@@ -377,6 +384,7 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'group: coordination.k8s.io',
     'kind: Lease',
     'name: hermes-maintenance',
+    '- .spec.volumeClaimTemplates\n',
   ])
 
   requireTerms(failures, productionPaths.runbook, files.runbook, [

--- a/scripts/hermes/validate-production.ts
+++ b/scripts/hermes/validate-production.ts
@@ -356,6 +356,7 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'holderIdentity: ""',
     'leaseDurationSeconds: 14400',
     '    ensure_lease',
+    'date -u +%Y-%m-%dT%H:%M:%S.000000Z',
     '{op: "test", path: "/spec/holderIdentity", value: $expected}',
     '{op: "replace", path: "/spec/holderIdentity", value: $replacement}',
     'patch lease "$lease" --type=json',


### PR DESCRIPTION
## Summary

- ignore only Kubernetes-defaulted fields inside Hermes StatefulSet PVC templates
- preserve drift detection for storage size, class, access mode, retention policy, and all workload fields
- emit the microsecond RFC3339 `Lease.spec.renewTime` required by the Kubernetes API
- add regression validation for every observed defaulted field, broad PVC-template ignores, and invalid Lease timestamps

## Related Issues

None

## Testing

- `bun test scripts/hermes/*.test.ts` (64 passing)
- `shellcheck scripts/hermes/maintenance-lock.sh`
- `bun run scripts/hermes/validate-production.ts`
- `bunx oxfmt --check scripts/hermes/validate-production.ts scripts/hermes/validate-production.test.ts`
- compared the live and rendered Hermes StatefulSet; the only drift is Kubernetes-added `apiVersion`, `kind`, `spec.volumeMode`, and `status` within `volumeClaimTemplates`
- confirmed `argocd app diff hermes` has no semantic workload diff while application status remains stale solely on the StatefulSet
- reproduced the old lock timestamp rejection live while the Lease remained unheld; the corrected lifecycle will be rerun after merge

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
