### PR TITLE
docs(bayn): allow runtime image digest forms

### DIFF
--- a/docs/bayn/architecture.md
+++ b/docs/bayn/architecture.md
@@ -114,7 +114,8 @@ GitOps owns one `apps/v1 Deployment` configured as a single writer and a dedicat
 Scaling to zero is a maintenance state, not a second deployment mode.
 
 Every promoted image requires live acceptance against one coherent writer: the pod spec's digest-pinned image reference
-must match the GitOps OCI index digest, and the running image ID must match that index's published platform digest for
-the scheduled node architecture. Startup must produce or recover durable terminal evidence, readiness must remain open
-across continuous probes, all dependencies must remain available, accounting must be exact, and HTTP status must retain
-observe-only authority. An Argo `Synced/Healthy` result without those observations is not sufficient.
+must match the GitOps OCI index digest. The runtime image ID is supporting evidence: its digest must be either that same
+index digest or the matching platform manifest declared by that index for the scheduled node architecture. Startup must
+produce or recover durable terminal evidence, readiness must remain open across continuous probes, all dependencies
+must remain available, accounting must be exact, and HTTP status must retain observe-only authority. An Argo
+`Synced/Healthy` result without those observations is not sufficient.


### PR DESCRIPTION
## Summary

- make the digest-pinned pod spec reference the authoritative comparison with the GitOps OCI index digest
- accept either the index digest or its matching platform child when interpreting runtime `imageID`
- align the acceptance contract with both the review finding on #13056 and the current live containerd representation

## Related Issues

Follow-up to #13056 and #13057.

## Testing

- `git diff --check`
- `bunx oxfmt --check docs/bayn/architecture.md`
- verified the live Bayn pod spec and runtime `imageID` both currently report the promoted index digest

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
