### PR TITLE
fix(tigresse): deploy persistent health client

### DIFF
--- a/.github/workflows/manual-docker-build-push.yaml
+++ b/.github/workflows/manual-docker-build-push.yaml
@@ -83,16 +83,16 @@ jobs:
           set -euo pipefail
           docker buildx imagetools create \
             --tag "${{ steps.image.outputs.target_transport }}" \
-            --metadata-file mirror-metadata.json \
             "${{ steps.image.outputs.source }}"
 
       - name: Verify digest and required platforms
         shell: bash
         run: |
           set -euo pipefail
-          test "$(jq -r '.containerimage.descriptor.digest' mirror-metadata.json)" = \
+          docker buildx imagetools inspect --raw \
+            "${{ steps.image.outputs.target_transport }}" > mirrored-index.json
+          test "sha256:$(sha256sum mirrored-index.json | cut -d ' ' -f1)" = \
             "${{ steps.image.outputs.source_digest }}"
-          docker buildx imagetools inspect --raw "${{ steps.image.outputs.target }}" > mirrored-index.json
           jq -e '
             any(.manifests[]?; .platform.os == "linux" and .platform.architecture == "amd64") and
             any(.manifests[]?; .platform.os == "linux" and .platform.architecture == "arm64")

--- a/argocd/applications/tigresse/charts/tigresse/Chart.yaml
+++ b/argocd/applications/tigresse/charts/tigresse/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: tigresse
 description: Production TigerBeetle Kubernetes operator
 type: application
-version: 0.1.6
-appVersion: v0.1.6
+version: 0.1.7
+appVersion: v0.1.7
 home: https://github.com/proompteng/tigresse
 sources:
   - https://github.com/proompteng/tigresse

--- a/argocd/applications/tigresse/kustomization.yaml
+++ b/argocd/applications/tigresse/kustomization.yaml
@@ -7,7 +7,7 @@ helmGlobals:
 
 helmCharts:
   - name: tigresse
-    version: 0.1.3
+    version: 0.1.7
     releaseName: tigresse
     namespace: tigresse-system
     includeCRDs: true

--- a/argocd/applications/tigresse/values.yaml
+++ b/argocd/applications/tigresse/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: registry.ide-newton.ts.net/lab/tigresse
-  tag: v0.1.6
-  digest: sha256:a357c07d629f9561f04b3452c1d9c41b81b9d816d29de415bd0141e859e92e39
+  tag: v0.1.7
+  digest: sha256:b04308528a46291e2c65562d04c2ac7644c4e7f25f2c247dae282b70f8856e2c
   pullPolicy: IfNotPresent
 
 podSecurityContext:


### PR DESCRIPTION
## Summary

- pin Tigresse v0.1.7 by its exact mirrored multi-platform OCI digest
- align the vendored chart and local Helm reference with the v0.1.7 release
- verify mirrored image identity from the raw target OCI index instead of unavailable Buildx metadata

## Related Issues

None

## Testing

- `actionlint .github/workflows/manual-docker-build-push.yaml`
- `kustomize build --enable-helm argocd/applications/tigresse`
- `bun run lint:argocd`
- verified the mirrored raw OCI index digest and linux/amd64 plus linux/arm64 manifests
- verified the vendored CRD SHA-256 against the v0.1.7 release asset

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.