### PR TITLE
feat(signal): bind authoritative Bayn universe

### DIFF
--- a/.github/workflows/bayn-release.yml
+++ b/.github/workflows/bayn-release.yml
@@ -8,12 +8,30 @@ on:
       - completed
 
 concurrency:
-  group: bayn-release
+  group: >-
+    bayn-release-${{
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      (
+        github.event.workflow_run.event == 'push' ||
+        github.event.workflow_run.event == 'workflow_dispatch'
+      ) &&
+      'current' ||
+      github.event.workflow_run.id
+    }}
   cancel-in-progress: true
 
 jobs:
   promote:
-    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main'
+    if: >-
+      ${{
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.head_branch == 'main' &&
+        (
+          github.event.workflow_run.event == 'push' ||
+          github.event.workflow_run.event == 'workflow_dispatch'
+        )
+      }}
     runs-on: arc-arm64
     permissions:
       actions: read

--- a/.github/workflows/signal-publisher-release.yml
+++ b/.github/workflows/signal-publisher-release.yml
@@ -8,12 +8,30 @@ on:
       - completed
 
 concurrency:
-  group: signal-publisher-release
+  group: >-
+    signal-publisher-release-${{
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      (
+        github.event.workflow_run.event == 'push' ||
+        github.event.workflow_run.event == 'workflow_dispatch'
+      ) &&
+      'current' ||
+      github.event.workflow_run.id
+    }}
   cancel-in-progress: true
 
 jobs:
   promote:
-    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main'
+    if: >-
+      ${{
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.head_branch == 'main' &&
+        (
+          github.event.workflow_run.event == 'push' ||
+          github.event.workflow_run.event == 'workflow_dispatch'
+        )
+      }}
     runs-on: arc-arm64
     permissions:
       actions: read

--- a/.github/workflows/signal-publisher-release.yml
+++ b/.github/workflows/signal-publisher-release.yml
@@ -8,7 +8,7 @@ on:
       - completed
 
 concurrency:
-  group: signal-publisher-release-${{ github.event.workflow_run.head_sha }}
+  group: signal-publisher-release
   cancel-in-progress: true
 
 jobs:
@@ -95,17 +95,20 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}
-          branch: codex/signal-publisher-release-${{ steps.release.outputs.tag }}
+          branch: codex/signal-publisher-release-current
           base: main
+          delete-branch: true
           title: 'chore(signal): promote publisher ${{ steps.release.outputs.tag }}'
           commit-message: 'chore(signal): promote publisher ${{ steps.release.outputs.tag }}'
           add-paths: |
             argocd/applications/torghut/clickhouse/kustomization.yaml
             argocd/applications/torghut/clickhouse/signal-publisher-cronjob.yaml
+            argocd/applications/torghut/clickhouse/signal-publisher-bayn-v1-backfill-job.yaml
           body: |
             ## Summary
 
-            Promote the immutable Signal adjusted-daily publisher image and activate its GitOps CronJob.
+            Pin the immutable Signal adjusted-daily publisher image and writer provenance. Both writers remain inert;
+            the reviewed rollout first runs the one-shot backfill alone, then removes it and enables the daily schedule.
 
             - Source commit: `${{ steps.release.outputs.source_sha }}`
             - Image tag: `${{ steps.release.outputs.tag }}`
@@ -113,7 +116,7 @@ jobs:
 
             ## Related Issues
 
-            PROOMPT-357
+            PROOMPT-393
 
             ## Testing
 
@@ -125,7 +128,7 @@ jobs:
 
             ## Breaking Changes
 
-            Adds a bounded, idempotent daily publisher. It has no broker or capital authority.
+            Pins a bounded publisher without activating a writer. It has no broker or capital authority.
 
             ## Checklist
 

--- a/.github/workflows/torghut-ws-release.yml
+++ b/.github/workflows/torghut-ws-release.yml
@@ -22,7 +22,22 @@ on:
         type: string
 
 concurrency:
-  group: torghut-ws-release
+  group: >-
+    torghut-ws-release-${{
+      (
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.head_branch == 'main' &&
+          (
+            github.event.workflow_run.event == 'push' ||
+            github.event.workflow_run.event == 'workflow_dispatch'
+          )
+        )
+      ) &&
+      'current' ||
+      github.run_id
+    }}
   cancel-in-progress: true
 
 jobs:
@@ -30,7 +45,14 @@ jobs:
     if: >-
       ${{
         github.event_name == 'workflow_dispatch' ||
-        (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main')
+        (
+          github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.head_branch == 'main' &&
+          (
+            github.event.workflow_run.event == 'push' ||
+            github.event.workflow_run.event == 'workflow_dispatch'
+          )
+        )
       }}
     runs-on: arc-arm64
     permissions:

--- a/.github/workflows/torghut-ws-release.yml
+++ b/.github/workflows/torghut-ws-release.yml
@@ -22,7 +22,7 @@ on:
         type: string
 
 concurrency:
-  group: torghut-ws-release-${{ github.event.workflow_run.head_sha || inputs.commit_sha || github.ref }}
+  group: torghut-ws-release
   cancel-in-progress: true
 
 jobs:
@@ -270,7 +270,7 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}
-          branch: codex/torghut-ws-release-${{ steps.meta.outputs.tag }}
+          branch: codex/torghut-ws-release-current
           base: main
           title: 'chore(torghut): promote ws image ${{ steps.meta.outputs.tag }}'
           commit-message: 'chore(torghut): promote ws image ${{ steps.meta.outputs.tag }}'

--- a/argocd/applications/torghut/clickhouse/bayn-universe-v1-configmap.yaml
+++ b/argocd/applications/torghut/clickhouse/bayn-universe-v1-configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bayn-universe-v1
+  namespace: torghut
+  labels:
+    app.kubernetes.io/name: bayn-universe
+    app.kubernetes.io/part-of: bayn
+  annotations:
+    bayn.proompteng.ai/contract: equity-infrastructure-v1
+data:
+  UNIVERSE_ID: equity-infrastructure-v1
+  UNIVERSE_SYMBOLS: AMD,AVGO,COHR,CRDO,LITE,MRVL,MU,NVDA,WDC
+  UNIVERSE_SYMBOL_HASH: ddcc8adc04dc29822969cddf02b821ea8110856162cca20a7ff28c1c43263e18
+  HISTORY_START_DATE: "2022-01-27"
+  HISTORY_FEED: sip

--- a/argocd/applications/torghut/clickhouse/clickhouse-cluster.yaml
+++ b/argocd/applications/torghut/clickhouse/clickhouse-cluster.yaml
@@ -125,6 +125,7 @@ spec:
         - GRANT SELECT ON signal.adjusted_daily_bars_v2
         - GRANT SELECT ON signal.exchange_sessions_v1
         - GRANT SELECT ON signal.snapshot_manifests_v1
+        - GRANT SELECT ON signal.snapshot_manifests_v2
       signal_publisher/password_sha256_hex:
         valueFrom:
           secretKeyRef:
@@ -140,6 +141,7 @@ spec:
         - GRANT SELECT, INSERT ON signal.adjusted_daily_bars_v2
         - GRANT SELECT, INSERT ON signal.exchange_sessions_v1
         - GRANT SELECT, INSERT ON signal.snapshot_manifests_v1
+        - GRANT SELECT, INSERT ON signal.snapshot_manifests_v2
       default/password_sha256_hex:
         valueFrom:
           secretKeyRef:

--- a/argocd/applications/torghut/clickhouse/kustomization.yaml
+++ b/argocd/applications/torghut/clickhouse/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - clickhouse-service.yaml
   - ta-replicated-table-migration-job.yaml
   - signal-schema-job.yaml
+  - bayn-universe-v1-configmap.yaml
   - signal-publisher-cronjob.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/signal-publisher

--- a/argocd/applications/torghut/clickhouse/signal-publisher-bayn-v1-backfill-job.yaml
+++ b/argocd/applications/torghut/clickhouse/signal-publisher-bayn-v1-backfill-job.yaml
@@ -1,0 +1,123 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: signal-adjusted-daily-bayn-v1-backfill
+  namespace: torghut
+  labels:
+    app.kubernetes.io/name: signal-adjusted-daily-publisher
+    app.kubernetes.io/part-of: signal
+  annotations:
+    argocd.argoproj.io/sync-wave: "5"
+spec:
+  suspend: true
+  backoffLimit: 1
+  activeDeadlineSeconds: 900
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: signal-adjusted-daily-publisher
+        app.kubernetes.io/part-of: signal
+        bayn.proompteng.ai/universe: equity-infrastructure-v1
+    spec:
+      automountServiceAccountToken: false
+      nodeSelector:
+        kubernetes.io/arch: arm64
+      restartPolicy: Never
+      serviceAccountName: torghut-runtime
+      securityContext:
+        fsGroup: 65532
+        runAsGroup: 65532
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: publish
+          image: registry.ide-newton.ts.net/lab/signal-publisher:bootstrap
+          imagePullPolicy: IfNotPresent
+          args:
+            - backfill
+            - --start
+            - "2022-01-27"
+            - --end
+            - "2026-07-20"
+          env:
+            - name: SIGNAL_UNIVERSE_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: bayn-universe-v1
+                  key: UNIVERSE_ID
+            - name: SIGNAL_UNIVERSE_SYMBOL_HASH
+              valueFrom:
+                configMapKeyRef:
+                  name: bayn-universe-v1
+                  key: UNIVERSE_SYMBOL_HASH
+            - name: SIGNAL_SYMBOLS
+              valueFrom:
+                configMapKeyRef:
+                  name: bayn-universe-v1
+                  key: UNIVERSE_SYMBOLS
+            - name: SIGNAL_START_DATE
+              valueFrom:
+                configMapKeyRef:
+                  name: bayn-universe-v1
+                  key: HISTORY_START_DATE
+            - name: SIGNAL_ALPACA_FEED
+              valueFrom:
+                configMapKeyRef:
+                  name: bayn-universe-v1
+                  key: HISTORY_FEED
+            - name: SIGNAL_CODE_REVISION
+              value: "01ac72aafca390609885c2093236f4a10dd14a32"
+            - name: SIGNAL_IMAGE_REPOSITORY
+              value: registry.ide-newton.ts.net/lab/signal-publisher
+            - name: SIGNAL_IMAGE_DIGEST
+              value: sha256:8f573122837bdc97ee90c3054b266606fcb2a269ea4edee0ff1e81bb641bebda
+            - name: SIGNAL_CLICKHOUSE_URL
+              value: http://torghut-clickhouse.torghut.svc.cluster.local:8123
+            - name: SIGNAL_CLICKHOUSE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: signal-publisher-clickhouse-auth
+                  key: username
+            - name: SIGNAL_CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: signal-publisher-clickhouse-auth
+                  key: password
+            - name: APCA_API_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: torghut-alpaca
+                  key: APCA_API_KEY_ID
+            - name: APCA_API_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: torghut-alpaca
+                  key: APCA_API_SECRET_KEY
+            - name: SIGNAL_CALENDAR_VERSION
+              value: alpaca-us-equity-calendar-v1
+            - name: SIGNAL_FINALIZATION_LAG_MINUTES
+              value: "90"
+            - name: SIGNAL_OPERATION_TIMEOUT_MS
+              value: "60000"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: "1"
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 128Mi

--- a/argocd/applications/torghut/clickhouse/signal-publisher-cronjob.yaml
+++ b/argocd/applications/torghut/clickhouse/signal-publisher-cronjob.yaml
@@ -13,7 +13,7 @@ spec:
   timeZone: America/New_York
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 3600
-  suspend: false
+  suspend: true
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   jobTemplate:
@@ -46,6 +46,31 @@ spec:
               args:
                 - daily
               env:
+                - name: SIGNAL_UNIVERSE_ID
+                  valueFrom:
+                    configMapKeyRef:
+                      name: bayn-universe-v1
+                      key: UNIVERSE_ID
+                - name: SIGNAL_UNIVERSE_SYMBOL_HASH
+                  valueFrom:
+                    configMapKeyRef:
+                      name: bayn-universe-v1
+                      key: UNIVERSE_SYMBOL_HASH
+                - name: SIGNAL_SYMBOLS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: bayn-universe-v1
+                      key: UNIVERSE_SYMBOLS
+                - name: SIGNAL_START_DATE
+                  valueFrom:
+                    configMapKeyRef:
+                      name: bayn-universe-v1
+                      key: HISTORY_START_DATE
+                - name: SIGNAL_ALPACA_FEED
+                  valueFrom:
+                    configMapKeyRef:
+                      name: bayn-universe-v1
+                      key: HISTORY_FEED
                 - name: SIGNAL_CODE_REVISION
                   value: "01ac72aafca390609885c2093236f4a10dd14a32"
                 - name: SIGNAL_IMAGE_REPOSITORY
@@ -74,12 +99,6 @@ spec:
                     secretKeyRef:
                       name: torghut-alpaca
                       key: APCA_API_SECRET_KEY
-                - name: SIGNAL_SYMBOLS
-                  value: DBC,EEM,EFA,GLD,IEF,SPY,TLT,VNQ
-                - name: SIGNAL_START_DATE
-                  value: "2017-01-01"
-                - name: SIGNAL_ALPACA_FEED
-                  value: sip
                 - name: SIGNAL_CALENDAR_VERSION
                   value: alpaca-us-equity-calendar-v1
                 - name: SIGNAL_FINALIZATION_LAG_MINUTES

--- a/argocd/applications/torghut/clickhouse/signal-schema-job.yaml
+++ b/argocd/applications/torghut/clickhouse/signal-schema-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: signal-adjusted-daily-schema-v1
+  name: signal-adjusted-daily-schema-v2
   namespace: torghut
   labels:
     app.kubernetes.io/name: signal-adjusted-daily-schema
@@ -119,12 +119,43 @@ spec:
                   '{replica}'
                 )
                 ORDER BY snapshot_id;
+
+                CREATE TABLE IF NOT EXISTS signal.snapshot_manifests_v2 ON CLUSTER default
+                (
+                  snapshot_id String,
+                  schema_version LowCardinality(String),
+                  publisher_source_revision FixedString(40),
+                  publisher_image_repository String,
+                  publisher_image_digest FixedString(71),
+                  universe_id LowCardinality(String),
+                  universe_symbol_hash FixedString(64),
+                  provider LowCardinality(String),
+                  source_feed LowCardinality(String),
+                  adjustment LowCardinality(String),
+                  calendar_version LowCardinality(String),
+                  requested_start Date,
+                  publication_asof Date,
+                  first_session Date,
+                  last_session Date,
+                  symbol_count UInt32,
+                  session_count UInt32,
+                  bar_count UInt64,
+                  bars_content_hash FixedString(64),
+                  sessions_content_hash FixedString(64),
+                  manifest_content_hash FixedString(64),
+                  finalized_at DateTime64(3, 'UTC')
+                )
+                ENGINE = ReplicatedMergeTree(
+                  '/clickhouse/tables/{cluster}/{shard}/signal_snapshot_manifests_v2',
+                  '{replica}'
+                )
+                ORDER BY snapshot_id;
               "
 
               "${client[@]}" --query "
                 SELECT throwIf(
-                  count() != 3
-                    OR countIf(engine = 'ReplicatedMergeTree') != 3
+                  count() != 4
+                    OR countIf(engine = 'ReplicatedMergeTree') != 4
                     OR countIf(
                       name = 'adjusted_daily_bars_v2'
                       AND sorting_key = 'snapshot_id, symbol, session_date'
@@ -139,12 +170,22 @@ spec:
                       name = 'snapshot_manifests_v1'
                       AND sorting_key = 'snapshot_id'
                       AND partition_key = ''
+                    ) != 1
+                    OR countIf(
+                      name = 'snapshot_manifests_v2'
+                      AND sorting_key = 'snapshot_id'
+                      AND partition_key = ''
                     ) != 1,
                   'Signal snapshot schema is incomplete or has the wrong engine'
                 )
                 FROM system.tables
                 WHERE database = 'signal'
-                  AND name IN ('adjusted_daily_bars_v2', 'exchange_sessions_v1', 'snapshot_manifests_v1')
+                  AND name IN (
+                    'adjusted_daily_bars_v2',
+                    'exchange_sessions_v1',
+                    'snapshot_manifests_v1',
+                    'snapshot_manifests_v2'
+                  )
               "
 
               "${client[@]}" --query "
@@ -190,15 +231,42 @@ spec:
                     'snapshot_manifests_v1.bars_content_hash:FixedString(64)',
                     'snapshot_manifests_v1.sessions_content_hash:FixedString(64)',
                     'snapshot_manifests_v1.manifest_content_hash:FixedString(64)',
-                    'snapshot_manifests_v1.finalized_at:DateTime64(3, \'UTC\')'
+                    'snapshot_manifests_v1.finalized_at:DateTime64(3, \'UTC\')',
+                    'snapshot_manifests_v2.snapshot_id:String',
+                    'snapshot_manifests_v2.schema_version:LowCardinality(String)',
+                    'snapshot_manifests_v2.publisher_source_revision:FixedString(40)',
+                    'snapshot_manifests_v2.publisher_image_repository:String',
+                    'snapshot_manifests_v2.publisher_image_digest:FixedString(71)',
+                    'snapshot_manifests_v2.universe_id:LowCardinality(String)',
+                    'snapshot_manifests_v2.universe_symbol_hash:FixedString(64)',
+                    'snapshot_manifests_v2.provider:LowCardinality(String)',
+                    'snapshot_manifests_v2.source_feed:LowCardinality(String)',
+                    'snapshot_manifests_v2.adjustment:LowCardinality(String)',
+                    'snapshot_manifests_v2.calendar_version:LowCardinality(String)',
+                    'snapshot_manifests_v2.requested_start:Date',
+                    'snapshot_manifests_v2.publication_asof:Date',
+                    'snapshot_manifests_v2.first_session:Date',
+                    'snapshot_manifests_v2.last_session:Date',
+                    'snapshot_manifests_v2.symbol_count:UInt32',
+                    'snapshot_manifests_v2.session_count:UInt32',
+                    'snapshot_manifests_v2.bar_count:UInt64',
+                    'snapshot_manifests_v2.bars_content_hash:FixedString(64)',
+                    'snapshot_manifests_v2.sessions_content_hash:FixedString(64)',
+                    'snapshot_manifests_v2.manifest_content_hash:FixedString(64)',
+                    'snapshot_manifests_v2.finalized_at:DateTime64(3, \'UTC\')'
                   ]),
-                  'Signal snapshot columns do not match the v1 contract'
+                  'Signal snapshot columns do not match the publication contracts'
                 )
                 FROM (
                   SELECT concat(table, '.', name, ':', type) AS signature
                   FROM system.columns
                   WHERE database = 'signal'
-                    AND table IN ('adjusted_daily_bars_v2', 'exchange_sessions_v1', 'snapshot_manifests_v1')
+                    AND table IN (
+                      'adjusted_daily_bars_v2',
+                      'exchange_sessions_v1',
+                      'snapshot_manifests_v1',
+                      'snapshot_manifests_v2'
+                    )
                 )
               "
           env:

--- a/argocd/applications/torghut/ws/configmap.yaml
+++ b/argocd/applications/torghut/ws/configmap.yaml
@@ -17,9 +17,8 @@ data:
   # Keep universe size capped at 12 to preserve headroom and avoid 405 symbol-limit failures.
   ALPACA_MARKET_DATA_CHANNELS: "trades,quotes,bars,updatedBars"
   OPTIONS_MARKET_HOLIDAYS: "2026-01-01,2026-01-19,2026-02-16,2026-04-03,2026-05-25,2026-06-19,2026-07-03,2026-09-07,2026-11-26,2026-12-25"
-  # Static executable universe; the live trading loop must not depend on Jangar.
-  SYMBOLS: "NVDA,AVGO,AMD,MU,MRVL,CRDO,COHR,LITE,SNDK,WDC"
-  SYMBOLS_ALLOWLIST: "NVDA,AVGO,AMD,MU,MRVL,CRDO,COHR,LITE,SNDK,WDC"
+  # The exact static universe is supplied by bayn-universe-v1 in deployment.yaml.
+  # The live market-data path must not depend on Jangar.
   SYMBOLS_POLL_INTERVAL_MS: "30000"
   SUBSCRIBE_BATCH_SIZE: "200"
   SHARD_COUNT: "1"

--- a/argocd/applications/torghut/ws/deployment.yaml
+++ b/argocd/applications/torghut/ws/deployment.yaml
@@ -37,6 +37,26 @@ spec:
             - configMapRef:
                 name: torghut-ws-config
           env:
+            - name: SYMBOLS
+              valueFrom:
+                configMapKeyRef:
+                  name: bayn-universe-v1
+                  key: UNIVERSE_SYMBOLS
+            - name: SYMBOLS_ALLOWLIST
+              valueFrom:
+                configMapKeyRef:
+                  name: bayn-universe-v1
+                  key: UNIVERSE_SYMBOLS
+            - name: MARKET_DATA_UNIVERSE_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: bayn-universe-v1
+                  key: UNIVERSE_ID
+            - name: MARKET_DATA_UNIVERSE_SYMBOL_HASH
+              valueFrom:
+                configMapKeyRef:
+                  name: bayn-universe-v1
+                  key: UNIVERSE_SYMBOL_HASH
             - name: ALPACA_KEY_ID
               valueFrom:
                 secretKeyRef:

--- a/docs/bayn/architecture.md
+++ b/docs/bayn/architecture.md
@@ -14,10 +14,11 @@ is replaced incrementally before any paper mutation work begins.
 ## Critical path
 
 1. A Signal-owned publisher captures adjusted daily bars and exchange sessions into an immutable snapshot and writes
-   its manifest last. Historical and daily modes use the same validation and finalization path.
-2. The runtime's dedicated ClickHouse identity has `SELECT` only. The Effect ClickHouse client reads one configured
-   manifest and its rows from the fixed `snapshot_manifests_v1`, `exchange_sessions_v1`, and `adjusted_daily_bars_v2`
-   tables using typed parameters and sequentially consistent reads.
+   its manifest last. Historical and daily modes use the same validation and finalization path. V2 manifests also bind
+   the authoritative universe ID and canonical symbol hash.
+2. The runtime's dedicated ClickHouse identity has `SELECT` only. The currently pinned TSMOM evidence reads V1
+   manifests; the staged universe publication uses `snapshot_manifests_v2`, `exchange_sessions_v1`, and
+   `adjusted_daily_bars_v2`. A later strategy integration must explicitly move Bayn to that V2 contract.
 3. Bayn reproduces the publisher's manifest, session, bar, and snapshot hashes; rejects mixed, duplicate, unexpected,
    incomplete, future, or out-of-bound input; and emits a bounded immutable input manifest.
 4. The committed `tsmom-v1` protocol forms signals at month-end close and executes at the next common session open.
@@ -35,8 +36,9 @@ broker secret, or Kubernetes API token. `maxSurge: 0` prevents overlapping runti
 
 ## Reproducibility
 
-The executable embeds its full source revision, OCI repository, and a behavior hash derived from the reviewed strategy
-and hashing sources. Startup strictly decodes the committed TSMOM parameter JSON, hashes the decoded value with
+The executable embeds its full source revision, OCI repository, and the versioned selected-strategy behavior identity.
+The TSMOM identity is guarded by a deterministic evaluator fingerprint so behavior-preserving refactors do not break a
+pinned qualification. Startup strictly decodes the committed TypeScript protocol, hashes the decoded value with
 canonical JSON, and refuses to run when configured source/repository attribution differs from the embedded build.
 GitOps supplies the immutable image-index digest after publication. Status and the in-memory evidence envelope expose
 all of those facts and their contract versions.

--- a/docs/bayn/authoritative-universe.md
+++ b/docs/bayn/authoritative-universe.md
@@ -1,0 +1,166 @@
+# Bayn authoritative universe
+
+Status: **selected; deployment proof pending**
+
+Last verified: 2026-07-21
+
+## Decision
+
+`equity-infrastructure-v1` contains these executable symbols, in canonical order:
+
+```text
+AMD,AVGO,COHR,CRDO,LITE,MRVL,MU,NVDA,WDC
+```
+
+The candidate pool was the fixed production websocket universe. Selection used only availability, history, feed, and
+capacity facts before any candidate return series was read. `SNDK` is the sole exclusion because it has only 358
+adjusted daily sessions; the unchanged research gate requires 252 warm-up sessions plus at least 504 evaluation
+sessions.
+
+The procedure is deterministic: admit every common stock in the fixed pool that is active, tradable, supported by
+both required feeds, has the required common history, and passes the capacity floor. All nine eligible instruments are
+selected, so no performance ranking or tie-breaker exists. There are no leveraged or inverse products. Alpaca's US
+equity calendar defines sessions and `adjustment=all` defines corporate-action handling. There is no automatic
+substitution; an addition, removal, calendar change, or adjustment change requires a new universe ID, symbol hash, and
+qualification record.
+
+The ETF universe from `PROOMPT-392` is abandoned. It was inherited without a selection procedure and is absent from
+the websocket subscription. Its image must not be promoted, deployed, or qualified. The runtime composition root
+remains on the previously deployed TSMOM implementation until a strategy for `equity-infrastructure-v1` is separately
+implemented and precommitted. This containment does not approve TSMOM or its ETF universe.
+
+## Pre-return eligibility evidence
+
+Evidence was read from the configured Alpaca Basic account on 2026-07-21. Delayed consolidated SIP adjusted daily bars
+provide history and execution-capacity screening after the account's 15-minute restriction; the live websocket
+provides real-time IEX observations. Every selected instrument is active, tradable, and already acknowledged on the
+production IEX websocket. The same live asset probe reported every selected symbol as a fractionable, marginable,
+shortable US equity; these flags are descriptive eligibility facts, not strategy inputs.
+
+At $1,000,000 simulated capital and a 35% per-symbol cap, the largest planned one-day order is $350,000. The committed
+capacity rule limits that amount to 1% of trailing-252-session fifth-percentile consolidated daily dollar volume, so a
+symbol must provide at least $35,000,000.
+
+| Symbol | Selected | SIP sessions through 2026-07-20 | First session | SIP p05 daily dollar volume | Reason               |
+| ------ | -------- | ------------------------------: | ------------- | --------------------------: | -------------------- |
+| AMD    | yes      |                           1,122 | 2022-01-27    |                     $4.909B | Eligible             |
+| AVGO   | yes      |                           1,122 | 2022-01-27    |                     $4.418B | Eligible             |
+| COHR   | yes      |                           1,122 | 2022-01-27    |                     $261.9M | Eligible             |
+| CRDO   | yes      |                           1,122 | 2022-01-27    |                     $384.4M | Eligible             |
+| LITE   | yes      |                           1,122 | 2022-01-27    |                     $262.7M | Eligible             |
+| MRVL   | yes      |                           1,122 | 2022-01-27    |                     $769.6M | Eligible             |
+| MU     | yes      |                           1,122 | 2022-01-27    |                     $1.819B | Eligible             |
+| NVDA   | yes      |                           1,122 | 2022-01-27    |                    $22.183B | Eligible             |
+| WDC    | yes      |                           1,122 | 2022-01-27    |                     $408.8M | Eligible             |
+| SNDK   | no       |                             358 | 2025-02-13    |                      $76.4M | Insufficient history |
+
+All nine selected symbols share the same 1,122 complete sessions and have 870 sessions after the 252-session warm-up,
+exceeding the 504-session minimum. No symbol was included or excluded using strategy performance.
+
+Every selected symbol has both the executable and reference role: it must exist in the live producer and the finalized
+historical publication, with no reference-only substitute. The following operational exposure labels were committed
+without consulting candidate returns and exist only to make concentration visible:
+
+| Symbol | Non-return exposure role          | Decision reason                                      |
+| ------ | --------------------------------- | ---------------------------------------------------- |
+| AMD    | compute processors                | complete history, supported feeds, capacity pass     |
+| AVGO   | networking and custom silicon     | complete history, supported feeds, capacity pass     |
+| COHR   | optical components                | complete history, supported feeds, capacity pass     |
+| CRDO   | high-speed connectivity silicon   | complete history, supported feeds, capacity pass     |
+| LITE   | optical components                | complete history, supported feeds, capacity pass     |
+| MRVL   | networking and storage silicon    | complete history, supported feeds, capacity pass     |
+| MU     | memory                            | complete history, supported feeds, capacity pass     |
+| NVDA   | accelerated compute               | complete history, supported feeds, capacity pass     |
+| WDC    | data storage                      | complete history, supported feeds, capacity pass     |
+| SNDK   | flash storage                     | excluded: only 358 adjusted daily sessions           |
+
+## Pre-rollout production baseline
+
+Read-only verification at 2026-07-21T09:20:51Z found one healthy websocket pod and one Alpaca connection. Alpaca had
+acknowledged the legacy ten-symbol set, including `SNDK`, on trades, quotes, bars, and updated bars. The scheduled V1
+Signal publisher was active. Both ClickHouse replicas agreed on two finalized V1 manifests; the latest snapshot
+`0e3188062fb6781f9dfdc048b4bfe9846d8f4ce74c5e429e296e3ebcd75e93a5` contains 2,398 sessions and 19,184 bars for
+the eight legacy ETFs `DBC,EEM,EFA,GLD,IEF,SPY,TLT,VNQ` through 2026-07-20. Neither producer nor database therefore
+matches the selected universe yet.
+
+## Data contract
+
+- `argocd/applications/torghut/clickhouse/bayn-universe-v1-configmap.yaml` is the versioned selection artifact.
+- The Git commit containing this document and ConfigMap is the immutable eligibility record. Runtime identity is the
+  universe ID plus canonical symbol hash; neither is inferred from a mutable database row.
+- The ConfigMap binds universe ID `equity-infrastructure-v1` to canonical symbol hash
+  `ddcc8adc04dc29822969cddf02b821ea8110856162cca20a7ff28c1c43263e18`.
+- The production websocket remains the live IEX producer. `SYMBOLS` and `SYMBOLS_ALLOWLIST` both reference the exact
+  nine-symbol ConfigMap value; a subset, superset, reorder, duplicate, or Jangar override fails startup.
+- The Signal publisher uses delayed consolidated SIP and the exact nine-symbol set. A bounded REST backfill supplies
+  history that a live websocket cannot provide; daily publications run after the Basic plan's 15-minute delay and use
+  the same validation and immutable `snapshot_manifests_v2` finalization path. Every manifest binds the universe ID and
+  symbol hash.
+- The later Bayn strategy integration must accept only a finalized V2 manifest whose universe ID, symbol hash, feed,
+  adjustment, calendar, bounds, and canonical symbols match the compiled strategy. A superset, subset, duplicate,
+  mixed feed, or missing session must fail closed. This rollout does not change Bayn's current pinned V1 evidence.
+- Historical and live events retain their transport and feed identity. Delayed SIP REST history is not relabeled as
+  real-time IEX websocket data.
+- Live envelopes preserve provider source, feed, provider event time, ingestion time, and updated-bar corrections.
+  Historical reconciliation is the exact replica readback and content-hash check performed before V2 finalization.
+
+The websocket itself is not the current latency bottleneck. A read-only production check at 2026-07-21 08:44 UTC
+measured about 32 milliseconds from the latest trade/bar event to Kafka, while the latest selected-symbol rows reached
+`ta_microbars` and `ta_signals` 14.2-35.9 seconds after event time. Those derived ClickHouse tables are therefore not
+an execution-price source. The first Bayn strategy remains finalized-daily; later order routing must consume a fresh
+websocket/Kafka quote or prove a materially tighter downstream bound.
+
+## Alpaca Basic coverage boundary
+
+Live authentication probes confirmed the account can use real-time `iex`, 15-minute-delayed `delayed_sip`, and the
+derived `overnight` feed. Real-time `sip` and `boats` authentication are not included. The active production IEX socket
+also occupies the account's single connection for that feed. The Basic plan permits 30 equity websocket symbols and
+200 historical requests per minute.
+
+The configured paper account's asset responses returned every selected symbol as active, tradable, and fractionable,
+but did not expose a non-null `overnight_tradable` field. Overnight eligibility is therefore unproven here and must be
+measured by `PROOMPT-396`, not inferred. The free overnight feed provides indicative real-time quotes and latest bars,
+but its trades are delayed 15 minutes; delayed BOATS history is available through REST. It may be added for observation
+and research, but it cannot become execution-price authority. Real-time consolidated pre-market and after-hours pricing
+requires Alpaca Algo Trader Plus. Any extended or overnight order path is a later authority change and must use
+supported limit-order semantics; this milestone submits no orders. The external contract is documented in Alpaca's
+[market-data plan matrix](https://docs.alpaca.markets/us/docs/about-market-data-api),
+[24/5 feed specification](https://docs.alpaca.markets/us/docs/245-trading-for-trading-api), and
+[extended-hours order rules](https://docs.alpaca.markets/us/docs/orders-at-alpaca).
+
+## Rollout and proof
+
+1. Merge the versioned ConfigMap, additive schema, websocket wiring, suspended CronJob, and dormant backfill template.
+   The backfill Job is not yet a rendered resource, so this phase cannot write Signal data.
+2. Promote immutable websocket and publisher images. Promotion pins source revisions and digests but leaves both Signal
+   writers inert.
+3. Through a reviewed GitOps change, add and start only the one-shot backfill Job while the CronJob remains suspended.
+   Require it to finalize exactly one SIP/all snapshot for all nine symbols from 2022-01-27 through
+   2026-07-20: 1,122 sessions and 10,098 bars.
+4. Reproduce the manifest, session, and bar hashes from both ClickHouse replicas and prove one manifest row whose
+   universe ID and symbol hash match the ConfigMap.
+5. Confirm websocket readiness reports the same universe ID, hash, and exact symbols, and that Alpaca acknowledged all
+   nine symbols on trades, quotes, bars, and updated bars.
+6. Remove the completed one-shot Job and enable the daily CronJob in one GitOps change. Never render both writers as
+   active. Retain two successful scheduled publications before declaring the publication lane stable.
+
+Rollback is fail-closed: suspend the active writer, preserve every finalized or partially staged row, and revert only
+after no Job is active. Bayn remains pinned to its existing rejected TSMOM evidence; this data rollout neither deploys
+a new strategy nor grants broker or capital authority.
+
+## Read-only ClickHouse proof
+
+After publication, the following aggregate must return nine rows with 1,122 sessions and a common 2022-01-27 through
+2026-07-20 range:
+
+```sql
+SELECT
+  symbol,
+  count() AS sessions,
+  min(session_date) AS first_session,
+  max(session_date) AS last_session
+FROM signal.adjusted_daily_bars_v2
+WHERE snapshot_id = '<finalized-snapshot-id>'
+GROUP BY symbol
+ORDER BY symbol;
+```

--- a/docs/bayn/signal-adjusted-daily-publications.md
+++ b/docs/bayn/signal-adjusted-daily-publications.md
@@ -6,8 +6,9 @@ program, not a long-running service. Its immutable image supports two commands:
 - `daily`: select the latest Alpaca exchange session whose close is at least the configured lag in the past.
 - `backfill --start YYYY-MM-DD --end YYYY-MM-DD`: publish one explicitly bounded historical capture.
 
-Both commands fetch the Alpaca calendar and paginated consolidated SIP bars, runtime-decode every response, and apply
-the same domain validation. The daily GitOps CronJob runs at 18:30 `America/New_York`, forbids overlap, and uses
+Both commands fetch the Alpaca calendar and paginated bars from the explicitly configured feed, runtime-decode every
+response, and apply the same domain validation. Production uses consolidated SIP only after Alpaca's Basic-plan
+15-minute delay has elapsed. The daily GitOps CronJob runs at 18:30 `America/New_York`, forbids overlap, and uses
 deterministic insert deduplication. Its historical query ends at the earlier of the session-date boundary or 15 minutes
 before invocation, satisfying Alpaca's Basic-plan delay without admitting an unfinished session. Publisher writes
 require both ClickHouse replicas to acknowledge each insert, and readback uses sequential consistency before the
@@ -23,10 +24,12 @@ The publisher stages rows in these additive replicated tables:
 
 - `signal.adjusted_daily_bars_v2`
 - `signal.exchange_sessions_v1`
+- `signal.snapshot_manifests_v2`
 
-Only after exact database readback does it append one row to `signal.snapshot_manifests_v1`. Manifest presence is the
-finalization boundary. A partial run is not finalized; an exact retry resumes it. Duplicate keys, unexpected rows,
-changed values, multiple manifests, or a hash mismatch invalidate the snapshot instead of replacing it.
+Only after exact database readback does it append one manifest row. Manifest presence is the finalization boundary. A
+V2 manifest binds the configured universe ID and canonical SHA-256 symbol hash in both its content identity and stored
+columns. A partial run is not finalized; an exact retry resumes it. Duplicate keys, unexpected rows, changed values,
+multiple manifests, or a hash mismatch invalidate the snapshot instead of replacing it.
 
 Every returned exchange session must contain exactly one valid OHLCV bar for every configured symbol. All bars must
 fall on a returned exchange session and inside the requested bounds. Any historical or final symbol-session gap blocks
@@ -39,35 +42,43 @@ parameter is supplied explicitly for symbol mapping.
 The provider contract follows Alpaca's [historical bars](https://docs.alpaca.markets/us/v1.4.2/reference/stockbars),
 [trading calendar](https://docs.alpaca.markets/us/v1.1/reference/getcalendar-1), and
 [market-data feed](https://docs.alpaca.markets/us/docs/market-data-faq) documentation. The publisher requests
-`adjustment=all`, explicitly selects the consolidated `sip` feed, exhausts pagination, and uses the returned session
-close so early-close days are not treated as ordinary 16:00 sessions. IEX remains a development override, not the
-production publication source.
+`adjustment=all`, explicitly records either `iex` or `sip`, exhausts pagination, and uses the returned session close so
+early-close days are not treated as ordinary 16:00 sessions. The current production selection is delayed `sip`; live
+IEX websocket events retain a different feed identity and are never relabeled as strategy input.
 
 ## Authority
 
-The `signal_publisher` ClickHouse principal has only `SELECT, INSERT` on the three publication tables. It cannot create,
-alter, truncate, or drop objects. Schema creation is an additive GitOps migration using the existing administrative
-identity. Bayn has only `SELECT`; its runtime uses the three publication tables and cannot mutate Signal data.
+The `signal_publisher` ClickHouse principal has only `SELECT, INSERT` on the current publication tables and the legacy
+V1 manifest retained for rollback. It cannot create, alter, truncate, drop, or access all tables through a wildcard.
+Schema creation is an additive GitOps migration using the existing administrative identity. Bayn has only explicit
+`SELECT` grants on the legacy and current read paths and cannot mutate Signal data.
 
 ## Operator invocation
 
-Run a historical publication from the promoted image by creating a one-off Job from the CronJob and replacing its
-arguments with `backfill --start <date> --end <date>`. Keep the same secrets and immutable image reference. Never run
-the removed Bayn backfill path or grant Bayn write access.
+Run a historical publication only through a reviewed one-off GitOps Job using
+`backfill --start <date> --end <date>`. Keep the same versioned universe ConfigMap, secrets, and immutable image
+reference as the CronJob. Remove the completed Job through GitOps after retaining its snapshot evidence. Never run the
+removed Bayn backfill path or grant Bayn write access.
 
 ## Rollout, evidence, and rollback
 
 GitOps first creates the sealed writer credential, applies the least-privilege ClickHouse user, runs the additive schema
-hook, and leaves the CronJob suspended. The ClickHouse operator may restart replicas sequentially when its user
-configuration changes; verify both replicas before promotion. Image promotion pins the source SHA and multi-platform
-digest and is the only step that unsuspends the schedule.
+hook, and leaves the CronJob suspended. The one-shot backfill file is a dormant template and is not rendered. The
+ClickHouse operator may restart replicas sequentially when its user configuration changes; verify both replicas before
+promotion. Image promotion pins the source SHA and multi-platform digest in both writer templates but activates
+nothing.
 
-Completion evidence requires two distinct scheduled publication observations. For each one, retain the Job name,
-source revision, image digest, snapshot ID, publication as-of date, exact row counts and hashes, one manifest row, and
-duplicate-key readbacks from ClickHouse. Also prove the publisher has only its three `SELECT, INSERT` grants and Bayn
-cannot insert.
+A separate reviewed GitOps change adds and starts only the one-shot backfill Job. The CronJob remains suspended until
+the bounded snapshot is reproduced from both replicas. Cleanup then removes the completed Job and enables the CronJob
+in one commit. CI rejects a rendered backfill whose template is suspended, an active writer without immutable
+provenance, or simultaneous active backfill and scheduled writers.
 
-Rollback is fail-closed: suspend the CronJob through GitOps, preserve finalized and partially staged rows for diagnosis,
-and revert the publisher/user manifests only after no Job is active. Do not delete either the legacy table or the
-additive snapshot tables. Bayn remains bound to its configured finalized snapshot until a separately reviewed GitOps
-change selects another one.
+Completion evidence requires the bounded backfill plus two distinct scheduled publication observations. For each one,
+retain the Job name, source revision, image digest, universe ID and symbol hash, snapshot ID, publication as-of date,
+exact row counts and hashes, one manifest row, and duplicate-key readbacks from both ClickHouse replicas. Also prove
+the publisher's explicit `SELECT, INSERT` grants and that Bayn cannot insert.
+
+Rollback is fail-closed: suspend the active writer through GitOps, preserve finalized and partially staged rows for
+diagnosis, and revert publisher or user manifests only after no Job is active. Do not delete either the legacy table or
+the additive snapshot tables. Bayn remains bound to its configured finalized snapshot until a separately reviewed
+GitOps change selects another one.

--- a/nix/images/signal-publisher.nix
+++ b/nix/images/signal-publisher.nix
@@ -16,8 +16,8 @@ import ./bun-workspace-service.nix {
   serviceName = "signal-publisher";
   packageName = "@proompteng/signal-publisher";
   depsHash = {
-    x86_64-linux = "sha256-y/+b5uIyouOpJ7NPWOFCHd8Bkttg5rPgfLTaxQh34B8=";
-    aarch64-linux = "sha256-OewlYC0LzrdmDh53USwqJS0/2TiHUfUV1THTWxl4DbU=";
+    x86_64-linux = "sha256-UqyymgIzC2N+mtmjTbrUVeZBzcaVIw8WV1UwnvsnLn4=";
+    aarch64-linux = "sha256-Xdu+YlnFFDg0zH653zwg73sDVUP0/EWsoeUn1tgrrKc=";
   };
   installFilters = [
     "@proompteng/signal-publisher"

--- a/packages/scripts/src/signal/gitops-contract.test.ts
+++ b/packages/scripts/src/signal/gitops-contract.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import { spawnSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
@@ -8,10 +9,22 @@ import { parse } from 'yaml'
 const root = resolve(import.meta.dir, '../../../..')
 const clickhouseDirectory = resolve(root, 'argocd/applications/torghut/clickhouse')
 const read = (path: string) => readFileSync(resolve(clickhouseDirectory, path), 'utf8')
+const readWsConfig = () => readFileSync(resolve(root, 'argocd/applications/torghut/ws/configmap.yaml'), 'utf8')
+const readWsDeployment = () => readFileSync(resolve(root, 'argocd/applications/torghut/ws/deployment.yaml'), 'utf8')
 
-const assertActivationProvenance = (cronJob: ReturnType<typeof parse>, kustomization: ReturnType<typeof parse>) => {
-  if (cronJob.spec.suspend) return
-  const container = cronJob.spec.jobTemplate.spec.template.spec.containers[0]
+const csv = (value: string): string[] => value.split(',').map((item) => item.trim())
+const environment = (container: { env: Array<{ name: string }> }) =>
+  new Map(container.env.map((entry) => [entry.name, entry]))
+const universeRef = (key: string) => ({ valueFrom: { configMapKeyRef: { name: 'bayn-universe-v1', key } } })
+
+const writerContainer = (writer: ReturnType<typeof parse>) =>
+  writer.kind === 'CronJob'
+    ? writer.spec.jobTemplate.spec.template.spec.containers[0]
+    : writer.spec.template.spec.containers[0]
+
+const assertActivationProvenance = (writer: ReturnType<typeof parse>, kustomization: ReturnType<typeof parse>) => {
+  if (writer.spec.suspend) return
+  const container = writerContainer(writer)
   const environment = new Map(container.env.map((entry: { name: string; value?: string }) => [entry.name, entry]))
   const image = kustomization.images.find(
     (entry: { name: string }) => entry.name === 'registry.ide-newton.ts.net/lab/signal-publisher',
@@ -26,9 +39,10 @@ const assertActivationProvenance = (cronJob: ReturnType<typeof parse>, kustomiza
 describe('Signal publisher GitOps authority contract', () => {
   test('requires immutable image provenance whenever the publisher is active', () => {
     const cronJob = parse(read('signal-publisher-cronjob.yaml'))
+    const backfillJob = parse(read('signal-publisher-bayn-v1-backfill-job.yaml'))
     const kustomization = parse(read('kustomization.yaml'))
     const container = cronJob.spec.jobTemplate.spec.template.spec.containers[0]
-    const environment = new Map(container.env.map((entry: { name: string; value?: string }) => [entry.name, entry]))
+    const variables = environment(container)
 
     expect(cronJob.spec).toMatchObject({
       schedule: '30 18 * * 1-5',
@@ -36,28 +50,85 @@ describe('Signal publisher GitOps authority contract', () => {
       concurrencyPolicy: 'Forbid',
     })
     expect(typeof cronJob.spec.suspend).toBe('boolean')
+    expect(typeof backfillJob.spec.suspend).toBe('boolean')
     expect(container.args).toEqual(['daily'])
+    const backfillManaged = kustomization.resources.includes('signal-publisher-bayn-v1-backfill-job.yaml')
+    expect(backfillManaged).toBe(!backfillJob.spec.suspend)
+    expect(cronJob.spec.suspend || backfillJob.spec.suspend).toBe(true)
     assertActivationProvenance(cronJob, kustomization)
-    expect(environment.get('SIGNAL_CLICKHOUSE_USERNAME')).toMatchObject({
+    assertActivationProvenance(backfillJob, kustomization)
+    expect(variables.get('SIGNAL_CLICKHOUSE_USERNAME')).toMatchObject({
       valueFrom: { secretKeyRef: { name: 'signal-publisher-clickhouse-auth', key: 'username' } },
     })
-    expect(environment.get('SIGNAL_CLICKHOUSE_PASSWORD')).toMatchObject({
+    expect(variables.get('SIGNAL_CLICKHOUSE_PASSWORD')).toMatchObject({
       valueFrom: { secretKeyRef: { name: 'signal-publisher-clickhouse-auth', key: 'password' } },
     })
-    expect(environment.get('SIGNAL_ALPACA_FEED')).toMatchObject({ value: 'sip' })
-    expect([...environment.keys()].filter((name) => /BROKER|TIGERBEETLE|CAPITAL/.test(name))).toEqual([])
+    expect(variables.get('SIGNAL_UNIVERSE_ID')).toMatchObject(universeRef('UNIVERSE_ID'))
+    expect(variables.get('SIGNAL_UNIVERSE_SYMBOL_HASH')).toMatchObject(universeRef('UNIVERSE_SYMBOL_HASH'))
+    expect(variables.get('SIGNAL_SYMBOLS')).toMatchObject(universeRef('UNIVERSE_SYMBOLS'))
+    expect(variables.get('SIGNAL_START_DATE')).toMatchObject(universeRef('HISTORY_START_DATE'))
+    expect(variables.get('SIGNAL_ALPACA_FEED')).toMatchObject(universeRef('HISTORY_FEED'))
+    expect([...variables.keys()].filter((name) => /BROKER|TIGERBEETLE|CAPITAL/.test(name))).toEqual([])
+  })
+
+  test('binds one exact versioned universe to websocket and both publisher modes', () => {
+    const universe = parse(read('bayn-universe-v1-configmap.yaml'))
+    const websocketConfig = parse(readWsConfig())
+    const websocketDeployment = parse(readWsDeployment())
+    const cronJob = parse(read('signal-publisher-cronjob.yaml'))
+    const backfill = parse(read('signal-publisher-bayn-v1-backfill-job.yaml'))
+    const selected = csv(universe.data.UNIVERSE_SYMBOLS)
+    const expectedHash = createHash('sha256').update(selected.join(',')).digest('hex')
+    const websocketVariables = environment(websocketDeployment.spec.template.spec.containers[0])
+    const cronVariables = environment(cronJob.spec.jobTemplate.spec.template.spec.containers[0])
+    const backfillVariables = environment(backfill.spec.template.spec.containers[0])
+
+    expect(universe.metadata.annotations['bayn.proompteng.ai/contract']).toBe('equity-infrastructure-v1')
+    expect(selected).toEqual(['AMD', 'AVGO', 'COHR', 'CRDO', 'LITE', 'MRVL', 'MU', 'NVDA', 'WDC'])
+    expect(universe.data).toMatchObject({
+      UNIVERSE_ID: 'equity-infrastructure-v1',
+      UNIVERSE_SYMBOL_HASH: expectedHash,
+      HISTORY_START_DATE: '2022-01-27',
+      HISTORY_FEED: 'sip',
+    })
+    expect(websocketConfig.data.SYMBOLS).toBeUndefined()
+    expect(websocketConfig.data.SYMBOLS_ALLOWLIST).toBeUndefined()
+    expect(websocketVariables.get('SYMBOLS')).toMatchObject(universeRef('UNIVERSE_SYMBOLS'))
+    expect(websocketVariables.get('SYMBOLS_ALLOWLIST')).toMatchObject(universeRef('UNIVERSE_SYMBOLS'))
+    expect(websocketVariables.get('MARKET_DATA_UNIVERSE_ID')).toMatchObject(universeRef('UNIVERSE_ID'))
+    expect(websocketVariables.get('MARKET_DATA_UNIVERSE_SYMBOL_HASH')).toMatchObject(
+      universeRef('UNIVERSE_SYMBOL_HASH'),
+    )
+    for (const variables of [cronVariables, backfillVariables]) {
+      expect(variables.get('SIGNAL_UNIVERSE_ID')).toMatchObject(universeRef('UNIVERSE_ID'))
+      expect(variables.get('SIGNAL_UNIVERSE_SYMBOL_HASH')).toMatchObject(universeRef('UNIVERSE_SYMBOL_HASH'))
+      expect(variables.get('SIGNAL_SYMBOLS')).toMatchObject(universeRef('UNIVERSE_SYMBOLS'))
+      expect(variables.get('SIGNAL_START_DATE')).toMatchObject(universeRef('HISTORY_START_DATE'))
+      expect(variables.get('SIGNAL_ALPACA_FEED')).toMatchObject(universeRef('HISTORY_FEED'))
+    }
+    expect(backfill.spec).toMatchObject({
+      suspend: true,
+      template: { spec: { containers: [{ args: ['backfill', '--start', '2022-01-27', '--end', '2026-07-20'] }] } },
+    })
+    expect(cronJob.spec.suspend).toBe(true)
+    expect(backfill.spec.template.spec.containers[0]).toMatchObject({
+      args: ['backfill', '--start', '2022-01-27', '--end', '2026-07-20'],
+    })
   })
 
   test('always permits a fail-closed suspension', () => {
     const cronJob = structuredClone(parse(read('signal-publisher-cronjob.yaml')))
+    const backfillJob = structuredClone(parse(read('signal-publisher-bayn-v1-backfill-job.yaml')))
     const kustomization = structuredClone(parse(read('kustomization.yaml')))
     cronJob.spec.suspend = true
+    backfillJob.spec.suspend = true
     kustomization.images[0].newTag = 'bootstrap'
     delete kustomization.images[0].digest
     expect(() => assertActivationProvenance(cronJob, kustomization)).not.toThrow()
+    expect(() => assertActivationProvenance(backfillJob, kustomization)).not.toThrow()
   })
 
-  test('limits database authority to the three append-only publication tables', () => {
+  test('limits database authority to the versioned append-only publication tables', () => {
     const installation = parse(read('clickhouse-cluster.yaml'))
     const profiles = installation.spec.configuration.profiles
     const users = installation.spec.configuration.users
@@ -71,12 +142,14 @@ describe('Signal publisher GitOps authority contract', () => {
       'GRANT SELECT, INSERT ON signal.adjusted_daily_bars_v2',
       'GRANT SELECT, INSERT ON signal.exchange_sessions_v1',
       'GRANT SELECT, INSERT ON signal.snapshot_manifests_v1',
+      'GRANT SELECT, INSERT ON signal.snapshot_manifests_v2',
     ])
     expect(users['bayn/grants/query']).toEqual([
       'GRANT SELECT ON signal.adjusted_daily_bars_v1',
       'GRANT SELECT ON signal.adjusted_daily_bars_v2',
       'GRANT SELECT ON signal.exchange_sessions_v1',
       'GRANT SELECT ON signal.snapshot_manifests_v1',
+      'GRANT SELECT ON signal.snapshot_manifests_v2',
     ])
     expect(users['signal_publisher/grants/query'].join('\n')).not.toMatch(/\b(?:ALTER|CREATE|DROP|SYSTEM)\b|\.\*/)
   })
@@ -91,13 +164,15 @@ describe('Signal publisher GitOps authority contract', () => {
     expect(shellSyntax.status).toBe(0)
     expect(schema.metadata.annotations['argocd.argoproj.io/sync-wave']).toBe('3')
     expect(parse(read('signal-publisher-cronjob.yaml')).metadata.annotations['argocd.argoproj.io/sync-wave']).toBe('4')
-    expect(migration.match(/ENGINE = ReplicatedMergeTree/g)).toHaveLength(3)
+    expect(migration.match(/ENGINE = ReplicatedMergeTree/g)).toHaveLength(4)
     expect(kustomization.resources).toEqual(
       expect.arrayContaining([
         'signal-publisher-sealed-secret.yaml',
         'signal-schema-job.yaml',
+        'bayn-universe-v1-configmap.yaml',
         'signal-publisher-cronjob.yaml',
       ]),
     )
+    expect(kustomization.resources).not.toContain('signal-publisher-bayn-v1-backfill-job.yaml')
   })
 })

--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
@@ -273,7 +273,8 @@ class ForwarderApp(
       scope.launch {
         logger.info {
           "dorvud-ws starting shard=${config.shardIndex}/${config.shardCount} " +
-            "jangarSymbolsUrl=${config.jangarSymbolsUrl} channels=${config.alpacaMarketDataChannels}"
+            "jangarSymbolsUrl=${config.jangarSymbolsUrl} channels=${config.alpacaMarketDataChannels} " +
+            "universeId=${config.universeContract?.id} universeSymbolHash=${config.universeContract?.symbolHash}"
         }
         val producer = producerFactory(config)
         val seq = SeqTracker()
@@ -379,6 +380,14 @@ class ForwarderApp(
       gates = gates,
       alpacaMarketDataWs = marketDataWsStatus.get(),
       marketDataChannels = channelSnapshot,
+      marketDataUniverse =
+        config.universeContract?.let { contract ->
+          MarketDataUniverseInfo(
+            id = contract.id,
+            symbolHash = contract.symbolHash,
+            symbols = contract.symbols,
+          )
+        },
     )
   }
 

--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderConfig.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderConfig.kt
@@ -5,6 +5,8 @@ import ai.proompteng.dorvud.platform.KafkaProducerSettings
 import ai.proompteng.dorvud.platform.KafkaTls
 import io.github.cdimascio.dotenv.dotenv
 import java.io.File
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
 import java.time.LocalDate
 import java.util.Properties
 
@@ -16,6 +18,18 @@ data class TopicConfig(
   val tradeUpdates: String?,
   val tradeUpdatesV2: String?,
 )
+
+data class MarketDataUniverseContract(
+  val id: String,
+  val symbolHash: String,
+  val symbols: List<String>,
+)
+
+internal fun canonicalSymbolHash(symbols: Collection<String>): String =
+  MessageDigest
+    .getInstance("SHA-256")
+    .digest(symbols.joinToString(",").toByteArray(StandardCharsets.UTF_8))
+    .joinToString("") { byte -> "%02x".format(byte.toInt() and 0xff) }
 
 enum class AlpacaMarketType {
   EQUITY,
@@ -44,6 +58,7 @@ data class ForwarderConfig(
   val jangarSymbolsUrl: String?,
   val staticSymbols: List<String>,
   val symbolAllowlist: Set<String>,
+  val universeContract: MarketDataUniverseContract? = null,
   val symbolsPollIntervalMs: Long,
   val subscribeBatchSize: Int,
   val shardCount: Int,
@@ -82,13 +97,13 @@ data class ForwarderConfig(
       if (symbolsPollIntervalMs <= 0) error("SYMBOLS_POLL_INTERVAL_MS must be > 0")
       if (subscribeBatchSize <= 0) error("SUBSCRIBE_BATCH_SIZE must be > 0")
 
-      val symbolAllowlist =
+      val configuredAllowlistSymbols =
         mergedEnv["SYMBOLS_ALLOWLIST"]
           ?.split(",")
           ?.map { it.trim().uppercase() }
           ?.filter { it.isNotEmpty() }
-          ?.toSet()
-          ?: emptySet()
+          ?: emptyList()
+      val symbolAllowlist = configuredAllowlistSymbols.toSet()
       if (symbolAllowlist.size > 12) error("SYMBOLS_ALLOWLIST must include no more than 12 symbols")
       val configuredStaticSymbols =
         mergedEnv["SYMBOLS"]
@@ -147,6 +162,43 @@ data class ForwarderConfig(
       if (jangarSymbolsUrl == null && staticSymbols.isEmpty()) {
         error("JANGAR_SYMBOLS_URL or SYMBOLS must be set")
       }
+
+      val universeId = mergedEnv["MARKET_DATA_UNIVERSE_ID"]?.trim()?.takeIf { it.isNotEmpty() }
+      val universeSymbolHash =
+        mergedEnv["MARKET_DATA_UNIVERSE_SYMBOL_HASH"]
+          ?.trim()
+          ?.takeIf { it.isNotEmpty() }
+      if ((universeId == null) != (universeSymbolHash == null)) {
+        error("MARKET_DATA_UNIVERSE_ID and MARKET_DATA_UNIVERSE_SYMBOL_HASH must be set together")
+      }
+      val universeContract =
+        universeId?.let { id ->
+          val expectedHash = requireNotNull(universeSymbolHash)
+          if (!id.matches(Regex("^[a-z0-9]+(?:[.-][a-z0-9]+)*$"))) {
+            error("MARKET_DATA_UNIVERSE_ID must be a versioned lowercase identifier")
+          }
+          if (!expectedHash.matches(Regex("^[0-9a-f]{64}$"))) {
+            error("MARKET_DATA_UNIVERSE_SYMBOL_HASH must be a lowercase SHA-256 hash")
+          }
+          if (jangarSymbolsUrl != null) {
+            error("a versioned market-data universe cannot use JANGAR_SYMBOLS_URL")
+          }
+          val configuredSymbols =
+            configuredStaticSymbols.map { it.trim().uppercase() }.filter { it.isNotEmpty() }
+          val canonicalSymbols =
+            configuredSymbols.distinct().sorted()
+          if (configuredSymbols != canonicalSymbols) {
+            error("SYMBOLS must be unique and canonically sorted for a versioned market-data universe")
+          }
+          if (configuredAllowlistSymbols != canonicalSymbols) {
+            error("SYMBOLS_ALLOWLIST must exactly match SYMBOLS for a versioned market-data universe")
+          }
+          val actualHash = canonicalSymbolHash(canonicalSymbols)
+          if (expectedHash != actualHash) {
+            error("MARKET_DATA_UNIVERSE_SYMBOL_HASH does not match canonical SYMBOLS")
+          }
+          MarketDataUniverseContract(id = id, symbolHash = actualHash, symbols = canonicalSymbols)
+        }
 
       val topics =
         TopicConfig(
@@ -246,6 +298,7 @@ data class ForwarderConfig(
         jangarSymbolsUrl = jangarSymbolsUrl,
         staticSymbols = staticSymbols,
         symbolAllowlist = symbolAllowlist,
+        universeContract = universeContract,
         symbolsPollIntervalMs = symbolsPollIntervalMs,
         subscribeBatchSize = subscribeBatchSize,
         shardCount = shardCount,

--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ReadinessDiagnostics.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ReadinessDiagnostics.kt
@@ -49,6 +49,14 @@ data class ReadinessInfo(
   val gates: ReadinessGates,
   @SerialName("alpaca_market_data_ws") val alpacaMarketDataWs: AlpacaMarketDataWebsocketStatus = AlpacaMarketDataWebsocketStatus(),
   @SerialName("market_data_channels") val marketDataChannels: List<MarketDataChannelReadiness> = emptyList(),
+  @SerialName("market_data_universe") val marketDataUniverse: MarketDataUniverseInfo? = null,
+)
+
+@Serializable
+data class MarketDataUniverseInfo(
+  val id: String,
+  @SerialName("symbol_hash") val symbolHash: String,
+  val symbols: List<String>,
 )
 
 @Serializable

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderConfigTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderConfigTest.kt
@@ -7,6 +7,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 
 class ForwarderConfigTest {
   @Test
@@ -46,6 +47,83 @@ class ForwarderConfigTest {
     assertEquals(listOf("trades", "quotes", "bars", "updatedBars"), cfg.alpacaMarketDataChannels)
     assertEquals(emptySet(), cfg.optionsMarketHolidays)
     assertEquals("torghut.trades.v1", cfg.topics.trades)
+    assertNull(cfg.universeContract)
+  }
+
+  @Test
+  fun `binds a versioned static universe to its canonical symbol hash`() {
+    val symbols = "AMD,AVGO,COHR,CRDO,LITE,MRVL,MU,NVDA,WDC"
+    val cfg =
+      ForwarderConfig.fromEnv(
+        mapOf(
+          "ALPACA_KEY_ID" to "key",
+          "ALPACA_SECRET_KEY" to "secret",
+          "SYMBOLS" to symbols,
+          "SYMBOLS_ALLOWLIST" to symbols,
+          "MARKET_DATA_UNIVERSE_ID" to "equity-infrastructure-v1",
+          "MARKET_DATA_UNIVERSE_SYMBOL_HASH" to
+            "ddcc8adc04dc29822969cddf02b821ea8110856162cca20a7ff28c1c43263e18",
+        ),
+      )
+
+    assertEquals(
+      MarketDataUniverseContract(
+        id = "equity-infrastructure-v1",
+        symbolHash = "ddcc8adc04dc29822969cddf02b821ea8110856162cca20a7ff28c1c43263e18",
+        symbols = listOf("AMD", "AVGO", "COHR", "CRDO", "LITE", "MRVL", "MU", "NVDA", "WDC"),
+      ),
+      cfg.universeContract,
+    )
+  }
+
+  @Test
+  fun `rejects drift in a versioned static universe`() {
+    val base =
+      mapOf(
+        "ALPACA_KEY_ID" to "key",
+        "ALPACA_SECRET_KEY" to "secret",
+        "SYMBOLS" to "AMD,NVDA",
+        "SYMBOLS_ALLOWLIST" to "AMD,NVDA",
+        "MARKET_DATA_UNIVERSE_ID" to "equity-infrastructure-v1",
+        "MARKET_DATA_UNIVERSE_SYMBOL_HASH" to canonicalSymbolHash(listOf("AMD", "NVDA")),
+      )
+
+    assertEquals(
+      "MARKET_DATA_UNIVERSE_SYMBOL_HASH does not match canonical SYMBOLS",
+      assertFailsWith<IllegalStateException> {
+        ForwarderConfig.fromEnv(base + ("MARKET_DATA_UNIVERSE_SYMBOL_HASH" to "0".repeat(64)))
+      }.message,
+    )
+    assertEquals(
+      "MARKET_DATA_UNIVERSE_ID must be a versioned lowercase identifier",
+      assertFailsWith<IllegalStateException> {
+        ForwarderConfig.fromEnv(base + ("MARKET_DATA_UNIVERSE_ID" to "Equity Infrastructure V1"))
+      }.message,
+    )
+    assertEquals(
+      "SYMBOLS_ALLOWLIST must exactly match SYMBOLS for a versioned market-data universe",
+      assertFailsWith<IllegalStateException> {
+        ForwarderConfig.fromEnv(base + ("SYMBOLS_ALLOWLIST" to "AMD"))
+      }.message,
+    )
+    assertEquals(
+      "SYMBOLS_ALLOWLIST must exactly match SYMBOLS for a versioned market-data universe",
+      assertFailsWith<IllegalStateException> {
+        ForwarderConfig.fromEnv(base + ("SYMBOLS_ALLOWLIST" to "NVDA,AMD"))
+      }.message,
+    )
+    assertEquals(
+      "SYMBOLS_ALLOWLIST must exactly match SYMBOLS for a versioned market-data universe",
+      assertFailsWith<IllegalStateException> {
+        ForwarderConfig.fromEnv(base + ("SYMBOLS_ALLOWLIST" to "AMD,NVDA,NVDA"))
+      }.message,
+    )
+    assertEquals(
+      "a versioned market-data universe cannot use JANGAR_SYMBOLS_URL",
+      assertFailsWith<IllegalStateException> {
+        ForwarderConfig.fromEnv(base + ("JANGAR_SYMBOLS_URL" to "http://jangar.test/symbols"))
+      }.message,
+    )
   }
 
   @Test

--- a/services/signal-publisher/README.md
+++ b/services/signal-publisher/README.md
@@ -1,10 +1,13 @@
 # Signal Publisher
 
-Publishes finalized, content-addressed Alpaca consolidated-SIP adjusted-daily snapshots and exchange-session manifests
-to Signal ClickHouse. It is the only writer for its three owned tables; Bayn consumes them read-only.
+Publishes finalized, content-addressed Alpaca adjusted-daily snapshots and exchange-session manifests to Signal
+ClickHouse. The feed, versioned universe ID, and canonical symbol hash are explicit in every V2 snapshot; production
+uses delayed consolidated SIP after the session is finalized. It is the only writer for its three current publication
+tables, and Bayn consumes them read-only.
 
 The same binary supports `daily` and the explicitly bounded `backfill --start DATE --end DATE` command. Production
-runs use the GitOps CronJob and an immutable promoted image. See
+runs use immutable promoted images. The one-shot backfill and scheduled writer are activated separately and never run
+concurrently. See
 [`docs/bayn/signal-adjusted-daily-publications.md`](../../docs/bayn/signal-adjusted-daily-publications.md) for the data
 contract and operating procedure.
 

--- a/services/signal-publisher/src/alpaca.test.ts
+++ b/services/signal-publisher/src/alpaca.test.ts
@@ -20,6 +20,10 @@ const config: PublisherConfig = {
     feed: 'sip',
   },
   symbols: ['SPY', 'TLT'],
+  universe: {
+    id: 'equity-infrastructure-v1',
+    symbolHash: 'e21a3ab82277c13c426e9efdeac7e9ff774b8e7e34b1fa5d39a9f41552202c52',
+  },
   startDate: '2026-07-16',
   calendarVersion: 'alpaca-us-equity-calendar-v1',
   finalizationLagMinutes: 90,

--- a/services/signal-publisher/src/config.test.ts
+++ b/services/signal-publisher/src/config.test.ts
@@ -13,6 +13,8 @@ const environment = {
   APCA_API_KEY_ID: 'key',
   APCA_API_SECRET_KEY: 'secret',
   SIGNAL_SYMBOLS: 'TLT,SPY',
+  SIGNAL_UNIVERSE_ID: 'equity-infrastructure-v1',
+  SIGNAL_UNIVERSE_SYMBOL_HASH: 'e21a3ab82277c13c426e9efdeac7e9ff774b8e7e34b1fa5d39a9f41552202c52',
   SIGNAL_START_DATE: '2017-01-01',
   SIGNAL_CODE_REVISION: sourceRevision,
   SIGNAL_IMAGE_REPOSITORY: imageRepository,
@@ -29,6 +31,10 @@ describe('Signal publisher config', () => {
     const config = await Effect.runPromise(provide(environment))
     expect(config.symbols).toEqual(['SPY', 'TLT'])
     expect(config.alpaca.feed).toBe('sip')
+    expect(config.universe).toEqual({
+      id: 'equity-infrastructure-v1',
+      symbolHash: 'e21a3ab82277c13c426e9efdeac7e9ff774b8e7e34b1fa5d39a9f41552202c52',
+    })
     expect(config.finalizationLagMinutes).toBe(90)
     expect(Redacted.isRedacted(config.alpaca.key)).toBe(true)
     expect(config.provenance).toEqual({
@@ -55,10 +61,14 @@ describe('Signal publisher config', () => {
     const invalidUrl = await Effect.runPromise(
       Effect.flip(provide({ ...environment, SIGNAL_CLICKHOUSE_URL: 'not-a-url' })),
     )
+    const mismatchedUniverse = await Effect.runPromise(
+      Effect.flip(provide({ ...environment, SIGNAL_UNIVERSE_SYMBOL_HASH: '0'.repeat(64) })),
+    )
 
     expect(missingBuild.message).toContain('compile-time build metadata')
     expect(mismatchedBuild.message).toContain('does not match embedded revision')
     expect(duplicateSymbols.message).toContain('contains duplicates')
     expect(invalidUrl.message).toContain('cannot be parsed as a URL')
+    expect(mismatchedUniverse.message).toContain('does not match canonical SIGNAL_SYMBOLS')
   })
 })

--- a/services/signal-publisher/src/config.ts
+++ b/services/signal-publisher/src/config.ts
@@ -1,6 +1,6 @@
 import { Config, Effect, Redacted, Schema, SchemaTransformation } from 'effect'
 
-import { IsoDateSchema, type IsoDate, type PublisherProvenance } from './domain'
+import { canonicalSymbolHash, IsoDateSchema, type IsoDate, type PublisherProvenance } from './domain'
 
 declare const __SIGNAL_PUBLISHER_BUILD_SOURCE_REVISION__: string | undefined
 declare const __SIGNAL_PUBLISHER_BUILD_IMAGE_REPOSITORY__: string | undefined
@@ -24,6 +24,10 @@ export interface PublisherConfig {
     readonly feed: 'iex' | 'sip'
   }
   readonly symbols: readonly string[]
+  readonly universe: {
+    readonly id: string
+    readonly symbolHash: string
+  }
   readonly startDate: IsoDate
   readonly calendarVersion: string
   readonly finalizationLagMinutes: number
@@ -44,6 +48,8 @@ const NonEmptyString = Schema.Trim.check(Schema.isMinLength(1))
 const SourceRevision = Schema.String.check(Schema.isPattern(/^[0-9a-f]{40}$/))
 const ImageRepository = Schema.String.check(Schema.isPattern(/^[a-z0-9.-]+(?::[0-9]+)?\/[a-z0-9._/-]+$/))
 const ImageDigest = Schema.String.check(Schema.isPattern(/^sha256:[0-9a-f]{64}$/))
+const UniverseId = Schema.String.check(Schema.isPattern(/^[a-z0-9]+(?:[.-][a-z0-9]+)*$/))
+const SymbolHash = Schema.String.check(Schema.isPattern(/^[0-9a-f]{64}$/))
 const PositiveInteger = Schema.Int.check(Schema.isGreaterThan(0))
 const SymbolList = Schema.Trim.pipe(
   Schema.decodeTo(
@@ -83,6 +89,8 @@ const rawConfig = Config.all({
   alpacaSecret: secretString('APCA_API_SECRET_KEY'),
   feed: Config.literals(['iex', 'sip'], 'SIGNAL_ALPACA_FEED').pipe(Config.withDefault('sip')),
   symbols: Config.schema(SymbolList, 'SIGNAL_SYMBOLS'),
+  universeId: Config.schema(UniverseId, 'SIGNAL_UNIVERSE_ID'),
+  universeSymbolHash: Config.schema(SymbolHash, 'SIGNAL_UNIVERSE_SYMBOL_HASH'),
   startDate: Config.schema(IsoDateSchema, 'SIGNAL_START_DATE'),
   calendarVersion: nonEmptyString('SIGNAL_CALENDAR_VERSION').pipe(Config.withDefault('alpaca-us-equity-calendar-v1')),
   finalizationLagMinutes: positiveInteger('SIGNAL_FINALIZATION_LAG_MINUTES', 90),
@@ -116,6 +124,9 @@ export const loadConfig = (
           for (const symbol of symbols) {
             if (!/^[A-Z][A-Z0-9.-]{0,14}$/.test(symbol)) throw new Error(`invalid symbol: ${symbol}`)
           }
+          if (config.universeSymbolHash !== canonicalSymbolHash(symbols)) {
+            throw new Error('SIGNAL_UNIVERSE_SYMBOL_HASH does not match canonical SIGNAL_SYMBOLS')
+          }
           return {
             clickhouse: {
               url: httpUrl(config.clickhouseUrl, 'SIGNAL_CLICKHOUSE_URL'),
@@ -130,6 +141,10 @@ export const loadConfig = (
               feed: config.feed,
             },
             symbols,
+            universe: {
+              id: config.universeId,
+              symbolHash: config.universeSymbolHash,
+            },
             startDate: config.startDate as IsoDate,
             calendarVersion: config.calendarVersion,
             finalizationLagMinutes: config.finalizationLagMinutes,

--- a/services/signal-publisher/src/domain.test.ts
+++ b/services/signal-publisher/src/domain.test.ts
@@ -33,6 +33,8 @@ const input = (overrides: Partial<BuildPublicationInput> = {}): BuildPublication
     { date: '2026-07-17', open: '09:30', close: '16:00' },
   ],
   symbols: ['SPY', 'TLT'],
+  universeId: 'equity-infrastructure-v1',
+  universeSymbolHash: 'e21a3ab82277c13c426e9efdeac7e9ff774b8e7e34b1fa5d39a9f41552202c52',
   feed: 'iex',
   calendarVersion: 'alpaca-us-equity-calendar-v1',
   requestedStart: '2026-07-16',
@@ -75,13 +77,17 @@ describe('Adjusted-daily snapshot domain', () => {
         finalizedAt: '2026-07-17 22:35:00.000',
       }),
     )
+    const renamedUniverse = buildPublication(input({ universeId: 'equity-infrastructure-v2' }))
 
     expect(first.manifest.snapshot_id).toBe(reordered.manifest.snapshot_id)
+    expect(first.manifest.snapshot_id).not.toBe(renamedUniverse.manifest.snapshot_id)
     expect(first.manifest.snapshot_id).toMatch(/^[a-f0-9]{64}$/)
     expect(Schema.decodeUnknownSync(SnapshotIdSchema)(first.manifest.snapshot_id)).toBe(first.manifest.snapshot_id)
     expect(first.manifest.manifest_content_hash).not.toBe(reordered.manifest.manifest_content_hash)
     expect(first.manifest).toMatchObject({
-      schema_version: 'signal.adjusted-daily-snapshot.v1',
+      schema_version: 'signal.adjusted-daily-snapshot.v2',
+      universe_id: 'equity-infrastructure-v1',
+      universe_symbol_hash: 'e21a3ab82277c13c426e9efdeac7e9ff774b8e7e34b1fa5d39a9f41552202c52',
       symbol_count: 2,
       session_count: 2,
       bar_count: 4,
@@ -92,6 +98,10 @@ describe('Adjusted-daily snapshot domain', () => {
   })
 
   test('rejects malformed, duplicate, non-session, and incomplete sessions', () => {
+    expect(() => buildPublication(input({ universeId: 'Equity Infrastructure' }))).toThrow('universe ID is invalid')
+    expect(() => buildPublication(input({ universeSymbolHash: '0'.repeat(64) }))).toThrow(
+      'universe symbol hash does not match canonical symbols',
+    )
     expect(() =>
       buildPublication(
         input({ barsBySymbol: { ...input().barsBySymbol, SPY: [{ ...bar('2026-07-17', 621), l: 700 }] } }),

--- a/services/signal-publisher/src/domain.ts
+++ b/services/signal-publisher/src/domain.ts
@@ -5,7 +5,7 @@ import { Schema } from 'effect'
 export const provider = 'alpaca' as const
 export const adjustment = 'all' as const
 export const calendarTimeZone = 'America/New_York' as const
-export const manifestSchemaVersion = 'signal.adjusted-daily-snapshot.v1' as const
+export const manifestSchemaVersion = 'signal.adjusted-daily-snapshot.v2' as const
 
 const validIsoDate = (value: string): boolean => {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false
@@ -96,6 +96,8 @@ export interface ManifestRow {
   readonly publisher_source_revision: string
   readonly publisher_image_repository: string
   readonly publisher_image_digest: string
+  readonly universe_id: string
+  readonly universe_symbol_hash: string
   readonly provider: typeof provider
   readonly source_feed: 'iex' | 'sip'
   readonly adjustment: typeof adjustment
@@ -123,6 +125,8 @@ export interface BuildPublicationInput {
   readonly barsBySymbol: Readonly<Record<string, readonly AlpacaBar[]>>
   readonly calendar: readonly AlpacaCalendarSession[]
   readonly symbols: readonly string[]
+  readonly universeId: string
+  readonly universeSymbolHash: string
   readonly feed: 'iex' | 'sip'
   readonly calendarVersion: string
   readonly requestedStart: IsoDate
@@ -207,11 +211,18 @@ const validateSymbols = (symbols: readonly string[]): readonly string[] => {
   return normalized
 }
 
+export const canonicalSymbolHash = (symbols: readonly string[]): string =>
+  createHash('sha256').update(validateSymbols(symbols).join(',')).digest('hex')
+
 const manifestHash = (manifest: Omit<ManifestRow, 'manifest_content_hash'>): string =>
   hashJson(manifest as unknown as Json)
 
 export const buildPublication = (input: BuildPublicationInput): Publication => {
   const symbols = validateSymbols(input.symbols)
+  if (!/^[a-z0-9]+(?:[.-][a-z0-9]+)*$/.test(input.universeId)) reject('universe ID is invalid')
+  if (input.universeSymbolHash !== canonicalSymbolHash(symbols)) {
+    reject('universe symbol hash does not match canonical symbols')
+  }
   if (input.requestedStart > input.publicationAsOf) reject('requested start must not be after publication as-of')
   if (
     !/^\d{4}-\d{2}-\d{2} (?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d\.\d{3}$/.test(input.finalizedAt) ||
@@ -281,6 +292,8 @@ export const buildPublication = (input: BuildPublicationInput): Publication => {
   const sessionsContentHash = hashJson(sessionsWithoutSnapshot as unknown as Json)
   const snapshotIdentity = {
     schemaVersion: manifestSchemaVersion,
+    universeId: input.universeId,
+    universeSymbolHash: input.universeSymbolHash,
     provider,
     feed: input.feed,
     adjustment,
@@ -294,20 +307,26 @@ export const buildPublication = (input: BuildPublicationInput): Publication => {
   const snapshotId = hashJson(snapshotIdentity)
   const bars = barsWithoutSnapshot.map((bar) => ({ snapshot_id: snapshotId, ...bar }))
   const sessions = sessionsWithoutSnapshot.map((session) => ({ snapshot_id: snapshotId, ...session }))
+  const firstSession = sessions[0]
+  if (firstSession === undefined) reject('calendar returned no exchange sessions')
+  const lastSession = sessions[sessions.length - 1]
+  if (lastSession === undefined) reject('calendar returned no exchange sessions')
   const manifestWithoutHash: Omit<ManifestRow, 'manifest_content_hash'> = {
     snapshot_id: snapshotId,
     schema_version: manifestSchemaVersion,
     publisher_source_revision: input.provenance.sourceRevision,
     publisher_image_repository: input.provenance.imageRepository,
     publisher_image_digest: input.provenance.imageDigest,
+    universe_id: input.universeId,
+    universe_symbol_hash: input.universeSymbolHash,
     provider,
     source_feed: input.feed,
     adjustment,
     calendar_version: input.calendarVersion,
     requested_start: input.requestedStart,
     publication_asof: input.publicationAsOf,
-    first_session: sessions[0].session_date,
-    last_session: sessions.at(-1)!.session_date,
+    first_session: firstSession.session_date,
+    last_session: lastSession.session_date,
     symbol_count: symbols.length,
     session_count: sessions.length,
     bar_count: bars.length,

--- a/services/signal-publisher/src/publish.test.ts
+++ b/services/signal-publisher/src/publish.test.ts
@@ -23,6 +23,8 @@ const publication = (
     },
     calendar: [{ date: '2026-07-17', open: '09:30', close: '16:00' }],
     symbols: ['SPY'],
+    universeId: 'equity-infrastructure-v1',
+    universeSymbolHash: '6493341e6b5636b2080fa9a1961f4fd3f1736f4486672060d2ef0e5d59b0f946',
     feed: 'iex',
     calendarVersion: 'alpaca-us-equity-calendar-v1',
     requestedStart: '2026-07-17',

--- a/services/signal-publisher/src/publish.ts
+++ b/services/signal-publisher/src/publish.ts
@@ -164,6 +164,8 @@ const loadPublication = (
           barsBySymbol,
           calendar: boundedCalendar,
           symbols: config.symbols,
+          universeId: config.universe.id,
+          universeSymbolHash: config.universe.symbolHash,
           feed: config.alpaca.feed,
           calendarVersion: config.calendarVersion,
           requestedStart,
@@ -276,6 +278,8 @@ export const publish = (
     yield* Effect.logInfo('Signal snapshot validated').pipe(
       Effect.annotateLogs({
         snapshotId: publication.manifest.snapshot_id,
+        universeId: publication.manifest.universe_id,
+        universeSymbolHash: publication.manifest.universe_symbol_hash,
         publicationAsOf: publication.manifest.publication_asof,
         barCount: publication.manifest.bar_count,
         sessionCount: publication.manifest.session_count,
@@ -285,6 +289,8 @@ export const publish = (
     yield* Effect.logInfo('Signal snapshot finalized').pipe(
       Effect.annotateLogs({
         snapshotId: result.snapshotId,
+        universeId: config.universe.id,
+        universeSymbolHash: config.universe.symbolHash,
         publicationAsOf: result.publicationAsOf,
         reused: result.reused,
         barCount: result.barCount,

--- a/services/signal-publisher/src/repository.ts
+++ b/services/signal-publisher/src/repository.ts
@@ -33,6 +33,7 @@ const Hash = Schema.String.check(Schema.isPattern(/^[0-9a-f]{64}$/))
 const SourceRevision = Schema.String.check(Schema.isPattern(/^[0-9a-f]{40}$/))
 const ImageRepository = Schema.String.check(Schema.isPattern(/^[a-z0-9.-]+(?::[0-9]+)?\/[a-z0-9._/-]+$/))
 const ImageDigest = Schema.String.check(Schema.isPattern(/^sha256:[0-9a-f]{64}$/))
+const UniverseId = Schema.String.check(Schema.isPattern(/^[a-z0-9]+(?:[.-][a-z0-9]+)*$/))
 const NonEmptyString = Schema.Trim.check(Schema.isMinLength(1))
 const FinalizedAt = Schema.String.check(Schema.isPattern(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}$/))
 
@@ -68,6 +69,8 @@ const ManifestRowSchema = Schema.Struct({
   publisher_source_revision: SourceRevision,
   publisher_image_repository: ImageRepository,
   publisher_image_digest: ImageDigest,
+  universe_id: UniverseId,
+  universe_symbol_hash: Hash,
   provider: Schema.Literal(provider),
   source_feed: Schema.Literals(['iex', 'sip']),
   adjustment: Schema.Literal(adjustment),
@@ -85,9 +88,10 @@ const ManifestRowSchema = Schema.Struct({
   finalized_at: FinalizedAt,
 })
 
-const decodeBars = Schema.decodeUnknownSync(Schema.Array(BarRowSchema))
-const decodeSessions = Schema.decodeUnknownSync(Schema.Array(SessionRowSchema))
-const decodeManifests = Schema.decodeUnknownSync(Schema.Array(ManifestRowSchema))
+const decodeBars = (input: unknown): readonly BarRow[] => Schema.decodeUnknownSync(Schema.Array(BarRowSchema))(input)
+const decodeSessions = (input: unknown): readonly SessionRow[] =>
+  Schema.decodeUnknownSync(Schema.Array(SessionRowSchema))(input)
+const decodeManifestRows = Schema.decodeUnknownSync(Schema.Array(ManifestRowSchema))
 
 const asCount = (value: string | number, name: string): number => {
   const parsed = typeof value === 'number' ? value : Number(value)
@@ -137,7 +141,7 @@ export const makeSnapshotRepository: Effect.Effect<SnapshotRepository, never, Cl
         ORDER BY session_date, symbol
       `.pipe(
         storage('failed to read staged bars'),
-        Effect.flatMap((rows) => decodeReadback('bar rows', () => decodeBars(rows) as readonly BarRow[])),
+        Effect.flatMap((rows) => decodeReadback('bar rows', () => decodeBars(rows))),
       )
 
     const loadSessions = (snapshotId: string): Effect.Effect<readonly SessionRow[], PublicationError> =>
@@ -155,9 +159,7 @@ export const makeSnapshotRepository: Effect.Effect<SnapshotRepository, never, Cl
         ORDER BY session_date
       `.pipe(
         storage('failed to read staged exchange sessions'),
-        Effect.flatMap((rows) =>
-          decodeReadback('exchange-session rows', () => decodeSessions(rows) as readonly SessionRow[]),
-        ),
+        Effect.flatMap((rows) => decodeReadback('exchange-session rows', () => decodeSessions(rows))),
       )
 
     const loadManifests = (snapshotId: string): Effect.Effect<readonly ManifestRow[], PublicationError> =>
@@ -168,6 +170,8 @@ export const makeSnapshotRepository: Effect.Effect<SnapshotRepository, never, Cl
           publisher_source_revision,
           publisher_image_repository,
           publisher_image_digest,
+          universe_id,
+          universe_symbol_hash,
           provider,
           source_feed,
           adjustment,
@@ -183,21 +187,19 @@ export const makeSnapshotRepository: Effect.Effect<SnapshotRepository, never, Cl
           sessions_content_hash,
           manifest_content_hash,
           toString(finalized_at) AS finalized_at
-        FROM signal.snapshot_manifests_v1
+        FROM signal.snapshot_manifests_v2
         WHERE snapshot_id = ${sql.param('String', snapshotId)}
         ORDER BY finalized_at
       `.pipe(
         storage('failed to read snapshot manifest'),
         Effect.flatMap((rows) =>
-          decodeReadback(
-            'manifest rows',
-            () =>
-              decodeManifests(rows).map((row) => ({
-                ...row,
-                symbol_count: asCount(row.symbol_count, 'symbol_count'),
-                session_count: asCount(row.session_count, 'session_count'),
-                bar_count: asCount(row.bar_count, 'bar_count'),
-              })) as readonly ManifestRow[],
+          decodeReadback('manifest rows', () =>
+            decodeManifestRows(rows).map((row) => ({
+              ...row,
+              symbol_count: asCount(row.symbol_count, 'symbol_count'),
+              session_count: asCount(row.session_count, 'session_count'),
+              bar_count: asCount(row.bar_count, 'bar_count'),
+            })),
           ),
         ),
       )
@@ -226,6 +228,6 @@ export const makeSnapshotRepository: Effect.Effect<SnapshotRepository, never, Cl
       loadManifests,
       insertBars: (snapshotId, rows) => insert('signal.adjusted_daily_bars_v2', snapshotId, 'bars', rows),
       insertSessions: (snapshotId, rows) => insert('signal.exchange_sessions_v1', snapshotId, 'sessions', rows),
-      insertManifest: (row) => insert('signal.snapshot_manifests_v1', row.snapshot_id, 'manifest', [row]),
+      insertManifest: (row) => insert('signal.snapshot_manifests_v2', row.snapshot_id, 'manifest', [row]),
     }
   })

--- a/services/signal-publisher/src/runtime-smoke.ts
+++ b/services/signal-publisher/src/runtime-smoke.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
 import process from 'node:process'
 
 const [entrypoint, sourceRevision, imageRepository] = process.argv.slice(2)
@@ -6,6 +7,9 @@ const [entrypoint, sourceRevision, imageRepository] = process.argv.slice(2)
 if (!entrypoint || !sourceRevision || !imageRepository) {
   throw new Error('usage: runtime-smoke ENTRYPOINT SOURCE_REVISION IMAGE_REPOSITORY')
 }
+
+const symbols = 'SPY'
+const symbolHash = createHash('sha256').update(symbols).digest('hex')
 
 const result = spawnSync('node', [entrypoint, 'daily'], {
   encoding: 'utf8',
@@ -19,7 +23,9 @@ const result = spawnSync('node', [entrypoint, 'daily'], {
     SIGNAL_ALPACA_TRADING_URL: 'http://127.0.0.1:1',
     APCA_API_KEY_ID: 'runtime-smoke',
     APCA_API_SECRET_KEY: 'runtime-smoke',
-    SIGNAL_SYMBOLS: 'SPY',
+    SIGNAL_UNIVERSE_ID: 'runtime-smoke-v1',
+    SIGNAL_UNIVERSE_SYMBOL_HASH: symbolHash,
+    SIGNAL_SYMBOLS: symbols,
     SIGNAL_START_DATE: '2026-07-17',
     SIGNAL_CODE_REVISION: sourceRevision,
     SIGNAL_IMAGE_REPOSITORY: imageRepository,

--- a/services/signal-publisher/src/update-manifests.test.ts
+++ b/services/signal-publisher/src/update-manifests.test.ts
@@ -6,18 +6,22 @@ const manifests = {
   kustomization:
     'images:\n  - name: registry.ide-newton.ts.net/lab/signal-publisher\n    newName: registry.ide-newton.ts.net/lab/signal-publisher\n    newTag: bootstrap\n',
   cronJob: `spec:\n  suspend: true\n  jobTemplate:\n    spec:\n      template:\n        spec:\n          containers:\n            - env:\n                - name: SIGNAL_CODE_REVISION\n                  value: bootstrap\n                - name: SIGNAL_IMAGE_DIGEST\n                  value: sha256:old\n`,
+  backfillJob: `spec:\n  suspend: true\n  template:\n    spec:\n      containers:\n        - env:\n            - name: SIGNAL_CODE_REVISION\n              value: bootstrap\n            - name: SIGNAL_IMAGE_DIGEST\n              value: sha256:old\n`,
 }
 
 describe('Signal publisher manifest promotion', () => {
-  test('pins the immutable image, binds provenance, and activates the CronJob', () => {
+  test('pins the immutable image and provenance without activating either writer', () => {
     const sourceSha = '1'.repeat(40)
     const digest = `sha256:${'b'.repeat(64)}`
     const updated = updateSignalPublisherManifests({ sourceSha, tag: `sha-${sourceSha}`, digest }, manifests)
 
     expect(updated.kustomization).toContain(`newTag: "sha-${sourceSha}"\n    digest: ${digest}`)
-    expect(updated.cronJob).toContain('suspend: false')
+    expect(updated.cronJob).toContain('suspend: true')
     expect(updated.cronJob).toContain(`- name: SIGNAL_CODE_REVISION\n                  value: "${sourceSha}"`)
     expect(updated.cronJob).toContain(`- name: SIGNAL_IMAGE_DIGEST\n                  value: ${digest}`)
+    expect(updated.backfillJob).toContain('suspend: true')
+    expect(updated.backfillJob).toContain(`- name: SIGNAL_CODE_REVISION\n              value: "${sourceSha}"`)
+    expect(updated.backfillJob).toContain(`- name: SIGNAL_IMAGE_DIGEST\n              value: ${digest}`)
   })
 
   test('rejects malformed release metadata without changing inputs', () => {
@@ -26,5 +30,6 @@ describe('Signal publisher manifest promotion', () => {
     ).toThrow('invalid source SHA')
     expect(manifests.kustomization).toContain('newTag: bootstrap')
     expect(manifests.cronJob).toContain('suspend: true')
+    expect(manifests.backfillJob).toContain('suspend: true')
   })
 })

--- a/services/signal-publisher/src/update-manifests.ts
+++ b/services/signal-publisher/src/update-manifests.ts
@@ -18,11 +18,13 @@ export interface ReleaseIdentity {
 export interface SignalPublisherManifests {
   readonly kustomization: string
   readonly cronJob: string
+  readonly backfillJob: string
 }
 
 interface UpdateFilesOptions extends ReleaseIdentity {
   readonly kustomizationPath: string
   readonly cronJobPath: string
+  readonly backfillJobPath: string
 }
 
 const replaceExactlyOnce = (source: string, pattern: RegExp, replacement: string, name: string): string => {
@@ -51,38 +53,41 @@ export const updateSignalPublisherManifests = (
     'Signal publisher image block',
   )
 
-  let cronJob = replaceExactlyOnce(
-    manifests.cronJob,
-    /(^  suspend: )(?:true|false)$/m,
-    '$1false',
-    'Signal publisher suspend state',
-  )
-  cronJob = replaceExactlyOnce(
-    cronJob,
-    /(                - name: SIGNAL_CODE_REVISION\n                  value: )[^\n]+/,
-    `$1${JSON.stringify(release.sourceSha)}`,
-    'SIGNAL_CODE_REVISION value',
-  )
-  cronJob = replaceExactlyOnce(
-    cronJob,
-    /(                - name: SIGNAL_IMAGE_DIGEST\n                  value: )[^\n]+/,
-    `$1${release.digest}`,
-    'SIGNAL_IMAGE_DIGEST value',
-  )
-  return { kustomization, cronJob }
+  const pinProvenance = (manifest: string, name: string): string => {
+    const withRevision = replaceExactlyOnce(
+      manifest,
+      /(^[ \t]+- name: SIGNAL_CODE_REVISION\n[ \t]+value: )[^\n]+/m,
+      `$1${JSON.stringify(release.sourceSha)}`,
+      `${name} SIGNAL_CODE_REVISION value`,
+    )
+    return replaceExactlyOnce(
+      withRevision,
+      /(^[ \t]+- name: SIGNAL_IMAGE_DIGEST\n[ \t]+value: )[^\n]+/m,
+      `$1${release.digest}`,
+      `${name} SIGNAL_IMAGE_DIGEST value`,
+    )
+  }
+
+  const cronJob = pinProvenance(manifests.cronJob, 'Signal publisher CronJob')
+  const backfillJob = pinProvenance(manifests.backfillJob, 'Signal publisher backfill Job')
+  return { kustomization, cronJob, backfillJob }
 }
 
 const updateFiles = (options: UpdateFilesOptions) =>
   Effect.gen(function* () {
     const fileSystem = yield* FileSystem.FileSystem
-    const [kustomization, cronJob] = yield* Effect.all([
+    const [kustomization, cronJob, backfillJob] = yield* Effect.all([
       fileSystem.readFileString(options.kustomizationPath),
       fileSystem.readFileString(options.cronJobPath),
+      fileSystem.readFileString(options.backfillJobPath),
     ])
-    const updated = yield* Effect.try(() => updateSignalPublisherManifests(options, { kustomization, cronJob }))
+    const updated = yield* Effect.try(() =>
+      updateSignalPublisherManifests(options, { kustomization, cronJob, backfillJob }),
+    )
     yield* Effect.all([
       fileSystem.writeFileString(options.kustomizationPath, updated.kustomization),
       fileSystem.writeFileString(options.cronJobPath, updated.cronJob),
+      fileSystem.writeFileString(options.backfillJobPath, updated.backfillJob),
     ])
   })
 
@@ -108,6 +113,7 @@ const parseArguments = (argv: readonly string[]): UpdateFilesOptions => {
     digest: required('--digest'),
     kustomizationPath: 'argocd/applications/torghut/clickhouse/kustomization.yaml',
     cronJobPath: 'argocd/applications/torghut/clickhouse/signal-publisher-cronjob.yaml',
+    backfillJobPath: 'argocd/applications/torghut/clickhouse/signal-publisher-bayn-v1-backfill-job.yaml',
   }
 }
 


### PR DESCRIPTION
## Summary

- Bind the versioned equity-infrastructure-v1 universe to the production websocket and Signal publisher from one ConfigMap.
- Add fail-closed universe identity validation, websocket readiness evidence, and Signal V2 manifests that bind universe ID and symbol hash.
- Stage an additive ClickHouse schema and dormant one-shot backfill while suspending the scheduled publisher; this PR cannot write Signal data.
- Make Bayn, Signal, and websocket promotions reuse one current PR without allowing failed or PR builds to cancel an eligible release.

## Related Issues

PROOMPT-393

## Testing

- bun run --filter @proompteng/signal-publisher test (19 passed)
- Signal TypeScript, format, Oxlint, type-aware Oxlint, and production bundle checks
- Bundled Signal runtime smoke with the required universe identity
- services/dorvud/gradlew :websockets:test :websockets:ktlintCheck
- bun test packages/scripts/src/signal/gitops-contract.test.ts (5 passed, 49 assertions)
- bun run lint:argocd
- kustomize build --enable-helm argocd/applications/torghut piped to kubeconform (99 resources; 72 valid, 0 invalid, 0 errors, 27 skipped)
- Strict kubeconform validation of the new universe ConfigMap and dormant backfill Job (2 valid)
- actionlint for Bayn, Signal, and websocket release workflows
- nix-instantiate syntax validation for the Signal image
- GitHub CI: AMD64 and ARM64 Signal images, Dorvud, Signal, Bayn PostgreSQL, packages, Argo, kubeconform, shared compatibility, and workflow lint all passed
- git diff --check

## Breaking Changes

The existing Signal CronJob is intentionally suspended. The V2 manifest table is additive; no existing Signal data is modified or deleted. The one-shot backfill is not rendered and no strategy, broker, or capital authority changes in this PR.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes are documented.
- [x] Documentation and rollout follow-ups are updated under PROOMPT-393.
