### PR TITLE
feat(bayn): enable observe-only Alpaca reads

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -60,6 +60,21 @@ spec:
               value: "b88f53887a31b6696f5bf6b56e4e10d9966057c6109a1d0721dc94677e566ec7"
             - name: BAYN_MAXIMUM_AUTHORITY
               value: OBSERVE
+            - name: BAYN_ALPACA_ACCOUNT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: bayn-alpaca-auth
+                  key: account-id
+            - name: BAYN_ALPACA_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: bayn-alpaca-auth
+                  key: key-id
+            - name: BAYN_ALPACA_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: bayn-alpaca-auth
+                  key: secret-key
             - name: BAYN_HEALTH_INTERVAL_MS
               value: "30000"
             - name: BAYN_OPERATION_TIMEOUT_MS


### PR DESCRIPTION
## Summary

- Bind Bayn to the existing `bayn-alpaca-auth` Secret for account, key, and secret values.
- Keep `BAYN_MAXIMUM_AUTHORITY=OBSERVE`, so startup performs the bounded GET-only Alpaca preflight without composing paper mutation resources.
- Make all three Secret keys required so missing credentials fail the Pod instead of silently disabling broker verification.

## Related Issues

PROOMPT-370

## Testing

- `kustomize build argocd/applications/bayn`
- `bash scripts/kubeconform.sh argocd/applications/bayn` (11 valid, 0 invalid, 0 errors; 5 unsupported resources skipped)
- Inspected rendered Deployment: authority is `OBSERVE` and all three Alpaca variables reference `bayn-alpaca-auth`.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.