### PR TITLE
feat(bayn): activate delayed SIP observation

### DIFF
--- a/argocd/applications/torghut/clickhouse/clickhouse-cluster.yaml
+++ b/argocd/applications/torghut/clickhouse/clickhouse-cluster.yaml
@@ -124,6 +124,7 @@ spec:
         - GRANT SELECT ON signal.adjusted_daily_bars_v1
         - GRANT SELECT ON signal.adjusted_daily_bars_v2
         - GRANT SELECT ON signal.exchange_sessions_v1
+        - GRANT SELECT ON signal.intraday_bars_1m_v1
         - GRANT SELECT ON signal.snapshot_manifests_v1
         - GRANT SELECT ON signal.snapshot_manifests_v2
       signal_publisher/password_sha256_hex:
@@ -140,6 +141,7 @@ spec:
       signal_publisher/grants/query:
         - GRANT SELECT, INSERT ON signal.adjusted_daily_bars_v2
         - GRANT SELECT, INSERT ON signal.exchange_sessions_v1
+        - GRANT INSERT ON signal.intraday_bars_1m_v1
         - GRANT SELECT, INSERT ON signal.snapshot_manifests_v1
         - GRANT SELECT, INSERT ON signal.snapshot_manifests_v2
       default/password_sha256_hex:

--- a/argocd/applications/torghut/kustomization.yaml
+++ b/argocd/applications/torghut/kustomization.yaml
@@ -50,5 +50,6 @@ resources:
   - clickhouse
   - ws
   - ta
+  - market-data-archive
   - ta-sim
   - notebooks

--- a/argocd/applications/torghut/market-data-archive/flinkdeployment.yaml
+++ b/argocd/applications/torghut/market-data-archive/flinkdeployment.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "4"
 spec:
-  # This directory remains outside the parent Kustomization until the image contains MarketDataArchiveJobKt.
+  # The TA release workflow pins the same immutable image used by the live and simulation TA jobs.
   image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:1a3fba53b409b7f1f37d2836c59497a73ed4c6ea244d9004ee3c2dbf945043d4
   imagePullPolicy: IfNotPresent
   restartNonce: 2

--- a/argocd/applications/torghut/ws/configmap.yaml
+++ b/argocd/applications/torghut/ws/configmap.yaml
@@ -10,8 +10,8 @@ data:
   ALPACA_MARKET_TYPE: "equity"
   ALPACA_CRYPTO_LOCATION: "us"
   ALPACA_FEED: "iex"
-  # Observation feeds are rolled out independently after the multi-feed runtime image is proven on IEX.
-  ALPACA_OBSERVATION_FEEDS: ""
+  # Roll out observation feeds independently; overnight remains disabled until delayed SIP is proven live.
+  ALPACA_OBSERVATION_FEEDS: "delayed_sip"
   ALPACA_STREAM_URL: "wss://stream.data.alpaca.markets"
   ALPACA_TRADE_STREAM_URL: "wss://paper-api.alpaca.markets/stream"
   ALPACA_BASE_URL: "https://data.alpaca.markets"

--- a/argocd/applications/torghut/ws/deployment.yaml
+++ b/argocd/applications/torghut/ws/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         app: torghut-ws
       annotations:
         kubectl.kubernetes.io/restartedAt: 2026-05-01T01:25:51.190Z
-        torghut.proompteng.ai/ws-config-generation: no-jangar-symbols
+        torghut.proompteng.ai/ws-config-generation: bayn-delayed-sip-v1
     spec:
       serviceAccountName: torghut-runtime
       securityContext:

--- a/argocd/applications/torghut/ws/deployment.yaml
+++ b/argocd/applications/torghut/ws/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: torghut
   labels:
     app: torghut-ws
+  annotations:
+    argocd.argoproj.io/sync-wave: "5"
 spec:
   replicas: 1
   revisionHistoryLimit: 2

--- a/packages/scripts/src/signal/gitops-contract.test.ts
+++ b/packages/scripts/src/signal/gitops-contract.test.ts
@@ -247,6 +247,12 @@ describe('Signal publisher GitOps authority contract', () => {
       valueFrom: { secretKeyRef: { name: 'signal-publisher-clickhouse-auth', key: 'password' } },
     })
     expect(websocket.data.ALPACA_OBSERVATION_FEEDS).toBe('delayed_sip')
+    expect(archive.metadata.annotations).toMatchObject({
+      'argocd.argoproj.io/sync-wave': '4',
+    })
+    expect(websocketDeployment.metadata.annotations).toMatchObject({
+      'argocd.argoproj.io/sync-wave': '5',
+    })
     expect(websocketDeployment.spec.template.metadata.annotations).toMatchObject({
       'torghut.proompteng.ai/ws-config-generation': 'bayn-delayed-sip-v1',
     })

--- a/packages/scripts/src/signal/gitops-contract.test.ts
+++ b/packages/scripts/src/signal/gitops-contract.test.ts
@@ -145,6 +145,7 @@ describe('Signal publisher GitOps authority contract', () => {
     expect(users['signal_publisher/grants/query']).toEqual([
       'GRANT SELECT, INSERT ON signal.adjusted_daily_bars_v2',
       'GRANT SELECT, INSERT ON signal.exchange_sessions_v1',
+      'GRANT INSERT ON signal.intraday_bars_1m_v1',
       'GRANT SELECT, INSERT ON signal.snapshot_manifests_v1',
       'GRANT SELECT, INSERT ON signal.snapshot_manifests_v2',
     ])
@@ -152,6 +153,7 @@ describe('Signal publisher GitOps authority contract', () => {
       'GRANT SELECT ON signal.adjusted_daily_bars_v1',
       'GRANT SELECT ON signal.adjusted_daily_bars_v2',
       'GRANT SELECT ON signal.exchange_sessions_v1',
+      'GRANT SELECT ON signal.intraday_bars_1m_v1',
       'GRANT SELECT ON signal.snapshot_manifests_v1',
       'GRANT SELECT ON signal.snapshot_manifests_v2',
     ])
@@ -199,7 +201,7 @@ describe('Signal publisher GitOps authority contract', () => {
     expect(kustomization.resources).toContain('intraday-bars-schema-job.yaml')
   })
 
-  test('keeps the three-feed archive dormant until its promoted image is available', () => {
+  test('activates the archive for delayed SIP while overnight observation remains disabled', () => {
     const torghutKustomization = parse(
       readFileSync(resolve(root, 'argocd/applications/torghut/kustomization.yaml'), 'utf8'),
     )
@@ -208,8 +210,11 @@ describe('Signal publisher GitOps authority contract', () => {
     const archive = parse(readFileSync(resolve(archiveDirectory, 'flinkdeployment.yaml'), 'utf8'))
     const config = parse(readFileSync(resolve(archiveDirectory, 'configmap.yaml'), 'utf8'))
     const websocket = parse(readWsConfig())
+    const websocketDeployment = parse(
+      readFileSync(resolve(root, 'argocd/applications/torghut/ws/deployment.yaml'), 'utf8'),
+    )
 
-    expect(torghutKustomization.resources).not.toContain('market-data-archive')
+    expect(torghutKustomization.resources).toContain('market-data-archive')
     expect(archiveKustomization.resources).toEqual([
       'configmap.yaml',
       'flinkdeployment.yaml',
@@ -241,7 +246,10 @@ describe('Signal publisher GitOps authority contract', () => {
     expect(archiveEnvironment.get('ARCHIVE_CLICKHOUSE_PASSWORD')).toMatchObject({
       valueFrom: { secretKeyRef: { name: 'signal-publisher-clickhouse-auth', key: 'password' } },
     })
-    expect(websocket.data.ALPACA_OBSERVATION_FEEDS).toBe('')
+    expect(websocket.data.ALPACA_OBSERVATION_FEEDS).toBe('delayed_sip')
+    expect(websocketDeployment.spec.template.metadata.annotations).toMatchObject({
+      'torghut.proompteng.ai/ws-config-generation': 'bayn-delayed-sip-v1',
+    })
   })
 
   test('provisions isolated bounded Kafka topics for observation feeds', () => {


### PR DESCRIPTION
## Summary

- Enable Alpaca delayed SIP as Bayn's first observation feed while keeping IEX primary and overnight disabled.
- Start the source-matched market-data archive and grant only the ClickHouse INSERT/SELECT access its writer and Bayn reader require.
- Make Argo wait for the wave-4 archive before recreating the wave-5 websocket, and lock that ordering in the authority contract.

## Related Issues

Linear: PROOMPT-396

## Testing

- `bun test packages/scripts/src/signal/gitops-contract.test.ts` — 8 passed, 104 assertions.
- `bunx oxfmt --check <changed paths>` — passed.
- `kustomize build --enable-helm argocd/applications/torghut` — rendered successfully.
- `bun run lint:argocd` — all rendered resources valid; 0 invalid, 0 errors.

## Rollout impact

- Argo CD starts `market-data-archive` at wave 4, waits for it to become healthy, then recreates the single websocket pod at wave 5.
- Broker execution, strategy selection, capital authority, and overnight ingestion remain unchanged.
- Rollback is a revert: delayed SIP disconnects and the archive deployment is removed from the rendered application; retained Kafka and ClickHouse data are not rewritten.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation, release notes, and follow-ups are updated or tracked.