### PR TITLE
chore(bayn): enable single writer

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/name: bayn
     app.kubernetes.io/part-of: bayn
 spec:
-  replicas: 0
+  replicas: 1
   revisionHistoryLimit: 2
   progressDeadlineSeconds: 600
   strategy:


### PR DESCRIPTION
## Summary

- Scale the Bayn Deployment from zero to exactly one replica.
- Keep maxSurge at zero so an update cannot create a second writer.
- Activate only the already-promoted Effect runtime at source b1285f3df40407a65f7dcbbd89711cbaf9861323 and digest sha256:e7a0795bf6957d63cc0f46c912994b91561e25846a5f7e760a97146c217589be.

## Related Issues

PROOMPT-400

## Testing

- `bun run lint:argocd`
- `kustomize build argocd/applications/bayn`
- `kubectl --context galactic-tailscale -n bayn apply --dry-run=server -f /tmp/bayn-single-writer-rendered.yaml`
- `git diff --check`
- Preflight: Argo is Synced/Healthy, Bayn has zero pods, the deployment has no qualification pin, CNPG is healthy, and the dedicated three-replica TigerBeetle cluster is running.

## Breaking Changes

This starts Bayn for the first time after the hard cut. It creates the current PostgreSQL schema, reads the pinned Signal snapshot from ClickHouse, and may append run-scoped accounting records to the dedicated TigerBeetle cluster. It does not place broker orders or gain capital authority. Rollback is to revert this PR and return replicas to zero; TigerBeetle records are append-only and remain isolated by run identity.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section is removed and Breaking Changes is filled in.
- [x] Documentation, release notes, and follow-ups are updated or tracked.