### PR TITLE
fix(dorvud): tolerate quiet equity bar symbols

### DIFF
--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
@@ -1526,8 +1526,8 @@ class ForwarderApp(
 
     val topic = feed.config.topicFor(env.channel, config.alpacaMarketType) ?: return null
 
-    feed.channelFreshness.recordSerializedEvent(env.channel, env.symbol)
-    sendKafka(producer, topic, env, env.channel, feed)
+    val serializedSequence = feed.channelFreshness.recordSerializedEvent(env.channel, env.symbol)
+    sendKafka(producer, topic, env, env.channel, feed, serializedSequence)
     return env.channel
   }
 
@@ -1537,6 +1537,7 @@ class ForwarderApp(
     env: Envelope<JsonElement>,
     marketDataChannel: String? = null,
     feed: MarketDataFeedRuntimeState? = null,
+    serializedSequence: Long? = null,
   ) {
     val payload = json.encodeToString(env)
     val record = ProducerRecord(topic, env.symbol, payload)
@@ -1550,7 +1551,11 @@ class ForwarderApp(
           recordKafkaFailure(exception, topic, feed)
         } else {
           metrics.recordKafkaProduceSuccess(topic)
-          feed?.channelFreshness?.recordKafkaSuccess(marketDataFreshnessChannelFor(env, marketDataChannel), env.symbol)
+          feed?.channelFreshness?.recordKafkaSuccess(
+            marketDataFreshnessChannelFor(env, marketDataChannel),
+            env.symbol,
+            serializedSequence,
+          )
           recordKafkaSuccess(feed)
         }
       }

--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/MarketDataChannelFreshness.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/MarketDataChannelFreshness.kt
@@ -134,9 +134,13 @@ internal class MarketDataChannelFreshnessTracker(
       val channelSymbols = symbolsByChannel[channel].orEmpty()
       val readinessMode = readinessModeFor(channel, marketType)
       val freshnessRequired = readinessMode == MarketDataChannelReadinessMode.CONTINUOUS
+      // Alpaca omits a stock minute bar when that symbol has no qualifying trades in the interval.
+      // Keep the channel freshness gate, but do not turn an expected per-symbol bar gap into a restart loop.
+      val equityBarMayBeAbsent = marketType == AlpacaMarketType.EQUITY && channel == "bars"
       val symbolCoverageRequired =
         readinessMode == MarketDataChannelReadinessMode.CONTINUOUS &&
-          marketType != AlpacaMarketType.OPTIONS
+          marketType != AlpacaMarketType.OPTIONS &&
+          !equityBarMayBeAbsent
       val state = latestByChannel[channel]
       val latestKafkaSuccessAt = state?.latestKafkaSuccessAtMs?.get()?.takeIf { it > 0 }
       val latestProviderAt = state?.latestProviderEventAtMs?.get()?.takeIf { it > 0 }
@@ -152,7 +156,10 @@ internal class MarketDataChannelFreshnessTracker(
           .filter { symbol -> symbol in channelSymbols }
           .sorted()
       val lagMs = latestKafkaSuccessAt?.let { (now - it).coerceAtLeast(0) }
-      val symbolCoverageDiagnostic = symbolCoverageRequired || marketType == AlpacaMarketType.OPTIONS
+      val symbolCoverageDiagnostic =
+        symbolCoverageRequired ||
+          marketType == AlpacaMarketType.OPTIONS ||
+          equityBarMayBeAbsent
       val symbolLagMs =
         channelSymbols
           .mapNotNull { symbol ->

--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/MarketDataChannelFreshness.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/MarketDataChannelFreshness.kt
@@ -92,6 +92,7 @@ internal class MarketDataChannelFreshnessTracker(
   fun clearSubscription() {
     subscribedSymbolsByChannel.set(emptyMap())
     latestSubscriptionAckAtMsByChannel.clear()
+    latestByChannel.values.forEach(ChannelFreshnessState::clearPendingDeliveries)
     subscribedSinceMs.set(0)
   }
 
@@ -105,16 +106,15 @@ internal class MarketDataChannelFreshnessTracker(
   fun recordSerializedEvent(
     channel: String,
     symbol: String?,
-  ) {
-    state(channel)?.recordSerializedEvent(nowMs(), symbol)
-  }
+  ): Long? = state(channel)?.recordSerializedEvent(nowMs(), symbol)
 
   fun recordKafkaSuccess(
     channel: String?,
     symbol: String?,
+    serializedSequence: Long? = null,
   ) {
     if (channel == null) return
-    state(channel)?.recordKafkaSuccess(nowMs(), symbol)
+    state(channel)?.recordKafkaSuccess(nowMs(), symbol, serializedSequence)
   }
 
   fun ready(): Boolean = snapshot().all { it.ready }
@@ -216,12 +216,20 @@ internal class MarketDataChannelFreshnessTracker(
           latestObservedInputForReadiness != null &&
           !kafkaSuccessCoversLatestObservedInput &&
           now - latestObservedInputForReadiness > maxLagMs
+      val pendingKafkaSince =
+        state?.pendingKafkaSinceMsBySymbol?.mapValues { (_, sinceAt) -> sinceAt.get() }.orEmpty()
+      val equityBarKafkaSuccessMissing =
+        equityBarMayBeAbsent &&
+          pendingKafkaSince.any { (symbol, sinceAt) ->
+            symbol in channelSymbols && sinceAt > 0 && now - sinceAt > maxLagMs
+          }
       val ready =
         when {
           !gateActive -> true
           channelSymbols.isEmpty() -> false
           !freshnessRequired -> !conditionalKafkaSuccessMissing
           latestKafkaSuccessAt == null -> false
+          equityBarKafkaSuccessMissing -> false
           gatedMissingSymbols.isNotEmpty() -> false
           gatedStaleSymbols.isNotEmpty() -> false
           lagMs == null -> false
@@ -262,6 +270,7 @@ internal class MarketDataChannelFreshnessTracker(
             ready -> "market_data_channel_fresh"
             channelSymbols.isEmpty() -> "market_data_channel_not_subscribed"
             conditionalKafkaSuccessMissing -> "market_data_channel_conditional_missing_kafka_success"
+            equityBarKafkaSuccessMissing -> "market_data_channel_observed_symbol_missing_kafka_success"
             freshnessRequired && latestKafkaSuccessAt == null -> "market_data_channel_missing_kafka_success"
             gatedMissingSymbols.isNotEmpty() -> "market_data_channel_missing_symbol_coverage"
             gatedStaleSymbols.isNotEmpty() -> "market_data_channel_stale_symbol_coverage"
@@ -278,12 +287,16 @@ internal class MarketDataChannelFreshnessTracker(
   }
 
   private class ChannelFreshnessState {
+    private val serializedSequence = AtomicLong(0)
     val latestProviderEventAtMs = AtomicLong(0)
     val latestSerializedAtMs = AtomicLong(0)
     val latestKafkaSuccessAtMs = AtomicLong(0)
     val latestSymbol = AtomicReference<String?>(null)
     val latestObservedInputAtMsBySymbol = ConcurrentHashMap<String, AtomicLong>()
     val latestKafkaSuccessAtMsBySymbol = ConcurrentHashMap<String, AtomicLong>()
+    val pendingKafkaSinceMsBySymbol = ConcurrentHashMap<String, AtomicLong>()
+    private val latestSerializedSequenceBySymbol = ConcurrentHashMap<String, AtomicLong>()
+    private val latestKafkaSuccessSequenceBySymbol = ConcurrentHashMap<String, AtomicLong>()
 
     fun recordProviderEvent(
       atMs: Long,
@@ -297,15 +310,23 @@ internal class MarketDataChannelFreshnessTracker(
     fun recordSerializedEvent(
       atMs: Long,
       symbol: String?,
-    ) {
+    ): Long? {
       latestSerializedAtMs.set(atMs)
       recordObservedInputSymbol(atMs, symbol)
       updateSymbol(symbol)
+      val normalized = normalizeSymbol(symbol) ?: return null
+      val sequence = serializedSequence.incrementAndGet()
+      latestSerializedSequenceBySymbol
+        .computeIfAbsent(normalized) { AtomicLong(0) }
+        .set(sequence)
+      pendingKafkaSinceMsBySymbol.computeIfAbsent(normalized) { AtomicLong(atMs) }
+      return sequence
     }
 
     fun recordKafkaSuccess(
       atMs: Long,
       symbol: String?,
+      serializedSequence: Long?,
     ) {
       latestKafkaSuccessAtMs.set(atMs)
       updateSymbol(symbol)
@@ -313,6 +334,21 @@ internal class MarketDataChannelFreshnessTracker(
       latestKafkaSuccessAtMsBySymbol
         .computeIfAbsent(normalized) { AtomicLong(0) }
         .set(atMs)
+      val acknowledgedSequence =
+        serializedSequence ?: latestSerializedSequenceBySymbol[normalized]?.get()
+      if (acknowledgedSequence != null) {
+        val latestAcknowledged =
+          latestKafkaSuccessSequenceBySymbol.computeIfAbsent(normalized) { AtomicLong(0) }
+        latestAcknowledged.accumulateAndGet(acknowledgedSequence, ::maxOf)
+        val latestSerialized = latestSerializedSequenceBySymbol[normalized]?.get()
+        if (latestSerialized != null && latestAcknowledged.get() >= latestSerialized) {
+          pendingKafkaSinceMsBySymbol.remove(normalized)
+        }
+      }
+    }
+
+    fun clearPendingDeliveries() {
+      pendingKafkaSinceMsBySymbol.clear()
     }
 
     private fun updateSymbol(symbol: String?) {

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/MarketDataChannelFreshnessTrackerTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/MarketDataChannelFreshnessTrackerTest.kt
@@ -353,6 +353,42 @@ class MarketDataChannelFreshnessTrackerTest {
   }
 
   @Test
+  fun `observed equity bars still require per-symbol kafka delivery`() {
+    var nowMs = Instant.parse("2026-07-07T14:00:00Z").toEpochMilli()
+    val tracker =
+      MarketDataChannelFreshnessTracker(
+        requiredChannels = listOf("bars"),
+        maxLagMs = 60_000,
+        warmupMs = 0,
+        nowMs = { nowMs },
+        marketType = AlpacaMarketType.EQUITY,
+      )
+
+    tracker.recordSubscriptionByChannel(mapOf("bars" to listOf("NVDA", "CRDO")))
+    tracker.recordProviderEvent("bars", "CRDO")
+    val firstCrdoSequence = requireNotNull(tracker.recordSerializedEvent("bars", "CRDO"))
+
+    nowMs += 30_000
+    tracker.recordProviderEvent("bars", "CRDO")
+    tracker.recordSerializedEvent("bars", "CRDO")
+    tracker.recordKafkaSuccess("bars", "CRDO", firstCrdoSequence)
+
+    nowMs += 31_000
+    tracker.recordProviderEvent("bars", "NVDA")
+    tracker.recordSerializedEvent("bars", "NVDA")
+    tracker.recordKafkaSuccess("bars", "NVDA")
+
+    val readiness = tracker.snapshot().single()
+
+    assertFalse(tracker.ready())
+    assertFalse(readiness.ready)
+    assertFalse(readiness.symbolCoverageRequired)
+    assertEquals("market_data_channel_observed_symbol_missing_kafka_success", readiness.reason)
+    assertEquals(emptyList(), readiness.missingSymbols)
+    assertEquals(listOf("CRDO", "NVDA"), readiness.freshSymbols)
+  }
+
+  @Test
   fun `post-session readiness exposes inactive gate and stale channel diagnostics`() {
     val nowMs = Instant.parse("2026-07-07T22:00:00Z").toEpochMilli()
     val tracker =

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/MarketDataChannelFreshnessTrackerTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/MarketDataChannelFreshnessTrackerTest.kt
@@ -193,7 +193,8 @@ class MarketDataChannelFreshnessTrackerTest {
     val byChannel = tracker.snapshot().associateBy { it.channel }
 
     assertFalse(tracker.ready())
-    assertFalse(byChannel.getValue("bars").ready)
+    assertTrue(byChannel.getValue("bars").ready)
+    assertFalse(byChannel.getValue("bars").symbolCoverageRequired)
     assertEquals(2, byChannel.getValue("bars").subscribedSymbolCount)
     assertEquals(listOf("AMD", "NVDA"), byChannel.getValue("bars").subscribedSymbols)
     assertEquals(nowMs, byChannel.getValue("bars").latestSubscriptionAckAtMs)
@@ -263,7 +264,8 @@ class MarketDataChannelFreshnessTrackerTest {
     val byChannel = tracker.snapshot().associateBy { it.channel }
 
     assertFalse(tracker.ready())
-    assertFalse(byChannel.getValue("bars").ready)
+    assertTrue(byChannel.getValue("bars").ready)
+    assertFalse(byChannel.getValue("bars").symbolCoverageRequired)
     assertEquals(2, byChannel.getValue("bars").subscribedSymbolCount)
     assertEquals(listOf("AMD", "NVDA"), byChannel.getValue("bars").subscribedSymbols)
     assertEquals(nowMs, byChannel.getValue("bars").latestSubscriptionAckAtMs)
@@ -314,6 +316,40 @@ class MarketDataChannelFreshnessTrackerTest {
     assertEquals("market_data_channel_stale_symbol_coverage", staleCoverage.reason)
     assertEquals(listOf("NVDA"), staleCoverage.staleSymbols)
     assertEquals(listOf("AMD"), staleCoverage.freshSymbols)
+  }
+
+  @Test
+  fun `quiet equity bar symbols remain diagnostic without restarting a fresh channel`() {
+    var nowMs = Instant.parse("2026-07-07T14:00:00Z").toEpochMilli()
+    val tracker =
+      MarketDataChannelFreshnessTracker(
+        requiredChannels = listOf("bars"),
+        maxLagMs = 60_000,
+        warmupMs = 0,
+        nowMs = { nowMs },
+        marketType = AlpacaMarketType.EQUITY,
+      )
+
+    tracker.recordSubscriptionByChannel(mapOf("bars" to listOf("NVDA", "CRDO")))
+    listOf("NVDA", "CRDO").forEach { symbol ->
+      tracker.recordProviderEvent("bars", symbol)
+      tracker.recordSerializedEvent("bars", symbol)
+      tracker.recordKafkaSuccess("bars", symbol)
+    }
+
+    nowMs += 61_000
+    tracker.recordProviderEvent("bars", "NVDA")
+    tracker.recordSerializedEvent("bars", "NVDA")
+    tracker.recordKafkaSuccess("bars", "NVDA")
+
+    val readiness = tracker.snapshot().single()
+
+    assertTrue(tracker.ready())
+    assertTrue(readiness.ready)
+    assertFalse(readiness.symbolCoverageRequired)
+    assertEquals("market_data_channel_fresh", readiness.reason)
+    assertEquals(listOf("CRDO"), readiness.staleSymbols)
+    assertEquals(listOf("NVDA"), readiness.freshSymbols)
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Keep Alpaca stock bar readiness gated on fresh channel-to-Kafka delivery and complete subscription acknowledgements.
- Preserve per-symbol bar lag diagnostics without restarting the producer when Alpaca legitimately emits no bar for a quiet symbol.
- Add regression coverage for the production failure where CRDO had no qualifying IEX bar for 239 seconds while all nine symbols were subscribed and the bar channel remained fresh.

Alpaca documents that a stock minute bar is not generated when an interval has no qualifying trades: https://docs.alpaca.markets/us/docs/market-data-faq

## Related Issues

Supports PROOMPT-393.

## Testing

- `cd services/dorvud && ./gradlew :websockets:test --tests ai.proompteng.dorvud.ws.MarketDataChannelFreshnessTrackerTest :websockets:ktlintCheck`
- `cd services/dorvud && ./gradlew :websockets:test :websockets:ktlintCheck :websockets:build`
- `git diff --check`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed; this change has no UI.
- [x] Documentation and follow-up live proof remain tracked by PROOMPT-393.
