### PR TITLE
fix(signal): keep dormant writers unrendered

### DIFF
--- a/argocd/applications/torghut/clickhouse/kustomization.yaml
+++ b/argocd/applications/torghut/clickhouse/kustomization.yaml
@@ -14,7 +14,6 @@ resources:
   - ta-replicated-table-migration-job.yaml
   - signal-schema-job.yaml
   - bayn-universe-v1-configmap.yaml
-  - signal-publisher-cronjob.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/signal-publisher
     newName: registry.ide-newton.ts.net/lab/signal-publisher

--- a/docs/bayn/authoritative-universe.md
+++ b/docs/bayn/authoritative-universe.md
@@ -130,11 +130,11 @@ supported limit-order semantics; this milestone submits no orders. The external 
 
 ## Rollout and proof
 
-1. Merge the versioned ConfigMap, additive schema, websocket wiring, suspended CronJob, and dormant backfill template.
-   The backfill Job is not yet a rendered resource, so this phase cannot write Signal data.
+1. Merge the versioned ConfigMap, additive schema, websocket wiring, and dormant CronJob and backfill templates.
+   Neither writer is rendered, so this phase cannot write Signal data or leave Argo waiting on a suspended CronJob.
 2. Promote immutable websocket and publisher images. Promotion pins source revisions and digests but leaves both Signal
    writers inert.
-3. Through a reviewed GitOps change, add and start only the one-shot backfill Job while the CronJob remains suspended.
+3. Through a reviewed GitOps change, add and start only the one-shot backfill Job while the CronJob remains absent.
    Require it to finalize exactly one SIP/all snapshot for all nine symbols from 2022-01-27 through
    2026-07-20: 1,122 sessions and 10,098 bars.
 4. Reproduce the manifest, session, and bar hashes from both ClickHouse replicas and prove one manifest row whose

--- a/docs/bayn/signal-adjusted-daily-publications.md
+++ b/docs/bayn/signal-adjusted-daily-publications.md
@@ -63,15 +63,15 @@ removed Bayn backfill path or grant Bayn write access.
 ## Rollout, evidence, and rollback
 
 GitOps first creates the sealed writer credential, applies the least-privilege ClickHouse user, runs the additive schema
-hook, and leaves the CronJob suspended. The one-shot backfill file is a dormant template and is not rendered. The
-ClickHouse operator may restart replicas sequentially when its user configuration changes; verify both replicas before
-promotion. Image promotion pins the source SHA and multi-platform digest in both writer templates but activates
-nothing.
+hook, and leaves both writer templates dormant and unrendered. A suspended CronJob is not retained because Argo marks
+it `Suspended` and waits indefinitely for `Healthy`. The ClickHouse operator may restart replicas sequentially when its
+user configuration changes; verify both replicas before promotion. Image promotion pins the source SHA and
+multi-platform digest in both writer templates but activates nothing.
 
-A separate reviewed GitOps change adds and starts only the one-shot backfill Job. The CronJob remains suspended until
-the bounded snapshot is reproduced from both replicas. Cleanup then removes the completed Job and enables the CronJob
-in one commit. CI rejects a rendered backfill whose template is suspended, an active writer without immutable
-provenance, or simultaneous active backfill and scheduled writers.
+A separate reviewed GitOps change adds and starts only the one-shot backfill Job. The CronJob remains absent until the
+bounded snapshot is reproduced from both replicas. Cleanup then removes the completed Job and renders the enabled
+CronJob in one commit. CI rejects a rendered suspended writer, an active unrendered writer, an active writer without
+immutable provenance, or simultaneous active backfill and scheduled writers.
 
 Completion evidence requires the bounded backfill plus two distinct scheduled publication observations. For each one,
 retain the Job name, source revision, image digest, universe ID and symbol hash, snapshot ID, publication as-of date,

--- a/packages/scripts/src/signal/gitops-contract.test.ts
+++ b/packages/scripts/src/signal/gitops-contract.test.ts
@@ -52,8 +52,11 @@ describe('Signal publisher GitOps authority contract', () => {
     expect(typeof cronJob.spec.suspend).toBe('boolean')
     expect(typeof backfillJob.spec.suspend).toBe('boolean')
     expect(container.args).toEqual(['daily'])
+    const cronManaged = kustomization.resources.includes('signal-publisher-cronjob.yaml')
     const backfillManaged = kustomization.resources.includes('signal-publisher-bayn-v1-backfill-job.yaml')
+    expect(cronManaged).toBe(!cronJob.spec.suspend)
     expect(backfillManaged).toBe(!backfillJob.spec.suspend)
+    expect(cronManaged && backfillManaged).toBe(false)
     expect(cronJob.spec.suspend || backfillJob.spec.suspend).toBe(true)
     assertActivationProvenance(cronJob, kustomization)
     assertActivationProvenance(backfillJob, kustomization)
@@ -170,9 +173,9 @@ describe('Signal publisher GitOps authority contract', () => {
         'signal-publisher-sealed-secret.yaml',
         'signal-schema-job.yaml',
         'bayn-universe-v1-configmap.yaml',
-        'signal-publisher-cronjob.yaml',
       ]),
     )
+    expect(kustomization.resources).not.toContain('signal-publisher-cronjob.yaml')
     expect(kustomization.resources).not.toContain('signal-publisher-bayn-v1-backfill-job.yaml')
   })
 })


### PR DESCRIPTION
## Summary

- Stop rendering the suspended Signal CronJob during the inert rollout phase.
- Keep both Signal writer templates dormant until a reviewed backfill or scheduled-publication activation.
- Enforce that a writer is rendered exactly when enabled and that both writers can never be active together.
- Document why this avoids Argo waiting forever on a CronJob whose health is Suspended.

## Related Issues

PROOMPT-393

## Testing

- bun test packages/scripts/src/signal/gitops-contract.test.ts (5 passed, 52 assertions)
- bun run lint:argocd
- Full Torghut kustomize render through kubeconform (98 resources; 71 valid, 0 invalid, 0 errors, 27 skipped)
- Render inspection confirms neither Signal writer exists
- bunx oxfmt --check packages/scripts/src/signal/gitops-contract.test.ts
- git diff --check

## Breaking Changes

The suspended Signal CronJob is pruned from the live application. No Signal writer is activated and no data is deleted.

## Checklist

- [x] Testing section documents exact validation.
- [x] Screenshots are not applicable; Breaking Changes are documented.
- [x] Documentation and rollout follow-up are updated.
