### PR TITLE
fix(bayn): preserve qualification pin on release

### DIFF
--- a/.github/workflows/bayn-release.yml
+++ b/.github/workflows/bayn-release.yml
@@ -125,9 +125,9 @@ jobs:
           body: |
             ## Summary
 
-            Promote the immutable Bayn image and atomically cut the runtime to the current Signal snapshot and the
-            dedicated Bayn TigerBeetle ledger. The generated manifest removes the legacy qualification pin rather
-            than converting or restoring legacy evidence.
+            Promote the immutable Bayn image while preserving the current terminal qualification pin, Signal
+            snapshot, and dedicated Bayn TigerBeetle ledger. The rollout recovers the pinned current-contract
+            evidence and does not create another qualification or accounting journal.
 
             - Source commit: `${{ steps.release.outputs.source_sha }}`
             - Image tag: `${{ steps.release.outputs.tag }}`
@@ -135,7 +135,7 @@ jobs:
 
             ## Related Issues
 
-            PROOMPT-399
+            PROOMPT-400
 
             ## Testing
 
@@ -147,9 +147,9 @@ jobs:
 
             ## Breaking Changes
 
-            The image applies the one-way current-protocol database migration. Merge only after a fresh CNPG backup
-            is verified and the dedicated `ledger` TigerBeetle cluster is healthy; rollback restores the pre-cut CNPG
-            backup and prior Git revision rather than attempting an in-place schema fallback.
+            This is a one-way current-contract runtime release. Databases with the legacy migration tracker are
+            rejected; there is no schema fallback or automatic rename. The existing terminal qualification remains
+            pinned so a behavior-preserving image release performs read-only recovery.
 
             ## Checklist
 

--- a/packages/scripts/src/bayn/update-manifests.test.ts
+++ b/packages/scripts/src/bayn/update-manifests.test.ts
@@ -13,7 +13,7 @@ afterEach(() => {
 })
 
 describe('Bayn manifest promotion', () => {
-  test('atomically promotes the current runtime and removes the legacy qualification pin', () => {
+  test('atomically promotes the current runtime without changing its qualification pin', () => {
     directory = mkdtempSync(join(tmpdir(), 'bayn-manifest-'))
     const kustomizationPath = join(directory, 'kustomization.yaml')
     const deploymentPath = join(directory, 'deployment.yaml')
@@ -47,7 +47,9 @@ describe('Bayn manifest promotion', () => {
       `- name: BAYN_IMAGE_REPOSITORY\n              value: registry.ide-newton.ts.net/lab/bayn`,
     )
     expect(readFileSync(deploymentPath, 'utf8')).toContain(`- name: BAYN_IMAGE_DIGEST\n              value: ${digest}`)
-    expect(readFileSync(deploymentPath, 'utf8')).not.toContain('BAYN_QUALIFICATION_RUN_ID')
+    expect(readFileSync(deploymentPath, 'utf8')).toContain(
+      '- name: BAYN_QUALIFICATION_RUN_ID\n              value: legacy-run',
+    )
     expect(readFileSync(deploymentPath, 'utf8')).toContain(
       '- name: BAYN_SIGNAL_SNAPSHOT_ID\n              value: "98f9b0cdee311b248d4ed36104fa46ff86c34d587d6e71a6706a9d778c110292"',
     )
@@ -75,7 +77,9 @@ describe('Bayn manifest promotion', () => {
       deploymentPath,
       applicationSetPath,
     })
-    expect(readFileSync(deploymentPath, 'utf8')).not.toContain('BAYN_QUALIFICATION_RUN_ID')
+    expect(readFileSync(deploymentPath, 'utf8')).toContain(
+      '- name: BAYN_QUALIFICATION_RUN_ID\n              value: legacy-run',
+    )
     expect(readFileSync(deploymentPath, 'utf8')).toContain(`value: ${nextSourceSha}`)
   })
 

--- a/packages/scripts/src/bayn/update-manifests.ts
+++ b/packages/scripts/src/bayn/update-manifests.ts
@@ -36,12 +36,6 @@ const replaceExactlyOnce = (source: string, pattern: RegExp, replacement: string
   return source.replace(pattern, replacement)
 }
 
-const removeAtMostOnce = (source: string, pattern: RegExp, name: string): string => {
-  const matches = [...source.matchAll(new RegExp(pattern.source, `${pattern.flags.replace('g', '')}g`))]
-  if (matches.length > 1) throw new Error(`expected at most one ${name}`)
-  return matches.length === 0 ? source : source.replace(pattern, '')
-}
-
 export const updateBaynManifests = (options: UpdateBaynManifestOptions): void => {
   if (!sourceShaPattern.test(options.sourceSha)) throw new Error(`invalid source SHA: ${options.sourceSha}`)
   if (!tagPattern.test(options.tag)) throw new Error(`invalid image tag: ${options.tag}`)
@@ -73,11 +67,6 @@ export const updateBaynManifests = (options: UpdateBaynManifestOptions): void =>
     /(            - name: BAYN_IMAGE_DIGEST\n              value: )[^\n]+/,
     `$1${options.digest}`,
     'BAYN_IMAGE_DIGEST value',
-  )
-  updatedDeployment = removeAtMostOnce(
-    updatedDeployment,
-    /            - name: BAYN_QUALIFICATION_RUN_ID\n              value: [^\n]+\n/,
-    'BAYN_QUALIFICATION_RUN_ID block',
   )
   for (const [name, value] of Object.entries(currentRuntimeConfiguration)) {
     updatedDeployment = replaceExactlyOnce(


### PR DESCRIPTION
## Summary

- Preserve `BAYN_QUALIFICATION_RUN_ID` when promoting a behavior-preserving Bayn image.
- Remove the release helper that silently deleted the terminal run pin.
- Update promotion coverage and release notes to require read-only pinned recovery.

## Related Issues

PROOMPT-400

## Testing

- `bun test packages/scripts/src/bayn/update-manifests.test.ts` — 2 passed, 0 failed.
- `bunx oxfmt --check packages/scripts/src/bayn/update-manifests.ts packages/scripts/src/bayn/update-manifests.test.ts .github/workflows/bayn-release.yml`
- `git diff --check`

## Breaking Changes

None. This prevents promotion automation from turning a behavior-preserving cleanup release into a new qualification and accounting write.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
