### PR TITLE
feat(signal): run cross-asset history backfill

### DIFF
--- a/argocd/applications/torghut/clickhouse/kustomization.yaml
+++ b/argocd/applications/torghut/clickhouse/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   - signal-schema-job.yaml
   - intraday-bars-schema-job.yaml
   - bayn-universe-v2-configmap.yaml
+  - signal-cross-asset-backfill-20160104-20260722.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/signal-publisher
     newName: registry.ide-newton.ts.net/lab/signal-publisher

--- a/argocd/applications/torghut/clickhouse/signal-cross-asset-backfill-20160104-20260722.yaml
+++ b/argocd/applications/torghut/clickhouse/signal-cross-asset-backfill-20160104-20260722.yaml
@@ -1,0 +1,122 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: signal-cross-asset-backfill-20160104-20260722
+  namespace: torghut
+  labels:
+    app.kubernetes.io/name: signal-adjusted-daily-publisher
+    app.kubernetes.io/part-of: signal
+  annotations:
+    argocd.argoproj.io/sync-wave: "5"
+spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 900
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: signal-adjusted-daily-publisher
+        app.kubernetes.io/part-of: signal
+        bayn.proompteng.ai/universe: cross-asset-taa-v1
+    spec:
+      automountServiceAccountToken: false
+      nodeSelector:
+        kubernetes.io/arch: arm64
+      restartPolicy: Never
+      serviceAccountName: torghut-runtime
+      securityContext:
+        fsGroup: 65532
+        runAsGroup: 65532
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: publish
+          image: registry.ide-newton.ts.net/lab/signal-publisher:bootstrap
+          imagePullPolicy: IfNotPresent
+          args:
+            - backfill
+            - --start
+            - "2016-01-04"
+            - --end
+            - "2026-07-22"
+          env:
+            - name: SIGNAL_UNIVERSE_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: bayn-universe-v2
+                  key: UNIVERSE_ID
+            - name: SIGNAL_UNIVERSE_SYMBOL_HASH
+              valueFrom:
+                configMapKeyRef:
+                  name: bayn-universe-v2
+                  key: UNIVERSE_SYMBOL_HASH
+            - name: SIGNAL_SYMBOLS
+              valueFrom:
+                configMapKeyRef:
+                  name: bayn-universe-v2
+                  key: UNIVERSE_SYMBOLS
+            - name: SIGNAL_START_DATE
+              valueFrom:
+                configMapKeyRef:
+                  name: bayn-universe-v2
+                  key: HISTORY_START_DATE
+            - name: SIGNAL_ALPACA_FEED
+              valueFrom:
+                configMapKeyRef:
+                  name: bayn-universe-v2
+                  key: HISTORY_FEED
+            - name: SIGNAL_CODE_REVISION
+              value: "72006ac26afef02e42fc1af8d434e49835cc40d6"
+            - name: SIGNAL_IMAGE_REPOSITORY
+              value: registry.ide-newton.ts.net/lab/signal-publisher
+            - name: SIGNAL_IMAGE_DIGEST
+              value: sha256:2561a79d2baaa998036344c121cc3986aedec365881911dd592d334163d82729
+            - name: SIGNAL_CLICKHOUSE_URL
+              value: http://torghut-clickhouse.torghut.svc.cluster.local:8123
+            - name: SIGNAL_CLICKHOUSE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: signal-publisher-clickhouse-auth
+                  key: username
+            - name: SIGNAL_CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: signal-publisher-clickhouse-auth
+                  key: password
+            - name: APCA_API_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: torghut-alpaca
+                  key: APCA_API_KEY_ID
+            - name: APCA_API_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: torghut-alpaca
+                  key: APCA_API_SECRET_KEY
+            - name: SIGNAL_CALENDAR_VERSION
+              value: alpaca-us-equity-calendar-v1
+            - name: SIGNAL_FINALIZATION_LAG_MINUTES
+              value: "90"
+            - name: SIGNAL_OPERATION_TIMEOUT_MS
+              value: "180000"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: "1"
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 128Mi

--- a/packages/scripts/src/signal/gitops-contract.test.ts
+++ b/packages/scripts/src/signal/gitops-contract.test.ts
@@ -13,6 +13,7 @@ const readWsConfig = () => readFileSync(resolve(root, 'argocd/applications/torgh
 const readWsDeployment = () => readFileSync(resolve(root, 'argocd/applications/torghut/ws/deployment.yaml'), 'utf8')
 const readSchedulerDeployment = () =>
   readFileSync(resolve(root, 'argocd/applications/torghut/scheduler-deployment.yaml'), 'utf8')
+const backfillManifest = 'signal-cross-asset-backfill-20160104-20260722.yaml'
 
 const csv = (value: string): string[] => value.split(',').map((item) => item.trim())
 const environment = (container: { env: Array<{ name: string }> }) =>
@@ -113,6 +114,54 @@ describe('Signal publisher GitOps authority contract', () => {
     expect(() => assertActivationProvenance(cronJob, kustomization)).not.toThrow()
   })
 
+  test('runs one bounded immutable cross-asset backfill while the scheduled writer is absent', () => {
+    const backfill = parse(read(backfillManifest))
+    const cronJob = parse(read('signal-publisher-cronjob.yaml'))
+    const kustomization = parse(read('kustomization.yaml'))
+    const container = backfill.spec.template.spec.containers[0]
+    const variables = environment(container)
+    const image = kustomization.images.find(
+      (entry: { name: string }) => entry.name === 'registry.ide-newton.ts.net/lab/signal-publisher',
+    )
+    const managedBackfills = kustomization.resources.filter((path: string) => path.includes('backfill'))
+
+    expect(cronJob.spec.suspend).toBe(true)
+    expect(kustomization.resources).not.toContain('signal-publisher-cronjob.yaml')
+    expect(managedBackfills).toEqual([backfillManifest])
+    expect(backfill.metadata).toMatchObject({
+      name: 'signal-cross-asset-backfill-20160104-20260722',
+      annotations: { 'argocd.argoproj.io/sync-wave': '5' },
+    })
+    expect(backfill.spec).toMatchObject({
+      backoffLimit: 1,
+      activeDeadlineSeconds: 900,
+      template: {
+        spec: {
+          automountServiceAccountToken: false,
+          restartPolicy: 'Never',
+          serviceAccountName: 'torghut-runtime',
+        },
+      },
+    })
+    expect(backfill.spec.ttlSecondsAfterFinished).toBeUndefined()
+    expect(container.args).toEqual(['backfill', '--start', '2016-01-04', '--end', '2026-07-22'])
+    expect(image).toMatchObject({
+      newName: 'registry.ide-newton.ts.net/lab/signal-publisher',
+      newTag: 'sha-72006ac26afef02e42fc1af8d434e49835cc40d6',
+      digest: 'sha256:2561a79d2baaa998036344c121cc3986aedec365881911dd592d334163d82729',
+    })
+    expect(variables.get('SIGNAL_CODE_REVISION')).toMatchObject({ value: image.newTag.slice(4) })
+    expect(variables.get('SIGNAL_IMAGE_REPOSITORY')).toMatchObject({ value: image.newName })
+    expect(variables.get('SIGNAL_IMAGE_DIGEST')).toMatchObject({ value: image.digest })
+    expect(variables.get('SIGNAL_UNIVERSE_ID')).toMatchObject(universeRef('UNIVERSE_ID'))
+    expect(variables.get('SIGNAL_UNIVERSE_SYMBOL_HASH')).toMatchObject(universeRef('UNIVERSE_SYMBOL_HASH'))
+    expect(variables.get('SIGNAL_SYMBOLS')).toMatchObject(universeRef('UNIVERSE_SYMBOLS'))
+    expect(variables.get('SIGNAL_START_DATE')).toMatchObject(universeRef('HISTORY_START_DATE'))
+    expect(variables.get('SIGNAL_ALPACA_FEED')).toMatchObject(universeRef('HISTORY_FEED'))
+    expect(variables.get('SIGNAL_OPERATION_TIMEOUT_MS')).toMatchObject({ value: '180000' })
+    expect([...variables.keys()].filter((name) => /BROKER|TIGERBEETLE|CAPITAL/.test(name))).toEqual([])
+  })
+
   test('limits database authority to the versioned append-only publication tables', () => {
     const installation = parse(read('clickhouse-cluster.yaml'))
     const profiles = installation.spec.configuration.profiles
@@ -162,6 +211,7 @@ describe('Signal publisher GitOps authority contract', () => {
     )
     expect(kustomization.resources.includes('signal-publisher-cronjob.yaml')).toBe(!cronJob.spec.suspend)
     expect(kustomization.resources).not.toContain('signal-publisher-bayn-v1-backfill-job.yaml')
+    expect(kustomization.resources).toContain(backfillManifest)
   })
 
   test('creates a replicated bounded intraday archive schema for Bayn reads', () => {


### PR DESCRIPTION
## Summary

- add one immutable GitOps Job to publish the finalized `cross-asset-taa-v1` adjusted-daily history from `2016-01-04` through `2026-07-22`
- reuse the promoted Signal publisher image, existing least-privilege ClickHouse writer, Alpaca credentials, and exact universe ConfigMap
- keep the scheduled publisher absent so only this bounded writer can run during the cutover
- prohibit broker, TigerBeetle, and capital authority in the rendered Job contract

## Related Issues

Part of PROOMPT-402

## Testing

- `bun test packages/scripts/src/signal/gitops-contract.test.ts` — 9 passed
- `bunx oxfmt --check packages/scripts/src/signal/gitops-contract.test.ts` — passed
- `bunx oxlint packages/scripts/src/signal/gitops-contract.test.ts` — 0 warnings and 0 errors
- `bun run lint:argocd` — 0 invalid resources and 0 errors
- `kustomize build --enable-helm argocd/applications/torghut` — rendered one digest-pinned backfill Job with exact bounds and no scheduled writer
- `git diff HEAD^ --check` — passed
- Alpaca calendar API confirmed `2026-07-22` was the latest completed exchange session after the configured 90-minute finalization lag

## Breaking Changes

This causes one bounded production data publication through GitOps. It performs read-only Alpaca historical/calendar requests and append-only writes to the existing Signal ClickHouse tables. It does not submit broker orders, mutate TigerBeetle, change Bayn deployment pins, or grant capital authority. After exact replica evidence is retained, a follow-up PR must remove this Job and restore the scheduled publisher.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and the section was removed.
- [x] Breaking changes and required follow-up actions are documented.
- [x] Documentation and production contract tests already describe the bounded publication sequence.