### PR TITLE
fix(bayn): separate route from qualification identity

### DIFF
--- a/.github/workflows/bayn-release.yml
+++ b/.github/workflows/bayn-release.yml
@@ -133,7 +133,7 @@ jobs:
           {
             echo "qualification_mode=$(jq -r '.qualificationMode' <<< "$promotion")"
             echo "had_qualification_pin=$(jq -r '.hadQualificationPin' <<< "$promotion")"
-            echo "runtime_bindings_match=$(jq -r '.runtimeBindingsMatch' <<< "$promotion")"
+            echo "qualification_bindings_match=$(jq -r '.qualificationBindingsMatch' <<< "$promotion")"
             echo "snapshot_changed=$(jq -r '.snapshotChanged' <<< "$promotion")"
             echo "deployed_snapshot_id=$(jq -r '.deployedSnapshotId' <<< "$promotion")"
             echo "candidate_snapshot_id=$(jq -r '.candidateSnapshotId' <<< "$promotion")"
@@ -168,7 +168,7 @@ jobs:
             - Image digest: `${{ steps.release.outputs.digest }}`
             - Qualification mode: `${{ steps.promotion.outputs.qualification_mode }}`
             - Existing pin: `${{ steps.promotion.outputs.had_qualification_pin }}`
-            - Runtime bindings match: `${{ steps.promotion.outputs.runtime_bindings_match }}`
+            - Qualification identity bindings match: `${{ steps.promotion.outputs.qualification_bindings_match }}`
             - Snapshot changed: `${{ steps.promotion.outputs.snapshot_changed }}`
             - Deployed snapshot: `${{ steps.promotion.outputs.deployed_snapshot_id }}`
             - Candidate snapshot: `${{ steps.promotion.outputs.candidate_snapshot_id }}`
@@ -193,10 +193,11 @@ jobs:
 
             This is a one-way current-contract runtime release. Databases with the old migration tracker are rejected;
             there is no schema fallback or automatic rename. `preserve` keeps the terminal run only when compiled
-            behavior, protocol parameters, Signal inputs, and TigerBeetle bindings all match. `replace` removes an
-            existing incompatible pin only for a fresh Signal snapshot. Once that one-shot release is unpinned, a
-            different source revision is rejected until the terminal run is pinned or the snapshot advances.
-            Promotion never creates a qualification pin.
+            behavior, protocol parameters, Signal inputs, TigerBeetle cluster ID, and TigerBeetle ledger all match.
+            Replica addresses are transport and are rewritten without relabeling qualification evidence. `replace`
+            removes an existing incompatible pin only for a fresh Signal snapshot. Once that one-shot release is
+            unpinned, a different source revision is rejected until the terminal run is pinned or the snapshot
+            advances. Promotion never creates a qualification pin.
 
             ## Checklist
 

--- a/docs/bayn/architecture.md
+++ b/docs/bayn/architecture.md
@@ -165,6 +165,9 @@ must remain available, accounting must be exact, and HTTP status must retain obs
 `Synced/Healthy` result without those observations is not sufficient.
 
 Outside an explicit one-shot qualification release, GitOps pins `BAYN_QUALIFICATION_RUN_ID` to one terminal run. The
-release writer preserves that pin while strategy and runtime bindings remain identical. After a fresh snapshot removes
-the pin for its one allowed source revision, promotion rejects a different source revision on that same unpinned
-snapshot; operational releases therefore cannot create extra qualification trials.
+release writer preserves that pin while compiled strategy identity, Signal identity and bounds, TigerBeetle cluster
+ID, and TigerBeetle ledger remain identical. TigerBeetle replica addresses are transport routing, not qualification
+identity, so the writer may restore replica-index order without relabeling terminal evidence. A cluster-ID or ledger
+change still requires a fresh Signal snapshot. After a fresh snapshot removes the pin for its one allowed source
+revision, promotion rejects a different source revision on that same unpinned snapshot; operational releases therefore
+cannot create extra qualification trials.

--- a/packages/scripts/src/bayn/update-manifests.test.ts
+++ b/packages/scripts/src/bayn/update-manifests.test.ts
@@ -27,6 +27,7 @@ const currentBindings = {
 interface FixtureOptions {
   readonly snapshotId?: string
   readonly publicationAsOf?: string
+  readonly tigerBeetleClusterId?: string
   readonly tigerBeetleAddresses?: string
   readonly behaviorHash?: string
   readonly parameterHash?: string
@@ -60,6 +61,7 @@ const makeFixture = (options: FixtureOptions = {}): FixturePaths => {
     ...currentBindings,
     BAYN_SIGNAL_SNAPSHOT_ID: options.snapshotId ?? currentBindings.BAYN_SIGNAL_SNAPSHOT_ID,
     BAYN_SIGNAL_PUBLICATION_ASOF: options.publicationAsOf ?? currentBindings.BAYN_SIGNAL_PUBLICATION_ASOF,
+    BAYN_TIGERBEETLE_CLUSTER_ID: options.tigerBeetleClusterId ?? currentBindings.BAYN_TIGERBEETLE_CLUSTER_ID,
     BAYN_TIGERBEETLE_ADDRESSES: options.tigerBeetleAddresses ?? currentBindings.BAYN_TIGERBEETLE_ADDRESSES,
   }
   const pin = options.qualificationRunId === undefined ? qualificationRunId : options.qualificationRunId
@@ -112,7 +114,7 @@ describe('Bayn manifest promotion', () => {
     expect(result).toMatchObject({
       qualificationMode: 'preserve',
       hadQualificationPin: true,
-      runtimeBindingsMatch: true,
+      qualificationBindingsMatch: true,
       snapshotChanged: false,
       deployedSnapshotId: currentSnapshotId,
       candidateSnapshotId: currentSnapshotId,
@@ -139,21 +141,28 @@ describe('Bayn manifest promotion', () => {
     expect(() => promote(paths)).toThrow('qualification replacement requires a fresh BAYN_SIGNAL_SNAPSHOT_ID')
   })
 
-  test('restores replica-index-ordered TigerBeetle addresses for a fresh qualification snapshot', () => {
+  test('preserves qualification while restoring replica-index-ordered TigerBeetle transport addresses', () => {
     const paths = makeFixture({
-      snapshotId: '4'.repeat(64),
-      publicationAsOf: '2026-07-19',
       tigerBeetleAddresses: 'ledger.bayn.svc.cluster.local:3000',
     })
 
     expect(promote(paths)).toMatchObject({
-      qualificationMode: 'replace',
-      runtimeBindingsMatch: false,
-      snapshotChanged: true,
+      qualificationMode: 'preserve',
+      qualificationBindingsMatch: true,
+      snapshotChanged: false,
     })
+    expect(readFileSync(paths.deploymentPath, 'utf8')).toContain(
+      environmentBlock('BAYN_QUALIFICATION_RUN_ID', qualificationRunId).trim(),
+    )
     expect(readFileSync(paths.deploymentPath, 'utf8')).toContain(
       environmentBlock('BAYN_TIGERBEETLE_ADDRESSES', currentBindings.BAYN_TIGERBEETLE_ADDRESSES).trim(),
     )
+  })
+
+  test('rejects a TigerBeetle cluster identity change against an already-qualified snapshot', () => {
+    const paths = makeFixture({ tigerBeetleClusterId: '2001' })
+
+    expect(() => promote(paths)).toThrow('qualification replacement requires a fresh BAYN_SIGNAL_SNAPSHOT_ID')
   })
 
   test('replaces a pin for a fresh snapshot and rejects a second unpinned source release', () => {
@@ -164,7 +173,7 @@ describe('Bayn manifest promotion', () => {
     expect(first).toMatchObject({
       qualificationMode: 'replace',
       hadQualificationPin: true,
-      runtimeBindingsMatch: false,
+      qualificationBindingsMatch: false,
       snapshotChanged: true,
       deployedSnapshotId: '4'.repeat(64),
       candidateSnapshotId: currentSnapshotId,

--- a/packages/scripts/src/bayn/update-manifests.ts
+++ b/packages/scripts/src/bayn/update-manifests.ts
@@ -7,7 +7,7 @@ const digestPattern = /^sha256:[0-9a-f]{64}$/
 const hashPattern = /^[0-9a-f]{64}$/
 const sourceShaPattern = /^[0-9a-f]{40}$/
 const tagPattern = /^[A-Za-z0-9._-]{1,128}$/
-const currentRuntimeConfiguration = {
+const currentQualificationIdentity = {
   BAYN_SIGNAL_SNAPSHOT_ID: '98f9b0cdee311b248d4ed36104fa46ff86c34d587d6e71a6706a9d778c110292',
   BAYN_SIGNAL_PUBLICATION_ASOF: '2026-07-20',
   BAYN_SIGNAL_CALENDAR_VERSION: 'alpaca-us-equity-calendar-v1',
@@ -17,9 +17,17 @@ const currentRuntimeConfiguration = {
   BAYN_SIGNAL_EVALUATION_START: '2023-01-30',
   BAYN_SIGNAL_EVALUATION_END: '2026-07-20',
   BAYN_TIGERBEETLE_CLUSTER_ID: '122731676035874920802382025803517750735',
+  BAYN_TIGERBEETLE_LEDGER: '7001',
+} as const
+
+const currentTransportConfiguration = {
   BAYN_TIGERBEETLE_ADDRESSES:
     'ledger-0.ledger-headless.bayn.svc.cluster.local:3000,ledger-1.ledger-headless.bayn.svc.cluster.local:3000,ledger-2.ledger-headless.bayn.svc.cluster.local:3000',
-  BAYN_TIGERBEETLE_LEDGER: '7001',
+} as const
+
+const currentRuntimeConfiguration = {
+  ...currentQualificationIdentity,
+  ...currentTransportConfiguration,
 } as const
 
 export interface UpdateBaynManifestOptions {
@@ -37,7 +45,7 @@ export interface UpdateBaynManifestOptions {
 export interface BaynManifestUpdate {
   readonly qualificationMode: 'preserve' | 'replace'
   readonly hadQualificationPin: boolean
-  readonly runtimeBindingsMatch: boolean
+  readonly qualificationBindingsMatch: boolean
   readonly snapshotChanged: boolean
   readonly deployedSnapshotId: string
   readonly candidateSnapshotId: string
@@ -103,13 +111,13 @@ export const updateBaynManifests = (options: UpdateBaynManifestOptions): BaynMan
   const deployedSnapshotId = environmentValue(deployment, 'BAYN_SIGNAL_SNAPSHOT_ID')
   const candidateSnapshotId = currentRuntimeConfiguration.BAYN_SIGNAL_SNAPSHOT_ID
   const snapshotChanged = deployedSnapshotId !== candidateSnapshotId
-  const runtimeBindingsMatch = Object.entries(currentRuntimeConfiguration).every(
+  const qualificationBindingsMatch = Object.entries(currentQualificationIdentity).every(
     ([name, value]) => environmentValue(deployment, name) === value,
   )
   const strategyIdentityMatches =
     deployedBehaviorHash === options.strategyBehaviorHash && deployedParameterHash === options.strategyParameterHash
   const qualificationMode =
-    hadQualificationPin && strategyIdentityMatches && runtimeBindingsMatch ? 'preserve' : 'replace'
+    hadQualificationPin && strategyIdentityMatches && qualificationBindingsMatch ? 'preserve' : 'replace'
   if (qualificationMode === 'replace' && hadQualificationPin && !snapshotChanged) {
     throw new Error('qualification replacement requires a fresh BAYN_SIGNAL_SNAPSHOT_ID')
   }
@@ -179,7 +187,7 @@ export const updateBaynManifests = (options: UpdateBaynManifestOptions): BaynMan
   return {
     qualificationMode,
     hadQualificationPin,
-    runtimeBindingsMatch,
+    qualificationBindingsMatch,
     snapshotChanged,
     deployedSnapshotId,
     candidateSnapshotId,


### PR DESCRIPTION
## Summary

- Define the exact qualification identity binding set instead of treating every promotion-managed runtime value as strategy evidence.
- Keep TigerBeetle cluster ID and ledger in qualification identity while classifying replica addresses as transport routing.
- Preserve an existing pin when only the route changes, but continue requiring a fresh Signal snapshot for cluster or economic binding changes.
- Rename release evidence from runtime bindings to qualification identity bindings so generated promotion PRs state the contract honestly.

## Related Issues

Follow-up for the P1 Codex finding on #13115 and PROOMPT-399.

## Testing

- bun test packages/scripts/src/bayn
- bun run --filter @proompteng/scripts lint
- bunx oxfmt --check packages/scripts/src/bayn/update-manifests.ts packages/scripts/src/bayn/update-manifests.test.ts
- actionlint -shellcheck empty -pyflakes empty .github/workflows/bayn-release.yml
- git diff --check

Focused coverage proves a route-only correction preserves the pin and rewrites the address, while a TigerBeetle cluster ID change still fails without a fresh snapshot.

## Breaking Changes

The internal promotion JSON and generated workflow output rename runtimeBindingsMatch to qualificationBindingsMatch. No deployed runtime, database, ledger, broker, or capital authority changes.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and this section is removed.
- [x] Breaking Changes are documented.
- [x] Follow-up is tracked in PROOMPT-399 and the source review thread.