### PR TITLE
fix(bayn): migrate all legacy protocol evidence

### DIFF
--- a/services/bayn/migrations/0008_current_protocol_only.ts
+++ b/services/bayn/migrations/0008_current_protocol_only.ts
@@ -24,7 +24,7 @@ export default Effect.gen(function* () {
         SELECT 1
         FROM protocol_locks
         WHERE strategy_name <> 'tsmom'
-          OR schema_version <> 'bayn.tsmom.protocol.v2'
+          OR schema_version NOT IN ('bayn.tsmom.protocol.v1', 'bayn.tsmom.protocol.v2')
       ) THEN
         RAISE EXCEPTION 'hard migration requires an empty database or legacy TSMOM-only evidence'
           USING ERRCODE = '55000';

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -215,6 +215,23 @@ describePostgres('PostgreSQL evaluation evidence', () => {
           )
         `
         yield* sql`
+          INSERT INTO bayn_protocol_locks (
+            protocol_hash,
+            schema_version,
+            strategy_name,
+            behavior_hash,
+            parameter_hash,
+            parameters
+          ) VALUES (
+            ${'e'.repeat(64)},
+            'bayn.tsmom.protocol.v1',
+            'tsmom',
+            ${'f'.repeat(64)},
+            ${'0'.repeat(64)},
+            '{}'::jsonb
+          )
+        `
+        yield* sql`
           INSERT INTO bayn_snapshot_references (
             snapshot_id,
             schema_version,


### PR DESCRIPTION
## Summary

- Hard-delete both deployed legacy TSMOM protocol versions during the one-way current-protocol migration.
- Preserve the guard against erasing any non-TSMOM protocol evidence.
- Reproduce the live v1-plus-v2 database shape in the PostgreSQL migration regression test.

## Related Issues

PROOMPT-392

## Testing

- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:55432/bayn_test bun test services/bayn/src/db/evidence-store.integration.test.ts` (23 passed)
- `bun run --filter @proompteng/bayn test` (134 passed, 25 PostgreSQL tests skipped and run separately above)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn build`
- `bunx oxfmt --check services/bayn/migrations/0008_current_protocol_only.ts services/bayn/src/db/evidence-store.integration.test.ts`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- Read-only CNPG preflight confirmed the live database contains both `bayn.tsmom.protocol.v1` and `bayn.tsmom.protocol.v2`.
- Streamed a read-only `pg_dump` of the live database into an isolated local PostgreSQL clone and ran the production migration layer: migration 8 applied, all ten evidence tables were empty, no `bayn_` relations remained, `restore_probe` was removed, and only current risk-balanced-trend constraints remained.

## Breaking Changes

This intentionally destroys all legacy TSMOM v1/v2 evidence when migration 8 runs. Recovery uses the completed pre-cut CNPG backup; there is no dual-read, conversion, or in-place schema fallback.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and the breaking migration is documented.
- [x] The release PR remains blocked until this fix is merged and a corrected immutable image is built.