### PR TITLE
chore(torghut): promote ta image sha-3f278efb99dc88427bfc6171acbd96b34627ec3e

### DIFF
--- a/argocd/applications/torghut-options/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut-options/ta/flinkdeployment.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     app: torghut-options-ta
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:e5b1aa4d6f2333c0eeab80f35623f5b9798346ed27e8c90c6aed0d6324aed742
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:a99f6a3bcb923c86bbc8583012c46e20f5b9e8c863e214b7b5233e4c65aa1950
   imagePullPolicy: IfNotPresent
-  restartNonce: 38
+  restartNonce: 39
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   flinkConfiguration:
@@ -91,9 +91,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: sha-314c93ab0289304193a287697665d6da9b409ba0
+              value: sha-3f278efb99dc88427bfc6171acbd96b34627ec3e
             - name: TORGHUT_TA_COMMIT
-              value: 314c93ab0289304193a287697665d6da9b409ba0
+              value: 3f278efb99dc88427bfc6171acbd96b34627ec3e
           ports:
             - containerPort: 9249
               name: metrics

--- a/argocd/applications/torghut/market-data-archive/flinkdeployment.yaml
+++ b/argocd/applications/torghut/market-data-archive/flinkdeployment.yaml
@@ -9,9 +9,9 @@ metadata:
     argocd.argoproj.io/sync-wave: "4"
 spec:
   # The TA release workflow pins the same immutable image used by the live and simulation TA jobs.
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:e5b1aa4d6f2333c0eeab80f35623f5b9798346ed27e8c90c6aed0d6324aed742
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:a99f6a3bcb923c86bbc8583012c46e20f5b9e8c863e214b7b5233e4c65aa1950
   imagePullPolicy: IfNotPresent
-  restartNonce: 5
+  restartNonce: 6
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   flinkConfiguration:
@@ -55,9 +55,9 @@ spec:
                   name: signal-publisher-clickhouse-auth
                   key: password
             - name: TORGHUT_TA_VERSION
-              value: sha-314c93ab0289304193a287697665d6da9b409ba0
+              value: sha-3f278efb99dc88427bfc6171acbd96b34627ec3e
             - name: TORGHUT_TA_COMMIT
-              value: 314c93ab0289304193a287697665d6da9b409ba0
+              value: 3f278efb99dc88427bfc6171acbd96b34627ec3e
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:

--- a/argocd/applications/torghut/ta-sim/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta-sim/flinkdeployment.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     app: torghut-ta-sim
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:e5b1aa4d6f2333c0eeab80f35623f5b9798346ed27e8c90c6aed0d6324aed742
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:a99f6a3bcb923c86bbc8583012c46e20f5b9e8c863e214b7b5233e4c65aa1950
   imagePullPolicy: IfNotPresent
-  restartNonce: 37
+  restartNonce: 38
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   logConfiguration:
@@ -157,9 +157,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: sha-314c93ab0289304193a287697665d6da9b409ba0
+              value: sha-3f278efb99dc88427bfc6171acbd96b34627ec3e
             - name: TORGHUT_TA_COMMIT
-              value: 314c93ab0289304193a287697665d6da9b409ba0
+              value: 3f278efb99dc88427bfc6171acbd96b34627ec3e
           ports:
             - containerPort: 9249
               name: metrics

--- a/argocd/applications/torghut/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta/flinkdeployment.yaml
@@ -8,9 +8,9 @@ metadata:
   labels:
     app: torghut-ta
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:e5b1aa4d6f2333c0eeab80f35623f5b9798346ed27e8c90c6aed0d6324aed742
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:a99f6a3bcb923c86bbc8583012c46e20f5b9e8c863e214b7b5233e4c65aa1950
   imagePullPolicy: IfNotPresent
-  restartNonce: 35
+  restartNonce: 36
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   logConfiguration:
@@ -157,9 +157,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: sha-314c93ab0289304193a287697665d6da9b409ba0
+              value: sha-3f278efb99dc88427bfc6171acbd96b34627ec3e
             - name: TORGHUT_TA_COMMIT
-              value: 314c93ab0289304193a287697665d6da9b409ba0
+              value: 3f278efb99dc88427bfc6171acbd96b34627ec3e
           ports:
             - containerPort: 9249
               name: metrics


### PR DESCRIPTION
## Summary
Promote the Torghut TA image into GitOps manifests.

- Source commit: `3f278efb99dc88427bfc6171acbd96b34627ec3e`
- Image tag: `sha-3f278efb99dc88427bfc6171acbd96b34627ec3e`
- Image digest: `sha256:a99f6a3bcb923c86bbc8583012c46e20f5b9e8c863e214b7b5233e4c65aa1950`
- Manifests: live TA, sim TA, Bayn market-data archive, options TA