### PR TITLE
fix(ci): validate OCI mirror references portably

### DIFF
--- a/.github/workflows/manual-docker-build-push.yaml
+++ b/.github/workflows/manual-docker-build-push.yaml
@@ -38,14 +38,14 @@ jobs:
     steps:
       - name: Log in to GHCR
         if: ${{ inputs.source_registry == 'ghcr.io' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Validate immutable references
         id: image
@@ -58,7 +58,7 @@ jobs:
           TARGET_TAG: ${{ inputs.target_tag }}
         run: |
           set -euo pipefail
-          repository_pattern='^[a-z0-9]+(?:[._-][a-z0-9]+)*(?:/[a-z0-9]+(?:[._-][a-z0-9]+)*)*$'
+          repository_pattern='^[a-z0-9]+([._-][a-z0-9]+)*(/[a-z0-9]+([._-][a-z0-9]+)*)*$'
           digest_pattern='^sha256:[0-9a-f]{64}$'
           tag_pattern='^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$'
           [[ "$SOURCE_REPOSITORY" =~ $repository_pattern ]]


### PR DESCRIPTION
## Summary

- replace the unsupported non-capturing Bash ERE groups with portable capturing groups
- move the Docker login and Buildx setup actions off the deprecated Node 20 majors
- preserve the digest-pinned multi-platform mirror contract

## Related Issues

PROOMPT-399

## Testing

- actionlint .github/workflows/manual-docker-build-push.yaml
- positive regex checks for proompteng/tigresse and tigresse
- negative regex check for ../bad
- failed mirror run 29874138119 confirmed GHCR authentication succeeded before the regex defect

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] The failed workflow evidence is linked by run ID.