### PR TITLE
fix(bayn): harden release contract

### DIFF
--- a/.github/workflows/bayn-release.yml
+++ b/.github/workflows/bayn-release.yml
@@ -103,20 +103,23 @@ jobs:
           IMAGE_DIGEST: ${{ steps.release.outputs.digest }}
         run: |
           set -euo pipefail
-          nix_hash() {
-            local name="$1"
-            local -a hashes
-            mapfile -t hashes < <(
-              git show "${SOURCE_SHA}:nix/images/bayn.nix" |
-                sed -nE "s/^[[:space:]]*${name} = \"([0-9a-f]{64})\";$/\\1/p"
-            )
-            test "${#hashes[@]}" -eq 1
-            printf '%s' "${hashes[0]}"
+          image_label() {
+            local config="$1"
+            local name="$2"
+            jq -er --arg name "$name" '.config.Labels[$name] | select(type == "string" and length > 0)' <<< "$config"
           }
 
-          strategy_behavior_hash="$(nix_hash strategyBehaviorHash)"
-          strategy_parameter_hash="$(nix_hash strategyParameterHash)"
-          nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/bayn@${IMAGE_DIGEST}" linux/amd64 linux/arm64
+          candidate_reference="registry.ide-newton.ts.net/lab/bayn@${IMAGE_DIGEST}"
+          nix run .#assert-oci-platforms -- "$candidate_reference" linux/amd64 linux/arm64
+          config_amd64="$(crane config --platform linux/amd64 "$candidate_reference")"
+          config_arm64="$(crane config --platform linux/arm64 "$candidate_reference")"
+          source_revision="$(image_label "$config_amd64" org.opencontainers.image.revision)"
+          strategy_behavior_hash="$(image_label "$config_amd64" proompteng.ai/bayn.strategy-behavior-hash)"
+          strategy_parameter_hash="$(image_label "$config_amd64" proompteng.ai/bayn.strategy-parameter-hash)"
+          test "$source_revision" = "$SOURCE_SHA"
+          test "$(image_label "$config_arm64" org.opencontainers.image.revision)" = "$source_revision"
+          test "$(image_label "$config_arm64" proompteng.ai/bayn.strategy-behavior-hash)" = "$strategy_behavior_hash"
+          test "$(image_label "$config_arm64" proompteng.ai/bayn.strategy-parameter-hash)" = "$strategy_parameter_hash"
           promotion="$(
             bun packages/scripts/src/bayn/update-manifests.ts \
               --source-sha "$SOURCE_SHA" \
@@ -131,6 +134,9 @@ jobs:
             echo "qualification_mode=$(jq -r '.qualificationMode' <<< "$promotion")"
             echo "had_qualification_pin=$(jq -r '.hadQualificationPin' <<< "$promotion")"
             echo "runtime_bindings_match=$(jq -r '.runtimeBindingsMatch' <<< "$promotion")"
+            echo "snapshot_changed=$(jq -r '.snapshotChanged' <<< "$promotion")"
+            echo "deployed_snapshot_id=$(jq -r '.deployedSnapshotId' <<< "$promotion")"
+            echo "candidate_snapshot_id=$(jq -r '.candidateSnapshotId' <<< "$promotion")"
             echo "deployed_source=$(jq -r '.deployedSourceSha' <<< "$promotion")"
             echo "deployed_behavior_hash=$(jq -r '.deployedBehaviorHash' <<< "$promotion")"
             echo "deployed_parameter_hash=$(jq -r '.deployedParameterHash' <<< "$promotion")"
@@ -163,6 +169,9 @@ jobs:
             - Qualification mode: `${{ steps.promotion.outputs.qualification_mode }}`
             - Existing pin: `${{ steps.promotion.outputs.had_qualification_pin }}`
             - Runtime bindings match: `${{ steps.promotion.outputs.runtime_bindings_match }}`
+            - Snapshot changed: `${{ steps.promotion.outputs.snapshot_changed }}`
+            - Deployed snapshot: `${{ steps.promotion.outputs.deployed_snapshot_id }}`
+            - Candidate snapshot: `${{ steps.promotion.outputs.candidate_snapshot_id }}`
             - Deployed behavior hash: `${{ steps.promotion.outputs.deployed_behavior_hash }}`
             - Candidate behavior hash: `${{ steps.promotion.outputs.candidate_behavior_hash }}`
             - Deployed parameter hash: `${{ steps.promotion.outputs.deployed_parameter_hash }}`
@@ -185,7 +194,8 @@ jobs:
             This is a one-way current-contract runtime release. Databases with the old migration tracker are rejected;
             there is no schema fallback or automatic rename. `preserve` keeps the terminal run only when compiled
             behavior, protocol parameters, Signal inputs, and TigerBeetle bindings all match. `replace` removes the
-            pin, and later unpinned promotions remain valid without reintroducing compatibility state.
+            pin only for a fresh Signal snapshot. After that qualification, another image requires its terminal run
+            to be pinned or another fresh snapshot.
 
             ## Checklist
 

--- a/nix/images/bayn.nix
+++ b/nix/images/bayn.nix
@@ -33,7 +33,7 @@ import ./bun-workspace-service.nix {
   buildCommands = [
     "bun --cwd=services/bayn run tsc"
     (
-      "bun --cwd=services/bayn build src/index.ts --target=node "
+      "bun --cwd=services/bayn build src/index.ts src/verify-build-contract.ts --target=node "
       + "--external tigerbeetle-node --outdir=dist "
       + buildDefine "__BAYN_BUILD_SOURCE_REVISION__" repoRevision
       + " "
@@ -43,13 +43,14 @@ import ./bun-workspace-service.nix {
       + " "
       + buildDefine "__BAYN_BUILD_STRATEGY_PARAMETER_HASH__" strategyParameterHash
     )
+    "node services/bayn/dist/verify-build-contract.js"
     "grep -F -- ${lib.escapeShellArg repoRevision} services/bayn/dist/index.js"
     "grep -F -- ${lib.escapeShellArg strategyBehaviorHash} services/bayn/dist/index.js"
     "grep -F -- ${lib.escapeShellArg strategyParameterHash} services/bayn/dist/index.js"
   ];
   runtimeInstallPhase = ''
     mkdir -p "$out/app/services/bayn/dist" "$out/app/services/bayn/node_modules/tigerbeetle-node"
-    cp "$TMPDIR/work/services/bayn/dist/"*.js "$out/app/services/bayn/dist/"
+    cp "$TMPDIR/work/services/bayn/dist/index.js" "$out/app/services/bayn/dist/"
     cp "$TMPDIR/work/services/bayn/package.json" "$out/app/services/bayn/package.json"
     cp -R -L "$TMPDIR/work/services/bayn/node_modules/tigerbeetle-node/." \
       "$out/app/services/bayn/node_modules/tigerbeetle-node/"

--- a/packages/scripts/src/bayn/update-manifests.test.ts
+++ b/packages/scripts/src/bayn/update-manifests.test.ts
@@ -1,9 +1,41 @@
 import { afterEach, describe, expect, test } from 'bun:test'
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
-import { join } from 'node:path'
 import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
-import { updateBaynManifests } from './update-manifests'
+import { updateBaynManifests, type UpdateBaynManifestOptions } from './update-manifests'
+
+const currentSnapshotId = '98f9b0cdee311b248d4ed36104fa46ff86c34d587d6e71a6706a9d778c110292'
+const strategyBehaviorHash = '1'.repeat(64)
+const strategyParameterHash = '2'.repeat(64)
+const qualificationRunId = '9'.repeat(64)
+const currentBindings = {
+  BAYN_SIGNAL_SNAPSHOT_ID: currentSnapshotId,
+  BAYN_SIGNAL_PUBLICATION_ASOF: '2026-07-20',
+  BAYN_SIGNAL_CALENDAR_VERSION: 'alpaca-us-equity-calendar-v1',
+  BAYN_SIGNAL_DATA_START: '2022-01-27',
+  BAYN_SIGNAL_DATA_END: '2026-07-20',
+  BAYN_SIGNAL_LOOKBACK_START: '2022-01-27',
+  BAYN_SIGNAL_EVALUATION_START: '2023-01-30',
+  BAYN_SIGNAL_EVALUATION_END: '2026-07-20',
+  BAYN_TIGERBEETLE_CLUSTER_ID: '122731676035874920802382025803517750735',
+  BAYN_TIGERBEETLE_ADDRESSES: 'ledger.bayn.svc.cluster.local:3000',
+  BAYN_TIGERBEETLE_LEDGER: '7001',
+} as const
+
+interface FixtureOptions {
+  readonly snapshotId?: string
+  readonly publicationAsOf?: string
+  readonly behaviorHash?: string
+  readonly parameterHash?: string
+  readonly qualificationRunId?: string | undefined
+}
+
+interface FixturePaths {
+  readonly kustomizationPath: string
+  readonly deploymentPath: string
+  readonly applicationSetPath: string
+}
 
 let directory: string | undefined
 
@@ -12,173 +44,119 @@ afterEach(() => {
   directory = undefined
 })
 
-describe('Bayn manifest promotion', () => {
-  test('derives qualification-pin handling from the complete runtime binding', () => {
-    directory = mkdtempSync(join(tmpdir(), 'bayn-manifest-'))
-    const kustomizationPath = join(directory, 'kustomization.yaml')
-    const deploymentPath = join(directory, 'deployment.yaml')
-    const applicationSetPath = join(directory, 'product.yaml')
-    const strategyBehaviorHash = '1'.repeat(64)
-    const strategyParameterHash = '2'.repeat(64)
-    writeFileSync(
-      kustomizationPath,
-      `images:\n  - name: registry.ide-newton.ts.net/lab/bayn\n    newName: registry.ide-newton.ts.net/lab/bayn\n    newTag: bootstrap\n`,
-    )
-    writeFileSync(
-      deploymentPath,
-      `metadata:\n  template:\n    metadata:\n      annotations:\n        kubectl.kubernetes.io/restartedAt: "old"\n    spec:\n      containers:\n        - env:\n            - name: BAYN_CODE_REVISION\n              value: bootstrap\n            - name: BAYN_IMAGE_REPOSITORY\n              value: registry.ide-newton.ts.net/lab/bayn\n            - name: BAYN_IMAGE_DIGEST\n              value: sha256:old\n            - name: BAYN_QUALIFICATION_RUN_ID\n              value: legacy-run\n            - name: BAYN_SIGNAL_SNAPSHOT_ID\n              value: legacy-snapshot\n            - name: BAYN_SIGNAL_PUBLICATION_ASOF\n              value: 2026-07-19\n            - name: BAYN_SIGNAL_CALENDAR_VERSION\n              value: legacy-calendar\n            - name: BAYN_SIGNAL_DATA_START\n              value: 2017-01-03\n            - name: BAYN_SIGNAL_DATA_END\n              value: 2026-07-19\n            - name: BAYN_SIGNAL_LOOKBACK_START\n              value: 2017-01-03\n            - name: BAYN_SIGNAL_EVALUATION_START\n              value: 2018-01-03\n            - name: BAYN_SIGNAL_EVALUATION_END\n              value: 2026-07-19\n            - name: BAYN_TIGERBEETLE_CLUSTER_ID\n              value: "2001"\n            - name: BAYN_TIGERBEETLE_ADDRESSES\n              value: old-ledger.example:3000\n            - name: BAYN_TIGERBEETLE_LEDGER\n              value: "7001"\n`,
-    )
-    writeFileSync(
-      deploymentPath,
-      readFileSync(deploymentPath, 'utf8').replace(
-        '            - name: BAYN_QUALIFICATION_RUN_ID\n',
-        `            - name: BAYN_STRATEGY_BEHAVIOR_HASH\n              value: old\n            - name: BAYN_STRATEGY_PARAMETER_HASH\n              value: old\n            - name: BAYN_QUALIFICATION_RUN_ID\n`,
-      ),
-    )
-    writeFileSync(
-      applicationSetPath,
-      `elements:\n              - name: bayn\n                path: argocd/applications/bayn\n                enabled: "false"\n              - name: next\n                enabled: "true"\n`,
-    )
-    const addQualificationPin = () =>
-      writeFileSync(
-        deploymentPath,
-        readFileSync(deploymentPath, 'utf8').replace(
-          '            - name: BAYN_SIGNAL_SNAPSHOT_ID\n',
-          `            - name: BAYN_QUALIFICATION_RUN_ID\n              value: ${'9'.repeat(64)}\n            - name: BAYN_SIGNAL_SNAPSHOT_ID\n`,
-        ),
-      )
-    const sourceSha = 'a'.repeat(40)
-    const digest = `sha256:${'b'.repeat(64)}`
-    const initial = updateBaynManifests({
-      sourceSha,
-      tag: `sha-${sourceSha}`,
-      digest,
-      strategyBehaviorHash,
-      strategyParameterHash,
-      rolloutTimestamp: '2026-07-19T10:00:00Z',
-      kustomizationPath,
-      deploymentPath,
-      applicationSetPath,
-    })
-    expect(initial).toMatchObject({
-      qualificationMode: 'replace',
-      hadQualificationPin: true,
-      runtimeBindingsMatch: false,
-    })
-    expect(readFileSync(kustomizationPath, 'utf8')).toContain(`newTag: "sha-${sourceSha}"\n    digest: ${digest}`)
-    expect(readFileSync(deploymentPath, 'utf8')).toContain(`value: ${sourceSha}`)
-    expect(readFileSync(deploymentPath, 'utf8')).toContain(
-      `- name: BAYN_IMAGE_REPOSITORY\n              value: registry.ide-newton.ts.net/lab/bayn`,
-    )
-    expect(readFileSync(deploymentPath, 'utf8')).toContain(`- name: BAYN_IMAGE_DIGEST\n              value: ${digest}`)
-    expect(readFileSync(deploymentPath, 'utf8')).toContain(
-      `- name: BAYN_STRATEGY_BEHAVIOR_HASH\n              value: "${strategyBehaviorHash}"`,
-    )
-    expect(readFileSync(deploymentPath, 'utf8')).toContain(
-      `- name: BAYN_STRATEGY_PARAMETER_HASH\n              value: "${strategyParameterHash}"`,
-    )
-    expect(readFileSync(deploymentPath, 'utf8')).not.toContain('BAYN_QUALIFICATION_RUN_ID')
-    expect(readFileSync(deploymentPath, 'utf8')).toContain(
-      '- name: BAYN_SIGNAL_SNAPSHOT_ID\n              value: "98f9b0cdee311b248d4ed36104fa46ff86c34d587d6e71a6706a9d778c110292"',
-    )
-    expect(readFileSync(deploymentPath, 'utf8')).toContain(
-      '- name: BAYN_SIGNAL_EVALUATION_START\n              value: "2023-01-30"',
-    )
-    expect(readFileSync(deploymentPath, 'utf8')).toContain(
-      '- name: BAYN_TIGERBEETLE_CLUSTER_ID\n              value: "122731676035874920802382025803517750735"',
-    )
-    expect(readFileSync(deploymentPath, 'utf8')).toContain(
-      '- name: BAYN_TIGERBEETLE_ADDRESSES\n              value: "ledger.bayn.svc.cluster.local:3000"',
-    )
-    expect(readFileSync(deploymentPath, 'utf8')).toContain('restartedAt: "2026-07-19T10:00:00Z"')
-    expect(readFileSync(applicationSetPath, 'utf8')).toContain(
-      '- name: bayn\n                path: argocd/applications/bayn\n                enabled: "true"',
-    )
+const environmentBlock = (name: string, value: string): string =>
+  `            - name: ${name}\n              value: ${JSON.stringify(value)}\n`
 
-    addQualificationPin()
-    const nextSourceSha = 'c'.repeat(40)
-    const preserved = updateBaynManifests({
-      sourceSha: nextSourceSha,
-      tag: `sha-${nextSourceSha}`,
-      digest: `sha256:${'d'.repeat(64)}`,
-      strategyBehaviorHash,
-      strategyParameterHash,
-      rolloutTimestamp: '2026-07-20T10:00:00Z',
-      kustomizationPath,
-      deploymentPath,
-      applicationSetPath,
-    })
-    expect(preserved).toMatchObject({
+const makeFixture = (options: FixtureOptions = {}): FixturePaths => {
+  directory = mkdtempSync(join(tmpdir(), 'bayn-manifest-'))
+  const paths = {
+    kustomizationPath: join(directory, 'kustomization.yaml'),
+    deploymentPath: join(directory, 'deployment.yaml'),
+    applicationSetPath: join(directory, 'product.yaml'),
+  }
+  const bindings = {
+    ...currentBindings,
+    BAYN_SIGNAL_SNAPSHOT_ID: options.snapshotId ?? currentBindings.BAYN_SIGNAL_SNAPSHOT_ID,
+    BAYN_SIGNAL_PUBLICATION_ASOF: options.publicationAsOf ?? currentBindings.BAYN_SIGNAL_PUBLICATION_ASOF,
+  }
+  const pin = options.qualificationRunId === undefined ? qualificationRunId : options.qualificationRunId
+  const environment = [
+    environmentBlock('BAYN_CODE_REVISION', '0'.repeat(40)),
+    environmentBlock('BAYN_IMAGE_REPOSITORY', 'registry.ide-newton.ts.net/lab/bayn'),
+    environmentBlock('BAYN_IMAGE_DIGEST', `sha256:${'0'.repeat(64)}`),
+    environmentBlock('BAYN_STRATEGY_BEHAVIOR_HASH', options.behaviorHash ?? strategyBehaviorHash),
+    environmentBlock('BAYN_STRATEGY_PARAMETER_HASH', options.parameterHash ?? strategyParameterHash),
+    pin === undefined ? '' : environmentBlock('BAYN_QUALIFICATION_RUN_ID', pin),
+    ...Object.entries(bindings).map(([name, value]) => environmentBlock(name, value)),
+  ].join('')
+
+  writeFileSync(
+    paths.kustomizationPath,
+    'images:\n  - name: registry.ide-newton.ts.net/lab/bayn\n    newName: registry.ide-newton.ts.net/lab/bayn\n    newTag: bootstrap\n',
+  )
+  writeFileSync(
+    paths.deploymentPath,
+    `metadata:\n  template:\n    metadata:\n      annotations:\n        kubectl.kubernetes.io/restartedAt: "old"\n    spec:\n      containers:\n        - env:\n${environment}`,
+  )
+  writeFileSync(
+    paths.applicationSetPath,
+    'elements:\n              - name: bayn\n                path: argocd/applications/bayn\n                enabled: "false"\n              - name: next\n                enabled: "true"\n',
+  )
+  return paths
+}
+
+const promote = (
+  paths: FixturePaths,
+  overrides: Partial<Pick<UpdateBaynManifestOptions, 'strategyBehaviorHash' | 'strategyParameterHash'>> = {},
+) => {
+  const sourceSha = 'a'.repeat(40)
+  return updateBaynManifests({
+    sourceSha,
+    tag: `sha-${sourceSha}`,
+    digest: `sha256:${'b'.repeat(64)}`,
+    strategyBehaviorHash: overrides.strategyBehaviorHash ?? strategyBehaviorHash,
+    strategyParameterHash: overrides.strategyParameterHash ?? strategyParameterHash,
+    rolloutTimestamp: '2026-07-22T10:00:00Z',
+    ...paths,
+  })
+}
+
+describe('Bayn manifest promotion', () => {
+  test('preserves a qualification pin only for identical strategy and runtime bindings', () => {
+    const paths = makeFixture()
+    const result = promote(paths)
+
+    expect(result).toMatchObject({
       qualificationMode: 'preserve',
       hadQualificationPin: true,
       runtimeBindingsMatch: true,
+      snapshotChanged: false,
+      deployedSnapshotId: currentSnapshotId,
+      candidateSnapshotId: currentSnapshotId,
     })
-    expect(readFileSync(deploymentPath, 'utf8')).toContain(
-      `- name: BAYN_QUALIFICATION_RUN_ID\n              value: ${'9'.repeat(64)}`,
+    expect(readFileSync(paths.deploymentPath, 'utf8')).toContain(
+      environmentBlock('BAYN_QUALIFICATION_RUN_ID', qualificationRunId).trim(),
     )
-    expect(readFileSync(deploymentPath, 'utf8')).toContain(`value: ${nextSourceSha}`)
+    expect(readFileSync(paths.applicationSetPath, 'utf8')).toContain('enabled: "true"')
+  })
 
-    writeFileSync(
-      deploymentPath,
-      readFileSync(deploymentPath, 'utf8').replace(
-        'BAYN_SIGNAL_PUBLICATION_ASOF\n              value: "2026-07-20"',
-        'BAYN_SIGNAL_PUBLICATION_ASOF\n              value: "2026-07-19"',
-      ),
+  test('rejects an incompatible strategy against an already-qualified snapshot without writing files', () => {
+    const paths = makeFixture()
+    const before = Object.values(paths).map((path) => readFileSync(path, 'utf8'))
+
+    expect(() => promote(paths, { strategyParameterHash: '3'.repeat(64) })).toThrow(
+      'qualification replacement requires a fresh BAYN_SIGNAL_SNAPSHOT_ID',
     )
-    const signalChangeSourceSha = 'e'.repeat(40)
-    const signalChange = updateBaynManifests({
-      sourceSha: signalChangeSourceSha,
-      tag: `sha-${signalChangeSourceSha}`,
-      digest: `sha256:${'f'.repeat(64)}`,
-      strategyBehaviorHash,
-      strategyParameterHash,
-      rolloutTimestamp: '2026-07-21T10:00:00Z',
-      kustomizationPath,
-      deploymentPath,
-      applicationSetPath,
-    })
-    expect(signalChange).toMatchObject({
+    expect(Object.values(paths).map((path) => readFileSync(path, 'utf8'))).toEqual(before)
+  })
+
+  test('rejects changed runtime bindings against an already-qualified snapshot', () => {
+    const paths = makeFixture({ publicationAsOf: '2026-07-19' })
+
+    expect(() => promote(paths)).toThrow('qualification replacement requires a fresh BAYN_SIGNAL_SNAPSHOT_ID')
+  })
+
+  test('replaces a pin for a fresh snapshot and rejects another unpinned release on that snapshot', () => {
+    const paths = makeFixture({ snapshotId: '4'.repeat(64), publicationAsOf: '2026-07-19' })
+    const changedParameterHash = '3'.repeat(64)
+    const first = promote(paths, { strategyParameterHash: changedParameterHash })
+
+    expect(first).toMatchObject({
       qualificationMode: 'replace',
       hadQualificationPin: true,
       runtimeBindingsMatch: false,
+      snapshotChanged: true,
+      deployedSnapshotId: '4'.repeat(64),
+      candidateSnapshotId: currentSnapshotId,
     })
-    expect(readFileSync(deploymentPath, 'utf8')).not.toContain('BAYN_QUALIFICATION_RUN_ID')
+    expect(readFileSync(paths.deploymentPath, 'utf8')).not.toContain('BAYN_QUALIFICATION_RUN_ID')
+    expect(readFileSync(paths.deploymentPath, 'utf8')).toContain(
+      environmentBlock('BAYN_SIGNAL_SNAPSHOT_ID', currentSnapshotId).trim(),
+    )
 
-    const unpinnedSourceSha = '6'.repeat(40)
-    const unpinned = updateBaynManifests({
-      sourceSha: unpinnedSourceSha,
-      tag: `sha-${unpinnedSourceSha}`,
-      digest: `sha256:${'7'.repeat(64)}`,
-      strategyBehaviorHash,
-      strategyParameterHash,
-      rolloutTimestamp: '2026-07-22T10:00:00Z',
-      kustomizationPath,
-      deploymentPath,
-      applicationSetPath,
-    })
-    expect(unpinned).toMatchObject({
-      qualificationMode: 'replace',
-      hadQualificationPin: false,
-      runtimeBindingsMatch: true,
-    })
-
-    addQualificationPin()
-    const changedParameters = updateBaynManifests({
-      sourceSha: '8'.repeat(40),
-      tag: `sha-${'8'.repeat(40)}`,
-      digest: `sha256:${'8'.repeat(64)}`,
-      strategyBehaviorHash,
-      strategyParameterHash: '8'.repeat(64),
-      rolloutTimestamp: '2026-07-23T10:00:00Z',
-      kustomizationPath,
-      deploymentPath,
-      applicationSetPath,
-    })
-    expect(changedParameters).toMatchObject({
-      qualificationMode: 'replace',
-      hadQualificationPin: true,
-      runtimeBindingsMatch: true,
-    })
+    expect(() => promote(paths, { strategyParameterHash: changedParameterHash })).toThrow(
+      'qualification replacement requires a fresh BAYN_SIGNAL_SNAPSHOT_ID',
+    )
   })
 
   test('rejects malformed release metadata', () => {
@@ -187,8 +165,8 @@ describe('Bayn manifest promotion', () => {
         sourceSha: 'main',
         tag: 'latest',
         digest: 'sha256:bad',
-        strategyBehaviorHash: '1'.repeat(64),
-        strategyParameterHash: '2'.repeat(64),
+        strategyBehaviorHash,
+        strategyParameterHash,
         rolloutTimestamp: 'now',
         applicationSetPath: 'unused',
       }),

--- a/packages/scripts/src/bayn/update-manifests.ts
+++ b/packages/scripts/src/bayn/update-manifests.ts
@@ -37,6 +37,9 @@ export interface BaynManifestUpdate {
   readonly qualificationMode: 'preserve' | 'replace'
   readonly hadQualificationPin: boolean
   readonly runtimeBindingsMatch: boolean
+  readonly snapshotChanged: boolean
+  readonly deployedSnapshotId: string
+  readonly candidateSnapshotId: string
   readonly deployedSourceSha: string
   readonly deployedBehaviorHash: string
   readonly deployedParameterHash: string
@@ -96,6 +99,9 @@ export const updateBaynManifests = (options: UpdateBaynManifestOptions): BaynMan
   const deployedSourceSha = environmentValue(deployment, 'BAYN_CODE_REVISION')
   const deployedBehaviorHash = environmentValue(deployment, 'BAYN_STRATEGY_BEHAVIOR_HASH')
   const deployedParameterHash = environmentValue(deployment, 'BAYN_STRATEGY_PARAMETER_HASH')
+  const deployedSnapshotId = environmentValue(deployment, 'BAYN_SIGNAL_SNAPSHOT_ID')
+  const candidateSnapshotId = currentRuntimeConfiguration.BAYN_SIGNAL_SNAPSHOT_ID
+  const snapshotChanged = deployedSnapshotId !== candidateSnapshotId
   const runtimeBindingsMatch = Object.entries(currentRuntimeConfiguration).every(
     ([name, value]) => environmentValue(deployment, name) === value,
   )
@@ -103,6 +109,9 @@ export const updateBaynManifests = (options: UpdateBaynManifestOptions): BaynMan
     deployedBehaviorHash === options.strategyBehaviorHash && deployedParameterHash === options.strategyParameterHash
   const qualificationMode =
     hadQualificationPin && strategyIdentityMatches && runtimeBindingsMatch ? 'preserve' : 'replace'
+  if (qualificationMode === 'replace' && !snapshotChanged) {
+    throw new Error('qualification replacement requires a fresh BAYN_SIGNAL_SNAPSHOT_ID')
+  }
   const imageBlock =
     /(  - name: registry\.ide-newton\.ts\.net\/lab\/bayn\n    newName: registry\.ide-newton\.ts\.net\/lab\/bayn\n    newTag: )[^\n]+(?:\n    digest: [^\n]+)?/
   const updatedKustomization = replaceExactlyOnce(
@@ -167,6 +176,9 @@ export const updateBaynManifests = (options: UpdateBaynManifestOptions): BaynMan
     qualificationMode,
     hadQualificationPin,
     runtimeBindingsMatch,
+    snapshotChanged,
+    deployedSnapshotId,
+    candidateSnapshotId,
     deployedSourceSha,
     deployedBehaviorHash,
     deployedParameterHash,

--- a/services/bayn/src/build.ts
+++ b/services/bayn/src/build.ts
@@ -1,4 +1,6 @@
-import { Schema } from 'effect'
+import { Effect, Schema } from 'effect'
+
+import { operationalError, type OperationalError } from './errors'
 
 declare const __BAYN_BUILD_SOURCE_REVISION__: string
 declare const __BAYN_BUILD_IMAGE_REPOSITORY__: string
@@ -40,3 +42,11 @@ export const embeddedBuildMetadata: EmbeddedBuildMetadata | undefined = hasNoEmb
       strategyBehaviorHash: strategyBehaviorHash ?? 'incomplete',
       strategyParameterHash: strategyParameterHash ?? 'incomplete',
     }
+
+export const verifyParameterHash = (
+  metadata: EmbeddedBuildMetadata,
+  actualParameterHash: string,
+): Effect.Effect<void, OperationalError> =>
+  metadata.strategyParameterHash === actualParameterHash
+    ? Effect.void
+    : Effect.fail(operationalError('config', 'provenance', 'compiled strategy parameters do not match build metadata'))

--- a/services/bayn/src/index.ts
+++ b/services/bayn/src/index.ts
@@ -3,10 +3,10 @@ import { ClickhouseClient } from '@effect/sql-clickhouse'
 import { Effect, Layer, Logger, Redacted } from 'effect'
 
 import { run } from './app'
+import { verifyParameterHash } from './build'
 import { loadConfig } from './config'
 import { makeRuntimeProvenance } from './contracts'
 import { EvidenceStoreRuntimeLive } from './db/evidence-store'
-import { operationalError } from './errors'
 import { JournalLive } from './ledger'
 import { MarketDataLive } from './market-data'
 import { hashParameters, loadDefaultProtocol } from './protocol'
@@ -16,11 +16,7 @@ const main = Effect.gen(function* () {
   const config = yield* loadConfig()
   const protocol = yield* loadDefaultProtocol
   const parameterHash = hashParameters(protocol)
-  if (parameterHash !== config.build.strategyParameterHash) {
-    return yield* Effect.fail(
-      operationalError('config', 'provenance', 'compiled strategy parameters do not match build metadata'),
-    )
-  }
+  yield* verifyParameterHash(config.build, parameterHash)
   const provenance = makeRuntimeProvenance({
     sourceRevision: config.build.sourceRevision,
     image: {

--- a/services/bayn/src/protocol.test.ts
+++ b/services/bayn/src/protocol.test.ts
@@ -1,19 +1,9 @@
 import { describe, expect, test } from 'bun:test'
 
-import { readFileSync } from 'node:fs'
-
 import { Effect, Exit } from 'effect'
 
+import { verifyParameterHash, type EmbeddedBuildMetadata } from './build'
 import { defaultProtocolDocument, hashParameters, loadDefaultProtocol, loadProtocol } from './protocol'
-
-const imageParameterHash = (): string => {
-  const imageSource = readFileSync(new URL('../../../nix/images/bayn.nix', import.meta.url), 'utf8')
-  const matches = [...imageSource.matchAll(/^\s*strategyParameterHash = "([a-f0-9]{64})";$/gm)]
-  if (matches.length !== 1 || matches[0]?.[1] === undefined) {
-    throw new Error('nix/images/bayn.nix must define exactly one strategyParameterHash')
-  }
-  return matches[0][1]
-}
 
 describe('strategy protocol', () => {
   test('decodes the committed protocol', async () => {
@@ -31,7 +21,25 @@ describe('strategy protocol', () => {
       maximumSymbolWeight: 0.35,
       maximumPortfolioVolatility: 0.1,
     })
-    expect(hashParameters(protocol)).toBe(imageParameterHash())
+    expect(hashParameters(protocol)).toMatch(/^[a-f0-9]{64}$/)
+  })
+
+  test('rejects build metadata for different compiled parameters', async () => {
+    const protocol = await Effect.runPromise(loadDefaultProtocol)
+    const parameterHash = hashParameters(protocol)
+    const metadata: EmbeddedBuildMetadata = {
+      sourceRevision: 'a'.repeat(40),
+      imageRepository: 'registry.example.test/lab/bayn',
+      strategyBehaviorHash: 'b'.repeat(64),
+      strategyParameterHash: parameterHash,
+    }
+
+    await Effect.runPromise(verifyParameterHash(metadata, parameterHash))
+    const exit = await Effect.runPromiseExit(
+      verifyParameterHash({ ...metadata, strategyParameterHash: '0'.repeat(64) }, parameterHash),
+    )
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) expect(exit.cause.toString()).toContain('compiled strategy parameters')
   })
 
   test('rejects legacy, malformed, and non-canonical documents', async () => {

--- a/services/bayn/src/verify-build-contract.ts
+++ b/services/bayn/src/verify-build-contract.ts
@@ -1,0 +1,20 @@
+import { NodeRuntime } from '@effect/platform-node'
+import { Effect, Schema } from 'effect'
+
+import { embeddedBuildMetadata, EmbeddedBuildMetadataSchema, verifyParameterHash } from './build'
+import { operationalError } from './errors'
+import { hashParameters, loadDefaultProtocol } from './protocol'
+
+const program = Effect.gen(function* () {
+  const metadata = yield* Schema.decodeUnknownEffect(EmbeddedBuildMetadataSchema, {
+    onExcessProperty: 'error',
+  })(embeddedBuildMetadata).pipe(
+    Effect.mapError((cause) =>
+      operationalError('config', 'provenance', 'production image is missing complete build metadata', cause),
+    ),
+  )
+  const protocol = yield* loadDefaultProtocol
+  yield* verifyParameterHash(metadata, hashParameters(protocol))
+})
+
+NodeRuntime.runMain(program)


### PR DESCRIPTION
## Summary

- Refuse qualification replacement unless the candidate advances to a fresh Signal snapshot, whether or not the current manifest is pinned.
- Execute a production build verifier that compares bundled parameter identity with the decoded TypeScript protocol.
- Read source, behavior, and parameter identity from both published OCI platform configs and record snapshot transition evidence in promotion PRs.

## Related Issues

PROOMPT-400
Follow-up to #13037

## Testing

- bun test packages/scripts/src/bayn/update-manifests.test.ts
- bun run --filter @proompteng/bayn test (116 passed, 25 integration tests skipped locally, 0 failed)
- bun run --filter @proompteng/bayn tsc
- bun run --filter @proompteng/bayn lint
- bun run --filter @proompteng/bayn lint:oxlint
- bun run --filter @proompteng/bayn lint:oxlint:type
- bun run --filter @proompteng/bayn build
- Compiled both production entry points with embedded metadata and ran dist/verify-build-contract.js successfully.
- Read amd64 and arm64 OCI configs for digest sha256:c934775ee7dc0285b9715880b4db771471c1841e68c39b2e3032e1ef0f8f938e; both exposed identical source, behavior, and parameter identities.
- actionlint .github/workflows/bayn-release.yml
- bun run lint:argocd (Invalid: 0)
- kustomize build argocd/applications/bayn
- git diff --check

## Breaking Changes

Qualification replacement now fails before manifest writes unless it advances to a fresh Signal snapshot. After an unpinned qualification consumes that snapshot, another image release requires the terminal run to be pinned or a further fresh snapshot. There is no compatibility fallback, schema rename, or automatic lock migration.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; breaking behavior is documented above.
- [x] Release evidence and the PROOMPT-400 follow-up are documented.