### PR TITLE
chore(bayn): promote image sha-0649e9171da8f3439759b89dc141980662c2dfb2

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: bayn
         app.kubernetes.io/part-of: bayn
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-21T23:35:08Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-22T00:51:11Z"
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
@@ -47,13 +47,11 @@ spec:
               protocol: TCP
           env:
             - name: BAYN_CODE_REVISION
-              value: aa8a68faf0ed92e90303d8b24f9a55ca8854c991
+              value: 0649e9171da8f3439759b89dc141980662c2dfb2
             - name: BAYN_IMAGE_REPOSITORY
               value: registry.ide-newton.ts.net/lab/bayn
             - name: BAYN_IMAGE_DIGEST
-              value: sha256:8eb055cf228e0339ee0c0df550846d57be21eade7ee18d5cc032560902d08e4e
-            - name: BAYN_QUALIFICATION_RUN_ID
-              value: "082669c8d9547911e39b7e3a8a6399978894114a5eacc9fc113b0c7b99b6bd88"
+              value: sha256:f7f3a1a4f097f6150040cb0b285a040fe985c971b24c76d594432b31b70b06cb
             - name: BAYN_HEALTH_INTERVAL_MS
               value: "30000"
             - name: BAYN_OPERATION_TIMEOUT_MS

--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -16,5 +16,5 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/bayn
     newName: registry.ide-newton.ts.net/lab/bayn
-    newTag: "sha-aa8a68faf0ed92e90303d8b24f9a55ca8854c991"
-    digest: sha256:8eb055cf228e0339ee0c0df550846d57be21eade7ee18d5cc032560902d08e4e
+    newTag: "sha-0649e9171da8f3439759b89dc141980662c2dfb2"
+    digest: sha256:f7f3a1a4f097f6150040cb0b285a040fe985c971b24c76d594432b31b70b06cb


### PR DESCRIPTION
## Summary

Promote the immutable Bayn image and atomically cut the runtime to the current Signal snapshot and the
dedicated Bayn TigerBeetle ledger. The generated manifest removes the legacy qualification pin rather
than converting or restoring legacy evidence.

- Source commit: `0649e9171da8f3439759b89dc141980662c2dfb2`
- Image tag: `sha-0649e9171da8f3439759b89dc141980662c2dfb2`
- Image digest: `sha256:f7f3a1a4f097f6150040cb0b285a040fe985c971b24c76d594432b31b70b06cb`

## Related Issues

PROOMPT-399

## Testing

- OCI index contains `linux/amd64` and `linux/arm64`.

## Screenshots (if applicable)

N/A

## Breaking Changes

The image applies the one-way current-protocol database migration. Merge only after a fresh CNPG backup
is verified and the dedicated `ledger` TigerBeetle cluster is healthy; rollback restores the pre-cut CNPG
backup and prior Git revision rather than attempting an in-place schema fallback.

## Checklist

- [x] Testing section documents exact validation.
- [x] Runtime source revision and image digest are immutable.
- [x] No broker or capital-promotion authority is introduced.