### PR TITLE
fix(bayn): preserve ClickHouse failure retryability

### DIFF
--- a/services/bayn/src/market-data.test.ts
+++ b/services/bayn/src/market-data.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from 'bun:test'
 
+import { AuthorizationError, ConnectionError, SqlError } from 'effect/unstable/sql/SqlError'
+
 import {
+  marketDataOperationError,
   verifyFinalizedCalendar,
   verifyFinalizedManifest,
   verifyFinalizedSnapshot,
@@ -183,6 +186,28 @@ const makeFixture = (): {
 }
 
 describe('finalized Signal snapshot reader', () => {
+  test('preserves ClickHouse retryability for check, inspect, and load failures', () => {
+    for (const operation of ['check', 'inspect', 'load'] as const) {
+      const authorization = marketDataOperationError(
+        operation,
+        'Signal query failed',
+        new SqlError({
+          reason: new AuthorizationError({ cause: new Error('SELECT denied'), operation: 'query' }),
+        }),
+      )
+      const connection = marketDataOperationError(
+        operation,
+        'Signal query failed',
+        new SqlError({
+          reason: new ConnectionError({ cause: new Error('connection reset'), operation: 'query' }),
+        }),
+      )
+
+      expect(authorization).toMatchObject({ component: 'market-data', operation, retryable: false })
+      expect(connection).toMatchObject({ component: 'market-data', operation, retryable: true })
+    }
+  })
+
   test('reproduces the authoritative V2 manifest and snapshot identities', () => {
     const universe = ['AMD', 'AVGO', 'COHR', 'CRDO', 'LITE', 'MRVL', 'MU', 'NVDA', 'WDC'] as const
     const publication = verifyFinalizedManifest([authoritativeManifest], {

--- a/services/bayn/src/market-data.ts
+++ b/services/bayn/src/market-data.ts
@@ -1,5 +1,6 @@
 import { ClickhouseClient } from '@effect/sql-clickhouse'
 import { Clock, Context, Effect, Layer, Schema } from 'effect'
+import { isSqlError } from 'effect/unstable/sql/SqlError'
 
 import type { RuntimeConfig } from './config'
 import { type EvaluationBounds, type FinalizedSnapshotProvenance, FinalizedSnapshotProvenanceSchema } from './contracts'
@@ -147,6 +148,16 @@ export interface MarketDataService {
 }
 
 export class MarketData extends Context.Service<MarketData, MarketDataService>()('bayn/MarketData') {}
+
+export const marketDataOperationError = (
+  operation: 'check' | 'inspect' | 'load',
+  message: string,
+  cause: unknown,
+): OperationalError => {
+  if (cause instanceof OperationalError) return cause
+  const makeError = isSqlError(cause) && !cause.isRetryable ? operationalError : retryableOperationalError
+  return makeError('market-data', operation, message, cause)
+}
 
 const asCount = (value: string | number, name: string): number => {
   const parsed = typeof value === 'number' ? value : Number(value)
@@ -586,9 +597,7 @@ const makeMarketData = (
         )
       }).pipe(
         Effect.mapError((cause) =>
-          cause instanceof OperationalError
-            ? cause
-            : retryableOperationalError('market-data', 'check', 'failed to check finalized Signal snapshot', cause),
+          marketDataOperationError('check', 'failed to check finalized Signal snapshot', cause),
         ),
       ),
       inspect: Effect.gen(function* () {
@@ -598,9 +607,7 @@ const makeMarketData = (
         return yield* verify('inspect', () => verifyFinalizedCalendar(rows, request(observedAt)))
       }).pipe(
         Effect.mapError((cause) =>
-          cause instanceof OperationalError
-            ? cause
-            : retryableOperationalError('market-data', 'inspect', 'failed to inspect finalized Signal calendar', cause),
+          marketDataOperationError('inspect', 'failed to inspect finalized Signal calendar', cause),
         ),
       ),
       load: Effect.gen(function* () {
@@ -612,11 +619,7 @@ const makeMarketData = (
           verifyFinalizedSnapshot(decodeSnapshotRows(bars, sessions, manifests), request(observedAt)),
         )
       }).pipe(
-        Effect.mapError((cause) =>
-          cause instanceof OperationalError
-            ? cause
-            : retryableOperationalError('market-data', 'load', 'failed to load finalized Signal snapshot', cause),
-        ),
+        Effect.mapError((cause) => marketDataOperationError('load', 'failed to load finalized Signal snapshot', cause)),
       ),
     }
   })

--- a/services/bayn/src/resources.test.ts
+++ b/services/bayn/src/resources.test.ts
@@ -1,13 +1,14 @@
 import { describe, expect, test } from 'bun:test'
 
 import { Cause, Effect, Exit, Option, Redacted, Ref } from 'effect'
+import { AuthorizationError, SqlError } from 'effect/unstable/sql/SqlError'
 
 import { initialize } from './app'
 import type { RuntimeConfig } from './config'
 import { EvidenceStore, type EvidenceStoreService } from './db/evidence-store'
 import { operationalError } from './errors'
 import { Journal, JournalLive, type JournalService, type TigerBeetleClient } from './ledger'
-import { MarketData, type MarketDataService } from './market-data'
+import { MarketData, marketDataOperationError, type MarketDataService } from './market-data'
 import { initialState } from './runtime-state'
 import { makeStrategy } from './strategy'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
@@ -309,6 +310,31 @@ describe('Bayn resource lifecycle', () => {
     expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
       status: 'FAILED',
       error: expect.stringContaining('market-data.verify'),
+    })
+  })
+
+  test('keeps ClickHouse authorization failures observable as terminal startup failures', async () => {
+    const authorization = new SqlError({
+      reason: new AuthorizationError({ cause: new Error('SELECT denied'), operation: 'query' }),
+    })
+    const marketData = marketDataService(
+      Effect.fail(marketDataOperationError('load', 'failed to load finalized Signal snapshot', authorization)),
+    )
+    const state = await Effect.runPromise(Ref.make(initialState()))
+
+    await Effect.runPromise(
+      Effect.scoped(
+        initialize(config, state, fixtureStrategy).pipe(
+          Effect.provideService(Journal, successfulJournal),
+          Effect.provideService(EvidenceStore, successfulEvidenceStore),
+          Effect.provideService(MarketData, marketData),
+        ),
+      ),
+    )
+
+    expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
+      status: 'FAILED',
+      error: expect.stringContaining('market-data.load'),
     })
   })
 


### PR DESCRIPTION
## Summary

- Preserve structured Effect `SqlError.isRetryable` semantics across Signal `check`, `inspect`, and `load` queries.
- Keep persistent ClickHouse authorization and other non-retryable query failures observable as terminal `FAILED` startup state while transient connection failures remain restartable.
- Add direct retryability coverage and a startup lifecycle regression without changing database code or contracts.

## Related Issues

Follow-up to #13063 review discussion https://github.com/proompteng/lab/pull/13063#discussion_r3627769446

## Testing

- `bun test services/bayn/src/market-data.test.ts services/bayn/src/resources.test.ts` — 19 passed
- `bun run --filter @proompteng/bayn test` — 123 passed, 25 DB integration tests skipped locally, 0 failed
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- `bun test packages/scripts/src/bayn` — 5 passed
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation and release notes are not required for this failure-classification correction.