### PR TITLE
chore(bayn): promote image sha-b1285f3df40407a65f7dcbbd89711cbaf9861323

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: bayn
         app.kubernetes.io/part-of: bayn
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-22T03:04:41Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-22T03:50:47Z"
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
@@ -47,11 +47,11 @@ spec:
               protocol: TCP
           env:
             - name: BAYN_CODE_REVISION
-              value: 99a62f6bd8688fe6817c0cde603570bdfd22a9d7
+              value: b1285f3df40407a65f7dcbbd89711cbaf9861323
             - name: BAYN_IMAGE_REPOSITORY
               value: registry.ide-newton.ts.net/lab/bayn
             - name: BAYN_IMAGE_DIGEST
-              value: sha256:6c9ac4ee07c65c5417be4ba483ce20ccf125ea8e043d42222789a0a716269b82
+              value: sha256:e7a0795bf6957d63cc0f46c912994b91561e25846a5f7e760a97146c217589be
             - name: BAYN_STRATEGY_BEHAVIOR_HASH
               value: "43cece33d3db232ffb02ba78826727e50b5795319d09d27e1baa0c04709eb056"
             - name: BAYN_STRATEGY_PARAMETER_HASH

--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -16,5 +16,5 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/bayn
     newName: registry.ide-newton.ts.net/lab/bayn
-    newTag: "sha-99a62f6bd8688fe6817c0cde603570bdfd22a9d7"
-    digest: sha256:6c9ac4ee07c65c5417be4ba483ce20ccf125ea8e043d42222789a0a716269b82
+    newTag: "sha-b1285f3df40407a65f7dcbbd89711cbaf9861323"
+    digest: sha256:e7a0795bf6957d63cc0f46c912994b91561e25846a5f7e760a97146c217589be


### PR DESCRIPTION
## Summary

Promote the immutable Bayn image against the current Signal snapshot and dedicated Bayn TigerBeetle
ledger. Qualification-pin handling is selected from the verified compiled behavior identity.

- Source commit: `b1285f3df40407a65f7dcbbd89711cbaf9861323`
- Image tag: `sha-b1285f3df40407a65f7dcbbd89711cbaf9861323`
- Image digest: `sha256:e7a0795bf6957d63cc0f46c912994b91561e25846a5f7e760a97146c217589be`
- Qualification mode: `replace`
- Existing pin: `false`
- Runtime bindings match: `true`
- Snapshot changed: `false`
- Deployed snapshot: `98f9b0cdee311b248d4ed36104fa46ff86c34d587d6e71a6706a9d778c110292`
- Candidate snapshot: `98f9b0cdee311b248d4ed36104fa46ff86c34d587d6e71a6706a9d778c110292`
- Deployed behavior hash: `43cece33d3db232ffb02ba78826727e50b5795319d09d27e1baa0c04709eb056`
- Candidate behavior hash: `43cece33d3db232ffb02ba78826727e50b5795319d09d27e1baa0c04709eb056`
- Deployed parameter hash: `cf639d3692da65271b12423f9b7c6c9663e1fb13ae7290dc56fcfa3acf16eb69`
- Candidate parameter hash: `cf639d3692da65271b12423f9b7c6c9663e1fb13ae7290dc56fcfa3acf16eb69`

## Related Issues

PROOMPT-400

## Testing

- OCI index contains `linux/amd64` and `linux/arm64`.

## Screenshots (if applicable)

N/A

## Breaking Changes

This is a one-way current-contract runtime release. Databases with the old migration tracker are rejected;
there is no schema fallback or automatic rename. `preserve` keeps a pin only when compiled behavior, protocol parameters, Signal inputs, and TigerBeetle bindings all match. `replace` removes an existing incompatible pin only for a fresh Signal snapshot; when no pin exists, later releases may remain unqualified on the same snapshot. Promotion never creates a qualification pin.

## Checklist

- [x] Testing section documents exact validation.
- [x] Runtime source revision and image digest are immutable.
- [x] No broker or capital-promotion authority is introduced.