### PR TITLE
fix(bayn): retry postgres connection refusals

### DIFF
--- a/docs/bayn/architecture.md
+++ b/docs/bayn/architecture.md
@@ -40,10 +40,11 @@ bindings and does not load bars, open a new lock, evaluate, journal, or persist.
 the recovered run after startup.
 
 A strategy rejection is terminal economic evidence, not an operational crash. ClickHouse and PostgreSQL layer
-acquisition retry a retryable SQL failure twice at one-second intervals; authentication and other terminal failures
-fail immediately. A transient startup dependency failure that remains after bounded acquisition escapes the scoped
-runtime, closes HTTP and acquired clients, and lets the Deployment restart the process. A deterministic contract or
-evidence failure enters `FAILED` and keeps HTTP available for diagnosis with readiness closed.
+acquisition retry a transient SQL failure twice at one-second intervals. PostgreSQL connection failures reported by
+the driver as `UnknownError` are retryable only for its `connect` operation; authentication and other terminal
+failures fail immediately. A transient startup dependency failure that remains after bounded acquisition escapes the
+scoped runtime, closes HTTP and acquired clients, and lets the Deployment restart the process. A deterministic
+contract or evidence failure enters `FAILED` and keeps HTTP available for diagnosis with readiness closed.
 
 ## Dormant paper mutation boundary
 

--- a/services/bayn/src/operations.test.ts
+++ b/services/bayn/src/operations.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, test } from 'bun:test'
 
 import { Effect, Exit, Fiber, Layer } from 'effect'
 import { TestClock } from 'effect/testing'
-import { AuthenticationError, AuthorizationError, ConnectionError, SqlError } from 'effect/unstable/sql/SqlError'
+import {
+  AuthenticationError,
+  AuthorizationError,
+  ConnectionError,
+  SqlError,
+  UnknownError,
+} from 'effect/unstable/sql/SqlError'
 
 import { DatabaseError } from './db/evidence-store'
 import { acquireSqlLayer, databaseOperation } from './operations'
@@ -67,6 +73,36 @@ describe('Bayn SQL dependency acquisition', () => {
       Effect.suspend(() => {
         attempts += 1
         return attempts === 1 ? Effect.fail(unavailable) : Effect.void
+      }),
+    )
+    const program = Effect.scoped(
+      Effect.gen(function* () {
+        const fiber = yield* acquireSqlLayer(dependencies).pipe(Effect.forkScoped({ startImmediately: true }))
+        yield* Effect.yieldNow
+        expect(attempts).toBe(1)
+        yield* TestClock.adjust('1 second')
+        yield* Fiber.join(fiber)
+        expect(attempts).toBe(2)
+      }),
+    ).pipe(Effect.provide(TestClock.layer()))
+
+    await Effect.runPromise(program)
+  })
+
+  test('retries a PostgreSQL connection refusal reported as an unknown SQL error', async () => {
+    let attempts = 0
+    const connectionRefused = new DatabaseError({
+      failure: 'unavailable',
+      operation: 'connect',
+      message: 'PostgreSQL operation failed',
+      cause: new SqlError({
+        reason: new UnknownError({ cause: new Error('connect ECONNREFUSED'), operation: 'connect' }),
+      }),
+    })
+    const dependencies = Layer.effectDiscard(
+      Effect.suspend(() => {
+        attempts += 1
+        return attempts === 1 ? Effect.fail(connectionRefused) : Effect.void
       }),
     )
     const program = Effect.scoped(

--- a/services/bayn/src/operations.ts
+++ b/services/bayn/src/operations.ts
@@ -5,13 +5,9 @@ import { DatabaseError } from './db/evidence-store'
 import { operationalError, retryableOperationalError, type Component, type OperationalError } from './errors'
 
 const isRetryableSqlAcquisition = (error: unknown): boolean => {
-  if (isSqlError(error)) return error.isRetryable
-  return (
-    error instanceof DatabaseError &&
-    error.failure === 'unavailable' &&
-    isSqlError(error.cause) &&
-    error.cause.isRetryable
-  )
+  const cause = error instanceof DatabaseError && error.failure === 'unavailable' ? error.cause : error
+  if (!isSqlError(cause)) return false
+  return cause.isRetryable || (cause.reason._tag === 'UnknownError' && cause.reason.operation === 'connect')
 }
 
 export const acquireSqlLayer = <A, E, R>(layer: Layer.Layer<A, E, R>) =>


### PR DESCRIPTION
## Summary

- Retry PostgreSQL connection acquisition when Effect SQL reports a connect-time refusal as UnknownError.
- Keep authentication, authorization, and non-connect unknown failures terminal.
- Add a TestClock regression and document the exact bounded acquisition contract.

## Related Issues

None

## Testing

- PATH=/Users/gregkonush/.bun/bin:/nix/store/h57ln4r40qr349z1r8ri90n9i9xid3r5-nodejs-24.11.1/bin:/usr/bin:/bin bun run test
- PATH=/Users/gregkonush/.bun/bin:/nix/store/h57ln4r40qr349z1r8ri90n9i9xid3r5-nodejs-24.11.1/bin:/usr/bin:/bin bun run tsc
- PATH=/Users/gregkonush/.bun/bin:/nix/store/h57ln4r40qr349z1r8ri90n9i9xid3r5-nodejs-24.11.1/bin:/usr/bin:/bin bun run lint
- PATH=/Users/gregkonush/.bun/bin:/nix/store/h57ln4r40qr349z1r8ri90n9i9xid3r5-nodejs-24.11.1/bin:/usr/bin:/bin bun run lint:oxlint
- PATH=/Users/gregkonush/.bun/bin:/nix/store/h57ln4r40qr349z1r8ri90n9i9xid3r5-nodejs-24.11.1/bin:/usr/bin:/bin bun run lint:oxlint:type
- PATH=/Users/gregkonush/.bun/bin:/nix/store/h57ln4r40qr349z1r8ri90n9i9xid3r5-nodejs-24.11.1/bin:/usr/bin:/bin bun run build
- BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:55433/bayn_test bun test services/bayn/src/db/evidence-store.integration.test.ts

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.