### PR TITLE
feat(bayn): define paper operation contracts

### DIFF
--- a/services/bayn/migrations/0002_paper_contracts.ts
+++ b/services/bayn/migrations/0002_paper_contracts.ts
@@ -1,0 +1,606 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+const immutableTables = [
+  'broker_events',
+  'account_snapshots',
+  'positions',
+  'orders',
+  'fills',
+  'broker_errors',
+  'rate_limits',
+  'risk_decisions',
+  'accounting_receipts',
+  'valuations',
+  'reconciliations',
+] as const
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient
+
+  yield* sql`
+    CREATE TABLE intents (
+      intent_id text PRIMARY KEY CHECK (intent_id ~ '^[0-9a-f]{64}$'),
+      schema_version text NOT NULL CHECK (schema_version = 'bayn.paper-intent.v1'),
+      risk_decision_id text CHECK (risk_decision_id ~ '^[0-9a-f]{64}$'),
+      account_id text NOT NULL CHECK (length(account_id) > 0 AND account_id = btrim(account_id)),
+      client_order_id text NOT NULL CHECK (length(client_order_id) > 0 AND client_order_id = btrim(client_order_id)),
+      symbol text NOT NULL CHECK (symbol ~ '^[A-Z][A-Z0-9.-]{0,15}$'),
+      side text NOT NULL CHECK (side IN ('BUY', 'SELL')),
+      order_type text NOT NULL CHECK (order_type IN ('MARKET', 'LIMIT')),
+      time_in_force text NOT NULL CHECK (time_in_force IN ('DAY', 'GTC', 'IOC', 'FOK')),
+      quantity_micros numeric(39, 0) NOT NULL CHECK (
+        quantity_micros > 0
+        AND quantity_micros <= 340282366920938463463374607431768211455
+      ),
+      notional_limit_micros numeric(39, 0) NOT NULL CHECK (
+        notional_limit_micros > 0
+        AND notional_limit_micros <= 340282366920938463463374607431768211455
+      ),
+      state text NOT NULL CHECK (
+        state IN ('PLANNED', 'APPROVED', 'IO_STARTED', 'ACKNOWLEDGED', 'UNKNOWN', 'TERMINAL', 'RECOVERED')
+      ),
+      terminal_outcome text CHECK (
+        terminal_outcome IN ('FILLED', 'CANCELED', 'EXPIRED', 'REJECTED', 'BLOCKED')
+      ),
+      state_version bigint NOT NULL DEFAULT 1 CHECK (state_version > 0),
+      created_at timestamptz NOT NULL,
+      updated_at timestamptz NOT NULL,
+      UNIQUE (intent_id, account_id),
+      UNIQUE (account_id, client_order_id),
+      CHECK (updated_at >= created_at),
+      CHECK (
+        (state = 'PLANNED' AND risk_decision_id IS NULL)
+        OR (state <> 'PLANNED' AND risk_decision_id IS NOT NULL)
+      ),
+      CHECK (
+        (state = 'TERMINAL' AND terminal_outcome IS NOT NULL)
+        OR (state <> 'TERMINAL' AND terminal_outcome IS NULL)
+      )
+    )
+  `
+
+  yield* sql`
+    CREATE TABLE broker_events (
+      event_id text PRIMARY KEY CHECK (event_id ~ '^[0-9a-f]{64}$'),
+      schema_version text NOT NULL CHECK (schema_version = 'bayn.paper-broker-event.v1'),
+      content_hash text NOT NULL CHECK (content_hash ~ '^[0-9a-f]{64}$'),
+      event_kind text NOT NULL CHECK (event_kind IN ('ACCOUNT', 'POSITION', 'ORDER', 'FILL', 'ERROR', 'RATE_LIMIT')),
+      broker text NOT NULL CHECK (broker = 'ALPACA'),
+      account_id text NOT NULL CHECK (length(account_id) > 0 AND account_id = btrim(account_id)),
+      source_event_id text NOT NULL CHECK (
+        length(source_event_id) > 0 AND source_event_id = btrim(source_event_id)
+      ),
+      source_sequence numeric(20, 0) NOT NULL CHECK (
+        source_sequence >= 0 AND source_sequence <= 18446744073709551615
+      ),
+      occurred_at timestamptz NOT NULL,
+      observed_at timestamptz NOT NULL,
+      UNIQUE (broker, account_id, source_event_id),
+      UNIQUE (broker, account_id, source_sequence),
+      UNIQUE (event_id, account_id, event_kind),
+      CHECK (observed_at >= occurred_at)
+    )
+  `
+
+  yield* sql`
+    CREATE TABLE account_snapshots (
+      event_id text PRIMARY KEY,
+      account_id text NOT NULL,
+      event_kind text GENERATED ALWAYS AS ('ACCOUNT') STORED,
+      schema_version text NOT NULL CHECK (schema_version = 'bayn.paper-account-snapshot.v1'),
+      status text NOT NULL CHECK (status IN ('ACTIVE', 'RESTRICTED', 'CLOSED')),
+      currency text NOT NULL CHECK (currency = 'USD'),
+      cash_micros numeric(39, 0) NOT NULL CHECK (
+        cash_micros BETWEEN -170141183460469231731687303715884105728
+        AND 170141183460469231731687303715884105727
+      ),
+      equity_micros numeric(39, 0) NOT NULL CHECK (
+        equity_micros BETWEEN -170141183460469231731687303715884105728
+        AND 170141183460469231731687303715884105727
+      ),
+      buying_power_micros numeric(39, 0) NOT NULL CHECK (
+        buying_power_micros BETWEEN -170141183460469231731687303715884105728
+        AND 170141183460469231731687303715884105727
+      ),
+      FOREIGN KEY (event_id, account_id, event_kind)
+        REFERENCES broker_events(event_id, account_id, event_kind) ON DELETE RESTRICT
+    )
+  `
+
+  yield* sql`
+    CREATE TABLE positions (
+      event_id text PRIMARY KEY,
+      account_id text NOT NULL,
+      event_kind text GENERATED ALWAYS AS ('POSITION') STORED,
+      schema_version text NOT NULL CHECK (schema_version = 'bayn.paper-position.v1'),
+      symbol text NOT NULL CHECK (symbol ~ '^[A-Z][A-Z0-9.-]{0,15}$'),
+      quantity_micros numeric(39, 0) NOT NULL CHECK (
+        quantity_micros BETWEEN -170141183460469231731687303715884105728
+        AND 170141183460469231731687303715884105727
+      ),
+      average_entry_price_micros numeric(39, 0) NOT NULL CHECK (
+        average_entry_price_micros >= 0
+        AND average_entry_price_micros <= 340282366920938463463374607431768211455
+      ),
+      market_price_micros numeric(39, 0) NOT NULL CHECK (
+        market_price_micros >= 0
+        AND market_price_micros <= 340282366920938463463374607431768211455
+      ),
+      market_value_micros numeric(39, 0) NOT NULL CHECK (
+        market_value_micros BETWEEN -170141183460469231731687303715884105728
+        AND 170141183460469231731687303715884105727
+      ),
+      unrealized_pnl_micros numeric(39, 0) NOT NULL CHECK (
+        unrealized_pnl_micros BETWEEN -170141183460469231731687303715884105728
+        AND 170141183460469231731687303715884105727
+      ),
+      FOREIGN KEY (event_id, account_id, event_kind)
+        REFERENCES broker_events(event_id, account_id, event_kind) ON DELETE RESTRICT
+    )
+  `
+
+  yield* sql`
+    CREATE TABLE orders (
+      event_id text PRIMARY KEY,
+      account_id text NOT NULL,
+      event_kind text GENERATED ALWAYS AS ('ORDER') STORED,
+      schema_version text NOT NULL CHECK (schema_version = 'bayn.paper-order.v1'),
+      broker_order_id text NOT NULL UNIQUE CHECK (
+        length(broker_order_id) > 0 AND broker_order_id = btrim(broker_order_id)
+      ),
+      client_order_id text NOT NULL CHECK (
+        length(client_order_id) > 0 AND client_order_id = btrim(client_order_id)
+      ),
+      intent_id text,
+      symbol text NOT NULL CHECK (symbol ~ '^[A-Z][A-Z0-9.-]{0,15}$'),
+      side text NOT NULL CHECK (side IN ('BUY', 'SELL')),
+      order_type text NOT NULL CHECK (order_type IN ('MARKET', 'LIMIT')),
+      time_in_force text NOT NULL CHECK (time_in_force IN ('DAY', 'GTC', 'IOC', 'FOK')),
+      quantity_micros numeric(39, 0) NOT NULL CHECK (
+        quantity_micros > 0
+        AND quantity_micros <= 340282366920938463463374607431768211455
+      ),
+      filled_quantity_micros numeric(39, 0) NOT NULL CHECK (
+        filled_quantity_micros >= 0
+        AND filled_quantity_micros <= quantity_micros
+      ),
+      limit_price_micros numeric(39, 0) CHECK (
+        limit_price_micros > 0
+        AND limit_price_micros <= 340282366920938463463374607431768211455
+      ),
+      status text NOT NULL CHECK (
+        status IN ('NEW', 'PARTIALLY_FILLED', 'FILLED', 'CANCELED', 'EXPIRED', 'REJECTED', 'PENDING')
+      ),
+      UNIQUE (account_id, client_order_id),
+      CHECK (
+        (order_type = 'LIMIT' AND limit_price_micros IS NOT NULL)
+        OR (order_type = 'MARKET' AND limit_price_micros IS NULL)
+      ),
+      FOREIGN KEY (event_id, account_id, event_kind)
+        REFERENCES broker_events(event_id, account_id, event_kind) ON DELETE RESTRICT,
+      FOREIGN KEY (intent_id, account_id)
+        REFERENCES intents(intent_id, account_id) ON DELETE RESTRICT
+    )
+  `
+
+  yield* sql`
+    CREATE TABLE fills (
+      event_id text PRIMARY KEY,
+      account_id text NOT NULL,
+      event_kind text GENERATED ALWAYS AS ('FILL') STORED,
+      schema_version text NOT NULL CHECK (schema_version = 'bayn.paper-fill.v1'),
+      fill_id text NOT NULL UNIQUE CHECK (length(fill_id) > 0 AND fill_id = btrim(fill_id)),
+      broker_order_id text NOT NULL CHECK (
+        length(broker_order_id) > 0 AND broker_order_id = btrim(broker_order_id)
+      ),
+      client_order_id text NOT NULL CHECK (
+        length(client_order_id) > 0 AND client_order_id = btrim(client_order_id)
+      ),
+      intent_id text,
+      symbol text NOT NULL CHECK (symbol ~ '^[A-Z][A-Z0-9.-]{0,15}$'),
+      side text NOT NULL CHECK (side IN ('BUY', 'SELL')),
+      quantity_micros numeric(39, 0) NOT NULL CHECK (
+        quantity_micros > 0
+        AND quantity_micros <= 340282366920938463463374607431768211455
+      ),
+      price_micros numeric(39, 0) NOT NULL CHECK (
+        price_micros > 0
+        AND price_micros <= 340282366920938463463374607431768211455
+      ),
+      fee_micros numeric(39, 0) NOT NULL CHECK (
+        fee_micros >= 0
+        AND fee_micros <= 340282366920938463463374607431768211455
+      ),
+      FOREIGN KEY (event_id, account_id, event_kind)
+        REFERENCES broker_events(event_id, account_id, event_kind) ON DELETE RESTRICT,
+      FOREIGN KEY (intent_id, account_id)
+        REFERENCES intents(intent_id, account_id) ON DELETE RESTRICT
+    )
+  `
+
+  yield* sql`
+    CREATE TABLE broker_errors (
+      event_id text PRIMARY KEY,
+      account_id text NOT NULL,
+      event_kind text GENERATED ALWAYS AS ('ERROR') STORED,
+      schema_version text NOT NULL CHECK (schema_version = 'bayn.paper-broker-error.v1'),
+      request_id text NOT NULL CHECK (length(request_id) > 0 AND request_id = btrim(request_id)),
+      code text NOT NULL CHECK (length(code) > 0 AND code = btrim(code)),
+      message text NOT NULL CHECK (length(message) > 0 AND message = btrim(message)),
+      retryable boolean NOT NULL,
+      mutation_outcome text NOT NULL CHECK (mutation_outcome IN ('KNOWN', 'UNKNOWN')),
+      FOREIGN KEY (event_id, account_id, event_kind)
+        REFERENCES broker_events(event_id, account_id, event_kind) ON DELETE RESTRICT
+    )
+  `
+
+  yield* sql`
+    CREATE TABLE rate_limits (
+      event_id text PRIMARY KEY,
+      account_id text NOT NULL,
+      event_kind text GENERATED ALWAYS AS ('RATE_LIMIT') STORED,
+      schema_version text NOT NULL CHECK (schema_version = 'bayn.paper-rate-limit.v1'),
+      request_limit numeric(20, 0) NOT NULL CHECK (
+        request_limit >= 0 AND request_limit <= 18446744073709551615
+      ),
+      remaining numeric(20, 0) NOT NULL CHECK (remaining >= 0 AND remaining <= request_limit),
+      resets_at timestamptz NOT NULL,
+      FOREIGN KEY (event_id, account_id, event_kind)
+        REFERENCES broker_events(event_id, account_id, event_kind) ON DELETE RESTRICT
+    )
+  `
+
+  yield* sql`
+    CREATE FUNCTION text_array_is_unique(items text[])
+    RETURNS boolean
+    LANGUAGE sql
+    IMMUTABLE
+    STRICT
+    AS $function$
+      SELECT cardinality(items) = count(DISTINCT item)
+      FROM unnest(items) AS item
+    $function$
+  `
+
+  yield* sql`
+    CREATE TABLE risk_decisions (
+      decision_id text PRIMARY KEY CHECK (decision_id ~ '^[0-9a-f]{64}$'),
+      schema_version text NOT NULL CHECK (schema_version = 'bayn.paper-risk-decision.v1'),
+      input_hash text NOT NULL CHECK (input_hash ~ '^[0-9a-f]{64}$'),
+      intent_id text NOT NULL UNIQUE REFERENCES intents(intent_id) ON DELETE RESTRICT,
+      policy_hash text NOT NULL CHECK (policy_hash ~ '^[0-9a-f]{64}$'),
+      outcome text NOT NULL CHECK (outcome IN ('APPROVED', 'BLOCKED')),
+      reason_codes text[] NOT NULL CHECK (
+        array_ndims(reason_codes) = 1
+        AND array_position(reason_codes, '') IS NULL
+        AND array_position(reason_codes, NULL) IS NULL
+      ),
+      decided_at timestamptz NOT NULL,
+      expires_at timestamptz NOT NULL,
+      UNIQUE (decision_id, intent_id),
+      CHECK (expires_at > decided_at),
+      CHECK (
+        (outcome = 'APPROVED' AND cardinality(reason_codes) = 0)
+        OR (outcome = 'BLOCKED' AND cardinality(reason_codes) > 0)
+      ),
+      CHECK (text_array_is_unique(reason_codes))
+    )
+  `
+
+  yield* sql`
+    ALTER TABLE intents
+    ADD CONSTRAINT intents_risk_decision_fk
+    FOREIGN KEY (risk_decision_id, intent_id) REFERENCES risk_decisions(decision_id, intent_id)
+    ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED
+  `
+
+  yield* sql`
+    CREATE FUNCTION numeric_array_is_strictly_ascending(items numeric[])
+    RETURNS boolean
+    LANGUAGE sql
+    IMMUTABLE
+    STRICT
+    AS $function$
+      SELECT COALESCE(bool_and(items[index] < items[index + 1]), true)
+      FROM generate_subscripts(items, 1) AS index
+      WHERE index < array_upper(items, 1)
+    $function$
+  `
+
+  yield* sql`
+    CREATE TABLE accounting_receipts (
+      receipt_id text PRIMARY KEY CHECK (receipt_id ~ '^[0-9a-f]{64}$'),
+      schema_version text NOT NULL CHECK (schema_version = 'bayn.paper-accounting-receipt.v1'),
+      intent_id text REFERENCES intents(intent_id) ON DELETE RESTRICT,
+      broker_event_id text NOT NULL REFERENCES broker_events(event_id) ON DELETE RESTRICT,
+      tigerbeetle_cluster_id numeric(39, 0) NOT NULL CHECK (
+        tigerbeetle_cluster_id > 0
+        AND tigerbeetle_cluster_id <= 340282366920938463463374607431768211455
+      ),
+      tigerbeetle_ledger bigint NOT NULL CHECK (tigerbeetle_ledger BETWEEN 1 AND 4294967295),
+      account_ids numeric(39, 0)[] NOT NULL CHECK (
+        array_ndims(account_ids) = 1
+        AND array_lower(account_ids, 1) = 1
+        AND cardinality(account_ids) >= 2
+        AND numeric_array_is_strictly_ascending(account_ids)
+        AND account_ids[1] > 0
+        AND account_ids[cardinality(account_ids)] <= 340282366920938463463374607431768211455
+      ),
+      transfer_ids numeric(39, 0)[] NOT NULL CHECK (
+        array_ndims(transfer_ids) = 1
+        AND array_lower(transfer_ids, 1) = 1
+        AND cardinality(transfer_ids) >= 1
+        AND numeric_array_is_strictly_ascending(transfer_ids)
+        AND transfer_ids[1] > 0
+        AND transfer_ids[cardinality(transfer_ids)] <= 340282366920938463463374607431768211455
+      ),
+      debit_micros numeric(39, 0) NOT NULL CHECK (
+        debit_micros > 0
+        AND debit_micros <= 340282366920938463463374607431768211455
+      ),
+      credit_micros numeric(39, 0) NOT NULL CHECK (
+        credit_micros > 0
+        AND credit_micros <= 340282366920938463463374607431768211455
+      ),
+      content_hash text NOT NULL CHECK (content_hash ~ '^[0-9a-f]{64}$'),
+      recorded_at timestamptz NOT NULL,
+      CHECK (debit_micros = credit_micros)
+    )
+  `
+
+  yield* sql`
+    CREATE TABLE valuations (
+      valuation_id text PRIMARY KEY CHECK (valuation_id ~ '^[0-9a-f]{64}$'),
+      schema_version text NOT NULL CHECK (schema_version = 'bayn.paper-valuation.v1'),
+      account_id text NOT NULL CHECK (length(account_id) > 0 AND account_id = btrim(account_id)),
+      source_hash text NOT NULL CHECK (source_hash ~ '^[0-9a-f]{64}$'),
+      cash_micros numeric(39, 0) NOT NULL CHECK (
+        cash_micros BETWEEN -170141183460469231731687303715884105728
+        AND 170141183460469231731687303715884105727
+      ),
+      long_market_value_micros numeric(39, 0) NOT NULL CHECK (
+        long_market_value_micros >= 0
+        AND long_market_value_micros <= 340282366920938463463374607431768211455
+      ),
+      short_market_value_micros numeric(39, 0) NOT NULL CHECK (
+        short_market_value_micros BETWEEN -170141183460469231731687303715884105728
+        AND 0
+      ),
+      equity_micros numeric(39, 0) NOT NULL CHECK (
+        equity_micros BETWEEN -170141183460469231731687303715884105728
+        AND 170141183460469231731687303715884105727
+      ),
+      as_of timestamptz NOT NULL,
+      CHECK (equity_micros = cash_micros + long_market_value_micros + short_market_value_micros)
+    )
+  `
+
+  yield* sql`
+    CREATE TABLE reconciliations (
+      reconciliation_id text PRIMARY KEY CHECK (reconciliation_id ~ '^[0-9a-f]{64}$'),
+      schema_version text NOT NULL CHECK (schema_version = 'bayn.paper-reconciliation.v1'),
+      account_id text NOT NULL CHECK (length(account_id) > 0 AND account_id = btrim(account_id)),
+      expected_hash text NOT NULL CHECK (expected_hash ~ '^[0-9a-f]{64}$'),
+      observed_hash text NOT NULL CHECK (observed_hash ~ '^[0-9a-f]{64}$'),
+      content_hash text NOT NULL CHECK (content_hash ~ '^[0-9a-f]{64}$'),
+      status text NOT NULL CHECK (status IN ('EXACT', 'DISCREPANCY')),
+      discrepancies jsonb NOT NULL CHECK (jsonb_typeof(discrepancies) = 'array'),
+      reconciled_at timestamptz NOT NULL,
+      CHECK (
+        (
+          status = 'EXACT'
+          AND expected_hash = observed_hash
+          AND jsonb_array_length(discrepancies) = 0
+        )
+        OR (
+          status = 'DISCREPANCY'
+          AND expected_hash <> observed_hash
+          AND jsonb_array_length(discrepancies) > 0
+        )
+      )
+    )
+  `
+
+  yield* sql`
+    CREATE TABLE authority_state (
+      singleton boolean PRIMARY KEY DEFAULT true CHECK (singleton),
+      schema_version text NOT NULL CHECK (schema_version = 'bayn.paper-authority.v1'),
+      generation_hash text NOT NULL CHECK (generation_hash ~ '^[0-9a-f]{64}$'),
+      maximum text NOT NULL CHECK (maximum IN ('OBSERVE', 'PAPER')),
+      effective text NOT NULL CHECK (effective IN ('OBSERVE', 'PAPER')),
+      kill_state text NOT NULL CHECK (kill_state IN ('CLEAR', 'ACTIVE')),
+      reason text CHECK (length(reason) > 0 AND reason = btrim(reason)),
+      version bigint NOT NULL CHECK (version > 0),
+      updated_at timestamptz NOT NULL,
+      CHECK (maximum = 'PAPER' OR effective = 'OBSERVE'),
+      CHECK (kill_state = 'CLEAR' OR effective = 'OBSERVE'),
+      CHECK (
+        (kill_state = 'ACTIVE' AND reason IS NOT NULL)
+        OR (kill_state = 'CLEAR' AND reason IS NULL)
+      )
+    )
+  `
+
+  yield* sql`
+    CREATE FUNCTION enforce_intent_transition()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+    BEGIN
+      IF TG_OP = 'DELETE' THEN
+        RAISE EXCEPTION 'intents cannot be deleted' USING ERRCODE = '55000';
+      END IF;
+
+      IF TG_OP = 'INSERT' THEN
+        IF NEW.state <> 'PLANNED'
+          OR NEW.risk_decision_id IS NOT NULL
+          OR NEW.terminal_outcome IS NOT NULL
+          OR NEW.state_version <> 1
+          OR NEW.updated_at <> NEW.created_at
+        THEN
+          RAISE EXCEPTION 'new intents must begin in PLANNED state' USING ERRCODE = '23514';
+        END IF;
+        RETURN NEW;
+      END IF;
+
+      IF (to_jsonb(OLD) - ARRAY['state', 'risk_decision_id', 'terminal_outcome', 'state_version', 'updated_at'])
+        <> (to_jsonb(NEW) - ARRAY['state', 'risk_decision_id', 'terminal_outcome', 'state_version', 'updated_at'])
+      THEN
+        RAISE EXCEPTION 'intent immutable fields cannot change' USING ERRCODE = '55000';
+      END IF;
+
+      IF NEW.state_version <> OLD.state_version + 1 OR NEW.updated_at <= OLD.updated_at THEN
+        RAISE EXCEPTION 'intent state version and time must advance' USING ERRCODE = '23514';
+      END IF;
+
+      IF NOT (CASE OLD.state
+        WHEN 'PLANNED' THEN NEW.state IN ('APPROVED', 'TERMINAL')
+        WHEN 'APPROVED' THEN NEW.state IN ('IO_STARTED', 'TERMINAL')
+        WHEN 'IO_STARTED' THEN NEW.state IN ('ACKNOWLEDGED', 'UNKNOWN', 'TERMINAL')
+        WHEN 'ACKNOWLEDGED' THEN NEW.state = 'TERMINAL'
+        WHEN 'UNKNOWN' THEN NEW.state = 'RECOVERED'
+        WHEN 'RECOVERED' THEN NEW.state IN ('ACKNOWLEDGED', 'TERMINAL')
+        WHEN 'TERMINAL' THEN false
+        ELSE false
+      END) THEN
+        RAISE EXCEPTION 'invalid intent transition from % to %', OLD.state, NEW.state USING ERRCODE = '23514';
+      END IF;
+
+      RETURN NEW;
+    END
+    $function$
+  `
+
+  yield* sql`
+    CREATE TRIGGER intents_transition_only
+    BEFORE INSERT OR UPDATE OR DELETE ON intents
+    FOR EACH ROW EXECUTE FUNCTION enforce_intent_transition()
+  `
+  yield* sql`
+    CREATE TRIGGER intents_reject_truncate
+    BEFORE TRUNCATE ON intents
+    FOR EACH STATEMENT EXECUTE FUNCTION reject_evidence_mutation()
+  `
+
+  yield* sql`
+    CREATE FUNCTION enforce_risk_decision_binding()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1
+        FROM intents
+        WHERE intent_id = NEW.intent_id AND risk_decision_id = NEW.decision_id
+      ) THEN
+        RAISE EXCEPTION 'risk decision is not bound to its intent' USING ERRCODE = '23514';
+      END IF;
+      RETURN NEW;
+    END
+    $function$
+  `
+
+  yield* sql`
+    CREATE CONSTRAINT TRIGGER risk_decision_binding
+    AFTER INSERT ON risk_decisions
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION enforce_risk_decision_binding()
+  `
+
+  yield* sql`
+    CREATE FUNCTION enforce_broker_event_payload()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+    DECLARE
+      payload_count integer;
+    BEGIN
+      SELECT count(*) INTO payload_count
+      FROM (
+        SELECT event_id FROM account_snapshots WHERE event_id = NEW.event_id
+        UNION ALL SELECT event_id FROM positions WHERE event_id = NEW.event_id
+        UNION ALL SELECT event_id FROM orders WHERE event_id = NEW.event_id
+        UNION ALL SELECT event_id FROM fills WHERE event_id = NEW.event_id
+        UNION ALL SELECT event_id FROM broker_errors WHERE event_id = NEW.event_id
+        UNION ALL SELECT event_id FROM rate_limits WHERE event_id = NEW.event_id
+      ) AS payloads;
+
+      IF payload_count <> 1 THEN
+        RAISE EXCEPTION 'broker event % must have exactly one typed payload', NEW.event_id USING ERRCODE = '23514';
+      END IF;
+      RETURN NEW;
+    END
+    $function$
+  `
+
+  yield* sql`
+    CREATE CONSTRAINT TRIGGER broker_event_payload
+    AFTER INSERT ON broker_events
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION enforce_broker_event_payload()
+  `
+
+  yield* sql`
+    CREATE FUNCTION enforce_authority_transition()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+    BEGIN
+      IF TG_OP = 'DELETE' THEN
+        RAISE EXCEPTION 'authority state cannot be deleted' USING ERRCODE = '55000';
+      END IF;
+
+      IF TG_OP = 'INSERT' THEN
+        IF NEW.version <> 1 THEN
+          RAISE EXCEPTION 'authority state must begin at version 1' USING ERRCODE = '23514';
+        END IF;
+        RETURN NEW;
+      END IF;
+
+      IF NEW.singleton <> OLD.singleton
+        OR NEW.schema_version <> OLD.schema_version
+        OR NEW.version <> OLD.version + 1
+        OR NEW.updated_at <= OLD.updated_at
+      THEN
+        RAISE EXCEPTION 'invalid authority state version' USING ERRCODE = '23514';
+      END IF;
+
+      IF NEW.generation_hash = OLD.generation_hash THEN
+        IF NEW.maximum <> OLD.maximum
+          OR (OLD.effective = 'OBSERVE' AND NEW.effective = 'PAPER')
+          OR (OLD.kill_state = 'ACTIVE' AND NEW.kill_state = 'CLEAR')
+        THEN
+          RAISE EXCEPTION 'authority can only decrease within a GitOps generation' USING ERRCODE = '23514';
+        END IF;
+      END IF;
+
+      RETURN NEW;
+    END
+    $function$
+  `
+
+  yield* sql`
+    CREATE TRIGGER authority_transition_only
+    BEFORE INSERT OR UPDATE OR DELETE ON authority_state
+    FOR EACH ROW EXECUTE FUNCTION enforce_authority_transition()
+  `
+  yield* sql`
+    CREATE TRIGGER authority_reject_truncate
+    BEFORE TRUNCATE ON authority_state
+    FOR EACH STATEMENT EXECUTE FUNCTION reject_evidence_mutation()
+  `
+
+  for (const table of immutableTables) {
+    yield* sql`
+      CREATE TRIGGER ${sql(`${table}_append_only`)}
+      BEFORE UPDATE OR DELETE ON ${sql(table)}
+      FOR EACH ROW EXECUTE FUNCTION reject_evidence_mutation()
+    `
+    yield* sql`
+      CREATE TRIGGER ${sql(`${table}_reject_truncate`)}
+      BEFORE TRUNCATE ON ${sql(table)}
+      FOR EACH STATEMENT EXECUTE FUNCTION reject_evidence_mutation()
+    `
+  }
+})

--- a/services/bayn/migrations/0002_paper_contracts.ts
+++ b/services/bayn/migrations/0002_paper_contracts.ts
@@ -146,7 +146,7 @@ export default Effect.gen(function* () {
       account_id text NOT NULL,
       event_kind text GENERATED ALWAYS AS ('ORDER') STORED,
       schema_version text NOT NULL CHECK (schema_version = 'bayn.paper-order.v1'),
-      broker_order_id text NOT NULL UNIQUE CHECK (
+      broker_order_id text NOT NULL CHECK (
         length(broker_order_id) > 0 AND broker_order_id = btrim(broker_order_id)
       ),
       client_order_id text NOT NULL CHECK (
@@ -172,10 +172,15 @@ export default Effect.gen(function* () {
       status text NOT NULL CHECK (
         status IN ('NEW', 'PARTIALLY_FILLED', 'FILLED', 'CANCELED', 'EXPIRED', 'REJECTED', 'PENDING')
       ),
-      UNIQUE (account_id, client_order_id),
       CHECK (
         (order_type = 'LIMIT' AND limit_price_micros IS NOT NULL)
         OR (order_type = 'MARKET' AND limit_price_micros IS NULL)
+      ),
+      CHECK (
+        (status = 'FILLED' AND filled_quantity_micros = quantity_micros)
+        OR (status = 'PARTIALLY_FILLED' AND filled_quantity_micros > 0 AND filled_quantity_micros < quantity_micros)
+        OR (status IN ('NEW', 'PENDING') AND filled_quantity_micros = 0)
+        OR (status IN ('CANCELED', 'EXPIRED', 'REJECTED') AND filled_quantity_micros < quantity_micros)
       ),
       FOREIGN KEY (event_id, account_id, event_kind)
         REFERENCES broker_events(event_id, account_id, event_kind) ON DELETE RESTRICT,
@@ -183,6 +188,9 @@ export default Effect.gen(function* () {
         REFERENCES intents(intent_id, account_id) ON DELETE RESTRICT
     )
   `
+
+  yield* sql`CREATE INDEX orders_account_broker_order_idx ON orders(account_id, broker_order_id)`
+  yield* sql`CREATE INDEX orders_account_client_order_idx ON orders(account_id, client_order_id)`
 
   yield* sql`
     CREATE TABLE fills (
@@ -323,6 +331,7 @@ export default Effect.gen(function* () {
         array_ndims(account_ids) = 1
         AND array_lower(account_ids, 1) = 1
         AND cardinality(account_ids) >= 2
+        AND array_position(account_ids, NULL) IS NULL
         AND numeric_array_is_strictly_ascending(account_ids)
         AND account_ids[1] > 0
         AND account_ids[cardinality(account_ids)] <= 340282366920938463463374607431768211455
@@ -331,6 +340,7 @@ export default Effect.gen(function* () {
         array_ndims(transfer_ids) = 1
         AND array_lower(transfer_ids, 1) = 1
         AND cardinality(transfer_ids) >= 1
+        AND array_position(transfer_ids, NULL) IS NULL
         AND numeric_array_is_strictly_ascending(transfer_ids)
         AND transfer_ids[1] > 0
         AND transfer_ids[cardinality(transfer_ids)] <= 340282366920938463463374607431768211455
@@ -427,6 +437,10 @@ export default Effect.gen(function* () {
     RETURNS trigger
     LANGUAGE plpgsql
     AS $function$
+    DECLARE
+      decision_outcome text;
+      decision_decided_at timestamptz;
+      decision_expires_at timestamptz;
     BEGIN
       IF TG_OP = 'DELETE' THEN
         RAISE EXCEPTION 'intents cannot be deleted' USING ERRCODE = '55000';
@@ -454,6 +468,10 @@ export default Effect.gen(function* () {
         RAISE EXCEPTION 'intent state version and time must advance' USING ERRCODE = '23514';
       END IF;
 
+      IF OLD.state <> 'PLANNED' AND NEW.risk_decision_id IS DISTINCT FROM OLD.risk_decision_id THEN
+        RAISE EXCEPTION 'intent risk decision cannot change after planning' USING ERRCODE = '55000';
+      END IF;
+
       IF NOT (CASE OLD.state
         WHEN 'PLANNED' THEN NEW.state IN ('APPROVED', 'TERMINAL')
         WHEN 'APPROVED' THEN NEW.state IN ('IO_STARTED', 'TERMINAL')
@@ -465,6 +483,40 @@ export default Effect.gen(function* () {
         ELSE false
       END) THEN
         RAISE EXCEPTION 'invalid intent transition from % to %', OLD.state, NEW.state USING ERRCODE = '23514';
+      END IF;
+
+      IF NEW.state = 'TERMINAL' AND NOT (CASE OLD.state
+        WHEN 'PLANNED' THEN NEW.terminal_outcome = 'BLOCKED'
+        WHEN 'APPROVED' THEN NEW.terminal_outcome IN ('BLOCKED', 'CANCELED')
+        WHEN 'IO_STARTED' THEN NEW.terminal_outcome IN ('FILLED', 'CANCELED', 'EXPIRED', 'REJECTED')
+        WHEN 'ACKNOWLEDGED' THEN NEW.terminal_outcome IN ('FILLED', 'CANCELED', 'EXPIRED', 'REJECTED')
+        WHEN 'RECOVERED' THEN NEW.terminal_outcome IN ('FILLED', 'CANCELED', 'EXPIRED', 'REJECTED')
+        ELSE false
+      END) THEN
+        RAISE EXCEPTION 'invalid terminal outcome % from %', NEW.terminal_outcome, OLD.state USING ERRCODE = '23514';
+      END IF;
+
+      IF OLD.state = 'PLANNED' OR NEW.state = 'IO_STARTED' THEN
+        SELECT outcome, decided_at, expires_at
+        INTO decision_outcome, decision_decided_at, decision_expires_at
+        FROM risk_decisions
+        WHERE decision_id = NEW.risk_decision_id AND intent_id = NEW.intent_id;
+
+        IF NOT FOUND THEN
+          RAISE EXCEPTION 'intent transition requires its bound risk decision' USING ERRCODE = '23503';
+        END IF;
+
+        IF decision_decided_at > NEW.updated_at OR decision_expires_at <= NEW.updated_at THEN
+          RAISE EXCEPTION 'intent transition requires a current risk decision' USING ERRCODE = '23514';
+        END IF;
+
+        IF NEW.state = 'TERMINAL' AND decision_outcome <> 'BLOCKED' THEN
+          RAISE EXCEPTION 'blocked terminal intent requires a blocked risk decision' USING ERRCODE = '23514';
+        END IF;
+
+        IF NEW.state <> 'TERMINAL' AND decision_outcome <> 'APPROVED' THEN
+          RAISE EXCEPTION 'broker I/O requires an approved risk decision' USING ERRCODE = '23514';
+        END IF;
       END IF;
 
       RETURN NEW;

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -160,19 +160,377 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     )
 
     expect(schema.tables.map((row) => row.table_name)).toEqual([
+      'account_snapshots',
+      'accounting_receipts',
+      'authority_state',
+      'broker_errors',
+      'broker_events',
       'evaluation_artifacts',
       'evaluation_events',
       'evaluation_runs',
+      'fills',
       'gate_outcomes',
+      'intents',
+      'orders',
+      'positions',
       'protocol_locks',
       'qualification_locks',
       'qualification_results',
       'qualification_trials',
+      'rate_limits',
+      'reconciliations',
+      'risk_decisions',
       'schema_migrations',
       'snapshot_references',
       'status_history',
+      'valuations',
     ])
-    expect(schema.migrations).toEqual([{ migration_id: 1, name: 'initial_schema' }])
+    expect(schema.migrations).toEqual([
+      { migration_id: 1, name: 'initial_schema' },
+      { migration_id: 2, name: 'paper_contracts' },
+    ])
+  })
+
+  test('requires one typed append-only payload and unique broker source ordering', async () => {
+    const result = await runtime.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* PgClient.PgClient
+        const insertAccount = (eventId: string, sourceEventId: string, sourceSequence: string, cash = '1000000') =>
+          sql.withTransaction(
+            Effect.gen(function* () {
+              yield* sql`
+                INSERT INTO broker_events (
+                  event_id, schema_version, content_hash, event_kind, broker, account_id,
+                  source_event_id, source_sequence, occurred_at, observed_at
+                ) VALUES (
+                  ${eventId}, 'bayn.paper-broker-event.v1', ${'f'.repeat(64)}, 'ACCOUNT', 'ALPACA',
+                  'paper-account-1', ${sourceEventId}, ${sourceSequence},
+                  '2026-07-22T06:00:00.000Z', '2026-07-22T06:01:00.000Z'
+                )
+              `
+              yield* sql`
+                INSERT INTO account_snapshots (
+                  event_id, account_id, schema_version, status, currency,
+                  cash_micros, equity_micros, buying_power_micros
+                ) VALUES (
+                  ${eventId}, 'paper-account-1', 'bayn.paper-account-snapshot.v1', 'ACTIVE', 'USD',
+                  ${cash}, 1000000, 2000000
+                )
+              `
+            }),
+          )
+
+        yield* insertAccount('1'.repeat(64), 'source-1', '1')
+        const duplicateSource = yield* Effect.exit(insertAccount('2'.repeat(64), 'source-1', '2'))
+        const duplicateSequence = yield* Effect.exit(insertAccount('3'.repeat(64), 'source-3', '1'))
+        const overflow = yield* Effect.exit(
+          insertAccount('4'.repeat(64), 'source-4', '4', '170141183460469231731687303715884105728'),
+        )
+        const missingPayload = yield* Effect.exit(
+          sql.withTransaction(
+            sql`
+              INSERT INTO broker_events (
+                event_id, schema_version, content_hash, event_kind, broker, account_id,
+                source_event_id, source_sequence, occurred_at, observed_at
+              ) VALUES (
+                ${'5'.repeat(64)}, 'bayn.paper-broker-event.v1', ${'e'.repeat(64)}, 'FILL', 'ALPACA',
+                'paper-account-1', 'source-5', 5,
+                '2026-07-22T06:00:00.000Z', '2026-07-22T06:01:00.000Z'
+              )
+            `,
+          ),
+        )
+        const update = yield* Effect.exit(sql`
+          UPDATE account_snapshots SET cash_micros = 2 WHERE event_id = ${'1'.repeat(64)}
+        `)
+        const deletion = yield* Effect.exit(sql`
+          DELETE FROM broker_events WHERE event_id = ${'1'.repeat(64)}
+        `)
+        const counts = yield* sql<{ events: number; accounts: number }>`
+          SELECT
+            (SELECT count(*)::integer FROM broker_events) AS events,
+            (SELECT count(*)::integer FROM account_snapshots) AS accounts
+        `
+        return { duplicateSequence, duplicateSource, overflow, missingPayload, update, deletion, counts: counts[0] }
+      }),
+    )
+
+    expect(Exit.isFailure(result.duplicateSource)).toBe(true)
+    expect(Exit.isFailure(result.duplicateSequence)).toBe(true)
+    expect(Exit.isFailure(result.overflow)).toBe(true)
+    expect(Exit.isFailure(result.missingPayload)).toBe(true)
+    expect(Exit.isFailure(result.update)).toBe(true)
+    expect(Exit.isFailure(result.deletion)).toBe(true)
+    expect(result.counts).toEqual({ events: 1, accounts: 1 })
+  })
+
+  test('enforces intent transitions, risk binding, and immutable decisions', async () => {
+    const result = await runtime.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* PgClient.PgClient
+        const intentId = '1'.repeat(64)
+        const decisionId = '2'.repeat(64)
+        yield* sql`
+          INSERT INTO intents (
+            intent_id, schema_version, account_id, client_order_id, symbol, side, order_type,
+            time_in_force, quantity_micros, notional_limit_micros, state, created_at, updated_at
+          ) VALUES (
+            ${intentId}, 'bayn.paper-intent.v1', 'paper-account-1', 'client-order-1', 'NVDA', 'BUY',
+            'MARKET', 'DAY', 1000000, 200000000, 'PLANNED',
+            '2026-07-22T06:00:00.000Z', '2026-07-22T06:00:00.000Z'
+          )
+        `
+        const invalidInitial = yield* Effect.exit(sql`
+          INSERT INTO intents (
+            intent_id, schema_version, risk_decision_id, account_id, client_order_id, symbol, side,
+            order_type, time_in_force, quantity_micros, notional_limit_micros, state,
+            created_at, updated_at
+          ) VALUES (
+            ${'3'.repeat(64)}, 'bayn.paper-intent.v1', ${'4'.repeat(64)}, 'paper-account-1',
+            'client-order-2', 'NVDA', 'BUY', 'MARKET', 'DAY', 1000000, 200000000, 'APPROVED',
+            '2026-07-22T06:00:00.000Z', '2026-07-22T06:00:00.000Z'
+          )
+        `)
+        yield* sql.withTransaction(
+          Effect.gen(function* () {
+            yield* sql`
+              INSERT INTO risk_decisions (
+                decision_id, schema_version, input_hash, intent_id, policy_hash, outcome,
+                reason_codes, decided_at, expires_at
+              ) VALUES (
+                ${decisionId}, 'bayn.paper-risk-decision.v1', ${'5'.repeat(64)}, ${intentId},
+                ${'6'.repeat(64)}, 'APPROVED', ARRAY[]::text[],
+                '2026-07-22T06:00:30.000Z', '2026-07-22T06:01:30.000Z'
+              )
+            `
+            yield* sql`
+              UPDATE intents
+              SET state = 'APPROVED', risk_decision_id = ${decisionId}, state_version = 2,
+                  updated_at = '2026-07-22T06:00:30.000Z'
+              WHERE intent_id = ${intentId}
+            `
+          }),
+        )
+        const skipState = yield* Effect.exit(sql`
+          UPDATE intents
+          SET state = 'ACKNOWLEDGED', state_version = 3, updated_at = '2026-07-22T06:00:40.000Z'
+          WHERE intent_id = ${intentId}
+        `)
+        const changeIdentity = yield* Effect.exit(sql`
+          UPDATE intents
+          SET state = 'IO_STARTED', symbol = 'AMD', state_version = 3,
+              updated_at = '2026-07-22T06:00:40.000Z'
+          WHERE intent_id = ${intentId}
+        `)
+        const orphan = yield* Effect.exit(
+          sql.withTransaction(
+            Effect.gen(function* () {
+              yield* sql`
+                INSERT INTO intents (
+                  intent_id, schema_version, account_id, client_order_id, symbol, side, order_type,
+                  time_in_force, quantity_micros, notional_limit_micros, state, created_at, updated_at
+                ) VALUES (
+                  ${'7'.repeat(64)}, 'bayn.paper-intent.v1', 'paper-account-1', 'client-order-3',
+                  'AMD', 'BUY', 'MARKET', 'DAY', 1000000, 200000000, 'PLANNED',
+                  '2026-07-22T06:00:00.000Z', '2026-07-22T06:00:00.000Z'
+                )
+              `
+              yield* sql`
+                INSERT INTO risk_decisions (
+                  decision_id, schema_version, input_hash, intent_id, policy_hash, outcome,
+                  reason_codes, decided_at, expires_at
+                ) VALUES (
+                  ${'8'.repeat(64)}, 'bayn.paper-risk-decision.v1', ${'9'.repeat(64)}, ${'7'.repeat(64)},
+                  ${'a'.repeat(64)}, 'BLOCKED', ARRAY['KILL_ACTIVE'],
+                  '2026-07-22T06:00:30.000Z', '2026-07-22T06:01:30.000Z'
+                )
+              `
+            }),
+          ),
+        )
+        const mutateDecision = yield* Effect.exit(sql`
+          UPDATE risk_decisions SET outcome = 'BLOCKED', reason_codes = ARRAY['CHANGED']
+          WHERE decision_id = ${decisionId}
+        `)
+        const deleteIntent = yield* Effect.exit(sql`DELETE FROM intents WHERE intent_id = ${intentId}`)
+        const state = yield* sql<{ state: string; state_version: number; decision_id: string }>`
+          SELECT intent.state, intent.state_version::integer, decision.decision_id
+          FROM intents AS intent
+          JOIN risk_decisions AS decision ON decision.intent_id = intent.intent_id
+          WHERE intent.intent_id = ${intentId}
+        `
+        return { invalidInitial, skipState, changeIdentity, orphan, mutateDecision, deleteIntent, state: state[0] }
+      }),
+    )
+
+    expect(Exit.isFailure(result.invalidInitial)).toBe(true)
+    expect(Exit.isFailure(result.skipState)).toBe(true)
+    expect(Exit.isFailure(result.changeIdentity)).toBe(true)
+    expect(Exit.isFailure(result.orphan)).toBe(true)
+    expect(Exit.isFailure(result.mutateDecision)).toBe(true)
+    expect(Exit.isFailure(result.deleteIntent)).toBe(true)
+    expect(result.state).toEqual({ state: 'APPROVED', state_version: 2, decision_id: '2'.repeat(64) })
+  })
+
+  test('enforces exact accounting evidence and downward-only authority', async () => {
+    const result = await runtime.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* PgClient.PgClient
+        const eventId = '1'.repeat(64)
+        yield* sql.withTransaction(
+          Effect.gen(function* () {
+            yield* sql`
+              INSERT INTO broker_events (
+                event_id, schema_version, content_hash, event_kind, broker, account_id,
+                source_event_id, source_sequence, occurred_at, observed_at
+              ) VALUES (
+                ${eventId}, 'bayn.paper-broker-event.v1', ${'2'.repeat(64)}, 'ACCOUNT', 'ALPACA',
+                'paper-account-1', 'source-account-1', 1,
+                '2026-07-22T06:00:00.000Z', '2026-07-22T06:01:00.000Z'
+              )
+            `
+            yield* sql`
+              INSERT INTO account_snapshots (
+                event_id, account_id, schema_version, status, currency,
+                cash_micros, equity_micros, buying_power_micros
+              ) VALUES (
+                ${eventId}, 'paper-account-1', 'bayn.paper-account-snapshot.v1', 'ACTIVE', 'USD',
+                1000000, 1000000, 2000000
+              )
+            `
+          }),
+        )
+        yield* sql`
+          INSERT INTO accounting_receipts (
+            receipt_id, schema_version, broker_event_id, tigerbeetle_cluster_id, tigerbeetle_ledger,
+            account_ids, transfer_ids, debit_micros, credit_micros, content_hash, recorded_at
+          ) VALUES (
+            ${'3'.repeat(64)}, 'bayn.paper-accounting-receipt.v1', ${eventId}, 2001, 7001,
+            ARRAY[1, 2]::numeric[], ARRAY[3]::numeric[], 1250000, 1250000, ${'4'.repeat(64)},
+            '2026-07-22T06:01:00.000Z'
+          )
+        `
+        yield* sql`
+          INSERT INTO valuations (
+            valuation_id, schema_version, account_id, source_hash, cash_micros,
+            long_market_value_micros, short_market_value_micros, equity_micros, as_of
+          ) VALUES (
+            ${'5'.repeat(64)}, 'bayn.paper-valuation.v1', 'paper-account-1', ${'6'.repeat(64)},
+            1000000, 2500000, -500000, 3000000, '2026-07-22T06:01:00.000Z'
+          )
+        `
+        yield* sql`
+          INSERT INTO reconciliations (
+            reconciliation_id, schema_version, account_id, expected_hash, observed_hash,
+            content_hash, status, discrepancies, reconciled_at
+          ) VALUES (
+            ${'7'.repeat(64)}, 'bayn.paper-reconciliation.v1', 'paper-account-1',
+            ${'8'.repeat(64)}, ${'8'.repeat(64)}, ${'9'.repeat(64)}, 'EXACT', '[]'::jsonb,
+            '2026-07-22T06:01:00.000Z'
+          )
+        `
+        yield* sql`
+          INSERT INTO authority_state (
+            schema_version, generation_hash, maximum, effective, kill_state, version, updated_at
+          ) VALUES (
+            'bayn.paper-authority.v1', ${'a'.repeat(64)}, 'OBSERVE', 'OBSERVE', 'CLEAR', 1,
+            '2026-07-22T06:00:00.000Z'
+          )
+        `
+        const unbalanced = yield* Effect.exit(sql`
+          INSERT INTO accounting_receipts (
+            receipt_id, schema_version, broker_event_id, tigerbeetle_cluster_id, tigerbeetle_ledger,
+            account_ids, transfer_ids, debit_micros, credit_micros, content_hash, recorded_at
+          ) VALUES (
+            ${'b'.repeat(64)}, 'bayn.paper-accounting-receipt.v1', ${eventId}, 2001, 7001,
+            ARRAY[1, 2]::numeric[], ARRAY[3]::numeric[], 1250000, 1249999, ${'c'.repeat(64)},
+            '2026-07-22T06:01:00.000Z'
+          )
+        `)
+        const unordered = yield* Effect.exit(sql`
+          INSERT INTO accounting_receipts (
+            receipt_id, schema_version, broker_event_id, tigerbeetle_cluster_id, tigerbeetle_ledger,
+            account_ids, transfer_ids, debit_micros, credit_micros, content_hash, recorded_at
+          ) VALUES (
+            ${'d'.repeat(64)}, 'bayn.paper-accounting-receipt.v1', ${eventId}, 2001, 7001,
+            ARRAY[2, 1]::numeric[], ARRAY[3]::numeric[], 1250000, 1250000, ${'e'.repeat(64)},
+            '2026-07-22T06:01:00.000Z'
+          )
+        `)
+        const badValuation = yield* Effect.exit(sql`
+          INSERT INTO valuations (
+            valuation_id, schema_version, account_id, source_hash, cash_micros,
+            long_market_value_micros, short_market_value_micros, equity_micros, as_of
+          ) VALUES (
+            ${'f'.repeat(64)}, 'bayn.paper-valuation.v1', 'paper-account-1', ${'0'.repeat(64)},
+            1000000, 2500000, -500000, 3000001, '2026-07-22T06:01:00.000Z'
+          )
+        `)
+        const badReconciliation = yield* Effect.exit(sql`
+          INSERT INTO reconciliations (
+            reconciliation_id, schema_version, account_id, expected_hash, observed_hash,
+            content_hash, status, discrepancies, reconciled_at
+          ) VALUES (
+            ${'0'.repeat(64)}, 'bayn.paper-reconciliation.v1', 'paper-account-1',
+            ${'1'.repeat(64)}, ${'2'.repeat(64)}, ${'3'.repeat(64)}, 'EXACT', '[]'::jsonb,
+            '2026-07-22T06:01:00.000Z'
+          )
+        `)
+        yield* sql`
+          UPDATE authority_state
+          SET generation_hash = ${'b'.repeat(64)}, maximum = 'PAPER', effective = 'PAPER',
+              version = 2, updated_at = '2026-07-22T06:01:00.000Z'
+        `
+        yield* sql`
+          UPDATE authority_state
+          SET effective = 'OBSERVE', version = 3, updated_at = '2026-07-22T06:02:00.000Z'
+        `
+        const escalation = yield* Effect.exit(sql`
+          UPDATE authority_state
+          SET effective = 'PAPER', version = 4, updated_at = '2026-07-22T06:03:00.000Z'
+        `)
+        yield* sql`
+          UPDATE authority_state
+          SET kill_state = 'ACTIVE', reason = 'operator kill', version = 4,
+              updated_at = '2026-07-22T06:03:00.000Z'
+        `
+        const clearKill = yield* Effect.exit(sql`
+          UPDATE authority_state
+          SET kill_state = 'CLEAR', reason = NULL, version = 5,
+              updated_at = '2026-07-22T06:04:00.000Z'
+        `)
+        const mutateReceipt = yield* Effect.exit(sql`
+          UPDATE accounting_receipts SET debit_micros = 1 WHERE receipt_id = ${'3'.repeat(64)}
+        `)
+        const authority = yield* sql<{
+          maximum: string
+          effective: string
+          kill_state: string
+          version: number
+        }>`
+          SELECT maximum, effective, kill_state, version::integer FROM authority_state
+        `
+        return {
+          unbalanced,
+          unordered,
+          badValuation,
+          badReconciliation,
+          escalation,
+          clearKill,
+          mutateReceipt,
+          authority: authority[0],
+        }
+      }),
+    )
+
+    expect(Exit.isFailure(result.unbalanced)).toBe(true)
+    expect(Exit.isFailure(result.unordered)).toBe(true)
+    expect(Exit.isFailure(result.badValuation)).toBe(true)
+    expect(Exit.isFailure(result.badReconciliation)).toBe(true)
+    expect(Exit.isFailure(result.escalation)).toBe(true)
+    expect(Exit.isFailure(result.clearKill)).toBe(true)
+    expect(Exit.isFailure(result.mutateReceipt)).toBe(true)
+    expect(result.authority).toEqual({ maximum: 'PAPER', effective: 'OBSERVE', kill_state: 'ACTIVE', version: 4 })
   })
 
   test('rejects the legacy migration tracker instead of creating a parallel schema', async () => {

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -219,6 +219,36 @@ describePostgres('PostgreSQL evaluation evidence', () => {
               `
             }),
           )
+        const insertOrder = (
+          eventId: string,
+          sourceEventId: string,
+          sourceSequence: string,
+          status: 'NEW' | 'FILLED',
+          filledQuantity: string,
+        ) =>
+          sql.withTransaction(
+            Effect.gen(function* () {
+              yield* sql`
+                INSERT INTO broker_events (
+                  event_id, schema_version, content_hash, event_kind, broker, account_id,
+                  source_event_id, source_sequence, occurred_at, observed_at
+                ) VALUES (
+                  ${eventId}, 'bayn.paper-broker-event.v1', ${'d'.repeat(64)}, 'ORDER', 'ALPACA',
+                  'paper-account-1', ${sourceEventId}, ${sourceSequence},
+                  '2026-07-22T06:00:00.000Z', '2026-07-22T06:01:00.000Z'
+                )
+              `
+              yield* sql`
+                INSERT INTO orders (
+                  event_id, account_id, schema_version, broker_order_id, client_order_id, symbol,
+                  side, order_type, time_in_force, quantity_micros, filled_quantity_micros, status
+                ) VALUES (
+                  ${eventId}, 'paper-account-1', 'bayn.paper-order.v1', 'broker-order-1',
+                  'client-order-1', 'NVDA', 'BUY', 'MARKET', 'DAY', 1000000, ${filledQuantity}, ${status}
+                )
+              `
+            }),
+          )
 
         yield* insertAccount('1'.repeat(64), 'source-1', '1')
         const duplicateSource = yield* Effect.exit(insertAccount('2'.repeat(64), 'source-1', '2'))
@@ -240,18 +270,31 @@ describePostgres('PostgreSQL evaluation evidence', () => {
             `,
           ),
         )
+        yield* insertOrder('6'.repeat(64), 'source-6', '2', 'NEW', '0')
+        yield* insertOrder('7'.repeat(64), 'source-7', '3', 'FILLED', '1000000')
+        const inconsistentFill = yield* Effect.exit(insertOrder('8'.repeat(64), 'source-8', '4', 'FILLED', '0'))
         const update = yield* Effect.exit(sql`
           UPDATE account_snapshots SET cash_micros = 2 WHERE event_id = ${'1'.repeat(64)}
         `)
         const deletion = yield* Effect.exit(sql`
           DELETE FROM broker_events WHERE event_id = ${'1'.repeat(64)}
         `)
-        const counts = yield* sql<{ events: number; accounts: number }>`
+        const counts = yield* sql<{ events: number; accounts: number; orders: number }>`
           SELECT
             (SELECT count(*)::integer FROM broker_events) AS events,
-            (SELECT count(*)::integer FROM account_snapshots) AS accounts
+            (SELECT count(*)::integer FROM account_snapshots) AS accounts,
+            (SELECT count(*)::integer FROM orders) AS orders
         `
-        return { duplicateSequence, duplicateSource, overflow, missingPayload, update, deletion, counts: counts[0] }
+        return {
+          duplicateSequence,
+          duplicateSource,
+          overflow,
+          missingPayload,
+          inconsistentFill,
+          update,
+          deletion,
+          counts: counts[0],
+        }
       }),
     )
 
@@ -259,9 +302,10 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     expect(Exit.isFailure(result.duplicateSequence)).toBe(true)
     expect(Exit.isFailure(result.overflow)).toBe(true)
     expect(Exit.isFailure(result.missingPayload)).toBe(true)
+    expect(Exit.isFailure(result.inconsistentFill)).toBe(true)
     expect(Exit.isFailure(result.update)).toBe(true)
     expect(Exit.isFailure(result.deletion)).toBe(true)
-    expect(result.counts).toEqual({ events: 1, accounts: 1 })
+    expect(result.counts).toEqual({ events: 3, accounts: 1, orders: 2 })
   })
 
   test('enforces intent transitions, risk binding, and immutable decisions', async () => {
@@ -322,6 +366,105 @@ describePostgres('PostgreSQL evaluation evidence', () => {
               updated_at = '2026-07-22T06:00:40.000Z'
           WHERE intent_id = ${intentId}
         `)
+        const expiredIo = yield* Effect.exit(sql`
+          UPDATE intents
+          SET state = 'IO_STARTED', state_version = 3, updated_at = '2026-07-22T06:01:30.000Z'
+          WHERE intent_id = ${intentId}
+        `)
+        const blockedApproval = yield* Effect.exit(
+          sql.withTransaction(
+            Effect.gen(function* () {
+              yield* sql`
+                INSERT INTO intents (
+                  intent_id, schema_version, account_id, client_order_id, symbol, side, order_type,
+                  time_in_force, quantity_micros, notional_limit_micros, state, created_at, updated_at
+                ) VALUES (
+                  ${'b'.repeat(64)}, 'bayn.paper-intent.v1', 'paper-account-1', 'client-order-4',
+                  'AMD', 'BUY', 'MARKET', 'DAY', 1000000, 200000000, 'PLANNED',
+                  '2026-07-22T06:00:00.000Z', '2026-07-22T06:00:00.000Z'
+                )
+              `
+              yield* sql`
+                INSERT INTO risk_decisions (
+                  decision_id, schema_version, input_hash, intent_id, policy_hash, outcome,
+                  reason_codes, decided_at, expires_at
+                ) VALUES (
+                  ${'c'.repeat(64)}, 'bayn.paper-risk-decision.v1', ${'d'.repeat(64)}, ${'b'.repeat(64)},
+                  ${'e'.repeat(64)}, 'BLOCKED', ARRAY['KILL_ACTIVE'],
+                  '2026-07-22T06:00:30.000Z', '2026-07-22T06:01:30.000Z'
+                )
+              `
+              yield* sql`
+                UPDATE intents
+                SET state = 'APPROVED', risk_decision_id = ${'c'.repeat(64)}, state_version = 2,
+                    updated_at = '2026-07-22T06:00:30.000Z'
+                WHERE intent_id = ${'b'.repeat(64)}
+              `
+            }),
+          ),
+        )
+        const invalidTerminal = yield* Effect.exit(
+          sql.withTransaction(
+            Effect.gen(function* () {
+              yield* sql`
+                INSERT INTO intents (
+                  intent_id, schema_version, account_id, client_order_id, symbol, side, order_type,
+                  time_in_force, quantity_micros, notional_limit_micros, state, created_at, updated_at
+                ) VALUES (
+                  ${'f'.repeat(64)}, 'bayn.paper-intent.v1', 'paper-account-1', 'client-order-5',
+                  'AMD', 'BUY', 'MARKET', 'DAY', 1000000, 200000000, 'PLANNED',
+                  '2026-07-22T06:00:00.000Z', '2026-07-22T06:00:00.000Z'
+                )
+              `
+              yield* sql`
+                INSERT INTO risk_decisions (
+                  decision_id, schema_version, input_hash, intent_id, policy_hash, outcome,
+                  reason_codes, decided_at, expires_at
+                ) VALUES (
+                  ${'0'.repeat(64)}, 'bayn.paper-risk-decision.v1', ${'1'.repeat(64)}, ${'f'.repeat(64)},
+                  ${'2'.repeat(64)}, 'BLOCKED', ARRAY['KILL_ACTIVE'],
+                  '2026-07-22T06:00:30.000Z', '2026-07-22T06:01:30.000Z'
+                )
+              `
+              yield* sql`
+                UPDATE intents
+                SET state = 'TERMINAL', terminal_outcome = 'FILLED', risk_decision_id = ${'0'.repeat(64)},
+                    state_version = 2, updated_at = '2026-07-22T06:00:30.000Z'
+                WHERE intent_id = ${'f'.repeat(64)}
+              `
+            }),
+          ),
+        )
+        yield* sql.withTransaction(
+          Effect.gen(function* () {
+            yield* sql`
+              INSERT INTO intents (
+                intent_id, schema_version, account_id, client_order_id, symbol, side, order_type,
+                time_in_force, quantity_micros, notional_limit_micros, state, created_at, updated_at
+              ) VALUES (
+                ${'a'.repeat(64)}, 'bayn.paper-intent.v1', 'paper-account-1', 'client-order-6',
+                'AMD', 'BUY', 'MARKET', 'DAY', 1000000, 200000000, 'PLANNED',
+                '2026-07-22T06:00:00.000Z', '2026-07-22T06:00:00.000Z'
+              )
+            `
+            yield* sql`
+              INSERT INTO risk_decisions (
+                decision_id, schema_version, input_hash, intent_id, policy_hash, outcome,
+                reason_codes, decided_at, expires_at
+              ) VALUES (
+                ${'9'.repeat(64)}, 'bayn.paper-risk-decision.v1', ${'8'.repeat(64)}, ${'a'.repeat(64)},
+                ${'7'.repeat(64)}, 'BLOCKED', ARRAY['KILL_ACTIVE'],
+                '2026-07-22T06:00:30.000Z', '2026-07-22T06:01:30.000Z'
+              )
+            `
+            yield* sql`
+              UPDATE intents
+              SET state = 'TERMINAL', terminal_outcome = 'BLOCKED', risk_decision_id = ${'9'.repeat(64)},
+                  state_version = 2, updated_at = '2026-07-22T06:00:30.000Z'
+              WHERE intent_id = ${'a'.repeat(64)}
+            `
+          }),
+        )
         const orphan = yield* Effect.exit(
           sql.withTransaction(
             Effect.gen(function* () {
@@ -359,17 +502,36 @@ describePostgres('PostgreSQL evaluation evidence', () => {
           JOIN risk_decisions AS decision ON decision.intent_id = intent.intent_id
           WHERE intent.intent_id = ${intentId}
         `
-        return { invalidInitial, skipState, changeIdentity, orphan, mutateDecision, deleteIntent, state: state[0] }
+        const blockedState = yield* sql<{ state: string; terminal_outcome: string }>`
+          SELECT state, terminal_outcome FROM intents WHERE intent_id = ${'a'.repeat(64)}
+        `
+        return {
+          invalidInitial,
+          skipState,
+          changeIdentity,
+          expiredIo,
+          blockedApproval,
+          invalidTerminal,
+          orphan,
+          mutateDecision,
+          deleteIntent,
+          state: state[0],
+          blockedState: blockedState[0],
+        }
       }),
     )
 
     expect(Exit.isFailure(result.invalidInitial)).toBe(true)
     expect(Exit.isFailure(result.skipState)).toBe(true)
     expect(Exit.isFailure(result.changeIdentity)).toBe(true)
+    expect(Exit.isFailure(result.expiredIo)).toBe(true)
+    expect(Exit.isFailure(result.blockedApproval)).toBe(true)
+    expect(Exit.isFailure(result.invalidTerminal)).toBe(true)
     expect(Exit.isFailure(result.orphan)).toBe(true)
     expect(Exit.isFailure(result.mutateDecision)).toBe(true)
     expect(Exit.isFailure(result.deleteIntent)).toBe(true)
     expect(result.state).toEqual({ state: 'APPROVED', state_version: 2, decision_id: '2'.repeat(64) })
+    expect(result.blockedState).toEqual({ state: 'TERMINAL', terminal_outcome: 'BLOCKED' })
   })
 
   test('enforces exact accounting evidence and downward-only authority', async () => {
@@ -457,6 +619,16 @@ describePostgres('PostgreSQL evaluation evidence', () => {
             '2026-07-22T06:01:00.000Z'
           )
         `)
+        const nullIdentifier = yield* Effect.exit(sql`
+          INSERT INTO accounting_receipts (
+            receipt_id, schema_version, broker_event_id, tigerbeetle_cluster_id, tigerbeetle_ledger,
+            account_ids, transfer_ids, debit_micros, credit_micros, content_hash, recorded_at
+          ) VALUES (
+            ${'e'.repeat(64)}, 'bayn.paper-accounting-receipt.v1', ${eventId}, 2001, 7001,
+            ARRAY[1, NULL, 2]::numeric[], ARRAY[3]::numeric[], 1250000, 1250000, ${'f'.repeat(64)},
+            '2026-07-22T06:01:00.000Z'
+          )
+        `)
         const badValuation = yield* Effect.exit(sql`
           INSERT INTO valuations (
             valuation_id, schema_version, account_id, source_hash, cash_micros,
@@ -513,6 +685,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
         return {
           unbalanced,
           unordered,
+          nullIdentifier,
           badValuation,
           badReconciliation,
           escalation,
@@ -525,6 +698,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
 
     expect(Exit.isFailure(result.unbalanced)).toBe(true)
     expect(Exit.isFailure(result.unordered)).toBe(true)
+    expect(Exit.isFailure(result.nullIdentifier)).toBe(true)
     expect(Exit.isFailure(result.badValuation)).toBe(true)
     expect(Exit.isFailure(result.badReconciliation)).toBe(true)
     expect(Exit.isFailure(result.escalation)).toBe(true)

--- a/services/bayn/src/db/migrations.ts
+++ b/services/bayn/src/db/migrations.ts
@@ -1,7 +1,9 @@
 import { PgMigrator } from '@effect/sql-pg'
 
 import initialSchema from '../../migrations/0001_initial_schema'
+import paperContracts from '../../migrations/0002_paper_contracts'
 
 export const migrationLoader = PgMigrator.fromRecord({
   '1_initial_schema': initialSchema,
+  '2_paper_contracts': paperContracts,
 })

--- a/services/bayn/src/paper.test.ts
+++ b/services/bayn/src/paper.test.ts
@@ -181,6 +181,21 @@ describe('paper contracts', () => {
 
   test('enforces order and rate-limit invariants', async () => {
     await expectFailure(decodeOrder({ ...order, filledQuantityMicros: '1000001' }))
+    await expectFailure(decodeOrder({ ...order, filledQuantityMicros: '0' }))
+    await expectFailure(decodeOrder({ ...order, filledQuantityMicros: order.quantityMicros }))
+    await expectFailure(decodeOrder({ ...order, status: OrderStatus.Filled, filledQuantityMicros: '0' }))
+    expect(
+      await Effect.runPromise(
+        decodeOrder({ ...order, status: OrderStatus.Filled, filledQuantityMicros: order.quantityMicros }),
+      ),
+    ).toMatchObject({ status: OrderStatus.Filled })
+    await expectFailure(decodeOrder({ ...order, status: OrderStatus.New }))
+    expect(
+      await Effect.runPromise(decodeOrder({ ...order, status: OrderStatus.New, filledQuantityMicros: '0' })),
+    ).toMatchObject({ status: OrderStatus.New })
+    await expectFailure(
+      decodeOrder({ ...order, status: OrderStatus.Canceled, filledQuantityMicros: order.quantityMicros }),
+    )
     await expectFailure(decodeOrder({ ...order, limitPriceMicros: '125000000' }))
     await expectFailure(decodeOrder({ ...order, orderType: OrderType.Limit }))
     expect(
@@ -239,9 +254,38 @@ describe('paper contracts', () => {
       'RECOVERED:TERMINAL',
     ])
 
+    const allowedTerminal = new Set([
+      'PLANNED:BLOCKED',
+      'APPROVED:BLOCKED',
+      'APPROVED:CANCELED',
+      'IO_STARTED:FILLED',
+      'IO_STARTED:CANCELED',
+      'IO_STARTED:EXPIRED',
+      'IO_STARTED:REJECTED',
+      'ACKNOWLEDGED:FILLED',
+      'ACKNOWLEDGED:CANCELED',
+      'ACKNOWLEDGED:EXPIRED',
+      'ACKNOWLEDGED:REJECTED',
+      'RECOVERED:FILLED',
+      'RECOVERED:CANCELED',
+      'RECOVERED:EXPIRED',
+      'RECOVERED:REJECTED',
+    ])
+
     for (const from of Object.values(IntentState)) {
       for (const to of Object.values(IntentState)) {
+        if (to === IntentState.Terminal) {
+          for (const outcome of Object.values(TerminalOutcome)) {
+            expect(isIntentTransitionAllowed(from, to, outcome), `${from}:${outcome}`).toBe(
+              allowedTerminal.has(`${from}:${outcome}`),
+            )
+          }
+          continue
+        }
         expect(isIntentTransitionAllowed(from, to), `${from}:${to}`).toBe(allowed.has(`${from}:${to}`))
+        expect(isIntentTransitionAllowed(from, to, TerminalOutcome.Blocked), `${from}:${to}:unexpected outcome`).toBe(
+          false,
+        )
       }
     }
   })
@@ -318,6 +362,7 @@ describe('paper contracts', () => {
     }
     expect(await Effect.runPromise(decodeValuation(valuation))).toEqual(valuation)
     await expectFailure(decodeValuation({ ...valuation, equityMicros: '3000001' }))
+    await expectFailure(decodeValuation({ ...valuation, shortMarketValueMicros: '500000', equityMicros: '4000000' }))
   })
 
   test('requires reconciliation evidence and downward-only effective authority', async () => {

--- a/services/bayn/src/paper.test.ts
+++ b/services/bayn/src/paper.test.ts
@@ -1,0 +1,365 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Effect, Exit } from 'effect'
+
+import {
+  AccountStatus,
+  Authority,
+  Broker,
+  IntentState,
+  KillState,
+  MutationOutcome,
+  OrderSide,
+  OrderStatus,
+  OrderType,
+  ReconciliationStatus,
+  RiskOutcome,
+  TerminalOutcome,
+  TimeInForce,
+  decodeAccountingReceipt,
+  decodeAccountSnapshot,
+  decodeAuthorityState,
+  decodeBrokerError,
+  decodeBrokerEvent,
+  decodeFill,
+  decodeIntent,
+  decodeOrder,
+  decodePosition,
+  decodeRateLimit,
+  decodeReconciliation,
+  decodeRiskDecision,
+  decodeRiskInput,
+  decodeValuation,
+  isIntentTransitionAllowed,
+} from './paper'
+
+const instant = '2026-07-22T06:00:00.000Z'
+const later = '2026-07-22T06:01:00.000Z'
+const hash = (character: string): string => character.repeat(64)
+const u64Max = '18446744073709551615'
+const u128Max = '340282366920938463463374607431768211455'
+const i128Min = '-170141183460469231731687303715884105728'
+const i128Max = '170141183460469231731687303715884105727'
+
+const expectFailure = async (effect: Effect.Effect<unknown, unknown>): Promise<void> => {
+  expect(Exit.isFailure(await Effect.runPromiseExit(effect))).toBe(true)
+}
+
+const account = {
+  schemaVersion: 'bayn.paper-account-snapshot.v1' as const,
+  accountId: 'paper-account-1',
+  status: AccountStatus.Active,
+  currency: 'USD' as const,
+  cashMicros: '1000000000000',
+  equityMicros: '1000000000000',
+  buyingPowerMicros: '2000000000000',
+  observedAt: later,
+}
+
+const position = {
+  schemaVersion: 'bayn.paper-position.v1' as const,
+  accountId: account.accountId,
+  symbol: 'NVDA',
+  quantityMicros: '1000000',
+  averageEntryPriceMicros: '100000000',
+  marketPriceMicros: '125000000',
+  marketValueMicros: '125000000',
+  unrealizedPnlMicros: '25000000',
+  observedAt: later,
+}
+
+const order = {
+  schemaVersion: 'bayn.paper-order.v1' as const,
+  accountId: account.accountId,
+  brokerOrderId: 'broker-order-1',
+  clientOrderId: 'client-order-1',
+  intentId: hash('1'),
+  symbol: 'NVDA',
+  side: OrderSide.Buy,
+  orderType: OrderType.Market,
+  timeInForce: TimeInForce.Day,
+  quantityMicros: '1000000',
+  filledQuantityMicros: '500000',
+  status: OrderStatus.PartiallyFilled,
+  observedAt: later,
+}
+
+const fill = {
+  schemaVersion: 'bayn.paper-fill.v1' as const,
+  accountId: account.accountId,
+  fillId: 'fill-1',
+  brokerOrderId: order.brokerOrderId,
+  clientOrderId: order.clientOrderId,
+  intentId: order.intentId,
+  symbol: order.symbol,
+  side: order.side,
+  quantityMicros: '500000',
+  priceMicros: '125000000',
+  feeMicros: '10000',
+  occurredAt: instant,
+}
+
+const brokerError = {
+  schemaVersion: 'bayn.paper-broker-error.v1' as const,
+  requestId: 'request-1',
+  code: 'TIMEOUT',
+  message: 'request timed out after I/O began',
+  retryable: false,
+  mutationOutcome: MutationOutcome.Unknown,
+  observedAt: later,
+}
+
+const rateLimit = {
+  schemaVersion: 'bayn.paper-rate-limit.v1' as const,
+  limit: '200',
+  remaining: '199',
+  resetsAt: later,
+  observedAt: later,
+}
+
+const source = {
+  schemaVersion: 'bayn.paper-broker-event.v1' as const,
+  eventId: hash('2'),
+  contentHash: hash('3'),
+  broker: Broker.Alpaca,
+  accountId: account.accountId,
+  sourceEventId: 'source-event-1',
+  sourceSequence: '1',
+  occurredAt: instant,
+  observedAt: later,
+}
+
+const intent = {
+  schemaVersion: 'bayn.paper-intent.v1' as const,
+  intentId: hash('4'),
+  accountId: account.accountId,
+  clientOrderId: order.clientOrderId,
+  symbol: order.symbol,
+  side: OrderSide.Buy,
+  orderType: OrderType.Market,
+  timeInForce: TimeInForce.Day,
+  quantityMicros: '1000000',
+  notionalLimitMicros: '200000000',
+  state: IntentState.Planned,
+  createdAt: instant,
+}
+
+describe('paper contracts', () => {
+  test('strictly decodes every broker payload and tagged event', async () => {
+    const contracts: ReadonlyArray<{
+      decode: (value: unknown) => Effect.Effect<unknown, unknown>
+      value: Record<string, unknown>
+    }> = [
+      { decode: decodeAccountSnapshot, value: account },
+      { decode: decodePosition, value: position },
+      { decode: decodeOrder, value: order },
+      { decode: decodeFill, value: fill },
+      { decode: decodeBrokerError, value: brokerError },
+      { decode: decodeRateLimit, value: rateLimit },
+    ]
+
+    for (const contract of contracts) {
+      expect(await Effect.runPromise(contract.decode(contract.value))).toEqual(contract.value)
+      await expectFailure(contract.decode({ ...contract.value, futureField: true }))
+    }
+
+    const events = [
+      { _tag: 'Account' as const, ...source, account },
+      { _tag: 'Position' as const, ...source, position },
+      { _tag: 'Order' as const, ...source, order },
+      { _tag: 'Fill' as const, ...source, fill },
+      { _tag: 'Error' as const, ...source, error: brokerError },
+      { _tag: 'RateLimit' as const, ...source, rateLimit },
+    ]
+    for (const event of events) expect(await Effect.runPromise(decodeBrokerEvent(event))).toEqual(event)
+
+    await expectFailure(decodeBrokerEvent({ ...events[0], observedAt: '2026-07-22T05:59:00.000Z' }))
+    await expectFailure(decodeBrokerEvent({ ...events[1], position: { ...position, accountId: 'other-account' } }))
+    await expectFailure(decodeBrokerEvent({ ...events[4], error: { ...brokerError, observedAt: instant } }))
+    await expectFailure(decodeBrokerEvent({ ...events[2], futureField: true }))
+  })
+
+  test('enforces order and rate-limit invariants', async () => {
+    await expectFailure(decodeOrder({ ...order, filledQuantityMicros: '1000001' }))
+    await expectFailure(decodeOrder({ ...order, limitPriceMicros: '125000000' }))
+    await expectFailure(decodeOrder({ ...order, orderType: OrderType.Limit }))
+    expect(
+      await Effect.runPromise(decodeOrder({ ...order, orderType: OrderType.Limit, limitPriceMicros: '125000000' })),
+    ).toMatchObject({ orderType: OrderType.Limit })
+    await expectFailure(decodeRateLimit({ ...rateLimit, remaining: '201' }))
+  })
+
+  test('accepts exact integer boundaries and rejects noncanonical or overflowing values', async () => {
+    expect(
+      await Effect.runPromise(
+        decodeAccountSnapshot({ ...account, cashMicros: i128Min, equityMicros: i128Max, buyingPowerMicros: i128Max }),
+      ),
+    ).toMatchObject({ cashMicros: i128Min, buyingPowerMicros: i128Max })
+    await expectFailure(decodeAccountSnapshot({ ...account, cashMicros: '-170141183460469231731687303715884105729' }))
+    await expectFailure(decodeAccountSnapshot({ ...account, equityMicros: '170141183460469231731687303715884105728' }))
+    await expectFailure(decodeAccountSnapshot({ ...account, cashMicros: '-0' }))
+    await expectFailure(decodeAccountSnapshot({ ...account, cashMicros: '01' }))
+    await expectFailure(decodeAccountSnapshot({ ...account, cashMicros: 1 }))
+
+    expect(
+      await Effect.runPromise(decodeBrokerEvent({ _tag: 'Account', ...source, sourceSequence: u64Max, account })),
+    ).toMatchObject({ sourceSequence: u64Max })
+    await expectFailure(
+      decodeBrokerEvent({ _tag: 'Account', ...source, sourceSequence: '18446744073709551616', account }),
+    )
+  })
+
+  test('binds risk evidence to every intent state', async () => {
+    expect(await Effect.runPromise(decodeIntent(intent))).toEqual(intent)
+    await expectFailure(decodeIntent({ ...intent, riskDecisionId: hash('5') }))
+    await expectFailure(decodeIntent({ ...intent, quantityMicros: '01' }))
+    await expectFailure(decodeIntent({ ...intent, terminalOutcome: TerminalOutcome.Filled }))
+
+    const approved = { ...intent, state: IntentState.Approved, riskDecisionId: hash('5') }
+    expect(await Effect.runPromise(decodeIntent(approved))).toEqual(approved)
+    await expectFailure(decodeIntent({ ...approved, riskDecisionId: undefined }))
+
+    const terminal = { ...approved, state: IntentState.Terminal, terminalOutcome: TerminalOutcome.Blocked }
+    expect(await Effect.runPromise(decodeIntent(terminal))).toEqual(terminal)
+    await expectFailure(decodeIntent({ ...terminal, terminalOutcome: undefined }))
+  })
+
+  test('defines the complete closed mutation transition graph', () => {
+    const allowed = new Set([
+      'PLANNED:APPROVED',
+      'PLANNED:TERMINAL',
+      'APPROVED:IO_STARTED',
+      'APPROVED:TERMINAL',
+      'IO_STARTED:ACKNOWLEDGED',
+      'IO_STARTED:UNKNOWN',
+      'IO_STARTED:TERMINAL',
+      'ACKNOWLEDGED:TERMINAL',
+      'UNKNOWN:RECOVERED',
+      'RECOVERED:ACKNOWLEDGED',
+      'RECOVERED:TERMINAL',
+    ])
+
+    for (const from of Object.values(IntentState)) {
+      for (const to of Object.values(IntentState)) {
+        expect(isIntentTransitionAllowed(from, to), `${from}:${to}`).toBe(allowed.has(`${from}:${to}`))
+      }
+    }
+  })
+
+  test('requires fresh risk inputs and immutable decisions with coherent reasons', async () => {
+    const input = {
+      schemaVersion: 'bayn.paper-risk-input.v1' as const,
+      inputHash: hash('6'),
+      intentId: intent.intentId,
+      policyHash: hash('7'),
+      accountSnapshotHash: hash('8'),
+      positionsHash: hash('9'),
+      ordersHash: hash('a'),
+      marketDataHash: hash('b'),
+      evaluatedAt: instant,
+      freshUntil: later,
+    }
+    expect(await Effect.runPromise(decodeRiskInput(input))).toEqual(input)
+    await expectFailure(decodeRiskInput({ ...input, freshUntil: instant }))
+    await expectFailure(decodeRiskInput({ ...input, futureField: true }))
+
+    const approved = {
+      schemaVersion: 'bayn.paper-risk-decision.v1' as const,
+      decisionId: hash('5'),
+      inputHash: input.inputHash,
+      intentId: intent.intentId,
+      policyHash: input.policyHash,
+      outcome: RiskOutcome.Approved,
+      reasonCodes: [],
+      decidedAt: instant,
+      expiresAt: later,
+    }
+    expect(await Effect.runPromise(decodeRiskDecision(approved))).toEqual(approved)
+    await expectFailure(decodeRiskDecision({ ...approved, reasonCodes: ['SHOULD_BE_EMPTY'] }))
+    await expectFailure(decodeRiskDecision({ ...approved, expiresAt: instant }))
+    expect(
+      await Effect.runPromise(
+        decodeRiskDecision({ ...approved, outcome: RiskOutcome.Blocked, reasonCodes: ['KILL_ACTIVE'] }),
+      ),
+    ).toMatchObject({ outcome: RiskOutcome.Blocked })
+  })
+
+  test('requires exact canonical TigerBeetle receipts and marked valuation', async () => {
+    const receipt = {
+      schemaVersion: 'bayn.paper-accounting-receipt.v1' as const,
+      receiptId: hash('c'),
+      intentId: intent.intentId,
+      brokerEventId: source.eventId,
+      tigerBeetleClusterId: u128Max,
+      tigerBeetleLedger: 4_294_967_295,
+      accountIds: ['1', '2'],
+      transferIds: ['3', '4'],
+      debitMicros: u128Max,
+      creditMicros: u128Max,
+      contentHash: hash('d'),
+      recordedAt: instant,
+    }
+    expect(await Effect.runPromise(decodeAccountingReceipt(receipt))).toEqual(receipt)
+    await expectFailure(decodeAccountingReceipt({ ...receipt, creditMicros: '1249999' }))
+    await expectFailure(decodeAccountingReceipt({ ...receipt, tigerBeetleLedger: 4_294_967_296 }))
+    await expectFailure(decodeAccountingReceipt({ ...receipt, accountIds: ['2', '1'] }))
+    await expectFailure(decodeAccountingReceipt({ ...receipt, tigerBeetleClusterId: `${u128Max}0` }))
+
+    const valuation = {
+      schemaVersion: 'bayn.paper-valuation.v1' as const,
+      valuationId: hash('e'),
+      accountId: account.accountId,
+      sourceHash: hash('f'),
+      cashMicros: '1000000',
+      longMarketValueMicros: '2500000',
+      shortMarketValueMicros: '-500000',
+      equityMicros: '3000000',
+      asOf: instant,
+    }
+    expect(await Effect.runPromise(decodeValuation(valuation))).toEqual(valuation)
+    await expectFailure(decodeValuation({ ...valuation, equityMicros: '3000001' }))
+  })
+
+  test('requires reconciliation evidence and downward-only effective authority', async () => {
+    const exact = {
+      schemaVersion: 'bayn.paper-reconciliation.v1' as const,
+      reconciliationId: hash('1'),
+      accountId: account.accountId,
+      expectedHash: hash('2'),
+      observedHash: hash('2'),
+      contentHash: hash('3'),
+      status: ReconciliationStatus.Exact,
+      discrepancies: [],
+      reconciledAt: instant,
+    }
+    expect(await Effect.runPromise(decodeReconciliation(exact))).toEqual(exact)
+    await expectFailure(decodeReconciliation({ ...exact, observedHash: hash('4') }))
+    await expectFailure(decodeReconciliation({ ...exact, status: ReconciliationStatus.Discrepancy, discrepancies: [] }))
+
+    const observe = {
+      schemaVersion: 'bayn.paper-authority.v1' as const,
+      generationHash: hash('5'),
+      maximum: Authority.Observe,
+      effective: Authority.Observe,
+      kill: KillState.Clear,
+      version: 1,
+      updatedAt: instant,
+    }
+    expect(await Effect.runPromise(decodeAuthorityState(observe))).toEqual(observe)
+    await expectFailure(decodeAuthorityState({ ...observe, effective: Authority.Paper }))
+    await expectFailure(
+      decodeAuthorityState({
+        ...observe,
+        maximum: Authority.Paper,
+        effective: Authority.Paper,
+        kill: KillState.Active,
+        reason: 'operator kill',
+      }),
+    )
+    expect(
+      await Effect.runPromise(
+        decodeAuthorityState({ ...observe, maximum: Authority.Paper, kill: KillState.Active, reason: 'operator kill' }),
+      ),
+    ).toMatchObject({ effective: Authority.Observe, kill: KillState.Active })
+  })
+})

--- a/services/bayn/src/paper.ts
+++ b/services/bayn/src/paper.ts
@@ -1,0 +1,538 @@
+import { Schema } from 'effect'
+
+import {
+  Sha256Schema as Sha256,
+  StrictNonEmptyStringSchema as NonEmptyString,
+  SymbolSchema as SymbolName,
+  UtcInstantSchema as UtcInstant,
+  strictParseOptions as StrictParseOptions,
+} from './schemas'
+
+const U32_MAX = 4_294_967_295
+const U64_MAX = 18_446_744_073_709_551_615n
+const U128_MAX = 340_282_366_920_938_463_463_374_607_431_768_211_455n
+const I128_MIN = -170_141_183_460_469_231_731_687_303_715_884_105_728n
+const I128_MAX = 170_141_183_460_469_231_731_687_303_715_884_105_727n
+
+const boundedInteger = (pattern: RegExp, minimum: bigint, maximum: bigint, expected: string) =>
+  Schema.String.check(
+    Schema.makeFilter(
+      (value: string) => {
+        if (!pattern.test(value)) return false
+        const parsed = BigInt(value)
+        return parsed >= minimum && parsed <= maximum
+      },
+      { expected },
+    ),
+  )
+
+const DecimalId = boundedInteger(/^[1-9][0-9]*$/, 1n, U128_MAX, 'a canonical positive u128 decimal string')
+const Sequence = boundedInteger(/^(?:0|[1-9][0-9]*)$/, 0n, U64_MAX, 'a canonical unsigned u64 decimal string')
+const SignedMicros = boundedInteger(/^(?:0|-?[1-9][0-9]*)$/, I128_MIN, I128_MAX, 'canonical signed i128 micros')
+const UnsignedMicros = boundedInteger(/^(?:0|[1-9][0-9]*)$/, 0n, U128_MAX, 'canonical unsigned u128 micros')
+const PositiveMicros = DecimalId
+const Ledger = Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: U32_MAX }))
+const Version = Schema.Int.check(Schema.isGreaterThan(0))
+const ReasonCodes = Schema.Array(NonEmptyString).check(Schema.isUnique())
+const isStrictlyAscending = (values: ReadonlyArray<string>): boolean => {
+  for (let index = 1; index < values.length; index += 1) {
+    if (BigInt(values[index - 1]) >= BigInt(values[index])) return false
+  }
+  return true
+}
+const OrderedDecimalIds = Schema.Array(DecimalId).check(
+  Schema.isMinLength(1),
+  Schema.isUnique(),
+  Schema.makeFilter(isStrictlyAscending, { expected: 'strictly ascending decimal identifiers' }),
+)
+
+export enum Broker {
+  Alpaca = 'ALPACA',
+}
+
+export enum AccountStatus {
+  Active = 'ACTIVE',
+  Restricted = 'RESTRICTED',
+  Closed = 'CLOSED',
+}
+
+export enum OrderSide {
+  Buy = 'BUY',
+  Sell = 'SELL',
+}
+
+export enum OrderType {
+  Market = 'MARKET',
+  Limit = 'LIMIT',
+}
+
+export enum TimeInForce {
+  Day = 'DAY',
+  GoodUntilCanceled = 'GTC',
+  ImmediateOrCancel = 'IOC',
+  FillOrKill = 'FOK',
+}
+
+export enum OrderStatus {
+  New = 'NEW',
+  PartiallyFilled = 'PARTIALLY_FILLED',
+  Filled = 'FILLED',
+  Canceled = 'CANCELED',
+  Expired = 'EXPIRED',
+  Rejected = 'REJECTED',
+  Pending = 'PENDING',
+}
+
+export enum MutationOutcome {
+  Known = 'KNOWN',
+  Unknown = 'UNKNOWN',
+}
+
+export enum IntentState {
+  Planned = 'PLANNED',
+  Approved = 'APPROVED',
+  IoStarted = 'IO_STARTED',
+  Acknowledged = 'ACKNOWLEDGED',
+  Unknown = 'UNKNOWN',
+  Terminal = 'TERMINAL',
+  Recovered = 'RECOVERED',
+}
+
+export enum TerminalOutcome {
+  Filled = 'FILLED',
+  Canceled = 'CANCELED',
+  Expired = 'EXPIRED',
+  Rejected = 'REJECTED',
+  Blocked = 'BLOCKED',
+}
+
+export enum RiskOutcome {
+  Approved = 'APPROVED',
+  Blocked = 'BLOCKED',
+}
+
+export enum ReconciliationStatus {
+  Exact = 'EXACT',
+  Discrepancy = 'DISCREPANCY',
+}
+
+export enum DiscrepancyKind {
+  Account = 'ACCOUNT',
+  Cash = 'CASH',
+  Position = 'POSITION',
+  Order = 'ORDER',
+  Fill = 'FILL',
+  Accounting = 'ACCOUNTING',
+  Valuation = 'VALUATION',
+}
+
+export enum Authority {
+  Observe = 'OBSERVE',
+  Paper = 'PAPER',
+}
+
+export enum KillState {
+  Clear = 'CLEAR',
+  Active = 'ACTIVE',
+}
+
+const AccountSnapshotBase = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.paper-account-snapshot.v1'),
+  accountId: NonEmptyString,
+  status: Schema.Enum(AccountStatus),
+  currency: Schema.Literal('USD'),
+  cashMicros: SignedMicros,
+  equityMicros: SignedMicros,
+  buyingPowerMicros: SignedMicros,
+  observedAt: UtcInstant,
+})
+
+export const AccountSnapshotSchema = AccountSnapshotBase
+export type AccountSnapshot = typeof AccountSnapshotSchema.Type
+
+export const PositionSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.paper-position.v1'),
+  accountId: NonEmptyString,
+  symbol: SymbolName,
+  quantityMicros: SignedMicros,
+  averageEntryPriceMicros: UnsignedMicros,
+  marketPriceMicros: UnsignedMicros,
+  marketValueMicros: SignedMicros,
+  unrealizedPnlMicros: SignedMicros,
+  observedAt: UtcInstant,
+})
+export type Position = typeof PositionSchema.Type
+
+const OrderBase = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.paper-order.v1'),
+  accountId: NonEmptyString,
+  brokerOrderId: NonEmptyString,
+  clientOrderId: NonEmptyString,
+  intentId: Schema.optionalKey(Sha256),
+  symbol: SymbolName,
+  side: Schema.Enum(OrderSide),
+  orderType: Schema.Enum(OrderType),
+  timeInForce: Schema.Enum(TimeInForce),
+  quantityMicros: PositiveMicros,
+  filledQuantityMicros: UnsignedMicros,
+  limitPriceMicros: Schema.optionalKey(PositiveMicros),
+  status: Schema.Enum(OrderStatus),
+  observedAt: UtcInstant,
+})
+
+export const OrderSchema = OrderBase.check(
+  Schema.makeFilter((order: typeof OrderBase.Type): readonly Schema.FilterIssue[] => {
+    const issues: Schema.FilterIssue[] = []
+    if (BigInt(order.filledQuantityMicros) > BigInt(order.quantityMicros)) {
+      issues.push({ path: ['filledQuantityMicros'], issue: 'must not exceed quantityMicros' })
+    }
+    if (order.orderType === OrderType.Limit && order.limitPriceMicros === undefined) {
+      issues.push({ path: ['limitPriceMicros'], issue: 'is required for a limit order' })
+    }
+    if (order.orderType === OrderType.Market && order.limitPriceMicros !== undefined) {
+      issues.push({ path: ['limitPriceMicros'], issue: 'must be absent for a market order' })
+    }
+    return issues
+  }),
+)
+export type Order = typeof OrderSchema.Type
+
+export const FillSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.paper-fill.v1'),
+  accountId: NonEmptyString,
+  fillId: NonEmptyString,
+  brokerOrderId: NonEmptyString,
+  clientOrderId: NonEmptyString,
+  intentId: Schema.optionalKey(Sha256),
+  symbol: SymbolName,
+  side: Schema.Enum(OrderSide),
+  quantityMicros: PositiveMicros,
+  priceMicros: PositiveMicros,
+  feeMicros: UnsignedMicros,
+  occurredAt: UtcInstant,
+})
+export type Fill = typeof FillSchema.Type
+
+export const BrokerErrorSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.paper-broker-error.v1'),
+  requestId: NonEmptyString,
+  code: NonEmptyString,
+  message: NonEmptyString,
+  retryable: Schema.Boolean,
+  mutationOutcome: Schema.Enum(MutationOutcome),
+  observedAt: UtcInstant,
+})
+export type BrokerError = typeof BrokerErrorSchema.Type
+
+const RateLimitBase = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.paper-rate-limit.v1'),
+  limit: Sequence,
+  remaining: Sequence,
+  resetsAt: UtcInstant,
+  observedAt: UtcInstant,
+})
+
+export const RateLimitSchema = RateLimitBase.check(
+  Schema.makeFilter((rateLimit: typeof RateLimitBase.Type) =>
+    BigInt(rateLimit.remaining) <= BigInt(rateLimit.limit)
+      ? []
+      : [{ path: ['remaining'], issue: 'must not exceed limit' }],
+  ),
+)
+export type RateLimit = typeof RateLimitSchema.Type
+
+const SourceFields = {
+  schemaVersion: Schema.Literal('bayn.paper-broker-event.v1'),
+  eventId: Sha256,
+  contentHash: Sha256,
+  broker: Schema.Enum(Broker),
+  accountId: NonEmptyString,
+  sourceEventId: NonEmptyString,
+  sourceSequence: Sequence,
+  occurredAt: UtcInstant,
+  observedAt: UtcInstant,
+} as const
+
+const BrokerEventBase = Schema.TaggedUnion({
+  Account: { ...SourceFields, account: AccountSnapshotSchema },
+  Position: { ...SourceFields, position: PositionSchema },
+  Order: { ...SourceFields, order: OrderSchema },
+  Fill: { ...SourceFields, fill: FillSchema },
+  Error: { ...SourceFields, error: BrokerErrorSchema },
+  RateLimit: { ...SourceFields, rateLimit: RateLimitSchema },
+})
+
+const brokerEventAccountId = (event: typeof BrokerEventBase.Type): string => {
+  switch (event._tag) {
+    case 'Account':
+      return event.account.accountId
+    case 'Position':
+      return event.position.accountId
+    case 'Order':
+      return event.order.accountId
+    case 'Fill':
+      return event.fill.accountId
+    case 'Error':
+    case 'RateLimit':
+      return event.accountId
+  }
+}
+
+const brokerEventPayloadTime = (event: typeof BrokerEventBase.Type): string => {
+  switch (event._tag) {
+    case 'Account':
+      return event.account.observedAt
+    case 'Position':
+      return event.position.observedAt
+    case 'Order':
+      return event.order.observedAt
+    case 'Fill':
+      return event.fill.occurredAt
+    case 'Error':
+      return event.error.observedAt
+    case 'RateLimit':
+      return event.rateLimit.observedAt
+  }
+}
+
+export const BrokerEventSchema = BrokerEventBase.check(
+  Schema.makeFilter((event: typeof BrokerEventBase.Type): readonly Schema.FilterIssue[] => {
+    const issues: Schema.FilterIssue[] = []
+    if (event.observedAt < event.occurredAt) {
+      issues.push({ path: ['observedAt'], issue: 'must not precede occurredAt' })
+    }
+    const payloadAccountId = brokerEventAccountId(event)
+    if (payloadAccountId !== event.accountId) {
+      issues.push({ path: [event._tag.toLowerCase(), 'accountId'], issue: 'must match the source accountId' })
+    }
+    const expectedPayloadTime = event._tag === 'Fill' ? event.occurredAt : event.observedAt
+    if (brokerEventPayloadTime(event) !== expectedPayloadTime) {
+      issues.push({ path: [event._tag.toLowerCase()], issue: 'timestamp must match the source event' })
+    }
+    return issues
+  }),
+)
+export type BrokerEvent = typeof BrokerEventSchema.Type
+
+const IntentBase = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.paper-intent.v1'),
+  intentId: Sha256,
+  riskDecisionId: Schema.optionalKey(Sha256),
+  accountId: NonEmptyString,
+  clientOrderId: NonEmptyString,
+  symbol: SymbolName,
+  side: Schema.Enum(OrderSide),
+  orderType: Schema.Enum(OrderType),
+  timeInForce: Schema.Enum(TimeInForce),
+  quantityMicros: PositiveMicros,
+  notionalLimitMicros: PositiveMicros,
+  state: Schema.Enum(IntentState),
+  terminalOutcome: Schema.optionalKey(Schema.Enum(TerminalOutcome)),
+  createdAt: UtcInstant,
+})
+
+export const IntentSchema = IntentBase.check(
+  Schema.makeFilter((intent: typeof IntentBase.Type): readonly Schema.FilterIssue[] => {
+    const issues: Schema.FilterIssue[] = []
+    const terminal = intent.state === IntentState.Terminal
+    if (terminal !== (intent.terminalOutcome !== undefined)) {
+      issues.push({
+        path: ['terminalOutcome'],
+        issue: terminal ? 'is required for a terminal intent' : 'must be absent before terminal state',
+      })
+    }
+    const planned = intent.state === IntentState.Planned
+    if (planned === (intent.riskDecisionId !== undefined)) {
+      issues.push({
+        path: ['riskDecisionId'],
+        issue: planned ? 'must be absent before risk evaluation' : 'is required after risk evaluation',
+      })
+    }
+    return issues
+  }),
+)
+export type Intent = typeof IntentSchema.Type
+
+const allowedTransitions: Readonly<Record<IntentState, readonly IntentState[]>> = {
+  [IntentState.Planned]: [IntentState.Approved, IntentState.Terminal],
+  [IntentState.Approved]: [IntentState.IoStarted, IntentState.Terminal],
+  [IntentState.IoStarted]: [IntentState.Acknowledged, IntentState.Unknown, IntentState.Terminal],
+  [IntentState.Acknowledged]: [IntentState.Terminal],
+  [IntentState.Unknown]: [IntentState.Recovered],
+  [IntentState.Recovered]: [IntentState.Acknowledged, IntentState.Terminal],
+  [IntentState.Terminal]: [],
+}
+
+export const isIntentTransitionAllowed = (from: IntentState, to: IntentState): boolean =>
+  allowedTransitions[from].includes(to)
+
+const RiskInputBase = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.paper-risk-input.v1'),
+  inputHash: Sha256,
+  intentId: Sha256,
+  policyHash: Sha256,
+  accountSnapshotHash: Sha256,
+  positionsHash: Sha256,
+  ordersHash: Sha256,
+  marketDataHash: Sha256,
+  evaluatedAt: UtcInstant,
+  freshUntil: UtcInstant,
+})
+
+export const RiskInputSchema = RiskInputBase.check(
+  Schema.makeFilter((input: typeof RiskInputBase.Type) =>
+    input.freshUntil > input.evaluatedAt ? [] : [{ path: ['freshUntil'], issue: 'must follow evaluatedAt' }],
+  ),
+)
+export type RiskInput = typeof RiskInputSchema.Type
+
+const RiskDecisionBase = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.paper-risk-decision.v1'),
+  decisionId: Sha256,
+  inputHash: Sha256,
+  intentId: Sha256,
+  policyHash: Sha256,
+  outcome: Schema.Enum(RiskOutcome),
+  reasonCodes: ReasonCodes,
+  decidedAt: UtcInstant,
+  expiresAt: UtcInstant,
+})
+
+export const RiskDecisionSchema = RiskDecisionBase.check(
+  Schema.makeFilter((decision: typeof RiskDecisionBase.Type): readonly Schema.FilterIssue[] => {
+    const issues: Schema.FilterIssue[] = []
+    if (decision.expiresAt <= decision.decidedAt) {
+      issues.push({ path: ['expiresAt'], issue: 'must follow decidedAt' })
+    }
+    const expectedReasons = decision.outcome === RiskOutcome.Blocked
+    if (expectedReasons === (decision.reasonCodes.length === 0)) {
+      issues.push({
+        path: ['reasonCodes'],
+        issue: expectedReasons ? 'must explain a blocked decision' : 'must be empty for an approved decision',
+      })
+    }
+    return issues
+  }),
+)
+export type RiskDecision = typeof RiskDecisionSchema.Type
+
+const AccountingReceiptBase = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.paper-accounting-receipt.v1'),
+  receiptId: Sha256,
+  intentId: Schema.optionalKey(Sha256),
+  brokerEventId: Sha256,
+  tigerBeetleClusterId: DecimalId,
+  tigerBeetleLedger: Ledger,
+  accountIds: OrderedDecimalIds.check(Schema.isMinLength(2)),
+  transferIds: OrderedDecimalIds,
+  debitMicros: PositiveMicros,
+  creditMicros: PositiveMicros,
+  contentHash: Sha256,
+  recordedAt: UtcInstant,
+})
+
+export const AccountingReceiptSchema = AccountingReceiptBase.check(
+  Schema.makeFilter((receipt: typeof AccountingReceiptBase.Type) =>
+    receipt.debitMicros === receipt.creditMicros ? [] : [{ path: ['creditMicros'], issue: 'must equal debitMicros' }],
+  ),
+)
+export type AccountingReceipt = typeof AccountingReceiptSchema.Type
+
+const ValuationBase = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.paper-valuation.v1'),
+  valuationId: Sha256,
+  accountId: NonEmptyString,
+  sourceHash: Sha256,
+  cashMicros: SignedMicros,
+  longMarketValueMicros: UnsignedMicros,
+  shortMarketValueMicros: SignedMicros,
+  equityMicros: SignedMicros,
+  asOf: UtcInstant,
+})
+
+export const ValuationSchema = ValuationBase.check(
+  Schema.makeFilter((valuation: typeof ValuationBase.Type) =>
+    BigInt(valuation.equityMicros) ===
+    BigInt(valuation.cashMicros) + BigInt(valuation.longMarketValueMicros) + BigInt(valuation.shortMarketValueMicros)
+      ? []
+      : [{ path: ['equityMicros'], issue: 'must equal cash plus long and short market value' }],
+  ),
+)
+export type Valuation = typeof ValuationSchema.Type
+
+export const DiscrepancySchema = Schema.Struct({
+  kind: Schema.Enum(DiscrepancyKind),
+  identity: NonEmptyString,
+  expected: NonEmptyString,
+  observed: NonEmptyString,
+})
+export type Discrepancy = typeof DiscrepancySchema.Type
+
+const ReconciliationBase = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.paper-reconciliation.v1'),
+  reconciliationId: Sha256,
+  accountId: NonEmptyString,
+  expectedHash: Sha256,
+  observedHash: Sha256,
+  contentHash: Sha256,
+  status: Schema.Enum(ReconciliationStatus),
+  discrepancies: Schema.Array(DiscrepancySchema),
+  reconciledAt: UtcInstant,
+})
+
+export const ReconciliationSchema = ReconciliationBase.check(
+  Schema.makeFilter((reconciliation: typeof ReconciliationBase.Type) => {
+    const exact = reconciliation.status === ReconciliationStatus.Exact
+    const matches = reconciliation.expectedHash === reconciliation.observedHash
+    if (exact && matches && reconciliation.discrepancies.length === 0) return []
+    if (!exact && !matches && reconciliation.discrepancies.length > 0) return []
+    return [{ path: ['status'], issue: 'must agree with hashes and discrepancies' }]
+  }),
+)
+export type Reconciliation = typeof ReconciliationSchema.Type
+
+const AuthorityStateBase = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.paper-authority.v1'),
+  generationHash: Sha256,
+  maximum: Schema.Enum(Authority),
+  effective: Schema.Enum(Authority),
+  kill: Schema.Enum(KillState),
+  reason: Schema.optionalKey(NonEmptyString),
+  version: Version,
+  updatedAt: UtcInstant,
+})
+
+export const AuthorityStateSchema = AuthorityStateBase.check(
+  Schema.makeFilter((authority: typeof AuthorityStateBase.Type): readonly Schema.FilterIssue[] => {
+    const issues: Schema.FilterIssue[] = []
+    if (authority.maximum === Authority.Observe && authority.effective !== Authority.Observe) {
+      issues.push({ path: ['effective'], issue: 'must not exceed the GitOps maximum' })
+    }
+    if (authority.kill === KillState.Active && authority.effective !== Authority.Observe) {
+      issues.push({ path: ['effective'], issue: 'must be OBSERVE while the kill is active' })
+    }
+    if ((authority.kill === KillState.Active) !== (authority.reason !== undefined)) {
+      issues.push({
+        path: ['reason'],
+        issue: authority.kill === KillState.Active ? 'is required while killed' : 'must be absent while clear',
+      })
+    }
+    return issues
+  }),
+)
+export type AuthorityState = typeof AuthorityStateSchema.Type
+
+export const decodeBrokerEvent = Schema.decodeUnknownEffect(BrokerEventSchema, StrictParseOptions)
+export const decodeAccountSnapshot = Schema.decodeUnknownEffect(AccountSnapshotSchema, StrictParseOptions)
+export const decodePosition = Schema.decodeUnknownEffect(PositionSchema, StrictParseOptions)
+export const decodeOrder = Schema.decodeUnknownEffect(OrderSchema, StrictParseOptions)
+export const decodeFill = Schema.decodeUnknownEffect(FillSchema, StrictParseOptions)
+export const decodeBrokerError = Schema.decodeUnknownEffect(BrokerErrorSchema, StrictParseOptions)
+export const decodeRateLimit = Schema.decodeUnknownEffect(RateLimitSchema, StrictParseOptions)
+export const decodeIntent = Schema.decodeUnknownEffect(IntentSchema, StrictParseOptions)
+export const decodeRiskInput = Schema.decodeUnknownEffect(RiskInputSchema, StrictParseOptions)
+export const decodeRiskDecision = Schema.decodeUnknownEffect(RiskDecisionSchema, StrictParseOptions)
+export const decodeAccountingReceipt = Schema.decodeUnknownEffect(AccountingReceiptSchema, StrictParseOptions)
+export const decodeValuation = Schema.decodeUnknownEffect(ValuationSchema, StrictParseOptions)
+export const decodeReconciliation = Schema.decodeUnknownEffect(ReconciliationSchema, StrictParseOptions)
+export const decodeAuthorityState = Schema.decodeUnknownEffect(AuthorityStateSchema, StrictParseOptions)

--- a/services/bayn/src/paper.ts
+++ b/services/bayn/src/paper.ts
@@ -29,6 +29,7 @@ const boundedInteger = (pattern: RegExp, minimum: bigint, maximum: bigint, expec
 const DecimalId = boundedInteger(/^[1-9][0-9]*$/, 1n, U128_MAX, 'a canonical positive u128 decimal string')
 const Sequence = boundedInteger(/^(?:0|[1-9][0-9]*)$/, 0n, U64_MAX, 'a canonical unsigned u64 decimal string')
 const SignedMicros = boundedInteger(/^(?:0|-?[1-9][0-9]*)$/, I128_MIN, I128_MAX, 'canonical signed i128 micros')
+const NonPositiveMicros = boundedInteger(/^(?:0|-[1-9][0-9]*)$/, I128_MIN, 0n, 'canonical non-positive i128 micros')
 const UnsignedMicros = boundedInteger(/^(?:0|[1-9][0-9]*)$/, 0n, U128_MAX, 'canonical unsigned u128 micros')
 const PositiveMicros = DecimalId
 const Ledger = Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: U32_MAX }))
@@ -185,6 +186,31 @@ export const OrderSchema = OrderBase.check(
     const issues: Schema.FilterIssue[] = []
     if (BigInt(order.filledQuantityMicros) > BigInt(order.quantityMicros)) {
       issues.push({ path: ['filledQuantityMicros'], issue: 'must not exceed quantityMicros' })
+    }
+    const filledQuantity = BigInt(order.filledQuantityMicros)
+    const quantity = BigInt(order.quantityMicros)
+    if (order.status === OrderStatus.Filled && filledQuantity !== quantity) {
+      issues.push({ path: ['filledQuantityMicros'], issue: 'must equal quantityMicros for a filled order' })
+    }
+    if (order.status === OrderStatus.PartiallyFilled && (filledQuantity === 0n || filledQuantity >= quantity)) {
+      issues.push({
+        path: ['filledQuantityMicros'],
+        issue: 'must be between zero and quantityMicros for a partial fill',
+      })
+    }
+    if ((order.status === OrderStatus.New || order.status === OrderStatus.Pending) && filledQuantity !== 0n) {
+      issues.push({ path: ['filledQuantityMicros'], issue: 'must be zero before any fill' })
+    }
+    if (
+      (order.status === OrderStatus.Canceled ||
+        order.status === OrderStatus.Expired ||
+        order.status === OrderStatus.Rejected) &&
+      filledQuantity >= quantity
+    ) {
+      issues.push({
+        path: ['filledQuantityMicros'],
+        issue: 'must be less than quantityMicros for an unfilled terminal order',
+      })
     }
     if (order.orderType === OrderType.Limit && order.limitPriceMicros === undefined) {
       issues.push({ path: ['limitPriceMicros'], issue: 'is required for a limit order' })
@@ -363,8 +389,38 @@ const allowedTransitions: Readonly<Record<IntentState, readonly IntentState[]>> 
   [IntentState.Terminal]: [],
 }
 
-export const isIntentTransitionAllowed = (from: IntentState, to: IntentState): boolean =>
-  allowedTransitions[from].includes(to)
+const allowedTerminalOutcomes: Readonly<Partial<Record<IntentState, readonly TerminalOutcome[]>>> = {
+  [IntentState.Planned]: [TerminalOutcome.Blocked],
+  [IntentState.Approved]: [TerminalOutcome.Blocked, TerminalOutcome.Canceled],
+  [IntentState.IoStarted]: [
+    TerminalOutcome.Filled,
+    TerminalOutcome.Canceled,
+    TerminalOutcome.Expired,
+    TerminalOutcome.Rejected,
+  ],
+  [IntentState.Acknowledged]: [
+    TerminalOutcome.Filled,
+    TerminalOutcome.Canceled,
+    TerminalOutcome.Expired,
+    TerminalOutcome.Rejected,
+  ],
+  [IntentState.Recovered]: [
+    TerminalOutcome.Filled,
+    TerminalOutcome.Canceled,
+    TerminalOutcome.Expired,
+    TerminalOutcome.Rejected,
+  ],
+}
+
+export const isIntentTransitionAllowed = (
+  from: IntentState,
+  to: IntentState,
+  terminalOutcome?: TerminalOutcome,
+): boolean => {
+  if (!allowedTransitions[from].includes(to)) return false
+  if (to !== IntentState.Terminal) return terminalOutcome === undefined
+  return terminalOutcome !== undefined && (allowedTerminalOutcomes[from]?.includes(terminalOutcome) ?? false)
+}
 
 const RiskInputBase = Schema.Struct({
   schemaVersion: Schema.Literal('bayn.paper-risk-input.v1'),
@@ -445,7 +501,7 @@ const ValuationBase = Schema.Struct({
   sourceHash: Sha256,
   cashMicros: SignedMicros,
   longMarketValueMicros: UnsignedMicros,
-  shortMarketValueMicros: SignedMicros,
+  shortMarketValueMicros: NonPositiveMicros,
   equityMicros: SignedMicros,
   asOf: UtcInstant,
 })


### PR DESCRIPTION
## Summary

- define strict Effect Schema contracts for broker observations, intents, risk decisions, TigerBeetle receipts, valuations, reconciliation, and authority
- add one additive PostgreSQL migration with typed domain tables, append-only evidence, state-transition enforcement, and observe/paper authority limits
- add focused contract tests and real PostgreSQL integration coverage without adding broker I/O, schedulers, repositories, or capital authority

## Related Issues

Closes [PROOMPT-370](https://linear.app/proompteng/issue/PROOMPT-370/define-broker-mutation-risk-accounting-and-reconciliation-contracts)

## Testing

- `bun test services/bayn/src/paper.test.ts`: 8 passed, 0 failed
- `BAYN_TEST_POSTGRES_URL=<isolated CNPG database> bun test services/bayn/src/db/evidence-store.integration.test.ts --timeout 30000`: 26 passed, 0 failed
- `bun run --filter @proompteng/bayn test`: 131 passed, 28 skipped, 0 failed
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`

## Breaking Changes

None. The migration only adds paper-operation tables and constraints; existing qualification evidence remains unchanged.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] Documentation and follow-up scope are tracked in PROOMPT-370.