### PR TITLE
fix(bayn): project exposure from exact quantities

### DIFF
--- a/services/bayn/src/risk.test.ts
+++ b/services/bayn/src/risk.test.ts
@@ -341,6 +341,34 @@ describe('bounded paper risk', () => {
     expect(result.metrics.postTradeSymbolExposureMicros).toBe('0')
   })
 
+  test('revalues the current symbol at the current reference price before projecting exposure', () => {
+    const state = makeState({
+      account: { ...baseState().account, buyingPowerMicros: '200000000' },
+      referencePriceMicros: '200000000',
+      expectedExecutionPriceMicros: '200000000',
+    })
+    const intent = makeIntent({ notionalLimitMicros: '200000000' })
+    const policy = makePolicy({
+      maxOrderNotionalMicros: '200000000',
+      maxSymbolExposureMicros: '400000000',
+      maxGrossExposureMicros: '500000000',
+      maxNetExposureMicros: '500000000',
+      maxDailyTradedNotionalMicros: '300000000',
+    })
+    const result = evaluate(intent, state, policy)
+
+    expect(result.decision.outcome).toBe(RiskOutcome.Approved)
+    expect(result.metrics.postTradeSymbolExposureMicros).toBe('400000000')
+    expect(result.metrics.postTradeGrossExposureMicros).toBe('500000000')
+    expect(result.metrics.postTradeNetExposureMicros).toBe('500000000')
+    expectBlocked(
+      Reason.SymbolExposureExceeded,
+      intent,
+      state,
+      makePolicy({ ...policy, maxSymbolExposureMicros: '399999999' }),
+    )
+  })
+
   test('fails closed on identity, authority, reconciliation, freshness, session, and mutation state', () => {
     expectBlocked(Reason.AccountMismatch, makeIntent(), makeState(), makePolicy({ accountId: 'another-account' }))
     expectBlocked(

--- a/services/bayn/src/risk.test.ts
+++ b/services/bayn/src/risk.test.ts
@@ -369,6 +369,77 @@ describe('bounded paper risk', () => {
     )
   })
 
+  test('projects short exposure at the current quote instead of the lower expected sell price', () => {
+    const positions = [
+      baseState().positions[0],
+      {
+        ...baseState().positions[1],
+        quantityMicros: '-1000000',
+        averageEntryPriceMicros: '200000000',
+        marketPriceMicros: '200000000',
+        marketValueMicros: '-200000000',
+        unrealizedPnlMicros: '0',
+      },
+    ]
+    const state = makeState({
+      account: { ...baseState().account, buyingPowerMicros: '200000000' },
+      positions,
+      referencePriceMicros: '200000000',
+      expectedExecutionPriceMicros: '198000000',
+    })
+    const intent = makeIntent({ side: OrderSide.Sell, notionalLimitMicros: '198000000' })
+    const policy = makePolicy({
+      maxOrderNotionalMicros: '198000000',
+      maxSymbolExposureMicros: '400000000',
+      maxGrossExposureMicros: '500000000',
+      maxNetExposureMicros: '300000000',
+      maxDailyTradedNotionalMicros: '298000000',
+    })
+    const result = evaluate(intent, state, policy)
+
+    expect(result.decision.outcome).toBe(RiskOutcome.Approved)
+    expect(result.metrics.orderNotionalMicros).toBe('198000000')
+    expect(result.metrics.postTradeSymbolExposureMicros).toBe('-400000000')
+    expectBlocked(
+      Reason.SymbolExposureExceeded,
+      intent,
+      state,
+      makePolicy({ ...policy, maxSymbolExposureMicros: '399999999' }),
+    )
+  })
+
+  test('rounds final net exposure outward after cross-symbol offsets', () => {
+    const state = makeState({
+      account: { ...baseState().account, buyingPowerMicros: '50' },
+      positions: [
+        {
+          ...baseState().positions[0],
+          quantityMicros: '2',
+          averageEntryPriceMicros: '50000000',
+          marketPriceMicros: '50000000',
+          marketValueMicros: '100',
+          unrealizedPnlMicros: '0',
+        },
+        {
+          ...baseState().positions[1],
+          quantityMicros: '-1',
+          averageEntryPriceMicros: '49100000',
+          marketPriceMicros: '49100000',
+          marketValueMicros: '-49',
+          unrealizedPnlMicros: '0',
+        },
+      ],
+      referencePriceMicros: '49100000',
+      expectedExecutionPriceMicros: '49100000',
+    })
+    const intent = makeIntent({ side: OrderSide.Sell, quantityMicros: '1', notionalLimitMicros: '50' })
+    const result = evaluate(intent, state, makePolicy())
+
+    expect(result.metrics.postTradeSymbolExposureMicros).toBe('-99')
+    expect(result.metrics.postTradeNetExposureMicros).toBe('2')
+    expectBlocked(Reason.NetExposureExceeded, intent, state, makePolicy({ maxNetExposureMicros: '1' }))
+  })
+
   test('fails closed on identity, authority, reconciliation, freshness, session, and mutation state', () => {
     expectBlocked(Reason.AccountMismatch, makeIntent(), makeState(), makePolicy({ accountId: 'another-account' }))
     expectBlocked(

--- a/services/bayn/src/risk.ts
+++ b/services/bayn/src/risk.ts
@@ -293,6 +293,8 @@ const absolute = (value: bigint): bigint => (value < 0n ? -value : value)
 const positiveDifference = (left: bigint, right: bigint): bigint => (left > right ? left - right : 0n)
 const divideUp = (numerator: bigint, denominator: bigint): bigint =>
   numerator === 0n ? 0n : (numerator + denominator - 1n) / denominator
+const divideAwayFromZero = (numerator: bigint, denominator: bigint): bigint =>
+  numerator < 0n ? -divideUp(-numerator, denominator) : divideUp(numerator, denominator)
 const instant = (value: string): number => Date.parse(value)
 const utc = (value: number): string => new Date(value).toISOString()
 
@@ -310,19 +312,22 @@ const isUnresolved = (status: OrderStatus): boolean =>
 export const evaluate = (intent: Intent, state: State, policy: Policy): Evaluation => {
   const evaluatedAt = instant(state.evaluatedAt)
   const policyHash = canonicalHashV1(policy)
-  const orderNotional = divideUp(
-    BigInt(intent.quantityMicros) * BigInt(state.expectedExecutionPriceMicros),
-    QUANTITY_SCALE,
-  )
+  const referencePrice = BigInt(state.referencePriceMicros)
+  const expectedPrice = BigInt(state.expectedExecutionPriceMicros)
+  const orderNotional = divideUp(BigInt(intent.quantityMicros) * expectedPrice, QUANTITY_SCALE)
   const direction = intent.side === OrderSide.Buy ? 1n : -1n
+  const markedExposure = (position: State['positions'][number]): bigint =>
+    position.symbol === intent.symbol
+      ? divideAwayFromZero(BigInt(position.quantityMicros) * referencePrice, QUANTITY_SCALE)
+      : BigInt(position.marketValueMicros)
   const currentSymbolExposure = state.positions
     .filter((position) => position.symbol === intent.symbol)
-    .reduce((total, position) => total + BigInt(position.marketValueMicros), 0n)
+    .reduce((total, position) => total + markedExposure(position), 0n)
   const currentGrossExposure = state.positions.reduce(
-    (total, position) => total + absolute(BigInt(position.marketValueMicros)),
+    (total, position) => total + absolute(markedExposure(position)),
     0n,
   )
-  const currentNetExposure = state.positions.reduce((total, position) => total + BigInt(position.marketValueMicros), 0n)
+  const currentNetExposure = state.positions.reduce((total, position) => total + markedExposure(position), 0n)
   const postTradeSymbolExposure = currentSymbolExposure + direction * orderNotional
   const exposureIncrease = positiveDifference(absolute(postTradeSymbolExposure), absolute(currentSymbolExposure))
   const postTradeGrossExposure =
@@ -331,8 +336,6 @@ export const evaluate = (intent: Intent, state: State, policy: Policy): Evaluati
   const dailyTradedNotional = BigInt(state.dailyTradedNotionalMicros) + orderNotional
   const dailyLoss = positiveDifference(BigInt(state.dayStartEquityMicros), BigInt(state.account.equityMicros))
   const drawdown = positiveDifference(BigInt(state.peakEquityMicros), BigInt(state.account.equityMicros))
-  const referencePrice = BigInt(state.referencePriceMicros)
-  const expectedPrice = BigInt(state.expectedExecutionPriceMicros)
   const adversePriceDifference =
     intent.side === OrderSide.Buy
       ? positiveDifference(expectedPrice, referencePrice)

--- a/services/bayn/src/risk.ts
+++ b/services/bayn/src/risk.ts
@@ -316,23 +316,28 @@ export const evaluate = (intent: Intent, state: State, policy: Policy): Evaluati
   const expectedPrice = BigInt(state.expectedExecutionPriceMicros)
   const orderNotional = divideUp(BigInt(intent.quantityMicros) * expectedPrice, QUANTITY_SCALE)
   const direction = intent.side === OrderSide.Buy ? 1n : -1n
-  const markedExposure = (position: State['positions'][number]): bigint =>
-    position.symbol === intent.symbol
-      ? divideAwayFromZero(BigInt(position.quantityMicros) * referencePrice, QUANTITY_SCALE)
-      : BigInt(position.marketValueMicros)
-  const currentSymbolExposure = state.positions
+  const currentSymbolQuantity = state.positions
     .filter((position) => position.symbol === intent.symbol)
-    .reduce((total, position) => total + markedExposure(position), 0n)
-  const currentGrossExposure = state.positions.reduce(
-    (total, position) => total + absolute(markedExposure(position)),
-    0n,
+    .reduce((total, position) => total + BigInt(position.quantityMicros), 0n)
+  const currentSymbolExposureNumerator = currentSymbolQuantity * referencePrice
+  const postTradeSymbolExposureNumerator =
+    (currentSymbolQuantity + direction * BigInt(intent.quantityMicros)) * referencePrice
+  const postTradeSymbolExposure = divideAwayFromZero(postTradeSymbolExposureNumerator, QUANTITY_SCALE)
+  const postTradeSymbolExposureMagnitude = divideUp(absolute(postTradeSymbolExposureNumerator), QUANTITY_SCALE)
+  const otherGrossExposure = state.positions
+    .filter((position) => position.symbol !== intent.symbol)
+    .reduce((total, position) => total + absolute(BigInt(position.marketValueMicros)), 0n)
+  const otherNetExposure = state.positions
+    .filter((position) => position.symbol !== intent.symbol)
+    .reduce((total, position) => total + BigInt(position.marketValueMicros), 0n)
+  const postTradeGrossExposure = otherGrossExposure + postTradeSymbolExposureMagnitude
+  const postTradeNetExposureNumerator = otherNetExposure * QUANTITY_SCALE + postTradeSymbolExposureNumerator
+  const postTradeNetExposure = divideAwayFromZero(postTradeNetExposureNumerator, QUANTITY_SCALE)
+  const postTradeNetExposureMagnitude = divideUp(absolute(postTradeNetExposureNumerator), QUANTITY_SCALE)
+  const exposureIncrease = divideUp(
+    positiveDifference(absolute(postTradeSymbolExposureNumerator), absolute(currentSymbolExposureNumerator)),
+    QUANTITY_SCALE,
   )
-  const currentNetExposure = state.positions.reduce((total, position) => total + markedExposure(position), 0n)
-  const postTradeSymbolExposure = currentSymbolExposure + direction * orderNotional
-  const exposureIncrease = positiveDifference(absolute(postTradeSymbolExposure), absolute(currentSymbolExposure))
-  const postTradeGrossExposure =
-    currentGrossExposure - absolute(currentSymbolExposure) + absolute(postTradeSymbolExposure)
-  const postTradeNetExposure = currentNetExposure + direction * orderNotional
   const dailyTradedNotional = BigInt(state.dailyTradedNotionalMicros) + orderNotional
   const dailyLoss = positiveDifference(BigInt(state.dayStartEquityMicros), BigInt(state.account.equityMicros))
   const drawdown = positiveDifference(BigInt(state.peakEquityMicros), BigInt(state.account.equityMicros))
@@ -518,8 +523,8 @@ export const evaluate = (intent: Intent, state: State, policy: Policy): Evaluati
     makeGate(
       Gate.SymbolExposure,
       Reason.SymbolExposureExceeded,
-      absolute(postTradeSymbolExposure) <= BigInt(policy.maxSymbolExposureMicros),
-      absolute(postTradeSymbolExposure),
+      postTradeSymbolExposureMagnitude <= BigInt(policy.maxSymbolExposureMicros),
+      postTradeSymbolExposureMagnitude,
       `<=${policy.maxSymbolExposureMicros}`,
     ),
     makeGate(
@@ -532,8 +537,8 @@ export const evaluate = (intent: Intent, state: State, policy: Policy): Evaluati
     makeGate(
       Gate.NetExposure,
       Reason.NetExposureExceeded,
-      absolute(postTradeNetExposure) <= BigInt(policy.maxNetExposureMicros),
-      absolute(postTradeNetExposure),
+      postTradeNetExposureMagnitude <= BigInt(policy.maxNetExposureMicros),
+      postTradeNetExposureMagnitude,
       `<=${policy.maxNetExposureMicros}`,
     ),
     makeGate(


### PR DESCRIPTION
## Summary

- Revalue the intent-symbol position and candidate quantity at the current reference quote before projecting symbol, gross, net, and buying-power exposure.
- Preserve quantity-price products until aggregate netting is complete, then round the final exposure away from zero so fractional micros cannot disappear.
- Add regressions for stale held marks, short sells below the reference quote, and cross-symbol offsets that previously rounded to zero.

## Related Issues

Follow-up for PROOMPT-373 and late Codex review on #13077.

## Testing

- bun test services/bayn/src/risk.test.ts (10 passed, 111 assertions)
- bun run --cwd services/bayn test (141 passed, 28 live-database tests skipped without database configuration, 0 failed, 789 assertions)
- bun run --cwd services/bayn tsc
- bun run --cwd services/bayn lint
- bun run --cwd services/bayn lint:oxlint
- bun run --cwd services/bayn lint:oxlint:type
- bun run --cwd services/bayn build
- git diff --check

## Breaking Changes

None. The risk evaluator remains inactive observe-only code with no broker capability.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Every actionable Codex finding has a focused regression and is resolved only after the fix is pushed.