### PR TITLE
fix(bayn): bound migration startup

### DIFF
--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -13,6 +13,7 @@ import {
   DatabaseError,
   EvidenceStore,
   EvidenceStoreRuntimeLive,
+  makeEvidenceStoreRuntimeLayer,
   type EvidenceStoreService,
   type StoredEvaluationEvidence,
 } from './db/evidence-store'
@@ -1034,6 +1035,43 @@ describe('Bayn startup lifecycle', () => {
         body: {
           operational: { status: 'FAILED' },
           error: expect.stringContaining('database.health-check'),
+        },
+      })
+      expect(await fetchJson(port, '/livez')).toMatchObject({ status: 200, body: { live: true } })
+      expect(await fetchJson(port, '/readyz')).toMatchObject({
+        status: 503,
+        body: { ready: false, status: 'FAILED' },
+      })
+    } finally {
+      await Effect.runPromise(Fiber.interrupt(fiber))
+    }
+  })
+
+  test('keeps HTTP live and interrupts a migration that exceeds the operation deadline', async () => {
+    let interrupted = false
+    const port = await unusedPort()
+    const timedOutDatabase = {
+      ...config,
+      port,
+      operationTimeoutMs: 10,
+    }
+    const stalledMigration = Effect.never.pipe(Effect.onInterrupt(() => Effect.sync(() => void (interrupted = true))))
+    const dependencies = Layer.mergeAll(
+      Layer.succeed(MarketData, marketDataService(Effect.succeed(makeSnapshot()))),
+      Layer.succeed(Journal, successfulJournal),
+      makeEvidenceStoreRuntimeLayer(timedOutDatabase, stalledMigration, Effect.succeed(successfulEvidenceStore)),
+      TsmomStrategyLayer(fixtureProtocol, provenance),
+    )
+    const fiber = Effect.runFork(run(timedOutDatabase).pipe(Effect.provide(dependencies)))
+
+    try {
+      const status = await waitForStatus(port, 'FAILED')
+      expect(interrupted).toBe(true)
+      expect(status).toMatchObject({
+        status: 200,
+        body: {
+          operational: { status: 'FAILED' },
+          error: expect.stringContaining('PostgreSQL migration timed out after 10ms'),
         },
       })
       expect(await fetchJson(port, '/livez')).toMatchObject({ status: 200, body: { live: true } })

--- a/services/bayn/src/db/evidence-store.ts
+++ b/services/bayn/src/db/evidence-store.ts
@@ -2041,16 +2041,44 @@ const migrations = migrate.pipe(
   Effect.asVoid,
 )
 
-const MigrationLive = Layer.effectDiscard(migrations)
-const EvidenceStoreLayer = Layer.effect(EvidenceStore, makeEvidenceStore)
-const EvidenceStoreDatabaseLayer = Layer.merge(MigrationLive, EvidenceStoreLayer)
+const withMigrationDeadline = <R>(
+  migration: Effect.Effect<void, DatabaseError, R>,
+  operationTimeoutMs: number,
+): Effect.Effect<void, DatabaseError, R> =>
+  migration.pipe(
+    Effect.timeoutOrElse({
+      duration: operationTimeoutMs,
+      orElse: () =>
+        Effect.fail(
+          databaseError('migration', 'migrate', `PostgreSQL migration timed out after ${operationTimeoutMs}ms`),
+        ),
+    }),
+  )
+
+const EvidenceStoreDatabaseLayer = <RMigration, RStore>(
+  config: Pick<RuntimeConfig, 'operationTimeoutMs'>,
+  migration: Effect.Effect<void, DatabaseError, RMigration>,
+  store: Effect.Effect<EvidenceStoreService, DatabaseError, RStore>,
+) =>
+  Layer.effect(
+    EvidenceStore,
+    Effect.gen(function* () {
+      yield* withMigrationDeadline(migration, config.operationTimeoutMs)
+      return yield* store
+    }),
+  )
 
 export const EvidenceStoreLive = (config: RuntimeConfig) =>
-  EvidenceStoreDatabaseLayer.pipe(Layer.provideMerge(PostgresClientLive(config)))
+  EvidenceStoreDatabaseLayer(config, migrations, makeEvidenceStore).pipe(Layer.provideMerge(PostgresClientLive(config)))
 
-export const EvidenceStoreRuntimeLive = (config: RuntimeConfig) =>
-  EvidenceStoreDatabaseLayer.pipe(
-    Layer.provide(PostgresClientLive(config)),
+export const makeEvidenceStoreRuntimeLayer = <RMigration, RStore>(
+  config: Pick<RuntimeConfig, 'operationTimeoutMs'>,
+  migration: Effect.Effect<void, DatabaseError, RMigration>,
+  store: Effect.Effect<EvidenceStoreService, DatabaseError, RStore>,
+) => recoverEvidenceStoreLayer(EvidenceStoreDatabaseLayer(config, migration, store))
+
+const recoverEvidenceStoreLayer = <R>(layer: Layer.Layer<EvidenceStore, DatabaseError, R>) =>
+  layer.pipe(
     Layer.catch((error) =>
       Layer.succeed(EvidenceStore, {
         check: Effect.fail(error),
@@ -2063,4 +2091,9 @@ export const EvidenceStoreRuntimeLive = (config: RuntimeConfig) =>
         readQualification: () => Effect.fail(error),
       }),
     ),
+  )
+
+export const EvidenceStoreRuntimeLive = (config: RuntimeConfig) =>
+  recoverEvidenceStoreLayer(
+    EvidenceStoreDatabaseLayer(config, migrations, makeEvidenceStore).pipe(Layer.provide(PostgresClientLive(config))),
   )


### PR DESCRIPTION
## Summary

- bound Bayn PostgreSQL migration acquisition with `BAYN_OPERATION_TIMEOUT_MS`
- sequence migration completion before constructing the real EvidenceStore service
- keep PostgreSQL connection/TLS acquisition and migration failures inside the existing fail-closed runtime fallback
- interrupt a stalled migration effect while bringing HTTP live with readiness closed and a typed migration-timeout status
- add a deterministic runtime-layer regression for the timeout path

## Related Issues

Remediates the unresolved Codex finding on #12901.

## Testing

- targeted runtime tests for database setup failure and migration timeout passed
- complete Bayn suite: `110 passed`, `21 integration tests skipped`, `0 failed`
- TypeScript compilation passed
- Oxfmt passed on all 42 source files
- Oxlint passed with zero warnings/errors
- type-aware Oxlint passed with zero warnings/errors
- production bundle built successfully (`474 modules`, `2.23 MB`)
- required GitHub CI and image build remain blocking before merge

## Rollout and impact

The normal healthy startup path is unchanged except that migration acquisition now shares the configured operation deadline. When PostgreSQL connection, TLS setup, or migrations fail or exceed that deadline, Bayn starts its HTTP server with `/livez` open, `/readyz` closed, and the typed database error visible in status instead of hanging before bind.

After merge:

- require the Bayn image build and immutable digest promotion
- verify Argo CD reaches `Synced/Healthy`
- verify the Bayn Deployment is 1/1 Ready on the promoted digest with zero restarts
- verify startup logs show migrations completing normally
- verify `/livez`, `/readyz`, and the Bayn status endpoint

Rollback is a narrow source/image revert; no schema or data rollback is required.

## Screenshots (if applicable)

N/A

## Breaking Changes

A migration that exceeds `BAYN_OPERATION_TIMEOUT_MS` now fails closed instead of waiting indefinitely.

## Checklist

- [x] Testing section documents exact validation.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Rollout impact, monitoring, and rollback are documented.
