### PR TITLE
docs(bayn): align architecture with current runtime

### DIFF
--- a/docs/bayn/architecture.md
+++ b/docs/bayn/architecture.md
@@ -1,116 +1,119 @@
 # Bayn architecture
 
-## Purpose and boundary
+## Boundary
 
-Bayn is being built as an autonomous quantitative evaluation, execution, and accounting service. Its first strategy is
-adjusted-ETF time-series momentum. The deployed runtime currently stops at evaluation and simulation accounting: it may
-not call a broker, submit an order, or promote capital. Later authority is unlocked only by the roadmap's economic,
-recovery, reconciliation, and observation gates.
+Bayn is a single-writer, paper-only quantitative qualification runtime. It evaluates one compiled
+`risk-balanced-trend` candidate against one immutable Signal snapshot, journals the deterministic simulation, verifies
+the accounting result, and exposes the resulting qualification evidence. It has no broker client, broker credential,
+order-submission path, or capital-promotion authority. Public status always reports maximum authority `observe`.
 
-The current deployment retains TigerBeetle as the deterministic simulation journal while Bayn-owned PostgreSQL stores
-the durable evaluation evidence. Signal input is an exact finalized, content-addressed snapshot. Simulation accounting
-is replaced incrementally before any paper mutation work begins.
+The runtime has three external I/O boundaries:
 
-## Critical path
+- Signal ClickHouse, read-only, for the configured finalized publication;
+- a dedicated Bayn TigerBeetle cluster for deterministic simulation accounting; and
+- the existing `EvidenceStore` interface for durable qualification evidence.
 
-1. A Signal-owned publisher captures adjusted daily bars and exchange sessions into an immutable snapshot and writes
-   its manifest last. Historical and daily modes use the same validation and finalization path. V2 manifests also bind
-   the authoritative universe ID and canonical symbol hash.
-2. The runtime's dedicated ClickHouse identity has `SELECT` only. The currently pinned TSMOM evidence reads V1
-   manifests; the staged universe publication uses `snapshot_manifests_v2`, `exchange_sessions_v1`, and
-   `adjusted_daily_bars_v2`. A later strategy integration must explicitly move Bayn to that V2 contract.
-3. Bayn reproduces the publisher's manifest, session, bar, and snapshot hashes; rejects mixed, duplicate, unexpected,
-   incomplete, future, or out-of-bound input; and emits a bounded immutable input manifest.
-4. The committed `tsmom-v1` protocol forms signals at month-end close and executes at the next common session open.
-5. One evaluator produces strategy, buy-and-hold, direct-volatility, and doubled-cost results on comparable dates.
-6. Deterministic events become double-entry transfers in a Bayn-owned TigerBeetle ledger. Existing IDs are accepted
-   only after object lookup and field comparison; accounts, transfers, and posted balances must reconcile exactly.
-7. After exact reconciliation, a single PostgreSQL transaction records the immutable protocol and snapshot references,
-   run identity, metrics, reconciliation receipt, ordered events, gate outcomes, and status history. The transaction
-   changes the run from `WRITING` to `COMPLETE` only after exact child-row counts match.
-8. Kubernetes readiness opens only after data validation, evaluation, journaling, reconciliation, and the durable
-   PostgreSQL commit complete.
+The implementation behind `EvidenceStore` is deliberately outside this document. Non-database cleanup must preserve
+that interface and every persisted evidence contract.
 
-There is one `apps/v1 Deployment`, one replica, and one container. It has no scheduler, CronJob, Knative revision,
-broker secret, or Kubernetes API token. `maxSurge: 0` prevents overlapping runtime writers during rollout.
+## Runtime flow
 
-## Reproducibility
+1. The composition root loads Effect Config, decodes the compiled protocol, verifies its parameter hash against the
+   build, and constructs one pure `Strategy` value.
+2. Startup inspects the configured finalized Signal V2 publication before loading bars. The manifest must match the
+   compiled universe, symbol hash, feed, adjustment, calendar, and evaluation bounds.
+3. Bayn derives the candidate identity and opens the immutable qualification lock through the existing evidence
+   boundary. A terminal result is recovered; an incomplete lock fails closed.
+4. For a new candidate, Bayn loads the locked bars, evaluates the strategy and benchmarks, journals the simulation to
+   TigerBeetle, and requires exact reconciliation.
+5. The evaluation graph and one terminal qualification result are committed through the existing evidence boundary.
+6. A health probe then verifies Signal identity, TigerBeetle state, durable evidence, and dependency connectivity.
+   Readiness opens only when startup evidence exists and every probe is available.
 
-The executable embeds its full source revision, OCI repository, and the versioned selected-strategy behavior identity.
-The TSMOM identity is guarded by a deterministic evaluator fingerprint so behavior-preserving refactors do not break a
-pinned qualification. Startup strictly decodes the committed TypeScript protocol, hashes the decoded value with
-canonical JSON, and refuses to run when configured source/repository attribution differs from the embedded build.
-GitOps supplies the immutable image-index digest after publication. Status and the in-memory evidence envelope expose
-all of those facts and their contract versions.
+`BAYN_QUALIFICATION_RUN_ID` selects the recovery path. That path verifies the stored strategy, Signal, and execution
+bindings and does not load bars, open a new lock, evaluate, journal, or persist. Continuous health checks still verify
+the recovered run after startup.
 
-Local package entry points remain usable through an explicit `development-configured` provenance mode. It is reported
-in HTTP status with an unverified behavior marker, forces evaluation and journaling off, and cannot override embedded
-build facts. The production Nix image does not enable that mode: absent, partial, or mismatched embedded attribution
-prevents startup.
+A strategy rejection is terminal economic evidence, not an operational crash. Startup or dependency defects leave the
+HTTP process live for diagnosis while readiness remains closed.
 
-The run ID is the SHA-256 hash of:
+## Effect composition
 
-- source revision and immutable OCI image identity;
-- compiled strategy behavior and the complete decoded protocol;
-- complete finalized Signal snapshot and exchange-calendar provenance; and
-- explicit data, lookback, and evaluation bounds.
+Effect is used at resource and failure boundaries, not as a container for ordinary TypeScript:
 
-Decision and fill IDs derive from canonical event payloads. TigerBeetle account and transfer IDs derive from the run ID,
-event ID, and journal leg. Repeating the same run is idempotent; a changed price, protocol, or source revision creates a
-different run namespace.
+- `Strategy`, protocol values, calculations, hashing, and qualification analysis are plain immutable values and pure
+  functions.
+- `MarketData`, `Journal`, and `EvidenceStore` are Effect services because they own external I/O and resource
+  lifecycles.
+- `src/index.ts` is the only composition root. It loads configuration, builds the pure strategy, assembles the three
+  I/O layers, and hands them to `run`.
+- `run` owns one scoped lifetime. It starts the HTTP layer, performs initialization, and forks the repeating health
+  monitor with `forkScoped`; scope closure releases the server and clients.
+- Operational timeouts and typed `OperationalError` values are applied where an external operation enters the
+  lifecycle. Domain functions throw only inside an `Effect.try` boundary that assigns the owning component and
+  operation.
+- HTTP receives the runtime state and the narrow evidence-read callback it needs. It does not depend on the strategy or
+  the complete evidence service.
 
-PostgreSQL uses the same run ID as its primary idempotency key. Exact replay returns the existing `COMPLETE` receipt
-only after verifying its protocol, snapshot, source revision, image, strategy, status sequence, child-row counts, and
-every stored payload against its content hash. A collision, partial run, altered payload, or divergent immutable
-reference fails closed. Protocol locks and snapshot references are inserted and read back inside the same transaction
-as the run, so no partial evidence survives a failed write.
+Do not introduce a `Context.Service` or `Layer` for a pure value merely to make it injectable. Add an Effect service
+only when a capability needs acquisition, release, configuration, retry, concurrency, or typed I/O failure.
 
-## Versioned contract boundary
+## Runtime state and probes
 
-The target evaluation path uses the executable v1 contracts in [`contracts/v1.md`](contracts/v1.md). They strictly
-decode finalized-snapshot provenance, evaluation bounds, run identity, evidence freshness, independent status axes, and
-authority. Unknown versions and excess fields fail closed. Run identity binds the full source revision, OCI image
-digest, compiled strategy behavior hash, decoded strategy parameters, finalized snapshot, exchange-calendar version,
-and explicit bounds through canonical JSON and SHA-256.
+The internal operational states are `STARTING`, `READY`, `DEGRADED`, and `FAILED`. Each health observation
+records one sequence number and independent `UNKNOWN`, `AVAILABLE`, or `UNAVAILABLE` results for PostgreSQL,
+Signal, TigerBeetle, and durable evidence. Readiness requires:
 
-Runtime provenance, finalized-snapshot identity, bounded reads, strict TSMOM parameter decoding, run identity, and
-transactional evaluation persistence are adopted contract slices. Continuous health and removal of the legacy
-TigerBeetle dependency remain separate roadmap tickets with their own rollout evidence.
+- operational state `READY`;
+- an active evaluation or recovered qualification; and
+- every dependency result `AVAILABLE`.
 
-## Economic test
+The monitor runs immediately after initialization and then at `BAYN_HEALTH_INTERVAL_MS`. A transient defect moves a
+previously ready runtime to `DEGRADED`; a later complete probe can reopen readiness without discarding the last valid
+evidence. `BAYN_OPERATION_TIMEOUT_MS` bounds every external startup and health operation.
 
-The protocol is long-or-cash across DBC, EEM, EFA, GLD, IEF, SPY, TLT, and VNQ. Direction is the majority sign across
-21, 63, 126, and 252-session momentum lookbacks. Rebalancing is monthly and the cost model is charged on every buy and
-sell. The verdict fails closed unless all committed gates pass: sufficient observations, positive return after costs,
-Sharpe improvement over both benchmarks, bounded drawdown, bounded turnover, and positive return with doubled costs.
+`GET /livez` proves only that the process and HTTP server are alive. `GET /readyz` exposes the current readiness
+decision. `GET /v1/status` keeps operational health, data identity, evidence, economic verdict, qualification,
+accounting, build provenance, and fixed authority separate.
 
-This evaluator result is not the excluded locked out-of-sample verdict. Changing the strategy because of the current
-result would contaminate that later test.
+## Strategy and economic contract
 
-## Accounting model
+The compiled `bayn.risk-balanced-trend.protocol.v2` uses the exact `equity-infrastructure-v1` universe:
 
-All USD amounts use integer micros in TigerBeetle. Per-run accounts are cash, equity, fees, realized gain, realized loss,
-and inventory cost per symbol. Buys move cash to inventory cost. Sells remove cost basis, move proceeds to cash, and
-separate realized gain or loss. Fees move cash to fee expense. Quantities and prices remain in the immutable evaluation
-event payload hash.
+`AMD, AVGO, COHR, CRDO, LITE, MRVL, MU, NVDA, WDC`.
 
-TigerBeetle is currently a single-replica shared dependency. Exact Bayn reconciliation is an accounting-integrity gate;
-it does not make that dependency highly available and does not grant trading authority. PostgreSQL durably records the
-result and receipt, but does not replace the double-entry ledger in this slice.
+At each month-end close, the strategy computes volatility-normalized returns over 21, 63, 126, and 252 sessions,
+averages them into a composite score, and assigns weight only to positive scores. Weights are redistributed under a 35%
+per-symbol cap, quantized deterministically, and scaled down when estimated portfolio volatility exceeds 10%. Residual
+exposure remains cash. Decisions execute only at the next exchange-session open under the compiled paper execution
+model.
 
-## Deployment and recovery
+The evaluator compares the candidate with buy-and-hold, direct-volatility timing, and doubled-cost results over aligned
+dates. Qualification also applies the committed statistical and walk-forward policy. Every decision, benchmark,
+execution assumption, gate, and result remains bound to the run identity; refactoring composition must not alter those
+values.
 
-The image is built for AMD64 and ARM64 with Nix, published under a source-SHA tag, and pinned in GitOps by digest. Argo
-CD owns the `bayn` namespace and Deployment. The ClickHouse credential is separately sealed, reflected only into the
-Bayn namespace, and granted table-level `SELECT`. Alpaca credentials and the insert/select-only Signal writer identity
-are mounted only into the Signal publisher CronJob and are never mounted into the Bayn runtime.
+## Reproducibility and failure semantics
 
-Bayn connects to `bayn-db-rw` with the CNPG-generated `bayn-db-app` URI and a read-only mount containing only
-`bayn-db-ca/ca.crt`; the CA private key is not mounted. TLS hostname and certificate verification are mandatory in a
-production artifact. Effect SQL owns the scoped two-connection pool and additive migrations. CNPG backup, retention,
-and isolated restore evidence are defined in [`cnpg-backup-restore.md`](cnpg-backup-restore.md).
+The executable embeds the source revision, image repository, strategy behavior hash, and parameter hash. Production
+startup rejects absent or mismatched embedded facts. GitOps supplies the immutable image-index digest, and the run ID
+also binds the complete decoded protocol, finalized Signal provenance, calendar, and explicit bounds.
 
-On restart, Bayn recomputes the deterministic run, verifies any existing TigerBeetle objects, and reconciles the full
-run again before reading or writing the matching PostgreSQL receipt. If ClickHouse, TigerBeetle, PostgreSQL, data
-validation, evaluation, reconciliation, migration, or persistence fails, the process remains live for diagnosis but
-readiness stays closed.
+The local `dev` and `start` scripts select `development-configured` provenance because those artifacts do not
+contain production build metadata. This changes only how provenance is verified and reported; it does not disable
+evaluation, journaling, health checks, or fail-closed behavior.
+
+Repeated execution of the same inputs is deterministic and must either recover exact terminal evidence or reproduce
+the same journal objects. Any mismatched manifest, universe, build identity, lock, journal object, reconciliation,
+qualification, or durable evidence closes readiness and never expands authority.
+
+## Deployment status
+
+GitOps owns one `apps/v1 Deployment` and a dedicated three-replica TigerBeetle cluster. When Bayn is active, the
+Deployment is a single writer and `maxSurge: 0` prevents overlapping writers during rollout. The pod has no broker
+secret and no Kubernetes API token.
+
+As of 2026-07-21, the Deployment is intentionally quiesced at zero replicas for the separately owned database
+reset/restore workstream. The non-database cleanup does not change replicas, the qualification pin, PostgreSQL
+resources, or stored evidence. Live acceptance remains pending until that workstream restores one coherent writer and
+the promoted image proves startup, readiness, status, and sustained health.

--- a/docs/bayn/authoritative-universe.md
+++ b/docs/bayn/authoritative-universe.md
@@ -1,6 +1,6 @@
 # Bayn authoritative universe
 
-Status: **selected; deployment proof pending**
+Status: **selected, published, and compiled; Bayn runtime proof paused by the separate database workstream**
 
 Last verified: 2026-07-21
 
@@ -25,9 +25,8 @@ substitution; an addition, removal, calendar change, or adjustment change requir
 qualification record.
 
 The ETF universe from `PROOMPT-392` is abandoned. It was inherited without a selection procedure and is absent from
-the websocket subscription. Its image must not be promoted, deployed, or qualified. The runtime composition root
-remains on the previously deployed TSMOM implementation until a strategy for `equity-infrastructure-v1` is separately
-implemented and precommitted. This containment does not approve TSMOM or its ETF universe.
+the websocket subscription. Bayn's compiled `bayn.risk-balanced-trend.protocol.v2` now binds this exact universe,
+universe ID, and symbol hash. Strategy construction and market-data inspection both reject any different universe.
 
 ## Pre-return eligibility evidence
 
@@ -61,27 +60,27 @@ Every selected symbol has both the executable and reference role: it must exist 
 historical publication, with no reference-only substitute. The following operational exposure labels were committed
 without consulting candidate returns and exist only to make concentration visible:
 
-| Symbol | Non-return exposure role          | Decision reason                                      |
-| ------ | --------------------------------- | ---------------------------------------------------- |
-| AMD    | compute processors                | complete history, supported feeds, capacity pass     |
-| AVGO   | networking and custom silicon     | complete history, supported feeds, capacity pass     |
-| COHR   | optical components                | complete history, supported feeds, capacity pass     |
-| CRDO   | high-speed connectivity silicon   | complete history, supported feeds, capacity pass     |
-| LITE   | optical components                | complete history, supported feeds, capacity pass     |
-| MRVL   | networking and storage silicon    | complete history, supported feeds, capacity pass     |
-| MU     | memory                            | complete history, supported feeds, capacity pass     |
-| NVDA   | accelerated compute               | complete history, supported feeds, capacity pass     |
-| WDC    | data storage                      | complete history, supported feeds, capacity pass     |
-| SNDK   | flash storage                     | excluded: only 358 adjusted daily sessions           |
+| Symbol | Non-return exposure role        | Decision reason                                  |
+| ------ | ------------------------------- | ------------------------------------------------ |
+| AMD    | compute processors              | complete history, supported feeds, capacity pass |
+| AVGO   | networking and custom silicon   | complete history, supported feeds, capacity pass |
+| COHR   | optical components              | complete history, supported feeds, capacity pass |
+| CRDO   | high-speed connectivity silicon | complete history, supported feeds, capacity pass |
+| LITE   | optical components              | complete history, supported feeds, capacity pass |
+| MRVL   | networking and storage silicon  | complete history, supported feeds, capacity pass |
+| MU     | memory                          | complete history, supported feeds, capacity pass |
+| NVDA   | accelerated compute             | complete history, supported feeds, capacity pass |
+| WDC    | data storage                    | complete history, supported feeds, capacity pass |
+| SNDK   | flash storage                   | excluded: only 358 adjusted daily sessions       |
 
-## Pre-rollout production baseline
+## Historical pre-rollout baseline (superseded)
 
 Read-only verification at 2026-07-21T09:20:51Z found one healthy websocket pod and one Alpaca connection. Alpaca had
 acknowledged the legacy ten-symbol set, including `SNDK`, on trades, quotes, bars, and updated bars. The scheduled V1
 Signal publisher was active. Both ClickHouse replicas agreed on two finalized V1 manifests; the latest snapshot
 `0e3188062fb6781f9dfdc048b4bfe9846d8f4ce74c5e429e296e3ebcd75e93a5` contains 2,398 sessions and 19,184 bars for
-the eight legacy ETFs `DBC,EEM,EFA,GLD,IEF,SPY,TLT,VNQ` through 2026-07-20. Neither producer nor database therefore
-matches the selected universe yet.
+the eight legacy ETFs `DBC,EEM,EFA,GLD,IEF,SPY,TLT,VNQ` through 2026-07-20. At that timestamp neither the producer nor
+the publication matched the selected universe. This paragraph is retained only as the before-rollout observation.
 
 ## Data contract
 
@@ -96,9 +95,9 @@ matches the selected universe yet.
   history that a live websocket cannot provide; daily publications run after the Basic plan's 15-minute delay and use
   the same validation and immutable `snapshot_manifests_v2` finalization path. Every manifest binds the universe ID and
   symbol hash.
-- The later Bayn strategy integration must accept only a finalized V2 manifest whose universe ID, symbol hash, feed,
-  adjustment, calendar, bounds, and canonical symbols match the compiled strategy. A superset, subset, duplicate,
-  mixed feed, or missing session must fail closed. This rollout does not change Bayn's current pinned V1 evidence.
+- Bayn accepts only a finalized V2 publication whose universe ID, symbol hash, feed, adjustment, calendar, bounds, and
+  canonical symbols match the compiled strategy. A superset, subset, duplicate, mixed feed, or missing session fails
+  closed.
 - Historical and live events retain their transport and feed identity. Delayed SIP REST history is not relabeled as
   real-time IEX websocket data.
 - Live envelopes preserve provider source, feed, provider event time, ingestion time, and updated-bar corrections.
@@ -128,25 +127,25 @@ supported limit-order semantics; this milestone submits no orders. The external 
 [24/5 feed specification](https://docs.alpaca.markets/us/docs/245-trading-for-trading-api), and
 [extended-hours order rules](https://docs.alpaca.markets/us/docs/orders-at-alpaca).
 
-## Rollout and proof
+## Current integration and remaining proof
 
-1. Merge the versioned ConfigMap, additive schema, websocket wiring, and dormant CronJob and backfill templates.
-   Neither writer is rendered, so this phase cannot write Signal data or leave Argo waiting on a suspended CronJob.
-2. Promote immutable websocket and publisher images. Promotion pins source revisions and digests but leaves both Signal
-   writers inert.
-3. Through a reviewed GitOps change, add and start only the one-shot backfill Job while the CronJob remains absent.
-   Require it to finalize exactly one SIP/all snapshot for all nine symbols from 2022-01-27 through
-   2026-07-20: 1,122 sessions and 10,098 bars.
-4. Reproduce the manifest, session, and bar hashes from both ClickHouse replicas and prove one manifest row whose
-   universe ID and symbol hash match the ConfigMap.
-5. Confirm websocket readiness reports the same universe ID, hash, and exact symbols, and that Alpaca acknowledged all
-   nine symbols on trades, quotes, bars, and updated bars.
-6. Remove the completed one-shot Job and enable the daily CronJob in one GitOps change. Never render both writers as
-   active. Retain two successful scheduled publications before declaring the publication lane stable.
+- The versioned ConfigMap supplies the exact universe to the websocket, archive pipeline, and Signal publisher.
+- GitOps renders the scheduled Signal publisher with delayed SIP history and the V2 finalization contract.
+- Bayn's compiled strategy, market-data reader, qualification lock, and tests all bind the same universe ID and symbol
+  hash.
+- Bayn GitOps selects finalized snapshot
+  `98f9b0cdee311b248d4ed36104fa46ff86c34d587d6e71a6706a9d778c110292` through 2026-07-20.
+- The Bayn Deployment is intentionally at zero replicas while the separate database workstream performs its
+  reset/restore. This document does not authorize changing that state.
 
-Rollback is fail-closed: suspend the active writer, preserve every finalized or partially staged row, and revert only
-after no Job is active. Bayn remains pinned to its existing rejected TSMOM evidence; this data rollout neither deploys
-a new strategy nor grants broker or capital authority.
+After that workstream restores one writer, live acceptance must prove the promoted image digest, the exact snapshot and
+universe binding, one ready endpoint, an observable terminal qualification, all continuous dependencies available, and
+fixed observe-only authority. Until then, Git and prior publication evidence prove integration but not current Bayn
+runtime behavior.
+
+Rollback remains fail-closed: stop the active Signal writer through GitOps, preserve finalized and partially staged
+publications, and revert only after no publication Job is active. A rollback does not grant broker or capital
+authority.
 
 ## Read-only ClickHouse proof
 

--- a/docs/bayn/contracts/v1.md
+++ b/docs/bayn/contracts/v1.md
@@ -1,120 +1,106 @@
-# Bayn v1 contracts
+# Bayn evaluation contracts
 
-These contracts are the shared boundary for Bayn evaluation evidence. The executable definitions live in
-`services/bayn/src/contracts.ts`; this document defines their meaning. Adding a field or enum value requires a new
-schema version. Decoders reject excess fields, unknown versions, malformed values, and cross-field invariant failures.
+This is the stable documentation path for Bayn's current versioned evaluation contracts. The executable definitions
+live in `services/bayn/src/contracts.ts`; individual schemas carry their own versions. Decoders reject excess fields,
+unknown versions, malformed values, and cross-field invariant failures.
 
-This contract slice changes no deployed authority. Bayn remains observe-only and has no broker client or credential.
+These contracts do not grant deployment authority. Bayn remains observe-only and contains no broker client or
+credential.
 
 ## Canonical representation
 
 All hashes use canonical JSON with recursively sorted UTF-16 object keys. The encoder accepts only plain JSON values,
-normalizes negative zero, and rejects non-finite numbers, sparse arrays, cycles, accessors, non-enumerable state, symbols,
-`undefined`, `bigint`, class instances, and invalid Unicode surrogates. Digests are lowercase SHA-256 values.
+normalizes negative zero, and rejects non-finite numbers, sparse arrays, cycles, accessors, non-enumerable state,
+symbols, `undefined`, `bigint`, class instances, and invalid Unicode surrogates. Digests are lowercase SHA-256
+values.
 
 Dates use `YYYY-MM-DD`. Instants use the canonical UTC form `YYYY-MM-DDTHH:mm:ss.sssZ`; implicit time zones and
-normalized invalid dates are not accepted.
+normalized invalid dates are rejected.
 
-## `bayn.finalized-snapshot.v2`
+## `bayn.finalized-snapshot.v3`
 
-A finalized snapshot identifies one immutable Signal publication. It binds the publisher manifest and publication
-schema versions, source/feed/adjustment contract, exchange-calendar version, publisher source and image identity,
-finalization instant, requested and covered sessions, canonical sorted symbol universe, bar and session counts, and both
-ordered content hashes. V2 replaces the unused preparatory V1 shape: it removes a `publishedAt` value that Signal never
-records and adds the provenance needed to reproduce the actual publication.
+A finalized snapshot identifies one immutable Signal publication. It binds:
 
-Required invariants:
+- the publisher manifest and publication schema versions;
+- universe ID, canonical symbol list, and symbol hash;
+- source, feed, adjustment, and exchange-calendar version;
+- publisher source revision and immutable image identity;
+- requested and covered sessions;
+- finalization instant, row count, and session count; and
+- ordered bar and exchange-session content hashes.
 
-- `firstSession <= lastSession` and `asOfSession == lastSession`;
+Required invariants include:
+
+- `requestedStart <= firstSession <= lastSession` and `asOfSession == lastSession`;
 - symbols are non-empty, unique, uppercase, and sorted;
-- `rowCount == sessionCount * symbols.length`;
-- snapshot, manifest, bar-content, and session-content identities are full SHA-256 hashes.
+- `rowCount == sessionCount * symbols.length`; and
+- the universe symbol hash equals SHA-256 of the comma-joined canonical symbols.
+
+V2 is a rejected legacy Bayn envelope. V3 adds the universe binding required by the compiled
+`equity-infrastructure-v1` strategy.
 
 ## `bayn.evaluation-bounds.v1`
 
-The bounds distinguish loaded data from the lookback and scored evaluation windows:
+Bounds distinguish loaded data from the lookback and scored evaluation windows:
 
 `dataStart <= lookbackStart <= evaluationStart <= evaluationEnd <= dataEnd`
 
-The finalized snapshot must cover `dataStart` through `dataEnd`. Bounds are part of run identity; changing any boundary
-creates a different run.
+The finalized snapshot must cover `dataStart` through `dataEnd`. Every bound participates in run identity.
 
 ## `bayn.run-identity.v1`
 
 The run ID is SHA-256 over the canonical object containing:
 
-- full Git source revision;
+- source revision;
 - OCI repository and immutable image digest;
 - compiled strategy name and behavior hash;
-- the complete already-decoded strategy parameter value;
+- the complete decoded strategy parameters;
 - complete finalized-snapshot provenance;
 - exchange-calendar version; and
 - explicit evaluation bounds.
 
-The top-level calendar version must match the snapshot. A persisted identity is accepted only when recomputing its hash
-produces the stored run ID. Equivalent object insertion order produces the same identity; changing any bound component
-produces a different identity.
+The top-level calendar must match the snapshot. The data bounds must stay inside the finalized snapshot. A decoded
+identity is valid only when recomputing the canonical hash produces its stored run ID.
 
-## `bayn.runtime-provenance.v1`
+## `bayn.runtime-provenance.v2`
 
-Runtime provenance is the deploy identity available before finalized snapshots and explicit evaluation bounds are
-adopted. It contains:
+Runtime provenance is the deploy identity available before a specific snapshot and bounds are combined into the run
+identity. It contains:
 
-- the full source revision embedded in the executable;
-- the configured OCI repository and immutable index digest;
-- the selected compiled strategy name and source-derived behavior hash;
-- the canonical hash and schema version of the already-decoded strategy parameters; and
-- the runtime-provenance, input-manifest, and evaluation contract versions.
+- source revision and immutable image identity;
+- strategy name, behavior hash, parameter hash, and parameter-schema version; and
+- the current runtime-provenance, input-manifest, and evaluation contract versions.
 
-The build also carries the source revision and behavior hash as OCI labels. Startup rejects a malformed embedded value,
-a configured source revision that differs from the executable, or a configured repository that differs from the
-executable. The digest is necessarily supplied after the image index is published; the release writer copies the exact
-published digest into GitOps, and rollout evidence compares the status value with the pod image reference.
+Production executables embed source revision, repository, behavior hash, and parameter hash. Startup rejects malformed
+embedded values and any configured source, repository, behavior, or parameter mismatch. The release writer supplies
+the image-index digest after publication, and status reports whether verification is `embedded` or
+`development-configured`.
 
-The standard package `dev` and `start` entry points opt into `development-configured` provenance because they do not
-produce the Nix OCI artifact. In that mode source and repository attribution come from validated Effect Config, the
-behavior hash is an explicit unverified marker, and startup evaluation and journaling are forced off. HTTP status
-reports `provenanceVerification: development-configured` outside this versioned envelope. Production is the default:
-missing or partial embedded facts fail closed, and development mode is rejected when embedded production facts exist.
+The package `dev` and `start` entry points select `development-configured` because their artifacts lack production
+build metadata. Configured provenance is still schema-validated. The mode does not disable evaluation, journaling,
+health checks, or fail-closed behavior, and it cannot override embedded production metadata.
 
-Runtime provenance alone is not the full `bayn.run-identity.v1` contract. Evaluation combines it with the decoded
-strategy parameters, verified finalized snapshot, calendar version, and explicit bounds before deriving the run ID.
+Runtime provenance is not a run identity. Evaluation combines it with the decoded protocol, verified finalized
+snapshot, calendar, and explicit bounds before deriving the run ID.
 
-## `bayn.evidence-freshness.v1`
+## Runtime status view
 
-Freshness contains `observedAt` and `validThrough`, with `observedAt <= validThrough`. Classification receives an
-explicit clock value:
+Runtime status is an operational HTTP view, not a persisted versioned evidence contract. Its source is
+`services/bayn/src/runtime-state.ts` and `services/bayn/src/http.ts`.
 
-- before `observedAt`: `INVALID`;
-- through `validThrough`: `CURRENT`;
-- after `validThrough`: `STALE`.
+- Operational states are `STARTING`, `READY`, `DEGRADED`, and `FAILED`.
+- Dependency states are `UNKNOWN`, `AVAILABLE`, and `UNAVAILABLE`.
+- Readiness requires an active evidence envelope and every dependency to be `AVAILABLE`.
+- Data and evidence project to `UNKNOWN`, `CURRENT`, or `INVALID`.
+- Economic and qualification status come from the terminal qualification evidence.
+- Accounting is `UNKNOWN`, `EXACT`, or `UNAVAILABLE`.
+- Authority is fixed at maximum `observe`; broker orders and capital promotion are always false.
 
-No domain contract reads ambient wall-clock time.
+The removed freshness, kill-state, paper, and live-bounded axes are not current Bayn contracts and must not be
+reintroduced in documentation without corresponding executable schemas and behavior.
 
-## `bayn.status.v1`
+## Verification
 
-Status keeps independent facts independent:
-
-| Axis                  | Values                                      |
-| --------------------- | ------------------------------------------- |
-| operational           | `STARTING`, `RUNNING`, `STOPPING`, `FAILED` |
-| dependency            | `UNKNOWN`, `AVAILABLE`, `UNAVAILABLE`       |
-| data                  | `UNKNOWN`, `FRESH`, `STALE`, `INVALID`      |
-| evidence              | `UNKNOWN`, `CURRENT`, `STALE`, `INVALID`    |
-| economic              | `UNKNOWN`, `QUALIFIED`, `REJECTED`          |
-| reconciliation        | `UNKNOWN`, `EXACT`, `DISCREPANCY`           |
-| kill                  | `UNKNOWN`, `CLEAR`, `ENGAGED`               |
-| maximum authority     | `observe`, `paper`, `live-bounded`          |
-| exercisable authority | `none`, `observe`, `paper`, `live-bounded`  |
-
-Exercisable authority is derived, never trusted. Observation requires a running service, available dependencies, fresh
-data, current evidence, exact reconciliation, and a clear kill state. Any unknown, stale, invalid, unavailable,
-discrepant, failed, or engaged required fact yields `none`. Paper or bounded-live authority additionally requires
-`QUALIFIED`; otherwise the highest possible authority is `observe`. Exercisable authority can never exceed the GitOps
-maximum.
-
-## Verification fixtures
-
-Contract tests cover valid decode, invalid calendar dates, duplicate and non-canonical symbols, invalid bounds, stale
-and future evidence, provenance/calendar mismatch, authority escalation, stored-hash mismatch, unknown versions, excess
-fields, canonical insertion-order stability, and mutation of every run-identity component.
+`services/bayn/src/contracts.test.ts` verifies current snapshot and bounds decoding, rejection of legacy versions and
+unknown fields, date and universe invariants, deterministic identity hashing, mutation sensitivity, stored-hash
+verification, and rejection of non-current runtime provenance.


### PR DESCRIPTION
## Summary

- Replace stale TSMOM, single-replica ledger, and development-mode claims with the current risk-balanced-trend runtime.
- Document the intended Effect v4 boundary: pure strategy values, I/O services, one composition root, and scoped runtime resources.
- Align the authoritative universe and executable-contract docs with the current V2 publication, V3 snapshot, V2 provenance, health, and authority behavior.
- Record the current zero-replica live-proof boundary without changing database code, SQL, migrations, persisted schemas, PostgreSQL manifests, or database integration tests.

## Related Issues

None

## Testing

- `bun run --filter @proompteng/bayn test` (116 passed, 23 database integration tests untouched and skipped without a test database)
- `bun run --filter @proompteng/bayn tsc`
- `bunx oxfmt --check docs/bayn/architecture.md docs/bayn/authoritative-universe.md docs/bayn/contracts/v1.md`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (screenshots not applicable).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
