### PR TITLE
feat(bayn): add continuous paper reconciliation

### DIFF
--- a/services/bayn/src/accounting.ts
+++ b/services/bayn/src/accounting.ts
@@ -118,6 +118,8 @@ interface Amounts {
   readonly cashDelta: bigint
 }
 
+type LedgerFill = Pick<Fill, 'accountId' | 'symbol' | 'side' | 'feeMicros'>
+
 const calculateAmounts = (fill: Fill, prior: PositionCost): Amounts => {
   const quantity = BigInt(fill.quantityMicros)
   const price = BigInt(fill.priceMicros)
@@ -155,7 +157,7 @@ const calculateAmounts = (fill: Fill, prior: PositionCost): Amounts => {
 const makeLedgerPlan = (
   transactionId: string,
   brokerEventId: string,
-  fill: Fill,
+  fill: LedgerFill,
   amounts: Amounts,
   ledger: number,
 ): LedgerPlan => {
@@ -244,6 +246,37 @@ const makeLedgerPlan = (
     accounts: [...accounts.values()].sort((left, right) => (left.id < right.id ? -1 : 1)),
     transfers: transfers.sort((left, right) => (left.id < right.id ? -1 : 1)),
   }
+}
+
+export const rebuildAccountingLedger = (transaction: AccountingTransaction, ledger: number): LedgerPlan => {
+  const decoded = decodeTransaction(transaction)
+  const { contentHash, ...material } = decoded
+  if (canonicalHashV1(material) !== contentHash) {
+    throw new Error('accounting transaction content hash does not match its immutable fields')
+  }
+  const plan = makeLedgerPlan(
+    decoded.transactionId,
+    decoded.brokerEventId,
+    {
+      accountId: decoded.accountId,
+      symbol: decoded.symbol,
+      side: decoded.side,
+      feeMicros: decoded.feeMicros,
+    },
+    {
+      notional: BigInt(decoded.notionalMicros),
+      costBasis: BigInt(decoded.costBasisMicros),
+      realizedPnl: BigInt(decoded.realizedPnlMicros),
+      quantityDelta: BigInt(decoded.quantityDeltaMicros),
+      costBasisDelta: BigInt(decoded.costBasisDeltaMicros),
+      cashDelta: BigInt(decoded.cashDeltaMicros),
+    },
+    ledger,
+  )
+  if (hashLedgerPlan(plan) !== decoded.ledgerPlanHash) {
+    throw new Error('accounting transaction ledger plan hash does not match its immutable fields')
+  }
+  return plan
 }
 
 export const prepareAccounting = (

--- a/services/bayn/src/app-test-support.ts
+++ b/services/bayn/src/app-test-support.ts
@@ -84,6 +84,7 @@ export const config: RuntimeConfig = {
 
 export const successfulJournal: JournalService = {
   post: () => Effect.void,
+  verifyAccount: () => Effect.succeed(true),
   check: Effect.void,
   checkRun: () => Effect.void,
   journalAndReconcile: (evaluation) =>

--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -14,6 +14,7 @@ import type { Strategy } from './strategy'
 export const run = (
   config: RuntimeConfig,
   strategy: Strategy,
+  reconciliation: Effect.Effect<void> = Effect.void,
 ): Effect.Effect<never, OperationalError, MarketData | Journal | EvidenceStore> =>
   Effect.scoped(
     Effect.gen(function* () {
@@ -24,6 +25,7 @@ export const run = (
       ).pipe(Effect.mapError((cause) => operationalError('http', 'listen', 'HTTP server failed to listen', cause)))
       yield* initialize(config, state, strategy)
       yield* monitor(config, state).pipe(Effect.forkScoped({ startImmediately: true }))
+      yield* reconciliation.pipe(Effect.forkScoped({ startImmediately: true }))
       return yield* Effect.never
     }),
   )

--- a/services/bayn/src/broker/observations.test.ts
+++ b/services/bayn/src/broker/observations.test.ts
@@ -46,7 +46,7 @@ const order: AlpacaOrder = {
   brokerOrderId: '8efc7b9a-8b2b-4000-9955-d36e7db0df74',
   clientOrderId: 'bayn-order-1',
   createdAt: '2026-07-22T15:29:59.000Z',
-  updatedAt: '2026-07-22T15:30:00.500Z',
+  updatedAt: '2026-07-22T15:30:00.500123Z',
   submittedAt: '2026-07-22T15:29:59.100Z',
   assetId: '9f1f6f68-9d4b-4db5-9b24-3fe1c15b5b4c',
   symbol: 'NVDA',
@@ -72,7 +72,7 @@ const activity: FillActivity = {
   quantityMicros: '1000000',
   side: AlpacaOrderSide.Buy,
   symbol: 'NVDA',
-  transactionTime: '2026-07-22T15:30:00.000Z',
+  transactionTime: '2026-07-22T15:30:00.000987Z',
   brokerOrderId: order.brokerOrderId,
   type: TradeActivityType.PartialFill,
   orderStatus: AlpacaOrderStatus.PartiallyFilled,
@@ -160,6 +160,8 @@ describe('paper broker observations', () => {
       filledQuantityMicros: '1000000',
       intentId: 'b'.repeat(64),
     })
+    expect(event.occurredAt).toBe('2026-07-22T15:30:00.500Z')
+    expect(event.sourceEventId).toBe(`order:${order.brokerOrderId}:${order.updatedAt}`)
     expect(() => orderObservation({ ...order, extendedHours: true }, evidence)).toThrow(
       'paper execution requires extended hours to be disabled',
     )
@@ -173,6 +175,7 @@ describe('paper broker observations', () => {
       clientOrderId: order.clientOrderId,
       feeMicros: '0',
       intentId: 'b'.repeat(64),
+      occurredAt: '2026-07-22T15:30:00.000Z',
     })
     expect(() => fillObservation({ ...activity, symbol: 'AMD' }, order, evidence)).toThrow(
       'Alpaca fill activity does not match its order',

--- a/services/bayn/src/broker/observations.test.ts
+++ b/services/bayn/src/broker/observations.test.ts
@@ -160,6 +160,9 @@ describe('paper broker observations', () => {
       filledQuantityMicros: '1000000',
       intentId: 'b'.repeat(64),
     })
+    expect(() => orderObservation({ ...order, extendedHours: true }, evidence)).toThrow(
+      'paper execution requires extended hours to be disabled',
+    )
   })
 
   test('binds a fill to its order and defaults paper fees to zero', () => {

--- a/services/bayn/src/broker/observations.ts
+++ b/services/bayn/src/broker/observations.ts
@@ -83,6 +83,8 @@ const decodeFill = Schema.decodeUnknownSync(FillEventInputSchema, strictParseOpt
 const decodePosition = Schema.decodeUnknownSync(PositionEventInputSchema, strictParseOptions)
 const decodePositionSnapshot = Schema.decodeUnknownSync(PositionSnapshotInputSchema, strictParseOptions)
 
+const canonicalInstant = (value: string): string => new Date(value).toISOString()
+
 const assertObservationTime = (observedAt: string, evidence: ReadEvidence): void => {
   if (observedAt !== evidence.observedAt) throw new Error('normalized broker payload and response evidence disagree')
 }
@@ -277,6 +279,7 @@ export const orderObservation = (value: AlpacaOrder, evidence: ReadEvidence, int
     status: orderStatus(value.status, value.filledQuantityMicros, value.quantityMicros),
     observedAt: value.observedAt,
   }
+  const occurredAt = canonicalInstant(value.updatedAt)
   return decodeEvent({
     _tag: 'Order',
     broker: Broker.Alpaca,
@@ -287,7 +290,7 @@ export const orderObservation = (value: AlpacaOrder, evidence: ReadEvidence, int
       order: withoutObservedAt(order),
       brokerUpdatedAt: value.updatedAt,
     }),
-    occurredAt: value.updatedAt,
+    occurredAt,
     observedAt: order.observedAt,
     order,
   })
@@ -307,6 +310,7 @@ export const fillObservation = (
   ) {
     throw new Error('Alpaca fill activity does not match its order')
   }
+  const occurredAt = canonicalInstant(activity.transactionTime)
   const fill = {
     schemaVersion: 'bayn.paper-fill.v1' as const,
     accountId: activity.accountId,
@@ -319,14 +323,18 @@ export const fillObservation = (
     quantityMicros: activity.quantityMicros,
     priceMicros: activity.priceMicros,
     feeMicros: options.feeMicros ?? '0',
-    occurredAt: activity.transactionTime,
+    occurredAt,
   }
   return decodeFill({
     _tag: 'Fill',
     broker: Broker.Alpaca,
     accountId: fill.accountId,
     sourceEventId: fill.fillId,
-    contentHash: canonicalHashV1({ schemaVersion: 'bayn.paper-fill-source.v1', fill }),
+    contentHash: canonicalHashV1({
+      schemaVersion: 'bayn.paper-fill-source.v1',
+      fill,
+      brokerTransactionTime: activity.transactionTime,
+    }),
     occurredAt: fill.occurredAt,
     observedAt: evidence.observedAt,
     fill,

--- a/services/bayn/src/broker/observations.ts
+++ b/services/bayn/src/broker/observations.ts
@@ -260,6 +260,7 @@ export const orderObservation = (value: AlpacaOrder, evidence: ReadEvidence, int
   if (value.quantityMicros === undefined || value.notionalMicros !== undefined) {
     throw new Error('paper accounting requires a quantity order')
   }
+  if (value.extendedHours) throw new Error('paper execution requires extended hours to be disabled')
   const order = {
     schemaVersion: 'bayn.paper-order.v1' as const,
     accountId: value.accountId,

--- a/services/bayn/src/config.test.ts
+++ b/services/bayn/src/config.test.ts
@@ -52,6 +52,7 @@ describe('Effect configuration', () => {
     expect(config.maximumAuthority).toBe(Authority.Observe)
     expect(config.healthIntervalMs).toBe(30_000)
     expect(config.operationTimeoutMs).toBe(30_000)
+    expect(config.alpaca).toBeUndefined()
     expect(config.clickhouse).toMatchObject({
       snapshotId: 'd'.repeat(64),
       publicationAsOf: '2026-07-17',
@@ -83,6 +84,38 @@ describe('Effect configuration', () => {
     const config = await Effect.runPromise(provideEnvironment(loadConfig(buildMetadata), pinned))
 
     expect(config.qualificationRunId).toBe('e'.repeat(64))
+  })
+
+  test('enables reconciliation only with one complete redacted Alpaca credential binding', async () => {
+    const configured = new Map(runtimeEnvironment)
+    configured.set('BAYN_ALPACA_ACCOUNT_ID', '61e69015-8549-4bfd-b9c3-01e75843f47d')
+    configured.set('BAYN_ALPACA_KEY_ID', 'paper-key')
+    configured.set('BAYN_ALPACA_SECRET_KEY', 'paper-secret')
+
+    const config = await Effect.runPromise(provideEnvironment(loadConfig(buildMetadata), configured))
+
+    expect(config.alpaca).toMatchObject({
+      accountId: '61e69015-8549-4bfd-b9c3-01e75843f47d',
+      proxyUrl: 'http://bayn-egress-proxy:3128',
+      retryAttempts: 2,
+      reconciliationIntervalMs: 30_000,
+    })
+    if (config.alpaca === undefined) throw new Error('expected an Alpaca configuration')
+    expect(Redacted.isRedacted(config.alpaca.key)).toBe(true)
+    expect(Redacted.isRedacted(config.alpaca.secret)).toBe(true)
+  })
+
+  test('rejects a partial Alpaca credential binding instead of silently staying dormant', async () => {
+    const partial = new Map(runtimeEnvironment)
+    partial.set('BAYN_ALPACA_KEY_ID', 'paper-key')
+
+    const error = await Effect.runPromise(Effect.flip(provideEnvironment(loadConfig(buildMetadata), partial)))
+
+    expect(error).toMatchObject({
+      _tag: 'OperationalError',
+      component: 'config',
+      operation: 'alpaca',
+    })
   })
 
   test('supports an explicit, visibly unverified development provenance path', async () => {

--- a/services/bayn/src/config.ts
+++ b/services/bayn/src/config.ts
@@ -26,6 +26,14 @@ export interface RuntimeConfig {
   readonly build: RuntimeBuildMetadata
   readonly healthIntervalMs: number
   readonly operationTimeoutMs: number
+  readonly alpaca?: {
+    readonly accountId: string
+    readonly key: Redacted.Redacted<string>
+    readonly secret: Redacted.Redacted<string>
+    readonly proxyUrl: string
+    readonly retryAttempts: number
+    readonly reconciliationIntervalMs: number
+  }
   readonly clickhouse: {
     readonly url: string
     readonly username: string
@@ -48,6 +56,7 @@ export interface RuntimeConfig {
 }
 
 const ProvenanceMode = Schema.Literals(['production', 'development'])
+const RetryAttempts = Schema.Int.check(Schema.isBetween({ minimum: 0, maximum: 3 }))
 const ReplicaAddresses = Schema.Trim.pipe(
   Schema.decodeTo(
     Schema.Array(NonEmptyString).check(Schema.isMinLength(1)),
@@ -84,6 +93,12 @@ const runtimeConfig = Config.all({
   ),
   healthIntervalMs: positiveInteger('BAYN_HEALTH_INTERVAL_MS', 30_000),
   operationTimeoutMs: positiveInteger('BAYN_OPERATION_TIMEOUT_MS', 30_000),
+  alpacaAccountId: Config.option(nonEmptyString('BAYN_ALPACA_ACCOUNT_ID')),
+  alpacaKey: Config.option(secretString('BAYN_ALPACA_KEY_ID')),
+  alpacaSecret: Config.option(secretString('BAYN_ALPACA_SECRET_KEY')),
+  alpacaProxyUrl: nonEmptyString('BAYN_ALPACA_PROXY_URL').pipe(Config.withDefault('http://bayn-egress-proxy:3128')),
+  alpacaRetryAttempts: Config.schema(RetryAttempts, 'BAYN_ALPACA_RETRY_ATTEMPTS').pipe(Config.withDefault(2)),
+  reconciliationIntervalMs: positiveInteger('BAYN_RECONCILIATION_INTERVAL_MS', 30_000),
   clickhouseUrl: nonEmptyString('BAYN_CLICKHOUSE_URL'),
   clickhouseUsername: nonEmptyString('BAYN_CLICKHOUSE_USERNAME'),
   clickhousePassword: secretString('BAYN_CLICKHOUSE_PASSWORD'),
@@ -121,6 +136,14 @@ const runtimeConfig = Config.all({
     provenanceMode: config.provenanceMode,
     healthIntervalMs: config.healthIntervalMs,
     operationTimeoutMs: config.operationTimeoutMs,
+    configuredAlpaca: {
+      accountId: config.alpacaAccountId,
+      key: config.alpacaKey,
+      secret: config.alpacaSecret,
+      proxyUrl: config.alpacaProxyUrl,
+      retryAttempts: config.alpacaRetryAttempts,
+      reconciliationIntervalMs: config.reconciliationIntervalMs,
+    },
     clickhouse: {
       url: config.clickhouseUrl,
       username: config.clickhouseUsername,
@@ -169,6 +192,30 @@ export const loadConfig = (
         catch: (cause) => operationalError('config', 'load', 'invalid Signal evaluation bounds', cause),
       }),
     ),
+    Effect.flatMap((config) => {
+      const credentials = Option.all({
+        accountId: config.configuredAlpaca.accountId,
+        key: config.configuredAlpaca.key,
+        secret: config.configuredAlpaca.secret,
+      })
+      const anyCredential =
+        Option.isSome(config.configuredAlpaca.accountId) ||
+        Option.isSome(config.configuredAlpaca.key) ||
+        Option.isSome(config.configuredAlpaca.secret)
+      if (anyCredential && Option.isNone(credentials)) {
+        return Effect.fail(
+          operationalError('config', 'alpaca', 'Alpaca account ID, key ID, and secret key must be configured together'),
+        )
+      }
+      const alpaca = Option.map(credentials, (value) => ({
+        ...value,
+        proxyUrl: config.configuredAlpaca.proxyUrl,
+        retryAttempts: config.configuredAlpaca.retryAttempts,
+        reconciliationIntervalMs: config.configuredAlpaca.reconciliationIntervalMs,
+      }))
+      const { configuredAlpaca: _configuredAlpaca, ...runtime } = config
+      return Effect.succeed({ ...runtime, ...(Option.isSome(alpaca) ? { alpaca: alpaca.value } : {}) })
+    }),
     Effect.flatMap((config) =>
       Effect.try({
         try: (): RuntimeConfig => {

--- a/services/bayn/src/db/accounting-rows.ts
+++ b/services/bayn/src/db/accounting-rows.ts
@@ -1,0 +1,81 @@
+import { Schema } from 'effect'
+
+import type { AccountingTransaction } from '../accounting'
+import { OrderSide, type AccountingReceipt } from '../paper'
+import { Sha256Schema as Sha256, StrictNonEmptyStringSchema as NonEmptyString } from '../schemas'
+
+export const AccountingTransactionRowSchema = Schema.Struct({
+  schema_version: Schema.Literal('bayn.paper-accounting-transaction.v1'),
+  transaction_id: Sha256,
+  broker_event_id: Sha256,
+  intent_id: Schema.NullOr(Sha256),
+  account_id: NonEmptyString,
+  symbol: Schema.String,
+  side: Schema.Enum(OrderSide),
+  quantity_micros: Schema.String,
+  price_micros: Schema.String,
+  notional_micros: Schema.String,
+  fee_micros: Schema.String,
+  cost_basis_micros: Schema.String,
+  realized_pnl_micros: Schema.String,
+  quantity_delta_micros: Schema.String,
+  cost_basis_delta_micros: Schema.String,
+  cash_delta_micros: Schema.String,
+  ledger_plan_hash: Sha256,
+  content_hash: Sha256,
+  occurred_at: Schema.DateValid,
+})
+
+export const AccountingReceiptRowSchema = Schema.Struct({
+  schema_version: Schema.Literal('bayn.paper-accounting-receipt.v1'),
+  receipt_id: Sha256,
+  intent_id: Schema.NullOr(Sha256),
+  broker_event_id: Sha256,
+  tigerbeetle_cluster_id: Schema.String,
+  tigerbeetle_ledger: Schema.Int,
+  account_ids: Schema.Array(Schema.String),
+  transfer_ids: Schema.Array(Schema.String),
+  debit_micros: Schema.String,
+  credit_micros: Schema.String,
+  content_hash: Sha256,
+  recorded_at: Schema.DateValid,
+})
+
+export const accountingTransactionFromRow = (
+  row: typeof AccountingTransactionRowSchema.Type,
+): AccountingTransaction => ({
+  schemaVersion: row.schema_version,
+  transactionId: row.transaction_id,
+  brokerEventId: row.broker_event_id,
+  ...(row.intent_id === null ? {} : { intentId: row.intent_id }),
+  accountId: row.account_id,
+  symbol: row.symbol,
+  side: row.side,
+  quantityMicros: row.quantity_micros,
+  priceMicros: row.price_micros,
+  notionalMicros: row.notional_micros,
+  feeMicros: row.fee_micros,
+  costBasisMicros: row.cost_basis_micros,
+  realizedPnlMicros: row.realized_pnl_micros,
+  quantityDeltaMicros: row.quantity_delta_micros,
+  costBasisDeltaMicros: row.cost_basis_delta_micros,
+  cashDeltaMicros: row.cash_delta_micros,
+  ledgerPlanHash: row.ledger_plan_hash,
+  contentHash: row.content_hash,
+  occurredAt: row.occurred_at.toISOString(),
+})
+
+export const accountingReceiptFromRow = (row: typeof AccountingReceiptRowSchema.Type): AccountingReceipt => ({
+  schemaVersion: row.schema_version,
+  receiptId: row.receipt_id,
+  ...(row.intent_id === null ? {} : { intentId: row.intent_id }),
+  brokerEventId: row.broker_event_id,
+  tigerBeetleClusterId: row.tigerbeetle_cluster_id,
+  tigerBeetleLedger: row.tigerbeetle_ledger,
+  accountIds: row.account_ids,
+  transferIds: row.transfer_ids,
+  debitMicros: row.debit_micros,
+  creditMicros: row.credit_micros,
+  contentHash: row.content_hash,
+  recordedAt: row.recorded_at.toISOString(),
+})

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -9,7 +9,17 @@ import { operationalError } from '../errors'
 import { canonicalHashV1 } from '../hash'
 import { hashLedgerPlan } from '../ledger-plan'
 import { Journal, type JournalService } from '../ledger'
-import { AccountStatus, Authority, Broker, OrderSide, OrderStatus, OrderType, TimeInForce } from '../paper'
+import {
+  AccountStatus,
+  Authority,
+  Broker,
+  DiscrepancyKind,
+  OrderSide,
+  OrderStatus,
+  OrderType,
+  ReconciliationStatus,
+  TimeInForce,
+} from '../paper'
 import type {
   BrokerEventInput,
   FillEventInput,
@@ -75,6 +85,7 @@ const journal = (control: JournalControl): JournalService => ({
         ? Effect.fail(operationalError('journal', 'post', 'injected TigerBeetle failure'))
         : Effect.void
     }),
+  verifyAccount: () => Effect.succeed(true),
   journalAndReconcile: () => Effect.die(new Error('unexpected simulation journal call')),
   check: Effect.void,
   checkRun: () => Effect.void,
@@ -93,7 +104,7 @@ const makeClientRuntime = () => ManagedRuntime.make(PostgresClientLive(config).p
 
 const makeEvidenceRuntime = () => ManagedRuntime.make(EvidenceStoreLive(config).pipe(Layer.provide(NodeServices.layer)))
 
-const accountEvent = (): BrokerEventInput => ({
+const accountEvent = (): Extract<BrokerEventInput, { readonly _tag: 'Account' }> => ({
   _tag: 'Account',
   broker: Broker.Alpaca,
   accountId,
@@ -113,7 +124,7 @@ const accountEvent = (): BrokerEventInput => ({
   },
 })
 
-const orderEvent = (): BrokerEventInput => ({
+const orderEvent = (): Extract<BrokerEventInput, { readonly _tag: 'Order' }> => ({
   _tag: 'Order',
   broker: Broker.Alpaca,
   accountId,
@@ -258,12 +269,112 @@ describePostgres('paper accounting persistence', () => {
     }
   }, 15_000)
 
+  test('treats cancel history as newer than submit history when broker timestamps tie', async () => {
+    const runtime = makeStoreRuntime({ fail: false, planHashes: [] })
+    const intentId = 'a'.repeat(64)
+    const brokerOrderId = orderEvent().order.brokerOrderId
+    try {
+      const result = await runtime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* PaperStore
+          const exactAccount = {
+            ...accountEvent(),
+            account: { ...accountEvent().account, equityMicros: accountEvent().account.cashMicros },
+          } satisfies BrokerEventInput
+          const accountReceipt = yield* store.ingest(exactAccount)
+          const positionsReceipt = yield* store.ingestPositions(
+            positionSnapshotInput(hash('mutation-ordering-empty-positions'), []),
+          )
+          const valuation = yield* store.value({
+            accountEventId: accountReceipt.eventId,
+            positionSnapshotId: positionsReceipt.snapshotId,
+          })
+          const sql = yield* PgClient.PgClient
+          yield* sql`
+            INSERT INTO intents (
+              intent_id, schema_version, account_id, client_order_id, symbol, side,
+              order_type, time_in_force, quantity_micros, notional_limit_micros,
+              state, state_version, created_at, updated_at,
+              strategy_name, cycle_id, decision_hash, policy_hash
+            ) VALUES (
+              ${intentId}, 'bayn.paper-intent.v2', ${accountId}, ${orderEvent().order.clientOrderId},
+              ${orderEvent().order.symbol}, 'BUY', 'MARKET', 'DAY', 3000000, 300000000,
+              'PLANNED', 1, ${occurredAt}, ${occurredAt},
+              'tsmom-v1', ${'9'.repeat(64)}, ${'b'.repeat(64)}, ${'c'.repeat(64)}
+            )
+          `
+          yield* sql`
+            INSERT INTO mutation_events (
+              event_id, schema_version, mutation_id, intent_id, sequence, operation, event_type,
+              request_hash, consistency_delay_ms, broker_order_id, request_id,
+              response_status, response_content_hash, occurred_at
+            ) VALUES
+              (
+                ${'1'.repeat(64)}, 'bayn.paper-mutation-event.v1', ${'3'.repeat(64)}, ${intentId}, 1,
+                'SUBMIT', 'SUBMIT_STARTED', ${'4'.repeat(64)}, 1000, NULL, NULL, NULL, NULL, ${occurredAt}
+              ),
+              (
+                ${'f'.repeat(64)}, 'bayn.paper-mutation-event.v1', ${'3'.repeat(64)}, ${intentId}, 2,
+                'SUBMIT', 'SUBMIT_ACCEPTED', ${'4'.repeat(64)}, 1000, ${brokerOrderId}, 'submit-request',
+                200, ${'5'.repeat(64)}, ${occurredAt}
+              ),
+              (
+                ${'2'.repeat(64)}, 'bayn.paper-mutation-event.v1', ${'6'.repeat(64)}, ${intentId}, 1,
+                'CANCEL', 'CANCEL_STARTED', ${'7'.repeat(64)}, 1000, ${brokerOrderId}, NULL, NULL, NULL, ${occurredAt}
+              ),
+              (
+                ${'0'.repeat(64)}, 'bayn.paper-mutation-event.v1', ${'6'.repeat(64)}, ${intentId}, 2,
+                'CANCEL', 'CANCEL_ACCEPTED', ${'7'.repeat(64)}, 1000, ${brokerOrderId}, 'cancel-request',
+                204, ${'8'.repeat(64)}, ${occurredAt}
+              )
+          `
+          return yield* store.reconcile({
+            account: exactAccount.account,
+            positions: [],
+            positionsObservedAt: observedAt,
+            orders: [{ ...orderEvent().order, intentId }],
+            ordersObservedAt: observedAt,
+            fills: [],
+            valuation,
+            reconciledAt: '2026-07-22T15:30:03.000Z',
+          })
+        }),
+      )
+
+      expect(result.reconciliation.discrepancies).toHaveLength(1)
+      expect(result.reconciliation.discrepancies[0]).toMatchObject({
+        kind: DiscrepancyKind.Mutation,
+        identity: intentId,
+        observed: `UNKNOWN:${occurredAt}`,
+      })
+      expect(result.metrics.oldestUnknownMutationAgeMs).toBe(3_000)
+    } finally {
+      await runtime.dispose()
+    }
+  }, 15_000)
+
   test('recovers the PostgreSQL-to-TigerBeetle crash window without duplicate accounting', async () => {
     const control: JournalControl = { fail: true, planHashes: [] }
     const runtime = makeStoreRuntime(control)
     const buy = fillEvent('fill-buy', OrderSide.Buy, '3000000', '100000000')
     const sell = fillEvent('fill-sell', OrderSide.Sell, '1000000', '120000000')
     try {
+      await runtime.runPromise(
+        Effect.flatMap(PaperStore, (store) =>
+          store.ingest({
+            ...accountEvent(),
+            sourceEventId: 'opening-account',
+            contentHash: hash('opening-account'),
+            occurredAt: '2026-07-22T15:29:59.000Z',
+            observedAt: '2026-07-22T15:29:59.000Z',
+            account: {
+              ...accountEvent().account,
+              equityMicros: accountEvent().account.cashMicros,
+              observedAt: '2026-07-22T15:29:59.000Z',
+            },
+          }),
+        ),
+      )
       const failed = await runtime.runPromiseExit(Effect.flatMap(PaperStore, (store) => store.account(buy)))
       expect(Exit.isFailure(failed)).toBe(true)
 
@@ -332,9 +443,46 @@ describePostgres('paper accounting persistence', () => {
         ]),
       )
       expect(stored.transactions.every((transaction) => /^[a-f0-9]{64}$/.test(transaction.ledger_plan_hash))).toBe(true)
-      expect(stored.counts).toEqual({ events: 2, transactions: 2, receipts: 2 })
+      expect(stored.counts).toEqual({ events: 3, transactions: 2, receipts: 2 })
       expect(Exit.isFailure(stored.immutable)).toBe(true)
       expect(Exit.isFailure(stored.truncate)).toBe(true)
+
+      const exact = await runtime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* PaperStore
+          const currentAccount = {
+            ...accountEvent(),
+            sourceEventId: 'current-account',
+            contentHash: hash('current-account'),
+            account: {
+              ...accountEvent().account,
+              cashMicros: '819999800',
+              equityMicros: '1019999800',
+            },
+          } satisfies BrokerEventInput
+          const accountReceipt = yield* store.ingest(currentAccount)
+          const position = positionEvent(hash('accounted-position'), 'asset-accounted', 'NVDA', '2000000', '200000000')
+          const positionsReceipt = yield* store.ingestPositions(
+            positionSnapshotInput(hash('accounted-position'), [position]),
+          )
+          const valuation = yield* store.value({
+            accountEventId: accountReceipt.eventId,
+            positionSnapshotId: positionsReceipt.snapshotId,
+          })
+          return yield* store.reconcile({
+            account: currentAccount.account,
+            positions: [position.position],
+            positionsObservedAt: observedAt,
+            orders: [],
+            ordersObservedAt: observedAt,
+            fills: [buy.fill, sell.fill],
+            valuation,
+            reconciledAt: '2026-07-22T15:31:00.000Z',
+          })
+        }),
+      )
+      expect(exact.reconciliation.status).toBe(ReconciliationStatus.Exact)
+      expect(exact.reconciliation.discrepancies).toEqual([])
     } finally {
       await runtime.dispose()
     }
@@ -416,6 +564,123 @@ describePostgres('paper accounting persistence', () => {
         equityMicros: '1000000000',
       })
       expect(result.counts).toEqual({ position_snapshots: 2, positions: 2, valuations: 2 })
+    } finally {
+      await runtime.dispose()
+    }
+  }, 15_000)
+
+  test('keeps discrepancy history in immutable reconciliation rows and never restores authority', async () => {
+    const runtime = makeStoreRuntime({ fail: false, planHashes: [] })
+    const exactAccount = {
+      ...accountEvent(),
+      account: { ...accountEvent().account, equityMicros: accountEvent().account.cashMicros },
+    } satisfies BrokerEventInput
+    try {
+      const result = await runtime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* PaperStore
+          const accountReceipt = yield* store.ingest(exactAccount)
+          const positionsReceipt = yield* store.ingestPositions(
+            positionSnapshotInput(hash('reconciliation-empty-positions'), []),
+          )
+          const valuation = yield* store.value({
+            accountEventId: accountReceipt.eventId,
+            positionSnapshotId: positionsReceipt.snapshotId,
+          })
+          const baseline = {
+            account: exactAccount.account,
+            positions: [],
+            positionsObservedAt: observedAt,
+            orders: [],
+            ordersObservedAt: observedAt,
+            fills: [],
+            valuation,
+            reconciledAt: '2026-07-22T15:30:02.000Z',
+          } as const
+          const exact = yield* store.reconcile(baseline)
+
+          const sql = yield* PgClient.PgClient
+          yield* sql`
+            INSERT INTO authority_state (
+              schema_version, generation_hash, maximum, effective, kill_state, version, updated_at
+            ) VALUES (
+              'bayn.paper-authority.v1', ${hash('paper-generation')}, 'PAPER', 'PAPER', 'CLEAR', 1,
+              '2026-07-22T15:30:02.500Z'
+            )
+          `
+
+          const mismatchInput = {
+            ...baseline,
+            orders: [orderEvent().order],
+            reconciledAt: '2026-07-22T15:30:03.000Z',
+          } as const
+          const mismatch = yield* store.reconcile(mismatchInput)
+          const replay = yield* store.reconcile(mismatchInput)
+          const ongoing = yield* store.reconcile({
+            ...mismatchInput,
+            reconciledAt: '2026-07-22T15:30:04.000Z',
+          })
+          const resolved = yield* store.reconcile({
+            ...baseline,
+            reconciledAt: '2026-07-22T15:30:05.000Z',
+          })
+
+          const rows = yield* sql<{ discrepancy_count: number; status: string }>`
+            SELECT status, jsonb_array_length(discrepancies)::integer AS discrepancy_count
+            FROM reconciliations
+            ORDER BY reconciled_at
+          `
+          const [authority] = yield* sql<{
+            effective: string
+            kill_state: string
+            reason: string | null
+            version: number
+          }>`
+            SELECT effective, kill_state, reason, version::integer
+            FROM authority_state
+          `
+          const mutateReconciliation = yield* Effect.exit(sql`
+            UPDATE reconciliations
+            SET content_hash = ${hash('mutated-reconciliation')}
+            WHERE reconciliation_id = ${mismatch.reconciliation.reconciliationId}
+          `)
+          return {
+            exact,
+            mismatch,
+            replay,
+            ongoing,
+            resolved,
+            rows,
+            authority,
+            mutateReconciliation,
+          }
+        }),
+      )
+
+      expect(result.exact.reconciliation.status).toBe(ReconciliationStatus.Exact)
+      expect(result.mismatch.reconciliation.status).toBe(ReconciliationStatus.Discrepancy)
+      expect(result.replay).toEqual(result.mismatch)
+      expect(result.mismatch.reconciliation.discrepancies).toHaveLength(1)
+      expect(result.ongoing.reconciliation.discrepancies[0]).toMatchObject({
+        discrepancyId: result.mismatch.reconciliation.discrepancies[0]?.discrepancyId,
+        firstObservedAt: '2026-07-22T15:30:03.000Z',
+        lastObservedAt: '2026-07-22T15:30:04.000Z',
+      })
+      expect(result.resolved.reconciliation.status).toBe(ReconciliationStatus.Exact)
+      expect(result.resolved.reconciliation.discrepancies).toEqual([])
+      expect(result.rows).toEqual([
+        { status: ReconciliationStatus.Exact, discrepancy_count: 0 },
+        { status: ReconciliationStatus.Discrepancy, discrepancy_count: 1 },
+        { status: ReconciliationStatus.Discrepancy, discrepancy_count: 1 },
+        { status: ReconciliationStatus.Exact, discrepancy_count: 0 },
+      ])
+      expect(result.authority).toEqual({
+        effective: 'OBSERVE',
+        kill_state: 'ACTIVE',
+        reason: `reconciliation discrepancy ${result.mismatch.reconciliation.reconciliationId}`,
+        version: 2,
+      })
+      expect(Exit.isFailure(result.mutateReconciliation)).toBe(true)
     } finally {
       await runtime.dispose()
     }

--- a/services/bayn/src/db/paper-store.ts
+++ b/services/bayn/src/db/paper-store.ts
@@ -25,12 +25,29 @@ import {
   AccountingReceiptSchema,
   Broker,
   BrokerEventSchema,
-  OrderSide,
   ValuationSchema,
   type AccountingReceipt,
   type Valuation,
 } from '../paper'
-import { Sha256Schema as Sha256, StrictNonEmptyStringSchema as NonEmptyString, strictParseOptions } from '../schemas'
+import {
+  Sha256Schema as Sha256,
+  StrictNonEmptyStringSchema as NonEmptyString,
+  UtcInstantSchema as UtcInstant,
+  strictParseOptions,
+} from '../schemas'
+import {
+  AccountingReceiptRowSchema,
+  AccountingTransactionRowSchema,
+  accountingReceiptFromRow,
+  accountingTransactionFromRow,
+} from './accounting-rows'
+import {
+  makeReconciliation,
+  restrictAuthority,
+  type BrokerSnapshot,
+  type IntentBinding,
+  type ReconciliationReport,
+} from './reconciliation'
 
 export const VALUATION_SNAPSHOT_MAX_SKEW_MS = 30_000
 
@@ -47,7 +64,15 @@ export interface PositionSnapshotReceipt {
 }
 
 export class PaperStoreError extends Data.TaggedError('PaperStoreError')<{
-  readonly operation: 'ingest' | 'positions' | 'account' | 'receipt' | 'valuation'
+  readonly operation:
+    | 'ingest'
+    | 'positions'
+    | 'account'
+    | 'receipt'
+    | 'valuation'
+    | 'bindings'
+    | 'reconciliation'
+    | 'authority'
   readonly failure: 'conflict' | 'decode' | 'invariant' | 'ledger' | 'query'
   readonly message: string
   readonly cause?: unknown
@@ -58,6 +83,9 @@ export interface PaperStoreShape {
   readonly ingestPositions: (input: PositionSnapshotInput) => Effect.Effect<PositionSnapshotReceipt, PaperStoreError>
   readonly account: (input: FillEventInput) => Effect.Effect<AccountingReceipt, PaperStoreError>
   readonly value: (input: ValuationInput) => Effect.Effect<Valuation, PaperStoreError>
+  readonly bindings: (accountId: string) => Effect.Effect<readonly IntentBinding[], PaperStoreError>
+  readonly reconcile: (snapshot: BrokerSnapshot) => Effect.Effect<ReconciliationReport, PaperStoreError>
+  readonly restrictAuthority: (reason: string, updatedAt: string) => Effect.Effect<void, PaperStoreError>
 }
 
 export class PaperStore extends Context.Service<PaperStore, PaperStoreShape>()('bayn/PaperStore') {}
@@ -72,41 +100,6 @@ const EventRow = Schema.Struct({
 const LastSequenceRow = Schema.Tuple([Schema.Struct({ last_sequence: Schema.String })])
 const PositionCostRow = Schema.Tuple([Schema.Struct({ quantity_micros: Schema.String, cost_micros: Schema.String })])
 const UnresolvedPredecessorRow = Schema.Tuple([Schema.Struct({ unresolved: Schema.Boolean })])
-const TransactionRow = Schema.Struct({
-  schema_version: Schema.Literal('bayn.paper-accounting-transaction.v1'),
-  transaction_id: Sha256,
-  broker_event_id: Sha256,
-  intent_id: Schema.NullOr(Sha256),
-  account_id: NonEmptyString,
-  symbol: Schema.String,
-  side: Schema.Enum(OrderSide),
-  quantity_micros: Schema.String,
-  price_micros: Schema.String,
-  notional_micros: Schema.String,
-  fee_micros: Schema.String,
-  cost_basis_micros: Schema.String,
-  realized_pnl_micros: Schema.String,
-  quantity_delta_micros: Schema.String,
-  cost_basis_delta_micros: Schema.String,
-  cash_delta_micros: Schema.String,
-  ledger_plan_hash: Sha256,
-  content_hash: Sha256,
-  occurred_at: Schema.DateValid,
-})
-const ReceiptRow = Schema.Struct({
-  schema_version: Schema.Literal('bayn.paper-accounting-receipt.v1'),
-  receipt_id: Sha256,
-  intent_id: Schema.NullOr(Sha256),
-  broker_event_id: Sha256,
-  tigerbeetle_cluster_id: Schema.String,
-  tigerbeetle_ledger: Schema.Int,
-  account_ids: Schema.Array(Schema.String),
-  transfer_ids: Schema.Array(Schema.String),
-  debit_micros: Schema.String,
-  credit_micros: Schema.String,
-  content_hash: Sha256,
-  recorded_at: Schema.DateValid,
-})
 const AccountRow = Schema.Tuple([
   Schema.Struct({
     event_id: Sha256,
@@ -145,6 +138,7 @@ const ValuationRow = Schema.Struct({
   equity_micros: Schema.String,
   as_of: Schema.DateValid,
 })
+const AuthorityRestrictionInput = Schema.Struct({ reason: NonEmptyString, updatedAt: UtcInstant })
 
 const decodeEventInput = Schema.decodeUnknownEffect(BrokerEventInputSchema, strictParseOptions)
 const decodeFillInput = Schema.decodeUnknownEffect(FillEventInputSchema, strictParseOptions)
@@ -154,8 +148,11 @@ const decodeEventRows = Schema.decodeUnknownEffect(Schema.Array(EventRow), stric
 const decodeLastSequence = Schema.decodeUnknownEffect(LastSequenceRow, strictParseOptions)
 const decodePositionCost = Schema.decodeUnknownEffect(PositionCostRow, strictParseOptions)
 const decodeUnresolvedPredecessor = Schema.decodeUnknownEffect(UnresolvedPredecessorRow, strictParseOptions)
-const decodeTransactionRows = Schema.decodeUnknownEffect(Schema.Array(TransactionRow), strictParseOptions)
-const decodeReceiptRows = Schema.decodeUnknownEffect(Schema.Array(ReceiptRow), strictParseOptions)
+const decodeTransactionRows = Schema.decodeUnknownEffect(
+  Schema.Array(AccountingTransactionRowSchema),
+  strictParseOptions,
+)
+const decodeReceiptRows = Schema.decodeUnknownEffect(Schema.Array(AccountingReceiptRowSchema), strictParseOptions)
 const decodeAccountRows = Schema.decodeUnknownEffect(AccountRow, strictParseOptions)
 const decodePositionRows = Schema.decodeUnknownEffect(Schema.Array(PositionRow), strictParseOptions)
 const decodePositionSnapshotRows = Schema.decodeUnknownEffect(Schema.Array(PositionSnapshotRow), strictParseOptions)
@@ -166,6 +163,7 @@ const decodeBrokerEvent = Schema.decodeUnknownEffect(BrokerEventSchema, strictPa
 const decodeReceipt = Schema.decodeUnknownEffect(AccountingReceiptSchema, strictParseOptions)
 const decodeValuation = Schema.decodeUnknownEffect(ValuationSchema, strictParseOptions)
 const decodeTransaction = Schema.decodeUnknownEffect(AccountingTransactionSchema, strictParseOptions)
+const decodeAuthorityRestriction = Schema.decodeUnknownEffect(AuthorityRestrictionInput, strictParseOptions)
 
 const messageOf = (cause: unknown): string => (cause instanceof Error ? cause.message : String(cause))
 
@@ -222,43 +220,6 @@ const eventIdOf = (input: BrokerEventInput): string =>
     contentHash: input.contentHash,
   })
 
-const transactionFromRow = (row: typeof TransactionRow.Type): AccountingTransaction => ({
-  schemaVersion: row.schema_version,
-  transactionId: row.transaction_id,
-  brokerEventId: row.broker_event_id,
-  ...(row.intent_id === null ? {} : { intentId: row.intent_id }),
-  accountId: row.account_id,
-  symbol: row.symbol,
-  side: row.side,
-  quantityMicros: row.quantity_micros,
-  priceMicros: row.price_micros,
-  notionalMicros: row.notional_micros,
-  feeMicros: row.fee_micros,
-  costBasisMicros: row.cost_basis_micros,
-  realizedPnlMicros: row.realized_pnl_micros,
-  quantityDeltaMicros: row.quantity_delta_micros,
-  costBasisDeltaMicros: row.cost_basis_delta_micros,
-  cashDeltaMicros: row.cash_delta_micros,
-  ledgerPlanHash: row.ledger_plan_hash,
-  contentHash: row.content_hash,
-  occurredAt: row.occurred_at.toISOString(),
-})
-
-const receiptFromRow = (row: typeof ReceiptRow.Type): AccountingReceipt => ({
-  schemaVersion: row.schema_version,
-  receiptId: row.receipt_id,
-  ...(row.intent_id === null ? {} : { intentId: row.intent_id }),
-  brokerEventId: row.broker_event_id,
-  tigerBeetleClusterId: row.tigerbeetle_cluster_id,
-  tigerBeetleLedger: row.tigerbeetle_ledger,
-  accountIds: row.account_ids,
-  transferIds: row.transfer_ids,
-  debitMicros: row.debit_micros,
-  creditMicros: row.credit_micros,
-  contentHash: row.content_hash,
-  recordedAt: row.recorded_at.toISOString(),
-})
-
 const valuationFromRow = (row: typeof ValuationRow.Type): Valuation => ({
   schemaVersion: row.schema_version,
   valuationId: row.valuation_id,
@@ -289,6 +250,7 @@ const makeStore = (config: Pick<RuntimeConfig, 'tigerBeetle'>) =>
   Effect.gen(function* () {
     const sql = yield* PgClient.PgClient
     const journal = yield* Journal
+    const reconciliation = makeReconciliation(sql, journal, config)
 
     const insertPayload = (eventId: string, input: BrokerEventInput, positionSnapshotId?: string) => {
       switch (input._tag) {
@@ -464,7 +426,7 @@ const makeStore = (config: Pick<RuntimeConfig, 'tigerBeetle'>) =>
           `.pipe(Effect.flatMap(decodeTransactionRows))
           if (rows.length === 0) return undefined
           if (rows.length !== 1) return yield* fail('account', 'invariant', 'fill has multiple accounting transactions')
-          return yield* decodeTransaction(transactionFromRow(rows[0]))
+          return yield* decodeTransaction(accountingTransactionFromRow(rows[0]))
         }),
       )
 
@@ -538,7 +500,7 @@ const makeStore = (config: Pick<RuntimeConfig, 'tigerBeetle'>) =>
           `.pipe(Effect.flatMap(decodeReceiptRows))
           if (rows.length === 0) return undefined
           if (rows.length !== 1) return yield* fail('receipt', 'invariant', 'fill has multiple accounting receipts')
-          return yield* decodeReceipt(receiptFromRow(rows[0]))
+          return yield* decodeReceipt(accountingReceiptFromRow(rows[0]))
         }),
       )
 
@@ -865,7 +827,25 @@ const makeStore = (config: Pick<RuntimeConfig, 'tigerBeetle'>) =>
         ),
       )
 
-    return { ingest, ingestPositions, account, value } satisfies PaperStoreShape
+    const bindings = (accountId: string) => run('bindings', reconciliation.bindings(accountId))
+    const reconcile = (snapshot: BrokerSnapshot) => run('reconciliation', reconciliation.reconcile(snapshot))
+    const lowerAuthority = (reason: string, updatedAt: string) =>
+      run(
+        'authority',
+        decodeAuthorityRestriction({ reason, updatedAt }).pipe(
+          Effect.flatMap((input) => restrictAuthority(sql, input.reason, input.updatedAt)),
+        ),
+      )
+
+    return {
+      ingest,
+      ingestPositions,
+      account,
+      value,
+      bindings,
+      reconcile,
+      restrictAuthority: lowerAuthority,
+    } satisfies PaperStoreShape
   })
 
 export const PaperStoreLive = (config: Pick<RuntimeConfig, 'tigerBeetle'>) =>

--- a/services/bayn/src/db/reconciliation.ts
+++ b/services/bayn/src/db/reconciliation.ts
@@ -1,0 +1,471 @@
+import { PgClient } from '@effect/sql-pg'
+import { Effect, Schema } from 'effect'
+
+import { rebuildAccountingLedger, type AccountingTransaction } from '../accounting'
+import { MutationOperation } from '../broker/alpaca-mutations'
+import type { RuntimeConfig } from '../config'
+import { canonicalHashV1 } from '../hash'
+import type { JournalService } from '../ledger'
+import {
+  DiscrepancySchema,
+  IntentState,
+  OrderSide,
+  OrderType,
+  ReconciliationStatus,
+  TerminalOutcome,
+  TimeInForce,
+  decodeAccountingReceipt,
+  decodeReconciliation,
+  type AccountSnapshot,
+  type AccountingReceipt,
+  type Discrepancy,
+  type Fill,
+  type Order,
+  type Position,
+  type Reconciliation,
+  type Valuation,
+} from '../paper'
+import {
+  compareReconciliation,
+  reconciledStateHash,
+  type IntentExpectation,
+  type ReconciliationMetrics,
+} from '../reconciliation'
+import {
+  Sha256Schema as Sha256,
+  StrictNonEmptyStringSchema as NonEmptyString,
+  UtcInstantSchema as UtcInstant,
+  strictParseOptions,
+} from '../schemas'
+import { MutationEventType } from '../execution/mutations'
+import {
+  AccountingReceiptRowSchema,
+  AccountingTransactionRowSchema,
+  accountingReceiptFromRow,
+  accountingTransactionFromRow,
+} from './accounting-rows'
+
+export interface IntentBinding {
+  readonly intentId: string
+  readonly clientOrderId: string
+}
+
+export interface BrokerSnapshot {
+  readonly account: AccountSnapshot
+  readonly positions: readonly Position[]
+  readonly positionsObservedAt: string
+  readonly orders: readonly Order[]
+  readonly ordersObservedAt: string
+  readonly fills: readonly Fill[]
+  readonly valuation: Valuation
+  readonly reconciledAt: string
+}
+
+export interface ReconciliationReport {
+  readonly reconciliation: Reconciliation
+  readonly metrics: ReconciliationMetrics
+}
+
+const IntentBindingRow = Schema.Struct({ intent_id: Sha256, client_order_id: NonEmptyString })
+const IntentRow = Schema.Struct({
+  intent_id: Sha256,
+  client_order_id: NonEmptyString,
+  symbol: Schema.String,
+  side: Schema.Enum(OrderSide),
+  order_type: Schema.Enum(OrderType),
+  time_in_force: Schema.Enum(TimeInForce),
+  quantity_micros: Schema.String,
+  state: Schema.Enum(IntentState),
+  terminal_outcome: Schema.NullOr(Schema.Enum(TerminalOutcome)),
+  broker_order_id: Schema.NullOr(NonEmptyString),
+  mutation_operation: Schema.NullOr(Schema.Enum(MutationOperation)),
+  mutation_event_type: Schema.NullOr(Schema.Enum(MutationEventType)),
+  mutation_occurred_at: Schema.NullOr(UtcInstant),
+})
+const DurableFillRow = Schema.Struct({
+  fill_id: NonEmptyString,
+  broker_order_id: NonEmptyString,
+  broker_event_id: Sha256,
+  transaction_id: Schema.NullOr(Sha256),
+  receipt_id: Schema.NullOr(Sha256),
+})
+const ProjectedPositionRow = Schema.Struct({
+  symbol: Schema.String,
+  quantity_micros: Schema.String,
+  cost_basis_micros: Schema.String,
+})
+const OpeningCashRow = Schema.Tuple([Schema.Struct({ cash_micros: Schema.String, observed_at: UtcInstant })])
+const PreviousReconciliationRows = Schema.Array(
+  Schema.Struct({ discrepancies: Schema.Array(DiscrepancySchema) }),
+).check(Schema.isMaxLength(1))
+const ReconciliationContentRow = Schema.Tuple([Schema.Struct({ content_hash: Sha256 })])
+
+const decodeBindings = Schema.decodeUnknownEffect(Schema.Array(IntentBindingRow), strictParseOptions)
+const decodeIntents = Schema.decodeUnknownEffect(Schema.Array(IntentRow), strictParseOptions)
+const decodeDurableFills = Schema.decodeUnknownEffect(Schema.Array(DurableFillRow), strictParseOptions)
+const decodeProjectedPositions = Schema.decodeUnknownEffect(Schema.Array(ProjectedPositionRow), strictParseOptions)
+const decodeOpeningCash = Schema.decodeUnknownEffect(OpeningCashRow, strictParseOptions)
+const decodeTransactions = Schema.decodeUnknownEffect(Schema.Array(AccountingTransactionRowSchema), strictParseOptions)
+const decodeReceipts = Schema.decodeUnknownEffect(Schema.Array(AccountingReceiptRowSchema), strictParseOptions)
+const decodePreviousReconciliation = Schema.decodeUnknownEffect(PreviousReconciliationRows, strictParseOptions)
+const decodeContent = Schema.decodeUnknownEffect(ReconciliationContentRow, strictParseOptions)
+const encodeDiscrepancies = Schema.encodeSync(Schema.fromJsonString(Schema.Array(DiscrepancySchema)))
+
+const attempt = <A>(evaluate: () => A): Effect.Effect<A, unknown> =>
+  Effect.try({ try: evaluate, catch: (cause) => cause })
+
+const unresolvedEvents = new Set<MutationEventType>([
+  MutationEventType.SubmitStarted,
+  MutationEventType.SubmitUnknown,
+  MutationEventType.RecoveryNotFound,
+  MutationEventType.RecoveryUnknown,
+  MutationEventType.CancelStarted,
+  MutationEventType.CancelAccepted,
+  MutationEventType.CancelUnknown,
+])
+
+const receiptMaterial = (receipt: AccountingReceipt) => ({
+  schemaVersion: receipt.schemaVersion,
+  ...(receipt.intentId === undefined ? {} : { intentId: receipt.intentId }),
+  brokerEventId: receipt.brokerEventId,
+  tigerBeetleClusterId: receipt.tigerBeetleClusterId,
+  tigerBeetleLedger: receipt.tigerBeetleLedger,
+  accountIds: receipt.accountIds,
+  transferIds: receipt.transferIds,
+  debitMicros: receipt.debitMicros,
+  creditMicros: receipt.creditMicros,
+})
+
+const receiptIsExact = (
+  transaction: AccountingTransaction,
+  receipt: AccountingReceipt | undefined,
+  plan: ReturnType<typeof rebuildAccountingLedger>,
+  config: Pick<RuntimeConfig, 'tigerBeetle'>,
+): boolean => {
+  if (receipt === undefined) return false
+  const accountIds = plan.accounts.map((account) => account.id.toString())
+  const transferIds = plan.transfers.map((transfer) => transfer.id.toString())
+  const posted = plan.transfers.reduce((sum, transfer) => sum + transfer.amount, 0n).toString()
+  return (
+    receipt.brokerEventId === transaction.brokerEventId &&
+    receipt.intentId === transaction.intentId &&
+    receipt.tigerBeetleClusterId === config.tigerBeetle.clusterId.toString() &&
+    receipt.tigerBeetleLedger === config.tigerBeetle.ledger &&
+    receipt.debitMicros === posted &&
+    receipt.creditMicros === posted &&
+    receipt.accountIds.length === accountIds.length &&
+    receipt.accountIds.every((value, index) => value === accountIds[index]) &&
+    receipt.transferIds.length === transferIds.length &&
+    receipt.transferIds.every((value, index) => value === transferIds[index]) &&
+    canonicalHashV1(receiptMaterial(receipt)) === receipt.contentHash
+  )
+}
+
+export const restrictAuthority = (
+  sql: PgClient.PgClient,
+  reason: string,
+  updatedAt: string,
+): Effect.Effect<void, unknown> =>
+  sql`
+    UPDATE authority_state
+    SET
+      effective = 'OBSERVE',
+      kill_state = 'ACTIVE',
+      reason = ${reason},
+      version = version + 1,
+      updated_at = ${updatedAt}
+    WHERE singleton
+      AND (effective <> 'OBSERVE' OR kill_state <> 'ACTIVE')
+  `.pipe(Effect.asVoid)
+
+export const makeReconciliation = (
+  sql: PgClient.PgClient,
+  journal: JournalService,
+  config: Pick<RuntimeConfig, 'tigerBeetle'>,
+) => {
+  const bindings = (accountId: string): Effect.Effect<readonly IntentBinding[], unknown> =>
+    sql<Record<string, unknown>>`
+      SELECT intent_id, client_order_id
+      FROM intents
+      WHERE account_id = ${accountId}
+      ORDER BY client_order_id
+    `.pipe(
+      Effect.flatMap(decodeBindings),
+      Effect.map((rows) => rows.map((row) => ({ intentId: row.intent_id, clientOrderId: row.client_order_id }))),
+    )
+
+  const reconcile = (snapshot: BrokerSnapshot): Effect.Effect<ReconciliationReport, unknown> =>
+    sql.withTransaction(
+      Effect.gen(function* () {
+        const accountId = snapshot.account.accountId
+        yield* sql`SELECT pg_advisory_xact_lock(hashtextextended(${`ALPACA:${accountId}`}, 0))`
+
+        const intentRows = yield* sql<Record<string, unknown>>`
+          SELECT
+            intent.intent_id,
+            intent.client_order_id,
+            intent.symbol,
+            intent.side,
+            intent.order_type,
+            intent.time_in_force,
+            intent.quantity_micros::text AS quantity_micros,
+            intent.state,
+            intent.terminal_outcome,
+            accepted.broker_order_id,
+            latest.operation AS mutation_operation,
+            latest.event_type AS mutation_event_type,
+            to_char(latest.occurred_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS mutation_occurred_at
+          FROM intents AS intent
+          LEFT JOIN LATERAL (
+            SELECT operation, event_type, occurred_at
+            FROM mutation_events
+            WHERE intent_id = intent.intent_id
+            ORDER BY
+              CASE operation WHEN 'CANCEL' THEN 1 ELSE 0 END DESC,
+              sequence DESC
+            LIMIT 1
+          ) AS latest ON true
+          LEFT JOIN LATERAL (
+            SELECT broker_order_id
+            FROM mutation_events
+            WHERE intent_id = intent.intent_id AND broker_order_id IS NOT NULL
+            ORDER BY
+              CASE operation WHEN 'CANCEL' THEN 1 ELSE 0 END DESC,
+              sequence DESC
+            LIMIT 1
+          ) AS accepted ON true
+          WHERE intent.account_id = ${accountId}
+          ORDER BY intent.client_order_id
+        `.pipe(Effect.flatMap(decodeIntents))
+        const intents: IntentExpectation[] = intentRows.map((row) => ({
+          intentId: row.intent_id,
+          clientOrderId: row.client_order_id,
+          symbol: row.symbol,
+          side: row.side,
+          orderType: row.order_type,
+          timeInForce: row.time_in_force,
+          quantityMicros: row.quantity_micros,
+          state: row.state,
+          ...(row.terminal_outcome === null ? {} : { terminalOutcome: row.terminal_outcome }),
+          expectsBrokerOrder: row.broker_order_id !== null,
+          ...(row.broker_order_id === null ? {} : { brokerOrderId: row.broker_order_id }),
+          ...(row.mutation_event_type !== null &&
+          (unresolvedEvents.has(row.mutation_event_type) ||
+            (row.mutation_operation === MutationOperation.Cancel &&
+              row.mutation_event_type === MutationEventType.RecoveryFound &&
+              row.state !== IntentState.Terminal)) &&
+          row.mutation_occurred_at !== null
+            ? { unknownSince: row.mutation_occurred_at }
+            : {}),
+        }))
+
+        const transactionRows = yield* sql<Record<string, unknown>>`
+          SELECT
+            schema_version, transaction_id, broker_event_id, intent_id, account_id, symbol, side,
+            quantity_micros::text AS quantity_micros, price_micros::text AS price_micros,
+            notional_micros::text AS notional_micros, fee_micros::text AS fee_micros,
+            cost_basis_micros::text AS cost_basis_micros, realized_pnl_micros::text AS realized_pnl_micros,
+            quantity_delta_micros::text AS quantity_delta_micros,
+            cost_basis_delta_micros::text AS cost_basis_delta_micros,
+            cash_delta_micros::text AS cash_delta_micros, ledger_plan_hash, content_hash, occurred_at
+          FROM accounting_transactions
+          WHERE account_id = ${accountId}
+          ORDER BY occurred_at, transaction_id
+        `.pipe(Effect.flatMap(decodeTransactions))
+        const transactions = transactionRows.map(accountingTransactionFromRow)
+        const receiptRows = yield* sql<Record<string, unknown>>`
+          SELECT
+            schema_version, receipt_id, intent_id, broker_event_id,
+            tigerbeetle_cluster_id::text AS tigerbeetle_cluster_id,
+            tigerbeetle_ledger::integer AS tigerbeetle_ledger,
+            ARRAY(
+              SELECT item.value::text FROM unnest(account_ids) AS item(value) ORDER BY item.value
+            ) AS account_ids,
+            ARRAY(
+              SELECT item.value::text FROM unnest(transfer_ids) AS item(value) ORDER BY item.value
+            ) AS transfer_ids,
+            debit_micros::text AS debit_micros, credit_micros::text AS credit_micros,
+            content_hash, recorded_at
+          FROM accounting_receipts
+          WHERE broker_event_id IN (SELECT broker_event_id FROM accounting_transactions WHERE account_id = ${accountId})
+          ORDER BY broker_event_id
+        `.pipe(Effect.flatMap(decodeReceipts))
+        const receipts = yield* Effect.forEach(receiptRows, (row) =>
+          decodeAccountingReceipt(accountingReceiptFromRow(row)),
+        )
+        const { exactReceipts, plans } = yield* attempt(() => {
+          const receiptsByEvent = new Map(receipts.map((receipt) => [receipt.brokerEventId, receipt]))
+          if (receiptsByEvent.size !== receipts.length) throw new Error('duplicate accounting receipt broker event')
+          const plans = transactions.map((transaction) =>
+            rebuildAccountingLedger(transaction, config.tigerBeetle.ledger),
+          )
+          const exactReceipts = new Map(
+            transactions.map((transaction, index) => [
+              transaction.brokerEventId,
+              receiptIsExact(transaction, receiptsByEvent.get(transaction.brokerEventId), plans[index], config),
+            ]),
+          )
+          return { exactReceipts, plans }
+        })
+        const ledgerExact = yield* journal.verifyAccount(accountId, plans)
+
+        const durableFillRows = yield* sql<Record<string, unknown>>`
+          SELECT
+            fill.fill_id,
+            fill.broker_order_id,
+            fill.event_id AS broker_event_id,
+            transaction.transaction_id,
+            receipt.receipt_id
+          FROM fills AS fill
+          LEFT JOIN accounting_transactions AS transaction ON transaction.broker_event_id = fill.event_id
+          LEFT JOIN accounting_receipts AS receipt ON receipt.broker_event_id = fill.event_id
+          WHERE fill.account_id = ${accountId}
+          ORDER BY fill.fill_id
+        `.pipe(Effect.flatMap(decodeDurableFills))
+        const durableFills = durableFillRows.map((row) => ({
+          fillId: row.fill_id,
+          brokerOrderId: row.broker_order_id,
+          accounted:
+            row.transaction_id !== null && row.receipt_id !== null && exactReceipts.get(row.broker_event_id) === true,
+        }))
+
+        const projectedPositionRows = yield* sql<Record<string, unknown>>`
+          SELECT
+            symbol,
+            sum(quantity_delta_micros)::text AS quantity_micros,
+            sum(cost_basis_delta_micros)::text AS cost_basis_micros
+          FROM accounting_transactions
+          WHERE account_id = ${accountId}
+          GROUP BY symbol
+          HAVING sum(quantity_delta_micros) <> 0
+          ORDER BY symbol
+        `.pipe(Effect.flatMap(decodeProjectedPositions))
+        const projectedPositions = projectedPositionRows.map((row) => ({
+          symbol: row.symbol,
+          quantityMicros: row.quantity_micros,
+          costBasisMicros: row.cost_basis_micros,
+        }))
+
+        const [openingCash] = yield* sql<Record<string, unknown>>`
+          SELECT
+            snapshot.cash_micros::text AS cash_micros,
+            to_char(event.observed_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS observed_at
+          FROM account_snapshots AS snapshot
+          JOIN broker_events AS event ON event.event_id = snapshot.event_id
+          WHERE snapshot.account_id = ${accountId}
+          ORDER BY event.source_sequence
+          LIMIT 1
+        `.pipe(Effect.flatMap(decodeOpeningCash))
+        const comparison = yield* attempt(() => {
+          if (transactions.some((transaction) => transaction.occurredAt < openingCash.observed_at)) {
+            throw new Error('paper accounting predates the opening cash snapshot')
+          }
+          const expectedCashMicros = transactions
+            .reduce((cash, transaction) => cash + BigInt(transaction.cashDeltaMicros), BigInt(openingCash.cash_micros))
+            .toString()
+          const accountingHash = canonicalHashV1({
+            schemaVersion: 'bayn.paper-accounting-state.v1',
+            accountId,
+            openingCash,
+            transactions,
+            receipts,
+            ledgerExact,
+          })
+          const stateHash = reconciledStateHash({
+            account: snapshot.account,
+            positions: snapshot.positions,
+            positionsObservedAt: snapshot.positionsObservedAt,
+            orders: snapshot.orders,
+            ordersObservedAt: snapshot.ordersObservedAt,
+            accountingHash,
+          })
+          return compareReconciliation({
+            accountId,
+            stateHash,
+            account: snapshot.account,
+            positions: snapshot.positions,
+            orders: snapshot.orders,
+            fills: snapshot.fills,
+            intents,
+            durableFills,
+            projectedPositions,
+            expectedCashMicros,
+            valuation: snapshot.valuation,
+            accountingHash,
+            ledgerExact,
+            reconciledAt: snapshot.reconciledAt,
+          })
+        })
+
+        const [previous] = yield* sql<Record<string, unknown>>`
+          SELECT discrepancies
+          FROM reconciliations
+          WHERE account_id = ${accountId}
+          ORDER BY reconciled_at DESC, reconciliation_id DESC
+          LIMIT 1
+        `.pipe(Effect.flatMap(decodePreviousReconciliation))
+        const { contentHash, discrepancies, reconciliationId, reconciliationMaterial, status } = yield* attempt(() => {
+          const prior = new Map((previous?.discrepancies ?? []).map((value) => [value.discrepancyId, value]))
+          const status =
+            comparison.discrepancies.length === 0 ? ReconciliationStatus.Exact : ReconciliationStatus.Discrepancy
+          const discrepancies: Discrepancy[] = comparison.discrepancies.map((value) => ({
+            ...value,
+            firstObservedAt: prior.get(value.discrepancyId)?.firstObservedAt ?? snapshot.reconciledAt,
+            lastObservedAt: snapshot.reconciledAt,
+          }))
+          const reconciliationMaterial = {
+            schemaVersion: 'bayn.paper-reconciliation.v1' as const,
+            accountId,
+            expectedHash: comparison.expectedHash,
+            observedHash: comparison.observedHash,
+            status,
+            discrepancies,
+            reconciledAt: snapshot.reconciledAt,
+          }
+          const reconciliationId = canonicalHashV1({
+            schemaVersion: 'bayn.paper-reconciliation-id.v1',
+            material: reconciliationMaterial,
+          })
+          const contentHash = canonicalHashV1({ ...reconciliationMaterial, reconciliationId })
+          return { contentHash, discrepancies, reconciliationId, reconciliationMaterial, status }
+        })
+        const reconciliation = yield* decodeReconciliation({
+          schemaVersion: reconciliationMaterial.schemaVersion,
+          reconciliationId,
+          accountId,
+          expectedHash: comparison.expectedHash,
+          observedHash: comparison.observedHash,
+          contentHash,
+          status,
+          discrepancies,
+          reconciledAt: snapshot.reconciledAt,
+        })
+        yield* sql`
+          INSERT INTO reconciliations (
+            reconciliation_id, schema_version, account_id, expected_hash, observed_hash,
+            content_hash, status, discrepancies, reconciled_at
+          ) VALUES (
+            ${reconciliation.reconciliationId}, ${reconciliation.schemaVersion}, ${reconciliation.accountId},
+            ${reconciliation.expectedHash}, ${reconciliation.observedHash}, ${reconciliation.contentHash},
+            ${reconciliation.status}, ${sql.json(encodeDiscrepancies(reconciliation.discrepancies))},
+            ${reconciliation.reconciledAt}
+          )
+          ON CONFLICT (reconciliation_id) DO NOTHING
+        `
+        const [stored] = yield* sql<Record<string, unknown>>`
+          SELECT content_hash FROM reconciliations WHERE reconciliation_id = ${reconciliationId}
+        `.pipe(Effect.flatMap(decodeContent))
+        if (stored.content_hash !== contentHash) {
+          return yield* Effect.fail(new Error('stored reconciliation differs from deterministic replay'))
+        }
+
+        if (comparison.discrepancies.length > 0) {
+          yield* restrictAuthority(sql, `reconciliation discrepancy ${reconciliationId}`, snapshot.reconciledAt)
+        }
+
+        return { reconciliation, metrics: comparison.metrics }
+      }),
+    )
+
+  return { bindings, reconcile }
+}

--- a/services/bayn/src/health.test.ts
+++ b/services/bayn/src/health.test.ts
@@ -30,6 +30,7 @@ describe('Bayn continuous health', () => {
     }
     const journal: JournalService = {
       post: () => Effect.die(new Error('health probes must not write TigerBeetle')),
+      verifyAccount: () => Effect.die(new Error('health probes must not reconcile paper accounting')),
       check: Effect.die(new Error('a durable run must use checkRun')),
       checkRun: () => Effect.sync(() => void (accountingChecks += 1)),
       journalAndReconcile: () => Effect.die(new Error('health probes must not write TigerBeetle')),

--- a/services/bayn/src/index.ts
+++ b/services/bayn/src/index.ts
@@ -3,14 +3,19 @@ import { ClickhouseClient } from '@effect/sql-clickhouse'
 import { Effect, Layer, Logger, Redacted } from 'effect'
 
 import { run } from './app'
+import { live as AlpacaReadLive } from './broker/alpaca'
 import { verifyParameterHash } from './build'
 import { loadConfig } from './config'
 import { makeRuntimeProvenance } from './contracts'
 import { EvidenceStoreLive } from './db/evidence-store'
+import { PaperStoreLive } from './db/paper-store'
+import { WriterFenceLive } from './execution/writer-fence'
+import { operationalError } from './errors'
 import { JournalLive } from './ledger'
 import { MarketDataLive } from './market-data'
 import { acquireSqlLayer } from './operations'
 import { hashParameters, loadDefaultProtocol } from './protocol'
+import { runContinuously } from './reconciler'
 import { makeStrategy } from './strategy'
 
 const main = Effect.gen(function* () {
@@ -47,8 +52,41 @@ const main = Effect.gen(function* () {
     Layer.provide(NodeHttpClient.layerNodeHttp),
   )
   const evidenceStore = yield* acquireSqlLayer(EvidenceStoreLive(config).pipe(Layer.provide(NodeServices.layer)))
-  const dependencies = Layer.mergeAll(marketData, JournalLive(config), Layer.succeedContext(evidenceStore))
-  return yield* run(config, strategy).pipe(Effect.provide(dependencies))
+  const journal = yield* acquireSqlLayer(JournalLive(config))
+  let reconciliation = Effect.void
+  if (config.alpaca !== undefined) {
+    const storage = Layer.mergeAll(Layer.succeedContext(evidenceStore), Layer.succeedContext(journal))
+    const paperStore = yield* Layer.build(PaperStoreLive(config).pipe(Layer.provide(storage)))
+    const writerFence = yield* Layer.build(
+      WriterFenceLive.pipe(Layer.provide(Layer.succeedContext(evidenceStore))),
+    ).pipe(
+      Effect.mapError((cause) =>
+        operationalError('database', 'writer-fence', 'paper writer fence acquisition failed', cause),
+      ),
+    )
+    const brokerRead = yield* Layer.build(
+      AlpacaReadLive({
+        expectedAccountId: config.alpaca.accountId,
+        key: config.alpaca.key,
+        secret: config.alpaca.secret,
+        proxyUrl: config.alpaca.proxyUrl,
+        operationTimeoutMs: config.operationTimeoutMs,
+        retryAttempts: config.alpaca.retryAttempts,
+      }),
+    ).pipe(
+      Effect.mapError((cause) => operationalError('config', 'alpaca', 'Alpaca paper account binding failed', cause)),
+    )
+    const reconciliationDependencies = Layer.mergeAll(
+      Layer.succeedContext(brokerRead),
+      Layer.succeedContext(paperStore),
+      Layer.succeedContext(writerFence),
+    )
+    reconciliation = runContinuously(config.alpaca.reconciliationIntervalMs).pipe(
+      Effect.provide(reconciliationDependencies),
+    )
+  }
+  const dependencies = Layer.mergeAll(marketData, Layer.succeedContext(journal), Layer.succeedContext(evidenceStore))
+  return yield* run(config, strategy, reconciliation).pipe(Effect.provide(dependencies))
 }).pipe(Effect.scoped)
 
 const program = main.pipe(Effect.annotateLogs({ service: 'bayn' }), Effect.provide(Logger.layer([Logger.consoleJson])))

--- a/services/bayn/src/ledger.test.ts
+++ b/services/bayn/src/ledger.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test'
 import { Effect, Redacted } from 'effect'
 import { CreateAccountStatus, CreateTransferStatus, type Account, type Transfer } from 'tigerbeetle-node'
 
-import { prepareAccounting } from './accounting'
+import { prepareAccounting, rebuildAccountingLedger } from './accounting'
 import type { RuntimeConfig } from './config'
 import { Authority, OrderSide, type Fill } from './paper'
 import {
@@ -200,9 +200,14 @@ describe('TigerBeetle simulation journal', () => {
     ).ledger
     const target = makeLedgerClient()
 
-    await Effect.runPromise(
-      withJournal(target.client, (journal) => journal.post(plan).pipe(Effect.andThen(journal.post(plan)))),
+    const exact = await Effect.runPromise(
+      withJournal(target.client, (journal) =>
+        journal
+          .post(plan)
+          .pipe(Effect.andThen(journal.post(plan)), Effect.andThen(journal.verifyAccount(fill.accountId, [plan]))),
+      ),
     )
+    expect(exact).toBeTrue()
     expect(target.accounts.size).toBe(plan.accounts.length)
     expect(target.transfers.size).toBe(plan.transfers.length)
 
@@ -214,6 +219,52 @@ describe('TigerBeetle simulation journal', () => {
     })
     const error = await Effect.runPromise(Effect.flip(withJournal(conflict.client, (journal) => journal.post(plan))))
     expect(error.message).toContain('does not match its plan')
+
+    target.transfers.set(plan.transfers[0].id + 1n, { ...plan.transfers[0], id: plan.transfers[0].id + 1n })
+    const extra = await Effect.runPromise(
+      withJournal(target.client, (journal) => journal.verifyAccount(fill.accountId, [plan])),
+    )
+    expect(extra).toBeFalse()
+
+    const unavailable = makeTigerBeetleClient({
+      queryAccounts: async () => {
+        throw new Error('unavailable')
+      },
+    })
+    const failure = await Effect.runPromise(
+      Effect.flip(withJournal(unavailable, (journal) => journal.verifyAccount(fill.accountId, [plan]))),
+    )
+    expect(failure.message).toContain('TigerBeetle verify-account-accounts failed')
+  })
+
+  test('rebuilds a paper transaction into the exact read-only ledger plan', () => {
+    const fill: Fill = {
+      schemaVersion: 'bayn.paper-fill.v1',
+      accountId: 'paper-account',
+      fillId: 'activity-2',
+      brokerOrderId: 'broker-order-2',
+      clientOrderId: 'client-order-2',
+      symbol: 'AMD',
+      side: OrderSide.Buy,
+      quantityMicros: '2000000',
+      priceMicros: '50000000',
+      feeMicros: '0',
+      occurredAt: '2026-07-22T15:31:00.000Z',
+    }
+    const prepared = prepareAccounting(
+      'b'.repeat(64),
+      fill,
+      { quantityMicros: '0', costMicros: '0' },
+      journalConfig.tigerBeetle.ledger,
+    )
+
+    expect(rebuildAccountingLedger(prepared.transaction, journalConfig.tigerBeetle.ledger)).toEqual(prepared.ledger)
+    expect(() =>
+      rebuildAccountingLedger(
+        { ...prepared.transaction, contentHash: 'c'.repeat(64) },
+        journalConfig.tigerBeetle.ledger,
+      ),
+    ).toThrow('content hash')
   })
 
   test('rejects a mismatched existing account before creating transfers', async () => {

--- a/services/bayn/src/ledger.ts
+++ b/services/bayn/src/ledger.ts
@@ -29,6 +29,7 @@ import type { ReconciliationResult } from './types'
 
 export interface JournalService {
   readonly post: (plan: LedgerPlan) => Effect.Effect<void, OperationalError>
+  readonly verifyAccount: (accountId: string, plans: readonly LedgerPlan[]) => Effect.Effect<boolean, OperationalError>
   readonly journalAndReconcile: (result: LedgerInput) => Effect.Effect<ReconciliationResult, OperationalError>
   readonly check: Effect.Effect<void, OperationalError>
   readonly checkRun: (result: ReconciliationResult) => Effect.Effect<void, OperationalError>
@@ -256,6 +257,75 @@ const post = (client: TigerBeetleRequestClient, plan: LedgerPlan): Effect.Effect
     })
   })
 
+const accountPlan = (accountId: string, plans: readonly LedgerPlan[]): LedgerPlan => {
+  const runKey = stableU128('bayn-paper-account-v1', accountId)
+  const runTag = stableU64('bayn-paper-account-v1', accountId)
+  const accounts = new Map<bigint, Account>()
+  const transfers = new Map<bigint, Transfer>()
+  for (const plan of plans) {
+    if (plan.runKey !== runKey || plan.runTag !== runTag) {
+      throw new Error(`accounting plan does not belong to paper account ${accountId}`)
+    }
+    for (const account of plan.accounts) {
+      const existing = accounts.get(account.id)
+      if (existing !== undefined) assertAccountsMatch('accounting account', [account], [existing])
+      else accounts.set(account.id, account)
+    }
+    for (const transfer of plan.transfers) {
+      if (transfers.has(transfer.id)) throw new Error(`duplicate accounting transfer ${transfer.id}`)
+      transfers.set(transfer.id, transfer)
+    }
+  }
+  return {
+    runKey,
+    runTag,
+    accounts: [...accounts.values()].sort((left, right) => (left.id < right.id ? -1 : 1)),
+    transfers: [...transfers.values()].sort((left, right) => (left.id < right.id ? -1 : 1)),
+  }
+}
+
+const verifyAccount = (
+  client: TigerBeetleRequestClient,
+  ledger: number,
+  accountId: string,
+  plans: readonly LedgerPlan[],
+): Effect.Effect<boolean, OperationalError> =>
+  Effect.gen(function* () {
+    const expected = yield* validate('build-account-reconciliation', () => accountPlan(accountId, plans))
+    if (expected.accounts.length >= BATCH_MAX || expected.transfers.length >= BATCH_MAX) {
+      return yield* Effect.fail(
+        operationalError('journal', 'verify-account', 'paper account exceeds the exact reconciliation limit'),
+      )
+    }
+    const [accounts, transfers] = yield* Effect.all(
+      [
+        client.request('verify-account-accounts', (active) =>
+          active.queryAccounts({
+            ...queryFilter(ledger),
+            user_data_128: expected.runKey,
+            limit: expected.accounts.length + 1,
+          }),
+        ),
+        client.request('verify-account-transfers', (active) =>
+          active.queryTransfers({
+            ...queryFilter(ledger),
+            user_data_64: expected.runTag,
+            limit: expected.transfers.length + 1,
+          }),
+        ),
+      ],
+      { concurrency: 'unbounded' },
+    )
+    return yield* Effect.sync(() => {
+      try {
+        assertReconciled(expected, accounts, transfers)
+        return true
+      } catch {
+        return false
+      }
+    })
+  })
+
 export const JournalLive = (
   config: Pick<RuntimeConfig, 'operationTimeoutMs' | 'tigerBeetle'>,
   dependencies?: JournalDependencies,
@@ -266,6 +336,7 @@ export const JournalLive = (
       const client = yield* makeTigerBeetleRequestClient(config, dependencies)
       return {
         post: (plan) => post(client, plan),
+        verifyAccount: (accountId, plans) => verifyAccount(client, config.tigerBeetle.ledger, accountId, plans),
         check: client
           .request('connectivity-check', (active) => active.lookupAccounts([stableU128('bayn-connectivity-probe')]))
           .pipe(Effect.asVoid),

--- a/services/bayn/src/paper.ts
+++ b/services/bayn/src/paper.ts
@@ -129,6 +129,7 @@ export enum DiscrepancyKind {
   Position = 'POSITION',
   Order = 'ORDER',
   Fill = 'FILL',
+  Mutation = 'MUTATION',
   Accounting = 'ACCOUNTING',
   Valuation = 'VALUATION',
 }
@@ -526,12 +527,28 @@ export const ValuationSchema = ValuationBase.check(
 )
 export type Valuation = typeof ValuationSchema.Type
 
-export const DiscrepancySchema = Schema.Struct({
+const DiscrepancyBase = Schema.Struct({
+  discrepancyId: Sha256,
   kind: Schema.Enum(DiscrepancyKind),
   identity: NonEmptyString,
   expected: NonEmptyString,
   observed: NonEmptyString,
+  evidenceHash: Sha256,
+  firstObservedAt: UtcInstant,
+  lastObservedAt: UtcInstant,
 })
+export const DiscrepancySchema = DiscrepancyBase.check(
+  Schema.makeFilter((value: typeof DiscrepancyBase.Type): readonly Schema.FilterIssue[] => {
+    const issues: Schema.FilterIssue[] = []
+    if (value.lastObservedAt < value.firstObservedAt) {
+      issues.push({ path: ['lastObservedAt'], issue: 'must not precede firstObservedAt' })
+    }
+    if (value.expected === value.observed) {
+      issues.push({ path: ['observed'], issue: 'must differ while the discrepancy is open' })
+    }
+    return issues
+  }),
+)
 export type Discrepancy = typeof DiscrepancySchema.Type
 
 const ReconciliationBase = Schema.Struct({

--- a/services/bayn/src/reconciler.test.ts
+++ b/services/bayn/src/reconciler.test.ts
@@ -1,0 +1,371 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Deferred, Effect, Fiber } from 'effect'
+import { TestClock } from 'effect/testing'
+
+import {
+  AccountStatus as BrokerAccountStatus,
+  AssetClass,
+  OrderClass,
+  OrderSide as BrokerSide,
+  OrderStatus as BrokerOrderStatus,
+  OrderType as BrokerOrderType,
+  TimeInForce as BrokerTimeInForce,
+  TradeActivityType,
+  BrokerRead,
+  BrokerReadError,
+  BrokerReadErrorKind,
+  type Account as BrokerAccount,
+  type BrokerReadShape,
+  type FillActivity,
+  type Order as BrokerOrder,
+  type ReadEvidence,
+} from './broker/alpaca'
+import { canonicalHashV1 } from './hash'
+import { ReconciliationStatus, type AccountingReceipt, type Valuation } from './paper'
+import { PaperStore, type PaperStoreShape } from './db/paper-store'
+import type { BrokerSnapshot, ReconciliationReport } from './db/reconciliation'
+import { WriterFence, type WriterFenceService } from './execution/writer-fence'
+import { ReconciliationError, runContinuously, runOnce } from './reconciler'
+
+const accountId = '61e69015-8549-4bfd-b9c3-01e75843f47d'
+const observedAt = '1970-01-01T00:00:00.000Z'
+const hash = (value: unknown): string => canonicalHashV1(value)
+
+const evidence = (identity: string): ReadEvidence => ({
+  requestId: `request-${identity}`,
+  status: 200,
+  contentHash: hash(identity),
+  observedAt,
+})
+
+const account: BrokerAccount = {
+  id: accountId,
+  status: BrokerAccountStatus.Active,
+  currency: 'USD',
+  cashMicros: '1000000000',
+  equityMicros: '1000000000',
+  buyingPowerMicros: '2000000000',
+  accountBlocked: false,
+  tradingBlocked: false,
+  tradeSuspendedByUser: false,
+  observedAt,
+}
+
+const order = (index: number): BrokerOrder => ({
+  accountId,
+  brokerOrderId: `broker-order-${index}`,
+  clientOrderId: `client-order-${index}`,
+  createdAt: observedAt,
+  updatedAt: observedAt,
+  submittedAt: new Date(index).toISOString(),
+  assetId: `asset-${index}`,
+  symbol: 'NVDA',
+  assetClass: AssetClass.UsEquity,
+  quantityMicros: '1000000',
+  filledQuantityMicros: '1000000',
+  filledAveragePriceMicros: '100000000',
+  orderClass: OrderClass.Simple,
+  orderType: BrokerOrderType.Market,
+  side: BrokerSide.Buy,
+  timeInForce: BrokerTimeInForce.Day,
+  status: BrokerOrderStatus.Filled,
+  extendedHours: false,
+  observedAt,
+})
+
+const fill = (index: number, sourceOrder = order(index)): FillActivity => ({
+  accountId,
+  activityId: `fill-${index}`,
+  cumulativeQuantityMicros: '1000000',
+  leavesQuantityMicros: '0',
+  priceMicros: '100000000',
+  quantityMicros: '1000000',
+  side: sourceOrder.side,
+  symbol: sourceOrder.symbol,
+  transactionTime: observedAt,
+  brokerOrderId: sourceOrder.brokerOrderId,
+  type: TradeActivityType.Fill,
+  orderStatus: BrokerOrderStatus.Filled,
+})
+
+const valuation: Valuation = {
+  schemaVersion: 'bayn.paper-valuation.v1',
+  valuationId: hash('valuation'),
+  accountId,
+  sourceHash: hash('valuation-source'),
+  cashMicros: account.cashMicros,
+  longMarketValueMicros: '0',
+  shortMarketValueMicros: '0',
+  equityMicros: account.cashMicros,
+  asOf: observedAt,
+}
+
+const receipt: AccountingReceipt = {
+  schemaVersion: 'bayn.paper-accounting-receipt.v1',
+  receiptId: hash('receipt'),
+  brokerEventId: hash('fill-event'),
+  tigerBeetleClusterId: '1',
+  tigerBeetleLedger: 1,
+  accountIds: ['1', '2'],
+  transferIds: ['3'],
+  debitMicros: '1',
+  creditMicros: '1',
+  contentHash: hash('receipt-content'),
+  recordedAt: observedAt,
+}
+
+const report = (snapshot: BrokerSnapshot): ReconciliationReport => ({
+  reconciliation: {
+    schemaVersion: 'bayn.paper-reconciliation.v1',
+    reconciliationId: hash('reconciliation'),
+    accountId,
+    expectedHash: hash('state'),
+    observedHash: hash('state'),
+    contentHash: hash('reconciliation-content'),
+    status: ReconciliationStatus.Exact,
+    discrepancies: [],
+    reconciledAt: snapshot.reconciledAt,
+  },
+  metrics: {
+    brokerPollAgeMs: 0,
+    oldestUnknownMutationAgeMs: 0,
+    cashDifferenceMicros: '0',
+    positionDifferenceMicros: '0',
+    equityDifferenceMicros: '0',
+    accountingExact: true,
+    discrepancyCount: 0,
+  },
+})
+
+interface StoreControl {
+  writes: number
+  reconciliations: BrokerSnapshot[]
+  restrictions: string[]
+}
+
+const makeStore = (control: StoreControl): PaperStoreShape => ({
+  ingest: (input) =>
+    Effect.sync(() => {
+      control.writes += 1
+      return { eventId: hash(input.sourceEventId), sourceSequence: String(control.writes), deduplicated: false }
+    }),
+  ingestPositions: (input) =>
+    Effect.sync(() => {
+      control.writes += 1
+      return { snapshotId: hash(input.sourceHash), eventIds: [], deduplicated: false }
+    }),
+  account: () =>
+    Effect.sync(() => {
+      control.writes += 1
+      return receipt
+    }),
+  value: () =>
+    Effect.sync(() => {
+      control.writes += 1
+      return valuation
+    }),
+  bindings: () => Effect.succeed([{ intentId: hash('intent'), clientOrderId: order(0).clientOrderId }]),
+  reconcile: (snapshot) =>
+    Effect.sync(() => {
+      control.writes += 1
+      control.reconciliations.push(snapshot)
+      return report(snapshot)
+    }),
+  restrictAuthority: (reason) =>
+    Effect.sync(() => {
+      control.restrictions.push(reason)
+    }),
+})
+
+const emptyRead = (): BrokerReadShape => ({
+  account: Effect.succeed({ value: account, evidence: evidence('account') }),
+  positions: Effect.succeed({ value: [], evidence: evidence('positions') }),
+  orders: () => Effect.succeed({ value: [], evidence: evidence('orders') }),
+  fillActivities: () => Effect.succeed({ value: { items: [] }, evidence: evidence('fills') }),
+  orderById: () => Effect.die(new Error('unexpected order lookup')),
+  orderByClientId: () => Effect.die(new Error('unexpected client order lookup')),
+})
+
+const fence: WriterFenceService = {
+  backendPid: 1,
+  check: Effect.void,
+  transaction: (effect) => effect,
+}
+
+const provide = (read: BrokerReadShape, store: PaperStoreShape) =>
+  runOnce.pipe(
+    Effect.provideService(BrokerRead, read),
+    Effect.provideService(PaperStore, store),
+    Effect.provideService(WriterFence, fence),
+  )
+
+describe('paper reconciliation loop', () => {
+  test('reads every broker page before persisting and binds fills to their orders', async () => {
+    const allOrders = Array.from({ length: 501 }, (_, index) => order(index))
+    const allFills = Array.from({ length: 101 }, (_, index) => fill(index, allOrders[index]))
+    const orderCursors: Array<string | undefined> = []
+    const fillCursors: Array<string | undefined> = []
+    const read: BrokerReadShape = {
+      ...emptyRead(),
+      orders: (query = {}) => {
+        orderCursors.push(query.after)
+        return Effect.succeed({
+          value: query.after === undefined ? allOrders.slice(0, 500) : allOrders.slice(500),
+          evidence: evidence(`orders-${orderCursors.length}`),
+        })
+      },
+      fillActivities: (query = {}) => {
+        fillCursors.push(query.pageToken)
+        const items = query.pageToken === undefined ? allFills.slice(0, 100) : allFills.slice(100)
+        return Effect.succeed({
+          value: {
+            items,
+            ...(query.pageToken === undefined ? { nextPageToken: allFills[99].activityId } : {}),
+          },
+          evidence: evidence(`fills-${fillCursors.length}`),
+        })
+      },
+    }
+    const control: StoreControl = { writes: 0, reconciliations: [], restrictions: [] }
+
+    await Effect.runPromise(provide(read, makeStore(control)))
+
+    expect(orderCursors).toEqual([undefined, allOrders[499].submittedAt])
+    expect(fillCursors).toEqual([undefined, allFills[99].activityId])
+    expect(control.reconciliations).toHaveLength(1)
+    expect(control.reconciliations[0].orders).toHaveLength(501)
+    expect(control.reconciliations[0].fills).toHaveLength(101)
+    expect(control.reconciliations[0].orders[0].intentId).toBe(hash('intent'))
+    expect(control.reconciliations[0].fills[0].intentId).toBe(hash('intent'))
+    expect(control.restrictions).toEqual([])
+  })
+
+  test('fails a duplicate page before any durable write or false resolution', async () => {
+    const duplicate = fill(0)
+    const read: BrokerReadShape = {
+      ...emptyRead(),
+      fillActivities: () =>
+        Effect.succeed({
+          value: { items: [duplicate], nextPageToken: duplicate.activityId },
+          evidence: evidence('duplicate-fill'),
+        }),
+    }
+    const control: StoreControl = { writes: 0, reconciliations: [], restrictions: [] }
+
+    const failure = await Effect.runPromise(provide(read, makeStore(control)).pipe(Effect.flip))
+    expect(failure).toBeInstanceOf(ReconciliationError)
+    expect(control.writes).toBe(0)
+    expect(control.reconciliations).toEqual([])
+    expect(control.restrictions).toEqual(['reconciliation pass incomplete'])
+  })
+
+  test('rejects broker history beyond the hard row limit before persisting', async () => {
+    let offset = 0
+    const read: BrokerReadShape = {
+      ...emptyRead(),
+      fillActivities: (query = {}) => {
+        const pageSize = query.pageSize ?? 100
+        const items = Array.from({ length: pageSize }, (_, index) => fill(offset + index))
+        offset += items.length
+        return Effect.succeed({
+          value: { items, nextPageToken: items[items.length - 1]?.activityId },
+          evidence: evidence(`fill-page-${offset}`),
+        })
+      },
+    }
+    const control: StoreControl = { writes: 0, reconciliations: [], restrictions: [] }
+
+    const failure = await Effect.runPromise(provide(read, makeStore(control)).pipe(Effect.flip))
+    expect(failure).toMatchObject({
+      _tag: 'ReconciliationError',
+      operation: 'pagination',
+      message: 'Alpaca fill history exceeds 10000 rows',
+    })
+    expect(offset).toBe(10_001)
+    expect(control.writes).toBe(0)
+    expect(control.restrictions).toEqual(['reconciliation pass incomplete'])
+  })
+
+  test('runs immediately and repeats on the Effect schedule', async () => {
+    const control: StoreControl = { writes: 0, reconciliations: [], restrictions: [] }
+    const program = Effect.scoped(
+      Effect.gen(function* () {
+        const fiber = yield* runContinuously(100).pipe(
+          Effect.provideService(BrokerRead, emptyRead()),
+          Effect.provideService(PaperStore, makeStore(control)),
+          Effect.provideService(WriterFence, fence),
+          Effect.forkScoped({ startImmediately: true }),
+        )
+        yield* Effect.yieldNow
+        expect(control.reconciliations).toHaveLength(1)
+        yield* TestClock.adjust(99)
+        expect(control.reconciliations).toHaveLength(1)
+        yield* TestClock.adjust(1)
+        expect(control.reconciliations).toHaveLength(2)
+        yield* Fiber.interrupt(fiber)
+      }),
+    ).pipe(Effect.provide(TestClock.layer()))
+
+    await Effect.runPromise(program)
+  })
+
+  test('restricts authority after a failed pass and retries on the same scoped loop', async () => {
+    const control: StoreControl = { writes: 0, reconciliations: [], restrictions: [] }
+    let attempts = 0
+    const read: BrokerReadShape = {
+      ...emptyRead(),
+      account: Effect.suspend(() => {
+        attempts += 1
+        return attempts === 1
+          ? Effect.fail(
+              new BrokerReadError({
+                operation: 'account',
+                kind: BrokerReadErrorKind.Transport,
+                message: 'injected read failure',
+                retryable: true,
+              }),
+            )
+          : Effect.succeed({ value: account, evidence: evidence('account') })
+      }),
+    }
+    const program = Effect.scoped(
+      Effect.gen(function* () {
+        const fiber = yield* runContinuously(100).pipe(
+          Effect.provideService(BrokerRead, read),
+          Effect.provideService(PaperStore, makeStore(control)),
+          Effect.provideService(WriterFence, fence),
+          Effect.forkScoped({ startImmediately: true }),
+        )
+        yield* Effect.yieldNow
+        expect(control.restrictions).toEqual(['reconciliation pass incomplete'])
+        expect(control.reconciliations).toEqual([])
+        yield* TestClock.adjust(100)
+        expect(control.reconciliations).toHaveLength(1)
+        yield* Fiber.interrupt(fiber)
+      }),
+    ).pipe(Effect.provide(TestClock.layer()))
+
+    await Effect.runPromise(program)
+  })
+
+  test('interrupts an in-flight read on shutdown without treating shutdown as a failed pass', async () => {
+    const control: StoreControl = { writes: 0, reconciliations: [], restrictions: [] }
+    const program = Effect.scoped(
+      Effect.gen(function* () {
+        const started = yield* Deferred.make<void>()
+        const read: BrokerReadShape = {
+          ...emptyRead(),
+          account: Deferred.succeed(started, undefined).pipe(Effect.andThen(Effect.never)),
+        }
+        const fiber = yield* provide(read, makeStore(control)).pipe(Effect.forkScoped({ startImmediately: true }))
+        yield* Deferred.await(started)
+        yield* Fiber.interrupt(fiber)
+      }),
+    )
+
+    await Effect.runPromise(program)
+    expect(control.writes).toBe(0)
+    expect(control.restrictions).toEqual([])
+  })
+})

--- a/services/bayn/src/reconciler.test.ts
+++ b/services/bayn/src/reconciler.test.ts
@@ -231,8 +231,8 @@ describe('paper reconciliation loop', () => {
 
     await Effect.runPromise(provide(read, makeStore(control)))
 
-    expect(orderCursors).toEqual([undefined, allOrders[499].submittedAt])
-    expect(fillCursors).toEqual([undefined, allFills[99].activityId])
+    expect(orderCursors).toEqual([undefined, allOrders[499].submittedAt, undefined, allOrders[499].submittedAt])
+    expect(fillCursors).toEqual([undefined, allFills[99].activityId, undefined, allFills[99].activityId])
     expect(control.reconciliations).toHaveLength(1)
     expect(control.reconciliations[0].orders).toHaveLength(501)
     expect(control.reconciliations[0].fills).toHaveLength(101)
@@ -255,6 +255,44 @@ describe('paper reconciliation loop', () => {
 
     const failure = await Effect.runPromise(provide(read, makeStore(control)).pipe(Effect.flip))
     expect(failure).toBeInstanceOf(ReconciliationError)
+    expect(control.writes).toBe(0)
+    expect(control.reconciliations).toEqual([])
+    expect(control.restrictions).toEqual(['reconciliation pass incomplete'])
+  })
+
+  test('rejects a broker mutation that races the account snapshot before any durable write', async () => {
+    const racedOrder = order(0)
+    const racedFill = fill(0, racedOrder)
+    let orderReads = 0
+    let fillReads = 0
+    const read: BrokerReadShape = {
+      ...emptyRead(),
+      orders: () => {
+        orderReads += 1
+        return Effect.succeed({
+          value: orderReads === 1 ? [] : [racedOrder],
+          evidence: evidence(`orders-${orderReads}`),
+        })
+      },
+      fillActivities: () => {
+        fillReads += 1
+        return Effect.succeed({
+          value: { items: fillReads === 1 ? [] : [racedFill] },
+          evidence: evidence(`fills-${fillReads}`),
+        })
+      },
+    }
+    const control: StoreControl = { writes: 0, reconciliations: [], restrictions: [] }
+
+    const failure = await Effect.runPromise(provide(read, makeStore(control)).pipe(Effect.flip))
+
+    expect(failure).toMatchObject({
+      _tag: 'ReconciliationError',
+      operation: 'snapshot',
+      message: 'broker history changed during reconciliation',
+    })
+    expect(orderReads).toBe(2)
+    expect(fillReads).toBe(2)
     expect(control.writes).toBe(0)
     expect(control.reconciliations).toEqual([])
     expect(control.restrictions).toEqual(['reconciliation pass incomplete'])

--- a/services/bayn/src/reconciler.ts
+++ b/services/bayn/src/reconciler.ts
@@ -21,6 +21,7 @@ import {
 import { PaperStore, type PaperStoreError, type PaperStoreShape } from './db/paper-store'
 import type { BrokerSnapshot, ReconciliationReport } from './db/reconciliation'
 import { WriterFence, type WriterFenceError, type WriterFenceService } from './execution/writer-fence'
+import { canonicalHashV1 } from './hash'
 
 const maximumRows = 10_000
 const ordersPageSize = 500
@@ -36,8 +37,13 @@ interface OrderRead {
   readonly observedAt: string
 }
 
+interface BrokerHistory {
+  readonly orders: OrderRead
+  readonly fills: readonly Observed<FillActivity>[]
+}
+
 export class ReconciliationError extends Data.TaggedError('ReconciliationError')<{
-  readonly operation: 'pagination' | 'normalization'
+  readonly operation: 'pagination' | 'normalization' | 'snapshot'
   readonly message: string
   readonly cause?: unknown
 }> {}
@@ -153,17 +159,41 @@ const readFills = (
     }
   })
 
+const readHistory = (
+  read: BrokerReadShape,
+  until: string,
+): Effect.Effect<BrokerHistory, BrokerReadError | ReconciliationError> =>
+  Effect.all({ orders: readOrders(read, until), fills: readFills(read, until) }, { concurrency: 2 })
+
+const historyHash = (history: BrokerHistory): string =>
+  canonicalHashV1({
+    schemaVersion: 'bayn.paper-broker-history.v1',
+    orders: history.orders.rows
+      .map(({ value }) => {
+        const { observedAt: _observedAt, ...material } = value
+        return material
+      })
+      .sort((left, right) => left.brokerOrderId.localeCompare(right.brokerOrderId)),
+    fills: history.fills
+      .map(({ value }) => value)
+      .sort((left, right) => left.activityId.localeCompare(right.activityId)),
+  })
+
 const run = (
   read: BrokerReadShape,
   store: PaperStoreShape,
   fence: WriterFenceService,
 ): Effect.Effect<ReconciliationReport, BrokerReadError | PaperStoreError | ReconciliationError | WriterFenceError> =>
   Effect.gen(function* () {
-    const until = new Date(yield* Clock.currentTimeMillis).toISOString()
-    const [orders, fills, accountResult, positionsResult] = yield* Effect.all(
-      [readOrders(read, until), readFills(read, until), read.account, read.positions],
-      { concurrency: 4 },
-    )
+    const beforeUntil = new Date(yield* Clock.currentTimeMillis).toISOString()
+    const before = yield* readHistory(read, beforeUntil)
+    const [accountResult, positionsResult] = yield* Effect.all([read.account, read.positions], { concurrency: 2 })
+    const afterUntil = new Date(yield* Clock.currentTimeMillis).toISOString()
+    const history = yield* readHistory(read, afterUntil)
+    if (historyHash(before) !== historyHash(history)) {
+      return yield* Effect.fail(failure('snapshot', 'broker history changed during reconciliation'))
+    }
+    const { orders, fills } = history
 
     return yield* fence.transaction(
       Effect.gen(function* () {

--- a/services/bayn/src/reconciler.ts
+++ b/services/bayn/src/reconciler.ts
@@ -1,0 +1,292 @@
+import { Cause, Clock, Data, Duration, Effect, Schedule } from 'effect'
+
+import {
+  BrokerRead,
+  OrderCollection,
+  SortDirection,
+  type BrokerReadError,
+  type BrokerReadShape,
+  type FillActivity,
+  type Order as BrokerOrder,
+  type ReadEvidence,
+} from './broker/alpaca'
+import {
+  accountObservation,
+  fillObservation,
+  orderObservation,
+  positionSnapshot,
+  type BrokerEventInput,
+  type FillEventInput,
+} from './broker/observations'
+import { PaperStore, type PaperStoreError, type PaperStoreShape } from './db/paper-store'
+import type { BrokerSnapshot, ReconciliationReport } from './db/reconciliation'
+import { WriterFence, type WriterFenceError, type WriterFenceService } from './execution/writer-fence'
+
+const maximumRows = 10_000
+const ordersPageSize = 500
+const fillsPageSize = 100
+
+interface Observed<A> {
+  readonly value: A
+  readonly evidence: ReadEvidence
+}
+
+interface OrderRead {
+  readonly rows: readonly Observed<BrokerOrder>[]
+  readonly observedAt: string
+}
+
+export class ReconciliationError extends Data.TaggedError('ReconciliationError')<{
+  readonly operation: 'pagination' | 'normalization'
+  readonly message: string
+  readonly cause?: unknown
+}> {}
+
+const failure = (operation: ReconciliationError['operation'], message: string, cause?: unknown): ReconciliationError =>
+  new ReconciliationError({ operation, message, cause })
+
+const attempt = <A>(operation: ReconciliationError['operation'], message: string, evaluate: () => A) =>
+  Effect.try({ try: evaluate, catch: (cause) => failure(operation, message, cause) })
+
+const timestampOrderKey = (value: string): string => {
+  const separator = value.indexOf('.')
+  if (separator === -1) return `${value.slice(0, -1)}.000000000Z`
+  return `${value.slice(0, separator)}.${value.slice(separator + 1, -1).padEnd(9, '0')}Z`
+}
+
+const readOrders = (
+  read: BrokerReadShape,
+  until: string,
+): Effect.Effect<OrderRead, BrokerReadError | ReconciliationError> =>
+  Effect.gen(function* () {
+    const rows: Observed<BrokerOrder>[] = []
+    const ids = new Set<string>()
+    let cursor: string | undefined
+    let previousSubmittedAt: string | undefined
+    let observedAt: string | undefined
+
+    while (true) {
+      const limit = Math.min(ordersPageSize, maximumRows + 1 - rows.length)
+      const page = yield* read.orders({
+        status: OrderCollection.All,
+        direction: SortDirection.Ascending,
+        limit,
+        until,
+        ...(cursor === undefined ? {} : { after: cursor }),
+      })
+      observedAt =
+        observedAt === undefined || page.evidence.observedAt > observedAt ? page.evidence.observedAt : observedAt
+      if (page.value.length > limit) {
+        return yield* Effect.fail(failure('pagination', 'Alpaca returned more orders than requested'))
+      }
+      if (page.value.length === 0) return { rows, observedAt }
+
+      for (const order of page.value) {
+        if (
+          previousSubmittedAt !== undefined &&
+          timestampOrderKey(order.submittedAt) < timestampOrderKey(previousSubmittedAt)
+        ) {
+          return yield* Effect.fail(failure('pagination', 'Alpaca order history is not ascending'))
+        }
+        if (cursor !== undefined && timestampOrderKey(order.submittedAt) <= timestampOrderKey(cursor)) {
+          return yield* Effect.fail(failure('pagination', 'Alpaca order timestamp cursor did not advance'))
+        }
+        if (ids.has(order.brokerOrderId)) {
+          return yield* Effect.fail(failure('pagination', `duplicate Alpaca order ${order.brokerOrderId}`))
+        }
+        ids.add(order.brokerOrderId)
+        rows.push({ value: order, evidence: page.evidence })
+        previousSubmittedAt = order.submittedAt
+        if (rows.length > maximumRows) {
+          return yield* Effect.fail(failure('pagination', `Alpaca order history exceeds ${maximumRows} rows`))
+        }
+      }
+
+      if (page.value.length < limit) return { rows, observedAt }
+      const next = page.value[page.value.length - 1]?.submittedAt
+      if (next === undefined || next === cursor) {
+        return yield* Effect.fail(failure('pagination', 'Alpaca order cursor did not advance'))
+      }
+      cursor = next
+    }
+  })
+
+const readFills = (
+  read: BrokerReadShape,
+  until: string,
+): Effect.Effect<readonly Observed<FillActivity>[], BrokerReadError | ReconciliationError> =>
+  Effect.gen(function* () {
+    const rows: Observed<FillActivity>[] = []
+    const ids = new Set<string>()
+    let cursor: string | undefined
+
+    while (true) {
+      const pageSize = Math.min(fillsPageSize, maximumRows + 1 - rows.length)
+      const page = yield* read.fillActivities({
+        direction: SortDirection.Ascending,
+        pageSize,
+        until,
+        ...(cursor === undefined ? {} : { pageToken: cursor }),
+      })
+      if (page.value.items.length > pageSize) {
+        return yield* Effect.fail(failure('pagination', 'Alpaca returned more fills than requested'))
+      }
+
+      for (const fill of page.value.items) {
+        if (ids.has(fill.activityId)) {
+          return yield* Effect.fail(failure('pagination', `duplicate Alpaca fill ${fill.activityId}`))
+        }
+        ids.add(fill.activityId)
+        rows.push({ value: fill, evidence: page.evidence })
+        if (rows.length > maximumRows) {
+          return yield* Effect.fail(failure('pagination', `Alpaca fill history exceeds ${maximumRows} rows`))
+        }
+      }
+
+      const next = page.value.nextPageToken
+      if (next === undefined) return rows
+      const last = page.value.items[page.value.items.length - 1]?.activityId
+      if (page.value.items.length === 0 || next === cursor || next !== last) {
+        return yield* Effect.fail(failure('pagination', 'Alpaca fill cursor did not advance'))
+      }
+      cursor = next
+    }
+  })
+
+const run = (
+  read: BrokerReadShape,
+  store: PaperStoreShape,
+  fence: WriterFenceService,
+): Effect.Effect<ReconciliationReport, BrokerReadError | PaperStoreError | ReconciliationError | WriterFenceError> =>
+  Effect.gen(function* () {
+    const until = new Date(yield* Clock.currentTimeMillis).toISOString()
+    const [orders, fills, accountResult, positionsResult] = yield* Effect.all(
+      [readOrders(read, until), readFills(read, until), read.account, read.positions],
+      { concurrency: 4 },
+    )
+
+    return yield* fence.transaction(
+      Effect.gen(function* () {
+        const bindings = yield* store.bindings(accountResult.value.id)
+
+        const normalized = yield* attempt('normalization', 'broker snapshot normalization failed', () => {
+          const intentByClient = new Map<string, string>()
+          for (const binding of bindings) {
+            if (intentByClient.has(binding.clientOrderId)) {
+              throw new Error(`duplicate intent client order ID ${binding.clientOrderId}`)
+            }
+            intentByClient.set(binding.clientOrderId, binding.intentId)
+          }
+
+          const orderById = new Map<string, BrokerOrder>()
+          const clientOrderIds = new Set<string>()
+          const orderEvents: Extract<BrokerEventInput, { readonly _tag: 'Order' }>[] = []
+          for (const observed of orders.rows) {
+            if (orderById.has(observed.value.brokerOrderId)) {
+              throw new Error(`duplicate broker order ID ${observed.value.brokerOrderId}`)
+            }
+            if (clientOrderIds.has(observed.value.clientOrderId)) {
+              throw new Error(`duplicate broker client order ID ${observed.value.clientOrderId}`)
+            }
+            orderById.set(observed.value.brokerOrderId, observed.value)
+            clientOrderIds.add(observed.value.clientOrderId)
+            const event = orderObservation(
+              observed.value,
+              observed.evidence,
+              intentByClient.get(observed.value.clientOrderId),
+            )
+            if (event._tag !== 'Order') throw new Error('normalized order event is not an order')
+            orderEvents.push(event)
+          }
+
+          const fillEvents = [...fills]
+            .sort((left, right) => {
+              const byTime = left.value.transactionTime.localeCompare(right.value.transactionTime)
+              return byTime === 0 ? left.value.activityId.localeCompare(right.value.activityId) : byTime
+            })
+            .map((observed): FillEventInput => {
+              const order = orderById.get(observed.value.brokerOrderId)
+              if (order === undefined) {
+                throw new Error(`Alpaca fill ${observed.value.activityId} references a missing order`)
+              }
+              return fillObservation(observed.value, order, observed.evidence, {
+                intentId: intentByClient.get(order.clientOrderId),
+              })
+            })
+
+          const accountEvent = accountObservation(accountResult)
+          if (accountEvent._tag !== 'Account') throw new Error('normalized account event is not an account')
+          return {
+            account: accountEvent,
+            positions: positionSnapshot(accountResult.value.id, positionsResult),
+            orderEvents,
+            fillEvents,
+          }
+        })
+
+        const accountReceipt = yield* store.ingest(normalized.account)
+        const positionsReceipt = yield* store.ingestPositions(normalized.positions)
+        yield* Effect.forEach(normalized.orderEvents, store.ingest, { discard: true })
+        yield* Effect.forEach(normalized.fillEvents, store.account, { discard: true })
+        const valuation = yield* store.value({
+          accountEventId: accountReceipt.eventId,
+          positionSnapshotId: positionsReceipt.snapshotId,
+        })
+        const reconciledAt = new Date(yield* Clock.currentTimeMillis).toISOString()
+        const report = yield* store.reconcile({
+          account: normalized.account.account,
+          positions: normalized.positions.positions.map((event) => event.position),
+          positionsObservedAt: normalized.positions.observedAt,
+          orders: normalized.orderEvents.map((event) => event.order),
+          ordersObservedAt: orders.observedAt,
+          fills: normalized.fillEvents.map((event) => event.fill),
+          valuation,
+          reconciledAt,
+        } satisfies BrokerSnapshot)
+
+        yield* Effect.logInfo('Paper account reconciliation completed').pipe(
+          Effect.annotateLogs({
+            accountId: report.reconciliation.accountId,
+            status: report.reconciliation.status,
+            reconciliationId: report.reconciliation.reconciliationId,
+            orderCount: normalized.orderEvents.length,
+            fillCount: normalized.fillEvents.length,
+            discrepancyCount: report.metrics.discrepancyCount,
+            brokerPollAgeMs: report.metrics.brokerPollAgeMs,
+            oldestUnknownMutationAgeMs: report.metrics.oldestUnknownMutationAgeMs,
+            accountingExact: report.metrics.accountingExact,
+          }),
+        )
+        return report
+      }),
+    )
+  }).pipe(Effect.withLogSpan('reconciliation'))
+
+export const runOnce: Effect.Effect<
+  ReconciliationReport,
+  BrokerReadError | PaperStoreError | ReconciliationError | WriterFenceError,
+  BrokerRead | PaperStore | WriterFence
+> = Effect.gen(function* () {
+  const read = yield* BrokerRead
+  const store = yield* PaperStore
+  const fence = yield* WriterFence
+  const restrict = Effect.gen(function* () {
+    const failedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
+    yield* fence.transaction(store.restrictAuthority('reconciliation pass incomplete', failedAt))
+  })
+  return yield* run(read, store, fence).pipe(
+    Effect.tapCause((cause) => (Cause.hasInterruptsOnly(cause) ? Effect.void : restrict)),
+  )
+})
+
+export const runContinuously = (interval: Duration.Input) =>
+  runOnce.pipe(
+    Effect.tapError((error) =>
+      Effect.logError('Paper account reconciliation failed; authority is restricted to OBSERVE').pipe(
+        Effect.annotateLogs({ errorTag: error._tag, operation: error.operation }),
+      ),
+    ),
+    Effect.catch(() => Effect.void),
+    Effect.repeat(Schedule.spaced(interval)),
+    Effect.asVoid,
+  )

--- a/services/bayn/src/reconciliation.test.ts
+++ b/services/bayn/src/reconciliation.test.ts
@@ -1,0 +1,290 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  AccountStatus,
+  DiscrepancyKind,
+  IntentState,
+  OrderSide,
+  OrderStatus,
+  OrderType,
+  TerminalOutcome,
+  TimeInForce,
+  type AccountSnapshot,
+  type Fill,
+  type Order,
+  type Position,
+  type Valuation,
+} from './paper'
+import { compareReconciliation, type ReconciliationSnapshot } from './reconciliation'
+
+const hash = (value: string): string => value.repeat(64).slice(0, 64)
+const observedAt = '2026-07-22T15:30:00.000Z'
+const reconciledAt = '2026-07-22T15:30:01.000Z'
+
+const account: AccountSnapshot = {
+  schemaVersion: 'bayn.paper-account-snapshot.v1',
+  accountId: 'paper-account',
+  status: AccountStatus.Active,
+  currency: 'USD',
+  cashMicros: '900000000',
+  equityMicros: '1000000000',
+  buyingPowerMicros: '900000000',
+  observedAt,
+}
+
+const position: Position = {
+  schemaVersion: 'bayn.paper-position.v1',
+  accountId: account.accountId,
+  symbol: 'NVDA',
+  quantityMicros: '1000000',
+  averageEntryPriceMicros: '90000000',
+  marketPriceMicros: '100000000',
+  marketValueMicros: '100000000',
+  unrealizedPnlMicros: '10000000',
+  observedAt,
+}
+
+const order: Order = {
+  schemaVersion: 'bayn.paper-order.v1',
+  accountId: account.accountId,
+  brokerOrderId: 'broker-order-1',
+  clientOrderId: 'bayn-order-1',
+  intentId: hash('1'),
+  symbol: position.symbol,
+  side: OrderSide.Buy,
+  orderType: OrderType.Market,
+  timeInForce: TimeInForce.Day,
+  quantityMicros: position.quantityMicros,
+  filledQuantityMicros: position.quantityMicros,
+  status: OrderStatus.Filled,
+  observedAt,
+}
+
+const fill: Fill = {
+  schemaVersion: 'bayn.paper-fill.v1',
+  accountId: account.accountId,
+  fillId: 'fill-1',
+  brokerOrderId: order.brokerOrderId,
+  clientOrderId: order.clientOrderId,
+  intentId: order.intentId,
+  symbol: order.symbol,
+  side: order.side,
+  quantityMicros: order.quantityMicros,
+  priceMicros: '90000000',
+  feeMicros: '0',
+  occurredAt: observedAt,
+}
+
+const valuation: Valuation = {
+  schemaVersion: 'bayn.paper-valuation.v1',
+  valuationId: hash('2'),
+  accountId: account.accountId,
+  sourceHash: hash('3'),
+  cashMicros: account.cashMicros,
+  longMarketValueMicros: position.marketValueMicros,
+  shortMarketValueMicros: '0',
+  equityMicros: account.equityMicros,
+  asOf: observedAt,
+}
+
+const snapshot = (overrides: Partial<ReconciliationSnapshot> = {}): ReconciliationSnapshot => ({
+  accountId: account.accountId,
+  stateHash: hash('4'),
+  account,
+  positions: [position],
+  orders: [order],
+  fills: [fill],
+  intents: [
+    {
+      intentId: order.intentId ?? hash('1'),
+      clientOrderId: order.clientOrderId,
+      symbol: order.symbol,
+      side: order.side,
+      orderType: order.orderType,
+      timeInForce: order.timeInForce,
+      quantityMicros: order.quantityMicros,
+      state: IntentState.Terminal,
+      terminalOutcome: TerminalOutcome.Filled,
+      expectsBrokerOrder: true,
+      brokerOrderId: order.brokerOrderId,
+    },
+  ],
+  durableFills: [{ fillId: fill.fillId, brokerOrderId: fill.brokerOrderId, accounted: true }],
+  projectedPositions: [
+    { symbol: position.symbol, quantityMicros: position.quantityMicros, costBasisMicros: '90000000' },
+  ],
+  expectedCashMicros: account.cashMicros,
+  valuation,
+  accountingHash: hash('5'),
+  ledgerExact: true,
+  reconciledAt,
+  ...overrides,
+})
+
+describe('paper reconciliation', () => {
+  test('returns one exact hash for a completely reconciled state', () => {
+    const result = compareReconciliation(snapshot())
+
+    expect(result.expectedHash).toBe(hash('4'))
+    expect(result.observedHash).toBe(result.expectedHash)
+    expect(result.discrepancies).toEqual([])
+    expect(result.metrics).toEqual({
+      brokerPollAgeMs: 1_000,
+      oldestUnknownMutationAgeMs: 0,
+      cashDifferenceMicros: '0',
+      positionDifferenceMicros: '0',
+      equityDifferenceMicros: '0',
+      accountingExact: true,
+      discrepancyCount: 0,
+    })
+  })
+
+  test('treats a restricted broker account as a blocking discrepancy', () => {
+    const result = compareReconciliation(snapshot({ account: { ...account, status: AccountStatus.Restricted } }))
+
+    expect(result.discrepancies).toHaveLength(1)
+    expect(result.discrepancies[0]).toMatchObject({
+      kind: DiscrepancyKind.Account,
+      expected: AccountStatus.Active,
+      observed: AccountStatus.Restricted,
+    })
+  })
+
+  test('reports every material mismatch with stable identities', () => {
+    const externalOrder = { ...order, brokerOrderId: 'external-order', clientOrderId: 'external-client' }
+    const input = snapshot({
+      account: { ...account, cashMicros: '899000000', equityMicros: '998000000' },
+      positions: [{ ...position, quantityMicros: '2000000' }],
+      orders: [order, externalOrder],
+      fills: [{ ...fill, fillId: 'missing-fill' }],
+      intents: [
+        {
+          intentId: order.intentId ?? hash('1'),
+          clientOrderId: order.clientOrderId,
+          symbol: order.symbol,
+          side: order.side,
+          orderType: order.orderType,
+          timeInForce: order.timeInForce,
+          quantityMicros: order.quantityMicros,
+          state: IntentState.Terminal,
+          terminalOutcome: TerminalOutcome.Filled,
+          expectsBrokerOrder: true,
+          brokerOrderId: order.brokerOrderId,
+          unknownSince: observedAt,
+        },
+      ],
+      durableFills: [{ fillId: fill.fillId, brokerOrderId: fill.brokerOrderId, accounted: false }],
+      ledgerExact: false,
+    })
+
+    const first = compareReconciliation(input)
+    const second = compareReconciliation(input)
+    const kinds = new Set(first.discrepancies.map((value) => value.kind))
+
+    expect(first).toEqual(second)
+    expect(first.observedHash).not.toBe(first.expectedHash)
+    expect(kinds).toEqual(
+      new Set([
+        DiscrepancyKind.Order,
+        DiscrepancyKind.Mutation,
+        DiscrepancyKind.Fill,
+        DiscrepancyKind.Accounting,
+        DiscrepancyKind.Position,
+        DiscrepancyKind.Cash,
+        DiscrepancyKind.Valuation,
+      ]),
+    )
+    expect(first.metrics).toMatchObject({
+      cashDifferenceMicros: '-1000000',
+      positionDifferenceMicros: '1000000',
+      equityDifferenceMicros: '-2000000',
+      accountingExact: false,
+    })
+    expect(new Set(first.discrepancies.map((value) => value.discrepancyId)).size).toBe(first.discrepancies.length)
+  })
+
+  test('detects a missing expected broker order', () => {
+    const result = compareReconciliation(snapshot({ orders: [] }))
+
+    expect(result.discrepancies).toHaveLength(1)
+    expect(result.discrepancies[0]).toMatchObject({
+      kind: DiscrepancyKind.Order,
+      identity: `${order.clientOrderId}:presence`,
+      observed: '<absent>',
+    })
+  })
+
+  test('detects a broker order before the intent expects one', () => {
+    const input = snapshot()
+    const result = compareReconciliation({
+      ...input,
+      intents: input.intents.map(({ brokerOrderId: _brokerOrderId, terminalOutcome: _terminalOutcome, ...intent }) => ({
+        ...intent,
+        state: IntentState.IoStarted,
+        expectsBrokerOrder: false,
+      })),
+    })
+
+    expect(result.discrepancies).toHaveLength(1)
+    expect(result.discrepancies[0]).toMatchObject({
+      kind: DiscrepancyKind.Order,
+      identity: `${order.clientOrderId}:presence`,
+      expected: '<absent>',
+      observed: order.brokerOrderId,
+    })
+  })
+
+  test('detects broker position cost drift independently of quantity', () => {
+    const result = compareReconciliation(
+      snapshot({ positions: [{ ...position, averageEntryPriceMicros: '91000000' }] }),
+    )
+
+    expect(result.discrepancies).toHaveLength(1)
+    expect(result.discrepancies[0]).toMatchObject({
+      kind: DiscrepancyKind.Position,
+      identity: `${position.symbol}:cost`,
+      expected: '90000000',
+      observed: '91000000',
+    })
+  })
+
+  test('keeps a ledger discrepancy identity stable while its evidence changes', () => {
+    const first = compareReconciliation(snapshot({ ledgerExact: false, accountingHash: hash('a') }))
+    const second = compareReconciliation(snapshot({ ledgerExact: false, accountingHash: hash('b') }))
+
+    expect(first.discrepancies).toHaveLength(1)
+    expect(second.discrepancies).toHaveLength(1)
+    expect(first.discrepancies[0].discrepancyId).toBe(second.discrepancies[0].discrepancyId)
+    expect(first.discrepancies[0].evidenceHash).not.toBe(second.discrepancies[0].evidenceHash)
+  })
+
+  test('compares the complete order contract, lifecycle, and aggregate fill quantity', () => {
+    const result = compareReconciliation(
+      snapshot({
+        orders: [
+          {
+            ...order,
+            orderType: OrderType.Limit,
+            limitPriceMicros: '90000000',
+            status: OrderStatus.PartiallyFilled,
+            filledQuantityMicros: '500000',
+          },
+        ],
+      }),
+    )
+
+    expect(new Set(result.discrepancies.map((value) => value.identity))).toEqual(
+      new Set([
+        `${order.clientOrderId}:content`,
+        `${order.clientOrderId}:lifecycle`,
+        `${order.brokerOrderId}:quantity`,
+      ]),
+    )
+  })
+
+  test('rejects duplicate broker identities before comparing', () => {
+    expect(() => compareReconciliation(snapshot({ orders: [order, { ...order }] }))).toThrow(
+      'duplicate broker client order ID',
+    )
+  })
+})

--- a/services/bayn/src/reconciliation.ts
+++ b/services/bayn/src/reconciliation.ts
@@ -1,0 +1,471 @@
+import { canonicalHashV1 } from './hash'
+import {
+  AccountStatus,
+  DiscrepancyKind,
+  IntentState,
+  OrderStatus,
+  TerminalOutcome,
+  type AccountSnapshot,
+  type Fill,
+  type Order,
+  type Position,
+  type Valuation,
+} from './paper'
+
+export interface IntentExpectation {
+  readonly intentId: string
+  readonly clientOrderId: string
+  readonly symbol: string
+  readonly side: Order['side']
+  readonly orderType: Order['orderType']
+  readonly timeInForce: Order['timeInForce']
+  readonly quantityMicros: string
+  readonly state: IntentState
+  readonly terminalOutcome?: TerminalOutcome
+  readonly expectsBrokerOrder: boolean
+  readonly brokerOrderId?: string
+  readonly unknownSince?: string
+}
+
+export interface DurableFill {
+  readonly fillId: string
+  readonly brokerOrderId: string
+  readonly accounted: boolean
+}
+
+export interface ProjectedPosition {
+  readonly symbol: string
+  readonly quantityMicros: string
+  readonly costBasisMicros: string
+}
+
+export interface ReconciliationSnapshot {
+  readonly accountId: string
+  readonly stateHash: string
+  readonly account: AccountSnapshot
+  readonly positions: readonly Position[]
+  readonly orders: readonly Order[]
+  readonly fills: readonly Fill[]
+  readonly intents: readonly IntentExpectation[]
+  readonly durableFills: readonly DurableFill[]
+  readonly projectedPositions: readonly ProjectedPosition[]
+  readonly expectedCashMicros: string
+  readonly valuation: Valuation
+  readonly accountingHash: string
+  readonly ledgerExact: boolean
+  readonly reconciledAt: string
+}
+
+export interface ReconciledStateMaterial {
+  readonly account: AccountSnapshot
+  readonly positions: readonly Position[]
+  readonly positionsObservedAt: string
+  readonly orders: readonly Order[]
+  readonly ordersObservedAt: string
+  readonly accountingHash: string
+}
+
+export interface DiscrepancyInput {
+  readonly discrepancyId: string
+  readonly kind: DiscrepancyKind
+  readonly identity: string
+  readonly expected: string
+  readonly observed: string
+  readonly evidenceHash: string
+}
+
+export interface ReconciliationMetrics {
+  readonly brokerPollAgeMs: number
+  readonly oldestUnknownMutationAgeMs: number
+  readonly cashDifferenceMicros: string
+  readonly positionDifferenceMicros: string
+  readonly equityDifferenceMicros: string
+  readonly accountingExact: boolean
+  readonly discrepancyCount: number
+}
+
+export interface ReconciliationComparison {
+  readonly expectedHash: string
+  readonly observedHash: string
+  readonly discrepancies: readonly DiscrepancyInput[]
+  readonly metrics: ReconciliationMetrics
+}
+
+const absent = '<absent>'
+const expectedResolution = '<resolved>'
+const openOrder = '<open>'
+
+const absolute = (value: bigint): bigint => (value < 0n ? -value : value)
+const roundMicrosProduct = (left: bigint, right: bigint): bigint => (left * right + 500_000n) / 1_000_000n
+
+export const reconciledStateHash = (state: ReconciledStateMaterial): string => {
+  const brokerStateHash = canonicalHashV1({
+    schemaVersion: 'bayn.paper-risk-broker-state.v1',
+    account: state.account,
+    positions: state.positions,
+    positionsObservedAt: state.positionsObservedAt,
+    orders: state.orders,
+    ordersObservedAt: state.ordersObservedAt,
+  })
+  return canonicalHashV1({
+    schemaVersion: 'bayn.paper-risk-reconciled-state.v1',
+    brokerStateHash,
+    accountingHash: state.accountingHash,
+  })
+}
+
+const instant = (value: string): number => {
+  const milliseconds = Date.parse(value)
+  if (!Number.isFinite(milliseconds)) throw new Error(`invalid reconciliation instant ${value}`)
+  return milliseconds
+}
+
+const indexUnique = <A>(values: readonly A[], identity: (value: A) => string, label: string): Map<string, A> => {
+  const indexed = new Map<string, A>()
+  for (const value of values) {
+    const key = identity(value)
+    if (indexed.has(key)) throw new Error(`duplicate ${label} ${key}`)
+    indexed.set(key, value)
+  }
+  return indexed
+}
+
+const discrepancy = (
+  accountId: string,
+  kind: DiscrepancyKind,
+  identity: string,
+  expected: string,
+  observed: string,
+): DiscrepancyInput => {
+  if (expected === observed) throw new Error(`discrepancy ${kind}:${identity} does not differ`)
+  const discrepancyId = canonicalHashV1({
+    schemaVersion: 'bayn.paper-discrepancy-id.v1',
+    accountId,
+    kind,
+    identity,
+  })
+  return {
+    discrepancyId,
+    kind,
+    identity,
+    expected,
+    observed,
+    evidenceHash: canonicalHashV1({
+      schemaVersion: 'bayn.paper-discrepancy-evidence.v1',
+      discrepancyId,
+      expected,
+      observed,
+    }),
+  }
+}
+
+const terminalOutcome = (status: OrderStatus): TerminalOutcome | undefined => {
+  switch (status) {
+    case OrderStatus.Filled:
+      return TerminalOutcome.Filled
+    case OrderStatus.Canceled:
+      return TerminalOutcome.Canceled
+    case OrderStatus.Expired:
+      return TerminalOutcome.Expired
+    case OrderStatus.Rejected:
+      return TerminalOutcome.Rejected
+    default:
+      return undefined
+  }
+}
+
+const compareOrders = (snapshot: ReconciliationSnapshot, discrepancies: DiscrepancyInput[]): void => {
+  const intents = indexUnique(snapshot.intents, (intent) => intent.clientOrderId, 'intent client order ID')
+  const ordersByClient = indexUnique(snapshot.orders, (order) => order.clientOrderId, 'broker client order ID')
+  indexUnique(snapshot.orders, (order) => order.brokerOrderId, 'broker order ID')
+
+  for (const intent of snapshot.intents) {
+    if ((intent.state === IntentState.Terminal) !== (intent.terminalOutcome !== undefined)) {
+      throw new Error(`intent ${intent.intentId} terminal state and outcome disagree`)
+    }
+    if (intent.expectsBrokerOrder !== (intent.brokerOrderId !== undefined)) {
+      throw new Error(`intent ${intent.intentId} broker order expectation and identity disagree`)
+    }
+  }
+
+  for (const order of snapshot.orders) {
+    const intent = intents.get(order.clientOrderId)
+    if (intent === undefined) {
+      discrepancies.push(
+        discrepancy(
+          snapshot.accountId,
+          DiscrepancyKind.Order,
+          `${order.clientOrderId}:presence`,
+          absent,
+          order.brokerOrderId,
+        ),
+      )
+      continue
+    }
+    if (!intent.expectsBrokerOrder) {
+      discrepancies.push(
+        discrepancy(
+          snapshot.accountId,
+          DiscrepancyKind.Order,
+          `${intent.clientOrderId}:presence`,
+          absent,
+          order.brokerOrderId,
+        ),
+      )
+      continue
+    }
+    const expectedBrokerOrderId = intent.brokerOrderId
+    if (expectedBrokerOrderId === undefined) throw new Error(`intent ${intent.intentId} has no broker order identity`)
+    const expectedOrder = [
+      expectedBrokerOrderId,
+      intent.symbol,
+      intent.side,
+      intent.orderType,
+      intent.timeInForce,
+      intent.quantityMicros,
+    ].join(':')
+    const observedOrder = [
+      order.brokerOrderId,
+      order.symbol,
+      order.side,
+      order.orderType,
+      order.timeInForce,
+      order.quantityMicros,
+    ].join(':')
+    if (expectedOrder !== observedOrder) {
+      discrepancies.push(
+        discrepancy(
+          snapshot.accountId,
+          DiscrepancyKind.Order,
+          `${intent.clientOrderId}:content`,
+          expectedOrder,
+          observedOrder,
+        ),
+      )
+    }
+    const expectedOutcome = intent.terminalOutcome ?? openOrder
+    const observedOutcome = terminalOutcome(order.status) ?? openOrder
+    if (expectedOutcome !== observedOutcome) {
+      discrepancies.push(
+        discrepancy(
+          snapshot.accountId,
+          DiscrepancyKind.Order,
+          `${intent.clientOrderId}:lifecycle`,
+          expectedOutcome,
+          observedOutcome,
+        ),
+      )
+    }
+  }
+
+  for (const intent of snapshot.intents) {
+    if (intent.expectsBrokerOrder && !ordersByClient.has(intent.clientOrderId)) {
+      const expectedBrokerOrderId = intent.brokerOrderId
+      if (expectedBrokerOrderId === undefined) throw new Error(`intent ${intent.intentId} has no broker order identity`)
+      discrepancies.push(
+        discrepancy(
+          snapshot.accountId,
+          DiscrepancyKind.Order,
+          `${intent.clientOrderId}:presence`,
+          expectedBrokerOrderId,
+          absent,
+        ),
+      )
+    }
+    if (intent.unknownSince !== undefined) {
+      discrepancies.push(
+        discrepancy(
+          snapshot.accountId,
+          DiscrepancyKind.Mutation,
+          intent.intentId,
+          expectedResolution,
+          `UNKNOWN:${intent.unknownSince}`,
+        ),
+      )
+    }
+  }
+}
+
+const compareFills = (snapshot: ReconciliationSnapshot, discrepancies: DiscrepancyInput[]): void => {
+  const observed = indexUnique(snapshot.fills, (fill) => fill.fillId, 'broker fill ID')
+  const durable = indexUnique(snapshot.durableFills, (fill) => fill.fillId, 'durable fill ID')
+  const filledByOrder = new Map<string, bigint>()
+  for (const fill of snapshot.fills) {
+    filledByOrder.set(fill.brokerOrderId, (filledByOrder.get(fill.brokerOrderId) ?? 0n) + BigInt(fill.quantityMicros))
+    const stored = durable.get(fill.fillId)
+    if (stored === undefined) {
+      discrepancies.push(discrepancy(snapshot.accountId, DiscrepancyKind.Fill, fill.fillId, 'durable', absent))
+      continue
+    }
+    if (stored.brokerOrderId !== fill.brokerOrderId) {
+      discrepancies.push(
+        discrepancy(snapshot.accountId, DiscrepancyKind.Fill, fill.fillId, stored.brokerOrderId, fill.brokerOrderId),
+      )
+    }
+    if (!stored.accounted) {
+      discrepancies.push(discrepancy(snapshot.accountId, DiscrepancyKind.Accounting, fill.fillId, 'POSTED', 'MISSING'))
+    }
+  }
+  for (const fill of snapshot.durableFills) {
+    if (!observed.has(fill.fillId)) {
+      discrepancies.push(discrepancy(snapshot.accountId, DiscrepancyKind.Fill, fill.fillId, 'broker', absent))
+    }
+  }
+  for (const order of snapshot.orders) {
+    const expected = order.filledQuantityMicros
+    const actual = (filledByOrder.get(order.brokerOrderId) ?? 0n).toString()
+    if (expected !== actual) {
+      discrepancies.push(
+        discrepancy(snapshot.accountId, DiscrepancyKind.Fill, `${order.brokerOrderId}:quantity`, expected, actual),
+      )
+    }
+  }
+}
+
+const comparePositions = (snapshot: ReconciliationSnapshot, discrepancies: DiscrepancyInput[]): bigint => {
+  const observed = indexUnique(snapshot.positions, (position) => position.symbol, 'broker position symbol')
+  const projected = indexUnique(snapshot.projectedPositions, (position) => position.symbol, 'projected position symbol')
+  let difference = 0n
+  for (const symbol of [...new Set([...observed.keys(), ...projected.keys()])].sort()) {
+    const expectedPosition = projected.get(symbol)
+    const observedPosition = observed.get(symbol)
+    const expectedQuantity = expectedPosition?.quantityMicros ?? '0'
+    const observedQuantity = observedPosition?.quantityMicros ?? '0'
+    difference += absolute(BigInt(expectedQuantity) - BigInt(observedQuantity))
+    if (expectedQuantity !== observedQuantity) {
+      discrepancies.push(
+        discrepancy(
+          snapshot.accountId,
+          DiscrepancyKind.Position,
+          `${symbol}:quantity`,
+          expectedQuantity,
+          observedQuantity,
+        ),
+      )
+    }
+    const expectedCost = expectedPosition?.costBasisMicros ?? '0'
+    const observedCost =
+      observedPosition === undefined
+        ? '0'
+        : roundMicrosProduct(
+            absolute(BigInt(observedPosition.quantityMicros)),
+            BigInt(observedPosition.averageEntryPriceMicros),
+          ).toString()
+    if (expectedCost !== observedCost) {
+      discrepancies.push(
+        discrepancy(snapshot.accountId, DiscrepancyKind.Position, `${symbol}:cost`, expectedCost, observedCost),
+      )
+    }
+  }
+  return difference
+}
+
+export const compareReconciliation = (snapshot: ReconciliationSnapshot): ReconciliationComparison => {
+  if (snapshot.account.accountId !== snapshot.accountId || snapshot.valuation.accountId !== snapshot.accountId) {
+    throw new Error('reconciliation snapshot contains another account')
+  }
+  if (snapshot.positions.some((position) => position.accountId !== snapshot.accountId)) {
+    throw new Error('reconciliation positions contain another account')
+  }
+  if (snapshot.orders.some((order) => order.accountId !== snapshot.accountId)) {
+    throw new Error('reconciliation orders contain another account')
+  }
+  if (snapshot.fills.some((fill) => fill.accountId !== snapshot.accountId)) {
+    throw new Error('reconciliation fills contain another account')
+  }
+
+  const discrepancies: DiscrepancyInput[] = []
+  if (snapshot.account.status !== AccountStatus.Active) {
+    discrepancies.push(
+      discrepancy(
+        snapshot.accountId,
+        DiscrepancyKind.Account,
+        snapshot.accountId,
+        AccountStatus.Active,
+        snapshot.account.status,
+      ),
+    )
+  }
+  compareOrders(snapshot, discrepancies)
+  compareFills(snapshot, discrepancies)
+  const positionDifference = comparePositions(snapshot, discrepancies)
+
+  const cashDifference = BigInt(snapshot.account.cashMicros) - BigInt(snapshot.expectedCashMicros)
+  if (cashDifference !== 0n) {
+    discrepancies.push(
+      discrepancy(
+        snapshot.accountId,
+        DiscrepancyKind.Cash,
+        snapshot.accountId,
+        snapshot.expectedCashMicros,
+        snapshot.account.cashMicros,
+      ),
+    )
+  }
+
+  const equityDifference = BigInt(snapshot.account.equityMicros) - BigInt(snapshot.valuation.equityMicros)
+  if (equityDifference !== 0n) {
+    discrepancies.push(
+      discrepancy(
+        snapshot.accountId,
+        DiscrepancyKind.Valuation,
+        snapshot.accountId,
+        snapshot.valuation.equityMicros,
+        snapshot.account.equityMicros,
+      ),
+    )
+  }
+  if (!snapshot.ledgerExact) {
+    discrepancies.push(
+      discrepancy(
+        snapshot.accountId,
+        DiscrepancyKind.Accounting,
+        `${snapshot.accountId}:ledger`,
+        'EXACT',
+        `MISMATCH:${snapshot.accountingHash}`,
+      ),
+    )
+  }
+
+  const ordered = [...discrepancies].sort((left, right) =>
+    left.discrepancyId < right.discrepancyId ? -1 : left.discrepancyId > right.discrepancyId ? 1 : 0,
+  )
+  if (new Set(ordered.map((value) => value.discrepancyId)).size !== ordered.length) {
+    throw new Error('reconciliation produced duplicate discrepancy identities')
+  }
+  const observedHash =
+    ordered.length === 0
+      ? snapshot.stateHash
+      : canonicalHashV1({
+          schemaVersion: 'bayn.paper-reconciliation-observed.v1',
+          stateHash: snapshot.stateHash,
+          discrepancies: ordered.map((value) => value.evidenceHash),
+        })
+
+  const reconciledAt = instant(snapshot.reconciledAt)
+  const brokerTimes = [
+    snapshot.account.observedAt,
+    snapshot.valuation.asOf,
+    ...snapshot.positions.map((position) => position.observedAt),
+    ...snapshot.orders.map((order) => order.observedAt),
+  ].map(instant)
+  const oldestBrokerTime = brokerTimes.length === 0 ? reconciledAt : Math.min(...brokerTimes)
+  const unknownTimes = snapshot.intents.flatMap((intent) =>
+    intent.unknownSince === undefined ? [] : [instant(intent.unknownSince)],
+  )
+
+  return {
+    expectedHash: snapshot.stateHash,
+    observedHash,
+    discrepancies: ordered,
+    metrics: {
+      brokerPollAgeMs: Math.max(0, reconciledAt - oldestBrokerTime),
+      oldestUnknownMutationAgeMs: unknownTimes.length === 0 ? 0 : Math.max(0, reconciledAt - Math.min(...unknownTimes)),
+      cashDifferenceMicros: cashDifference.toString(),
+      positionDifferenceMicros: positionDifference.toString(),
+      equityDifferenceMicros: equityDifference.toString(),
+      accountingExact: snapshot.ledgerExact,
+      discrepancyCount: ordered.length,
+    },
+  }
+}

--- a/services/bayn/src/resources.test.ts
+++ b/services/bayn/src/resources.test.ts
@@ -57,6 +57,7 @@ const config: RuntimeConfig = {
 
 const successfulJournal: JournalService = {
   post: () => Effect.void,
+  verifyAccount: () => Effect.succeed(true),
   check: Effect.void,
   checkRun: () => Effect.void,
   journalAndReconcile: (evaluation) =>

--- a/services/bayn/src/risk.test.ts
+++ b/services/bayn/src/risk.test.ts
@@ -19,6 +19,7 @@ import {
   TimeInForce,
   type Intent,
 } from './paper'
+import { reconciledStateHash } from './reconciliation'
 import { BrokerMode, PolicySchema, Reason, StateSchema, evaluate, type Policy, type State } from './risk'
 import { strictParseOptions } from './schemas'
 
@@ -91,21 +92,13 @@ const baseState = (): State => {
   ]
   const orders: readonly ReturnType<typeof openOrder>[] = []
   const accountingHash = hash('a')
-  const brokerStateHash = canonicalHashV1({
-    schemaVersion: 'bayn.paper-risk-broker-state.v1',
+  const reconciledStateHashValue = reconciledStateHash({
     account,
     positions,
     positionsObservedAt: observedAt,
     orders,
     ordersObservedAt: observedAt,
-  })
-  const reconciledStateHash = canonicalHashV1({
-    schemaVersion: 'bayn.paper-risk-reconciled-state.v1',
-    brokerStateHash,
     accountingHash,
-    dailyTradedNotionalMicros: '100000000',
-    dayStartEquityMicros: '1000000000',
-    peakEquityMicros: '1050000000',
   })
   return decodeState({
     schemaVersion: 'bayn.paper-risk-state.v1',
@@ -119,8 +112,8 @@ const baseState = (): State => {
       schemaVersion: 'bayn.paper-reconciliation.v1',
       reconciliationId: hash('1'),
       accountId: 'paper-account-1',
-      expectedHash: reconciledStateHash,
-      observedHash: reconciledStateHash,
+      expectedHash: reconciledStateHashValue,
+      observedHash: reconciledStateHashValue,
       contentHash: hash('3'),
       status: ReconciliationStatus.Exact,
       discrepancies: [],
@@ -155,28 +148,20 @@ const baseState = (): State => {
 const makeState = (overrides: Partial<State> = {}): State => {
   const merged = { ...baseState(), ...overrides }
   if (overrides.reconciliation !== undefined) return decodeState(merged)
-  const brokerStateHash = canonicalHashV1({
-    schemaVersion: 'bayn.paper-risk-broker-state.v1',
+  const reconciledStateHashValue = reconciledStateHash({
     account: merged.account,
     positions: merged.positions,
     positionsObservedAt: merged.positionsObservedAt,
     orders: merged.orders,
     ordersObservedAt: merged.ordersObservedAt,
-  })
-  const reconciledStateHash = canonicalHashV1({
-    schemaVersion: 'bayn.paper-risk-reconciled-state.v1',
-    brokerStateHash,
     accountingHash: merged.accountingHash,
-    dailyTradedNotionalMicros: merged.dailyTradedNotionalMicros,
-    dayStartEquityMicros: merged.dayStartEquityMicros,
-    peakEquityMicros: merged.peakEquityMicros,
   })
   return decodeState({
     ...merged,
     reconciliation: {
       ...merged.reconciliation,
-      expectedHash: reconciledStateHash,
-      observedHash: reconciledStateHash,
+      expectedHash: reconciledStateHashValue,
+      observedHash: reconciledStateHashValue,
     },
   })
 }
@@ -258,6 +243,14 @@ describe('bounded paper risk', () => {
       }),
     ).toThrow()
     expect(() => decodeState({ ...state, marketDataObservedAt: '2026-07-22T14:00:00.001Z' })).toThrow()
+
+    const earlierOrderObservation = '2026-07-22T13:59:29.000Z'
+    const paginated = makeState({
+      orders: [{ ...openOrder('broker-1'), observedAt: earlierOrderObservation }, openOrder('broker-2')],
+      ordersObservedAt: observedAt,
+    })
+    expect(paginated.orders.map((order) => order.observedAt)).toEqual([earlierOrderObservation, observedAt])
+    expect(() => decodeState({ ...paginated, ordersObservedAt: earlierOrderObservation })).toThrow()
     expect(() => decodeState({ ...state, submissionCutoffAt: state.sessionOpenAt })).toThrow()
   })
 
@@ -512,7 +505,16 @@ describe('bounded paper risk', () => {
           observedHash: hash('8'),
           status: ReconciliationStatus.Discrepancy,
           discrepancies: [
-            { kind: DiscrepancyKind.Account, identity: 'paper-account-1', expected: 'expected', observed: 'observed' },
+            {
+              discrepancyId: hash('9'),
+              kind: DiscrepancyKind.Account,
+              identity: 'paper-account-1',
+              expected: 'expected',
+              observed: 'observed',
+              evidenceHash: hash('b'),
+              firstObservedAt: observedAt,
+              lastObservedAt: observedAt,
+            },
           ],
         },
       }),

--- a/services/bayn/src/risk.ts
+++ b/services/bayn/src/risk.ts
@@ -26,6 +26,7 @@ import {
   type RiskDecision,
   type RiskInput,
 } from './paper'
+import { reconciledStateHash } from './reconciliation'
 import {
   Sha256Schema as Sha256,
   StrictNonEmptyStringSchema as NonEmptyString,
@@ -244,12 +245,19 @@ export const StateSchema = StateBase.check(
     if (new Set(clientOrderIds).size !== clientOrderIds.length) {
       issues.push({ path: ['orders'], issue: 'must have unique clientOrderId values' })
     }
+    const latestOrderObservation = state.orders.reduce(
+      (latest, order) => (order.observedAt > latest ? order.observedAt : latest),
+      '',
+    )
+    if (state.orders.length > 0 && latestOrderObservation !== state.ordersObservedAt) {
+      issues.push({ path: ['ordersObservedAt'], issue: 'must equal the latest paginated order observation' })
+    }
     for (const [index, order] of state.orders.entries()) {
       if (order.accountId !== accountId) {
         issues.push({ path: ['orders', index, 'accountId'], issue: 'must match the account snapshot' })
       }
-      if (order.observedAt !== state.ordersObservedAt) {
-        issues.push({ path: ['orders', index, 'observedAt'], issue: 'must match ordersObservedAt' })
+      if (order.observedAt > state.ordersObservedAt) {
+        issues.push({ path: ['orders', index, 'observedAt'], issue: 'must not follow ordersObservedAt' })
       }
     }
     if (BigInt(state.peakEquityMicros) < BigInt(state.account.equityMicros)) {
@@ -347,26 +355,19 @@ export const evaluate = (intent: Intent, state: State, policy: Policy): Evaluati
       : positiveDifference(referencePrice, expectedPrice)
   const adverseSlippageBps = divideUp(adversePriceDifference * BASIS_POINTS, referencePrice)
   const unresolvedOrderCount = state.orders.filter((order) => isUnresolved(order.status)).length
-  const brokerStateHash = canonicalHashV1({
-    schemaVersion: 'bayn.paper-risk-broker-state.v1',
+  const reconciledHash = reconciledStateHash({
     account: state.account,
     positions: state.positions,
     positionsObservedAt: state.positionsObservedAt,
     orders: state.orders,
     ordersObservedAt: state.ordersObservedAt,
-  })
-  const reconciledStateHash = canonicalHashV1({
-    schemaVersion: 'bayn.paper-risk-reconciled-state.v1',
-    brokerStateHash,
     accountingHash: state.accountingHash,
-    dailyTradedNotionalMicros: state.dailyTradedNotionalMicros,
-    dayStartEquityMicros: state.dayStartEquityMicros,
-    peakEquityMicros: state.peakEquityMicros,
   })
   const oldestBrokerState = Math.min(
     instant(state.account.observedAt),
     instant(state.positionsObservedAt),
     instant(state.ordersObservedAt),
+    ...state.orders.map((order) => instant(order.observedAt)),
     instant(state.reconciliation.reconciledAt),
     instant(state.authorityObservedAt),
   )
@@ -452,10 +453,10 @@ export const evaluate = (intent: Intent, state: State, policy: Policy): Evaluati
       Gate.Reconciliation,
       Reason.ReconciliationNotExact,
       state.reconciliation.status === ReconciliationStatus.Exact &&
-        state.reconciliation.expectedHash === reconciledStateHash &&
-        state.reconciliation.observedHash === reconciledStateHash,
+        state.reconciliation.expectedHash === reconciledHash &&
+        state.reconciliation.observedHash === reconciledHash,
       `${state.reconciliation.status}:${state.reconciliation.expectedHash}:${state.reconciliation.observedHash}`,
-      `${ReconciliationStatus.Exact}:${reconciledStateHash}:${reconciledStateHash}`,
+      `${ReconciliationStatus.Exact}:${reconciledHash}:${reconciledHash}`,
     ),
     makeGate(
       Gate.BrokerStateFreshness,

--- a/services/bayn/src/startup.test.ts
+++ b/services/bayn/src/startup.test.ts
@@ -55,6 +55,7 @@ describe('Bayn startup lifecycle', () => {
         }),
         Effect.provideService(Journal, {
           post: () => forbidden('pinned startup must not write TigerBeetle'),
+          verifyAccount: () => forbidden('pinned startup must not reconcile paper accounting'),
           check: forbidden('pinned startup must not check TigerBeetle'),
           checkRun: () => forbidden('pinned startup must not check a TigerBeetle run'),
           journalAndReconcile: () => forbidden('pinned startup must not write TigerBeetle'),
@@ -150,6 +151,7 @@ describe('Bayn startup lifecycle', () => {
     }
     const journal: JournalService = {
       post: () => Effect.void,
+      verifyAccount: () => Effect.succeed(true),
       check: Effect.void,
       checkRun: () => Effect.void,
       journalAndReconcile: () => {
@@ -221,6 +223,7 @@ describe('Bayn startup lifecycle', () => {
     }
     const journal: JournalService = {
       post: () => Effect.void,
+      verifyAccount: () => Effect.succeed(true),
       check: Effect.void,
       checkRun: () => Effect.void,
       journalAndReconcile: () => {
@@ -286,6 +289,7 @@ describe('Bayn startup lifecycle', () => {
     }
     const journal: JournalService = {
       post: () => Effect.void,
+      verifyAccount: () => Effect.succeed(true),
       check: Effect.void,
       checkRun: () => Effect.void,
       journalAndReconcile: () => {


### PR DESCRIPTION
## Summary

- Add one scoped, observe-only reconciliation loop that remains dormant until the complete Alpaca credential tuple is configured.
- Compare bounded broker orders, fills, positions, cash, and equity against immutable PostgreSQL intents/accounting plus TigerBeetle records and balances.
- Persist typed reconciliation evidence in the existing `reconciliations` table and restrict authority to `OBSERVE` on incomplete or failed passes.
- Canonicalize broker timestamps at the durable boundary and reject any order/fill history mutation that races a reconciliation poll.
- Keep deployment topology unchanged: no scheduler, new service hierarchy, table, or migration.

## Related Issues

Closes PROOMPT-377

## Testing

- `bun run --filter @proompteng/bayn test` — 207 passed, 42 skipped, 0 failed.
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:15432/bayn_test bun test services/bayn/src/db/paper-store.integration.test.ts` — 5 passed, 0 failed against the dedicated CNPG test database and TigerBeetle.
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn build`
- `git diff --check origin/main...HEAD`

## Breaking Changes

None. Reconciliation is dormant until PROOMPT-371 supplies the dedicated paper-account credentials; the runtime cannot submit, cancel, or replace broker orders and cannot raise authority.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.