### PR TITLE
fix(hermes): clean GitHub auth staging files

### DIFF
--- a/argocd/applications/hermes/bootstrap-github.sh
+++ b/argocd/applications/hermes/bootstrap-github.sh
@@ -150,7 +150,7 @@ if [ "$github_permission" != ADMIN ]; then
   exit 1
 fi
 mv -f -- "$gh_auth_stage_dir/hosts.yml" "$gh_hosts_path"
-rmdir -- "$gh_auth_stage_dir"
+rm -rf -- "$gh_auth_stage_dir"
 
 : >"$git_config_tmp"
 chmod 0600 "$git_config_tmp"

--- a/scripts/hermes/bootstrap-github.test.ts
+++ b/scripts/hermes/bootstrap-github.test.ts
@@ -76,6 +76,7 @@ case "\${1:-}" in
     test "$token" = "$TEST_EXPECTED_GH_TOKEN"
     mkdir -p "$GH_CONFIG_DIR"
     printf 'github.com:\\n    user: tuslagch\\n    oauth_token: %s\\n    git_protocol: https\\n' "$token" >"$GH_CONFIG_DIR/hosts.yml"
+    printf 'git_protocol: https\\n' >"$GH_CONFIG_DIR/config.yml"
     ;;
   api)
     test "\${2:-}" = user

--- a/scripts/hermes/validate-production.ts
+++ b/scripts/hermes/validate-production.ts
@@ -542,9 +542,15 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'chmod 0600 "$gh_auth_stage_dir/hosts.yml"',
     'if [ "$github_login" != tuslagch ]; then',
     'if [ "$github_permission" != ADMIN ]; then',
+    'rm -rf -- "$gh_auth_stage_dir"',
     'github_bootstrap_ready=true',
   ])
-  forbidTerms(failures, productionPaths.githubBootstrap, files.githubBootstrap, ['curl ', 'wget ', ':latest'])
+  forbidTerms(failures, productionPaths.githubBootstrap, files.githubBootstrap, [
+    'rmdir -- "$gh_auth_stage_dir"',
+    'curl ',
+    'wget ',
+    ':latest',
+  ])
   requireTerms(failures, productionPaths.workspaceAgents, files.workspaceAgents, [
     'Kubernetes access is cluster-wide read-only.',
     'Kubernetes Secrets and service-account token subresources are outside your authority.',


### PR DESCRIPTION
## Summary

- remove the exact GitHub CLI staging directory after moving `hosts.yml` instead of requiring it to be empty
- model the additional `config.yml` written by official `gh auth login` in the bootstrap regression
- reject reintroducing the incompatible `rmdir` behavior in production validation

## Related Issues

None

## Testing

- `bun test scripts/hermes/bootstrap-github.test.ts scripts/hermes/validate-production.test.ts` (100 pass)
- `bun run scripts/hermes/validate-production.ts` (38 surfaces)
- `shellcheck argocd/applications/hermes/bootstrap-github.sh`
- `bunx oxfmt --check scripts/hermes/bootstrap-github.test.ts scripts/hermes/validate-production.ts`
- `bun run lint:argocd`
- focused server-side Kubernetes dry-run with `argocd-controller` field manager
- production rollout reproduced the official GitHub CLI extra staging file; Hermes was immediately restored to healthy revision `b34cedec335120d0ccbaf4e437becc6346ca7ae6`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section is not applicable and was removed.
- [x] Breaking Changes is filled in.
- [x] Documentation, release notes, and follow-ups are updated or tracked.