### PR TITLE
feat(bayn): add bounded paper risk evaluation

### DIFF
--- a/services/bayn/src/paper.ts
+++ b/services/bayn/src/paper.ts
@@ -32,6 +32,12 @@ const SignedMicros = boundedInteger(/^(?:0|-?[1-9][0-9]*)$/, I128_MIN, I128_MAX,
 const NonPositiveMicros = boundedInteger(/^(?:0|-[1-9][0-9]*)$/, I128_MIN, 0n, 'canonical non-positive i128 micros')
 const UnsignedMicros = boundedInteger(/^(?:0|[1-9][0-9]*)$/, 0n, U128_MAX, 'canonical unsigned u128 micros')
 const PositiveMicros = DecimalId
+
+export {
+  PositiveMicros as PositiveMicrosSchema,
+  SignedMicros as SignedMicrosSchema,
+  UnsignedMicros as UnsignedMicrosSchema,
+}
 const Ledger = Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: U32_MAX }))
 const Version = Schema.Int.check(Schema.isGreaterThan(0))
 const ReasonCodes = Schema.Array(NonEmptyString).check(Schema.isUnique())

--- a/services/bayn/src/risk.test.ts
+++ b/services/bayn/src/risk.test.ts
@@ -141,6 +141,7 @@ const baseState = (): State => {
     dayStartEquityMicros: '1000000000',
     peakEquityMicros: '1050000000',
     accountingHash,
+    marketDataSymbol: 'NVDA',
     marketDataHash: hash('5'),
     referencePriceMicros: '100000000',
     expectedExecutionPriceMicros: '100000000',
@@ -233,6 +234,7 @@ describe('bounded paper risk', () => {
     expect(() => decodePolicy({ ...rawPolicy, allowedOrderTypes: [OrderType.Limit] })).toThrow()
     expect(() => decodePolicy({ ...rawPolicy, maxOrderNotionalMicros: '01' })).toThrow()
     expect(() => decodePolicy({ ...rawPolicy, maxOrderNotionalMicros: '9223372036854775808' })).toThrow()
+    expect(() => decodePolicy({ ...rawPolicy, maxUnresolvedOrders: 1 })).toThrow()
     expect(() => decodePolicy({ ...rawPolicy, decisionTtlMs: 86_400_001 })).toThrow()
     expect(() => decodePolicy({ ...rawPolicy, extra: true })).toThrow()
 
@@ -303,7 +305,7 @@ describe('bounded paper risk', () => {
     for (const [reason, intent, state, policy] of cases) expectBlocked(reason, intent, state, policy)
   })
 
-  test('blocks adverse slippage and unresolved-order overflow at their next unit', () => {
+  test('blocks adverse slippage and any unresolved order', () => {
     const slippageState = makeState({
       account: { ...baseState().account, buyingPowerMicros: '101000000' },
       expectedExecutionPriceMicros: '101000000',
@@ -326,10 +328,7 @@ describe('bounded paper risk', () => {
     )
 
     const oneOrder = makeState({ orders: [openOrder('broker-1')] })
-    expect(evaluate(makeIntent(), oneOrder, makePolicy({ maxUnresolvedOrders: 1 })).decision.outcome).toBe(
-      RiskOutcome.Approved,
-    )
-    expectBlocked(Reason.UnresolvedOrdersExceeded, makeIntent(), oneOrder, makePolicy({ maxUnresolvedOrders: 0 }))
+    expectBlocked(Reason.UnresolvedOrdersExceeded, makeIntent(), oneOrder, makePolicy())
   })
 
   test('does not require buying power for a position-reducing sell', () => {
@@ -355,6 +354,7 @@ describe('bounded paper risk', () => {
       makeState({ account: { ...baseState().account, equityMicros: '0' } }),
     )
     expectBlocked(Reason.SymbolNotAllowed, makeIntent(), makeState(), makePolicy({ allowedSymbols: ['AMD'] }))
+    expectBlocked(Reason.MarketDataSymbolMismatch, makeIntent(), makeState({ marketDataSymbol: 'AMD' }), makePolicy())
     expectBlocked(Reason.OrderTypeNotAllowed, makeIntent({ orderType: OrderType.Limit }), makeState(), makePolicy())
     expectBlocked(
       Reason.TimeInForceNotAllowed,

--- a/services/bayn/src/risk.test.ts
+++ b/services/bayn/src/risk.test.ts
@@ -1,0 +1,470 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Schema } from 'effect'
+
+import { canonicalHashV1 } from './hash'
+import {
+  AccountStatus,
+  Authority,
+  DiscrepancyKind,
+  IntentSchema,
+  IntentState,
+  KillState,
+  OrderSide,
+  OrderStatus,
+  OrderType,
+  ReconciliationStatus,
+  RiskOutcome,
+  TerminalOutcome,
+  TimeInForce,
+  type Intent,
+} from './paper'
+import { BrokerMode, PolicySchema, Reason, StateSchema, evaluate, type Policy, type State } from './risk'
+import { strictParseOptions } from './schemas'
+
+const evaluatedAt = '2026-07-22T14:00:00.000Z'
+const observedAt = '2026-07-22T13:59:30.000Z'
+const hash = (character: string): string => character.repeat(64)
+
+const decodePolicy = Schema.decodeUnknownSync(PolicySchema, strictParseOptions)
+const decodeState = Schema.decodeUnknownSync(StateSchema, strictParseOptions)
+const decodeIntent = Schema.decodeUnknownSync(IntentSchema, strictParseOptions)
+
+const makePolicy = (overrides: Partial<Policy> = {}): Policy =>
+  decodePolicy({
+    schemaVersion: 'bayn.paper-risk-policy.v1',
+    accountId: 'paper-account-1',
+    brokerMode: BrokerMode.Paper,
+    allowedSymbols: ['AMD', 'NVDA'],
+    allowedOrderTypes: [OrderType.Market],
+    allowedTimeInForce: [TimeInForce.Day, TimeInForce.GoodUntilCanceled],
+    maxOrderNotionalMicros: '100000000',
+    maxSymbolExposureMicros: '200000000',
+    maxGrossExposureMicros: '300000000',
+    maxNetExposureMicros: '300000000',
+    maxDailyTradedNotionalMicros: '200000000',
+    maxDailyLossMicros: '50000000',
+    maxDrawdownMicros: '100000000',
+    maxIntentAgeMs: 60_000,
+    maxBrokerStateAgeMs: 60_000,
+    maxMarketDataAgeMs: 60_000,
+    maxAdverseSlippageBps: 100,
+    maxUnresolvedOrders: 0,
+    decisionTtlMs: 30_000,
+    ...overrides,
+  })
+
+const baseState = (): State => {
+  const account = {
+    schemaVersion: 'bayn.paper-account-snapshot.v1' as const,
+    accountId: 'paper-account-1',
+    status: AccountStatus.Active,
+    currency: 'USD' as const,
+    cashMicros: '750000000',
+    equityMicros: '950000000',
+    buyingPowerMicros: '100000000',
+    observedAt,
+  }
+  const positions = [
+    {
+      schemaVersion: 'bayn.paper-position.v1' as const,
+      accountId: 'paper-account-1',
+      symbol: 'AMD',
+      quantityMicros: '1000000',
+      averageEntryPriceMicros: '90000000',
+      marketPriceMicros: '100000000',
+      marketValueMicros: '100000000',
+      unrealizedPnlMicros: '10000000',
+      observedAt,
+    },
+    {
+      schemaVersion: 'bayn.paper-position.v1' as const,
+      accountId: 'paper-account-1',
+      symbol: 'NVDA',
+      quantityMicros: '1000000',
+      averageEntryPriceMicros: '90000000',
+      marketPriceMicros: '100000000',
+      marketValueMicros: '100000000',
+      unrealizedPnlMicros: '10000000',
+      observedAt,
+    },
+  ]
+  const orders: readonly ReturnType<typeof openOrder>[] = []
+  const accountingHash = hash('a')
+  const brokerStateHash = canonicalHashV1({
+    schemaVersion: 'bayn.paper-risk-broker-state.v1',
+    account,
+    positions,
+    positionsObservedAt: observedAt,
+    orders,
+    ordersObservedAt: observedAt,
+  })
+  const reconciledStateHash = canonicalHashV1({
+    schemaVersion: 'bayn.paper-risk-reconciled-state.v1',
+    brokerStateHash,
+    accountingHash,
+    dailyTradedNotionalMicros: '100000000',
+    dayStartEquityMicros: '1000000000',
+    peakEquityMicros: '1050000000',
+  })
+  return decodeState({
+    schemaVersion: 'bayn.paper-risk-state.v1',
+    brokerMode: BrokerMode.Paper,
+    account,
+    positions,
+    positionsObservedAt: observedAt,
+    orders,
+    ordersObservedAt: observedAt,
+    reconciliation: {
+      schemaVersion: 'bayn.paper-reconciliation.v1',
+      reconciliationId: hash('1'),
+      accountId: 'paper-account-1',
+      expectedHash: reconciledStateHash,
+      observedHash: reconciledStateHash,
+      contentHash: hash('3'),
+      status: ReconciliationStatus.Exact,
+      discrepancies: [],
+      reconciledAt: observedAt,
+    },
+    authority: {
+      schemaVersion: 'bayn.paper-authority.v1',
+      generationHash: hash('4'),
+      maximum: Authority.Paper,
+      effective: Authority.Paper,
+      kill: KillState.Clear,
+      version: 1,
+      updatedAt: observedAt,
+    },
+    authorityObservedAt: observedAt,
+    unknownMutationCount: 0,
+    dailyTradedNotionalMicros: '100000000',
+    dayStartEquityMicros: '1000000000',
+    peakEquityMicros: '1050000000',
+    accountingHash,
+    marketDataHash: hash('5'),
+    referencePriceMicros: '100000000',
+    expectedExecutionPriceMicros: '100000000',
+    marketDataObservedAt: observedAt,
+    sessionOpenAt: '2026-07-22T13:30:00.000Z',
+    submissionCutoffAt: '2026-07-22T20:00:00.000Z',
+    evaluatedAt,
+  })
+}
+
+const makeState = (overrides: Partial<State> = {}): State => {
+  const merged = { ...baseState(), ...overrides }
+  if (overrides.reconciliation !== undefined) return decodeState(merged)
+  const brokerStateHash = canonicalHashV1({
+    schemaVersion: 'bayn.paper-risk-broker-state.v1',
+    account: merged.account,
+    positions: merged.positions,
+    positionsObservedAt: merged.positionsObservedAt,
+    orders: merged.orders,
+    ordersObservedAt: merged.ordersObservedAt,
+  })
+  const reconciledStateHash = canonicalHashV1({
+    schemaVersion: 'bayn.paper-risk-reconciled-state.v1',
+    brokerStateHash,
+    accountingHash: merged.accountingHash,
+    dailyTradedNotionalMicros: merged.dailyTradedNotionalMicros,
+    dayStartEquityMicros: merged.dayStartEquityMicros,
+    peakEquityMicros: merged.peakEquityMicros,
+  })
+  return decodeState({
+    ...merged,
+    reconciliation: {
+      ...merged.reconciliation,
+      expectedHash: reconciledStateHash,
+      observedHash: reconciledStateHash,
+    },
+  })
+}
+
+const makeIntent = (overrides: Partial<Intent> = {}): Intent =>
+  decodeIntent({
+    schemaVersion: 'bayn.paper-intent.v1',
+    intentId: hash('6'),
+    accountId: 'paper-account-1',
+    clientOrderId: 'risk-test-order-1',
+    symbol: 'NVDA',
+    side: OrderSide.Buy,
+    orderType: OrderType.Market,
+    timeInForce: TimeInForce.Day,
+    quantityMicros: '1000000',
+    notionalLimitMicros: '100000000',
+    state: IntentState.Planned,
+    createdAt: '2026-07-22T13:59:45.000Z',
+    ...overrides,
+  })
+
+const expectBlocked = (reason: Reason, intent = makeIntent(), state = makeState(), policy = makePolicy()): void => {
+  const result = evaluate(intent, state, policy)
+  expect(result.decision.outcome).toBe(RiskOutcome.Blocked)
+  expect(result.decision.reasonCodes).toContain(reason)
+}
+
+const openOrder = (brokerOrderId: string) => ({
+  schemaVersion: 'bayn.paper-order.v1' as const,
+  accountId: 'paper-account-1',
+  brokerOrderId,
+  clientOrderId: `client-${brokerOrderId}`,
+  symbol: 'NVDA',
+  side: OrderSide.Buy,
+  orderType: OrderType.Market,
+  timeInForce: TimeInForce.Day,
+  quantityMicros: '1000000',
+  filledQuantityMicros: '0',
+  status: OrderStatus.New,
+  observedAt,
+})
+
+describe('bounded paper risk', () => {
+  test('strictly decodes complete policy and coherent state', () => {
+    expect(makePolicy().schemaVersion).toBe('bayn.paper-risk-policy.v1')
+    expect(makeState().schemaVersion).toBe('bayn.paper-risk-state.v1')
+
+    const rawPolicy = { ...makePolicy() }
+    const missingPolicy: Record<string, unknown> = { ...rawPolicy }
+    delete missingPolicy.maxOrderNotionalMicros
+    expect(() => decodePolicy(missingPolicy)).toThrow()
+    expect(() => decodePolicy({ ...rawPolicy, brokerMode: 'LIVE' })).toThrow()
+    expect(() => decodePolicy({ ...rawPolicy, allowedSymbols: ['NVDA', 'AMD'] })).toThrow()
+    expect(() => decodePolicy({ ...rawPolicy, allowedSymbols: ['AMD', 'AMD'] })).toThrow()
+    expect(() => decodePolicy({ ...rawPolicy, allowedOrderTypes: [OrderType.Limit] })).toThrow()
+    expect(() => decodePolicy({ ...rawPolicy, maxOrderNotionalMicros: '01' })).toThrow()
+    expect(() => decodePolicy({ ...rawPolicy, maxOrderNotionalMicros: '9223372036854775808' })).toThrow()
+    expect(() => decodePolicy({ ...rawPolicy, decisionTtlMs: 86_400_001 })).toThrow()
+    expect(() => decodePolicy({ ...rawPolicy, extra: true })).toThrow()
+
+    const state = baseState()
+    expect(() => decodeState({ ...state, brokerMode: 'LIVE' })).toThrow()
+    expect(() =>
+      decodeState({
+        ...state,
+        positions: [{ ...state.positions[0], accountId: 'another-account' }, state.positions[1]],
+      }),
+    ).toThrow()
+    expect(() => decodeState({ ...state, positions: [...state.positions].reverse() })).toThrow()
+    expect(() =>
+      decodeState({
+        ...state,
+        positions: [{ ...state.positions[0], marketValueMicros: '-100000000' }, state.positions[1]],
+      }),
+    ).toThrow()
+    expect(() => decodeState({ ...state, marketDataObservedAt: '2026-07-22T14:00:00.001Z' })).toThrow()
+    expect(() => decodeState({ ...state, submissionCutoffAt: state.sessionOpenAt })).toThrow()
+  })
+
+  test('approves the exact limit boundary and binds a deterministic decision', () => {
+    const first = evaluate(makeIntent(), makeState(), makePolicy())
+    const second = evaluate(makeIntent(), makeState(), makePolicy())
+
+    expect(first).toEqual(second)
+    expect(first.decision.outcome).toBe(RiskOutcome.Approved)
+    expect(first.decision.reasonCodes).toEqual([])
+    expect(first.gates.every((gate) => gate.passed)).toBe(true)
+    expect(first.input.freshUntil).toBe('2026-07-22T14:00:30.000Z')
+    expect(first.metrics).toEqual({
+      orderNotionalMicros: '100000000',
+      postTradeSymbolExposureMicros: '200000000',
+      postTradeGrossExposureMicros: '300000000',
+      postTradeNetExposureMicros: '300000000',
+      dailyTradedNotionalMicros: '200000000',
+      dailyLossMicros: '50000000',
+      drawdownMicros: '100000000',
+      adverseSlippageBps: '0',
+      unresolvedOrderCount: 0,
+    })
+  })
+
+  test('blocks one micro beyond every money and exposure limit', () => {
+    const cases: readonly [Reason, Intent, State, Policy][] = [
+      [Reason.IntentNotionalExceeded, makeIntent({ notionalLimitMicros: '99999999' }), makeState(), makePolicy()],
+      [Reason.OrderNotionalExceeded, makeIntent(), makeState(), makePolicy({ maxOrderNotionalMicros: '99999999' })],
+      [
+        Reason.BuyingPowerExceeded,
+        makeIntent(),
+        makeState({ account: { ...baseState().account, buyingPowerMicros: '99999999' } }),
+        makePolicy(),
+      ],
+      [Reason.SymbolExposureExceeded, makeIntent(), makeState(), makePolicy({ maxSymbolExposureMicros: '199999999' })],
+      [Reason.GrossExposureExceeded, makeIntent(), makeState(), makePolicy({ maxGrossExposureMicros: '299999999' })],
+      [Reason.NetExposureExceeded, makeIntent(), makeState(), makePolicy({ maxNetExposureMicros: '299999999' })],
+      [
+        Reason.DailyTradedNotionalExceeded,
+        makeIntent(),
+        makeState(),
+        makePolicy({ maxDailyTradedNotionalMicros: '199999999' }),
+      ],
+      [Reason.DailyLossExceeded, makeIntent(), makeState(), makePolicy({ maxDailyLossMicros: '49999999' })],
+      [Reason.DrawdownExceeded, makeIntent(), makeState(), makePolicy({ maxDrawdownMicros: '99999999' })],
+    ]
+
+    for (const [reason, intent, state, policy] of cases) expectBlocked(reason, intent, state, policy)
+  })
+
+  test('blocks adverse slippage and unresolved-order overflow at their next unit', () => {
+    const slippageState = makeState({
+      account: { ...baseState().account, buyingPowerMicros: '101000000' },
+      expectedExecutionPriceMicros: '101000000',
+    })
+    const slippageIntent = makeIntent({ notionalLimitMicros: '101000000' })
+    const slippagePolicy = makePolicy({
+      maxOrderNotionalMicros: '101000000',
+      maxSymbolExposureMicros: '201000000',
+      maxGrossExposureMicros: '301000000',
+      maxNetExposureMicros: '301000000',
+      maxDailyTradedNotionalMicros: '201000000',
+      maxAdverseSlippageBps: 100,
+    })
+    expect(evaluate(slippageIntent, slippageState, slippagePolicy).decision.outcome).toBe(RiskOutcome.Approved)
+    expectBlocked(
+      Reason.AdverseSlippageExceeded,
+      slippageIntent,
+      slippageState,
+      makePolicy({ ...slippagePolicy, maxAdverseSlippageBps: 99 }),
+    )
+
+    const oneOrder = makeState({ orders: [openOrder('broker-1')] })
+    expect(evaluate(makeIntent(), oneOrder, makePolicy({ maxUnresolvedOrders: 1 })).decision.outcome).toBe(
+      RiskOutcome.Approved,
+    )
+    expectBlocked(Reason.UnresolvedOrdersExceeded, makeIntent(), oneOrder, makePolicy({ maxUnresolvedOrders: 0 }))
+  })
+
+  test('does not require buying power for a position-reducing sell', () => {
+    const result = evaluate(
+      makeIntent({ side: OrderSide.Sell }),
+      makeState({ account: { ...baseState().account, buyingPowerMicros: '0' } }),
+      makePolicy(),
+    )
+    expect(result.decision.outcome).toBe(RiskOutcome.Approved)
+    expect(result.metrics.postTradeSymbolExposureMicros).toBe('0')
+  })
+
+  test('fails closed on identity, authority, reconciliation, freshness, session, and mutation state', () => {
+    expectBlocked(Reason.AccountMismatch, makeIntent(), makeState(), makePolicy({ accountId: 'another-account' }))
+    expectBlocked(
+      Reason.AccountNotActive,
+      makeIntent(),
+      makeState({ account: { ...baseState().account, status: AccountStatus.Restricted } }),
+    )
+    expectBlocked(
+      Reason.EquityNotPositive,
+      makeIntent(),
+      makeState({ account: { ...baseState().account, equityMicros: '0' } }),
+    )
+    expectBlocked(Reason.SymbolNotAllowed, makeIntent(), makeState(), makePolicy({ allowedSymbols: ['AMD'] }))
+    expectBlocked(Reason.OrderTypeNotAllowed, makeIntent({ orderType: OrderType.Limit }), makeState(), makePolicy())
+    expectBlocked(
+      Reason.TimeInForceNotAllowed,
+      makeIntent(),
+      makeState(),
+      makePolicy({ allowedTimeInForce: [TimeInForce.GoodUntilCanceled] }),
+    )
+    expectBlocked(
+      Reason.IntentNotPlanned,
+      makeIntent({
+        state: IntentState.Terminal,
+        riskDecisionId: hash('7'),
+        terminalOutcome: TerminalOutcome.Blocked,
+      }),
+    )
+    expectBlocked(Reason.IntentTimeInvalid, makeIntent({ createdAt: '2026-07-22T14:00:00.001Z' }))
+    expectBlocked(
+      Reason.IntentStale,
+      makeIntent({ createdAt: '2026-07-22T13:59:00.000Z' }),
+      makeState(),
+      makePolicy({ maxIntentAgeMs: 60_000 }),
+    )
+    expectBlocked(
+      Reason.AuthorityNotPaper,
+      makeIntent(),
+      makeState({
+        authority: {
+          ...baseState().authority,
+          maximum: Authority.Observe,
+          effective: Authority.Observe,
+        },
+      }),
+    )
+    expectBlocked(
+      Reason.KillActive,
+      makeIntent(),
+      makeState({
+        authority: {
+          ...baseState().authority,
+          effective: Authority.Observe,
+          kill: KillState.Active,
+          reason: 'operator kill',
+        },
+      }),
+    )
+    expectBlocked(
+      Reason.ReconciliationNotExact,
+      makeIntent(),
+      makeState({
+        reconciliation: {
+          ...baseState().reconciliation,
+          observedHash: hash('8'),
+          status: ReconciliationStatus.Discrepancy,
+          discrepancies: [
+            { kind: DiscrepancyKind.Account, identity: 'paper-account-1', expected: 'expected', observed: 'observed' },
+          ],
+        },
+      }),
+    )
+    expectBlocked(
+      Reason.ReconciliationNotExact,
+      makeIntent(),
+      makeState({
+        reconciliation: {
+          ...baseState().reconciliation,
+          expectedHash: hash('a'),
+          observedHash: hash('a'),
+        },
+      }),
+    )
+    expectBlocked(Reason.BrokerStateStale, makeIntent(), makeState(), makePolicy({ maxBrokerStateAgeMs: 30_000 }))
+    expectBlocked(Reason.MarketDataStale, makeIntent(), makeState(), makePolicy({ maxMarketDataAgeMs: 30_000 }))
+    expectBlocked(Reason.OutsideSession, makeIntent(), makeState({ submissionCutoffAt: evaluatedAt }), makePolicy())
+    expectBlocked(Reason.UnknownMutation, makeIntent(), makeState({ unknownMutationCount: 1 }), makePolicy())
+  })
+
+  test('binds every intent, policy, and evidence change and caps approval lifetime', () => {
+    const baseline = evaluate(makeIntent(), makeState(), makePolicy())
+    const changedIntent = evaluate(makeIntent({ clientOrderId: 'risk-test-order-2' }), makeState(), makePolicy())
+    const changedPolicy = evaluate(makeIntent(), makeState(), makePolicy({ allowedSymbols: ['AMD', 'NVDA', 'WDC'] }))
+    const changedState = evaluate(makeIntent(), makeState({ marketDataHash: hash('9') }), makePolicy())
+    const changedAccounting = evaluate(makeIntent(), makeState({ accountingHash: hash('b') }), makePolicy())
+
+    expect(changedIntent.input.intentId).toBe(baseline.input.intentId)
+    expect(changedIntent.input.inputHash).not.toBe(baseline.input.inputHash)
+    expect(changedIntent.decision.decisionId).not.toBe(baseline.decision.decisionId)
+    expect(changedPolicy.policyHash).not.toBe(baseline.policyHash)
+    expect(changedPolicy.input.inputHash).not.toBe(baseline.input.inputHash)
+    expect(changedState.input.inputHash).not.toBe(baseline.input.inputHash)
+    expect(changedAccounting.input.inputHash).not.toBe(baseline.input.inputHash)
+
+    const ttlCapped = evaluate(makeIntent(), makeState(), makePolicy({ decisionTtlMs: 1_000 }))
+    const freshnessCapped = evaluate(
+      makeIntent(),
+      makeState(),
+      makePolicy({ decisionTtlMs: 60_000, maxBrokerStateAgeMs: 30_001, maxMarketDataAgeMs: 30_001 }),
+    )
+    const cutoffCapped = evaluate(
+      makeIntent(),
+      makeState({ submissionCutoffAt: '2026-07-22T14:00:00.001Z' }),
+      makePolicy({ decisionTtlMs: 60_000 }),
+    )
+    const intentCapped = evaluate(
+      makeIntent(),
+      makeState(),
+      makePolicy({ decisionTtlMs: 60_000, maxIntentAgeMs: 15_001 }),
+    )
+    expect(ttlCapped.input.freshUntil).toBe('2026-07-22T14:00:01.000Z')
+    expect(freshnessCapped.input.freshUntil).toBe('2026-07-22T14:00:00.001Z')
+    expect(cutoffCapped.input.freshUntil).toBe('2026-07-22T14:00:00.001Z')
+    expect(intentCapped.input.freshUntil).toBe('2026-07-22T14:00:00.001Z')
+  })
+})

--- a/services/bayn/src/risk.ts
+++ b/services/bayn/src/risk.ts
@@ -1,0 +1,638 @@
+import { Schema } from 'effect'
+
+import { canonicalHashV1 } from './hash'
+import {
+  AccountSnapshotSchema,
+  AccountStatus,
+  Authority,
+  AuthorityStateSchema,
+  IntentState,
+  KillState,
+  OrderSchema,
+  OrderSide,
+  OrderStatus,
+  OrderType,
+  PositionSchema,
+  PositiveMicrosSchema,
+  ReconciliationSchema,
+  ReconciliationStatus,
+  RiskDecisionSchema,
+  RiskInputSchema,
+  RiskOutcome,
+  SignedMicrosSchema,
+  TimeInForce,
+  UnsignedMicrosSchema,
+  type Intent,
+  type RiskDecision,
+  type RiskInput,
+} from './paper'
+import {
+  Sha256Schema as Sha256,
+  StrictNonEmptyStringSchema as NonEmptyString,
+  SymbolSchema as SymbolName,
+  UtcInstantSchema as UtcInstant,
+  strictParseOptions as StrictParseOptions,
+} from './schemas'
+
+const MAX_POLICY_MICROS = 9_223_372_036_854_775_807n
+const MAX_AGE_MS = 86_400_000
+const MAX_OPEN_ORDERS = 1_000
+const BASIS_POINTS = 10_000n
+const QUANTITY_SCALE = 1_000_000n
+
+const LimitMicros = UnsignedMicrosSchema.check(
+  Schema.makeFilter((value: string) => BigInt(value) <= MAX_POLICY_MICROS, {
+    expected: `canonical micros not exceeding ${MAX_POLICY_MICROS}`,
+  }),
+)
+const AgeMilliseconds = Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: MAX_AGE_MS }))
+const OrderCount = Schema.Int.check(Schema.isBetween({ minimum: 0, maximum: MAX_OPEN_ORDERS }))
+const BasisPointLimit = Schema.Int.check(Schema.isBetween({ minimum: 0, maximum: Number(BASIS_POINTS) }))
+
+const isSorted = (values: ReadonlyArray<string>): boolean => {
+  for (let index = 1; index < values.length; index += 1) {
+    if (values[index - 1] >= values[index]) return false
+  }
+  return true
+}
+
+const SortedUniqueStrings = Schema.makeFilter((values: ReadonlyArray<string>) => isSorted(values), {
+  expected: 'a strictly sorted unique array',
+})
+
+export enum BrokerMode {
+  Paper = 'PAPER',
+}
+
+export enum Gate {
+  IntentState = 'intent_state',
+  IntentTime = 'intent_time',
+  IntentFreshness = 'intent_freshness',
+  Account = 'account',
+  AccountStatus = 'account_status',
+  Equity = 'equity',
+  Symbol = 'symbol',
+  OrderType = 'order_type',
+  TimeInForce = 'time_in_force',
+  Authority = 'authority',
+  Kill = 'kill',
+  Reconciliation = 'reconciliation',
+  BrokerStateFreshness = 'broker_state_freshness',
+  MarketDataFreshness = 'market_data_freshness',
+  Session = 'session',
+  UnknownMutations = 'unknown_mutations',
+  UnresolvedOrders = 'unresolved_orders',
+  IntentNotional = 'intent_notional',
+  OrderNotional = 'order_notional',
+  BuyingPower = 'buying_power',
+  AdverseSlippage = 'adverse_slippage',
+  SymbolExposure = 'symbol_exposure',
+  GrossExposure = 'gross_exposure',
+  NetExposure = 'net_exposure',
+  DailyTradedNotional = 'daily_traded_notional',
+  DailyLoss = 'daily_loss',
+  Drawdown = 'drawdown',
+}
+
+export enum Reason {
+  IntentNotPlanned = 'INTENT_NOT_PLANNED',
+  IntentTimeInvalid = 'INTENT_TIME_INVALID',
+  IntentStale = 'INTENT_STALE',
+  AccountMismatch = 'ACCOUNT_MISMATCH',
+  AccountNotActive = 'ACCOUNT_NOT_ACTIVE',
+  EquityNotPositive = 'EQUITY_NOT_POSITIVE',
+  SymbolNotAllowed = 'SYMBOL_NOT_ALLOWED',
+  OrderTypeNotAllowed = 'ORDER_TYPE_NOT_ALLOWED',
+  TimeInForceNotAllowed = 'TIME_IN_FORCE_NOT_ALLOWED',
+  AuthorityNotPaper = 'AUTHORITY_NOT_PAPER',
+  KillActive = 'KILL_ACTIVE',
+  ReconciliationNotExact = 'RECONCILIATION_NOT_EXACT',
+  BrokerStateStale = 'BROKER_STATE_STALE',
+  MarketDataStale = 'MARKET_DATA_STALE',
+  OutsideSession = 'OUTSIDE_SESSION',
+  UnknownMutation = 'UNKNOWN_MUTATION',
+  UnresolvedOrdersExceeded = 'UNRESOLVED_ORDERS_EXCEEDED',
+  IntentNotionalExceeded = 'INTENT_NOTIONAL_EXCEEDED',
+  OrderNotionalExceeded = 'ORDER_NOTIONAL_EXCEEDED',
+  BuyingPowerExceeded = 'BUYING_POWER_EXCEEDED',
+  AdverseSlippageExceeded = 'ADVERSE_SLIPPAGE_EXCEEDED',
+  SymbolExposureExceeded = 'SYMBOL_EXPOSURE_EXCEEDED',
+  GrossExposureExceeded = 'GROSS_EXPOSURE_EXCEEDED',
+  NetExposureExceeded = 'NET_EXPOSURE_EXCEEDED',
+  DailyTradedNotionalExceeded = 'DAILY_TRADED_NOTIONAL_EXCEEDED',
+  DailyLossExceeded = 'DAILY_LOSS_EXCEEDED',
+  DrawdownExceeded = 'DRAWDOWN_EXCEEDED',
+}
+
+export const PolicySchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.paper-risk-policy.v1'),
+  accountId: NonEmptyString,
+  brokerMode: Schema.Literal(BrokerMode.Paper),
+  allowedSymbols: Schema.Array(SymbolName).check(Schema.isMinLength(1), Schema.isUnique(), SortedUniqueStrings),
+  allowedOrderTypes: Schema.Tuple([Schema.Literal(OrderType.Market)]),
+  allowedTimeInForce: Schema.Array(Schema.Enum(TimeInForce)).check(
+    Schema.isMinLength(1),
+    Schema.isUnique(),
+    SortedUniqueStrings,
+  ),
+  maxOrderNotionalMicros: LimitMicros,
+  maxSymbolExposureMicros: LimitMicros,
+  maxGrossExposureMicros: LimitMicros,
+  maxNetExposureMicros: LimitMicros,
+  maxDailyTradedNotionalMicros: LimitMicros,
+  maxDailyLossMicros: LimitMicros,
+  maxDrawdownMicros: LimitMicros,
+  maxIntentAgeMs: AgeMilliseconds,
+  maxBrokerStateAgeMs: AgeMilliseconds,
+  maxMarketDataAgeMs: AgeMilliseconds,
+  maxAdverseSlippageBps: BasisPointLimit,
+  maxUnresolvedOrders: OrderCount,
+  decisionTtlMs: AgeMilliseconds,
+})
+export type Policy = typeof PolicySchema.Type
+
+const StateBase = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.paper-risk-state.v1'),
+  brokerMode: Schema.Literal(BrokerMode.Paper),
+  account: AccountSnapshotSchema,
+  positions: Schema.Array(PositionSchema),
+  positionsObservedAt: UtcInstant,
+  orders: Schema.Array(OrderSchema),
+  ordersObservedAt: UtcInstant,
+  reconciliation: ReconciliationSchema,
+  authority: AuthorityStateSchema,
+  authorityObservedAt: UtcInstant,
+  unknownMutationCount: OrderCount,
+  dailyTradedNotionalMicros: UnsignedMicrosSchema,
+  dayStartEquityMicros: SignedMicrosSchema,
+  peakEquityMicros: SignedMicrosSchema,
+  accountingHash: Sha256,
+  marketDataHash: Sha256,
+  referencePriceMicros: PositiveMicrosSchema,
+  expectedExecutionPriceMicros: PositiveMicrosSchema,
+  marketDataObservedAt: UtcInstant,
+  sessionOpenAt: UtcInstant,
+  submissionCutoffAt: UtcInstant,
+  evaluatedAt: UtcInstant,
+})
+
+const timeDoesNotFollow = (candidate: string, boundary: string): boolean => candidate > boundary
+
+export const StateSchema = StateBase.check(
+  Schema.makeFilter((state: typeof StateBase.Type): readonly Schema.FilterIssue[] => {
+    const issues: Schema.FilterIssue[] = []
+    const accountId = state.account.accountId
+    if (state.sessionOpenAt >= state.submissionCutoffAt) {
+      issues.push({ path: ['submissionCutoffAt'], issue: 'must follow sessionOpenAt' })
+    }
+    const timestamps = [
+      ['account', 'observedAt', state.account.observedAt],
+      ['positionsObservedAt', state.positionsObservedAt],
+      ['ordersObservedAt', state.ordersObservedAt],
+      ['reconciliation', 'reconciledAt', state.reconciliation.reconciledAt],
+      ['authorityObservedAt', state.authorityObservedAt],
+      ['marketDataObservedAt', state.marketDataObservedAt],
+    ] as const
+    for (const path of timestamps) {
+      const candidate = path[path.length - 1]
+      if (timeDoesNotFollow(candidate, state.evaluatedAt)) {
+        issues.push({ path: path.slice(0, -1), issue: 'must not follow evaluatedAt' })
+      }
+    }
+    if (state.reconciliation.accountId !== accountId) {
+      issues.push({ path: ['reconciliation', 'accountId'], issue: 'must match the account snapshot' })
+    }
+    if (state.authority.updatedAt > state.authorityObservedAt) {
+      issues.push({ path: ['authorityObservedAt'], issue: 'must not precede the authority update' })
+    }
+    if (
+      state.reconciliation.reconciledAt < state.account.observedAt ||
+      state.reconciliation.reconciledAt < state.positionsObservedAt ||
+      state.reconciliation.reconciledAt < state.ordersObservedAt
+    ) {
+      issues.push({ path: ['reconciliation', 'reconciledAt'], issue: 'must cover every broker snapshot' })
+    }
+    const positionSymbols = state.positions.map((position) => position.symbol)
+    if (new Set(positionSymbols).size !== positionSymbols.length || !isSorted(positionSymbols)) {
+      issues.push({ path: ['positions'], issue: 'must be unique and sorted by symbol' })
+    }
+    for (const [index, position] of state.positions.entries()) {
+      if (position.accountId !== accountId) {
+        issues.push({ path: ['positions', index, 'accountId'], issue: 'must match the account snapshot' })
+      }
+      if (position.observedAt !== state.positionsObservedAt) {
+        issues.push({ path: ['positions', index, 'observedAt'], issue: 'must match positionsObservedAt' })
+      }
+      const quantity = BigInt(position.quantityMicros)
+      const marketValue = BigInt(position.marketValueMicros)
+      if (
+        (quantity === 0n) !== (marketValue === 0n) ||
+        (quantity > 0n && marketValue < 0n) ||
+        (quantity < 0n && marketValue > 0n)
+      ) {
+        issues.push({ path: ['positions', index, 'marketValueMicros'], issue: 'must have the quantity sign' })
+      }
+    }
+    const brokerOrderIds = state.orders.map((order) => order.brokerOrderId)
+    if (new Set(brokerOrderIds).size !== brokerOrderIds.length || !isSorted(brokerOrderIds)) {
+      issues.push({ path: ['orders'], issue: 'must be unique and sorted by brokerOrderId' })
+    }
+    const clientOrderIds = state.orders.map((order) => order.clientOrderId)
+    if (new Set(clientOrderIds).size !== clientOrderIds.length) {
+      issues.push({ path: ['orders'], issue: 'must have unique clientOrderId values' })
+    }
+    for (const [index, order] of state.orders.entries()) {
+      if (order.accountId !== accountId) {
+        issues.push({ path: ['orders', index, 'accountId'], issue: 'must match the account snapshot' })
+      }
+      if (order.observedAt !== state.ordersObservedAt) {
+        issues.push({ path: ['orders', index, 'observedAt'], issue: 'must match ordersObservedAt' })
+      }
+    }
+    if (BigInt(state.peakEquityMicros) < BigInt(state.account.equityMicros)) {
+      issues.push({ path: ['peakEquityMicros'], issue: 'must not be less than current equity' })
+    }
+    return issues
+  }),
+)
+export type State = typeof StateSchema.Type
+
+export type GateResult = {
+  readonly name: Gate
+  readonly passed: boolean
+  readonly reason: Reason
+  readonly actual: string
+  readonly required: string
+}
+
+export type Evaluation = {
+  readonly policyHash: string
+  readonly input: RiskInput
+  readonly decision: RiskDecision
+  readonly gates: readonly GateResult[]
+  readonly metrics: {
+    readonly orderNotionalMicros: string
+    readonly postTradeSymbolExposureMicros: string
+    readonly postTradeGrossExposureMicros: string
+    readonly postTradeNetExposureMicros: string
+    readonly dailyTradedNotionalMicros: string
+    readonly dailyLossMicros: string
+    readonly drawdownMicros: string
+    readonly adverseSlippageBps: string
+    readonly unresolvedOrderCount: number
+  }
+}
+
+const decodeInput = Schema.decodeUnknownSync(RiskInputSchema, StrictParseOptions)
+const decodeDecision = Schema.decodeUnknownSync(RiskDecisionSchema, StrictParseOptions)
+
+const absolute = (value: bigint): bigint => (value < 0n ? -value : value)
+const positiveDifference = (left: bigint, right: bigint): bigint => (left > right ? left - right : 0n)
+const divideUp = (numerator: bigint, denominator: bigint): bigint =>
+  numerator === 0n ? 0n : (numerator + denominator - 1n) / denominator
+const instant = (value: string): number => Date.parse(value)
+const utc = (value: number): string => new Date(value).toISOString()
+
+const makeGate = (
+  name: Gate,
+  reason: Reason,
+  passed: boolean,
+  actual: string | number | bigint,
+  required: string | number | bigint,
+): GateResult => ({ name, reason, passed, actual: String(actual), required: String(required) })
+
+const isUnresolved = (status: OrderStatus): boolean =>
+  status === OrderStatus.New || status === OrderStatus.PartiallyFilled || status === OrderStatus.Pending
+
+export const evaluate = (intent: Intent, state: State, policy: Policy): Evaluation => {
+  const evaluatedAt = instant(state.evaluatedAt)
+  const policyHash = canonicalHashV1(policy)
+  const orderNotional = divideUp(
+    BigInt(intent.quantityMicros) * BigInt(state.expectedExecutionPriceMicros),
+    QUANTITY_SCALE,
+  )
+  const direction = intent.side === OrderSide.Buy ? 1n : -1n
+  const currentSymbolExposure = state.positions
+    .filter((position) => position.symbol === intent.symbol)
+    .reduce((total, position) => total + BigInt(position.marketValueMicros), 0n)
+  const currentGrossExposure = state.positions.reduce(
+    (total, position) => total + absolute(BigInt(position.marketValueMicros)),
+    0n,
+  )
+  const currentNetExposure = state.positions.reduce((total, position) => total + BigInt(position.marketValueMicros), 0n)
+  const postTradeSymbolExposure = currentSymbolExposure + direction * orderNotional
+  const exposureIncrease = positiveDifference(absolute(postTradeSymbolExposure), absolute(currentSymbolExposure))
+  const postTradeGrossExposure =
+    currentGrossExposure - absolute(currentSymbolExposure) + absolute(postTradeSymbolExposure)
+  const postTradeNetExposure = currentNetExposure + direction * orderNotional
+  const dailyTradedNotional = BigInt(state.dailyTradedNotionalMicros) + orderNotional
+  const dailyLoss = positiveDifference(BigInt(state.dayStartEquityMicros), BigInt(state.account.equityMicros))
+  const drawdown = positiveDifference(BigInt(state.peakEquityMicros), BigInt(state.account.equityMicros))
+  const referencePrice = BigInt(state.referencePriceMicros)
+  const expectedPrice = BigInt(state.expectedExecutionPriceMicros)
+  const adversePriceDifference =
+    intent.side === OrderSide.Buy
+      ? positiveDifference(expectedPrice, referencePrice)
+      : positiveDifference(referencePrice, expectedPrice)
+  const adverseSlippageBps = divideUp(adversePriceDifference * BASIS_POINTS, referencePrice)
+  const unresolvedOrderCount = state.orders.filter((order) => isUnresolved(order.status)).length
+  const brokerStateHash = canonicalHashV1({
+    schemaVersion: 'bayn.paper-risk-broker-state.v1',
+    account: state.account,
+    positions: state.positions,
+    positionsObservedAt: state.positionsObservedAt,
+    orders: state.orders,
+    ordersObservedAt: state.ordersObservedAt,
+  })
+  const reconciledStateHash = canonicalHashV1({
+    schemaVersion: 'bayn.paper-risk-reconciled-state.v1',
+    brokerStateHash,
+    accountingHash: state.accountingHash,
+    dailyTradedNotionalMicros: state.dailyTradedNotionalMicros,
+    dayStartEquityMicros: state.dayStartEquityMicros,
+    peakEquityMicros: state.peakEquityMicros,
+  })
+  const oldestBrokerState = Math.min(
+    instant(state.account.observedAt),
+    instant(state.positionsObservedAt),
+    instant(state.ordersObservedAt),
+    instant(state.reconciliation.reconciledAt),
+    instant(state.authorityObservedAt),
+  )
+  const brokerFreshUntil = oldestBrokerState + policy.maxBrokerStateAgeMs
+  const marketFreshUntil = instant(state.marketDataObservedAt) + policy.maxMarketDataAgeMs
+  const sessionOpen = instant(state.sessionOpenAt)
+  const submissionCutoff = instant(state.submissionCutoffAt)
+
+  const gates = [
+    makeGate(Gate.IntentState, Reason.IntentNotPlanned, intent.state === IntentState.Planned, intent.state, 'PLANNED'),
+    makeGate(
+      Gate.IntentTime,
+      Reason.IntentTimeInvalid,
+      instant(intent.createdAt) <= evaluatedAt,
+      intent.createdAt,
+      `<=${state.evaluatedAt}`,
+    ),
+    makeGate(
+      Gate.IntentFreshness,
+      Reason.IntentStale,
+      evaluatedAt < instant(intent.createdAt) + policy.maxIntentAgeMs,
+      evaluatedAt - instant(intent.createdAt),
+      `<${policy.maxIntentAgeMs}`,
+    ),
+    makeGate(
+      Gate.Account,
+      Reason.AccountMismatch,
+      intent.accountId === policy.accountId && state.account.accountId === policy.accountId,
+      `${intent.accountId}:${state.account.accountId}`,
+      policy.accountId,
+    ),
+    makeGate(
+      Gate.AccountStatus,
+      Reason.AccountNotActive,
+      state.account.status === AccountStatus.Active,
+      state.account.status,
+      AccountStatus.Active,
+    ),
+    makeGate(
+      Gate.Equity,
+      Reason.EquityNotPositive,
+      BigInt(state.account.equityMicros) > 0n,
+      state.account.equityMicros,
+      '>0',
+    ),
+    makeGate(
+      Gate.Symbol,
+      Reason.SymbolNotAllowed,
+      policy.allowedSymbols.includes(intent.symbol),
+      intent.symbol,
+      policy.allowedSymbols.join(','),
+    ),
+    makeGate(
+      Gate.OrderType,
+      Reason.OrderTypeNotAllowed,
+      intent.orderType === OrderType.Market,
+      intent.orderType,
+      policy.allowedOrderTypes.join(','),
+    ),
+    makeGate(
+      Gate.TimeInForce,
+      Reason.TimeInForceNotAllowed,
+      policy.allowedTimeInForce.includes(intent.timeInForce),
+      intent.timeInForce,
+      policy.allowedTimeInForce.join(','),
+    ),
+    makeGate(
+      Gate.Authority,
+      Reason.AuthorityNotPaper,
+      state.authority.maximum === Authority.Paper && state.authority.effective === Authority.Paper,
+      `${state.authority.maximum}:${state.authority.effective}`,
+      'PAPER:PAPER',
+    ),
+    makeGate(Gate.Kill, Reason.KillActive, state.authority.kill === KillState.Clear, state.authority.kill, 'CLEAR'),
+    makeGate(
+      Gate.Reconciliation,
+      Reason.ReconciliationNotExact,
+      state.reconciliation.status === ReconciliationStatus.Exact &&
+        state.reconciliation.expectedHash === reconciledStateHash &&
+        state.reconciliation.observedHash === reconciledStateHash,
+      `${state.reconciliation.status}:${state.reconciliation.expectedHash}:${state.reconciliation.observedHash}`,
+      `${ReconciliationStatus.Exact}:${reconciledStateHash}:${reconciledStateHash}`,
+    ),
+    makeGate(
+      Gate.BrokerStateFreshness,
+      Reason.BrokerStateStale,
+      evaluatedAt < brokerFreshUntil,
+      evaluatedAt - oldestBrokerState,
+      `<${policy.maxBrokerStateAgeMs}`,
+    ),
+    makeGate(
+      Gate.MarketDataFreshness,
+      Reason.MarketDataStale,
+      evaluatedAt < marketFreshUntil,
+      evaluatedAt - instant(state.marketDataObservedAt),
+      `<${policy.maxMarketDataAgeMs}`,
+    ),
+    makeGate(
+      Gate.Session,
+      Reason.OutsideSession,
+      evaluatedAt >= sessionOpen && evaluatedAt < submissionCutoff,
+      state.evaluatedAt,
+      `[${state.sessionOpenAt},${state.submissionCutoffAt})`,
+    ),
+    makeGate(
+      Gate.UnknownMutations,
+      Reason.UnknownMutation,
+      state.unknownMutationCount === 0,
+      state.unknownMutationCount,
+      0,
+    ),
+    makeGate(
+      Gate.UnresolvedOrders,
+      Reason.UnresolvedOrdersExceeded,
+      unresolvedOrderCount <= policy.maxUnresolvedOrders,
+      unresolvedOrderCount,
+      `<=${policy.maxUnresolvedOrders}`,
+    ),
+    makeGate(
+      Gate.IntentNotional,
+      Reason.IntentNotionalExceeded,
+      orderNotional <= BigInt(intent.notionalLimitMicros),
+      orderNotional,
+      `<=${intent.notionalLimitMicros}`,
+    ),
+    makeGate(
+      Gate.OrderNotional,
+      Reason.OrderNotionalExceeded,
+      orderNotional <= BigInt(policy.maxOrderNotionalMicros),
+      orderNotional,
+      `<=${policy.maxOrderNotionalMicros}`,
+    ),
+    makeGate(
+      Gate.BuyingPower,
+      Reason.BuyingPowerExceeded,
+      exposureIncrease <= BigInt(state.account.buyingPowerMicros),
+      exposureIncrease,
+      `<=${state.account.buyingPowerMicros}`,
+    ),
+    makeGate(
+      Gate.AdverseSlippage,
+      Reason.AdverseSlippageExceeded,
+      adverseSlippageBps <= BigInt(policy.maxAdverseSlippageBps),
+      adverseSlippageBps,
+      `<=${policy.maxAdverseSlippageBps}`,
+    ),
+    makeGate(
+      Gate.SymbolExposure,
+      Reason.SymbolExposureExceeded,
+      absolute(postTradeSymbolExposure) <= BigInt(policy.maxSymbolExposureMicros),
+      absolute(postTradeSymbolExposure),
+      `<=${policy.maxSymbolExposureMicros}`,
+    ),
+    makeGate(
+      Gate.GrossExposure,
+      Reason.GrossExposureExceeded,
+      postTradeGrossExposure <= BigInt(policy.maxGrossExposureMicros),
+      postTradeGrossExposure,
+      `<=${policy.maxGrossExposureMicros}`,
+    ),
+    makeGate(
+      Gate.NetExposure,
+      Reason.NetExposureExceeded,
+      absolute(postTradeNetExposure) <= BigInt(policy.maxNetExposureMicros),
+      absolute(postTradeNetExposure),
+      `<=${policy.maxNetExposureMicros}`,
+    ),
+    makeGate(
+      Gate.DailyTradedNotional,
+      Reason.DailyTradedNotionalExceeded,
+      dailyTradedNotional <= BigInt(policy.maxDailyTradedNotionalMicros),
+      dailyTradedNotional,
+      `<=${policy.maxDailyTradedNotionalMicros}`,
+    ),
+    makeGate(
+      Gate.DailyLoss,
+      Reason.DailyLossExceeded,
+      dailyLoss <= BigInt(policy.maxDailyLossMicros),
+      dailyLoss,
+      `<=${policy.maxDailyLossMicros}`,
+    ),
+    makeGate(
+      Gate.Drawdown,
+      Reason.DrawdownExceeded,
+      drawdown <= BigInt(policy.maxDrawdownMicros),
+      drawdown,
+      `<=${policy.maxDrawdownMicros}`,
+    ),
+  ] as const
+
+  const reasonCodes = gates.filter((gate) => !gate.passed).map((gate) => gate.reason)
+  const outcome = reasonCodes.length === 0 ? RiskOutcome.Approved : RiskOutcome.Blocked
+  const approvalExpiry = Math.min(
+    evaluatedAt + policy.decisionTtlMs,
+    instant(intent.createdAt) + policy.maxIntentAgeMs,
+    brokerFreshUntil,
+    marketFreshUntil,
+    submissionCutoff,
+  )
+  const expiresAt = utc(
+    outcome === RiskOutcome.Approved ? approvalExpiry : evaluatedAt + Math.min(1_000, policy.decisionTtlMs),
+  )
+  const accountSnapshotHash = canonicalHashV1({
+    account: state.account,
+    authority: state.authority,
+    authorityObservedAt: state.authorityObservedAt,
+    accountingHash: state.accountingHash,
+    brokerMode: state.brokerMode,
+    reconciliation: state.reconciliation,
+    dailyTradedNotionalMicros: state.dailyTradedNotionalMicros,
+    dayStartEquityMicros: state.dayStartEquityMicros,
+    peakEquityMicros: state.peakEquityMicros,
+  })
+  const positionsHash = canonicalHashV1({ items: state.positions, observedAt: state.positionsObservedAt })
+  const ordersHash = canonicalHashV1({
+    items: state.orders,
+    observedAt: state.ordersObservedAt,
+    unknownMutationCount: state.unknownMutationCount,
+  })
+  const marketDataHash = canonicalHashV1({
+    sourceHash: state.marketDataHash,
+    observedAt: state.marketDataObservedAt,
+    referencePriceMicros: state.referencePriceMicros,
+    expectedExecutionPriceMicros: state.expectedExecutionPriceMicros,
+    sessionOpenAt: state.sessionOpenAt,
+    submissionCutoffAt: state.submissionCutoffAt,
+  })
+  const inputMaterial = {
+    schemaVersion: 'bayn.paper-risk-evaluation-input.v1',
+    intent,
+    policy,
+    state,
+    componentHashes: { accountSnapshotHash, positionsHash, ordersHash, marketDataHash },
+  } as const
+  const inputHash = canonicalHashV1(inputMaterial)
+  const input = decodeInput({
+    schemaVersion: 'bayn.paper-risk-input.v1',
+    inputHash,
+    intentId: intent.intentId,
+    policyHash,
+    accountSnapshotHash,
+    positionsHash,
+    ordersHash,
+    marketDataHash,
+    evaluatedAt: state.evaluatedAt,
+    freshUntil: expiresAt,
+  })
+  const decisionMaterial = {
+    schemaVersion: 'bayn.paper-risk-decision.v1',
+    inputHash,
+    intentId: intent.intentId,
+    policyHash,
+    outcome,
+    reasonCodes,
+    decidedAt: state.evaluatedAt,
+    expiresAt,
+  } as const
+  const decision = decodeDecision({ ...decisionMaterial, decisionId: canonicalHashV1(decisionMaterial) })
+
+  return {
+    policyHash,
+    input,
+    decision,
+    gates,
+    metrics: {
+      orderNotionalMicros: orderNotional.toString(),
+      postTradeSymbolExposureMicros: postTradeSymbolExposure.toString(),
+      postTradeGrossExposureMicros: postTradeGrossExposure.toString(),
+      postTradeNetExposureMicros: postTradeNetExposure.toString(),
+      dailyTradedNotionalMicros: dailyTradedNotional.toString(),
+      dailyLossMicros: dailyLoss.toString(),
+      drawdownMicros: drawdown.toString(),
+      adverseSlippageBps: adverseSlippageBps.toString(),
+      unresolvedOrderCount,
+    },
+  }
+}
+
+export const decodePolicy = Schema.decodeUnknownEffect(PolicySchema, StrictParseOptions)
+export const decodeState = Schema.decodeUnknownEffect(StateSchema, StrictParseOptions)

--- a/services/bayn/src/risk.ts
+++ b/services/bayn/src/risk.ts
@@ -36,7 +36,7 @@ import {
 
 const MAX_POLICY_MICROS = 9_223_372_036_854_775_807n
 const MAX_AGE_MS = 86_400_000
-const MAX_OPEN_ORDERS = 1_000
+const MAX_UNKNOWN_MUTATIONS = 1_000
 const BASIS_POINTS = 10_000n
 const QUANTITY_SCALE = 1_000_000n
 
@@ -46,7 +46,7 @@ const LimitMicros = UnsignedMicrosSchema.check(
   }),
 )
 const AgeMilliseconds = Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: MAX_AGE_MS }))
-const OrderCount = Schema.Int.check(Schema.isBetween({ minimum: 0, maximum: MAX_OPEN_ORDERS }))
+const MutationCount = Schema.Int.check(Schema.isBetween({ minimum: 0, maximum: MAX_UNKNOWN_MUTATIONS }))
 const BasisPointLimit = Schema.Int.check(Schema.isBetween({ minimum: 0, maximum: Number(BASIS_POINTS) }))
 
 const isSorted = (values: ReadonlyArray<string>): boolean => {
@@ -72,6 +72,7 @@ export enum Gate {
   AccountStatus = 'account_status',
   Equity = 'equity',
   Symbol = 'symbol',
+  MarketDataSymbol = 'market_data_symbol',
   OrderType = 'order_type',
   TimeInForce = 'time_in_force',
   Authority = 'authority',
@@ -102,6 +103,7 @@ export enum Reason {
   AccountNotActive = 'ACCOUNT_NOT_ACTIVE',
   EquityNotPositive = 'EQUITY_NOT_POSITIVE',
   SymbolNotAllowed = 'SYMBOL_NOT_ALLOWED',
+  MarketDataSymbolMismatch = 'MARKET_DATA_SYMBOL_MISMATCH',
   OrderTypeNotAllowed = 'ORDER_TYPE_NOT_ALLOWED',
   TimeInForceNotAllowed = 'TIME_IN_FORCE_NOT_ALLOWED',
   AuthorityNotPaper = 'AUTHORITY_NOT_PAPER',
@@ -146,7 +148,7 @@ export const PolicySchema = Schema.Struct({
   maxBrokerStateAgeMs: AgeMilliseconds,
   maxMarketDataAgeMs: AgeMilliseconds,
   maxAdverseSlippageBps: BasisPointLimit,
-  maxUnresolvedOrders: OrderCount,
+  maxUnresolvedOrders: Schema.Literal(0),
   decisionTtlMs: AgeMilliseconds,
 })
 export type Policy = typeof PolicySchema.Type
@@ -162,11 +164,12 @@ const StateBase = Schema.Struct({
   reconciliation: ReconciliationSchema,
   authority: AuthorityStateSchema,
   authorityObservedAt: UtcInstant,
-  unknownMutationCount: OrderCount,
+  unknownMutationCount: MutationCount,
   dailyTradedNotionalMicros: UnsignedMicrosSchema,
   dayStartEquityMicros: SignedMicrosSchema,
   peakEquityMicros: SignedMicrosSchema,
   accountingHash: Sha256,
+  marketDataSymbol: SymbolName,
   marketDataHash: Sha256,
   referencePriceMicros: PositiveMicrosSchema,
   expectedExecutionPriceMicros: PositiveMicrosSchema,
@@ -409,6 +412,13 @@ export const evaluate = (intent: Intent, state: State, policy: Policy): Evaluati
       policy.allowedSymbols.join(','),
     ),
     makeGate(
+      Gate.MarketDataSymbol,
+      Reason.MarketDataSymbolMismatch,
+      state.marketDataSymbol === intent.symbol,
+      state.marketDataSymbol,
+      intent.symbol,
+    ),
+    makeGate(
       Gate.OrderType,
       Reason.OrderTypeNotAllowed,
       intent.orderType === OrderType.Market,
@@ -576,6 +586,7 @@ export const evaluate = (intent: Intent, state: State, policy: Policy): Evaluati
     unknownMutationCount: state.unknownMutationCount,
   })
   const marketDataHash = canonicalHashV1({
+    symbol: state.marketDataSymbol,
     sourceHash: state.marketDataHash,
     observedAt: state.marketDataObservedAt,
     referencePriceMicros: state.referencePriceMicros,


### PR DESCRIPTION
## Summary

- Add a pure deterministic paper-risk evaluator with a fully required, bounded Effect Schema policy.
- Fail closed across identity, authority, reconciliation, freshness, session, mutation, notional, exposure, loss, drawdown, and slippage gates.
- Bind the exact intent, policy, broker, accounting, authority, and symbol-specific market evidence into deterministic input and decision hashes.
- Require zero unresolved orders until durable per-order reservations exist; keep this slice observe-only with no broker capability, I/O, or durable writes.

## Related Issues

Closes PROOMPT-373

## Testing

- bun test services/bayn/src/risk.test.ts (7 passed, 96 assertions)
- bun run --cwd services/bayn test (138 passed, 28 database integration tests skipped without live database configuration, 0 failed, 774 assertions)
- bun run --cwd services/bayn tsc
- bun run --cwd services/bayn lint
- bun run --cwd services/bayn lint:oxlint
- bun run --cwd services/bayn lint:oxlint:type
- bun run --cwd services/bayn build
- GitHub postgres-integration passed against PostgreSQL

## Breaking Changes

None. The evaluator is not wired into runtime authority or broker mutation.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Implementation scope and rollout follow-up are documented in the PROOMPT-373 Linear plan.