### PR TITLE
feat(bayn): enforce paper-only egress boundary

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -58,6 +58,8 @@ spec:
               value: "cf639d3692da65271b12423f9b7c6c9663e1fb13ae7290dc56fcfa3acf16eb69"
             - name: BAYN_QUALIFICATION_RUN_ID
               value: "b88f53887a31b6696f5bf6b56e4e10d9966057c6109a1d0721dc94677e566ec7"
+            - name: BAYN_MAXIMUM_AUTHORITY
+              value: OBSERVE
             - name: BAYN_HEALTH_INTERVAL_MS
               value: "30000"
             - name: BAYN_OPERATION_TIMEOUT_MS

--- a/argocd/applications/bayn/egress-proxy.yaml
+++ b/argocd/applications/bayn/egress-proxy.yaml
@@ -1,0 +1,126 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bayn-egress-proxy
+  labels:
+    app.kubernetes.io/name: bayn-egress-proxy
+    app.kubernetes.io/part-of: bayn
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: bayn-egress-proxy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bayn-egress-proxy
+        app.kubernetes.io/part-of: bayn
+    spec:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 13
+        runAsGroup: 13
+        fsGroup: 13
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: squid
+          image: docker.io/ubuntu/squid@sha256:8a3baed477e2c282ab8aa5edad442f69873246964f225c5c2ae8364b6610963c
+          imagePullPolicy: IfNotPresent
+          command:
+            - /usr/sbin/squid
+          args:
+            - -f
+            - /etc/squid/squid.conf
+            - -NYC
+          ports:
+            - name: proxy
+              containerPort: 3128
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+              ephemeral-storage: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+              ephemeral-storage: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 13
+            runAsGroup: 13
+            seccompProfile:
+              type: RuntimeDefault
+          startupProbe:
+            tcpSocket:
+              port: proxy
+            periodSeconds: 2
+            failureThreshold: 30
+          readinessProbe:
+            tcpSocket:
+              port: proxy
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
+          livenessProbe:
+            tcpSocket:
+              port: proxy
+            periodSeconds: 30
+            timeoutSeconds: 2
+            failureThreshold: 3
+          volumeMounts:
+            - name: config
+              mountPath: /etc/squid/squid.conf
+              subPath: squid.conf
+              readOnly: true
+            - name: logs
+              mountPath: /var/log/squid
+            - name: spool
+              mountPath: /var/spool/squid
+            - name: run
+              mountPath: /run/squid
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: config
+          configMap:
+            name: bayn-egress-proxy
+            defaultMode: 0444
+        - name: logs
+          emptyDir:
+            sizeLimit: 128Mi
+        - name: spool
+          emptyDir:
+            sizeLimit: 64Mi
+        - name: run
+          emptyDir:
+            sizeLimit: 8Mi
+        - name: tmp
+          emptyDir:
+            sizeLimit: 64Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bayn-egress-proxy
+  labels:
+    app.kubernetes.io/name: bayn-egress-proxy
+    app.kubernetes.io/part-of: bayn
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: bayn-egress-proxy
+  ports:
+    - name: proxy
+      port: 3128
+      targetPort: proxy
+      protocol: TCP

--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -10,9 +10,14 @@ resources:
   - postgres-scheduled-backup.yaml
   - tigerbeetle-cluster.yaml
   - tigerbeetle-networkpolicy.yaml
+  - egress-proxy.yaml
   - deployment.yaml
   - service.yaml
   - networkpolicy.yaml
+configMapGenerator:
+  - name: bayn-egress-proxy
+    files:
+      - squid.conf
 images:
   - name: registry.ide-newton.ts.net/lab/bayn
     newName: registry.ide-newton.ts.net/lab/bayn

--- a/argocd/applications/bayn/networkpolicy.yaml
+++ b/argocd/applications/bayn/networkpolicy.yaml
@@ -55,6 +55,13 @@ spec:
       ports:
         - port: 5432
           protocol: TCP
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: bayn-egress-proxy
+      ports:
+        - port: 3128
+          protocol: TCP
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -105,4 +112,56 @@ spec:
               app.kubernetes.io/name: observability-cluster-metrics-alloy
       ports:
         - port: 9187
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: bayn-egress-proxy
+  labels:
+    app.kubernetes.io/name: bayn-egress-proxy
+    app.kubernetes.io/part-of: bayn
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: bayn-egress-proxy
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: bayn
+      ports:
+        - port: 3128
+          protocol: TCP
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 0.0.0.0/8
+              - 10.0.0.0/8
+              - 100.64.0.0/10
+              - 127.0.0.0/8
+              - 169.254.0.0/16
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+              - 224.0.0.0/4
+              - 240.0.0.0/4
+      ports:
+        - port: 443
           protocol: TCP

--- a/argocd/applications/bayn/squid.conf
+++ b/argocd/applications/bayn/squid.conf
@@ -1,0 +1,24 @@
+http_port 3128
+
+acl SSL_ports port 443
+acl CONNECT method CONNECT
+acl paper_api dstdomain paper-api.alpaca.markets
+acl blocked_private_v4 dst 0.0.0.0/8 10.0.0.0/8 100.64.0.0/10 127.0.0.0/8 169.254.0.0/16 172.16.0.0/12 192.168.0.0/16 224.0.0.0/4 240.0.0.0/4
+acl blocked_private_v6 dst ::1/128 fc00::/7 fe80::/10 ff00::/8
+
+http_access deny !CONNECT
+http_access deny CONNECT !SSL_ports
+http_access deny !paper_api
+http_access deny blocked_private_v4
+http_access deny blocked_private_v6
+http_access allow CONNECT paper_api
+http_access deny all
+
+cache deny all
+cache_mem 32 MB
+maximum_object_size 0 KB
+
+access_log stdio:/dev/stdout
+cache_log /dev/stderr
+pid_filename /run/squid/squid.pid
+coredump_dir /tmp

--- a/argocd/applications/kube-router/preflight-hook.yaml
+++ b/argocd/applications/kube-router/preflight-hook.yaml
@@ -57,16 +57,32 @@ spec:
               fi
 
               while IFS= read -r namespace; do
+                if [[ "$namespace" == bayn ]]; then
+                  kubectl -n "$namespace" get networkpolicy kube-router-rollout-allow-all -o json |
+                    jq -e '
+                      .spec.podSelector.matchLabels == {
+                        "network-policy.proompteng.ai/retired-rollout-policy": "bayn"
+                      } and
+                      (.spec.policyTypes | sort) == ["Egress", "Ingress"] and
+                      (.spec | has("ingress") | not) and
+                      (.spec | has("egress") | not)
+                    ' >/dev/null
+                  continue
+                fi
+
                 kubectl -n "$namespace" get networkpolicy kube-router-rollout-allow-all -o json |
-                  jq -e '
-                    .spec.podSelector == {} and
-                    (.spec.policyTypes | sort) == ["Egress", "Ingress"] and
-                    .spec.ingress == [{}] and
-                    .spec.egress == [{}]
-                  ' >/dev/null
+                    jq -e '
+                      .spec.podSelector == {} and
+                      (.spec.policyTypes | sort) == ["Egress", "Ingress"] and
+                      .spec.ingress == [{}] and
+                      .spec.egress == [{}]
+                    ' >/dev/null
               done <<< "$expected_namespaces"
 
-              echo 'All existing NetworkPolicy namespaces have a traffic-neutral activation policy.'
+              kubectl -n bayn get pods -l 'network-policy.proompteng.ai/retired-rollout-policy=bayn' -o json |
+                jq -e '.items | length == 0' >/dev/null
+
+              echo 'All existing NetworkPolicy namespaces have an approved rollout policy state.'
           resources:
             requests:
               cpu: 25m

--- a/argocd/applications/kube-router/rbac.yaml
+++ b/argocd/applications/kube-router/rbac.yaml
@@ -56,6 +56,13 @@ metadata:
     argocd.argoproj.io/sync-wave: "-3"
 rules:
   - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+  - apiGroups:
       - networking.k8s.io
     resources:
       - networkpolicies

--- a/argocd/applications/kube-router/safety-policies.yaml
+++ b/argocd/applications/kube-router/safety-policies.yaml
@@ -37,6 +37,9 @@ spec:
   egress:
     - {}
 ---
+# Bayn has namespace-specific policies and no longer uses the traffic-neutral
+# rollout exception. Keep this retained object inert because its original
+# Prune=false annotation prevents one-step deletion.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -46,14 +49,12 @@ metadata:
     argocd.argoproj.io/sync-wave: "-3"
     argocd.argoproj.io/sync-options: Prune=false
 spec:
-  podSelector: {}
+  podSelector:
+    matchLabels:
+      network-policy.proompteng.ai/retired-rollout-policy: bayn
   policyTypes:
     - Ingress
     - Egress
-  ingress:
-    - {}
-  egress:
-    - {}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/docs/runbooks/kube-router-network-policy-rollout.md
+++ b/docs/runbooks/kube-router-network-policy-rollout.md
@@ -64,8 +64,10 @@ argocd app sync kube-router --revision "$main_revision" --prune=false --timeout 
 kubectl -n kube-system rollout status daemonset/kube-router --timeout=10m
 ```
 
-The sync hook must print `All existing NetworkPolicy namespaces have a traffic-neutral activation policy.` If it fails,
-the DaemonSet wave is not applied. Update the declared safety coverage through Git and rerun CI; do not bypass the hook.
+The sync hook must print `All existing NetworkPolicy namespaces have an approved rollout policy state.` It requires
+traffic-neutral rollout policies everywhere except Bayn, whose retained `Prune=false` object must use the inert retired
+selector and match no Pods. If the hook fails, the DaemonSet wave is not applied. Update the declared policy state
+through Git and rerun CI; do not bypass the hook.
 
 Verify every desired node has one ready controller, the pinned image index or its architecture-specific child manifest
 is running, the process architecture matches the node, health is green, and policy metrics exist. Container runtimes

--- a/scripts/kube-router/validate-production.test.ts
+++ b/scripts/kube-router/validate-production.test.ts
@@ -75,6 +75,17 @@ test('rejects a safety policy that can deny traffic', async () => {
   )
 })
 
+test('rejects a retired safety policy that can select Bayn pods', async () => {
+  const files = copy(await loadProductionFiles())
+  files.safetyPolicies = files.safetyPolicies.replace(
+    '      network-policy.proompteng.ai/retired-rollout-policy: bayn',
+    '      app.kubernetes.io/name: bayn',
+  )
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.safetyPolicies}: bayn is not an inert retired rollout policy`,
+  )
+})
+
 test('rejects bypassing the live namespace preflight', async () => {
   const files = copy(await loadProductionFiles())
   files.preflightHook = files.preflightHook.replace(
@@ -125,6 +136,17 @@ test('rejects write-capable controller RBAC', async () => {
   const files = copy(await loadProductionFiles())
   files.rbac = files.rbac.replace('      - watch', '      - watch\n      - update')
   expect(validateProductionContent(files)).toContain(`${productionPaths.rbac}: kube-router must remain read-only`)
+})
+
+test('rejects a preflight that cannot prove the retired selector matches no Pods', async () => {
+  const files = copy(await loadProductionFiles())
+  files.rbac = files.rbac.replace(
+    /rules:\n  - apiGroups:\n      - ""\n    resources:\n      - pods\n    verbs:\n      - get\n      - list\n  - apiGroups:\n      - networking\.k8s\.io/,
+    'rules:\n  - apiGroups:\n      - networking.k8s.io',
+  )
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.rbac}: preflight must read policy state and retired-selector Pod matches`,
+  )
 })
 
 test('rejects telemetry that drops DaemonSet readiness', async () => {

--- a/scripts/kube-router/validate-production.ts
+++ b/scripts/kube-router/validate-production.ts
@@ -4,7 +4,21 @@ import { readFile } from 'node:fs/promises'
 const kubeRouterImage =
   'docker.io/cloudnativelabs/kube-router@sha256:0991f2cc7aaabe107b51c0c554d6b843f0483fd319b94f437fab638470c47c22'
 const kubectlImage = 'docker.io/bitnami/kubectl@sha256:a67b11e95e953f550f020a41970185ccc5f83d78b86b8c575d02c904aa0f9cd7'
-const safetyNamespaces = ['agents', 'argocd', 'bayn', 'bilig', 'kafka', 'media', 'pgadmin', 'synthesis', 'torghut']
+const trafficNeutralSafetyNamespaces = [
+  'agents',
+  'argocd',
+  'bilig',
+  'kafka',
+  'media',
+  'pgadmin',
+  'synthesis',
+  'torghut',
+]
+const retiredSafetyNamespace = 'bayn'
+const safetyNamespaces = [...trafficNeutralSafetyNamespaces, retiredSafetyNamespace]
+const retiredSafetySelector = {
+  'network-policy.proompteng.ai/retired-rollout-policy': retiredSafetyNamespace,
+}
 
 export const productionPaths = {
   kustomization: 'argocd/applications/kube-router/kustomization.yaml',
@@ -175,16 +189,35 @@ export function validateProductionContent(files: ProductionFiles): string[] {
   }
   for (const policy of safetyPolicies) {
     const namespace = policy.metadata?.namespace ?? '<missing>'
-    if (
+    const invalidMetadata =
       policy.apiVersion !== 'networking.k8s.io/v1' ||
       policy.kind !== 'NetworkPolicy' ||
       policy.metadata?.name !== 'kube-router-rollout-allow-all' ||
-      JSON.stringify(policy.spec?.podSelector) !== '{}' ||
       JSON.stringify(sortedStrings(policy.spec?.policyTypes)) !== JSON.stringify(['Egress', 'Ingress']) ||
-      JSON.stringify(policy.spec?.ingress) !== '[{}]' ||
-      JSON.stringify(policy.spec?.egress) !== '[{}]' ||
       policy.metadata?.annotations?.['argocd.argoproj.io/sync-wave'] !== '-3' ||
       policy.metadata?.annotations?.['argocd.argoproj.io/sync-options'] !== 'Prune=false'
+
+    if (invalidMetadata) {
+      failures.push(`${productionPaths.safetyPolicies}: ${namespace} is not a retained traffic-neutral safety policy`)
+      continue
+    }
+
+    if (namespace === retiredSafetyNamespace) {
+      if (
+        JSON.stringify(policy.spec?.podSelector?.matchLabels) !== JSON.stringify(retiredSafetySelector) ||
+        policy.spec?.ingress !== undefined ||
+        policy.spec?.egress !== undefined
+      ) {
+        failures.push(`${productionPaths.safetyPolicies}: ${namespace} is not an inert retired rollout policy`)
+      }
+      continue
+    }
+
+    if (
+      !trafficNeutralSafetyNamespaces.includes(namespace) ||
+      JSON.stringify(policy.spec?.podSelector) !== '{}' ||
+      JSON.stringify(policy.spec?.ingress) !== '[{}]' ||
+      JSON.stringify(policy.spec?.egress) !== '[{}]'
     ) {
       failures.push(`${productionPaths.safetyPolicies}: ${namespace} is not a retained traffic-neutral safety policy`)
     }
@@ -207,6 +240,9 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'kubectl get networkpolicies.networking.k8s.io --all-namespaces -o json',
     'if [[ "$actual_namespaces" != "$expected_namespaces" ]]',
     'kubectl -n "$namespace" get networkpolicy kube-router-rollout-allow-all -o json',
+    'if [[ "$namespace" == bayn ]]',
+    'network-policy.proompteng.ai/retired-rollout-policy',
+    "kubectl -n bayn get pods -l 'network-policy.proompteng.ai/retired-rollout-policy=bayn' -o json",
     '.spec.podSelector == {}',
     '.spec.ingress == [{}]',
     '.spec.egress == [{}]',
@@ -218,6 +254,17 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     if (verbs.some((verb: string) => ['*', 'create', 'delete', 'deletecollection', 'patch', 'update'].includes(verb))) {
       failures.push(`${productionPaths.rbac}: ${role.metadata?.name} must remain read-only`)
     }
+  }
+  const preflightRole = roles.find((role) => role.metadata?.name === 'kube-router-policy-preflight')
+  const hasExactReadRule = (apiGroup: string, resource: string): boolean =>
+    (preflightRole?.rules ?? []).some(
+      (rule: YamlObject) =>
+        JSON.stringify(sortedStrings(rule.apiGroups)) === JSON.stringify([apiGroup]) &&
+        JSON.stringify(sortedStrings(rule.resources)) === JSON.stringify([resource]) &&
+        JSON.stringify(sortedStrings(rule.verbs)) === JSON.stringify(['get', 'list']),
+    )
+  if (!hasExactReadRule('', 'pods') || !hasExactReadRule('networking.k8s.io', 'networkpolicies')) {
+    failures.push(`${productionPaths.rbac}: preflight must read policy state and retired-selector Pod matches`)
   }
   requireTerms(failures, productionPaths.rbac, files.rbac, [
     '- endpointslices',

--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -9,6 +9,10 @@ to TigerBeetle. Bayn contains no broker client or capital-promotion path.
 - Node.js is the production runtime; Effect owns dependency acquisition, failure handling, and shutdown.
 - Effect Config validates environment input. `BAYN_OPERATION_TIMEOUT_MS` bounds dependency operations, and
   `BAYN_HEALTH_INTERVAL_MS` controls the continuous health interval; both default to 30 seconds.
+- `BAYN_MAXIMUM_AUTHORITY` is a closed `OBSERVE`/`PAPER` process ceiling and defaults to `OBSERVE`. It never creates a
+  broker capability; the deployed runtime remains `OBSERVE` and contains no submit, cancel, or replace path.
+- Public egress is denied from the Bayn Pod. A separate CONNECT proxy permits only
+  `paper-api.alpaca.markets:443`; the service has no broker credential or client until a later reviewed slice.
 - Signal ClickHouse is read-only at runtime. Data publication and provider credentials are owned by the separate Signal
   adjusted-daily publisher; Bayn contains no DDL or backfill command.
 - Bayn owns a two-instance CloudNativePG cluster. The runtime uses the generated application URI over verified TLS,
@@ -84,7 +88,7 @@ to TigerBeetle. Bayn contains no broker client or capital-promotion path.
 - `GET /livez`: process liveness.
 - `GET /readyz`: current dependency, evidence, and accounting readiness.
 - `GET /v1/status`: operational dependencies, data and evidence identity, terminal qualification, economic verdict,
-  accounting, current build provenance, qualification-execution provenance, and fixed observe-only authority.
+  accounting, current build provenance, qualification-execution provenance, and the configured authority ceiling.
 - `GET /v1/evaluations/:runId`: complete content-hashed evidence for one exact run ID. The service is ClusterIP-only
   and the Bayn network policy limits HTTP ingress to the namespace.
 

--- a/services/bayn/src/app-test-support.ts
+++ b/services/bayn/src/app-test-support.ts
@@ -6,6 +6,7 @@ import type { RuntimeConfig } from './config'
 import type { EvidenceStoreService, StoredEvaluationEvidence } from './db/evidence-store'
 import type { JournalService } from './ledger'
 import type { MarketDataService } from './market-data'
+import { Authority } from './paper'
 import { makeQualificationResult } from './qualification'
 import { summarizeEvaluation } from './risk-balanced-trend'
 import type { RuntimeState } from './runtime-state'
@@ -46,6 +47,7 @@ export const historicalEvidence: StoredEvaluationEvidence = {
 export const config: RuntimeConfig = {
   host: '127.0.0.1',
   port: 0,
+  maximumAuthority: Authority.Observe,
   build: {
     sourceRevision: provenance.sourceRevision,
     imageRepository: provenance.image.repository,

--- a/services/bayn/src/config.test.ts
+++ b/services/bayn/src/config.test.ts
@@ -4,6 +4,7 @@ import { ConfigProvider, Effect, Redacted } from 'effect'
 
 import type { EmbeddedBuildMetadata } from './build'
 import { loadConfig } from './config'
+import { Authority } from './paper'
 
 const sourceRevision = 'a'.repeat(40)
 const imageRepository = 'registry.ide-newton.ts.net/lab/bayn'
@@ -48,6 +49,7 @@ describe('Effect configuration', () => {
     expect(config.host).toBe('0.0.0.0')
     expect(config.port).toBe(8080)
     expect(config.qualificationRunId).toBeUndefined()
+    expect(config.maximumAuthority).toBe(Authority.Observe)
     expect(config.healthIntervalMs).toBe(30_000)
     expect(config.operationTimeoutMs).toBe(30_000)
     expect(config.clickhouse).toMatchObject({
@@ -134,6 +136,23 @@ describe('Effect configuration', () => {
     invalid.set('BAYN_QUALIFICATION_RUN_ID', 'not-a-run-id')
 
     const error = await Effect.runPromise(Effect.flip(provideEnvironment(loadConfig(buildMetadata), invalid)))
+    expect(error).toMatchObject({
+      _tag: 'OperationalError',
+      component: 'config',
+      operation: 'load',
+    })
+  })
+
+  test('accepts only the closed broker-authority vocabulary', async () => {
+    const paper = new Map(runtimeEnvironment)
+    paper.set('BAYN_MAXIMUM_AUTHORITY', Authority.Paper)
+    expect((await Effect.runPromise(provideEnvironment(loadConfig(buildMetadata), paper))).maximumAuthority).toBe(
+      Authority.Paper,
+    )
+
+    const live = new Map(runtimeEnvironment)
+    live.set('BAYN_MAXIMUM_AUTHORITY', 'LIVE')
+    const error = await Effect.runPromise(Effect.flip(provideEnvironment(loadConfig(buildMetadata), live)))
     expect(error).toMatchObject({
       _tag: 'OperationalError',
       component: 'config',

--- a/services/bayn/src/config.ts
+++ b/services/bayn/src/config.ts
@@ -3,6 +3,7 @@ import { Config, Effect, Option, Redacted, Schema, SchemaTransformation } from '
 import { EmbeddedBuildMetadataSchema, embeddedBuildMetadata, type EmbeddedBuildMetadata } from './build'
 import { EvaluationBoundsSchema, IsoDateSchema, Sha256Schema, type EvaluationBounds } from './contracts'
 import { operationalError, type OperationalError } from './errors'
+import { Authority } from './paper'
 import {
   GitSourceRevisionSchema as SourceRevision,
   ImageDigestSchema as ImageDigest,
@@ -21,6 +22,7 @@ export interface RuntimeConfig {
   readonly host: string
   readonly port: number
   readonly qualificationRunId?: string
+  readonly maximumAuthority: Authority
   readonly build: RuntimeBuildMetadata
   readonly healthIntervalMs: number
   readonly operationTimeoutMs: number
@@ -77,6 +79,9 @@ const runtimeConfig = Config.all({
   strategyParameterHash: Config.schema(Sha256Schema, 'BAYN_STRATEGY_PARAMETER_HASH'),
   provenanceMode: Config.schema(ProvenanceMode, 'BAYN_PROVENANCE_MODE').pipe(Config.withDefault('production')),
   qualificationRunId: Config.option(Config.schema(Sha256Schema, 'BAYN_QUALIFICATION_RUN_ID')),
+  maximumAuthority: Config.schema(Schema.Enum(Authority), 'BAYN_MAXIMUM_AUTHORITY').pipe(
+    Config.withDefault(Authority.Observe),
+  ),
   healthIntervalMs: positiveInteger('BAYN_HEALTH_INTERVAL_MS', 30_000),
   operationTimeoutMs: positiveInteger('BAYN_OPERATION_TIMEOUT_MS', 30_000),
   clickhouseUrl: nonEmptyString('BAYN_CLICKHOUSE_URL'),
@@ -105,6 +110,7 @@ const runtimeConfig = Config.all({
     host: config.host,
     port: config.port,
     qualificationRunId: Option.getOrUndefined(config.qualificationRunId),
+    maximumAuthority: config.maximumAuthority,
     configuredBuild: {
       sourceRevision: config.sourceRevision,
       imageRepository: config.imageRepository,

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -7,6 +7,7 @@ import { Cause, Deferred, Duration, Effect, Exit, Fiber, Layer, ManagedRuntime, 
 import type { RuntimeConfig } from '../config'
 import { canonicalHashV1 } from '../hash'
 import { buildLedgerPlan } from '../ledger'
+import { Authority } from '../paper'
 import { makeQualificationResult } from '../qualification'
 import { evaluateRiskBalancedTrend } from '../risk-balanced-trend'
 import { makeStrategy } from '../strategy-service'
@@ -27,6 +28,7 @@ const describePostgres = postgresUrl === undefined ? describe.skip : describe
 const makeConfig = (url = testUrl): RuntimeConfig => ({
   host: '127.0.0.1',
   port: 8080,
+  maximumAuthority: Authority.Observe,
   build: {
     sourceRevision: 'a'.repeat(40),
     imageRepository: 'registry.ide-newton.ts.net/lab/bayn',

--- a/services/bayn/src/http.test.ts
+++ b/services/bayn/src/http.test.ts
@@ -13,6 +13,7 @@ import {
 } from './app-test-support'
 import { DatabaseError, type EvidenceStoreService } from './db/evidence-store'
 import { makeHttpLayer } from './http'
+import { Authority } from './paper'
 import { initialState } from './runtime-state'
 
 describe('Bayn HTTP probes', () => {
@@ -24,7 +25,12 @@ describe('Bayn HTTP probes', () => {
           const state = yield* Ref.make(initialState())
           const context = yield* Layer.build(
             makeHttpLayer(
-              { host: '127.0.0.1', operationTimeoutMs: 250, port: 0 },
+              {
+                host: '127.0.0.1',
+                maximumAuthority: Authority.Observe,
+                operationTimeoutMs: 250,
+                port: 0,
+              },
               state,
               provenance,
               'embedded',
@@ -135,7 +141,12 @@ describe('Bayn HTTP probes', () => {
           const state = yield* Ref.make(initialState())
           const context = yield* Layer.build(
             makeHttpLayer(
-              { host: '127.0.0.1', operationTimeoutMs: 250, port: 0 },
+              {
+                host: '127.0.0.1',
+                maximumAuthority: Authority.Observe,
+                operationTimeoutMs: 250,
+                port: 0,
+              },
               state,
               provenance,
               'embedded',
@@ -148,6 +159,32 @@ describe('Bayn HTTP probes', () => {
           expect(
             yield* Effect.promise(() => fetchJson(address.port, `/v1/evaluations/${historicalRunId}`)),
           ).toMatchObject({ status: 503, body: { error: 'evidence_unavailable' } })
+        }),
+      ),
+    )
+  })
+
+  test('reports the configured ceiling without implying broker capability', async () => {
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const state = yield* Ref.make(initialState())
+          const context = yield* Layer.build(
+            makeHttpLayer(
+              { host: '127.0.0.1', maximumAuthority: Authority.Paper, operationTimeoutMs: 250, port: 0 },
+              state,
+              provenance,
+              'embedded',
+              successfulEvidenceStore.read,
+            ),
+          )
+          const address = Context.get(context, HttpServer.HttpServer).address
+          if (address._tag !== 'TcpAddress') throw new Error('test server did not bind a TCP port')
+
+          expect(yield* Effect.promise(() => fetchJson(address.port, '/v1/status'))).toMatchObject({
+            status: 200,
+            body: { authority: { maximum: 'paper', brokerOrders: false, capitalPromotion: false } },
+          })
         }),
       ),
     )

--- a/services/bayn/src/http.ts
+++ b/services/bayn/src/http.ts
@@ -6,6 +6,7 @@ import { HttpRouter, HttpServerRequest, HttpServerResponse } from 'effect/unstab
 
 import type { RuntimeBuildMetadata, RuntimeConfig } from './config'
 import type { RuntimeProvenance } from './contracts'
+import { Authority } from './paper'
 import { isReady, type DependencyHealth, type RuntimeState } from './runtime-state'
 
 type ReadEvidence = (runId: string) => Effect.Effect<Option.Option<unknown>, { readonly message: string }>
@@ -17,6 +18,7 @@ const verifiedState = (state: RuntimeState, dependency: DependencyHealth) => {
 
 const publicState = (
   state: RuntimeState,
+  maximumAuthority: Authority,
   provenance: RuntimeProvenance,
   provenanceVerification: RuntimeBuildMetadata['verification'],
 ) => {
@@ -62,7 +64,7 @@ const publicState = (
       reconciliation: state.evidence?.reconciliation ?? null,
     },
     authority: {
-      maximum: 'observe',
+      maximum: maximumAuthority === Authority.Paper ? 'paper' : 'observe',
       brokerOrders: false,
       capitalPromotion: false,
     },
@@ -79,7 +81,7 @@ const jsonResponse = (body: unknown, status = 200, headers?: Readonly<Record<str
   HttpServerResponse.json(body, { status, headers }).pipe(Effect.orDie)
 
 export const makeHttpLayer = (
-  config: Pick<RuntimeConfig, 'host' | 'operationTimeoutMs' | 'port'>,
+  config: Pick<RuntimeConfig, 'host' | 'maximumAuthority' | 'operationTimeoutMs' | 'port'>,
   state: Ref.Ref<RuntimeState>,
   provenance: RuntimeProvenance,
   provenanceVerification: RuntimeBuildMetadata['verification'],
@@ -104,7 +106,9 @@ export const makeHttpLayer = (
     }),
   )
   const status = Ref.get(state).pipe(
-    Effect.flatMap((current) => jsonResponse(publicState(current, provenance, provenanceVerification))),
+    Effect.flatMap((current) =>
+      jsonResponse(publicState(current, config.maximumAuthority, provenance, provenanceVerification)),
+    ),
   )
   const historicalEvaluation = HttpRouter.params.pipe(
     Effect.flatMap(({ runId }) => {

--- a/services/bayn/src/ledger.test.ts
+++ b/services/bayn/src/ledger.test.ts
@@ -3,6 +3,7 @@ import { Effect, Redacted } from 'effect'
 import { CreateAccountStatus, CreateTransferStatus, type Account, type Transfer } from 'tigerbeetle-node'
 
 import type { RuntimeConfig } from './config'
+import { Authority } from './paper'
 import {
   assertReconciled,
   buildLedgerPlan,
@@ -215,6 +216,7 @@ describe('TigerBeetle simulation journal', () => {
     const config: RuntimeConfig = {
       host: '127.0.0.1',
       port: 0,
+      maximumAuthority: Authority.Observe,
       build: {
         sourceRevision: provenance.sourceRevision,
         imageRepository: provenance.image.repository,

--- a/services/bayn/src/resources.test.ts
+++ b/services/bayn/src/resources.test.ts
@@ -9,6 +9,7 @@ import { EvidenceStore, type EvidenceStoreService } from './db/evidence-store'
 import { operationalError } from './errors'
 import { Journal, JournalLive, type JournalService, type TigerBeetleClient } from './ledger'
 import { MarketData, marketDataOperationError, type MarketDataService } from './market-data'
+import { Authority } from './paper'
 import { initialState } from './runtime-state'
 import { makeStrategy } from './strategy'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
@@ -19,6 +20,7 @@ const fixtureStrategy = makeStrategy(fixtureProtocol, provenance)
 const config: RuntimeConfig = {
   host: '127.0.0.1',
   port: 0,
+  maximumAuthority: Authority.Observe,
   build: {
     sourceRevision: provenance.sourceRevision,
     imageRepository: provenance.image.repository,


### PR DESCRIPTION
## Summary

- Decode a closed OBSERVE/PAPER process ceiling through Effect Config, default it to OBSERVE, and expose that ceiling without implying broker or capital capability.
- Add a Bayn-owned CONNECT proxy that permits only paper-api.alpaca.markets:443 and denies arbitrary, live, and private destinations.
- Keep the Bayn Pod on deny-by-default egress with only its existing dependencies plus the proxy, and retire the namespace-wide kube-router allow-all exception that would otherwise nullify those policies.
- Add no Alpaca credential, broker client, database change, or mutation path.

## Related Issues

PROOMPT-371, Slice A. This PR does not close the issue; dedicated paper-account creation and credential binding remain a separate external-state slice.

## Testing

- bun test services/bayn/src/config.test.ts services/bayn/src/http.test.ts (13 passed, 46 assertions)
- bun run --filter @proompteng/bayn test (143 passed, 28 live-database tests skipped without database configuration, 0 failed, 793 assertions)
- bun run --filter @proompteng/bayn tsc
- bun run --filter @proompteng/bayn lint
- bun run --filter @proompteng/bayn lint:oxlint
- bun run --filter @proompteng/bayn lint:oxlint:type
- bun run --filter @proompteng/bayn build
- kustomize build argocd/applications/bayn | kubeconform -strict -summary -ignore-missing-schemas (16 resources, 0 invalid, 0 errors)
- kubeconform -strict -summary -ignore-missing-schemas argocd/applications/kube-router/safety-policies.yaml (9 resources, 0 invalid, 0 errors)
- bun run lint:argocd (0 invalid, 0 errors across all reported batches)
- Parsed argocd/applications/bayn/squid.conf with the pinned Squid 6.6 binary using squid -k parse (success)
- Live selector check found zero Pods carrying the retired rollout-policy marker.
- git diff --check

## Breaking Changes

The Bayn namespace graduates from the temporary kube-router allow-all rollout exception to its explicit namespace policies. Bayn remains OBSERVE with no broker credentials or client.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Linear issue and implementation plan were corrected; credential binding remains explicitly tracked as Slice B.
- [x] The actionable Codex P1 was fixed, replied to with commit evidence, and resolved.