### PR TITLE
build(hermes): package lab toolchain image

### DIFF
--- a/.github/workflows/hermes-toolchain-build-push.yml
+++ b/.github/workflows/hermes-toolchain-build-push.yml
@@ -1,0 +1,40 @@
+name: hermes-toolchain-build-push
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/actions/setup-nix-toolchain/**'
+      - '.github/workflows/hermes-toolchain-build-push.yml'
+      - '.github/workflows/nix-oci-build-common.yml'
+      - 'flake.lock'
+      - 'flake.nix'
+      - 'nix/ci-nix-oci-summary.sh'
+      - 'nix/ci-run-timed.sh'
+      - 'nix/images/hermes-toolchain.nix'
+      - 'nix/oci-inspect-archive.sh'
+      - 'nix/oci-push.sh'
+      - 'nix/oci-release-contract.sh'
+      - 'nix/packages.nix'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  nix-image:
+    uses: ./.github/workflows/nix-oci-build-common.yml
+    with:
+      image_name: hermes-toolchain
+      package_attr: hermes-toolchain-image
+      tag: sha-${{ github.sha }}
+      pr_number: ${{ github.event.pull_request.number || '' }}
+      latest: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' }}
+      publish_on_dispatch: true
+      release_artifact_name: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' && 'hermes-toolchain-release-contract' || '' }}
+    secrets: inherit

--- a/flake.nix
+++ b/flake.nix
@@ -213,6 +213,17 @@
             "arc-runner-image" = import ./nix/images/arc-runner.nix {
               inherit pkgs lib ciToolchain;
             };
+            "hermes-toolchain-image" = import ./nix/images/hermes-toolchain.nix {
+              inherit pkgs lib nodejs go;
+              inherit (exact)
+                bun
+                helm
+                kubeconform
+                kustomize
+                shellcheck
+                yq
+                ;
+            };
             "oirat-image" = import ./nix/images/oirat.nix {
               inherit pkgs lib nodejs;
               repoRoot = ./.;

--- a/nix/images/agents.nix
+++ b/nix/images/agents.nix
@@ -254,7 +254,7 @@ let
 
   depsHash = {
     x86_64-linux = "sha256-EY+nZK3pCullEk0zPkKQVY54wMFO/WzPPSitfZlhe5M=";
-    aarch64-linux = lib.fakeHash;
+    aarch64-linux = "sha256-uA8804g8MEmdyARzsVe4VrSoIlwunEq8rEcxkvdh1ek=";
   };
 
   installFilters = [

--- a/nix/images/agents.nix
+++ b/nix/images/agents.nix
@@ -253,8 +253,8 @@ let
   };
 
   depsHash = {
-    x86_64-linux = "sha256-j5l62hDf+S8Mj6DUADWjEL1j+tOf8ZuLh6Acj3+Qs+c=";
-    aarch64-linux = "sha256-e4JzqFcTPfksh5X+wrNfJ/PPHCNnjf82Up03j6CClKY=";
+    x86_64-linux = "sha256-EY+nZK3pCullEk0zPkKQVY54wMFO/WzPPSitfZlhe5M=";
+    aarch64-linux = lib.fakeHash;
   };
 
   installFilters = [

--- a/nix/images/hermes-toolchain.nix
+++ b/nix/images/hermes-toolchain.nix
@@ -1,0 +1,67 @@
+{
+  pkgs,
+  lib,
+  nodejs,
+  bun,
+  go,
+  helm,
+  kustomize,
+  kubeconform,
+  shellcheck,
+  yq,
+}:
+
+let
+  tools = [
+    nodejs
+    bun
+    go
+    helm
+    kustomize
+    kubeconform
+    shellcheck
+    pkgs.jq
+    yq
+  ];
+
+  toolchain = pkgs.buildEnv {
+    name = "hermes-lab-toolchain";
+    paths = tools;
+    pathsToLink = [ "/bin" ];
+  };
+in
+pkgs.dockerTools.buildLayeredImage {
+  name = "registry.ide-newton.ts.net/lab/hermes-toolchain";
+  tag = "nix";
+  created = "1970-01-01T00:00:01Z";
+  maxLayers = 32;
+  contents = [
+    toolchain
+    pkgs.cacert
+  ];
+  config = {
+    Cmd = [
+      "node"
+      "--version"
+    ];
+    Env = [
+      "PATH=${lib.makeBinPath tools}"
+      "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+    ];
+    Labels = {
+      "org.opencontainers.image.title" = "hermes-lab-toolchain";
+      "org.opencontainers.image.description" = "Curated Lab development and validation toolchain for Hermes";
+      "org.opencontainers.image.source" = "https://github.com/proompteng/lab";
+      "proompteng.ai/toolchain.bun" = lib.getVersion bun;
+      "proompteng.ai/toolchain.go" = lib.getVersion go;
+      "proompteng.ai/toolchain.helm" = lib.getVersion helm;
+      "proompteng.ai/toolchain.jq" = lib.getVersion pkgs.jq;
+      "proompteng.ai/toolchain.kubeconform" = lib.getVersion kubeconform;
+      "proompteng.ai/toolchain.kustomize" = lib.getVersion kustomize;
+      "proompteng.ai/toolchain.node" = lib.getVersion nodejs;
+      "proompteng.ai/toolchain.shellcheck" = lib.getVersion shellcheck;
+      "proompteng.ai/toolchain.yq" = lib.getVersion yq;
+    };
+    User = "10000:10000";
+  };
+}


### PR DESCRIPTION
## Summary

- Add a dedicated Nix OCI image containing the exact Lab Node, Bun, Go, Helm, Kustomize, kubeconform, ShellCheck, jq, and yq toolchain.
- Publish deterministic amd64 and arm64 images through the existing Nix OCI workflow with immutable release contracts.
- Refresh the locked Agents dependency closures required by the repository-wide shared-flake gate after recent `bun.lock` changes.
- Keep the runtime change separate: this PR publishes the artifact only; the follow-up rollout PR will pin its digest into Hermes.

Root cause: the upstream Hermes runtime has Node 22 and omits the repository build and infrastructure CLIs. Reusing the locked Nix package definitions prevents a second version source of truth. The shared `flake.nix` change also exercises the Agents Nix smoke build; its fixed-output dependency hashes had drifted after main changed `bun.lock`, so both architecture hashes were re-derived and verified without publishing branch images.

Operational impact: no workload manifests change in this PR. Merging triggers the Hermes toolchain image publication and, because `nix/images/agents.nix` changes, the existing Agents image publication workflow. The Hermes workload remains unchanged until the follow-up digest-pinning PR.

## Related Issues

None

## Testing

- `git diff --check`
- `nix-instantiate --parse nix/images/hermes-toolchain.nix`
- `nix-instantiate --parse nix/images/agents.nix`
- `bunx actionlint .github/workflows/hermes-toolchain-build-push.yml`
- Corrected non-publishing Agents workflow dispatch verified the dependency closure on both x86_64 and aarch64 runners (run 29894655355; representative jobs 88842148058 and 88842148103).
- Required PR CI run 29894650293.
- `nix flake check --no-build` deferred to CI because the local Nix daemon socket refused connections; the CI shared-compat validation covers the flake evaluation.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.