### PR TITLE
fix(buzz): decouple release from cache export

### DIFF
--- a/.github/workflows/buzz-relay-build-push.yml
+++ b/.github/workflows/buzz-relay-build-push.yml
@@ -124,7 +124,6 @@ jobs:
             LAB_GIT_SHA=${{ github.sha }}
             UPSTREAM_IMAGE=${{ matrix.upstream_image }}
           cache-from: type=registry,ref=${{ env.IMAGE_REPOSITORY }}:cache-${{ matrix.architecture }}
-          cache-to: type=registry,ref=${{ env.IMAGE_REPOSITORY }}:cache-${{ matrix.architecture }},mode=max
 
   publish-index:
     if: github.event_name != 'pull_request'

--- a/packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts
+++ b/packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts
@@ -52,6 +52,7 @@ describe('Buzz production GitOps contract', () => {
     )
     expect(workflow).toContain('UPSTREAM_IMAGE=${{ matrix.upstream_image }}')
     expect(workflow.match(/driver-opts: network=host/g)).toHaveLength(2)
+    expect(workflow).not.toContain('cache-to:')
     expect(workflow).toContain('git -C upstream apply --check')
     expect(workflow).toContain('any(.manifests[]?; .platform.os == "linux"')
     expect(dockerfile).toContain('cargo test --release --locked -p buzz-relay api::git::store::tests:: --lib')


### PR DESCRIPTION
## Summary

- Remove registry cache export from the Buzz release build.
- Keep cache import as a best-effort acceleration without allowing cache publication to cancel a valid image push.
- Add a production contract preventing cache export from re-entering this release path.

## Related Issues

None

## Testing

- `actionlint .github/workflows/buzz-relay-build-push.yml`
- `bun test packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts`
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts`
- `git diff --check`
- Failure evidence: the prior release completed relay tests and compilation, then registry cache export returned HTTP 400 on a long layer upload and cancelled the concurrent image push.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.