### PR TITLE
fix(hermes): authenticate agent GitHub tooling

### DIFF
--- a/argocd/applications/hermes/README.md
+++ b/argocd/applications/hermes/README.md
@@ -33,13 +33,17 @@ smoke test, manifest change, and normal CI/Codex review.
   the `hermes` ServiceAccount. Bootstrap writes a non-secret kubeconfig that follows the rotating projected token by file
   path rather than persisting token material.
 - The API key comes from `onepassword-infra` through External Secrets. No secret is committed to Git.
-- The `tuslagch` GitHub OAuth token is committed only as a namespace-scoped SealedSecret ciphertext. The gateway receives
-  it as `GH_TOKEN`/`GITHUB_TOKEN`; plaintext is not written to the PVC, Git config, or a rendered manifest.
+- The `tuslagch` GitHub OAuth token is committed only as a namespace-scoped SealedSecret ciphertext. Only the bootstrap init
+  container receives `GH_TOKEN`; it creates a mode-`0400` GitHub CLI auth file in a per-Pod `emptyDir` shared read-only with
+  the gateway. The pinned Hermes runtime intentionally strips `GH_TOKEN` and `GITHUB_TOKEN` from model-authored terminal
+  subprocesses, so environment-only authentication is insufficient. The token never enters the gateway environment, data
+  PVC, backups, Git config, or a rendered manifest.
 - GitHub token rotation must reseal `hermes-github-auth` and increment the StatefulSet's
-  `hermes.proompteng.ai/github-auth-revision` annotation so the environment-backed credential takes effect in a new Pod.
+  `hermes.proompteng.ai/github-auth-revision` annotation so the Secret-backed credential takes effect in a new Pod.
 - Bootstrap downloads GitHub CLI `2.96.0` from its official release, enforces SHA-256
   `83d5c2ccad5498f58bf6368acb1ab32588cf43ab3a4b1c301bf36328b1c8bd60`, caches the verified archive, and recreates the
-  `tuslagch` Git identity and `gh auth git-credential` helper on every start.
+  `tuslagch` Git identity, GitHub CLI authentication, and `gh auth git-credential` helper on every start. Bootstrap fails
+  closed unless `gh api user` returns `tuslagch` and repository permission is `ADMIN`.
 - API key rotation requires a bounded Secret refresh, gateway Pod restart, and old-key rejection/new-key acceptance proof.
 - The API is cluster-local and requires bearer authentication for model requests and detailed health.
 - Plugins, MCP servers, delegation, cron, hooks, and speech-to-text remain disabled. Terminal access is explicit for CLI,

--- a/argocd/applications/hermes/bootstrap-github.sh
+++ b/argocd/applications/hermes/bootstrap-github.sh
@@ -9,6 +9,9 @@ gh_archive_sha256=${GH_CLI_ARCHIVE_SHA256:-83d5c2ccad5498f58bf6368acb1ab32588cf4
 gh_archive_url=${GH_CLI_ARCHIVE_URL:-https://github.com/cli/cli/releases/download/v${gh_version}/${gh_archive_name}}
 gh_cache_dir=${GH_CLI_CACHE_DIR:-${HOME:?HOME is required}/.cache/hermes-tools}
 gh_install_path=${GH_CLI_INSTALL_PATH:-/opt/tools/gh}
+gh_config_dir=${GH_CONFIG_DIR:?GH_CONFIG_DIR is required}
+gh_hosts_path=${gh_config_dir}/hosts.yml
+gh_auth_stage_dir=${gh_config_dir}/.bootstrap.$$
 git_config_path=${HERMES_GIT_CONFIG_PATH:-${HOME}/.gitconfig}
 python_bin=${HERMES_PYTHON_BIN:-/opt/hermes/.venv/bin/python}
 archive_path=${gh_cache_dir}/${gh_archive_name}
@@ -35,7 +38,7 @@ fi
 
 cleanup() {
   rm -f -- "$archive_tmp" "$git_config_tmp"
-  rm -rf -- "$extract_dir"
+  rm -rf -- "$extract_dir" "$gh_auth_stage_dir"
 }
 trap cleanup EXIT HUP INT TERM
 
@@ -46,6 +49,17 @@ if [ ! -d "$gh_install_dir" ]; then
 fi
 if [ ! -w "$gh_install_dir" ]; then
   echo "GitHub CLI install directory is not writable: $gh_install_dir" >&2
+  exit 1
+fi
+if [ ! -d "$gh_config_dir" ]; then
+  install -d -m 0700 "$gh_config_dir"
+fi
+if [ ! -w "$gh_config_dir" ]; then
+  echo "GitHub CLI config directory is not writable: $gh_config_dir" >&2
+  exit 1
+fi
+if [ -z "${GH_TOKEN:-}" ]; then
+  echo 'GH_TOKEN is required for GitHub CLI bootstrap' >&2
   exit 1
 fi
 
@@ -106,6 +120,34 @@ PY
 install -m 0555 "$extract_dir/gh" "$gh_install_path"
 "$gh_install_path" --version | grep -F "gh version $gh_version" >/dev/null
 
+install -d -m 0700 "$gh_auth_stage_dir"
+printf '%s' "$GH_TOKEN" | env -u GH_TOKEN -u GITHUB_TOKEN \
+  GH_CONFIG_DIR="$gh_auth_stage_dir" GH_PROMPT_DISABLED=1 \
+  "$gh_install_path" auth login \
+    --hostname github.com \
+    --git-protocol https \
+    --with-token \
+    --insecure-storage
+if [ ! -s "$gh_auth_stage_dir/hosts.yml" ]; then
+  echo 'GitHub CLI did not create its authentication file' >&2
+  exit 1
+fi
+chmod 0400 "$gh_auth_stage_dir/hosts.yml"
+github_login=$(env -u GH_TOKEN -u GITHUB_TOKEN GH_CONFIG_DIR="$gh_auth_stage_dir" \
+  "$gh_install_path" api user --jq .login)
+if [ "$github_login" != tuslagch ]; then
+  echo "GitHub CLI authenticated as unexpected account: $github_login" >&2
+  exit 1
+fi
+github_permission=$(env -u GH_TOKEN -u GITHUB_TOKEN GH_CONFIG_DIR="$gh_auth_stage_dir" \
+  "$gh_install_path" repo view proompteng/lab --json viewerPermission --jq .viewerPermission)
+if [ "$github_permission" != ADMIN ]; then
+  echo "tuslagch lacks ADMIN permission on proompteng/lab: $github_permission" >&2
+  exit 1
+fi
+mv -f -- "$gh_auth_stage_dir/hosts.yml" "$gh_hosts_path"
+rmdir -- "$gh_auth_stage_dir"
+
 : >"$git_config_tmp"
 chmod 0600 "$git_config_tmp"
 git config --file "$git_config_tmp" user.name tuslagch
@@ -122,4 +164,4 @@ git config --file "$git_config_tmp" --add credential.https://gist.github.com.hel
 git config --file "$git_config_tmp" --add credential.https://gist.github.com.helper "!$gh_install_path auth git-credential"
 mv -- "$git_config_tmp" "$git_config_path"
 
-printf 'github_bootstrap_ready=true gh_version=%s git_user=tuslagch\n' "$gh_version"
+printf 'github_bootstrap_ready=true gh_version=%s git_user=tuslagch repo_permission=ADMIN\n' "$gh_version"

--- a/argocd/applications/hermes/statefulset.yaml
+++ b/argocd/applications/hermes/statefulset.yaml
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        hermes.proompteng.ai/github-auth-revision: "1"
+        hermes.proompteng.ai/github-auth-revision: "2"
       labels:
         app.kubernetes.io/name: hermes
         app.kubernetes.io/component: gateway
@@ -65,6 +65,15 @@ spec:
               value: /opt/data
             - name: HOME
               value: /opt/data/home
+            - name: GH_CONFIG_DIR
+              value: /opt/github-auth
+            - name: GH_PROMPT_DISABLED
+              value: "1"
+            - name: GH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-github-auth
+                  key: GH_TOKEN
             - name: KUBECONFIG
               value: /opt/data/home/.kube/config
             - name: GIT_TERMINAL_PROMPT
@@ -116,6 +125,8 @@ spec:
               readOnly: true
             - name: tools
               mountPath: /opt/tools
+            - name: github-auth
+              mountPath: /opt/github-auth
       containers:
         - name: hermes
           image: registry.ide-newton.ts.net/lab/hermes-agent@sha256:3db34ce19adfa080736a2a3feb0316dbcccc588faa9afe7fd8ae1c03b4f1a53a
@@ -141,21 +152,11 @@ spec:
             - name: XDG_CACHE_HOME
               value: /opt/data/home/.cache
             - name: GH_CONFIG_DIR
-              value: /opt/data/home/.config/gh
+              value: /opt/github-auth
             - name: GH_PROMPT_DISABLED
               value: "1"
             - name: GH_PAGER
               value: cat
-            - name: GH_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: hermes-github-auth
-                  key: GH_TOKEN
-            - name: GITHUB_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: hermes-github-auth
-                  key: GH_TOKEN
             - name: GIT_CONFIG_NOSYSTEM
               value: "1"
             - name: GIT_CONFIG_GLOBAL
@@ -285,6 +286,9 @@ spec:
             - name: tools
               mountPath: /opt/tools
               readOnly: true
+            - name: github-auth
+              mountPath: /opt/github-auth
+              readOnly: true
       volumes:
         - name: config
           configMap:
@@ -308,6 +312,9 @@ spec:
         - name: tools
           emptyDir:
             sizeLimit: 128Mi
+        - name: github-auth
+          emptyDir:
+            sizeLimit: 1Mi
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/docs/runbooks/hermes-production-rollout.md
+++ b/docs/runbooks/hermes-production-rollout.md
@@ -300,12 +300,14 @@ The expected mirrored amd64 manifest digest is
      set -eu
      test "$(command -v gh)" = /opt/tools/gh
      gh --version | grep -F "gh version 2.96.0"
-     test "$(gh api user --jq .login)" = tuslagch
-     test "$(gh repo view proompteng/lab --json viewerPermission --jq .viewerPermission)" = ADMIN
+     test "$(env -u GH_TOKEN -u GITHUB_TOKEN gh api user --jq .login)" = tuslagch
+     test "$(env -u GH_TOKEN -u GITHUB_TOKEN gh repo view proompteng/lab --json viewerPermission --jq .viewerPermission)" = ADMIN
      test "$(git config --global user.name)" = tuslagch
      test "$(git config --global user.email)" = 241203724+tuslagch@users.noreply.github.com
      git config --global --get-all credential.https://github.com.helper | grep -Fx "!/opt/tools/gh auth git-credential"
      ! grep -Eq "gh[opsu]_[A-Za-z0-9]+" /opt/data/home/.gitconfig
+     test -r /opt/github-auth/hosts.yml
+     test "$(stat -c %a /opt/github-auth/hosts.yml)" = 400
      test ! -e /opt/data/home/.config/gh/hosts.yml
      git ls-remote --exit-code origin refs/heads/main >/dev/null
      git push --dry-run origin HEAD:refs/heads/codex/hermes-github-auth-proof
@@ -314,8 +316,9 @@ The expected mirrored amd64 manifest digest is
 
    The dry run performs GitHub authentication and branch authorization without creating a remote ref. A real change must
    use a unique `codex/` branch, an explicitly requested push, and a pull request; force pushes and direct `main` pushes
-   remain forbidden. `GH_TOKEN`/`GITHUB_TOKEN` come only from `hermes-github-auth`, and neither `gh auth login` nor a
-   plaintext `hosts.yml` is part of the production bootstrap.
+   remain forbidden. Only the bootstrap init container receives `GH_TOKEN` from `hermes-github-auth`; it runs the documented
+   `gh auth login --with-token --insecure-storage` flow into a mode-`0400` per-Pod `emptyDir`. The gateway receives that
+   volume read-only and has no GitHub token environment variable. The auth file never enters the data PVC or Hermes backups.
 
 ## API key rotation
 

--- a/scripts/hermes/bootstrap-github.test.ts
+++ b/scripts/hermes/bootstrap-github.test.ts
@@ -41,21 +41,62 @@ test('installs a verified GitHub CLI archive and recreates deterministic Git con
   const archive = join(root, `${archiveRootName}.tar.gz`)
   const home = join(root, 'home')
   const tools = join(root, 'tools')
+  const ghConfigDir = join(root, 'github-auth')
   const cache = join(root, 'cache')
   const testTmp = join(root, 'tmp')
   const installedGh = join(tools, 'gh')
+  const ghHosts = join(ghConfigDir, 'hosts.yml')
   const gitConfig = join(home, '.gitconfig')
+  const testToken = 'test-token-value-with-sufficient-length'
 
   await Promise.all([
     mkdir(fakeGhDirectory, { recursive: true }),
     mkdir(home, { recursive: true }),
     mkdir(tools, { recursive: true }),
+    mkdir(ghConfigDir, { recursive: true }),
     mkdir(cache, { recursive: true }),
     mkdir(testTmp, { recursive: true }),
   ])
-  await writeFile(fakeGh, `#!/bin/sh\nprintf 'gh version ${version} (test)\\n'\n`)
+  await writeFile(
+    fakeGh,
+    `#!/bin/sh
+set -eu
+
+case "\${1:-}" in
+  --version)
+    printf 'gh version ${version} (test)\\n'
+    ;;
+  auth)
+    test "\${2:-}" = login
+    token=
+    IFS= read -r token || true
+    test "$token" = "$TEST_EXPECTED_GH_TOKEN"
+    mkdir -p "$GH_CONFIG_DIR"
+    printf 'github.com:\\n    user: tuslagch\\n    oauth_token: %s\\n    git_protocol: https\\n' "$token" >"$GH_CONFIG_DIR/hosts.yml"
+    ;;
+  api)
+    test "\${2:-}" = user
+    test -z "\${GH_TOKEN:-}"
+    test -z "\${GITHUB_TOKEN:-}"
+    grep -F "oauth_token: $TEST_EXPECTED_GH_TOKEN" "$GH_CONFIG_DIR/hosts.yml" >/dev/null
+    printf 'tuslagch\\n'
+    ;;
+  repo)
+    test "\${2:-}" = view
+    test -z "\${GH_TOKEN:-}"
+    test -z "\${GITHUB_TOKEN:-}"
+    grep -F "oauth_token: $TEST_EXPECTED_GH_TOKEN" "$GH_CONFIG_DIR/hosts.yml" >/dev/null
+    printf 'ADMIN\\n'
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+`,
+  )
   await chmod(fakeGh, 0o755)
   await chmod(tools, 0o775)
+  await chmod(ghConfigDir, 0o775)
   await run(['tar', '-czf', archive, '-C', sourceRoot, archiveRootName])
 
   const checksum = createHash('sha256')
@@ -70,18 +111,31 @@ test('installs a verified GitHub CLI archive and recreates deterministic Git con
     GH_CLI_CACHE_DIR: cache,
     GH_CLI_INSTALL_PATH: installedGh,
     GH_CLI_VERSION: version,
+    GH_CONFIG_DIR: ghConfigDir,
+    GH_TOKEN: testToken,
     HERMES_GIT_CONFIG_PATH: gitConfig,
     HERMES_PYTHON_BIN: python,
     HOME: home,
+    TEST_EXPECTED_GH_TOKEN: testToken,
     TMPDIR: testTmp,
   }
 
   expect(await run(['/bin/sh', bootstrapScript], environment)).toContain(
-    `github_bootstrap_ready=true gh_version=${version} git_user=tuslagch`,
+    `github_bootstrap_ready=true gh_version=${version} git_user=tuslagch repo_permission=ADMIN`,
   )
   expect((await stat(installedGh)).mode & 0o777).toBe(0o555)
   expect((await stat(tools)).mode & 0o777).toBe(0o775)
+  expect((await stat(ghConfigDir)).mode & 0o777).toBe(0o775)
+  expect((await stat(ghHosts)).mode & 0o777).toBe(0o400)
+  expect(await readFile(ghHosts, 'utf8')).toContain(`oauth_token: ${testToken}`)
   expect(await run([installedGh, '--version'])).toContain(`gh version ${version}`)
+  expect(
+    await run([installedGh, 'api', 'user', '--jq', '.login'], {
+      ...environment,
+      GITHUB_TOKEN: '',
+      GH_TOKEN: '',
+    }),
+  ).toBe('tuslagch\n')
   expect(await run(['git', 'config', '--file', gitConfig, 'user.name'])).toBe('tuslagch\n')
   expect(await run(['git', 'config', '--file', gitConfig, 'user.email'])).toBe(
     '241203724+tuslagch@users.noreply.github.com\n',

--- a/scripts/hermes/validate-production.test.ts
+++ b/scripts/hermes/validate-production.test.ts
@@ -155,7 +155,28 @@ test('rejects a GitHub token without a matching sealed SecretKeyRef', async () =
   files.statefulSet = files.statefulSet.replace('- name: GH_TOKEN\n', '- name: GH_TOKEN_DISABLED\n')
 
   expect(validateProductionContent(files)).toContain(
-    `${productionPaths.statefulSet}: GH_TOKEN must use the sealed hermes-github-auth GH_TOKEN`,
+    `${productionPaths.statefulSet}: only the bootstrap init container may receive the sealed GitHub token`,
+  )
+})
+
+test('rejects exposing the GitHub token in the gateway environment', async () => {
+  const files = await loadProductionFiles()
+  files.statefulSet = files.statefulSet.replace(
+    '            - name: GIT_CONFIG_NOSYSTEM\n',
+    '            - name: GITHUB_TOKEN\n              value: plaintext\n            - name: GIT_CONFIG_NOSYSTEM\n',
+  )
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.statefulSet}: contains forbidden production term "name: GITHUB_TOKEN"`,
+  )
+})
+
+test('rejects persisting GitHub CLI auth on the Hermes data volume', async () => {
+  const files = await loadProductionFiles()
+  files.statefulSet = files.statefulSet.replaceAll('/opt/github-auth', '/opt/data/home/.config/gh')
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.statefulSet}: contains forbidden production term "value: /opt/data/home/.config/gh"`,
   )
 })
 

--- a/scripts/hermes/validate-production.ts
+++ b/scripts/hermes/validate-production.ts
@@ -113,7 +113,7 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'whenDeleted: Retain',
     'whenScaled: Retain',
     'automountServiceAccountToken: true',
-    'hermes.proompteng.ai/github-auth-revision: "1"',
+    'hermes.proompteng.ai/github-auth-revision: "2"',
     'runAsUser: 10000',
     'runAsGroup: 10000',
     'readOnlyRootFilesystem: true',
@@ -129,14 +129,15 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     `reference: ${kubectlImage}`,
     'mountPath: /opt/kubectl-image',
     'mountPath: /opt/tools',
+    'mountPath: /opt/github-auth',
+    'sizeLimit: 1Mi',
     'value: /opt/tools:/opt/hermes/bin:',
     'name: KUBECONFIG',
     'value: /opt/data/home/.kube/config',
     'name: GH_CONFIG_DIR',
-    'value: /opt/data/home/.config/gh',
+    'value: /opt/github-auth',
     'name: GH_PROMPT_DISABLED',
     'name: GH_TOKEN',
-    'name: GITHUB_TOKEN',
     'name: GIT_CONFIG_NOSYSTEM',
     'name: GIT_CONFIG_GLOBAL',
     'value: /opt/data/home/.gitconfig',
@@ -155,6 +156,8 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     '        - name: backup\n',
     'value: gho_',
     'value: github_pat_',
+    'name: GITHUB_TOKEN',
+    'value: /opt/data/home/.config/gh',
   ])
   if (count(files.statefulSet, `reference: ${kubectlImage}`) !== 1) {
     failures.push(`${productionPaths.statefulSet}: kubectl must use exactly one immutable Kubernetes 1.35 OCI volume`)
@@ -177,21 +180,32 @@ export function validateProductionContent(files: ProductionFiles): string[] {
       )
     }
   }
-  for (const key of ['GH_TOKEN', 'GITHUB_TOKEN']) {
-    const reference = [
-      `            - name: ${key}`,
-      '              valueFrom:',
-      '                secretKeyRef:',
-      '                  name: hermes-github-auth',
-      '                  key: GH_TOKEN',
-    ].join('\n')
-    if (count(files.statefulSet, `            - name: ${key}\n`) !== 1 || count(files.statefulSet, reference) !== 1) {
-      failures.push(`${productionPaths.statefulSet}: ${key} must use the sealed hermes-github-auth GH_TOKEN`)
-    }
+  const githubTokenReference = [
+    '            - name: GH_TOKEN',
+    '              valueFrom:',
+    '                secretKeyRef:',
+    '                  name: hermes-github-auth',
+    '                  key: GH_TOKEN',
+  ].join('\n')
+  if (
+    count(files.statefulSet, '            - name: GH_TOKEN\n') !== 1 ||
+    count(files.statefulSet, githubTokenReference) !== 1 ||
+    count(files.statefulSet, '                  key: GH_TOKEN\n') !== 1
+  ) {
+    failures.push(
+      `${productionPaths.statefulSet}: only the bootstrap init container may receive the sealed GitHub token`,
+    )
   }
-  if (count(files.statefulSet, '                  key: GH_TOKEN\n') !== 2) {
-    failures.push(`${productionPaths.statefulSet}: exactly two GitHub token environment references are required`)
+  if (count(files.statefulSet, '            - name: GH_CONFIG_DIR\n') !== 2) {
+    failures.push(`${productionPaths.statefulSet}: init and gateway must share exactly one GitHub CLI config directory`)
   }
+  if (count(files.statefulSet, 'name: github-auth\n') !== 3) {
+    failures.push(`${productionPaths.statefulSet}: GitHub auth must use two mounts and one ephemeral volume`)
+  }
+  requireTerms(failures, productionPaths.statefulSet, files.statefulSet, [
+    '            - name: github-auth\n              mountPath: /opt/github-auth\n              readOnly: true',
+    '        - name: github-auth\n          emptyDir:\n            sizeLimit: 1Mi',
+  ])
 
   if (count(files.backupCronJob, `image: ${hermesImage}`) !== 1) {
     failures.push(`${productionPaths.backupCronJob}: backup must use the immutable mirrored Hermes digest`)
@@ -509,20 +523,20 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'install -m 0555 "$extract_dir/gh" "$gh_install_path"',
     'if [ ! -d "$gh_install_dir" ]; then',
     'if [ ! -w "$gh_install_dir" ]; then',
+    'if [ ! -w "$gh_config_dir" ]; then',
     'git config --file "$git_config_tmp" user.name tuslagch',
     'git config --file "$git_config_tmp" user.email 241203724+tuslagch@users.noreply.github.com',
     'git config --file "$git_config_tmp" commit.gpgsign false',
     '"!$gh_install_path auth git-credential"',
+    'env -u GH_TOKEN -u GITHUB_TOKEN',
+    '--with-token',
+    '--insecure-storage',
+    'chmod 0400 "$gh_auth_stage_dir/hosts.yml"',
+    'if [ "$github_login" != tuslagch ]; then',
+    'if [ "$github_permission" != ADMIN ]; then',
     'github_bootstrap_ready=true',
   ])
-  forbidTerms(failures, productionPaths.githubBootstrap, files.githubBootstrap, [
-    'gh auth login',
-    'GH_TOKEN',
-    'GITHUB_TOKEN',
-    'curl ',
-    'wget ',
-    ':latest',
-  ])
+  forbidTerms(failures, productionPaths.githubBootstrap, files.githubBootstrap, ['curl ', 'wget ', ':latest'])
   requireTerms(failures, productionPaths.workspaceAgents, files.workspaceAgents, [
     'Kubernetes access is cluster-wide read-only.',
     'Kubernetes Secrets and service-account token subresources are outside your authority.',
@@ -540,8 +554,10 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'digest-pinned Kubernetes 1.35 `kubectl` binary',
     'only `get`, `list`, and `watch`',
     '`tuslagch` GitHub OAuth token is committed only as a namespace-scoped SealedSecret ciphertext',
+    'intentionally strips `GH_TOKEN` and `GITHUB_TOKEN` from model-authored terminal',
     '`hermes.proompteng.ai/github-auth-revision` annotation',
     'GitHub CLI `2.96.0`',
+    'per-Pod `emptyDir`',
     githubCliArchiveSha256,
   ])
 
@@ -818,10 +834,12 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'git -C /opt/data/workspace/tuslagch/lab cat-file -e HEAD:AGENTS.md',
     'test "$(command -v gh)" = /opt/tools/gh',
     'gh --version | grep -F "gh version 2.96.0"',
-    'test "$(gh api user --jq .login)" = tuslagch',
-    'test "$(gh repo view proompteng/lab --json viewerPermission --jq .viewerPermission)" = ADMIN',
+    'test "$(env -u GH_TOKEN -u GITHUB_TOKEN gh api user --jq .login)" = tuslagch',
+    'test "$(env -u GH_TOKEN -u GITHUB_TOKEN gh repo view proompteng/lab --json viewerPermission --jq .viewerPermission)" = ADMIN',
     'git config --global --get-all credential.https://github.com.helper',
     '! grep -Eq "gh[opsu]_[A-Za-z0-9]+" /opt/data/home/.gitconfig',
+    'test -r /opt/github-auth/hosts.yml',
+    'test "$(stat -c %a /opt/github-auth/hosts.yml)" = 400',
     'test ! -e /opt/data/home/.config/gh/hosts.yml',
     'git push --dry-run origin HEAD:refs/heads/codex/hermes-github-auth-proof',
     'gateway service-account identity, allowed cluster-wide reads, rejected Secret reads and writes, and the lab checkout SHA',


### PR DESCRIPTION
## Summary

- persist Tuslagch GitHub CLI authentication in a mode-`0400` per-Pod `emptyDir` because Hermes strips token environment variables from terminal subprocesses
- expose the auth volume read-only to the gateway while limiting the SealedSecret environment reference to the bootstrap init container
- fail bootstrap unless the authenticated account is `tuslagch` with `ADMIN` permission on `proompteng/lab`
- add regression coverage and update production validation and rollout evidence

## Related Issues

None

## Testing

- `bun test scripts/hermes/*.test.ts` (111 pass)
- `bun run scripts/hermes/validate-production.ts` (38 surfaces)
- `shellcheck argocd/applications/hermes/*.sh`
- `bunx oxfmt --check scripts/hermes/bootstrap-github.test.ts scripts/hermes/validate-production.ts scripts/hermes/validate-production.test.ts`
- `bun run lint:argocd`
- focused kubeconform validation (16 valid, 0 invalid, 3 skipped CRDs)
- server-side dry-run with `argocd-controller` field manager
- live official `gh auth login --with-token --insecure-storage` contract test followed by authenticated API and repository-permission checks with `GH_TOKEN` and `GITHUB_TOKEN` removed

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section is not applicable and was removed.
- [x] Breaking Changes is filled in.
- [x] Documentation, release notes, and follow-ups are updated or tracked.