### PR TITLE
fix(buzz): add Ceph RGW compatibility image

### DIFF
--- a/.github/workflows/buzz-relay-build-push.yml
+++ b/.github/workflows/buzz-relay-build-push.yml
@@ -1,0 +1,142 @@
+name: Buzz Relay Build and Push
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - 'third_party/buzz/**'
+      - '.github/workflows/buzz-relay-build-push.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'third_party/buzz/**'
+      - '.github/workflows/buzz-relay-build-push.yml'
+  workflow_dispatch:
+
+env:
+  UPSTREAM_REVISION: acfbb1bb6af54cb29cb152496ff43b8285dcb8cf
+  UPSTREAM_IMAGE: ghcr.io/block/buzz@sha256:29fe13981a726fe43642fe03cbd6cc87142579a90bbf9897e3c1b370d1037428
+  IMAGE_REPOSITORY: registry.ide-newton.ts.net/lab/buzz
+
+jobs:
+  verify:
+    if: github.event_name == 'pull_request'
+    runs-on: arc-arm64
+    steps:
+      - name: Checkout deployment repository
+        uses: actions/checkout@v5
+
+      - name: Checkout pinned Buzz source
+        uses: actions/checkout@v5
+        with:
+          repository: block/buzz
+          ref: ${{ env.UPSTREAM_REVISION }}
+          path: upstream
+          persist-credentials: false
+
+      - name: Verify and apply compatibility patch
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git -C upstream rev-parse HEAD)" = "$UPSTREAM_REVISION"
+          git -C upstream apply --check ../third_party/buzz/ceph-rgw.patch
+          git -C upstream apply ../third_party/buzz/ceph-rgw.patch
+          git -C upstream diff --check
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and test arm64 image
+        uses: docker/build-push-action@v6
+        with:
+          context: upstream
+          file: third_party/buzz/Dockerfile
+          platforms: linux/arm64
+          push: false
+          build-args: |
+            LAB_GIT_SHA=${{ github.sha }}
+            UPSTREAM_IMAGE=${{ env.UPSTREAM_IMAGE }}
+          cache-from: type=registry,ref=${{ env.IMAGE_REPOSITORY }}:cache-arm64
+
+  build:
+    if: github.event_name != 'pull_request'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - architecture: amd64
+            runner: arc-amd64
+          - architecture: arm64
+            runner: arc-arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout deployment repository
+        uses: actions/checkout@v5
+
+      - name: Checkout pinned Buzz source
+        uses: actions/checkout@v5
+        with:
+          repository: block/buzz
+          ref: ${{ env.UPSTREAM_REVISION }}
+          path: upstream
+          persist-credentials: false
+
+      - name: Verify and apply compatibility patch
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git -C upstream rev-parse HEAD)" = "$UPSTREAM_REVISION"
+          git -C upstream apply --check ../third_party/buzz/ceph-rgw.patch
+          git -C upstream apply ../third_party/buzz/ceph-rgw.patch
+          git -C upstream diff --check
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push native image
+        uses: docker/build-push-action@v6
+        with:
+          context: upstream
+          file: third_party/buzz/Dockerfile
+          platforms: linux/${{ matrix.architecture }}
+          push: true
+          tags: ${{ env.IMAGE_REPOSITORY }}:sha-${{ github.sha }}-${{ matrix.architecture }}
+          build-args: |
+            LAB_GIT_SHA=${{ github.sha }}
+            UPSTREAM_IMAGE=${{ env.UPSTREAM_IMAGE }}
+          cache-from: type=registry,ref=${{ env.IMAGE_REPOSITORY }}:cache-${{ matrix.architecture }}
+          cache-to: type=registry,ref=${{ env.IMAGE_REPOSITORY }}:cache-${{ matrix.architecture }},mode=max
+
+  publish-index:
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: arc-arm64
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Publish multi-architecture index
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${IMAGE_REPOSITORY}:sha-${GITHUB_SHA}"
+          docker buildx imagetools create \
+            --tag "$tag" \
+            "${IMAGE_REPOSITORY}:sha-${GITHUB_SHA}-amd64" \
+            "${IMAGE_REPOSITORY}:sha-${GITHUB_SHA}-arm64"
+          docker buildx imagetools inspect --raw "$tag" > index.json
+          jq -e '
+            any(.manifests[]?; .platform.os == "linux" and .platform.architecture == "amd64") and
+            any(.manifests[]?; .platform.os == "linux" and .platform.architecture == "arm64")
+          ' index.json
+          digest="sha256:$(sha256sum index.json | cut -d ' ' -f1)"
+          {
+            echo '### Buzz relay image'
+            echo
+            echo "- Image: ${tag}@${digest}"
+            echo '- Platforms: linux/amd64, linux/arm64'
+            echo "- Upstream: ${UPSTREAM_REVISION}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts
+++ b/packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts
@@ -32,6 +32,26 @@ describe('Buzz production GitOps contract', () => {
     }
   })
 
+  test('builds the Ceph compatibility relay from pinned upstream inputs for both cluster architectures', () => {
+    const workflow = readRepoFile('.github/workflows/buzz-relay-build-push.yml')
+    const dockerfile = readRepoFile('third_party/buzz/Dockerfile')
+    const patch = readRepoFile('third_party/buzz/ceph-rgw.patch')
+
+    for (const source of [workflow, dockerfile]) {
+      expect(source).toContain('acfbb1bb6af54cb29cb152496ff43b8285dcb8cf')
+      expect(source).toContain('sha256:29fe13981a726fe43642fe03cbd6cc87142579a90bbf9897e3c1b370d1037428')
+    }
+
+    expect(workflow).toContain('runner: arc-amd64')
+    expect(workflow).toContain('runner: arc-arm64')
+    expect(workflow).toContain('git -C upstream apply --check')
+    expect(workflow).toContain('any(.manifests[]?; .platform.os == "linux"')
+    expect(dockerfile).toContain('cargo test --release --locked -p buzz-relay api::git::store::tests:: --lib')
+    expect(patch).toContain('BUZZ_GIT_S3_COMPATIBILITY')
+    expect(patch).toContain('<Code>ConcurrentModification</Code>')
+    expect(patch).toContain('<Code>ConditionalRequestConflict</Code>')
+  })
+
   test('uses external stateful dependencies and Ceph while keeping unsafe features off', () => {
     const values = buzzFile('values.yaml')
     const postgres = buzzFile('postgres-cluster.yaml')

--- a/third_party/buzz/Dockerfile
+++ b/third_party/buzz/Dockerfile
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1.7
+
+ARG RUST_VERSION=1.95
+ARG DEBIAN_VERSION=bookworm
+ARG UPSTREAM_IMAGE=ghcr.io/block/buzz@sha256:29fe13981a726fe43642fe03cbd6cc87142579a90bbf9897e3c1b370d1037428
+
+FROM rust:${RUST_VERSION}-${DEBIAN_VERSION} AS builder
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        git \
+        libssl-dev \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+COPY . .
+
+RUN cargo test --release --locked -p buzz-relay api::git::store::tests:: --lib \
+    && cargo build --release --locked -p buzz-relay --bin buzz-relay \
+    && strip target/release/buzz-relay
+
+FROM ${UPSTREAM_IMAGE} AS runtime
+
+ARG LAB_GIT_SHA=unknown
+LABEL org.opencontainers.image.source="https://github.com/proompteng/lab" \
+      org.opencontainers.image.revision="${LAB_GIT_SHA}" \
+      org.opencontainers.image.description="Buzz relay with the bounded Ceph RGW conditional-write compatibility patch" \
+      io.proompteng.buzz.upstream-revision="acfbb1bb6af54cb29cb152496ff43b8285dcb8cf" \
+      io.proompteng.buzz.upstream-image="ghcr.io/block/buzz@sha256:29fe13981a726fe43642fe03cbd6cc87142579a90bbf9897e3c1b370d1037428"
+
+COPY --from=builder --chown=1000:1000 --chmod=0755 \
+    /build/target/release/buzz-relay /usr/local/bin/buzz-relay

--- a/third_party/buzz/README.md
+++ b/third_party/buzz/README.md
@@ -1,0 +1,33 @@
+# Buzz relay Ceph RGW compatibility image
+
+This derivative image keeps the upstream Buzz `v0.4.23` runtime and replaces
+only `buzz-relay` with a binary built from upstream revision
+`acfbb1bb6af54cb29cb152496ff43b8285dcb8cf` plus
+[`ceph-rgw.patch`](./ceph-rgw.patch).
+
+The patch is intentionally opt-in through
+`BUZZ_GIT_S3_COMPATIBILITY=ceph-rgw`. It:
+
+- removes one matching pair of HTTP quotes from an ETag only at the Ceph RGW
+  `If-Match` request boundary;
+- recognizes only `409` responses whose XML code is
+  `ConditionalRequestConflict` (Amazon S3) or `ConcurrentModification` (Ceph
+  RGW) as a lost compare-and-swap race;
+- preserves fail-closed handling for every unrelated `409`;
+- leaves standard S3 and MinIO behavior unchanged when the setting is absent.
+
+## Evidence
+
+Against the production Ceph Squid `19.2.4` RGW, a fresh quoted ETag returned
+`412`, the same ETag without outer quotes returned `200`, and a 32-writer
+unquoted `If-Match` race produced exactly one `200` plus 31
+`409 ConcurrentModification` responses. The final object matched the winning
+payload. Amazon S3 documents `409 ConditionalRequestConflict` as a possible
+conditional-write conflict, so Buzz must distinguish that semantic response
+from unrelated `409` errors.
+
+The build workflow checks out the exact upstream revision, verifies and applies
+the patch, runs the focused relay tests, builds on native amd64 and arm64
+runners, and publishes one multi-architecture image. The deployment consumes
+that image by digest. Remove this derivative after upstream ships equivalent
+Ceph RGW compatibility.

--- a/third_party/buzz/ceph-rgw.patch
+++ b/third_party/buzz/ceph-rgw.patch
@@ -1,0 +1,218 @@
+--- a/crates/buzz-relay/src/api/git/store.rs
++++ b/crates/buzz-relay/src/api/git/store.rs
+@@ -4,15 +4,17 @@
+ //! and the CAS pointer swap (axiom A3) described in
+ //! `docs/git-on-object-storage.md`.
+ //!
+-//! ## The 412 sharp edge
++//! ## Conditional-conflict sharp edges
+ //!
+ //! `rust-s3 = "0.37"` is shared across the workspace with `buzz-media`. The
+ //! `fail-on-err` Cargo feature is unified ON across the build graph, which
+ //! means non-2xx responses arrive here as `S3Error::HttpFailWithBody(code,
+ //! body)` *before* the caller sees `ResponseData`. The pointer-CAS path treats
+-//! the precondition-failure status (412) as a *semantic* result (`LostRace`),
+-//! not an error — see `classify_cas`. Empirically verified against MinIO in
+-//! `probe::probe_412_surfacing`.
++//! precondition failures (`412`) and recognized concurrent conditional-write
++//! conflicts (`409`) as a *semantic* result (`LostRace`), not an error — see
++//! `classify_cas`. Empirically verified against MinIO in
++//! `probe::probe_412_surfacing` and Ceph RGW Squid in the deployment
++//! conformance probe.
+ //!
+ //! ## Content addressing (A1)
+ //!
+@@ -24,6 +26,7 @@
+ 
+ #![allow(dead_code)] // wired in by the push path in a follow-up commit
+ 
++use std::borrow::Cow;
+ use std::sync::Arc;
+ 
+ use bytes::Bytes;
+@@ -36,6 +39,38 @@
+ #[derive(Debug, Clone, PartialEq, Eq)]
+ pub struct ETag(pub String);
+ 
++#[derive(Debug, Clone, Copy, PartialEq, Eq)]
++enum S3Compatibility {
++    Standard,
++    CephRgw,
++}
++
++impl S3Compatibility {
++    fn from_env() -> Result<Self, StoreError> {
++        let raw = std::env::var("BUZZ_GIT_S3_COMPATIBILITY").unwrap_or_default();
++        match raw.trim() {
++            "" | "standard" => Ok(Self::Standard),
++            "ceph-rgw" => Ok(Self::CephRgw),
++            other => Err(StoreError::Config(format!(
++                "BUZZ_GIT_S3_COMPATIBILITY must be 'standard' or 'ceph-rgw', got {other:?}"
++            ))),
++        }
++    }
++
++    fn if_match_value<'a>(self, etag: &'a str) -> Cow<'a, str> {
++        match self {
++            Self::Standard => Cow::Borrowed(etag),
++            Self::CephRgw => {
++                if etag.len() >= 2 && etag.starts_with('"') && etag.ends_with('"') {
++                    Cow::Owned(etag[1..etag.len() - 1].to_string())
++                } else {
++                    Cow::Borrowed(etag)
++                }
++            }
++        }
++    }
++}
++
+ /// Precondition for `put_pointer`.
+ #[derive(Debug, Clone)]
+ pub enum Precond {
+@@ -58,7 +93,7 @@
+ pub enum CasOutcome {
+     /// CAS succeeded; the new pointer ETag (suitable for the next `IfMatch`).
+     Won(ETag),
+-    /// CAS lost the race (server returned 412).
++    /// CAS lost the race (server returned 412 or a recognized conditional-write 409).
+     LostRace,
+ }
+ 
+@@ -169,6 +204,7 @@
+ #[derive(Clone)]
+ pub struct GitStore {
+     bucket: Arc<Bucket>,
++    compatibility: S3Compatibility,
+ }
+ 
+ impl GitStore {
+@@ -191,6 +227,7 @@
+         bucket_name: &str,
+         region: &str,
+     ) -> Result<Self, StoreError> {
++        let compatibility = S3Compatibility::from_env()?;
+         let region = Region::Custom {
+             region: region.into(),
+             endpoint: endpoint.into(),
+@@ -212,8 +249,14 @@
+         let bucket = Bucket::new(bucket_name, region, creds)
+             .map_err(StoreError::Backend)?
+             .with_path_style();
++        if compatibility == S3Compatibility::CephRgw {
++            tracing::info!(
++                "BUZZ_GIT_S3_COMPATIBILITY=ceph-rgw — using Ceph RGW If-Match token compatibility"
++            );
++        }
+         Ok(Self {
+             bucket: Arc::from(bucket),
++            compatibility,
+         })
+     }
+ 
+@@ -490,12 +533,13 @@
+                 headers.insert(axum::http::header::IF_NONE_MATCH, "*".parse().unwrap());
+             }
+             Precond::IfMatch(ETag(tag)) => {
++                let value = self.compatibility.if_match_value(tag);
+                 headers.insert(
+                     axum::http::header::IF_MATCH,
+-                    tag.parse().map_err(|_| {
++                    value.parse().map_err(|_| {
+                         StoreError::Backend(S3Error::HttpFailWithBody(
+                             400,
+-                            format!("invalid etag {tag}"),
++                            format!("invalid etag {value}"),
+                         ))
+                     })?,
+                 );
+@@ -510,9 +554,10 @@
+ 
+     /// Map a rust-s3 PUT outcome to a `CasOutcome`.
+     ///
+-    /// 412 → `LostRace`. 2xx → `Won(etag)` (etag read from response headers,
+-    /// empty if missing — callers must tolerate empty etag and re-HEAD if they
+-    /// need it strictly). Everything else bubbles as `StoreError::Backend`.
++    /// 412 and recognized conditional-write 409 responses → `LostRace`.
++    /// 2xx → `Won(etag)` (etag read from response headers, empty if missing —
++    /// callers must tolerate empty etag and re-HEAD if they need it strictly).
++    /// Everything else bubbles as `StoreError::Backend`.
+     fn classify_cas(
+         result: Result<s3::request::ResponseData, S3Error>,
+     ) -> Result<CasOutcome, StoreError> {
+@@ -538,7 +583,11 @@
+                     })?;
+                 Ok(CasOutcome::Won(ETag(etag)))
+             }
+-            Err(S3Error::HttpFailWithBody(412, _)) => Ok(CasOutcome::LostRace),
++            Err(S3Error::HttpFailWithBody(code, body))
++                if Self::is_conditional_conflict(code, &body) =>
++            {
++                Ok(CasOutcome::LostRace)
++            }
+             Ok(resp) => Err(StoreError::Backend(S3Error::HttpFailWithBody(
+                 resp.status_code(),
+                 "unexpected status".into(),
+@@ -547,6 +596,13 @@
+         }
+     }
+ 
++    fn is_conditional_conflict(code: u16, body: &str) -> bool {
++        code == 412
++            || (code == 409
++                && (body.contains("<Code>ConditionalRequestConflict</Code>")
++                    || body.contains("<Code>ConcurrentModification</Code>")))
++    }
++
+     /// Conformance probe — deployment gate per `docs/git-on-object-storage.md`
+     /// §Conformance. Fail-closed: any phase failure returns
+     /// `StoreError::Probe(ProbeFailure)` and the caller (relay startup) MUST
+@@ -931,9 +987,49 @@
+     fn classify_cas_412_is_lost_race() {
+         let r = Err(S3Error::HttpFailWithBody(412, "PreconditionFailed".into()));
+         assert_eq!(GitStore::classify_cas(r).unwrap(), CasOutcome::LostRace);
++    }
++
++    #[test]
++    fn classify_cas_known_409_conflicts_are_lost_races() {
++        for code in ["ConditionalRequestConflict", "ConcurrentModification"] {
++            let body = format!("<Error><Code>{code}</Code></Error>");
++            let result = Err(S3Error::HttpFailWithBody(409, body));
++            assert_eq!(
++                GitStore::classify_cas(result).unwrap(),
++                CasOutcome::LostRace
++            );
++        }
+     }
+ 
+     #[test]
++    fn classify_cas_unrelated_409_bubbles() {
++        let result = Err(S3Error::HttpFailWithBody(
++            409,
++            "<Error><Code>BucketAlreadyExists</Code></Error>".into(),
++        ));
++        assert!(matches!(
++            GitStore::classify_cas(result),
++            Err(StoreError::Backend(S3Error::HttpFailWithBody(409, _)))
++        ));
++    }
++
++    #[test]
++    fn ceph_rgw_compatibility_unquotes_if_match_etags() {
++        assert_eq!(
++            S3Compatibility::CephRgw.if_match_value("\"593616de\""),
++            "593616de"
++        );
++        assert_eq!(
++            S3Compatibility::CephRgw.if_match_value("already-unquoted"),
++            "already-unquoted"
++        );
++        assert_eq!(
++            S3Compatibility::Standard.if_match_value("\"593616de\""),
++            "\"593616de\""
++        );
++    }
++
++    #[test]
+     fn classify_cas_other_4xx_bubbles() {
+         let r = Err(S3Error::HttpFailWithBody(403, "AccessDenied".into()));
+         assert!(matches!(


### PR DESCRIPTION
## Summary

- Add a narrowly scoped Buzz v0.4.23 patch for Ceph RGW If-Match token handling and recognized conditional-write conflicts.
- Build and test a derivative relay on native amd64 and arm64 runners, then publish a verified multi-architecture index from pinned upstream source and runtime digests.
- Document the live Ceph Squid evidence and guard the image supply-chain contract with repository tests.

## Related Issues

None

## Testing

- `cargo fmt --all -- --check` against patched upstream Buzz `acfbb1bb6af54cb29cb152496ff43b8285dcb8cf`.
- `cargo test --release --locked -p buzz-relay api::git::store::tests:: --lib` (9 passed).
- `docker buildx build --check --platform linux/arm64 ...` for the derivative Dockerfile (no warnings).
- `actionlint .github/workflows/buzz-relay-build-push.yml`.
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts .github/workflows/buzz-relay-build-push.yml third_party/buzz/README.md`.
- `bun test packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts` (7 passed).
- `bun run lint:argocd` (all manifests valid).
- Live Ceph RGW 19.2.4 diagnostic: quoted current ETag returned 412, unquoted current ETag returned 200, and a 32-writer unquoted If-Match race produced one 200 plus 31 `409 ConcurrentModification` responses with the final object matching a racer payload.

## Breaking Changes

None. A follow-up GitOps change will pin the published multi-architecture image digest and opt Buzz into `BUZZ_GIT_S3_COMPATIBILITY=ceph-rgw`.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.