### PR TITLE
fix(bayn): provide ClickHouse HTTP client

### DIFF
--- a/services/bayn/src/index.ts
+++ b/services/bayn/src/index.ts
@@ -40,7 +40,7 @@ const main = Effect.gen(function* () {
       database: 'signal',
       application: 'bayn',
       request_timeout: config.operationTimeoutMs,
-    }),
+    }).pipe(Layer.provide(NodeHttpClient.layerNodeHttp)),
   )
   const marketData = MarketDataLive(config, protocol).pipe(
     Layer.provide(Layer.succeedContext(clickhouse)),


### PR DESCRIPTION
## Summary

- provide the Node HTTP client while constructing the Effect ClickHouse layer
- make SQL acquisition self-contained instead of depending on a later market-data provider
- address the unresolved P1 review finding from PR #13064

## Related Issues

None. Follow-up to #13064 and https://github.com/proompteng/lab/pull/13064#discussion_r3627709954.

## Testing

- `bun test services/bayn/src/clickhouse-patch.test.ts`
- `bun run --filter @proompteng/bayn test` (121 passed, 25 integration tests skipped because no test PostgreSQL URL was configured)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation, release notes, and follow-ups are updated or tracked.