### PR TITLE
docs(bayn): record live runtime proof

### DIFF
--- a/docs/bayn/architecture.md
+++ b/docs/bayn/architecture.md
@@ -107,13 +107,13 @@ Repeated execution of the same inputs is deterministic and must either recover e
 the same journal objects. Any mismatched manifest, universe, build identity, lock, journal object, reconciliation,
 qualification, or durable evidence closes readiness and never expands authority.
 
-## Deployment status
+## Deployment contract
 
-GitOps owns one `apps/v1 Deployment` and a dedicated three-replica TigerBeetle cluster. When Bayn is active, the
-Deployment is a single writer and `maxSurge: 0` prevents overlapping writers during rollout. The pod has no broker
-secret and no Kubernetes API token.
+GitOps owns one `apps/v1 Deployment` configured as a single writer and a dedicated three-replica TigerBeetle cluster.
+`maxSurge: 0` prevents overlapping writers during rollout. The pod has no broker secret and no Kubernetes API token.
+Scaling to zero is a maintenance state, not a second deployment mode.
 
-As of 2026-07-21, the Deployment is intentionally quiesced at zero replicas for the separately owned database
-reset/restore workstream. The non-database cleanup does not change replicas, the qualification pin, PostgreSQL
-resources, or stored evidence. Live acceptance remains pending until that workstream restores one coherent writer and
-the promoted image proves startup, readiness, status, and sustained health.
+Every promoted image requires live acceptance against one coherent writer: the running image ID must match the GitOps
+digest, startup must produce or recover durable terminal evidence, readiness must remain open across continuous probes,
+all dependencies must remain available, accounting must be exact, and HTTP status must retain observe-only authority.
+An Argo `Synced/Healthy` result without those observations is not sufficient.

--- a/docs/bayn/authoritative-universe.md
+++ b/docs/bayn/authoritative-universe.md
@@ -1,8 +1,8 @@
 # Bayn authoritative universe
 
-Status: **selected, published, and compiled; Bayn runtime proof paused by the separate database workstream**
+Status: **selected, published, compiled, and live-verified**
 
-Last verified: 2026-07-21
+Last verified: 2026-07-22T04:25:49.456Z
 
 ## Decision
 
@@ -127,7 +127,7 @@ supported limit-order semantics; this milestone submits no orders. The external 
 [24/5 feed specification](https://docs.alpaca.markets/us/docs/245-trading-for-trading-api), and
 [extended-hours order rules](https://docs.alpaca.markets/us/docs/orders-at-alpaca).
 
-## Current integration and remaining proof
+## Current integration and live proof
 
 - The versioned ConfigMap supplies the exact universe to the websocket, archive pipeline, and Signal publisher.
 - GitOps renders the scheduled Signal publisher with delayed SIP history and the V2 finalization contract.
@@ -135,13 +135,15 @@ supported limit-order semantics; this milestone submits no orders. The external 
   hash.
 - Bayn GitOps selects finalized snapshot
   `98f9b0cdee311b248d4ed36104fa46ff86c34d587d6e71a6706a9d778c110292` through 2026-07-20.
-- The Bayn Deployment is intentionally at zero replicas while the separate database workstream performs its
-  reset/restore. This document does not authorize changing that state.
-
-After that workstream restores one writer, live acceptance must prove the promoted image digest, the exact snapshot and
-universe binding, one ready endpoint, an observable terminal qualification, all continuous dependencies available, and
-fixed observe-only authority. Until then, Git and prior publication evidence prove integration but not current Bayn
-runtime behavior.
+- Live verification observed one ready, zero-restart Bayn writer at source revision
+  `407d9d20b47374efd0c53f94befd9aac719e3bee` and image-index digest
+  `sha256:3cacc27ace90ce637362f0dcf408d43c03e69c6018461bd1fd72b9cc24c82cbf`.
+- Run `b88f53887a31b6696f5bf6b56e4e10d9966057c6109a1d0721dc94677e566ec7` evaluated the exact nine-symbol snapshot.
+  Data and evidence were `CURRENT`, all four continuous dependencies were `AVAILABLE`, accounting was `EXACT`, and
+  readiness remained open through probe sequence 19.
+- The economic evaluation passed all seven gates, while the terminal qualification correctly remained `REJECTED` and
+  non-executable for insufficient statistical power. Status retained maximum authority `observe`, with broker orders
+  and capital promotion disabled.
 
 Rollback remains fail-closed: stop the active Signal writer through GitOps, preserve finalized and partially staged
 publications, and revert only after no publication Job is active. A rollback does not grant broker or capital


### PR DESCRIPTION
## Summary

- Replace the temporary zero-replica blocker text with the durable single-writer deployment and live-acceptance contract.
- Record the verified source revision, image digest, Signal snapshot, evaluation run, readiness, accounting, qualification, and authority results.
- Keep the change strictly documentation-only; no database implementation, SQL, migration, persisted contract, PostgreSQL manifest, or integration test changes.

## Related Issues

None

## Testing

- `bun run --cwd services/bayn test` (115 passed, 25 database integration tests skipped locally)
- `bun run --cwd services/bayn tsc`
- `bun run --cwd services/bayn lint`
- `bun run --cwd services/bayn lint:oxlint`
- `bun run --cwd services/bayn lint:oxlint:type`
- `bun run --cwd services/bayn build`
- `bunx oxfmt --check docs/bayn`
- Live `/livez`, `/readyz`, `/v1/status`, and `/v1/evaluations/:runId` verification through the ClusterIP service
- Continuous health observed from probe sequence 14 through 19 with all dependencies available and zero pod restarts
- OCI index and embedded labels verified for `linux/amd64` and `linux/arm64`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately (screenshots not applicable).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
