### PR TITLE
feat(bayn): expose autonomous cycle operations

### DIFF
--- a/services/bayn/src/app-test-support.ts
+++ b/services/bayn/src/app-test-support.ts
@@ -62,10 +62,6 @@ export const config: RuntimeConfig = {
   cycleStallThresholdMs: 300_000,
   reconciliationStaleThresholdMs: 120_000,
   unknownMutationThresholdMs: 300_000,
-  autonomousCycle: {
-    enabled: false,
-    pollIntervalMs: 30_000,
-  },
   clickhouse: {
     url: 'http://clickhouse.test:8123',
     username: 'bayn',
@@ -286,7 +282,6 @@ export const readyState = (): RuntimeState => {
         tigerBeetle: { status: 'AVAILABLE', checkedAt: '2026-07-20T00:00:00.000Z', error: null },
         evidence: { status: 'AVAILABLE', checkedAt: '2026-07-20T00:00:00.000Z', error: null },
         cycle: { status: 'AVAILABLE', checkedAt: '2026-07-20T00:00:00.000Z', error: null },
-        cycleRunner: { status: 'AVAILABLE', checkedAt: '2026-07-20T00:00:00.000Z', error: null },
       },
     },
     cycle: deriveCycleOperationsStatus(
@@ -296,13 +291,12 @@ export const readyState = (): RuntimeState => {
         unfinishedCycleCount: 0,
         authority: null,
         reconciliation: null,
-        mutations: { eventCount: 0, unresolvedCount: 0, oldestUnresolvedAt: null },
+        mutations: { eventCount: 0, unresolvedCount: 0, oldestUnresolvedAt: null, latestOccurredAt: null },
       },
       Date.parse('2026-07-20T00:00:00.000Z'),
       Authority.Observe,
       config,
     ),
-    cycleRunner: { enabled: false, status: 'DISABLED', checkedAt: null, error: null },
     broker: null,
     error: null,
   }

--- a/services/bayn/src/app-test-support.ts
+++ b/services/bayn/src/app-test-support.ts
@@ -3,6 +3,7 @@ import { expect } from 'bun:test'
 import { Effect, Option, Redacted } from 'effect'
 
 import type { RuntimeConfig } from './config'
+import { deriveCycleOperationsStatus } from './cycle-observability'
 import type { EvidenceStoreService, StoredEvaluationEvidence } from './db/evidence-store'
 import type { JournalService } from './ledger'
 import type { MarketDataService } from './market-data'
@@ -58,6 +59,13 @@ export const config: RuntimeConfig = {
   },
   healthIntervalMs: 100,
   operationTimeoutMs: 250,
+  cycleStallThresholdMs: 300_000,
+  reconciliationStaleThresholdMs: 120_000,
+  unknownMutationThresholdMs: 300_000,
+  autonomousCycle: {
+    enabled: false,
+    pollIntervalMs: 30_000,
+  },
   clickhouse: {
     url: 'http://clickhouse.test:8123',
     username: 'bayn',
@@ -277,8 +285,24 @@ export const readyState = (): RuntimeState => {
         signal: { status: 'AVAILABLE', checkedAt: '2026-07-20T00:00:00.000Z', error: null },
         tigerBeetle: { status: 'AVAILABLE', checkedAt: '2026-07-20T00:00:00.000Z', error: null },
         evidence: { status: 'AVAILABLE', checkedAt: '2026-07-20T00:00:00.000Z', error: null },
+        cycle: { status: 'AVAILABLE', checkedAt: '2026-07-20T00:00:00.000Z', error: null },
+        cycleRunner: { status: 'AVAILABLE', checkedAt: '2026-07-20T00:00:00.000Z', error: null },
       },
     },
+    cycle: deriveCycleOperationsStatus(
+      {
+        current: null,
+        last: null,
+        unfinishedCycleCount: 0,
+        authority: null,
+        reconciliation: null,
+        mutations: { eventCount: 0, unresolvedCount: 0, oldestUnresolvedAt: null },
+      },
+      Date.parse('2026-07-20T00:00:00.000Z'),
+      Authority.Observe,
+      config,
+    ),
+    cycleRunner: { enabled: false, status: 'DISABLED', checkedAt: null, error: null },
     broker: null,
     error: null,
   }

--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -1,9 +1,13 @@
 import { Effect, Layer, Ref } from 'effect'
 
+import { BrokerRead } from './broker/alpaca'
 import type { RuntimeConfig } from './config'
+import { startAutonomousCycleLoop, type CycleCandidate } from './cycle-runner'
+import { CycleObservability } from './db/cycle-observability'
+import { CycleStore, type CycleStoreShape } from './db/cycle-store'
 import { EvidenceStore } from './db/evidence-store'
 import { operationalError, type OperationalError } from './errors'
-import { monitor, type BrokerProbe } from './health'
+import { monitor, type BrokerProbe, type CycleRunnerFiber } from './health'
 import { makeHttpLayer } from './http'
 import { Journal } from './ledger'
 import { MarketData } from './market-data'
@@ -11,21 +15,49 @@ import { initialState } from './runtime-state'
 import { initialize } from './startup'
 import type { Strategy } from './strategy'
 
+export interface AutonomousCycleComposition {
+  readonly candidate: Effect.Effect<CycleCandidate | undefined, OperationalError>
+  readonly store: CycleStoreShape
+}
+
 export const run = (
   config: RuntimeConfig,
   strategy: Strategy,
   reconciliation: Effect.Effect<void> = Effect.void,
   broker?: BrokerProbe,
-): Effect.Effect<never, OperationalError, MarketData | Journal | EvidenceStore> =>
+  autonomousCycle?: AutonomousCycleComposition,
+): Effect.Effect<never, OperationalError, MarketData | Journal | EvidenceStore | CycleObservability> =>
   Effect.scoped(
     Effect.gen(function* () {
       const evidenceStore = yield* EvidenceStore
-      const state = yield* Ref.make(initialState(broker))
+      const state = yield* Ref.make(initialState(broker, config.autonomousCycle.enabled))
+      let cycleRunner: CycleRunnerFiber | undefined
+      if (config.autonomousCycle.enabled) {
+        if (broker === undefined || autonomousCycle === undefined) {
+          return yield* Effect.fail(
+            operationalError(
+              'config',
+              'autonomous-cycle',
+              'enabled autonomous cycle composition requires BrokerRead, CycleStore, and a verified candidate source',
+            ),
+          )
+        }
+        cycleRunner = yield* startAutonomousCycleLoop({
+          candidate: autonomousCycle.candidate,
+          pollIntervalMs: config.autonomousCycle.pollIntervalMs,
+        }).pipe(
+          Effect.provideService(BrokerRead, broker.read),
+          Effect.provideService(CycleStore, autonomousCycle.store),
+          Effect.mapError((cause) =>
+            operationalError('config', 'autonomous-cycle', 'autonomous cycle runner failed to start', cause),
+          ),
+        )
+      }
       yield* Layer.build(
         makeHttpLayer(config, state, strategy.provenance, config.build.verification, evidenceStore.read),
       ).pipe(Effect.mapError((cause) => operationalError('http', 'listen', 'HTTP server failed to listen', cause)))
       yield* initialize(config, state, strategy)
-      yield* monitor(config, state, broker).pipe(Effect.forkScoped({ startImmediately: true }))
+      yield* monitor(config, state, broker, cycleRunner).pipe(Effect.forkScoped({ startImmediately: true }))
       yield* reconciliation
       return yield* Effect.never
     }),

--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -1,13 +1,10 @@
 import { Effect, Layer, Ref } from 'effect'
 
-import { BrokerRead } from './broker/alpaca'
 import type { RuntimeConfig } from './config'
-import { startAutonomousCycleLoop, type CycleCandidate } from './cycle-runner'
 import { CycleObservability } from './db/cycle-observability'
-import { CycleStore, type CycleStoreShape } from './db/cycle-store'
 import { EvidenceStore } from './db/evidence-store'
 import { operationalError, type OperationalError } from './errors'
-import { monitor, type BrokerProbe, type CycleRunnerFiber } from './health'
+import { monitor, type BrokerProbe } from './health'
 import { makeHttpLayer } from './http'
 import { Journal } from './ledger'
 import { MarketData } from './market-data'
@@ -15,49 +12,21 @@ import { initialState } from './runtime-state'
 import { initialize } from './startup'
 import type { Strategy } from './strategy'
 
-export interface AutonomousCycleComposition {
-  readonly candidate: Effect.Effect<CycleCandidate | undefined, OperationalError>
-  readonly store: CycleStoreShape
-}
-
 export const run = (
   config: RuntimeConfig,
   strategy: Strategy,
   reconciliation: Effect.Effect<void> = Effect.void,
   broker?: BrokerProbe,
-  autonomousCycle?: AutonomousCycleComposition,
 ): Effect.Effect<never, OperationalError, MarketData | Journal | EvidenceStore | CycleObservability> =>
   Effect.scoped(
     Effect.gen(function* () {
       const evidenceStore = yield* EvidenceStore
-      const state = yield* Ref.make(initialState(broker, config.autonomousCycle.enabled))
-      let cycleRunner: CycleRunnerFiber | undefined
-      if (config.autonomousCycle.enabled) {
-        if (broker === undefined || autonomousCycle === undefined) {
-          return yield* Effect.fail(
-            operationalError(
-              'config',
-              'autonomous-cycle',
-              'enabled autonomous cycle composition requires BrokerRead, CycleStore, and a verified candidate source',
-            ),
-          )
-        }
-        cycleRunner = yield* startAutonomousCycleLoop({
-          candidate: autonomousCycle.candidate,
-          pollIntervalMs: config.autonomousCycle.pollIntervalMs,
-        }).pipe(
-          Effect.provideService(BrokerRead, broker.read),
-          Effect.provideService(CycleStore, autonomousCycle.store),
-          Effect.mapError((cause) =>
-            operationalError('config', 'autonomous-cycle', 'autonomous cycle runner failed to start', cause),
-          ),
-        )
-      }
+      const state = yield* Ref.make(initialState(broker))
       yield* Layer.build(
         makeHttpLayer(config, state, strategy.provenance, config.build.verification, evidenceStore.read),
       ).pipe(Effect.mapError((cause) => operationalError('http', 'listen', 'HTTP server failed to listen', cause)))
       yield* initialize(config, state, strategy)
-      yield* monitor(config, state, broker, cycleRunner).pipe(Effect.forkScoped({ startImmediately: true }))
+      yield* monitor(config, state, broker).pipe(Effect.forkScoped({ startImmediately: true }))
       yield* reconciliation
       return yield* Effect.never
     }),

--- a/services/bayn/src/config.test.ts
+++ b/services/bayn/src/config.test.ts
@@ -52,6 +52,13 @@ describe('Effect configuration', () => {
     expect(config.maximumAuthority).toBe(Authority.Observe)
     expect(config.healthIntervalMs).toBe(30_000)
     expect(config.operationTimeoutMs).toBe(30_000)
+    expect(config.cycleStallThresholdMs).toBe(300_000)
+    expect(config.reconciliationStaleThresholdMs).toBe(120_000)
+    expect(config.unknownMutationThresholdMs).toBe(300_000)
+    expect(config.autonomousCycle).toEqual({
+      enabled: false,
+      pollIntervalMs: 30_000,
+    })
     expect(config.alpaca).toBeUndefined()
     expect(config.clickhouse).toMatchObject({
       snapshotId: 'd'.repeat(64),
@@ -135,6 +142,26 @@ describe('Effect configuration', () => {
     })
   })
 
+  test('requires a complete read-only Alpaca binding before enabling the autonomous loop', async () => {
+    const enabled = new Map(runtimeEnvironment)
+    enabled.set('BAYN_AUTONOMOUS_CYCLE_ENABLED', 'true')
+    const error = await Effect.runPromise(Effect.flip(provideEnvironment(loadConfig(buildMetadata), enabled)))
+
+    expect(error).toMatchObject({
+      _tag: 'OperationalError',
+      component: 'config',
+      operation: 'alpaca',
+      message: 'the autonomous cycle loop requires a complete Alpaca account binding',
+    })
+
+    enabled.set('BAYN_ALPACA_ACCOUNT_ID', '61e69015-8549-4bfd-b9c3-01e75843f47d')
+    enabled.set('BAYN_ALPACA_KEY_ID', 'paper-key')
+    enabled.set('BAYN_ALPACA_SECRET_KEY', 'paper-secret')
+    expect(
+      (await Effect.runPromise(provideEnvironment(loadConfig(buildMetadata), enabled))).autonomousCycle.enabled,
+    ).toBe(true)
+  })
+
   test('supports an explicit, visibly unverified development provenance path', async () => {
     const development = new Map(runtimeEnvironment)
     development.set('BAYN_PROVENANCE_MODE', 'development')
@@ -179,6 +206,24 @@ describe('Effect configuration', () => {
       component: 'config',
       operation: 'load',
     })
+  })
+
+  test('keeps operational alert thresholds positive and bounded to one day', async () => {
+    for (const [name, value] of [
+      ['BAYN_CYCLE_STALL_THRESHOLD_MS', '999'],
+      ['BAYN_RECONCILIATION_STALE_THRESHOLD_MS', '86400001'],
+      ['BAYN_UNKNOWN_MUTATION_THRESHOLD_MS', '0'],
+    ] as const) {
+      const invalid = new Map(runtimeEnvironment)
+      invalid.set(name, value)
+
+      const error = await Effect.runPromise(Effect.flip(provideEnvironment(loadConfig(buildMetadata), invalid)))
+      expect(error).toMatchObject({
+        _tag: 'OperationalError',
+        component: 'config',
+        operation: 'load',
+      })
+    }
   })
 
   test('rejects an invalid pinned qualification run ID', async () => {

--- a/services/bayn/src/config.test.ts
+++ b/services/bayn/src/config.test.ts
@@ -55,10 +55,6 @@ describe('Effect configuration', () => {
     expect(config.cycleStallThresholdMs).toBe(300_000)
     expect(config.reconciliationStaleThresholdMs).toBe(120_000)
     expect(config.unknownMutationThresholdMs).toBe(300_000)
-    expect(config.autonomousCycle).toEqual({
-      enabled: false,
-      pollIntervalMs: 30_000,
-    })
     expect(config.alpaca).toBeUndefined()
     expect(config.clickhouse).toMatchObject({
       snapshotId: 'd'.repeat(64),
@@ -140,26 +136,6 @@ describe('Effect configuration', () => {
       operation: 'alpaca',
       message: 'PAPER maximum authority requires a complete Alpaca account binding',
     })
-  })
-
-  test('requires a complete read-only Alpaca binding before enabling the autonomous loop', async () => {
-    const enabled = new Map(runtimeEnvironment)
-    enabled.set('BAYN_AUTONOMOUS_CYCLE_ENABLED', 'true')
-    const error = await Effect.runPromise(Effect.flip(provideEnvironment(loadConfig(buildMetadata), enabled)))
-
-    expect(error).toMatchObject({
-      _tag: 'OperationalError',
-      component: 'config',
-      operation: 'alpaca',
-      message: 'the autonomous cycle loop requires a complete Alpaca account binding',
-    })
-
-    enabled.set('BAYN_ALPACA_ACCOUNT_ID', '61e69015-8549-4bfd-b9c3-01e75843f47d')
-    enabled.set('BAYN_ALPACA_KEY_ID', 'paper-key')
-    enabled.set('BAYN_ALPACA_SECRET_KEY', 'paper-secret')
-    expect(
-      (await Effect.runPromise(provideEnvironment(loadConfig(buildMetadata), enabled))).autonomousCycle.enabled,
-    ).toBe(true)
   })
 
   test('supports an explicit, visibly unverified development provenance path', async () => {

--- a/services/bayn/src/config.ts
+++ b/services/bayn/src/config.ts
@@ -26,6 +26,13 @@ export interface RuntimeConfig {
   readonly build: RuntimeBuildMetadata
   readonly healthIntervalMs: number
   readonly operationTimeoutMs: number
+  readonly cycleStallThresholdMs: number
+  readonly reconciliationStaleThresholdMs: number
+  readonly unknownMutationThresholdMs: number
+  readonly autonomousCycle: {
+    readonly enabled: boolean
+    readonly pollIntervalMs: number
+  }
   readonly alpaca?: {
     readonly accountId: string
     readonly key: Redacted.Redacted<string>
@@ -57,6 +64,7 @@ export interface RuntimeConfig {
 
 const ProvenanceMode = Schema.Literals(['production', 'development'])
 const RetryAttempts = Schema.Int.check(Schema.isBetween({ minimum: 0, maximum: 3 }))
+const OperationalThresholdMs = Schema.Int.check(Schema.isBetween({ minimum: 1_000, maximum: 86_400_000 }))
 const ReplicaAddresses = Schema.Trim.pipe(
   Schema.decodeTo(
     Schema.Array(NonEmptyString).check(Schema.isMinLength(1)),
@@ -78,6 +86,9 @@ const secretString = (name: string) => nonEmptyString(name).pipe(Config.map((val
 const positiveInteger = (name: string, fallback: number) =>
   Config.schema(PositiveInteger, name).pipe(Config.withDefault(fallback))
 
+const operationalThreshold = (name: string, fallback: number) =>
+  Config.schema(OperationalThresholdMs, name).pipe(Config.withDefault(fallback))
+
 const runtimeConfig = Config.all({
   host: nonEmptyString('BAYN_HTTP_HOST').pipe(Config.withDefault('0.0.0.0')),
   port: Config.port('BAYN_HTTP_PORT').pipe(Config.withDefault(8080)),
@@ -93,6 +104,11 @@ const runtimeConfig = Config.all({
   ),
   healthIntervalMs: positiveInteger('BAYN_HEALTH_INTERVAL_MS', 30_000),
   operationTimeoutMs: positiveInteger('BAYN_OPERATION_TIMEOUT_MS', 30_000),
+  cycleStallThresholdMs: operationalThreshold('BAYN_CYCLE_STALL_THRESHOLD_MS', 300_000),
+  reconciliationStaleThresholdMs: operationalThreshold('BAYN_RECONCILIATION_STALE_THRESHOLD_MS', 120_000),
+  unknownMutationThresholdMs: operationalThreshold('BAYN_UNKNOWN_MUTATION_THRESHOLD_MS', 300_000),
+  autonomousCycleEnabled: Config.boolean('BAYN_AUTONOMOUS_CYCLE_ENABLED').pipe(Config.withDefault(false)),
+  autonomousCyclePollIntervalMs: positiveInteger('BAYN_AUTONOMOUS_CYCLE_POLL_INTERVAL_MS', 30_000),
   alpacaAccountId: Config.option(nonEmptyString('BAYN_ALPACA_ACCOUNT_ID')),
   alpacaKey: Config.option(secretString('BAYN_ALPACA_KEY_ID')),
   alpacaSecret: Config.option(secretString('BAYN_ALPACA_SECRET_KEY')),
@@ -136,6 +152,13 @@ const runtimeConfig = Config.all({
     provenanceMode: config.provenanceMode,
     healthIntervalMs: config.healthIntervalMs,
     operationTimeoutMs: config.operationTimeoutMs,
+    cycleStallThresholdMs: config.cycleStallThresholdMs,
+    reconciliationStaleThresholdMs: config.reconciliationStaleThresholdMs,
+    unknownMutationThresholdMs: config.unknownMutationThresholdMs,
+    autonomousCycle: {
+      enabled: config.autonomousCycleEnabled,
+      pollIntervalMs: config.autonomousCyclePollIntervalMs,
+    },
     configuredAlpaca: {
       accountId: config.alpacaAccountId,
       key: config.alpacaKey,
@@ -216,6 +239,11 @@ export const loadConfig = (
       if (config.maximumAuthority === Authority.Paper && Option.isNone(alpaca)) {
         return Effect.fail(
           operationalError('config', 'alpaca', 'PAPER maximum authority requires a complete Alpaca account binding'),
+        )
+      }
+      if (config.autonomousCycle.enabled && Option.isNone(alpaca)) {
+        return Effect.fail(
+          operationalError('config', 'alpaca', 'the autonomous cycle loop requires a complete Alpaca account binding'),
         )
       }
       const { configuredAlpaca: _configuredAlpaca, ...runtime } = config

--- a/services/bayn/src/config.ts
+++ b/services/bayn/src/config.ts
@@ -29,10 +29,6 @@ export interface RuntimeConfig {
   readonly cycleStallThresholdMs: number
   readonly reconciliationStaleThresholdMs: number
   readonly unknownMutationThresholdMs: number
-  readonly autonomousCycle: {
-    readonly enabled: boolean
-    readonly pollIntervalMs: number
-  }
   readonly alpaca?: {
     readonly accountId: string
     readonly key: Redacted.Redacted<string>
@@ -107,8 +103,6 @@ const runtimeConfig = Config.all({
   cycleStallThresholdMs: operationalThreshold('BAYN_CYCLE_STALL_THRESHOLD_MS', 300_000),
   reconciliationStaleThresholdMs: operationalThreshold('BAYN_RECONCILIATION_STALE_THRESHOLD_MS', 120_000),
   unknownMutationThresholdMs: operationalThreshold('BAYN_UNKNOWN_MUTATION_THRESHOLD_MS', 300_000),
-  autonomousCycleEnabled: Config.boolean('BAYN_AUTONOMOUS_CYCLE_ENABLED').pipe(Config.withDefault(false)),
-  autonomousCyclePollIntervalMs: positiveInteger('BAYN_AUTONOMOUS_CYCLE_POLL_INTERVAL_MS', 30_000),
   alpacaAccountId: Config.option(nonEmptyString('BAYN_ALPACA_ACCOUNT_ID')),
   alpacaKey: Config.option(secretString('BAYN_ALPACA_KEY_ID')),
   alpacaSecret: Config.option(secretString('BAYN_ALPACA_SECRET_KEY')),
@@ -155,10 +149,6 @@ const runtimeConfig = Config.all({
     cycleStallThresholdMs: config.cycleStallThresholdMs,
     reconciliationStaleThresholdMs: config.reconciliationStaleThresholdMs,
     unknownMutationThresholdMs: config.unknownMutationThresholdMs,
-    autonomousCycle: {
-      enabled: config.autonomousCycleEnabled,
-      pollIntervalMs: config.autonomousCyclePollIntervalMs,
-    },
     configuredAlpaca: {
       accountId: config.alpacaAccountId,
       key: config.alpacaKey,
@@ -239,11 +229,6 @@ export const loadConfig = (
       if (config.maximumAuthority === Authority.Paper && Option.isNone(alpaca)) {
         return Effect.fail(
           operationalError('config', 'alpaca', 'PAPER maximum authority requires a complete Alpaca account binding'),
-        )
-      }
-      if (config.autonomousCycle.enabled && Option.isNone(alpaca)) {
-        return Effect.fail(
-          operationalError('config', 'alpaca', 'the autonomous cycle loop requires a complete Alpaca account binding'),
         )
       }
       const { configuredAlpaca: _configuredAlpaca, ...runtime } = config

--- a/services/bayn/src/cycle-observability.test.ts
+++ b/services/bayn/src/cycle-observability.test.ts
@@ -224,6 +224,7 @@ describe('autonomous cycle operations classification', () => {
           status: ReconciliationStatus.Exact,
           discrepancyCount: 0,
           reconciledAt: now,
+          coversLatestMutation: true,
         },
       }),
       Date.parse(now),
@@ -277,7 +278,7 @@ describe('autonomous cycle operations classification', () => {
     })
   })
 
-  test('requires PAPER reconciliation at or after the latest selected-account mutation', () => {
+  test('requires PAPER reconciliation to cover the latest selected-account mutation', () => {
     const authority = {
       maximum: Authority.Paper,
       effective: Authority.Paper,
@@ -286,7 +287,7 @@ describe('autonomous cycle operations classification', () => {
       updatedAt: now,
     } as const
     const latestOccurredAt = '2026-07-20T11:59:00.000Z'
-    const input = (reconciledAt: string) =>
+    const input = (coversLatestMutation: boolean) =>
       projection({
         authority,
         reconciliation: {
@@ -294,7 +295,8 @@ describe('autonomous cycle operations classification', () => {
           reconciliationId: '8'.repeat(64),
           status: ReconciliationStatus.Exact,
           discrepancyCount: 0,
-          reconciledAt,
+          reconciledAt: latestOccurredAt,
+          coversLatestMutation,
         },
         mutations: {
           eventCount: 2,
@@ -303,13 +305,8 @@ describe('autonomous cycle operations classification', () => {
           latestOccurredAt,
         },
       })
-    const covered = deriveCycleOperationsStatus(input(latestOccurredAt), Date.parse(now), Authority.Paper, thresholds)
-    const predates = deriveCycleOperationsStatus(
-      input('2026-07-20T11:58:59.999Z'),
-      Date.parse(now),
-      Authority.Paper,
-      thresholds,
-    )
+    const covered = deriveCycleOperationsStatus(input(true), Date.parse(now), Authority.Paper, thresholds)
+    const predates = deriveCycleOperationsStatus(input(false), Date.parse(now), Authority.Paper, thresholds)
 
     expect(covered).toMatchObject({
       condition: CycleOperationsCondition.Waiting,
@@ -342,6 +339,7 @@ describe('autonomous cycle operations classification', () => {
           status: ReconciliationStatus.Discrepancy,
           discrepancyCount: 1,
           reconciledAt: now,
+          coversLatestMutation: true,
         },
       }),
       Date.parse(now),
@@ -357,6 +355,7 @@ describe('autonomous cycle operations classification', () => {
           status: ReconciliationStatus.Exact,
           discrepancyCount: 0,
           reconciledAt: '2026-07-20T11:58:00.000Z',
+          coversLatestMutation: true,
         },
       }),
       Date.parse(now),

--- a/services/bayn/src/cycle-observability.test.ts
+++ b/services/bayn/src/cycle-observability.test.ts
@@ -1,0 +1,330 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  CycleOperationsCondition,
+  CycleOperationsReason,
+  deriveCycleOperationsStatus,
+  type CycleOperationsProjection,
+  type CycleOperationsSnapshot,
+} from './cycle-observability'
+import { CycleState, CycleTerminalReason } from './cycle'
+import { Authority, KillState, ReconciliationStatus } from './paper'
+
+const now = '2026-07-20T12:00:00.000Z'
+const thresholds = {
+  cycleStallThresholdMs: 300_000,
+  reconciliationStaleThresholdMs: 120_000,
+  unknownMutationThresholdMs: 300_000,
+}
+
+const snapshot = (phase: CycleState, overrides: Partial<CycleOperationsSnapshot> = {}): CycleOperationsSnapshot => ({
+  cycleId: '1'.repeat(64),
+  accountId: 'paper-account-1',
+  signalSessionDate: '2026-07-17',
+  executionSessionDate: '2026-07-20',
+  phase,
+  snapshotId: phase === CycleState.Pending ? null : '2'.repeat(64),
+  decisionHash: phase === CycleState.Completed || phase === CycleState.NoTrade ? '3'.repeat(64) : null,
+  terminalReason: phase === CycleState.Blocked ? CycleTerminalReason.DataStale : null,
+  submissionOpenAt: '2026-07-20T11:30:00.000Z',
+  submissionCutoffAt: '2026-07-20T12:30:00.000Z',
+  executionOpenAt: '2026-07-20T12:32:00.000Z',
+  executionCloseAt: '2026-07-20T20:00:00.000Z',
+  createdAt: '2026-07-20T11:29:00.000Z',
+  updatedAt: '2026-07-20T11:59:00.000Z',
+  terminalAt:
+    phase === CycleState.Completed || phase === CycleState.NoTrade || phase === CycleState.Blocked
+      ? '2026-07-20T11:59:00.000Z'
+      : null,
+  ...overrides,
+})
+
+const projection = (overrides: Partial<CycleOperationsProjection> = {}): CycleOperationsProjection => ({
+  current: null,
+  last: null,
+  unfinishedCycleCount: 0,
+  authority: null,
+  reconciliation: null,
+  mutations: { eventCount: 0, unresolvedCount: 0, oldestUnresolvedAt: null },
+  ...overrides,
+})
+
+describe('autonomous cycle operations classification', () => {
+  test('distinguishes expected publication waiting from exact deadline and attempt stalls', () => {
+    const pending = snapshot(CycleState.Pending, {
+      submissionOpenAt: '2026-07-20T12:00:00.000Z',
+      updatedAt: '2026-07-20T11:00:00.000Z',
+    })
+    const waiting = deriveCycleOperationsStatus(
+      projection({ current: pending, unfinishedCycleCount: 1 }),
+      Date.parse('2026-07-20T11:59:59.999Z'),
+      Authority.Observe,
+      thresholds,
+    )
+    const missed = deriveCycleOperationsStatus(
+      projection({ current: pending, unfinishedCycleCount: 1 }),
+      Date.parse(pending.submissionOpenAt),
+      Authority.Observe,
+      thresholds,
+    )
+    const boundPending = snapshot(CycleState.Pending, {
+      snapshotId: '2'.repeat(64),
+      submissionOpenAt: '2026-07-20T11:55:00.000Z',
+      updatedAt: '2026-07-20T11:55:00.000Z',
+    })
+    const stale = deriveCycleOperationsStatus(
+      projection({ current: boundPending, unfinishedCycleCount: 1 }),
+      Date.parse(now),
+      Authority.Observe,
+      thresholds,
+    )
+
+    expect(waiting).toMatchObject({
+      condition: CycleOperationsCondition.Waiting,
+      reason: CycleOperationsReason.AwaitingSignalPublication,
+    })
+    expect(missed).toMatchObject({
+      condition: CycleOperationsCondition.Stalled,
+      reason: CycleOperationsReason.MissedPublicationDeadline,
+      alerts: { cycleStalled: true },
+    })
+    expect(stale).toMatchObject({
+      condition: CycleOperationsCondition.Stalled,
+      reason: CycleOperationsReason.AttemptStale,
+      attemptAgeMs: 300_000,
+    })
+  })
+
+  test('keeps snapshot-bound PENDING expected before submission opens', () => {
+    const pending = snapshot(CycleState.Pending, {
+      snapshotId: '2'.repeat(64),
+      submissionOpenAt: '2026-07-20T12:05:00.000Z',
+      submissionCutoffAt: '2026-07-20T12:30:00.000Z',
+      updatedAt: '2026-07-20T11:00:00.000Z',
+    })
+    const beforeOpen = deriveCycleOperationsStatus(
+      projection({ current: pending, unfinishedCycleCount: 1 }),
+      Date.parse(now),
+      Authority.Observe,
+      thresholds,
+    )
+    const atOpen = deriveCycleOperationsStatus(
+      projection({ current: pending, unfinishedCycleCount: 1 }),
+      Date.parse(pending.submissionOpenAt),
+      Authority.Observe,
+      thresholds,
+    )
+
+    expect(beforeOpen).toMatchObject({
+      condition: CycleOperationsCondition.Waiting,
+      reason: CycleOperationsReason.AwaitingSubmissionOpen,
+      attemptAgeMs: 3_600_000,
+      alerts: { cycleStalled: false },
+    })
+    expect(atOpen).toMatchObject({
+      condition: CycleOperationsCondition.Running,
+      reason: CycleOperationsReason.AwaitingActivation,
+      alerts: { cycleStalled: false },
+    })
+  })
+
+  test('keeps ACTIVE healthy after cutoff through execution close and stalls exactly at close', () => {
+    const active = snapshot(CycleState.Active, {
+      submissionCutoffAt: '2026-07-20T11:58:00.000Z',
+      executionOpenAt: '2026-07-20T12:00:00.000Z',
+      executionCloseAt: '2026-07-20T20:00:00.000Z',
+      updatedAt: '2026-07-20T11:57:00.000Z',
+    })
+    const afterCutoff = deriveCycleOperationsStatus(
+      projection({ current: active, unfinishedCycleCount: 1 }),
+      Date.parse(now),
+      Authority.Observe,
+      thresholds,
+    )
+    const atClose = deriveCycleOperationsStatus(
+      projection({ current: active, unfinishedCycleCount: 1 }),
+      Date.parse(active.executionCloseAt),
+      Authority.Observe,
+      thresholds,
+    )
+
+    expect(afterCutoff).toMatchObject({
+      condition: CycleOperationsCondition.Running,
+      reason: CycleOperationsReason.Active,
+      alerts: { cycleStalled: false },
+    })
+    expect(atClose).toMatchObject({
+      condition: CycleOperationsCondition.Stalled,
+      reason: CycleOperationsReason.MissedExecutionClose,
+      alerts: { cycleStalled: true },
+    })
+  })
+
+  test('keeps a blocked terminal result failed through a later attempt and clears on confirmed terminal success', () => {
+    const blocked = snapshot(CycleState.Blocked)
+    const recovering = deriveCycleOperationsStatus(
+      projection({
+        current: snapshot(CycleState.Active, {
+          cycleId: '4'.repeat(64),
+          signalSessionDate: '2026-07-20',
+          executionSessionDate: '2026-07-21',
+          submissionOpenAt: '2026-07-20T12:00:00.000Z',
+          submissionCutoffAt: '2026-07-20T12:30:00.000Z',
+          executionOpenAt: '2026-07-20T12:32:00.000Z',
+          executionCloseAt: '2026-07-20T20:00:00.000Z',
+          updatedAt: '2026-07-20T11:59:59.000Z',
+        }),
+        last: blocked,
+        unfinishedCycleCount: 1,
+      }),
+      Date.parse(now),
+      Authority.Observe,
+      thresholds,
+    )
+    const recovered = deriveCycleOperationsStatus(
+      projection({
+        last: snapshot(CycleState.Completed, {
+          cycleId: '4'.repeat(64),
+          updatedAt: now,
+          terminalAt: now,
+        }),
+      }),
+      Date.parse(now),
+      Authority.Observe,
+      thresholds,
+    )
+
+    expect(recovering).toMatchObject({
+      condition: CycleOperationsCondition.Failed,
+      reason: CycleOperationsReason.LastCycleBlocked,
+      alerts: { cycleFailed: true },
+    })
+    expect(recovered).toMatchObject({
+      condition: CycleOperationsCondition.Waiting,
+      reason: CycleOperationsReason.LastCycleCompleted,
+      alerts: { cycleFailed: false, cycleStalled: false },
+    })
+  })
+
+  test('keeps OBSERVE credential-free while PAPER requires coherent durable authority and reconciliation', () => {
+    const observe = deriveCycleOperationsStatus(projection(), Date.parse(now), Authority.Observe, thresholds)
+    const missingPaper = deriveCycleOperationsStatus(projection(), Date.parse(now), Authority.Paper, thresholds)
+    const readyPaper = deriveCycleOperationsStatus(
+      projection({
+        authority: {
+          maximum: Authority.Paper,
+          effective: Authority.Observe,
+          kill: KillState.Clear,
+          reason: null,
+          updatedAt: now,
+        },
+        reconciliation: {
+          accountId: 'paper-account-1',
+          reconciliationId: '5'.repeat(64),
+          status: ReconciliationStatus.Exact,
+          discrepancyCount: 0,
+          reconciledAt: now,
+        },
+      }),
+      Date.parse(now),
+      Authority.Paper,
+      thresholds,
+    )
+
+    expect(observe).toMatchObject({
+      condition: CycleOperationsCondition.Waiting,
+      reason: CycleOperationsReason.NoCycleRecorded,
+      authority: null,
+    })
+    expect(missingPaper).toMatchObject({
+      condition: CycleOperationsCondition.Failed,
+      reason: CycleOperationsReason.AuthorityMissing,
+      alerts: { authorityIncoherent: true },
+    })
+    expect(readyPaper).toMatchObject({
+      condition: CycleOperationsCondition.Waiting,
+      reason: CycleOperationsReason.NoCycleRecorded,
+      alerts: { authorityIncoherent: false, reconciliationBlocked: false },
+    })
+  })
+
+  test('fails unresolved mutation immediately and raises its stale alert at the exact threshold', () => {
+    const unresolved = projection({
+      mutations: {
+        eventCount: 1,
+        unresolvedCount: 1,
+        oldestUnresolvedAt: '2026-07-20T11:55:00.000Z',
+      },
+    })
+    const before = deriveCycleOperationsStatus(
+      unresolved,
+      Date.parse('2026-07-20T11:59:59.999Z'),
+      Authority.Observe,
+      thresholds,
+    )
+    const atThreshold = deriveCycleOperationsStatus(unresolved, Date.parse(now), Authority.Observe, thresholds)
+
+    expect(before).toMatchObject({
+      condition: CycleOperationsCondition.Failed,
+      reason: CycleOperationsReason.UnresolvedMutation,
+      zeroMutation: false,
+      alerts: { cycleFailed: true, unknownMutationStale: false },
+    })
+    expect(atThreshold).toMatchObject({
+      oldestUnresolvedMutationAgeMs: 300_000,
+      alerts: { unknownMutationStale: true },
+    })
+  })
+
+  test('blocks PAPER on discrepancy and exact reconciliation staleness boundaries', () => {
+    const authority = {
+      maximum: Authority.Paper,
+      effective: Authority.Paper,
+      kill: KillState.Clear,
+      reason: null,
+      updatedAt: now,
+    } as const
+    const discrepancy = deriveCycleOperationsStatus(
+      projection({
+        authority,
+        reconciliation: {
+          accountId: 'paper-account-1',
+          reconciliationId: '6'.repeat(64),
+          status: ReconciliationStatus.Discrepancy,
+          discrepancyCount: 1,
+          reconciledAt: now,
+        },
+      }),
+      Date.parse(now),
+      Authority.Paper,
+      thresholds,
+    )
+    const stale = deriveCycleOperationsStatus(
+      projection({
+        authority,
+        reconciliation: {
+          accountId: 'paper-account-1',
+          reconciliationId: '7'.repeat(64),
+          status: ReconciliationStatus.Exact,
+          discrepancyCount: 0,
+          reconciledAt: '2026-07-20T11:58:00.000Z',
+        },
+      }),
+      Date.parse(now),
+      Authority.Paper,
+      thresholds,
+    )
+
+    expect(discrepancy).toMatchObject({
+      condition: CycleOperationsCondition.Failed,
+      reason: CycleOperationsReason.ReconciliationDiscrepancy,
+      alerts: { reconciliationBlocked: true },
+    })
+    expect(stale).toMatchObject({
+      condition: CycleOperationsCondition.Failed,
+      reason: CycleOperationsReason.ReconciliationStale,
+      reconciliationAgeMs: 120_000,
+      alerts: { reconciliationBlocked: true },
+    })
+  })
+})

--- a/services/bayn/src/cycle-observability.test.ts
+++ b/services/bayn/src/cycle-observability.test.ts
@@ -45,7 +45,7 @@ const projection = (overrides: Partial<CycleOperationsProjection> = {}): CycleOp
   unfinishedCycleCount: 0,
   authority: null,
   reconciliation: null,
-  mutations: { eventCount: 0, unresolvedCount: 0, oldestUnresolvedAt: null },
+  mutations: { eventCount: 0, unresolvedCount: 0, oldestUnresolvedAt: null, latestOccurredAt: null },
   ...overrides,
 })
 
@@ -254,6 +254,7 @@ describe('autonomous cycle operations classification', () => {
         eventCount: 1,
         unresolvedCount: 1,
         oldestUnresolvedAt: '2026-07-20T11:55:00.000Z',
+        latestOccurredAt: '2026-07-20T11:55:00.000Z',
       },
     })
     const before = deriveCycleOperationsStatus(
@@ -273,6 +274,54 @@ describe('autonomous cycle operations classification', () => {
     expect(atThreshold).toMatchObject({
       oldestUnresolvedMutationAgeMs: 300_000,
       alerts: { unknownMutationStale: true },
+    })
+  })
+
+  test('requires PAPER reconciliation at or after the latest selected-account mutation', () => {
+    const authority = {
+      maximum: Authority.Paper,
+      effective: Authority.Paper,
+      kill: KillState.Clear,
+      reason: null,
+      updatedAt: now,
+    } as const
+    const latestOccurredAt = '2026-07-20T11:59:00.000Z'
+    const input = (reconciledAt: string) =>
+      projection({
+        authority,
+        reconciliation: {
+          accountId: 'paper-account-1',
+          reconciliationId: '8'.repeat(64),
+          status: ReconciliationStatus.Exact,
+          discrepancyCount: 0,
+          reconciledAt,
+        },
+        mutations: {
+          eventCount: 2,
+          unresolvedCount: 0,
+          oldestUnresolvedAt: null,
+          latestOccurredAt,
+        },
+      })
+    const covered = deriveCycleOperationsStatus(input(latestOccurredAt), Date.parse(now), Authority.Paper, thresholds)
+    const predates = deriveCycleOperationsStatus(
+      input('2026-07-20T11:58:59.999Z'),
+      Date.parse(now),
+      Authority.Paper,
+      thresholds,
+    )
+
+    expect(covered).toMatchObject({
+      condition: CycleOperationsCondition.Waiting,
+      reason: CycleOperationsReason.NoCycleRecorded,
+      reconciliationCoversLatestMutation: true,
+      alerts: { reconciliationBlocked: false },
+    })
+    expect(predates).toMatchObject({
+      condition: CycleOperationsCondition.Failed,
+      reason: CycleOperationsReason.ReconciliationPredatesMutation,
+      reconciliationCoversLatestMutation: false,
+      alerts: { reconciliationBlocked: true },
     })
   })
 

--- a/services/bayn/src/cycle-observability.ts
+++ b/services/bayn/src/cycle-observability.ts
@@ -1,0 +1,275 @@
+import { Authority, KillState, ReconciliationStatus } from './paper'
+import { CycleState, type CycleTerminalReason } from './cycle'
+
+export interface CycleOperationsThresholds {
+  readonly cycleStallThresholdMs: number
+  readonly reconciliationStaleThresholdMs: number
+  readonly unknownMutationThresholdMs: number
+}
+
+export interface CycleOperationsSnapshot {
+  readonly cycleId: string
+  readonly accountId: string
+  readonly signalSessionDate: string
+  readonly executionSessionDate: string
+  readonly phase: CycleState
+  readonly snapshotId: string | null
+  readonly decisionHash: string | null
+  readonly terminalReason: CycleTerminalReason | null
+  readonly submissionOpenAt: string
+  readonly submissionCutoffAt: string
+  readonly executionOpenAt: string
+  readonly executionCloseAt: string
+  readonly createdAt: string
+  readonly updatedAt: string
+  readonly terminalAt: string | null
+}
+
+export interface DurableAuthorityObservation {
+  readonly maximum: Authority
+  readonly effective: Authority
+  readonly kill: KillState
+  readonly reason: string | null
+  readonly updatedAt: string
+}
+
+export interface ReconciliationObservation {
+  readonly accountId: string
+  readonly reconciliationId: string
+  readonly status: ReconciliationStatus
+  readonly discrepancyCount: number
+  readonly reconciledAt: string
+}
+
+export interface MutationObservation {
+  readonly eventCount: number
+  readonly unresolvedCount: number
+  readonly oldestUnresolvedAt: string | null
+}
+
+export interface CycleOperationsProjection {
+  readonly current: CycleOperationsSnapshot | null
+  readonly last: CycleOperationsSnapshot | null
+  readonly unfinishedCycleCount: number
+  readonly authority: DurableAuthorityObservation | null
+  readonly reconciliation: ReconciliationObservation | null
+  readonly mutations: MutationObservation
+}
+
+export enum CycleOperationsCondition {
+  Unknown = 'UNKNOWN',
+  Waiting = 'WAITING',
+  Running = 'RUNNING',
+  Stalled = 'STALLED',
+  Failed = 'FAILED',
+}
+
+export enum CycleOperationsReason {
+  ObservationUnavailable = 'OBSERVATION_UNAVAILABLE',
+  NoCycleRecorded = 'NO_CYCLE_RECORDED',
+  AwaitingSignalPublication = 'AWAITING_SIGNAL_PUBLICATION',
+  AwaitingSubmissionOpen = 'AWAITING_SUBMISSION_OPEN',
+  AwaitingActivation = 'AWAITING_ACTIVATION',
+  Active = 'ACTIVE',
+  LastCycleCompleted = 'LAST_CYCLE_COMPLETED',
+  LastCycleNoTrade = 'LAST_CYCLE_NO_TRADE',
+  LastCycleBlocked = 'LAST_CYCLE_BLOCKED',
+  MissedPublicationDeadline = 'MISSED_PUBLICATION_DEADLINE',
+  MissedSubmissionCutoff = 'MISSED_SUBMISSION_CUTOFF',
+  MissedExecutionClose = 'MISSED_EXECUTION_CLOSE',
+  AttemptStale = 'ATTEMPT_STALE',
+  MultipleUnfinishedCycles = 'MULTIPLE_UNFINISHED_CYCLES',
+  AuthorityMissing = 'AUTHORITY_MISSING',
+  AuthorityMaximumMismatch = 'AUTHORITY_MAXIMUM_MISMATCH',
+  KillActive = 'KILL_ACTIVE',
+  UnresolvedMutation = 'UNRESOLVED_MUTATION',
+  ReconciliationMissing = 'RECONCILIATION_MISSING',
+  ReconciliationDiscrepancy = 'RECONCILIATION_DISCREPANCY',
+  ReconciliationStale = 'RECONCILIATION_STALE',
+}
+
+export interface CycleOperationsAlerts {
+  readonly cycleStalled: boolean
+  readonly cycleFailed: boolean
+  readonly unknownMutationStale: boolean
+  readonly reconciliationBlocked: boolean
+  readonly killActive: boolean
+  readonly authorityIncoherent: boolean
+}
+
+export interface CycleOperationsStatus extends CycleOperationsProjection {
+  readonly schemaVersion: 'bayn.cycle-operations-status.v1'
+  readonly condition: CycleOperationsCondition
+  readonly reason: CycleOperationsReason
+  readonly checkedAt: string | null
+  readonly attemptAgeMs: number | null
+  readonly oldestUnresolvedMutationAgeMs: number | null
+  readonly reconciliationAgeMs: number | null
+  readonly zeroMutation: boolean | null
+  readonly alerts: CycleOperationsAlerts
+  readonly error: string | null
+}
+
+const ageAt = (instant: string | null, nowMs: number): number | null =>
+  instant === null ? null : Math.max(0, nowMs - Date.parse(instant))
+
+const initialProjection = (): CycleOperationsProjection => ({
+  current: null,
+  last: null,
+  unfinishedCycleCount: 0,
+  authority: null,
+  reconciliation: null,
+  mutations: {
+    eventCount: 0,
+    unresolvedCount: 0,
+    oldestUnresolvedAt: null,
+  },
+})
+
+export const unknownCycleOperationsStatus = (error: string | null = null): CycleOperationsStatus => ({
+  schemaVersion: 'bayn.cycle-operations-status.v1',
+  ...initialProjection(),
+  condition: CycleOperationsCondition.Unknown,
+  reason: CycleOperationsReason.ObservationUnavailable,
+  checkedAt: null,
+  attemptAgeMs: null,
+  oldestUnresolvedMutationAgeMs: null,
+  reconciliationAgeMs: null,
+  zeroMutation: null,
+  alerts: {
+    cycleStalled: false,
+    cycleFailed: false,
+    unknownMutationStale: false,
+    reconciliationBlocked: false,
+    killActive: false,
+    authorityIncoherent: false,
+  },
+  error,
+})
+
+const lifecycleCondition = (
+  projection: CycleOperationsProjection,
+  nowMs: number,
+  cycleStallThresholdMs: number,
+): readonly [CycleOperationsCondition, CycleOperationsReason] => {
+  if (projection.last?.phase === CycleState.Blocked) {
+    return [CycleOperationsCondition.Failed, CycleOperationsReason.LastCycleBlocked]
+  }
+
+  const current = projection.current
+  if (current === null) {
+    if (projection.last?.phase === CycleState.Completed) {
+      return [CycleOperationsCondition.Waiting, CycleOperationsReason.LastCycleCompleted]
+    }
+    if (projection.last?.phase === CycleState.NoTrade) {
+      return [CycleOperationsCondition.Waiting, CycleOperationsReason.LastCycleNoTrade]
+    }
+    return [CycleOperationsCondition.Waiting, CycleOperationsReason.NoCycleRecorded]
+  }
+
+  if (current.phase === CycleState.Pending) {
+    if (nowMs >= Date.parse(current.submissionCutoffAt)) {
+      return [CycleOperationsCondition.Stalled, CycleOperationsReason.MissedSubmissionCutoff]
+    }
+    if (current.snapshotId === null) {
+      return nowMs >= Date.parse(current.submissionOpenAt)
+        ? [CycleOperationsCondition.Stalled, CycleOperationsReason.MissedPublicationDeadline]
+        : [CycleOperationsCondition.Waiting, CycleOperationsReason.AwaitingSignalPublication]
+    }
+    if (nowMs < Date.parse(current.submissionOpenAt)) {
+      return [CycleOperationsCondition.Waiting, CycleOperationsReason.AwaitingSubmissionOpen]
+    }
+    const progressStartedAt = Math.max(Date.parse(current.updatedAt), Date.parse(current.submissionOpenAt))
+    if (nowMs - progressStartedAt >= cycleStallThresholdMs) {
+      return [CycleOperationsCondition.Stalled, CycleOperationsReason.AttemptStale]
+    }
+    return [CycleOperationsCondition.Running, CycleOperationsReason.AwaitingActivation]
+  }
+
+  if (current.phase === CycleState.Active) {
+    if (nowMs >= Date.parse(current.executionCloseAt)) {
+      return [CycleOperationsCondition.Stalled, CycleOperationsReason.MissedExecutionClose]
+    }
+    return [CycleOperationsCondition.Running, CycleOperationsReason.Active]
+  }
+
+  return [CycleOperationsCondition.Failed, CycleOperationsReason.MultipleUnfinishedCycles]
+}
+
+export const deriveCycleOperationsStatus = (
+  projection: CycleOperationsProjection,
+  nowMs: number,
+  maximumAuthority: Authority,
+  thresholds: CycleOperationsThresholds,
+): CycleOperationsStatus => {
+  const checkedAt = new Date(nowMs).toISOString()
+  const attemptAgeMs = ageAt(projection.current?.updatedAt ?? null, nowMs)
+  const oldestUnresolvedMutationAgeMs = ageAt(projection.mutations.oldestUnresolvedAt, nowMs)
+  const reconciliationAgeMs = ageAt(projection.reconciliation?.reconciledAt ?? null, nowMs)
+  const authorityMissing = maximumAuthority === Authority.Paper && projection.authority === null
+  const authorityMaximumMismatch = projection.authority !== null && projection.authority.maximum !== maximumAuthority
+  const authorityIncoherent = authorityMissing || authorityMaximumMismatch
+  const killActive = projection.authority?.kill === KillState.Active
+  const reconciliationMissing = maximumAuthority === Authority.Paper && projection.reconciliation === null
+  const reconciliationDiscrepancy = projection.reconciliation?.status === ReconciliationStatus.Discrepancy
+  const reconciliationStale =
+    maximumAuthority === Authority.Paper &&
+    reconciliationAgeMs !== null &&
+    reconciliationAgeMs >= thresholds.reconciliationStaleThresholdMs
+  const reconciliationBlocked = reconciliationMissing || reconciliationDiscrepancy || reconciliationStale
+  const unknownMutationStale =
+    projection.mutations.unresolvedCount > 0 &&
+    oldestUnresolvedMutationAgeMs !== null &&
+    oldestUnresolvedMutationAgeMs >= thresholds.unknownMutationThresholdMs
+
+  let condition: CycleOperationsCondition
+  let reason: CycleOperationsReason
+  if (projection.unfinishedCycleCount > 1) {
+    condition = CycleOperationsCondition.Failed
+    reason = CycleOperationsReason.MultipleUnfinishedCycles
+  } else if (authorityMissing) {
+    condition = CycleOperationsCondition.Failed
+    reason = CycleOperationsReason.AuthorityMissing
+  } else if (authorityMaximumMismatch) {
+    condition = CycleOperationsCondition.Failed
+    reason = CycleOperationsReason.AuthorityMaximumMismatch
+  } else if (killActive) {
+    condition = CycleOperationsCondition.Failed
+    reason = CycleOperationsReason.KillActive
+  } else if (projection.mutations.unresolvedCount > 0) {
+    condition = CycleOperationsCondition.Failed
+    reason = CycleOperationsReason.UnresolvedMutation
+  } else if (reconciliationMissing) {
+    condition = CycleOperationsCondition.Failed
+    reason = CycleOperationsReason.ReconciliationMissing
+  } else if (reconciliationDiscrepancy) {
+    condition = CycleOperationsCondition.Failed
+    reason = CycleOperationsReason.ReconciliationDiscrepancy
+  } else if (reconciliationStale) {
+    condition = CycleOperationsCondition.Failed
+    reason = CycleOperationsReason.ReconciliationStale
+  } else {
+    ;[condition, reason] = lifecycleCondition(projection, nowMs, thresholds.cycleStallThresholdMs)
+  }
+
+  return {
+    schemaVersion: 'bayn.cycle-operations-status.v1',
+    ...projection,
+    condition,
+    reason,
+    checkedAt,
+    attemptAgeMs,
+    oldestUnresolvedMutationAgeMs,
+    reconciliationAgeMs,
+    zeroMutation: projection.mutations.eventCount === 0,
+    alerts: {
+      cycleStalled: condition === CycleOperationsCondition.Stalled,
+      cycleFailed: condition === CycleOperationsCondition.Failed,
+      unknownMutationStale,
+      reconciliationBlocked,
+      killActive,
+      authorityIncoherent,
+    },
+    error: null,
+  }
+}

--- a/services/bayn/src/cycle-observability.ts
+++ b/services/bayn/src/cycle-observability.ts
@@ -45,6 +45,7 @@ export interface MutationObservation {
   readonly eventCount: number
   readonly unresolvedCount: number
   readonly oldestUnresolvedAt: string | null
+  readonly latestOccurredAt: string | null
 }
 
 export interface CycleOperationsProjection {
@@ -85,6 +86,7 @@ export enum CycleOperationsReason {
   UnresolvedMutation = 'UNRESOLVED_MUTATION',
   ReconciliationMissing = 'RECONCILIATION_MISSING',
   ReconciliationDiscrepancy = 'RECONCILIATION_DISCREPANCY',
+  ReconciliationPredatesMutation = 'RECONCILIATION_PREDATES_MUTATION',
   ReconciliationStale = 'RECONCILIATION_STALE',
 }
 
@@ -105,6 +107,7 @@ export interface CycleOperationsStatus extends CycleOperationsProjection {
   readonly attemptAgeMs: number | null
   readonly oldestUnresolvedMutationAgeMs: number | null
   readonly reconciliationAgeMs: number | null
+  readonly reconciliationCoversLatestMutation: boolean | null
   readonly zeroMutation: boolean | null
   readonly alerts: CycleOperationsAlerts
   readonly error: string | null
@@ -123,6 +126,7 @@ const initialProjection = (): CycleOperationsProjection => ({
     eventCount: 0,
     unresolvedCount: 0,
     oldestUnresolvedAt: null,
+    latestOccurredAt: null,
   },
 })
 
@@ -135,6 +139,7 @@ export const unknownCycleOperationsStatus = (error: string | null = null): Cycle
   attemptAgeMs: null,
   oldestUnresolvedMutationAgeMs: null,
   reconciliationAgeMs: null,
+  reconciliationCoversLatestMutation: null,
   zeroMutation: null,
   alerts: {
     cycleStalled: false,
@@ -212,11 +217,19 @@ export const deriveCycleOperationsStatus = (
   const killActive = projection.authority?.kill === KillState.Active
   const reconciliationMissing = maximumAuthority === Authority.Paper && projection.reconciliation === null
   const reconciliationDiscrepancy = projection.reconciliation?.status === ReconciliationStatus.Discrepancy
+  const reconciliationCoversLatestMutation =
+    projection.reconciliation === null
+      ? null
+      : projection.mutations.latestOccurredAt === null ||
+        Date.parse(projection.reconciliation.reconciledAt) >= Date.parse(projection.mutations.latestOccurredAt)
+  const reconciliationPredatesMutation =
+    maximumAuthority === Authority.Paper && reconciliationCoversLatestMutation === false
   const reconciliationStale =
     maximumAuthority === Authority.Paper &&
     reconciliationAgeMs !== null &&
     reconciliationAgeMs >= thresholds.reconciliationStaleThresholdMs
-  const reconciliationBlocked = reconciliationMissing || reconciliationDiscrepancy || reconciliationStale
+  const reconciliationBlocked =
+    reconciliationMissing || reconciliationDiscrepancy || reconciliationPredatesMutation || reconciliationStale
   const unknownMutationStale =
     projection.mutations.unresolvedCount > 0 &&
     oldestUnresolvedMutationAgeMs !== null &&
@@ -245,6 +258,9 @@ export const deriveCycleOperationsStatus = (
   } else if (reconciliationDiscrepancy) {
     condition = CycleOperationsCondition.Failed
     reason = CycleOperationsReason.ReconciliationDiscrepancy
+  } else if (reconciliationPredatesMutation) {
+    condition = CycleOperationsCondition.Failed
+    reason = CycleOperationsReason.ReconciliationPredatesMutation
   } else if (reconciliationStale) {
     condition = CycleOperationsCondition.Failed
     reason = CycleOperationsReason.ReconciliationStale
@@ -261,6 +277,7 @@ export const deriveCycleOperationsStatus = (
     attemptAgeMs,
     oldestUnresolvedMutationAgeMs,
     reconciliationAgeMs,
+    reconciliationCoversLatestMutation,
     zeroMutation: projection.mutations.eventCount === 0,
     alerts: {
       cycleStalled: condition === CycleOperationsCondition.Stalled,

--- a/services/bayn/src/cycle-observability.ts
+++ b/services/bayn/src/cycle-observability.ts
@@ -39,6 +39,7 @@ export interface ReconciliationObservation {
   readonly status: ReconciliationStatus
   readonly discrepancyCount: number
   readonly reconciledAt: string
+  readonly coversLatestMutation: boolean
 }
 
 export interface MutationObservation {
@@ -217,11 +218,7 @@ export const deriveCycleOperationsStatus = (
   const killActive = projection.authority?.kill === KillState.Active
   const reconciliationMissing = maximumAuthority === Authority.Paper && projection.reconciliation === null
   const reconciliationDiscrepancy = projection.reconciliation?.status === ReconciliationStatus.Discrepancy
-  const reconciliationCoversLatestMutation =
-    projection.reconciliation === null
-      ? null
-      : projection.mutations.latestOccurredAt === null ||
-        Date.parse(projection.reconciliation.reconciledAt) >= Date.parse(projection.mutations.latestOccurredAt)
+  const reconciliationCoversLatestMutation = projection.reconciliation?.coversLatestMutation ?? null
   const reconciliationPredatesMutation =
     maximumAuthority === Authority.Paper && reconciliationCoversLatestMutation === false
   const reconciliationStale =

--- a/services/bayn/src/db/cycle-observability.integration.test.ts
+++ b/services/bayn/src/db/cycle-observability.integration.test.ts
@@ -83,7 +83,11 @@ const makeDraft = (dedicatedAccountId = accountId) => {
   return makeCycleDraft(identity, makeCycleWindow(signalSession('2026-03-06'), executionCalendar, executionPolicy))
 }
 
-const seedSafetyState = (maximum = Authority.Observe, effective = Authority.Observe) =>
+const seedSafetyState = (
+  maximum = Authority.Observe,
+  effective = Authority.Observe,
+  reconciledAt = '2026-03-06T21:00:00.000Z',
+) =>
   Effect.gen(function* () {
     const sql = yield* PgClient.PgClient
     yield* sql`
@@ -113,7 +117,7 @@ const seedSafetyState = (maximum = Authority.Observe, effective = Authority.Obse
       ${'1'.repeat(64)},
       'EXACT',
       ${sql.json([])},
-      ${'2026-03-06T21:00:00.000Z'}
+      ${reconciledAt}
     )
   `
   })
@@ -170,9 +174,10 @@ const seedUnresolvedMutation = (mutationAccountId = accountId) =>
   `
   })
 
-const seedAcceptedMutation = Effect.gen(function* () {
-  const sql = yield* PgClient.PgClient
-  yield* sql`
+const seedAcceptedMutation = (occurredAt = '2026-03-06T21:03:00.000Z') =>
+  Effect.gen(function* () {
+    const sql = yield* PgClient.PgClient
+    yield* sql`
     INSERT INTO mutation_events (
       event_id, schema_version, mutation_id, intent_id, sequence, operation,
       event_type, request_hash, consistency_delay_ms, broker_order_id,
@@ -191,10 +196,10 @@ const seedAcceptedMutation = Effect.gen(function* () {
       'broker-request-observability',
       200,
       ${'7'.repeat(64)},
-      ${'2026-03-06T21:03:00.000Z'}
+      ${occurredAt}
     )
   `
-})
+  })
 
 describePostgres('PostgreSQL cycle observability projection', () => {
   let runtime: ReturnType<typeof makeRuntime>
@@ -340,13 +345,13 @@ describePostgres('PostgreSQL cycle observability projection', () => {
     })
   })
 
-  test('keeps PAPER blocked when a resolved mutation is newer than the last exact reconciliation', async () => {
+  test('keeps PAPER blocked when a sub-millisecond resolved mutation follows exact reconciliation', async () => {
     const result = await runtime.runPromise(
       Effect.gen(function* () {
         const observability = yield* CycleObservability
-        yield* seedSafetyState(Authority.Paper, Authority.Paper)
+        yield* seedSafetyState(Authority.Paper, Authority.Paper, '2026-03-06T21:02:00.000000Z')
         yield* seedUnresolvedMutation()
-        yield* seedAcceptedMutation
+        yield* seedAcceptedMutation('2026-03-06T21:02:00.000500Z')
         const projected = yield* observability.read(qualificationRunId, accountId)
         const status = deriveCycleOperationsStatus(projected, Date.parse('2026-03-06T21:03:30.000Z'), Authority.Paper, {
           cycleStallThresholdMs: 300_000,
@@ -361,13 +366,14 @@ describePostgres('PostgreSQL cycle observability projection', () => {
       reconciliation: {
         accountId,
         status: 'EXACT',
-        reconciledAt: '2026-03-06T21:00:00.000Z',
+        reconciledAt: '2026-03-06T21:02:00.000Z',
+        coversLatestMutation: false,
       },
       mutations: {
         eventCount: 2,
         unresolvedCount: 0,
         oldestUnresolvedAt: null,
-        latestOccurredAt: '2026-03-06T21:03:00.000Z',
+        latestOccurredAt: '2026-03-06T21:02:00.000Z',
       },
     })
     expect(result.status).toMatchObject({

--- a/services/bayn/src/db/cycle-observability.integration.test.ts
+++ b/services/bayn/src/db/cycle-observability.integration.test.ts
@@ -1,0 +1,281 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test'
+
+import { NodeServices } from '@effect/platform-node'
+import { PgClient, PgMigrator } from '@effect/sql-pg'
+import { Effect, Layer, ManagedRuntime, Redacted } from 'effect'
+
+import {
+  CycleState,
+  CycleTerminalReason,
+  makeCycleDraft,
+  makeCycleExecutionPolicy,
+  makeCycleIdentity,
+  makeCycleWindow,
+  makeExecutionCalendarObservation,
+} from '../cycle'
+import type { SignalSessionRow } from '../market-data'
+import { Authority, KillState } from '../paper'
+import type { IsoDate } from '../types'
+import { CycleObservability, CycleObservabilityLive } from './cycle-observability'
+import { CycleStore, CycleStoreLive } from './cycle-store'
+import { PostgresClientLive } from './evidence-store'
+import { migrationLoader } from './migrations'
+
+const postgresUrl = process.env.BAYN_TEST_POSTGRES_URL
+const testUrl = postgresUrl ?? 'postgresql://bayn:bayn@127.0.0.1:5432/bayn_test'
+const describePostgres = postgresUrl === undefined ? describe.skip : describe
+const qualificationRunId = 'a'.repeat(64)
+const accountId = 'paper-account-observability'
+const reconciliationId = 'd'.repeat(64)
+const reconciliationHash = 'e'.repeat(64)
+
+const databaseConfig = {
+  operationTimeoutMs: 5_000,
+  postgres: { url: Redacted.make(testUrl), tls: false, caPath: '/unused' },
+}
+
+const makeRuntime = () =>
+  ManagedRuntime.make(
+    Layer.mergeAll(CycleStoreLive, CycleObservabilityLive).pipe(
+      Layer.provideMerge(PostgresClientLive(databaseConfig)),
+      Layer.provideMerge(NodeServices.layer),
+    ),
+  )
+
+const signalSession = (
+  sessionDate: IsoDate,
+): Pick<SignalSessionRow, 'calendar_version' | 'session_date' | 'close_time' | 'timezone'> => ({
+  calendar_version: 'signal-XNYS-2026-v1',
+  session_date: sessionDate,
+  close_time: '16:00',
+  timezone: 'America/New_York',
+})
+
+const makeDraft = () => {
+  const executionPolicy = makeCycleExecutionPolicy({
+    schemaVersion: 'bayn.autonomous-cycle-execution-policy.v1',
+    strategyExecutionModelHash: 'b'.repeat(64),
+    submissionWindowMs: 30 * 60 * 1_000,
+    submissionCutoffBeforeOpenMs: 2 * 60 * 1_000,
+  })
+  const executionCalendar = makeExecutionCalendarObservation({
+    schemaVersion: 'bayn.alpaca-market-calendar-observation.v1',
+    source: 'alpaca-v2-calendar',
+    date: '2026-03-09',
+    openAt: '2026-03-09T13:30:00.000Z',
+    closeAt: '2026-03-09T20:00:00.000Z',
+  })
+  const identity = makeCycleIdentity({
+    schemaVersion: 'bayn.autonomous-cycle-identity.v1',
+    strategyName: 'risk-balanced-trend',
+    qualificationRunId,
+    strategyProtocolHash: 'c'.repeat(64),
+    accountId,
+    signalSessionDate: '2026-03-06',
+    signalCalendarVersion: 'signal-XNYS-2026-v1',
+    executionSessionDate: executionCalendar.executionSessionDate,
+    executionCalendarSchemaVersion: executionCalendar.executionCalendarSchemaVersion,
+    executionCalendarSource: executionCalendar.executionCalendarSource,
+    executionCalendarHash: executionCalendar.executionCalendarHash,
+    executionPolicy,
+  })
+  return makeCycleDraft(identity, makeCycleWindow(signalSession('2026-03-06'), executionCalendar, executionPolicy))
+}
+
+const seedSafetyState = Effect.gen(function* () {
+  const sql = yield* PgClient.PgClient
+  yield* sql`
+    INSERT INTO authority_state (
+      schema_version, generation_hash, maximum, effective, kill_state, reason, version, updated_at
+    ) VALUES (
+      'bayn.paper-authority.v1',
+      ${'f'.repeat(64)},
+      ${Authority.Observe},
+      ${Authority.Observe},
+      ${KillState.Clear},
+      NULL,
+      1,
+      ${'2026-03-06T21:00:00.000Z'}
+    )
+  `
+  yield* sql`
+    INSERT INTO reconciliations (
+      reconciliation_id, schema_version, account_id, expected_hash, observed_hash,
+      content_hash, status, discrepancies, reconciled_at
+    ) VALUES (
+      ${reconciliationId},
+      'bayn.paper-reconciliation.v1',
+      ${accountId},
+      ${reconciliationHash},
+      ${reconciliationHash},
+      ${'1'.repeat(64)},
+      'EXACT',
+      ${sql.json([])},
+      ${'2026-03-06T21:00:00.000Z'}
+    )
+  `
+})
+
+const seedUnresolvedMutation = Effect.gen(function* () {
+  const sql = yield* PgClient.PgClient
+  const intentId = '2'.repeat(64)
+  yield* sql`
+    INSERT INTO intents (
+      intent_id, schema_version, risk_decision_id, account_id, client_order_id,
+      symbol, side, order_type, time_in_force, quantity_micros, notional_limit_micros,
+      state, terminal_outcome, state_version, created_at, updated_at
+    ) VALUES (
+      ${intentId},
+      'bayn.paper-intent.v1',
+      NULL,
+      ${accountId},
+      'bayn-observability-test-order',
+      'SPY',
+      'BUY',
+      'MARKET',
+      'DAY',
+      1000000,
+      1000000,
+      'PLANNED',
+      NULL,
+      1,
+      ${'2026-03-06T21:02:00.000Z'},
+      ${'2026-03-06T21:02:00.000Z'}
+    )
+  `
+  yield* sql`
+    INSERT INTO mutation_events (
+      event_id, schema_version, mutation_id, intent_id, sequence, operation,
+      event_type, request_hash, consistency_delay_ms, broker_order_id,
+      request_id, response_status, response_content_hash, occurred_at
+    ) VALUES (
+      ${'3'.repeat(64)},
+      'bayn.paper-mutation-event.v1',
+      ${'4'.repeat(64)},
+      ${intentId},
+      1,
+      'SUBMIT',
+      'SUBMIT_STARTED',
+      ${'5'.repeat(64)},
+      1000,
+      NULL,
+      NULL,
+      NULL,
+      NULL,
+      ${'2026-03-06T21:02:00.000Z'}
+    )
+  `
+})
+
+describePostgres('PostgreSQL cycle observability projection', () => {
+  let runtime: ReturnType<typeof makeRuntime>
+
+  beforeAll(() => {
+    const parsed = new URL(testUrl)
+    if (!['127.0.0.1', 'localhost', '[::1]'].includes(parsed.hostname) || !parsed.pathname.endsWith('_test')) {
+      throw new Error('BAYN_TEST_POSTGRES_URL must target a local database whose name ends in _test')
+    }
+    runtime = makeRuntime()
+  })
+
+  beforeEach(async () => {
+    await runtime.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* PgClient.PgClient
+        yield* sql`DROP SCHEMA public CASCADE`
+        yield* sql`CREATE SCHEMA public`
+      }),
+    )
+    await runtime.dispose()
+    runtime = makeRuntime()
+    await runtime.runPromise(PgMigrator.run({ loader: migrationLoader, table: 'schema_migrations' }))
+  })
+
+  afterAll(async () => {
+    await runtime?.dispose()
+  })
+
+  test('reads bounded current/last and safety state without changing durable counts', async () => {
+    const draft = makeDraft()
+    const result = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* CycleStore
+        const observability = yield* CycleObservability
+        const sql = yield* PgClient.PgClient
+        yield* seedSafetyState
+        const empty = yield* observability.read(qualificationRunId, accountId)
+        yield* store.acquire(draft, '2026-03-06T21:01:00.000Z')
+
+        const current = yield* observability.read(qualificationRunId, accountId)
+        yield* store.block(
+          draft.identity.cycleId,
+          CycleTerminalReason.MissedPublication,
+          draft.window.publicationDeadlineAt,
+        )
+        yield* seedUnresolvedMutation
+        const blocked = yield* observability.read(qualificationRunId, accountId)
+        const blockedReplay = yield* observability.read(qualificationRunId, accountId)
+        const [counts] = yield* sql<{
+          cycles: number
+          intents: number
+          mutations: number
+          reconciliations: number
+        }>`
+          SELECT
+            (SELECT count(*)::integer FROM autonomous_cycles) AS cycles,
+            (SELECT count(*)::integer FROM intents) AS intents,
+            (SELECT count(*)::integer FROM mutation_events) AS mutations,
+            (SELECT count(*)::integer FROM reconciliations) AS reconciliations
+        `
+        return { blocked, blockedReplay, counts, current, empty }
+      }),
+    )
+
+    expect(result.empty).toMatchObject({
+      current: null,
+      last: null,
+      reconciliation: { accountId, reconciliationId, status: 'EXACT', discrepancyCount: 0 },
+    })
+    expect(result.current).toMatchObject({
+      current: {
+        cycleId: draft.identity.cycleId,
+        accountId,
+        phase: CycleState.Pending,
+        signalSessionDate: '2026-03-06',
+        executionSessionDate: '2026-03-09',
+        submissionCutoffAt: draft.window.submissionCutoffAt,
+      },
+      last: null,
+      unfinishedCycleCount: 1,
+      authority: {
+        maximum: Authority.Observe,
+        effective: Authority.Observe,
+        kill: KillState.Clear,
+      },
+      reconciliation: {
+        accountId,
+        reconciliationId,
+        status: 'EXACT',
+        discrepancyCount: 0,
+      },
+      mutations: { eventCount: 0, unresolvedCount: 0, oldestUnresolvedAt: null },
+    })
+    expect(result.blocked).toMatchObject({
+      current: null,
+      last: {
+        cycleId: draft.identity.cycleId,
+        phase: CycleState.Blocked,
+        terminalReason: CycleTerminalReason.MissedPublication,
+        terminalAt: draft.window.publicationDeadlineAt,
+      },
+      unfinishedCycleCount: 0,
+      mutations: {
+        eventCount: 1,
+        unresolvedCount: 1,
+        oldestUnresolvedAt: '2026-03-06T21:02:00.000Z',
+      },
+    })
+    expect(result.blockedReplay).toEqual(result.blocked)
+    expect(result.counts).toEqual({ cycles: 1, intents: 1, mutations: 1, reconciliations: 1 })
+  })
+})

--- a/services/bayn/src/db/cycle-observability.integration.test.ts
+++ b/services/bayn/src/db/cycle-observability.integration.test.ts
@@ -13,6 +13,7 @@ import {
   makeCycleWindow,
   makeExecutionCalendarObservation,
 } from '../cycle'
+import { CycleOperationsCondition, CycleOperationsReason, deriveCycleOperationsStatus } from '../cycle-observability'
 import type { SignalSessionRow } from '../market-data'
 import { Authority, KillState } from '../paper'
 import type { IsoDate } from '../types'
@@ -51,7 +52,7 @@ const signalSession = (
   timezone: 'America/New_York',
 })
 
-const makeDraft = () => {
+const makeDraft = (dedicatedAccountId = accountId) => {
   const executionPolicy = makeCycleExecutionPolicy({
     schemaVersion: 'bayn.autonomous-cycle-execution-policy.v1',
     strategyExecutionModelHash: 'b'.repeat(64),
@@ -70,7 +71,7 @@ const makeDraft = () => {
     strategyName: 'risk-balanced-trend',
     qualificationRunId,
     strategyProtocolHash: 'c'.repeat(64),
-    accountId,
+    accountId: dedicatedAccountId,
     signalSessionDate: '2026-03-06',
     signalCalendarVersion: 'signal-XNYS-2026-v1',
     executionSessionDate: executionCalendar.executionSessionDate,
@@ -82,23 +83,24 @@ const makeDraft = () => {
   return makeCycleDraft(identity, makeCycleWindow(signalSession('2026-03-06'), executionCalendar, executionPolicy))
 }
 
-const seedSafetyState = Effect.gen(function* () {
-  const sql = yield* PgClient.PgClient
-  yield* sql`
+const seedSafetyState = (maximum = Authority.Observe, effective = Authority.Observe) =>
+  Effect.gen(function* () {
+    const sql = yield* PgClient.PgClient
+    yield* sql`
     INSERT INTO authority_state (
       schema_version, generation_hash, maximum, effective, kill_state, reason, version, updated_at
     ) VALUES (
       'bayn.paper-authority.v1',
       ${'f'.repeat(64)},
-      ${Authority.Observe},
-      ${Authority.Observe},
+      ${maximum},
+      ${effective},
       ${KillState.Clear},
       NULL,
       1,
       ${'2026-03-06T21:00:00.000Z'}
     )
   `
-  yield* sql`
+    yield* sql`
     INSERT INTO reconciliations (
       reconciliation_id, schema_version, account_id, expected_hash, observed_hash,
       content_hash, status, discrepancies, reconciled_at
@@ -114,12 +116,13 @@ const seedSafetyState = Effect.gen(function* () {
       ${'2026-03-06T21:00:00.000Z'}
     )
   `
-})
+  })
 
-const seedUnresolvedMutation = Effect.gen(function* () {
-  const sql = yield* PgClient.PgClient
-  const intentId = '2'.repeat(64)
-  yield* sql`
+const seedUnresolvedMutation = (mutationAccountId = accountId) =>
+  Effect.gen(function* () {
+    const sql = yield* PgClient.PgClient
+    const intentId = '2'.repeat(64)
+    yield* sql`
     INSERT INTO intents (
       intent_id, schema_version, risk_decision_id, account_id, client_order_id,
       symbol, side, order_type, time_in_force, quantity_micros, notional_limit_micros,
@@ -128,7 +131,7 @@ const seedUnresolvedMutation = Effect.gen(function* () {
       ${intentId},
       'bayn.paper-intent.v1',
       NULL,
-      ${accountId},
+      ${mutationAccountId},
       'bayn-observability-test-order',
       'SPY',
       'BUY',
@@ -143,7 +146,7 @@ const seedUnresolvedMutation = Effect.gen(function* () {
       ${'2026-03-06T21:02:00.000Z'}
     )
   `
-  yield* sql`
+    yield* sql`
     INSERT INTO mutation_events (
       event_id, schema_version, mutation_id, intent_id, sequence, operation,
       event_type, request_hash, consistency_delay_ms, broker_order_id,
@@ -163,6 +166,32 @@ const seedUnresolvedMutation = Effect.gen(function* () {
       NULL,
       NULL,
       ${'2026-03-06T21:02:00.000Z'}
+    )
+  `
+  })
+
+const seedAcceptedMutation = Effect.gen(function* () {
+  const sql = yield* PgClient.PgClient
+  yield* sql`
+    INSERT INTO mutation_events (
+      event_id, schema_version, mutation_id, intent_id, sequence, operation,
+      event_type, request_hash, consistency_delay_ms, broker_order_id,
+      request_id, response_status, response_content_hash, occurred_at
+    ) VALUES (
+      ${'6'.repeat(64)},
+      'bayn.paper-mutation-event.v1',
+      ${'4'.repeat(64)},
+      ${'2'.repeat(64)},
+      2,
+      'SUBMIT',
+      'SUBMIT_ACCEPTED',
+      ${'5'.repeat(64)},
+      1000,
+      'broker-order-observability',
+      'broker-request-observability',
+      200,
+      ${'7'.repeat(64)},
+      ${'2026-03-06T21:03:00.000Z'}
     )
   `
 })
@@ -202,7 +231,7 @@ describePostgres('PostgreSQL cycle observability projection', () => {
         const store = yield* CycleStore
         const observability = yield* CycleObservability
         const sql = yield* PgClient.PgClient
-        yield* seedSafetyState
+        yield* seedSafetyState()
         const empty = yield* observability.read(qualificationRunId, accountId)
         yield* store.acquire(draft, '2026-03-06T21:01:00.000Z')
 
@@ -212,7 +241,7 @@ describePostgres('PostgreSQL cycle observability projection', () => {
           CycleTerminalReason.MissedPublication,
           draft.window.publicationDeadlineAt,
         )
-        yield* seedUnresolvedMutation
+        yield* seedUnresolvedMutation()
         const blocked = yield* observability.read(qualificationRunId, accountId)
         const blockedReplay = yield* observability.read(qualificationRunId, accountId)
         const [counts] = yield* sql<{
@@ -258,7 +287,7 @@ describePostgres('PostgreSQL cycle observability projection', () => {
         status: 'EXACT',
         discrepancyCount: 0,
       },
-      mutations: { eventCount: 0, unresolvedCount: 0, oldestUnresolvedAt: null },
+      mutations: { eventCount: 0, unresolvedCount: 0, oldestUnresolvedAt: null, latestOccurredAt: null },
     })
     expect(result.blocked).toMatchObject({
       current: null,
@@ -273,9 +302,79 @@ describePostgres('PostgreSQL cycle observability projection', () => {
         eventCount: 1,
         unresolvedCount: 1,
         oldestUnresolvedAt: '2026-03-06T21:02:00.000Z',
+        latestOccurredAt: '2026-03-06T21:02:00.000Z',
       },
     })
     expect(result.blockedReplay).toEqual(result.blocked)
     expect(result.counts).toEqual({ cycles: 1, intents: 1, mutations: 1, reconciliations: 1 })
+  })
+
+  test('isolates mutation evidence by account and rejects an explicit account-to-cycle mismatch', async () => {
+    const otherAccountId = 'paper-account-unrelated'
+    const otherDraft = makeDraft(otherAccountId)
+    const result = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* CycleStore
+        const observability = yield* CycleObservability
+        yield* seedSafetyState()
+        yield* seedUnresolvedMutation(otherAccountId)
+
+        const isolated = yield* observability.read(qualificationRunId, accountId)
+        yield* store.acquire(otherDraft, '2026-03-06T21:01:00.000Z')
+        const mismatch = yield* Effect.flip(observability.read(qualificationRunId, accountId))
+        return { isolated, mismatch }
+      }),
+    )
+
+    expect(result.isolated).toMatchObject({
+      current: null,
+      last: null,
+      reconciliation: { accountId },
+      mutations: { eventCount: 0, unresolvedCount: 0, oldestUnresolvedAt: null, latestOccurredAt: null },
+    })
+    expect(result.mismatch).toMatchObject({
+      _tag: 'CycleObservabilityError',
+      operation: 'read',
+      failure: 'invariant',
+      message: `configured account ${accountId} differs from the projected current or last cycle`,
+    })
+  })
+
+  test('keeps PAPER blocked when a resolved mutation is newer than the last exact reconciliation', async () => {
+    const result = await runtime.runPromise(
+      Effect.gen(function* () {
+        const observability = yield* CycleObservability
+        yield* seedSafetyState(Authority.Paper, Authority.Paper)
+        yield* seedUnresolvedMutation()
+        yield* seedAcceptedMutation
+        const projected = yield* observability.read(qualificationRunId, accountId)
+        const status = deriveCycleOperationsStatus(projected, Date.parse('2026-03-06T21:03:30.000Z'), Authority.Paper, {
+          cycleStallThresholdMs: 300_000,
+          reconciliationStaleThresholdMs: 300_000,
+          unknownMutationThresholdMs: 300_000,
+        })
+        return { projected, status }
+      }),
+    )
+
+    expect(result.projected).toMatchObject({
+      reconciliation: {
+        accountId,
+        status: 'EXACT',
+        reconciledAt: '2026-03-06T21:00:00.000Z',
+      },
+      mutations: {
+        eventCount: 2,
+        unresolvedCount: 0,
+        oldestUnresolvedAt: null,
+        latestOccurredAt: '2026-03-06T21:03:00.000Z',
+      },
+    })
+    expect(result.status).toMatchObject({
+      condition: CycleOperationsCondition.Failed,
+      reason: CycleOperationsReason.ReconciliationPredatesMutation,
+      reconciliationCoversLatestMutation: false,
+      alerts: { reconciliationBlocked: true, unknownMutationStale: false },
+    })
   })
 })

--- a/services/bayn/src/db/cycle-observability.ts
+++ b/services/bayn/src/db/cycle-observability.ts
@@ -87,6 +87,7 @@ const ProjectionRowSchema = Schema.Struct({
   reconciliation_status: Schema.NullOr(Schema.Enum(ReconciliationStatus)),
   reconciliation_discrepancy_count: Schema.NullOr(NonNegativeIntegerSchema),
   reconciled_at: NullableDate,
+  reconciliation_covers_latest_mutation: Schema.NullOr(Schema.Boolean),
   mutation_event_count: NonNegativeIntegerSchema,
   unresolved_mutation_count: NonNegativeIntegerSchema,
   oldest_unresolved_mutation_at: NullableDate,
@@ -179,7 +180,8 @@ const reconciliationFromRow = (row: ProjectionRow): ReconciliationObservation | 
     row.reconciliation_account_id === null ||
     row.reconciliation_status === null ||
     row.reconciliation_discrepancy_count === null ||
-    row.reconciled_at === null
+    row.reconciled_at === null ||
+    row.reconciliation_covers_latest_mutation === null
   ) {
     throw readError('invariant', 'reconciliation projection is incomplete')
   }
@@ -189,6 +191,7 @@ const reconciliationFromRow = (row: ProjectionRow): ReconciliationObservation | 
     status: row.reconciliation_status,
     discrepancyCount: row.reconciliation_discrepancy_count,
     reconciledAt: row.reconciled_at.toISOString(),
+    coversLatestMutation: row.reconciliation_covers_latest_mutation,
   }
 }
 
@@ -366,6 +369,11 @@ const makeCycleObservability = Effect.gen(function* () {
             reconciliation.status AS reconciliation_status,
             jsonb_array_length(reconciliation.discrepancies) AS reconciliation_discrepancy_count,
             reconciliation.reconciled_at,
+            CASE
+              WHEN reconciliation.reconciliation_id IS NULL THEN NULL
+              WHEN NOT EXISTS (SELECT 1 FROM account_mutation_events) THEN true
+              ELSE reconciliation.reconciled_at >= (SELECT max(occurred_at) FROM account_mutation_events)
+            END AS reconciliation_covers_latest_mutation,
             (SELECT count(*)::integer FROM account_mutation_events) AS mutation_event_count,
             (SELECT count(*)::integer FROM unresolved_mutations) AS unresolved_mutation_count,
             (SELECT min(occurred_at) FROM unresolved_mutations) AS oldest_unresolved_mutation_at,

--- a/services/bayn/src/db/cycle-observability.ts
+++ b/services/bayn/src/db/cycle-observability.ts
@@ -74,6 +74,8 @@ const ProjectionRowSchema = Schema.Struct({
   last_created_at: NullableDate,
   last_updated_at: NullableDate,
   last_terminal_at: NullableInstant,
+  selected_account_id: Schema.NullOr(StrictNonEmptyStringSchema),
+  account_mismatch: Schema.Boolean,
   unfinished_cycle_count: NonNegativeIntegerSchema,
   authority_maximum: Schema.NullOr(Schema.Enum(Authority)),
   authority_effective: Schema.NullOr(Schema.Enum(Authority)),
@@ -88,6 +90,7 @@ const ProjectionRowSchema = Schema.Struct({
   mutation_event_count: NonNegativeIntegerSchema,
   unresolved_mutation_count: NonNegativeIntegerSchema,
   oldest_unresolved_mutation_at: NullableDate,
+  latest_mutation_at: NullableDate,
 })
 type ProjectionRow = typeof ProjectionRowSchema.Type
 
@@ -189,18 +192,27 @@ const reconciliationFromRow = (row: ProjectionRow): ReconciliationObservation | 
   }
 }
 
-const projectionFromRow = (row: ProjectionRow): CycleOperationsProjection => ({
-  current: snapshotFromRow(row, 'current'),
-  last: snapshotFromRow(row, 'last'),
-  unfinishedCycleCount: row.unfinished_cycle_count,
-  authority: authorityFromRow(row),
-  reconciliation: reconciliationFromRow(row),
-  mutations: {
-    eventCount: row.mutation_event_count,
-    unresolvedCount: row.unresolved_mutation_count,
-    oldestUnresolvedAt: row.oldest_unresolved_mutation_at?.toISOString() ?? null,
-  },
-})
+const projectionFromRow = (row: ProjectionRow): CycleOperationsProjection => {
+  if (row.account_mismatch) {
+    throw readError(
+      'invariant',
+      `configured account ${row.selected_account_id ?? 'unknown'} differs from the projected current or last cycle`,
+    )
+  }
+  return {
+    current: snapshotFromRow(row, 'current'),
+    last: snapshotFromRow(row, 'last'),
+    unfinishedCycleCount: row.unfinished_cycle_count,
+    authority: authorityFromRow(row),
+    reconciliation: reconciliationFromRow(row),
+    mutations: {
+      eventCount: row.mutation_event_count,
+      unresolvedCount: row.unresolved_mutation_count,
+      oldestUnresolvedAt: row.oldest_unresolved_mutation_at?.toISOString() ?? null,
+      latestOccurredAt: row.latest_mutation_at?.toISOString() ?? null,
+    },
+  }
+}
 
 const makeCycleObservability = Effect.gen(function* () {
   const sql = yield* PgClient.PgClient
@@ -240,18 +252,15 @@ const makeCycleObservability = Effect.gen(function* () {
             ORDER BY execution_session_date DESC, terminal_at DESC, cycle_id
             LIMIT 1
           ),
+          requested_account AS (
+            SELECT ${expectedAccountId ?? null}::text AS account_id
+          ),
           selected_account AS (
-            SELECT account_id
-            FROM (
-              SELECT 1 AS priority, account_id FROM current_cycle
-              UNION ALL
-              SELECT 2 AS priority, account_id FROM last_cycle
-              UNION ALL
-              SELECT 3 AS priority, ${expectedAccountId ?? null}::text AS account_id
-            ) AS candidates
-            WHERE account_id IS NOT NULL
-            ORDER BY priority
-            LIMIT 1
+            SELECT coalesce(
+              (SELECT account_id FROM requested_account),
+              (SELECT account_id FROM current_cycle),
+              (SELECT account_id FROM last_cycle)
+            ) AS account_id
           ),
           latest_reconciliation AS (
             SELECT *
@@ -260,14 +269,21 @@ const makeCycleObservability = Effect.gen(function* () {
             ORDER BY reconciled_at DESC, reconciliation_id
             LIMIT 1
           ),
+          account_mutation_events AS (
+            SELECT
+              events.*,
+              intents.state
+            FROM mutation_events AS events
+            JOIN intents ON intents.intent_id = events.intent_id
+            WHERE intents.account_id = (SELECT account_id FROM selected_account)
+          ),
           latest_mutations AS (
             SELECT DISTINCT ON (events.mutation_id)
               events.event_type,
               events.occurred_at,
               events.operation,
-              intents.state
-            FROM mutation_events AS events
-            JOIN intents ON intents.intent_id = events.intent_id
+              events.state
+            FROM account_mutation_events AS events
             ORDER BY events.mutation_id, events.sequence DESC
           ),
           unresolved_mutations AS (
@@ -320,6 +336,21 @@ const makeCycleObservability = Effect.gen(function* () {
             last.created_at AS last_created_at,
             last.updated_at AS last_updated_at,
             last.terminal_at AS last_terminal_at,
+            (SELECT account_id FROM selected_account) AS selected_account_id,
+            (
+              (SELECT account_id FROM requested_account) IS NOT NULL
+              AND (
+                (
+                  current.account_id IS NOT NULL
+                  AND current.account_id <> (SELECT account_id FROM requested_account)
+                )
+                OR
+                (
+                  last.account_id IS NOT NULL
+                  AND last.account_id <> (SELECT account_id FROM requested_account)
+                )
+              )
+            ) AS account_mismatch,
             (
               SELECT count(*)::integer
               FROM scoped_cycles
@@ -335,9 +366,10 @@ const makeCycleObservability = Effect.gen(function* () {
             reconciliation.status AS reconciliation_status,
             jsonb_array_length(reconciliation.discrepancies) AS reconciliation_discrepancy_count,
             reconciliation.reconciled_at,
-            (SELECT count(*)::integer FROM mutation_events) AS mutation_event_count,
+            (SELECT count(*)::integer FROM account_mutation_events) AS mutation_event_count,
             (SELECT count(*)::integer FROM unresolved_mutations) AS unresolved_mutation_count,
-            (SELECT min(occurred_at) FROM unresolved_mutations) AS oldest_unresolved_mutation_at
+            (SELECT min(occurred_at) FROM unresolved_mutations) AS oldest_unresolved_mutation_at,
+            (SELECT max(occurred_at) FROM account_mutation_events) AS latest_mutation_at
           FROM (VALUES (true)) AS singleton(seed)
           LEFT JOIN current_cycle AS current ON true
           LEFT JOIN last_cycle AS last ON true

--- a/services/bayn/src/db/cycle-observability.ts
+++ b/services/bayn/src/db/cycle-observability.ts
@@ -1,0 +1,373 @@
+import { PgClient } from '@effect/sql-pg'
+import { Context, Data, Effect, Layer, Schema } from 'effect'
+import { isSqlError } from 'effect/unstable/sql/SqlError'
+
+import {
+  type CycleOperationsProjection,
+  type CycleOperationsSnapshot,
+  type DurableAuthorityObservation,
+  type ReconciliationObservation,
+} from '../cycle-observability'
+import { CycleState, CycleTerminalReason } from '../cycle'
+import { Authority, KillState, ReconciliationStatus } from '../paper'
+import {
+  IsoDateSchema,
+  NonNegativeIntegerSchema,
+  Sha256Schema,
+  StrictNonEmptyStringSchema,
+  strictParseOptions,
+} from '../schemas'
+
+export class CycleObservabilityError extends Data.TaggedError('CycleObservabilityError')<{
+  readonly operation: 'read'
+  readonly failure: 'decode' | 'invariant' | 'query'
+  readonly message: string
+  readonly cause?: unknown
+}> {}
+
+export interface CycleObservabilityShape {
+  readonly read: (
+    qualificationRunId: string,
+    accountId?: string,
+  ) => Effect.Effect<CycleOperationsProjection, CycleObservabilityError>
+}
+
+export class CycleObservability extends Context.Service<CycleObservability, CycleObservabilityShape>()(
+  'bayn/CycleObservability',
+) {}
+
+const NullableDate = Schema.NullOr(Schema.DateValid)
+const NullableString = Schema.NullOr(Schema.String)
+const NullableSha256 = Schema.NullOr(Sha256Schema)
+const NullableInstant = Schema.NullOr(Schema.DateValid)
+const NullableCycleState = Schema.NullOr(Schema.Enum(CycleState))
+const NullableTerminalReason = Schema.NullOr(Schema.Enum(CycleTerminalReason))
+
+const ProjectionRowSchema = Schema.Struct({
+  current_cycle_id: NullableSha256,
+  current_account_id: Schema.NullOr(StrictNonEmptyStringSchema),
+  current_signal_session_date: Schema.NullOr(IsoDateSchema),
+  current_execution_session_date: Schema.NullOr(IsoDateSchema),
+  current_state: NullableCycleState,
+  current_snapshot_id: NullableSha256,
+  current_decision_hash: NullableSha256,
+  current_terminal_reason: NullableTerminalReason,
+  current_submission_open_at: NullableDate,
+  current_submission_cutoff_at: NullableDate,
+  current_execution_open_at: NullableDate,
+  current_execution_close_at: NullableDate,
+  current_created_at: NullableDate,
+  current_updated_at: NullableDate,
+  current_terminal_at: NullableInstant,
+  last_cycle_id: NullableSha256,
+  last_account_id: Schema.NullOr(StrictNonEmptyStringSchema),
+  last_signal_session_date: Schema.NullOr(IsoDateSchema),
+  last_execution_session_date: Schema.NullOr(IsoDateSchema),
+  last_state: NullableCycleState,
+  last_snapshot_id: NullableSha256,
+  last_decision_hash: NullableSha256,
+  last_terminal_reason: NullableTerminalReason,
+  last_submission_open_at: NullableDate,
+  last_submission_cutoff_at: NullableDate,
+  last_execution_open_at: NullableDate,
+  last_execution_close_at: NullableDate,
+  last_created_at: NullableDate,
+  last_updated_at: NullableDate,
+  last_terminal_at: NullableInstant,
+  unfinished_cycle_count: NonNegativeIntegerSchema,
+  authority_maximum: Schema.NullOr(Schema.Enum(Authority)),
+  authority_effective: Schema.NullOr(Schema.Enum(Authority)),
+  authority_kill: Schema.NullOr(Schema.Enum(KillState)),
+  authority_reason: NullableString,
+  authority_updated_at: NullableDate,
+  reconciliation_id: NullableSha256,
+  reconciliation_account_id: Schema.NullOr(StrictNonEmptyStringSchema),
+  reconciliation_status: Schema.NullOr(Schema.Enum(ReconciliationStatus)),
+  reconciliation_discrepancy_count: Schema.NullOr(NonNegativeIntegerSchema),
+  reconciled_at: NullableDate,
+  mutation_event_count: NonNegativeIntegerSchema,
+  unresolved_mutation_count: NonNegativeIntegerSchema,
+  oldest_unresolved_mutation_at: NullableDate,
+})
+type ProjectionRow = typeof ProjectionRowSchema.Type
+
+const ProjectionRowsSchema = Schema.Tuple([ProjectionRowSchema])
+const decodeRunId = Schema.decodeUnknownEffect(Sha256Schema, strictParseOptions)
+const decodeAccountId = Schema.decodeUnknownEffect(StrictNonEmptyStringSchema, strictParseOptions)
+const decodeProjectionRows = Schema.decodeUnknownEffect(ProjectionRowsSchema, strictParseOptions)
+
+const messageOf = (cause: unknown): string => (cause instanceof Error ? cause.message : String(cause))
+
+const readError = (
+  failure: CycleObservabilityError['failure'],
+  message: string,
+  cause?: unknown,
+): CycleObservabilityError =>
+  new CycleObservabilityError({
+    operation: 'read',
+    failure,
+    message: cause === undefined ? message : `${message}: ${messageOf(cause)}`,
+    cause,
+  })
+
+const snapshotFromRow = (row: ProjectionRow, prefix: 'current' | 'last'): CycleOperationsSnapshot | null => {
+  const cycleId = row[`${prefix}_cycle_id`]
+  if (cycleId === null) return null
+  const accountId = row[`${prefix}_account_id`]
+  const signalSessionDate = row[`${prefix}_signal_session_date`]
+  const executionSessionDate = row[`${prefix}_execution_session_date`]
+  const phase = row[`${prefix}_state`]
+  const submissionOpenAt = row[`${prefix}_submission_open_at`]
+  const submissionCutoffAt = row[`${prefix}_submission_cutoff_at`]
+  const executionOpenAt = row[`${prefix}_execution_open_at`]
+  const executionCloseAt = row[`${prefix}_execution_close_at`]
+  const createdAt = row[`${prefix}_created_at`]
+  const updatedAt = row[`${prefix}_updated_at`]
+  if (
+    accountId === null ||
+    signalSessionDate === null ||
+    executionSessionDate === null ||
+    phase === null ||
+    submissionOpenAt === null ||
+    submissionCutoffAt === null ||
+    executionOpenAt === null ||
+    executionCloseAt === null ||
+    createdAt === null ||
+    updatedAt === null
+  ) {
+    throw readError('invariant', `${prefix} cycle projection is incomplete`)
+  }
+  return {
+    cycleId,
+    accountId,
+    signalSessionDate,
+    executionSessionDate,
+    phase,
+    snapshotId: row[`${prefix}_snapshot_id`],
+    decisionHash: row[`${prefix}_decision_hash`],
+    terminalReason: row[`${prefix}_terminal_reason`],
+    submissionOpenAt: submissionOpenAt.toISOString(),
+    submissionCutoffAt: submissionCutoffAt.toISOString(),
+    executionOpenAt: executionOpenAt.toISOString(),
+    executionCloseAt: executionCloseAt.toISOString(),
+    createdAt: createdAt.toISOString(),
+    updatedAt: updatedAt.toISOString(),
+    terminalAt: row[`${prefix}_terminal_at`]?.toISOString() ?? null,
+  }
+}
+
+const authorityFromRow = (row: ProjectionRow): DurableAuthorityObservation | null => {
+  if (row.authority_maximum === null) return null
+  if (row.authority_effective === null || row.authority_kill === null || row.authority_updated_at === null) {
+    throw readError('invariant', 'durable authority projection is incomplete')
+  }
+  return {
+    maximum: row.authority_maximum,
+    effective: row.authority_effective,
+    kill: row.authority_kill,
+    reason: row.authority_reason,
+    updatedAt: row.authority_updated_at.toISOString(),
+  }
+}
+
+const reconciliationFromRow = (row: ProjectionRow): ReconciliationObservation | null => {
+  if (row.reconciliation_id === null) return null
+  if (
+    row.reconciliation_account_id === null ||
+    row.reconciliation_status === null ||
+    row.reconciliation_discrepancy_count === null ||
+    row.reconciled_at === null
+  ) {
+    throw readError('invariant', 'reconciliation projection is incomplete')
+  }
+  return {
+    reconciliationId: row.reconciliation_id,
+    accountId: row.reconciliation_account_id,
+    status: row.reconciliation_status,
+    discrepancyCount: row.reconciliation_discrepancy_count,
+    reconciledAt: row.reconciled_at.toISOString(),
+  }
+}
+
+const projectionFromRow = (row: ProjectionRow): CycleOperationsProjection => ({
+  current: snapshotFromRow(row, 'current'),
+  last: snapshotFromRow(row, 'last'),
+  unfinishedCycleCount: row.unfinished_cycle_count,
+  authority: authorityFromRow(row),
+  reconciliation: reconciliationFromRow(row),
+  mutations: {
+    eventCount: row.mutation_event_count,
+    unresolvedCount: row.unresolved_mutation_count,
+    oldestUnresolvedAt: row.oldest_unresolved_mutation_at?.toISOString() ?? null,
+  },
+})
+
+const makeCycleObservability = Effect.gen(function* () {
+  const sql = yield* PgClient.PgClient
+
+  const read = (
+    qualificationRunId: string,
+    accountId?: string,
+  ): Effect.Effect<CycleOperationsProjection, CycleObservabilityError> =>
+    Effect.all([
+      decodeRunId(qualificationRunId).pipe(
+        Effect.mapError((cause) => readError('decode', 'invalid qualification run identity', cause)),
+      ),
+      accountId === undefined
+        ? Effect.succeed(undefined)
+        : decodeAccountId(accountId).pipe(
+            Effect.mapError((cause) => readError('decode', 'invalid cycle observability account identity', cause)),
+          ),
+    ]).pipe(
+      Effect.flatMap(([runId, expectedAccountId]) =>
+        sql<Record<string, unknown>>`
+          WITH scoped_cycles AS (
+            SELECT *
+            FROM autonomous_cycles
+            WHERE qualification_run_id = ${runId}
+          ),
+          current_cycle AS (
+            SELECT *
+            FROM scoped_cycles
+            WHERE state IN ('PENDING', 'ACTIVE')
+            ORDER BY execution_session_date DESC, created_at DESC, cycle_id
+            LIMIT 1
+          ),
+          last_cycle AS (
+            SELECT *
+            FROM scoped_cycles
+            WHERE state IN ('COMPLETED', 'NO_TRADE', 'BLOCKED')
+            ORDER BY execution_session_date DESC, terminal_at DESC, cycle_id
+            LIMIT 1
+          ),
+          selected_account AS (
+            SELECT account_id
+            FROM (
+              SELECT 1 AS priority, account_id FROM current_cycle
+              UNION ALL
+              SELECT 2 AS priority, account_id FROM last_cycle
+              UNION ALL
+              SELECT 3 AS priority, ${expectedAccountId ?? null}::text AS account_id
+            ) AS candidates
+            WHERE account_id IS NOT NULL
+            ORDER BY priority
+            LIMIT 1
+          ),
+          latest_reconciliation AS (
+            SELECT *
+            FROM reconciliations
+            WHERE account_id = (SELECT account_id FROM selected_account)
+            ORDER BY reconciled_at DESC, reconciliation_id
+            LIMIT 1
+          ),
+          latest_mutations AS (
+            SELECT DISTINCT ON (events.mutation_id)
+              events.event_type,
+              events.occurred_at,
+              events.operation,
+              intents.state
+            FROM mutation_events AS events
+            JOIN intents ON intents.intent_id = events.intent_id
+            ORDER BY events.mutation_id, events.sequence DESC
+          ),
+          unresolved_mutations AS (
+            SELECT occurred_at
+            FROM latest_mutations
+            WHERE
+              event_type IN (
+                'SUBMIT_STARTED',
+                'SUBMIT_UNKNOWN',
+                'RECOVERY_NOT_FOUND',
+                'RECOVERY_UNKNOWN',
+                'CANCEL_STARTED',
+                'CANCEL_ACCEPTED',
+                'CANCEL_UNKNOWN'
+              )
+              OR (
+                operation = 'CANCEL'
+                AND event_type = 'RECOVERY_FOUND'
+                AND state <> 'TERMINAL'
+              )
+          )
+          SELECT
+            current.cycle_id AS current_cycle_id,
+            current.account_id AS current_account_id,
+            current.signal_session_date::text AS current_signal_session_date,
+            current.execution_session_date::text AS current_execution_session_date,
+            current.state AS current_state,
+            current.snapshot_id AS current_snapshot_id,
+            current.decision_hash AS current_decision_hash,
+            current.terminal_reason AS current_terminal_reason,
+            current.submission_open_at AS current_submission_open_at,
+            current.submission_cutoff_at AS current_submission_cutoff_at,
+            current.execution_open_at AS current_execution_open_at,
+            current.execution_close_at AS current_execution_close_at,
+            current.created_at AS current_created_at,
+            current.updated_at AS current_updated_at,
+            current.terminal_at AS current_terminal_at,
+            last.cycle_id AS last_cycle_id,
+            last.account_id AS last_account_id,
+            last.signal_session_date::text AS last_signal_session_date,
+            last.execution_session_date::text AS last_execution_session_date,
+            last.state AS last_state,
+            last.snapshot_id AS last_snapshot_id,
+            last.decision_hash AS last_decision_hash,
+            last.terminal_reason AS last_terminal_reason,
+            last.submission_open_at AS last_submission_open_at,
+            last.submission_cutoff_at AS last_submission_cutoff_at,
+            last.execution_open_at AS last_execution_open_at,
+            last.execution_close_at AS last_execution_close_at,
+            last.created_at AS last_created_at,
+            last.updated_at AS last_updated_at,
+            last.terminal_at AS last_terminal_at,
+            (
+              SELECT count(*)::integer
+              FROM scoped_cycles
+              WHERE state IN ('PENDING', 'ACTIVE')
+            ) AS unfinished_cycle_count,
+            authority.maximum AS authority_maximum,
+            authority.effective AS authority_effective,
+            authority.kill_state AS authority_kill,
+            authority.reason AS authority_reason,
+            authority.updated_at AS authority_updated_at,
+            reconciliation.reconciliation_id,
+            reconciliation.account_id AS reconciliation_account_id,
+            reconciliation.status AS reconciliation_status,
+            jsonb_array_length(reconciliation.discrepancies) AS reconciliation_discrepancy_count,
+            reconciliation.reconciled_at,
+            (SELECT count(*)::integer FROM mutation_events) AS mutation_event_count,
+            (SELECT count(*)::integer FROM unresolved_mutations) AS unresolved_mutation_count,
+            (SELECT min(occurred_at) FROM unresolved_mutations) AS oldest_unresolved_mutation_at
+          FROM (VALUES (true)) AS singleton(seed)
+          LEFT JOIN current_cycle AS current ON true
+          LEFT JOIN last_cycle AS last ON true
+          LEFT JOIN authority_state AS authority ON authority.singleton
+          LEFT JOIN latest_reconciliation AS reconciliation ON true
+        `.pipe(
+          Effect.mapError((cause) =>
+            isSqlError(cause)
+              ? readError('query', 'autonomous cycle observability query failed', cause)
+              : readError('query', 'autonomous cycle observability failed unexpectedly', cause),
+          ),
+        ),
+      ),
+      Effect.flatMap((rows) =>
+        decodeProjectionRows(rows).pipe(
+          Effect.mapError((cause) => readError('decode', 'autonomous cycle observability decoding failed', cause)),
+        ),
+      ),
+      Effect.flatMap(([row]) =>
+        Effect.try({
+          try: () => projectionFromRow(row),
+          catch: (cause) =>
+            cause instanceof CycleObservabilityError
+              ? cause
+              : readError('invariant', 'autonomous cycle observability projection failed', cause),
+        }),
+      ),
+    )
+
+  return { read } satisfies CycleObservabilityShape
+})
+
+export const CycleObservabilityLive = Layer.effect(CycleObservability, makeCycleObservability)

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -53,6 +53,13 @@ const makeConfig = (url = testUrl): RuntimeConfig => ({
   },
   healthIntervalMs: 30_000,
   operationTimeoutMs: 5_000,
+  cycleStallThresholdMs: 300_000,
+  reconciliationStaleThresholdMs: 120_000,
+  unknownMutationThresholdMs: 300_000,
+  autonomousCycle: {
+    enabled: false,
+    pollIntervalMs: 30_000,
+  },
   clickhouse: {
     url: 'http://clickhouse.invalid',
     username: 'bayn',

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -56,10 +56,6 @@ const makeConfig = (url = testUrl): RuntimeConfig => ({
   cycleStallThresholdMs: 300_000,
   reconciliationStaleThresholdMs: 120_000,
   unknownMutationThresholdMs: 300_000,
-  autonomousCycle: {
-    enabled: false,
-    pollIntervalMs: 30_000,
-  },
   clickhouse: {
     url: 'http://clickhouse.invalid',
     username: 'bayn',

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -56,10 +56,6 @@ const config: RuntimeConfig = {
   cycleStallThresholdMs: 300_000,
   reconciliationStaleThresholdMs: 120_000,
   unknownMutationThresholdMs: 300_000,
-  autonomousCycle: {
-    enabled: false,
-    pollIntervalMs: 30_000,
-  },
   clickhouse: {
     url: 'http://clickhouse.invalid',
     username: 'bayn',

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -53,6 +53,13 @@ const config: RuntimeConfig = {
   },
   healthIntervalMs: 30_000,
   operationTimeoutMs: 5_000,
+  cycleStallThresholdMs: 300_000,
+  reconciliationStaleThresholdMs: 120_000,
+  unknownMutationThresholdMs: 300_000,
+  autonomousCycle: {
+    enabled: false,
+    pollIntervalMs: 30_000,
+  },
   clickhouse: {
     url: 'http://clickhouse.invalid',
     username: 'bayn',

--- a/services/bayn/src/health.test.ts
+++ b/services/bayn/src/health.test.ts
@@ -9,13 +9,12 @@ import { AccountStatus, type BrokerReadShape, type ReadResult, type Account } fr
 import { unusedMarketCalendar } from './broker/alpaca-test-support'
 import { CycleOperationsCondition, CycleOperationsReason, type CycleOperationsProjection } from './cycle-observability'
 import { CycleState } from './cycle'
-import { CycleRunnerError } from './cycle-runner'
 import { CycleObservability, type CycleObservabilityShape } from './db/cycle-observability'
 import { EvidenceStore } from './db/evidence-store'
 import type { BrokerProbe } from './health'
 import { Journal, type JournalService } from './ledger'
 import { MarketData, type MarketDataService } from './market-data'
-import { initialState, type RuntimeState } from './runtime-state'
+import { initialState } from './runtime-state'
 import { makeSnapshot } from './test-fixtures'
 
 const brokerAccountId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
@@ -59,7 +58,7 @@ const emptyCycleProjection = (): CycleOperationsProjection => ({
   unfinishedCycleCount: 0,
   authority: null,
   reconciliation: null,
-  mutations: { eventCount: 0, unresolvedCount: 0, oldestUnresolvedAt: null },
+  mutations: { eventCount: 0, unresolvedCount: 0, oldestUnresolvedAt: null, latestOccurredAt: null },
 })
 
 const cycleObservability = (
@@ -372,67 +371,5 @@ describe('Bayn continuous health', () => {
     }).pipe(Effect.provide(TestClock.layer()))
 
     await Effect.runPromise(program)
-  })
-
-  test('surfaces the sole runner fiber failure and clears only after a live replacement is observed', async () => {
-    const enabledConfig = { ...config, autonomousCycle: { ...config.autonomousCycle, enabled: true } }
-    const initial: RuntimeState = {
-      ...readyState(),
-      cycleRunner: { enabled: true, status: 'STARTING', checkedAt: null, error: null },
-      health: {
-        ...readyState().health,
-        dependencies: {
-          ...readyState().health.dependencies,
-          cycleRunner: { status: 'UNKNOWN', checkedAt: null, error: null },
-        },
-      },
-    }
-    const state = await Effect.runPromise(Ref.make(initial))
-    const dependencies = (
-      effect: Effect.Effect<void, never, MarketData | Journal | EvidenceStore | CycleObservability>,
-    ) =>
-      effect.pipe(
-        Effect.provideService(MarketData, {
-          check: Effect.succeed(makeSnapshot().manifest.finalizedSnapshot),
-          inspect: Effect.die(new Error('health probes must not inspect sessions')),
-          load: Effect.die(new Error('health probes must not load bars')),
-        }),
-        Effect.provideService(Journal, { ...successfulJournal, checkRun: () => Effect.void }),
-        Effect.provideService(EvidenceStore, recoveringStore(initial)),
-        Effect.provideService(CycleObservability, cycleObservability()),
-      )
-
-    await Effect.runPromise(
-      Effect.scoped(
-        Effect.gen(function* () {
-          const failed = yield* Effect.fail(
-            new CycleRunnerError({
-              operation: 'market-calendar',
-              failure: 'calendar-read',
-              message: 'calendar unavailable',
-            }),
-          ).pipe(Effect.forkScoped({ startImmediately: true }))
-          yield* Effect.yieldNow
-          yield* dependencies(probe(enabledConfig, state, undefined, failed))
-          expect(yield* Ref.get(state)).toMatchObject({
-            status: 'DEGRADED',
-            health: { dependencies: { cycleRunner: { status: 'UNAVAILABLE' } } },
-            cycleRunner: {
-              enabled: true,
-              status: 'FAILED',
-              error: expect.stringContaining('calendar unavailable'),
-            },
-          })
-
-          const running = yield* Effect.never.pipe(Effect.forkScoped({ startImmediately: true }))
-          yield* dependencies(probe(enabledConfig, state, undefined, running))
-          expect(yield* Ref.get(state)).toMatchObject({
-            status: 'READY',
-            health: { dependencies: { cycleRunner: { status: 'AVAILABLE', error: null } } },
-            cycleRunner: { enabled: true, status: 'RUNNING', error: null },
-          })
-        }),
-      ),
-    )
   })
 })

--- a/services/bayn/src/health.test.ts
+++ b/services/bayn/src/health.test.ts
@@ -313,6 +313,9 @@ describe('Bayn continuous health', () => {
         Effect.provideService(MarketData, {
           check: Effect.succeed(makeSnapshot().manifest.finalizedSnapshot),
           inspect: Effect.die(new Error('health probes must not inspect sessions')),
+          inspectPublication: () => Effect.die(new Error('health probes must not inspect cycle publications')),
+          inspectSnapshotPublication: () =>
+            Effect.die(new Error('health probes must not inspect bound cycle publications')),
           load: Effect.die(new Error('health probes must not load bars')),
         }),
         Effect.provideService(Journal, { ...successfulJournal, checkRun: () => Effect.void }),

--- a/services/bayn/src/health.test.ts
+++ b/services/bayn/src/health.test.ts
@@ -7,11 +7,15 @@ import { config, successfulJournal, readyState, recoveringStore } from './app-te
 import { monitor, probe } from './app'
 import { AccountStatus, type BrokerReadShape, type ReadResult, type Account } from './broker/alpaca'
 import { unusedMarketCalendar } from './broker/alpaca-test-support'
+import { CycleOperationsCondition, CycleOperationsReason, type CycleOperationsProjection } from './cycle-observability'
+import { CycleState } from './cycle'
+import { CycleRunnerError } from './cycle-runner'
+import { CycleObservability, type CycleObservabilityShape } from './db/cycle-observability'
 import { EvidenceStore } from './db/evidence-store'
 import type { BrokerProbe } from './health'
 import { Journal, type JournalService } from './ledger'
 import { MarketData, type MarketDataService } from './market-data'
-import { initialState } from './runtime-state'
+import { initialState, type RuntimeState } from './runtime-state'
 import { makeSnapshot } from './test-fixtures'
 
 const brokerAccountId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
@@ -49,6 +53,19 @@ const brokerRead = (account: BrokerReadShape['account']): BrokerReadShape => {
   }
 }
 
+const emptyCycleProjection = (): CycleOperationsProjection => ({
+  current: null,
+  last: null,
+  unfinishedCycleCount: 0,
+  authority: null,
+  reconciliation: null,
+  mutations: { eventCount: 0, unresolvedCount: 0, oldestUnresolvedAt: null },
+})
+
+const cycleObservability = (
+  read: CycleObservabilityShape['read'] = () => Effect.succeed(emptyCycleProjection()),
+): CycleObservabilityShape => ({ read })
+
 describe('Bayn continuous health', () => {
   test('requires the configured broker account GET while keeping execution disabled under OBSERVE', async () => {
     let observedAccountId = brokerAccountId
@@ -63,7 +80,9 @@ describe('Bayn continuous health', () => {
       broker: initialState(broker).broker,
     }
     const state = await Effect.runPromise(Ref.make(initial))
-    const dependencies = (effect: Effect.Effect<void, never, MarketData | Journal | EvidenceStore>) =>
+    const dependencies = (
+      effect: Effect.Effect<void, never, MarketData | Journal | EvidenceStore | CycleObservability>,
+    ) =>
       effect.pipe(
         Effect.provideService(MarketData, {
           check: Effect.succeed(makeSnapshot().manifest.finalizedSnapshot),
@@ -75,6 +94,7 @@ describe('Bayn continuous health', () => {
         }),
         Effect.provideService(Journal, { ...successfulJournal, checkRun: () => Effect.void }),
         Effect.provideService(EvidenceStore, recoveringStore(initial)),
+        Effect.provideService(CycleObservability, cycleObservability()),
       )
 
     await Effect.runPromise(dependencies(probe(config, state, broker)))
@@ -137,11 +157,14 @@ describe('Bayn continuous health', () => {
       ...recoveringStore(initial),
       check: Effect.suspend(() => (databaseAvailable ? Effect.void : Effect.fail(new Error('database unavailable')))),
     }
-    const dependencies = (effect: Effect.Effect<void, never, MarketData | Journal | EvidenceStore>) =>
+    const dependencies = (
+      effect: Effect.Effect<void, never, MarketData | Journal | EvidenceStore | CycleObservability>,
+    ) =>
       effect.pipe(
         Effect.provideService(MarketData, marketData),
         Effect.provideService(Journal, journal),
         Effect.provideService(EvidenceStore, evidenceStore),
+        Effect.provideService(CycleObservability, cycleObservability()),
       )
 
     await Effect.runPromise(dependencies(probe(config, state)))
@@ -214,6 +237,7 @@ describe('Bayn continuous health', () => {
           Effect.provideService(MarketData, marketData),
           Effect.provideService(Journal, journal),
           Effect.provideService(EvidenceStore, recoveringStore(initial)),
+          Effect.provideService(CycleObservability, cycleObservability()),
           Effect.forkScoped({ startImmediately: true }),
         )
         yield* Effect.yieldNow
@@ -250,10 +274,165 @@ describe('Bayn continuous health', () => {
         Effect.provideService(MarketData, marketData),
         Effect.provideService(Journal, { ...successfulJournal, checkRun: () => Effect.void }),
         Effect.provideService(EvidenceStore, recoveringStore(initial)),
+        Effect.provideService(CycleObservability, cycleObservability()),
       ),
     )
     await Effect.runPromise(Deferred.await(started))
     await Effect.runPromise(Fiber.interrupt(fiber))
     expect(interrupted).toBe(true)
+  })
+
+  test('treats the stall threshold as exclusive and clears only after a later terminal success', async () => {
+    const initial = readyState()
+    const state = await Effect.runPromise(Ref.make(initial))
+    const pending = {
+      cycleId: '1'.repeat(64),
+      accountId: 'paper-account-1',
+      signalSessionDate: '2026-07-17',
+      executionSessionDate: '2026-07-20',
+      phase: CycleState.Pending,
+      snapshotId: '2'.repeat(64),
+      decisionHash: null,
+      terminalReason: null,
+      submissionOpenAt: '2026-07-20T00:00:00.000Z',
+      submissionCutoffAt: '2026-07-20T01:00:00.000Z',
+      executionOpenAt: '2026-07-20T01:02:00.000Z',
+      executionCloseAt: '2026-07-20T20:00:00.000Z',
+      createdAt: '2026-07-20T00:00:00.000Z',
+      updatedAt: '2026-07-20T00:00:00.000Z',
+      terminalAt: null,
+    } as const
+    let projection: CycleOperationsProjection = {
+      ...emptyCycleProjection(),
+      current: pending,
+      unfinishedCycleCount: 1,
+    }
+    const dependencies = (
+      effect: Effect.Effect<void, never, MarketData | Journal | EvidenceStore | CycleObservability>,
+    ) =>
+      effect.pipe(
+        Effect.provideService(MarketData, {
+          check: Effect.succeed(makeSnapshot().manifest.finalizedSnapshot),
+          inspect: Effect.die(new Error('health probes must not inspect sessions')),
+          load: Effect.die(new Error('health probes must not load bars')),
+        }),
+        Effect.provideService(Journal, { ...successfulJournal, checkRun: () => Effect.void }),
+        Effect.provideService(EvidenceStore, recoveringStore(initial)),
+        Effect.provideService(
+          CycleObservability,
+          cycleObservability(() => Effect.sync(() => projection)),
+        ),
+      )
+    const thresholdConfig = { ...config, cycleStallThresholdMs: 300_000 }
+    const program = Effect.gen(function* () {
+      yield* TestClock.setTime(Date.parse('2026-07-20T00:04:59.999Z'))
+      yield* dependencies(probe(thresholdConfig, state))
+      expect(yield* Ref.get(state)).toMatchObject({
+        status: 'READY',
+        cycle: {
+          condition: CycleOperationsCondition.Running,
+          reason: CycleOperationsReason.AwaitingActivation,
+          attemptAgeMs: 299_999,
+          alerts: { cycleStalled: false, cycleFailed: false },
+        },
+      })
+
+      yield* TestClock.adjust(1)
+      yield* dependencies(probe(thresholdConfig, state))
+      expect(yield* Ref.get(state)).toMatchObject({
+        status: 'DEGRADED',
+        cycle: {
+          condition: CycleOperationsCondition.Stalled,
+          reason: CycleOperationsReason.AttemptStale,
+          attemptAgeMs: 300_000,
+          alerts: { cycleStalled: true },
+        },
+      })
+
+      projection = {
+        ...emptyCycleProjection(),
+        last: {
+          ...pending,
+          phase: CycleState.Completed,
+          decisionHash: '3'.repeat(64),
+          updatedAt: '2026-07-20T00:05:01.000Z',
+          terminalAt: '2026-07-20T00:05:01.000Z',
+        },
+      }
+      yield* TestClock.adjust(1_000)
+      yield* dependencies(probe(thresholdConfig, state))
+      expect(yield* Ref.get(state)).toMatchObject({
+        status: 'READY',
+        cycle: {
+          condition: CycleOperationsCondition.Waiting,
+          reason: CycleOperationsReason.LastCycleCompleted,
+          alerts: { cycleStalled: false, cycleFailed: false },
+        },
+      })
+    }).pipe(Effect.provide(TestClock.layer()))
+
+    await Effect.runPromise(program)
+  })
+
+  test('surfaces the sole runner fiber failure and clears only after a live replacement is observed', async () => {
+    const enabledConfig = { ...config, autonomousCycle: { ...config.autonomousCycle, enabled: true } }
+    const initial: RuntimeState = {
+      ...readyState(),
+      cycleRunner: { enabled: true, status: 'STARTING', checkedAt: null, error: null },
+      health: {
+        ...readyState().health,
+        dependencies: {
+          ...readyState().health.dependencies,
+          cycleRunner: { status: 'UNKNOWN', checkedAt: null, error: null },
+        },
+      },
+    }
+    const state = await Effect.runPromise(Ref.make(initial))
+    const dependencies = (
+      effect: Effect.Effect<void, never, MarketData | Journal | EvidenceStore | CycleObservability>,
+    ) =>
+      effect.pipe(
+        Effect.provideService(MarketData, {
+          check: Effect.succeed(makeSnapshot().manifest.finalizedSnapshot),
+          inspect: Effect.die(new Error('health probes must not inspect sessions')),
+          load: Effect.die(new Error('health probes must not load bars')),
+        }),
+        Effect.provideService(Journal, { ...successfulJournal, checkRun: () => Effect.void }),
+        Effect.provideService(EvidenceStore, recoveringStore(initial)),
+        Effect.provideService(CycleObservability, cycleObservability()),
+      )
+
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const failed = yield* Effect.fail(
+            new CycleRunnerError({
+              operation: 'market-calendar',
+              failure: 'calendar-read',
+              message: 'calendar unavailable',
+            }),
+          ).pipe(Effect.forkScoped({ startImmediately: true }))
+          yield* Effect.yieldNow
+          yield* dependencies(probe(enabledConfig, state, undefined, failed))
+          expect(yield* Ref.get(state)).toMatchObject({
+            status: 'DEGRADED',
+            health: { dependencies: { cycleRunner: { status: 'UNAVAILABLE' } } },
+            cycleRunner: {
+              enabled: true,
+              status: 'FAILED',
+              error: expect.stringContaining('calendar unavailable'),
+            },
+          })
+
+          const running = yield* Effect.never.pipe(Effect.forkScoped({ startImmediately: true }))
+          yield* dependencies(probe(enabledConfig, state, undefined, running))
+          expect(yield* Ref.get(state)).toMatchObject({
+            status: 'READY',
+            health: { dependencies: { cycleRunner: { status: 'AVAILABLE', error: null } } },
+            cycleRunner: { enabled: true, status: 'RUNNING', error: null },
+          })
+        }),
+      ),
+    )
   })
 })

--- a/services/bayn/src/health.ts
+++ b/services/bayn/src/health.ts
@@ -1,4 +1,4 @@
-import { Cause, Clock, Duration, Effect, Exit, Fiber, Option, Ref, Schedule } from 'effect'
+import { Cause, Clock, Duration, Effect, Exit, Option, Ref, Schedule } from 'effect'
 
 import type { BrokerReadShape } from './broker/alpaca'
 import type { RuntimeConfig } from './config'
@@ -8,7 +8,6 @@ import {
   deriveCycleOperationsStatus,
   unknownCycleOperationsStatus,
 } from './cycle-observability'
-import type { CycleRunnerError } from './cycle-runner'
 import { CycleObservability } from './db/cycle-observability'
 import { EvidenceStore, type QualificationRecord, type RecoveredEvaluationEvidence } from './db/evidence-store'
 import { operationalError, type OperationalError } from './errors'
@@ -19,7 +18,6 @@ import { databaseOperation, withinDeadline } from './operations'
 import type {
   BrokerConfiguration,
   BrokerStatus,
-  CycleRunnerStatus,
   DependencyHealth,
   RuntimeEvidence,
   RuntimeHealth,
@@ -41,8 +39,6 @@ interface ValueProbeResult<A> extends ProbeResult {
 export interface BrokerProbe extends BrokerConfiguration {
   readonly read: BrokerReadShape
 }
-
-export type CycleRunnerFiber = Fiber.Fiber<void, CycleRunnerError>
 
 const observe = <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<ProbeResult, never, R> =>
   Effect.gen(function* () {
@@ -134,42 +130,10 @@ const dependencyHealth = (result: ProbeResult, checkedAt: string): DependencyHea
   error: result.error,
 })
 
-const inspectCycleRunner = (
-  enabled: boolean,
-  fiber: CycleRunnerFiber | undefined,
-  checkedAt: string,
-): Effect.Effect<CycleRunnerStatus> => {
-  if (!enabled) {
-    return Effect.succeed({ enabled: false, status: 'DISABLED', checkedAt, error: null })
-  }
-  if (fiber === undefined) {
-    return Effect.succeed({
-      enabled: true,
-      status: 'FAILED',
-      checkedAt,
-      error: 'autonomous cycle loop is enabled but its sole runner fiber is missing',
-    })
-  }
-  return Effect.sync(() => fiber.pollUnsafe()).pipe(
-    Effect.map((exit): CycleRunnerStatus => {
-      if (exit === undefined) return { enabled: true, status: 'RUNNING', checkedAt, error: null }
-      return {
-        enabled: true,
-        status: 'FAILED',
-        checkedAt,
-        error: Exit.isSuccess(exit)
-          ? 'autonomous cycle loop exited unexpectedly'
-          : `autonomous cycle loop failed: ${Cause.pretty(exit.cause)}`,
-      }
-    }),
-  )
-}
-
 export const probe = (
   config: RuntimeConfig,
   state: Ref.Ref<RuntimeState>,
   broker?: BrokerProbe,
-  cycleRunner?: CycleRunnerFiber,
 ): Effect.Effect<void, never, MarketData | Journal | EvidenceStore | CycleObservability> =>
   Effect.gen(function* () {
     const marketData = yield* MarketData
@@ -247,7 +211,6 @@ export const probe = (
       { concurrency: 'unbounded' },
     )
     const checkedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
-    const cycleRunnerStatus = yield* inspectCycleRunner(config.autonomousCycle.enabled, cycleRunner, checkedAt)
     const cycle =
       cycleResult.error === null && cycleResult.value !== null
         ? deriveCycleOperationsStatus(cycleResult.value, Date.parse(checkedAt), config.maximumAuthority, config)
@@ -285,7 +248,6 @@ export const probe = (
         tigerBeetle: dependencyHealth(tigerBeetle, checkedAt),
         evidence: dependencyHealth(durableEvidence, checkedAt),
         cycle: dependencyHealth(cycleResult, checkedAt),
-        cycleRunner: dependencyHealth(cycleRunnerStatus, checkedAt),
       },
     }
     const dependencyFailures = Object.entries(health.dependencies).filter(([, dependency]) => dependency.error !== null)
@@ -302,14 +264,13 @@ export const probe = (
       if (!failedDependencies.includes('cycle')) failedDependencies.push('cycle')
       failureMessages.push(`cycle: ${cycle.reason}`)
     }
-    let next: RuntimeState = { ...current, health, cycle, cycleRunner: cycleRunnerStatus, broker: brokerStatus }
+    let next: RuntimeState = { ...current, health, cycle, broker: brokerStatus }
     if (evidence !== null && failureMessages.length === 0) {
       next = {
         ...current,
         status: 'READY',
         health,
         cycle,
-        cycleRunner: cycleRunnerStatus,
         broker: brokerStatus,
         error: null,
       }
@@ -319,7 +280,6 @@ export const probe = (
         status: 'DEGRADED',
         health,
         cycle,
-        cycleRunner: cycleRunnerStatus,
         broker: brokerStatus,
         error: failureMessages.join('; '),
       }
@@ -361,27 +321,14 @@ export const probe = (
         }),
       )
     }
-    if (next.cycleRunner.status !== current.cycleRunner.status) {
-      const log = next.cycleRunner.status === 'FAILED' ? Effect.logWarning : Effect.logInfo
-      yield* log(`Bayn autonomous cycle runner changed to ${next.cycleRunner.status}`).pipe(
-        Effect.annotateLogs({
-          service: 'bayn',
-          checkedAt,
-          cycleRunnerEnabled: next.cycleRunner.enabled,
-          cycleRunnerStatus: next.cycleRunner.status,
-          cycleRunnerError: next.cycleRunner.error ?? '',
-        }),
-      )
-    }
   }).pipe(Effect.withLogSpan('health'))
 
 export const monitor = (
   config: RuntimeConfig,
   state: Ref.Ref<RuntimeState>,
   broker?: BrokerProbe,
-  cycleRunner?: CycleRunnerFiber,
 ): Effect.Effect<void, never, MarketData | Journal | EvidenceStore | CycleObservability> =>
-  probe(config, state, broker, cycleRunner).pipe(
+  probe(config, state, broker).pipe(
     Effect.repeat(Schedule.spaced(Duration.millis(config.healthIntervalMs))),
     Effect.asVoid,
   )

--- a/services/bayn/src/health.ts
+++ b/services/bayn/src/health.ts
@@ -1,8 +1,15 @@
-import { Cause, Clock, Duration, Effect, Exit, Option, Ref, Schedule } from 'effect'
+import { Cause, Clock, Duration, Effect, Exit, Fiber, Option, Ref, Schedule } from 'effect'
 
 import type { BrokerReadShape } from './broker/alpaca'
 import type { RuntimeConfig } from './config'
 import type { FinalizedSnapshotProvenance } from './contracts'
+import {
+  CycleOperationsCondition,
+  deriveCycleOperationsStatus,
+  unknownCycleOperationsStatus,
+} from './cycle-observability'
+import type { CycleRunnerError } from './cycle-runner'
+import { CycleObservability } from './db/cycle-observability'
 import { EvidenceStore, type QualificationRecord, type RecoveredEvaluationEvidence } from './db/evidence-store'
 import { operationalError, type OperationalError } from './errors'
 import { canonicalHashV1 } from './hash'
@@ -12,6 +19,7 @@ import { databaseOperation, withinDeadline } from './operations'
 import type {
   BrokerConfiguration,
   BrokerStatus,
+  CycleRunnerStatus,
   DependencyHealth,
   RuntimeEvidence,
   RuntimeHealth,
@@ -26,9 +34,15 @@ interface BrokerProbeResult extends ProbeResult {
   readonly accountId: string | null
 }
 
+interface ValueProbeResult<A> extends ProbeResult {
+  readonly value: A | null
+}
+
 export interface BrokerProbe extends BrokerConfiguration {
   readonly read: BrokerReadShape
 }
+
+export type CycleRunnerFiber = Fiber.Fiber<void, CycleRunnerError>
 
 const observe = <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<ProbeResult, never, R> =>
   Effect.gen(function* () {
@@ -53,6 +67,15 @@ const observeBroker = (read: BrokerReadShape, timeoutMs: number): Effect.Effect<
     if (Cause.hasInterrupts(exit.cause)) return yield* Effect.interrupt
     const errors = Cause.prettyErrors(exit.cause).map((error) => error.message)
     return { accountId: null, error: errors.join('; ') || 'unknown broker probe failure' }
+  })
+
+const observeValue = <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<ValueProbeResult<A>, never, R> =>
+  Effect.gen(function* () {
+    const exit = yield* Effect.exit(effect)
+    if (Exit.isSuccess(exit)) return { value: exit.value, error: null }
+    if (Cause.hasInterrupts(exit.cause)) return yield* Effect.interrupt
+    const errors = Cause.prettyErrors(exit.cause).map((error) => error.message)
+    return { value: null, error: errors.join('; ') || 'unknown probe failure' }
   })
 
 const ensureSignalIdentity = (
@@ -111,18 +134,51 @@ const dependencyHealth = (result: ProbeResult, checkedAt: string): DependencyHea
   error: result.error,
 })
 
+const inspectCycleRunner = (
+  enabled: boolean,
+  fiber: CycleRunnerFiber | undefined,
+  checkedAt: string,
+): Effect.Effect<CycleRunnerStatus> => {
+  if (!enabled) {
+    return Effect.succeed({ enabled: false, status: 'DISABLED', checkedAt, error: null })
+  }
+  if (fiber === undefined) {
+    return Effect.succeed({
+      enabled: true,
+      status: 'FAILED',
+      checkedAt,
+      error: 'autonomous cycle loop is enabled but its sole runner fiber is missing',
+    })
+  }
+  return Effect.sync(() => fiber.pollUnsafe()).pipe(
+    Effect.map((exit): CycleRunnerStatus => {
+      if (exit === undefined) return { enabled: true, status: 'RUNNING', checkedAt, error: null }
+      return {
+        enabled: true,
+        status: 'FAILED',
+        checkedAt,
+        error: Exit.isSuccess(exit)
+          ? 'autonomous cycle loop exited unexpectedly'
+          : `autonomous cycle loop failed: ${Cause.pretty(exit.cause)}`,
+      }
+    }),
+  )
+}
+
 export const probe = (
   config: RuntimeConfig,
   state: Ref.Ref<RuntimeState>,
   broker?: BrokerProbe,
-): Effect.Effect<void, never, MarketData | Journal | EvidenceStore> =>
+  cycleRunner?: CycleRunnerFiber,
+): Effect.Effect<void, never, MarketData | Journal | EvidenceStore | CycleObservability> =>
   Effect.gen(function* () {
     const marketData = yield* MarketData
     const journal = yield* Journal
     const evidenceStore = yield* EvidenceStore
+    const cycleObservability = yield* CycleObservability
     const current = yield* Ref.get(state)
     const evidence = current.evidence
-    const [[postgresql, signal, tigerBeetle, durableEvidence], brokerResult] = yield* Effect.all(
+    const [[postgresql, signal, tigerBeetle, durableEvidence, cycleResult], brokerResult] = yield* Effect.all(
       [
         Effect.all(
           [
@@ -170,6 +226,19 @@ export const probe = (
                     ),
                   ),
             ),
+            observeValue(
+              evidence === null
+                ? Effect.fail(operationalError('database', 'cycle-observability', 'startup evidence is unavailable'))
+                : withinDeadline(
+                    databaseOperation(
+                      cycleObservability.read(evidence.evaluation.runId, broker?.expectedAccountId),
+                      'cycle-observability',
+                    ),
+                    config.operationTimeoutMs,
+                    'database',
+                    'cycle-observability',
+                  ),
+            ),
           ],
           { concurrency: 'unbounded' },
         ),
@@ -178,6 +247,14 @@ export const probe = (
       { concurrency: 'unbounded' },
     )
     const checkedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
+    const cycleRunnerStatus = yield* inspectCycleRunner(config.autonomousCycle.enabled, cycleRunner, checkedAt)
+    const cycle =
+      cycleResult.error === null && cycleResult.value !== null
+        ? deriveCycleOperationsStatus(cycleResult.value, Date.parse(checkedAt), config.maximumAuthority, config)
+        : {
+            ...unknownCycleOperationsStatus(cycleResult.error ?? 'cycle observability probe did not run'),
+            checkedAt,
+          }
     let brokerStatus: BrokerStatus | null = current.broker
     if (broker !== undefined) {
       const result = brokerResult ?? { accountId: null, error: 'broker probe did not run' }
@@ -207,6 +284,8 @@ export const probe = (
         signal: dependencyHealth(signal, checkedAt),
         tigerBeetle: dependencyHealth(tigerBeetle, checkedAt),
         evidence: dependencyHealth(durableEvidence, checkedAt),
+        cycle: dependencyHealth(cycleResult, checkedAt),
+        cycleRunner: dependencyHealth(cycleRunnerStatus, checkedAt),
       },
     }
     const dependencyFailures = Object.entries(health.dependencies).filter(([, dependency]) => dependency.error !== null)
@@ -219,14 +298,28 @@ export const probe = (
       failedDependencies.push('broker')
       failureMessages.push(`broker: ${brokerStatus.error ?? 'account binding unavailable'}`)
     }
-    let next: RuntimeState = { ...current, health, broker: brokerStatus }
+    if (cycle.condition === CycleOperationsCondition.Stalled || cycle.condition === CycleOperationsCondition.Failed) {
+      if (!failedDependencies.includes('cycle')) failedDependencies.push('cycle')
+      failureMessages.push(`cycle: ${cycle.reason}`)
+    }
+    let next: RuntimeState = { ...current, health, cycle, cycleRunner: cycleRunnerStatus, broker: brokerStatus }
     if (evidence !== null && failureMessages.length === 0) {
-      next = { ...current, status: 'READY', health, broker: brokerStatus, error: null }
+      next = {
+        ...current,
+        status: 'READY',
+        health,
+        cycle,
+        cycleRunner: cycleRunnerStatus,
+        broker: brokerStatus,
+        error: null,
+      }
     } else if (evidence !== null) {
       next = {
         ...current,
         status: 'DEGRADED',
         health,
+        cycle,
+        cycleRunner: cycleRunnerStatus,
         broker: brokerStatus,
         error: failureMessages.join('; '),
       }
@@ -244,14 +337,51 @@ export const probe = (
         }),
       )
     }
+    if (next.cycle.condition !== current.cycle.condition || next.cycle.reason !== current.cycle.reason) {
+      const cycleObservationAvailable = next.cycle.condition !== CycleOperationsCondition.Unknown
+      const log =
+        next.cycle.condition === CycleOperationsCondition.Stalled ||
+        next.cycle.condition === CycleOperationsCondition.Failed
+          ? Effect.logWarning
+          : Effect.logInfo
+      yield* log(`Bayn cycle operations changed to ${next.cycle.condition}`).pipe(
+        Effect.annotateLogs({
+          service: 'bayn',
+          checkedAt,
+          cycleCondition: next.cycle.condition,
+          cycleReason: next.cycle.reason,
+          currentCycleId: next.cycle.current?.cycleId ?? '',
+          currentPhase: next.cycle.current?.phase ?? '',
+          signalSessionDate: next.cycle.current?.signalSessionDate ?? '',
+          submissionCutoffAt: next.cycle.current?.submissionCutoffAt ?? '',
+          attemptAgeMs: next.cycle.attemptAgeMs ?? -1,
+          unfinishedCycleCount: cycleObservationAvailable ? next.cycle.unfinishedCycleCount : 'unknown',
+          unresolvedMutationCount: cycleObservationAvailable ? next.cycle.mutations.unresolvedCount : 'unknown',
+          zeroMutation: cycleObservationAvailable ? next.cycle.zeroMutation : 'unknown',
+        }),
+      )
+    }
+    if (next.cycleRunner.status !== current.cycleRunner.status) {
+      const log = next.cycleRunner.status === 'FAILED' ? Effect.logWarning : Effect.logInfo
+      yield* log(`Bayn autonomous cycle runner changed to ${next.cycleRunner.status}`).pipe(
+        Effect.annotateLogs({
+          service: 'bayn',
+          checkedAt,
+          cycleRunnerEnabled: next.cycleRunner.enabled,
+          cycleRunnerStatus: next.cycleRunner.status,
+          cycleRunnerError: next.cycleRunner.error ?? '',
+        }),
+      )
+    }
   }).pipe(Effect.withLogSpan('health'))
 
 export const monitor = (
   config: RuntimeConfig,
   state: Ref.Ref<RuntimeState>,
   broker?: BrokerProbe,
-): Effect.Effect<void, never, MarketData | Journal | EvidenceStore> =>
-  probe(config, state, broker).pipe(
+  cycleRunner?: CycleRunnerFiber,
+): Effect.Effect<void, never, MarketData | Journal | EvidenceStore | CycleObservability> =>
+  probe(config, state, broker, cycleRunner).pipe(
     Effect.repeat(Schedule.spaced(Duration.millis(config.healthIntervalMs))),
     Effect.asVoid,
   )

--- a/services/bayn/src/http.test.ts
+++ b/services/bayn/src/http.test.ts
@@ -315,8 +315,6 @@ describe('Bayn HTTP probes', () => {
     expect(metrics).toContain('bayn_cycle_condition{condition="unknown"} 1')
     expect(metrics).toContain('bayn_cycle_reason{reason="observation_unavailable"} 1')
     expect(metrics).toContain('bayn_cycle_phase{phase="unknown"} 1')
-    expect(metrics).toContain('bayn_cycle_runner_enabled 0')
-    expect(metrics).toContain('bayn_cycle_runner_status{status="disabled"} 1')
     expect(metrics).toContain('bayn_zero_mutation_confirmed 0')
     expect(metrics).not.toContain('bayn_cycle_unfinished_count ')
     expect(metrics).not.toContain('bayn_mutation_events_total ')

--- a/services/bayn/src/http.test.ts
+++ b/services/bayn/src/http.test.ts
@@ -4,6 +4,7 @@ import { Context, Effect, Layer, Ref } from 'effect'
 import { HttpServer } from 'effect/unstable/http'
 
 import {
+  config,
   provenance,
   historicalRunId,
   successfulEvidenceStore,
@@ -15,7 +16,7 @@ import type { BrokerReadShape } from './broker/alpaca'
 import { unusedMarketCalendar } from './broker/alpaca-test-support'
 import { DatabaseError, type EvidenceStoreService } from './db/evidence-store'
 import type { BrokerProbe } from './health'
-import { makeHttpLayer } from './http'
+import { makeHttpLayer, renderPrometheusMetrics } from './http'
 import { Authority } from './paper'
 import { initialState } from './runtime-state'
 
@@ -29,10 +30,13 @@ describe('Bayn HTTP probes', () => {
           const context = yield* Layer.build(
             makeHttpLayer(
               {
+                cycleStallThresholdMs: config.cycleStallThresholdMs,
                 host: '127.0.0.1',
                 maximumAuthority: Authority.Observe,
                 operationTimeoutMs: 250,
                 port: 0,
+                reconciliationStaleThresholdMs: config.reconciliationStaleThresholdMs,
+                unknownMutationThresholdMs: config.unknownMutationThresholdMs,
               },
               state,
               provenance,
@@ -65,6 +69,12 @@ describe('Bayn HTTP probes', () => {
             body: {
               service: 'bayn',
               operational: { status: 'READY', ready: true, probeSequence: 1 },
+              cycle: {
+                condition: 'WAITING',
+                reason: 'NO_CYCLE_RECORDED',
+                zeroMutation: true,
+                mutations: { eventCount: 0, unresolvedCount: 0 },
+              },
               authority: { maximum: 'observe', brokerOrders: false, capitalPromotion: false },
               broker: {
                 configured: false,
@@ -89,6 +99,14 @@ describe('Bayn HTTP probes', () => {
           expect(statusResponse.body.economic).not.toHaveProperty('status')
           expect(statusResponse.body.qualification).not.toHaveProperty('status')
           expect(statusResponse.body.qualification).not.toHaveProperty('executable')
+          const metricsResponse = yield* Effect.promise(() => fetch(`http://127.0.0.1:${port}/metrics`))
+          const metrics = yield* Effect.promise(() => metricsResponse.text())
+          expect(metricsResponse.status).toBe(200)
+          expect(metricsResponse.headers.get('content-type')).toContain('text/plain')
+          expect(metrics).toContain('bayn_cycle_condition{condition="waiting"} 1')
+          expect(metrics).toContain('bayn_mutation_events_total 0')
+          expect(metrics).toContain('bayn_broker_orders_enabled 0')
+          expect(metrics).toContain('bayn_capital_promotion_enabled 0')
           expect(yield* Effect.promise(() => fetchJson(port, `/v1/evaluations/${historicalRunId}`))).toMatchObject({
             status: 200,
             body: { run: { runId: historicalRunId } },
@@ -106,10 +124,27 @@ describe('Bayn HTTP probes', () => {
             status: 503,
             body: { ready: false, status: 'FAILED' },
           })
-          expect(yield* Effect.promise(() => fetchJson(port, '/v1/status'))).toMatchObject({
+          const failedStatus = yield* Effect.promise(() => fetchJson(port, '/v1/status'))
+          expect(failedStatus).toMatchObject({
             status: 200,
-            body: { operational: { status: 'FAILED' }, error: 'test failure' },
+            body: {
+              operational: { status: 'FAILED' },
+              cycle: {
+                observationAvailable: false,
+                condition: 'UNKNOWN',
+                zeroMutation: null,
+              },
+              authority: { durable: { available: false } },
+              error: 'test failure',
+            },
           })
+          const failedBody = failedStatus.body as {
+            readonly authority: { readonly durable: Record<string, unknown> }
+            readonly cycle: Record<string, unknown>
+          }
+          expect(failedBody.cycle).not.toHaveProperty('unfinishedCycleCount')
+          expect(failedBody.cycle).not.toHaveProperty('mutations')
+          expect(failedBody.authority.durable).not.toHaveProperty('configured')
           expect(yield* Effect.promise(() => fetchJson(port, '/v1/evidence/latest'))).toMatchObject({
             status: 404,
             body: { error: 'not_found' },
@@ -152,10 +187,13 @@ describe('Bayn HTTP probes', () => {
           const context = yield* Layer.build(
             makeHttpLayer(
               {
+                cycleStallThresholdMs: config.cycleStallThresholdMs,
                 host: '127.0.0.1',
                 maximumAuthority: Authority.Observe,
                 operationTimeoutMs: 250,
                 port: 0,
+                reconciliationStaleThresholdMs: config.reconciliationStaleThresholdMs,
+                unknownMutationThresholdMs: config.unknownMutationThresholdMs,
               },
               state,
               provenance,
@@ -181,7 +219,15 @@ describe('Bayn HTTP probes', () => {
           const state = yield* Ref.make(initialState())
           const context = yield* Layer.build(
             makeHttpLayer(
-              { host: '127.0.0.1', maximumAuthority: Authority.Paper, operationTimeoutMs: 250, port: 0 },
+              {
+                cycleStallThresholdMs: config.cycleStallThresholdMs,
+                host: '127.0.0.1',
+                maximumAuthority: Authority.Paper,
+                operationTimeoutMs: 250,
+                port: 0,
+                reconciliationStaleThresholdMs: config.reconciliationStaleThresholdMs,
+                unknownMutationThresholdMs: config.unknownMutationThresholdMs,
+              },
               state,
               provenance,
               'embedded',
@@ -228,10 +274,13 @@ describe('Bayn HTTP probes', () => {
           const context = yield* Layer.build(
             makeHttpLayer(
               {
+                cycleStallThresholdMs: config.cycleStallThresholdMs,
                 host: '127.0.0.1',
                 maximumAuthority: Authority.Observe,
                 operationTimeoutMs: 250,
                 port: 0,
+                reconciliationStaleThresholdMs: config.reconciliationStaleThresholdMs,
+                unknownMutationThresholdMs: config.unknownMutationThresholdMs,
               },
               state,
               provenance,
@@ -257,5 +306,23 @@ describe('Bayn HTTP probes', () => {
         }),
       ),
     )
+  })
+
+  test('does not synthesize durable cycle, mutation, reconciliation, or authority observations', () => {
+    const metrics = renderPrometheusMetrics(initialState(), config, provenance, 'embedded')
+
+    expect(metrics).toContain('bayn_cycle_observation_available 0')
+    expect(metrics).toContain('bayn_cycle_condition{condition="unknown"} 1')
+    expect(metrics).toContain('bayn_cycle_reason{reason="observation_unavailable"} 1')
+    expect(metrics).toContain('bayn_cycle_phase{phase="unknown"} 1')
+    expect(metrics).toContain('bayn_cycle_runner_enabled 0')
+    expect(metrics).toContain('bayn_cycle_runner_status{status="disabled"} 1')
+    expect(metrics).toContain('bayn_zero_mutation_confirmed 0')
+    expect(metrics).not.toContain('bayn_cycle_unfinished_count ')
+    expect(metrics).not.toContain('bayn_mutation_events_total ')
+    expect(metrics).not.toContain('bayn_unresolved_mutations ')
+    expect(metrics).not.toContain('bayn_reconciliation_available ')
+    expect(metrics).not.toContain('bayn_authority_coherent ')
+    expect(metrics).not.toContain('bayn_authority_kill_active ')
   })
 })

--- a/services/bayn/src/http.ts
+++ b/services/bayn/src/http.ts
@@ -43,12 +43,10 @@ const publicCycleState = (state: RuntimeState) =>
         checkedAt: state.cycle.checkedAt,
         zeroMutation: null,
         error: state.cycle.error,
-        runner: state.cycleRunner,
       }
     : {
         ...state.cycle,
         observationAvailable: true,
-        runner: state.cycleRunner,
       }
 
 const publicState = (
@@ -166,7 +164,6 @@ export const renderPrometheusMetrics = (
   const conditions = Object.values(CycleOperationsCondition)
   const reasons = Object.values(CycleOperationsReason)
   const phases = ['unknown', 'none', ...Object.values(CycleState).map((phase) => phase.toLowerCase())]
-  const runnerStatuses = ['DISABLED', 'STARTING', 'RUNNING', 'FAILED'] as const
   const effectiveAuthority =
     state.cycle.authority === null
       ? 'unknown'
@@ -191,15 +188,6 @@ export const renderPrometheusMetrics = (
     '# HELP bayn_cycle_phase Current unfinished cycle phase, or the latest terminal phase when idle.',
     '# TYPE bayn_cycle_phase gauge',
     ...phases.map((phase) => `bayn_cycle_phase{phase="${phase}"} ${cyclePhase === phase ? 1 : 0}`),
-    '# HELP bayn_cycle_runner_enabled Whether GitOps enables the sole in-process autonomous cycle runner.',
-    '# TYPE bayn_cycle_runner_enabled gauge',
-    `bayn_cycle_runner_enabled ${state.cycleRunner.enabled ? 1 : 0}`,
-    '# HELP bayn_cycle_runner_status Current state of the sole in-process autonomous cycle runner.',
-    '# TYPE bayn_cycle_runner_status gauge',
-    ...runnerStatuses.map(
-      (status) =>
-        `bayn_cycle_runner_status{status="${status.toLowerCase()}"} ${state.cycleRunner.status === status ? 1 : 0}`,
-    ),
     ...(cycleObservationAvailable
       ? [
           '# HELP bayn_cycle_unfinished_count Number of unfinished cycles for the bound qualification run.',
@@ -252,6 +240,9 @@ export const renderPrometheusMetrics = (
           '# HELP bayn_reconciliation_age_seconds Age of the latest selected-account reconciliation.',
           '# TYPE bayn_reconciliation_age_seconds gauge',
           `bayn_reconciliation_age_seconds ${prometheusNumber((state.cycle.reconciliationAgeMs ?? 0) / 1_000)}`,
+          '# HELP bayn_reconciliation_covers_latest_mutation Whether reconciliation is at or after the latest selected-account mutation.',
+          '# TYPE bayn_reconciliation_covers_latest_mutation gauge',
+          `bayn_reconciliation_covers_latest_mutation ${booleanMetric(state.cycle.reconciliationCoversLatestMutation)}`,
         ]
       : []),
     '# HELP bayn_reconciliation_stale_threshold_seconds Configured reconciliation staleness threshold.',

--- a/services/bayn/src/http.ts
+++ b/services/bayn/src/http.ts
@@ -6,6 +6,8 @@ import { HttpRouter, HttpServerRequest, HttpServerResponse } from 'effect/unstab
 
 import type { RuntimeBuildMetadata, RuntimeConfig } from './config'
 import type { RuntimeProvenance } from './contracts'
+import { CycleOperationsCondition, CycleOperationsReason } from './cycle-observability'
+import { CycleState } from './cycle'
 import { Authority } from './paper'
 import { isReady, type DependencyHealth, type RuntimeState } from './runtime-state'
 
@@ -30,6 +32,24 @@ const publicBrokerState = (state: RuntimeState) =>
         error: null,
       }
     : state.broker
+
+const publicCycleState = (state: RuntimeState) =>
+  state.cycle.condition === CycleOperationsCondition.Unknown
+    ? {
+        schemaVersion: state.cycle.schemaVersion,
+        observationAvailable: false,
+        condition: state.cycle.condition,
+        reason: state.cycle.reason,
+        checkedAt: state.cycle.checkedAt,
+        zeroMutation: null,
+        error: state.cycle.error,
+        runner: state.cycleRunner,
+      }
+    : {
+        ...state.cycle,
+        observationAvailable: true,
+        runner: state.cycleRunner,
+      }
 
 const publicState = (
   state: RuntimeState,
@@ -78,9 +98,34 @@ const publicState = (
       status: accounting,
       reconciliation: state.evidence?.reconciliation ?? null,
     },
+    cycle: publicCycleState(state),
     broker: publicBrokerState(state),
     authority: {
       maximum: maximumAuthority === Authority.Paper ? 'paper' : 'observe',
+      durable:
+        state.cycle.condition === CycleOperationsCondition.Unknown
+          ? {
+              available: false,
+            }
+          : state.cycle.authority === null
+            ? {
+                available: true,
+                configured: false,
+                maximum: null,
+                effective: null,
+                kill: null,
+                reason: null,
+                updatedAt: null,
+              }
+            : {
+                available: true,
+                configured: true,
+                maximum: state.cycle.authority.maximum === Authority.Paper ? 'paper' : 'observe',
+                effective: state.cycle.authority.effective === Authority.Paper ? 'paper' : 'observe',
+                kill: state.cycle.authority.kill.toLowerCase(),
+                reason: state.cycle.authority.reason,
+                updatedAt: state.cycle.authority.updatedAt,
+              },
       brokerOrders: false,
       capitalPromotion: false,
     },
@@ -93,11 +138,181 @@ const publicState = (
   }
 }
 
+const prometheusLabel = (value: string): string =>
+  value.replaceAll('\\', '\\\\').replaceAll('\n', '\\n').replaceAll('"', '\\"')
+
+const prometheusNumber = (value: number): string => (Number.isFinite(value) ? String(value) : '0')
+
+const epochSeconds = (instant: string | null | undefined): number =>
+  instant === null || instant === undefined ? 0 : Date.parse(instant) / 1_000
+
+const booleanMetric = (value: boolean | null): number => (value === true ? 1 : 0)
+
+export const renderPrometheusMetrics = (
+  state: RuntimeState,
+  config: Pick<
+    RuntimeConfig,
+    'cycleStallThresholdMs' | 'maximumAuthority' | 'reconciliationStaleThresholdMs' | 'unknownMutationThresholdMs'
+  >,
+  provenance: RuntimeProvenance,
+  provenanceVerification: RuntimeBuildMetadata['verification'],
+): string => {
+  const publicBroker = publicBrokerState(state)
+  const cycleObservationAvailable = state.cycle.condition !== CycleOperationsCondition.Unknown
+  const cyclePhase =
+    cycleObservationAvailable === false
+      ? 'unknown'
+      : (state.cycle.current?.phase ?? state.cycle.last?.phase ?? 'none').toLowerCase()
+  const conditions = Object.values(CycleOperationsCondition)
+  const reasons = Object.values(CycleOperationsReason)
+  const phases = ['unknown', 'none', ...Object.values(CycleState).map((phase) => phase.toLowerCase())]
+  const runnerStatuses = ['DISABLED', 'STARTING', 'RUNNING', 'FAILED'] as const
+  const effectiveAuthority =
+    state.cycle.authority === null
+      ? 'unknown'
+      : state.cycle.authority.effective === Authority.Paper
+        ? 'paper'
+        : 'observe'
+  const lines = [
+    '# HELP bayn_cycle_observation_available Whether the bounded PostgreSQL cycle projection is current.',
+    '# TYPE bayn_cycle_observation_available gauge',
+    `bayn_cycle_observation_available ${cycleObservationAvailable ? 1 : 0}`,
+    '# HELP bayn_cycle_condition Current bounded autonomous-cycle operations condition.',
+    '# TYPE bayn_cycle_condition gauge',
+    ...conditions.map(
+      (condition) =>
+        `bayn_cycle_condition{condition="${condition.toLowerCase()}"} ${state.cycle.condition === condition ? 1 : 0}`,
+    ),
+    '# HELP bayn_cycle_reason Current bounded autonomous-cycle operations reason.',
+    '# TYPE bayn_cycle_reason gauge',
+    ...reasons.map(
+      (reason) => `bayn_cycle_reason{reason="${reason.toLowerCase()}"} ${state.cycle.reason === reason ? 1 : 0}`,
+    ),
+    '# HELP bayn_cycle_phase Current unfinished cycle phase, or the latest terminal phase when idle.',
+    '# TYPE bayn_cycle_phase gauge',
+    ...phases.map((phase) => `bayn_cycle_phase{phase="${phase}"} ${cyclePhase === phase ? 1 : 0}`),
+    '# HELP bayn_cycle_runner_enabled Whether GitOps enables the sole in-process autonomous cycle runner.',
+    '# TYPE bayn_cycle_runner_enabled gauge',
+    `bayn_cycle_runner_enabled ${state.cycleRunner.enabled ? 1 : 0}`,
+    '# HELP bayn_cycle_runner_status Current state of the sole in-process autonomous cycle runner.',
+    '# TYPE bayn_cycle_runner_status gauge',
+    ...runnerStatuses.map(
+      (status) =>
+        `bayn_cycle_runner_status{status="${status.toLowerCase()}"} ${state.cycleRunner.status === status ? 1 : 0}`,
+    ),
+    ...(cycleObservationAvailable
+      ? [
+          '# HELP bayn_cycle_unfinished_count Number of unfinished cycles for the bound qualification run.',
+          '# TYPE bayn_cycle_unfinished_count gauge',
+          `bayn_cycle_unfinished_count ${state.cycle.unfinishedCycleCount}`,
+          '# HELP bayn_cycle_attempt_age_seconds Age of the current cycle state transition.',
+          '# TYPE bayn_cycle_attempt_age_seconds gauge',
+          `bayn_cycle_attempt_age_seconds ${prometheusNumber((state.cycle.attemptAgeMs ?? 0) / 1_000)}`,
+          '# HELP bayn_cycle_submission_cutoff_timestamp_seconds Bound broker submission cutoff.',
+          '# TYPE bayn_cycle_submission_cutoff_timestamp_seconds gauge',
+          `bayn_cycle_submission_cutoff_timestamp_seconds ${prometheusNumber(epochSeconds(state.cycle.current?.submissionCutoffAt))}`,
+          '# HELP bayn_cycle_execution_close_timestamp_seconds Bound current execution-session close.',
+          '# TYPE bayn_cycle_execution_close_timestamp_seconds gauge',
+          `bayn_cycle_execution_close_timestamp_seconds ${prometheusNumber(epochSeconds(state.cycle.current?.executionCloseAt))}`,
+          '# HELP bayn_cycle_last_terminal_timestamp_seconds Latest terminal cycle timestamp.',
+          '# TYPE bayn_cycle_last_terminal_timestamp_seconds gauge',
+          `bayn_cycle_last_terminal_timestamp_seconds ${prometheusNumber(epochSeconds(state.cycle.last?.terminalAt))}`,
+        ]
+      : []),
+    '# HELP bayn_cycle_stall_threshold_seconds Configured attempt-stall threshold.',
+    '# TYPE bayn_cycle_stall_threshold_seconds gauge',
+    `bayn_cycle_stall_threshold_seconds ${prometheusNumber(config.cycleStallThresholdMs / 1_000)}`,
+    ...(cycleObservationAvailable
+      ? [
+          '# HELP bayn_mutation_events_total Durable broker mutation event count.',
+          '# TYPE bayn_mutation_events_total counter',
+          `bayn_mutation_events_total ${state.cycle.mutations.eventCount}`,
+          '# HELP bayn_unresolved_mutations Durable unresolved broker mutation count.',
+          '# TYPE bayn_unresolved_mutations gauge',
+          `bayn_unresolved_mutations ${state.cycle.mutations.unresolvedCount}`,
+          '# HELP bayn_oldest_unresolved_mutation_age_seconds Age of the oldest unresolved broker mutation.',
+          '# TYPE bayn_oldest_unresolved_mutation_age_seconds gauge',
+          `bayn_oldest_unresolved_mutation_age_seconds ${prometheusNumber((state.cycle.oldestUnresolvedMutationAgeMs ?? 0) / 1_000)}`,
+        ]
+      : []),
+    '# HELP bayn_zero_mutation_confirmed Whether the current projection confirms zero durable mutation events.',
+    '# TYPE bayn_zero_mutation_confirmed gauge',
+    `bayn_zero_mutation_confirmed ${state.cycle.zeroMutation === true ? 1 : 0}`,
+    '# HELP bayn_unknown_mutation_threshold_seconds Configured unresolved-mutation alert threshold.',
+    '# TYPE bayn_unknown_mutation_threshold_seconds gauge',
+    `bayn_unknown_mutation_threshold_seconds ${prometheusNumber(config.unknownMutationThresholdMs / 1_000)}`,
+    ...(cycleObservationAvailable
+      ? [
+          '# HELP bayn_reconciliation_available Whether a complete reconciliation exists for the selected account.',
+          '# TYPE bayn_reconciliation_available gauge',
+          `bayn_reconciliation_available ${booleanMetric(state.cycle.reconciliation !== null)}`,
+          '# HELP bayn_reconciliation_exact Whether the latest selected-account reconciliation is exact.',
+          '# TYPE bayn_reconciliation_exact gauge',
+          `bayn_reconciliation_exact ${booleanMetric(state.cycle.reconciliation?.status === 'EXACT')}`,
+          '# HELP bayn_reconciliation_age_seconds Age of the latest selected-account reconciliation.',
+          '# TYPE bayn_reconciliation_age_seconds gauge',
+          `bayn_reconciliation_age_seconds ${prometheusNumber((state.cycle.reconciliationAgeMs ?? 0) / 1_000)}`,
+        ]
+      : []),
+    '# HELP bayn_reconciliation_stale_threshold_seconds Configured reconciliation staleness threshold.',
+    '# TYPE bayn_reconciliation_stale_threshold_seconds gauge',
+    `bayn_reconciliation_stale_threshold_seconds ${prometheusNumber(config.reconciliationStaleThresholdMs / 1_000)}`,
+    '# HELP bayn_authority_maximum Configured maximum authority.',
+    '# TYPE bayn_authority_maximum gauge',
+    `bayn_authority_maximum{authority="observe"} ${config.maximumAuthority === Authority.Observe ? 1 : 0}`,
+    `bayn_authority_maximum{authority="paper"} ${config.maximumAuthority === Authority.Paper ? 1 : 0}`,
+    ...(cycleObservationAvailable
+      ? [
+          '# HELP bayn_authority_effective Durable effective authority when initialized.',
+          '# TYPE bayn_authority_effective gauge',
+          ...(['unknown', 'observe', 'paper'] as const).map(
+            (authority) =>
+              `bayn_authority_effective{authority="${authority}"} ${effectiveAuthority === authority ? 1 : 0}`,
+          ),
+          '# HELP bayn_authority_coherent Whether durable and configured authority agree.',
+          '# TYPE bayn_authority_coherent gauge',
+          `bayn_authority_coherent ${state.cycle.alerts.authorityIncoherent ? 0 : 1}`,
+          '# HELP bayn_authority_kill_active Whether the durable paper kill is active.',
+          '# TYPE bayn_authority_kill_active gauge',
+          `bayn_authority_kill_active ${state.cycle.alerts.killActive ? 1 : 0}`,
+        ]
+      : []),
+    '# HELP bayn_broker_configured Whether an exact Alpaca account binding is configured.',
+    '# TYPE bayn_broker_configured gauge',
+    `bayn_broker_configured ${publicBroker.configured ? 1 : 0}`,
+    '# HELP bayn_broker_read_available Whether the bounded Alpaca GET probe succeeds.',
+    '# TYPE bayn_broker_read_available gauge',
+    `bayn_broker_read_available ${booleanMetric(publicBroker.readAvailable)}`,
+    '# HELP bayn_broker_account_bound Whether the observed Alpaca account matches the configured identity.',
+    '# TYPE bayn_broker_account_bound gauge',
+    `bayn_broker_account_bound ${booleanMetric(publicBroker.accountBound)}`,
+    '# HELP bayn_broker_orders_enabled Whether broker mutation dispatch is enabled in this runtime.',
+    '# TYPE bayn_broker_orders_enabled gauge',
+    'bayn_broker_orders_enabled 0',
+    '# HELP bayn_capital_promotion_enabled Whether capital promotion is enabled in this runtime.',
+    '# TYPE bayn_capital_promotion_enabled gauge',
+    'bayn_capital_promotion_enabled 0',
+    '# HELP bayn_build_info Verified runtime build provenance.',
+    '# TYPE bayn_build_info gauge',
+    `bayn_build_info{source_revision="${prometheusLabel(provenance.sourceRevision)}",image_digest="${prometheusLabel(provenance.image.digest)}",verification="${prometheusLabel(provenanceVerification)}"} 1`,
+  ]
+  return `${lines.join('\n')}\n`
+}
+
 const jsonResponse = (body: unknown, status = 200, headers?: Readonly<Record<string, string>>) =>
   HttpServerResponse.json(body, { status, headers }).pipe(Effect.orDie)
 
 export const makeHttpLayer = (
-  config: Pick<RuntimeConfig, 'host' | 'maximumAuthority' | 'operationTimeoutMs' | 'port'>,
+  config: Pick<
+    RuntimeConfig,
+    | 'cycleStallThresholdMs'
+    | 'host'
+    | 'maximumAuthority'
+    | 'operationTimeoutMs'
+    | 'port'
+    | 'reconciliationStaleThresholdMs'
+    | 'unknownMutationThresholdMs'
+  >,
   state: Ref.Ref<RuntimeState>,
   provenance: RuntimeProvenance,
   provenanceVerification: RuntimeBuildMetadata['verification'],
@@ -111,6 +326,13 @@ export const makeHttpLayer = (
         .map(([name]) => name)
       if (current.broker !== null && (current.broker.accountBound !== true || current.broker.readAvailable !== true)) {
         failedDependencies.push('broker')
+      }
+      if (
+        current.cycle.condition === CycleOperationsCondition.Unknown ||
+        current.cycle.condition === CycleOperationsCondition.Stalled ||
+        current.cycle.condition === CycleOperationsCondition.Failed
+      ) {
+        if (!failedDependencies.includes('cycle')) failedDependencies.push('cycle')
       }
       return jsonResponse(
         {
@@ -127,6 +349,14 @@ export const makeHttpLayer = (
   const status = Ref.get(state).pipe(
     Effect.flatMap((current) =>
       jsonResponse(publicState(current, config.maximumAuthority, provenance, provenanceVerification)),
+    ),
+  )
+  const metrics = Ref.get(state).pipe(
+    Effect.map((current) =>
+      HttpServerResponse.text(renderPrometheusMetrics(current, config, provenance, provenanceVerification), {
+        contentType: 'text/plain; version=0.0.4; charset=utf-8',
+        headers: { 'cache-control': 'no-store' },
+      }),
     ),
   )
   const historicalEvaluation = HttpRouter.params.pipe(
@@ -163,6 +393,7 @@ export const makeHttpLayer = (
   const routes = HttpRouter.addAll([
     HttpRouter.route('GET', '/livez', jsonResponse({ service: 'bayn', live: true })),
     HttpRouter.route('GET', '/readyz', ready),
+    HttpRouter.route('GET', '/metrics', metrics),
     HttpRouter.route('GET', '/v1/status', status),
     HttpRouter.route('GET', '/v1/evaluations/:runId', historicalEvaluation),
     HttpRouter.route('*', '*', fallback),

--- a/services/bayn/src/index.ts
+++ b/services/bayn/src/index.ts
@@ -9,6 +9,7 @@ import { BrokerMutation, makeMutation } from './broker/alpaca-mutations'
 import { verifyBehaviorHash, verifyParameterHash } from './build'
 import { loadConfig } from './config'
 import { makeRuntimeProvenance } from './contracts'
+import { CycleObservabilityLive } from './db/cycle-observability'
 import { EvidenceStoreLive } from './db/evidence-store'
 import { PaperStoreLive } from './db/paper-store'
 import { IntentStoreLive } from './execution/intents'
@@ -61,6 +62,7 @@ const main = Effect.gen(function* () {
     Layer.provide(NodeHttpClient.layerNodeHttp),
   )
   const evidenceStore = yield* acquireSqlLayer(EvidenceStoreLive(config).pipe(Layer.provide(NodeServices.layer)))
+  const cycleObservability = CycleObservabilityLive.pipe(Layer.provide(Layer.succeedContext(evidenceStore)))
   const journal = yield* acquireSqlLayer(JournalLive(config))
   let reconciliation = Effect.void
   let broker: BrokerProbe | undefined
@@ -131,7 +133,12 @@ const main = Effect.gen(function* () {
       reconciliation = runContinuously(config.alpaca.reconciliationIntervalMs).pipe(Effect.provide(paperExecution))
     }
   }
-  const dependencies = Layer.mergeAll(marketData, Layer.succeedContext(journal), Layer.succeedContext(evidenceStore))
+  const dependencies = Layer.mergeAll(
+    marketData,
+    cycleObservability,
+    Layer.succeedContext(journal),
+    Layer.succeedContext(evidenceStore),
+  )
   return yield* run(config, strategy, reconciliation, broker).pipe(Effect.provide(dependencies))
 }).pipe(Effect.scoped)
 

--- a/services/bayn/src/ledger.test.ts
+++ b/services/bayn/src/ledger.test.ts
@@ -334,6 +334,13 @@ describe('TigerBeetle simulation journal', () => {
       },
       healthIntervalMs: 30_000,
       operationTimeoutMs: 1_000,
+      cycleStallThresholdMs: 300_000,
+      reconciliationStaleThresholdMs: 120_000,
+      unknownMutationThresholdMs: 300_000,
+      autonomousCycle: {
+        enabled: false,
+        pollIntervalMs: 30_000,
+      },
       clickhouse: {
         url: 'http://clickhouse.test',
         username: 'bayn',

--- a/services/bayn/src/ledger.test.ts
+++ b/services/bayn/src/ledger.test.ts
@@ -337,10 +337,6 @@ describe('TigerBeetle simulation journal', () => {
       cycleStallThresholdMs: 300_000,
       reconciliationStaleThresholdMs: 120_000,
       unknownMutationThresholdMs: 300_000,
-      autonomousCycle: {
-        enabled: false,
-        pollIntervalMs: 30_000,
-      },
       clickhouse: {
         url: 'http://clickhouse.test',
         username: 'bayn',

--- a/services/bayn/src/resources.test.ts
+++ b/services/bayn/src/resources.test.ts
@@ -34,10 +34,6 @@ const config: RuntimeConfig = {
   cycleStallThresholdMs: 300_000,
   reconciliationStaleThresholdMs: 120_000,
   unknownMutationThresholdMs: 300_000,
-  autonomousCycle: {
-    enabled: false,
-    pollIntervalMs: 30_000,
-  },
   clickhouse: {
     url: 'http://clickhouse.test:8123',
     username: 'bayn',

--- a/services/bayn/src/resources.test.ts
+++ b/services/bayn/src/resources.test.ts
@@ -31,6 +31,13 @@ const config: RuntimeConfig = {
   },
   healthIntervalMs: 100,
   operationTimeoutMs: 20,
+  cycleStallThresholdMs: 300_000,
+  reconciliationStaleThresholdMs: 120_000,
+  unknownMutationThresholdMs: 300_000,
+  autonomousCycle: {
+    enabled: false,
+    pollIntervalMs: 30_000,
+  },
   clickhouse: {
     url: 'http://clickhouse.test:8123',
     username: 'bayn',

--- a/services/bayn/src/runtime-state.ts
+++ b/services/bayn/src/runtime-state.ts
@@ -39,15 +39,7 @@ export interface RuntimeHealth {
     readonly tigerBeetle: DependencyHealth
     readonly evidence: DependencyHealth
     readonly cycle: DependencyHealth
-    readonly cycleRunner: DependencyHealth
   }
-}
-
-export interface CycleRunnerStatus {
-  readonly enabled: boolean
-  readonly status: 'DISABLED' | 'STARTING' | 'RUNNING' | 'FAILED'
-  readonly checkedAt: string | null
-  readonly error: string | null
 }
 
 export interface BrokerConfiguration {
@@ -70,14 +62,13 @@ export interface RuntimeState {
   readonly evidence: RuntimeEvidence | null
   readonly health: RuntimeHealth
   readonly cycle: CycleOperationsStatus
-  readonly cycleRunner: CycleRunnerStatus
   readonly broker: BrokerStatus | null
   readonly error: string | null
 }
 
 const unknownDependency = (): DependencyHealth => ({ status: 'UNKNOWN', checkedAt: null, error: null })
 
-export const initialState = (broker?: BrokerConfiguration, autonomousCycleEnabled = false): RuntimeState => ({
+export const initialState = (broker?: BrokerConfiguration): RuntimeState => ({
   status: 'STARTING',
   evidence: null,
   health: {
@@ -89,16 +80,9 @@ export const initialState = (broker?: BrokerConfiguration, autonomousCycleEnable
       tigerBeetle: unknownDependency(),
       evidence: unknownDependency(),
       cycle: unknownDependency(),
-      cycleRunner: autonomousCycleEnabled ? unknownDependency() : { ...unknownDependency(), status: 'AVAILABLE' },
     },
   },
   cycle: unknownCycleOperationsStatus(),
-  cycleRunner: {
-    enabled: autonomousCycleEnabled,
-    status: autonomousCycleEnabled ? 'STARTING' : 'DISABLED',
-    checkedAt: null,
-    error: null,
-  },
   broker:
     broker === undefined
       ? null
@@ -122,6 +106,5 @@ export const isReady = (state: RuntimeState): boolean =>
   state.cycle.condition !== CycleOperationsCondition.Unknown &&
   state.cycle.condition !== CycleOperationsCondition.Stalled &&
   state.cycle.condition !== CycleOperationsCondition.Failed &&
-  (state.cycleRunner.status === 'DISABLED' || state.cycleRunner.status === 'RUNNING') &&
   (state.broker === null || (state.broker.accountBound === true && state.broker.readAvailable === true)) &&
   Object.values(state.health.dependencies).every((dependency) => dependency.status === 'AVAILABLE')

--- a/services/bayn/src/runtime-state.ts
+++ b/services/bayn/src/runtime-state.ts
@@ -1,4 +1,9 @@
 import type { RuntimeProvenance } from './contracts'
+import {
+  CycleOperationsCondition,
+  type CycleOperationsStatus,
+  unknownCycleOperationsStatus,
+} from './cycle-observability'
 import type { QualificationResult } from './qualification'
 import type { EvaluationSummary, ReconciliationResult } from './types'
 
@@ -33,7 +38,16 @@ export interface RuntimeHealth {
     readonly signal: DependencyHealth
     readonly tigerBeetle: DependencyHealth
     readonly evidence: DependencyHealth
+    readonly cycle: DependencyHealth
+    readonly cycleRunner: DependencyHealth
   }
+}
+
+export interface CycleRunnerStatus {
+  readonly enabled: boolean
+  readonly status: 'DISABLED' | 'STARTING' | 'RUNNING' | 'FAILED'
+  readonly checkedAt: string | null
+  readonly error: string | null
 }
 
 export interface BrokerConfiguration {
@@ -55,13 +69,15 @@ export interface RuntimeState {
   readonly status: 'STARTING' | 'READY' | 'DEGRADED' | 'FAILED'
   readonly evidence: RuntimeEvidence | null
   readonly health: RuntimeHealth
+  readonly cycle: CycleOperationsStatus
+  readonly cycleRunner: CycleRunnerStatus
   readonly broker: BrokerStatus | null
   readonly error: string | null
 }
 
 const unknownDependency = (): DependencyHealth => ({ status: 'UNKNOWN', checkedAt: null, error: null })
 
-export const initialState = (broker?: BrokerConfiguration): RuntimeState => ({
+export const initialState = (broker?: BrokerConfiguration, autonomousCycleEnabled = false): RuntimeState => ({
   status: 'STARTING',
   evidence: null,
   health: {
@@ -72,7 +88,16 @@ export const initialState = (broker?: BrokerConfiguration): RuntimeState => ({
       signal: unknownDependency(),
       tigerBeetle: unknownDependency(),
       evidence: unknownDependency(),
+      cycle: unknownDependency(),
+      cycleRunner: autonomousCycleEnabled ? unknownDependency() : { ...unknownDependency(), status: 'AVAILABLE' },
     },
+  },
+  cycle: unknownCycleOperationsStatus(),
+  cycleRunner: {
+    enabled: autonomousCycleEnabled,
+    status: autonomousCycleEnabled ? 'STARTING' : 'DISABLED',
+    checkedAt: null,
+    error: null,
   },
   broker:
     broker === undefined
@@ -94,5 +119,9 @@ export const initialState = (broker?: BrokerConfiguration): RuntimeState => ({
 export const isReady = (state: RuntimeState): boolean =>
   state.status === 'READY' &&
   state.evidence !== null &&
+  state.cycle.condition !== CycleOperationsCondition.Unknown &&
+  state.cycle.condition !== CycleOperationsCondition.Stalled &&
+  state.cycle.condition !== CycleOperationsCondition.Failed &&
+  (state.cycleRunner.status === 'DISABLED' || state.cycleRunner.status === 'RUNNING') &&
   (state.broker === null || (state.broker.accountBound === true && state.broker.readAvailable === true)) &&
   Object.values(state.health.dependencies).every((dependency) => dependency.status === 'AVAILABLE')

--- a/services/bayn/src/startup.test.ts
+++ b/services/bayn/src/startup.test.ts
@@ -25,6 +25,7 @@ import {
 } from './app-test-support'
 import { initialize, run } from './app'
 import { makeStrategyProtocolHash } from './contracts'
+import { CycleObservability } from './db/cycle-observability'
 import {
   DatabaseError,
   EvidenceStore,
@@ -42,6 +43,18 @@ import { evaluateRiskBalancedTrend, summarizeEvaluation } from './risk-balanced-
 import { initialState } from './runtime-state'
 import type { Strategy } from './strategy'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
+
+const cycleObservability = {
+  read: () =>
+    Effect.succeed({
+      current: null,
+      last: null,
+      unfinishedCycleCount: 0,
+      authority: null,
+      reconciliation: null,
+      mutations: { eventCount: 0, unresolvedCount: 0, oldestUnresolvedAt: null },
+    }),
+}
 
 describe('Bayn startup lifecycle', () => {
   test('recovers a pinned terminal qualification without inspecting data or writing state', async () => {
@@ -519,6 +532,32 @@ describe('Bayn startup lifecycle', () => {
     expect(await Effect.runPromise(Ref.get(state))).toMatchObject({ status: 'STARTING', evidence: null, error: null })
   })
 
+  test('fails closed when the autonomous loop has no broker and verified-candidate composition', async () => {
+    const error = await Effect.runPromise(
+      Effect.flip(
+        run(
+          {
+            ...config,
+            autonomousCycle: { ...config.autonomousCycle, enabled: true },
+          },
+          fixtureStrategy,
+        ),
+      ).pipe(
+        Effect.provideService(MarketData, marketDataService(Effect.succeed(makeSnapshot()))),
+        Effect.provideService(Journal, successfulJournal),
+        Effect.provideService(EvidenceStore, successfulEvidenceStore),
+        Effect.provideService(CycleObservability, cycleObservability),
+      ),
+    )
+
+    expect(error).toMatchObject({
+      _tag: 'OperationalError',
+      component: 'config',
+      operation: 'autonomous-cycle',
+      message: 'enabled autonomous cycle composition requires BrokerRead, CycleStore, and a verified candidate source',
+    })
+  })
+
   test('propagates an unexpected defect instead of leaving a detached STARTING worker', async () => {
     const marketData = marketDataService(Effect.die(new Error('unexpected startup defect')))
     const exit = await Effect.runPromiseExit(
@@ -526,6 +565,7 @@ describe('Bayn startup lifecycle', () => {
         Effect.provideService(MarketData, marketData),
         Effect.provideService(Journal, successfulJournal),
         Effect.provideService(EvidenceStore, successfulEvidenceStore),
+        Effect.provideService(CycleObservability, cycleObservability),
         Effect.timeoutOrElse({
           duration: 250,
           orElse: () =>
@@ -547,6 +587,7 @@ describe('Bayn startup lifecycle', () => {
         Effect.provideService(MarketData, marketDataService(Effect.succeed(makeSnapshot()))),
         Effect.provideService(Journal, successfulJournal),
         Effect.provideService(EvidenceStore, successfulEvidenceStore),
+        Effect.provideService(CycleObservability, cycleObservability),
         Effect.timeoutOrElse({
           duration: 250,
           orElse: () => Effect.fail(operationalError('http', 'test', 'run remained alive after reconciliation died')),
@@ -572,6 +613,7 @@ describe('Bayn startup lifecycle', () => {
         Effect.provideService(MarketData, marketDataService(Effect.succeed(makeSnapshot()))),
         Effect.provideService(Journal, journal),
         Effect.provideService(EvidenceStore, successfulEvidenceStore),
+        Effect.provideService(CycleObservability, cycleObservability),
         Effect.timeoutOrElse({
           duration: 250,
           orElse: () =>

--- a/services/bayn/src/startup.test.ts
+++ b/services/bayn/src/startup.test.ts
@@ -52,7 +52,7 @@ const cycleObservability = {
       unfinishedCycleCount: 0,
       authority: null,
       reconciliation: null,
-      mutations: { eventCount: 0, unresolvedCount: 0, oldestUnresolvedAt: null },
+      mutations: { eventCount: 0, unresolvedCount: 0, oldestUnresolvedAt: null, latestOccurredAt: null },
     }),
 }
 
@@ -530,32 +530,6 @@ describe('Bayn startup lifecycle', () => {
     expect(Exit.isFailure(exit)).toBe(true)
     if (Exit.isFailure(exit)) expect(Cause.pretty(exit.cause)).toContain('load timed out')
     expect(await Effect.runPromise(Ref.get(state))).toMatchObject({ status: 'STARTING', evidence: null, error: null })
-  })
-
-  test('fails closed when the autonomous loop has no broker and verified-candidate composition', async () => {
-    const error = await Effect.runPromise(
-      Effect.flip(
-        run(
-          {
-            ...config,
-            autonomousCycle: { ...config.autonomousCycle, enabled: true },
-          },
-          fixtureStrategy,
-        ),
-      ).pipe(
-        Effect.provideService(MarketData, marketDataService(Effect.succeed(makeSnapshot()))),
-        Effect.provideService(Journal, successfulJournal),
-        Effect.provideService(EvidenceStore, successfulEvidenceStore),
-        Effect.provideService(CycleObservability, cycleObservability),
-      ),
-    )
-
-    expect(error).toMatchObject({
-      _tag: 'OperationalError',
-      component: 'config',
-      operation: 'autonomous-cycle',
-      message: 'enabled autonomous cycle composition requires BrokerRead, CycleStore, and a verified candidate source',
-    })
   })
 
   test('propagates an unexpected defect instead of leaving a detached STARTING worker', async () => {


### PR DESCRIPTION
## Summary

- add one strict, account-bound, read-only PostgreSQL projection for current and last autonomous cycles plus durable authority, reconciliation, and account-scoped mutation safety state
- classify expected waiting, active execution, stalls, and failures from durable cycle windows, and expose bounded service status and Prometheus metrics without synthetic success
- fail closed when the configured account differs from projected cycle state or when exact reconciliation predates the latest relevant account mutation, using PostgreSQL timestamp precision
- preserve OBSERVE and zero broker mutation; scheduler/runtime candidate composition remains outside this dependency-sized slice

## Related Issues

[PROOMPT-384](https://linear.app/proompteng/issue/PROOMPT-384/add-autonomous-cycle-telemetry-dashboards-alerts-and-post-deploy)

## Testing

- `bun test src/cycle-observability.test.ts src/db/cycle-observability.integration.test.ts src/health.test.ts src/http.test.ts src/config.test.ts src/startup.test.ts src/cycle-readiness.test.ts` (54 passed, 5 supported-environment PostgreSQL skips, 0 failed)
- `bun test` from `services/bayn` (298 passed, 61 supported-environment PostgreSQL skips, 0 failed)
- `bun run tsc`
- `bun run lint`
- `bun run lint:oxlint`
- `bun run lint:oxlint:type`
- `bun run build`
- Local PostgreSQL execution was unavailable through the existing supported CNPG `_test` route; no temporary namespace pod or direct infrastructure mutation was used. The focused regression uses the existing `BAYN_TEST_POSTGRES_URL` CI path.

## Breaking Changes

None. No autonomous runner flag or dead composition scaffold is introduced. Final runtime composition is held for the narrow latest-finalized Signal manifest/session read with no bars, true month-end filtering, one existing Alpaca calendar read, and idempotent acquisition/binding.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes are handled above.
- [x] PROOMPT-384 GitOps dashboard, alert rollout, and post-deploy evidence remain tracked in Linear.