### PR TITLE
chore(bayn): promote image sha-db8d8149a539a712b6dc050d614bee28db5defa6

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: bayn
         app.kubernetes.io/part-of: bayn
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-22T12:45:10Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-22T12:57:40Z"
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
@@ -47,11 +47,11 @@ spec:
               protocol: TCP
           env:
             - name: BAYN_CODE_REVISION
-              value: 34aa763b183b0a9152cde8c15a9b47efdd2df72b
+              value: db8d8149a539a712b6dc050d614bee28db5defa6
             - name: BAYN_IMAGE_REPOSITORY
               value: registry.ide-newton.ts.net/lab/bayn
             - name: BAYN_IMAGE_DIGEST
-              value: sha256:bd407dc6422cb6b222fcbbf7e60fef5d0aafe508c9ca6d7327e5443f00b98539
+              value: sha256:e48b3d491e706eb9cbb73f5b744286245e6862649fef4f4d2e264fdeb36ef2b0
             - name: BAYN_STRATEGY_BEHAVIOR_HASH
               value: "43cece33d3db232ffb02ba78826727e50b5795319d09d27e1baa0c04709eb056"
             - name: BAYN_STRATEGY_PARAMETER_HASH

--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -21,5 +21,5 @@ configMapGenerator:
 images:
   - name: registry.ide-newton.ts.net/lab/bayn
     newName: registry.ide-newton.ts.net/lab/bayn
-    newTag: "sha-34aa763b183b0a9152cde8c15a9b47efdd2df72b"
-    digest: sha256:bd407dc6422cb6b222fcbbf7e60fef5d0aafe508c9ca6d7327e5443f00b98539
+    newTag: "sha-db8d8149a539a712b6dc050d614bee28db5defa6"
+    digest: sha256:e48b3d491e706eb9cbb73f5b744286245e6862649fef4f4d2e264fdeb36ef2b0


### PR DESCRIPTION
## Summary

Promote the immutable Bayn image against the current Signal snapshot and dedicated Bayn TigerBeetle
ledger. Qualification-pin handling is selected from the verified compiled behavior identity.

- Source commit: `db8d8149a539a712b6dc050d614bee28db5defa6`
- Image tag: `sha-db8d8149a539a712b6dc050d614bee28db5defa6`
- Image digest: `sha256:e48b3d491e706eb9cbb73f5b744286245e6862649fef4f4d2e264fdeb36ef2b0`
- Qualification mode: `preserve`
- Existing pin: `true`
- Runtime bindings match: `true`
- Snapshot changed: `false`
- Deployed snapshot: `98f9b0cdee311b248d4ed36104fa46ff86c34d587d6e71a6706a9d778c110292`
- Candidate snapshot: `98f9b0cdee311b248d4ed36104fa46ff86c34d587d6e71a6706a9d778c110292`
- Deployed behavior hash: `43cece33d3db232ffb02ba78826727e50b5795319d09d27e1baa0c04709eb056`
- Candidate behavior hash: `43cece33d3db232ffb02ba78826727e50b5795319d09d27e1baa0c04709eb056`
- Deployed parameter hash: `cf639d3692da65271b12423f9b7c6c9663e1fb13ae7290dc56fcfa3acf16eb69`
- Candidate parameter hash: `cf639d3692da65271b12423f9b7c6c9663e1fb13ae7290dc56fcfa3acf16eb69`

## Related Issues

PROOMPT-400

## Testing

- OCI index contains `linux/amd64` and `linux/arm64`.

## Screenshots (if applicable)

N/A

## Breaking Changes

This is a one-way current-contract runtime release. Databases with the old migration tracker are rejected;
there is no schema fallback or automatic rename. `preserve` keeps the terminal run only when compiled
behavior, protocol parameters, Signal inputs, and TigerBeetle bindings all match. `replace` removes an
existing incompatible pin only for a fresh Signal snapshot. Once that one-shot release is unpinned, a
different source revision is rejected until the terminal run is pinned or the snapshot advances.
Promotion never creates a qualification pin.

## Checklist

- [x] Testing section documents exact validation.
- [x] Runtime source revision and image digest are immutable.
- [x] No broker or capital-promotion authority is introduced.