### PR TITLE
fix(ci): bypass registry ingress for OCI mirrors

### DIFF
--- a/.github/workflows/manual-docker-build-push.yaml
+++ b/.github/workflows/manual-docker-build-push.yaml
@@ -46,6 +46,11 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          buildkitd-config-inline: |
+            [registry."registry.registry.svc.cluster.local"]
+              http = true
+              insecure = true
 
       - name: Validate immutable references
         id: image
@@ -69,6 +74,7 @@ jobs:
             echo "source=${SOURCE_REGISTRY}/${SOURCE_REPOSITORY}@${SOURCE_DIGEST}"
             echo "source_digest=${SOURCE_DIGEST}"
             echo "target=registry.ide-newton.ts.net/lab/${TARGET_REPOSITORY}:${TARGET_TAG}"
+            echo "target_transport=registry.registry.svc.cluster.local/lab/${TARGET_REPOSITORY}:${TARGET_TAG}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Copy complete OCI index
@@ -76,7 +82,7 @@ jobs:
         run: |
           set -euo pipefail
           docker buildx imagetools create \
-            --tag "${{ steps.image.outputs.target }}" \
+            --tag "${{ steps.image.outputs.target_transport }}" \
             --metadata-file mirror-metadata.json \
             "${{ steps.image.outputs.source }}"
 


### PR DESCRIPTION
## Summary

- route OCI mirror writes directly to the in-cluster registry service
- configure BuildKit to use the service HTTP endpoint explicitly
- keep verification and deployed references on registry.ide-newton.ts.net

## Related Issues

PROOMPT-399

## Testing

- actionlint .github/workflows/manual-docker-build-push.yaml
- git diff --check
- mirror run 29874305774 proved the tailnet ingress terminated the blob PUT after exactly five minutes
- registry service is ClusterIP registry.registry.svc.cluster.local:80 and has no NetworkPolicy restriction

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] The failed workflow and live registry evidence are recorded.