### PR TITLE
fix(bayn): move ledger to local NVMe

### DIFF
--- a/argocd/applications/bayn/networkpolicy.yaml
+++ b/argocd/applications/bayn/networkpolicy.yaml
@@ -54,7 +54,7 @@ spec:
     - to:
         - podSelector:
             matchLabels:
-              app.kubernetes.io/instance: bayn-tigerbeetle
+              app.kubernetes.io/instance: ledger
       ports:
         - port: 3000
           protocol: TCP

--- a/argocd/applications/bayn/tigerbeetle-cluster.yaml
+++ b/argocd/applications/bayn/tigerbeetle-cluster.yaml
@@ -1,19 +1,19 @@
 apiVersion: tigerbeetle.proompteng.ai/v1alpha1
 kind: TigerBeetleCluster
 metadata:
-  name: bayn-tigerbeetle
+  name: ledger
   labels:
-    app.kubernetes.io/name: bayn-tigerbeetle
+    app.kubernetes.io/name: ledger
     app.kubernetes.io/part-of: bayn
 spec:
-  clusterID: "222397790944575595450310052784555675227"
+  clusterID: "122731676035874920802382025803517750735"
   replicas: 3
   image:
     repository: ghcr.io/tigerbeetle/tigerbeetle
     tag: "0.17.9@sha256:48f623f9c1e9b6cc44d77ca93634595ae99cce3246ded418763eb1a62eee45e9"
     pullPolicy: IfNotPresent
   storage:
-    className: rook-ceph-block
+    className: local-path
     size: 100Gi
   resources:
     requests:
@@ -26,11 +26,11 @@ spec:
       requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:
             matchLabels:
-              app.kubernetes.io/instance: bayn-tigerbeetle
+              app.kubernetes.io/instance: ledger
           topologyKey: kubernetes.io/hostname
   pdb:
     enabled: true
     minAvailable: 2
   health:
-    checkIntervalSeconds: 5
+    checkIntervalSeconds: 30
   deletionPolicy: Retain

--- a/argocd/applications/bayn/tigerbeetle-networkpolicy.yaml
+++ b/argocd/applications/bayn/tigerbeetle-networkpolicy.yaml
@@ -1,14 +1,14 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: bayn-tigerbeetle
+  name: ledger
   labels:
-    app.kubernetes.io/name: bayn-tigerbeetle
+    app.kubernetes.io/name: ledger
     app.kubernetes.io/part-of: bayn
 spec:
   podSelector:
     matchLabels:
-      app.kubernetes.io/instance: bayn-tigerbeetle
+      app.kubernetes.io/instance: ledger
   policyTypes:
     - Ingress
   ingress:
@@ -18,7 +18,7 @@ spec:
               app.kubernetes.io/name: bayn
         - podSelector:
             matchLabels:
-              app.kubernetes.io/instance: bayn-tigerbeetle
+              app.kubernetes.io/instance: ledger
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: tigresse-system


### PR DESCRIPTION
## Summary

- replace the unused Ceph-backed `bayn-tigerbeetle` resource with a fresh `ledger` cluster and unique cluster ID
- place one 100 GiB local-path volume on each of the three nodes through required pod anti-affinity and WaitForFirstConsumer binding
- retain the two-replica disruption quorum and move protocol checks from five seconds to thirty seconds
- update Bayn and ledger network-policy selectors for the new cluster identity

## Related Issues

PROOMPT-399

## Testing

- `kustomize build --enable-helm argocd/applications/bayn`
- `kubectl apply --dry-run=server -n bayn -f argocd/applications/bayn/tigerbeetle-cluster.yaml -f argocd/applications/bayn/tigerbeetle-networkpolicy.yaml`
- `bun run lint:argocd`
- `git diff --check`
- read-only Talos mount verification: 1.80 TB, 3.62 TB, and 249.91 GB free on the three independent local NVMe-backed paths

## Breaking Changes

This intentionally replaces the unused, empty cluster identity. Argo CD will prune the old CR while its Retain policy preserves the old Ceph PVCs for explicit cleanup after the new cluster is proven. The running Bayn deployment remains on the existing Torghut ledger until the pinned restore and later cutover PRs.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] Operational follow-up and retained-PVC cleanup are tracked by PROOMPT-399.