### PR TITLE
chore(bayn): promote image sha-aa8a68faf0ed92e90303d8b24f9a55ca8854c991

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: bayn
         app.kubernetes.io/part-of: bayn
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-21T13:21:47Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-21T23:35:08Z"
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
@@ -47,13 +47,11 @@ spec:
               protocol: TCP
           env:
             - name: BAYN_CODE_REVISION
-              value: 05e08fabbca2cbef071125e364814bcb23ba364b
+              value: aa8a68faf0ed92e90303d8b24f9a55ca8854c991
             - name: BAYN_IMAGE_REPOSITORY
               value: registry.ide-newton.ts.net/lab/bayn
             - name: BAYN_IMAGE_DIGEST
-              value: sha256:a838caa7f7426cabfe2d1a8ffcf1f60e938fdd13dce3910a7ff8c853baa3ae89
-            - name: BAYN_QUALIFICATION_RUN_ID
-              value: 42d8bbfaf1a2ce7759b2283384e8f41298fe3a354ba7c0e1756bb8a3e64af177
+              value: sha256:8eb055cf228e0339ee0c0df550846d57be21eade7ee18d5cc032560902d08e4e
             - name: BAYN_HEALTH_INTERVAL_MS
               value: "30000"
             - name: BAYN_OPERATION_TIMEOUT_MS
@@ -71,19 +69,19 @@ spec:
                   name: bayn-clickhouse-auth
                   key: password
             - name: BAYN_SIGNAL_SNAPSHOT_ID
-              value: 0e3188062fb6781f9dfdc048b4bfe9846d8f4ce74c5e429e296e3ebcd75e93a5
+              value: "98f9b0cdee311b248d4ed36104fa46ff86c34d587d6e71a6706a9d778c110292"
             - name: BAYN_SIGNAL_PUBLICATION_ASOF
               value: "2026-07-20"
             - name: BAYN_SIGNAL_CALENDAR_VERSION
-              value: alpaca-us-equity-calendar-v1
+              value: "alpaca-us-equity-calendar-v1"
             - name: BAYN_SIGNAL_DATA_START
-              value: "2017-01-03"
+              value: "2022-01-27"
             - name: BAYN_SIGNAL_DATA_END
               value: "2026-07-20"
             - name: BAYN_SIGNAL_LOOKBACK_START
-              value: "2017-01-03"
+              value: "2022-01-27"
             - name: BAYN_SIGNAL_EVALUATION_START
-              value: "2018-01-03"
+              value: "2023-01-30"
             - name: BAYN_SIGNAL_EVALUATION_END
               value: "2026-07-20"
             - name: BAYN_POSTGRES_URL
@@ -96,9 +94,9 @@ spec:
             - name: BAYN_POSTGRES_CA_PATH
               value: /var/run/secrets/bayn/postgres/ca.crt
             - name: BAYN_TIGERBEETLE_CLUSTER_ID
-              value: "2001"
+              value: "122731676035874920802382025803517750735"
             - name: BAYN_TIGERBEETLE_ADDRESSES
-              value: torghut-tigerbeetle.torghut.svc.cluster.local:3000
+              value: "ledger.bayn.svc.cluster.local:3000"
             - name: BAYN_TIGERBEETLE_LEDGER
               value: "7001"
             - name: NODE_ENV

--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -24,5 +24,5 @@ configMapGenerator:
 images:
   - name: registry.ide-newton.ts.net/lab/bayn
     newName: registry.ide-newton.ts.net/lab/bayn
-    newTag: "sha-05e08fabbca2cbef071125e364814bcb23ba364b"
-    digest: sha256:a838caa7f7426cabfe2d1a8ffcf1f60e938fdd13dce3910a7ff8c853baa3ae89
+    newTag: "sha-aa8a68faf0ed92e90303d8b24f9a55ca8854c991"
+    digest: sha256:8eb055cf228e0339ee0c0df550846d57be21eade7ee18d5cc032560902d08e4e

--- a/argocd/applications/bayn/networkpolicy.yaml
+++ b/argocd/applications/bayn/networkpolicy.yaml
@@ -42,16 +42,6 @@ spec:
         - port: 8123
           protocol: TCP
     - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: torghut
-          podSelector:
-            matchLabels:
-              app.kubernetes.io/instance: torghut-tigerbeetle
-      ports:
-        - port: 3000
-          protocol: TCP
-    - to:
         - podSelector:
             matchLabels:
               app.kubernetes.io/instance: ledger


### PR DESCRIPTION
## Summary

Promote the corrected immutable Bayn image and atomically cut the runtime to the current Signal snapshot and dedicated Bayn TigerBeetle ledger. The same revision removes network access to the old Torghut ledger. Migration 8 hard-deletes legacy TSMOM v1/v2 evidence; it does not convert, dual-read, or restore it.

- Source commit: `aa8a68faf0ed92e90303d8b24f9a55ca8854c991`
- Image tag: `sha-aa8a68faf0ed92e90303d8b24f9a55ca8854c991`
- Image digest: `sha256:8eb055cf228e0339ee0c0df550846d57be21eade7ee18d5cc032560902d08e4e`

## Related Issues

PROOMPT-392
PROOMPT-399

## Testing

- Image index raw digest matches exactly and contains `linux/amd64` and `linux/arm64`.
- Full Bayn suite: 134 passed; 23 PostgreSQL integration tests passed separately; TypeScript, build, Oxfmt, Oxlint, and type-aware Oxlint passed on source PR #13030.
- Streamed a read-only dump of the live migration-6 database into an isolated local PostgreSQL clone and ran the production migration layer: migration 8 applied, all ten evidence tables were empty, no `bayn_` relations remained, `restore_probe` was removed, and only current risk-balanced-trend constraints remained.
- Fresh CNPG backup `bayn-db-hard-cut-20260721t2312z` completed as backup ID `20260721T231233` with begin/end WAL recorded.
- Dedicated `ledger` cluster remained Ready and ClientProtocolHealthy for 20 minutes with stable restarts and zero recurring client, eviction, view-change, heartbeat, panic, fatal, or error events after the startup baseline.
- `kustomize build argocd/applications/bayn` contains only source `aa8a68f`, digest `8eb055c`, Signal snapshot `98f9b0c`, ledger ID `122731676035874920802382025803517750735`, and `ledger.bayn.svc.cluster.local:3000`; it contains no qualification pin or old ledger access.
- `bun run lint:argocd` passed.

## Breaking Changes

This intentionally destroys all legacy TSMOM v1/v2 evidence when migration 8 runs. Rollback restores the completed pre-cut CNPG backup and prior Git revision; there is no in-place schema fallback. Broker orders and capital promotion remain disabled.

## Checklist

- [x] Testing section documents exact validation.
- [x] Runtime source revision and image digest are immutable.
- [x] The destructive migration has a completed backup and live-shaped rehearsal.
- [x] No broker or capital-promotion authority is introduced.