### PR TITLE
feat(bayn): add cycle operations telemetry

### DIFF
--- a/argocd/applications/bayn/networkpolicy.yaml
+++ b/argocd/applications/bayn/networkpolicy.yaml
@@ -18,6 +18,16 @@ spec:
       ports:
         - port: http
           protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: observability-cluster-metrics-alloy
+      ports:
+        - port: http
+          protocol: TCP
   egress:
     - to:
         - namespaceSelector:

--- a/argocd/applications/observability/README.md
+++ b/argocd/applications/observability/README.md
@@ -84,8 +84,12 @@ The observability app owns the cluster metrics pipeline used for ARC runner sizi
 
 - `observability-kube-state-metrics`: Kubernetes object state and request/limit/allocatable metrics, plus
   CloudNativePG backup and scheduled-backup timestamps.
-- `observability-cluster-metrics-alloy`: scrapes kube-state-metrics, kubelet, every CloudNativePG instance, and the Ceph manager; it applies bounded metric allowlists, including logical-slot WAL retention and pod-level `/dev/rbd*` I/O only, before remote-writing to Mimir.
+- `observability-cluster-metrics-alloy`: scrapes kube-state-metrics, kubelet, every CloudNativePG instance, the Ceph
+  manager, and Bayn's bounded service metrics; it applies metric allowlists, including logical-slot WAL retention and
+  pod-level `/dev/rbd*` I/O only, before remote-writing to Mimir.
 - `arc-runner-capacity-dashboard`: Grafana dashboard for ARC CPU, memory, pending pods, and requested CPU saturation.
+- `bayn-cycle-operations-dashboard`: Grafana dashboard for canonical cycle condition/reason, phase, attempt age, and
+  OBSERVE safety facts.
 - `graf-mimir-rules`: records Torghut PostgreSQL and Ceph pressure baselines and alerts on Buzz relay/Redis/CNPG
   health, stale Buzz backups, missing telemetry, low PVC capacity, WAL archive backlog, logical-slot WAL retention,
   forced checkpoints, Ceph slow operations, scrub debt, and OSD latency.

--- a/argocd/applications/observability/bayn-cycle-operations-dashboard-configmap.yaml
+++ b/argocd/applications/observability/bayn-cycle-operations-dashboard-configmap.yaml
@@ -1,0 +1,383 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bayn-cycle-operations-dashboard
+  namespace: observability
+data:
+  bayn-cycle-operations-dashboard.json: |
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "grafana",
+              "uid": "-- Grafana --"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "graphTooltip": 0,
+      "id": null,
+      "links": [],
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 0,
+            "y": 0
+          },
+          "id": 1,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "targets": [
+            {
+              "expr": "up{job=\"bayn\",namespace=\"bayn\",service=\"bayn\"}",
+              "legendFormat": "scrape",
+              "refId": "A"
+            }
+          ],
+          "title": "Metrics scrape",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 6,
+            "y": 0
+          },
+          "id": 2,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "targets": [
+            {
+              "expr": "bayn_cycle_observation_available{job=\"bayn\",namespace=\"bayn\",service=\"bayn\"}",
+              "legendFormat": "projection",
+              "refId": "A"
+            }
+          ],
+          "title": "Cycle projection",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "mappings": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 12,
+            "y": 0
+          },
+          "id": 3,
+          "options": {
+            "colorMode": "none",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "targets": [
+            {
+              "expr": "bayn_authority_effective{job=\"bayn\",namespace=\"bayn\",service=\"bayn\",authority=\"observe\"}",
+              "legendFormat": "effective OBSERVE",
+              "refId": "A"
+            },
+            {
+              "expr": "bayn_zero_mutation_confirmed{job=\"bayn\",namespace=\"bayn\",service=\"bayn\"}",
+              "legendFormat": "zero mutation confirmed",
+              "refId": "B"
+            },
+            {
+              "expr": "bayn_broker_orders_enabled{job=\"bayn\",namespace=\"bayn\",service=\"bayn\"}",
+              "legendFormat": "broker orders enabled",
+              "refId": "C"
+            },
+            {
+              "expr": "bayn_capital_promotion_enabled{job=\"bayn\",namespace=\"bayn\",service=\"bayn\"}",
+              "legendFormat": "capital promotion enabled",
+              "refId": "D"
+            }
+          ],
+          "title": "Authority and mutation facts",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 5
+          },
+          "id": 4,
+          "options": {
+            "alignValue": "left",
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.9,
+            "showValue": "auto",
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "bayn_cycle_condition{job=\"bayn\",namespace=\"bayn\",service=\"bayn\"} == 1",
+              "legendFormat": "{{condition}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Canonical cycle condition",
+          "type": "state-timeline"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 5
+          },
+          "id": 5,
+          "options": {
+            "alignValue": "left",
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.9,
+            "showValue": "auto",
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "bayn_cycle_reason{job=\"bayn\",namespace=\"bayn\",service=\"bayn\"} == 1",
+              "legendFormat": "{{reason}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Canonical cycle reason",
+          "type": "state-timeline"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 5
+          },
+          "id": 6,
+          "options": {
+            "alignValue": "left",
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.9,
+            "showValue": "auto",
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "bayn_cycle_phase{job=\"bayn\",namespace=\"bayn\",service=\"bayn\"} == 1",
+              "legendFormat": "{{phase}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Durable cycle phase",
+          "type": "state-timeline"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 13
+          },
+          "id": 7,
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "bayn_cycle_attempt_age_seconds{job=\"bayn\",namespace=\"bayn\",service=\"bayn\"}",
+              "legendFormat": "attempt age",
+              "refId": "A"
+            }
+          ],
+          "title": "Current cycle attempt age",
+          "type": "timeseries"
+        }
+      ],
+      "refresh": "30s",
+      "schemaVersion": 42,
+      "tags": [
+        "bayn",
+        "trading",
+        "operations"
+      ],
+      "templating": {
+        "list": []
+      },
+      "time": {
+        "from": "now-6h",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "browser",
+      "title": "Bayn Cycle Operations",
+      "uid": "bayn-cycle-operations",
+      "version": 1,
+      "weekStart": ""
+    }

--- a/argocd/applications/observability/cluster-metrics-alloy-config.river
+++ b/argocd/applications/observability/cluster-metrics-alloy-config.river
@@ -90,6 +90,30 @@ prometheus.scrape "ceph_storage" {
   forward_to      = [prometheus.relabel.ceph_storage_metrics.receiver]
 }
 
+prometheus.relabel "bayn_metrics" {
+  forward_to = [prometheus.remote_write.mimir.receiver]
+
+  rule {
+    action        = "keep"
+    source_labels = ["__name__"]
+    regex         = "up|bayn_.*"
+  }
+}
+
+prometheus.scrape "bayn" {
+  job_name = "bayn"
+  targets = [
+    {
+      "__address__" = "bayn.bayn.svc.cluster.local:80",
+      "namespace"   = "bayn",
+      "service"     = "bayn",
+    },
+  ]
+  scrape_interval = "30s"
+  scrape_timeout  = "10s"
+  forward_to      = [prometheus.relabel.bayn_metrics.receiver]
+}
+
 prometheus.relabel "arc_resource_metrics" {
   forward_to = [prometheus.remote_write.mimir.receiver]
 

--- a/argocd/applications/observability/cluster-metrics-alloy-config.river
+++ b/argocd/applications/observability/cluster-metrics-alloy-config.river
@@ -90,6 +90,39 @@ prometheus.scrape "ceph_storage" {
   forward_to      = [prometheus.relabel.ceph_storage_metrics.receiver]
 }
 
+discovery.kubernetes "bayn_pods" {
+  role = "pod"
+
+  namespaces {
+    names = ["bayn"]
+  }
+
+  selectors {
+    role  = "pod"
+    label = "app.kubernetes.io/name=bayn"
+  }
+}
+
+discovery.relabel "bayn_metrics" {
+  targets = discovery.kubernetes.bayn_pods.targets
+
+  rule {
+    action        = "keep"
+    source_labels = ["__meta_kubernetes_pod_container_port_name"]
+    regex         = "http"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_namespace"]
+    target_label  = "namespace"
+  }
+
+  rule {
+    replacement  = "bayn"
+    target_label = "service"
+  }
+}
+
 prometheus.relabel "bayn_metrics" {
   forward_to = [prometheus.remote_write.mimir.receiver]
 
@@ -101,14 +134,8 @@ prometheus.relabel "bayn_metrics" {
 }
 
 prometheus.scrape "bayn" {
-  job_name = "bayn"
-  targets = [
-    {
-      "__address__" = "bayn.bayn.svc.cluster.local:80",
-      "namespace"   = "bayn",
-      "service"     = "bayn",
-    },
-  ]
+  job_name        = "bayn"
+  targets         = discovery.relabel.bayn_metrics.output
   scrape_interval = "30s"
   scrape_timeout  = "10s"
   forward_to      = [prometheus.relabel.bayn_metrics.receiver]

--- a/argocd/applications/observability/cluster-metrics-alloy-deployment.yaml
+++ b/argocd/applications/observability/cluster-metrics-alloy-deployment.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        observability.proompteng.ai/config-sha256: b9a60712c9fc52f99acbaba0c1166317facc974c329dbade4cb1f9b892fc5db4
+        observability.proompteng.ai/config-sha256: 77902b17bdfdb9453e977a7c4457a8a04eeb1b13c5d6e597cf91c1e7f8175af3
       labels:
         app.kubernetes.io/name: observability-cluster-metrics-alloy
         app.kubernetes.io/component: cluster-metrics

--- a/argocd/applications/observability/cluster-metrics-alloy-deployment.yaml
+++ b/argocd/applications/observability/cluster-metrics-alloy-deployment.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        observability.proompteng.ai/config-sha256: 77902b17bdfdb9453e977a7c4457a8a04eeb1b13c5d6e597cf91c1e7f8175af3
+        observability.proompteng.ai/config-sha256: ac8910a39885660e87359612d3c88ada87f8de8727e70ad29525332f78dd3ba4
       labels:
         app.kubernetes.io/name: observability-cluster-metrics-alloy
         app.kubernetes.io/component: cluster-metrics

--- a/argocd/applications/observability/graf-mimir-rules.yaml
+++ b/argocd/applications/observability/graf-mimir-rules.yaml
@@ -2719,6 +2719,88 @@ data:
                 Batch runs are reporting market-closed skips during expected market-open windows.
                 Validate Torghut trading status probe semantics and pre-open probe contracts.
               runbook_url: docs/runbooks/torghut-market-context-ingest.md
+      - name: bayn-cycle-operations.rules
+        rules:
+          - alert: BaynMetricsUnavailable
+            expr: |
+              (
+                up{
+                  job="bayn",
+                  namespace="bayn",
+                  service="bayn"
+                } != 1
+              )
+              or
+              absent(
+                up{
+                  job="bayn",
+                  namespace="bayn",
+                  service="bayn"
+                }
+              )
+            for: 2m
+            labels:
+              severity: critical
+              team: trading
+              service: bayn
+              notify: email
+            annotations:
+              summary: Bayn metrics are unavailable
+              description: The existing Bayn service cannot be scraped for two minutes.
+              runbook_url: docs/runbooks/bayn-cycle-operations.md
+          - alert: BaynCycleObservationUnavailable
+            expr: |
+              bayn_cycle_observation_available{
+                job="bayn",
+                namespace="bayn",
+                service="bayn"
+              } == 0
+            for: 2m
+            labels:
+              severity: critical
+              team: trading
+              service: bayn
+              notify: email
+            annotations:
+              summary: Bayn cycle projection is unavailable
+              description: The bounded autonomous-cycle PostgreSQL projection has failed for two minutes.
+              runbook_url: docs/runbooks/bayn-cycle-operations.md
+          - alert: BaynCycleStalled
+            expr: |
+              bayn_cycle_condition{
+                job="bayn",
+                namespace="bayn",
+                service="bayn",
+                condition="stalled"
+              } == 1
+            for: 1m
+            labels:
+              severity: critical
+              team: trading
+              service: bayn
+              notify: email
+            annotations:
+              summary: Bayn autonomous cycle is stalled
+              description: A persisted cycle missed a pending publication/submission deadline, exceeded the pending attempt age, or remained ACTIVE through execution close.
+              runbook_url: docs/runbooks/bayn-cycle-operations.md
+          - alert: BaynCycleFailed
+            expr: |
+              bayn_cycle_condition{
+                job="bayn",
+                namespace="bayn",
+                service="bayn",
+                condition="failed"
+              } == 1
+            for: 1m
+            labels:
+              severity: critical
+              team: trading
+              service: bayn
+              notify: email
+            annotations:
+              summary: Bayn autonomous cycle is failed
+              description: A durable blocked cycle or fail-closed authority, reconciliation, or mutation condition remains current.
+              runbook_url: docs/runbooks/bayn-cycle-operations.md
       - name: kafka-critical-service.rules
         rules:
           - alert: KafkaBrokerUnavailable

--- a/argocd/applications/observability/grafana-values.yaml
+++ b/argocd/applications/observability/grafana-values.yaml
@@ -52,6 +52,7 @@ dashboardsConfigMaps:
   codex-pipeline-dashboard: codex-pipeline-dashboard
   torghut-execution-recovery-dashboard: torghut-execution-recovery-dashboard
   arc-runner-capacity-dashboard: arc-runner-capacity-dashboard
+  bayn-cycle-operations-dashboard: bayn-cycle-operations-dashboard
 
 dashboardProviders:
   dashboardproviders.yaml:
@@ -97,3 +98,11 @@ dashboardProviders:
         editable: true
         options:
           path: /var/lib/grafana/dashboards/arc-runner-capacity-dashboard
+      - name: bayn-cycle-operations-dashboard
+        orgId: 1
+        folder: ''
+        type: file
+        disableDeletion: false
+        editable: true
+        options:
+          path: /var/lib/grafana/dashboards/bayn-cycle-operations-dashboard

--- a/argocd/applications/observability/kustomization.yaml
+++ b/argocd/applications/observability/kustomization.yaml
@@ -22,6 +22,7 @@ resources:
   - codex-pipeline-dashboard-configmap.yaml
   - torghut-execution-recovery-dashboard-configmap.yaml
   - arc-runner-capacity-dashboard-configmap.yaml
+  - bayn-cycle-operations-dashboard-configmap.yaml
   - cluster-metrics-alloy-rbac.yaml
   - cluster-metrics-alloy-deployment.yaml
 

--- a/docs/runbooks/bayn-cycle-operations.md
+++ b/docs/runbooks/bayn-cycle-operations.md
@@ -13,7 +13,7 @@ Bayn remains fail-closed. A healthy pod, a clear alert, or a terminal cycle does
 
 ## Alert actions
 
-- `BaynMetricsUnavailable`: verify the Bayn pod and Service, the observability Alloy scrape target, and the NetworkPolicy.
+- `BaynMetricsUnavailable`: verify the Bayn pod, the observability Alloy pod-discovery target, and the NetworkPolicy.
 - `BaynCycleObservationUnavailable`: inspect `cycle.error` in `GET /v1/status`, then restore the existing PostgreSQL
   projection path. Do not substitute cached or synthetic state.
 - `BaynCycleStalled`: branch on `cycle.reason` in `GET /v1/status`. `submissionCutoffAt` is a deadline only while the

--- a/docs/runbooks/bayn-cycle-operations.md
+++ b/docs/runbooks/bayn-cycle-operations.md
@@ -1,0 +1,25 @@
+# Bayn cycle operations
+
+Bayn remains fail-closed. A healthy pod, a clear alert, or a terminal cycle does not grant broker or capital authority.
+
+## Read the bounded state
+
+1. Read `GET /v1/status` and record `build`, `qualification`, `cycle`, `authority`, and `broker`.
+2. Confirm `authority.brokerOrders=false` and `authority.capitalPromotion=false` before any OBSERVE investigation.
+3. Use `cycle.current.cycleId`, `cycle.last.cycleId`, the selected sessions, cutoff, phase, and reason to correlate
+   structured Bayn logs. Cycle IDs are intentionally absent from Prometheus labels.
+4. Compare the durable mutation event count before and after the observation window. Do not infer zero mutation from
+   readiness alone.
+
+## Alert actions
+
+- `BaynMetricsUnavailable`: verify the Bayn pod and Service, the observability Alloy scrape target, and the NetworkPolicy.
+- `BaynCycleObservationUnavailable`: inspect `cycle.error` in `GET /v1/status`, then restore the existing PostgreSQL
+  projection path. Do not substitute cached or synthetic state.
+- `BaynCycleStalled`: branch on `cycle.reason` in `GET /v1/status`. `submissionCutoffAt` is a deadline only while the
+  cycle is `PENDING`; an `ACTIVE` cycle remains expected through `executionCloseAt`.
+- `BaynCycleFailed`: preserve `cycle.reason` and the terminal cycle identity. Resolve the underlying authority,
+  reconciliation, mutation, broker, or durable-cycle state through its existing writer contract; never clear the
+  alert by editing monitoring state.
+
+An alert clears only when its source-of-truth state changes and the next bounded projection confirms recovery.

--- a/packages/scripts/src/shared/__tests__/bayn-cycle-observability-contract.test.ts
+++ b/packages/scripts/src/shared/__tests__/bayn-cycle-observability-contract.test.ts
@@ -1,0 +1,101 @@
+import { createHash } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+
+import { describe, expect, test } from 'bun:test'
+import YAML from 'yaml'
+
+const repoRoot = new URL('../../../../../', import.meta.url)
+const readRepoFile = (path: string): string => readFileSync(new URL(path, repoRoot), 'utf8')
+
+interface MimirRule {
+  readonly alert: string
+  readonly expr: string
+  readonly for: string
+}
+
+const baynRules = (): readonly MimirRule[] => {
+  const configMap = YAML.parse(readRepoFile('argocd/applications/observability/graf-mimir-rules.yaml')) as Record<
+    string,
+    any
+  >
+  const rules = YAML.parse(configMap.data['graf-rules.yaml']) as {
+    groups: readonly { readonly name: string; readonly rules: readonly MimirRule[] }[]
+  }
+  const group = rules.groups.find(({ name }) => name === 'bayn-cycle-operations.rules')
+  if (group === undefined) throw new Error('Bayn cycle operations rule group is missing')
+  return group.rules
+}
+
+describe('Bayn cycle operations alert contract', () => {
+  test('alerts only on scrape health and canonical service conditions', () => {
+    const rules = baynRules()
+    expect(rules.map(({ alert }) => alert)).toEqual([
+      'BaynMetricsUnavailable',
+      'BaynCycleObservationUnavailable',
+      'BaynCycleStalled',
+      'BaynCycleFailed',
+    ])
+    expect(rules.every((rule) => rule.for === '1m' || rule.for === '2m')).toBe(true)
+
+    const expressions = Object.fromEntries(rules.map((rule) => [rule.alert, rule.expr]))
+    expect(expressions.BaynMetricsUnavailable).toContain('up{')
+    expect(expressions.BaynCycleObservationUnavailable).toContain('bayn_cycle_observation_available')
+    expect(expressions.BaynCycleStalled).toContain('condition="stalled"')
+    expect(expressions.BaynCycleFailed).toContain('condition="failed"')
+    expect(rules.map(({ expr }) => expr).join('\n')).not.toMatch(
+      /cycle_id|account_id|decision_hash|mutation_id|bayn_authority_|bayn_broker_|bayn_reconciliation_|bayn_unresolved_/,
+    )
+  })
+
+  test('scrapes only bounded Bayn metrics through the existing cluster collector', () => {
+    const rules = baynRules()
+    const alloy = readRepoFile('argocd/applications/observability/cluster-metrics-alloy-config.river')
+    const deployment = YAML.parse(
+      readRepoFile('argocd/applications/observability/cluster-metrics-alloy-deployment.yaml'),
+    ) as Record<string, any>
+    const digest = createHash('sha256').update(alloy).digest('hex')
+
+    expect(alloy).toContain('prometheus.scrape "bayn"')
+    expect(alloy).toContain('"__address__" = "bayn.bayn.svc.cluster.local:80"')
+    expect(alloy).toContain('regex         = "up|bayn_.*"')
+    expect(deployment.spec.template.metadata.annotations['observability.proompteng.ai/config-sha256']).toBe(digest)
+
+    const policies = YAML.parseAllDocuments(readRepoFile('argocd/applications/bayn/networkpolicy.yaml')).map(
+      (document) => document.toJSON() as Record<string, any>,
+    )
+    const bayn = policies.find((policy) => policy.metadata?.name === 'bayn')
+    expect(bayn?.spec.ingress).toContainEqual({
+      from: [
+        {
+          namespaceSelector: {
+            matchLabels: { 'kubernetes.io/metadata.name': 'observability' },
+          },
+          podSelector: {
+            matchLabels: { 'app.kubernetes.io/name': 'observability-cluster-metrics-alloy' },
+          },
+        },
+      ],
+      ports: [{ port: 'http', protocol: 'TCP' }],
+    })
+
+    const dashboardConfigMap = YAML.parse(
+      readRepoFile('argocd/applications/observability/bayn-cycle-operations-dashboard-configmap.yaml'),
+    ) as Record<string, any>
+    const dashboard = JSON.parse(dashboardConfigMap.data['bayn-cycle-operations-dashboard.json']) as {
+      readonly uid: string
+      readonly panels: readonly { readonly targets?: readonly { readonly expr?: string }[] }[]
+    }
+    const dashboardExpressions = dashboard.panels.flatMap(({ targets = [] }) =>
+      targets.flatMap(({ expr }) => (expr === undefined ? [] : [expr])),
+    )
+    const kustomization = readRepoFile('argocd/applications/observability/kustomization.yaml')
+    const grafanaValues = readRepoFile('argocd/applications/observability/grafana-values.yaml')
+
+    expect(dashboard.uid).toBe('bayn-cycle-operations')
+    expect(kustomization).toContain('bayn-cycle-operations-dashboard-configmap.yaml')
+    expect(grafanaValues).toContain('bayn-cycle-operations-dashboard: bayn-cycle-operations-dashboard')
+    expect([...rules.map(({ expr }) => expr), ...dashboardExpressions].join('\n')).not.toMatch(
+      /cycle_id|account_id|decision_hash|mutation_id|client_order_id/,
+    )
+  })
+})

--- a/packages/scripts/src/shared/__tests__/bayn-cycle-observability-contract.test.ts
+++ b/packages/scripts/src/shared/__tests__/bayn-cycle-observability-contract.test.ts
@@ -55,8 +55,10 @@ describe('Bayn cycle operations alert contract', () => {
     ) as Record<string, any>
     const digest = createHash('sha256').update(alloy).digest('hex')
 
-    expect(alloy).toContain('prometheus.scrape "bayn"')
-    expect(alloy).toContain('"__address__" = "bayn.bayn.svc.cluster.local:80"')
+    expect(alloy).toContain('discovery.kubernetes "bayn_pods"')
+    expect(alloy).toContain('label = "app.kubernetes.io/name=bayn"')
+    expect(alloy).toContain('targets         = discovery.relabel.bayn_metrics.output')
+    expect(alloy).not.toContain('__meta_kubernetes_pod_ready')
     expect(alloy).toContain('regex         = "up|bayn_.*"')
     expect(deployment.spec.template.metadata.annotations['observability.proompteng.ai/config-sha256']).toBe(digest)
 


### PR DESCRIPTION
## Summary

- scrape the existing Bayn `/metrics` endpoint through the shared Alloy collector with a scoped NetworkPolicy path and rollout checksum
- provision a focused Grafana dashboard plus four alerts over scrape health and the service-computed cycle condition
- add the status-driven operator runbook and a contract regression for scrape wiring, bounded labels, dashboard provisioning, and canonical alerts

This PR does not modify `argocd/applications/bayn/deployment.yaml`, the rejected qualification pin, broker authority, or cycle runtime composition.

## Related Issues

[PROOMPT-384](https://linear.app/proompteng/issue/PROOMPT-384/add-autonomous-cycle-telemetry-dashboards-alerts-and-post-deploy) (operations/GitOps slice; does not close the remaining guarded runtime composition and live proof)

## Testing

- `bun test packages/scripts/src/shared/__tests__/bayn-cycle-observability-contract.test.ts`
- `bun run --filter @proompteng/scripts lint`
- `bun run --cwd packages/scripts lint:oxlint:type`
- `bunx tsc --noEmit --project packages/scripts/tsconfig.atlas.json`
- `bun test packages/scripts/src` (645 passed)
- `bash scripts/kubeconform.sh argocd/applications/bayn/networkpolicy.yaml argocd/applications/observability/bayn-cycle-operations-dashboard-configmap.yaml argocd/applications/observability/cluster-metrics-alloy-deployment.yaml argocd/applications/observability/graf-mimir-rules.yaml argocd/applications/observability/kustomization.yaml`
- `kustomize build argocd/applications/bayn | kubeconform --strict --summary --ignore-missing-schemas --schema-location schemas/custom/{{.ResourceKind}}{{.KindSuffix}}.json --schema-location default`
- `kustomize build --enable-helm argocd/applications/observability | kubeconform --strict --summary --ignore-missing-schemas --schema-location schemas/custom/{{.ResourceKind}}{{.KindSuffix}}.json --schema-location default`
- root-scripts parity: Flamingo migration validation, Hermes production validation/tests (123 passed), kube-router production validation/tests (24 passed)
- `bash scripts/argo-lint.sh`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.