### PR TITLE
feat(bayn): add recoverable paper mutations

### DIFF
--- a/docs/bayn/architecture.md
+++ b/docs/bayn/architecture.md
@@ -4,14 +4,19 @@
 
 Bayn is a single-writer, paper-only quantitative qualification runtime. It evaluates one compiled
 `risk-balanced-trend` candidate against one immutable Signal snapshot, journals the deterministic simulation, verifies
-the accounting result, and exposes the resulting qualification evidence. It has no broker client, broker credential,
-order-submission path, or capital-promotion authority. Public status always reports maximum authority `observe`.
+the accounting result, and exposes the resulting qualification evidence. It has no runtime broker credential,
+order-submission entry point, or capital-promotion authority. The source tree includes a dormant paper-only broker adapter
+and recovery coordinator; the composition root does not build them and the pod has no broker credential. Public status
+continues to report the GitOps authority ceiling independently of that dormant code.
 
 The runtime has three external I/O boundaries:
 
 - Signal ClickHouse, read-only, for the configured finalized publication;
 - a dedicated Bayn TigerBeetle cluster for deterministic simulation accounting; and
 - the existing `EvidenceStore` interface for durable qualification evidence.
+
+The dormant paper path would add Alpaca through the existing egress proxy only after a qualified strategy, a dedicated
+paper account, a reviewed credential, and explicit GitOps authority are present.
 
 The implementation behind `EvidenceStore` is deliberately outside this document. Non-database cleanup must preserve
 that interface and every persisted evidence contract.
@@ -39,6 +44,29 @@ retryable SQL failure twice at one-second intervals; authentication and other te
 transient startup dependency failure that remains after bounded acquisition escapes the scoped runtime, closes HTTP
 and acquired clients, and lets the Deployment restart the process. A deterministic contract or evidence failure
 enters `FAILED` and keeps HTTP available for diagnosis with readiness closed.
+
+## Dormant paper mutation boundary
+
+Paper mutation uses one deliberately small transaction/I/O boundary:
+
+1. A committed approved intent and current paper authority acquire the single-writer fence.
+2. PostgreSQL records `SUBMIT_STARTED`, the exact request hash, deterministic client-order ID, and immutable broker
+   consistency delay before the first POST.
+3. Exactly one Alpaca request is made. Decoded 4xx rejections are terminal; a timeout, interruption, malformed response,
+   server response, or post-send crash remains `UNKNOWN`.
+4. Recovery waits the committed delay and performs `GET /v2/orders:by_client_order_id`. It never wraps POST or DELETE
+   in a generic retry.
+5. Cancel targets only a recorded broker order ID. A kill may permit that cancellation, but it cannot authorize a new
+   exposure-increasing intent.
+
+`mutation_events` is append-only and enforces the transition sequence, request identity, response identity, broker
+order identity, and consistency delay in PostgreSQL. Any unresolved submit or cancel blocks later exposure-increasing
+intents; terminal recovery releases that block. There is no scheduler, public order route, arbitrary order API, blind
+flatten, runtime registry, or alternate writer.
+
+This path is intentionally dormant: `src/index.ts` does not provide `BrokerMutation` or invoke the coordinator, GitOps
+does not mount an Alpaca credential, and the current qualification is not execution authority. Enabling paper operation
+requires a separate reviewed change and live readback against the dedicated paper account.
 
 ## Effect composition
 

--- a/docs/bayn/contracts/v1.md
+++ b/docs/bayn/contracts/v1.md
@@ -4,8 +4,8 @@ This is the stable documentation path for Bayn's current versioned evaluation co
 live in `services/bayn/src/contracts.ts`; individual schemas carry their own versions. Decoders reject excess fields,
 unknown versions, malformed values, and cross-field invariant failures.
 
-These contracts do not grant deployment authority. Bayn remains observe-only and contains no broker client or
-credential.
+These contracts do not grant deployment authority. Bayn remains observe-only. Its dormant paper mutation source is not
+composed by the runtime and the pod contains no broker credential.
 
 ## Canonical representation
 
@@ -95,7 +95,8 @@ Runtime status is an operational HTTP view, not a persisted versioned evidence c
 - `economic.verdict` contains the economic gate result and `qualification.verdict` contains the terminal qualification
   result. Neither is an execution flag; authority remains a separate fixed field.
 - Accounting is `UNKNOWN`, `EXACT`, or `UNAVAILABLE`.
-- Authority is fixed at maximum `observe`; broker orders and capital promotion are always false.
+- The deployed authority ceiling is `observe`; broker orders and capital promotion remain false. Dormant mutation code
+  does not change either fact.
 
 The removed freshness, kill-state, paper, and live-bounded axes are not current Bayn contracts and must not be
 reintroduced in documentation without corresponding executable schemas and behavior.

--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -2,7 +2,8 @@
 
 Bayn is a single-writer, paper-only quantitative qualification runtime. Its current protocol evaluates the frozen
 risk-balanced trend candidate on the authoritative infrastructure-equity universe and journals the resulting simulation
-to TigerBeetle. Bayn contains no broker client or capital-promotion path.
+to TigerBeetle. Its source contains a dormant, paper-only Alpaca mutation capability, but the deployed composition has
+no broker credentials, mutation layer, execution entry point, or capital-promotion path.
 
 ## Runtime contract
 
@@ -10,14 +11,17 @@ to TigerBeetle. Bayn contains no broker client or capital-promotion path.
 - Effect Config validates environment input. `BAYN_OPERATION_TIMEOUT_MS` bounds dependency operations, and
   `BAYN_HEALTH_INTERVAL_MS` controls the continuous health interval; both default to 30 seconds.
 - `BAYN_MAXIMUM_AUTHORITY` is a closed `OBSERVE`/`PAPER` process ceiling and defaults to `OBSERVE`. It never creates a
-  broker capability; the deployed runtime remains `OBSERVE` and contains no submit, cancel, or replace path.
+  broker capability; the deployed runtime remains `OBSERVE` and does not compose the submit/cancel capability.
 - Public egress is denied from the Bayn Pod. A separate CONNECT proxy permits only
-  `paper-api.alpaca.markets:443`; the service has no broker credential or client until a later reviewed slice.
+  `paper-api.alpaca.markets:443`. The pod has no broker credential, so the dormant client cannot authenticate or run.
 - Signal ClickHouse is read-only at runtime. Data publication and provider credentials are owned by the separate Signal
   adjusted-daily publisher; Bayn contains no DDL or backfill command.
 - Bayn owns a two-instance CloudNativePG cluster. The runtime uses the generated application URI over verified TLS,
   runs versioned Effect SQL migrations at startup, and keeps a two-connection pool for its single-writer operation plus
   query cancellation.
+- PostgreSQL stores paper mutation transitions in one append-only `mutation_events` table. Request identity, broker
+  response identity, and the lookup delay are committed before use; unresolved outcomes block later exposure. The
+  deployed observe-only runtime does not create mutation rows.
 - The composition root builds one pure strategy value and passes it explicitly to the lifecycle. Effect services and
   layers are reserved for I/O resources. The compiled `bayn.risk-balanced-trend.protocol.v2` owns its authoritative
   universe and execution contract; the HTTP and startup lifecycle remain strategy-independent.
@@ -64,9 +68,9 @@ to TigerBeetle. Bayn contains no broker client or capital-promotion path.
   Any terminal-result failure rolls the evaluation graph back and leaves the lock visibly incomplete. An incomplete
   lock is never silently retried and blocks every new candidate; a locked candidate cannot bypass the terminal result
   through the ordinary persistence path.
-- One current-only initial migration creates the unprefixed evidence and qualification schema. Startup rejects a
-  legacy migration tracker or retired migration history after the hard cut; it never reads, converts, or falls back to
-  legacy records.
+- The current-only migration chain owns the unprefixed evidence, qualification, intent, and mutation schema. Startup
+  rejects a legacy migration tracker or retired migration history after the hard cut; it never reads, converts, or
+  falls back to legacy records.
 - The execution path and independent reducer use integer micros for cash, quantity, prices, spread, slippage, fees,
   cash yield, positions, and every marked-equity point. Full, partial, and rejected orders are durable. Evaluation and
   recovery require exact zero-difference cash, fee, position, and equity reconstruction.

--- a/services/bayn/migrations/0005_mutation_recovery.ts
+++ b/services/bayn/migrations/0005_mutation_recovery.ts
@@ -1,0 +1,160 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient
+
+  yield* sql`
+    CREATE TABLE mutation_events (
+      event_id text PRIMARY KEY CHECK (event_id ~ '^[0-9a-f]{64}$'),
+      schema_version text NOT NULL CHECK (schema_version = 'bayn.paper-mutation-event.v1'),
+      mutation_id text NOT NULL CHECK (mutation_id ~ '^[0-9a-f]{64}$'),
+      intent_id text NOT NULL REFERENCES intents(intent_id) ON DELETE RESTRICT,
+      sequence bigint NOT NULL CHECK (sequence > 0),
+      operation text NOT NULL CHECK (operation IN ('SUBMIT', 'CANCEL')),
+      event_type text NOT NULL CHECK (event_type IN (
+        'SUBMIT_STARTED',
+        'SUBMIT_ACCEPTED',
+        'SUBMIT_REJECTED',
+        'SUBMIT_UNKNOWN',
+        'RECOVERY_FOUND',
+        'RECOVERY_NOT_FOUND',
+        'RECOVERY_UNKNOWN',
+        'CANCEL_STARTED',
+        'CANCEL_ACCEPTED',
+        'CANCEL_UNKNOWN'
+      )),
+      request_hash text NOT NULL CHECK (request_hash ~ '^[0-9a-f]{64}$'),
+      consistency_delay_ms integer NOT NULL CHECK (consistency_delay_ms BETWEEN 1 AND 300000),
+      broker_order_id text CHECK (
+        length(broker_order_id) > 0 AND broker_order_id = btrim(broker_order_id)
+      ),
+      request_id text CHECK (length(request_id) > 0 AND request_id = btrim(request_id)),
+      response_status smallint CHECK (response_status BETWEEN 100 AND 599),
+      response_content_hash text CHECK (response_content_hash ~ '^[0-9a-f]{64}$'),
+      occurred_at timestamptz NOT NULL,
+      UNIQUE (mutation_id, sequence),
+      UNIQUE (intent_id, operation, sequence),
+      CHECK (
+        (request_id IS NULL AND response_status IS NULL AND response_content_hash IS NULL)
+        OR (request_id IS NOT NULL AND response_status IS NOT NULL AND response_content_hash IS NOT NULL)
+      ),
+      CHECK (
+        (event_type = 'SUBMIT_STARTED' AND operation = 'SUBMIT' AND broker_order_id IS NULL AND response_status IS NULL)
+        OR (
+          event_type = 'SUBMIT_ACCEPTED'
+          AND operation = 'SUBMIT'
+          AND broker_order_id IS NOT NULL
+          AND response_status = 200
+        )
+        OR (
+          event_type = 'SUBMIT_REJECTED'
+          AND operation = 'SUBMIT'
+          AND broker_order_id IS NULL
+          AND response_status IN (400, 401, 403, 404, 422)
+        )
+        OR (event_type = 'SUBMIT_UNKNOWN' AND operation = 'SUBMIT' AND broker_order_id IS NULL)
+        OR (event_type = 'RECOVERY_FOUND' AND broker_order_id IS NOT NULL AND response_status = 200)
+        OR (
+          event_type = 'RECOVERY_NOT_FOUND'
+          AND response_status = 404
+          AND (
+            (operation = 'SUBMIT' AND broker_order_id IS NULL)
+            OR (operation = 'CANCEL' AND broker_order_id IS NOT NULL)
+          )
+        )
+        OR (event_type = 'RECOVERY_UNKNOWN')
+        OR (event_type = 'CANCEL_STARTED' AND operation = 'CANCEL' AND broker_order_id IS NOT NULL AND response_status IS NULL)
+        OR (
+          event_type = 'CANCEL_ACCEPTED'
+          AND operation = 'CANCEL'
+          AND broker_order_id IS NOT NULL
+          AND response_status = 204
+        )
+        OR (event_type = 'CANCEL_UNKNOWN' AND operation = 'CANCEL' AND broker_order_id IS NOT NULL)
+      )
+    )
+  `
+
+  yield* sql`
+    CREATE UNIQUE INDEX mutation_events_one_start
+    ON mutation_events(intent_id, operation)
+    WHERE sequence = 1
+  `
+
+  yield* sql`
+    CREATE FUNCTION enforce_mutation_event_transition()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+    DECLARE
+      previous mutation_events%ROWTYPE;
+    BEGIN
+      SELECT * INTO previous
+      FROM mutation_events
+      WHERE mutation_id = NEW.mutation_id
+      ORDER BY sequence DESC
+      LIMIT 1
+      FOR UPDATE;
+
+      IF NOT FOUND THEN
+        IF NEW.sequence <> 1 OR NEW.event_type NOT IN ('SUBMIT_STARTED', 'CANCEL_STARTED') THEN
+          RAISE EXCEPTION 'mutation must begin with its STARTED event' USING ERRCODE = '23514';
+        END IF;
+        RETURN NEW;
+      END IF;
+
+      IF NEW.sequence <> previous.sequence + 1
+        OR NEW.intent_id <> previous.intent_id
+        OR NEW.operation <> previous.operation
+        OR NEW.request_hash <> previous.request_hash
+        OR NEW.consistency_delay_ms <> previous.consistency_delay_ms
+        OR NEW.occurred_at < previous.occurred_at
+      THEN
+        RAISE EXCEPTION 'mutation identity and sequence must remain exact' USING ERRCODE = '23514';
+      END IF;
+
+      IF previous.broker_order_id IS NOT NULL
+        AND NEW.broker_order_id IS DISTINCT FROM previous.broker_order_id
+      THEN
+        RAISE EXCEPTION 'mutation broker order identity cannot change' USING ERRCODE = '23514';
+      END IF;
+
+      IF NOT (CASE previous.event_type
+        WHEN 'SUBMIT_STARTED' THEN NEW.event_type IN ('SUBMIT_ACCEPTED', 'SUBMIT_REJECTED', 'SUBMIT_UNKNOWN')
+        WHEN 'SUBMIT_UNKNOWN' THEN NEW.event_type IN ('RECOVERY_FOUND', 'RECOVERY_NOT_FOUND', 'RECOVERY_UNKNOWN')
+        WHEN 'CANCEL_STARTED' THEN NEW.event_type IN ('CANCEL_ACCEPTED', 'CANCEL_UNKNOWN')
+        WHEN 'CANCEL_ACCEPTED' THEN NEW.event_type IN ('RECOVERY_FOUND', 'RECOVERY_NOT_FOUND', 'RECOVERY_UNKNOWN')
+        WHEN 'CANCEL_UNKNOWN' THEN NEW.event_type IN ('RECOVERY_FOUND', 'RECOVERY_NOT_FOUND', 'RECOVERY_UNKNOWN')
+        WHEN 'RECOVERY_NOT_FOUND' THEN NEW.event_type IN ('RECOVERY_FOUND', 'RECOVERY_NOT_FOUND', 'RECOVERY_UNKNOWN')
+        WHEN 'RECOVERY_UNKNOWN' THEN NEW.event_type IN ('RECOVERY_FOUND', 'RECOVERY_NOT_FOUND', 'RECOVERY_UNKNOWN')
+        WHEN 'RECOVERY_FOUND' THEN
+          previous.operation = 'CANCEL'
+          AND NEW.event_type IN ('RECOVERY_FOUND', 'RECOVERY_NOT_FOUND', 'RECOVERY_UNKNOWN')
+        ELSE false
+      END) THEN
+        RAISE EXCEPTION 'invalid mutation transition from % to %', previous.event_type, NEW.event_type
+          USING ERRCODE = '23514';
+      END IF;
+
+      RETURN NEW;
+    END
+    $function$
+  `
+
+  yield* sql`
+    CREATE TRIGGER mutation_event_transition_only
+    BEFORE INSERT ON mutation_events
+    FOR EACH ROW EXECUTE FUNCTION enforce_mutation_event_transition()
+  `
+  yield* sql`
+    CREATE TRIGGER mutation_events_append_only
+    BEFORE UPDATE OR DELETE ON mutation_events
+    FOR EACH ROW EXECUTE FUNCTION reject_evidence_mutation()
+  `
+  yield* sql`
+    CREATE TRIGGER mutation_events_reject_truncate
+    BEFORE TRUNCATE ON mutation_events
+    FOR EACH STATEMENT EXECUTE FUNCTION reject_evidence_mutation()
+  `
+})

--- a/services/bayn/src/broker/alpaca-mutations.test.ts
+++ b/services/bayn/src/broker/alpaca-mutations.test.ts
@@ -20,6 +20,19 @@ const accountId = 'e6fe16f3-64a4-4921-8928-cadf02f92f98'
 const orderId = '61e69015-8549-4bfd-b9c3-01e75843f47d'
 const assetId = 'b0b6dd9d-8b9b-48a9-ba46-b9d54906e415'
 
+const accountResponse = {
+  id: accountId,
+  account_number: '010203ABCD',
+  status: 'ACTIVE',
+  currency: 'USD',
+  cash: '100000',
+  equity: '100000',
+  buying_power: '200000',
+  account_blocked: false,
+  trading_blocked: false,
+  trade_suspended_by_user: false,
+}
+
 const options: MutationOptions = {
   expectedAccountId: accountId,
   key: Redacted.make('paper-key'),
@@ -102,12 +115,21 @@ const response = (
     }),
   )
 
+const withVerifiedAccount = (client: HttpClient.HttpClient): HttpClient.HttpClient =>
+  HttpClient.make((request, url) =>
+    url.pathname === '/v2/account' ? Effect.succeed(response(request, accountResponse)) : client.execute(request),
+  )
+
 const withMutation = <A, E>(
   client: HttpClient.HttpClient,
   use: (mutation: BrokerMutationShape) => Effect.Effect<A, E>,
   mutationOptions: MutationOptions = options,
-): Effect.Effect<A, BrokerMutationError | E> =>
-  makeMutation(mutationOptions).pipe(Effect.flatMap(use), Effect.provideService(HttpClient.HttpClient, client))
+): Effect.Effect<A, BrokerMutationError | E> => {
+  return makeMutation(mutationOptions).pipe(
+    Effect.flatMap(use),
+    Effect.provideService(HttpClient.HttpClient, withVerifiedAccount(client)),
+  )
+}
 
 const requestBody = (request: Parameters<Parameters<typeof HttpClient.make>[0]>[0]): unknown => {
   if (request.body._tag !== 'Uint8Array') throw new Error('expected a JSON request body')
@@ -115,6 +137,26 @@ const requestBody = (request: Parameters<Parameters<typeof HttpClient.make>[0]>[
 }
 
 describe('Alpaca paper mutations', () => {
+  test('refuses to expose mutation capability when the credentials resolve a different account', async () => {
+    let mutationCalls = 0
+    const client = HttpClient.make(() => {
+      mutationCalls += 1
+      return Effect.die(new Error('mutation request must not run'))
+    })
+    const wrongAccount = '40b22fc4-23bc-446c-bf07-bea43b5d6c35'
+
+    const failure = await Effect.runPromise(
+      Effect.flip(withMutation(client, () => Effect.void, { ...options, expectedAccountId: wrongAccount })),
+    )
+
+    expect(failure).toMatchObject({
+      operation: MutationOperation.Submit,
+      failure: MutationFailure.Configuration,
+      outcome: MutationOutcome.Known,
+    })
+    expect(mutationCalls).toBe(0)
+  })
+
   test('submits the exact IO_STARTED intent once and verifies the accepted order', async () => {
     const requests: Array<{ body: unknown; method: string; url: string }> = []
     const client = HttpClient.make((request, url) => {
@@ -217,7 +259,7 @@ describe('Alpaca paper mutations', () => {
           return yield* Fiber.join(fiber)
         }),
       ),
-      Effect.provideService(HttpClient.HttpClient, client),
+      Effect.provideService(HttpClient.HttpClient, withVerifiedAccount(client)),
       Effect.provide(TestClock.layer()),
     )
 
@@ -250,7 +292,7 @@ describe('Alpaca paper mutations', () => {
           return yield* Fiber.join(fiber)
         }),
       ),
-      Effect.provideService(HttpClient.HttpClient, client),
+      Effect.provideService(HttpClient.HttpClient, withVerifiedAccount(client)),
       Effect.provide(TestClock.layer()),
     )
 

--- a/services/bayn/src/broker/alpaca-mutations.test.ts
+++ b/services/bayn/src/broker/alpaca-mutations.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Effect, Fiber, Redacted } from 'effect'
+import { TestClock } from 'effect/testing'
+import { HttpClient, HttpClientResponse } from 'effect/unstable/http'
+
+import { canonicalHashV1 } from '../hash'
+import { IntentState, MutationOutcome, OrderSide, OrderType, TimeInForce, type Intent } from '../paper'
+import {
+  BrokerMutationError,
+  MutationFailure,
+  MutationOperation,
+  makeMutation,
+  type BrokerMutationShape,
+  type MutationOptions,
+} from './alpaca-mutations'
+import { OrderStatus } from './alpaca'
+
+const accountId = 'e6fe16f3-64a4-4921-8928-cadf02f92f98'
+const orderId = '61e69015-8549-4bfd-b9c3-01e75843f47d'
+const assetId = 'b0b6dd9d-8b9b-48a9-ba46-b9d54906e415'
+
+const options: MutationOptions = {
+  expectedAccountId: accountId,
+  key: Redacted.make('paper-key'),
+  secret: Redacted.make('paper-secret'),
+  proxyUrl: 'http://bayn-egress-proxy:3128',
+  operationTimeoutMs: 1_000,
+}
+
+const intent: Intent = {
+  schemaVersion: 'bayn.paper-intent.v2',
+  intentId: 'a'.repeat(64),
+  riskDecisionId: 'b'.repeat(64),
+  strategyName: 'risk-balanced-trend',
+  cycleId: 'c'.repeat(64),
+  decisionHash: 'd'.repeat(64),
+  policyHash: 'e'.repeat(64),
+  accountId,
+  clientOrderId: `b1_${'A'.repeat(43)}`,
+  symbol: 'AMD',
+  side: OrderSide.Buy,
+  orderType: OrderType.Market,
+  timeInForce: TimeInForce.Day,
+  quantityMicros: '1250000',
+  notionalLimitMicros: '200000000',
+  state: IntentState.IoStarted,
+  createdAt: '2026-07-22T12:00:00.000Z',
+}
+
+const orderResponse = {
+  id: orderId,
+  client_order_id: intent.clientOrderId,
+  created_at: '2026-07-22T12:00:01.100Z',
+  updated_at: '2026-07-22T12:00:01.100Z',
+  submitted_at: '2026-07-22T12:00:01.000Z',
+  filled_at: null,
+  expired_at: null,
+  canceled_at: null,
+  failed_at: null,
+  replaced_at: null,
+  replaced_by: null,
+  replaces: null,
+  asset_id: assetId,
+  symbol: intent.symbol,
+  asset_class: 'us_equity',
+  notional: null,
+  qty: '1.25',
+  filled_qty: '0',
+  filled_avg_price: null,
+  order_class: '',
+  order_type: 'market',
+  type: 'market',
+  side: 'buy',
+  time_in_force: 'day',
+  limit_price: null,
+  stop_price: null,
+  status: 'accepted',
+  extended_hours: false,
+  legs: null,
+  trail_percent: null,
+  trail_price: null,
+  hwm: null,
+}
+
+const responseHeaders = {
+  'content-type': 'application/json',
+  'x-request-id': 'req-123',
+}
+
+const response = (
+  request: Parameters<typeof HttpClientResponse.fromWeb>[0],
+  body: unknown,
+  status = 200,
+  headers: Record<string, string> = responseHeaders,
+) =>
+  HttpClientResponse.fromWeb(
+    request,
+    new Response(status === 204 ? null : JSON.stringify(body), {
+      status,
+      headers,
+    }),
+  )
+
+const withMutation = <A, E>(
+  client: HttpClient.HttpClient,
+  use: (mutation: BrokerMutationShape) => Effect.Effect<A, E>,
+  mutationOptions: MutationOptions = options,
+): Effect.Effect<A, BrokerMutationError | E> =>
+  makeMutation(mutationOptions).pipe(Effect.flatMap(use), Effect.provideService(HttpClient.HttpClient, client))
+
+const requestBody = (request: Parameters<Parameters<typeof HttpClient.make>[0]>[0]): unknown => {
+  if (request.body._tag !== 'Uint8Array') throw new Error('expected a JSON request body')
+  return JSON.parse(new TextDecoder().decode(request.body.body))
+}
+
+describe('Alpaca paper mutations', () => {
+  test('submits the exact IO_STARTED intent once and verifies the accepted order', async () => {
+    const requests: Array<{ body: unknown; method: string; url: string }> = []
+    const client = HttpClient.make((request, url) => {
+      requests.push({ body: requestBody(request), method: request.method, url: url.toString() })
+      return Effect.succeed(response(request, orderResponse))
+    })
+
+    const receipt = await Effect.runPromise(withMutation(client, (mutation) => mutation.submit(intent)))
+
+    const body = {
+      symbol: 'AMD',
+      qty: '1.25',
+      side: 'buy',
+      type: 'market',
+      time_in_force: 'day',
+      client_order_id: intent.clientOrderId,
+      extended_hours: false,
+    }
+    expect(requests).toEqual([{ body, method: 'POST', url: 'https://paper-api.alpaca.markets/v2/orders' }])
+    expect(receipt).toMatchObject({
+      requestHash: canonicalHashV1(body),
+      order: {
+        accountId,
+        brokerOrderId: orderId,
+        clientOrderId: intent.clientOrderId,
+        status: OrderStatus.Accepted,
+        quantityMicros: intent.quantityMicros,
+      },
+      evidence: {
+        requestId: 'req-123',
+        status: 200,
+        contentHash: canonicalHashV1(orderResponse),
+      },
+    })
+  })
+
+  test('fails before I/O for an unmarked intent or unsupported fractional GTC order', async () => {
+    let calls = 0
+    const client = HttpClient.make((request) => {
+      calls += 1
+      return Effect.succeed(response(request, orderResponse))
+    })
+    const approved = { ...intent, state: IntentState.Approved }
+    const fractionalGtc = { ...intent, timeInForce: TimeInForce.GoodUntilCanceled }
+
+    const failures = await Effect.runPromise(
+      Effect.all([
+        Effect.flip(withMutation(client, (mutation) => mutation.submit(approved))),
+        Effect.flip(withMutation(client, (mutation) => mutation.submit(fractionalGtc))),
+      ]),
+    )
+
+    expect(failures).toEqual([
+      expect.objectContaining({ failure: MutationFailure.InvalidRequest, outcome: MutationOutcome.Known }),
+      expect.objectContaining({ failure: MutationFailure.InvalidRequest, outcome: MutationOutcome.Known }),
+    ])
+    expect(calls).toBe(0)
+  })
+
+  test('classifies a decoded 422 as a known rejection and never retries', async () => {
+    let calls = 0
+    const error = { code: 40310000, message: 'insufficient buying power' }
+    const client = HttpClient.make((request) => {
+      calls += 1
+      return Effect.succeed(response(request, error, 422))
+    })
+
+    const failure = await Effect.runPromise(Effect.flip(withMutation(client, (mutation) => mutation.submit(intent))))
+
+    expect(failure).toMatchObject({
+      operation: MutationOperation.Submit,
+      failure: MutationFailure.Rejected,
+      outcome: MutationOutcome.Known,
+      brokerCode: '40310000',
+      evidence: { status: 422, requestId: 'req-123', contentHash: canonicalHashV1(error) },
+    })
+    expect(calls).toBe(1)
+  })
+
+  test('interrupts a timed-out submit and reports UNKNOWN without retry', async () => {
+    let calls = 0
+    let interrupted = false
+    const client = HttpClient.make(() => {
+      calls += 1
+      return Effect.never.pipe(
+        Effect.onInterrupt(() =>
+          Effect.sync(() => {
+            interrupted = true
+          }),
+        ),
+      )
+    })
+
+    const program = makeMutation({ ...options, operationTimeoutMs: 10 }).pipe(
+      Effect.flatMap((mutation) =>
+        Effect.gen(function* () {
+          const fiber = yield* Effect.flip(mutation.submit(intent)).pipe(Effect.forkChild)
+          yield* Effect.yieldNow
+          yield* TestClock.adjust(10)
+          return yield* Fiber.join(fiber)
+        }),
+      ),
+      Effect.provideService(HttpClient.HttpClient, client),
+      Effect.provide(TestClock.layer()),
+    )
+
+    const failure = await Effect.runPromise(program)
+    expect(failure).toMatchObject({
+      operation: MutationOperation.Submit,
+      failure: MutationFailure.Unknown,
+      outcome: MutationOutcome.Unknown,
+    })
+    expect(calls).toBe(1)
+    expect(interrupted).toBe(true)
+  })
+
+  test('applies the mutation deadline while the broker response body is still streaming', async () => {
+    let calls = 0
+    const client = HttpClient.make((request) => {
+      calls += 1
+      const body = new ReadableStream<Uint8Array>({ start: () => undefined })
+      return Effect.succeed(
+        HttpClientResponse.fromWeb(request, new Response(body, { status: 200, headers: responseHeaders })),
+      )
+    })
+
+    const program = makeMutation({ ...options, operationTimeoutMs: 10 }).pipe(
+      Effect.flatMap((mutation) =>
+        Effect.gen(function* () {
+          const fiber = yield* Effect.flip(mutation.submit(intent)).pipe(Effect.forkChild)
+          yield* Effect.yieldNow
+          yield* TestClock.adjust(10)
+          return yield* Fiber.join(fiber)
+        }),
+      ),
+      Effect.provideService(HttpClient.HttpClient, client),
+      Effect.provide(TestClock.layer()),
+    )
+
+    const failure = await Effect.runPromise(program)
+    expect(failure).toMatchObject({
+      operation: MutationOperation.Submit,
+      failure: MutationFailure.Unknown,
+      outcome: MutationOutcome.Unknown,
+    })
+    expect(calls).toBe(1)
+  })
+
+  test('cancels a positively identified order once; every non-204 result requires lookup', async () => {
+    let status = 204
+    const requests: Array<{ method: string; url: string }> = []
+    const client = HttpClient.make((request, url) => {
+      requests.push({ method: request.method, url: url.toString() })
+      return Effect.succeed(response(request, { code: 500, message: 'unknown' }, status))
+    })
+
+    const receipt = await Effect.runPromise(withMutation(client, (mutation) => mutation.cancel(orderId)))
+    expect(receipt).toMatchObject({
+      brokerOrderId: orderId,
+      evidence: { status: 204, requestId: 'req-123', contentHash: canonicalHashV1(null) },
+    })
+
+    status = 500
+    const failure = await Effect.runPromise(Effect.flip(withMutation(client, (mutation) => mutation.cancel(orderId))))
+    expect(failure).toMatchObject({
+      operation: MutationOperation.Cancel,
+      failure: MutationFailure.Unknown,
+      outcome: MutationOutcome.Unknown,
+      evidence: {
+        status: 500,
+        requestId: 'req-123',
+        contentHash: canonicalHashV1({ code: 500, message: 'unknown' }),
+      },
+    })
+    expect(requests).toEqual([
+      { method: 'DELETE', url: `https://paper-api.alpaca.markets/v2/orders/${orderId}` },
+      { method: 'DELETE', url: `https://paper-api.alpaca.markets/v2/orders/${orderId}` },
+    ])
+  })
+})

--- a/services/bayn/src/broker/alpaca-mutations.ts
+++ b/services/bayn/src/broker/alpaca-mutations.ts
@@ -18,6 +18,7 @@ import {
   OrderType,
   TimeInForce,
   alpacaHttpLayer,
+  make as makeRead,
   normalizeOrder,
   paperTradingUrl,
   type Order,
@@ -281,6 +282,19 @@ export const makeMutation = (
       )
     }
     const client = yield* HttpClient.HttpClient
+    const read = yield* makeRead({
+      expectedAccountId: runtime.expectedAccountId,
+      key: options.key,
+      secret: options.secret,
+      proxyUrl: options.proxyUrl,
+      operationTimeoutMs: runtime.operationTimeoutMs,
+      retryAttempts: 0,
+    }).pipe(
+      Effect.mapError((cause) => configurationError('Alpaca mutation account verification could not start', cause)),
+    )
+    yield* read.account.pipe(
+      Effect.mapError((cause) => configurationError('Alpaca mutation account verification failed', cause)),
+    )
 
     const submit = (input: Intent) =>
       Effect.gen(function* () {

--- a/services/bayn/src/broker/alpaca-mutations.ts
+++ b/services/bayn/src/broker/alpaca-mutations.ts
@@ -1,0 +1,501 @@
+import { Cause, Clock, Context, Data, Effect, Layer, Redacted, Schema } from 'effect'
+import { Headers, HttpClient, HttpClientRequest, HttpClientResponse } from 'effect/unstable/http'
+
+import { canonicalHashV1 } from '../hash'
+import {
+  IntentSchema,
+  IntentState,
+  MutationOutcome,
+  OrderSide as DomainSide,
+  OrderType as DomainOrderType,
+  TimeInForce as DomainTimeInForce,
+  type Intent,
+} from '../paper'
+import { StrictNonEmptyStringSchema as NonEmptyString, UtcInstantSchema as UtcInstant } from '../schemas'
+import {
+  OrderResponseSchema,
+  OrderSide,
+  OrderType,
+  TimeInForce,
+  alpacaHttpLayer,
+  normalizeOrder,
+  paperTradingUrl,
+  type Order,
+} from './alpaca'
+
+const responseParseOptions = { onExcessProperty: 'ignore' } as const
+const inputParseOptions = { onExcessProperty: 'error' } as const
+const redactedHeaders = [
+  'authorization',
+  'cookie',
+  'set-cookie',
+  'x-api-key',
+  'apca-api-key-id',
+  'apca-api-secret-key',
+] as const
+
+const Uuid = Schema.String.check(
+  Schema.isPattern(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/),
+)
+const RequestId = NonEmptyString.check(Schema.isMaxLength(256))
+const ErrorCode = Schema.Union([NonEmptyString.check(Schema.isMaxLength(64)), Schema.Int])
+const ErrorMessage = NonEmptyString.check(Schema.isMaxLength(1_000))
+const PositiveInteger = Schema.Int.check(Schema.isGreaterThan(0))
+
+const ResponseHeadersSchema = Schema.Struct({
+  'x-request-id': RequestId,
+})
+const ErrorResponseSchema = Schema.Struct({
+  code: ErrorCode,
+  message: ErrorMessage,
+})
+const OptionsSchema = Schema.Struct({
+  expectedAccountId: Uuid,
+  operationTimeoutMs: PositiveInteger,
+})
+
+const decodeHeaders = HttpClientResponse.schemaHeaders(ResponseHeadersSchema, responseParseOptions)
+const decodeErrorResponse = Schema.decodeUnknownEffect(ErrorResponseSchema, responseParseOptions)
+const decodeOrderResponse = Schema.decodeUnknownEffect(OrderResponseSchema, responseParseOptions)
+const decodeIntent = Schema.decodeUnknownEffect(IntentSchema, inputParseOptions)
+const decodeOptions = Schema.decodeUnknownEffect(OptionsSchema, inputParseOptions)
+
+export enum MutationOperation {
+  Submit = 'SUBMIT',
+  Cancel = 'CANCEL',
+}
+
+export enum MutationFailure {
+  Configuration = 'CONFIGURATION',
+  InvalidRequest = 'INVALID_REQUEST',
+  Rejected = 'REJECTED',
+  Unknown = 'UNKNOWN',
+}
+
+export const MutationEvidenceSchema = Schema.Struct({
+  requestId: RequestId,
+  status: Schema.Int.check(Schema.isBetween({ minimum: 100, maximum: 599 })),
+  contentHash: Schema.String.check(Schema.isPattern(/^[0-9a-f]{64}$/)),
+  observedAt: UtcInstant,
+})
+export type MutationEvidence = typeof MutationEvidenceSchema.Type
+
+export class BrokerMutationError extends Data.TaggedError('BrokerMutationError')<{
+  readonly operation: MutationOperation
+  readonly failure: MutationFailure
+  readonly outcome: MutationOutcome
+  readonly message: string
+  readonly requestHash?: string
+  readonly evidence?: Partial<MutationEvidence>
+  readonly brokerCode?: string
+  readonly cause?: Readonly<Record<string, string>>
+}> {}
+
+export interface MutationOptions {
+  readonly expectedAccountId: string
+  readonly key: Redacted.Redacted<string>
+  readonly secret: Redacted.Redacted<string>
+  readonly proxyUrl: string
+  readonly operationTimeoutMs: number
+}
+
+export interface SubmitReceipt {
+  readonly requestHash: string
+  readonly order: Order
+  readonly evidence: MutationEvidence
+}
+
+export interface CancelReceipt {
+  readonly requestHash: string
+  readonly brokerOrderId: string
+  readonly evidence: MutationEvidence
+}
+
+export interface BrokerMutationShape {
+  readonly submit: (intent: Intent) => Effect.Effect<SubmitReceipt, BrokerMutationError>
+  readonly cancel: (brokerOrderId: string) => Effect.Effect<CancelReceipt, BrokerMutationError>
+}
+
+export class BrokerMutation extends Context.Service<BrokerMutation, BrokerMutationShape>()('bayn/BrokerMutation') {}
+
+const causeSummary = (cause: unknown): Readonly<Record<string, string>> => {
+  if (Schema.isSchemaError(cause)) return { tag: cause._tag, message: cause.message }
+  if (typeof cause === 'object' && cause !== null && '_tag' in cause && typeof cause._tag === 'string') {
+    const reason =
+      'reason' in cause && typeof cause.reason === 'object' && cause.reason !== null && '_tag' in cause.reason
+        ? String(cause.reason._tag)
+        : undefined
+    return { tag: cause._tag, ...(reason === undefined ? {} : { reason }) }
+  }
+  if (cause instanceof Error) return { tag: cause.name }
+  return { tag: typeof cause }
+}
+
+const configurationError = (message: string, cause?: unknown) =>
+  new BrokerMutationError({
+    operation: MutationOperation.Submit,
+    failure: MutationFailure.Configuration,
+    outcome: MutationOutcome.Known,
+    message,
+    cause: cause === undefined ? undefined : causeSummary(cause),
+  })
+
+const invalidRequest = (operation: MutationOperation, message: string, cause?: unknown) =>
+  new BrokerMutationError({
+    operation,
+    failure: MutationFailure.InvalidRequest,
+    outcome: MutationOutcome.Known,
+    message,
+    cause: cause === undefined ? undefined : causeSummary(cause),
+  })
+
+const unknownOutcome = (
+  operation: MutationOperation,
+  message: string,
+  requestHash?: string,
+  evidence?: Partial<MutationEvidence>,
+  cause?: unknown,
+) =>
+  new BrokerMutationError({
+    operation,
+    failure: MutationFailure.Unknown,
+    outcome: MutationOutcome.Unknown,
+    message,
+    requestHash,
+    evidence,
+    cause: cause === undefined ? undefined : causeSummary(cause),
+  })
+
+const knownRejection = (requestHash: string, evidence: MutationEvidence, code: string | number, message: string) =>
+  new BrokerMutationError({
+    operation: MutationOperation.Submit,
+    failure: MutationFailure.Rejected,
+    outcome: MutationOutcome.Known,
+    message: `Alpaca rejected the order (${String(code)}): ${message}`,
+    requestHash,
+    evidence,
+    brokerCode: String(code),
+  })
+
+const microsToDecimal = (value: string): string => {
+  const micros = BigInt(value)
+  const whole = micros / 1_000_000n
+  const fraction = (micros % 1_000_000n).toString().padStart(6, '0').replace(/0+$/, '')
+  return fraction.length === 0 ? whole.toString() : `${whole.toString()}.${fraction}`
+}
+
+const side = (value: DomainSide): OrderSide => {
+  switch (value) {
+    case DomainSide.Buy:
+      return OrderSide.Buy
+    case DomainSide.Sell:
+      return OrderSide.Sell
+  }
+}
+
+const timeInForce = (value: DomainTimeInForce): TimeInForce => {
+  switch (value) {
+    case DomainTimeInForce.Day:
+      return TimeInForce.Day
+    case DomainTimeInForce.GoodUntilCanceled:
+      return TimeInForce.GoodUntilCanceled
+    case DomainTimeInForce.ImmediateOrCancel:
+      return TimeInForce.ImmediateOrCancel
+    case DomainTimeInForce.FillOrKill:
+      return TimeInForce.FillOrKill
+  }
+}
+
+export const orderRequestBody = (intent: Intent) => {
+  if (intent.orderType !== DomainOrderType.Market) throw new Error('Bayn broker submission supports market orders only')
+  if (intent.timeInForce !== DomainTimeInForce.Day && BigInt(intent.quantityMicros) % 1_000_000n !== 0n) {
+    throw new Error('fractional market orders require DAY time in force')
+  }
+  return {
+    symbol: intent.symbol,
+    qty: microsToDecimal(intent.quantityMicros),
+    side: side(intent.side),
+    type: OrderType.Market,
+    time_in_force: timeInForce(intent.timeInForce),
+    client_order_id: intent.clientOrderId,
+    extended_hours: false,
+  } as const
+}
+
+export const submitBody = (intent: Intent) => {
+  if (intent.state !== IntentState.IoStarted) throw new Error('intent must be IO_STARTED before broker submission')
+  return orderRequestBody(intent)
+}
+
+export const cancelRequestHash = (brokerOrderId: string): string =>
+  canonicalHashV1({ operation: MutationOperation.Cancel, brokerOrderId })
+
+const credentials = (key: string, secret: string) => ({
+  'APCA-API-KEY-ID': key,
+  'APCA-API-SECRET-KEY': secret,
+})
+
+const responseEvidence = (
+  requestId: string,
+  status: number,
+  contentHash: string,
+  observedAt: string,
+): MutationEvidence => ({ requestId, status, contentHash, observedAt })
+
+const withDeadline = <A>(
+  operation: MutationOperation,
+  requestHash: string,
+  timeoutMs: number,
+  effect: Effect.Effect<A, unknown>,
+): Effect.Effect<A, BrokerMutationError> =>
+  effect.pipe(
+    Effect.timeout(`${timeoutMs} millis`),
+    Effect.mapError((cause) =>
+      cause instanceof BrokerMutationError
+        ? cause
+        : unknownOutcome(
+            operation,
+            Cause.isTimeoutError(cause)
+              ? `Alpaca ${operation.toLowerCase()} exceeded its ${timeoutMs}ms deadline`
+              : `Alpaca ${operation.toLowerCase()} outcome is unknown because no valid response was available`,
+            requestHash,
+            undefined,
+            cause,
+          ),
+    ),
+  )
+
+export const makeMutation = (
+  options: MutationOptions,
+): Effect.Effect<BrokerMutationShape, BrokerMutationError, HttpClient.HttpClient> =>
+  Effect.gen(function* () {
+    const runtime = yield* decodeOptions({
+      expectedAccountId: options.expectedAccountId,
+      operationTimeoutMs: options.operationTimeoutMs,
+    }).pipe(Effect.mapError((cause) => configurationError('invalid Alpaca mutation options', cause)))
+    const key = Redacted.value(options.key)
+    const secret = Redacted.value(options.secret)
+    if (key.length === 0 || key.trim() !== key || secret.length === 0 || secret.trim() !== secret) {
+      return yield* Effect.fail(
+        configurationError('Alpaca credentials must be non-empty without surrounding whitespace'),
+      )
+    }
+    const client = yield* HttpClient.HttpClient
+
+    const submit = (input: Intent) =>
+      Effect.gen(function* () {
+        const intent = yield* decodeIntent(input).pipe(
+          Effect.mapError((cause) => invalidRequest(MutationOperation.Submit, 'invalid order intent', cause)),
+        )
+        const body = yield* Effect.try({
+          try: () => submitBody(intent),
+          catch: (cause) => invalidRequest(MutationOperation.Submit, 'order intent cannot be submitted', cause),
+        })
+        const requestHash = canonicalHashV1(body)
+        const request = yield* HttpClientRequest.bodyJson(
+          HttpClientRequest.post(new URL('/v2/orders', paperTradingUrl), {
+            acceptJson: true,
+            headers: credentials(key, secret),
+          }),
+          body,
+        ).pipe(
+          Effect.mapError((cause) =>
+            invalidRequest(MutationOperation.Submit, 'order request cannot be encoded', cause),
+          ),
+        )
+        return yield* withDeadline(
+          MutationOperation.Submit,
+          requestHash,
+          runtime.operationTimeoutMs,
+          Effect.gen(function* () {
+            const response = yield* client.execute(request)
+            const observedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
+            const headers = yield* decodeHeaders(response).pipe(
+              Effect.mapError((cause) =>
+                unknownOutcome(
+                  MutationOperation.Submit,
+                  'Alpaca submit response headers are invalid',
+                  requestHash,
+                  { status: response.status },
+                  cause,
+                ),
+              ),
+            )
+            const raw = yield* response.json.pipe(
+              Effect.mapError((cause) =>
+                unknownOutcome(
+                  MutationOperation.Submit,
+                  'Alpaca submit response body is not valid JSON',
+                  requestHash,
+                  { status: response.status, requestId: headers['x-request-id'] },
+                  cause,
+                ),
+              ),
+            )
+            const contentHash = yield* Effect.try({
+              try: () => canonicalHashV1(raw),
+              catch: (cause) =>
+                unknownOutcome(
+                  MutationOperation.Submit,
+                  'Alpaca submit response cannot be canonically hashed',
+                  requestHash,
+                  { status: response.status, requestId: headers['x-request-id'] },
+                  cause,
+                ),
+            })
+            const evidence = responseEvidence(headers['x-request-id'], response.status, contentHash, observedAt)
+
+            if (response.status !== 200) {
+              const failure = yield* decodeErrorResponse(raw).pipe(
+                Effect.mapError((cause) =>
+                  unknownOutcome(
+                    MutationOperation.Submit,
+                    'Alpaca submit error response is invalid',
+                    requestHash,
+                    evidence,
+                    cause,
+                  ),
+                ),
+              )
+              if ([400, 401, 403, 404, 422].includes(response.status)) {
+                return yield* Effect.fail(knownRejection(requestHash, evidence, failure.code, failure.message))
+              }
+              return yield* Effect.fail(
+                unknownOutcome(
+                  MutationOperation.Submit,
+                  `Alpaca submit returned ambiguous HTTP ${response.status}`,
+                  requestHash,
+                  evidence,
+                ),
+              )
+            }
+
+            const decoded = yield* decodeOrderResponse(raw).pipe(
+              Effect.mapError((cause) =>
+                unknownOutcome(
+                  MutationOperation.Submit,
+                  'Alpaca submit response does not match the order schema',
+                  requestHash,
+                  evidence,
+                  cause,
+                ),
+              ),
+            )
+            const order = yield* Effect.try({
+              try: () => normalizeOrder(decoded, runtime.expectedAccountId, observedAt),
+              catch: (cause) =>
+                unknownOutcome(
+                  MutationOperation.Submit,
+                  'Alpaca submit response violates the order contract',
+                  requestHash,
+                  evidence,
+                  cause,
+                ),
+            })
+            if (
+              order.clientOrderId !== intent.clientOrderId ||
+              order.symbol !== intent.symbol ||
+              order.side !== body.side ||
+              order.orderType !== body.type ||
+              order.timeInForce !== body.time_in_force ||
+              order.quantityMicros !== intent.quantityMicros ||
+              order.extendedHours
+            ) {
+              return yield* Effect.fail(
+                unknownOutcome(
+                  MutationOperation.Submit,
+                  'Alpaca accepted an order that does not match the durable intent',
+                  requestHash,
+                  evidence,
+                ),
+              )
+            }
+            return { requestHash, order, evidence } satisfies SubmitReceipt
+          }),
+        )
+      }).pipe(
+        Effect.provideService(Headers.CurrentRedactedNames, redactedHeaders),
+        Effect.withSpan('broker.mutation', {
+          attributes: { 'broker.system': 'alpaca', 'broker.operation': MutationOperation.Submit },
+        }),
+      )
+
+    const cancel = (brokerOrderId: string) =>
+      Effect.gen(function* () {
+        const orderId = yield* Schema.decodeUnknownEffect(Uuid)(brokerOrderId).pipe(
+          Effect.mapError((cause) => invalidRequest(MutationOperation.Cancel, 'invalid Alpaca order ID', cause)),
+        )
+        const requestHash = cancelRequestHash(orderId)
+        const request = HttpClientRequest.delete(
+          new URL(`/v2/orders/${encodeURIComponent(orderId)}`, paperTradingUrl),
+          { headers: credentials(key, secret) },
+        )
+        return yield* withDeadline(
+          MutationOperation.Cancel,
+          requestHash,
+          runtime.operationTimeoutMs,
+          Effect.gen(function* () {
+            const response = yield* client.execute(request)
+            const observedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
+            const headers = yield* decodeHeaders(response).pipe(
+              Effect.mapError((cause) =>
+                unknownOutcome(
+                  MutationOperation.Cancel,
+                  'Alpaca cancel response headers are invalid',
+                  requestHash,
+                  { status: response.status },
+                  cause,
+                ),
+              ),
+            )
+            const contentHash =
+              response.status === 204
+                ? canonicalHashV1(null)
+                : yield* response.text.pipe(
+                    Effect.flatMap((body) =>
+                      Effect.try({
+                        try: () => canonicalHashV1(JSON.parse(body)),
+                        catch: () => undefined,
+                      }).pipe(Effect.orElseSucceed(() => canonicalHashV1(body))),
+                    ),
+                    Effect.mapError((cause) =>
+                      unknownOutcome(
+                        MutationOperation.Cancel,
+                        'Alpaca cancel response body could not be read',
+                        requestHash,
+                        { status: response.status, requestId: headers['x-request-id'] },
+                        cause,
+                      ),
+                    ),
+                  )
+            const evidence = responseEvidence(headers['x-request-id'], response.status, contentHash, observedAt)
+            if (response.status !== 204) {
+              return yield* Effect.fail(
+                unknownOutcome(
+                  MutationOperation.Cancel,
+                  `Alpaca cancel returned HTTP ${response.status}; order lookup is required`,
+                  requestHash,
+                  evidence,
+                ),
+              )
+            }
+            return { requestHash, brokerOrderId: orderId, evidence } satisfies CancelReceipt
+          }),
+        )
+      }).pipe(
+        Effect.provideService(Headers.CurrentRedactedNames, redactedHeaders),
+        Effect.withSpan('broker.mutation', {
+          attributes: { 'broker.system': 'alpaca', 'broker.operation': MutationOperation.Cancel },
+        }),
+      )
+
+    return { submit, cancel }
+  })
+
+export const mutationLayer = (
+  options: MutationOptions,
+): Layer.Layer<BrokerMutation, BrokerMutationError, HttpClient.HttpClient> =>
+  Layer.effect(BrokerMutation, makeMutation(options))
+
+export const mutationLive = (options: MutationOptions) =>
+  mutationLayer(options).pipe(Layer.provide(alpacaHttpLayer(options.proxyUrl)))

--- a/services/bayn/src/broker/alpaca.ts
+++ b/services/bayn/src/broker/alpaca.ts
@@ -9,7 +9,7 @@ import {
   SymbolSchema as SymbolName,
 } from '../schemas'
 
-const tradingUrl = 'https://paper-api.alpaca.markets'
+export const paperTradingUrl = 'https://paper-api.alpaca.markets'
 const defaultFillActivitiesPageSize = 100
 const responseParseOptions = { onExcessProperty: 'ignore' } as const
 const inputParseOptions = { onExcessProperty: 'error' } as const
@@ -213,6 +213,7 @@ export class BrokerReadError extends Data.TaggedError('BrokerReadError')<{
   readonly status?: number
   readonly requestId?: string
   readonly contentHash?: string
+  readonly observedAt?: string
   readonly cause?: unknown
 }> {}
 
@@ -389,7 +390,7 @@ const PositionResponseSchema = Schema.Struct({
   current_price: Decimal,
 })
 
-const OrderResponseSchema = Schema.Struct({
+export const OrderResponseSchema = Schema.Struct({
   id: Uuid,
   client_order_id: ClientOrderId,
   created_at: Timestamp,
@@ -597,6 +598,7 @@ const statusError = (
   status: number,
   requestId: string,
   contentHash: string,
+  observedAt: string,
   code: string | number,
   detail: string,
 ): BrokerReadError => {
@@ -620,6 +622,7 @@ const statusError = (
     status,
     requestId,
     contentHash,
+    observedAt,
   })
 }
 
@@ -719,7 +722,7 @@ const normalizePosition = (
   }
 }
 
-const normalizeOrder = (raw: typeof OrderResponseSchema.Type, accountId: string, observedAt: string): Order => {
+export const normalizeOrder = (raw: typeof OrderResponseSchema.Type, accountId: string, observedAt: string): Order => {
   if (raw.asset_class !== AssetClass.UsEquity) throw new Error(`unsupported order asset class ${raw.asset_class}`)
   if ((raw.qty === null) === (raw.notional === null))
     throw new Error('order must contain exactly one of qty or notional')
@@ -891,7 +894,7 @@ export const makeProxyDispatcher = (
 const proxyLayer = (proxyUrl: string): Layer.Layer<NodeHttpClient.Dispatcher, BrokerReadError> =>
   Layer.effect(NodeHttpClient.Dispatcher, makeProxyDispatcher(proxyUrl))
 
-const httpLayer = (proxyUrl: string): Layer.Layer<HttpClient.HttpClient, BrokerReadError> =>
+export const alpacaHttpLayer = (proxyUrl: string): Layer.Layer<HttpClient.HttpClient, BrokerReadError> =>
   NodeHttpClient.layerUndiciNoDispatcher.pipe(Layer.provide(proxyLayer(proxyUrl)))
 
 export const make = (options: ReadOptions): Effect.Effect<BrokerReadShape, BrokerReadError, HttpClient.HttpClient> =>
@@ -978,7 +981,15 @@ export const make = (options: ReadOptions): Effect.Effect<BrokerReadShape, Broke
             ),
           )
           return yield* Effect.fail(
-            statusError(operation, response.status, evidence.requestId, contentHash, failure.code, failure.message),
+            statusError(
+              operation,
+              response.status,
+              evidence.requestId,
+              contentHash,
+              evidence.observedAt,
+              failure.code,
+              failure.message,
+            ),
           )
         }
 
@@ -1007,7 +1018,7 @@ export const make = (options: ReadOptions): Effect.Effect<BrokerReadShape, Broke
         Effect.withSpan('broker.read', { attributes: { 'broker.system': 'alpaca', 'broker.operation': operation } }),
       )
 
-    const account = readJson('account', new URL('/v2/account', tradingUrl), decodeAccount).pipe(
+    const account = readJson('account', new URL('/v2/account', paperTradingUrl), decodeAccount).pipe(
       Effect.flatMap((result) =>
         result.value.id === runtime.expectedAccountId
           ? normalize('account', result.evidence, () =>
@@ -1027,7 +1038,7 @@ export const make = (options: ReadOptions): Effect.Effect<BrokerReadShape, Broke
       ),
     )
 
-    const positions = readJson('positions', new URL('/v2/positions', tradingUrl), decodePositions).pipe(
+    const positions = readJson('positions', new URL('/v2/positions', paperTradingUrl), decodePositions).pipe(
       Effect.flatMap((result) =>
         normalize('positions', result.evidence, () =>
           result.value.map((position) =>
@@ -1040,7 +1051,7 @@ export const make = (options: ReadOptions): Effect.Effect<BrokerReadShape, Broke
     const orders = (query: OrdersQuery = {}) =>
       decodeInput('orders', decodeOrdersQuery, query, 'invalid Alpaca orders query').pipe(
         Effect.flatMap((decoded) => {
-          const url = new URL('/v2/orders', tradingUrl)
+          const url = new URL('/v2/orders', paperTradingUrl)
           if (decoded.status !== undefined) url.searchParams.set('status', decoded.status)
           if (decoded.limit !== undefined) url.searchParams.set('limit', String(decoded.limit))
           if (decoded.after !== undefined) url.searchParams.set('after', decoded.after)
@@ -1060,7 +1071,7 @@ export const make = (options: ReadOptions): Effect.Effect<BrokerReadShape, Broke
     const orderById = (orderId: string) =>
       decodeInput('order-by-id', decodeOrderId, orderId, 'invalid Alpaca order ID').pipe(
         Effect.flatMap((decoded) =>
-          readJson('order-by-id', new URL(`/v2/orders/${encodeURIComponent(decoded)}`, tradingUrl), decodeOrder),
+          readJson('order-by-id', new URL(`/v2/orders/${encodeURIComponent(decoded)}`, paperTradingUrl), decodeOrder),
         ),
         Effect.flatMap((result) =>
           normalize('order-by-id', result.evidence, () =>
@@ -1072,7 +1083,7 @@ export const make = (options: ReadOptions): Effect.Effect<BrokerReadShape, Broke
     const orderByClientId = (clientOrderId: string) =>
       decodeInput('order-by-client-id', decodeClientOrderId, clientOrderId, 'invalid Alpaca client order ID').pipe(
         Effect.flatMap((decoded) => {
-          const url = new URL('/v2/orders:by_client_order_id', tradingUrl)
+          const url = new URL('/v2/orders:by_client_order_id', paperTradingUrl)
           url.searchParams.set('client_order_id', decoded)
           return readJson('order-by-client-id', url, decodeOrder)
         }),
@@ -1086,7 +1097,7 @@ export const make = (options: ReadOptions): Effect.Effect<BrokerReadShape, Broke
     const fillActivities = (query: FillActivitiesQuery = {}) =>
       decodeInput('fill-activities', decodeFillActivitiesQuery, query, 'invalid Alpaca fill activities query').pipe(
         Effect.flatMap((decoded) => {
-          const url = new URL('/v2/account/activities/FILL', tradingUrl)
+          const url = new URL('/v2/account/activities/FILL', paperTradingUrl)
           const pageSize = decoded.pageSize ?? defaultFillActivitiesPageSize
           if (decoded.date !== undefined) url.searchParams.set('date', decoded.date)
           if (decoded.after !== undefined) url.searchParams.set('after', decoded.after)
@@ -1117,4 +1128,4 @@ export const layer = (options: ReadOptions): Layer.Layer<BrokerRead, BrokerReadE
   Layer.effect(BrokerRead, make(options).pipe(Effect.tap((read) => read.account)))
 
 export const live = (options: ReadOptions): Layer.Layer<BrokerRead, BrokerReadError> =>
-  layer(options).pipe(Layer.provide(httpLayer(options.proxyUrl)))
+  layer(options).pipe(Layer.provide(alpacaHttpLayer(options.proxyUrl)))

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -6,10 +6,21 @@ import { Cause, Deferred, Duration, Effect, Exit, Fiber, Layer, ManagedRuntime, 
 
 import type { RuntimeConfig } from '../config'
 import { IntentStore, IntentStoreLive, plan, type IntentPlan } from '../execution/intents'
+import { MutationEventType, MutationStore, MutationStoreLive } from '../execution/mutations'
+import { MutationOperation } from '../broker/alpaca-mutations'
 import { WriterFence, WriterFenceLive } from '../execution/writer-fence'
 import { canonicalHashV1 } from '../hash'
 import { buildLedgerPlan } from '../ledger'
-import { Authority, decodeRiskDecision, OrderSide, OrderType, RiskOutcome, TimeInForce, type Intent } from '../paper'
+import {
+  Authority,
+  decodeRiskDecision,
+  OrderSide,
+  OrderType,
+  RiskOutcome,
+  TerminalOutcome,
+  TimeInForce,
+  type Intent,
+} from '../paper'
 import { makeQualificationResult } from '../qualification'
 import { evaluateRiskBalancedTrend } from '../risk-balanced-trend'
 import { makeStrategy } from '../strategy-service'
@@ -26,6 +37,7 @@ import {
 const postgresUrl = process.env.BAYN_TEST_POSTGRES_URL
 const testUrl = postgresUrl ?? 'postgresql://bayn:bayn@127.0.0.1:5432/bayn_test'
 const describePostgres = postgresUrl === undefined ? describe.skip : describe
+const orderId = '61e69015-8549-4bfd-b9c3-01e75843f47d'
 
 const makeConfig = (url = testUrl): RuntimeConfig => ({
   host: '127.0.0.1',
@@ -76,6 +88,15 @@ const makeExecutionRuntime = (config = makeConfig()) =>
     ),
   )
 
+const makeMutationRuntime = (config = makeConfig()) =>
+  ManagedRuntime.make(
+    MutationStoreLive.pipe(
+      Layer.provideMerge(WriterFenceLive),
+      Layer.provideMerge(PostgresClientLive(config)),
+      Layer.provide(NodeServices.layer),
+    ),
+  )
+
 const intentPlan = (overrides: Partial<IntentPlan> = {}): IntentPlan => ({
   schemaVersion: 'bayn.paper-intent-plan.v1',
   strategyName: 'risk-balanced-trend',
@@ -112,6 +133,17 @@ const riskDecision = (
   } as const
   return decodeRiskDecision({ ...material, decisionId: canonicalHashV1(material) })
 }
+
+const sqlIntentState = (intentId: string) =>
+  Effect.gen(function* () {
+    const sql = yield* PgClient.PgClient
+    const rows = yield* sql<{ state: string; state_version: number }>`
+      SELECT state, state_version::integer
+      FROM intents
+      WHERE intent_id = ${intentId}
+    `
+    return rows[0]
+  })
 
 const riskBalancedTrendSnapshot = makeSnapshot(800)
 
@@ -221,6 +253,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       'fills',
       'gate_outcomes',
       'intents',
+      'mutation_events',
       'orders',
       'positions',
       'protocol_locks',
@@ -240,6 +273,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       { migration_id: 2, name: 'paper_contracts' },
       { migration_id: 3, name: 'intent_risk_clock' },
       { migration_id: 4, name: 'deterministic_intents' },
+      { migration_id: 5, name: 'mutation_recovery' },
     ])
   })
 
@@ -474,6 +508,275 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     expect(Exit.isFailure(observed.check)).toBe(true)
     expect(Exit.isFailure(observed.commit)).toBe(true)
     expect(observed.count).toBe(0)
+  })
+
+  test('linearizes one submit and records its exact acknowledged outcome', async () => {
+    const execution = makeExecutionRuntime()
+    const intent = await Effect.runPromise(plan(intentPlan({ cycleId: '1'.repeat(64) })))
+    const decision = await Effect.runPromise(riskDecision(intent, RiskOutcome.Approved))
+    await execution.runPromise(
+      Effect.gen(function* () {
+        yield* Effect.flatMap(IntentStore, (store) => store.commit(intent, decision))
+        const sql = yield* PgClient.PgClient
+        yield* sql`
+          INSERT INTO authority_state (
+            schema_version, generation_hash, maximum, effective, kill_state, version, updated_at
+          ) VALUES (
+            'bayn.paper-authority.v1', ${'9'.repeat(64)}, 'PAPER', 'PAPER', 'CLEAR', 1,
+            ${new Date(Date.now() + 1).toISOString()}
+          )
+        `
+      }),
+    )
+    await execution.dispose()
+
+    const mutation = makeMutationRuntime()
+    const startedAt = new Date(Date.now() + 100).toISOString()
+    const requestHash = '8'.repeat(64)
+    const evidence = {
+      requestId: 'submit-request-1',
+      status: 200,
+      contentHash: '7'.repeat(64),
+      observedAt: new Date(Date.now() + 200).toISOString(),
+    }
+    const observed = await mutation.runPromise(
+      Effect.gen(function* () {
+        const store = yield* MutationStore
+        const starts = yield* Effect.all(
+          [
+            store.beginSubmit(intent.intentId, requestHash, 1_000, startedAt),
+            store.beginSubmit(intent.intentId, requestHash, 1_000, startedAt),
+          ],
+          { concurrency: 'unbounded' },
+        )
+        const changedDelay = yield* Effect.exit(store.beginSubmit(intent.intentId, requestHash, 2_000, startedAt))
+        const accepted = yield* store.submitAccepted(intent.intentId, requestHash, orderId, evidence)
+        const replay = yield* store.submitAccepted(intent.intentId, requestHash, orderId, evidence)
+        const sql = yield* PgClient.PgClient
+        const state = yield* sql<{ events: number; state: string; state_version: number }>`
+          SELECT
+            state,
+            state_version::integer,
+            (SELECT count(*)::integer FROM mutation_events WHERE intent_id = ${intent.intentId}) AS events
+          FROM intents
+          WHERE intent_id = ${intent.intentId}
+        `
+        return { accepted, changedDelay, replay, starts, state: state[0] }
+      }),
+    )
+    await mutation.dispose()
+
+    expect(observed.starts.filter((receipt) => receipt.started)).toHaveLength(1)
+    expect(observed.starts.filter((receipt) => !receipt.started)).toHaveLength(1)
+    expect(Exit.isFailure(observed.changedDelay)).toBe(true)
+    expect(observed.accepted.eventType).toBe(MutationEventType.SubmitAccepted)
+    expect(observed.accepted.consistencyDelayMs).toBe(1_000)
+    expect(observed.replay.eventId).toBe(observed.accepted.eventId)
+    expect(observed.state).toEqual({ state: 'ACKNOWLEDGED', state_version: 4, events: 2 })
+  })
+
+  test('keeps an ambiguous submit UNKNOWN until lookup recovers the exact broker order', async () => {
+    const execution = makeExecutionRuntime()
+    const intent = await Effect.runPromise(plan(intentPlan({ cycleId: '2'.repeat(64) })))
+    const decision = await Effect.runPromise(riskDecision(intent, RiskOutcome.Approved))
+    await execution.runPromise(
+      Effect.gen(function* () {
+        yield* Effect.flatMap(IntentStore, (store) => store.commit(intent, decision))
+        const sql = yield* PgClient.PgClient
+        yield* sql`
+          INSERT INTO authority_state (
+            schema_version, generation_hash, maximum, effective, kill_state, version, updated_at
+          ) VALUES (
+            'bayn.paper-authority.v1', ${'9'.repeat(64)}, 'PAPER', 'PAPER', 'CLEAR', 1,
+            ${new Date(Date.now() + 1).toISOString()}
+          )
+        `
+      }),
+    )
+    await execution.dispose()
+
+    const mutation = makeMutationRuntime()
+    const requestHash = '6'.repeat(64)
+    const base = Date.now() + 100
+    const observed = await mutation.runPromise(
+      Effect.gen(function* () {
+        const store = yield* MutationStore
+        yield* store.beginSubmit(intent.intentId, requestHash, 1_000, new Date(base).toISOString())
+        yield* store.submitUnknown(intent.intentId, requestHash, new Date(base + 1).toISOString())
+        const notFound = yield* store.recoveryNotFound(intent.intentId, MutationOperation.Submit, requestHash, {
+          requestId: 'lookup-request-1',
+          status: 404,
+          contentHash: '5'.repeat(64),
+          observedAt: new Date(base + 2).toISOString(),
+        })
+        const before = yield* sqlIntentState(intent.intentId)
+        const found = yield* store.recoveryFound(intent.intentId, MutationOperation.Submit, requestHash, orderId, {
+          requestId: 'lookup-request-2',
+          status: 200,
+          contentHash: '4'.repeat(64),
+          observedAt: new Date(base + 3).toISOString(),
+        })
+        const after = yield* sqlIntentState(intent.intentId)
+        return { after, before, found, notFound }
+      }),
+    )
+    await mutation.dispose()
+
+    expect(observed.notFound.eventType).toBe(MutationEventType.RecoveryNotFound)
+    expect(observed.before).toEqual({ state: 'UNKNOWN', state_version: 4 })
+    expect(observed.found.eventType).toBe(MutationEventType.RecoveryFound)
+    expect(observed.after).toEqual({ state: 'ACKNOWLEDGED', state_version: 6 })
+  })
+
+  test('allows kill-mode cancellation of an identified order and resolves the cancel race', async () => {
+    const execution = makeExecutionRuntime()
+    const intent = await Effect.runPromise(plan(intentPlan({ cycleId: '3'.repeat(64) })))
+    const decision = await Effect.runPromise(riskDecision(intent, RiskOutcome.Approved))
+    await execution.runPromise(
+      Effect.gen(function* () {
+        yield* Effect.flatMap(IntentStore, (store) => store.commit(intent, decision))
+        const sql = yield* PgClient.PgClient
+        yield* sql`
+          INSERT INTO authority_state (
+            schema_version, generation_hash, maximum, effective, kill_state, version, updated_at
+          ) VALUES (
+            'bayn.paper-authority.v1', ${'9'.repeat(64)}, 'PAPER', 'PAPER', 'CLEAR', 1,
+            ${new Date(Date.now() + 1).toISOString()}
+          )
+        `
+      }),
+    )
+    await execution.dispose()
+
+    const mutation = makeMutationRuntime()
+    const submitHash = '3'.repeat(64)
+    const cancelHash = '2'.repeat(64)
+    const base = Date.now() + 100
+    const observed = await mutation.runPromise(
+      Effect.gen(function* () {
+        const store = yield* MutationStore
+        yield* store.beginSubmit(intent.intentId, submitHash, 1_000, new Date(base).toISOString())
+        yield* store.submitAccepted(intent.intentId, submitHash, orderId, {
+          requestId: 'submit-request',
+          status: 200,
+          contentHash: '1'.repeat(64),
+          observedAt: new Date(base + 1).toISOString(),
+        })
+        const sql = yield* PgClient.PgClient
+        yield* sql`
+          UPDATE authority_state
+          SET effective = 'OBSERVE', kill_state = 'ACTIVE', reason = 'operator kill', version = 2,
+              updated_at = ${new Date(base + 2).toISOString()}
+          WHERE singleton
+        `
+        yield* store.beginCancel(intent.intentId, cancelHash, orderId, 1_000, new Date(base + 3).toISOString())
+        yield* store.cancelUnknown(intent.intentId, cancelHash, orderId, new Date(base + 4).toISOString())
+        const notFound = yield* store.recoveryNotFound(intent.intentId, MutationOperation.Cancel, cancelHash, {
+          requestId: 'cancel-lookup-not-found',
+          status: 404,
+          contentHash: 'f'.repeat(64),
+          observedAt: new Date(base + 5).toISOString(),
+        })
+        yield* store.recoveryFound(
+          intent.intentId,
+          MutationOperation.Cancel,
+          cancelHash,
+          orderId,
+          {
+            requestId: 'cancel-lookup',
+            status: 200,
+            contentHash: '0'.repeat(64),
+            observedAt: new Date(base + 6).toISOString(),
+          },
+          TerminalOutcome.Canceled,
+        )
+        return { notFound, state: yield* sqlIntentState(intent.intentId) }
+      }),
+    )
+    await mutation.dispose()
+
+    expect(observed.notFound).toMatchObject({
+      eventType: MutationEventType.RecoveryNotFound,
+      brokerOrderId: orderId,
+    })
+    expect(observed.state).toEqual({ state: 'TERMINAL', state_version: 5 })
+  })
+
+  test('blocks later exposure only while an earlier mutation outcome remains unresolved', async () => {
+    const execution = makeExecutionRuntime()
+    const first = await Effect.runPromise(plan(intentPlan({ cycleId: '4'.repeat(64) })))
+    const second = await Effect.runPromise(plan(intentPlan({ cycleId: '5'.repeat(64) })))
+    const firstDecision = await Effect.runPromise(riskDecision(first, RiskOutcome.Approved))
+    const secondDecision = await Effect.runPromise(riskDecision(second, RiskOutcome.Approved))
+    await execution.runPromise(
+      Effect.gen(function* () {
+        const store = yield* IntentStore
+        yield* store.commit(first, firstDecision)
+        yield* store.commit(second, secondDecision)
+        const sql = yield* PgClient.PgClient
+        yield* sql`
+          INSERT INTO authority_state (
+            schema_version, generation_hash, maximum, effective, kill_state, version, updated_at
+          ) VALUES (
+            'bayn.paper-authority.v1', ${'9'.repeat(64)}, 'PAPER', 'PAPER', 'CLEAR', 1,
+            ${new Date(Date.now() + 1).toISOString()}
+          )
+        `
+      }),
+    )
+    await execution.dispose()
+
+    const mutation = makeMutationRuntime()
+    const firstSubmitHash = 'a'.repeat(64)
+    const firstCancelHash = 'b'.repeat(64)
+    const secondSubmitHash = 'c'.repeat(64)
+    const base = Date.now() + 100
+    const observed = await mutation.runPromise(
+      Effect.gen(function* () {
+        const store = yield* MutationStore
+        yield* store.beginSubmit(first.intentId, firstSubmitHash, 1_000, new Date(base).toISOString())
+        yield* store.submitUnknown(first.intentId, firstSubmitHash, new Date(base + 1).toISOString())
+        const blockedBySubmit = yield* Effect.exit(
+          store.beginSubmit(second.intentId, secondSubmitHash, 1_000, new Date(base + 2).toISOString()),
+        )
+        yield* store.recoveryFound(first.intentId, MutationOperation.Submit, firstSubmitHash, orderId, {
+          requestId: 'submit-recovery',
+          status: 200,
+          contentHash: 'd'.repeat(64),
+          observedAt: new Date(base + 3).toISOString(),
+        })
+        yield* store.beginCancel(first.intentId, firstCancelHash, orderId, 1_000, new Date(base + 4).toISOString())
+        yield* store.cancelUnknown(first.intentId, firstCancelHash, orderId, new Date(base + 5).toISOString())
+        const blockedByCancel = yield* Effect.exit(
+          store.beginSubmit(second.intentId, secondSubmitHash, 1_000, new Date(base + 6).toISOString()),
+        )
+        yield* store.recoveryFound(
+          first.intentId,
+          MutationOperation.Cancel,
+          firstCancelHash,
+          orderId,
+          {
+            requestId: 'cancel-recovery',
+            status: 200,
+            contentHash: 'e'.repeat(64),
+            observedAt: new Date(base + 7).toISOString(),
+          },
+          TerminalOutcome.Canceled,
+        )
+        const secondStart = yield* store.beginSubmit(
+          second.intentId,
+          secondSubmitHash,
+          1_000,
+          new Date(base + 8).toISOString(),
+        )
+        return { blockedByCancel, blockedBySubmit, secondStart }
+      }),
+    )
+    await mutation.dispose()
+
+    expect(Exit.isFailure(observed.blockedBySubmit)).toBe(true)
+    expect(Exit.isFailure(observed.blockedByCancel)).toBe(true)
+    expect(observed.secondStart.started).toBe(true)
   })
 
   test('requires one typed append-only payload and unique broker source ordering', async () => {

--- a/services/bayn/src/db/migrations.ts
+++ b/services/bayn/src/db/migrations.ts
@@ -4,10 +4,12 @@ import initialSchema from '../../migrations/0001_initial_schema'
 import paperContracts from '../../migrations/0002_paper_contracts'
 import intentRiskClock from '../../migrations/0003_intent_risk_clock'
 import deterministicIntents from '../../migrations/0004_deterministic_intents'
+import mutationRecovery from '../../migrations/0005_mutation_recovery'
 
 export const migrationLoader = PgMigrator.fromRecord({
   '1_initial_schema': initialSchema,
   '2_paper_contracts': paperContracts,
   '3_intent_risk_clock': intentRiskClock,
   '4_deterministic_intents': deterministicIntents,
+  '5_mutation_recovery': mutationRecovery,
 })

--- a/services/bayn/src/execution/coordinator.test.ts
+++ b/services/bayn/src/execution/coordinator.test.ts
@@ -1,0 +1,486 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Effect, Exit, Option } from 'effect'
+import { TestClock } from 'effect/testing'
+
+import {
+  BrokerMutation,
+  BrokerMutationError,
+  MutationFailure,
+  MutationOperation,
+  cancelRequestHash,
+  orderRequestBody,
+  type BrokerMutationShape,
+  type MutationEvidence,
+} from '../broker/alpaca-mutations'
+import {
+  AssetClass,
+  BrokerRead,
+  BrokerReadError,
+  BrokerReadErrorKind,
+  OrderClass,
+  OrderSide as BrokerSide,
+  OrderStatus,
+  OrderType as BrokerOrderType,
+  TimeInForce as BrokerTimeInForce,
+  type BrokerReadShape,
+  type Order,
+} from '../broker/alpaca'
+import { canonicalHashV1 } from '../hash'
+import { IntentState, MutationOutcome, OrderSide, OrderType, TerminalOutcome, TimeInForce, type Intent } from '../paper'
+import { cancel, ExecutionError, ExecutionFailure, recover, submit } from './coordinator'
+import { IntentStore, type IntentStoreService, type StoredIntent } from './intents'
+import { MutationEventType, MutationStore, mutationId, type MutationEvent, type MutationStoreShape } from './mutations'
+import { WriterFence, WriterFenceError } from './writer-fence'
+
+const intentId = 'a'.repeat(64)
+const orderId = '61e69015-8549-4bfd-b9c3-01e75843f47d'
+const accountId = 'e6fe16f3-64a4-4921-8928-cadf02f92f98'
+const initialTime = '1969-12-31T23:59:59.000Z'
+
+const intent: Intent = {
+  schemaVersion: 'bayn.paper-intent.v2',
+  intentId,
+  riskDecisionId: 'b'.repeat(64),
+  strategyName: 'risk-balanced-trend',
+  cycleId: 'c'.repeat(64),
+  decisionHash: 'd'.repeat(64),
+  policyHash: 'e'.repeat(64),
+  accountId,
+  clientOrderId: `b1_${'A'.repeat(43)}`,
+  symbol: 'AMD',
+  side: OrderSide.Buy,
+  orderType: OrderType.Market,
+  timeInForce: TimeInForce.Day,
+  quantityMicros: '1250000',
+  notionalLimitMicros: '200000000',
+  state: IntentState.Approved,
+  createdAt: initialTime,
+}
+
+const brokerOrder = (status = OrderStatus.Accepted, observedAt = '1970-01-01T00:00:01.000Z'): Order => ({
+  accountId,
+  brokerOrderId: orderId,
+  clientOrderId: intent.clientOrderId,
+  createdAt: observedAt,
+  updatedAt: observedAt,
+  submittedAt: observedAt,
+  assetId: 'b0b6dd9d-8b9b-48a9-ba46-b9d54906e415',
+  symbol: intent.symbol,
+  assetClass: AssetClass.UsEquity,
+  quantityMicros: intent.quantityMicros,
+  filledQuantityMicros: status === OrderStatus.Filled ? intent.quantityMicros : '0',
+  orderClass: OrderClass.Simple,
+  orderType: BrokerOrderType.Market,
+  side: BrokerSide.Buy,
+  timeInForce: BrokerTimeInForce.Day,
+  status,
+  extendedHours: false,
+  observedAt,
+})
+
+const evidence = (status: number, observedAt: string): MutationEvidence => ({
+  requestId: `request-${status}`,
+  status,
+  contentHash: canonicalHashV1({ status, observedAt }),
+  observedAt,
+})
+
+const completeEvidence = (response: Partial<MutationEvidence> | undefined): MutationEvidence | undefined =>
+  response?.requestId !== undefined &&
+  response.status !== undefined &&
+  response.contentHash !== undefined &&
+  response.observedAt !== undefined
+    ? {
+        requestId: response.requestId,
+        status: response.status,
+        contentHash: response.contentHash,
+        observedAt: response.observedAt,
+      }
+    : undefined
+
+interface HarnessOptions {
+  readonly crashAfterSubmit?: boolean
+  readonly lostFence?: boolean
+  readonly notFoundOnce?: boolean
+  readonly unknownSubmit?: boolean
+}
+
+const makeHarness = (options: HarnessOptions = {}) => {
+  let stored: StoredIntent = { intent, stateVersion: 3, updatedAt: initialTime }
+  const latest = new Map<MutationOperation, MutationEvent>()
+  let submitCalls = 0
+  let cancelCalls = 0
+  let lookupCalls = 0
+
+  const event = (
+    operation: MutationOperation,
+    eventType: MutationEventType,
+    requestHash: string,
+    consistencyDelayMs: number,
+    occurredAt: string,
+    brokerOrderId?: string,
+    response?: MutationEvidence,
+  ): MutationEvent => {
+    const previous = latest.get(operation)
+    const sequence = (previous?.sequence ?? 0) + 1
+    const value: MutationEvent = {
+      schemaVersion: 'bayn.paper-mutation-event.v1',
+      eventId: canonicalHashV1({ operation, sequence, eventType, occurredAt }),
+      mutationId: mutationId(intentId, operation),
+      intentId,
+      sequence,
+      operation,
+      eventType,
+      requestHash,
+      consistencyDelayMs,
+      ...((brokerOrderId ?? previous?.brokerOrderId)
+        ? { brokerOrderId: brokerOrderId ?? previous?.brokerOrderId }
+        : {}),
+      ...(response === undefined
+        ? {}
+        : {
+            requestId: response.requestId,
+            responseStatus: response.status,
+            responseContentHash: response.contentHash,
+          }),
+      occurredAt,
+    }
+    latest.set(operation, value)
+    return value
+  }
+
+  const setState = (state: IntentState, updatedAt: string, terminalOutcome?: TerminalOutcome) => {
+    stored = {
+      ...stored,
+      intent: { ...stored.intent, state, ...(terminalOutcome === undefined ? {} : { terminalOutcome }) },
+      stateVersion: stored.stateVersion + 1,
+      updatedAt,
+    }
+  }
+
+  const intentStore: IntentStoreService = {
+    commit: () => Effect.die(new Error('unexpected commit')),
+    markIoStarted: () => Effect.die(new Error('unexpected markIoStarted')),
+    read: (id) => Effect.succeed(id === intentId ? Option.some(stored) : Option.none()),
+  }
+
+  const mutationStore: MutationStoreShape = {
+    beginSubmit: (_intentId, requestHash, consistencyDelayMs, occurredAt) => {
+      const existing = latest.get(MutationOperation.Submit)
+      if (existing !== undefined) return Effect.succeed({ event: existing, started: false })
+      const started = event(
+        MutationOperation.Submit,
+        MutationEventType.SubmitStarted,
+        requestHash,
+        consistencyDelayMs,
+        occurredAt,
+      )
+      setState(IntentState.IoStarted, occurredAt)
+      return Effect.succeed({ event: started, started: true })
+    },
+    submitAccepted: (_intentId, requestHash, brokerOrderId, response, terminal) => {
+      const accepted = event(
+        MutationOperation.Submit,
+        MutationEventType.SubmitAccepted,
+        requestHash,
+        latest.get(MutationOperation.Submit)?.consistencyDelayMs ?? 1,
+        response.observedAt,
+        brokerOrderId,
+        response,
+      )
+      setState(terminal === undefined ? IntentState.Acknowledged : IntentState.Terminal, response.observedAt, terminal)
+      return Effect.succeed(accepted)
+    },
+    submitRejected: (_intentId, requestHash, response) => {
+      const rejected = event(
+        MutationOperation.Submit,
+        MutationEventType.SubmitRejected,
+        requestHash,
+        latest.get(MutationOperation.Submit)?.consistencyDelayMs ?? 1,
+        response.observedAt,
+        undefined,
+        response,
+      )
+      setState(IntentState.Terminal, response.observedAt, TerminalOutcome.Rejected)
+      return Effect.succeed(rejected)
+    },
+    submitUnknown: (_intentId, requestHash, occurredAt, response) => {
+      const unknown = event(
+        MutationOperation.Submit,
+        MutationEventType.SubmitUnknown,
+        requestHash,
+        latest.get(MutationOperation.Submit)?.consistencyDelayMs ?? 1,
+        occurredAt,
+        undefined,
+        completeEvidence(response),
+      )
+      setState(IntentState.Unknown, occurredAt)
+      return Effect.succeed(unknown)
+    },
+    beginCancel: (_intentId, requestHash, brokerOrderId, consistencyDelayMs, occurredAt) => {
+      const existing = latest.get(MutationOperation.Cancel)
+      if (existing !== undefined) return Effect.succeed({ event: existing, started: false })
+      return Effect.succeed({
+        event: event(
+          MutationOperation.Cancel,
+          MutationEventType.CancelStarted,
+          requestHash,
+          consistencyDelayMs,
+          occurredAt,
+          brokerOrderId,
+        ),
+        started: true,
+      })
+    },
+    cancelAccepted: (_intentId, requestHash, brokerOrderId, response) =>
+      Effect.succeed(
+        event(
+          MutationOperation.Cancel,
+          MutationEventType.CancelAccepted,
+          requestHash,
+          latest.get(MutationOperation.Cancel)?.consistencyDelayMs ?? 1,
+          response.observedAt,
+          brokerOrderId,
+          response,
+        ),
+      ),
+    cancelUnknown: (_intentId, requestHash, brokerOrderId, occurredAt, response) =>
+      Effect.succeed(
+        event(
+          MutationOperation.Cancel,
+          MutationEventType.CancelUnknown,
+          requestHash,
+          latest.get(MutationOperation.Cancel)?.consistencyDelayMs ?? 1,
+          occurredAt,
+          brokerOrderId,
+          completeEvidence(response),
+        ),
+      ),
+    recoveryFound: (_intentId, operation, requestHash, brokerOrderId, response, terminal) => {
+      const found = event(
+        operation,
+        MutationEventType.RecoveryFound,
+        requestHash,
+        latest.get(operation)?.consistencyDelayMs ?? 1,
+        response.observedAt,
+        brokerOrderId,
+        response,
+      )
+      if (operation === MutationOperation.Submit) {
+        setState(
+          terminal === undefined ? IntentState.Acknowledged : IntentState.Terminal,
+          response.observedAt,
+          terminal,
+        )
+      } else if (terminal !== undefined) {
+        setState(IntentState.Terminal, response.observedAt, terminal)
+      }
+      return Effect.succeed(found)
+    },
+    recoveryNotFound: (_intentId, operation, requestHash, response) =>
+      Effect.succeed(
+        event(
+          operation,
+          MutationEventType.RecoveryNotFound,
+          requestHash,
+          latest.get(operation)?.consistencyDelayMs ?? 1,
+          response.observedAt,
+          undefined,
+          response,
+        ),
+      ),
+    recoveryUnknown: (_intentId, operation, requestHash, occurredAt, response) =>
+      Effect.succeed(
+        event(
+          operation,
+          MutationEventType.RecoveryUnknown,
+          requestHash,
+          latest.get(operation)?.consistencyDelayMs ?? 1,
+          occurredAt,
+          undefined,
+          completeEvidence(response),
+        ),
+      ),
+    latest: (_intentId, operation) => Effect.succeed(latest.get(operation)),
+  }
+
+  const mutation: BrokerMutationShape = {
+    submit: (submitted) => {
+      submitCalls += 1
+      if (latest.get(MutationOperation.Submit)?.eventType !== MutationEventType.SubmitStarted) {
+        return Effect.die(new Error('submit happened before SUBMIT_STARTED was durable'))
+      }
+      if (options.crashAfterSubmit) return Effect.die(new Error('injected crash after send'))
+      const hash = canonicalHashV1(orderRequestBody(submitted))
+      if (options.unknownSubmit) {
+        return Effect.fail(
+          new BrokerMutationError({
+            operation: MutationOperation.Submit,
+            failure: MutationFailure.Unknown,
+            outcome: MutationOutcome.Unknown,
+            message: 'injected timeout',
+            requestHash: hash,
+          }),
+        )
+      }
+      const response = evidence(200, '1970-01-01T00:00:00.100Z')
+      return Effect.succeed({ requestHash: hash, order: brokerOrder(), evidence: response })
+    },
+    cancel: (brokerOrderId) => {
+      cancelCalls += 1
+      const response = evidence(204, '1970-01-01T00:00:01.100Z')
+      return Effect.succeed({ requestHash: cancelRequestHash(brokerOrderId), brokerOrderId, evidence: response })
+    },
+  }
+
+  const read: BrokerReadShape = {
+    account: Effect.die(new Error('unexpected account read')),
+    positions: Effect.die(new Error('unexpected positions read')),
+    orders: () => Effect.die(new Error('unexpected orders read')),
+    orderById: () => Effect.die(new Error('unexpected order-by-id read')),
+    orderByClientId: () => {
+      lookupCalls += 1
+      if (options.notFoundOnce && lookupCalls === 1) {
+        return Effect.fail(
+          new BrokerReadError({
+            operation: 'order-by-client-id',
+            kind: BrokerReadErrorKind.NotFound,
+            message: 'injected delayed visibility',
+            retryable: false,
+            status: 404,
+            requestId: 'lookup-not-found',
+            contentHash: canonicalHashV1({ code: 404, message: 'order not found' }),
+            observedAt: '1970-01-01T00:00:01.000Z',
+          }),
+        )
+      }
+      const value =
+        latest.get(MutationOperation.Cancel) === undefined
+          ? brokerOrder(OrderStatus.Accepted)
+          : brokerOrder(OrderStatus.Canceled)
+      return Effect.succeed({ value, evidence: evidence(200, '1970-01-01T00:00:02.000Z') })
+    },
+    fillActivities: () => Effect.die(new Error('unexpected fill read')),
+  }
+
+  const provide = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+    effect.pipe(
+      Effect.provideService(IntentStore, intentStore),
+      Effect.provideService(MutationStore, mutationStore),
+      Effect.provideService(BrokerMutation, mutation),
+      Effect.provideService(BrokerRead, read),
+      Effect.provideService(WriterFence, {
+        backendPid: 1,
+        check: options.lostFence
+          ? Effect.fail(
+              new WriterFenceError({
+                failure: 'unavailable',
+                operation: 'check',
+                message: 'injected writer-fence loss',
+              }),
+            )
+          : Effect.void,
+      }),
+      Effect.provide(TestClock.layer()),
+    )
+
+  return {
+    provide,
+    calls: () => ({ submit: submitCalls, cancel: cancelCalls, lookup: lookupCalls }),
+    state: () => stored.intent.state,
+  }
+}
+
+describe('paper execution coordinator', () => {
+  test('records before submission and never calls the broker again for a replayed intent', async () => {
+    const harness = makeHarness()
+    const result = await Effect.runPromise(
+      harness.provide(
+        Effect.gen(function* () {
+          const accepted = yield* submit(intentId, 1_000)
+          const replay = yield* submit(intentId, 1_000)
+          return { accepted, replay }
+        }),
+      ),
+    )
+
+    expect(result.accepted.eventType).toBe(MutationEventType.SubmitAccepted)
+    expect(result.replay.eventId).toBe(result.accepted.eventId)
+    expect(harness.calls()).toEqual({ submit: 1, cancel: 0, lookup: 0 })
+    expect(harness.state()).toBe(IntentState.Acknowledged)
+  })
+
+  test('makes no broker call when the writer fence is lost after recording I/O start', async () => {
+    const harness = makeHarness({ lostFence: true })
+    const failure = await Effect.runPromise(harness.provide(Effect.flip(submit(intentId, 1_000))))
+
+    expect(failure).toBeInstanceOf(WriterFenceError)
+    expect(harness.calls()).toEqual({ submit: 0, cancel: 0, lookup: 0 })
+    expect(harness.state()).toBe(IntentState.IoStarted)
+  })
+
+  test('persists UNKNOWN and refuses lookup until the committed consistency delay elapses', async () => {
+    const harness = makeHarness({ notFoundOnce: true, unknownSubmit: true })
+    const result = await Effect.runPromise(
+      harness.provide(
+        Effect.gen(function* () {
+          const unknown = yield* submit(intentId, 1_000)
+          const tooEarly = yield* Effect.flip(recover(intentId, MutationOperation.Submit))
+          yield* TestClock.adjust(1_000)
+          const notFound = yield* recover(intentId, MutationOperation.Submit)
+          yield* TestClock.adjust(1_000)
+          const found = yield* recover(intentId, MutationOperation.Submit)
+          return { found, notFound, tooEarly, unknown }
+        }),
+      ),
+    )
+
+    expect(result.unknown.eventType).toBe(MutationEventType.SubmitUnknown)
+    expect(result.tooEarly).toBeInstanceOf(ExecutionError)
+    expect(result.tooEarly).toMatchObject({ failure: ExecutionFailure.RecoveryTooEarly })
+    expect(result.notFound.eventType).toBe(MutationEventType.RecoveryNotFound)
+    expect(result.found.eventType).toBe(MutationEventType.RecoveryFound)
+    expect(harness.calls()).toEqual({ submit: 1, cancel: 0, lookup: 2 })
+    expect(harness.state()).toBe(IntentState.Acknowledged)
+  })
+
+  test('recovers an injected post-send crash by lookup without resubmitting', async () => {
+    const harness = makeHarness({ crashAfterSubmit: true })
+    const result = await Effect.runPromise(
+      harness.provide(
+        Effect.gen(function* () {
+          const crashed = yield* Effect.exit(submit(intentId, 1_000))
+          yield* TestClock.adjust(1_000)
+          const found = yield* recover(intentId, MutationOperation.Submit)
+          return { crashed, found }
+        }),
+      ),
+    )
+
+    expect(Exit.isFailure(result.crashed)).toBe(true)
+    expect(result.found.eventType).toBe(MutationEventType.RecoveryFound)
+    expect(harness.calls()).toEqual({ submit: 1, cancel: 0, lookup: 1 })
+    expect(harness.state()).toBe(IntentState.Acknowledged)
+  })
+
+  test('cancels only the identified order and resolves terminal state through lookup', async () => {
+    const harness = makeHarness()
+    const result = await Effect.runPromise(
+      harness.provide(
+        Effect.gen(function* () {
+          yield* submit(intentId, 1_000)
+          const accepted = yield* cancel(intentId, 1_000)
+          yield* TestClock.adjust(3_000)
+          const found = yield* recover(intentId, MutationOperation.Cancel)
+          return { accepted, found }
+        }),
+      ),
+    )
+
+    expect(result.accepted.eventType).toBe(MutationEventType.CancelAccepted)
+    expect(result.found.eventType).toBe(MutationEventType.RecoveryFound)
+    expect(harness.calls()).toEqual({ submit: 1, cancel: 1, lookup: 1 })
+    expect(harness.state()).toBe(IntentState.Terminal)
+  })
+})

--- a/services/bayn/src/execution/coordinator.ts
+++ b/services/bayn/src/execution/coordinator.ts
@@ -1,0 +1,344 @@
+import { Clock, Data, Effect, Option, Schema } from 'effect'
+
+import {
+  BrokerMutation,
+  MutationEvidenceSchema,
+  MutationFailure,
+  MutationOperation,
+  cancelRequestHash,
+  orderRequestBody,
+  type MutationEvidence,
+} from '../broker/alpaca-mutations'
+import {
+  BrokerRead,
+  BrokerReadError,
+  BrokerReadErrorKind,
+  OrderStatus,
+  type Order,
+  type ReadEvidence,
+} from '../broker/alpaca'
+import { canonicalHashV1 } from '../hash'
+import { IntentState, TerminalOutcome, type Intent } from '../paper'
+import { IntentStore } from './intents'
+import { MutationEventType, MutationStore, type MutationEvent } from './mutations'
+import { WriterFence } from './writer-fence'
+
+export enum ExecutionFailure {
+  IntentNotFound = 'INTENT_NOT_FOUND',
+  InvalidState = 'INVALID_STATE',
+  RecoveryTooEarly = 'RECOVERY_TOO_EARLY',
+}
+
+export class ExecutionError extends Data.TaggedError('ExecutionError')<{
+  readonly operation: MutationOperation
+  readonly failure: ExecutionFailure
+  readonly message: string
+  readonly eligibleAt?: string
+  readonly cause?: unknown
+}> {}
+
+const now = Clock.currentTimeMillis.pipe(Effect.map((millis) => new Date(millis).toISOString()))
+
+const readIntent = (operation: MutationOperation, intentId: string) =>
+  Effect.gen(function* () {
+    const store = yield* IntentStore
+    const stored = yield* store.read(intentId)
+    if (Option.isNone(stored)) {
+      return yield* Effect.fail(
+        new ExecutionError({
+          operation,
+          failure: ExecutionFailure.IntentNotFound,
+          message: `intent ${intentId} does not exist`,
+        }),
+      )
+    }
+    return stored.value
+  })
+
+const nextInstant = (instant: string, current: string): string =>
+  new Date(Math.max(Date.parse(current), Date.parse(instant) + 1)).toISOString()
+
+const requestHash = (operation: MutationOperation, intent: Intent) =>
+  Effect.try({
+    try: () => canonicalHashV1(orderRequestBody(intent)),
+    catch: (cause) =>
+      new ExecutionError({
+        operation,
+        failure: ExecutionFailure.InvalidState,
+        message: 'intent cannot be represented as an Alpaca paper order',
+        cause,
+      }),
+  })
+
+const terminalOutcome = (status: OrderStatus): TerminalOutcome | undefined => {
+  switch (status) {
+    case OrderStatus.Filled:
+      return TerminalOutcome.Filled
+    case OrderStatus.Canceled:
+      return TerminalOutcome.Canceled
+    case OrderStatus.Expired:
+      return TerminalOutcome.Expired
+    case OrderStatus.Rejected:
+      return TerminalOutcome.Rejected
+    default:
+      return undefined
+  }
+}
+
+const exactOrder = (intent: Intent, order: Order): boolean => {
+  const body = orderRequestBody(intent)
+  return (
+    order.accountId === intent.accountId &&
+    order.clientOrderId === intent.clientOrderId &&
+    order.symbol === intent.symbol &&
+    order.side === body.side &&
+    order.orderType === body.type &&
+    order.timeInForce === body.time_in_force &&
+    order.quantityMicros === intent.quantityMicros &&
+    order.extendedHours === false
+  )
+}
+
+const isCompleteEvidence = (value: unknown): value is MutationEvidence => Schema.is(MutationEvidenceSchema)(value)
+
+const mutationEvidence = (evidence: ReadEvidence): MutationEvidence => ({
+  requestId: evidence.requestId,
+  status: evidence.status,
+  contentHash: evidence.contentHash,
+  observedAt: evidence.observedAt,
+})
+
+const readErrorEvidence = (error: BrokerReadError): MutationEvidence | undefined => {
+  const candidate = {
+    requestId: error.requestId,
+    status: error.status,
+    contentHash: error.contentHash,
+    observedAt: error.observedAt,
+  }
+  return isCompleteEvidence(candidate) ? candidate : undefined
+}
+
+const isSubmitResolved = (event: MutationEvent): boolean =>
+  event.eventType === MutationEventType.SubmitAccepted ||
+  event.eventType === MutationEventType.SubmitRejected ||
+  event.eventType === MutationEventType.RecoveryFound
+
+const validateRecovery = (stored: Intent, event: MutationEvent) =>
+  Effect.gen(function* () {
+    const expectedHash =
+      event.operation === MutationOperation.Submit
+        ? yield* requestHash(event.operation, stored)
+        : event.brokerOrderId === undefined
+          ? undefined
+          : cancelRequestHash(event.brokerOrderId)
+    const validState =
+      event.operation === MutationOperation.Submit
+        ? stored.state === IntentState.IoStarted || stored.state === IntentState.Unknown
+        : stored.state === IntentState.Acknowledged
+    if (expectedHash === event.requestHash && validState) return
+    return yield* Effect.fail(
+      new ExecutionError({
+        operation: event.operation,
+        failure: ExecutionFailure.InvalidState,
+        message: 'durable mutation identity or intent state does not permit broker recovery',
+      }),
+    )
+  })
+
+export const submit = (intentId: string, consistencyDelayMs: number) =>
+  Effect.gen(function* () {
+    const intents = yield* IntentStore
+    const mutations = yield* MutationStore
+    const broker = yield* BrokerMutation
+    const fence = yield* WriterFence
+    const before = yield* readIntent(MutationOperation.Submit, intentId)
+    const hash = yield* requestHash(MutationOperation.Submit, before.intent)
+    const current = yield* now
+    const started = yield* mutations.beginSubmit(
+      intentId,
+      hash,
+      consistencyDelayMs,
+      nextInstant(before.updatedAt, current),
+    )
+    if (!started.started) return started.event
+
+    const after = yield* intents.read(intentId)
+    if (Option.isNone(after) || after.value.intent.state !== IntentState.IoStarted) {
+      return yield* Effect.fail(
+        new ExecutionError({
+          operation: MutationOperation.Submit,
+          failure: ExecutionFailure.InvalidState,
+          message: 'started submit cannot read back its IO_STARTED intent',
+        }),
+      )
+    }
+    yield* fence.check
+
+    return yield* broker.submit(after.value.intent).pipe(
+      Effect.matchEffect({
+        onFailure: (error) => {
+          if (
+            error.failure === MutationFailure.Rejected &&
+            error.requestHash === hash &&
+            isCompleteEvidence(error.evidence)
+          ) {
+            return mutations.submitRejected(intentId, hash, error.evidence)
+          }
+          return isCompleteEvidence(error.evidence)
+            ? mutations.submitUnknown(intentId, hash, error.evidence.observedAt, error.evidence)
+            : now.pipe(Effect.flatMap((occurredAt) => mutations.submitUnknown(intentId, hash, occurredAt)))
+        },
+        onSuccess: (receipt) => {
+          if (receipt.requestHash !== hash || !exactOrder(after.value.intent, receipt.order)) {
+            return mutations.submitUnknown(intentId, hash, receipt.evidence.observedAt, receipt.evidence)
+          }
+          return mutations.submitAccepted(
+            intentId,
+            hash,
+            receipt.order.brokerOrderId,
+            receipt.evidence,
+            terminalOutcome(receipt.order.status),
+          )
+        },
+      }),
+    )
+  })
+
+const brokerOrderId = (event: MutationEvent | undefined): string | undefined => {
+  if (event?.eventType === MutationEventType.SubmitAccepted) return event.brokerOrderId
+  if (event?.eventType === MutationEventType.RecoveryFound) return event.brokerOrderId
+  return undefined
+}
+
+export const cancel = (intentId: string, consistencyDelayMs: number) =>
+  Effect.gen(function* () {
+    const mutations = yield* MutationStore
+    const broker = yield* BrokerMutation
+    const fence = yield* WriterFence
+    const intent = yield* readIntent(MutationOperation.Cancel, intentId)
+    const submitEvent = yield* mutations.latest(intentId, MutationOperation.Submit)
+    const orderId = brokerOrderId(submitEvent)
+    if (orderId === undefined) {
+      return yield* Effect.fail(
+        new ExecutionError({
+          operation: MutationOperation.Cancel,
+          failure: ExecutionFailure.InvalidState,
+          message: 'cancellation requires a positively identified broker order',
+        }),
+      )
+    }
+    const hash = cancelRequestHash(orderId)
+    const current = yield* now
+    const started = yield* mutations.beginCancel(
+      intentId,
+      hash,
+      orderId,
+      consistencyDelayMs,
+      nextInstant(intent.updatedAt, current),
+    )
+    if (!started.started) return started.event
+    yield* fence.check
+
+    return yield* broker.cancel(orderId).pipe(
+      Effect.matchEffect({
+        onFailure: (error) =>
+          isCompleteEvidence(error.evidence)
+            ? mutations.cancelUnknown(intentId, hash, orderId, error.evidence.observedAt, error.evidence)
+            : now.pipe(Effect.flatMap((occurredAt) => mutations.cancelUnknown(intentId, hash, orderId, occurredAt))),
+        onSuccess: (receipt) => {
+          if (receipt.requestHash !== hash || receipt.brokerOrderId !== orderId) {
+            return mutations.cancelUnknown(intentId, hash, orderId, receipt.evidence.observedAt, receipt.evidence)
+          }
+          return mutations.cancelAccepted(intentId, hash, orderId, receipt.evidence)
+        },
+      }),
+    )
+  })
+
+const ensureRecoveryDelay = (operation: MutationOperation, event: MutationEvent, currentMillis: number) => {
+  const eligibleMillis = Date.parse(event.occurredAt) + event.consistencyDelayMs
+  if (currentMillis >= eligibleMillis) return Effect.void
+  const eligibleAt = new Date(eligibleMillis).toISOString()
+  return Effect.fail(
+    new ExecutionError({
+      operation,
+      failure: ExecutionFailure.RecoveryTooEarly,
+      message: `broker lookup is not allowed before ${eligibleAt}`,
+      eligibleAt,
+    }),
+  )
+}
+
+const markInterruptedStart = (event: MutationEvent, occurredAt: string) =>
+  Effect.flatMap(MutationStore, (store) => {
+    if (event.eventType === MutationEventType.SubmitStarted) {
+      return store.submitUnknown(event.intentId, event.requestHash, occurredAt)
+    }
+    if (event.eventType === MutationEventType.CancelStarted && event.brokerOrderId !== undefined) {
+      return store.cancelUnknown(event.intentId, event.requestHash, event.brokerOrderId, occurredAt)
+    }
+    return Effect.succeed(event)
+  })
+
+export const recover = (intentId: string, operation: MutationOperation) =>
+  Effect.gen(function* () {
+    const mutations = yield* MutationStore
+    const broker = yield* BrokerRead
+    const stored = yield* readIntent(operation, intentId)
+    const latest = yield* mutations.latest(intentId, operation)
+    if (latest === undefined) {
+      return yield* Effect.fail(
+        new ExecutionError({
+          operation,
+          failure: ExecutionFailure.InvalidState,
+          message: 'mutation does not exist',
+        }),
+      )
+    }
+    if (operation === MutationOperation.Submit && isSubmitResolved(latest)) return latest
+    if (
+      operation === MutationOperation.Cancel &&
+      stored.intent.state === IntentState.Terminal &&
+      latest.eventType === MutationEventType.RecoveryFound
+    ) {
+      return latest
+    }
+    yield* validateRecovery(stored.intent, latest)
+
+    const currentMillis = yield* Clock.currentTimeMillis
+    yield* ensureRecoveryDelay(operation, latest, currentMillis)
+    const interrupted = yield* markInterruptedStart(latest, new Date(currentMillis).toISOString())
+
+    return yield* broker.orderByClientId(stored.intent.clientOrderId).pipe(
+      Effect.matchEffect({
+        onFailure: (error) => {
+          const evidence = readErrorEvidence(error)
+          if (error.kind === BrokerReadErrorKind.NotFound && evidence !== undefined) {
+            return mutations.recoveryNotFound(intentId, operation, interrupted.requestHash, evidence)
+          }
+          const occurredAt = evidence?.observedAt ?? new Date(currentMillis).toISOString()
+          return mutations.recoveryUnknown(intentId, operation, interrupted.requestHash, occurredAt, evidence)
+        },
+        onSuccess: (result) => {
+          const evidence = mutationEvidence(result.evidence)
+          if (!exactOrder(stored.intent, result.value)) {
+            return mutations.recoveryUnknown(
+              intentId,
+              operation,
+              interrupted.requestHash,
+              evidence.observedAt,
+              evidence,
+            )
+          }
+          return mutations.recoveryFound(
+            intentId,
+            operation,
+            interrupted.requestHash,
+            result.value.brokerOrderId,
+            evidence,
+            terminalOutcome(result.value.status),
+          )
+        },
+      }),
+    )
+  })

--- a/services/bayn/src/execution/mutations.ts
+++ b/services/bayn/src/execution/mutations.ts
@@ -1,0 +1,806 @@
+import { PgClient } from '@effect/sql-pg'
+import { Context, Data, Effect, Layer, Schema } from 'effect'
+
+import { canonicalHashV1 } from '../hash'
+import { Authority, IntentState, KillState, TerminalOutcome } from '../paper'
+import {
+  Sha256Schema as Sha256,
+  StrictNonEmptyStringSchema as NonEmptyString,
+  UtcInstantSchema as UtcInstant,
+  strictParseOptions,
+} from '../schemas'
+import { MutationEvidenceSchema, MutationOperation, type MutationEvidence } from '../broker/alpaca-mutations'
+import { mutationFence, WriterFence, WriterFenceError } from './writer-fence'
+
+export enum MutationEventType {
+  SubmitStarted = 'SUBMIT_STARTED',
+  SubmitAccepted = 'SUBMIT_ACCEPTED',
+  SubmitRejected = 'SUBMIT_REJECTED',
+  SubmitUnknown = 'SUBMIT_UNKNOWN',
+  RecoveryFound = 'RECOVERY_FOUND',
+  RecoveryNotFound = 'RECOVERY_NOT_FOUND',
+  RecoveryUnknown = 'RECOVERY_UNKNOWN',
+  CancelStarted = 'CANCEL_STARTED',
+  CancelAccepted = 'CANCEL_ACCEPTED',
+  CancelUnknown = 'CANCEL_UNKNOWN',
+}
+
+const Sequence = Schema.Int.check(Schema.isGreaterThan(0))
+const HttpStatus = Schema.Int.check(Schema.isBetween({ minimum: 100, maximum: 599 }))
+const ConsistencyDelay = Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 300_000 }))
+const MutationEventSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.paper-mutation-event.v1'),
+  eventId: Sha256,
+  mutationId: Sha256,
+  intentId: Sha256,
+  sequence: Sequence,
+  operation: Schema.Enum(MutationOperation),
+  eventType: Schema.Enum(MutationEventType),
+  requestHash: Sha256,
+  consistencyDelayMs: ConsistencyDelay,
+  brokerOrderId: Schema.optionalKey(NonEmptyString),
+  requestId: Schema.optionalKey(NonEmptyString),
+  responseStatus: Schema.optionalKey(HttpStatus),
+  responseContentHash: Schema.optionalKey(Sha256),
+  occurredAt: UtcInstant,
+})
+export type MutationEvent = typeof MutationEventSchema.Type
+
+const StoredEventRow = Schema.Struct({
+  schema_version: Schema.Literal('bayn.paper-mutation-event.v1'),
+  event_id: Sha256,
+  mutation_id: Sha256,
+  intent_id: Sha256,
+  sequence: Sequence,
+  operation: Schema.Enum(MutationOperation),
+  event_type: Schema.Enum(MutationEventType),
+  request_hash: Sha256,
+  consistency_delay_ms: ConsistencyDelay,
+  broker_order_id: Schema.NullOr(NonEmptyString),
+  request_id: Schema.NullOr(NonEmptyString),
+  response_status: Schema.NullOr(HttpStatus),
+  response_content_hash: Schema.NullOr(Sha256),
+  occurred_at: UtcInstant,
+})
+const decodeRows = Schema.decodeUnknownEffect(Schema.Array(StoredEventRow), strictParseOptions)
+const decodeSha = Schema.decodeUnknownEffect(Sha256)
+const decodeTime = Schema.decodeUnknownEffect(UtcInstant)
+const decodeBrokerOrderId = Schema.decodeUnknownEffect(NonEmptyString.check(Schema.isMaxLength(256)))
+const decodeEvidence = Schema.decodeUnknownEffect(MutationEvidenceSchema, strictParseOptions)
+
+const eventIdentity = (event: Omit<MutationEvent, 'eventId'>) => ({
+  schemaVersion: event.schemaVersion,
+  mutationId: event.mutationId,
+  intentId: event.intentId,
+  sequence: event.sequence,
+  operation: event.operation,
+  eventType: event.eventType,
+  requestHash: event.requestHash,
+  consistencyDelayMs: event.consistencyDelayMs,
+  ...(event.brokerOrderId === undefined ? {} : { brokerOrderId: event.brokerOrderId }),
+  ...(event.requestId === undefined ? {} : { requestId: event.requestId }),
+  ...(event.responseStatus === undefined ? {} : { responseStatus: event.responseStatus }),
+  ...(event.responseContentHash === undefined ? {} : { responseContentHash: event.responseContentHash }),
+  occurredAt: event.occurredAt,
+})
+
+export const mutationId = (intentId: string, operation: MutationOperation): string =>
+  canonicalHashV1({ schemaVersion: 'bayn.paper-mutation.v1', intentId, operation })
+
+const makeEvent = (event: Omit<MutationEvent, 'eventId' | 'schemaVersion'>): MutationEvent => {
+  const content = { schemaVersion: 'bayn.paper-mutation-event.v1' as const, ...event }
+  return { ...content, eventId: canonicalHashV1(eventIdentity(content)) }
+}
+
+const toEvent = (row: typeof StoredEventRow.Type): MutationEvent => ({
+  schemaVersion: row.schema_version,
+  eventId: row.event_id,
+  mutationId: row.mutation_id,
+  intentId: row.intent_id,
+  sequence: row.sequence,
+  operation: row.operation,
+  eventType: row.event_type,
+  requestHash: row.request_hash,
+  consistencyDelayMs: row.consistency_delay_ms,
+  ...(row.broker_order_id === null ? {} : { brokerOrderId: row.broker_order_id }),
+  ...(row.request_id === null ? {} : { requestId: row.request_id }),
+  ...(row.response_status === null ? {} : { responseStatus: row.response_status }),
+  ...(row.response_content_hash === null ? {} : { responseContentHash: row.response_content_hash }),
+  occurredAt: row.occurred_at,
+})
+
+export class MutationStoreError extends Data.TaggedError('MutationStoreError')<{
+  readonly operation: 'begin-submit' | 'record-submit' | 'begin-cancel' | 'record-cancel' | 'record-recovery' | 'read'
+  readonly failure: 'authority' | 'conflict' | 'decode' | 'invariant' | 'query'
+  readonly message: string
+  readonly cause?: unknown
+}> {}
+
+export interface StartReceipt {
+  readonly event: MutationEvent
+  readonly started: boolean
+}
+
+export interface MutationStoreShape {
+  readonly beginSubmit: (
+    intentId: string,
+    requestHash: string,
+    consistencyDelayMs: number,
+    occurredAt: string,
+  ) => Effect.Effect<StartReceipt, MutationStoreError | WriterFenceError>
+  readonly submitAccepted: (
+    intentId: string,
+    requestHash: string,
+    brokerOrderId: string,
+    evidence: MutationEvidence,
+    terminalOutcome?: TerminalOutcome,
+  ) => Effect.Effect<MutationEvent, MutationStoreError | WriterFenceError>
+  readonly submitRejected: (
+    intentId: string,
+    requestHash: string,
+    evidence: MutationEvidence,
+  ) => Effect.Effect<MutationEvent, MutationStoreError | WriterFenceError>
+  readonly submitUnknown: (
+    intentId: string,
+    requestHash: string,
+    occurredAt: string,
+    evidence?: Partial<MutationEvidence>,
+  ) => Effect.Effect<MutationEvent, MutationStoreError | WriterFenceError>
+  readonly beginCancel: (
+    intentId: string,
+    requestHash: string,
+    brokerOrderId: string,
+    consistencyDelayMs: number,
+    occurredAt: string,
+  ) => Effect.Effect<StartReceipt, MutationStoreError | WriterFenceError>
+  readonly cancelAccepted: (
+    intentId: string,
+    requestHash: string,
+    brokerOrderId: string,
+    evidence: MutationEvidence,
+  ) => Effect.Effect<MutationEvent, MutationStoreError | WriterFenceError>
+  readonly cancelUnknown: (
+    intentId: string,
+    requestHash: string,
+    brokerOrderId: string,
+    occurredAt: string,
+    evidence?: Partial<MutationEvidence>,
+  ) => Effect.Effect<MutationEvent, MutationStoreError | WriterFenceError>
+  readonly recoveryFound: (
+    intentId: string,
+    operation: MutationOperation,
+    requestHash: string,
+    brokerOrderId: string,
+    evidence: MutationEvidence,
+    terminalOutcome?: TerminalOutcome,
+  ) => Effect.Effect<MutationEvent, MutationStoreError | WriterFenceError>
+  readonly recoveryNotFound: (
+    intentId: string,
+    operation: MutationOperation,
+    requestHash: string,
+    evidence: MutationEvidence,
+  ) => Effect.Effect<MutationEvent, MutationStoreError | WriterFenceError>
+  readonly recoveryUnknown: (
+    intentId: string,
+    operation: MutationOperation,
+    requestHash: string,
+    occurredAt: string,
+    evidence?: Partial<MutationEvidence>,
+  ) => Effect.Effect<MutationEvent, MutationStoreError | WriterFenceError>
+  readonly latest: (
+    intentId: string,
+    operation: MutationOperation,
+  ) => Effect.Effect<MutationEvent | undefined, MutationStoreError>
+}
+
+export class MutationStore extends Context.Service<MutationStore, MutationStoreShape>()('bayn/MutationStore') {}
+
+const storeError = (
+  operation: MutationStoreError['operation'],
+  failure: MutationStoreError['failure'],
+  message: string,
+  cause?: unknown,
+) => new MutationStoreError({ operation, failure, message, cause })
+
+const selectLatest = (sql: PgClient.PgClient, intentId: string, operation: MutationOperation) => sql`
+  SELECT
+    schema_version,
+    event_id,
+    mutation_id,
+    intent_id,
+    sequence::integer,
+    operation,
+    event_type,
+    request_hash,
+    consistency_delay_ms,
+    broker_order_id,
+    request_id,
+    response_status::integer,
+    response_content_hash,
+    to_char(occurred_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS occurred_at
+  FROM mutation_events
+  WHERE intent_id = ${intentId} AND operation = ${operation}
+  ORDER BY sequence DESC
+  LIMIT 1
+`
+
+const makeStore = Effect.gen(function* () {
+  const sql = yield* PgClient.PgClient
+  const fence = yield* WriterFence
+
+  const run = <A, E, R>(
+    operation: MutationStoreError['operation'],
+    effect: Effect.Effect<A, E, R>,
+  ): Effect.Effect<A, MutationStoreError | WriterFenceError, R> =>
+    effect.pipe(
+      Effect.mapError((cause) =>
+        cause instanceof MutationStoreError || cause instanceof WriterFenceError
+          ? cause
+          : storeError(operation, 'query', `mutation ${operation} failed`, cause),
+      ),
+    )
+
+  const withFence = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+    sql.withTransaction(
+      Effect.gen(function* () {
+        yield* sql`SELECT pg_advisory_xact_lock(${mutationFence.namespace}, ${mutationFence.key})`
+        yield* fence.check
+        return yield* effect
+      }),
+    )
+
+  const latest = (intentId: string, operation: MutationOperation) =>
+    Effect.gen(function* () {
+      const decodedIntentId = yield* decodeSha(intentId).pipe(
+        Effect.mapError((cause) => storeError('read', 'decode', 'invalid intent ID', cause)),
+      )
+      const rows = yield* decodeRows(yield* selectLatest(sql, decodedIntentId, operation)).pipe(
+        Effect.mapError((cause) => storeError('read', 'decode', 'stored mutation event failed decoding', cause)),
+      )
+      return rows[0] === undefined ? undefined : toEvent(rows[0])
+    }).pipe(
+      Effect.mapError((cause) =>
+        cause instanceof MutationStoreError ? cause : storeError('read', 'query', 'mutation read failed', cause),
+      ),
+    )
+
+  const append = (event: MutationEvent) =>
+    Effect.as(
+      sql`
+        INSERT INTO mutation_events (
+          event_id,
+          schema_version,
+          mutation_id,
+          intent_id,
+          sequence,
+          operation,
+          event_type,
+          request_hash,
+          consistency_delay_ms,
+          broker_order_id,
+          request_id,
+          response_status,
+          response_content_hash,
+          occurred_at
+        ) VALUES (
+          ${event.eventId},
+          ${event.schemaVersion},
+          ${event.mutationId},
+          ${event.intentId},
+          ${event.sequence},
+          ${event.operation},
+          ${event.eventType},
+          ${event.requestHash},
+          ${event.consistencyDelayMs},
+          ${event.brokerOrderId ?? null},
+          ${event.requestId ?? null},
+          ${event.responseStatus ?? null},
+          ${event.responseContentHash ?? null},
+          ${event.occurredAt}
+        )
+      `,
+      event,
+    )
+
+  const assertAuthority = (operation: 'submit' | 'cancel') =>
+    Effect.gen(function* () {
+      const rows = yield* sql<{ effective: string; kill_state: string; maximum: string }>`
+        SELECT maximum, effective, kill_state
+        FROM authority_state
+        WHERE singleton
+        FOR UPDATE
+      `
+      const authority = rows[0]
+      if (authority === undefined) {
+        return yield* Effect.fail(
+          storeError(
+            operation === 'submit' ? 'begin-submit' : 'begin-cancel',
+            'authority',
+            'paper authority is not initialized',
+          ),
+        )
+      }
+      if (authority.maximum !== Authority.Paper) {
+        return yield* Effect.fail(
+          storeError(
+            operation === 'submit' ? 'begin-submit' : 'begin-cancel',
+            'authority',
+            'GitOps maximum authority is not PAPER',
+          ),
+        )
+      }
+      if (
+        operation === 'submit' &&
+        (authority.effective !== Authority.Paper || authority.kill_state !== KillState.Clear)
+      ) {
+        return yield* Effect.fail(storeError('begin-submit', 'authority', 'effective authority is not PAPER and clear'))
+      }
+      if (
+        operation === 'cancel' &&
+        authority.kill_state === KillState.Clear &&
+        authority.effective !== Authority.Paper
+      ) {
+        return yield* Effect.fail(
+          storeError('begin-cancel', 'authority', 'cancellation requires PAPER authority or an active kill'),
+        )
+      }
+    })
+
+  const assertNoOtherUnresolved = (intentId: string) =>
+    Effect.gen(function* () {
+      const rows = yield* sql<{ unresolved: boolean }>`
+        SELECT EXISTS (
+          SELECT 1
+          FROM (
+            SELECT DISTINCT ON (events.mutation_id)
+              events.intent_id,
+              events.operation,
+              events.event_type,
+              intents.state
+            FROM mutation_events AS events
+            JOIN intents ON intents.intent_id = events.intent_id
+            ORDER BY events.mutation_id, events.sequence DESC
+          ) AS latest
+          WHERE latest.intent_id <> ${intentId}
+            AND (
+              latest.event_type IN (
+                'SUBMIT_STARTED',
+                'SUBMIT_UNKNOWN',
+                'RECOVERY_NOT_FOUND',
+                'RECOVERY_UNKNOWN',
+                'CANCEL_STARTED',
+                'CANCEL_ACCEPTED',
+                'CANCEL_UNKNOWN'
+              )
+              OR (
+                latest.operation = 'CANCEL'
+                AND latest.event_type = 'RECOVERY_FOUND'
+                AND latest.state <> 'TERMINAL'
+              )
+            )
+        ) AS unresolved
+      `
+      if (rows[0]?.unresolved !== false) {
+        return yield* Effect.fail(
+          storeError('begin-submit', 'invariant', 'another broker mutation has an unresolved outcome'),
+        )
+      }
+    })
+
+  const begin = (
+    operation: MutationOperation,
+    intentId: string,
+    requestHash: string,
+    consistencyDelayMs: number,
+    occurredAt: string,
+    brokerOrderId?: string,
+  ) =>
+    run(
+      operation === MutationOperation.Submit ? 'begin-submit' : 'begin-cancel',
+      Effect.gen(function* () {
+        const decodedIntentId = yield* decodeSha(intentId).pipe(
+          Effect.mapError((cause) =>
+            storeError(
+              operation === MutationOperation.Submit ? 'begin-submit' : 'begin-cancel',
+              'decode',
+              'invalid intent ID',
+              cause,
+            ),
+          ),
+        )
+        const decodedRequestHash = yield* decodeSha(requestHash).pipe(
+          Effect.mapError((cause) =>
+            storeError(
+              operation === MutationOperation.Submit ? 'begin-submit' : 'begin-cancel',
+              'decode',
+              'invalid request hash',
+              cause,
+            ),
+          ),
+        )
+        const decodedConsistencyDelay = yield* Schema.decodeUnknownEffect(ConsistencyDelay)(consistencyDelayMs).pipe(
+          Effect.mapError((cause) =>
+            storeError(
+              operation === MutationOperation.Submit ? 'begin-submit' : 'begin-cancel',
+              'decode',
+              'invalid broker consistency delay',
+              cause,
+            ),
+          ),
+        )
+        const decodedTime = yield* decodeTime(occurredAt).pipe(
+          Effect.mapError((cause) =>
+            storeError(
+              operation === MutationOperation.Submit ? 'begin-submit' : 'begin-cancel',
+              'decode',
+              'invalid mutation time',
+              cause,
+            ),
+          ),
+        )
+        const decodedBrokerOrderId =
+          brokerOrderId === undefined
+            ? undefined
+            : yield* decodeBrokerOrderId(brokerOrderId).pipe(
+                Effect.mapError((cause) =>
+                  storeError(
+                    operation === MutationOperation.Submit ? 'begin-submit' : 'begin-cancel',
+                    'decode',
+                    'invalid broker order ID',
+                    cause,
+                  ),
+                ),
+              )
+        return yield* withFence(
+          Effect.gen(function* () {
+            const existing = yield* latest(decodedIntentId, operation)
+            if (existing !== undefined) {
+              if (
+                existing.requestHash !== decodedRequestHash ||
+                existing.consistencyDelayMs !== decodedConsistencyDelay ||
+                (operation === MutationOperation.Cancel && existing.brokerOrderId !== decodedBrokerOrderId) ||
+                existing.mutationId !== mutationId(decodedIntentId, operation)
+              ) {
+                return yield* Effect.fail(
+                  storeError(
+                    operation === MutationOperation.Submit ? 'begin-submit' : 'begin-cancel',
+                    'conflict',
+                    'mutation identity was reused with different request content',
+                  ),
+                )
+              }
+              return { event: existing, started: false } satisfies StartReceipt
+            }
+
+            yield* assertAuthority(operation === MutationOperation.Submit ? 'submit' : 'cancel')
+            if (operation === MutationOperation.Submit) yield* assertNoOtherUnresolved(decodedIntentId)
+            const intents = yield* sql<{ state: string; updated_at: string }>`
+              SELECT state, to_char(updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS updated_at
+              FROM intents
+              WHERE intent_id = ${decodedIntentId}
+              FOR UPDATE
+            `
+            const intent = intents[0]
+            if (intent === undefined) {
+              return yield* Effect.fail(
+                storeError(
+                  operation === MutationOperation.Submit ? 'begin-submit' : 'begin-cancel',
+                  'invariant',
+                  'intent does not exist',
+                ),
+              )
+            }
+            const requiredState =
+              operation === MutationOperation.Submit ? IntentState.Approved : IntentState.Acknowledged
+            if (intent.state !== requiredState) {
+              return yield* Effect.fail(
+                storeError(
+                  operation === MutationOperation.Submit ? 'begin-submit' : 'begin-cancel',
+                  'invariant',
+                  `${operation.toLowerCase()} requires an ${requiredState} intent`,
+                ),
+              )
+            }
+            if (decodedTime <= intent.updated_at) {
+              return yield* Effect.fail(
+                storeError(
+                  operation === MutationOperation.Submit ? 'begin-submit' : 'begin-cancel',
+                  'invariant',
+                  'mutation time must follow the intent state',
+                ),
+              )
+            }
+
+            const event = makeEvent({
+              mutationId: mutationId(decodedIntentId, operation),
+              intentId: decodedIntentId,
+              sequence: 1,
+              operation,
+              eventType:
+                operation === MutationOperation.Submit
+                  ? MutationEventType.SubmitStarted
+                  : MutationEventType.CancelStarted,
+              requestHash: decodedRequestHash,
+              consistencyDelayMs: decodedConsistencyDelay,
+              ...(decodedBrokerOrderId === undefined ? {} : { brokerOrderId: decodedBrokerOrderId }),
+              occurredAt: decodedTime,
+            })
+            yield* append(event)
+            if (operation === MutationOperation.Submit) {
+              const transitioned = yield* sql<{ intent_id: string }>`
+                UPDATE intents
+                SET state = ${IntentState.IoStarted}, state_version = state_version + 1, updated_at = ${decodedTime}
+                WHERE intent_id = ${decodedIntentId} AND state = ${IntentState.Approved}
+                RETURNING intent_id
+              `
+              if (transitioned.length !== 1) {
+                return yield* Effect.fail(
+                  storeError('begin-submit', 'conflict', 'approved intent transition lost its race'),
+                )
+              }
+            }
+            return { event, started: true } satisfies StartReceipt
+          }),
+        )
+      }),
+    )
+
+  const appendOutcome = (
+    storeOperation: MutationStoreError['operation'],
+    intentId: string,
+    operation: MutationOperation,
+    requestHash: string,
+    eventType: MutationEventType,
+    occurredAt: string,
+    fields: {
+      readonly brokerOrderId?: string
+      readonly evidence?: Partial<MutationEvidence>
+      readonly nextState?: IntentState
+      readonly fromState?: IntentState
+      readonly terminalOutcome?: TerminalOutcome
+      readonly recover?: boolean
+    },
+  ) =>
+    run(
+      storeOperation,
+      Effect.gen(function* () {
+        const decodedIntentId = yield* decodeSha(intentId).pipe(
+          Effect.mapError((cause) => storeError(storeOperation, 'decode', 'invalid intent ID', cause)),
+        )
+        const decodedRequestHash = yield* decodeSha(requestHash).pipe(
+          Effect.mapError((cause) => storeError(storeOperation, 'decode', 'invalid request hash', cause)),
+        )
+        const decodedTime = yield* decodeTime(occurredAt).pipe(
+          Effect.mapError((cause) => storeError(storeOperation, 'decode', 'invalid mutation time', cause)),
+        )
+        const decodedBrokerOrderId =
+          fields.brokerOrderId === undefined
+            ? undefined
+            : yield* decodeBrokerOrderId(fields.brokerOrderId).pipe(
+                Effect.mapError((cause) => storeError(storeOperation, 'decode', 'invalid broker order ID', cause)),
+              )
+        const decodedEvidence =
+          fields.evidence?.requestId === undefined ||
+          fields.evidence.status === undefined ||
+          fields.evidence.contentHash === undefined ||
+          fields.evidence.observedAt === undefined
+            ? undefined
+            : yield* decodeEvidence(fields.evidence).pipe(
+                Effect.mapError((cause) => storeError(storeOperation, 'decode', 'invalid broker evidence', cause)),
+              )
+        return yield* withFence(
+          Effect.gen(function* () {
+            const previous = yield* latest(decodedIntentId, operation)
+            if (previous === undefined) {
+              return yield* Effect.fail(
+                storeError(storeOperation, 'invariant', 'mutation STARTED event does not exist'),
+              )
+            }
+            if (previous.requestHash !== decodedRequestHash) {
+              return yield* Effect.fail(storeError(storeOperation, 'conflict', 'mutation request hash changed'))
+            }
+            const eventBrokerOrderId = decodedBrokerOrderId ?? previous.brokerOrderId
+            const event = makeEvent({
+              mutationId: previous.mutationId,
+              intentId: decodedIntentId,
+              sequence: previous.sequence + 1,
+              operation,
+              eventType,
+              requestHash: decodedRequestHash,
+              consistencyDelayMs: previous.consistencyDelayMs,
+              ...(eventBrokerOrderId === undefined ? {} : { brokerOrderId: eventBrokerOrderId }),
+              ...(decodedEvidence?.requestId === undefined ? {} : { requestId: decodedEvidence.requestId }),
+              ...(decodedEvidence?.status === undefined ? {} : { responseStatus: decodedEvidence.status }),
+              ...(decodedEvidence?.contentHash === undefined
+                ? {}
+                : { responseContentHash: decodedEvidence.contentHash }),
+              occurredAt: decodedTime,
+            })
+            if (
+              previous.eventType === event.eventType &&
+              previous.requestId === event.requestId &&
+              previous.responseStatus === event.responseStatus &&
+              previous.responseContentHash === event.responseContentHash &&
+              previous.brokerOrderId === event.brokerOrderId
+            ) {
+              return previous
+            }
+            yield* append(event)
+
+            if (fields.recover === true) {
+              const recovered = yield* sql<{ intent_id: string }>`
+                UPDATE intents
+                SET state = ${IntentState.Recovered}, state_version = state_version + 1, updated_at = ${decodedTime}
+                WHERE intent_id = ${decodedIntentId} AND state = ${IntentState.Unknown}
+                RETURNING intent_id
+              `
+              if (recovered.length !== 1) {
+                return yield* Effect.fail(
+                  storeError(storeOperation, 'conflict', 'unknown intent recovery lost its race'),
+                )
+              }
+              if (fields.nextState !== undefined) {
+                const transitioned = yield* sql<{ intent_id: string }>`
+                  UPDATE intents
+                  SET
+                    state = ${fields.nextState},
+                    terminal_outcome = ${fields.terminalOutcome ?? null},
+                    state_version = state_version + 1,
+                    updated_at = GREATEST(
+                      ${decodedTime}::timestamptz + interval '1 microsecond',
+                      updated_at + interval '1 microsecond'
+                  )
+                  WHERE intent_id = ${decodedIntentId} AND state = ${IntentState.Recovered}
+                  RETURNING intent_id
+                `
+                if (transitioned.length !== 1) {
+                  return yield* Effect.fail(
+                    storeError(storeOperation, 'conflict', 'recovered intent outcome lost its race'),
+                  )
+                }
+              }
+            } else if (fields.nextState !== undefined) {
+              const transitioned = yield* sql<{ intent_id: string }>`
+                UPDATE intents
+                SET
+                  state = ${fields.nextState},
+                  terminal_outcome = ${fields.terminalOutcome ?? null},
+                  state_version = state_version + 1,
+                  updated_at = GREATEST(${decodedTime}::timestamptz, updated_at + interval '1 microsecond')
+                WHERE intent_id = ${decodedIntentId} AND state = ${fields.fromState ?? IntentState.IoStarted}
+                RETURNING intent_id
+              `
+              if (transitioned.length !== 1) {
+                return yield* Effect.fail(
+                  storeError(storeOperation, 'conflict', 'intent mutation outcome lost its race'),
+                )
+              }
+            }
+            return event
+          }),
+        )
+      }),
+    )
+
+  const completeEvidence = (evidence: Partial<MutationEvidence> | undefined): Partial<MutationEvidence> | undefined =>
+    evidence?.requestId !== undefined &&
+    evidence.status !== undefined &&
+    evidence.contentHash !== undefined &&
+    evidence.observedAt !== undefined
+      ? evidence
+      : undefined
+
+  return {
+    beginSubmit: (intentId, requestHash, consistencyDelayMs, occurredAt) =>
+      begin(MutationOperation.Submit, intentId, requestHash, consistencyDelayMs, occurredAt),
+    submitAccepted: (intentId, requestHash, brokerOrderId, evidence, terminalOutcome) => {
+      const terminal = terminalOutcome !== undefined
+      return appendOutcome(
+        'record-submit',
+        intentId,
+        MutationOperation.Submit,
+        requestHash,
+        MutationEventType.SubmitAccepted,
+        evidence.observedAt,
+        {
+          brokerOrderId,
+          evidence,
+          nextState: terminal ? IntentState.Terminal : IntentState.Acknowledged,
+          ...(terminalOutcome === undefined ? {} : { terminalOutcome }),
+        },
+      )
+    },
+    submitRejected: (intentId, requestHash, evidence) =>
+      appendOutcome(
+        'record-submit',
+        intentId,
+        MutationOperation.Submit,
+        requestHash,
+        MutationEventType.SubmitRejected,
+        evidence.observedAt,
+        {
+          evidence,
+          nextState: IntentState.Terminal,
+          terminalOutcome: TerminalOutcome.Rejected,
+        },
+      ),
+    submitUnknown: (intentId, requestHash, occurredAt, evidence) =>
+      appendOutcome(
+        'record-submit',
+        intentId,
+        MutationOperation.Submit,
+        requestHash,
+        MutationEventType.SubmitUnknown,
+        occurredAt,
+        { evidence: completeEvidence(evidence), nextState: IntentState.Unknown },
+      ),
+    beginCancel: (intentId, requestHash, brokerOrderId, consistencyDelayMs, occurredAt) =>
+      begin(MutationOperation.Cancel, intentId, requestHash, consistencyDelayMs, occurredAt, brokerOrderId),
+    cancelAccepted: (intentId, requestHash, brokerOrderId, evidence) =>
+      appendOutcome(
+        'record-cancel',
+        intentId,
+        MutationOperation.Cancel,
+        requestHash,
+        MutationEventType.CancelAccepted,
+        evidence.observedAt,
+        { brokerOrderId, evidence },
+      ),
+    cancelUnknown: (intentId, requestHash, brokerOrderId, occurredAt, evidence) =>
+      appendOutcome(
+        'record-cancel',
+        intentId,
+        MutationOperation.Cancel,
+        requestHash,
+        MutationEventType.CancelUnknown,
+        occurredAt,
+        { brokerOrderId, evidence: completeEvidence(evidence) },
+      ),
+    recoveryFound: (intentId, operation, requestHash, brokerOrderId, evidence, terminalOutcome) => {
+      const terminal = terminalOutcome !== undefined
+      return appendOutcome(
+        'record-recovery',
+        intentId,
+        operation,
+        requestHash,
+        MutationEventType.RecoveryFound,
+        evidence.observedAt,
+        {
+          brokerOrderId,
+          evidence,
+          recover: operation === MutationOperation.Submit,
+          ...(operation === MutationOperation.Submit || terminal
+            ? {
+                nextState: terminal ? IntentState.Terminal : IntentState.Acknowledged,
+                ...(operation === MutationOperation.Cancel ? { fromState: IntentState.Acknowledged } : {}),
+                ...(terminalOutcome === undefined ? {} : { terminalOutcome }),
+              }
+            : {}),
+        },
+      )
+    },
+    recoveryNotFound: (intentId, operation, requestHash, evidence) =>
+      appendOutcome(
+        'record-recovery',
+        intentId,
+        operation,
+        requestHash,
+        MutationEventType.RecoveryNotFound,
+        evidence.observedAt,
+        { evidence },
+      ),
+    recoveryUnknown: (intentId, operation, requestHash, occurredAt, evidence) =>
+      appendOutcome(
+        'record-recovery',
+        intentId,
+        operation,
+        requestHash,
+        MutationEventType.RecoveryUnknown,
+        occurredAt,
+        { evidence: completeEvidence(evidence) },
+      ),
+    latest,
+  } satisfies MutationStoreShape
+})
+
+export const MutationStoreLive = Layer.effect(MutationStore, makeStore)


### PR DESCRIPTION
## Summary

- add a typed Alpaca paper submit/cancel adapter with exact request/response identity, bounded interruption, and no mutation retry
- commit an append-only PostgreSQL mutation state machine under paper authority and the single-writer fence before broker I/O
- recover ambiguous submit/cancel outcomes only by deterministic client-order lookup after the committed consistency delay
- keep the capability dormant: no runtime composition, broker credential, public order route, scheduler, or authority expansion
- document the dormant boundary and its explicit enablement gates

## Related Issues

Related to PROOMPT-375. The issue remains open until qualification and dedicated-paper-account gates allow live recovery evidence.

## Testing

- `bun run --filter @proompteng/bayn test` — 171 passed, 36 PostgreSQL tests skipped without the explicit test URL
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type` — zero warnings
- `bun run --filter @proompteng/bayn build`
- `BAYN_TEST_POSTGRES_URL=<isolated-bayn_codex_test> bun test --timeout 30000 services/bayn/src/db/evidence-store.integration.test.ts` — 33 passed
- focused final PostgreSQL rerun for concurrent submit, kill cancellation, and unresolved-outcome blocking — 3 passed
- temporary `bayn_codex_test` database and port-forward removed after validation

## Breaking Changes

Adds forward migration `5_mutation_recovery`, which creates the append-only `mutation_events` table and its transition triggers. It does not wire broker I/O or change deployed authority.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation and the Linear implementation plan are updated or already linked.