### PR TITLE
fix(bayn): forward archive quorum setting

### DIFF
--- a/argocd/applications/torghut/market-data-archive/configmap.yaml
+++ b/argocd/applications/torghut/market-data-archive/configmap.yaml
@@ -15,7 +15,8 @@ data:
   ARCHIVE_OVERNIGHT_BARS_TOPIC: "bayn.market-data.overnight.bars.1m.v1"
   ARCHIVE_CHECKPOINT_INTERVAL_MS: "60000"
   ARCHIVE_PARALLELISM: "3"
-  ARCHIVE_CLICKHOUSE_URL: "jdbc:clickhouse://torghut-clickhouse.torghut.svc.cluster.local:8123/signal?insert_quorum_parallel=1"
+  # ClickHouse JDBC v2 forwards server settings only with the clickhouse_setting_ prefix.
+  ARCHIVE_CLICKHOUSE_URL: "jdbc:clickhouse://torghut-clickhouse.torghut.svc.cluster.local:8123/signal?clickhouse_setting_insert_quorum_parallel=1"
   ARCHIVE_CLICKHOUSE_USERNAME: "signal_publisher"
   ARCHIVE_CLICKHOUSE_BATCH_SIZE: "100"
   ARCHIVE_CLICKHOUSE_FLUSH_MS: "1000"

--- a/argocd/applications/torghut/market-data-archive/flinkdeployment.yaml
+++ b/argocd/applications/torghut/market-data-archive/flinkdeployment.yaml
@@ -11,7 +11,7 @@ spec:
   # The TA release workflow pins the same immutable image used by the live and simulation TA jobs.
   image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:1a3fba53b409b7f1f37d2836c59497a73ed4c6ea244d9004ee3c2dbf945043d4
   imagePullPolicy: IfNotPresent
-  restartNonce: 3
+  restartNonce: 4
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   flinkConfiguration:

--- a/packages/scripts/src/signal/gitops-contract.test.ts
+++ b/packages/scripts/src/signal/gitops-contract.test.ts
@@ -222,7 +222,7 @@ describe('Signal publisher GitOps authority contract', () => {
       'pdb.yaml',
     ])
     expect(archive.spec).toMatchObject({
-      restartNonce: 3,
+      restartNonce: 4,
       job: {
         entryClass: 'ai.proompteng.dorvud.ta.flink.MarketDataArchiveJobKt',
         parallelism: 3,
@@ -236,7 +236,7 @@ describe('Signal publisher GitOps authority contract', () => {
       ARCHIVE_OVERNIGHT_BARS_TOPIC: 'bayn.market-data.overnight.bars.1m.v1',
       ARCHIVE_PARALLELISM: '3',
       ARCHIVE_CLICKHOUSE_URL:
-        'jdbc:clickhouse://torghut-clickhouse.torghut.svc.cluster.local:8123/signal?insert_quorum_parallel=1',
+        'jdbc:clickhouse://torghut-clickhouse.torghut.svc.cluster.local:8123/signal?clickhouse_setting_insert_quorum_parallel=1',
       ARCHIVE_CLICKHOUSE_USERNAME: 'signal_publisher',
     })
     const archiveEnvironment = environment(archive.spec.podTemplate.spec.containers[0])


### PR DESCRIPTION
## Summary

- forward `insert_quorum_parallel=1` using the `clickhouse_setting_` prefix required by ClickHouse JDBC 0.9.5
- restart only the market-data archive at nonce 4 so the corrected connection property takes effect
- preserve two-replica quorum, the shared publisher profile, and read-only Bayn authority
- lock the driver-specific URL and restart nonce in the Signal GitOps contract

## Related Issues

PROOMPT-396

## Testing

- `bun test packages/scripts/src/signal/gitops-contract.test.ts` - 8 passed, 104 assertions
- `bunx oxfmt --check packages/scripts/src/signal/gitops-contract.test.ts`
- `kustomize build --enable-helm argocd/applications/torghut`
- `bun run lint:argocd` - 0 invalid resources, 0 errors
- `git diff --check`
- live nonce-3 evidence: ClickHouse JDBC 0.9.5 still emitted `Another quorum insert has been already started` because the bare URL property was not forwarded as a server setting

## Breaking Changes

None. The archive restarts once from its retained Flink checkpoint. Kafka source offsets and the append-only source key keep replay idempotent.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; rollout and rollback impact is documented.
- [x] No broker, order, or capital-promotion authority is introduced.