### PR TITLE
chore(torghut): promote hyperliquid feed image sha-b20cdafc9e2bd9b75b2b61039a1a34f14bf46399

### DIFF
--- a/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
@@ -32,18 +32,18 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-hyperliquid-feed
-          image: registry.ide-newton.ts.net/lab/torghut-hyperliquid-feed@sha256:c357c2aefdc99809682b47d86cb892a1dc51a9f49f6bdb14a64a5c00dc727789
+          image: registry.ide-newton.ts.net/lab/torghut-hyperliquid-feed@sha256:582b69acec3ffa8aef3fa7421dbd9bd399a09fd99a63e703e581c4909f6dc3ad
           imagePullPolicy: Always
           envFrom:
             - configMapRef:
                 name: torghut-hyperliquid-feed-config
           env:
             - name: TORGHUT_HYPERLIQUID_FEED_VERSION
-              value: main-sha-7a49af3cd6fcb462e2030ba82d8f1a7d70e276aa
+              value: main-sha-b20cdafc9e2bd9b75b2b61039a1a34f14bf46399
             - name: TORGHUT_HYPERLIQUID_FEED_COMMIT
-              value: 7a49af3cd6fcb462e2030ba82d8f1a7d70e276aa
+              value: b20cdafc9e2bd9b75b2b61039a1a34f14bf46399
             - name: TORGHUT_HYPERLIQUID_FEED_IMAGE_DIGEST
-              value: sha256:c357c2aefdc99809682b47d86cb892a1dc51a9f49f6bdb14a64a5c00dc727789
+              value: sha256:582b69acec3ffa8aef3fa7421dbd9bd399a09fd99a63e703e581c4909f6dc3ad
             - name: KAFKA_SASL_USER
               value: torghut-hyperliquid-feed
             - name: KAFKA_SASL_PASSWORD


### PR DESCRIPTION
## Summary

- Promote the immutable Torghut Hyperliquid feed image built from `b20cdafc9e2bd9b75b2b61039a1a34f14bf46399`.
- Pin the single direct feed runtime to `sha256:582b69acec3ffa8aef3fa7421dbd9bd399a09fd99a63e703e581c4909f6dc3ad`.
- Preserve one source commit and image digest for the production feed.

## Related Issues

None.

## Testing

- The source commit passed its required CI before merge to `main`.
- The release workflow verified the multi-architecture image contract before creating this PR.
- The deploy gate validates the manifest against source `b20cdafc9e2bd9b75b2b61039a1a34f14bf46399` and tag `sha-b20cdafc9e2bd9b75b2b61039a1a34f14bf46399`.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact automated release validation.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] The production feed manifest carries the immutable source and image identity.