### PR TITLE
refactor(bayn): simplify Effect runtime composition

### DIFF
--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -14,8 +14,9 @@ to TigerBeetle. Bayn contains no broker client or capital-promotion path.
 - Bayn owns a two-instance CloudNativePG cluster. The runtime uses the generated application URI over verified TLS,
   runs versioned Effect SQL migrations at startup, and keeps a two-connection pool for its single-writer operation plus
   query cancellation.
-- The composition root selects one strategy capability. The compiled `bayn.risk-balanced-trend.protocol.v2` owns its
-  authoritative universe and execution contract; the HTTP and startup lifecycle remain strategy-independent.
+- The composition root builds one pure strategy value and passes it explicitly to the lifecycle. Effect services and
+  layers are reserved for I/O resources. The compiled `bayn.risk-balanced-trend.protocol.v2` owns its authoritative
+  universe and execution contract; the HTTP and startup lifecycle remain strategy-independent.
 - The typed protocol is compiled into the image and runtime-decoded with Effect Schema. Strategies remain reviewed
   TypeScript rather than JSON.
 - The executable embeds source, repository, and strategy-behavior identity. Startup verifies configured attribution,

--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -7,7 +7,7 @@ import { Cause, Context, Effect, Exit, Fiber, Layer, Option, Redacted, Ref } fro
 import { TestClock } from 'effect/testing'
 import { HttpServer } from 'effect/unstable/http'
 
-import { initialState, initialize, makeHttpLayer, monitor, probe, run, type RuntimeState } from './app'
+import { initialize, monitor, probe, run } from './app'
 import type { RuntimeConfig } from './config'
 import {
   DatabaseError,
@@ -18,11 +18,13 @@ import {
   type StoredEvaluationEvidence,
 } from './db/evidence-store'
 import { operationalError } from './errors'
+import { makeHttpLayer } from './http'
 import { Journal, type JournalService } from './ledger'
 import { MarketData, type MarketDataService } from './market-data'
 import { makeQualificationResult } from './qualification'
 import { evaluateRiskBalancedTrend, summarizeEvaluation } from './risk-balanced-trend'
-import { Strategy, StrategyLayer, makeStrategy, type StrategyService } from './strategy-service'
+import { initialState, type RuntimeState } from './runtime-state'
+import { makeStrategy, type Strategy } from './strategy-service'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
 
 const provenance = makeTestProvenance()
@@ -343,7 +345,7 @@ describe('Bayn HTTP probes', () => {
               state,
               provenance,
               'embedded',
-              successfulEvidenceStore,
+              successfulEvidenceStore.read,
             ),
           )
           const address = Context.get(context, HttpServer.HttpServer).address
@@ -451,7 +453,7 @@ describe('Bayn HTTP probes', () => {
               state,
               provenance,
               'embedded',
-              unavailableStore,
+              unavailableStore.read,
             ),
           )
           const address = Context.get(context, HttpServer.HttpServer).address
@@ -595,7 +597,7 @@ describe('Bayn startup lifecycle', () => {
     const state = await Effect.runPromise(Ref.make(initialState()))
 
     await Effect.runPromise(
-      initialize(pinnedRuntimeConfig, state).pipe(
+      initialize(pinnedRuntimeConfig, state, fixtureStrategy).pipe(
         Effect.provideService(MarketData, {
           check: forbidden('pinned startup must not check Signal'),
           inspect: forbidden('pinned startup must not inspect Signal'),
@@ -613,7 +615,6 @@ describe('Bayn startup lifecycle', () => {
           openQualification: () => forbidden('pinned startup must not open a qualification lock'),
           persist: () => forbidden('pinned startup must not persist evidence'),
         }),
-        Effect.provideService(Strategy, fixtureStrategy),
       ),
     )
 
@@ -669,11 +670,10 @@ describe('Bayn startup lifecycle', () => {
     for (const testCase of cases) {
       const state = await Effect.runPromise(Ref.make(initialState()))
       await Effect.runPromise(
-        initialize(testCase.config, state).pipe(
+        initialize(testCase.config, state, testCase.strategy).pipe(
           Effect.provideService(MarketData, marketDataService(Effect.die(new Error('must not load bars')))),
           Effect.provideService(Journal, successfulJournal),
           Effect.provideService(EvidenceStore, testCase.store),
-          Effect.provideService(Strategy, testCase.strategy),
         ),
       )
       expect(await Effect.runPromise(Ref.get(state)), testCase.name).toMatchObject({
@@ -690,7 +690,7 @@ describe('Bayn startup lifecycle', () => {
     let evaluations = 0
     let journalWrites = 0
     let persistenceWrites = 0
-    const strategy: StrategyService = {
+    const strategy: Strategy = {
       ...fixtureStrategy,
       evaluate: () => {
         evaluations += 1
@@ -730,14 +730,13 @@ describe('Bayn startup lifecycle', () => {
     const state = await Effect.runPromise(Ref.make(initialState()))
 
     await Effect.runPromise(
-      initialize(config, state).pipe(
+      initialize(config, state, strategy).pipe(
         Effect.provideService(
           MarketData,
           marketDataService(Effect.die(new Error('terminal recovery must not load bars')), snapshot),
         ),
         Effect.provideService(Journal, journal),
         Effect.provideService(EvidenceStore, store),
-        Effect.provideService(Strategy, strategy),
       ),
     )
 
@@ -761,7 +760,7 @@ describe('Bayn startup lifecycle', () => {
     let evaluations = 0
     let journalWrites = 0
     let persistenceWrites = 0
-    const strategy: StrategyService = {
+    const strategy: Strategy = {
       ...fixtureStrategy,
       evaluate: () => {
         evaluations += 1
@@ -787,14 +786,13 @@ describe('Bayn startup lifecycle', () => {
     const state = await Effect.runPromise(Ref.make(initialState()))
 
     await Effect.runPromise(
-      initialize(config, state).pipe(
+      initialize(config, state, strategy).pipe(
         Effect.provideService(
           MarketData,
           marketDataService(Effect.die(new Error('incomplete qualification must not load bars')), snapshot),
         ),
         Effect.provideService(Journal, journal),
         Effect.provideService(EvidenceStore, store),
-        Effect.provideService(Strategy, strategy),
       ),
     )
 
@@ -814,7 +812,7 @@ describe('Bayn startup lifecycle', () => {
     const snapshot = makeSnapshot()
     let evaluations = 0
     let journalWrites = 0
-    const strategy: StrategyService = {
+    const strategy: Strategy = {
       ...fixtureStrategy,
       evaluate: () => {
         evaluations += 1
@@ -844,14 +842,13 @@ describe('Bayn startup lifecycle', () => {
     const state = await Effect.runPromise(Ref.make(initialState()))
 
     await Effect.runPromise(
-      initialize(config, state).pipe(
+      initialize(config, state, strategy).pipe(
         Effect.provideService(
           MarketData,
           marketDataService(Effect.die(new Error('corrupt recovery must not load bars')), snapshot),
         ),
         Effect.provideService(Journal, journal),
         Effect.provideService(EvidenceStore, store),
-        Effect.provideService(Strategy, strategy),
       ),
     )
 
@@ -867,7 +864,7 @@ describe('Bayn startup lifecycle', () => {
     let calls = 0
     const snapshot = makeSnapshot()
     const state = await Effect.runPromise(Ref.make(initialState()))
-    const strategy: StrategyService = {
+    const strategy: Strategy = {
       ...fixtureStrategy,
       name: 'test-strategy',
       evaluate: (bars, manifest) => {
@@ -877,11 +874,10 @@ describe('Bayn startup lifecycle', () => {
     }
 
     await Effect.runPromise(
-      initialize(config, state).pipe(
+      initialize(config, state, strategy).pipe(
         Effect.provideService(MarketData, marketDataService(Effect.succeed(snapshot))),
         Effect.provideService(Journal, successfulJournal),
         Effect.provideService(EvidenceStore, successfulEvidenceStore),
-        Effect.provideService(Strategy, strategy),
       ),
     )
 
@@ -895,11 +891,10 @@ describe('Bayn startup lifecycle', () => {
     const marketData = marketDataService(Effect.succeed(snapshot))
 
     await Effect.runPromise(
-      initialize(config, state).pipe(
+      initialize(config, state, fixtureStrategy).pipe(
         Effect.provideService(MarketData, marketData),
         Effect.provideService(Journal, successfulJournal),
         Effect.provideService(EvidenceStore, successfulEvidenceStore),
-        Effect.provide(StrategyLayer(fixtureProtocol, provenance)),
       ),
     )
 
@@ -917,11 +912,10 @@ describe('Bayn startup lifecycle', () => {
     const marketData = marketDataService(Effect.succeed(shortSnapshot), shortSnapshot)
 
     await Effect.runPromise(
-      initialize(config, state).pipe(
+      initialize(config, state, fixtureStrategy).pipe(
         Effect.provideService(MarketData, marketData),
         Effect.provideService(Journal, successfulJournal),
         Effect.provideService(EvidenceStore, successfulEvidenceStore),
-        Effect.provide(StrategyLayer(fixtureProtocol, provenance)),
       ),
     )
 
@@ -939,11 +933,10 @@ describe('Bayn startup lifecycle', () => {
     )
 
     await Effect.runPromise(
-      initialize({ ...config, operationTimeoutMs: 10 }, state).pipe(
+      initialize({ ...config, operationTimeoutMs: 10 }, state, fixtureStrategy).pipe(
         Effect.provideService(MarketData, marketData),
         Effect.provideService(Journal, successfulJournal),
         Effect.provideService(EvidenceStore, successfulEvidenceStore),
-        Effect.provide(StrategyLayer(fixtureProtocol, provenance)),
       ),
     )
 
@@ -957,11 +950,10 @@ describe('Bayn startup lifecycle', () => {
   test('propagates an unexpected defect instead of leaving a detached STARTING worker', async () => {
     const marketData = marketDataService(Effect.die(new Error('unexpected startup defect')))
     const exit = await Effect.runPromiseExit(
-      run(config).pipe(
+      run(config, fixtureStrategy).pipe(
         Effect.provideService(MarketData, marketData),
         Effect.provideService(Journal, successfulJournal),
         Effect.provideService(EvidenceStore, successfulEvidenceStore),
-        Effect.provide(StrategyLayer(fixtureProtocol, provenance)),
         Effect.timeoutOrElse({
           duration: 250,
           orElse: () =>
@@ -998,11 +990,10 @@ describe('Bayn startup lifecycle', () => {
     }
 
     await Effect.runPromise(
-      initialize(config, state).pipe(
+      initialize(config, state, fixtureStrategy).pipe(
         Effect.provideService(MarketData, marketDataService(Effect.succeed(makeSnapshot()))),
         Effect.provideService(Journal, successfulJournal),
         Effect.provideService(EvidenceStore, unavailable),
-        Effect.provide(StrategyLayer(fixtureProtocol, provenance)),
       ),
     )
 
@@ -1028,9 +1019,8 @@ describe('Bayn startup lifecycle', () => {
       Layer.succeed(MarketData, marketDataService(Effect.succeed(makeSnapshot()))),
       Layer.succeed(Journal, successfulJournal),
       EvidenceStoreRuntimeLive(unavailableDatabase).pipe(Layer.provide(NodeServices.layer)),
-      StrategyLayer(fixtureProtocol, provenance),
     )
-    const fiber = Effect.runFork(run(unavailableDatabase).pipe(Effect.provide(dependencies)))
+    const fiber = Effect.runFork(run(unavailableDatabase, fixtureStrategy).pipe(Effect.provide(dependencies)))
 
     try {
       const status = await waitForStatus(port, 'FAILED')
@@ -1064,9 +1054,8 @@ describe('Bayn startup lifecycle', () => {
       Layer.succeed(MarketData, marketDataService(Effect.succeed(makeSnapshot()))),
       Layer.succeed(Journal, successfulJournal),
       makeEvidenceStoreRuntimeLayer(timedOutDatabase, stalledMigration, Effect.succeed(successfulEvidenceStore)),
-      StrategyLayer(fixtureProtocol, provenance),
     )
-    const fiber = Effect.runFork(run(timedOutDatabase).pipe(Effect.provide(dependencies)))
+    const fiber = Effect.runFork(run(timedOutDatabase, fixtureStrategy).pipe(Effect.provide(dependencies)))
 
     try {
       const status = await waitForStatus(port, 'FAILED')

--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -1,233 +1,28 @@
-import { createServer } from 'node:http'
-
-import { NodeHttpServer } from '@effect/platform-node'
 import { Cause, Clock, Duration, Effect, Exit, Layer, Option, Ref, Schedule } from 'effect'
-import { HttpRouter, HttpServerRequest, HttpServerResponse } from 'effect/unstable/http'
 
-import type { RuntimeBuildMetadata, RuntimeConfig } from './config'
+import type { RuntimeConfig } from './config'
 import { makeRuntimeProvenance, type FinalizedSnapshotProvenance, type RuntimeProvenance } from './contracts'
 import {
   EvidenceStore,
-  type EvidenceStoreService,
-  type PersistenceReceipt,
   type QualificationRecord,
   type RecoveredEvaluationEvidence,
   type StoredEvaluationEvidence,
 } from './db/evidence-store'
 import { formatError, operationalError, type Component, type OperationalError } from './errors'
 import { canonicalHashV1 } from './hash'
+import { makeHttpLayer } from './http'
 import { Journal } from './ledger'
 import { MarketData } from './market-data'
-import { makeQualificationResult, type QualificationResult } from './qualification'
+import { makeQualificationResult } from './qualification'
 import { summarizeEvaluation } from './risk-balanced-trend'
-import { Strategy } from './strategy-service'
-import type { EvaluationSummary, ReconciliationResult } from './types'
-
-export interface RuntimeEvidence {
-  readonly startupMode: 'evaluated' | 'pinned' | 'recovered'
-  readonly provenance: RuntimeProvenance
-  readonly evaluation: EvaluationSummary
-  readonly reconciliation: ReconciliationResult
-  readonly persistence: PersistenceReceipt
-  readonly qualification: QualificationResult
-}
-
-export interface DependencyHealth {
-  readonly status: 'UNKNOWN' | 'AVAILABLE' | 'UNAVAILABLE'
-  readonly checkedAt: string | null
-  readonly error: string | null
-}
-
-export interface RuntimeHealth {
-  readonly sequence: number
-  readonly checkedAt: string | null
-  readonly dependencies: {
-    readonly postgresql: DependencyHealth
-    readonly signal: DependencyHealth
-    readonly tigerBeetle: DependencyHealth
-    readonly evidence: DependencyHealth
-  }
-}
-
-export interface RuntimeState {
-  readonly status: 'STARTING' | 'READY' | 'DEGRADED' | 'FAILED'
-  readonly evidence: RuntimeEvidence | null
-  readonly health: RuntimeHealth
-  readonly error: string | null
-}
-
-const unknownDependency = (): DependencyHealth => ({ status: 'UNKNOWN', checkedAt: null, error: null })
-
-export const initialState = (): RuntimeState => ({
-  status: 'STARTING',
-  evidence: null,
-  health: {
-    sequence: 0,
-    checkedAt: null,
-    dependencies: {
-      postgresql: unknownDependency(),
-      signal: unknownDependency(),
-      tigerBeetle: unknownDependency(),
-      evidence: unknownDependency(),
-    },
-  },
-  error: null,
-})
-
-const allAvailable = (health: RuntimeHealth): boolean =>
-  Object.values(health.dependencies).every((dependency) => dependency.status === 'AVAILABLE')
-
-const isReady = (state: RuntimeState): boolean =>
-  state.status === 'READY' && state.evidence !== null && allAvailable(state.health)
-
-const json = (value: unknown): string =>
-  JSON.stringify(value, (_, nested) => (typeof nested === 'bigint' ? nested.toString() : nested))
-
-const verifiedState = (evidence: RuntimeEvidence | null, dependency: DependencyHealth) => {
-  if (evidence === null || dependency.status === 'UNKNOWN') return 'UNKNOWN'
-  return dependency.status === 'AVAILABLE' ? 'CURRENT' : 'INVALID'
-}
-
-const publicState = (
-  state: RuntimeState,
-  provenance: RuntimeProvenance,
-  provenanceVerification: RuntimeBuildMetadata['verification'],
-) => {
-  let economic = 'UNKNOWN'
-  let accounting = 'UNKNOWN'
-  if (state.evidence !== null) {
-    economic = state.evidence.qualification.verdict
-    if (state.health.dependencies.tigerBeetle.status === 'AVAILABLE') accounting = 'EXACT'
-    if (state.health.dependencies.tigerBeetle.status === 'UNAVAILABLE') accounting = 'UNAVAILABLE'
-  }
-
-  return {
-    service: 'bayn',
-    operational: {
-      status: state.status,
-      ready: isReady(state),
-      probeSequence: state.health.sequence,
-      checkedAt: state.health.checkedAt,
-    },
-    dependencies: state.health.dependencies,
-    data: {
-      status: verifiedState(state.evidence, state.health.dependencies.signal),
-      input: state.evidence?.evaluation.input ?? null,
-    },
-    evidence: {
-      status: verifiedState(state.evidence, state.health.dependencies.evidence),
-      runId: state.evidence?.evaluation.runId ?? null,
-      startupMode: state.evidence?.startupMode ?? null,
-      persistence: state.evidence?.persistence ?? null,
-    },
-    economic: {
-      status: economic,
-      verdict: state.evidence?.qualification.evaluationVerdict ?? null,
-    },
-    qualification: {
-      status: state.evidence?.qualification.verdict ?? 'UNKNOWN',
-      executable: state.evidence?.qualification.verdict === 'QUALIFIED',
-      lockId: state.evidence?.qualification.lockId ?? null,
-      resultHash: state.evidence?.qualification.resultHash ?? null,
-      analysisHash: state.evidence?.qualification.analysis.analysisHash ?? null,
-      candidateOrdinal: state.evidence?.qualification.analysis.candidateOrdinal ?? null,
-      reasonCodes: state.evidence?.qualification.reasonCodes ?? [],
-      executionProvenance: state.evidence?.provenance ?? null,
-    },
-    accounting: {
-      status: accounting,
-      reconciliation: state.evidence?.reconciliation ?? null,
-    },
-    authority: {
-      maximum: 'observe',
-      brokerOrders: false,
-      capitalPromotion: false,
-    },
-    build: {
-      sourceRevision: provenance.sourceRevision,
-      image: provenance.image,
-      verification: provenanceVerification,
-    },
-    error: state.error,
-  }
-}
-
-const jsonResponse = (body: unknown, status = 200, headers?: Readonly<Record<string, string>>) =>
-  HttpServerResponse.text(json(body), { status, contentType: 'application/json', headers })
-
-export const makeHttpLayer = (
-  config: Pick<RuntimeConfig, 'host' | 'operationTimeoutMs' | 'port'>,
-  state: Ref.Ref<RuntimeState>,
-  provenance: RuntimeProvenance,
-  provenanceVerification: RuntimeBuildMetadata['verification'],
-  evidenceStore: EvidenceStoreService,
-): ReturnType<typeof NodeHttpServer.layer> => {
-  const ready = Ref.get(state).pipe(
-    Effect.map((current) => {
-      const ready = isReady(current)
-      const failedDependencies = Object.entries(current.health.dependencies)
-        .filter(([, dependency]) => dependency.status !== 'AVAILABLE')
-        .map(([name]) => name)
-      return jsonResponse(
-        {
-          ready,
-          status: current.status,
-          checkedAt: current.health.checkedAt,
-          probeSequence: current.health.sequence,
-          failedDependencies,
-        },
-        ready ? 200 : 503,
-      )
-    }),
-  )
-  const status = Ref.get(state).pipe(
-    Effect.map((current) => jsonResponse(publicState(current, provenance, provenanceVerification))),
-  )
-  const historicalEvaluation = HttpRouter.params.pipe(
-    Effect.flatMap(({ runId }) => {
-      if (runId === undefined || !/^[0-9a-f]{64}$/.test(runId)) {
-        return Effect.succeed(jsonResponse({ error: 'invalid_run_id' }, 400))
-      }
-      return evidenceStore.read(runId).pipe(
-        Effect.timeoutOrElse({
-          duration: config.operationTimeoutMs,
-          orElse: () => Effect.fail(new Error(`evidence read timed out after ${config.operationTimeoutMs}ms`)),
-        }),
-        Effect.map((stored) =>
-          Option.match(stored, {
-            onNone: () => jsonResponse({ error: 'evaluation_not_found' }, 404),
-            onSome: (evidence) => jsonResponse(evidence),
-          }),
-        ),
-        Effect.catch((error) =>
-          Effect.logError('Bayn historical evidence read failed').pipe(
-            Effect.annotateLogs({ service: 'bayn', runId, error: error.message }),
-            Effect.as(jsonResponse({ error: 'evidence_unavailable' }, 503)),
-          ),
-        ),
-      )
-    }),
-  )
-  const fallback = (
-    request: HttpServerRequest.HttpServerRequest,
-  ): Effect.Effect<HttpServerResponse.HttpServerResponse> =>
-    Effect.succeed(
-      request.method === 'GET'
-        ? jsonResponse({ error: 'not_found' }, 404)
-        : jsonResponse({ error: 'method_not_allowed' }, 405, { allow: 'GET' }),
-    )
-  const routes: Layer.Layer<never, never, HttpRouter.HttpRouter> = HttpRouter.addAll([
-    HttpRouter.route<never, never>('GET', '/livez', jsonResponse({ service: 'bayn', live: true })),
-    HttpRouter.route<never, never>('GET', '/readyz', ready),
-    HttpRouter.route<never, never>('GET', '/v1/status', status),
-    HttpRouter.route('GET', '/v1/evaluations/:runId', historicalEvaluation),
-    HttpRouter.route<never, never>('*', '*', fallback),
-  ] as const)
-
-  return HttpRouter.serve(routes, { disableLogger: true }).pipe(
-    Layer.provideMerge(NodeHttpServer.layer(() => createServer(), { host: config.host, port: config.port })),
-  )
-}
+import {
+  initialState,
+  type DependencyHealth,
+  type RuntimeEvidence,
+  type RuntimeHealth,
+  type RuntimeState,
+} from './runtime-state'
+import type { Strategy } from './strategy-service'
 
 const withinDeadline = <A, R>(
   effect: Effect.Effect<A, OperationalError, R>,
@@ -291,9 +86,9 @@ const recoverPinnedQualification = (
   config: RuntimeConfig,
   runId: string,
   state: Ref.Ref<RuntimeState>,
-): Effect.Effect<void, OperationalError, Strategy | EvidenceStore> =>
+  strategy: Strategy,
+): Effect.Effect<void, OperationalError, EvidenceStore> =>
   Effect.gen(function* () {
-    const strategy = yield* Strategy
     const evidenceStore = yield* EvidenceStore
     yield* Effect.logInfo('Bayn pinned qualification recovery started').pipe(
       Effect.annotateLogs({
@@ -418,11 +213,11 @@ const recoverPinnedQualification = (
 const evaluateAndJournal = (
   config: RuntimeConfig,
   state: Ref.Ref<RuntimeState>,
-): Effect.Effect<void, OperationalError, MarketData | Journal | Strategy | EvidenceStore> =>
+  strategy: Strategy,
+): Effect.Effect<void, OperationalError, MarketData | Journal | EvidenceStore> =>
   Effect.gen(function* () {
     const marketData = yield* MarketData
     const journal = yield* Journal
-    const strategy = yield* Strategy
     const evidenceStore = yield* EvidenceStore
     yield* Effect.logInfo('Bayn startup evaluation started').pipe(
       Effect.annotateLogs({
@@ -626,10 +421,11 @@ const evaluateAndJournal = (
 export const initialize = (
   config: RuntimeConfig,
   state: Ref.Ref<RuntimeState>,
-): Effect.Effect<void, never, MarketData | Journal | Strategy | EvidenceStore> =>
+  strategy: Strategy,
+): Effect.Effect<void, never, MarketData | Journal | EvidenceStore> =>
   (config.qualificationRunId === undefined
-    ? evaluateAndJournal(config, state)
-    : recoverPinnedQualification(config, config.qualificationRunId, state)
+    ? evaluateAndJournal(config, state, strategy)
+    : recoverPinnedQualification(config, config.qualificationRunId, state, strategy)
   ).pipe(Effect.catch((error) => failStartup(state, error)))
 
 interface ProbeResult<A> {
@@ -807,16 +603,16 @@ export const monitor = (
 
 export const run = (
   config: RuntimeConfig,
-): Effect.Effect<never, OperationalError, MarketData | Journal | Strategy | EvidenceStore> =>
+  strategy: Strategy,
+): Effect.Effect<never, OperationalError, MarketData | Journal | EvidenceStore> =>
   Effect.scoped(
     Effect.gen(function* () {
-      const strategy = yield* Strategy
       const evidenceStore = yield* EvidenceStore
       const state = yield* Ref.make(initialState())
       yield* Layer.build(
-        makeHttpLayer(config, state, strategy.provenance, config.build.verification, evidenceStore),
+        makeHttpLayer(config, state, strategy.provenance, config.build.verification, evidenceStore.read),
       ).pipe(Effect.mapError((cause) => operationalError('http', 'listen', 'HTTP server failed to listen', cause)))
-      yield* initialize(config, state)
+      yield* initialize(config, state, strategy)
       yield* monitor(config, state).pipe(Effect.forkScoped({ startImmediately: true }))
       return yield* Effect.never
     }),

--- a/services/bayn/src/http.ts
+++ b/services/bayn/src/http.ts
@@ -1,0 +1,160 @@
+import { createServer } from 'node:http'
+
+import { NodeHttpServer } from '@effect/platform-node'
+import { Effect, Layer, Option, Ref } from 'effect'
+import { HttpRouter, HttpServerRequest, HttpServerResponse } from 'effect/unstable/http'
+
+import type { RuntimeBuildMetadata, RuntimeConfig } from './config'
+import type { RuntimeProvenance } from './contracts'
+import { isReady, type DependencyHealth, type RuntimeState } from './runtime-state'
+
+type ReadEvidence = (runId: string) => Effect.Effect<Option.Option<unknown>, { readonly message: string }>
+
+const json = (value: unknown): string =>
+  JSON.stringify(value, (_, nested) => (typeof nested === 'bigint' ? nested.toString() : nested))
+
+const verifiedState = (state: RuntimeState, dependency: DependencyHealth) => {
+  if (state.evidence === null || dependency.status === 'UNKNOWN') return 'UNKNOWN'
+  return dependency.status === 'AVAILABLE' ? 'CURRENT' : 'INVALID'
+}
+
+const publicState = (
+  state: RuntimeState,
+  provenance: RuntimeProvenance,
+  provenanceVerification: RuntimeBuildMetadata['verification'],
+) => {
+  let economic = 'UNKNOWN'
+  let accounting = 'UNKNOWN'
+  if (state.evidence !== null) {
+    economic = state.evidence.qualification.verdict
+    if (state.health.dependencies.tigerBeetle.status === 'AVAILABLE') accounting = 'EXACT'
+    if (state.health.dependencies.tigerBeetle.status === 'UNAVAILABLE') accounting = 'UNAVAILABLE'
+  }
+
+  return {
+    service: 'bayn',
+    operational: {
+      status: state.status,
+      ready: isReady(state),
+      probeSequence: state.health.sequence,
+      checkedAt: state.health.checkedAt,
+    },
+    dependencies: state.health.dependencies,
+    data: {
+      status: verifiedState(state, state.health.dependencies.signal),
+      input: state.evidence?.evaluation.input ?? null,
+    },
+    evidence: {
+      status: verifiedState(state, state.health.dependencies.evidence),
+      runId: state.evidence?.evaluation.runId ?? null,
+      startupMode: state.evidence?.startupMode ?? null,
+      persistence: state.evidence?.persistence ?? null,
+    },
+    economic: {
+      status: economic,
+      verdict: state.evidence?.qualification.evaluationVerdict ?? null,
+    },
+    qualification: {
+      status: state.evidence?.qualification.verdict ?? 'UNKNOWN',
+      executable: state.evidence?.qualification.verdict === 'QUALIFIED',
+      lockId: state.evidence?.qualification.lockId ?? null,
+      resultHash: state.evidence?.qualification.resultHash ?? null,
+      analysisHash: state.evidence?.qualification.analysis.analysisHash ?? null,
+      candidateOrdinal: state.evidence?.qualification.analysis.candidateOrdinal ?? null,
+      reasonCodes: state.evidence?.qualification.reasonCodes ?? [],
+      executionProvenance: state.evidence?.provenance ?? null,
+    },
+    accounting: {
+      status: accounting,
+      reconciliation: state.evidence?.reconciliation ?? null,
+    },
+    authority: {
+      maximum: 'observe',
+      brokerOrders: false,
+      capitalPromotion: false,
+    },
+    build: {
+      sourceRevision: provenance.sourceRevision,
+      image: provenance.image,
+      verification: provenanceVerification,
+    },
+    error: state.error,
+  }
+}
+
+const jsonResponse = (body: unknown, status = 200, headers?: Readonly<Record<string, string>>) =>
+  HttpServerResponse.text(json(body), { status, contentType: 'application/json', headers })
+
+export const makeHttpLayer = (
+  config: Pick<RuntimeConfig, 'host' | 'operationTimeoutMs' | 'port'>,
+  state: Ref.Ref<RuntimeState>,
+  provenance: RuntimeProvenance,
+  provenanceVerification: RuntimeBuildMetadata['verification'],
+  readEvidence: ReadEvidence,
+): ReturnType<typeof NodeHttpServer.layer> => {
+  const ready = Ref.get(state).pipe(
+    Effect.map((current) => {
+      const ready = isReady(current)
+      const failedDependencies = Object.entries(current.health.dependencies)
+        .filter(([, dependency]) => dependency.status !== 'AVAILABLE')
+        .map(([name]) => name)
+      return jsonResponse(
+        {
+          ready,
+          status: current.status,
+          checkedAt: current.health.checkedAt,
+          probeSequence: current.health.sequence,
+          failedDependencies,
+        },
+        ready ? 200 : 503,
+      )
+    }),
+  )
+  const status = Ref.get(state).pipe(
+    Effect.map((current) => jsonResponse(publicState(current, provenance, provenanceVerification))),
+  )
+  const historicalEvaluation = HttpRouter.params.pipe(
+    Effect.flatMap(({ runId }) => {
+      if (runId === undefined || !/^[0-9a-f]{64}$/.test(runId)) {
+        return Effect.succeed(jsonResponse({ error: 'invalid_run_id' }, 400))
+      }
+      return readEvidence(runId).pipe(
+        Effect.timeoutOrElse({
+          duration: config.operationTimeoutMs,
+          orElse: () => Effect.fail(new Error(`evidence read timed out after ${config.operationTimeoutMs}ms`)),
+        }),
+        Effect.map((stored) =>
+          Option.match(stored, {
+            onNone: () => jsonResponse({ error: 'evaluation_not_found' }, 404),
+            onSome: (evidence) => jsonResponse(evidence),
+          }),
+        ),
+        Effect.catch((error) =>
+          Effect.logError('Bayn historical evidence read failed').pipe(
+            Effect.annotateLogs({ service: 'bayn', runId, error: error.message }),
+            Effect.as(jsonResponse({ error: 'evidence_unavailable' }, 503)),
+          ),
+        ),
+      )
+    }),
+  )
+  const fallback = (
+    request: HttpServerRequest.HttpServerRequest,
+  ): Effect.Effect<HttpServerResponse.HttpServerResponse> =>
+    Effect.succeed(
+      request.method === 'GET'
+        ? jsonResponse({ error: 'not_found' }, 404)
+        : jsonResponse({ error: 'method_not_allowed' }, 405, { allow: 'GET' }),
+    )
+  const routes: Layer.Layer<never, never, HttpRouter.HttpRouter> = HttpRouter.addAll([
+    HttpRouter.route<never, never>('GET', '/livez', jsonResponse({ service: 'bayn', live: true })),
+    HttpRouter.route<never, never>('GET', '/readyz', ready),
+    HttpRouter.route<never, never>('GET', '/v1/status', status),
+    HttpRouter.route('GET', '/v1/evaluations/:runId', historicalEvaluation),
+    HttpRouter.route<never, never>('*', '*', fallback),
+  ] as const)
+
+  return HttpRouter.serve(routes, { disableLogger: true }).pipe(
+    Layer.provideMerge(NodeHttpServer.layer(() => createServer(), { host: config.host, port: config.port })),
+  )
+}

--- a/services/bayn/src/index.ts
+++ b/services/bayn/src/index.ts
@@ -10,7 +10,7 @@ import { EvidenceStoreRuntimeLive } from './db/evidence-store'
 import { JournalLive } from './ledger'
 import { MarketDataLive } from './market-data'
 import { hashParameters, loadDefaultProtocol } from './protocol'
-import { makeStrategy, Strategy } from './strategy-service'
+import { makeStrategy } from './strategy-service'
 
 const main = Effect.gen(function* () {
   const config = yield* loadConfig()
@@ -48,9 +48,8 @@ const main = Effect.gen(function* () {
     marketData,
     JournalLive(config),
     EvidenceStoreRuntimeLive(config).pipe(Layer.provide(NodeServices.layer)),
-    Layer.succeed(Strategy, strategy),
   )
-  return yield* run(config).pipe(Effect.provide(dependencies))
+  return yield* run(config, strategy).pipe(Effect.provide(dependencies))
 })
 
 const program = main.pipe(Effect.annotateLogs({ service: 'bayn' }), Effect.provide(Logger.layer([Logger.consoleJson])))

--- a/services/bayn/src/resources.test.ts
+++ b/services/bayn/src/resources.test.ts
@@ -3,16 +3,18 @@ import { describe, expect, test } from 'bun:test'
 import { Effect, Option, Redacted, Ref } from 'effect'
 import { createClient as createTigerBeetleClient, type Client } from 'tigerbeetle-node'
 
-import { initialState, initialize } from './app'
+import { initialize } from './app'
 import type { RuntimeConfig } from './config'
 import { EvidenceStore, type EvidenceStoreService } from './db/evidence-store'
 import { operationalError } from './errors'
 import { Journal, JournalLive, type JournalService } from './ledger'
 import { MarketData, type MarketDataService } from './market-data'
-import { StrategyLayer } from './strategy-service'
+import { initialState } from './runtime-state'
+import { makeStrategy } from './strategy-service'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
 
 const provenance = makeTestProvenance()
+const fixtureStrategy = makeStrategy(fixtureProtocol, provenance)
 
 const config: RuntimeConfig = {
   host: '127.0.0.1',
@@ -214,11 +216,10 @@ describe('Bayn resource lifecycle', () => {
 
     await Effect.runPromise(
       Effect.scoped(
-        initialize(config, state).pipe(
+        initialize(config, state, fixtureStrategy).pipe(
           Effect.provideService(Journal, successfulJournal),
           Effect.provideService(EvidenceStore, successfulEvidenceStore),
           Effect.provideService(MarketData, marketData),
-          Effect.provide(StrategyLayer(fixtureProtocol, provenance)),
         ),
       ),
     )
@@ -240,11 +241,10 @@ describe('Bayn resource lifecycle', () => {
 
     await Effect.runPromise(
       Effect.scoped(
-        initialize(config, state).pipe(
+        initialize(config, state, fixtureStrategy).pipe(
           Effect.provideService(Journal, successfulJournal),
           Effect.provideService(EvidenceStore, successfulEvidenceStore),
           Effect.provideService(MarketData, marketData),
-          Effect.provide(StrategyLayer(fixtureProtocol, provenance)),
         ),
       ),
     )
@@ -274,10 +274,9 @@ describe('Bayn resource lifecycle', () => {
 
     await Effect.runPromise(
       Effect.scoped(
-        initialize(config, state).pipe(
+        initialize(config, state, fixtureStrategy).pipe(
           Effect.provideService(MarketData, marketData),
           Effect.provideService(EvidenceStore, successfulEvidenceStore),
-          Effect.provide(StrategyLayer(fixtureProtocol, provenance)),
           Effect.provide(
             JournalLive(config, {
               createClient: (() => tigerBeetleClient) as unknown as typeof createTigerBeetleClient,

--- a/services/bayn/src/runtime-state.ts
+++ b/services/bayn/src/runtime-state.ts
@@ -1,0 +1,60 @@
+import type { RuntimeProvenance } from './contracts'
+import type { PersistenceReceipt } from './db/evidence-store'
+import type { QualificationResult } from './qualification'
+import type { EvaluationSummary, ReconciliationResult } from './types'
+
+export interface RuntimeEvidence {
+  readonly startupMode: 'evaluated' | 'pinned' | 'recovered'
+  readonly provenance: RuntimeProvenance
+  readonly evaluation: EvaluationSummary
+  readonly reconciliation: ReconciliationResult
+  readonly persistence: PersistenceReceipt
+  readonly qualification: QualificationResult
+}
+
+export interface DependencyHealth {
+  readonly status: 'UNKNOWN' | 'AVAILABLE' | 'UNAVAILABLE'
+  readonly checkedAt: string | null
+  readonly error: string | null
+}
+
+export interface RuntimeHealth {
+  readonly sequence: number
+  readonly checkedAt: string | null
+  readonly dependencies: {
+    readonly postgresql: DependencyHealth
+    readonly signal: DependencyHealth
+    readonly tigerBeetle: DependencyHealth
+    readonly evidence: DependencyHealth
+  }
+}
+
+export interface RuntimeState {
+  readonly status: 'STARTING' | 'READY' | 'DEGRADED' | 'FAILED'
+  readonly evidence: RuntimeEvidence | null
+  readonly health: RuntimeHealth
+  readonly error: string | null
+}
+
+const unknownDependency = (): DependencyHealth => ({ status: 'UNKNOWN', checkedAt: null, error: null })
+
+export const initialState = (): RuntimeState => ({
+  status: 'STARTING',
+  evidence: null,
+  health: {
+    sequence: 0,
+    checkedAt: null,
+    dependencies: {
+      postgresql: unknownDependency(),
+      signal: unknownDependency(),
+      tigerBeetle: unknownDependency(),
+      evidence: unknownDependency(),
+    },
+  },
+  error: null,
+})
+
+export const isReady = (state: RuntimeState): boolean =>
+  state.status === 'READY' &&
+  state.evidence !== null &&
+  Object.values(state.health.dependencies).every((dependency) => dependency.status === 'AVAILABLE')

--- a/services/bayn/src/strategy-service.ts
+++ b/services/bayn/src/strategy-service.ts
@@ -1,5 +1,3 @@
-import { Context, Layer } from 'effect'
-
 import type { RuntimeProvenance } from './contracts'
 import {
   defaultQualificationStatisticsPolicyDocument,
@@ -16,7 +14,7 @@ import {
 import { evaluateRiskBalancedTrend, prepareRiskBalancedTrendQualification } from './risk-balanced-trend'
 import type { DailyBar, EvaluationResult, InputManifest, IsoDate, Protocol } from './types'
 
-export interface StrategyService {
+export interface Strategy {
   readonly name: string
   readonly universe: readonly string[]
   readonly parameters: Protocol
@@ -30,8 +28,6 @@ export interface StrategyService {
   readonly analyze: (evaluation: EvaluationResult, priorTrialRunIds: readonly string[]) => QualificationAnalysis
 }
 
-export class Strategy extends Context.Service<Strategy, StrategyService>()('bayn/Strategy') {}
-
 const requireMatchingUniverse = (manifest: InputManifest, protocol: Protocol): InputManifest => {
   const snapshot = manifest.finalizedSnapshot
   if (
@@ -44,7 +40,7 @@ const requireMatchingUniverse = (manifest: InputManifest, protocol: Protocol): I
   return manifest
 }
 
-export const makeStrategy = (protocol: Protocol, provenance: RuntimeProvenance): StrategyService => {
+export const makeStrategy = (protocol: Protocol, provenance: RuntimeProvenance): Strategy => {
   const benchmarkPolicy = makeQualificationPolicyDocument('bayn.risk-balanced-trend-benchmark-policy.v1', {
     schemaVersion: 'bayn.risk-balanced-trend-benchmark-policy.v1',
     comparison: 'stronger-of-buy-and-hold-or-direct-volatility-timing',
@@ -116,6 +112,3 @@ export const makeStrategy = (protocol: Protocol, provenance: RuntimeProvenance):
       ),
   }
 }
-
-export const StrategyLayer = (protocol: Protocol, provenance: RuntimeProvenance) =>
-  Layer.succeed(Strategy, makeStrategy(protocol, provenance))


### PR DESCRIPTION
## Summary

- Remove the pure strategy from Effect Context and Layer composition and pass it explicitly from the composition root.
- Separate HTTP transport and pure runtime state from lifecycle orchestration, and narrow HTTP evidence access to one read function.
- Preserve Bayn behavior and persistence interfaces while removing strategy-layer setup from runtime and tests.

## Related Issues

None

## Testing

- `bun run --filter @proompteng/bayn test` (116 passed; 23 PostgreSQL integration cases skipped because `BAYN_TEST_POSTGRES_URL` is not configured)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.