### PR TITLE
chore(torghut): promote ws image sha-6505770489cf68472c7a879df3abc3d9467a6d49

### DIFF
--- a/argocd/applications/torghut-options/ws/deployment.yaml
+++ b/argocd/applications/torghut-options/ws/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws-options
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:f60b6d5c403179bb176baf8f8d6fc54c12ee08e71590bc8c24d4743c079a4a05
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:6b181db36d6e455930d08ade5c3e9c91ebdb292aaaa9e450b425230f660b2160
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -54,9 +54,9 @@ spec:
                   name: torghut-options
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-sha-b20cdafc9e2bd9b75b2b61039a1a34f14bf46399
+              value: main-sha-6505770489cf68472c7a879df3abc3d9467a6d49
             - name: TORGHUT_WS_COMMIT
-              value: b20cdafc9e2bd9b75b2b61039a1a34f14bf46399
+              value: 6505770489cf68472c7a879df3abc3d9467a6d49
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:

--- a/argocd/applications/torghut/ws/deployment.yaml
+++ b/argocd/applications/torghut/ws/deployment.yaml
@@ -33,7 +33,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:f60b6d5c403179bb176baf8f8d6fc54c12ee08e71590bc8c24d4743c079a4a05
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:6b181db36d6e455930d08ade5c3e9c91ebdb292aaaa9e450b425230f660b2160
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -77,9 +77,9 @@ spec:
                   name: torghut-ws
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-sha-b20cdafc9e2bd9b75b2b61039a1a34f14bf46399
+              value: main-sha-6505770489cf68472c7a879df3abc3d9467a6d49
             - name: TORGHUT_WS_COMMIT
-              value: b20cdafc9e2bd9b75b2b61039a1a34f14bf46399
+              value: 6505770489cf68472c7a879df3abc3d9467a6d49
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:


### PR DESCRIPTION
## Summary
Promote the Torghut websocket image into GitOps manifests.

- Source commit: `6505770489cf68472c7a879df3abc3d9467a6d49`
- Image tag: `sha-6505770489cf68472c7a879df3abc3d9467a6d49`
- Image digest: `sha256:6b181db36d6e455930d08ade5c3e9c91ebdb292aaaa9e450b425230f660b2160`