### PR TITLE
feat(bayn): discover autonomous cycle publications

### DIFF
--- a/services/bayn/src/app-test-support.ts
+++ b/services/bayn/src/app-test-support.ts
@@ -115,6 +115,9 @@ export const marketDataService = (
       timezone: 'America/New_York',
     },
   })),
+  inspectCyclePublications: Effect.die(
+    new Error('startup test market data must not inspect cycle publication candidates'),
+  ),
   inspectPublication: () => Effect.die(new Error('startup test market data must not inspect cycle publications')),
   inspectSnapshotPublication: () =>
     Effect.die(new Error('startup test market data must not inspect bound cycle publications')),

--- a/services/bayn/src/cycle-readiness.test.ts
+++ b/services/bayn/src/cycle-readiness.test.ts
@@ -154,6 +154,7 @@ const marketDataService = (
   return {
     check: unused,
     inspect: unused,
+    inspectCyclePublications: unused,
     inspectPublication,
     inspectSnapshotPublication,
     load: unused,
@@ -171,6 +172,7 @@ const cycleStore = (control: StoreControl): CycleStoreShape => {
   return {
     acquire: unused,
     read: () => Effect.succeed(Option.some(control.current)),
+    readAuthoritySlot: unused,
     bindSnapshot: (_cycleId, inputManifest, observedAt) =>
       Effect.sync(() => {
         control.binds += 1

--- a/services/bayn/src/cycle-readiness.ts
+++ b/services/bayn/src/cycle-readiness.ts
@@ -113,6 +113,80 @@ const blockMissedPublication = (
     ),
   )
 
+export const bindFinalizedCyclePublication = (
+  cycle: AutonomousCycle,
+  inspection: MarketDataInspection,
+  observedAt: string,
+): Effect.Effect<CyclePublicationReadiness, CycleReadinessError, CycleStore> =>
+  Effect.gen(function* () {
+    const store = yield* CycleStore
+    if (cycle.state === CycleState.Blocked) {
+      return { outcome: 'BLOCKED', observedAt, cycle }
+    }
+    const snapshotId = inspection.manifest.finalizedSnapshot.snapshotId
+    if (cycle.bindings.snapshotId !== undefined) {
+      if (cycle.bindings.snapshotId !== snapshotId) {
+        return yield* Effect.fail(
+          readinessError(
+            'bind-publication',
+            'contract',
+            'finalized Signal publication differs from the immutable cycle binding',
+          ),
+        )
+      }
+      const freshness = yield* Effect.try({
+        try: () => measurePublicationFreshness(cycle, inspection, observedAt),
+        catch: (cause) =>
+          readinessError('measure-freshness', 'contract', 'finalized Signal publication freshness is invalid', cause),
+      })
+      return { outcome: 'ALREADY_BOUND', observedAt, cycle, snapshotId, freshness }
+    }
+    if (cycle.state !== CycleState.Pending) {
+      return yield* Effect.fail(
+        readinessError('bind-publication', 'contract', `unbound cycle ${cycle.identity.cycleId} is not pending`),
+      )
+    }
+    if (observedAt >= cycle.window.publicationDeadlineAt) {
+      return yield* blockMissedPublication(store, cycle.identity.cycleId, observedAt)
+    }
+    if (observedAt < cycle.window.signalCloseAt) {
+      return yield* Effect.fail(
+        readinessError(
+          'bind-publication',
+          'contract',
+          'finalized Signal publication cannot bind before the cycle signal close',
+        ),
+      )
+    }
+    const freshness = yield* Effect.try({
+      try: () => measurePublicationFreshness(cycle, inspection, observedAt),
+      catch: (cause) =>
+        readinessError('measure-freshness', 'contract', 'finalized Signal publication freshness is invalid', cause),
+    })
+    const receipt = yield* store
+      .bindSnapshot(cycle.identity.cycleId, inspection.manifest, observedAt)
+      .pipe(
+        Effect.mapError((cause) =>
+          readinessError(
+            'bind-publication',
+            'store',
+            'failed to persist and bind the finalized Signal publication',
+            cause,
+          ),
+        ),
+      )
+    return yield* Effect.try({
+      try: () => boundResult(receipt.changed ? 'BOUND' : 'ALREADY_BOUND', receipt, observedAt, freshness),
+      catch: (cause) =>
+        readinessError(
+          'bind-publication',
+          'contract',
+          'finalized Signal publication binding returned an invalid cycle',
+          cause,
+        ),
+    })
+  })
+
 const inspectBoundPublication = (
   cycle: AutonomousCycle,
   marketData: MarketDataService,
@@ -245,38 +319,7 @@ export const runCyclePublicationReadiness = (
                 cycle,
               } as const
             }
-            const freshness = yield* Effect.try({
-              try: () => measurePublicationFreshness(cycle, publication.inspection, observedAt),
-              catch: (cause) =>
-                readinessError(
-                  'measure-freshness',
-                  'contract',
-                  'finalized Signal publication freshness is invalid',
-                  cause,
-                ),
-            })
-            const receipt = yield* store
-              .bindSnapshot(cycle.identity.cycleId, publication.inspection.manifest, observedAt)
-              .pipe(
-                Effect.mapError((cause) =>
-                  readinessError(
-                    'bind-publication',
-                    'store',
-                    'failed to persist and bind the finalized Signal publication',
-                    cause,
-                  ),
-                ),
-              )
-            return yield* Effect.try({
-              try: () => boundResult(receipt.changed ? 'BOUND' : 'ALREADY_BOUND', receipt, observedAt, freshness),
-              catch: (cause) =>
-                readinessError(
-                  'bind-publication',
-                  'contract',
-                  'finalized Signal publication binding returned an invalid cycle',
-                  cause,
-                ),
-            })
+            return yield* bindFinalizedCyclePublication(cycle, publication.inspection, observedAt)
           }),
       },
     )

--- a/services/bayn/src/cycle-runner.test.ts
+++ b/services/bayn/src/cycle-runner.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Cause, Deferred, Effect, Exit, Fiber, Logger, References } from 'effect'
+import { Deferred, Effect, Fiber, Logger, Option, References } from 'effect'
 import { TestClock } from 'effect/testing'
 
 import {
@@ -11,20 +11,36 @@ import {
   type MarketCalendarObservation,
   type MarketCalendarQuery,
 } from './broker/alpaca'
-import { CycleState, makeCycleExecutionPolicy, type AutonomousCycle, type CycleDraft } from './cycle'
+import {
+  CycleState,
+  CycleTerminalReason,
+  makeCycleExecutionPolicy,
+  type AutonomousCycle,
+  type CycleDraft,
+} from './cycle'
 import {
   isMonthEndCycleDue,
   makeDueCycleDraft,
+  marketCalendarQueryForPublications,
   marketCalendarQueryForSignal,
   runAutonomousCyclePass,
   selectNextExecutionSession,
   startAutonomousCycleLoop,
   type CycleCandidate,
+  type CycleRunContext,
 } from './cycle-runner'
-import { CycleStore, type CycleStoreShape } from './db/cycle-store'
-import { canonicalHashV1 } from './hash'
-import type { IsoDate } from './types'
+import { CycleStore, type CycleAuthoritySlot, type CycleStoreShape } from './db/cycle-store'
+import { canonicalHashV1, sha256 } from './hash'
+import {
+  MarketData,
+  type FinalizedPublicationDiscovery,
+  type MarketDataInspection,
+  type MarketDataService,
+} from './market-data'
+import { DataFeed, DataSource, PriceAdjustment, PublicationSchema, type InputManifest, type IsoDate } from './types'
 
+const signalCalendarVersion = 'signal-XNYS-2026-v1'
+const snapshotId = 'd'.repeat(64)
 const evidence = {
   requestId: 'calendar-request',
   status: 200,
@@ -39,20 +55,26 @@ const executionPolicy = makeCycleExecutionPolicy({
   submissionCutoffBeforeOpenMs: 2 * 60 * 1_000,
 })
 
-const candidate = (
-  signalSessionDate: IsoDate = '2026-01-30',
-  accountId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
-): CycleCandidate => ({
+const context = (accountId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'): CycleRunContext => ({
   qualificationRunId: '1'.repeat(64),
   strategyProtocolHash: '2'.repeat(64),
   accountId,
-  signalSession: {
-    calendar_version: 'signal-XNYS-2026-v1',
-    session_date: signalSessionDate,
-    close_time: '16:00',
-    timezone: 'America/New_York',
-  },
   executionPolicy,
+})
+
+const signalSession = (sessionDate: IsoDate) => ({
+  calendar_version: signalCalendarVersion,
+  session_date: sessionDate,
+  close_time: '16:00',
+  timezone: 'America/New_York' as const,
+})
+
+const candidate = (
+  sessionDate: IsoDate = '2026-01-30',
+  accountId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+): CycleCandidate => ({
+  ...context(accountId),
+  signalSession: signalSession(sessionDate),
 })
 
 const calendar = (
@@ -98,42 +120,201 @@ const brokerRead = (marketCalendar: BrokerReadShape['marketCalendar']): BrokerRe
   }
 }
 
-const cycleFrom = (draft: CycleDraft, observedAt: string): AutonomousCycle => ({
-  ...draft,
-  state: CycleState.Pending,
-  bindings: {},
-  stateVersion: 1,
-  createdAt: observedAt,
-  updatedAt: observedAt,
+const makeInputManifest = (
+  sessionDate: IsoDate,
+  finalizedAt = `${sessionDate}T21:15:00.000Z`,
+  publicationSnapshotId = snapshotId,
+): InputManifest => {
+  const symbol = 'SPY'
+  const finalizedSnapshot = {
+    schemaVersion: 'bayn.finalized-snapshot.v3' as const,
+    snapshotId: publicationSnapshotId,
+    publicationId: '4'.repeat(64),
+    publicationSchemaVersion: PublicationSchema.AdjustedDailySnapshotV2,
+    universeId: 'cross-asset-taa-v1' as const,
+    universeSymbolHash: sha256(symbol),
+    source: DataSource.Alpaca,
+    sourceFeed: DataFeed.Sip,
+    adjustment: PriceAdjustment.All,
+    calendarVersion: signalCalendarVersion,
+    publisherSourceRevision: '5'.repeat(40),
+    publisherImage: {
+      repository: 'registry.example.com/signal-publisher',
+      digest: `sha256:${'6'.repeat(64)}`,
+    },
+    finalizedAt,
+    requestedStart: sessionDate,
+    firstSession: sessionDate,
+    lastSession: sessionDate,
+    asOfSession: sessionDate,
+    symbols: [symbol],
+    rowCount: 1,
+    sessionCount: 1,
+    contentHash: '7'.repeat(64),
+    sessionsContentHash: '8'.repeat(64),
+  }
+  const material: Omit<InputManifest, 'hash'> = {
+    schemaVersion: 'bayn.input-manifest.v3',
+    database: 'signal',
+    tables: {
+      bars: 'adjusted_daily_bars_v2',
+      sessions: 'exchange_sessions_v1',
+      manifests: 'snapshot_manifests_v2',
+    },
+    bounds: {
+      schemaVersion: 'bayn.evaluation-bounds.v1',
+      dataStart: sessionDate,
+      dataEnd: sessionDate,
+      lookbackStart: sessionDate,
+      evaluationStart: sessionDate,
+      evaluationEnd: sessionDate,
+    },
+    rowCount: 1,
+    sessionCount: 1,
+    firstSession: sessionDate,
+    lastSession: sessionDate,
+    symbols: [{ symbol, rows: 1, firstSession: sessionDate, lastSession: sessionDate }],
+    finalizedSnapshot,
+  }
+  return { ...material, hash: canonicalHashV1(material) }
+}
+
+const finalizedPublicationInspection = (
+  sessionDate: IsoDate = '2026-01-30',
+  finalizedAt?: string,
+  publicationSnapshotId?: string,
+): MarketDataInspection => ({
+  manifest: makeInputManifest(sessionDate, finalizedAt, publicationSnapshotId),
+  sessionDates: [sessionDate],
+  signalSession: signalSession(sessionDate),
 })
+
+const finalizedPublications = (
+  publications: readonly MarketDataInspection[],
+  observedAt = '2026-01-30T21:15:00.000Z',
+): FinalizedPublicationDiscovery => ({
+  outcome: 'FINALIZED',
+  observedAt,
+  publications,
+})
+
+const finalizedPublication = (
+  sessionDate: IsoDate = '2026-01-30',
+  finalizedAt?: string,
+): FinalizedPublicationDiscovery =>
+  finalizedPublications(
+    [finalizedPublicationInspection(sessionDate, finalizedAt)],
+    finalizedAt ?? `${sessionDate}T21:15:00.000Z`,
+  )
+
+const marketDataService = (
+  inspectCyclePublications: MarketDataService['inspectCyclePublications'],
+): MarketDataService => {
+  const unused = Effect.die(new Error('cycle runner must inspect only bounded finalized publication candidates'))
+  return {
+    check: unused,
+    inspect: unused,
+    inspectCyclePublications,
+    inspectPublication: () => unused,
+    inspectSnapshotPublication: () => unused,
+    load: unused,
+  }
+}
+
+const cycleFrom = (draft: CycleDraft, observedAt: string): AutonomousCycle => {
+  const missed = observedAt >= draft.window.publicationDeadlineAt
+  return {
+    ...draft,
+    state: missed ? CycleState.Blocked : CycleState.Pending,
+    bindings: {},
+    ...(missed ? { terminalReason: CycleTerminalReason.MissedPublication, terminalAt: observedAt } : {}),
+    stateVersion: 1,
+    createdAt: observedAt,
+    updatedAt: observedAt,
+  }
+}
+
+const slotKey = (slot: CycleAuthoritySlot): string =>
+  `${slot.qualificationRunId}\u001f${slot.accountId}\u001f${slot.signalSessionDate}`
 
 interface StoreControl {
   readonly acquisitions: Array<{ readonly draft: CycleDraft; readonly observedAt: string }>
+  binds: number
 }
 
 const cycleStore = (control: StoreControl): CycleStoreShape => {
   const cycles = new Map<string, AutonomousCycle>()
-  const unused = () => Effect.die(new Error('cycle runner must only acquire a cycle'))
+  const slots = new Map<string, string>()
+  const readCycle = (cycleId: string): AutonomousCycle | undefined => cycles.get(cycleId)
+  const unused = () => Effect.die(new Error('cycle runner used an unexpected store operation'))
   return {
     acquire: (draft, observedAt) =>
       Effect.sync(() => {
         control.acquisitions.push({ draft, observedAt })
-        const existing = cycles.get(draft.identity.cycleId)
-        if (existing !== undefined) return { cycle: existing, created: false }
+        const key = slotKey({
+          qualificationRunId: draft.identity.qualificationRunId,
+          accountId: draft.identity.accountId,
+          signalSessionDate: draft.identity.signalSessionDate,
+        })
+        const existingId = slots.get(key)
+        if (existingId !== undefined) {
+          const existing = readCycle(existingId)
+          if (existing === undefined) throw new Error('test authority slot lost its cycle')
+          return { cycle: existing, created: false }
+        }
         const created = cycleFrom(draft, observedAt)
         cycles.set(draft.identity.cycleId, created)
+        slots.set(key, draft.identity.cycleId)
         return { cycle: created, created: true }
       }),
-    read: unused,
-    bindSnapshot: unused,
+    read: (cycleId) =>
+      Effect.sync(() => {
+        const cycle = readCycle(cycleId)
+        return cycle === undefined ? Option.none() : Option.some(cycle)
+      }),
+    readAuthoritySlot: (slot) =>
+      Effect.sync(() => {
+        const cycleId = slots.get(slotKey(slot))
+        if (cycleId === undefined) return Option.none()
+        const cycle = readCycle(cycleId)
+        return cycle === undefined ? Option.none() : Option.some(cycle)
+      }),
+    bindSnapshot: (cycleId, manifest, observedAt) =>
+      Effect.sync(() => {
+        control.binds += 1
+        const cycle = readCycle(cycleId)
+        if (cycle === undefined) throw new Error('test binding could not find the cycle')
+        const existing = cycle.bindings.snapshotId
+        if (existing !== undefined) {
+          if (existing !== manifest.finalizedSnapshot.snapshotId) throw new Error('test store refused replacement')
+          return { cycle, changed: false }
+        }
+        const updated = {
+          ...cycle,
+          bindings: { snapshotId: manifest.finalizedSnapshot.snapshotId },
+          stateVersion: cycle.stateVersion + 1,
+          updatedAt: observedAt,
+        }
+        cycles.set(cycleId, updated)
+        return { cycle: updated, changed: true }
+      }),
     activate: unused,
     bindDecision: unused,
     block: unused,
   }
 }
 
-const provide = <A, E, R>(effect: Effect.Effect<A, E, R>, read: BrokerReadShape, store: CycleStoreShape) =>
-  effect.pipe(Effect.provideService(BrokerRead, read), Effect.provideService(CycleStore, store))
+const provide = <A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+  read: BrokerReadShape,
+  store: CycleStoreShape,
+  marketData: MarketDataService,
+) =>
+  effect.pipe(
+    Effect.provideService(BrokerRead, read),
+    Effect.provideService(CycleStore, store),
+    Effect.provideService(MarketData, marketData),
+  )
 
 describe('autonomous cycle runner', () => {
   test('builds one bounded calendar query and selects the first session strictly after Signal', () => {
@@ -166,17 +347,14 @@ describe('autonomous cycle runner', () => {
     expect(selected?.date).toBe('2026-02-02')
   })
 
-  test('keeps the month-end predicate pure and binds only selected-session material', () => {
+  test('keeps month-end selection pure and cycle identity independent of calendar query evidence', () => {
     expect(isMonthEndCycleDue('2026-01-29', '2026-01-30')).toBe(false)
     expect(isMonthEndCycleDue('2026-01-30', '2026-02-02')).toBe(true)
 
     const selected = selectNextExecutionSession('2026-01-30', monthEndCalendar)
     if (selected === undefined) throw new Error('month-end fixture must have an execution session')
     const first = makeDueCycleDraft(candidate(), monthEndCalendar, selected)
-    const changedEvidence = calendar([selected], {
-      start: '2026-01-31',
-      end: '2026-02-10',
-    })
+    const changedEvidence = calendar([selected], { start: '2026-01-31', end: '2026-02-10' })
     const second = makeDueCycleDraft(candidate(), changedEvidence, selected)
     expect(first?.identity.cycleId).toBe(second?.identity.cycleId)
     expect(first?.window).toMatchObject({
@@ -187,19 +365,26 @@ describe('autonomous cycle runner', () => {
       executionOpenAt: '2026-02-02T14:30:00.000Z',
       executionCloseAt: '2026-02-02T20:00:00.000Z',
     })
-
-    const ordinaryCandidate = candidate('2026-01-29')
-    const ordinarySession = {
-      date: '2026-01-30',
-      openAt: '2026-01-30T14:30:00.000Z',
-      closeAt: '2026-01-30T18:00:00.000Z',
-    }
-    expect(makeDueCycleDraft(ordinaryCandidate, calendar([ordinarySession]), ordinarySession)).toBeUndefined()
   })
 
-  test('does not acquire an ordinary session and retains response evidence outside identity', async () => {
-    const control: StoreControl = { acquisitions: [] }
-    let observedQuery: MarketCalendarQuery | undefined
+  test('does nothing when no finalized publication exists and never reads the broker', async () => {
+    const control: StoreControl = { acquisitions: [], binds: 0 }
+    const result = await Effect.runPromise(
+      provide(
+        runAutonomousCyclePass(context()),
+        brokerRead(() => Effect.die(new Error('missing publication must not read the broker'))),
+        cycleStore(control),
+        marketDataService(Effect.succeed({ outcome: 'MISSING', observedAt: '2026-01-30T21:01:00.000Z' })),
+      ),
+    )
+
+    expect(result).toEqual({ outcome: 'NO_PUBLICATION', observedAt: '2026-01-30T21:01:00.000Z' })
+    expect(control).toEqual({ acquisitions: [], binds: 0 })
+  })
+
+  test('uses one calendar read and does not acquire an ordinary terminal session', async () => {
+    const control: StoreControl = { acquisitions: [], binds: 0 }
+    const queries: MarketCalendarQuery[] = []
     const observation = calendar([
       {
         date: '2026-01-30',
@@ -208,33 +393,257 @@ describe('autonomous cycle runner', () => {
       },
     ])
     const read = brokerRead((query) => {
-      observedQuery = query
+      queries.push(query)
       return Effect.succeed({ value: observation, evidence })
     })
 
     const result = await Effect.runPromise(
       Effect.gen(function* () {
-        yield* TestClock.setTime(Date.parse('2026-01-29T21:01:00.000Z'))
-        return yield* provide(runAutonomousCyclePass(candidate('2026-01-29')), read, cycleStore(control))
+        yield* TestClock.setTime(Date.parse('2026-01-29T21:20:00.000Z'))
+        return yield* provide(
+          runAutonomousCyclePass(context()),
+          read,
+          cycleStore(control),
+          marketDataService(Effect.succeed(finalizedPublication('2026-01-29'))),
+        )
       }).pipe(Effect.provide(TestClock.layer())),
     )
 
-    expect(observedQuery).toEqual(marketCalendarQueryForSignal('2026-01-29'))
     expect(result).toMatchObject({
       outcome: 'NOT_DUE',
       signalSessionDate: '2026-01-29',
       executionSessionDate: '2026-01-30',
-      calendarResponseHash: observation.normalizedResponseHash,
-      calendarReadContentHash: evidence.contentHash,
     })
-    expect(control.acquisitions).toEqual([])
+    expect(queries).toEqual([marketCalendarQueryForSignal('2026-01-29')])
+    expect(control).toEqual({ acquisitions: [], binds: 0 })
+  })
+
+  test('catches an unacquired month-end publication hidden by a newer daily publication after downtime', async () => {
+    const control: StoreControl = { acquisitions: [], binds: 0 }
+    const store = cycleStore(control)
+    const queries: MarketCalendarQuery[] = []
+    const observation = calendar(
+      [
+        {
+          date: '2026-01-30',
+          openAt: '2026-01-30T14:30:00.000Z',
+          closeAt: '2026-01-30T21:00:00.000Z',
+        },
+        {
+          date: '2026-02-02',
+          openAt: '2026-02-02T14:30:00.000Z',
+          closeAt: '2026-02-02T21:00:00.000Z',
+        },
+        {
+          date: '2026-02-03',
+          openAt: '2026-02-03T14:30:00.000Z',
+          closeAt: '2026-02-03T21:00:00.000Z',
+        },
+      ],
+      { start: '2026-01-30', end: '2026-03-01' },
+    )
+    let calendarReads = 0
+    const read = brokerRead((query) => {
+      calendarReads += 1
+      queries.push(query)
+      return Effect.succeed({ value: observation, evidence })
+    })
+    const publications = [
+      finalizedPublicationInspection('2026-02-02', '2026-02-02T21:15:00.000Z', 'e'.repeat(64)),
+      finalizedPublicationInspection('2026-01-30', '2026-01-30T21:15:00.000Z'),
+    ]
+    const marketData = marketDataService(
+      Effect.succeed(finalizedPublications(publications, '2026-02-02T21:15:00.000Z')),
+    )
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse('2026-02-02T21:20:00.000Z'))
+        const caughtUp = yield* provide(runAutonomousCyclePass(context()), read, store, marketData)
+        const restarted = yield* provide(runAutonomousCyclePass(context()), read, store, marketData)
+        return { caughtUp, restarted }
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(result.caughtUp).toMatchObject({
+      outcome: 'ACQUIRED',
+      signalSessionDate: '2026-01-30',
+      executionSessionDate: '2026-02-02',
+      readiness: {
+        outcome: 'BLOCKED',
+        cycle: {
+          state: CycleState.Blocked,
+          terminalReason: CycleTerminalReason.MissedPublication,
+          identity: { signalSessionDate: '2026-01-30' },
+          bindings: {},
+        },
+      },
+    })
+    expect(result.restarted).toMatchObject({
+      outcome: 'RESUMED',
+      signalSessionDate: '2026-01-30',
+      readiness: {
+        outcome: 'BLOCKED',
+        cycle: { identity: { cycleId: control.acquisitions[0]?.draft.identity.cycleId } },
+      },
+    })
+    expect(queries).toEqual([marketCalendarQueryForPublications(publications)])
+    expect(calendarReads).toBe(1)
+    expect(control.acquisitions).toHaveLength(1)
+    expect(control.binds).toBe(0)
+  })
+
+  test('discovers, acquires, and atomically binds the manifest-authoritative month-end publication', async () => {
+    const control: StoreControl = { acquisitions: [], binds: 0 }
+    const queries: MarketCalendarQuery[] = []
+    const read = brokerRead((query) => {
+      queries.push(query)
+      return Effect.succeed({ value: monthEndCalendar, evidence })
+    })
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse('2026-01-30T21:20:00.000Z'))
+        return yield* provide(
+          runAutonomousCyclePass(context()),
+          read,
+          cycleStore(control),
+          marketDataService(Effect.succeed(finalizedPublication())),
+        )
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(result).toMatchObject({
+      outcome: 'ACQUIRED',
+      readiness: {
+        outcome: 'BOUND',
+        snapshotId,
+        cycle: {
+          state: CycleState.Pending,
+          identity: {
+            signalSessionDate: '2026-01-30',
+            signalCalendarVersion,
+            executionSessionDate: '2026-02-02',
+          },
+          bindings: { snapshotId },
+        },
+      },
+    })
+    expect(queries).toEqual([marketCalendarQueryForSignal('2026-01-30')])
+    expect(control.acquisitions).toHaveLength(1)
+    expect(control.binds).toBe(1)
+  })
+
+  test('persists a late publication as missed and never binds it at or after the exact deadline', async () => {
+    const control: StoreControl = { acquisitions: [], binds: 0 }
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse('2026-02-02T13:58:00.000Z'))
+        return yield* provide(
+          runAutonomousCyclePass(context()),
+          brokerRead(() => Effect.succeed({ value: monthEndCalendar, evidence })),
+          cycleStore(control),
+          marketDataService(Effect.succeed(finalizedPublication())),
+        )
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(result).toMatchObject({
+      outcome: 'ACQUIRED',
+      readiness: {
+        outcome: 'BLOCKED',
+        cycle: {
+          state: CycleState.Blocked,
+          terminalReason: CycleTerminalReason.MissedPublication,
+          terminalAt: '2026-02-02T13:58:00.000Z',
+        },
+      },
+    })
+    expect(control.binds).toBe(0)
+  })
+
+  test('returns an existing authority slot on restart without a second calendar read or duplicate binding', async () => {
+    const control: StoreControl = { acquisitions: [], binds: 0 }
+    const store = cycleStore(control)
+    let calendarReads = 0
+    const read = brokerRead(() => {
+      calendarReads += 1
+      return Effect.succeed({ value: monthEndCalendar, evidence })
+    })
+    const marketData = marketDataService(Effect.succeed(finalizedPublication()))
+
+    const results = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse('2026-01-30T21:20:00.000Z'))
+        const first = yield* provide(runAutonomousCyclePass(context()), read, store, marketData)
+        yield* TestClock.setTime(Date.parse('2026-01-30T21:21:00.000Z'))
+        const restarted = yield* provide(runAutonomousCyclePass(context()), read, store, marketData)
+        return { first, restarted }
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(results.first.outcome).toBe('ACQUIRED')
+    expect(results.restarted).toMatchObject({
+      outcome: 'ALREADY_ACQUIRED',
+      cycle: { bindings: { snapshotId } },
+    })
+    expect(calendarReads).toBe(1)
+    expect(control.acquisitions).toHaveLength(1)
+    expect(control.binds).toBe(1)
+  })
+
+  test('resumes the exact bind after a crash immediately following durable acquisition', async () => {
+    const control: StoreControl = { acquisitions: [], binds: 0 }
+    const store = cycleStore(control)
+    const crashAfterAcquire: CycleStoreShape = {
+      ...store,
+      bindSnapshot: () => Effect.die(new Error('injected crash after durable acquisition')),
+    }
+    let calendarReads = 0
+    const read = brokerRead(() => {
+      calendarReads += 1
+      return Effect.succeed({ value: monthEndCalendar, evidence })
+    })
+    const marketData = marketDataService(Effect.succeed(finalizedPublication()))
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse('2026-01-30T21:20:00.000Z'))
+        const crashed = yield* Effect.exit(
+          provide(runAutonomousCyclePass(context()), read, crashAfterAcquire, marketData),
+        )
+        yield* TestClock.setTime(Date.parse('2026-01-30T21:21:00.000Z'))
+        const resumed = yield* provide(runAutonomousCyclePass(context()), read, store, marketData)
+        return { crashed, resumed }
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(result.crashed._tag).toBe('Failure')
+    expect(result.resumed).toMatchObject({
+      outcome: 'RESUMED',
+      readiness: {
+        outcome: 'BOUND',
+        snapshotId,
+        cycle: { bindings: { snapshotId } },
+      },
+    })
+    expect(calendarReads).toBe(1)
+    expect(control.acquisitions).toHaveLength(1)
+    expect(control.binds).toBe(1)
   })
 
   test('fails typed when the bounded calendar has no future session or BrokerRead rejects drift', async () => {
-    const control: StoreControl = { acquisitions: [] }
-    const empty = brokerRead(() => Effect.succeed({ value: calendar([]), evidence }))
+    const control: StoreControl = { acquisitions: [], binds: 0 }
+    const store = cycleStore(control)
+    const marketData = marketDataService(Effect.succeed(finalizedPublication()))
     const missing = await Effect.runPromise(
-      Effect.flip(provide(runAutonomousCyclePass(candidate()), empty, cycleStore(control))),
+      Effect.flip(
+        provide(
+          runAutonomousCyclePass(context()),
+          brokerRead(() => Effect.succeed({ value: calendar([]), evidence })),
+          store,
+          marketData,
+        ),
+      ),
     )
     expect(missing).toMatchObject({
       _tag: 'CycleRunnerError',
@@ -248,9 +657,15 @@ describe('autonomous cycle runner', () => {
       message: 'injected normalized response drift',
       retryable: false,
     })
-    const rejected = brokerRead(() => Effect.fail(drift))
     const invalid = await Effect.runPromise(
-      Effect.flip(provide(runAutonomousCyclePass(candidate()), rejected, cycleStore(control))),
+      Effect.flip(
+        provide(
+          runAutonomousCyclePass(context()),
+          brokerRead(() => Effect.fail(drift)),
+          store,
+          marketData,
+        ),
+      ),
     )
     expect(invalid).toMatchObject({
       _tag: 'CycleRunnerError',
@@ -261,78 +676,74 @@ describe('autonomous cycle runner', () => {
     expect(control.acquisitions).toEqual([])
   })
 
-  test('passes exact clock instants and committed boundaries to the store unchanged', async () => {
-    const control: StoreControl = { acquisitions: [] }
-    const read = brokerRead(() => Effect.succeed({ value: monthEndCalendar, evidence }))
-    const boundaries = [
-      '2026-01-30T21:00:00.000Z',
-      '2026-02-02T13:58:00.000Z',
-      '2026-02-02T14:28:00.000Z',
-      '2026-02-02T14:30:00.000Z',
-    ] as const
-    const program = Effect.gen(function* () {
-      for (const boundary of boundaries) {
-        yield* TestClock.setTime(Date.parse(boundary))
-        yield* provide(runAutonomousCyclePass(candidate()), read, cycleStore(control))
-      }
-    }).pipe(Effect.provide(TestClock.layer()))
-
-    await Effect.runPromise(program)
-    expect(control.acquisitions.map((acquisition) => acquisition.observedAt)).toEqual([...boundaries])
-    expect(
-      control.acquisitions.every(
-        (acquisition) =>
-          acquisition.draft.window.submissionOpenAt < acquisition.draft.window.submissionCutoffAt &&
-          acquisition.draft.window.submissionCutoffAt < acquisition.draft.window.executionOpenAt,
-      ),
-    ).toBe(true)
-  })
-
-  test('runs immediately, repeats on Schedule.spaced, and reacquires the same cycle on restart', async () => {
-    const control: StoreControl = { acquisitions: [] }
+  test('runs immediately, repeats on Schedule.spaced, and avoids duplicate work after acquisition', async () => {
+    const control: StoreControl = { acquisitions: [], binds: 0 }
     const store = cycleStore(control)
-    const read = brokerRead(() => Effect.succeed({ value: monthEndCalendar, evidence }))
+    let calendarReads = 0
+    const read = brokerRead(() => {
+      calendarReads += 1
+      return Effect.succeed({ value: monthEndCalendar, evidence })
+    })
     const program = Effect.scoped(
       Effect.gen(function* () {
-        yield* TestClock.setTime(Date.parse('2026-01-30T21:01:00.000Z'))
+        yield* TestClock.setTime(Date.parse('2026-01-30T21:20:00.000Z'))
         const fiber = yield* provide(
           startAutonomousCycleLoop({
-            candidate: Effect.succeed(candidate()),
+            context: Effect.succeed(context()),
             pollIntervalMs: 100,
           }),
           read,
           store,
+          marketDataService(Effect.succeed(finalizedPublication())),
         )
         yield* Effect.yieldNow
         expect(control.acquisitions).toHaveLength(1)
         yield* TestClock.adjust(99)
         expect(control.acquisitions).toHaveLength(1)
         yield* TestClock.adjust(1)
-        expect(control.acquisitions).toHaveLength(2)
+        expect(control.acquisitions).toHaveLength(1)
         yield* Fiber.interrupt(fiber)
       }),
     ).pipe(Effect.provide(TestClock.layer()))
 
     await Effect.runPromise(program)
-    const restart = await Effect.runPromise(
-      Effect.gen(function* () {
-        yield* TestClock.setTime(Date.parse('2026-01-30T21:02:00.000Z'))
-        return yield* provide(runAutonomousCyclePass(candidate()), read, store)
-      }).pipe(Effect.provide(TestClock.layer())),
-    )
-    expect(restart.outcome).toBe('REACQUIRED')
-    expect(new Set(control.acquisitions.map((acquisition) => acquisition.draft.identity.cycleId)).size).toBe(1)
+    expect(calendarReads).toBe(1)
+    expect(control.binds).toBe(1)
   })
 
-  test('publishes NOT_DUE broker-calendar evidence before the loop waits', async () => {
-    const control: StoreControl = { acquisitions: [] }
-    const observation = calendar([
-      {
-        date: '2026-01-30',
-        openAt: '2026-01-30T14:30:00.000Z',
-        closeAt: '2026-01-30T18:00:00.000Z',
-      },
-    ])
+  test('scope closure interrupts in-flight publication discovery', async () => {
+    const started = await Effect.runPromise(Deferred.make<void>())
+    let interrupted = false
+    const latest = Deferred.succeed(started, undefined).pipe(
+      Effect.andThen(Effect.never),
+      Effect.onInterrupt(() => Effect.sync(() => void (interrupted = true))),
+    )
+    const control: StoreControl = { acquisitions: [], binds: 0 }
+
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          yield* provide(
+            startAutonomousCycleLoop({
+              context: Effect.succeed(context()),
+              pollIntervalMs: 100,
+            }),
+            brokerRead(() => Effect.die(new Error('in-flight publication read must not reach the broker'))),
+            cycleStore(control),
+            marketDataService(latest),
+          )
+          yield* Deferred.await(started)
+        }),
+      ),
+    )
+    expect(interrupted).toBe(true)
+    expect(control).toEqual({ acquisitions: [], binds: 0 })
+  })
+
+  test('logs a failed pass and runs the next scheduled pass without killing the scoped loop', async () => {
+    const contextFailure = new Error('qualification context unavailable')
+    const control: StoreControl = { acquisitions: [], binds: 0 }
+    let contextLoads = 0
     const logs: Array<{ readonly message: unknown; readonly annotations: Record<string, unknown> }> = []
     const logger = Logger.make<unknown, void>((options) => {
       logs.push({
@@ -342,138 +753,89 @@ describe('autonomous cycle runner', () => {
     })
     const program = Effect.scoped(
       Effect.gen(function* () {
-        yield* TestClock.setTime(Date.parse('2026-01-29T21:01:00.000Z'))
+        yield* TestClock.setTime(Date.parse('2026-01-30T21:20:00.000Z'))
         const fiber = yield* provide(
           startAutonomousCycleLoop({
-            candidate: Effect.succeed(candidate('2026-01-29')),
+            context: Effect.suspend(() => {
+              contextLoads += 1
+              return contextLoads === 1 ? Effect.fail(contextFailure) : Effect.succeed(context())
+            }),
             pollIntervalMs: 100,
           }),
-          brokerRead(() => Effect.succeed({ value: observation, evidence })),
+          brokerRead(() => Effect.succeed({ value: monthEndCalendar, evidence })),
           cycleStore(control),
+          marketDataService(Effect.succeed(finalizedPublication())),
         )
         yield* Effect.yieldNow
+        expect(contextLoads).toBe(1)
+        expect(control.acquisitions).toEqual([])
+        yield* TestClock.adjust(100)
+        expect(contextLoads).toBe(2)
+        expect(control.acquisitions).toHaveLength(1)
         yield* Fiber.interrupt(fiber)
       }),
     ).pipe(Effect.provide(Logger.layer([logger])), Effect.provide(TestClock.layer()))
 
     await Effect.runPromise(program)
-    expect(control.acquisitions).toEqual([])
-    expect(logs).toEqual([
-      {
-        message: ['Bayn autonomous cycle pass completed'],
-        annotations: {
-          outcome: 'NOT_DUE',
-          signalSessionDate: '2026-01-29',
-          executionSessionDate: '2026-01-30',
-          observedAt: '2026-01-29T21:01:00.000Z',
-          calendarResponseHash: observation.normalizedResponseHash,
-          calendarReadContentHash: evidence.contentHash,
-        },
-      },
-    ])
+    expect(
+      logs.some(
+        (entry) =>
+          Array.isArray(entry.message) &&
+          entry.message.includes('Bayn autonomous cycle pass failed') &&
+          entry.annotations.operation === 'load-context' &&
+          entry.annotations.failure === 'context',
+      ),
+    ).toBe(true)
+    expect(control.binds).toBe(1)
   })
 
-  test('scope closure interrupts an in-flight calendar read', async () => {
-    const started = await Effect.runPromise(Deferred.make<void>())
-    let interrupted = false
-    const read = brokerRead(() =>
-      Deferred.succeed(started, undefined).pipe(
-        Effect.andThen(Effect.never),
-        Effect.onInterrupt(() => Effect.sync(() => void (interrupted = true))),
-      ),
-    )
-    const control: StoreControl = { acquisitions: [] }
-
+  test('keeps repeated context failures scoped and interruptible without touching discovery or the broker', async () => {
+    const contextFailure = new Error('qualification context unavailable')
+    const control: StoreControl = { acquisitions: [], binds: 0 }
     await Effect.runPromise(
       Effect.scoped(
         Effect.gen(function* () {
-          yield* provide(
-            startAutonomousCycleLoop({
-              candidate: Effect.succeed(candidate()),
-              pollIntervalMs: 100,
-            }),
-            read,
-            cycleStore(control),
-          )
-          yield* Deferred.await(started)
-        }),
-      ),
-    )
-    expect(interrupted).toBe(true)
-    expect(control.acquisitions).toEqual([])
-  })
-
-  test('maps candidate-source failures without touching the broker', async () => {
-    const candidateFailure = new Error('Signal candidate unavailable')
-    const control: StoreControl = { acquisitions: [] }
-    const failure = await Effect.runPromise(
-      Effect.scoped(
-        Effect.gen(function* () {
           const fiber = yield* provide(
             startAutonomousCycleLoop({
-              candidate: Effect.fail(candidateFailure),
+              context: Effect.fail(contextFailure),
               pollIntervalMs: 100,
             }),
-            brokerRead(() => Effect.die(new Error('failed candidate must not read the broker'))),
+            brokerRead(() => Effect.die(new Error('failed context must not read the broker'))),
             cycleStore(control),
+            marketDataService(Effect.die(new Error('failed context must not inspect finalized publications'))),
           )
-          return yield* Effect.flip(Fiber.join(fiber))
+          yield* Effect.yieldNow
+          return yield* Fiber.interrupt(fiber)
         }),
       ),
     )
-    expect(failure).toMatchObject({
-      _tag: 'CycleRunnerError',
-      operation: 'load-candidate',
-      failure: 'candidate',
-      cause: candidateFailure,
-    })
-    expect(control.acquisitions).toEqual([])
+    expect(control).toEqual({ acquisitions: [], binds: 0 })
   })
 
-  test('exposes a failed scoped fiber for scheduler health on defects', async () => {
-    const read = brokerRead(() => Effect.die(new Error('injected broker defect')))
-    const control: StoreControl = { acquisitions: [] }
-    const exit = await Effect.runPromise(
-      Effect.scoped(
-        Effect.gen(function* () {
-          const fiber = yield* provide(
-            startAutonomousCycleLoop({
-              candidate: Effect.succeed(candidate()),
-              pollIntervalMs: 100,
-            }),
-            read,
-            cycleStore(control),
-          )
-          return yield* Fiber.await(fiber)
-        }),
-      ),
-    )
-    expect(Exit.isFailure(exit)).toBe(true)
-    if (Exit.isFailure(exit)) expect(Cause.pretty(exit.cause)).toContain('injected broker defect')
-    expect(control.acquisitions).toEqual([])
-  })
-
-  test('rejects an invalid loop interval before forking or touching dependencies', async () => {
-    const control: StoreControl = { acquisitions: [] }
-    const failure = await Effect.runPromise(
-      Effect.flip(
-        Effect.scoped(
-          provide(
-            startAutonomousCycleLoop({
-              candidate: Effect.succeed(candidate()),
-              pollIntervalMs: 0,
-            }),
-            brokerRead(() => Effect.die(new Error('invalid config must not read the broker'))),
-            cycleStore(control),
+  test('rejects invalid loop intervals before starting discovery', async () => {
+    const control: StoreControl = { acquisitions: [], binds: 0 }
+    for (const pollIntervalMs of [0, -1, 0.5, Number.MAX_SAFE_INTEGER + 1]) {
+      const failure = await Effect.runPromise(
+        Effect.flip(
+          Effect.scoped(
+            provide(
+              startAutonomousCycleLoop({
+                context: Effect.succeed(context()),
+                pollIntervalMs,
+              }),
+              brokerRead(() => Effect.die(new Error('invalid config must not read the broker'))),
+              cycleStore(control),
+              marketDataService(Effect.die(new Error('invalid config must not inspect publications'))),
+            ),
           ),
         ),
-      ),
-    )
-    expect(failure).toMatchObject({
-      _tag: 'CycleRunnerError',
-      operation: 'configure',
-      failure: 'invalid-config',
-    })
-    expect(control.acquisitions).toEqual([])
+      )
+      expect(failure).toMatchObject({
+        _tag: 'CycleRunnerError',
+        operation: 'configure',
+        failure: 'invalid-config',
+      })
+    }
+    expect(control).toEqual({ acquisitions: [], binds: 0 })
   })
 })

--- a/services/bayn/src/cycle-runner.ts
+++ b/services/bayn/src/cycle-runner.ts
@@ -1,4 +1,4 @@
-import { Clock, Data, Duration, Effect, Fiber, Schedule, Scope } from 'effect'
+import { Clock, Data, Duration, Effect, Fiber, Option, Schedule, Scope } from 'effect'
 
 import {
   BrokerRead,
@@ -11,16 +11,32 @@ import {
   makeCycleIdentity,
   makeCycleWindow,
   makeExecutionCalendarObservation,
+  type AutonomousCycle,
   type CycleDraft,
   type CycleExecutionPolicy,
 } from './cycle'
+import {
+  bindFinalizedCyclePublication,
+  type CyclePublicationReadiness,
+  type CycleReadinessError,
+} from './cycle-readiness'
 import { CycleStore, type CycleAcquireReceipt } from './db/cycle-store'
-import type { SignalSessionRow } from './market-data'
+import type { OperationalError } from './errors'
+import { MarketData, type MarketDataInspection, type SignalSessionRow } from './market-data'
 
 const calendarRangeDays = 31
+// This leaves at least 10 calendar days after the newest candidate inside Alpaca's 31-day observation bound.
+const publicationCatchUpRangeDays = 21
 const millisecondsPerDay = 86_400_000
 
 type SignalCycleSession = Pick<SignalSessionRow, 'calendar_version' | 'session_date' | 'close_time' | 'timezone'>
+
+export interface CycleRunContext {
+  readonly qualificationRunId: string
+  readonly strategyProtocolHash: string
+  readonly accountId: string
+  readonly executionPolicy: CycleExecutionPolicy
+}
 
 export interface CycleCandidate {
   readonly qualificationRunId: string
@@ -30,7 +46,25 @@ export interface CycleCandidate {
   readonly executionPolicy: CycleExecutionPolicy
 }
 
+type CycleBindingResult = Exclude<CyclePublicationReadiness, { readonly outcome: 'WAITING' }>
+
 export type CycleRunResult =
+  | {
+      readonly outcome: 'NO_PUBLICATION'
+      readonly observedAt: string
+    }
+  | {
+      readonly outcome: 'ALREADY_ACQUIRED'
+      readonly signalSessionDate: string
+      readonly observedAt: string
+      readonly cycle: CycleBindingResult['cycle']
+    }
+  | {
+      readonly outcome: 'RESUMED'
+      readonly signalSessionDate: string
+      readonly observedAt: string
+      readonly readiness: CycleBindingResult
+    }
   | {
       readonly outcome: 'NOT_DUE'
       readonly signalSessionDate: string
@@ -47,23 +81,34 @@ export type CycleRunResult =
       readonly calendarResponseHash: string
       readonly calendarReadContentHash: string
       readonly receipt: CycleAcquireReceipt
+      readonly readiness: CycleBindingResult
     }
 
 export class CycleRunnerError extends Data.TaggedError('CycleRunnerError')<{
   readonly operation:
     | 'acquire-cycle'
+    | 'bind-publication'
     | 'build-cycle'
     | 'configure'
-    | 'load-candidate'
+    | 'inspect-publication'
+    | 'load-context'
     | 'market-calendar'
+    | 'read-authority-slot'
     | 'select-session'
-  readonly failure: 'calendar-read' | 'calendar-unavailable' | 'candidate' | 'contract' | 'invalid-config' | 'store'
+  readonly failure:
+    | 'calendar-read'
+    | 'calendar-unavailable'
+    | 'context'
+    | 'contract'
+    | 'invalid-config'
+    | 'market-data'
+    | 'store'
   readonly message: string
   readonly cause?: unknown
 }> {}
 
 export interface AutonomousCycleLoopOptions<E = never, R = never> {
-  readonly candidate: Effect.Effect<CycleCandidate | undefined, E, R>
+  readonly context: Effect.Effect<CycleRunContext | undefined, E, R>
   readonly pollIntervalMs: number
 }
 
@@ -74,6 +119,33 @@ const runnerError = (
   cause?: unknown,
 ): CycleRunnerError => new CycleRunnerError({ operation, failure, message, cause })
 
+const bindDiscoveredPublication = (
+  cycle: AutonomousCycle,
+  inspection: MarketDataInspection,
+  observedAt: string,
+): Effect.Effect<CycleBindingResult, CycleRunnerError, CycleStore> =>
+  bindFinalizedCyclePublication(cycle, inspection, observedAt).pipe(
+    Effect.mapError((cause: CycleReadinessError) =>
+      runnerError(
+        'bind-publication',
+        cause.failure === 'store' ? 'store' : 'contract',
+        'exact finalized Signal publication binding failed',
+        cause,
+      ),
+    ),
+    Effect.flatMap((readiness) =>
+      readiness.outcome === 'WAITING'
+        ? Effect.fail(
+            runnerError(
+              'bind-publication',
+              'contract',
+              'discovered finalized Signal publication unexpectedly remained waiting',
+            ),
+          )
+        : Effect.succeed(readiness),
+    ),
+  )
+
 const addUtcDays = (date: string, days: number): string =>
   new Date(Date.parse(`${date}T00:00:00.000Z`) + days * millisecondsPerDay).toISOString().slice(0, 10)
 
@@ -81,6 +153,33 @@ export const marketCalendarQueryForSignal = (signalSessionDate: string): MarketC
   start: signalSessionDate,
   end: addUtcDays(signalSessionDate, calendarRangeDays - 1),
 })
+
+export const marketCalendarQueryForPublications = (
+  publications: readonly MarketDataInspection[],
+): MarketCalendarQuery => {
+  const sessionDates = publications.map((publication) => publication.signalSession.session_date).sort()
+  const earliest = sessionDates[0]
+  if (earliest === undefined) throw new TypeError('cycle publication discovery must contain at least one session')
+  return marketCalendarQueryForSignal(earliest)
+}
+
+const boundedCyclePublications = (publications: readonly MarketDataInspection[]): readonly MarketDataInspection[] => {
+  const ordered = [...publications].sort((left, right) =>
+    right.signalSession.session_date.localeCompare(left.signalSession.session_date),
+  )
+  const latest = ordered[0]?.signalSession.session_date
+  if (latest === undefined) throw new TypeError('cycle publication discovery must contain at least one publication')
+  const earliest = addUtcDays(latest, -(publicationCatchUpRangeDays - 1))
+  const sessionDates = new Set<string>()
+  return ordered.filter((publication) => {
+    const sessionDate = publication.signalSession.session_date
+    if (sessionDates.has(sessionDate)) {
+      throw new TypeError(`cycle publication discovery contains duplicate session ${sessionDate}`)
+    }
+    sessionDates.add(sessionDate)
+    return sessionDate >= earliest
+  })
+}
 
 export const selectNextExecutionSession = (
   signalSessionDate: string,
@@ -128,12 +227,65 @@ export const makeDueCycleDraft = (
 }
 
 export const runAutonomousCyclePass = (
-  candidate: CycleCandidate,
-): Effect.Effect<CycleRunResult, CycleRunnerError, BrokerRead | CycleStore> =>
+  context: CycleRunContext,
+): Effect.Effect<CycleRunResult, CycleRunnerError, BrokerRead | CycleStore | MarketData> =>
   Effect.gen(function* () {
     const broker = yield* BrokerRead
     const store = yield* CycleStore
-    const query = marketCalendarQueryForSignal(candidate.signalSession.session_date)
+    const marketData = yield* MarketData
+    const discovery = yield* marketData.inspectCyclePublications.pipe(
+      Effect.mapError((cause: OperationalError) =>
+        runnerError(
+          'inspect-publication',
+          'market-data',
+          'bounded finalized Signal publication discovery failed',
+          cause,
+        ),
+      ),
+    )
+    if (discovery.outcome === 'MISSING') {
+      return { outcome: 'NO_PUBLICATION', observedAt: discovery.observedAt }
+    }
+    const publications = yield* Effect.try({
+      try: () => boundedCyclePublications(discovery.publications),
+      catch: (cause) =>
+        runnerError('inspect-publication', 'contract', 'bounded cycle publication discovery is invalid', cause),
+    })
+    for (const publication of publications) {
+      const signalSessionDate = publication.signalSession.session_date
+      const existing = yield* store
+        .readAuthoritySlot({
+          qualificationRunId: context.qualificationRunId,
+          accountId: context.accountId,
+          signalSessionDate,
+        })
+        .pipe(
+          Effect.mapError((cause) =>
+            runnerError('read-authority-slot', 'store', 'durable autonomous cycle authority-slot read failed', cause),
+          ),
+        )
+      if (Option.isNone(existing)) continue
+      if (existing.value.bindings.snapshotId === undefined) {
+        const observedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
+        const readiness = yield* bindDiscoveredPublication(existing.value, publication, observedAt)
+        return {
+          outcome: 'RESUMED',
+          signalSessionDate,
+          observedAt,
+          readiness,
+        }
+      }
+      return {
+        outcome: 'ALREADY_ACQUIRED',
+        signalSessionDate,
+        observedAt: discovery.observedAt,
+        cycle: existing.value,
+      }
+    }
+    const query = yield* Effect.try({
+      try: () => marketCalendarQueryForPublications(publications),
+      catch: (cause) => runnerError('market-calendar', 'contract', 'cycle calendar query construction failed', cause),
+    })
     const calendar = yield* broker
       .marketCalendar(query)
       .pipe(
@@ -141,68 +293,137 @@ export const runAutonomousCyclePass = (
           runnerError('market-calendar', 'calendar-read', 'authoritative broker calendar read failed', cause),
         ),
       )
-    const executionSession = selectNextExecutionSession(candidate.signalSession.session_date, calendar.value)
-    if (executionSession === undefined) {
-      return yield* Effect.fail(
-        runnerError(
-          'select-session',
-          'calendar-unavailable',
-          `broker calendar has no trading session after ${candidate.signalSession.session_date}`,
-        ),
-      )
-    }
     const observedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
-    const common = {
-      signalSessionDate: candidate.signalSession.session_date,
-      executionSessionDate: executionSession.date,
-      observedAt,
-      calendarResponseHash: calendar.value.normalizedResponseHash,
-      calendarReadContentHash: calendar.evidence.contentHash,
-    } as const
-    const draft = yield* Effect.try({
-      try: () => makeDueCycleDraft(candidate, calendar.value, executionSession),
-      catch: (cause) => runnerError('build-cycle', 'contract', 'autonomous cycle draft construction failed', cause),
-    })
-    if (draft === undefined) return { outcome: 'NOT_DUE', ...common }
-    const receipt = yield* store
-      .acquire(draft, observedAt)
-      .pipe(
-        Effect.mapError((cause) =>
-          runnerError('acquire-cycle', 'store', 'durable autonomous cycle acquisition failed', cause),
-        ),
-      )
-    return {
-      outcome: receipt.created ? 'ACQUIRED' : 'REACQUIRED',
-      ...common,
-      receipt,
+    let latestNotDue: Extract<CycleRunResult, { readonly outcome: 'NOT_DUE' }> | undefined
+    for (const publication of publications) {
+      const candidate: CycleCandidate = {
+        qualificationRunId: context.qualificationRunId,
+        strategyProtocolHash: context.strategyProtocolHash,
+        accountId: context.accountId,
+        signalSession: publication.signalSession,
+        executionPolicy: context.executionPolicy,
+      }
+      const signalSessionDate = candidate.signalSession.session_date
+      const executionSession = selectNextExecutionSession(signalSessionDate, calendar.value)
+      if (executionSession === undefined) {
+        return yield* Effect.fail(
+          runnerError(
+            'select-session',
+            'calendar-unavailable',
+            `broker calendar has no trading session after ${signalSessionDate}`,
+          ),
+        )
+      }
+      const common = {
+        signalSessionDate,
+        executionSessionDate: executionSession.date,
+        observedAt,
+        calendarResponseHash: calendar.value.normalizedResponseHash,
+        calendarReadContentHash: calendar.evidence.contentHash,
+      } as const
+      const draft = yield* Effect.try({
+        try: () => makeDueCycleDraft(candidate, calendar.value, executionSession),
+        catch: (cause) => runnerError('build-cycle', 'contract', 'autonomous cycle draft construction failed', cause),
+      })
+      if (draft === undefined) {
+        if (latestNotDue === undefined) {
+          latestNotDue = { outcome: 'NOT_DUE', ...common }
+        }
+        continue
+      }
+      const receipt = yield* store
+        .acquire(draft, observedAt)
+        .pipe(
+          Effect.mapError((cause) =>
+            runnerError('acquire-cycle', 'store', 'durable autonomous cycle acquisition failed', cause),
+          ),
+        )
+      const readiness = yield* bindDiscoveredPublication(receipt.cycle, publication, observedAt)
+      return {
+        outcome: receipt.created ? 'ACQUIRED' : 'REACQUIRED',
+        ...common,
+        receipt,
+        readiness,
+      }
     }
+    if (latestNotDue !== undefined) return latestNotDue
+    return yield* Effect.fail(
+      runnerError('inspect-publication', 'contract', 'bounded cycle publication discovery produced no candidates'),
+    )
   })
 
-const logCompletedPass = (result: CycleRunResult): Effect.Effect<void> =>
-  Effect.logInfo('Bayn autonomous cycle pass completed').pipe(
+const logCompletedPass = (result: CycleRunResult): Effect.Effect<void> => {
+  switch (result.outcome) {
+    case 'NO_PUBLICATION':
+      return Effect.logInfo('Bayn autonomous cycle pass completed').pipe(
+        Effect.annotateLogs({ outcome: result.outcome, observedAt: result.observedAt }),
+      )
+    case 'ALREADY_ACQUIRED':
+      return Effect.logInfo('Bayn autonomous cycle pass completed').pipe(
+        Effect.annotateLogs({
+          outcome: result.outcome,
+          signalSessionDate: result.signalSessionDate,
+          observedAt: result.observedAt,
+          cycleId: result.cycle.identity.cycleId,
+          cycleState: result.cycle.state,
+        }),
+      )
+    case 'RESUMED':
+      return Effect.logInfo('Bayn autonomous cycle pass completed').pipe(
+        Effect.annotateLogs({
+          outcome: result.outcome,
+          signalSessionDate: result.signalSessionDate,
+          observedAt: result.observedAt,
+          cycleId: result.readiness.cycle.identity.cycleId,
+          cycleState: result.readiness.cycle.state,
+          publicationReadiness: result.readiness.outcome,
+        }),
+      )
+    case 'NOT_DUE':
+      return Effect.logInfo('Bayn autonomous cycle pass completed').pipe(
+        Effect.annotateLogs({
+          outcome: result.outcome,
+          signalSessionDate: result.signalSessionDate,
+          executionSessionDate: result.executionSessionDate,
+          observedAt: result.observedAt,
+          calendarResponseHash: result.calendarResponseHash,
+          calendarReadContentHash: result.calendarReadContentHash,
+        }),
+      )
+    case 'ACQUIRED':
+    case 'REACQUIRED':
+      return Effect.logInfo('Bayn autonomous cycle pass completed').pipe(
+        Effect.annotateLogs({
+          outcome: result.outcome,
+          signalSessionDate: result.signalSessionDate,
+          executionSessionDate: result.executionSessionDate,
+          observedAt: result.observedAt,
+          calendarResponseHash: result.calendarResponseHash,
+          calendarReadContentHash: result.calendarReadContentHash,
+          cycleId: result.readiness.cycle.identity.cycleId,
+          cycleState: result.readiness.cycle.state,
+          publicationReadiness: result.readiness.outcome,
+          persistenceDeduplicated: !result.receipt.created,
+        }),
+      )
+  }
+}
+
+const logFailedPass = (error: CycleRunnerError): Effect.Effect<void> =>
+  Effect.logError('Bayn autonomous cycle pass failed').pipe(
     Effect.annotateLogs({
-      outcome: result.outcome,
-      signalSessionDate: result.signalSessionDate,
-      executionSessionDate: result.executionSessionDate,
-      observedAt: result.observedAt,
-      calendarResponseHash: result.calendarResponseHash,
-      calendarReadContentHash: result.calendarReadContentHash,
-      ...(result.outcome === 'NOT_DUE'
-        ? {}
-        : {
-            cycleId: result.receipt.cycle.identity.cycleId,
-            cycleState: result.receipt.cycle.state,
-            persistenceDeduplicated: !result.receipt.created,
-          }),
+      operation: error.operation,
+      failure: error.failure,
+      message: error.message,
     }),
   )
 
 const runLoopPass = <E, R>(
-  candidate: Effect.Effect<CycleCandidate | undefined, E, R>,
-): Effect.Effect<void, CycleRunnerError, BrokerRead | CycleStore | R> =>
-  candidate.pipe(
+  context: Effect.Effect<CycleRunContext | undefined, E, R>,
+): Effect.Effect<void, CycleRunnerError, BrokerRead | CycleStore | MarketData | R> =>
+  context.pipe(
     Effect.mapError((cause) =>
-      runnerError('load-candidate', 'candidate', 'autonomous cycle candidate discovery failed', cause),
+      runnerError('load-context', 'context', 'autonomous cycle context loading failed', cause),
     ),
     Effect.flatMap((value) =>
       value === undefined
@@ -214,13 +435,19 @@ const runLoopPass = <E, R>(
 
 export const startAutonomousCycleLoop = <E, R>(
   options: AutonomousCycleLoopOptions<E, R>,
-): Effect.Effect<Fiber.Fiber<void, CycleRunnerError>, CycleRunnerError, BrokerRead | CycleStore | R | Scope.Scope> => {
+): Effect.Effect<
+  Fiber.Fiber<void, never>,
+  CycleRunnerError,
+  BrokerRead | CycleStore | MarketData | R | Scope.Scope
+> => {
   if (!Number.isSafeInteger(options.pollIntervalMs) || options.pollIntervalMs <= 0) {
     return Effect.fail(
       runnerError('configure', 'invalid-config', 'cycle loop interval must be a positive safe integer'),
     )
   }
-  return runLoopPass(options.candidate).pipe(
+  return runLoopPass(options.context).pipe(
+    Effect.tapError(logFailedPass),
+    Effect.catch(() => Effect.void),
     Effect.repeat(Schedule.spaced(Duration.millis(options.pollIntervalMs))),
     Effect.asVoid,
     Effect.forkScoped({ startImmediately: true }),

--- a/services/bayn/src/db/cycle-store.integration.test.ts
+++ b/services/bayn/src/db/cycle-store.integration.test.ts
@@ -16,9 +16,20 @@ import {
   makeExecutionCalendarObservation,
   type CycleDraft,
 } from '../cycle'
-import { runAutonomousCyclePass, type CycleCandidate, type CycleRunResult } from '../cycle-runner'
+import {
+  makeDueCycleDraft,
+  runAutonomousCyclePass,
+  selectNextExecutionSession,
+  type CycleRunContext,
+  type CycleRunResult,
+} from '../cycle-runner'
 import { canonicalHashV1, sha256 } from '../hash'
-import type { SignalSessionRow } from '../market-data'
+import {
+  MarketData,
+  type FinalizedPublicationInspection,
+  type MarketDataService,
+  type SignalSessionRow,
+} from '../market-data'
 import { DataFeed, DataSource, PriceAdjustment, PublicationSchema, type InputManifest, type IsoDate } from '../types'
 import { CycleStore, CycleStoreLive } from './cycle-store'
 import { PostgresClientLive } from './evidence-store'
@@ -126,6 +137,7 @@ const makeInputManifest = (
   options: {
     readonly asOfSession?: IsoDate
     readonly calendarVersion?: string
+    readonly finalizedAt?: string
     readonly lastSession?: IsoDate
   } = {},
 ): InputManifest => {
@@ -147,7 +159,7 @@ const makeInputManifest = (
       repository: 'registry.example.com/signal-publisher',
       digest: `sha256:${'2'.repeat(64)}`,
     },
-    finalizedAt: '2026-03-06T21:01:00.000Z',
+    finalizedAt: options.finalizedAt ?? '2026-03-06T21:01:00.000Z',
     requestedStart: lastSession,
     firstSession: lastSession,
     lastSession,
@@ -190,11 +202,10 @@ const activeAt = '2026-03-06T21:03:00.000Z'
 const decisionAt = '2026-03-06T21:04:00.000Z'
 const terminalAt = '2026-03-06T21:05:00.000Z'
 
-const runnerCandidate = (accountId: string): CycleCandidate => ({
+const runnerContext = (accountId: string): CycleRunContext => ({
   qualificationRunId: 'a'.repeat(64),
   strategyProtocolHash: 'b'.repeat(64),
   accountId,
-  signalSession: signalSession('2026-01-30'),
   executionPolicy: makeCycleExecutionPolicy({
     schemaVersion: 'bayn.autonomous-cycle-execution-policy.v1',
     strategyExecutionModelHash: 'c'.repeat(64),
@@ -202,6 +213,36 @@ const runnerCandidate = (accountId: string): CycleCandidate => ({
     submissionCutoffBeforeOpenMs: 2 * 60 * 1_000,
   }),
 })
+
+const runnerPublication = (): Extract<FinalizedPublicationInspection, { readonly outcome: 'FINALIZED' }> => ({
+  outcome: 'FINALIZED',
+  observedAt: '2026-01-30T21:01:00.000Z',
+  inspection: {
+    manifest: makeInputManifest(snapshotA, {
+      asOfSession: '2026-01-30',
+      finalizedAt: '2026-01-30T21:00:30.000Z',
+      lastSession: '2026-01-30',
+    }),
+    sessionDates: ['2026-01-30'],
+    signalSession: signalSession('2026-01-30'),
+  },
+})
+
+const runnerMarketData = (): MarketDataService => {
+  const unused = Effect.die(new Error('autonomous cycle runner must inspect only bounded publication candidates'))
+  return {
+    check: unused,
+    inspect: unused,
+    inspectCyclePublications: Effect.succeed({
+      outcome: 'FINALIZED',
+      observedAt: runnerPublication().observedAt,
+      publications: [runnerPublication().inspection],
+    }),
+    inspectPublication: () => unused,
+    inspectSnapshotPublication: () => unused,
+    load: unused,
+  }
+}
 
 const runnerCalendar = (): MarketCalendarObservation => {
   const material = {
@@ -271,7 +312,7 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
     await runtime.dispose()
     runtime = makeRuntime()
     await runtime.runPromise(PgMigrator.run({ loader: migrationLoader, table: 'schema_migrations' }))
-  })
+  }, 15_000)
 
   afterAll(async () => {
     await runtime?.dispose()
@@ -317,7 +358,7 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
   })
 
   test('concurrent runner passes and restart converge on one OBSERVE cycle', async () => {
-    const candidate = runnerCandidate('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa')
+    const context = runnerContext('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa')
     const queries: Array<{ readonly start: string; readonly end: string }> = []
     const read = runnerBrokerRead(queries)
     const result = await runtime.runPromise(
@@ -325,46 +366,96 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
         yield* TestClock.setTime(Date.parse('2026-01-30T21:01:00.000Z'))
         const concurrent = yield* Effect.all(
           [
-            runAutonomousCyclePass(candidate).pipe(Effect.provideService(BrokerRead, read)),
-            runAutonomousCyclePass(structuredClone(candidate)).pipe(Effect.provideService(BrokerRead, read)),
+            runAutonomousCyclePass(context).pipe(Effect.provideService(BrokerRead, read)),
+            runAutonomousCyclePass(structuredClone(context)).pipe(Effect.provideService(BrokerRead, read)),
           ],
           { concurrency: 'unbounded' },
         )
+        const readsAfterConcurrent = queries.length
         yield* TestClock.setTime(Date.parse('2026-01-30T21:02:00.000Z'))
-        const restarted = yield* runAutonomousCyclePass(candidate).pipe(Effect.provideService(BrokerRead, read))
+        const restarted = yield* runAutonomousCyclePass(context).pipe(Effect.provideService(BrokerRead, read))
         const sql = yield* PgClient.PgClient
         const [count] = yield* sql<{ count: number }>`
           SELECT count(*)::integer AS count
           FROM autonomous_cycles
-          WHERE qualification_run_id = ${candidate.qualificationRunId}
-            AND account_id = ${candidate.accountId}
-            AND signal_session_date = ${candidate.signalSession.session_date}
+          WHERE qualification_run_id = ${context.qualificationRunId}
+            AND account_id = ${context.accountId}
+            AND signal_session_date = '2026-01-30'
         `
-        return { concurrent, count: count.count, restarted }
-      }).pipe(Effect.provide(TestClock.layer())),
+        return { concurrent, count: count.count, readsAfterConcurrent, restarted }
+      }).pipe(Effect.provideService(MarketData, runnerMarketData()), Effect.provide(TestClock.layer())),
     )
 
-    expect(result.concurrent.map((pass) => pass.outcome).sort()).toEqual(['ACQUIRED', 'REACQUIRED'])
+    expect(result.concurrent.some((pass) => pass.outcome === 'ACQUIRED')).toBe(true)
+    expect(result.concurrent.every((pass) => pass.outcome !== 'NO_PUBLICATION' && pass.outcome !== 'NOT_DUE')).toBe(
+      true,
+    )
     expect(result.restarted).toMatchObject({
-      outcome: 'REACQUIRED',
-      receipt: {
-        created: false,
-        cycle: {
-          state: CycleState.Pending,
-          identity: {
-            accountId: candidate.accountId,
-            signalSessionDate: candidate.signalSession.session_date,
-            executionSessionDate: '2026-02-02',
-          },
+      outcome: 'ALREADY_ACQUIRED',
+      cycle: {
+        state: CycleState.Pending,
+        bindings: { snapshotId: snapshotA },
+        identity: {
+          accountId: context.accountId,
+          signalSessionDate: '2026-01-30',
+          executionSessionDate: '2026-02-02',
         },
       },
     })
     expect(result.count).toBe(1)
-    expect(queries).toEqual([
-      { start: '2026-01-30', end: '2026-03-01' },
-      { start: '2026-01-30', end: '2026-03-01' },
-      { start: '2026-01-30', end: '2026-03-01' },
-    ])
+    expect(queries).toHaveLength(result.readsAfterConcurrent)
+    expect(queries.length).toBeGreaterThanOrEqual(1)
+    expect(queries.length).toBeLessThanOrEqual(2)
+    expect(queries.every((query) => query.start === '2026-01-30' && query.end === '2026-03-01')).toBe(true)
+  })
+
+  test('resumes an exact publication binding after a crash between acquire and bind', async () => {
+    const context = runnerContext('aaaaaaaa-aaaa-4aaa-8aaa-bbbbbbbbbbbb')
+    const publication = runnerPublication()
+    if (publication.outcome !== 'FINALIZED') throw new Error('runner publication fixture must be finalized')
+    const executionSession = selectNextExecutionSession('2026-01-30', runnerCalendar())
+    if (executionSession === undefined) throw new Error('runner calendar fixture must contain an execution session')
+    const draft = makeDueCycleDraft(
+      { ...context, signalSession: publication.inspection.signalSession },
+      runnerCalendar(),
+      executionSession,
+    )
+    if (draft === undefined) throw new Error('runner fixture must produce a month-end cycle')
+    const noCalendarRead: BrokerReadShape = {
+      ...runnerBrokerRead([]),
+      marketCalendar: () =>
+        Effect.die(new Error('existing unbound authority slot must resume without another calendar read')),
+    }
+
+    const result = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* CycleStore
+        const acquired = yield* store.acquire(draft, '2026-01-30T21:01:00.000Z')
+        yield* TestClock.setTime(Date.parse('2026-01-30T21:02:00.000Z'))
+        const resumed = yield* runAutonomousCyclePass(context).pipe(Effect.provideService(BrokerRead, noCalendarRead))
+        const sql = yield* PgClient.PgClient
+        const [counts] = yield* sql<{ cycles: number; references: number }>`
+          SELECT
+            (SELECT count(*)::integer FROM autonomous_cycles) AS cycles,
+            (SELECT count(*)::integer FROM snapshot_references) AS references
+        `
+        return { acquired, counts, resumed }
+      }).pipe(Effect.provideService(MarketData, runnerMarketData()), Effect.provide(TestClock.layer())),
+    )
+
+    expect(result.acquired).toMatchObject({
+      created: true,
+      cycle: { state: CycleState.Pending, bindings: {} },
+    })
+    expect(result.resumed).toMatchObject({
+      outcome: 'RESUMED',
+      readiness: {
+        outcome: 'BOUND',
+        snapshotId: snapshotA,
+        cycle: { bindings: { snapshotId: snapshotA } },
+      },
+    })
+    expect(result.counts).toEqual({ cycles: 1, references: 1 })
   })
 
   test('runner Clock preserves every pre-open acquisition boundary in PostgreSQL', async () => {
@@ -397,22 +488,24 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
         const observed: Array<Extract<CycleRunResult, { readonly outcome: 'ACQUIRED' | 'REACQUIRED' }>> = []
         for (const boundary of cases) {
           yield* TestClock.setTime(Date.parse(boundary.observedAt))
-          const result = yield* runAutonomousCyclePass(runnerCandidate(boundary.accountId)).pipe(
+          const result = yield* runAutonomousCyclePass(runnerContext(boundary.accountId)).pipe(
             Effect.provideService(BrokerRead, read),
           )
-          if (result.outcome === 'NOT_DUE') throw new Error('month-end runner fixture must acquire a cycle')
+          if (result.outcome !== 'ACQUIRED' && result.outcome !== 'REACQUIRED') {
+            throw new Error('month-end runner fixture must acquire a cycle')
+          }
           observed.push(result)
         }
         return observed
-      }).pipe(Effect.provide(TestClock.layer())),
+      }).pipe(Effect.provideService(MarketData, runnerMarketData()), Effect.provide(TestClock.layer())),
     )
 
-    expect(results.map((result) => result.receipt.cycle.state)).toEqual(cases.map((boundary) => boundary.state))
-    expect(results.map((result) => result.receipt.cycle.updatedAt)).toEqual(
+    expect(results.map((result) => result.readiness.cycle.state)).toEqual(cases.map((boundary) => boundary.state))
+    expect(results.map((result) => result.readiness.cycle.updatedAt)).toEqual(
       cases.map((boundary) => boundary.observedAt),
     )
     for (const result of results.slice(1)) {
-      expect(result.receipt.cycle).toMatchObject({
+      expect(result.readiness.cycle).toMatchObject({
         state: CycleState.Blocked,
         terminalReason: CycleTerminalReason.MissedPublication,
       })
@@ -420,8 +513,8 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
     expect(
       results.every(
         (result) =>
-          result.receipt.cycle.window.submissionOpenAt < result.receipt.cycle.window.submissionCutoffAt &&
-          result.receipt.cycle.window.submissionCutoffAt < result.receipt.cycle.window.executionOpenAt,
+          result.readiness.cycle.window.submissionOpenAt < result.readiness.cycle.window.submissionCutoffAt &&
+          result.readiness.cycle.window.submissionCutoffAt < result.readiness.cycle.window.executionOpenAt,
       ),
     ).toBe(true)
   })

--- a/services/bayn/src/db/cycle-store.ts
+++ b/services/bayn/src/db/cycle-store.ts
@@ -22,7 +22,7 @@ import {
   UtcInstantSchema,
   strictParseOptions,
 } from '../schemas'
-import type { InputManifest } from '../types'
+import type { InputManifest, IsoDate } from '../types'
 import { ensureSnapshotReference } from './snapshot-reference'
 
 export interface CycleAcquireReceipt {
@@ -35,8 +35,21 @@ export interface CycleMutationReceipt {
   readonly changed: boolean
 }
 
+export interface CycleAuthoritySlot {
+  readonly qualificationRunId: string
+  readonly accountId: string
+  readonly signalSessionDate: IsoDate
+}
+
 export class CycleStoreError extends Data.TaggedError('CycleStoreError')<{
-  readonly operation: 'acquire' | 'activate' | 'bind-decision' | 'bind-snapshot' | 'block' | 'read'
+  readonly operation:
+    | 'acquire'
+    | 'activate'
+    | 'bind-decision'
+    | 'bind-snapshot'
+    | 'block'
+    | 'read'
+    | 'read-authority-slot'
   readonly failure: 'conflict' | 'decode' | 'invariant' | 'not-found' | 'query'
   readonly message: string
   readonly cause?: unknown
@@ -45,6 +58,9 @@ export class CycleStoreError extends Data.TaggedError('CycleStoreError')<{
 export interface CycleStoreShape {
   readonly acquire: (draft: CycleDraft, observedAt: string) => Effect.Effect<CycleAcquireReceipt, CycleStoreError>
   readonly read: (cycleId: string) => Effect.Effect<Option.Option<AutonomousCycle>, CycleStoreError>
+  readonly readAuthoritySlot: (
+    slot: CycleAuthoritySlot,
+  ) => Effect.Effect<Option.Option<AutonomousCycle>, CycleStoreError>
   readonly bindSnapshot: (
     cycleId: string,
     inputManifest: InputManifest,
@@ -103,6 +119,11 @@ const StoredCycleRowSchema = Schema.Struct({
 type StoredCycleRow = typeof StoredCycleRowSchema.Type
 
 const CycleIdInputSchema = Schema.Struct({ cycleId: Sha256Schema, observedAt: UtcInstantSchema })
+const CycleAuthoritySlotSchema = Schema.Struct({
+  qualificationRunId: Sha256Schema,
+  accountId: StrictNonEmptyStringSchema,
+  signalSessionDate: IsoDateSchema,
+})
 const SnapshotInputSchema = Schema.Struct({
   cycleId: Sha256Schema,
   observedAt: UtcInstantSchema,
@@ -121,6 +142,7 @@ const MutationRowsSchema = Schema.Array(Schema.Struct({ cycle_id: Sha256Schema }
 
 const decodeStoredCycleRows = Schema.decodeUnknownEffect(Schema.Array(StoredCycleRowSchema), strictParseOptions)
 const decodeCycleIdInput = Schema.decodeUnknownEffect(CycleIdInputSchema, strictParseOptions)
+const decodeCycleAuthoritySlot = Schema.decodeUnknownEffect(CycleAuthoritySlotSchema, strictParseOptions)
 const decodeSnapshotInput = Schema.decodeUnknownEffect(SnapshotInputSchema, strictParseOptions)
 const decodeDecisionInput = Schema.decodeUnknownEffect(DecisionInputSchema, strictParseOptions)
 const decodeBlockInput = Schema.decodeUnknownEffect(BlockInputSchema, strictParseOptions)
@@ -262,6 +284,29 @@ const selectCycle = (
       `
   return rows.pipe(Effect.flatMap(decodeRows))
 }
+
+const selectCycleByAuthoritySlot = (
+  sql: PgClient.PgClient,
+  slot: CycleAuthoritySlot,
+): Effect.Effect<readonly AutonomousCycle[], unknown> =>
+  sql<Record<string, unknown>>`
+    SELECT
+      cycle_id, schema_version, identity_schema_version, strategy_name,
+      qualification_run_id, strategy_protocol_hash, account_id,
+      signal_session_date::text AS signal_session_date, signal_calendar_version,
+      execution_policy_schema_version, execution_policy_hash,
+      strategy_execution_model_hash, submission_window_ms, submission_cutoff_before_open_ms,
+      window_schema_version, execution_calendar_schema_version,
+      execution_calendar_source, execution_calendar_hash,
+      execution_session_date::text AS execution_session_date,
+      signal_close_at, publication_deadline_at, submission_open_at,
+      execution_open_at, execution_close_at, submission_cutoff_at, state, snapshot_id,
+      decision_hash, terminal_reason, state_version, created_at, updated_at, terminal_at
+    FROM autonomous_cycles
+    WHERE qualification_run_id = ${slot.qualificationRunId}
+      AND account_id = ${slot.accountId}
+      AND signal_session_date = ${slot.signalSessionDate}
+  `.pipe(Effect.flatMap(decodeRows))
 
 const exactlyOne = (
   operation: CycleStoreError['operation'],
@@ -435,6 +480,22 @@ const makeCycleStore = Effect.gen(function* () {
         Effect.flatMap((decodedId) => selectCycle(sql, decodedId, false)),
         Effect.flatMap((rows) => {
           if (rows.length > 1) return fail('read', 'invariant', 'cycle identity returned multiple rows')
+          return Effect.succeed(rows[0] === undefined ? Option.none() : Option.some(rows[0]))
+        }),
+      ),
+    )
+
+  const readAuthoritySlot = (
+    slot: CycleAuthoritySlot,
+  ): Effect.Effect<Option.Option<AutonomousCycle>, CycleStoreError> =>
+    run(
+      'read-authority-slot',
+      decodeCycleAuthoritySlot(slot).pipe(
+        Effect.flatMap((decoded) => selectCycleByAuthoritySlot(sql, decoded)),
+        Effect.flatMap((rows) => {
+          if (rows.length > 1) {
+            return fail('read-authority-slot', 'invariant', 'cycle authority slot returned multiple rows')
+          }
           return Effect.succeed(rows[0] === undefined ? Option.none() : Option.some(rows[0]))
         }),
       ),
@@ -636,7 +697,7 @@ const makeCycleStore = Effect.gen(function* () {
       ),
     )
 
-  return { acquire, read, bindSnapshot, activate, bindDecision, block } satisfies CycleStoreShape
+  return { acquire, read, readAuthoritySlot, bindSnapshot, activate, bindDecision, block } satisfies CycleStoreShape
 })
 
 export const CycleStoreLive = Layer.effect(CycleStore, makeCycleStore)

--- a/services/bayn/src/health.test.ts
+++ b/services/bayn/src/health.test.ts
@@ -86,6 +86,9 @@ describe('Bayn continuous health', () => {
         Effect.provideService(MarketData, {
           check: Effect.succeed(makeSnapshot().manifest.finalizedSnapshot),
           inspect: Effect.die(new Error('health probes must not inspect sessions')),
+          inspectCyclePublications: Effect.die(
+            new Error('health probes must not inspect cycle publication candidates'),
+          ),
           inspectPublication: () => Effect.die(new Error('health probes must not inspect cycle publications')),
           inspectSnapshotPublication: () =>
             Effect.die(new Error('health probes must not inspect bound cycle publications')),
@@ -140,6 +143,7 @@ describe('Bayn continuous health', () => {
           : Effect.die(new Error('Signal connection defect')),
       ),
       inspect: Effect.die(new Error('health probes must not inspect sessions')),
+      inspectCyclePublications: Effect.die(new Error('health probes must not inspect cycle publication candidates')),
       inspectPublication: () => Effect.die(new Error('health probes must not inspect cycle publications')),
       inspectSnapshotPublication: () =>
         Effect.die(new Error('health probes must not inspect bound cycle publications')),
@@ -224,6 +228,7 @@ describe('Bayn continuous health', () => {
         return makeSnapshot().manifest.finalizedSnapshot
       }),
       inspect: Effect.die(new Error('health monitor must not inspect sessions')),
+      inspectCyclePublications: Effect.die(new Error('health monitor must not inspect cycle publication candidates')),
       inspectPublication: () => Effect.die(new Error('health monitor must not inspect cycle publications')),
       inspectSnapshotPublication: () =>
         Effect.die(new Error('health monitor must not inspect bound cycle publications')),
@@ -263,6 +268,7 @@ describe('Bayn continuous health', () => {
         Effect.onInterrupt(() => Effect.sync(() => void (interrupted = true))),
       ),
       inspect: Effect.die(new Error('health monitor must not inspect sessions')),
+      inspectCyclePublications: Effect.die(new Error('health monitor must not inspect cycle publication candidates')),
       inspectPublication: () => Effect.die(new Error('health monitor must not inspect cycle publications')),
       inspectSnapshotPublication: () =>
         Effect.die(new Error('health monitor must not inspect bound cycle publications')),
@@ -313,6 +319,9 @@ describe('Bayn continuous health', () => {
         Effect.provideService(MarketData, {
           check: Effect.succeed(makeSnapshot().manifest.finalizedSnapshot),
           inspect: Effect.die(new Error('health probes must not inspect sessions')),
+          inspectCyclePublications: Effect.die(
+            new Error('health probes must not inspect cycle publication candidates'),
+          ),
           inspectPublication: () => Effect.die(new Error('health probes must not inspect cycle publications')),
           inspectSnapshotPublication: () =>
             Effect.die(new Error('health probes must not inspect bound cycle publications')),

--- a/services/bayn/src/market-data.test.ts
+++ b/services/bayn/src/market-data.test.ts
@@ -221,7 +221,63 @@ const makePublicationRevision = (
   }
 }
 
+const makeLaterPublication = (
+  fixture: ReturnType<typeof makeFixture>,
+): {
+  readonly manifest: SignalManifestRow
+  readonly sessions: readonly SignalSessionRow[]
+} => {
+  const source = fixture.rows.manifests[0]
+  const sessionMaterial = [
+    ...fixture.rows.sessions.map(({ snapshot_id: _, ...session }) => session),
+    {
+      calendar_version: source.calendar_version,
+      session_date: '2025-01-31',
+      open_time: '09:30',
+      close_time: '16:00',
+      timezone: 'America/New_York',
+      provider: source.provider,
+    },
+  ] as const
+  const sessionsContentHash = canonicalHashV1(sessionMaterial)
+  const barsContentHash = '4'.repeat(64)
+  const snapshotId = canonicalHashV1({
+    schemaVersion: source.schema_version,
+    provider: source.provider,
+    feed: source.source_feed,
+    adjustment: source.adjustment,
+    calendarVersion: source.calendar_version,
+    requestedStart: source.requested_start,
+    publicationAsOf: '2025-01-31',
+    symbols,
+    barsContentHash,
+    sessionsContentHash,
+    universeId: source.universe_id,
+    universeSymbolHash: source.universe_symbol_hash,
+  })
+  const { manifest_content_hash: _, ...sourceWithoutManifestHash } = source
+  const manifestMaterial = {
+    ...sourceWithoutManifestHash,
+    snapshot_id: snapshotId,
+    publication_asof: '2025-01-31',
+    last_session: '2025-01-31',
+    session_count: sessionMaterial.length,
+    bar_count: sessionMaterial.length * symbols.length,
+    bars_content_hash: barsContentHash,
+    sessions_content_hash: sessionsContentHash,
+    finalized_at: '2025-02-01 01:00:00.000',
+  } as const
+  return {
+    manifest: {
+      ...manifestMaterial,
+      manifest_content_hash: canonicalHashV1(manifestMaterial),
+    },
+    sessions: sessionMaterial.map((session) => ({ snapshot_id: snapshotId, ...session })),
+  }
+}
+
 interface CapturedQuery {
+  readonly kind: 'bars' | 'manifest' | 'sessions'
   readonly text: string
   readonly parameters: readonly unknown[]
 }
@@ -243,20 +299,41 @@ const makeClickhouseFixture = (
       const text = strings.join('?')
       const parameters = fragments.map((fragment) => fragment.value)
       if (text.includes('FROM signal.snapshot_manifests_v2') && text.includes('WHERE universe_id')) {
-        queries.push({ text, parameters })
+        queries.push({ kind: 'manifest', text, parameters })
         const calendarVersion = parameters.at(-1)
-        return text.includes('AND calendar_version =')
+        const matching = text.includes('AND calendar_version =')
           ? manifests.filter((manifest) => manifest.calendar_version === calendarVersion)
           : manifests
+        if (!text.includes('ORDER BY publication_asof DESC')) return matching
+        const ordered = [...matching].sort((left, right) => {
+          if (left.publication_asof !== right.publication_asof) {
+            return right.publication_asof.localeCompare(left.publication_asof)
+          }
+          if (left.finalized_at !== right.finalized_at) return right.finalized_at.localeCompare(left.finalized_at)
+          return right.snapshot_id.localeCompare(left.snapshot_id)
+        })
+        const limit = Number(parameters.at(-1))
+        const publicationDates = new Set<string>()
+        return ordered.filter((manifest) => {
+          if (publicationDates.has(manifest.publication_asof) || publicationDates.size >= limit) return false
+          publicationDates.add(manifest.publication_asof)
+          return true
+        })
       }
       if (text.includes('FROM signal.snapshot_manifests_v2') && text.includes('WHERE snapshot_id')) {
-        queries.push({ text, parameters })
+        queries.push({ kind: 'manifest', text, parameters })
         const requestedSnapshotId = parameters[0]
         return manifests.filter((manifest) => manifest.snapshot_id === requestedSnapshotId)
       }
       if (text.includes('FROM signal.exchange_sessions_v1')) {
-        const requestedSnapshotId = parameters[0]
-        return sessions.filter((session) => session.snapshot_id === requestedSnapshotId)
+        queries.push({ kind: 'sessions', text, parameters })
+        const requestedSnapshotIds = parameters[0]
+        return Array.isArray(requestedSnapshotIds)
+          ? sessions.filter((session) => requestedSnapshotIds.includes(session.snapshot_id))
+          : sessions.filter((session) => session.snapshot_id === requestedSnapshotIds)
+      }
+      if (text.includes('FROM signal.adjusted_daily_bars_v2')) {
+        queries.push({ kind: 'bars', text, parameters })
       }
       return []
     })
@@ -531,11 +608,88 @@ describe('finalized Signal snapshot reader', () => {
       throw new Error('both exact-calendar publication reads must be finalized')
     }
     expect(results[1].inspection).toEqual(results[0].inspection)
-    expect(queries).toHaveLength(2)
-    for (const query of queries) {
+    const manifestQueries = queries.filter((query) => query.kind === 'manifest')
+    expect(manifestQueries).toHaveLength(2)
+    expect(queries.filter((query) => query.kind === 'sessions')).toHaveLength(2)
+    expect(queries.filter((query) => query.kind === 'bars')).toHaveLength(0)
+    for (const query of manifestQueries) {
       expect(query.text).toContain('AND calendar_version =')
       expect(query.parameters).toContain(fixture.request.calendarVersion)
     }
+  })
+
+  test('discovers bounded exact finalized publications without using pinned snapshot or publication dates', async () => {
+    const fixture = makeFixture()
+    const latest = makeLaterPublication(fixture)
+    const queries: CapturedQuery[] = []
+    const client = makeClickhouseFixture(
+      [...fixture.rows.manifests, latest.manifest],
+      [...fixture.rows.sessions, ...latest.sessions],
+      queries,
+    )
+    const layer = MarketDataLive(
+      {
+        operationTimeoutMs: 5_000,
+        clickhouse: {
+          url: 'http://clickhouse.test:8123',
+          username: 'bayn',
+          password: Redacted.make('secret'),
+          snapshotId,
+          publicationAsOf: fixture.request.publicationAsOf,
+          calendarVersion: fixture.request.calendarVersion,
+          bounds: fixture.request.bounds,
+        },
+      },
+      {
+        universeId: fixture.request.universeId,
+        universeSymbolHash: fixture.request.universeSymbolHash,
+        universe: fixture.request.universe,
+        historyStart: fixture.request.historyStart,
+        evaluationStart: fixture.request.evaluationStart,
+      },
+    ).pipe(Layer.provide(Layer.succeed(ClickhouseClient.ClickhouseClient, client)))
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const marketData = yield* MarketData
+        return yield* marketData.inspectCyclePublications
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(result.outcome).toBe('FINALIZED')
+    if (result.outcome !== 'FINALIZED') throw new Error('publication fixture must be finalized')
+    expect(result.publications[0]).toMatchObject({
+      manifest: {
+        finalizedSnapshot: {
+          snapshotId: latest.manifest.snapshot_id,
+          asOfSession: '2025-01-31',
+          calendarVersion: fixture.request.calendarVersion,
+        },
+      },
+      signalSession: {
+        session_date: '2025-01-31',
+        calendar_version: fixture.request.calendarVersion,
+        close_time: '16:00',
+        timezone: 'America/New_York',
+      },
+    })
+    expect(result.publications.map((publication) => publication.signalSession.session_date)).toEqual([
+      '2025-01-31',
+      '2025-01-03',
+    ])
+    const manifestQueries = queries.filter((query) => query.kind === 'manifest')
+    const sessionQueries = queries.filter((query) => query.kind === 'sessions')
+    expect(manifestQueries).toHaveLength(1)
+    expect(sessionQueries).toHaveLength(1)
+    expect(queries.filter((query) => query.kind === 'bars')).toHaveLength(0)
+    expect(manifestQueries[0]?.text).toContain('AND universe_symbol_hash =')
+    expect(manifestQueries[0]?.text).toContain('ORDER BY publication_asof DESC, finalized_at DESC, snapshot_id DESC')
+    expect(manifestQueries[0]?.text).toContain('LIMIT 1 BY publication_asof')
+    expect(manifestQueries[0]?.text).toContain('LIMIT ?')
+    expect(manifestQueries[0]?.parameters).not.toContain(snapshotId)
+    expect(manifestQueries[0]?.parameters).not.toContain(fixture.request.publicationAsOf)
+    expect(sessionQueries[0]?.text).toContain('WHERE has(')
+    expect(sessionQueries[0]?.parameters).toEqual([[latest.manifest.snapshot_id, snapshotId]])
   })
 
   test('re-reads an immutable bound snapshot after a corrected snapshot is finalized under the same keys', async () => {
@@ -598,13 +752,16 @@ describe('finalized Signal snapshot reader', () => {
       throw new Error('the immutable original snapshot must remain directly readable')
     }
     expect(results.originalReadback.inspection).toEqual(results.original.inspection)
-    expect(queries).toHaveLength(3)
-    expect(queries.map((query) => query.parameters[0])).toEqual([
+    const manifestQueries = queries.filter((query) => query.kind === 'manifest')
+    expect(manifestQueries).toHaveLength(3)
+    expect(queries.filter((query) => query.kind === 'sessions')).toHaveLength(3)
+    expect(queries.filter((query) => query.kind === 'bars')).toHaveLength(0)
+    expect(manifestQueries.map((query) => query.parameters[0])).toEqual([
       snapshotId,
       correction.manifest.snapshot_id,
       snapshotId,
     ])
-    expect(queries.every((query) => query.text.includes('WHERE snapshot_id ='))).toBe(true)
+    expect(manifestQueries.every((query) => query.text.includes('WHERE snapshot_id ='))).toBe(true)
   })
 
   test('rejects duplicate manifests, sessions, and bars', () => {

--- a/services/bayn/src/market-data.ts
+++ b/services/bayn/src/market-data.ts
@@ -36,6 +36,9 @@ const tables = {
   manifests: 'snapshot_manifests_v2',
 } as const
 const calendarTimeZone = 'America/New_York' as const
+// A 21-calendar-day catch-up interval contains at most 15 weekday publications. One extra bounded row keeps the
+// MarketData seam complete while the runner clamps by calendar date before its single broker-calendar read.
+const cyclePublicationCandidateLimit = 16
 const SnapshotIdSchema = HashSchema
 const FixedDecimalSchema = Schema.String.check(Schema.isPattern(/^(?:0|[1-9]\d*)\.\d{8}$/))
 const MarketTimeSchema = Schema.String.check(Schema.isPattern(/^(?:0\d|1\d|2[0-3]):[0-5]\d$/))
@@ -168,9 +171,21 @@ export type FinalizedPublicationInspection =
       readonly inspection: MarketDataInspection
     }
 
+export type FinalizedPublicationDiscovery =
+  | {
+      readonly outcome: 'MISSING'
+      readonly observedAt: string
+    }
+  | {
+      readonly outcome: 'FINALIZED'
+      readonly observedAt: string
+      readonly publications: readonly MarketDataInspection[]
+    }
+
 export interface MarketDataService {
   readonly check: Effect.Effect<FinalizedSnapshotProvenance, OperationalError>
   readonly inspect: Effect.Effect<MarketDataInspection, OperationalError>
+  readonly inspectCyclePublications: Effect.Effect<FinalizedPublicationDiscovery, OperationalError>
   readonly inspectPublication: (
     request: FinalizedPublicationRequest,
   ) => Effect.Effect<FinalizedPublicationInspection, OperationalError>
@@ -678,6 +693,39 @@ const makeMarketData = (
         ORDER BY snapshot_id, finalized_at
       `.pipe(sql.withQueryId(`bayn-cycle-manifest-${request.signalSessionDate}`))
 
+    const loadCyclePublicationManifests = sql`
+      SELECT
+        snapshot_id,
+        schema_version,
+        publisher_source_revision,
+        publisher_image_repository,
+        publisher_image_digest,
+        universe_id,
+        universe_symbol_hash,
+        provider,
+        source_feed,
+        adjustment,
+        calendar_version,
+        toString(requested_start) AS requested_start,
+        toString(publication_asof) AS publication_asof,
+        toString(first_session) AS first_session,
+        toString(last_session) AS last_session,
+        symbol_count,
+        session_count,
+        bar_count,
+        bars_content_hash,
+        sessions_content_hash,
+        manifest_content_hash,
+        toString(finalized_at) AS finalized_at
+      FROM signal.snapshot_manifests_v2
+      WHERE universe_id = ${sql.param('String', contract.universeId)}
+        AND universe_symbol_hash = ${sql.param('String', contract.universeSymbolHash)}
+        AND requested_start = toDate(${sql.param('String', contract.historyStart)})
+      ORDER BY publication_asof DESC, finalized_at DESC, snapshot_id DESC
+      LIMIT 1 BY publication_asof
+      LIMIT ${sql.param('UInt8', cyclePublicationCandidateLimit)}
+    `.pipe(sql.withQueryId('bayn-cycle-publication-candidates'))
+
     const loadSnapshotPublicationManifest = (request: SnapshotPublicationRequest) =>
       sql`
         SELECT
@@ -722,6 +770,21 @@ const makeMarketData = (
         WHERE snapshot_id = ${sql.param('String', snapshotId)}
         ORDER BY session_date
       `.pipe(sql.withQueryId(`bayn-cycle-sessions-${snapshotId.slice(-32)}`))
+
+    const loadCyclePublicationSessions = (snapshotIds: readonly string[]) =>
+      sql`
+        SELECT
+          snapshot_id,
+          calendar_version,
+          toString(session_date) AS session_date,
+          open_time,
+          close_time,
+          timezone,
+          provider
+        FROM signal.exchange_sessions_v1
+        WHERE has(${sql.param('Array(String)', snapshotIds)}, snapshot_id)
+        ORDER BY snapshot_id, session_date
+      `.pipe(sql.withQueryId('bayn-cycle-publication-candidate-sessions'))
 
     const request = (observedAt: string): SnapshotRequest => {
       const common = {
@@ -792,6 +855,71 @@ const makeMarketData = (
         return { outcome: 'FINALIZED', observedAt: inspectedAt, inspection } as const
       })
 
+    const inspectCyclePublicationRows = (manifestRows: readonly unknown[]) =>
+      Effect.gen(function* () {
+        const manifests = yield* verify('inspect-publication', () => decodeSnapshotRows([], [], manifestRows).manifests)
+        if (manifests.length === 0) {
+          const observedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
+          return { outcome: 'MISSING', observedAt } as const
+        }
+        if (manifests.length > cyclePublicationCandidateLimit) {
+          return yield* verify('inspect-publication', () => {
+            throw new Error(
+              `cycle publication discovery returned ${manifests.length} manifests; expected at most ${cyclePublicationCandidateLimit}`,
+            )
+          })
+        }
+        const ordered = [...manifests].sort((left, right) => {
+          if (left.publication_asof !== right.publication_asof) {
+            return right.publication_asof.localeCompare(left.publication_asof)
+          }
+          if (left.finalized_at !== right.finalized_at) return right.finalized_at.localeCompare(left.finalized_at)
+          return right.snapshot_id.localeCompare(left.snapshot_id)
+        })
+        const publicationDates = new Set<string>()
+        for (const manifest of ordered) {
+          if (publicationDates.has(manifest.publication_asof)) {
+            return yield* verify('inspect-publication', () => {
+              throw new Error(`cycle publication discovery returned duplicate date ${manifest.publication_asof}`)
+            })
+          }
+          publicationDates.add(manifest.publication_asof)
+        }
+        const snapshotIds = ordered.map((manifest) => manifest.snapshot_id)
+        const sessionRows = yield* loadCyclePublicationSessions(snapshotIds)
+        const inspectedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
+        const publications = yield* verify('inspect-publication', () => {
+          const sessions = decodeSnapshotRows([], sessionRows, []).sessions
+          const expectedSnapshotIds = new Set(snapshotIds)
+          if (sessions.some((session) => !expectedSnapshotIds.has(session.snapshot_id))) {
+            throw new Error('cycle publication session query returned an unexpected snapshot ID')
+          }
+          return ordered.map((manifest) => {
+            const inspection = verifyFinalizedPublication(
+              {
+                manifests: [manifest],
+                sessions: sessions.filter((session) => session.snapshot_id === manifest.snapshot_id),
+              },
+              {
+                signalSessionDate: manifest.publication_asof,
+                signalCalendarVersion: manifest.calendar_version,
+              },
+              contract,
+              inspectedAt,
+            )
+            if (inspection === undefined) {
+              throw new Error(`cycle publication ${manifest.snapshot_id} disappeared before verification`)
+            }
+            return inspection
+          })
+        })
+        return {
+          outcome: 'FINALIZED',
+          observedAt: inspectedAt,
+          publications,
+        } as const
+      })
+
     return {
       check: Effect.gen(function* () {
         const observedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
@@ -812,6 +940,16 @@ const makeMarketData = (
       }).pipe(
         Effect.mapError((cause) =>
           marketDataOperationError('inspect', 'failed to inspect finalized Signal calendar', cause),
+        ),
+      ),
+      inspectCyclePublications: loadCyclePublicationManifests.pipe(
+        Effect.flatMap(inspectCyclePublicationRows),
+        Effect.mapError((cause) =>
+          marketDataOperationError(
+            'inspect-publication',
+            'failed to inspect bounded finalized Signal publication candidates',
+            cause,
+          ),
         ),
       ),
       inspectPublication: (input) =>

--- a/services/bayn/src/resources.test.ts
+++ b/services/bayn/src/resources.test.ts
@@ -82,6 +82,7 @@ const marketDataService = (load: MarketDataService['load']): MarketDataService =
       },
     }
   }),
+  inspectCyclePublications: Effect.die(new Error('resource lifecycle must not inspect cycle publication candidates')),
   inspectPublication: () => Effect.die(new Error('resource lifecycle must not inspect cycle publications')),
   inspectSnapshotPublication: () =>
     Effect.die(new Error('resource lifecycle must not inspect bound cycle publications')),

--- a/services/bayn/src/startup.test.ts
+++ b/services/bayn/src/startup.test.ts
@@ -71,6 +71,7 @@ describe('Bayn startup lifecycle', () => {
         Effect.provideService(MarketData, {
           check: forbidden('pinned startup must not check Signal'),
           inspect: forbidden('pinned startup must not inspect Signal'),
+          inspectCyclePublications: forbidden('pinned startup must not inspect cycle publication candidates'),
           inspectPublication: () => forbidden('pinned startup must not inspect a cycle publication'),
           inspectSnapshotPublication: () => forbidden('pinned startup must not inspect a bound cycle publication'),
           load: forbidden('pinned startup must not load Signal bars'),


### PR DESCRIPTION
## Summary

- Discover a bounded newest-first batch of corrected-per-session finalized Signal publications, verifying every selected manifest and terminal session without reading bars.
- Clamp discovery to the newest 21 calendar days and use one bounded Alpaca calendar observation to select an unacquired due month-end even when newer ordinary daily publications exist.
- Preserve exact authority-slot idempotency: resume an unbound acquire/bind crash, keep a bound cycle immutable, and persist late catch-up as the existing precise missed-publication block.
- Keep the one scoped Effect loop alive across typed pass failures by logging, catching to void, and continuing the existing spaced schedule.
- Preserve OBSERVE-only zero mutation and leave application composition, config, health/status production wiring, protocol/risk, decision persistence, and GitOps out of this slice.

## Related Issues

PROOMPT-380 owns this reusable bounded due-publication discovery/acquire/bind seam. PROOMPT-381 owns exact publication readiness. Both remain In Progress until real application composition and live OBSERVE evidence.

PROOMPT-383 now owns only recovery-first ordering/composition: resume the oldest already-acquired unfinished cycle before invoking this seam, without duplicating catch-up or calendar selection.

## Testing

- bunx oxfmt --check src
- bun run lint:oxlint
- bun run lint:oxlint:type
- bun run tsc
- bun run build
- bun test src/market-data.test.ts src/cycle-readiness.test.ts src/cycle-runner.test.ts (35 passed)
- bun test (303 passed, 62 PostgreSQL tests skipped by default)
- BAYN_TEST_POSTGRES_URL=<local bayn_test URL> bun test src/db/cycle-store.integration.test.ts (9 passed)

## Breaking Changes

None externally. The unmerged internal MarketData seam is finalized as inspectCyclePublications, replacing the insufficient latest-only draft; all in-repository providers are updated. Lane B application composition remains a separate follow-up.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; no user interface changed.
- [x] Breaking Changes are documented.
- [x] PROOMPT-380/383 issue descriptions and implementation documents encode the single-owner discovery/recovery split.