### PR TITLE
fix(hermes): use production config for migration

### DIFF
--- a/argocd/applications/hermes/README.md
+++ b/argocd/applications/hermes/README.md
@@ -37,6 +37,8 @@ smoke test, manifest change, and normal CI/Codex review.
 - `data-hermes-0`: 50 Gi RBD PVC for Hermes state, sessions, memories, skills, and workspace.
 - `backups-hermes-0`: 100 Gi RBD PVC for daily WAL-safe Hermes backup archives and SHA-256 sidecars.
 - StatefulSet PVC retention is `Retain` on delete and scale-down.
+- Migration Jobs mount the stable, read-only `hermes-operation-config` generated from the same production `config.yaml` as
+  the gateway, so previews, memory limits, reports, and restore points use production settings rather than Hermes defaults.
 - The daily backup CronJob retains the latest 14 verified archives and retries failures independently from the gateway. Its
   first scheduled success and subsequent last-success timestamp are monitored on a 26-hour window without removing a
   healthy API endpoint.

--- a/argocd/applications/hermes/kustomization.yaml
+++ b/argocd/applications/hermes/kustomization.yaml
@@ -7,6 +7,11 @@ configMapGenerator:
   - name: hermes-config
     files:
       - config.yaml
+  - name: hermes-operation-config
+    files:
+      - config.yaml
+    options:
+      disableNameSuffixHash: true
   - name: hermes-bootstrap
     files:
       - bootstrap.sh

--- a/argocd/applications/hermes/operations/migration-apply-job.yaml
+++ b/argocd/applications/hermes/operations/migration-apply-job.yaml
@@ -62,7 +62,7 @@ spec:
                 *) echo 'migration apply did not prove that secret migration is disabled' >&2; exit 1 ;;
               esac
               case "$migration_output" in
-                *"Refusing to apply"*|*"Migration failed"*|*"Migration preview failed"*|*"OpenClaw directory not found"*)
+                *"Refusing to apply"*|*"Migration failed"*|*"Migration preview failed"*|*"directory not found"*)
                   echo 'migration command reported a refusal or failure' >&2
                   exit 1
                   ;;
@@ -75,7 +75,7 @@ spec:
               import sys
 
               started_at = int(sys.argv[1])
-              report_root = pathlib.Path('/opt/data/migration/openclaw')
+              report_root = pathlib.Path('/opt/data/migration') / ('open' + 'claw')
               reports = [
                   path
                   for path in report_root.glob('*/report.json')
@@ -105,6 +105,8 @@ spec:
                       raise RuntimeError(f'migration report lacks a resolved {kind} item')
                   if item.get('reason') in {'Source file not found', 'No workspace/memory/ directory found'}:
                       raise RuntimeError(f'migration report did not consume the audited {kind} source')
+                  if item.get('details', {}).get('char_limit') != 4400:
+                      raise RuntimeError(f'migration report did not use the production memory limit: {kind}')
               for kind in ('soul', 'workspace-agents'):
                   item = items.get(kind)
                   if item is None or item.get('status') != 'skipped':
@@ -159,12 +161,20 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /opt/data
+            - name: config
+              mountPath: /opt/data/config.yaml
+              subPath: config.yaml
+              readOnly: true
             - name: tmp
               mountPath: /tmp
       volumes:
         - name: data
           persistentVolumeClaim:
             claimName: data-hermes-0
+        - name: config
+          configMap:
+            name: hermes-operation-config
+            defaultMode: 0444
         - name: tmp
           emptyDir:
             sizeLimit: 1Gi

--- a/argocd/applications/hermes/operations/migration-dry-run-job.yaml
+++ b/argocd/applications/hermes/operations/migration-dry-run-job.yaml
@@ -59,7 +59,7 @@ spec:
                 *) echo 'migration preview did not prove that secret migration is disabled' >&2; exit 1 ;;
               esac
               case "$migration_output" in
-                *"Conflicts ("*|*" conflict(s)"*|*"Refusing to apply"*|*"Migration preview failed"*|*"OpenClaw directory not found"*)
+                *"Conflicts ("*|*" conflict(s)"*|*"Refusing to apply"*|*"Migration preview failed"*|*"directory not found"*)
                   echo 'migration preview contains a conflict or refusal' >&2
                   exit 1
                   ;;
@@ -101,12 +101,20 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /opt/data
+            - name: config
+              mountPath: /opt/data/config.yaml
+              subPath: config.yaml
+              readOnly: true
             - name: tmp
               mountPath: /tmp
       volumes:
         - name: data
           persistentVolumeClaim:
             claimName: data-hermes-0
+        - name: config
+          configMap:
+            name: hermes-operation-config
+            defaultMode: 0444
         - name: tmp
           emptyDir:
             sizeLimit: 1Gi

--- a/docs/runbooks/hermes-production-rollout.md
+++ b/docs/runbooks/hermes-production-rollout.md
@@ -412,7 +412,9 @@ unset stale_maintenance_holder
 4. If the preview is correct, use the same shell and Lease to run the apply Job. Preserve its Job name, log, report summary,
    and generated restore-point archive as migration evidence. The Job verifies its current JSON report, zero
    conflicts/errors, excluded secrets, untouched GitOps-owned identity files, and a current restore point before it can
-   complete. Keep the Lease held for the final resync:
+   complete. It also requires the report to use the production `memory_char_limit` of `4400`; the stable read-only
+   `hermes-operation-config` is generated from the same `config.yaml` mounted by the gateway. Keep the Lease held for the
+   final resync:
 
    ```bash
    set -euo pipefail

--- a/scripts/hermes/validate-production.test.ts
+++ b/scripts/hermes/validate-production.test.ts
@@ -581,6 +581,15 @@ test('rejects an apply Job without runtime proof that secrets are disabled', asy
   )
 })
 
+test('rejects migration Jobs without the stable production config', async () => {
+  const files = await loadProductionFiles()
+  files.migrationApply = files.migrationApply.replace('name: hermes-operation-config', 'name: missing-config')
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.migrationApply}: missing production invariant "name: hermes-operation-config"`,
+  )
+})
+
 test('rejects restore archive selection that expands the glob on the operator host', async () => {
   const files = await loadProductionFiles()
   files.runbook = files.runbook.replace(

--- a/scripts/hermes/validate-production.ts
+++ b/scripts/hermes/validate-production.ts
@@ -68,6 +68,8 @@ export function validateProductionContent(files: ProductionFiles): string[] {
 
   requireTerms(failures, productionPaths.kustomization, files.kustomization, [
     'namespace: hermes',
+    'name: hermes-operation-config',
+    'options:\n      disableNameSuffixHash: true',
     '- statefulset.yaml',
     '- backup-cronjob.yaml',
     '- network-policy.yaml',
@@ -169,6 +171,7 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'inherit_mcp_toolsets: false',
     'mcp_servers: {}',
     'hooks_auto_accept: false',
+    'memory_char_limit: 4400',
   ])
   forbidTerms(failures, productionPaths.config, files.config, ['api_key:', 'token:', 'allow_all_users: true'])
 
@@ -253,6 +256,9 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     '--dry-run',
     'migration preview contains a conflict or refusal',
     'migration_preview_verified=true conflicts=0 secrets=false',
+    'name: hermes-operation-config',
+    'mountPath: /opt/data/config.yaml',
+    'subPath: config.yaml',
   ])
   requireTerms(failures, productionPaths.migrationApply, files.migrationApply, [
     '--source /opt/data/migration/source',
@@ -265,11 +271,15 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     "summary.get('conflict', 0) != 0 or summary.get('error', 0) != 0",
     "{'secret-settings', 'provider-keys'} & selected",
     "for kind in ('user-profile', 'daily-memory'):",
+    "item.get('details', {}).get('char_limit') != 4400",
     "for kind in ('soul', 'workspace-agents'):",
     "for kind in ('secret-settings', 'provider-keys', 'discord-settings', 'slack-settings'):",
     "pathlib.Path('/opt/data/backups').glob('pre-migration-*.zip')",
     'migration_report_verified=true',
     'operator_owned_identity_unchanged=true secrets=false',
+    'name: hermes-operation-config',
+    'mountPath: /opt/data/config.yaml',
+    'subPath: config.yaml',
   ])
   forbidTerms(failures, productionPaths.migrationDryRun, files.migrationDryRun, ['--overwrite'])
   forbidTerms(failures, productionPaths.migrationApply, files.migrationApply, ['--overwrite'])


### PR DESCRIPTION
## Summary

- deploy a stable operation ConfigMap generated from the gateway production config
- mount that ConfigMap read-only in both migration Jobs
- require migration reports to use the production 4,400-character memory limit
- avoid the apply wrapper falsely matching itself as an OpenClaw process

## Related Issues

None

## Testing

- bun test scripts/hermes/*.test.ts - 72 passing tests
- bun run scripts/hermes/validate-production.ts
- bunx oxfmt --check scripts/hermes/validate-production.ts scripts/hermes/validate-production.test.ts
- sh -n on both rendered migration scripts
- Python compile check on the embedded report verifier
- kubeconform on both operation Jobs
- kustomize build plus kubeconform - 15 resources, 14 valid, one custom schema skipped

## Breaking Changes

None. Argo must reconcile the new non-secret operation ConfigMap before the next migration Job.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
