### PR TITLE
feat(bayn): add bounded Alpaca calendar read

### DIFF
--- a/services/bayn/src/broker/alpaca-test-support.ts
+++ b/services/bayn/src/broker/alpaca-test-support.ts
@@ -1,0 +1,6 @@
+import { Effect } from 'effect'
+
+import type { BrokerReadShape } from './alpaca'
+
+export const unusedMarketCalendar: BrokerReadShape['marketCalendar'] = () =>
+  Effect.die(new Error('unexpected Alpaca market calendar read'))

--- a/services/bayn/src/broker/alpaca.test.ts
+++ b/services/bayn/src/broker/alpaca.test.ts
@@ -26,6 +26,7 @@ import {
   readPreflightTimeoutMs,
   verifyReadAccess,
   type BrokerReadShape,
+  type MarketCalendarQuery,
   type ReadOptions,
 } from './alpaca'
 
@@ -152,6 +153,11 @@ const withClient = <A, E>(
 ): Effect.Effect<A, BrokerReadError | E> =>
   make(readOptions).pipe(Effect.flatMap(use), Effect.provideService(HttpClient.HttpClient, client))
 
+const readMarketCalendar = (read: BrokerReadShape, query: MarketCalendarQuery) => {
+  if (read.marketCalendar === undefined) return Effect.die('live Alpaca read is missing marketCalendar')
+  return read.marketCalendar(query)
+}
+
 describe('Alpaca paper reads', () => {
   test('reads and runtime-decodes the configured paper account without leaking credentials', async () => {
     let method = ''
@@ -184,7 +190,15 @@ describe('Alpaca paper reads', () => {
     expect(secret).toBe('paper-secret')
     expect(inspected).not.toContain('paper-key')
     expect(inspected).not.toContain('paper-secret')
-    expect(surface).toEqual(['account', 'fillActivities', 'orderByClientId', 'orderById', 'orders', 'positions'])
+    expect(surface).toEqual([
+      'account',
+      'fillActivities',
+      'marketCalendar',
+      'orderByClientId',
+      'orderById',
+      'orders',
+      'positions',
+    ])
     expect(result.value).toMatchObject({
       id: accountId,
       status: AccountStatus.Active,
@@ -204,6 +218,120 @@ describe('Alpaca paper reads', () => {
         reset: '1784664000',
         retryAfter: undefined,
       },
+    })
+  })
+
+  test('reads one bounded market calendar range and returns deterministic UTC observation evidence', async () => {
+    let method = ''
+    let requestedUrl: URL | undefined
+    const response = [
+      { date: '2026-03-09', open: '09:30', close: '16:00', session_open: '0400', session_close: '2000' },
+      { date: '2026-03-06', open: '09:30', close: '16:00', session_open: '0400', session_close: '2000' },
+    ]
+    const client = HttpClient.make((request, url) => {
+      method = request.method
+      requestedUrl = url
+      return Effect.succeed(jsonResponse(request, response))
+    })
+
+    const result = await Effect.runPromise(
+      withClient(client, (read) => readMarketCalendar(read, { start: '2026-03-06', end: '2026-03-10' })),
+    )
+
+    expect(method).toBe('GET')
+    expect(requestedUrl?.pathname).toBe('/v2/calendar')
+    expect(requestedUrl?.searchParams.toString()).toBe('start=2026-03-06&end=2026-03-10&date_type=TRADING')
+    const normalized = {
+      schemaVersion: 'bayn.alpaca-market-calendar-observation.v1',
+      source: 'alpaca-v2-calendar',
+      requestedRange: { start: '2026-03-06', end: '2026-03-10' },
+      timeZone: 'UTC',
+      sessions: [
+        {
+          date: '2026-03-06',
+          openAt: '2026-03-06T14:30:00.000Z',
+          closeAt: '2026-03-06T21:00:00.000Z',
+        },
+        {
+          date: '2026-03-09',
+          openAt: '2026-03-09T13:30:00.000Z',
+          closeAt: '2026-03-09T20:00:00.000Z',
+        },
+      ],
+    } as const
+    expect(result.value).toEqual({
+      ...normalized,
+      normalizedResponseHash: canonicalHashV1(normalized),
+    })
+    expect(result.evidence).toMatchObject({
+      requestId: 'req-123',
+      status: 200,
+      contentHash: canonicalHashV1(response),
+    })
+  })
+
+  test('rejects reversed or overlong market calendar ranges before broker I/O', async () => {
+    let calls = 0
+    const client = HttpClient.make((request) => {
+      calls += 1
+      return Effect.succeed(jsonResponse(request, []))
+    })
+
+    const reversed = await Effect.runPromise(
+      Effect.flip(withClient(client, (read) => readMarketCalendar(read, { start: '2026-03-10', end: '2026-03-09' }))),
+    )
+    expect(reversed).toMatchObject({
+      operation: 'market-calendar',
+      kind: BrokerReadErrorKind.InvalidRequest,
+      retryable: false,
+    })
+
+    const overlong = await Effect.runPromise(
+      Effect.flip(withClient(client, (read) => readMarketCalendar(read, { start: '2026-01-01', end: '2026-02-01' }))),
+    )
+    expect(overlong).toMatchObject({
+      operation: 'market-calendar',
+      kind: BrokerReadErrorKind.InvalidRequest,
+      retryable: false,
+    })
+    expect(calls).toBe(0)
+  })
+
+  test('fails closed on malformed, duplicate, or out-of-range market calendar rows', async () => {
+    let response: unknown = [{ date: '2026-03-09', open: '9:30', close: '16:00' }]
+    const client = HttpClient.make((request) => Effect.succeed(jsonResponse(request, response)))
+    const query = { start: '2026-03-06', end: '2026-03-10' }
+
+    const malformed = await Effect.runPromise(
+      Effect.flip(withClient(client, (read) => readMarketCalendar(read, query))),
+    )
+    expect(malformed).toMatchObject({
+      operation: 'market-calendar',
+      kind: BrokerReadErrorKind.InvalidResponse,
+      retryable: false,
+    })
+
+    response = [
+      { date: '2026-03-09', open: '09:30', close: '16:00' },
+      { date: '2026-03-09', open: '09:30', close: '16:00' },
+    ]
+    const duplicate = await Effect.runPromise(
+      Effect.flip(withClient(client, (read) => readMarketCalendar(read, query))),
+    )
+    expect(duplicate).toMatchObject({
+      operation: 'market-calendar',
+      kind: BrokerReadErrorKind.InvalidResponse,
+      retryable: false,
+    })
+
+    response = [{ date: '2026-03-11', open: '09:30', close: '16:00' }]
+    const outsideRange = await Effect.runPromise(
+      Effect.flip(withClient(client, (read) => readMarketCalendar(read, query))),
+    )
+    expect(outsideRange).toMatchObject({
+      operation: 'market-calendar',
+      kind: BrokerReadErrorKind.InvalidResponse,
+      retryable: false,
     })
   })
 

--- a/services/bayn/src/broker/alpaca.test.ts
+++ b/services/bayn/src/broker/alpaca.test.ts
@@ -329,13 +329,17 @@ describe('Alpaca paper reads', () => {
       requests.push({ method: request.method, url })
       if (url.pathname === '/v2/account') return Effect.succeed(jsonResponse(request, accountResponse))
       if (url.pathname === '/v2/positions') return Effect.succeed(jsonResponse(request, []))
-      if (url.pathname === '/v2/orders' || url.pathname === '/v2/account/activities/FILL') {
+      if (
+        url.pathname === '/v2/orders' ||
+        url.pathname === '/v2/account/activities/FILL' ||
+        url.pathname === '/v2/calendar'
+      ) {
         return Effect.succeed(jsonResponse(request, []))
       }
       return Effect.succeed(jsonResponse(request, { code: 40410000, message: 'order not found' }, 404))
     })
 
-    const proof = await Effect.runPromise(withClient(client, verifyReadAccess))
+    const proof = await Effect.runPromise(withClient(client, verifyReadAccess).pipe(Effect.provide(TestClock.layer())))
 
     expect(proof).toMatchObject({
       accountId,
@@ -343,6 +347,7 @@ describe('Alpaca paper reads', () => {
       openOrderCount: 0,
       recentOrderCount: 0,
       fillCount: 0,
+      marketCalendarSessionCount: 0,
       orderById: 'NOT_FOUND',
       orderByClientId: 'NOT_FOUND',
     })
@@ -350,7 +355,8 @@ describe('Alpaca paper reads', () => {
     expect(proof.positionsHash).toMatch(/^[a-f0-9]{64}$/)
     expect(proof.ordersHash).toMatch(/^[a-f0-9]{64}$/)
     expect(proof.fillsHash).toMatch(/^[a-f0-9]{64}$/)
-    expect(requests).toHaveLength(7)
+    expect(proof.marketCalendarHash).toMatch(/^[a-f0-9]{64}$/)
+    expect(requests).toHaveLength(8)
     expect(requests.every(({ method }) => method === 'GET')).toBe(true)
     expect(
       requests
@@ -363,12 +369,18 @@ describe('Alpaca paper reads', () => {
     const fill = requests.find(({ url }) => url.pathname === '/v2/account/activities/FILL')
     expect(fill?.url.searchParams.get('page_size')).toBe('1')
     expect(fill?.url.searchParams.get('direction')).toBe('desc')
+    const calendar = requests.find(({ url }) => url.pathname === '/v2/calendar')
+    expect(calendar?.url.searchParams.toString()).toBe('start=1970-01-01&end=1970-01-14&date_type=TRADING')
   })
 
   test('preflights ordinary non-empty orders whose optional Alpaca fields are null', async () => {
     const client = HttpClient.make((request, url) => {
       if (url.pathname === '/v2/account') return Effect.succeed(jsonResponse(request, accountResponse))
-      if (url.pathname === '/v2/positions' || url.pathname === '/v2/account/activities/FILL') {
+      if (
+        url.pathname === '/v2/positions' ||
+        url.pathname === '/v2/account/activities/FILL' ||
+        url.pathname === '/v2/calendar'
+      ) {
         return Effect.succeed(jsonResponse(request, []))
       }
       return Effect.succeed(jsonResponse(request, url.pathname === '/v2/orders' ? [orderResponse] : orderResponse))
@@ -384,6 +396,24 @@ describe('Alpaca paper reads', () => {
       orderByClientId: 'MATCHED',
     })
     expect(proof.ordersHash).toMatch(/^[a-f0-9]{64}$/)
+  })
+
+  test('fails the complete startup preflight when the market calendar payload is invalid', async () => {
+    const client = HttpClient.make((request, url) => {
+      if (url.pathname === '/v2/account') return Effect.succeed(jsonResponse(request, accountResponse))
+      if (url.pathname === '/v2/calendar') {
+        return Effect.succeed(jsonResponse(request, [{ date: '2026-07-23', open: '9:30', close: '16:00' }]))
+      }
+      return Effect.succeed(jsonResponse(request, []))
+    })
+
+    const failure = await Effect.runPromise(Effect.flip(withClient(client, verifyReadAccess)))
+
+    expect(failure).toMatchObject({
+      operation: 'market-calendar',
+      kind: BrokerReadErrorKind.InvalidResponse,
+      retryable: false,
+    })
   })
 
   test('bounds the complete startup preflight below the Kubernetes startup-probe budget', async () => {

--- a/services/bayn/src/broker/alpaca.test.ts
+++ b/services/bayn/src/broker/alpaca.test.ts
@@ -26,7 +26,6 @@ import {
   readPreflightTimeoutMs,
   verifyReadAccess,
   type BrokerReadShape,
-  type MarketCalendarQuery,
   type ReadOptions,
 } from './alpaca'
 
@@ -153,11 +152,6 @@ const withClient = <A, E>(
 ): Effect.Effect<A, BrokerReadError | E> =>
   make(readOptions).pipe(Effect.flatMap(use), Effect.provideService(HttpClient.HttpClient, client))
 
-const readMarketCalendar = (read: BrokerReadShape, query: MarketCalendarQuery) => {
-  if (read.marketCalendar === undefined) return Effect.die('live Alpaca read is missing marketCalendar')
-  return read.marketCalendar(query)
-}
-
 describe('Alpaca paper reads', () => {
   test('reads and runtime-decodes the configured paper account without leaking credentials', async () => {
     let method = ''
@@ -235,7 +229,7 @@ describe('Alpaca paper reads', () => {
     })
 
     const result = await Effect.runPromise(
-      withClient(client, (read) => readMarketCalendar(read, { start: '2026-03-06', end: '2026-03-10' })),
+      withClient(client, (read) => read.marketCalendar({ start: '2026-03-06', end: '2026-03-10' })),
     )
 
     expect(method).toBe('GET')
@@ -278,7 +272,7 @@ describe('Alpaca paper reads', () => {
     })
 
     const reversed = await Effect.runPromise(
-      Effect.flip(withClient(client, (read) => readMarketCalendar(read, { start: '2026-03-10', end: '2026-03-09' }))),
+      Effect.flip(withClient(client, (read) => read.marketCalendar({ start: '2026-03-10', end: '2026-03-09' }))),
     )
     expect(reversed).toMatchObject({
       operation: 'market-calendar',
@@ -287,7 +281,7 @@ describe('Alpaca paper reads', () => {
     })
 
     const overlong = await Effect.runPromise(
-      Effect.flip(withClient(client, (read) => readMarketCalendar(read, { start: '2026-01-01', end: '2026-02-01' }))),
+      Effect.flip(withClient(client, (read) => read.marketCalendar({ start: '2026-01-01', end: '2026-02-01' }))),
     )
     expect(overlong).toMatchObject({
       operation: 'market-calendar',
@@ -302,9 +296,7 @@ describe('Alpaca paper reads', () => {
     const client = HttpClient.make((request) => Effect.succeed(jsonResponse(request, response)))
     const query = { start: '2026-03-06', end: '2026-03-10' }
 
-    const malformed = await Effect.runPromise(
-      Effect.flip(withClient(client, (read) => readMarketCalendar(read, query))),
-    )
+    const malformed = await Effect.runPromise(Effect.flip(withClient(client, (read) => read.marketCalendar(query))))
     expect(malformed).toMatchObject({
       operation: 'market-calendar',
       kind: BrokerReadErrorKind.InvalidResponse,
@@ -315,9 +307,7 @@ describe('Alpaca paper reads', () => {
       { date: '2026-03-09', open: '09:30', close: '16:00' },
       { date: '2026-03-09', open: '09:30', close: '16:00' },
     ]
-    const duplicate = await Effect.runPromise(
-      Effect.flip(withClient(client, (read) => readMarketCalendar(read, query))),
-    )
+    const duplicate = await Effect.runPromise(Effect.flip(withClient(client, (read) => read.marketCalendar(query))))
     expect(duplicate).toMatchObject({
       operation: 'market-calendar',
       kind: BrokerReadErrorKind.InvalidResponse,
@@ -325,9 +315,7 @@ describe('Alpaca paper reads', () => {
     })
 
     response = [{ date: '2026-03-11', open: '09:30', close: '16:00' }]
-    const outsideRange = await Effect.runPromise(
-      Effect.flip(withClient(client, (read) => readMarketCalendar(read, query))),
-    )
+    const outsideRange = await Effect.runPromise(Effect.flip(withClient(client, (read) => read.marketCalendar(query))))
     expect(outsideRange).toMatchObject({
       operation: 'market-calendar',
       kind: BrokerReadErrorKind.InvalidResponse,

--- a/services/bayn/src/broker/alpaca.ts
+++ b/services/bayn/src/broker/alpaca.ts
@@ -12,6 +12,7 @@ import {
 export const paperTradingUrl = 'https://paper-api.alpaca.markets'
 const defaultFillActivitiesPageSize = 100
 const maxMarketCalendarRangeDays = 31
+const marketCalendarPreflightRangeDays = 14
 const millisecondsPerDay = 86_400_000
 const marketCalendarSchemaVersion = 'bayn.alpaca-market-calendar-observation.v1' as const
 const marketCalendarSource = 'alpaca-v2-calendar' as const
@@ -408,6 +409,8 @@ export interface ReadPreflight {
   readonly ordersHash: string
   readonly fillCount: number
   readonly fillsHash: string
+  readonly marketCalendarSessionCount: number
+  readonly marketCalendarHash: string
   readonly orderById: 'MATCHED' | 'NOT_FOUND'
   readonly orderByClientId: 'MATCHED' | 'NOT_FOUND'
 }
@@ -1335,6 +1338,12 @@ const verifyOrderLookup = (
 export const verifyReadAccess = (read: BrokerReadShape): Effect.Effect<ReadPreflight, BrokerReadError> =>
   Effect.gen(function* () {
     const account = yield* read.account
+    const calendarStart = new Date(yield* Clock.currentTimeMillis).toISOString().slice(0, 10)
+    const calendarEnd = new Date(
+      Date.parse(`${calendarStart}T00:00:00.000Z`) + (marketCalendarPreflightRangeDays - 1) * millisecondsPerDay,
+    )
+      .toISOString()
+      .slice(0, 10)
     const responses = yield* Effect.all(
       {
         positions: read.positions,
@@ -1345,8 +1354,9 @@ export const verifyReadAccess = (read: BrokerReadShape): Effect.Effect<ReadPrefl
           direction: SortDirection.Descending,
         }),
         fills: read.fillActivities({ pageSize: 1, direction: SortDirection.Descending }),
+        marketCalendar: read.marketCalendar({ start: calendarStart, end: calendarEnd }),
       },
-      { concurrency: 4 },
+      { concurrency: 5 },
     )
     const order = responses.recentOrders.value[0] ?? responses.openOrders.value[0]
     const lookups =
@@ -1373,6 +1383,8 @@ export const verifyReadAccess = (read: BrokerReadShape): Effect.Effect<ReadPrefl
         }),
         fillCount: responses.fills.value.items.length,
         fillsHash: canonicalHashV1(responses.fills.value.items),
+        marketCalendarSessionCount: responses.marketCalendar.value.sessions.length,
+        marketCalendarHash: responses.marketCalendar.value.normalizedResponseHash,
         ...lookups,
       }),
       catch: (cause) =>
@@ -1395,6 +1407,8 @@ export const verifyReadAccess = (read: BrokerReadShape): Effect.Effect<ReadPrefl
         ordersHash: proof.ordersHash,
         fillCount: proof.fillCount,
         fillsHash: proof.fillsHash,
+        marketCalendarSessionCount: proof.marketCalendarSessionCount,
+        marketCalendarHash: proof.marketCalendarHash,
         orderById: proof.orderById,
         orderByClientId: proof.orderByClientId,
       }),

--- a/services/bayn/src/broker/alpaca.ts
+++ b/services/bayn/src/broker/alpaca.ts
@@ -391,7 +391,7 @@ export interface BrokerReadShape {
   readonly orderById: (orderId: string) => Effect.Effect<ReadResult<Order>, BrokerReadError>
   readonly orderByClientId: (clientOrderId: string) => Effect.Effect<ReadResult<Order>, BrokerReadError>
   readonly fillActivities: (query?: FillActivitiesQuery) => Effect.Effect<ReadResult<FillActivityPage>, BrokerReadError>
-  readonly marketCalendar?: (
+  readonly marketCalendar: (
     query: MarketCalendarQuery,
   ) => Effect.Effect<ReadResult<MarketCalendarObservation>, BrokerReadError>
 }

--- a/services/bayn/src/broker/alpaca.ts
+++ b/services/bayn/src/broker/alpaca.ts
@@ -1,5 +1,5 @@
 import { NodeHttpClient, Undici } from '@effect/platform-node'
-import { Cause, Clock, Context, Data, Effect, Layer, Redacted, Schema, Scope } from 'effect'
+import { Cause, Clock, Context, Data, DateTime, Effect, Layer, Redacted, Schema, Scope } from 'effect'
 import { Headers, HttpClient, HttpClientError, HttpClientRequest, HttpClientResponse } from 'effect/unstable/http'
 
 import { canonicalHashV1 } from '../hash'
@@ -11,6 +11,11 @@ import {
 
 export const paperTradingUrl = 'https://paper-api.alpaca.markets'
 const defaultFillActivitiesPageSize = 100
+const maxMarketCalendarRangeDays = 31
+const millisecondsPerDay = 86_400_000
+const marketCalendarSchemaVersion = 'bayn.alpaca-market-calendar-observation.v1' as const
+const marketCalendarSource = 'alpaca-v2-calendar' as const
+const marketCalendarTimeZone = 'America/New_York' as const
 export const readPreflightTimeoutMs = 45_000
 const responseParseOptions = { onExcessProperty: 'ignore' } as const
 const inputParseOptions = { onExcessProperty: 'error' } as const
@@ -206,6 +211,7 @@ export type BrokerReadOperation =
   | 'order-by-id'
   | 'order-by-client-id'
   | 'fill-activities'
+  | 'market-calendar'
 
 export class BrokerReadError extends Data.TaggedError('BrokerReadError')<{
   readonly operation: BrokerReadOperation
@@ -336,6 +342,29 @@ export interface FillActivityPage {
   readonly nextPageToken?: string
 }
 
+export interface MarketCalendarQuery {
+  readonly start: string
+  readonly end: string
+}
+
+export interface MarketCalendarSession {
+  readonly date: string
+  readonly openAt: string
+  readonly closeAt: string
+}
+
+export interface MarketCalendarObservation {
+  readonly schemaVersion: typeof marketCalendarSchemaVersion
+  readonly source: typeof marketCalendarSource
+  readonly requestedRange: {
+    readonly start: string
+    readonly end: string
+  }
+  readonly timeZone: 'UTC'
+  readonly sessions: readonly MarketCalendarSession[]
+  readonly normalizedResponseHash: string
+}
+
 export interface OrdersQuery {
   readonly status?: OrderCollection
   readonly limit?: number
@@ -362,6 +391,9 @@ export interface BrokerReadShape {
   readonly orderById: (orderId: string) => Effect.Effect<ReadResult<Order>, BrokerReadError>
   readonly orderByClientId: (clientOrderId: string) => Effect.Effect<ReadResult<Order>, BrokerReadError>
   readonly fillActivities: (query?: FillActivitiesQuery) => Effect.Effect<ReadResult<FillActivityPage>, BrokerReadError>
+  readonly marketCalendar?: (
+    query: MarketCalendarQuery,
+  ) => Effect.Effect<ReadResult<MarketCalendarObservation>, BrokerReadError>
 }
 
 export class BrokerRead extends Context.Service<BrokerRead, BrokerReadShape>()('bayn/BrokerRead') {}
@@ -457,6 +489,15 @@ const FillActivityResponseSchema = Schema.Struct({
   order_status: Schema.optionalKey(Schema.Enum(OrderStatus)),
 })
 
+const MarketTimeSchema = Schema.String.check(Schema.isPattern(/^(?:[01]\d|2[0-3]):[0-5]\d$/))
+const MarketCalendarResponseSchema = Schema.Array(
+  Schema.Struct({
+    date: IsoDate,
+    open: MarketTimeSchema,
+    close: MarketTimeSchema,
+  }),
+)
+
 const ResponseHeadersSchema = Schema.Struct({
   'x-request-id': RequestId,
   'x-ratelimit-limit': Schema.optionalKey(Schema.String.check(Schema.isPattern(/^\d+$/))),
@@ -498,6 +539,23 @@ const FillActivitiesQuerySchema = FillActivitiesQueryBase.check(
   ),
 )
 
+const MarketCalendarQueryBase = Schema.Struct({
+  start: IsoDate,
+  end: IsoDate,
+})
+const MarketCalendarQuerySchema = MarketCalendarQueryBase.check(
+  Schema.makeFilter((query: typeof MarketCalendarQueryBase.Type) => {
+    if (query.start > query.end) {
+      return [{ path: ['end'], issue: 'must be on or after start' }]
+    }
+    const inclusiveDays =
+      (Date.parse(`${query.end}T00:00:00.000Z`) - Date.parse(`${query.start}T00:00:00.000Z`)) / millisecondsPerDay + 1
+    return inclusiveDays > maxMarketCalendarRangeDays
+      ? [{ path: ['end'], issue: `range must not exceed ${maxMarketCalendarRangeDays} inclusive calendar days` }]
+      : []
+  }),
+)
+
 const RuntimeOptionsSchema = Schema.Struct({
   expectedAccountId: Uuid,
   operationTimeoutMs: PositiveInteger,
@@ -511,10 +569,12 @@ const decodePositions = Schema.decodeUnknownEffect(Schema.Array(PositionResponse
 const decodeOrders = Schema.decodeUnknownEffect(Schema.Array(OrderResponseSchema), responseParseOptions)
 const decodeOrder = Schema.decodeUnknownEffect(OrderResponseSchema, responseParseOptions)
 const decodeFillActivities = Schema.decodeUnknownEffect(Schema.Array(FillActivityResponseSchema), responseParseOptions)
+const decodeMarketCalendar = Schema.decodeUnknownEffect(MarketCalendarResponseSchema, responseParseOptions)
 const decodeResponseHeaders = HttpClientResponse.schemaHeaders(ResponseHeadersSchema, responseParseOptions)
 const decodeErrorResponse = Schema.decodeUnknownEffect(ErrorResponseSchema, responseParseOptions)
 const decodeOrdersQuery = Schema.decodeUnknownEffect(OrdersQuerySchema, inputParseOptions)
 const decodeFillActivitiesQuery = Schema.decodeUnknownEffect(FillActivitiesQuerySchema, inputParseOptions)
+const decodeMarketCalendarQuery = Schema.decodeUnknownEffect(MarketCalendarQuerySchema, inputParseOptions)
 const decodeOrderId = Schema.decodeUnknownEffect(Uuid)
 const decodeClientOrderId = Schema.decodeUnknownEffect(ClientOrderId)
 const decodeRuntimeOptions = Schema.decodeUnknownEffect(RuntimeOptionsSchema, inputParseOptions)
@@ -848,6 +908,64 @@ const normalizeFillActivity = (raw: typeof FillActivityResponseSchema.Type, acco
   }
 }
 
+const marketCalendarInstant = (date: string, time: string, field: 'open' | 'close'): string => {
+  const zoned = DateTime.makeZoned(
+    {
+      year: Number(date.slice(0, 4)),
+      month: Number(date.slice(5, 7)),
+      day: Number(date.slice(8, 10)),
+      hour: Number(time.slice(0, 2)),
+      minute: Number(time.slice(3, 5)),
+      second: 0,
+      millisecond: 0,
+    },
+    {
+      timeZone: marketCalendarTimeZone,
+      adjustForTimeZone: true,
+      disambiguation: 'reject',
+    },
+  )
+  if (zoned._tag === 'None') {
+    throw new Error(`market calendar ${field} is not a valid ${marketCalendarTimeZone} wall-clock instant`)
+  }
+  return DateTime.formatIso(zoned.value)
+}
+
+const normalizeMarketCalendar = (
+  raw: typeof MarketCalendarResponseSchema.Type,
+  query: typeof MarketCalendarQueryBase.Type,
+): MarketCalendarObservation => {
+  const sessions = raw
+    .map((session): MarketCalendarSession => {
+      if (session.date < query.start || session.date > query.end) {
+        throw new Error(`market calendar session ${session.date} is outside the requested range`)
+      }
+      const openAt = marketCalendarInstant(session.date, session.open, 'open')
+      const closeAt = marketCalendarInstant(session.date, session.close, 'close')
+      if (openAt >= closeAt) throw new Error(`market calendar session ${session.date} has invalid hours`)
+      return { date: session.date, openAt, closeAt }
+    })
+    .sort((left, right) => (left.date < right.date ? -1 : left.date > right.date ? 1 : 0))
+
+  for (let index = 1; index < sessions.length; index += 1) {
+    if (sessions[index - 1]?.date === sessions[index]?.date) {
+      throw new Error(`market calendar contains duplicate session ${sessions[index]?.date ?? ''}`)
+    }
+  }
+
+  const normalized = {
+    schemaVersion: marketCalendarSchemaVersion,
+    source: marketCalendarSource,
+    requestedRange: { start: query.start, end: query.end },
+    timeZone: 'UTC' as const,
+    sessions,
+  }
+  return {
+    ...normalized,
+    normalizedResponseHash: canonicalHashV1(normalized),
+  }
+}
+
 const responseEvidence = (
   headers: typeof ResponseHeadersSchema.Type,
   status: number,
@@ -1080,6 +1198,21 @@ export const make = (options: ReadOptions): Effect.Effect<BrokerReadShape, Broke
       ),
     )
 
+    const marketCalendar = (query: MarketCalendarQuery) =>
+      decodeInput('market-calendar', decodeMarketCalendarQuery, query, 'invalid Alpaca market calendar query').pipe(
+        Effect.flatMap((decoded) => {
+          const url = new URL('/v2/calendar', paperTradingUrl)
+          url.searchParams.set('start', decoded.start)
+          url.searchParams.set('end', decoded.end)
+          url.searchParams.set('date_type', 'TRADING')
+          return readJson('market-calendar', url, decodeMarketCalendar).pipe(
+            Effect.flatMap((result) =>
+              normalize('market-calendar', result.evidence, () => normalizeMarketCalendar(result.value, decoded)),
+            ),
+          )
+        }),
+      )
+
     const orders = (query: OrdersQuery = {}) =>
       decodeInput('orders', decodeOrdersQuery, query, 'invalid Alpaca orders query').pipe(
         Effect.flatMap((decoded) => {
@@ -1153,7 +1286,7 @@ export const make = (options: ReadOptions): Effect.Effect<BrokerReadShape, Broke
         ),
       )
 
-    return { account, positions, orders, orderById, orderByClientId, fillActivities }
+    return { account, positions, orders, orderById, orderByClientId, fillActivities, marketCalendar }
   })
 
 const missingOrderId = '00000000-0000-4000-8000-000000000000'

--- a/services/bayn/src/execution/coordinator.test.ts
+++ b/services/bayn/src/execution/coordinator.test.ts
@@ -26,6 +26,7 @@ import {
   type BrokerReadShape,
   type Order,
 } from '../broker/alpaca'
+import { unusedMarketCalendar } from '../broker/alpaca-test-support'
 import { canonicalHashV1 } from '../hash'
 import {
   IntentState,
@@ -389,6 +390,7 @@ const makeHarness = (options: HarnessOptions = {}) => {
       return Effect.succeed({ value, evidence: evidence(200, '1970-01-01T00:00:02.000Z') })
     },
     fillActivities: () => Effect.die(new Error('unexpected fill read')),
+    marketCalendar: unusedMarketCalendar,
   }
 
   const provide = <A, E, R>(effect: Effect.Effect<A, E, R>) =>

--- a/services/bayn/src/health.test.ts
+++ b/services/bayn/src/health.test.ts
@@ -6,6 +6,7 @@ import { TestClock } from 'effect/testing'
 import { config, successfulJournal, readyState, recoveringStore } from './app-test-support'
 import { monitor, probe } from './app'
 import { AccountStatus, type BrokerReadShape, type ReadResult, type Account } from './broker/alpaca'
+import { unusedMarketCalendar } from './broker/alpaca-test-support'
 import { EvidenceStore } from './db/evidence-store'
 import type { BrokerProbe } from './health'
 import { Journal, type JournalService } from './ledger'
@@ -44,6 +45,7 @@ const brokerRead = (account: BrokerReadShape['account']): BrokerReadShape => {
     orderById: () => unused,
     orderByClientId: () => unused,
     fillActivities: () => unused,
+    marketCalendar: unusedMarketCalendar,
   }
 }
 

--- a/services/bayn/src/http.test.ts
+++ b/services/bayn/src/http.test.ts
@@ -12,6 +12,7 @@ import {
   readyState,
 } from './app-test-support'
 import type { BrokerReadShape } from './broker/alpaca'
+import { unusedMarketCalendar } from './broker/alpaca-test-support'
 import { DatabaseError, type EvidenceStoreService } from './db/evidence-store'
 import type { BrokerProbe } from './health'
 import { makeHttpLayer } from './http'
@@ -208,6 +209,7 @@ describe('Bayn HTTP probes', () => {
       orderById: () => unused,
       orderByClientId: () => unused,
       fillActivities: () => unused,
+      marketCalendar: unusedMarketCalendar,
     }
     const broker: BrokerProbe = {
       read,

--- a/services/bayn/src/reconciler.test.ts
+++ b/services/bayn/src/reconciler.test.ts
@@ -21,6 +21,7 @@ import {
   type Order as BrokerOrder,
   type ReadEvidence,
 } from './broker/alpaca'
+import { unusedMarketCalendar } from './broker/alpaca-test-support'
 import { canonicalHashV1 } from './hash'
 import { ReconciliationStatus, type AccountingReceipt, type Valuation } from './paper'
 import { PaperStore, type PaperStoreShape } from './db/paper-store'
@@ -186,6 +187,7 @@ const emptyRead = (): BrokerReadShape => ({
   fillActivities: () => Effect.succeed({ value: { items: [] }, evidence: evidence('fills') }),
   orderById: () => Effect.die(new Error('unexpected order lookup')),
   orderByClientId: () => Effect.die(new Error('unexpected client order lookup')),
+  marketCalendar: unusedMarketCalendar,
 })
 
 const fence: WriterFenceService = {


### PR DESCRIPTION
## Summary

- add one bounded GET-only `/v2/calendar` operation to the existing Alpaca `BrokerRead` capability with explicit `TRADING` semantics
- runtime-decode calendar rows, normalize New York market hours to canonical UTC across DST, and produce deterministic sorted duplicate-free sessions
- return bindable source/schema/range metadata plus a normalized response hash while preserving the existing raw-response evidence; no scheduler, simulation, mutation, migration, or GitOps paths change

## Related Issues

PROOMPT-406

## Testing

- `cd services/bayn && bun test src/broker/alpaca.test.ts` (19 passed)
- `cd services/bayn && bun test` (228 passed, 45 environment-gated PostgreSQL integration cases skipped)
- `cd services/bayn && bun run tsc`
- `cd services/bayn && bun run lint`
- `cd services/bayn && bun run lint:oxlint`
- `cd services/bayn && bun run lint:oxlint:type`
- `cd services/bayn && bun run build`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Follow-up composition remains tracked in PROOMPT-406; this PR is only the exclusive broker-read slice.