### PR TITLE
chore(bayn): promote image sha-f136a4363317e5c055e0cd2bac891df0a174a814

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: bayn
         app.kubernetes.io/part-of: bayn
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-22T02:11:45Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-22T02:48:58Z"
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
@@ -47,11 +47,11 @@ spec:
               protocol: TCP
           env:
             - name: BAYN_CODE_REVISION
-              value: d17fb3db11ed3a11a6f9c0d511d43120cfc538ec
+              value: f136a4363317e5c055e0cd2bac891df0a174a814
             - name: BAYN_IMAGE_REPOSITORY
               value: registry.ide-newton.ts.net/lab/bayn
             - name: BAYN_IMAGE_DIGEST
-              value: sha256:30dcafd540a82c5fc2a2ae887e0fdf9fabd64896a828bedcda394f8594a35750
+              value: sha256:0fd39b2b21059182f6cf694f39d5c8c0e27057a65fc5ee3e11b6b569f328dc7c
             - name: BAYN_STRATEGY_BEHAVIOR_HASH
               value: "43cece33d3db232ffb02ba78826727e50b5795319d09d27e1baa0c04709eb056"
             - name: BAYN_STRATEGY_PARAMETER_HASH

--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -56,8 +56,6 @@ spec:
               value: "43cece33d3db232ffb02ba78826727e50b5795319d09d27e1baa0c04709eb056"
             - name: BAYN_STRATEGY_PARAMETER_HASH
               value: "cf639d3692da65271b12423f9b7c6c9663e1fb13ae7290dc56fcfa3acf16eb69"
-            - name: BAYN_QUALIFICATION_RUN_ID
-              value: "082669c8d9547911e39b7e3a8a6399978894114a5eacc9fc113b0c7b99b6bd88"
             - name: BAYN_HEALTH_INTERVAL_MS
               value: "30000"
             - name: BAYN_OPERATION_TIMEOUT_MS

--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -16,5 +16,5 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/bayn
     newName: registry.ide-newton.ts.net/lab/bayn
-    newTag: "sha-d17fb3db11ed3a11a6f9c0d511d43120cfc538ec"
-    digest: sha256:30dcafd540a82c5fc2a2ae887e0fdf9fabd64896a828bedcda394f8594a35750
+    newTag: "sha-f136a4363317e5c055e0cd2bac891df0a174a814"
+    digest: sha256:0fd39b2b21059182f6cf694f39d5c8c0e27057a65fc5ee3e11b6b569f328dc7c


### PR DESCRIPTION
## Summary

Promote the immutable Bayn image containing the single current PostgreSQL schema while the service remains quiesced.

- Source commit: f136a4363317e5c055e0cd2bac891df0a174a814
- Image tag: sha-f136a4363317e5c055e0cd2bac891df0a174a814
- Image digest: sha256:0fd39b2b21059182f6cf694f39d5c8c0e27057a65fc5ee3e11b6b569f328dc7c
- Deployment replicas remain 0
- The stale qualification pin is removed because its PostgreSQL evidence was explicitly reset
- Signal and dedicated TigerBeetle bindings are unchanged

## Related Issues

PROOMPT-400

## Testing

- OCI index contains linux/amd64 and linux/arm64.
- kustomize build argocd/applications/bayn
- bun test packages/scripts/src/bayn/update-manifests.test.ts (5 passed)

## Breaking Changes

This is an intentional one-way hard cut. The old PostgreSQL schema and migration history were deleted only after Bayn reached zero pods. There is no migration fallback and no old qualification recovery. TigerBeetle data was not modified. A separate reviewed GitOps change will restore one Bayn replica and require a fresh durable evaluation on the clean schema.

## Checklist

- [x] Testing section documents exact validation.
- [x] Runtime source revision and image digest are immutable.
- [x] Bayn remains quiesced for the database reset boundary.
- [x] No broker or capital-promotion authority is introduced.