### PR TITLE
feat(bayn): add autonomous cycle runner

### DIFF
--- a/nix/images/bayn.nix
+++ b/nix/images/bayn.nix
@@ -21,8 +21,8 @@ import ./bun-workspace-service.nix {
   serviceName = "bayn";
   packageName = "@proompteng/bayn";
   depsHash = {
-    x86_64-linux = "sha256-+Pc9/PwLvC7t3hmN/owxwFoDoSKFg9h05VAIp/3C0DE=";
-    aarch64-linux = "sha256-7TTGoDjmxMi0zJ44u6oCW3ZqjAJByB6ehTuG6lCCzdM=";
+    x86_64-linux = "sha256-lPw4xA54l9s6o+46ulCWRA593QjsPyCS44/QSmQJyME=";
+    aarch64-linux = "sha256-5FQ4nmCpYkbLVzbG8vrCf4+Aqi943QylJlmlUQVWqdQ=";
   };
   installFilters = [
     "@proompteng/bayn"

--- a/services/bayn/src/cycle-runner.test.ts
+++ b/services/bayn/src/cycle-runner.test.ts
@@ -1,0 +1,479 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Cause, Deferred, Effect, Exit, Fiber, Logger, References } from 'effect'
+import { TestClock } from 'effect/testing'
+
+import {
+  BrokerRead,
+  BrokerReadError,
+  BrokerReadErrorKind,
+  type BrokerReadShape,
+  type MarketCalendarObservation,
+  type MarketCalendarQuery,
+} from './broker/alpaca'
+import { CycleState, makeCycleExecutionPolicy, type AutonomousCycle, type CycleDraft } from './cycle'
+import {
+  isMonthEndCycleDue,
+  makeDueCycleDraft,
+  marketCalendarQueryForSignal,
+  runAutonomousCyclePass,
+  selectNextExecutionSession,
+  startAutonomousCycleLoop,
+  type CycleCandidate,
+} from './cycle-runner'
+import { CycleStore, type CycleStoreShape } from './db/cycle-store'
+import { canonicalHashV1 } from './hash'
+import type { IsoDate } from './types'
+
+const evidence = {
+  requestId: 'calendar-request',
+  status: 200,
+  contentHash: 'c'.repeat(64),
+  observedAt: '2026-01-30T21:01:00.000Z',
+}
+
+const executionPolicy = makeCycleExecutionPolicy({
+  schemaVersion: 'bayn.autonomous-cycle-execution-policy.v1',
+  strategyExecutionModelHash: '3'.repeat(64),
+  submissionWindowMs: 30 * 60 * 1_000,
+  submissionCutoffBeforeOpenMs: 2 * 60 * 1_000,
+})
+
+const candidate = (
+  signalSessionDate: IsoDate = '2026-01-30',
+  accountId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+): CycleCandidate => ({
+  qualificationRunId: '1'.repeat(64),
+  strategyProtocolHash: '2'.repeat(64),
+  accountId,
+  signalSession: {
+    calendar_version: 'signal-XNYS-2026-v1',
+    session_date: signalSessionDate,
+    close_time: '16:00',
+    timezone: 'America/New_York',
+  },
+  executionPolicy,
+})
+
+const calendar = (
+  sessions: MarketCalendarObservation['sessions'],
+  requestedRange: MarketCalendarObservation['requestedRange'] = {
+    start: '2026-01-30',
+    end: '2026-03-01',
+  },
+): MarketCalendarObservation => {
+  const material = {
+    schemaVersion: 'bayn.alpaca-market-calendar-observation.v1' as const,
+    source: 'alpaca-v2-calendar' as const,
+    requestedRange,
+    timeZone: 'UTC' as const,
+    sessions,
+  }
+  return { ...material, normalizedResponseHash: canonicalHashV1(material) }
+}
+
+const monthEndCalendar = calendar([
+  {
+    date: '2026-01-30',
+    openAt: '2026-01-30T14:30:00.000Z',
+    closeAt: '2026-01-30T21:00:00.000Z',
+  },
+  {
+    date: '2026-02-02',
+    openAt: '2026-02-02T14:30:00.000Z',
+    closeAt: '2026-02-02T20:00:00.000Z',
+  },
+])
+
+const brokerRead = (marketCalendar: BrokerReadShape['marketCalendar']): BrokerReadShape => {
+  const unused = Effect.die(new Error('cycle runner must use only the broker calendar read'))
+  return {
+    account: unused,
+    positions: unused,
+    orders: () => unused,
+    orderById: () => unused,
+    orderByClientId: () => unused,
+    fillActivities: () => unused,
+    marketCalendar,
+  }
+}
+
+const cycleFrom = (draft: CycleDraft, observedAt: string): AutonomousCycle => ({
+  ...draft,
+  state: CycleState.Pending,
+  bindings: {},
+  stateVersion: 1,
+  createdAt: observedAt,
+  updatedAt: observedAt,
+})
+
+interface StoreControl {
+  readonly acquisitions: Array<{ readonly draft: CycleDraft; readonly observedAt: string }>
+}
+
+const cycleStore = (control: StoreControl): CycleStoreShape => {
+  const cycles = new Map<string, AutonomousCycle>()
+  const unused = () => Effect.die(new Error('cycle runner must only acquire a cycle'))
+  return {
+    acquire: (draft, observedAt) =>
+      Effect.sync(() => {
+        control.acquisitions.push({ draft, observedAt })
+        const existing = cycles.get(draft.identity.cycleId)
+        if (existing !== undefined) return { cycle: existing, created: false }
+        const created = cycleFrom(draft, observedAt)
+        cycles.set(draft.identity.cycleId, created)
+        return { cycle: created, created: true }
+      }),
+    read: unused,
+    bindSnapshot: unused,
+    activate: unused,
+    bindDecision: unused,
+    block: unused,
+  }
+}
+
+const provide = <A, E, R>(effect: Effect.Effect<A, E, R>, read: BrokerReadShape, store: CycleStoreShape) =>
+  effect.pipe(Effect.provideService(BrokerRead, read), Effect.provideService(CycleStore, store))
+
+describe('autonomous cycle runner', () => {
+  test('builds one bounded calendar query and selects the first session strictly after Signal', () => {
+    const query = marketCalendarQueryForSignal('2026-01-30')
+    const inclusiveDays =
+      (Date.parse(`${query.end}T00:00:00.000Z`) - Date.parse(`${query.start}T00:00:00.000Z`)) / 86_400_000 + 1
+    expect(query).toEqual({ start: '2026-01-30', end: '2026-03-01' })
+    expect(inclusiveDays).toBe(31)
+
+    const selected = selectNextExecutionSession(
+      '2026-01-30',
+      calendar([
+        {
+          date: '2026-02-03',
+          openAt: '2026-02-03T14:30:00.000Z',
+          closeAt: '2026-02-03T21:00:00.000Z',
+        },
+        {
+          date: '2026-01-30',
+          openAt: '2026-01-30T14:30:00.000Z',
+          closeAt: '2026-01-30T21:00:00.000Z',
+        },
+        {
+          date: '2026-02-02',
+          openAt: '2026-02-02T14:30:00.000Z',
+          closeAt: '2026-02-02T20:00:00.000Z',
+        },
+      ]),
+    )
+    expect(selected?.date).toBe('2026-02-02')
+  })
+
+  test('keeps the month-end predicate pure and binds only selected-session material', () => {
+    expect(isMonthEndCycleDue('2026-01-29', '2026-01-30')).toBe(false)
+    expect(isMonthEndCycleDue('2026-01-30', '2026-02-02')).toBe(true)
+
+    const selected = selectNextExecutionSession('2026-01-30', monthEndCalendar)
+    if (selected === undefined) throw new Error('month-end fixture must have an execution session')
+    const first = makeDueCycleDraft(candidate(), monthEndCalendar, selected)
+    const changedEvidence = calendar([selected], {
+      start: '2026-01-31',
+      end: '2026-02-10',
+    })
+    const second = makeDueCycleDraft(candidate(), changedEvidence, selected)
+    expect(first?.identity.cycleId).toBe(second?.identity.cycleId)
+    expect(first?.window).toMatchObject({
+      signalCloseAt: '2026-01-30T21:00:00.000Z',
+      publicationDeadlineAt: '2026-02-02T13:58:00.000Z',
+      submissionOpenAt: '2026-02-02T13:58:00.000Z',
+      submissionCutoffAt: '2026-02-02T14:28:00.000Z',
+      executionOpenAt: '2026-02-02T14:30:00.000Z',
+      executionCloseAt: '2026-02-02T20:00:00.000Z',
+    })
+
+    const ordinaryCandidate = candidate('2026-01-29')
+    const ordinarySession = {
+      date: '2026-01-30',
+      openAt: '2026-01-30T14:30:00.000Z',
+      closeAt: '2026-01-30T18:00:00.000Z',
+    }
+    expect(makeDueCycleDraft(ordinaryCandidate, calendar([ordinarySession]), ordinarySession)).toBeUndefined()
+  })
+
+  test('does not acquire an ordinary session and retains response evidence outside identity', async () => {
+    const control: StoreControl = { acquisitions: [] }
+    let observedQuery: MarketCalendarQuery | undefined
+    const observation = calendar([
+      {
+        date: '2026-01-30',
+        openAt: '2026-01-30T14:30:00.000Z',
+        closeAt: '2026-01-30T18:00:00.000Z',
+      },
+    ])
+    const read = brokerRead((query) => {
+      observedQuery = query
+      return Effect.succeed({ value: observation, evidence })
+    })
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse('2026-01-29T21:01:00.000Z'))
+        return yield* provide(runAutonomousCyclePass(candidate('2026-01-29')), read, cycleStore(control))
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(observedQuery).toEqual(marketCalendarQueryForSignal('2026-01-29'))
+    expect(result).toMatchObject({
+      outcome: 'NOT_DUE',
+      signalSessionDate: '2026-01-29',
+      executionSessionDate: '2026-01-30',
+      calendarResponseHash: observation.normalizedResponseHash,
+      calendarReadContentHash: evidence.contentHash,
+    })
+    expect(control.acquisitions).toEqual([])
+  })
+
+  test('fails typed when the bounded calendar has no future session or BrokerRead rejects drift', async () => {
+    const control: StoreControl = { acquisitions: [] }
+    const empty = brokerRead(() => Effect.succeed({ value: calendar([]), evidence }))
+    const missing = await Effect.runPromise(
+      Effect.flip(provide(runAutonomousCyclePass(candidate()), empty, cycleStore(control))),
+    )
+    expect(missing).toMatchObject({
+      _tag: 'CycleRunnerError',
+      operation: 'select-session',
+      failure: 'calendar-unavailable',
+    })
+
+    const drift = new BrokerReadError({
+      operation: 'market-calendar',
+      kind: BrokerReadErrorKind.InvalidResponse,
+      message: 'injected normalized response drift',
+      retryable: false,
+    })
+    const rejected = brokerRead(() => Effect.fail(drift))
+    const invalid = await Effect.runPromise(
+      Effect.flip(provide(runAutonomousCyclePass(candidate()), rejected, cycleStore(control))),
+    )
+    expect(invalid).toMatchObject({
+      _tag: 'CycleRunnerError',
+      operation: 'market-calendar',
+      failure: 'calendar-read',
+      cause: drift,
+    })
+    expect(control.acquisitions).toEqual([])
+  })
+
+  test('passes exact clock instants and committed boundaries to the store unchanged', async () => {
+    const control: StoreControl = { acquisitions: [] }
+    const read = brokerRead(() => Effect.succeed({ value: monthEndCalendar, evidence }))
+    const boundaries = [
+      '2026-01-30T21:00:00.000Z',
+      '2026-02-02T13:58:00.000Z',
+      '2026-02-02T14:28:00.000Z',
+      '2026-02-02T14:30:00.000Z',
+    ] as const
+    const program = Effect.gen(function* () {
+      for (const boundary of boundaries) {
+        yield* TestClock.setTime(Date.parse(boundary))
+        yield* provide(runAutonomousCyclePass(candidate()), read, cycleStore(control))
+      }
+    }).pipe(Effect.provide(TestClock.layer()))
+
+    await Effect.runPromise(program)
+    expect(control.acquisitions.map((acquisition) => acquisition.observedAt)).toEqual([...boundaries])
+    expect(
+      control.acquisitions.every(
+        (acquisition) =>
+          acquisition.draft.window.submissionOpenAt < acquisition.draft.window.submissionCutoffAt &&
+          acquisition.draft.window.submissionCutoffAt < acquisition.draft.window.executionOpenAt,
+      ),
+    ).toBe(true)
+  })
+
+  test('runs immediately, repeats on Schedule.spaced, and reacquires the same cycle on restart', async () => {
+    const control: StoreControl = { acquisitions: [] }
+    const store = cycleStore(control)
+    const read = brokerRead(() => Effect.succeed({ value: monthEndCalendar, evidence }))
+    const program = Effect.scoped(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse('2026-01-30T21:01:00.000Z'))
+        const fiber = yield* provide(
+          startAutonomousCycleLoop({
+            candidate: Effect.succeed(candidate()),
+            pollIntervalMs: 100,
+          }),
+          read,
+          store,
+        )
+        yield* Effect.yieldNow
+        expect(control.acquisitions).toHaveLength(1)
+        yield* TestClock.adjust(99)
+        expect(control.acquisitions).toHaveLength(1)
+        yield* TestClock.adjust(1)
+        expect(control.acquisitions).toHaveLength(2)
+        yield* Fiber.interrupt(fiber)
+      }),
+    ).pipe(Effect.provide(TestClock.layer()))
+
+    await Effect.runPromise(program)
+    const restart = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse('2026-01-30T21:02:00.000Z'))
+        return yield* provide(runAutonomousCyclePass(candidate()), read, store)
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+    expect(restart.outcome).toBe('REACQUIRED')
+    expect(new Set(control.acquisitions.map((acquisition) => acquisition.draft.identity.cycleId)).size).toBe(1)
+  })
+
+  test('publishes NOT_DUE broker-calendar evidence before the loop waits', async () => {
+    const control: StoreControl = { acquisitions: [] }
+    const observation = calendar([
+      {
+        date: '2026-01-30',
+        openAt: '2026-01-30T14:30:00.000Z',
+        closeAt: '2026-01-30T18:00:00.000Z',
+      },
+    ])
+    const logs: Array<{ readonly message: unknown; readonly annotations: Record<string, unknown> }> = []
+    const logger = Logger.make<unknown, void>((options) => {
+      logs.push({
+        message: options.message,
+        annotations: { ...options.fiber.getRef(References.CurrentLogAnnotations) },
+      })
+    })
+    const program = Effect.scoped(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse('2026-01-29T21:01:00.000Z'))
+        const fiber = yield* provide(
+          startAutonomousCycleLoop({
+            candidate: Effect.succeed(candidate('2026-01-29')),
+            pollIntervalMs: 100,
+          }),
+          brokerRead(() => Effect.succeed({ value: observation, evidence })),
+          cycleStore(control),
+        )
+        yield* Effect.yieldNow
+        yield* Fiber.interrupt(fiber)
+      }),
+    ).pipe(Effect.provide(Logger.layer([logger])), Effect.provide(TestClock.layer()))
+
+    await Effect.runPromise(program)
+    expect(control.acquisitions).toEqual([])
+    expect(logs).toEqual([
+      {
+        message: ['Bayn autonomous cycle pass completed'],
+        annotations: {
+          outcome: 'NOT_DUE',
+          signalSessionDate: '2026-01-29',
+          executionSessionDate: '2026-01-30',
+          observedAt: '2026-01-29T21:01:00.000Z',
+          calendarResponseHash: observation.normalizedResponseHash,
+          calendarReadContentHash: evidence.contentHash,
+        },
+      },
+    ])
+  })
+
+  test('scope closure interrupts an in-flight calendar read', async () => {
+    const started = await Effect.runPromise(Deferred.make<void>())
+    let interrupted = false
+    const read = brokerRead(() =>
+      Deferred.succeed(started, undefined).pipe(
+        Effect.andThen(Effect.never),
+        Effect.onInterrupt(() => Effect.sync(() => void (interrupted = true))),
+      ),
+    )
+    const control: StoreControl = { acquisitions: [] }
+
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          yield* provide(
+            startAutonomousCycleLoop({
+              candidate: Effect.succeed(candidate()),
+              pollIntervalMs: 100,
+            }),
+            read,
+            cycleStore(control),
+          )
+          yield* Deferred.await(started)
+        }),
+      ),
+    )
+    expect(interrupted).toBe(true)
+    expect(control.acquisitions).toEqual([])
+  })
+
+  test('maps candidate-source failures without touching the broker', async () => {
+    const candidateFailure = new Error('Signal candidate unavailable')
+    const control: StoreControl = { acquisitions: [] }
+    const failure = await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fiber = yield* provide(
+            startAutonomousCycleLoop({
+              candidate: Effect.fail(candidateFailure),
+              pollIntervalMs: 100,
+            }),
+            brokerRead(() => Effect.die(new Error('failed candidate must not read the broker'))),
+            cycleStore(control),
+          )
+          return yield* Effect.flip(Fiber.join(fiber))
+        }),
+      ),
+    )
+    expect(failure).toMatchObject({
+      _tag: 'CycleRunnerError',
+      operation: 'load-candidate',
+      failure: 'candidate',
+      cause: candidateFailure,
+    })
+    expect(control.acquisitions).toEqual([])
+  })
+
+  test('exposes a failed scoped fiber for scheduler health on defects', async () => {
+    const read = brokerRead(() => Effect.die(new Error('injected broker defect')))
+    const control: StoreControl = { acquisitions: [] }
+    const exit = await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fiber = yield* provide(
+            startAutonomousCycleLoop({
+              candidate: Effect.succeed(candidate()),
+              pollIntervalMs: 100,
+            }),
+            read,
+            cycleStore(control),
+          )
+          return yield* Fiber.await(fiber)
+        }),
+      ),
+    )
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) expect(Cause.pretty(exit.cause)).toContain('injected broker defect')
+    expect(control.acquisitions).toEqual([])
+  })
+
+  test('rejects an invalid loop interval before forking or touching dependencies', async () => {
+    const control: StoreControl = { acquisitions: [] }
+    const failure = await Effect.runPromise(
+      Effect.flip(
+        Effect.scoped(
+          provide(
+            startAutonomousCycleLoop({
+              candidate: Effect.succeed(candidate()),
+              pollIntervalMs: 0,
+            }),
+            brokerRead(() => Effect.die(new Error('invalid config must not read the broker'))),
+            cycleStore(control),
+          ),
+        ),
+      ),
+    )
+    expect(failure).toMatchObject({
+      _tag: 'CycleRunnerError',
+      operation: 'configure',
+      failure: 'invalid-config',
+    })
+    expect(control.acquisitions).toEqual([])
+  })
+})

--- a/services/bayn/src/cycle-runner.ts
+++ b/services/bayn/src/cycle-runner.ts
@@ -1,0 +1,228 @@
+import { Clock, Data, Duration, Effect, Fiber, Schedule, Scope } from 'effect'
+
+import {
+  BrokerRead,
+  type MarketCalendarObservation,
+  type MarketCalendarQuery,
+  type MarketCalendarSession,
+} from './broker/alpaca'
+import {
+  makeCycleDraft,
+  makeCycleIdentity,
+  makeCycleWindow,
+  makeExecutionCalendarObservation,
+  type CycleDraft,
+  type CycleExecutionPolicy,
+} from './cycle'
+import { CycleStore, type CycleAcquireReceipt } from './db/cycle-store'
+import type { SignalSessionRow } from './market-data'
+
+const calendarRangeDays = 31
+const millisecondsPerDay = 86_400_000
+
+type SignalCycleSession = Pick<SignalSessionRow, 'calendar_version' | 'session_date' | 'close_time' | 'timezone'>
+
+export interface CycleCandidate {
+  readonly qualificationRunId: string
+  readonly strategyProtocolHash: string
+  readonly accountId: string
+  readonly signalSession: SignalCycleSession
+  readonly executionPolicy: CycleExecutionPolicy
+}
+
+export type CycleRunResult =
+  | {
+      readonly outcome: 'NOT_DUE'
+      readonly signalSessionDate: string
+      readonly executionSessionDate: string
+      readonly observedAt: string
+      readonly calendarResponseHash: string
+      readonly calendarReadContentHash: string
+    }
+  | {
+      readonly outcome: 'ACQUIRED' | 'REACQUIRED'
+      readonly signalSessionDate: string
+      readonly executionSessionDate: string
+      readonly observedAt: string
+      readonly calendarResponseHash: string
+      readonly calendarReadContentHash: string
+      readonly receipt: CycleAcquireReceipt
+    }
+
+export class CycleRunnerError extends Data.TaggedError('CycleRunnerError')<{
+  readonly operation:
+    | 'acquire-cycle'
+    | 'build-cycle'
+    | 'configure'
+    | 'load-candidate'
+    | 'market-calendar'
+    | 'select-session'
+  readonly failure: 'calendar-read' | 'calendar-unavailable' | 'candidate' | 'contract' | 'invalid-config' | 'store'
+  readonly message: string
+  readonly cause?: unknown
+}> {}
+
+export interface AutonomousCycleLoopOptions<E = never, R = never> {
+  readonly candidate: Effect.Effect<CycleCandidate | undefined, E, R>
+  readonly pollIntervalMs: number
+}
+
+const runnerError = (
+  operation: CycleRunnerError['operation'],
+  failure: CycleRunnerError['failure'],
+  message: string,
+  cause?: unknown,
+): CycleRunnerError => new CycleRunnerError({ operation, failure, message, cause })
+
+const addUtcDays = (date: string, days: number): string =>
+  new Date(Date.parse(`${date}T00:00:00.000Z`) + days * millisecondsPerDay).toISOString().slice(0, 10)
+
+export const marketCalendarQueryForSignal = (signalSessionDate: string): MarketCalendarQuery => ({
+  start: signalSessionDate,
+  end: addUtcDays(signalSessionDate, calendarRangeDays - 1),
+})
+
+export const selectNextExecutionSession = (
+  signalSessionDate: string,
+  observation: MarketCalendarObservation,
+): MarketCalendarSession | undefined => {
+  let selected: MarketCalendarSession | undefined
+  for (const session of observation.sessions) {
+    if (session.date > signalSessionDate && (selected === undefined || session.date < selected.date)) {
+      selected = session
+    }
+  }
+  return selected
+}
+
+export const isMonthEndCycleDue = (signalSessionDate: string, executionSessionDate: string): boolean =>
+  signalSessionDate.slice(0, 7) !== executionSessionDate.slice(0, 7)
+
+export const makeDueCycleDraft = (
+  candidate: CycleCandidate,
+  observation: MarketCalendarObservation,
+  executionSession: MarketCalendarSession,
+): CycleDraft | undefined => {
+  if (!isMonthEndCycleDue(candidate.signalSession.session_date, executionSession.date)) return undefined
+  const executionCalendar = makeExecutionCalendarObservation({
+    schemaVersion: observation.schemaVersion,
+    source: observation.source,
+    ...executionSession,
+  })
+  const identity = makeCycleIdentity({
+    schemaVersion: 'bayn.autonomous-cycle-identity.v1',
+    strategyName: 'risk-balanced-trend',
+    qualificationRunId: candidate.qualificationRunId,
+    strategyProtocolHash: candidate.strategyProtocolHash,
+    accountId: candidate.accountId,
+    signalSessionDate: candidate.signalSession.session_date,
+    signalCalendarVersion: candidate.signalSession.calendar_version,
+    executionSessionDate: executionCalendar.executionSessionDate,
+    executionCalendarSchemaVersion: executionCalendar.executionCalendarSchemaVersion,
+    executionCalendarSource: executionCalendar.executionCalendarSource,
+    executionCalendarHash: executionCalendar.executionCalendarHash,
+    executionPolicy: candidate.executionPolicy,
+  })
+  const window = makeCycleWindow(candidate.signalSession, executionCalendar, candidate.executionPolicy)
+  return makeCycleDraft(identity, window)
+}
+
+export const runAutonomousCyclePass = (
+  candidate: CycleCandidate,
+): Effect.Effect<CycleRunResult, CycleRunnerError, BrokerRead | CycleStore> =>
+  Effect.gen(function* () {
+    const broker = yield* BrokerRead
+    const store = yield* CycleStore
+    const query = marketCalendarQueryForSignal(candidate.signalSession.session_date)
+    const calendar = yield* broker
+      .marketCalendar(query)
+      .pipe(
+        Effect.mapError((cause) =>
+          runnerError('market-calendar', 'calendar-read', 'authoritative broker calendar read failed', cause),
+        ),
+      )
+    const executionSession = selectNextExecutionSession(candidate.signalSession.session_date, calendar.value)
+    if (executionSession === undefined) {
+      return yield* Effect.fail(
+        runnerError(
+          'select-session',
+          'calendar-unavailable',
+          `broker calendar has no trading session after ${candidate.signalSession.session_date}`,
+        ),
+      )
+    }
+    const observedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
+    const common = {
+      signalSessionDate: candidate.signalSession.session_date,
+      executionSessionDate: executionSession.date,
+      observedAt,
+      calendarResponseHash: calendar.value.normalizedResponseHash,
+      calendarReadContentHash: calendar.evidence.contentHash,
+    } as const
+    const draft = yield* Effect.try({
+      try: () => makeDueCycleDraft(candidate, calendar.value, executionSession),
+      catch: (cause) => runnerError('build-cycle', 'contract', 'autonomous cycle draft construction failed', cause),
+    })
+    if (draft === undefined) return { outcome: 'NOT_DUE', ...common }
+    const receipt = yield* store
+      .acquire(draft, observedAt)
+      .pipe(
+        Effect.mapError((cause) =>
+          runnerError('acquire-cycle', 'store', 'durable autonomous cycle acquisition failed', cause),
+        ),
+      )
+    return {
+      outcome: receipt.created ? 'ACQUIRED' : 'REACQUIRED',
+      ...common,
+      receipt,
+    }
+  })
+
+const logCompletedPass = (result: CycleRunResult): Effect.Effect<void> =>
+  Effect.logInfo('Bayn autonomous cycle pass completed').pipe(
+    Effect.annotateLogs({
+      outcome: result.outcome,
+      signalSessionDate: result.signalSessionDate,
+      executionSessionDate: result.executionSessionDate,
+      observedAt: result.observedAt,
+      calendarResponseHash: result.calendarResponseHash,
+      calendarReadContentHash: result.calendarReadContentHash,
+      ...(result.outcome === 'NOT_DUE'
+        ? {}
+        : {
+            cycleId: result.receipt.cycle.identity.cycleId,
+            cycleState: result.receipt.cycle.state,
+            persistenceDeduplicated: !result.receipt.created,
+          }),
+    }),
+  )
+
+const runLoopPass = <E, R>(
+  candidate: Effect.Effect<CycleCandidate | undefined, E, R>,
+): Effect.Effect<void, CycleRunnerError, BrokerRead | CycleStore | R> =>
+  candidate.pipe(
+    Effect.mapError((cause) =>
+      runnerError('load-candidate', 'candidate', 'autonomous cycle candidate discovery failed', cause),
+    ),
+    Effect.flatMap((value) =>
+      value === undefined
+        ? Effect.void
+        : runAutonomousCyclePass(value).pipe(Effect.tap(logCompletedPass), Effect.asVoid),
+    ),
+    Effect.withLogSpan('autonomous-cycle'),
+  )
+
+export const startAutonomousCycleLoop = <E, R>(
+  options: AutonomousCycleLoopOptions<E, R>,
+): Effect.Effect<Fiber.Fiber<void, CycleRunnerError>, CycleRunnerError, BrokerRead | CycleStore | R | Scope.Scope> => {
+  if (!Number.isSafeInteger(options.pollIntervalMs) || options.pollIntervalMs <= 0) {
+    return Effect.fail(
+      runnerError('configure', 'invalid-config', 'cycle loop interval must be a positive safe integer'),
+    )
+  }
+  return runLoopPass(options.candidate).pipe(
+    Effect.repeat(Schedule.spaced(Duration.millis(options.pollIntervalMs))),
+    Effect.asVoid,
+    Effect.forkScoped({ startImmediately: true }),
+  )
+}

--- a/services/bayn/src/db/cycle-store.integration.test.ts
+++ b/services/bayn/src/db/cycle-store.integration.test.ts
@@ -3,7 +3,9 @@ import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:tes
 import { NodeServices } from '@effect/platform-node'
 import { PgClient, PgMigrator } from '@effect/sql-pg'
 import { Cause, Effect, Exit, Layer, ManagedRuntime, Option, Redacted } from 'effect'
+import { TestClock } from 'effect/testing'
 
+import { BrokerRead, type BrokerReadShape, type MarketCalendarObservation } from '../broker/alpaca'
 import {
   CycleState,
   CycleTerminalReason,
@@ -14,6 +16,8 @@ import {
   makeExecutionCalendarObservation,
   type CycleDraft,
 } from '../cycle'
+import { runAutonomousCyclePass, type CycleCandidate, type CycleRunResult } from '../cycle-runner'
+import { canonicalHashV1 } from '../hash'
 import type { SignalSessionRow } from '../market-data'
 import type { IsoDate } from '../types'
 import { CycleStore, CycleStoreLive } from './cycle-store'
@@ -122,6 +126,65 @@ const activeAt = '2026-03-06T21:03:00.000Z'
 const decisionAt = '2026-03-06T21:04:00.000Z'
 const terminalAt = '2026-03-06T21:05:00.000Z'
 
+const runnerCandidate = (accountId: string): CycleCandidate => ({
+  qualificationRunId: 'a'.repeat(64),
+  strategyProtocolHash: 'b'.repeat(64),
+  accountId,
+  signalSession: signalSession('2026-01-30'),
+  executionPolicy: makeCycleExecutionPolicy({
+    schemaVersion: 'bayn.autonomous-cycle-execution-policy.v1',
+    strategyExecutionModelHash: 'c'.repeat(64),
+    submissionWindowMs: 30 * 60 * 1_000,
+    submissionCutoffBeforeOpenMs: 2 * 60 * 1_000,
+  }),
+})
+
+const runnerCalendar = (): MarketCalendarObservation => {
+  const material = {
+    schemaVersion: 'bayn.alpaca-market-calendar-observation.v1' as const,
+    source: 'alpaca-v2-calendar' as const,
+    requestedRange: { start: '2026-01-30', end: '2026-03-01' },
+    timeZone: 'UTC' as const,
+    sessions: [
+      {
+        date: '2026-01-30',
+        openAt: '2026-01-30T14:30:00.000Z',
+        closeAt: '2026-01-30T21:00:00.000Z',
+      },
+      {
+        date: '2026-02-02',
+        openAt: '2026-02-02T14:30:00.000Z',
+        closeAt: '2026-02-02T21:00:00.000Z',
+      },
+    ],
+  }
+  return { ...material, normalizedResponseHash: canonicalHashV1(material) }
+}
+
+const runnerBrokerRead = (queries: Array<{ readonly start: string; readonly end: string }>): BrokerReadShape => {
+  const unused = Effect.die(new Error('autonomous cycle runner must use only marketCalendar'))
+  return {
+    account: unused,
+    positions: unused,
+    orders: () => unused,
+    orderById: () => unused,
+    orderByClientId: () => unused,
+    fillActivities: () => unused,
+    marketCalendar: (query) => {
+      queries.push(query)
+      return Effect.succeed({
+        value: runnerCalendar(),
+        evidence: {
+          requestId: `calendar-${queries.length}`,
+          status: 200,
+          contentHash: String(queries.length).repeat(64),
+          observedAt: '2026-01-30T21:01:00.000Z',
+        },
+      })
+    },
+  }
+}
+
 describePostgres('PostgreSQL autonomous cycle store', () => {
   let runtime: ReturnType<typeof makeRuntime>
 
@@ -197,6 +260,116 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
       },
     })
     expect(observed.count).toBe(1)
+  })
+
+  test('concurrent runner passes and restart converge on one OBSERVE cycle', async () => {
+    const candidate = runnerCandidate('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa')
+    const queries: Array<{ readonly start: string; readonly end: string }> = []
+    const read = runnerBrokerRead(queries)
+    const result = await runtime.runPromise(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse('2026-01-30T21:01:00.000Z'))
+        const concurrent = yield* Effect.all(
+          [
+            runAutonomousCyclePass(candidate).pipe(Effect.provideService(BrokerRead, read)),
+            runAutonomousCyclePass(structuredClone(candidate)).pipe(Effect.provideService(BrokerRead, read)),
+          ],
+          { concurrency: 'unbounded' },
+        )
+        yield* TestClock.setTime(Date.parse('2026-01-30T21:02:00.000Z'))
+        const restarted = yield* runAutonomousCyclePass(candidate).pipe(Effect.provideService(BrokerRead, read))
+        const sql = yield* PgClient.PgClient
+        const [count] = yield* sql<{ count: number }>`
+          SELECT count(*)::integer AS count
+          FROM autonomous_cycles
+          WHERE qualification_run_id = ${candidate.qualificationRunId}
+            AND account_id = ${candidate.accountId}
+            AND signal_session_date = ${candidate.signalSession.session_date}
+        `
+        return { concurrent, count: count.count, restarted }
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(result.concurrent.map((pass) => pass.outcome).sort()).toEqual(['ACQUIRED', 'REACQUIRED'])
+    expect(result.restarted).toMatchObject({
+      outcome: 'REACQUIRED',
+      receipt: {
+        created: false,
+        cycle: {
+          state: CycleState.Pending,
+          identity: {
+            accountId: candidate.accountId,
+            signalSessionDate: candidate.signalSession.session_date,
+            executionSessionDate: '2026-02-02',
+          },
+        },
+      },
+    })
+    expect(result.count).toBe(1)
+    expect(queries).toEqual([
+      { start: '2026-01-30', end: '2026-03-01' },
+      { start: '2026-01-30', end: '2026-03-01' },
+      { start: '2026-01-30', end: '2026-03-01' },
+    ])
+  })
+
+  test('runner Clock preserves every pre-open acquisition boundary in PostgreSQL', async () => {
+    const cases = [
+      {
+        accountId: '10000000-0000-4000-8000-000000000001',
+        observedAt: '2026-02-02T13:57:59.999Z',
+        state: CycleState.Pending,
+      },
+      {
+        accountId: '10000000-0000-4000-8000-000000000002',
+        observedAt: '2026-02-02T13:58:00.000Z',
+        state: CycleState.Blocked,
+      },
+      {
+        accountId: '10000000-0000-4000-8000-000000000003',
+        observedAt: '2026-02-02T14:28:00.000Z',
+        state: CycleState.Blocked,
+      },
+      {
+        accountId: '10000000-0000-4000-8000-000000000004',
+        observedAt: '2026-02-02T14:30:00.000Z',
+        state: CycleState.Blocked,
+      },
+    ] as const
+    const queries: Array<{ readonly start: string; readonly end: string }> = []
+    const read = runnerBrokerRead(queries)
+    const results = await runtime.runPromise(
+      Effect.gen(function* () {
+        const observed: Array<Extract<CycleRunResult, { readonly outcome: 'ACQUIRED' | 'REACQUIRED' }>> = []
+        for (const boundary of cases) {
+          yield* TestClock.setTime(Date.parse(boundary.observedAt))
+          const result = yield* runAutonomousCyclePass(runnerCandidate(boundary.accountId)).pipe(
+            Effect.provideService(BrokerRead, read),
+          )
+          if (result.outcome === 'NOT_DUE') throw new Error('month-end runner fixture must acquire a cycle')
+          observed.push(result)
+        }
+        return observed
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(results.map((result) => result.receipt.cycle.state)).toEqual(cases.map((boundary) => boundary.state))
+    expect(results.map((result) => result.receipt.cycle.updatedAt)).toEqual(
+      cases.map((boundary) => boundary.observedAt),
+    )
+    for (const result of results.slice(1)) {
+      expect(result.receipt.cycle).toMatchObject({
+        state: CycleState.Blocked,
+        terminalReason: CycleTerminalReason.MissedPublication,
+      })
+    }
+    expect(
+      results.every(
+        (result) =>
+          result.receipt.cycle.window.submissionOpenAt < result.receipt.cycle.window.submissionCutoffAt &&
+          result.receipt.cycle.window.submissionCutoffAt < result.receipt.cycle.window.executionOpenAt,
+      ),
+    ).toBe(true)
   })
 
   test('reserves one capital-authority slot across changed calendar and policy inputs', async () => {


### PR DESCRIPTION
## Summary

- add pure month-end session selection and deterministic cycle-draft construction from the decoded `BrokerRead.marketCalendar` observation
- add one scoped in-process Effect `Clock`/`Schedule` loop that acquires directly through `CycleStore`, exposes typed operational failure, and interrupts with its owning scope
- preserve full broker response/read hashes outside cycle identity and emit one structured completion record before each scheduled wait
- prove OBSERVE-only behavior, exact pre-open boundaries, concurrent acquisition deduplication, restart-safe reacquisition, and `NOT_DUE` evidence without broker mutation or Lane A/B runtime wiring
- refresh Bayn platform dependency hashes from the Nix fixed-output evidence produced after the current-main root manifest change

## Related Issues

Progresses PROOMPT-380. Runtime composition remains deliberately in progress for the Lane B-owned `index.ts`/config/health integration.

## Testing

- `bun test` (260 passed, 54 PostgreSQL tests skipped without the integration URL)
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:55432/bayn_test bun test src/db/evidence-store.integration.test.ts` (35 passed)
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:55432/bayn_test bun test src/db/paper-store.integration.test.ts` (7 passed)
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:55432/bayn_test bun test src/db/cycle-store.integration.test.ts` (7 passed)
- `bun run tsc`
- `bun run lint`
- `bun run lint:oxlint`
- `bun run lint:oxlint:type`
- `bun run build`
- `nix-instantiate --parse nix/images/bayn.nix`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] Follow-up runtime composition remains tracked by PROOMPT-380 and respects Lane B ownership.