### PR TITLE
feat(hermes): add lab toolchain

### DIFF
--- a/.github/workflows/hermes-toolchain-release.yml
+++ b/.github/workflows/hermes-toolchain-release.yml
@@ -1,0 +1,200 @@
+name: hermes-toolchain-release
+
+on:
+  workflow_run:
+    workflows:
+      - hermes-toolchain-build-push
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: Commit SHA to promote.
+        required: false
+        type: string
+      image_tag:
+        description: Image tag to promote.
+        required: false
+        type: string
+      image_digest:
+        description: Image digest override (sha256:...).
+        required: false
+        type: string
+
+concurrency:
+  group: hermes-toolchain-release-${{ github.event.workflow_run.head_sha || inputs.commit_sha || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  promote:
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main')
+      }}
+    runs-on: arc-arm64
+    permissions:
+      actions: read
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Download release contract
+        if: github.event_name == 'workflow_run'
+        uses: actions/download-artifact@v4
+        with:
+          name: hermes-toolchain-release-contract
+          path: .artifacts/hermes-toolchain
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Nix toolchain
+        uses: ./.github/actions/setup-nix-toolchain
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          require-preinstalled: 'true'
+          install-ci-toolchain: 'true'
+          extra-nix-config: |
+            experimental-features = nix-command flakes
+            substituters = http://attic.attic.svc.cluster.local/lab https://cache.nixos.org/
+            extra-trusted-public-keys = ${{ vars.ATTIC_PUBLIC_KEY }}
+
+      - name: Resolve release metadata
+        id: meta
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          COMMIT_SHA_INPUT: ${{ inputs.commit_sha }}
+          IMAGE_TAG_INPUT: ${{ inputs.image_tag }}
+          IMAGE_DIGEST_INPUT: ${{ inputs.image_digest }}
+        run: |
+          set -euo pipefail
+          image='registry.ide-newton.ts.net/lab/hermes-toolchain'
+          contract='.artifacts/hermes-toolchain/release-contract.json'
+
+          if [[ "${EVENT_NAME}" == "workflow_run" ]]; then
+            source_sha="$(jq -r '.sourceSha' "${contract}")"
+            tag="$(jq -r '.tag' "${contract}")"
+            digest="$(jq -r '.digest' "${contract}")"
+            contract_image="$(jq -r '.image' "${contract}")"
+            test "${source_sha}" = "${WORKFLOW_RUN_HEAD_SHA}"
+            test "${contract_image}" = "${image}"
+          else
+            source_sha="${COMMIT_SHA_INPUT:-$(git rev-parse HEAD)}"
+            tag="${IMAGE_TAG_INPUT:-sha-${source_sha}}"
+            digest="${IMAGE_DIGEST_INPUT:-}"
+            if [[ -z "${digest}" ]]; then
+              digest="$(crane digest "${image}:${tag}")"
+            fi
+          fi
+
+          if [[ ! "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "Invalid Hermes toolchain digest: ${digest}" >&2
+            exit 1
+          fi
+          if [[ "${source_sha}" != "$(git rev-parse HEAD)" ]]; then
+            changed_paths="$(git diff --name-only "${source_sha}..HEAD")"
+            toolchain_input_changes="$({
+              printf '%s\n' "${changed_paths}" | grep -E \
+                -e '^\.github/actions/setup-nix-toolchain/' \
+                -e '^\.github/workflows/hermes-toolchain-build-push\.yml$' \
+                -e '^\.github/workflows/nix-oci-build-common\.yml$' \
+                -e '^flake\.lock$' \
+                -e '^flake\.nix$' \
+                -e '^nix/ci-nix-oci-summary\.sh$' \
+                -e '^nix/ci-run-timed\.sh$' \
+                -e '^nix/images/hermes-toolchain\.nix$' \
+                -e '^nix/oci-inspect-archive\.sh$' \
+                -e '^nix/oci-push\.sh$' \
+                -e '^nix/oci-release-contract\.sh$' \
+                -e '^nix/packages\.nix$' || true
+            })"
+            if [[ -n "${toolchain_input_changes}" ]]; then
+              echo 'promote=false' >> "${GITHUB_OUTPUT}"
+              echo "Stale Hermes toolchain build ${source_sha}; current main is $(git rev-parse HEAD)." >&2
+              printf '%s\n' "${toolchain_input_changes}" >&2
+              exit 0
+            fi
+          fi
+
+          {
+            echo 'promote=true'
+            echo "image=${image}"
+            echo "tag=${tag}"
+            echo "digest=${digest}"
+            echo "source_sha=${source_sha}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Verify promoted Hermes toolchain index
+        if: steps.meta.outputs.promote == 'true'
+        env:
+          IMAGE: ${{ steps.meta.outputs.image }}
+          DIGEST: ${{ steps.meta.outputs.digest }}
+        run: |
+          set -euo pipefail
+          nix run .#assert-oci-platforms -- "${IMAGE}@${DIGEST}" linux/amd64 linux/arm64
+
+      - name: Update Hermes toolchain image
+        if: steps.meta.outputs.promote == 'true'
+        env:
+          IMAGE: ${{ steps.meta.outputs.image }}
+          DIGEST: ${{ steps.meta.outputs.digest }}
+        run: |
+          set -euo pipefail
+          export IMAGE_REF="${IMAGE}@${DIGEST}"
+          perl -0pi -e 's#reference: registry\.ide-newton\.ts\.net/lab/hermes-toolchain\@sha256:[0-9a-f]{64}#reference: $ENV{IMAGE_REF}#g' \
+            argocd/applications/hermes/statefulset.yaml
+          test "$(grep -cF "reference: ${IMAGE_REF}" argocd/applications/hermes/statefulset.yaml)" -eq 1
+
+      - name: Create Hermes toolchain release pull request
+        if: steps.meta.outputs.promote == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}
+          branch: codex/hermes-toolchain-release-${{ steps.meta.outputs.tag }}
+          title: 'chore(hermes): promote toolchain image ${{ steps.meta.outputs.tag }}'
+          commit-message: 'chore(hermes): promote toolchain image ${{ steps.meta.outputs.tag }}'
+          body: |
+            ## Summary
+
+            - Promote the Hermes Lab toolchain to `${{ steps.meta.outputs.image }}@${{ steps.meta.outputs.digest }}`.
+            - Source commit: `${{ steps.meta.outputs.source_sha }}`.
+            - Preserve the existing Hermes runtime, credentials, network policy, and read-only Kubernetes authority.
+
+            ## Related Issues
+
+            N/A
+
+            ## Testing
+
+            - `nix run .#assert-oci-platforms -- "${{ steps.meta.outputs.image }}@${{ steps.meta.outputs.digest }}" linux/amd64 linux/arm64`
+            - `bun run scripts/hermes/validate-production.ts`
+
+            ## Screenshots (if applicable)
+
+            N/A
+
+            ## Breaking Changes
+
+            None
+
+            ## Checklist
+
+            - [x] Testing section documents the exact validation performed (or `N/A` with justification).
+            - [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
+            - [x] Documentation, release notes, and follow-ups are updated or tracked.
+          labels: |
+            automated-pr
+            nix-oci
+            agents
+          add-paths: |
+            argocd/applications/hermes/statefulset.yaml
+
+      - name: Promotion skipped
+        if: steps.meta.outputs.promote != 'true'
+        run: echo 'Skipping stale Hermes toolchain promotion because image inputs changed after the build.'

--- a/argocd/applications/hermes/README.md
+++ b/argocd/applications/hermes/README.md
@@ -12,6 +12,11 @@ never use the Discord token concurrently.
 - Upstream multi-architecture index: `sha256:9c841866021c54c4596849f6135717e8a4d52ba510b7f52c50aef1de1a283973`.
 - Mirrored amd64 manifest: `registry.ide-newton.ts.net/lab/hermes-agent@sha256:3db34ce19adfa080736a2a3feb0316dbcccc588faa9afe7fd8ae1c03b4f1a53a`.
 - Squid egress proxy: `docker.io/ubuntu/squid:6.6-24.04_edge` pinned by digest in `egress-proxy.yaml`.
+- Lab toolchain:
+  `registry.ide-newton.ts.net/lab/hermes-toolchain@sha256:3ced4cade50538d778f1438754fea57b2f7bce1fb2e6ab0e92787a707c66d031`.
+  The dedicated multi-architecture Nix OCI image is pinned by index digest and restricted to Node `24.11.1`, Bun/Bunx
+  `1.3.14`, Go `1.25.5`, Helm `3.19.1`, Kustomize `5.8.0`, kubeconform `0.7.0`, ShellCheck `0.11.0`, jq `1.8.1`, and yq
+  `4.49.2`.
 
 All runtime image references are immutable digests. Updating Hermes requires a new release review, amd64 mirror, rootless
 smoke test, manifest change, and normal CI/Codex review.
@@ -32,6 +37,9 @@ smoke test, manifest change, and normal CI/Codex review.
   only `get`, `list`, and `watch`, excludes core Secrets and interactive Pod subresources, and is bound cluster-wide only to
   the `hermes` ServiceAccount. Bootstrap writes a non-secret kubeconfig that follows the rotating projected token by file
   path rather than persisting token material.
+- Hermes receives the curated Lab toolchain through a second read-only OCI image volume. Only its `/bin` facade and
+  `/nix/store` closure are mounted; the image does not include Nix, a container engine, GitHub credentials, `kubectl`, or
+  any additional Kubernetes authority. Bootstrap fails closed unless every tool reports the repository-pinned version.
 - The API key comes from `onepassword-infra` through External Secrets. No secret is committed to Git.
 - The `tuslagch` GitHub OAuth token is committed only as a namespace-scoped SealedSecret ciphertext. Only the bootstrap init
   container receives `GH_TOKEN`; it creates mode-`0600` GitHub CLI auth files in a per-Pod `emptyDir` shared read-only with
@@ -44,7 +52,7 @@ smoke test, manifest change, and normal CI/Codex review.
   `83d5c2ccad5498f58bf6368acb1ab32588cf43ab3a4b1c301bf36328b1c8bd60`, caches the verified archive, and recreates the
   `tuslagch` Git identity, GitHub CLI authentication, and `gh auth git-credential` helper on every start. Bootstrap fails
   closed unless `gh api user` returns `tuslagch` and repository permission is `ADMIN`.
-- The immutable `/etc/profile.d/hermes-tools.sh` restores `/opt/tools` and the pinned Hermes paths after Debian's login
+- The immutable `/etc/profile.d/hermes-tools.sh` restores `/opt/tools`, `/opt/lab-toolchain/bin`, and the pinned Hermes paths after Debian's login
   profile resets `PATH`; Hermes explicitly sources it while capturing each terminal session, so bare `gh` and `kubectl`
   resolve consistently from API and Discord terminals.
 - API key rotation requires a bounded Secret refresh, gateway Pod restart, and old-key rejection/new-key acceptance proof.

--- a/argocd/applications/hermes/bootstrap.sh
+++ b/argocd/applications/hermes/bootstrap.sh
@@ -3,6 +3,33 @@ set -eu
 
 umask 077
 
+toolchain_bin=/opt/lab-toolchain/bin
+
+check_tool_version() {
+  tool_name=$1
+  expected_version=$2
+  shift 2
+  actual_version=$("$@")
+  if [ "$actual_version" != "$expected_version" ]; then
+    printf '%s version mismatch: expected %s, got %s\n' "$tool_name" "$expected_version" "$actual_version" >&2
+    exit 1
+  fi
+}
+
+check_tool_version node v24.11.1 "$toolchain_bin/node" --version
+check_tool_version bun 1.3.14 "$toolchain_bin/bun" --version
+check_tool_version bunx 1.3.14 "$toolchain_bin/bunx" --version
+check_tool_version go 'go version go1.25.5 linux/amd64' "$toolchain_bin/go" version
+check_tool_version helm v3.19.1 "$toolchain_bin/helm" version --template '{{.Version}}'
+check_tool_version jq jq-1.8.1 "$toolchain_bin/jq" --version
+check_tool_version kustomize v5.8.0 "$toolchain_bin/kustomize" version
+check_tool_version kubeconform v0.7.0 "$toolchain_bin/kubeconform" -v
+shellcheck_version=$("$toolchain_bin/shellcheck" --version | sed -n 's/^version: //p')
+check_tool_version shellcheck 0.11.0 printf '%s' "$shellcheck_version"
+yq_version=$("$toolchain_bin/yq" --version | sed 's/^.* version //')
+check_tool_version yq v4.49.2 printf '%s' "$yq_version"
+unset shellcheck_version yq_version
+
 mkdir -p \
   /opt/data/cron \
   /opt/data/home \

--- a/argocd/applications/hermes/bootstrap/TOOLS.md
+++ b/argocd/applications/hermes/bootstrap/TOOLS.md
@@ -5,6 +5,8 @@
 - Primary model: `qwen36-flamingo` through the internal Flamingo service.
 - Default agent working directory and local lab checkout: `/opt/data/workspace/tuslagch/lab`.
 - GitHub CLI `2.96.0` and Git are authenticated as `tuslagch`; use `codex/` branches and pull requests for authorized changes.
+- The immutable Lab toolchain provides Node `24.11.1`, Bun/Bunx `1.3.14`, Go `1.25.5`, Helm `3.19.1`, Kustomize
+  `5.8.0`, kubeconform `0.7.0`, ShellCheck `0.11.0`, jq `1.8.1`, and yq `4.49.2` from `/opt/lab-toolchain/bin`.
 - `kubectl` has cluster-wide read access to non-secret resources. Writes, Kubernetes Secrets, exec, attach, copy, proxy, and
   port-forward are denied by RBAC.
 - Host mounts, container sockets, cloud fallbacks, MCP servers, cron, dashboard, and delegation are not available.

--- a/argocd/applications/hermes/statefulset.yaml
+++ b/argocd/applications/hermes/statefulset.yaml
@@ -123,6 +123,14 @@ spec:
             - name: kubectl-image
               mountPath: /opt/kubectl-image
               readOnly: true
+            - name: lab-toolchain-image
+              mountPath: /opt/lab-toolchain/bin
+              subPath: bin
+              readOnly: true
+            - name: lab-toolchain-image
+              mountPath: /nix/store
+              subPath: nix/store
+              readOnly: true
             - name: tools
               mountPath: /opt/tools
             - name: github-auth
@@ -164,7 +172,7 @@ spec:
             - name: GIT_TERMINAL_PROMPT
               value: "0"
             - name: PATH
-              value: /opt/tools:/opt/hermes/bin:/opt/hermes/.venv/bin:/opt/data/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+              value: /opt/tools:/opt/lab-toolchain/bin:/opt/hermes/bin:/opt/hermes/.venv/bin:/opt/data/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
             - name: API_SERVER_ENABLED
               value: "true"
             - name: API_SERVER_HOST
@@ -290,6 +298,14 @@ spec:
             - name: tools
               mountPath: /opt/tools
               readOnly: true
+            - name: lab-toolchain-image
+              mountPath: /opt/lab-toolchain/bin
+              subPath: bin
+              readOnly: true
+            - name: lab-toolchain-image
+              mountPath: /nix/store
+              subPath: nix/store
+              readOnly: true
             - name: github-auth
               mountPath: /opt/github-auth
               readOnly: true
@@ -312,6 +328,10 @@ spec:
         - name: kubectl-image
           image:
             reference: registry.k8s.io/kubectl@sha256:0bb95b2a450875fc8ceaea2f9987a99fe27c228846e2e00b93b65ebb0d59034e
+            pullPolicy: IfNotPresent
+        - name: lab-toolchain-image
+          image:
+            reference: registry.ide-newton.ts.net/lab/hermes-toolchain@sha256:3ced4cade50538d778f1438754fea57b2f7bce1fb2e6ab0e92787a707c66d031
             pullPolicy: IfNotPresent
         - name: tools
           emptyDir:

--- a/argocd/applications/hermes/terminal-profile.sh
+++ b/argocd/applications/hermes/terminal-profile.sh
@@ -3,4 +3,4 @@
 # Debian's /etc/profile replaces the container PATH for every login shell.
 # Hermes captures that login environment for terminal sessions, so reassert
 # the immutable production tool path after the system profile initializes.
-export PATH='/opt/tools:/opt/hermes/bin:/opt/hermes/.venv/bin:/opt/data/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+export PATH='/opt/tools:/opt/lab-toolchain/bin:/opt/hermes/bin:/opt/hermes/.venv/bin:/opt/data/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'

--- a/docs/runbooks/hermes-production-rollout.md
+++ b/docs/runbooks/hermes-production-rollout.md
@@ -29,19 +29,41 @@ main_revision=$(git rev-parse origin/main)
 test "$(git rev-parse HEAD)" = "$main_revision"
 upstream_digest=$(crane digest docker.io/nousresearch/hermes-agent:v2026.7.7.2)
 mirror_digest=$(crane digest registry.ide-newton.ts.net/lab/hermes-agent:v2026.7.7.2-amd64)
+toolchain_ref=registry.ide-newton.ts.net/lab/hermes-toolchain@sha256:3ced4cade50538d778f1438754fea57b2f7bce1fb2e6ab0e92787a707c66d031
+toolchain_digest=$(crane digest "$toolchain_ref")
 test "$upstream_digest" = sha256:9c841866021c54c4596849f6135717e8a4d52ba510b7f52c50aef1de1a283973
 test "$mirror_digest" = sha256:3db34ce19adfa080736a2a3feb0316dbcccc588faa9afe7fd8ae1c03b4f1a53a
+test "$toolchain_digest" = sha256:3ced4cade50538d778f1438754fea57b2f7bce1fb2e6ab0e92787a707c66d031
+toolchain_platforms=$(crane manifest "$toolchain_ref" | jq -r \
+  '[.manifests[].platform | "\(.os)/\(.architecture)"] | sort | join(",")')
+test "$toolchain_platforms" = linux/amd64,linux/arm64
+for platform in linux/amd64 linux/arm64; do
+  crane config --platform "$platform" "$toolchain_ref" | jq -e '
+    .config.Labels["proompteng.ai/toolchain.node"] == "24.11.1" and
+    .config.Labels["proompteng.ai/toolchain.bun"] == "1.3.14" and
+    .config.Labels["proompteng.ai/toolchain.go"] == "1.25.5" and
+    .config.Labels["proompteng.ai/toolchain.helm"] == "3.19.1" and
+    .config.Labels["proompteng.ai/toolchain.kustomize"] == "5.8.0" and
+    .config.Labels["proompteng.ai/toolchain.kubeconform"] == "0.7.0" and
+    .config.Labels["proompteng.ai/toolchain.shellcheck"] == "0.11.0" and
+    .config.Labels["proompteng.ai/toolchain.jq"] == "1.8.1" and
+    .config.Labels["proompteng.ai/toolchain.yq"] == "4.49.2"
+  '
+done
 argocd app get hermes --refresh >/dev/null
 hermes_revision=$(kubectl -n argocd get application hermes -o jsonpath='{.status.sync.revision}')
 test "$hermes_revision" = "$main_revision"
 printf 'main=%s upstream=%s mirror=%s argo=%s\n' \
   "$main_revision" "$upstream_digest" "$mirror_digest" "$hermes_revision"
-unset main_revision upstream_digest mirror_digest hermes_revision
+printf 'toolchain=%s platforms=%s\n' "$toolchain_digest" "$toolchain_platforms"
+unset main_revision upstream_digest mirror_digest toolchain_ref toolchain_digest toolchain_platforms platform hermes_revision
 ```
 
 The expected upstream index digest is `sha256:9c841866021c54c4596849f6135717e8a4d52ba510b7f52c50aef1de1a283973`.
 The expected mirrored amd64 manifest digest is
 `sha256:3db34ce19adfa080736a2a3feb0316dbcccc588faa9afe7fd8ae1c03b4f1a53a`.
+The expected Hermes toolchain multi-architecture index digest is
+`sha256:3ced4cade50538d778f1438754fea57b2f7bce1fb2e6ab0e92787a707c66d031`.
 
 ## Phase 0: preflight and secret
 
@@ -209,7 +231,50 @@ The expected mirrored amd64 manifest digest is
    then monitors its last successful completion. A missing CronJob still alerts, and backup failure never changes the
    gateway Pod's readiness.
 
-2. Port-forward the cluster-local API and keep the key out of command output:
+2. Prove every curated development tool through the same login-shell boundary used by Hermes terminals, then run real
+   validation from the durable lab checkout without changing its existing branch or dirty state:
+
+   ```bash
+   kubectl -n hermes exec hermes-0 -c hermes -- /usr/bin/bash -lc '
+     set -euo pipefail
+     test "$(command -v gh)" = /opt/tools/gh
+     test "$(command -v kubectl)" = /opt/tools/kubectl
+     test "$(command -v node)" = /opt/lab-toolchain/bin/node
+     test "$(command -v bun)" = /opt/lab-toolchain/bin/bun
+     test "$(command -v bunx)" = /opt/lab-toolchain/bin/bunx
+     test "$(command -v go)" = /opt/lab-toolchain/bin/go
+     test "$(command -v helm)" = /opt/lab-toolchain/bin/helm
+     test "$(command -v jq)" = /opt/lab-toolchain/bin/jq
+     test "$(command -v kustomize)" = /opt/lab-toolchain/bin/kustomize
+     test "$(command -v kubeconform)" = /opt/lab-toolchain/bin/kubeconform
+     test "$(command -v shellcheck)" = /opt/lab-toolchain/bin/shellcheck
+     test "$(command -v yq)" = /opt/lab-toolchain/bin/yq
+     test "$(node --version)" = v24.11.1
+     test "$(bun --version)" = 1.3.14
+     test "$(bunx --version)" = 1.3.14
+     test "$(go version)" = "go version go1.25.5 linux/amd64"
+     test "$(helm version --template "{{.Version}}")" = v3.19.1
+     test "$(jq --version)" = jq-1.8.1
+     test "$(kustomize version)" = v5.8.0
+     test "$(kubeconform -v)" = v0.7.0
+     test "$(shellcheck --version | awk '\''$1 == "version:" { print $2 }'\'')" = 0.11.0
+     test "$(yq --version | sed '\''s/^.* version //'\'')" = v4.49.2
+     cd /opt/data/workspace/tuslagch/lab
+     workspace_status_before=$(git status --short)
+     bun run scripts/hermes/validate-production.ts
+     shellcheck argocd/applications/hermes/*.sh
+     kustomize build --enable-helm argocd/applications/hermes >/tmp/hermes-toolchain-render.yaml
+     kubeconform -strict -summary -ignore-missing-schemas /tmp/hermes-toolchain-render.yaml
+     go test ./services/prt -run "^$"
+     test "$(git status --short)" = "$workspace_status_before"
+     printf "hermes_lab_toolchain_ready=true checkout=%s\n" "$(git rev-parse HEAD)"
+   '
+   ```
+
+   The toolchain image supplies binaries only. GitHub authentication remains in `/opt/github-auth`, `kubectl` remains the
+   separately pinned read-only client, and this acceptance step must leave the existing checkout byte-for-byte untouched.
+
+3. Port-forward the cluster-local API and keep the key out of command output:
 
    ```bash
    kubectl -n hermes port-forward service/hermes 18642:8642
@@ -232,7 +297,7 @@ The expected mirrored amd64 manifest digest is
    unset hermes_api_key
    ```
 
-3. Prove state survives a restart. Create a harmless canary file, restart the pod, and read it back:
+4. Prove state survives a restart. Create a harmless canary file, restart the pod, and read it back:
 
    ```bash
    set -euo pipefail
@@ -242,7 +307,7 @@ The expected mirrored amd64 manifest digest is
    kubectl -n hermes exec hermes-0 -c hermes -- test -s /opt/data/workspace/tuslagch/.rollout-canary
    ```
 
-4. Prove direct-egress containment, public HTTPS through Squid, and private-destination denial:
+5. Prove direct-egress containment, public HTTPS through Squid, and private-destination denial:
 
    ```bash
    set -euo pipefail
@@ -271,7 +336,7 @@ The expected mirrored amd64 manifest digest is
    The direct public request must fail. Discord, GitHub, and an arbitrary public HTTPS destination must work through Squid,
    while the metadata destination must receive Squid's explicit denial.
 
-5. Prove the cluster reader and local lab checkout from inside the gateway:
+6. Prove the cluster reader and local lab checkout from inside the gateway:
 
    ```bash
    set -euo pipefail
@@ -301,7 +366,7 @@ The expected mirrored amd64 manifest digest is
    Secrets, service-account token subresources, `exec`, `attach`, `proxy`, and `port-forward`. The server-side dry-run is an
    authorization proof: it must be rejected before admission and must not create a ConfigMap.
 
-6. Prove the authenticated GitHub identity and non-mutating branch-push capability from inside the gateway:
+7. Prove the authenticated GitHub identity and non-mutating branch-push capability from inside the gateway:
 
    ```bash
    set -euo pipefail
@@ -895,6 +960,8 @@ The rollout record is complete only when it includes:
 
 - merged PRs and exact `main` revisions for API canary and Discord cutover;
 - image digests and upstream release commit;
+- Hermes toolchain index digest, both platform manifests, OCI version labels, exact login-shell versions, and real lab
+  validation with an unchanged checkout status;
 - Argo `Synced/Healthy` readback at those revisions;
 - ExternalSecret Ready conditions and secret field lengths/counts without values;
 - pod UID, read-only rootfs, scoped service-account token, NetworkPolicy, PVC, and verified backup evidence;

--- a/scripts/hermes/validate-production.test.ts
+++ b/scripts/hermes/validate-production.test.ts
@@ -48,6 +48,63 @@ test('rejects a mutable kubectl image volume', async () => {
   )
 })
 
+test('rejects a mutable Hermes toolchain image volume', async () => {
+  const files = await loadProductionFiles()
+  files.statefulSet = files.statefulSet.replace(
+    /registry\.ide-newton\.ts\.net\/lab\/hermes-toolchain@sha256:[a-f0-9]+/,
+    'registry.ide-newton.ts.net/lab/hermes-toolchain:latest',
+  )
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.statefulSet}: Lab tools must use exactly one immutable Hermes toolchain OCI volume`,
+  )
+})
+
+test('rejects omitting the Hermes toolchain bin mount from one container', async () => {
+  const files = await loadProductionFiles()
+  files.statefulSet = files.statefulSet.replace(
+    '              mountPath: /opt/lab-toolchain/bin\n              subPath: bin',
+    '              mountPath: /opt/lab-toolchain-disabled/bin\n              subPath: bin',
+  )
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.statefulSet}: init and gateway must mount the immutable toolchain bin facade read-only`,
+  )
+})
+
+test('rejects omitting the Hermes toolchain closure mount from one container', async () => {
+  const files = await loadProductionFiles()
+  files.statefulSet = files.statefulSet.replace(
+    '              mountPath: /nix/store\n              subPath: nix/store',
+    '              mountPath: /nix/store-disabled\n              subPath: nix/store',
+  )
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.statefulSet}: init and gateway must mount the immutable Nix closure read-only`,
+  )
+})
+
+test('rejects bootstrap without exact Hermes toolchain version checks', async () => {
+  const files = await loadProductionFiles()
+  files.bootstrap = files.bootstrap.replace(
+    'check_tool_version node v24.11.1 "$toolchain_bin/node" --version',
+    '"$toolchain_bin/node" --version',
+  )
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.bootstrap}: missing production invariant "check_tool_version node v24.11.1 \\"$toolchain_bin/node\\" --version"`,
+  )
+})
+
+test('rejects expanding the curated Hermes toolchain package set', async () => {
+  const files = await loadProductionFiles()
+  files.toolchainImage = files.toolchainImage.replace('    pkgs.jq\n', '    pkgs.jq\n    pkgs.docker-client\n')
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.toolchainImage}: contains forbidden production term "    pkgs.docker-client\\n"`,
+  )
+})
+
 test('rejects a gateway working directory above the lab checkout', async () => {
   const files = await loadProductionFiles()
   files.config = files.config.replace('  cwd: /opt/data/workspace/tuslagch/lab', '  cwd: /opt/data/workspace/tuslagch')
@@ -219,7 +276,7 @@ test('rejects persisting GitHub CLI auth on the Hermes data volume', async () =>
 test('rejects a terminal login profile that omits the production tools path', async () => {
   const files = await loadProductionFiles()
   const expectedExport =
-    "export PATH='/opt/tools:/opt/hermes/bin:/opt/hermes/.venv/bin:/opt/data/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'"
+    "export PATH='/opt/tools:/opt/lab-toolchain/bin:/opt/hermes/bin:/opt/hermes/.venv/bin:/opt/data/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'"
   files.terminalProfile = files.terminalProfile.replace(expectedExport, "export PATH='/usr/local/bin:/usr/bin:/bin'")
 
   expect(validateProductionContent(files)).toContain(

--- a/scripts/hermes/validate-production.ts
+++ b/scripts/hermes/validate-production.ts
@@ -5,10 +5,12 @@ const hermesImage =
   'registry.ide-newton.ts.net/lab/hermes-agent@sha256:3db34ce19adfa080736a2a3feb0316dbcccc588faa9afe7fd8ae1c03b4f1a53a'
 const squidImage = 'docker.io/ubuntu/squid@sha256:8a3baed477e2c282ab8aa5edad442f69873246964f225c5c2ae8364b6610963c'
 const kubectlImage = 'registry.k8s.io/kubectl@sha256:0bb95b2a450875fc8ceaea2f9987a99fe27c228846e2e00b93b65ebb0d59034e'
+const hermesToolchainImage =
+  'registry.ide-newton.ts.net/lab/hermes-toolchain@sha256:3ced4cade50538d778f1438754fea57b2f7bce1fb2e6ab0e92787a707c66d031'
 const githubCliVersion = '2.96.0'
 const githubCliArchiveSha256 = '83d5c2ccad5498f58bf6368acb1ab32588cf43ab3a4b1c301bf36328b1c8bd60'
 const terminalPath =
-  '/opt/tools:/opt/hermes/bin:/opt/hermes/.venv/bin:/opt/data/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+  '/opt/tools:/opt/lab-toolchain/bin:/opt/hermes/bin:/opt/hermes/.venv/bin:/opt/data/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
 
 export const productionPaths = {
   kustomization: 'argocd/applications/hermes/kustomization.yaml',
@@ -50,6 +52,9 @@ export const productionPaths = {
   runbook: 'docs/runbooks/hermes-production-rollout.md',
   impactMap: '.github/ci/impact-map.yml',
   pullRequestWorkflow: '.github/workflows/pull-request.yml',
+  toolchainImage: 'nix/images/hermes-toolchain.nix',
+  toolchainBuildWorkflow: '.github/workflows/hermes-toolchain-build-push.yml',
+  toolchainReleaseWorkflow: '.github/workflows/hermes-toolchain-release.yml',
 } as const
 
 export type ProductionPath = keyof typeof productionPaths
@@ -136,7 +141,7 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'mountPath: /opt/github-auth',
     'mountPath: /etc/profile.d/hermes-tools.sh\n              subPath: terminal-profile.sh\n              readOnly: true',
     'sizeLimit: 1Mi',
-    'value: /opt/tools:/opt/hermes/bin:',
+    'value: /opt/tools:/opt/lab-toolchain/bin:/opt/hermes/bin:',
     'name: KUBECONFIG',
     'value: /opt/data/home/.kube/config',
     'name: GH_CONFIG_DIR',
@@ -169,6 +174,34 @@ export function validateProductionContent(files: ProductionFiles): string[] {
   ])
   if (count(files.statefulSet, `reference: ${kubectlImage}`) !== 1) {
     failures.push(`${productionPaths.statefulSet}: kubectl must use exactly one immutable Kubernetes 1.35 OCI volume`)
+  }
+  if (count(files.statefulSet, `reference: ${hermesToolchainImage}`) !== 1) {
+    failures.push(
+      `${productionPaths.statefulSet}: Lab tools must use exactly one immutable Hermes toolchain OCI volume`,
+    )
+  }
+  const toolchainBinMount = [
+    '            - name: lab-toolchain-image',
+    '              mountPath: /opt/lab-toolchain/bin',
+    '              subPath: bin',
+    '              readOnly: true',
+  ].join('\n')
+  const toolchainStoreMount = [
+    '            - name: lab-toolchain-image',
+    '              mountPath: /nix/store',
+    '              subPath: nix/store',
+    '              readOnly: true',
+  ].join('\n')
+  if (count(files.statefulSet, toolchainBinMount) !== 2) {
+    failures.push(
+      `${productionPaths.statefulSet}: init and gateway must mount the immutable toolchain bin facade read-only`,
+    )
+  }
+  if (count(files.statefulSet, toolchainStoreMount) !== 2) {
+    failures.push(`${productionPaths.statefulSet}: init and gateway must mount the immutable Nix closure read-only`)
+  }
+  if (count(files.statefulSet, '        - name: lab-toolchain-image\n          image:\n') !== 1) {
+    failures.push(`${productionPaths.statefulSet}: the toolchain must use exactly one OCI image volume`)
   }
   for (const key of ['DISCORD_BOT_TOKEN', 'DISCORD_ALLOWED_USERS']) {
     const reference = [
@@ -515,6 +548,17 @@ export function validateProductionContent(files: ProductionFiles): string[] {
   }
 
   requireTerms(failures, productionPaths.bootstrap, files.bootstrap, [
+    'toolchain_bin=/opt/lab-toolchain/bin',
+    'check_tool_version node v24.11.1 "$toolchain_bin/node" --version',
+    'check_tool_version bun 1.3.14 "$toolchain_bin/bun" --version',
+    'check_tool_version bunx 1.3.14 "$toolchain_bin/bunx" --version',
+    'check_tool_version go \'go version go1.25.5 linux/amd64\' "$toolchain_bin/go" version',
+    'check_tool_version helm v3.19.1 "$toolchain_bin/helm" version --template \'{{.Version}}\'',
+    'check_tool_version jq jq-1.8.1 "$toolchain_bin/jq" --version',
+    'check_tool_version kustomize v5.8.0 "$toolchain_bin/kustomize" version',
+    'check_tool_version kubeconform v0.7.0 "$toolchain_bin/kubeconform" -v',
+    'check_tool_version shellcheck 0.11.0',
+    'check_tool_version yq v4.49.2',
     'install -m 0555 /opt/kubectl-image/bin/kubectl /opt/tools/kubectl',
     '/opt/tools/kubectl version --client=true',
     'install -d -m 0700 "$kubeconfig_dir"',
@@ -604,6 +648,8 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'Writes, Kubernetes Secrets, exec, attach, copy, proxy, and',
     '/opt/data/workspace/tuslagch/lab',
     'GitHub CLI `2.96.0` and Git are authenticated as `tuslagch`',
+    'Node `24.11.1`, Bun/Bunx `1.3.14`, Go `1.25.5`',
+    '/opt/lab-toolchain/bin',
   ])
   requireTerms(failures, productionPaths.readme, files.readme, [
     'digest-pinned Kubernetes 1.35 `kubectl` binary',
@@ -616,6 +662,58 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'bounded retries for transient pod-network startup races',
     '/etc/profile.d/hermes-tools.sh',
     githubCliArchiveSha256,
+    'dedicated multi-architecture Nix OCI image is pinned by index digest',
+    hermesToolchainImage,
+    'Bootstrap fails closed unless every tool reports the repository-pinned version.',
+  ])
+
+  const expectedToolchainPackages = `tools = [
+    nodejs
+    bun
+    go
+    helm
+    kustomize
+    kubeconform
+    shellcheck
+    pkgs.jq
+    yq
+  ];`
+  requireTerms(failures, productionPaths.toolchainImage, files.toolchainImage, [
+    expectedToolchainPackages,
+    'name = "registry.ide-newton.ts.net/lab/hermes-toolchain";',
+    'created = "1970-01-01T00:00:01Z";',
+    'User = "10000:10000";',
+    '"proompteng.ai/toolchain.node" = lib.getVersion nodejs;',
+    '"proompteng.ai/toolchain.bun" = lib.getVersion bun;',
+    '"proompteng.ai/toolchain.go" = lib.getVersion go;',
+  ])
+  forbidTerms(failures, productionPaths.toolchainImage, files.toolchainImage, [
+    'pkgs.nix',
+    '    pkgs.docker-client\n',
+    '    pkgs.docker\n',
+    'pkgs.skopeo',
+    'pkgs.regclient',
+    'pkgs.gh',
+    'kubectl',
+    'argocd',
+    'opentofu',
+    'terraform',
+  ])
+  requireTerms(failures, productionPaths.toolchainBuildWorkflow, files.toolchainBuildWorkflow, [
+    'name: hermes-toolchain-build-push',
+    'image_name: hermes-toolchain',
+    'package_attr: hermes-toolchain-image',
+    'hermes-toolchain-release-contract',
+  ])
+  requireTerms(failures, productionPaths.toolchainReleaseWorkflow, files.toolchainReleaseWorkflow, [
+    'name: hermes-toolchain-release',
+    '      - hermes-toolchain-build-push',
+    'name: hermes-toolchain-release-contract',
+    'nix run .#assert-oci-platforms -- "${IMAGE}@${DIGEST}" linux/amd64 linux/arm64',
+    'argocd/applications/hermes/statefulset.yaml',
+    'automated-pr',
+    'nix-oci',
+    'agents',
   ])
 
   const operationDeadlines = {
@@ -887,6 +985,19 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'test "$(kubectl auth can-i create deployments.apps --all-namespaces || true)" = no',
     'test "$(pwd -P)" = /opt/data/workspace/tuslagch/lab',
     'test "$(git rev-parse --show-toplevel)" = /opt/data/workspace/tuslagch/lab',
+    'test "$(command -v node)" = /opt/lab-toolchain/bin/node',
+    'test "$(command -v bun)" = /opt/lab-toolchain/bin/bun',
+    'test "$(command -v go)" = /opt/lab-toolchain/bin/go',
+    'test "$(node --version)" = v24.11.1',
+    'test "$(bun --version)" = 1.3.14',
+    'test "$(go version)" = "go version go1.25.5 linux/amd64"',
+    'bun run scripts/hermes/validate-production.ts',
+    'shellcheck argocd/applications/hermes/*.sh',
+    'kustomize build --enable-helm argocd/applications/hermes >/tmp/hermes-toolchain-render.yaml',
+    'kubeconform -strict -summary -ignore-missing-schemas /tmp/hermes-toolchain-render.yaml',
+    'go test ./services/prt -run "^$"',
+    'test "$(git status --short)" = "$workspace_status_before"',
+    'hermes_lab_toolchain_ready=true checkout=%s',
     '! kubectl -n hermes get secret hermes-api-auth',
     '! kubectl -n hermes create configmap hermes-readonly-proof',
     'git -C /opt/data/workspace/tuslagch/lab remote get-url origin',
@@ -921,6 +1032,11 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'test "$(git rev-parse HEAD)" = "$main_revision"',
     'test "$upstream_digest" = sha256:9c841866021c54c4596849f6135717e8a4d52ba510b7f52c50aef1de1a283973',
     'test "$mirror_digest" = sha256:3db34ce19adfa080736a2a3feb0316dbcccc588faa9afe7fd8ae1c03b4f1a53a',
+    'toolchain_ref=registry.ide-newton.ts.net/lab/hermes-toolchain@sha256:3ced4cade50538d778f1438754fea57b2f7bce1fb2e6ab0e92787a707c66d031',
+    'test "$toolchain_digest" = sha256:3ced4cade50538d778f1438754fea57b2f7bce1fb2e6ab0e92787a707c66d031',
+    'test "$toolchain_platforms" = linux/amd64,linux/arm64',
+    '.config.Labels["proompteng.ai/toolchain.node"] == "24.11.1"',
+    '.config.Labels["proompteng.ai/toolchain.yq"] == "4.49.2"',
     'argocd app get hermes --refresh >/dev/null',
     "hermes_revision=$(kubectl -n argocd get application hermes -o jsonpath='{.status.sync.revision}')",
     'test "$hermes_revision" = "$main_revision"',


### PR DESCRIPTION
## Summary

- Pin the multi-architecture Hermes Lab toolchain index from #13065 at `registry.ide-newton.ts.net/lab/hermes-toolchain@sha256:3ced4cade50538d778f1438754fea57b2f7bce1fb2e6ab0e92787a707c66d031`.
- Mount only its read-only `/bin` facade and Nix closure into the bootstrap init container and regular Hermes gateway Pod.
- Fail bootstrap unless Node 24.11.1, Bun/Bunx 1.3.14, Go 1.25.5, Helm 3.19.1, Kustomize 5.8.0, kubeconform 0.7.0, ShellCheck 0.11.0, jq 1.8.1, and yq 4.49.2 match exactly.
- Add immutable-image/mount/package-set regression coverage, rollout evidence, and future digest-promotion automation.

Root cause: the upstream Hermes runtime carries Node 22 but omits the repository build and infrastructure validation CLIs, so the production agent could inspect Lab but could not validate normal Lab changes end to end.

Operational impact: this rolls only the existing regular Hermes StatefulSet Pod. It adds no VM, container engine, Nix CLI, secret access, RBAC verbs, network allowance, or Kubernetes write authority. Rollback is the manifest revert; the data and backup PVCs are retained.

## Related Issues

None

## Testing

- `git diff --check`
- `sh -n argocd/applications/hermes/bootstrap.sh argocd/applications/hermes/terminal-profile.sh`
- `shellcheck argocd/applications/hermes/*.sh`
- `actionlint .github/workflows/hermes-toolchain-build-push.yml .github/workflows/hermes-toolchain-release.yml`
- `oxfmt --check scripts/hermes/validate-production.ts scripts/hermes/validate-production.test.ts`
- `nix-instantiate --parse nix/images/hermes-toolchain.nix`
- `bun run scripts/hermes/validate-production.ts` (42 surfaces)
- `bun test scripts/hermes/*.test.ts` (123 pass)
- `kustomize build --enable-helm argocd/applications/hermes`
- `kubeconform -strict -summary -ignore-missing-schemas /tmp/hermes-toolchain-rollout.yaml` (16 valid, 0 invalid, 3 skipped)
- `kubectl -n hermes apply --dry-run=server -f /tmp/hermes-toolchain-rollout.yaml` (19 resources accepted)
- CI publication run 29895323214 verified the OCI index platforms and release contract; both platform configs carry the exact version labels.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
