### PR TITLE
fix(bayn): close paper execution safety gaps

### DIFF
--- a/services/bayn/migrations/0008_identified_submit_unknown.ts
+++ b/services/bayn/migrations/0008_identified_submit_unknown.ts
@@ -1,0 +1,49 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient
+
+  yield* sql`
+    ALTER TABLE mutation_events
+    DROP CONSTRAINT mutation_events_check1
+  `
+
+  yield* sql`
+    ALTER TABLE mutation_events
+    ADD CONSTRAINT mutation_events_event_contract_check CHECK (
+      (event_type = 'SUBMIT_STARTED' AND operation = 'SUBMIT' AND broker_order_id IS NULL AND response_status IS NULL)
+      OR (
+        event_type = 'SUBMIT_ACCEPTED'
+        AND operation = 'SUBMIT'
+        AND broker_order_id IS NOT NULL
+        AND response_status = 200
+      )
+      OR (
+        event_type = 'SUBMIT_REJECTED'
+        AND operation = 'SUBMIT'
+        AND broker_order_id IS NULL
+        AND response_status IN (400, 401, 403, 404, 422)
+      )
+      OR (event_type = 'SUBMIT_UNKNOWN' AND operation = 'SUBMIT')
+      OR (event_type = 'RECOVERY_FOUND' AND broker_order_id IS NOT NULL AND response_status = 200)
+      OR (
+        event_type = 'RECOVERY_NOT_FOUND'
+        AND response_status = 404
+        AND (
+          operation = 'SUBMIT'
+          OR (operation = 'CANCEL' AND broker_order_id IS NOT NULL)
+        )
+      )
+      OR (event_type = 'RECOVERY_UNKNOWN')
+      OR (event_type = 'CANCEL_STARTED' AND operation = 'CANCEL' AND broker_order_id IS NOT NULL AND response_status IS NULL)
+      OR (
+        event_type = 'CANCEL_ACCEPTED'
+        AND operation = 'CANCEL'
+        AND broker_order_id IS NOT NULL
+        AND response_status = 204
+      )
+      OR (event_type = 'CANCEL_UNKNOWN' AND operation = 'CANCEL' AND broker_order_id IS NOT NULL)
+    )
+  `
+})

--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -25,7 +25,7 @@ export const run = (
       ).pipe(Effect.mapError((cause) => operationalError('http', 'listen', 'HTTP server failed to listen', cause)))
       yield* initialize(config, state, strategy)
       yield* monitor(config, state).pipe(Effect.forkScoped({ startImmediately: true }))
-      yield* reconciliation.pipe(Effect.forkScoped({ startImmediately: true }))
+      yield* reconciliation
       return yield* Effect.never
     }),
   )

--- a/services/bayn/src/broker/alpaca-mutations.test.ts
+++ b/services/bayn/src/broker/alpaca-mutations.test.ts
@@ -193,6 +193,21 @@ describe('Alpaca paper mutations', () => {
     })
   })
 
+  test('preserves the broker order ID when Alpaca accepts a mismatched order', async () => {
+    const mismatched = { ...orderResponse, symbol: 'NVDA' }
+    const client = HttpClient.make((request) => Effect.succeed(response(request, mismatched)))
+
+    const failure = await Effect.runPromise(Effect.flip(withMutation(client, (mutation) => mutation.submit(intent))))
+
+    expect(failure).toMatchObject({
+      operation: MutationOperation.Submit,
+      failure: MutationFailure.Unknown,
+      outcome: MutationOutcome.Unknown,
+      brokerOrderId: orderId,
+      evidence: { status: 200, requestId: 'req-123', contentHash: canonicalHashV1(mismatched) },
+    })
+  })
+
   test('fails before I/O for an unmarked intent or unsupported fractional GTC order', async () => {
     let calls = 0
     const client = HttpClient.make((request) => {

--- a/services/bayn/src/broker/alpaca-mutations.ts
+++ b/services/bayn/src/broker/alpaca-mutations.ts
@@ -87,6 +87,7 @@ export class BrokerMutationError extends Data.TaggedError('BrokerMutationError')
   readonly message: string
   readonly requestHash?: string
   readonly evidence?: Partial<MutationEvidence>
+  readonly brokerOrderId?: string
   readonly brokerCode?: string
   readonly cause?: Readonly<Record<string, string>>
 }> {}
@@ -175,6 +176,17 @@ const knownRejection = (requestHash: string, evidence: MutationEvidence, code: s
     requestHash,
     evidence,
     brokerCode: String(code),
+  })
+
+const mismatchedAcceptedOrder = (requestHash: string, evidence: MutationEvidence, brokerOrderId: string) =>
+  new BrokerMutationError({
+    operation: MutationOperation.Submit,
+    failure: MutationFailure.Unknown,
+    outcome: MutationOutcome.Unknown,
+    message: 'Alpaca accepted an order that does not match the durable intent',
+    requestHash,
+    evidence,
+    brokerOrderId,
   })
 
 const microsToDecimal = (value: string): string => {
@@ -414,14 +426,7 @@ export const makeMutation = (
               order.quantityMicros !== intent.quantityMicros ||
               order.extendedHours
             ) {
-              return yield* Effect.fail(
-                unknownOutcome(
-                  MutationOperation.Submit,
-                  'Alpaca accepted an order that does not match the durable intent',
-                  requestHash,
-                  evidence,
-                ),
-              )
+              return yield* Effect.fail(mismatchedAcceptedOrder(requestHash, evidence, order.brokerOrderId))
             }
             return { requestHash, order, evidence } satisfies SubmitReceipt
           }),

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -7,7 +7,7 @@ import { Cause, Deferred, Duration, Effect, Exit, Fiber, Layer, ManagedRuntime, 
 import type { RuntimeConfig } from '../config'
 import { IntentStore, IntentStoreLive, plan, type IntentPlan } from '../execution/intents'
 import { MutationEventType, MutationStore, MutationStoreLive } from '../execution/mutations'
-import { MutationOperation } from '../broker/alpaca-mutations'
+import { MutationOperation, cancelRequestHash } from '../broker/alpaca-mutations'
 import { WriterFence, WriterFenceLive } from '../execution/writer-fence'
 import { canonicalHashV1 } from '../hash'
 import { buildLedgerPlan } from '../ledger'
@@ -278,6 +278,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       { migration_id: 5, name: 'mutation_recovery' },
       { migration_id: 6, name: 'current_risk_clock' },
       { migration_id: 7, name: 'accounting' },
+      { migration_id: 8, name: 'identified_submit_unknown' },
     ])
   })
 
@@ -715,6 +716,96 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     expect(observed.before).toEqual({ state: 'UNKNOWN', state_version: 4 })
     expect(observed.found.eventType).toBe(MutationEventType.RecoveryFound)
     expect(observed.after).toEqual({ state: 'ACKNOWLEDGED', state_version: 6 })
+  })
+
+  test('cancels an identified mismatched order while its submit remains UNKNOWN', async () => {
+    const execution = makeExecutionRuntime()
+    const intent = await Effect.runPromise(plan(intentPlan({ cycleId: '8'.repeat(64) })))
+    const decision = await Effect.runPromise(riskDecision(intent, RiskOutcome.Approved))
+    await execution.runPromise(
+      Effect.gen(function* () {
+        yield* Effect.flatMap(IntentStore, (store) => store.commit(intent, decision))
+        const sql = yield* PgClient.PgClient
+        yield* sql`
+          INSERT INTO authority_state (
+            schema_version, generation_hash, maximum, effective, kill_state, version, updated_at
+          ) VALUES (
+            'bayn.paper-authority.v1', ${'9'.repeat(64)}, 'PAPER', 'PAPER', 'CLEAR', 1,
+            ${new Date(Date.now() + 1).toISOString()}
+          )
+        `
+      }),
+    )
+    await execution.dispose()
+
+    const mutation = makeMutationRuntime()
+    const submitHash = '6'.repeat(64)
+    const cancelHash = cancelRequestHash(orderId)
+    const base = Date.now() + 100
+    const observed = await mutation.runPromise(
+      Effect.gen(function* () {
+        const store = yield* MutationStore
+        yield* store.beginSubmit(intent.intentId, submitHash, 1_000, new Date(base).toISOString())
+        const unknown = yield* store.submitUnknown(
+          intent.intentId,
+          submitHash,
+          new Date(base + 1).toISOString(),
+          {
+            requestId: 'mismatched-submit',
+            status: 200,
+            contentHash: '5'.repeat(64),
+            observedAt: new Date(base + 1).toISOString(),
+          },
+          orderId,
+        )
+        const notFound = yield* store.recoveryNotFound(intent.intentId, MutationOperation.Submit, submitHash, {
+          requestId: 'submit-lookup-not-found',
+          status: 404,
+          contentHash: '4'.repeat(64),
+          observedAt: new Date(base + 2).toISOString(),
+        })
+        const cancelStarted = yield* store.beginCancel(
+          intent.intentId,
+          cancelHash,
+          orderId,
+          1_000,
+          new Date(base + 3).toISOString(),
+        )
+        yield* store.cancelAccepted(intent.intentId, cancelHash, orderId, {
+          requestId: 'cancel-request',
+          status: 204,
+          contentHash: '3'.repeat(64),
+          observedAt: new Date(base + 4).toISOString(),
+        })
+        const canceled = yield* store.recoveryFound(
+          intent.intentId,
+          MutationOperation.Cancel,
+          cancelHash,
+          orderId,
+          {
+            requestId: 'cancel-lookup',
+            status: 200,
+            contentHash: '2'.repeat(64),
+            observedAt: new Date(base + 5).toISOString(),
+          },
+          TerminalOutcome.Canceled,
+        )
+        return { cancelStarted, canceled, notFound, state: yield* sqlIntentState(intent.intentId), unknown }
+      }),
+    )
+    await mutation.dispose()
+
+    expect(observed.unknown).toMatchObject({
+      eventType: MutationEventType.SubmitUnknown,
+      brokerOrderId: orderId,
+    })
+    expect(observed.notFound).toMatchObject({
+      eventType: MutationEventType.RecoveryNotFound,
+      brokerOrderId: orderId,
+    })
+    expect(observed.cancelStarted.started).toBe(true)
+    expect(observed.canceled.eventType).toBe(MutationEventType.RecoveryFound)
+    expect(observed.state.state).toBe('TERMINAL')
   })
 
   test('allows kill-mode cancellation of an identified order and resolves the cancel race', async () => {

--- a/services/bayn/src/db/migrations.ts
+++ b/services/bayn/src/db/migrations.ts
@@ -7,6 +7,7 @@ import deterministicIntents from '../../migrations/0004_deterministic_intents'
 import mutationRecovery from '../../migrations/0005_mutation_recovery'
 import currentRiskClock from '../../migrations/0006_current_risk_clock'
 import accounting from '../../migrations/0007_accounting'
+import identifiedSubmitUnknown from '../../migrations/0008_identified_submit_unknown'
 
 export const migrationLoader = PgMigrator.fromRecord({
   '1_initial_schema': initialSchema,
@@ -16,4 +17,5 @@ export const migrationLoader = PgMigrator.fromRecord({
   '5_mutation_recovery': mutationRecovery,
   '6_current_risk_clock': currentRiskClock,
   '7_accounting': accounting,
+  '8_identified_submit_unknown': identifiedSubmitUnknown,
 })

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -241,7 +241,9 @@ describePostgres('paper accounting persistence', () => {
       const result = await runtime.runPromise(
         Effect.gen(function* () {
           const store = yield* PaperStore
+          const baselineBefore = yield* store.hasAccountBaseline(accountId)
           const first = yield* store.ingest(accountEvent())
+          const baselineAfter = yield* store.hasAccountBaseline(accountId)
           const replay = yield* store.ingest(accountEvent())
           const order = yield* store.ingest(orderEvent())
           const conflict = yield* Effect.exit(
@@ -254,11 +256,13 @@ describePostgres('paper accounting persistence', () => {
               (SELECT count(*)::integer FROM account_snapshots) AS accounts,
               (SELECT count(*)::integer FROM orders) AS orders
           `
-          return { first, replay, order, conflict, counts }
+          return { baselineAfter, baselineBefore, first, replay, order, conflict, counts }
         }),
       )
 
       expect(result.first).toMatchObject({ sourceSequence: '0', deduplicated: false })
+      expect(result.baselineBefore).toBe(false)
+      expect(result.baselineAfter).toBe(true)
       expect(result.replay).toEqual({ ...result.first, deduplicated: true })
       expect(result.order).toMatchObject({ sourceSequence: '1', deduplicated: false })
       expect(Exit.isFailure(result.conflict)).toBe(true)

--- a/services/bayn/src/db/paper-store.ts
+++ b/services/bayn/src/db/paper-store.ts
@@ -70,6 +70,7 @@ export class PaperStoreError extends Data.TaggedError('PaperStoreError')<{
     | 'account'
     | 'receipt'
     | 'valuation'
+    | 'baseline'
     | 'bindings'
     | 'reconciliation'
     | 'authority'
@@ -83,6 +84,7 @@ export interface PaperStoreShape {
   readonly ingestPositions: (input: PositionSnapshotInput) => Effect.Effect<PositionSnapshotReceipt, PaperStoreError>
   readonly account: (input: FillEventInput) => Effect.Effect<AccountingReceipt, PaperStoreError>
   readonly value: (input: ValuationInput) => Effect.Effect<Valuation, PaperStoreError>
+  readonly hasAccountBaseline: (accountId: string) => Effect.Effect<boolean, PaperStoreError>
   readonly bindings: (accountId: string) => Effect.Effect<readonly IntentBinding[], PaperStoreError>
   readonly reconcile: (snapshot: BrokerSnapshot) => Effect.Effect<ReconciliationReport, PaperStoreError>
   readonly restrictAuthority: (reason: string, updatedAt: string) => Effect.Effect<void, PaperStoreError>
@@ -100,6 +102,7 @@ const EventRow = Schema.Struct({
 const LastSequenceRow = Schema.Tuple([Schema.Struct({ last_sequence: Schema.String })])
 const PositionCostRow = Schema.Tuple([Schema.Struct({ quantity_micros: Schema.String, cost_micros: Schema.String })])
 const UnresolvedPredecessorRow = Schema.Tuple([Schema.Struct({ unresolved: Schema.Boolean })])
+const AccountBaselineRow = Schema.Tuple([Schema.Struct({ exists: Schema.Boolean })])
 const AccountRow = Schema.Tuple([
   Schema.Struct({
     event_id: Sha256,
@@ -148,6 +151,8 @@ const decodeEventRows = Schema.decodeUnknownEffect(Schema.Array(EventRow), stric
 const decodeLastSequence = Schema.decodeUnknownEffect(LastSequenceRow, strictParseOptions)
 const decodePositionCost = Schema.decodeUnknownEffect(PositionCostRow, strictParseOptions)
 const decodeUnresolvedPredecessor = Schema.decodeUnknownEffect(UnresolvedPredecessorRow, strictParseOptions)
+const decodeAccountBaseline = Schema.decodeUnknownEffect(AccountBaselineRow, strictParseOptions)
+const decodeAccountId = Schema.decodeUnknownEffect(NonEmptyString, strictParseOptions)
 const decodeTransactionRows = Schema.decodeUnknownEffect(
   Schema.Array(AccountingTransactionRowSchema),
   strictParseOptions,
@@ -827,6 +832,20 @@ const makeStore = (config: Pick<RuntimeConfig, 'tigerBeetle'>) =>
         ),
       )
 
+    const hasAccountBaseline = (accountId: string) =>
+      run(
+        'baseline',
+        decodeAccountId(accountId).pipe(
+          Effect.flatMap((decodedAccountId) =>
+            sql<Record<string, unknown>>`
+              SELECT EXISTS (
+                SELECT 1 FROM account_snapshots WHERE account_id = ${decodedAccountId}
+              ) AS exists
+            `.pipe(Effect.flatMap(decodeAccountBaseline)),
+          ),
+          Effect.map((rows) => rows[0].exists),
+        ),
+      )
     const bindings = (accountId: string) => run('bindings', reconciliation.bindings(accountId))
     const reconcile = (snapshot: BrokerSnapshot) => run('reconciliation', reconciliation.reconcile(snapshot))
     const lowerAuthority = (reason: string, updatedAt: string) =>
@@ -842,6 +861,7 @@ const makeStore = (config: Pick<RuntimeConfig, 'tigerBeetle'>) =>
       ingestPositions,
       account,
       value,
+      hasAccountBaseline,
       bindings,
       reconcile,
       restrictAuthority: lowerAuthority,

--- a/services/bayn/src/execution/coordinator.test.ts
+++ b/services/bayn/src/execution/coordinator.test.ts
@@ -104,6 +104,8 @@ interface HarnessOptions {
   readonly lostFence?: boolean
   readonly notFoundOnce?: boolean
   readonly unknownSubmit?: boolean
+  readonly submitError?: BrokerMutationError
+  readonly submittedOrder?: Order
 }
 
 const makeHarness = (options: HarnessOptions = {}) => {
@@ -205,14 +207,14 @@ const makeHarness = (options: HarnessOptions = {}) => {
       setState(IntentState.Terminal, response.observedAt, TerminalOutcome.Rejected)
       return Effect.succeed(rejected)
     },
-    submitUnknown: (_intentId, requestHash, occurredAt, response) => {
+    submitUnknown: (_intentId, requestHash, occurredAt, response, brokerOrderId) => {
       const unknown = event(
         MutationOperation.Submit,
         MutationEventType.SubmitUnknown,
         requestHash,
         latest.get(MutationOperation.Submit)?.consistencyDelayMs ?? 1,
         occurredAt,
-        undefined,
+        brokerOrderId,
         completeEvidence(response),
       )
       setState(IntentState.Unknown, occurredAt)
@@ -312,6 +314,7 @@ const makeHarness = (options: HarnessOptions = {}) => {
         return Effect.die(new Error('submit happened before SUBMIT_STARTED was durable'))
       }
       if (options.crashAfterSubmit) return Effect.die(new Error('injected crash after send'))
+      if (options.submitError !== undefined) return Effect.fail(options.submitError)
       const hash = canonicalHashV1(orderRequestBody(submitted))
       if (options.unknownSubmit) {
         return Effect.fail(
@@ -325,7 +328,7 @@ const makeHarness = (options: HarnessOptions = {}) => {
         )
       }
       const response = evidence(200, '1970-01-01T00:00:00.100Z')
-      return Effect.succeed({ requestHash: hash, order: brokerOrder(), evidence: response })
+      return Effect.succeed({ requestHash: hash, order: options.submittedOrder ?? brokerOrder(), evidence: response })
     },
     cancel: (brokerOrderId) => {
       cancelCalls += 1
@@ -410,6 +413,54 @@ describe('paper execution coordinator', () => {
     expect(result.replay.eventId).toBe(result.accepted.eventId)
     expect(harness.calls()).toEqual({ submit: 1, cancel: 0, lookup: 0 })
     expect(harness.state()).toBe(IntentState.Acknowledged)
+  })
+
+  test('keeps a partial broker fill UNKNOWN instead of recording a false terminal fill', async () => {
+    const harness = makeHarness({
+      submittedOrder: { ...brokerOrder(OrderStatus.Filled), filledQuantityMicros: '500000' },
+    })
+
+    const result = await Effect.runPromise(harness.provide(submit(intentId, 1_000)))
+
+    expect(result).toMatchObject({
+      eventType: MutationEventType.SubmitUnknown,
+      brokerOrderId: orderId,
+    })
+    expect(harness.calls()).toEqual({ submit: 1, cancel: 0, lookup: 0 })
+    expect(harness.state()).toBe(IntentState.Unknown)
+  })
+
+  test('can cancel a mismatched accepted order while the intent remains UNKNOWN', async () => {
+    const response = evidence(200, '1970-01-01T00:00:00.100Z')
+    const harness = makeHarness({
+      submitError: new BrokerMutationError({
+        operation: MutationOperation.Submit,
+        failure: MutationFailure.Unknown,
+        outcome: MutationOutcome.Unknown,
+        message: 'accepted order differs from durable intent',
+        requestHash: canonicalHashV1(orderRequestBody(intent)),
+        evidence: response,
+        brokerOrderId: orderId,
+      }),
+    })
+
+    const result = await Effect.runPromise(
+      harness.provide(
+        Effect.gen(function* () {
+          const unknown = yield* submit(intentId, 1_000)
+          const canceled = yield* cancel(intentId, 1_000)
+          return { unknown, canceled }
+        }),
+      ),
+    )
+
+    expect(result.unknown).toMatchObject({
+      eventType: MutationEventType.SubmitUnknown,
+      brokerOrderId: orderId,
+    })
+    expect(result.canceled.eventType).toBe(MutationEventType.CancelAccepted)
+    expect(harness.calls()).toEqual({ submit: 1, cancel: 1, lookup: 0 })
+    expect(harness.state()).toBe(IntentState.Unknown)
   })
 
   test('makes no broker call when the writer fence is lost after recording I/O start', async () => {

--- a/services/bayn/src/execution/coordinator.test.ts
+++ b/services/bayn/src/execution/coordinator.test.ts
@@ -106,6 +106,7 @@ interface HarnessOptions {
   readonly unknownSubmit?: boolean
   readonly submitError?: BrokerMutationError
   readonly submittedOrder?: Order
+  readonly lookupOrder?: Order
 }
 
 const makeHarness = (options: HarnessOptions = {}) => {
@@ -359,9 +360,10 @@ const makeHarness = (options: HarnessOptions = {}) => {
         )
       }
       const value =
-        latest.get(MutationOperation.Cancel) === undefined
+        options.lookupOrder ??
+        (latest.get(MutationOperation.Cancel) === undefined
           ? brokerOrder(OrderStatus.Accepted)
-          : brokerOrder(OrderStatus.Canceled)
+          : brokerOrder(OrderStatus.Canceled))
       return Effect.succeed({ value, evidence: evidence(200, '1970-01-01T00:00:02.000Z') })
     },
     fillActivities: () => Effect.die(new Error('unexpected fill read')),
@@ -395,6 +397,17 @@ const makeHarness = (options: HarnessOptions = {}) => {
     state: () => stored.intent.state,
   }
 }
+
+const mismatchedSubmissionError = () =>
+  new BrokerMutationError({
+    operation: MutationOperation.Submit,
+    failure: MutationFailure.Unknown,
+    outcome: MutationOutcome.Unknown,
+    message: 'accepted order differs from durable intent',
+    requestHash: canonicalHashV1(orderRequestBody(intent)),
+    evidence: evidence(200, '1970-01-01T00:00:00.100Z'),
+    brokerOrderId: orderId,
+  })
 
 describe('paper execution coordinator', () => {
   test('records before submission and never calls the broker again for a replayed intent', async () => {
@@ -430,18 +443,10 @@ describe('paper execution coordinator', () => {
     expect(harness.state()).toBe(IntentState.Unknown)
   })
 
-  test('can cancel a mismatched accepted order while the intent remains UNKNOWN', async () => {
-    const response = evidence(200, '1970-01-01T00:00:00.100Z')
+  test('cancels and closes a zero-fill mismatched accepted order by its broker ID', async () => {
     const harness = makeHarness({
-      submitError: new BrokerMutationError({
-        operation: MutationOperation.Submit,
-        failure: MutationFailure.Unknown,
-        outcome: MutationOutcome.Unknown,
-        message: 'accepted order differs from durable intent',
-        requestHash: canonicalHashV1(orderRequestBody(intent)),
-        evidence: response,
-        brokerOrderId: orderId,
-      }),
+      lookupOrder: { ...brokerOrder(OrderStatus.Canceled), symbol: 'NVDA' },
+      submitError: mismatchedSubmissionError(),
     })
 
     const result = await Effect.runPromise(
@@ -449,7 +454,9 @@ describe('paper execution coordinator', () => {
         Effect.gen(function* () {
           const unknown = yield* submit(intentId, 1_000)
           const canceled = yield* cancel(intentId, 1_000)
-          return { unknown, canceled }
+          yield* TestClock.adjust(3_000)
+          const found = yield* recover(intentId, MutationOperation.Cancel)
+          return { unknown, canceled, found }
         }),
       ),
     )
@@ -459,7 +466,34 @@ describe('paper execution coordinator', () => {
       brokerOrderId: orderId,
     })
     expect(result.canceled.eventType).toBe(MutationEventType.CancelAccepted)
-    expect(harness.calls()).toEqual({ submit: 1, cancel: 1, lookup: 0 })
+    expect(result.found.eventType).toBe(MutationEventType.RecoveryFound)
+    expect(harness.calls()).toEqual({ submit: 1, cancel: 1, lookup: 1 })
+    expect(harness.state()).toBe(IntentState.Terminal)
+  })
+
+  test('keeps a partially filled mismatched order UNKNOWN after cancellation', async () => {
+    const harness = makeHarness({
+      lookupOrder: {
+        ...brokerOrder(OrderStatus.Canceled),
+        symbol: 'NVDA',
+        filledQuantityMicros: '1',
+      },
+      submitError: mismatchedSubmissionError(),
+    })
+
+    const result = await Effect.runPromise(
+      harness.provide(
+        Effect.gen(function* () {
+          yield* submit(intentId, 1_000)
+          yield* cancel(intentId, 1_000)
+          yield* TestClock.adjust(3_000)
+          return yield* recover(intentId, MutationOperation.Cancel)
+        }),
+      ),
+    )
+
+    expect(result.eventType).toBe(MutationEventType.RecoveryUnknown)
+    expect(harness.calls()).toEqual({ submit: 1, cancel: 1, lookup: 1 })
     expect(harness.state()).toBe(IntentState.Unknown)
   })
 

--- a/services/bayn/src/execution/coordinator.ts
+++ b/services/bayn/src/execution/coordinator.ts
@@ -95,6 +95,7 @@ const exactOrder = (intent: Intent, order: Order): boolean => {
     order.orderType === body.type &&
     order.timeInForce === body.time_in_force &&
     order.quantityMicros === intent.quantityMicros &&
+    (order.status !== OrderStatus.Filled || order.filledQuantityMicros === intent.quantityMicros) &&
     order.extendedHours === false
   )
 }
@@ -134,7 +135,8 @@ const validateRecovery = (stored: Intent, event: MutationEvent) =>
     const validState =
       event.operation === MutationOperation.Submit
         ? stored.state === IntentState.IoStarted || stored.state === IntentState.Unknown
-        : stored.state === IntentState.Acknowledged
+        : stored.state === IntentState.Acknowledged ||
+          (stored.state === IntentState.Unknown && event.brokerOrderId !== undefined)
     if (expectedHash === event.requestHash && validState) return
     return yield* Effect.fail(
       new ExecutionError({
@@ -185,12 +187,22 @@ export const submit = (intentId: string, consistencyDelayMs: number) =>
             return mutations.submitRejected(intentId, hash, error.evidence)
           }
           return isCompleteEvidence(error.evidence)
-            ? mutations.submitUnknown(intentId, hash, error.evidence.observedAt, error.evidence)
-            : now.pipe(Effect.flatMap((occurredAt) => mutations.submitUnknown(intentId, hash, occurredAt)))
+            ? mutations.submitUnknown(intentId, hash, error.evidence.observedAt, error.evidence, error.brokerOrderId)
+            : now.pipe(
+                Effect.flatMap((occurredAt) =>
+                  mutations.submitUnknown(intentId, hash, occurredAt, undefined, error.brokerOrderId),
+                ),
+              )
         },
         onSuccess: (receipt) => {
           if (receipt.requestHash !== hash || !exactOrder(after.value.intent, receipt.order)) {
-            return mutations.submitUnknown(intentId, hash, receipt.evidence.observedAt, receipt.evidence)
+            return mutations.submitUnknown(
+              intentId,
+              hash,
+              receipt.evidence.observedAt,
+              receipt.evidence,
+              receipt.order.brokerOrderId,
+            )
           }
           return mutations.submitAccepted(
             intentId,
@@ -204,12 +216,6 @@ export const submit = (intentId: string, consistencyDelayMs: number) =>
     )
   })
 
-const brokerOrderId = (event: MutationEvent | undefined): string | undefined => {
-  if (event?.eventType === MutationEventType.SubmitAccepted) return event.brokerOrderId
-  if (event?.eventType === MutationEventType.RecoveryFound) return event.brokerOrderId
-  return undefined
-}
-
 export const cancel = (intentId: string, consistencyDelayMs: number) =>
   Effect.gen(function* () {
     const mutations = yield* MutationStore
@@ -217,7 +223,7 @@ export const cancel = (intentId: string, consistencyDelayMs: number) =>
     const fence = yield* WriterFence
     const intent = yield* readIntent(MutationOperation.Cancel, intentId)
     const submitEvent = yield* mutations.latest(intentId, MutationOperation.Submit)
-    const orderId = brokerOrderId(submitEvent)
+    const orderId = submitEvent?.brokerOrderId
     if (orderId === undefined) {
       return yield* Effect.fail(
         new ExecutionError({

--- a/services/bayn/src/execution/coordinator.ts
+++ b/services/bayn/src/execution/coordinator.ts
@@ -327,7 +327,14 @@ export const recover = (intentId: string, operation: MutationOperation) =>
         },
         onSuccess: (result) => {
           const evidence = mutationEvidence(result.evidence)
-          if (!exactOrder(stored.intent, result.value)) {
+          const outcome = terminalOutcome(result.value.status)
+          const neutralizedMismatchedOrder =
+            operation === MutationOperation.Cancel &&
+            interrupted.brokerOrderId === result.value.brokerOrderId &&
+            result.value.filledQuantityMicros === '0' &&
+            outcome !== undefined &&
+            outcome !== TerminalOutcome.Filled
+          if (!exactOrder(stored.intent, result.value) && !neutralizedMismatchedOrder) {
             return mutations.recoveryUnknown(
               intentId,
               operation,
@@ -342,7 +349,7 @@ export const recover = (intentId: string, operation: MutationOperation) =>
             interrupted.requestHash,
             result.value.brokerOrderId,
             evidence,
-            terminalOutcome(result.value.status),
+            outcome,
           )
         },
       }),

--- a/services/bayn/src/execution/mutations.ts
+++ b/services/bayn/src/execution/mutations.ts
@@ -169,6 +169,7 @@ export interface MutationStoreShape {
     requestHash: string,
     occurredAt: string,
     evidence?: Partial<MutationEvidence>,
+    brokerOrderId?: string,
   ) => Effect.Effect<MutationEvent, MutationStoreError | WriterFenceError>
   readonly beginCancel: (
     intentId: string,
@@ -218,6 +219,15 @@ export interface MutationStoreShape {
 }
 
 export class MutationStore extends Context.Service<MutationStore, MutationStoreShape>()('bayn/MutationStore') {}
+
+const isIdentifiedUnresolvedSubmit = (event: MutationEvent | undefined, brokerOrderId: string): boolean => {
+  if (event?.operation !== MutationOperation.Submit || event.brokerOrderId !== brokerOrderId) return false
+  return (
+    event.eventType === MutationEventType.SubmitUnknown ||
+    event.eventType === MutationEventType.RecoveryNotFound ||
+    event.eventType === MutationEventType.RecoveryUnknown
+  )
+}
 
 const storeError = (
   operation: MutationStoreError['operation'],
@@ -445,7 +455,15 @@ const makeStore = Effect.gen(function* () {
             }
             const requiredState =
               operation === MutationOperation.Submit ? IntentState.Approved : IntentState.Acknowledged
-            if (intent.state !== requiredState) {
+            const identifiedUnknownSubmit =
+              operation === MutationOperation.Cancel &&
+              intent.state === IntentState.Unknown &&
+              input.brokerOrderId !== undefined &&
+              isIdentifiedUnresolvedSubmit(
+                yield* readLatest(input.intentId, MutationOperation.Submit),
+                input.brokerOrderId,
+              )
+            if (intent.state !== requiredState && !identifiedUnknownSubmit) {
               return yield* Effect.fail(
                 storeError(
                   storeOperation,
@@ -509,6 +527,7 @@ const makeStore = Effect.gen(function* () {
       readonly fromState?: IntentState
       readonly terminalOutcome?: TerminalOutcome
       readonly recover?: boolean
+      readonly recoverUnknown?: boolean
     },
   ) =>
     run(
@@ -592,6 +611,19 @@ const makeStore = Effect.gen(function* () {
                 }
               }
             } else if (fields.nextState !== undefined) {
+              let fromState = fields.fromState ?? IntentState.IoStarted
+              if (fields.recoverUnknown === true) {
+                const recovered = yield* sql<{ intent_id: string }>`
+                  UPDATE intents
+                  SET
+                    state = ${IntentState.Recovered},
+                    state_version = state_version + 1,
+                    updated_at = GREATEST(${input.occurredAt}::timestamptz, updated_at + interval '1 microsecond')
+                  WHERE intent_id = ${input.intentId} AND state = ${IntentState.Unknown}
+                  RETURNING intent_id
+                `
+                if (recovered.length === 1) fromState = IntentState.Recovered
+              }
               const transitioned = yield* sql<{ intent_id: string }>`
                 UPDATE intents
                 SET
@@ -599,7 +631,7 @@ const makeStore = Effect.gen(function* () {
                   terminal_outcome = ${fields.terminalOutcome ?? null},
                   state_version = state_version + 1,
                   updated_at = GREATEST(${input.occurredAt}::timestamptz, updated_at + interval '1 microsecond')
-                WHERE intent_id = ${input.intentId} AND state = ${fields.fromState ?? IntentState.IoStarted}
+                WHERE intent_id = ${input.intentId} AND state = ${fromState}
                 RETURNING intent_id
               `
               if (transitioned.length !== 1) {
@@ -648,7 +680,7 @@ const makeStore = Effect.gen(function* () {
           terminalOutcome: TerminalOutcome.Rejected,
         },
       ),
-    submitUnknown: (intentId, requestHash, occurredAt, evidence) =>
+    submitUnknown: (intentId, requestHash, occurredAt, evidence, brokerOrderId) =>
       appendOutcome(
         'record-submit',
         intentId,
@@ -656,7 +688,11 @@ const makeStore = Effect.gen(function* () {
         requestHash,
         MutationEventType.SubmitUnknown,
         occurredAt,
-        { evidence: completeEvidence(evidence), nextState: IntentState.Unknown },
+        {
+          ...(brokerOrderId === undefined ? {} : { brokerOrderId }),
+          evidence: completeEvidence(evidence),
+          nextState: IntentState.Unknown,
+        },
       ),
     beginCancel: (intentId, requestHash, brokerOrderId, consistencyDelayMs, occurredAt) =>
       begin(MutationOperation.Cancel, intentId, requestHash, consistencyDelayMs, occurredAt, brokerOrderId),
@@ -696,7 +732,9 @@ const makeStore = Effect.gen(function* () {
           ...(operation === MutationOperation.Submit || terminal
             ? {
                 nextState: terminal ? IntentState.Terminal : IntentState.Acknowledged,
-                ...(operation === MutationOperation.Cancel ? { fromState: IntentState.Acknowledged } : {}),
+                ...(operation === MutationOperation.Cancel
+                  ? { fromState: IntentState.Acknowledged, recoverUnknown: true }
+                  : {}),
                 ...(terminalOutcome === undefined ? {} : { terminalOutcome }),
               }
             : {}),

--- a/services/bayn/src/reconciler.test.ts
+++ b/services/bayn/src/reconciler.test.ts
@@ -144,7 +144,7 @@ interface StoreControl {
   restrictions: string[]
 }
 
-const makeStore = (control: StoreControl): PaperStoreShape => ({
+const makeStore = (control: StoreControl, hasAccountBaseline = true): PaperStoreShape => ({
   ingest: (input) =>
     Effect.sync(() => {
       control.writes += 1
@@ -165,6 +165,7 @@ const makeStore = (control: StoreControl): PaperStoreShape => ({
       control.writes += 1
       return valuation
     }),
+  hasAccountBaseline: () => Effect.succeed(hasAccountBaseline),
   bindings: () => Effect.succeed([{ intentId: hash('intent'), clientOrderId: order(0).clientOrderId }]),
   reconcile: (snapshot) =>
     Effect.sync(() => {
@@ -239,6 +240,57 @@ describe('paper reconciliation loop', () => {
     expect(control.reconciliations[0].orders[0].intentId).toBe(hash('intent'))
     expect(control.reconciliations[0].fills[0].intentId).toBe(hash('intent'))
     expect(control.restrictions).toEqual([])
+  })
+
+  test('rejects historical fills on an uninitialized account before ingesting broker state', async () => {
+    const existingOrder = order(0)
+    const existingFill = fill(0, existingOrder)
+    const read: BrokerReadShape = {
+      ...emptyRead(),
+      orders: () => Effect.succeed({ value: [existingOrder], evidence: evidence('orders') }),
+      fillActivities: () => Effect.succeed({ value: { items: [existingFill] }, evidence: evidence('fills') }),
+    }
+    const control: StoreControl = { writes: 0, reconciliations: [], restrictions: [] }
+
+    const failure = await Effect.runPromise(provide(read, makeStore(control, false)).pipe(Effect.flip))
+
+    expect(failure).toMatchObject({
+      _tag: 'ReconciliationError',
+      operation: 'snapshot',
+      message: 'paper account has fill history before Bayn established an opening cash baseline',
+    })
+    expect(control.writes).toBe(0)
+    expect(control.reconciliations).toEqual([])
+    expect(control.restrictions).toEqual(['reconciliation pass incomplete'])
+  })
+
+  test('orders fills by normalized instants before accounting', async () => {
+    const earlierOrder = { ...order(0), submittedAt: '2026-07-22T12:00:00.000Z' }
+    const laterOrder = { ...order(1), submittedAt: '2026-07-22T12:00:01.000Z' }
+    const earlierFill = {
+      ...fill(0, earlierOrder),
+      activityId: 'fill-earlier',
+      transactionTime: '2026-07-22T12:00:00.1Z',
+    }
+    const laterFill = {
+      ...fill(1, laterOrder),
+      activityId: 'fill-later',
+      transactionTime: '2026-07-22T12:00:00.100001Z',
+    }
+    const read: BrokerReadShape = {
+      ...emptyRead(),
+      orders: () => Effect.succeed({ value: [earlierOrder, laterOrder], evidence: evidence('orders') }),
+      fillActivities: () => Effect.succeed({ value: { items: [laterFill, earlierFill] }, evidence: evidence('fills') }),
+    }
+    const control: StoreControl = { writes: 0, reconciliations: [], restrictions: [] }
+
+    await Effect.runPromise(provide(read, makeStore(control)))
+
+    expect(control.reconciliations).toHaveLength(1)
+    expect(control.reconciliations[0].fills.map((candidate) => candidate.fillId)).toEqual([
+      earlierFill.activityId,
+      laterFill.activityId,
+    ])
   })
 
   test('fails a duplicate page before any durable write or false resolution', async () => {

--- a/services/bayn/src/reconciler.ts
+++ b/services/bayn/src/reconciler.ts
@@ -198,6 +198,11 @@ const run = (
     return yield* fence.transaction(
       Effect.gen(function* () {
         const bindings = yield* store.bindings(accountResult.value.id)
+        if (fills.length > 0 && !(yield* store.hasAccountBaseline(accountResult.value.id))) {
+          return yield* Effect.fail(
+            failure('snapshot', 'paper account has fill history before Bayn established an opening cash baseline'),
+          )
+        }
 
         const normalized = yield* attempt('normalization', 'broker snapshot normalization failed', () => {
           const intentByClient = new Map<string, string>()
@@ -231,7 +236,9 @@ const run = (
 
           const fillEvents = [...fills]
             .sort((left, right) => {
-              const byTime = left.value.transactionTime.localeCompare(right.value.transactionTime)
+              const byTime = timestampOrderKey(left.value.transactionTime).localeCompare(
+                timestampOrderKey(right.value.transactionTime),
+              )
               return byTime === 0 ? left.value.activityId.localeCompare(right.value.activityId) : byTime
             })
             .map((observed): FillEventInput => {

--- a/services/bayn/src/startup.test.ts
+++ b/services/bayn/src/startup.test.ts
@@ -426,6 +426,26 @@ describe('Bayn startup lifecycle', () => {
     }
   })
 
+  test('terminates the runtime when continuous reconciliation dies', async () => {
+    const exit = await Effect.runPromiseExit(
+      run(config, fixtureStrategy, Effect.die(new Error('unexpected reconciliation defect'))).pipe(
+        Effect.provideService(MarketData, marketDataService(Effect.succeed(makeSnapshot()))),
+        Effect.provideService(Journal, successfulJournal),
+        Effect.provideService(EvidenceStore, successfulEvidenceStore),
+        Effect.timeoutOrElse({
+          duration: 250,
+          orElse: () => Effect.fail(operationalError('http', 'test', 'run remained alive after reconciliation died')),
+        }),
+      ),
+    )
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) {
+      expect(Cause.pretty(exit.cause)).toContain('unexpected reconciliation defect')
+      expect(Cause.pretty(exit.cause)).not.toContain('remained alive')
+    }
+  })
+
   test('exits the scoped runtime on a retryable startup dependency failure', async () => {
     let interrupted = false
     const journal: JournalService = {


### PR DESCRIPTION
## Summary

- Preserve Alpaca broker order IDs for accepted-but-mismatched submissions, cancel the exact identified order, and close only zero-fill neutral terminal outcomes; live or partially filled mismatches remain fail-closed.
- Reject inconsistent terminal fills, order fills by normalized instants, and reject non-pristine accounts until Bayn has an opening account baseline.
- Join continuous reconciliation so defects terminate the runtime, and add the hard PostgreSQL contract migration required for identified unknown submissions.
- Add unit and real-CNPG regressions for each reviewed failure path; broker credentials remain unconsumed and paper mutation authority is unchanged.

## Related Issues

PROOMPT-370, PROOMPT-371. Remediates actionable review findings from #13087 and #13101.

## Testing

- `bun test --timeout 30000 services/bayn/src/execution/coordinator.test.ts services/bayn/src/reconciler.test.ts services/bayn/src/startup.test.ts services/bayn/src/broker/alpaca-mutations.test.ts` — 41 pass.
- `env -u BAYN_TEST_POSTGRES_URL bun test --timeout 30000 services/bayn/src` — 214 pass, 43 PostgreSQL tests skipped, 0 fail.
- `BAYN_TEST_POSTGRES_URL=<CNPG bayn_test URL> bun test --timeout 30000 services/bayn/src/db/evidence-store.integration.test.ts services/bayn/src/db/paper-store.integration.test.ts` — 40 pass, 0 fail against the live CNPG test database; the test schema was reset afterward.
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- `git diff --check`

## Breaking Changes

Database migration 8 replaces the current `mutation_events` event-contract check constraint during the normal deployment migration. No broker credential binding, order submission, capital-authority, or TigerBeetle change is included.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.