### PR TITLE
fix(froussard): refresh Nix dependency hashes

### DIFF
--- a/nix/images/froussard.nix
+++ b/nix/images/froussard.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "froussard";
   packageName = "froussard";
   depsHash = {
-    x86_64-linux = "sha256-3MVjycp6fxdUgsqUeEJIeXQvOdyRZ8CG/wjAHT6IVlQ=";
-    aarch64-linux = "sha256-oKUEn057bF7SzVEioPrXlVA0r/0L19QLA404VHstt4A=";
+    x86_64-linux = "sha256-Q6BOhqton41StaCJ7xf+xxNl0xTg60kPDWehi39ElFk=";
+    aarch64-linux = "sha256-e0YrfnZItavJzZDl1oFt3RGt9W0SNl52ZNIP7izA2A4=";
   };
   installFilters = [
     "@proompteng/agent-contracts"

--- a/packages/scripts/src/froussard/__tests__/nix-image-contract.test.ts
+++ b/packages/scripts/src/froussard/__tests__/nix-image-contract.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { repoRoot } from '../../shared/cli'
+
+describe('froussard Nix image contract', () => {
+  it('pins the dependency closures observed by both native builders', () => {
+    const image = readFileSync(join(repoRoot, 'nix/images/froussard.nix'), 'utf8')
+
+    expect(image).toContain('x86_64-linux = "sha256-Q6BOhqton41StaCJ7xf+xxNl0xTg60kPDWehi39ElFk="')
+    expect(image).toContain('aarch64-linux = "sha256-e0YrfnZItavJzZDl1oFt3RGt9W0SNl52ZNIP7izA2A4="')
+  })
+})


### PR DESCRIPTION
## Summary

- refresh the Froussard fixed-output dependency hashes from the exact amd64 and arm64 Nix builder results
- add a focused contract that pins both native dependency closures
- preserve the version/commit promotion workflow merged in #12962

## Related Issues

Follow-up required by the real Froussard build run after #12962; completes rollout of the unresolved Codex finding on #12892.

## Testing

- failing real workflow run `29809079394` reported:
  - amd64 expected `sha256-Q6BOhqton41StaCJ7xf+xxNl0xTg60kPDWehi39ElFk=`
  - arm64 expected `sha256-e0YrfnZItavJzZDl1oFt3RGt9W0SNl52ZNIP7izA2A4=`
- Oxfmt passed for the new contract
- Oxlint passed with zero warnings/errors
- `bun test ./packages/scripts/src/froussard/__tests__/nix-image-contract.test.ts ./packages/scripts/src/froussard/__tests__/release-metadata.test.ts ./packages/scripts/src/shared/__tests__/oci.test.ts` (`53 passed`)
- required GitHub CI and both native Nix image builds remain blocking before merge

## Rollout and impact

This changes only the Nix fixed-output dependency closures. After merge, run the real Froussard workflow and require both native image builds, multi-architecture index publication, release-contract promotion, Argo CD convergence, Knative readiness, zero restarts, and live version/commit verification.

Rollback is a narrow revert to the previous hashes only if the corresponding prior dependency closure can still be reproduced.

## Screenshots (if applicable)

N/A

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact builder evidence and focused tests.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Rollout impact, monitoring, and rollback are documented.
