### PR TITLE
fix(bayn): restore qualification runtime isolation

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -60,21 +60,6 @@ spec:
               value: "b88f53887a31b6696f5bf6b56e4e10d9966057c6109a1d0721dc94677e566ec7"
             - name: BAYN_MAXIMUM_AUTHORITY
               value: OBSERVE
-            - name: BAYN_ALPACA_ACCOUNT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: bayn-alpaca-auth
-                  key: account-id
-            - name: BAYN_ALPACA_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  name: bayn-alpaca-auth
-                  key: key-id
-            - name: BAYN_ALPACA_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: bayn-alpaca-auth
-                  key: secret-key
             - name: BAYN_HEALTH_INTERVAL_MS
               value: "30000"
             - name: BAYN_OPERATION_TIMEOUT_MS

--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -119,7 +119,7 @@ spec:
             - name: BAYN_TIGERBEETLE_CLUSTER_ID
               value: "122731676035874920802382025803517750735"
             - name: BAYN_TIGERBEETLE_ADDRESSES
-              value: "ledger.bayn.svc.cluster.local:3000"
+              value: "ledger-0.ledger-headless.bayn.svc.cluster.local:3000,ledger-1.ledger-headless.bayn.svc.cluster.local:3000,ledger-2.ledger-headless.bayn.svc.cluster.local:3000"
             - name: BAYN_TIGERBEETLE_LEDGER
               value: "7001"
             - name: NODE_ENV

--- a/packages/scripts/src/bayn/update-manifests.test.ts
+++ b/packages/scripts/src/bayn/update-manifests.test.ts
@@ -19,13 +19,15 @@ const currentBindings = {
   BAYN_SIGNAL_EVALUATION_START: '2023-01-30',
   BAYN_SIGNAL_EVALUATION_END: '2026-07-20',
   BAYN_TIGERBEETLE_CLUSTER_ID: '122731676035874920802382025803517750735',
-  BAYN_TIGERBEETLE_ADDRESSES: 'ledger.bayn.svc.cluster.local:3000',
+  BAYN_TIGERBEETLE_ADDRESSES:
+    'ledger-0.ledger-headless.bayn.svc.cluster.local:3000,ledger-1.ledger-headless.bayn.svc.cluster.local:3000,ledger-2.ledger-headless.bayn.svc.cluster.local:3000',
   BAYN_TIGERBEETLE_LEDGER: '7001',
 } as const
 
 interface FixtureOptions {
   readonly snapshotId?: string
   readonly publicationAsOf?: string
+  readonly tigerBeetleAddresses?: string
   readonly behaviorHash?: string
   readonly parameterHash?: string
   readonly qualificationRunId?: string | undefined
@@ -58,6 +60,7 @@ const makeFixture = (options: FixtureOptions = {}): FixturePaths => {
     ...currentBindings,
     BAYN_SIGNAL_SNAPSHOT_ID: options.snapshotId ?? currentBindings.BAYN_SIGNAL_SNAPSHOT_ID,
     BAYN_SIGNAL_PUBLICATION_ASOF: options.publicationAsOf ?? currentBindings.BAYN_SIGNAL_PUBLICATION_ASOF,
+    BAYN_TIGERBEETLE_ADDRESSES: options.tigerBeetleAddresses ?? currentBindings.BAYN_TIGERBEETLE_ADDRESSES,
   }
   const pin = options.qualificationRunId === undefined ? qualificationRunId : options.qualificationRunId
   const environment = [
@@ -134,6 +137,23 @@ describe('Bayn manifest promotion', () => {
     const paths = makeFixture({ publicationAsOf: '2026-07-19' })
 
     expect(() => promote(paths)).toThrow('qualification replacement requires a fresh BAYN_SIGNAL_SNAPSHOT_ID')
+  })
+
+  test('restores replica-index-ordered TigerBeetle addresses for a fresh qualification snapshot', () => {
+    const paths = makeFixture({
+      snapshotId: '4'.repeat(64),
+      publicationAsOf: '2026-07-19',
+      tigerBeetleAddresses: 'ledger.bayn.svc.cluster.local:3000',
+    })
+
+    expect(promote(paths)).toMatchObject({
+      qualificationMode: 'replace',
+      runtimeBindingsMatch: false,
+      snapshotChanged: true,
+    })
+    expect(readFileSync(paths.deploymentPath, 'utf8')).toContain(
+      environmentBlock('BAYN_TIGERBEETLE_ADDRESSES', currentBindings.BAYN_TIGERBEETLE_ADDRESSES).trim(),
+    )
   })
 
   test('replaces a pin for a fresh snapshot and rejects a second unpinned source release', () => {

--- a/packages/scripts/src/bayn/update-manifests.ts
+++ b/packages/scripts/src/bayn/update-manifests.ts
@@ -17,7 +17,8 @@ const currentRuntimeConfiguration = {
   BAYN_SIGNAL_EVALUATION_START: '2023-01-30',
   BAYN_SIGNAL_EVALUATION_END: '2026-07-20',
   BAYN_TIGERBEETLE_CLUSTER_ID: '122731676035874920802382025803517750735',
-  BAYN_TIGERBEETLE_ADDRESSES: 'ledger.bayn.svc.cluster.local:3000',
+  BAYN_TIGERBEETLE_ADDRESSES:
+    'ledger-0.ledger-headless.bayn.svc.cluster.local:3000,ledger-1.ledger-headless.bayn.svc.cluster.local:3000,ledger-2.ledger-headless.bayn.svc.cluster.local:3000',
   BAYN_TIGERBEETLE_LEDGER: '7001',
 } as const
 


### PR DESCRIPTION
## Summary

- Replace the load-balanced TigerBeetle service address with the three stable ordinal pod DNS endpoints in replica-index order.
- Keep Bayn promotion automation on the same exact runtime binding so a later image promotion cannot restore the unsafe service address.
- Stop mounting the sealed Alpaca paper credential after its completed observe-only proof so the authoritative-universe and one-shot qualification gates run with no broker credential.
- Add focused regression coverage for repairing an unordered TigerBeetle binding during a fresh qualification snapshot transition.

## Related Issues

PROOMPT-393
PROOMPT-399

## Testing

- bun test packages/scripts/src/bayn
- bun test services/bayn/src/config.test.ts services/bayn/src/startup.test.ts
- bun run --filter @proompteng/scripts lint
- bash scripts/kubeconform.sh argocd/applications/bayn
- kustomize build argocd/applications/bayn; verified exactly one ordered three-replica BAYN_TIGERBEETLE_ADDRESSES value, zero mounted Alpaca variables, and one retained SealedSecret resource
- Live preflight from the current Bayn pod resolved each ordinal DNS name to exactly one unique Tigresse replica IP
- git diff --check

## Rollout and rollback

Argo CD rolls the single Bayn replica with maxSurge 0. The replacement pod resolves each stable ordinal endpoint independently and starts without Alpaca environment variables; the sealed Secret remains retained for a later authorized paper-execution gate. No TigerBeetle data, cluster configuration, broker state, or capital authority changes. Roll back this commit before any qualification lock opens if the replacement pod cannot resolve all three endpoints or recover the pinned accounting/readiness state.

## Breaking Changes

Bayn intentionally loses runtime access to the Alpaca paper credential until a later reviewed paper-execution authorization restores it.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; this is a runtime isolation correction.
- [x] Breaking Changes are documented.
- [x] Documentation and follow-ups are updated in PROOMPT-393, PROOMPT-398, and PROOMPT-399.