### PR TITLE
feat(bayn): persist deterministic order intents

### DIFF
--- a/nix/images/bayn.nix
+++ b/nix/images/bayn.nix
@@ -21,8 +21,8 @@ import ./bun-workspace-service.nix {
   serviceName = "bayn";
   packageName = "@proompteng/bayn";
   depsHash = {
-    x86_64-linux = "sha256-6bS/Ym9kkrtBzDzGwGeEvXIZUbaF6RRi3/SYmMj9dKI=";
-    aarch64-linux = "sha256-uC+RIwq4rQ8EoPnaSWrZYlnJmWJ76lwCCjSTr9ZfrAI=";
+    x86_64-linux = "sha256-+Pc9/PwLvC7t3hmN/owxwFoDoSKFg9h05VAIp/3C0DE=";
+    aarch64-linux = "sha256-7TTGoDjmxMi0zJ44u6oCW3ZqjAJByB6ehTuG6lCCzdM=";
   };
   installFilters = [
     "@proompteng/bayn"

--- a/services/bayn/migrations/0004_deterministic_intents.ts
+++ b/services/bayn/migrations/0004_deterministic_intents.ts
@@ -1,0 +1,57 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient
+
+  yield* sql`
+    DO $migration$
+    BEGIN
+      IF EXISTS (SELECT 1 FROM intents) OR EXISTS (SELECT 1 FROM risk_decisions) THEN
+        RAISE EXCEPTION 'deterministic intent hard cut requires empty intents and risk_decisions'
+          USING ERRCODE = '55000';
+      END IF;
+    END
+    $migration$
+  `
+
+  yield* sql`
+    ALTER TABLE intents
+      DROP CONSTRAINT intents_schema_version_check,
+      ADD COLUMN strategy_name text NOT NULL CHECK (
+        length(strategy_name) > 0 AND strategy_name = btrim(strategy_name)
+      ),
+      ADD COLUMN cycle_id text NOT NULL CHECK (cycle_id ~ '^[0-9a-f]{64}$'),
+      ADD COLUMN decision_hash text NOT NULL CHECK (decision_hash ~ '^[0-9a-f]{64}$'),
+      ADD COLUMN policy_hash text NOT NULL CHECK (policy_hash ~ '^[0-9a-f]{64}$'),
+      ADD CONSTRAINT intents_schema_version_check CHECK (schema_version = 'bayn.paper-intent.v2'),
+      ADD CONSTRAINT intents_client_order_id_length CHECK (length(client_order_id) <= 48),
+      ADD CONSTRAINT intents_decision_target_unique UNIQUE (
+        account_id,
+        strategy_name,
+        cycle_id,
+        decision_hash,
+        symbol
+      )
+  `
+
+  yield* sql`
+    CREATE OR REPLACE FUNCTION enforce_risk_decision_binding()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1
+        FROM intents
+        WHERE intent_id = NEW.intent_id
+          AND risk_decision_id = NEW.decision_id
+          AND policy_hash = NEW.policy_hash
+      ) THEN
+        RAISE EXCEPTION 'risk decision is not bound to its intent and policy' USING ERRCODE = '23514';
+      END IF;
+      RETURN NEW;
+    END
+    $function$
+  `
+})

--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -3,6 +3,7 @@ import { Effect, Layer, Ref } from 'effect'
 import type { RuntimeConfig } from './config'
 import { EvidenceStore } from './db/evidence-store'
 import { operationalError, type OperationalError } from './errors'
+import { WriterFence } from './execution/writer-fence'
 import { monitor } from './health'
 import { makeHttpLayer } from './http'
 import { Journal } from './ledger'
@@ -14,9 +15,15 @@ import type { Strategy } from './strategy'
 export const run = (
   config: RuntimeConfig,
   strategy: Strategy,
-): Effect.Effect<never, OperationalError, MarketData | Journal | EvidenceStore> =>
+): Effect.Effect<never, OperationalError, MarketData | Journal | EvidenceStore | WriterFence> =>
   Effect.scoped(
     Effect.gen(function* () {
+      const writerFence = yield* WriterFence
+      yield* writerFence.check.pipe(
+        Effect.mapError((cause) =>
+          operationalError('database', 'check-writer-fence', 'paper writer fence is unavailable', cause),
+        ),
+      )
       const evidenceStore = yield* EvidenceStore
       const state = yield* Ref.make(initialState())
       yield* Layer.build(

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -5,9 +5,11 @@ import { PgClient } from '@effect/sql-pg'
 import { Cause, Deferred, Duration, Effect, Exit, Fiber, Layer, ManagedRuntime, Option, Redacted } from 'effect'
 
 import type { RuntimeConfig } from '../config'
+import { IntentStore, IntentStoreLive, plan, type IntentPlan } from '../execution/intents'
+import { WriterFence, WriterFenceLive } from '../execution/writer-fence'
 import { canonicalHashV1 } from '../hash'
 import { buildLedgerPlan } from '../ledger'
-import { Authority } from '../paper'
+import { Authority, decodeRiskDecision, OrderSide, OrderType, RiskOutcome, TimeInForce, type Intent } from '../paper'
 import { makeQualificationResult } from '../qualification'
 import { evaluateRiskBalancedTrend } from '../risk-balanced-trend'
 import { makeStrategy } from '../strategy-service'
@@ -64,6 +66,52 @@ const makeEvidenceRuntime = (config = makeConfig()) =>
 
 const makeClientRuntime = (config = makeConfig()) =>
   ManagedRuntime.make(PostgresClientLive(config).pipe(Layer.provide(NodeServices.layer)))
+
+const makeExecutionRuntime = (config = makeConfig()) =>
+  ManagedRuntime.make(
+    IntentStoreLive.pipe(
+      Layer.provideMerge(WriterFenceLive),
+      Layer.provideMerge(PostgresClientLive(config)),
+      Layer.provide(NodeServices.layer),
+    ),
+  )
+
+const intentPlan = (overrides: Partial<IntentPlan> = {}): IntentPlan => ({
+  schemaVersion: 'bayn.paper-intent-plan.v1',
+  strategyName: 'risk-balanced-trend',
+  cycleId: 'a'.repeat(64),
+  decisionHash: 'b'.repeat(64),
+  policyHash: 'c'.repeat(64),
+  accountId: 'paper-account-1',
+  symbol: 'NVDA',
+  side: OrderSide.Buy,
+  orderType: OrderType.Market,
+  timeInForce: TimeInForce.Day,
+  quantityMicros: '1000000',
+  notionalLimitMicros: '200000000',
+  createdAt: new Date(Date.now() - 1_000).toISOString(),
+  ...overrides,
+})
+
+const riskDecision = (
+  intent: Intent,
+  outcome: RiskOutcome,
+  times: { readonly decidedAt?: string; readonly expiresAt?: string } = {},
+) => {
+  const now = Date.now()
+  const decidedAt = times.decidedAt ?? new Date(now).toISOString()
+  const material = {
+    schemaVersion: 'bayn.paper-risk-decision.v1',
+    inputHash: 'd'.repeat(64),
+    intentId: intent.intentId,
+    policyHash: intent.policyHash,
+    outcome,
+    reasonCodes: outcome === RiskOutcome.Approved ? [] : ['KILL_ACTIVE'],
+    decidedAt,
+    expiresAt: times.expiresAt ?? new Date(now + 60_000).toISOString(),
+  } as const
+  return decodeRiskDecision({ ...material, decisionId: canonicalHashV1(material) })
+}
 
 const riskBalancedTrendSnapshot = makeSnapshot(800)
 
@@ -191,7 +239,241 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       { migration_id: 1, name: 'initial_schema' },
       { migration_id: 2, name: 'paper_contracts' },
       { migration_id: 3, name: 'intent_risk_clock' },
+      { migration_id: 4, name: 'deterministic_intents' },
     ])
+  })
+
+  test('atomically commits one deterministic approved intent under one writer fence', async () => {
+    const execution = makeExecutionRuntime()
+    const secondOwner = makeExecutionRuntime()
+    const intent = await Effect.runPromise(plan(intentPlan()))
+    const decision = await Effect.runPromise(riskDecision(intent, RiskOutcome.Approved))
+
+    const observed = await Effect.runPromise(
+      Effect.gen(function* () {
+        const commits = yield* Effect.promise(() =>
+          execution.runPromise(
+            Effect.gen(function* () {
+              const store = yield* IntentStore
+              return yield* Effect.all([store.commit(intent, decision), store.commit(intent, decision)], {
+                concurrency: 'unbounded',
+              })
+            }),
+          ),
+        )
+        const secondOwnerExit = yield* Effect.promise(() =>
+          secondOwner.runPromiseExit(Effect.flatMap(WriterFence, (fence) => fence.check)),
+        )
+        const transitionTime = new Date(Date.now() + 1_000).toISOString()
+        const transitions = yield* Effect.promise(() =>
+          execution.runPromise(
+            Effect.gen(function* () {
+              const store = yield* IntentStore
+              return yield* Effect.all(
+                [
+                  store.markIoStarted(intent.intentId, transitionTime),
+                  store.markIoStarted(intent.intentId, transitionTime),
+                ],
+                { concurrency: 'unbounded' },
+              )
+            }),
+          ),
+        )
+        const stored = yield* Effect.promise(() =>
+          runtime.runPromise(
+            Effect.gen(function* () {
+              const sql = yield* PgClient.PgClient
+              const rows = yield* sql<{
+                client_order_id: string
+                decisions: number
+                intents: number
+                state: string
+                state_version: number
+              }>`
+                SELECT
+                  intent.client_order_id,
+                  intent.state,
+                  intent.state_version::integer,
+                  (SELECT count(*)::integer FROM intents) AS intents,
+                  (SELECT count(*)::integer FROM risk_decisions) AS decisions
+                FROM intents AS intent
+                WHERE intent.intent_id = ${intent.intentId}
+              `
+              return rows[0]
+            }),
+          ),
+        )
+        return { commits, secondOwnerExit, stored, transitions }
+      }).pipe(
+        Effect.ensuring(
+          Effect.all([Effect.promise(() => secondOwner.dispose()), Effect.promise(() => execution.dispose())], {
+            concurrency: 'unbounded',
+          }).pipe(Effect.asVoid),
+        ),
+      ),
+    )
+
+    expect(
+      observed.commits.map((receipt) => receipt.deduplicated).sort((left, right) => Number(left) - Number(right)),
+    ).toEqual([false, true])
+    expect(observed.commits[0].record.intent.intentId).toBe(intent.intentId)
+    expect(observed.commits[1].record.intent.clientOrderId).toBe(intent.clientOrderId)
+    expect(Exit.isFailure(observed.secondOwnerExit)).toBe(true)
+    expect(
+      observed.transitions.map((receipt) => receipt.deduplicated).sort((left, right) => Number(left) - Number(right)),
+    ).toEqual([false, true])
+    expect(observed.stored).toEqual({
+      client_order_id: intent.clientOrderId,
+      state: 'IO_STARTED',
+      state_version: 3,
+      intents: 1,
+      decisions: 1,
+    })
+  })
+
+  test('atomically blocks rejected risk and rejects divergent deterministic reuse', async () => {
+    const execution = makeExecutionRuntime()
+    const input = intentPlan({ cycleId: 'e'.repeat(64) })
+    const intent = await Effect.runPromise(plan(input))
+    const decision = await Effect.runPromise(riskDecision(intent, RiskOutcome.Blocked))
+    const divergent = await Effect.runPromise(plan({ ...input, policyHash: 'f'.repeat(64) }))
+    const divergentDecision = await Effect.runPromise(riskDecision(divergent, RiskOutcome.Blocked))
+
+    const observed = await Effect.runPromise(
+      Effect.gen(function* () {
+        const forgedDecision = yield* Effect.promise(() =>
+          execution.runPromiseExit(
+            Effect.flatMap(IntentStore, (store) => store.commit(intent, { ...decision, decisionId: '0'.repeat(64) })),
+          ),
+        )
+        const receipt = yield* Effect.promise(() =>
+          execution.runPromise(Effect.flatMap(IntentStore, (store) => store.commit(intent, decision))),
+        )
+        const conflict = yield* Effect.promise(() =>
+          execution.runPromiseExit(Effect.flatMap(IntentStore, (store) => store.commit(divergent, divergentDecision))),
+        )
+        const counts = yield* Effect.promise(() =>
+          runtime.runPromise(
+            Effect.gen(function* () {
+              const sql = yield* PgClient.PgClient
+              return yield* sql<{ decisions: number; intents: number }>`
+                SELECT
+                  (SELECT count(*)::integer FROM intents) AS intents,
+                  (SELECT count(*)::integer FROM risk_decisions) AS decisions
+              `
+            }),
+          ),
+        )
+        return { conflict, counts: counts[0], forgedDecision, receipt }
+      }).pipe(Effect.ensuring(Effect.promise(() => execution.dispose()))),
+    )
+
+    expect(observed.receipt.deduplicated).toBe(false)
+    expect(observed.receipt.record).toMatchObject({
+      decision: { decisionId: decision.decisionId, outcome: RiskOutcome.Blocked },
+      intent: { state: 'TERMINAL', terminalOutcome: 'BLOCKED' },
+      stateVersion: 2,
+    })
+    expect(Exit.isFailure(observed.conflict)).toBe(true)
+    expect(Exit.isFailure(observed.forgedDecision)).toBe(true)
+    if (Exit.isFailure(observed.forgedDecision)) {
+      expect(Cause.pretty(observed.forgedDecision.cause)).toContain(
+        'risk decision does not match its deterministic identity',
+      )
+    }
+    if (Exit.isFailure(observed.conflict)) {
+      expect(Cause.pretty(observed.conflict.cause)).toContain(
+        'deterministic intent identity was reused with different content',
+      )
+    }
+    expect(observed.counts).toEqual({ decisions: 1, intents: 1 })
+  })
+
+  test('rolls back both records when an approval is stale at commit', async () => {
+    const execution = makeExecutionRuntime()
+    const now = Date.now()
+    const intent = await Effect.runPromise(
+      plan(
+        intentPlan({
+          cycleId: 'f'.repeat(64),
+          createdAt: new Date(now - 180_000).toISOString(),
+        }),
+      ),
+    )
+    const decision = await Effect.runPromise(
+      riskDecision(intent, RiskOutcome.Approved, {
+        decidedAt: new Date(now - 120_000).toISOString(),
+        expiresAt: new Date(now - 60_000).toISOString(),
+      }),
+    )
+
+    const observed = await Effect.runPromise(
+      Effect.gen(function* () {
+        const commit = yield* Effect.promise(() =>
+          execution.runPromiseExit(Effect.flatMap(IntentStore, (store) => store.commit(intent, decision))),
+        )
+        const counts = yield* Effect.promise(() =>
+          runtime.runPromise(
+            Effect.gen(function* () {
+              const sql = yield* PgClient.PgClient
+              return yield* sql<{ decisions: number; intents: number }>`
+                SELECT
+                  (SELECT count(*)::integer FROM intents) AS intents,
+                  (SELECT count(*)::integer FROM risk_decisions) AS decisions
+              `
+            }),
+          ),
+        )
+        return { commit, counts: counts[0] }
+      }).pipe(Effect.ensuring(Effect.promise(() => execution.dispose()))),
+    )
+
+    expect(Exit.isFailure(observed.commit)).toBe(true)
+    expect(observed.counts).toEqual({ decisions: 0, intents: 0 })
+  })
+
+  test('loses mutation authority when the reserved writer session dies', async () => {
+    const execution = makeExecutionRuntime()
+    const intent = await Effect.runPromise(plan(intentPlan({ cycleId: 'e'.repeat(64) })))
+    const decision = await Effect.runPromise(riskDecision(intent, RiskOutcome.Approved))
+
+    const observed = await Effect.runPromise(
+      Effect.gen(function* () {
+        const backendPid = yield* Effect.promise(() =>
+          execution.runPromise(Effect.map(WriterFence, (fence) => fence.backendPid)),
+        )
+        const terminated = yield* Effect.promise(() =>
+          runtime.runPromise(
+            Effect.gen(function* () {
+              const sql = yield* PgClient.PgClient
+              return yield* sql<{ terminated: boolean }>`
+                SELECT pg_terminate_backend(${backendPid}) AS terminated
+              `
+            }),
+          ),
+        )
+        const check = yield* Effect.promise(() =>
+          execution.runPromiseExit(Effect.flatMap(WriterFence, (fence) => fence.check)),
+        )
+        const commit = yield* Effect.promise(() =>
+          execution.runPromiseExit(Effect.flatMap(IntentStore, (store) => store.commit(intent, decision))),
+        )
+        const count = yield* Effect.promise(() =>
+          runtime.runPromise(
+            Effect.gen(function* () {
+              const sql = yield* PgClient.PgClient
+              return yield* sql<{ count: number }>`SELECT count(*)::integer AS count FROM intents`
+            }),
+          ),
+        )
+        return { check, commit, count: count[0]?.count, terminated: terminated[0]?.terminated }
+      }).pipe(Effect.ensuring(Effect.promise(() => execution.dispose()))),
+    )
+
+    expect(observed.terminated).toBe(true)
+    expect(Exit.isFailure(observed.check)).toBe(true)
+    expect(Exit.isFailure(observed.commit)).toBe(true)
+    expect(observed.count).toBe(0)
   })
 
   test('requires one typed append-only payload and unique broker source ordering', async () => {
@@ -320,21 +602,25 @@ describePostgres('PostgreSQL evaluation evidence', () => {
         const decisionId = '2'.repeat(64)
         yield* sql`
           INSERT INTO intents (
-            intent_id, schema_version, account_id, client_order_id, symbol, side, order_type,
+            intent_id, schema_version, strategy_name, cycle_id, decision_hash, policy_hash,
+            account_id, client_order_id, symbol, side, order_type,
             time_in_force, quantity_micros, notional_limit_micros, state, created_at, updated_at
           ) VALUES (
-            ${intentId}, 'bayn.paper-intent.v1', 'paper-account-1', 'client-order-1', 'NVDA', 'BUY',
+            ${intentId}, 'bayn.paper-intent.v2', 'risk-balanced-trend', ${intentId}, ${'5'.repeat(64)},
+            ${'6'.repeat(64)}, 'paper-account-1', 'client-order-1', 'NVDA', 'BUY',
             'MARKET', 'DAY', 1000000, 200000000, 'PLANNED',
             '2026-07-22T06:00:00.000Z', '2026-07-22T06:00:00.000Z'
           )
         `
         const invalidInitial = yield* Effect.exit(sql`
           INSERT INTO intents (
-            intent_id, schema_version, risk_decision_id, account_id, client_order_id, symbol, side,
-            order_type, time_in_force, quantity_micros, notional_limit_micros, state,
+            intent_id, schema_version, risk_decision_id, strategy_name, cycle_id, decision_hash,
+            policy_hash, account_id, client_order_id, symbol, side, order_type, time_in_force,
+            quantity_micros, notional_limit_micros, state,
             created_at, updated_at
           ) VALUES (
-            ${'3'.repeat(64)}, 'bayn.paper-intent.v1', ${'4'.repeat(64)}, 'paper-account-1',
+            ${'3'.repeat(64)}, 'bayn.paper-intent.v2', ${'4'.repeat(64)}, 'risk-balanced-trend',
+            ${'3'.repeat(64)}, ${'4'.repeat(64)}, ${'5'.repeat(64)}, 'paper-account-1',
             'client-order-2', 'NVDA', 'BUY', 'MARKET', 'DAY', 1000000, 200000000, 'APPROVED',
             '2026-07-22T06:00:00.000Z', '2026-07-22T06:00:00.000Z'
           )
@@ -381,10 +667,12 @@ describePostgres('PostgreSQL evaluation evidence', () => {
           Effect.gen(function* () {
             yield* sql`
               INSERT INTO intents (
-                intent_id, schema_version, account_id, client_order_id, symbol, side, order_type,
+                intent_id, schema_version, strategy_name, cycle_id, decision_hash, policy_hash,
+                account_id, client_order_id, symbol, side, order_type,
                 time_in_force, quantity_micros, notional_limit_micros, state, created_at, updated_at
               ) VALUES (
-                ${staleIntentId}, 'bayn.paper-intent.v1', 'paper-account-1', 'client-order-stale',
+                ${staleIntentId}, 'bayn.paper-intent.v2', 'risk-balanced-trend', ${staleIntentId},
+                ${'4'.repeat(64)}, ${'3'.repeat(64)}, 'paper-account-1', 'client-order-stale',
                 'NVDA', 'BUY', 'MARKET', 'DAY', 1000000, 200000000, 'PLANNED',
                 statement_timestamp() - interval '1 minute', statement_timestamp() - interval '1 minute'
               )
@@ -494,10 +782,12 @@ describePostgres('PostgreSQL evaluation evidence', () => {
             Effect.gen(function* () {
               yield* sql`
                 INSERT INTO intents (
-                  intent_id, schema_version, account_id, client_order_id, symbol, side, order_type,
+                  intent_id, schema_version, strategy_name, cycle_id, decision_hash, policy_hash,
+                  account_id, client_order_id, symbol, side, order_type,
                   time_in_force, quantity_micros, notional_limit_micros, state, created_at, updated_at
                 ) VALUES (
-                  ${'b'.repeat(64)}, 'bayn.paper-intent.v1', 'paper-account-1', 'client-order-4',
+                  ${'b'.repeat(64)}, 'bayn.paper-intent.v2', 'risk-balanced-trend', ${'b'.repeat(64)},
+                  ${'d'.repeat(64)}, ${'e'.repeat(64)}, 'paper-account-1', 'client-order-4',
                   'AMD', 'BUY', 'MARKET', 'DAY', 1000000, 200000000, 'PLANNED',
                   '2026-07-22T06:00:00.000Z', '2026-07-22T06:00:00.000Z'
                 )
@@ -526,10 +816,12 @@ describePostgres('PostgreSQL evaluation evidence', () => {
             Effect.gen(function* () {
               yield* sql`
                 INSERT INTO intents (
-                  intent_id, schema_version, account_id, client_order_id, symbol, side, order_type,
+                  intent_id, schema_version, strategy_name, cycle_id, decision_hash, policy_hash,
+                  account_id, client_order_id, symbol, side, order_type,
                   time_in_force, quantity_micros, notional_limit_micros, state, created_at, updated_at
                 ) VALUES (
-                  ${'f'.repeat(64)}, 'bayn.paper-intent.v1', 'paper-account-1', 'client-order-5',
+                  ${'f'.repeat(64)}, 'bayn.paper-intent.v2', 'risk-balanced-trend', ${'f'.repeat(64)},
+                  ${'1'.repeat(64)}, ${'2'.repeat(64)}, 'paper-account-1', 'client-order-5',
                   'AMD', 'BUY', 'MARKET', 'DAY', 1000000, 200000000, 'PLANNED',
                   '2026-07-22T06:00:00.000Z', '2026-07-22T06:00:00.000Z'
                 )
@@ -557,10 +849,12 @@ describePostgres('PostgreSQL evaluation evidence', () => {
           Effect.gen(function* () {
             yield* sql`
               INSERT INTO intents (
-                intent_id, schema_version, account_id, client_order_id, symbol, side, order_type,
+                intent_id, schema_version, strategy_name, cycle_id, decision_hash, policy_hash,
+                account_id, client_order_id, symbol, side, order_type,
                 time_in_force, quantity_micros, notional_limit_micros, state, created_at, updated_at
               ) VALUES (
-                ${'a'.repeat(64)}, 'bayn.paper-intent.v1', 'paper-account-1', 'client-order-6',
+                ${'a'.repeat(64)}, 'bayn.paper-intent.v2', 'risk-balanced-trend', ${'a'.repeat(64)},
+                ${'8'.repeat(64)}, ${'7'.repeat(64)}, 'paper-account-1', 'client-order-6',
                 'AMD', 'BUY', 'MARKET', 'DAY', 1000000, 200000000, 'PLANNED',
                 '2026-07-22T06:00:00.000Z', '2026-07-22T06:00:00.000Z'
               )
@@ -588,10 +882,12 @@ describePostgres('PostgreSQL evaluation evidence', () => {
             Effect.gen(function* () {
               yield* sql`
                 INSERT INTO intents (
-                  intent_id, schema_version, account_id, client_order_id, symbol, side, order_type,
+                  intent_id, schema_version, strategy_name, cycle_id, decision_hash, policy_hash,
+                  account_id, client_order_id, symbol, side, order_type,
                   time_in_force, quantity_micros, notional_limit_micros, state, created_at, updated_at
                 ) VALUES (
-                  ${'7'.repeat(64)}, 'bayn.paper-intent.v1', 'paper-account-1', 'client-order-3',
+                  ${'7'.repeat(64)}, 'bayn.paper-intent.v2', 'risk-balanced-trend', ${'7'.repeat(64)},
+                  ${'9'.repeat(64)}, ${'a'.repeat(64)}, 'paper-account-1', 'client-order-3',
                   'AMD', 'BUY', 'MARKET', 'DAY', 1000000, 200000000, 'PLANNED',
                   '2026-07-22T06:00:00.000Z', '2026-07-22T06:00:00.000Z'
                 )
@@ -1707,14 +2003,36 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     expect(result.counts).toEqual({ runs: 0, protocols: 0, snapshots: 0, events: 0 })
   })
 
-  test('cancels an interrupted query and returns its pooled connection', async () => {
-    const rows = await runtime.runPromise(
+  test('rolls back an interrupted transaction and returns its pooled connection', async () => {
+    const observed = await runtime.runPromise(
       Effect.gen(function* () {
         const sql = yield* PgClient.PgClient
-        const sleeper = yield* Effect.forkChild(sql`SELECT pg_sleep(30)`)
-        yield* Effect.sleep('250 millis')
+        const inserted = yield* Deferred.make<void>()
+        const sleeper = yield* Effect.forkChild(
+          sql.withTransaction(
+            Effect.gen(function* () {
+              yield* sql`
+                INSERT INTO intents (
+                  intent_id, schema_version, strategy_name, cycle_id, decision_hash, policy_hash,
+                  account_id, client_order_id, symbol, side, order_type, time_in_force,
+                  quantity_micros, notional_limit_micros, state, created_at, updated_at
+                ) VALUES (
+                  ${'6'.repeat(64)}, 'bayn.paper-intent.v2', 'risk-balanced-trend', ${'7'.repeat(64)},
+                  ${'8'.repeat(64)}, ${'9'.repeat(64)}, 'paper-account-1', 'interrupted-order',
+                  'NVDA', 'BUY', 'MARKET', 'DAY', 1000000, 200000000, 'PLANNED',
+                  statement_timestamp(), statement_timestamp()
+                )
+              `
+              yield* Deferred.succeed(inserted, undefined)
+              yield* sql`SELECT pg_sleep(30)`
+            }),
+          ),
+        )
+        yield* Deferred.await(inserted)
         yield* Fiber.interrupt(sleeper)
-        return yield* sql<{ value: number }>`SELECT 1::integer AS value`.pipe(
+        return yield* sql<{ intents: number; value: number }>`
+          SELECT 1::integer AS value, count(*)::integer AS intents FROM intents
+        `.pipe(
           Effect.timeoutOrElse({
             duration: '2 seconds',
             orElse: () => Effect.fail(new Error('PostgreSQL pool did not recover')),
@@ -1723,7 +2041,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       }),
     )
 
-    expect(rows).toEqual([{ value: 1 }])
+    expect(observed).toEqual([{ intents: 0, value: 1 }])
   })
 
   test('closes the PostgreSQL pool when its managed scope is disposed', async () => {

--- a/services/bayn/src/db/migrations.ts
+++ b/services/bayn/src/db/migrations.ts
@@ -3,9 +3,11 @@ import { PgMigrator } from '@effect/sql-pg'
 import initialSchema from '../../migrations/0001_initial_schema'
 import paperContracts from '../../migrations/0002_paper_contracts'
 import intentRiskClock from '../../migrations/0003_intent_risk_clock'
+import deterministicIntents from '../../migrations/0004_deterministic_intents'
 
 export const migrationLoader = PgMigrator.fromRecord({
   '1_initial_schema': initialSchema,
   '2_paper_contracts': paperContracts,
   '3_intent_risk_clock': intentRiskClock,
+  '4_deterministic_intents': deterministicIntents,
 })

--- a/services/bayn/src/execution/intents.test.ts
+++ b/services/bayn/src/execution/intents.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Effect, Exit } from 'effect'
+
+import { IntentState, OrderSide, OrderType, TimeInForce } from '../paper'
+import { plan, type IntentPlan } from './intents'
+
+const hash = (digit: string): string => digit.repeat(64)
+
+const input: IntentPlan = {
+  schemaVersion: 'bayn.paper-intent-plan.v1',
+  strategyName: 'risk-balanced-trend',
+  cycleId: hash('1'),
+  decisionHash: hash('2'),
+  policyHash: hash('3'),
+  accountId: 'paper-account-1',
+  symbol: 'NVDA',
+  side: OrderSide.Buy,
+  orderType: OrderType.Market,
+  timeInForce: TimeInForce.Day,
+  quantityMicros: '1000000',
+  notionalLimitMicros: '200000000',
+  createdAt: '2026-07-22T10:00:00.000Z',
+}
+
+describe('deterministic paper intents', () => {
+  test('derives one stable full intent identity and Alpaca-bounded client order ID', async () => {
+    const [first, second] = await Effect.runPromise(Effect.all([plan(input), plan({ ...input })]))
+
+    expect(first).toEqual(second)
+    expect(first.intentId).toMatch(/^[0-9a-f]{64}$/)
+    expect(first.clientOrderId).toMatch(/^b1_[A-Za-z0-9_-]{43}$/)
+    expect(first.clientOrderId).toHaveLength(46)
+    expect(first.state).toBe(IntentState.Planned)
+    expect(first.riskDecisionId).toBeUndefined()
+  })
+
+  test('binds account, strategy, cycle, decision, and target material', async () => {
+    const baseline = await Effect.runPromise(plan(input))
+    const variants: readonly IntentPlan[] = [
+      { ...input, accountId: 'paper-account-2' },
+      { ...input, strategyName: 'another-strategy' },
+      { ...input, cycleId: hash('4') },
+      { ...input, decisionHash: hash('5') },
+      { ...input, symbol: 'AMD' },
+      { ...input, side: OrderSide.Sell },
+      { ...input, orderType: OrderType.Limit },
+      { ...input, timeInForce: TimeInForce.GoodUntilCanceled },
+      { ...input, quantityMicros: '2000000' },
+      { ...input, notionalLimitMicros: '300000000' },
+    ]
+    const planned = await Effect.runPromise(Effect.forEach(variants, plan))
+
+    expect(new Set(planned.map((intent) => intent.intentId)).size).toBe(variants.length)
+    expect(planned.every((intent) => intent.intentId !== baseline.intentId)).toBe(true)
+    expect(planned.every((intent) => intent.clientOrderId !== baseline.clientOrderId)).toBe(true)
+  })
+
+  test('keeps the order identity stable when policy or observation time drifts', async () => {
+    const [baseline, changedPolicy, changedTime] = await Effect.runPromise(
+      Effect.all([
+        plan(input),
+        plan({ ...input, policyHash: hash('6') }),
+        plan({ ...input, createdAt: '2026-07-22T10:00:01.000Z' }),
+      ]),
+    )
+
+    expect(changedPolicy.intentId).toBe(baseline.intentId)
+    expect(changedPolicy.clientOrderId).toBe(baseline.clientOrderId)
+    expect(changedTime.intentId).toBe(baseline.intentId)
+    expect(changedTime.clientOrderId).toBe(baseline.clientOrderId)
+  })
+
+  test('rejects malformed plans before deriving an identity', async () => {
+    const result = await Effect.runPromiseExit(
+      plan({ ...input, cycleId: 'not-a-hash', quantityMicros: '0', extra: true }),
+    )
+
+    expect(Exit.isFailure(result)).toBe(true)
+  })
+})

--- a/services/bayn/src/execution/intents.ts
+++ b/services/bayn/src/execution/intents.ts
@@ -1,0 +1,572 @@
+import { Buffer } from 'node:buffer'
+
+import { PgClient } from '@effect/sql-pg'
+import { Context, Data, Effect, Layer, Option, Schema } from 'effect'
+import type { Fragment } from 'effect/unstable/sql/Statement'
+
+import { canonicalHashV1 } from '../hash'
+import {
+  decodeIntent,
+  decodeRiskDecision,
+  IntentSchema,
+  IntentState,
+  OrderSide,
+  OrderType,
+  PositiveMicrosSchema,
+  RiskDecisionSchema,
+  RiskOutcome,
+  TerminalOutcome,
+  TimeInForce,
+  type Intent,
+  type RiskDecision,
+} from '../paper'
+import {
+  Sha256Schema as Sha256,
+  StrictNonEmptyStringSchema as NonEmptyString,
+  SymbolSchema as SymbolName,
+  UtcInstantSchema as UtcInstant,
+  strictParseOptions,
+} from '../schemas'
+import { mutationFence, WriterFence, WriterFenceError } from './writer-fence'
+
+export const IntentPlanSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.paper-intent-plan.v1'),
+  strategyName: NonEmptyString,
+  cycleId: Sha256,
+  decisionHash: Sha256,
+  policyHash: Sha256,
+  accountId: NonEmptyString,
+  symbol: SymbolName,
+  side: Schema.Enum(OrderSide),
+  orderType: Schema.Enum(OrderType),
+  timeInForce: Schema.Enum(TimeInForce),
+  quantityMicros: PositiveMicrosSchema,
+  notionalLimitMicros: PositiveMicrosSchema,
+  createdAt: UtcInstant,
+})
+export type IntentPlan = typeof IntentPlanSchema.Type
+
+const decodePlan = Schema.decodeUnknownEffect(IntentPlanSchema, strictParseOptions)
+const intentEquivalent = Schema.toEquivalence(IntentSchema)
+const decisionEquivalent = Schema.toEquivalence(RiskDecisionSchema)
+
+const identityMaterial = (input: IntentPlan) => ({
+  schemaVersion: 'bayn.paper-intent-identity.v1',
+  strategyName: input.strategyName,
+  cycleId: input.cycleId,
+  decisionHash: input.decisionHash,
+  accountId: input.accountId,
+  symbol: input.symbol,
+  side: input.side,
+  orderType: input.orderType,
+  timeInForce: input.timeInForce,
+  quantityMicros: input.quantityMicros,
+  notionalLimitMicros: input.notionalLimitMicros,
+})
+
+const clientOrderId = (intentId: string): string => `b1_${Buffer.from(intentId, 'hex').toString('base64url')}`
+
+export const plan = (input: unknown) =>
+  decodePlan(input).pipe(
+    Effect.flatMap((decoded) => {
+      const intentId = canonicalHashV1(identityMaterial(decoded))
+      return decodeIntent({
+        schemaVersion: 'bayn.paper-intent.v2',
+        intentId,
+        strategyName: decoded.strategyName,
+        cycleId: decoded.cycleId,
+        decisionHash: decoded.decisionHash,
+        policyHash: decoded.policyHash,
+        accountId: decoded.accountId,
+        clientOrderId: clientOrderId(intentId),
+        symbol: decoded.symbol,
+        side: decoded.side,
+        orderType: decoded.orderType,
+        timeInForce: decoded.timeInForce,
+        quantityMicros: decoded.quantityMicros,
+        notionalLimitMicros: decoded.notionalLimitMicros,
+        state: IntentState.Planned,
+        createdAt: decoded.createdAt,
+      })
+    }),
+  )
+
+export class IntentStoreError extends Data.TaggedError('IntentStoreError')<{
+  readonly failure: 'conflict' | 'decode' | 'invariant' | 'query'
+  readonly operation: 'commit' | 'mark-io-started' | 'read'
+  readonly message: string
+  readonly cause?: unknown
+}> {}
+
+export interface StoredIntent {
+  readonly intent: Intent
+  readonly decision?: RiskDecision
+  readonly stateVersion: number
+  readonly updatedAt: string
+}
+
+export interface IntentReceipt {
+  readonly record: StoredIntent
+  readonly deduplicated: boolean
+}
+
+export interface IntentStoreService {
+  readonly commit: (
+    intent: Intent,
+    decision: RiskDecision,
+  ) => Effect.Effect<IntentReceipt, IntentStoreError | WriterFenceError>
+  readonly markIoStarted: (
+    intentId: string,
+    updatedAt: string,
+  ) => Effect.Effect<IntentReceipt, IntentStoreError | WriterFenceError>
+  readonly read: (intentId: string) => Effect.Effect<Option.Option<StoredIntent>, IntentStoreError>
+}
+
+export class IntentStore extends Context.Service<IntentStore, IntentStoreService>()('bayn/IntentStore') {}
+
+const intentRowFields = {
+  schema_version: Schema.Literal('bayn.paper-intent.v2'),
+  intent_id: Sha256,
+  risk_decision_id: Schema.NullOr(Sha256),
+  strategy_name: NonEmptyString,
+  cycle_id: Sha256,
+  decision_hash: Sha256,
+  policy_hash: Sha256,
+  account_id: NonEmptyString,
+  client_order_id: NonEmptyString,
+  symbol: SymbolName,
+  side: Schema.Enum(OrderSide),
+  order_type: Schema.Enum(OrderType),
+  time_in_force: Schema.Enum(TimeInForce),
+  quantity_micros: PositiveMicrosSchema,
+  notional_limit_micros: PositiveMicrosSchema,
+  state: Schema.Enum(IntentState),
+  terminal_outcome: Schema.NullOr(Schema.Enum(TerminalOutcome)),
+  state_version: Schema.Int.check(Schema.isGreaterThan(0)),
+  created_at: UtcInstant,
+  updated_at: UtcInstant,
+} as const
+
+const WithoutDecisionRow = Schema.Struct({
+  ...intentRowFields,
+  decision_id: Schema.Null,
+  input_hash: Schema.Null,
+  decision_policy_hash: Schema.Null,
+  outcome: Schema.Null,
+  reason_codes: Schema.Null,
+  decided_at: Schema.Null,
+  expires_at: Schema.Null,
+})
+const WithDecisionRow = Schema.Struct({
+  ...intentRowFields,
+  decision_id: Sha256,
+  input_hash: Sha256,
+  decision_policy_hash: Sha256,
+  outcome: Schema.Enum(RiskOutcome),
+  reason_codes: Schema.Array(NonEmptyString).check(Schema.isUnique()),
+  decided_at: UtcInstant,
+  expires_at: UtcInstant,
+})
+const StoredRow = Schema.Union([WithoutDecisionRow, WithDecisionRow])
+type StoredRow = typeof StoredRow.Type
+const decodeRows = Schema.decodeUnknownEffect(Schema.Array(StoredRow), strictParseOptions)
+const decodeIntentId = Schema.decodeUnknownEffect(Sha256)
+const decodeUpdatedAt = Schema.decodeUnknownEffect(UtcInstant)
+
+const selectRows = (sql: PgClient.PgClient, predicate: Fragment) => sql`
+  SELECT
+    intent.schema_version,
+    intent.intent_id,
+    intent.risk_decision_id,
+    intent.strategy_name,
+    intent.cycle_id,
+    intent.decision_hash,
+    intent.policy_hash,
+    intent.account_id,
+    intent.client_order_id,
+    intent.symbol,
+    intent.side,
+    intent.order_type,
+    intent.time_in_force,
+    intent.quantity_micros::text,
+    intent.notional_limit_micros::text,
+    intent.state,
+    intent.terminal_outcome,
+    intent.state_version::integer,
+    to_char(intent.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS created_at,
+    to_char(intent.updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS updated_at,
+    decision.decision_id,
+    decision.input_hash,
+    decision.policy_hash AS decision_policy_hash,
+    decision.outcome,
+    decision.reason_codes,
+    to_char(decision.decided_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS decided_at,
+    to_char(decision.expires_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS expires_at
+  FROM intents AS intent
+  LEFT JOIN risk_decisions AS decision ON decision.intent_id = intent.intent_id
+  WHERE ${predicate}
+`
+
+const toRecord = (row: StoredRow) =>
+  Effect.gen(function* () {
+    const intent = yield* decodeIntent({
+      schemaVersion: row.schema_version,
+      intentId: row.intent_id,
+      ...(row.risk_decision_id === null ? {} : { riskDecisionId: row.risk_decision_id }),
+      strategyName: row.strategy_name,
+      cycleId: row.cycle_id,
+      decisionHash: row.decision_hash,
+      policyHash: row.policy_hash,
+      accountId: row.account_id,
+      clientOrderId: row.client_order_id,
+      symbol: row.symbol,
+      side: row.side,
+      orderType: row.order_type,
+      timeInForce: row.time_in_force,
+      quantityMicros: row.quantity_micros,
+      notionalLimitMicros: row.notional_limit_micros,
+      state: row.state,
+      ...(row.terminal_outcome === null ? {} : { terminalOutcome: row.terminal_outcome }),
+      createdAt: row.created_at,
+    })
+    const decision =
+      row.decision_id === null
+        ? undefined
+        : yield* decodeRiskDecision({
+            schemaVersion: 'bayn.paper-risk-decision.v1',
+            decisionId: row.decision_id,
+            inputHash: row.input_hash,
+            intentId: row.intent_id,
+            policyHash: row.decision_policy_hash,
+            outcome: row.outcome,
+            reasonCodes: row.reason_codes,
+            decidedAt: row.decided_at,
+            expiresAt: row.expires_at,
+          })
+    return { intent, decision, stateVersion: row.state_version, updatedAt: row.updated_at } satisfies StoredIntent
+  })
+
+const immutableIntentHash = (intent: Intent): string =>
+  canonicalHashV1({
+    schemaVersion: intent.schemaVersion,
+    intentId: intent.intentId,
+    strategyName: intent.strategyName,
+    cycleId: intent.cycleId,
+    decisionHash: intent.decisionHash,
+    policyHash: intent.policyHash,
+    accountId: intent.accountId,
+    clientOrderId: intent.clientOrderId,
+    symbol: intent.symbol,
+    side: intent.side,
+    orderType: intent.orderType,
+    timeInForce: intent.timeInForce,
+    quantityMicros: intent.quantityMicros,
+    notionalLimitMicros: intent.notionalLimitMicros,
+    createdAt: intent.createdAt,
+  })
+
+const storeError = (
+  failure: IntentStoreError['failure'],
+  operation: IntentStoreError['operation'],
+  message: string,
+  cause?: unknown,
+) => new IntentStoreError({ failure, operation, message, cause })
+
+const makeStore = Effect.gen(function* () {
+  const sql = yield* PgClient.PgClient
+  const fence = yield* WriterFence
+
+  const run = <A, E, R>(
+    operation: IntentStoreError['operation'],
+    effect: Effect.Effect<A, E, R>,
+  ): Effect.Effect<A, IntentStoreError | WriterFenceError, R> =>
+    effect.pipe(
+      Effect.mapError((cause) =>
+        cause instanceof WriterFenceError || cause instanceof IntentStoreError
+          ? cause
+          : storeError('query', operation, `intent ${operation} failed`, cause),
+      ),
+    )
+
+  const decodeStored = (operation: IntentStoreError['operation'], rows: unknown) =>
+    decodeRows(rows).pipe(
+      Effect.mapError((cause) => storeError('decode', operation, 'stored intent rows failed schema decoding', cause)),
+      Effect.flatMap((decoded) =>
+        Effect.forEach(decoded, (row) =>
+          toRecord(row).pipe(
+            Effect.mapError((cause) =>
+              storeError('decode', operation, 'stored intent payload failed schema decoding', cause),
+            ),
+          ),
+        ),
+      ),
+    )
+
+  const readById = (operation: IntentStoreError['operation'], intentId: string) =>
+    Effect.gen(function* () {
+      const decodedId = yield* decodeIntentId(intentId).pipe(
+        Effect.mapError((cause) => storeError('decode', operation, 'invalid intent ID', cause)),
+      )
+      const rows = yield* selectRows(sql, sql`intent.intent_id = ${decodedId}`)
+      const records = yield* decodeStored(operation, rows)
+      if (records.length > 1) {
+        return yield* Effect.fail(storeError('invariant', operation, 'intent ID returned multiple records'))
+      }
+      return Option.fromNullishOr(records[0])
+    })
+
+  const withFence = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+    sql.withTransaction(
+      Effect.gen(function* () {
+        yield* sql`SELECT pg_advisory_xact_lock(${mutationFence.namespace}, ${mutationFence.key})`
+        yield* fence.check
+        return yield* effect
+      }),
+    )
+
+  const commit = (inputIntent: Intent, inputDecision: RiskDecision) =>
+    run(
+      'commit',
+      Effect.gen(function* () {
+        const expectedIntent = yield* plan({
+          schemaVersion: 'bayn.paper-intent-plan.v1',
+          strategyName: inputIntent.strategyName,
+          cycleId: inputIntent.cycleId,
+          decisionHash: inputIntent.decisionHash,
+          policyHash: inputIntent.policyHash,
+          accountId: inputIntent.accountId,
+          symbol: inputIntent.symbol,
+          side: inputIntent.side,
+          orderType: inputIntent.orderType,
+          timeInForce: inputIntent.timeInForce,
+          quantityMicros: inputIntent.quantityMicros,
+          notionalLimitMicros: inputIntent.notionalLimitMicros,
+          createdAt: inputIntent.createdAt,
+        }).pipe(Effect.mapError((cause) => storeError('decode', 'commit', 'invalid planned intent', cause)))
+        if (!intentEquivalent(inputIntent, expectedIntent)) {
+          return yield* Effect.fail(
+            storeError('invariant', 'commit', 'planned intent does not match its deterministic identity'),
+          )
+        }
+        const decision = yield* decodeRiskDecision(inputDecision).pipe(
+          Effect.mapError((cause) => storeError('decode', 'commit', 'invalid risk decision', cause)),
+        )
+        const { decisionId, ...decisionMaterial } = decision
+        if (decisionId !== canonicalHashV1(decisionMaterial)) {
+          return yield* Effect.fail(
+            storeError('invariant', 'commit', 'risk decision does not match its deterministic identity'),
+          )
+        }
+        if (decision.intentId !== inputIntent.intentId || decision.policyHash !== inputIntent.policyHash) {
+          return yield* Effect.fail(
+            storeError('invariant', 'commit', 'risk decision does not match the intent and policy'),
+          )
+        }
+
+        return yield* withFence(
+          Effect.gen(function* () {
+            yield* sql`
+              INSERT INTO intents (
+                intent_id,
+                schema_version,
+                strategy_name,
+                cycle_id,
+                decision_hash,
+                policy_hash,
+                account_id,
+                client_order_id,
+                symbol,
+                side,
+                order_type,
+                time_in_force,
+                quantity_micros,
+                notional_limit_micros,
+                state,
+                created_at,
+                updated_at
+              ) VALUES (
+                ${inputIntent.intentId},
+                ${inputIntent.schemaVersion},
+                ${inputIntent.strategyName},
+                ${inputIntent.cycleId},
+                ${inputIntent.decisionHash},
+                ${inputIntent.policyHash},
+                ${inputIntent.accountId},
+                ${inputIntent.clientOrderId},
+                ${inputIntent.symbol},
+                ${inputIntent.side},
+                ${inputIntent.orderType},
+                ${inputIntent.timeInForce},
+                ${inputIntent.quantityMicros},
+                ${inputIntent.notionalLimitMicros},
+                ${inputIntent.state},
+                ${inputIntent.createdAt},
+                ${inputIntent.createdAt}
+              )
+              ON CONFLICT DO NOTHING
+            `
+
+            const conflictRows = yield* selectRows(
+              sql,
+              sql`
+                intent.intent_id = ${inputIntent.intentId}
+                OR (intent.account_id = ${inputIntent.accountId} AND intent.client_order_id = ${inputIntent.clientOrderId})
+                OR (
+                  intent.account_id = ${inputIntent.accountId}
+                  AND intent.strategy_name = ${inputIntent.strategyName}
+                  AND intent.cycle_id = ${inputIntent.cycleId}
+                  AND intent.decision_hash = ${inputIntent.decisionHash}
+                  AND intent.symbol = ${inputIntent.symbol}
+                )
+              `,
+            ).pipe(Effect.flatMap((rows) => decodeStored('commit', rows)))
+            if (conflictRows.length !== 1) {
+              return yield* Effect.fail(
+                storeError('conflict', 'commit', 'intent uniqueness boundary did not resolve to one record'),
+              )
+            }
+            const existing = conflictRows[0]
+            if (immutableIntentHash(existing.intent) !== immutableIntentHash(inputIntent)) {
+              return yield* Effect.fail(
+                storeError('conflict', 'commit', 'deterministic intent identity was reused with different content'),
+              )
+            }
+            if (existing.decision !== undefined) {
+              const expectedState =
+                decision.outcome === RiskOutcome.Approved ? IntentState.Approved : IntentState.Terminal
+              if (
+                !decisionEquivalent(existing.decision, decision) ||
+                existing.intent.riskDecisionId !== decision.decisionId ||
+                existing.intent.state !== expectedState ||
+                (expectedState === IntentState.Terminal && existing.intent.terminalOutcome !== TerminalOutcome.Blocked)
+              ) {
+                return yield* Effect.fail(
+                  storeError('conflict', 'commit', 'stored intent decision diverges from the requested decision'),
+                )
+              }
+              return { record: existing, deduplicated: true } satisfies IntentReceipt
+            }
+            if (existing.intent.state !== IntentState.Planned || existing.intent.riskDecisionId !== undefined) {
+              return yield* Effect.fail(storeError('invariant', 'commit', 'intent without a decision is not PLANNED'))
+            }
+
+            const insertedDecision = yield* sql<{ decision_id: string }>`
+              INSERT INTO risk_decisions (
+                decision_id,
+                schema_version,
+                input_hash,
+                intent_id,
+                policy_hash,
+                outcome,
+                reason_codes,
+                decided_at,
+                expires_at
+              ) VALUES (
+                ${decision.decisionId},
+                ${decision.schemaVersion},
+                ${decision.inputHash},
+                ${decision.intentId},
+                ${decision.policyHash},
+                ${decision.outcome},
+                ${decision.reasonCodes},
+                ${decision.decidedAt},
+                ${decision.expiresAt}
+              )
+              ON CONFLICT DO NOTHING
+              RETURNING decision_id
+            `
+            if (insertedDecision.length !== 1) {
+              return yield* Effect.fail(
+                storeError('conflict', 'commit', 'risk decision identity was already used by different content'),
+              )
+            }
+
+            const approved = decision.outcome === RiskOutcome.Approved
+            const transitioned = yield* sql<{ intent_id: string }>`
+              UPDATE intents
+              SET
+                risk_decision_id = ${decision.decisionId},
+                state = ${approved ? IntentState.Approved : IntentState.Terminal},
+                terminal_outcome = ${approved ? null : TerminalOutcome.Blocked},
+                state_version = state_version + 1,
+                updated_at = ${decision.decidedAt}
+              WHERE intent_id = ${inputIntent.intentId} AND state = ${IntentState.Planned}
+              RETURNING intent_id
+            `
+            if (transitioned.length !== 1) {
+              return yield* Effect.fail(storeError('conflict', 'commit', 'planned intent transition lost its race'))
+            }
+
+            const stored = yield* readById('commit', inputIntent.intentId)
+            if (Option.isNone(stored)) {
+              return yield* Effect.fail(storeError('invariant', 'commit', 'committed intent cannot be read back'))
+            }
+            return { record: stored.value, deduplicated: false } satisfies IntentReceipt
+          }),
+        )
+      }),
+    )
+
+  const markIoStarted = (intentId: string, updatedAt: string) =>
+    run(
+      'mark-io-started',
+      Effect.gen(function* () {
+        const decodedId = yield* decodeIntentId(intentId).pipe(
+          Effect.mapError((cause) => storeError('decode', 'mark-io-started', 'invalid intent ID', cause)),
+        )
+        const decodedTime = yield* decodeUpdatedAt(updatedAt).pipe(
+          Effect.mapError((cause) => storeError('decode', 'mark-io-started', 'invalid transition time', cause)),
+        )
+        return yield* withFence(
+          Effect.gen(function* () {
+            const current = yield* readById('mark-io-started', decodedId)
+            if (Option.isNone(current)) {
+              return yield* Effect.fail(storeError('invariant', 'mark-io-started', 'intent does not exist'))
+            }
+            if (current.value.intent.state === IntentState.IoStarted) {
+              return { record: current.value, deduplicated: true } satisfies IntentReceipt
+            }
+            if (
+              current.value.intent.state !== IntentState.Approved ||
+              current.value.decision?.outcome !== RiskOutcome.Approved
+            ) {
+              return yield* Effect.fail(
+                storeError('invariant', 'mark-io-started', 'only an approved intent may enter IO_STARTED'),
+              )
+            }
+            const transitioned = yield* sql<{ intent_id: string }>`
+              UPDATE intents
+              SET state = ${IntentState.IoStarted}, state_version = state_version + 1, updated_at = ${decodedTime}
+              WHERE intent_id = ${decodedId} AND state = ${IntentState.Approved}
+              RETURNING intent_id
+            `
+            if (transitioned.length !== 1) {
+              return yield* Effect.fail(
+                storeError('conflict', 'mark-io-started', 'approved intent transition lost its race'),
+              )
+            }
+            const stored = yield* readById('mark-io-started', decodedId)
+            if (Option.isNone(stored)) {
+              return yield* Effect.fail(
+                storeError('invariant', 'mark-io-started', 'IO_STARTED intent cannot be read back'),
+              )
+            }
+            return { record: stored.value, deduplicated: false } satisfies IntentReceipt
+          }),
+        )
+      }),
+    )
+
+  return {
+    commit,
+    markIoStarted,
+    read: (intentId) =>
+      readById('read', intentId).pipe(
+        Effect.mapError((cause) =>
+          cause instanceof IntentStoreError ? cause : storeError('query', 'read', 'intent read failed', cause),
+        ),
+      ),
+  } satisfies IntentStoreService
+})
+
+export const IntentStoreLive = Layer.effect(IntentStore, makeStore)

--- a/services/bayn/src/execution/writer-fence.ts
+++ b/services/bayn/src/execution/writer-fence.ts
@@ -1,0 +1,105 @@
+import { PgClient } from '@effect/sql-pg'
+import { Context, Data, Effect, Layer, Schema } from 'effect'
+
+const LOCK_NAMESPACE = 1_111_578_958 // ASCII "BAYN"
+const WRITER_LEASE = 1
+
+const AcquireRows = Schema.Tuple([Schema.Tuple([Schema.Boolean, Schema.Int])])
+const HeldRows = Schema.Tuple([Schema.Tuple([Schema.Boolean])])
+
+export class WriterFenceError extends Data.TaggedError('WriterFenceError')<{
+  readonly failure: 'busy' | 'decode' | 'unavailable'
+  readonly operation: 'acquire' | 'check'
+  readonly message: string
+  readonly cause?: unknown
+}> {}
+
+export interface WriterFenceService {
+  readonly backendPid: number
+  readonly check: Effect.Effect<void, WriterFenceError>
+}
+
+export class WriterFence extends Context.Service<WriterFence, WriterFenceService>()('bayn/WriterFence') {}
+
+const unavailable = (operation: 'acquire' | 'check', cause: unknown) =>
+  new WriterFenceError({
+    failure: 'unavailable',
+    operation,
+    message: `PostgreSQL writer fence ${operation} failed`,
+    cause,
+  })
+
+const decodeFailure = (operation: 'acquire' | 'check', cause: unknown) =>
+  new WriterFenceError({
+    failure: 'decode',
+    operation,
+    message: `PostgreSQL writer fence ${operation} returned an invalid result`,
+    cause,
+  })
+
+const acquire = Effect.gen(function* () {
+  const sql = yield* PgClient.PgClient
+  const connection = yield* sql.reserve.pipe(Effect.mapError((cause) => unavailable('acquire', cause)))
+  const rows = yield* connection
+    .executeValues('SELECT pg_try_advisory_lock($1::integer, $2::integer), pg_backend_pid()', [
+      LOCK_NAMESPACE,
+      WRITER_LEASE,
+    ])
+    .pipe(Effect.mapError((cause) => unavailable('acquire', cause)))
+  const [[acquired, backendPid]] = yield* Schema.decodeUnknownEffect(AcquireRows)(rows).pipe(
+    Effect.mapError((cause) => decodeFailure('acquire', cause)),
+  )
+  if (!acquired) {
+    return yield* Effect.fail(
+      new WriterFenceError({
+        failure: 'busy',
+        operation: 'acquire',
+        message: 'another PostgreSQL session owns the paper writer fence',
+      }),
+    )
+  }
+
+  yield* Effect.addFinalizer(() =>
+    connection
+      .executeValues('SELECT pg_advisory_unlock($1::integer, $2::integer)', [LOCK_NAMESPACE, WRITER_LEASE])
+      .pipe(Effect.ignore),
+  )
+
+  const check = Effect.gen(function* () {
+    const heldRows = yield* connection
+      .executeValues(
+        `SELECT EXISTS (
+          SELECT 1
+          FROM pg_locks
+          WHERE locktype = 'advisory'
+            AND pid = pg_backend_pid()
+            AND classid = $1::integer::oid
+            AND objid = $2::integer::oid
+            AND objsubid = 2
+            AND mode = 'ExclusiveLock'
+            AND granted
+        )`,
+        [LOCK_NAMESPACE, WRITER_LEASE],
+      )
+      .pipe(Effect.mapError((cause) => unavailable('check', cause)))
+    const [[held]] = yield* Schema.decodeUnknownEffect(HeldRows)(heldRows).pipe(
+      Effect.mapError((cause) => decodeFailure('check', cause)),
+    )
+    if (!held) {
+      return yield* Effect.fail(
+        new WriterFenceError({
+          failure: 'unavailable',
+          operation: 'check',
+          message: 'PostgreSQL paper writer fence is no longer held',
+        }),
+      )
+    }
+  })
+
+  yield* check
+  return { backendPid, check } satisfies WriterFenceService
+})
+
+export const WriterFenceLive = Layer.effect(WriterFence, acquire)
+
+export const mutationFence = { namespace: LOCK_NAMESPACE, key: 2 } as const

--- a/services/bayn/src/health.test.ts
+++ b/services/bayn/src/health.test.ts
@@ -6,17 +6,21 @@ import { TestClock } from 'effect/testing'
 import { config, successfulJournal, readyState, recoveringStore } from './app-test-support'
 import { monitor, probe } from './app'
 import { EvidenceStore } from './db/evidence-store'
+import { WriterFence, WriterFenceError, type WriterFenceService } from './execution/writer-fence'
 import { Journal, type JournalService } from './ledger'
 import { MarketData, type MarketDataService } from './market-data'
 import { makeSnapshot } from './test-fixtures'
 
 describe('Bayn continuous health', () => {
+  const healthyWriter: WriterFenceService = { backendPid: 1, check: Effect.void }
+
   test('degrades on a probe defect, preserves evidence, and recovers only after a complete success', async () => {
     const initial = readyState()
     const initialEvidence = initial.evidence
     if (initialEvidence === null) throw new Error('ready fixture must contain evidence')
     const state = await Effect.runPromise(Ref.make(initial))
     let signalAvailable = false
+    let writerAvailable = true
     let accountingChecks = 0
     const marketData: MarketDataService = {
       check: Effect.suspend(() =>
@@ -32,11 +36,26 @@ describe('Bayn continuous health', () => {
       checkRun: () => Effect.sync(() => void (accountingChecks += 1)),
       journalAndReconcile: () => Effect.die(new Error('health probes must not write TigerBeetle')),
     }
-    const dependencies = (effect: Effect.Effect<void, never, MarketData | Journal | EvidenceStore>) =>
+    const writer: WriterFenceService = {
+      backendPid: 1,
+      check: Effect.suspend(() =>
+        writerAvailable
+          ? Effect.void
+          : Effect.fail(
+              new WriterFenceError({
+                failure: 'unavailable',
+                operation: 'check',
+                message: 'writer lease lost',
+              }),
+            ),
+      ),
+    }
+    const dependencies = (effect: Effect.Effect<void, never, MarketData | Journal | EvidenceStore | WriterFence>) =>
       effect.pipe(
         Effect.provideService(MarketData, marketData),
         Effect.provideService(Journal, journal),
         Effect.provideService(EvidenceStore, recoveringStore(initial)),
+        Effect.provideService(WriterFence, writer),
       )
 
     await Effect.runPromise(dependencies(probe(config, state)))
@@ -69,7 +88,22 @@ describe('Bayn continuous health', () => {
         },
       },
     })
-    expect(accountingChecks).toBe(2)
+
+    writerAvailable = false
+    await Effect.runPromise(dependencies(probe(config, state)))
+    expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
+      status: 'DEGRADED',
+      health: {
+        sequence: 4,
+        dependencies: {
+          postgresql: { status: 'UNAVAILABLE', error: expect.stringContaining('writer lease lost') },
+          signal: { status: 'AVAILABLE' },
+          tigerBeetle: { status: 'AVAILABLE' },
+          evidence: { status: 'AVAILABLE' },
+        },
+      },
+    })
+    expect(accountingChecks).toBe(3)
   })
 
   test('runs immediately and then on the configured Effect schedule', async () => {
@@ -91,6 +125,7 @@ describe('Bayn continuous health', () => {
           Effect.provideService(MarketData, marketData),
           Effect.provideService(Journal, journal),
           Effect.provideService(EvidenceStore, recoveringStore(initial)),
+          Effect.provideService(WriterFence, healthyWriter),
           Effect.forkScoped({ startImmediately: true }),
         )
         yield* Effect.yieldNow
@@ -124,6 +159,7 @@ describe('Bayn continuous health', () => {
         Effect.provideService(MarketData, marketData),
         Effect.provideService(Journal, { ...successfulJournal, checkRun: () => Effect.void }),
         Effect.provideService(EvidenceStore, recoveringStore(initial)),
+        Effect.provideService(WriterFence, healthyWriter),
       ),
     )
     await Effect.runPromise(Deferred.await(started))

--- a/services/bayn/src/health.ts
+++ b/services/bayn/src/health.ts
@@ -4,6 +4,7 @@ import type { RuntimeConfig } from './config'
 import type { FinalizedSnapshotProvenance } from './contracts'
 import { EvidenceStore, type QualificationRecord, type RecoveredEvaluationEvidence } from './db/evidence-store'
 import { operationalError, type OperationalError } from './errors'
+import { WriterFence } from './execution/writer-fence'
 import { canonicalHashV1 } from './hash'
 import { Journal } from './ledger'
 import { MarketData } from './market-data'
@@ -82,18 +83,22 @@ const dependencyHealth = (result: ProbeResult, checkedAt: string): DependencyHea
 export const probe = (
   config: RuntimeConfig,
   state: Ref.Ref<RuntimeState>,
-): Effect.Effect<void, never, MarketData | Journal | EvidenceStore> =>
+): Effect.Effect<void, never, MarketData | Journal | EvidenceStore | WriterFence> =>
   Effect.gen(function* () {
     const marketData = yield* MarketData
     const journal = yield* Journal
     const evidenceStore = yield* EvidenceStore
+    const writerFence = yield* WriterFence
     const current = yield* Ref.get(state)
     const evidence = current.evidence
     const [postgresql, signal, tigerBeetle, durableEvidence] = yield* Effect.all(
       [
         observe(
           withinDeadline(
-            databaseOperation(evidenceStore.check, 'continuous-health'),
+            databaseOperation(
+              Effect.all([evidenceStore.check, writerFence.check], { concurrency: 'unbounded' }).pipe(Effect.asVoid),
+              'continuous-health',
+            ),
             config.operationTimeoutMs,
             'database',
             'continuous-health',
@@ -179,5 +184,5 @@ export const probe = (
 export const monitor = (
   config: RuntimeConfig,
   state: Ref.Ref<RuntimeState>,
-): Effect.Effect<void, never, MarketData | Journal | EvidenceStore> =>
+): Effect.Effect<void, never, MarketData | Journal | EvidenceStore | WriterFence> =>
   probe(config, state).pipe(Effect.repeat(Schedule.spaced(Duration.millis(config.healthIntervalMs))), Effect.asVoid)

--- a/services/bayn/src/index.ts
+++ b/services/bayn/src/index.ts
@@ -7,6 +7,8 @@ import { verifyParameterHash } from './build'
 import { loadConfig } from './config'
 import { makeRuntimeProvenance } from './contracts'
 import { EvidenceStoreLive } from './db/evidence-store'
+import { IntentStoreLive } from './execution/intents'
+import { WriterFenceLive } from './execution/writer-fence'
 import { JournalLive } from './ledger'
 import { MarketDataLive } from './market-data'
 import { acquireSqlLayer } from './operations'
@@ -46,11 +48,9 @@ const main = Effect.gen(function* () {
     Layer.provide(Layer.succeedContext(clickhouse)),
     Layer.provide(NodeHttpClient.layerNodeHttp),
   )
-  const dependencies = Layer.mergeAll(
-    marketData,
-    JournalLive(config),
-    EvidenceStoreLive(config).pipe(Layer.provide(NodeServices.layer)),
-  )
+  const database = EvidenceStoreLive(config).pipe(Layer.provide(NodeServices.layer))
+  const persistence = IntentStoreLive.pipe(Layer.provideMerge(WriterFenceLive), Layer.provideMerge(database))
+  const dependencies = Layer.mergeAll(marketData, JournalLive(config), persistence)
   return yield* run(config, strategy).pipe(Effect.provide(dependencies))
 }).pipe(Effect.scoped)
 

--- a/services/bayn/src/paper.test.ts
+++ b/services/bayn/src/paper.test.ts
@@ -130,8 +130,12 @@ const source = {
 }
 
 const intent = {
-  schemaVersion: 'bayn.paper-intent.v1' as const,
+  schemaVersion: 'bayn.paper-intent.v2' as const,
   intentId: hash('4'),
+  strategyName: 'risk-balanced-trend',
+  cycleId: hash('5'),
+  decisionHash: hash('6'),
+  policyHash: hash('7'),
   accountId: account.accountId,
   clientOrderId: order.clientOrderId,
   symbol: order.symbol,

--- a/services/bayn/src/paper.ts
+++ b/services/bayn/src/paper.ts
@@ -347,9 +347,13 @@ export const BrokerEventSchema = BrokerEventBase.check(
 export type BrokerEvent = typeof BrokerEventSchema.Type
 
 const IntentBase = Schema.Struct({
-  schemaVersion: Schema.Literal('bayn.paper-intent.v1'),
+  schemaVersion: Schema.Literal('bayn.paper-intent.v2'),
   intentId: Sha256,
   riskDecisionId: Schema.optionalKey(Sha256),
+  strategyName: NonEmptyString,
+  cycleId: Sha256,
+  decisionHash: Sha256,
+  policyHash: Sha256,
   accountId: NonEmptyString,
   clientOrderId: NonEmptyString,
   symbol: SymbolName,

--- a/services/bayn/src/risk.test.ts
+++ b/services/bayn/src/risk.test.ts
@@ -183,8 +183,12 @@ const makeState = (overrides: Partial<State> = {}): State => {
 
 const makeIntent = (overrides: Partial<Intent> = {}): Intent =>
   decodeIntent({
-    schemaVersion: 'bayn.paper-intent.v1',
+    schemaVersion: 'bayn.paper-intent.v2',
     intentId: hash('6'),
+    strategyName: 'risk-balanced-trend',
+    cycleId: hash('7'),
+    decisionHash: hash('8'),
+    policyHash: canonicalHashV1(makePolicy()),
     accountId: 'paper-account-1',
     clientOrderId: 'risk-test-order-1',
     symbol: 'NVDA',

--- a/services/bayn/src/startup.test.ts
+++ b/services/bayn/src/startup.test.ts
@@ -29,6 +29,7 @@ import {
   type EvidenceStoreService,
 } from './db/evidence-store'
 import { operationalError } from './errors'
+import { WriterFence, WriterFenceError, type WriterFenceService } from './execution/writer-fence'
 import { Journal, type JournalService } from './ledger'
 import { MarketData } from './market-data'
 import { evaluateRiskBalancedTrend, summarizeEvaluation } from './risk-balanced-trend'
@@ -37,6 +38,8 @@ import type { Strategy } from './strategy'
 import { fixtureProtocol, makeSnapshot } from './test-fixtures'
 
 describe('Bayn startup lifecycle', () => {
+  const writerFence: WriterFenceService = { backendPid: 1, check: Effect.void }
+
   test('recovers a pinned terminal qualification without inspecting data or writing state', async () => {
     let forbiddenCalls = 0
     const forbidden = (message: string) =>
@@ -403,6 +406,7 @@ describe('Bayn startup lifecycle', () => {
         Effect.provideService(MarketData, marketData),
         Effect.provideService(Journal, successfulJournal),
         Effect.provideService(EvidenceStore, successfulEvidenceStore),
+        Effect.provideService(WriterFence, writerFence),
         Effect.timeoutOrElse({
           duration: 250,
           orElse: () =>
@@ -429,6 +433,7 @@ describe('Bayn startup lifecycle', () => {
         Effect.provideService(MarketData, marketDataService(Effect.succeed(makeSnapshot()))),
         Effect.provideService(Journal, journal),
         Effect.provideService(EvidenceStore, successfulEvidenceStore),
+        Effect.provideService(WriterFence, writerFence),
         Effect.timeoutOrElse({
           duration: 250,
           orElse: () =>
@@ -443,6 +448,25 @@ describe('Bayn startup lifecycle', () => {
       expect(Cause.pretty(exit.cause)).toContain('connectivity-check timed out')
       expect(Cause.pretty(exit.cause)).not.toContain('remained live')
     }
+  })
+
+  test('fails before startup work when the writer fence is unavailable', async () => {
+    const unavailable = new WriterFenceError({
+      failure: 'busy',
+      operation: 'acquire',
+      message: 'another session owns the writer fence',
+    })
+    const exit = await Effect.runPromiseExit(
+      run(config, fixtureStrategy).pipe(
+        Effect.provideService(MarketData, marketDataService(Effect.die(new Error('must not inspect Signal')))),
+        Effect.provideService(Journal, successfulJournal),
+        Effect.provideService(EvidenceStore, successfulEvidenceStore),
+        Effect.provideService(WriterFence, { backendPid: 2, check: Effect.fail(unavailable) }),
+      ),
+    )
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) expect(Cause.pretty(exit.cause)).toContain('paper writer fence is unavailable')
   })
 
   test('returns a retryable startup failure when durable evidence cannot be committed', async () => {


### PR DESCRIPTION
## Summary

- Hard-upgrade the empty paper intent contract to v2 with strategy, cycle, decision, and policy identity.
- Persist deterministic Alpaca-bounded client order IDs and atomic immutable risk decisions with exact retry convergence.
- Enforce one scoped PostgreSQL writer owner and recheck the lease inside every state-changing transaction.
- Verify the writer fence before startup work and during continuous health; broker mutation remains absent and authority remains OBSERVE.
- Refresh the architecture-specific Nix dependency hashes from the amd64 and arm64 builder results.

## Related Issues

Closes PROOMPT-374

## Testing

- bun run --filter @proompteng/bayn test: 161 passed, 32 PostgreSQL tests intentionally skipped without a test URL.
- bun run --filter @proompteng/bayn tsc
- bun run --filter @proompteng/bayn lint
- bun run --filter @proompteng/bayn lint:oxlint
- bun run --filter @proompteng/bayn lint:oxlint:type
- bun run --filter @proompteng/bayn build
- Isolated CNPG database integration suite with 30 passed and 0 failed, including approval, block, deduplication, divergent reuse, lease loss, stale-risk rollback, interruption rollback, and migration coverage.
- Read-only production preflight confirmed zero intent rows and zero risk decision rows before the hard migration.
- Initial cross-architecture image jobs produced exact Nix fixed-output hashes for amd64 and arm64; both image builds pass with the updated declarations.
- Writer-lease health regression proves a READY pod becomes DEGRADED when its reserved lease disappears.

## Breaking Changes

Migration 4 intentionally aborts when intents or risk_decisions contain rows and replaces the intent wire contract with bayn.paper-intent.v2. The production preflight is empty, so no durable intent evidence is rewritten.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] The linked Linear implementation plan documents rollout, rollback, and follow-up boundaries.