### PR TITLE
fix(bayn): allow concurrent archive quorum writes

### DIFF
--- a/argocd/applications/torghut/market-data-archive/configmap.yaml
+++ b/argocd/applications/torghut/market-data-archive/configmap.yaml
@@ -15,7 +15,7 @@ data:
   ARCHIVE_OVERNIGHT_BARS_TOPIC: "bayn.market-data.overnight.bars.1m.v1"
   ARCHIVE_CHECKPOINT_INTERVAL_MS: "60000"
   ARCHIVE_PARALLELISM: "3"
-  ARCHIVE_CLICKHOUSE_URL: "jdbc:clickhouse://torghut-clickhouse.torghut.svc.cluster.local:8123/signal"
+  ARCHIVE_CLICKHOUSE_URL: "jdbc:clickhouse://torghut-clickhouse.torghut.svc.cluster.local:8123/signal?insert_quorum_parallel=1"
   ARCHIVE_CLICKHOUSE_USERNAME: "signal_publisher"
   ARCHIVE_CLICKHOUSE_BATCH_SIZE: "100"
   ARCHIVE_CLICKHOUSE_FLUSH_MS: "1000"

--- a/argocd/applications/torghut/market-data-archive/flinkdeployment.yaml
+++ b/argocd/applications/torghut/market-data-archive/flinkdeployment.yaml
@@ -11,7 +11,7 @@ spec:
   # The TA release workflow pins the same immutable image used by the live and simulation TA jobs.
   image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:1a3fba53b409b7f1f37d2836c59497a73ed4c6ea244d9004ee3c2dbf945043d4
   imagePullPolicy: IfNotPresent
-  restartNonce: 2
+  restartNonce: 3
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   flinkConfiguration:

--- a/packages/scripts/src/signal/gitops-contract.test.ts
+++ b/packages/scripts/src/signal/gitops-contract.test.ts
@@ -222,6 +222,7 @@ describe('Signal publisher GitOps authority contract', () => {
       'pdb.yaml',
     ])
     expect(archive.spec).toMatchObject({
+      restartNonce: 3,
       job: {
         entryClass: 'ai.proompteng.dorvud.ta.flink.MarketDataArchiveJobKt',
         parallelism: 3,
@@ -234,6 +235,8 @@ describe('Signal publisher GitOps authority contract', () => {
       ARCHIVE_DELAYED_SIP_BARS_TOPIC: 'bayn.market-data.delayed-sip.bars.1m.v1',
       ARCHIVE_OVERNIGHT_BARS_TOPIC: 'bayn.market-data.overnight.bars.1m.v1',
       ARCHIVE_PARALLELISM: '3',
+      ARCHIVE_CLICKHOUSE_URL:
+        'jdbc:clickhouse://torghut-clickhouse.torghut.svc.cluster.local:8123/signal?insert_quorum_parallel=1',
       ARCHIVE_CLICKHOUSE_USERNAME: 'signal_publisher',
     })
     const archiveEnvironment = environment(archive.spec.podTemplate.spec.containers[0])


### PR DESCRIPTION
## Summary

- enable parallel quorum inserts only for the three-way Bayn market-data archive sink
- preserve the shared `signal_publisher` profile, two-replica write quorum, and Bayn's read-only authority
- increment the Flink restart nonce so the corrected JDBC session setting takes effect through GitOps
- lock the scoped setting and restart in the existing Signal GitOps contract

## Related Issues

PROOMPT-396

## Testing

- `bun test packages/scripts/src/signal/gitops-contract.test.ts` - 8 passed, 104 assertions
- `bunx oxfmt --check packages/scripts/src/signal/gitops-contract.test.ts`
- `kustomize build --enable-helm argocd/applications/torghut`
- `bun run lint:argocd` - 0 invalid resources, 0 errors
- `git diff --check`
- live reproduction: three concurrent Flink sinks received `UNSATISFIED_QUORUM_FOR_PREVIOUS_WRITE` while `signal_publisher/insert_quorum_parallel` was `0`; both ClickHouse replicas were active with empty replication queues

## Breaking Changes

None. The archive restarts once from its Kafka checkpoint/consumer-group state; source offsets keep replay idempotent.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed because this is a data-path configuration fix.
- [x] Breaking Changes and rollout impact are documented.
- [x] No trading, broker, or capital authority changes.
