### PR TITLE
fix(bayn): complete hard database cut

### DIFF
--- a/services/bayn/migrations/0008_current_protocol_only.ts
+++ b/services/bayn/migrations/0008_current_protocol_only.ts
@@ -61,6 +61,9 @@ export default Effect.gen(function* () {
     RESTART IDENTITY
   `
 
+  yield* sql`DROP SCHEMA IF EXISTS restore_probe CASCADE`
+  yield* sql`ALTER SEQUENCE bayn_status_history_sequence_seq RENAME TO status_history_sequence_seq`
+
   for (const [table, trigger] of truncateGuards) {
     yield* sql`ALTER TABLE ${sql(table)} ENABLE TRIGGER ${sql(trigger)}`
   }

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -187,6 +187,10 @@ describePostgres('PostgreSQL evaluation evidence', () => {
         const sql = yield* PgClient.PgClient
         yield* sql`DROP SCHEMA public CASCADE`
         yield* sql`CREATE SCHEMA public`
+        yield* sql`DROP SCHEMA IF EXISTS restore_probe CASCADE`
+        yield* sql`CREATE SCHEMA restore_probe`
+        yield* sql`CREATE TABLE restore_probe.evidence (proof_id text PRIMARY KEY, proof_value text NOT NULL)`
+        yield* sql`INSERT INTO restore_probe.evidence VALUES ('legacy-restore-proof', 'must-be-deleted')`
         const deployedMigrations = migrationLoader.pipe(
           Effect.map((migrations) => migrations.filter(([id]) => id <= 5)),
         )
@@ -372,6 +376,18 @@ describePostgres('PostgreSQL evaluation evidence', () => {
           FROM pg_catalog.pg_tables
           WHERE schemaname = 'public' AND tablename LIKE 'bayn\_%' ESCAPE '\'
         `
+        const legacyRelations = yield* sql<{ count: number }>`
+          SELECT count(*)::integer AS count
+          FROM pg_catalog.pg_class AS relation
+          INNER JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = relation.relnamespace
+          WHERE namespace.nspname = 'public' AND left(relation.relname, 5) = 'bayn_'
+        `
+        const currentSequence = yield* sql<{ exists: boolean }>`
+          SELECT to_regclass('public.status_history_sequence_seq') IS NOT NULL AS exists
+        `
+        const restoreProbe = yield* sql<{ exists: boolean }>`
+          SELECT to_regnamespace('restore_probe') IS NOT NULL AS exists
+        `
         const migrations = yield* sql<{ count: number }>`
           SELECT count(*)::integer AS count FROM schema_migrations
         `
@@ -391,13 +407,23 @@ describePostgres('PostgreSQL evaluation evidence', () => {
         `
         return {
           legacyTableCount: legacyTables[0]?.count,
+          legacyRelationCount: legacyRelations[0]?.count,
+          currentSequenceExists: currentSequence[0]?.exists,
+          restoreProbeExists: restoreProbe[0]?.exists,
           migrationCount: migrations[0]?.count,
           evidenceCount: evidence[0]?.count,
         }
       }),
     )
 
-    expect(migrated).toEqual({ legacyTableCount: 0, migrationCount: 8, evidenceCount: 0 })
+    expect(migrated).toEqual({
+      legacyTableCount: 0,
+      legacyRelationCount: 0,
+      currentSequenceExists: true,
+      restoreProbeExists: false,
+      migrationCount: 8,
+      evidenceCount: 0,
+    })
   })
 
   test('rejects legacy protocol rows after the hard cut', async () => {


### PR DESCRIPTION
## Summary

- make migration 8 drop the obsolete `restore_probe` schema instead of leaving backup-proof data in the runtime database
- rename the final service-prefixed PostgreSQL sequence during the one-way hard cut
- assert that the migrated database contains no `bayn_` relations, no restore-probe schema, and only the current sequence name

## Related Issues

PROOMPT-392

## Testing

- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:***@127.0.0.1:55432/bayn_test bun test services/bayn/src/db/evidence-store.integration.test.ts` — 23 pass
- `bun run --filter @proompteng/bayn test` — 134 pass, 25 PostgreSQL tests skipped and run separately above
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- read-only CNPG inspection confirmed the pre-cut database contains `restore_probe.evidence` and `bayn_status_history_sequence_seq`

## Breaking Changes

This intentionally deletes the legacy restore-proof schema when migration 8 runs. Current runtime evidence is already hard-deleted by the same migration.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.