### PR TITLE
fix(bayn): document unpinned release semantics

### DIFF
--- a/.github/workflows/bayn-release.yml
+++ b/.github/workflows/bayn-release.yml
@@ -193,9 +193,9 @@ jobs:
 
             This is a one-way current-contract runtime release. Databases with the old migration tracker are rejected;
             there is no schema fallback or automatic rename. `preserve` keeps the terminal run only when compiled
-            behavior, protocol parameters, Signal inputs, and TigerBeetle bindings all match. `replace` removes the
-            pin only for a fresh Signal snapshot. After that qualification, another image requires its terminal run
-            to be pinned or another fresh snapshot.
+            behavior, protocol parameters, Signal inputs, and TigerBeetle bindings all match. `replace` removes an
+            existing incompatible pin only for a fresh Signal snapshot; when no pin exists, later releases may remain
+            unqualified on the same snapshot. Promotion never creates a qualification pin.
 
             ## Checklist
 


### PR DESCRIPTION
## Summary

- Correct the generated Bayn promotion PR text to match the implemented qualification transition.
- Distinguish replacement of an existing incompatible pin from a release that already has no pin.
- State explicitly that image promotion never creates qualification authority.

## Related Issues

PROOMPT-400

## Testing

- `actionlint .github/workflows/bayn-release.yml`
- `bunx oxfmt --check .github/workflows/bayn-release.yml`
- `git diff --check`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section is removed and Breaking Changes is filled in.
- [x] Documentation, release notes, and follow-ups are updated or tracked.