### PR TITLE
chore(froussard): promote nix image sha-6b02655e7355673c6648dc83ba30e166605e6196

### DIFF
--- a/argocd/applications/froussard/knative-service.yaml
+++ b/argocd/applications/froussard/knative-service.yaml
@@ -24,7 +24,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: app
-          image: registry.ide-newton.ts.net/lab/froussard@sha256:eb327d3e089480a75ca3276f60d650cc767c5d7a43221ea27ddaeadbf522add6
+          image: registry.ide-newton.ts.net/lab/froussard@sha256:9d0df32aee2a490a8b101bce3fa632e291152f418dc50bb8dd250726ba103a2c
           imagePullPolicy: Always
           ports:
             - containerPort: 8080
@@ -73,9 +73,9 @@ spec:
             - name: OTEL_SERVICE_NAMESPACE
               value: froussard
             - name: FROUSSARD_VERSION
-              value: v0.596.0-2330-g4000b49f4
+              value: v0.596.0-2373-g6b02655e7
             - name: FROUSSARD_COMMIT
-              value: 4000b49f4435a9b8b27a6cc2b368258ace30e4e7
+              value: 6b02655e7355673c6648dc83ba30e166605e6196
             - name: LGTM_TEMPO_TRACES_ENDPOINT
               value: http://observability-tempo-gateway.observability.svc.cluster.local:4317
             - name: LGTM_MIMIR_METRICS_ENDPOINT


### PR DESCRIPTION
## Summary

- Promote `froussard` to `registry.ide-newton.ts.net/lab/froussard@sha256:9d0df32aee2a490a8b101bce3fa632e291152f418dc50bb8dd250726ba103a2c`.
- Source commit: `6b02655e7355673c6648dc83ba30e166605e6196`.
- Source version: `v0.596.0-2373-g6b02655e7`.
- Built by the shared Nix OCI workflow without Docker Buildx.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/froussard@sha256:9d0df32aee2a490a8b101bce3fa632e291152f418dc50bb8dd250726ba103a2c" linux/amd64 linux/arm64`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.