### PR TITLE
fix(buzz): pin relay with startup migrations

### DIFF
--- a/argocd/applications/buzz/kustomization.yaml
+++ b/argocd/applications/buzz/kustomization.yaml
@@ -30,8 +30,8 @@ helmCharts:
 images:
   - name: ghcr.io/block/buzz
     newName: ghcr.io/block/buzz
-    newTag: 0.1.0
-    digest: sha256:e7f25874ef10581485d4c548f3f1cf76f986aeffbfafee00bcb8edc2855dedea
+    newTag: sha-acfbb1b
+    digest: sha256:29fe13981a726fe43642fe03cbd6cc87142579a90bbf9897e3c1b370d1037428
 
 patches:
   - target:

--- a/argocd/applications/buzz/values.yaml
+++ b/argocd/applications/buzz/values.yaml
@@ -2,7 +2,7 @@ quickstart: false
 
 image:
   repository: ghcr.io/block/buzz
-  tag: 0.1.0
+  tag: sha-acfbb1b
   pullPolicy: IfNotPresent
 
 replicaCount: 2

--- a/docs/runbooks/buzz-production.md
+++ b/docs/runbooks/buzz-production.md
@@ -7,8 +7,9 @@ Buzz is deployed to the `buzz` namespace by the `buzz` Argo CD application. It i
 
 - Helm chart: `oci://ghcr.io/block/buzz/charts/buzz:0.1.6`
   (`sha256:88b96378cabd6b64c9bb8da9824a608daac3b0965d2aa17019e70248c07d517c`).
-- Relay image: `ghcr.io/block/buzz:0.1.0`
-  (`sha256:e7f25874ef10581485d4c548f3f1cf76f986aeffbfafee00bcb8edc2855dedea`).
+- Relay image: `ghcr.io/block/buzz:sha-acfbb1b`
+  (`sha256:29fe13981a726fe43642fe03cbd6cc87142579a90bbf9897e3c1b370d1037428`, source revision
+  `acfbb1bb6af54cb29cb152496ff43b8285dcb8cf`).
 - `RELAY_OWNER_PUBKEY` is public and committed in `argocd/applications/buzz/values.yaml`.
 - The owner's `nsec` is stored only in the human-owned `buzz-owner` item in the 1Password `Private` vault.
 - `buzz-runtime` in the 1Password `infra` vault contains the stable relay private key, Git hook HMAC secret, and

--- a/packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts
+++ b/packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts
@@ -24,6 +24,8 @@ describe('Buzz production GitOps contract', () => {
 
     expect(kustomization).toContain('version: 0.1.6')
     expect(kustomization).toContain('sha256:88b96378cabd6b64c9bb8da9824a608daac3b0965d2aa17019e70248c07d517c')
+    expect(kustomization).toContain('newTag: sha-acfbb1b')
+    expect(kustomization).toContain('sha256:29fe13981a726fe43642fe03cbd6cc87142579a90bbf9897e3c1b370d1037428')
 
     for (const manifest of [kustomization, postgres, redis, alloy]) {
       expect(manifest).toContain('sha256:')


### PR DESCRIPTION
## Summary

- Replace the chart-default relay image with upstream commit `acfbb1bb6af54cb29cb152496ff43b8285dcb8cf`, pinned as `sha-acfbb1b@sha256:29fe13981a726fe43642fe03cbd6cc87142579a90bbf9897e3c1b370d1037428`.
- Use the first verified multi-arch upstream image whose startup path executes `db.migrate()` before partition and owner bootstrap when `BUZZ_AUTO_MIGRATE=true`.
- Update the production contract and runbook with the exact source revision and digest.

## Related Issues

None.

## Testing

- `bun test ./packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts`
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts docs/runbooks/buzz-production.md`
- `bunx oxlint packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts`
- `bun run lint:argocd`
- `kustomize build --enable-helm argocd/applications/buzz` with an exact rendered-image assertion, followed by `kubectl apply --server-side --dry-run=server` in an existing restricted namespace.
- Verified the OCI index contains linux/amd64 and linux/arm64 and resolves to the pinned digest.
- Verified upstream source revision `acfbb1b` runs `db.migrate()` before `ensure_future_partitions` and owner bootstrap.
- Live failure evidence: chart-default image revision `9ee5aee` connected to PostgreSQL but had no startup migration call, then exited on missing `events` and `relay_members` tables.

## Breaking Changes

None. PostgreSQL is new and contains no application data; its CNPG PVCs and completed backup remain preserved.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
