### PR TITLE
fix(bayn): make execution planning live-causal

### DIFF
--- a/docs/bayn/architecture.md
+++ b/docs/bayn/architecture.md
@@ -145,7 +145,9 @@ exposure remains cash. The strategy parameters and thresholds are unchanged from
 
 The v3 execution model is live-causal. Once the signal session is finalized, planning uses that session's close-price
 vector and a content-hashed reconciled broker state observed before planning. The bounded Alpaca calendar response
-binds its request range, source/version, response hash, and the selected future session's exact UTC open and close.
+binds its request range, source/version, complete normalized session set, response hash, and the selected future
+session's exact UTC open and close. Decoding revalidates the response hash and requires that selected session to be the
+first post-signal session in the bound observation.
 Ordinary non-extended `DAY` market orders may be submitted only after the plan is committed and before a fixed
 15-minute pre-open cutoff. Risk approval is valid in `[submissionOpenAt, submissionCutoffAt)`. Planned buys reserve
 aggregate pre-submit buying power and cannot spend planned sell proceeds. The selected session open is a fill outcome:

--- a/docs/bayn/architecture.md
+++ b/docs/bayn/architecture.md
@@ -24,7 +24,7 @@ that interface and every persisted evidence contract.
 ## Runtime flow
 
 1. The composition root loads Effect Config, decodes the compiled protocol, verifies its parameter hash against the
-   build, and constructs one pure `Strategy` value.
+   build, verifies the compiled behavior identity, and constructs one pure `Strategy` value.
 2. Startup inspects the configured finalized Signal V2 publication before loading bars. The manifest must match the
    compiled universe, symbol hash, feed, adjustment, calendar, and evaluation bounds.
 3. Bayn derives the candidate identity and opens the immutable qualification lock through the existing evidence
@@ -54,11 +54,13 @@ Paper mutation uses one deliberately small transaction/I/O boundary:
 1. A committed approved intent and current paper authority acquire the single-writer fence.
 2. PostgreSQL records `SUBMIT_STARTED`, the exact request hash, deterministic client-order ID, and immutable broker
    consistency delay before the first POST.
-3. Exactly one Alpaca request is made. Decoded 4xx rejections are terminal; a timeout, interruption, malformed response,
+3. The coordinator rechecks the committed risk-decision expiry with the Effect clock immediately before POST or
+   DELETE. The interval is half-open, so the exact cutoff instant makes zero broker mutations.
+4. Exactly one Alpaca request is made. Decoded 4xx rejections are terminal; a timeout, interruption, malformed response,
    server response, or post-send crash remains `UNKNOWN`.
-4. Recovery waits the committed delay and performs `GET /v2/orders:by_client_order_id`. It never wraps POST or DELETE
+5. Recovery waits the committed delay and performs `GET /v2/orders:by_client_order_id`. It never wraps POST or DELETE
    in a generic retry.
-5. Cancel targets only a recorded broker order ID. A kill may permit that cancellation, but it cannot authorize a new
+6. Cancel targets only a recorded broker order ID. A kill may permit that cancellation, but it cannot authorize a new
    exposure-increasing intent.
 
 `mutation_events` is append-only and enforces the transition sequence, request identity, response identity, broker
@@ -121,7 +123,7 @@ fixed exclusively by `authority`.
 
 ## Strategy and economic contract
 
-The compiled `bayn.risk-balanced-trend.protocol.v2` candidate uses the exact `cross-asset-taa-v1` universe:
+The compiled `bayn.risk-balanced-trend.protocol.v3` precommit uses the exact `cross-asset-taa-v1` universe:
 
 `DBC, EFA, IEF, SPY, VNQ`.
 
@@ -139,8 +141,20 @@ database recovery under `OBSERVE`; the pin clears no qualification or mutation g
 At each month-end close, the strategy computes volatility-normalized returns over 21, 63, 126, and 252 sessions,
 averages them into a composite score, and assigns weight only to positive scores. Weights are redistributed under a 35%
 per-symbol cap, quantized deterministically, and scaled down when estimated portfolio volatility exceeds 10%. Residual
-exposure remains cash. Decisions execute only at the next exchange-session open under the compiled paper execution
-model.
+exposure remains cash. The strategy parameters and thresholds are unchanged from the rejected v2 run.
+
+The v3 execution model is live-causal. Once the signal session is finalized, planning uses that session's close-price
+vector and a content-hashed reconciled broker state observed before planning. The bounded Alpaca calendar response
+binds its request range, source/version, response hash, and the selected future session's exact UTC open and close.
+Ordinary non-extended `DAY` market orders may be submitted only after the plan is committed and before a fixed
+15-minute pre-open cutoff. Risk approval is valid in `[submissionOpenAt, submissionCutoffAt)`. Planned buys reserve
+aggregate pre-submit buying power and cannot spend planned sell proceeds. The selected session open is a fill outcome:
+changing it may alter fills, gaps, slippage, shortfall, and performance, but cannot alter planned quantities.
+
+The source-controlled precommit identities are behavior
+`dc614c54bbf43842d83cd88497e835f7bb25c413eb6e8bd7cbab0a925ec9b2dd` and parameters
+`e5e4cc5d22b84c4dc8fc65c306d097fda063b0058253da5b900fe1d462d437b3`. They do not relabel
+the terminal v2 rejection and do not constitute a new qualification.
 
 The evaluator compares the candidate with buy-and-hold, direct-volatility timing, and doubled-cost results over aligned
 dates. Qualification also applies the committed statistical and walk-forward policy. Every decision, benchmark,

--- a/docs/bayn/authoritative-universe.md
+++ b/docs/bayn/authoritative-universe.md
@@ -1,10 +1,10 @@
 # Bayn authoritative universe
 
-Status: **precommitted; finalized Signal snapshot accepted; qualification release ready**
+Status: **universe retained; released v2 candidate rejected; causal v3 precommit not qualified**
 
 ## Current contract
 
-Bayn's next qualification candidate uses one fixed, canonically ordered universe:
+Bayn's corrected causal precommit retains one fixed, canonically ordered universe:
 
 ```text
 DBC,EFA,IEF,SPY,VNQ
@@ -21,7 +21,8 @@ DBC,EFA,IEF,SPY,VNQ
 | Calendar         | `alpaca-us-equity-calendar-v1`                                     |
 
 The hash is SHA-256 over the exact CSV string above. A reorder, addition, removal, feed change, adjustment change, or
-calendar change is a different contract and requires a new candidate.
+calendar change is a different contract and requires a new candidate. The v3 causal repair changes neither this
+universe nor the strategy parameters or qualification thresholds.
 
 ## Selection rationale
 
@@ -118,6 +119,23 @@ non-authorizing under `OBSERVE`: the execution model was not live-causal, and th
 that pre-lock Bayn/operator reads of the bars table returned only bounded publication count/hash evidence. The two
 independent audits therefore fail both candidate-bar chronology and principal checks rather than exempting those reads.
 PROOMPT-406 owns the causal contract and corrected precommit; this record clears no M2.2 or paper-mutation gate.
+
+## Corrected causal precommit
+
+`bayn.risk-balanced-trend.protocol.v3` plans quantities from the finalized signal-session close and reconciled
+pre-plan broker state, then treats the selected next-session open only as a fill outcome. The bounded Alpaca calendar
+identity fixes the future session open, close, and a 15-minute pre-open cutoff. Planned buys reserve only pre-submit
+cash and cannot spend planned sell proceeds. The strategy horizons, weight cap, volatility target, universe, and
+qualification gates remain unchanged.
+
+The source-controlled identities are:
+
+- behavior `dc614c54bbf43842d83cd88497e835f7bb25c413eb6e8bd7cbab0a925ec9b2dd`;
+- parameters `e5e4cc5d22b84c4dc8fc65c306d097fda063b0058253da5b900fe1d462d437b3`; and
+- deterministic fixture evaluation `8be4f2f76c69bd7eeb2984bc08cd1d49013d2b349c8c574683851d4052a4901f`.
+
+These hashes are a corrected precommit, not a qualification result. The pinned v2 run remains terminal `REJECTED`;
+no qualification rerun is part of PROOMPT-406.
 
 Publication rollback remains fail-closed: stop new publication through GitOps and preserve finalized or partially
 staged rows for diagnosis. Never delete M2.1 evidence or Signal publication tables.

--- a/nix/images/bayn.nix
+++ b/nix/images/bayn.nix
@@ -20,8 +20,8 @@ import ./bun-workspace-service.nix {
   serviceName = "bayn";
   packageName = "@proompteng/bayn";
   depsHash = {
-    x86_64-linux = "sha256-+Pc9/PwLvC7t3hmN/owxwFoDoSKFg9h05VAIp/3C0DE=";
-    aarch64-linux = "sha256-7TTGoDjmxMi0zJ44u6oCW3ZqjAJByB6ehTuG6lCCzdM=";
+    x86_64-linux = "sha256-lPw4xA54l9s6o+46ulCWRA593QjsPyCS44/QSmQJyME=";
+    aarch64-linux = "sha256-5FQ4nmCpYkbLVzbG8vrCf4+Aqi943QylJlmlUQVWqdQ=";
   };
   installFilters = [
     "@proompteng/bayn"

--- a/nix/images/bayn.nix
+++ b/nix/images/bayn.nix
@@ -9,11 +9,10 @@
 
 let
   imageRepository = "registry.ide-newton.ts.net/lab/bayn";
-  # Immutable identity for bayn.risk-balanced-trend.behavior.v1. The deterministic evaluator and decision fingerprints
-  # are locked in risk-balanced-trend.test.ts, so behavior-preserving refactors retain the same identity.
-  strategyBehaviorHash = "43cece33d3db232ffb02ba78826727e50b5795319d09d27e1baa0c04709eb056";
-  # Canonical hash of the compiled bayn.risk-balanced-trend.protocol.v2 document.
-  strategyParameterHash = "649148eeaaf1f3aa1f1dd6d129a93aeef6b07f63e1aa60b6ed79f91a9cf7bbf8";
+  # SHA-256 identity for bayn.risk-balanced-trend.behavior.v2, verified by the production executable.
+  strategyBehaviorHash = "dc614c54bbf43842d83cd88497e835f7bb25c413eb6e8bd7cbab0a925ec9b2dd";
+  # Canonical hash of the compiled bayn.risk-balanced-trend.protocol.v3 document.
+  strategyParameterHash = "e5e4cc5d22b84c4dc8fc65c306d097fda063b0058253da5b900fe1d462d437b3";
   buildDefine = name: value: "--define ${name}=${lib.escapeShellArg (builtins.toJSON value)}";
 in
 import ./bun-workspace-service.nix {

--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -1,10 +1,10 @@
 # Bayn
 
-Bayn is a single-writer, paper-only quantitative qualification runtime. Its next protocol precommits the frozen
-risk-balanced trend candidate on a five-sleeve cross-asset ETF universe. The explicit one-shot release omits
-`BAYN_QUALIFICATION_RUN_ID` so startup can open the exact candidate lock and conduct the single permitted evaluation.
-GitOps remains `OBSERVE` and carries no Alpaca credentials, so qualification has no broker dependency and makes zero
-broker calls. The paper mutation capability, execution entry point, and capital-promotion path remain dormant.
+Bayn is a single-writer, paper-only quantitative qualification runtime. The released cross-asset one-shot is terminal
+`REJECTED`, pinned by `BAYN_QUALIFICATION_RUN_ID`, and non-authorizing. The next source-controlled precommit is
+`bayn.risk-balanced-trend.protocol.v3`: the same strategy parameters and thresholds with a corrected live-causal
+execution contract. It is not qualified and this change does not rerun qualification. GitOps remains `OBSERVE`; the
+paper mutation capability, execution entry point, and capital-promotion path remain dormant.
 
 ## Runtime contract
 
@@ -27,12 +27,16 @@ broker calls. The paper mutation capability, execution entry point, and capital-
   I/O. Fill accounting persists Alpaca's full source timestamp and orders equal timestamps by fill ID, rejects late
   predecessors, and records a receipt only after the complete TigerBeetle transaction-tag transfer set matches.
 - The composition root builds one pure strategy value and passes it explicitly to the lifecycle. Effect services and
-  layers are reserved for I/O resources. The compiled `bayn.risk-balanced-trend.protocol.v2` owns its authoritative
-  universe and execution contract; the HTTP and startup lifecycle remain strategy-independent.
+  layers are reserved for I/O resources. The compiled `bayn.risk-balanced-trend.protocol.v3` owns its authoritative
+  universe and causal execution contract; the HTTP and startup lifecycle remain strategy-independent. Protocol v2
+  remains decodable only so immutable historical evidence can be recovered.
 - The typed protocol is compiled into the image and runtime-decoded with Effect Schema. Strategies remain reviewed
   TypeScript rather than JSON.
-- The executable embeds source, repository, and strategy-behavior identity. Startup verifies configured attribution,
-  and status exposes the promoted image digest, parameter hash, and contract versions.
+- The executable embeds source, repository, and strategy-behavior identity. Startup verifies the compiled behavior and
+  parameter hashes against those embedded facts, and status exposes the promoted image digest, parameter hash, and
+  contract versions. The v3 precommit uses behavior hash
+  `dc614c54bbf43842d83cd88497e835f7bb25c413eb6e8bd7cbab0a925ec9b2dd` and parameter hash
+  `e5e4cc5d22b84c4dc8fc65c306d097fda063b0058253da5b900fe1d462d437b3`.
 - The package `dev` and `start` scripts use explicit `development-configured` provenance because their artifacts are
   not OCI production builds. That mode is visible in status and cannot override an executable with embedded metadata;
   it does not change lifecycle or authority. The Nix image starts in the default production mode and fails closed if
@@ -49,8 +53,11 @@ broker calls. The paper mutation capability, execution entry point, and capital-
 - Production GitOps carries that pin outside an explicit one-shot qualification release. The release writer refuses a
   second source revision on the same unpinned snapshot, preventing operational releases from creating new trials.
 - The compiled risk-balanced trend decision function records every normalized trend horizon, volatility estimate,
-  portfolio-volatility scale, and target weight at a month-end close. Decisions may execute only at the next exchange
-  session open.
+  portfolio-volatility scale, and target weight at a month-end close. Quantities are planned only after that Signal
+  session is finalized, using its close prices and reconciled broker state observed before planning. Ordinary
+  non-extended `DAY` market orders may be submitted only after the plan is committed and before the fixed 15-minute
+  pre-open cutoff. The next exchange-session open affects fills and performance, never planned quantities; planned
+  buys reserve only pre-submit cash and cannot spend proceeds from planned sells.
 - After exact TigerBeetle reconciliation, one PostgreSQL transaction records the immutable protocol lock, input
   snapshot reference, run identity, metrics, simulated orders, fills, cash changes, daily position marks, daily
   returns, turnover, fees, drawdown, aligned benchmark series, the full equity series, independent marked-equity
@@ -78,6 +85,12 @@ broker calls. The paper mutation capability, execution entry point, and capital-
 - The Alpaca read adapter may be acquired while maximum authority is `OBSERVE`, but it performs GET-only preflight and
   does not build the paper store, reserve the writer fence, start reconciliation, or change PostgreSQL or TigerBeetle.
   The mutation adapter and recovery coordinator remain dormant source foundations.
+- The bounded Alpaca calendar observation is content-hashed with its request range, source/version, and normalized UTC
+  sessions. A causal execution-session binding selects the first future session and binds its exact open, close,
+  pre-open cutoff, finalized Signal identity, and reconciled planning-state identity. Paper risk approves only in
+  `[submissionOpenAt, submissionCutoffAt)` and reserves aggregate buying power across planned buys. The coordinator
+  rechecks the committed risk-decision expiry with the Effect clock immediately before POST or DELETE; the cutoff
+  instant itself permits zero broker mutations.
 - The execution path and independent reducer use integer micros for cash, quantity, prices, spread, slippage, fees,
   cash yield, positions, and every marked-equity point. Full, partial, and rejected orders are durable. Evaluation and
   recovery require exact zero-difference cash, fee, position, and equity reconstruction.
@@ -119,6 +132,10 @@ chronology on every physical ClickHouse replica with a separately supplied audit
 `origin/main` history. Query-log classification uses ClickHouse's recorded table metadata rather than spoofable SQL
 text. It emits one `bayn.qualification-audit.v2` JSON report and exits nonzero on any failed check. Run it twice and
 require identical `auditHash` values.
+
+The current auditor independently replays only causal protocol v3 evidence. Protocol v2 remains recoverable by run ID,
+but its rejected qualification must be replayed with the source revision and immutable image recorded on that run; a
+current-source audit fails explicitly instead of applying v3 semantics to historical evidence.
 
 ```sh
 BAYN_AUDIT_RUN_ID=<run-id> \

--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -86,11 +86,12 @@ paper mutation capability, execution entry point, and capital-promotion path rem
   does not build the paper store, reserve the writer fence, start reconciliation, or change PostgreSQL or TigerBeetle.
   The mutation adapter and recovery coordinator remain dormant source foundations.
 - The bounded Alpaca calendar observation is content-hashed with its request range, source/version, and normalized UTC
-  sessions. A causal execution-session binding selects the first future session and binds its exact open, close,
-  pre-open cutoff, finalized Signal identity, and reconciled planning-state identity. Paper risk approves only in
-  `[submissionOpenAt, submissionCutoffAt)` and reserves aggregate buying power across planned buys. The coordinator
-  rechecks the committed risk-decision expiry with the Effect clock immediately before POST or DELETE; the cutoff
-  instant itself permits zero broker mutations.
+  sessions. A causal execution-session binding retains and revalidates that complete observation, selects its first
+  post-signal session, and binds the session's exact open, close, pre-open cutoff, finalized Signal identity, and
+  reconciled planning-state identity. Paper risk approves only in `[submissionOpenAt, submissionCutoffAt)` and
+  reserves aggregate buying power across planned buys. The coordinator rechecks the committed risk-decision expiry
+  with the Effect clock, then atomically revalidates it in the fenced mutation-start transaction immediately before
+  POST or DELETE; the cutoff instant itself permits zero broker mutations and no durable STARTED event.
 - The execution path and independent reducer use integer micros for cash, quantity, prices, spread, slippage, fees,
   cash yield, positions, and every marked-equity point. Full, partial, and rejected orders are durable. Evaluation and
   recovery require exact zero-difference cash, fee, position, and equity reconstruction.

--- a/services/bayn/migrations/0011_causal_protocol.ts
+++ b/services/bayn/migrations/0011_causal_protocol.ts
@@ -1,0 +1,22 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient
+
+  yield* sql`
+    ALTER TABLE protocol_locks
+    DROP CONSTRAINT protocol_locks_schema_version_check
+  `
+
+  yield* sql`
+    ALTER TABLE protocol_locks
+    ADD CONSTRAINT protocol_locks_schema_version_check
+    CHECK (
+      schema_version IN (
+        'bayn.risk-balanced-trend.protocol.v2',
+        'bayn.risk-balanced-trend.protocol.v3'
+      )
+    )
+  `
+})

--- a/services/bayn/src/audit/audit.ts
+++ b/services/bayn/src/audit/audit.ts
@@ -251,12 +251,16 @@ export const auditQualification = (input: QualificationAuditInput): Qualificatio
   const { resultHash, ...resultMaterial } = result
   const analysis = result.analysis
   const { analysisHash, ...analysisMaterial } = analysis
-  if (
-    database.protocol.strategyName !== contract.name ||
-    database.run.strategyName !== contract.name ||
-    database.protocol.schemaVersion !== 'bayn.risk-balanced-trend.protocol.v2'
-  ) {
+  if (database.protocol.strategyName !== contract.name || database.run.strategyName !== contract.name) {
     throw new Error('stored qualification uses an unsupported strategy contract')
+  }
+  if (
+    database.protocol.schemaVersion !== 'bayn.risk-balanced-trend.protocol.v3' ||
+    input.protocol.schemaVersion !== 'bayn.risk-balanced-trend.protocol.v3'
+  ) {
+    throw new Error(
+      'current auditor requires causal protocol v3; audit immutable v2 evidence with its source-pinned image',
+    )
   }
   const provenance = makeRuntimeProvenance({
     sourceRevision: database.run.sourceRevision,

--- a/services/bayn/src/audit/reference.ts
+++ b/services/bayn/src/audit/reference.ts
@@ -439,6 +439,30 @@ const order = (
   return { id: canonicalHashV1({ runId, kind: 'order', ...material }), ...material }
 }
 
+const restrictReferenceBuyFill = (
+  runId: string,
+  simulatedOrder: SimulatedOrder,
+  permittedQuantity: bigint,
+): SimulatedOrder => {
+  const modeledQuantity = BigInt(simulatedOrder.filledQuantityMicros)
+  if (modeledQuantity === 0n || modeledQuantity === permittedQuantity) return simulatedOrder
+  if (permittedQuantity < 0n || permittedQuantity > modeledQuantity) {
+    throw new Error('reference buying-power adjustment must only reduce a modeled buy fill')
+  }
+  const material = {
+    decisionId: simulatedOrder.decisionId,
+    sessionDate: simulatedOrder.sessionDate,
+    symbol: simulatedOrder.symbol,
+    side: simulatedOrder.side,
+    requestedQuantityMicros: simulatedOrder.requestedQuantityMicros,
+    filledQuantityMicros: permittedQuantity.toString(),
+    status: permittedQuantity === 0n ? ('rejected' as const) : ('partially-filled' as const),
+    rejectionReason: permittedQuantity === 0n ? ('insufficient-buying-power' as const) : null,
+    unfilledRemainder: 'canceled' as const,
+  }
+  return { id: canonicalHashV1({ runId, kind: 'order', ...material }), ...material }
+}
+
 const fill = (
   runId: string,
   decision: DecisionEvent,
@@ -490,6 +514,9 @@ const replay = (
   runId: string,
   retainTrace: boolean,
 ): Replay => {
+  if (protocol.executionModel.schemaVersion !== 'bayn.execution-model.v2') {
+    throw new Error('reference replay requires the causal bayn.execution-model.v2 contract')
+  }
   const targetBySession = new Map(targets.map((target) => [target.executionIndex, target]))
   const positions = new Map<string, Position>()
   const initial = BigInt(protocol.initialCapitalMicros)
@@ -518,6 +545,7 @@ const replay = (
     const beforeSpread = spread
     const beforeSlippage = slippage
     const beforeYield = cashYield
+    const planningCashSnapshot = cash
 
     if (previousDate !== undefined) {
       const elapsedDays = elapsedCalendarDays(previousDate, session.date)
@@ -561,43 +589,158 @@ const replay = (
         decisions.push({ ...target.plan, decisionId: decision.id, executionDate: decision.executionDate })
       }
 
-      const opens = Object.fromEntries(
+      const planPrices = Object.fromEntries(
+        protocol.universe.map((symbol) => [
+          symbol,
+          referencePriceMicros(sessions[target.signalIndex].bars[symbol].close, protocol.executionModel),
+        ]),
+      ) as Readonly<Record<string, bigint>>
+      const fillPrices = Object.fromEntries(
         protocol.universe.map((symbol) => [
           symbol,
           referencePriceMicros(session.bars[symbol].open, protocol.executionModel),
         ]),
       ) as Readonly<Record<string, bigint>>
-      const equityAtOpen =
-        cash +
+      const cashAvailableWhenPlanned = planningCashSnapshot
+      const planEquity =
+        planningCashSnapshot +
         protocol.universe.reduce(
-          (sum, symbol) => sum + notionalMicros(positions.get(symbol)?.quantityMicros ?? 0n, opens[symbol]),
+          (sum, symbol) => sum + notionalMicros(positions.get(symbol)?.quantityMicros ?? 0n, planPrices[symbol]),
           0n,
         )
       const desired = Object.fromEntries(
         protocol.universe.map((symbol) => [
           symbol,
-          desiredQuantityMicros(equityAtOpen, target.weights[symbol], opens[symbol], protocol.executionModel),
+          desiredQuantityMicros(planEquity, target.weights[symbol], planPrices[symbol], protocol.executionModel),
         ]),
       ) as Readonly<Record<string, bigint>>
       const sessionFills: FillEvent[] = []
 
-      for (const symbol of [...protocol.universe].sort()) {
-        const position = positions.get(symbol) ?? { quantityMicros: 0n, costBasisMicros: 0n }
-        if (desired[symbol] >= position.quantityMicros) continue
-        const simulatedOrder = order(
+      const sellPlans = [...protocol.universe]
+        .sort()
+        .map((symbol) => {
+          const held = positions.get(symbol)?.quantityMicros ?? 0n
+          return { symbol, quantityMicros: desired[symbol] < held ? held - desired[symbol] : 0n }
+        })
+        .filter((candidate) => candidate.quantityMicros > 0n)
+      const buyPlans = [...protocol.universe]
+        .sort()
+        .map((symbol) => {
+          const held = positions.get(symbol)?.quantityMicros ?? 0n
+          return { symbol, quantityMicros: desired[symbol] > held ? desired[symbol] - held : 0n }
+        })
+        .filter((candidate) => candidate.quantityMicros > 0n)
+      const planFitsCash = (scale: bigint): boolean => {
+        const candidates: FeeInput[] = []
+        for (const candidate of buyPlans) {
+          const quantity = scaleQuantityMicros(candidate.quantityMicros, scale, protocol.executionModel)
+          if (
+            quantity === 0n ||
+            notionalMicros(quantity, planPrices[candidate.symbol]) <
+              BigInt(protocol.executionModel.precision.minimumBuyNotionalMicros)
+          ) {
+            continue
+          }
+          const terms = makeFillTerms(
+            'buy',
+            quantity,
+            planPrices[candidate.symbol],
+            protocol.executionModel,
+            costMultiplierMicros,
+          )
+          candidates.push({ side: 'buy', quantityMicros: quantity, notionalMicros: terms.notionalMicros })
+        }
+        const candidateFees = calculateSessionFees(candidates, protocol.executionModel, costMultiplierMicros)
+        return (
+          candidates.reduce((total, candidate) => total + candidate.notionalMicros, 0n) + candidateFees.totalMicros <=
+          cashAvailableWhenPlanned
+        )
+      }
+      let acceptedPlanScale = 0n
+      let upperPlanScale = ppm
+      while (acceptedPlanScale < upperPlanScale) {
+        const midpoint = (acceptedPlanScale + upperPlanScale + 1n) / 2n
+        if (planFitsCash(midpoint)) acceptedPlanScale = midpoint
+        else upperPlanScale = midpoint - 1n
+      }
+      const sellOrders = sellPlans.map((candidate) =>
+        order(
           runId,
           decision,
           session.date,
-          symbol,
+          candidate.symbol,
           'sell',
-          position.quantityMicros - desired[symbol],
-          opens[symbol],
+          candidate.quantityMicros,
+          fillPrices[candidate.symbol],
           protocol,
+        ),
+      )
+      const unboundedBuyOrders = buyPlans.flatMap((candidate): SimulatedOrder[] => {
+        const requested = scaleQuantityMicros(candidate.quantityMicros, acceptedPlanScale, protocol.executionModel)
+        return requested === 0n ||
+          notionalMicros(requested, planPrices[candidate.symbol]) <
+            BigInt(protocol.executionModel.precision.minimumBuyNotionalMicros)
+          ? []
+          : [
+              order(
+                runId,
+                decision,
+                session.date,
+                candidate.symbol,
+                'buy',
+                requested,
+                fillPrices[candidate.symbol],
+                protocol,
+              ),
+            ]
+      })
+      const fillsFitPlannedCash = (scale: bigint): boolean => {
+        const candidates: FeeInput[] = []
+        for (const candidate of unboundedBuyOrders) {
+          const quantity = scaleQuantityMicros(BigInt(candidate.filledQuantityMicros), scale, protocol.executionModel)
+          if (quantity === 0n) continue
+          const terms = makeFillTerms(
+            'buy',
+            quantity,
+            fillPrices[candidate.symbol],
+            protocol.executionModel,
+            costMultiplierMicros,
+          )
+          candidates.push({ side: 'buy', quantityMicros: quantity, notionalMicros: terms.notionalMicros })
+        }
+        const candidateFees = calculateSessionFees(candidates, protocol.executionModel, costMultiplierMicros)
+        return (
+          candidates.reduce((total, candidate) => total + candidate.notionalMicros, 0n) + candidateFees.totalMicros <=
+          cashAvailableWhenPlanned
         )
+      }
+      let acceptedFillScale = 0n
+      let upperFillScale = ppm
+      while (acceptedFillScale < upperFillScale) {
+        const midpoint = (acceptedFillScale + upperFillScale + 1n) / 2n
+        if (fillsFitPlannedCash(midpoint)) acceptedFillScale = midpoint
+        else upperFillScale = midpoint - 1n
+      }
+      const buyOrders = unboundedBuyOrders.map((candidate) =>
+        restrictReferenceBuyFill(
+          runId,
+          candidate,
+          scaleQuantityMicros(BigInt(candidate.filledQuantityMicros), acceptedFillScale, protocol.executionModel),
+        ),
+      )
+
+      for (const simulatedOrder of sellOrders) {
         if (retainTrace) orders.push(simulatedOrder)
+        const position = positions.get(simulatedOrder.symbol) ?? { quantityMicros: 0n, costBasisMicros: 0n }
         const quantity = BigInt(simulatedOrder.filledQuantityMicros)
         if (quantity === 0n) continue
-        const terms = makeFillTerms('sell', quantity, opens[symbol], protocol.executionModel, costMultiplierMicros)
+        const terms = makeFillTerms(
+          'sell',
+          quantity,
+          fillPrices[simulatedOrder.symbol],
+          protocol.executionModel,
+          costMultiplierMicros,
+        )
         const costBasis = saleCostBasisMicros(position.costBasisMicros, quantity, position.quantityMicros)
         const event = fill(runId, decision, simulatedOrder, terms, costBasis)
         cash += terms.notionalMicros
@@ -606,7 +749,7 @@ const replay = (
         slippage += terms.slippageCostMicros
         position.quantityMicros -= quantity
         position.costBasisMicros -= costBasis
-        positions.set(symbol, position)
+        positions.set(simulatedOrder.symbol, position)
         sessionFills.push(event)
         if (retainTrace) {
           events.push(event)
@@ -614,74 +757,14 @@ const replay = (
         }
       }
 
-      const buys = [...protocol.universe]
-        .sort()
-        .map((symbol) => {
-          const position = positions.get(symbol) ?? { quantityMicros: 0n, costBasisMicros: 0n }
-          return {
-            symbol,
-            position,
-            quantityMicros: desired[symbol] > position.quantityMicros ? desired[symbol] - position.quantityMicros : 0n,
-            referencePriceMicros: opens[symbol],
-          }
-        })
-        .filter((candidate) => candidate.quantityMicros > 0n)
-      const sellFees: FeeInput[] = sessionFills.map((event) => ({
-        side: event.side,
-        quantityMicros: BigInt(event.quantityMicros),
-        notionalMicros: BigInt(event.notionalMicros),
-      }))
-      const isAffordable = (scale: bigint): boolean => {
-        const buyFees: FeeInput[] = []
-        for (const candidate of buys) {
-          const quantity = scaleQuantityMicros(candidate.quantityMicros, scale, protocol.executionModel)
-          if (
-            quantity === 0n ||
-            notionalMicros(quantity, candidate.referencePriceMicros) <
-              BigInt(protocol.executionModel.precision.minimumBuyNotionalMicros)
-          ) {
-            continue
-          }
-          const terms = makeFillTerms(
-            'buy',
-            quantity,
-            candidate.referencePriceMicros,
-            protocol.executionModel,
-            costMultiplierMicros,
-          )
-          buyFees.push({ side: 'buy', quantityMicros: quantity, notionalMicros: terms.notionalMicros })
-        }
-        const fee = calculateSessionFees([...sellFees, ...buyFees], protocol.executionModel, costMultiplierMicros)
-        return buyFees.reduce((sum, value) => sum + value.notionalMicros, 0n) + fee.totalMicros <= cash
-      }
-      let minimum = 0n
-      let maximum = ppm
-      while (minimum < maximum) {
-        const candidate = (minimum + maximum + 1n) / 2n
-        if (isAffordable(candidate)) minimum = candidate
-        else maximum = candidate - 1n
-      }
-
-      for (const candidate of buys) {
-        const requested = scaleQuantityMicros(candidate.quantityMicros, minimum, protocol.executionModel)
-        if (requested === 0n) continue
-        const simulatedOrder = order(
-          runId,
-          decision,
-          session.date,
-          candidate.symbol,
-          'buy',
-          requested,
-          candidate.referencePriceMicros,
-          protocol,
-        )
+      for (const simulatedOrder of buyOrders) {
         if (retainTrace) orders.push(simulatedOrder)
         const quantity = BigInt(simulatedOrder.filledQuantityMicros)
         if (quantity === 0n) continue
         const terms = makeFillTerms(
           'buy',
           quantity,
-          candidate.referencePriceMicros,
+          fillPrices[simulatedOrder.symbol],
           protocol.executionModel,
           costMultiplierMicros,
         )
@@ -690,9 +773,10 @@ const replay = (
         turnover += terms.notionalMicros
         spread += terms.spreadCostMicros
         slippage += terms.slippageCostMicros
-        candidate.position.quantityMicros += quantity
-        candidate.position.costBasisMicros += terms.notionalMicros
-        positions.set(candidate.symbol, candidate.position)
+        const position = positions.get(simulatedOrder.symbol) ?? { quantityMicros: 0n, costBasisMicros: 0n }
+        position.quantityMicros += quantity
+        position.costBasisMicros += terms.notionalMicros
+        positions.set(simulatedOrder.symbol, position)
         sessionFills.push(event)
         if (retainTrace) {
           events.push(event)

--- a/services/bayn/src/behavior.ts
+++ b/services/bayn/src/behavior.ts
@@ -1,0 +1,4 @@
+import { sha256 } from './hash'
+
+export const riskBalancedTrendBehaviorVersion = 'bayn.risk-balanced-trend.behavior.v2' as const
+export const riskBalancedTrendBehaviorHash = sha256(riskBalancedTrendBehaviorVersion)

--- a/services/bayn/src/build.ts
+++ b/services/bayn/src/build.ts
@@ -51,3 +51,11 @@ export const verifyParameterHash = (
   metadata.strategyParameterHash === actualParameterHash
     ? Effect.void
     : Effect.fail(operationalError('config', 'provenance', 'compiled strategy parameters do not match build metadata'))
+
+export const verifyBehaviorHash = (
+  metadata: EmbeddedBuildMetadata,
+  actualBehaviorHash: string,
+): Effect.Effect<void, OperationalError> =>
+  metadata.strategyBehaviorHash === actualBehaviorHash
+    ? Effect.void
+    : Effect.fail(operationalError('config', 'provenance', 'compiled strategy behavior does not match build metadata'))

--- a/services/bayn/src/contracts.test.ts
+++ b/services/bayn/src/contracts.test.ts
@@ -71,19 +71,32 @@ describe('current contracts', () => {
     await expectFailure(decodeRunIdentity({ ...baseline, runId: '9'.repeat(64) }))
   })
 
-  test('accepts only current runtime provenance', async () => {
+  test('accepts current and immutable historical runtime provenance', async () => {
     const provenance = makeTestProvenance()
     expect(await Effect.runPromise(decodeRuntimeProvenance(provenance))).toEqual(provenance)
     expect(provenance).toMatchObject({
       schemaVersion: 'bayn.runtime-provenance.v2',
       strategy: {
         name: 'risk-balanced-trend',
-        parameterSchemaVersion: 'bayn.risk-balanced-trend.protocol.v2',
+        parameterSchemaVersion: 'bayn.risk-balanced-trend.protocol.v3',
       },
       contractVersions: {
         inputManifest: 'bayn.input-manifest.v3',
         evaluation: 'bayn.evaluation.v6',
       },
+    })
+    expect(
+      await Effect.runPromise(
+        decodeRuntimeProvenance({
+          ...provenance,
+          strategy: {
+            ...provenance.strategy,
+            parameterSchemaVersion: 'bayn.risk-balanced-trend.protocol.v2',
+          },
+        }),
+      ),
+    ).toMatchObject({
+      strategy: { parameterSchemaVersion: 'bayn.risk-balanced-trend.protocol.v2' },
     })
     await expectFailure(decodeRuntimeProvenance({ ...provenance, futureField: true }))
     await expectFailure(

--- a/services/bayn/src/contracts.ts
+++ b/services/bayn/src/contracts.ts
@@ -171,7 +171,10 @@ const RuntimeProvenanceBase = Schema.Struct({
     name: Schema.Literal('risk-balanced-trend'),
     behaviorHash: Sha256Schema,
     parameterHash: Sha256Schema,
-    parameterSchemaVersion: Schema.Literal('bayn.risk-balanced-trend.protocol.v2'),
+    parameterSchemaVersion: Schema.Literals([
+      'bayn.risk-balanced-trend.protocol.v2',
+      'bayn.risk-balanced-trend.protocol.v3',
+    ]),
   }),
   contractVersions: Schema.Struct({
     runtimeProvenance: Schema.Literal('bayn.runtime-provenance.v2'),

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -25,7 +25,7 @@ import { makeQualificationResult } from '../qualification'
 import { evaluateRiskBalancedTrend } from '../risk-balanced-trend'
 import { makeStrategy } from '../strategy'
 import { makeSnapshot, makeTestProvenance, fixtureProtocol } from '../test-fixtures'
-import type { Protocol } from '../types'
+import type { CausalProtocol, Protocol } from '../types'
 import {
   DatabaseError,
   EvidenceStore,
@@ -282,6 +282,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       { migration_id: 8, name: 'identified_submit_unknown' },
       { migration_id: 9, name: 'fill_source_timestamp' },
       { migration_id: 10, name: 'autonomous_cycles' },
+      { migration_id: 11, name: 'causal_protocol' },
     ])
   })
 
@@ -1745,7 +1746,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     if (Exit.isFailure(exit)) expect(Cause.pretty(exit.cause)).toContain('legacy migration history is unsupported')
   })
 
-  test('accepts only the current protocol contract', async () => {
+  test('accepts the current and immutable historical protocol contracts', async () => {
     const exits = await runtime.runPromise(
       Effect.gen(function* () {
         const sql = yield* PgClient.PgClient
@@ -1761,7 +1762,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
             '{}'::jsonb
           )
         `)
-        const current = yield* Effect.exit(sql`
+        const historical = yield* Effect.exit(sql`
           INSERT INTO protocol_locks (
             protocol_hash, schema_version, strategy_name, behavior_hash, parameter_hash, parameters
           ) VALUES (
@@ -1773,11 +1774,24 @@ describePostgres('PostgreSQL evaluation evidence', () => {
             '{}'::jsonb
           )
         `)
-        return { current, unsupported }
+        const current = yield* Effect.exit(sql`
+          INSERT INTO protocol_locks (
+            protocol_hash, schema_version, strategy_name, behavior_hash, parameter_hash, parameters
+          ) VALUES (
+            ${'6'.repeat(64)},
+            'bayn.risk-balanced-trend.protocol.v3',
+            'risk-balanced-trend',
+            ${'7'.repeat(64)},
+            ${'8'.repeat(64)},
+            '{}'::jsonb
+          )
+        `)
+        return { current, historical, unsupported }
       }),
     )
 
     expect(Exit.isFailure(exits.unsupported)).toBe(true)
+    expect(Exit.isSuccess(exits.historical)).toBe(true)
     expect(Exit.isSuccess(exits.current)).toBe(true)
   })
 
@@ -2007,7 +2021,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
   })
 
   test('persists and recovers fee, partial-fill, and nonzero cash-yield evidence', async () => {
-    const protocol: Protocol = {
+    const protocol: CausalProtocol = {
       ...fixtureProtocol,
       executionModel: {
         ...fixtureProtocol.executionModel,
@@ -2245,7 +2259,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     if (Option.isSome(result.stored)) {
       expect(result.stored.value.protocol).toMatchObject({
         strategyName: 'risk-balanced-trend',
-        schemaVersion: 'bayn.risk-balanced-trend.protocol.v2',
+        schemaVersion: 'bayn.risk-balanced-trend.protocol.v3',
         parameters: fixtureProtocol,
       })
       expect(result.stored.value.run).toMatchObject({

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -669,6 +669,57 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     expect(observed.state).toEqual({ state: 'ACKNOWLEDGED', state_version: 4, events: 2 })
   })
 
+  test('does not append a mutation start after its approved risk decision expires', async () => {
+    const execution = makeExecutionRuntime()
+    const intent = await Effect.runPromise(plan(intentPlan({ cycleId: '0'.repeat(64) })))
+    const expiresAtMillis = Date.now() + 1_000
+    const decision = await Effect.runPromise(
+      riskDecision(intent, RiskOutcome.Approved, { expiresAt: new Date(expiresAtMillis).toISOString() }),
+    )
+    await execution.runPromise(
+      Effect.gen(function* () {
+        yield* Effect.flatMap(IntentStore, (store) => store.commit(intent, decision))
+        const sql = yield* PgClient.PgClient
+        yield* sql`
+          INSERT INTO authority_state (
+            schema_version, generation_hash, maximum, effective, kill_state, version, updated_at
+          ) VALUES (
+            'bayn.paper-authority.v1', ${'9'.repeat(64)}, 'PAPER', 'PAPER', 'CLEAR', 1,
+            ${new Date(Date.now() + 1).toISOString()}
+          )
+        `
+      }),
+    )
+    await execution.dispose()
+    await Bun.sleep(Math.max(0, expiresAtMillis - Date.now() + 50))
+
+    const mutation = makeMutationRuntime()
+    const observed = await mutation.runPromise(
+      Effect.gen(function* () {
+        const store = yield* MutationStore
+        const start = yield* Effect.exit(
+          store.beginSubmit(intent.intentId, '8'.repeat(64), 1_000, new Date().toISOString()),
+        )
+        const sql = yield* PgClient.PgClient
+        const rows = yield* sql<{ events: number; state: string }>`
+          SELECT
+            state,
+            (SELECT count(*)::integer FROM mutation_events WHERE intent_id = ${intent.intentId}) AS events
+          FROM intents
+          WHERE intent_id = ${intent.intentId}
+        `
+        return { start, state: rows[0] }
+      }),
+    )
+    await mutation.dispose()
+
+    expect(Exit.isFailure(observed.start)).toBe(true)
+    if (Exit.isFailure(observed.start)) {
+      expect(Cause.pretty(observed.start.cause)).toContain('current approved risk decision')
+    }
+    expect(observed.state).toEqual({ state: 'APPROVED', events: 0 })
+  })
+
   test('keeps an ambiguous submit UNKNOWN until lookup recovers the exact broker order', async () => {
     const execution = makeExecutionRuntime()
     const intent = await Effect.runPromise(plan(intentPlan({ cycleId: '2'.repeat(64) })))

--- a/services/bayn/src/db/migrations.ts
+++ b/services/bayn/src/db/migrations.ts
@@ -10,6 +10,7 @@ import accounting from '../../migrations/0007_accounting'
 import identifiedSubmitUnknown from '../../migrations/0008_identified_submit_unknown'
 import fillSourceTimestamp from '../../migrations/0009_fill_source_timestamp'
 import autonomousCycles from '../../migrations/0010_autonomous_cycles'
+import causalProtocol from '../../migrations/0011_causal_protocol'
 
 export const migrationLoader = PgMigrator.fromRecord({
   '1_initial_schema': initialSchema,
@@ -22,4 +23,5 @@ export const migrationLoader = PgMigrator.fromRecord({
   '8_identified_submit_unknown': identifiedSubmitUnknown,
   '9_fill_source_timestamp': fillSourceTimestamp,
   '10_autonomous_cycles': autonomousCycles,
+  '11_causal_protocol': causalProtocol,
 })

--- a/services/bayn/src/evidence-contracts.ts
+++ b/services/bayn/src/evidence-contracts.ts
@@ -236,7 +236,9 @@ export const SimulatedOrdersArtifactSchema = Schema.Struct({
       requestedQuantityMicros: Micros,
       filledQuantityMicros: Micros,
       status: Schema.Literals(['filled', 'partially-filled', 'rejected']),
-      rejectionReason: Schema.NullOr(Schema.Literals(['below-minimum-buy-notional', 'zero-after-rounding'])),
+      rejectionReason: Schema.NullOr(
+        Schema.Literals(['below-minimum-buy-notional', 'zero-after-rounding', 'insufficient-buying-power']),
+      ),
       unfilledRemainder: Schema.Literals(['none', 'canceled']),
     }),
   ).check(Schema.isMinLength(1)),

--- a/services/bayn/src/execution-model.ts
+++ b/services/bayn/src/execution-model.ts
@@ -7,16 +7,21 @@ const BPS = 10_000n
 const WEIGHT_SCALE = 1_000_000_000_000n
 
 export const defaultExecutionModel: ExecutionModel = {
-  schemaVersion: 'bayn.execution-model.v1',
+  schemaVersion: 'bayn.execution-model.v2',
   venue: 'alpaca-paper',
   assetClass: 'us-equity',
   order: {
     type: 'market',
     timeInForce: 'day',
     extendedHours: false,
-    submitAfter: 'signal-session-close',
-    submitBefore: 'next-session-open',
-    priceReference: 'next-session-open',
+    planAfter: 'signal-session-finalized',
+    submitAfter: 'plan-committed',
+    submitBefore: 'fixed-pre-open-cutoff',
+    planningPriceReference: 'signal-session-close',
+    planningBrokerStateReference: 'reconciled-pre-plan-broker-state',
+    fillPriceReference: 'next-session-open',
+    buyingPowerPolicy: 'pre-submit-cash-without-sell-proceeds',
+    submissionCutoffLeadMinutes: 15,
   },
   precision: {
     quantityIncrementMicros: '1',

--- a/services/bayn/src/execution-session.test.ts
+++ b/services/bayn/src/execution-session.test.ts
@@ -12,7 +12,7 @@ const hash = (character: string): string => character.repeat(64)
 
 const calendar = (
   sessions: MarketCalendarObservation['sessions'],
-  requestedRange = { start: '2026-07-03', end: '2026-07-10' },
+  requestedRange = { start: '2026-07-02', end: '2026-07-10' },
 ): MarketCalendarObservation => {
   const material = {
     schemaVersion: 'bayn.alpaca-market-calendar-observation.v1',
@@ -85,7 +85,7 @@ describe('causal execution-session binding', () => {
       },
       calendar: calendar(
         [{ date: '2026-03-09', openAt: '2026-03-09T13:30:00.000Z', closeAt: '2026-03-09T20:00:00.000Z' }],
-        { start: '2026-03-07', end: '2026-03-10' },
+        { start: '2026-03-06', end: '2026-03-10' },
       ),
       executionModel: defaultExecutionModel,
     })
@@ -138,5 +138,16 @@ describe('causal execution-session binding', () => {
         bindingHash: canonicalHashV1(tamperedMaterial),
       }),
     ).toThrow('must equal execution open minus the declared fixed cutoff lead')
+  })
+
+  test('rejects a truncated calendar range that can skip the actual next exchange session', () => {
+    expect(() =>
+      bind(
+        calendar([{ date: '2026-07-10', openAt: '2026-07-10T13:30:00.000Z', closeAt: '2026-07-10T20:00:00.000Z' }], {
+          start: '2026-07-10',
+          end: '2026-07-10',
+        }),
+      ),
+    ).toThrow('market calendar request must start on or before the signal session')
   })
 })

--- a/services/bayn/src/execution-session.test.ts
+++ b/services/bayn/src/execution-session.test.ts
@@ -140,6 +140,29 @@ describe('causal execution-session binding', () => {
     ).toThrow('must equal execution open minus the declared fixed cutoff lead')
   })
 
+  test('rejects a rehashed execution session that is not selected by the bound calendar observation', () => {
+    const valid = bind(
+      calendar([{ date: '2026-07-06', openAt: '2026-07-06T13:30:00.000Z', closeAt: '2026-07-06T20:00:00.000Z' }]),
+    )
+    const { bindingHash: _, ...validMaterial } = valid
+    const tamperedMaterial = {
+      ...validMaterial,
+      executionSession: {
+        date: '2026-07-07',
+        openAt: '2026-07-07T13:30:00.000Z',
+        closeAt: '2026-07-07T20:00:00.000Z',
+      },
+      submissionCutoffAt: '2026-07-07T13:15:00.000Z',
+    }
+
+    expect(() =>
+      decodeBinding({
+        ...tamperedMaterial,
+        bindingHash: canonicalHashV1(tamperedMaterial),
+      }),
+    ).toThrow('must be the first post-signal session in the normalized calendar observation')
+  })
+
   test('rejects a truncated calendar range that can skip the actual next exchange session', () => {
     expect(() =>
       bind(

--- a/services/bayn/src/execution-session.test.ts
+++ b/services/bayn/src/execution-session.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { MarketCalendarObservation } from './broker/alpaca'
+import { defaultExecutionModel } from './execution-model'
+import { bindExecutionSession } from './execution-session'
+import { canonicalHashV1 } from './hash'
+
+const hash = (character: string): string => character.repeat(64)
+
+const calendar = (
+  sessions: MarketCalendarObservation['sessions'],
+  requestedRange = { start: '2026-07-03', end: '2026-07-10' },
+): MarketCalendarObservation => {
+  const material = {
+    schemaVersion: 'bayn.alpaca-market-calendar-observation.v1',
+    source: 'alpaca-v2-calendar',
+    requestedRange,
+    timeZone: 'UTC',
+    sessions,
+  } as const
+  return { ...material, normalizedResponseHash: canonicalHashV1(material) }
+}
+
+const bind = (observation: MarketCalendarObservation) =>
+  bindExecutionSession({
+    signal: {
+      sessionDate: '2026-07-02',
+      finalizedAt: '2026-07-02T22:00:00.000Z',
+      contentHash: hash('a'),
+    },
+    planningBrokerState: {
+      observedAt: '2026-07-02T22:01:00.000Z',
+      contentHash: hash('b'),
+    },
+    calendar: observation,
+    executionModel: defaultExecutionModel,
+  })
+
+describe('causal execution-session binding', () => {
+  test('binds a holiday gap, fixed pre-open cutoff, and early close without assuming session hours', () => {
+    const result = bind(
+      calendar([
+        {
+          date: '2026-07-06',
+          openAt: '2026-07-06T13:30:00.000Z',
+          closeAt: '2026-07-06T17:00:00.000Z',
+        },
+        {
+          date: '2026-07-07',
+          openAt: '2026-07-07T13:30:00.000Z',
+          closeAt: '2026-07-07T20:00:00.000Z',
+        },
+      ]),
+    )
+
+    expect(result).toMatchObject({
+      schemaVersion: 'bayn.execution-session-binding.v1',
+      executionSession: {
+        date: '2026-07-06',
+        openAt: '2026-07-06T13:30:00.000Z',
+        closeAt: '2026-07-06T17:00:00.000Z',
+      },
+      submissionOpenAt: '2026-07-02T22:01:00.000Z',
+      submissionCutoffAt: '2026-07-06T13:15:00.000Z',
+      submissionCutoffLeadMinutes: 15,
+    })
+    expect(result.bindingHash).toMatch(/^[a-f0-9]{64}$/)
+  })
+
+  test('preserves the DST-normalized open supplied by the bounded broker observation', () => {
+    const result = bindExecutionSession({
+      signal: {
+        sessionDate: '2026-03-06',
+        finalizedAt: '2026-03-06T22:00:00.000Z',
+        contentHash: hash('c'),
+      },
+      planningBrokerState: {
+        observedAt: '2026-03-06T22:01:00.000Z',
+        contentHash: hash('d'),
+      },
+      calendar: calendar(
+        [{ date: '2026-03-09', openAt: '2026-03-09T13:30:00.000Z', closeAt: '2026-03-09T20:00:00.000Z' }],
+        { start: '2026-03-07', end: '2026-03-10' },
+      ),
+      executionModel: defaultExecutionModel,
+    })
+
+    expect(result.submissionCutoffAt).toBe('2026-03-09T13:15:00.000Z')
+  })
+
+  test('fails closed on calendar hash drift and a planning window that opens at the cutoff', () => {
+    const observation = calendar([
+      { date: '2026-07-06', openAt: '2026-07-06T13:30:00.000Z', closeAt: '2026-07-06T20:00:00.000Z' },
+    ])
+    expect(() =>
+      bind({
+        ...observation,
+        sessions: [{ ...observation.sessions[0], closeAt: '2026-07-06T19:00:00.000Z' }],
+      }),
+    ).toThrow('normalized response hash')
+
+    expect(() =>
+      bindExecutionSession({
+        signal: {
+          sessionDate: '2026-07-02',
+          finalizedAt: '2026-07-06T13:15:00.000Z',
+          contentHash: hash('e'),
+        },
+        planningBrokerState: {
+          observedAt: '2026-07-06T13:14:59.999Z',
+          contentHash: hash('f'),
+        },
+        calendar: observation,
+        executionModel: defaultExecutionModel,
+      }),
+    ).toThrow('submissionOpenAt < submissionCutoffAt < executionSession.openAt')
+  })
+})

--- a/services/bayn/src/execution-session.test.ts
+++ b/services/bayn/src/execution-session.test.ts
@@ -163,6 +163,40 @@ describe('causal execution-session binding', () => {
     ).toThrow('must be the first post-signal session in the normalized calendar observation')
   })
 
+  test('rejects a rehashed calendar whose UTC instants do not belong to the declared session date', () => {
+    const valid = bind(
+      calendar([{ date: '2026-07-06', openAt: '2026-07-06T13:30:00.000Z', closeAt: '2026-07-06T20:00:00.000Z' }]),
+    )
+    const shiftedSession = {
+      date: '2026-07-06',
+      openAt: '2026-07-10T13:30:00.000Z',
+      closeAt: '2026-07-10T20:00:00.000Z',
+    } as const
+    const shiftedCalendarMaterial = {
+      ...valid.calendar,
+      sessions: [shiftedSession],
+    }
+    const { normalizedResponseHash: _, ...calendarMaterial } = shiftedCalendarMaterial
+    const shiftedCalendar = {
+      ...calendarMaterial,
+      normalizedResponseHash: canonicalHashV1(calendarMaterial),
+    }
+    const { bindingHash: __, ...validMaterial } = valid
+    const tamperedMaterial = {
+      ...validMaterial,
+      calendar: shiftedCalendar,
+      executionSession: shiftedSession,
+      submissionCutoffAt: '2026-07-10T13:15:00.000Z',
+    }
+
+    expect(() =>
+      decodeBinding({
+        ...tamperedMaterial,
+        bindingHash: canonicalHashV1(tamperedMaterial),
+      }),
+    ).toThrow('must have valid hours on its declared UTC session date within the requested range')
+  })
+
   test('rejects a truncated calendar range that can skip the actual next exchange session', () => {
     expect(() =>
       bind(

--- a/services/bayn/src/execution-session.test.ts
+++ b/services/bayn/src/execution-session.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, test } from 'bun:test'
 
+import { Schema } from 'effect'
+
 import type { MarketCalendarObservation } from './broker/alpaca'
 import { defaultExecutionModel } from './execution-model'
-import { bindExecutionSession } from './execution-session'
+import { bindExecutionSession, ExecutionSessionBindingSchema } from './execution-session'
 import { canonicalHashV1 } from './hash'
+import { strictParseOptions } from './schemas'
 
 const hash = (character: string): string => character.repeat(64)
 
@@ -35,6 +38,8 @@ const bind = (observation: MarketCalendarObservation) =>
     calendar: observation,
     executionModel: defaultExecutionModel,
   })
+
+const decodeBinding = Schema.decodeUnknownSync(ExecutionSessionBindingSchema, strictParseOptions)
 
 describe('causal execution-session binding', () => {
   test('binds a holiday gap, fixed pre-open cutoff, and early close without assuming session hours', () => {
@@ -114,5 +119,24 @@ describe('causal execution-session binding', () => {
         executionModel: defaultExecutionModel,
       }),
     ).toThrow('submissionOpenAt < submissionCutoffAt < executionSession.openAt')
+  })
+
+  test('rejects a rehashed binding whose cutoff does not match the declared lead', () => {
+    const observation = calendar([
+      { date: '2026-07-06', openAt: '2026-07-06T13:30:00.000Z', closeAt: '2026-07-06T20:00:00.000Z' },
+    ])
+    const valid = bind(observation)
+    const { bindingHash: _, ...validMaterial } = valid
+    const tamperedMaterial = {
+      ...validMaterial,
+      submissionCutoffAt: '2026-07-06T13:29:59.999Z',
+    }
+
+    expect(() =>
+      decodeBinding({
+        ...tamperedMaterial,
+        bindingHash: canonicalHashV1(tamperedMaterial),
+      }),
+    ).toThrow('must equal execution open minus the declared fixed cutoff lead')
   })
 })

--- a/services/bayn/src/execution-session.ts
+++ b/services/bayn/src/execution-session.ts
@@ -119,6 +119,9 @@ export const bindExecutionSession = (input: BindExecutionSessionInput): Executio
       throw new Error('Alpaca market calendar sessions must be unique and strictly ordered')
     }
   }
+  if (input.calendar.requestedRange.start > input.signal.sessionDate) {
+    throw new Error('Alpaca market calendar request must start on or before the signal session')
+  }
   const executionSession = input.calendar.sessions.find((session) => session.date > input.signal.sessionDate)
   if (executionSession === undefined) {
     throw new Error('Alpaca market calendar response does not contain a future execution session')

--- a/services/bayn/src/execution-session.ts
+++ b/services/bayn/src/execution-session.ts
@@ -12,6 +12,14 @@ const CalendarIdentitySchema = Schema.Struct({
     start: IsoDateSchema,
     end: IsoDateSchema,
   }),
+  timeZone: Schema.Literal('UTC'),
+  sessions: Schema.Array(
+    Schema.Struct({
+      date: IsoDateSchema,
+      openAt: UtcInstantSchema,
+      closeAt: UtcInstantSchema,
+    }),
+  ).check(Schema.isMinLength(1)),
   normalizedResponseHash: Sha256Schema,
 })
 
@@ -43,6 +51,54 @@ export const ExecutionSessionBindingSchema = ExecutionSessionBindingBase.check(
     const issues: Schema.FilterIssue[] = []
     if (binding.signal.sessionDate >= binding.executionSession.date) {
       issues.push({ path: ['executionSession', 'date'], issue: 'must follow the finalized signal session' })
+    }
+    if (binding.calendar.requestedRange.start > binding.signal.sessionDate) {
+      issues.push({
+        path: ['calendar', 'requestedRange', 'start'],
+        issue: 'must be on or before the signal session',
+      })
+    }
+    for (let index = 0; index < binding.calendar.sessions.length; index += 1) {
+      const session = binding.calendar.sessions[index]
+      if (
+        session.date < binding.calendar.requestedRange.start ||
+        session.date > binding.calendar.requestedRange.end ||
+        session.openAt >= session.closeAt
+      ) {
+        issues.push({
+          path: ['calendar', 'sessions', index],
+          issue: 'must have valid hours within the requested range',
+        })
+      }
+      if (index > 0 && binding.calendar.sessions[index - 1].date >= session.date) {
+        issues.push({
+          path: ['calendar', 'sessions', index],
+          issue: 'must be unique and strictly ordered',
+        })
+      }
+    }
+    const calendarMaterial = {
+      schemaVersion: binding.calendar.schemaVersion,
+      source: binding.calendar.source,
+      requestedRange: binding.calendar.requestedRange,
+      timeZone: binding.calendar.timeZone,
+      sessions: binding.calendar.sessions,
+    }
+    if (binding.calendar.normalizedResponseHash !== canonicalHashV1(calendarMaterial)) {
+      issues.push({
+        path: ['calendar', 'normalizedResponseHash'],
+        issue: 'must match the complete normalized calendar observation',
+      })
+    }
+    const selectedSession = binding.calendar.sessions.find((session) => session.date > binding.signal.sessionDate)
+    if (
+      selectedSession === undefined ||
+      canonicalHashV1(selectedSession) !== canonicalHashV1(binding.executionSession)
+    ) {
+      issues.push({
+        path: ['executionSession'],
+        issue: 'must be the first post-signal session in the normalized calendar observation',
+      })
     }
     if (binding.executionSession.openAt >= binding.executionSession.closeAt) {
       issues.push({ path: ['executionSession', 'closeAt'], issue: 'must follow the execution open' })
@@ -146,6 +202,8 @@ export const bindExecutionSession = (input: BindExecutionSessionInput): Executio
       schemaVersion: input.calendar.schemaVersion,
       source: input.calendar.source,
       requestedRange: input.calendar.requestedRange,
+      timeZone: input.calendar.timeZone,
+      sessions: input.calendar.sessions,
       normalizedResponseHash: input.calendar.normalizedResponseHash,
     },
     executionSession,

--- a/services/bayn/src/execution-session.ts
+++ b/services/bayn/src/execution-session.ts
@@ -65,6 +65,15 @@ export const ExecutionSessionBindingSchema = ExecutionSessionBindingBase.check(
         issue: 'must produce submissionOpenAt < submissionCutoffAt < executionSession.openAt',
       })
     }
+    const expectedSubmissionCutoffAt = new Date(
+      Date.parse(binding.executionSession.openAt) - binding.submissionCutoffLeadMinutes * 60_000,
+    ).toISOString()
+    if (binding.submissionCutoffAt !== expectedSubmissionCutoffAt) {
+      issues.push({
+        path: ['submissionCutoffAt'],
+        issue: 'must equal execution open minus the declared fixed cutoff lead',
+      })
+    }
     const { bindingHash, ...material } = binding
     if (bindingHash !== canonicalHashV1(material)) {
       issues.push({ path: ['bindingHash'], issue: 'must match the causal execution-session material' })

--- a/services/bayn/src/execution-session.ts
+++ b/services/bayn/src/execution-session.ts
@@ -63,11 +63,13 @@ export const ExecutionSessionBindingSchema = ExecutionSessionBindingBase.check(
       if (
         session.date < binding.calendar.requestedRange.start ||
         session.date > binding.calendar.requestedRange.end ||
+        session.openAt.slice(0, 10) !== session.date ||
+        session.closeAt.slice(0, 10) !== session.date ||
         session.openAt >= session.closeAt
       ) {
         issues.push({
           path: ['calendar', 'sessions', index],
-          issue: 'must have valid hours within the requested range',
+          issue: 'must have valid hours on its declared UTC session date within the requested range',
         })
       }
       if (index > 0 && binding.calendar.sessions[index - 1].date >= session.date) {

--- a/services/bayn/src/execution-session.ts
+++ b/services/bayn/src/execution-session.ts
@@ -1,0 +1,145 @@
+import { Schema } from 'effect'
+
+import type { MarketCalendarObservation } from './broker/alpaca'
+import { canonicalHashV1 } from './hash'
+import type { ExecutionModel } from './protocol'
+import { IsoDateSchema, Sha256Schema, UtcInstantSchema, strictParseOptions as StrictParseOptions } from './schemas'
+
+const CalendarIdentitySchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.alpaca-market-calendar-observation.v1'),
+  source: Schema.Literal('alpaca-v2-calendar'),
+  requestedRange: Schema.Struct({
+    start: IsoDateSchema,
+    end: IsoDateSchema,
+  }),
+  normalizedResponseHash: Sha256Schema,
+})
+
+const ExecutionSessionBindingBase = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.execution-session-binding.v1'),
+  signal: Schema.Struct({
+    sessionDate: IsoDateSchema,
+    finalizedAt: UtcInstantSchema,
+    contentHash: Sha256Schema,
+  }),
+  planningBrokerState: Schema.Struct({
+    observedAt: UtcInstantSchema,
+    contentHash: Sha256Schema,
+  }),
+  calendar: CalendarIdentitySchema,
+  executionSession: Schema.Struct({
+    date: IsoDateSchema,
+    openAt: UtcInstantSchema,
+    closeAt: UtcInstantSchema,
+  }),
+  submissionOpenAt: UtcInstantSchema,
+  submissionCutoffAt: UtcInstantSchema,
+  submissionCutoffLeadMinutes: Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 120 })),
+  bindingHash: Sha256Schema,
+})
+
+export const ExecutionSessionBindingSchema = ExecutionSessionBindingBase.check(
+  Schema.makeFilter((binding: typeof ExecutionSessionBindingBase.Type) => {
+    const issues: Schema.FilterIssue[] = []
+    if (binding.signal.sessionDate >= binding.executionSession.date) {
+      issues.push({ path: ['executionSession', 'date'], issue: 'must follow the finalized signal session' })
+    }
+    if (binding.executionSession.openAt >= binding.executionSession.closeAt) {
+      issues.push({ path: ['executionSession', 'closeAt'], issue: 'must follow the execution open' })
+    }
+    if (
+      binding.signal.finalizedAt > binding.submissionOpenAt ||
+      binding.planningBrokerState.observedAt > binding.submissionOpenAt
+    ) {
+      issues.push({
+        path: ['submissionOpenAt'],
+        issue: 'must not precede finalized signal data or reconciled planning broker state',
+      })
+    }
+    if (
+      binding.submissionOpenAt >= binding.submissionCutoffAt ||
+      binding.submissionCutoffAt >= binding.executionSession.openAt
+    ) {
+      issues.push({
+        path: ['submissionCutoffAt'],
+        issue: 'must produce submissionOpenAt < submissionCutoffAt < executionSession.openAt',
+      })
+    }
+    const { bindingHash, ...material } = binding
+    if (bindingHash !== canonicalHashV1(material)) {
+      issues.push({ path: ['bindingHash'], issue: 'must match the causal execution-session material' })
+    }
+    return issues
+  }),
+)
+export type ExecutionSessionBinding = typeof ExecutionSessionBindingSchema.Type
+
+export interface BindExecutionSessionInput {
+  readonly signal: {
+    readonly sessionDate: string
+    readonly finalizedAt: string
+    readonly contentHash: string
+  }
+  readonly planningBrokerState: {
+    readonly observedAt: string
+    readonly contentHash: string
+  }
+  readonly calendar: MarketCalendarObservation
+  readonly executionModel: ExecutionModel
+}
+
+const decodeBinding = Schema.decodeUnknownSync(ExecutionSessionBindingSchema, StrictParseOptions)
+
+const observationMaterial = (observation: MarketCalendarObservation) => ({
+  schemaVersion: observation.schemaVersion,
+  source: observation.source,
+  requestedRange: observation.requestedRange,
+  timeZone: observation.timeZone,
+  sessions: observation.sessions,
+})
+
+export const bindExecutionSession = (input: BindExecutionSessionInput): ExecutionSessionBinding => {
+  if (input.executionModel.schemaVersion !== 'bayn.execution-model.v2') {
+    throw new Error('causal execution-session binding requires bayn.execution-model.v2')
+  }
+  if (canonicalHashV1(observationMaterial(input.calendar)) !== input.calendar.normalizedResponseHash) {
+    throw new Error('Alpaca market calendar normalized response hash does not match its content')
+  }
+  for (let index = 1; index < input.calendar.sessions.length; index += 1) {
+    if (input.calendar.sessions[index - 1].date >= input.calendar.sessions[index].date) {
+      throw new Error('Alpaca market calendar sessions must be unique and strictly ordered')
+    }
+  }
+  const executionSession = input.calendar.sessions.find((session) => session.date > input.signal.sessionDate)
+  if (executionSession === undefined) {
+    throw new Error('Alpaca market calendar response does not contain a future execution session')
+  }
+  if (
+    executionSession.date < input.calendar.requestedRange.start ||
+    executionSession.date > input.calendar.requestedRange.end
+  ) {
+    throw new Error('execution session is outside the bound Alpaca market calendar request')
+  }
+  const submissionOpenAt =
+    input.signal.finalizedAt >= input.planningBrokerState.observedAt
+      ? input.signal.finalizedAt
+      : input.planningBrokerState.observedAt
+  const cutoffLeadMinutes = input.executionModel.order.submissionCutoffLeadMinutes
+  const submissionCutoffAt = new Date(Date.parse(executionSession.openAt) - cutoffLeadMinutes * 60_000).toISOString()
+  const material = {
+    schemaVersion: 'bayn.execution-session-binding.v1',
+    signal: input.signal,
+    planningBrokerState: input.planningBrokerState,
+    calendar: {
+      schemaVersion: input.calendar.schemaVersion,
+      source: input.calendar.source,
+      requestedRange: input.calendar.requestedRange,
+      normalizedResponseHash: input.calendar.normalizedResponseHash,
+    },
+    executionSession,
+    submissionOpenAt,
+    submissionCutoffAt,
+    submissionCutoffLeadMinutes: cutoffLeadMinutes,
+  } as const
+  return decodeBinding({ ...material, bindingHash: canonicalHashV1(material) })
+}

--- a/services/bayn/src/execution/coordinator.test.ts
+++ b/services/bayn/src/execution/coordinator.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Effect, Exit, Option } from 'effect'
+import { Cause, Effect, Exit, Option } from 'effect'
 import { TestClock } from 'effect/testing'
 
 import {
@@ -194,7 +194,12 @@ const makeHarness = (options: HarnessOptions = {}) => {
   const mutationStore: MutationStoreShape = {
     beginSubmit: (_intentId, requestHash, consistencyDelayMs, occurredAt) => {
       const existing = latest.get(MutationOperation.Submit)
-      if (existing !== undefined) return Effect.succeed({ event: existing, started: false })
+      if (existing !== undefined) {
+        if (existing.requestHash !== requestHash || existing.consistencyDelayMs !== consistencyDelayMs) {
+          return Effect.die(new Error('mutation identity was reused with different request content'))
+        }
+        return Effect.succeed({ event: existing, started: false })
+      }
       const started = event(
         MutationOperation.Submit,
         MutationEventType.SubmitStarted,
@@ -246,7 +251,16 @@ const makeHarness = (options: HarnessOptions = {}) => {
     },
     beginCancel: (_intentId, requestHash, brokerOrderId, consistencyDelayMs, occurredAt) => {
       const existing = latest.get(MutationOperation.Cancel)
-      if (existing !== undefined) return Effect.succeed({ event: existing, started: false })
+      if (existing !== undefined) {
+        if (
+          existing.requestHash !== requestHash ||
+          existing.consistencyDelayMs !== consistencyDelayMs ||
+          existing.brokerOrderId !== brokerOrderId
+        ) {
+          return Effect.die(new Error('mutation identity was reused with different request content'))
+        }
+        return Effect.succeed({ event: existing, started: false })
+      }
       return Effect.succeed({
         event: event(
           MutationOperation.Cancel,
@@ -498,6 +512,7 @@ describe('paper execution coordinator', () => {
       harness.provide(
         Effect.gen(function* () {
           const accepted = yield* submit(intentId, 1_000)
+          yield* TestClock.adjust(600_000)
           const replay = yield* submit(intentId, 1_000)
           return { accepted, replay }
         }),
@@ -508,6 +523,24 @@ describe('paper execution coordinator', () => {
     expect(result.replay.eventId).toBe(result.accepted.eventId)
     expect(harness.calls()).toEqual({ submit: 1, cancel: 0, lookup: 0 })
     expect(harness.state()).toBe(IntentState.Acknowledged)
+  })
+
+  test('rejects a submit replay whose committed consistency delay changes', async () => {
+    const harness = makeHarness()
+    const result = await Effect.runPromise(
+      harness.provide(
+        Effect.gen(function* () {
+          yield* submit(intentId, 1_000)
+          return yield* Effect.exit(submit(intentId, 1_001))
+        }),
+      ),
+    )
+
+    expect(Exit.isFailure(result)).toBe(true)
+    if (Exit.isFailure(result)) {
+      expect(Cause.pretty(result.cause)).toContain('mutation identity was reused with different request content')
+    }
+    expect(harness.calls()).toEqual({ submit: 1, cancel: 0, lookup: 0 })
   })
 
   test('keeps a partial broker fill UNKNOWN instead of recording a false terminal fill', async () => {
@@ -650,6 +683,25 @@ describe('paper execution coordinator', () => {
     expect(result.found.eventType).toBe(MutationEventType.RecoveryFound)
     expect(harness.calls()).toEqual({ submit: 1, cancel: 1, lookup: 1 })
     expect(harness.state()).toBe(IntentState.Terminal)
+  })
+
+  test('rejects a cancel replay whose committed consistency delay changes', async () => {
+    const harness = makeHarness()
+    const result = await Effect.runPromise(
+      harness.provide(
+        Effect.gen(function* () {
+          yield* submit(intentId, 1_000)
+          yield* cancel(intentId, 1_000)
+          return yield* Effect.exit(cancel(intentId, 1_001))
+        }),
+      ),
+    )
+
+    expect(Exit.isFailure(result)).toBe(true)
+    if (Exit.isFailure(result)) {
+      expect(Cause.pretty(result.cause)).toContain('mutation identity was reused with different request content')
+    }
+    expect(harness.calls()).toEqual({ submit: 1, cancel: 1, lookup: 0 })
   })
 
   test('makes zero DELETE calls when the risk decision expires exactly at cancellation', async () => {

--- a/services/bayn/src/execution/coordinator.test.ts
+++ b/services/bayn/src/execution/coordinator.test.ts
@@ -612,13 +612,13 @@ describe('paper execution coordinator', () => {
     expect(harness.state()).toBe(IntentState.Unknown)
   })
 
-  test('makes no broker call when the writer fence is lost after recording I/O start', async () => {
+  test('makes no broker call or durable start when the writer fence is already lost', async () => {
     const harness = makeHarness({ lostFence: true })
     const failure = await Effect.runPromise(harness.provide(Effect.flip(submit(intentId, 1_000))))
 
     expect(failure).toBeInstanceOf(WriterFenceError)
     expect(harness.calls()).toEqual({ submit: 0, cancel: 0, lookup: 0 })
-    expect(harness.state()).toBe(IntentState.IoStarted)
+    expect(harness.state()).toBe(IntentState.Approved)
   })
 
   test('persists UNKNOWN and refuses lookup until the committed consistency delay elapses', async () => {

--- a/services/bayn/src/execution/coordinator.test.ts
+++ b/services/bayn/src/execution/coordinator.test.ts
@@ -472,6 +472,26 @@ describe('paper execution coordinator', () => {
     expect(harness.state()).toBe(IntentState.Approved)
   })
 
+  test('makes zero POST calls when the risk decision expires exactly at submission', async () => {
+    const harness = makeHarness()
+    const failure = await Effect.runPromise(
+      harness.provide(
+        Effect.gen(function* () {
+          yield* TestClock.adjust(600_000)
+          return yield* Effect.flip(submit(intentId, 1_000))
+        }),
+      ),
+    )
+
+    expect(failure).toBeInstanceOf(ExecutionError)
+    expect(failure).toMatchObject({
+      failure: ExecutionFailure.InvalidState,
+      message: `submission risk decision expired at ${riskDecision.expiresAt}`,
+    })
+    expect(harness.calls()).toEqual({ submit: 0, cancel: 0, lookup: 0 })
+    expect(harness.state()).toBe(IntentState.Approved)
+  })
+
   test('records before submission and never calls the broker again for a replayed intent', async () => {
     const harness = makeHarness()
     const result = await Effect.runPromise(
@@ -630,5 +650,26 @@ describe('paper execution coordinator', () => {
     expect(result.found.eventType).toBe(MutationEventType.RecoveryFound)
     expect(harness.calls()).toEqual({ submit: 1, cancel: 1, lookup: 1 })
     expect(harness.state()).toBe(IntentState.Terminal)
+  })
+
+  test('makes zero DELETE calls when the risk decision expires exactly at cancellation', async () => {
+    const harness = makeHarness()
+    const failure = await Effect.runPromise(
+      harness.provide(
+        Effect.gen(function* () {
+          yield* submit(intentId, 1_000)
+          yield* TestClock.adjust(600_000)
+          return yield* Effect.flip(cancel(intentId, 1_000))
+        }),
+      ),
+    )
+
+    expect(failure).toBeInstanceOf(ExecutionError)
+    expect(failure).toMatchObject({
+      failure: ExecutionFailure.InvalidState,
+      message: `cancellation risk decision expired at ${riskDecision.expiresAt}`,
+    })
+    expect(harness.calls()).toEqual({ submit: 1, cancel: 0, lookup: 0 })
+    expect(harness.state()).toBe(IntentState.Acknowledged)
   })
 })

--- a/services/bayn/src/execution/coordinator.ts
+++ b/services/bayn/src/execution/coordinator.ts
@@ -231,10 +231,13 @@ export const submit = (intentId: string, consistencyDelayMs: number) =>
     const broker = yield* BrokerMutation
     const fence = yield* WriterFence
     const existing = yield* mutations.latest(intentId, MutationOperation.Submit)
-    if (existing !== undefined) return existing
     const before = yield* readIntent(MutationOperation.Submit, intentId)
-    yield* requireActiveRiskDecision(MutationOperation.Submit, before)
     const hash = yield* requestHash(MutationOperation.Submit, before.intent)
+    if (existing !== undefined) {
+      const replay = yield* mutations.beginSubmit(intentId, hash, consistencyDelayMs, existing.occurredAt)
+      return replay.event
+    }
+    yield* requireActiveRiskDecision(MutationOperation.Submit, before)
     const current = yield* now
     const started = yield* mutations.beginSubmit(
       intentId,
@@ -303,9 +306,6 @@ export const cancel = (intentId: string, consistencyDelayMs: number) =>
     const broker = yield* BrokerMutation
     const fence = yield* WriterFence
     const existing = yield* mutations.latest(intentId, MutationOperation.Cancel)
-    if (existing !== undefined) return existing
-    const intent = yield* readIntent(MutationOperation.Cancel, intentId)
-    yield* requireActiveRiskDecision(MutationOperation.Cancel, intent)
     const submitEvent = yield* mutations.latest(intentId, MutationOperation.Submit)
     const orderId = submitEvent?.brokerOrderId
     if (orderId === undefined) {
@@ -318,6 +318,12 @@ export const cancel = (intentId: string, consistencyDelayMs: number) =>
       )
     }
     const hash = cancelRequestHash(orderId)
+    if (existing !== undefined) {
+      const replay = yield* mutations.beginCancel(intentId, hash, orderId, consistencyDelayMs, existing.occurredAt)
+      return replay.event
+    }
+    const intent = yield* readIntent(MutationOperation.Cancel, intentId)
+    yield* requireActiveRiskDecision(MutationOperation.Cancel, intent)
     const current = yield* now
     const started = yield* mutations.beginCancel(
       intentId,

--- a/services/bayn/src/execution/coordinator.ts
+++ b/services/bayn/src/execution/coordinator.ts
@@ -226,7 +226,6 @@ const validateRecovery = (stored: Intent, event: MutationEvent) =>
 
 export const submit = (intentId: string, consistencyDelayMs: number) =>
   Effect.gen(function* () {
-    const intents = yield* IntentStore
     const mutations = yield* MutationStore
     const broker = yield* BrokerMutation
     const fence = yield* WriterFence
@@ -237,6 +236,7 @@ export const submit = (intentId: string, consistencyDelayMs: number) =>
       const replay = yield* mutations.beginSubmit(intentId, hash, consistencyDelayMs, existing.occurredAt)
       return replay.event
     }
+    yield* fence.check
     yield* requireActiveRiskDecision(MutationOperation.Submit, before)
     const current = yield* now
     const started = yield* mutations.beginSubmit(
@@ -247,20 +247,9 @@ export const submit = (intentId: string, consistencyDelayMs: number) =>
     )
     if (!started.started) return started.event
 
-    const after = yield* intents.read(intentId)
-    if (Option.isNone(after) || after.value.intent.state !== IntentState.IoStarted) {
-      return yield* Effect.fail(
-        new ExecutionError({
-          operation: MutationOperation.Submit,
-          failure: ExecutionFailure.InvalidState,
-          message: 'started submit cannot read back its IO_STARTED intent',
-        }),
-      )
-    }
-    yield* fence.check
-    yield* requireActiveRiskDecision(MutationOperation.Submit, after.value, 'submission', true)
+    const submittedIntent: Intent = { ...before.intent, state: IntentState.IoStarted }
 
-    return yield* broker.submit(after.value.intent).pipe(
+    return yield* broker.submit(submittedIntent).pipe(
       Effect.matchEffect({
         onFailure: (error) => {
           if (
@@ -279,7 +268,7 @@ export const submit = (intentId: string, consistencyDelayMs: number) =>
               )
         },
         onSuccess: (receipt) => {
-          if (receipt.requestHash !== hash || !exactOrder(after.value.intent, receipt.order)) {
+          if (receipt.requestHash !== hash || !exactOrder(submittedIntent, receipt.order)) {
             return mutations.submitUnknown(
               intentId,
               hash,
@@ -323,6 +312,7 @@ export const cancel = (intentId: string, consistencyDelayMs: number) =>
       return replay.event
     }
     const intent = yield* readIntent(MutationOperation.Cancel, intentId)
+    yield* fence.check
     yield* requireActiveRiskDecision(MutationOperation.Cancel, intent)
     const current = yield* now
     const started = yield* mutations.beginCancel(
@@ -333,9 +323,6 @@ export const cancel = (intentId: string, consistencyDelayMs: number) =>
       nextInstant(intent.updatedAt, current),
     )
     if (!started.started) return started.event
-    yield* fence.check
-    const currentIntent = yield* readIntent(MutationOperation.Cancel, intentId)
-    yield* requireActiveRiskDecision(MutationOperation.Cancel, currentIntent)
 
     return yield* broker.cancel(orderId).pipe(
       Effect.matchEffect({

--- a/services/bayn/src/execution/coordinator.ts
+++ b/services/bayn/src/execution/coordinator.ts
@@ -19,7 +19,7 @@ import {
 } from '../broker/alpaca'
 import { canonicalHashV1 } from '../hash'
 import { IntentState, RiskOutcome, TerminalOutcome, type Intent } from '../paper'
-import { IntentStore, type IntentStoreError } from './intents'
+import { IntentStore, type IntentStoreError, type StoredIntent } from './intents'
 import { MutationEventType, MutationStore, type MutationEvent } from './mutations'
 import { WriterFence } from './writer-fence'
 
@@ -132,36 +132,52 @@ const isSubmitResolved = (event: MutationEvent): boolean =>
   event.eventType === MutationEventType.SubmitRejected ||
   event.eventType === MutationEventType.RecoveryFound
 
+const requireActiveRiskDecision = (
+  operation: MutationOperation,
+  stored: StoredIntent,
+  operationLabel = operation === MutationOperation.Submit ? 'submission' : 'cancellation',
+  allowIoStarted = false,
+) =>
+  Effect.gen(function* () {
+    const decision = stored.decision
+    const validIntentState =
+      operation === MutationOperation.Submit
+        ? stored.intent.state === IntentState.Approved ||
+          (allowIoStarted && stored.intent.state === IntentState.IoStarted)
+        : stored.intent.state === IntentState.Acknowledged || stored.intent.state === IntentState.Unknown
+    if (
+      !validIntentState ||
+      decision?.outcome !== RiskOutcome.Approved ||
+      stored.intent.riskDecisionId !== decision.decisionId
+    ) {
+      return yield* Effect.fail(
+        new ExecutionError({
+          operation,
+          failure: ExecutionFailure.InvalidState,
+          message: `${operationLabel} requires one committed approved intent and matching risk decision`,
+        }),
+      )
+    }
+    const currentTime = yield* Clock.currentTimeMillis
+    if (currentTime >= Date.parse(decision.expiresAt)) {
+      return yield* Effect.fail(
+        new ExecutionError({
+          operation,
+          failure: ExecutionFailure.InvalidState,
+          message: `${operationLabel} risk decision expired at ${decision.expiresAt}`,
+        }),
+      )
+    }
+    return stored
+  })
+
 export const dryRunSubmit = (
   intentId: string,
 ): Effect.Effect<DryRunSubmit, ExecutionError | IntentStoreError, IntentStore> =>
   readIntent(MutationOperation.Submit, intentId).pipe(
     Effect.flatMap((stored) =>
       Effect.gen(function* () {
-        const decision = stored.decision
-        if (
-          stored.intent.state !== IntentState.Approved ||
-          decision?.outcome !== RiskOutcome.Approved ||
-          stored.intent.riskDecisionId !== decision.decisionId
-        ) {
-          return yield* Effect.fail(
-            new ExecutionError({
-              operation: MutationOperation.Submit,
-              failure: ExecutionFailure.InvalidState,
-              message: 'dry-run submission requires one committed approved intent and matching risk decision',
-            }),
-          )
-        }
-        const currentTime = yield* Clock.currentTimeMillis
-        if (currentTime >= Date.parse(decision.expiresAt)) {
-          return yield* Effect.fail(
-            new ExecutionError({
-              operation: MutationOperation.Submit,
-              failure: ExecutionFailure.InvalidState,
-              message: `dry-run submission risk decision expired at ${decision.expiresAt}`,
-            }),
-          )
-        }
+        yield* requireActiveRiskDecision(MutationOperation.Submit, stored, 'dry-run submission')
         return yield* Effect.try({
           try: (): DryRunSubmit => {
             const request = orderRequestBody(stored.intent)
@@ -214,7 +230,10 @@ export const submit = (intentId: string, consistencyDelayMs: number) =>
     const mutations = yield* MutationStore
     const broker = yield* BrokerMutation
     const fence = yield* WriterFence
+    const existing = yield* mutations.latest(intentId, MutationOperation.Submit)
+    if (existing !== undefined) return existing
     const before = yield* readIntent(MutationOperation.Submit, intentId)
+    yield* requireActiveRiskDecision(MutationOperation.Submit, before)
     const hash = yield* requestHash(MutationOperation.Submit, before.intent)
     const current = yield* now
     const started = yield* mutations.beginSubmit(
@@ -236,6 +255,7 @@ export const submit = (intentId: string, consistencyDelayMs: number) =>
       )
     }
     yield* fence.check
+    yield* requireActiveRiskDecision(MutationOperation.Submit, after.value, 'submission', true)
 
     return yield* broker.submit(after.value.intent).pipe(
       Effect.matchEffect({
@@ -282,7 +302,10 @@ export const cancel = (intentId: string, consistencyDelayMs: number) =>
     const mutations = yield* MutationStore
     const broker = yield* BrokerMutation
     const fence = yield* WriterFence
+    const existing = yield* mutations.latest(intentId, MutationOperation.Cancel)
+    if (existing !== undefined) return existing
     const intent = yield* readIntent(MutationOperation.Cancel, intentId)
+    yield* requireActiveRiskDecision(MutationOperation.Cancel, intent)
     const submitEvent = yield* mutations.latest(intentId, MutationOperation.Submit)
     const orderId = submitEvent?.brokerOrderId
     if (orderId === undefined) {
@@ -305,6 +328,8 @@ export const cancel = (intentId: string, consistencyDelayMs: number) =>
     )
     if (!started.started) return started.event
     yield* fence.check
+    const currentIntent = yield* readIntent(MutationOperation.Cancel, intentId)
+    yield* requireActiveRiskDecision(MutationOperation.Cancel, currentIntent)
 
     return yield* broker.cancel(orderId).pipe(
       Effect.matchEffect({

--- a/services/bayn/src/execution/mutations.ts
+++ b/services/bayn/src/execution/mutations.ts
@@ -293,9 +293,9 @@ const makeStore = Effect.gen(function* () {
       ),
     )
 
-  const append = (event: MutationEvent) =>
-    Effect.as(
-      sql`
+  const append = (event: MutationEvent, requireCurrentRisk = false) =>
+    Effect.gen(function* () {
+      const rows = yield* sql<{ event_id: string }>`
         INSERT INTO mutation_events (
           event_id,
           schema_version,
@@ -311,7 +311,8 @@ const makeStore = Effect.gen(function* () {
           response_status,
           response_content_hash,
           occurred_at
-        ) VALUES (
+        )
+        SELECT
           ${event.eventId},
           ${event.schemaVersion},
           ${event.mutationId},
@@ -326,10 +327,28 @@ const makeStore = Effect.gen(function* () {
           ${event.responseStatus ?? null},
           ${event.responseContentHash ?? null},
           ${event.occurredAt}
+        WHERE ${!requireCurrentRisk}
+          OR EXISTS (
+            SELECT 1
+            FROM intents AS intent
+            JOIN risk_decisions AS decision
+              ON decision.decision_id = intent.risk_decision_id
+              AND decision.intent_id = intent.intent_id
+            WHERE intent.intent_id = ${event.intentId}
+              AND decision.outcome = 'APPROVED'
+              AND decision.decided_at <= clock_timestamp()
+              AND decision.expires_at > clock_timestamp()
+          )
+        RETURNING event_id
+      `
+      if (rows.length !== 1) {
+        const operation = event.operation === MutationOperation.Submit ? 'begin-submit' : 'begin-cancel'
+        return yield* Effect.fail(
+          storeError(operation, 'invariant', 'mutation start requires a current approved risk decision'),
         )
-      `,
-      event,
-    )
+      }
+      return event
+    })
 
   const assertAuthority = (operation: MutationOperation) =>
     Effect.gen(function* () {
@@ -405,28 +424,6 @@ const makeStore = Effect.gen(function* () {
       }
     })
 
-  const assertCurrentRisk = (intentId: string, storeOperation: 'begin-submit' | 'begin-cancel') =>
-    Effect.gen(function* () {
-      const rows = yield* sql<{ current: boolean }>`
-        SELECT EXISTS (
-          SELECT 1
-          FROM intents AS intent
-          JOIN risk_decisions AS decision
-            ON decision.decision_id = intent.risk_decision_id
-            AND decision.intent_id = intent.intent_id
-          WHERE intent.intent_id = ${intentId}
-            AND decision.outcome = 'APPROVED'
-            AND decision.decided_at <= clock_timestamp()
-            AND decision.expires_at > clock_timestamp()
-        ) AS current
-      `
-      if (rows[0]?.current !== true) {
-        return yield* Effect.fail(
-          storeError(storeOperation, 'invariant', 'mutation start requires a current approved risk decision'),
-        )
-      }
-    })
-
   const begin = (
     operation: MutationOperation,
     intentId: string,
@@ -494,7 +491,6 @@ const makeStore = Effect.gen(function* () {
                 ),
               )
             }
-            yield* assertCurrentRisk(input.intentId, storeOperation)
             if (input.occurredAt <= intent.updated_at) {
               return yield* Effect.fail(
                 storeError(storeOperation, 'invariant', 'mutation time must follow the intent state'),
@@ -515,7 +511,7 @@ const makeStore = Effect.gen(function* () {
               ...(input.brokerOrderId === undefined ? {} : { brokerOrderId: input.brokerOrderId }),
               occurredAt: input.occurredAt,
             })
-            yield* append(event)
+            yield* append(event, true)
             if (operation === MutationOperation.Submit) {
               const transitioned = yield* sql<{ intent_id: string }>`
                 UPDATE intents

--- a/services/bayn/src/execution/mutations.ts
+++ b/services/bayn/src/execution/mutations.ts
@@ -405,6 +405,28 @@ const makeStore = Effect.gen(function* () {
       }
     })
 
+  const assertCurrentRisk = (intentId: string, storeOperation: 'begin-submit' | 'begin-cancel') =>
+    Effect.gen(function* () {
+      const rows = yield* sql<{ current: boolean }>`
+        SELECT EXISTS (
+          SELECT 1
+          FROM intents AS intent
+          JOIN risk_decisions AS decision
+            ON decision.decision_id = intent.risk_decision_id
+            AND decision.intent_id = intent.intent_id
+          WHERE intent.intent_id = ${intentId}
+            AND decision.outcome = 'APPROVED'
+            AND decision.decided_at <= clock_timestamp()
+            AND decision.expires_at > clock_timestamp()
+        ) AS current
+      `
+      if (rows[0]?.current !== true) {
+        return yield* Effect.fail(
+          storeError(storeOperation, 'invariant', 'mutation start requires a current approved risk decision'),
+        )
+      }
+    })
+
   const begin = (
     operation: MutationOperation,
     intentId: string,
@@ -472,6 +494,7 @@ const makeStore = Effect.gen(function* () {
                 ),
               )
             }
+            yield* assertCurrentRisk(input.intentId, storeOperation)
             if (input.occurredAt <= intent.updated_at) {
               return yield* Effect.fail(
                 storeError(storeOperation, 'invariant', 'mutation time must follow the intent state'),

--- a/services/bayn/src/index.ts
+++ b/services/bayn/src/index.ts
@@ -3,9 +3,10 @@ import { ClickhouseClient } from '@effect/sql-clickhouse'
 import { Context, Effect, Layer, Logger, Redacted } from 'effect'
 
 import { run } from './app'
+import { riskBalancedTrendBehaviorHash } from './behavior'
 import { BrokerRead, alpacaHttpLayer, live as AlpacaReadLive } from './broker/alpaca'
 import { BrokerMutation, makeMutation } from './broker/alpaca-mutations'
-import { verifyParameterHash } from './build'
+import { verifyBehaviorHash, verifyParameterHash } from './build'
 import { loadConfig } from './config'
 import { makeRuntimeProvenance } from './contracts'
 import { EvidenceStoreLive } from './db/evidence-store'
@@ -27,7 +28,10 @@ const main = Effect.gen(function* () {
   const config = yield* loadConfig()
   const protocol = yield* loadDefaultProtocol
   const parameterHash = hashParameters(protocol)
-  yield* verifyParameterHash(config.build, parameterHash)
+  yield* Effect.all([
+    verifyBehaviorHash(config.build, riskBalancedTrendBehaviorHash),
+    verifyParameterHash(config.build, parameterHash),
+  ])
   const provenance = makeRuntimeProvenance({
     sourceRevision: config.build.sourceRevision,
     image: {
@@ -36,7 +40,7 @@ const main = Effect.gen(function* () {
     },
     strategy: {
       name: 'risk-balanced-trend',
-      behaviorHash: config.build.strategyBehaviorHash,
+      behaviorHash: riskBalancedTrendBehaviorHash,
       parameterHash,
       parameterSchemaVersion: protocol.schemaVersion,
     },

--- a/services/bayn/src/protocol.test.ts
+++ b/services/bayn/src/protocol.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, test } from 'bun:test'
 
 import { Effect, Exit } from 'effect'
 
-import { verifyParameterHash, type EmbeddedBuildMetadata } from './build'
+import { riskBalancedTrendBehaviorHash } from './behavior'
+import { verifyBehaviorHash, verifyParameterHash, type EmbeddedBuildMetadata } from './build'
 import { defaultProtocolDocument, hashParameters, loadDefaultProtocol, loadProtocol } from './protocol'
 
 describe('strategy protocol', () => {
@@ -10,7 +11,7 @@ describe('strategy protocol', () => {
     const protocol = await Effect.runPromise(loadDefaultProtocol)
 
     expect(protocol).toMatchObject({
-      schemaVersion: 'bayn.risk-balanced-trend.protocol.v2',
+      schemaVersion: 'bayn.risk-balanced-trend.protocol.v3',
       universeId: 'cross-asset-taa-v1',
       universeSymbolHash: 'c15a52d125073a20c3addee154974ef32b4ef009c40a46b05b54743f075c0fe8',
       universe: ['DBC', 'EFA', 'IEF', 'SPY', 'VNQ'],
@@ -20,6 +21,16 @@ describe('strategy protocol', () => {
       volatilityWindow: 63,
       maximumSymbolWeight: 0.35,
       maximumPortfolioVolatility: 0.1,
+      executionModel: {
+        schemaVersion: 'bayn.execution-model.v2',
+        order: {
+          planningPriceReference: 'signal-session-close',
+          planningBrokerStateReference: 'reconciled-pre-plan-broker-state',
+          fillPriceReference: 'next-session-open',
+          buyingPowerPolicy: 'pre-submit-cash-without-sell-proceeds',
+          submissionCutoffLeadMinutes: 15,
+        },
+      },
     })
     expect(hashParameters(protocol)).toMatch(/^[a-f0-9]{64}$/)
   })
@@ -30,16 +41,22 @@ describe('strategy protocol', () => {
     const metadata: EmbeddedBuildMetadata = {
       sourceRevision: 'a'.repeat(40),
       imageRepository: 'registry.example.test/lab/bayn',
-      strategyBehaviorHash: 'b'.repeat(64),
+      strategyBehaviorHash: riskBalancedTrendBehaviorHash,
       strategyParameterHash: parameterHash,
     }
 
     await Effect.runPromise(verifyParameterHash(metadata, parameterHash))
+    await Effect.runPromise(verifyBehaviorHash(metadata, riskBalancedTrendBehaviorHash))
     const exit = await Effect.runPromiseExit(
       verifyParameterHash({ ...metadata, strategyParameterHash: '0'.repeat(64) }, parameterHash),
     )
     expect(Exit.isFailure(exit)).toBe(true)
     if (Exit.isFailure(exit)) expect(exit.cause.toString()).toContain('compiled strategy parameters')
+    const behaviorExit = await Effect.runPromiseExit(
+      verifyBehaviorHash({ ...metadata, strategyBehaviorHash: '0'.repeat(64) }, riskBalancedTrendBehaviorHash),
+    )
+    expect(Exit.isFailure(behaviorExit)).toBe(true)
+    if (Exit.isFailure(behaviorExit)) expect(behaviorExit.cause.toString()).toContain('compiled strategy behavior')
   })
 
   test('rejects legacy, malformed, and non-canonical documents', async () => {
@@ -65,11 +82,40 @@ describe('strategy protocol', () => {
     }
   })
 
+  test('decodes the frozen v2 protocol only for immutable historical evidence', async () => {
+    const historical = {
+      ...defaultProtocolDocument,
+      schemaVersion: 'bayn.risk-balanced-trend.protocol.v2',
+      executionModel: {
+        ...defaultProtocolDocument.executionModel,
+        schemaVersion: 'bayn.execution-model.v1',
+        order: {
+          type: 'market',
+          timeInForce: 'day',
+          extendedHours: false,
+          submitAfter: 'signal-session-close',
+          submitBefore: 'next-session-open',
+          priceReference: 'next-session-open',
+        },
+      },
+    } as const
+
+    const protocol = await Effect.runPromise(loadProtocol(historical))
+
+    expect(protocol.schemaVersion).toBe('bayn.risk-balanced-trend.protocol.v2')
+    expect(protocol.executionModel.schemaVersion).toBe('bayn.execution-model.v1')
+  })
+
   test('requires every execution fact', async () => {
     const requiredPaths = [
       ['order', 'type'],
       ['order', 'timeInForce'],
       ['order', 'extendedHours'],
+      ['order', 'planningPriceReference'],
+      ['order', 'planningBrokerStateReference'],
+      ['order', 'fillPriceReference'],
+      ['order', 'buyingPowerPolicy'],
+      ['order', 'submissionCutoffLeadMinutes'],
       ['precision', 'quantityIncrementMicros'],
       ['precision', 'priceIncrementMicros'],
       ['precision', 'minimumBuyNotionalMicros'],

--- a/services/bayn/src/protocol.ts
+++ b/services/bayn/src/protocol.ts
@@ -22,6 +22,7 @@ export const DIRECT_VOLATILITY_WINDOW = 63
 const PositiveUnitInterval = Schema.Finite.check(Schema.isGreaterThan(0), Schema.isLessThanOrEqualTo(1))
 const BasisPoints = NonNegativeFinite.check(Schema.isLessThanOrEqualTo(10_000))
 const PartsPerMillion = Schema.Int.check(Schema.isBetween({ minimum: 0, maximum: 1_000_000 }))
+const SubmissionCutoffLeadMinutes = Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 120 }))
 const EconomicThresholdsSchema = Schema.Struct({
   minimumObservations: PositiveInteger,
   minimumAnnualizedReturn: Schema.Finite.check(Schema.isGreaterThan(-1)),
@@ -32,18 +33,9 @@ const EconomicThresholdsSchema = Schema.Struct({
 })
 export type EconomicThresholds = typeof EconomicThresholdsSchema.Type
 
-export const ExecutionModelSchema = Schema.Struct({
-  schemaVersion: Schema.Literal('bayn.execution-model.v1'),
+const ExecutionModelCommon = {
   venue: Schema.Literal('alpaca-paper'),
   assetClass: Schema.Literal('us-equity'),
-  order: Schema.Struct({
-    type: Schema.Literal('market'),
-    timeInForce: Schema.Literal('day'),
-    extendedHours: Schema.Literal(false),
-    submitAfter: Schema.Literal('signal-session-close'),
-    submitBefore: Schema.Literal('next-session-open'),
-    priceReference: Schema.Literal('next-session-open'),
-  }),
   precision: Schema.Struct({
     quantityIncrementMicros: PositiveMicros,
     priceIncrementMicros: PositiveMicros,
@@ -75,21 +67,58 @@ export const ExecutionModelSchema = Schema.Struct({
     remainder: Schema.Literal('cancel'),
   }),
   doubleCostMultiplier: Schema.Literal(2),
-}).check(
-  Schema.makeFilter((model: typeof ExecutionModelSchema.Type) => {
-    const issues: Schema.FilterIssue[] = []
-    if (model.partialFills.probabilityPpm > 0 && model.partialFills.filledFractionPpm === 0) {
-      issues.push({
-        path: ['partialFills', 'filledFractionPpm'],
-        issue: 'must be positive when partial fills are enabled',
-      })
-    }
-    if (model.partialFills.filledFractionPpm >= 1_000_000) {
-      issues.push({ path: ['partialFills', 'filledFractionPpm'], issue: 'must describe a partial, not complete, fill' })
-    }
-    return issues
+} as const
+
+const ExecutionModelV1Base = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.execution-model.v1'),
+  ...ExecutionModelCommon,
+  order: Schema.Struct({
+    type: Schema.Literal('market'),
+    timeInForce: Schema.Literal('day'),
+    extendedHours: Schema.Literal(false),
+    submitAfter: Schema.Literal('signal-session-close'),
+    submitBefore: Schema.Literal('next-session-open'),
+    priceReference: Schema.Literal('next-session-open'),
   }),
-)
+})
+
+const ExecutionModelV2Base = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.execution-model.v2'),
+  ...ExecutionModelCommon,
+  order: Schema.Struct({
+    type: Schema.Literal('market'),
+    timeInForce: Schema.Literal('day'),
+    extendedHours: Schema.Literal(false),
+    planAfter: Schema.Literal('signal-session-finalized'),
+    submitAfter: Schema.Literal('plan-committed'),
+    submitBefore: Schema.Literal('fixed-pre-open-cutoff'),
+    planningPriceReference: Schema.Literal('signal-session-close'),
+    planningBrokerStateReference: Schema.Literal('reconciled-pre-plan-broker-state'),
+    fillPriceReference: Schema.Literal('next-session-open'),
+    buyingPowerPolicy: Schema.Literal('pre-submit-cash-without-sell-proceeds'),
+    submissionCutoffLeadMinutes: SubmissionCutoffLeadMinutes,
+  }),
+})
+
+const executionModelIssues = (
+  model: typeof ExecutionModelV1Base.Type | typeof ExecutionModelV2Base.Type,
+): readonly Schema.FilterIssue[] => {
+  const issues: Schema.FilterIssue[] = []
+  if (model.partialFills.probabilityPpm > 0 && model.partialFills.filledFractionPpm === 0) {
+    issues.push({
+      path: ['partialFills', 'filledFractionPpm'],
+      issue: 'must be positive when partial fills are enabled',
+    })
+  }
+  if (model.partialFills.filledFractionPpm >= 1_000_000) {
+    issues.push({ path: ['partialFills', 'filledFractionPpm'], issue: 'must describe a partial, not complete, fill' })
+  }
+  return issues
+}
+
+export const ExecutionModelV1Schema = ExecutionModelV1Base.check(Schema.makeFilter(executionModelIssues))
+export const ExecutionModelV2Schema = ExecutionModelV2Base.check(Schema.makeFilter(executionModelIssues))
+export const ExecutionModelSchema = Schema.Union([ExecutionModelV1Schema, ExecutionModelV2Schema])
 export type ExecutionModel = typeof ExecutionModelSchema.Type
 
 const defaultEconomicThresholds = {
@@ -109,8 +138,7 @@ const universeContract = {
   evaluationStart: '2017-01-03',
 } as const
 
-const ProtocolBase = Schema.Struct({
-  schemaVersion: Schema.Literal('bayn.risk-balanced-trend.protocol.v2'),
+const ProtocolCommon = {
   universeId: UniverseIdSchema,
   universeSymbolHash: Sha256Schema,
   universe: Schema.Array(SymbolName).check(Schema.isMinLength(1)),
@@ -124,55 +152,71 @@ const ProtocolBase = Schema.Struct({
   maximumPortfolioVolatility: PositiveUnitInterval,
   directVolatilityTarget: PositiveUnitInterval,
   initialCapitalMicros: PositiveMicros,
-  executionModel: ExecutionModelSchema,
   thresholds: EconomicThresholdsSchema,
+} as const
+
+const ProtocolV2Base = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.risk-balanced-trend.protocol.v2'),
+  ...ProtocolCommon,
+  executionModel: ExecutionModelV1Schema,
 })
 
-export const ProtocolSchema = ProtocolBase.check(
-  Schema.makeFilter((parameters: typeof ProtocolBase.Type) => {
-    const issues: Schema.FilterIssue[] = []
-    const sortedUniverse = [...new Set(parameters.universe)].sort()
-    if (sortedUniverse.length !== parameters.universe.length) {
-      issues.push({ path: ['universe'], issue: 'must not contain duplicate symbols' })
-    } else if (sortedUniverse.some((symbol, index) => symbol !== parameters.universe[index])) {
-      issues.push({ path: ['universe'], issue: 'must be sorted in canonical order' })
+const ProtocolV3Base = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.risk-balanced-trend.protocol.v3'),
+  ...ProtocolCommon,
+  executionModel: ExecutionModelV2Schema,
+})
+
+const protocolIssues = (
+  parameters: typeof ProtocolV2Base.Type | typeof ProtocolV3Base.Type,
+): readonly Schema.FilterIssue[] => {
+  const issues: Schema.FilterIssue[] = []
+  const sortedUniverse = [...new Set(parameters.universe)].sort()
+  if (sortedUniverse.length !== parameters.universe.length) {
+    issues.push({ path: ['universe'], issue: 'must not contain duplicate symbols' })
+  } else if (sortedUniverse.some((symbol, index) => symbol !== parameters.universe[index])) {
+    issues.push({ path: ['universe'], issue: 'must be sorted in canonical order' })
+  }
+  if (parameters.universeSymbolHash !== sha256(parameters.universe.join(','))) {
+    issues.push({ path: ['universeSymbolHash'], issue: 'must match the canonical universe' })
+  }
+  if (
+    parameters.universeSymbolHash !== universeContract.symbolHash ||
+    parameters.universe.join(',') !== universeContract.symbols.join(',') ||
+    parameters.historyStart !== universeContract.historyStart ||
+    parameters.evaluationStart !== universeContract.evaluationStart
+  ) {
+    issues.push({ path: ['universeId'], issue: 'must identify its exact source-controlled universe contract' })
+  }
+  if (parameters.evaluationStart <= parameters.historyStart) {
+    issues.push({ path: ['evaluationStart'], issue: 'must follow historyStart' })
+  }
+  for (let index = 1; index < parameters.horizons.length; index += 1) {
+    if (parameters.horizons[index] <= parameters.horizons[index - 1]) {
+      issues.push({ path: ['horizons', index], issue: 'must be unique and strictly increasing' })
+      break
     }
-    if (parameters.universeSymbolHash !== sha256(parameters.universe.join(','))) {
-      issues.push({ path: ['universeSymbolHash'], issue: 'must match the canonical universe' })
-    }
-    if (
-      parameters.universeSymbolHash !== universeContract.symbolHash ||
-      parameters.universe.join(',') !== universeContract.symbols.join(',') ||
-      parameters.historyStart !== universeContract.historyStart ||
-      parameters.evaluationStart !== universeContract.evaluationStart
-    ) {
-      issues.push({ path: ['universeId'], issue: 'must identify its exact source-controlled universe contract' })
-    }
-    if (parameters.evaluationStart <= parameters.historyStart) {
-      issues.push({ path: ['evaluationStart'], issue: 'must follow historyStart' })
-    }
-    for (let index = 1; index < parameters.horizons.length; index += 1) {
-      if (parameters.horizons[index] <= parameters.horizons[index - 1]) {
-        issues.push({ path: ['horizons', index], issue: 'must be unique and strictly increasing' })
-        break
-      }
-    }
-    if (parameters.volatilityWindow < 2) {
-      issues.push({ path: ['volatilityWindow'], issue: 'must contain at least two returns for covariance' })
-    }
-    if (Math.max(parameters.volatilityWindow, ...parameters.horizons) < DIRECT_VOLATILITY_WINDOW) {
-      issues.push({
-        path: ['horizons'],
-        issue: `must provide at least ${DIRECT_VOLATILITY_WINDOW} sessions for the direct-volatility benchmark`,
-      })
-    }
-    return issues
-  }),
-)
+  }
+  if (parameters.volatilityWindow < 2) {
+    issues.push({ path: ['volatilityWindow'], issue: 'must contain at least two returns for covariance' })
+  }
+  if (Math.max(parameters.volatilityWindow, ...parameters.horizons) < DIRECT_VOLATILITY_WINDOW) {
+    issues.push({
+      path: ['horizons'],
+      issue: `must provide at least ${DIRECT_VOLATILITY_WINDOW} sessions for the direct-volatility benchmark`,
+    })
+  }
+  return issues
+}
+
+export const ProtocolV2Schema = ProtocolV2Base.check(Schema.makeFilter(protocolIssues))
+export const ProtocolV3Schema = ProtocolV3Base.check(Schema.makeFilter(protocolIssues))
+export const ProtocolSchema = Schema.Union([ProtocolV2Schema, ProtocolV3Schema])
 export type Protocol = typeof ProtocolSchema.Type
+export type CausalProtocol = typeof ProtocolV3Schema.Type
 
 export const defaultProtocolDocument = {
-  schemaVersion: 'bayn.risk-balanced-trend.protocol.v2',
+  schemaVersion: 'bayn.risk-balanced-trend.protocol.v3',
   universeId: universeContract.id,
   universeSymbolHash: universeContract.symbolHash,
   universe: universeContract.symbols,
@@ -200,6 +244,13 @@ export const loadProtocol = (input: unknown): Effect.Effect<Protocol, Operationa
     ),
   )
 
-export const loadDefaultProtocol = loadProtocol(defaultProtocolDocument)
+export const loadDefaultProtocol: Effect.Effect<CausalProtocol, OperationalError> = Schema.decodeUnknownEffect(
+  ProtocolV3Schema,
+  StrictParseOptions,
+)(defaultProtocolDocument).pipe(
+  Effect.mapError((cause) =>
+    operationalError('strategy', 'parameters', 'invalid risk-balanced trend parameters', cause),
+  ),
+)
 
 export const hashParameters = (parameters: Protocol): string => canonicalHashV1(parameters)

--- a/services/bayn/src/qualification-audit.test.ts
+++ b/services/bayn/src/qualification-audit.test.ts
@@ -352,6 +352,21 @@ describe('qualification audit', () => {
     expect(report.checks.find((check) => check.name === 'reference-strategy')?.passed).toBe(false)
   })
 
+  test('requires the source-pinned auditor for immutable protocol v2 evidence', () => {
+    const input = fixture()
+    const database = {
+      ...input.database,
+      protocol: {
+        ...input.database.protocol,
+        schemaVersion: 'bayn.risk-balanced-trend.protocol.v2',
+      },
+    }
+
+    expect(() => auditQualification({ ...input, database })).toThrow(
+      'current auditor requires causal protocol v3; audit immutable v2 evidence with its source-pinned image',
+    )
+  })
+
   test('fails closed when candidate bars were read before the lock', () => {
     const input = fixture()
     const signalAccess = input.signalAccess.map((record) =>

--- a/services/bayn/src/qualification-reference.test.ts
+++ b/services/bayn/src/qualification-reference.test.ts
@@ -37,20 +37,23 @@ describe('independent qualification reference', () => {
     expect(canonicalHashV1(changed.strategy.decisions)).not.toBe(canonicalHashV1(original.strategy.decisions))
   })
 
-  test('independently keeps planned quantities invariant to the future execution open', () => {
+  test('independently keeps planned quantities invariant to future execution OHLC', () => {
     const snapshot = makeSnapshot(900)
     const provenance = makeTestProvenance()
     const actual = evaluateRiskBalancedTrend(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance)
     const executionDate = actual.signalDecisions[0].executionDate
-    const changedBars = snapshot.bars.map((bar) =>
-      bar.sessionDate === executionDate
-        ? {
-            ...bar,
-            open: bar.open * 1.5,
-            high: Math.max(bar.high, bar.open * 1.5),
-          }
-        : bar,
-    )
+    const changedBars = snapshot.bars.map((bar) => {
+      if (bar.sessionDate !== executionDate) return bar
+      const open = bar.open * 1.5
+      const close = bar.close * 1.2
+      return {
+        ...bar,
+        open,
+        high: Math.max(open, close, bar.high * 1.1),
+        low: Math.min(open, close, bar.low * 0.8),
+        close,
+      }
+    })
     const changedActual = evaluateRiskBalancedTrend(changedBars, snapshot.manifest, fixtureProtocol, provenance)
     const changedReference = evaluateReference(changedBars, snapshot.manifest, fixtureProtocol, provenance)
     const requests = (orders: typeof actual.simulation.orders) =>

--- a/services/bayn/src/qualification-reference.test.ts
+++ b/services/bayn/src/qualification-reference.test.ts
@@ -36,4 +36,37 @@ describe('independent qualification reference', () => {
 
     expect(canonicalHashV1(changed.strategy.decisions)).not.toBe(canonicalHashV1(original.strategy.decisions))
   })
+
+  test('independently keeps planned quantities invariant to the future execution open', () => {
+    const snapshot = makeSnapshot(900)
+    const provenance = makeTestProvenance()
+    const actual = evaluateRiskBalancedTrend(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance)
+    const executionDate = actual.signalDecisions[0].executionDate
+    const changedBars = snapshot.bars.map((bar) =>
+      bar.sessionDate === executionDate
+        ? {
+            ...bar,
+            open: bar.open * 1.5,
+            high: Math.max(bar.high, bar.open * 1.5),
+          }
+        : bar,
+    )
+    const changedActual = evaluateRiskBalancedTrend(changedBars, snapshot.manifest, fixtureProtocol, provenance)
+    const changedReference = evaluateReference(changedBars, snapshot.manifest, fixtureProtocol, provenance)
+    const requests = (orders: typeof actual.simulation.orders) =>
+      orders
+        .filter((order) => order.sessionDate === executionDate)
+        .map(({ decisionId, sessionDate, symbol, side, requestedQuantityMicros }) => ({
+          decisionId,
+          sessionDate,
+          symbol,
+          side,
+          requestedQuantityMicros,
+        }))
+
+    expect(requests(changedActual.simulation.orders)).toEqual(requests(actual.simulation.orders))
+    expect(requests(changedReference.strategy.trace?.orders ?? [])).toEqual(requests(actual.simulation.orders))
+    expect(changedActual.strategy.endingEquityMicros).not.toBe(actual.strategy.endingEquityMicros)
+    expect(changedReference.strategy.trace).toEqual(changedActual.simulation)
+  })
 })

--- a/services/bayn/src/risk-balanced-trend.test.ts
+++ b/services/bayn/src/risk-balanced-trend.test.ts
@@ -8,9 +8,9 @@ import {
 } from './risk-balanced-trend'
 import { makeStrategy } from './strategy'
 import { makeSnapshot, makeTestProvenance, fixtureProtocol } from './test-fixtures'
-import type { IsoDate, Protocol } from './types'
+import type { CausalProtocol, IsoDate } from './types'
 
-const shortProtocol = (overrides: Partial<Protocol> = {}): Protocol => ({
+const shortProtocol = (overrides: Partial<CausalProtocol> = {}): CausalProtocol => ({
   ...fixtureProtocol,
   universe: ['DBC', 'EEM', 'EFA'],
   horizons: [1, 2],
@@ -293,9 +293,9 @@ describe('risk-balanced trend candidate', () => {
     )
     expect(analysis.priorTrialRunIds).toEqual(priorTrialRunIds)
     expect(analysis.candidateOrdinal).toBe(9)
-    expect(canonicalHashV1(first)).toBe('22d3431616d263dbc4c4f31ef3fb14966453938e7db8ebf7a9bc37b93b99f93f')
+    expect(canonicalHashV1(first)).toBe('8be4f2f76c69bd7eeb2984bc08cd1d49013d2b349c8c574683851d4052a4901f')
     expect(canonicalHashV1(first.signalDecisions)).toBe(
-      '3aa21296a6fd28dd03971af9b8fa8e0420d7c0e6aed18e7faf9e0a3554bc3e2d',
+      'e0803e7a3d0258f508b054262f6ba5a1760b4a35d78816c1c701c7d783061568',
     )
   })
 })

--- a/services/bayn/src/risk.test.ts
+++ b/services/bayn/src/risk.test.ts
@@ -23,13 +23,28 @@ import { reconciledStateHash } from './reconciliation'
 import { BrokerMode, PolicySchema, Reason, StateSchema, evaluate, type Policy, type State } from './risk'
 import { strictParseOptions } from './schemas'
 
-const evaluatedAt = '2026-07-22T14:00:00.000Z'
-const observedAt = '2026-07-22T13:59:30.000Z'
+const evaluatedAt = '2026-07-21T21:00:00.000Z'
+const observedAt = '2026-07-21T20:59:30.000Z'
 const hash = (character: string): string => character.repeat(64)
 
 const decodePolicy = Schema.decodeUnknownSync(PolicySchema, strictParseOptions)
 const decodeState = Schema.decodeUnknownSync(StateSchema, strictParseOptions)
 const decodeIntent = Schema.decodeUnknownSync(IntentSchema, strictParseOptions)
+
+const rehashExecutionSession = (
+  binding: Omit<State['executionSession'], 'bindingHash'>,
+): State['executionSession'] => ({
+  ...binding,
+  bindingHash: canonicalHashV1(binding),
+})
+
+const changeExecutionWindow = (
+  binding: State['executionSession'],
+  overrides: Partial<Pick<State['executionSession'], 'submissionOpenAt' | 'submissionCutoffAt'>>,
+): State['executionSession'] => {
+  const { bindingHash: _, ...material } = binding
+  return rehashExecutionSession({ ...material, ...overrides })
+}
 
 const makePolicy = (overrides: Partial<Policy> = {}): Policy =>
   decodePolicy({
@@ -100,8 +115,34 @@ const baseState = (): State => {
     ordersObservedAt: observedAt,
     accountingHash,
   })
+  const executionSession = rehashExecutionSession({
+    schemaVersion: 'bayn.execution-session-binding.v1',
+    signal: {
+      sessionDate: '2026-07-21',
+      finalizedAt: '2026-07-21T20:58:00.000Z',
+      contentHash: hash('5'),
+    },
+    planningBrokerState: {
+      observedAt,
+      contentHash: reconciledStateHashValue,
+    },
+    calendar: {
+      schemaVersion: 'bayn.alpaca-market-calendar-observation.v1',
+      source: 'alpaca-v2-calendar',
+      requestedRange: { start: '2026-07-22', end: '2026-07-31' },
+      normalizedResponseHash: hash('c'),
+    },
+    executionSession: {
+      date: '2026-07-22',
+      openAt: '2026-07-22T13:30:00.000Z',
+      closeAt: '2026-07-22T20:00:00.000Z',
+    },
+    submissionOpenAt: observedAt,
+    submissionCutoffAt: '2026-07-22T13:15:00.000Z',
+    submissionCutoffLeadMinutes: 15,
+  })
   return decodeState({
-    schemaVersion: 'bayn.paper-risk-state.v1',
+    schemaVersion: 'bayn.paper-risk-state.v2',
     brokerMode: BrokerMode.Paper,
     account,
     positions,
@@ -139,15 +180,14 @@ const baseState = (): State => {
     referencePriceMicros: '100000000',
     expectedExecutionPriceMicros: '100000000',
     marketDataObservedAt: observedAt,
-    sessionOpenAt: '2026-07-22T13:30:00.000Z',
-    submissionCutoffAt: '2026-07-22T20:00:00.000Z',
+    executionSession,
+    reservedBuyingPowerMicros: '0',
     evaluatedAt,
   })
 }
 
 const makeState = (overrides: Partial<State> = {}): State => {
   const merged = { ...baseState(), ...overrides }
-  if (overrides.reconciliation !== undefined) return decodeState(merged)
   const reconciledStateHashValue = reconciledStateHash({
     account: merged.account,
     positions: merged.positions,
@@ -156,13 +196,27 @@ const makeState = (overrides: Partial<State> = {}): State => {
     ordersObservedAt: merged.ordersObservedAt,
     accountingHash: merged.accountingHash,
   })
-  return decodeState({
-    ...merged,
-    reconciliation: {
+  const reconciliation =
+    overrides.reconciliation ??
+    ({
       ...merged.reconciliation,
       expectedHash: reconciledStateHashValue,
       observedHash: reconciledStateHashValue,
+    } satisfies State['reconciliation'])
+  const sourceExecutionSession = overrides.executionSession ?? merged.executionSession
+  const { bindingHash: _, ...bindingMaterial } = sourceExecutionSession
+  const executionSession = rehashExecutionSession({
+    ...bindingMaterial,
+    signal: { ...bindingMaterial.signal, contentHash: merged.marketDataHash },
+    planningBrokerState: {
+      observedAt: reconciliation.reconciledAt,
+      contentHash: reconciliation.observedHash,
     },
+  })
+  return decodeState({
+    ...merged,
+    reconciliation,
+    executionSession,
   })
 }
 
@@ -183,7 +237,7 @@ const makeIntent = (overrides: Partial<Intent> = {}): Intent =>
     quantityMicros: '1000000',
     notionalLimitMicros: '100000000',
     state: IntentState.Planned,
-    createdAt: '2026-07-22T13:59:45.000Z',
+    createdAt: '2026-07-21T20:59:45.000Z',
     ...overrides,
   })
 
@@ -211,7 +265,7 @@ const openOrder = (brokerOrderId: string) => ({
 describe('bounded paper risk', () => {
   test('strictly decodes complete policy and coherent state', () => {
     expect(makePolicy().schemaVersion).toBe('bayn.paper-risk-policy.v1')
-    expect(makeState().schemaVersion).toBe('bayn.paper-risk-state.v1')
+    expect(makeState().schemaVersion).toBe('bayn.paper-risk-state.v2')
 
     const rawPolicy = { ...makePolicy() }
     const missingPolicy: Record<string, unknown> = { ...rawPolicy }
@@ -242,16 +296,31 @@ describe('bounded paper risk', () => {
         positions: [{ ...state.positions[0], marketValueMicros: '-100000000' }, state.positions[1]],
       }),
     ).toThrow()
-    expect(() => decodeState({ ...state, marketDataObservedAt: '2026-07-22T14:00:00.001Z' })).toThrow()
+    expect(() => decodeState({ ...state, marketDataObservedAt: '2026-07-21T21:00:00.001Z' })).toThrow()
+    expect(() =>
+      decodeState({
+        ...state,
+        executionSession: { ...state.executionSession, bindingHash: hash('0') },
+      }),
+    ).toThrow()
 
-    const earlierOrderObservation = '2026-07-22T13:59:29.000Z'
+    const earlierOrderObservation = '2026-07-21T20:59:29.000Z'
     const paginated = makeState({
       orders: [{ ...openOrder('broker-1'), observedAt: earlierOrderObservation }, openOrder('broker-2')],
       ordersObservedAt: observedAt,
     })
     expect(paginated.orders.map((order) => order.observedAt)).toEqual([earlierOrderObservation, observedAt])
     expect(() => decodeState({ ...paginated, ordersObservedAt: earlierOrderObservation })).toThrow()
-    expect(() => decodeState({ ...state, submissionCutoffAt: state.sessionOpenAt })).toThrow()
+    const { bindingHash: _, ...binding } = state.executionSession
+    expect(() =>
+      decodeState({
+        ...state,
+        executionSession: rehashExecutionSession({
+          ...binding,
+          submissionOpenAt: binding.submissionCutoffAt,
+        }),
+      }),
+    ).toThrow()
   })
 
   test('approves the exact limit boundary and binds a deterministic decision', () => {
@@ -262,7 +331,7 @@ describe('bounded paper risk', () => {
     expect(first.decision.outcome).toBe(RiskOutcome.Approved)
     expect(first.decision.reasonCodes).toEqual([])
     expect(first.gates.every((gate) => gate.passed)).toBe(true)
-    expect(first.input.freshUntil).toBe('2026-07-22T14:00:30.000Z')
+    expect(first.input.freshUntil).toBe('2026-07-21T21:00:30.000Z')
     expect(first.metrics).toEqual({
       orderNotionalMicros: '100000000',
       postTradeSymbolExposureMicros: '200000000',
@@ -272,8 +341,28 @@ describe('bounded paper risk', () => {
       dailyLossMicros: '50000000',
       drawdownMicros: '100000000',
       adverseSlippageBps: '0',
+      aggregateBuyingPowerMicros: '100000000',
       unresolvedOrderCount: 0,
     })
+  })
+
+  test('approves at submission open and blocks immediately before it and exactly at cutoff', () => {
+    const state = makeState()
+    const atOpen = makeState({
+      executionSession: changeExecutionWindow(state.executionSession, { submissionOpenAt: evaluatedAt }),
+    })
+    const beforeOpen = makeState({
+      executionSession: changeExecutionWindow(state.executionSession, {
+        submissionOpenAt: '2026-07-21T21:00:00.001Z',
+      }),
+    })
+    const atCutoff = makeState({
+      executionSession: changeExecutionWindow(state.executionSession, { submissionCutoffAt: evaluatedAt }),
+    })
+
+    expect(evaluate(makeIntent(), atOpen, makePolicy()).decision.outcome).toBe(RiskOutcome.Approved)
+    expectBlocked(Reason.OutsideSession, makeIntent(), beforeOpen, makePolicy())
+    expectBlocked(Reason.OutsideSession, makeIntent(), atCutoff, makePolicy())
   })
 
   test('blocks one micro beyond every money and exposure limit', () => {
@@ -300,6 +389,7 @@ describe('bounded paper risk', () => {
     ]
 
     for (const [reason, intent, state, policy] of cases) expectBlocked(reason, intent, state, policy)
+    expectBlocked(Reason.BuyingPowerExceeded, makeIntent(), makeState({ reservedBuyingPowerMicros: '1' }), makePolicy())
   })
 
   test('blocks adverse slippage and any unresolved order', () => {
@@ -477,10 +567,10 @@ describe('bounded paper risk', () => {
         terminalOutcome: TerminalOutcome.Blocked,
       }),
     )
-    expectBlocked(Reason.IntentTimeInvalid, makeIntent({ createdAt: '2026-07-22T14:00:00.001Z' }))
+    expectBlocked(Reason.IntentTimeInvalid, makeIntent({ createdAt: '2026-07-21T21:00:00.001Z' }))
     expectBlocked(
       Reason.IntentStale,
-      makeIntent({ createdAt: '2026-07-22T13:59:00.000Z' }),
+      makeIntent({ createdAt: '2026-07-21T20:59:00.000Z' }),
       makeState(),
       makePolicy({ maxIntentAgeMs: 60_000 }),
     )
@@ -543,7 +633,15 @@ describe('bounded paper risk', () => {
     )
     expectBlocked(Reason.BrokerStateStale, makeIntent(), makeState(), makePolicy({ maxBrokerStateAgeMs: 30_000 }))
     expectBlocked(Reason.MarketDataStale, makeIntent(), makeState(), makePolicy({ maxMarketDataAgeMs: 30_000 }))
-    expectBlocked(Reason.OutsideSession, makeIntent(), makeState({ submissionCutoffAt: evaluatedAt }), makePolicy())
+    const state = makeState()
+    expectBlocked(
+      Reason.OutsideSession,
+      makeIntent(),
+      makeState({
+        executionSession: changeExecutionWindow(state.executionSession, { submissionCutoffAt: evaluatedAt }),
+      }),
+      makePolicy(),
+    )
     expectBlocked(Reason.UnknownMutation, makeIntent(), makeState({ unknownMutationCount: 1 }), makePolicy())
   })
 
@@ -570,7 +668,11 @@ describe('bounded paper risk', () => {
     )
     const cutoffCapped = evaluate(
       makeIntent(),
-      makeState({ submissionCutoffAt: '2026-07-22T14:00:00.001Z' }),
+      makeState({
+        executionSession: changeExecutionWindow(makeState().executionSession, {
+          submissionCutoffAt: '2026-07-21T21:00:00.001Z',
+        }),
+      }),
       makePolicy({ decisionTtlMs: 60_000 }),
     )
     const intentCapped = evaluate(
@@ -578,9 +680,9 @@ describe('bounded paper risk', () => {
       makeState(),
       makePolicy({ decisionTtlMs: 60_000, maxIntentAgeMs: 15_001 }),
     )
-    expect(ttlCapped.input.freshUntil).toBe('2026-07-22T14:00:01.000Z')
-    expect(freshnessCapped.input.freshUntil).toBe('2026-07-22T14:00:00.001Z')
-    expect(cutoffCapped.input.freshUntil).toBe('2026-07-22T14:00:00.001Z')
-    expect(intentCapped.input.freshUntil).toBe('2026-07-22T14:00:00.001Z')
+    expect(ttlCapped.input.freshUntil).toBe('2026-07-21T21:00:01.000Z')
+    expect(freshnessCapped.input.freshUntil).toBe('2026-07-21T21:00:00.001Z')
+    expect(cutoffCapped.input.freshUntil).toBe('2026-07-21T21:00:00.001Z')
+    expect(intentCapped.input.freshUntil).toBe('2026-07-21T21:00:00.001Z')
   })
 })

--- a/services/bayn/src/risk.test.ts
+++ b/services/bayn/src/risk.test.ts
@@ -53,19 +53,27 @@ const changeExecutionWindow = (
   const signalDate = new Date(Date.parse(`${executionDate}T00:00:00.000Z`) - 24 * 60 * 60_000)
     .toISOString()
     .slice(0, 10) as State['executionSession']['signal']['sessionDate']
+  const executionSession = {
+    date: executionDate,
+    openAt: executionOpenAt,
+    closeAt: new Date(Date.parse(executionOpenAt) + 2 * 60 * 60_000).toISOString(),
+  }
+  const calendar = {
+    schemaVersion: material.calendar.schemaVersion,
+    source: material.calendar.source,
+    requestedRange: { start: signalDate, end: executionDate },
+    timeZone: material.calendar.timeZone,
+    sessions: [executionSession],
+  }
   return rehashExecutionSession({
     ...material,
     ...overrides,
     signal: { ...material.signal, sessionDate: signalDate },
     calendar: {
-      ...material.calendar,
-      requestedRange: { start: executionDate, end: executionDate },
+      ...calendar,
+      normalizedResponseHash: canonicalHashV1(calendar),
     },
-    executionSession: {
-      date: executionDate,
-      openAt: executionOpenAt,
-      closeAt: new Date(Date.parse(executionOpenAt) + 2 * 60 * 60_000).toISOString(),
-    },
+    executionSession,
   })
 }
 
@@ -138,6 +146,19 @@ const baseState = (): State => {
     ordersObservedAt: observedAt,
     accountingHash,
   })
+  const calendar = {
+    schemaVersion: 'bayn.alpaca-market-calendar-observation.v1' as const,
+    source: 'alpaca-v2-calendar' as const,
+    requestedRange: { start: '2026-07-21' as const, end: '2026-07-31' as const },
+    timeZone: 'UTC' as const,
+    sessions: [
+      {
+        date: '2026-07-22' as const,
+        openAt: '2026-07-22T13:30:00.000Z',
+        closeAt: '2026-07-22T20:00:00.000Z',
+      },
+    ],
+  }
   const executionSession = rehashExecutionSession({
     schemaVersion: 'bayn.execution-session-binding.v1',
     signal: {
@@ -149,17 +170,8 @@ const baseState = (): State => {
       observedAt,
       contentHash: reconciledStateHashValue,
     },
-    calendar: {
-      schemaVersion: 'bayn.alpaca-market-calendar-observation.v1',
-      source: 'alpaca-v2-calendar',
-      requestedRange: { start: '2026-07-22', end: '2026-07-31' },
-      normalizedResponseHash: hash('c'),
-    },
-    executionSession: {
-      date: '2026-07-22',
-      openAt: '2026-07-22T13:30:00.000Z',
-      closeAt: '2026-07-22T20:00:00.000Z',
-    },
+    calendar: { ...calendar, normalizedResponseHash: canonicalHashV1(calendar) },
+    executionSession: calendar.sessions[0],
     submissionOpenAt: observedAt,
     submissionCutoffAt: '2026-07-22T13:15:00.000Z',
     submissionCutoffLeadMinutes: 15,

--- a/services/bayn/src/risk.test.ts
+++ b/services/bayn/src/risk.test.ts
@@ -383,7 +383,9 @@ describe('bounded paper risk', () => {
       executionSession: changeExecutionWindow(state.executionSession, { submissionCutoffAt: evaluatedAt }),
     })
 
-    expect(evaluate(makeIntent(), atOpen, makePolicy()).decision.outcome).toBe(RiskOutcome.Approved)
+    expect(evaluate(makeIntent({ createdAt: evaluatedAt }), atOpen, makePolicy()).decision.outcome).toBe(
+      RiskOutcome.Approved,
+    )
     expectBlocked(Reason.OutsideSession, makeIntent(), beforeOpen, makePolicy())
     expectBlocked(Reason.OutsideSession, makeIntent(), atCutoff, makePolicy())
   })
@@ -591,6 +593,7 @@ describe('bounded paper risk', () => {
       }),
     )
     expectBlocked(Reason.IntentTimeInvalid, makeIntent({ createdAt: '2026-07-21T21:00:00.001Z' }))
+    expectBlocked(Reason.IntentTimeInvalid, makeIntent({ createdAt: '2026-07-21T20:59:29.999Z' }))
     expectBlocked(
       Reason.IntentStale,
       makeIntent({ createdAt: '2026-07-21T20:59:00.000Z' }),

--- a/services/bayn/src/risk.test.ts
+++ b/services/bayn/src/risk.test.ts
@@ -43,7 +43,30 @@ const changeExecutionWindow = (
   overrides: Partial<Pick<State['executionSession'], 'submissionOpenAt' | 'submissionCutoffAt'>>,
 ): State['executionSession'] => {
   const { bindingHash: _, ...material } = binding
-  return rehashExecutionSession({ ...material, ...overrides })
+  if (overrides.submissionCutoffAt === undefined) {
+    return rehashExecutionSession({ ...material, ...overrides })
+  }
+  const executionOpenAt = new Date(
+    Date.parse(overrides.submissionCutoffAt) + material.submissionCutoffLeadMinutes * 60_000,
+  ).toISOString()
+  const executionDate = executionOpenAt.slice(0, 10) as State['executionSession']['executionSession']['date']
+  const signalDate = new Date(Date.parse(`${executionDate}T00:00:00.000Z`) - 24 * 60 * 60_000)
+    .toISOString()
+    .slice(0, 10) as State['executionSession']['signal']['sessionDate']
+  return rehashExecutionSession({
+    ...material,
+    ...overrides,
+    signal: { ...material.signal, sessionDate: signalDate },
+    calendar: {
+      ...material.calendar,
+      requestedRange: { start: executionDate, end: executionDate },
+    },
+    executionSession: {
+      date: executionDate,
+      openAt: executionOpenAt,
+      closeAt: new Date(Date.parse(executionOpenAt) + 2 * 60 * 60_000).toISOString(),
+    },
+  })
 }
 
 const makePolicy = (overrides: Partial<Policy> = {}): Policy =>

--- a/services/bayn/src/risk.ts
+++ b/services/bayn/src/risk.ts
@@ -391,9 +391,9 @@ export const evaluate = (intent: Intent, state: State, policy: Policy): Evaluati
     makeGate(
       Gate.IntentTime,
       Reason.IntentTimeInvalid,
-      instant(intent.createdAt) <= evaluatedAt,
+      instant(intent.createdAt) >= submissionOpen && instant(intent.createdAt) <= evaluatedAt,
       intent.createdAt,
-      `<=${state.evaluatedAt}`,
+      `[${state.executionSession.submissionOpenAt},${state.evaluatedAt}]`,
     ),
     makeGate(
       Gate.IntentFreshness,

--- a/services/bayn/src/risk.ts
+++ b/services/bayn/src/risk.ts
@@ -1,6 +1,7 @@
 import { Schema } from 'effect'
 
 import { canonicalHashV1 } from './hash'
+import { ExecutionSessionBindingSchema } from './execution-session'
 import {
   AccountSnapshotSchema,
   AccountStatus,
@@ -157,7 +158,7 @@ export const PolicySchema = Schema.Struct({
 export type Policy = typeof PolicySchema.Type
 
 const StateBase = Schema.Struct({
-  schemaVersion: Schema.Literal('bayn.paper-risk-state.v1'),
+  schemaVersion: Schema.Literal('bayn.paper-risk-state.v2'),
   brokerMode: Schema.Literal(BrokerMode.Paper),
   account: AccountSnapshotSchema,
   positions: Schema.Array(PositionSchema),
@@ -177,8 +178,8 @@ const StateBase = Schema.Struct({
   referencePriceMicros: PositiveMicrosSchema,
   expectedExecutionPriceMicros: PositiveMicrosSchema,
   marketDataObservedAt: UtcInstant,
-  sessionOpenAt: UtcInstant,
-  submissionCutoffAt: UtcInstant,
+  executionSession: ExecutionSessionBindingSchema,
+  reservedBuyingPowerMicros: UnsignedMicrosSchema,
   evaluatedAt: UtcInstant,
 })
 
@@ -188,8 +189,17 @@ export const StateSchema = StateBase.check(
   Schema.makeFilter((state: typeof StateBase.Type): readonly Schema.FilterIssue[] => {
     const issues: Schema.FilterIssue[] = []
     const accountId = state.account.accountId
-    if (state.sessionOpenAt >= state.submissionCutoffAt) {
-      issues.push({ path: ['submissionCutoffAt'], issue: 'must follow sessionOpenAt' })
+    if (state.executionSession.signal.contentHash !== state.marketDataHash) {
+      issues.push({ path: ['marketDataHash'], issue: 'must match the finalized signal-session binding' })
+    }
+    if (
+      state.executionSession.planningBrokerState.contentHash !== state.reconciliation.observedHash ||
+      state.executionSession.planningBrokerState.observedAt !== state.reconciliation.reconciledAt
+    ) {
+      issues.push({
+        path: ['executionSession', 'planningBrokerState'],
+        issue: 'must match the exact reconciled broker state used for planning',
+      })
     }
     const timestamps = [
       ['account', 'observedAt', state.account.observedAt],
@@ -292,6 +302,7 @@ export type Evaluation = {
     readonly dailyLossMicros: string
     readonly drawdownMicros: string
     readonly adverseSlippageBps: string
+    readonly aggregateBuyingPowerMicros: string
     readonly unresolvedOrderCount: number
   }
 }
@@ -329,7 +340,6 @@ export const evaluate = (intent: Intent, state: State, policy: Policy): Evaluati
   const currentSymbolQuantity = state.positions
     .filter((position) => position.symbol === intent.symbol)
     .reduce((total, position) => total + BigInt(position.quantityMicros), 0n)
-  const currentSymbolExposureNumerator = currentSymbolQuantity * referencePrice
   const postTradeSymbolQuantity = currentSymbolQuantity + direction * BigInt(intent.quantityMicros)
   const postTradeSymbolExposureNumerator = postTradeSymbolQuantity * referencePrice
   const postTradeSymbolExposure = divideAwayFromZero(postTradeSymbolExposureNumerator, QUANTITY_SCALE)
@@ -344,10 +354,8 @@ export const evaluate = (intent: Intent, state: State, policy: Policy): Evaluati
   const postTradeNetExposureNumerator = otherNetExposure * QUANTITY_SCALE + postTradeSymbolExposureNumerator
   const postTradeNetExposure = divideAwayFromZero(postTradeNetExposureNumerator, QUANTITY_SCALE)
   const postTradeNetExposureMagnitude = divideUp(absolute(postTradeNetExposureNumerator), QUANTITY_SCALE)
-  const exposureIncrease = divideUp(
-    positiveDifference(absolute(postTradeSymbolExposureNumerator), absolute(currentSymbolExposureNumerator)),
-    QUANTITY_SCALE,
-  )
+  const aggregateBuyingPower =
+    BigInt(state.reservedBuyingPowerMicros) + (intent.side === OrderSide.Buy ? orderNotional : 0n)
   const dailyTradedNotional = BigInt(state.dailyTradedNotionalMicros) + orderNotional
   const dailyLoss = positiveDifference(BigInt(state.dayStartEquityMicros), BigInt(state.account.equityMicros))
   const drawdown = positiveDifference(BigInt(state.peakEquityMicros), BigInt(state.account.equityMicros))
@@ -375,8 +383,8 @@ export const evaluate = (intent: Intent, state: State, policy: Policy): Evaluati
   )
   const brokerFreshUntil = oldestBrokerState + policy.maxBrokerStateAgeMs
   const marketFreshUntil = instant(state.marketDataObservedAt) + policy.maxMarketDataAgeMs
-  const sessionOpen = instant(state.sessionOpenAt)
-  const submissionCutoff = instant(state.submissionCutoffAt)
+  const submissionOpen = instant(state.executionSession.submissionOpenAt)
+  const submissionCutoff = instant(state.executionSession.submissionCutoffAt)
 
   const gates = [
     makeGate(Gate.IntentState, Reason.IntentNotPlanned, intent.state === IntentState.Planned, intent.state, 'PLANNED'),
@@ -477,9 +485,9 @@ export const evaluate = (intent: Intent, state: State, policy: Policy): Evaluati
     makeGate(
       Gate.Session,
       Reason.OutsideSession,
-      evaluatedAt >= sessionOpen && evaluatedAt < submissionCutoff,
+      evaluatedAt >= submissionOpen && evaluatedAt < submissionCutoff,
       state.evaluatedAt,
-      `[${state.sessionOpenAt},${state.submissionCutoffAt})`,
+      `[${state.executionSession.submissionOpenAt},${state.executionSession.submissionCutoffAt})`,
     ),
     makeGate(
       Gate.UnknownMutations,
@@ -512,8 +520,8 @@ export const evaluate = (intent: Intent, state: State, policy: Policy): Evaluati
     makeGate(
       Gate.BuyingPower,
       Reason.BuyingPowerExceeded,
-      exposureIncrease <= BigInt(state.account.buyingPowerMicros),
-      exposureIncrease,
+      aggregateBuyingPower <= BigInt(state.account.buyingPowerMicros),
+      aggregateBuyingPower,
       `<=${state.account.buyingPowerMicros}`,
     ),
     makeGate(
@@ -609,8 +617,7 @@ export const evaluate = (intent: Intent, state: State, policy: Policy): Evaluati
     observedAt: state.marketDataObservedAt,
     referencePriceMicros: state.referencePriceMicros,
     expectedExecutionPriceMicros: state.expectedExecutionPriceMicros,
-    sessionOpenAt: state.sessionOpenAt,
-    submissionCutoffAt: state.submissionCutoffAt,
+    executionSession: state.executionSession,
   })
   const inputMaterial = {
     schemaVersion: 'bayn.paper-risk-evaluation-input.v1',
@@ -658,6 +665,7 @@ export const evaluate = (intent: Intent, state: State, policy: Policy): Evaluati
       dailyLossMicros: dailyLoss.toString(),
       drawdownMicros: drawdown.toString(),
       adverseSlippageBps: adverseSlippageBps.toString(),
+      aggregateBuyingPowerMicros: aggregateBuyingPower.toString(),
       unresolvedOrderCount,
     },
   }

--- a/services/bayn/src/simulation-causality.test.ts
+++ b/services/bayn/src/simulation-causality.test.ts
@@ -30,20 +30,28 @@ const bar = (symbol: string, sessionDate: IsoDate, open: number, close = 100) =>
   publicationSchemaVersion: PublicationSchema.AdjustedDailySnapshotV2,
 })
 
-const sessions = (secondOpen = 100): readonly AlignedSession[] => [
-  {
-    date: '2026-01-02',
-    bars: Object.fromEntries(symbols.map((symbol) => [symbol, bar(symbol, '2026-01-02', 100)])),
-  },
-  {
-    date: '2026-01-05',
-    bars: Object.fromEntries(symbols.map((symbol) => [symbol, bar(symbol, '2026-01-05', secondOpen)])),
-  },
-  {
-    date: '2026-01-06',
-    bars: Object.fromEntries(symbols.map((symbol) => [symbol, bar(symbol, '2026-01-06', 100)])),
-  },
-]
+type Ohlc = Pick<ReturnType<typeof bar>, 'open' | 'high' | 'low' | 'close'>
+
+const sessions = (unseenExecutionOhlc: Partial<Ohlc> = {}): readonly AlignedSession[] => {
+  const executionBar = (symbol: string) => ({
+    ...bar(symbol, '2026-01-05', unseenExecutionOhlc.open ?? 100, unseenExecutionOhlc.close ?? 100),
+    ...unseenExecutionOhlc,
+  })
+  return [
+    {
+      date: '2026-01-02',
+      bars: Object.fromEntries(symbols.map((symbol) => [symbol, bar(symbol, '2026-01-02', 100)])),
+    },
+    {
+      date: '2026-01-05',
+      bars: Object.fromEntries(symbols.map((symbol) => [symbol, executionBar(symbol)])),
+    },
+    {
+      date: '2026-01-06',
+      bars: Object.fromEntries(symbols.map((symbol) => [symbol, bar(symbol, '2026-01-06', 100)])),
+    },
+  ]
+}
 
 const plan = (signalDate: IsoDate, targetWeights: Readonly<Record<string, number>>): DecisionPlan => ({
   schemaVersion: 'bayn.risk-balanced-trend-decision-plan.v1',
@@ -111,9 +119,9 @@ const requests = (result: ReturnType<typeof run>, sessionDate: IsoDate) =>
     }))
 
 describe('live-causal simulation', () => {
-  test('keeps planned order requests invariant when the unseen execution open changes', () => {
+  test('keeps planned order requests invariant when every unseen execution OHLC value changes', () => {
     const baseline = run(sessions())
-    const gapped = run(sessions(150))
+    const gapped = run(sessions({ open: 150, high: 170, low: 80, close: 120 }))
 
     expect(requests(gapped, '2026-01-05')).toEqual(requests(baseline, '2026-01-05'))
     expect(gapped.metrics.endingEquityMicros).not.toBe(baseline.metrics.endingEquityMicros)

--- a/services/bayn/src/simulation-causality.test.ts
+++ b/services/bayn/src/simulation-causality.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from 'bun:test'
+
+import { defaultExecutionModel, MICROS } from './execution-model'
+import { canonicalHashV1 } from './hash'
+import { simulate, type AlignedSession, type SimulationTarget } from './simulation'
+import { fixtureProtocol } from './test-fixtures'
+import {
+  DataFeed,
+  DataSource,
+  PriceAdjustment,
+  PublicationSchema,
+  type DecisionPlan,
+  type IsoDate,
+  type SimulationProtocol,
+} from './types'
+
+const symbols = ['AAA', 'BBB'] as const
+
+const bar = (symbol: string, sessionDate: IsoDate, open: number, close = 100) => ({
+  symbol,
+  sessionDate,
+  open,
+  high: Math.max(open, close),
+  low: Math.min(open, close),
+  close,
+  volume: 1_000_000,
+  source: DataSource.Alpaca,
+  sourceFeed: DataFeed.Sip,
+  adjustment: PriceAdjustment.All,
+  publicationSchemaVersion: PublicationSchema.AdjustedDailySnapshotV2,
+})
+
+const sessions = (secondOpen = 100): readonly AlignedSession[] => [
+  {
+    date: '2026-01-02',
+    bars: Object.fromEntries(symbols.map((symbol) => [symbol, bar(symbol, '2026-01-02', 100)])),
+  },
+  {
+    date: '2026-01-05',
+    bars: Object.fromEntries(symbols.map((symbol) => [symbol, bar(symbol, '2026-01-05', secondOpen)])),
+  },
+  {
+    date: '2026-01-06',
+    bars: Object.fromEntries(symbols.map((symbol) => [symbol, bar(symbol, '2026-01-06', 100)])),
+  },
+]
+
+const plan = (signalDate: IsoDate, targetWeights: Readonly<Record<string, number>>): DecisionPlan => ({
+  schemaVersion: 'bayn.risk-balanced-trend-decision-plan.v1',
+  signalDate,
+  covarianceWindow: {
+    returnCount: 1,
+    firstSession: signalDate,
+    lastSession: signalDate,
+    sessionsHash: canonicalHashV1([signalDate]),
+  },
+  estimatedAnnualizedPortfolioVolatility: 0,
+  exposureScale: 1,
+  targetWeights,
+  signals: symbols.map((symbol) => ({
+    symbol,
+    horizons: [{ horizonSessions: 1, return: 0, normalizedTrend: 0 }],
+    dailyVolatility: 0,
+    annualizedVolatility: 0,
+    compositeScore: 0,
+    positiveScore: 0,
+    eligible: true,
+    uncappedWeight: targetWeights[symbol],
+    cappedWeight: targetWeights[symbol],
+    targetWeight: targetWeights[symbol],
+  })),
+})
+
+const protocol: SimulationProtocol = {
+  universe: symbols,
+  directVolatilityTarget: fixtureProtocol.directVolatilityTarget,
+  initialCapitalMicros: (100n * MICROS).toString(),
+  executionModel: {
+    ...defaultExecutionModel,
+    partialFills: { ...defaultExecutionModel.partialFills, probabilityPpm: 0 },
+  },
+  thresholds: fixtureProtocol.thresholds,
+}
+
+const targets: readonly SimulationTarget[] = [
+  {
+    signalIndex: 0,
+    executionIndex: 1,
+    weights: { AAA: 1, BBB: 0 },
+    decision: plan('2026-01-02', { AAA: 1, BBB: 0 }),
+  },
+  {
+    signalIndex: 1,
+    executionIndex: 2,
+    weights: { AAA: 0, BBB: 1 },
+    decision: plan('2026-01-05', { AAA: 0, BBB: 1 }),
+  },
+]
+
+const run = (input: readonly AlignedSession[]) => simulate(input, targets, 1, protocol, MICROS, 'a'.repeat(64), true)
+
+const requests = (result: ReturnType<typeof run>, sessionDate: IsoDate) =>
+  result.simulation?.orders
+    .filter((order) => order.sessionDate === sessionDate)
+    .map(({ decisionId, sessionDate: date, symbol, side, requestedQuantityMicros }) => ({
+      decisionId,
+      sessionDate: date,
+      symbol,
+      side,
+      requestedQuantityMicros,
+    }))
+
+describe('live-causal simulation', () => {
+  test('keeps planned order requests invariant when the unseen execution open changes', () => {
+    const baseline = run(sessions())
+    const gapped = run(sessions(150))
+
+    expect(requests(gapped, '2026-01-05')).toEqual(requests(baseline, '2026-01-05'))
+    expect(gapped.metrics.endingEquityMicros).not.toBe(baseline.metrics.endingEquityMicros)
+    expect(gapped.simulation?.orders.some((order) => order.status === 'partially-filled')).toBe(true)
+  })
+
+  test('does not fund a planned rotation buy with proceeds from its planned sell', () => {
+    const result = run(sessions())
+    const rotationOrders = result.simulation?.orders.filter((order) => order.sessionDate === '2026-01-06') ?? []
+    const priorCash = result.simulation?.dailyMarks.find((mark) => mark.sessionDate === '2026-01-05')?.cashMicros
+
+    expect(BigInt(priorCash ?? '0')).toBeLessThan(BigInt(defaultExecutionModel.precision.minimumBuyNotionalMicros))
+    expect(rotationOrders.some((order) => order.side === 'sell')).toBe(true)
+    expect(rotationOrders.some((order) => order.side === 'buy')).toBe(false)
+  })
+})

--- a/services/bayn/src/simulation.ts
+++ b/services/bayn/src/simulation.ts
@@ -254,6 +254,30 @@ const makeOrder = (
   return { id: canonicalHashV1({ runId, kind: 'order', ...payload }), ...payload }
 }
 
+const limitOrderFillToBuyingPower = (
+  runId: string,
+  order: SimulatedOrder,
+  filledQuantityMicros: bigint,
+): SimulatedOrder => {
+  const originalFilled = BigInt(order.filledQuantityMicros)
+  if (originalFilled === 0n || filledQuantityMicros === originalFilled) return order
+  if (filledQuantityMicros < 0n || filledQuantityMicros > originalFilled) {
+    throw new Error('buying-power fill adjustment must reduce the modeled fill')
+  }
+  const payload = {
+    decisionId: order.decisionId,
+    sessionDate: order.sessionDate,
+    symbol: order.symbol,
+    side: order.side,
+    requestedQuantityMicros: order.requestedQuantityMicros,
+    filledQuantityMicros: filledQuantityMicros.toString(),
+    status: filledQuantityMicros === 0n ? ('rejected' as const) : ('partially-filled' as const),
+    rejectionReason: filledQuantityMicros === 0n ? ('insufficient-buying-power' as const) : null,
+    unfilledRemainder: 'canceled' as const,
+  }
+  return { id: canonicalHashV1({ runId, kind: 'order', ...payload }), ...payload }
+}
+
 const makeFill = (
   runId: string,
   decision: DecisionEvent,
@@ -328,6 +352,9 @@ export const simulate = (
   runId: string,
   recordEvents: boolean,
 ): SimulationResult => {
+  if (protocol.executionModel.schemaVersion !== 'bayn.execution-model.v2') {
+    throw new Error('simulation requires the causal bayn.execution-model.v2 contract')
+  }
   const targetsByExecution = new Map(targets.map((target) => [target.executionIndex, target]))
   const positions = new Map<string, Position>()
   const initialCapitalMicros = BigInt(protocol.initialCapitalMicros)
@@ -356,6 +383,7 @@ export const simulate = (
     const spreadBeforeSession = totalSpreadCostMicros
     const slippageBeforeSession = totalSlippageCostMicros
     const cashYieldBeforeSession = totalCashYieldMicros
+    const planningCashSnapshotMicros = cashMicros
 
     if (previousSessionDate !== undefined) {
       const elapsedDays = elapsedCalendarDays(previousSessionDate, session.date)
@@ -401,47 +429,159 @@ export const simulate = (
         signalDecisions.push({ ...target.decision, decisionId: decision.id, executionDate: decision.executionDate })
       }
 
-      const openPrices = Object.fromEntries(
+      const planningPrices = Object.fromEntries(
+        Object.entries(sessions[target.signalIndex].bars).map(([symbol, bar]) => [
+          symbol,
+          referencePriceMicros(bar.close, protocol.executionModel),
+        ]),
+      ) as Readonly<Record<string, bigint>>
+      const executionOpenPrices = Object.fromEntries(
         Object.entries(session.bars).map(([symbol, bar]) => [
           symbol,
           referencePriceMicros(bar.open, protocol.executionModel),
         ]),
       ) as Readonly<Record<string, bigint>>
-      const preTradeEquityMicros =
-        cashMicros +
-        Object.entries(openPrices).reduce(
+      const planningCashMicros = planningCashSnapshotMicros
+      const planningEquityMicros =
+        planningCashSnapshotMicros +
+        Object.entries(planningPrices).reduce(
           (value, [symbol, price]) => value + notionalMicros(positions.get(symbol)?.quantityMicros ?? 0n, price),
           0n,
         )
       const desiredQuantities = Object.fromEntries(
         Object.entries(target.weights).map(([symbol, weight]) => [
           symbol,
-          desiredQuantityMicros(preTradeEquityMicros, weight, openPrices[symbol], protocol.executionModel),
+          desiredQuantityMicros(planningEquityMicros, weight, planningPrices[symbol], protocol.executionModel),
         ]),
       ) as Readonly<Record<string, bigint>>
       const sessionFills: FillEvent[] = []
 
-      for (const symbol of Object.keys(target.weights).sort()) {
-        const position = positions.get(symbol) ?? { quantityMicros: 0n, costBasisMicros: 0n }
-        const desired = desiredQuantities[symbol]
-        if (desired >= position.quantityMicros) continue
-        const order = makeOrder(
+      const plannedSells = Object.keys(target.weights)
+        .sort()
+        .map((symbol) => {
+          const position = positions.get(symbol) ?? { quantityMicros: 0n, costBasisMicros: 0n }
+          return {
+            symbol,
+            quantityMicros:
+              desiredQuantities[symbol] < position.quantityMicros
+                ? position.quantityMicros - desiredQuantities[symbol]
+                : 0n,
+          }
+        })
+        .filter((sell) => sell.quantityMicros > 0n)
+      const proposedBuys = Object.keys(target.weights)
+        .sort()
+        .map((symbol) => {
+          const position = positions.get(symbol) ?? { quantityMicros: 0n, costBasisMicros: 0n }
+          return {
+            symbol,
+            quantityMicros:
+              desiredQuantities[symbol] > position.quantityMicros
+                ? desiredQuantities[symbol] - position.quantityMicros
+                : 0n,
+          }
+        })
+        .filter((buy) => buy.quantityMicros > 0n)
+      const plannedBuysAffordable = (scalePpm: bigint): boolean => {
+        const buyInputs = proposedBuys.flatMap((buy): FeeInput[] => {
+          const quantity = scaleQuantityMicros(buy.quantityMicros, scalePpm, protocol.executionModel)
+          if (
+            quantity === 0n ||
+            notionalMicros(quantity, planningPrices[buy.symbol]) <
+              BigInt(protocol.executionModel.precision.minimumBuyNotionalMicros)
+          ) {
+            return []
+          }
+          const terms = makeFillTerms(
+            'buy',
+            quantity,
+            planningPrices[buy.symbol],
+            protocol.executionModel,
+            costMultiplierMicros,
+          )
+          return [{ side: 'buy', quantityMicros: quantity, notionalMicros: terms.notionalMicros }]
+        })
+        const fees = calculateSessionFees(buyInputs, protocol.executionModel, costMultiplierMicros)
+        return buyInputs.reduce((sum, fill) => sum + fill.notionalMicros, 0n) + fees.totalMicros <= planningCashMicros
+      }
+      let plannedBuyScale = 0n
+      let maximumPlannedBuyScale = ppm
+      while (plannedBuyScale < maximumPlannedBuyScale) {
+        const candidate = (plannedBuyScale + maximumPlannedBuyScale + 1n) / 2n
+        if (plannedBuysAffordable(candidate)) plannedBuyScale = candidate
+        else maximumPlannedBuyScale = candidate - 1n
+      }
+      const sellOrders = plannedSells.map((sell) =>
+        makeOrder(
           runId,
           decision,
           session.date,
-          symbol,
+          sell.symbol,
           'sell',
-          position.quantityMicros - desired,
-          openPrices[symbol],
+          sell.quantityMicros,
+          executionOpenPrices[sell.symbol],
           protocol,
-        )
+        ),
+      )
+      const plannedBuyOrders = proposedBuys.flatMap((buy): SimulatedOrder[] => {
+        const requestedQuantity = scaleQuantityMicros(buy.quantityMicros, plannedBuyScale, protocol.executionModel)
+        return requestedQuantity === 0n ||
+          notionalMicros(requestedQuantity, planningPrices[buy.symbol]) <
+            BigInt(protocol.executionModel.precision.minimumBuyNotionalMicros)
+          ? []
+          : [
+              makeOrder(
+                runId,
+                decision,
+                session.date,
+                buy.symbol,
+                'buy',
+                requestedQuantity,
+                executionOpenPrices[buy.symbol],
+                protocol,
+              ),
+            ]
+      })
+      const executionBuysAffordable = (scalePpm: bigint): boolean => {
+        const buyInputs = plannedBuyOrders.flatMap((order): FeeInput[] => {
+          const quantity = scaleQuantityMicros(BigInt(order.filledQuantityMicros), scalePpm, protocol.executionModel)
+          if (quantity === 0n) return []
+          const terms = makeFillTerms(
+            'buy',
+            quantity,
+            executionOpenPrices[order.symbol],
+            protocol.executionModel,
+            costMultiplierMicros,
+          )
+          return [{ side: 'buy', quantityMicros: quantity, notionalMicros: terms.notionalMicros }]
+        })
+        const fees = calculateSessionFees(buyInputs, protocol.executionModel, costMultiplierMicros)
+        return buyInputs.reduce((sum, fill) => sum + fill.notionalMicros, 0n) + fees.totalMicros <= planningCashMicros
+      }
+      let executionBuyScale = 0n
+      let maximumExecutionBuyScale = ppm
+      while (executionBuyScale < maximumExecutionBuyScale) {
+        const candidate = (executionBuyScale + maximumExecutionBuyScale + 1n) / 2n
+        if (executionBuysAffordable(candidate)) executionBuyScale = candidate
+        else maximumExecutionBuyScale = candidate - 1n
+      }
+      const buyOrders = plannedBuyOrders.map((order) =>
+        limitOrderFillToBuyingPower(
+          runId,
+          order,
+          scaleQuantityMicros(BigInt(order.filledQuantityMicros), executionBuyScale, protocol.executionModel),
+        ),
+      )
+
+      for (const order of sellOrders) {
         if (recordEvents) orders.push(order)
+        const position = positions.get(order.symbol) ?? { quantityMicros: 0n, costBasisMicros: 0n }
         const filledQuantity = BigInt(order.filledQuantityMicros)
         if (filledQuantity > 0n) {
           const terms = makeFillTerms(
             'sell',
             filledQuantity,
-            openPrices[symbol],
+            executionOpenPrices[order.symbol],
             protocol.executionModel,
             costMultiplierMicros,
           )
@@ -453,7 +593,7 @@ export const simulate = (
           totalSlippageCostMicros += terms.slippageCostMicros
           position.quantityMicros -= filledQuantity
           position.costBasisMicros -= costBasis
-          positions.set(symbol, position)
+          positions.set(order.symbol, position)
           sessionFills.push(fill)
           if (recordEvents) {
             events.push(fill)
@@ -462,78 +602,14 @@ export const simulate = (
         }
       }
 
-      const proposedBuys = Object.keys(target.weights)
-        .sort()
-        .map((symbol) => {
-          const position = positions.get(symbol) ?? { quantityMicros: 0n, costBasisMicros: 0n }
-          const quantityMicros =
-            desiredQuantities[symbol] > position.quantityMicros
-              ? desiredQuantities[symbol] - position.quantityMicros
-              : 0n
-          return { symbol, position, quantityMicros, referencePriceMicros: openPrices[symbol] }
-        })
-        .filter((buy) => buy.quantityMicros > 0n)
-
-      const sellFeeInputs: FeeInput[] = sessionFills.map((fill) => ({
-        side: fill.side,
-        quantityMicros: BigInt(fill.quantityMicros),
-        notionalMicros: BigInt(fill.notionalMicros),
-      }))
-      const affordable = (scalePpm: bigint): boolean => {
-        const buyInputs = proposedBuys.flatMap((buy): FeeInput[] => {
-          const quantity = scaleQuantityMicros(buy.quantityMicros, scalePpm, protocol.executionModel)
-          if (
-            quantity === 0n ||
-            notionalMicros(quantity, buy.referencePriceMicros) <
-              BigInt(protocol.executionModel.precision.minimumBuyNotionalMicros)
-          ) {
-            return []
-          }
-          const terms = makeFillTerms(
-            'buy',
-            quantity,
-            buy.referencePriceMicros,
-            protocol.executionModel,
-            costMultiplierMicros,
-          )
-          return [{ side: 'buy', quantityMicros: quantity, notionalMicros: terms.notionalMicros }]
-        })
-        const fees = calculateSessionFees(
-          [...sellFeeInputs, ...buyInputs],
-          protocol.executionModel,
-          costMultiplierMicros,
-        )
-        const buyNotional = buyInputs.reduce((sum, fill) => sum + fill.notionalMicros, 0n)
-        return buyNotional + fees.totalMicros <= cashMicros
-      }
-      let low = 0n
-      let high = ppm
-      while (low < high) {
-        const middle = (low + high + 1n) / 2n
-        if (affordable(middle)) low = middle
-        else high = middle - 1n
-      }
-
-      for (const buy of proposedBuys) {
-        const requestedQuantity = scaleQuantityMicros(buy.quantityMicros, low, protocol.executionModel)
-        if (requestedQuantity === 0n) continue
-        const order = makeOrder(
-          runId,
-          decision,
-          session.date,
-          buy.symbol,
-          'buy',
-          requestedQuantity,
-          buy.referencePriceMicros,
-          protocol,
-        )
+      for (const order of buyOrders) {
         if (recordEvents) orders.push(order)
         const filledQuantity = BigInt(order.filledQuantityMicros)
         if (filledQuantity > 0n) {
           const terms = makeFillTerms(
             'buy',
             filledQuantity,
-            buy.referencePriceMicros,
+            executionOpenPrices[order.symbol],
             protocol.executionModel,
             costMultiplierMicros,
           )
@@ -542,9 +618,10 @@ export const simulate = (
           turnoverMicros += terms.notionalMicros
           totalSpreadCostMicros += terms.spreadCostMicros
           totalSlippageCostMicros += terms.slippageCostMicros
-          buy.position.quantityMicros += filledQuantity
-          buy.position.costBasisMicros += terms.notionalMicros
-          positions.set(buy.symbol, buy.position)
+          const position = positions.get(order.symbol) ?? { quantityMicros: 0n, costBasisMicros: 0n }
+          position.quantityMicros += filledQuantity
+          position.costBasisMicros += terms.notionalMicros
+          positions.set(order.symbol, position)
           sessionFills.push(fill)
           if (recordEvents) {
             events.push(fill)

--- a/services/bayn/src/startup.test.ts
+++ b/services/bayn/src/startup.test.ts
@@ -16,25 +16,32 @@ import {
   fixtureQualification,
   pinnedExecutionProvenance,
   pinnedEvaluation,
+  pinnedLock,
   pinnedQualification,
   pinnedRuntimeConfig,
+  pinnedStoredEvidence,
+  pinnedStrategy,
   pinnedStore,
 } from './app-test-support'
 import { initialize, run } from './app'
+import { makeStrategyProtocolHash } from './contracts'
 import {
   DatabaseError,
   EvidenceStore,
   EvidenceStoreLive,
   makeEvidenceStoreLayer,
   type EvidenceStoreService,
+  type StoredEvaluationEvidence,
 } from './db/evidence-store'
 import { operationalError } from './errors'
 import { Journal, type JournalService } from './ledger'
 import { MarketData } from './market-data'
+import { defaultProtocolDocument, loadProtocol } from './protocol'
+import { makeQualificationLock, makeQualificationResult } from './qualification'
 import { evaluateRiskBalancedTrend, summarizeEvaluation } from './risk-balanced-trend'
 import { initialState } from './runtime-state'
 import type { Strategy } from './strategy'
-import { fixtureProtocol, makeSnapshot } from './test-fixtures'
+import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
 
 describe('Bayn startup lifecycle', () => {
   test('recovers a pinned terminal qualification without inspecting data or writing state', async () => {
@@ -82,19 +89,125 @@ describe('Bayn startup lifecycle', () => {
     })
   })
 
-  test('fails pinned recovery closed on strategy, snapshot, terminal-result, and durable-evidence drift', async () => {
-    const cases = [
-      {
-        name: 'strategy',
-        config: pinnedRuntimeConfig,
-        strategy: {
-          ...fixtureStrategy,
-          provenance: {
-            ...fixtureStrategy.provenance,
-            strategy: { ...fixtureStrategy.provenance.strategy, behaviorHash: '0'.repeat(64) },
+  test('recovers immutable protocol v2 evidence independently of the compiled v3 strategy', async () => {
+    const historicalProtocol = Effect.runSync(
+      loadProtocol({
+        ...defaultProtocolDocument,
+        schemaVersion: 'bayn.risk-balanced-trend.protocol.v2',
+        executionModel: {
+          ...defaultProtocolDocument.executionModel,
+          schemaVersion: 'bayn.execution-model.v1',
+          order: {
+            type: 'market',
+            timeInForce: 'day',
+            extendedHours: false,
+            submitAfter: 'signal-session-close',
+            submitBefore: 'next-session-open',
+            priceReference: 'next-session-open',
           },
         },
-        store: pinnedStore(),
+      }),
+    )
+    const historicalProvenance = makeTestProvenance(historicalProtocol, {
+      sourceRevision: pinnedExecutionProvenance.sourceRevision,
+      imageDigest: pinnedExecutionProvenance.image.digest,
+      behaviorHash: 'c'.repeat(64),
+    })
+    const historicalProtocolHash = makeStrategyProtocolHash(historicalProvenance.strategy)
+    const historicalStoredEvidence: StoredEvaluationEvidence = {
+      ...pinnedStoredEvidence,
+      protocol: {
+        protocolHash: historicalProtocolHash,
+        schemaVersion: historicalProtocol.schemaVersion,
+        strategyName: historicalProvenance.strategy.name,
+        behaviorHash: historicalProvenance.strategy.behaviorHash,
+        parameterHash: historicalProvenance.strategy.parameterHash,
+        parameters: historicalProtocol,
+      },
+      run: {
+        ...pinnedStoredEvidence.run,
+        protocolHash: historicalProtocolHash,
+        sourceRevision: historicalProvenance.sourceRevision,
+        imageRepository: historicalProvenance.image.repository,
+        imageDigest: historicalProvenance.image.digest,
+      },
+    }
+    const { lockId: _, ...pinnedLockMaterial } = pinnedLock
+    const historicalLock = makeQualificationLock({
+      ...pinnedLockMaterial,
+      protocolHash: historicalProtocolHash,
+      sourceRevision: historicalProvenance.sourceRevision,
+      image: historicalProvenance.image,
+    })
+    const historicalQualification = makeQualificationResult(
+      historicalLock,
+      pinnedEvaluation.verdict,
+      pinnedStrategy.analyze(pinnedEvaluation, []),
+    )
+    const store: EvidenceStoreService = {
+      ...pinnedStore(),
+      read: () => Effect.succeed(Option.some(historicalStoredEvidence)),
+      readQualification: () =>
+        Effect.succeed(Option.some({ state: 'TERMINAL', lock: historicalLock, result: historicalQualification })),
+      recover: (runId, recoveredProvenance) =>
+        Effect.sync(() => {
+          expect(runId).toBe(pinnedEvaluation.runId)
+          expect(recoveredProvenance).toEqual(historicalProvenance)
+          return Option.some({
+            evaluation: summarizeEvaluation(pinnedEvaluation),
+            reconciliation: {
+              runId,
+              accountCount: 13,
+              transferCount: pinnedEvaluation.events.length,
+              exact: true,
+            },
+            persistence: {
+              runId,
+              deduplicated: true,
+              artifactCount: 17,
+              eventCount: pinnedEvaluation.events.length,
+              gateCount: pinnedEvaluation.verdict.gates.length,
+            },
+          })
+        }),
+    }
+    const state = await Effect.runPromise(Ref.make(initialState()))
+
+    await Effect.runPromise(
+      initialize(pinnedRuntimeConfig, state, fixtureStrategy).pipe(
+        Effect.provideService(MarketData, marketDataService(Effect.die(new Error('must not load bars')))),
+        Effect.provideService(Journal, successfulJournal),
+        Effect.provideService(EvidenceStore, store),
+      ),
+    )
+
+    expect(fixtureStrategy.provenance.strategy.parameterSchemaVersion).toBe('bayn.risk-balanced-trend.protocol.v3')
+    expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
+      status: 'STARTING',
+      evidence: {
+        startupMode: 'pinned',
+        provenance: historicalProvenance,
+        qualification: { verdict: 'REJECTED' },
+      },
+    })
+  })
+
+  test('fails pinned recovery closed on stored-protocol, snapshot, terminal-result, and durable-evidence drift', async () => {
+    const cases = [
+      {
+        name: 'stored protocol',
+        config: pinnedRuntimeConfig,
+        strategy: fixtureStrategy,
+        store: {
+          ...pinnedStore(),
+          read: () =>
+            Effect.succeed(
+              Option.some({
+                ...pinnedStoredEvidence,
+                protocol: { ...pinnedStoredEvidence.protocol, parameterHash: '0'.repeat(64) },
+              }),
+            ),
+        },
       },
       {
         name: 'snapshot',

--- a/services/bayn/src/startup.ts
+++ b/services/bayn/src/startup.ts
@@ -1,7 +1,7 @@
 import { Effect, Option, Ref } from 'effect'
 
 import type { RuntimeConfig } from './config'
-import { makeRuntimeProvenance, type RuntimeProvenance } from './contracts'
+import { makeRuntimeProvenance, makeStrategyProtocolHash, type RuntimeProvenance } from './contracts'
 import { EvidenceStore, type StoredEvaluationEvidence } from './db/evidence-store'
 import { formatError, operationalError, type OperationalError } from './errors'
 import { canonicalHashV1 } from './hash'
@@ -42,7 +42,7 @@ const provenanceFromStored = (stored: StoredEvaluationEvidence): RuntimeProvenan
   ) {
     throw new Error('stored evaluation uses an unsupported strategy contract')
   }
-  return makeRuntimeProvenance({
+  const provenance = makeRuntimeProvenance({
     sourceRevision: stored.run.sourceRevision,
     image: { repository: stored.run.imageRepository, digest: stored.run.imageDigest },
     strategy: {
@@ -52,13 +52,20 @@ const provenanceFromStored = (stored: StoredEvaluationEvidence): RuntimeProvenan
       parameterSchemaVersion: stored.protocol.schemaVersion,
     },
   })
+  if (
+    canonicalHashV1(stored.protocol.parameters) !== provenance.strategy.parameterHash ||
+    stored.protocol.protocolHash !== makeStrategyProtocolHash(provenance.strategy) ||
+    stored.run.protocolHash !== stored.protocol.protocolHash
+  ) {
+    throw new Error('stored evaluation protocol does not match its own provenance')
+  }
+  return provenance
 }
 
 const recoverPinnedQualification = (
   config: RuntimeConfig,
   runId: string,
   state: Ref.Ref<RuntimeState>,
-  strategy: Strategy,
 ): Effect.Effect<void, OperationalError, EvidenceStore> =>
   Effect.gen(function* () {
     const evidenceStore = yield* EvidenceStore
@@ -107,12 +114,8 @@ const recoverPinnedQualification = (
           throw new Error('stored evaluation and terminal qualification run IDs differ')
         }
         if (
-          canonicalHashV1(executionProvenance.strategy) !== canonicalHashV1(strategy.provenance.strategy) ||
-          canonicalHashV1(stored.protocol.parameters) !== canonicalHashV1(strategy.parameters)
-        ) {
-          throw new Error('compiled strategy differs from the pinned qualification protocol')
-        }
-        if (
+          qualification.lock.candidateRunId !== runId ||
+          qualification.lock.protocolHash !== stored.run.protocolHash ||
           qualification.lock.sourceRevision !== executionProvenance.sourceRevision ||
           canonicalHashV1(qualification.lock.image) !== canonicalHashV1(executionProvenance.image)
         ) {
@@ -397,5 +400,5 @@ export const initialize = (
 ): Effect.Effect<void, OperationalError, MarketData | Journal | EvidenceStore> =>
   (config.qualificationRunId === undefined
     ? evaluateAndJournal(config, state, strategy)
-    : recoverPinnedQualification(config, config.qualificationRunId, state, strategy)
+    : recoverPinnedQualification(config, config.qualificationRunId, state)
   ).pipe(Effect.catch((error) => (error.retryable ? Effect.fail(error) : failStartup(state, error))))

--- a/services/bayn/src/startup.ts
+++ b/services/bayn/src/startup.ts
@@ -37,7 +37,8 @@ const failStartup = (state: Ref.Ref<RuntimeState>, error: OperationalError): Eff
 const provenanceFromStored = (stored: StoredEvaluationEvidence): RuntimeProvenance => {
   if (
     stored.protocol.strategyName !== 'risk-balanced-trend' ||
-    stored.protocol.schemaVersion !== 'bayn.risk-balanced-trend.protocol.v2'
+    (stored.protocol.schemaVersion !== 'bayn.risk-balanced-trend.protocol.v2' &&
+      stored.protocol.schemaVersion !== 'bayn.risk-balanced-trend.protocol.v3')
   ) {
     throw new Error('stored evaluation uses an unsupported strategy contract')
   }

--- a/services/bayn/src/types.ts
+++ b/services/bayn/src/types.ts
@@ -41,7 +41,7 @@ export type {
   SymbolCoverage,
   SymbolSignal,
 } from './evidence-contracts'
-export type { EconomicThresholds, ExecutionModel, Protocol } from './protocol'
+export type { CausalProtocol, EconomicThresholds, ExecutionModel, Protocol } from './protocol'
 export { DIRECT_VOLATILITY_WINDOW } from './protocol'
 export type { IsoDate } from './schemas'
 

--- a/services/bayn/src/verify-build-contract.ts
+++ b/services/bayn/src/verify-build-contract.ts
@@ -1,7 +1,8 @@
 import { NodeRuntime } from '@effect/platform-node'
 import { Effect, Schema } from 'effect'
 
-import { embeddedBuildMetadata, EmbeddedBuildMetadataSchema, verifyParameterHash } from './build'
+import { riskBalancedTrendBehaviorHash } from './behavior'
+import { embeddedBuildMetadata, EmbeddedBuildMetadataSchema, verifyBehaviorHash, verifyParameterHash } from './build'
 import { operationalError } from './errors'
 import { hashParameters, loadDefaultProtocol } from './protocol'
 import { strictParseOptions } from './schemas'
@@ -16,7 +17,10 @@ const program = Effect.gen(function* () {
     ),
   )
   const protocol = yield* loadDefaultProtocol
-  yield* verifyParameterHash(metadata, hashParameters(protocol))
+  yield* Effect.all([
+    verifyBehaviorHash(metadata, riskBalancedTrendBehaviorHash),
+    verifyParameterHash(metadata, hashParameters(protocol)),
+  ])
 })
 
 NodeRuntime.runMain(program)


### PR DESCRIPTION
## Summary

- version the corrected causal execution contract so plans use finalized signal-session closes and reconciled pre-plan broker state while fills remain bound to the next session open
- reserve aggregate buys against pre-submit cash without crediting sell proceeds, and reproduce the same contract in an independently implemented audit reference
- retain and verify the complete bounded broker-calendar observation, require the actual first post-signal session, bind every UTC open/close instant to its declared session date, and enforce the half-open submission window in risk
- recheck mutation authority before start and make the fenced STARTED insert conditional on a current approved risk decision, leaving no start row when the cutoff has arrived
- recover immutable protocol v2 evidence from its own verified provenance without equating it to the compiled v3 candidate
- preserve protocol v2 as immutable rejected evidence, precommit distinct v3 behavior/parameter identities, and document that no qualification rerun or execution authority is granted

## Related Issues

PROOMPT-406

## Testing

- `bun run --cwd services/bayn tsc`
- `bun run --cwd services/bayn test --only-failures` — 267 passed, 53 PostgreSQL-only tests skipped
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:55433/bayn_test bun test services/bayn/src/db/evidence-store.integration.test.ts` — 36 passed on PostgreSQL 18
- focused PostgreSQL mutation-start validation — normal submit/outcome and expired no-start cases both passed; the expired case retained `APPROVED` with zero mutation rows
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:55433/bayn_test bun test services/bayn/src/db/paper-store.integration.test.ts` — 7 passed
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:55433/bayn_test bun test services/bayn/src/db/cycle-store.integration.test.ts` — 5 passed
- `bun test packages/scripts/src/bayn` — 9 passed
- `bunx oxfmt --check services/bayn docs/bayn/architecture.md docs/bayn/authoritative-universe.md nix/images/bayn.nix`
- `bun run --cwd services/bayn lint:oxlint`
- `bun run --cwd services/bayn lint:oxlint:type`
- `bun run --cwd services/bayn build`
- coherently rehashed calendar/session timestamp substitution regression — rejected when July 10 UTC instants claim the July 6 session date
- all seven actionable Codex review threads have pushed regression fixes, evidence replies, and resolved discussions
- local `nix eval --raw .#bayn-image.drvPath` could not run because the Nix daemon socket refused connections; required amd64/arm64 image builds remain enforced by PR CI

## Breaking Changes

The active source contract advances from protocol v2/execution-model v1 to protocol v3/execution-model v2 and adds migration `0011_causal_protocol`. Protocol v2 remains decodable and recoverable only as immutable historical evidence. The new image must not replace the currently pinned rejected v2 runtime without a future fresh qualification; the release writer is expected to hold it.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (screenshots are not applicable; no UI changed).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
