### PR TITLE
fix(bayn): gate qualification pin reuse

### DIFF
--- a/.github/workflows/bayn-release.yml
+++ b/.github/workflows/bayn-release.yml
@@ -95,6 +95,7 @@ jobs:
             extra-trusted-public-keys = ${{ vars.ATTIC_PUBLIC_KEY }}
 
       - name: Verify and pin image
+        id: promotion
         shell: bash
         env:
           SOURCE_SHA: ${{ steps.release.outputs.source_sha }}
@@ -102,12 +103,40 @@ jobs:
           IMAGE_DIGEST: ${{ steps.release.outputs.digest }}
         run: |
           set -euo pipefail
+          nix_hash() {
+            local name="$1"
+            local -a hashes
+            mapfile -t hashes < <(
+              git show "${SOURCE_SHA}:nix/images/bayn.nix" |
+                sed -nE "s/^[[:space:]]*${name} = \"([0-9a-f]{64})\";$/\\1/p"
+            )
+            test "${#hashes[@]}" -eq 1
+            printf '%s' "${hashes[0]}"
+          }
+
+          strategy_behavior_hash="$(nix_hash strategyBehaviorHash)"
+          strategy_parameter_hash="$(nix_hash strategyParameterHash)"
           nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/bayn@${IMAGE_DIGEST}" linux/amd64 linux/arm64
-          bun run packages/scripts/src/bayn/update-manifests.ts \
-            --source-sha "$SOURCE_SHA" \
-            --tag "$IMAGE_TAG" \
-            --digest "$IMAGE_DIGEST" \
-            --rollout-timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          promotion="$(
+            bun packages/scripts/src/bayn/update-manifests.ts \
+              --source-sha "$SOURCE_SHA" \
+              --tag "$IMAGE_TAG" \
+              --digest "$IMAGE_DIGEST" \
+              --strategy-behavior-hash "$strategy_behavior_hash" \
+              --strategy-parameter-hash "$strategy_parameter_hash" \
+              --rollout-timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          )"
+          jq -e '.qualificationMode == "preserve" or .qualificationMode == "replace"' <<< "$promotion"
+          {
+            echo "qualification_mode=$(jq -r '.qualificationMode' <<< "$promotion")"
+            echo "had_qualification_pin=$(jq -r '.hadQualificationPin' <<< "$promotion")"
+            echo "runtime_bindings_match=$(jq -r '.runtimeBindingsMatch' <<< "$promotion")"
+            echo "deployed_source=$(jq -r '.deployedSourceSha' <<< "$promotion")"
+            echo "deployed_behavior_hash=$(jq -r '.deployedBehaviorHash' <<< "$promotion")"
+            echo "deployed_parameter_hash=$(jq -r '.deployedParameterHash' <<< "$promotion")"
+            echo "candidate_behavior_hash=$(jq -r '.candidateBehaviorHash' <<< "$promotion")"
+            echo "candidate_parameter_hash=$(jq -r '.candidateParameterHash' <<< "$promotion")"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Create deploy pull request
         uses: peter-evans/create-pull-request@v7
@@ -125,13 +154,19 @@ jobs:
           body: |
             ## Summary
 
-            Promote the immutable Bayn image while preserving the current terminal qualification pin, Signal
-            snapshot, and dedicated Bayn TigerBeetle ledger. The rollout recovers the pinned current-contract
-            evidence and does not create another qualification or accounting journal.
+            Promote the immutable Bayn image against the current Signal snapshot and dedicated Bayn TigerBeetle
+            ledger. Qualification-pin handling is selected from the verified compiled behavior identity.
 
             - Source commit: `${{ steps.release.outputs.source_sha }}`
             - Image tag: `${{ steps.release.outputs.tag }}`
             - Image digest: `${{ steps.release.outputs.digest }}`
+            - Qualification mode: `${{ steps.promotion.outputs.qualification_mode }}`
+            - Existing pin: `${{ steps.promotion.outputs.had_qualification_pin }}`
+            - Runtime bindings match: `${{ steps.promotion.outputs.runtime_bindings_match }}`
+            - Deployed behavior hash: `${{ steps.promotion.outputs.deployed_behavior_hash }}`
+            - Candidate behavior hash: `${{ steps.promotion.outputs.candidate_behavior_hash }}`
+            - Deployed parameter hash: `${{ steps.promotion.outputs.deployed_parameter_hash }}`
+            - Candidate parameter hash: `${{ steps.promotion.outputs.candidate_parameter_hash }}`
 
             ## Related Issues
 
@@ -147,9 +182,10 @@ jobs:
 
             ## Breaking Changes
 
-            This is a one-way current-contract runtime release. Databases with the legacy migration tracker are
-            rejected; there is no schema fallback or automatic rename. The existing terminal qualification remains
-            pinned so a behavior-preserving image release performs read-only recovery.
+            This is a one-way current-contract runtime release. Databases with the old migration tracker are rejected;
+            there is no schema fallback or automatic rename. `preserve` keeps the terminal run only when compiled
+            behavior, protocol parameters, Signal inputs, and TigerBeetle bindings all match. `replace` removes the
+            pin, and later unpinned promotions remain valid without reintroducing compatibility state.
 
             ## Checklist
 

--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -52,6 +52,10 @@ spec:
               value: registry.ide-newton.ts.net/lab/bayn
             - name: BAYN_IMAGE_DIGEST
               value: sha256:8eb055cf228e0339ee0c0df550846d57be21eade7ee18d5cc032560902d08e4e
+            - name: BAYN_STRATEGY_BEHAVIOR_HASH
+              value: "43cece33d3db232ffb02ba78826727e50b5795319d09d27e1baa0c04709eb056"
+            - name: BAYN_STRATEGY_PARAMETER_HASH
+              value: "cf639d3692da65271b12423f9b7c6c9663e1fb13ae7290dc56fcfa3acf16eb69"
             - name: BAYN_QUALIFICATION_RUN_ID
               value: "082669c8d9547911e39b7e3a8a6399978894114a5eacc9fc113b0c7b99b6bd88"
             - name: BAYN_HEALTH_INTERVAL_MS

--- a/nix/images/bayn.nix
+++ b/nix/images/bayn.nix
@@ -12,6 +12,8 @@ let
   # Immutable identity for bayn.risk-balanced-trend.behavior.v1. The deterministic evaluator and decision fingerprints
   # are locked in risk-balanced-trend.test.ts, so behavior-preserving refactors retain the same identity.
   strategyBehaviorHash = "43cece33d3db232ffb02ba78826727e50b5795319d09d27e1baa0c04709eb056";
+  # Canonical hash of the compiled bayn.risk-balanced-trend.protocol.v2 document.
+  strategyParameterHash = "cf639d3692da65271b12423f9b7c6c9663e1fb13ae7290dc56fcfa3acf16eb69";
   buildDefine = name: value: "--define ${name}=${lib.escapeShellArg (builtins.toJSON value)}";
 in
 import ./bun-workspace-service.nix {
@@ -38,9 +40,12 @@ import ./bun-workspace-service.nix {
       + buildDefine "__BAYN_BUILD_IMAGE_REPOSITORY__" imageRepository
       + " "
       + buildDefine "__BAYN_BUILD_STRATEGY_BEHAVIOR_HASH__" strategyBehaviorHash
+      + " "
+      + buildDefine "__BAYN_BUILD_STRATEGY_PARAMETER_HASH__" strategyParameterHash
     )
     "grep -F -- ${lib.escapeShellArg repoRevision} services/bayn/dist/index.js"
     "grep -F -- ${lib.escapeShellArg strategyBehaviorHash} services/bayn/dist/index.js"
+    "grep -F -- ${lib.escapeShellArg strategyParameterHash} services/bayn/dist/index.js"
   ];
   runtimeInstallPhase = ''
     mkdir -p "$out/app/services/bayn/dist" "$out/app/services/bayn/node_modules/tigerbeetle-node"
@@ -64,5 +69,6 @@ import ./bun-workspace-service.nix {
   labels = {
     "org.opencontainers.image.revision" = repoRevision;
     "proompteng.ai/bayn.strategy-behavior-hash" = strategyBehaviorHash;
+    "proompteng.ai/bayn.strategy-parameter-hash" = strategyParameterHash;
   };
 }

--- a/packages/scripts/src/bayn/update-manifests.test.ts
+++ b/packages/scripts/src/bayn/update-manifests.test.ts
@@ -13,11 +13,13 @@ afterEach(() => {
 })
 
 describe('Bayn manifest promotion', () => {
-  test('atomically promotes the current runtime without changing its qualification pin', () => {
+  test('derives qualification-pin handling from the complete runtime binding', () => {
     directory = mkdtempSync(join(tmpdir(), 'bayn-manifest-'))
     const kustomizationPath = join(directory, 'kustomization.yaml')
     const deploymentPath = join(directory, 'deployment.yaml')
     const applicationSetPath = join(directory, 'product.yaml')
+    const strategyBehaviorHash = '1'.repeat(64)
+    const strategyParameterHash = '2'.repeat(64)
     writeFileSync(
       kustomizationPath,
       `images:\n  - name: registry.ide-newton.ts.net/lab/bayn\n    newName: registry.ide-newton.ts.net/lab/bayn\n    newTag: bootstrap\n`,
@@ -27,19 +29,41 @@ describe('Bayn manifest promotion', () => {
       `metadata:\n  template:\n    metadata:\n      annotations:\n        kubectl.kubernetes.io/restartedAt: "old"\n    spec:\n      containers:\n        - env:\n            - name: BAYN_CODE_REVISION\n              value: bootstrap\n            - name: BAYN_IMAGE_REPOSITORY\n              value: registry.ide-newton.ts.net/lab/bayn\n            - name: BAYN_IMAGE_DIGEST\n              value: sha256:old\n            - name: BAYN_QUALIFICATION_RUN_ID\n              value: legacy-run\n            - name: BAYN_SIGNAL_SNAPSHOT_ID\n              value: legacy-snapshot\n            - name: BAYN_SIGNAL_PUBLICATION_ASOF\n              value: 2026-07-19\n            - name: BAYN_SIGNAL_CALENDAR_VERSION\n              value: legacy-calendar\n            - name: BAYN_SIGNAL_DATA_START\n              value: 2017-01-03\n            - name: BAYN_SIGNAL_DATA_END\n              value: 2026-07-19\n            - name: BAYN_SIGNAL_LOOKBACK_START\n              value: 2017-01-03\n            - name: BAYN_SIGNAL_EVALUATION_START\n              value: 2018-01-03\n            - name: BAYN_SIGNAL_EVALUATION_END\n              value: 2026-07-19\n            - name: BAYN_TIGERBEETLE_CLUSTER_ID\n              value: "2001"\n            - name: BAYN_TIGERBEETLE_ADDRESSES\n              value: old-ledger.example:3000\n            - name: BAYN_TIGERBEETLE_LEDGER\n              value: "7001"\n`,
     )
     writeFileSync(
+      deploymentPath,
+      readFileSync(deploymentPath, 'utf8').replace(
+        '            - name: BAYN_QUALIFICATION_RUN_ID\n',
+        `            - name: BAYN_STRATEGY_BEHAVIOR_HASH\n              value: old\n            - name: BAYN_STRATEGY_PARAMETER_HASH\n              value: old\n            - name: BAYN_QUALIFICATION_RUN_ID\n`,
+      ),
+    )
+    writeFileSync(
       applicationSetPath,
       `elements:\n              - name: bayn\n                path: argocd/applications/bayn\n                enabled: "false"\n              - name: next\n                enabled: "true"\n`,
     )
+    const addQualificationPin = () =>
+      writeFileSync(
+        deploymentPath,
+        readFileSync(deploymentPath, 'utf8').replace(
+          '            - name: BAYN_SIGNAL_SNAPSHOT_ID\n',
+          `            - name: BAYN_QUALIFICATION_RUN_ID\n              value: ${'9'.repeat(64)}\n            - name: BAYN_SIGNAL_SNAPSHOT_ID\n`,
+        ),
+      )
     const sourceSha = 'a'.repeat(40)
     const digest = `sha256:${'b'.repeat(64)}`
-    updateBaynManifests({
+    const initial = updateBaynManifests({
       sourceSha,
       tag: `sha-${sourceSha}`,
       digest,
+      strategyBehaviorHash,
+      strategyParameterHash,
       rolloutTimestamp: '2026-07-19T10:00:00Z',
       kustomizationPath,
       deploymentPath,
       applicationSetPath,
+    })
+    expect(initial).toMatchObject({
+      qualificationMode: 'replace',
+      hadQualificationPin: true,
+      runtimeBindingsMatch: false,
     })
     expect(readFileSync(kustomizationPath, 'utf8')).toContain(`newTag: "sha-${sourceSha}"\n    digest: ${digest}`)
     expect(readFileSync(deploymentPath, 'utf8')).toContain(`value: ${sourceSha}`)
@@ -48,8 +72,12 @@ describe('Bayn manifest promotion', () => {
     )
     expect(readFileSync(deploymentPath, 'utf8')).toContain(`- name: BAYN_IMAGE_DIGEST\n              value: ${digest}`)
     expect(readFileSync(deploymentPath, 'utf8')).toContain(
-      '- name: BAYN_QUALIFICATION_RUN_ID\n              value: legacy-run',
+      `- name: BAYN_STRATEGY_BEHAVIOR_HASH\n              value: "${strategyBehaviorHash}"`,
     )
+    expect(readFileSync(deploymentPath, 'utf8')).toContain(
+      `- name: BAYN_STRATEGY_PARAMETER_HASH\n              value: "${strategyParameterHash}"`,
+    )
+    expect(readFileSync(deploymentPath, 'utf8')).not.toContain('BAYN_QUALIFICATION_RUN_ID')
     expect(readFileSync(deploymentPath, 'utf8')).toContain(
       '- name: BAYN_SIGNAL_SNAPSHOT_ID\n              value: "98f9b0cdee311b248d4ed36104fa46ff86c34d587d6e71a6706a9d778c110292"',
     )
@@ -67,20 +95,90 @@ describe('Bayn manifest promotion', () => {
       '- name: bayn\n                path: argocd/applications/bayn\n                enabled: "true"',
     )
 
+    addQualificationPin()
     const nextSourceSha = 'c'.repeat(40)
-    updateBaynManifests({
+    const preserved = updateBaynManifests({
       sourceSha: nextSourceSha,
       tag: `sha-${nextSourceSha}`,
       digest: `sha256:${'d'.repeat(64)}`,
+      strategyBehaviorHash,
+      strategyParameterHash,
       rolloutTimestamp: '2026-07-20T10:00:00Z',
       kustomizationPath,
       deploymentPath,
       applicationSetPath,
     })
+    expect(preserved).toMatchObject({
+      qualificationMode: 'preserve',
+      hadQualificationPin: true,
+      runtimeBindingsMatch: true,
+    })
     expect(readFileSync(deploymentPath, 'utf8')).toContain(
-      '- name: BAYN_QUALIFICATION_RUN_ID\n              value: legacy-run',
+      `- name: BAYN_QUALIFICATION_RUN_ID\n              value: ${'9'.repeat(64)}`,
     )
     expect(readFileSync(deploymentPath, 'utf8')).toContain(`value: ${nextSourceSha}`)
+
+    writeFileSync(
+      deploymentPath,
+      readFileSync(deploymentPath, 'utf8').replace(
+        'BAYN_SIGNAL_PUBLICATION_ASOF\n              value: "2026-07-20"',
+        'BAYN_SIGNAL_PUBLICATION_ASOF\n              value: "2026-07-19"',
+      ),
+    )
+    const signalChangeSourceSha = 'e'.repeat(40)
+    const signalChange = updateBaynManifests({
+      sourceSha: signalChangeSourceSha,
+      tag: `sha-${signalChangeSourceSha}`,
+      digest: `sha256:${'f'.repeat(64)}`,
+      strategyBehaviorHash,
+      strategyParameterHash,
+      rolloutTimestamp: '2026-07-21T10:00:00Z',
+      kustomizationPath,
+      deploymentPath,
+      applicationSetPath,
+    })
+    expect(signalChange).toMatchObject({
+      qualificationMode: 'replace',
+      hadQualificationPin: true,
+      runtimeBindingsMatch: false,
+    })
+    expect(readFileSync(deploymentPath, 'utf8')).not.toContain('BAYN_QUALIFICATION_RUN_ID')
+
+    const unpinnedSourceSha = '6'.repeat(40)
+    const unpinned = updateBaynManifests({
+      sourceSha: unpinnedSourceSha,
+      tag: `sha-${unpinnedSourceSha}`,
+      digest: `sha256:${'7'.repeat(64)}`,
+      strategyBehaviorHash,
+      strategyParameterHash,
+      rolloutTimestamp: '2026-07-22T10:00:00Z',
+      kustomizationPath,
+      deploymentPath,
+      applicationSetPath,
+    })
+    expect(unpinned).toMatchObject({
+      qualificationMode: 'replace',
+      hadQualificationPin: false,
+      runtimeBindingsMatch: true,
+    })
+
+    addQualificationPin()
+    const changedParameters = updateBaynManifests({
+      sourceSha: '8'.repeat(40),
+      tag: `sha-${'8'.repeat(40)}`,
+      digest: `sha256:${'8'.repeat(64)}`,
+      strategyBehaviorHash,
+      strategyParameterHash: '8'.repeat(64),
+      rolloutTimestamp: '2026-07-23T10:00:00Z',
+      kustomizationPath,
+      deploymentPath,
+      applicationSetPath,
+    })
+    expect(changedParameters).toMatchObject({
+      qualificationMode: 'replace',
+      hadQualificationPin: true,
+      runtimeBindingsMatch: true,
+    })
   })
 
   test('rejects malformed release metadata', () => {
@@ -89,6 +187,8 @@ describe('Bayn manifest promotion', () => {
         sourceSha: 'main',
         tag: 'latest',
         digest: 'sha256:bad',
+        strategyBehaviorHash: '1'.repeat(64),
+        strategyParameterHash: '2'.repeat(64),
         rolloutTimestamp: 'now',
         applicationSetPath: 'unused',
       }),

--- a/packages/scripts/src/bayn/update-manifests.ts
+++ b/packages/scripts/src/bayn/update-manifests.ts
@@ -4,6 +4,7 @@ import { readFileSync, writeFileSync } from 'node:fs'
 import process from 'node:process'
 
 const digestPattern = /^sha256:[0-9a-f]{64}$/
+const hashPattern = /^[0-9a-f]{64}$/
 const sourceShaPattern = /^[0-9a-f]{40}$/
 const tagPattern = /^[A-Za-z0-9._-]{1,128}$/
 const currentRuntimeConfiguration = {
@@ -24,10 +25,23 @@ export interface UpdateBaynManifestOptions {
   readonly sourceSha: string
   readonly tag: string
   readonly digest: string
+  readonly strategyBehaviorHash: string
+  readonly strategyParameterHash: string
   readonly rolloutTimestamp: string
   readonly kustomizationPath?: string
   readonly deploymentPath?: string
   readonly applicationSetPath?: string
+}
+
+export interface BaynManifestUpdate {
+  readonly qualificationMode: 'preserve' | 'replace'
+  readonly hadQualificationPin: boolean
+  readonly runtimeBindingsMatch: boolean
+  readonly deployedSourceSha: string
+  readonly deployedBehaviorHash: string
+  readonly deployedParameterHash: string
+  readonly candidateBehaviorHash: string
+  readonly candidateParameterHash: string
 }
 
 const replaceExactlyOnce = (source: string, pattern: RegExp, replacement: string, name: string): string => {
@@ -36,16 +50,59 @@ const replaceExactlyOnce = (source: string, pattern: RegExp, replacement: string
   return source.replace(pattern, replacement)
 }
 
-export const updateBaynManifests = (options: UpdateBaynManifestOptions): void => {
+const environmentValue = (deployment: string, name: string): string => {
+  const pattern = new RegExp(`            - name: ${name}\\n              value: ([^\\n]+)\\n`, 'g')
+  const matches = [...deployment.matchAll(pattern)]
+  if (matches.length !== 1) throw new Error(`expected exactly one ${name} value`)
+  const value = matches[0]?.[1]?.trim()
+  if (value === undefined) throw new Error(`missing ${name} value`)
+  return value.startsWith('"') ? String(JSON.parse(value)) : value
+}
+
+const qualificationPin = /            - name: BAYN_QUALIFICATION_RUN_ID\n              value: [^\n]+\n/
+
+const transitionQualificationPin = (
+  deployment: string,
+  mode: 'preserve' | 'replace',
+  hadQualificationPin: boolean,
+): string => {
+  if (mode === 'preserve') {
+    if (!hadQualificationPin) throw new Error('cannot preserve a missing BAYN_QUALIFICATION_RUN_ID block')
+    return deployment
+  }
+  return hadQualificationPin ? deployment.replace(qualificationPin, '') : deployment
+}
+
+export const updateBaynManifests = (options: UpdateBaynManifestOptions): BaynManifestUpdate => {
   if (!sourceShaPattern.test(options.sourceSha)) throw new Error(`invalid source SHA: ${options.sourceSha}`)
   if (!tagPattern.test(options.tag)) throw new Error(`invalid image tag: ${options.tag}`)
   if (!digestPattern.test(options.digest)) throw new Error(`invalid image digest: ${options.digest}`)
+  if (!hashPattern.test(options.strategyBehaviorHash)) {
+    throw new Error(`invalid strategy behavior hash: ${options.strategyBehaviorHash}`)
+  }
+  if (!hashPattern.test(options.strategyParameterHash)) {
+    throw new Error(`invalid strategy parameter hash: ${options.strategyParameterHash}`)
+  }
   if (Number.isNaN(Date.parse(options.rolloutTimestamp))) throw new Error('rollout timestamp must be ISO-8601')
 
   const kustomizationPath = options.kustomizationPath ?? 'argocd/applications/bayn/kustomization.yaml'
   const deploymentPath = options.deploymentPath ?? 'argocd/applications/bayn/deployment.yaml'
   const applicationSetPath = options.applicationSetPath ?? 'argocd/applicationsets/product.yaml'
   const kustomization = readFileSync(kustomizationPath, 'utf8')
+  const deployment = readFileSync(deploymentPath, 'utf8')
+  const qualificationPins = [...deployment.matchAll(new RegExp(qualificationPin.source, 'g'))]
+  if (qualificationPins.length > 1) throw new Error('expected at most one BAYN_QUALIFICATION_RUN_ID block')
+  const hadQualificationPin = qualificationPins.length === 1
+  const deployedSourceSha = environmentValue(deployment, 'BAYN_CODE_REVISION')
+  const deployedBehaviorHash = environmentValue(deployment, 'BAYN_STRATEGY_BEHAVIOR_HASH')
+  const deployedParameterHash = environmentValue(deployment, 'BAYN_STRATEGY_PARAMETER_HASH')
+  const runtimeBindingsMatch = Object.entries(currentRuntimeConfiguration).every(
+    ([name, value]) => environmentValue(deployment, name) === value,
+  )
+  const strategyIdentityMatches =
+    deployedBehaviorHash === options.strategyBehaviorHash && deployedParameterHash === options.strategyParameterHash
+  const qualificationMode =
+    hadQualificationPin && strategyIdentityMatches && runtimeBindingsMatch ? 'preserve' : 'replace'
   const imageBlock =
     /(  - name: registry\.ide-newton\.ts\.net\/lab\/bayn\n    newName: registry\.ide-newton\.ts\.net\/lab\/bayn\n    newTag: )[^\n]+(?:\n    digest: [^\n]+)?/
   const updatedKustomization = replaceExactlyOnce(
@@ -55,7 +112,6 @@ export const updateBaynManifests = (options: UpdateBaynManifestOptions): void =>
     'Bayn image block',
   )
 
-  const deployment = readFileSync(deploymentPath, 'utf8')
   let updatedDeployment = replaceExactlyOnce(
     deployment,
     /(            - name: BAYN_CODE_REVISION\n              value: )[^\n]+/,
@@ -68,6 +124,19 @@ export const updateBaynManifests = (options: UpdateBaynManifestOptions): void =>
     `$1${options.digest}`,
     'BAYN_IMAGE_DIGEST value',
   )
+  updatedDeployment = replaceExactlyOnce(
+    updatedDeployment,
+    /(            - name: BAYN_STRATEGY_BEHAVIOR_HASH\n              value: )[^\n]+/,
+    `$1${JSON.stringify(options.strategyBehaviorHash)}`,
+    'BAYN_STRATEGY_BEHAVIOR_HASH value',
+  )
+  updatedDeployment = replaceExactlyOnce(
+    updatedDeployment,
+    /(            - name: BAYN_STRATEGY_PARAMETER_HASH\n              value: )[^\n]+/,
+    `$1${JSON.stringify(options.strategyParameterHash)}`,
+    'BAYN_STRATEGY_PARAMETER_HASH value',
+  )
+  updatedDeployment = transitionQualificationPin(updatedDeployment, qualificationMode, hadQualificationPin)
   for (const [name, value] of Object.entries(currentRuntimeConfiguration)) {
     updatedDeployment = replaceExactlyOnce(
       updatedDeployment,
@@ -94,6 +163,16 @@ export const updateBaynManifests = (options: UpdateBaynManifestOptions): void =>
   writeFileSync(kustomizationPath, updatedKustomization)
   writeFileSync(deploymentPath, updatedDeployment)
   writeFileSync(applicationSetPath, updatedApplicationSet)
+  return {
+    qualificationMode,
+    hadQualificationPin,
+    runtimeBindingsMatch,
+    deployedSourceSha,
+    deployedBehaviorHash,
+    deployedParameterHash,
+    candidateBehaviorHash: options.strategyBehaviorHash,
+    candidateParameterHash: options.strategyParameterHash,
+  }
 }
 
 const parseArguments = (argumentsToParse: readonly string[]): UpdateBaynManifestOptions => {
@@ -113,13 +192,15 @@ const parseArguments = (argumentsToParse: readonly string[]): UpdateBaynManifest
     sourceSha: required('--source-sha'),
     tag: required('--tag'),
     digest: required('--digest'),
+    strategyBehaviorHash: required('--strategy-behavior-hash'),
+    strategyParameterHash: required('--strategy-parameter-hash'),
     rolloutTimestamp: required('--rollout-timestamp'),
   }
 }
 
 if (import.meta.main) {
   try {
-    updateBaynManifests(parseArguments(process.argv.slice(2)))
+    process.stdout.write(JSON.stringify(updateBaynManifests(parseArguments(process.argv.slice(2)))))
   } catch (cause) {
     console.error(cause instanceof Error ? cause.message : String(cause))
     process.exitCode = 1

--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -64,6 +64,7 @@ const config: RuntimeConfig = {
     imageRepository: provenance.image.repository,
     imageDigest: provenance.image.digest,
     strategyBehaviorHash: provenance.strategy.behaviorHash,
+    strategyParameterHash: provenance.strategy.parameterHash,
     verification: 'embedded',
   },
   healthIntervalMs: 100,

--- a/services/bayn/src/build.ts
+++ b/services/bayn/src/build.ts
@@ -3,6 +3,7 @@ import { Schema } from 'effect'
 declare const __BAYN_BUILD_SOURCE_REVISION__: string
 declare const __BAYN_BUILD_IMAGE_REPOSITORY__: string
 declare const __BAYN_BUILD_STRATEGY_BEHAVIOR_HASH__: string
+declare const __BAYN_BUILD_STRATEGY_PARAMETER_HASH__: string
 
 const SourceRevision = Schema.String.check(Schema.isPattern(/^[a-f0-9]{40}$/))
 const ImageRepository = Schema.String.check(Schema.isPattern(/^[a-z0-9.-]+(?::[0-9]+)?\/[a-z0-9._/-]+$/))
@@ -12,6 +13,7 @@ export const EmbeddedBuildMetadataSchema = Schema.Struct({
   sourceRevision: SourceRevision,
   imageRepository: ImageRepository,
   strategyBehaviorHash: Sha256,
+  strategyParameterHash: Sha256,
 })
 export type EmbeddedBuildMetadata = typeof EmbeddedBuildMetadataSchema.Type
 
@@ -21,9 +23,14 @@ const imageRepository =
   typeof __BAYN_BUILD_IMAGE_REPOSITORY__ === 'undefined' ? undefined : __BAYN_BUILD_IMAGE_REPOSITORY__
 const strategyBehaviorHash =
   typeof __BAYN_BUILD_STRATEGY_BEHAVIOR_HASH__ === 'undefined' ? undefined : __BAYN_BUILD_STRATEGY_BEHAVIOR_HASH__
+const strategyParameterHash =
+  typeof __BAYN_BUILD_STRATEGY_PARAMETER_HASH__ === 'undefined' ? undefined : __BAYN_BUILD_STRATEGY_PARAMETER_HASH__
 
 const hasNoEmbeddedMetadata =
-  sourceRevision === undefined && imageRepository === undefined && strategyBehaviorHash === undefined
+  sourceRevision === undefined &&
+  imageRepository === undefined &&
+  strategyBehaviorHash === undefined &&
+  strategyParameterHash === undefined
 
 export const embeddedBuildMetadata: EmbeddedBuildMetadata | undefined = hasNoEmbeddedMetadata
   ? undefined
@@ -31,4 +38,5 @@ export const embeddedBuildMetadata: EmbeddedBuildMetadata | undefined = hasNoEmb
       sourceRevision: sourceRevision ?? 'incomplete',
       imageRepository: imageRepository ?? 'incomplete',
       strategyBehaviorHash: strategyBehaviorHash ?? 'incomplete',
+      strategyParameterHash: strategyParameterHash ?? 'incomplete',
     }

--- a/services/bayn/src/config.test.ts
+++ b/services/bayn/src/config.test.ts
@@ -12,12 +12,15 @@ const buildMetadata: EmbeddedBuildMetadata = {
   sourceRevision,
   imageRepository,
   strategyBehaviorHash: 'c'.repeat(64),
+  strategyParameterHash: 'f'.repeat(64),
 }
 
 const runtimeEnvironment = new Map([
   ['BAYN_CODE_REVISION', sourceRevision],
   ['BAYN_IMAGE_REPOSITORY', imageRepository],
   ['BAYN_IMAGE_DIGEST', imageDigest],
+  ['BAYN_STRATEGY_BEHAVIOR_HASH', buildMetadata.strategyBehaviorHash],
+  ['BAYN_STRATEGY_PARAMETER_HASH', buildMetadata.strategyParameterHash],
   ['BAYN_CLICKHOUSE_URL', 'http://clickhouse.test:8123'],
   ['BAYN_CLICKHOUSE_USERNAME', 'bayn'],
   ['BAYN_CLICKHOUSE_PASSWORD', 'secret'],
@@ -93,6 +96,7 @@ describe('Effect configuration', () => {
       verification: 'development-configured',
     })
     expect(config.build.strategyBehaviorHash).toMatch(/^[a-f0-9]{64}$/)
+    expect(config.build.strategyParameterHash).toMatch(/^[a-f0-9]{64}$/)
   })
 
   test('does not let missing build facts or development mode bypass production verification', async () => {
@@ -165,6 +169,8 @@ describe('Effect configuration', () => {
     for (const [name, value] of [
       ['BAYN_CODE_REVISION', 'd'.repeat(40)],
       ['BAYN_IMAGE_REPOSITORY', 'registry.example.invalid/bayn'],
+      ['BAYN_STRATEGY_BEHAVIOR_HASH', 'd'.repeat(64)],
+      ['BAYN_STRATEGY_PARAMETER_HASH', 'e'.repeat(64)],
     ] as const) {
       const invalid = new Map(runtimeEnvironment)
       invalid.set(name, value)

--- a/services/bayn/src/config.ts
+++ b/services/bayn/src/config.ts
@@ -3,7 +3,6 @@ import { Config, Effect, Option, Redacted, Schema, SchemaTransformation } from '
 import { EmbeddedBuildMetadataSchema, embeddedBuildMetadata, type EmbeddedBuildMetadata } from './build'
 import { EvaluationBoundsSchema, IsoDateSchema, Sha256Schema, type EvaluationBounds } from './contracts'
 import { operationalError, type OperationalError } from './errors'
-import { sha256 } from './hash'
 
 export interface RuntimeBuildMetadata extends EmbeddedBuildMetadata {
   readonly imageDigest: string
@@ -44,7 +43,6 @@ const SourceRevision = Schema.String.check(Schema.isPattern(/^[a-f0-9]{40}$/))
 const ImageRepository = Schema.String.check(Schema.isPattern(/^[a-z0-9.-]+(?::[0-9]+)?\/[a-z0-9._/-]+$/))
 const ImageDigest = Schema.String.check(Schema.isPattern(/^sha256:[a-f0-9]{64}$/))
 const ProvenanceMode = Schema.Literals(['production', 'development'])
-const developmentBehaviorHash = sha256('bayn.development-configured-behavior.v1')
 const ReplicaAddresses = Schema.Trim.pipe(
   Schema.decodeTo(
     Schema.Array(NonEmptyString).check(Schema.isMinLength(1)),
@@ -72,6 +70,8 @@ const runtimeConfig = Config.all({
   sourceRevision: Config.schema(SourceRevision, 'BAYN_CODE_REVISION'),
   imageRepository: Config.schema(ImageRepository, 'BAYN_IMAGE_REPOSITORY'),
   imageDigest: Config.schema(ImageDigest, 'BAYN_IMAGE_DIGEST'),
+  strategyBehaviorHash: Config.schema(Sha256Schema, 'BAYN_STRATEGY_BEHAVIOR_HASH'),
+  strategyParameterHash: Config.schema(Sha256Schema, 'BAYN_STRATEGY_PARAMETER_HASH'),
   provenanceMode: Config.schema(ProvenanceMode, 'BAYN_PROVENANCE_MODE').pipe(Config.withDefault('production')),
   qualificationRunId: Config.option(Config.schema(Sha256Schema, 'BAYN_QUALIFICATION_RUN_ID')),
   healthIntervalMs: positiveInteger('BAYN_HEALTH_INTERVAL_MS', 30_000),
@@ -106,6 +106,8 @@ const runtimeConfig = Config.all({
       sourceRevision: config.sourceRevision,
       imageRepository: config.imageRepository,
       imageDigest: config.imageDigest,
+      strategyBehaviorHash: config.strategyBehaviorHash,
+      strategyParameterHash: config.strategyParameterHash,
     },
     provenanceMode: config.provenanceMode,
     healthIntervalMs: config.healthIntervalMs,
@@ -176,7 +178,8 @@ export const loadConfig = (
               ? {
                   sourceRevision: config.configuredBuild.sourceRevision,
                   imageRepository: config.configuredBuild.imageRepository,
-                  strategyBehaviorHash: developmentBehaviorHash,
+                  strategyBehaviorHash: config.configuredBuild.strategyBehaviorHash,
+                  strategyParameterHash: config.configuredBuild.strategyParameterHash,
                 }
               : decodeEmbeddedBuildMetadata(embedded)
           if (embedded !== undefined) {
@@ -189,6 +192,12 @@ export const loadConfig = (
               throw new Error(
                 `configured image repository ${config.configuredBuild.imageRepository} does not match embedded repository ${decodedBuild.imageRepository}`,
               )
+            }
+            if (config.configuredBuild.strategyBehaviorHash !== decodedBuild.strategyBehaviorHash) {
+              throw new Error('configured strategy behavior hash does not match embedded build metadata')
+            }
+            if (config.configuredBuild.strategyParameterHash !== decodedBuild.strategyParameterHash) {
+              throw new Error('configured strategy parameter hash does not match embedded build metadata')
             }
           }
           const { configuredBuild, provenanceMode, ...runtime } = config

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -33,6 +33,7 @@ const makeConfig = (url = testUrl): RuntimeConfig => ({
     imageRepository: 'registry.ide-newton.ts.net/lab/bayn',
     imageDigest: `sha256:${'b'.repeat(64)}`,
     strategyBehaviorHash: 'c'.repeat(64),
+    strategyParameterHash: 'd'.repeat(64),
     verification: 'embedded',
   },
   healthIntervalMs: 30_000,

--- a/services/bayn/src/index.ts
+++ b/services/bayn/src/index.ts
@@ -6,6 +6,7 @@ import { run } from './app'
 import { loadConfig } from './config'
 import { makeRuntimeProvenance } from './contracts'
 import { EvidenceStoreRuntimeLive } from './db/evidence-store'
+import { operationalError } from './errors'
 import { JournalLive } from './ledger'
 import { MarketDataLive } from './market-data'
 import { hashParameters, loadDefaultProtocol } from './protocol'
@@ -14,6 +15,12 @@ import { makeStrategy, Strategy } from './strategy-service'
 const main = Effect.gen(function* () {
   const config = yield* loadConfig()
   const protocol = yield* loadDefaultProtocol
+  const parameterHash = hashParameters(protocol)
+  if (parameterHash !== config.build.strategyParameterHash) {
+    return yield* Effect.fail(
+      operationalError('config', 'provenance', 'compiled strategy parameters do not match build metadata'),
+    )
+  }
   const provenance = makeRuntimeProvenance({
     sourceRevision: config.build.sourceRevision,
     image: {
@@ -23,7 +30,7 @@ const main = Effect.gen(function* () {
     strategy: {
       name: 'risk-balanced-trend',
       behaviorHash: config.build.strategyBehaviorHash,
-      parameterHash: hashParameters(protocol),
+      parameterHash,
       parameterSchemaVersion: protocol.schemaVersion,
     },
   })

--- a/services/bayn/src/ledger.test.ts
+++ b/services/bayn/src/ledger.test.ts
@@ -212,6 +212,7 @@ describe('TigerBeetle simulation journal', () => {
         imageRepository: provenance.image.repository,
         imageDigest: provenance.image.digest,
         strategyBehaviorHash: provenance.strategy.behaviorHash,
+        strategyParameterHash: provenance.strategy.parameterHash,
         verification: 'embedded',
       },
       healthIntervalMs: 30_000,

--- a/services/bayn/src/protocol.test.ts
+++ b/services/bayn/src/protocol.test.ts
@@ -1,8 +1,19 @@
 import { describe, expect, test } from 'bun:test'
 
+import { readFileSync } from 'node:fs'
+
 import { Effect, Exit } from 'effect'
 
 import { defaultProtocolDocument, hashParameters, loadDefaultProtocol, loadProtocol } from './protocol'
+
+const imageParameterHash = (): string => {
+  const imageSource = readFileSync(new URL('../../../nix/images/bayn.nix', import.meta.url), 'utf8')
+  const matches = [...imageSource.matchAll(/^\s*strategyParameterHash = "([a-f0-9]{64})";$/gm)]
+  if (matches.length !== 1 || matches[0]?.[1] === undefined) {
+    throw new Error('nix/images/bayn.nix must define exactly one strategyParameterHash')
+  }
+  return matches[0][1]
+}
 
 describe('strategy protocol', () => {
   test('decodes the committed protocol', async () => {
@@ -20,7 +31,7 @@ describe('strategy protocol', () => {
       maximumSymbolWeight: 0.35,
       maximumPortfolioVolatility: 0.1,
     })
-    expect(hashParameters(protocol)).toMatch(/^[a-f0-9]{64}$/)
+    expect(hashParameters(protocol)).toBe(imageParameterHash())
   })
 
   test('rejects legacy, malformed, and non-canonical documents', async () => {

--- a/services/bayn/src/resources.test.ts
+++ b/services/bayn/src/resources.test.ts
@@ -22,6 +22,7 @@ const config: RuntimeConfig = {
     imageRepository: provenance.image.repository,
     imageDigest: provenance.image.digest,
     strategyBehaviorHash: provenance.strategy.behaviorHash,
+    strategyParameterHash: provenance.strategy.parameterHash,
     verification: 'embedded',
   },
   healthIntervalMs: 100,


### PR DESCRIPTION
## Summary

- Bind every Bayn image and deployment to compiled strategy behavior plus canonical protocol parameters.
- Derive qualification-pin handling from the complete recoverable binding: strategy, Signal snapshot/bounds, TigerBeetle target, and pin presence.
- Preserve only an exactly compatible terminal run; otherwise remove one pin or continue safely when already unpinned.
- Fail startup when configured, embedded, and runtime-computed strategy identity diverges.

## Related Issues

PROOMPT-400

Follow-up to #13035 and all Codex review findings on this PR.

## Testing

- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn test` — 115 passed, 25 skipped, 0 failed.
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- `bun test packages/scripts/src/bayn` — 2 passed, 0 failed; covers compatible preserve, Signal-driven replace, parameter-driven replace, and a later unpinned promotion.
- `actionlint -shellcheck '' -pyflakes '' .github/workflows/bayn-release.yml`
- `bun run lint:argocd`
- `kustomize build argocd/applications/bayn`
- Runtime protocol hashing reproduced `cf639d3692da65271b12423f9b7c6c9663e1fb13ae7290dc56fcfa3acf16eb69`, matching Nix and GitOps identity.
- `git diff --check`

## Breaking Changes

Bayn now requires `BAYN_STRATEGY_BEHAVIOR_HASH` and `BAYN_STRATEGY_PARAMETER_HASH`, and production verifies them against embedded build metadata. Promotion derives `preserve` only from a complete matching runtime binding; otherwise it uses `replace`. Databases with the old migration tracker remain hard-rejected with no fallback or automatic rename.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
