### PR TITLE
fix(bayn): close merged review findings

### DIFF
--- a/.github/workflows/bayn-ci.yml
+++ b/.github/workflows/bayn-ci.yml
@@ -64,4 +64,6 @@ jobs:
           --filter @proompteng/source
           --filter @proompteng/bayn
       - name: Verify durable evidence on PostgreSQL 18
-        run: bun test services/bayn/src/db/evidence-store.integration.test.ts
+        run: |
+          bun test services/bayn/src/db/evidence-store.integration.test.ts
+          bun test services/bayn/src/db/paper-store.integration.test.ts

--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -23,7 +23,7 @@ The paper mutation capability, execution entry point, and capital-promotion path
   response identity, and the lookup delay are committed before use; unresolved outcomes block later exposure. The
   deployed observe-only runtime does not create mutation rows.
 - Paper execution is long-only: risk blocks an existing short or a sell beyond reconciled long inventory before broker
-  I/O. Fill accounting follows broker occurrence time with a stable source-identity tie-breaker, rejects late
+  I/O. Fill accounting persists Alpaca's full source timestamp and orders equal timestamps by fill ID, rejects late
   predecessors, and records a receipt only after the complete TigerBeetle transaction-tag transfer set matches.
 - The composition root builds one pure strategy value and passes it explicitly to the lifecycle. Effect services and
   layers are reserved for I/O resources. The compiled `bayn.risk-balanced-trend.protocol.v2` owns its authoritative

--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -22,6 +22,9 @@ The paper mutation capability, execution entry point, and capital-promotion path
 - PostgreSQL stores paper mutation transitions in one append-only `mutation_events` table. Request identity, broker
   response identity, and the lookup delay are committed before use; unresolved outcomes block later exposure. The
   deployed observe-only runtime does not create mutation rows.
+- Paper execution is long-only: risk blocks an existing short or a sell beyond reconciled long inventory before broker
+  I/O. Fill accounting follows broker occurrence time with a stable source-identity tie-breaker, rejects late
+  predecessors, and records a receipt only after the complete TigerBeetle transaction-tag transfer set matches.
 - The composition root builds one pure strategy value and passes it explicitly to the lifecycle. Effect services and
   layers are reserved for I/O resources. The compiled `bayn.risk-balanced-trend.protocol.v2` owns its authoritative
   universe and execution contract; the HTTP and startup lifecycle remain strategy-independent.

--- a/services/bayn/migrations/0009_fill_source_timestamp.ts
+++ b/services/bayn/migrations/0009_fill_source_timestamp.ts
@@ -1,0 +1,28 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient
+
+  yield* sql`
+    DO $$
+    BEGIN
+      IF EXISTS (SELECT 1 FROM fills) THEN
+        RAISE EXCEPTION 'fill source timestamp migration requires an empty fills table';
+      END IF;
+    END
+    $$
+  `
+
+  yield* sql`
+    ALTER TABLE fills
+    ADD COLUMN source_timestamp text NOT NULL CHECK (
+      source_timestamp ~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}[.][0-9]{9}Z$'
+    )
+  `
+
+  yield* sql`
+    CREATE INDEX fills_account_source_order_idx
+    ON fills(account_id, symbol, source_timestamp COLLATE "C", fill_id COLLATE "C")
+  `
+})

--- a/services/bayn/src/broker/alpaca.test.ts
+++ b/services/bayn/src/broker/alpaca.test.ts
@@ -249,6 +249,27 @@ describe('Alpaca paper reads', () => {
     expect(fill?.url.searchParams.get('direction')).toBe('desc')
   })
 
+  test('preflights ordinary non-empty orders whose optional Alpaca fields are null', async () => {
+    const client = HttpClient.make((request, url) => {
+      if (url.pathname === '/v2/account') return Effect.succeed(jsonResponse(request, accountResponse))
+      if (url.pathname === '/v2/positions' || url.pathname === '/v2/account/activities/FILL') {
+        return Effect.succeed(jsonResponse(request, []))
+      }
+      return Effect.succeed(jsonResponse(request, url.pathname === '/v2/orders' ? [orderResponse] : orderResponse))
+    })
+
+    const proof = await Effect.runPromise(withClient(client, verifyReadAccess))
+
+    expect(proof).toMatchObject({
+      accountId,
+      openOrderCount: 1,
+      recentOrderCount: 1,
+      orderById: 'MATCHED',
+      orderByClientId: 'MATCHED',
+    })
+    expect(proof.ordersHash).toMatch(/^[a-f0-9]{64}$/)
+  })
+
   test('bounds the complete startup preflight below the Kubernetes startup-probe budget', async () => {
     let interrupted = 0
     const client = HttpClient.make((request, url) => {

--- a/services/bayn/src/broker/alpaca.ts
+++ b/services/bayn/src/broker/alpaca.ts
@@ -765,6 +765,20 @@ export const normalizeOrder = (raw: typeof OrderResponseSchema.Type, accountId: 
     throw new Error('trailing-stop order must contain exactly one trailing offset')
   }
 
+  const filledAt = optionalTimestamp(raw.filled_at)
+  const expiredAt = optionalTimestamp(raw.expired_at)
+  const canceledAt = optionalTimestamp(raw.canceled_at)
+  const failedAt = optionalTimestamp(raw.failed_at)
+  const replacedAt = optionalTimestamp(raw.replaced_at)
+  const replacedBy = raw.replaced_by ?? undefined
+  const replaces = raw.replaces ?? undefined
+  const filledAveragePriceMicros = optionalMicros(raw.filled_avg_price, false, 'filled average price')
+  const limitPriceMicros = optionalMicros(raw.limit_price, false, 'limit price')
+  const stopPriceMicros = optionalMicros(raw.stop_price, false, 'stop price')
+  const trailPercentMicros = optionalMicros(raw.trail_percent, false, 'trail percent')
+  const trailPriceMicros = optionalMicros(raw.trail_price, false, 'trail price')
+  const highWaterMarkMicros = optionalMicros(raw.hwm, false, 'high water mark')
+
   return {
     accountId,
     brokerOrderId: raw.id,
@@ -772,31 +786,31 @@ export const normalizeOrder = (raw: typeof OrderResponseSchema.Type, accountId: 
     createdAt: raw.created_at,
     updatedAt: raw.updated_at,
     submittedAt: raw.submitted_at,
-    filledAt: optionalTimestamp(raw.filled_at),
-    expiredAt: optionalTimestamp(raw.expired_at),
-    canceledAt: optionalTimestamp(raw.canceled_at),
-    failedAt: optionalTimestamp(raw.failed_at),
-    replacedAt: optionalTimestamp(raw.replaced_at),
-    replacedBy: raw.replaced_by ?? undefined,
-    replaces: raw.replaces ?? undefined,
+    ...(filledAt === undefined ? {} : { filledAt }),
+    ...(expiredAt === undefined ? {} : { expiredAt }),
+    ...(canceledAt === undefined ? {} : { canceledAt }),
+    ...(failedAt === undefined ? {} : { failedAt }),
+    ...(replacedAt === undefined ? {} : { replacedAt }),
+    ...(replacedBy === undefined ? {} : { replacedBy }),
+    ...(replaces === undefined ? {} : { replaces }),
     assetId: raw.asset_id,
     symbol: raw.symbol,
     assetClass: raw.asset_class,
-    quantityMicros,
-    notionalMicros,
+    ...(quantityMicros === undefined ? {} : { quantityMicros }),
+    ...(notionalMicros === undefined ? {} : { notionalMicros }),
     filledQuantityMicros,
-    filledAveragePriceMicros: optionalMicros(raw.filled_avg_price, false, 'filled average price'),
+    ...(filledAveragePriceMicros === undefined ? {} : { filledAveragePriceMicros }),
     orderClass: raw.order_class === '' ? OrderClass.Simple : raw.order_class,
     orderType: raw.order_type,
     side: raw.side,
     timeInForce: raw.time_in_force,
-    limitPriceMicros: optionalMicros(raw.limit_price, false, 'limit price'),
-    stopPriceMicros: optionalMicros(raw.stop_price, false, 'stop price'),
+    ...(limitPriceMicros === undefined ? {} : { limitPriceMicros }),
+    ...(stopPriceMicros === undefined ? {} : { stopPriceMicros }),
     status: raw.status,
     extendedHours: raw.extended_hours,
-    trailPercentMicros: optionalMicros(raw.trail_percent, false, 'trail percent'),
-    trailPriceMicros: optionalMicros(raw.trail_price, false, 'trail price'),
-    highWaterMarkMicros: optionalMicros(raw.hwm, false, 'high water mark'),
+    ...(trailPercentMicros === undefined ? {} : { trailPercentMicros }),
+    ...(trailPriceMicros === undefined ? {} : { trailPriceMicros }),
+    ...(highWaterMarkMicros === undefined ? {} : { highWaterMarkMicros }),
     observedAt,
   }
 }
@@ -817,6 +831,7 @@ const normalizeFillActivity = (raw: typeof FillActivityResponseSchema.Type, acco
   ) {
     throw new Error(`fill activity type ${raw.type} is inconsistent with leaves quantity`)
   }
+  const orderStatus = raw.order_status
   return {
     accountId,
     activityId: raw.id,
@@ -829,7 +844,7 @@ const normalizeFillActivity = (raw: typeof FillActivityResponseSchema.Type, acco
     transactionTime: raw.transaction_time,
     brokerOrderId: raw.order_id,
     type: raw.type,
-    orderStatus: raw.order_status,
+    ...(orderStatus === undefined ? {} : { orderStatus }),
   }
 }
 
@@ -1211,21 +1226,31 @@ export const verifyReadAccess = (read: BrokerReadShape): Effect.Effect<ReadPrefl
             orderById: verifyOrderLookup('order-by-id', order, read.orderById(order.brokerOrderId)),
             orderByClientId: verifyOrderLookup('order-by-client-id', order, read.orderByClientId(order.clientOrderId)),
           })
-    const proof: ReadPreflight = {
-      accountId: account.value.id,
-      accountHash: canonicalHashV1(account.value),
-      positionCount: responses.positions.value.length,
-      positionsHash: canonicalHashV1(responses.positions.value),
-      openOrderCount: responses.openOrders.value.length,
-      recentOrderCount: responses.recentOrders.value.length,
-      ordersHash: canonicalHashV1({
-        open: responses.openOrders.value,
-        recent: responses.recentOrders.value,
+    const proof = yield* Effect.try({
+      try: (): ReadPreflight => ({
+        accountId: account.value.id,
+        accountHash: canonicalHashV1(account.value),
+        positionCount: responses.positions.value.length,
+        positionsHash: canonicalHashV1(responses.positions.value),
+        openOrderCount: responses.openOrders.value.length,
+        recentOrderCount: responses.recentOrders.value.length,
+        ordersHash: canonicalHashV1({
+          open: responses.openOrders.value,
+          recent: responses.recentOrders.value,
+        }),
+        fillCount: responses.fills.value.items.length,
+        fillsHash: canonicalHashV1(responses.fills.value.items),
+        ...lookups,
       }),
-      fillCount: responses.fills.value.items.length,
-      fillsHash: canonicalHashV1(responses.fills.value.items),
-      ...lookups,
-    }
+      catch: (cause) =>
+        new BrokerReadError({
+          operation: 'preflight',
+          kind: BrokerReadErrorKind.InvalidResponse,
+          message: 'Alpaca observe-only preflight data is not canonical JSON',
+          retryable: false,
+          cause: safeCause(cause),
+        }),
+    })
     yield* Effect.logInfo('Alpaca observe-only read preflight passed').pipe(
       Effect.annotateLogs({
         accountId: proof.accountId,

--- a/services/bayn/src/broker/observations.test.ts
+++ b/services/bayn/src/broker/observations.test.ts
@@ -177,6 +177,7 @@ describe('paper broker observations', () => {
       intentId: 'b'.repeat(64),
       occurredAt: '2026-07-22T15:30:00.000Z',
     })
+    expect(event.sourceTimestamp).toBe('2026-07-22T15:30:00.000987000Z')
     expect(() => fillObservation({ ...activity, symbol: 'AMD' }, order, evidence)).toThrow(
       'Alpaca fill activity does not match its order',
     )

--- a/services/bayn/src/broker/observations.ts
+++ b/services/bayn/src/broker/observations.ts
@@ -17,6 +17,7 @@ import {
   Sha256Schema as Sha256,
   StrictNonEmptyStringSchema as NonEmptyString,
   UtcInstantSchema as UtcInstant,
+  UtcOrderTimestampSchema as UtcOrderTimestamp,
   strictParseOptions,
 } from '../schemas'
 import {
@@ -46,13 +47,14 @@ export const BrokerEventInputSchema = Schema.TaggedUnion({
   Account: { ...CommonEventInput, account: AccountSnapshotSchema },
   Position: { ...CommonEventInput, position: PositionSchema },
   Order: { ...CommonEventInput, order: OrderSchema },
-  Fill: { ...CommonEventInput, fill: FillSchema },
+  Fill: { ...CommonEventInput, sourceTimestamp: UtcOrderTimestamp, fill: FillSchema },
 })
 export type BrokerEventInput = typeof BrokerEventInputSchema.Type
 
 export const FillEventInputSchema = Schema.Struct({
   _tag: Schema.Literal('Fill'),
   ...CommonEventInput,
+  sourceTimestamp: UtcOrderTimestamp,
   fill: FillSchema,
 })
 export type FillEventInput = typeof FillEventInputSchema.Type
@@ -84,6 +86,12 @@ const decodePosition = Schema.decodeUnknownSync(PositionEventInputSchema, strict
 const decodePositionSnapshot = Schema.decodeUnknownSync(PositionSnapshotInputSchema, strictParseOptions)
 
 const canonicalInstant = (value: string): string => new Date(value).toISOString()
+
+export const sourceTimestamp = (value: string): string => {
+  const match = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(?:\.(\d{1,9}))?Z$/.exec(value)
+  if (match === null) throw new Error('broker timestamp is not a UTC RFC 3339 instant')
+  return `${match[1]}.${(match[2] ?? '').padEnd(9, '0')}Z`
+}
 
 const assertObservationTime = (observedAt: string, evidence: ReadEvidence): void => {
   if (observedAt !== evidence.observedAt) throw new Error('normalized broker payload and response evidence disagree')
@@ -330,6 +338,7 @@ export const fillObservation = (
     broker: Broker.Alpaca,
     accountId: fill.accountId,
     sourceEventId: fill.fillId,
+    sourceTimestamp: sourceTimestamp(activity.transactionTime),
     contentHash: canonicalHashV1({
       schemaVersion: 'bayn.paper-fill-source.v1',
       fill,

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -23,7 +23,7 @@ import {
 } from '../paper'
 import { makeQualificationResult } from '../qualification'
 import { evaluateRiskBalancedTrend } from '../risk-balanced-trend'
-import { makeStrategy } from '../strategy-service'
+import { makeStrategy } from '../strategy'
 import { makeSnapshot, makeTestProvenance, fixtureProtocol } from '../test-fixtures'
 import type { Protocol } from '../types'
 import {

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -279,6 +279,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       { migration_id: 6, name: 'current_risk_clock' },
       { migration_id: 7, name: 'accounting' },
       { migration_id: 8, name: 'identified_submit_unknown' },
+      { migration_id: 9, name: 'fill_source_timestamp' },
     ])
   })
 
@@ -1500,10 +1501,11 @@ describePostgres('PostgreSQL evaluation evidence', () => {
             yield* sql`
               INSERT INTO fills (
                 event_id, account_id, schema_version, fill_id, broker_order_id, client_order_id,
-                symbol, side, quantity_micros, price_micros, fee_micros
+                symbol, side, quantity_micros, price_micros, fee_micros, source_timestamp
               ) VALUES (
                 ${fillEventId}, 'paper-account-1', 'bayn.paper-fill.v1', 'fill-1', 'broker-order-1',
-                'client-order-1', 'NVDA', 'BUY', 1000000, 1250000, 0
+                'client-order-1', 'NVDA', 'BUY', 1000000, 1250000, 0,
+                '2026-07-22T06:00:30.000000000Z'
               )
             `
             yield* sql`

--- a/services/bayn/src/db/migrations.ts
+++ b/services/bayn/src/db/migrations.ts
@@ -8,6 +8,7 @@ import mutationRecovery from '../../migrations/0005_mutation_recovery'
 import currentRiskClock from '../../migrations/0006_current_risk_clock'
 import accounting from '../../migrations/0007_accounting'
 import identifiedSubmitUnknown from '../../migrations/0008_identified_submit_unknown'
+import fillSourceTimestamp from '../../migrations/0009_fill_source_timestamp'
 
 export const migrationLoader = PgMigrator.fromRecord({
   '1_initial_schema': initialSchema,
@@ -18,4 +19,5 @@ export const migrationLoader = PgMigrator.fromRecord({
   '6_current_risk_clock': currentRiskClock,
   '7_accounting': accounting,
   '8_identified_submit_unknown': identifiedSubmitUnknown,
+  '9_fill_source_timestamp': fillSourceTimestamp,
 })

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -590,8 +590,9 @@ describePostgres('paper accounting persistence', () => {
         Effect.gen(function* () {
           const store = yield* PaperStore
           const arrivedFirst = yield* store.ingest(second)
-          yield* store.account(first)
+          const firstReceipt = yield* store.account(first)
           yield* store.account(second)
+          const replay = yield* store.account(first)
           const rejected = yield* Effect.exit(store.account(latePredecessor))
           const sql = yield* PgClient.PgClient
           const transactions = yield* sql<{
@@ -616,11 +617,12 @@ describePostgres('paper accounting persistence', () => {
               (SELECT count(*)::integer FROM broker_events) AS events,
               (SELECT count(*)::integer FROM accounting_transactions) AS transactions
           `
-          return { arrivedFirst, rejected, transactions, counts }
+          return { arrivedFirst, firstReceipt, replay, rejected, transactions, counts }
         }),
       )
 
       expect(result.arrivedFirst).toMatchObject({ sourceSequence: '0', deduplicated: false })
+      expect(result.replay).toEqual(result.firstReceipt)
       expect(result.transactions).toEqual([
         {
           source_event_id: 'fill-a',
@@ -642,7 +644,7 @@ describePostgres('paper accounting persistence', () => {
         expect(Cause.pretty(result.rejected.cause)).toContain('later fill was already accounted')
       }
       expect(result.counts).toEqual({ events: 2, transactions: 2 })
-      expect(control.planHashes).toHaveLength(2)
+      expect(control.planHashes).toHaveLength(3)
     } finally {
       await runtime.dispose()
     }

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -148,7 +148,13 @@ const orderEvent = (): Extract<BrokerEventInput, { readonly _tag: 'Order' }> => 
   },
 })
 
-const fillEvent = (id: string, side: OrderSide, quantityMicros: string, priceMicros: string): FillEventInput => {
+const fillEvent = (
+  id: string,
+  side: OrderSide,
+  quantityMicros: string,
+  priceMicros: string,
+  eventOccurredAt = occurredAt,
+): FillEventInput => {
   const fill = {
     schemaVersion: 'bayn.paper-fill.v1' as const,
     accountId,
@@ -160,7 +166,7 @@ const fillEvent = (id: string, side: OrderSide, quantityMicros: string, priceMic
     quantityMicros,
     priceMicros,
     feeMicros: '100',
-    occurredAt,
+    occurredAt: eventOccurredAt,
   }
   return {
     _tag: 'Fill',
@@ -168,7 +174,7 @@ const fillEvent = (id: string, side: OrderSide, quantityMicros: string, priceMic
     accountId,
     sourceEventId: id,
     contentHash: canonicalHashV1({ schemaVersion: 'bayn.paper-fill-source.v1', fill }),
-    occurredAt,
+    occurredAt: eventOccurredAt,
     observedAt,
     fill,
   }
@@ -568,6 +574,107 @@ describePostgres('paper accounting persistence', () => {
         equityMicros: '1000000000',
       })
       expect(result.counts).toEqual({ position_snapshots: 2, positions: 2, valuations: 2 })
+    } finally {
+      await runtime.dispose()
+    }
+  }, 15_000)
+
+  test('derives cost basis in broker economic order and rejects a late predecessor', async () => {
+    const control: JournalControl = { fail: false, planHashes: [] }
+    const runtime = makeStoreRuntime(control)
+    const first = fillEvent('fill-a', OrderSide.Buy, '3000000', '100000000', '2026-07-22T15:29:59.000Z')
+    const second = fillEvent('fill-b', OrderSide.Sell, '1000000', '120000000')
+    const latePredecessor = fillEvent('fill-0', OrderSide.Buy, '1000000', '90000000', '2026-07-22T15:29:58.000Z')
+    try {
+      const result = await runtime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* PaperStore
+          const arrivedFirst = yield* store.ingest(second)
+          yield* store.account(first)
+          yield* store.account(second)
+          const rejected = yield* Effect.exit(store.account(latePredecessor))
+          const sql = yield* PgClient.PgClient
+          const transactions = yield* sql<{
+            cost_basis_micros: string
+            realized_pnl_micros: string
+            side: string
+            source_event_id: string
+            source_sequence: string
+          }>`
+            SELECT
+              event.source_event_id,
+              event.source_sequence::text,
+              transaction.side,
+              transaction.cost_basis_micros::text,
+              transaction.realized_pnl_micros::text
+            FROM accounting_transactions AS transaction
+            JOIN broker_events AS event ON event.event_id = transaction.broker_event_id
+            ORDER BY event.occurred_at, event.source_event_id COLLATE "C"
+          `
+          const [counts] = yield* sql<{ events: number; transactions: number }>`
+            SELECT
+              (SELECT count(*)::integer FROM broker_events) AS events,
+              (SELECT count(*)::integer FROM accounting_transactions) AS transactions
+          `
+          return { arrivedFirst, rejected, transactions, counts }
+        }),
+      )
+
+      expect(result.arrivedFirst).toMatchObject({ sourceSequence: '0', deduplicated: false })
+      expect(result.transactions).toEqual([
+        {
+          source_event_id: 'fill-a',
+          source_sequence: '1',
+          side: 'BUY',
+          cost_basis_micros: '300000000',
+          realized_pnl_micros: '0',
+        },
+        {
+          source_event_id: 'fill-b',
+          source_sequence: '0',
+          side: 'SELL',
+          cost_basis_micros: '100000000',
+          realized_pnl_micros: '20000000',
+        },
+      ])
+      expect(Exit.isFailure(result.rejected)).toBe(true)
+      if (Exit.isFailure(result.rejected)) {
+        expect(Cause.pretty(result.rejected.cause)).toContain('later fill was already accounted')
+      }
+      expect(result.counts).toEqual({ events: 2, transactions: 2 })
+      expect(control.planHashes).toHaveLength(2)
+    } finally {
+      await runtime.dispose()
+    }
+  }, 15_000)
+
+  test('fails closed when an economic predecessor has no accounting transaction', async () => {
+    const control: JournalControl = { fail: false, planHashes: [] }
+    const runtime = makeStoreRuntime(control)
+    const first = fillEvent('fill-missing', OrderSide.Buy, '1000000', '100000000', '2026-07-22T15:29:59.000Z')
+    const second = fillEvent('fill-later', OrderSide.Sell, '1000000', '120000000')
+    try {
+      const result = await runtime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* PaperStore
+          yield* store.ingest(first)
+          const rejected = yield* Effect.exit(store.account(second))
+          const sql = yield* PgClient.PgClient
+          const [counts] = yield* sql<{ events: number; transactions: number }>`
+            SELECT
+              (SELECT count(*)::integer FROM broker_events) AS events,
+              (SELECT count(*)::integer FROM accounting_transactions) AS transactions
+          `
+          return { rejected, counts }
+        }),
+      )
+
+      expect(Exit.isFailure(result.rejected)).toBe(true)
+      if (Exit.isFailure(result.rejected)) {
+        expect(Cause.pretty(result.rejected.cause)).toContain('earlier fill has not been posted')
+      }
+      expect(result.counts).toEqual({ events: 1, transactions: 0 })
+      expect(control.planHashes).toHaveLength(0)
     } finally {
       await runtime.dispose()
     }

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -20,12 +20,13 @@ import {
   ReconciliationStatus,
   TimeInForce,
 } from '../paper'
-import type {
-  BrokerEventInput,
-  FillEventInput,
-  PositionEventInput,
-  PositionSnapshotInput,
-  ValuationInput,
+import {
+  sourceTimestamp,
+  type BrokerEventInput,
+  type FillEventInput,
+  type PositionEventInput,
+  type PositionSnapshotInput,
+  type ValuationInput,
 } from '../broker/observations'
 import { EvidenceStore, EvidenceStoreLive, PostgresClientLive } from './evidence-store'
 import { PaperStore, PaperStoreLive } from './paper-store'
@@ -154,6 +155,7 @@ const fillEvent = (
   quantityMicros: string,
   priceMicros: string,
   eventOccurredAt = occurredAt,
+  brokerTimestamp = sourceTimestamp(eventOccurredAt),
 ): FillEventInput => {
   const fill = {
     schemaVersion: 'bayn.paper-fill.v1' as const,
@@ -173,7 +175,12 @@ const fillEvent = (
     broker: Broker.Alpaca,
     accountId,
     sourceEventId: id,
-    contentHash: canonicalHashV1({ schemaVersion: 'bayn.paper-fill-source.v1', fill }),
+    sourceTimestamp: brokerTimestamp,
+    contentHash: canonicalHashV1({
+      schemaVersion: 'bayn.paper-fill-source.v1',
+      fill,
+      brokerTransactionTime: brokerTimestamp,
+    }),
     occurredAt: eventOccurredAt,
     observedAt,
     fill,
@@ -582,9 +589,30 @@ describePostgres('paper accounting persistence', () => {
   test('derives cost basis in broker economic order and rejects a late predecessor', async () => {
     const control: JournalControl = { fail: false, planHashes: [] }
     const runtime = makeStoreRuntime(control)
-    const first = fillEvent('fill-a', OrderSide.Buy, '3000000', '100000000', '2026-07-22T15:29:59.000Z')
-    const second = fillEvent('fill-b', OrderSide.Sell, '1000000', '120000000')
-    const latePredecessor = fillEvent('fill-0', OrderSide.Buy, '1000000', '90000000', '2026-07-22T15:29:58.000Z')
+    const first = fillEvent(
+      'fill-z',
+      OrderSide.Buy,
+      '3000000',
+      '100000000',
+      occurredAt,
+      '2026-07-22T15:30:00.000100000Z',
+    )
+    const second = fillEvent(
+      'fill-a',
+      OrderSide.Sell,
+      '1000000',
+      '120000000',
+      occurredAt,
+      '2026-07-22T15:30:00.000900000Z',
+    )
+    const latePredecessor = fillEvent(
+      'fill-0',
+      OrderSide.Buy,
+      '1000000',
+      '90000000',
+      occurredAt,
+      '2026-07-22T15:30:00.000050000Z',
+    )
     try {
       const result = await runtime.runPromise(
         Effect.gen(function* () {
@@ -610,7 +638,8 @@ describePostgres('paper accounting persistence', () => {
               transaction.realized_pnl_micros::text
             FROM accounting_transactions AS transaction
             JOIN broker_events AS event ON event.event_id = transaction.broker_event_id
-            ORDER BY event.occurred_at, event.source_event_id COLLATE "C"
+            JOIN fills AS fill ON fill.event_id = event.event_id
+            ORDER BY fill.source_timestamp COLLATE "C", fill.fill_id COLLATE "C"
           `
           const [counts] = yield* sql<{ events: number; transactions: number }>`
             SELECT
@@ -625,14 +654,14 @@ describePostgres('paper accounting persistence', () => {
       expect(result.replay).toEqual(result.firstReceipt)
       expect(result.transactions).toEqual([
         {
-          source_event_id: 'fill-a',
+          source_event_id: 'fill-z',
           source_sequence: '1',
           side: 'BUY',
           cost_basis_micros: '300000000',
           realized_pnl_micros: '0',
         },
         {
-          source_event_id: 'fill-b',
+          source_event_id: 'fill-a',
           source_sequence: '0',
           side: 'SELL',
           cost_basis_micros: '100000000',

--- a/services/bayn/src/db/paper-store.ts
+++ b/services/bayn/src/db/paper-store.ts
@@ -300,12 +300,12 @@ const makeStore = (config: Pick<RuntimeConfig, 'tigerBeetle'>) =>
           return sql`
             INSERT INTO fills (
               event_id, account_id, schema_version, fill_id, broker_order_id, client_order_id, intent_id,
-              symbol, side, quantity_micros, price_micros, fee_micros
+              symbol, side, quantity_micros, price_micros, fee_micros, source_timestamp
             ) VALUES (
               ${eventId}, ${input.fill.accountId}, ${input.fill.schemaVersion}, ${input.fill.fillId},
               ${input.fill.brokerOrderId}, ${input.fill.clientOrderId}, ${input.fill.intentId ?? null},
               ${input.fill.symbol}, ${input.fill.side}, ${input.fill.quantityMicros}, ${input.fill.priceMicros},
-              ${input.fill.feeMicros}
+              ${input.fill.feeMicros}, ${input.sourceTimestamp}
             )
           `.pipe(Effect.asVoid)
       }
@@ -365,20 +365,20 @@ const makeStore = (config: Pick<RuntimeConfig, 'tigerBeetle'>) =>
 
     const economicallyPrecedes = (input: FillEventInput) => sql`
       (
-        event.occurred_at < ${input.occurredAt}
+        candidate_fill.source_timestamp COLLATE "C" < (${input.sourceTimestamp}::text COLLATE "C")
         OR (
-          event.occurred_at = ${input.occurredAt}
-          AND event.source_event_id COLLATE "C" < (${input.sourceEventId}::text COLLATE "C")
+          candidate_fill.source_timestamp = ${input.sourceTimestamp}
+          AND candidate_fill.fill_id COLLATE "C" < (${input.fill.fillId}::text COLLATE "C")
         )
       )
     `
 
     const economicallyFollows = (input: FillEventInput) => sql`
       (
-        event.occurred_at > ${input.occurredAt}
+        candidate_fill.source_timestamp COLLATE "C" > (${input.sourceTimestamp}::text COLLATE "C")
         OR (
-          event.occurred_at = ${input.occurredAt}
-          AND event.source_event_id COLLATE "C" > (${input.sourceEventId}::text COLLATE "C")
+          candidate_fill.source_timestamp = ${input.sourceTimestamp}
+          AND candidate_fill.fill_id COLLATE "C" > (${input.fill.fillId}::text COLLATE "C")
         )
       )
     `
@@ -391,7 +391,7 @@ const makeStore = (config: Pick<RuntimeConfig, 'tigerBeetle'>) =>
             COALESCE(sum(transaction.quantity_delta_micros), 0)::text AS quantity_micros,
             COALESCE(sum(transaction.cost_basis_delta_micros), 0)::text AS cost_micros
           FROM accounting_transactions AS transaction
-          JOIN broker_events AS event ON event.event_id = transaction.broker_event_id
+          JOIN fills AS candidate_fill ON candidate_fill.event_id = transaction.broker_event_id
           WHERE transaction.account_id = ${input.accountId}
             AND transaction.symbol = ${input.fill.symbol}
             AND ${economicallyPrecedes(input)}
@@ -411,6 +411,7 @@ const makeStore = (config: Pick<RuntimeConfig, 'tigerBeetle'>) =>
           SELECT EXISTS (
             SELECT 1
             FROM broker_events AS event
+            JOIN fills AS candidate_fill ON candidate_fill.event_id = event.event_id
             LEFT JOIN accounting_transactions AS transaction ON transaction.broker_event_id = event.event_id
             LEFT JOIN accounting_receipts AS receipt ON receipt.broker_event_id = transaction.broker_event_id
             WHERE event.broker = ${input.broker}
@@ -436,7 +437,7 @@ const makeStore = (config: Pick<RuntimeConfig, 'tigerBeetle'>) =>
           SELECT EXISTS (
             SELECT 1
             FROM accounting_transactions AS transaction
-            JOIN broker_events AS event ON event.event_id = transaction.broker_event_id
+            JOIN fills AS candidate_fill ON candidate_fill.event_id = transaction.broker_event_id
             WHERE transaction.account_id = ${input.accountId}
               AND transaction.symbol = ${input.fill.symbol}
               AND ${economicallyFollows(input)}

--- a/services/bayn/src/db/paper-store.ts
+++ b/services/bayn/src/db/paper-store.ts
@@ -363,10 +363,27 @@ const makeStore = (config: Pick<RuntimeConfig, 'tigerBeetle'>) =>
         }),
       )
 
-    const priorPosition = (
-      input: FillEventInput,
-      sourceSequence: string,
-    ): Effect.Effect<PositionCost, PaperStoreError> =>
+    const economicallyPrecedes = (input: FillEventInput) => sql`
+      (
+        event.occurred_at < ${input.occurredAt}
+        OR (
+          event.occurred_at = ${input.occurredAt}
+          AND event.source_event_id COLLATE "C" < (${input.sourceEventId}::text COLLATE "C")
+        )
+      )
+    `
+
+    const economicallyFollows = (input: FillEventInput) => sql`
+      (
+        event.occurred_at > ${input.occurredAt}
+        OR (
+          event.occurred_at = ${input.occurredAt}
+          AND event.source_event_id COLLATE "C" > (${input.sourceEventId}::text COLLATE "C")
+        )
+      )
+    `
+
+    const priorPosition = (input: FillEventInput): Effect.Effect<PositionCost, PaperStoreError> =>
       run(
         'account',
         sql<Record<string, unknown>>`
@@ -377,7 +394,7 @@ const makeStore = (config: Pick<RuntimeConfig, 'tigerBeetle'>) =>
           JOIN broker_events AS event ON event.event_id = transaction.broker_event_id
           WHERE transaction.account_id = ${input.accountId}
             AND transaction.symbol = ${input.fill.symbol}
-            AND event.source_sequence < ${sourceSequence}
+            AND ${economicallyPrecedes(input)}
         `.pipe(
           Effect.flatMap(decodePositionCost),
           Effect.map(([position]) => ({
@@ -387,10 +404,32 @@ const makeStore = (config: Pick<RuntimeConfig, 'tigerBeetle'>) =>
         ),
       )
 
-    const requirePostedPredecessors = (
-      input: FillEventInput,
-      sourceSequence: string,
-    ): Effect.Effect<void, PaperStoreError> =>
+    const requirePostedPredecessors = (input: FillEventInput): Effect.Effect<void, PaperStoreError> =>
+      run(
+        'account',
+        sql<Record<string, unknown>>`
+          SELECT EXISTS (
+            SELECT 1
+            FROM broker_events AS event
+            LEFT JOIN accounting_transactions AS transaction ON transaction.broker_event_id = event.event_id
+            LEFT JOIN accounting_receipts AS receipt ON receipt.broker_event_id = transaction.broker_event_id
+            WHERE event.broker = ${input.broker}
+              AND event.account_id = ${input.accountId}
+              AND event.event_kind = 'FILL'
+              AND ${economicallyPrecedes(input)}
+              AND (transaction.transaction_id IS NULL OR receipt.receipt_id IS NULL)
+          ) AS unresolved
+        `.pipe(
+          Effect.flatMap(decodeUnresolvedPredecessor),
+          Effect.flatMap(([result]) =>
+            result.unresolved
+              ? fail('account', 'conflict', 'an earlier fill has not been posted to TigerBeetle')
+              : Effect.void,
+          ),
+        ),
+      )
+
+    const requireNoPreparedSuccessors = (input: FillEventInput): Effect.Effect<void, PaperStoreError> =>
       run(
         'account',
         sql<Record<string, unknown>>`
@@ -398,16 +437,15 @@ const makeStore = (config: Pick<RuntimeConfig, 'tigerBeetle'>) =>
             SELECT 1
             FROM accounting_transactions AS transaction
             JOIN broker_events AS event ON event.event_id = transaction.broker_event_id
-            LEFT JOIN accounting_receipts AS receipt ON receipt.broker_event_id = transaction.broker_event_id
             WHERE transaction.account_id = ${input.accountId}
-              AND event.source_sequence < ${sourceSequence}
-              AND receipt.receipt_id IS NULL
+              AND transaction.symbol = ${input.fill.symbol}
+              AND ${economicallyFollows(input)}
           ) AS unresolved
         `.pipe(
           Effect.flatMap(decodeUnresolvedPredecessor),
           Effect.flatMap(([result]) =>
             result.unresolved
-              ? fail('account', 'conflict', 'an earlier fill has not been posted to TigerBeetle')
+              ? fail('account', 'conflict', 'a later fill was already accounted before this economic predecessor')
               : Effect.void,
           ),
         ),
@@ -464,8 +502,9 @@ const makeStore = (config: Pick<RuntimeConfig, 'tigerBeetle'>) =>
         sql.withTransaction(
           Effect.gen(function* () {
             const event = yield* append(input)
-            yield* requirePostedPredecessors(input, event.sourceSequence)
-            const position = yield* priorPosition(input, event.sourceSequence)
+            yield* requirePostedPredecessors(input)
+            yield* requireNoPreparedSuccessors(input)
+            const position = yield* priorPosition(input)
             const expected = yield* Effect.try({
               try: () => prepareAccounting(event.eventId, input.fill, position, config.tigerBeetle.ledger),
               catch: (cause) => error('account', 'invariant', 'fill accounting plan is invalid', cause),

--- a/services/bayn/src/db/paper-store.ts
+++ b/services/bayn/src/db/paper-store.ts
@@ -502,14 +502,14 @@ const makeStore = (config: Pick<RuntimeConfig, 'tigerBeetle'>) =>
         sql.withTransaction(
           Effect.gen(function* () {
             const event = yield* append(input)
+            const stored = yield* readPrepared(event.eventId)
             yield* requirePostedPredecessors(input)
-            yield* requireNoPreparedSuccessors(input)
+            if (stored === undefined) yield* requireNoPreparedSuccessors(input)
             const position = yield* priorPosition(input)
             const expected = yield* Effect.try({
               try: () => prepareAccounting(event.eventId, input.fill, position, config.tigerBeetle.ledger),
               catch: (cause) => error('account', 'invariant', 'fill accounting plan is invalid', cause),
             })
-            const stored = yield* readPrepared(event.eventId)
             if (stored === undefined) {
               yield* insertPrepared(expected)
               return expected

--- a/services/bayn/src/ledger.test.ts
+++ b/services/bayn/src/ledger.test.ts
@@ -199,6 +199,18 @@ describe('TigerBeetle simulation journal', () => {
       { quantityMicros: '0', costMicros: '0' },
       journalConfig.tigerBeetle.ledger,
     ).ledger
+    const invalidTarget = makeLedgerClient()
+    const invalidPlan = {
+      ...plan,
+      transfers: plan.transfers.map((transfer, index) => (index === 0 ? { ...transfer, user_data_128: 0n } : transfer)),
+    }
+    const invalid = await Effect.runPromise(
+      Effect.flip(withJournal(invalidTarget.client, (journal) => journal.post(invalidPlan))),
+    )
+    expect(invalid.message).toContain('nonzero transaction tag')
+    expect(invalidTarget.accounts.size).toBe(0)
+    expect(invalidTarget.transfers.size).toBe(0)
+
     const target = makeLedgerClient()
 
     const exact = await Effect.runPromise(

--- a/services/bayn/src/ledger.test.ts
+++ b/services/bayn/src/ledger.test.ts
@@ -100,6 +100,7 @@ const makeLedgerClient = () => {
         .filter(
           (transfer) =>
             transfer.ledger === filter.ledger &&
+            (filter.user_data_128 === 0n || transfer.user_data_128 === filter.user_data_128) &&
             (filter.user_data_64 === 0n || transfer.user_data_64 === filter.user_data_64),
         )
         .slice(0, filter.limit),
@@ -221,6 +222,10 @@ describe('TigerBeetle simulation journal', () => {
     expect(error.message).toContain('does not match its plan')
 
     target.transfers.set(plan.transfers[0].id + 1n, { ...plan.transfers[0], id: plan.transfers[0].id + 1n })
+    const postWithExtra = await Effect.runPromise(
+      Effect.flip(withJournal(target.client, (journal) => journal.post(plan))),
+    )
+    expect(postWithExtra.message).toContain('transfer set mismatch')
     const extra = await Effect.runPromise(
       withJournal(target.client, (journal) => journal.verifyAccount(fill.accountId, [plan])),
     )

--- a/services/bayn/src/ledger.ts
+++ b/services/bayn/src/ledger.ts
@@ -256,9 +256,9 @@ const post = (client: TigerBeetleRequestClient, plan: LedgerPlan): Effect.Effect
     if (plan.accounts.length >= BATCH_MAX || plan.transfers.length >= BATCH_MAX) {
       return yield* Effect.fail(operationalError('journal', 'post', 'TigerBeetle posting plan exceeds batch limits'))
     }
+    const transferQuery = yield* validate('build-transaction-transfer-query', () => transactionTransferQuery(plan))
     yield* createAndVerifyAccounts(client, plan.accounts)
     yield* createAndVerifyTransfers(client, plan.transfers)
-    const transferQuery = yield* validate('build-transaction-transfer-query', () => transactionTransferQuery(plan))
     const [accounts, transfers] = yield* Effect.all(
       [
         client.request('verify-posted-accounts', (active) =>

--- a/services/bayn/src/ledger.ts
+++ b/services/bayn/src/ledger.ts
@@ -113,6 +113,24 @@ const queryFilter = (ledger: number): QueryFilter => ({
   flags: 0,
 })
 
+const transactionTransferQuery = (plan: LedgerPlan): QueryFilter => {
+  const first = plan.transfers[0]
+  if (first === undefined) throw new Error('accounting plan contains no transfers')
+  if (
+    first.user_data_128 === 0n ||
+    plan.transfers.some(
+      (transfer) => transfer.ledger !== first.ledger || transfer.user_data_128 !== first.user_data_128,
+    )
+  ) {
+    throw new Error('accounting transfers do not share one nonzero transaction tag and ledger')
+  }
+  return {
+    ...queryFilter(first.ledger),
+    user_data_128: first.user_data_128,
+    limit: plan.transfers.length + 1,
+  }
+}
+
 const assertPersistedRun = (
   result: ReconciliationResult,
   ledger: number,
@@ -240,14 +258,13 @@ const post = (client: TigerBeetleRequestClient, plan: LedgerPlan): Effect.Effect
     }
     yield* createAndVerifyAccounts(client, plan.accounts)
     yield* createAndVerifyTransfers(client, plan.transfers)
+    const transferQuery = yield* validate('build-transaction-transfer-query', () => transactionTransferQuery(plan))
     const [accounts, transfers] = yield* Effect.all(
       [
         client.request('verify-posted-accounts', (active) =>
           active.lookupAccounts(plan.accounts.map((account) => account.id)),
         ),
-        client.request('verify-posted-transfers', (active) =>
-          active.lookupTransfers(plan.transfers.map((transfer) => transfer.id)),
-        ),
+        client.request('verify-posted-transfers', (active) => active.queryTransfers(transferQuery)),
       ],
       { concurrency: 'unbounded' },
     )

--- a/services/bayn/src/paper.test.ts
+++ b/services/bayn/src/paper.test.ts
@@ -171,7 +171,7 @@ describe('paper contracts', () => {
       { _tag: 'Account' as const, ...source, account },
       { _tag: 'Position' as const, ...source, position },
       { _tag: 'Order' as const, ...source, order },
-      { _tag: 'Fill' as const, ...source, fill },
+      { _tag: 'Fill' as const, ...source, sourceTimestamp: '2026-07-22T06:00:00.000000000Z', fill },
       { _tag: 'Error' as const, ...source, error: brokerError },
       { _tag: 'RateLimit' as const, ...source, rateLimit },
     ]

--- a/services/bayn/src/paper.ts
+++ b/services/bayn/src/paper.ts
@@ -5,6 +5,7 @@ import {
   StrictNonEmptyStringSchema as NonEmptyString,
   SymbolSchema as SymbolName,
   UtcInstantSchema as UtcInstant,
+  UtcOrderTimestampSchema as UtcOrderTimestamp,
   strictParseOptions as StrictParseOptions,
 } from './schemas'
 
@@ -290,7 +291,7 @@ const BrokerEventBase = Schema.TaggedUnion({
   Account: { ...SourceFields, account: AccountSnapshotSchema },
   Position: { ...SourceFields, position: PositionSchema },
   Order: { ...SourceFields, order: OrderSchema },
-  Fill: { ...SourceFields, fill: FillSchema },
+  Fill: { ...SourceFields, sourceTimestamp: UtcOrderTimestamp, fill: FillSchema },
   Error: { ...SourceFields, error: BrokerErrorSchema },
   RateLimit: { ...SourceFields, rateLimit: RateLimitSchema },
 })

--- a/services/bayn/src/reconciler.test.ts
+++ b/services/bayn/src/reconciler.test.ts
@@ -269,12 +269,12 @@ describe('paper reconciliation loop', () => {
     const laterOrder = { ...order(1), submittedAt: '2026-07-22T12:00:01.000Z' }
     const earlierFill = {
       ...fill(0, earlierOrder),
-      activityId: 'fill-earlier',
+      activityId: 'fill-z',
       transactionTime: '2026-07-22T12:00:00.1Z',
     }
     const laterFill = {
       ...fill(1, laterOrder),
-      activityId: 'fill-later',
+      activityId: 'fill-a',
       transactionTime: '2026-07-22T12:00:00.100001Z',
     }
     const read: BrokerReadShape = {

--- a/services/bayn/src/reconciler.ts
+++ b/services/bayn/src/reconciler.ts
@@ -15,6 +15,7 @@ import {
   fillObservation,
   orderObservation,
   positionSnapshot,
+  sourceTimestamp,
   type BrokerEventInput,
   type FillEventInput,
 } from './broker/observations'
@@ -54,11 +55,7 @@ const failure = (operation: ReconciliationError['operation'], message: string, c
 const attempt = <A>(operation: ReconciliationError['operation'], message: string, evaluate: () => A) =>
   Effect.try({ try: evaluate, catch: (cause) => failure(operation, message, cause) })
 
-const timestampOrderKey = (value: string): string => {
-  const separator = value.indexOf('.')
-  if (separator === -1) return `${value.slice(0, -1)}.000000000Z`
-  return `${value.slice(0, separator)}.${value.slice(separator + 1, -1).padEnd(9, '0')}Z`
-}
+const compareText = (left: string, right: string): number => (left < right ? -1 : left > right ? 1 : 0)
 
 const readOrders = (
   read: BrokerReadShape,
@@ -90,11 +87,11 @@ const readOrders = (
       for (const order of page.value) {
         if (
           previousSubmittedAt !== undefined &&
-          timestampOrderKey(order.submittedAt) < timestampOrderKey(previousSubmittedAt)
+          sourceTimestamp(order.submittedAt) < sourceTimestamp(previousSubmittedAt)
         ) {
           return yield* Effect.fail(failure('pagination', 'Alpaca order history is not ascending'))
         }
-        if (cursor !== undefined && timestampOrderKey(order.submittedAt) <= timestampOrderKey(cursor)) {
+        if (cursor !== undefined && sourceTimestamp(order.submittedAt) <= sourceTimestamp(cursor)) {
           return yield* Effect.fail(failure('pagination', 'Alpaca order timestamp cursor did not advance'))
         }
         if (ids.has(order.brokerOrderId)) {
@@ -236,10 +233,11 @@ const run = (
 
           const fillEvents = [...fills]
             .sort((left, right) => {
-              const byTime = timestampOrderKey(left.value.transactionTime).localeCompare(
-                timestampOrderKey(right.value.transactionTime),
+              const byTime = compareText(
+                sourceTimestamp(left.value.transactionTime),
+                sourceTimestamp(right.value.transactionTime),
               )
-              return byTime === 0 ? left.value.activityId.localeCompare(right.value.activityId) : byTime
+              return byTime === 0 ? compareText(left.value.activityId, right.value.activityId) : byTime
             })
             .map((observed): FillEventInput => {
               const order = orderById.get(observed.value.brokerOrderId)

--- a/services/bayn/src/risk.test.ts
+++ b/services/bayn/src/risk.test.ts
@@ -338,6 +338,16 @@ describe('bounded paper risk', () => {
     expect(result.metrics.postTradeSymbolExposureMicros).toBe('0')
   })
 
+  test('blocks a sell that would open a short position', () => {
+    const intent = makeIntent({ side: OrderSide.Sell, quantityMicros: '2000000', notionalLimitMicros: '200000000' })
+    const policy = makePolicy({
+      maxOrderNotionalMicros: '200000000',
+      maxDailyTradedNotionalMicros: '300000000',
+    })
+
+    expectBlocked(Reason.ShortPositionNotAllowed, intent, makeState(), policy)
+  })
+
   test('revalues the current symbol at the current reference price before projecting exposure', () => {
     const state = makeState({
       account: { ...baseState().account, buyingPowerMicros: '200000000' },
@@ -366,7 +376,7 @@ describe('bounded paper risk', () => {
     )
   })
 
-  test('projects short exposure at the current quote instead of the lower expected sell price', () => {
+  test('blocks an existing short while retaining conservative exposure metrics', () => {
     const positions = [
       baseState().positions[0],
       {
@@ -394,7 +404,8 @@ describe('bounded paper risk', () => {
     })
     const result = evaluate(intent, state, policy)
 
-    expect(result.decision.outcome).toBe(RiskOutcome.Approved)
+    expect(result.decision.outcome).toBe(RiskOutcome.Blocked)
+    expect(result.decision.reasonCodes).toContain(Reason.ShortPositionNotAllowed)
     expect(result.metrics.orderNotionalMicros).toBe('198000000')
     expect(result.metrics.postTradeSymbolExposureMicros).toBe('-400000000')
     expectBlocked(

--- a/services/bayn/src/risk.ts
+++ b/services/bayn/src/risk.ts
@@ -88,6 +88,7 @@ export enum Gate {
   OrderNotional = 'order_notional',
   BuyingPower = 'buying_power',
   AdverseSlippage = 'adverse_slippage',
+  LongOnly = 'long_only',
   SymbolExposure = 'symbol_exposure',
   GrossExposure = 'gross_exposure',
   NetExposure = 'net_exposure',
@@ -119,6 +120,7 @@ export enum Reason {
   OrderNotionalExceeded = 'ORDER_NOTIONAL_EXCEEDED',
   BuyingPowerExceeded = 'BUYING_POWER_EXCEEDED',
   AdverseSlippageExceeded = 'ADVERSE_SLIPPAGE_EXCEEDED',
+  ShortPositionNotAllowed = 'SHORT_POSITION_NOT_ALLOWED',
   SymbolExposureExceeded = 'SYMBOL_EXPOSURE_EXCEEDED',
   GrossExposureExceeded = 'GROSS_EXPOSURE_EXCEEDED',
   NetExposureExceeded = 'NET_EXPOSURE_EXCEEDED',
@@ -328,8 +330,8 @@ export const evaluate = (intent: Intent, state: State, policy: Policy): Evaluati
     .filter((position) => position.symbol === intent.symbol)
     .reduce((total, position) => total + BigInt(position.quantityMicros), 0n)
   const currentSymbolExposureNumerator = currentSymbolQuantity * referencePrice
-  const postTradeSymbolExposureNumerator =
-    (currentSymbolQuantity + direction * BigInt(intent.quantityMicros)) * referencePrice
+  const postTradeSymbolQuantity = currentSymbolQuantity + direction * BigInt(intent.quantityMicros)
+  const postTradeSymbolExposureNumerator = postTradeSymbolQuantity * referencePrice
   const postTradeSymbolExposure = divideAwayFromZero(postTradeSymbolExposureNumerator, QUANTITY_SCALE)
   const postTradeSymbolExposureMagnitude = divideUp(absolute(postTradeSymbolExposureNumerator), QUANTITY_SCALE)
   const otherGrossExposure = state.positions
@@ -520,6 +522,13 @@ export const evaluate = (intent: Intent, state: State, policy: Policy): Evaluati
       adverseSlippageBps <= BigInt(policy.maxAdverseSlippageBps),
       adverseSlippageBps,
       `<=${policy.maxAdverseSlippageBps}`,
+    ),
+    makeGate(
+      Gate.LongOnly,
+      Reason.ShortPositionNotAllowed,
+      currentSymbolQuantity >= 0n && postTradeSymbolQuantity >= 0n,
+      `${currentSymbolQuantity}:${postTradeSymbolQuantity}`,
+      '>=0:>=0',
     ),
     makeGate(
       Gate.SymbolExposure,

--- a/services/bayn/src/schemas.ts
+++ b/services/bayn/src/schemas.ts
@@ -14,6 +14,13 @@ const isUtcInstant = (value: string): boolean => {
   return !Number.isNaN(date.getTime()) && date.toISOString() === value
 }
 
+const isUtcOrderTimestamp = (value: string): boolean => {
+  const match = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})\.(\d{9})Z$/.exec(value)
+  if (match === null) return false
+  const date = new Date(`${match[1]}.${match[2].slice(0, 3)}Z`)
+  return !Number.isNaN(date.getTime()) && date.toISOString().slice(0, 19) === match[1]
+}
+
 export const StrictNonEmptyStringSchema = Schema.String.check(
   Schema.makeFilter((value: string) => value.length > 0 && value.trim() === value, {
     expected: 'a non-empty string without surrounding whitespace',
@@ -24,6 +31,11 @@ export const IsoDateSchema = Schema.String.pipe(Schema.refine(isIsoDate, { expec
 export type IsoDate = typeof IsoDateSchema.Type
 export const UtcInstantSchema = Schema.String.check(
   Schema.makeFilter(isUtcInstant, { expected: 'a canonical UTC instant (YYYY-MM-DDTHH:mm:ss.sssZ)' }),
+)
+export const UtcOrderTimestampSchema = Schema.String.check(
+  Schema.makeFilter(isUtcOrderTimestamp, {
+    expected: 'a canonical UTC ordering timestamp (YYYY-MM-DDTHH:mm:ss.nnnnnnnnnZ)',
+  }),
 )
 export const Sha256Schema = Schema.String.check(Schema.isPattern(/^[a-f0-9]{64}$/))
 export const ImageDigestSchema = Schema.String.check(Schema.isPattern(/^sha256:[a-f0-9]{64}$/))

--- a/services/bayn/src/strategy-service.ts
+++ b/services/bayn/src/strategy-service.ts
@@ -1,2 +1,0 @@
-// Kept only for the database workstream's existing integration-test import path.
-export { makeStrategy, type Strategy } from './strategy'


### PR DESCRIPTION
## Summary

- canonicalize optional Alpaca order and fill fields before hashing, and map preflight hash failures into the typed broker error channel
- enforce the long-only paper risk invariant before broker I/O
- derive immutable cost basis in broker economic order, reject missing or late predecessors, and preserve deterministic replay
- verify the complete TigerBeetle transaction transfer set before receipting and validate transaction identity before any ledger write
- remove the dead strategy compatibility shim and run paper persistence regression tests in PostgreSQL CI

## Related Issues

Addresses all unresolved post-merge review findings on #13099 and #13109. Advances PROOMPT-371 and PROOMPT-372 without granting broker mutation or capital authority.

## Testing

- `bun test services/bayn/src/broker/alpaca.test.ts services/bayn/src/risk.test.ts services/bayn/src/ledger.test.ts` (36 passed)
- `BAYN_TEST_POSTGRES_URL=<local PostgreSQL 18> bun test services/bayn/src/db/evidence-store.integration.test.ts` (35 passed)
- `BAYN_TEST_POSTGRES_URL=<local PostgreSQL 18> bun test services/bayn/src/db/paper-store.integration.test.ts` (7 passed)
- `bun run --filter @proompteng/bayn test` (218 passed, 45 expected database skips, 0 failed)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- `bun test packages/scripts/src/bayn` (5 passed)

## Breaking Changes

Paper risk now rejects an existing short position or any sell that would open a short. This is an intentional fail-closed correction matching the long-only accounting model. No database migration is required.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation is updated and PostgreSQL-backed accounting coverage runs in CI.