### PR TITLE
fix(hermes): retry checkout network startup

### DIFF
--- a/argocd/applications/hermes/README.md
+++ b/argocd/applications/hermes/README.md
@@ -50,9 +50,10 @@ smoke test, manifest change, and normal CI/Codex review.
   authenticated API, and Discord sessions; manual approvals and unconditional deny rules remain enabled.
 - Only `/opt/data/workspace/tuslagch`, Hermes-managed memory, and Hermes-managed skills are writable agent surfaces.
 - Bootstrap maintains `proompteng/lab` at `/opt/data/workspace/tuslagch/lab`. Initial clone and clean-main refresh remain
-  credential-free; interactive runtime Git and GitHub CLI operations use the sealed `tuslagch` identity. Clean `main`
-  checkouts fast-forward on restart; dirty worktrees and non-main branches are preserved. Both the gateway's documented
-  `terminal.cwd` and the container working directory point at this repository root.
+  credential-free and use bounded retries for transient pod-network startup races; interactive runtime Git and GitHub CLI
+  operations use the sealed `tuslagch` identity. Clean `main` checkouts fast-forward on restart; dirty worktrees and non-main
+  branches are preserved. Both the gateway's documented `terminal.cwd` and the container working directory point at this
+  repository root.
 
 ## State and recovery
 

--- a/argocd/applications/hermes/bootstrap-lab-checkout.sh
+++ b/argocd/applications/hermes/bootstrap-lab-checkout.sh
@@ -10,10 +10,24 @@ repository_url=${LAB_REPOSITORY_URL:-https://github.com/proompteng/lab.git}
 checkout_ref=${LAB_CHECKOUT_REF:-main}
 checkout_dir=${LAB_CHECKOUT_DIR:-/opt/data/workspace/tuslagch/lab}
 revision_file=${LAB_CHECKOUT_REVISION_FILE:-/opt/data/workspace/tuslagch/.lab-source-revision}
+retry_attempts=${LAB_CHECKOUT_RETRY_ATTEMPTS:-5}
+retry_delay_seconds=${LAB_CHECKOUT_RETRY_DELAY_SECONDS:-2}
 
 case "$checkout_ref" in
   ''|*[!A-Za-z0-9._/-]*)
     echo "invalid lab checkout ref: $checkout_ref" >&2
+    exit 1
+    ;;
+esac
+case "$retry_attempts" in
+  ''|*[!0-9]*|0)
+    echo "invalid lab checkout retry attempts: $retry_attempts" >&2
+    exit 1
+    ;;
+esac
+case "$retry_delay_seconds" in
+  ''|*[!0-9]*)
+    echo "invalid lab checkout retry delay: $retry_delay_seconds" >&2
     exit 1
     ;;
 esac
@@ -25,19 +39,43 @@ fi
 
 mkdir -p "$(dirname "$checkout_dir")" "$(dirname "$revision_file")"
 
+retry_checkout_command() {
+  operation=$1
+  shift
+  attempt=1
+  while [ "$attempt" -le "$retry_attempts" ]; do
+    if "$@"; then
+      return 0
+    fi
+    if [ "$attempt" -lt "$retry_attempts" ]; then
+      echo "warning: lab checkout $operation attempt $attempt/$retry_attempts failed; retrying in ${retry_delay_seconds}s" >&2
+      sleep "$retry_delay_seconds"
+    fi
+    attempt=$((attempt + 1))
+  done
+  return 1
+}
+
 if [ ! -e "$checkout_dir" ]; then
   staging_dir="${checkout_dir}.clone.$$"
   cleanup_staging() {
     rm -rf -- "$staging_dir"
   }
   trap cleanup_staging EXIT HUP INT TERM
-  git -c protocol.version=2 clone \
-    --filter=blob:none \
-    --no-tags \
-    --single-branch \
-    --branch "$checkout_ref" \
-    "$repository_url" \
-    "$staging_dir"
+  clone_checkout() {
+    rm -rf -- "$staging_dir"
+    git -c protocol.version=2 clone \
+      --filter=blob:none \
+      --no-tags \
+      --single-branch \
+      --branch "$checkout_ref" \
+      "$repository_url" \
+      "$staging_dir"
+  }
+  if ! retry_checkout_command clone clone_checkout; then
+    echo "could not clone lab checkout after $retry_attempts attempts" >&2
+    exit 1
+  fi
   mv -- "$staging_dir" "$checkout_dir"
   trap - EXIT HUP INT TERM
 elif [ ! -d "$checkout_dir/.git" ]; then
@@ -50,12 +88,15 @@ else
     exit 1
   fi
 
-  if git -C "$checkout_dir" fetch \
-    --filter=blob:none \
-    --no-tags \
-    --prune \
-    origin \
-    "refs/heads/$checkout_ref:refs/remotes/origin/$checkout_ref"; then
+  fetch_checkout() {
+    git -C "$checkout_dir" fetch \
+      --filter=blob:none \
+      --no-tags \
+      --prune \
+      origin \
+      "refs/heads/$checkout_ref:refs/remotes/origin/$checkout_ref"
+  }
+  if retry_checkout_command fetch fetch_checkout; then
     current_branch=$(git -C "$checkout_dir" symbolic-ref --quiet --short HEAD || true)
     if [ "$current_branch" = "$checkout_ref" ] && [ -z "$(git -C "$checkout_dir" status --porcelain)" ]; then
       git -C "$checkout_dir" merge --ff-only "refs/remotes/origin/$checkout_ref"

--- a/scripts/hermes/bootstrap-lab-checkout.test.ts
+++ b/scripts/hermes/bootstrap-lab-checkout.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'bun:test'
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -22,6 +22,7 @@ async function runCheckout(
   repository: string,
   checkout: string,
   revisionFile: string,
+  environment: Record<string, string> = {},
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
   const process = Bun.spawn(['/bin/sh', script], {
     env: {
@@ -31,6 +32,9 @@ async function runCheckout(
       LAB_CHECKOUT_REF: 'main',
       LAB_CHECKOUT_DIR: checkout,
       LAB_CHECKOUT_REVISION_FILE: revisionFile,
+      LAB_CHECKOUT_RETRY_ATTEMPTS: '3',
+      LAB_CHECKOUT_RETRY_DELAY_SECONDS: '0',
+      ...environment,
     },
     stdout: 'pipe',
     stderr: 'pipe',
@@ -50,6 +54,9 @@ test('creates, fast-forwards, and preserves a dirty lab checkout', async () => {
   const source = join(root, 'source')
   const checkout = join(root, 'checkout')
   const revisionFile = join(root, 'lab-source-revision')
+  const fakeBin = join(root, 'bin')
+  const retryMarkers = join(root, 'retry-markers')
+  const gitShim = join(fakeBin, 'git')
 
   try {
     await git(root, 'init', '--initial-branch=main', source)
@@ -59,24 +66,54 @@ test('creates, fast-forwards, and preserves a dirty lab checkout', async () => {
     await git(source, 'add', 'README.md')
     await git(source, 'commit', '-m', 'first')
 
-    const initial = await runCheckout(source, checkout, revisionFile)
+    const realGit = Bun.which('git')
+    if (!realGit) throw new Error('git is required for the checkout bootstrap test')
+    await Promise.all([mkdir(fakeBin), mkdir(retryMarkers)])
+    await writeFile(
+      gitShim,
+      `#!/bin/sh
+set -eu
+for argument in "$@"; do
+  case "$argument" in
+    clone|fetch)
+      marker="$GIT_RETRY_MARKER_DIR/$argument"
+      if [ ! -e "$marker" ]; then
+        : >"$marker"
+        exit 1
+      fi
+      ;;
+  esac
+done
+exec "$REAL_GIT" "$@"
+`,
+    )
+    await chmod(gitShim, 0o755)
+    const retryEnvironment = {
+      GIT_RETRY_MARKER_DIR: retryMarkers,
+      PATH: `${fakeBin}:${processEnv.PATH ?? ''}`,
+      REAL_GIT: realGit,
+    }
+
+    const initial = await runCheckout(source, checkout, revisionFile, retryEnvironment)
     expect(initial.exitCode).toBe(0)
     expect(initial.stdout).toContain('lab_checkout_ready=true')
+    expect(initial.stderr).toContain('lab checkout clone attempt 1/3 failed; retrying in 0s')
     expect(await readFile(join(checkout, 'README.md'), 'utf8')).toBe('first\n')
     expect((await readFile(revisionFile, 'utf8')).trim()).toBe(await git(source, 'rev-parse', 'HEAD'))
 
     await writeFile(join(source, 'README.md'), 'second\n')
     await git(source, 'add', 'README.md')
     await git(source, 'commit', '-m', 'second')
-    const refreshed = await runCheckout(source, checkout, revisionFile)
+    const refreshed = await runCheckout(source, checkout, revisionFile, retryEnvironment)
     expect(refreshed.exitCode).toBe(0)
+    expect(refreshed.stderr).toContain('lab checkout fetch attempt 1/3 failed; retrying in 0s')
     expect(await readFile(join(checkout, 'README.md'), 'utf8')).toBe('second\n')
 
     await writeFile(join(checkout, 'README.md'), 'local work\n')
     await writeFile(join(source, 'README.md'), 'third\n')
     await git(source, 'add', 'README.md')
     await git(source, 'commit', '-m', 'third')
-    const preserved = await runCheckout(source, checkout, revisionFile)
+    const preserved = await runCheckout(source, checkout, revisionFile, retryEnvironment)
     expect(preserved.exitCode).toBe(0)
     expect(preserved.stdout).toContain('preserving local lab checkout state')
     expect(await readFile(join(checkout, 'README.md'), 'utf8')).toBe('local work\n')

--- a/scripts/hermes/validate-production.ts
+++ b/scripts/hermes/validate-production.ts
@@ -511,7 +511,12 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'https://github.com/proompteng/lab.git',
     'LAB_CHECKOUT_REF:-main',
     'LAB_CHECKOUT_DIR:-/opt/data/workspace/tuslagch/lab',
+    'LAB_CHECKOUT_RETRY_ATTEMPTS:-5',
+    'LAB_CHECKOUT_RETRY_DELAY_SECONDS:-2',
     'if [ -L "$checkout_dir" ]',
+    'retry_checkout_command()',
+    'retry_checkout_command clone clone_checkout',
+    'retry_checkout_command fetch fetch_checkout',
     '--filter=blob:none',
     'git -C "$checkout_dir" fetch',
     'git -C "$checkout_dir" merge --ff-only',
@@ -572,6 +577,7 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     '`hermes.proompteng.ai/github-auth-revision` annotation',
     'GitHub CLI `2.96.0`',
     'per-Pod `emptyDir`',
+    'bounded retries for transient pod-network startup races',
     githubCliArchiveSha256,
   ])
 


### PR DESCRIPTION
## Summary

- retry credential-free lab clone and fetch operations up to five times with a two-second delay
- preserve the existing verified worktree only after all bounded fetch attempts fail
- validate retry configuration and cover first-attempt clone and fetch failures with a deterministic Git shim
- document the observed pod-network startup race

## Related Issues

None

## Testing

- `bun test scripts/hermes/*.test.ts` (112 pass)
- `bun run scripts/hermes/validate-production.ts` (38 surfaces)
- `shellcheck argocd/applications/hermes/bootstrap-lab-checkout.sh`
- `bunx oxfmt --check scripts/hermes/bootstrap-lab-checkout.test.ts scripts/hermes/validate-production.ts`
- `bun run lint:argocd`
- focused server-side Kubernetes dry-run with `argocd-controller` field manager
- two production pod starts reproduced a first-fetch failure before later GitHub calls succeeded through the same healthy proxy

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section is not applicable and was removed.
- [x] Breaking Changes is filled in.
- [x] Documentation, release notes, and follow-ups are updated or tracked.