### PR TITLE
chore(torghut): promote image sha-314c93ab0289304193a287697665d6da9b409ba0

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -54,7 +54,7 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: b9b3f9aaed7508518ba63a889e3492a4729ed361
+              value: 314c93ab0289304193a287697665d6da9b409ba0
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:e6448c4c476344eea647f4926872169c25adaa011a5d69c60dfc017cff8d05d9
             - name: PYTHONPATH

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -46,7 +46,7 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: b9b3f9aaed7508518ba63a889e3492a4729ed361
+              value: 314c93ab0289304193a287697665d6da9b409ba0
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:e6448c4c476344eea647f4926872169c25adaa011a5d69c60dfc017cff8d05d9
             - name: DB_DSN

--- a/argocd/applications/torghut-options/archive/deployment.yaml
+++ b/argocd/applications/torghut-options/archive/deployment.yaml
@@ -100,9 +100,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2411-gb9b3f9aae
+              value: v0.596.0-2517-g314c93ab0
             - name: TORGHUT_OPTIONS_COMMIT
-              value: b9b3f9aaed7508518ba63a889e3492a4729ed361
+              value: 314c93ab0289304193a287697665d6da9b409ba0
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -110,9 +110,9 @@ spec:
                   name: torghut-ws-config
                   key: SYMBOLS_ALLOWLIST
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2411-gb9b3f9aae
+              value: v0.596.0-2517-g314c93ab0
             - name: TORGHUT_OPTIONS_COMMIT
-              value: b9b3f9aaed7508518ba63a889e3492a4729ed361
+              value: 314c93ab0289304193a287697665d6da9b409ba0
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -106,9 +106,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-2411-gb9b3f9aae
+              value: v0.596.0-2517-g314c93ab0
             - name: TORGHUT_OPTIONS_COMMIT
-              value: b9b3f9aaed7508518ba63a889e3492a4729ed361
+              value: 314c93ab0289304193a287697665d6da9b409ba0
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/broker-economic-ledger-reconciliation-cronjob.yaml
+++ b/argocd/applications/torghut/broker-economic-ledger-reconciliation-cronjob.yaml
@@ -92,9 +92,9 @@ spec:
                 - name: TRADING_ACCOUNT_LABEL
                   value: PA3SX7FYNUTF
                 - name: TORGHUT_VERSION
-                  value: v0.596.0-2411-gb9b3f9aae
+                  value: v0.596.0-2517-g314c93ab0
                 - name: TORGHUT_COMMIT
-                  value: b9b3f9aaed7508518ba63a889e3492a4729ed361
+                  value: 314c93ab0289304193a287697665d6da9b409ba0
                 - name: TORGHUT_IMAGE_DIGEST
                   value: sha256:e6448c4c476344eea647f4926872169c25adaa011a5d69c60dfc017cff8d05d9
                 - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-21T18:43:27Z"
+        client.knative.dev/updateTimestamp: "2026-07-23T01:21:37Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -528,9 +528,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2411-gb9b3f9aae
+              value: v0.596.0-2517-g314c93ab0
             - name: TORGHUT_COMMIT
-              value: b9b3f9aaed7508518ba63a889e3492a4729ed361
+              value: 314c93ab0289304193a287697665d6da9b409ba0
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:e6448c4c476344eea647f4926872169c25adaa011a5d69c60dfc017cff8d05d9
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-21T18:43:27Z"
+        client.knative.dev/updateTimestamp: "2026-07-23T01:21:37Z"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
     spec:
@@ -453,9 +453,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2411-gb9b3f9aae
+              value: v0.596.0-2517-g314c93ab0
             - name: TORGHUT_COMMIT
-              value: b9b3f9aaed7508518ba63a889e3492a4729ed361
+              value: 314c93ab0289304193a287697665d6da9b409ba0
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:e6448c4c476344eea647f4926872169c25adaa011a5d69c60dfc017cff8d05d9
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/order-lineage-reconciliation-cronjob.yaml
+++ b/argocd/applications/torghut/order-lineage-reconciliation-cronjob.yaml
@@ -88,9 +88,9 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_VERSION
-                  value: v0.596.0-2411-gb9b3f9aae
+                  value: v0.596.0-2517-g314c93ab0
                 - name: TORGHUT_COMMIT
-                  value: b9b3f9aaed7508518ba63a889e3492a4729ed361
+                  value: 314c93ab0289304193a287697665d6da9b409ba0
                 - name: TORGHUT_IMAGE_DIGEST
                   value: sha256:e6448c4c476344eea647f4926872169c25adaa011a5d69c60dfc017cff8d05d9
                 - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -470,9 +470,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-2411-gb9b3f9aae
+              value: v0.596.0-2517-g314c93ab0
             - name: TORGHUT_COMMIT
-              value: b9b3f9aaed7508518ba63a889e3492a4729ed361
+              value: 314c93ab0289304193a287697665d6da9b409ba0
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:e6448c4c476344eea647f4926872169c25adaa011a5d69c60dfc017cff8d05d9
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `314c93ab0289304193a287697665d6da9b409ba0`
- Image tag: `sha-314c93ab0289304193a287697665d6da9b409ba0`
- Image digest: `sha256:e6448c4c476344eea647f4926872169c25adaa011a5d69c60dfc017cff8d05d9`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher