### PR TITLE
fix(bayn): enforce database-time risk expiry

### DIFF
--- a/services/bayn/migrations/0003_intent_risk_clock.ts
+++ b/services/bayn/migrations/0003_intent_risk_clock.ts
@@ -1,0 +1,105 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient
+
+  yield* sql`
+    CREATE OR REPLACE FUNCTION enforce_intent_transition()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+    DECLARE
+      decision_outcome text;
+      decision_decided_at timestamptz;
+      decision_expires_at timestamptz;
+      decision_checked_at timestamptz;
+    BEGIN
+      IF TG_OP = 'DELETE' THEN
+        RAISE EXCEPTION 'intents cannot be deleted' USING ERRCODE = '55000';
+      END IF;
+
+      IF TG_OP = 'INSERT' THEN
+        IF NEW.state <> 'PLANNED'
+          OR NEW.risk_decision_id IS NOT NULL
+          OR NEW.terminal_outcome IS NOT NULL
+          OR NEW.state_version <> 1
+          OR NEW.updated_at <> NEW.created_at
+        THEN
+          RAISE EXCEPTION 'new intents must begin in PLANNED state' USING ERRCODE = '23514';
+        END IF;
+        RETURN NEW;
+      END IF;
+
+      IF (to_jsonb(OLD) - ARRAY['state', 'risk_decision_id', 'terminal_outcome', 'state_version', 'updated_at'])
+        <> (to_jsonb(NEW) - ARRAY['state', 'risk_decision_id', 'terminal_outcome', 'state_version', 'updated_at'])
+      THEN
+        RAISE EXCEPTION 'intent immutable fields cannot change' USING ERRCODE = '55000';
+      END IF;
+
+      IF NEW.state_version <> OLD.state_version + 1 OR NEW.updated_at <= OLD.updated_at THEN
+        RAISE EXCEPTION 'intent state version and time must advance' USING ERRCODE = '23514';
+      END IF;
+
+      IF OLD.state <> 'PLANNED' AND NEW.risk_decision_id IS DISTINCT FROM OLD.risk_decision_id THEN
+        RAISE EXCEPTION 'intent risk decision cannot change after planning' USING ERRCODE = '55000';
+      END IF;
+
+      IF NOT (CASE OLD.state
+        WHEN 'PLANNED' THEN NEW.state IN ('APPROVED', 'TERMINAL')
+        WHEN 'APPROVED' THEN NEW.state IN ('IO_STARTED', 'TERMINAL')
+        WHEN 'IO_STARTED' THEN NEW.state IN ('ACKNOWLEDGED', 'UNKNOWN', 'TERMINAL')
+        WHEN 'ACKNOWLEDGED' THEN NEW.state = 'TERMINAL'
+        WHEN 'UNKNOWN' THEN NEW.state = 'RECOVERED'
+        WHEN 'RECOVERED' THEN NEW.state IN ('ACKNOWLEDGED', 'TERMINAL')
+        WHEN 'TERMINAL' THEN false
+        ELSE false
+      END) THEN
+        RAISE EXCEPTION 'invalid intent transition from % to %', OLD.state, NEW.state USING ERRCODE = '23514';
+      END IF;
+
+      IF NEW.state = 'TERMINAL' AND NOT (CASE OLD.state
+        WHEN 'PLANNED' THEN NEW.terminal_outcome = 'BLOCKED'
+        WHEN 'APPROVED' THEN NEW.terminal_outcome IN ('BLOCKED', 'CANCELED')
+        WHEN 'IO_STARTED' THEN NEW.terminal_outcome IN ('FILLED', 'CANCELED', 'EXPIRED', 'REJECTED')
+        WHEN 'ACKNOWLEDGED' THEN NEW.terminal_outcome IN ('FILLED', 'CANCELED', 'EXPIRED', 'REJECTED')
+        WHEN 'RECOVERED' THEN NEW.terminal_outcome IN ('FILLED', 'CANCELED', 'EXPIRED', 'REJECTED')
+        ELSE false
+      END) THEN
+        RAISE EXCEPTION 'invalid terminal outcome % from %', NEW.terminal_outcome, OLD.state USING ERRCODE = '23514';
+      END IF;
+
+      IF OLD.state = 'PLANNED' OR NEW.state = 'IO_STARTED' THEN
+        decision_checked_at := statement_timestamp();
+
+        SELECT outcome, decided_at, expires_at
+        INTO decision_outcome, decision_decided_at, decision_expires_at
+        FROM risk_decisions
+        WHERE decision_id = NEW.risk_decision_id AND intent_id = NEW.intent_id;
+
+        IF NOT FOUND THEN
+          RAISE EXCEPTION 'intent transition requires its bound risk decision' USING ERRCODE = '23503';
+        END IF;
+
+        IF decision_decided_at > NEW.updated_at
+          OR decision_expires_at <= NEW.updated_at
+          OR decision_decided_at > decision_checked_at
+          OR decision_expires_at <= decision_checked_at
+        THEN
+          RAISE EXCEPTION 'intent transition requires a current risk decision' USING ERRCODE = '23514';
+        END IF;
+
+        IF NEW.state = 'TERMINAL' AND decision_outcome <> 'BLOCKED' THEN
+          RAISE EXCEPTION 'blocked terminal intent requires a blocked risk decision' USING ERRCODE = '23514';
+        END IF;
+
+        IF NEW.state <> 'TERMINAL' AND decision_outcome <> 'APPROVED' THEN
+          RAISE EXCEPTION 'broker I/O requires an approved risk decision' USING ERRCODE = '23514';
+        END IF;
+      END IF;
+
+      RETURN NEW;
+    END
+    $function$
+  `
+})

--- a/services/bayn/migrations/0003_intent_risk_clock.ts
+++ b/services/bayn/migrations/0003_intent_risk_clock.ts
@@ -70,7 +70,7 @@ export default Effect.gen(function* () {
       END IF;
 
       IF OLD.state = 'PLANNED' OR NEW.state = 'IO_STARTED' THEN
-        decision_checked_at := statement_timestamp();
+        decision_checked_at := clock_timestamp();
 
         SELECT outcome, decided_at, expires_at
         INTO decision_outcome, decision_decided_at, decision_expires_at

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:tes
 
 import { NodeServices } from '@effect/platform-node'
 import { PgClient } from '@effect/sql-pg'
-import { Cause, Effect, Exit, Fiber, Layer, ManagedRuntime, Option, Redacted } from 'effect'
+import { Cause, Deferred, Duration, Effect, Exit, Fiber, Layer, ManagedRuntime, Option, Redacted } from 'effect'
 
 import type { RuntimeConfig } from '../config'
 import { canonicalHashV1 } from '../hash'
@@ -310,6 +310,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
   })
 
   test('enforces intent transitions, risk binding, and immutable decisions', async () => {
+    const observerRuntime = makeClientRuntime()
     const result = await runtime.runPromise(
       Effect.gen(function* () {
         const sql = yield* PgClient.PgClient
@@ -393,7 +394,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
               ) VALUES (
                 ${staleDecisionId}, 'bayn.paper-risk-decision.v1', ${'4'.repeat(64)}, ${staleIntentId},
                 ${'3'.repeat(64)}, 'APPROVED', ARRAY[]::text[],
-                statement_timestamp(), statement_timestamp() + interval '500 milliseconds'
+                statement_timestamp(), statement_timestamp() + interval '5 seconds'
               )
             `
             yield* sql`
@@ -404,21 +405,88 @@ describePostgres('PostgreSQL evaluation evidence', () => {
             `
           }),
         )
-        yield* sql`
-          SELECT pg_sleep_until(expires_at + interval '10 milliseconds')
-          FROM risk_decisions
-          WHERE decision_id = ${staleDecisionId}
-        `
-        const backdatedExpiredIo = yield* Effect.exit(sql`
-          UPDATE intents
-          SET state = 'IO_STARTED', state_version = 3,
-              updated_at = (
-                SELECT expires_at - interval '1 microsecond'
-                FROM risk_decisions
-                WHERE decision_id = ${staleDecisionId}
+        const lockHeld = yield* Deferred.make<void>()
+        const releaseLock = yield* Deferred.make<void>()
+        const lockHolder = yield* Effect.forkChild(
+          sql.withTransaction(
+            Effect.gen(function* () {
+              yield* sql`SELECT intent_id FROM intents WHERE intent_id = ${staleIntentId} FOR UPDATE`
+              yield* Deferred.succeed(lockHeld, undefined)
+              yield* Deferred.await(releaseLock)
+            }),
+          ),
+          { startImmediately: true },
+        )
+        yield* Deferred.await(lockHeld)
+        const { backdatedExpiredIo, lockWait } = yield* Effect.gen(function* () {
+          const update = yield* Effect.forkChild(
+            Effect.exit(sql`
+              UPDATE intents /* bayn_test_lock_wait */
+              SET state = 'IO_STARTED', state_version = 3,
+                  updated_at = (
+                    SELECT expires_at - interval '1 microsecond'
+                    FROM risk_decisions
+                    WHERE decision_id = ${staleDecisionId}
+                  )
+              WHERE intent_id = ${staleIntentId}
+            `),
+            { startImmediately: true },
+          )
+          const lockWait = yield* Effect.gen(function* () {
+            type LockActivity = {
+              query: string
+              started_before_expiry: boolean
+              state: string
+              wait_event_type: string | null
+            }
+            let activities: readonly LockActivity[] = []
+            for (let attempt = 0; attempt < 200; attempt += 1) {
+              activities = yield* Effect.promise(() =>
+                observerRuntime.runPromise(
+                  Effect.gen(function* () {
+                    const observerSql = yield* PgClient.PgClient
+                    return yield* observerSql<LockActivity>`
+                      SELECT
+                        activity.query,
+                        activity.state,
+                        activity.wait_event_type,
+                        activity.query_start < decision.expires_at AS started_before_expiry
+                      FROM pg_stat_activity AS activity
+                      CROSS JOIN risk_decisions AS decision
+                      WHERE activity.pid <> pg_backend_pid()
+                        AND activity.usename = current_user
+                        AND activity.datname = current_database()
+                        AND decision.decision_id = ${staleDecisionId}
+                    `
+                  }),
+                ),
               )
-          WHERE intent_id = ${staleIntentId}
-        `)
+              const observed = activities.find(
+                (row) => row.wait_event_type === 'Lock' && row.query.toUpperCase().includes('UPDATE INTENTS'),
+              )
+              if (observed !== undefined) {
+                return { waiting: true, started_before_expiry: observed.started_before_expiry }
+              }
+              yield* Effect.sleep(Duration.millis(10))
+            }
+            return yield* Effect.fail(`update is not waiting on the lock: ${JSON.stringify(activities)}`)
+          })
+          yield* Effect.promise(() =>
+            observerRuntime.runPromise(
+              Effect.gen(function* () {
+                const observerSql = yield* PgClient.PgClient
+                yield* observerSql`
+                  SELECT pg_sleep_until(expires_at + interval '10 milliseconds')
+                  FROM risk_decisions
+                  WHERE decision_id = ${staleDecisionId}
+                `
+              }),
+            ),
+          )
+          yield* Deferred.succeed(releaseLock, undefined)
+          return { backdatedExpiredIo: yield* Fiber.join(update), lockWait }
+        }).pipe(Effect.ensuring(Deferred.succeed(releaseLock, undefined).pipe(Effect.ignore)))
+        yield* Fiber.join(lockHolder)
         const blockedApproval = yield* Effect.exit(
           sql.withTransaction(
             Effect.gen(function* () {
@@ -574,6 +642,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
           changeIdentity,
           expiredIo,
           backdatedExpiredIo,
+          lockWait,
           blockedApproval,
           invalidTerminal,
           orphan,
@@ -583,7 +652,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
           blockedState: blockedState[0],
           staleState: staleState[0],
         }
-      }),
+      }).pipe(Effect.ensuring(Effect.promise(() => observerRuntime.dispose()))),
     )
 
     expect(Exit.isFailure(result.invalidInitial)).toBe(true)
@@ -594,6 +663,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     if (Exit.isFailure(result.backdatedExpiredIo)) {
       expect(Cause.pretty(result.backdatedExpiredIo.cause)).toContain('current risk decision')
     }
+    expect(result.lockWait).toEqual({ waiting: true, started_before_expiry: true })
     expect(Exit.isFailure(result.blockedApproval)).toBe(true)
     expect(Exit.isFailure(result.invalidTerminal)).toBe(true)
     expect(Exit.isFailure(result.orphan)).toBe(true)

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -188,6 +188,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     expect(schema.migrations).toEqual([
       { migration_id: 1, name: 'initial_schema' },
       { migration_id: 2, name: 'paper_contracts' },
+      { migration_id: 3, name: 'intent_risk_clock' },
     ])
   })
 
@@ -344,7 +345,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
               ) VALUES (
                 ${decisionId}, 'bayn.paper-risk-decision.v1', ${'5'.repeat(64)}, ${intentId},
                 ${'6'.repeat(64)}, 'APPROVED', ARRAY[]::text[],
-                '2026-07-22T06:00:30.000Z', '2026-07-22T06:01:30.000Z'
+                '2026-07-22T06:00:30.000Z', '2099-01-01T00:00:00.000Z'
               )
             `
             yield* sql`
@@ -368,8 +369,55 @@ describePostgres('PostgreSQL evaluation evidence', () => {
         `)
         const expiredIo = yield* Effect.exit(sql`
           UPDATE intents
-          SET state = 'IO_STARTED', state_version = 3, updated_at = '2026-07-22T06:01:30.000Z'
+          SET state = 'IO_STARTED', state_version = 3, updated_at = '2099-01-01T00:00:00.000Z'
           WHERE intent_id = ${intentId}
+        `)
+        const staleIntentId = '4'.repeat(64)
+        const staleDecisionId = '3'.repeat(64)
+        yield* sql.withTransaction(
+          Effect.gen(function* () {
+            yield* sql`
+              INSERT INTO intents (
+                intent_id, schema_version, account_id, client_order_id, symbol, side, order_type,
+                time_in_force, quantity_micros, notional_limit_micros, state, created_at, updated_at
+              ) VALUES (
+                ${staleIntentId}, 'bayn.paper-intent.v1', 'paper-account-1', 'client-order-stale',
+                'NVDA', 'BUY', 'MARKET', 'DAY', 1000000, 200000000, 'PLANNED',
+                statement_timestamp() - interval '1 minute', statement_timestamp() - interval '1 minute'
+              )
+            `
+            yield* sql`
+              INSERT INTO risk_decisions (
+                decision_id, schema_version, input_hash, intent_id, policy_hash, outcome,
+                reason_codes, decided_at, expires_at
+              ) VALUES (
+                ${staleDecisionId}, 'bayn.paper-risk-decision.v1', ${'4'.repeat(64)}, ${staleIntentId},
+                ${'3'.repeat(64)}, 'APPROVED', ARRAY[]::text[],
+                statement_timestamp(), statement_timestamp() + interval '500 milliseconds'
+              )
+            `
+            yield* sql`
+              UPDATE intents
+              SET state = 'APPROVED', risk_decision_id = ${staleDecisionId}, state_version = 2,
+                  updated_at = statement_timestamp()
+              WHERE intent_id = ${staleIntentId}
+            `
+          }),
+        )
+        yield* sql`
+          SELECT pg_sleep_until(expires_at + interval '10 milliseconds')
+          FROM risk_decisions
+          WHERE decision_id = ${staleDecisionId}
+        `
+        const backdatedExpiredIo = yield* Effect.exit(sql`
+          UPDATE intents
+          SET state = 'IO_STARTED', state_version = 3,
+              updated_at = (
+                SELECT expires_at - interval '1 microsecond'
+                FROM risk_decisions
+                WHERE decision_id = ${staleDecisionId}
+              )
+          WHERE intent_id = ${staleIntentId}
         `)
         const blockedApproval = yield* Effect.exit(
           sql.withTransaction(
@@ -391,7 +439,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
                 ) VALUES (
                   ${'c'.repeat(64)}, 'bayn.paper-risk-decision.v1', ${'d'.repeat(64)}, ${'b'.repeat(64)},
                   ${'e'.repeat(64)}, 'BLOCKED', ARRAY['KILL_ACTIVE'],
-                  '2026-07-22T06:00:30.000Z', '2026-07-22T06:01:30.000Z'
+                  '2026-07-22T06:00:30.000Z', '2099-01-01T00:00:00.000Z'
                 )
               `
               yield* sql`
@@ -423,7 +471,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
                 ) VALUES (
                   ${'0'.repeat(64)}, 'bayn.paper-risk-decision.v1', ${'1'.repeat(64)}, ${'f'.repeat(64)},
                   ${'2'.repeat(64)}, 'BLOCKED', ARRAY['KILL_ACTIVE'],
-                  '2026-07-22T06:00:30.000Z', '2026-07-22T06:01:30.000Z'
+                  '2026-07-22T06:00:30.000Z', '2099-01-01T00:00:00.000Z'
                 )
               `
               yield* sql`
@@ -454,7 +502,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
               ) VALUES (
                 ${'9'.repeat(64)}, 'bayn.paper-risk-decision.v1', ${'8'.repeat(64)}, ${'a'.repeat(64)},
                 ${'7'.repeat(64)}, 'BLOCKED', ARRAY['KILL_ACTIVE'],
-                '2026-07-22T06:00:30.000Z', '2026-07-22T06:01:30.000Z'
+                '2026-07-22T06:00:30.000Z', '2099-01-01T00:00:00.000Z'
               )
             `
             yield* sql`
@@ -485,7 +533,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
                 ) VALUES (
                   ${'8'.repeat(64)}, 'bayn.paper-risk-decision.v1', ${'9'.repeat(64)}, ${'7'.repeat(64)},
                   ${'a'.repeat(64)}, 'BLOCKED', ARRAY['KILL_ACTIVE'],
-                  '2026-07-22T06:00:30.000Z', '2026-07-22T06:01:30.000Z'
+                  '2026-07-22T06:00:30.000Z', '2099-01-01T00:00:00.000Z'
                 )
               `
             }),
@@ -505,11 +553,27 @@ describePostgres('PostgreSQL evaluation evidence', () => {
         const blockedState = yield* sql<{ state: string; terminal_outcome: string }>`
           SELECT state, terminal_outcome FROM intents WHERE intent_id = ${'a'.repeat(64)}
         `
+        const staleState = yield* sql<{
+          database_after_expiry: boolean
+          event_before_expiry: boolean
+          state: string
+          state_version: number
+        }>`
+          SELECT
+            intent.state,
+            intent.state_version::integer,
+            intent.updated_at < decision.expires_at AS event_before_expiry,
+            statement_timestamp() >= decision.expires_at AS database_after_expiry
+          FROM intents AS intent
+          JOIN risk_decisions AS decision ON decision.decision_id = intent.risk_decision_id
+          WHERE intent.intent_id = ${staleIntentId}
+        `
         return {
           invalidInitial,
           skipState,
           changeIdentity,
           expiredIo,
+          backdatedExpiredIo,
           blockedApproval,
           invalidTerminal,
           orphan,
@@ -517,6 +581,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
           deleteIntent,
           state: state[0],
           blockedState: blockedState[0],
+          staleState: staleState[0],
         }
       }),
     )
@@ -525,6 +590,10 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     expect(Exit.isFailure(result.skipState)).toBe(true)
     expect(Exit.isFailure(result.changeIdentity)).toBe(true)
     expect(Exit.isFailure(result.expiredIo)).toBe(true)
+    expect(Exit.isFailure(result.backdatedExpiredIo)).toBe(true)
+    if (Exit.isFailure(result.backdatedExpiredIo)) {
+      expect(Cause.pretty(result.backdatedExpiredIo.cause)).toContain('current risk decision')
+    }
     expect(Exit.isFailure(result.blockedApproval)).toBe(true)
     expect(Exit.isFailure(result.invalidTerminal)).toBe(true)
     expect(Exit.isFailure(result.orphan)).toBe(true)
@@ -532,7 +601,13 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     expect(Exit.isFailure(result.deleteIntent)).toBe(true)
     expect(result.state).toEqual({ state: 'APPROVED', state_version: 2, decision_id: '2'.repeat(64) })
     expect(result.blockedState).toEqual({ state: 'TERMINAL', terminal_outcome: 'BLOCKED' })
-  })
+    expect(result.staleState).toEqual({
+      state: 'APPROVED',
+      state_version: 2,
+      event_before_expiry: true,
+      database_after_expiry: true,
+    })
+  }, 15_000)
 
   test('enforces exact accounting evidence and downward-only authority', async () => {
     const result = await runtime.runPromise(

--- a/services/bayn/src/db/migrations.ts
+++ b/services/bayn/src/db/migrations.ts
@@ -2,8 +2,10 @@ import { PgMigrator } from '@effect/sql-pg'
 
 import initialSchema from '../../migrations/0001_initial_schema'
 import paperContracts from '../../migrations/0002_paper_contracts'
+import intentRiskClock from '../../migrations/0003_intent_risk_clock'
 
 export const migrationLoader = PgMigrator.fromRecord({
   '1_initial_schema': initialSchema,
   '2_paper_contracts': paperContracts,
+  '3_intent_risk_clock': intentRiskClock,
 })


### PR DESCRIPTION
## Summary

- add an immutable follow-up migration that validates risk-decision expiry against the PostgreSQL wall clock after row-lock acquisition
- retain event-time ordering checks so backdated intent timestamps cannot authorize expired broker I/O
- reproduce a statement that starts before expiry, waits on an intent lock until after expiry, and verify it fails closed

## Related Issues

PROOMPT-370 post-merge review follow-up.

## Testing

- `BAYN_TEST_POSTGRES_URL=<isolated-cnpg-test-db> bun test --timeout 30000 services/bayn/src/db/evidence-store.integration.test.ts` — 26 passed, 0 failed, 120 assertions
- `bun run --filter @proompteng/bayn test` — 131 passed, 28 PostgreSQL tests skipped without an environment, 0 failed, 678 assertions
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`

## Breaking Changes

None. Migration 3 replaces only the intent-transition trigger function; it does not rewrite or delete evidence.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] The post-merge review follow-up is linked and will be resolved after the fix is present.
