### PR TITLE
fix(hermes): prove source writer quiescence

### DIFF
--- a/docs/runbooks/hermes-production-rollout.md
+++ b/docs/runbooks/hermes-production-rollout.md
@@ -540,7 +540,7 @@ Cutover sequence:
    printf 'openclaw_discord_allowed_users=%s\n' "$discord_allowed_user_count"
    virtctl ssh -n openclaw --username ubuntu --identity-file /Users/gregkonush/.ssh/id_ed25519 \
      --local-ssh-opts='-o IdentityAgent=none' --local-ssh-opts='-o IdentitiesOnly=yes' \
-     --command='set -eu; systemctl --user stop openclaw-gateway.service; test "$(systemctl --user is-active openclaw-gateway.service || true)" = inactive; if pgrep -f "[o]penclaw.*gateway" >/dev/null; then exit 1; fi; sync' \
+     --command='set -eu; test "$(systemctl --user show openclaw-gateway.service --property=KillMode --value)" = control-group; systemctl --user stop openclaw-gateway.service; test "$(systemctl --user is-active openclaw-gateway.service || true)" = inactive; test "$(systemctl --user show openclaw-gateway.service --property=MainPID --value)" = 0; sync' \
      vm/openclaw
    ```
 

--- a/scripts/hermes/validate-production.test.ts
+++ b/scripts/hermes/validate-production.test.ts
@@ -120,6 +120,21 @@ test('rejects stopping the source before Discord credentials are captured', asyn
   )
 })
 
+test('rejects a gateway quiescence check that matches its own remote shell', async () => {
+  const files = await loadProductionFiles()
+  files.runbook = files.runbook.replace(
+    'test "$(systemctl --user show openclaw-gateway.service --property=MainPID --value)" = 0',
+    'if pgrep -f "[o]penclaw.*gateway" >/dev/null; then exit 1; fi',
+  )
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.runbook}: missing production invariant "test \\"$(systemctl --user show openclaw-gateway.service --property=MainPID --value)\\" = 0"`,
+  )
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.runbook}: contains forbidden production term "pgrep -f \\"[o]penclaw.*gateway\\""`,
+  )
+})
+
 test('rejects transferring the Discord token before the OpenClaw VMI is absent', async () => {
   const files = await loadProductionFiles()
   files.runbook = files.runbook.replace(

--- a/scripts/hermes/validate-production.ts
+++ b/scripts/hermes/validate-production.ts
@@ -725,7 +725,10 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'numeric Discord allowlist required',
     'test "${#discord_bot_token}" -ge 20',
     'case "$discord_allowed_users" in ""|,*|*,|*,,*|*[!0-9,]*) exit 1 ;; esac',
+    'test "$(systemctl --user show openclaw-gateway.service --property=KillMode --value)" = control-group',
     'systemctl --user stop openclaw-gateway.service',
+    'test "$(systemctl --user is-active openclaw-gateway.service || true)" = inactive',
+    'test "$(systemctl --user show openclaw-gateway.service --property=MainPID --value)" = 0',
     'repeat Phase 2 steps 1 through 4 from a fresh',
     '`hermes_stage_dir`',
     'Do not reuse the earlier archive.',
@@ -759,6 +762,7 @@ export function validateProductionContent(files: ProductionFiles): string[] {
   forbidTerms(failures, productionPaths.runbook, cutoverSection, [
     'argocd app sync openclaw --prune=true',
     'allow_all_users: true',
+    'pgrep -f "[o]penclaw.*gateway"',
   ])
   if (cutoverSection.includes('kubectl -n openclaw wait virtualmachineinstance/openclaw --for=delete')) {
     failures.push(`${productionPaths.runbook}: cutover must treat an already-absent OpenClaw VMI as stopped`)


### PR DESCRIPTION
## Summary

- replace the self-matching OpenClaw `pgrep -f` cutover check with systemd unit-state proof
- require `KillMode=control-group`, inactive state, and `MainPID=0` before final reconciliation
- reject the unsafe self-matching check in production validation with regression coverage

## Related Issues

Follow-up to #12920.

## Testing

- `bun test scripts/hermes` — 88 passed, 0 failed.
- `bun run scripts/hermes/validate-production.ts` — validated 28 production surfaces.
- `bunx oxfmt --check docs/runbooks/hermes-production-rollout.md scripts/hermes/validate-production.ts scripts/hermes/validate-production.test.ts` — passed.
- `git diff --check` — passed.
- live regression: with Hermes still API-only, systemd proved `KillMode=control-group`, stopped OpenClaw to inactive with `MainPID=0`, then restored the gateway to active.

## Breaking Changes

None. This corrects the fail-closed source-quiescence gate before cutover resumes.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
