### PR TITLE
chore(bayn): promote image sha-f0ed955340dea04344636e0dc45406d23218b8c4

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: bayn
         app.kubernetes.io/part-of: bayn
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-21T06:53:04Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-21T08:11:04Z"
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
@@ -47,11 +47,11 @@ spec:
               protocol: TCP
           env:
             - name: BAYN_CODE_REVISION
-              value: 44caf4a3575d725a77e5b26aa2be9db392be756e
+              value: f0ed955340dea04344636e0dc45406d23218b8c4
             - name: BAYN_IMAGE_REPOSITORY
               value: registry.ide-newton.ts.net/lab/bayn
             - name: BAYN_IMAGE_DIGEST
-              value: sha256:b8dccb4007104931550154b395a29b213a2ca0b4a1ed7f6438a2f2200a5878f3
+              value: sha256:245f9c1e2fac585efa912f4681c1e3af1fa133502402e10c8f604049942831e5
             - name: BAYN_QUALIFICATION_RUN_ID
               value: 42d8bbfaf1a2ce7759b2283384e8f41298fe3a354ba7c0e1756bb8a3e64af177
             - name: BAYN_HEALTH_INTERVAL_MS

--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -22,5 +22,5 @@ configMapGenerator:
 images:
   - name: registry.ide-newton.ts.net/lab/bayn
     newName: registry.ide-newton.ts.net/lab/bayn
-    newTag: "sha-44caf4a3575d725a77e5b26aa2be9db392be756e"
-    digest: sha256:b8dccb4007104931550154b395a29b213a2ca0b4a1ed7f6438a2f2200a5878f3
+    newTag: "sha-f0ed955340dea04344636e0dc45406d23218b8c4"
+    digest: sha256:245f9c1e2fac585efa912f4681c1e3af1fa133502402e10c8f604049942831e5


### PR DESCRIPTION
## Summary

Promote the immutable Bayn image, activate the Bayn Argo application, and bind runtime evidence to its
source commit.

- Source commit: `f0ed955340dea04344636e0dc45406d23218b8c4`
- Image tag: `sha-f0ed955340dea04344636e0dc45406d23218b8c4`
- Image digest: `sha256:245f9c1e2fac585efa912f4681c1e3af1fa133502402e10c8f604049942831e5`

## Related Issues

PROOMPT-353

## Testing

- OCI index contains `linux/amd64` and `linux/arm64`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents exact validation.
- [x] Runtime source revision and image digest are immutable.
- [x] No broker or capital-promotion authority is introduced.