### PR TITLE
fix(torghut): cancel timed-out TigerBeetle requests

### DIFF
--- a/services/torghut/app/trading/scheduler/capital_controls.py
+++ b/services/torghut/app/trading/scheduler/capital_controls.py
@@ -22,7 +22,12 @@ from ..broker_mutation_receipts import BrokerMutationPurpose
 from ..execution_adapters import ExecutionAdapter
 from ..models import StrategyDecision
 from ..session_context import regular_session_open_utc_for
-from ..tigerbeetle_client import check_tigerbeetle_health
+from ..tigerbeetle_client import (
+    RealTigerBeetleClient,
+    TigerBeetleHealth,
+    check_tigerbeetle_health,
+    create_tigerbeetle_client,
+)
 from ..tigerbeetle_reconcile.latest_tigerbeetle_reconciliation_status_p import (
     latest_tigerbeetle_reconciliation_status_payload,
 )
@@ -59,6 +64,23 @@ class CapitalSafetyController:
         self.sleep = sleep
         self._ledger_checked_at_monotonic: float | None = None
         self._ledger_stop_reason_cache: str | None = None
+        self._ledger_client: RealTigerBeetleClient | None = None
+
+    def close(self) -> None:
+        client = self._ledger_client
+        self._ledger_client = None
+        if client is not None:
+            client.close()
+
+    def _check_ledger_protocol(self) -> TigerBeetleHealth:
+        if not settings.tigerbeetle_enabled:
+            return check_tigerbeetle_health(settings)
+        if self._ledger_client is None:
+            self._ledger_client = create_tigerbeetle_client(settings)
+        health = check_tigerbeetle_health(settings, client=self._ledger_client)
+        if not health.ok:
+            self.close()
+        return health
 
     def evaluate(self, session: Session, snapshot: PositionSnapshot) -> None:
         if settings.trading_mode != "live":
@@ -224,7 +246,7 @@ class CapitalSafetyController:
             return self._ledger_stop_reason_cache
         if protocol_required:
             try:
-                protocol_health = check_tigerbeetle_health(settings)
+                protocol_health = self._check_ledger_protocol()
             except Exception as exc:
                 logger.exception("TigerBeetle protocol safety check failed")
                 reason = f"tigerbeetle_protocol_unavailable:{type(exc).__name__}"

--- a/services/torghut/app/trading/scheduler/runtime.py
+++ b/services/torghut/app/trading/scheduler/runtime.py
@@ -552,6 +552,7 @@ class TradingScheduler(
         )
         for pipeline in active_pipelines:
             pipeline.order_feed_ingestor.close()
+            pipeline.capital_safety.close()
         self._pipelines = []
         self._pipeline = None
         await asyncio.to_thread(self._leadership.release)

--- a/services/torghut/app/trading/tigerbeetle_client.py
+++ b/services/torghut/app/trading/tigerbeetle_client.py
@@ -45,6 +45,7 @@ def _run_with_timeout(
     operation_name: str,
     timeout_seconds: float,
     operation: Callable[[], _T],
+    on_timeout: Callable[[], None] | None = None,
 ) -> _T:
     result_queue: queue.Queue[tuple[bool, _T | BaseException]] = queue.Queue(maxsize=1)
 
@@ -63,9 +64,17 @@ def _run_with_timeout(
     try:
         ok, value = result_queue.get(timeout=max(float(timeout_seconds), 0.001))
     except queue.Empty as exc:
-        raise TigerBeetleClientTimeoutError(
+        timeout_error = TigerBeetleClientTimeoutError(
             f"tigerbeetle_{operation_name}_timeout:{timeout_seconds:.3f}s"
-        ) from exc
+        )
+        if on_timeout is not None:
+            on_timeout()
+        thread.join(timeout=1.0)
+        if thread.is_alive():
+            timeout_error.add_note(
+                "timed-out TigerBeetle worker did not stop after cancellation"
+            )
+        raise timeout_error from exc
     if ok:
         return cast(_T, value)
     if isinstance(value, TigerBeetleClientError):
@@ -176,23 +185,31 @@ class RealTigerBeetleClient:
         official_addresses = resolve_replica_addresses(replica_addresses)
         self._tb: Any = tb
         self._rpc_timeout_seconds = max(float(rpc_timeout_seconds), 0.001)
-        self._client: Any = _run_with_timeout(
-            operation_name="connect",
-            timeout_seconds=self._rpc_timeout_seconds,
-            operation=lambda: tb.ClientSync(
-                cluster_id=cluster_id,
-                replica_addresses=",".join(official_addresses),
-            ),
+        self._close_lock = threading.Lock()
+        self._closed = False
+        self._client: Any = tb.ClientSync(
+            cluster_id=cluster_id,
+            replica_addresses=",".join(official_addresses),
         )
 
     def close(self) -> None:
-        close = getattr(self._client, "close", None)
-        if callable(close):
-            close()
-            return
-        exit_fn = getattr(self._client, "__exit__", None)
-        if callable(exit_fn):
-            exit_fn(None, None, None)
+        with self._close_lock:
+            if self._closed:
+                return
+            self._closed = True
+            client = self._client
+        client.close()
+
+    def _run(self, operation_name: str, operation: Callable[[], _T]) -> _T:
+        with self._close_lock:
+            if self._closed:
+                raise TigerBeetleClientError("tigerbeetle_client_closed")
+        return _run_with_timeout(
+            operation_name=operation_name,
+            timeout_seconds=self._rpc_timeout_seconds,
+            operation=operation,
+            on_timeout=self.close,
+        )
 
     def nop(self) -> None:
         # The Python client does not expose TigerBeetle's internal NOP request.
@@ -238,35 +255,31 @@ class RealTigerBeetleClient:
         )
 
     def create_accounts(self, accounts: Sequence[object]) -> Sequence[object]:
-        return _run_with_timeout(
-            operation_name="create_accounts",
-            timeout_seconds=self._rpc_timeout_seconds,
-            operation=lambda: self._client.create_accounts(
+        return self._run(
+            "create_accounts",
+            lambda: self._client.create_accounts(
                 [self._account_event(item) for item in accounts]
             ),
         )
 
     def lookup_accounts(self, ids: Sequence[int]) -> Sequence[object]:
-        return _run_with_timeout(
-            operation_name="lookup_accounts",
-            timeout_seconds=self._rpc_timeout_seconds,
-            operation=lambda: self._client.lookup_accounts(list(ids)),
+        return self._run(
+            "lookup_accounts",
+            lambda: self._client.lookup_accounts(list(ids)),
         )
 
     def create_transfers(self, transfers: Sequence[object]) -> Sequence[object]:
-        return _run_with_timeout(
-            operation_name="create_transfers",
-            timeout_seconds=self._rpc_timeout_seconds,
-            operation=lambda: self._client.create_transfers(
+        return self._run(
+            "create_transfers",
+            lambda: self._client.create_transfers(
                 [self._transfer_event(item) for item in transfers]
             ),
         )
 
     def lookup_transfers(self, ids: Sequence[int]) -> Sequence[object]:
-        return _run_with_timeout(
-            operation_name="lookup_transfers",
-            timeout_seconds=self._rpc_timeout_seconds,
-            operation=lambda: self._client.lookup_transfers(list(ids)),
+        return self._run(
+            "lookup_transfers",
+            lambda: self._client.lookup_transfers(list(ids)),
         )
 
 

--- a/services/torghut/tests/scheduler/test_runtime_leadership.py
+++ b/services/torghut/tests/scheduler/test_runtime_leadership.py
@@ -109,6 +109,7 @@ class TradingSchedulerLeadershipTests(IsolatedAsyncioTestCase):
             SimpleNamespace(
                 account_label="paper",
                 order_feed_ingestor=SimpleNamespace(close=Mock()),
+                capital_safety=SimpleNamespace(close=Mock()),
             )
         ]
         scheduler._pipeline = scheduler._pipelines[0]
@@ -122,6 +123,7 @@ class TradingSchedulerLeadershipTests(IsolatedAsyncioTestCase):
         leadership = _FakeLeadership()
         fatal_exit = Mock()
         scheduler = self._prepared_scheduler(leadership, fatal_exit=fatal_exit)
+        pipeline = scheduler._pipelines[0]
 
         await scheduler.start()
         await scheduler.stop()
@@ -129,6 +131,7 @@ class TradingSchedulerLeadershipTests(IsolatedAsyncioTestCase):
         self.assertEqual(leadership.acquire_calls, 1)
         self.assertEqual(leadership.release_calls, 1)
         self.assertFalse(scheduler.leadership_status.acquired)
+        pipeline.capital_safety.close.assert_called_once_with()
         fatal_exit.assert_not_called()
 
     async def test_unexpected_loop_return_is_process_fatal(self) -> None:
@@ -345,6 +348,7 @@ class TradingSchedulerLeadershipTests(IsolatedAsyncioTestCase):
         pipeline = SimpleNamespace(
             account_label="paper",
             order_feed_ingestor=SimpleNamespace(close=Mock()),
+            capital_safety=SimpleNamespace(close=Mock()),
             run_once=blocking_run_once,
         )
         scheduler._pipelines = [pipeline]
@@ -405,6 +409,7 @@ class TradingSchedulerLeadershipTests(IsolatedAsyncioTestCase):
         pipeline = SimpleNamespace(
             account_label="paper",
             order_feed_ingestor=SimpleNamespace(close=Mock()),
+            capital_safety=SimpleNamespace(close=Mock()),
             run_once=run_once,
             ingest_broker_account_activities=ingest_broker_account_activities,
         )

--- a/services/torghut/tests/test_capital_controls.py
+++ b/services/torghut/tests/test_capital_controls.py
@@ -4,7 +4,7 @@ from datetime import datetime, time, timezone
 from decimal import Decimal
 from types import SimpleNamespace
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 from zoneinfo import ZoneInfo
 
 from app.config import settings
@@ -113,6 +113,10 @@ class TestCapitalSafetyController(TestCase):
             patch.object(settings, "tigerbeetle_reconcile_required", True),
             patch.object(controller, "_load_risk_snapshot", return_value=risk),
             patch(
+                "app.trading.scheduler.capital_controls.create_tigerbeetle_client",
+                return_value=Mock(),
+            ),
+            patch(
                 "app.trading.scheduler.capital_controls.check_tigerbeetle_health",
                 return_value=SimpleNamespace(enabled=True, ok=True),
             ),
@@ -147,6 +151,10 @@ class TestCapitalSafetyController(TestCase):
             patch.object(settings, "tigerbeetle_required", True),
             patch.object(settings, "tigerbeetle_reconcile_required", False),
             patch(
+                "app.trading.scheduler.capital_controls.create_tigerbeetle_client",
+                return_value=Mock(),
+            ),
+            patch(
                 "app.trading.scheduler.capital_controls.check_tigerbeetle_health",
                 return_value=SimpleNamespace(enabled=True, ok=True),
             ),
@@ -164,6 +172,53 @@ class TestCapitalSafetyController(TestCase):
 
         self.assertIsNone(reason)
         self.assertEqual(controller.state.capital_ledger_state, "current")
+
+    def test_protocol_checks_reuse_one_client_until_controller_close(self) -> None:
+        controller = self._controller()
+        client = SimpleNamespace(nop=Mock(), close=Mock())
+        now = datetime(2026, 7, 10, 15, 0, tzinfo=ZoneInfo("America/New_York"))
+
+        with (
+            patch.object(settings, "tigerbeetle_enabled", True),
+            patch.object(settings, "tigerbeetle_required", True),
+            patch.object(settings, "tigerbeetle_reconcile_required", False),
+            patch(
+                "app.trading.scheduler.capital_controls.create_tigerbeetle_client",
+                return_value=client,
+            ) as create_client,
+        ):
+            self.assertIsNone(
+                controller._ledger_stop_reason(SimpleNamespace(), now=now)
+            )
+            controller._ledger_checked_at_monotonic = None
+            self.assertIsNone(
+                controller._ledger_stop_reason(SimpleNamespace(), now=now)
+            )
+            controller.close()
+            controller.close()
+
+        create_client.assert_called_once_with(settings)
+        self.assertEqual(client.nop.call_count, 2)
+        client.close.assert_called_once_with()
+
+    def test_required_disabled_protocol_fails_closed_without_creating_client(
+        self,
+    ) -> None:
+        controller = self._controller()
+        now = datetime(2026, 7, 10, 15, 0, tzinfo=ZoneInfo("America/New_York"))
+
+        with (
+            patch.object(settings, "tigerbeetle_enabled", False),
+            patch.object(settings, "tigerbeetle_required", True),
+            patch.object(settings, "tigerbeetle_reconcile_required", False),
+            patch(
+                "app.trading.scheduler.capital_controls.create_tigerbeetle_client"
+            ) as create_client,
+        ):
+            reason = controller._ledger_stop_reason(SimpleNamespace(), now=now)
+
+        self.assertEqual(reason, "tigerbeetle_protocol_unavailable")
+        create_client.assert_not_called()
 
     def test_required_protocol_failure_latches_stop_without_reconciliation(
         self,
@@ -184,6 +239,10 @@ class TestCapitalSafetyController(TestCase):
             patch.object(settings, "tigerbeetle_required", True),
             patch.object(settings, "tigerbeetle_reconcile_required", False),
             patch.object(controller, "_load_risk_snapshot", return_value=risk),
+            patch(
+                "app.trading.scheduler.capital_controls.create_tigerbeetle_client",
+                return_value=Mock(),
+            ),
             patch(
                 "app.trading.scheduler.capital_controls.check_tigerbeetle_health",
                 return_value=SimpleNamespace(enabled=True, ok=False),
@@ -212,6 +271,10 @@ class TestCapitalSafetyController(TestCase):
         with (
             patch.object(settings, "tigerbeetle_required", True),
             patch.object(settings, "tigerbeetle_reconcile_required", False),
+            patch(
+                "app.trading.scheduler.capital_controls.create_tigerbeetle_client",
+                return_value=Mock(),
+            ),
             patch(
                 "app.trading.scheduler.capital_controls.check_tigerbeetle_health",
                 side_effect=ModuleNotFoundError("tigerbeetle package unavailable"),

--- a/services/torghut/tests/test_scheduler_market_context_status.py
+++ b/services/torghut/tests/test_scheduler_market_context_status.py
@@ -54,6 +54,7 @@ class _PipelineWithLlmReview:
 class _PipelineLabelStub:
     account_label = "live"
     order_feed_ingestor = SimpleNamespace(close=Mock())
+    capital_safety = SimpleNamespace(close=Mock())
 
 
 class TestTradingSchedulerMarketContextStatus(TestCase):

--- a/services/torghut/tests/test_tigerbeetle_client.py
+++ b/services/torghut/tests/test_tigerbeetle_client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import socket
 import sys
-import time
+import threading
 from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import patch
@@ -180,66 +180,32 @@ class TestTigerBeetleClient(TestCase):
             )
         self.assertIsInstance(raised.exception.__cause__, RuntimeError)
 
-    def test_real_client_times_out_blocked_account_rpc(self) -> None:
-        class _BlockingSync:
-            def __init__(self, *, cluster_id: int, replica_addresses: str) -> None:
-                del cluster_id, replica_addresses
+    def test_real_client_timeout_cancels_worker_and_closes_client(self) -> None:
+        instances: list[object] = []
+        worker_finished = threading.Event()
 
-            def create_accounts(self, accounts: list[object]) -> list[object]:
-                del accounts
-                time.sleep(0.2)
-                return []
-
-        fake_module = SimpleNamespace(
-            ClientSync=_BlockingSync,
-            Account=_TigerBeetleEvent,
-            Transfer=_TigerBeetleEvent,
-        )
-        with (
-            patch.dict(sys.modules, {"tigerbeetle": fake_module}),
-            patch(
-                "app.trading.tigerbeetle_client.socket.getaddrinfo",
-                return_value=[
-                    (
-                        socket.AF_INET,
-                        socket.SOCK_STREAM,
-                        6,
-                        "",
-                        ("10.99.251.1", 3000),
-                    )
-                ],
-            ),
-        ):
-            client = RealTigerBeetleClient(
-                cluster_id=2001,
-                replica_addresses=[
-                    "torghut-tigerbeetle.torghut.svc.cluster.local:3000"
-                ],
-                rpc_timeout_seconds=0.01,
-            )
-            account = TigerBeetleAccountSpec(
-                account_id=11,
-                account_key="cash:paper:usd",
-                ledger=LEDGER_USD_MICRO,
-                code=1001,
-                account_label="paper",
-            )
-
-            with self.assertRaisesRegex(
-                TigerBeetleClientTimeoutError,
-                "tigerbeetle_create_accounts_timeout",
-            ):
-                client.create_accounts([account])
-
-    def test_real_client_times_out_blocked_health_lookup(self) -> None:
         class _BlockingHealthSync:
             def __init__(self, *, cluster_id: int, replica_addresses: str) -> None:
                 del cluster_id, replica_addresses
+                self.release = threading.Event()
+                self.closed = False
+                self.lookup_calls = 0
+                self.close_calls = 0
+                instances.append(self)
 
             def lookup_accounts(self, ids: list[int]) -> list[object]:
                 del ids
-                time.sleep(0.2)
+                self.lookup_calls += 1
+                self.release.wait(timeout=1.0)
+                worker_finished.set()
+                if self.closed:
+                    raise RuntimeError("client closed")
                 return []
+
+            def close(self) -> None:
+                self.close_calls += 1
+                self.closed = True
+                self.release.set()
 
         fake_module = SimpleNamespace(
             ClientSync=_BlockingHealthSync,
@@ -275,43 +241,18 @@ class TestTigerBeetleClient(TestCase):
             ):
                 client.nop()
 
-    def test_real_client_times_out_blocked_connect(self) -> None:
-        class _BlockingConnectSync:
-            def __init__(self, *, cluster_id: int, replica_addresses: str) -> None:
-                del cluster_id, replica_addresses
-                time.sleep(0.2)
-
-        fake_module = SimpleNamespace(
-            ClientSync=_BlockingConnectSync,
-            Account=_TigerBeetleEvent,
-            Transfer=_TigerBeetleEvent,
-        )
-        with (
-            patch.dict(sys.modules, {"tigerbeetle": fake_module}),
-            patch(
-                "app.trading.tigerbeetle_client.socket.getaddrinfo",
-                return_value=[
-                    (
-                        socket.AF_INET,
-                        socket.SOCK_STREAM,
-                        6,
-                        "",
-                        ("10.99.251.1", 3000),
-                    )
-                ],
-            ),
-        ):
+            sync = instances[0]
+            self.assertTrue(worker_finished.is_set())
+            self.assertTrue(sync.closed)
+            self.assertEqual(sync.close_calls, 1)
             with self.assertRaisesRegex(
-                TigerBeetleClientTimeoutError,
-                "tigerbeetle_connect_timeout",
+                TigerBeetleClientError,
+                "tigerbeetle_client_closed",
             ):
-                RealTigerBeetleClient(
-                    cluster_id=2001,
-                    replica_addresses=[
-                        "torghut-tigerbeetle.torghut.svc.cluster.local:3000"
-                    ],
-                    rpc_timeout_seconds=0.01,
-                )
+                client.nop()
+            client.close()
+            self.assertEqual(sync.lookup_calls, 1)
+            self.assertEqual(sync.close_calls, 1)
 
     def test_real_client_converts_domain_specs_to_official_events(self) -> None:
         instances: list[object] = []
@@ -407,19 +348,3 @@ class TestTigerBeetleClient(TestCase):
         self.assertEqual(sync.created_transfers[0].id, 22)
         self.assertEqual(sync.lookup_account_requests[-1], [HEALTH_PROBE_ACCOUNT_ID])
         self.assertTrue(sync.closed)
-
-    def test_real_client_close_uses_exit_when_close_missing(self) -> None:
-        class _ExitOnly:
-            def __init__(self) -> None:
-                self.exited = False
-
-            def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
-                self.exited = True
-
-        client: RealTigerBeetleClient = object.__new__(RealTigerBeetleClient)
-        owned = _ExitOnly()
-        client._client = owned
-
-        client.close()
-
-        self.assertTrue(owned.exited)


### PR DESCRIPTION
## Summary

- cancel an in-flight official TigerBeetle request when the Torghut RPC deadline expires
- reuse one TigerBeetle protocol client per capital-safety controller instead of reconnecting every 30 seconds
- close the reused client during scheduler shutdown while preserving fail-closed capital behavior

## Related Issues

PROOMPT-393 (runtime prerequisite for natural publication validation)

## Testing

- `uv run --frozen ruff check app/trading/tigerbeetle_client.py app/trading/scheduler/capital_controls.py app/trading/scheduler/runtime.py tests/test_tigerbeetle_client.py tests/test_capital_controls.py tests/scheduler/test_runtime_leadership.py`
- `.venv/bin/python -m pytest -q tests/test_tigerbeetle_client.py tests/test_capital_controls.py tests/scheduler/test_runtime_leadership.py tests/tigerbeetle_journal tests/tigerbeetle_reconcile tests/economic_ledger/test_tigerbeetle_parity.py tests/test_tigerbeetle_status.py tests/test_tigerbeetle_runtime_ledger_parity.py` (166 passed)
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed because this is a backend runtime fix.
- [x] Breaking Changes section is filled in.
- [x] Documentation and follow-up impact are tracked in PROOMPT-393.