### PR TITLE
fix(bayn): scope postgres refusal retries

### DIFF
--- a/docs/bayn/architecture.md
+++ b/docs/bayn/architecture.md
@@ -41,10 +41,11 @@ the recovered run after startup.
 
 A strategy rejection is terminal economic evidence, not an operational crash. ClickHouse and PostgreSQL layer
 acquisition retry a transient SQL failure twice at one-second intervals. PostgreSQL connection failures reported by
-the driver as `UnknownError` are retryable only for its `connect` operation; authentication and other terminal
-failures fail immediately. A transient startup dependency failure that remains after bounded acquisition escapes the
-scoped runtime, closes HTTP and acquired clients, and lets the Deployment restart the process. A deterministic
-contract or evidence failure enters `FAILED` and keeps HTTP available for diagnosis with readiness closed.
+the driver as `UnknownError` are retryable only when the `connect` operation carries `ECONNREFUSED`; authentication,
+TLS configuration, and other terminal failures fail immediately. A transient startup dependency failure that remains
+after bounded acquisition escapes the scoped runtime, closes HTTP and acquired clients, and lets the Deployment
+restart the process. A deterministic contract or evidence failure enters `FAILED` and keeps HTTP available for
+diagnosis with readiness closed.
 
 ## Dormant paper mutation boundary
 

--- a/services/bayn/src/operations.test.ts
+++ b/services/bayn/src/operations.test.ts
@@ -96,7 +96,10 @@ describe('Bayn SQL dependency acquisition', () => {
       operation: 'connect',
       message: 'PostgreSQL operation failed',
       cause: new SqlError({
-        reason: new UnknownError({ cause: new Error('connect ECONNREFUSED'), operation: 'connect' }),
+        reason: new UnknownError({
+          cause: Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' }),
+          operation: 'connect',
+        }),
       }),
     })
     const dependencies = Layer.effectDiscard(
@@ -117,6 +120,54 @@ describe('Bayn SQL dependency acquisition', () => {
     ).pipe(Effect.provide(TestClock.layer()))
 
     await Effect.runPromise(program)
+  })
+
+  test('keeps unverified and non-PostgreSQL unknown connect errors terminal', async () => {
+    const countAttempts = (failure: unknown) => {
+      let attempts = 0
+      return Effect.scoped(
+        Effect.gen(function* () {
+          const fiber = yield* acquireSqlLayer(
+            Layer.effectDiscard(
+              Effect.sync(() => {
+                attempts += 1
+              }).pipe(Effect.andThen(Effect.fail(failure))),
+            ),
+          ).pipe(Effect.forkScoped({ startImmediately: true }))
+          yield* Effect.yieldNow
+          yield* TestClock.adjust('3 seconds')
+          const exit = yield* Fiber.await(fiber)
+          return { attempts, exit }
+        }),
+      ).pipe(Effect.provide(TestClock.layer()))
+    }
+    const rawRefusal = new SqlError({
+      reason: new UnknownError({
+        cause: Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' }),
+        operation: 'connect',
+      }),
+    })
+    const invalidTls = new DatabaseError({
+      failure: 'unavailable',
+      operation: 'connect',
+      message: 'PostgreSQL operation failed',
+      cause: new SqlError({
+        reason: new UnknownError({
+          cause: Object.assign(new Error('invalid certificate'), { code: 'ERR_TLS_CERT_ALTNAME_INVALID' }),
+          operation: 'connect',
+        }),
+      }),
+    })
+
+    const [raw, tls] = await Promise.all([
+      Effect.runPromise(countAttempts(rawRefusal)),
+      Effect.runPromise(countAttempts(invalidTls)),
+    ])
+
+    expect(Exit.isFailure(raw.exit)).toBe(true)
+    expect(raw.attempts).toBe(1)
+    expect(Exit.isFailure(tls.exit)).toBe(true)
+    expect(tls.attempts).toBe(1)
   })
 
   test('interrupts a pending retry', async () => {

--- a/services/bayn/src/operations.ts
+++ b/services/bayn/src/operations.ts
@@ -5,9 +5,18 @@ import { DatabaseError } from './db/evidence-store'
 import { operationalError, retryableOperationalError, type Component, type OperationalError } from './errors'
 
 const isRetryableSqlAcquisition = (error: unknown): boolean => {
-  const cause = error instanceof DatabaseError && error.failure === 'unavailable' ? error.cause : error
-  if (!isSqlError(cause)) return false
-  return cause.isRetryable || (cause.reason._tag === 'UnknownError' && cause.reason.operation === 'connect')
+  if (isSqlError(error)) return error.isRetryable
+  if (!(error instanceof DatabaseError) || error.failure !== 'unavailable' || !isSqlError(error.cause)) return false
+  if (error.cause.isRetryable) return true
+  const reason = error.cause.reason
+  return (
+    reason._tag === 'UnknownError' &&
+    reason.operation === 'connect' &&
+    typeof reason.cause === 'object' &&
+    reason.cause !== null &&
+    'code' in reason.cause &&
+    reason.cause.code === 'ECONNREFUSED'
+  )
 }
 
 export const acquireSqlLayer = <A, E, R>(layer: Layer.Layer<A, E, R>) =>


### PR DESCRIPTION
## Summary

- Restrict the Effect UnknownError retry exception to PostgreSQL DatabaseError failures with the exact ECONNREFUSED code.
- Keep raw ClickHouse unknown-connect failures, invalid TLS failures, authentication, and authorization terminal.
- Add regressions for both terminal cases and document the exact bounded retry contract.

## Related Issues

Follow-up to #13095 and discussion_r3630677260.

## Testing

- PATH=/Users/gregkonush/.bun/bin:/nix/store/h57ln4r40qr349z1r8ri90n9i9xid3r5-nodejs-24.11.1/bin:/usr/bin:/bin bun run test
- PATH=/Users/gregkonush/.bun/bin:/nix/store/h57ln4r40qr349z1r8ri90n9i9xid3r5-nodejs-24.11.1/bin:/usr/bin:/bin bun run tsc
- PATH=/Users/gregkonush/.bun/bin:/nix/store/h57ln4r40qr349z1r8ri90n9i9xid3r5-nodejs-24.11.1/bin:/usr/bin:/bin bun run lint
- PATH=/Users/gregkonush/.bun/bin:/nix/store/h57ln4r40qr349z1r8ri90n9i9xid3r5-nodejs-24.11.1/bin:/usr/bin:/bin bun run lint:oxlint
- PATH=/Users/gregkonush/.bun/bin:/nix/store/h57ln4r40qr349z1r8ri90n9i9xid3r5-nodejs-24.11.1/bin:/usr/bin:/bin bun run lint:oxlint:type
- PATH=/Users/gregkonush/.bun/bin:/nix/store/h57ln4r40qr349z1r8ri90n9i9xid3r5-nodejs-24.11.1/bin:/usr/bin:/bin bun run build
- BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:55433/bayn_test bun test services/bayn/src/db/evidence-store.integration.test.ts

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.