### PR TITLE
feat(hermes): add read-only cluster access

### DIFF
--- a/argocd/applications/hermes/README.md
+++ b/argocd/applications/hermes/README.md
@@ -19,18 +19,25 @@ smoke test, manifest change, and normal CI/Codex review.
 ## Runtime boundaries
 
 - The gateway and independent backup CronJob run as UID/GID `10000`; Squid runs as UID/GID `13`.
-- Root filesystems are read-only, all Linux capabilities are dropped, seccomp is `RuntimeDefault`, and no pod receives a
-  Kubernetes service-account token.
+- Root filesystems are read-only, all Linux capabilities are dropped, and seccomp is `RuntimeDefault`. Only the gateway Pod
+  receives a rotating Kubernetes service-account token; backup, migration, restore, and egress-proxy Pods explicitly disable
+  token mounting.
 - The namespace enforces the Kubernetes `restricted` Pod Security profile.
-- Default-deny NetworkPolicies permit the gateway to reach only cluster DNS, Flamingo, and the allowlisted Squid proxy once
-  a compatible policy engine is present. Flannel alone does not enforce these objects; the runbook's disposable live probe
-  must pass before the first sync.
-- Squid permits HTTPS `CONNECT` only to Discord-owned domains and blocks private, tailnet, metadata, and multicast ranges.
+- Default-deny NetworkPolicies permit the gateway to reach only cluster DNS, the Kubernetes API service, Flamingo, and the
+  allowlisted Squid proxy once a compatible policy engine is present. Flannel alone does not enforce these objects; the
+  runbook's disposable live probe must pass before the first sync.
+- Squid permits HTTPS `CONNECT` only to Discord-owned domains and GitHub, and blocks other destinations plus private,
+  tailnet, metadata, and multicast ranges.
+- Hermes receives a digest-pinned Kubernetes 1.35 `kubectl` binary through an OCI image volume. Its custom ClusterRole has
+  only `get`, `list`, and `watch`, excludes core Secrets and interactive Pod subresources, and is bound cluster-wide only to
+  the `hermes` ServiceAccount.
 - The API key comes from `onepassword-infra` through External Secrets. No secret is committed to Git.
 - API key rotation requires a bounded Secret refresh, gateway Pod restart, and old-key rejection/new-key acceptance proof.
 - The API is cluster-local and requires bearer authentication for model requests and detailed health.
 - Plugins, MCP servers, delegation, cron, hooks, speech-to-text, and Discord are disabled for the initial canary.
 - Only `/opt/data/workspace/tuslagch`, Hermes-managed memory, and Hermes-managed skills are writable agent surfaces.
+- Bootstrap maintains a credential-free `proompteng/lab` checkout at `/opt/data/workspace/tuslagch/lab`. Clean `main`
+  checkouts fast-forward on restart; dirty worktrees and non-main branches are preserved.
 
 ## State and recovery
 

--- a/argocd/applications/hermes/bootstrap-lab-checkout.sh
+++ b/argocd/applications/hermes/bootstrap-lab-checkout.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+set -eu
+
+umask 077
+export GIT_TERMINAL_PROMPT="${GIT_TERMINAL_PROMPT:-0}"
+export GIT_CONFIG_NOSYSTEM=1
+export GIT_CONFIG_GLOBAL=/dev/null
+
+repository_url=${LAB_REPOSITORY_URL:-https://github.com/proompteng/lab.git}
+checkout_ref=${LAB_CHECKOUT_REF:-main}
+checkout_dir=${LAB_CHECKOUT_DIR:-/opt/data/workspace/tuslagch/lab}
+revision_file=${LAB_CHECKOUT_REVISION_FILE:-/opt/data/workspace/tuslagch/.lab-source-revision}
+
+case "$checkout_ref" in
+  ''|*[!A-Za-z0-9._/-]*)
+    echo "invalid lab checkout ref: $checkout_ref" >&2
+    exit 1
+    ;;
+esac
+
+if [ -L "$checkout_dir" ]; then
+  echo "lab checkout path must not be a symbolic link: $checkout_dir" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$checkout_dir")" "$(dirname "$revision_file")"
+
+if [ ! -e "$checkout_dir" ]; then
+  staging_dir="${checkout_dir}.clone.$$"
+  cleanup_staging() {
+    rm -rf -- "$staging_dir"
+  }
+  trap cleanup_staging EXIT HUP INT TERM
+  git -c protocol.version=2 clone \
+    --filter=blob:none \
+    --no-tags \
+    --single-branch \
+    --branch "$checkout_ref" \
+    "$repository_url" \
+    "$staging_dir"
+  mv -- "$staging_dir" "$checkout_dir"
+  trap - EXIT HUP INT TERM
+elif [ ! -d "$checkout_dir/.git" ]; then
+  echo "lab checkout path exists but is not a Git worktree: $checkout_dir" >&2
+  exit 1
+else
+  configured_remote=$(git -C "$checkout_dir" remote get-url origin)
+  if [ "$configured_remote" != "$repository_url" ]; then
+    echo "lab checkout origin mismatch: $configured_remote" >&2
+    exit 1
+  fi
+
+  if git -C "$checkout_dir" fetch \
+    --filter=blob:none \
+    --no-tags \
+    --prune \
+    origin \
+    "refs/heads/$checkout_ref:refs/remotes/origin/$checkout_ref"; then
+    current_branch=$(git -C "$checkout_dir" symbolic-ref --quiet --short HEAD || true)
+    if [ "$current_branch" = "$checkout_ref" ] && [ -z "$(git -C "$checkout_dir" status --porcelain)" ]; then
+      git -C "$checkout_dir" merge --ff-only "refs/remotes/origin/$checkout_ref"
+    else
+      echo "preserving local lab checkout state; refreshed origin/$checkout_ref only"
+    fi
+  else
+    echo "warning: could not refresh lab checkout; preserving the existing verified worktree" >&2
+  fi
+fi
+
+revision=$(git -C "$checkout_dir" rev-parse HEAD)
+revision_tmp="${revision_file}.tmp.$$"
+printf '%s\n' "$revision" >"$revision_tmp"
+mv -- "$revision_tmp" "$revision_file"
+printf 'lab_checkout_ready=true revision=%s path=%s\n' "$revision" "$checkout_dir"

--- a/argocd/applications/hermes/bootstrap.sh
+++ b/argocd/applications/hermes/bootstrap.sh
@@ -15,6 +15,11 @@ mkdir -p \
   /opt/data/skills \
   /opt/data/workspace/tuslagch
 
+install -m 0555 /opt/kubectl-image/bin/kubectl /opt/tools/kubectl
+/opt/tools/kubectl version --client=true >/tmp/kubectl-version.log
+
+/bin/sh /opt/bootstrap/bootstrap-lab-checkout.sh
+
 seed_file() {
   source_path=$1
   destination_path=$2

--- a/argocd/applications/hermes/bootstrap/AGENTS.md
+++ b/argocd/applications/hermes/bootstrap/AGENTS.md
@@ -16,7 +16,10 @@ This workspace is the only mutable work area for Tuslagch. Treat it as durable u
 - Ask before sending messages, publishing content, changing external systems, or making any public action.
 - Never claim an action succeeded without a fresh readback from the authoritative surface.
 - Never weaken approvals, network policy, authentication, or this workspace policy.
-- Do not invoke Kubernetes, container engines, SSH, arbitrary network clients, or service-management commands.
+- Kubernetes access is cluster-wide read-only. Use `kubectl` for inspection, logs, events, status, and diagnostics only.
+- Never use `kubectl` to create, apply, edit, patch, replace, delete, scale, execute in, attach to, copy to, or port-forward
+  a resource. Kubernetes Secrets and service-account token subresources are outside your authority.
+- Do not invoke container engines, SSH, arbitrary network clients, or service-management commands.
 - Do not install or enable skills, plugins, MCP servers, cron jobs, hooks, delegation, or new messaging platforms without Greg's explicit request and an operator-reviewed GitOps change.
 - Do not modify `/opt/data/config.yaml`, `/opt/data/SOUL.md`, `/opt/data/IDENTITY.md`, `/opt/data/TOOLS.md`, or `/opt/data/HEARTBEAT.md`; they are operator-managed.
 - Destructive commands and irreversible actions require explicit approval. Prefer recoverable operations.
@@ -40,4 +43,5 @@ This workspace is the only mutable work area for Tuslagch. Treat it as durable u
 - Flamingo is the only approved model endpoint.
 - The API and Discord channel are operator-controlled surfaces; their availability does not expand authority.
 - A healthy process is not proof of a completed external action.
+- The local `proompteng/lab` checkout is `/opt/data/workspace/tuslagch/lab`; preserve local work when inspecting it.
 - If a required capability is disabled, explain the boundary and ask for an operator-reviewed rollout instead of bypassing it.

--- a/argocd/applications/hermes/bootstrap/TOOLS.md
+++ b/argocd/applications/hermes/bootstrap/TOOLS.md
@@ -3,8 +3,11 @@
 - Mutable workspace: `/opt/data/workspace/tuslagch`.
 - Curated memory: `/opt/data/memories`.
 - Primary model: `qwen36-flamingo` through the internal Flamingo service.
-- Kubernetes credentials, host mounts, container sockets, cloud fallbacks, MCP servers, cron, dashboard, and delegation are not available.
-- Discord egress is forced through an operator-managed domain allowlist.
+- Local lab checkout: `/opt/data/workspace/tuslagch/lab`.
+- `kubectl` has cluster-wide read access to non-secret resources. Writes, Kubernetes Secrets, exec, attach, copy, proxy, and
+  port-forward are denied by RBAC.
+- Host mounts, container sockets, cloud fallbacks, MCP servers, cron, dashboard, and delegation are not available.
+- Discord and GitHub egress are forced through an operator-managed domain allowlist.
 - The authenticated API is for canary and operator validation; possession of its key is equivalent to trusted operator access.
 
 Do not add credentials or private infrastructure details to this file.

--- a/argocd/applications/hermes/config.yaml
+++ b/argocd/applications/hermes/config.yaml
@@ -66,6 +66,8 @@ agent:
   reasoning_effort: medium
   coding_instructions:
     - Keep all mutable work inside /opt/data/workspace/tuslagch.
+    - Use /opt/data/workspace/tuslagch/lab as the local proompteng/lab checkout for code and GitOps inspection.
+    - Kubernetes access is cluster-wide read-only; never attempt to mutate resources or read Kubernetes Secrets.
     - Never claim an external action completed without a fresh readback.
 
 platform_toolsets:
@@ -98,7 +100,6 @@ approvals:
   mcp_reload_confirm: true
   destructive_slash_confirm: true
   deny:
-    - "*kubectl*"
     - "*docker*"
     - "*podman*"
     - "*printenv*"
@@ -114,7 +115,27 @@ approvals:
     - "*scp *"
     - "*git push --force*"
 
-command_allowlist: []
+command_allowlist:
+  - "kubectl get *"
+  - "kubectl * get *"
+  - "kubectl describe *"
+  - "kubectl * describe *"
+  - "kubectl logs *"
+  - "kubectl * logs *"
+  - "kubectl top *"
+  - "kubectl * top *"
+  - "kubectl events *"
+  - "kubectl * events *"
+  - "kubectl api-resources*"
+  - "kubectl api-versions*"
+  - "kubectl cluster-info*"
+  - "kubectl version*"
+  - "kubectl explain *"
+  - "kubectl auth can-i *"
+  - "kubectl rollout status *"
+  - "kubectl * rollout status *"
+  - "kubectl rollout history *"
+  - "kubectl * rollout history *"
 
 checkpoints:
   enabled: true

--- a/argocd/applications/hermes/kustomization.yaml
+++ b/argocd/applications/hermes/kustomization.yaml
@@ -15,6 +15,7 @@ configMapGenerator:
   - name: hermes-bootstrap
     files:
       - bootstrap.sh
+      - bootstrap-lab-checkout.sh
       - backup-once.sh
       - AGENTS.md=bootstrap/AGENTS.md
       - HEARTBEAT.md=bootstrap/HEARTBEAT.md
@@ -28,6 +29,7 @@ configMapGenerator:
 
 resources:
   - serviceaccount.yaml
+  - rbac.yaml
   - external-secret.yaml
   - discord-sealed-secret.yaml
   - service.yaml

--- a/argocd/applications/hermes/network-policy.yaml
+++ b/argocd/applications/hermes/network-policy.yaml
@@ -62,6 +62,12 @@ spec:
       ports:
         - protocol: TCP
           port: 3128
+    - to:
+        - ipBlock:
+            cidr: 10.96.0.1/32
+      ports:
+        - protocol: TCP
+          port: 443
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/argocd/applications/hermes/rbac.yaml
+++ b/argocd/applications/hermes/rbac.yaml
@@ -1,0 +1,137 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hermes-cluster-reader
+  labels:
+    app.kubernetes.io/name: hermes
+    app.kubernetes.io/component: gateway
+rules:
+  # Core resources are explicit so Kubernetes Secrets, service-account token
+  # subresources, exec, attach, proxy, and port-forward are never readable.
+  - apiGroups: [""]
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - limitranges
+      - namespaces
+      - nodes
+      - persistentvolumeclaims
+      - persistentvolumes
+      - pods
+      - pods/log
+      - replicationcontrollers
+      - resourcequotas
+      - serviceaccounts
+      - services
+    verbs: [get, list, watch]
+  # Enumerate installed non-core API groups instead of using an API-group
+  # wildcard, which would also match the core API group and expose Secrets.
+  - apiGroups:
+      - acme.cert-manager.io
+      - actions.github.com
+      - admissionregistration.k8s.io
+      - agents.proompteng.ai
+      - apiextensions.k8s.io
+      - apiregistration.k8s.io
+      - approvals.proompteng.ai
+      - apps
+      - argocd-image-updater.argoproj.io
+      - argoproj.io
+      - artifacts.proompteng.ai
+      - autoscaling
+      - autoscaling.internal.knative.dev
+      - backup.kubevirt.io
+      - barmancloud.cnpg.io
+      - batch
+      - bitnami.com
+      - budgets.proompteng.ai
+      - caching.internal.knative.dev
+      - cdi.kubevirt.io
+      - ceph.rook.io
+      - cert-manager.io
+      - certificates.k8s.io
+      - clickhouse-keeper.altinity.com
+      - clickhouse.altinity.com
+      - clone.kubevirt.io
+      - coordination.k8s.io
+      - core.openfeature.dev
+      - core.strimzi.io
+      - crdb.cockroachlabs.com
+      - csi.ceph.io
+      - discovery.k8s.io
+      - eventing.knative.dev
+      - events.k8s.io
+      - export.kubevirt.io
+      - extensions.istio.io
+      - external-secrets.io
+      - flink.apache.org
+      - flowcontrol.apiserver.k8s.io
+      - flows.knative.dev
+      - forklift.cdi.kubevirt.io
+      - gateway.networking.k8s.io
+      - generators.external-secrets.io
+      - groupsnapshot.storage.k8s.io
+      - hub.traefik.io
+      - instancetype.kubevirt.io
+      - internal.kafka.eventing.knative.dev
+      - jetstream.nats.io
+      - kafka.strimzi.io
+      - kubevirt.io
+      - messaging.knative.dev
+      - metallb.io
+      - metrics.k8s.io
+      - migrations.kubevirt.io
+      - networking.internal.knative.dev
+      - networking.istio.io
+      - networking.k8s.io
+      - nfd.k8s-sigs.io
+      - node.k8s.io
+      - nvidia.com
+      - objectbucket.io
+      - operator.knative.dev
+      - orchestration.proompteng.ai
+      - policy
+      - pool.kubevirt.io
+      - postgresql.cnpg.io
+      - rbac.authorization.k8s.io
+      - redis.redis.opstreelabs.in
+      - resource.k8s.io
+      - schedules.proompteng.ai
+      - scheduling.k8s.io
+      - security.istio.io
+      - security.proompteng.ai
+      - serving.knative.dev
+      - signals.proompteng.ai
+      - sinks.knative.dev
+      - snapshot.kubevirt.io
+      - snapshot.storage.k8s.io
+      - sources.knative.dev
+      - storage.k8s.io
+      - subresources.kubevirt.io
+      - swarm.proompteng.ai
+      - tailscale.com
+      - telemetry.istio.io
+      - tigerbeetle.proompteng.ai
+      - tools.proompteng.ai
+      - traefik.io
+      - upload.cdi.kubevirt.io
+      - workspaces.proompteng.ai
+    resources: ["*"]
+    verbs: [get, list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hermes-cluster-reader
+  labels:
+    app.kubernetes.io/name: hermes
+    app.kubernetes.io/component: gateway
+subjects:
+  - kind: ServiceAccount
+    name: hermes
+    namespace: hermes
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hermes-cluster-reader

--- a/argocd/applications/hermes/serviceaccount.yaml
+++ b/argocd/applications/hermes/serviceaccount.yaml
@@ -6,4 +6,4 @@ metadata:
   labels:
     app.kubernetes.io/name: hermes
     app.kubernetes.io/component: gateway
-automountServiceAccountToken: false
+automountServiceAccountToken: true

--- a/argocd/applications/hermes/squid.conf
+++ b/argocd/applications/hermes/squid.conf
@@ -8,10 +8,12 @@ acl allowed_discord dstdomain .discordapp.com
 acl allowed_discord dstdomain .discordapp.net
 acl allowed_discord dstdomain .discordcdn.com
 acl allowed_discord dstdomain .discord.media
+acl allowed_github dstdomain .github.com
 
 http_access deny !CONNECT
 http_access deny CONNECT !SSL_ports
 http_access allow CONNECT allowed_discord
+http_access allow CONNECT allowed_github
 http_access deny all
 
 cache deny all

--- a/argocd/applications/hermes/statefulset.yaml
+++ b/argocd/applications/hermes/statefulset.yaml
@@ -28,7 +28,7 @@ spec:
         app.kubernetes.io/version: v2026.7.7.2
     spec:
       serviceAccountName: hermes
-      automountServiceAccountToken: false
+      automountServiceAccountToken: true
       enableServiceLinks: false
       terminationGracePeriodSeconds: 120
       nodeSelector:
@@ -63,6 +63,18 @@ spec:
               value: /opt/data
             - name: HOME
               value: /opt/data/home
+            - name: GIT_TERMINAL_PROMPT
+              value: "0"
+            - name: LAB_REPOSITORY_URL
+              value: https://github.com/proompteng/lab.git
+            - name: LAB_CHECKOUT_REF
+              value: main
+            - name: HTTP_PROXY
+              value: http://hermes-egress-proxy.hermes.svc.cluster.local:3128
+            - name: HTTPS_PROXY
+              value: http://hermes-egress-proxy.hermes.svc.cluster.local:3128
+            - name: NO_PROXY
+              value: localhost,127.0.0.1,.svc,.svc.cluster.local,10.96.0.1
           resources:
             requests:
               cpu: 50m
@@ -95,6 +107,11 @@ spec:
               readOnly: true
             - name: tmp
               mountPath: /tmp
+            - name: kubectl-image
+              mountPath: /opt/kubectl-image
+              readOnly: true
+            - name: tools
+              mountPath: /opt/tools
       containers:
         - name: hermes
           image: registry.ide-newton.ts.net/lab/hermes-agent@sha256:3db34ce19adfa080736a2a3feb0316dbcccc588faa9afe7fd8ae1c03b4f1a53a
@@ -116,6 +133,8 @@ spec:
               value: /opt/data/home
             - name: XDG_CACHE_HOME
               value: /opt/data/home/.cache
+            - name: PATH
+              value: /opt/tools:/opt/hermes/bin:/opt/hermes/.venv/bin:/opt/data/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
             - name: API_SERVER_ENABLED
               value: "true"
             - name: API_SERVER_HOST
@@ -146,7 +165,7 @@ spec:
             - name: HTTPS_PROXY
               value: http://hermes-egress-proxy.hermes.svc.cluster.local:3128
             - name: NO_PROXY
-              value: localhost,127.0.0.1,.svc,.svc.cluster.local,flamingo.flamingo.svc.cluster.local
+              value: localhost,127.0.0.1,.svc,.svc.cluster.local,10.96.0.1,flamingo.flamingo.svc.cluster.local
             - name: TZ
               value: America/Los_Angeles
           ports:
@@ -234,6 +253,9 @@ spec:
               mountPath: /tmp
             - name: shm
               mountPath: /dev/shm
+            - name: tools
+              mountPath: /opt/tools
+              readOnly: true
       volumes:
         - name: config
           configMap:
@@ -250,6 +272,13 @@ spec:
           emptyDir:
             medium: Memory
             sizeLimit: 1Gi
+        - name: kubectl-image
+          image:
+            reference: registry.k8s.io/kubectl@sha256:0bb95b2a450875fc8ceaea2f9987a99fe27c228846e2e00b93b65ebb0d59034e
+            pullPolicy: IfNotPresent
+        - name: tools
+          emptyDir:
+            sizeLimit: 128Mi
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/docs/runbooks/hermes-production-rollout.md
+++ b/docs/runbooks/hermes-production-rollout.md
@@ -146,7 +146,8 @@ The expected mirrored amd64 manifest digest is
    kubectl -n hermes rollout status deployment/hermes-egress-proxy --timeout=5m
    kubectl -n hermes rollout status statefulset/hermes --timeout=15m
    kubectl -n hermes get pod hermes-0 -o jsonpath='{range .spec.containers[*]}{.name}{"="}{.image}{"\n"}{end}'
-   kubectl -n hermes get pod hermes-0 -o jsonpath='{.spec.securityContext.runAsUser}{" "}{.spec.automountServiceAccountToken}{"\n"}'
+   test "$(kubectl -n hermes get pod hermes-0 -o jsonpath='{.spec.securityContext.runAsUser}')" = 10000
+   test "$(kubectl -n hermes get pod hermes-0 -o jsonpath='{.spec.automountServiceAccountToken}')" = true
    kubectl -n hermes get pvc data-hermes-0 backups-hermes-0
    maintenance_holder="backup-canary-$(openssl rand -hex 8)"
    release_maintenance_lock() { bash scripts/hermes/maintenance-lock.sh release "$maintenance_holder"; }
@@ -252,11 +253,42 @@ The expected mirrored amd64 manifest digest is
    fi
    kubectl -n hermes exec hermes-0 -c hermes -- /opt/hermes/.venv/bin/python -c \
      'import urllib.request; request=urllib.request.Request("https://discord.com/api/v10/gateway", headers={"User-Agent":"DiscordBot (https://proompteng.ai, 1.0)"}); response=urllib.request.urlopen(request, timeout=10); assert response.status == 200; response.read(1)'
+   kubectl -n hermes exec hermes-0 -c hermes -- \
+     git ls-remote --exit-code https://github.com/proompteng/lab.git refs/heads/main
    kubectl -n hermes exec hermes-0 -c hermes -- /bin/sh -c \
      '! /opt/hermes/.venv/bin/python -c '\''import urllib.request; urllib.request.urlopen("https://example.com", timeout=5)'\'''
    ```
 
-   The direct public request must fail. Discord through Squid must connect, and the non-allowlisted domain must fail.
+   The direct public request must fail. Discord and the credential-free GitHub checkout path must work through Squid, and
+   the non-allowlisted domain must fail.
+
+5. Prove the cluster reader and local lab checkout from inside the gateway:
+
+   ```bash
+   set -euo pipefail
+   kubectl -n hermes exec hermes-0 -c hermes -- sh -c '
+     set -eu
+     test "$(kubectl auth can-i list pods --all-namespaces)" = yes
+     test "$(kubectl auth can-i get pods/log --all-namespaces)" = yes
+     test "$(kubectl auth can-i get secrets --all-namespaces)" = no
+     test "$(kubectl auth can-i create deployments.apps --all-namespaces)" = no
+     kubectl get pods --all-namespaces --request-timeout=10s >/tmp/hermes-cluster-pods
+     test -s /tmp/hermes-cluster-pods
+     kubectl -n hermes logs statefulset/hermes --tail=1 >/tmp/hermes-gateway-log
+     ! kubectl -n hermes get secret hermes-api-auth >/tmp/hermes-secret 2>&1
+     ! kubectl -n hermes create configmap hermes-readonly-proof \
+       --from-literal=proof=denied --dry-run=server -o name >/tmp/hermes-write 2>&1
+     test "$(git -C /opt/data/workspace/tuslagch/lab remote get-url origin)" = \
+       https://github.com/proompteng/lab.git
+     test "$(cat /opt/data/workspace/tuslagch/.lab-source-revision)" = \
+       "$(git -C /opt/data/workspace/tuslagch/lab rev-parse HEAD)"
+     git -C /opt/data/workspace/tuslagch/lab cat-file -e HEAD:AGENTS.md
+   '
+   ```
+
+   The `hermes-cluster-reader` ClusterRole must contain only `get`, `list`, and `watch`. It intentionally excludes core
+   Secrets, service-account token subresources, `exec`, `attach`, `proxy`, and `port-forward`. The server-side dry-run is an
+   authorization proof: it must be rejected before admission and must not create a ConfigMap.
 
 ## API key rotation
 
@@ -823,7 +855,8 @@ The rollout record is complete only when it includes:
 - image digests and upstream release commit;
 - Argo `Synced/Healthy` readback at those revisions;
 - ExternalSecret Ready conditions and secret field lengths/counts without values;
-- pod UID, read-only rootfs, no-token, NetworkPolicy, PVC, and verified backup evidence;
+- pod UID, read-only rootfs, scoped service-account token, NetworkPolicy, PVC, and verified backup evidence;
+- gateway service-account identity, allowed cluster-wide reads, rejected Secret reads and writes, and the lab checkout SHA;
 - authenticated API rejection/success, Flamingo model response, and persistence after restart;
 - migration dry-run/apply Job identities and report counts;
 - single-writer Discord message lifecycle IDs and non-allowlisted-user rejection;

--- a/scripts/hermes/bootstrap-lab-checkout.test.ts
+++ b/scripts/hermes/bootstrap-lab-checkout.test.ts
@@ -1,0 +1,86 @@
+import { expect, test } from 'bun:test'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const script = join(import.meta.dir, '../../argocd/applications/hermes/bootstrap-lab-checkout.sh')
+
+async function git(cwd: string, ...args: string[]): Promise<string> {
+  const process = Bun.spawn(['git', ...args], { cwd, stdout: 'pipe', stderr: 'pipe' })
+  const [exitCode, stdout, stderr] = await Promise.all([
+    process.exited,
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+  ])
+  if (exitCode !== 0) {
+    throw new Error(`git ${args.join(' ')} failed: ${stderr}`)
+  }
+  return stdout.trim()
+}
+
+async function runCheckout(
+  repository: string,
+  checkout: string,
+  revisionFile: string,
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const process = Bun.spawn(['/bin/sh', script], {
+    env: {
+      ...processEnv,
+      GIT_TERMINAL_PROMPT: '0',
+      LAB_REPOSITORY_URL: repository,
+      LAB_CHECKOUT_REF: 'main',
+      LAB_CHECKOUT_DIR: checkout,
+      LAB_CHECKOUT_REVISION_FILE: revisionFile,
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const [exitCode, stdout, stderr] = await Promise.all([
+    process.exited,
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+  ])
+  return { exitCode, stdout, stderr }
+}
+
+const processEnv = { ...Bun.env }
+
+test('creates, fast-forwards, and preserves a dirty lab checkout', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'hermes-lab-checkout-'))
+  const source = join(root, 'source')
+  const checkout = join(root, 'checkout')
+  const revisionFile = join(root, 'lab-source-revision')
+
+  try {
+    await git(root, 'init', '--initial-branch=main', source)
+    await git(source, 'config', 'user.name', 'Hermes Test')
+    await git(source, 'config', 'user.email', 'hermes-test@example.invalid')
+    await writeFile(join(source, 'README.md'), 'first\n')
+    await git(source, 'add', 'README.md')
+    await git(source, 'commit', '-m', 'first')
+
+    const initial = await runCheckout(source, checkout, revisionFile)
+    expect(initial.exitCode).toBe(0)
+    expect(initial.stdout).toContain('lab_checkout_ready=true')
+    expect(await readFile(join(checkout, 'README.md'), 'utf8')).toBe('first\n')
+    expect((await readFile(revisionFile, 'utf8')).trim()).toBe(await git(source, 'rev-parse', 'HEAD'))
+
+    await writeFile(join(source, 'README.md'), 'second\n')
+    await git(source, 'add', 'README.md')
+    await git(source, 'commit', '-m', 'second')
+    const refreshed = await runCheckout(source, checkout, revisionFile)
+    expect(refreshed.exitCode).toBe(0)
+    expect(await readFile(join(checkout, 'README.md'), 'utf8')).toBe('second\n')
+
+    await writeFile(join(checkout, 'README.md'), 'local work\n')
+    await writeFile(join(source, 'README.md'), 'third\n')
+    await git(source, 'add', 'README.md')
+    await git(source, 'commit', '-m', 'third')
+    const preserved = await runCheckout(source, checkout, revisionFile)
+    expect(preserved.exitCode).toBe(0)
+    expect(preserved.stdout).toContain('preserving local lab checkout state')
+    expect(await readFile(join(checkout, 'README.md'), 'utf8')).toBe('local work\n')
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})

--- a/scripts/hermes/validate-production.test.ts
+++ b/scripts/hermes/validate-production.test.ts
@@ -6,6 +6,57 @@ test('accepts the committed Hermes production surfaces', async () => {
   expect(validateProductionContent(await loadProductionFiles())).toEqual([])
 })
 
+test('rejects Kubernetes write verbs in the Hermes ClusterRole', async () => {
+  const files = await loadProductionFiles()
+  files.rbac = files.rbac.replace('verbs: [get, list, watch]', 'verbs: [get, list, watch, create]')
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.rbac}: every RBAC rule must contain only get, list, and watch`,
+  )
+})
+
+test('rejects Kubernetes Secret access in the Hermes ClusterRole', async () => {
+  const files = await loadProductionFiles()
+  files.rbac = files.rbac.replace('      - services\n', '      - services\n      - secrets\n')
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.rbac}: contains forbidden production term "      - secrets"`,
+  )
+})
+
+test('rejects disabling the gateway service-account token', async () => {
+  const files = await loadProductionFiles()
+  files.statefulSet = files.statefulSet.replace(
+    '      automountServiceAccountToken: true',
+    '      automountServiceAccountToken: false',
+  )
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.statefulSet}: missing production invariant "automountServiceAccountToken: true"`,
+  )
+})
+
+test('rejects a mutable kubectl image volume', async () => {
+  const files = await loadProductionFiles()
+  files.statefulSet = files.statefulSet.replace(
+    /registry\.k8s\.io\/kubectl@sha256:[a-f0-9]+/,
+    'registry.k8s.io/kubectl:latest',
+  )
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.statefulSet}: kubectl must use exactly one immutable Kubernetes 1.35 OCI volume`,
+  )
+})
+
+test('rejects restoring the blanket kubectl command deny', async () => {
+  const files = await loadProductionFiles()
+  files.config = files.config.replace('  deny:\n', '  deny:\n    - "*kubectl*"\n')
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.config}: contains forbidden production term "    - \\"*kubectl*\\""`,
+  )
+})
+
 test('rejects a mutable Hermes runtime image', async () => {
   const files = await loadProductionFiles()
   files.statefulSet = files.statefulSet.replace(

--- a/scripts/hermes/validate-production.ts
+++ b/scripts/hermes/validate-production.ts
@@ -4,6 +4,7 @@ import { readFile } from 'node:fs/promises'
 const hermesImage =
   'registry.ide-newton.ts.net/lab/hermes-agent@sha256:3db34ce19adfa080736a2a3feb0316dbcccc588faa9afe7fd8ae1c03b4f1a53a'
 const squidImage = 'docker.io/ubuntu/squid@sha256:8a3baed477e2c282ab8aa5edad442f69873246964f225c5c2ae8364b6610963c'
+const kubectlImage = 'registry.k8s.io/kubectl@sha256:0bb95b2a450875fc8ceaea2f9987a99fe27c228846e2e00b93b65ebb0d59034e'
 
 export const productionPaths = {
   kustomization: 'argocd/applications/hermes/kustomization.yaml',
@@ -15,7 +16,14 @@ export const productionPaths = {
   discordSealedSecret: 'argocd/applications/hermes/discord-sealed-secret.yaml',
   networkPolicy: 'argocd/applications/hermes/network-policy.yaml',
   egressProxy: 'argocd/applications/hermes/egress-proxy.yaml',
+  squidConfig: 'argocd/applications/hermes/squid.conf',
   serviceAccount: 'argocd/applications/hermes/serviceaccount.yaml',
+  rbac: 'argocd/applications/hermes/rbac.yaml',
+  bootstrap: 'argocd/applications/hermes/bootstrap.sh',
+  labCheckout: 'argocd/applications/hermes/bootstrap-lab-checkout.sh',
+  workspaceAgents: 'argocd/applications/hermes/bootstrap/AGENTS.md',
+  workspaceTools: 'argocd/applications/hermes/bootstrap/TOOLS.md',
+  readme: 'argocd/applications/hermes/README.md',
   migrationDryRun: 'argocd/applications/hermes/operations/migration-dry-run-job.yaml',
   migrationApply: 'argocd/applications/hermes/operations/migration-apply-job.yaml',
   restoreStage: 'argocd/applications/hermes/operations/restore-stage-pod.yaml',
@@ -77,8 +85,10 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     '- statefulset.yaml',
     '- backup-cronjob.yaml',
     '- network-policy.yaml',
+    '- rbac.yaml',
     '- external-secret.yaml',
     '- discord-sealed-secret.yaml',
+    '- bootstrap-lab-checkout.sh',
   ])
   forbidTerms(failures, productionPaths.kustomization, files.kustomization, [
     'kind: Namespace',
@@ -96,7 +106,7 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'persistentVolumeClaimRetentionPolicy:',
     'whenDeleted: Retain',
     'whenScaled: Retain',
-    'automountServiceAccountToken: false',
+    'automountServiceAccountToken: true',
     'runAsUser: 10000',
     'runAsGroup: 10000',
     'readOnlyRootFilesystem: true',
@@ -109,6 +119,13 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'name: backups',
     'mountPath: /opt/backups\n              readOnly: true',
     'storageClassName: rook-ceph-block',
+    `reference: ${kubectlImage}`,
+    'mountPath: /opt/kubectl-image',
+    'mountPath: /opt/tools',
+    'value: /opt/tools:/opt/hermes/bin:',
+    'value: https://github.com/proompteng/lab.git',
+    'value: main',
+    'value: localhost,127.0.0.1,.svc,.svc.cluster.local,10.96.0.1',
   ])
   forbidTerms(failures, productionPaths.statefulSet, files.statefulSet, [
     ':latest',
@@ -118,6 +135,9 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'hostPID: true',
     '        - name: backup\n',
   ])
+  if (count(files.statefulSet, `reference: ${kubectlImage}`) !== 1) {
+    failures.push(`${productionPaths.statefulSet}: kubectl must use exactly one immutable Kubernetes 1.35 OCI volume`)
+  }
   for (const key of ['DISCORD_BOT_TOKEN', 'DISCORD_ALLOWED_USERS']) {
     const reference = [
       `            - name: ${key}`,
@@ -197,8 +217,20 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'mcp_servers: {}',
     'hooks_auto_accept: false',
     'memory_char_limit: 4400',
+    'Use /opt/data/workspace/tuslagch/lab as the local proompteng/lab checkout',
+    'Kubernetes access is cluster-wide read-only',
+    '  - "kubectl get *"',
+    '  - "kubectl * get *"',
+    '  - "kubectl logs *"',
+    '  - "kubectl * logs *"',
+    '  - "kubectl auth can-i *"',
   ])
-  forbidTerms(failures, productionPaths.config, files.config, ['api_key:', 'token:', 'allow_all_users: true'])
+  forbidTerms(failures, productionPaths.config, files.config, [
+    'api_key:',
+    'token:',
+    'allow_all_users: true',
+    '    - "*kubectl*"',
+  ])
 
   requireTerms(failures, productionPaths.externalSecret, files.externalSecret, [
     'name: onepassword-infra',
@@ -293,6 +325,7 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     '- 100.64.0.0/10',
     '- 169.254.0.0/16',
     '- 192.168.0.0/16',
+    'cidr: 10.96.0.1/32',
   ])
   forbidTerms(failures, productionPaths.networkPolicy, files.networkPolicy, [
     '          port: 80\n',
@@ -308,16 +341,90 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'readOnlyRootFilesystem: true',
     'allowPrivilegeEscalation: false',
   ])
+  requireTerms(failures, productionPaths.squidConfig, files.squidConfig, [
+    'acl allowed_discord dstdomain .discord.com',
+    'acl allowed_github dstdomain .github.com',
+    'http_access allow CONNECT allowed_discord',
+    'http_access allow CONNECT allowed_github',
+    'http_access deny all',
+  ])
+  forbidTerms(failures, productionPaths.squidConfig, files.squidConfig, [
+    'http_access allow all',
+    'dstdomain .gitlab.com',
+  ])
 
   requireTerms(failures, productionPaths.serviceAccount, files.serviceAccount, [
     'kind: ServiceAccount',
-    'automountServiceAccountToken: false',
+    'automountServiceAccountToken: true',
   ])
   forbidTerms(failures, productionPaths.serviceAccount, files.serviceAccount, [
     'kind: Role',
     'kind: ClusterRole',
     'kind: RoleBinding',
     'kind: ClusterRoleBinding',
+  ])
+
+  requireTerms(failures, productionPaths.rbac, files.rbac, [
+    'kind: ClusterRole',
+    'name: hermes-cluster-reader',
+    'apiGroups: [""]',
+    'resources: ["*"]',
+    'kind: ClusterRoleBinding',
+    'kind: ServiceAccount',
+    'name: hermes',
+    'namespace: hermes',
+    'name: hermes-cluster-reader',
+    '      - pods',
+    '      - pods/log',
+  ])
+  forbidTerms(failures, productionPaths.rbac, files.rbac, [
+    'apiGroups: ["*"]',
+    '      - secrets',
+    '      - serviceaccounts/token',
+    '      - pods/exec',
+    '      - pods/attach',
+    '      - pods/portforward',
+    '      - services/proxy',
+    'name: cluster-admin',
+  ])
+  const rbacVerbLists = [...files.rbac.matchAll(/^\s+verbs:\s+\[([^\]]+)]$/gm)]
+  if (rbacVerbLists.length !== 2 || rbacVerbLists.some((match) => match[1]?.replaceAll(' ', '') !== 'get,list,watch')) {
+    failures.push(`${productionPaths.rbac}: every RBAC rule must contain only get, list, and watch`)
+  }
+
+  requireTerms(failures, productionPaths.bootstrap, files.bootstrap, [
+    'install -m 0555 /opt/kubectl-image/bin/kubectl /opt/tools/kubectl',
+    '/opt/tools/kubectl version --client=true',
+    '/bin/sh /opt/bootstrap/bootstrap-lab-checkout.sh',
+  ])
+  requireTerms(failures, productionPaths.labCheckout, files.labCheckout, [
+    'set -eu',
+    'GIT_TERMINAL_PROMPT',
+    'https://github.com/proompteng/lab.git',
+    'LAB_CHECKOUT_REF:-main',
+    'LAB_CHECKOUT_DIR:-/opt/data/workspace/tuslagch/lab',
+    'if [ -L "$checkout_dir" ]',
+    '--filter=blob:none',
+    'git -C "$checkout_dir" fetch',
+    'git -C "$checkout_dir" merge --ff-only',
+    'preserving local lab checkout state',
+    'preserving the existing verified worktree',
+    'lab_checkout_ready=true',
+  ])
+  requireTerms(failures, productionPaths.workspaceAgents, files.workspaceAgents, [
+    'Kubernetes access is cluster-wide read-only.',
+    'Kubernetes Secrets and service-account token subresources are outside your authority.',
+    '/opt/data/workspace/tuslagch/lab',
+  ])
+  requireTerms(failures, productionPaths.workspaceTools, files.workspaceTools, [
+    '`kubectl` has cluster-wide read access to non-secret resources.',
+    'Writes, Kubernetes Secrets, exec, attach, copy, proxy, and',
+    '/opt/data/workspace/tuslagch/lab',
+  ])
+  requireTerms(failures, productionPaths.readme, files.readme, [
+    'digest-pinned Kubernetes 1.35 `kubectl` binary',
+    'only `get`, `list`, and `watch`',
+    'credential-free `proompteng/lab` checkout',
   ])
 
   const operationDeadlines = {
@@ -580,6 +687,16 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'The CronJob must remain suspended until every prior backup',
     'if kubectl -n hermes exec hermes-0 -c hermes -- /opt/hermes/.venv/bin/python -c',
     'direct public egress unexpectedly succeeded',
+    'git ls-remote --exit-code https://github.com/proompteng/lab.git refs/heads/main',
+    'test "$(kubectl auth can-i list pods --all-namespaces)" = yes',
+    'test "$(kubectl auth can-i get secrets --all-namespaces)" = no',
+    'test "$(kubectl auth can-i create deployments.apps --all-namespaces)" = no',
+    '! kubectl -n hermes get secret hermes-api-auth',
+    '! kubectl -n hermes create configmap hermes-readonly-proof',
+    'git -C /opt/data/workspace/tuslagch/lab remote get-url origin',
+    'cat /opt/data/workspace/tuslagch/.lab-source-revision',
+    'git -C /opt/data/workspace/tuslagch/lab cat-file -e HEAD:AGENTS.md',
+    'gateway service-account identity, allowed cluster-wide reads, rejected Secret reads and writes, and the lab checkout SHA',
     "'rm -rf -- /opt/data/migration/source && mkdir -p /opt/data/migration/source'",
     "find /opt/backups -maxdepth 1 -type f -name 'hermes-backup-*.zip' -print",
     'test "$sidecar_archive" = "$archive_name"',


### PR DESCRIPTION
## Summary

- Give the Hermes gateway cluster-wide get/list/watch access while excluding Kubernetes Secrets, write verbs, and interactive pod subresources.
- Install digest-pinned Kubernetes 1.35 kubectl from an OCI image volume and permit only the API service through the gateway network policy.
- Maintain a credential-free, persistent proompteng/lab checkout at /opt/data/workspace/tuslagch/lab while preserving dirty worktrees and non-main branches.
- Allow only GitHub and Discord through the Squid egress proxy and document live authorization and checkout proof.

## Related Issues

None

## Testing

- `bun run scripts/hermes/validate-production.ts` (validated 36 production surfaces)
- `bun test scripts/hermes/*.test.ts` (98 passed, 0 failed)
- `bunx oxfmt --check scripts/hermes/validate-production.ts scripts/hermes/validate-production.test.ts scripts/hermes/bootstrap-lab-checkout.test.ts`
- `shellcheck argocd/applications/hermes/bootstrap.sh argocd/applications/hermes/bootstrap-lab-checkout.sh`
- `kustomize build --enable-helm argocd/applications/hermes | kubeconform -strict -ignore-missing-schemas -summary` (0 invalid, 0 errors)
- Rendered manifests passed `kubectl -n hermes apply --dry-run=server -f ...`
- Live image-volume probe copied and executed the pinned kubectl client as v1.35.0 linux/amd64.
- Live preflight confirmed /opt/data/workspace/tuslagch/lab is absent, so first bootstrap will create it without overwriting existing data.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
