### PR TITLE
fix(bayn): audit prior terminal results

### DIFF
--- a/services/bayn/src/qualification-audit-command.ts
+++ b/services/bayn/src/qualification-audit-command.ts
@@ -237,11 +237,22 @@ const readDatabase = Effect.fnUntraced(function* (runId: string) {
       )
       const trials = yield* decodeTrialRows(
         yield* sql`
-            SELECT run_id
-            FROM qualification_trials
-            WHERE observed_at < (
-              SELECT created_at FROM qualification_locks WHERE candidate_run_id = ${runId}
+            WITH target_lock AS (
+              SELECT created_at
+              FROM qualification_locks
+              WHERE candidate_run_id = ${runId}
             )
+            SELECT run_id FROM (
+              SELECT trial.run_id
+              FROM qualification_trials AS trial
+              CROSS JOIN target_lock
+              WHERE trial.observed_at < target_lock.created_at
+              UNION
+              SELECT result.run_id
+              FROM qualification_results AS result
+              CROSS JOIN target_lock
+              WHERE result.committed_at < target_lock.created_at
+            ) AS prior_trials
             ORDER BY run_id
           `,
       )

--- a/services/bayn/src/qualification-audit.test.ts
+++ b/services/bayn/src/qualification-audit.test.ts
@@ -9,14 +9,13 @@ import { makeStrategy } from './strategy'
 import { summarizeEvaluation } from './risk-balanced-trend'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
 
-const fixture = (): QualificationAuditInput => {
+const fixture = (priorTrialRunIds: readonly string[] = []): QualificationAuditInput => {
   const snapshot = makeSnapshot(900)
   const protocol = fixtureProtocol
   const provenance = makeTestProvenance()
   const strategy = makeStrategy(protocol, provenance)
   const evaluation = strategy.evaluate(snapshot.bars, snapshot.manifest)
   const sessionDates = [...new Set(snapshot.bars.map((bar) => bar.sessionDate))].sort()
-  const priorTrialRunIds: readonly string[] = []
   const lock = strategy.prepareLock(snapshot.manifest, sessionDates, priorTrialRunIds)
   const analysis = strategy.analyze(evaluation, priorTrialRunIds)
   const result = makeQualificationResult(lock, evaluation.verdict, analysis)
@@ -318,6 +317,15 @@ describe('qualification audit', () => {
     ])
     expect(first.policies.policySetHash).toBe(canonicalHashV1(first.policies.documents))
     expect(second.auditHash).toBe(first.auditHash)
+  })
+
+  test('passes for a later candidate when prior terminal result lineage is complete', () => {
+    const priorRunId = '0'.repeat(64)
+    const report = auditQualification(fixture([priorRunId]))
+
+    expect(report.status).toBe('PASS')
+    expect(report.checks.find((check) => check.name === 'locked-prior-trial-lineage')?.passed).toBe(true)
+    expect(report.checks.find((check) => check.name === 'analysis-lineage')?.passed).toBe(true)
   })
 
   test('fails closed on stored evidence drift', () => {


### PR DESCRIPTION
## Summary

- reconstruct qualification lineage at the target lock by unioning explicit trials with terminal qualification results committed before that lock
- preserve the lock-time cutoff so later candidates cannot contaminate a historical audit
- add regression coverage for a second candidate whose prior terminal-result lineage must pass both lineage gates

## Related Issues

PROOMPT-394

## Testing

- live fail-closed reproduction against run `87c0dac69efcfa7bdedb5bbcffe26f7ee9a14de8c05baea613f488eb869a305f`: all evidence/provenance/query chronology checks passed, while the old query falsely reported 0 prior trials against locked ordinal 2
- `bun test services/bayn/src/qualification-audit.test.ts` (18 passed)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint:oxlint` (0 warnings, 0 errors)
- `bunx oxfmt --check services/bayn/src/qualification-audit-command.ts services/bayn/src/qualification-audit.test.ts`
- `git diff --check`

## Breaking Changes

None. This changes only the read-only operator audit's historical lineage query; it does not alter qualification data, runtime strategy behavior, authority, broker access, or deployed execution.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed; this change has no visual surface. Breaking Changes is filled in.
- [x] Documentation and follow-up evidence are tracked by PROOMPT-394.
