### PR TITLE
fix(bayn): bind dossier to qualification pin

### DIFF
--- a/packages/scripts/src/bayn/update-manifests.test.ts
+++ b/packages/scripts/src/bayn/update-manifests.test.ts
@@ -32,6 +32,7 @@ interface FixtureOptions {
   readonly behaviorHash?: string
   readonly parameterHash?: string
   readonly qualificationRunId?: string | undefined
+  readonly qualificationDossierRunId?: string
 }
 
 interface FixturePaths {
@@ -68,7 +69,7 @@ const makeFixture = (options: FixtureOptions = {}): FixturePaths => {
   const dossierGenerator =
     pin === undefined
       ? ''
-      : `configMapGenerator:\n  - name: bayn-qualification-dossier\n    files:\n      - qualification-dossier.json=qualification-dossiers/${pin}.json\n`
+      : `configMapGenerator:\n  - name: bayn-qualification-dossier\n    files:\n      - qualification-dossier.json=qualification-dossiers/${options.qualificationDossierRunId ?? pin}.json\n`
   const dossierMounts =
     pin === undefined
       ? ''
@@ -142,6 +143,14 @@ describe('Bayn manifest promotion', () => {
     expect(() => promote(paths, { strategyParameterHash: '3'.repeat(64) })).toThrow(
       'qualification replacement requires a fresh BAYN_SIGNAL_SNAPSHOT_ID',
     )
+    expect(Object.values(paths).map((path) => readFileSync(path, 'utf8'))).toEqual(before)
+  })
+
+  test('rejects a dossier that does not belong to the pinned run without writing files', () => {
+    const paths = makeFixture({ qualificationDossierRunId: '8'.repeat(64) })
+    const before = Object.values(paths).map((path) => readFileSync(path, 'utf8'))
+
+    expect(() => promote(paths)).toThrow('qualification dossier run ID must match the pinned run ID')
     expect(Object.values(paths).map((path) => readFileSync(path, 'utf8'))).toEqual(before)
   })
 

--- a/packages/scripts/src/bayn/update-manifests.ts
+++ b/packages/scripts/src/bayn/update-manifests.ts
@@ -73,7 +73,7 @@ const environmentValue = (deployment: string, name: string): string => {
 
 const qualificationPin = /            - name: BAYN_QUALIFICATION_RUN_ID\n              value: [^\n]+\n/
 const qualificationDossierGenerator =
-  /  - name: bayn-qualification-dossier\n    files:\n      - qualification-dossier\.json=qualification-dossiers\/[0-9a-f]{64}\.json\n/
+  /  - name: bayn-qualification-dossier\n    files:\n      - qualification-dossier\.json=qualification-dossiers\/([0-9a-f]{64})\.json\n/
 const qualificationDossierMount =
   /            - name: qualification-dossier\n              mountPath: \/var\/run\/bayn\/qualification\n              readOnly: true\n/
 const qualificationDossierVolume =
@@ -125,6 +125,11 @@ export const updateBaynManifests = (options: UpdateBaynManifestOptions): BaynMan
   const hadQualificationDossier = dossierPartCounts[0] === 1
   if (hadQualificationDossier !== hadQualificationPin) {
     throw new Error('qualification pin and dossier must occur together')
+  }
+  if (hadQualificationPin) {
+    const pinnedRunId = environmentValue(deployment, 'BAYN_QUALIFICATION_RUN_ID')
+    const dossierRunId = kustomization.match(qualificationDossierGenerator)?.[1]
+    if (dossierRunId !== pinnedRunId) throw new Error('qualification dossier run ID must match the pinned run ID')
   }
   const deployedSourceSha = environmentValue(deployment, 'BAYN_CODE_REVISION')
   const deployedBehaviorHash = environmentValue(deployment, 'BAYN_STRATEGY_BEHAVIOR_HASH')


### PR DESCRIPTION
## Summary

- Extracts the qualification run ID from the generated dossier path during Bayn release promotion.
- Fails closed unless that ID exactly matches `BAYN_QUALIFICATION_RUN_ID`.
- Adds a regression proving a mismatched dossier and pin are rejected before any manifest write.

## Related Issues

Follow-up to PROOMPT-394 and PR #13119.

## Testing

- `bun test packages/scripts/src/bayn` — 8 passed.
- Focused Oxfmt — passed.
- Focused type-aware Oxlint — 0 warnings and 0 errors.
- `git diff --check` — passed.

## Breaking Changes

None. This tightens the existing fail-closed release invariant.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] The post-merge Codex finding on PR #13119 is tracked by this follow-up.