### PR TITLE
fix(hermes): fail closed on unsafe SQLite backups

### DIFF
--- a/argocd/applications/hermes/README.md
+++ b/argocd/applications/hermes/README.md
@@ -40,6 +40,9 @@ smoke test, manifest change, and normal CI/Codex review.
 - The daily backup CronJob retains the latest 14 verified archives and retries failures independently from the gateway. Its
   first scheduled success and subsequent last-success timestamp are monitored on a 26-hour window without removing a
   healthy API endpoint.
+- The pinned backup process opens SQLite databases in read-only mode, but its data PVC mount is write-capable because WAL
+  readers must create or update shared-memory sidecars. The Pod has no service-account token and the wrapper rejects any
+  SQLite safe-copy fallback, verifies every archived database with `PRAGMA quick_check`, then publishes the SHA-256 sidecar.
 - OpenClaw's VM and PVC remain intact and stopped for at least 14 days after cutover. Do not run `hermes claw cleanup` during
   the rollback window.
 

--- a/argocd/applications/hermes/backup-cronjob.yaml
+++ b/argocd/applications/hermes/backup-cronjob.yaml
@@ -91,7 +91,8 @@ spec:
               volumeMounts:
                 - name: data
                   mountPath: /opt/data
-                  readOnly: true
+                  # SQLite read-only WAL connections still create or update shared-memory sidecars.
+                  readOnly: false
                 - name: backups
                   mountPath: /opt/backups
                 - name: bootstrap
@@ -103,7 +104,7 @@ spec:
             - name: data
               persistentVolumeClaim:
                 claimName: data-hermes-0
-                readOnly: true
+                readOnly: false
             - name: backups
               persistentVolumeClaim:
                 claimName: backups-hermes-0

--- a/argocd/applications/hermes/backup-once.sh
+++ b/argocd/applications/hermes/backup-once.sh
@@ -20,7 +20,50 @@ cleanup() {
 trap cleanup EXIT HUP INT TERM
 
 mkdir -p "$backup_dir" "${HOME:-/tmp/home}"
-/opt/hermes/.venv/bin/hermes backup --output "$pending_archive"
+if backup_output=$(/opt/hermes/.venv/bin/hermes backup --output "$pending_archive" 2>&1); then
+  printf '%s\n' "$backup_output"
+else
+  backup_status=$?
+  printf '%s\n' "$backup_output" >&2
+  exit "$backup_status"
+fi
+case "$backup_output" in
+  *"SQLite safe copy failed"*|*"Raw copy also failed"*|*"Warnings ("*)
+    echo 'Hermes backup reported an unsafe or incomplete database copy' >&2
+    exit 1
+    ;;
+esac
+unset backup_output backup_status
+
+/opt/hermes/.venv/bin/python - "$pending_archive" <<'PY'
+import shutil
+import sqlite3
+import sys
+import tempfile
+import zipfile
+
+archive = sys.argv[1]
+database_count = 0
+with zipfile.ZipFile(archive) as backup:
+    corrupt_entry = backup.testzip()
+    if corrupt_entry is not None:
+        raise RuntimeError(f"corrupt zip entry: {corrupt_entry}")
+    for entry in (candidate for candidate in backup.infolist() if candidate.filename.endswith(".db")):
+        with tempfile.NamedTemporaryFile(dir="/tmp", suffix=".db") as extracted:
+            with backup.open(entry) as source:
+                shutil.copyfileobj(source, extracted)
+            extracted.flush()
+            connection = sqlite3.connect(f"file:{extracted.name}?mode=ro", uri=True)
+            results = [row[0] for row in connection.execute("PRAGMA quick_check")]
+            connection.close()
+            if results != ["ok"]:
+                raise RuntimeError(f"SQLite integrity check failed: {entry.filename}")
+        database_count += 1
+if database_count == 0:
+    raise RuntimeError("backup contains no SQLite databases")
+print(f"Verified {database_count} SQLite database snapshot(s)")
+PY
+
 pending_digest=$(sha256sum "$pending_archive")
 expected_digest=${pending_digest%% *}
 printf '%s  %s\n' "$expected_digest" "$archive_name" >"$pending_checksum"

--- a/docs/runbooks/hermes-production-rollout.md
+++ b/docs/runbooks/hermes-production-rollout.md
@@ -164,9 +164,12 @@ The expected mirrored amd64 manifest digest is
 
    The maintenance Lease must remain held. The CronJob must remain suspended until every prior backup and the one-off Job
    have terminated; `concurrencyPolicy` does not prevent a manually created Job from overlapping the schedule. The one-off
-   Job must complete and its log and checksum verification must succeed. A standalone Job does not update the CronJob's
-   status; `HermesBackupStale` grants a new CronJob 26 hours for its first scheduled success, then monitors its last
-   successful completion. A missing CronJob still alerts, and backup failure never changes the gateway Pod's readiness.
+   Job must complete and its log, archived SQLite integrity checks, and checksum verification must succeed. The data mount
+   is write-capable only because SQLite read-only WAL connections require shared-memory sidecar access; the pinned backup
+   process still opens each source database in read-only mode and fails closed on any safe-copy fallback.
+   A standalone Job does not update the CronJob's status; `HermesBackupStale` grants a new CronJob 26 hours for its first scheduled success,
+   then monitors its last successful completion. A missing CronJob still alerts, and backup failure never changes the
+   gateway Pod's readiness.
 
 2. Port-forward the cluster-local API and keep the key out of command output:
 

--- a/scripts/hermes/validate-production.test.ts
+++ b/scripts/hermes/validate-production.test.ts
@@ -203,6 +203,33 @@ test('rejects publishing a backup archive before its verified checksum', async (
   )
 })
 
+test('rejects a read-only data mount that prevents SQLite WAL-safe backup', async () => {
+  const files = await loadProductionFiles()
+  files.backupCronJob = files.backupCronJob.replaceAll('readOnly: false', 'readOnly: true')
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.backupCronJob}: missing production invariant "claimName: data-hermes-0\\n                readOnly: false"`,
+  )
+})
+
+test('rejects publishing a backup after SQLite falls back to a raw copy', async () => {
+  const files = await loadProductionFiles()
+  files.backupScript = files.backupScript.replace('*"SQLite safe copy failed"*|', '')
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.backupScript}: missing production invariant "*\\\"SQLite safe copy failed\\\"*|*\\\"Raw copy also failed\\\"*|*\\\"Warnings (\\\"*)"`,
+  )
+})
+
+test('rejects a backup without archived SQLite integrity checks', async () => {
+  const files = await loadProductionFiles()
+  files.backupScript = files.backupScript.replace('connection.execute("PRAGMA quick_check")', '[("ok",)]')
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.backupScript}: missing production invariant "connection.execute(\\\"PRAGMA quick_check\\\")"`,
+  )
+})
+
 test('rejects availability alerts that ignore missing metrics', async () => {
   const files = await loadProductionFiles()
   files.mimirRules = files.mimirRules.replace(

--- a/scripts/hermes/validate-production.ts
+++ b/scripts/hermes/validate-production.ts
@@ -128,11 +128,18 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'readOnlyRootFilesystem: true',
     '/opt/bootstrap/backup-once.sh',
     'claimName: data-hermes-0',
+    'mountPath: /opt/data\n                  # SQLite read-only WAL connections still create or update shared-memory sidecars.\n                  readOnly: false',
+    'claimName: data-hermes-0\n                readOnly: false',
     'claimName: backups-hermes-0',
   ])
   forbidTerms(failures, productionPaths.backupCronJob, files.backupCronJob, [':latest', 'restartPolicy: Never'])
 
   const backupPublicationSteps = [
+    'backup_output=$(/opt/hermes/.venv/bin/hermes backup --output "$pending_archive" 2>&1)',
+    '*"SQLite safe copy failed"*|*"Raw copy also failed"*|*"Warnings ("*)',
+    'corrupt_entry = backup.testzip()',
+    'connection.execute("PRAGMA quick_check")',
+    'if database_count == 0:',
     'pending_digest=$(sha256sum "$pending_archive")',
     'printf \'%s  %s\\n\' "$expected_digest" "$pending_archive" | sha256sum -c -',
     'mv -- "$pending_checksum" "$archive.sha256"',


### PR DESCRIPTION
## Summary

- allow the pinned backup process to create SQLite WAL shared-memory sidecars while it still opens source databases in read-only mode
- fail the Job on any SQLite safe-copy fallback or skipped-file warning instead of publishing a misleading successful archive
- verify zip integrity and run `PRAGMA quick_check` on every archived SQLite database before publishing the archive and SHA-256 sidecar

## Related Issues

None

## Testing

- `shellcheck argocd/applications/hermes/backup-once.sh`
- compiled the embedded Python archive-integrity verifier
- `bun test scripts/hermes/*.test.ts` (67 passing)
- `bun run scripts/hermes/validate-production.ts`
- `kustomize build argocd/applications/hermes | kubeconform -strict -summary -ignore-missing-schemas` (13 valid, 1 custom schema skipped)
- reproduced the persistent fallback in the live read-only backup Pod: `source_parent_writable=False`, SQLite `OperationalError: unable to open database file`
- proved the narrow mount change with the same pinned image and Pod policy: `source_parent_writable=True`, `journal_mode=wal`, `source_connect=ok`, and `backup_api=ok`
- independently verified all three databases in the existing archive with `PRAGMA quick_check`; a post-merge clean backup remains the promotion gate

## Breaking Changes

None. The backup Pod gains write access to the data PVC solely for SQLite WAL sidecar handling; it remains non-root, tokenless, capability-free, and pinned by digest.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
