### PR TITLE
fix(bayn): require explicit fresh qualification release

### DIFF
--- a/.github/workflows/bayn-release.yml
+++ b/.github/workflows/bayn-release.yml
@@ -127,12 +127,14 @@ jobs:
               --digest "$IMAGE_DIGEST" \
               --strategy-behavior-hash "$strategy_behavior_hash" \
               --strategy-parameter-hash "$strategy_parameter_hash" \
+              --qualification-intent preserve \
               --rollout-timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           )"
-          jq -e '(.promotionAction == "promote" or .promotionAction == "hold") and (.qualificationMode == "preserve" or .qualificationMode == "replace")' <<< "$promotion"
+          jq -e '(.promotionAction == "promote" or .promotionAction == "hold") and .qualificationIntent == "preserve" and (.qualificationMode == "preserve" or .qualificationMode == "replace")' <<< "$promotion"
           {
             echo "promotion_action=$(jq -r '.promotionAction' <<< "$promotion")"
             echo "promotion_reason=$(jq -r '.promotionReason' <<< "$promotion")"
+            echo "qualification_intent=$(jq -r '.qualificationIntent' <<< "$promotion")"
             echo "qualification_mode=$(jq -r '.qualificationMode' <<< "$promotion")"
             echo "had_qualification_pin=$(jq -r '.hadQualificationPin' <<< "$promotion")"
             echo "qualification_bindings_match=$(jq -r '.qualificationBindingsMatch' <<< "$promotion")"
@@ -191,6 +193,7 @@ jobs:
             - Source commit: `${{ steps.release.outputs.source_sha }}`
             - Image tag: `${{ steps.release.outputs.tag }}`
             - Image digest: `${{ steps.release.outputs.digest }}`
+            - Qualification intent: `${{ steps.promotion.outputs.qualification_intent }}`
             - Qualification mode: `${{ steps.promotion.outputs.qualification_mode }}`
             - Existing pin: `${{ steps.promotion.outputs.had_qualification_pin }}`
             - Qualification identity bindings match: `${{ steps.promotion.outputs.qualification_bindings_match }}`
@@ -219,8 +222,9 @@ jobs:
             This is a one-way current-contract runtime release. Databases with the old migration tracker are rejected;
             there is no schema fallback or automatic rename. `preserve` keeps the terminal run only when compiled
             behavior, protocol parameters, Signal inputs, TigerBeetle cluster ID, and TigerBeetle ledger all match.
-            Replica addresses are transport and are rewritten without relabeling qualification evidence. `replace`
-            removes an existing incompatible pin only for a fresh Signal snapshot. Once that one-shot release is
+            Replica addresses are transport and are rewritten without relabeling qualification evidence. Automatic
+            releases declare `preserve` intent and cannot remove an incompatible pin. A separate explicit `fresh`
+            invocation may replace the pin and dossier only for a new Signal snapshot. Once that one-shot release is
             unpinned, a different source revision is rejected until the terminal run is pinned or the snapshot
             advances. Promotion never creates a qualification pin.
 

--- a/packages/scripts/src/bayn/release-workflow.test.ts
+++ b/packages/scripts/src/bayn/release-workflow.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+
+const workflow = readFileSync('.github/workflows/bayn-release.yml', 'utf8')
+
+describe('Bayn release workflow', () => {
+  test('automatic releases explicitly preserve terminal qualification evidence', () => {
+    expect(workflow).toContain('--qualification-intent preserve')
+    expect(workflow).toContain('.qualificationIntent == "preserve"')
+  })
+})

--- a/packages/scripts/src/bayn/update-manifests.test.ts
+++ b/packages/scripts/src/bayn/update-manifests.test.ts
@@ -31,7 +31,7 @@ interface FixtureOptions {
   readonly tigerBeetleAddresses?: string
   readonly behaviorHash?: string
   readonly parameterHash?: string
-  readonly qualificationRunId?: string | undefined
+  readonly qualificationRunId?: string | null
   readonly qualificationDossierRunId?: string
 }
 
@@ -65,7 +65,7 @@ const makeFixture = (options: FixtureOptions = {}): FixturePaths => {
     BAYN_TIGERBEETLE_CLUSTER_ID: options.tigerBeetleClusterId ?? currentBindings.BAYN_TIGERBEETLE_CLUSTER_ID,
     BAYN_TIGERBEETLE_ADDRESSES: options.tigerBeetleAddresses ?? currentBindings.BAYN_TIGERBEETLE_ADDRESSES,
   }
-  const pin = options.qualificationRunId === undefined ? qualificationRunId : options.qualificationRunId
+  const pin = options.qualificationRunId === null ? undefined : (options.qualificationRunId ?? qualificationRunId)
   const dossierGenerator =
     pin === undefined
       ? ''
@@ -103,6 +103,7 @@ const promote = (
   paths: FixturePaths,
   overrides: Partial<Pick<UpdateBaynManifestOptions, 'strategyBehaviorHash' | 'strategyParameterHash'>> = {},
   sourceSha = 'a'.repeat(40),
+  qualificationIntent: UpdateBaynManifestOptions['qualificationIntent'] = 'preserve',
 ) => {
   return updateBaynManifests({
     sourceSha,
@@ -110,6 +111,7 @@ const promote = (
     digest: `sha256:${'b'.repeat(64)}`,
     strategyBehaviorHash: overrides.strategyBehaviorHash ?? strategyBehaviorHash,
     strategyParameterHash: overrides.strategyParameterHash ?? strategyParameterHash,
+    qualificationIntent,
     rolloutTimestamp: '2026-07-22T10:00:00Z',
     ...paths,
   })
@@ -144,7 +146,7 @@ describe('Bayn manifest promotion', () => {
 
     expect(promote(paths, { strategyParameterHash: '3'.repeat(64) })).toMatchObject({
       promotionAction: 'hold',
-      promotionReason: 'strategy-identity-change-requires-fresh-snapshot',
+      promotionReason: 'qualification-change-requires-explicit-fresh-mode',
       qualificationMode: 'replace',
       hadQualificationPin: true,
       qualificationBindingsMatch: true,
@@ -164,7 +166,12 @@ describe('Bayn manifest promotion', () => {
   test('rejects changed runtime bindings against an already-qualified snapshot', () => {
     const paths = makeFixture({ publicationAsOf: '2026-07-19' })
 
-    expect(() => promote(paths)).toThrow('qualification replacement requires a fresh BAYN_SIGNAL_SNAPSHOT_ID')
+    expect(promote(paths)).toMatchObject({
+      promotionAction: 'hold',
+      promotionReason: 'qualification-change-requires-explicit-fresh-mode',
+      qualificationIntent: 'preserve',
+      qualificationMode: 'replace',
+    })
   })
 
   test('preserves qualification while restoring replica-index-ordered TigerBeetle transport addresses', () => {
@@ -187,20 +194,38 @@ describe('Bayn manifest promotion', () => {
     )
   })
 
-  test('rejects a TigerBeetle cluster identity change against an already-qualified snapshot', () => {
+  test('holds a TigerBeetle cluster identity change against an already-qualified snapshot', () => {
     const paths = makeFixture({ tigerBeetleClusterId: '2001' })
 
-    expect(() => promote(paths)).toThrow('qualification replacement requires a fresh BAYN_SIGNAL_SNAPSHOT_ID')
+    expect(promote(paths)).toMatchObject({
+      promotionAction: 'hold',
+      promotionReason: 'qualification-change-requires-explicit-fresh-mode',
+      qualificationIntent: 'preserve',
+      qualificationMode: 'replace',
+    })
   })
 
-  test('replaces a pin for a fresh snapshot and rejects a second unpinned source release', () => {
+  test('requires explicit fresh intent before replacing a pin for a new snapshot', () => {
     const paths = makeFixture({ snapshotId: '4'.repeat(64), publicationAsOf: '2026-07-19' })
     const changedParameterHash = '3'.repeat(64)
-    const first = promote(paths, { strategyParameterHash: changedParameterHash })
+    const before = Object.values(paths).map((path) => readFileSync(path, 'utf8'))
+
+    expect(promote(paths, { strategyParameterHash: changedParameterHash })).toMatchObject({
+      promotionAction: 'hold',
+      promotionReason: 'qualification-change-requires-explicit-fresh-mode',
+      qualificationIntent: 'preserve',
+      qualificationMode: 'replace',
+      hadQualificationPin: true,
+      snapshotChanged: true,
+    })
+    expect(Object.values(paths).map((path) => readFileSync(path, 'utf8'))).toEqual(before)
+
+    const first = promote(paths, { strategyParameterHash: changedParameterHash }, 'a'.repeat(40), 'fresh')
 
     expect(first).toMatchObject({
       promotionAction: 'promote',
       promotionReason: 'eligible',
+      qualificationIntent: 'fresh',
       qualificationMode: 'replace',
       hadQualificationPin: true,
       qualificationBindingsMatch: false,
@@ -214,10 +239,33 @@ describe('Bayn manifest promotion', () => {
     expect(readFileSync(paths.deploymentPath, 'utf8')).toContain(
       environmentBlock('BAYN_SIGNAL_SNAPSHOT_ID', currentSnapshotId).trim(),
     )
+  })
+
+  test('rejects fresh qualification without a new snapshot or existing terminal pin', () => {
+    const sameSnapshot = makeFixture()
+    expect(() => promote(sameSnapshot, {}, 'a'.repeat(40), 'fresh')).toThrow(
+      'fresh qualification requires a new BAYN_SIGNAL_SNAPSHOT_ID',
+    )
+
+    const unpinned = makeFixture({
+      snapshotId: '4'.repeat(64),
+      publicationAsOf: '2026-07-19',
+      qualificationRunId: null,
+    })
+    expect(() => promote(unpinned, {}, 'a'.repeat(40), 'fresh')).toThrow(
+      'fresh qualification requires an existing terminal qualification pin',
+    )
+  })
+
+  test('rejects a second source release while a qualification is unpinned', () => {
+    const paths = makeFixture({ snapshotId: '4'.repeat(64), publicationAsOf: '2026-07-19' })
+    const changedParameterHash = '3'.repeat(64)
+    promote(paths, { strategyParameterHash: changedParameterHash }, 'a'.repeat(40), 'fresh')
 
     expect(promote(paths, { strategyParameterHash: changedParameterHash })).toMatchObject({
       promotionAction: 'promote',
       promotionReason: 'eligible',
+      qualificationIntent: 'preserve',
       qualificationMode: 'replace',
       hadQualificationPin: false,
       snapshotChanged: false,
@@ -240,9 +288,23 @@ describe('Bayn manifest promotion', () => {
         digest: 'sha256:bad',
         strategyBehaviorHash,
         strategyParameterHash,
+        qualificationIntent: 'preserve',
         rolloutTimestamp: 'now',
         applicationSetPath: 'unused',
       }),
     ).toThrow('invalid source SHA')
+
+    expect(() =>
+      updateBaynManifests({
+        sourceSha: 'a'.repeat(40),
+        tag: 'sha-main',
+        digest: `sha256:${'b'.repeat(64)}`,
+        strategyBehaviorHash,
+        strategyParameterHash,
+        qualificationIntent: 'invalid' as UpdateBaynManifestOptions['qualificationIntent'],
+        rolloutTimestamp: '2026-07-22T10:00:00Z',
+        applicationSetPath: 'unused',
+      }),
+    ).toThrow('invalid qualification intent')
   })
 })

--- a/packages/scripts/src/bayn/update-manifests.ts
+++ b/packages/scripts/src/bayn/update-manifests.ts
@@ -36,6 +36,7 @@ export interface UpdateBaynManifestOptions {
   readonly digest: string
   readonly strategyBehaviorHash: string
   readonly strategyParameterHash: string
+  readonly qualificationIntent: 'preserve' | 'fresh'
   readonly rolloutTimestamp: string
   readonly kustomizationPath?: string
   readonly deploymentPath?: string
@@ -44,7 +45,8 @@ export interface UpdateBaynManifestOptions {
 
 export interface BaynManifestUpdate {
   readonly promotionAction: 'promote' | 'hold'
-  readonly promotionReason: 'eligible' | 'strategy-identity-change-requires-fresh-snapshot'
+  readonly promotionReason: 'eligible' | 'qualification-change-requires-explicit-fresh-mode'
+  readonly qualificationIntent: 'preserve' | 'fresh'
   readonly qualificationMode: 'preserve' | 'replace'
   readonly hadQualificationPin: boolean
   readonly qualificationBindingsMatch: boolean
@@ -106,6 +108,9 @@ export const updateBaynManifests = (options: UpdateBaynManifestOptions): BaynMan
   if (!hashPattern.test(options.strategyParameterHash)) {
     throw new Error(`invalid strategy parameter hash: ${options.strategyParameterHash}`)
   }
+  if (options.qualificationIntent !== 'preserve' && options.qualificationIntent !== 'fresh') {
+    throw new Error(`invalid qualification intent: ${String(options.qualificationIntent)}`)
+  }
   if (Number.isNaN(Date.parse(options.rolloutTimestamp))) throw new Error('rollout timestamp must be ISO-8601')
 
   const kustomizationPath = options.kustomizationPath ?? 'argocd/applications/bayn/kustomization.yaml'
@@ -147,6 +152,7 @@ export const updateBaynManifests = (options: UpdateBaynManifestOptions): BaynMan
   const qualificationMode =
     hadQualificationPin && strategyIdentityMatches && qualificationBindingsMatch ? 'preserve' : 'replace'
   const updateDetails = {
+    qualificationIntent: options.qualificationIntent,
     qualificationMode,
     hadQualificationPin,
     qualificationBindingsMatch,
@@ -159,15 +165,18 @@ export const updateBaynManifests = (options: UpdateBaynManifestOptions): BaynMan
     candidateBehaviorHash: options.strategyBehaviorHash,
     candidateParameterHash: options.strategyParameterHash,
   } as const
-  if (hadQualificationPin && !strategyIdentityMatches && qualificationBindingsMatch && !snapshotChanged) {
+  if (options.qualificationIntent === 'fresh') {
+    if (!hadQualificationPin) throw new Error('fresh qualification requires an existing terminal qualification pin')
+    if (!snapshotChanged) throw new Error('fresh qualification requires a new BAYN_SIGNAL_SNAPSHOT_ID')
+    if (qualificationMode !== 'replace') {
+      throw new Error('fresh qualification requires changed qualification identity')
+    }
+  } else if (qualificationMode === 'replace' && hadQualificationPin) {
     return {
       promotionAction: 'hold',
-      promotionReason: 'strategy-identity-change-requires-fresh-snapshot',
+      promotionReason: 'qualification-change-requires-explicit-fresh-mode',
       ...updateDetails,
     }
-  }
-  if (qualificationMode === 'replace' && hadQualificationPin && !snapshotChanged) {
-    throw new Error('qualification replacement requires a fresh BAYN_SIGNAL_SNAPSHOT_ID')
   }
   if (!hadQualificationPin && !snapshotChanged && deployedSourceSha !== options.sourceSha) {
     throw new Error('an unpinned qualification snapshot cannot accept a second source release')
@@ -264,6 +273,7 @@ const parseArguments = (argumentsToParse: readonly string[]): UpdateBaynManifest
     digest: required('--digest'),
     strategyBehaviorHash: required('--strategy-behavior-hash'),
     strategyParameterHash: required('--strategy-parameter-hash'),
+    qualificationIntent: required('--qualification-intent') as UpdateBaynManifestOptions['qualificationIntent'],
     rolloutTimestamp: required('--rollout-timestamp'),
   }
 }

--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -46,8 +46,10 @@ The paper mutation capability, execution entry point, and capital-promotion path
 - `BAYN_QUALIFICATION_RUN_ID` optionally pins one terminal qualification across operational image updates. Startup
   verifies the stored strategy and Signal bindings, then recovers it without inspecting bars, opening a lock,
   evaluating, journaling, or persisting.
-- Production GitOps carries that pin outside an explicit one-shot qualification release. The release writer refuses a
-  second source revision on the same unpinned snapshot, preventing operational releases from creating new trials.
+- Production GitOps carries that pin outside an explicit one-shot qualification release. Automatic releases declare
+  preserve intent and hold any qualification-identity change. Removing a terminal pin and its dossier requires an
+  explicit fresh intent plus a new Signal snapshot. The writer then refuses a second source revision on that unpinned
+  snapshot, preventing operational releases from creating new trials.
 - The compiled risk-balanced trend decision function records every normalized trend horizon, volatility estimate,
   portfolio-volatility scale, and target weight at a month-end close. Decisions may execute only at the next exchange
   session open.


### PR DESCRIPTION
## Summary

- require every Bayn manifest release to declare `preserve` or `fresh` qualification intent
- make the automatic release workflow declare `preserve` and hold every qualification-identity change without writing GitOps files
- permit pin and dossier removal only with explicit `fresh` intent, an existing terminal pin, and a new Signal snapshot
- retain the existing one-source-per-unpinned-snapshot guard and document the one-shot contract

## Related Issues

Supports PROOMPT-403

## Testing

- `bun test packages/scripts/src/bayn` — 11 passed, 0 failed
- `bunx oxlint --config .oxlintrc.json packages/scripts/src/bayn/update-manifests.ts packages/scripts/src/bayn/update-manifests.test.ts packages/scripts/src/bayn/release-workflow.test.ts` — 0 warnings, 0 errors
- `bunx oxlint --config .oxlintrc.json --type-aware --tsconfig packages/scripts/tsconfig.json packages/scripts/src/bayn/update-manifests.ts packages/scripts/src/bayn/update-manifests.test.ts packages/scripts/src/bayn/release-workflow.test.ts` — 0 warnings, 0 errors
- `bunx oxfmt --check packages/scripts/src/bayn/update-manifests.ts packages/scripts/src/bayn/update-manifests.test.ts packages/scripts/src/bayn/release-workflow.test.ts .github/workflows/bayn-release.yml services/bayn/README.md`
- `actionlint -shellcheck '' -pyflakes '' .github/workflows/bayn-release.yml`
- `bunx tsc --ignoreConfig --noEmit --strict --target ES2024 --module preserve --moduleResolution bundler --types bun packages/scripts/src/bayn/update-manifests.ts packages/scripts/src/bayn/update-manifests.test.ts packages/scripts/src/bayn/release-workflow.test.ts`
- Repository-wide `packages/scripts` TypeScript still reports unrelated existing errors outside the changed Bayn files; the strict targeted compile above is clean.

## Breaking Changes

Automatic Bayn releases can no longer infer qualification replacement. A one-shot qualification release must invoke the writer with `--qualification-intent fresh` and a new source-controlled Signal snapshot identity.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is completed.
- [x] Documentation and the PROOMPT-403 follow-up are updated or tracked.
