### PR TITLE
feat(bayn): bind observe-only broker execution

### DIFF
--- a/services/bayn/src/app-test-support.ts
+++ b/services/bayn/src/app-test-support.ts
@@ -270,6 +270,7 @@ export const readyState = (): RuntimeState => {
         evidence: { status: 'AVAILABLE', checkedAt: '2026-07-20T00:00:00.000Z', error: null },
       },
     },
+    broker: null,
     error: null,
   }
 }

--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -3,7 +3,7 @@ import { Effect, Layer, Ref } from 'effect'
 import type { RuntimeConfig } from './config'
 import { EvidenceStore } from './db/evidence-store'
 import { operationalError, type OperationalError } from './errors'
-import { monitor } from './health'
+import { monitor, type BrokerProbe } from './health'
 import { makeHttpLayer } from './http'
 import { Journal } from './ledger'
 import { MarketData } from './market-data'
@@ -15,16 +15,17 @@ export const run = (
   config: RuntimeConfig,
   strategy: Strategy,
   reconciliation: Effect.Effect<void> = Effect.void,
+  broker?: BrokerProbe,
 ): Effect.Effect<never, OperationalError, MarketData | Journal | EvidenceStore> =>
   Effect.scoped(
     Effect.gen(function* () {
       const evidenceStore = yield* EvidenceStore
-      const state = yield* Ref.make(initialState())
+      const state = yield* Ref.make(initialState(broker))
       yield* Layer.build(
         makeHttpLayer(config, state, strategy.provenance, config.build.verification, evidenceStore.read),
       ).pipe(Effect.mapError((cause) => operationalError('http', 'listen', 'HTTP server failed to listen', cause)))
       yield* initialize(config, state, strategy)
-      yield* monitor(config, state).pipe(Effect.forkScoped({ startImmediately: true }))
+      yield* monitor(config, state, broker).pipe(Effect.forkScoped({ startImmediately: true }))
       yield* reconciliation
       return yield* Effect.never
     }),

--- a/services/bayn/src/broker/alpaca-mutations.test.ts
+++ b/services/bayn/src/broker/alpaca-mutations.test.ts
@@ -5,7 +5,7 @@ import { TestClock } from 'effect/testing'
 import { HttpClient, HttpClientResponse } from 'effect/unstable/http'
 
 import { canonicalHashV1 } from '../hash'
-import { IntentState, MutationOutcome, OrderSide, OrderType, TimeInForce, type Intent } from '../paper'
+import { Authority, IntentState, MutationOutcome, OrderSide, OrderType, TimeInForce, type Intent } from '../paper'
 import {
   BrokerMutationError,
   MutationFailure,
@@ -35,6 +35,7 @@ const accountResponse = {
 
 const options: MutationOptions = {
   expectedAccountId: accountId,
+  maximumAuthority: Authority.Paper,
   key: Redacted.make('paper-key'),
   secret: Redacted.make('paper-secret'),
   proxyUrl: 'http://bayn-egress-proxy:3128',
@@ -137,6 +138,30 @@ const requestBody = (request: Parameters<Parameters<typeof HttpClient.make>[0]>[
 }
 
 describe('Alpaca paper mutations', () => {
+  test('refuses to construct mutation capability below explicit PAPER authority', async () => {
+    let requests = 0
+    const client = HttpClient.make(() => {
+      requests += 1
+      return Effect.die(new Error('OBSERVE must not make a broker request through the mutation constructor'))
+    })
+
+    const failure = await Effect.runPromise(
+      Effect.flip(
+        makeMutation({ ...options, maximumAuthority: Authority.Observe }).pipe(
+          Effect.provideService(HttpClient.HttpClient, client),
+        ),
+      ),
+    )
+
+    expect(failure).toMatchObject({
+      operation: MutationOperation.Submit,
+      failure: MutationFailure.Configuration,
+      outcome: MutationOutcome.Known,
+      message: 'Alpaca mutation capability requires explicit PAPER maximum authority',
+    })
+    expect(requests).toBe(0)
+  })
+
   test('refuses to expose mutation capability when the credentials resolve a different account', async () => {
     let mutationCalls = 0
     const client = HttpClient.make(() => {

--- a/services/bayn/src/broker/alpaca-mutations.ts
+++ b/services/bayn/src/broker/alpaca-mutations.ts
@@ -3,6 +3,7 @@ import { Headers, HttpClient, HttpClientRequest, HttpClientResponse } from 'effe
 
 import { canonicalHashV1 } from '../hash'
 import {
+  Authority,
   IntentSchema,
   IntentState,
   MutationOutcome,
@@ -51,6 +52,7 @@ const ErrorResponseSchema = Schema.Struct({
 })
 const OptionsSchema = Schema.Struct({
   expectedAccountId: Uuid,
+  maximumAuthority: Schema.Enum(Authority),
   operationTimeoutMs: PositiveInteger,
 })
 
@@ -94,6 +96,7 @@ export class BrokerMutationError extends Data.TaggedError('BrokerMutationError')
 
 export interface MutationOptions {
   readonly expectedAccountId: string
+  readonly maximumAuthority: Authority
   readonly key: Redacted.Redacted<string>
   readonly secret: Redacted.Redacted<string>
   readonly proxyUrl: string
@@ -283,8 +286,14 @@ export const makeMutation = (
   Effect.gen(function* () {
     const runtime = yield* decodeOptions({
       expectedAccountId: options.expectedAccountId,
+      maximumAuthority: options.maximumAuthority,
       operationTimeoutMs: options.operationTimeoutMs,
     }).pipe(Effect.mapError((cause) => configurationError('invalid Alpaca mutation options', cause)))
+    if (runtime.maximumAuthority !== Authority.Paper) {
+      return yield* Effect.fail(
+        configurationError('Alpaca mutation capability requires explicit PAPER maximum authority'),
+      )
+    }
     const key = Redacted.value(options.key)
     const secret = Redacted.value(options.secret)
     if (key.length === 0 || key.trim() !== key || secret.length === 0 || secret.trim() !== secret) {

--- a/services/bayn/src/config.test.ts
+++ b/services/bayn/src/config.test.ts
@@ -118,6 +118,23 @@ describe('Effect configuration', () => {
     })
   })
 
+  test('requires a complete Alpaca binding for PAPER while allowing credential-free OBSERVE', async () => {
+    const observe = await Effect.runPromise(provideEnvironment(loadConfig(buildMetadata), runtimeEnvironment))
+    expect(observe.maximumAuthority).toBe(Authority.Observe)
+    expect(observe.alpaca).toBeUndefined()
+
+    const paper = new Map(runtimeEnvironment)
+    paper.set('BAYN_MAXIMUM_AUTHORITY', Authority.Paper)
+    const error = await Effect.runPromise(Effect.flip(provideEnvironment(loadConfig(buildMetadata), paper)))
+
+    expect(error).toMatchObject({
+      _tag: 'OperationalError',
+      component: 'config',
+      operation: 'alpaca',
+      message: 'PAPER maximum authority requires a complete Alpaca account binding',
+    })
+  })
+
   test('supports an explicit, visibly unverified development provenance path', async () => {
     const development = new Map(runtimeEnvironment)
     development.set('BAYN_PROVENANCE_MODE', 'development')
@@ -179,6 +196,9 @@ describe('Effect configuration', () => {
   test('accepts only the closed broker-authority vocabulary', async () => {
     const paper = new Map(runtimeEnvironment)
     paper.set('BAYN_MAXIMUM_AUTHORITY', Authority.Paper)
+    paper.set('BAYN_ALPACA_ACCOUNT_ID', '61e69015-8549-4bfd-b9c3-01e75843f47d')
+    paper.set('BAYN_ALPACA_KEY_ID', 'paper-key')
+    paper.set('BAYN_ALPACA_SECRET_KEY', 'paper-secret')
     expect((await Effect.runPromise(provideEnvironment(loadConfig(buildMetadata), paper))).maximumAuthority).toBe(
       Authority.Paper,
     )

--- a/services/bayn/src/config.ts
+++ b/services/bayn/src/config.ts
@@ -213,6 +213,11 @@ export const loadConfig = (
         retryAttempts: config.configuredAlpaca.retryAttempts,
         reconciliationIntervalMs: config.configuredAlpaca.reconciliationIntervalMs,
       }))
+      if (config.maximumAuthority === Authority.Paper && Option.isNone(alpaca)) {
+        return Effect.fail(
+          operationalError('config', 'alpaca', 'PAPER maximum authority requires a complete Alpaca account binding'),
+        )
+      }
       const { configuredAlpaca: _configuredAlpaca, ...runtime } = config
       return Effect.succeed({ ...runtime, ...(Option.isSome(alpaca) ? { alpaca: alpaca.value } : {}) })
     }),

--- a/services/bayn/src/execution/coordinator.test.ts
+++ b/services/bayn/src/execution/coordinator.test.ts
@@ -413,7 +413,7 @@ const makeHarness = (options: HarnessOptions = {}) => {
       Effect.provide(TestClock.layer()),
     )
   const provideIntentRead = <A, E>(effect: Effect.Effect<A, E, IntentStore>) =>
-    effect.pipe(Effect.provideService(IntentStore, intentStore))
+    effect.pipe(Effect.provideService(IntentStore, intentStore), Effect.provide(TestClock.layer()))
 
   return {
     provide,
@@ -445,6 +445,26 @@ describe('paper execution coordinator', () => {
       clientOrderId: intent.clientOrderId,
       requestHash: canonicalHashV1(orderRequestBody(intent)),
       request: orderRequestBody(intent),
+    })
+    expect(harness.calls()).toEqual({ submit: 0, cancel: 0, lookup: 0 })
+    expect(harness.state()).toBe(IntentState.Approved)
+  })
+
+  test('rejects a dry-run request when its approved risk decision has expired', async () => {
+    const harness = makeHarness()
+    const failure = await Effect.runPromise(
+      harness.provideIntentRead(
+        Effect.gen(function* () {
+          yield* TestClock.adjust(600_000)
+          return yield* Effect.flip(dryRunSubmit(intentId))
+        }),
+      ),
+    )
+
+    expect(failure).toBeInstanceOf(ExecutionError)
+    expect(failure).toMatchObject({
+      failure: ExecutionFailure.InvalidState,
+      message: `dry-run submission risk decision expired at ${riskDecision.expiresAt}`,
     })
     expect(harness.calls()).toEqual({ submit: 0, cancel: 0, lookup: 0 })
     expect(harness.state()).toBe(IntentState.Approved)

--- a/services/bayn/src/execution/coordinator.test.ts
+++ b/services/bayn/src/execution/coordinator.test.ts
@@ -27,8 +27,18 @@ import {
   type Order,
 } from '../broker/alpaca'
 import { canonicalHashV1 } from '../hash'
-import { IntentState, MutationOutcome, OrderSide, OrderType, TerminalOutcome, TimeInForce, type Intent } from '../paper'
-import { cancel, ExecutionError, ExecutionFailure, recover, submit } from './coordinator'
+import {
+  IntentState,
+  MutationOutcome,
+  OrderSide,
+  OrderType,
+  RiskOutcome,
+  TerminalOutcome,
+  TimeInForce,
+  type Intent,
+  type RiskDecision,
+} from '../paper'
+import { cancel, dryRunSubmit, ExecutionError, ExecutionFailure, recover, submit } from './coordinator'
 import { IntentStore, type IntentStoreService, type StoredIntent } from './intents'
 import { MutationEventType, MutationStore, mutationId, type MutationEvent, type MutationStoreShape } from './mutations'
 import { WriterFence, WriterFenceError } from './writer-fence'
@@ -56,6 +66,18 @@ const intent: Intent = {
   notionalLimitMicros: '200000000',
   state: IntentState.Approved,
   createdAt: initialTime,
+}
+
+const riskDecision: RiskDecision = {
+  schemaVersion: 'bayn.paper-risk-decision.v1',
+  decisionId: 'b'.repeat(64),
+  inputHash: 'f'.repeat(64),
+  intentId,
+  policyHash: intent.policyHash,
+  outcome: RiskOutcome.Approved,
+  reasonCodes: [],
+  decidedAt: initialTime,
+  expiresAt: '1970-01-01T00:10:00.000Z',
 }
 
 const brokerOrder = (status = OrderStatus.Accepted, observedAt = '1970-01-01T00:00:01.000Z'): Order => ({
@@ -110,7 +132,7 @@ interface HarnessOptions {
 }
 
 const makeHarness = (options: HarnessOptions = {}) => {
-  let stored: StoredIntent = { intent, stateVersion: 3, updatedAt: initialTime }
+  let stored: StoredIntent = { intent, decision: riskDecision, stateVersion: 3, updatedAt: initialTime }
   const latest = new Map<MutationOperation, MutationEvent>()
   let submitCalls = 0
   let cancelCalls = 0
@@ -390,9 +412,12 @@ const makeHarness = (options: HarnessOptions = {}) => {
       }),
       Effect.provide(TestClock.layer()),
     )
+  const provideIntentRead = <A, E>(effect: Effect.Effect<A, E, IntentStore>) =>
+    effect.pipe(Effect.provideService(IntentStore, intentStore))
 
   return {
     provide,
+    provideIntentRead,
     calls: () => ({ submit: submitCalls, cancel: cancelCalls, lookup: lookupCalls }),
     state: () => stored.intent.state,
   }
@@ -410,6 +435,21 @@ const mismatchedSubmissionError = () =>
   })
 
 describe('paper execution coordinator', () => {
+  test('renders the exact committed request without touching the broker or mutation store', async () => {
+    const harness = makeHarness()
+    const result = await Effect.runPromise(harness.provideIntentRead(dryRunSubmit(intentId)))
+
+    expect(result).toEqual({
+      schemaVersion: 'bayn.paper-submit-dry-run.v1',
+      intentId,
+      clientOrderId: intent.clientOrderId,
+      requestHash: canonicalHashV1(orderRequestBody(intent)),
+      request: orderRequestBody(intent),
+    })
+    expect(harness.calls()).toEqual({ submit: 0, cancel: 0, lookup: 0 })
+    expect(harness.state()).toBe(IntentState.Approved)
+  })
+
   test('records before submission and never calls the broker again for a replayed intent', async () => {
     const harness = makeHarness()
     const result = await Effect.runPromise(

--- a/services/bayn/src/execution/coordinator.ts
+++ b/services/bayn/src/execution/coordinator.ts
@@ -18,8 +18,8 @@ import {
   type ReadEvidence,
 } from '../broker/alpaca'
 import { canonicalHashV1 } from '../hash'
-import { IntentState, TerminalOutcome, type Intent } from '../paper'
-import { IntentStore } from './intents'
+import { IntentState, RiskOutcome, TerminalOutcome, type Intent } from '../paper'
+import { IntentStore, type IntentStoreError } from './intents'
 import { MutationEventType, MutationStore, type MutationEvent } from './mutations'
 import { WriterFence } from './writer-fence'
 
@@ -36,6 +36,14 @@ export class ExecutionError extends Data.TaggedError('ExecutionError')<{
   readonly eligibleAt?: string
   readonly cause?: unknown
 }> {}
+
+export interface DryRunSubmit {
+  readonly schemaVersion: 'bayn.paper-submit-dry-run.v1'
+  readonly intentId: string
+  readonly clientOrderId: string
+  readonly requestHash: string
+  readonly request: ReturnType<typeof orderRequestBody>
+}
 
 const now = Clock.currentTimeMillis.pipe(Effect.map((millis) => new Date(millis).toISOString()))
 
@@ -123,6 +131,46 @@ const isSubmitResolved = (event: MutationEvent): boolean =>
   event.eventType === MutationEventType.SubmitAccepted ||
   event.eventType === MutationEventType.SubmitRejected ||
   event.eventType === MutationEventType.RecoveryFound
+
+export const dryRunSubmit = (
+  intentId: string,
+): Effect.Effect<DryRunSubmit, ExecutionError | IntentStoreError, IntentStore> =>
+  readIntent(MutationOperation.Submit, intentId).pipe(
+    Effect.flatMap((stored) => {
+      if (
+        stored.intent.state !== IntentState.Approved ||
+        stored.decision?.outcome !== RiskOutcome.Approved ||
+        stored.intent.riskDecisionId !== stored.decision.decisionId
+      ) {
+        return Effect.fail(
+          new ExecutionError({
+            operation: MutationOperation.Submit,
+            failure: ExecutionFailure.InvalidState,
+            message: 'dry-run submission requires one committed approved intent and matching risk decision',
+          }),
+        )
+      }
+      return Effect.try({
+        try: (): DryRunSubmit => {
+          const request = orderRequestBody(stored.intent)
+          return {
+            schemaVersion: 'bayn.paper-submit-dry-run.v1',
+            intentId: stored.intent.intentId,
+            clientOrderId: stored.intent.clientOrderId,
+            requestHash: canonicalHashV1(request),
+            request,
+          }
+        },
+        catch: (cause) =>
+          new ExecutionError({
+            operation: MutationOperation.Submit,
+            failure: ExecutionFailure.InvalidState,
+            message: 'approved intent cannot be represented as an Alpaca paper order',
+            cause,
+          }),
+      })
+    }),
+  )
 
 const validateRecovery = (stored: Intent, event: MutationEvent) =>
   Effect.gen(function* () {

--- a/services/bayn/src/execution/coordinator.ts
+++ b/services/bayn/src/execution/coordinator.ts
@@ -136,40 +136,53 @@ export const dryRunSubmit = (
   intentId: string,
 ): Effect.Effect<DryRunSubmit, ExecutionError | IntentStoreError, IntentStore> =>
   readIntent(MutationOperation.Submit, intentId).pipe(
-    Effect.flatMap((stored) => {
-      if (
-        stored.intent.state !== IntentState.Approved ||
-        stored.decision?.outcome !== RiskOutcome.Approved ||
-        stored.intent.riskDecisionId !== stored.decision.decisionId
-      ) {
-        return Effect.fail(
-          new ExecutionError({
-            operation: MutationOperation.Submit,
-            failure: ExecutionFailure.InvalidState,
-            message: 'dry-run submission requires one committed approved intent and matching risk decision',
-          }),
-        )
-      }
-      return Effect.try({
-        try: (): DryRunSubmit => {
-          const request = orderRequestBody(stored.intent)
-          return {
-            schemaVersion: 'bayn.paper-submit-dry-run.v1',
-            intentId: stored.intent.intentId,
-            clientOrderId: stored.intent.clientOrderId,
-            requestHash: canonicalHashV1(request),
-            request,
-          }
-        },
-        catch: (cause) =>
-          new ExecutionError({
-            operation: MutationOperation.Submit,
-            failure: ExecutionFailure.InvalidState,
-            message: 'approved intent cannot be represented as an Alpaca paper order',
-            cause,
-          }),
-      })
-    }),
+    Effect.flatMap((stored) =>
+      Effect.gen(function* () {
+        const decision = stored.decision
+        if (
+          stored.intent.state !== IntentState.Approved ||
+          decision?.outcome !== RiskOutcome.Approved ||
+          stored.intent.riskDecisionId !== decision.decisionId
+        ) {
+          return yield* Effect.fail(
+            new ExecutionError({
+              operation: MutationOperation.Submit,
+              failure: ExecutionFailure.InvalidState,
+              message: 'dry-run submission requires one committed approved intent and matching risk decision',
+            }),
+          )
+        }
+        const currentTime = yield* Clock.currentTimeMillis
+        if (currentTime >= Date.parse(decision.expiresAt)) {
+          return yield* Effect.fail(
+            new ExecutionError({
+              operation: MutationOperation.Submit,
+              failure: ExecutionFailure.InvalidState,
+              message: `dry-run submission risk decision expired at ${decision.expiresAt}`,
+            }),
+          )
+        }
+        return yield* Effect.try({
+          try: (): DryRunSubmit => {
+            const request = orderRequestBody(stored.intent)
+            return {
+              schemaVersion: 'bayn.paper-submit-dry-run.v1',
+              intentId: stored.intent.intentId,
+              clientOrderId: stored.intent.clientOrderId,
+              requestHash: canonicalHashV1(request),
+              request,
+            }
+          },
+          catch: (cause) =>
+            new ExecutionError({
+              operation: MutationOperation.Submit,
+              failure: ExecutionFailure.InvalidState,
+              message: 'approved intent cannot be represented as an Alpaca paper order',
+              cause,
+            }),
+        })
+      }),
+    ),
   )
 
 const validateRecovery = (stored: Intent, event: MutationEvent) =>

--- a/services/bayn/src/health.test.ts
+++ b/services/bayn/src/health.test.ts
@@ -5,12 +5,102 @@ import { TestClock } from 'effect/testing'
 
 import { config, successfulJournal, readyState, recoveringStore } from './app-test-support'
 import { monitor, probe } from './app'
+import { AccountStatus, type BrokerReadShape, type ReadResult, type Account } from './broker/alpaca'
 import { EvidenceStore } from './db/evidence-store'
+import type { BrokerProbe } from './health'
 import { Journal, type JournalService } from './ledger'
 import { MarketData, type MarketDataService } from './market-data'
+import { initialState } from './runtime-state'
 import { makeSnapshot } from './test-fixtures'
 
+const brokerAccountId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const accountResult = (id = brokerAccountId): ReadResult<Account> => ({
+  value: {
+    id,
+    status: AccountStatus.Active,
+    currency: 'USD',
+    cashMicros: '1000000',
+    equityMicros: '1000000',
+    buyingPowerMicros: '1000000',
+    accountBlocked: false,
+    tradingBlocked: false,
+    tradeSuspendedByUser: false,
+    observedAt: '2026-07-20T00:00:00.000Z',
+  },
+  evidence: {
+    requestId: 'broker-health-request',
+    status: 200,
+    contentHash: 'a'.repeat(64),
+    observedAt: '2026-07-20T00:00:00.000Z',
+  },
+})
+
+const brokerRead = (account: BrokerReadShape['account']): BrokerReadShape => {
+  const unused = Effect.die(new Error('continuous broker health must only read the account'))
+  return {
+    account,
+    positions: unused,
+    orders: () => unused,
+    orderById: () => unused,
+    orderByClientId: () => unused,
+    fillActivities: () => unused,
+  }
+}
+
 describe('Bayn continuous health', () => {
+  test('requires the configured broker account GET while keeping execution disabled under OBSERVE', async () => {
+    let observedAccountId = brokerAccountId
+    const broker: BrokerProbe = {
+      read: brokerRead(Effect.sync(() => accountResult(observedAccountId))),
+      expectedAccountId: brokerAccountId,
+      executionEligible: false,
+      executionDisabledReason: 'MAXIMUM_AUTHORITY_OBSERVE',
+    }
+    const initial = {
+      ...readyState(),
+      broker: initialState(broker).broker,
+    }
+    const state = await Effect.runPromise(Ref.make(initial))
+    const dependencies = (effect: Effect.Effect<void, never, MarketData | Journal | EvidenceStore>) =>
+      effect.pipe(
+        Effect.provideService(MarketData, {
+          check: Effect.succeed(makeSnapshot().manifest.finalizedSnapshot),
+          inspect: Effect.die(new Error('health probes must not inspect sessions')),
+          load: Effect.die(new Error('health probes must not load bars')),
+        }),
+        Effect.provideService(Journal, { ...successfulJournal, checkRun: () => Effect.void }),
+        Effect.provideService(EvidenceStore, recoveringStore(initial)),
+      )
+
+    await Effect.runPromise(dependencies(probe(config, state, broker)))
+    expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
+      status: 'READY',
+      broker: {
+        configured: true,
+        expectedAccountId: brokerAccountId,
+        accountId: brokerAccountId,
+        accountBound: true,
+        readAvailable: true,
+        executionEligible: false,
+        executionDisabledReason: 'MAXIMUM_AUTHORITY_OBSERVE',
+        error: null,
+      },
+    })
+
+    observedAccountId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+    await Effect.runPromise(dependencies(probe(config, state, broker)))
+    expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
+      status: 'DEGRADED',
+      broker: {
+        accountId: observedAccountId,
+        accountBound: false,
+        readAvailable: true,
+        error: `Alpaca account probe resolved ${observedAccountId}, expected ${brokerAccountId}`,
+      },
+      error: expect.stringContaining('broker: Alpaca account probe resolved'),
+    })
+  })
+
   test('degrades on a probe defect, preserves evidence, and recovers only after a complete success', async () => {
     const initial = readyState()
     const initialEvidence = initial.evidence

--- a/services/bayn/src/health.ts
+++ b/services/bayn/src/health.ts
@@ -1,5 +1,6 @@
 import { Cause, Clock, Duration, Effect, Exit, Option, Ref, Schedule } from 'effect'
 
+import type { BrokerReadShape } from './broker/alpaca'
 import type { RuntimeConfig } from './config'
 import type { FinalizedSnapshotProvenance } from './contracts'
 import { EvidenceStore, type QualificationRecord, type RecoveredEvaluationEvidence } from './db/evidence-store'
@@ -8,10 +9,25 @@ import { canonicalHashV1 } from './hash'
 import { Journal } from './ledger'
 import { MarketData } from './market-data'
 import { databaseOperation, withinDeadline } from './operations'
-import type { DependencyHealth, RuntimeEvidence, RuntimeHealth, RuntimeState } from './runtime-state'
+import type {
+  BrokerConfiguration,
+  BrokerStatus,
+  DependencyHealth,
+  RuntimeEvidence,
+  RuntimeHealth,
+  RuntimeState,
+} from './runtime-state'
 
 interface ProbeResult {
   readonly error: string | null
+}
+
+interface BrokerProbeResult extends ProbeResult {
+  readonly accountId: string | null
+}
+
+export interface BrokerProbe extends BrokerConfiguration {
+  readonly read: BrokerReadShape
 }
 
 const observe = <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<ProbeResult, never, R> =>
@@ -21,6 +37,22 @@ const observe = <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<ProbeRe
     if (Cause.hasInterrupts(exit.cause)) return yield* Effect.interrupt
     const errors = Cause.prettyErrors(exit.cause).map((error) => error.message)
     return { error: errors.join('; ') || 'unknown probe failure' }
+  })
+
+const observeBroker = (read: BrokerReadShape, timeoutMs: number): Effect.Effect<BrokerProbeResult> =>
+  Effect.gen(function* () {
+    const exit = yield* Effect.exit(
+      read.account.pipe(
+        Effect.timeoutOrElse({
+          duration: timeoutMs,
+          orElse: () => Effect.fail(new Error(`Alpaca account probe timed out after ${timeoutMs}ms`)),
+        }),
+      ),
+    )
+    if (Exit.isSuccess(exit)) return { accountId: exit.value.value.id, error: null }
+    if (Cause.hasInterrupts(exit.cause)) return yield* Effect.interrupt
+    const errors = Cause.prettyErrors(exit.cause).map((error) => error.message)
+    return { accountId: null, error: errors.join('; ') || 'unknown broker probe failure' }
   })
 
 const ensureSignalIdentity = (
@@ -82,6 +114,7 @@ const dependencyHealth = (result: ProbeResult, checkedAt: string): DependencyHea
 export const probe = (
   config: RuntimeConfig,
   state: Ref.Ref<RuntimeState>,
+  broker?: BrokerProbe,
 ): Effect.Effect<void, never, MarketData | Journal | EvidenceStore> =>
   Effect.gen(function* () {
     const marketData = yield* MarketData
@@ -89,56 +122,83 @@ export const probe = (
     const evidenceStore = yield* EvidenceStore
     const current = yield* Ref.get(state)
     const evidence = current.evidence
-    const [postgresql, signal, tigerBeetle, durableEvidence] = yield* Effect.all(
+    const [[postgresql, signal, tigerBeetle, durableEvidence], brokerResult] = yield* Effect.all(
       [
-        observe(
-          withinDeadline(
-            databaseOperation(evidenceStore.check, 'continuous-health'),
-            config.operationTimeoutMs,
-            'database',
-            'continuous-health',
-          ),
-        ),
-        observe(
-          withinDeadline(marketData.check, config.operationTimeoutMs, 'market-data', 'continuous-health').pipe(
-            Effect.flatMap((snapshot) => ensureSignalIdentity(snapshot, evidence)),
-          ),
-        ),
-        observe(
-          withinDeadline(
-            evidence === null ? journal.check : journal.checkRun(evidence.reconciliation),
-            config.operationTimeoutMs,
-            'journal',
-            'continuous-health',
-          ),
-        ),
-        observe(
-          evidence === null
-            ? Effect.fail(operationalError('database', 'verify-evidence', 'startup evidence is unavailable'))
-            : withinDeadline(
-                Effect.all([
-                  databaseOperation(
-                    evidenceStore.recover(evidence.evaluation.runId, evidence.provenance),
-                    'continuous-recovery',
-                  ),
-                  databaseOperation(
-                    evidenceStore.readQualification(evidence.evaluation.runId),
-                    'continuous-qualification',
-                  ),
-                ]),
+        Effect.all(
+          [
+            observe(
+              withinDeadline(
+                databaseOperation(evidenceStore.check, 'continuous-health'),
                 config.operationTimeoutMs,
                 'database',
-                'continuous-recovery',
-              ).pipe(
-                Effect.flatMap(([recovered, qualification]) =>
-                  ensureDurableEvidence(recovered, qualification, evidence),
-                ),
+                'continuous-health',
               ),
+            ),
+            observe(
+              withinDeadline(marketData.check, config.operationTimeoutMs, 'market-data', 'continuous-health').pipe(
+                Effect.flatMap((snapshot) => ensureSignalIdentity(snapshot, evidence)),
+              ),
+            ),
+            observe(
+              withinDeadline(
+                evidence === null ? journal.check : journal.checkRun(evidence.reconciliation),
+                config.operationTimeoutMs,
+                'journal',
+                'continuous-health',
+              ),
+            ),
+            observe(
+              evidence === null
+                ? Effect.fail(operationalError('database', 'verify-evidence', 'startup evidence is unavailable'))
+                : withinDeadline(
+                    Effect.all([
+                      databaseOperation(
+                        evidenceStore.recover(evidence.evaluation.runId, evidence.provenance),
+                        'continuous-recovery',
+                      ),
+                      databaseOperation(
+                        evidenceStore.readQualification(evidence.evaluation.runId),
+                        'continuous-qualification',
+                      ),
+                    ]),
+                    config.operationTimeoutMs,
+                    'database',
+                    'continuous-recovery',
+                  ).pipe(
+                    Effect.flatMap(([recovered, qualification]) =>
+                      ensureDurableEvidence(recovered, qualification, evidence),
+                    ),
+                  ),
+            ),
+          ],
+          { concurrency: 'unbounded' },
         ),
+        broker === undefined ? Effect.succeed(undefined) : observeBroker(broker.read, config.operationTimeoutMs),
       ],
       { concurrency: 'unbounded' },
     )
     const checkedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
+    let brokerStatus: BrokerStatus | null = current.broker
+    if (broker !== undefined) {
+      const result = brokerResult ?? { accountId: null, error: 'broker probe did not run' }
+      const accountBound = result.error === null && result.accountId === broker.expectedAccountId
+      const bindingError =
+        result.error ??
+        (accountBound
+          ? null
+          : `Alpaca account probe resolved ${result.accountId ?? 'no account'}, expected ${broker.expectedAccountId}`)
+      brokerStatus = {
+        configured: true,
+        expectedAccountId: broker.expectedAccountId,
+        accountId: result.accountId,
+        accountBound,
+        readAvailable: result.error === null,
+        checkedAt,
+        error: bindingError,
+        executionEligible: broker.executionEligible,
+        executionDisabledReason: broker.executionDisabledReason,
+      }
+    }
     const health: RuntimeHealth = {
       sequence: current.health.sequence + 1,
       checkedAt,
@@ -149,16 +209,26 @@ export const probe = (
         evidence: dependencyHealth(durableEvidence, checkedAt),
       },
     }
-    const failures = Object.entries(health.dependencies).filter(([, dependency]) => dependency.error !== null)
-    let next: RuntimeState = { ...current, health }
-    if (evidence !== null && failures.length === 0) {
-      next = { ...current, status: 'READY', health, error: null }
+    const dependencyFailures = Object.entries(health.dependencies).filter(([, dependency]) => dependency.error !== null)
+    const failedDependencies = dependencyFailures.map(([name]) => name)
+    const failureMessages = dependencyFailures.map(([name, dependency]) => `${name}: ${dependency.error}`)
+    if (
+      brokerStatus !== null &&
+      (brokerStatus.error !== null || brokerStatus.accountBound !== true || brokerStatus.readAvailable !== true)
+    ) {
+      failedDependencies.push('broker')
+      failureMessages.push(`broker: ${brokerStatus.error ?? 'account binding unavailable'}`)
+    }
+    let next: RuntimeState = { ...current, health, broker: brokerStatus }
+    if (evidence !== null && failureMessages.length === 0) {
+      next = { ...current, status: 'READY', health, broker: brokerStatus, error: null }
     } else if (evidence !== null) {
       next = {
         ...current,
         status: 'DEGRADED',
         health,
-        error: failures.map(([name, dependency]) => `${name}: ${dependency.error}`).join('; '),
+        broker: brokerStatus,
+        error: failureMessages.join('; '),
       }
     }
     yield* Ref.set(state, next)
@@ -170,7 +240,7 @@ export const probe = (
           service: 'bayn',
           checkedAt,
           probeSequence: health.sequence,
-          failedDependencies: failures.map(([name]) => name).join(','),
+          failedDependencies: failedDependencies.join(','),
         }),
       )
     }
@@ -179,5 +249,9 @@ export const probe = (
 export const monitor = (
   config: RuntimeConfig,
   state: Ref.Ref<RuntimeState>,
+  broker?: BrokerProbe,
 ): Effect.Effect<void, never, MarketData | Journal | EvidenceStore> =>
-  probe(config, state).pipe(Effect.repeat(Schedule.spaced(Duration.millis(config.healthIntervalMs))), Effect.asVoid)
+  probe(config, state, broker).pipe(
+    Effect.repeat(Schedule.spaced(Duration.millis(config.healthIntervalMs))),
+    Effect.asVoid,
+  )

--- a/services/bayn/src/http.test.ts
+++ b/services/bayn/src/http.test.ts
@@ -11,7 +11,9 @@ import {
   fetchJson,
   readyState,
 } from './app-test-support'
+import type { BrokerReadShape } from './broker/alpaca'
 import { DatabaseError, type EvidenceStoreService } from './db/evidence-store'
+import type { BrokerProbe } from './health'
 import { makeHttpLayer } from './http'
 import { Authority } from './paper'
 import { initialState } from './runtime-state'
@@ -63,6 +65,13 @@ describe('Bayn HTTP probes', () => {
               service: 'bayn',
               operational: { status: 'READY', ready: true, probeSequence: 1 },
               authority: { maximum: 'observe', brokerOrders: false, capitalPromotion: false },
+              broker: {
+                configured: false,
+                accountBound: false,
+                readAvailable: false,
+                executionEligible: false,
+                executionDisabledReason: 'ALPACA_NOT_CONFIGURED',
+              },
               build: { sourceRevision: provenance.sourceRevision, verification: 'embedded' },
               data: { status: 'CURRENT' },
               evidence: { status: 'CURRENT' },
@@ -185,6 +194,64 @@ describe('Bayn HTTP probes', () => {
             status: 200,
             body: { authority: { maximum: 'paper', brokerOrders: false, capitalPromotion: false } },
           })
+        }),
+      ),
+    )
+  })
+
+  test('keeps broker read capability out of runtime state and public status', async () => {
+    const unused = Effect.die(new Error('status must not invoke broker reads'))
+    const read: BrokerReadShape = {
+      account: unused,
+      positions: unused,
+      orders: () => unused,
+      orderById: () => unused,
+      orderByClientId: () => unused,
+      fillActivities: () => unused,
+    }
+    const broker: BrokerProbe = {
+      read,
+      expectedAccountId: 'paper-account-1',
+      executionEligible: false,
+      executionDisabledReason: 'MAXIMUM_AUTHORITY_OBSERVE',
+    }
+    const runtimeState = initialState(broker)
+    expect(runtimeState.broker).not.toHaveProperty('read')
+    expect(Object.values(runtimeState.broker ?? {}).some((value) => typeof value === 'function')).toBe(false)
+
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const state = yield* Ref.make(runtimeState)
+          const context = yield* Layer.build(
+            makeHttpLayer(
+              {
+                host: '127.0.0.1',
+                maximumAuthority: Authority.Observe,
+                operationTimeoutMs: 250,
+                port: 0,
+              },
+              state,
+              provenance,
+              'embedded',
+              successfulEvidenceStore.read,
+            ),
+          )
+          const address = Context.get(context, HttpServer.HttpServer).address
+          if (address._tag !== 'TcpAddress') throw new Error('test server did not bind a TCP port')
+
+          const response = yield* Effect.promise(() => fetchJson(address.port, '/v1/status'))
+          expect(response.body).toMatchObject({
+            broker: {
+              configured: true,
+              expectedAccountId: 'paper-account-1',
+              executionEligible: false,
+              executionDisabledReason: 'MAXIMUM_AUTHORITY_OBSERVE',
+            },
+          })
+          const publicBroker = response.body.broker as Record<string, unknown>
+          expect(publicBroker).not.toHaveProperty('read')
+          expect(Object.values(publicBroker).some((value) => typeof value === 'function')).toBe(false)
         }),
       ),
     )

--- a/services/bayn/src/http.ts
+++ b/services/bayn/src/http.ts
@@ -16,6 +16,21 @@ const verifiedState = (state: RuntimeState, dependency: DependencyHealth) => {
   return dependency.status === 'AVAILABLE' ? 'CURRENT' : 'INVALID'
 }
 
+const publicBrokerState = (state: RuntimeState) =>
+  state.broker === null
+    ? {
+        configured: false,
+        expectedAccountId: null,
+        accountId: null,
+        accountBound: false,
+        readAvailable: false,
+        checkedAt: null,
+        executionEligible: false,
+        executionDisabledReason: 'ALPACA_NOT_CONFIGURED',
+        error: null,
+      }
+    : state.broker
+
 const publicState = (
   state: RuntimeState,
   maximumAuthority: Authority,
@@ -63,6 +78,7 @@ const publicState = (
       status: accounting,
       reconciliation: state.evidence?.reconciliation ?? null,
     },
+    broker: publicBrokerState(state),
     authority: {
       maximum: maximumAuthority === Authority.Paper ? 'paper' : 'observe',
       brokerOrders: false,
@@ -93,6 +109,9 @@ export const makeHttpLayer = (
       const failedDependencies = Object.entries(current.health.dependencies)
         .filter(([, dependency]) => dependency.status !== 'AVAILABLE')
         .map(([name]) => name)
+      if (current.broker !== null && (current.broker.accountBound !== true || current.broker.readAvailable !== true)) {
+        failedDependencies.push('broker')
+      }
       return jsonResponse(
         {
           ready,

--- a/services/bayn/src/index.ts
+++ b/services/bayn/src/index.ts
@@ -1,16 +1,20 @@
 import { NodeHttpClient, NodeRuntime, NodeServices } from '@effect/platform-node'
 import { ClickhouseClient } from '@effect/sql-clickhouse'
-import { Effect, Layer, Logger, Redacted } from 'effect'
+import { Context, Effect, Layer, Logger, Redacted } from 'effect'
 
 import { run } from './app'
-import { live as AlpacaReadLive } from './broker/alpaca'
+import { BrokerRead, alpacaHttpLayer, live as AlpacaReadLive } from './broker/alpaca'
+import { BrokerMutation, makeMutation } from './broker/alpaca-mutations'
 import { verifyParameterHash } from './build'
 import { loadConfig } from './config'
 import { makeRuntimeProvenance } from './contracts'
 import { EvidenceStoreLive } from './db/evidence-store'
 import { PaperStoreLive } from './db/paper-store'
+import { IntentStoreLive } from './execution/intents'
+import { MutationStoreLive } from './execution/mutations'
 import { WriterFenceLive } from './execution/writer-fence'
 import { operationalError } from './errors'
+import type { BrokerProbe } from './health'
 import { JournalLive } from './ledger'
 import { MarketDataLive } from './market-data'
 import { acquireSqlLayer } from './operations'
@@ -55,6 +59,7 @@ const main = Effect.gen(function* () {
   const evidenceStore = yield* acquireSqlLayer(EvidenceStoreLive(config).pipe(Layer.provide(NodeServices.layer)))
   const journal = yield* acquireSqlLayer(JournalLive(config))
   let reconciliation = Effect.void
+  let broker: BrokerProbe | undefined
   if (config.alpaca !== undefined) {
     const brokerRead = yield* Layer.build(
       AlpacaReadLive({
@@ -68,9 +73,22 @@ const main = Effect.gen(function* () {
     ).pipe(
       Effect.mapError((cause) => operationalError('config', 'alpaca', 'Alpaca paper account binding failed', cause)),
     )
+    broker = {
+      read: Context.get(brokerRead, BrokerRead),
+      expectedAccountId: config.alpaca.accountId,
+      executionEligible: false,
+      executionDisabledReason:
+        config.maximumAuthority === Authority.Observe
+          ? 'MAXIMUM_AUTHORITY_OBSERVE'
+          : 'PAPER_DISPATCH_REQUIRES_CYCLE_GATES',
+    }
     if (config.maximumAuthority === Authority.Paper) {
       const storage = Layer.mergeAll(Layer.succeedContext(evidenceStore), Layer.succeedContext(journal))
-      const paperStore = yield* Layer.build(PaperStoreLive(config).pipe(Layer.provide(storage)))
+      const paperStore = yield* Layer.build(PaperStoreLive(config).pipe(Layer.provide(storage))).pipe(
+        Effect.mapError((cause) =>
+          operationalError('database', 'paper-store', 'paper persistence composition failed', cause),
+        ),
+      )
       const writerFence = yield* Layer.build(
         WriterFenceLive.pipe(Layer.provide(Layer.succeedContext(evidenceStore))),
       ).pipe(
@@ -78,18 +96,39 @@ const main = Effect.gen(function* () {
           operationalError('database', 'writer-fence', 'paper writer fence acquisition failed', cause),
         ),
       )
-      const reconciliationDependencies = Layer.mergeAll(
+      const brokerMutation = yield* Layer.build(
+        Layer.effect(
+          BrokerMutation,
+          makeMutation({
+            expectedAccountId: config.alpaca.accountId,
+            maximumAuthority: config.maximumAuthority,
+            key: config.alpaca.key,
+            secret: config.alpaca.secret,
+            proxyUrl: config.alpaca.proxyUrl,
+            operationTimeoutMs: config.operationTimeoutMs,
+          }),
+        ).pipe(Layer.provide(alpacaHttpLayer(config.alpaca.proxyUrl))),
+      ).pipe(
+        Effect.mapError((cause) =>
+          operationalError('config', 'alpaca-mutation', 'Alpaca paper mutation binding failed', cause),
+        ),
+      )
+      const persistence = Layer.mergeAll(Layer.succeedContext(evidenceStore), Layer.succeedContext(writerFence))
+      const intentStore = yield* Layer.build(IntentStoreLive.pipe(Layer.provide(persistence)))
+      const mutationStore = yield* Layer.build(MutationStoreLive.pipe(Layer.provide(persistence)))
+      const paperExecution = Layer.mergeAll(
         Layer.succeedContext(brokerRead),
+        Layer.succeedContext(brokerMutation),
         Layer.succeedContext(paperStore),
         Layer.succeedContext(writerFence),
+        Layer.succeedContext(intentStore),
+        Layer.succeedContext(mutationStore),
       )
-      reconciliation = runContinuously(config.alpaca.reconciliationIntervalMs).pipe(
-        Effect.provide(reconciliationDependencies),
-      )
+      reconciliation = runContinuously(config.alpaca.reconciliationIntervalMs).pipe(Effect.provide(paperExecution))
     }
   }
   const dependencies = Layer.mergeAll(marketData, Layer.succeedContext(journal), Layer.succeedContext(evidenceStore))
-  return yield* run(config, strategy, reconciliation).pipe(Effect.provide(dependencies))
+  return yield* run(config, strategy, reconciliation, broker).pipe(Effect.provide(dependencies))
 }).pipe(Effect.scoped)
 
 const program = main.pipe(Effect.annotateLogs({ service: 'bayn' }), Effect.provide(Logger.layer([Logger.consoleJson])))

--- a/services/bayn/src/runtime-state.ts
+++ b/services/bayn/src/runtime-state.ts
@@ -36,16 +36,32 @@ export interface RuntimeHealth {
   }
 }
 
+export interface BrokerConfiguration {
+  readonly expectedAccountId: string
+  readonly executionEligible: boolean
+  readonly executionDisabledReason: string | null
+}
+
+export interface BrokerStatus extends BrokerConfiguration {
+  readonly configured: true
+  readonly accountId: string | null
+  readonly accountBound: boolean | null
+  readonly readAvailable: boolean | null
+  readonly checkedAt: string | null
+  readonly error: string | null
+}
+
 export interface RuntimeState {
   readonly status: 'STARTING' | 'READY' | 'DEGRADED' | 'FAILED'
   readonly evidence: RuntimeEvidence | null
   readonly health: RuntimeHealth
+  readonly broker: BrokerStatus | null
   readonly error: string | null
 }
 
 const unknownDependency = (): DependencyHealth => ({ status: 'UNKNOWN', checkedAt: null, error: null })
 
-export const initialState = (): RuntimeState => ({
+export const initialState = (broker?: BrokerConfiguration): RuntimeState => ({
   status: 'STARTING',
   evidence: null,
   health: {
@@ -58,10 +74,25 @@ export const initialState = (): RuntimeState => ({
       evidence: unknownDependency(),
     },
   },
+  broker:
+    broker === undefined
+      ? null
+      : {
+          configured: true,
+          expectedAccountId: broker.expectedAccountId,
+          executionEligible: broker.executionEligible,
+          executionDisabledReason: broker.executionDisabledReason,
+          accountId: null,
+          accountBound: null,
+          readAvailable: null,
+          checkedAt: null,
+          error: null,
+        },
   error: null,
 })
 
 export const isReady = (state: RuntimeState): boolean =>
   state.status === 'READY' &&
   state.evidence !== null &&
+  (state.broker === null || (state.broker.accountBound === true && state.broker.readAvailable === true)) &&
   Object.values(state.health.dependencies).every((dependency) => dependency.status === 'AVAILABLE')


### PR DESCRIPTION
## Summary

- Bind the existing Alpaca GET-only client into Bayn's single composition root and expose concrete account-binding/read status without retaining broker capabilities in public runtime state.
- Keep OBSERVE mutation-impossible: the mutation capability refuses construction below explicit `PAPER`, while the current OBSERVE root composes only reads/status and the exact dry-run request seam.
- Reuse the existing PAPER persistence, writer fence, mutation store, broker mutation, and reconciliation components only under the configured `PAPER` ceiling; cycle qualification remains outside this change.
- Fail configuration closed when `PAPER` is selected without a complete Alpaca binding, while preserving credential-free `OBSERVE` and the existing partial-credential failure.
- Reject expired approvals at the dry-run boundary before rendering any broker request.
- Add regression coverage for exact account binding, readiness degradation, capability non-leakage, deterministic/current dry-run requests, the PAPER construction gate, and authority/broker configuration coherence.

## Related Issues

PROOMPT-404

## Testing

- `bun run --filter @proompteng/bayn test` — 225 passed, 0 failed, 45 PostgreSQL integration cases skipped without `BAYN_TEST_POSTGRES_URL`.
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn build`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `git diff --check`
- CI `postgres-integration` — passed on PostgreSQL 18 for reviewed/fixed head `71dc0d0410`, including both `evidence-store.integration.test.ts` and `paper-store.integration.test.ts`.
- CI monorepo checks, changed-area validation, and both amd64/arm64 image builds — passed on `71dc0d0410`.
- Automatic Codex review — one expiry finding fixed in `71dc0d0410`; thread replied to with evidence and resolved, with zero unresolved review threads.
- Local PostgreSQL limitation: the existing CNPG `_test` port-forward transport terminated with `read: connection reset by peer` and `error: lost connection to pod` when the PostgreSQL client closed, so local DB integration was stopped. The exact temporary database was removed and no relay pod remains; supported CI provides the DB proof instead.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; no UI changed.
- [x] Breaking Changes is filled in.
- [x] Documentation and deployment follow-ups remain tracked in PROOMPT-404; this PR does not edit `argocd/applications/bayn/deployment.yaml`.