### PR TITLE
fix(bayn): recover closed TigerBeetle clients

### DIFF
--- a/nix/images/bayn.nix
+++ b/nix/images/bayn.nix
@@ -19,8 +19,8 @@ import ./bun-workspace-service.nix {
   serviceName = "bayn";
   packageName = "@proompteng/bayn";
   depsHash = {
-    x86_64-linux = "sha256-PIrg1j+HNm1PUD9OHHdPYaVu2xdJ9SohAFxHsxSf9iM=";
-    aarch64-linux = "sha256-PwP+ISp9QUubnxee0JdDntGBpIUquiBXZXNTa29D8O0=";
+    x86_64-linux = "sha256-HOivxpn3uqVZlCG3XM/zeh9sg7yNXUzh1nHcLpNsBmA=";
+    aarch64-linux = "sha256-d5QZaVMgc+DgKfwaoiXKulU/iBV8VVBbhEQWdXd6dzk=";
   };
   installFilters = [
     "@proompteng/bayn"

--- a/services/bayn/src/ledger.ts
+++ b/services/bayn/src/ledger.ts
@@ -11,7 +11,7 @@ import {
   type Transfer,
   createClient,
 } from 'tigerbeetle-node'
-import { Context, Effect, Layer } from 'effect'
+import { Context, Effect, Layer, ScopedRef, Semaphore } from 'effect'
 
 import type { RuntimeConfig } from './config'
 import { operationalError, type OperationalError } from './errors'
@@ -445,11 +445,12 @@ export const assertReconciled = (
   }
 }
 
-const request = <A>(client: Client, operation: string, execute: () => Promise<A>): Effect.Effect<A, OperationalError> =>
-  Effect.tryPromise({
-    try: execute,
-    catch: (cause) => operationalError('journal', operation, `TigerBeetle ${operation} failed`, cause),
-  }).pipe(Effect.onInterrupt(() => Effect.sync(() => client.destroy())))
+interface LedgerClient {
+  readonly request: <A>(
+    operation: string,
+    execute: (client: Client) => Promise<A>,
+  ) => Effect.Effect<A, OperationalError>
+}
 
 const validate = <A>(operation: string, evaluate: () => A): Effect.Effect<A, OperationalError> =>
   Effect.try({
@@ -457,9 +458,12 @@ const validate = <A>(operation: string, evaluate: () => A): Effect.Effect<A, Ope
     catch: (cause) => operationalError('journal', operation, `TigerBeetle ${operation} failed`, cause),
   })
 
-const createAndVerifyAccounts = (client: Client, accounts: readonly Account[]): Effect.Effect<void, OperationalError> =>
+const createAndVerifyAccounts = (
+  client: LedgerClient,
+  accounts: readonly Account[],
+): Effect.Effect<void, OperationalError> =>
   Effect.gen(function* () {
-    const results = yield* request(client, 'create-accounts', () => client.createAccounts([...accounts]))
+    const results = yield* client.request('create-accounts', (active) => active.createAccounts([...accounts]))
     const existingIds = yield* validate('verify-account-results', () => {
       if (results.length !== accounts.length) {
         throw new Error('TigerBeetle returned an incomplete account result batch')
@@ -478,7 +482,7 @@ const createAndVerifyAccounts = (client: Client, accounts: readonly Account[]): 
     })
     if (existingIds.length === 0) return
 
-    const existing = yield* request(client, 'lookup-existing-accounts', () => client.lookupAccounts(existingIds))
+    const existing = yield* client.request('lookup-existing-accounts', (active) => active.lookupAccounts(existingIds))
     const expected = accounts.filter((value) => existingIds.includes(value.id))
     yield* validate('verify-existing-accounts', () =>
       assertUniqueExact('existing account', existing, expected, accountMetadataMatches),
@@ -486,11 +490,11 @@ const createAndVerifyAccounts = (client: Client, accounts: readonly Account[]): 
   })
 
 const createAndVerifyTransfers = (
-  client: Client,
+  client: LedgerClient,
   transfers: readonly Transfer[],
 ): Effect.Effect<void, OperationalError> =>
   Effect.gen(function* () {
-    const results = yield* request(client, 'create-transfers', () => client.createTransfers([...transfers]))
+    const results = yield* client.request('create-transfers', (active) => active.createTransfers([...transfers]))
     const existingIds = yield* validate('verify-transfer-results', () => {
       if (results.length !== transfers.length) {
         throw new Error('TigerBeetle returned an incomplete transfer result batch')
@@ -509,7 +513,7 @@ const createAndVerifyTransfers = (
     })
     if (existingIds.length === 0) return
 
-    const existing = yield* request(client, 'lookup-existing-transfers', () => client.lookupTransfers(existingIds))
+    const existing = yield* client.request('lookup-existing-transfers', (active) => active.lookupTransfers(existingIds))
     const expected = transfers.filter((value) => existingIds.includes(value.id))
     yield* validate('verify-existing-transfers', () =>
       assertUniqueExact('existing transfer', existing, expected, transferMatches),
@@ -595,7 +599,7 @@ const assertPersistedRun = (
 }
 
 const checkRun = (
-  client: Client,
+  client: LedgerClient,
   ledger: number,
   result: ReconciliationResult,
 ): Effect.Effect<void, OperationalError> =>
@@ -609,11 +613,11 @@ const checkRun = (
     const runTag = stableU64('bayn-run-v1', result.runId)
     const [accounts, transfers] = yield* Effect.all(
       [
-        request(client, 'check-run-accounts', () =>
-          client.queryAccounts({ ...queryFilter(ledger), user_data_128: runKey, limit: result.accountCount + 1 }),
+        client.request('check-run-accounts', (active) =>
+          active.queryAccounts({ ...queryFilter(ledger), user_data_128: runKey, limit: result.accountCount + 1 }),
         ),
-        request(client, 'check-run-transfers', () =>
-          client.queryTransfers({ ...queryFilter(ledger), user_data_64: runTag, limit: result.transferCount + 1 }),
+        client.request('check-run-transfers', (active) =>
+          active.queryTransfers({ ...queryFilter(ledger), user_data_64: runTag, limit: result.transferCount + 1 }),
         ),
       ],
       { concurrency: 'unbounded' },
@@ -622,7 +626,7 @@ const checkRun = (
   })
 
 const journalAndReconcile = (
-  client: Client,
+  client: LedgerClient,
   ledger: number,
   result: EvaluationResult,
 ): Effect.Effect<ReconciliationResult, OperationalError> =>
@@ -634,8 +638,8 @@ const journalAndReconcile = (
     const transferQuery = { ...queryFilter(ledger), user_data_64: plan.runTag, limit: plan.transfers.length + 1 }
     const [accounts, transfers] = yield* Effect.all(
       [
-        request(client, 'query-accounts', () => client.queryAccounts(accountQuery)),
-        request(client, 'query-transfers', () => client.queryTransfers(transferQuery)),
+        client.request('query-accounts', (active) => active.queryAccounts(accountQuery)),
+        client.request('query-transfers', (active) => active.queryTransfers(transferQuery)),
       ],
       { concurrency: 'unbounded' },
     )
@@ -658,48 +662,81 @@ export const JournalLive = (
 ): Layer.Layer<Journal, OperationalError> =>
   Layer.effect(
     Journal,
-    Effect.acquireRelease(
-      dependencies.resolveReplicaAddresses(config.tigerBeetle.replicaAddresses).pipe(
-        Effect.flatMap((replicaAddresses) =>
-          Effect.try({
-            try: () =>
-              dependencies.createClient({
-                cluster_id: config.tigerBeetle.clusterId,
-                replica_addresses: replicaAddresses,
-              }),
-            catch: (cause) => operationalError('journal', 'connect', 'failed to create TigerBeetle client', cause),
+    Effect.gen(function* () {
+      const acquireClient = Effect.acquireRelease(
+        dependencies.resolveReplicaAddresses(config.tigerBeetle.replicaAddresses).pipe(
+          Effect.flatMap((replicaAddresses) =>
+            Effect.try({
+              try: () =>
+                dependencies.createClient({
+                  cluster_id: config.tigerBeetle.clusterId,
+                  replica_addresses: replicaAddresses,
+                }),
+              catch: (cause) => operationalError('journal', 'connect', 'failed to create TigerBeetle client', cause),
+            }),
+          ),
+          Effect.timeoutOrElse({
+            duration: config.operationTimeoutMs,
+            orElse: () =>
+              Effect.fail(
+                operationalError(
+                  'journal',
+                  'connect',
+                  `TigerBeetle client creation timed out after ${config.operationTimeoutMs}ms`,
+                ),
+              ),
           }),
         ),
-        Effect.timeoutOrElse({
-          duration: config.operationTimeoutMs,
-          orElse: () =>
-            Effect.fail(
-              operationalError(
-                'journal',
-                'connect',
-                `TigerBeetle client creation timed out after ${config.operationTimeoutMs}ms`,
+        (client) =>
+          Effect.try({
+            try: () => client.destroy(),
+            catch: (cause) => operationalError('journal', 'close', 'failed to close TigerBeetle client', cause),
+          }).pipe(
+            Effect.catch((error) =>
+              Effect.logWarning('TigerBeetle client close failed').pipe(
+                Effect.annotateLogs({ component: error.component, operation: error.operation, error: error.message }),
               ),
             ),
-        }),
-      ),
-      (client) =>
-        Effect.try({
-          try: () => client.destroy(),
-          catch: (cause) => operationalError('journal', 'close', 'failed to close TigerBeetle client', cause),
-        }).pipe(
+          ),
+      )
+      const clients = yield* ScopedRef.fromAcquire(acquireClient)
+      const semaphore = yield* Semaphore.make(1)
+      const refresh = (trigger: string): Effect.Effect<void> =>
+        ScopedRef.set(clients, acquireClient).pipe(
+          Effect.tap(() => Effect.logInfo('TigerBeetle client refreshed').pipe(Effect.annotateLogs({ trigger }))),
           Effect.catch((error) =>
-            Effect.logWarning('TigerBeetle client close failed').pipe(
-              Effect.annotateLogs({ component: error.component, operation: error.operation, error: error.message }),
+            Effect.logWarning('TigerBeetle client refresh failed').pipe(
+              Effect.annotateLogs({
+                trigger,
+                component: error.component,
+                operation: error.operation,
+                error: error.message,
+              }),
             ),
           ),
-        ),
-    ).pipe(
-      Effect.map((client) => ({
-        check: request(client, 'connectivity-check', () =>
-          client.lookupAccounts([stableU128('bayn-connectivity-probe')]),
-        ).pipe(Effect.asVoid),
+        )
+      const client: LedgerClient = {
+        request: <A>(operation: string, execute: (active: Client) => Promise<A>) =>
+          semaphore.withPermit(
+            ScopedRef.get(clients).pipe(
+              Effect.flatMap((active) =>
+                Effect.tryPromise({
+                  try: () => execute(active),
+                  catch: (cause) => operationalError('journal', operation, `TigerBeetle ${operation} failed`, cause),
+                }).pipe(
+                  Effect.onInterrupt(() => refresh(`interrupted:${operation}`)),
+                  Effect.catch((error) => refresh(`failed:${operation}`).pipe(Effect.andThen(Effect.fail(error)))),
+                ),
+              ),
+            ),
+          ),
+      }
+      return {
+        check: client
+          .request('connectivity-check', (active) => active.lookupAccounts([stableU128('bayn-connectivity-probe')]))
+          .pipe(Effect.asVoid),
         checkRun: (result) => checkRun(client, config.tigerBeetle.ledger, result),
         journalAndReconcile: (result) => journalAndReconcile(client, config.tigerBeetle.ledger, result),
-      })),
-    ),
+      }
+    }),
   )

--- a/services/bayn/src/ledger.ts
+++ b/services/bayn/src/ledger.ts
@@ -11,7 +11,7 @@ import {
   type Transfer,
   createClient,
 } from 'tigerbeetle-node'
-import { Context, Effect, Layer, ScopedRef, Semaphore } from 'effect'
+import { Context, Effect, Layer, Option, ScopedRef, Semaphore } from 'effect'
 
 import type { RuntimeConfig } from './config'
 import { operationalError, type OperationalError } from './errors'
@@ -699,26 +699,51 @@ export const JournalLive = (
             ),
           ),
       )
-      const clients = yield* ScopedRef.fromAcquire(acquireClient)
+      const clients = yield* ScopedRef.fromAcquire(acquireClient.pipe(Effect.map(Option.some)))
       const semaphore = yield* Semaphore.make(1)
+      const installClient = ScopedRef.set(clients, acquireClient.pipe(Effect.map(Option.some)))
       const refresh = (trigger: string): Effect.Effect<void> =>
-        ScopedRef.set(clients, acquireClient).pipe(
-          Effect.tap(() => Effect.logInfo('TigerBeetle client refreshed').pipe(Effect.annotateLogs({ trigger }))),
-          Effect.catch((error) =>
-            Effect.logWarning('TigerBeetle client refresh failed').pipe(
-              Effect.annotateLogs({
-                trigger,
-                component: error.component,
-                operation: error.operation,
-                error: error.message,
-              }),
+        ScopedRef.set(clients, Effect.succeed(Option.none<Client>())).pipe(
+          Effect.andThen(
+            installClient.pipe(
+              Effect.tap(() => Effect.logInfo('TigerBeetle client refreshed').pipe(Effect.annotateLogs({ trigger }))),
+              Effect.catch((error) =>
+                Effect.logWarning('TigerBeetle client refresh failed').pipe(
+                  Effect.annotateLogs({
+                    trigger,
+                    component: error.component,
+                    operation: error.operation,
+                    error: error.message,
+                  }),
+                ),
+              ),
             ),
           ),
         )
+      const getClient = ScopedRef.get(clients).pipe(
+        Effect.flatMap(
+          Option.match({
+            onSome: Effect.succeed,
+            onNone: () =>
+              installClient.pipe(
+                Effect.andThen(ScopedRef.get(clients)),
+                Effect.flatMap(
+                  Option.match({
+                    onSome: Effect.succeed,
+                    onNone: () =>
+                      Effect.fail(
+                        operationalError('journal', 'connect', 'TigerBeetle client unavailable after refresh'),
+                      ),
+                  }),
+                ),
+              ),
+          }),
+        ),
+      )
       const client: LedgerClient = {
         request: <A>(operation: string, execute: (active: Client) => Promise<A>) =>
           semaphore.withPermit(
-            ScopedRef.get(clients).pipe(
+            getClient.pipe(
               Effect.flatMap((active) =>
                 Effect.tryPromise({
                   try: () => execute(active),

--- a/services/bayn/src/resources.test.ts
+++ b/services/bayn/src/resources.test.ts
@@ -112,6 +112,51 @@ describe('Bayn resource lifecycle', () => {
     expect(tigerBeetleCloseCount).toBe(1)
   })
 
+  test('replaces a failed TigerBeetle client so the next probe recovers', async () => {
+    const closeCounts = [0, 0]
+    const clients = [
+      {
+        lookupAccounts: async () => {
+          throw new Error('Client was closed.')
+        },
+        destroy: () => void (closeCounts[0] += 1),
+      },
+      {
+        lookupAccounts: async () => [],
+        destroy: () => void (closeCounts[1] += 1),
+      },
+    ] as unknown as Client[]
+    let clientIndex = 0
+    const createClient = (): Client => {
+      const client = clients[clientIndex]
+      if (client === undefined) throw new Error('unexpected TigerBeetle client acquisition')
+      clientIndex += 1
+      return client
+    }
+
+    const firstError = await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const journal = yield* Journal
+          const error = yield* Effect.flip(journal.check)
+          yield* journal.check
+          return error
+        }).pipe(
+          Effect.provide(
+            JournalLive(config, {
+              createClient: createClient as typeof createTigerBeetleClient,
+              resolveReplicaAddresses: () => Effect.succeed(['3000']),
+            }),
+          ),
+        ),
+      ),
+    )
+
+    expect(firstError.message).toContain('Client was closed')
+    expect(clientIndex).toBe(2)
+    expect(closeCounts).toEqual([1, 1])
+  })
+
   test('interrupts an in-flight market-data read when the startup deadline expires', async () => {
     let interrupted = false
     const marketData = marketDataService(

--- a/services/bayn/src/resources.test.ts
+++ b/services/bayn/src/resources.test.ts
@@ -157,6 +157,53 @@ describe('Bayn resource lifecycle', () => {
     expect(closeCounts).toEqual([1, 1])
   })
 
+  test('invalidates an interrupted TigerBeetle client when replacement acquisition fails', async () => {
+    const closeCounts = [0, 0]
+    let rejectLookup: ((cause: Error) => void) | undefined
+    const interruptedClient = {
+      lookupAccounts: () =>
+        new Promise<never>((_, reject) => {
+          rejectLookup = reject
+        }),
+      destroy: () => {
+        closeCounts[0] += 1
+        rejectLookup?.(new Error('client closed'))
+      },
+    } as unknown as Client
+    const recoveredClient = {
+      lookupAccounts: async () => [],
+      destroy: () => void (closeCounts[1] += 1),
+    } as unknown as Client
+    let clientAcquisitions = 0
+    const createClient = (): Client => {
+      clientAcquisitions += 1
+      if (clientAcquisitions === 1) return interruptedClient
+      if (clientAcquisitions === 2) throw new Error('replacement unavailable')
+      if (clientAcquisitions === 3) return recoveredClient
+      throw new Error('unexpected TigerBeetle client acquisition')
+    }
+
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const journal = yield* Journal
+          yield* journal.check.pipe(Effect.timeout(5), Effect.ignore)
+          yield* journal.check
+        }).pipe(
+          Effect.provide(
+            JournalLive(config, {
+              createClient: createClient as typeof createTigerBeetleClient,
+              resolveReplicaAddresses: () => Effect.succeed(['3000']),
+            }),
+          ),
+        ),
+      ),
+    )
+
+    expect(clientAcquisitions).toBe(3)
+    expect(closeCounts).toEqual([1, 1])
+  })
+
   test('interrupts an in-flight market-data read when the startup deadline expires', async () => {
     let interrupted = false
     const marketData = marketDataService(


### PR DESCRIPTION
## Summary

- replace Bayn's failed or interrupted scoped TigerBeetle client before the next ledger operation
- invalidate the active handle before replacement acquisition so a failed refresh cannot leave a closed client reusable
- serialize client use and refresh while preserving fail-closed semantics: the current failed operation is never retried
- add regression coverage for both a closed-client failure and an interrupted request whose first replacement acquisition fails
- refresh deterministic Nix dependency hashes for the current repository lock and manifests

## Related Issues

PROOMPT-396

## Testing

- `bun test services/bayn/src/resources.test.ts` - 6 passed
- `bun run --filter @proompteng/bayn test` - 124 passed, 24 skipped, 0 failed, 567 assertions
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint:type` - 0 warnings, 0 errors
- `bun run --filter @proompteng/bayn build`
- `nix-instantiate --parse nix/images/bayn.nix`
- `git diff --check`
- GitHub CI: Bayn and PostgreSQL tests, shared compatibility, and Nix image builds for amd64 and arm64 passed on current head

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed because this is a runtime lifecycle fix.
- [x] Breaking Changes documented.
- [x] Review feedback is fixed, evidenced, replied to, and resolved.
- [x] No documentation or release-note change is required; live rollout evidence will be recorded against PROOMPT-396.
