### PR TITLE
chore(torghut): promote ta image sha-b20cdafc9e2bd9b75b2b61039a1a34f14bf46399

### DIFF
--- a/argocd/applications/torghut-options/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut-options/ta/flinkdeployment.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     app: torghut-options-ta
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:158499b56e165329827be2fee52494484e1aa33736cdbc07a07aed2b243659dd
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:1a3fba53b409b7f1f37d2836c59497a73ed4c6ea244d9004ee3c2dbf945043d4
   imagePullPolicy: IfNotPresent
-  restartNonce: 36
+  restartNonce: 37
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   flinkConfiguration:
@@ -91,9 +91,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: sha-7a49af3cd6fcb462e2030ba82d8f1a7d70e276aa
+              value: sha-b20cdafc9e2bd9b75b2b61039a1a34f14bf46399
             - name: TORGHUT_TA_COMMIT
-              value: 7a49af3cd6fcb462e2030ba82d8f1a7d70e276aa
+              value: b20cdafc9e2bd9b75b2b61039a1a34f14bf46399
           ports:
             - containerPort: 9249
               name: metrics

--- a/argocd/applications/torghut/market-data-archive/flinkdeployment.yaml
+++ b/argocd/applications/torghut/market-data-archive/flinkdeployment.yaml
@@ -9,9 +9,9 @@ metadata:
     argocd.argoproj.io/sync-wave: "4"
 spec:
   # This directory remains outside the parent Kustomization until the image contains MarketDataArchiveJobKt.
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:158499b56e165329827be2fee52494484e1aa33736cdbc07a07aed2b243659dd
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:1a3fba53b409b7f1f37d2836c59497a73ed4c6ea244d9004ee3c2dbf945043d4
   imagePullPolicy: IfNotPresent
-  restartNonce: 1
+  restartNonce: 2
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   flinkConfiguration:
@@ -55,9 +55,9 @@ spec:
                   name: signal-publisher-clickhouse-auth
                   key: password
             - name: TORGHUT_TA_VERSION
-              value: sha-7a49af3cd6fcb462e2030ba82d8f1a7d70e276aa
+              value: sha-b20cdafc9e2bd9b75b2b61039a1a34f14bf46399
             - name: TORGHUT_TA_COMMIT
-              value: 7a49af3cd6fcb462e2030ba82d8f1a7d70e276aa
+              value: b20cdafc9e2bd9b75b2b61039a1a34f14bf46399
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:

--- a/argocd/applications/torghut/ta-sim/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta-sim/flinkdeployment.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     app: torghut-ta-sim
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:158499b56e165329827be2fee52494484e1aa33736cdbc07a07aed2b243659dd
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:1a3fba53b409b7f1f37d2836c59497a73ed4c6ea244d9004ee3c2dbf945043d4
   imagePullPolicy: IfNotPresent
-  restartNonce: 35
+  restartNonce: 36
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   logConfiguration:
@@ -157,9 +157,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: sha-7a49af3cd6fcb462e2030ba82d8f1a7d70e276aa
+              value: sha-b20cdafc9e2bd9b75b2b61039a1a34f14bf46399
             - name: TORGHUT_TA_COMMIT
-              value: 7a49af3cd6fcb462e2030ba82d8f1a7d70e276aa
+              value: b20cdafc9e2bd9b75b2b61039a1a34f14bf46399
           ports:
             - containerPort: 9249
               name: metrics

--- a/argocd/applications/torghut/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta/flinkdeployment.yaml
@@ -8,9 +8,9 @@ metadata:
   labels:
     app: torghut-ta
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:158499b56e165329827be2fee52494484e1aa33736cdbc07a07aed2b243659dd
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:1a3fba53b409b7f1f37d2836c59497a73ed4c6ea244d9004ee3c2dbf945043d4
   imagePullPolicy: IfNotPresent
-  restartNonce: 33
+  restartNonce: 34
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   logConfiguration:
@@ -157,9 +157,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: sha-7a49af3cd6fcb462e2030ba82d8f1a7d70e276aa
+              value: sha-b20cdafc9e2bd9b75b2b61039a1a34f14bf46399
             - name: TORGHUT_TA_COMMIT
-              value: 7a49af3cd6fcb462e2030ba82d8f1a7d70e276aa
+              value: b20cdafc9e2bd9b75b2b61039a1a34f14bf46399
           ports:
             - containerPort: 9249
               name: metrics


### PR DESCRIPTION
## Summary
Promote the Torghut TA image into GitOps manifests.

- Source commit: `b20cdafc9e2bd9b75b2b61039a1a34f14bf46399`
- Image tag: `sha-b20cdafc9e2bd9b75b2b61039a1a34f14bf46399`
- Image digest: `sha256:1a3fba53b409b7f1f37d2836c59497a73ed4c6ea244d9004ee3c2dbf945043d4`
- Manifests: live TA, sim TA, Bayn market-data archive, options TA