### PR TITLE
chore(signal): promote publisher sha-72006ac26afef02e42fc1af8d434e49835cc40d6

### DIFF
--- a/argocd/applications/torghut/clickhouse/kustomization.yaml
+++ b/argocd/applications/torghut/clickhouse/kustomization.yaml
@@ -18,5 +18,5 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/signal-publisher
     newName: registry.ide-newton.ts.net/lab/signal-publisher
-    newTag: "sha-01ac72aafca390609885c2093236f4a10dd14a32"
-    digest: sha256:8f573122837bdc97ee90c3054b266606fcb2a269ea4edee0ff1e81bb641bebda
+    newTag: "sha-72006ac26afef02e42fc1af8d434e49835cc40d6"
+    digest: sha256:2561a79d2baaa998036344c121cc3986aedec365881911dd592d334163d82729

--- a/argocd/applications/torghut/clickhouse/signal-publisher-bayn-v1-backfill-job.yaml
+++ b/argocd/applications/torghut/clickhouse/signal-publisher-bayn-v1-backfill-job.yaml
@@ -68,11 +68,11 @@ spec:
                   name: bayn-universe-v1
                   key: HISTORY_FEED
             - name: SIGNAL_CODE_REVISION
-              value: "01ac72aafca390609885c2093236f4a10dd14a32"
+              value: "72006ac26afef02e42fc1af8d434e49835cc40d6"
             - name: SIGNAL_IMAGE_REPOSITORY
               value: registry.ide-newton.ts.net/lab/signal-publisher
             - name: SIGNAL_IMAGE_DIGEST
-              value: sha256:8f573122837bdc97ee90c3054b266606fcb2a269ea4edee0ff1e81bb641bebda
+              value: sha256:2561a79d2baaa998036344c121cc3986aedec365881911dd592d334163d82729
             - name: SIGNAL_CLICKHOUSE_URL
               value: http://torghut-clickhouse.torghut.svc.cluster.local:8123
             - name: SIGNAL_CLICKHOUSE_USERNAME

--- a/argocd/applications/torghut/clickhouse/signal-publisher-cronjob.yaml
+++ b/argocd/applications/torghut/clickhouse/signal-publisher-cronjob.yaml
@@ -72,11 +72,11 @@ spec:
                       name: bayn-universe-v1
                       key: HISTORY_FEED
                 - name: SIGNAL_CODE_REVISION
-                  value: "01ac72aafca390609885c2093236f4a10dd14a32"
+                  value: "72006ac26afef02e42fc1af8d434e49835cc40d6"
                 - name: SIGNAL_IMAGE_REPOSITORY
                   value: registry.ide-newton.ts.net/lab/signal-publisher
                 - name: SIGNAL_IMAGE_DIGEST
-                  value: sha256:8f573122837bdc97ee90c3054b266606fcb2a269ea4edee0ff1e81bb641bebda
+                  value: sha256:2561a79d2baaa998036344c121cc3986aedec365881911dd592d334163d82729
                 - name: SIGNAL_CLICKHOUSE_URL
                   value: http://torghut-clickhouse.torghut.svc.cluster.local:8123
                 - name: SIGNAL_CLICKHOUSE_USERNAME


### PR DESCRIPTION
## Summary

Pin the immutable Signal adjusted-daily publisher image and writer provenance. Both writers remain inert;
the reviewed rollout first runs the one-shot backfill alone, then removes it and enables the daily schedule.

- Source commit: `72006ac26afef02e42fc1af8d434e49835cc40d6`
- Image tag: `sha-72006ac26afef02e42fc1af8d434e49835cc40d6`
- Image digest: `sha256:2561a79d2baaa998036344c121cc3986aedec365881911dd592d334163d82729`

## Related Issues

PROOMPT-393

## Testing

- OCI index contains `linux/amd64` and `linux/arm64`.

## Screenshots (if applicable)

N/A

## Breaking Changes

Pins a bounded publisher without activating a writer. It has no broker or capital authority.

## Checklist

- [x] Testing section documents exact validation.
- [x] Runtime source revision and image digest are immutable.
- [x] No broker or capital-promotion authority is introduced.