### PR TITLE
fix(dorvud): keep off-session websocket readiness stable

### DIFF
--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
@@ -99,6 +99,19 @@ internal fun alpacaMarketDataStreamUrl(
     AlpacaMarketType.OPTIONS -> "${config.alpacaStreamUrl.trimEnd('/')}/v1beta1/${feed.feed}"
   }
 
+internal fun marketDataIdleRequiresReconnect(
+  sessionReady: Boolean,
+  now: Instant,
+  marketType: AlpacaMarketType,
+  marketHolidays: Set<LocalDate>,
+  equityFeed: EquityFeed?,
+): Boolean =
+  !sessionReady ||
+    marketDataFreshnessGateActive(
+      marketSessionState(now, marketType, marketHolidays),
+      equityFeed,
+    )
+
 internal fun alpacaBarsBackfillUrl(config: ForwarderConfig): String =
   when (config.alpacaMarketType) {
     AlpacaMarketType.EQUITY -> "${config.alpacaBaseUrl.trimEnd('/')}/v2/stocks/bars"
@@ -534,22 +547,40 @@ class ForwarderApp(
         header("Content-Type", "application/msgpack")
       }
     }) {
+      var authOk = false
+      var subscribedOk = false
+
       suspend fun decodeNextMessages(): List<AlpacaMessage> {
-        val frame =
-          withTimeoutOrNull(config.marketDataReadIdleTimeoutMs) {
-            incoming.receive()
-          } ?: error(
-            "alpaca market-data websocket idle for ${config.marketDataReadIdleTimeoutMs}ms; reconnecting",
-          )
-        val elements = decodeMarketDataFrame(frame) ?: return emptyList()
-        val messages: List<JsonElement> =
-          if (elements is JsonArray) elements.toList() else listOf(elements)
-        return messages.mapNotNull { el ->
-          try {
-            json.decodeFromJsonElement(AlpacaMessageSerializer, el)
-          } catch (e: SerializationException) {
-            logger.warn(e) { "failed to decode alpaca message; dropping" }
-            null
+        while (true) {
+          val frame =
+            withTimeoutOrNull(config.marketDataReadIdleTimeoutMs) {
+              incoming.receive()
+            }
+          if (frame == null) {
+            val reconnect =
+              marketDataIdleRequiresReconnect(
+                sessionReady = authOk && subscribedOk,
+                now = Instant.ofEpochMilli(nowMs()),
+                marketType = config.alpacaMarketType,
+                marketHolidays = config.optionsMarketHolidays,
+                equityFeed = feed.config.equityFeed,
+              )
+            if (reconnect) {
+              error("alpaca market-data websocket idle for ${config.marketDataReadIdleTimeoutMs}ms; reconnecting")
+            }
+            continue
+          }
+
+          val elements = decodeMarketDataFrame(frame) ?: return emptyList()
+          val messages: List<JsonElement> =
+            if (elements is JsonArray) elements.toList() else listOf(elements)
+          return messages.mapNotNull { el ->
+            try {
+              json.decodeFromJsonElement(AlpacaMessageSerializer, el)
+            } catch (e: SerializationException) {
+              logger.warn(e) { "failed to decode alpaca message; dropping" }
+              null
+            }
           }
         }
       }
@@ -566,8 +597,6 @@ class ForwarderApp(
 
       val subscribedSymbols = mutableSetOf<String>()
       val subscribedLock = Mutex()
-      var authOk = false
-      var subscribedOk = false
       var readyNotified = false
       val subscribedSince = AtomicReference<Instant?>(null)
       val lastOptionsMarketDataEventAt = AtomicReference<Instant?>(null)

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/MarketDataChannelFreshnessTrackerTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/MarketDataChannelFreshnessTrackerTest.kt
@@ -8,6 +8,34 @@ import kotlin.test.assertTrue
 
 class MarketDataChannelFreshnessTrackerTest {
   @Test
+  fun `read idle reconnects only while the feed session is active`() {
+    val regularSession = Instant.parse("2026-07-07T14:00:00Z")
+    val overnightSession = Instant.parse("2026-07-08T01:00:00Z")
+
+    assertTrue(
+      marketDataIdleRequiresReconnect(true, regularSession, AlpacaMarketType.EQUITY, emptySet(), EquityFeed.Iex),
+    )
+    assertFalse(
+      marketDataIdleRequiresReconnect(true, overnightSession, AlpacaMarketType.EQUITY, emptySet(), EquityFeed.Iex),
+    )
+    assertTrue(
+      marketDataIdleRequiresReconnect(true, regularSession, AlpacaMarketType.EQUITY, emptySet(), EquityFeed.DelayedSip),
+    )
+    assertFalse(
+      marketDataIdleRequiresReconnect(true, overnightSession, AlpacaMarketType.EQUITY, emptySet(), EquityFeed.DelayedSip),
+    )
+    assertFalse(
+      marketDataIdleRequiresReconnect(true, regularSession, AlpacaMarketType.EQUITY, emptySet(), EquityFeed.Overnight),
+    )
+    assertTrue(
+      marketDataIdleRequiresReconnect(true, overnightSession, AlpacaMarketType.EQUITY, emptySet(), EquityFeed.Overnight),
+    )
+    assertTrue(
+      marketDataIdleRequiresReconnect(false, overnightSession, AlpacaMarketType.EQUITY, emptySet(), EquityFeed.Iex),
+    )
+  }
+
+  @Test
   fun `observation freshness gates follow the feed active session`() {
     val delayedSipPre =
       MarketDataChannelFreshnessTracker(


### PR DESCRIPTION
## Summary

- Keep an authenticated market-data session open when its configured feed is outside its active market session instead of treating expected silence as failure.
- Preserve active-session idle reconnects and the existing 20-second WebSocket ping/pong liveness path.
- Cover IEX, delayed SIP, and overnight feed boundaries with a focused regression test.

## Related Issues

Supports [PROOMPT-393](https://linear.app/proompteng/issue/PROOMPT-393/select-and-bind-the-authoritative-bayn-universe).

## Testing

- `cd services/dorvud && ./gradlew :websockets:test --tests ai.proompteng.dorvud.ws.MarketDataChannelFreshnessTrackerTest`
- `cd services/dorvud && ./gradlew :websockets:test :websockets:ktlintCheck`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed; this change has no UI.
- [x] Breaking Changes handled above; release and live verification remain tracked by PROOMPT-393.