### PR TITLE
test(tigresse): update inventory image digest

### DIFF
--- a/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
+++ b/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
@@ -284,7 +284,7 @@ describe('enabled app inventory', () => {
       class: 'vendor-manifest',
       hasHelmChart: true,
       repoImages: [
-        'registry.ide-newton.ts.net/lab/tigresse@sha256:a357c07d629f9561f04b3452c1d9c41b81b9d816d29de415bd0141e859e92e39',
+        'registry.ide-newton.ts.net/lab/tigresse@sha256:b04308528a46291e2c65562d04c2ac7644c4e7f25f2c247dae282b70f8856e2c',
       ],
     })
     expect(entry('tigresse').deferredReason).toContain('proompteng/tigresse')


### PR DESCRIPTION
## Summary

- Align the enabled-app inventory assertion with the Tigresse digest already merged in #13027.
- Restore the repository-wide packages-scripts test baseline.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/enabled-apps.test.ts` — 20 passed, 0 failed.
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/enabled-apps.test.ts`
- `git diff --check`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
