### PR TITLE
fix(bayn): restart after database setup failure

### DIFF
--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from 'bun:test'
 import { randomUUID } from 'node:crypto'
-import { createServer } from 'node:http'
 
 import { NodeServices } from '@effect/platform-node'
 import { Cause, Context, Effect, Exit, Fiber, Layer, Option, Redacted, Ref } from 'effect'
@@ -12,8 +11,8 @@ import type { RuntimeConfig } from './config'
 import {
   DatabaseError,
   EvidenceStore,
-  EvidenceStoreRuntimeLive,
-  makeEvidenceStoreRuntimeLayer,
+  EvidenceStoreLive,
+  makeEvidenceStoreLayer,
   type EvidenceStoreService,
   type StoredEvaluationEvidence,
 } from './db/evidence-store'
@@ -243,37 +242,6 @@ const fetchJson = async (port: number, path: string, method = 'GET') => {
     allow: response.headers.get('allow'),
     body: (await response.json()) as Record<string, unknown>,
   }
-}
-
-const unusedPort = () =>
-  new Promise<number>((resolve, reject) => {
-    const server = createServer()
-    server.once('error', reject)
-    server.listen(0, '127.0.0.1', () => {
-      const address = server.address()
-      if (address === null || typeof address === 'string') {
-        server.close()
-        reject(new Error('test server did not bind a TCP port'))
-        return
-      }
-      server.close((error) => (error === undefined ? resolve(address.port) : reject(error)))
-    })
-  })
-
-const waitForStatus = async (port: number, expectedStatus: string) => {
-  const deadline = Date.now() + 2_000
-  let lastError: unknown
-  while (Date.now() < deadline) {
-    try {
-      const response = await fetchJson(port, '/v1/status')
-      const operational = response.body.operational as { readonly status?: string } | undefined
-      if (operational?.status === expectedStatus) return response
-    } catch (error) {
-      lastError = error
-    }
-    await Bun.sleep(20)
-  }
-  throw new Error(`Bayn did not reach ${expectedStatus}`, { cause: lastError })
 }
 
 const readyState = (): RuntimeState => {
@@ -1004,76 +972,40 @@ describe('Bayn startup lifecycle', () => {
     })
   })
 
-  test('keeps HTTP live and readiness closed when database layer setup fails', async () => {
-    const port = await unusedPort()
+  test('fails layer construction when database setup fails', async () => {
     const unavailableDatabase = {
       ...config,
-      port,
       postgres: {
         ...config.postgres,
         tls: true,
         caPath: `/tmp/bayn-missing-ca-${randomUUID()}.crt`,
       },
     }
-    const dependencies = Layer.mergeAll(
-      Layer.succeed(MarketData, marketDataService(Effect.succeed(makeSnapshot()))),
-      Layer.succeed(Journal, successfulJournal),
-      EvidenceStoreRuntimeLive(unavailableDatabase).pipe(Layer.provide(NodeServices.layer)),
+    const exit = await Effect.runPromiseExit(
+      Effect.scoped(Layer.build(EvidenceStoreLive(unavailableDatabase).pipe(Layer.provide(NodeServices.layer)))),
     )
-    const fiber = Effect.runFork(run(unavailableDatabase, fixtureStrategy).pipe(Effect.provide(dependencies)))
 
-    try {
-      const status = await waitForStatus(port, 'FAILED')
-      expect(status).toMatchObject({
-        status: 200,
-        body: {
-          operational: { status: 'FAILED' },
-          error: expect.stringContaining('database.health-check'),
-        },
-      })
-      expect(await fetchJson(port, '/livez')).toMatchObject({ status: 200, body: { live: true } })
-      expect(await fetchJson(port, '/readyz')).toMatchObject({
-        status: 503,
-        body: { ready: false, status: 'FAILED' },
-      })
-    } finally {
-      await Effect.runPromise(Fiber.interrupt(fiber))
-    }
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) expect(Cause.pretty(exit.cause)).toContain('failed to read PostgreSQL CA certificate')
   })
 
-  test('keeps HTTP live and interrupts a migration that exceeds the operation deadline', async () => {
+  test('interrupts and fails layer construction when a migration exceeds the operation deadline', async () => {
     let interrupted = false
-    const port = await unusedPort()
     const timedOutDatabase = {
       ...config,
-      port,
       operationTimeoutMs: 10,
     }
     const stalledMigration = Effect.never.pipe(Effect.onInterrupt(() => Effect.sync(() => void (interrupted = true))))
-    const dependencies = Layer.mergeAll(
-      Layer.succeed(MarketData, marketDataService(Effect.succeed(makeSnapshot()))),
-      Layer.succeed(Journal, successfulJournal),
-      makeEvidenceStoreRuntimeLayer(timedOutDatabase, stalledMigration, Effect.succeed(successfulEvidenceStore)),
+    const exit = await Effect.runPromiseExit(
+      Effect.scoped(
+        Layer.build(
+          makeEvidenceStoreLayer(timedOutDatabase, stalledMigration, Effect.succeed(successfulEvidenceStore)),
+        ),
+      ),
     )
-    const fiber = Effect.runFork(run(timedOutDatabase, fixtureStrategy).pipe(Effect.provide(dependencies)))
 
-    try {
-      const status = await waitForStatus(port, 'FAILED')
-      expect(interrupted).toBe(true)
-      expect(status).toMatchObject({
-        status: 200,
-        body: {
-          operational: { status: 'FAILED' },
-          error: expect.stringContaining('PostgreSQL migration timed out after 10ms'),
-        },
-      })
-      expect(await fetchJson(port, '/livez')).toMatchObject({ status: 200, body: { live: true } })
-      expect(await fetchJson(port, '/readyz')).toMatchObject({
-        status: 503,
-        body: { ready: false, status: 'FAILED' },
-      })
-    } finally {
-      await Effect.runPromise(Fiber.interrupt(fiber))
-    }
+    expect(interrupted).toBe(true)
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) expect(Cause.pretty(exit.cause)).toContain('PostgreSQL migration timed out after 10ms')
   })
 })

--- a/services/bayn/src/db/evidence-store.ts
+++ b/services/bayn/src/db/evidence-store.ts
@@ -2116,7 +2116,7 @@ const withMigrationDeadline = <R>(
     }),
   )
 
-const EvidenceStoreDatabaseLayer = <RMigration, RStore>(
+export const makeEvidenceStoreLayer = <RMigration, RStore>(
   config: Pick<RuntimeConfig, 'operationTimeoutMs'>,
   migration: Effect.Effect<void, DatabaseError, RMigration>,
   store: Effect.Effect<EvidenceStoreService, DatabaseError, RStore>,
@@ -2130,31 +2130,4 @@ const EvidenceStoreDatabaseLayer = <RMigration, RStore>(
   )
 
 export const EvidenceStoreLive = (config: RuntimeConfig) =>
-  EvidenceStoreDatabaseLayer(config, migrations, makeEvidenceStore).pipe(Layer.provideMerge(PostgresClientLive(config)))
-
-export const makeEvidenceStoreRuntimeLayer = <RMigration, RStore>(
-  config: Pick<RuntimeConfig, 'operationTimeoutMs'>,
-  migration: Effect.Effect<void, DatabaseError, RMigration>,
-  store: Effect.Effect<EvidenceStoreService, DatabaseError, RStore>,
-) => recoverEvidenceStoreLayer(EvidenceStoreDatabaseLayer(config, migration, store))
-
-const recoverEvidenceStoreLayer = <R>(layer: Layer.Layer<EvidenceStore, DatabaseError, R>) =>
-  layer.pipe(
-    Layer.catch((error) =>
-      Layer.succeed(EvidenceStore, {
-        check: Effect.fail(error),
-        persist: () => Effect.fail(error),
-        read: () => Effect.fail(error),
-        readArtifactItems: () => Effect.fail(error),
-        recover: () => Effect.fail(error),
-        listPriorTrials: Effect.fail(error),
-        openQualification: () => Effect.fail(error),
-        readQualification: () => Effect.fail(error),
-      }),
-    ),
-  )
-
-export const EvidenceStoreRuntimeLive = (config: RuntimeConfig) =>
-  recoverEvidenceStoreLayer(
-    EvidenceStoreDatabaseLayer(config, migrations, makeEvidenceStore).pipe(Layer.provide(PostgresClientLive(config))),
-  )
+  makeEvidenceStoreLayer(config, migrations, makeEvidenceStore).pipe(Layer.provideMerge(PostgresClientLive(config)))

--- a/services/bayn/src/index.ts
+++ b/services/bayn/src/index.ts
@@ -6,7 +6,7 @@ import { run } from './app'
 import { verifyParameterHash } from './build'
 import { loadConfig } from './config'
 import { makeRuntimeProvenance } from './contracts'
-import { EvidenceStoreRuntimeLive } from './db/evidence-store'
+import { EvidenceStoreLive } from './db/evidence-store'
 import { JournalLive } from './ledger'
 import { MarketDataLive } from './market-data'
 import { hashParameters, loadDefaultProtocol } from './protocol'
@@ -47,7 +47,7 @@ const main = Effect.gen(function* () {
   const dependencies = Layer.mergeAll(
     marketData,
     JournalLive(config),
-    EvidenceStoreRuntimeLive(config).pipe(Layer.provide(NodeServices.layer)),
+    EvidenceStoreLive(config).pipe(Layer.provide(NodeServices.layer)),
   )
   return yield* run(config, strategy).pipe(Effect.provide(dependencies))
 })


### PR DESCRIPTION
## Summary

- Remove the permanently failing EvidenceStore fallback created after database Layer acquisition fails.
- Keep migration acquisition bounded, but let the scoped Effect program terminate so Kubernetes can retry from a fresh PostgreSQL pool.
- Delete the duplicate runtime layer API and replace the old live-but-stuck tests with exact layer-failure and interruption coverage.

## Related Issues

PROOMPT-400

## Testing

- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:55432/bayn_test bun run --filter @proompteng/bayn test` — 138 passed, including 23 PostgreSQL integration tests.
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint` — zero warnings.
- `bun run --filter @proompteng/bayn lint:oxlint:type` — zero warnings.
- `bun run --filter @proompteng/bayn build`
- Live reproduction: the first hard-cut migration committed schema_migrations ID 1, then the 30-second Layer deadline expired during a CNPG synchronous-replica interruption. The old runtime stayed live with readiness 503 and could never reacquire the store.

## Breaking Changes

A PostgreSQL certificate, connection, or migration acquisition failure now terminates the Bayn process after the existing bounded deadline instead of serving a permanently poisoned EvidenceStore. Kubernetes restarts the single writer and retries acquisition. This does not relax migration validation, increase timeouts, add fallback schemas, or change broker/capital authority.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section is removed and Breaking Changes is filled in.
- [x] Documentation, release notes, and follow-ups are updated or tracked.