### PR TITLE
chore(torghut): promote image sha-b9b3f9aaed7508518ba63a889e3492a4729ed361

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -24,7 +24,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: migrate
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9f044c8bdde23d537b2ea26427396f9da84e29cbca9cb9a8df9903345366e0aa
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e6448c4c476344eea647f4926872169c25adaa011a5d69c60dfc017cff8d05d9
           imagePullPolicy: Always
           workingDir: /app
           command:
@@ -54,9 +54,9 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: b9918c79b3a30dd69b41835b64982ce4eafa1a8c
+              value: b9b3f9aaed7508518ba63a889e3492a4729ed361
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:9f044c8bdde23d537b2ea26427396f9da84e29cbca9cb9a8df9903345366e0aa
+              value: sha256:e6448c4c476344eea647f4926872169c25adaa011a5d69c60dfc017cff8d05d9
             - name: PYTHONPATH
               value: /app
             - name: DB_DSN

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-hyperliquid-runtime
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9f044c8bdde23d537b2ea26427396f9da84e29cbca9cb9a8df9903345366e0aa
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e6448c4c476344eea647f4926872169c25adaa011a5d69c60dfc017cff8d05d9
           imagePullPolicy: Always
           command:
             - uvicorn
@@ -46,9 +46,9 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: b9918c79b3a30dd69b41835b64982ce4eafa1a8c
+              value: b9b3f9aaed7508518ba63a889e3492a4729ed361
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:9f044c8bdde23d537b2ea26427396f9da84e29cbca9cb9a8df9903345366e0aa
+              value: sha256:e6448c4c476344eea647f4926872169c25adaa011a5d69c60dfc017cff8d05d9
             - name: DB_DSN
               valueFrom:
                 secretKeyRef:

--- a/argocd/applications/torghut-options/archive/deployment.yaml
+++ b/argocd/applications/torghut-options/archive/deployment.yaml
@@ -35,7 +35,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: await-options-schema
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9f044c8bdde23d537b2ea26427396f9da84e29cbca9cb9a8df9903345366e0aa
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e6448c4c476344eea647f4926872169c25adaa011a5d69c60dfc017cff8d05d9
           imagePullPolicy: IfNotPresent
           command:
             - python
@@ -64,7 +64,7 @@ spec:
                 - ALL
       containers:
         - name: torghut-options-archive
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9f044c8bdde23d537b2ea26427396f9da84e29cbca9cb9a8df9903345366e0aa
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e6448c4c476344eea647f4926872169c25adaa011a5d69c60dfc017cff8d05d9
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -100,9 +100,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2359-gb9918c79b
+              value: v0.596.0-2411-gb9b3f9aae
             - name: TORGHUT_OPTIONS_COMMIT
-              value: b9918c79b3a30dd69b41835b64982ce4eafa1a8c
+              value: b9b3f9aaed7508518ba63a889e3492a4729ed361
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -33,7 +33,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: await-options-schema
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9f044c8bdde23d537b2ea26427396f9da84e29cbca9cb9a8df9903345366e0aa
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e6448c4c476344eea647f4926872169c25adaa011a5d69c60dfc017cff8d05d9
           imagePullPolicy: IfNotPresent
           command:
             - python
@@ -62,7 +62,7 @@ spec:
                 - ALL
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9f044c8bdde23d537b2ea26427396f9da84e29cbca9cb9a8df9903345366e0aa
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e6448c4c476344eea647f4926872169c25adaa011a5d69c60dfc017cff8d05d9
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -110,9 +110,9 @@ spec:
                   name: torghut-ws-config
                   key: SYMBOLS_ALLOWLIST
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2359-gb9918c79b
+              value: v0.596.0-2411-gb9b3f9aae
             - name: TORGHUT_OPTIONS_COMMIT
-              value: b9918c79b3a30dd69b41835b64982ce4eafa1a8c
+              value: b9b3f9aaed7508518ba63a889e3492a4729ed361
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: await-options-schema
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9f044c8bdde23d537b2ea26427396f9da84e29cbca9cb9a8df9903345366e0aa
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e6448c4c476344eea647f4926872169c25adaa011a5d69c60dfc017cff8d05d9
           imagePullPolicy: IfNotPresent
           command:
             - python
@@ -63,7 +63,7 @@ spec:
                 - ALL
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9f044c8bdde23d537b2ea26427396f9da84e29cbca9cb9a8df9903345366e0aa
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e6448c4c476344eea647f4926872169c25adaa011a5d69c60dfc017cff8d05d9
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -106,9 +106,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2359-gb9918c79b
+              value: v0.596.0-2411-gb9b3f9aae
             - name: TORGHUT_OPTIONS_COMMIT
-              value: b9918c79b3a30dd69b41835b64982ce4eafa1a8c
+              value: b9b3f9aaed7508518ba63a889e3492a4729ed361
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:9f044c8bdde23d537b2ea26427396f9da84e29cbca9cb9a8df9903345366e0aa
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e6448c4c476344eea647f4926872169c25adaa011a5d69c60dfc017cff8d05d9
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:9f044c8bdde23d537b2ea26427396f9da84e29cbca9cb9a8df9903345366e0aa
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e6448c4c476344eea647f4926872169c25adaa011a5d69c60dfc017cff8d05d9
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:9f044c8bdde23d537b2ea26427396f9da84e29cbca9cb9a8df9903345366e0aa
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e6448c4c476344eea647f4926872169c25adaa011a5d69c60dfc017cff8d05d9
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:9f044c8bdde23d537b2ea26427396f9da84e29cbca9cb9a8df9903345366e0aa
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e6448c4c476344eea647f4926872169c25adaa011a5d69c60dfc017cff8d05d9
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/broker-economic-ledger-reconciliation-cronjob.yaml
+++ b/argocd/applications/torghut/broker-economic-ledger-reconciliation-cronjob.yaml
@@ -36,7 +36,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: reconcile
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:9f044c8bdde23d537b2ea26427396f9da84e29cbca9cb9a8df9903345366e0aa
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:e6448c4c476344eea647f4926872169c25adaa011a5d69c60dfc017cff8d05d9
               imagePullPolicy: IfNotPresent
               securityContext:
                 seccompProfile:
@@ -92,11 +92,11 @@ spec:
                 - name: TRADING_ACCOUNT_LABEL
                   value: PA3SX7FYNUTF
                 - name: TORGHUT_VERSION
-                  value: v0.596.0-2359-gb9918c79b
+                  value: v0.596.0-2411-gb9b3f9aae
                 - name: TORGHUT_COMMIT
-                  value: b9918c79b3a30dd69b41835b64982ce4eafa1a8c
+                  value: b9b3f9aaed7508518ba63a889e3492a4729ed361
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:9f044c8bdde23d537b2ea26427396f9da84e29cbca9cb9a8df9903345366e0aa
+                  value: sha256:e6448c4c476344eea647f4926872169c25adaa011a5d69c60dfc017cff8d05d9
                 - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
                   value: linux/amd64,linux/arm64
                 - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9f044c8bdde23d537b2ea26427396f9da84e29cbca9cb9a8df9903345366e0aa
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e6448c4c476344eea647f4926872169c25adaa011a5d69c60dfc017cff8d05d9
           workingDir: /app
           command:
             - /bin/sh

--- a/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
+++ b/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-generated-resource-retention
           containers:
             - name: prune-generated-residue
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:9f044c8bdde23d537b2ea26427396f9da84e29cbca9cb9a8df9903345366e0aa
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:e6448c4c476344eea647f4926872169c25adaa011a5d69c60dfc017cff8d05d9
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:9f044c8bdde23d537b2ea26427396f9da84e29cbca9cb9a8df9903345366e0aa
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:e6448c4c476344eea647f4926872169c25adaa011a5d69c60dfc017cff8d05d9
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-21T06:18:19Z"
+        client.knative.dev/updateTimestamp: "2026-07-21T18:43:27Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -34,7 +34,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9f044c8bdde23d537b2ea26427396f9da84e29cbca9cb9a8df9903345366e0aa
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e6448c4c476344eea647f4926872169c25adaa011a5d69c60dfc017cff8d05d9
           ports:
             - name: http1
               containerPort: 8181
@@ -528,11 +528,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2359-gb9918c79b
+              value: v0.596.0-2411-gb9b3f9aae
             - name: TORGHUT_COMMIT
-              value: b9918c79b3a30dd69b41835b64982ce4eafa1a8c
+              value: b9b3f9aaed7508518ba63a889e3492a4729ed361
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:9f044c8bdde23d537b2ea26427396f9da84e29cbca9cb9a8df9903345366e0aa
+              value: sha256:e6448c4c476344eea647f4926872169c25adaa011a5d69c60dfc017cff8d05d9
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-21T06:18:19Z"
+        client.knative.dev/updateTimestamp: "2026-07-21T18:43:27Z"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
     spec:
@@ -30,7 +30,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9f044c8bdde23d537b2ea26427396f9da84e29cbca9cb9a8df9903345366e0aa
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e6448c4c476344eea647f4926872169c25adaa011a5d69c60dfc017cff8d05d9
           ports:
             - name: http1
               containerPort: 8181
@@ -453,11 +453,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2359-gb9918c79b
+              value: v0.596.0-2411-gb9b3f9aae
             - name: TORGHUT_COMMIT
-              value: b9918c79b3a30dd69b41835b64982ce4eafa1a8c
+              value: b9b3f9aaed7508518ba63a889e3492a4729ed361
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:9f044c8bdde23d537b2ea26427396f9da84e29cbca9cb9a8df9903345366e0aa
+              value: sha256:e6448c4c476344eea647f4926872169c25adaa011a5d69c60dfc017cff8d05d9
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/order-lineage-reconciliation-cronjob.yaml
+++ b/argocd/applications/torghut/order-lineage-reconciliation-cronjob.yaml
@@ -39,7 +39,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: reconcile
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:9f044c8bdde23d537b2ea26427396f9da84e29cbca9cb9a8df9903345366e0aa
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:e6448c4c476344eea647f4926872169c25adaa011a5d69c60dfc017cff8d05d9
               imagePullPolicy: IfNotPresent
               securityContext:
                 allowPrivilegeEscalation: false
@@ -88,11 +88,11 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_VERSION
-                  value: v0.596.0-2359-gb9918c79b
+                  value: v0.596.0-2411-gb9b3f9aae
                 - name: TORGHUT_COMMIT
-                  value: b9918c79b3a30dd69b41835b64982ce4eafa1a8c
+                  value: b9b3f9aaed7508518ba63a889e3492a4729ed361
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:9f044c8bdde23d537b2ea26427396f9da84e29cbca9cb9a8df9903345366e0aa
+                  value: sha256:e6448c4c476344eea647f4926872169c25adaa011a5d69c60dfc017cff8d05d9
                 - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
                   value: linux/amd64,linux/arm64
                 - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -37,7 +37,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9f044c8bdde23d537b2ea26427396f9da84e29cbca9cb9a8df9903345366e0aa
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e6448c4c476344eea647f4926872169c25adaa011a5d69c60dfc017cff8d05d9
           command:
             - uvicorn
           args:
@@ -470,11 +470,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2359-gb9918c79b
+              value: v0.596.0-2411-gb9b3f9aae
             - name: TORGHUT_COMMIT
-              value: b9918c79b3a30dd69b41835b64982ce4eafa1a8c
+              value: b9b3f9aaed7508518ba63a889e3492a4729ed361
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:9f044c8bdde23d537b2ea26427396f9da84e29cbca9cb9a8df9903345366e0aa
+              value: sha256:e6448c4c476344eea647f4926872169c25adaa011a5d69c60dfc017cff8d05d9
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: smoke
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9f044c8bdde23d537b2ea26427396f9da84e29cbca9cb9a8df9903345366e0aa
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e6448c4c476344eea647f4926872169c25adaa011a5d69c60dfc017cff8d05d9
           imagePullPolicy: IfNotPresent
           securityContext:
             seccompProfile:


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `b9b3f9aaed7508518ba63a889e3492a4729ed361`
- Image tag: `sha-b9b3f9aaed7508518ba63a889e3492a4729ed361`
- Image digest: `sha256:e6448c4c476344eea647f4926872169c25adaa011a5d69c60dfc017cff8d05d9`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher