### PR TITLE
feat(bayn): persist observe shadow decisions

### DIFF
--- a/services/bayn/migrations/0012_observe_shadow_decisions.ts
+++ b/services/bayn/migrations/0012_observe_shadow_decisions.ts
@@ -1,0 +1,85 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient
+
+  yield* sql`
+    DO $migration$
+    BEGIN
+      IF EXISTS (SELECT 1 FROM autonomous_cycles WHERE decision_hash IS NOT NULL) THEN
+        RAISE EXCEPTION 'shadow decision hard cut requires no preexisting autonomous cycle decision binding'
+          USING ERRCODE = '55000';
+      END IF;
+    END
+    $migration$
+  `
+
+  yield* sql`
+    CREATE TABLE autonomous_cycle_shadow_decisions (
+      cycle_id text PRIMARY KEY REFERENCES autonomous_cycles(cycle_id) ON DELETE RESTRICT
+        CHECK (cycle_id ~ '^[0-9a-f]{64}$'),
+      decision_hash text NOT NULL CHECK (decision_hash ~ '^[0-9a-f]{64}$'),
+      schema_version text NOT NULL CHECK (schema_version = 'bayn.observe-shadow-decision.v1'),
+      document jsonb NOT NULL CHECK (jsonb_typeof(document) = 'object'),
+      created_at timestamptz NOT NULL,
+      UNIQUE (cycle_id, decision_hash),
+      CHECK (
+        document ->> 'schemaVersion' = schema_version
+        AND document ->> 'mode' = 'OBSERVE'
+        AND document ->> 'dispatchable' = 'false'
+        AND document ->> 'contentHash' = decision_hash
+        AND document #>> '{bindings,cycleId}' = cycle_id
+        AND (document ->> 'createdAt')::timestamptz = created_at
+      )
+    )
+  `
+
+  yield* sql`
+    ALTER TABLE autonomous_cycles
+    ADD CONSTRAINT autonomous_cycles_shadow_decision_fk
+    FOREIGN KEY (cycle_id, decision_hash)
+    REFERENCES autonomous_cycle_shadow_decisions(cycle_id, decision_hash)
+    ON DELETE RESTRICT
+    DEFERRABLE INITIALLY DEFERRED
+  `
+
+  yield* sql`
+    CREATE FUNCTION enforce_autonomous_cycle_shadow_binding()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1
+        FROM autonomous_cycles
+        WHERE cycle_id = NEW.cycle_id
+          AND decision_hash = NEW.decision_hash
+      ) THEN
+        RAISE EXCEPTION 'shadow decision must bind atomically to its autonomous cycle'
+          USING ERRCODE = '23514';
+      END IF;
+      RETURN NEW;
+    END
+    $function$
+  `
+
+  yield* sql`
+    CREATE CONSTRAINT TRIGGER autonomous_cycle_shadow_decision_binding
+    AFTER INSERT ON autonomous_cycle_shadow_decisions
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION enforce_autonomous_cycle_shadow_binding()
+  `
+
+  yield* sql`
+    CREATE TRIGGER autonomous_cycle_shadow_decisions_append_only
+    BEFORE UPDATE OR DELETE ON autonomous_cycle_shadow_decisions
+    FOR EACH ROW EXECUTE FUNCTION reject_evidence_mutation()
+  `
+
+  yield* sql`
+    CREATE TRIGGER autonomous_cycle_shadow_decisions_reject_truncate
+    BEFORE TRUNCATE ON autonomous_cycle_shadow_decisions
+    FOR EACH STATEMENT EXECUTE FUNCTION reject_evidence_mutation()
+  `
+})

--- a/services/bayn/migrations/0012_observe_shadow_decisions.ts
+++ b/services/bayn/migrations/0012_observe_shadow_decisions.ts
@@ -19,16 +19,16 @@ export default Effect.gen(function* () {
     CREATE TABLE autonomous_cycle_shadow_decisions (
       cycle_id text PRIMARY KEY REFERENCES autonomous_cycles(cycle_id) ON DELETE RESTRICT
         CHECK (cycle_id ~ '^[0-9a-f]{64}$'),
-      decision_hash text NOT NULL CHECK (decision_hash ~ '^[0-9a-f]{64}$'),
       schema_version text NOT NULL CHECK (schema_version = 'bayn.observe-shadow-decision.v1'),
       document jsonb NOT NULL CHECK (jsonb_typeof(document) = 'object'),
+      decision_hash text GENERATED ALWAYS AS (document ->> 'contentHash') STORED NOT NULL
+        CHECK (decision_hash ~ '^[0-9a-f]{64}$'),
       created_at timestamptz NOT NULL,
       UNIQUE (cycle_id, decision_hash),
       CHECK (
         document ->> 'schemaVersion' = schema_version
         AND document ->> 'mode' = 'OBSERVE'
         AND document ->> 'dispatchable' = 'false'
-        AND document ->> 'contentHash' = decision_hash
         AND document #>> '{bindings,cycleId}' = cycle_id
         AND (document ->> 'createdAt')::timestamptz = created_at
       )

--- a/services/bayn/src/cycle-readiness.test.ts
+++ b/services/bayn/src/cycle-readiness.test.ts
@@ -173,6 +173,7 @@ const cycleStore = (control: StoreControl): CycleStoreShape => {
     acquire: unused,
     read: () => Effect.succeed(Option.some(control.current)),
     readAuthoritySlot: unused,
+    readDecisionDocument: unused,
     bindSnapshot: (_cycleId, inputManifest, observedAt) =>
       Effect.sync(() => {
         control.binds += 1

--- a/services/bayn/src/cycle-runner.test.ts
+++ b/services/bayn/src/cycle-runner.test.ts
@@ -279,6 +279,7 @@ const cycleStore = (control: StoreControl): CycleStoreShape => {
         const cycle = readCycle(cycleId)
         return cycle === undefined ? Option.none() : Option.some(cycle)
       }),
+    readDecisionDocument: unused,
     bindSnapshot: (cycleId, manifest, observedAt) =>
       Effect.sync(() => {
         control.binds += 1

--- a/services/bayn/src/cycle.ts
+++ b/services/bayn/src/cycle.ts
@@ -11,6 +11,7 @@ import {
   UtcInstantSchema,
   strictParseOptions,
 } from './schemas'
+import { ObserveShadowDecisionDocumentSchema } from './shadow-decision-contract'
 
 const cycleTimeZone = 'America/New_York' as const
 const SubmissionWindowMsSchema = PositiveIntegerSchema.check(Schema.isLessThanOrEqualTo(86_400_000))
@@ -287,6 +288,7 @@ export type CycleDraft = typeof CycleDraftSchema.Type
 const CycleBindingsSchema = Schema.Struct({
   snapshotId: Schema.optionalKey(Sha256Schema),
   decisionHash: Schema.optionalKey(Sha256Schema),
+  shadowDecision: Schema.optionalKey(ObserveShadowDecisionDocumentSchema),
 })
 export type CycleBindings = typeof CycleBindingsSchema.Type
 
@@ -309,6 +311,22 @@ export const AutonomousCycleSchema = AutonomousCycleBase.check(
     }
     if (cycle.bindings.decisionHash !== undefined && cycle.bindings.snapshotId === undefined) {
       issues.push({ path: ['bindings', 'decisionHash'], issue: 'requires a bound snapshot' })
+    }
+    if ((cycle.bindings.decisionHash === undefined) !== (cycle.bindings.shadowDecision === undefined)) {
+      issues.push({ path: ['bindings', 'shadowDecision'], issue: 'must be bound atomically with the decision hash' })
+    }
+    const shadowDecision = cycle.bindings.shadowDecision
+    if (
+      shadowDecision !== undefined &&
+      (shadowDecision.bindings.cycleId !== cycle.identity.cycleId ||
+        shadowDecision.bindings.strategyName !== cycle.identity.strategyName ||
+        shadowDecision.bindings.strategyProtocolHash !== cycle.identity.strategyProtocolHash ||
+        shadowDecision.bindings.snapshotId !== cycle.bindings.snapshotId ||
+        shadowDecision.contentHash !== cycle.bindings.decisionHash ||
+        shadowDecision.bindings.accountId !== cycle.identity.accountId ||
+        shadowDecision.submissionCutoffAt !== cycle.window.submissionCutoffAt)
+    ) {
+      issues.push({ path: ['bindings', 'shadowDecision'], issue: 'must match the autonomous cycle bindings' })
     }
 
     switch (cycle.state) {

--- a/services/bayn/src/cycle.ts
+++ b/services/bayn/src/cycle.ts
@@ -11,8 +11,6 @@ import {
   UtcInstantSchema,
   strictParseOptions,
 } from './schemas'
-import { ObserveShadowDecisionDocumentSchema } from './shadow-decision-contract'
-
 const cycleTimeZone = 'America/New_York' as const
 const SubmissionWindowMsSchema = PositiveIntegerSchema.check(Schema.isLessThanOrEqualTo(86_400_000))
 const maximumSubmissionDurationMs = 86_400_000
@@ -288,7 +286,6 @@ export type CycleDraft = typeof CycleDraftSchema.Type
 const CycleBindingsSchema = Schema.Struct({
   snapshotId: Schema.optionalKey(Sha256Schema),
   decisionHash: Schema.optionalKey(Sha256Schema),
-  shadowDecision: Schema.optionalKey(ObserveShadowDecisionDocumentSchema),
 })
 export type CycleBindings = typeof CycleBindingsSchema.Type
 
@@ -312,23 +309,6 @@ export const AutonomousCycleSchema = AutonomousCycleBase.check(
     if (cycle.bindings.decisionHash !== undefined && cycle.bindings.snapshotId === undefined) {
       issues.push({ path: ['bindings', 'decisionHash'], issue: 'requires a bound snapshot' })
     }
-    if ((cycle.bindings.decisionHash === undefined) !== (cycle.bindings.shadowDecision === undefined)) {
-      issues.push({ path: ['bindings', 'shadowDecision'], issue: 'must be bound atomically with the decision hash' })
-    }
-    const shadowDecision = cycle.bindings.shadowDecision
-    if (
-      shadowDecision !== undefined &&
-      (shadowDecision.bindings.cycleId !== cycle.identity.cycleId ||
-        shadowDecision.bindings.strategyName !== cycle.identity.strategyName ||
-        shadowDecision.bindings.strategyProtocolHash !== cycle.identity.strategyProtocolHash ||
-        shadowDecision.bindings.snapshotId !== cycle.bindings.snapshotId ||
-        shadowDecision.contentHash !== cycle.bindings.decisionHash ||
-        shadowDecision.bindings.accountId !== cycle.identity.accountId ||
-        shadowDecision.submissionCutoffAt !== cycle.window.submissionCutoffAt)
-    ) {
-      issues.push({ path: ['bindings', 'shadowDecision'], issue: 'must match the autonomous cycle bindings' })
-    }
-
     switch (cycle.state) {
       case CycleState.Pending:
         if (

--- a/services/bayn/src/db/cycle-store.integration.test.ts
+++ b/services/bayn/src/db/cycle-store.integration.test.ts
@@ -231,7 +231,6 @@ const makeShadowDecision = (
   draft: CycleDraft,
   boundSnapshotId: string,
   options: {
-    readonly accountSnapshotHash?: string
     readonly createdAt?: string
     readonly snapshotContentHash?: string
     readonly strategyDecisionHash?: string
@@ -267,7 +266,6 @@ const makeShadowDecision = (
       strategyDecisionHash: options.strategyDecisionHash ?? strategyDecisionHash,
       policyHash: '2'.repeat(64),
       accountId: draft.identity.accountId,
-      accountSnapshotHash: options.accountSnapshotHash ?? '3'.repeat(64),
       planningBrokerStateHash: reconciliation.observedHash,
       reconciliationId: reconciliation.reconciliationId,
       reconciliationHash: reconciliation.contentHash,
@@ -806,7 +804,7 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
   test('atomically binds one content-hashed shadow decision with replay and zero dispatch state', async () => {
     const draft = makeDraft('paper-account-shadow-binding')
     const document = makeShadowDecision(draft, snapshotA)
-    const divergent = makeShadowDecision(draft, snapshotA, { accountSnapshotHash: '7'.repeat(64) })
+    const divergent = makeShadowDecision(draft, snapshotA, { strategyDecisionHash: '7'.repeat(64) })
     const wrongSnapshot = makeShadowDecision(draft, snapshotA, { snapshotContentHash: '7'.repeat(64) })
     const missingDocumentDraft = makeDraft('paper-account-shadow-missing-document')
     const orphanDocumentDraft = makeDraft('paper-account-shadow-orphan-document')

--- a/services/bayn/src/db/cycle-store.integration.test.ts
+++ b/services/bayn/src/db/cycle-store.integration.test.ts
@@ -30,6 +30,9 @@ import {
   type MarketDataService,
   type SignalSessionRow,
 } from '../market-data'
+import { ReconciliationStatus } from '../paper'
+import { makeObserveShadowDecisionDocument } from '../shadow-decision-contract'
+import { TargetPlanReason, TargetPlanStatus } from '../target-planner'
 import { DataFeed, DataSource, PriceAdjustment, PublicationSchema, type InputManifest, type IsoDate } from '../types'
 import { CycleStore, CycleStoreLive } from './cycle-store'
 import { PostgresClientLive } from './evidence-store'
@@ -45,7 +48,7 @@ const staleSnapshot = '6'.repeat(64)
 const wrongCalendarSnapshot = '7'.repeat(64)
 const wrongAsOfSnapshot = '8'.repeat(64)
 const missingSnapshot = '9'.repeat(64)
-const decisionHash = 'f'.repeat(64)
+const strategyDecisionHash = 'f'.repeat(64)
 
 const databaseConfig = {
   operationTimeoutMs: 5_000,
@@ -201,6 +204,110 @@ const snapshotAt = '2026-03-06T21:02:00.000Z'
 const activeAt = '2026-03-06T21:03:00.000Z'
 const decisionAt = '2026-03-06T21:04:00.000Z'
 const terminalAt = '2026-03-06T21:05:00.000Z'
+
+const shadowReconciliation = (draft: CycleDraft) => {
+  const planningBrokerStateHash = '4'.repeat(64)
+  const material = {
+    schemaVersion: 'bayn.paper-reconciliation.v1' as const,
+    accountId: draft.identity.accountId,
+    expectedHash: planningBrokerStateHash,
+    observedHash: planningBrokerStateHash,
+    status: ReconciliationStatus.Exact,
+    discrepancies: [],
+    reconciledAt: snapshotAt,
+  }
+  const reconciliationId = canonicalHashV1({
+    schemaVersion: 'bayn.paper-reconciliation-id.v1',
+    material,
+  })
+  return {
+    ...material,
+    reconciliationId,
+    contentHash: canonicalHashV1({ ...material, reconciliationId }),
+  }
+}
+
+const makeShadowDecision = (
+  draft: CycleDraft,
+  boundSnapshotId: string,
+  options: {
+    readonly accountSnapshotHash?: string
+    readonly createdAt?: string
+    readonly snapshotContentHash?: string
+    readonly strategyDecisionHash?: string
+  } = {},
+) => {
+  const reconciliation = shadowReconciliation(draft)
+  const targetPlanMaterial = {
+    schemaVersion: 'bayn.paper-reference-target-plan.v1' as const,
+    inputHash: '1'.repeat(64),
+    status: TargetPlanStatus.NoTrade,
+    reason: TargetPlanReason.TargetsSatisfied,
+    targets: [],
+    intentTargets: [],
+    requiredReferenceBuyNotionalMicros: '0',
+    availableBuyingPowerMicros: '0',
+    residualBuyingPowerMicros: '0',
+  }
+  const targetPlan = {
+    ...targetPlanMaterial,
+    outputHash: canonicalHashV1(targetPlanMaterial),
+  }
+  return makeObserveShadowDecisionDocument({
+    schemaVersion: 'bayn.observe-shadow-decision.v1',
+    mode: 'OBSERVE',
+    dispatchable: false,
+    bindings: {
+      strategyName: draft.identity.strategyName,
+      cycleId: draft.identity.cycleId,
+      strategyProtocolHash: draft.identity.strategyProtocolHash,
+      snapshotId: boundSnapshotId,
+      snapshotContentHash: options.snapshotContentHash ?? boundSnapshotId,
+      snapshotFinalizedAt: acquireAt,
+      strategyDecisionHash: options.strategyDecisionHash ?? strategyDecisionHash,
+      policyHash: '2'.repeat(64),
+      accountId: draft.identity.accountId,
+      accountSnapshotHash: options.accountSnapshotHash ?? '3'.repeat(64),
+      planningBrokerStateHash: reconciliation.observedHash,
+      reconciliationId: reconciliation.reconciliationId,
+      reconciliationHash: reconciliation.contentHash,
+    },
+    targetPlan,
+    deltaRisk: [],
+    createdAt: options.createdAt ?? decisionAt,
+    submissionCutoffAt: draft.window.submissionCutoffAt,
+    expiresAt: draft.window.submissionCutoffAt,
+  })
+}
+
+const insertShadowReconciliation = (draft: CycleDraft) =>
+  Effect.gen(function* () {
+    const sql = yield* PgClient.PgClient
+    const reconciliation = shadowReconciliation(draft)
+    yield* sql`
+      INSERT INTO reconciliations (
+        reconciliation_id,
+        schema_version,
+        account_id,
+        expected_hash,
+        observed_hash,
+        content_hash,
+        status,
+        discrepancies,
+        reconciled_at
+      ) VALUES (
+        ${reconciliation.reconciliationId},
+        ${reconciliation.schemaVersion},
+        ${reconciliation.accountId},
+        ${reconciliation.expectedHash},
+        ${reconciliation.observedHash},
+        ${reconciliation.contentHash},
+        ${reconciliation.status},
+        '[]'::jsonb,
+        ${reconciliation.reconciledAt}
+      )
+    `
+  })
 
 const runnerContext = (accountId: string): CycleRunContext => ({
   qualificationRunId: 'a'.repeat(64),
@@ -696,15 +803,168 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
     })
   })
 
-  test('keeps completion unreachable and preserves blocked terminal history across runtimes', async () => {
-    const draft = makeDraft()
+  test('atomically binds one content-hashed shadow decision with replay and zero dispatch state', async () => {
+    const draft = makeDraft('paper-account-shadow-binding')
+    const document = makeShadowDecision(draft, snapshotA)
+    const divergent = makeShadowDecision(draft, snapshotA, { accountSnapshotHash: '7'.repeat(64) })
+    const wrongSnapshot = makeShadowDecision(draft, snapshotA, { snapshotContentHash: '7'.repeat(64) })
+    const missingDocumentDraft = makeDraft('paper-account-shadow-missing-document')
+    const orphanDocumentDraft = makeDraft('paper-account-shadow-orphan-document')
+    const orphanDocument = makeShadowDecision(orphanDocumentDraft, snapshotB)
+
     const result = await runtime.runPromise(
       Effect.gen(function* () {
         const store = yield* CycleStore
         yield* store.acquire(draft, acquireAt)
         yield* store.bindSnapshot(draft.identity.cycleId, makeInputManifest(snapshotA), snapshotAt)
         yield* store.activate(draft.identity.cycleId, activeAt)
-        yield* store.bindDecision(draft.identity.cycleId, decisionHash, decisionAt)
+
+        const missingEvidence = yield* Effect.exit(store.bindDecision(draft.identity.cycleId, document, decisionAt))
+        yield* insertShadowReconciliation(draft)
+        const wrongEvidence = yield* Effect.exit(store.bindDecision(draft.identity.cycleId, wrongSnapshot, decisionAt))
+        const bound = yield* store.bindDecision(draft.identity.cycleId, document, decisionAt)
+        const replay = yield* store.bindDecision(draft.identity.cycleId, structuredClone(document), decisionAt)
+        const authoritySlot = yield* store.readAuthoritySlot({
+          qualificationRunId: draft.identity.qualificationRunId,
+          accountId: draft.identity.accountId,
+          signalSessionDate: draft.identity.signalSessionDate,
+        })
+        const conflict = yield* Effect.exit(store.bindDecision(draft.identity.cycleId, divergent, decisionAt))
+
+        yield* store.acquire(missingDocumentDraft, acquireAt)
+        yield* store.bindSnapshot(missingDocumentDraft.identity.cycleId, makeInputManifest(snapshotA), snapshotAt)
+        yield* store.activate(missingDocumentDraft.identity.cycleId, activeAt)
+
+        yield* store.acquire(orphanDocumentDraft, acquireAt)
+        yield* store.bindSnapshot(orphanDocumentDraft.identity.cycleId, makeInputManifest(snapshotB), snapshotAt)
+        yield* store.activate(orphanDocumentDraft.identity.cycleId, activeAt)
+
+        const sql = yield* PgClient.PgClient
+        const missingDocument = yield* Effect.exit(
+          sql.withTransaction(sql`
+            UPDATE autonomous_cycles
+            SET
+              decision_hash = ${'8'.repeat(64)},
+              state_version = state_version + 1,
+              updated_at = ${decisionAt}
+            WHERE cycle_id = ${missingDocumentDraft.identity.cycleId}
+          `),
+        )
+        const orphanDocumentInsert = yield* Effect.exit(
+          sql.withTransaction(sql`
+            INSERT INTO autonomous_cycle_shadow_decisions (
+              cycle_id,
+              decision_hash,
+              schema_version,
+              document,
+              created_at
+            ) VALUES (
+              ${orphanDocumentDraft.identity.cycleId},
+              ${orphanDocument.contentHash},
+              ${orphanDocument.schemaVersion},
+              ${sql.json(orphanDocument)},
+              ${orphanDocument.createdAt}
+            )
+          `),
+        )
+        const directUpdate = yield* Effect.exit(sql`
+          UPDATE autonomous_cycle_shadow_decisions
+          SET document = ${sql.json(document)}
+          WHERE cycle_id = ${draft.identity.cycleId}
+        `)
+        const directDelete = yield* Effect.exit(sql`
+          DELETE FROM autonomous_cycle_shadow_decisions
+          WHERE cycle_id = ${draft.identity.cycleId}
+        `)
+        const directTruncate = yield* Effect.exit(sql`TRUNCATE autonomous_cycle_shadow_decisions`)
+        const rows = yield* sql<{
+          cycle_decision_hash: string
+          document_decision_hash: string
+          document: unknown
+        }>`
+          SELECT
+            cycle.decision_hash AS cycle_decision_hash,
+            shadow.decision_hash AS document_decision_hash,
+            shadow.document
+          FROM autonomous_cycles AS cycle
+          JOIN autonomous_cycle_shadow_decisions AS shadow USING (cycle_id)
+          WHERE cycle.cycle_id = ${draft.identity.cycleId}
+        `
+        const [counts] = yield* sql<{
+          intents: number
+          mutation_events: number
+          risk_decisions: number
+          shadow_decisions: number
+        }>`
+          SELECT
+            (SELECT count(*)::integer FROM autonomous_cycle_shadow_decisions) AS shadow_decisions,
+            (SELECT count(*)::integer FROM intents) AS intents,
+            (SELECT count(*)::integer FROM risk_decisions) AS risk_decisions,
+            (SELECT count(*)::integer FROM mutation_events) AS mutation_events
+        `
+        return {
+          authoritySlot,
+          bound,
+          conflict,
+          counts,
+          directDelete,
+          directTruncate,
+          directUpdate,
+          missingDocument,
+          missingEvidence,
+          orphanDocumentInsert,
+          replay,
+          rows,
+          wrongEvidence,
+        }
+      }),
+    )
+
+    expect(result.bound.changed).toBe(true)
+    expect(result.bound.cycle.bindings).toEqual({
+      snapshotId: snapshotA,
+      decisionHash: document.contentHash,
+      shadowDecision: document,
+    })
+    expect(result.replay.changed).toBe(false)
+    expect(result.replay.cycle).toEqual(result.bound.cycle)
+    expect(Option.isSome(result.authoritySlot)).toBe(true)
+    if (Option.isNone(result.authoritySlot)) throw new Error('bound authority slot must remain readable')
+    expect(result.authoritySlot.value).toEqual(result.bound.cycle)
+    expect(Exit.isFailure(result.conflict)).toBe(true)
+    expect(Exit.isFailure(result.missingEvidence)).toBe(true)
+    expect(Exit.isFailure(result.wrongEvidence)).toBe(true)
+    expect(Exit.isFailure(result.missingDocument)).toBe(true)
+    expect(Exit.isFailure(result.orphanDocumentInsert)).toBe(true)
+    expect(Exit.isFailure(result.directUpdate)).toBe(true)
+    expect(Exit.isFailure(result.directDelete)).toBe(true)
+    expect(Exit.isFailure(result.directTruncate)).toBe(true)
+    expect(result.rows).toEqual([
+      {
+        cycle_decision_hash: document.contentHash,
+        document_decision_hash: document.contentHash,
+        document,
+      },
+    ])
+    expect(result.counts).toEqual({
+      shadow_decisions: 1,
+      intents: 0,
+      risk_decisions: 0,
+      mutation_events: 0,
+    })
+  })
+
+  test('keeps completion unreachable and preserves blocked terminal history across runtimes', async () => {
+    const draft = makeDraft()
+    const shadowDecision = makeShadowDecision(draft, snapshotA)
+    const result = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* CycleStore
+        yield* store.acquire(draft, acquireAt)
+        yield* store.bindSnapshot(draft.identity.cycleId, makeInputManifest(snapshotA), snapshotAt)
+        yield* store.activate(draft.identity.cycleId, activeAt)
+        yield* insertShadowReconciliation(draft)
+        yield* store.bindDecision(draft.identity.cycleId, shadowDecision, decisionAt)
 
         const sql = yield* PgClient.PgClient
         const directCompleted = yield* Effect.exit(sql`
@@ -755,7 +1015,11 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
     expect(Exit.isFailure(result.directNoTrade)).toBe(true)
     expect(result.blocked.cycle).toMatchObject({
       state: CycleState.Blocked,
-      bindings: { snapshotId: snapshotA, decisionHash },
+      bindings: {
+        snapshotId: snapshotA,
+        decisionHash: shadowDecision.contentHash,
+        shadowDecision,
+      },
       terminalReason: CycleTerminalReason.DataStale,
       terminalAt,
     })
@@ -854,7 +1118,7 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
         yield* store.activate(decisionDraft.identity.cycleId, activeAt)
         const decisionAtCutoff = yield* store.bindDecision(
           decisionDraft.identity.cycleId,
-          decisionHash,
+          makeShadowDecision(decisionDraft, snapshotB),
           decisionDraft.window.submissionCutoffAt,
         )
 

--- a/services/bayn/src/db/cycle-store.integration.test.ts
+++ b/services/bayn/src/db/cycle-store.integration.test.ts
@@ -824,6 +824,7 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
         const wrongEvidence = yield* Effect.exit(store.bindDecision(draft.identity.cycleId, wrongSnapshot, decisionAt))
         const bound = yield* store.bindDecision(draft.identity.cycleId, document, decisionAt)
         const replay = yield* store.bindDecision(draft.identity.cycleId, structuredClone(document), decisionAt)
+        const storedDocument = yield* store.readDecisionDocument(draft.identity.cycleId)
         const authoritySlot = yield* store.readAuthoritySlot({
           qualificationRunId: draft.identity.qualificationRunId,
           accountId: draft.identity.accountId,
@@ -854,13 +855,11 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
           sql.withTransaction(sql`
             INSERT INTO autonomous_cycle_shadow_decisions (
               cycle_id,
-              decision_hash,
               schema_version,
               document,
               created_at
             ) VALUES (
               ${orphanDocumentDraft.identity.cycleId},
-              ${orphanDocument.contentHash},
               ${orphanDocument.schemaVersion},
               ${sql.json(orphanDocument)},
               ${orphanDocument.createdAt}
@@ -915,6 +914,7 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
           orphanDocumentInsert,
           replay,
           rows,
+          storedDocument,
           wrongEvidence,
         }
       }),
@@ -924,10 +924,12 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
     expect(result.bound.cycle.bindings).toEqual({
       snapshotId: snapshotA,
       decisionHash: document.contentHash,
-      shadowDecision: document,
     })
     expect(result.replay.changed).toBe(false)
     expect(result.replay.cycle).toEqual(result.bound.cycle)
+    expect(Option.isSome(result.storedDocument)).toBe(true)
+    if (Option.isNone(result.storedDocument)) throw new Error('bound decision document must remain readable')
+    expect(result.storedDocument.value).toEqual(document)
     expect(Option.isSome(result.authoritySlot)).toBe(true)
     if (Option.isNone(result.authoritySlot)) throw new Error('bound authority slot must remain readable')
     expect(result.authoritySlot.value).toEqual(result.bound.cycle)
@@ -1018,7 +1020,6 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
       bindings: {
         snapshotId: snapshotA,
         decisionHash: shadowDecision.contentHash,
-        shadowDecision,
       },
       terminalReason: CycleTerminalReason.DataStale,
       terminalAt,
@@ -1030,11 +1031,19 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
 
     const secondRuntime = makeRuntime()
     const durable = await secondRuntime.runPromise(
-      Effect.flatMap(CycleStore, (store) => store.read(draft.identity.cycleId)),
+      Effect.gen(function* () {
+        const store = yield* CycleStore
+        return {
+          cycle: yield* store.read(draft.identity.cycleId),
+          document: yield* store.readDecisionDocument(draft.identity.cycleId),
+        }
+      }),
     )
     await secondRuntime.dispose()
-    expect(Option.isSome(durable)).toBe(true)
-    if (Option.isSome(durable)) expect(durable.value).toEqual(result.blocked.cycle)
+    expect(Option.isSome(durable.cycle)).toBe(true)
+    if (Option.isSome(durable.cycle)) expect(durable.cycle.value).toEqual(result.blocked.cycle)
+    expect(Option.isSome(durable.document)).toBe(true)
+    if (Option.isSome(durable.document)) expect(durable.document.value).toEqual(shadowDecision)
   })
 
   test('enforces initial lifecycle state and distinct publication and submission deadlines', async () => {

--- a/services/bayn/src/db/cycle-store.ts
+++ b/services/bayn/src/db/cycle-store.ts
@@ -51,6 +51,7 @@ export class CycleStoreError extends Data.TaggedError('CycleStoreError')<{
     | 'block'
     | 'read'
     | 'read-authority-slot'
+    | 'read-decision-document'
   readonly failure: 'conflict' | 'decode' | 'invariant' | 'not-found' | 'query'
   readonly message: string
   readonly cause?: unknown
@@ -62,6 +63,9 @@ export interface CycleStoreShape {
   readonly readAuthoritySlot: (
     slot: CycleAuthoritySlot,
   ) => Effect.Effect<Option.Option<AutonomousCycle>, CycleStoreError>
+  readonly readDecisionDocument: (
+    cycleId: string,
+  ) => Effect.Effect<Option.Option<ObserveShadowDecisionDocument>, CycleStoreError>
   readonly bindSnapshot: (
     cycleId: string,
     inputManifest: InputManifest,
@@ -111,7 +115,6 @@ const StoredCycleRowSchema = Schema.Struct({
   state: Schema.Enum(CycleState),
   snapshot_id: Schema.NullOr(Sha256Schema),
   decision_hash: Schema.NullOr(Sha256Schema),
-  shadow_decision: Schema.NullOr(ObserveShadowDecisionDocumentSchema),
   terminal_reason: Schema.NullOr(Schema.Enum(CycleTerminalReason)),
   state_version: PositiveIntegerSchema,
   created_at: Schema.DateValid,
@@ -142,6 +145,7 @@ const BlockInputSchema = Schema.Struct({
 })
 const MutationRowsSchema = Schema.Array(Schema.Struct({ cycle_id: Sha256Schema })).check(Schema.isMaxLength(1))
 const DecisionEvidenceMatchSchema = Schema.Tuple([Schema.Struct({ matches: Schema.Boolean })])
+const StoredDecisionDocumentRowsSchema = Schema.Array(Schema.Struct({ document: ObserveShadowDecisionDocumentSchema }))
 
 const decodeStoredCycleRows = Schema.decodeUnknownEffect(Schema.Array(StoredCycleRowSchema), strictParseOptions)
 const decodeCycleIdInput = Schema.decodeUnknownEffect(CycleIdInputSchema, strictParseOptions)
@@ -152,6 +156,10 @@ const decodeBlockInput = Schema.decodeUnknownEffect(BlockInputSchema, strictPars
 const decodeCycleDraft = Schema.decodeUnknownEffect(CycleDraftSchema, strictParseOptions)
 const decodeMutationRows = Schema.decodeUnknownEffect(MutationRowsSchema, strictParseOptions)
 const decodeDecisionEvidenceMatch = Schema.decodeUnknownEffect(DecisionEvidenceMatchSchema, strictParseOptions)
+const decodeStoredDecisionDocumentRows = Schema.decodeUnknownEffect(
+  StoredDecisionDocumentRowsSchema,
+  strictParseOptions,
+)
 const shadowDecisionEquivalent = Schema.toEquivalence(ObserveShadowDecisionDocumentSchema)
 
 const messageOf = (cause: unknown): string => (cause instanceof Error ? cause.message : String(cause))
@@ -237,7 +245,6 @@ const rowToCycle = (row: StoredCycleRow): Effect.Effect<AutonomousCycle, Schema.
     bindings: {
       ...(row.snapshot_id === null ? {} : { snapshotId: row.snapshot_id }),
       ...(row.decision_hash === null ? {} : { decisionHash: row.decision_hash }),
-      ...(row.shadow_decision === null ? {} : { shadowDecision: row.shadow_decision }),
     },
     ...(row.terminal_reason === null ? {} : { terminalReason: row.terminal_reason }),
     stateVersion: row.state_version,
@@ -267,13 +274,7 @@ const selectCycle = (
           execution_session_date::text AS execution_session_date,
           signal_close_at, publication_deadline_at, submission_open_at,
           execution_open_at, execution_close_at, submission_cutoff_at, state, snapshot_id,
-          decision_hash,
-          (
-            SELECT document
-            FROM autonomous_cycle_shadow_decisions
-            WHERE cycle_id = autonomous_cycles.cycle_id
-          ) AS shadow_decision,
-          terminal_reason, state_version, created_at, updated_at, terminal_at
+          decision_hash, terminal_reason, state_version, created_at, updated_at, terminal_at
         FROM autonomous_cycles
         WHERE cycle_id = ${cycleId}
         FOR UPDATE
@@ -290,13 +291,7 @@ const selectCycle = (
           execution_session_date::text AS execution_session_date,
           signal_close_at, publication_deadline_at, submission_open_at,
           execution_open_at, execution_close_at, submission_cutoff_at, state, snapshot_id,
-          decision_hash,
-          (
-            SELECT document
-            FROM autonomous_cycle_shadow_decisions
-            WHERE cycle_id = autonomous_cycles.cycle_id
-          ) AS shadow_decision,
-          terminal_reason, state_version, created_at, updated_at, terminal_at
+          decision_hash, terminal_reason, state_version, created_at, updated_at, terminal_at
         FROM autonomous_cycles
         WHERE cycle_id = ${cycleId}
       `
@@ -319,18 +314,22 @@ const selectCycleByAuthoritySlot = (
       execution_session_date::text AS execution_session_date,
       signal_close_at, publication_deadline_at, submission_open_at,
       execution_open_at, execution_close_at, submission_cutoff_at, state, snapshot_id,
-      decision_hash,
-      (
-        SELECT document
-        FROM autonomous_cycle_shadow_decisions
-        WHERE cycle_id = autonomous_cycles.cycle_id
-      ) AS shadow_decision,
-      terminal_reason, state_version, created_at, updated_at, terminal_at
+      decision_hash, terminal_reason, state_version, created_at, updated_at, terminal_at
     FROM autonomous_cycles
     WHERE qualification_run_id = ${slot.qualificationRunId}
       AND account_id = ${slot.accountId}
       AND signal_session_date = ${slot.signalSessionDate}
   `.pipe(Effect.flatMap(decodeRows))
+
+const selectDecisionDocument = (
+  sql: PgClient.PgClient,
+  cycleId: string,
+): Effect.Effect<readonly { readonly document: ObserveShadowDecisionDocument }[], unknown> =>
+  sql<Record<string, unknown>>`
+    SELECT document
+    FROM autonomous_cycle_shadow_decisions
+    WHERE cycle_id = ${cycleId}
+  `.pipe(Effect.flatMap(decodeStoredDecisionDocumentRows))
 
 const exactlyOne = (
   operation: CycleStoreError['operation'],
@@ -547,6 +546,25 @@ const makeCycleStore = Effect.gen(function* () {
       ),
     )
 
+  const readDecisionDocument = (
+    cycleId: string,
+  ): Effect.Effect<Option.Option<ObserveShadowDecisionDocument>, CycleStoreError> =>
+    run(
+      'read-decision-document',
+      Schema.decodeUnknownEffect(
+        Sha256Schema,
+        strictParseOptions,
+      )(cycleId).pipe(
+        Effect.flatMap((decodedId) => selectDecisionDocument(sql, decodedId)),
+        Effect.flatMap((rows) => {
+          if (rows.length > 1) {
+            return fail('read-decision-document', 'invariant', 'cycle decision document returned multiple rows')
+          }
+          return Effect.succeed(rows[0] === undefined ? Option.none() : Option.some(rows[0].document))
+        }),
+      ),
+    )
+
   const persistSnapshotReference = (inputManifest: InputManifest): Effect.Effect<void, unknown> =>
     ensureSnapshotReference(sql, inputManifest).pipe(
       Effect.flatMap((matches) =>
@@ -690,10 +708,13 @@ const makeCycleStore = Effect.gen(function* () {
             Effect.gen(function* () {
               const cycle = yield* readLocked('bind-decision', input.cycleId)
               if (cycle.bindings.decisionHash !== undefined) {
+                const storedRows = yield* selectDecisionDocument(sql, input.cycleId)
+                const storedDocument = storedRows[0]?.document
                 if (
                   cycle.bindings.decisionHash !== input.document.contentHash ||
-                  cycle.bindings.shadowDecision === undefined ||
-                  !shadowDecisionEquivalent(cycle.bindings.shadowDecision, input.document)
+                  storedRows.length !== 1 ||
+                  storedDocument === undefined ||
+                  !shadowDecisionEquivalent(storedDocument, input.document)
                 ) {
                   return yield* fail('bind-decision', 'conflict', 'cycle decision binding cannot be replaced')
                 }
@@ -733,13 +754,11 @@ const makeCycleStore = Effect.gen(function* () {
               yield* sql`
                 INSERT INTO autonomous_cycle_shadow_decisions (
                   cycle_id,
-                  decision_hash,
                   schema_version,
                   document,
                   created_at
                 ) VALUES (
                   ${input.cycleId},
-                  ${input.document.contentHash},
                   ${input.document.schemaVersion},
                   ${sql.json(input.document)},
                   ${input.document.createdAt}
@@ -784,7 +803,16 @@ const makeCycleStore = Effect.gen(function* () {
       ),
     )
 
-  return { acquire, read, readAuthoritySlot, bindSnapshot, activate, bindDecision, block } satisfies CycleStoreShape
+  return {
+    acquire,
+    read,
+    readAuthoritySlot,
+    readDecisionDocument,
+    bindSnapshot,
+    activate,
+    bindDecision,
+    block,
+  } satisfies CycleStoreShape
 })
 
 export const CycleStoreLive = Layer.effect(CycleStore, makeCycleStore)

--- a/services/bayn/src/db/cycle-store.ts
+++ b/services/bayn/src/db/cycle-store.ts
@@ -22,6 +22,7 @@ import {
   UtcInstantSchema,
   strictParseOptions,
 } from '../schemas'
+import { ObserveShadowDecisionDocumentSchema, type ObserveShadowDecisionDocument } from '../shadow-decision-contract'
 import type { InputManifest, IsoDate } from '../types'
 import { ensureSnapshotReference } from './snapshot-reference'
 
@@ -69,7 +70,7 @@ export interface CycleStoreShape {
   readonly activate: (cycleId: string, observedAt: string) => Effect.Effect<CycleMutationReceipt, CycleStoreError>
   readonly bindDecision: (
     cycleId: string,
-    decisionHash: string,
+    document: ObserveShadowDecisionDocument,
     observedAt: string,
   ) => Effect.Effect<CycleMutationReceipt, CycleStoreError>
   readonly block: (
@@ -110,6 +111,7 @@ const StoredCycleRowSchema = Schema.Struct({
   state: Schema.Enum(CycleState),
   snapshot_id: Schema.NullOr(Sha256Schema),
   decision_hash: Schema.NullOr(Sha256Schema),
+  shadow_decision: Schema.NullOr(ObserveShadowDecisionDocumentSchema),
   terminal_reason: Schema.NullOr(Schema.Enum(CycleTerminalReason)),
   state_version: PositiveIntegerSchema,
   created_at: Schema.DateValid,
@@ -130,7 +132,7 @@ const SnapshotInputSchema = Schema.Struct({
 })
 const DecisionInputSchema = Schema.Struct({
   cycleId: Sha256Schema,
-  decisionHash: Sha256Schema,
+  document: ObserveShadowDecisionDocumentSchema,
   observedAt: UtcInstantSchema,
 })
 const BlockInputSchema = Schema.Struct({
@@ -139,6 +141,7 @@ const BlockInputSchema = Schema.Struct({
   observedAt: UtcInstantSchema,
 })
 const MutationRowsSchema = Schema.Array(Schema.Struct({ cycle_id: Sha256Schema })).check(Schema.isMaxLength(1))
+const DecisionEvidenceMatchSchema = Schema.Tuple([Schema.Struct({ matches: Schema.Boolean })])
 
 const decodeStoredCycleRows = Schema.decodeUnknownEffect(Schema.Array(StoredCycleRowSchema), strictParseOptions)
 const decodeCycleIdInput = Schema.decodeUnknownEffect(CycleIdInputSchema, strictParseOptions)
@@ -148,6 +151,8 @@ const decodeDecisionInput = Schema.decodeUnknownEffect(DecisionInputSchema, stri
 const decodeBlockInput = Schema.decodeUnknownEffect(BlockInputSchema, strictParseOptions)
 const decodeCycleDraft = Schema.decodeUnknownEffect(CycleDraftSchema, strictParseOptions)
 const decodeMutationRows = Schema.decodeUnknownEffect(MutationRowsSchema, strictParseOptions)
+const decodeDecisionEvidenceMatch = Schema.decodeUnknownEffect(DecisionEvidenceMatchSchema, strictParseOptions)
+const shadowDecisionEquivalent = Schema.toEquivalence(ObserveShadowDecisionDocumentSchema)
 
 const messageOf = (cause: unknown): string => (cause instanceof Error ? cause.message : String(cause))
 
@@ -232,6 +237,7 @@ const rowToCycle = (row: StoredCycleRow): Effect.Effect<AutonomousCycle, Schema.
     bindings: {
       ...(row.snapshot_id === null ? {} : { snapshotId: row.snapshot_id }),
       ...(row.decision_hash === null ? {} : { decisionHash: row.decision_hash }),
+      ...(row.shadow_decision === null ? {} : { shadowDecision: row.shadow_decision }),
     },
     ...(row.terminal_reason === null ? {} : { terminalReason: row.terminal_reason }),
     stateVersion: row.state_version,
@@ -261,7 +267,13 @@ const selectCycle = (
           execution_session_date::text AS execution_session_date,
           signal_close_at, publication_deadline_at, submission_open_at,
           execution_open_at, execution_close_at, submission_cutoff_at, state, snapshot_id,
-          decision_hash, terminal_reason, state_version, created_at, updated_at, terminal_at
+          decision_hash,
+          (
+            SELECT document
+            FROM autonomous_cycle_shadow_decisions
+            WHERE cycle_id = autonomous_cycles.cycle_id
+          ) AS shadow_decision,
+          terminal_reason, state_version, created_at, updated_at, terminal_at
         FROM autonomous_cycles
         WHERE cycle_id = ${cycleId}
         FOR UPDATE
@@ -278,7 +290,13 @@ const selectCycle = (
           execution_session_date::text AS execution_session_date,
           signal_close_at, publication_deadline_at, submission_open_at,
           execution_open_at, execution_close_at, submission_cutoff_at, state, snapshot_id,
-          decision_hash, terminal_reason, state_version, created_at, updated_at, terminal_at
+          decision_hash,
+          (
+            SELECT document
+            FROM autonomous_cycle_shadow_decisions
+            WHERE cycle_id = autonomous_cycles.cycle_id
+          ) AS shadow_decision,
+          terminal_reason, state_version, created_at, updated_at, terminal_at
         FROM autonomous_cycles
         WHERE cycle_id = ${cycleId}
       `
@@ -301,7 +319,13 @@ const selectCycleByAuthoritySlot = (
       execution_session_date::text AS execution_session_date,
       signal_close_at, publication_deadline_at, submission_open_at,
       execution_open_at, execution_close_at, submission_cutoff_at, state, snapshot_id,
-      decision_hash, terminal_reason, state_version, created_at, updated_at, terminal_at
+      decision_hash,
+      (
+        SELECT document
+        FROM autonomous_cycle_shadow_decisions
+        WHERE cycle_id = autonomous_cycles.cycle_id
+      ) AS shadow_decision,
+      terminal_reason, state_version, created_at, updated_at, terminal_at
     FROM autonomous_cycles
     WHERE qualification_run_id = ${slot.qualificationRunId}
       AND account_id = ${slot.accountId}
@@ -348,6 +372,28 @@ const makeCycleStore = Effect.gen(function* () {
           ? Effect.void
           : fail(operation, 'conflict', 'cycle changed concurrently before the conditional update'),
       ),
+    )
+
+  const decisionEvidenceMatches = (document: ObserveShadowDecisionDocument): Effect.Effect<boolean, unknown> =>
+    sql<Record<string, unknown>>`
+      SELECT EXISTS (
+        SELECT 1
+        FROM snapshot_references AS snapshot
+        CROSS JOIN reconciliations AS reconciliation
+        WHERE snapshot.snapshot_id = ${document.bindings.snapshotId}
+          AND snapshot.content_hash = ${document.bindings.snapshotContentHash}
+          AND snapshot.manifest ->> 'finalizedAt' = ${document.bindings.snapshotFinalizedAt}
+          AND reconciliation.reconciliation_id = ${document.bindings.reconciliationId}
+          AND reconciliation.account_id = ${document.bindings.accountId}
+          AND reconciliation.expected_hash = ${document.bindings.planningBrokerStateHash}
+          AND reconciliation.observed_hash = ${document.bindings.planningBrokerStateHash}
+          AND reconciliation.content_hash = ${document.bindings.reconciliationHash}
+          AND reconciliation.status = 'EXACT'
+          AND reconciliation.reconciled_at <= ${document.createdAt}
+      ) AS matches
+    `.pipe(
+      Effect.flatMap(decodeDecisionEvidenceMatch),
+      Effect.map(([match]) => match.matches),
     )
 
   const blockCycle = (
@@ -633,18 +679,22 @@ const makeCycleStore = Effect.gen(function* () {
 
   const bindDecision = (
     cycleId: string,
-    decisionHash: string,
+    document: ObserveShadowDecisionDocument,
     observedAt: string,
   ): Effect.Effect<CycleMutationReceipt, CycleStoreError> =>
     run(
       'bind-decision',
-      decodeDecisionInput({ cycleId, decisionHash, observedAt }).pipe(
+      decodeDecisionInput({ cycleId, document, observedAt }).pipe(
         Effect.flatMap((input) =>
           sql.withTransaction(
             Effect.gen(function* () {
               const cycle = yield* readLocked('bind-decision', input.cycleId)
               if (cycle.bindings.decisionHash !== undefined) {
-                if (cycle.bindings.decisionHash !== input.decisionHash) {
+                if (
+                  cycle.bindings.decisionHash !== input.document.contentHash ||
+                  cycle.bindings.shadowDecision === undefined ||
+                  !shadowDecisionEquivalent(cycle.bindings.shadowDecision, input.document)
+                ) {
                   return yield* fail('bind-decision', 'conflict', 'cycle decision binding cannot be replaced')
                 }
                 return { cycle, changed: false }
@@ -655,13 +705,50 @@ const makeCycleStore = Effect.gen(function* () {
               if (input.observedAt >= cycle.window.submissionCutoffAt) {
                 return yield* blockCycle('bind-decision', cycle, CycleTerminalReason.MissedSubmission, input.observedAt)
               }
+              if (
+                input.document.bindings.cycleId !== cycle.identity.cycleId ||
+                input.document.bindings.strategyName !== cycle.identity.strategyName ||
+                input.document.bindings.strategyProtocolHash !== cycle.identity.strategyProtocolHash ||
+                input.document.bindings.snapshotId !== cycle.bindings.snapshotId ||
+                input.document.bindings.accountId !== cycle.identity.accountId ||
+                input.document.submissionCutoffAt !== cycle.window.submissionCutoffAt ||
+                input.document.createdAt !== input.observedAt
+              ) {
+                return yield* fail(
+                  'bind-decision',
+                  'invariant',
+                  'shadow decision does not match the active autonomous cycle',
+                )
+              }
               if (input.observedAt < cycle.updatedAt) {
                 return yield* fail('bind-decision', 'conflict', 'cycle update time cannot move backward')
               }
+              if (!(yield* decisionEvidenceMatches(input.document))) {
+                return yield* fail(
+                  'bind-decision',
+                  'invariant',
+                  'shadow decision does not match the durable snapshot and exact reconciliation evidence',
+                )
+              }
+              yield* sql`
+                INSERT INTO autonomous_cycle_shadow_decisions (
+                  cycle_id,
+                  decision_hash,
+                  schema_version,
+                  document,
+                  created_at
+                ) VALUES (
+                  ${input.cycleId},
+                  ${input.document.contentHash},
+                  ${input.document.schemaVersion},
+                  ${sql.json(input.document)},
+                  ${input.document.createdAt}
+                )
+              `
               const updatedRows = yield* sql<Record<string, unknown>>`
                 UPDATE autonomous_cycles
                 SET
-                  decision_hash = ${input.decisionHash},
+                  decision_hash = ${input.document.contentHash},
                   state_version = ${cycle.stateVersion + 1},
                   updated_at = ${input.observedAt}
                 WHERE cycle_id = ${input.cycleId}

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -249,6 +249,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       'accounting_receipts',
       'accounting_transactions',
       'authority_state',
+      'autonomous_cycle_shadow_decisions',
       'autonomous_cycles',
       'broker_errors',
       'broker_events',
@@ -286,6 +287,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       { migration_id: 9, name: 'fill_source_timestamp' },
       { migration_id: 10, name: 'autonomous_cycles' },
       { migration_id: 11, name: 'causal_protocol' },
+      { migration_id: 12, name: 'observe_shadow_decisions' },
     ])
   })
 

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -240,10 +240,18 @@ describePostgres('PostgreSQL evaluation evidence', () => {
         const migrations = yield* sql<{ migration_id: number; name: string }>`
           SELECT migration_id, name FROM schema_migrations ORDER BY migration_id
         `
-        return { tables, migrations }
+        const [decisionHashColumn] = yield* sql<{ is_generated: string }>`
+          SELECT is_generated
+          FROM information_schema.columns
+          WHERE table_schema = 'public'
+            AND table_name = 'autonomous_cycle_shadow_decisions'
+            AND column_name = 'decision_hash'
+        `
+        return { decisionHashColumn, tables, migrations }
       }),
     )
 
+    expect(schema.decisionHashColumn).toEqual({ is_generated: 'ALWAYS' })
     expect(schema.tables.map((row) => row.table_name)).toEqual([
       'account_snapshots',
       'accounting_receipts',

--- a/services/bayn/src/db/migrations.ts
+++ b/services/bayn/src/db/migrations.ts
@@ -11,6 +11,7 @@ import identifiedSubmitUnknown from '../../migrations/0008_identified_submit_unk
 import fillSourceTimestamp from '../../migrations/0009_fill_source_timestamp'
 import autonomousCycles from '../../migrations/0010_autonomous_cycles'
 import causalProtocol from '../../migrations/0011_causal_protocol'
+import observeShadowDecisions from '../../migrations/0012_observe_shadow_decisions'
 
 export const migrationLoader = PgMigrator.fromRecord({
   '1_initial_schema': initialSchema,
@@ -24,4 +25,5 @@ export const migrationLoader = PgMigrator.fromRecord({
   '9_fill_source_timestamp': fillSourceTimestamp,
   '10_autonomous_cycles': autonomousCycles,
   '11_causal_protocol': causalProtocol,
+  '12_observe_shadow_decisions': observeShadowDecisions,
 })

--- a/services/bayn/src/execution/intents.ts
+++ b/services/bayn/src/execution/intents.ts
@@ -64,12 +64,14 @@ const identityMaterial = (input: IntentPlan) => ({
   notionalLimitMicros: input.notionalLimitMicros,
 })
 
+export const intentIdForPlan = (input: IntentPlan): string => canonicalHashV1(identityMaterial(input))
+
 const clientOrderId = (intentId: string): string => `b1_${Buffer.from(intentId, 'hex').toString('base64url')}`
 
 export const plan = (input: unknown) =>
   decodePlan(input).pipe(
     Effect.flatMap((decoded) => {
-      const intentId = canonicalHashV1(identityMaterial(decoded))
+      const intentId = intentIdForPlan(decoded)
       return decodeIntent({
         schemaVersion: 'bayn.paper-intent.v2',
         intentId,

--- a/services/bayn/src/risk.test.ts
+++ b/services/bayn/src/risk.test.ts
@@ -394,12 +394,21 @@ describe('bounded paper risk', () => {
     const atCutoff = makeState({
       executionSession: changeExecutionWindow(state.executionSession, { submissionCutoffAt: evaluatedAt }),
     })
+    const nearCutoffAt = '2026-07-21T21:00:00.500Z'
+    const observeNearCutoff = makeState({
+      authority: { ...state.authority, effective: Authority.Observe },
+      executionSession: changeExecutionWindow(state.executionSession, { submissionCutoffAt: nearCutoffAt }),
+    })
 
     expect(evaluate(makeIntent({ createdAt: evaluatedAt }), atOpen, makePolicy()).decision.outcome).toBe(
       RiskOutcome.Approved,
     )
     expectBlocked(Reason.OutsideSession, makeIntent(), beforeOpen, makePolicy())
     expectBlocked(Reason.OutsideSession, makeIntent(), atCutoff, makePolicy())
+    const nearCutoff = evaluate(makeIntent(), observeNearCutoff, makePolicy())
+    expect(nearCutoff.decision.reasonCodes).toContain(Reason.AuthorityNotPaper)
+    expect(nearCutoff.decision.expiresAt).toBe(nearCutoffAt)
+    expect(nearCutoff.input.freshUntil).toBe(nearCutoffAt)
   })
 
   test('blocks one micro beyond every money and exposure limit', () => {

--- a/services/bayn/src/risk.ts
+++ b/services/bayn/src/risk.ts
@@ -671,7 +671,7 @@ export const evaluate = (
     executionSession: state.executionSession,
   })
   const inputMaterial = {
-    schemaVersion: 'bayn.paper-risk-evaluation-input.v1',
+    schemaVersion: 'bayn.paper-risk-evaluation-input.v2',
     intent,
     policy,
     state,

--- a/services/bayn/src/risk.ts
+++ b/services/bayn/src/risk.ts
@@ -636,9 +636,10 @@ export const evaluate = (intent: Intent, state: State, policy: Policy): Evaluati
     marketFreshUntil,
     submissionCutoff,
   )
-  const expiresAt = utc(
-    outcome === RiskOutcome.Approved ? approvalExpiry : evaluatedAt + Math.min(1_000, policy.decisionTtlMs),
-  )
+  const ordinaryBlockedExpiry = evaluatedAt + Math.min(1_000, policy.decisionTtlMs)
+  const blockedExpiry =
+    evaluatedAt < submissionCutoff ? Math.min(ordinaryBlockedExpiry, submissionCutoff) : ordinaryBlockedExpiry
+  const expiresAt = utc(outcome === RiskOutcome.Approved ? approvalExpiry : blockedExpiry)
   const accountSnapshotHash = canonicalHashV1({
     account: state.account,
     authority: state.authority,

--- a/services/bayn/src/risk.ts
+++ b/services/bayn/src/risk.ts
@@ -375,24 +375,29 @@ const makeGate = (
 const isUnresolved = (status: OrderStatus): boolean =>
   status === OrderStatus.New || status === OrderStatus.PartiallyFilled || status === OrderStatus.Pending
 
-export const evaluate = (intent: Intent, state: State, policy: Policy): Evaluation => {
+export const evaluate = (
+  intent: Intent,
+  state: State,
+  policy: Policy,
+  proposedPositions: State['positions'] = state.positions,
+): Evaluation => {
   const evaluatedAt = instant(state.evaluatedAt)
   const policyHash = canonicalHashV1(policy)
   const referencePrice = BigInt(state.referencePriceMicros)
   const expectedPrice = BigInt(state.expectedExecutionPriceMicros)
   const orderNotional = divideUp(BigInt(intent.quantityMicros) * expectedPrice, QUANTITY_SCALE)
   const direction = intent.side === OrderSide.Buy ? 1n : -1n
-  const currentSymbolQuantity = state.positions
+  const currentSymbolQuantity = proposedPositions
     .filter((position) => position.symbol === intent.symbol)
     .reduce((total, position) => total + BigInt(position.quantityMicros), 0n)
   const postTradeSymbolQuantity = currentSymbolQuantity + direction * BigInt(intent.quantityMicros)
   const postTradeSymbolExposureNumerator = postTradeSymbolQuantity * referencePrice
   const postTradeSymbolExposure = divideAwayFromZero(postTradeSymbolExposureNumerator, QUANTITY_SCALE)
   const postTradeSymbolExposureMagnitude = divideUp(absolute(postTradeSymbolExposureNumerator), QUANTITY_SCALE)
-  const otherGrossExposure = state.positions
+  const otherGrossExposure = proposedPositions
     .filter((position) => position.symbol !== intent.symbol)
     .reduce((total, position) => total + absolute(BigInt(position.marketValueMicros)), 0n)
-  const otherNetExposure = state.positions
+  const otherNetExposure = proposedPositions
     .filter((position) => position.symbol !== intent.symbol)
     .reduce((total, position) => total + BigInt(position.marketValueMicros), 0n)
   const postTradeGrossExposure = otherGrossExposure + postTradeSymbolExposureMagnitude
@@ -651,7 +656,7 @@ export const evaluate = (intent: Intent, state: State, policy: Policy): Evaluati
     dayStartEquityMicros: state.dayStartEquityMicros,
     peakEquityMicros: state.peakEquityMicros,
   })
-  const positionsHash = canonicalHashV1({ items: state.positions, observedAt: state.positionsObservedAt })
+  const positionsHash = canonicalHashV1({ items: proposedPositions, observedAt: state.positionsObservedAt })
   const ordersHash = canonicalHashV1({
     items: state.orders,
     observedAt: state.ordersObservedAt,
@@ -670,6 +675,7 @@ export const evaluate = (intent: Intent, state: State, policy: Policy): Evaluati
     intent,
     policy,
     state,
+    proposedPositions,
     componentHashes: { accountSnapshotHash, positionsHash, ordersHash, marketDataHash },
   } as const
   const inputHash = canonicalHashV1(inputMaterial)

--- a/services/bayn/src/risk.ts
+++ b/services/bayn/src/risk.ts
@@ -24,8 +24,6 @@ import {
   TimeInForce,
   UnsignedMicrosSchema,
   type Intent,
-  type RiskDecision,
-  type RiskInput,
 } from './paper'
 import { reconciledStateHash } from './reconciliation'
 import {
@@ -280,32 +278,79 @@ export const StateSchema = StateBase.check(
 )
 export type State = typeof StateSchema.Type
 
-export type GateResult = {
-  readonly name: Gate
-  readonly passed: boolean
-  readonly reason: Reason
-  readonly actual: string
-  readonly required: string
-}
+const GateResultSchema = Schema.Struct({
+  name: Schema.Enum(Gate),
+  passed: Schema.Boolean,
+  reason: Schema.Enum(Reason),
+  actual: NonEmptyString,
+  required: NonEmptyString,
+})
+export type GateResult = typeof GateResultSchema.Type
 
-export type Evaluation = {
-  readonly policyHash: string
-  readonly input: RiskInput
-  readonly decision: RiskDecision
-  readonly gates: readonly GateResult[]
-  readonly metrics: {
-    readonly orderNotionalMicros: string
-    readonly postTradeSymbolExposureMicros: string
-    readonly postTradeGrossExposureMicros: string
-    readonly postTradeNetExposureMicros: string
-    readonly dailyTradedNotionalMicros: string
-    readonly dailyLossMicros: string
-    readonly drawdownMicros: string
-    readonly adverseSlippageBps: string
-    readonly aggregateBuyingPowerMicros: string
-    readonly unresolvedOrderCount: number
-  }
-}
+const EvaluationMetricsSchema = Schema.Struct({
+  orderNotionalMicros: UnsignedMicrosSchema,
+  postTradeSymbolExposureMicros: SignedMicrosSchema,
+  postTradeGrossExposureMicros: UnsignedMicrosSchema,
+  postTradeNetExposureMicros: SignedMicrosSchema,
+  dailyTradedNotionalMicros: UnsignedMicrosSchema,
+  dailyLossMicros: UnsignedMicrosSchema,
+  drawdownMicros: UnsignedMicrosSchema,
+  adverseSlippageBps: UnsignedMicrosSchema,
+  aggregateBuyingPowerMicros: UnsignedMicrosSchema,
+  unresolvedOrderCount: MutationCount,
+})
+
+const EvaluationBase = Schema.Struct({
+  policyHash: Sha256,
+  input: RiskInputSchema,
+  decision: RiskDecisionSchema,
+  gates: Schema.Array(GateResultSchema),
+  metrics: EvaluationMetricsSchema,
+})
+
+export const EvaluationSchema = EvaluationBase.check(
+  Schema.makeFilter((evaluation: typeof EvaluationBase.Type): readonly Schema.FilterIssue[] => {
+    const issues: Schema.FilterIssue[] = []
+    if (
+      evaluation.policyHash !== evaluation.input.policyHash ||
+      evaluation.policyHash !== evaluation.decision.policyHash ||
+      evaluation.input.inputHash !== evaluation.decision.inputHash ||
+      evaluation.input.intentId !== evaluation.decision.intentId
+    ) {
+      issues.push({ path: ['decision'], issue: 'must bind the exact risk input, intent, and policy' })
+    }
+    if (
+      evaluation.input.evaluatedAt !== evaluation.decision.decidedAt ||
+      evaluation.input.freshUntil !== evaluation.decision.expiresAt
+    ) {
+      issues.push({ path: ['decision'], issue: 'must retain the risk input evaluation and expiry times' })
+    }
+    const { decisionId, ...decisionMaterial } = evaluation.decision
+    if (decisionId !== canonicalHashV1(decisionMaterial)) {
+      issues.push({ path: ['decision', 'decisionId'], issue: 'must match the canonical risk decision material' })
+    }
+    const gateNames = Object.values(Gate)
+    if (
+      evaluation.gates.length !== gateNames.length ||
+      evaluation.gates.some((gate, index) => gate.name !== gateNames[index])
+    ) {
+      issues.push({ path: ['gates'], issue: 'must contain every risk gate in canonical order' })
+    }
+    const failedReasons = evaluation.gates.filter((gate) => !gate.passed).map((gate) => gate.reason)
+    if (
+      failedReasons.length !== evaluation.decision.reasonCodes.length ||
+      failedReasons.some((reason, index) => reason !== evaluation.decision.reasonCodes[index])
+    ) {
+      issues.push({ path: ['decision', 'reasonCodes'], issue: 'must match the failed risk gates in order' })
+    }
+    const expectedOutcome = failedReasons.length === 0 ? RiskOutcome.Approved : RiskOutcome.Blocked
+    if (evaluation.decision.outcome !== expectedOutcome) {
+      issues.push({ path: ['decision', 'outcome'], issue: 'must agree with the complete risk gate set' })
+    }
+    return issues
+  }),
+)
+export type Evaluation = typeof EvaluationSchema.Type
 
 const decodeInput = Schema.decodeUnknownSync(RiskInputSchema, StrictParseOptions)
 const decodeDecision = Schema.decodeUnknownSync(RiskDecisionSchema, StrictParseOptions)

--- a/services/bayn/src/shadow-decision-contract.ts
+++ b/services/bayn/src/shadow-decision-contract.ts
@@ -1,0 +1,140 @@
+import { Schema } from 'effect'
+
+import { intentIdForPlan } from './execution/intents'
+import { canonicalHashV1 } from './hash'
+import { PositiveMicrosSchema, RiskOutcome } from './paper'
+import { EvaluationSchema, Reason } from './risk'
+import { Sha256Schema, StrictNonEmptyStringSchema, UtcInstantSchema, strictParseOptions } from './schemas'
+import { TargetPlanResultSchema, TargetPlanStatus } from './target-planner'
+
+const ShadowDecisionBindingsSchema = Schema.Struct({
+  strategyName: StrictNonEmptyStringSchema,
+  cycleId: Sha256Schema,
+  strategyProtocolHash: Sha256Schema,
+  snapshotId: Sha256Schema,
+  snapshotContentHash: Sha256Schema,
+  snapshotFinalizedAt: UtcInstantSchema,
+  strategyDecisionHash: Sha256Schema,
+  policyHash: Sha256Schema,
+  accountId: StrictNonEmptyStringSchema,
+  accountSnapshotHash: Sha256Schema,
+  planningBrokerStateHash: Sha256Schema,
+  reconciliationId: Sha256Schema,
+  reconciliationHash: Sha256Schema,
+})
+export type ShadowDecisionBindings = typeof ShadowDecisionBindingsSchema.Type
+
+const DeltaRiskEvaluationSchema = Schema.Struct({
+  notionalLimitMicros: PositiveMicrosSchema,
+  evaluation: EvaluationSchema,
+})
+export type DeltaRiskEvaluation = typeof DeltaRiskEvaluationSchema.Type
+
+const ObserveShadowDecisionMaterialSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.observe-shadow-decision.v1'),
+  mode: Schema.Literal('OBSERVE'),
+  dispatchable: Schema.Literal(false),
+  bindings: ShadowDecisionBindingsSchema,
+  targetPlan: TargetPlanResultSchema,
+  deltaRisk: Schema.Array(DeltaRiskEvaluationSchema),
+  createdAt: UtcInstantSchema,
+  submissionCutoffAt: UtcInstantSchema,
+  expiresAt: UtcInstantSchema,
+})
+export type ObserveShadowDecisionMaterial = typeof ObserveShadowDecisionMaterialSchema.Type
+
+const materialIssues = (document: ObserveShadowDecisionMaterial): readonly Schema.FilterIssue[] => {
+  const issues: Schema.FilterIssue[] = []
+  if (document.expiresAt !== document.submissionCutoffAt) {
+    issues.push({ path: ['expiresAt'], issue: 'must equal the immutable cycle submission cutoff' })
+  }
+  if (document.createdAt >= document.submissionCutoffAt) {
+    issues.push({ path: ['createdAt'], issue: 'must precede the immutable cycle submission cutoff' })
+  }
+
+  const targets = document.targetPlan.intentTargets
+  const expectedRiskCount = document.targetPlan.status === TargetPlanStatus.Planned ? targets.length : 0
+  if (document.deltaRisk.length !== expectedRiskCount) {
+    issues.push({ path: ['deltaRisk'], issue: 'must align one-for-one with the ordered planned target deltas' })
+  }
+  for (const [index, target] of targets.entries()) {
+    if (
+      target.strategyName !== document.bindings.strategyName ||
+      target.cycleId !== document.bindings.cycleId ||
+      target.decisionHash !== document.bindings.strategyDecisionHash ||
+      target.policyHash !== document.bindings.policyHash ||
+      target.accountId !== document.bindings.accountId ||
+      target.createdAt !== document.createdAt
+    ) {
+      issues.push({ path: ['targetPlan', 'intentTargets', index], issue: 'must match the shadow decision bindings' })
+    }
+  }
+  for (const [index, risk] of document.deltaRisk.entries()) {
+    const evaluation = risk.evaluation
+    const target = targets[index]
+    if (
+      target !== undefined &&
+      evaluation.input.intentId !==
+        intentIdForPlan({
+          schemaVersion: 'bayn.paper-intent-plan.v1',
+          ...target,
+          notionalLimitMicros: risk.notionalLimitMicros,
+        })
+    ) {
+      issues.push({
+        path: ['deltaRisk', index, 'evaluation', 'input', 'intentId'],
+        issue: 'must bind the corresponding ordered target delta',
+      })
+    }
+    if (evaluation.policyHash !== document.bindings.policyHash) {
+      issues.push({ path: ['deltaRisk', index, 'evaluation', 'policyHash'], issue: 'must match the bound policy' })
+    }
+    if (
+      evaluation.decision.outcome !== RiskOutcome.Blocked ||
+      !evaluation.decision.reasonCodes.includes(Reason.AuthorityNotPaper)
+    ) {
+      issues.push({
+        path: ['deltaRisk', index, 'evaluation', 'decision'],
+        issue: 'OBSERVE risk must remain blocked by non-paper authority',
+      })
+    }
+    if (
+      evaluation.decision.decidedAt !== document.createdAt ||
+      evaluation.decision.expiresAt > document.submissionCutoffAt
+    ) {
+      issues.push({
+        path: ['deltaRisk', index, 'evaluation', 'decision'],
+        issue: 'must be evaluated with this shadow decision and expire by the cycle cutoff',
+      })
+    }
+  }
+  return issues
+}
+
+const ObserveShadowDecisionDocumentBase = Schema.Struct({
+  ...ObserveShadowDecisionMaterialSchema.fields,
+  contentHash: Sha256Schema,
+})
+
+export const ObserveShadowDecisionDocumentSchema = ObserveShadowDecisionDocumentBase.check(
+  Schema.makeFilter((document: typeof ObserveShadowDecisionDocumentBase.Type): readonly Schema.FilterIssue[] => {
+    const { contentHash, ...material } = document
+    const issues = [...materialIssues(material)]
+    if (contentHash !== canonicalHashV1(material)) {
+      issues.push({ path: ['contentHash'], issue: 'must match the canonical shadow decision material' })
+    }
+    return issues
+  }),
+)
+export type ObserveShadowDecisionDocument = typeof ObserveShadowDecisionDocumentSchema.Type
+
+const decodeDocumentSync = Schema.decodeUnknownSync(ObserveShadowDecisionDocumentSchema, strictParseOptions)
+
+export const makeObserveShadowDecisionDocument = (
+  material: ObserveShadowDecisionMaterial,
+): ObserveShadowDecisionDocument => decodeDocumentSync({ ...material, contentHash: canonicalHashV1(material) })
+
+export const decodeObserveShadowDecisionDocument = Schema.decodeUnknownEffect(
+  ObserveShadowDecisionDocumentSchema,
+  strictParseOptions,
+)

--- a/services/bayn/src/shadow-decision-contract.ts
+++ b/services/bayn/src/shadow-decision-contract.ts
@@ -17,7 +17,6 @@ const ShadowDecisionBindingsSchema = Schema.Struct({
   strategyDecisionHash: Sha256Schema,
   policyHash: Sha256Schema,
   accountId: StrictNonEmptyStringSchema,
-  accountSnapshotHash: Sha256Schema,
   planningBrokerStateHash: Sha256Schema,
   reconciliationId: Sha256Schema,
   reconciliationHash: Sha256Schema,

--- a/services/bayn/src/shadow-decision.test.ts
+++ b/services/bayn/src/shadow-decision.test.ts
@@ -1,0 +1,567 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Effect, Exit, Schema } from 'effect'
+
+import {
+  AutonomousCycleSchema,
+  CycleState,
+  makeCycleDraft,
+  makeCycleExecutionPolicy,
+  makeCycleIdentity,
+  makeCycleWindow,
+  makeExecutionCalendarObservation,
+  type AutonomousCycle,
+} from './cycle'
+import { defaultExecutionModel } from './execution-model'
+import { bindExecutionSession } from './execution-session'
+import { canonicalHashV1 } from './hash'
+import {
+  AccountStatus,
+  Authority,
+  KillState,
+  OrderSide,
+  OrderType,
+  ReconciliationStatus,
+  RiskOutcome,
+  TimeInForce,
+  type AccountSnapshot,
+  type Position,
+  type Reconciliation,
+} from './paper'
+import { reconciledStateHash } from './reconciliation'
+import { BrokerMode, PolicySchema, Reason, StateSchema, type Policy, type State } from './risk'
+import { strictParseOptions } from './schemas'
+import { decodeObserveShadowDecisionDocument, type ObserveShadowDecisionDocument } from './shadow-decision-contract'
+import {
+  buildObserveShadowDecision,
+  type ObserveShadowDecisionInput,
+  type ShadowDeltaRiskInput,
+} from './shadow-decision'
+import { TargetPlanReason, TargetPlanStatus, type TargetPlannerInput } from './target-planner'
+import type { DecisionPlan } from './types'
+
+const hash = (character: string): string => character.repeat(64)
+const accountId = 'paper-account-1'
+const signalDate = '2026-07-21' as const
+const executionDate = '2026-07-22' as const
+const brokerObservedAt = '2026-07-22T13:00:00.000Z'
+const plannedAt = '2026-07-22T13:05:00.000Z'
+const snapshotFinalizedAt = '2026-07-21T20:05:00.000Z'
+const snapshotId = hash('2')
+const snapshotContentHash = hash('3')
+const accountingHash = hash('a')
+
+const decodeCycle = Schema.decodeUnknownSync(AutonomousCycleSchema, strictParseOptions)
+const decodePolicy = Schema.decodeUnknownSync(PolicySchema, strictParseOptions)
+const decodeState = Schema.decodeUnknownSync(StateSchema, strictParseOptions)
+
+const makeCycle = (): AutonomousCycle => {
+  const executionPolicy = makeCycleExecutionPolicy({
+    schemaVersion: 'bayn.autonomous-cycle-execution-policy.v1',
+    strategyExecutionModelHash: canonicalHashV1(defaultExecutionModel),
+    submissionWindowMs: 3_600_000,
+    submissionCutoffBeforeOpenMs: 900_000,
+  })
+  const executionCalendar = makeExecutionCalendarObservation({
+    schemaVersion: 'bayn.alpaca-market-calendar-observation.v1',
+    source: 'alpaca-v2-calendar',
+    date: executionDate,
+    openAt: '2026-07-22T13:30:00.000Z',
+    closeAt: '2026-07-22T20:00:00.000Z',
+  })
+  const identity = makeCycleIdentity({
+    schemaVersion: 'bayn.autonomous-cycle-identity.v1',
+    strategyName: 'risk-balanced-trend',
+    qualificationRunId: hash('1'),
+    strategyProtocolHash: hash('4'),
+    accountId,
+    signalSessionDate: signalDate,
+    signalCalendarVersion: 'XNYS-v1',
+    executionSessionDate: executionDate,
+    executionCalendarSchemaVersion: executionCalendar.executionCalendarSchemaVersion,
+    executionCalendarSource: executionCalendar.executionCalendarSource,
+    executionCalendarHash: executionCalendar.executionCalendarHash,
+    executionPolicy,
+  })
+  const window = makeCycleWindow(
+    {
+      calendar_version: 'XNYS-v1',
+      session_date: signalDate,
+      close_time: '16:00',
+      timezone: 'America/New_York',
+    },
+    executionCalendar,
+    executionPolicy,
+  )
+  const draft = makeCycleDraft(identity, window)
+  return decodeCycle({
+    ...draft,
+    state: CycleState.Active,
+    bindings: { snapshotId },
+    stateVersion: 3,
+    createdAt: '2026-07-22T11:45:00.000Z',
+    updatedAt: '2026-07-22T12:45:00.000Z',
+  })
+}
+
+const position = (symbol: string): Position => ({
+  schemaVersion: 'bayn.paper-position.v1',
+  accountId,
+  symbol,
+  quantityMicros: '1000000',
+  averageEntryPriceMicros: '100000000',
+  marketPriceMicros: '100000000',
+  marketValueMicros: '100000000',
+  unrealizedPnlMicros: '0',
+  observedAt: brokerObservedAt,
+})
+
+const makeBrokerState = () => {
+  const account: AccountSnapshot = {
+    schemaVersion: 'bayn.paper-account-snapshot.v1',
+    accountId,
+    status: AccountStatus.Active,
+    currency: 'USD',
+    cashMicros: '800000000',
+    equityMicros: '1000000000',
+    buyingPowerMicros: '1000000000',
+    observedAt: brokerObservedAt,
+  }
+  const positions = [position('AMD'), position('NVDA')]
+  const orders = [] as const
+  const stateHash = reconciledStateHash({
+    account,
+    positions,
+    positionsObservedAt: brokerObservedAt,
+    orders,
+    ordersObservedAt: brokerObservedAt,
+    accountingHash,
+  })
+  const reconciliationMaterial = {
+    schemaVersion: 'bayn.paper-reconciliation.v1' as const,
+    accountId,
+    expectedHash: stateHash,
+    observedHash: stateHash,
+    status: ReconciliationStatus.Exact,
+    discrepancies: [],
+    reconciledAt: brokerObservedAt,
+  }
+  const reconciliationId = canonicalHashV1({
+    schemaVersion: 'bayn.paper-reconciliation-id.v1',
+    material: reconciliationMaterial,
+  })
+  const reconciliation: Reconciliation = {
+    ...reconciliationMaterial,
+    reconciliationId,
+    contentHash: canonicalHashV1({ ...reconciliationMaterial, reconciliationId }),
+  }
+  return { account, positions, orders, reconciliation, stateHash }
+}
+
+const makeDecision = (targetWeights: Readonly<Record<string, number>>): DecisionPlan => ({
+  schemaVersion: 'bayn.risk-balanced-trend-decision-plan.v1',
+  signalDate,
+  covarianceWindow: {
+    returnCount: 63,
+    firstSession: '2026-04-22',
+    lastSession: signalDate,
+    sessionsHash: hash('5'),
+  },
+  estimatedAnnualizedPortfolioVolatility: 0.08,
+  exposureScale: 1,
+  targetWeights,
+  signals: ['AMD', 'NVDA'].map((symbol) => ({
+    symbol,
+    horizons: [{ horizonSessions: 21, return: 0.1, normalizedTrend: 1 }],
+    dailyVolatility: 0.01,
+    annualizedVolatility: 0.15,
+    compositeScore: 1,
+    positiveScore: 1,
+    eligible: true,
+    uncappedWeight: targetWeights[symbol],
+    cappedWeight: targetWeights[symbol],
+    targetWeight: targetWeights[symbol],
+  })),
+})
+
+const makePolicy = (): Policy =>
+  decodePolicy({
+    schemaVersion: 'bayn.paper-risk-policy.v1',
+    accountId,
+    brokerMode: BrokerMode.Paper,
+    allowedSymbols: ['AMD', 'NVDA'],
+    allowedOrderTypes: [OrderType.Market],
+    allowedTimeInForce: [TimeInForce.Day],
+    maxOrderNotionalMicros: '600000000',
+    maxSymbolExposureMicros: '600000000',
+    maxGrossExposureMicros: '1000000000',
+    maxNetExposureMicros: '1000000000',
+    maxDailyTradedNotionalMicros: '1000000000',
+    maxDailyLossMicros: '100000000',
+    maxDrawdownMicros: '100000000',
+    maxIntentAgeMs: 1_800_000,
+    maxBrokerStateAgeMs: 1_800_000,
+    maxMarketDataAgeMs: 1_800_000,
+    maxAdverseSlippageBps: 100,
+    maxUnresolvedOrders: 0,
+    decisionTtlMs: 1_200_000,
+  })
+
+const referencePrices = () => {
+  const material = {
+    schemaVersion: 'bayn.signal-session-reference-prices.v1' as const,
+    signalDate,
+    observedAt: brokerObservedAt,
+    priceMicros: { AMD: '100000000', NVDA: '100000000' },
+  }
+  return { ...material, contentHash: canonicalHashV1(material) }
+}
+
+const makePlannerInput = (
+  cycle: AutonomousCycle,
+  decision: DecisionPlan,
+  policy: Policy,
+  maximumInputAgeMs = 1_800_000,
+): TargetPlannerInput => {
+  const brokerState = makeBrokerState()
+  return {
+    schemaVersion: 'bayn.paper-target-planner-input.v1',
+    strategyName: 'risk-balanced-trend',
+    cycleId: cycle.identity.cycleId,
+    decisionHash: canonicalHashV1(decision),
+    policyHash: canonicalHashV1(policy),
+    accountId,
+    signalDate,
+    targetWeights: decision.targetWeights,
+    referencePrices: referencePrices(),
+    brokerState: {
+      account: brokerState.account,
+      positions: brokerState.positions,
+      positionsObservedAt: brokerObservedAt,
+      orders: brokerState.orders,
+      ordersObservedAt: brokerObservedAt,
+      accountingHash,
+      reconciliation: brokerState.reconciliation,
+      unknownOrderCount: 0,
+    },
+    precision: defaultExecutionModel.precision,
+    maximumInputAgeMs,
+    submissionCutoffAt: cycle.window.submissionCutoffAt,
+    observedAt: plannedAt,
+  }
+}
+
+const makeRiskState = (cycle: AutonomousCycle, symbol: string): State => {
+  const brokerState = makeBrokerState()
+  const calendarMaterial = {
+    schemaVersion: 'bayn.alpaca-market-calendar-observation.v1' as const,
+    source: 'alpaca-v2-calendar' as const,
+    requestedRange: { start: signalDate, end: executionDate },
+    timeZone: 'UTC' as const,
+    sessions: [
+      {
+        date: executionDate,
+        openAt: cycle.window.executionOpenAt,
+        closeAt: cycle.window.executionCloseAt,
+      },
+    ],
+  }
+  const executionSession = bindExecutionSession({
+    signal: {
+      sessionDate: signalDate,
+      finalizedAt: snapshotFinalizedAt,
+      contentHash: snapshotContentHash,
+    },
+    planningBrokerState: {
+      observedAt: brokerObservedAt,
+      contentHash: brokerState.stateHash,
+    },
+    calendar: {
+      ...calendarMaterial,
+      normalizedResponseHash: canonicalHashV1(calendarMaterial),
+    },
+    executionModel: defaultExecutionModel,
+  })
+  return decodeState({
+    schemaVersion: 'bayn.paper-risk-state.v2',
+    brokerMode: BrokerMode.Paper,
+    account: brokerState.account,
+    positions: brokerState.positions,
+    positionsObservedAt: brokerObservedAt,
+    orders: brokerState.orders,
+    ordersObservedAt: brokerObservedAt,
+    reconciliation: brokerState.reconciliation,
+    authority: {
+      schemaVersion: 'bayn.paper-authority.v1',
+      generationHash: hash('6'),
+      maximum: Authority.Paper,
+      effective: Authority.Observe,
+      kill: KillState.Clear,
+      version: 1,
+      updatedAt: brokerObservedAt,
+    },
+    authorityObservedAt: brokerObservedAt,
+    unknownMutationCount: 0,
+    dailyTradedNotionalMicros: '0',
+    dayStartEquityMicros: '1000000000',
+    peakEquityMicros: '1000000000',
+    accountingHash,
+    marketDataSymbol: symbol,
+    marketDataHash: snapshotContentHash,
+    referencePriceMicros: '100000000',
+    expectedExecutionPriceMicros: '100000000',
+    marketDataObservedAt: brokerObservedAt,
+    executionSession,
+    reservedBuyingPowerMicros: '0',
+    evaluatedAt: plannedAt,
+  })
+}
+
+const makeInput = (
+  targetWeights: Readonly<Record<string, number>> = { AMD: 0.4, NVDA: 0.6 },
+): ObserveShadowDecisionInput => {
+  const cycle = makeCycle()
+  const compiledDecision = makeDecision(targetWeights)
+  const policy = makePolicy()
+  const plannerInput = makePlannerInput(cycle, compiledDecision, policy)
+  const quantities: Readonly<Record<string, string>> = {
+    AMD: '3000000',
+    NVDA: '5000000',
+  }
+  const riskInputs: ShadowDeltaRiskInput[] =
+    targetWeights.AMD === 0.4 && targetWeights.NVDA === 0.6
+      ? ['AMD', 'NVDA'].map((symbol) => ({
+          symbol,
+          notionalLimitMicros: (
+            (BigInt(quantities[symbol]) * BigInt(plannerInput.referencePrices.priceMicros[symbol])) /
+            1_000_000n
+          ).toString(),
+          state: makeRiskState(cycle, symbol),
+        }))
+      : []
+  return {
+    cycle,
+    snapshot: {
+      snapshotId,
+      contentHash: snapshotContentHash,
+      finalizedAt: snapshotFinalizedAt,
+    },
+    compiledDecision,
+    plannerInput,
+    policy,
+    riskInputs,
+  }
+}
+
+const build = (input: ObserveShadowDecisionInput): Promise<ObserveShadowDecisionDocument> =>
+  Effect.runPromise(buildObserveShadowDecision(input))
+
+describe('OBSERVE shadow decision', () => {
+  test('binds exact final target deltas and cumulative v3 risk without any dispatchable intent state', async () => {
+    const input = makeInput()
+    const first = await build(input)
+    const replay = await build(makeInput())
+
+    expect(replay).toEqual(first)
+    expect(first).toMatchObject({
+      schemaVersion: 'bayn.observe-shadow-decision.v1',
+      mode: 'OBSERVE',
+      dispatchable: false,
+      bindings: {
+        cycleId: input.cycle.identity.cycleId,
+        snapshotId,
+        snapshotContentHash,
+        strategyDecisionHash: canonicalHashV1(input.compiledDecision),
+        policyHash: canonicalHashV1(input.policy),
+        accountSnapshotHash: canonicalHashV1(input.plannerInput.brokerState.account),
+        planningBrokerStateHash: input.plannerInput.brokerState.reconciliation.observedHash,
+        reconciliationId: input.plannerInput.brokerState.reconciliation.reconciliationId,
+        reconciliationHash: input.plannerInput.brokerState.reconciliation.contentHash,
+      },
+      submissionCutoffAt: input.cycle.window.submissionCutoffAt,
+      expiresAt: input.cycle.window.submissionCutoffAt,
+      targetPlan: {
+        status: TargetPlanStatus.Planned,
+        reason: null,
+        requiredReferenceBuyNotionalMicros: '800000000',
+        residualBuyingPowerMicros: '200000000',
+      },
+    })
+    expect(
+      first.targetPlan.targets.map(({ symbol, currentQuantityMicros, targetQuantityMicros }) => [
+        symbol,
+        currentQuantityMicros,
+        targetQuantityMicros,
+      ]),
+    ).toEqual([
+      ['AMD', '1000000', '4000000'],
+      ['NVDA', '1000000', '6000000'],
+    ])
+    expect(
+      first.targetPlan.intentTargets.map(({ symbol, side, quantityMicros }) => [symbol, side, quantityMicros]),
+    ).toEqual([
+      ['AMD', OrderSide.Buy, '3000000'],
+      ['NVDA', OrderSide.Buy, '5000000'],
+    ])
+    expect(
+      first.targetPlan.intentTargets.every((target) => target.decisionHash === first.bindings.strategyDecisionHash),
+    ).toBe(true)
+    expect(first.deltaRisk.map(({ evaluation }) => evaluation.metrics.aggregateBuyingPowerMicros)).toEqual([
+      '300000000',
+      '800000000',
+    ])
+    expect(first.deltaRisk.map(({ evaluation }) => evaluation.metrics.dailyTradedNotionalMicros)).toEqual([
+      '300000000',
+      '800000000',
+    ])
+    expect(
+      first.deltaRisk.every(
+        ({ evaluation }) =>
+          evaluation.decision.outcome === RiskOutcome.Blocked &&
+          evaluation.decision.reasonCodes.includes(Reason.AuthorityNotPaper) &&
+          evaluation.decision.expiresAt <= first.submissionCutoffAt,
+      ),
+    ).toBe(true)
+    expect(
+      first.targetPlan.intentTargets.every(
+        (target) => !('intentId' in target) && !('clientOrderId' in target) && !('state' in target),
+      ),
+    ).toBe(true)
+    const { contentHash, ...material } = first
+    expect(contentHash).toBe(canonicalHashV1(material))
+    const boundCycle = decodeCycle({
+      ...input.cycle,
+      bindings: {
+        snapshotId,
+        decisionHash: first.contentHash,
+        shadowDecision: first,
+      },
+      stateVersion: input.cycle.stateVersion + 1,
+      updatedAt: first.createdAt,
+    })
+    expect(boundCycle.bindings.decisionHash).toBe(first.contentHash)
+  })
+
+  test('persists deterministic NO_TRADE and pre-cutoff blocked planner results without ignored risk input', async () => {
+    const noTrade = await build(makeInput({ AMD: 0.1, NVDA: 0.1 }))
+    const staleInput = makeInput()
+    const stale = await build({
+      ...staleInput,
+      plannerInput: {
+        ...staleInput.plannerInput,
+        maximumInputAgeMs: 1,
+      },
+      riskInputs: [],
+    })
+
+    expect(noTrade.targetPlan).toMatchObject({
+      status: TargetPlanStatus.NoTrade,
+      reason: TargetPlanReason.TargetsSatisfied,
+    })
+    expect(noTrade.deltaRisk).toEqual([])
+    expect(stale.targetPlan).toMatchObject({
+      status: TargetPlanStatus.Blocked,
+      reason: TargetPlanReason.InputStale,
+    })
+    expect(stale.deltaRisk).toEqual([])
+    expect(noTrade.expiresAt).toBe(noTrade.submissionCutoffAt)
+    expect(stale.expiresAt).toBe(stale.submissionCutoffAt)
+  })
+
+  test('fails closed on drift in cycle, snapshot, compiled decision, risk state, or OBSERVE authority', async () => {
+    const input = makeInput()
+    const variants: ObserveShadowDecisionInput[] = [
+      {
+        ...input,
+        snapshot: { ...input.snapshot, snapshotId: hash('f') },
+      },
+      {
+        ...input,
+        compiledDecision: makeDecision({ AMD: 0.5, NVDA: 0.5 }),
+      },
+      {
+        ...input,
+        riskInputs: input.riskInputs.map((riskInput, index) =>
+          index === 0
+            ? {
+                ...riskInput,
+                state: {
+                  ...riskInput.state,
+                  reconciliation: { ...riskInput.state.reconciliation, contentHash: hash('e') },
+                },
+              }
+            : riskInput,
+        ),
+      },
+      {
+        ...input,
+        riskInputs: input.riskInputs.map((riskInput, index) =>
+          index === 0
+            ? {
+                ...riskInput,
+                state: {
+                  ...riskInput.state,
+                  authority: { ...riskInput.state.authority, effective: Authority.Paper },
+                },
+              }
+            : riskInput,
+        ),
+      },
+    ]
+
+    for (const variant of variants) {
+      const exit = await Effect.runPromiseExit(buildObserveShadowDecision(variant))
+      expect(Exit.isFailure(exit)).toBe(true)
+    }
+  })
+
+  test('durable schema rejects approval, coordinator fields, and content-hash rewrites', async () => {
+    const document = await build(makeInput())
+    const noTradeDocument = await build(makeInput({ AMD: 0.1, NVDA: 0.1 }))
+    const approved = {
+      ...document,
+      deltaRisk: document.deltaRisk.map((risk, index) =>
+        index === 0
+          ? {
+              ...risk,
+              evaluation: {
+                ...risk.evaluation,
+                decision: {
+                  ...risk.evaluation.decision,
+                  outcome: RiskOutcome.Approved,
+                  reasonCodes: [],
+                },
+              },
+            }
+          : risk,
+      ),
+    }
+    const coordinatorMaterial = {
+      ...document,
+      targetPlan: {
+        ...document.targetPlan,
+        intentTargets: document.targetPlan.intentTargets.map((target, index) =>
+          index === 0 ? { ...target, intentId: hash('f'), clientOrderId: 'broker-consumable' } : target,
+        ),
+      },
+    }
+    const rewritten = { ...document, targetPlan: { ...document.targetPlan, outputHash: hash('f') } }
+    const cutoffMaterial = {
+      ...noTradeDocument,
+      createdAt: noTradeDocument.submissionCutoffAt,
+    }
+    const { contentHash: _, ...cutoffWithoutHash } = cutoffMaterial
+    const exactCutoff = { ...cutoffWithoutHash, contentHash: canonicalHashV1(cutoffWithoutHash) }
+    const swappedMaterial = {
+      ...document,
+      deltaRisk: [...document.deltaRisk].reverse(),
+    }
+    const { contentHash: _swappedHash, ...swappedWithoutHash } = swappedMaterial
+    const swappedRisk = { ...swappedWithoutHash, contentHash: canonicalHashV1(swappedWithoutHash) }
+
+    for (const candidate of [approved, coordinatorMaterial, rewritten, exactCutoff, swappedRisk]) {
+      const exit = await Effect.runPromiseExit(decodeObserveShadowDecisionDocument(candidate))
+      expect(Exit.isFailure(exit)).toBe(true)
+    }
+  })
+})

--- a/services/bayn/src/shadow-decision.test.ts
+++ b/services/bayn/src/shadow-decision.test.ts
@@ -29,7 +29,7 @@ import {
   type Reconciliation,
 } from './paper'
 import { reconciledStateHash } from './reconciliation'
-import { BrokerMode, PolicySchema, Reason, StateSchema, type Policy, type State } from './risk'
+import { BrokerMode, Gate, PolicySchema, Reason, StateSchema, type Policy, type State } from './risk'
 import { strictParseOptions } from './schemas'
 import { decodeObserveShadowDecisionDocument, type ObserveShadowDecisionDocument } from './shadow-decision-contract'
 import {
@@ -373,7 +373,6 @@ describe('OBSERVE shadow decision', () => {
         snapshotContentHash,
         strategyDecisionHash: canonicalHashV1(input.compiledDecision),
         policyHash: canonicalHashV1(input.policy),
-        accountSnapshotHash: canonicalHashV1(input.plannerInput.brokerState.account),
         planningBrokerStateHash: input.plannerInput.brokerState.reconciliation.observedHash,
         reconciliationId: input.plannerInput.brokerState.reconciliation.reconciliationId,
         reconciliationHash: input.plannerInput.brokerState.reconciliation.contentHash,
@@ -422,6 +421,18 @@ describe('OBSERVE shadow decision', () => {
       '500000000',
       '1000000000',
     ])
+    expect(first.deltaRisk.map(({ evaluation }) => evaluation.decision.reasonCodes)).toEqual([
+      [Reason.AuthorityNotPaper],
+      [Reason.AuthorityNotPaper],
+    ])
+    expect(
+      first.deltaRisk.every(
+        ({ evaluation }) => evaluation.gates.find((gate) => gate.name === Gate.Reconciliation)?.passed === true,
+      ),
+    ).toBe(true)
+    expect(first.deltaRisk[1]?.evaluation.input.positionsHash).not.toBe(
+      first.deltaRisk[0]?.evaluation.input.positionsHash,
+    )
     expect(
       first.deltaRisk.every(
         ({ evaluation }) =>

--- a/services/bayn/src/shadow-decision.test.ts
+++ b/services/bayn/src/shadow-decision.test.ts
@@ -414,6 +414,14 @@ describe('OBSERVE shadow decision', () => {
       '300000000',
       '800000000',
     ])
+    expect(first.deltaRisk.map(({ evaluation }) => evaluation.metrics.postTradeGrossExposureMicros)).toEqual([
+      '500000000',
+      '1000000000',
+    ])
+    expect(first.deltaRisk.map(({ evaluation }) => evaluation.metrics.postTradeNetExposureMicros)).toEqual([
+      '500000000',
+      '1000000000',
+    ])
     expect(
       first.deltaRisk.every(
         ({ evaluation }) =>
@@ -434,12 +442,17 @@ describe('OBSERVE shadow decision', () => {
       bindings: {
         snapshotId,
         decisionHash: first.contentHash,
-        shadowDecision: first,
       },
       stateVersion: input.cycle.stateVersion + 1,
       updatedAt: first.createdAt,
     })
     expect(boundCycle.bindings.decisionHash).toBe(first.contentHash)
+    expect(() =>
+      decodeCycle({
+        ...boundCycle,
+        bindings: { ...boundCycle.bindings, shadowDecision: first },
+      }),
+    ).toThrow()
   })
 
   test('persists deterministic NO_TRADE and pre-cutoff blocked planner results without ignored risk input', async () => {
@@ -466,6 +479,25 @@ describe('OBSERVE shadow decision', () => {
     expect(stale.deltaRisk).toEqual([])
     expect(noTrade.expiresAt).toBe(noTrade.submissionCutoffAt)
     expect(stale.expiresAt).toBe(stale.submissionCutoffAt)
+  })
+
+  test('clamps blocked risk evidence at the last instant before the exclusive cycle cutoff', async () => {
+    const input = makeInput()
+    const createdAt = new Date(Date.parse(input.cycle.window.submissionCutoffAt) - 1).toISOString()
+    const document = await build({
+      ...input,
+      plannerInput: { ...input.plannerInput, observedAt: createdAt },
+      riskInputs: input.riskInputs.map((riskInput) => ({
+        ...riskInput,
+        state: { ...riskInput.state, evaluatedAt: createdAt },
+      })),
+    })
+
+    expect(document.createdAt).toBe(createdAt)
+    expect(document.deltaRisk).toHaveLength(2)
+    expect(document.deltaRisk.every(({ evaluation }) => evaluation.decision.expiresAt === document.expiresAt)).toBe(
+      true,
+    )
   })
 
   test('fails closed on drift in cycle, snapshot, compiled decision, risk state, or OBSERVE authority', async () => {

--- a/services/bayn/src/shadow-decision.test.ts
+++ b/services/bayn/src/shadow-decision.test.ts
@@ -433,6 +433,7 @@ describe('OBSERVE shadow decision', () => {
     expect(first.deltaRisk[1]?.evaluation.input.positionsHash).not.toBe(
       first.deltaRisk[0]?.evaluation.input.positionsHash,
     )
+    expect(first.deltaRisk[1]?.evaluation.input.inputHash).not.toBe(first.deltaRisk[0]?.evaluation.input.inputHash)
     expect(
       first.deltaRisk.every(
         ({ evaluation }) =>

--- a/services/bayn/src/shadow-decision.ts
+++ b/services/bayn/src/shadow-decision.ts
@@ -1,0 +1,265 @@
+import { Data, Effect } from 'effect'
+
+import type { AutonomousCycle } from './cycle'
+import { CycleState } from './cycle'
+import { plan, type IntentPlan } from './execution/intents'
+import { canonicalHashV1 } from './hash'
+import { Authority, OrderSide, RiskOutcome } from './paper'
+import { reconciledStateHash } from './reconciliation'
+import { decodeState, evaluate, Reason, type Policy, type State } from './risk'
+import {
+  makeObserveShadowDecisionDocument,
+  type DeltaRiskEvaluation,
+  type ObserveShadowDecisionDocument,
+} from './shadow-decision-contract'
+import { TargetPlanStatus, planTargets, type TargetPlannerInput } from './target-planner'
+import type { DecisionPlan } from './types'
+
+export interface ShadowSnapshotBinding {
+  readonly snapshotId: string
+  readonly contentHash: string
+  readonly finalizedAt: string
+}
+
+export interface ShadowDeltaRiskInput {
+  readonly symbol: string
+  readonly notionalLimitMicros: string
+  readonly state: State
+}
+
+export interface ObserveShadowDecisionInput {
+  readonly cycle: AutonomousCycle
+  readonly snapshot: ShadowSnapshotBinding
+  readonly compiledDecision: DecisionPlan
+  readonly plannerInput: TargetPlannerInput
+  readonly policy: Policy
+  readonly riskInputs: readonly ShadowDeltaRiskInput[]
+}
+
+export class ShadowDecisionError extends Data.TaggedError('ShadowDecisionError')<{
+  readonly failure: 'binding' | 'contract' | 'risk'
+  readonly message: string
+  readonly cause?: unknown
+}> {}
+
+const error = (failure: ShadowDecisionError['failure'], message: string, cause?: unknown): ShadowDecisionError =>
+  new ShadowDecisionError({ failure, message, cause })
+
+const fail = (failure: ShadowDecisionError['failure'], message: string): Effect.Effect<never, ShadowDecisionError> =>
+  Effect.fail(error(failure, message))
+
+const sameHash = (left: unknown, right: unknown): boolean => canonicalHashV1(left) === canonicalHashV1(right)
+
+const plannerBrokerStateMaterial = (input: TargetPlannerInput) => ({
+  account: input.brokerState.account,
+  positions: input.brokerState.positions,
+  positionsObservedAt: input.brokerState.positionsObservedAt,
+  orders: input.brokerState.orders,
+  ordersObservedAt: input.brokerState.ordersObservedAt,
+  accountingHash: input.brokerState.accountingHash,
+})
+
+const riskBrokerStateMaterial = (state: State) => ({
+  account: state.account,
+  positions: state.positions,
+  positionsObservedAt: state.positionsObservedAt,
+  orders: state.orders,
+  ordersObservedAt: state.ordersObservedAt,
+  accountingHash: state.accountingHash,
+})
+
+const validateBindings = (
+  input: ObserveShadowDecisionInput,
+  strategyDecisionHash: string,
+  policyHash: string,
+): string | null => {
+  const { cycle, plannerInput, snapshot } = input
+  if (cycle.state !== CycleState.Active) return 'shadow planning requires an active autonomous cycle'
+  if (cycle.bindings.snapshotId !== snapshot.snapshotId) {
+    return 'shadow snapshot must match the immutable cycle snapshot binding'
+  }
+  if (
+    plannerInput.cycleId !== cycle.identity.cycleId ||
+    plannerInput.strategyName !== cycle.identity.strategyName ||
+    plannerInput.accountId !== cycle.identity.accountId ||
+    plannerInput.signalDate !== cycle.identity.signalSessionDate ||
+    plannerInput.submissionCutoffAt !== cycle.window.submissionCutoffAt
+  ) {
+    return 'target planner identity must match the active autonomous cycle'
+  }
+  if (
+    plannerInput.decisionHash !== strategyDecisionHash ||
+    plannerInput.policyHash !== policyHash ||
+    input.policy.accountId !== cycle.identity.accountId
+  ) {
+    return 'target planner decision and policy must match the compiled shadow inputs'
+  }
+  if (
+    input.compiledDecision.signalDate !== plannerInput.signalDate ||
+    !sameHash(input.compiledDecision.targetWeights, plannerInput.targetWeights)
+  ) {
+    return 'compiled strategy decision must match the target planner weights and signal session'
+  }
+  if (plannerInput.observedAt < cycle.updatedAt) {
+    return 'shadow decision creation cannot precede the durable cycle state'
+  }
+  return null
+}
+
+const validateRiskState = (
+  input: ObserveShadowDecisionInput,
+  riskInput: ShadowDeltaRiskInput,
+  commonExecutionSessionHash: string,
+): string | null => {
+  const { cycle, plannerInput, snapshot } = input
+  const state = riskInput.state
+  if (state.authority.effective !== Authority.Observe) return 'shadow risk requires effective OBSERVE authority'
+  if (state.evaluatedAt !== plannerInput.observedAt) return 'shadow risk time must match target planning time'
+  if (state.marketDataSymbol !== riskInput.symbol) return 'shadow risk market symbol must match its target delta'
+  if (state.marketDataHash !== snapshot.contentHash) return 'shadow risk data must match the finalized snapshot content'
+  if (
+    state.executionSession.signal.sessionDate !== cycle.identity.signalSessionDate ||
+    state.executionSession.signal.finalizedAt !== snapshot.finalizedAt ||
+    state.executionSession.signal.contentHash !== snapshot.contentHash
+  ) {
+    return 'shadow risk signal binding must match the finalized cycle snapshot'
+  }
+  if (
+    state.executionSession.executionSession.date !== cycle.identity.executionSessionDate ||
+    state.executionSession.executionSession.openAt !== cycle.window.executionOpenAt ||
+    state.executionSession.executionSession.closeAt !== cycle.window.executionCloseAt ||
+    state.executionSession.submissionCutoffAt !== cycle.window.submissionCutoffAt ||
+    state.executionSession.submissionOpenAt < cycle.window.submissionOpenAt
+  ) {
+    return 'shadow risk execution session must remain inside the immutable cycle window'
+  }
+  if (state.executionSession.bindingHash !== commonExecutionSessionHash) {
+    return 'every target delta must use one execution-session binding'
+  }
+  if (
+    state.referencePriceMicros !== plannerInput.referencePrices.priceMicros[riskInput.symbol] ||
+    !sameHash(riskBrokerStateMaterial(state), plannerBrokerStateMaterial(plannerInput)) ||
+    !sameHash(state.reconciliation, plannerInput.brokerState.reconciliation)
+  ) {
+    return 'shadow risk must use the exact target-planning price, account, and reconciliation state'
+  }
+  return null
+}
+
+export const buildObserveShadowDecision = (
+  input: ObserveShadowDecisionInput,
+): Effect.Effect<ObserveShadowDecisionDocument, ShadowDecisionError> =>
+  Effect.gen(function* () {
+    const strategyDecisionHash = canonicalHashV1(input.compiledDecision)
+    const policyHash = canonicalHashV1(input.policy)
+    const bindingFailure = validateBindings(input, strategyDecisionHash, policyHash)
+    if (bindingFailure !== null) return yield* fail('binding', bindingFailure)
+
+    const planner = yield* Effect.try({
+      try: () => planTargets(input.plannerInput),
+      catch: (cause) => error('contract', 'target planning failed', cause),
+    })
+    if (planner.status !== TargetPlanStatus.Planned && input.riskInputs.length !== 0) {
+      return yield* fail('binding', 'NO_TRADE and BLOCKED target plans cannot retain ignored risk inputs')
+    }
+    if (planner.status === TargetPlanStatus.Planned && planner.intentTargets.length !== input.riskInputs.length) {
+      return yield* fail('binding', 'planned target deltas require exactly one risk input per symbol')
+    }
+
+    const riskInputs = new Map(input.riskInputs.map((riskInput) => [riskInput.symbol, riskInput]))
+    if (riskInputs.size !== input.riskInputs.length) {
+      return yield* fail('binding', 'shadow risk inputs must contain unique symbols')
+    }
+    const firstRiskInput = input.riskInputs[0]
+    const commonExecutionSessionHash = firstRiskInput?.state.executionSession.bindingHash ?? ''
+    const baseReservedBuyingPower = firstRiskInput?.state.reservedBuyingPowerMicros ?? '0'
+    const baseDailyTradedNotional = firstRiskInput?.state.dailyTradedNotionalMicros ?? '0'
+    for (const candidate of input.riskInputs) {
+      if (
+        candidate.state.reservedBuyingPowerMicros !== baseReservedBuyingPower ||
+        candidate.state.dailyTradedNotionalMicros !== baseDailyTradedNotional
+      ) {
+        return yield* fail(
+          'binding',
+          'every shadow risk input must start from one reservation and daily-notional state',
+        )
+      }
+      const stateFailure = validateRiskState(input, candidate, commonExecutionSessionHash)
+      if (stateFailure !== null) return yield* fail('binding', stateFailure)
+    }
+
+    let reservedBuyingPower = BigInt(baseReservedBuyingPower)
+    let dailyTradedNotional = BigInt(baseDailyTradedNotional)
+    const deltaRisk: DeltaRiskEvaluation[] = []
+
+    for (const targetIntent of planner.intentTargets) {
+      const provided = riskInputs.get(targetIntent.symbol)
+      if (provided === undefined) return yield* fail('binding', 'planned target delta is missing its risk input')
+      const intentPlan: IntentPlan = {
+        schemaVersion: 'bayn.paper-intent-plan.v1',
+        ...targetIntent,
+        notionalLimitMicros: provided.notionalLimitMicros,
+      }
+      const intent = yield* plan(intentPlan).pipe(
+        Effect.mapError((cause) => error('contract', 'shadow target delta could not form a valid risk intent', cause)),
+      )
+      const state = yield* decodeState({
+        ...provided.state,
+        reservedBuyingPowerMicros: reservedBuyingPower.toString(),
+        dailyTradedNotionalMicros: dailyTradedNotional.toString(),
+      }).pipe(Effect.mapError((cause) => error('contract', 'cumulative shadow risk state is invalid', cause)))
+      const evaluation = yield* Effect.try({
+        try: () => evaluate(intent, state, input.policy),
+        catch: (cause) => error('risk', 'shadow target risk evaluation failed', cause),
+      })
+      if (
+        evaluation.policyHash !== policyHash ||
+        evaluation.decision.outcome !== RiskOutcome.Blocked ||
+        !evaluation.decision.reasonCodes.includes(Reason.AuthorityNotPaper)
+      ) {
+        return yield* fail('risk', 'OBSERVE shadow risk must remain blocked by non-paper authority')
+      }
+
+      const orderNotional = BigInt(evaluation.metrics.orderNotionalMicros)
+      dailyTradedNotional += orderNotional
+      if (targetIntent.side === OrderSide.Buy) reservedBuyingPower += orderNotional
+      deltaRisk.push({
+        notionalLimitMicros: provided.notionalLimitMicros,
+        evaluation,
+      })
+    }
+
+    const document = yield* Effect.try({
+      try: () =>
+        makeObserveShadowDecisionDocument({
+          schemaVersion: 'bayn.observe-shadow-decision.v1',
+          mode: 'OBSERVE',
+          dispatchable: false,
+          bindings: {
+            strategyName: input.plannerInput.strategyName,
+            cycleId: input.cycle.identity.cycleId,
+            strategyProtocolHash: input.cycle.identity.strategyProtocolHash,
+            snapshotId: input.snapshot.snapshotId,
+            snapshotContentHash: input.snapshot.contentHash,
+            snapshotFinalizedAt: input.snapshot.finalizedAt,
+            strategyDecisionHash,
+            policyHash,
+            accountId: input.plannerInput.accountId,
+            accountSnapshotHash: canonicalHashV1(input.plannerInput.brokerState.account),
+            planningBrokerStateHash: reconciledStateHash(plannerBrokerStateMaterial(input.plannerInput)),
+            reconciliationId: input.plannerInput.brokerState.reconciliation.reconciliationId,
+            reconciliationHash: input.plannerInput.brokerState.reconciliation.contentHash,
+          },
+          targetPlan: planner,
+          deltaRisk,
+          submissionCutoffAt: input.cycle.window.submissionCutoffAt,
+          expiresAt: input.cycle.window.submissionCutoffAt,
+          createdAt: input.plannerInput.observedAt,
+        }),
+      catch: (cause) => error('contract', 'shadow decision document failed durable contract validation', cause),
+    })
+    if (input.cycle.bindings.decisionHash !== undefined && input.cycle.bindings.decisionHash !== document.contentHash) {
+      return yield* fail('binding', 'shadow document must match the immutable cycle decision binding')
+    }
+    return document
+  })

--- a/services/bayn/src/shadow-decision.ts
+++ b/services/bayn/src/shadow-decision.ts
@@ -4,7 +4,7 @@ import type { AutonomousCycle } from './cycle'
 import { CycleState } from './cycle'
 import { plan, type IntentPlan } from './execution/intents'
 import { canonicalHashV1 } from './hash'
-import { Authority, OrderSide, RiskOutcome } from './paper'
+import { Authority, OrderSide, RiskOutcome, type Position } from './paper'
 import { reconciledStateHash } from './reconciliation'
 import { decodeState, evaluate, Reason, type Policy, type State } from './risk'
 import {
@@ -12,7 +12,7 @@ import {
   type DeltaRiskEvaluation,
   type ObserveShadowDecisionDocument,
 } from './shadow-decision-contract'
-import { TargetPlanStatus, planTargets, type TargetPlannerInput } from './target-planner'
+import { TargetPlanStatus, planTargets, type PlannedTargetQuantity, type TargetPlannerInput } from './target-planner'
 import type { DecisionPlan } from './types'
 
 export interface ShadowSnapshotBinding {
@@ -67,6 +67,46 @@ const riskBrokerStateMaterial = (state: State) => ({
   ordersObservedAt: state.ordersObservedAt,
   accountingHash: state.accountingHash,
 })
+
+const QUANTITY_SCALE = 1_000_000n
+const absolute = (value: bigint): bigint => (value < 0n ? -value : value)
+const divideAwayFromZero = (numerator: bigint): bigint => {
+  const magnitude = absolute(numerator)
+  const rounded = magnitude === 0n ? 0n : (magnitude + QUANTITY_SCALE - 1n) / QUANTITY_SCALE
+  return numerator < 0n ? -rounded : rounded
+}
+const compareSymbols = (left: Position, right: Position): number => {
+  if (left.symbol < right.symbol) return -1
+  if (left.symbol > right.symbol) return 1
+  return 0
+}
+
+const projectTargetPosition = (
+  positions: readonly Position[],
+  target: PlannedTargetQuantity,
+  accountId: string,
+  observedAt: string,
+): readonly Position[] => {
+  const retained = positions.filter((position) => position.symbol !== target.symbol)
+  const quantity = BigInt(target.targetQuantityMicros)
+  if (quantity === 0n) return retained
+
+  const previous = positions.find((position) => position.symbol === target.symbol)
+  const referencePrice = BigInt(target.referencePriceMicros)
+  const averageEntryPrice = BigInt(previous?.averageEntryPriceMicros ?? target.referencePriceMicros)
+  const projected: Position = {
+    schemaVersion: 'bayn.paper-position.v1',
+    accountId: previous?.accountId ?? accountId,
+    symbol: target.symbol,
+    quantityMicros: target.targetQuantityMicros,
+    averageEntryPriceMicros: averageEntryPrice.toString(),
+    marketPriceMicros: target.referencePriceMicros,
+    marketValueMicros: divideAwayFromZero(quantity * referencePrice).toString(),
+    unrealizedPnlMicros: divideAwayFromZero(quantity * (referencePrice - averageEntryPrice)).toString(),
+    observedAt: previous?.observedAt ?? observedAt,
+  }
+  return [...retained, projected].sort(compareSymbols)
+}
 
 const validateBindings = (
   input: ObserveShadowDecisionInput,
@@ -190,6 +230,8 @@ export const buildObserveShadowDecision = (
 
     let reservedBuyingPower = BigInt(baseReservedBuyingPower)
     let dailyTradedNotional = BigInt(baseDailyTradedNotional)
+    let projectedPositions = firstRiskInput?.state.positions ?? []
+    const targetsBySymbol = new Map(planner.targets.map((target) => [target.symbol, target]))
     const deltaRisk: DeltaRiskEvaluation[] = []
 
     for (const targetIntent of planner.intentTargets) {
@@ -205,6 +247,7 @@ export const buildObserveShadowDecision = (
       )
       const state = yield* decodeState({
         ...provided.state,
+        positions: projectedPositions,
         reservedBuyingPowerMicros: reservedBuyingPower.toString(),
         dailyTradedNotionalMicros: dailyTradedNotional.toString(),
       }).pipe(Effect.mapError((cause) => error('contract', 'cumulative shadow risk state is invalid', cause)))
@@ -223,6 +266,14 @@ export const buildObserveShadowDecision = (
       const orderNotional = BigInt(evaluation.metrics.orderNotionalMicros)
       dailyTradedNotional += orderNotional
       if (targetIntent.side === OrderSide.Buy) reservedBuyingPower += orderNotional
+      const target = targetsBySymbol.get(targetIntent.symbol)
+      if (target === undefined) return yield* fail('contract', 'planned target delta is missing its final quantity')
+      projectedPositions = projectTargetPosition(
+        projectedPositions,
+        target,
+        input.plannerInput.accountId,
+        provided.state.positionsObservedAt,
+      )
       deltaRisk.push({
         notionalLimitMicros: provided.notionalLimitMicros,
         evaluation,

--- a/services/bayn/src/shadow-decision.ts
+++ b/services/bayn/src/shadow-decision.ts
@@ -247,12 +247,11 @@ export const buildObserveShadowDecision = (
       )
       const state = yield* decodeState({
         ...provided.state,
-        positions: projectedPositions,
         reservedBuyingPowerMicros: reservedBuyingPower.toString(),
         dailyTradedNotionalMicros: dailyTradedNotional.toString(),
       }).pipe(Effect.mapError((cause) => error('contract', 'cumulative shadow risk state is invalid', cause)))
       const evaluation = yield* Effect.try({
-        try: () => evaluate(intent, state, input.policy),
+        try: () => evaluate(intent, state, input.policy, projectedPositions),
         catch: (cause) => error('risk', 'shadow target risk evaluation failed', cause),
       })
       if (
@@ -296,7 +295,6 @@ export const buildObserveShadowDecision = (
             strategyDecisionHash,
             policyHash,
             accountId: input.plannerInput.accountId,
-            accountSnapshotHash: canonicalHashV1(input.plannerInput.brokerState.account),
             planningBrokerStateHash: reconciledStateHash(plannerBrokerStateMaterial(input.plannerInput)),
             reconciliationId: input.plannerInput.brokerState.reconciliation.reconciliationId,
             reconciliationHash: input.plannerInput.brokerState.reconciliation.contentHash,

--- a/services/bayn/src/target-planner.ts
+++ b/services/bayn/src/target-planner.ts
@@ -1,4 +1,6 @@
-import type { IntentPlan } from './execution/intents'
+import { Schema } from 'effect'
+
+import { IntentPlanSchema, type IntentPlan } from './execution/intents'
 import { desiredQuantityMicros, MICROS } from './execution-model'
 import { canonicalHashV1 } from './hash'
 import {
@@ -12,7 +14,15 @@ import {
 } from './paper'
 import type { ExecutionModel } from './protocol'
 import { reconciledStateHash, type ReconciledStateMaterial } from './reconciliation'
-import type { IsoDate } from './schemas'
+import {
+  PositiveMicrosSchema,
+  Sha256Schema,
+  SignedMicrosSchema,
+  SymbolSchema,
+  UnitIntervalSchema,
+  UnsignedMicrosSchema,
+  type IsoDate,
+} from './schemas'
 import type { SignalDecision } from './types'
 
 const WEIGHT_SUM_TOLERANCE = 1e-12
@@ -93,6 +103,75 @@ export interface TargetPlanResult {
 }
 
 type OutputMaterial = Omit<TargetPlanResult, 'outputHash'>
+
+const PlannedTargetQuantitySchema = Schema.Struct({
+  symbol: SymbolSchema,
+  targetWeight: UnitIntervalSchema,
+  referencePriceMicros: PositiveMicrosSchema,
+  currentQuantityMicros: SignedMicrosSchema,
+  targetQuantityMicros: SignedMicrosSchema,
+})
+
+const ReferenceTargetIntentSchema = Schema.Struct({
+  strategyName: IntentPlanSchema.fields.strategyName,
+  cycleId: IntentPlanSchema.fields.cycleId,
+  decisionHash: IntentPlanSchema.fields.decisionHash,
+  policyHash: IntentPlanSchema.fields.policyHash,
+  accountId: IntentPlanSchema.fields.accountId,
+  symbol: IntentPlanSchema.fields.symbol,
+  side: IntentPlanSchema.fields.side,
+  orderType: IntentPlanSchema.fields.orderType,
+  timeInForce: IntentPlanSchema.fields.timeInForce,
+  quantityMicros: IntentPlanSchema.fields.quantityMicros,
+  createdAt: IntentPlanSchema.fields.createdAt,
+})
+
+const TargetPlanResultBase = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.paper-reference-target-plan.v1'),
+  inputHash: Sha256Schema,
+  outputHash: Sha256Schema,
+  status: Schema.Enum(TargetPlanStatus),
+  reason: Schema.NullOr(Schema.Enum(TargetPlanReason)),
+  targets: Schema.Array(PlannedTargetQuantitySchema),
+  intentTargets: Schema.Array(ReferenceTargetIntentSchema),
+  requiredReferenceBuyNotionalMicros: UnsignedMicrosSchema,
+  availableBuyingPowerMicros: SignedMicrosSchema,
+  residualBuyingPowerMicros: SignedMicrosSchema,
+})
+
+export const TargetPlanResultSchema = TargetPlanResultBase.check(
+  Schema.makeFilter((result: typeof TargetPlanResultBase.Type): readonly Schema.FilterIssue[] => {
+    const issues: Schema.FilterIssue[] = []
+    const { outputHash, ...material } = result
+    if (outputHash !== canonicalHashV1(material)) {
+      issues.push({ path: ['outputHash'], issue: 'must match the canonical target-plan output material' })
+    }
+    if (result.status === TargetPlanStatus.Planned && (result.reason !== null || result.intentTargets.length === 0)) {
+      issues.push({ path: ['status'], issue: 'PLANNED requires target deltas and no reason' })
+    }
+    if (
+      result.status === TargetPlanStatus.NoTrade &&
+      (result.reason !== TargetPlanReason.TargetsSatisfied || result.intentTargets.length !== 0)
+    ) {
+      issues.push({ path: ['status'], issue: 'NO_TRADE requires TARGETS_SATISFIED and no target deltas' })
+    }
+    if (result.status === TargetPlanStatus.Blocked && (result.reason === null || result.intentTargets.length !== 0)) {
+      issues.push({ path: ['status'], issue: 'BLOCKED requires one reason and no target deltas' })
+    }
+    const targetSymbols = result.targets.map((target) => target.symbol)
+    if (new Set(targetSymbols).size !== targetSymbols.length) {
+      issues.push({ path: ['targets'], issue: 'must contain one target per symbol' })
+    }
+    const intentSymbols = result.intentTargets.map((intent) => intent.symbol)
+    if (
+      new Set(intentSymbols).size !== intentSymbols.length ||
+      intentSymbols.some((symbol) => !targetSymbols.includes(symbol))
+    ) {
+      issues.push({ path: ['intentTargets'], issue: 'must contain at most one delta for each persisted target' })
+    }
+    return issues
+  }),
+)
 
 const compareText = (left: string, right: string): number => (left < right ? -1 : left > right ? 1 : 0)
 


### PR DESCRIPTION
## Summary

- define one versioned, content-hashed, non-dispatchable OBSERVE decision document that reuses the canonical target-plan and risk-evaluation contracts
- evaluate ordered target deltas with cumulative buying-power, notional, and proposed-position exposure while preserving the exact reconciled broker snapshot; the risk input hashes every proposed position set without fabricating reconciliation evidence
- persist the document atomically with `autonomous_cycles.decision_hash = document.contentHash`; keep ordinary cycle reads hash-only and expose `CycleStore.readDecisionDocument` for explicit recovery
- bind the exact snapshot, compiled strategy decision, source-controlled policy, planning broker state, and reconciliation while omitting redundant unverifiable bindings
- prove append-only replay/conflict behavior and zero intent, risk-decision, mutation, or broker-dispatch state

## Related Issues

PROOMPT-382

## Testing

- `bun run --filter @proompteng/bayn tsc`
- `bun run --cwd services/bayn lint:oxlint`
- `bun run --cwd services/bayn lint:oxlint:type`
- `bunx oxfmt --check services/bayn/src/risk.ts services/bayn/src/shadow-decision.ts services/bayn/src/shadow-decision-contract.ts services/bayn/src/shadow-decision.test.ts services/bayn/src/db/cycle-store.integration.test.ts`
- `bun test services/bayn/src/shadow-decision.test.ts services/bayn/src/risk.test.ts` (17 passed, 165 assertions)
- `bun run --cwd services/bayn test` (308 passed, 63 PostgreSQL-gated skipped, 1,441 assertions)
- `bun test packages/scripts/src/bayn` (9 passed)
- `bun run --cwd services/bayn build`
- PostgreSQL 18: `bun test services/bayn/src/db/evidence-store.integration.test.ts` (36 passed, 168 assertions)
- PostgreSQL 18: `bun test services/bayn/src/db/paper-store.integration.test.ts` (7 passed, 56 assertions)
- PostgreSQL 18: `bun test services/bayn/src/db/cycle-store.integration.test.ts` (10 passed, 88 assertions)

## Breaking Changes

Migration 12 intentionally fails closed if an existing autonomous cycle already has a non-null `decision_hash`, because no legacy hash can be represented as the exact shadow document required by the new atomic binding. `CycleStore.bindDecision` now accepts the canonical document rather than an unbound hash; ordinary cycle and authority-slot reads retain only its content hash, and the full document is loaded explicitly with `readDecisionDocument`. There is no production decision writer in this slice.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation and subsequent runtime composition remain tracked by PROOMPT-382.