### PR TITLE
chore(torghut): promote ws image sha-72006ac26afef02e42fc1af8d434e49835cc40d6

### DIFF
--- a/argocd/applications/torghut-options/ws/deployment.yaml
+++ b/argocd/applications/torghut-options/ws/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws-options
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:6f472c1c20d03fb366724515e5078ce1e63e42fbca3b1b6bf892fb11c1230d48
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:5308554da88f6ad422ec10bb24df9c72f89cf0e1824142f10350d394b20cc04d
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -54,9 +54,9 @@ spec:
                   name: torghut-options
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-sha-45b9c4c210af8175043ba30b677aca58cf043b26
+              value: main-sha-72006ac26afef02e42fc1af8d434e49835cc40d6
             - name: TORGHUT_WS_COMMIT
-              value: 45b9c4c210af8175043ba30b677aca58cf043b26
+              value: 72006ac26afef02e42fc1af8d434e49835cc40d6
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:

--- a/argocd/applications/torghut/ws/deployment.yaml
+++ b/argocd/applications/torghut/ws/deployment.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:6f472c1c20d03fb366724515e5078ce1e63e42fbca3b1b6bf892fb11c1230d48
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:5308554da88f6ad422ec10bb24df9c72f89cf0e1824142f10350d394b20cc04d
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -75,9 +75,9 @@ spec:
                   name: torghut-ws
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-sha-45b9c4c210af8175043ba30b677aca58cf043b26
+              value: main-sha-72006ac26afef02e42fc1af8d434e49835cc40d6
             - name: TORGHUT_WS_COMMIT
-              value: 45b9c4c210af8175043ba30b677aca58cf043b26
+              value: 72006ac26afef02e42fc1af8d434e49835cc40d6
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:


### PR DESCRIPTION
## Summary
Promote the Torghut websocket image into GitOps manifests.

- Source commit: `72006ac26afef02e42fc1af8d434e49835cc40d6`
- Image tag: `sha-72006ac26afef02e42fc1af8d434e49835cc40d6`
- Image digest: `sha256:5308554da88f6ad422ec10bb24df9c72f89cf0e1824142f10350d394b20cc04d`