### PR TITLE
chore(bayn): promote image sha-427976e4b5612fd1d2eb65ddf01f987fe0850c00

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: bayn
         app.kubernetes.io/part-of: bayn
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-23T03:44:29Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-23T05:39:34Z"
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
@@ -47,11 +47,11 @@ spec:
               protocol: TCP
           env:
             - name: BAYN_CODE_REVISION
-              value: 6e36949f82d8fbab510b01b7499923b535f110cc
+              value: 427976e4b5612fd1d2eb65ddf01f987fe0850c00
             - name: BAYN_IMAGE_REPOSITORY
               value: registry.ide-newton.ts.net/lab/bayn
             - name: BAYN_IMAGE_DIGEST
-              value: sha256:b0fb63e90e0e9b5b8b1a0883b8b0a498f5d05d194d669efe024aaec8162529ec
+              value: sha256:88f1a072f2f9b89f0563bc845eca14f83e3eba3b7135cbd931a7010f5147fd64
             - name: BAYN_STRATEGY_BEHAVIOR_HASH
               value: "43cece33d3db232ffb02ba78826727e50b5795319d09d27e1baa0c04709eb056"
             - name: BAYN_STRATEGY_PARAMETER_HASH

--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -22,5 +22,5 @@ configMapGenerator:
 images:
   - name: registry.ide-newton.ts.net/lab/bayn
     newName: registry.ide-newton.ts.net/lab/bayn
-    newTag: "sha-6e36949f82d8fbab510b01b7499923b535f110cc"
-    digest: sha256:b0fb63e90e0e9b5b8b1a0883b8b0a498f5d05d194d669efe024aaec8162529ec
+    newTag: "sha-427976e4b5612fd1d2eb65ddf01f987fe0850c00"
+    digest: sha256:88f1a072f2f9b89f0563bc845eca14f83e3eba3b7135cbd931a7010f5147fd64


### PR DESCRIPTION
## Summary

Promote the immutable Bayn image against the current Signal snapshot and dedicated Bayn TigerBeetle
ledger. Qualification-pin handling is selected from the verified compiled behavior identity.

- Source commit: `427976e4b5612fd1d2eb65ddf01f987fe0850c00`
- Image tag: `sha-427976e4b5612fd1d2eb65ddf01f987fe0850c00`
- Image digest: `sha256:88f1a072f2f9b89f0563bc845eca14f83e3eba3b7135cbd931a7010f5147fd64`
- Qualification mode: `preserve`
- Existing pin: `true`
- Qualification identity bindings match: `true`
- Snapshot changed: `false`
- Deployed snapshot: `840c75885270b349d4a992e003918ce7e6fe39730f981a20b2e88ae2db45a2e2`
- Candidate snapshot: `840c75885270b349d4a992e003918ce7e6fe39730f981a20b2e88ae2db45a2e2`
- Deployed behavior hash: `43cece33d3db232ffb02ba78826727e50b5795319d09d27e1baa0c04709eb056`
- Candidate behavior hash: `43cece33d3db232ffb02ba78826727e50b5795319d09d27e1baa0c04709eb056`
- Deployed parameter hash: `649148eeaaf1f3aa1f1dd6d129a93aeef6b07f63e1aa60b6ed79f91a9cf7bbf8`
- Candidate parameter hash: `649148eeaaf1f3aa1f1dd6d129a93aeef6b07f63e1aa60b6ed79f91a9cf7bbf8`

## Related Issues

PROOMPT-400

## Testing

- OCI index contains `linux/amd64` and `linux/arm64`.

## Screenshots (if applicable)

N/A

## Breaking Changes

This is a one-way current-contract runtime release. Databases with the old migration tracker are rejected;
there is no schema fallback or automatic rename. `preserve` keeps the terminal run only when compiled
behavior, protocol parameters, Signal inputs, TigerBeetle cluster ID, and TigerBeetle ledger all match.
Replica addresses are transport and are rewritten without relabeling qualification evidence. `replace`
removes an existing incompatible pin only for a fresh Signal snapshot. Once that one-shot release is
unpinned, a different source revision is rejected until the terminal run is pinned or the snapshot
advances. Promotion never creates a qualification pin.

## Checklist

- [x] Testing section documents exact validation.
- [x] Runtime source revision and image digest are immutable.
- [x] No broker or capital-promotion authority is introduced.