### PR TITLE
fix(bayn): isolate observe-only broker reads

### DIFF
--- a/docs/bayn/architecture.md
+++ b/docs/bayn/architecture.md
@@ -4,10 +4,10 @@
 
 Bayn is a single-writer, paper-only quantitative qualification runtime. It evaluates one compiled
 `risk-balanced-trend` candidate against one immutable Signal snapshot, journals the deterministic simulation, verifies
-the accounting result, and exposes the resulting qualification evidence. It has no runtime broker credential,
-order-submission entry point, or capital-promotion authority. The source tree includes dormant paper-only read and
-mutation adapters plus a recovery coordinator; the composition root does not build them and the pod has no broker
-credential. Public status currently reports maximum authority `observe` independently of that dormant code.
+the accounting result, and exposes the resulting qualification evidence. It has no order-submission entry point or
+capital-promotion authority. A dedicated paper credential may build the GET-only Alpaca read adapter while authority
+remains `OBSERVE`; paper mutation and recovery remain dormant. Public status reports maximum authority independently
+of credential presence.
 
 The runtime has three external I/O boundaries:
 
@@ -15,8 +15,8 @@ The runtime has three external I/O boundaries:
 - a dedicated Bayn TigerBeetle cluster for deterministic simulation accounting; and
 - the existing `EvidenceStore` interface for durable qualification evidence.
 
-The dormant paper path would add Alpaca through the existing egress proxy only after a qualified strategy, a dedicated
-paper account, a reviewed credential, and explicit GitOps authority are present.
+Alpaca is reachable only through the existing paper-host CONNECT proxy. Credential binding first performs a bounded,
+runtime-decoded GET-only preflight. Paper reconciliation and mutation remain separate authority-gated steps.
 
 The implementation behind `EvidenceStore` is deliberately outside this document. Non-database cleanup must preserve
 that interface and every persisted evidence contract.
@@ -66,9 +66,10 @@ order identity, and consistency delay in PostgreSQL. Any unresolved submit or ca
 intents; terminal recovery releases that block. There is no scheduler, public order route, arbitrary order API, blind
 flatten, runtime registry, or alternate writer.
 
-This path is intentionally dormant: `src/index.ts` does not provide `BrokerMutation` or invoke the coordinator, GitOps
-does not mount an Alpaca credential, and the current qualification is not execution authority. Enabling paper operation
-requires a separate reviewed change and live readback against the dedicated paper account.
+This path is intentionally dormant: `src/index.ts` does not provide `BrokerMutation` or invoke the coordinator, and the
+current qualification is not execution authority. A credential mounted under `OBSERVE` performs GET-only preflight;
+the paper store, writer fence, and reconciliation loop are built only under `PAPER`. Enabling paper operation requires
+a separate reviewed change and an audited qualified result.
 
 ## Effect composition
 
@@ -91,9 +92,9 @@ Effect is used at resource and failure boundaries, not as a container for ordina
   operation.
 - HTTP receives the runtime state and the narrow evidence-read callback it needs. It does not depend on the strategy or
   the complete evidence service.
-- The Alpaca read and mutation adapters, risk evaluator, intent and mutation stores, writer fence, and recovery
-  coordinator remain outside the runtime composition until the qualification and authority gates explicitly permit a
-  paper slice.
+- The Alpaca read adapter may enter runtime composition for GET-only preflight under `OBSERVE`. The mutation adapter,
+  intent and mutation stores, writer fence, reconciliation loop, and recovery coordinator remain outside composition
+  until the authority gates explicitly permit a paper slice.
 
 Do not introduce a `Context.Service` or `Layer` for a pure value merely to make it injectable. Add an Effect service
 only when a capability needs acquisition, release, configuration, retry, concurrency, or typed I/O failure.
@@ -152,8 +153,9 @@ qualification, or durable evidence closes readiness and never expands authority.
 ## Deployment contract
 
 GitOps owns one `apps/v1 Deployment` configured as a single writer and a dedicated three-replica TigerBeetle cluster.
-`maxSurge: 0` prevents overlapping writers during rollout. The pod has no broker secret and no Kubernetes API token.
-Scaling to zero is a maintenance state, not a second deployment mode.
+`maxSurge: 0` prevents overlapping writers during rollout. The pod has no Kubernetes API token. A broker Secret may be
+consumed only by this Deployment and does not expand authority. Scaling to zero is a maintenance state, not a second
+deployment mode.
 
 Every promoted image requires live acceptance against one coherent writer: the pod spec's digest-pinned image reference
 must match the GitOps OCI index digest. The runtime image ID is supporting evidence: its digest must be either that same

--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -2,8 +2,8 @@
 
 Bayn is a single-writer, paper-only quantitative qualification runtime. Its current protocol evaluates the frozen
 risk-balanced trend candidate on the authoritative infrastructure-equity universe and journals the resulting simulation
-to TigerBeetle. Its source contains a dormant, paper-only Alpaca mutation capability, but the deployed composition has
-no broker credentials, mutation layer, execution entry point, or capital-promotion path.
+to TigerBeetle. Alpaca credentials may enable a bounded GET-only account preflight while authority remains `OBSERVE`.
+The paper mutation capability, execution entry point, and capital-promotion path remain dormant.
 
 ## Runtime contract
 
@@ -13,7 +13,8 @@ no broker credentials, mutation layer, execution entry point, or capital-promoti
 - `BAYN_MAXIMUM_AUTHORITY` is a closed `OBSERVE`/`PAPER` process ceiling and defaults to `OBSERVE`. It never creates a
   broker capability; the deployed runtime remains `OBSERVE` and does not compose the submit/cancel capability.
 - Public egress is denied from the Bayn Pod. A separate CONNECT proxy permits only
-  `paper-api.alpaca.markets:443`. The pod has no broker credential, so the dormant client cannot authenticate or run.
+  `paper-api.alpaca.markets:443`. A configured Alpaca credential is accepted only after account, position, order,
+  order-lookup, and fill reads pass the runtime-decoded preflight through that proxy.
 - Signal ClickHouse is read-only at runtime. Data publication and provider credentials are owned by the separate Signal
   adjusted-daily publisher; Bayn contains no DDL or backfill command.
 - Bayn owns a two-instance CloudNativePG cluster. The runtime uses the generated application URI over verified TLS,
@@ -70,10 +71,9 @@ no broker credentials, mutation layer, execution entry point, or capital-promoti
 - The current-only migration chain owns the unprefixed evidence, qualification, intent, and mutation schema. Startup
   rejects a legacy migration tracker or retired migration history after the hard cut; it never reads, converts, or
   falls back to legacy records.
-- Alpaca read and mutation adapters, deterministic risk, intent and mutation persistence, the writer fence, and the
-  recovery coordinator remain dormant source foundations. The composition root does not acquire broker credentials,
-  construct either adapter, reserve the writer fence, or expose the stores or coordinator while qualification is
-  rejected and maximum authority is `OBSERVE`.
+- The Alpaca read adapter may be acquired while maximum authority is `OBSERVE`, but it performs GET-only preflight and
+  does not build the paper store, reserve the writer fence, start reconciliation, or change PostgreSQL or TigerBeetle.
+  The mutation adapter and recovery coordinator remain dormant source foundations.
 - The execution path and independent reducer use integer micros for cash, quantity, prices, spread, slippage, fees,
   cash yield, positions, and every marked-equity point. Full, partial, and rejected orders are durable. Evaluation and
   recovery require exact zero-difference cash, fee, position, and equity reconstruction.

--- a/services/bayn/src/broker/alpaca.test.ts
+++ b/services/bayn/src/broker/alpaca.test.ts
@@ -23,6 +23,7 @@ import {
   layer,
   make,
   makeProxyDispatcher,
+  verifyReadAccess,
   type BrokerReadShape,
   type ReadOptions,
 } from './alpaca'
@@ -203,6 +204,48 @@ describe('Alpaca paper reads', () => {
         retryAfter: undefined,
       },
     })
+  })
+
+  test('preflights the complete GET-only surface without persisting or inventing an order', async () => {
+    const requests: Array<{ method: string; url: URL }> = []
+    const client = HttpClient.make((request, url) => {
+      requests.push({ method: request.method, url })
+      if (url.pathname === '/v2/account') return Effect.succeed(jsonResponse(request, accountResponse))
+      if (url.pathname === '/v2/positions') return Effect.succeed(jsonResponse(request, []))
+      if (url.pathname === '/v2/orders' || url.pathname === '/v2/account/activities/FILL') {
+        return Effect.succeed(jsonResponse(request, []))
+      }
+      return Effect.succeed(jsonResponse(request, { code: 40410000, message: 'order not found' }, 404))
+    })
+
+    const proof = await Effect.runPromise(withClient(client, verifyReadAccess))
+
+    expect(proof).toMatchObject({
+      accountId,
+      positionCount: 0,
+      openOrderCount: 0,
+      recentOrderCount: 0,
+      fillCount: 0,
+      orderById: 'NOT_FOUND',
+      orderByClientId: 'NOT_FOUND',
+    })
+    expect(proof.accountHash).toMatch(/^[a-f0-9]{64}$/)
+    expect(proof.positionsHash).toMatch(/^[a-f0-9]{64}$/)
+    expect(proof.ordersHash).toMatch(/^[a-f0-9]{64}$/)
+    expect(proof.fillsHash).toMatch(/^[a-f0-9]{64}$/)
+    expect(requests).toHaveLength(7)
+    expect(requests.every(({ method }) => method === 'GET')).toBe(true)
+    expect(
+      requests
+        .filter(({ url }) => url.pathname === '/v2/orders')
+        .map(({ url }) => url.searchParams.get('status'))
+        .sort(),
+    ).toEqual(['all', 'open'])
+    expect(requests.some(({ url }) => url.pathname === `/v2/orders/00000000-0000-4000-8000-000000000000`)).toBe(true)
+    expect(requests.some(({ url }) => url.pathname === '/v2/orders:by_client_order_id')).toBe(true)
+    const fill = requests.find(({ url }) => url.pathname === '/v2/account/activities/FILL')
+    expect(fill?.url.searchParams.get('page_size')).toBe('1')
+    expect(fill?.url.searchParams.get('direction')).toBe('desc')
   })
 
   test('normalizes equity positions exactly and rejects precision loss', async () => {

--- a/services/bayn/src/broker/alpaca.test.ts
+++ b/services/bayn/src/broker/alpaca.test.ts
@@ -23,6 +23,7 @@ import {
   layer,
   make,
   makeProxyDispatcher,
+  readPreflightTimeoutMs,
   verifyReadAccess,
   type BrokerReadShape,
   type ReadOptions,
@@ -239,13 +240,47 @@ describe('Alpaca paper reads', () => {
       requests
         .filter(({ url }) => url.pathname === '/v2/orders')
         .map(({ url }) => url.searchParams.get('status'))
-        .sort(),
+        .sort((left, right) => (left ?? '').localeCompare(right ?? '')),
     ).toEqual(['all', 'open'])
     expect(requests.some(({ url }) => url.pathname === `/v2/orders/00000000-0000-4000-8000-000000000000`)).toBe(true)
     expect(requests.some(({ url }) => url.pathname === '/v2/orders:by_client_order_id')).toBe(true)
     const fill = requests.find(({ url }) => url.pathname === '/v2/account/activities/FILL')
     expect(fill?.url.searchParams.get('page_size')).toBe('1')
     expect(fill?.url.searchParams.get('direction')).toBe('desc')
+  })
+
+  test('bounds the complete startup preflight below the Kubernetes startup-probe budget', async () => {
+    let interrupted = 0
+    const client = HttpClient.make((request, url) => {
+      if (url.pathname === '/v2/account') return Effect.succeed(jsonResponse(request, accountResponse))
+      return Effect.never.pipe(
+        Effect.onInterrupt(() =>
+          Effect.sync(() => {
+            interrupted += 1
+          }),
+        ),
+      )
+    })
+
+    const program = withClient(
+      client,
+      (read) =>
+        Effect.gen(function* () {
+          const fiber = yield* Effect.flip(verifyReadAccess(read)).pipe(Effect.forkChild)
+          yield* Effect.yieldNow
+          yield* TestClock.adjust(readPreflightTimeoutMs)
+          return yield* Fiber.join(fiber)
+        }),
+      { ...options, operationTimeoutMs: 120_000, retryAttempts: 0 },
+    ).pipe(Effect.provide(TestClock.layer()))
+
+    const failure = await Effect.runPromise(program)
+    expect(failure).toMatchObject({
+      kind: BrokerReadErrorKind.Timeout,
+      operation: 'preflight',
+      retryable: true,
+    })
+    expect(interrupted).toBeGreaterThan(0)
   })
 
   test('normalizes equity positions exactly and rejects precision loss', async () => {

--- a/services/bayn/src/broker/alpaca.ts
+++ b/services/bayn/src/broker/alpaca.ts
@@ -364,6 +364,20 @@ export interface BrokerReadShape {
 
 export class BrokerRead extends Context.Service<BrokerRead, BrokerReadShape>()('bayn/BrokerRead') {}
 
+export interface ReadPreflight {
+  readonly accountId: string
+  readonly accountHash: string
+  readonly positionCount: number
+  readonly positionsHash: string
+  readonly openOrderCount: number
+  readonly recentOrderCount: number
+  readonly ordersHash: string
+  readonly fillCount: number
+  readonly fillsHash: string
+  readonly orderById: 'MATCHED' | 'NOT_FOUND'
+  readonly orderByClientId: 'MATCHED' | 'NOT_FOUND'
+}
+
 const AccountResponseSchema = Schema.Struct({
   id: Uuid,
   account_number: NonEmptyString,
@@ -1125,8 +1139,111 @@ export const make = (options: ReadOptions): Effect.Effect<BrokerReadShape, Broke
     return { account, positions, orders, orderById, orderByClientId, fillActivities }
   })
 
+const missingOrderId = '00000000-0000-4000-8000-000000000000'
+const missingClientOrderId = 'bayn-observe-read-proof-does-not-exist'
+
+const expectNotFound = (
+  operation: 'order-by-id' | 'order-by-client-id',
+  read: Effect.Effect<ReadResult<Order>, BrokerReadError>,
+): Effect.Effect<'NOT_FOUND', BrokerReadError> =>
+  read.pipe(
+    Effect.matchEffect({
+      onFailure: (error) =>
+        error.kind === BrokerReadErrorKind.NotFound ? Effect.succeed('NOT_FOUND' as const) : Effect.fail(error),
+      onSuccess: (result) =>
+        Effect.fail(
+          invalidResponse(
+            operation,
+            `Alpaca ${operation} unexpectedly resolved the observe-only proof identity`,
+            result.evidence,
+            result.value,
+          ),
+        ),
+    }),
+  )
+
+const verifyOrderLookup = (
+  operation: 'order-by-id' | 'order-by-client-id',
+  expected: Order,
+  read: Effect.Effect<ReadResult<Order>, BrokerReadError>,
+): Effect.Effect<'MATCHED', BrokerReadError> =>
+  read.pipe(
+    Effect.flatMap((result) =>
+      result.value.brokerOrderId === expected.brokerOrderId && result.value.clientOrderId === expected.clientOrderId
+        ? Effect.succeed('MATCHED' as const)
+        : Effect.fail(
+            invalidResponse(
+              operation,
+              `Alpaca ${operation} returned a different order during observe-only preflight`,
+              result.evidence,
+              result.value,
+            ),
+          ),
+    ),
+  )
+
+export const verifyReadAccess = (read: BrokerReadShape): Effect.Effect<ReadPreflight, BrokerReadError> =>
+  Effect.gen(function* () {
+    const account = yield* read.account
+    const responses = yield* Effect.all(
+      {
+        positions: read.positions,
+        openOrders: read.orders({ status: OrderCollection.Open, limit: 1 }),
+        recentOrders: read.orders({
+          status: OrderCollection.All,
+          limit: 1,
+          direction: SortDirection.Descending,
+        }),
+        fills: read.fillActivities({ pageSize: 1, direction: SortDirection.Descending }),
+      },
+      { concurrency: 4 },
+    )
+    const order = responses.recentOrders.value[0] ?? responses.openOrders.value[0]
+    const lookups =
+      order === undefined
+        ? yield* Effect.all({
+            orderById: expectNotFound('order-by-id', read.orderById(missingOrderId)),
+            orderByClientId: expectNotFound('order-by-client-id', read.orderByClientId(missingClientOrderId)),
+          })
+        : yield* Effect.all({
+            orderById: verifyOrderLookup('order-by-id', order, read.orderById(order.brokerOrderId)),
+            orderByClientId: verifyOrderLookup('order-by-client-id', order, read.orderByClientId(order.clientOrderId)),
+          })
+    const proof: ReadPreflight = {
+      accountId: account.value.id,
+      accountHash: canonicalHashV1(account.value),
+      positionCount: responses.positions.value.length,
+      positionsHash: canonicalHashV1(responses.positions.value),
+      openOrderCount: responses.openOrders.value.length,
+      recentOrderCount: responses.recentOrders.value.length,
+      ordersHash: canonicalHashV1({
+        open: responses.openOrders.value,
+        recent: responses.recentOrders.value,
+      }),
+      fillCount: responses.fills.value.items.length,
+      fillsHash: canonicalHashV1(responses.fills.value.items),
+      ...lookups,
+    }
+    yield* Effect.logInfo('Alpaca observe-only read preflight passed').pipe(
+      Effect.annotateLogs({
+        accountId: proof.accountId,
+        accountHash: proof.accountHash,
+        positionCount: proof.positionCount,
+        positionsHash: proof.positionsHash,
+        openOrderCount: proof.openOrderCount,
+        recentOrderCount: proof.recentOrderCount,
+        ordersHash: proof.ordersHash,
+        fillCount: proof.fillCount,
+        fillsHash: proof.fillsHash,
+        orderById: proof.orderById,
+        orderByClientId: proof.orderByClientId,
+      }),
+    )
+    return proof
+  }).pipe(Effect.withLogSpan('broker.read.preflight'))
+
 export const layer = (options: ReadOptions): Layer.Layer<BrokerRead, BrokerReadError, HttpClient.HttpClient> =>
-  Layer.effect(BrokerRead, make(options).pipe(Effect.tap((read) => read.account)))
+  Layer.effect(BrokerRead, make(options).pipe(Effect.tap(verifyReadAccess)))
 
 export const live = (options: ReadOptions): Layer.Layer<BrokerRead, BrokerReadError> =>
   layer(options).pipe(Layer.provide(alpacaHttpLayer(options.proxyUrl)))

--- a/services/bayn/src/broker/alpaca.ts
+++ b/services/bayn/src/broker/alpaca.ts
@@ -11,6 +11,7 @@ import {
 
 export const paperTradingUrl = 'https://paper-api.alpaca.markets'
 const defaultFillActivitiesPageSize = 100
+export const readPreflightTimeoutMs = 45_000
 const responseParseOptions = { onExcessProperty: 'ignore' } as const
 const inputParseOptions = { onExcessProperty: 'error' } as const
 const redactedHeaders = [
@@ -198,6 +199,7 @@ export enum BrokerReadErrorKind {
 export type BrokerReadOperation =
   | 'configuration'
   | 'proxy'
+  | 'preflight'
   | 'account'
   | 'positions'
   | 'orders'
@@ -1240,7 +1242,21 @@ export const verifyReadAccess = (read: BrokerReadShape): Effect.Effect<ReadPrefl
       }),
     )
     return proof
-  }).pipe(Effect.withLogSpan('broker.read.preflight'))
+  }).pipe(
+    Effect.timeoutOrElse({
+      duration: readPreflightTimeoutMs,
+      orElse: () =>
+        Effect.fail(
+          new BrokerReadError({
+            operation: 'preflight',
+            kind: BrokerReadErrorKind.Timeout,
+            message: `Alpaca observe-only read preflight exceeded its ${readPreflightTimeoutMs}ms startup deadline`,
+            retryable: true,
+          }),
+        ),
+    }),
+    Effect.withLogSpan('broker.read.preflight'),
+  )
 
 export const layer = (options: ReadOptions): Layer.Layer<BrokerRead, BrokerReadError, HttpClient.HttpClient> =>
   Layer.effect(BrokerRead, make(options).pipe(Effect.tap(verifyReadAccess)))

--- a/services/bayn/src/config.test.ts
+++ b/services/bayn/src/config.test.ts
@@ -86,7 +86,7 @@ describe('Effect configuration', () => {
     expect(config.qualificationRunId).toBe('e'.repeat(64))
   })
 
-  test('enables reconciliation only with one complete redacted Alpaca credential binding', async () => {
+  test('loads one complete redacted Alpaca read binding', async () => {
     const configured = new Map(runtimeEnvironment)
     configured.set('BAYN_ALPACA_ACCOUNT_ID', '61e69015-8549-4bfd-b9c3-01e75843f47d')
     configured.set('BAYN_ALPACA_KEY_ID', 'paper-key')

--- a/services/bayn/src/index.ts
+++ b/services/bayn/src/index.ts
@@ -14,6 +14,7 @@ import { operationalError } from './errors'
 import { JournalLive } from './ledger'
 import { MarketDataLive } from './market-data'
 import { acquireSqlLayer } from './operations'
+import { Authority } from './paper'
 import { hashParameters, loadDefaultProtocol } from './protocol'
 import { runContinuously } from './reconciler'
 import { makeStrategy } from './strategy'
@@ -55,15 +56,6 @@ const main = Effect.gen(function* () {
   const journal = yield* acquireSqlLayer(JournalLive(config))
   let reconciliation = Effect.void
   if (config.alpaca !== undefined) {
-    const storage = Layer.mergeAll(Layer.succeedContext(evidenceStore), Layer.succeedContext(journal))
-    const paperStore = yield* Layer.build(PaperStoreLive(config).pipe(Layer.provide(storage)))
-    const writerFence = yield* Layer.build(
-      WriterFenceLive.pipe(Layer.provide(Layer.succeedContext(evidenceStore))),
-    ).pipe(
-      Effect.mapError((cause) =>
-        operationalError('database', 'writer-fence', 'paper writer fence acquisition failed', cause),
-      ),
-    )
     const brokerRead = yield* Layer.build(
       AlpacaReadLive({
         expectedAccountId: config.alpaca.accountId,
@@ -76,14 +68,25 @@ const main = Effect.gen(function* () {
     ).pipe(
       Effect.mapError((cause) => operationalError('config', 'alpaca', 'Alpaca paper account binding failed', cause)),
     )
-    const reconciliationDependencies = Layer.mergeAll(
-      Layer.succeedContext(brokerRead),
-      Layer.succeedContext(paperStore),
-      Layer.succeedContext(writerFence),
-    )
-    reconciliation = runContinuously(config.alpaca.reconciliationIntervalMs).pipe(
-      Effect.provide(reconciliationDependencies),
-    )
+    if (config.maximumAuthority === Authority.Paper) {
+      const storage = Layer.mergeAll(Layer.succeedContext(evidenceStore), Layer.succeedContext(journal))
+      const paperStore = yield* Layer.build(PaperStoreLive(config).pipe(Layer.provide(storage)))
+      const writerFence = yield* Layer.build(
+        WriterFenceLive.pipe(Layer.provide(Layer.succeedContext(evidenceStore))),
+      ).pipe(
+        Effect.mapError((cause) =>
+          operationalError('database', 'writer-fence', 'paper writer fence acquisition failed', cause),
+        ),
+      )
+      const reconciliationDependencies = Layer.mergeAll(
+        Layer.succeedContext(brokerRead),
+        Layer.succeedContext(paperStore),
+        Layer.succeedContext(writerFence),
+      )
+      reconciliation = runContinuously(config.alpaca.reconciliationIntervalMs).pipe(
+        Effect.provide(reconciliationDependencies),
+      )
+    }
   }
   const dependencies = Layer.mergeAll(marketData, Layer.succeedContext(journal), Layer.succeedContext(evidenceStore))
   return yield* run(config, strategy, reconciliation).pipe(Effect.provide(dependencies))


### PR DESCRIPTION
## Summary

- require a bounded GET-only Alpaca preflight before publishing the read capability
- keep the paper store, writer fence, and reconciliation loop outside runtime composition while authority is `OBSERVE`
- document the credential, read, reconciliation, and mutation boundaries without mounting the Secret in this source PR

## Related Issues

Advances PROOMPT-371
Advances PROOMPT-372

## Testing

- `bun test services/bayn/src/broker/alpaca.test.ts services/bayn/src/config.test.ts` — 26 passed, 0 failed
- `bun run --filter @proompteng/bayn test` — 215 passed, 43 PostgreSQL tests skipped, 0 failed
- `bun run --filter @proompteng/bayn tsc`
- `bunx oxfmt --check services/bayn docs/bayn/architecture.md`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- `git diff --check`
- Node-targeted live preflight through the existing Bayn proxy and dedicated paper credential: expected account matched; positions, open/recent orders, and fills were empty; order-by-ID and order-by-client-ID returned typed `NOT_FOUND`; no credential value was printed

## Breaking Changes

None. The source PR deliberately does not add a Deployment Secret reference. The reviewed image and credential references must be promoted atomically so the previous image can never consume the credential.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation and Linear follow-up state are updated.