### PR TITLE
refactor(bayn): enforce Effect boundaries

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -56,8 +56,6 @@ spec:
               value: "43cece33d3db232ffb02ba78826727e50b5795319d09d27e1baa0c04709eb056"
             - name: BAYN_STRATEGY_PARAMETER_HASH
               value: "cf639d3692da65271b12423f9b7c6c9663e1fb13ae7290dc56fcfa3acf16eb69"
-            - name: BAYN_QUALIFICATION_RUN_ID
-              value: "082669c8d9547911e39b7e3a8a6399978894114a5eacc9fc113b0c7b99b6bd88"
             - name: BAYN_HEALTH_INTERVAL_MS
               value: "30000"
             - name: BAYN_OPERATION_TIMEOUT_MS

--- a/bun.lock
+++ b/bun.lock
@@ -718,10 +718,10 @@
       "version": "0.1.0",
       "dependencies": {
         "@clickhouse/client": "1.23.1",
-        "@effect/platform-node": "4.0.0-beta.99",
-        "@effect/sql-clickhouse": "4.0.0-beta.99",
-        "@effect/sql-pg": "4.0.0-beta.99",
-        "effect": "4.0.0-beta.99",
+        "@effect/platform-node": "4.0.0-beta.100",
+        "@effect/sql-clickhouse": "4.0.0-beta.100",
+        "@effect/sql-pg": "4.0.0-beta.100",
+        "effect": "4.0.0-beta.100",
         "tigerbeetle-node": "0.17.9",
       },
       "devDependencies": {
@@ -1030,6 +1030,7 @@
   },
   "patchedDependencies": {
     "@effect/sql-clickhouse@4.0.0-beta.99": "patches/@effect%2Fsql-clickhouse@4.0.0-beta.99.patch",
+    "@effect/sql-clickhouse@4.0.0-beta.100": "patches/@effect%2Fsql-clickhouse@4.0.0-beta.100.patch",
   },
   "packages": {
     "@a2a-js/sdk": ["@a2a-js/sdk@0.3.13", "", { "dependencies": { "uuid": "^11.1.0" }, "peerDependencies": { "@bufbuild/protobuf": "^2.10.2", "@grpc/grpc-js": "^1.11.0", "express": "^4.21.2 || ^5.1.0" }, "optionalPeers": ["@bufbuild/protobuf", "@grpc/grpc-js", "express"] }, "sha512-BZr0f9JVNQs3GKOM9xINWCh6OKIJWZFPyqqVqTym5mxO2Eemc6I/0zL7zWnljHzGdaf5aZQyQN5xa6PSH62q+A=="],
@@ -1404,9 +1405,9 @@
 
     "@effect/sql": ["@effect/sql@0.51.1", "", { "dependencies": { "uuid": "^11.0.3" }, "peerDependencies": { "@effect/experimental": "^0.60.0", "@effect/platform": "^0.96.1", "effect": "^3.21.2" } }, "sha512-iPDAefrJcI0HcTk9keP9Gq8Pg08K1HmpnmZZt85AqyTcvorhoNsXDFiKBbPldfV2CortwVkacX8KjO9GPpSYCA=="],
 
-    "@effect/sql-clickhouse": ["@effect/sql-clickhouse@4.0.0-beta.99", "", { "dependencies": { "@clickhouse/client": "^1.23.1" }, "peerDependencies": { "@effect/platform-node": "^4.0.0-beta.99", "effect": "^4.0.0-beta.99" } }, "sha512-krsAI8L5ORdR/g4CXYTaGdKwekvdHXfXrJfrJbv9HRDFvAu9Q8DYVqk2Wl232sbfANm0Xqz3seeeYDn1OKWonQ=="],
+    "@effect/sql-clickhouse": ["@effect/sql-clickhouse@4.0.0-beta.100", "", { "dependencies": { "@clickhouse/client": "^1.23.1" }, "peerDependencies": { "@effect/platform-node": "^4.0.0-beta.100", "effect": "^4.0.0-beta.100" } }, "sha512-Ezypiv/jySrTHQ4GReAikQHwnHP1NB1Ae/uV/FyVHVfsOJSrdSzzN9rzOvihuga+OnyJUmNfWuPhhNrenWLqIw=="],
 
-    "@effect/sql-pg": ["@effect/sql-pg@4.0.0-beta.99", "", { "dependencies": { "pg": "^8.22.0", "pg-connection-string": "2.14.0", "pg-cursor": "^2.21.0", "pg-pool": "^3.14.0", "pg-types": "^4.1.0" }, "peerDependencies": { "effect": "^4.0.0-beta.99" } }, "sha512-ZZCKdArioVX29YcH+0HjiYeZiTAEnngU8ao3cBGZXrUOZwcvzknGWNOS7aGzES7hSK/HDBKPu2t14LGgtSgsCA=="],
+    "@effect/sql-pg": ["@effect/sql-pg@4.0.0-beta.100", "", { "dependencies": { "pg": "^8.22.0", "pg-connection-string": "2.14.0", "pg-cursor": "^2.21.0", "pg-pool": "^3.14.0", "pg-types": "^4.1.0" }, "peerDependencies": { "effect": "^4.0.0-beta.100" } }, "sha512-KU8P7FMeYw/0bbTrqpRIvmRaUetY/r5JAkX8ydsxtryBJu4JL7v8lm6ijOtoDHHS9kdcNGYGpiZZnn5AaQQJMQ=="],
 
     "@effect/typeclass": ["@effect/typeclass@0.38.0", "", { "peerDependencies": { "effect": "^3.19.0" } }, "sha512-lMUcJTRtG8KXhXoczapZDxbLK5os7M6rn0zkvOgncJW++A0UyelZfMVMKdT5R+fgpZcsAU/1diaqw3uqLJwGxA=="],
 
@@ -3498,7 +3499,7 @@
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
-    "crossws": ["crossws@0.4.5", "", { "peerDependencies": { "srvx": ">=0.11.5" }, "optionalPeers": ["srvx"] }, "sha512-wUR89x/Rw7/8t+vn0CmGDYM9TD6VtARGb0LD5jq2wjtMy1vCP4M+sm6N6TigWeTYvnA8MoW29NqqXD0ep0rfBA=="],
+    "crossws": ["crossws@0.4.10", "", { "peerDependencies": { "srvx": ">=0.11.5" }, "optionalPeers": ["srvx"] }, "sha512-pz3oubH/dt12KjqsUB0IuXW4nwRDQ583iDsP4555Cpdqx0NoU7pGlWBcayyFI8f/l/idRpgjMEfwuOxSWJYlIA=="],
 
     "crypt": ["crypt@0.0.2", "", {}, "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow=="],
 
@@ -5762,7 +5763,7 @@
 
     "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
-    "yaml": ["yaml@2.8.4", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog=="],
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "yaml-ast-parser": ["yaml-ast-parser@0.0.43", "", {}, "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A=="],
 
@@ -5940,8 +5941,6 @@
 
     "@dotenvx/dotenvx/which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
 
-    "@earendil-works/pi-agent-core/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
-
     "@earendil-works/pi-ai/@smithy/node-http-handler": ["@smithy/node-http-handler@4.7.3", "", { "dependencies": { "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA=="],
 
     "@earendil-works/pi-coding-agent/diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
@@ -5952,9 +5951,9 @@
 
     "@earendil-works/pi-coding-agent/undici": ["undici@8.3.0", "", {}, "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q=="],
 
-    "@earendil-works/pi-coding-agent/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
-
     "@ecies/ciphers/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
+
+    "@effect/cli/yaml": ["yaml@2.8.4", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog=="],
 
     "@effect/experimental/@effect/platform": ["@effect/platform@0.94.2", "", { "dependencies": { "find-my-way-ts": "^0.1.6", "msgpackr": "^1.11.4", "multipasta": "^0.2.7" }, "peerDependencies": { "effect": "^3.19.15" } }, "sha512-85vdwpnK4oH/rJ3EuX/Gi2Hkt+K4HvXWr9bxCuqvty9hxyEcRxkJcqTesYrcVoQB6aULb1Za2B0MKoTbvffB3Q=="],
 
@@ -5962,11 +5961,11 @@
 
     "@effect/platform-node-shared/ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
-    "@effect/sql-clickhouse/@effect/platform-node": ["@effect/platform-node@4.0.0-beta.99", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.99", "mime": "^4.1.0", "undici": "^8.7.0" }, "peerDependencies": { "effect": "^4.0.0-beta.99", "ioredis": "^5.7.0" } }, "sha512-jnK2KMW4W50AEOKK+Tgvab3YPHBxa3ApLQE8BCad+LH57JOziKzOjqtEpAgJgmao3t77x1UESK4JraaHJDHaYA=="],
+    "@effect/sql-clickhouse/@effect/platform-node": ["@effect/platform-node@4.0.0-beta.100", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.100", "mime": "^4.1.0", "undici": "^8.7.0" }, "peerDependencies": { "effect": "^4.0.0-beta.100", "ioredis": "^5.7.0" } }, "sha512-nH5xgxOLfPj5Bi0/o4OaDsR98Z59lHKGty+TDqckg7zRz6jry82hGW982NRPduzX0MJloDsGp/3rfeN4Hu7Keg=="],
 
-    "@effect/sql-clickhouse/effect": ["effect@4.0.0-beta.99", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-hP1C61uzINfLl/4kKMwcqksxd34s4sQ3VSjsWjhGrkx9CRlXaqnfOK9dpTEKynQ6rA7wU9rb3c+48eDYw7uzxA=="],
+    "@effect/sql-clickhouse/effect": ["effect@4.0.0-beta.100", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-K4ed+BS3HyE+NoAZ8pJss2DpuK41mb856IO7ZlPfnwBXbq8oTtAAurrsVnwe2hzPamIuaZp/Pq4/xp9qORYv8Q=="],
 
-    "@effect/sql-pg/effect": ["effect@4.0.0-beta.99", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-hP1C61uzINfLl/4kKMwcqksxd34s4sQ3VSjsWjhGrkx9CRlXaqnfOK9dpTEKynQ6rA7wU9rb3c+48eDYw7uzxA=="],
+    "@effect/sql-pg/effect": ["effect@4.0.0-beta.100", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-K4ed+BS3HyE+NoAZ8pJss2DpuK41mb856IO7ZlPfnwBXbq8oTtAAurrsVnwe2hzPamIuaZp/Pq4/xp9qORYv8Q=="],
 
     "@effect/sql-pg/pg": ["pg@8.22.0", "", { "dependencies": { "pg-connection-string": "^2.14.0", "pg-pool": "^3.14.0", "pg-protocol": "^1.15.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.4.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA=="],
 
@@ -6236,13 +6235,9 @@
 
     "@proompteng/agents/nitro": ["nitro@3.0.260522-beta", "", { "dependencies": { "consola": "^3.4.2", "crossws": "^0.4.5", "db0": "^0.3.4", "env-runner": "^0.1.9", "h3": "^2.0.1-rc.22", "hookable": "^6.1.1", "nf3": "^0.3.17", "ocache": "^0.1.4", "ofetch": "^2.0.0-alpha.3", "ohash": "^2.0.11", "rolldown": "^1.0.2", "srvx": "^0.11.15", "unenv": "^2.0.0-rc.24", "unstorage": "^2.0.0-alpha.7" }, "peerDependencies": { "@vercel/queue": "^0.2.0", "dotenv": "*", "giget": "*", "jiti": "^2.6.1", "rollup": "^4.60.3", "vite": "^7 || ^8", "xml2js": "^0.6.2", "zephyr-agent": "^0.2.0" }, "optionalPeers": ["@vercel/queue", "dotenv", "giget", "jiti", "rollup", "vite", "xml2js", "zephyr-agent"], "bin": { "nitro": "dist/cli/index.mjs" } }, "sha512-L/z2eOWgkiQHc65kv+SEMgau505afSRF7NJlbooaaZEZscFrNSD7rXZzeVubQlgIzPbhOG8o73bk9soIiGTHRA=="],
 
-    "@proompteng/agents/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+    "@proompteng/bayn/@effect/platform-node": ["@effect/platform-node@4.0.0-beta.100", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.100", "mime": "^4.1.0", "undici": "^8.7.0" }, "peerDependencies": { "effect": "^4.0.0-beta.100", "ioredis": "^5.7.0" } }, "sha512-nH5xgxOLfPj5Bi0/o4OaDsR98Z59lHKGty+TDqckg7zRz6jry82hGW982NRPduzX0MJloDsGp/3rfeN4Hu7Keg=="],
 
-    "@proompteng/bayn/@effect/platform-node": ["@effect/platform-node@4.0.0-beta.99", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.99", "mime": "^4.1.0", "undici": "^8.7.0" }, "peerDependencies": { "effect": "^4.0.0-beta.99", "ioredis": "^5.7.0" } }, "sha512-jnK2KMW4W50AEOKK+Tgvab3YPHBxa3ApLQE8BCad+LH57JOziKzOjqtEpAgJgmao3t77x1UESK4JraaHJDHaYA=="],
-
-    "@proompteng/bayn/effect": ["effect@4.0.0-beta.99", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-hP1C61uzINfLl/4kKMwcqksxd34s4sQ3VSjsWjhGrkx9CRlXaqnfOK9dpTEKynQ6rA7wU9rb3c+48eDYw7uzxA=="],
-
-    "@proompteng/bumba/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+    "@proompteng/bayn/effect": ["effect@4.0.0-beta.100", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-K4ed+BS3HyE+NoAZ8pJss2DpuK41mb856IO7ZlPfnwBXbq8oTtAAurrsVnwe2hzPamIuaZp/Pq4/xp9qORYv8Q=="],
 
     "@proompteng/design/react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
@@ -6253,8 +6248,6 @@
     "@proompteng/jangar/@tailwindcss/vite": ["@tailwindcss/vite@4.2.4", "", { "dependencies": { "@tailwindcss/node": "4.2.4", "@tailwindcss/oxide": "4.2.4", "tailwindcss": "4.2.4" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw=="],
 
     "@proompteng/jangar/@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.1", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-rc.7" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ=="],
-
-    "@proompteng/jangar/crossws": ["crossws@0.4.10", "", { "peerDependencies": { "srvx": ">=0.11.5" }, "optionalPeers": ["srvx"] }, "sha512-pz3oubH/dt12KjqsUB0IuXW4nwRDQ583iDsP4555Cpdqx0NoU7pGlWBcayyFI8f/l/idRpgjMEfwuOxSWJYlIA=="],
 
     "@proompteng/jangar/tailwind-merge": ["tailwind-merge@3.5.0", "", {}, "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A=="],
 
@@ -6270,13 +6263,11 @@
 
     "@proompteng/sag/recharts": ["recharts@3.8.0", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ=="],
 
-    "@proompteng/scripts/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
-
     "@proompteng/signal-publisher/@effect/platform-node": ["@effect/platform-node@4.0.0-beta.99", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.99", "mime": "^4.1.0", "undici": "^8.7.0" }, "peerDependencies": { "effect": "^4.0.0-beta.99", "ioredis": "^5.7.0" } }, "sha512-jnK2KMW4W50AEOKK+Tgvab3YPHBxa3ApLQE8BCad+LH57JOziKzOjqtEpAgJgmao3t77x1UESK4JraaHJDHaYA=="],
 
-    "@proompteng/signal-publisher/effect": ["effect@4.0.0-beta.99", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-hP1C61uzINfLl/4kKMwcqksxd34s4sQ3VSjsWjhGrkx9CRlXaqnfOK9dpTEKynQ6rA7wU9rb3c+48eDYw7uzxA=="],
+    "@proompteng/signal-publisher/@effect/sql-clickhouse": ["@effect/sql-clickhouse@4.0.0-beta.99", "", { "dependencies": { "@clickhouse/client": "^1.23.1" }, "peerDependencies": { "@effect/platform-node": "^4.0.0-beta.99", "effect": "^4.0.0-beta.99" } }, "sha512-krsAI8L5ORdR/g4CXYTaGdKwekvdHXfXrJfrJbv9HRDFvAu9Q8DYVqk2Wl232sbfANm0Xqz3seeeYDn1OKWonQ=="],
 
-    "@proompteng/symphony/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+    "@proompteng/signal-publisher/effect": ["effect@4.0.0-beta.99", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-hP1C61uzINfLl/4kKMwcqksxd34s4sQ3VSjsWjhGrkx9CRlXaqnfOK9dpTEKynQ6rA7wU9rb3c+48eDYw7uzxA=="],
 
     "@radix-ui/react-alert-dialog/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
@@ -6446,7 +6437,9 @@
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
-    "app/nitro": ["nitro-nightly@3.0.1-20260711-223101-ff018c15", "", { "dependencies": { "consola": "^3.4.2", "crossws": "^0.4.9", "db0": "^0.3.4", "env-runner": "^0.1.16", "h3": "^2.0.1-rc.25", "h3-rules": "^0.1.0", "hookable": "^6.1.1", "nf3": "^0.3.22", "ocache": "^0.2.0", "ofetch": "^2.0.0-alpha.3", "ohash": "^2.0.11", "rolldown": "^1.1.5", "rou3": "^0.9.1", "srvx": "^0.11.22", "unenv": "^2.0.0-rc.24", "unstorage": "^2.0.0-alpha.7" }, "peerDependencies": { "@vercel/queue": "^0.4.0", "dotenv": "*", "giget": "*", "jiti": "^2.7.0", "rollup": "^4.62.0", "vite": "^7 || ^8", "xml2js": "^0.6.2", "zephyr-agent": "^1.1.2" }, "optionalPeers": ["@vercel/queue", "dotenv", "giget", "jiti", "rollup", "vite", "xml2js", "zephyr-agent"], "bin": { "nitro": "dist/cli/index.mjs" } }, "sha512-wiEGu7C2Z3rvQ3Xqj1b6jVt28rvgDtVeFCrfYd0MSWa0l0D5U/AqMwV2AUKF4cqtVcp8w/dbsjRadYvHJzyOUQ=="],
+    "app/nitro": ["nitro-nightly@3.0.1-20260721-095825-c1ff6ba6", "", { "dependencies": { "consola": "^3.4.2", "crossws": "^0.4.10", "db0": "^0.3.4", "env-runner": "^0.1.16", "h3": "^2.0.1-rc.25", "h3-rules": "^0.1.0", "hookable": "^6.1.1", "nf3": "^0.3.22", "ocache": "^0.2.0", "ofetch": "^2.0.0-alpha.3", "ohash": "^2.0.11", "rolldown": "^1.2.0", "rou3": "^0.9.1", "srvx": "^0.11.22", "unenv": "^2.0.0-rc.24", "unstorage": "^2.0.0-alpha.7" }, "peerDependencies": { "@vercel/queue": "^0.4.0", "dotenv": "*", "giget": "*", "jiti": "^2.7.0", "rollup": "^4.62.2", "vite": "^7 || ^8", "xml2js": "^0.6.2", "zephyr-agent": "^1.1.2" }, "optionalPeers": ["@vercel/queue", "dotenv", "giget", "jiti", "rollup", "vite", "xml2js", "zephyr-agent"], "bin": { "nitro": "dist/cli/index.mjs" } }, "sha512-/zs7m2lfMlrt45B0cqbemv04cLsbc2cEwd6SsdU2zQ2NDww58BxqT87D1EWu8w08RxOqqBR7T1hb0m5I3fz0JA=="],
+
+    "app/pg": ["pg@8.22.0", "", { "dependencies": { "pg-connection-string": "^2.14.0", "pg-pool": "^3.14.0", "pg-protocol": "^1.15.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.4.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA=="],
 
     "archiver/readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
 
@@ -6485,6 +6478,8 @@
     "boxen/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
     "cacheable-request/get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
+
+    "cdk8s/yaml": ["yaml@2.8.4", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog=="],
 
     "cdk8s-cli/@types/node": ["@types/node@16.18.126", "", {}, "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw=="],
 
@@ -6527,6 +6522,8 @@
     "clone-response/mimic-response": ["mimic-response@1.0.1", "", {}, "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="],
 
     "cmdk/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.4", "", { "dependencies": { "@radix-ui/react-slot": "1.2.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg=="],
+
+    "cms/pg": ["pg@8.22.0", "", { "dependencies": { "pg-connection-string": "^2.14.0", "pg-pool": "^3.14.0", "pg-protocol": "^1.15.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.4.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA=="],
 
     "cms/react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
@@ -6586,6 +6583,8 @@
 
     "encoding-sniffer/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
+    "env-runner/crossws": ["crossws@0.4.5", "", { "peerDependencies": { "srvx": ">=0.11.5" }, "optionalPeers": ["srvx"] }, "sha512-wUR89x/Rw7/8t+vn0CmGDYM9TD6VtARGb0LD5jq2wjtMy1vCP4M+sm6N6TigWeTYvnA8MoW29NqqXD0ep0rfBA=="],
+
     "esast-util-from-js/acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
     "estree-util-to-js/source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
@@ -6601,8 +6600,6 @@
     "find-workspaces/yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
     "font-ligatures/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
-
-    "froussard/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "fumadocs-core/next": ["next@16.2.4", "", { "dependencies": { "@next/env": "16.2.4", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.4", "@next/swc-darwin-x64": "16.2.4", "@next/swc-linux-arm64-gnu": "16.2.4", "@next/swc-linux-arm64-musl": "16.2.4", "@next/swc-linux-x64-gnu": "16.2.4", "@next/swc-linux-x64-musl": "16.2.4", "@next/swc-win32-arm64-msvc": "16.2.4", "@next/swc-win32-x64-msvc": "16.2.4", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q=="],
 
@@ -6818,6 +6815,8 @@
 
     "next/postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
 
+    "nitro/crossws": ["crossws@0.4.5", "", { "peerDependencies": { "srvx": ">=0.11.5" }, "optionalPeers": ["srvx"] }, "sha512-wUR89x/Rw7/8t+vn0CmGDYM9TD6VtARGb0LD5jq2wjtMy1vCP4M+sm6N6TigWeTYvnA8MoW29NqqXD0ep0rfBA=="],
+
     "nitro/h3": ["h3@2.0.1-rc.20", "", { "dependencies": { "rou3": "^0.8.1", "srvx": "^0.11.13" }, "peerDependencies": { "crossws": "^0.4.1" }, "optionalPeers": ["crossws"], "bin": { "h3": "bin/h3.mjs" } }, "sha512-28ljodXuUp0fZovdiSRq4G9OgrxCztrJe5VdYzXAB7ueRvI7pIUqLU14Xi3XqdYJ/khXjfpUOOD2EQa6CmBgsg=="],
 
     "node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
@@ -6997,6 +6996,8 @@
     "strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "synthesis/nitro": ["nitro@3.0.260610-beta", "", { "dependencies": { "consola": "^3.4.2", "crossws": "^0.4.6", "db0": "^0.3.4", "env-runner": "^0.1.12", "h3": "2.0.1-rc.22", "hookable": "^6.1.1", "nf3": "^0.3.17", "ocache": "^0.1.5", "ofetch": "2.0.0-alpha.3", "ohash": "^2.0.11", "rolldown": "^1.1.0", "srvx": "^0.11.16", "unenv": "2.0.0-rc.24", "unstorage": "2.0.0-alpha.7" }, "peerDependencies": { "@vercel/queue": "^0.3.0", "dotenv": "*", "giget": "*", "jiti": "^2.7.0", "rollup": "^4.61.1", "vite": "^7 || ^8", "xml2js": "^0.6.2", "zephyr-agent": "^0.2.0" }, "optionalPeers": ["@vercel/queue", "dotenv", "giget", "jiti", "rollup", "vite", "xml2js", "zephyr-agent"], "bin": { "nitro": "dist/cli/index.mjs" } }, "sha512-KPb4L5yaF/Rx/xoGMpgHRJvZhbhGiqbRKOwwPLCH9jKTKTsEUHLjnJas85AeCzaswqa8Wi52eQBtRsODC4PS0Q=="],
+
+    "synthesis/pg": ["pg@8.22.0", "", { "dependencies": { "pg-connection-string": "^2.14.0", "pg-pool": "^3.14.0", "pg-protocol": "^1.15.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.4.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA=="],
 
     "synthesis/react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
@@ -7178,7 +7179,7 @@
 
     "@effect/experimental/@effect/platform/msgpackr": ["msgpackr@1.11.8", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.2" } }, "sha512-bC4UGzHhVvgDNS7kn9tV8fAucIYUBuGojcaLiz7v+P63Lmtm0Xeji8B/8tYKddALXxJLpwIeBmUN3u64C4YkRA=="],
 
-    "@effect/sql-clickhouse/@effect/platform-node/@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.99", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.0" }, "peerDependencies": { "effect": "^4.0.0-beta.99" } }, "sha512-POBAowafsAAb3bH1x1rJlWnv32yMAazFgEuRW5LhkW/JJA5VGoEk9OnuoUkIH1OW6K/X6IrdNpqcO+5e9lPQJA=="],
+    "@effect/sql-clickhouse/@effect/platform-node/@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.100", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.0" }, "peerDependencies": { "effect": "^4.0.0-beta.100" } }, "sha512-PMsCXQeK2wnlmnqGCc79oqK9CX8ipZvoHxAy/CRojMF+zHIluxh61L3pzWAYEbMb19Be4Bxgqs7gK2hiV8H8Pg=="],
 
     "@effect/sql-clickhouse/@effect/platform-node/mime": ["mime@4.1.0", "", { "bin": { "mime": "bin/cli.js" } }, "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw=="],
 
@@ -7196,8 +7197,6 @@
 
     "@effect/sql-clickhouse/effect/uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
 
-    "@effect/sql-clickhouse/effect/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
-
     "@effect/sql-pg/effect/fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
 
     "@effect/sql-pg/effect/ini": ["ini@7.0.0", "", {}, "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w=="],
@@ -7209,8 +7208,6 @@
     "@effect/sql-pg/effect/toml": ["toml@4.3.0", "", {}, "sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A=="],
 
     "@effect/sql-pg/effect/uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
-
-    "@effect/sql-pg/effect/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "@effect/sql-pg/pg/pg-cloudflare": ["pg-cloudflare@1.4.0", "", {}, "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A=="],
 
@@ -7502,13 +7499,15 @@
 
     "@payloadcms/ui/next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
+    "@proompteng/agents/nitro/crossws": ["crossws@0.4.5", "", { "peerDependencies": { "srvx": ">=0.11.5" }, "optionalPeers": ["srvx"] }, "sha512-wUR89x/Rw7/8t+vn0CmGDYM9TD6VtARGb0LD5jq2wjtMy1vCP4M+sm6N6TigWeTYvnA8MoW29NqqXD0ep0rfBA=="],
+
     "@proompteng/agents/nitro/env-runner": ["env-runner@0.1.9", "", { "dependencies": { "crossws": "^0.4.5", "exsolve": "^1.0.8", "httpxy": "^0.5.3", "srvx": "^0.11.15" }, "peerDependencies": { "@netlify/runtime": "^4.1.23", "@vercel/queue": "^0.2.0", "miniflare": "^4.20260515.0" }, "optionalPeers": ["@netlify/runtime", "@vercel/queue", "miniflare"], "bin": { "env-runner": "dist/cli.mjs" } }, "sha512-W9AiZlPx0uXtghAJiTBkeZOgyQdecVvoln3cHoOEZswPq0cVMi+WBhUQjdUn+JcZFAFgOt+i5fcO7C2zniZoCg=="],
 
     "@proompteng/agents/nitro/nf3": ["nf3@0.3.17", "", {}, "sha512-N9zEWySuJFw+gR0lhS5863YsvNeudOdqRyFvNb+jMXbeTJOdrjDqkCpDginIZfUm0LzT1t1nCRiDeqQm/8kirQ=="],
 
     "@proompteng/agents/nitro/rolldown": ["rolldown@1.0.2", "", { "dependencies": { "@oxc-project/types": "=0.132.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.2", "@rolldown/binding-darwin-arm64": "1.0.2", "@rolldown/binding-darwin-x64": "1.0.2", "@rolldown/binding-freebsd-x64": "1.0.2", "@rolldown/binding-linux-arm-gnueabihf": "1.0.2", "@rolldown/binding-linux-arm64-gnu": "1.0.2", "@rolldown/binding-linux-arm64-musl": "1.0.2", "@rolldown/binding-linux-ppc64-gnu": "1.0.2", "@rolldown/binding-linux-s390x-gnu": "1.0.2", "@rolldown/binding-linux-x64-gnu": "1.0.2", "@rolldown/binding-linux-x64-musl": "1.0.2", "@rolldown/binding-openharmony-arm64": "1.0.2", "@rolldown/binding-wasm32-wasi": "1.0.2", "@rolldown/binding-win32-arm64-msvc": "1.0.2", "@rolldown/binding-win32-x64-msvc": "1.0.2" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g=="],
 
-    "@proompteng/bayn/@effect/platform-node/@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.99", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.0" }, "peerDependencies": { "effect": "^4.0.0-beta.99" } }, "sha512-POBAowafsAAb3bH1x1rJlWnv32yMAazFgEuRW5LhkW/JJA5VGoEk9OnuoUkIH1OW6K/X6IrdNpqcO+5e9lPQJA=="],
+    "@proompteng/bayn/@effect/platform-node/@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.100", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.0" }, "peerDependencies": { "effect": "^4.0.0-beta.100" } }, "sha512-PMsCXQeK2wnlmnqGCc79oqK9CX8ipZvoHxAy/CRojMF+zHIluxh61L3pzWAYEbMb19Be4Bxgqs7gK2hiV8H8Pg=="],
 
     "@proompteng/bayn/@effect/platform-node/mime": ["mime@4.1.0", "", { "bin": { "mime": "bin/cli.js" } }, "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw=="],
 
@@ -7525,10 +7524,6 @@
     "@proompteng/bayn/effect/toml": ["toml@4.3.0", "", {}, "sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A=="],
 
     "@proompteng/bayn/effect/uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
-
-    "@proompteng/bayn/effect/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
-
-    "@proompteng/golink/nitro/crossws": ["crossws@0.4.10", "", { "peerDependencies": { "srvx": ">=0.11.5" }, "optionalPeers": ["srvx"] }, "sha512-pz3oubH/dt12KjqsUB0IuXW4nwRDQ583iDsP4555Cpdqx0NoU7pGlWBcayyFI8f/l/idRpgjMEfwuOxSWJYlIA=="],
 
     "@proompteng/golink/nitro/env-runner": ["env-runner@0.1.16", "", { "dependencies": { "crossws": "^0.4.8", "exsolve": "^1.1.0", "httpxy": "^0.5.4", "srvx": "^0.11.19" }, "peerDependencies": { "@netlify/runtime": "^4.1.23", "@vercel/queue": ">=0.2.0", "miniflare": "^4.20260515.0", "wrangler": "^4.0.0" }, "optionalPeers": ["@netlify/runtime", "@vercel/queue", "miniflare", "wrangler"], "bin": { "env-runner": "dist/cli.mjs" } }, "sha512-2LRJM4P2KLX6J83QZZrMqvgCDt/D5ea7wPcI3yYiy5cG/9rX5QwdwZFx0D7ktWnjdRyZxYjttGGorb5nFqb1CA=="],
 
@@ -7551,8 +7546,6 @@
     "@proompteng/jangar/vite/rolldown": ["rolldown@1.0.0-rc.17", "", { "dependencies": { "@oxc-project/types": "=0.127.0", "@rolldown/pluginutils": "1.0.0-rc.17" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-x64": "1.0.0-rc.17", "@rolldown/binding-freebsd-x64": "1.0.0-rc.17", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA=="],
 
     "@proompteng/jangar/vite/tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
-
-    "@proompteng/sag/nitro/crossws": ["crossws@0.4.10", "", { "peerDependencies": { "srvx": ">=0.11.5" }, "optionalPeers": ["srvx"] }, "sha512-pz3oubH/dt12KjqsUB0IuXW4nwRDQ583iDsP4555Cpdqx0NoU7pGlWBcayyFI8f/l/idRpgjMEfwuOxSWJYlIA=="],
 
     "@proompteng/sag/nitro/env-runner": ["env-runner@0.1.16", "", { "dependencies": { "crossws": "^0.4.8", "exsolve": "^1.1.0", "httpxy": "^0.5.4", "srvx": "^0.11.19" }, "peerDependencies": { "@netlify/runtime": "^4.1.23", "@vercel/queue": ">=0.2.0", "miniflare": "^4.20260515.0", "wrangler": "^4.0.0" }, "optionalPeers": ["@netlify/runtime", "@vercel/queue", "miniflare", "wrangler"], "bin": { "env-runner": "dist/cli.mjs" } }, "sha512-2LRJM4P2KLX6J83QZZrMqvgCDt/D5ea7wPcI3yYiy5cG/9rX5QwdwZFx0D7ktWnjdRyZxYjttGGorb5nFqb1CA=="],
 
@@ -7583,8 +7576,6 @@
     "@proompteng/signal-publisher/effect/toml": ["toml@4.3.0", "", {}, "sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A=="],
 
     "@proompteng/signal-publisher/effect/uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
-
-    "@proompteng/signal-publisher/effect/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "@radix-ui/react-popper/@floating-ui/react-dom/@floating-ui/dom": ["@floating-ui/dom@1.7.5", "", { "dependencies": { "@floating-ui/core": "^1.7.4", "@floating-ui/utils": "^0.2.10" } }, "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg=="],
 
@@ -7670,8 +7661,6 @@
 
     "accepts/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
-    "app/nitro/crossws": ["crossws@0.4.10", "", { "peerDependencies": { "srvx": ">=0.11.5" }, "optionalPeers": ["srvx"] }, "sha512-pz3oubH/dt12KjqsUB0IuXW4nwRDQ583iDsP4555Cpdqx0NoU7pGlWBcayyFI8f/l/idRpgjMEfwuOxSWJYlIA=="],
-
     "app/nitro/env-runner": ["env-runner@0.1.16", "", { "dependencies": { "crossws": "^0.4.8", "exsolve": "^1.1.0", "httpxy": "^0.5.4", "srvx": "^0.11.19" }, "peerDependencies": { "@netlify/runtime": "^4.1.23", "@vercel/queue": ">=0.2.0", "miniflare": "^4.20260515.0", "wrangler": "^4.0.0" }, "optionalPeers": ["@netlify/runtime", "@vercel/queue", "miniflare", "wrangler"], "bin": { "env-runner": "dist/cli.mjs" } }, "sha512-2LRJM4P2KLX6J83QZZrMqvgCDt/D5ea7wPcI3yYiy5cG/9rX5QwdwZFx0D7ktWnjdRyZxYjttGGorb5nFqb1CA=="],
 
     "app/nitro/h3": ["h3@2.0.1-rc.25", "", { "dependencies": { "rou3": "^0.9.1", "srvx": "^0.11.22" }, "peerDependencies": { "crossws": "^0.4.9" }, "optionalPeers": ["crossws"], "bin": { "h3": "bin/h3.mjs" } }, "sha512-uIK++Up28xDt4n0+bSWfVssRivNXpUmMmA6CCiK6j9+utLcBMcFK97Gn9PlSZwAPW9oLy3CjGJ4ag40CY9YYtQ=="],
@@ -7680,11 +7669,19 @@
 
     "app/nitro/ocache": ["ocache@0.2.0", "", { "dependencies": { "ohash": "^2.0.11" } }, "sha512-QE+SxXf/A8yR01rEOg2X5KwUe+mARHo1xQXl+iwLMzLIH06S5lBOZhhHQWp7T5etfFa8nOnRhvjGuo9YBCWwig=="],
 
-    "app/nitro/rolldown": ["rolldown@1.1.5", "", { "dependencies": { "@oxc-project/types": "=0.139.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.5", "@rolldown/binding-darwin-arm64": "1.1.5", "@rolldown/binding-darwin-x64": "1.1.5", "@rolldown/binding-freebsd-x64": "1.1.5", "@rolldown/binding-linux-arm-gnueabihf": "1.1.5", "@rolldown/binding-linux-arm64-gnu": "1.1.5", "@rolldown/binding-linux-arm64-musl": "1.1.5", "@rolldown/binding-linux-ppc64-gnu": "1.1.5", "@rolldown/binding-linux-s390x-gnu": "1.1.5", "@rolldown/binding-linux-x64-gnu": "1.1.5", "@rolldown/binding-linux-x64-musl": "1.1.5", "@rolldown/binding-openharmony-arm64": "1.1.5", "@rolldown/binding-wasm32-wasi": "1.1.5", "@rolldown/binding-win32-arm64-msvc": "1.1.5", "@rolldown/binding-win32-x64-msvc": "1.1.5" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA=="],
+    "app/nitro/rolldown": ["rolldown@1.2.0", "", { "dependencies": { "@oxc-project/types": "=0.140.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.2.0", "@rolldown/binding-darwin-arm64": "1.2.0", "@rolldown/binding-darwin-x64": "1.2.0", "@rolldown/binding-freebsd-x64": "1.2.0", "@rolldown/binding-linux-arm-gnueabihf": "1.2.0", "@rolldown/binding-linux-arm64-gnu": "1.2.0", "@rolldown/binding-linux-arm64-musl": "1.2.0", "@rolldown/binding-linux-ppc64-gnu": "1.2.0", "@rolldown/binding-linux-s390x-gnu": "1.2.0", "@rolldown/binding-linux-x64-gnu": "1.2.0", "@rolldown/binding-linux-x64-musl": "1.2.0", "@rolldown/binding-openharmony-arm64": "1.2.0", "@rolldown/binding-wasm32-wasi": "1.2.0", "@rolldown/binding-win32-arm64-msvc": "1.2.0", "@rolldown/binding-win32-x64-msvc": "1.2.0" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-u7tgm5l4Yw1iTqUL4EcYOAt7fFvCgQMLeidrnD4GALlC6aOznCjezYajgxeyKw27u0Q5N7fwgCzjVyPIWzwuBA=="],
 
     "app/nitro/rou3": ["rou3@0.9.1", "", {}, "sha512-z/sSmzvtwMDDnxsPVhfWMuG6F6mbmhFDXoVqLmMfbpDD9qfV3GDmSQpf0+W296/ZDIpW2wcMmBfpVFzcnOi/nA=="],
 
     "app/nitro/srvx": ["srvx@0.11.22", "", { "bin": { "srvx": "bin/srvx.mjs" } }, "sha512-LqZxxBDMKuMAZzFzJnDCkFOrs9MZQZr0LvHiO/SuSZVdQaXD7xQ5UWTUxheJrQPve1qk9MG2B/yttUvJxw8egQ=="],
+
+    "app/pg/pg-cloudflare": ["pg-cloudflare@1.4.0", "", {}, "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A=="],
+
+    "app/pg/pg-connection-string": ["pg-connection-string@2.14.0", "", {}, "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg=="],
+
+    "app/pg/pg-pool": ["pg-pool@3.14.0", "", { "peerDependencies": { "pg": ">=8.0" } }, "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw=="],
+
+    "app/pg/pg-protocol": ["pg-protocol@1.15.0", "", {}, "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ=="],
 
     "archiver-utils/glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
@@ -7775,6 +7772,14 @@
     "clipboardy/is-wsl/is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
 
     "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "cms/pg/pg-cloudflare": ["pg-cloudflare@1.4.0", "", {}, "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A=="],
+
+    "cms/pg/pg-connection-string": ["pg-connection-string@2.14.0", "", {}, "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg=="],
+
+    "cms/pg/pg-pool": ["pg-pool@3.14.0", "", { "peerDependencies": { "pg": ">=8.0" } }, "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw=="],
+
+    "cms/pg/pg-protocol": ["pg-protocol@1.15.0", "", {}, "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ=="],
 
     "color/color-convert/color-name": ["color-name@2.1.0", "", {}, "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg=="],
 
@@ -7963,8 +7968,6 @@
     "gcp-metadata/gaxios/rimraf": ["rimraf@5.0.10", "", { "dependencies": { "glob": "^10.3.7" }, "bin": { "rimraf": "dist/esm/bin.mjs" } }, "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ=="],
 
     "gray-matter/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
-
-    "h3-rules/h3/crossws": ["crossws@0.4.10", "", { "peerDependencies": { "srvx": ">=0.11.5" }, "optionalPeers": ["srvx"] }, "sha512-pz3oubH/dt12KjqsUB0IuXW4nwRDQ583iDsP4555Cpdqx0NoU7pGlWBcayyFI8f/l/idRpgjMEfwuOxSWJYlIA=="],
 
     "h3-rules/h3/srvx": ["srvx@0.11.22", "", { "bin": { "srvx": "bin/srvx.mjs" } }, "sha512-LqZxxBDMKuMAZzFzJnDCkFOrs9MZQZr0LvHiO/SuSZVdQaXD7xQ5UWTUxheJrQPve1qk9MG2B/yttUvJxw8egQ=="],
 
@@ -8186,8 +8189,6 @@
 
     "readdir-glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
-    "reestr/nitro/crossws": ["crossws@0.4.10", "", { "peerDependencies": { "srvx": ">=0.11.5" }, "optionalPeers": ["srvx"] }, "sha512-pz3oubH/dt12KjqsUB0IuXW4nwRDQ583iDsP4555Cpdqx0NoU7pGlWBcayyFI8f/l/idRpgjMEfwuOxSWJYlIA=="],
-
     "reestr/nitro/env-runner": ["env-runner@0.1.16", "", { "dependencies": { "crossws": "^0.4.8", "exsolve": "^1.1.0", "httpxy": "^0.5.4", "srvx": "^0.11.19" }, "peerDependencies": { "@netlify/runtime": "^4.1.23", "@vercel/queue": ">=0.2.0", "miniflare": "^4.20260515.0", "wrangler": "^4.0.0" }, "optionalPeers": ["@netlify/runtime", "@vercel/queue", "miniflare", "wrangler"], "bin": { "env-runner": "dist/cli.mjs" } }, "sha512-2LRJM4P2KLX6J83QZZrMqvgCDt/D5ea7wPcI3yYiy5cG/9rX5QwdwZFx0D7ktWnjdRyZxYjttGGorb5nFqb1CA=="],
 
     "reestr/nitro/nf3": ["nf3@0.3.17", "", {}, "sha512-N9zEWySuJFw+gR0lhS5863YsvNeudOdqRyFvNb+jMXbeTJOdrjDqkCpDginIZfUm0LzT1t1nCRiDeqQm/8kirQ=="],
@@ -8216,8 +8217,6 @@
 
     "streamroller/fs-extra/universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
 
-    "synthesis/nitro/crossws": ["crossws@0.4.10", "", { "peerDependencies": { "srvx": ">=0.11.5" }, "optionalPeers": ["srvx"] }, "sha512-pz3oubH/dt12KjqsUB0IuXW4nwRDQ583iDsP4555Cpdqx0NoU7pGlWBcayyFI8f/l/idRpgjMEfwuOxSWJYlIA=="],
-
     "synthesis/nitro/env-runner": ["env-runner@0.1.16", "", { "dependencies": { "crossws": "^0.4.8", "exsolve": "^1.1.0", "httpxy": "^0.5.4", "srvx": "^0.11.19" }, "peerDependencies": { "@netlify/runtime": "^4.1.23", "@vercel/queue": ">=0.2.0", "miniflare": "^4.20260515.0", "wrangler": "^4.0.0" }, "optionalPeers": ["@netlify/runtime", "@vercel/queue", "miniflare", "wrangler"], "bin": { "env-runner": "dist/cli.mjs" } }, "sha512-2LRJM4P2KLX6J83QZZrMqvgCDt/D5ea7wPcI3yYiy5cG/9rX5QwdwZFx0D7ktWnjdRyZxYjttGGorb5nFqb1CA=="],
 
     "synthesis/nitro/nf3": ["nf3@0.3.17", "", {}, "sha512-N9zEWySuJFw+gR0lhS5863YsvNeudOdqRyFvNb+jMXbeTJOdrjDqkCpDginIZfUm0LzT1t1nCRiDeqQm/8kirQ=="],
@@ -8227,6 +8226,14 @@
     "synthesis/nitro/rolldown": ["rolldown@1.1.5", "", { "dependencies": { "@oxc-project/types": "=0.139.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.5", "@rolldown/binding-darwin-arm64": "1.1.5", "@rolldown/binding-darwin-x64": "1.1.5", "@rolldown/binding-freebsd-x64": "1.1.5", "@rolldown/binding-linux-arm-gnueabihf": "1.1.5", "@rolldown/binding-linux-arm64-gnu": "1.1.5", "@rolldown/binding-linux-arm64-musl": "1.1.5", "@rolldown/binding-linux-ppc64-gnu": "1.1.5", "@rolldown/binding-linux-s390x-gnu": "1.1.5", "@rolldown/binding-linux-x64-gnu": "1.1.5", "@rolldown/binding-linux-x64-musl": "1.1.5", "@rolldown/binding-openharmony-arm64": "1.1.5", "@rolldown/binding-wasm32-wasi": "1.1.5", "@rolldown/binding-win32-arm64-msvc": "1.1.5", "@rolldown/binding-win32-x64-msvc": "1.1.5" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA=="],
 
     "synthesis/nitro/srvx": ["srvx@0.11.22", "", { "bin": { "srvx": "bin/srvx.mjs" } }, "sha512-LqZxxBDMKuMAZzFzJnDCkFOrs9MZQZr0LvHiO/SuSZVdQaXD7xQ5UWTUxheJrQPve1qk9MG2B/yttUvJxw8egQ=="],
+
+    "synthesis/pg/pg-cloudflare": ["pg-cloudflare@1.4.0", "", {}, "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A=="],
+
+    "synthesis/pg/pg-connection-string": ["pg-connection-string@2.14.0", "", {}, "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg=="],
+
+    "synthesis/pg/pg-pool": ["pg-pool@3.14.0", "", { "peerDependencies": { "pg": ">=8.0" } }, "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw=="],
+
+    "synthesis/pg/pg-protocol": ["pg-protocol@1.15.0", "", {}, "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ=="],
 
     "tanstack-router-react-example-with-trpc-react-query/@tanstack/react-router/@tanstack/history": ["@tanstack/history@1.161.6", "", {}, "sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg=="],
 
@@ -8772,37 +8779,37 @@
 
     "app/nitro/env-runner/httpxy": ["httpxy@0.5.5", "", {}, "sha512-uDjmnPyp1q4Sgzf3w+J/Fc6UqcCEj0x4Wjp7OqK5dGhNeDgpyrAmnS6ey8QWrX3SWDon2DMKf9sBa5X9+CVyMA=="],
 
-    "app/nitro/rolldown/@oxc-project/types": ["@oxc-project/types@0.139.0", "", {}, "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw=="],
+    "app/nitro/rolldown/@oxc-project/types": ["@oxc-project/types@0.140.0", "", {}, "sha512-h5LUOzGArYemnW1NMz/DuuQhBi96J6JL2Bk8zE4kvqxB5Sg3jxmCiH4uyOWHDkiKSt5vWlG4FIwCR/DbstcNRQ=="],
 
-    "app/nitro/rolldown/@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.5", "", { "os": "android", "cpu": "arm64" }, "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ=="],
+    "app/nitro/rolldown/@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.2.0", "", { "os": "android", "cpu": "arm64" }, "sha512-9yB1l95IrJuNGDFdOYe79vdApdz6WWBCObE+rQ2LUliYUlcyFwSYIb2xb5/Ifw7dAtMy2ZqNyd8QTSOc7duAKw=="],
 
-    "app/nitro/rolldown/@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.1.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw=="],
+    "app/nitro/rolldown/@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.2.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-pexNaW9ACLUOaBITOpU6qVu4VrsOFIjTv6bzgu0YUATo4eUJx0V605PxwZfndpPOn0ilqGqvGQ0M8UW0IE24jg=="],
 
-    "app/nitro/rolldown/@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.1.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g=="],
+    "app/nitro/rolldown/@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.2.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-NqKYaq0355ZmNMG4QGpxtEDxsc7tGDhjhCm4PpE0cwnBW+5Il95LJyq414niEiaKLVjnVHBEjSo1wngKxJNiFw=="],
 
-    "app/nitro/rolldown/@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.1.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA=="],
+    "app/nitro/rolldown/@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.2.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-3vPoHzh6eBTz9IbB0/qZdSr0Qeks2echn+I4cHu2joV74VriPDdldswksEDzrl1mBB+oPRi+67+3Ib59paxIPQ=="],
 
-    "app/nitro/rolldown/@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.1.5", "", { "os": "linux", "cpu": "arm" }, "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw=="],
+    "app/nitro/rolldown/@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.2.0", "", { "os": "linux", "cpu": "arm" }, "sha512-E6NNefZ1bUVmKJq2tJkf45J4Zyczj7qm9rUT7NY+Xo2474Y13qWAwc2tvBt0BAVbmtXR1llkxXg0Ou1jbDf2SQ=="],
 
-    "app/nitro/rolldown/@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q=="],
+    "app/nitro/rolldown/@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.2.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-D+TgkdgM1vu+7/Fpf8+v0ARW+RXEP9Ccazgm8zQ4JFFd9Q7SrYQ2TakU5S5ihazQDgpKyAgZDOcIFsvoHmTZ8w=="],
 
-    "app/nitro/rolldown/@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA=="],
+    "app/nitro/rolldown/@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.2.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-wUqdwJBbAv0APN87GecstdMUtLjjNTs0hBALpxETD73mccFxdmt/XeizXDtN5RAlBwNKmI+Tg+blect2G+8IeQ=="],
 
-    "app/nitro/rolldown/@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.1.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg=="],
+    "app/nitro/rolldown/@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.2.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9DtF35qR9/NrfhM4oxLplCzVVjE+KKm8Pjemi0i/sdhAWkUasjmSo8WTTubNJClhSHCfyk2yeyoXDQEDPtDAAw=="],
 
-    "app/nitro/rolldown/@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.1.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA=="],
+    "app/nitro/rolldown/@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.2.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-RzuHrBh8X8Hntd2N4VR02QGEciq/9JhcZoTpR/Cee6otRrlILGCf3cg2ygHuih+ZebUnWmMrDX6ITI85btO6rQ=="],
 
-    "app/nitro/rolldown/@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ=="],
+    "app/nitro/rolldown/@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.2.0", "", { "os": "linux", "cpu": "x64" }, "sha512-MK7L0018jjh1jR3mh21G2j1zAVcpscJBlPo2z19pRjv2XOYGRhaV4LyiD8HO6nCDdZln9IFgCMIV5yt4E3klGQ=="],
 
-    "app/nitro/rolldown/@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg=="],
+    "app/nitro/rolldown/@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.2.0", "", { "os": "linux", "cpu": "x64" }, "sha512-gyrxLQ9NfGb/9LoVnC4kb9miUghw1mghnkfYvNHSnVIXriabnfgGPUP4RLcJm87q3KgYz4FYUG8IDiWUT+CpSw=="],
 
-    "app/nitro/rolldown/@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.1.5", "", { "os": "none", "cpu": "arm64" }, "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw=="],
+    "app/nitro/rolldown/@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.2.0", "", { "os": "none", "cpu": "arm64" }, "sha512-/6VFMQGRmrhP77KXDC+StIxGzcNp5JOIyYtw0CQ8gPlzhpiIRucYfoM5FaFamHd5BJYIdH86yfP46l1p3WdrFA=="],
 
-    "app/nitro/rolldown/@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.1.5", "", { "dependencies": { "@emnapi/core": "1.11.1", "@emnapi/runtime": "1.11.1", "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA=="],
+    "app/nitro/rolldown/@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.2.0", "", { "dependencies": { "@emnapi/core": "1.11.2", "@emnapi/runtime": "1.11.2", "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-rwdbUL465kisF24WEJLvP3JrEG6E5GRuIHt5wpMwHGERtHe4Wm2CIvtf5gTBgr2tGOHKh5NdKEAFS2VkOPE91g=="],
 
-    "app/nitro/rolldown/@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.1.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw=="],
+    "app/nitro/rolldown/@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.2.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-+5suHwRiKGmhwyUaNT8a5QbrBvLFh2DbO910TEmGRH1aSxwrCezodvGQnulv4uiWEIv1Kq4ypRsJ5+O+ry1DiA=="],
 
-    "app/nitro/rolldown/@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.1.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA=="],
+    "app/nitro/rolldown/@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.2.0", "", { "os": "win32", "cpu": "x64" }, "sha512-WfFv6/qGufotqBSBzBYwgpCkJBk8Nj7697LL9vTz/XWc67e0r3oewu8iMRwQj3AUL45GVD7wVsPjCsAAtW66Wg=="],
 
     "archiver-utils/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
@@ -9344,9 +9351,9 @@
 
     "@proompteng/signal-publisher/effect/msgpackr/msgpackr-extract/@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4", "", { "os": "win32", "cpu": "x64" }, "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ=="],
 
-    "app/nitro/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
+    "app/nitro/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA=="],
 
-    "app/nitro/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
+    "app/nitro/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA=="],
 
     "app/nitro/rolldown/@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
 

--- a/docs/bayn/cnpg-backup-restore.md
+++ b/docs/bayn/cnpg-backup-restore.md
@@ -58,7 +58,17 @@ the recovery Cluster has no backup stanza and only reads that archive.
    kubectl -n bayn wait --for=jsonpath='{.status.phase}'=completed backup/bayn-db-proof-UTC_SUFFIX --timeout=30m
    ```
 
-3. Add a temporary, uniquely named recovery `Cluster` and matching ingress-only `NetworkPolicy` to a reviewed GitOps
+3. Remove the proof schema from the primary after the backup completes, then verify that it is absent. The proof remains
+   in the immutable backup selected by the recovery Cluster.
+
+   ```sh
+   kubectl cnpg psql -n bayn bayn-db -- -d bayn -v ON_ERROR_STOP=1 -c "drop schema restore_probe cascade"
+   kubectl cnpg psql -n bayn bayn-db -- -d bayn -Atqc "select to_regnamespace('restore_probe') is null"
+   ```
+
+   The verification query must return `t`.
+
+4. Add a temporary, uniquely named recovery `Cluster` and matching ingress-only `NetworkPolicy` to a reviewed GitOps
    change. The policy permits only its own peers, the CNPG operator on ports 5432/8000, and Alloy on 9187. Use one
    instance, the same pinned image and storage class, and this recovery source:
 
@@ -79,10 +89,10 @@ the recovery Cluster has no backup stanza and only reads that archive.
            serverName: bayn-db-live
    ```
 
-4. After Argo reports the recovery Cluster healthy, query the exact proof row through `kubectl cnpg psql`. Record the
+5. After Argo reports the recovery Cluster healthy, query the exact proof row through `kubectl cnpg psql`. Record the
    primary and recovery Cluster UIDs, backup name/ID, start/end timestamps, source image digest, proof row, and recovery
    duration in PROOMPT-358.
 
-5. Remove the temporary manifest through GitOps only after the evidence is recorded. Deleting the recovery Cluster or
+6. Remove the temporary manifest through GitOps only after the evidence is recorded. Deleting the recovery Cluster or
    its PVC requires explicit approval. Never alter or delete `bayn-db`, `cnpg-bayn-db`, or another service's storage as
    part of the drill.

--- a/nix/images/bayn.nix
+++ b/nix/images/bayn.nix
@@ -21,8 +21,8 @@ import ./bun-workspace-service.nix {
   serviceName = "bayn";
   packageName = "@proompteng/bayn";
   depsHash = {
-    x86_64-linux = "sha256-HOivxpn3uqVZlCG3XM/zeh9sg7yNXUzh1nHcLpNsBmA=";
-    aarch64-linux = "sha256-d5QZaVMgc+DgKfwaoiXKulU/iBV8VVBbhEQWdXd6dzk=";
+    x86_64-linux = "sha256-vnLP/fHHTk2aDFGr3nSihUWlYEA5XqmYhcU8VUA7JXo=";
+    aarch64-linux = "sha256-lgfO40BKK6uVO2/yjEjPziUvTy+IOQEaQx7g4g0EXb4=";
   };
   installFilters = [
     "@proompteng/bayn"

--- a/nix/images/signal-publisher.nix
+++ b/nix/images/signal-publisher.nix
@@ -16,8 +16,8 @@ import ./bun-workspace-service.nix {
   serviceName = "signal-publisher";
   packageName = "@proompteng/signal-publisher";
   depsHash = {
-    x86_64-linux = "sha256-UqyymgIzC2N+mtmjTbrUVeZBzcaVIw8WV1UwnvsnLn4=";
-    aarch64-linux = "sha256-Xdu+YlnFFDg0zH653zwg73sDVUP0/EWsoeUn1tgrrKc=";
+    x86_64-linux = "sha256-ZShN/ISkl+4eSNeh7y7lsNpvNtTOhZtGgNIJH7iWD/c=";
+    aarch64-linux = "sha256-P9PM81hh7EWEKJ4TkC2Yi7S4KAsanPWt4MAHlUWsK2w=";
   };
   installFilters = [
     "@proompteng/signal-publisher"

--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
   },
   "packageManager": "bun@1.3.14",
   "patchedDependencies": {
-    "@effect/sql-clickhouse@4.0.0-beta.99": "patches/@effect%2Fsql-clickhouse@4.0.0-beta.99.patch"
+    "@effect/sql-clickhouse@4.0.0-beta.99": "patches/@effect%2Fsql-clickhouse@4.0.0-beta.99.patch",
+    "@effect/sql-clickhouse@4.0.0-beta.100": "patches/@effect%2Fsql-clickhouse@4.0.0-beta.100.patch"
   }
 }

--- a/packages/scripts/src/bayn/update-manifests.test.ts
+++ b/packages/scripts/src/bayn/update-manifests.test.ts
@@ -136,7 +136,7 @@ describe('Bayn manifest promotion', () => {
     expect(() => promote(paths)).toThrow('qualification replacement requires a fresh BAYN_SIGNAL_SNAPSHOT_ID')
   })
 
-  test('replaces a pin for a fresh snapshot and rejects another unpinned release on that snapshot', () => {
+  test('replaces a pin for a fresh snapshot and permits later releases while unqualified', () => {
     const paths = makeFixture({ snapshotId: '4'.repeat(64), publicationAsOf: '2026-07-19' })
     const changedParameterHash = '3'.repeat(64)
     const first = promote(paths, { strategyParameterHash: changedParameterHash })
@@ -154,9 +154,15 @@ describe('Bayn manifest promotion', () => {
       environmentBlock('BAYN_SIGNAL_SNAPSHOT_ID', currentSnapshotId).trim(),
     )
 
-    expect(() => promote(paths, { strategyParameterHash: changedParameterHash })).toThrow(
-      'qualification replacement requires a fresh BAYN_SIGNAL_SNAPSHOT_ID',
-    )
+    const second = promote(paths, { strategyParameterHash: changedParameterHash })
+
+    expect(second).toMatchObject({
+      qualificationMode: 'replace',
+      hadQualificationPin: false,
+      runtimeBindingsMatch: true,
+      snapshotChanged: false,
+    })
+    expect(readFileSync(paths.deploymentPath, 'utf8')).not.toContain('BAYN_QUALIFICATION_RUN_ID')
   })
 
   test('rejects malformed release metadata', () => {

--- a/packages/scripts/src/bayn/update-manifests.ts
+++ b/packages/scripts/src/bayn/update-manifests.ts
@@ -109,7 +109,7 @@ export const updateBaynManifests = (options: UpdateBaynManifestOptions): BaynMan
     deployedBehaviorHash === options.strategyBehaviorHash && deployedParameterHash === options.strategyParameterHash
   const qualificationMode =
     hadQualificationPin && strategyIdentityMatches && runtimeBindingsMatch ? 'preserve' : 'replace'
-  if (qualificationMode === 'replace' && !snapshotChanged) {
+  if (qualificationMode === 'replace' && hadQualificationPin && !snapshotChanged) {
     throw new Error('qualification replacement requires a fresh BAYN_SIGNAL_SNAPSHOT_ID')
   }
   const imageBlock =

--- a/patches/@effect%2Fsql-clickhouse@4.0.0-beta.100.patch
+++ b/patches/@effect%2Fsql-clickhouse@4.0.0-beta.100.patch
@@ -1,0 +1,23 @@
+diff --git a/dist/ClickhouseClient.js b/dist/ClickhouseClient.js
+--- a/dist/ClickhouseClient.js
++++ b/dist/ClickhouseClient.js
+@@ -97,7 +97,7 @@ export const make = options => Effect.gen(function* () {
+   const transformRows = options.transformResultNames ? Statement.defaultTransforms(options.transformResultNames).array : undefined;
+   const client = Clickhouse.createClient(options);
+   yield* Effect.acquireRelease(Effect.tryPromise({
+-    try: () => client.exec({
++    try: () => client.command({
+       query: "SELECT 1"
+     }),
+     catch: cause => new SqlError({
+diff --git a/src/ClickhouseClient.ts b/src/ClickhouseClient.ts
+--- a/src/ClickhouseClient.ts
++++ b/src/ClickhouseClient.ts
+@@ -180,6 +180,6 @@ export const make = (
+     yield* Effect.acquireRelease(
+       Effect.tryPromise({
+-        try: () => client.exec({ query: "SELECT 1" }),
++        try: () => client.command({ query: "SELECT 1" }),
+         catch: (cause) =>
+           new SqlError({ reason: classifyError(cause, "ClickhouseClient: Failed to connect", "connect", "connection") })
+       }),

--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -58,9 +58,9 @@ to TigerBeetle. Bayn contains no broker client or capital-promotion path.
   Any terminal-result failure rolls the evaluation graph back and leaves the lock visibly incomplete. An incomplete
   lock is never silently retried and blocks every new candidate; a locked candidate cannot bypass the terminal result
   through the ordinary persistence path.
-- Migration 8 is a deliberate one-way reset from the never-promoted TSMOM evidence contract. In one transaction it
-  deletes the old evidence graph and installs current-only SQL constraints. The runtime does not read, convert, restore,
-  or fall back to TSMOM records.
+- One current-only initial migration creates the unprefixed evidence and qualification schema. Startup rejects a
+  legacy migration tracker or retired migration history after the hard cut; it never reads, converts, or falls back to
+  legacy records.
 - The execution path and independent reducer use integer micros for cash, quantity, prices, spread, slippage, fees,
   cash yield, positions, and every marked-equity point. Full, partial, and rejected orders are durable. Evaluation and
   recovery require exact zero-difference cash, fee, position, and equity reconstruction.

--- a/services/bayn/package.json
+++ b/services/bayn/package.json
@@ -16,10 +16,10 @@
   },
   "dependencies": {
     "@clickhouse/client": "1.23.1",
-    "@effect/platform-node": "4.0.0-beta.99",
-    "@effect/sql-clickhouse": "4.0.0-beta.99",
-    "@effect/sql-pg": "4.0.0-beta.99",
-    "effect": "4.0.0-beta.99",
+    "@effect/platform-node": "4.0.0-beta.100",
+    "@effect/sql-clickhouse": "4.0.0-beta.100",
+    "@effect/sql-pg": "4.0.0-beta.100",
+    "effect": "4.0.0-beta.100",
     "tigerbeetle-node": "0.17.9"
   },
   "devDependencies": {

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -175,6 +175,81 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     expect(schema.migrations).toEqual([{ migration_id: 1, name: 'initial_schema' }])
   })
 
+  test('rejects the legacy migration tracker instead of creating a parallel schema', async () => {
+    await runtime.dispose()
+    const client = makeClientRuntime()
+    await client.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* PgClient.PgClient
+        yield* sql`DROP SCHEMA public CASCADE`
+        yield* sql`CREATE SCHEMA public`
+        yield* sql`CREATE TABLE bayn_schema_migrations (migration_id integer PRIMARY KEY)`
+      }),
+    )
+
+    const legacyRuntime = makeEvidenceRuntime()
+    const exit = await legacyRuntime.runPromiseExit(Effect.flatMap(EvidenceStore, (store) => store.check))
+    await legacyRuntime.dispose()
+
+    const trackers = await client.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* PgClient.PgClient
+        const rows = yield* sql<{ current_exists: boolean; legacy_exists: boolean }>`
+          SELECT
+            to_regclass('public.schema_migrations') IS NOT NULL AS current_exists,
+            to_regclass('public.bayn_schema_migrations') IS NOT NULL AS legacy_exists
+        `
+        yield* sql`DROP SCHEMA public CASCADE`
+        yield* sql`CREATE SCHEMA public`
+        return rows[0]
+      }),
+    )
+    await client.dispose()
+    runtime = makeEvidenceRuntime()
+    await runtime.runPromise(Effect.flatMap(EvidenceStore, (store) => store.check))
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) expect(Cause.pretty(exit.cause)).toContain('legacy migration tracker is unsupported')
+    expect(trackers).toEqual({ current_exists: false, legacy_exists: true })
+  })
+
+  test('rejects the retired migration history instead of skipping the initial schema', async () => {
+    await runtime.dispose()
+    const client = makeClientRuntime()
+    await client.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* PgClient.PgClient
+        yield* sql`DROP SCHEMA public CASCADE`
+        yield* sql`CREATE SCHEMA public`
+        yield* sql`
+          CREATE TABLE schema_migrations (
+            migration_id integer PRIMARY KEY,
+            created_at timestamptz NOT NULL DEFAULT now(),
+            name text NOT NULL
+          )
+        `
+        yield* sql`INSERT INTO schema_migrations (migration_id, name) VALUES (1, 'evaluation_evidence')`
+      }),
+    )
+
+    const legacyRuntime = makeEvidenceRuntime()
+    const exit = await legacyRuntime.runPromiseExit(Effect.flatMap(EvidenceStore, (store) => store.check))
+    await legacyRuntime.dispose()
+    await client.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* PgClient.PgClient
+        yield* sql`DROP SCHEMA public CASCADE`
+        yield* sql`CREATE SCHEMA public`
+      }),
+    )
+    await client.dispose()
+    runtime = makeEvidenceRuntime()
+    await runtime.runPromise(Effect.flatMap(EvidenceStore, (store) => store.check))
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) expect(Cause.pretty(exit.cause)).toContain('legacy migration history is unsupported')
+  })
+
   test('accepts only the current protocol contract', async () => {
     const exits = await runtime.runPromise(
       Effect.gen(function* () {

--- a/services/bayn/src/db/evidence-store.ts
+++ b/services/bayn/src/db/evidence-store.ts
@@ -23,6 +23,7 @@ import {
   decodeReconciliationResult,
   decodeRiskBalancedTrendSignalDecisionsArtifact,
   decodeSimulatedOrdersArtifact,
+  EvaluationEventSchema,
   makeEquitySeriesArtifact,
 } from '../evidence-contracts'
 import { canonicalHashV1 } from '../hash'
@@ -35,7 +36,15 @@ import {
 import { ProtocolSchema } from '../protocol'
 import { summarizeEvaluation } from '../risk-balanced-trend'
 import { reconcileMarkedEquity } from '../simulation-reconciliation'
-import type { EvaluationResult, EvaluationSummary, InputManifest, Protocol, ReconciliationResult } from '../types'
+import type {
+  EconomicVerdict,
+  EvaluationEvent,
+  EvaluationResult,
+  EvaluationSummary,
+  InputManifest,
+  Protocol,
+  ReconciliationResult,
+} from '../types'
 import { migrationLoader } from './migrations'
 
 export type DatabaseFailure = 'constraint' | 'decode' | 'invariant' | 'migration' | 'query' | 'unavailable'
@@ -85,7 +94,7 @@ export interface ArtifactItemPage {
   readonly schemaVersion: string
   readonly contentHash: string
   readonly itemCount: number
-  readonly items: readonly { readonly ordinal: number; readonly payload: unknown }[]
+  readonly items: readonly { readonly ordinal: number; readonly payload: Schema.Json }[]
   readonly nextAfterOrdinal: number | null
 }
 
@@ -146,20 +155,26 @@ export interface StoredEvaluationEvidence {
     readonly id: string
     readonly kind: 'decision' | 'fill' | 'fee' | 'cash-yield'
     readonly contentHash: string
-    readonly payload: unknown
+    readonly payload: EvaluationEvent
   }[]
   readonly gates: readonly {
     readonly ordinal: number
     readonly name: string
     readonly passed: boolean
-    readonly actual: unknown
-    readonly required: unknown
+    readonly actual: EconomicVerdict['gates'][number]['actual']
+    readonly required: EconomicVerdict['gates'][number]['required']
     readonly contentHash: string
   }[]
-  readonly statuses: readonly {
-    readonly status: 'WRITING' | 'COMPLETE'
-    readonly detail: unknown
-  }[]
+  readonly statuses: readonly (
+    | {
+        readonly status: 'WRITING'
+        readonly detail: { readonly artifactCount: number; readonly eventCount: number; readonly gateCount: number }
+      }
+    | {
+        readonly status: 'COMPLETE'
+        readonly detail: { readonly reconciliationExact: true; readonly verdict: 'PASS' | 'FAIL_CLOSED' }
+      }
+  )[]
 }
 
 export interface RecoveredEvaluationEvidence {
@@ -173,6 +188,7 @@ const GitRevision = Schema.String.check(Schema.isPattern(/^(?:[0-9a-f]{40}|[0-9a
 const ImageDigest = Schema.String.check(Schema.isPattern(/^sha256:[0-9a-f]{64}$/))
 const PositiveInteger = Schema.Int.check(Schema.isGreaterThan(0))
 const NonNegativeInteger = Schema.Int.check(Schema.isGreaterThanOrEqualTo(0))
+const GateScalar = Schema.Union([Schema.Finite, Schema.Boolean, Schema.String])
 const RunRequest = Schema.Struct({ runId: Sha256 })
 const InsertedRun = Schema.Struct({ run_id: Sha256 })
 const HealthRow = Schema.Struct({ value: Schema.Literal(1) })
@@ -222,7 +238,7 @@ const ArtifactReferenceRow = Schema.Struct({
   artifact_name: Schema.String,
   schema_version: Schema.String,
   content_hash: Sha256,
-  payload: Schema.Unknown,
+  payload: Schema.Json,
 })
 const ArtifactSeriesMetadataRow = Schema.Struct({
   schema_version: Schema.String,
@@ -231,38 +247,59 @@ const ArtifactSeriesMetadataRow = Schema.Struct({
 })
 const ArtifactItemRow = Schema.Struct({
   ordinal: NonNegativeInteger,
-  payload: Schema.Unknown,
+  payload: Schema.Json,
 })
 const EventReferenceRow = Schema.Struct({
   ordinal: NonNegativeInteger,
   event_id: Sha256,
   event_kind: Schema.Literals(['decision', 'fill', 'fee', 'cash-yield']),
   content_hash: Sha256,
-  payload: Schema.Unknown,
+  payload: EvaluationEventSchema,
 })
 const GateReferenceRow = Schema.Struct({
   ordinal: NonNegativeInteger,
   gate_name: Schema.String,
   passed: Schema.Boolean,
-  actual: Schema.Unknown,
-  required: Schema.Unknown,
+  actual: GateScalar,
+  required: GateScalar,
   content_hash: Sha256,
 })
-const StatusReferenceRow = Schema.Struct({
-  status: Schema.Literals(['WRITING', 'COMPLETE']),
-  detail: Schema.Unknown,
-})
+const StatusReferenceRow = Schema.Union([
+  Schema.Struct({
+    status: Schema.Literal('WRITING'),
+    detail: Schema.Struct({
+      artifactCount: PositiveInteger,
+      eventCount: NonNegativeInteger,
+      gateCount: PositiveInteger,
+    }),
+  }),
+  Schema.Struct({
+    status: Schema.Literal('COMPLETE'),
+    detail: Schema.Struct({
+      reconciliationExact: Schema.Literal(true),
+      verdict: Schema.Literals(['PASS', 'FAIL_CLOSED']),
+    }),
+  }),
+])
 const QualificationTrialRow = Schema.Struct({ run_id: Sha256 })
 const QualificationRow = Schema.Struct({
-  lock_payload: Schema.Unknown,
-  result_payload: Schema.NullOr(Schema.Unknown),
+  lock_payload: QualificationLockSchema,
+  result_payload: Schema.NullOr(QualificationResultSchema),
 })
+const MigrationBoundaryRow = Schema.Struct({
+  current_exists: Schema.Boolean,
+  legacy_exists: Schema.Boolean,
+})
+const MigrationIdentityRow = Schema.Struct({ migration_id: PositiveInteger, name: Schema.String })
 const CandidateRunCountRow = Schema.Struct({ count: NonNegativeInteger })
 const InsertedLockRow = Schema.Struct({ lock_id: Sha256 })
 const InsertedResultRow = Schema.Struct({ lock_id: Sha256 })
 const StrictParseOptions = { onExcessProperty: 'error' } as const
 const decodeQualificationLock = Schema.decodeUnknownSync(QualificationLockSchema, StrictParseOptions)
 const decodeQualificationResult = Schema.decodeUnknownSync(QualificationResultSchema, StrictParseOptions)
+const decodeMigrationBoundary = Schema.decodeUnknownEffect(Schema.Tuple([MigrationBoundaryRow]), StrictParseOptions)
+const decodeMigrationIdentities = Schema.decodeUnknownEffect(Schema.Array(MigrationIdentityRow), StrictParseOptions)
+const encodeJson = Schema.encodeSync(Schema.fromJsonString(Schema.Json))
 
 const messageOf = (cause: unknown): string => (cause instanceof Error ? cause.message : String(cause))
 
@@ -638,7 +675,7 @@ const makePersistencePlan = (input: PersistEvaluationInput) => {
       costMultiplierMicros: evaluation.simulation.costMultiplierMicros,
     },
     artifacts: [...baseArtifacts]
-      .sort((left, right) => left.name.localeCompare(right.name))
+      .sort((left, right) => (left.name < right.name ? -1 : left.name > right.name ? 1 : 0))
       .map((artifact) => ({
         name: artifact.name,
         schemaVersion: artifact.schemaVersion,
@@ -679,8 +716,7 @@ type PersistencePlan = ReturnType<typeof makePersistencePlan>
 
 const makeEvidenceStore = Effect.gen(function* () {
   const sql = yield* PgClient.PgClient
-  const jsonScalar = (value: number | boolean | string) =>
-    sql.json(typeof value === 'string' ? JSON.stringify(value) : value)
+  const jsonScalar = (value: number | boolean | string) => sql.json(encodeJson(value))
 
   const health = SqlSchema.findOne({
     Request: Schema.Void,
@@ -926,7 +962,7 @@ const makeEvidenceStore = Effect.gen(function* () {
       sourceRevision: GitRevision,
       imageRepository: Schema.String,
       imageDigest: ImageDigest,
-      payload: Schema.Unknown,
+      payload: QualificationLockSchema,
     }),
     Result: InsertedLockRow,
     execute: (request) => sql`
@@ -963,7 +999,7 @@ const makeEvidenceStore = Effect.gen(function* () {
       verdict: Schema.Literals(['QUALIFIED', 'REJECTED']),
       analysisHash: Sha256,
       resultHash: Sha256,
-      payload: Schema.Unknown,
+      payload: QualificationResultSchema,
     }),
     Result: InsertedResultRow,
     execute: (request) => sql`
@@ -1007,9 +1043,9 @@ const makeEvidenceStore = Effect.gen(function* () {
   })
 
   const decodeQualificationRecord = (row: typeof QualificationRow.Type): QualificationRecord => {
-    const lock = decodeQualificationLock(row.lock_payload)
+    const lock = row.lock_payload
     if (row.result_payload === null) return { state: 'OPENED_INCOMPLETE', lock }
-    const result = decodeQualificationResult(row.result_payload)
+    const result = row.result_payload
     if (result.lockId !== lock.lockId || result.runId !== lock.candidateRunId) {
       throw new TypeError('stored qualification result diverges from its lock')
     }
@@ -1150,7 +1186,9 @@ const makeEvidenceStore = Effect.gen(function* () {
       const events = yield* getEventReferences({ runId: plan.evaluation.runId })
       const gates = yield* getGateReferences({ runId: plan.evaluation.runId })
       const statuses = yield* getStatusReferences({ runId: plan.evaluation.runId })
-      const expectedArtifacts = [...plan.artifacts].sort((left, right) => left.name.localeCompare(right.name))
+      const expectedArtifacts = [...plan.artifacts].sort((left, right) =>
+        left.name < right.name ? -1 : left.name > right.name ? 1 : 0,
+      )
       yield* ensure(
         artifacts.every((artifact, index) => {
           const expected = expectedArtifacts[index]
@@ -1284,25 +1322,17 @@ const makeEvidenceStore = Effect.gen(function* () {
         'read-evidence',
         'stored gate content hash or ordering diverged',
       )
-      const completeDetail = statuses[1]?.detail
-      const completeDetailValid =
-        typeof completeDetail === 'object' &&
-        completeDetail !== null &&
-        'reconciliationExact' in completeDetail &&
-        completeDetail.reconciliationExact === true &&
-        'verdict' in completeDetail &&
-        (completeDetail.verdict === 'PASS' || completeDetail.verdict === 'FAIL_CLOSED')
+      const [writing, complete] = statuses
       yield* ensure(
         statuses.length === 2 &&
-          statuses[0].status === 'WRITING' &&
-          canonicalHashV1(statuses[0].detail) ===
+          writing?.status === 'WRITING' &&
+          canonicalHashV1(writing.detail) ===
             canonicalHashV1({
               artifactCount: row.artifact_count,
               eventCount: row.event_count,
               gateCount: row.gate_count,
             }) &&
-          statuses[1].status === 'COMPLETE' &&
-          completeDetailValid,
+          complete?.status === 'COMPLETE',
         'read-evidence',
         'stored status history is incomplete or divergent',
       )
@@ -1631,6 +1661,12 @@ const makeEvidenceStore = Effect.gen(function* () {
         const dailyMarks = yield* decodeDailyPositionMarksArtifact(dailyMarksArtifact.payload)
         const inputManifest = yield* decodeInputManifestArtifact(inputManifestArtifact.payload)
         const artifactItemCounts = new Map<string, number>([
+          ['evaluation-summary', 0],
+          ['input-manifest', 0],
+          ['strategy', 0],
+          ['buy-and-hold', 0],
+          ['direct-volatility-timing', 0],
+          ['double-cost-strategy', 0],
           ['simulated-orders', orders.items.length],
           ['cash-changes', cashChanges.items.length],
           ['daily-position-marks', dailyMarks.items.length],
@@ -1639,7 +1675,25 @@ const makeEvidenceStore = Effect.gen(function* () {
           ['direct-volatility-timing-series', directVolatilitySeries.items.length],
           ['double-cost-strategy-series', doubleCostSeries.items.length],
           ['equity-series', equitySeries.items.length],
+          ['marked-equity-reconciliation', 0],
+          ['reconciliation', 0],
         ])
+        const manifestArtifacts = yield* Effect.forEach(
+          stored.artifacts
+            .filter((artifact) => artifact.name !== 'qualification-artifact-manifest')
+            .sort((left, right) => (left.name < right.name ? -1 : left.name > right.name ? 1 : 0)),
+          (artifact) =>
+            Effect.fromOption(Option.fromUndefinedOr(artifactItemCounts.get(artifact.name)), () =>
+              databaseError('invariant', 'recover-evidence', `unsupported qualification artifact: ${artifact.name}`),
+            ).pipe(
+              Effect.map((itemCount) => ({
+                name: artifact.name,
+                schemaVersion: artifact.schemaVersion,
+                itemCount,
+                contentHash: artifact.contentHash,
+              })),
+            ),
+        )
         const expectedArtifactManifest = {
           schemaVersion: 'bayn.qualification-artifact-manifest.v1',
           identity: {
@@ -1661,15 +1715,7 @@ const makeEvidenceStore = Effect.gen(function* () {
             executionModel: orders.executionModel,
             costMultiplierMicros: orders.costMultiplierMicros,
           },
-          artifacts: stored.artifacts
-            .filter((artifact) => artifact.name !== 'qualification-artifact-manifest')
-            .sort((left, right) => left.name.localeCompare(right.name))
-            .map((artifact) => ({
-              name: artifact.name,
-              schemaVersion: artifact.schemaVersion,
-              itemCount: artifactItemCounts.get(artifact.name) ?? 0,
-              contentHash: artifact.contentHash,
-            })),
+          artifacts: manifestArtifacts,
           events: {
             count: stored.events.length,
             contentHash: canonicalHashV1(
@@ -2017,7 +2063,33 @@ export const PostgresClientLive = (config: Pick<RuntimeConfig, 'operationTimeout
   )
 }
 
-const migrate = PgMigrator.run({ loader: migrationLoader, table: 'schema_migrations' })
+const migrate = Effect.gen(function* () {
+  const sql = yield* PgClient.PgClient
+  const [boundary] = yield* decodeMigrationBoundary(
+    yield* sql`
+      SELECT
+        to_regclass('public.schema_migrations') IS NOT NULL AS current_exists,
+        to_regclass('public.bayn_schema_migrations') IS NOT NULL AS legacy_exists
+    `,
+  )
+  if (boundary.legacy_exists) {
+    return yield* Effect.fail(
+      databaseError('migration', 'migrate', 'legacy migration tracker is unsupported after the hard cut'),
+    )
+  }
+  if (boundary.current_exists) {
+    const identities = yield* decodeMigrationIdentities(
+      yield* sql`SELECT migration_id, name FROM schema_migrations WHERE migration_id = 1`,
+    )
+    const [initial] = identities
+    if (identities.length !== 1 || initial?.name !== 'initial_schema') {
+      return yield* Effect.fail(
+        databaseError('migration', 'migrate', 'legacy migration history is unsupported after the hard cut'),
+      )
+    }
+  }
+  yield* PgMigrator.run({ loader: migrationLoader, table: 'schema_migrations' })
+})
 
 const migrations = migrate.pipe(
   Effect.mapError((cause) =>

--- a/services/bayn/src/evidence-contracts.ts
+++ b/services/bayn/src/evidence-contracts.ts
@@ -211,9 +211,14 @@ const CashYieldEventSchema = Schema.Struct({
   amountMicros: Micros,
 })
 
-export const EvaluationEventsSchema = Schema.Array(
-  Schema.Union([DecisionEventSchema, FillEventSchema, FeeEventSchema, CashYieldEventSchema]),
-)
+export const EvaluationEventSchema = Schema.Union([
+  DecisionEventSchema,
+  FillEventSchema,
+  FeeEventSchema,
+  CashYieldEventSchema,
+])
+
+export const EvaluationEventsSchema = Schema.Array(EvaluationEventSchema)
 
 export const SimulatedOrdersArtifactSchema = Schema.Struct({
   schemaVersion: Schema.Literal('bayn.simulated-orders.v2'),

--- a/services/bayn/src/hash.test.ts
+++ b/services/bayn/src/hash.test.ts
@@ -1,13 +1,8 @@
 import { describe, expect, test } from 'bun:test'
 
-import { canonicalHashV1, canonicalJson, canonicalJsonV1, hashObject, stableU128, stableU64 } from './hash'
+import { canonicalHashV1, canonicalJsonV1, stableU128, stableU64 } from './hash'
 
 describe('canonical hashing', () => {
-  test('does not depend on object insertion order', () => {
-    expect(canonicalJson({ z: 1, a: { y: 2, x: 3 } })).toBe(canonicalJson({ a: { x: 3, y: 2 }, z: 1 }))
-    expect(hashObject({ b: 2, a: 1 })).toBe(hashObject({ a: 1, b: 2 }))
-  })
-
   test('uses deterministic UTF-16 key order and normalizes negative zero', () => {
     expect(canonicalJsonV1({ '\u20ac': 1, '\r': 2, a: -0, '\ud83d\ude00': 3 })).toBe('{"\\r":2,"a":0,"€":1,"😀":3}')
     expect(canonicalJsonV1({ nested: { '2': 2, '10': 1 } })).toBe('{"nested":{"10":1,"2":2}}')

--- a/services/bayn/src/hash.ts
+++ b/services/bayn/src/hash.ts
@@ -1,24 +1,6 @@
 import { createHash } from 'node:crypto'
 
-const canonicalizeLegacyValue = (value: unknown): unknown => {
-  if (Array.isArray(value)) {
-    return value.map(canonicalizeLegacyValue)
-  }
-  if (value !== null && typeof value === 'object') {
-    return Object.fromEntries(
-      Object.entries(value as Record<string, unknown>)
-        .sort(([left], [right]) => left.localeCompare(right))
-        .map(([key, nested]) => [key, canonicalizeLegacyValue(nested)]),
-    )
-  }
-  return value
-}
-
-export const canonicalJson = (value: unknown): string => JSON.stringify(canonicalizeLegacyValue(value))
-
 export const sha256 = (value: string): string => createHash('sha256').update(value).digest('hex')
-
-export const hashObject = (value: unknown): string => sha256(canonicalJson(value))
 
 const compareUtf16 = (left: string, right: string): number => (left < right ? -1 : left > right ? 1 : 0)
 

--- a/services/bayn/src/http.ts
+++ b/services/bayn/src/http.ts
@@ -6,12 +6,12 @@ import { HttpRouter, HttpServerRequest, HttpServerResponse } from 'effect/unstab
 
 import type { RuntimeBuildMetadata, RuntimeConfig } from './config'
 import type { RuntimeProvenance } from './contracts'
+import type { StoredEvaluationEvidence } from './db/evidence-store'
 import { isReady, type DependencyHealth, type RuntimeState } from './runtime-state'
 
-type ReadEvidence = (runId: string) => Effect.Effect<Option.Option<unknown>, { readonly message: string }>
-
-const json = (value: unknown): string =>
-  JSON.stringify(value, (_, nested) => (typeof nested === 'bigint' ? nested.toString() : nested))
+type ReadEvidence = (
+  runId: string,
+) => Effect.Effect<Option.Option<StoredEvaluationEvidence>, { readonly message: string }>
 
 const verifiedState = (state: RuntimeState, dependency: DependencyHealth) => {
   if (state.evidence === null || dependency.status === 'UNKNOWN') return 'UNKNOWN'
@@ -83,7 +83,7 @@ const publicState = (
 }
 
 const jsonResponse = (body: unknown, status = 200, headers?: Readonly<Record<string, string>>) =>
-  HttpServerResponse.text(json(body), { status, contentType: 'application/json', headers })
+  HttpServerResponse.json(body, { status, headers }).pipe(Effect.orDie)
 
 export const makeHttpLayer = (
   config: Pick<RuntimeConfig, 'host' | 'operationTimeoutMs' | 'port'>,
@@ -93,7 +93,7 @@ export const makeHttpLayer = (
   readEvidence: ReadEvidence,
 ): ReturnType<typeof NodeHttpServer.layer> => {
   const ready = Ref.get(state).pipe(
-    Effect.map((current) => {
+    Effect.flatMap((current) => {
       const ready = isReady(current)
       const failedDependencies = Object.entries(current.health.dependencies)
         .filter(([, dependency]) => dependency.status !== 'AVAILABLE')
@@ -111,19 +111,19 @@ export const makeHttpLayer = (
     }),
   )
   const status = Ref.get(state).pipe(
-    Effect.map((current) => jsonResponse(publicState(current, provenance, provenanceVerification))),
+    Effect.flatMap((current) => jsonResponse(publicState(current, provenance, provenanceVerification))),
   )
   const historicalEvaluation = HttpRouter.params.pipe(
     Effect.flatMap(({ runId }) => {
       if (runId === undefined || !/^[0-9a-f]{64}$/.test(runId)) {
-        return Effect.succeed(jsonResponse({ error: 'invalid_run_id' }, 400))
+        return jsonResponse({ error: 'invalid_run_id' }, 400)
       }
       return readEvidence(runId).pipe(
         Effect.timeoutOrElse({
           duration: config.operationTimeoutMs,
           orElse: () => Effect.fail(new Error(`evidence read timed out after ${config.operationTimeoutMs}ms`)),
         }),
-        Effect.map((stored) =>
+        Effect.flatMap((stored) =>
           Option.match(stored, {
             onNone: () => jsonResponse({ error: 'evaluation_not_found' }, 404),
             onSome: (evidence) => jsonResponse(evidence),
@@ -132,7 +132,7 @@ export const makeHttpLayer = (
         Effect.catch((error) =>
           Effect.logError('Bayn historical evidence read failed').pipe(
             Effect.annotateLogs({ service: 'bayn', runId, error: error.message }),
-            Effect.as(jsonResponse({ error: 'evidence_unavailable' }, 503)),
+            Effect.andThen(jsonResponse({ error: 'evidence_unavailable' }, 503)),
           ),
         ),
       )
@@ -141,20 +141,18 @@ export const makeHttpLayer = (
   const fallback = (
     request: HttpServerRequest.HttpServerRequest,
   ): Effect.Effect<HttpServerResponse.HttpServerResponse> =>
-    Effect.succeed(
-      request.method === 'GET'
-        ? jsonResponse({ error: 'not_found' }, 404)
-        : jsonResponse({ error: 'method_not_allowed' }, 405, { allow: 'GET' }),
-    )
-  const routes: Layer.Layer<never, never, HttpRouter.HttpRouter> = HttpRouter.addAll([
-    HttpRouter.route<never, never>('GET', '/livez', jsonResponse({ service: 'bayn', live: true })),
-    HttpRouter.route<never, never>('GET', '/readyz', ready),
-    HttpRouter.route<never, never>('GET', '/v1/status', status),
+    request.method === 'GET'
+      ? jsonResponse({ error: 'not_found' }, 404)
+      : jsonResponse({ error: 'method_not_allowed' }, 405, { allow: 'GET' })
+  const routes = HttpRouter.addAll([
+    HttpRouter.route('GET', '/livez', jsonResponse({ service: 'bayn', live: true })),
+    HttpRouter.route('GET', '/readyz', ready),
+    HttpRouter.route('GET', '/v1/status', status),
     HttpRouter.route('GET', '/v1/evaluations/:runId', historicalEvaluation),
-    HttpRouter.route<never, never>('*', '*', fallback),
+    HttpRouter.route('*', '*', fallback),
   ] as const)
 
   return HttpRouter.serve(routes, { disableLogger: true }).pipe(
-    Layer.provideMerge(NodeHttpServer.layer(() => createServer(), { host: config.host, port: config.port })),
+    Layer.provideMerge(NodeHttpServer.layer(createServer, { host: config.host, port: config.port })),
   )
 }

--- a/services/bayn/src/ledger.test.ts
+++ b/services/bayn/src/ledger.test.ts
@@ -1,13 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import { Effect, Redacted } from 'effect'
-import {
-  createClient as createTigerBeetleClient,
-  CreateAccountStatus,
-  CreateTransferStatus,
-  type Account,
-  type Client,
-  type Transfer,
-} from 'tigerbeetle-node'
+import { CreateAccountStatus, CreateTransferStatus, type Account, type Transfer } from 'tigerbeetle-node'
 
 import type { RuntimeConfig } from './config'
 import {
@@ -18,20 +11,26 @@ import {
   JournalLive,
   resolveReplicaAddresses,
   type JournalService,
+  type TigerBeetleClient,
 } from './ledger'
 import { evaluateRiskBalancedTrend } from './risk-balanced-trend'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
 
 const materializeAccounts = (plan: ReturnType<typeof buildLedgerPlan>): Account[] => {
   const balances = new Map(plan.accounts.map((account) => [account.id, { debits: 0n, credits: 0n }]))
+  const balance = (accountId: bigint) => {
+    const value = balances.get(accountId)
+    if (value === undefined) throw new Error(`ledger fixture has no account ${accountId}`)
+    return value
+  }
   for (const transfer of plan.transfers) {
-    balances.get(transfer.debit_account_id)!.debits += transfer.amount
-    balances.get(transfer.credit_account_id)!.credits += transfer.amount
+    balance(transfer.debit_account_id).debits += transfer.amount
+    balance(transfer.credit_account_id).credits += transfer.amount
   }
   return plan.accounts.map((account) => ({
     ...account,
-    debits_posted: balances.get(account.id)!.debits,
-    credits_posted: balances.get(account.id)!.credits,
+    debits_posted: balance(account.id).debits,
+    credits_posted: balance(account.id).credits,
     timestamp: 1n,
   }))
 }
@@ -44,10 +43,21 @@ const journalConfig = {
   tigerBeetle: { clusterId: 222397790944575595450310052784555675227n, replicaAddresses: ['3000'], ledger: 7_001 },
 } satisfies Pick<RuntimeConfig, 'operationTimeoutMs' | 'tigerBeetle'>
 
+const makeTigerBeetleClient = (overrides: Partial<TigerBeetleClient> = {}): TigerBeetleClient => ({
+  createAccounts: async () => [],
+  createTransfers: async () => [],
+  lookupAccounts: async () => [],
+  lookupTransfers: async () => [],
+  queryAccounts: async () => [],
+  queryTransfers: async () => [],
+  destroy: () => undefined,
+  ...overrides,
+})
+
 const makeLedgerClient = () => {
   const accounts = new Map<bigint, Account>()
   const transfers = new Map<bigint, Transfer>()
-  const client: Client = {
+  const client: TigerBeetleClient = {
     createAccounts: async (batch) =>
       batch.map((account) => {
         if (accounts.has(account.id)) return { timestamp: 1n, status: CreateAccountStatus.exists }
@@ -75,8 +85,6 @@ const makeLedgerClient = () => {
         const transfer = transfers.get(id)
         return transfer === undefined ? [] : [transfer]
       }),
-    getAccountTransfers: async () => [],
-    getAccountBalances: async () => [],
     queryAccounts: async (filter) =>
       [...accounts.values()]
         .filter(
@@ -98,14 +106,14 @@ const makeLedgerClient = () => {
   return { accounts, transfers, client }
 }
 
-const withJournal = <A, E>(client: Client, use: (journal: JournalService) => Effect.Effect<A, E>) =>
+const withJournal = <A, E>(client: TigerBeetleClient, use: (journal: JournalService) => Effect.Effect<A, E>) =>
   Effect.scoped(
     Effect.gen(function* () {
       return yield* use(yield* Journal)
     }).pipe(
       Effect.provide(
         JournalLive(journalConfig, {
-          createClient: (() => client) as unknown as typeof createTigerBeetleClient,
+          createClient: () => client,
           resolveReplicaAddresses: () => Effect.succeed(['3000']),
         }),
       ),
@@ -191,7 +199,7 @@ describe('TigerBeetle simulation journal', () => {
     let accounts = materializeAccounts(plan)
     const transfers = materializeTransfers(plan)
     let writes = 0
-    const client = {
+    const client = makeTigerBeetleClient({
       queryAccounts: async () => accounts,
       queryTransfers: async () => transfers,
       createAccounts: async () => {
@@ -203,7 +211,7 @@ describe('TigerBeetle simulation journal', () => {
         return []
       },
       destroy: () => undefined,
-    } as unknown as Client
+    })
     const config: RuntimeConfig = {
       host: '127.0.0.1',
       port: 0,
@@ -243,7 +251,7 @@ describe('TigerBeetle simulation journal', () => {
         }).pipe(
           Effect.provide(
             JournalLive(config, {
-              createClient: (() => client) as unknown as typeof createTigerBeetleClient,
+              createClient: () => client,
               resolveReplicaAddresses: () => Effect.succeed(['3000']),
             }),
           ),

--- a/services/bayn/src/ledger.ts
+++ b/services/bayn/src/ledger.ts
@@ -5,6 +5,7 @@ import {
   AccountFlags,
   type Account,
   type Client,
+  type ClientInitArgs,
   CreateAccountStatus,
   CreateTransferStatus,
   type QueryFilter,
@@ -15,7 +16,7 @@ import { Context, Effect, Layer, Option, ScopedRef, Semaphore } from 'effect'
 
 import type { RuntimeConfig } from './config'
 import { operationalError, type OperationalError } from './errors'
-import { canonicalHashV1, hashObject, stableU128, stableU64 } from './hash'
+import { canonicalHashV1, stableU128, stableU64 } from './hash'
 import type { CashYieldEvent, EvaluationEvent, FeeEvent, FillEvent, InputManifest, ReconciliationResult } from './types'
 
 const SCHEMA_VERSION = 2
@@ -233,7 +234,7 @@ const transfer = (
   credit_account_id: creditAccountId,
   amount,
   pending_id: 0n,
-  user_data_128: stableU128('bayn-event-v1', hashObject(event)),
+  user_data_128: stableU128('bayn-event-v1', canonicalHashV1(event)),
   user_data_64: runTag,
   user_data_32: SCHEMA_VERSION,
   timeout: 0,
@@ -492,7 +493,7 @@ export const assertReconciled = (
 interface LedgerClient {
   readonly request: <A>(
     operation: string,
-    execute: (client: Client) => Promise<A>,
+    execute: (client: TigerBeetleClient) => Promise<A>,
   ) => Effect.Effect<A, OperationalError>
 }
 
@@ -692,11 +693,22 @@ const journalAndReconcile = (
   })
 
 export interface JournalDependencies {
-  readonly createClient: typeof createClient
+  readonly createClient: (options: ClientInitArgs) => TigerBeetleClient
   readonly resolveReplicaAddresses: (
     configuredAddresses: readonly string[],
   ) => Effect.Effect<string[], OperationalError>
 }
+
+export type TigerBeetleClient = Pick<
+  Client,
+  | 'createAccounts'
+  | 'createTransfers'
+  | 'lookupAccounts'
+  | 'lookupTransfers'
+  | 'queryAccounts'
+  | 'queryTransfers'
+  | 'destroy'
+>
 
 const defaultDependencies: JournalDependencies = { createClient, resolveReplicaAddresses }
 
@@ -744,57 +756,61 @@ export const JournalLive = (
           ),
       )
       const clients = yield* ScopedRef.fromAcquire(acquireClient.pipe(Effect.map(Option.some)))
-      const semaphore = yield* Semaphore.make(1)
+      const clientState = yield* Semaphore.make(1)
       const installClient = ScopedRef.set(clients, acquireClient.pipe(Effect.map(Option.some)))
-      const refresh = (trigger: string): Effect.Effect<void> =>
-        ScopedRef.set(clients, Effect.succeed(Option.none<Client>())).pipe(
-          Effect.andThen(
-            installClient.pipe(
-              Effect.tap(() => Effect.logInfo('TigerBeetle client refreshed').pipe(Effect.annotateLogs({ trigger }))),
-              Effect.catch((error) =>
-                Effect.logWarning('TigerBeetle client refresh failed').pipe(
-                  Effect.annotateLogs({
-                    trigger,
-                    component: error.component,
-                    operation: error.operation,
-                    error: error.message,
-                  }),
-                ),
-              ),
-            ),
-          ),
-        )
+      const getInstalledClient = ScopedRef.get(clients).pipe(
+        Effect.flatMap(
+          Option.match({
+            onSome: Effect.succeed,
+            onNone: () => Effect.fail(operationalError('journal', 'connect', 'TigerBeetle client is unavailable')),
+          }),
+        ),
+      )
       const getClient = ScopedRef.get(clients).pipe(
         Effect.flatMap(
           Option.match({
             onSome: Effect.succeed,
             onNone: () =>
-              installClient.pipe(
-                Effect.andThen(ScopedRef.get(clients)),
-                Effect.flatMap(
-                  Option.match({
-                    onSome: Effect.succeed,
-                    onNone: () =>
-                      Effect.fail(
-                        operationalError('journal', 'connect', 'TigerBeetle client unavailable after refresh'),
-                      ),
-                  }),
+              clientState.withPermit(
+                ScopedRef.get(clients).pipe(
+                  Effect.flatMap(
+                    Option.match({
+                      onSome: Effect.succeed,
+                      onNone: () => installClient.pipe(Effect.andThen(getInstalledClient)),
+                    }),
+                  ),
                 ),
               ),
           }),
         ),
       )
+      const invalidateClient = (active: TigerBeetleClient, trigger: string): Effect.Effect<void> =>
+        clientState
+          .withPermitsIfAvailable(1)(
+            ScopedRef.get(clients).pipe(
+              Effect.flatMap((current) =>
+                Option.isSome(current) && current.value === active
+                  ? ScopedRef.set(clients, Effect.succeed(Option.none<TigerBeetleClient>())).pipe(
+                      Effect.andThen(
+                        Effect.logWarning('TigerBeetle client invalidated').pipe(Effect.annotateLogs({ trigger })),
+                      ),
+                    )
+                  : Effect.void,
+              ),
+            ),
+          )
+          .pipe(Effect.asVoid)
       const client: LedgerClient = {
-        request: <A>(operation: string, execute: (active: Client) => Promise<A>) =>
-          semaphore.withPermit(
-            getClient.pipe(
-              Effect.flatMap((active) =>
-                Effect.tryPromise({
-                  try: () => execute(active),
-                  catch: (cause) => operationalError('journal', operation, `TigerBeetle ${operation} failed`, cause),
-                }).pipe(
-                  Effect.onInterrupt(() => refresh(`interrupted:${operation}`)),
-                  Effect.catch((error) => refresh(`failed:${operation}`).pipe(Effect.andThen(Effect.fail(error)))),
+        request: <A>(operation: string, execute: (active: TigerBeetleClient) => Promise<A>) =>
+          getClient.pipe(
+            Effect.flatMap((active) =>
+              Effect.tryPromise({
+                try: () => execute(active),
+                catch: (cause) => operationalError('journal', operation, `TigerBeetle ${operation} failed`, cause),
+              }).pipe(
+                Effect.onInterrupt(() => invalidateClient(active, `interrupted:${operation}`)),
+                Effect.catch((error) =>
+                  invalidateClient(active, `failed:${operation}`).pipe(Effect.andThen(Effect.fail(error))),
                 ),
               ),
             ),

--- a/services/bayn/src/market-data.ts
+++ b/services/bayn/src/market-data.ts
@@ -341,7 +341,9 @@ const verifyCalendar = (
 ): VerifiedCalendar => {
   const verifiedManifest = verifyManifest(manifests, request)
   const { finalizedSnapshot, manifest, universe } = verifiedManifest
-  const orderedSessions = [...sessions].sort((left, right) => left.session_date.localeCompare(right.session_date))
+  const orderedSessions = [...sessions].sort((left, right) =>
+    left.session_date < right.session_date ? -1 : left.session_date > right.session_date ? 1 : 0,
+  )
   const sessionDates = new Set<string>()
   for (const session of orderedSessions) {
     if (session.snapshot_id !== request.snapshotId) throw new Error('exchange session has a mixed snapshot ID')
@@ -419,8 +421,14 @@ export const verifyFinalizedSnapshot = (rows: SnapshotRows, request: SnapshotReq
   const sessionDates = new Set(calendar.orderedSessions.map((session) => session.session_date))
   const orderedBars = [...rows.bars].sort((left, right) =>
     left.session_date === right.session_date
-      ? left.symbol.localeCompare(right.symbol)
-      : left.session_date.localeCompare(right.session_date),
+      ? left.symbol < right.symbol
+        ? -1
+        : 1
+      : left.session_date < right.session_date
+        ? -1
+        : left.session_date > right.session_date
+          ? 1
+          : 0,
   )
   const barKeys = new Set<string>()
   const actualSymbols = new Set<string>()
@@ -470,14 +478,14 @@ const decodeSnapshotRows = (
   sessions: readonly unknown[],
   manifests: readonly unknown[],
 ): SnapshotRows => ({
-  bars: decodeBars(bars) as readonly SignalBarRow[],
-  sessions: decodeSessions(sessions) as readonly SignalSessionRow[],
+  bars: decodeBars(bars),
+  sessions: decodeSessions(sessions),
   manifests: decodeManifests(manifests).map((manifest) => ({
     ...manifest,
     symbol_count: asCount(manifest.symbol_count, 'symbol_count'),
     session_count: asCount(manifest.session_count, 'session_count'),
     bar_count: asCount(manifest.bar_count, 'bar_count'),
-  })) as readonly SignalManifestRow[],
+  })),
 })
 
 const makeMarketData = (

--- a/services/bayn/src/protocol.test.ts
+++ b/services/bayn/src/protocol.test.ts
@@ -86,7 +86,7 @@ describe('strategy protocol', () => {
     ] as const
 
     for (const path of requiredPaths) {
-      const document = structuredClone(defaultProtocolDocument) as unknown as Record<string, unknown>
+      const document: Record<string, unknown> = structuredClone(defaultProtocolDocument)
       let parent = document.executionModel as Record<string, unknown>
       for (const segment of path.slice(0, -1)) parent = parent[segment] as Record<string, unknown>
       const key = path.at(-1)

--- a/services/bayn/src/qualification-audit-command.ts
+++ b/services/bayn/src/qualification-audit-command.ts
@@ -1,12 +1,13 @@
 import { NodeHttpClient, NodeRuntime, NodeServices } from '@effect/platform-node'
 import { ClickhouseClient } from '@effect/sql-clickhouse'
 import { PgClient } from '@effect/sql-pg'
-import { Cause, Config, Effect, FileSystem, Layer, Logger, Redacted, Schema, Stdio, Stream } from 'effect'
+import { Config, Effect, FileSystem, Layer, Logger, Redacted, Schema, Stdio, Stream } from 'effect'
 import { ChildProcess, ChildProcessSpawner } from 'effect/unstable/process'
 
-import { decodeInputManifestArtifact } from './evidence-contracts'
+import { EvaluationEventSchema, decodeInputManifestArtifact } from './evidence-contracts'
 import { MarketData, MarketDataLive } from './market-data'
 import { ProtocolSchema } from './protocol'
+import { QualificationLockSchema, QualificationResultSchema } from './qualification'
 import {
   auditQualification,
   type AuditDatabaseSnapshot,
@@ -21,50 +22,68 @@ const Sha256 = Schema.String.check(Schema.isPattern(/^[0-9a-f]{64}$/))
 const PositiveInteger = Schema.Int.check(Schema.isGreaterThan(0))
 const NonNegativeInteger = Schema.Int.check(Schema.isGreaterThanOrEqualTo(0))
 const IsoInstant = Schema.String.check(Schema.isPattern(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z$/))
-const ReplicaName = Schema.Trim.check(Schema.isMinLength(1))
+const NonEmptyString = Schema.Trim.check(Schema.isMinLength(1))
+const ReplicaName = NonEmptyString
+const GateScalar = Schema.Union([Schema.Finite, Schema.Boolean, Schema.String])
 const AuditClickhouseUrls = Config.Array(Schema.URLFromString).check(Schema.isMinLength(2), Schema.isUnique())
 
 const RunRow = Schema.Struct({
   run_id: Sha256,
   protocol_hash: Sha256,
   snapshot_id: Sha256,
-  evaluation_schema_version: Schema.String,
-  source_revision: Schema.String,
-  image_repository: Schema.String,
-  image_digest: Schema.String,
-  strategy_name: Schema.String,
+  evaluation_schema_version: NonEmptyString,
+  source_revision: NonEmptyString,
+  image_repository: NonEmptyString,
+  image_digest: NonEmptyString,
+  strategy_name: Schema.Literal('risk-balanced-trend'),
   initial_capital_micros: Schema.String,
-  status: Schema.String,
+  status: Schema.Literal('COMPLETE'),
   artifact_count: PositiveInteger,
   event_count: NonNegativeInteger,
   gate_count: PositiveInteger,
-  schema_version: Schema.String,
+  schema_version: NonEmptyString,
   behavior_hash: Sha256,
   parameter_hash: Sha256,
-  parameters: Schema.Unknown,
+  parameters: ProtocolSchema,
 })
 const ArtifactRow = Schema.Struct({
-  artifact_name: Schema.String,
-  schema_version: Schema.String,
+  artifact_name: NonEmptyString,
+  schema_version: NonEmptyString,
   content_hash: Sha256,
-  payload: Schema.Unknown,
+  payload: Schema.Json,
 })
 const EventRow = Schema.Struct({
   ordinal: NonNegativeInteger,
   event_id: Sha256,
-  event_kind: Schema.String,
+  event_kind: Schema.Literals(['decision', 'fill', 'fee', 'cash-yield']),
   content_hash: Sha256,
-  payload: Schema.Unknown,
+  payload: EvaluationEventSchema,
 })
 const GateRow = Schema.Struct({
   ordinal: NonNegativeInteger,
-  gate_name: Schema.String,
+  gate_name: NonEmptyString,
   passed: Schema.Boolean,
-  actual: Schema.Unknown,
-  required: Schema.Unknown,
+  actual: GateScalar,
+  required: GateScalar,
   content_hash: Sha256,
 })
-const StatusRow = Schema.Struct({ status: Schema.String, detail: Schema.Unknown })
+const StatusRow = Schema.Union([
+  Schema.Struct({
+    status: Schema.Literal('WRITING'),
+    detail: Schema.Struct({
+      artifactCount: PositiveInteger,
+      eventCount: NonNegativeInteger,
+      gateCount: PositiveInteger,
+    }),
+  }),
+  Schema.Struct({
+    status: Schema.Literal('COMPLETE'),
+    detail: Schema.Struct({
+      reconciliationExact: Schema.Literal(true),
+      verdict: Schema.Literals(['PASS', 'FAIL_CLOSED']),
+    }),
+  }),
+])
 const TrialRow = Schema.Struct({ run_id: Sha256 })
 const QualificationRow = Schema.Struct({
   lock_created_at: IsoInstant,
@@ -73,34 +92,31 @@ const QualificationRow = Schema.Struct({
   analysis_hash: Sha256,
   result_hash: Sha256,
   verdict: Schema.Literals(['QUALIFIED', 'REJECTED']),
-  lock_payload: Schema.Unknown,
-  result_payload: Schema.Unknown,
+  lock_payload: QualificationLockSchema,
+  result_payload: QualificationResultSchema,
 })
 const ReadOnlyRow = Schema.Struct({ read_only: Schema.Boolean })
 const AccessRow = Schema.Struct({
   replica: ReplicaName,
-  query_id: Schema.String,
+  query_id: NonEmptyString,
   query_start_time: IsoInstant,
-  user: Schema.String,
+  user: NonEmptyString,
   kind: Schema.Literals(['manifest', 'sessions', 'bars']),
 })
 const ReplicaRow = Schema.Struct({ replica: ReplicaName })
 
-const decodeRunRows = Schema.decodeUnknownSync(Schema.Array(RunRow), StrictParseOptions)
-const decodeArtifactRows = Schema.decodeUnknownSync(Schema.Array(ArtifactRow), StrictParseOptions)
-const decodeEventRows = Schema.decodeUnknownSync(Schema.Array(EventRow), StrictParseOptions)
-const decodeGateRows = Schema.decodeUnknownSync(Schema.Array(GateRow), StrictParseOptions)
-const decodeStatusRows = Schema.decodeUnknownSync(Schema.Array(StatusRow), StrictParseOptions)
-const decodeTrialRows = Schema.decodeUnknownSync(Schema.Array(TrialRow), StrictParseOptions)
-const decodeQualificationRows = Schema.decodeUnknownSync(Schema.Array(QualificationRow), StrictParseOptions)
-const decodeReadOnlyRows = Schema.decodeUnknownSync(Schema.Array(ReadOnlyRow), StrictParseOptions)
-const decodeAccessRows = Schema.decodeUnknownSync(Schema.Array(AccessRow), StrictParseOptions)
-const decodeReplicaRows = Schema.decodeUnknownSync(Schema.Array(ReplicaRow), StrictParseOptions)
-
-const exactlyOne = <A>(values: readonly A[], name: string): A => {
-  if (values.length !== 1) throw new Error(`${name} returned ${values.length} rows; expected exactly one`)
-  return values[0]
-}
+const decodeRunRow = Schema.decodeUnknownEffect(Schema.Tuple([RunRow]), StrictParseOptions)
+const decodeArtifactRows = Schema.decodeUnknownEffect(Schema.Array(ArtifactRow), StrictParseOptions)
+const decodeEventRows = Schema.decodeUnknownEffect(Schema.Array(EventRow), StrictParseOptions)
+const decodeGateRows = Schema.decodeUnknownEffect(Schema.Array(GateRow), StrictParseOptions)
+const decodeStatusRows = Schema.decodeUnknownEffect(Schema.Array(StatusRow), StrictParseOptions)
+const decodeTrialRows = Schema.decodeUnknownEffect(Schema.Array(TrialRow), StrictParseOptions)
+const decodeQualificationRow = Schema.decodeUnknownEffect(Schema.Tuple([QualificationRow]), StrictParseOptions)
+const decodeReadOnlyRow = Schema.decodeUnknownEffect(Schema.Tuple([ReadOnlyRow]), StrictParseOptions)
+const decodeAccessRows = Schema.decodeUnknownEffect(Schema.Array(AccessRow), StrictParseOptions)
+const decodeReplicaRow = Schema.decodeUnknownEffect(Schema.Tuple([ReplicaRow]), StrictParseOptions)
+const decodeReplicaRows = Schema.decodeUnknownEffect(Schema.Array(ReplicaRow), StrictParseOptions)
+const encodeJson = Schema.encodeUnknownEffect(Schema.fromJsonString(Schema.Json))
 
 const config = Config.all({
   output: Config.schema(Schema.Literals(['audit', 'dossier']), 'BAYN_AUDIT_OUTPUT').pipe(Config.withDefault('audit')),
@@ -126,7 +142,9 @@ type AuditConfig = Config.Success<typeof config>
 const postgresLayer = (input: AuditConfig) => {
   const readCertificate = Effect.gen(function* () {
     if (!input.postgresTls) return undefined
-    if (input.postgresCaPath.length === 0) throw new Error('BAYN_AUDIT_POSTGRES_CA_PATH is required with TLS')
+    if (input.postgresCaPath.length === 0) {
+      return yield* Effect.fail(new Error('BAYN_AUDIT_POSTGRES_CA_PATH is required with TLS'))
+    }
     const fileSystem = yield* FileSystem.FileSystem
     return yield* fileSystem.readFileString(input.postgresCaPath)
   })
@@ -150,19 +168,16 @@ const postgresLayer = (input: AuditConfig) => {
   )
 }
 
-const readDatabase = (runId: string): Effect.Effect<AuditDatabaseSnapshot, unknown, PgClient.PgClient> =>
-  Effect.gen(function* () {
-    const sql = yield* PgClient.PgClient
-    return yield* sql.withTransaction(
-      Effect.gen(function* () {
-        yield* sql`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY`
-        const readOnly = exactlyOne(
-          decodeReadOnlyRows(yield* sql`SELECT current_setting('transaction_read_only') = 'on' AS read_only`),
-          'transaction mode',
-        )
-        const run = exactlyOne(
-          decodeRunRows(
-            yield* sql`
+const readDatabase = Effect.fnUntraced(function* (runId: string) {
+  const sql = yield* PgClient.PgClient
+  return yield* sql.withTransaction(
+    Effect.gen(function* () {
+      yield* sql`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY`
+      const [readOnly] = yield* decodeReadOnlyRow(
+        yield* sql`SELECT current_setting('transaction_read_only') = 'on' AS read_only`,
+      )
+      const [run] = yield* decodeRunRow(
+        yield* sql`
               SELECT
                 run.run_id,
                 run.protocol_hash,
@@ -185,43 +200,41 @@ const readDatabase = (runId: string): Effect.Effect<AuditDatabaseSnapshot, unkno
               JOIN protocol_locks AS protocol USING (protocol_hash)
               WHERE run.run_id = ${runId}
             `,
-          ),
-          'evaluation run',
-        )
-        const artifacts = decodeArtifactRows(
-          yield* sql`
+      )
+      const artifacts = yield* decodeArtifactRows(
+        yield* sql`
             SELECT artifact_name, schema_version, content_hash, payload
             FROM evaluation_artifacts
             WHERE run_id = ${runId}
             ORDER BY artifact_name
           `,
-        )
-        const events = decodeEventRows(
-          yield* sql`
+      )
+      const events = yield* decodeEventRows(
+        yield* sql`
             SELECT ordinal, event_id, event_kind, content_hash, payload
             FROM evaluation_events
             WHERE run_id = ${runId}
             ORDER BY ordinal
           `,
-        )
-        const gates = decodeGateRows(
-          yield* sql`
+      )
+      const gates = yield* decodeGateRows(
+        yield* sql`
             SELECT ordinal, gate_name, passed, actual, required, content_hash
             FROM gate_outcomes
             WHERE run_id = ${runId}
             ORDER BY ordinal
           `,
-        )
-        const statuses = decodeStatusRows(
-          yield* sql`
+      )
+      const statuses = yield* decodeStatusRows(
+        yield* sql`
             SELECT status, detail
             FROM status_history
             WHERE run_id = ${runId}
             ORDER BY sequence
           `,
-        )
-        const trials = decodeTrialRows(
-          yield* sql`
+      )
+      const trials = yield* decodeTrialRows(
+        yield* sql`
             SELECT run_id
             FROM qualification_trials
             WHERE observed_at < (
@@ -229,10 +242,9 @@ const readDatabase = (runId: string): Effect.Effect<AuditDatabaseSnapshot, unkno
             )
             ORDER BY run_id
           `,
-        )
-        const qualification = exactlyOne(
-          decodeQualificationRows(
-            yield* sql`
+      )
+      const [qualification] = yield* decodeQualificationRow(
+        yield* sql`
               SELECT
                 to_char(lock.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"') AS lock_created_at,
                 to_char(result.committed_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"') AS result_committed_at,
@@ -246,71 +258,69 @@ const readDatabase = (runId: string): Effect.Effect<AuditDatabaseSnapshot, unkno
               JOIN qualification_results AS result USING (lock_id)
               WHERE lock.candidate_run_id = ${runId}
             `,
-          ),
-          'terminal qualification',
-        )
-        return {
-          transactionReadOnly: readOnly.read_only,
-          protocol: {
-            protocolHash: run.protocol_hash,
-            schemaVersion: run.schema_version,
-            strategyName: run.strategy_name,
-            behaviorHash: run.behavior_hash,
-            parameterHash: run.parameter_hash,
-            parameters: run.parameters,
-          },
-          run: {
-            runId: run.run_id,
-            protocolHash: run.protocol_hash,
-            snapshotId: run.snapshot_id,
-            evaluationSchemaVersion: run.evaluation_schema_version,
-            sourceRevision: run.source_revision,
-            imageRepository: run.image_repository,
-            imageDigest: run.image_digest,
-            strategyName: run.strategy_name,
-            initialCapitalMicros: run.initial_capital_micros,
-            status: run.status,
-            artifactCount: run.artifact_count,
-            eventCount: run.event_count,
-            gateCount: run.gate_count,
-          },
-          artifacts: artifacts.map((row) => ({
-            name: row.artifact_name,
-            schemaVersion: row.schema_version,
-            contentHash: row.content_hash,
-            payload: row.payload,
-          })),
-          events: events.map((row) => ({
-            ordinal: row.ordinal,
-            id: row.event_id,
-            kind: row.event_kind,
-            contentHash: row.content_hash,
-            payload: row.payload,
-          })),
-          gates: gates.map((row) => ({
-            ordinal: row.ordinal,
-            name: row.gate_name,
-            passed: row.passed,
-            actual: row.actual,
-            required: row.required,
-            contentHash: row.content_hash,
-          })),
-          statuses,
-          priorTrialRunIds: trials.map((row) => row.run_id),
-          qualification: {
-            lockCreatedAt: qualification.lock_created_at,
-            resultCommittedAt: qualification.result_committed_at,
-            storedLockId: qualification.lock_id,
-            storedAnalysisHash: qualification.analysis_hash,
-            storedResultHash: qualification.result_hash,
-            storedVerdict: qualification.verdict,
-            lock: qualification.lock_payload,
-            result: qualification.result_payload,
-          },
-        }
-      }),
-    )
-  })
+      )
+      return {
+        transactionReadOnly: readOnly.read_only,
+        protocol: {
+          protocolHash: run.protocol_hash,
+          schemaVersion: run.schema_version,
+          strategyName: run.strategy_name,
+          behaviorHash: run.behavior_hash,
+          parameterHash: run.parameter_hash,
+          parameters: run.parameters,
+        },
+        run: {
+          runId: run.run_id,
+          protocolHash: run.protocol_hash,
+          snapshotId: run.snapshot_id,
+          evaluationSchemaVersion: run.evaluation_schema_version,
+          sourceRevision: run.source_revision,
+          imageRepository: run.image_repository,
+          imageDigest: run.image_digest,
+          strategyName: run.strategy_name,
+          initialCapitalMicros: run.initial_capital_micros,
+          status: run.status,
+          artifactCount: run.artifact_count,
+          eventCount: run.event_count,
+          gateCount: run.gate_count,
+        },
+        artifacts: artifacts.map((row) => ({
+          name: row.artifact_name,
+          schemaVersion: row.schema_version,
+          contentHash: row.content_hash,
+          payload: row.payload,
+        })),
+        events: events.map((row) => ({
+          ordinal: row.ordinal,
+          id: row.event_id,
+          kind: row.event_kind,
+          contentHash: row.content_hash,
+          payload: row.payload,
+        })),
+        gates: gates.map((row) => ({
+          ordinal: row.ordinal,
+          name: row.gate_name,
+          passed: row.passed,
+          actual: row.actual,
+          required: row.required,
+          contentHash: row.content_hash,
+        })),
+        statuses,
+        priorTrialRunIds: trials.map((row) => row.run_id),
+        qualification: {
+          lockCreatedAt: qualification.lock_created_at,
+          resultCommittedAt: qualification.result_committed_at,
+          storedLockId: qualification.lock_id,
+          storedAnalysisHash: qualification.analysis_hash,
+          storedResultHash: qualification.result_hash,
+          storedVerdict: qualification.verdict,
+          lock: qualification.lock_payload,
+          result: qualification.result_payload,
+        },
+      } satisfies AuditDatabaseSnapshot
+    }),
+  )
+})
 
 const loadSignal = (input: AuditConfig, manifest: InputManifest, protocol: Protocol) => {
   const marketDataConfig = {
@@ -354,31 +364,28 @@ interface SignalReplicaAccess {
 const readSignalReplicaAccess = (
   input: AuditConfig,
   url: URL,
-  ordinal: number,
   database: AuditDatabaseSnapshot,
   finalizedAt: string,
   manifestTable: InputManifest['tables']['manifests'],
 ): Effect.Effect<SignalReplicaAccess, unknown> => {
   const program = Effect.gen(function* () {
     const sql = yield* ClickhouseClient.ClickhouseClient
-    const replica = exactlyOne(
-      decodeReplicaRows(
-        yield* sql`
+    const [replicaRow] = yield* decodeReplicaRow(
+      yield* sql`
           SELECT host_name AS replica
           FROM system.clusters
           WHERE cluster = 'default' AND is_local
         `,
-      ),
-      `ClickHouse audit endpoint ${ordinal}`,
-    ).replica
-    const topology = decodeReplicaRows(
+    )
+    const replica = replicaRow.replica
+    const topology = (yield* decodeReplicaRows(
       yield* sql`
         SELECT host_name AS replica
         FROM system.clusters
         WHERE cluster = 'default'
         ORDER BY shard_num, replica_num
       `,
-    ).map((row) => row.replica)
+    )).map((row) => row.replica)
     const rows = yield* sql`
       SELECT
         ${sql.param('String', replica)} AS replica,
@@ -408,7 +415,7 @@ const readSignalReplicaAccess = (
     return {
       replica,
       topology,
-      access: decodeAccessRows(rows).map((row) => ({
+      access: (yield* decodeAccessRows(rows)).map((row) => ({
         replica: row.replica,
         queryId: row.query_id,
         queryStartTime: row.query_start_time,
@@ -439,9 +446,7 @@ const readSignalAccess = (
   manifestTable: InputManifest['tables']['manifests'],
 ): Effect.Effect<{ readonly replicas: readonly string[]; readonly access: readonly SignalAccessRecord[] }, unknown> =>
   Effect.all(
-    input.auditClickhouseUrls.map((url, ordinal) =>
-      readSignalReplicaAccess(input, url, ordinal, database, finalizedAt, manifestTable),
-    ),
+    input.auditClickhouseUrls.map((url) => readSignalReplicaAccess(input, url, database, finalizedAt, manifestTable)),
     { concurrency: 'unbounded' },
   ).pipe(
     Effect.flatMap((sources) =>
@@ -509,15 +514,11 @@ const main = Effect.gen(function* () {
   const input = yield* config
   const database = yield* readDatabase(input.runId).pipe(Effect.provide(postgresLayer(input)))
   const inputManifestArtifact = database.artifacts.find((artifact) => artifact.name === 'input-manifest')
-  if (inputManifestArtifact === undefined) throw new Error('input-manifest artifact is missing')
+  if (inputManifestArtifact === undefined) {
+    return yield* Effect.fail(new Error('input-manifest artifact is missing'))
+  }
   const manifest = yield* decodeInputManifestArtifact(inputManifestArtifact.payload)
-  if (manifest.schemaVersion !== 'bayn.input-manifest.v3') {
-    throw new Error('qualification audit requires the current universe-bound input manifest')
-  }
-  const protocol = yield* Schema.decodeUnknownEffect(ProtocolSchema, StrictParseOptions)(database.protocol.parameters)
-  if (database.protocol.strategyName !== 'risk-balanced-trend' || database.run.strategyName !== 'risk-balanced-trend') {
-    throw new Error('stored strategy name does not match its protocol schema')
-  }
+  const protocol = database.protocol.parameters
   const signal = yield* loadSignal(input, manifest, protocol)
   const signalAccess = yield* readSignalAccess(
     input,
@@ -525,13 +526,12 @@ const main = Effect.gen(function* () {
     manifest.finalizedSnapshot.finalizedAt,
     manifest.tables.manifests,
   )
-  const result = database.qualification.result as Readonly<Record<string, unknown>>
-  const analysis = result.analysis as Readonly<Record<string, unknown>>
+  const result = database.qualification.result
   const repository = yield* repositoryAudit(
     input.repositoryPath,
     database.run.sourceRevision,
     database.qualification.lockCreatedAt,
-    [database.run.runId, String(result.resultHash), String(analysis.analysisHash)],
+    [database.run.runId, result.resultHash, result.analysis.analysisHash],
   )
   const auditInput = {
     bars: signal.bars,
@@ -543,24 +543,22 @@ const main = Effect.gen(function* () {
     signalPrincipals: { candidate: input.signalUsername, publishers: [input.signalPublisherUsername] },
     repository,
   }
-  const report = input.output === 'dossier' ? makeQualificationDossier(auditInput) : auditQualification(auditInput)
+  const report = yield* Effect.try({
+    try: () => (input.output === 'dossier' ? makeQualificationDossier(auditInput) : auditQualification(auditInput)),
+    catch: (cause) => cause,
+  })
+  const output = yield* encodeJson(report)
   const stdio = yield* Stdio.Stdio
-  yield* Stream.run(Stream.make(`${JSON.stringify(report)}\n`), stdio.stdout())
+  yield* Stream.run(Stream.make(`${output}\n`), stdio.stdout())
   if (input.output === 'audit' && 'status' in report && report.status !== 'PASS') {
     return yield* Effect.fail(new Error('qualification audit failed'))
   }
 })
 
 const program = main.pipe(
-  Effect.tapCause((cause) =>
-    Cause.hasInterruptsOnly(cause)
-      ? Effect.void
-      : Effect.logError('Bayn qualification audit failed').pipe(
-          Effect.annotateLogs({ service: 'bayn-qualification-audit', cause: Cause.pretty(cause) }),
-        ),
-  ),
+  Effect.annotateLogs({ service: 'bayn-qualification-audit' }),
   Effect.provide(Logger.layer([Logger.consoleJson])),
   Effect.provide(NodeServices.layer),
 )
 
-NodeRuntime.runMain(program, { disableErrorReporting: true })
+NodeRuntime.runMain(program)

--- a/services/bayn/src/qualification-audit.test.ts
+++ b/services/bayn/src/qualification-audit.test.ts
@@ -134,7 +134,7 @@ const fixture = (): QualificationAuditInput => {
       costMultiplierMicros: evaluation.simulation.costMultiplierMicros,
     },
     artifacts: [...base]
-      .sort((left, right) => left.name.localeCompare(right.name))
+      .sort((left, right) => (left.name < right.name ? -1 : left.name > right.name ? 1 : 0))
       .map((value) => ({
         name: value.name,
         schemaVersion: value.schemaVersion,
@@ -194,7 +194,7 @@ const fixture = (): QualificationAuditInput => {
       eventCount: events.length,
       gateCount: gates.length,
     },
-    artifacts: [...artifacts].sort((left, right) => left.name.localeCompare(right.name)),
+    artifacts: [...artifacts].sort((left, right) => (left.name < right.name ? -1 : left.name > right.name ? 1 : 0)),
     events,
     gates,
     statuses: [
@@ -401,26 +401,6 @@ describe('qualification audit', () => {
   })
 
   test.each([
-    [
-      'policy',
-      () => {
-        const input = fixture()
-        const lock = structuredClone(input.database.qualification.lock) as Record<string, unknown>
-        const policies = lock.policies as Record<string, Record<string, unknown>>
-        lock.policies = {
-          ...policies,
-          thresholds: { ...policies.thresholds, content: { schemaVersion: 'tampered' } },
-        }
-        return {
-          ...input,
-          database: {
-            ...input.database,
-            qualification: { ...input.database.qualification, lock },
-          },
-        }
-      },
-      'lock-policy-hashes',
-    ],
     [
       'trial-lineage',
       () => {

--- a/services/bayn/src/qualification-audit.ts
+++ b/services/bayn/src/qualification-audit.ts
@@ -1,8 +1,24 @@
+import { Schema } from 'effect'
+
+import { makeRuntimeProvenance } from './contracts'
+import { ReconciliationResultSchema } from './evidence-contracts'
 import { canonicalHashV1 } from './hash'
+import type { QualificationLock, QualificationResult } from './qualification'
 import { evaluateReference, type ReferenceEvaluation } from './qualification-reference'
 import { reconcileMarkedEquity } from './simulation-reconciliation'
-import { makeRuntimeProvenance } from './contracts'
-import { ContractVersion, type DailyBar, type InputManifest, type Protocol, type SimulationTrace } from './types'
+import {
+  ContractVersion,
+  type DailyBar,
+  type EconomicVerdict,
+  type EvaluationEvent,
+  type InputManifest,
+  type Protocol,
+  type SimulationTrace,
+} from './types'
+
+const StrictParseOptions = { onExcessProperty: 'error' } as const
+const decodeReconciliation = Schema.decodeUnknownSync(ReconciliationResultSchema, StrictParseOptions)
+type GateScalar = EconomicVerdict['gates'][number]['actual']
 
 export interface StoredArtifact {
   readonly name: string
@@ -14,17 +30,17 @@ export interface StoredArtifact {
 export interface StoredEvent {
   readonly ordinal: number
   readonly id: string
-  readonly kind: string
+  readonly kind: EvaluationEvent['kind']
   readonly contentHash: string
-  readonly payload: unknown
+  readonly payload: EvaluationEvent
 }
 
 export interface StoredGate {
   readonly ordinal: number
   readonly name: string
   readonly passed: boolean
-  readonly actual: unknown
-  readonly required: unknown
+  readonly actual: GateScalar
+  readonly required: GateScalar
   readonly contentHash: string
 }
 
@@ -36,7 +52,7 @@ export interface AuditDatabaseSnapshot {
     readonly strategyName: string
     readonly behaviorHash: string
     readonly parameterHash: string
-    readonly parameters: unknown
+    readonly parameters: Protocol
   }
   readonly run: {
     readonly runId: string
@@ -48,7 +64,7 @@ export interface AuditDatabaseSnapshot {
     readonly imageDigest: string
     readonly strategyName: string
     readonly initialCapitalMicros: string
-    readonly status: string
+    readonly status: 'COMPLETE'
     readonly artifactCount: number
     readonly eventCount: number
     readonly gateCount: number
@@ -56,7 +72,16 @@ export interface AuditDatabaseSnapshot {
   readonly artifacts: readonly StoredArtifact[]
   readonly events: readonly StoredEvent[]
   readonly gates: readonly StoredGate[]
-  readonly statuses: readonly { readonly status: string; readonly detail: unknown }[]
+  readonly statuses: readonly (
+    | {
+        readonly status: 'WRITING'
+        readonly detail: { readonly artifactCount: number; readonly eventCount: number; readonly gateCount: number }
+      }
+    | {
+        readonly status: 'COMPLETE'
+        readonly detail: { readonly reconciliationExact: true; readonly verdict: 'PASS' | 'FAIL_CLOSED' }
+      }
+  )[]
   readonly priorTrialRunIds: readonly string[]
   readonly qualification: {
     readonly lockCreatedAt: string
@@ -64,9 +89,9 @@ export interface AuditDatabaseSnapshot {
     readonly storedLockId: string
     readonly storedAnalysisHash: string
     readonly storedResultHash: string
-    readonly storedVerdict: string
-    readonly lock: unknown
-    readonly result: unknown
+    readonly storedVerdict: QualificationResult['verdict']
+    readonly lock: QualificationLock
+    readonly result: QualificationResult
   }
 }
 
@@ -145,32 +170,7 @@ export interface QualificationAuditReport {
   readonly auditHash: string
 }
 
-type JsonObject = Readonly<Record<string, unknown>>
-
-const object = (value: unknown, name: string): JsonObject => {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) throw new Error(`${name} must be an object`)
-  return value as JsonObject
-}
-
-const array = (value: unknown, name: string): readonly unknown[] => {
-  if (!Array.isArray(value)) throw new Error(`${name} must be an array`)
-  return value
-}
-
-const string = (value: unknown, name: string): string => {
-  if (typeof value !== 'string' || value.length === 0) throw new Error(`${name} must be a non-empty string`)
-  return value
-}
-
-const without = (value: JsonObject, key: string): JsonObject =>
-  Object.fromEntries(Object.entries(value).filter(([name]) => name !== key))
-
 const same = (left: unknown, right: unknown): boolean => canonicalHashV1(left) === canonicalHashV1(right)
-
-const itemCount = (payload: unknown): number => {
-  if (typeof payload !== 'object' || payload === null || !('items' in payload)) return 0
-  return Array.isArray(payload.items) ? payload.items.length : 0
-}
 
 const expectedResultReason = (gateName: string): string =>
   `EVALUATION_${gateName
@@ -234,10 +234,12 @@ export const auditQualification = (input: QualificationAuditInput): Qualificatio
   }
   const database = input.database
   const artifact = new Map(database.artifacts.map((value) => [value.name, value]))
-  const lock = object(database.qualification.lock, 'qualification lock')
-  const result = object(database.qualification.result, 'qualification result')
-  const lockId = string(lock.lockId, 'qualification lock ID')
-  const resultHash = string(result.resultHash, 'qualification result hash')
+  const lock = database.qualification.lock
+  const { lockId, ...lockMaterial } = lock
+  const result = database.qualification.result
+  const { resultHash, ...resultMaterial } = result
+  const analysis = result.analysis
+  const { analysisHash, ...analysisMaterial } = analysis
   if (
     database.protocol.strategyName !== contract.name ||
     database.run.strategyName !== contract.name ||
@@ -326,15 +328,13 @@ export const auditQualification = (input: QualificationAuditInput): Qualificatio
   )
   check(
     'event-hashes-and-order',
-    database.events.every((value, index) => {
-      const payload = object(value.payload, `event ${index}`)
-      return (
+    database.events.every(
+      (value, index) =>
         value.ordinal === index &&
-        value.id === payload.id &&
-        value.kind === payload.kind &&
-        canonicalHashV1(payload) === value.contentHash
-      )
-    }),
+        value.id === value.payload.id &&
+        value.kind === value.payload.kind &&
+        canonicalHashV1(value.payload) === value.contentHash,
+    ),
     `${database.events.length} events`,
   )
   check(
@@ -433,12 +433,35 @@ export const auditQualification = (input: QualificationAuditInput): Qualificatio
     `economicStatus=${reference.verdict.status}`,
   )
 
-  const reconciliation = object(artifact.get('reconciliation')?.payload, 'TigerBeetle reconciliation artifact')
+  const reconciliation = decodeReconciliation(artifact.get('reconciliation')?.payload)
   check(
     'accounting-reconciliation-identity',
     reconciliation.runId === database.run.runId && reconciliation.exact === true,
-    `runId=${String(reconciliation.runId)} exact=${String(reconciliation.exact)}`,
+    `runId=${reconciliation.runId} exact=${reconciliation.exact}`,
   )
+  const artifactItemCounts = new Map<string, number>([
+    ['evaluation-summary', 0],
+    ['input-manifest', 0],
+    ['strategy', 0],
+    ['buy-and-hold', 0],
+    ['direct-volatility-timing', 0],
+    ['double-cost-strategy', 0],
+    ['simulated-orders', reference.strategy.trace.orders.length],
+    ['cash-changes', reference.strategy.trace.cashChanges.length],
+    ['daily-position-marks', reference.strategy.trace.dailyMarks.length],
+    [contract.decisionArtifactName, reference.strategy.decisions.length],
+    ['buy-and-hold-series', reference.buyAndHold.daily.length],
+    ['direct-volatility-timing-series', reference.directVolTiming.daily.length],
+    ['double-cost-strategy-series', reference.doubleCostStrategy.daily.length],
+    ['equity-series', markedEquity.equitySeries.length],
+    ['marked-equity-reconciliation', 0],
+    ['reconciliation', 0],
+  ])
+  const artifactItemCount = (name: string): number => {
+    const count = artifactItemCounts.get(name)
+    if (count === undefined) throw new Error(`unsupported qualification artifact: ${name}`)
+    return count
+  }
   const baseArtifacts = database.artifacts.filter((value) => value.name !== 'qualification-artifact-manifest')
   const qualificationManifest = {
     schemaVersion: 'bayn.qualification-artifact-manifest.v1',
@@ -462,11 +485,11 @@ export const auditQualification = (input: QualificationAuditInput): Qualificatio
       costMultiplierMicros: MICROS_STRING,
     },
     artifacts: [...baseArtifacts]
-      .sort((left, right) => left.name.localeCompare(right.name))
+      .sort((left, right) => (left.name < right.name ? -1 : left.name > right.name ? 1 : 0))
       .map((value) => ({
         name: value.name,
         schemaVersion: value.schemaVersion,
-        itemCount: itemCount(value.payload),
+        itemCount: artifactItemCount(value.name),
         contentHash: value.contentHash,
       })),
     events: {
@@ -488,34 +511,29 @@ export const auditQualification = (input: QualificationAuditInput): Qualificatio
     `contentHash=${canonicalHashV1(qualificationManifest)}`,
   )
 
-  check('lock-hash', canonicalHashV1(without(lock, 'lockId')) === lockId, `lockId=${lockId}`)
+  check('lock-hash', canonicalHashV1(lockMaterial) === lockId, `lockId=${lockId}`)
   check(
     'qualification-row-binding',
     database.qualification.storedLockId === lockId &&
-      database.qualification.storedAnalysisHash ===
-        string(object(result.analysis, 'qualification analysis').analysisHash, 'analysis hash') &&
+      database.qualification.storedAnalysisHash === result.analysis.analysisHash &&
       database.qualification.storedResultHash === resultHash &&
       database.qualification.storedVerdict === result.verdict,
     `storedResultHash=${database.qualification.storedResultHash}`,
   )
-  const lockData = object(lock.data, 'qualification lock data')
+  const lockData = lock.data
   const lockContractBinding =
     lock.schemaVersion === 'bayn.qualification-lock.v3' &&
     lock.universeId === input.protocol.universeId &&
     lock.universeSymbolHash === input.protocol.universeSymbolHash &&
     lockData.inputManifestHash === input.manifest.hash
-  const lockPolicies = object(lock.policies, 'qualification lock policies')
-  const policyDocuments = Object.entries(lockPolicies)
-    .sort(([left], [right]) => left.localeCompare(right))
-    .map(([name, value]) => {
-      const policy = object(value, `qualification policy ${name}`)
-      return {
-        name,
-        schemaVersion: string(policy.schemaVersion, `qualification policy ${name} schema version`),
-        contentHash: string(policy.contentHash, `qualification policy ${name} content hash`),
-        content: policy.content,
-      }
-    })
+  const policyDocuments = (
+    [
+      ['benchmark', lock.policies.benchmark],
+      ['execution', lock.policies.execution],
+      ['thresholds', lock.policies.thresholds],
+      ['uncertainty', lock.policies.uncertainty],
+    ] as const
+  ).map(([name, policy]) => ({ name, ...policy }))
   check(
     'lock-candidate-binding',
     lock.candidateRunId === database.run.runId &&
@@ -551,26 +569,16 @@ export const auditQualification = (input: QualificationAuditInput): Qualificatio
     `${database.priorTrialRunIds.length} prior trials`,
   )
 
-  const analysis = object(result.analysis, 'qualification analysis')
-  const analysisHash = string(analysis.analysisHash, 'qualification analysis hash')
-  check(
-    'analysis-hash',
-    canonicalHashV1(without(analysis, 'analysisHash')) === analysisHash,
-    `analysisHash=${analysisHash}`,
-  )
-  check('result-hash', canonicalHashV1(without(result, 'resultHash')) === resultHash, `resultHash=${resultHash}`)
+  check('analysis-hash', canonicalHashV1(analysisMaterial) === analysisHash, `analysisHash=${analysisHash}`)
+  check('result-hash', canonicalHashV1(resultMaterial) === resultHash, `resultHash=${resultHash}`)
   const economicPass = reference.verdict.gates.every((gate) => gate.passed)
   const analysisPass = analysis.status === 'PASS'
   const expectedQualification = economicPass && analysisPass ? 'QUALIFIED' : 'REJECTED'
   const expectedEconomicReasons = reference.verdict.gates
     .filter((gate) => !gate.passed)
     .map((gate) => expectedResultReason(gate.name))
-  const reasonCodes = array(result.reasonCodes, 'qualification reason codes').map((value) =>
-    string(value, 'reason code'),
-  )
-  const analysisReasonCodes = array(analysis.reasonCodes, 'qualification analysis reason codes').map((value) =>
-    string(value, 'analysis reason code'),
-  )
+  const reasonCodes = result.reasonCodes
+  const analysisReasonCodes = analysis.reasonCodes
   const expectedReasonCodes = [...new Set([...expectedEconomicReasons, ...analysisReasonCodes])].sort()
   check(
     'analysis-lineage',
@@ -591,9 +599,9 @@ export const auditQualification = (input: QualificationAuditInput): Qualificatio
 
   const sortedReplicas = [...input.signalReplicas].sort()
   const sortedAccess = [...input.signalAccess].sort((left, right) => {
-    if (left.queryStartTime !== right.queryStartTime) return left.queryStartTime.localeCompare(right.queryStartTime)
-    if (left.replica !== right.replica) return left.replica.localeCompare(right.replica)
-    return left.queryId.localeCompare(right.queryId)
+    if (left.queryStartTime !== right.queryStartTime) return left.queryStartTime < right.queryStartTime ? -1 : 1
+    if (left.replica !== right.replica) return left.replica < right.replica ? -1 : 1
+    return left.queryId < right.queryId ? -1 : left.queryId > right.queryId ? 1 : 0
   })
   const candidateAccess = sortedAccess.filter((value) => value.user === input.signalPrincipals.candidate)
   const candidateBarReads = candidateAccess.filter((value) => value.kind === 'bars')

--- a/services/bayn/src/qualification-dossier.ts
+++ b/services/bayn/src/qualification-dossier.ts
@@ -31,7 +31,7 @@ const evidenceSummary = (database: AuditDatabaseSnapshot) => ({
       itemCount: itemCount(artifact.payload),
       contentHash: artifact.contentHash,
     }))
-    .sort((left, right) => left.name.localeCompare(right.name)),
+    .sort((left, right) => (left.name < right.name ? -1 : left.name > right.name ? 1 : 0)),
   events: {
     count: database.events.length,
     contentHash: canonicalHashV1(

--- a/services/bayn/src/qualification-reference.ts
+++ b/services/bayn/src/qualification-reference.ts
@@ -16,7 +16,7 @@ import {
   type FeeInput,
   type FillTerms,
 } from './execution-model'
-import { canonicalHashV1, hashObject } from './hash'
+import { canonicalHashV1 } from './hash'
 import type {
   CashChange,
   DailyBar,
@@ -99,7 +99,7 @@ const align = (bars: readonly DailyBar[], manifest: InputManifest, universe: rea
     grouped.set(bar.sessionDate, day)
   }
   const sessions = [...grouped.entries()]
-    .sort(([left], [right]) => left.localeCompare(right))
+    .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
     .map(([date, day]): Session => {
       if (day.size !== universe.length || universe.some((symbol) => !day.has(symbol))) {
         throw new Error(`reference input session ${date} is incomplete`)
@@ -436,7 +436,7 @@ const order = (
     rejectionReason: outcome.rejectionReason,
     unfilledRemainder: outcome.unfilledRemainder,
   }
-  return { id: hashObject({ runId, kind: 'order', ...material }), ...material }
+  return { id: canonicalHashV1({ runId, kind: 'order', ...material }), ...material }
 }
 
 const fill = (
@@ -460,7 +460,7 @@ const fill = (
     slippageCostMicros: terms.slippageCostMicros.toString(),
     costBasisMicros: costBasisMicros.toString(),
   }
-  return { kind: 'fill', id: hashObject({ runId, kind: 'fill', ...material }), ...material }
+  return { kind: 'fill', id: canonicalHashV1({ runId, kind: 'fill', ...material }), ...material }
 }
 
 const cashChange = (
@@ -478,7 +478,7 @@ const cashChange = (
     amountMicros: amountMicros.toString(),
     cashAfterMicros: cashAfterMicros.toString(),
   }
-  return { id: hashObject({ runId, kind: 'cash-change', ...material }), ...material }
+  return { id: canonicalHashV1({ runId, kind: 'cash-change', ...material }), ...material }
 }
 
 const replay = (
@@ -534,7 +534,7 @@ const replay = (
           }
           const event = {
             kind: 'cash-yield' as const,
-            id: hashObject({ runId, kind: 'cash-yield', ...material }),
+            id: canonicalHashV1({ runId, kind: 'cash-yield', ...material }),
             ...material,
           }
           events.push(event)
@@ -552,7 +552,7 @@ const replay = (
       }
       const decision: DecisionEvent = {
         kind: 'decision',
-        id: hashObject({ runId, kind: 'decision', ...decisionMaterial }),
+        id: canonicalHashV1({ runId, kind: 'decision', ...decisionMaterial }),
         ...decisionMaterial,
       }
       if (retainTrace) {
@@ -723,7 +723,7 @@ const replay = (
           }
           const event: FeeEvent = {
             kind: 'fee',
-            id: hashObject({ runId, kind: 'fee', ...material }),
+            id: canonicalHashV1({ runId, kind: 'fee', ...material }),
             ...material,
           }
           events.push(event)

--- a/services/bayn/src/resources.test.ts
+++ b/services/bayn/src/resources.test.ts
@@ -1,13 +1,12 @@
 import { describe, expect, test } from 'bun:test'
 
 import { Effect, Option, Redacted, Ref } from 'effect'
-import { createClient as createTigerBeetleClient, type Client } from 'tigerbeetle-node'
 
 import { initialize } from './app'
 import type { RuntimeConfig } from './config'
 import { EvidenceStore, type EvidenceStoreService } from './db/evidence-store'
 import { operationalError } from './errors'
-import { Journal, JournalLive, type JournalService } from './ledger'
+import { Journal, JournalLive, type JournalService, type TigerBeetleClient } from './ledger'
 import { MarketData, type MarketDataService } from './market-data'
 import { initialState } from './runtime-state'
 import { makeStrategy } from './strategy-service'
@@ -90,12 +89,23 @@ const successfulEvidenceStore: EvidenceStoreService = {
     }),
 }
 
+const makeTigerBeetleClient = (overrides: Partial<TigerBeetleClient> = {}): TigerBeetleClient => ({
+  createAccounts: async () => [],
+  createTransfers: async () => [],
+  lookupAccounts: async () => [],
+  lookupTransfers: async () => [],
+  queryAccounts: async () => [],
+  queryTransfers: async () => [],
+  destroy: () => undefined,
+  ...overrides,
+})
+
 describe('Bayn resource lifecycle', () => {
   test('closes the TigerBeetle client exactly once when its scope exits', async () => {
     let tigerBeetleCloseCount = 0
-    const tigerBeetleClient = {
+    const tigerBeetleClient = makeTigerBeetleClient({
       destroy: () => void (tigerBeetleCloseCount += 1),
-    } as unknown as Client
+    })
 
     await Effect.runPromise(
       Effect.scoped(
@@ -104,7 +114,7 @@ describe('Bayn resource lifecycle', () => {
         }).pipe(
           Effect.provide(
             JournalLive(config, {
-              createClient: (() => tigerBeetleClient) as unknown as typeof createTigerBeetleClient,
+              createClient: () => tigerBeetleClient,
               resolveReplicaAddresses: () => Effect.succeed(['3000']),
             }),
           ),
@@ -118,19 +128,19 @@ describe('Bayn resource lifecycle', () => {
   test('replaces a failed TigerBeetle client so the next probe recovers', async () => {
     const closeCounts = [0, 0]
     const clients = [
-      {
+      makeTigerBeetleClient({
         lookupAccounts: async () => {
           throw new Error('Client was closed.')
         },
         destroy: () => void (closeCounts[0] += 1),
-      },
-      {
+      }),
+      makeTigerBeetleClient({
         lookupAccounts: async () => [],
         destroy: () => void (closeCounts[1] += 1),
-      },
-    ] as unknown as Client[]
+      }),
+    ]
     let clientIndex = 0
-    const createClient = (): Client => {
+    const createClient = (): TigerBeetleClient => {
       const client = clients[clientIndex]
       if (client === undefined) throw new Error('unexpected TigerBeetle client acquisition')
       clientIndex += 1
@@ -147,7 +157,7 @@ describe('Bayn resource lifecycle', () => {
         }).pipe(
           Effect.provide(
             JournalLive(config, {
-              createClient: createClient as typeof createTigerBeetleClient,
+              createClient,
               resolveReplicaAddresses: () => Effect.succeed(['3000']),
             }),
           ),
@@ -160,10 +170,52 @@ describe('Bayn resource lifecycle', () => {
     expect(closeCounts).toEqual([1, 1])
   })
 
-  test('invalidates an interrupted TigerBeetle client when replacement acquisition fails', async () => {
+  test('runs independent TigerBeetle reconciliation reads concurrently', async () => {
+    const gate = Promise.withResolvers<void>()
+    let active = 0
+    let maximumConcurrency = 0
+    const query = async <A>(result: A): Promise<A> => {
+      active += 1
+      maximumConcurrency = Math.max(maximumConcurrency, active)
+      if (maximumConcurrency === 2) gate.resolve()
+      await gate.promise
+      active -= 1
+      return result
+    }
+    const client = makeTigerBeetleClient({
+      queryAccounts: () => query([]),
+      queryTransfers: () => query([]),
+      destroy: () => undefined,
+    })
+
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const journal = yield* Journal
+          yield* journal.checkRun({ runId: 'a'.repeat(64), accountCount: 0, transferCount: 0, exact: true }).pipe(
+            Effect.timeoutOrElse({
+              duration: 250,
+              orElse: () => Effect.fail(new Error('paired TigerBeetle queries were serialized')),
+            }),
+          )
+        }).pipe(
+          Effect.provide(
+            JournalLive(config, {
+              createClient: () => client,
+              resolveReplicaAddresses: () => Effect.succeed(['3000']),
+            }),
+          ),
+        ),
+      ),
+    )
+
+    expect(maximumConcurrency).toBe(2)
+  })
+
+  test('invalidates an interrupted TigerBeetle client and defers replacement to the next request', async () => {
     const closeCounts = [0, 0]
     let rejectLookup: ((cause: Error) => void) | undefined
-    const interruptedClient = {
+    const interruptedClient = makeTigerBeetleClient({
       lookupAccounts: () =>
         new Promise<never>((_, reject) => {
           rejectLookup = reject
@@ -172,30 +224,34 @@ describe('Bayn resource lifecycle', () => {
         closeCounts[0] += 1
         rejectLookup?.(new Error('client closed'))
       },
-    } as unknown as Client
-    const recoveredClient = {
+    })
+    const recoveredClient = makeTigerBeetleClient({
       lookupAccounts: async () => [],
       destroy: () => void (closeCounts[1] += 1),
-    } as unknown as Client
+    })
     let clientAcquisitions = 0
-    const createClient = (): Client => {
+    const createClient = (): TigerBeetleClient => {
       clientAcquisitions += 1
       if (clientAcquisitions === 1) return interruptedClient
       if (clientAcquisitions === 2) throw new Error('replacement unavailable')
       if (clientAcquisitions === 3) return recoveredClient
       throw new Error('unexpected TigerBeetle client acquisition')
     }
+    let acquisitionsAfterInterrupt = 0
 
-    await Effect.runPromise(
+    const replacementError = await Effect.runPromise(
       Effect.scoped(
         Effect.gen(function* () {
           const journal = yield* Journal
           yield* journal.check.pipe(Effect.timeout(5), Effect.ignore)
+          acquisitionsAfterInterrupt = clientAcquisitions
+          const error = yield* Effect.flip(journal.check)
           yield* journal.check
+          return error
         }).pipe(
           Effect.provide(
             JournalLive(config, {
-              createClient: createClient as typeof createTigerBeetleClient,
+              createClient,
               resolveReplicaAddresses: () => Effect.succeed(['3000']),
             }),
           ),
@@ -203,8 +259,10 @@ describe('Bayn resource lifecycle', () => {
       ),
     )
 
+    expect(acquisitionsAfterInterrupt).toBe(1)
     expect(clientAcquisitions).toBe(3)
     expect(closeCounts).toEqual([1, 1])
+    expect(replacementError.message).toContain('replacement unavailable')
   })
 
   test('interrupts an in-flight market-data read when the startup deadline expires', async () => {
@@ -258,7 +316,7 @@ describe('Bayn resource lifecycle', () => {
   test('destroys TigerBeetle to cancel its indefinite retry when the startup deadline expires', async () => {
     let destroyed = false
     let rejectLookup: ((cause: Error) => void) | undefined
-    const tigerBeetleClient = {
+    const tigerBeetleClient = makeTigerBeetleClient({
       lookupAccounts: () =>
         new Promise<never>((_, reject) => {
           rejectLookup = reject
@@ -268,7 +326,7 @@ describe('Bayn resource lifecycle', () => {
         destroyed = true
         rejectLookup?.(new Error('client closed'))
       },
-    } as unknown as Client
+    })
     const marketData = marketDataService(Effect.succeed(makeSnapshot()))
     const state = await Effect.runPromise(Ref.make(initialState()))
 
@@ -279,7 +337,7 @@ describe('Bayn resource lifecycle', () => {
           Effect.provideService(EvidenceStore, successfulEvidenceStore),
           Effect.provide(
             JournalLive(config, {
-              createClient: (() => tigerBeetleClient) as unknown as typeof createTigerBeetleClient,
+              createClient: () => tigerBeetleClient,
               resolveReplicaAddresses: () => Effect.succeed(['3000']),
             }),
           ),

--- a/services/bayn/src/simulation-reconciliation.test.ts
+++ b/services/bayn/src/simulation-reconciliation.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 
 import { MARKED_EQUITY_TOLERANCE_MICROS, reconcileMarkedEquity } from './simulation-reconciliation'
-import { hashObject } from './hash'
+import { canonicalHashV1 } from './hash'
 import { evaluateRiskBalancedTrend } from './risk-balanced-trend'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
 import type { EvaluationEvent, SimulationTrace } from './types'
@@ -93,7 +93,7 @@ describe('independent marked-equity reconciliation', () => {
       index === firstFillIndex
         ? {
             ...changedNotionalPayload,
-            id: hashObject({ runId: evaluation.runId, kind: 'fill', ...fillIdentityPayload }),
+            id: canonicalHashV1({ runId: evaluation.runId, kind: 'fill', ...fillIdentityPayload }),
           }
         : event,
     )
@@ -112,7 +112,7 @@ describe('independent marked-equity reconciliation', () => {
       index === firstFeeIndex
         ? {
             ...changedFeePayload,
-            id: hashObject({ runId: evaluation.runId, kind: 'fee', ...feeIdentityPayload }),
+            id: canonicalHashV1({ runId: evaluation.runId, kind: 'fee', ...feeIdentityPayload }),
           }
         : event,
     )

--- a/services/bayn/src/simulation-reconciliation.ts
+++ b/services/bayn/src/simulation-reconciliation.ts
@@ -1,5 +1,5 @@
 import { accrueCashYield, calculateSessionFees, makeFillTerms, notionalMicros, type FeeInput } from './execution-model'
-import { hashObject } from './hash'
+import { canonicalHashV1 } from './hash'
 import type {
   CashChange,
   CashYieldEvent,
@@ -45,7 +45,7 @@ const uniqueById = <A extends { readonly id: string }>(values: readonly A[], nam
 const validateDecisionIdentity = (runId: string, decision: DecisionEvent): void => {
   const { id: _, kind: __, ...payload } = decision
   ensure(
-    decision.id === hashObject({ runId, kind: 'decision', ...payload }),
+    decision.id === canonicalHashV1({ runId, kind: 'decision', ...payload }),
     `decision ${decision.id} has an invalid identity`,
   )
 }
@@ -77,7 +77,7 @@ const validateFill = (runId: string, fill: FillEvent, order: SimulatedOrder, tra
   )
   unsigned(fill.costBasisMicros, 'fill cost basis')
   const { id: _, kind: __, ...payload } = fill
-  ensure(fill.id === hashObject({ runId, kind: 'fill', ...payload }), `fill ${fill.id} has an invalid identity`)
+  ensure(fill.id === canonicalHashV1({ runId, kind: 'fill', ...payload }), `fill ${fill.id} has an invalid identity`)
 }
 
 const validateOrder = (
@@ -111,7 +111,10 @@ const validateOrder = (
   }
   ensure((fill === undefined) === (filled === 0n), `order ${order.id} fill presence diverges from its status`)
   const { id: _, ...payload } = order
-  ensure(order.id === hashObject({ runId, kind: 'order', ...payload }), `order ${order.id} has an invalid identity`)
+  ensure(
+    order.id === canonicalHashV1({ runId, kind: 'order', ...payload }),
+    `order ${order.id} has an invalid identity`,
+  )
   if (fill !== undefined) validateFill(runId, fill, order, trace)
 }
 
@@ -143,7 +146,7 @@ const validateFee = (
   ensure(expected.catMicros === BigInt(fee.catMicros), `fee ${fee.id} CAT component diverges`)
   ensure(expected.totalMicros === BigInt(fee.totalMicros), `fee ${fee.id} total diverges`)
   const { id: _, kind: __, ...payload } = fee
-  ensure(fee.id === hashObject({ runId, kind: 'fee', ...payload }), `fee ${fee.id} has an invalid identity`)
+  ensure(fee.id === canonicalHashV1({ runId, kind: 'fee', ...payload }), `fee ${fee.id} has an invalid identity`)
 }
 
 const validateCashChange = (
@@ -163,7 +166,7 @@ const validateCashChange = (
   )
   const { id: _, ...payload } = change
   ensure(
-    change.id === hashObject({ runId, kind: 'cash-change', ...payload }),
+    change.id === canonicalHashV1({ runId, kind: 'cash-change', ...payload }),
     `cash change ${change.id} has an invalid identity`,
   )
 }
@@ -294,7 +297,7 @@ export const reconcileMarkedEquity = (input: {
         cumulativeCashYield += expected
         const { id: _, kind: __, ...payload } = event
         ensure(
-          event.id === hashObject({ runId: input.runId, kind: 'cash-yield', ...payload }),
+          event.id === canonicalHashV1({ runId: input.runId, kind: 'cash-yield', ...payload }),
           `cash-yield event ${event.id} has an invalid identity`,
         )
       }

--- a/services/bayn/src/simulation.ts
+++ b/services/bayn/src/simulation.ts
@@ -16,7 +16,7 @@ import {
   type FeeInput,
   type FillTerms,
 } from './execution-model'
-import { canonicalHashV1, hashObject } from './hash'
+import { canonicalHashV1 } from './hash'
 import {
   ContractVersion,
   DIRECT_VOLATILITY_WINDOW,
@@ -98,7 +98,7 @@ export const alignBars = (
     session.set(bar.symbol, bar)
     byDate.set(bar.sessionDate, session)
   }
-  const sessions = [...byDate.entries()].sort(([left], [right]) => left.localeCompare(right))
+  const sessions = [...byDate.entries()].sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
   if (sessions.length !== inputManifest.sessionCount) {
     throw new Error('strategy input session count does not match manifest')
   }
@@ -251,7 +251,7 @@ const makeOrder = (
     rejectionReason: outcome.rejectionReason,
     unfilledRemainder: outcome.unfilledRemainder,
   }
-  return { id: hashObject({ runId, kind: 'order', ...payload }), ...payload }
+  return { id: canonicalHashV1({ runId, kind: 'order', ...payload }), ...payload }
 }
 
 const makeFill = (
@@ -275,7 +275,7 @@ const makeFill = (
     slippageCostMicros: terms.slippageCostMicros.toString(),
     costBasisMicros: costBasisMicros.toString(),
   }
-  return { kind: 'fill', id: hashObject({ runId, kind: 'fill', ...payload }), ...payload }
+  return { kind: 'fill', id: canonicalHashV1({ runId, kind: 'fill', ...payload }), ...payload }
 }
 
 const makeCashChange = (
@@ -293,7 +293,7 @@ const makeCashChange = (
     amountMicros: amountMicros.toString(),
     cashAfterMicros: cashAfterMicros.toString(),
   }
-  return { id: hashObject({ runId, kind: 'cash-change', ...payload }), ...payload }
+  return { id: canonicalHashV1({ runId, kind: 'cash-change', ...payload }), ...payload }
 }
 
 const makeFeeEvent = (runId: string, sessionDate: IsoDate, fees: ReturnType<typeof calculateSessionFees>): FeeEvent => {
@@ -305,7 +305,7 @@ const makeFeeEvent = (runId: string, sessionDate: IsoDate, fees: ReturnType<type
     catMicros: fees.catMicros.toString(),
     totalMicros: fees.totalMicros.toString(),
   }
-  return { kind: 'fee', id: hashObject({ runId, kind: 'fee', ...payload }), ...payload }
+  return { kind: 'fee', id: canonicalHashV1({ runId, kind: 'fee', ...payload }), ...payload }
 }
 
 const makeCashYieldEvent = (
@@ -316,7 +316,7 @@ const makeCashYieldEvent = (
   amountMicros: bigint,
 ) => {
   const payload = { sessionDate, elapsedDays, annualYieldBps, amountMicros: amountMicros.toString() }
-  return { kind: 'cash-yield' as const, id: hashObject({ runId, kind: 'cash-yield', ...payload }), ...payload }
+  return { kind: 'cash-yield' as const, id: canonicalHashV1({ runId, kind: 'cash-yield', ...payload }), ...payload }
 }
 
 export const simulate = (
@@ -386,7 +386,7 @@ export const simulate = (
       }
       const decision: DecisionEvent = {
         kind: 'decision',
-        id: hashObject({ runId, kind: 'decision', ...decisionPayload }),
+        id: canonicalHashV1({ runId, kind: 'decision', ...decisionPayload }),
         ...decisionPayload,
       }
       if (recordEvents) {
@@ -609,7 +609,7 @@ export const simulate = (
         ...performance,
         cashMicros: cashMicros.toString(),
         positions: Object.entries(session.bars)
-          .sort(([left], [right]) => left.localeCompare(right))
+          .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
           .map(([symbol]) => {
             const position = positions.get(symbol) ?? { quantityMicros: 0n, costBasisMicros: 0n }
             const priceMicros = closingPrices[symbol]


### PR DESCRIPTION
## Summary

- pin Bayn to the current Effect 4 beta.100 cohort and use official Effect HTTP, configuration, SQL, logging, schema-decoding, and scoped-resource patterns at runtime boundaries
- collapse durable identity onto one strict canonical hash contract and decode PostgreSQL/audit payloads into their real schemas instead of manual object shims or unsafe casts
- make TigerBeetle client lifecycle interruption-safe without serializing independent reconciliation reads, with typed test adapters and focused concurrency/finalizer coverage
- enforce the one-way PostgreSQL schema cut, remove the stale qualification pin, and keep unqualified image promotion possible without weakening protection for an existing qualification

## Related Issues

None

## Testing

- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:55432/bayn_test bun run --filter @proompteng/bayn test` (138 passed, including 23 PostgreSQL integration cases)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- `bun test packages/scripts/src/bayn/update-manifests.test.ts` (5 passed)
- `bunx oxfmt --check package.json services/bayn/package.json packages/scripts/src/bayn/update-manifests.ts packages/scripts/src/bayn/update-manifests.test.ts`
- `bunx oxlint --config .oxlintrc.json packages/scripts/src/bayn/update-manifests.ts packages/scripts/src/bayn/update-manifests.test.ts`
- `bun run lint:argocd`

## Breaking Changes

Bayn now accepts only the squashed `initial_schema` migration history and refuses the retired tracker/history. The deployment is intentionally still scaled to zero, the Bayn PostgreSQL `public` schema has already been reset, and this PR removes the stale qualification pin. It does not mutate TigerBeetle or grant broker/capital authority.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
