### PR TITLE
fix(buzz): pin native upstream runtime images

### DIFF
--- a/.github/workflows/buzz-relay-build-push.yml
+++ b/.github/workflows/buzz-relay-build-push.yml
@@ -58,6 +58,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: network=host
 
       - name: Build and test native image
         uses: docker/build-push-action@v6
@@ -107,6 +109,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: network=host
 
       - name: Build and push native image
         uses: docker/build-push-action@v6

--- a/.github/workflows/buzz-relay-build-push.yml
+++ b/.github/workflows/buzz-relay-build-push.yml
@@ -69,8 +69,10 @@ jobs:
         include:
           - architecture: amd64
             runner: arc-amd64
+            upstream_image: ghcr.io/block/buzz@sha256:0c015d0942b2b302b7264362a103165093960aaacc87d3c0f7bbcf68116950f5
           - architecture: arm64
             runner: arc-arm64
+            upstream_image: ghcr.io/block/buzz@sha256:5a091bb6b91572dbc34743cb36d6e56fd170408243b263c825ff764017c524f5
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout deployment repository
@@ -106,7 +108,7 @@ jobs:
           tags: ${{ env.IMAGE_REPOSITORY }}:sha-${{ github.sha }}-${{ matrix.architecture }}
           build-args: |
             LAB_GIT_SHA=${{ github.sha }}
-            UPSTREAM_IMAGE=${{ env.UPSTREAM_IMAGE }}
+            UPSTREAM_IMAGE=${{ matrix.upstream_image }}
           cache-from: type=registry,ref=${{ env.IMAGE_REPOSITORY }}:cache-${{ matrix.architecture }}
           cache-to: type=registry,ref=${{ env.IMAGE_REPOSITORY }}:cache-${{ matrix.architecture }},mode=max
 

--- a/.github/workflows/buzz-relay-build-push.yml
+++ b/.github/workflows/buzz-relay-build-push.yml
@@ -24,7 +24,17 @@ env:
 jobs:
   verify:
     if: github.event_name == 'pull_request'
-    runs-on: arc-arm64
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - architecture: amd64
+            runner: arc-amd64
+            upstream_image: ghcr.io/block/buzz@sha256:0c015d0942b2b302b7264362a103165093960aaacc87d3c0f7bbcf68116950f5
+          - architecture: arm64
+            runner: arc-arm64
+            upstream_image: ghcr.io/block/buzz@sha256:5a091bb6b91572dbc34743cb36d6e56fd170408243b263c825ff764017c524f5
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout deployment repository
         uses: actions/checkout@v5
@@ -49,17 +59,17 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and test arm64 image
+      - name: Build and test native image
         uses: docker/build-push-action@v6
         with:
           context: upstream
           file: third_party/buzz/Dockerfile
-          platforms: linux/arm64
+          platforms: linux/${{ matrix.architecture }}
           push: false
           build-args: |
             LAB_GIT_SHA=${{ github.sha }}
-            UPSTREAM_IMAGE=${{ env.UPSTREAM_IMAGE }}
-          cache-from: type=registry,ref=${{ env.IMAGE_REPOSITORY }}:cache-arm64
+            UPSTREAM_IMAGE=${{ matrix.upstream_image }}
+          cache-from: type=registry,ref=${{ env.IMAGE_REPOSITORY }}:cache-${{ matrix.architecture }}
 
   build:
     if: github.event_name != 'pull_request'

--- a/packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts
+++ b/packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts
@@ -51,6 +51,7 @@ describe('Buzz production GitOps contract', () => {
       'upstream_image: ghcr.io/block/buzz@sha256:5a091bb6b91572dbc34743cb36d6e56fd170408243b263c825ff764017c524f5',
     )
     expect(workflow).toContain('UPSTREAM_IMAGE=${{ matrix.upstream_image }}')
+    expect(workflow.match(/driver-opts: network=host/g)).toHaveLength(2)
     expect(workflow).toContain('git -C upstream apply --check')
     expect(workflow).toContain('any(.manifests[]?; .platform.os == "linux"')
     expect(dockerfile).toContain('cargo test --release --locked -p buzz-relay api::git::store::tests:: --lib')

--- a/packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts
+++ b/packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts
@@ -44,6 +44,13 @@ describe('Buzz production GitOps contract', () => {
 
     expect(workflow).toContain('runner: arc-amd64')
     expect(workflow).toContain('runner: arc-arm64')
+    expect(workflow).toContain(
+      'upstream_image: ghcr.io/block/buzz@sha256:0c015d0942b2b302b7264362a103165093960aaacc87d3c0f7bbcf68116950f5',
+    )
+    expect(workflow).toContain(
+      'upstream_image: ghcr.io/block/buzz@sha256:5a091bb6b91572dbc34743cb36d6e56fd170408243b263c825ff764017c524f5',
+    )
+    expect(workflow).toContain('UPSTREAM_IMAGE=${{ matrix.upstream_image }}')
     expect(workflow).toContain('git -C upstream apply --check')
     expect(workflow).toContain('any(.manifests[]?; .platform.os == "linux"')
     expect(dockerfile).toContain('cargo test --release --locked -p buzz-relay api::git::store::tests:: --lib')

--- a/third_party/buzz/README.md
+++ b/third_party/buzz/README.md
@@ -28,6 +28,7 @@ from unrelated `409` errors.
 
 The build workflow checks out the exact upstream revision, verifies and applies
 the patch, runs the focused relay tests, builds on native amd64 and arm64
-runners, and publishes one multi-architecture image. The deployment consumes
-that image by digest. Remove this derivative after upstream ships equivalent
-Ceph RGW compatibility.
+runners, pins each build to the matching upstream platform-manifest digest, and
+publishes one multi-architecture image. The deployment consumes that image by
+digest. Remove this derivative after upstream ships equivalent Ceph RGW
+compatibility.


### PR DESCRIPTION
## Summary

- Pin the AMD64 and ARM64 Buzz build jobs to their matching upstream platform-manifest digests.
- Keep the verified upstream multi-architecture index digest as the source contract while avoiding runner-specific index resolution.
- Extend the production contract and derivative-image documentation for the native runtime pins.

## Related Issues

None

## Testing

- `actionlint .github/workflows/buzz-relay-build-push.yml`
- `bun test packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts`
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts`
- `git diff --check`
- Verified both platform digests and architectures against `ghcr.io/block/buzz@sha256:29fe13981a726fe43642fe03cbd6cc87142579a90bbf9897e3c1b370d1037428` with `docker buildx imagetools inspect --raw` and `jq`.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.