### PR TITLE
fix(openclaw): transition VM run strategy atomically

### DIFF
--- a/docs/runbooks/hermes-production-rollout.md
+++ b/docs/runbooks/hermes-production-rollout.md
@@ -562,6 +562,27 @@ Cutover sequence:
    argocd app sync openclaw --prune \
      --resource rbac.authorization.k8s.io:ClusterRoleBinding:openclaw-vm-cluster-admin
    test -z "$(kubectl -n openclaw get clusterrolebinding openclaw-vm-cluster-admin --ignore-not-found -o name)"
+   openclaw_run_state=$(kubectl -n openclaw get virtualmachine openclaw -o json | jq -r '
+     if .spec.running == true and (.spec | has("runStrategy") | not) then "legacy-running"
+     elif .spec.runStrategy == "Always" and (.spec | has("running") | not) then "runstrategy-running"
+     elif .spec.runStrategy == "Halted" and (.spec | has("running") | not) then "halted"
+     else "unexpected"
+     end')
+   case "$openclaw_run_state" in
+     legacy-running)
+       kubectl -n openclaw patch virtualmachine openclaw --type=json \
+         -p='[{"op":"test","path":"/spec/running","value":true},{"op":"remove","path":"/spec/running"},{"op":"add","path":"/spec/runStrategy","value":"Halted"}]'
+       ;;
+     runstrategy-running)
+       kubectl -n openclaw patch virtualmachine openclaw --type=json \
+         -p='[{"op":"test","path":"/spec/runStrategy","value":"Always"},{"op":"replace","path":"/spec/runStrategy","value":"Halted"}]'
+       ;;
+     halted) ;;
+     *) echo 'OpenClaw VM has an unexpected run-state schema; refusing cutover' >&2; exit 1 ;;
+   esac
+   kubectl -n openclaw get virtualmachine openclaw -o json | \
+     jq -e '.spec.runStrategy == "Halted" and (.spec | has("running") | not)'
+   unset openclaw_run_state
    argocd app sync openclaw --prune=false
    openclaw_stop_deadline=$(( $(date +%s) + 600 ))
    while :; do

--- a/scripts/hermes/validate-production.test.ts
+++ b/scripts/hermes/validate-production.test.ts
@@ -108,6 +108,18 @@ test('rejects whole-application pruning during OpenClaw cutover', async () => {
   )
 })
 
+test('rejects an OpenClaw sync without an admission-safe runStrategy transition', async () => {
+  const files = await loadProductionFiles()
+  files.runbook = files.runbook.replace(
+    '-p=\'[{"op":"test","path":"/spec/running","value":true},{"op":"remove","path":"/spec/running"},{"op":"add","path":"/spec/runStrategy","value":"Halted"}]\'',
+    '-p=\'[{"op":"add","path":"/spec/runStrategy","value":"Halted"}]\'',
+  )
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.runbook}: missing production invariant "-p='[{\\"op\\":\\"test\\",\\"path\\":\\"/spec/running\\",\\"value\\":true},{\\"op\\":\\"remove\\",\\"path\\":\\"/spec/running\\"},{\\"op\\":\\"add\\",\\"path\\":\\"/spec/runStrategy\\",\\"value\\":\\"Halted\\"}]'"`,
+  )
+})
+
 test('rejects stopping the source before Discord credentials are captured', async () => {
   const files = await loadProductionFiles()
   files.runbook = files.runbook.replace(

--- a/scripts/hermes/validate-production.ts
+++ b/scripts/hermes/validate-production.ts
@@ -737,6 +737,14 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'cutover step 5.',
     'argocd app sync openclaw --prune \\\n     --resource rbac.authorization.k8s.io:ClusterRoleBinding:openclaw-vm-cluster-admin',
     'get clusterrolebinding openclaw-vm-cluster-admin --ignore-not-found -o name',
+    'openclaw_run_state=$(kubectl -n openclaw get virtualmachine openclaw -o json',
+    'if .spec.running == true and (.spec | has("runStrategy") | not) then "legacy-running"',
+    'elif .spec.runStrategy == "Always" and (.spec | has("running") | not) then "runstrategy-running"',
+    'elif .spec.runStrategy == "Halted" and (.spec | has("running") | not) then "halted"',
+    '-p=\'[{"op":"test","path":"/spec/running","value":true},{"op":"remove","path":"/spec/running"},{"op":"add","path":"/spec/runStrategy","value":"Halted"}]\'',
+    '-p=\'[{"op":"test","path":"/spec/runStrategy","value":"Always"},{"op":"replace","path":"/spec/runStrategy","value":"Halted"}]\'',
+    'OpenClaw VM has an unexpected run-state schema; refusing cutover',
+    'jq -e \'.spec.runStrategy == "Halted" and (.spec | has("running") | not)\'',
     'argocd app sync openclaw --prune=false',
     'openclaw_vmi_name=$(kubectl -n openclaw get virtualmachineinstance openclaw --ignore-not-found -o name)',
     'op item get --vault infra hermes-runtime --format json',
@@ -774,6 +782,9 @@ export function validateProductionContent(files: ProductionFiles): string[] {
   const clusterAdminAbsentIndex = cutoverSection.indexOf(
     'get clusterrolebinding openclaw-vm-cluster-admin --ignore-not-found -o name',
   )
+  const openClawRunStrategyTransitionIndex = cutoverSection.indexOf(
+    'openclaw_run_state=$(kubectl -n openclaw get virtualmachine openclaw -o json',
+  )
   const cutoverOpenClawSyncIndex = cutoverSection.indexOf('argocd app sync openclaw --prune=false')
   const openClawVmiAbsentIndex = cutoverSection.indexOf('if [ -z "$openclaw_vmi_name" ]')
   const credentialTransferIndex = cutoverSection.indexOf('op item edit --vault infra hermes-runtime')
@@ -796,7 +807,8 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     finalReconciliationIndex <= openClawGatewayStopIndex ||
     clusterAdminPruneIndex <= finalReconciliationIndex ||
     clusterAdminAbsentIndex <= clusterAdminPruneIndex ||
-    cutoverOpenClawSyncIndex <= clusterAdminAbsentIndex ||
+    openClawRunStrategyTransitionIndex <= clusterAdminAbsentIndex ||
+    cutoverOpenClawSyncIndex <= openClawRunStrategyTransitionIndex ||
     openClawVmiAbsentIndex <= cutoverOpenClawSyncIndex ||
     credentialTransferIndex <= openClawVmiAbsentIndex ||
     credentialCleanupIndex <= credentialTransferIndex ||


### PR DESCRIPTION
## Summary

- add a retry-safe state gate for legacy `spec.running`, `runStrategy: Always`, and already-halted OpenClaw VMs
- atomically remove deprecated `spec.running` and add `runStrategy: Halted` so KubeVirt admission never sees both fields
- require live post-transition proof before the full OpenClaw Argo sync

## Related Issues

Follow-up to #12920 and #12979.

## Testing

- `bun test scripts/hermes` — 89 passed, 0 failed.
- `bun run scripts/hermes/validate-production.ts` — validated 28 production surfaces.
- `bunx oxfmt --check docs/runbooks/hermes-production-rollout.md scripts/hermes/validate-production.ts scripts/hermes/validate-production.test.ts` — passed.
- `git diff --check` — passed.
- `kubectl -n openclaw patch virtualmachine/openclaw --type=json --dry-run=server ...` — the exact atomic transition passed live server admission and left the live VM unchanged in `legacy-running` state.

## Breaking Changes

None. This is the one-time admission-safe transition required before the already-merged `runStrategy: Halted` GitOps state can reconcile.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
