### PR TITLE
feat(bayn): bind finalized cycle publications

### DIFF
--- a/nix/images/bayn.nix
+++ b/nix/images/bayn.nix
@@ -20,8 +20,8 @@ import ./bun-workspace-service.nix {
   serviceName = "bayn";
   packageName = "@proompteng/bayn";
   depsHash = {
-    x86_64-linux = "sha256-lPw4xA54l9s6o+46ulCWRA593QjsPyCS44/QSmQJyME=";
-    aarch64-linux = "sha256-5FQ4nmCpYkbLVzbG8vrCf4+Aqi943QylJlmlUQVWqdQ=";
+    x86_64-linux = "sha256-3T9NleNP3UBEZPRTft2TnFqWzjiElCQClS+tS+RJJJ8=";
+    aarch64-linux = "sha256-hROeunyxMcEa5uVtPM+AHHkuYvzV1aqx7YYeEK1EsWs=";
   };
   installFilters = [
     "@proompteng/bayn"

--- a/services/bayn/src/app-test-support.ts
+++ b/services/bayn/src/app-test-support.ts
@@ -112,6 +112,8 @@ export const marketDataService = (
     },
   })),
   inspectPublication: () => Effect.die(new Error('startup test market data must not inspect cycle publications')),
+  inspectSnapshotPublication: () =>
+    Effect.die(new Error('startup test market data must not inspect bound cycle publications')),
   load,
 })
 

--- a/services/bayn/src/app-test-support.ts
+++ b/services/bayn/src/app-test-support.ts
@@ -104,7 +104,14 @@ export const marketDataService = (
   inspect: Effect.sync(() => ({
     manifest: inspectedSnapshot.manifest,
     sessionDates: [...new Set(inspectedSnapshot.bars.map((bar) => bar.sessionDate))].sort(),
+    signalSession: {
+      calendar_version: inspectedSnapshot.manifest.finalizedSnapshot.calendarVersion,
+      session_date: inspectedSnapshot.manifest.lastSession,
+      close_time: '16:00',
+      timezone: 'America/New_York',
+    },
   })),
+  inspectPublication: () => Effect.die(new Error('startup test market data must not inspect cycle publications')),
   load,
 })
 

--- a/services/bayn/src/cycle-readiness.test.ts
+++ b/services/bayn/src/cycle-readiness.test.ts
@@ -1,0 +1,397 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Effect, Option } from 'effect'
+import { TestClock } from 'effect/testing'
+
+import {
+  CycleState,
+  CycleTerminalReason,
+  makeCycleDraft,
+  makeCycleExecutionPolicy,
+  makeCycleIdentity,
+  makeCycleWindow,
+  makeExecutionCalendarObservation,
+  type AutonomousCycle,
+} from './cycle'
+import { measurePublicationFreshness, runCyclePublicationReadiness } from './cycle-readiness'
+import { CycleStore, type CycleStoreShape } from './db/cycle-store'
+import { operationalError } from './errors'
+import { canonicalHashV1, sha256 } from './hash'
+import { MarketData, type FinalizedPublicationInspection, type MarketDataService } from './market-data'
+import { DataFeed, DataSource, PriceAdjustment, PublicationSchema, type InputManifest } from './types'
+
+const signalCalendarVersion = 'signal-XNYS-2026-v1'
+const snapshotId = 'd'.repeat(64)
+
+const executionPolicy = makeCycleExecutionPolicy({
+  schemaVersion: 'bayn.autonomous-cycle-execution-policy.v1',
+  strategyExecutionModelHash: '3'.repeat(64),
+  submissionWindowMs: 30 * 60 * 1_000,
+  submissionCutoffBeforeOpenMs: 2 * 60 * 1_000,
+})
+
+const makeCycle = (): AutonomousCycle => {
+  const signalSession = {
+    calendar_version: signalCalendarVersion,
+    session_date: '2026-01-30' as const,
+    close_time: '16:00',
+    timezone: 'America/New_York' as const,
+  }
+  const executionCalendar = makeExecutionCalendarObservation({
+    schemaVersion: 'bayn.alpaca-market-calendar-observation.v1',
+    source: 'alpaca-v2-calendar',
+    date: '2026-02-02',
+    openAt: '2026-02-02T14:30:00.000Z',
+    closeAt: '2026-02-02T21:00:00.000Z',
+  })
+  const identity = makeCycleIdentity({
+    schemaVersion: 'bayn.autonomous-cycle-identity.v1',
+    strategyName: 'risk-balanced-trend',
+    qualificationRunId: '1'.repeat(64),
+    strategyProtocolHash: '2'.repeat(64),
+    accountId: 'paper-account',
+    signalSessionDate: signalSession.session_date,
+    signalCalendarVersion,
+    executionSessionDate: executionCalendar.executionSessionDate,
+    executionCalendarSchemaVersion: executionCalendar.executionCalendarSchemaVersion,
+    executionCalendarSource: executionCalendar.executionCalendarSource,
+    executionCalendarHash: executionCalendar.executionCalendarHash,
+    executionPolicy,
+  })
+  const draft = makeCycleDraft(identity, makeCycleWindow(signalSession, executionCalendar, executionPolicy))
+  return {
+    ...draft,
+    state: CycleState.Pending,
+    bindings: {},
+    stateVersion: 1,
+    createdAt: '2026-01-30T20:00:00.000Z',
+    updatedAt: '2026-01-30T20:00:00.000Z',
+  }
+}
+
+const makeInputManifest = (finalizedAt = '2026-01-30T21:15:00.000Z'): InputManifest => {
+  const symbol = 'SPY'
+  const finalizedSnapshot = {
+    schemaVersion: 'bayn.finalized-snapshot.v3' as const,
+    snapshotId,
+    publicationId: '4'.repeat(64),
+    publicationSchemaVersion: PublicationSchema.AdjustedDailySnapshotV2,
+    universeId: 'cross-asset-taa-v1' as const,
+    universeSymbolHash: sha256(symbol),
+    source: DataSource.Alpaca,
+    sourceFeed: DataFeed.Sip,
+    adjustment: PriceAdjustment.All,
+    calendarVersion: signalCalendarVersion,
+    publisherSourceRevision: '5'.repeat(40),
+    publisherImage: {
+      repository: 'registry.example.com/signal-publisher',
+      digest: `sha256:${'6'.repeat(64)}`,
+    },
+    finalizedAt,
+    requestedStart: '2026-01-30' as const,
+    firstSession: '2026-01-30' as const,
+    lastSession: '2026-01-30' as const,
+    asOfSession: '2026-01-30' as const,
+    symbols: [symbol],
+    rowCount: 1,
+    sessionCount: 1,
+    contentHash: '7'.repeat(64),
+    sessionsContentHash: '8'.repeat(64),
+  }
+  const material: Omit<InputManifest, 'hash'> = {
+    schemaVersion: 'bayn.input-manifest.v3',
+    database: 'signal',
+    tables: {
+      bars: 'adjusted_daily_bars_v2',
+      sessions: 'exchange_sessions_v1',
+      manifests: 'snapshot_manifests_v2',
+    },
+    bounds: {
+      schemaVersion: 'bayn.evaluation-bounds.v1',
+      dataStart: '2026-01-30',
+      dataEnd: '2026-01-30',
+      lookbackStart: '2026-01-30',
+      evaluationStart: '2026-01-30',
+      evaluationEnd: '2026-01-30',
+    },
+    rowCount: 1,
+    sessionCount: 1,
+    firstSession: '2026-01-30',
+    lastSession: '2026-01-30',
+    symbols: [
+      {
+        symbol,
+        rows: 1,
+        firstSession: '2026-01-30',
+        lastSession: '2026-01-30',
+      },
+    ],
+    finalizedSnapshot,
+  }
+  return { ...material, hash: canonicalHashV1(material) }
+}
+
+const finalizedPublication = (manifest = makeInputManifest()): FinalizedPublicationInspection => ({
+  outcome: 'FINALIZED',
+  observedAt: '2026-01-30T21:20:00.000Z',
+  inspection: {
+    manifest,
+    sessionDates: ['2026-01-30'],
+    signalSession: {
+      calendar_version: signalCalendarVersion,
+      session_date: '2026-01-30',
+      close_time: '16:00',
+      timezone: 'America/New_York',
+    },
+  },
+})
+
+const marketDataService = (inspectPublication: MarketDataService['inspectPublication']): MarketDataService => {
+  const unused = Effect.die(new Error('cycle readiness must only inspect the exact finalized publication'))
+  return {
+    check: unused,
+    inspect: unused,
+    inspectPublication,
+    load: unused,
+  }
+}
+
+interface StoreControl {
+  current: AutonomousCycle
+  binds: number
+  blocks: number
+}
+
+const cycleStore = (control: StoreControl): CycleStoreShape => {
+  const unused = () => Effect.die(new Error('cycle readiness used an unexpected store operation'))
+  return {
+    acquire: unused,
+    read: () => Effect.succeed(Option.some(control.current)),
+    bindSnapshot: (_cycleId, inputManifest, observedAt) =>
+      Effect.sync(() => {
+        control.binds += 1
+        const existing = control.current.bindings.snapshotId
+        if (existing === undefined) {
+          control.current = {
+            ...control.current,
+            bindings: { snapshotId: inputManifest.finalizedSnapshot.snapshotId },
+            stateVersion: control.current.stateVersion + 1,
+            updatedAt: observedAt,
+          }
+          return { cycle: control.current, changed: true }
+        }
+        if (existing !== inputManifest.finalizedSnapshot.snapshotId) {
+          throw new Error('test store refused snapshot replacement')
+        }
+        return { cycle: control.current, changed: false }
+      }),
+    activate: unused,
+    bindDecision: unused,
+    block: (_cycleId, reason, observedAt) =>
+      Effect.sync(() => {
+        control.blocks += 1
+        control.current = {
+          ...control.current,
+          state: CycleState.Blocked,
+          terminalReason: reason,
+          stateVersion: control.current.stateVersion + 1,
+          updatedAt: observedAt,
+          terminalAt: observedAt,
+        }
+        return { cycle: control.current, changed: true }
+      }),
+  }
+}
+
+const provide = (
+  cycle: AutonomousCycle,
+  inspectPublication: MarketDataService['inspectPublication'],
+  control: StoreControl,
+) =>
+  runCyclePublicationReadiness(cycle).pipe(
+    Effect.provideService(MarketData, marketDataService(inspectPublication)),
+    Effect.provideService(CycleStore, cycleStore(control)),
+  )
+
+describe('autonomous cycle finalized-publication readiness', () => {
+  test('waits before Signal close without reading publication data', async () => {
+    const cycle = makeCycle()
+    const control: StoreControl = { current: cycle, binds: 0, blocks: 0 }
+    let inspections = 0
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse('2026-01-30T20:59:59.999Z'))
+        return yield* provide(
+          cycle,
+          () =>
+            Effect.sync(() => {
+              inspections += 1
+              return finalizedPublication()
+            }),
+          control,
+        )
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(result).toMatchObject({ outcome: 'WAITING', reason: 'SIGNAL_SESSION_OPEN' })
+    expect(inspections).toBe(0)
+    expect(control).toMatchObject({ binds: 0, blocks: 0 })
+  })
+
+  test('survives a missing publication and binds the delayed exact snapshot on restart', async () => {
+    const cycle = makeCycle()
+    const control: StoreControl = { current: cycle, binds: 0, blocks: 0 }
+    let finalized = false
+    const inspect = () =>
+      Effect.succeed(
+        finalized ? finalizedPublication() : ({ outcome: 'MISSING', observedAt: '2026-01-30T21:01:00.000Z' } as const),
+      )
+    const results = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse('2026-01-30T21:01:00.000Z'))
+        const waiting = yield* provide(control.current, inspect, control)
+        finalized = true
+        yield* TestClock.setTime(Date.parse('2026-01-30T21:20:00.000Z'))
+        const bound = yield* provide(control.current, inspect, control)
+        return { bound, waiting }
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(results.waiting).toMatchObject({ outcome: 'WAITING', reason: 'PUBLICATION_MISSING' })
+    expect(results.bound).toMatchObject({
+      outcome: 'BOUND',
+      snapshotId,
+      freshness: {
+        dataAgeMs: 5 * 60 * 1_000,
+        publicationDelayMs: 15 * 60 * 1_000,
+      },
+    })
+    expect(control).toMatchObject({ binds: 1, blocks: 0 })
+  })
+
+  test('blocks at the exact deadline without inspecting Signal or binding a snapshot', async () => {
+    const cycle = makeCycle()
+    const control: StoreControl = { current: cycle, binds: 0, blocks: 0 }
+    let inspections = 0
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse(cycle.window.publicationDeadlineAt))
+        return yield* provide(
+          cycle,
+          () =>
+            Effect.sync(() => {
+              inspections += 1
+              return finalizedPublication()
+            }),
+          control,
+        )
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(result).toMatchObject({
+      outcome: 'BLOCKED',
+      cycle: {
+        state: CycleState.Blocked,
+        terminalReason: CycleTerminalReason.MissedPublication,
+        terminalAt: cycle.window.publicationDeadlineAt,
+      },
+    })
+    expect(inspections).toBe(0)
+    expect(control).toMatchObject({ binds: 0, blocks: 1 })
+  })
+
+  test('blocks an invalid inspection that crosses the deadline and never binds its data', async () => {
+    const cycle = makeCycle()
+    const control: StoreControl = { current: cycle, binds: 0, blocks: 0 }
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse(cycle.window.publicationDeadlineAt) - 1)
+        return yield* provide(
+          cycle,
+          () =>
+            TestClock.setTime(Date.parse(cycle.window.publicationDeadlineAt)).pipe(
+              Effect.andThen(
+                Effect.fail(operationalError('market-data', 'inspect-publication', 'mutated finalized manifest')),
+              ),
+            ),
+          control,
+        )
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(result).toMatchObject({
+      outcome: 'BLOCKED',
+      cycle: {
+        terminalReason: CycleTerminalReason.MissedPublication,
+      },
+    })
+    expect(control).toMatchObject({ binds: 0, blocks: 1 })
+  })
+
+  test('fails invalid freshness before the deadline and refuses to replace an existing binding', async () => {
+    const cycle = makeCycle()
+    const control: StoreControl = { current: cycle, binds: 0, blocks: 0 }
+    const invalid = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse('2026-01-30T21:20:00.000Z'))
+        return yield* Effect.flip(
+          provide(
+            cycle,
+            () => Effect.succeed(finalizedPublication(makeInputManifest('2026-01-30T20:59:00.000Z'))),
+            control,
+          ),
+        )
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+    expect(invalid).toMatchObject({
+      _tag: 'CycleReadinessError',
+      operation: 'measure-freshness',
+      failure: 'contract',
+    })
+    expect(control).toMatchObject({ binds: 0, blocks: 0 })
+    const publication = finalizedPublication()
+    if (publication.outcome !== 'FINALIZED') throw new Error('finalized fixture must contain an inspection')
+    expect(() =>
+      measurePublicationFreshness(
+        cycle,
+        {
+          ...publication.inspection,
+          signalSession: { ...publication.inspection.signalSession, close_time: '13:00' },
+        },
+        '2026-01-30T21:20:00.000Z',
+      ),
+    ).toThrow('verified Signal session material does not match the cycle window')
+
+    const boundCycle: AutonomousCycle = {
+      ...cycle,
+      bindings: { snapshotId },
+      stateVersion: 2,
+      updatedAt: '2026-01-30T21:20:00.000Z',
+    }
+    control.current = boundCycle
+    let inspections = 0
+    const rebound = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse('2026-01-30T21:21:00.000Z'))
+        return yield* provide(
+          boundCycle,
+          () =>
+            Effect.sync(() => {
+              inspections += 1
+              return finalizedPublication({
+                ...makeInputManifest(),
+                finalizedSnapshot: {
+                  ...makeInputManifest().finalizedSnapshot,
+                  snapshotId: 'e'.repeat(64),
+                },
+              })
+            }),
+          control,
+        )
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+    expect(rebound).toMatchObject({ outcome: 'ALREADY_BOUND', snapshotId })
+    expect(inspections).toBe(0)
+    expect(control.binds).toBe(0)
+  })
+})

--- a/services/bayn/src/cycle-readiness.test.ts
+++ b/services/bayn/src/cycle-readiness.test.ts
@@ -378,20 +378,49 @@ describe('autonomous cycle finalized-publication readiness', () => {
           () =>
             Effect.sync(() => {
               inspections += 1
-              return finalizedPublication({
-                ...makeInputManifest(),
-                finalizedSnapshot: {
-                  ...makeInputManifest().finalizedSnapshot,
-                  snapshotId: 'e'.repeat(64),
-                },
-              })
+              return finalizedPublication()
             }),
           control,
         )
       }).pipe(Effect.provide(TestClock.layer())),
     )
-    expect(rebound).toMatchObject({ outcome: 'ALREADY_BOUND', snapshotId })
-    expect(inspections).toBe(0)
+    expect(rebound).toMatchObject({
+      outcome: 'ALREADY_BOUND',
+      snapshotId,
+      freshness: {
+        dataAgeMs: 6 * 60 * 1_000,
+        publicationDelayMs: 15 * 60 * 1_000,
+      },
+    })
+    const replacement = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse('2026-01-30T21:22:00.000Z'))
+        return yield* Effect.flip(
+          provide(
+            boundCycle,
+            () =>
+              Effect.sync(() => {
+                inspections += 1
+                const manifest = makeInputManifest()
+                return finalizedPublication({
+                  ...manifest,
+                  finalizedSnapshot: {
+                    ...manifest.finalizedSnapshot,
+                    snapshotId: 'e'.repeat(64),
+                  },
+                })
+              }),
+            control,
+          ),
+        )
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+    expect(replacement).toMatchObject({
+      _tag: 'CycleReadinessError',
+      operation: 'inspect-publication',
+      failure: 'contract',
+    })
+    expect(inspections).toBe(2)
     expect(control.binds).toBe(0)
   })
 })

--- a/services/bayn/src/cycle-readiness.test.ts
+++ b/services/bayn/src/cycle-readiness.test.ts
@@ -146,12 +146,16 @@ const finalizedPublication = (manifest = makeInputManifest()): FinalizedPublicat
   },
 })
 
-const marketDataService = (inspectPublication: MarketDataService['inspectPublication']): MarketDataService => {
+const marketDataService = (
+  inspectPublication: MarketDataService['inspectPublication'],
+  inspectSnapshotPublication: MarketDataService['inspectSnapshotPublication'] = (input) => inspectPublication(input),
+): MarketDataService => {
   const unused = Effect.die(new Error('cycle readiness must only inspect the exact finalized publication'))
   return {
     check: unused,
     inspect: unused,
     inspectPublication,
+    inspectSnapshotPublication,
     load: unused,
   }
 }
@@ -207,9 +211,10 @@ const provide = (
   cycle: AutonomousCycle,
   inspectPublication: MarketDataService['inspectPublication'],
   control: StoreControl,
+  inspectSnapshotPublication?: MarketDataService['inspectSnapshotPublication'],
 ) =>
   runCyclePublicationReadiness(cycle).pipe(
-    Effect.provideService(MarketData, marketDataService(inspectPublication)),
+    Effect.provideService(MarketData, marketDataService(inspectPublication, inspectSnapshotPublication)),
     Effect.provideService(CycleStore, cycleStore(control)),
   )
 
@@ -369,18 +374,17 @@ describe('autonomous cycle finalized-publication readiness', () => {
       updatedAt: '2026-01-30T21:20:00.000Z',
     }
     control.current = boundCycle
-    let inspections = 0
+    const inspectedSnapshotIds: string[] = []
+    const unexpectedSessionLookup = () =>
+      Effect.die(new Error('bound readiness must not rediscover publications by session and calendar'))
     const rebound = await Effect.runPromise(
       Effect.gen(function* () {
         yield* TestClock.setTime(Date.parse('2026-01-30T21:21:00.000Z'))
-        return yield* provide(
-          boundCycle,
-          () =>
-            Effect.sync(() => {
-              inspections += 1
-              return finalizedPublication()
-            }),
-          control,
+        return yield* provide(boundCycle, unexpectedSessionLookup, control, (request) =>
+          Effect.sync(() => {
+            inspectedSnapshotIds.push(request.snapshotId)
+            return finalizedPublication()
+          }),
         )
       }).pipe(Effect.provide(TestClock.layer())),
     )
@@ -396,21 +400,18 @@ describe('autonomous cycle finalized-publication readiness', () => {
       Effect.gen(function* () {
         yield* TestClock.setTime(Date.parse('2026-01-30T21:22:00.000Z'))
         return yield* Effect.flip(
-          provide(
-            boundCycle,
-            () =>
-              Effect.sync(() => {
-                inspections += 1
-                const manifest = makeInputManifest()
-                return finalizedPublication({
-                  ...manifest,
-                  finalizedSnapshot: {
-                    ...manifest.finalizedSnapshot,
-                    snapshotId: 'e'.repeat(64),
-                  },
-                })
-              }),
-            control,
+          provide(boundCycle, unexpectedSessionLookup, control, (request) =>
+            Effect.sync(() => {
+              inspectedSnapshotIds.push(request.snapshotId)
+              const manifest = makeInputManifest()
+              return finalizedPublication({
+                ...manifest,
+                finalizedSnapshot: {
+                  ...manifest.finalizedSnapshot,
+                  snapshotId: 'e'.repeat(64),
+                },
+              })
+            }),
           ),
         )
       }).pipe(Effect.provide(TestClock.layer())),
@@ -420,7 +421,7 @@ describe('autonomous cycle finalized-publication readiness', () => {
       operation: 'inspect-publication',
       failure: 'contract',
     })
-    expect(inspections).toBe(2)
+    expect(inspectedSnapshotIds).toEqual([snapshotId, snapshotId])
     expect(control.binds).toBe(0)
   })
 })

--- a/services/bayn/src/cycle-readiness.ts
+++ b/services/bayn/src/cycle-readiness.ts
@@ -3,7 +3,7 @@ import { Clock, Data, Effect } from 'effect'
 import { CycleState, CycleTerminalReason, signalSessionCloseAt, type AutonomousCycle } from './cycle'
 import { CycleStore, type CycleMutationReceipt, type CycleStoreError, type CycleStoreShape } from './db/cycle-store'
 import type { OperationalError } from './errors'
-import { MarketData, type MarketDataInspection } from './market-data'
+import { MarketData, type MarketDataInspection, type MarketDataService } from './market-data'
 
 export interface PublicationFreshness {
   readonly dataAgeMs: number
@@ -113,6 +113,70 @@ const blockMissedPublication = (
     ),
   )
 
+const inspectBoundPublication = (
+  cycle: AutonomousCycle,
+  marketData: MarketDataService,
+): Effect.Effect<CyclePublicationReadiness, CycleReadinessError> =>
+  marketData
+    .inspectPublication({
+      signalSessionDate: cycle.identity.signalSessionDate,
+      signalCalendarVersion: cycle.identity.signalCalendarVersion,
+    })
+    .pipe(
+      Effect.mapError((cause) =>
+        readinessError(
+          'inspect-publication',
+          'market-data',
+          'failed to read back the bound finalized Signal publication',
+          cause,
+        ),
+      ),
+      Effect.flatMap((publication) =>
+        Effect.gen(function* () {
+          if (publication.outcome === 'MISSING') {
+            return yield* Effect.fail(
+              readinessError(
+                'inspect-publication',
+                'contract',
+                'bound finalized Signal publication is missing from its durable source',
+              ),
+            )
+          }
+          const boundSnapshotId = cycle.bindings.snapshotId
+          if (
+            boundSnapshotId === undefined ||
+            publication.inspection.manifest.finalizedSnapshot.snapshotId !== boundSnapshotId
+          ) {
+            return yield* Effect.fail(
+              readinessError(
+                'inspect-publication',
+                'contract',
+                'finalized Signal publication does not match the immutable cycle binding',
+              ),
+            )
+          }
+          const observedAt = yield* currentTime
+          const freshness = yield* Effect.try({
+            try: () => measurePublicationFreshness(cycle, publication.inspection, observedAt),
+            catch: (cause) =>
+              readinessError(
+                'measure-freshness',
+                'contract',
+                'bound finalized Signal publication freshness is invalid',
+                cause,
+              ),
+          })
+          return {
+            outcome: 'ALREADY_BOUND',
+            observedAt,
+            cycle,
+            snapshotId: boundSnapshotId,
+            freshness,
+          } as const
+        }),
+      ),
+    )
+
 export const runCyclePublicationReadiness = (
   cycle: AutonomousCycle,
 ): Effect.Effect<CyclePublicationReadiness, CycleReadinessError, MarketData | CycleStore> =>
@@ -125,12 +189,7 @@ export const runCyclePublicationReadiness = (
       return { outcome: 'BLOCKED', observedAt: initialObservedAt, cycle }
     }
     if (cycle.bindings.snapshotId !== undefined) {
-      return {
-        outcome: 'ALREADY_BOUND',
-        observedAt: initialObservedAt,
-        cycle,
-        snapshotId: cycle.bindings.snapshotId,
-      }
+      return yield* inspectBoundPublication(cycle, marketData)
     }
     if (cycle.state !== CycleState.Pending) {
       return yield* Effect.fail(

--- a/services/bayn/src/cycle-readiness.ts
+++ b/services/bayn/src/cycle-readiness.ts
@@ -1,0 +1,222 @@
+import { Clock, Data, Effect } from 'effect'
+
+import { CycleState, CycleTerminalReason, signalSessionCloseAt, type AutonomousCycle } from './cycle'
+import { CycleStore, type CycleMutationReceipt, type CycleStoreError, type CycleStoreShape } from './db/cycle-store'
+import type { OperationalError } from './errors'
+import { MarketData, type MarketDataInspection } from './market-data'
+
+export interface PublicationFreshness {
+  readonly dataAgeMs: number
+  readonly publicationDelayMs: number
+}
+
+export type CyclePublicationReadiness =
+  | {
+      readonly outcome: 'WAITING'
+      readonly reason: 'SIGNAL_SESSION_OPEN' | 'PUBLICATION_MISSING'
+      readonly observedAt: string
+      readonly cycle: AutonomousCycle
+    }
+  | {
+      readonly outcome: 'BOUND' | 'ALREADY_BOUND'
+      readonly observedAt: string
+      readonly cycle: AutonomousCycle
+      readonly snapshotId: string
+      readonly freshness?: PublicationFreshness
+    }
+  | {
+      readonly outcome: 'BLOCKED'
+      readonly observedAt: string
+      readonly cycle: AutonomousCycle
+    }
+
+export class CycleReadinessError extends Data.TaggedError('CycleReadinessError')<{
+  readonly operation: 'bind-publication' | 'inspect-publication' | 'measure-freshness' | 'missed-publication'
+  readonly failure: 'contract' | 'market-data' | 'store'
+  readonly message: string
+  readonly cause?: unknown
+}> {}
+
+const readinessError = (
+  operation: CycleReadinessError['operation'],
+  failure: CycleReadinessError['failure'],
+  message: string,
+  cause?: unknown,
+): CycleReadinessError => new CycleReadinessError({ operation, failure, message, cause })
+
+const currentTime = Clock.currentTimeMillis.pipe(Effect.map((millis) => new Date(millis).toISOString()))
+
+const elapsed = (later: string, earlier: string, name: string): number => {
+  const milliseconds = Date.parse(later) - Date.parse(earlier)
+  if (!Number.isSafeInteger(milliseconds) || milliseconds < 0) {
+    throw new TypeError(`${name} must be a non-negative safe millisecond duration`)
+  }
+  return milliseconds
+}
+
+export const measurePublicationFreshness = (
+  cycle: AutonomousCycle,
+  inspection: MarketDataInspection,
+  observedAt: string,
+): PublicationFreshness => {
+  const snapshot = inspection.manifest.finalizedSnapshot
+  if (
+    snapshot.asOfSession !== cycle.identity.signalSessionDate ||
+    snapshot.lastSession !== cycle.identity.signalSessionDate
+  ) {
+    throw new TypeError('finalized Signal publication does not end at the cycle signal session')
+  }
+  if (snapshot.calendarVersion !== cycle.identity.signalCalendarVersion) {
+    throw new TypeError('finalized Signal publication does not match the cycle Signal calendar')
+  }
+  if (
+    inspection.signalSession.session_date !== cycle.identity.signalSessionDate ||
+    inspection.signalSession.calendar_version !== cycle.identity.signalCalendarVersion ||
+    signalSessionCloseAt(inspection.signalSession) !== cycle.window.signalCloseAt
+  ) {
+    throw new TypeError('verified Signal session material does not match the cycle window')
+  }
+  return {
+    dataAgeMs: elapsed(observedAt, snapshot.finalizedAt, 'Signal data age'),
+    publicationDelayMs: elapsed(snapshot.finalizedAt, cycle.window.signalCloseAt, 'Signal publication delay'),
+  }
+}
+
+const boundResult = (
+  outcome: 'BOUND' | 'ALREADY_BOUND',
+  receipt: CycleMutationReceipt,
+  observedAt: string,
+  freshness?: PublicationFreshness,
+): CyclePublicationReadiness => {
+  const snapshotId = receipt.cycle.bindings.snapshotId
+  if (snapshotId === undefined) {
+    throw new TypeError('successful finalized-publication binding did not retain a snapshot ID')
+  }
+  return {
+    outcome,
+    observedAt,
+    cycle: receipt.cycle,
+    snapshotId,
+    ...(freshness === undefined ? {} : { freshness }),
+  }
+}
+
+const blockMissedPublication = (
+  store: CycleStoreShape,
+  cycleId: string,
+  observedAt: string,
+): Effect.Effect<CyclePublicationReadiness, CycleReadinessError> =>
+  store.block(cycleId, CycleTerminalReason.MissedPublication, observedAt).pipe(
+    Effect.map((receipt) => ({ outcome: 'BLOCKED', observedAt, cycle: receipt.cycle }) as const),
+    Effect.mapError((cause: CycleStoreError) =>
+      readinessError('missed-publication', 'store', 'failed to persist the missed publication deadline', cause),
+    ),
+  )
+
+export const runCyclePublicationReadiness = (
+  cycle: AutonomousCycle,
+): Effect.Effect<CyclePublicationReadiness, CycleReadinessError, MarketData | CycleStore> =>
+  Effect.gen(function* () {
+    const marketData = yield* MarketData
+    const store = yield* CycleStore
+    const initialObservedAt = yield* currentTime
+
+    if (cycle.state === CycleState.Blocked) {
+      return { outcome: 'BLOCKED', observedAt: initialObservedAt, cycle }
+    }
+    if (cycle.bindings.snapshotId !== undefined) {
+      return {
+        outcome: 'ALREADY_BOUND',
+        observedAt: initialObservedAt,
+        cycle,
+        snapshotId: cycle.bindings.snapshotId,
+      }
+    }
+    if (cycle.state !== CycleState.Pending) {
+      return yield* Effect.fail(
+        readinessError('inspect-publication', 'contract', `unbound cycle ${cycle.identity.cycleId} is not pending`),
+      )
+    }
+    if (initialObservedAt >= cycle.window.publicationDeadlineAt) {
+      return yield* blockMissedPublication(store, cycle.identity.cycleId, initialObservedAt)
+    }
+    if (initialObservedAt < cycle.window.signalCloseAt) {
+      return {
+        outcome: 'WAITING',
+        reason: 'SIGNAL_SESSION_OPEN',
+        observedAt: initialObservedAt,
+        cycle,
+      }
+    }
+
+    return yield* Effect.matchEffect(
+      marketData.inspectPublication({
+        signalSessionDate: cycle.identity.signalSessionDate,
+        signalCalendarVersion: cycle.identity.signalCalendarVersion,
+      }),
+      {
+        onFailure: (cause: OperationalError) =>
+          Effect.gen(function* () {
+            const observedAt = yield* currentTime
+            if (observedAt >= cycle.window.publicationDeadlineAt) {
+              return yield* blockMissedPublication(store, cycle.identity.cycleId, observedAt)
+            }
+            return yield* Effect.fail(
+              readinessError(
+                'inspect-publication',
+                'market-data',
+                'finalized Signal publication inspection failed before its deadline',
+                cause,
+              ),
+            )
+          }),
+        onSuccess: (publication) =>
+          Effect.gen(function* () {
+            const observedAt = yield* currentTime
+            if (observedAt >= cycle.window.publicationDeadlineAt) {
+              return yield* blockMissedPublication(store, cycle.identity.cycleId, observedAt)
+            }
+            if (publication.outcome === 'MISSING') {
+              return {
+                outcome: 'WAITING',
+                reason: 'PUBLICATION_MISSING',
+                observedAt,
+                cycle,
+              } as const
+            }
+            const freshness = yield* Effect.try({
+              try: () => measurePublicationFreshness(cycle, publication.inspection, observedAt),
+              catch: (cause) =>
+                readinessError(
+                  'measure-freshness',
+                  'contract',
+                  'finalized Signal publication freshness is invalid',
+                  cause,
+                ),
+            })
+            const receipt = yield* store
+              .bindSnapshot(cycle.identity.cycleId, publication.inspection.manifest, observedAt)
+              .pipe(
+                Effect.mapError((cause) =>
+                  readinessError(
+                    'bind-publication',
+                    'store',
+                    'failed to persist and bind the finalized Signal publication',
+                    cause,
+                  ),
+                ),
+              )
+            return yield* Effect.try({
+              try: () => boundResult(receipt.changed ? 'BOUND' : 'ALREADY_BOUND', receipt, observedAt, freshness),
+              catch: (cause) =>
+                readinessError(
+                  'bind-publication',
+                  'contract',
+                  'finalized Signal publication binding returned an invalid cycle',
+                  cause,
+                ),
+            })
+          }),
+      },
+    )
+  })

--- a/services/bayn/src/cycle-readiness.ts
+++ b/services/bayn/src/cycle-readiness.ts
@@ -116,9 +116,14 @@ const blockMissedPublication = (
 const inspectBoundPublication = (
   cycle: AutonomousCycle,
   marketData: MarketDataService,
-): Effect.Effect<CyclePublicationReadiness, CycleReadinessError> =>
-  marketData
-    .inspectPublication({
+): Effect.Effect<CyclePublicationReadiness, CycleReadinessError> => {
+  const boundSnapshotId = cycle.bindings.snapshotId
+  if (boundSnapshotId === undefined) {
+    return Effect.fail(readinessError('inspect-publication', 'contract', 'bound cycle does not retain a snapshot ID'))
+  }
+  return marketData
+    .inspectSnapshotPublication({
+      snapshotId: boundSnapshotId,
       signalSessionDate: cycle.identity.signalSessionDate,
       signalCalendarVersion: cycle.identity.signalCalendarVersion,
     })
@@ -142,11 +147,7 @@ const inspectBoundPublication = (
               ),
             )
           }
-          const boundSnapshotId = cycle.bindings.snapshotId
-          if (
-            boundSnapshotId === undefined ||
-            publication.inspection.manifest.finalizedSnapshot.snapshotId !== boundSnapshotId
-          ) {
+          if (publication.inspection.manifest.finalizedSnapshot.snapshotId !== boundSnapshotId) {
             return yield* Effect.fail(
               readinessError(
                 'inspect-publication',
@@ -176,6 +177,7 @@ const inspectBoundPublication = (
         }),
       ),
     )
+}
 
 export const runCyclePublicationReadiness = (
   cycle: AutonomousCycle,

--- a/services/bayn/src/cycle.ts
+++ b/services/bayn/src/cycle.ts
@@ -366,6 +366,13 @@ export type AutonomousCycle = typeof AutonomousCycleSchema.Type
 
 type SignalCycleSessionRow = Pick<SignalSessionRow, 'calendar_version' | 'session_date' | 'close_time' | 'timezone'>
 
+export const signalSessionCloseAt = (signalSession: SignalCycleSessionRow): string => {
+  if (signalSession.timezone !== cycleTimeZone) {
+    throw new TypeError('Signal session timezone must be America/New_York')
+  }
+  return localMarketTimeToUtc(signalSession.session_date, signalSession.close_time)
+}
+
 export const makeCycleExecutionPolicy = (material: CycleExecutionPolicyMaterial): CycleExecutionPolicy => ({
   ...material,
   executionPolicyHash: canonicalHashV1(material),
@@ -422,7 +429,7 @@ export const makeCycleWindow = (
   } catch {
     throw new TypeError('selected broker calendar session is invalid')
   }
-  const signalCloseAt = localMarketTimeToUtc(signalSession.session_date, signalSession.close_time)
+  const signalCloseAt = signalSessionCloseAt(signalSession)
   const executionOpenAt = executionCalendar.executionOpenAt
   const submissionCutoffAt = new Date(Date.parse(executionOpenAt) - submissionCutoffBeforeOpenMs).toISOString()
   const submissionOpenAt = new Date(Date.parse(submissionCutoffAt) - submissionWindowMs).toISOString()

--- a/services/bayn/src/db/cycle-store.integration.test.ts
+++ b/services/bayn/src/db/cycle-store.integration.test.ts
@@ -32,6 +32,7 @@ const snapshotA = 'd'.repeat(64)
 const snapshotB = 'e'.repeat(64)
 const staleSnapshot = '6'.repeat(64)
 const wrongCalendarSnapshot = '7'.repeat(64)
+const wrongAsOfSnapshot = '8'.repeat(64)
 const missingSnapshot = '9'.repeat(64)
 const decisionHash = 'f'.repeat(64)
 
@@ -123,6 +124,7 @@ const insertSnapshotReference = (
 const makeInputManifest = (
   snapshotId: string,
   options: {
+    readonly asOfSession?: IsoDate
     readonly calendarVersion?: string
     readonly lastSession?: IsoDate
   } = {},
@@ -149,7 +151,7 @@ const makeInputManifest = (
     requestedStart: lastSession,
     firstSession: lastSession,
     lastSession,
-    asOfSession: lastSession,
+    asOfSession: options.asOfSession ?? lastSession,
     symbols: [symbol],
     rowCount: 1,
     sessionCount: 1,
@@ -564,6 +566,41 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
     const reboundSnapshotId = result.rebound.cycle.bindings.snapshotId
     if (reboundSnapshotId === undefined) throw new Error('successful binding must retain its snapshot ID')
     expect(result.references.map((row) => row.snapshot_id)).toContain(reboundSnapshotId)
+  })
+
+  test('rolls back snapshot persistence when publication as-of identity differs from the cycle session', async () => {
+    const draft = makeDraft('paper-account-as-of-mismatch')
+    const result = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* CycleStore
+        yield* store.acquire(draft, acquireAt)
+
+        const binding = yield* Effect.exit(
+          store.bindSnapshot(
+            draft.identity.cycleId,
+            makeInputManifest(wrongAsOfSnapshot, { asOfSession: '2026-03-05' }),
+            snapshotAt,
+          ),
+        )
+        const cycle = yield* store.read(draft.identity.cycleId)
+        const sql = yield* PgClient.PgClient
+        const [reference] = yield* sql<{ count: number }>`
+          SELECT count(*)::integer AS count
+          FROM snapshot_references
+          WHERE snapshot_id = ${wrongAsOfSnapshot}
+        `
+        return { binding, cycle, referenceCount: reference.count }
+      }),
+    )
+
+    expect(Exit.isFailure(result.binding)).toBe(true)
+    expect(result.referenceCount).toBe(0)
+    expect(Option.isSome(result.cycle)).toBe(true)
+    if (Option.isNone(result.cycle)) throw new Error('acquired cycle must remain readable after rejected binding')
+    expect(result.cycle.value).toMatchObject({
+      state: CycleState.Pending,
+      bindings: {},
+    })
   })
 
   test('keeps completion unreachable and preserves blocked terminal history across runtimes', async () => {

--- a/services/bayn/src/db/cycle-store.integration.test.ts
+++ b/services/bayn/src/db/cycle-store.integration.test.ts
@@ -17,9 +17,9 @@ import {
   type CycleDraft,
 } from '../cycle'
 import { runAutonomousCyclePass, type CycleCandidate, type CycleRunResult } from '../cycle-runner'
-import { canonicalHashV1 } from '../hash'
+import { canonicalHashV1, sha256 } from '../hash'
 import type { SignalSessionRow } from '../market-data'
-import type { IsoDate } from '../types'
+import { DataFeed, DataSource, PriceAdjustment, PublicationSchema, type InputManifest, type IsoDate } from '../types'
 import { CycleStore, CycleStoreLive } from './cycle-store'
 import { PostgresClientLive } from './evidence-store'
 import { migrationLoader } from './migrations'
@@ -120,6 +120,68 @@ const insertSnapshotReference = (
     `
   })
 
+const makeInputManifest = (
+  snapshotId: string,
+  options: {
+    readonly calendarVersion?: string
+    readonly lastSession?: IsoDate
+  } = {},
+): InputManifest => {
+  const lastSession = options.lastSession ?? '2026-03-06'
+  const symbol = 'SPY'
+  const finalizedSnapshot = {
+    schemaVersion: 'bayn.finalized-snapshot.v3' as const,
+    snapshotId,
+    publicationId: snapshotId,
+    publicationSchemaVersion: PublicationSchema.AdjustedDailySnapshotV2,
+    universeId: 'cross-asset-taa-v1' as const,
+    universeSymbolHash: sha256(symbol),
+    source: DataSource.Alpaca,
+    sourceFeed: DataFeed.Sip,
+    adjustment: PriceAdjustment.All,
+    calendarVersion: options.calendarVersion ?? signalCalendarVersion,
+    publisherSourceRevision: '1'.repeat(40),
+    publisherImage: {
+      repository: 'registry.example.com/signal-publisher',
+      digest: `sha256:${'2'.repeat(64)}`,
+    },
+    finalizedAt: '2026-03-06T21:01:00.000Z',
+    requestedStart: lastSession,
+    firstSession: lastSession,
+    lastSession,
+    asOfSession: lastSession,
+    symbols: [symbol],
+    rowCount: 1,
+    sessionCount: 1,
+    contentHash: snapshotId,
+    sessionsContentHash: '3'.repeat(64),
+  }
+  const material: Omit<InputManifest, 'hash'> = {
+    schemaVersion: 'bayn.input-manifest.v3',
+    database: 'signal',
+    tables: {
+      bars: 'adjusted_daily_bars_v2',
+      sessions: 'exchange_sessions_v1',
+      manifests: 'snapshot_manifests_v2',
+    },
+    bounds: {
+      schemaVersion: 'bayn.evaluation-bounds.v1',
+      dataStart: lastSession,
+      dataEnd: lastSession,
+      lookbackStart: lastSession,
+      evaluationStart: lastSession,
+      evaluationEnd: lastSession,
+    },
+    rowCount: 1,
+    sessionCount: 1,
+    firstSession: lastSession,
+    lastSession,
+    symbols: [{ symbol, rows: 1, firstSession: lastSession, lastSession }],
+    finalizedSnapshot,
+  }
+  return { ...material, hash: canonicalHashV1(material) }
+}
+
 const acquireAt = '2026-03-06T21:01:00.000Z'
 const snapshotAt = '2026-03-06T21:02:00.000Z'
 const activeAt = '2026-03-06T21:03:00.000Z'
@@ -207,16 +269,6 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
     await runtime.dispose()
     runtime = makeRuntime()
     await runtime.runPromise(PgMigrator.run({ loader: migrationLoader, table: 'schema_migrations' }))
-    await runtime.runPromise(
-      Effect.gen(function* () {
-        yield* insertSnapshotReference(snapshotA)
-        yield* insertSnapshotReference(snapshotB)
-        yield* insertSnapshotReference(staleSnapshot, { lastSession: '2026-03-05' })
-        yield* insertSnapshotReference(wrongCalendarSnapshot, {
-          calendarVersion: 'signal-XNYS-2026-revised',
-        })
-      }),
-    )
   })
 
   afterAll(async () => {
@@ -413,7 +465,7 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
     expect(result.count).toBe(1)
   })
 
-  test('requires durable snapshots, rejects pre-close binding, and serializes competing bindings', async () => {
+  test('atomically persists publications, rejects invalid timing/provenance, and serializes competing bindings', async () => {
     const temporalDraft = makeDraft('paper-account-temporal')
     const bindingDraft = makeDraft('paper-account-binding')
     const result = await runtime.runPromise(
@@ -422,38 +474,58 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
 
         yield* store.acquire(temporalDraft, '2026-03-06T20:58:00.000Z')
         const preClose = yield* Effect.exit(
-          store.bindSnapshot(temporalDraft.identity.cycleId, snapshotA, '2026-03-06T20:59:00.000Z'),
+          store.bindSnapshot(temporalDraft.identity.cycleId, makeInputManifest(snapshotA), '2026-03-06T20:59:00.000Z'),
         )
         const atClose = yield* store.bindSnapshot(
           temporalDraft.identity.cycleId,
-          snapshotA,
+          makeInputManifest(snapshotA),
           temporalDraft.window.signalCloseAt,
         )
 
         yield* store.acquire(bindingDraft, acquireAt)
+        yield* insertSnapshotReference(missingSnapshot)
         const missingReference = yield* Effect.exit(
-          store.bindSnapshot(bindingDraft.identity.cycleId, missingSnapshot, snapshotAt),
+          store.bindSnapshot(bindingDraft.identity.cycleId, makeInputManifest(missingSnapshot), snapshotAt),
         )
         const staleReference = yield* Effect.exit(
-          store.bindSnapshot(bindingDraft.identity.cycleId, staleSnapshot, snapshotAt),
+          store.bindSnapshot(
+            bindingDraft.identity.cycleId,
+            makeInputManifest(staleSnapshot, { lastSession: '2026-03-05' }),
+            snapshotAt,
+          ),
         )
         const wrongCalendarReference = yield* Effect.exit(
-          store.bindSnapshot(bindingDraft.identity.cycleId, wrongCalendarSnapshot, snapshotAt),
+          store.bindSnapshot(
+            bindingDraft.identity.cycleId,
+            makeInputManifest(wrongCalendarSnapshot, { calendarVersion: 'signal-XNYS-2026-revised' }),
+            snapshotAt,
+          ),
         )
         const bindingExits = yield* Effect.all(
           [
-            Effect.exit(store.bindSnapshot(bindingDraft.identity.cycleId, snapshotA, snapshotAt)),
-            Effect.exit(store.bindSnapshot(bindingDraft.identity.cycleId, snapshotB, snapshotAt)),
+            Effect.exit(store.bindSnapshot(bindingDraft.identity.cycleId, makeInputManifest(snapshotA), snapshotAt)),
+            Effect.exit(store.bindSnapshot(bindingDraft.identity.cycleId, makeInputManifest(snapshotB), snapshotAt)),
           ],
           { concurrency: 'unbounded' },
         )
         const selectedSnapshot = bindingExits.find(Exit.isSuccess)?.value.cycle.bindings.snapshotId ?? snapshotA
-        const rebound = yield* store.bindSnapshot(bindingDraft.identity.cycleId, selectedSnapshot, snapshotAt)
+        const rebound = yield* store.bindSnapshot(
+          bindingDraft.identity.cycleId,
+          makeInputManifest(selectedSnapshot),
+          snapshotAt,
+        )
+        const sql = yield* PgClient.PgClient
+        const references = yield* sql<{ snapshot_id: string }>`
+          SELECT snapshot_id
+          FROM snapshot_references
+          ORDER BY snapshot_id
+        `
         return {
           atClose,
           bindingExits,
           missingReference,
           preClose,
+          references,
           rebound,
           staleReference,
           wrongCalendarReference,
@@ -467,21 +539,31 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
     }
     expect(result.atClose.changed).toBe(true)
     expect(Exit.isFailure(result.missingReference)).toBe(true)
+    if (Exit.isFailure(result.missingReference)) {
+      expect(Cause.pretty(result.missingReference.cause)).toContain(
+        'stored snapshot reference diverged from the finalized Signal publication',
+      )
+    }
     expect(Exit.isFailure(result.staleReference)).toBe(true)
     if (Exit.isFailure(result.staleReference)) {
       expect(Cause.pretty(result.staleReference.cause)).toContain(
-        'autonomous cycle snapshot does not match signal session and calendar',
+        'finalized Signal publication does not match the cycle signal session and calendar',
       )
     }
     expect(Exit.isFailure(result.wrongCalendarReference)).toBe(true)
     if (Exit.isFailure(result.wrongCalendarReference)) {
       expect(Cause.pretty(result.wrongCalendarReference.cause)).toContain(
-        'autonomous cycle snapshot does not match signal session and calendar',
+        'finalized Signal publication does not match the cycle signal session and calendar',
       )
     }
     expect(result.bindingExits.filter(Exit.isSuccess)).toHaveLength(1)
     expect(result.bindingExits.filter(Exit.isFailure)).toHaveLength(1)
     expect(result.rebound.changed).toBe(false)
+    expect(result.references.map((row) => row.snapshot_id)).not.toContain(staleSnapshot)
+    expect(result.references.map((row) => row.snapshot_id)).not.toContain(wrongCalendarSnapshot)
+    const reboundSnapshotId = result.rebound.cycle.bindings.snapshotId
+    if (reboundSnapshotId === undefined) throw new Error('successful binding must retain its snapshot ID')
+    expect(result.references.map((row) => row.snapshot_id)).toContain(reboundSnapshotId)
   })
 
   test('keeps completion unreachable and preserves blocked terminal history across runtimes', async () => {
@@ -490,7 +572,7 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
       Effect.gen(function* () {
         const store = yield* CycleStore
         yield* store.acquire(draft, acquireAt)
-        yield* store.bindSnapshot(draft.identity.cycleId, snapshotA, snapshotAt)
+        yield* store.bindSnapshot(draft.identity.cycleId, makeInputManifest(snapshotA), snapshotAt)
         yield* store.activate(draft.identity.cycleId, activeAt)
         yield* store.bindDecision(draft.identity.cycleId, decisionHash, decisionAt)
 
@@ -572,7 +654,7 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
       Effect.gen(function* () {
         const store = yield* CycleStore
         yield* store.acquire(initialDraft, acquireAt)
-        yield* store.bindSnapshot(initialDraft.identity.cycleId, snapshotA, snapshotAt)
+        yield* store.bindSnapshot(initialDraft.identity.cycleId, makeInputManifest(snapshotA), snapshotAt)
         const sql = yield* PgClient.PgClient
         const invalidInitialActive = yield* Effect.exit(sql`
           INSERT INTO autonomous_cycles (
@@ -617,7 +699,7 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
         `)
 
         yield* store.acquire(activationDraft, acquireAt)
-        yield* store.bindSnapshot(activationDraft.identity.cycleId, snapshotA, snapshotAt)
+        yield* store.bindSnapshot(activationDraft.identity.cycleId, makeInputManifest(snapshotA), snapshotAt)
         const earlySubmissionMiss = yield* Effect.exit(
           store.block(
             activationDraft.identity.cycleId,
@@ -631,14 +713,14 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
         )
 
         yield* store.acquire(afterCutoffDraft, acquireAt)
-        yield* store.bindSnapshot(afterCutoffDraft.identity.cycleId, snapshotA, snapshotAt)
+        yield* store.bindSnapshot(afterCutoffDraft.identity.cycleId, makeInputManifest(snapshotA), snapshotAt)
         const activationAfterCutoff = yield* store.activate(
           afterCutoffDraft.identity.cycleId,
           new Date(Date.parse(afterCutoffDraft.window.submissionCutoffAt) + 1).toISOString(),
         )
 
         yield* store.acquire(decisionDraft, acquireAt)
-        yield* store.bindSnapshot(decisionDraft.identity.cycleId, snapshotB, snapshotAt)
+        yield* store.bindSnapshot(decisionDraft.identity.cycleId, makeInputManifest(snapshotB), snapshotAt)
         yield* store.activate(decisionDraft.identity.cycleId, activeAt)
         const decisionAtCutoff = yield* store.bindDecision(
           decisionDraft.identity.cycleId,

--- a/services/bayn/src/db/cycle-store.ts
+++ b/services/bayn/src/db/cycle-store.ts
@@ -460,13 +460,11 @@ const makeCycleStore = Effect.gen(function* () {
   ): Effect.Effect<CycleMutationReceipt, CycleStoreError> =>
     run(
       'bind-snapshot',
-      Effect.all({
-        input: decodeSnapshotInput({ cycleId, observedAt }),
-        inputManifest: decodeInputManifestArtifact(inputManifest),
-      }).pipe(
-        Effect.flatMap(({ input, inputManifest: decodedManifest }) =>
+      decodeSnapshotInput({ cycleId, observedAt }).pipe(
+        Effect.flatMap((input) =>
           sql.withTransaction(
             Effect.gen(function* () {
+              const decodedManifest = yield* decodeInputManifestArtifact(inputManifest)
               const cycle = yield* readLocked('bind-snapshot', input.cycleId)
               const snapshot = decodedManifest.finalizedSnapshot
               if (input.observedAt < cycle.window.signalCloseAt) {
@@ -477,6 +475,7 @@ const makeCycleStore = Effect.gen(function* () {
                 )
               }
               if (
+                snapshot.asOfSession !== cycle.identity.signalSessionDate ||
                 snapshot.lastSession !== cycle.identity.signalSessionDate ||
                 snapshot.calendarVersion !== cycle.identity.signalCalendarVersion
               ) {

--- a/services/bayn/src/db/cycle-store.ts
+++ b/services/bayn/src/db/cycle-store.ts
@@ -13,6 +13,7 @@ import {
   type AutonomousCycle,
   type CycleDraft,
 } from '../cycle'
+import { decodeInputManifestArtifact } from '../evidence-contracts'
 import {
   IsoDateSchema,
   PositiveIntegerSchema,
@@ -21,6 +22,8 @@ import {
   UtcInstantSchema,
   strictParseOptions,
 } from '../schemas'
+import type { InputManifest } from '../types'
+import { ensureSnapshotReference } from './snapshot-reference'
 
 export interface CycleAcquireReceipt {
   readonly cycle: AutonomousCycle
@@ -44,7 +47,7 @@ export interface CycleStoreShape {
   readonly read: (cycleId: string) => Effect.Effect<Option.Option<AutonomousCycle>, CycleStoreError>
   readonly bindSnapshot: (
     cycleId: string,
-    snapshotId: string,
+    inputManifest: InputManifest,
     observedAt: string,
   ) => Effect.Effect<CycleMutationReceipt, CycleStoreError>
   readonly activate: (cycleId: string, observedAt: string) => Effect.Effect<CycleMutationReceipt, CycleStoreError>
@@ -102,7 +105,6 @@ type StoredCycleRow = typeof StoredCycleRowSchema.Type
 const CycleIdInputSchema = Schema.Struct({ cycleId: Sha256Schema, observedAt: UtcInstantSchema })
 const SnapshotInputSchema = Schema.Struct({
   cycleId: Sha256Schema,
-  snapshotId: Sha256Schema,
   observedAt: UtcInstantSchema,
 })
 const DecisionInputSchema = Schema.Struct({
@@ -438,18 +440,35 @@ const makeCycleStore = Effect.gen(function* () {
       ),
     )
 
+  const persistSnapshotReference = (inputManifest: InputManifest): Effect.Effect<void, unknown> =>
+    ensureSnapshotReference(sql, inputManifest).pipe(
+      Effect.flatMap((matches) =>
+        matches
+          ? Effect.void
+          : fail(
+              'bind-snapshot',
+              'conflict',
+              'stored snapshot reference diverged from the finalized Signal publication',
+            ),
+      ),
+    )
+
   const bindSnapshot = (
     cycleId: string,
-    snapshotId: string,
+    inputManifest: InputManifest,
     observedAt: string,
   ): Effect.Effect<CycleMutationReceipt, CycleStoreError> =>
     run(
       'bind-snapshot',
-      decodeSnapshotInput({ cycleId, snapshotId, observedAt }).pipe(
-        Effect.flatMap((input) =>
+      Effect.all({
+        input: decodeSnapshotInput({ cycleId, observedAt }),
+        inputManifest: decodeInputManifestArtifact(inputManifest),
+      }).pipe(
+        Effect.flatMap(({ input, inputManifest: decodedManifest }) =>
           sql.withTransaction(
             Effect.gen(function* () {
               const cycle = yield* readLocked('bind-snapshot', input.cycleId)
+              const snapshot = decodedManifest.finalizedSnapshot
               if (input.observedAt < cycle.window.signalCloseAt) {
                 return yield* fail(
                   'bind-snapshot',
@@ -457,10 +476,21 @@ const makeCycleStore = Effect.gen(function* () {
                   'snapshot binding cannot precede the Signal session close',
                 )
               }
+              if (
+                snapshot.lastSession !== cycle.identity.signalSessionDate ||
+                snapshot.calendarVersion !== cycle.identity.signalCalendarVersion
+              ) {
+                return yield* fail(
+                  'bind-snapshot',
+                  'invariant',
+                  'finalized Signal publication does not match the cycle signal session and calendar',
+                )
+              }
               if (cycle.bindings.snapshotId !== undefined) {
-                if (cycle.bindings.snapshotId !== input.snapshotId) {
+                if (cycle.bindings.snapshotId !== snapshot.snapshotId) {
                   return yield* fail('bind-snapshot', 'conflict', 'cycle snapshot binding cannot be replaced')
                 }
+                yield* persistSnapshotReference(decodedManifest)
                 return { cycle, changed: false }
               }
               if (cycle.state !== CycleState.Pending) {
@@ -477,10 +507,11 @@ const makeCycleStore = Effect.gen(function* () {
               if (input.observedAt < cycle.updatedAt) {
                 return yield* fail('bind-snapshot', 'conflict', 'cycle update time cannot move backward')
               }
+              yield* persistSnapshotReference(decodedManifest)
               const updatedRows = yield* sql<Record<string, unknown>>`
                 UPDATE autonomous_cycles
                 SET
-                  snapshot_id = ${input.snapshotId},
+                  snapshot_id = ${snapshot.snapshotId},
                   state_version = ${cycle.stateVersion + 1},
                   updated_at = ${input.observedAt}
                 WHERE cycle_id = ${input.cycleId}

--- a/services/bayn/src/db/evidence-store.ts
+++ b/services/bayn/src/db/evidence-store.ts
@@ -46,6 +46,7 @@ import type {
   ReconciliationResult,
 } from '../types'
 import { migrationLoader } from './migrations'
+import { ensureSnapshotReference as ensureSnapshotReferenceRow } from './snapshot-reference'
 
 export type DatabaseFailure = 'constraint' | 'decode' | 'invariant' | 'migration' | 'query' | 'unavailable'
 
@@ -1109,42 +1110,9 @@ const makeEvidenceStore = Effect.gen(function* () {
 
   const ensureSnapshotReference = (inputManifest: InputManifest) =>
     Effect.gen(function* () {
-      const snapshot = inputManifest.finalizedSnapshot
-      yield* sql`
-        INSERT INTO snapshot_references (
-          snapshot_id,
-          schema_version,
-          database_name,
-          table_name,
-          dataset_version,
-          source,
-          source_feed,
-          adjustment,
-          content_hash,
-          row_count,
-          first_session,
-          last_session,
-          manifest
-        ) VALUES (
-          ${snapshot.snapshotId},
-          ${snapshot.schemaVersion},
-          ${inputManifest.database},
-          ${inputManifest.tables.bars},
-          ${snapshot.publicationSchemaVersion},
-          ${snapshot.source},
-          ${snapshot.sourceFeed},
-          ${snapshot.adjustment},
-          ${snapshot.contentHash},
-          ${snapshot.rowCount},
-          ${snapshot.firstSession},
-          ${snapshot.lastSession},
-          ${sql.json(snapshot)}
-        )
-        ON CONFLICT (snapshot_id) DO NOTHING
-      `
-      const storedSnapshot = yield* getSnapshot({ snapshotId: snapshot.snapshotId })
+      const matches = yield* ensureSnapshotReferenceRow(sql, inputManifest)
       yield* ensure(
-        snapshotReferenceMatches(storedSnapshot, inputManifest),
+        matches,
         'snapshot-reference',
         'stored snapshot reference diverged from the evaluated input manifest',
       )

--- a/services/bayn/src/db/snapshot-reference.ts
+++ b/services/bayn/src/db/snapshot-reference.ts
@@ -1,0 +1,71 @@
+import { PgClient } from '@effect/sql-pg'
+import { Effect, Schema } from 'effect'
+
+import { strictParseOptions } from '../schemas'
+import type { InputManifest } from '../types'
+
+const SnapshotReferenceMatchSchema = Schema.Tuple([
+  Schema.Struct({
+    matches: Schema.Boolean,
+  }),
+])
+
+const decodeSnapshotReferenceMatch = Schema.decodeUnknownEffect(SnapshotReferenceMatchSchema, strictParseOptions)
+
+export const ensureSnapshotReference = (
+  sql: PgClient.PgClient,
+  inputManifest: InputManifest,
+): Effect.Effect<boolean, unknown> =>
+  Effect.gen(function* () {
+    const snapshot = inputManifest.finalizedSnapshot
+    yield* sql`
+      INSERT INTO snapshot_references (
+        snapshot_id,
+        schema_version,
+        database_name,
+        table_name,
+        dataset_version,
+        source,
+        source_feed,
+        adjustment,
+        content_hash,
+        row_count,
+        first_session,
+        last_session,
+        manifest
+      ) VALUES (
+        ${snapshot.snapshotId},
+        ${snapshot.schemaVersion},
+        ${inputManifest.database},
+        ${inputManifest.tables.bars},
+        ${snapshot.publicationSchemaVersion},
+        ${snapshot.source},
+        ${snapshot.sourceFeed},
+        ${snapshot.adjustment},
+        ${snapshot.contentHash},
+        ${snapshot.rowCount},
+        ${snapshot.firstSession},
+        ${snapshot.lastSession},
+        ${sql.json(snapshot)}
+      )
+      ON CONFLICT (snapshot_id) DO NOTHING
+    `
+    const [match] = yield* sql<Record<string, unknown>>`
+      SELECT count(*) = 1 AS matches
+      FROM snapshot_references
+      WHERE snapshot_id = ${snapshot.snapshotId}
+        AND schema_version = ${snapshot.schemaVersion}
+        AND database_name = ${inputManifest.database}
+        AND table_name = ${inputManifest.tables.bars}
+        AND dataset_version = ${snapshot.publicationSchemaVersion}
+        AND source = ${snapshot.source}
+        AND source_feed = ${snapshot.sourceFeed}
+        AND adjustment = ${snapshot.adjustment}
+        AND content_hash = ${snapshot.contentHash}
+        AND row_count = ${snapshot.rowCount}
+        AND first_session = ${snapshot.firstSession}
+        AND last_session = ${snapshot.lastSession}
+        AND manifest = ${sql.json(snapshot)}
+    `.pipe(Effect.flatMap(decodeSnapshotReferenceMatch))
+    return match.matches
+  })

--- a/services/bayn/src/health.test.ts
+++ b/services/bayn/src/health.test.ts
@@ -68,6 +68,7 @@ describe('Bayn continuous health', () => {
         Effect.provideService(MarketData, {
           check: Effect.succeed(makeSnapshot().manifest.finalizedSnapshot),
           inspect: Effect.die(new Error('health probes must not inspect sessions')),
+          inspectPublication: () => Effect.die(new Error('health probes must not inspect cycle publications')),
           load: Effect.die(new Error('health probes must not load bars')),
         }),
         Effect.provideService(Journal, { ...successfulJournal, checkRun: () => Effect.void }),
@@ -118,6 +119,7 @@ describe('Bayn continuous health', () => {
           : Effect.die(new Error('Signal connection defect')),
       ),
       inspect: Effect.die(new Error('health probes must not inspect sessions')),
+      inspectPublication: () => Effect.die(new Error('health probes must not inspect cycle publications')),
       load: Effect.die(new Error('health probes must not load bars')),
     }
     const journal: JournalService = {
@@ -196,6 +198,7 @@ describe('Bayn continuous health', () => {
         return makeSnapshot().manifest.finalizedSnapshot
       }),
       inspect: Effect.die(new Error('health monitor must not inspect sessions')),
+      inspectPublication: () => Effect.die(new Error('health monitor must not inspect cycle publications')),
       load: Effect.die(new Error('health monitor must not load bars')),
     }
     const journal: JournalService = { ...successfulJournal, checkRun: () => Effect.void }
@@ -231,6 +234,7 @@ describe('Bayn continuous health', () => {
         Effect.onInterrupt(() => Effect.sync(() => void (interrupted = true))),
       ),
       inspect: Effect.die(new Error('health monitor must not inspect sessions')),
+      inspectPublication: () => Effect.die(new Error('health monitor must not inspect cycle publications')),
       load: Effect.die(new Error('health monitor must not load bars')),
     }
     const fiber = Effect.runFork(

--- a/services/bayn/src/health.test.ts
+++ b/services/bayn/src/health.test.ts
@@ -69,6 +69,8 @@ describe('Bayn continuous health', () => {
           check: Effect.succeed(makeSnapshot().manifest.finalizedSnapshot),
           inspect: Effect.die(new Error('health probes must not inspect sessions')),
           inspectPublication: () => Effect.die(new Error('health probes must not inspect cycle publications')),
+          inspectSnapshotPublication: () =>
+            Effect.die(new Error('health probes must not inspect bound cycle publications')),
           load: Effect.die(new Error('health probes must not load bars')),
         }),
         Effect.provideService(Journal, { ...successfulJournal, checkRun: () => Effect.void }),
@@ -120,6 +122,8 @@ describe('Bayn continuous health', () => {
       ),
       inspect: Effect.die(new Error('health probes must not inspect sessions')),
       inspectPublication: () => Effect.die(new Error('health probes must not inspect cycle publications')),
+      inspectSnapshotPublication: () =>
+        Effect.die(new Error('health probes must not inspect bound cycle publications')),
       load: Effect.die(new Error('health probes must not load bars')),
     }
     const journal: JournalService = {
@@ -199,6 +203,8 @@ describe('Bayn continuous health', () => {
       }),
       inspect: Effect.die(new Error('health monitor must not inspect sessions')),
       inspectPublication: () => Effect.die(new Error('health monitor must not inspect cycle publications')),
+      inspectSnapshotPublication: () =>
+        Effect.die(new Error('health monitor must not inspect bound cycle publications')),
       load: Effect.die(new Error('health monitor must not load bars')),
     }
     const journal: JournalService = { ...successfulJournal, checkRun: () => Effect.void }
@@ -235,6 +241,8 @@ describe('Bayn continuous health', () => {
       ),
       inspect: Effect.die(new Error('health monitor must not inspect sessions')),
       inspectPublication: () => Effect.die(new Error('health monitor must not inspect cycle publications')),
+      inspectSnapshotPublication: () =>
+        Effect.die(new Error('health monitor must not inspect bound cycle publications')),
       load: Effect.die(new Error('health monitor must not load bars')),
     }
     const fiber = Effect.runFork(

--- a/services/bayn/src/market-data.test.ts
+++ b/services/bayn/src/market-data.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, test } from 'bun:test'
 
+import { ClickhouseClient } from '@effect/sql-clickhouse'
+import { Effect, Layer, Redacted } from 'effect'
 import { AuthorizationError, ConnectionError, SqlError } from 'effect/unstable/sql/SqlError'
 
+import { canonicalHashV1 } from './hash'
 import {
+  MarketData,
+  MarketDataLive,
   marketDataOperationError,
   verifyFinalizedCalendar,
   verifyFinalizedManifest,
@@ -11,6 +16,8 @@ import {
   type SnapshotRows,
   type SnapshotRequest,
   type FinalizedPublicationRequest,
+  type SignalManifestRow,
+  type SignalSessionRow,
 } from './market-data'
 import { DataFeed, DataSource, PriceAdjustment, PublicationSchema } from './types'
 
@@ -160,6 +167,92 @@ const makeFixture = (): {
       observedAt: '2025-01-04T02:00:00.000Z',
     },
   }
+}
+
+const makeCalendarRevision = (
+  fixture: ReturnType<typeof makeFixture>,
+  calendarVersion: string,
+): {
+  readonly manifest: SignalManifestRow
+  readonly sessions: readonly SignalSessionRow[]
+} => {
+  const source = fixture.rows.manifests[0]
+  const sessionMaterial = fixture.rows.sessions.map(({ snapshot_id: _, ...session }) => ({
+    ...session,
+    calendar_version: calendarVersion,
+  }))
+  const sessionsContentHash = canonicalHashV1(sessionMaterial)
+  const revisedSnapshotId = canonicalHashV1({
+    schemaVersion: source.schema_version,
+    provider: source.provider,
+    feed: source.source_feed,
+    adjustment: source.adjustment,
+    calendarVersion,
+    requestedStart: source.requested_start,
+    publicationAsOf: source.publication_asof,
+    symbols,
+    barsContentHash: source.bars_content_hash,
+    sessionsContentHash,
+    universeId: source.universe_id,
+    universeSymbolHash: source.universe_symbol_hash,
+  })
+  const { manifest_content_hash: _, ...sourceWithoutManifestHash } = source
+  const manifestMaterial = {
+    ...sourceWithoutManifestHash,
+    snapshot_id: revisedSnapshotId,
+    calendar_version: calendarVersion,
+    sessions_content_hash: sessionsContentHash,
+  }
+  return {
+    manifest: {
+      ...manifestMaterial,
+      manifest_content_hash: canonicalHashV1(manifestMaterial),
+    },
+    sessions: sessionMaterial.map((session) => ({ snapshot_id: revisedSnapshotId, ...session })),
+  }
+}
+
+interface CapturedQuery {
+  readonly text: string
+  readonly parameters: readonly unknown[]
+}
+
+interface ClickhouseParameter {
+  readonly value: unknown
+}
+
+const makeClickhouseFixture = (
+  manifests: readonly SignalManifestRow[],
+  sessions: readonly SignalSessionRow[],
+  queries: CapturedQuery[],
+): ClickhouseClient.ClickhouseClient => {
+  const statement = (
+    strings: TemplateStringsArray,
+    ...fragments: readonly ClickhouseParameter[]
+  ): Effect.Effect<readonly unknown[]> => {
+    const text = strings.join('?')
+    const parameters = fragments.map((fragment) => fragment.value)
+    if (text.includes('FROM signal.snapshot_manifests_v2') && text.includes('WHERE universe_id')) {
+      queries.push({ text, parameters })
+      const calendarVersion = parameters.at(-1)
+      const rows = text.includes('AND calendar_version =')
+        ? manifests.filter((manifest) => manifest.calendar_version === calendarVersion)
+        : manifests
+      return Effect.succeed(rows)
+    }
+    if (text.includes('FROM signal.exchange_sessions_v1')) {
+      const requestedSnapshotId = parameters[0]
+      return Effect.succeed(sessions.filter((session) => session.snapshot_id === requestedSnapshotId))
+    }
+    return Effect.succeed([])
+  }
+  return Object.assign(statement, {
+    param: (_dataType: string, value: unknown): ClickhouseParameter => ({ value }),
+    withQueryId:
+      (_queryId: string) =>
+      <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+        effect,
+  }) as unknown as ClickhouseClient.ClickhouseClient
 }
 
 describe('finalized Signal snapshot reader', () => {
@@ -312,6 +405,123 @@ describe('finalized Signal snapshot reader', () => {
         fixture.request.observedAt,
       ),
     ).toThrow('manifest content hash is invalid')
+  })
+
+  test('selects the exact calendar publication when the same Signal session has a revised calendar', () => {
+    const fixture = makeFixture()
+    const revisedCalendarVersion = 'alpaca-us-equity-calendar-v2'
+    const revision = makeCalendarRevision(fixture, revisedCalendarVersion)
+    const contract = {
+      universeId: fixture.request.universeId,
+      universeSymbolHash: fixture.request.universeSymbolHash,
+      universe: fixture.request.universe,
+      historyStart: fixture.request.historyStart,
+      evaluationStart: fixture.request.evaluationStart,
+    }
+    const manifests = [...fixture.rows.manifests, revision.manifest]
+    const original = verifyFinalizedPublication(
+      { manifests, sessions: fixture.rows.sessions },
+      {
+        signalSessionDate: '2025-01-03',
+        signalCalendarVersion: fixture.request.calendarVersion,
+      },
+      contract,
+      fixture.request.observedAt,
+    )
+    const revised = verifyFinalizedPublication(
+      { manifests, sessions: revision.sessions },
+      {
+        signalSessionDate: '2025-01-03',
+        signalCalendarVersion: revisedCalendarVersion,
+      },
+      contract,
+      fixture.request.observedAt,
+    )
+    const originalReadback = verifyFinalizedPublication(
+      { manifests, sessions: fixture.rows.sessions },
+      {
+        signalSessionDate: '2025-01-03',
+        signalCalendarVersion: fixture.request.calendarVersion,
+      },
+      contract,
+      fixture.request.observedAt,
+    )
+
+    expect(original?.manifest.finalizedSnapshot).toMatchObject({
+      snapshotId,
+      calendarVersion: fixture.request.calendarVersion,
+    })
+    expect(revised?.manifest.finalizedSnapshot).toMatchObject({
+      snapshotId: revision.manifest.snapshot_id,
+      calendarVersion: revisedCalendarVersion,
+    })
+    expect(originalReadback).toEqual(original)
+  })
+
+  test('queries and re-reads a finalized publication by exact calendar identity', async () => {
+    const fixture = makeFixture()
+    const revisedCalendarVersion = 'alpaca-us-equity-calendar-v2'
+    const revision = makeCalendarRevision(fixture, revisedCalendarVersion)
+    const queries: CapturedQuery[] = []
+    const client = makeClickhouseFixture(
+      [...fixture.rows.manifests, revision.manifest],
+      [...fixture.rows.sessions, ...revision.sessions],
+      queries,
+    )
+    const contract = {
+      universeId: fixture.request.universeId,
+      universeSymbolHash: fixture.request.universeSymbolHash,
+      universe: fixture.request.universe,
+      historyStart: fixture.request.historyStart,
+      evaluationStart: fixture.request.evaluationStart,
+    }
+    const layer = MarketDataLive(
+      {
+        operationTimeoutMs: 5_000,
+        clickhouse: {
+          url: 'http://clickhouse.test:8123',
+          username: 'bayn',
+          password: Redacted.make('secret'),
+          snapshotId,
+          publicationAsOf: fixture.request.publicationAsOf,
+          calendarVersion: fixture.request.calendarVersion,
+          bounds: fixture.request.bounds,
+        },
+      },
+      contract,
+    ).pipe(Layer.provide(Layer.succeed(ClickhouseClient.ClickhouseClient, client)))
+    const input = {
+      signalSessionDate: '2025-01-03',
+      signalCalendarVersion: fixture.request.calendarVersion,
+    } satisfies FinalizedPublicationRequest
+    const results = await Effect.runPromise(
+      Effect.gen(function* () {
+        const marketData = yield* MarketData
+        return [yield* marketData.inspectPublication(input), yield* marketData.inspectPublication(input)] as const
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(results[0]).toMatchObject({
+      outcome: 'FINALIZED',
+      inspection: {
+        manifest: { finalizedSnapshot: { snapshotId, calendarVersion: fixture.request.calendarVersion } },
+      },
+    })
+    expect(results[1]).toMatchObject({
+      outcome: 'FINALIZED',
+      inspection: {
+        manifest: { finalizedSnapshot: { snapshotId, calendarVersion: fixture.request.calendarVersion } },
+      },
+    })
+    if (results[0].outcome !== 'FINALIZED' || results[1].outcome !== 'FINALIZED') {
+      throw new Error('both exact-calendar publication reads must be finalized')
+    }
+    expect(results[1].inspection).toEqual(results[0].inspection)
+    expect(queries).toHaveLength(2)
+    for (const query of queries) {
+      expect(query.text).toContain('AND calendar_version =')
+      expect(query.parameters).toContain(fixture.request.calendarVersion)
+    }
   })
 
   test('rejects duplicate manifests, sessions, and bars', () => {

--- a/services/bayn/src/market-data.test.ts
+++ b/services/bayn/src/market-data.test.ts
@@ -18,6 +18,7 @@ import {
   type FinalizedPublicationRequest,
   type SignalManifestRow,
   type SignalSessionRow,
+  type SnapshotPublicationRequest,
 } from './market-data'
 import { DataFeed, DataSource, PriceAdjustment, PublicationSchema } from './types'
 
@@ -169,14 +170,20 @@ const makeFixture = (): {
   }
 }
 
-const makeCalendarRevision = (
+const makePublicationRevision = (
   fixture: ReturnType<typeof makeFixture>,
-  calendarVersion: string,
+  options: {
+    readonly barsContentHash?: string
+    readonly calendarVersion?: string
+    readonly finalizedAt?: string
+  },
 ): {
   readonly manifest: SignalManifestRow
   readonly sessions: readonly SignalSessionRow[]
 } => {
   const source = fixture.rows.manifests[0]
+  const calendarVersion = options.calendarVersion ?? source.calendar_version
+  const barsContentHash = options.barsContentHash ?? source.bars_content_hash
   const sessionMaterial = fixture.rows.sessions.map(({ snapshot_id: _, ...session }) => ({
     ...session,
     calendar_version: calendarVersion,
@@ -191,7 +198,7 @@ const makeCalendarRevision = (
     requestedStart: source.requested_start,
     publicationAsOf: source.publication_asof,
     symbols,
-    barsContentHash: source.bars_content_hash,
+    barsContentHash,
     sessionsContentHash,
     universeId: source.universe_id,
     universeSymbolHash: source.universe_symbol_hash,
@@ -201,7 +208,9 @@ const makeCalendarRevision = (
     ...sourceWithoutManifestHash,
     snapshot_id: revisedSnapshotId,
     calendar_version: calendarVersion,
+    bars_content_hash: barsContentHash,
     sessions_content_hash: sessionsContentHash,
+    finalized_at: options.finalizedAt ?? source.finalized_at,
   }
   return {
     manifest: {
@@ -229,23 +238,28 @@ const makeClickhouseFixture = (
   const statement = (
     strings: TemplateStringsArray,
     ...fragments: readonly ClickhouseParameter[]
-  ): Effect.Effect<readonly unknown[]> => {
-    const text = strings.join('?')
-    const parameters = fragments.map((fragment) => fragment.value)
-    if (text.includes('FROM signal.snapshot_manifests_v2') && text.includes('WHERE universe_id')) {
-      queries.push({ text, parameters })
-      const calendarVersion = parameters.at(-1)
-      const rows = text.includes('AND calendar_version =')
-        ? manifests.filter((manifest) => manifest.calendar_version === calendarVersion)
-        : manifests
-      return Effect.succeed(rows)
-    }
-    if (text.includes('FROM signal.exchange_sessions_v1')) {
-      const requestedSnapshotId = parameters[0]
-      return Effect.succeed(sessions.filter((session) => session.snapshot_id === requestedSnapshotId))
-    }
-    return Effect.succeed([])
-  }
+  ): Effect.Effect<readonly unknown[]> =>
+    Effect.sync(() => {
+      const text = strings.join('?')
+      const parameters = fragments.map((fragment) => fragment.value)
+      if (text.includes('FROM signal.snapshot_manifests_v2') && text.includes('WHERE universe_id')) {
+        queries.push({ text, parameters })
+        const calendarVersion = parameters.at(-1)
+        return text.includes('AND calendar_version =')
+          ? manifests.filter((manifest) => manifest.calendar_version === calendarVersion)
+          : manifests
+      }
+      if (text.includes('FROM signal.snapshot_manifests_v2') && text.includes('WHERE snapshot_id')) {
+        queries.push({ text, parameters })
+        const requestedSnapshotId = parameters[0]
+        return manifests.filter((manifest) => manifest.snapshot_id === requestedSnapshotId)
+      }
+      if (text.includes('FROM signal.exchange_sessions_v1')) {
+        const requestedSnapshotId = parameters[0]
+        return sessions.filter((session) => session.snapshot_id === requestedSnapshotId)
+      }
+      return []
+    })
   return Object.assign(statement, {
     param: (_dataType: string, value: unknown): ClickhouseParameter => ({ value }),
     withQueryId:
@@ -410,7 +424,7 @@ describe('finalized Signal snapshot reader', () => {
   test('selects the exact calendar publication when the same Signal session has a revised calendar', () => {
     const fixture = makeFixture()
     const revisedCalendarVersion = 'alpaca-us-equity-calendar-v2'
-    const revision = makeCalendarRevision(fixture, revisedCalendarVersion)
+    const revision = makePublicationRevision(fixture, { calendarVersion: revisedCalendarVersion })
     const contract = {
       universeId: fixture.request.universeId,
       universeSymbolHash: fixture.request.universeSymbolHash,
@@ -461,7 +475,7 @@ describe('finalized Signal snapshot reader', () => {
   test('queries and re-reads a finalized publication by exact calendar identity', async () => {
     const fixture = makeFixture()
     const revisedCalendarVersion = 'alpaca-us-equity-calendar-v2'
-    const revision = makeCalendarRevision(fixture, revisedCalendarVersion)
+    const revision = makePublicationRevision(fixture, { calendarVersion: revisedCalendarVersion })
     const queries: CapturedQuery[] = []
     const client = makeClickhouseFixture(
       [...fixture.rows.manifests, revision.manifest],
@@ -522,6 +536,75 @@ describe('finalized Signal snapshot reader', () => {
       expect(query.text).toContain('AND calendar_version =')
       expect(query.parameters).toContain(fixture.request.calendarVersion)
     }
+  })
+
+  test('re-reads an immutable bound snapshot after a corrected snapshot is finalized under the same keys', async () => {
+    const fixture = makeFixture()
+    const correction = makePublicationRevision(fixture, {
+      barsContentHash: '4'.repeat(64),
+      finalizedAt: '2025-01-04 01:30:00.000',
+    })
+    const queries: CapturedQuery[] = []
+    const client = makeClickhouseFixture(
+      [...fixture.rows.manifests, correction.manifest],
+      [...fixture.rows.sessions, ...correction.sessions],
+      queries,
+    )
+    const layer = MarketDataLive(
+      {
+        operationTimeoutMs: 5_000,
+        clickhouse: {
+          url: 'http://clickhouse.test:8123',
+          username: 'bayn',
+          password: Redacted.make('secret'),
+          snapshotId,
+          publicationAsOf: fixture.request.publicationAsOf,
+          calendarVersion: fixture.request.calendarVersion,
+          bounds: fixture.request.bounds,
+        },
+      },
+      {
+        universeId: fixture.request.universeId,
+        universeSymbolHash: fixture.request.universeSymbolHash,
+        universe: fixture.request.universe,
+        historyStart: fixture.request.historyStart,
+        evaluationStart: fixture.request.evaluationStart,
+      },
+    ).pipe(Layer.provide(Layer.succeed(ClickhouseClient.ClickhouseClient, client)))
+    const request = (requestedSnapshotId: string): SnapshotPublicationRequest => ({
+      snapshotId: requestedSnapshotId,
+      signalSessionDate: '2025-01-03',
+      signalCalendarVersion: fixture.request.calendarVersion,
+    })
+    const results = await Effect.runPromise(
+      Effect.gen(function* () {
+        const marketData = yield* MarketData
+        const original = yield* marketData.inspectSnapshotPublication(request(snapshotId))
+        const corrected = yield* marketData.inspectSnapshotPublication(request(correction.manifest.snapshot_id))
+        const originalReadback = yield* marketData.inspectSnapshotPublication(request(snapshotId))
+        return { corrected, original, originalReadback }
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(results.original).toMatchObject({
+      outcome: 'FINALIZED',
+      inspection: { manifest: { finalizedSnapshot: { snapshotId } } },
+    })
+    expect(results.corrected).toMatchObject({
+      outcome: 'FINALIZED',
+      inspection: { manifest: { finalizedSnapshot: { snapshotId: correction.manifest.snapshot_id } } },
+    })
+    if (results.original.outcome !== 'FINALIZED' || results.originalReadback.outcome !== 'FINALIZED') {
+      throw new Error('the immutable original snapshot must remain directly readable')
+    }
+    expect(results.originalReadback.inspection).toEqual(results.original.inspection)
+    expect(queries).toHaveLength(3)
+    expect(queries.map((query) => query.parameters[0])).toEqual([
+      snapshotId,
+      correction.manifest.snapshot_id,
+      snapshotId,
+    ])
+    expect(queries.every((query) => query.text.includes('WHERE snapshot_id ='))).toBe(true)
   })
 
   test('rejects duplicate manifests, sessions, and bars', () => {

--- a/services/bayn/src/market-data.test.ts
+++ b/services/bayn/src/market-data.test.ts
@@ -6,9 +6,11 @@ import {
   marketDataOperationError,
   verifyFinalizedCalendar,
   verifyFinalizedManifest,
+  verifyFinalizedPublication,
   verifyFinalizedSnapshot,
   type SnapshotRows,
   type SnapshotRequest,
+  type FinalizedPublicationRequest,
 } from './market-data'
 import { DataFeed, DataSource, PriceAdjustment, PublicationSchema } from './types'
 
@@ -162,7 +164,7 @@ const makeFixture = (): {
 
 describe('finalized Signal snapshot reader', () => {
   test('preserves ClickHouse retryability for check, inspect, and load failures', () => {
-    for (const operation of ['check', 'inspect', 'load'] as const) {
+    for (const operation of ['check', 'inspect', 'inspect-publication', 'load'] as const) {
       const authorization = marketDataOperationError(
         operation,
         'Signal query failed',
@@ -236,6 +238,80 @@ describe('finalized Signal snapshot reader', () => {
 
     expect(inspection.manifest).toEqual(snapshot.manifest)
     expect(inspection.sessionDates).toEqual(['2025-01-02', '2025-01-03'])
+    expect(inspection.signalSession).toEqual({
+      calendar_version: 'alpaca-us-equity-calendar-v1',
+      session_date: '2025-01-03',
+      close_time: '16:00',
+      timezone: 'America/New_York',
+    })
+  })
+
+  test('resolves one exact finalized cycle publication and exposes its verified Signal session', () => {
+    const fixture = makeFixture()
+    const contract = {
+      universeId: fixture.request.universeId,
+      universeSymbolHash: fixture.request.universeSymbolHash,
+      universe: fixture.request.universe,
+      historyStart: fixture.request.historyStart,
+      evaluationStart: fixture.request.evaluationStart,
+    }
+    const input = {
+      signalSessionDate: '2025-01-03',
+      signalCalendarVersion: fixture.request.calendarVersion,
+    } satisfies FinalizedPublicationRequest
+    const rows = { manifests: fixture.rows.manifests, sessions: fixture.rows.sessions }
+
+    expect(
+      verifyFinalizedPublication({ manifests: [], sessions: [] }, input, contract, fixture.request.observedAt),
+    ).toBe(undefined)
+    const inspection = verifyFinalizedPublication(rows, input, contract, fixture.request.observedAt)
+    expect(inspection).toMatchObject({
+      manifest: {
+        bounds: {
+          dataStart: '2025-01-02',
+          dataEnd: '2025-01-03',
+          evaluationEnd: '2025-01-03',
+        },
+        finalizedSnapshot: {
+          snapshotId,
+          asOfSession: '2025-01-03',
+        },
+      },
+      signalSession: {
+        calendar_version: 'alpaca-us-equity-calendar-v1',
+        session_date: '2025-01-03',
+        close_time: '16:00',
+        timezone: 'America/New_York',
+      },
+    })
+
+    expect(() =>
+      verifyFinalizedPublication(
+        { ...rows, manifests: [...rows.manifests, rows.manifests[0]] },
+        input,
+        contract,
+        fixture.request.observedAt,
+      ),
+    ).toThrow('2 finalized manifests; expected exactly one')
+    expect(() =>
+      verifyFinalizedPublication(
+        { ...rows, sessions: rows.sessions.slice(0, -1) },
+        input,
+        contract,
+        fixture.request.observedAt,
+      ),
+    ).toThrow('exchange-session count does not match manifest')
+    expect(() =>
+      verifyFinalizedPublication(
+        {
+          ...rows,
+          manifests: [{ ...rows.manifests[0], universe_symbol_hash: '0'.repeat(64) }],
+        },
+        input,
+        contract,
+        fixture.request.observedAt,
+      ),
+    ).toThrow('manifest content hash is invalid')
   })
 
   test('rejects duplicate manifests, sessions, and bars', () => {

--- a/services/bayn/src/market-data.ts
+++ b/services/bayn/src/market-data.ts
@@ -462,33 +462,37 @@ export const verifyFinalizedPublication = (
   contract: MarketDataContract,
   observedAt: string,
 ): MarketDataInspection | undefined => {
-  if (rows.manifests.length === 0) return undefined
-  if (rows.manifests.length !== 1) {
+  const manifests = rows.manifests.filter((manifest) => manifest.calendar_version === input.signalCalendarVersion)
+  if (manifests.length === 0) return undefined
+  if (manifests.length !== 1) {
     throw new Error(
-      `Signal session ${input.signalSessionDate} has ${rows.manifests.length} finalized manifests; expected exactly one`,
+      `Signal session ${input.signalSessionDate} and calendar ${input.signalCalendarVersion} have ${manifests.length} finalized manifests; expected exactly one`,
     )
   }
-  const manifest = rows.manifests[0]
+  const manifest = manifests[0]
   if (manifest === undefined) throw new Error('finalized Signal manifest disappeared during verification')
-  return verifyFinalizedCalendar(rows, {
-    snapshotId: manifest.snapshot_id,
-    publicationAsOf: input.signalSessionDate,
-    calendarVersion: input.signalCalendarVersion,
-    universe: contract.universe,
-    bounds: {
-      schemaVersion: 'bayn.evaluation-bounds.v1',
-      dataStart: contract.historyStart,
-      dataEnd: input.signalSessionDate,
-      lookbackStart: contract.historyStart,
+  return verifyFinalizedCalendar(
+    { sessions: rows.sessions, manifests },
+    {
+      snapshotId: manifest.snapshot_id,
+      publicationAsOf: input.signalSessionDate,
+      calendarVersion: input.signalCalendarVersion,
+      universe: contract.universe,
+      bounds: {
+        schemaVersion: 'bayn.evaluation-bounds.v1',
+        dataStart: contract.historyStart,
+        dataEnd: input.signalSessionDate,
+        lookbackStart: contract.historyStart,
+        evaluationStart: contract.evaluationStart,
+        evaluationEnd: input.signalSessionDate,
+      },
+      observedAt,
+      universeId: contract.universeId,
+      universeSymbolHash: contract.universeSymbolHash,
+      historyStart: contract.historyStart,
       evaluationStart: contract.evaluationStart,
-      evaluationEnd: input.signalSessionDate,
     },
-    observedAt,
-    universeId: contract.universeId,
-    universeSymbolHash: contract.universeSymbolHash,
-    historyStart: contract.historyStart,
-    evaluationStart: contract.evaluationStart,
-  })
+  )
 }
 
 export const verifyFinalizedSnapshot = (rows: SnapshotRows, request: SnapshotRequest): MarketDataSnapshot => {
@@ -663,6 +667,7 @@ const makeMarketData = (
         WHERE universe_id = ${sql.param('String', contract.universeId)}
           AND requested_start = toDate(${sql.param('String', contract.historyStart)})
           AND publication_asof = toDate(${sql.param('String', request.signalSessionDate)})
+          AND calendar_version = ${sql.param('String', request.signalCalendarVersion)}
         ORDER BY snapshot_id, finalized_at
       `.pipe(sql.withQueryId(`bayn-cycle-manifest-${request.signalSessionDate}`))
 

--- a/services/bayn/src/market-data.ts
+++ b/services/bayn/src/market-data.ts
@@ -153,6 +153,10 @@ export interface FinalizedPublicationRequest {
   readonly signalCalendarVersion: string
 }
 
+export interface SnapshotPublicationRequest extends FinalizedPublicationRequest {
+  readonly snapshotId: string
+}
+
 export type FinalizedPublicationInspection =
   | {
       readonly outcome: 'MISSING'
@@ -169,6 +173,9 @@ export interface MarketDataService {
   readonly inspect: Effect.Effect<MarketDataInspection, OperationalError>
   readonly inspectPublication: (
     request: FinalizedPublicationRequest,
+  ) => Effect.Effect<FinalizedPublicationInspection, OperationalError>
+  readonly inspectSnapshotPublication: (
+    request: SnapshotPublicationRequest,
   ) => Effect.Effect<FinalizedPublicationInspection, OperationalError>
   readonly load: Effect.Effect<MarketDataSnapshot, OperationalError>
 }
@@ -671,6 +678,36 @@ const makeMarketData = (
         ORDER BY snapshot_id, finalized_at
       `.pipe(sql.withQueryId(`bayn-cycle-manifest-${request.signalSessionDate}`))
 
+    const loadSnapshotPublicationManifest = (request: SnapshotPublicationRequest) =>
+      sql`
+        SELECT
+          snapshot_id,
+          schema_version,
+          publisher_source_revision,
+          publisher_image_repository,
+          publisher_image_digest,
+          universe_id,
+          universe_symbol_hash,
+          provider,
+          source_feed,
+          adjustment,
+          calendar_version,
+          toString(requested_start) AS requested_start,
+          toString(publication_asof) AS publication_asof,
+          toString(first_session) AS first_session,
+          toString(last_session) AS last_session,
+          symbol_count,
+          session_count,
+          bar_count,
+          bars_content_hash,
+          sessions_content_hash,
+          manifest_content_hash,
+          toString(finalized_at) AS finalized_at
+        FROM signal.snapshot_manifests_v2
+        WHERE snapshot_id = ${sql.param('String', request.snapshotId)}
+        ORDER BY finalized_at
+      `.pipe(sql.withQueryId(`bayn-bound-manifest-${request.snapshotId.slice(-32)}`))
+
     const loadPublicationSessions = (snapshotId: string) =>
       sql`
         SELECT
@@ -708,6 +745,52 @@ const makeMarketData = (
         try: body,
         catch: (cause) => operationalError('market-data', operation, 'Signal snapshot verification failed', cause),
       })
+    const inspectPublicationRows = (
+      input: FinalizedPublicationRequest,
+      manifestRows: readonly unknown[],
+      expectedSnapshotId?: string,
+    ) =>
+      Effect.gen(function* () {
+        const manifests = yield* verify('inspect-publication', () => decodeSnapshotRows([], [], manifestRows).manifests)
+        const observedAt = (): Effect.Effect<string> =>
+          Clock.currentTimeMillis.pipe(Effect.map((millis) => new Date(millis).toISOString()))
+        if (manifests.length === 0) {
+          return { outcome: 'MISSING', observedAt: yield* observedAt() } as const
+        }
+        if (
+          expectedSnapshotId !== undefined &&
+          manifests.some((manifest) => manifest.snapshot_id !== expectedSnapshotId)
+        ) {
+          return yield* verify('inspect-publication', () => {
+            throw new Error('bound finalized Signal query returned a different snapshot ID')
+          })
+        }
+        const manifest = manifests[0]
+        if (manifest === undefined) {
+          return yield* verify('inspect-publication', () => {
+            throw new Error('finalized Signal manifest disappeared before its session read')
+          })
+        }
+        const sessionRows = yield* loadPublicationSessions(manifest.snapshot_id)
+        const inspectedAt = yield* observedAt()
+        const inspection = yield* verify('inspect-publication', () =>
+          verifyFinalizedPublication(decodeSnapshotRows([], sessionRows, manifestRows), input, contract, inspectedAt),
+        )
+        if (inspection === undefined) {
+          return yield* verify('inspect-publication', () => {
+            throw new Error('finalized Signal manifest disappeared before verification')
+          })
+        }
+        if (
+          expectedSnapshotId !== undefined &&
+          inspection.manifest.finalizedSnapshot.snapshotId !== expectedSnapshotId
+        ) {
+          return yield* verify('inspect-publication', () => {
+            throw new Error('verified finalized Signal publication differs from the bound snapshot ID')
+          })
+        }
+        return { outcome: 'FINALIZED', observedAt: inspectedAt, inspection } as const
+      })
 
     return {
       check: Effect.gen(function* () {
@@ -732,39 +815,23 @@ const makeMarketData = (
         ),
       ),
       inspectPublication: (input) =>
-        Effect.gen(function* () {
-          const manifestRows = yield* loadPublicationManifests(input)
-          const manifests = yield* verify(
-            'inspect-publication',
-            () => decodeSnapshotRows([], [], manifestRows).manifests,
-          )
-          const observedAt = (): Effect.Effect<string> =>
-            Clock.currentTimeMillis.pipe(Effect.map((millis) => new Date(millis).toISOString()))
-          if (manifests.length === 0) {
-            return { outcome: 'MISSING', observedAt: yield* observedAt() } as const
-          }
-          const manifest = manifests[0]
-          if (manifest === undefined) {
-            return yield* verify('inspect-publication', () => {
-              throw new Error('finalized Signal manifest disappeared before its session read')
-            })
-          }
-          const sessionRows = yield* loadPublicationSessions(manifest.snapshot_id)
-          const inspectedAt = yield* observedAt()
-          const inspection = yield* verify('inspect-publication', () =>
-            verifyFinalizedPublication(decodeSnapshotRows([], sessionRows, manifestRows), input, contract, inspectedAt),
-          )
-          if (inspection === undefined) {
-            return yield* verify('inspect-publication', () => {
-              throw new Error('finalized Signal manifest disappeared before verification')
-            })
-          }
-          return { outcome: 'FINALIZED', observedAt: inspectedAt, inspection } as const
-        }).pipe(
+        loadPublicationManifests(input).pipe(
+          Effect.flatMap((manifestRows) => inspectPublicationRows(input, manifestRows)),
           Effect.mapError((cause) =>
             marketDataOperationError(
               'inspect-publication',
               `failed to inspect finalized Signal publication for ${input.signalSessionDate}`,
+              cause,
+            ),
+          ),
+        ),
+      inspectSnapshotPublication: (input) =>
+        loadSnapshotPublicationManifest(input).pipe(
+          Effect.flatMap((manifestRows) => inspectPublicationRows(input, manifestRows, input.snapshotId)),
+          Effect.mapError((cause) =>
+            marketDataOperationError(
+              'inspect-publication',
+              `failed to inspect bound finalized Signal publication ${input.snapshotId}`,
               cause,
             ),
           ),

--- a/services/bayn/src/market-data.ts
+++ b/services/bayn/src/market-data.ts
@@ -127,7 +127,7 @@ export interface SnapshotRequest {
   readonly evaluationStart: IsoDate
 }
 
-type MarketDataContract = Pick<
+export type MarketDataContract = Pick<
   Protocol,
   'universeId' | 'universeSymbolHash' | 'universe' | 'historyStart' | 'evaluationStart'
 >
@@ -137,21 +137,46 @@ export interface MarketDataSnapshot {
   readonly manifest: InputManifest
 }
 
+export type VerifiedSignalSession = Pick<
+  SignalSessionRow,
+  'calendar_version' | 'session_date' | 'close_time' | 'timezone'
+>
+
 export interface MarketDataInspection {
   readonly manifest: InputManifest
   readonly sessionDates: readonly IsoDate[]
+  readonly signalSession: VerifiedSignalSession
 }
+
+export interface FinalizedPublicationRequest {
+  readonly signalSessionDate: IsoDate
+  readonly signalCalendarVersion: string
+}
+
+export type FinalizedPublicationInspection =
+  | {
+      readonly outcome: 'MISSING'
+      readonly observedAt: string
+    }
+  | {
+      readonly outcome: 'FINALIZED'
+      readonly observedAt: string
+      readonly inspection: MarketDataInspection
+    }
 
 export interface MarketDataService {
   readonly check: Effect.Effect<FinalizedSnapshotProvenance, OperationalError>
   readonly inspect: Effect.Effect<MarketDataInspection, OperationalError>
+  readonly inspectPublication: (
+    request: FinalizedPublicationRequest,
+  ) => Effect.Effect<FinalizedPublicationInspection, OperationalError>
   readonly load: Effect.Effect<MarketDataSnapshot, OperationalError>
 }
 
 export class MarketData extends Context.Service<MarketData, MarketDataService>()('bayn/MarketData') {}
 
 export const marketDataOperationError = (
-  operation: 'check' | 'inspect' | 'load',
+  operation: 'check' | 'inspect' | 'inspect-publication' | 'load',
   message: string,
   cause: unknown,
 ): OperationalError => {
@@ -417,10 +442,53 @@ export const verifyFinalizedCalendar = (
   request: SnapshotRequest,
 ): MarketDataInspection => {
   const calendar = verifyCalendar(rows.sessions, rows.manifests, request)
+  const signalSession = calendar.boundedSessions.at(-1)
+  if (signalSession === undefined) throw new Error('finalized Signal calendar has no terminal session')
   return {
     manifest: calendar.inputManifest,
     sessionDates: calendar.boundedSessions.map((session) => session.session_date),
+    signalSession: {
+      calendar_version: signalSession.calendar_version,
+      session_date: signalSession.session_date,
+      close_time: signalSession.close_time,
+      timezone: signalSession.timezone,
+    },
   }
+}
+
+export const verifyFinalizedPublication = (
+  rows: Pick<SnapshotRows, 'sessions' | 'manifests'>,
+  input: FinalizedPublicationRequest,
+  contract: MarketDataContract,
+  observedAt: string,
+): MarketDataInspection | undefined => {
+  if (rows.manifests.length === 0) return undefined
+  if (rows.manifests.length !== 1) {
+    throw new Error(
+      `Signal session ${input.signalSessionDate} has ${rows.manifests.length} finalized manifests; expected exactly one`,
+    )
+  }
+  const manifest = rows.manifests[0]
+  if (manifest === undefined) throw new Error('finalized Signal manifest disappeared during verification')
+  return verifyFinalizedCalendar(rows, {
+    snapshotId: manifest.snapshot_id,
+    publicationAsOf: input.signalSessionDate,
+    calendarVersion: input.signalCalendarVersion,
+    universe: contract.universe,
+    bounds: {
+      schemaVersion: 'bayn.evaluation-bounds.v1',
+      dataStart: contract.historyStart,
+      dataEnd: input.signalSessionDate,
+      lookbackStart: contract.historyStart,
+      evaluationStart: contract.evaluationStart,
+      evaluationEnd: input.signalSessionDate,
+    },
+    observedAt,
+    universeId: contract.universeId,
+    universeSymbolHash: contract.universeSymbolHash,
+    historyStart: contract.historyStart,
+    evaluationStart: contract.evaluationStart,
+  })
 }
 
 export const verifyFinalizedSnapshot = (rows: SnapshotRows, request: SnapshotRequest): MarketDataSnapshot => {
@@ -566,6 +634,53 @@ const makeMarketData = (
             ORDER BY session_date, symbol
           `.pipe(sql.withQueryId(`bayn-bars-${config.clickhouse.snapshotId.slice(-32)}`))
 
+    const loadPublicationManifests = (request: FinalizedPublicationRequest) =>
+      sql`
+        SELECT
+          snapshot_id,
+          schema_version,
+          publisher_source_revision,
+          publisher_image_repository,
+          publisher_image_digest,
+          universe_id,
+          universe_symbol_hash,
+          provider,
+          source_feed,
+          adjustment,
+          calendar_version,
+          toString(requested_start) AS requested_start,
+          toString(publication_asof) AS publication_asof,
+          toString(first_session) AS first_session,
+          toString(last_session) AS last_session,
+          symbol_count,
+          session_count,
+          bar_count,
+          bars_content_hash,
+          sessions_content_hash,
+          manifest_content_hash,
+          toString(finalized_at) AS finalized_at
+        FROM signal.snapshot_manifests_v2
+        WHERE universe_id = ${sql.param('String', contract.universeId)}
+          AND requested_start = toDate(${sql.param('String', contract.historyStart)})
+          AND publication_asof = toDate(${sql.param('String', request.signalSessionDate)})
+        ORDER BY snapshot_id, finalized_at
+      `.pipe(sql.withQueryId(`bayn-cycle-manifest-${request.signalSessionDate}`))
+
+    const loadPublicationSessions = (snapshotId: string) =>
+      sql`
+        SELECT
+          snapshot_id,
+          calendar_version,
+          toString(session_date) AS session_date,
+          open_time,
+          close_time,
+          timezone,
+          provider
+        FROM signal.exchange_sessions_v1
+        WHERE snapshot_id = ${sql.param('String', snapshotId)}
+        ORDER BY session_date
+      `.pipe(sql.withQueryId(`bayn-cycle-sessions-${snapshotId.slice(-32)}`))
+
     const request = (observedAt: string): SnapshotRequest => {
       const common = {
         snapshotId: config.clickhouse.snapshotId,
@@ -611,6 +726,44 @@ const makeMarketData = (
           marketDataOperationError('inspect', 'failed to inspect finalized Signal calendar', cause),
         ),
       ),
+      inspectPublication: (input) =>
+        Effect.gen(function* () {
+          const manifestRows = yield* loadPublicationManifests(input)
+          const manifests = yield* verify(
+            'inspect-publication',
+            () => decodeSnapshotRows([], [], manifestRows).manifests,
+          )
+          const observedAt = (): Effect.Effect<string> =>
+            Clock.currentTimeMillis.pipe(Effect.map((millis) => new Date(millis).toISOString()))
+          if (manifests.length === 0) {
+            return { outcome: 'MISSING', observedAt: yield* observedAt() } as const
+          }
+          const manifest = manifests[0]
+          if (manifest === undefined) {
+            return yield* verify('inspect-publication', () => {
+              throw new Error('finalized Signal manifest disappeared before its session read')
+            })
+          }
+          const sessionRows = yield* loadPublicationSessions(manifest.snapshot_id)
+          const inspectedAt = yield* observedAt()
+          const inspection = yield* verify('inspect-publication', () =>
+            verifyFinalizedPublication(decodeSnapshotRows([], sessionRows, manifestRows), input, contract, inspectedAt),
+          )
+          if (inspection === undefined) {
+            return yield* verify('inspect-publication', () => {
+              throw new Error('finalized Signal manifest disappeared before verification')
+            })
+          }
+          return { outcome: 'FINALIZED', observedAt: inspectedAt, inspection } as const
+        }).pipe(
+          Effect.mapError((cause) =>
+            marketDataOperationError(
+              'inspect-publication',
+              `failed to inspect finalized Signal publication for ${input.signalSessionDate}`,
+              cause,
+            ),
+          ),
+        ),
       load: Effect.gen(function* () {
         const observedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
         const [manifests, sessions, bars] = yield* Effect.all([loadManifests, loadSessions, loadBars], {

--- a/services/bayn/src/resources.test.ts
+++ b/services/bayn/src/resources.test.ts
@@ -71,8 +71,15 @@ const marketDataService = (load: MarketDataService['load']): MarketDataService =
     return {
       manifest: snapshot.manifest,
       sessionDates: [...new Set(snapshot.bars.map((bar) => bar.sessionDate))].sort(),
+      signalSession: {
+        calendar_version: snapshot.manifest.finalizedSnapshot.calendarVersion,
+        session_date: snapshot.manifest.lastSession,
+        close_time: '16:00',
+        timezone: 'America/New_York',
+      },
     }
   }),
+  inspectPublication: () => Effect.die(new Error('resource lifecycle must not inspect cycle publications')),
   load,
 })
 

--- a/services/bayn/src/resources.test.ts
+++ b/services/bayn/src/resources.test.ts
@@ -80,6 +80,8 @@ const marketDataService = (load: MarketDataService['load']): MarketDataService =
     }
   }),
   inspectPublication: () => Effect.die(new Error('resource lifecycle must not inspect cycle publications')),
+  inspectSnapshotPublication: () =>
+    Effect.die(new Error('resource lifecycle must not inspect bound cycle publications')),
   load,
 })
 

--- a/services/bayn/src/startup.test.ts
+++ b/services/bayn/src/startup.test.ts
@@ -59,6 +59,7 @@ describe('Bayn startup lifecycle', () => {
           check: forbidden('pinned startup must not check Signal'),
           inspect: forbidden('pinned startup must not inspect Signal'),
           inspectPublication: () => forbidden('pinned startup must not inspect a cycle publication'),
+          inspectSnapshotPublication: () => forbidden('pinned startup must not inspect a bound cycle publication'),
           load: forbidden('pinned startup must not load Signal bars'),
         }),
         Effect.provideService(Journal, {

--- a/services/bayn/src/startup.test.ts
+++ b/services/bayn/src/startup.test.ts
@@ -58,6 +58,7 @@ describe('Bayn startup lifecycle', () => {
         Effect.provideService(MarketData, {
           check: forbidden('pinned startup must not check Signal'),
           inspect: forbidden('pinned startup must not inspect Signal'),
+          inspectPublication: () => forbidden('pinned startup must not inspect a cycle publication'),
           load: forbidden('pinned startup must not load Signal bars'),
         }),
         Effect.provideService(Journal, {


### PR DESCRIPTION
## Summary

- Resolve the one finalized Signal publication for a cycle's universe, history start, Signal session, and calendar through the existing manifest/calendar verifier.
- Expose the exact verified terminal Signal session for scheduler composition and apply strict Effect `Clock` deadline semantics with bounded data-age/publication-delay evidence.
- Persist the verified snapshot reference and immutable cycle binding in one conditional PostgreSQL transaction; concurrent or replacement inputs fail closed.
- Keep the slice OBSERVE-only: readiness requires only `MarketData` and `CycleStore` and performs no broker read or mutation.
- Refresh the Bayn dependency closure hashes reported by both current-main image builders after the unrelated Buzz directory addition changed the filtered Nix source.

## Related Issues

- PROOMPT-381 — source prerequisite only; the issue remains In Progress until Lane B composes the seam and GitOps/live freshness evidence passes.
- PROOMPT-380 — remains In Progress pending real application composition and live OBSERVE proof.

## Testing

- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bunx oxfmt --check services/bayn/src`
- `nix-instantiate --parse nix/images/bayn.nix`
- `bun test services/bayn/src/cycle.test.ts services/bayn/src/cycle-runner.test.ts services/bayn/src/market-data.test.ts services/bayn/src/cycle-readiness.test.ts` — 36 passed
- `bun run --filter @proompteng/bayn test` — 287 passed, 56 PostgreSQL tests skipped without the opt-in URL
- `BAYN_TEST_POSTGRES_URL=postgresql://... bun test services/bayn/src/db/cycle-store.integration.test.ts` against disposable PostgreSQL 17 — 8 passed
- `BAYN_TEST_POSTGRES_URL=postgresql://... bun test services/bayn/src/db/evidence-store.integration.test.ts` against disposable PostgreSQL 17 — 36 passed
- `bun run --filter @proompteng/bayn build`

## Breaking Changes

- Internal Bayn composition must provide the new `MarketDataService.inspectPublication` method and can consume `MarketDataInspection.signalSession` directly.
- `CycleStore.bindSnapshot` now accepts the verified `InputManifest` instead of an unproven snapshot ID so reference persistence and binding are atomic.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.



