### PR TITLE
fix(hermes): allow API endpoint egress

### DIFF
--- a/argocd/applications/hermes/README.md
+++ b/argocd/applications/hermes/README.md
@@ -23,9 +23,9 @@ smoke test, manifest change, and normal CI/Codex review.
   receives a rotating Kubernetes service-account token; backup, migration, restore, and egress-proxy Pods explicitly disable
   token mounting.
 - The namespace enforces the Kubernetes `restricted` Pod Security profile.
-- Default-deny NetworkPolicies permit the gateway to reach only cluster DNS, the Kubernetes API service, Flamingo, and the
-  allowlisted Squid proxy once a compatible policy engine is present. Flannel alone does not enforce these objects; the
-  runbook's disposable live probe must pass before the first sync.
+- Default-deny NetworkPolicies permit the gateway to reach only cluster DNS, the Kubernetes API service and its pinned
+  control-plane endpoints, Flamingo, and the allowlisted Squid proxy once a compatible policy engine is present. Flannel
+  alone does not enforce these objects; the runbook's disposable live probe must pass before the first sync.
 - Squid permits HTTPS `CONNECT` only to Discord-owned domains and GitHub, and blocks other destinations plus private,
   tailnet, metadata, and multicast ranges.
 - Hermes receives a digest-pinned Kubernetes 1.35 `kubectl` binary through an OCI image volume. Its custom ClusterRole has

--- a/argocd/applications/hermes/network-policy.yaml
+++ b/argocd/applications/hermes/network-policy.yaml
@@ -68,6 +68,19 @@ spec:
       ports:
         - protocol: TCP
           port: 443
+    # This cluster's policy engine evaluates Service traffic after kube-proxy
+    # translates it to a control-plane endpoint. Keep the service VIP above and
+    # allow only the current Kubernetes API endpoints on their secure port.
+    - to:
+        - ipBlock:
+            cidr: 100.100.244.141/32
+        - ipBlock:
+            cidr: 100.100.244.142/32
+        - ipBlock:
+            cidr: 100.100.244.190/32
+      ports:
+        - protocol: TCP
+          port: 6443
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/scripts/hermes/validate-production.test.ts
+++ b/scripts/hermes/validate-production.test.ts
@@ -57,6 +57,15 @@ test('rejects restoring the blanket kubectl command deny', async () => {
   )
 })
 
+test('rejects omitting the translated Kubernetes API endpoints', async () => {
+  const files = await loadProductionFiles()
+  files.networkPolicy = files.networkPolicy.replace('            cidr: 100.100.244.141/32\n', '')
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.networkPolicy}: missing production invariant "cidr: 100.100.244.141/32"`,
+  )
+})
+
 test('rejects a mutable Hermes runtime image', async () => {
   const files = await loadProductionFiles()
   files.statefulSet = files.statefulSet.replace(

--- a/scripts/hermes/validate-production.ts
+++ b/scripts/hermes/validate-production.ts
@@ -326,6 +326,10 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     '- 169.254.0.0/16',
     '- 192.168.0.0/16',
     'cidr: 10.96.0.1/32',
+    'cidr: 100.100.244.141/32',
+    'cidr: 100.100.244.142/32',
+    'cidr: 100.100.244.190/32',
+    'port: 6443',
   ])
   forbidTerms(failures, productionPaths.networkPolicy, files.networkPolicy, [
     '          port: 80\n',


### PR DESCRIPTION
## Summary

- Allow Hermes to reach the three current Kubernetes control-plane endpoints on TCP 6443 in addition to the service VIP.
- Preserve the default-deny gateway policy and keep every other tailnet destination blocked.
- Add regression validation for the translated API endpoint rules and document the CNI behavior.

## Related Issues

Follow-up to #12986

## Testing

- `bun run scripts/hermes/validate-production.ts` (validated 36 production surfaces)
- `bun test scripts/hermes/*.test.ts` (99 passed, 0 failed)
- `bunx oxfmt --check scripts/hermes/validate-production.ts scripts/hermes/validate-production.test.ts`
- `kustomize build --enable-helm argocd/applications/hermes | kubeconform -strict -ignore-missing-schemas -summary` (0 invalid, 0 errors)
- Rendered manifests passed `kubectl -n hermes apply --dry-run=server -f ...`
- Live pre-fix proof: the gateway received connection refused for the service VIP and all three translated API endpoints while the default-deny NetworkPolicy was active.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
