### PR TITLE
fix(hermes): seal Discord cutover credentials

### DIFF
--- a/argocd/applications/hermes/discord-sealed-secret.yaml
+++ b/argocd/applications/hermes/discord-sealed-secret.yaml
@@ -1,0 +1,22 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: hermes-discord-auth
+  namespace: hermes
+  labels:
+    app.kubernetes.io/name: hermes
+    app.kubernetes.io/component: gateway
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+spec:
+  encryptedData:
+    DISCORD_ALLOWED_USERS: AgCNdXbopk4GW6SR933SpUVN+shxwT7pkXPNxAEL5AZmmxJJkDCAs6Zvikfwp+jbwnD4uxKO0O1ZEcFlAs7IzZhMPqIMr7ospXm2U1KvTqdO1NhWbxTMZVKv4URs3tOwsghW9BVnGc+0DTM/qEhV+wtRgoq7pOeYnBok75LjEGi+R3pugXuKwfWKfxWLBc6+FbUwlrFy0vjH1O4RcZKCtmFshNIzWvoEOJ8b+3/SPhoeXLUJZ8F+8KANGa0AOMc5mqBwdR6naC3DFgCXxsWUYz+V0gNtx6WhtAkcKf7Y0uo+Et8C/4EUuM/NbutKkyImRAhiA67zdKuzxizyM3a+AGaG7RARX9/dF5axLvwmyw4H3jPLfXpBOW8gccD3GkuuVuTPCHLUVn6UXpLZVfFh1Buf7unBb+ZT3g+0aXpx+myL3mP47CcwoDQ9oQaZowVq+yLQDMq8CHB5HIOFNShX2JkV+Wx48kmB32wWXX4VsJokzArUgLXnO1n151DmJr/OMW4Rm40uc6eytj+aSPQgkl/v/vH5XPyBeoT0FxA3ItBfa9WO6q8w31ioSJkbL2uYtPr1Oo7A0RCDGnOKsQjZroO7M2CviW7HYj+IcvEYY6UbvIxsaGAirfUrBWne4TgykjJBWcAosrMzxFXCXSa592zxAS60i8vwQWm9PMzwuylK2rW6E36wCH5dfX6AB78dTSElBs8MQ35hkqb7YXHYfeOMjPk=
+    DISCORD_BOT_TOKEN: AgBgVuK2TRm9wfinfywXP5dbYaIOwh63Klp9TZ4nxiS2k1yUfuDKCa1NNHjLoUUBZN/e/twvHgh464eFsg202i2y12QK9Q40yP+B7IRnJjQJ4l5f4QT5AWzKC0LxERBjv3lhDSNLz+8/AhnVWMbRHcC6SXRClR6UupsgyK7EwtU3a5wq6hQJ0kjLqJvBhcnqVpbhiKoGSiw9BDOpTUeEt65Yczsj+jf7S3ss5A4D/SDonVZM3Id5TP7w1VcGwFrwZPYL2maJfsCSGFMN55+YxivgORCPKw780K7/c3OcioQHi70iQGKD4MChMClgwsiCAK53nI1xb0/Fc3QbxvZmzYDevW58HrEK1cw3si6UwA8DM4KO1JIQjriOxHxG1OxowH50PiNfDf8dUCOZlxKlA+s5hHPugU9Ut/x5hjRdqBjm0I8jLeRAXIQzOmoGLD+Icg/VgHX5CEeur9Tvf36GoYK57EoM6LCpXs+VXXAcBX+N161dMNcRCMWHc3W7FRwj2tZS7rzqsdh2GUh7oHoeW9XdVhQhmMJqQpZVE5Kj7wSKoIFwbpS3bm0ZG5JhtEMkUouTKOFuaL75WWV+e0rp9ykP+BCioIw21N6wvGsbAoKPMNAmnSyCGs/ki1oeX2Xt5Fww7uVeB0HNMakhrMJyQuvlmBY8jy88iuznbdMJ3fYrtmOJ4MdvmwLpeJXiUr8K83aS7QVcOPU3ybs314wdY95mwWjXeE6sXk22NSd1QuW+NGT8dG/x6qhlq/nEkz/3SqNb2IwKCNqUWuooX1hHmCbvbWPGyOTn6FM=
+  template:
+    metadata:
+      name: hermes-discord-auth
+      namespace: hermes
+      labels:
+        app.kubernetes.io/name: hermes
+        app.kubernetes.io/component: gateway
+    type: Opaque

--- a/argocd/applications/hermes/external-secret.yaml
+++ b/argocd/applications/hermes/external-secret.yaml
@@ -28,17 +28,3 @@ spec:
         key: hermes-runtime/API_SERVER_KEY
         metadataPolicy: None
         nullBytePolicy: Ignore
-    - secretKey: DISCORD_BOT_TOKEN
-      remoteRef:
-        conversionStrategy: Default
-        decodingStrategy: None
-        key: hermes-runtime/DISCORD_BOT_TOKEN
-        metadataPolicy: None
-        nullBytePolicy: Ignore
-    - secretKey: DISCORD_ALLOWED_USERS
-      remoteRef:
-        conversionStrategy: Default
-        decodingStrategy: None
-        key: hermes-runtime/DISCORD_ALLOWED_USERS
-        metadataPolicy: None
-        nullBytePolicy: Ignore

--- a/argocd/applications/hermes/kustomization.yaml
+++ b/argocd/applications/hermes/kustomization.yaml
@@ -29,6 +29,7 @@ configMapGenerator:
 resources:
   - serviceaccount.yaml
   - external-secret.yaml
+  - discord-sealed-secret.yaml
   - service.yaml
   - egress-proxy.yaml
   - network-policy.yaml

--- a/argocd/applications/hermes/statefulset.yaml
+++ b/argocd/applications/hermes/statefulset.yaml
@@ -132,12 +132,12 @@ spec:
             - name: DISCORD_BOT_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: hermes-api-auth
+                  name: hermes-discord-auth
                   key: DISCORD_BOT_TOKEN
             - name: DISCORD_ALLOWED_USERS
               valueFrom:
                 secretKeyRef:
-                  name: hermes-api-auth
+                  name: hermes-discord-auth
                   key: DISCORD_ALLOWED_USERS
             - name: DISCORD_PROXY
               value: http://hermes-egress-proxy.hermes.svc.cluster.local:3128

--- a/docs/runbooks/hermes-production-rollout.md
+++ b/docs/runbooks/hermes-production-rollout.md
@@ -505,27 +505,85 @@ unset stale_maintenance_holder
 
 Discord activation requires a second PR. That PR must:
 
-- add an ExternalSecret mapping `hermes-runtime/DISCORD_BOT_TOKEN` and `hermes-runtime/DISCORD_ALLOWED_USERS`;
+- add the name- and namespace-bound `hermes-discord-auth` SealedSecret with only `DISCORD_BOT_TOKEN` and
+  `DISCORD_ALLOWED_USERS`;
+- leave `hermes-api-auth` and its ExternalSecret responsible only for `API_SERVER_KEY`;
 - inject both secret keys into the gateway container;
 - set `platforms.discord.enabled: true`;
 - set OpenClaw `spec.runStrategy: Halted` and remove the OpenClaw `cluster-admin` binding;
 - retain the OpenClaw VM, root-disk PVC, cloud-init Secret, and scoped read-only rollback resources;
-- retain manual Argo automation so the token transfer and sync are ordered by the operator.
+- retain manual Argo automation so secret staging, source quiescence, and the full sync are ordered by the operator.
+
+Generate or rotate `discord-sealed-secret.yaml` while OpenClaw is still the sole writer. Use explicit strict scope. Plaintext
+may exist only in this private shell and in the two command pipelines; only ciphertext is written to Git:
+
+```bash
+set -euo pipefail
+cleanup_discord_credentials() {
+  unset discord_bot_token discord_allowed_users discord_bot_token_cipher discord_allowed_users_cipher
+}
+abort_discord_credentials() { trap - EXIT HUP INT TERM; cleanup_discord_credentials; exit 130; }
+trap cleanup_discord_credentials EXIT
+trap abort_discord_credentials HUP INT TERM
+discord_bot_token=$(virtctl ssh -n openclaw --username ubuntu --identity-file /Users/gregkonush/.ssh/id_ed25519 \
+  --local-ssh-opts='-o IdentityAgent=none' --local-ssh-opts='-o IdentitiesOnly=yes' \
+  --command='set -eu; jq -er '\''.channels.discord.token | select(type == "string" and length >= 20)'\'' /home/ubuntu/.openclaw/openclaw.json' \
+  vm/openclaw)
+discord_allowed_users=$(virtctl ssh -n openclaw --username ubuntu --identity-file /Users/gregkonush/.ssh/id_ed25519 \
+  --local-ssh-opts='-o IdentityAgent=none' --local-ssh-opts='-o IdentitiesOnly=yes' \
+  --command='set -eu; jq -er '\''[.channels.discord.allowFrom[]?, .channels.discord.guilds[]?.users[]?] | if length > 0 and all(.[]; type == "string" and test("^[0-9]+$")) then unique | join(",") else error("numeric Discord allowlist required") end'\'' /home/ubuntu/.openclaw/openclaw.json' \
+  vm/openclaw)
+test "${#discord_bot_token}" -ge 20
+case "$discord_allowed_users" in ""|,*|*,|*,,*|*[!0-9,]*) exit 1 ;; esac
+discord_bot_token_cipher=$(printf '%s' "$discord_bot_token" | kubeseal --raw --from-file=/dev/stdin \
+  --controller-name sealed-secrets --controller-namespace sealed-secrets \
+  --namespace hermes --name hermes-discord-auth --scope strict)
+discord_allowed_users_cipher=$(printf '%s' "$discord_allowed_users" | kubeseal --raw --from-file=/dev/stdin \
+  --controller-name sealed-secrets --controller-namespace sealed-secrets \
+  --namespace hermes --name hermes-discord-auth --scope strict)
+DISCORD_BOT_TOKEN_CIPHER="$discord_bot_token_cipher" \
+DISCORD_ALLOWED_USERS_CIPHER="$discord_allowed_users_cipher" \
+  yq -i '
+    .spec.encryptedData.DISCORD_BOT_TOKEN = strenv(DISCORD_BOT_TOKEN_CIPHER) |
+    .spec.encryptedData.DISCORD_ALLOWED_USERS = strenv(DISCORD_ALLOWED_USERS_CIPHER)
+  ' argocd/applications/hermes/discord-sealed-secret.yaml
+if rg -q --fixed-strings --file <(printf '%s\n%s\n' "$discord_bot_token" "$discord_allowed_users") \
+  argocd/applications/hermes/discord-sealed-secret.yaml; then
+  echo 'plaintext Discord credential found in SealedSecret manifest' >&2
+  exit 1
+fi
+kubeseal --validate --controller-name sealed-secrets --controller-namespace sealed-secrets \
+  < argocd/applications/hermes/discord-sealed-secret.yaml
+printf 'discord_ciphertext_valid=true allowlist_count=%s\n' \
+  "$(printf '%s\n' "$discord_allowed_users" | awk -F, '{print NF}')"
+cleanup_discord_credentials
+trap - EXIT HUP INT TERM
+```
 
 Cutover sequence:
 
-1. In a dedicated private credential shell, capture the existing bot token and numeric allowlist without printing either
-   value. Keep this shell open through step 4. Record only the allowlist count, quiesce OpenClaw's Discord writer while the
-   VM remains reachable, and prove the gateway process is inactive:
+1. After the activation PR is merged, resource-sync only the SealedSecret while the live Hermes StatefulSet is still the
+   API-only revision. Compare the generated Secret exactly with the OpenClaw source without printing either value, prove
+   Hermes has no Discord credential references, then quiesce OpenClaw and prove its gateway process is inactive. A failure
+   before the stop leaves OpenClaw as the writer; do not continue on any failure:
 
    ```bash
    set -euo pipefail
    cleanup_discord_credentials() {
-     unset discord_bot_token discord_allowed_users discord_allowed_user_count
+     unset discord_bot_token discord_allowed_users sealed_discord_bot_token sealed_discord_allowed_users
+     unset discord_secret_keys hermes_discord_ref_count
    }
    abort_discord_credentials() { trap - EXIT HUP INT TERM; cleanup_discord_credentials; exit 130; }
    trap cleanup_discord_credentials EXIT
    trap abort_discord_credentials HUP INT TERM
+   kubeseal --validate --controller-name sealed-secrets --controller-namespace sealed-secrets \
+     < argocd/applications/hermes/discord-sealed-secret.yaml
+   argocd app sync hermes --prune=false \
+     --resource bitnami.com:SealedSecret:hermes-discord-auth
+   kubectl -n hermes wait sealedsecret/hermes-discord-auth --for=condition=Synced --timeout=5m
+   discord_secret_keys=$(kubectl -n hermes get secret hermes-discord-auth -o json | \
+     jq -r '.data | keys | sort | join(",")')
+   test "$discord_secret_keys" = DISCORD_ALLOWED_USERS,DISCORD_BOT_TOKEN
    discord_bot_token=$(virtctl ssh -n openclaw --username ubuntu --identity-file /Users/gregkonush/.ssh/id_ed25519 \
      --local-ssh-opts='-o IdentityAgent=none' --local-ssh-opts='-o IdentitiesOnly=yes' \
      --command='set -eu; jq -er '\''.channels.discord.token | select(type == "string" and length >= 20)'\'' /home/ubuntu/.openclaw/openclaw.json' \
@@ -536,24 +594,35 @@ Cutover sequence:
      vm/openclaw)
    test "${#discord_bot_token}" -ge 20
    case "$discord_allowed_users" in ""|,*|*,|*,,*|*[!0-9,]*) exit 1 ;; esac
-   discord_allowed_user_count=$(printf '%s\n' "$discord_allowed_users" | awk -F, '{print NF}')
-   printf 'openclaw_discord_allowed_users=%s\n' "$discord_allowed_user_count"
+   sealed_discord_bot_token=$(kubectl -n hermes get secret hermes-discord-auth \
+     -o jsonpath='{.data.DISCORD_BOT_TOKEN}' | base64 -d)
+   sealed_discord_allowed_users=$(kubectl -n hermes get secret hermes-discord-auth \
+     -o jsonpath='{.data.DISCORD_ALLOWED_USERS}' | base64 -d)
+   test "$sealed_discord_bot_token" = "$discord_bot_token"
+   test "$sealed_discord_allowed_users" = "$discord_allowed_users"
+   hermes_discord_ref_count=$(kubectl -n hermes get statefulset hermes -o json | jq '
+     [.spec.template.spec.containers[] | select(.name == "hermes") | .env[]? |
+       select(.name == "DISCORD_BOT_TOKEN" or .name == "DISCORD_ALLOWED_USERS")] | length')
+   test "$hermes_discord_ref_count" = 0
+   printf 'sealed_discord_source_match=true allowlist_count=%s hermes_discord_refs=0\n' \
+     "$(printf '%s\n' "$discord_allowed_users" | awk -F, '{print NF}')"
    virtctl ssh -n openclaw --username ubuntu --identity-file /Users/gregkonush/.ssh/id_ed25519 \
      --local-ssh-opts='-o IdentityAgent=none' --local-ssh-opts='-o IdentitiesOnly=yes' \
      --command='set -eu; test "$(systemctl --user show openclaw-gateway.service --property=KillMode --value)" = control-group; systemctl --user stop openclaw-gateway.service; test "$(systemctl --user is-active openclaw-gateway.service || true)" = inactive; test "$(systemctl --user show openclaw-gateway.service --property=MainPID --value)" = 0; sync' \
      vm/openclaw
+   cleanup_discord_credentials
+   trap - EXIT HUP INT TERM
    ```
 
 2. In a separate maintenance shell, with the source quiesced, repeat Phase 2 steps 1 through 4 from a fresh
    `hermes_stage_dir`. Preserve the new audit output, dry-run Job, apply Job, and restore-point archive as the final
    reconciliation evidence. Do not reuse the earlier archive. Leave the Hermes StatefulSet at zero and backups suspended;
    do not run Phase 2 step 5 because merged `main` now enables Discord. Keep the same Phase 2 shell and Lease open through
-   cutover step 5. Keep the credential shell from step 1 open through step 4. If this final migration fails, keep Hermes
-   Discord disabled. If cutover is abandoned before the VMI is stopped, restart `openclaw-gateway.service`, resync the last
-   API-only Hermes revision, release the Lease, clear the credential variables, and repeat this final reconciliation before
-   any later attempt.
+   cutover step 4. If this final migration fails, keep Hermes Discord disabled. If cutover is abandoned before the VMI is
+   stopped, restart `openclaw-gateway.service`, resync the last API-only Hermes revision, release the Lease, and repeat this
+   final reconciliation before any later attempt.
 3. In the same shell, assert continued Lease ownership, sync the merged OpenClaw GitOps change, and prove its VMI is gone
-   before provisioning Hermes with the shared token:
+   before enabling Hermes Discord:
 
    ```bash
    set -euo pipefail
@@ -594,7 +663,7 @@ Cutover sequence:
      fi
      if [ "$(date +%s)" -ge "$openclaw_stop_deadline" ]; then
        kubectl -n openclaw get virtualmachineinstance openclaw -o wide >&2
-       echo 'OpenClaw VMI did not stop; do not provision Hermes with the Discord token' >&2
+       echo 'OpenClaw VMI did not stop; do not enable Hermes Discord' >&2
        exit 1
      fi
      sleep 5
@@ -602,46 +671,9 @@ Cutover sequence:
    unset openclaw_vmi_name openclaw_stop_deadline
    ```
 
-4. Only after the OpenClaw VMI is absent, use the credential shell from step 1 to transfer the captured bot token and numeric
-   allowlist directly into the `hermes-runtime` 1Password item. Verify the fields without printing them, clear the variables,
-   and keep the Lease-owning shell open:
-
-   ```bash
-   set -euo pipefail
-   test -n "${discord_bot_token:-}"
-   test -n "${discord_allowed_users:-}"
-   op item get --vault infra hermes-runtime --format json | \
-     jq --rawfile discord_bot_token <(printf '%s' "$discord_bot_token") \
-       --rawfile discord_allowed_users <(printf '%s' "$discord_allowed_users") '
-       def upsert_field($id; $type; $label; $value):
-         ([.fields[] | select(.label == $label)] | length) as $count
-         | if $count == 0 then
-             .fields += [{id: $id, type: $type, label: $label, value: $value}]
-           elif $count == 1 then
-             .fields |= map(if .label == $label then .type = $type | .value = $value else . end)
-           else
-             error("duplicate field: " + $label)
-           end;
-       upsert_field("DISCORD_BOT_TOKEN"; "CONCEALED"; "DISCORD_BOT_TOKEN"; $discord_bot_token)
-       | upsert_field("DISCORD_ALLOWED_USERS"; "STRING"; "DISCORD_ALLOWED_USERS"; $discord_allowed_users)
-     ' | op item edit --vault infra hermes-runtime >/dev/null
-   op item get --vault infra hermes-runtime --format json | \
-     jq -e --rawfile expected_discord_bot_token <(printf '%s' "$discord_bot_token") \
-       --rawfile expected_discord_allowed_users <(printf '%s' "$discord_allowed_users") '
-       ([.fields[] | select(
-         .label == "DISCORD_BOT_TOKEN" and .value == $expected_discord_bot_token
-       )] | length == 1) and
-       ([.fields[] | select(
-         .label == "DISCORD_ALLOWED_USERS" and .value == $expected_discord_allowed_users
-       )] | length == 1)
-     ' >/dev/null
-   cleanup_discord_credentials
-   trap - EXIT HUP INT TERM
-   ```
-
-5. Keep the Lease-owning shell open. Sync Hermes from merged `main` only after the OpenClaw VMI is gone. Wait for the
-   updated ExternalSecret and rollout, verify backups are enabled, then release the Lease. Prove only one Discord bot
-   session is active. This sync restores the Hermes replicas and backups:
+4. Keep the Lease-owning shell open. Sync Hermes from merged `main` only after the OpenClaw VMI is gone. Wait for the
+   API ExternalSecret, Discord SealedSecret, and rollout; verify backups are enabled, then release the Lease. Prove only one
+   Discord bot session is active. This sync restores the Hermes replicas and backups:
 
    ```bash
    set -euo pipefail
@@ -649,10 +681,13 @@ Cutover sequence:
    test "$(kubectl -n hermes get lease hermes-maintenance -o jsonpath='{.spec.holderIdentity}')" = "$maintenance_holder"
    argocd app sync hermes --prune=false
    kubectl -n hermes wait externalsecret/hermes-api-auth --for=condition=Ready --timeout=5m
+   kubectl -n hermes wait sealedsecret/hermes-discord-auth --for=condition=Synced --timeout=5m
    kubectl -n hermes rollout status statefulset/hermes --timeout=15m
-   discord_secret_keys=$(kubectl -n hermes get secret hermes-api-auth -o json | jq -r '.data | keys | sort | join(",")')
-   test "$discord_secret_keys" = API_SERVER_KEY,DISCORD_ALLOWED_USERS,DISCORD_BOT_TOKEN
-   unset discord_secret_keys
+   api_secret_keys=$(kubectl -n hermes get secret hermes-api-auth -o json | jq -r '.data | keys | sort | join(",")')
+   discord_secret_keys=$(kubectl -n hermes get secret hermes-discord-auth -o json | jq -r '.data | keys | sort | join(",")')
+   test "$api_secret_keys" = API_SERVER_KEY
+   test "$discord_secret_keys" = DISCORD_ALLOWED_USERS,DISCORD_BOT_TOKEN
+   unset api_secret_keys discord_secret_keys
    test "$(kubectl -n hermes get cronjob hermes-backup -o jsonpath='{.spec.suspend}')" = false
    test -z "$(kubectl -n openclaw get virtualmachineinstance openclaw --ignore-not-found -o name)"
    test "$(kubectl -n hermes get statefulset hermes -o jsonpath='{.status.readyReplicas}')" = 1
@@ -662,9 +697,9 @@ Cutover sequence:
    unset maintenance_holder
    ```
 
-6. From the allowlisted account, send a unique canary message and capture the inbound message ID, Hermes session ID, response
+5. From the allowlisted account, send a unique canary message and capture the inbound message ID, Hermes session ID, response
    message ID, and timestamp. Verify a non-allowlisted account is rejected or ignored.
-7. Restart `hermes-0`, send a second canary, and verify session/memory continuity plus a current successful backup.
+6. Restart `hermes-0`, send a second canary, and verify session/memory continuity plus a current successful backup.
 
 Do not declare cutover complete from pod readiness alone.
 

--- a/scripts/hermes/validate-production.test.ts
+++ b/scripts/hermes/validate-production.test.ts
@@ -53,19 +53,37 @@ test('rejects a Discord token without a matching gateway SecretKeyRef', async ()
   files.statefulSet = files.statefulSet.replace('- name: DISCORD_BOT_TOKEN\n', '- name: DISCORD_BOT_TOKEN_DISABLED\n')
 
   expect(validateProductionContent(files)).toContain(
-    `${productionPaths.statefulSet}: DISCORD_BOT_TOKEN must have exactly one matching SecretKeyRef`,
+    `${productionPaths.statefulSet}: DISCORD_BOT_TOKEN must have exactly one matching hermes-discord-auth SecretKeyRef`,
   )
 })
 
-test('rejects a Discord allowlist without a matching 1Password mapping', async () => {
+test('rejects a Discord allowlist missing from the SealedSecret', async () => {
   const files = await loadProductionFiles()
-  files.externalSecret = files.externalSecret.replace(
-    '    - secretKey: DISCORD_ALLOWED_USERS\n',
-    '    - secretKey: DISCORD_ALLOWED_USERS_DISABLED\n',
+  files.discordSealedSecret = files.discordSealedSecret.replace(
+    '    DISCORD_ALLOWED_USERS:',
+    '    DISCORD_ALLOWED_USERS_DISABLED:',
   )
 
   expect(validateProductionContent(files)).toContain(
-    `${productionPaths.externalSecret}: DISCORD_ALLOWED_USERS must have exactly one 1Password mapping`,
+    `${productionPaths.discordSealedSecret}: encryptedData must contain exactly the Discord token and allowlist`,
+  )
+})
+
+test('rejects Discord fields in the API ExternalSecret', async () => {
+  const files = await loadProductionFiles()
+  files.externalSecret += '\n    - secretKey: DISCORD_BOT_TOKEN\n'
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.externalSecret}: contains forbidden production term "DISCORD_BOT_TOKEN"`,
+  )
+})
+
+test('rejects a broadly scoped Discord SealedSecret', async () => {
+  const files = await loadProductionFiles()
+  files.discordSealedSecret += '\n    sealedsecrets.bitnami.com/namespace-wide: "true"\n'
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.discordSealedSecret}: contains forbidden production term "sealedsecrets.bitnami.com/namespace-wide"`,
   )
 })
 
@@ -132,11 +150,11 @@ test('rejects an OpenClaw sync without an admission-safe runStrategy transition'
   )
 })
 
-test('rejects stopping the source before Discord credentials are captured', async () => {
+test('rejects stopping the source before the sealed credentials match', async () => {
   const files = await loadProductionFiles()
   files.runbook = files.runbook.replace(
-    '   discord_bot_token=$(virtctl ssh',
-    '   systemctl --user stop openclaw-gateway.service\n   discord_bot_token=$(virtctl ssh',
+    '   test "$sealed_discord_bot_token" = "$discord_bot_token"',
+    '   systemctl --user stop openclaw-gateway.service\n   test "$sealed_discord_bot_token" = "$discord_bot_token"',
   )
 
   expect(validateProductionContent(files)).toContain(
@@ -159,11 +177,11 @@ test('rejects a gateway quiescence check that matches its own remote shell', asy
   )
 })
 
-test('rejects transferring the Discord token before the OpenClaw VMI is absent', async () => {
+test('rejects a full Hermes sync before the OpenClaw VMI is absent', async () => {
   const files = await loadProductionFiles()
   files.runbook = files.runbook.replace(
     '   argocd app sync openclaw --prune=false\n',
-    '   op item edit --vault infra hermes-runtime\n   argocd app sync openclaw --prune=false\n',
+    '   argocd app sync hermes --prune=false\n   argocd app sync openclaw --prune=false\n',
   )
 
   expect(validateProductionContent(files)).toContain(
@@ -171,24 +189,27 @@ test('rejects transferring the Discord token before the OpenClaw VMI is absent',
   )
 })
 
-test('rejects exposing secrets through 1Password assignment arguments', async () => {
+test('rejects plaintext fields in the Discord SealedSecret', async () => {
   const files = await loadProductionFiles()
-  files.runbook += '\nop item edit --vault infra hermes-runtime "DISCORD_BOT_TOKEN[password]=$discord_bot_token"\n'
+  files.discordSealedSecret = files.discordSealedSecret.replace(
+    '  encryptedData:\n',
+    '  stringData:\n    DISCORD_BOT_TOKEN: plaintext\n  encryptedData:\n',
+  )
 
   expect(validateProductionContent(files)).toContain(
-    `${productionPaths.runbook}: contains forbidden production term "DISCORD_BOT_TOKEN[password]="`,
+    `${productionPaths.discordSealedSecret}: contains forbidden production term "\\n  stringData:"`,
   )
 })
 
 test('rejects a Discord credential transfer without exact-value verification', async () => {
   const files = await loadProductionFiles()
   files.runbook = files.runbook.replace(
-    '.value == $expected_discord_bot_token',
-    '(.value | type == "string" and length >= 20)',
+    'test "$sealed_discord_bot_token" = "$discord_bot_token"',
+    'test "${#sealed_discord_bot_token}" -ge 20',
   )
 
   expect(validateProductionContent(files)).toContain(
-    `${productionPaths.runbook}: missing production invariant ".value == $expected_discord_bot_token"`,
+    `${productionPaths.runbook}: missing production invariant "test \\"$sealed_discord_bot_token\\" = \\"$discord_bot_token\\""`,
   )
 })
 

--- a/scripts/hermes/validate-production.ts
+++ b/scripts/hermes/validate-production.ts
@@ -12,6 +12,7 @@ export const productionPaths = {
   backupScript: 'argocd/applications/hermes/backup-once.sh',
   config: 'argocd/applications/hermes/config.yaml',
   externalSecret: 'argocd/applications/hermes/external-secret.yaml',
+  discordSealedSecret: 'argocd/applications/hermes/discord-sealed-secret.yaml',
   networkPolicy: 'argocd/applications/hermes/network-policy.yaml',
   egressProxy: 'argocd/applications/hermes/egress-proxy.yaml',
   serviceAccount: 'argocd/applications/hermes/serviceaccount.yaml',
@@ -77,6 +78,7 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     '- backup-cronjob.yaml',
     '- network-policy.yaml',
     '- external-secret.yaml',
+    '- discord-sealed-secret.yaml',
   ])
   forbidTerms(failures, productionPaths.kustomization, files.kustomization, [
     'kind: Namespace',
@@ -117,11 +119,21 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     '        - name: backup\n',
   ])
   for (const key of ['DISCORD_BOT_TOKEN', 'DISCORD_ALLOWED_USERS']) {
+    const reference = [
+      `            - name: ${key}`,
+      '              valueFrom:',
+      '                secretKeyRef:',
+      '                  name: hermes-discord-auth',
+      `                  key: ${key}`,
+    ].join('\n')
     if (
       count(files.statefulSet, `            - name: ${key}\n`) !== 1 ||
-      count(files.statefulSet, `                  key: ${key}\n`) !== 1
+      count(files.statefulSet, `                  key: ${key}\n`) !== 1 ||
+      count(files.statefulSet, reference) !== 1
     ) {
-      failures.push(`${productionPaths.statefulSet}: ${key} must have exactly one matching SecretKeyRef`)
+      failures.push(
+        `${productionPaths.statefulSet}: ${key} must have exactly one matching hermes-discord-auth SecretKeyRef`,
+      )
     }
   }
 
@@ -191,19 +203,54 @@ export function validateProductionContent(files: ProductionFiles): string[] {
   requireTerms(failures, productionPaths.externalSecret, files.externalSecret, [
     'name: onepassword-infra',
     'deletionPolicy: Retain',
+    'secretKey: API_SERVER_KEY',
     'key: hermes-runtime/API_SERVER_KEY',
-    'secretKey: DISCORD_BOT_TOKEN',
-    'key: hermes-runtime/DISCORD_BOT_TOKEN',
-    'secretKey: DISCORD_ALLOWED_USERS',
-    'key: hermes-runtime/DISCORD_ALLOWED_USERS',
   ])
-  forbidTerms(failures, productionPaths.externalSecret, files.externalSecret, ['dataFrom:', 'kind: Secret'])
-  for (const key of ['DISCORD_BOT_TOKEN', 'DISCORD_ALLOWED_USERS']) {
-    if (
-      count(files.externalSecret, `    - secretKey: ${key}\n`) !== 1 ||
-      count(files.externalSecret, `        key: hermes-runtime/${key}\n`) !== 1
-    ) {
-      failures.push(`${productionPaths.externalSecret}: ${key} must have exactly one 1Password mapping`)
+  forbidTerms(failures, productionPaths.externalSecret, files.externalSecret, [
+    'dataFrom:',
+    'kind: Secret',
+    'DISCORD_BOT_TOKEN',
+    'DISCORD_ALLOWED_USERS',
+  ])
+  if (
+    count(files.externalSecret, '    - secretKey: API_SERVER_KEY\n') !== 1 ||
+    count(files.externalSecret, '        key: hermes-runtime/API_SERVER_KEY\n') !== 1
+  ) {
+    failures.push(`${productionPaths.externalSecret}: API_SERVER_KEY must have exactly one 1Password mapping`)
+  }
+
+  requireTerms(failures, productionPaths.discordSealedSecret, files.discordSealedSecret, [
+    'apiVersion: bitnami.com/v1alpha1',
+    'kind: SealedSecret',
+    'name: hermes-discord-auth',
+    'namespace: hermes',
+    'argocd.argoproj.io/sync-wave: "-3"',
+    '  encryptedData:',
+    '  template:',
+    '    type: Opaque',
+  ])
+  forbidTerms(failures, productionPaths.discordSealedSecret, files.discordSealedSecret, [
+    'kind: Secret',
+    '\n  data:',
+    '\n  stringData:',
+    'sealedsecrets.bitnami.com/cluster-wide',
+    'sealedsecrets.bitnami.com/namespace-wide',
+  ])
+  const sealedDiscordKeys = [...files.discordSealedSecret.matchAll(/^    (DISCORD_[A-Z_]+): (\S+)$/gm)]
+  if (
+    sealedDiscordKeys.length !== 2 ||
+    sealedDiscordKeys
+      .map(([_, key]) => key)
+      .sort()
+      .join(',') !== 'DISCORD_ALLOWED_USERS,DISCORD_BOT_TOKEN'
+  ) {
+    failures.push(
+      `${productionPaths.discordSealedSecret}: encryptedData must contain exactly the Discord token and allowlist`,
+    )
+  }
+  for (const [_, key, ciphertext] of sealedDiscordKeys) {
+    if (!/^Ag[A-Za-z0-9+/=]{100,}$/.test(ciphertext)) {
+      failures.push(`${productionPaths.discordSealedSecret}: ${key} must contain non-placeholder sealed ciphertext`)
     }
   }
 
@@ -719,12 +766,21 @@ export function validateProductionContent(files: ProductionFiles): string[] {
   requireTerms(failures, productionPaths.runbook, cutoverSection, [
     'cleanup_discord_credentials() {',
     'trap cleanup_discord_credentials EXIT',
+    'kubeseal --raw --from-file=/dev/stdin',
+    '--namespace hermes --name hermes-discord-auth --scope strict',
+    'argocd/applications/hermes/discord-sealed-secret.yaml',
+    'kubeseal --validate --controller-name sealed-secrets --controller-namespace sealed-secrets',
+    '--resource bitnami.com:SealedSecret:hermes-discord-auth',
+    'wait sealedsecret/hermes-discord-auth --for=condition=Synced',
     '.channels.discord.token | select(type == "string" and length >= 20)',
     '.channels.discord.allowFrom[]?',
     '.channels.discord.guilds[]?.users[]?',
     'numeric Discord allowlist required',
     'test "${#discord_bot_token}" -ge 20',
     'case "$discord_allowed_users" in ""|,*|*,|*,,*|*[!0-9,]*) exit 1 ;; esac',
+    'test "$sealed_discord_bot_token" = "$discord_bot_token"',
+    'test "$sealed_discord_allowed_users" = "$discord_allowed_users"',
+    'test "$hermes_discord_ref_count" = 0',
     'test "$(systemctl --user show openclaw-gateway.service --property=KillMode --value)" = control-group',
     'systemctl --user stop openclaw-gateway.service',
     'test "$(systemctl --user is-active openclaw-gateway.service || true)" = inactive',
@@ -734,7 +790,7 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'Do not reuse the earlier archive.',
     'do not run Phase 2 step 5 because merged `main` now enables',
     'Keep the same Phase 2 shell and Lease open through',
-    'cutover step 5.',
+    'cutover step 4.',
     'if kubectl -n openclaw get clusterrolebinding openclaw-vm-cluster-admin >/dev/null 2>&1; then',
     'argocd app sync openclaw --prune \\\n       --resource rbac.authorization.k8s.io:ClusterRoleBinding:openclaw-vm-cluster-admin',
     'get clusterrolebinding openclaw-vm-cluster-admin --ignore-not-found -o name',
@@ -748,35 +804,25 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'jq -e \'.spec.runStrategy == "Halted" and (.spec | has("running") | not)\'',
     'argocd app sync openclaw --prune=false',
     'openclaw_vmi_name=$(kubectl -n openclaw get virtualmachineinstance openclaw --ignore-not-found -o name)',
-    'op item get --vault infra hermes-runtime --format json',
-    'jq --rawfile discord_bot_token <(printf \'%s\' "$discord_bot_token")',
-    '--rawfile discord_allowed_users <(printf \'%s\' "$discord_allowed_users")',
-    'def upsert_field($id; $type; $label; $value):',
-    'error("duplicate field: " + $label)',
-    'upsert_field("DISCORD_BOT_TOKEN"; "CONCEALED"; "DISCORD_BOT_TOKEN"; $discord_bot_token)',
-    'upsert_field("DISCORD_ALLOWED_USERS"; "STRING"; "DISCORD_ALLOWED_USERS"; $discord_allowed_users)',
-    'op item edit --vault infra hermes-runtime',
-    'jq -e --rawfile expected_discord_bot_token <(printf \'%s\' "$discord_bot_token")',
-    '--rawfile expected_discord_allowed_users <(printf \'%s\' "$discord_allowed_users")',
-    '.value == $expected_discord_bot_token',
-    '.value == $expected_discord_allowed_users',
-    '.label == "DISCORD_BOT_TOKEN"',
-    '.label == "DISCORD_ALLOWED_USERS"',
-    '| length == 1) and',
     'cleanup_discord_credentials',
     'Sync Hermes from merged `main` only after the OpenClaw VMI is gone',
-    'test "$discord_secret_keys" = API_SERVER_KEY,DISCORD_ALLOWED_USERS,DISCORD_BOT_TOKEN',
+    'test "$api_secret_keys" = API_SERVER_KEY',
+    'test "$discord_secret_keys" = DISCORD_ALLOWED_USERS,DISCORD_BOT_TOKEN',
     "rg -m1 '\\[discord\\] Connected as '",
   ])
   forbidTerms(failures, productionPaths.runbook, cutoverSection, [
     'argocd app sync openclaw --prune=true',
     'allow_all_users: true',
     'pgrep -f "[o]penclaw.*gateway"',
+    'op item ',
   ])
   if (cutoverSection.includes('kubectl -n openclaw wait virtualmachineinstance/openclaw --for=delete')) {
     failures.push(`${productionPaths.runbook}: cutover must treat an already-absent OpenClaw VMI as stopped`)
   }
-  const credentialCaptureIndex = cutoverSection.indexOf('discord_bot_token=$(virtctl ssh')
+  const sealedSecretStageIndex = cutoverSection.indexOf('--resource bitnami.com:SealedSecret:hermes-discord-auth')
+  const credentialCaptureIndex = cutoverSection.lastIndexOf('discord_bot_token=$(virtctl ssh')
+  const credentialMatchIndex = cutoverSection.indexOf('test "$sealed_discord_bot_token" = "$discord_bot_token"')
+  const noHermesDiscordRefIndex = cutoverSection.indexOf('test "$hermes_discord_ref_count" = 0')
   const openClawGatewayStopIndex = cutoverSection.indexOf('systemctl --user stop openclaw-gateway.service')
   const finalReconciliationIndex = cutoverSection.indexOf('repeat Phase 2 steps 1 through 4')
   const clusterAdminPruneIndex = cutoverSection.indexOf('argocd app sync openclaw --prune \\')
@@ -788,9 +834,8 @@ export function validateProductionContent(files: ProductionFiles): string[] {
   )
   const cutoverOpenClawSyncIndex = cutoverSection.indexOf('argocd app sync openclaw --prune=false')
   const openClawVmiAbsentIndex = cutoverSection.indexOf('if [ -z "$openclaw_vmi_name" ]')
-  const credentialTransferIndex = cutoverSection.indexOf('op item edit --vault infra hermes-runtime')
-  const credentialCleanupIndex = cutoverSection.lastIndexOf('\n   cleanup_discord_credentials\n')
-  const cutoverHermesSyncIndex = cutoverSection.indexOf('argocd app sync hermes --prune=false')
+  const credentialCleanupIndex = cutoverSection.indexOf('\n   cleanup_discord_credentials\n')
+  const cutoverHermesSyncIndex = cutoverSection.indexOf('\n   argocd app sync hermes --prune=false\n')
   const discordConnectedIndex = cutoverSection.indexOf("rg -m1 '\\[discord\\] Connected as '")
   const cutoverReleaseIndex = cutoverSection.lastIndexOf('\n   release_maintenance_lock\n')
   if (
@@ -803,17 +848,19 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     failures.push(`${productionPaths.runbook}: cutover must hold the migration Lease until Hermes is restored`)
   }
   if (
-    credentialCaptureIndex < 0 ||
-    openClawGatewayStopIndex <= credentialCaptureIndex ||
+    sealedSecretStageIndex < 0 ||
+    credentialCaptureIndex <= sealedSecretStageIndex ||
+    credentialMatchIndex <= credentialCaptureIndex ||
+    noHermesDiscordRefIndex <= credentialMatchIndex ||
+    openClawGatewayStopIndex <= noHermesDiscordRefIndex ||
+    credentialCleanupIndex <= openClawGatewayStopIndex ||
     finalReconciliationIndex <= openClawGatewayStopIndex ||
     clusterAdminPruneIndex <= finalReconciliationIndex ||
     clusterAdminAbsentIndex <= clusterAdminPruneIndex ||
     openClawRunStrategyTransitionIndex <= clusterAdminAbsentIndex ||
     cutoverOpenClawSyncIndex <= openClawRunStrategyTransitionIndex ||
     openClawVmiAbsentIndex <= cutoverOpenClawSyncIndex ||
-    credentialTransferIndex <= openClawVmiAbsentIndex ||
-    credentialCleanupIndex <= credentialTransferIndex ||
-    cutoverHermesSyncIndex <= credentialCleanupIndex ||
+    cutoverHermesSyncIndex <= openClawVmiAbsentIndex ||
     discordConnectedIndex <= cutoverHermesSyncIndex
   ) {
     failures.push(`${productionPaths.runbook}: Discord cutover operations are out of order`)


### PR DESCRIPTION
## Summary

- move Hermes Discord token and allowlist delivery from the API ExternalSecret to a strict name- and namespace-bound SealedSecret
- stage and exactly verify the Discord Secret while live Hermes remains API-only, then preserve the fail-closed single-writer cutover order
- extend production validation to reject plaintext, broad SealedSecret scope, mixed API/Discord secret ownership, and unsafe sync ordering
- keep the existing API key on its ExternalSecret and retain all OpenClaw rollback assets

## Related Issues

None

## Testing

- `bun test scripts/hermes/*.test.ts` (92 passed)
- `bunx oxfmt --check scripts/hermes/validate-production.ts scripts/hermes/validate-production.test.ts`
- `bun run lint:argocd` (0 invalid, 0 errors)
- `kustomize build --enable-helm argocd/applications/hermes | kubectl apply -n hermes --dry-run=server -f -`
- `kubeseal --validate --controller-name sealed-secrets --controller-namespace sealed-secrets < argocd/applications/hermes/discord-sealed-secret.yaml`
- verified the source Discord token is absent from the worktree without printing it
- verified OpenClaw remains active, live Hermes has zero Discord credential refs, and the SealedSecret is not yet live

## Breaking Changes

None. The Hermes application is manual and remains unsynced; the live writer is unchanged until the ordered cutover.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
