### PR TITLE
fix(buzz): deploy Ceph-compatible relay image

### DIFF
--- a/argocd/applications/buzz/alloy-deployment.yaml
+++ b/argocd/applications/buzz/alloy-deployment.yaml
@@ -31,6 +31,7 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - run
+            - --server.http.listen-addr=0.0.0.0:12345
             - /etc/alloy/config.alloy
           workingDir: /var/lib/alloy
           ports:

--- a/argocd/applications/buzz/kustomization.yaml
+++ b/argocd/applications/buzz/kustomization.yaml
@@ -29,9 +29,9 @@ helmCharts:
 
 images:
   - name: ghcr.io/block/buzz
-    newName: ghcr.io/block/buzz
-    newTag: sha-acfbb1b
-    digest: sha256:29fe13981a726fe43642fe03cbd6cc87142579a90bbf9897e3c1b370d1037428
+    newName: registry.ide-newton.ts.net/lab/buzz
+    newTag: sha-dba56ff36e19307d93a738c9005aaa3cbfa718df
+    digest: sha256:16d08bf8e2772a93924de1a49746a034d3410387d6095b214ed2e798aa7d6cfb
 
 patches:
   - target:

--- a/argocd/applications/buzz/values.yaml
+++ b/argocd/applications/buzz/values.yaml
@@ -27,6 +27,9 @@ relay:
   allowNipOaAuth: true
   pubkeyAllowlist: false
   huddleAudioAvailable: false
+  extraEnv:
+    - name: BUZZ_GIT_S3_COMPATIBILITY
+      value: ceph-rgw
   topologySpreadConstraints:
     - maxSkew: 1
       topologyKey: kubernetes.io/hostname

--- a/docs/runbooks/buzz-production.md
+++ b/docs/runbooks/buzz-production.md
@@ -7,9 +7,17 @@ Buzz is deployed to the `buzz` namespace by the `buzz` Argo CD application. It i
 
 - Helm chart: `oci://ghcr.io/block/buzz/charts/buzz:0.1.6`
   (`sha256:88b96378cabd6b64c9bb8da9824a608daac3b0965d2aa17019e70248c07d517c`).
-- Relay image: `ghcr.io/block/buzz:sha-acfbb1b`
-  (`sha256:29fe13981a726fe43642fe03cbd6cc87142579a90bbf9897e3c1b370d1037428`, source revision
-  `acfbb1bb6af54cb29cb152496ff43b8285dcb8cf`).
+- Relay image:
+  `registry.ide-newton.ts.net/lab/buzz:sha-dba56ff36e19307d93a738c9005aaa3cbfa718df`
+  (`sha256:16d08bf8e2772a93924de1a49746a034d3410387d6095b214ed2e798aa7d6cfb`, lab revision
+  `dba56ff36e19307d93a738c9005aaa3cbfa718df`).
+- The derivative image preserves upstream runtime index
+  `ghcr.io/block/buzz@sha256:29fe13981a726fe43642fe03cbd6cc87142579a90bbf9897e3c1b370d1037428`
+  and replaces only `buzz-relay`, built from upstream revision
+  `acfbb1bb6af54cb29cb152496ff43b8285dcb8cf` with the bounded Ceph RGW patch.
+- `BUZZ_GIT_S3_COMPATIBILITY=ceph-rgw` enables the compatibility boundary. Remove the derivative and this setting
+  after upstream ships equivalent quoted-ETag and conditional-conflict handling and the production A3 conformance
+  test passes on the upstream image.
 - `RELAY_OWNER_PUBKEY` is public and committed in `argocd/applications/buzz/values.yaml`.
 - The owner's `nsec` is stored only in the human-owned `buzz-owner` item in the 1Password `Private` vault.
 - `buzz-runtime` in the 1Password `infra` vault contains the stable relay private key, Git hook HMAC secret, and

--- a/packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts
+++ b/packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts
@@ -24,12 +24,15 @@ describe('Buzz production GitOps contract', () => {
 
     expect(kustomization).toContain('version: 0.1.6')
     expect(kustomization).toContain('sha256:88b96378cabd6b64c9bb8da9824a608daac3b0965d2aa17019e70248c07d517c')
-    expect(kustomization).toContain('newTag: sha-acfbb1b')
-    expect(kustomization).toContain('sha256:29fe13981a726fe43642fe03cbd6cc87142579a90bbf9897e3c1b370d1037428')
+    expect(kustomization).toContain('newName: registry.ide-newton.ts.net/lab/buzz')
+    expect(kustomization).toContain('newTag: sha-dba56ff36e19307d93a738c9005aaa3cbfa718df')
+    expect(kustomization).toContain('sha256:16d08bf8e2772a93924de1a49746a034d3410387d6095b214ed2e798aa7d6cfb')
 
     for (const manifest of [kustomization, postgres, redis, alloy]) {
       expect(manifest).toContain('sha256:')
     }
+
+    expect(alloy).toContain('--server.http.listen-addr=0.0.0.0:12345')
   })
 
   test('builds the Ceph compatibility relay from pinned upstream inputs for both cluster architectures', () => {
@@ -73,6 +76,8 @@ describe('Buzz production GitOps contract', () => {
       'replicaCount: 2',
       'requireAuthToken: true',
       'requireRelayMembership: true',
+      'BUZZ_GIT_S3_COMPATIBILITY',
+      'value: ceph-rgw',
       'huddleAudioAvailable: false',
       'pairingRelay:\n  enabled: false',
       'persistence:\n  git:\n    enabled: false',

--- a/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
+++ b/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
@@ -258,7 +258,7 @@ describe('enabled app inventory', () => {
   })
 
   it('keeps repo-image apps without local build ownership out of Nix migration state', () => {
-    for (const name of ['analysis', 'bilig', 'hermes', 'tigresse']) {
+    for (const name of ['analysis', 'bilig', 'buzz', 'hermes', 'tigresse']) {
       expect(entry(name).class).toBe('vendor-manifest')
       expect(entry(name).repoImages.length).toBeGreaterThan(0)
       expect(entry(name).buildScriptPath).toBeUndefined()
@@ -266,6 +266,18 @@ describe('enabled app inventory', () => {
       expect(entry(name).nixImageAttr).toBeUndefined()
       expect(entry(name).deferredReason).toBeTruthy()
     }
+  })
+
+  it('tracks Buzz as a reviewed upstream derivative, not an in-repo Nix image gap', () => {
+    expect(entry('buzz')).toMatchObject({
+      class: 'vendor-manifest',
+      hasHelmChart: true,
+      repoImages: [
+        'registry.ide-newton.ts.net/lab/buzz@sha256:16d08bf8e2772a93924de1a49746a034d3410387d6095b214ed2e798aa7d6cfb',
+      ],
+      workflowPaths: ['.github/workflows/buzz-relay-build-push.yml'],
+    })
+    expect(entry('buzz').deferredReason).toContain('block/buzz')
   })
 
   it('tracks Hermes as a reviewed upstream mirror, not an in-repo image build gap', () => {

--- a/packages/scripts/src/shared/enabled-apps.ts
+++ b/packages/scripts/src/shared/enabled-apps.ts
@@ -128,6 +128,10 @@ const manifestOnlyRepoImageApps = new Map<string, string>([
   ['analysis', 'repo image is tracked by image updater, but no local source build/deploy path exists in this repo'],
   ['bilig', 'repo image is produced outside this checkout; this app is GitOps/image-updater managed here'],
   [
+    'buzz',
+    'relay source lives in the upstream block/buzz repository; lab builds a bounded Ceph RGW compatibility derivative and pins its image digest',
+  ],
+  [
     'hermes',
     'agent source lives in the upstream NousResearch/hermes-agent repository; lab mirrors a reviewed release and pins its image digest',
   ],


### PR DESCRIPTION
## Summary

- Pin Buzz to the verified multi-architecture derivative relay image built from upstream `acfbb1b` with the bounded Ceph RGW conditional-write compatibility patch.
- Enable the patch only through `BUZZ_GIT_S3_COMPATIBILITY=ceph-rgw`.
- Bind the namespace-local Alloy HTTP endpoint to the pod network so its Kubernetes health probes succeed.
- Document image provenance, compatibility scope, and the removal condition.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts` (7 pass)
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts`
- `git diff --check`
- `bun run lint:argocd` (all rendered resource sets valid)
- `kustomize build --enable-helm argocd/applications/buzz | kubectl apply -n buzz --server-side --dry-run=server --field-manager=argocd-controller -f -`
- Verified the render contains no `Namespace`, pins two relay replicas to `registry.ide-newton.ts.net/lab/buzz:sha-dba56ff36e19307d93a738c9005aaa3cbfa718df@sha256:16d08bf8e2772a93924de1a49746a034d3410387d6095b214ed2e798aa7d6cfb`, and sets `BUZZ_GIT_S3_COMPATIBILITY=ceph-rgw`.
- Verified the OCI index contains `linux/amd64` and `linux/arm64`; both manifests carry lab revision `dba56ff36e19307d93a738c9005aaa3cbfa718df`, upstream revision `acfbb1bb6af54cb29cb152496ff43b8285dcb8cf`, and the pinned upstream runtime index label.
- Verified `alloy run --help` supports `--server.http.listen-addr`; live failure evidence showed the prior default bound `127.0.0.1:12345` while probes targeted the pod IP.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.