### PR TITLE
fix(bayn): audit every ClickHouse replica

### DIFF
--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -1,8 +1,8 @@
 # Bayn
 
-Bayn is a single-writer, paper-only quantitative research runtime. Its first protocol evaluates a frozen long-or-cash
-time-series momentum strategy on adjusted ETF daily bars, compares it with buy-and-hold and direct-volatility timing,
-and journals the resulting simulation to TigerBeetle. It contains no broker client and has no capital-promotion path.
+Bayn is a single-writer, paper-only quantitative qualification runtime. Its current protocol evaluates the frozen
+risk-balanced trend candidate on the authoritative infrastructure-equity universe and journals the resulting simulation
+to TigerBeetle. Historical TSMOM evidence remains readable. Bayn contains no broker client or capital-promotion path.
 
 ## Runtime contract
 
@@ -14,10 +14,10 @@ and journals the resulting simulation to TigerBeetle. It contains no broker clie
 - Bayn owns a two-instance CloudNativePG cluster. The runtime uses the generated application URI over verified TLS,
   runs additive Effect SQL migrations at startup, and keeps a two-connection pool for its single-writer operation plus
   query cancellation.
-- The composition root selects one strategy capability. TSMOM is the first implementation and owns its protocol and
-  universe; the HTTP and startup lifecycle do not depend on TSMOM directly.
-- The typed `bayn.tsmom.protocol.v2` default is compiled into the image and runtime-decoded with Effect Schema before
-  use. It contains the complete versioned execution model; strategies remain reviewed TypeScript rather than JSON.
+- The composition root selects one strategy capability. The compiled `bayn.risk-balanced-trend.protocol.v1` owns its
+  authoritative universe and execution contract; the HTTP and startup lifecycle remain strategy-independent.
+- The typed protocol is compiled into the image and runtime-decoded with Effect Schema. Strategies remain reviewed
+  TypeScript rather than JSON.
 - The executable embeds source, repository, and strategy-behavior identity. Startup verifies configured attribution,
   and status exposes the promoted image digest, parameter hash, and contract versions.
 - The package `dev` and `start` scripts use explicit `development-configured` provenance because their artifacts are
@@ -92,9 +92,9 @@ bun run --filter @proompteng/bayn lint:oxlint
 For a terminal locked candidate, `audit:qualification` performs an operator-side, read-only reproduction. It reads the
 evidence graph in one PostgreSQL `REPEATABLE READ, READ ONLY` transaction, reloads the finalized Signal snapshot,
 replays the candidate and all benchmarks without importing the production strategy, checks ClickHouse query-start
-chronology with a separately supplied audit principal, and checks authoritative `origin/main` history. It emits one
-`bayn.qualification-audit.v1` JSON report and exits nonzero on any failed check. Run it twice and require identical
-`auditHash` values.
+chronology on every physical ClickHouse replica with a separately supplied audit principal, and checks authoritative
+`origin/main` history. It emits one `bayn.qualification-audit.v2` JSON report and exits nonzero on any failed check. Run
+it twice and require identical `auditHash` values.
 
 ```sh
 BAYN_AUDIT_RUN_ID=<run-id> \
@@ -103,7 +103,7 @@ BAYN_AUDIT_SIGNAL_URL=<signal-clickhouse-url> \
 BAYN_AUDIT_SIGNAL_USERNAME=<readonly-bayn-user> \
 BAYN_AUDIT_SIGNAL_PUBLISHER_USERNAME=<signal-publisher-user> \
 BAYN_AUDIT_SIGNAL_PASSWORD=<readonly-bayn-password> \
-BAYN_AUDIT_CLICKHOUSE_URL=<clickhouse-audit-url> \
+BAYN_AUDIT_CLICKHOUSE_URLS=<replica-0-audit-url>,<replica-1-audit-url> \
 BAYN_AUDIT_CLICKHOUSE_USERNAME=<query-log-audit-user> \
 BAYN_AUDIT_CLICKHOUSE_PASSWORD=<query-log-audit-password> \
 BAYN_AUDIT_REPOSITORY_PATH=<lab-checkout> \
@@ -114,7 +114,7 @@ The audit command is not part of the deployed runtime and never calls TigerBeetl
 ClickHouse credential is operator-supplied only to read `system.query_log`; the service keeps its normal Signal
 read-only identity.
 
-Set `BAYN_AUDIT_OUTPUT=dossier` on the same command to emit `bayn.qualification-dossier.v1`. The deterministic dossier
+Set `BAYN_AUDIT_OUTPUT=dossier` on the same command to emit `bayn.qualification-dossier.v2`. The deterministic dossier
 binds the full audited subject, evidence-set hashes, immutable lock/result, prior trials, contamination records,
 verdict, and observe-only authority. GitOps publishes the reviewed JSON as the content-hashed
 `bayn-qualification-dossier` ConfigMap.
@@ -126,5 +126,6 @@ BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:5432/bayn_test \
   bun test services/bayn/src/db/evidence-store.integration.test.ts
 ```
 
-Bayn reads the fixed `adjusted_daily_bars_v2`, `exchange_sessions_v1`, and `snapshot_manifests_v1` tables through the
-official Effect ClickHouse client. Its Signal identity is read-only and has no DDL, insert, or mutation authority.
+The current candidate reads `adjusted_daily_bars_v2`, `exchange_sessions_v1`, and `snapshot_manifests_v2` through the
+official Effect ClickHouse client. Historical TSMOM audits retain an explicit V1-manifest reader. Bayn's Signal identity
+is read-only and has no DDL, insert, or mutation authority.

--- a/services/bayn/src/qualification-audit-command.ts
+++ b/services/bayn/src/qualification-audit-command.ts
@@ -21,6 +21,8 @@ const Sha256 = Schema.String.check(Schema.isPattern(/^[0-9a-f]{64}$/))
 const PositiveInteger = Schema.Int.check(Schema.isGreaterThan(0))
 const NonNegativeInteger = Schema.Int.check(Schema.isGreaterThanOrEqualTo(0))
 const IsoInstant = Schema.String.check(Schema.isPattern(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z$/))
+const ReplicaName = Schema.Trim.check(Schema.isMinLength(1))
+const AuditClickhouseUrls = Config.Array(Schema.URLFromString).check(Schema.isMinLength(2), Schema.isUnique())
 
 const RunRow = Schema.Struct({
   run_id: Sha256,
@@ -76,11 +78,13 @@ const QualificationRow = Schema.Struct({
 })
 const ReadOnlyRow = Schema.Struct({ read_only: Schema.Boolean })
 const AccessRow = Schema.Struct({
+  replica: ReplicaName,
   query_id: Schema.String,
   query_start_time: IsoInstant,
   user: Schema.String,
   kind: Schema.Literals(['manifest', 'sessions', 'bars']),
 })
+const ReplicaRow = Schema.Struct({ replica: ReplicaName })
 
 const decodeRunRows = Schema.decodeUnknownSync(Schema.Array(RunRow), StrictParseOptions)
 const decodeArtifactRows = Schema.decodeUnknownSync(Schema.Array(ArtifactRow), StrictParseOptions)
@@ -91,6 +95,7 @@ const decodeTrialRows = Schema.decodeUnknownSync(Schema.Array(TrialRow), StrictP
 const decodeQualificationRows = Schema.decodeUnknownSync(Schema.Array(QualificationRow), StrictParseOptions)
 const decodeReadOnlyRows = Schema.decodeUnknownSync(Schema.Array(ReadOnlyRow), StrictParseOptions)
 const decodeAccessRows = Schema.decodeUnknownSync(Schema.Array(AccessRow), StrictParseOptions)
+const decodeReplicaRows = Schema.decodeUnknownSync(Schema.Array(ReplicaRow), StrictParseOptions)
 
 const exactlyOne = <A>(values: readonly A[], name: string): A => {
   if (values.length !== 1) throw new Error(`${name} returned ${values.length} rows; expected exactly one`)
@@ -107,7 +112,7 @@ const config = Config.all({
   signalUsername: Config.string('BAYN_AUDIT_SIGNAL_USERNAME'),
   signalPublisherUsername: Config.string('BAYN_AUDIT_SIGNAL_PUBLISHER_USERNAME'),
   signalPassword: Config.redacted('BAYN_AUDIT_SIGNAL_PASSWORD'),
-  auditClickhouseUrl: Config.string('BAYN_AUDIT_CLICKHOUSE_URL'),
+  auditClickhouseUrls: Config.schema(AuditClickhouseUrls, 'BAYN_AUDIT_CLICKHOUSE_URLS'),
   auditClickhouseUsername: Config.string('BAYN_AUDIT_CLICKHOUSE_USERNAME'),
   auditClickhousePassword: Config.redacted('BAYN_AUDIT_CLICKHOUSE_PASSWORD'),
   repositoryPath: Config.string('BAYN_AUDIT_REPOSITORY_PATH').pipe(Config.withDefault('.')),
@@ -351,16 +356,43 @@ const loadSignal = (input: AuditConfig, manifest: InputManifest, protocol: Strat
   )
 }
 
-const readSignalAccess = (
+interface SignalReplicaAccess {
+  readonly replica: string
+  readonly topology: readonly string[]
+  readonly access: readonly SignalAccessRecord[]
+}
+
+const readSignalReplicaAccess = (
   input: AuditConfig,
+  url: URL,
+  ordinal: number,
   database: AuditDatabaseSnapshot,
   finalizedAt: string,
   manifestTable: InputManifest['tables']['manifests'],
-): Effect.Effect<readonly SignalAccessRecord[], unknown> => {
+): Effect.Effect<SignalReplicaAccess, unknown> => {
   const program = Effect.gen(function* () {
     const sql = yield* ClickhouseClient.ClickhouseClient
+    const replica = exactlyOne(
+      decodeReplicaRows(
+        yield* sql`
+          SELECT host_name AS replica
+          FROM system.clusters
+          WHERE cluster = 'default' AND is_local
+        `,
+      ),
+      `ClickHouse audit endpoint ${ordinal}`,
+    ).replica
+    const topology = decodeReplicaRows(
+      yield* sql`
+        SELECT host_name AS replica
+        FROM system.clusters
+        WHERE cluster = 'default'
+        ORDER BY shard_num, replica_num
+      `,
+    ).map((row) => row.replica)
     const rows = yield* sql`
       SELECT
+        ${sql.param('String', replica)} AS replica,
         query_id,
         formatDateTime(toTimeZone(query_start_time_microseconds, 'UTC'), '%Y-%m-%dT%H:%i:%S.%fZ') AS query_start_time,
         user,
@@ -384,17 +416,22 @@ const readSignalAccess = (
         )
       ORDER BY query_start_time_microseconds, query_id
     `.pipe(sql.withQueryId(`bayn-audit-access-${database.run.runId.slice(-24)}`))
-    return decodeAccessRows(rows).map((row) => ({
-      queryId: row.query_id,
-      queryStartTime: row.query_start_time,
-      user: row.user,
-      kind: row.kind,
-    }))
+    return {
+      replica,
+      topology,
+      access: decodeAccessRows(rows).map((row) => ({
+        replica: row.replica,
+        queryId: row.query_id,
+        queryStartTime: row.query_start_time,
+        user: row.user,
+        kind: row.kind,
+      })),
+    }
   })
   return program.pipe(
     Effect.provide(
       ClickhouseClient.layer({
-        url: input.auditClickhouseUrl,
+        url: url.href,
         username: input.auditClickhouseUsername,
         password: Redacted.value(input.auditClickhousePassword),
         database: 'system',
@@ -405,6 +442,45 @@ const readSignalAccess = (
     Effect.provide(NodeHttpClient.layerNodeHttp),
   )
 }
+
+const readSignalAccess = (
+  input: AuditConfig,
+  database: AuditDatabaseSnapshot,
+  finalizedAt: string,
+  manifestTable: InputManifest['tables']['manifests'],
+): Effect.Effect<{ readonly replicas: readonly string[]; readonly access: readonly SignalAccessRecord[] }, unknown> =>
+  Effect.all(
+    input.auditClickhouseUrls.map((url, ordinal) =>
+      readSignalReplicaAccess(input, url, ordinal, database, finalizedAt, manifestTable),
+    ),
+    { concurrency: 'unbounded' },
+  ).pipe(
+    Effect.flatMap((sources) =>
+      Effect.try({
+        try: () => {
+          const observed = sources.map((source) => source.replica).sort()
+          if (new Set(observed).size !== observed.length) {
+            throw new Error('ClickHouse audit endpoints resolved to duplicate replicas')
+          }
+          const topology = [...(sources[0]?.topology ?? [])].sort()
+          if (topology.length < 2 || new Set(topology).size !== topology.length) {
+            throw new Error('ClickHouse audit topology must contain at least two unique replicas')
+          }
+          if (sources.some((source) => [...source.topology].sort().join('\0') !== topology.join('\0'))) {
+            throw new Error('ClickHouse audit endpoints report divergent replica topology')
+          }
+          if (observed.join('\0') !== topology.join('\0')) {
+            throw new Error('ClickHouse audit endpoints do not cover every configured cluster replica')
+          }
+          if (sources.some((source) => source.access.some((record) => record.replica !== source.replica))) {
+            throw new Error('ClickHouse query-log rows do not match their audited replica')
+          }
+          return { replicas: observed, access: sources.flatMap((source) => source.access) }
+        },
+        catch: (cause) => cause,
+      }),
+    ),
+  )
 
 const repositoryAudit = (
   repositoryPath: string,
@@ -474,7 +550,8 @@ const main = Effect.gen(function* () {
     manifest: signal.manifest,
     protocol,
     database,
-    signalAccess,
+    signalReplicas: signalAccess.replicas,
+    signalAccess: signalAccess.access,
     signalPrincipals: { candidate: input.signalUsername, publishers: [input.signalPublisherUsername] },
     repository,
   }

--- a/services/bayn/src/qualification-audit.test.ts
+++ b/services/bayn/src/qualification-audit.test.ts
@@ -231,16 +231,50 @@ const fixture = (profile: 'tsmom' | 'risk-balanced-trend' = 'tsmom'): Qualificat
     manifest: snapshot.manifest,
     protocol,
     database,
+    signalReplicas: ['replica-0', 'replica-1'],
     signalAccess: [
       {
+        replica: 'replica-0',
         queryId: 'publisher',
         queryStartTime: '2026-07-20T11:59:58.000000Z',
         user: 'signal-publisher',
         kind: 'bars',
       },
-      { queryId: 'manifest', queryStartTime: '2026-07-20T11:59:59.000000Z', user: 'bayn', kind: 'manifest' },
-      { queryId: 'sessions', queryStartTime: '2026-07-20T12:00:01.000000Z', user: 'bayn', kind: 'sessions' },
-      { queryId: 'bars', queryStartTime: '2026-07-20T12:00:01.100000Z', user: 'bayn', kind: 'bars' },
+      {
+        replica: 'replica-0',
+        queryId: 'manifest-inspect',
+        queryStartTime: '2026-07-20T11:59:59.000000Z',
+        user: 'bayn',
+        kind: 'manifest',
+      },
+      {
+        replica: 'replica-1',
+        queryId: 'sessions-inspect',
+        queryStartTime: '2026-07-20T11:59:59.100000Z',
+        user: 'bayn',
+        kind: 'sessions',
+      },
+      {
+        replica: 'replica-1',
+        queryId: 'manifest-load',
+        queryStartTime: '2026-07-20T12:00:01.000000Z',
+        user: 'bayn',
+        kind: 'manifest',
+      },
+      {
+        replica: 'replica-0',
+        queryId: 'sessions-load',
+        queryStartTime: '2026-07-20T12:00:01.050000Z',
+        user: 'bayn',
+        kind: 'sessions',
+      },
+      {
+        replica: 'replica-1',
+        queryId: 'bars',
+        queryStartTime: '2026-07-20T12:00:01.100000Z',
+        user: 'bayn',
+        kind: 'bars',
+      },
     ],
     signalPrincipals: { candidate: 'bayn', publishers: ['signal-publisher'] },
     repository: { sourceCommitExists: true, sourceCommitAncestorOfMain: true, preLockResultReferences: [] },
@@ -333,7 +367,7 @@ describe('qualification audit', () => {
     expect(report.checks.find((check) => check.name === 'reference-strategy')?.passed).toBe(false)
   })
 
-  test('fails closed when candidate data was read before the lock', () => {
+  test('fails closed when candidate bars were read before the lock', () => {
     const input = fixture()
     const signalAccess = input.signalAccess.map((record) =>
       record.user === 'bayn' && record.kind === 'bars'
@@ -343,7 +377,7 @@ describe('qualification audit', () => {
     const report = auditQualification({ ...input, signalAccess })
 
     expect(report.status).toBe('FAIL')
-    expect(report.checks.find((check) => check.name === 'signal-lock-before-candidate-data')?.passed).toBe(false)
+    expect(report.checks.find((check) => check.name === 'signal-lock-before-candidate-bars')?.passed).toBe(false)
   })
 
   test.each([
@@ -438,8 +472,20 @@ describe('qualification audit', () => {
           const input = fixture()
           return { ...input, signalAccess: input.signalAccess.filter((record) => record.queryId !== 'bars') }
         })(),
-        'signal-lock-before-candidate-data',
+        'signal-lock-before-candidate-bars',
       ],
+      [
+        'calendar-preflight',
+        (() => {
+          const input = fixture()
+          return {
+            ...input,
+            signalAccess: input.signalAccess.filter((record) => record.queryId !== 'sessions-inspect'),
+          }
+        })(),
+        'signal-calendar-inspected-before-lock',
+      ],
+      ['replica-coverage', { ...fixture(), signalReplicas: ['replica-0'] }, 'signal-query-log-replica-coverage'],
       [
         'principal',
         (() => {
@@ -449,6 +495,7 @@ describe('qualification audit', () => {
             signalAccess: [
               ...input.signalAccess,
               {
+                replica: 'replica-0',
                 queryId: 'unknown',
                 queryStartTime: '2026-07-20T11:59:59.500000Z',
                 user: 'notebook',
@@ -491,7 +538,8 @@ describe('qualification dossier', () => {
     const second = makeQualificationDossier(fixture())
     const { dossierHash, ...material } = first
 
-    expect(first.schemaVersion).toBe('bayn.qualification-dossier.v1')
+    expect(first.schemaVersion).toBe('bayn.qualification-dossier.v2')
+    expect(first.audit.schemaVersion).toBe('bayn.qualification-audit.v2')
     expect(first.audit.status).toBe('PASS')
     expect(first.audit.checks.every((check) => check.passed)).toBe(true)
     expect(first.subject.run.runId).toBe(first.qualification.result.runId)

--- a/services/bayn/src/qualification-audit.ts
+++ b/services/bayn/src/qualification-audit.ts
@@ -81,6 +81,7 @@ export interface AuditDatabaseSnapshot {
 }
 
 export interface SignalAccessRecord {
+  readonly replica: string
   readonly queryId: string
   readonly queryStartTime: string
   readonly user: string
@@ -103,6 +104,7 @@ export interface QualificationAuditInput {
   readonly manifest: InputManifest
   readonly protocol: StrategyProtocol
   readonly database: AuditDatabaseSnapshot
+  readonly signalReplicas: readonly string[]
   readonly signalAccess: readonly SignalAccessRecord[]
   readonly signalPrincipals: SignalPrincipals
   readonly repository: RepositoryAudit
@@ -115,7 +117,7 @@ export interface AuditCheck {
 }
 
 export interface QualificationAuditReport {
-  readonly schemaVersion: 'bayn.qualification-audit.v1'
+  readonly schemaVersion: 'bayn.qualification-audit.v2'
   readonly runId: string
   readonly status: 'PASS' | 'FAIL'
   readonly reference: {
@@ -144,6 +146,7 @@ export interface QualificationAuditReport {
   readonly contamination: {
     readonly lockCreatedAt: string
     readonly resultCommittedAt: string
+    readonly replicas: readonly string[]
     readonly principals: SignalPrincipals
     readonly access: readonly SignalAccessRecord[]
   }
@@ -627,34 +630,64 @@ export const auditQualification = (input: QualificationAuditInput): Qualificatio
     `verdict=${String(result.verdict)} reasons=${reasonCodes.join(',')}`,
   )
 
-  const sortedAccess = [...input.signalAccess].sort((left, right) =>
-    left.queryStartTime === right.queryStartTime
-      ? left.queryId.localeCompare(right.queryId)
-      : left.queryStartTime.localeCompare(right.queryStartTime),
-  )
+  const sortedReplicas = [...input.signalReplicas].sort()
+  const sortedAccess = [...input.signalAccess].sort((left, right) => {
+    if (left.queryStartTime !== right.queryStartTime) return left.queryStartTime.localeCompare(right.queryStartTime)
+    if (left.replica !== right.replica) return left.replica.localeCompare(right.replica)
+    return left.queryId.localeCompare(right.queryId)
+  })
   const candidateAccess = sortedAccess.filter((value) => value.user === input.signalPrincipals.candidate)
-  const candidateReads = candidateAccess.filter((value) => value.kind === 'sessions' || value.kind === 'bars')
+  const candidateBarReads = candidateAccess.filter((value) => value.kind === 'bars')
+  const candidateSessionReads = candidateAccess.filter((value) => value.kind === 'sessions')
   const manifestReads = candidateAccess.filter((value) => value.kind === 'manifest')
-  const preLockCandidateReads = candidateReads.filter(
+  const preLockBarReads = candidateBarReads.filter(
     (value) => value.queryStartTime < database.qualification.lockCreatedAt,
   )
+  const preLockSessionReads = candidateSessionReads.filter(
+    (value) => value.queryStartTime < database.qualification.lockCreatedAt,
+  )
+  const preLockManifestReads = manifestReads.filter(
+    (value) => value.queryStartTime < database.qualification.lockCreatedAt,
+  )
+  const lockedSessionReads = candidateSessionReads.filter(
+    (value) =>
+      value.queryStartTime >= database.qualification.lockCreatedAt &&
+      value.queryStartTime <= database.qualification.resultCommittedAt,
+  )
+  const lockedManifestReads = manifestReads.filter(
+    (value) =>
+      value.queryStartTime >= database.qualification.lockCreatedAt &&
+      value.queryStartTime <= database.qualification.resultCommittedAt,
+  )
   check(
-    'signal-lock-before-candidate-data',
-    preLockCandidateReads.length === 0 &&
-      candidateReads.length === 2 &&
-      candidateReads.every(
+    'signal-query-log-replica-coverage',
+    sortedReplicas.length >= 2 &&
+      new Set(sortedReplicas).size === sortedReplicas.length &&
+      sortedAccess.every((value) => sortedReplicas.includes(value.replica)),
+    `${sortedReplicas.length} replicas=${sortedReplicas.join(',')}`,
+  )
+  check(
+    'signal-lock-before-candidate-bars',
+    preLockBarReads.length === 0 &&
+      candidateBarReads.length === 1 &&
+      candidateBarReads.every(
         (value) =>
           value.queryStartTime >= database.qualification.lockCreatedAt &&
           value.queryStartTime <= database.qualification.resultCommittedAt,
       ),
-    `lock=${database.qualification.lockCreatedAt} candidateReads=${candidateReads
-      .map((value) => `${value.kind}@${value.queryStartTime}`)
+    `lock=${database.qualification.lockCreatedAt} barReads=${candidateBarReads
+      .map((value) => `${value.replica}@${value.queryStartTime}`)
       .join(',')}`,
   )
   check(
+    'signal-calendar-inspected-before-lock',
+    preLockSessionReads.length >= 1 && lockedSessionReads.length >= 1,
+    `preLock=${preLockSessionReads.length} locked=${lockedSessionReads.length}`,
+  )
+  check(
     'signal-manifest-inspected-before-lock',
-    manifestReads.some((value) => value.queryStartTime < database.qualification.lockCreatedAt),
-    `${manifestReads.length} manifest reads`,
+    preLockManifestReads.length >= 1 && lockedManifestReads.length >= 1,
+    `preLock=${preLockManifestReads.length} locked=${lockedManifestReads.length}`,
   )
   check(
     'signal-read-principals',
@@ -680,7 +713,7 @@ export const auditQualification = (input: QualificationAuditInput): Qualificatio
   )
 
   const material = {
-    schemaVersion: 'bayn.qualification-audit.v1' as const,
+    schemaVersion: 'bayn.qualification-audit.v2' as const,
     runId: database.run.runId,
     status: checks.every((value) => value.passed) ? ('PASS' as const) : ('FAIL' as const),
     reference: {
@@ -704,6 +737,7 @@ export const auditQualification = (input: QualificationAuditInput): Qualificatio
     contamination: {
       lockCreatedAt: database.qualification.lockCreatedAt,
       resultCommittedAt: database.qualification.resultCommittedAt,
+      replicas: sortedReplicas,
       principals: input.signalPrincipals,
       access: sortedAccess,
     },

--- a/services/bayn/src/qualification-dossier.ts
+++ b/services/bayn/src/qualification-dossier.ts
@@ -72,7 +72,7 @@ const validateSubject = (
 }
 
 export interface QualificationDossier {
-  readonly schemaVersion: 'bayn.qualification-dossier.v1'
+  readonly schemaVersion: 'bayn.qualification-dossier.v2'
   readonly subject: {
     readonly run: AuditDatabaseSnapshot['run']
     readonly protocol: AuditDatabaseSnapshot['protocol']
@@ -117,7 +117,7 @@ export const makeQualificationDossier = (input: QualificationAuditInput): Qualif
   assert(canonicalHashV1(lock.priorTrialRunIds) === canonicalHashV1(database.priorTrialRunIds), 'trial lineage differs')
 
   const material = {
-    schemaVersion: 'bayn.qualification-dossier.v1' as const,
+    schemaVersion: 'bayn.qualification-dossier.v2' as const,
     subject: {
       run: database.run,
       protocol: database.protocol,


### PR DESCRIPTION
## Summary

- Fix qualification query-history auditing to read every physical ClickHouse replica instead of whichever replica a load-balanced service selects.
- Fail closed on duplicate endpoints, incomplete replica coverage, divergent topology, or query rows attributed to the wrong replica.
- Match the runtime protocol: permit manifest and calendar preflight before the immutable lock, require their locked reads, and prohibit candidate bar access before the lock.
- Version new audit and dossier output as v2 while preserving historical committed evidence.
- This changes operator-side read-only qualification tooling only; it does not deploy Bayn, promote the candidate, execute orders, or alter capital authority.

## Related Issues

Related: PROOMPT-394

## Testing

- `bun test services/bayn/src/qualification-audit.test.ts`
- `bun run --filter @proompteng/bayn test` — 127 passed, 24 database-gated tests skipped, 0 failed.
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- Ran the operator audit twice against both live ClickHouse replicas for the historical terminal TSMOM run; both reports passed with audit hash `04d12ecce85b2407d660e6931c66e3eb53e4327e20777361abf5d849078858a` and contained all 14 query-history records.

## Breaking Changes

Operator audit configuration now requires `BAYN_AUDIT_CLICKHOUSE_URLS` with one direct URL per physical replica instead of the singular `BAYN_AUDIT_CLICKHOUSE_URL`. New reports use `bayn.qualification-audit.v2` and `bayn.qualification-dossier.v2`. The deployed runtime and historical committed evidence are unchanged.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.