### PR TITLE
feat(websocket): isolate observation universe

### DIFF
--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
@@ -350,12 +350,12 @@ class ForwarderApp(
               launch {
                 val symbolsTracker =
                   SymbolsTracker(
-                    normalizeSymbols(feed.config.symbols),
+                    normalizeSymbols(feed.config.symbols, feed.config.symbolAllowlist),
                     config.jangarSymbolsUrl?.takeIf { feed.config.core }?.let { url ->
                       suspend {
                         runCatching { fetchDesiredSymbols(url) }
                           .getOrElse { err -> throw RuntimeException("jangar desired symbols fetch failed url=$url", err) }
-                          .let(::normalizeSymbols)
+                          .let { symbols -> normalizeSymbols(symbols, feed.config.symbolAllowlist) }
                       }
                     },
                   )
@@ -1065,11 +1065,14 @@ class ForwarderApp(
     }
   }
 
-  private fun normalizeSymbols(symbols: List<String>): List<String> =
+  private fun normalizeSymbols(
+    symbols: List<String>,
+    symbolAllowlist: Set<String>,
+  ): List<String> =
     symbols
       .map { it.trim().uppercase() }
       .filter { it.isNotEmpty() }
-      .filter { config.symbolAllowlist.isEmpty() || it in config.symbolAllowlist }
+      .filter { symbolAllowlist.isEmpty() || it in symbolAllowlist }
       .filter { ownsSymbol(it) }
       .distinct()
 

--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
@@ -344,22 +344,21 @@ class ForwarderApp(
             null
           }
 
-        val symbolsTracker =
-          SymbolsTracker(
-            normalizeSymbols(config.staticSymbols),
-            config.jangarSymbolsUrl?.let { url ->
-              suspend {
-                runCatching { fetchDesiredSymbols(url) }
-                  .getOrElse { err -> throw RuntimeException("jangar desired symbols fetch failed url=$url", err) }
-                  .let(::normalizeSymbols)
-              }
-            },
-          )
-
         val jobs =
           marketDataFeeds
             .map { feed ->
               launch {
+                val symbolsTracker =
+                  SymbolsTracker(
+                    normalizeSymbols(feed.config.symbols),
+                    config.jangarSymbolsUrl?.takeIf { feed.config.core }?.let { url ->
+                      suspend {
+                        runCatching { fetchDesiredSymbols(url) }
+                          .getOrElse { err -> throw RuntimeException("jangar desired symbols fetch failed url=$url", err) }
+                          .let(::normalizeSymbols)
+                      }
+                    },
+                  )
                 streamMarketDataLoop(producer, feed, symbolsTracker)
               }
             }.toMutableList()
@@ -733,7 +732,7 @@ class ForwarderApp(
       }
 
       val poller =
-        config.jangarSymbolsUrl?.let {
+        config.jangarSymbolsUrl?.takeIf { feed.config.core }?.let {
           launch {
             while (isActive) {
               delay(config.symbolsPollIntervalMs)

--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderConfig.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderConfig.kt
@@ -58,6 +58,7 @@ data class ForwarderConfig(
   val jangarSymbolsUrl: String?,
   val staticSymbols: List<String>,
   val symbolAllowlist: Set<String>,
+  val observationSymbols: List<String> = emptyList(),
   val universeContract: MarketDataUniverseContract? = null,
   val symbolsPollIntervalMs: Long,
   val subscribeBatchSize: Int,
@@ -118,6 +119,17 @@ data class ForwarderConfig(
         } else {
           configuredStaticSymbols.filter { it.trim().uppercase() in symbolAllowlist }
         }
+      val configuredObservationSymbols =
+        mergedEnv["ALPACA_OBSERVATION_SYMBOLS"]
+          ?.split(",")
+          ?.map { it.trim().uppercase() }
+          ?.filter { it.isNotEmpty() }
+      if (configuredObservationSymbols != null && configuredObservationSymbols.isEmpty()) {
+        error("ALPACA_OBSERVATION_SYMBOLS must include at least one symbol")
+      }
+      val observationSymbols =
+        configuredObservationSymbols
+          ?: configuredStaticSymbols.map { it.trim().uppercase() }.filter { it.isNotEmpty() }
       val alpacaMarketType =
         when (mergedEnv["ALPACA_MARKET_TYPE"]?.trim()?.lowercase() ?: "equity") {
           "equity" -> AlpacaMarketType.EQUITY
@@ -175,6 +187,9 @@ data class ForwarderConfig(
       if ((universeId == null) != (universeSymbolHash == null)) {
         error("MARKET_DATA_UNIVERSE_ID and MARKET_DATA_UNIVERSE_SYMBOL_HASH must be set together")
       }
+      if (configuredObservationSymbols != null && universeId == null) {
+        error("ALPACA_OBSERVATION_SYMBOLS requires a versioned market-data universe")
+      }
       val universeContract =
         universeId?.let { id ->
           val expectedHash = requireNotNull(universeSymbolHash)
@@ -187,19 +202,19 @@ data class ForwarderConfig(
           if (jangarSymbolsUrl != null) {
             error("a versioned market-data universe cannot use JANGAR_SYMBOLS_URL")
           }
-          val configuredSymbols =
-            configuredStaticSymbols.map { it.trim().uppercase() }.filter { it.isNotEmpty() }
+          val configuredSymbols = observationSymbols
           val canonicalSymbols =
             configuredSymbols.distinct().sorted()
+          val symbolSource = if (configuredObservationSymbols == null) "SYMBOLS" else "ALPACA_OBSERVATION_SYMBOLS"
           if (configuredSymbols != canonicalSymbols) {
-            error("SYMBOLS must be unique and canonically sorted for a versioned market-data universe")
+            error("$symbolSource must be unique and canonically sorted for a versioned market-data universe")
           }
-          if (configuredAllowlistSymbols != canonicalSymbols) {
+          if (configuredObservationSymbols == null && configuredAllowlistSymbols != canonicalSymbols) {
             error("SYMBOLS_ALLOWLIST must exactly match SYMBOLS for a versioned market-data universe")
           }
           val actualHash = canonicalSymbolHash(canonicalSymbols)
           if (expectedHash != actualHash) {
-            error("MARKET_DATA_UNIVERSE_SYMBOL_HASH does not match canonical SYMBOLS")
+            error("MARKET_DATA_UNIVERSE_SYMBOL_HASH does not match canonical $symbolSource")
           }
           MarketDataUniverseContract(id = id, symbolHash = actualHash, symbols = canonicalSymbols)
         }
@@ -222,7 +237,8 @@ data class ForwarderConfig(
           coreFeed = alpacaFeed,
           coreTopics = topics,
           mergedEnv = mergedEnv,
-          configuredSymbols = staticSymbols,
+          coreSymbols = staticSymbols,
+          observationSymbols = observationSymbols,
           hasVersionedUniverse = universeContract != null,
         )
       val enableBarsBackfill = mergedEnv["ENABLE_BARS_BACKFILL"]?.toBooleanStrictOrNull() ?: false
@@ -312,6 +328,7 @@ data class ForwarderConfig(
         jangarSymbolsUrl = jangarSymbolsUrl,
         staticSymbols = staticSymbols,
         symbolAllowlist = symbolAllowlist,
+        observationSymbols = observationSymbols,
         universeContract = universeContract,
         symbolsPollIntervalMs = symbolsPollIntervalMs,
         subscribeBatchSize = subscribeBatchSize,
@@ -369,7 +386,8 @@ data class ForwarderConfig(
       coreFeed: String,
       coreTopics: TopicConfig,
       mergedEnv: Map<String, String>,
-      configuredSymbols: List<String>,
+      coreSymbols: List<String>,
+      observationSymbols: List<String>,
       hasVersionedUniverse: Boolean,
     ): List<ObservationFeedConfig> {
       val requested =
@@ -388,7 +406,7 @@ data class ForwarderConfig(
       if (requested.distinct().size != requested.size) {
         error("ALPACA_OBSERVATION_FEEDS must not contain duplicates")
       }
-      if (!hasVersionedUniverse || configuredSymbols.isEmpty()) {
+      if (!hasVersionedUniverse || observationSymbols.isEmpty()) {
         error("ALPACA_OBSERVATION_FEEDS requires a versioned static market-data universe")
       }
 
@@ -433,7 +451,7 @@ data class ForwarderConfig(
       if (duplicateTopics.isNotEmpty()) {
         error("market-data feed topics must be unique: ${duplicateTopics.sorted().joinToString(",")}")
       }
-      val subscriptionCount = configuredSymbols.size * (feeds.size + 1)
+      val subscriptionCount = coreSymbols.size + observationSymbols.size * feeds.size
       if (subscriptionCount > 30) {
         error("configured market-data feeds require $subscriptionCount symbol subscriptions; Alpaca Basic allows 30")
       }

--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/MarketDataFeed.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/MarketDataFeed.kt
@@ -53,6 +53,7 @@ data class FeedRuntimeConfig(
   val channels: List<String>,
   val topics: TopicConfig,
   val symbols: List<String>,
+  val symbolAllowlist: Set<String>,
   val core: Boolean,
 )
 
@@ -119,6 +120,7 @@ internal fun ForwarderConfig.marketDataFeedConfigs(): List<FeedRuntimeConfig> {
       channels = alpacaMarketDataChannels,
       topics = topics,
       symbols = staticSymbols,
+      symbolAllowlist = symbolAllowlist,
       core = true,
     )
   return listOf(core) +
@@ -129,6 +131,7 @@ internal fun ForwarderConfig.marketDataFeedConfigs(): List<FeedRuntimeConfig> {
         channels = defaultAlpacaMarketDataChannels(AlpacaMarketType.EQUITY),
         topics = observation.topics,
         symbols = observationSymbols,
+        symbolAllowlist = emptySet(),
         core = false,
       )
     }

--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/MarketDataFeed.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/MarketDataFeed.kt
@@ -52,6 +52,7 @@ data class FeedRuntimeConfig(
   val equityFeed: EquityFeed?,
   val channels: List<String>,
   val topics: TopicConfig,
+  val symbols: List<String>,
   val core: Boolean,
 )
 
@@ -117,6 +118,7 @@ internal fun ForwarderConfig.marketDataFeedConfigs(): List<FeedRuntimeConfig> {
       equityFeed = coreEquityFeed,
       channels = alpacaMarketDataChannels,
       topics = topics,
+      symbols = staticSymbols,
       core = true,
     )
   return listOf(core) +
@@ -126,6 +128,7 @@ internal fun ForwarderConfig.marketDataFeedConfigs(): List<FeedRuntimeConfig> {
         equityFeed = observation.feed,
         channels = defaultAlpacaMarketDataChannels(AlpacaMarketType.EQUITY),
         topics = observation.topics,
+        symbols = observationSymbols,
         core = false,
       )
     }

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderConfigTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderConfigTest.kt
@@ -98,7 +98,9 @@ class ForwarderConfigTest {
     assertEquals(coreSymbols, cfg.staticSymbols)
     assertEquals(observationSymbols, cfg.observationSymbols)
     assertEquals(observationSymbols, cfg.universeContract?.symbols)
-    assertEquals(listOf(coreSymbols, observationSymbols), cfg.marketDataFeedConfigs().map { it.symbols })
+    val runtimes = cfg.marketDataFeedConfigs()
+    assertEquals(listOf(coreSymbols, observationSymbols), runtimes.map { it.symbols })
+    assertEquals(listOf(coreSymbols.toSet(), emptySet()), runtimes.map { it.symbolAllowlist })
   }
 
   @Test

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderConfigTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderConfigTest.kt
@@ -77,6 +77,31 @@ class ForwarderConfigTest {
   }
 
   @Test
+  fun `keeps core trading symbols separate from the observation universe`() {
+    val coreSymbols = listOf("AMD", "AVGO", "COHR", "CRDO", "LITE", "MRVL", "MU", "NVDA", "WDC")
+    val observationSymbols = listOf("DBC", "EFA", "IEF", "SPY", "VNQ")
+    val cfg =
+      ForwarderConfig.fromEnv(
+        mapOf(
+          "ALPACA_KEY_ID" to "key",
+          "ALPACA_SECRET_KEY" to "secret",
+          "ALPACA_FEED" to "iex",
+          "ALPACA_OBSERVATION_FEEDS" to "delayed_sip",
+          "SYMBOLS" to coreSymbols.joinToString(","),
+          "SYMBOLS_ALLOWLIST" to coreSymbols.joinToString(","),
+          "ALPACA_OBSERVATION_SYMBOLS" to observationSymbols.joinToString(","),
+          "MARKET_DATA_UNIVERSE_ID" to "cross-asset-taa-v1",
+          "MARKET_DATA_UNIVERSE_SYMBOL_HASH" to canonicalSymbolHash(observationSymbols),
+        ) + observationTopics,
+      )
+
+    assertEquals(coreSymbols, cfg.staticSymbols)
+    assertEquals(observationSymbols, cfg.observationSymbols)
+    assertEquals(observationSymbols, cfg.universeContract?.symbols)
+    assertEquals(listOf(coreSymbols, observationSymbols), cfg.marketDataFeedConfigs().map { it.symbols })
+  }
+
+  @Test
   fun `rejects unsafe or incomplete observation-feed configuration`() {
     val base =
       mapOf(
@@ -158,6 +183,7 @@ class ForwarderConfigTest {
     assertEquals("http://jangar.test/api/torghut/symbols", cfg.jangarSymbolsUrl)
     assertEquals(emptyList(), cfg.staticSymbols)
     assertEquals(emptySet(), cfg.symbolAllowlist)
+    assertEquals(emptyList(), cfg.observationSymbols)
     assertEquals(30_000, cfg.symbolsPollIntervalMs)
     assertEquals(200, cfg.subscribeBatchSize)
     assertEquals(1, cfg.shardCount)
@@ -256,6 +282,39 @@ class ForwarderConfigTest {
       "a versioned market-data universe cannot use JANGAR_SYMBOLS_URL",
       assertFailsWith<IllegalStateException> {
         ForwarderConfig.fromEnv(base + ("JANGAR_SYMBOLS_URL" to "http://jangar.test/symbols"))
+      }.message,
+    )
+  }
+
+  @Test
+  fun `rejects drift in an explicit observation universe`() {
+    val base =
+      mapOf(
+        "ALPACA_KEY_ID" to "key",
+        "ALPACA_SECRET_KEY" to "secret",
+        "SYMBOLS" to "AMD,NVDA",
+        "SYMBOLS_ALLOWLIST" to "AMD,NVDA",
+        "ALPACA_OBSERVATION_SYMBOLS" to "DBC,SPY",
+        "MARKET_DATA_UNIVERSE_ID" to "cross-asset-taa-v1",
+        "MARKET_DATA_UNIVERSE_SYMBOL_HASH" to canonicalSymbolHash(listOf("DBC", "SPY")),
+      )
+
+    assertEquals(
+      "ALPACA_OBSERVATION_SYMBOLS must be unique and canonically sorted for a versioned market-data universe",
+      assertFailsWith<IllegalStateException> {
+        ForwarderConfig.fromEnv(base + ("ALPACA_OBSERVATION_SYMBOLS" to "SPY,DBC"))
+      }.message,
+    )
+    assertEquals(
+      "MARKET_DATA_UNIVERSE_SYMBOL_HASH does not match canonical ALPACA_OBSERVATION_SYMBOLS",
+      assertFailsWith<IllegalStateException> {
+        ForwarderConfig.fromEnv(base + ("MARKET_DATA_UNIVERSE_SYMBOL_HASH" to "0".repeat(64)))
+      }.message,
+    )
+    assertEquals(
+      "ALPACA_OBSERVATION_SYMBOLS requires a versioned market-data universe",
+      assertFailsWith<IllegalStateException> {
+        ForwarderConfig.fromEnv(base - "MARKET_DATA_UNIVERSE_ID" - "MARKET_DATA_UNIVERSE_SYMBOL_HASH")
       }.message,
     )
   }

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/MarketDataFeedTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/MarketDataFeedTest.kt
@@ -67,6 +67,7 @@ class MarketDataFeedTest {
             tradeUpdates = null,
             tradeUpdatesV2 = null,
           ),
+        symbols = listOf("SPY"),
         core = feed == EquityFeed.Iex,
       )
 

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/MarketDataFeedTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/MarketDataFeedTest.kt
@@ -68,6 +68,7 @@ class MarketDataFeedTest {
             tradeUpdatesV2 = null,
           ),
         symbols = listOf("SPY"),
+        symbolAllowlist = emptySet(),
         core = feed == EquityFeed.Iex,
       )
 


### PR DESCRIPTION
## Summary

- let observation-only Alpaca feeds subscribe to a fixed symbol universe that is independent from the core trading feed
- keep one WebSocket process and one connection per feed while preserving the core Torghut symbols
- bind the versioned market-data contract to the observation symbols and enforce the aggregate Alpaca Basic 30-symbol subscription limit
- preserve existing behavior when `ALPACA_OBSERVATION_SYMBOLS` is absent so the image can roll safely before GitOps activates the split

## Related Issues

Part of PROOMPT-402

## Testing

- `./gradlew :websockets:test --tests ai.proompteng.dorvud.ws.ForwarderConfigTest --tests ai.proompteng.dorvud.ws.MarketDataFeedTest :websockets:ktlintCheck` — passed
- `./gradlew :websockets:test :websockets:build` — passed
- `git diff --check` — passed

## Breaking Changes

None. The new `ALPACA_OBSERVATION_SYMBOLS` variable is optional; when absent, observation feeds retain the current core-symbol behavior. The follow-up GitOps PR will activate separate Bayn observation symbols only after this image is promoted.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and this section is removed.
- [x] Breaking Changes and rollout sequencing are documented.
- [x] Follow-up GitOps activation remains tracked in PROOMPT-402.