### PR TITLE
chore(bayn): quiesce database writer

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/name: bayn
     app.kubernetes.io/part-of: bayn
 spec:
-  replicas: 1
+  replicas: 0
   revisionHistoryLimit: 2
   progressDeadlineSeconds: 600
   strategy:


### PR DESCRIPTION
## Summary\n\n- scale the Bayn deployment to zero through GitOps\n- quiesce the only PostgreSQL evidence writer before the authorized hard schema reset\n- keep CNPG, Signal access resources, and the dedicated TigerBeetle cluster running\n\n## Related Issues\n\nNone\n\n## Testing\n\n- apiVersion: v1
automountServiceAccountToken: false
kind: ServiceAccount
metadata:
  labels:
    app.kubernetes.io/name: bayn
    app.kubernetes.io/part-of: bayn
  name: bayn
  namespace: bayn
---
apiVersion: v1
kind: Secret
metadata:
  annotations:
    reflector.v1.k8s.emberstack.com/reflects: torghut/bayn-clickhouse-auth
  name: bayn-clickhouse-auth
  namespace: bayn
type: Opaque
---
apiVersion: v1
kind: Service
metadata:
  labels:
    app.kubernetes.io/name: bayn
    app.kubernetes.io/part-of: bayn
  name: bayn
  namespace: bayn
spec:
  ports:
  - name: http
    port: 80
    protocol: TCP
    targetPort: http
  selector:
    app.kubernetes.io/name: bayn
  type: ClusterIP
---
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app.kubernetes.io/name: bayn
    app.kubernetes.io/part-of: bayn
  name: bayn
  namespace: bayn
spec:
  progressDeadlineSeconds: 600
  replicas: 0
  revisionHistoryLimit: 2
  selector:
    matchLabels:
      app.kubernetes.io/name: bayn
  strategy:
    rollingUpdate:
      maxSurge: 0
      maxUnavailable: 1
    type: RollingUpdate
  template:
    metadata:
      annotations:
        kubectl.kubernetes.io/restartedAt: "2026-07-22T02:11:45Z"
      labels:
        app.kubernetes.io/name: bayn
        app.kubernetes.io/part-of: bayn
    spec:
      automountServiceAccountToken: false
      containers:
      - env:
        - name: BAYN_CODE_REVISION
          value: d17fb3db11ed3a11a6f9c0d511d43120cfc538ec
        - name: BAYN_IMAGE_REPOSITORY
          value: registry.ide-newton.ts.net/lab/bayn
        - name: BAYN_IMAGE_DIGEST
          value: sha256:30dcafd540a82c5fc2a2ae887e0fdf9fabd64896a828bedcda394f8594a35750
        - name: BAYN_STRATEGY_BEHAVIOR_HASH
          value: 43cece33d3db232ffb02ba78826727e50b5795319d09d27e1baa0c04709eb056
        - name: BAYN_STRATEGY_PARAMETER_HASH
          value: cf639d3692da65271b12423f9b7c6c9663e1fb13ae7290dc56fcfa3acf16eb69
        - name: BAYN_QUALIFICATION_RUN_ID
          value: 082669c8d9547911e39b7e3a8a6399978894114a5eacc9fc113b0c7b99b6bd88
        - name: BAYN_HEALTH_INTERVAL_MS
          value: "30000"
        - name: BAYN_OPERATION_TIMEOUT_MS
          value: "30000"
        - name: BAYN_CLICKHOUSE_URL
          value: http://torghut-clickhouse.torghut.svc.cluster.local:8123
        - name: BAYN_CLICKHOUSE_USERNAME
          valueFrom:
            secretKeyRef:
              key: username
              name: bayn-clickhouse-auth
        - name: BAYN_CLICKHOUSE_PASSWORD
          valueFrom:
            secretKeyRef:
              key: password
              name: bayn-clickhouse-auth
        - name: BAYN_SIGNAL_SNAPSHOT_ID
          value: 98f9b0cdee311b248d4ed36104fa46ff86c34d587d6e71a6706a9d778c110292
        - name: BAYN_SIGNAL_PUBLICATION_ASOF
          value: "2026-07-20"
        - name: BAYN_SIGNAL_CALENDAR_VERSION
          value: alpaca-us-equity-calendar-v1
        - name: BAYN_SIGNAL_DATA_START
          value: "2022-01-27"
        - name: BAYN_SIGNAL_DATA_END
          value: "2026-07-20"
        - name: BAYN_SIGNAL_LOOKBACK_START
          value: "2022-01-27"
        - name: BAYN_SIGNAL_EVALUATION_START
          value: "2023-01-30"
        - name: BAYN_SIGNAL_EVALUATION_END
          value: "2026-07-20"
        - name: BAYN_POSTGRES_URL
          valueFrom:
            secretKeyRef:
              key: fqdn-uri
              name: bayn-db-app
        - name: BAYN_POSTGRES_TLS
          value: "true"
        - name: BAYN_POSTGRES_CA_PATH
          value: /var/run/secrets/bayn/postgres/ca.crt
        - name: BAYN_TIGERBEETLE_CLUSTER_ID
          value: "122731676035874920802382025803517750735"
        - name: BAYN_TIGERBEETLE_ADDRESSES
          value: ledger.bayn.svc.cluster.local:3000
        - name: BAYN_TIGERBEETLE_LEDGER
          value: "7001"
        - name: NODE_ENV
          value: production
        image: registry.ide-newton.ts.net/lab/bayn:sha-d17fb3db11ed3a11a6f9c0d511d43120cfc538ec@sha256:30dcafd540a82c5fc2a2ae887e0fdf9fabd64896a828bedcda394f8594a35750
        imagePullPolicy: IfNotPresent
        livenessProbe:
          failureThreshold: 3
          httpGet:
            path: /livez
            port: http
          periodSeconds: 10
          timeoutSeconds: 2
        name: bayn
        ports:
        - containerPort: 8080
          name: http
          protocol: TCP
        readinessProbe:
          failureThreshold: 2
          httpGet:
            path: /readyz
            port: http
          periodSeconds: 5
          timeoutSeconds: 2
        resources:
          limits:
            cpu: "2"
            memory: 1Gi
          requests:
            cpu: 250m
            memory: 256Mi
        securityContext:
          allowPrivilegeEscalation: false
          capabilities:
            drop:
            - ALL
          readOnlyRootFilesystem: true
          seccompProfile:
            type: Unconfined
        startupProbe:
          failureThreshold: 30
          httpGet:
            path: /livez
            port: http
          periodSeconds: 2
        volumeMounts:
        - mountPath: /tmp
          name: tmp
        - mountPath: /var/run/secrets/bayn/postgres
          name: postgres-ca
          readOnly: true
      nodeSelector:
        kubernetes.io/arch: arm64
      securityContext:
        fsGroup: 65532
        runAsGroup: 65532
        runAsNonRoot: true
        runAsUser: 65532
        seccompProfile:
          type: RuntimeDefault
      serviceAccountName: bayn
      terminationGracePeriodSeconds: 30
      volumes:
      - emptyDir:
          sizeLimit: 256Mi
        name: tmp
      - name: postgres-ca
        secret:
          defaultMode: 292
          items:
          - key: ca.crt
            path: ca.crt
          secretName: bayn-db-ca
---
apiVersion: barmancloud.cnpg.io/v1
kind: ObjectStore
metadata:
  annotations:
    argocd.argoproj.io/sync-options: Prune=false,Delete=false,SkipDryRunOnMissingResource=true
    argocd.argoproj.io/sync-wave: "-8"
  labels:
    app.kubernetes.io/name: bayn-db
    app.kubernetes.io/part-of: bayn
  name: bayn-db
  namespace: bayn
spec:
  configuration:
    data:
      additionalCommandArgs:
      - --max-bandwidth
      - 8MB
      compression: snappy
      jobs: 1
    destinationPath: s3://cnpg-bayn/
    endpointURL: http://rook-ceph-rgw-objectstore.rook-ceph.svc.cluster.local:80
    s3Credentials:
      accessKeyId:
        key: AWS_ACCESS_KEY_ID
        name: cnpg-bayn-db
      secretAccessKey:
        key: AWS_SECRET_ACCESS_KEY
        name: cnpg-bayn-db
    wal:
      compression: snappy
      maxParallel: 2
  instanceSidecarConfiguration:
    logLevel: info
    resources:
      limits:
        cpu: 500m
        memory: 512Mi
      requests:
        cpu: 100m
        memory: 128Mi
    retentionPolicyIntervalSeconds: 1800
  retentionPolicy: 14d
---
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  labels:
    app.kubernetes.io/name: bayn
    app.kubernetes.io/part-of: bayn
  name: bayn
  namespace: bayn
spec:
  egress:
  - ports:
    - port: 53
      protocol: UDP
    - port: 53
      protocol: TCP
    to:
    - namespaceSelector:
        matchLabels:
          kubernetes.io/metadata.name: kube-system
      podSelector:
        matchLabels:
          k8s-app: kube-dns
  - ports:
    - port: 8123
      protocol: TCP
    to:
    - namespaceSelector:
        matchLabels:
          kubernetes.io/metadata.name: torghut
      podSelector:
        matchLabels:
          clickhouse.altinity.com/chi: torghut-clickhouse
  - ports:
    - port: 3000
      protocol: TCP
    to:
    - podSelector:
        matchLabels:
          app.kubernetes.io/instance: ledger
  - ports:
    - port: 5432
      protocol: TCP
    to:
    - podSelector:
        matchLabels:
          cnpg.io/cluster: bayn-db
  ingress:
  - from:
    - podSelector: {}
    ports:
    - port: http
      protocol: TCP
  podSelector:
    matchLabels:
      app.kubernetes.io/name: bayn
  policyTypes:
  - Ingress
  - Egress
---
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  labels:
    app.kubernetes.io/name: bayn-db
    app.kubernetes.io/part-of: bayn
  name: bayn-db
  namespace: bayn
spec:
  ingress:
  - from:
    - podSelector:
        matchLabels:
          app.kubernetes.io/name: bayn
    ports:
    - port: 5432
      protocol: TCP
  - from:
    - podSelector:
        matchLabels:
          cnpg.io/cluster: bayn-db
    ports:
    - port: 5432
      protocol: TCP
  - from:
    - namespaceSelector:
        matchLabels:
          kubernetes.io/metadata.name: cloudnative-pg
      podSelector:
        matchLabels:
          app.kubernetes.io/name: cloudnative-pg
    ports:
    - port: 5432
      protocol: TCP
    - port: 8000
      protocol: TCP
  - from:
    - namespaceSelector:
        matchLabels:
          kubernetes.io/metadata.name: observability
      podSelector:
        matchLabels:
          app.kubernetes.io/name: observability-cluster-metrics-alloy
    ports:
    - port: 9187
      protocol: TCP
  podSelector:
    matchLabels:
      cnpg.io/cluster: bayn-db
  policyTypes:
  - Ingress
---
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  labels:
    app.kubernetes.io/name: ledger
    app.kubernetes.io/part-of: bayn
  name: ledger
  namespace: bayn
spec:
  ingress:
  - from:
    - podSelector:
        matchLabels:
          app.kubernetes.io/name: bayn
    - podSelector:
        matchLabels:
          app.kubernetes.io/instance: ledger
    - namespaceSelector:
        matchLabels:
          kubernetes.io/metadata.name: tigresse-system
      podSelector:
        matchLabels:
          app.kubernetes.io/name: tigresse
    ports:
    - port: 3000
      protocol: TCP
  podSelector:
    matchLabels:
      app.kubernetes.io/instance: ledger
  policyTypes:
  - Ingress
---
apiVersion: objectbucket.io/v1alpha1
kind: ObjectBucketClaim
metadata:
  annotations:
    argocd.argoproj.io/sync-options: Prune=false,Delete=false
    argocd.argoproj.io/sync-wave: "-10"
  name: cnpg-bayn-db
  namespace: bayn
spec:
  bucketName: cnpg-bayn
  storageClassName: rook-ceph-bucket
---
apiVersion: postgresql.cnpg.io/v1
kind: Cluster
metadata:
  annotations:
    argocd.argoproj.io/sync-options: Prune=false,Delete=false
    argocd.argoproj.io/sync-wave: "-5"
  labels:
    app.kubernetes.io/name: bayn-db
    app.kubernetes.io/part-of: bayn
  name: bayn-db
  namespace: bayn
spec:
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: kubernetes.io/arch
            operator: In
            values:
            - amd64
    podAntiAffinityType: required
    topologyKey: kubernetes.io/hostname
  bootstrap:
    initdb:
      dataChecksums: true
      database: bayn
      encoding: UTF8
      owner: bayn_app
  description: Bayn control and evaluation evidence
  enablePDB: true
  enableSuperuserAccess: false
  imageName: ghcr.io/cloudnative-pg/postgresql:18.4-system-trixie@sha256:9287ce030c6f3ce822e383b019ae4aaf1e8370bff3b39f9c51dc10d69dc97219
  imagePullPolicy: IfNotPresent
  instances: 2
  maxSyncReplicas: 1
  minSyncReplicas: 1
  plugins:
  - isWALArchiver: true
    name: barman-cloud.cloudnative-pg.io
    parameters:
      barmanObjectName: bayn-db
      serverName: bayn-db-live
  postgresql:
    parameters:
      password_encryption: scram-sha-256
      ssl_min_protocol_version: TLSv1.3
  primaryUpdateMethod: switchover
  primaryUpdateStrategy: unsupervised
  resources:
    limits:
      cpu: "2"
      memory: 2Gi
    requests:
      cpu: 250m
      memory: 512Mi
  storage:
    resizeInUseVolumes: true
    size: 10Gi
    storageClass: rook-ceph-block
---
apiVersion: postgresql.cnpg.io/v1
kind: ScheduledBackup
metadata:
  annotations:
    argocd.argoproj.io/sync-wave: "0"
  labels:
    app.kubernetes.io/name: bayn-db
    app.kubernetes.io/part-of: bayn
  name: bayn-db-daily
  namespace: bayn
spec:
  backupOwnerReference: cluster
  cluster:
    name: bayn-db
  immediate: true
  method: plugin
  pluginConfiguration:
    name: barman-cloud.cloudnative-pg.io
  schedule: 0 0 3 * * *
  target: prefer-standby
---
apiVersion: tigerbeetle.proompteng.ai/v1alpha1
kind: TigerBeetleCluster
metadata:
  labels:
    app.kubernetes.io/name: ledger
    app.kubernetes.io/part-of: bayn
  name: ledger
  namespace: bayn
spec:
  affinity:
    podAntiAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
      - labelSelector:
          matchLabels:
            app.kubernetes.io/instance: ledger
        topologyKey: kubernetes.io/hostname
  clusterID: "122731676035874920802382025803517750735"
  deletionPolicy: Retain
  health:
    checkIntervalSeconds: 30
  image:
    pullPolicy: IfNotPresent
    repository: ghcr.io/tigerbeetle/tigerbeetle
    tag: 0.17.9@sha256:48f623f9c1e9b6cc44d77ca93634595ae99cce3246ded418763eb1a62eee45e9
  pdb:
    enabled: true
    minAvailable: 2
  replicas: 3
  resources:
    limits:
      memory: 8Gi
    requests:
      cpu: "2"
      memory: 8Gi
  storage:
    className: local-path
    size: 100Gi\n- bun test v1.3.14 (0d9b296a) (10 passed)\n\n## Breaking Changes\n\nBayn is intentionally unavailable while its PostgreSQL schema is reset and the new single-schema image is promoted. No CNPG cluster, backup, or TigerBeetle data is deleted.\n\n## Checklist\n\n- [x] Testing section documents the exact validation performed.\n- [x] Screenshots are not applicable; the temporary outage is documented.\n- [x] The follow-up restore, unpinned evaluation, and live proof remain part of this task.