### PR TITLE
feat(bayn): add dedicated TigerBeetle restore foundation

### DIFF
--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -12,6 +12,8 @@ resources:
   - postgres-restore-proof-networkpolicy.yaml
   - postgres-m1-restore-proof.yaml
   - postgres-m1-restore-proof-networkpolicy.yaml
+  - tigerbeetle-cluster.yaml
+  - tigerbeetle-networkpolicy.yaml
   - deployment.yaml
   - service.yaml
   - networkpolicy.yaml

--- a/argocd/applications/bayn/networkpolicy.yaml
+++ b/argocd/applications/bayn/networkpolicy.yaml
@@ -54,6 +54,13 @@ spec:
     - to:
         - podSelector:
             matchLabels:
+              app.kubernetes.io/instance: bayn-tigerbeetle
+      ports:
+        - port: 3000
+          protocol: TCP
+    - to:
+        - podSelector:
+            matchLabels:
               cnpg.io/cluster: bayn-db
       ports:
         - port: 5432

--- a/argocd/applications/bayn/tigerbeetle-cluster.yaml
+++ b/argocd/applications/bayn/tigerbeetle-cluster.yaml
@@ -1,0 +1,36 @@
+apiVersion: tigerbeetle.proompteng.ai/v1alpha1
+kind: TigerBeetleCluster
+metadata:
+  name: bayn-tigerbeetle
+  labels:
+    app.kubernetes.io/name: bayn-tigerbeetle
+    app.kubernetes.io/part-of: bayn
+spec:
+  clusterID: "222397790944575595450310052784555675227"
+  replicas: 3
+  image:
+    repository: ghcr.io/tigerbeetle/tigerbeetle
+    tag: "0.17.9@sha256:48f623f9c1e9b6cc44d77ca93634595ae99cce3246ded418763eb1a62eee45e9"
+    pullPolicy: IfNotPresent
+  storage:
+    className: rook-ceph-block
+    size: 100Gi
+  resources:
+    requests:
+      cpu: "2"
+      memory: 8Gi
+    limits:
+      memory: 8Gi
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/instance: bayn-tigerbeetle
+          topologyKey: kubernetes.io/hostname
+  pdb:
+    enabled: true
+    minAvailable: 2
+  health:
+    checkIntervalSeconds: 5
+  deletionPolicy: Retain

--- a/argocd/applications/bayn/tigerbeetle-networkpolicy.yaml
+++ b/argocd/applications/bayn/tigerbeetle-networkpolicy.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: bayn-tigerbeetle
+  labels:
+    app.kubernetes.io/name: bayn-tigerbeetle
+    app.kubernetes.io/part-of: bayn
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: bayn-tigerbeetle
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: bayn
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: bayn-tigerbeetle
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: tigresse-system
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: tigresse
+      ports:
+        - port: 3000
+          protocol: TCP

--- a/nix/images/bayn.nix
+++ b/nix/images/bayn.nix
@@ -31,7 +31,7 @@ import ./bun-workspace-service.nix {
   buildCommands = [
     "bun --cwd=services/bayn run tsc"
     (
-      "bun --cwd=services/bayn build src/index.ts --target=node "
+      "bun --cwd=services/bayn build src/index.ts src/restore-ledger-command.ts --target=node "
       + "--external tigerbeetle-node --outdir=dist "
       + buildDefine "__BAYN_BUILD_SOURCE_REVISION__" repoRevision
       + " "
@@ -41,10 +41,12 @@ import ./bun-workspace-service.nix {
     )
     "grep -F -- ${lib.escapeShellArg repoRevision} services/bayn/dist/index.js"
     "grep -F -- ${lib.escapeShellArg strategyBehaviorHash} services/bayn/dist/index.js"
+    "grep -F -- ${lib.escapeShellArg repoRevision} services/bayn/dist/restore-ledger-command.js"
+    "grep -F -- ${lib.escapeShellArg imageRepository} services/bayn/dist/restore-ledger-command.js"
   ];
   runtimeInstallPhase = ''
     mkdir -p "$out/app/services/bayn/dist" "$out/app/services/bayn/node_modules/tigerbeetle-node"
-    cp "$TMPDIR/work/services/bayn/dist/index.js" "$out/app/services/bayn/dist/index.js"
+    cp "$TMPDIR/work/services/bayn/dist/"*.js "$out/app/services/bayn/dist/"
     cp "$TMPDIR/work/services/bayn/package.json" "$out/app/services/bayn/package.json"
     cp -R -L "$TMPDIR/work/services/bayn/node_modules/tigerbeetle-node/." \
       "$out/app/services/bayn/node_modules/tigerbeetle-node/"

--- a/nix/images/bayn.nix
+++ b/nix/images/bayn.nix
@@ -19,8 +19,8 @@ import ./bun-workspace-service.nix {
   serviceName = "bayn";
   packageName = "@proompteng/bayn";
   depsHash = {
-    x86_64-linux = "sha256-HOivxpn3uqVZlCG3XM/zeh9sg7yNXUzh1nHcLpNsBmA=";
-    aarch64-linux = "sha256-d5QZaVMgc+DgKfwaoiXKulU/iBV8VVBbhEQWdXd6dzk=";
+    x86_64-linux = "sha256-hy7Ahylm6c2lJCvVT9TofRe377xOcLSsRatg+jXFxZ8=";
+    aarch64-linux = "sha256-lWIf2A69EbXcfg8o7ejS7LPhA0Gv+m3UF8Yq5Ham/Zc=";
   };
   installFilters = [
     "@proompteng/bayn"

--- a/services/bayn/package.json
+++ b/services/bayn/package.json
@@ -5,9 +5,10 @@
   "type": "module",
   "scripts": {
     "audit:qualification": "bun src/qualification-audit-command.ts",
-    "build": "bun build src/index.ts --target=node --external tigerbeetle-node --outdir=dist",
+    "build": "bun build src/index.ts src/restore-ledger-command.ts --target=node --external tigerbeetle-node --outdir=dist",
     "dev": "BAYN_PROVENANCE_MODE=development bun --watch src/index.ts",
     "start": "BAYN_PROVENANCE_MODE=development node dist/index.js",
+    "restore:ledger": "node dist/restore-ledger-command.js",
     "lint": "bunx oxfmt --check src",
     "lint:oxlint": "oxlint --config ../../.oxlintrc.json .",
     "lint:oxlint:type": "oxlint --config ../../.oxlintrc.json --type-aware --tsconfig ./tsconfig.json .",

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -71,6 +71,13 @@ const makeEvidenceRuntime = (config = makeConfig()) =>
 const makeClientRuntime = (config = makeConfig()) =>
   ManagedRuntime.make(PostgresClientLive(config).pipe(Layer.provide(NodeServices.layer)))
 
+const makeReadOnlyClientRuntime = (config = makeConfig()) =>
+  ManagedRuntime.make(
+    PostgresClientLive(config, { applicationName: 'bayn-ledger-restore-test', readOnly: true }).pipe(
+      Layer.provide(NodeServices.layer),
+    ),
+  )
+
 const snapshot = makeSnapshot(800)
 const riskBalancedTrendSnapshot = makeRiskBalancedTrendSnapshot(800)
 
@@ -285,6 +292,26 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     expect(observed.mode).toEqual({ isolation: 'repeatable read', read_only: true })
     expect(Exit.isFailure(observed.write)).toBe(true)
     expect(observed.rows).toEqual([{ count: 0 }])
+  })
+
+  test('enforces read-only PostgreSQL sessions for ledger restore', async () => {
+    const scoped = makeReadOnlyClientRuntime()
+    try {
+      const observed = await scoped.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* PgClient.PgClient
+          const mode = yield* sql<{ read_only: boolean }>`
+            SELECT current_setting('default_transaction_read_only') = 'on' AS read_only
+          `
+          const write = yield* Effect.exit(sql`CREATE TEMP TABLE ledger_restore_write_probe (id integer)`)
+          return { mode: mode[0], write }
+        }),
+      )
+      expect(observed.mode).toEqual({ read_only: true })
+      expect(Exit.isFailure(observed.write)).toBe(true)
+    } finally {
+      await scoped.dispose()
+    }
   })
 
   test('commits one complete run and deduplicates an exact replay', async () => {

--- a/services/bayn/src/db/evidence-store.ts
+++ b/services/bayn/src/db/evidence-store.ts
@@ -1,5 +1,5 @@
 import { PgClient, PgMigrator } from '@effect/sql-pg'
-import { Context, Data, Effect, FileSystem, Layer, Match, Option, Schema } from 'effect'
+import { Context, Data, Effect, FileSystem, Layer, Match, Option, Redacted, Schema } from 'effect'
 import { SqlSchema } from 'effect/unstable/sql'
 import { isSqlError, type SqlErrorReason } from 'effect/unstable/sql/SqlError'
 
@@ -2040,23 +2040,56 @@ const makeEvidenceStore = Effect.gen(function* () {
   } satisfies EvidenceStoreService
 })
 
-export const PostgresClientLive = (config: RuntimeConfig) => {
+export interface PostgresClientOptions {
+  readonly applicationName?: string
+  readonly readOnly?: boolean
+}
+
+const connectionUrl = (
+  url: Redacted.Redacted<string>,
+  readOnly: boolean,
+): Effect.Effect<Redacted.Redacted<string>, DatabaseError> => {
+  if (!readOnly) return Effect.succeed(url)
+  return Effect.try({
+    try: () => {
+      const parsed = new URL(Redacted.value(url))
+      const existing = parsed.searchParams.get('options')?.trim()
+      parsed.searchParams.set(
+        'options',
+        [existing, '-c default_transaction_read_only=on']
+          .filter((value): value is string => value !== undefined && value.length > 0)
+          .join(' '),
+      )
+      return Redacted.make(parsed.toString())
+    },
+    catch: () => databaseError('unavailable', 'connect', 'invalid PostgreSQL connection URL'),
+  })
+}
+
+export const PostgresClientLive = (
+  config: Pick<RuntimeConfig, 'operationTimeoutMs' | 'postgres'>,
+  options: PostgresClientOptions = {},
+) => {
   const readCertificate = Effect.gen(function* () {
     if (!config.postgres.tls) return undefined
     const fileSystem = yield* FileSystem.FileSystem
     return yield* fileSystem.readFileString(config.postgres.caPath)
   })
   return Layer.unwrap(
-    readCertificate.pipe(
-      Effect.mapError((cause) =>
-        databaseError('unavailable', 'tls', 'failed to read PostgreSQL CA certificate', cause),
+    Effect.all({
+      ca: readCertificate.pipe(
+        Effect.mapError((cause) =>
+          databaseError('unavailable', 'tls', 'failed to read PostgreSQL CA certificate', cause),
+        ),
       ),
-      Effect.map((ca) =>
+      url: connectionUrl(config.postgres.url, options.readOnly === true),
+    }).pipe(
+      Effect.map(({ ca, url }) =>
         PgClient.layerFrom(
           PgClient.make({
-            url: config.postgres.url,
+            url,
             ssl: ca === undefined ? undefined : { ca, rejectUnauthorized: true },
-            applicationName: 'bayn',
+            applicationName: options.applicationName ?? 'bayn',
             connectTimeout: config.operationTimeoutMs,
             idleTimeout: '30 seconds',
             maxConnections: 2,
@@ -2158,4 +2191,14 @@ const recoverEvidenceStoreLayer = <R>(layer: Layer.Layer<EvidenceStore, Database
 export const EvidenceStoreRuntimeLive = (config: RuntimeConfig) =>
   recoverEvidenceStoreLayer(
     EvidenceStoreDatabaseLayer(config, migrations, makeEvidenceStore).pipe(Layer.provide(PostgresClientLive(config))),
+  )
+
+export const EvidenceStoreReadOnlyLive = (config: Pick<RuntimeConfig, 'operationTimeoutMs' | 'postgres'>) =>
+  EvidenceStoreDatabaseLayer(config, Effect.void, makeEvidenceStore).pipe(
+    Layer.provideMerge(
+      PostgresClientLive(config, {
+        applicationName: 'bayn-ledger-restore',
+        readOnly: true,
+      }),
+    ),
   )

--- a/services/bayn/src/ledger-restore.test.ts
+++ b/services/bayn/src/ledger-restore.test.ts
@@ -1,0 +1,380 @@
+import { describe, expect, test } from 'bun:test'
+import { ConfigProvider, Effect, Fiber, Option, Redacted } from 'effect'
+import { TestClock } from 'effect/testing'
+
+import type { EmbeddedBuildMetadata } from './build'
+import { makeStrategyProtocolHash } from './contracts'
+import { EvidenceStore, type EvidenceStoreService, type StoredEvaluationEvidence } from './db/evidence-store'
+import { canonicalHashV1 } from './hash'
+import { buildLedgerPlan, Journal, type JournalService, type LedgerInput } from './ledger'
+import { loadRestoreConfig, restoreLedger, type RestoreConfig, type RestoreContract } from './ledger-restore'
+import { makeQualificationResult } from './qualification'
+import { evaluateTsmom, summarizeEvaluation } from './strategy'
+import { makeTsmomStrategy } from './strategy-service'
+import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
+
+const snapshot = makeSnapshot(800)
+const provenance = makeTestProvenance()
+const evaluation = evaluateTsmom(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance)
+const strategy = makeTsmomStrategy(fixtureProtocol, provenance)
+const sessionDates = [...new Set(snapshot.bars.map((bar) => bar.sessionDate))].sort()
+const lock = strategy.prepareLock(snapshot.manifest, sessionDates, [])
+const qualificationResult = makeQualificationResult(lock, evaluation.verdict, strategy.analyze(evaluation, []))
+const plan = buildLedgerPlan(evaluation, 7_001)
+const reconciliation = {
+  runId: evaluation.runId,
+  accountCount: plan.accounts.length,
+  transferCount: plan.transfers.length,
+  exact: true as const,
+}
+
+const stored: StoredEvaluationEvidence = {
+  protocol: {
+    protocolHash: makeStrategyProtocolHash(provenance.strategy),
+    schemaVersion: fixtureProtocol.schemaVersion,
+    strategyName: 'tsmom',
+    behaviorHash: provenance.strategy.behaviorHash,
+    parameterHash: provenance.strategy.parameterHash,
+    parameters: fixtureProtocol,
+  },
+  run: {
+    runId: evaluation.runId,
+    protocolHash: evaluation.protocolHash,
+    snapshotId: snapshot.manifest.finalizedSnapshot.snapshotId,
+    evaluationSchemaVersion: evaluation.schemaVersion,
+    sourceRevision: provenance.sourceRevision,
+    imageRepository: provenance.image.repository,
+    imageDigest: provenance.image.digest,
+    strategyName: 'tsmom',
+    initialCapitalMicros: evaluation.initialCapitalMicros,
+    artifactCount: 17,
+    eventCount: evaluation.events.length,
+    gateCount: evaluation.verdict.gates.length,
+  },
+  artifacts: [
+    {
+      name: 'input-manifest',
+      schemaVersion: snapshot.manifest.schemaVersion,
+      contentHash: canonicalHashV1(snapshot.manifest),
+      payload: snapshot.manifest,
+    },
+  ],
+  events: evaluation.events.map((event, ordinal) => ({
+    ordinal,
+    id: event.id,
+    kind: event.kind,
+    contentHash: canonicalHashV1(event),
+    payload: event,
+  })),
+  gates: [],
+  statuses: [
+    { status: 'WRITING', detail: {} },
+    { status: 'COMPLETE', detail: { reconciliationExact: true, verdict: evaluation.verdict.status } },
+  ],
+}
+
+const config: RestoreConfig = {
+  runId: evaluation.runId,
+  expectedAccountCount: reconciliation.accountCount,
+  expectedTransferCount: reconciliation.transferCount,
+  operationTimeoutMs: 1_000,
+  build: {
+    sourceRevision: 'd'.repeat(40),
+    imageRepository: 'registry.ide-newton.ts.net/lab/bayn',
+    imageDigest: `sha256:${'e'.repeat(64)}`,
+  },
+  postgres: {
+    url: Redacted.make('postgresql://bayn:secret@postgres.test:5432/bayn'),
+    tls: true,
+    caPath: '/var/run/secrets/bayn/postgres/ca.crt',
+  },
+  tigerBeetle: {
+    clusterId: 222397790944575595450310052784555675227n,
+    replicaAddresses: [
+      'bayn-tigerbeetle-0.bayn-tigerbeetle-headless.bayn.svc.cluster.local:3000',
+      'bayn-tigerbeetle-1.bayn-tigerbeetle-headless.bayn.svc.cluster.local:3000',
+      'bayn-tigerbeetle-2.bayn-tigerbeetle-headless.bayn.svc.cluster.local:3000',
+    ],
+    ledger: 7_001,
+  },
+}
+
+const restoreBuild: EmbeddedBuildMetadata = {
+  sourceRevision: config.build.sourceRevision,
+  imageRepository: config.build.imageRepository,
+  strategyBehaviorHash: 'f'.repeat(64),
+}
+const restoreContract: RestoreContract = {
+  runId: config.runId,
+  expectedAccountCount: config.expectedAccountCount,
+  expectedTransferCount: config.expectedTransferCount,
+  target: config.tigerBeetle,
+}
+const restoreEnvironment = new Map([
+  ['BAYN_LEDGER_RESTORE_RUN_ID', config.runId],
+  ['BAYN_LEDGER_RESTORE_EXPECTED_ACCOUNT_COUNT', String(config.expectedAccountCount)],
+  ['BAYN_LEDGER_RESTORE_EXPECTED_TRANSFER_COUNT', String(config.expectedTransferCount)],
+  ['BAYN_OPERATION_TIMEOUT_MS', String(config.operationTimeoutMs)],
+  ['BAYN_CODE_REVISION', config.build.sourceRevision],
+  ['BAYN_IMAGE_REPOSITORY', config.build.imageRepository],
+  ['BAYN_IMAGE_DIGEST', config.build.imageDigest],
+  ['BAYN_POSTGRES_URL', Redacted.value(config.postgres.url)],
+  ['BAYN_TIGERBEETLE_CLUSTER_ID', config.tigerBeetle.clusterId.toString()],
+  ['BAYN_TIGERBEETLE_ADDRESSES', config.tigerBeetle.replicaAddresses.join(',')],
+  ['BAYN_TIGERBEETLE_LEDGER', String(config.tigerBeetle.ledger)],
+])
+
+const provideEnvironment = <A, E>(effect: Effect.Effect<A, E>, environment: Map<string, string>) =>
+  effect.pipe(
+    Effect.provideService(ConfigProvider.ConfigProvider, ConfigProvider.fromUnknown(Object.fromEntries(environment))),
+  )
+
+const evidenceStore = (qualification = true): EvidenceStoreService => ({
+  check: Effect.void,
+  persist: () => Effect.die('restore must not persist'),
+  read: (runId) => Effect.succeed(runId === evaluation.runId ? Option.some(stored) : Option.none()),
+  readArtifactItems: () => Effect.die('restore must not page artifacts'),
+  recover: (runId, recoveredProvenance) => {
+    expect(runId).toBe(evaluation.runId)
+    expect(recoveredProvenance).toEqual(provenance)
+    return Effect.succeed(
+      Option.some({
+        evaluation: summarizeEvaluation(evaluation),
+        reconciliation,
+        persistence: {
+          runId: evaluation.runId,
+          deduplicated: true,
+          artifactCount: 17,
+          eventCount: evaluation.events.length,
+          gateCount: evaluation.verdict.gates.length,
+        },
+      }),
+    )
+  },
+  listPriorTrials: Effect.die('restore must not list trials'),
+  openQualification: () => Effect.die('restore must not open a qualification'),
+  readQualification: () =>
+    Effect.succeed(
+      qualification ? Option.some({ state: 'TERMINAL', lock, result: qualificationResult }) : Option.none(),
+    ),
+})
+
+const runRestore = (restoreConfig: RestoreConfig, store: EvidenceStoreService, journal: JournalService) =>
+  restoreLedger(restoreConfig).pipe(
+    Effect.provideService(EvidenceStore, store),
+    Effect.provideService(Journal, journal),
+  )
+
+describe('dedicated TigerBeetle restore', () => {
+  test('loads only the strict operator configuration', async () => {
+    const loaded = await Effect.runPromise(
+      provideEnvironment(loadRestoreConfig(restoreBuild, restoreContract), restoreEnvironment),
+    )
+
+    expect(loaded).toEqual(config)
+  })
+
+  test('requires embedded provenance, PostgreSQL TLS, and a non-zero u128 cluster ID', async () => {
+    const missingBuild = await Effect.runPromise(
+      Effect.flip(provideEnvironment(loadRestoreConfig(undefined, restoreContract), restoreEnvironment)),
+    )
+    expect(missingBuild).toMatchObject({ component: 'config', operation: 'load-ledger-restore' })
+
+    for (const [name, value] of [
+      ['BAYN_POSTGRES_TLS', 'false'],
+      ['BAYN_TIGERBEETLE_CLUSTER_ID', '0'],
+      ['BAYN_TIGERBEETLE_CLUSTER_ID', (1n << 128n).toString()],
+    ] as const) {
+      const invalid = new Map(restoreEnvironment)
+      invalid.set(name, value)
+      const error = await Effect.runPromise(
+        Effect.flip(provideEnvironment(loadRestoreConfig(restoreBuild, restoreContract), invalid)),
+      )
+      expect(error).toMatchObject({ component: 'config', operation: 'load-ledger-restore' })
+    }
+  })
+
+  test('rejects drift from the pinned run, counts, target cluster, replica order, or ledger', async () => {
+    for (const [name, value] of [
+      ['BAYN_LEDGER_RESTORE_RUN_ID', '1'.repeat(64)],
+      ['BAYN_LEDGER_RESTORE_EXPECTED_ACCOUNT_COUNT', String(config.expectedAccountCount + 1)],
+      ['BAYN_LEDGER_RESTORE_EXPECTED_TRANSFER_COUNT', String(config.expectedTransferCount + 1)],
+      ['BAYN_TIGERBEETLE_CLUSTER_ID', String(config.tigerBeetle.clusterId + 1n)],
+      ['BAYN_TIGERBEETLE_ADDRESSES', [...config.tigerBeetle.replicaAddresses].reverse().join(',')],
+      ['BAYN_TIGERBEETLE_LEDGER', String(config.tigerBeetle.ledger + 1)],
+    ] as const) {
+      const drifted = new Map(restoreEnvironment)
+      drifted.set(name, value)
+      const error = await Effect.runPromise(
+        Effect.flip(provideEnvironment(loadRestoreConfig(restoreBuild, restoreContract), drifted)),
+      )
+      expect(error.message).toContain('pinned one-shot contract')
+    }
+  })
+
+  test('restores one terminal run and emits a deterministic receipt', async () => {
+    const inputs: LedgerInput[] = []
+    const journal: JournalService = {
+      check: Effect.die('restore must not use a connectivity-only check'),
+      checkRun: () => Effect.die('restore must use exact create-and-verify'),
+      journalAndReconcile: (input) => {
+        inputs.push(input)
+        return Effect.succeed(reconciliation)
+      },
+    }
+
+    const first = await Effect.runPromise(runRestore(config, evidenceStore(), journal))
+    const second = await Effect.runPromise(runRestore(config, evidenceStore(), journal))
+
+    expect(inputs).toEqual([
+      {
+        runId: evaluation.runId,
+        initialCapitalMicros: evaluation.initialCapitalMicros,
+        inputManifest: evaluation.inputManifest,
+        events: evaluation.events,
+      },
+      {
+        runId: evaluation.runId,
+        initialCapitalMicros: evaluation.initialCapitalMicros,
+        inputManifest: evaluation.inputManifest,
+        events: evaluation.events,
+      },
+    ])
+    expect(first).toEqual(second)
+    expect(first).toMatchObject({
+      schemaVersion: 'bayn.ledger-restore-receipt.v1',
+      source: {
+        revision: provenance.sourceRevision,
+        image: provenance.image,
+      },
+      restore: {
+        revision: config.build.sourceRevision,
+        image: {
+          repository: config.build.imageRepository,
+          digest: config.build.imageDigest,
+        },
+      },
+      target: {
+        clusterId: config.tigerBeetle.clusterId.toString(),
+        ledger: 7_001,
+      },
+      runId: evaluation.runId,
+      qualification: qualificationResult.verdict,
+      accountCount: reconciliation.accountCount,
+      transferCount: reconciliation.transferCount,
+      exact: true,
+      planHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+    })
+  })
+
+  test('rejects a run without a terminal qualification before touching TigerBeetle', async () => {
+    let writes = 0
+    const journal: JournalService = {
+      check: Effect.void,
+      checkRun: () => Effect.void,
+      journalAndReconcile: () => {
+        writes += 1
+        return Effect.succeed(reconciliation)
+      },
+    }
+
+    const error = await Effect.runPromise(Effect.flip(runRestore(config, evidenceStore(false), journal)))
+    expect(error.message).toContain('has no terminal qualification')
+    expect(writes).toBe(0)
+  })
+
+  test('rejects a missing pinned run before touching TigerBeetle', async () => {
+    let writes = 0
+    const missing: EvidenceStoreService = {
+      ...evidenceStore(),
+      read: () => Effect.succeed(Option.none()),
+    }
+    const journal: JournalService = {
+      check: Effect.void,
+      checkRun: () => Effect.void,
+      journalAndReconcile: () => {
+        writes += 1
+        return Effect.succeed(reconciliation)
+      },
+    }
+
+    const error = await Effect.runPromise(Effect.flip(runRestore(config, missing, journal)))
+    expect(error.message).toContain(`run ${config.runId} is missing`)
+    expect(writes).toBe(0)
+  })
+
+  test('rejects malformed PostgreSQL evidence before touching TigerBeetle', async () => {
+    let writes = 0
+    const malformed: StoredEvaluationEvidence = {
+      ...stored,
+      artifacts: [{ ...stored.artifacts[0], payload: { schemaVersion: 'malformed' } }],
+    }
+    const store: EvidenceStoreService = {
+      ...evidenceStore(),
+      read: () => Effect.succeed(Option.some(malformed)),
+    }
+    const journal: JournalService = {
+      check: Effect.void,
+      checkRun: () => Effect.void,
+      journalAndReconcile: () => {
+        writes += 1
+        return Effect.succeed(reconciliation)
+      },
+    }
+
+    const error = await Effect.runPromise(Effect.flip(runRestore(config, store, journal)))
+    expect(error.message).toContain('stored ledger input is invalid')
+    expect(writes).toBe(0)
+  })
+
+  test('rejects precommitted count drift before touching TigerBeetle', async () => {
+    let writes = 0
+    const journal: JournalService = {
+      check: Effect.void,
+      checkRun: () => Effect.void,
+      journalAndReconcile: () => {
+        writes += 1
+        return Effect.succeed(reconciliation)
+      },
+    }
+    const drifted = { ...config, expectedTransferCount: config.expectedTransferCount + 1 }
+
+    const error = await Effect.runPromise(Effect.flip(runRestore(drifted, evidenceStore(), journal)))
+    expect(error.message).toContain('precommitted ledger counts diverged')
+    expect(writes).toBe(0)
+  })
+
+  test('rejects a target reconciliation that differs from immutable evidence', async () => {
+    const journal: JournalService = {
+      check: Effect.void,
+      checkRun: () => Effect.void,
+      journalAndReconcile: () => Effect.succeed({ ...reconciliation, transferCount: reconciliation.transferCount - 1 }),
+    }
+
+    const error = await Effect.runPromise(Effect.flip(runRestore(config, evidenceStore(), journal)))
+    expect(error.message).toContain('target reconciliation differs')
+  })
+
+  test('interrupts an unknown TigerBeetle outcome and fails within the operator deadline', async () => {
+    let interrupted = false
+    const journal: JournalService = {
+      check: Effect.void,
+      checkRun: () => Effect.void,
+      journalAndReconcile: () =>
+        Effect.never.pipe(Effect.onInterrupt(() => Effect.sync(() => void (interrupted = true)))),
+    }
+    const timed = { ...config, operationTimeoutMs: 10 }
+    const program = Effect.gen(function* () {
+      const fiber = yield* Effect.flip(runRestore(timed, evidenceStore(), journal)).pipe(
+        Effect.forkChild({ startImmediately: true }),
+      )
+      yield* Effect.yieldNow
+      yield* TestClock.adjust(timed.operationTimeoutMs)
+      return yield* Fiber.join(fiber)
+    }).pipe(Effect.provide(TestClock.layer()))
+
+    const error = await Effect.runPromise(program)
+    expect(error.message).toContain('journal restore-and-reconcile timed out after 10ms')
+    expect(interrupted).toBe(true)
+  })
+})

--- a/services/bayn/src/ledger-restore.ts
+++ b/services/bayn/src/ledger-restore.ts
@@ -1,0 +1,375 @@
+import { Config, Effect, Option, Redacted, Schema, SchemaTransformation } from 'effect'
+
+import { EmbeddedBuildMetadataSchema, embeddedBuildMetadata, type EmbeddedBuildMetadata } from './build'
+import { makeRuntimeProvenance, Sha256Schema } from './contracts'
+import { EvidenceStore, type StoredEvaluationEvidence } from './db/evidence-store'
+import { decodeEvaluationEvents, decodeInputManifestArtifact } from './evidence-contracts'
+import { operationalError, type OperationalError } from './errors'
+import { canonicalHashV1 } from './hash'
+import { buildLedgerPlan, hashLedgerPlan, Journal, type LedgerInput } from './ledger'
+
+export interface RestoreConfig {
+  readonly runId: string
+  readonly expectedAccountCount: number
+  readonly expectedTransferCount: number
+  readonly operationTimeoutMs: number
+  readonly build: {
+    readonly sourceRevision: string
+    readonly imageRepository: string
+    readonly imageDigest: string
+  }
+  readonly postgres: {
+    readonly url: Redacted.Redacted<string>
+    readonly tls: boolean
+    readonly caPath: string
+  }
+  readonly tigerBeetle: {
+    readonly clusterId: bigint
+    readonly replicaAddresses: readonly string[]
+    readonly ledger: number
+  }
+}
+
+export interface RestoreContract {
+  readonly runId: string
+  readonly expectedAccountCount: number
+  readonly expectedTransferCount: number
+  readonly target: {
+    readonly clusterId: bigint
+    readonly replicaAddresses: readonly string[]
+    readonly ledger: number
+  }
+}
+
+export const restoreContract: RestoreContract = {
+  runId: '42d8bbfaf1a2ce7759b2283384e8f41298fe3a354ba7c0e1756bb8a3e64af177',
+  expectedAccountCount: 14,
+  expectedTransferCount: 906,
+  target: {
+    clusterId: 222397790944575595450310052784555675227n,
+    replicaAddresses: [
+      'bayn-tigerbeetle-0.bayn-tigerbeetle-headless.bayn.svc.cluster.local:3000',
+      'bayn-tigerbeetle-1.bayn-tigerbeetle-headless.bayn.svc.cluster.local:3000',
+      'bayn-tigerbeetle-2.bayn-tigerbeetle-headless.bayn.svc.cluster.local:3000',
+    ],
+    ledger: 7_001,
+  },
+}
+
+export interface RestoreReceipt {
+  readonly schemaVersion: 'bayn.ledger-restore-receipt.v1'
+  readonly source: {
+    readonly revision: string
+    readonly image: {
+      readonly repository: string
+      readonly digest: string
+    }
+  }
+  readonly restore: {
+    readonly revision: string
+    readonly image: {
+      readonly repository: string
+      readonly digest: string
+    }
+  }
+  readonly target: {
+    readonly clusterId: string
+    readonly ledger: number
+  }
+  readonly runId: string
+  readonly qualification: 'QUALIFIED' | 'REJECTED'
+  readonly accountCount: number
+  readonly transferCount: number
+  readonly exact: true
+  readonly planHash: string
+}
+
+const NonEmptyString = Schema.Trim.check(Schema.isMinLength(1))
+const PositiveInteger = Schema.Int.check(Schema.isGreaterThan(0))
+const SourceRevision = Schema.String.check(Schema.isPattern(/^[a-f0-9]{40}$/))
+const ImageRepository = Schema.String.check(Schema.isPattern(/^[a-z0-9.-]+(?::[0-9]+)?\/[a-z0-9._/-]+$/))
+const ImageDigest = Schema.String.check(Schema.isPattern(/^sha256:[a-f0-9]{64}$/))
+const ReplicaAddresses = Schema.Trim.pipe(
+  Schema.decodeTo(
+    Schema.Array(NonEmptyString).check(Schema.isMinLength(1)),
+    SchemaTransformation.transform<readonly string[], string>({
+      decode: (value) =>
+        value
+          .split(',')
+          .map((address) => address.trim())
+          .filter(Boolean),
+      encode: (addresses) => addresses.join(','),
+    }),
+  ),
+)
+
+const restoreConfig = Config.all({
+  runId: Config.schema(Sha256Schema, 'BAYN_LEDGER_RESTORE_RUN_ID'),
+  expectedAccountCount: Config.schema(PositiveInteger, 'BAYN_LEDGER_RESTORE_EXPECTED_ACCOUNT_COUNT'),
+  expectedTransferCount: Config.schema(PositiveInteger, 'BAYN_LEDGER_RESTORE_EXPECTED_TRANSFER_COUNT'),
+  operationTimeoutMs: Config.schema(PositiveInteger, 'BAYN_OPERATION_TIMEOUT_MS').pipe(Config.withDefault(30_000)),
+  sourceRevision: Config.schema(SourceRevision, 'BAYN_CODE_REVISION'),
+  imageRepository: Config.schema(ImageRepository, 'BAYN_IMAGE_REPOSITORY'),
+  imageDigest: Config.schema(ImageDigest, 'BAYN_IMAGE_DIGEST'),
+  postgresUrl: Config.redacted('BAYN_POSTGRES_URL'),
+  postgresTls: Config.boolean('BAYN_POSTGRES_TLS').pipe(Config.withDefault(true)),
+  postgresCaPath: Config.schema(NonEmptyString, 'BAYN_POSTGRES_CA_PATH').pipe(
+    Config.withDefault('/var/run/secrets/bayn/postgres/ca.crt'),
+  ),
+  tigerBeetleClusterId: Config.schema(Schema.BigIntFromString, 'BAYN_TIGERBEETLE_CLUSTER_ID'),
+  tigerBeetleReplicaAddresses: Config.schema(ReplicaAddresses, 'BAYN_TIGERBEETLE_ADDRESSES'),
+  tigerBeetleLedger: Config.schema(PositiveInteger, 'BAYN_TIGERBEETLE_LEDGER'),
+})
+
+const StrictParseOptions = { onExcessProperty: 'error' } as const
+const decodeEmbeddedBuildMetadata = Schema.decodeUnknownSync(EmbeddedBuildMetadataSchema, StrictParseOptions)
+const maxU128 = (1n << 128n) - 1n
+
+export const loadRestoreConfig = (
+  embedded: EmbeddedBuildMetadata | undefined = embeddedBuildMetadata,
+  contract: RestoreContract = restoreContract,
+): Effect.Effect<RestoreConfig, OperationalError> =>
+  restoreConfig.pipe(
+    Effect.mapError((cause) =>
+      operationalError('config', 'load-ledger-restore', 'invalid restore configuration', cause),
+    ),
+    Effect.flatMap((config) =>
+      Effect.try({
+        try: (): RestoreConfig => {
+          if (embedded === undefined) throw new Error('ledger restore requires compile-time build metadata')
+          if (!config.postgresTls) throw new Error('ledger restore requires verified PostgreSQL TLS')
+          if (config.tigerBeetleClusterId <= 0n || config.tigerBeetleClusterId > maxU128) {
+            throw new Error('TigerBeetle cluster ID must be a non-zero u128')
+          }
+          if (config.tigerBeetleLedger > 0xffff_ffff) throw new Error('TigerBeetle ledger must fit in a u32')
+          if (
+            config.runId !== contract.runId ||
+            config.expectedAccountCount !== contract.expectedAccountCount ||
+            config.expectedTransferCount !== contract.expectedTransferCount ||
+            config.tigerBeetleClusterId !== contract.target.clusterId ||
+            config.tigerBeetleLedger !== contract.target.ledger ||
+            config.tigerBeetleReplicaAddresses.length !== contract.target.replicaAddresses.length ||
+            config.tigerBeetleReplicaAddresses.some(
+              (address, index) => address !== contract.target.replicaAddresses[index],
+            )
+          ) {
+            throw new Error('restore configuration does not match the pinned one-shot contract')
+          }
+          const build = decodeEmbeddedBuildMetadata(embedded)
+          if (config.sourceRevision !== build.sourceRevision) {
+            throw new Error('configured source revision does not match the restore executable')
+          }
+          if (config.imageRepository !== build.imageRepository) {
+            throw new Error('configured image repository does not match the restore executable')
+          }
+          return {
+            runId: config.runId,
+            expectedAccountCount: config.expectedAccountCount,
+            expectedTransferCount: config.expectedTransferCount,
+            operationTimeoutMs: config.operationTimeoutMs,
+            build: {
+              sourceRevision: build.sourceRevision,
+              imageRepository: build.imageRepository,
+              imageDigest: config.imageDigest,
+            },
+            postgres: {
+              url: config.postgresUrl,
+              tls: config.postgresTls,
+              caPath: config.postgresCaPath,
+            },
+            tigerBeetle: {
+              clusterId: config.tigerBeetleClusterId,
+              replicaAddresses: config.tigerBeetleReplicaAddresses,
+              ledger: config.tigerBeetleLedger,
+            },
+          }
+        },
+        catch: (cause) =>
+          operationalError('config', 'load-ledger-restore', 'invalid ledger restore configuration', cause),
+      }),
+    ),
+  )
+
+const databaseOperation = <A>(
+  effect: Effect.Effect<A, { readonly message: string }>,
+  operation: string,
+): Effect.Effect<A, OperationalError> =>
+  effect.pipe(
+    Effect.mapError((cause) => operationalError('database', operation, `PostgreSQL ${operation} failed`, cause)),
+  )
+
+const withinDeadline = <A, R>(
+  effect: Effect.Effect<A, OperationalError, R>,
+  timeoutMs: number,
+  component: 'database' | 'journal',
+  operation: string,
+): Effect.Effect<A, OperationalError, R> =>
+  effect.pipe(
+    Effect.timeoutOrElse({
+      duration: timeoutMs,
+      orElse: () =>
+        Effect.fail(operationalError(component, operation, `${component} ${operation} timed out after ${timeoutMs}ms`)),
+    }),
+  )
+
+const storedProvenance = (stored: StoredEvaluationEvidence) =>
+  makeRuntimeProvenance({
+    sourceRevision: stored.run.sourceRevision,
+    image: { repository: stored.run.imageRepository, digest: stored.run.imageDigest },
+    strategy: {
+      name: stored.protocol.strategyName,
+      behaviorHash: stored.protocol.behaviorHash,
+      parameterHash: stored.protocol.parameterHash,
+      parameterSchemaVersion: stored.protocol.schemaVersion,
+    },
+  })
+
+export const restoreLedger = (
+  config: RestoreConfig,
+): Effect.Effect<RestoreReceipt, OperationalError, EvidenceStore | Journal> =>
+  Effect.gen(function* () {
+    const evidenceStore = yield* EvidenceStore
+    const journal = yield* Journal
+    const storedOption = yield* withinDeadline(
+      databaseOperation(evidenceStore.read(config.runId), 'read-ledger-restore-evidence'),
+      config.operationTimeoutMs,
+      'database',
+      'read-ledger-restore-evidence',
+    )
+    if (Option.isNone(storedOption)) {
+      return yield* Effect.fail(
+        operationalError('database', 'read-ledger-restore-evidence', `run ${config.runId} is missing`),
+      )
+    }
+    const stored = storedOption.value
+    const provenance = yield* Effect.try({
+      try: () => storedProvenance(stored),
+      catch: (cause) =>
+        operationalError('database', 'validate-ledger-restore', 'stored execution provenance is invalid', cause),
+    })
+    const [qualificationOption, recoveredOption] = yield* withinDeadline(
+      databaseOperation(
+        Effect.all([evidenceStore.readQualification(config.runId), evidenceStore.recover(config.runId, provenance)]),
+        'recover-ledger-restore-evidence',
+      ),
+      config.operationTimeoutMs,
+      'database',
+      'recover-ledger-restore-evidence',
+    )
+    if (Option.isNone(qualificationOption) || qualificationOption.value.state !== 'TERMINAL') {
+      return yield* Effect.fail(
+        operationalError('database', 'validate-ledger-restore', `run ${config.runId} has no terminal qualification`),
+      )
+    }
+    if (Option.isNone(recoveredOption)) {
+      return yield* Effect.fail(
+        operationalError('database', 'validate-ledger-restore', `run ${config.runId} cannot be recovered`),
+      )
+    }
+    const qualification = qualificationOption.value
+    const recovered = recoveredOption.value
+    const inputArtifacts = stored.artifacts.filter((artifact) => artifact.name === 'input-manifest')
+    if (inputArtifacts.length !== 1) {
+      return yield* Effect.fail(
+        operationalError('database', 'validate-ledger-restore', 'stored run must have exactly one input manifest'),
+      )
+    }
+    const [inputManifest, events] = yield* Effect.all([
+      decodeInputManifestArtifact(inputArtifacts[0].payload),
+      decodeEvaluationEvents(stored.events.map((event) => event.payload)),
+    ]).pipe(
+      Effect.mapError((cause) =>
+        operationalError('database', 'validate-ledger-restore', 'stored ledger input is invalid', cause),
+      ),
+    )
+    const ledgerInput: LedgerInput = {
+      runId: stored.run.runId,
+      initialCapitalMicros: stored.run.initialCapitalMicros,
+      inputManifest,
+      events,
+    }
+    const plan = yield* Effect.try({
+      try: () => buildLedgerPlan(ledgerInput, config.tigerBeetle.ledger),
+      catch: (cause) => operationalError('journal', 'plan-ledger-restore', 'ledger restore plan is invalid', cause),
+    })
+    const planHash = hashLedgerPlan(plan)
+    yield* Effect.try({
+      try: () => {
+        if (
+          stored.run.runId !== config.runId ||
+          qualification.lock.candidateRunId !== config.runId ||
+          qualification.result.runId !== config.runId ||
+          recovered.evaluation.runId !== config.runId ||
+          recovered.reconciliation.runId !== config.runId
+        ) {
+          throw new Error('run identities diverged')
+        }
+        if (
+          qualification.lock.protocolHash !== stored.run.protocolHash ||
+          qualification.lock.sourceRevision !== stored.run.sourceRevision ||
+          canonicalHashV1(qualification.lock.image) !==
+            canonicalHashV1({ repository: stored.run.imageRepository, digest: stored.run.imageDigest }) ||
+          canonicalHashV1(qualification.result.evaluationVerdict) !== canonicalHashV1(recovered.evaluation.verdict)
+        ) {
+          throw new Error('qualification binding diverged from stored evidence')
+        }
+        if (
+          recovered.reconciliation.accountCount !== config.expectedAccountCount ||
+          recovered.reconciliation.transferCount !== config.expectedTransferCount ||
+          plan.accounts.length !== config.expectedAccountCount ||
+          plan.transfers.length !== config.expectedTransferCount
+        ) {
+          throw new Error('precommitted ledger counts diverged from the recovered evidence or restore plan')
+        }
+        if (
+          stored.events.some((event, index) => event.id !== events[index]?.id || event.kind !== events[index]?.kind)
+        ) {
+          throw new Error('decoded ledger events diverged from their durable references')
+        }
+      },
+      catch: (cause) =>
+        operationalError('database', 'validate-ledger-restore', 'ledger restore evidence failed validation', cause),
+    })
+    const reconciliation = yield* withinDeadline(
+      journal.journalAndReconcile(ledgerInput),
+      config.operationTimeoutMs,
+      'journal',
+      'restore-and-reconcile',
+    )
+    yield* Effect.try({
+      try: () => {
+        if (canonicalHashV1(reconciliation) !== canonicalHashV1(recovered.reconciliation)) {
+          throw new Error('target reconciliation differs from the immutable source receipt')
+        }
+      },
+      catch: (cause) =>
+        operationalError('journal', 'restore-and-reconcile', 'target ledger reconciliation failed', cause),
+    })
+    return {
+      schemaVersion: 'bayn.ledger-restore-receipt.v1' as const,
+      source: {
+        revision: stored.run.sourceRevision,
+        image: {
+          repository: stored.run.imageRepository,
+          digest: stored.run.imageDigest,
+        },
+      },
+      restore: {
+        revision: config.build.sourceRevision,
+        image: {
+          repository: config.build.imageRepository,
+          digest: config.build.imageDigest,
+        },
+      },
+      target: {
+        clusterId: config.tigerBeetle.clusterId.toString(),
+        ledger: config.tigerBeetle.ledger,
+      },
+      runId: config.runId,
+      qualification: qualification.result.verdict,
+      accountCount: reconciliation.accountCount,
+      transferCount: reconciliation.transferCount,
+      exact: true as const,
+      planHash,
+    }
+  }).pipe(Effect.withLogSpan('restore-ledger'))

--- a/services/bayn/src/ledger.test.ts
+++ b/services/bayn/src/ledger.test.ts
@@ -1,11 +1,19 @@
 import { describe, expect, test } from 'bun:test'
 import { Effect, Redacted } from 'effect'
-import { createClient as createTigerBeetleClient, type Account, type Client, type Transfer } from 'tigerbeetle-node'
+import {
+  createClient as createTigerBeetleClient,
+  CreateAccountStatus,
+  CreateTransferStatus,
+  type Account,
+  type Client,
+  type Transfer,
+} from 'tigerbeetle-node'
 
 import type { RuntimeConfig } from './config'
 import {
   assertReconciled,
   buildLedgerPlan,
+  hashLedgerPlan,
   Journal,
   JournalLive,
   resolveReplicaAddresses,
@@ -31,6 +39,79 @@ const materializeAccounts = (plan: ReturnType<typeof buildLedgerPlan>): Account[
 const materializeTransfers = (plan: ReturnType<typeof buildLedgerPlan>): Transfer[] =>
   plan.transfers.map((transfer) => ({ ...transfer, timestamp: 1n }))
 
+const journalConfig = {
+  operationTimeoutMs: 1_000,
+  tigerBeetle: { clusterId: 222397790944575595450310052784555675227n, replicaAddresses: ['3000'], ledger: 7_001 },
+} satisfies Pick<RuntimeConfig, 'operationTimeoutMs' | 'tigerBeetle'>
+
+const makeLedgerClient = () => {
+  const accounts = new Map<bigint, Account>()
+  const transfers = new Map<bigint, Transfer>()
+  const client: Client = {
+    createAccounts: async (batch) =>
+      batch.map((account) => {
+        if (accounts.has(account.id)) return { timestamp: 1n, status: CreateAccountStatus.exists }
+        accounts.set(account.id, { ...account, timestamp: 1n })
+        return { timestamp: 1n, status: CreateAccountStatus.created }
+      }),
+    createTransfers: async (batch) =>
+      batch.map((transfer) => {
+        if (transfers.has(transfer.id)) return { timestamp: 1n, status: CreateTransferStatus.exists }
+        const debit = accounts.get(transfer.debit_account_id)
+        const credit = accounts.get(transfer.credit_account_id)
+        if (debit === undefined || credit === undefined) throw new Error('transfer references an unknown account')
+        accounts.set(debit.id, { ...debit, debits_posted: debit.debits_posted + transfer.amount })
+        accounts.set(credit.id, { ...credit, credits_posted: credit.credits_posted + transfer.amount })
+        transfers.set(transfer.id, { ...transfer, timestamp: 1n })
+        return { timestamp: 1n, status: CreateTransferStatus.created }
+      }),
+    lookupAccounts: async (ids) =>
+      ids.flatMap((id) => {
+        const account = accounts.get(id)
+        return account === undefined ? [] : [account]
+      }),
+    lookupTransfers: async (ids) =>
+      ids.flatMap((id) => {
+        const transfer = transfers.get(id)
+        return transfer === undefined ? [] : [transfer]
+      }),
+    getAccountTransfers: async () => [],
+    getAccountBalances: async () => [],
+    queryAccounts: async (filter) =>
+      [...accounts.values()]
+        .filter(
+          (account) =>
+            account.ledger === filter.ledger &&
+            (filter.user_data_128 === 0n || account.user_data_128 === filter.user_data_128),
+        )
+        .slice(0, filter.limit),
+    queryTransfers: async (filter) =>
+      [...transfers.values()]
+        .filter(
+          (transfer) =>
+            transfer.ledger === filter.ledger &&
+            (filter.user_data_64 === 0n || transfer.user_data_64 === filter.user_data_64),
+        )
+        .slice(0, filter.limit),
+    destroy: () => undefined,
+  }
+  return { accounts, transfers, client }
+}
+
+const withJournal = <A, E>(client: Client, use: (journal: JournalService) => Effect.Effect<A, E>) =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      return yield* use(yield* Journal)
+    }).pipe(
+      Effect.provide(
+        JournalLive(journalConfig, {
+          createClient: (() => client) as unknown as typeof createTigerBeetleClient,
+          resolveReplicaAddresses: () => Effect.succeed(['3000']),
+        }),
+      ),
+    ),
+  )
+
 describe('TigerBeetle simulation journal', () => {
   test('plans deterministic double-entry transfers and reconciles exact sets and balances', () => {
     const snapshot = makeSnapshot()
@@ -38,6 +119,9 @@ describe('TigerBeetle simulation journal', () => {
     const first = buildLedgerPlan(result, 7001)
     const second = buildLedgerPlan(result, 7001)
     expect(first).toEqual(second)
+    expect(hashLedgerPlan(first)).toMatch(/^[a-f0-9]{64}$/)
+    expect(hashLedgerPlan(first)).toBe(hashLedgerPlan(second))
+    expect(hashLedgerPlan(first)).not.toBe(hashLedgerPlan(buildLedgerPlan(result, 7002)))
     expect(first.accounts).toHaveLength(fixtureProtocol.universe.length + 6)
     expect(first.transfers.length).toBeGreaterThan(1)
     expect(() => assertReconciled(first, materializeAccounts(first), materializeTransfers(first))).not.toThrow()
@@ -59,6 +143,44 @@ describe('TigerBeetle simulation journal', () => {
         transfers,
       ),
     ).toThrow('balance does not reconcile exactly')
+  })
+
+  test('creates an empty target exactly once and verifies an idempotent replay', async () => {
+    const snapshot = makeSnapshot()
+    const result = evaluateTsmom(snapshot.bars, snapshot.manifest, fixtureProtocol, makeTestProvenance())
+    const plan = buildLedgerPlan(result, journalConfig.tigerBeetle.ledger)
+    const target = makeLedgerClient()
+
+    const reconciliations = await Effect.runPromise(
+      withJournal(target.client, (journal) =>
+        Effect.all([journal.journalAndReconcile(result), journal.journalAndReconcile(result)]),
+      ),
+    )
+
+    expect(reconciliations[0]).toEqual(reconciliations[1])
+    expect(reconciliations[0]).toEqual({
+      runId: result.runId,
+      accountCount: plan.accounts.length,
+      transferCount: plan.transfers.length,
+      exact: true,
+    })
+    expect(target.accounts.size).toBe(plan.accounts.length)
+    expect(target.transfers.size).toBe(plan.transfers.length)
+  })
+
+  test('rejects a mismatched existing account before creating transfers', async () => {
+    const snapshot = makeSnapshot()
+    const result = evaluateTsmom(snapshot.bars, snapshot.manifest, fixtureProtocol, makeTestProvenance())
+    const plan = buildLedgerPlan(result, journalConfig.tigerBeetle.ledger)
+    const target = makeLedgerClient()
+    target.accounts.set(plan.accounts[0].id, { ...plan.accounts[0], code: plan.accounts[0].code + 1, timestamp: 1n })
+
+    const error = await Effect.runPromise(
+      Effect.flip(withJournal(target.client, (journal) => journal.journalAndReconcile(result))),
+    )
+
+    expect(error.message).toContain('does not match its plan')
+    expect(target.transfers.size).toBe(0)
   })
 
   test('checks the persisted run read-only and rejects changed TigerBeetle balances', async () => {
@@ -138,21 +260,30 @@ describe('TigerBeetle simulation journal', () => {
 })
 
 describe('TigerBeetle replica addresses', () => {
-  test('resolves service hostnames once at startup and preserves numeric addresses', async () => {
+  test('resolves ordinal hostnames in configured order and preserves numeric addresses', async () => {
     const lookups: string[] = []
     const addresses = await Effect.runPromise(
       resolveReplicaAddresses(
-        ['torghut-tigerbeetle.torghut.svc.cluster.local:3000', '10.244.5.234:3000', '127.0.0.1', '3001'],
+        [
+          'bayn-tigerbeetle-0.bayn-tigerbeetle-headless.bayn.svc.cluster.local:3000',
+          'bayn-tigerbeetle-1.bayn-tigerbeetle-headless.bayn.svc.cluster.local:3000',
+          '10.244.5.236:3000',
+          '127.0.0.1',
+          '3001',
+        ],
         (hostname) =>
           Effect.sync(() => {
             lookups.push(hostname)
-            return ['10.244.5.234', '10.244.5.235']
+            return [hostname.includes('-0.') ? '10.244.5.234' : '10.244.5.235']
           }),
       ),
     )
 
-    expect(lookups).toEqual(['torghut-tigerbeetle.torghut.svc.cluster.local'])
-    expect(addresses).toEqual(['10.244.5.234:3000', '10.244.5.235:3000', '127.0.0.1', '3001'])
+    expect(lookups).toEqual([
+      'bayn-tigerbeetle-0.bayn-tigerbeetle-headless.bayn.svc.cluster.local',
+      'bayn-tigerbeetle-1.bayn-tigerbeetle-headless.bayn.svc.cluster.local',
+    ])
+    expect(addresses).toEqual(['10.244.5.234:3000', '10.244.5.235:3000', '10.244.5.236:3000', '127.0.0.1', '3001'])
   })
 
   test('rejects malformed, out-of-range, and IPv6-only endpoints', async () => {
@@ -168,5 +299,10 @@ describe('TigerBeetle replica addresses', () => {
     expect(Effect.runPromise(resolveReplicaAddresses(['::1']))).rejects.toThrow(
       'IPv6 TigerBeetle replica addresses are not supported',
     )
+    expect(
+      Effect.runPromise(
+        resolveReplicaAddresses(['replica-0:3000', 'replica-1:3000'], () => Effect.succeed(['10.0.0.1'])),
+      ),
+    ).rejects.toThrow('resolved to duplicate IPv4 addresses')
   })
 })

--- a/services/bayn/src/ledger.test.ts
+++ b/services/bayn/src/ledger.test.ts
@@ -301,6 +301,11 @@ describe('TigerBeetle replica addresses', () => {
     )
     expect(
       Effect.runPromise(
+        resolveReplicaAddresses(['unordered-headless-service:3000'], () => Effect.succeed(['10.0.0.1', '10.0.0.2'])),
+      ),
+    ).rejects.toThrow('must resolve to exactly one IPv4 address')
+    expect(
+      Effect.runPromise(
         resolveReplicaAddresses(['replica-0:3000', 'replica-1:3000'], () => Effect.succeed(['10.0.0.1'])),
       ),
     ).rejects.toThrow('resolved to duplicate IPv4 addresses')

--- a/services/bayn/src/ledger.ts
+++ b/services/bayn/src/ledger.ts
@@ -109,7 +109,16 @@ const resolveReplicaAddress = (
         ),
       )
     }
-    return ipv4Addresses.map((ipv4Address) => `${ipv4Address}:${port}`)
+    if (ipv4Addresses.length !== 1) {
+      return yield* Effect.fail(
+        operationalError(
+          'journal',
+          'resolve-replica-addresses',
+          `TigerBeetle replica hostname must resolve to exactly one IPv4 address: ${hostname}`,
+        ),
+      )
+    }
+    return [`${ipv4Addresses[0]}:${port}`]
   })
 
 export const resolveReplicaAddresses = (

--- a/services/bayn/src/ledger.ts
+++ b/services/bayn/src/ledger.ts
@@ -15,8 +15,8 @@ import { Context, Effect, Layer, Option, ScopedRef, Semaphore } from 'effect'
 
 import type { RuntimeConfig } from './config'
 import { operationalError, type OperationalError } from './errors'
-import { hashObject, stableU128, stableU64 } from './hash'
-import type { CashYieldEvent, EvaluationResult, FeeEvent, FillEvent, ReconciliationResult } from './types'
+import { canonicalHashV1, hashObject, stableU128, stableU64 } from './hash'
+import type { CashYieldEvent, EvaluationEvent, FeeEvent, FillEvent, InputManifest, ReconciliationResult } from './types'
 
 const SCHEMA_VERSION = 2
 const BATCH_MAX = 8_189
@@ -126,7 +126,21 @@ export const resolveReplicaAddresses = (
       )
     : Effect.forEach(configuredAddresses, (address) => resolveReplicaAddress(address, resolveHostname), {
         concurrency: 'unbounded',
-      }).pipe(Effect.map((resolved) => [...new Set(resolved.flat())]))
+      }).pipe(
+        Effect.flatMap((resolved) => {
+          const addresses = resolved.flat()
+          if (new Set(addresses).size !== addresses.length) {
+            return Effect.fail(
+              operationalError(
+                'journal',
+                'resolve-replica-addresses',
+                'TigerBeetle replica hostnames resolved to duplicate IPv4 addresses',
+              ),
+            )
+          }
+          return Effect.succeed(addresses)
+        }),
+      )
 
 const AccountCode = {
   cash: 110,
@@ -155,8 +169,15 @@ export interface LedgerPlan {
   readonly transfers: readonly Transfer[]
 }
 
+export interface LedgerInput {
+  readonly runId: string
+  readonly initialCapitalMicros: string
+  readonly inputManifest: InputManifest
+  readonly events: readonly EvaluationEvent[]
+}
+
 export interface JournalService {
-  readonly journalAndReconcile: (result: EvaluationResult) => Effect.Effect<ReconciliationResult, OperationalError>
+  readonly journalAndReconcile: (result: LedgerInput) => Effect.Effect<ReconciliationResult, OperationalError>
   readonly check: Effect.Effect<void, OperationalError>
   readonly checkRun: (result: ReconciliationResult) => Effect.Effect<void, OperationalError>
 }
@@ -219,7 +240,7 @@ const positiveAmount = (value: string, name: string): bigint => {
   return parsed
 }
 
-export const buildLedgerPlan = (result: EvaluationResult, ledger: number): LedgerPlan => {
+export const buildLedgerPlan = (result: LedgerInput, ledger: number): LedgerPlan => {
   const runKey = stableU128('bayn-run-v1', result.runId)
   const runTag = stableU64('bayn-run-v1', result.runId)
   const accountsByName = new Map<string, Account>()
@@ -373,6 +394,20 @@ export const buildLedgerPlan = (result: EvaluationResult, ledger: number): Ledge
     transfers: transfers.sort((left, right) => (left.id < right.id ? -1 : 1)),
   }
 }
+
+const serializeRecord = (record: Account | Transfer): Record<string, number | string> =>
+  Object.fromEntries(
+    Object.entries(record).map(([key, value]) => [key, typeof value === 'bigint' ? value.toString() : value]),
+  )
+
+export const hashLedgerPlan = (plan: LedgerPlan): string =>
+  canonicalHashV1({
+    schemaVersion: 'bayn.ledger-plan.v1',
+    runKey: plan.runKey.toString(),
+    runTag: plan.runTag.toString(),
+    accounts: plan.accounts.map(serializeRecord),
+    transfers: plan.transfers.map(serializeRecord),
+  })
 
 const accountMetadataMatches = (actual: Account, expected: Account): boolean =>
   actual.id === expected.id &&
@@ -628,7 +663,7 @@ const checkRun = (
 const journalAndReconcile = (
   client: LedgerClient,
   ledger: number,
-  result: EvaluationResult,
+  result: LedgerInput,
 ): Effect.Effect<ReconciliationResult, OperationalError> =>
   Effect.gen(function* () {
     const plan = yield* validate('build-plan', () => buildLedgerPlan(result, ledger))
@@ -657,7 +692,7 @@ export interface JournalDependencies {
 const defaultDependencies: JournalDependencies = { createClient, resolveReplicaAddresses }
 
 export const JournalLive = (
-  config: RuntimeConfig,
+  config: Pick<RuntimeConfig, 'operationTimeoutMs' | 'tigerBeetle'>,
   dependencies: JournalDependencies = defaultDependencies,
 ): Layer.Layer<Journal, OperationalError> =>
   Layer.effect(

--- a/services/bayn/src/restore-ledger-command.ts
+++ b/services/bayn/src/restore-ledger-command.ts
@@ -1,0 +1,46 @@
+import { NodeRuntime, NodeServices } from '@effect/platform-node'
+import { Effect, Layer, Logger } from 'effect'
+
+import { EvidenceStoreReadOnlyLive } from './db/evidence-store'
+import { JournalLive } from './ledger'
+import { loadRestoreConfig, restoreLedger } from './ledger-restore'
+
+const main = loadRestoreConfig().pipe(
+  Effect.flatMap((config) => {
+    const dependencies = Layer.merge(
+      JournalLive(config),
+      EvidenceStoreReadOnlyLive(config).pipe(Layer.provide(NodeServices.layer)),
+    )
+    return restoreLedger(config).pipe(
+      Effect.tap((receipt) =>
+        Effect.logInfo('Bayn ledger restore completed').pipe(
+          Effect.annotateLogs({
+            receiptSchemaVersion: receipt.schemaVersion,
+            evaluationSourceRevision: receipt.source.revision,
+            evaluationImageRepository: receipt.source.image.repository,
+            evaluationImageDigest: receipt.source.image.digest,
+            restoreSourceRevision: receipt.restore.revision,
+            restoreImageRepository: receipt.restore.image.repository,
+            restoreImageDigest: receipt.restore.image.digest,
+            targetClusterId: receipt.target.clusterId,
+            targetLedger: receipt.target.ledger,
+            runId: receipt.runId,
+            qualification: receipt.qualification,
+            accountCount: receipt.accountCount,
+            transferCount: receipt.transferCount,
+            exact: receipt.exact,
+            planHash: receipt.planHash,
+          }),
+        ),
+      ),
+      Effect.provide(dependencies),
+    )
+  }),
+)
+
+const program = main.pipe(
+  Effect.annotateLogs({ service: 'bayn', command: 'restore-ledger' }),
+  Effect.provide(Logger.layer([Logger.consoleJson])),
+)
+
+NodeRuntime.runMain(program)


### PR DESCRIPTION
## Summary

- add a Bayn-owned three-replica Tigresse cluster with retained Ceph storage, required node anti-affinity, a PDB, a digest-pinned multi-architecture TigerBeetle 0.17.9 image, and narrow ingress/egress policy
- add an operator-only Effect command that reconstructs the single pinned run from read-only PostgreSQL evidence through the existing deterministic journal and emits a source/restore/target-bound receipt
- pin the restore to run `42d8bbfaf1a2ce7759b2283384e8f41298fe3a354ba7c0e1756bb8a3e64af177`, 14 accounts, 906 transfers, cluster `222397790944575595450310052784555675227`, ledger 7001, and three ordinal pod DNS addresses
- reject multi-address, duplicate, or reordered replica resolution, mismatched existing TigerBeetle records, malformed evidence, incomplete qualification, count drift, target reconciliation drift, and unknown outcomes
- keep the running Bayn Deployment on the existing Torghut endpoint; this PR does not restore data or cut over runtime traffic

## Related Issues

Part of PROOMPT-399. Blocks PROOMPT-398 until the later restore and cutover receipts are complete.

## Testing

- `bun run --filter @proompteng/bayn test` — 139 passed, 25 PostgreSQL integration tests skipped without an isolated test database, 0 failed
- `bun test services/bayn/src/ledger.test.ts services/bayn/src/ledger-restore.test.ts` — 17 passed, 0 failed
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type` — exits 0; retains one pre-existing warning in `qualification-audit-command.ts`
- `bun run --filter @proompteng/bayn build` — emits `index.js` and `restore-ledger-command.js`
- `bun run lint:argocd` — 0 invalid resources and 0 errors
- `kustomize build argocd/applications/bayn | kubectl apply -n bayn --dry-run=server -f -`
- `crane digest ghcr.io/tigerbeetle/tigerbeetle:0.17.9` and raw manifest inspection — index digest matches the manifest and includes linux/amd64 plus linux/arm64
- read-only `kubectl cnpg psql` verification — the pinned run is COMPLETE/REJECTED with 17 artifacts, 740 events, 7 gates, and exact 14/906 reconciliation
- `nix build .#bayn-image --no-link -L` could not run locally because the host Nix daemon socket refused connections; image CI is a required merge gate

## Rollout and impact

- Argo reconciliation of this PR provisions three TigerBeetle pods and three retained 100 GiB `rook-ceph-block` PVCs. It does not change Bayn's configured endpoint or mutate either ledger.
- Current Rook Ceph health is `HEALTH_WARN` for `BLUESTORE_SLOW_OP_ALERT`. Do not execute the restore or cutover until Ceph is `HEALTH_OK`.
- Main must publish the immutable image before the GitOps restore Job can use this executable. The automatic application-promotion PR must not be merged: current source composes the unqualified risk-balanced-trend candidate, while the running Deployment must remain on its proven TSMOM image and pinned TSMOM qualification.
- No Torghut manifest, broker credential, broker request, strategy qualification, or capital authority changes.

## Breaking Changes

None. The running Bayn endpoint remains unchanged in this PR.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked in PROOMPT-399 and its attached implementation plan.