### PR TITLE
chore(torghut): promote ws image sha-df986bdc984a2ae8dbc81c77e697396552d5aaa6

### DIFF
--- a/argocd/applications/torghut-options/ws/deployment.yaml
+++ b/argocd/applications/torghut-options/ws/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws-options
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:c5753db003befaa6525469de4bf659bc774c4543531bae2dcd2f145ecb8e608b
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:387f0dc9f64b525bbc71bb9cc455dd240baa567092ffa14bf4bd04ae02b45900
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -54,9 +54,9 @@ spec:
                   name: torghut-options
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-sha-b03f46c00bf843ca1b0d17f81c9bf85ed6bad34d
+              value: main-sha-df986bdc984a2ae8dbc81c77e697396552d5aaa6
             - name: TORGHUT_WS_COMMIT
-              value: b03f46c00bf843ca1b0d17f81c9bf85ed6bad34d
+              value: df986bdc984a2ae8dbc81c77e697396552d5aaa6
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:

--- a/argocd/applications/torghut/ws/deployment.yaml
+++ b/argocd/applications/torghut/ws/deployment.yaml
@@ -33,7 +33,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:c5753db003befaa6525469de4bf659bc774c4543531bae2dcd2f145ecb8e608b
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:387f0dc9f64b525bbc71bb9cc455dd240baa567092ffa14bf4bd04ae02b45900
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -77,9 +77,9 @@ spec:
                   name: torghut-ws
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-sha-b03f46c00bf843ca1b0d17f81c9bf85ed6bad34d
+              value: main-sha-df986bdc984a2ae8dbc81c77e697396552d5aaa6
             - name: TORGHUT_WS_COMMIT
-              value: b03f46c00bf843ca1b0d17f81c9bf85ed6bad34d
+              value: df986bdc984a2ae8dbc81c77e697396552d5aaa6
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:


### PR DESCRIPTION
## Summary
Promote the Torghut websocket image into GitOps manifests.

- Source commit: `df986bdc984a2ae8dbc81c77e697396552d5aaa6`
- Image tag: `sha-df986bdc984a2ae8dbc81c77e697396552d5aaa6`
- Image digest: `sha256:387f0dc9f64b525bbc71bb9cc455dd240baa567092ffa14bf4bd04ae02b45900`