### PR TITLE
fix(kube-router): recognize enforced Hermes policies

### DIFF
--- a/argocd/applications/kube-router/preflight-hook.yaml
+++ b/argocd/applications/kube-router/preflight-hook.yaml
@@ -42,7 +42,7 @@ spec:
             - |
               set -o pipefail
               expected_namespaces=$(
-                printf '%s\n' agents argocd bayn bilig kafka media pgadmin synthesis torghut | sort -u
+                printf '%s\n' agents argocd bayn bilig hermes kafka media pgadmin synthesis torghut | sort -u
               )
               actual_namespaces=$(
                 kubectl get networkpolicies.networking.k8s.io --all-namespaces -o json |
@@ -57,7 +57,8 @@ spec:
               fi
 
               while IFS= read -r namespace; do
-                if [[ "$namespace" == bayn ]]; then
+                case "$namespace" in
+                bayn)
                   kubectl -n "$namespace" get networkpolicy kube-router-rollout-allow-all -o json |
                     jq -e '
                       .spec.podSelector.matchLabels == {
@@ -67,16 +68,23 @@ spec:
                       (.spec | has("ingress") | not) and
                       (.spec | has("egress") | not)
                     ' >/dev/null
-                  continue
-                fi
-
-                kubectl -n "$namespace" get networkpolicy kube-router-rollout-allow-all -o json |
+                  ;;
+                hermes)
+                  if kubectl -n "$namespace" get networkpolicy kube-router-rollout-allow-all >/dev/null 2>&1; then
+                    echo 'Hermes must not have a rollout allow-all exception.' >&2
+                    exit 1
+                  fi
+                  ;;
+                *)
+                  kubectl -n "$namespace" get networkpolicy kube-router-rollout-allow-all -o json |
                     jq -e '
                       .spec.podSelector == {} and
                       (.spec.policyTypes | sort) == ["Egress", "Ingress"] and
                       .spec.ingress == [{}] and
                       .spec.egress == [{}]
                     ' >/dev/null
+                  ;;
+                esac
               done <<< "$expected_namespaces"
 
               kubectl -n bayn get pods -l 'network-policy.proompteng.ai/retired-rollout-policy=bayn' -o json |

--- a/docs/runbooks/kube-router-network-policy-rollout.md
+++ b/docs/runbooks/kube-router-network-policy-rollout.md
@@ -65,9 +65,9 @@ kubectl -n kube-system rollout status daemonset/kube-router --timeout=10m
 ```
 
 The sync hook must print `All existing NetworkPolicy namespaces have an approved rollout policy state.` It requires
-traffic-neutral rollout policies everywhere except Bayn, whose retained `Prune=false` object must use the inert retired
-selector and match no Pods. If the hook fails, the DaemonSet wave is not applied. Update the declared policy state
-through Git and rerun CI; do not bypass the hook.
+traffic-neutral rollout policies in namespaces not yet graduated, Bayn's retained `Prune=false` object to use the inert
+retired selector and match no Pods, and enforced Hermes to have no rollout allow-all exception. If the hook fails, the
+DaemonSet wave is not applied. Update the declared policy state through Git and rerun CI; do not bypass the hook.
 
 Verify every desired node has one ready controller, the pinned image index or its architecture-specific child manifest
 is running, the process architecture matches the node, health is green, and policy metrics exist. Container runtimes

--- a/scripts/kube-router/validate-production.test.ts
+++ b/scripts/kube-router/validate-production.test.ts
@@ -97,6 +97,25 @@ test('rejects bypassing the live namespace preflight', async () => {
   )
 })
 
+test('rejects a preflight that permits a rollout exception in enforced Hermes', async () => {
+  const files = copy(await loadProductionFiles())
+  files.preflightHook = files.preflightHook.replace(
+    'Hermes must not have a rollout allow-all exception.',
+    'Hermes rollout exception accepted.',
+  )
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.preflightHook}: missing production invariant "Hermes must not have a rollout allow-all exception."`,
+  )
+})
+
+test('rejects safety coverage that omits enforced Hermes', async () => {
+  const files = copy(await loadProductionFiles())
+  files.coverageProbe = files.coverageProbe.replace("    printf '%s\\n' hermes", '    true')
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.coverageProbe}: missing production invariant "printf '%s\\\\n' hermes"`,
+  )
+})
+
 test('rejects automatic controller activation', async () => {
   const files = copy(await loadProductionFiles())
   files.platform = files.platform.replace(/(\n\s+- name: kube-router\n[\s\S]*?automation:) manual/, '$1 auto')

--- a/scripts/kube-router/validate-production.ts
+++ b/scripts/kube-router/validate-production.ts
@@ -16,6 +16,7 @@ const trafficNeutralSafetyNamespaces = [
 ]
 const retiredSafetyNamespace = 'bayn'
 const safetyNamespaces = [...trafficNeutralSafetyNamespaces, retiredSafetyNamespace]
+const enforcedNamespaces = ['hermes']
 const retiredSafetySelector = {
   'network-policy.proompteng.ai/retired-rollout-policy': retiredSafetyNamespace,
 }
@@ -236,12 +237,13 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     failures.push(`${productionPaths.preflightHook}: the bounded pre-DaemonSet coverage gate is incomplete`)
   }
   requireTerms(failures, productionPaths.preflightHook, files.preflightHook, [
-    "printf '%s\\n' agents argocd bayn bilig kafka media pgadmin synthesis torghut | sort -u",
+    `printf '%s\\n' ${[...safetyNamespaces, ...enforcedNamespaces].sort().join(' ')} | sort -u`,
     'kubectl get networkpolicies.networking.k8s.io --all-namespaces -o json',
     'if [[ "$actual_namespaces" != "$expected_namespaces" ]]',
     'kubectl -n "$namespace" get networkpolicy kube-router-rollout-allow-all -o json',
-    'if [[ "$namespace" == bayn ]]',
+    'case "$namespace" in',
     'network-policy.proompteng.ai/retired-rollout-policy',
+    'Hermes must not have a rollout allow-all exception.',
     "kubectl -n bayn get pods -l 'network-policy.proompteng.ai/retired-rollout-policy=bayn' -o json",
     '.spec.podSelector == {}',
     '.spec.ingress == [{}]',
@@ -346,6 +348,7 @@ export function validateProductionContent(files: ProductionFiles): string[] {
 
   requireTerms(failures, productionPaths.coverageProbe, files.coverageProbe, [
     'set -euo pipefail',
+    "printf '%s\\n' hermes",
     'kubectl get networkpolicies.networking.k8s.io --all-namespaces -o json',
     'if [[ "$actual_namespaces" != "$desired_namespaces" ]]',
   ])

--- a/scripts/kube-router/verify-safety-coverage.sh
+++ b/scripts/kube-router/verify-safety-coverage.sh
@@ -5,8 +5,10 @@ repo_root=$(git rev-parse --show-toplevel)
 safety_manifest="$repo_root/argocd/applications/kube-router/safety-policies.yaml"
 
 desired_namespaces=$(
-  yq eval-all --no-doc --unwrapScalar 'select(.kind == "NetworkPolicy") | .metadata.namespace' "$safety_manifest" |
-    sort -u
+  {
+    yq eval-all --no-doc --unwrapScalar 'select(.kind == "NetworkPolicy") | .metadata.namespace' "$safety_manifest"
+    printf '%s\n' hermes
+  } | sort -u
 )
 actual_namespaces=$(
   kubectl get networkpolicies.networking.k8s.io --all-namespaces -o json |


### PR DESCRIPTION
## Summary

- Add Hermes to the audited live NetworkPolicy namespace set without creating an allow-all exception.
- Require the preflight to distinguish temporary traffic-neutral policies, the inert retired Bayn policy, and enforced Hermes policies.
- Keep the operator coverage check, validation tests, and rollout runbook aligned with those states.

## Related Issues

PROOMPT-371

## Testing

- `bun run scripts/kube-router/validate-production.ts`
- `bun test scripts/kube-router/*.test.ts` (23 pass)
- `bun run lint:argocd` (0 invalid resources)
- `bash -n scripts/kube-router/verify-safety-coverage.sh`
- Executed the exact rendered preflight script read-only against the live cluster; it printed the approved policy-state success message.

## Breaking Changes

None. Hermes remains enforced and receives no rollout allow-all policy; Bayn keeps its inert retained policy.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section is removed and Breaking Changes is filled in.
- [x] Documentation and follow-up behavior are updated.