### PR TITLE
docs(bayn): distinguish OCI image digests

### DIFF
--- a/docs/bayn/architecture.md
+++ b/docs/bayn/architecture.md
@@ -113,7 +113,8 @@ GitOps owns one `apps/v1 Deployment` configured as a single writer and a dedicat
 `maxSurge: 0` prevents overlapping writers during rollout. The pod has no broker secret and no Kubernetes API token.
 Scaling to zero is a maintenance state, not a second deployment mode.
 
-Every promoted image requires live acceptance against one coherent writer: the running image ID must match the GitOps
-digest, startup must produce or recover durable terminal evidence, readiness must remain open across continuous probes,
-all dependencies must remain available, accounting must be exact, and HTTP status must retain observe-only authority.
-An Argo `Synced/Healthy` result without those observations is not sufficient.
+Every promoted image requires live acceptance against one coherent writer: the pod spec's digest-pinned image reference
+must match the GitOps OCI index digest, and the running image ID must match that index's published platform digest for
+the scheduled node architecture. Startup must produce or recover durable terminal evidence, readiness must remain open
+across continuous probes, all dependencies must remain available, accounting must be exact, and HTTP status must retain
+observe-only authority. An Argo `Synced/Healthy` result without those observations is not sufficient.


### PR DESCRIPTION
## Summary

- distinguish the GitOps-pinned OCI index digest from the platform manifest digest reported by containerd
- require the pod spec image reference and runtime image ID to be validated against their corresponding published digests
- address the actionable review finding on #13056 without changing Bayn runtime or database code

## Related Issues

Follow-up to #13056.

## Testing

- `git diff --check`
- `bunx oxfmt --check docs/bayn/architecture.md`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
