### PR TITLE
feat(bayn): restore pinned ledger to dedicated cluster

### DIFF
--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -14,6 +14,8 @@ resources:
   - postgres-m1-restore-proof-networkpolicy.yaml
   - tigerbeetle-cluster.yaml
   - tigerbeetle-networkpolicy.yaml
+  - ledger-restore-job.yaml
+  - ledger-restore-networkpolicy.yaml
   - deployment.yaml
   - service.yaml
   - networkpolicy.yaml
@@ -26,3 +28,7 @@ images:
     newName: registry.ide-newton.ts.net/lab/bayn
     newTag: "sha-05e08fabbca2cbef071125e364814bcb23ba364b"
     digest: sha256:a838caa7f7426cabfe2d1a8ffcf1f60e938fdd13dce3910a7ff8c853baa3ae89
+  - name: bayn-ledger-restore
+    newName: registry.ide-newton.ts.net/lab/bayn
+    newTag: "sha-09f332cc5048dd8454bafafe1e2ca01e8939524a"
+    digest: sha256:17f73fb9a5665da7f44ba7539983f7a40784d945585aa7b691e700b19092b8f2

--- a/argocd/applications/bayn/ledger-restore-job.yaml
+++ b/argocd/applications/bayn/ledger-restore-job.yaml
@@ -1,0 +1,105 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: bayn-ledger-restore-09f332cc
+  labels:
+    app.kubernetes.io/name: bayn-ledger-restore
+    app.kubernetes.io/part-of: bayn
+    app.kubernetes.io/component: ledger-restore
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: 300
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bayn-ledger-restore
+        app.kubernetes.io/part-of: bayn
+        app.kubernetes.io/component: ledger-restore
+    spec:
+      serviceAccountName: bayn
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      restartPolicy: Never
+      terminationGracePeriodSeconds: 30
+      nodeSelector:
+        kubernetes.io/arch: arm64
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: restore
+          image: bayn-ledger-restore
+          imagePullPolicy: IfNotPresent
+          command:
+            - node
+            - dist/restore-ledger-command.js
+          env:
+            - name: BAYN_LEDGER_RESTORE_RUN_ID
+              value: 42d8bbfaf1a2ce7759b2283384e8f41298fe3a354ba7c0e1756bb8a3e64af177
+            - name: BAYN_LEDGER_RESTORE_EXPECTED_ACCOUNT_COUNT
+              value: "14"
+            - name: BAYN_LEDGER_RESTORE_EXPECTED_TRANSFER_COUNT
+              value: "906"
+            - name: BAYN_OPERATION_TIMEOUT_MS
+              value: "30000"
+            - name: BAYN_CODE_REVISION
+              value: 09f332cc5048dd8454bafafe1e2ca01e8939524a
+            - name: BAYN_IMAGE_REPOSITORY
+              value: registry.ide-newton.ts.net/lab/bayn
+            - name: BAYN_IMAGE_DIGEST
+              value: sha256:17f73fb9a5665da7f44ba7539983f7a40784d945585aa7b691e700b19092b8f2
+            - name: BAYN_POSTGRES_URL
+              valueFrom:
+                secretKeyRef:
+                  name: bayn-db-app
+                  key: fqdn-uri
+            - name: BAYN_POSTGRES_TLS
+              value: "true"
+            - name: BAYN_POSTGRES_CA_PATH
+              value: /var/run/secrets/bayn/postgres/ca.crt
+            - name: BAYN_TIGERBEETLE_CLUSTER_ID
+              value: "222397790944575595450310052784555675227"
+            - name: BAYN_TIGERBEETLE_ADDRESSES
+              value: "bayn-tigerbeetle-0.bayn-tigerbeetle-headless.bayn.svc.cluster.local:3000,bayn-tigerbeetle-1.bayn-tigerbeetle-headless.bayn.svc.cluster.local:3000,bayn-tigerbeetle-2.bayn-tigerbeetle-headless.bayn.svc.cluster.local:3000"
+            - name: BAYN_TIGERBEETLE_LEDGER
+              value: "7001"
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: "2"
+              memory: 1Gi
+          securityContext:
+            seccompProfile:
+              type: Unconfined
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: postgres-ca
+              mountPath: /var/run/secrets/bayn/postgres
+              readOnly: true
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 256Mi
+        - name: postgres-ca
+          secret:
+            secretName: bayn-db-ca
+            defaultMode: 0444
+            items:
+              - key: ca.crt
+                path: ca.crt

--- a/argocd/applications/bayn/ledger-restore-networkpolicy.yaml
+++ b/argocd/applications/bayn/ledger-restore-networkpolicy.yaml
@@ -1,0 +1,40 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: bayn-ledger-restore
+  labels:
+    app.kubernetes.io/name: bayn-ledger-restore
+    app.kubernetes.io/part-of: bayn
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: bayn-ledger-restore
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    - to:
+        - podSelector:
+            matchLabels:
+              cnpg.io/cluster: bayn-db
+      ports:
+        - port: 5432
+          protocol: TCP
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: bayn-tigerbeetle
+      ports:
+        - port: 3000
+          protocol: TCP

--- a/argocd/applications/bayn/networkpolicy.yaml
+++ b/argocd/applications/bayn/networkpolicy.yaml
@@ -90,6 +90,13 @@ spec:
     - from:
         - podSelector:
             matchLabels:
+              app.kubernetes.io/name: bayn-ledger-restore
+      ports:
+        - port: 5432
+          protocol: TCP
+    - from:
+        - podSelector:
+            matchLabels:
               cnpg.io/cluster: bayn-db
       ports:
         - port: 5432

--- a/argocd/applications/bayn/tigerbeetle-networkpolicy.yaml
+++ b/argocd/applications/bayn/tigerbeetle-networkpolicy.yaml
@@ -18,6 +18,9 @@ spec:
               app.kubernetes.io/name: bayn
         - podSelector:
             matchLabels:
+              app.kubernetes.io/name: bayn-ledger-restore
+        - podSelector:
+            matchLabels:
               app.kubernetes.io/instance: bayn-tigerbeetle
         - namespaceSelector:
             matchLabels:


### PR DESCRIPTION
## Summary

- add one GitOps-owned, zero-retry Job pinned to Bayn image `sha256:17f73fb9a5665da7f44ba7539983f7a40784d945585aa7b691e700b19092b8f2` and source `09f332cc5048dd8454bafafe1e2ca01e8939524a`
- bind execution to the single approved run, exact 14-account/906-transfer contract, immutable dedicated cluster ID, ledger 7001, and replica-index-ordered ordinal addresses
- give the Job a dedicated identity and least-privilege DNS/PostgreSQL/TigerBeetle policy; it receives no ClickHouse or broker configuration
- leave the running Bayn Deployment on its proven TSMOM image and Torghut TigerBeetle endpoint

## Related Issues

Part of PROOMPT-399. The issue remains open until restore evidence and the separate endpoint-only cutover are complete.

## Testing

- `kustomize build argocd/applications/bayn` — rendered the Job with the immutable restore image while preserving the Deployment's existing image and endpoint
- `kustomize build argocd/applications/bayn | kubectl apply -n bayn --dry-run=server -f -`
- `bun run lint:argocd` — 0 invalid resources and 0 errors
- explicit render assertions verified the exact Job digest, ordered target addresses, old Deployment digest/endpoint, and absence of ClickHouse, broker, or Alpaca inputs
- `git diff --check`

## Rollout and impact

- This PR is intentionally draft. Merging it creates and runs `bayn-ledger-restore-09f332cc` exactly once; do not mark ready or merge while Rook Ceph reports `HEALTH_WARN`.
- Before merge, capture PostgreSQL evidence hashes/counts, prove the new target ledger is empty, and re-prove old Torghut counts. After execution, require the machine-readable restore receipt and an independent exact 14/906 query before any cutover.
- The automatic Bayn application-promotion PR #13007 must remain unmerged. This Job uses the new image only as an operator command; the unqualified risk-balanced-trend runtime is not promoted or deployed.
- `backoffLimit: 0` preserves an unknown outcome for explicit inspection. Any rerun requires a reviewed Job-name change after proving idempotent safety.

## Breaking Changes

None. The running Bayn Deployment is unchanged.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are tracked in PROOMPT-399 and its implementation plan.
