### PR TITLE
fix(bayn): fence qualification releases

### DIFF
--- a/.github/workflows/bayn-release.yml
+++ b/.github/workflows/bayn-release.yml
@@ -194,8 +194,9 @@ jobs:
             This is a one-way current-contract runtime release. Databases with the old migration tracker are rejected;
             there is no schema fallback or automatic rename. `preserve` keeps the terminal run only when compiled
             behavior, protocol parameters, Signal inputs, and TigerBeetle bindings all match. `replace` removes an
-            existing incompatible pin only for a fresh Signal snapshot; when no pin exists, later releases may remain
-            unqualified on the same snapshot. Promotion never creates a qualification pin.
+            existing incompatible pin only for a fresh Signal snapshot. Once that one-shot release is unpinned, a
+            different source revision is rejected until the terminal run is pinned or the snapshot advances.
+            Promotion never creates a qualification pin.
 
             ## Checklist
 

--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -56,6 +56,8 @@ spec:
               value: "43cece33d3db232ffb02ba78826727e50b5795319d09d27e1baa0c04709eb056"
             - name: BAYN_STRATEGY_PARAMETER_HASH
               value: "cf639d3692da65271b12423f9b7c6c9663e1fb13ae7290dc56fcfa3acf16eb69"
+            - name: BAYN_QUALIFICATION_RUN_ID
+              value: "b88f53887a31b6696f5bf6b56e4e10d9966057c6109a1d0721dc94677e566ec7"
             - name: BAYN_HEALTH_INTERVAL_MS
               value: "30000"
             - name: BAYN_OPERATION_TIMEOUT_MS

--- a/docs/bayn/architecture.md
+++ b/docs/bayn/architecture.md
@@ -119,3 +119,8 @@ index digest or the matching platform manifest declared by that index for the sc
 produce or recover durable terminal evidence, readiness must remain open across continuous probes, all dependencies
 must remain available, accounting must be exact, and HTTP status must retain observe-only authority. An Argo
 `Synced/Healthy` result without those observations is not sufficient.
+
+Outside an explicit one-shot qualification release, GitOps pins `BAYN_QUALIFICATION_RUN_ID` to one terminal run. The
+release writer preserves that pin while strategy and runtime bindings remain identical. After a fresh snapshot removes
+the pin for its one allowed source revision, promotion rejects a different source revision on that same unpinned
+snapshot; operational releases therefore cannot create extra qualification trials.

--- a/packages/scripts/src/bayn/update-manifests.test.ts
+++ b/packages/scripts/src/bayn/update-manifests.test.ts
@@ -88,8 +88,8 @@ const makeFixture = (options: FixtureOptions = {}): FixturePaths => {
 const promote = (
   paths: FixturePaths,
   overrides: Partial<Pick<UpdateBaynManifestOptions, 'strategyBehaviorHash' | 'strategyParameterHash'>> = {},
+  sourceSha = 'a'.repeat(40),
 ) => {
-  const sourceSha = 'a'.repeat(40)
   return updateBaynManifests({
     sourceSha,
     tag: `sha-${sourceSha}`,
@@ -136,7 +136,7 @@ describe('Bayn manifest promotion', () => {
     expect(() => promote(paths)).toThrow('qualification replacement requires a fresh BAYN_SIGNAL_SNAPSHOT_ID')
   })
 
-  test('replaces a pin for a fresh snapshot and permits later releases while unqualified', () => {
+  test('replaces a pin for a fresh snapshot and rejects a second unpinned source release', () => {
     const paths = makeFixture({ snapshotId: '4'.repeat(64), publicationAsOf: '2026-07-19' })
     const changedParameterHash = '3'.repeat(64)
     const first = promote(paths, { strategyParameterHash: changedParameterHash })
@@ -154,14 +154,18 @@ describe('Bayn manifest promotion', () => {
       environmentBlock('BAYN_SIGNAL_SNAPSHOT_ID', currentSnapshotId).trim(),
     )
 
-    const second = promote(paths, { strategyParameterHash: changedParameterHash })
-
-    expect(second).toMatchObject({
+    expect(promote(paths, { strategyParameterHash: changedParameterHash })).toMatchObject({
       qualificationMode: 'replace',
       hadQualificationPin: false,
-      runtimeBindingsMatch: true,
       snapshotChanged: false,
+      deployedSourceSha: 'a'.repeat(40),
     })
+
+    const beforeSecondRelease = Object.values(paths).map((path) => readFileSync(path, 'utf8'))
+    expect(() => promote(paths, { strategyParameterHash: changedParameterHash }, 'c'.repeat(40))).toThrow(
+      'an unpinned qualification snapshot cannot accept a second source release',
+    )
+    expect(Object.values(paths).map((path) => readFileSync(path, 'utf8'))).toEqual(beforeSecondRelease)
     expect(readFileSync(paths.deploymentPath, 'utf8')).not.toContain('BAYN_QUALIFICATION_RUN_ID')
   })
 

--- a/packages/scripts/src/bayn/update-manifests.ts
+++ b/packages/scripts/src/bayn/update-manifests.ts
@@ -112,6 +112,9 @@ export const updateBaynManifests = (options: UpdateBaynManifestOptions): BaynMan
   if (qualificationMode === 'replace' && hadQualificationPin && !snapshotChanged) {
     throw new Error('qualification replacement requires a fresh BAYN_SIGNAL_SNAPSHOT_ID')
   }
+  if (!hadQualificationPin && !snapshotChanged && deployedSourceSha !== options.sourceSha) {
+    throw new Error('an unpinned qualification snapshot cannot accept a second source release')
+  }
   const imageBlock =
     /(  - name: registry\.ide-newton\.ts\.net\/lab\/bayn\n    newName: registry\.ide-newton\.ts\.net\/lab\/bayn\n    newTag: )[^\n]+(?:\n    digest: [^\n]+)?/
   const updatedKustomization = replaceExactlyOnce(

--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -34,6 +34,8 @@ to TigerBeetle. Bayn contains no broker client or capital-promotion path.
 - `BAYN_QUALIFICATION_RUN_ID` optionally pins one terminal qualification across operational image updates. Startup
   verifies the stored strategy and Signal bindings, then recovers it without inspecting bars, opening a lock,
   evaluating, journaling, or persisting.
+- Production GitOps carries that pin outside an explicit one-shot qualification release. The release writer refuses a
+  second source revision on the same unpinned snapshot, preventing operational releases from creating new trials.
 - The compiled risk-balanced trend decision function records every normalized trend horizon, volatility estimate,
   portfolio-volatility scale, and target weight at a month-end close. Decisions may execute only at the next exchange
   session open.


### PR DESCRIPTION
## Summary

- pin production to the existing terminal Bayn qualification run so pod restarts recover evidence instead of opening another trial
- reject a different source revision on the same unpinned Signal snapshot while retaining idempotent same-source release retries
- document the one-shot qualification boundary in the release workflow and Bayn operating contract

## Related Issues

[PROOMPT-393](https://linear.app/proompteng/issue/PROOMPT-393/select-and-bind-the-authoritative-bayn-universe)

## Testing

- `bun test packages/scripts/src/bayn/update-manifests.test.ts` (5 passed)
- `bunx oxfmt --check packages/scripts/src/bayn/update-manifests.ts packages/scripts/src/bayn/update-manifests.test.ts`
- `bunx oxlint --config .oxlintrc.json packages/scripts/src/bayn/update-manifests.ts packages/scripts/src/bayn/update-manifests.test.ts`
- `bunx oxlint --config .oxlintrc.json --type-aware --tsconfig packages/scripts/tsconfig.json packages/scripts/src/bayn/update-manifests.ts packages/scripts/src/bayn/update-manifests.test.ts`
- `actionlint .github/workflows/bayn-release.yml`
- `kustomize build argocd/applications/bayn`
- `bun run lint:argocd`

## Breaking Changes

A Bayn release now fails closed when it attempts to put a different source revision on an already-consumed, unpinned Signal snapshot. Operators must first pin the terminal run or advance to a fresh snapshot.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation and release behavior are updated.