### PR TITLE
fix(hermes): fail closed on migration conflicts

### DIFF
--- a/argocd/applications/hermes/operations/migration-apply-job.yaml
+++ b/argocd/applications/hermes/operations/migration-apply-job.yaml
@@ -35,19 +35,91 @@ spec:
           image: registry.ide-newton.ts.net/lab/hermes-agent@sha256:3db34ce19adfa080736a2a3feb0316dbcccc588faa9afe7fd8ae1c03b4f1a53a
           imagePullPolicy: IfNotPresent
           command:
-            - /opt/hermes/.venv/bin/hermes
+            - /bin/sh
+            - -ec
           args:
-            - claw
-            - migrate
-            - --source
-            - /opt/data/migration/openclaw
-            - --preset
-            - user-data
-            - --workspace-target
-            - /opt/data/workspace/tuslagch
-            - --skill-conflict
-            - skip
-            - --yes
+            - |
+              operator_files='/opt/data/SOUL.md /opt/data/IDENTITY.md /opt/data/TOOLS.md /opt/data/HEARTBEAT.md /opt/data/workspace/tuslagch/AGENTS.md'
+              operator_digests_before=$(sha256sum $operator_files)
+              migration_started_at=$(date +%s)
+              if migration_output=$(
+                /opt/hermes/.venv/bin/hermes claw migrate \
+                  --source /opt/data/migration/source \
+                  --preset user-data \
+                  --workspace-target /opt/data/workspace/tuslagch \
+                  --skill-conflict skip \
+                  --yes 2>&1
+              ); then
+                :
+              else
+                migration_status=$?
+                printf '%s\n' "$migration_output" >&2
+                exit "$migration_status"
+              fi
+              printf '%s\n' "$migration_output"
+              case "$migration_output" in
+                *"Refusing to apply"*|*"Migration failed"*|*"Migration preview failed"*|*"OpenClaw directory not found"*)
+                  echo 'migration command reported a refusal or failure' >&2
+                  exit 1
+                  ;;
+              esac
+              operator_digests_after=$(sha256sum $operator_files)
+              test "$operator_digests_after" = "$operator_digests_before"
+              /opt/hermes/.venv/bin/python - "$migration_started_at" <<'PY'
+              import json
+              import pathlib
+              import sys
+
+              started_at = int(sys.argv[1])
+              report_root = pathlib.Path('/opt/data/migration/openclaw')
+              reports = [
+                  path
+                  for path in report_root.glob('*/report.json')
+                  if path.stat().st_mtime >= started_at - 1
+              ]
+              if len(reports) != 1:
+                  raise RuntimeError(f'expected one current migration report, found {len(reports)}')
+              report_path = reports[0]
+              report = json.loads(report_path.read_text())
+              summary = report.get('summary', {})
+              if report.get('mode') != 'execute':
+                  raise RuntimeError('migration report is not an execute report')
+              if report.get('source_root') != '/opt/data/migration/source':
+                  raise RuntimeError('migration report source does not match the audited staging tree')
+              if report.get('migrate_secrets') is not False:
+                  raise RuntimeError('migration report does not prove that secrets were excluded')
+              if summary.get('conflict', 0) != 0 or summary.get('error', 0) != 0:
+                  raise RuntimeError('migration report contains conflicts or errors')
+
+              items = {item.get('kind'): item for item in report.get('items', [])}
+              for kind in ('user-profile', 'daily-memory'):
+                  item = items.get(kind)
+                  if item is None or item.get('status') not in {'migrated', 'skipped'}:
+                      raise RuntimeError(f'migration report lacks a resolved {kind} item')
+                  if item.get('reason') in {'Source file not found', 'No workspace/memory/ directory found'}:
+                      raise RuntimeError(f'migration report did not consume the audited {kind} source')
+              for kind in ('soul', 'workspace-agents'):
+                  item = items.get(kind)
+                  if item is None or item.get('status') != 'skipped':
+                      raise RuntimeError(f'GitOps-owned item was not skipped: {kind}')
+
+              backups = [
+                  path
+                  for path in pathlib.Path('/opt/data/backups').glob('pre-migration-*.zip')
+                  if path.stat().st_mtime >= started_at - 1
+              ]
+              if not backups:
+                  raise RuntimeError('migration did not create a current restore-point archive')
+              backup_path = max(backups, key=lambda path: path.stat().st_mtime)
+              print(
+                  'migration_report_verified=true '
+                  f'conflicts=0 errors=0 migrated={summary.get("migrated", 0)} '
+                  f'skipped={summary.get("skipped", 0)} '
+                  f'report={report_path.parent.name}/report.json '
+                  f'restore_point={backup_path.name}'
+              )
+              PY
+              printf '%s\n' 'operator_owned_identity_unchanged=true secrets=false'
           env:
             - name: HERMES_HOME
               value: /opt/data

--- a/argocd/applications/hermes/operations/migration-dry-run-job.yaml
+++ b/argocd/applications/hermes/operations/migration-dry-run-job.yaml
@@ -35,19 +35,44 @@ spec:
           image: registry.ide-newton.ts.net/lab/hermes-agent@sha256:3db34ce19adfa080736a2a3feb0316dbcccc588faa9afe7fd8ae1c03b4f1a53a
           imagePullPolicy: IfNotPresent
           command:
-            - /opt/hermes/.venv/bin/hermes
+            - /bin/sh
+            - -ec
           args:
-            - claw
-            - migrate
-            - --source
-            - /opt/data/migration/openclaw
-            - --preset
-            - user-data
-            - --workspace-target
-            - /opt/data/workspace/tuslagch
-            - --skill-conflict
-            - skip
-            - --dry-run
+            - |
+              if migration_output=$(
+                /opt/hermes/.venv/bin/hermes claw migrate \
+                  --source /opt/data/migration/source \
+                  --preset user-data \
+                  --workspace-target /opt/data/workspace/tuslagch \
+                  --skill-conflict skip \
+                  --dry-run 2>&1
+              ); then
+                :
+              else
+                migration_status=$?
+                printf '%s\n' "$migration_output" >&2
+                exit "$migration_status"
+              fi
+              printf '%s\n' "$migration_output"
+              case "$migration_output" in
+                *"Secrets:     no"*) ;;
+                *) echo 'migration preview did not prove that secret migration is disabled' >&2; exit 1 ;;
+              esac
+              case "$migration_output" in
+                *"Conflicts ("*|*" conflict(s)"*|*"Refusing to apply"*|*"Migration preview failed"*|*"OpenClaw directory not found"*)
+                  echo 'migration preview contains a conflict or refusal' >&2
+                  exit 1
+                  ;;
+              esac
+              case "$migration_output" in
+                *"user-profile"*) ;;
+                *) echo 'migration preview is missing the audited user profile' >&2; exit 1 ;;
+              esac
+              case "$migration_output" in
+                *"daily-memory"*) ;;
+                *) echo 'migration preview is missing the audited daily memory' >&2; exit 1 ;;
+              esac
+              printf '%s\n' 'migration_preview_verified=true conflicts=0 secrets=false'
           env:
             - name: HERMES_HOME
               value: /opt/data

--- a/docs/runbooks/hermes-production-rollout.md
+++ b/docs/runbooks/hermes-production-rollout.md
@@ -214,7 +214,7 @@ The expected mirrored amd64 manifest digest is
      exit 1
    fi
    kubectl -n hermes exec hermes-0 -c hermes -- /opt/hermes/.venv/bin/python -c \
-     'import urllib.request; urllib.request.urlopen("https://discord.com/robots.txt", timeout=10).read(1)'
+     'import urllib.request; request=urllib.request.Request("https://discord.com/api/v10/gateway", headers={"User-Agent":"DiscordBot (https://proompteng.ai, 1.0)"}); response=urllib.request.urlopen(request, timeout=10); assert response.status == 200; response.read(1)'
    kubectl -n hermes exec hermes-0 -c hermes -- /bin/sh -c \
      '! /opt/hermes/.venv/bin/python -c '\''import urllib.request; urllib.request.urlopen("https://example.com", timeout=5)'\'''
    ```
@@ -306,8 +306,9 @@ unset stale_maintenance_holder
 
 ## Phase 2: non-secret user-data migration
 
-1. Build a sanitized source archive from the OpenClaw workspace. Only the listed identity and memory paths are exported;
-   `.openclaw/openclaw.json`, credentials, tokens, sessions, and logs never enter the archive:
+1. Build a sanitized source archive from the OpenClaw workspace. Only the user profile, memory, and optional skills are
+   exported; `.openclaw/openclaw.json`, credentials, tokens, sessions, logs, and operator-managed identity/policy files
+   never enter the archive. `AGENTS.md`, `SOUL.md`, `IDENTITY.md`, `TOOLS.md`, and `HEARTBEAT.md` remain GitOps-owned:
 
    ```bash
    set -euo pipefail
@@ -317,8 +318,8 @@ unset stale_maintenance_holder
      set -o pipefail
      virtctl ssh -n openclaw --username ubuntu --identity-file /Users/gregkonush/.ssh/id_ed25519 \
        --local-ssh-opts='-o IdentityAgent=none' --local-ssh-opts='-o IdentitiesOnly=yes' \
-       --command='set -eu; cd /home/ubuntu/github.com/lab/services/tuslagch; for path in AGENTS.md SOUL.md IDENTITY.md USER.md TOOLS.md HEARTBEAT.md memory; do test -r "$path"; done; set -- AGENTS.md SOUL.md IDENTITY.md USER.md TOOLS.md HEARTBEAT.md memory; for path in MEMORY.md skills; do if test -e "$path" || test -L "$path"; then test -r "$path"; set -- "$@" "$path"; fi; done; tar -czf - "$@"' \
-       vm/openclaw | tar -xzf - -C "$hermes_stage_dir/openclaw/workspace"
+       --command='set -eu; cd /home/ubuntu/github.com/lab/services/tuslagch; for path in USER.md memory; do test -r "$path"; done; set -- USER.md memory; for path in MEMORY.md skills; do if test -e "$path" || test -L "$path"; then test -r "$path"; set -- "$@" "$path"; fi; done; tar -czf - "$@"' \
+       vm/openclaw </dev/null | tar -xzf - -C "$hermes_stage_dir/openclaw/workspace"
    ); then
      rm -rf -- "$hermes_stage_dir"
      unset hermes_stage_dir
@@ -336,9 +337,9 @@ unset stale_maintenance_holder
    symlinks, non-text content, credential-like or opaque high-entropy values, and bounded-size violations without printing
    detected values. An audit failure blocks migration: inspect the reported file privately, redact or remove only the
    flagged material in `$hermes_stage_dir`, and rerun the unchanged auditor. Never weaken or bypass the patterns. Also review
-   the file-name-only inventory and stop if it contains config, credential, token, session, or log files. The six identity
-   files and `memory/` are required; `MEMORY.md` and `skills/` are included only when present, and any unreadable selected
-   path or descendant fails the pipe.
+   the file-name-only inventory and stop if it contains config, credential, token, session, log, or operator-managed
+   identity/policy files. `USER.md` and `memory/` are required; `MEMORY.md` and `skills/` are included only when present,
+   and any unreadable selected path or descendant fails the pipe.
 
 2. In one dedicated private Bash process, acquire the maintenance Lease for the entire staging, dry-run, and apply
    transaction. Keep this same shell open through step 5. Suspend new backups and wait up to 65 minutes for every active
@@ -366,8 +367,8 @@ unset stale_maintenance_holder
    done
    unset backup_wait_deadline
    kubectl -n hermes exec hermes-0 -c hermes -- sh -c \
-     'rm -rf -- /opt/data/migration/openclaw && mkdir -p /opt/data/migration/openclaw'
-   kubectl -n hermes cp "$hermes_stage_dir/openclaw/." hermes-0:/opt/data/migration/openclaw -c hermes
+     'rm -rf -- /opt/data/migration/source && mkdir -p /opt/data/migration/source'
+   kubectl -n hermes cp "$hermes_stage_dir/openclaw/." hermes-0:/opt/data/migration/source -c hermes
    rm -rf -- "$hermes_stage_dir"
    unset hermes_stage_dir
    kubectl -n hermes scale statefulset/hermes --replicas=0
@@ -388,8 +389,8 @@ unset stale_maintenance_holder
    ```
 
 3. In the same shell, assert continued Lease ownership, run the merged dry-run Job, and review its complete log. It must
-   contain no secret migration and no unresolved conflict. Exit the shell to release the Lease if the preview is not
-   accepted:
+   contain `migration_preview_verified=true conflicts=0 secrets=false`, no secret migration, and no unresolved conflict.
+   Exit the shell to release the Lease if the preview is not accepted:
 
    ```bash
    set -euo pipefail
@@ -404,10 +405,14 @@ unset stale_maintenance_holder
      exit 1
    fi
    kubectl -n hermes logs "$dry_run_job"
+   kubectl -n hermes logs "$dry_run_job" | grep -Fqx \
+     'migration_preview_verified=true conflicts=0 secrets=false'
    ```
 
 4. If the preview is correct, use the same shell and Lease to run the apply Job. Preserve its Job name, log, report summary,
-   and generated restore-point archive as migration evidence. Keep the Lease held for the final resync:
+   and generated restore-point archive as migration evidence. The Job verifies its current JSON report, zero
+   conflicts/errors, excluded secrets, untouched GitOps-owned identity files, and a current restore point before it can
+   complete. Keep the Lease held for the final resync:
 
    ```bash
    set -euo pipefail
@@ -422,6 +427,10 @@ unset stale_maintenance_holder
      exit 1
    fi
    kubectl -n hermes logs "$migration_job"
+   kubectl -n hermes logs "$migration_job" | grep -Fq \
+     'migration_report_verified=true conflicts=0 errors=0'
+   kubectl -n hermes logs "$migration_job" | grep -Fqx \
+     'operator_owned_identity_unchanged=true secrets=false'
    ```
 
 5. In the same shell, restore desired replicas through Argo, verify backups are enabled, then release the Lease. Repeat the

--- a/scripts/hermes/audit-migration-source.test.ts
+++ b/scripts/hermes/audit-migration-source.test.ts
@@ -12,9 +12,7 @@ async function makeFixture(): Promise<string> {
   temporaryRoots.push(root)
   await mkdir(join(root, 'workspace', 'memory'), { recursive: true })
   await mkdir(join(root, 'workspace', 'skills'), { recursive: true })
-  for (const name of ['AGENTS.md', 'HEARTBEAT.md', 'IDENTITY.md', 'SOUL.md', 'TOOLS.md', 'USER.md']) {
-    await writeFile(join(root, 'workspace', name), `Safe ${name} content.\n`)
-  }
+  await writeFile(join(root, 'workspace', 'USER.md'), 'Safe user profile content.\n')
   await writeFile(join(root, 'workspace', 'MEMORY.md'), 'Safe memory note. API tokens are never stored here.\n')
   return root
 }
@@ -40,18 +38,28 @@ describe('OpenClaw migration source audit', () => {
     await writeFile(join(root, 'workspace', 'skills', 'example.md'), 'A safe skill with no credentials.\n')
 
     const result = await auditMigrationSource(root)
-    expect(result.files).toBe(8)
+    expect(result.files).toBe(3)
     expect(result.totalBytes).toBeGreaterThan(0)
     expect(result.issues).toEqual([])
   })
 
-  test('rejects a missing required identity path', async () => {
+  test('rejects a missing required user profile', async () => {
     const root = await makeFixture()
-    await rm(join(root, 'workspace', 'IDENTITY.md'))
+    await rm(join(root, 'workspace', 'USER.md'))
 
     expect((await auditMigrationSource(root)).issues).toContainEqual({
-      path: 'workspace/IDENTITY.md',
+      path: 'workspace/USER.md',
       reason: 'required migration path is missing',
+    })
+  })
+
+  test('rejects GitOps-owned identity and policy files', async () => {
+    const root = await makeFixture()
+    await writeFile(join(root, 'workspace', 'AGENTS.md'), 'Unsafe source policy.\n')
+
+    expect((await auditMigrationSource(root)).issues).toContainEqual({
+      path: 'workspace/AGENTS.md',
+      reason: 'path is outside the approved user-data allowlist',
     })
   })
 

--- a/scripts/hermes/audit-migration-source.ts
+++ b/scripts/hermes/audit-migration-source.ts
@@ -5,25 +5,11 @@ const maxFiles = 5_000
 const maxFileBytes = 5 * 1024 * 1024
 const maxTotalBytes = 100 * 1024 * 1024
 
-const allowedWorkspaceFiles = new Set([
-  'AGENTS.md',
-  'HEARTBEAT.md',
-  'IDENTITY.md',
-  'MEMORY.md',
-  'SOUL.md',
-  'TOOLS.md',
-  'USER.md',
-])
+// Hermes identity and operating-policy files are owned by GitOps. Only user
+// profile and memory content may cross the OpenClaw migration boundary.
+const allowedWorkspaceFiles = new Set(['MEMORY.md', 'USER.md'])
 const allowedWorkspaceDirectories = new Set(['memory', 'skills'])
-const requiredMigrationPaths = new Set([
-  'workspace/AGENTS.md',
-  'workspace/HEARTBEAT.md',
-  'workspace/IDENTITY.md',
-  'workspace/SOUL.md',
-  'workspace/TOOLS.md',
-  'workspace/USER.md',
-  'workspace/memory',
-])
+const requiredMigrationPaths = new Set(['workspace/USER.md', 'workspace/memory'])
 const forbiddenPathComponents = new Set([
   '.aws',
   '.env',

--- a/scripts/hermes/validate-production.test.ts
+++ b/scripts/hermes/validate-production.test.ts
@@ -137,8 +137,8 @@ test('rejects automatic Argo reconciliation during the staged migration', async 
 test('rejects secret migration in the apply Job', async () => {
   const files = await loadProductionFiles()
   files.migrationApply = files.migrationApply.replace(
-    '            - --yes',
-    '            - --migrate-secrets\n            - --yes',
+    '                  --yes 2>&1',
+    '                  --migrate-secrets \\\n                  --yes 2>&1',
   )
 
   expect(validateProductionContent(files)).toContain(
@@ -517,19 +517,19 @@ test('rejects a containment check that aborts on expected direct-egress denial',
 test('rejects migration staging that overlays a previous source tree', async () => {
   const files = await loadProductionFiles()
   files.runbook = files.runbook.replace(
-    "'rm -rf -- /opt/data/migration/openclaw && mkdir -p /opt/data/migration/openclaw'",
-    "'mkdir -p /opt/data/migration/openclaw'",
+    "'rm -rf -- /opt/data/migration/source && mkdir -p /opt/data/migration/source'",
+    "'mkdir -p /opt/data/migration/source'",
   )
 
   expect(validateProductionContent(files)).toContain(
-    `${productionPaths.runbook}: missing production invariant "'rm -rf -- /opt/data/migration/openclaw && mkdir -p /opt/data/migration/openclaw'"`,
+    `${productionPaths.runbook}: missing production invariant "'rm -rf -- /opt/data/migration/source && mkdir -p /opt/data/migration/source'"`,
   )
 })
 
 test('rejects migration staging that races an active backup', async () => {
   const files = await loadProductionFiles()
   const stagingCommand =
-    "   kubectl -n hermes exec hermes-0 -c hermes -- sh -c \\\n     'rm -rf -- /opt/data/migration/openclaw && mkdir -p /opt/data/migration/openclaw'\n"
+    "   kubectl -n hermes exec hermes-0 -c hermes -- sh -c \\\n     'rm -rf -- /opt/data/migration/source && mkdir -p /opt/data/migration/source'\n"
   files.runbook = files.runbook.replace(stagingCommand, '')
   const phaseTwoStart = files.runbook.indexOf('## Phase 2:')
   const phaseTwo = files.runbook
@@ -542,6 +542,30 @@ test('rejects migration staging that races an active backup', async () => {
 
   expect(validateProductionContent(files)).toContain(
     `${productionPaths.runbook}: migration must quiesce backups before replacing the staging tree`,
+  )
+})
+
+test('rejects staging GitOps-owned identity or policy files', async () => {
+  const files = await loadProductionFiles()
+  files.runbook = files.runbook.replace(
+    'for path in USER.md memory; do test -r "$path"; done',
+    'for path in AGENTS.md USER.md memory; do test -r "$path"; done',
+  )
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.runbook}: missing production invariant "for path in USER.md memory; do test -r \\"$path\\"; done"`,
+  )
+})
+
+test('rejects an apply Job that trusts the migration command exit code alone', async () => {
+  const files = await loadProductionFiles()
+  files.migrationApply = files.migrationApply.replace(
+    'migration_report_verified=true',
+    'migration_command_finished=true',
+  )
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.migrationApply}: missing production invariant "migration_report_verified=true"`,
   )
 })
 

--- a/scripts/hermes/validate-production.ts
+++ b/scripts/hermes/validate-production.ts
@@ -247,10 +247,33 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'activeDeadlineSeconds: 3900',
   ])
   forbidTerms(failures, productionPaths.restoreStage, files.restoreStage, ['kind: Secret', ':latest'])
-  requireTerms(failures, productionPaths.migrationDryRun, files.migrationDryRun, ['--preset', 'user-data', '--dry-run'])
-  requireTerms(failures, productionPaths.migrationApply, files.migrationApply, ['--preset', 'user-data', '--yes'])
+  requireTerms(failures, productionPaths.migrationDryRun, files.migrationDryRun, [
+    '--source /opt/data/migration/source',
+    '--preset user-data',
+    '--dry-run',
+    'migration preview contains a conflict or refusal',
+    'migration_preview_verified=true conflicts=0 secrets=false',
+  ])
+  requireTerms(failures, productionPaths.migrationApply, files.migrationApply, [
+    '--source /opt/data/migration/source',
+    '--preset user-data',
+    '--yes',
+    'operator_digests_before=$(sha256sum $operator_files)',
+    "report.get('source_root') != '/opt/data/migration/source'",
+    "report.get('migrate_secrets') is not False",
+    "summary.get('conflict', 0) != 0 or summary.get('error', 0) != 0",
+    "for kind in ('user-profile', 'daily-memory'):",
+    "for kind in ('soul', 'workspace-agents'):",
+    "pathlib.Path('/opt/data/backups').glob('pre-migration-*.zip')",
+    'migration_report_verified=true',
+    'operator_owned_identity_unchanged=true secrets=false',
+  ])
+  forbidTerms(failures, productionPaths.migrationDryRun, files.migrationDryRun, ['--overwrite'])
+  forbidTerms(failures, productionPaths.migrationApply, files.migrationApply, ['--overwrite'])
   requireTerms(failures, productionPaths.migrationAudit, files.migrationAudit, [
+    "allowedWorkspaceFiles = new Set(['MEMORY.md', 'USER.md'])",
     "allowedWorkspaceDirectories = new Set(['memory', 'skills'])",
+    "requiredMigrationPaths = new Set(['workspace/USER.md', 'workspace/memory'])",
     'source root must be a real directory',
     'source contains no approved files',
     'requiredMigrationPaths',
@@ -415,6 +438,7 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'OpenClaw VM/PVC identities',
     'single-writer Discord message lifecycle IDs',
     'bun run scripts/hermes/audit-migration-source.ts "$hermes_stage_dir/openclaw"',
+    '`AGENTS.md`, `SOUL.md`, `IDENTITY.md`, `TOOLS.md`, and `HEARTBEAT.md` remain GitOps-owned',
     'An audit failure blocks migration:',
     'redact or remove only the',
     'flagged material in `$hermes_stage_dir`',
@@ -423,11 +447,15 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'kubectl -n hermes delete "$dry_run_job" --wait=true',
     'kubectl -n hermes delete "$migration_job" --wait=true',
     'kubectl -n hermes delete "$restore_job" --wait=true',
-    'for path in AGENTS.md SOUL.md IDENTITY.md USER.md TOOLS.md HEARTBEAT.md memory; do test -r "$path"; done',
+    'for path in USER.md memory; do test -r "$path"; done',
+    'vm/openclaw </dev/null | tar -xzf -',
+    'migration_preview_verified=true conflicts=0 secrets=false',
+    'migration_report_verified=true conflicts=0 errors=0',
+    'operator_owned_identity_unchanged=true secrets=false',
     'The CronJob must remain suspended until every prior backup',
     'if kubectl -n hermes exec hermes-0 -c hermes -- /opt/hermes/.venv/bin/python -c',
     'direct public egress unexpectedly succeeded',
-    "'rm -rf -- /opt/data/migration/openclaw && mkdir -p /opt/data/migration/openclaw'",
+    "'rm -rf -- /opt/data/migration/source && mkdir -p /opt/data/migration/source'",
     "find /opt/backups -maxdepth 1 -type f -name 'hermes-backup-*.zip' -print",
     'test "$sidecar_archive" = "$archive_name"',
     'test "$sidecar_archive" = "$archive"',
@@ -479,6 +507,9 @@ export function validateProductionContent(files: ProductionFiles): string[] {
   forbidTerms(failures, productionPaths.runbook, files.runbook, [
     '--ignore-failed-read',
     'kubectl -n hermes exec hermes-0 -c hermes -- mkdir -p /opt/data/migration/openclaw',
+    'for path in AGENTS.md SOUL.md IDENTITY.md USER.md TOOLS.md HEARTBEAT.md memory',
+    "'rm -rf -- /opt/data/migration/openclaw && mkdir -p /opt/data/migration/openclaw'",
+    'vm/openclaw | tar -xzf -',
     'kubectl -n hermes exec hermes-restore-stage -c stage -- ls -1 /opt/backups/hermes-backup-*.zip',
   ])
   const suspendBackupCommand =
@@ -493,7 +524,7 @@ export function validateProductionContent(files: ProductionFiles): string[] {
   }
   const migrationSection = files.runbook.match(/## Phase 2:[\s\S]*?## Phase 3:/)?.[0] ?? ''
   if (
-    migrationSection.indexOf(suspendBackupCommand) > migrationSection.indexOf('rm -rf -- /opt/data/migration/openclaw')
+    migrationSection.indexOf(suspendBackupCommand) > migrationSection.indexOf('rm -rf -- /opt/data/migration/source')
   ) {
     failures.push(`${productionPaths.runbook}: migration must quiesce backups before replacing the staging tree`)
   }


### PR DESCRIPTION
## Summary

- keep GitOps-owned Hermes identity and policy files outside the OpenClaw migration boundary
- use a neutral audited source path so the migration process does not identify itself as OpenClaw
- fail dry runs on conflicts/refusals and require an execute report with zero conflicts/errors, excluded secrets, unchanged operator files, and a current restore point
- update the production runbook and regression validators for the live failure modes

## Related Issues

None

## Testing

- `bun test scripts/hermes/*.test.ts` — 70 passing tests
- `bun run scripts/hermes/validate-production.ts`
- `bunx oxfmt --check scripts/hermes/audit-migration-source.ts scripts/hermes/audit-migration-source.test.ts scripts/hermes/validate-production.ts scripts/hermes/validate-production.test.ts`
- `sh -n` on both rendered migration container scripts
- Python compile check on the embedded migration report verifier
- `kubeconform -strict -summary` on both operation Jobs
- `kustomize build argocd/applications/hermes | kubeconform -strict -summary -ignore-missing-schemas`

## Breaking Changes

None. The migration must be retried from merged `main`; the prior failed run applied no data.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
