### PR TITLE
fix(hermes): make GitHub auth bootstrap retry-safe

### DIFF
--- a/argocd/applications/hermes/README.md
+++ b/argocd/applications/hermes/README.md
@@ -34,7 +34,7 @@ smoke test, manifest change, and normal CI/Codex review.
   path rather than persisting token material.
 - The API key comes from `onepassword-infra` through External Secrets. No secret is committed to Git.
 - The `tuslagch` GitHub OAuth token is committed only as a namespace-scoped SealedSecret ciphertext. Only the bootstrap init
-  container receives `GH_TOKEN`; it creates a mode-`0400` GitHub CLI auth file in a per-Pod `emptyDir` shared read-only with
+  container receives `GH_TOKEN`; it creates a mode-`0600` GitHub CLI auth file in a per-Pod `emptyDir` shared read-only with
   the gateway. The pinned Hermes runtime intentionally strips `GH_TOKEN` and `GITHUB_TOKEN` from model-authored terminal
   subprocesses, so environment-only authentication is insufficient. The token never enters the gateway environment, data
   PVC, backups, Git config, or a rendered manifest.

--- a/argocd/applications/hermes/bootstrap-github.sh
+++ b/argocd/applications/hermes/bootstrap-github.sh
@@ -62,6 +62,10 @@ if [ -z "${GH_TOKEN:-}" ]; then
   echo 'GH_TOKEN is required for GitHub CLI bootstrap' >&2
   exit 1
 fi
+# This volume is per-Pod and the gateway has not started yet. Clear any file
+# left by a failed init attempt so GitHub CLI never tries to migrate a
+# partially initialized or read-only auth file on retry.
+rm -f -- "$gh_hosts_path"
 
 archive_is_valid() {
   [ -f "$archive_path" ] && printf '%s  %s\n' "$gh_archive_sha256" "$archive_path" | sha256sum -c - >/dev/null 2>&1
@@ -132,7 +136,7 @@ if [ ! -s "$gh_auth_stage_dir/hosts.yml" ]; then
   echo 'GitHub CLI did not create its authentication file' >&2
   exit 1
 fi
-chmod 0400 "$gh_auth_stage_dir/hosts.yml"
+chmod 0600 "$gh_auth_stage_dir/hosts.yml"
 github_login=$(env -u GH_TOKEN -u GITHUB_TOKEN GH_CONFIG_DIR="$gh_auth_stage_dir" \
   "$gh_install_path" api user --jq .login)
 if [ "$github_login" != tuslagch ]; then

--- a/argocd/applications/hermes/bootstrap.sh
+++ b/argocd/applications/hermes/bootstrap.sh
@@ -47,7 +47,6 @@ chmod 0600 "$kubeconfig_tmp"
 mv -- "$kubeconfig_tmp" "$kubeconfig_path"
 
 /bin/sh /opt/bootstrap/bootstrap-lab-checkout.sh
-/bin/sh /opt/bootstrap/bootstrap-github.sh
 
 seed_file() {
   source_path=$1
@@ -60,3 +59,4 @@ seed_file() {
 seed_file /opt/bootstrap/USER.md /opt/data/memories/USER.md
 
 /opt/hermes/.venv/bin/hermes config check >/tmp/hermes-config-check.log
+/bin/sh /opt/bootstrap/bootstrap-github.sh

--- a/docs/runbooks/hermes-production-rollout.md
+++ b/docs/runbooks/hermes-production-rollout.md
@@ -307,7 +307,7 @@ The expected mirrored amd64 manifest digest is
      git config --global --get-all credential.https://github.com.helper | grep -Fx "!/opt/tools/gh auth git-credential"
      ! grep -Eq "gh[opsu]_[A-Za-z0-9]+" /opt/data/home/.gitconfig
      test -r /opt/github-auth/hosts.yml
-     test "$(stat -c %a /opt/github-auth/hosts.yml)" = 400
+     test "$(stat -c %a /opt/github-auth/hosts.yml)" = 600
      test ! -e /opt/data/home/.config/gh/hosts.yml
      git ls-remote --exit-code origin refs/heads/main >/dev/null
      git push --dry-run origin HEAD:refs/heads/codex/hermes-github-auth-proof
@@ -317,7 +317,7 @@ The expected mirrored amd64 manifest digest is
    The dry run performs GitHub authentication and branch authorization without creating a remote ref. A real change must
    use a unique `codex/` branch, an explicitly requested push, and a pull request; force pushes and direct `main` pushes
    remain forbidden. Only the bootstrap init container receives `GH_TOKEN` from `hermes-github-auth`; it runs the documented
-   `gh auth login --with-token --insecure-storage` flow into a mode-`0400` per-Pod `emptyDir`. The gateway receives that
+   `gh auth login --with-token --insecure-storage` flow into a mode-`0600` per-Pod `emptyDir`. The gateway receives that
    volume read-only and has no GitHub token environment variable. The auth file never enters the data PVC or Hermes backups.
 
 ## API key rotation

--- a/scripts/hermes/bootstrap-github.test.ts
+++ b/scripts/hermes/bootstrap-github.test.ts
@@ -64,6 +64,9 @@ set -eu
 
 case "\${1:-}" in
   --version)
+    if [ -e "\${GH_CONFIG_DIR:-}/hosts.yml" ]; then
+      printf '\\n' >>"$GH_CONFIG_DIR/hosts.yml"
+    fi
     printf 'gh version ${version} (test)\\n'
     ;;
   auth)
@@ -126,7 +129,7 @@ esac
   expect((await stat(installedGh)).mode & 0o777).toBe(0o555)
   expect((await stat(tools)).mode & 0o777).toBe(0o775)
   expect((await stat(ghConfigDir)).mode & 0o777).toBe(0o775)
-  expect((await stat(ghHosts)).mode & 0o777).toBe(0o400)
+  expect((await stat(ghHosts)).mode & 0o777).toBe(0o600)
   expect(await readFile(ghHosts, 'utf8')).toContain(`oauth_token: ${testToken}`)
   expect(await run([installedGh, '--version'])).toContain(`gh version ${version}`)
   expect(
@@ -146,6 +149,7 @@ esac
   ).toContain(`!${installedGh} auth git-credential`)
   expect(await readFile(gitConfig, 'utf8')).not.toMatch(/gh[opsu]_[A-Za-z0-9]+/)
 
+  await chmod(ghHosts, 0o400)
   await chmod(installedGh, 0o755)
   await writeFile(installedGh, 'corrupt')
   await run(['/bin/sh', bootstrapScript], environment)

--- a/scripts/hermes/validate-production.test.ts
+++ b/scripts/hermes/validate-production.test.ts
@@ -99,6 +99,18 @@ test('rejects persisting a service-account token in the kubeconfig', async () =>
   )
 })
 
+test('rejects touching GitHub auth after the final bootstrap step', async () => {
+  const files = await loadProductionFiles()
+  files.bootstrap = files.bootstrap.replace(
+    '/opt/hermes/.venv/bin/hermes config check >/tmp/hermes-config-check.log\n/bin/sh /opt/bootstrap/bootstrap-github.sh',
+    '/bin/sh /opt/bootstrap/bootstrap-github.sh\n/opt/hermes/.venv/bin/hermes config check >/tmp/hermes-config-check.log',
+  )
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.bootstrap}: GitHub auth must be the final bootstrap step`,
+  )
+})
+
 test('rejects a mutable Hermes runtime image', async () => {
   const files = await loadProductionFiles()
   files.statefulSet = files.statefulSet.replace(

--- a/scripts/hermes/validate-production.ts
+++ b/scripts/hermes/validate-production.ts
@@ -498,6 +498,13 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'token: $(cat',
     'certificate-authority-data:',
   ])
+  const configCheckPosition = files.bootstrap.indexOf(
+    '/opt/hermes/.venv/bin/hermes config check >/tmp/hermes-config-check.log',
+  )
+  const githubBootstrapPosition = files.bootstrap.indexOf('/bin/sh /opt/bootstrap/bootstrap-github.sh')
+  if (configCheckPosition < 0 || githubBootstrapPosition <= configCheckPosition) {
+    failures.push(`${productionPaths.bootstrap}: GitHub auth must be the final bootstrap step`)
+  }
   requireTerms(failures, productionPaths.labCheckout, files.labCheckout, [
     'set -eu',
     'GIT_TERMINAL_PROMPT',
@@ -524,6 +531,7 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'if [ ! -d "$gh_install_dir" ]; then',
     'if [ ! -w "$gh_install_dir" ]; then',
     'if [ ! -w "$gh_config_dir" ]; then',
+    'rm -f -- "$gh_hosts_path"',
     'git config --file "$git_config_tmp" user.name tuslagch',
     'git config --file "$git_config_tmp" user.email 241203724+tuslagch@users.noreply.github.com',
     'git config --file "$git_config_tmp" commit.gpgsign false',
@@ -531,7 +539,7 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'env -u GH_TOKEN -u GITHUB_TOKEN',
     '--with-token',
     '--insecure-storage',
-    'chmod 0400 "$gh_auth_stage_dir/hosts.yml"',
+    'chmod 0600 "$gh_auth_stage_dir/hosts.yml"',
     'if [ "$github_login" != tuslagch ]; then',
     'if [ "$github_permission" != ADMIN ]; then',
     'github_bootstrap_ready=true',
@@ -839,7 +847,7 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'git config --global --get-all credential.https://github.com.helper',
     '! grep -Eq "gh[opsu]_[A-Za-z0-9]+" /opt/data/home/.gitconfig',
     'test -r /opt/github-auth/hosts.yml',
-    'test "$(stat -c %a /opt/github-auth/hosts.yml)" = 400',
+    'test "$(stat -c %a /opt/github-auth/hosts.yml)" = 600',
     'test ! -e /opt/data/home/.config/gh/hosts.yml',
     'git push --dry-run origin HEAD:refs/heads/codex/hermes-github-auth-proof',
     'gateway service-account identity, allowed cluster-wide reads, rejected Secret reads and writes, and the lab checkout SHA',


### PR DESCRIPTION
## Summary

- make the ephemeral GitHub CLI auth file mode `0600` while init is active; the gateway still mounts the volume read-only
- run GitHub auth as the final init step so later bootstrap validation cannot trigger a config migration
- clear auth left by a failed init attempt before retrying
- add regressions for retrying with an existing read-only auth file and for bootstrap ordering

## Related Issues

None

## Testing

- `bun test scripts/hermes/*.test.ts` (112 pass after the added regression)
- `bun run scripts/hermes/validate-production.ts` (38 surfaces)
- `shellcheck argocd/applications/hermes/*.sh`
- `bunx oxfmt --check scripts/hermes/bootstrap-github.test.ts scripts/hermes/validate-production.ts scripts/hermes/validate-production.test.ts`
- `bun run lint:argocd`
- focused server-side Kubernetes dry-run with `argocd-controller` field manager
- production rollout attempt reproduced the GitHub CLI migration failure; Hermes was immediately restored to healthy revision `b34cedec335120d0ccbaf4e437becc6346ca7ae6`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section is not applicable and was removed.
- [x] Breaking Changes is filled in.
- [x] Documentation, release notes, and follow-ups are updated or tracked.