### PR TITLE
chore(signal): promote publisher sha-5c3bb55917c9082e8b77dc61ae284cbf74dd9268

### DIFF
--- a/argocd/applications/torghut/clickhouse/kustomization.yaml
+++ b/argocd/applications/torghut/clickhouse/kustomization.yaml
@@ -19,5 +19,5 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/signal-publisher
     newName: registry.ide-newton.ts.net/lab/signal-publisher
-    newTag: "sha-72006ac26afef02e42fc1af8d434e49835cc40d6"
-    digest: sha256:2561a79d2baaa998036344c121cc3986aedec365881911dd592d334163d82729
+    newTag: "sha-5c3bb55917c9082e8b77dc61ae284cbf74dd9268"
+    digest: sha256:0175115e0aa27968919680fd4a6cb99e00e54dc1c40b1ec41d5c34c1bbbbf6df

--- a/argocd/applications/torghut/clickhouse/signal-publisher-cronjob.yaml
+++ b/argocd/applications/torghut/clickhouse/signal-publisher-cronjob.yaml
@@ -72,11 +72,11 @@ spec:
                       name: bayn-universe-v2
                       key: HISTORY_FEED
                 - name: SIGNAL_CODE_REVISION
-                  value: "72006ac26afef02e42fc1af8d434e49835cc40d6"
+                  value: "5c3bb55917c9082e8b77dc61ae284cbf74dd9268"
                 - name: SIGNAL_IMAGE_REPOSITORY
                   value: registry.ide-newton.ts.net/lab/signal-publisher
                 - name: SIGNAL_IMAGE_DIGEST
-                  value: sha256:2561a79d2baaa998036344c121cc3986aedec365881911dd592d334163d82729
+                  value: sha256:0175115e0aa27968919680fd4a6cb99e00e54dc1c40b1ec41d5c34c1bbbbf6df
                 - name: SIGNAL_CLICKHOUSE_URL
                   value: http://torghut-clickhouse.torghut.svc.cluster.local:8123
                 - name: SIGNAL_CLICKHOUSE_USERNAME


### PR DESCRIPTION
## Summary

Pin the immutable Signal adjusted-daily publisher image and scheduled-writer provenance.

- Source commit: `5c3bb55917c9082e8b77dc61ae284cbf74dd9268`
- Image tag: `sha-5c3bb55917c9082e8b77dc61ae284cbf74dd9268`
- Image digest: `sha256:0175115e0aa27968919680fd4a6cb99e00e54dc1c40b1ec41d5c34c1bbbbf6df`

## Related Issues

PROOMPT-393

## Testing

- OCI index contains `linux/amd64` and `linux/arm64`.

## Screenshots (if applicable)

N/A

## Breaking Changes

Pins a bounded publisher without changing scheduled-writer activation. It has no broker or capital authority.

## Checklist

- [x] Testing section documents exact validation.
- [x] Runtime source revision and image digest are immutable.
- [x] No broker or capital-promotion authority is introduced.