### PR TITLE
fix(hermes): configure in-cluster kubectl

### DIFF
--- a/argocd/applications/hermes/README.md
+++ b/argocd/applications/hermes/README.md
@@ -30,7 +30,8 @@ smoke test, manifest change, and normal CI/Codex review.
   tailnet, metadata, and multicast ranges.
 - Hermes receives a digest-pinned Kubernetes 1.35 `kubectl` binary through an OCI image volume. Its custom ClusterRole has
   only `get`, `list`, and `watch`, excludes core Secrets and interactive Pod subresources, and is bound cluster-wide only to
-  the `hermes` ServiceAccount.
+  the `hermes` ServiceAccount. Bootstrap writes a non-secret kubeconfig that follows the rotating projected token by file
+  path rather than persisting token material.
 - The API key comes from `onepassword-infra` through External Secrets. No secret is committed to Git.
 - API key rotation requires a bounded Secret refresh, gateway Pod restart, and old-key rejection/new-key acceptance proof.
 - The API is cluster-local and requires bearer authentication for model requests and detailed health.

--- a/argocd/applications/hermes/bootstrap.sh
+++ b/argocd/applications/hermes/bootstrap.sh
@@ -18,6 +18,34 @@ mkdir -p \
 install -m 0555 /opt/kubectl-image/bin/kubectl /opt/tools/kubectl
 /opt/tools/kubectl version --client=true >/tmp/kubectl-version.log
 
+kubeconfig_dir=${HOME}/.kube
+kubeconfig_path=${kubeconfig_dir}/config
+kubeconfig_tmp=${kubeconfig_path}.tmp.$$
+: "${KUBERNETES_SERVICE_HOST:?Kubernetes service host is required}"
+: "${KUBERNETES_SERVICE_PORT:?Kubernetes service port is required}"
+install -d -m 0700 "$kubeconfig_dir"
+cat >"$kubeconfig_tmp" <<EOF
+apiVersion: v1
+kind: Config
+clusters:
+  - name: in-cluster
+    cluster:
+      certificate-authority: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      server: https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}
+contexts:
+  - name: in-cluster
+    context:
+      cluster: in-cluster
+      user: hermes
+current-context: in-cluster
+users:
+  - name: hermes
+    user:
+      tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+EOF
+chmod 0600 "$kubeconfig_tmp"
+mv -- "$kubeconfig_tmp" "$kubeconfig_path"
+
 /bin/sh /opt/bootstrap/bootstrap-lab-checkout.sh
 
 seed_file() {

--- a/argocd/applications/hermes/statefulset.yaml
+++ b/argocd/applications/hermes/statefulset.yaml
@@ -63,6 +63,8 @@ spec:
               value: /opt/data
             - name: HOME
               value: /opt/data/home
+            - name: KUBECONFIG
+              value: /opt/data/home/.kube/config
             - name: GIT_TERMINAL_PROMPT
               value: "0"
             - name: LAB_REPOSITORY_URL
@@ -131,6 +133,8 @@ spec:
               value: "1"
             - name: HOME
               value: /opt/data/home
+            - name: KUBECONFIG
+              value: /opt/data/home/.kube/config
             - name: XDG_CACHE_HOME
               value: /opt/data/home/.cache
             - name: PATH

--- a/scripts/hermes/bootstrap-lab-checkout.test.ts
+++ b/scripts/hermes/bootstrap-lab-checkout.test.ts
@@ -6,7 +6,7 @@ import { join } from 'node:path'
 const script = join(import.meta.dir, '../../argocd/applications/hermes/bootstrap-lab-checkout.sh')
 
 async function git(cwd: string, ...args: string[]): Promise<string> {
-  const process = Bun.spawn(['git', ...args], { cwd, stdout: 'pipe', stderr: 'pipe' })
+  const process = Bun.spawn(['git', '-c', 'commit.gpgsign=false', ...args], { cwd, stdout: 'pipe', stderr: 'pipe' })
   const [exitCode, stdout, stderr] = await Promise.all([
     process.exited,
     new Response(process.stdout).text(),

--- a/scripts/hermes/validate-production.test.ts
+++ b/scripts/hermes/validate-production.test.ts
@@ -66,6 +66,18 @@ test('rejects omitting the translated Kubernetes API endpoints', async () => {
   )
 })
 
+test('rejects persisting a service-account token in the kubeconfig', async () => {
+  const files = await loadProductionFiles()
+  files.bootstrap = files.bootstrap.replace(
+    '      tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token',
+    '      token: ${SERVICE_ACCOUNT_TOKEN}',
+  )
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.bootstrap}: contains forbidden production term "token: \${"`,
+  )
+})
+
 test('rejects a mutable Hermes runtime image', async () => {
   const files = await loadProductionFiles()
   files.statefulSet = files.statefulSet.replace(

--- a/scripts/hermes/validate-production.ts
+++ b/scripts/hermes/validate-production.ts
@@ -123,6 +123,8 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'mountPath: /opt/kubectl-image',
     'mountPath: /opt/tools',
     'value: /opt/tools:/opt/hermes/bin:',
+    'name: KUBECONFIG',
+    'value: /opt/data/home/.kube/config',
     'value: https://github.com/proompteng/lab.git',
     'value: main',
     'value: localhost,127.0.0.1,.svc,.svc.cluster.local,10.96.0.1',
@@ -399,7 +401,17 @@ export function validateProductionContent(files: ProductionFiles): string[] {
   requireTerms(failures, productionPaths.bootstrap, files.bootstrap, [
     'install -m 0555 /opt/kubectl-image/bin/kubectl /opt/tools/kubectl',
     '/opt/tools/kubectl version --client=true',
+    'install -d -m 0700 "$kubeconfig_dir"',
+    'certificate-authority: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
+    'server: https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}',
+    'tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token',
+    'chmod 0600 "$kubeconfig_tmp"',
     '/bin/sh /opt/bootstrap/bootstrap-lab-checkout.sh',
+  ])
+  forbidTerms(failures, productionPaths.bootstrap, files.bootstrap, [
+    'token: ${',
+    'token: $(cat',
+    'certificate-authority-data:',
   ])
   requireTerms(failures, productionPaths.labCheckout, files.labCheckout, [
     'set -eu',


### PR DESCRIPTION
## Summary

- Generate a standard in-cluster kubeconfig during Hermes bootstrap so ordinary resource commands use the projected service-account identity.
- Reference the rotating token and CA by file path; no token material is copied into persistent storage.
- Make the Git checkout test independent of workstation commit-signing configuration.
- Add production validation for kubeconfig location, permissions, rotating token-file use, and embedded-token rejection.

## Related Issues

Follow-up to #12986 and #12987

## Testing

- `bun run scripts/hermes/validate-production.ts` (validated 36 production surfaces)
- `bun test scripts/hermes/*.test.ts` (100 passed, 0 failed)
- `bunx oxfmt --check scripts/hermes/validate-production.ts scripts/hermes/validate-production.test.ts scripts/hermes/bootstrap-lab-checkout.test.ts`
- `shellcheck argocd/applications/hermes/bootstrap.sh`
- `kustomize build --enable-helm argocd/applications/hermes | kubeconform -strict -ignore-missing-schemas -summary` (0 invalid, 0 errors)
- Rendered manifests passed `kubectl -n hermes apply --dry-run=server -f ...`
- Live preflight used the same CA, rotating token-file reference, and service endpoint to list 451 pods successfully.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
