### PR TITLE
fix(hermes): preserve tools volume permissions

### DIFF
--- a/argocd/applications/hermes/bootstrap-github.sh
+++ b/argocd/applications/hermes/bootstrap-github.sh
@@ -39,7 +39,15 @@ cleanup() {
 }
 trap cleanup EXIT HUP INT TERM
 
-install -d -m 0700 "$gh_cache_dir" "$(dirname "$gh_install_path")" "$(dirname "$git_config_path")"
+gh_install_dir=$(dirname "$gh_install_path")
+install -d -m 0700 "$gh_cache_dir" "$(dirname "$git_config_path")"
+if [ ! -d "$gh_install_dir" ]; then
+  install -d -m 0700 "$gh_install_dir"
+fi
+if [ ! -w "$gh_install_dir" ]; then
+  echo "GitHub CLI install directory is not writable: $gh_install_dir" >&2
+  exit 1
+fi
 
 archive_is_valid() {
   [ -f "$archive_path" ] && printf '%s  %s\n' "$gh_archive_sha256" "$archive_path" | sha256sum -c - >/dev/null 2>&1

--- a/scripts/hermes/bootstrap-github.test.ts
+++ b/scripts/hermes/bootstrap-github.test.ts
@@ -55,6 +55,7 @@ test('installs a verified GitHub CLI archive and recreates deterministic Git con
   ])
   await writeFile(fakeGh, `#!/bin/sh\nprintf 'gh version ${version} (test)\\n'\n`)
   await chmod(fakeGh, 0o755)
+  await chmod(tools, 0o775)
   await run(['tar', '-czf', archive, '-C', sourceRoot, archiveRootName])
 
   const checksum = createHash('sha256')
@@ -79,6 +80,7 @@ test('installs a verified GitHub CLI archive and recreates deterministic Git con
     `github_bootstrap_ready=true gh_version=${version} git_user=tuslagch`,
   )
   expect((await stat(installedGh)).mode & 0o777).toBe(0o555)
+  expect((await stat(tools)).mode & 0o777).toBe(0o775)
   expect(await run([installedGh, '--version'])).toContain(`gh version ${version}`)
   expect(await run(['git', 'config', '--file', gitConfig, 'user.name'])).toBe('tuslagch\n')
   expect(await run(['git', 'config', '--file', gitConfig, 'user.email'])).toBe(

--- a/scripts/hermes/validate-production.ts
+++ b/scripts/hermes/validate-production.ts
@@ -507,6 +507,8 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'printf \'%s  %s\\n\' "$gh_archive_sha256" "$archive_tmp" | sha256sum -c -',
     'member_name = f"gh_{version}_linux_amd64/bin/gh"',
     'install -m 0555 "$extract_dir/gh" "$gh_install_path"',
+    'if [ ! -d "$gh_install_dir" ]; then',
+    'if [ ! -w "$gh_install_dir" ]; then',
     'git config --file "$git_config_tmp" user.name tuslagch',
     'git config --file "$git_config_tmp" user.email 241203724+tuslagch@users.noreply.github.com',
     'git config --file "$git_config_tmp" commit.gpgsign false',


### PR DESCRIPTION
## Summary

- preserve the Kubernetes-managed `/opt/tools` mount permissions during GitHub CLI bootstrap
- fail clearly when the mounted install directory is not writable
- add regression coverage for the production `0775` emptyDir mount mode

## Related Issues

None

## Testing

- `bun test scripts/hermes/bootstrap-github.test.ts scripts/hermes/validate-production.test.ts`
- `bun run scripts/hermes/validate-production.ts`
- `shellcheck argocd/applications/hermes/bootstrap-github.sh`
- `bunx oxfmt --check scripts/hermes/bootstrap-github.test.ts scripts/hermes/validate-production.ts`
- focused server-side Kubernetes dry-run for the Hermes overlay

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section is not applicable and was removed.
- [x] Breaking Changes is filled in.
- [x] Documentation, release notes, and follow-ups are updated or tracked.