### PR TITLE
chore(torghut): promote ws image sha-b20cdafc9e2bd9b75b2b61039a1a34f14bf46399

### DIFF
--- a/argocd/applications/torghut-options/ws/deployment.yaml
+++ b/argocd/applications/torghut-options/ws/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws-options
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:5308554da88f6ad422ec10bb24df9c72f89cf0e1824142f10350d394b20cc04d
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:f60b6d5c403179bb176baf8f8d6fc54c12ee08e71590bc8c24d4743c079a4a05
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -54,9 +54,9 @@ spec:
                   name: torghut-options
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-sha-72006ac26afef02e42fc1af8d434e49835cc40d6
+              value: main-sha-b20cdafc9e2bd9b75b2b61039a1a34f14bf46399
             - name: TORGHUT_WS_COMMIT
-              value: 72006ac26afef02e42fc1af8d434e49835cc40d6
+              value: b20cdafc9e2bd9b75b2b61039a1a34f14bf46399
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:

--- a/argocd/applications/torghut/ws/deployment.yaml
+++ b/argocd/applications/torghut/ws/deployment.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:5308554da88f6ad422ec10bb24df9c72f89cf0e1824142f10350d394b20cc04d
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:f60b6d5c403179bb176baf8f8d6fc54c12ee08e71590bc8c24d4743c079a4a05
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -75,9 +75,9 @@ spec:
                   name: torghut-ws
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-sha-72006ac26afef02e42fc1af8d434e49835cc40d6
+              value: main-sha-b20cdafc9e2bd9b75b2b61039a1a34f14bf46399
             - name: TORGHUT_WS_COMMIT
-              value: 72006ac26afef02e42fc1af8d434e49835cc40d6
+              value: b20cdafc9e2bd9b75b2b61039a1a34f14bf46399
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:


### PR DESCRIPTION
## Summary
Promote the Torghut websocket image into GitOps manifests.

- Source commit: `b20cdafc9e2bd9b75b2b61039a1a34f14bf46399`
- Image tag: `sha-b20cdafc9e2bd9b75b2b61039a1a34f14bf46399`
- Image digest: `sha256:f60b6d5c403179bb176baf8f8d6fc54c12ee08e71590bc8c24d4743c079a4a05`