### PR TITLE
fix(bayn): retry transient SQL startup

### DIFF
--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -5,8 +5,9 @@ import { NodeServices } from '@effect/platform-node'
 import { Cause, Context, Effect, Exit, Fiber, Layer, Option, Redacted, Ref } from 'effect'
 import { TestClock } from 'effect/testing'
 import { HttpServer } from 'effect/unstable/http'
+import { AuthenticationError, ConnectionError, SqlError } from 'effect/unstable/sql/SqlError'
 
-import { initialize, monitor, probe, run } from './app'
+import { acquireSqlLayer, initialize, monitor, probe, run } from './app'
 import type { RuntimeConfig } from './config'
 import {
   DatabaseError,
@@ -555,6 +556,95 @@ describe('Bayn continuous health', () => {
 })
 
 describe('Bayn startup lifecycle', () => {
+  test('retries only retryable SQL dependency acquisition failures', async () => {
+    let attempts = 0
+    const retryable = new SqlError({
+      reason: new ConnectionError({ cause: new Error('transient timeout'), operation: 'connect' }),
+    })
+    const dependencies = Layer.effectDiscard(
+      Effect.suspend(() => {
+        attempts += 1
+        return attempts === 1 ? Effect.fail(retryable) : Effect.void
+      }),
+    )
+    const program = Effect.scoped(
+      Effect.gen(function* () {
+        const fiber = yield* acquireSqlLayer(dependencies).pipe(Effect.forkScoped({ startImmediately: true }))
+        yield* Effect.yieldNow
+        expect(attempts).toBe(1)
+        yield* TestClock.adjust('1 second')
+        yield* Fiber.join(fiber)
+        expect(attempts).toBe(2)
+      }),
+    ).pipe(Effect.provide(TestClock.layer()))
+
+    await Effect.runPromise(program)
+
+    attempts = 0
+    const nonRetryable = new SqlError({
+      reason: new AuthenticationError({ cause: new Error('invalid credentials'), operation: 'connect' }),
+    })
+    const exit = await Effect.runPromiseExit(
+      Effect.scoped(
+        acquireSqlLayer(
+          Layer.effectDiscard(
+            Effect.sync(() => {
+              attempts += 1
+            }).pipe(Effect.andThen(Effect.fail(nonRetryable))),
+          ),
+        ),
+      ),
+    )
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    expect(attempts).toBe(1)
+  })
+
+  test('interrupts a pending SQL acquisition retry', async () => {
+    let attempts = 0
+    const retryable = new SqlError({
+      reason: new ConnectionError({ cause: new Error('transient timeout'), operation: 'connect' }),
+    })
+    const program = Effect.scoped(
+      Effect.gen(function* () {
+        const fiber = yield* acquireSqlLayer(
+          Layer.effectDiscard(
+            Effect.sync(() => {
+              attempts += 1
+            }).pipe(Effect.andThen(Effect.fail(retryable))),
+          ),
+        ).pipe(Effect.forkScoped({ startImmediately: true }))
+        yield* Effect.yieldNow
+        expect(attempts).toBe(1)
+        yield* Fiber.interrupt(fiber)
+        yield* TestClock.adjust('2 seconds')
+        expect(attempts).toBe(1)
+      }),
+    ).pipe(Effect.provide(TestClock.layer()))
+
+    await Effect.runPromise(program)
+  })
+
+  test('releases an acquired SQL layer exactly once', async () => {
+    let releases = 0
+
+    await Effect.runPromise(
+      Effect.scoped(
+        acquireSqlLayer(
+          Layer.effectDiscard(
+            Effect.acquireRelease(Effect.void, () =>
+              Effect.sync(() => {
+                releases += 1
+              }),
+            ),
+          ),
+        ),
+      ),
+    )
+
+    expect(releases).toBe(1)
+  })
+
   test('recovers a pinned terminal qualification without inspecting data or writing state', async () => {
     let forbiddenCalls = 0
     const forbidden = (message: string) =>

--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -1,4 +1,5 @@
 import { Cause, Clock, Duration, Effect, Exit, Layer, Option, Ref, Schedule } from 'effect'
+import { isSqlError } from 'effect/unstable/sql/SqlError'
 
 import type { RuntimeConfig } from './config'
 import { makeRuntimeProvenance, type FinalizedSnapshotProvenance, type RuntimeProvenance } from './contracts'
@@ -23,6 +24,15 @@ import {
   type RuntimeState,
 } from './runtime-state'
 import type { Strategy } from './strategy-service'
+
+export const acquireSqlLayer = <A, E, R>(layer: Layer.Layer<A, E, R>) =>
+  Layer.build(layer).pipe(
+    Effect.retry({
+      times: 2,
+      schedule: Schedule.spaced(Duration.seconds(1)),
+      while: (error) => isSqlError(error) && error.isRetryable,
+    }),
+  )
 
 const withinDeadline = <A, R>(
   effect: Effect.Effect<A, OperationalError, R>,

--- a/services/bayn/src/index.ts
+++ b/services/bayn/src/index.ts
@@ -2,7 +2,7 @@ import { NodeHttpClient, NodeRuntime, NodeServices } from '@effect/platform-node
 import { ClickhouseClient } from '@effect/sql-clickhouse'
 import { Effect, Layer, Logger, Redacted } from 'effect'
 
-import { run } from './app'
+import { acquireSqlLayer, run } from './app'
 import { verifyParameterHash } from './build'
 import { loadConfig } from './config'
 import { makeRuntimeProvenance } from './contracts'
@@ -31,17 +31,18 @@ const main = Effect.gen(function* () {
     },
   })
   const strategy = makeStrategy(protocol, provenance)
+  const clickhouse = yield* acquireSqlLayer(
+    ClickhouseClient.layer({
+      url: config.clickhouse.url,
+      username: config.clickhouse.username,
+      password: Redacted.value(config.clickhouse.password),
+      database: 'signal',
+      application: 'bayn',
+      request_timeout: config.operationTimeoutMs,
+    }),
+  )
   const marketData = MarketDataLive(config, protocol).pipe(
-    Layer.provide(
-      ClickhouseClient.layer({
-        url: config.clickhouse.url,
-        username: config.clickhouse.username,
-        password: Redacted.value(config.clickhouse.password),
-        database: 'signal',
-        application: 'bayn',
-        request_timeout: config.operationTimeoutMs,
-      }),
-    ),
+    Layer.provide(Layer.succeedContext(clickhouse)),
     Layer.provide(NodeHttpClient.layerNodeHttp),
   )
   const dependencies = Layer.mergeAll(
@@ -50,7 +51,7 @@ const main = Effect.gen(function* () {
     EvidenceStoreLive(config).pipe(Layer.provide(NodeServices.layer)),
   )
   return yield* run(config, strategy).pipe(Effect.provide(dependencies))
-})
+}).pipe(Effect.scoped)
 
 const program = main.pipe(Effect.annotateLogs({ service: 'bayn' }), Effect.provide(Logger.layer([Logger.consoleJson])))
 


### PR DESCRIPTION
## Summary

- retry Effect SQL client acquisition after structured retryable connection failures instead of exiting the Bayn process after one five-second ClickHouse timeout
- scope the retry to the ClickHouse layer only; PostgreSQL, TigerBeetle, evaluation, qualification, and accounting work are never replayed
- keep the policy bounded to two retries with one-second spacing and fail non-retryable authentication/configuration errors immediately
- verify success, non-retryable failure, interruption, and exactly-once layer release with Effect TestClock coverage

## Related Issues

[PROOMPT-393](https://linear.app/proompteng/issue/PROOMPT-393/select-and-bind-the-authoritative-bayn-universe)

## Testing

- `bun run --filter @proompteng/bayn test` (118 passed, 25 integration tests skipped, 0 failed)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`

## Breaking Changes

None. Persistent or non-retryable SQL acquisition failures still fail startup; only Effect SQL failures marked retryable receive the bounded retry.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] No documentation or release-note follow-up is required.