### PR TITLE
fix(hermes): expose tools in terminal login shells

### DIFF
--- a/argocd/applications/hermes/README.md
+++ b/argocd/applications/hermes/README.md
@@ -44,6 +44,9 @@ smoke test, manifest change, and normal CI/Codex review.
   `83d5c2ccad5498f58bf6368acb1ab32588cf43ab3a4b1c301bf36328b1c8bd60`, caches the verified archive, and recreates the
   `tuslagch` Git identity, GitHub CLI authentication, and `gh auth git-credential` helper on every start. Bootstrap fails
   closed unless `gh api user` returns `tuslagch` and repository permission is `ADMIN`.
+- The immutable `/etc/profile.d/hermes-tools.sh` restores `/opt/tools` and the pinned Hermes paths after Debian's login
+  profile resets `PATH`; Hermes explicitly sources it while capturing each terminal session, so bare `gh` and `kubectl`
+  resolve consistently from API and Discord terminals.
 - API key rotation requires a bounded Secret refresh, gateway Pod restart, and old-key rejection/new-key acceptance proof.
 - The API is cluster-local and requires bearer authentication for model requests and detailed health.
 - Plugins, MCP servers, delegation, cron, hooks, and speech-to-text remain disabled. Terminal access is explicit for CLI,

--- a/argocd/applications/hermes/config.yaml
+++ b/argocd/applications/hermes/config.yaml
@@ -13,6 +13,8 @@ terminal:
   timeout: 180
   lifetime_seconds: 900
   home_mode: profile
+  shell_init_files:
+    - /etc/profile.d/hermes-tools.sh
 
 tool_loop_guardrails:
   warnings_enabled: true

--- a/argocd/applications/hermes/kustomization.yaml
+++ b/argocd/applications/hermes/kustomization.yaml
@@ -17,6 +17,7 @@ configMapGenerator:
       - bootstrap.sh
       - bootstrap-lab-checkout.sh
       - bootstrap-github.sh
+      - terminal-profile.sh
       - backup-once.sh
       - AGENTS.md=bootstrap/AGENTS.md
       - HEARTBEAT.md=bootstrap/HEARTBEAT.md

--- a/argocd/applications/hermes/statefulset.yaml
+++ b/argocd/applications/hermes/statefulset.yaml
@@ -250,6 +250,10 @@ spec:
             timeoutSeconds: 3
             failureThreshold: 3
           volumeMounts:
+            - name: bootstrap
+              mountPath: /etc/profile.d/hermes-tools.sh
+              subPath: terminal-profile.sh
+              readOnly: true
             - name: data
               mountPath: /opt/data
             - name: config

--- a/argocd/applications/hermes/terminal-profile.sh
+++ b/argocd/applications/hermes/terminal-profile.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Debian's /etc/profile replaces the container PATH for every login shell.
+# Hermes captures that login environment for terminal sessions, so reassert
+# the immutable production tool path after the system profile initializes.
+export PATH='/opt/tools:/opt/hermes/bin:/opt/hermes/.venv/bin:/opt/data/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'

--- a/docs/runbooks/hermes-production-rollout.md
+++ b/docs/runbooks/hermes-production-rollout.md
@@ -305,7 +305,7 @@ The expected mirrored amd64 manifest digest is
 
    ```bash
    set -euo pipefail
-   kubectl -n hermes exec hermes-0 -c hermes -- sh -c '
+   kubectl -n hermes exec hermes-0 -c hermes -- /usr/bin/bash -lc '
      set -eu
      test "$(command -v gh)" = /opt/tools/gh
      gh --version | grep -F "gh version 2.96.0"

--- a/scripts/hermes/validate-production.test.ts
+++ b/scripts/hermes/validate-production.test.ts
@@ -216,6 +216,53 @@ test('rejects persisting GitHub CLI auth on the Hermes data volume', async () =>
   )
 })
 
+test('rejects a terminal login profile that omits the production tools path', async () => {
+  const files = await loadProductionFiles()
+  const expectedExport =
+    "export PATH='/opt/tools:/opt/hermes/bin:/opt/hermes/.venv/bin:/opt/data/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'"
+  files.terminalProfile = files.terminalProfile.replace(expectedExport, "export PATH='/usr/local/bin:/usr/bin:/bin'")
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.terminalProfile}: missing production invariant ${JSON.stringify(expectedExport)}`,
+  )
+})
+
+test('rejects a gateway that does not mount the immutable terminal login profile', async () => {
+  const files = await loadProductionFiles()
+  files.statefulSet = files.statefulSet.replace(
+    'mountPath: /etc/profile.d/hermes-tools.sh',
+    'mountPath: /etc/profile.d/hermes-tools-disabled.sh',
+  )
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.statefulSet}: the gateway must mount exactly one immutable terminal login profile`,
+  )
+})
+
+test('rejects terminal sessions that do not source the immutable tools profile', async () => {
+  const files = await loadProductionFiles()
+  const expectedShellInit = 'shell_init_files:\n    - /etc/profile.d/hermes-tools.sh'
+  files.config = files.config.replace(expectedShellInit, 'auto_source_bashrc: true')
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.config}: missing production invariant ${JSON.stringify(expectedShellInit)}`,
+  )
+})
+
+test('rejects a GitHub rollout check that bypasses the Hermes login-shell boundary', async () => {
+  const files = await loadProductionFiles()
+  const expectedLoginProof =
+    'kubectl -n hermes exec hermes-0 -c hermes -- /usr/bin/bash -lc \'\n     set -eu\n     test "$(command -v gh)" = /opt/tools/gh'
+  files.runbook = files.runbook.replace(
+    expectedLoginProof,
+    'kubectl -n hermes exec hermes-0 -c hermes -- sh -c \'\n     set -eu\n     test "$(command -v gh)" = /opt/tools/gh',
+  )
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.runbook}: missing production invariant ${JSON.stringify(expectedLoginProof)}`,
+  )
+})
+
 test('rejects plaintext GitHub credentials', async () => {
   const files = await loadProductionFiles()
   files.githubSealedSecret = files.githubSealedSecret.replace(

--- a/scripts/hermes/validate-production.ts
+++ b/scripts/hermes/validate-production.ts
@@ -7,6 +7,8 @@ const squidImage = 'docker.io/ubuntu/squid@sha256:8a3baed477e2c282ab8aa5edad442f
 const kubectlImage = 'registry.k8s.io/kubectl@sha256:0bb95b2a450875fc8ceaea2f9987a99fe27c228846e2e00b93b65ebb0d59034e'
 const githubCliVersion = '2.96.0'
 const githubCliArchiveSha256 = '83d5c2ccad5498f58bf6368acb1ab32588cf43ab3a4b1c301bf36328b1c8bd60'
+const terminalPath =
+  '/opt/tools:/opt/hermes/bin:/opt/hermes/.venv/bin:/opt/data/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
 
 export const productionPaths = {
   kustomization: 'argocd/applications/hermes/kustomization.yaml',
@@ -25,6 +27,7 @@ export const productionPaths = {
   bootstrap: 'argocd/applications/hermes/bootstrap.sh',
   labCheckout: 'argocd/applications/hermes/bootstrap-lab-checkout.sh',
   githubBootstrap: 'argocd/applications/hermes/bootstrap-github.sh',
+  terminalProfile: 'argocd/applications/hermes/terminal-profile.sh',
   workspaceAgents: 'argocd/applications/hermes/bootstrap/AGENTS.md',
   workspaceTools: 'argocd/applications/hermes/bootstrap/TOOLS.md',
   readme: 'argocd/applications/hermes/README.md',
@@ -95,6 +98,7 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     '- github-sealed-secret.yaml',
     '- bootstrap-lab-checkout.sh',
     '- bootstrap-github.sh',
+    '- terminal-profile.sh',
   ])
   forbidTerms(failures, productionPaths.kustomization, files.kustomization, [
     'kind: Namespace',
@@ -130,6 +134,7 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'mountPath: /opt/kubectl-image',
     'mountPath: /opt/tools',
     'mountPath: /opt/github-auth',
+    'mountPath: /etc/profile.d/hermes-tools.sh\n              subPath: terminal-profile.sh\n              readOnly: true',
     'sizeLimit: 1Mi',
     'value: /opt/tools:/opt/hermes/bin:',
     'name: KUBECONFIG',
@@ -147,6 +152,9 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'value: main',
     'value: localhost,127.0.0.1,.svc,.svc.cluster.local,10.96.0.1',
   ])
+  if (count(files.statefulSet, 'mountPath: /etc/profile.d/hermes-tools.sh\n') !== 1) {
+    failures.push(`${productionPaths.statefulSet}: the gateway must mount exactly one immutable terminal login profile`)
+  }
   forbidTerms(failures, productionPaths.statefulSet, files.statefulSet, [
     ':latest',
     'privileged: true',
@@ -260,6 +268,7 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     '_config_version: 33',
     'base_url: http://flamingo.flamingo.svc.cluster.local/v1',
     'terminal:\n  backend: local\n  cwd: /opt/data/workspace/tuslagch/lab',
+    'shell_init_files:\n    - /etc/profile.d/hermes-tools.sh',
     'discord:\n    enabled: true',
     'api_server:\n    enabled: true',
     'cron_mode: deny',
@@ -582,6 +591,7 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'wget ',
     ':latest',
   ])
+  requireTerms(failures, productionPaths.terminalProfile, files.terminalProfile, [`export PATH='${terminalPath}'`])
   requireTerms(failures, productionPaths.workspaceAgents, files.workspaceAgents, [
     'Kubernetes access is cluster-wide read-only.',
     'Kubernetes Secrets and service-account token subresources are outside your authority.',
@@ -604,6 +614,7 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'GitHub CLI `2.96.0`',
     'per-Pod `emptyDir`',
     'bounded retries for transient pod-network startup races',
+    '/etc/profile.d/hermes-tools.sh',
     githubCliArchiveSha256,
   ])
 
@@ -881,6 +892,7 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'git -C /opt/data/workspace/tuslagch/lab remote get-url origin',
     'cat /opt/data/workspace/tuslagch/.lab-source-revision',
     'git -C /opt/data/workspace/tuslagch/lab cat-file -e HEAD:AGENTS.md',
+    'kubectl -n hermes exec hermes-0 -c hermes -- /usr/bin/bash -lc \'\n     set -eu\n     test "$(command -v gh)" = /opt/tools/gh',
     'test "$(command -v gh)" = /opt/tools/gh',
     'gh --version | grep -F "gh version 2.96.0"',
     'test "$(env -u GH_TOKEN -u GITHUB_TOKEN gh api user --jq .login)" = tuslagch',


### PR DESCRIPTION
## Summary

- Mount an immutable login profile that restores the production tool PATH after Debian resets it.
- Explicitly source that profile while Hermes captures API and Discord terminal environments.
- Strengthen the production validator and rollout proof so a non-login shell cannot mask this failure again.

## Related Issues

None

## Testing

- bun test scripts/hermes/validate-production.test.ts scripts/hermes/bootstrap-github.test.ts
- bun run scripts/hermes/validate-production.ts
- bun run lint:argocd
- shellcheck argocd/applications/hermes/*.sh
- scripts/kubeconform.sh argocd/applications/hermes /tmp/hermes-gh-cli-path.yaml
- kubectl apply -n hermes --as=system:serviceaccount:argocd:argocd-application-controller --server-side --dry-run=server --field-manager=argocd-controller -f /tmp/hermes-gh-cli-path.yaml -o name

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.