### PR TITLE
feat(bayn): recover autonomous observe cycles

### DIFF
--- a/services/bayn/migrations/0013_autonomous_cycle_terminal_transitions.ts
+++ b/services/bayn/migrations/0013_autonomous_cycle_terminal_transitions.ts
@@ -1,0 +1,174 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient
+
+  yield* sql`
+    CREATE OR REPLACE FUNCTION enforce_autonomous_cycle_lifecycle()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+    DECLARE
+      mutable_columns text[] := ARRAY[
+        'state',
+        'snapshot_id',
+        'decision_hash',
+        'terminal_reason',
+        'state_version',
+        'updated_at',
+        'terminal_at'
+      ];
+      expected_target_status text;
+    BEGIN
+      IF TG_OP = 'DELETE' THEN
+        RAISE EXCEPTION 'autonomous cycles cannot be deleted' USING ERRCODE = '55000';
+      END IF;
+
+      IF TG_OP = 'INSERT' THEN
+        IF NEW.state_version <> 1 OR NEW.created_at <> NEW.updated_at OR NOT (
+          (NEW.state = 'PENDING' AND NEW.snapshot_id IS NULL AND NEW.decision_hash IS NULL)
+          OR (
+            NEW.state = 'BLOCKED'
+            AND NEW.snapshot_id IS NULL
+            AND NEW.decision_hash IS NULL
+            AND NEW.terminal_reason = 'BLOCKED_MISSED_PUBLICATION_DEADLINE'
+            AND NEW.updated_at >= NEW.publication_deadline_at
+          )
+        ) THEN
+          RAISE EXCEPTION 'invalid initial autonomous cycle state' USING ERRCODE = '23514';
+        END IF;
+        RETURN NEW;
+      END IF;
+
+      IF OLD.state IN ('COMPLETED', 'NO_TRADE', 'BLOCKED') THEN
+        RAISE EXCEPTION 'terminal autonomous cycle history cannot change' USING ERRCODE = '55000';
+      END IF;
+
+      IF (OLD.state, NEW.state) NOT IN (
+        ('PENDING', 'PENDING'),
+        ('PENDING', 'ACTIVE'),
+        ('PENDING', 'BLOCKED'),
+        ('ACTIVE', 'ACTIVE'),
+        ('ACTIVE', 'COMPLETED'),
+        ('ACTIVE', 'NO_TRADE'),
+        ('ACTIVE', 'BLOCKED')
+      ) THEN
+        RAISE EXCEPTION 'invalid autonomous cycle state transition' USING ERRCODE = '23514';
+      END IF;
+      IF OLD.state = NEW.state AND NOT (
+        (
+          OLD.state = 'PENDING'
+          AND OLD.snapshot_id IS NULL
+          AND NEW.snapshot_id IS NOT NULL
+          AND NEW.decision_hash IS NOT DISTINCT FROM OLD.decision_hash
+        )
+        OR (
+          OLD.state = 'ACTIVE'
+          AND NEW.snapshot_id IS NOT DISTINCT FROM OLD.snapshot_id
+          AND OLD.decision_hash IS NULL
+          AND NEW.decision_hash IS NOT NULL
+        )
+      ) THEN
+        RAISE EXCEPTION 'invalid autonomous cycle binding transition' USING ERRCODE = '23514';
+      END IF;
+      IF OLD.state <> NEW.state AND (
+        NEW.snapshot_id IS DISTINCT FROM OLD.snapshot_id
+        OR NEW.decision_hash IS DISTINCT FROM OLD.decision_hash
+      ) THEN
+        RAISE EXCEPTION 'autonomous cycle state transitions cannot change bindings' USING ERRCODE = '23514';
+      END IF;
+      IF to_jsonb(OLD) - mutable_columns <> to_jsonb(NEW) - mutable_columns THEN
+        RAISE EXCEPTION 'autonomous cycle identity and deadlines cannot change' USING ERRCODE = '55000';
+      END IF;
+      IF NEW.state_version <> OLD.state_version + 1 OR NEW.updated_at < OLD.updated_at THEN
+        RAISE EXCEPTION 'autonomous cycle version and time must advance monotonically' USING ERRCODE = '23514';
+      END IF;
+      IF OLD.snapshot_id IS NULL AND NEW.snapshot_id IS NOT NULL THEN
+        IF NEW.updated_at < NEW.signal_close_at THEN
+          RAISE EXCEPTION 'autonomous cycle snapshot cannot bind before signal close' USING ERRCODE = '23514';
+        END IF;
+        IF NEW.updated_at >= NEW.publication_deadline_at THEN
+          RAISE EXCEPTION 'autonomous cycle snapshot missed publication deadline' USING ERRCODE = '23514';
+        END IF;
+        IF NOT EXISTS (
+          SELECT 1
+          FROM snapshot_references
+          WHERE snapshot_id = NEW.snapshot_id
+            AND last_session = NEW.signal_session_date
+            AND manifest->>'calendarVersion' = NEW.signal_calendar_version
+        ) THEN
+          RAISE EXCEPTION 'autonomous cycle snapshot does not match signal session and calendar'
+            USING ERRCODE = '23514';
+        END IF;
+      END IF;
+      IF NEW.state = 'ACTIVE' AND NEW.updated_at >= NEW.submission_cutoff_at THEN
+        RAISE EXCEPTION 'autonomous cycle activation or decision missed submission cutoff' USING ERRCODE = '23514';
+      END IF;
+      IF NEW.state IN ('COMPLETED', 'NO_TRADE') THEN
+        expected_target_status := CASE NEW.state
+          WHEN 'COMPLETED' THEN 'PLANNED'
+          ELSE 'NO_TRADE'
+        END;
+        IF NOT EXISTS (
+          SELECT 1
+          FROM autonomous_cycle_shadow_decisions
+          WHERE cycle_id = NEW.cycle_id
+            AND decision_hash = NEW.decision_hash
+            AND document #>> '{targetPlan,status}' = expected_target_status
+        ) THEN
+          RAISE EXCEPTION 'autonomous cycle terminal state does not match its shadow decision'
+            USING ERRCODE = '23514';
+        END IF;
+      END IF;
+      IF NEW.state = 'BLOCKED' AND OLD.state = 'ACTIVE' AND OLD.decision_hash IS NOT NULL THEN
+        IF NOT EXISTS (
+          SELECT 1
+          FROM autonomous_cycle_shadow_decisions
+          WHERE cycle_id = NEW.cycle_id
+            AND decision_hash = NEW.decision_hash
+            AND document #>> '{targetPlan,status}' = 'BLOCKED'
+            AND NEW.terminal_reason = CASE document #>> '{targetPlan,reason}'
+              WHEN 'SUBMISSION_CUTOFF_REACHED' THEN 'BLOCKED_MISSED_SUBMISSION_DEADLINE'
+              WHEN 'IDENTITY_MISMATCH' THEN 'BLOCKED_PROVENANCE_MISMATCH'
+              WHEN 'INPUT_MISMATCH' THEN 'BLOCKED_DATA_INVALID'
+              WHEN 'INPUT_STALE' THEN 'BLOCKED_DATA_STALE'
+              WHEN 'RECONCILIATION_NOT_EXACT' THEN 'BLOCKED_RECONCILIATION'
+              WHEN 'ACCOUNT_NOT_ACTIVE' THEN 'BLOCKED_BROKER_DISABLED'
+              WHEN 'UNKNOWN_ORDER' THEN 'BLOCKED_UNRESOLVED_MUTATION'
+              WHEN 'UNRESOLVED_ORDER' THEN 'BLOCKED_UNRESOLVED_MUTATION'
+              WHEN 'BELOW_MINIMUM_BUY_NOTIONAL' THEN 'BLOCKED_RISK'
+              WHEN 'INSUFFICIENT_BUYING_POWER' THEN 'BLOCKED_RISK'
+              WHEN 'NON_POSITIVE_EQUITY' THEN 'BLOCKED_RISK'
+              WHEN 'SHORT_POSITION_NOT_ALLOWED' THEN 'BLOCKED_RISK'
+              ELSE NULL
+            END
+        ) THEN
+          RAISE EXCEPTION 'autonomous cycle blocked reason does not match its shadow decision'
+            USING ERRCODE = '23514';
+        END IF;
+      END IF;
+      IF (
+        NEW.state = 'BLOCKED'
+        AND NEW.terminal_reason = 'BLOCKED_MISSED_PUBLICATION_DEADLINE'
+        AND (
+          OLD.state <> 'PENDING'
+          OR OLD.snapshot_id IS NOT NULL
+          OR NEW.updated_at < NEW.publication_deadline_at
+        )
+      ) THEN
+        RAISE EXCEPTION 'invalid missed-publication transition' USING ERRCODE = '23514';
+      END IF;
+      IF (
+        NEW.state = 'BLOCKED'
+        AND NEW.terminal_reason = 'BLOCKED_MISSED_SUBMISSION_DEADLINE'
+        AND NEW.updated_at < NEW.submission_cutoff_at
+      ) THEN
+        RAISE EXCEPTION 'invalid missed-submission transition' USING ERRCODE = '23514';
+      END IF;
+
+      RETURN NEW;
+    END
+    $function$
+  `
+})

--- a/services/bayn/src/cycle-readiness.test.ts
+++ b/services/bayn/src/cycle-readiness.test.ts
@@ -174,6 +174,7 @@ const cycleStore = (control: StoreControl): CycleStoreShape => {
     read: () => Effect.succeed(Option.some(control.current)),
     readAuthoritySlot: unused,
     readDecisionDocument: unused,
+    readOldestUnfinished: unused,
     bindSnapshot: (_cycleId, inputManifest, observedAt) =>
       Effect.sync(() => {
         control.binds += 1
@@ -194,6 +195,7 @@ const cycleStore = (control: StoreControl): CycleStoreShape => {
       }),
     activate: unused,
     bindDecision: unused,
+    finish: unused,
     block: (_cycleId, reason, observedAt) =>
       Effect.sync(() => {
         control.blocks += 1

--- a/services/bayn/src/cycle-recovery.ts
+++ b/services/bayn/src/cycle-recovery.ts
@@ -1,0 +1,183 @@
+import {
+  CycleState,
+  CycleTerminalReason,
+  cycleTerminalReasonForTargetPlanBlock,
+  isTerminalCycleState,
+  type AutonomousCycle,
+  type CycleCompletionState,
+} from './cycle'
+import type { CyclePublicationReadiness } from './cycle-readiness'
+import type { ObserveShadowDecisionDocument } from './shadow-decision-contract'
+import { TargetPlanStatus } from './target-planner'
+
+export type CycleRecoverySelection =
+  | { readonly action: 'DISCOVER' }
+  | {
+      readonly action: 'BLOCK'
+      readonly cycleId: string
+      readonly observedAt: string
+      readonly reason: CycleTerminalReason
+    }
+  | { readonly action: 'READ_PUBLICATION'; readonly cycle: AutonomousCycle }
+  | {
+      readonly action: 'RETURN_READINESS'
+      readonly result: CyclePublicationReadiness
+      readonly recoveryAction: 'BLOCKED' | 'BOUND_SNAPSHOT' | 'WAITING'
+    }
+  | {
+      readonly action: 'ACTIVATE'
+      readonly cycleId: string
+      readonly observedAt: string
+    }
+  | { readonly action: 'BUILD_DECISION'; readonly cycle: AutonomousCycle }
+  | { readonly action: 'READ_DECISION'; readonly cycle: AutonomousCycle }
+  | {
+      readonly action: 'FINISH'
+      readonly cycleId: string
+      readonly observedAt: string
+      readonly state: CycleCompletionState
+    }
+
+export interface CycleRecoveryState {
+  readonly qualificationRunId: string
+  readonly accountId: string
+  readonly strategyProtocolHash: string
+  readonly observedAt: string
+  readonly cycle: AutonomousCycle | undefined
+  readonly readiness?: CyclePublicationReadiness
+  readonly decisionDocument?: ObserveShadowDecisionDocument | null
+}
+
+const validateDecisionBinding = (cycle: AutonomousCycle, document: ObserveShadowDecisionDocument): void => {
+  if (
+    cycle.bindings.decisionHash !== document.contentHash ||
+    cycle.bindings.snapshotId !== document.bindings.snapshotId ||
+    cycle.identity.cycleId !== document.bindings.cycleId ||
+    cycle.identity.strategyName !== document.bindings.strategyName ||
+    cycle.identity.strategyProtocolHash !== document.bindings.strategyProtocolHash ||
+    cycle.identity.accountId !== document.bindings.accountId ||
+    cycle.window.submissionCutoffAt !== document.submissionCutoffAt ||
+    document.createdAt > cycle.updatedAt
+  ) {
+    throw new TypeError('durable shadow decision does not match the active cycle binding')
+  }
+}
+
+const selectBoundDecision = (
+  cycle: AutonomousCycle,
+  document: ObserveShadowDecisionDocument | null | undefined,
+  observedAt: string,
+): CycleRecoverySelection => {
+  if (document === undefined) return { action: 'READ_DECISION', cycle }
+  if (document === null) throw new TypeError('decision-bound cycle is missing its durable document')
+  validateDecisionBinding(cycle, document)
+  switch (document.targetPlan.status) {
+    case TargetPlanStatus.Planned:
+      return {
+        action: 'FINISH',
+        cycleId: cycle.identity.cycleId,
+        observedAt,
+        state: CycleState.Completed,
+      }
+    case TargetPlanStatus.NoTrade:
+      return {
+        action: 'FINISH',
+        cycleId: cycle.identity.cycleId,
+        observedAt,
+        state: CycleState.NoTrade,
+      }
+    case TargetPlanStatus.Blocked: {
+      const reason = document.targetPlan.reason
+      if (reason === null) throw new TypeError('blocked target plan requires its durable reason')
+      return {
+        action: 'BLOCK',
+        cycleId: cycle.identity.cycleId,
+        observedAt,
+        reason: cycleTerminalReasonForTargetPlanBlock(reason),
+      }
+    }
+  }
+}
+
+export const selectCycleRecovery = (state: CycleRecoveryState): CycleRecoverySelection => {
+  const { cycle, decisionDocument, readiness } = state
+  if (cycle === undefined) {
+    if (readiness !== undefined || decisionDocument !== undefined) {
+      throw new TypeError('recovery evidence requires an unfinished cycle')
+    }
+    return { action: 'DISCOVER' }
+  }
+  if (cycle.identity.qualificationRunId !== state.qualificationRunId || cycle.identity.accountId !== state.accountId) {
+    throw new TypeError('unfinished cycle does not match the configured recovery scope')
+  }
+  if (isTerminalCycleState(cycle.state)) {
+    throw new TypeError('terminal cycles must not enter autonomous recovery')
+  }
+  if (cycle.state === CycleState.Active && cycle.bindings.decisionHash !== undefined) {
+    if (readiness !== undefined) throw new TypeError('active cycle recovery does not accept publication readiness')
+    return selectBoundDecision(cycle, decisionDocument, state.observedAt)
+  }
+  if (
+    cycle.state === CycleState.Pending &&
+    cycle.bindings.snapshotId === undefined &&
+    state.observedAt >= cycle.window.publicationDeadlineAt
+  ) {
+    return {
+      action: 'BLOCK',
+      cycleId: cycle.identity.cycleId,
+      observedAt: state.observedAt,
+      reason: CycleTerminalReason.MissedPublication,
+    }
+  }
+  if (
+    (cycle.state === CycleState.Active || cycle.bindings.snapshotId !== undefined) &&
+    state.observedAt >= cycle.window.submissionCutoffAt
+  ) {
+    return {
+      action: 'BLOCK',
+      cycleId: cycle.identity.cycleId,
+      observedAt: state.observedAt,
+      reason: CycleTerminalReason.MissedSubmission,
+    }
+  }
+  if (cycle.identity.strategyProtocolHash !== state.strategyProtocolHash) {
+    return {
+      action: 'BLOCK',
+      cycleId: cycle.identity.cycleId,
+      observedAt: state.observedAt,
+      reason: CycleTerminalReason.ProvenanceMismatch,
+    }
+  }
+  if (cycle.state === CycleState.Active) {
+    if (readiness !== undefined) throw new TypeError('active cycle recovery does not accept publication readiness')
+    if (decisionDocument !== undefined) {
+      throw new TypeError('unbound active cycle cannot have durable decision evidence')
+    }
+    return { action: 'BUILD_DECISION', cycle }
+  }
+  if (cycle.state !== CycleState.Pending) {
+    throw new TypeError(`unsupported unfinished cycle state ${cycle.state}`)
+  }
+  if (decisionDocument !== undefined) {
+    throw new TypeError('pending cycle recovery does not accept decision evidence')
+  }
+  if (readiness === undefined) return { action: 'READ_PUBLICATION', cycle }
+  if (readiness.cycle.identity.cycleId !== cycle.identity.cycleId) {
+    throw new TypeError('publication readiness must describe the selected unfinished cycle')
+  }
+
+  switch (readiness.outcome) {
+    case 'WAITING':
+      return { action: 'RETURN_READINESS', recoveryAction: 'WAITING', result: readiness }
+    case 'BLOCKED':
+      return { action: 'RETURN_READINESS', recoveryAction: 'BLOCKED', result: readiness }
+    case 'BOUND':
+      return { action: 'RETURN_READINESS', recoveryAction: 'BOUND_SNAPSHOT', result: readiness }
+    case 'ALREADY_BOUND':
+      return {
+        action: 'ACTIVATE',
+        cycleId: readiness.cycle.identity.cycleId,
+        observedAt: readiness.observedAt,
+      }
+  }
+}

--- a/services/bayn/src/cycle-recovery.ts
+++ b/services/bayn/src/cycle-recovery.ts
@@ -29,6 +29,11 @@ export type CycleRecoverySelection =
       readonly cycleId: string
       readonly observedAt: string
     }
+  | {
+      readonly action: 'WAIT'
+      readonly cycle: AutonomousCycle
+      readonly observedAt: string
+    }
   | { readonly action: 'BUILD_DECISION'; readonly cycle: AutonomousCycle }
   | { readonly action: 'READ_DECISION'; readonly cycle: AutonomousCycle }
   | {
@@ -152,6 +157,9 @@ export const selectCycleRecovery = (state: CycleRecoveryState): CycleRecoverySel
     if (readiness !== undefined) throw new TypeError('active cycle recovery does not accept publication readiness')
     if (decisionDocument !== undefined) {
       throw new TypeError('unbound active cycle cannot have durable decision evidence')
+    }
+    if (state.observedAt < cycle.window.submissionOpenAt) {
+      return { action: 'WAIT', cycle, observedAt: state.observedAt }
     }
     return { action: 'BUILD_DECISION', cycle }
   }

--- a/services/bayn/src/cycle-runner.test.ts
+++ b/services/bayn/src/cycle-runner.test.ts
@@ -254,12 +254,16 @@ const cycleFrom = (draft: CycleDraft, observedAt: string): AutonomousCycle => {
   }
 }
 
-const makeNoTradeDecision = (cycle: AutonomousCycle, createdAt: string): ObserveShadowDecisionDocument => {
+const makeDecision = (
+  cycle: AutonomousCycle,
+  createdAt: string,
+  blockedReason?: Exclude<TargetPlanReason, TargetPlanReason.TargetsSatisfied>,
+): ObserveShadowDecisionDocument => {
   const targetPlanMaterial = {
     schemaVersion: 'bayn.paper-reference-target-plan.v1' as const,
     inputHash: '4'.repeat(64),
-    status: TargetPlanStatus.NoTrade,
-    reason: TargetPlanReason.TargetsSatisfied,
+    status: blockedReason === undefined ? TargetPlanStatus.NoTrade : TargetPlanStatus.Blocked,
+    reason: blockedReason ?? TargetPlanReason.TargetsSatisfied,
     targets: [],
     intentTargets: [],
     requiredReferenceBuyNotionalMicros: '0',
@@ -576,12 +580,12 @@ describe('autonomous cycle runner', () => {
       ),
     ).toThrow('terminal cycles must not enter autonomous recovery')
 
-    const decision = makeNoTradeDecision(active, '2026-01-30T21:24:00.000Z')
+    const decision = makeDecision(active, '2026-01-30T21:23:30.000Z')
     const decisionBound: AutonomousCycle = {
       ...active,
       bindings: { ...active.bindings, decisionHash: decision.contentHash },
       stateVersion: active.stateVersion + 1,
-      updatedAt: decision.createdAt,
+      updatedAt: '2026-01-30T21:24:00.000Z',
     }
     const afterCutoff = new Date(Date.parse(active.window.submissionCutoffAt) + 1).toISOString()
     expect(
@@ -605,6 +609,26 @@ describe('autonomous cycle runner', () => {
       cycleId: decisionBound.identity.cycleId,
       observedAt: afterCutoff,
       state: CycleState.NoTrade,
+    })
+
+    const blockedDecision = makeDecision(active, decision.createdAt, TargetPlanReason.InputStale)
+    const blockedDecisionBound: AutonomousCycle = {
+      ...decisionBound,
+      bindings: { ...active.bindings, decisionHash: blockedDecision.contentHash },
+    }
+    expect(
+      selectCycleRecovery(
+        recoveryState(blockedDecisionBound, {
+          strategyProtocolHash: 'f'.repeat(64),
+          observedAt: afterCutoff,
+          decisionDocument: blockedDecision,
+        }),
+      ),
+    ).toEqual({
+      action: 'BLOCK',
+      cycleId: blockedDecisionBound.identity.cycleId,
+      observedAt: afterCutoff,
+      reason: CycleTerminalReason.DataStale,
     })
   })
 
@@ -918,7 +942,7 @@ describe('autonomous cycle runner', () => {
         const activated = yield* provide(runAutonomousCyclePass(context()), read, store, marketData)
         yield* TestClock.setTime(Date.parse(decisionAt))
         const decisionBound = yield* provide(
-          runAutonomousCyclePass(context(undefined, (cycle) => Effect.succeed(makeNoTradeDecision(cycle, decisionAt)))),
+          runAutonomousCyclePass(context(undefined, (cycle) => Effect.succeed(makeDecision(cycle, decisionAt)))),
           read,
           store,
           marketData,
@@ -981,7 +1005,7 @@ describe('autonomous cycle runner', () => {
         return yield* provide(
           runAutonomousCyclePass(
             context(undefined, (cycle) =>
-              TestClock.adjust(9 * 60_000).pipe(Effect.as(makeNoTradeDecision(cycle, documentCreatedAt))),
+              TestClock.adjust(9 * 60_000).pipe(Effect.as(makeDecision(cycle, documentCreatedAt))),
             ),
           ),
           read,

--- a/services/bayn/src/cycle-runner.test.ts
+++ b/services/bayn/src/cycle-runner.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Deferred, Effect, Fiber, Logger, Option, References } from 'effect'
+import { Cause, Deferred, Effect, Fiber, Logger, Option, References } from 'effect'
 import { TestClock } from 'effect/testing'
 
 import {
@@ -27,8 +27,10 @@ import {
   selectNextExecutionSession,
   startAutonomousCycleLoop,
   type CycleCandidate,
+  type CyclePassObservation,
   type CycleRunContext,
 } from './cycle-runner'
+import { selectCycleRecovery, type CycleRecoveryState } from './cycle-recovery'
 import { CycleStore, type CycleAuthoritySlot, type CycleStoreShape } from './db/cycle-store'
 import { canonicalHashV1, sha256 } from './hash'
 import {
@@ -37,6 +39,8 @@ import {
   type MarketDataInspection,
   type MarketDataService,
 } from './market-data'
+import { makeObserveShadowDecisionDocument, type ObserveShadowDecisionDocument } from './shadow-decision-contract'
+import { TargetPlanReason, TargetPlanStatus } from './target-planner'
 import { DataFeed, DataSource, PriceAdjustment, PublicationSchema, type InputManifest, type IsoDate } from './types'
 
 const signalCalendarVersion = 'signal-XNYS-2026-v1'
@@ -55,12 +59,19 @@ const executionPolicy = makeCycleExecutionPolicy({
   submissionCutoffBeforeOpenMs: 2 * 60 * 1_000,
 })
 
-const context = (accountId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'): CycleRunContext => ({
+const context = (
+  accountId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+  buildDecision: CycleRunContext['buildDecision'] = () =>
+    Effect.die(new Error('cycle runner built an unexpected decision')),
+): CycleRunContext => ({
   qualificationRunId: '1'.repeat(64),
   strategyProtocolHash: '2'.repeat(64),
   accountId,
   executionPolicy,
+  buildDecision,
 })
+
+const ignorePass = () => Effect.void
 
 const signalSession = (sessionDate: IsoDate) => ({
   calendar_version: signalCalendarVersion,
@@ -209,14 +220,23 @@ const finalizedPublication = (
 
 const marketDataService = (
   inspectCyclePublications: MarketDataService['inspectCyclePublications'],
+  exactPublication?: MarketDataInspection,
 ): MarketDataService => {
   const unused = Effect.die(new Error('cycle runner must inspect only bounded finalized publication candidates'))
+  const inspectExactPublication = () =>
+    exactPublication === undefined
+      ? unused
+      : Effect.succeed({
+          outcome: 'FINALIZED' as const,
+          observedAt: exactPublication.manifest.finalizedSnapshot.finalizedAt,
+          inspection: exactPublication,
+        })
   return {
     check: unused,
     inspect: unused,
     inspectCyclePublications,
-    inspectPublication: () => unused,
-    inspectSnapshotPublication: () => unused,
+    inspectPublication: inspectExactPublication,
+    inspectSnapshotPublication: inspectExactPublication,
     load: unused,
   }
 }
@@ -234,6 +254,49 @@ const cycleFrom = (draft: CycleDraft, observedAt: string): AutonomousCycle => {
   }
 }
 
+const makeNoTradeDecision = (cycle: AutonomousCycle, createdAt: string): ObserveShadowDecisionDocument => {
+  const targetPlanMaterial = {
+    schemaVersion: 'bayn.paper-reference-target-plan.v1' as const,
+    inputHash: '4'.repeat(64),
+    status: TargetPlanStatus.NoTrade,
+    reason: TargetPlanReason.TargetsSatisfied,
+    targets: [],
+    intentTargets: [],
+    requiredReferenceBuyNotionalMicros: '0',
+    availableBuyingPowerMicros: '0',
+    residualBuyingPowerMicros: '0',
+  }
+  const snapshot = cycle.bindings.snapshotId
+  if (snapshot === undefined) throw new Error('shadow decision fixture requires a bound snapshot')
+  return makeObserveShadowDecisionDocument({
+    schemaVersion: 'bayn.observe-shadow-decision.v1',
+    mode: 'OBSERVE',
+    dispatchable: false,
+    bindings: {
+      strategyName: cycle.identity.strategyName,
+      cycleId: cycle.identity.cycleId,
+      strategyProtocolHash: cycle.identity.strategyProtocolHash,
+      snapshotId: snapshot,
+      snapshotContentHash: '5'.repeat(64),
+      snapshotFinalizedAt: cycle.window.signalCloseAt,
+      strategyDecisionHash: '6'.repeat(64),
+      policyHash: '7'.repeat(64),
+      accountId: cycle.identity.accountId,
+      planningBrokerStateHash: '8'.repeat(64),
+      reconciliationId: '9'.repeat(64),
+      reconciliationHash: 'a'.repeat(64),
+    },
+    targetPlan: {
+      ...targetPlanMaterial,
+      outputHash: canonicalHashV1(targetPlanMaterial),
+    },
+    deltaRisk: [],
+    createdAt,
+    submissionCutoffAt: cycle.window.submissionCutoffAt,
+    expiresAt: cycle.window.submissionCutoffAt,
+  })
+}
+
 const slotKey = (slot: CycleAuthoritySlot): string =>
   `${slot.qualificationRunId}\u001f${slot.accountId}\u001f${slot.signalSessionDate}`
 
@@ -245,8 +308,8 @@ interface StoreControl {
 const cycleStore = (control: StoreControl): CycleStoreShape => {
   const cycles = new Map<string, AutonomousCycle>()
   const slots = new Map<string, string>()
+  const documents = new Map<string, ObserveShadowDecisionDocument>()
   const readCycle = (cycleId: string): AutonomousCycle | undefined => cycles.get(cycleId)
-  const unused = () => Effect.die(new Error('cycle runner used an unexpected store operation'))
   return {
     acquire: (draft, observedAt) =>
       Effect.sync(() => {
@@ -279,7 +342,26 @@ const cycleStore = (control: StoreControl): CycleStoreShape => {
         const cycle = readCycle(cycleId)
         return cycle === undefined ? Option.none() : Option.some(cycle)
       }),
-    readDecisionDocument: unused,
+    readDecisionDocument: (cycleId) =>
+      Effect.sync(() => {
+        const document = documents.get(cycleId)
+        return document === undefined ? Option.none() : Option.some(document)
+      }),
+    readOldestUnfinished: (scope) =>
+      Effect.sync(() => {
+        const oldest = [...cycles.values()]
+          .filter(
+            (cycle) =>
+              cycle.identity.qualificationRunId === scope.qualificationRunId &&
+              cycle.identity.accountId === scope.accountId &&
+              (cycle.state === CycleState.Pending || cycle.state === CycleState.Active),
+          )
+          .sort((left, right) => {
+            const session = left.identity.signalSessionDate.localeCompare(right.identity.signalSessionDate)
+            return session === 0 ? left.identity.cycleId.localeCompare(right.identity.cycleId) : session
+          })[0]
+        return oldest === undefined ? Option.none() : Option.some(oldest)
+      }),
     bindSnapshot: (cycleId, manifest, observedAt) =>
       Effect.sync(() => {
         control.binds += 1
@@ -299,9 +381,104 @@ const cycleStore = (control: StoreControl): CycleStoreShape => {
         cycles.set(cycleId, updated)
         return { cycle: updated, changed: true }
       }),
-    activate: unused,
-    bindDecision: unused,
-    block: unused,
+    activate: (cycleId, observedAt) =>
+      Effect.sync(() => {
+        const cycle = readCycle(cycleId)
+        if (cycle === undefined) throw new Error('test activation could not find the cycle')
+        if (cycle.state === CycleState.Active) return { cycle, changed: false }
+        if (cycle.state !== CycleState.Pending || cycle.bindings.snapshotId === undefined) {
+          throw new Error('test activation requires a snapshot-bound pending cycle')
+        }
+        if (observedAt >= cycle.window.submissionCutoffAt) {
+          const blocked = {
+            ...cycle,
+            state: CycleState.Blocked,
+            terminalReason: CycleTerminalReason.MissedSubmission,
+            stateVersion: cycle.stateVersion + 1,
+            updatedAt: observedAt,
+            terminalAt: observedAt,
+          }
+          cycles.set(cycleId, blocked)
+          return { cycle: blocked, changed: true }
+        }
+        const active = {
+          ...cycle,
+          state: CycleState.Active,
+          stateVersion: cycle.stateVersion + 1,
+          updatedAt: observedAt,
+        }
+        cycles.set(cycleId, active)
+        return { cycle: active, changed: true }
+      }),
+    bindDecision: (cycleId, document, observedAt) =>
+      Effect.sync(() => {
+        const cycle = readCycle(cycleId)
+        if (cycle === undefined) throw new Error('test decision binding could not find the cycle')
+        if (cycle.bindings.decisionHash !== undefined) {
+          if (cycle.bindings.decisionHash !== document.contentHash) {
+            throw new Error('test store refused decision replacement')
+          }
+          return { cycle, changed: false }
+        }
+        if (cycle.state !== CycleState.Active) throw new Error('test decision binding requires an active cycle')
+        if (observedAt >= cycle.window.submissionCutoffAt) {
+          const blocked = {
+            ...cycle,
+            state: CycleState.Blocked,
+            terminalReason: CycleTerminalReason.MissedSubmission,
+            stateVersion: cycle.stateVersion + 1,
+            updatedAt: observedAt,
+            terminalAt: observedAt,
+          }
+          cycles.set(cycleId, blocked)
+          return { cycle: blocked, changed: true }
+        }
+        const updated = {
+          ...cycle,
+          bindings: { ...cycle.bindings, decisionHash: document.contentHash },
+          stateVersion: cycle.stateVersion + 1,
+          updatedAt: observedAt,
+        }
+        documents.set(cycleId, document)
+        cycles.set(cycleId, updated)
+        return { cycle: updated, changed: true }
+      }),
+    finish: (cycleId, state, observedAt) =>
+      Effect.sync(() => {
+        const cycle = readCycle(cycleId)
+        if (cycle === undefined) throw new Error('test cycle finish could not find the cycle')
+        if (cycle.state === state) return { cycle, changed: false }
+        if (cycle.state !== CycleState.Active || cycle.bindings.decisionHash === undefined) {
+          throw new Error('test cycle finish requires a decision-bound active cycle')
+        }
+        const finished = {
+          ...cycle,
+          state,
+          stateVersion: cycle.stateVersion + 1,
+          updatedAt: observedAt,
+          terminalAt: observedAt,
+        }
+        cycles.set(cycleId, finished)
+        return { cycle: finished, changed: true }
+      }),
+    block: (cycleId, reason, observedAt) =>
+      Effect.sync(() => {
+        const cycle = readCycle(cycleId)
+        if (cycle === undefined) throw new Error('test blocking could not find the cycle')
+        if (cycle.state === CycleState.Blocked && cycle.terminalReason === reason) {
+          return { cycle, changed: false }
+        }
+        const blocked = {
+          ...cycle,
+          state: CycleState.Blocked,
+          terminalReason: reason,
+          stateVersion: cycle.stateVersion + 1,
+          updatedAt: observedAt,
+          terminalAt: observedAt,
+        }
+        cycles.set(cycleId, blocked)
+        return { cycle: blocked, changed: true }
+      }),
   }
 }
 
@@ -317,7 +494,120 @@ const provide = <A, E, R>(
     Effect.provideService(MarketData, marketData),
   )
 
+const recoveryState = (
+  cycle: AutonomousCycle | undefined,
+  overrides: Partial<Omit<CycleRecoveryState, 'cycle'>> = {},
+): CycleRecoveryState => ({
+  qualificationRunId: context().qualificationRunId,
+  accountId: context().accountId,
+  strategyProtocolHash: context().strategyProtocolHash,
+  observedAt: '2026-01-30T21:23:00.000Z',
+  cycle,
+  ...overrides,
+})
+
 describe('autonomous cycle runner', () => {
+  test('selects recovery from durable cycle state and publication readiness without effects', () => {
+    const executionSession = selectNextExecutionSession('2026-01-30', monthEndCalendar)
+    if (executionSession === undefined) throw new Error('recovery fixture requires an execution session')
+    const draft = makeDueCycleDraft(candidate(), monthEndCalendar, executionSession)
+    if (draft === undefined) throw new Error('recovery fixture requires a due cycle')
+    const pending = cycleFrom(draft, '2026-01-30T21:20:00.000Z')
+    const bound: AutonomousCycle = {
+      ...pending,
+      bindings: { snapshotId },
+      stateVersion: pending.stateVersion + 1,
+      updatedAt: '2026-01-30T21:21:00.000Z',
+    }
+    const active: AutonomousCycle = {
+      ...bound,
+      state: CycleState.Active,
+      stateVersion: bound.stateVersion + 1,
+      updatedAt: '2026-01-30T21:22:00.000Z',
+    }
+
+    expect(selectCycleRecovery(recoveryState(undefined))).toEqual({ action: 'DISCOVER' })
+    expect(selectCycleRecovery(recoveryState(pending))).toEqual({ action: 'READ_PUBLICATION', cycle: pending })
+    expect(
+      selectCycleRecovery(
+        recoveryState(pending, {
+          readiness: {
+            outcome: 'WAITING',
+            reason: 'PUBLICATION_MISSING',
+            observedAt: '2026-01-30T21:21:00.000Z',
+            cycle: pending,
+          },
+        }),
+      ),
+    ).toMatchObject({ action: 'RETURN_READINESS', recoveryAction: 'WAITING' })
+    expect(
+      selectCycleRecovery(
+        recoveryState(pending, {
+          readiness: {
+            outcome: 'BOUND',
+            observedAt: bound.updatedAt,
+            cycle: bound,
+            snapshotId,
+          },
+        }),
+      ),
+    ).toMatchObject({ action: 'RETURN_READINESS', recoveryAction: 'BOUND_SNAPSHOT' })
+    expect(
+      selectCycleRecovery(
+        recoveryState(bound, {
+          readiness: {
+            outcome: 'ALREADY_BOUND',
+            observedAt: bound.updatedAt,
+            cycle: bound,
+            snapshotId,
+          },
+        }),
+      ),
+    ).toEqual({ action: 'ACTIVATE', cycleId: bound.identity.cycleId, observedAt: bound.updatedAt })
+    expect(selectCycleRecovery(recoveryState(active))).toEqual({ action: 'BUILD_DECISION', cycle: active })
+    expect(() =>
+      selectCycleRecovery(
+        recoveryState({
+          ...pending,
+          state: CycleState.Blocked,
+          terminalReason: CycleTerminalReason.MissedPublication,
+          terminalAt: pending.updatedAt,
+        }),
+      ),
+    ).toThrow('terminal cycles must not enter autonomous recovery')
+
+    const decision = makeNoTradeDecision(active, '2026-01-30T21:24:00.000Z')
+    const decisionBound: AutonomousCycle = {
+      ...active,
+      bindings: { ...active.bindings, decisionHash: decision.contentHash },
+      stateVersion: active.stateVersion + 1,
+      updatedAt: decision.createdAt,
+    }
+    const afterCutoff = new Date(Date.parse(active.window.submissionCutoffAt) + 1).toISOString()
+    expect(
+      selectCycleRecovery(
+        recoveryState(decisionBound, {
+          strategyProtocolHash: 'f'.repeat(64),
+          observedAt: afterCutoff,
+        }),
+      ),
+    ).toEqual({ action: 'READ_DECISION', cycle: decisionBound })
+    expect(
+      selectCycleRecovery(
+        recoveryState(decisionBound, {
+          strategyProtocolHash: 'f'.repeat(64),
+          observedAt: afterCutoff,
+          decisionDocument: decision,
+        }),
+      ),
+    ).toEqual({
+      action: 'FINISH',
+      cycleId: decisionBound.identity.cycleId,
+      observedAt: afterCutoff,
+      state: CycleState.NoTrade,
+    })
+  })
+
   test('builds one bounded calendar query and selects the first session strictly after Signal', () => {
     const query = marketCalendarQueryForSignal('2026-01-30')
     const inclusiveDays =
@@ -481,15 +771,15 @@ describe('autonomous cycle runner', () => {
       },
     })
     expect(result.restarted).toMatchObject({
-      outcome: 'RESUMED',
-      signalSessionDate: '2026-01-30',
-      readiness: {
-        outcome: 'BLOCKED',
-        cycle: { identity: { cycleId: control.acquisitions[0]?.draft.identity.cycleId } },
-      },
+      outcome: 'NOT_DUE',
+      signalSessionDate: '2026-02-02',
+      executionSessionDate: '2026-02-03',
     })
-    expect(queries).toEqual([marketCalendarQueryForPublications(publications)])
-    expect(calendarReads).toBe(1)
+    expect(queries).toEqual([
+      marketCalendarQueryForPublications(publications),
+      marketCalendarQueryForSignal('2026-02-02'),
+    ])
+    expect(calendarReads).toBe(2)
     expect(control.acquisitions).toHaveLength(1)
     expect(control.binds).toBe(0)
   })
@@ -508,7 +798,7 @@ describe('autonomous cycle runner', () => {
           runAutonomousCyclePass(context()),
           read,
           cycleStore(control),
-          marketDataService(Effect.succeed(finalizedPublication())),
+          marketDataService(Effect.succeed(finalizedPublication()), finalizedPublicationInspection()),
         )
       }).pipe(Effect.provide(TestClock.layer())),
     )
@@ -536,19 +826,23 @@ describe('autonomous cycle runner', () => {
 
   test('persists a late publication as missed and never binds it at or after the exact deadline', async () => {
     const control: StoreControl = { acquisitions: [], binds: 0 }
+    const store = cycleStore(control)
+    let calendarReads = 0
+    const read = brokerRead(() => {
+      calendarReads += 1
+      return Effect.succeed({ value: monthEndCalendar, evidence })
+    })
+    const marketData = marketDataService(Effect.succeed(finalizedPublication()))
     const result = await Effect.runPromise(
       Effect.gen(function* () {
         yield* TestClock.setTime(Date.parse('2026-02-02T13:58:00.000Z'))
-        return yield* provide(
-          runAutonomousCyclePass(context()),
-          brokerRead(() => Effect.succeed({ value: monthEndCalendar, evidence })),
-          cycleStore(control),
-          marketDataService(Effect.succeed(finalizedPublication())),
-        )
+        const acquired = yield* provide(runAutonomousCyclePass(context()), read, store, marketData)
+        const restarted = yield* provide(runAutonomousCyclePass(context()), read, store, marketData)
+        return { acquired, restarted }
       }).pipe(Effect.provide(TestClock.layer())),
     )
 
-    expect(result).toMatchObject({
+    expect(result.acquired).toMatchObject({
       outcome: 'ACQUIRED',
       readiness: {
         outcome: 'BLOCKED',
@@ -559,10 +853,19 @@ describe('autonomous cycle runner', () => {
         },
       },
     })
+    expect(result.restarted).toMatchObject({
+      outcome: 'ALREADY_TERMINAL',
+      signalSessionDate: '2026-01-30',
+      cycle: {
+        state: CycleState.Blocked,
+        terminalReason: CycleTerminalReason.MissedPublication,
+      },
+    })
+    expect(calendarReads).toBe(1)
     expect(control.binds).toBe(0)
   })
 
-  test('returns an existing authority slot on restart without a second calendar read or duplicate binding', async () => {
+  test('reinspects and activates a bound cycle on restart before any new discovery', async () => {
     const control: StoreControl = { acquisitions: [], binds: 0 }
     const store = cycleStore(control)
     let calendarReads = 0
@@ -570,7 +873,8 @@ describe('autonomous cycle runner', () => {
       calendarReads += 1
       return Effect.succeed({ value: monthEndCalendar, evidence })
     })
-    const marketData = marketDataService(Effect.succeed(finalizedPublication()))
+    const inspection = finalizedPublicationInspection()
+    const marketData = marketDataService(Effect.succeed(finalizedPublication()), inspection)
 
     const results = await Effect.runPromise(
       Effect.gen(function* () {
@@ -584,12 +888,124 @@ describe('autonomous cycle runner', () => {
 
     expect(results.first.outcome).toBe('ACQUIRED')
     expect(results.restarted).toMatchObject({
-      outcome: 'ALREADY_ACQUIRED',
-      cycle: { bindings: { snapshotId } },
+      outcome: 'RECOVERED',
+      action: 'ACTIVATED',
+      cycle: { state: CycleState.Active, bindings: { snapshotId } },
     })
     expect(calendarReads).toBe(1)
     expect(control.acquisitions).toHaveLength(1)
     expect(control.binds).toBe(1)
+  })
+
+  test('finishes an exact pre-cutoff decision after cutoff and a runtime protocol change', async () => {
+    const control: StoreControl = { acquisitions: [], binds: 0 }
+    const store = cycleStore(control)
+    let calendarReads = 0
+    const read = brokerRead(() => {
+      calendarReads += 1
+      return Effect.succeed({ value: monthEndCalendar, evidence })
+    })
+    const inspection = finalizedPublicationInspection()
+    const marketData = marketDataService(Effect.succeed(finalizedPublication()), inspection)
+    const decisionAt = '2026-02-02T14:20:00.000Z'
+    const afterCutoff = '2026-02-02T14:29:00.000Z'
+
+    const results = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse('2026-01-30T21:20:00.000Z'))
+        const acquired = yield* provide(runAutonomousCyclePass(context()), read, store, marketData)
+        yield* TestClock.setTime(Date.parse('2026-01-30T21:21:00.000Z'))
+        const activated = yield* provide(runAutonomousCyclePass(context()), read, store, marketData)
+        yield* TestClock.setTime(Date.parse(decisionAt))
+        const decisionBound = yield* provide(
+          runAutonomousCyclePass(context(undefined, (cycle) => Effect.succeed(makeNoTradeDecision(cycle, decisionAt)))),
+          read,
+          store,
+          marketData,
+        )
+        yield* TestClock.setTime(Date.parse(afterCutoff))
+        const changedProtocol = {
+          ...context(),
+          strategyProtocolHash: 'f'.repeat(64),
+        }
+        const recovered = yield* provide(runAutonomousCyclePass(changedProtocol), read, store, marketData)
+        return { acquired, activated, decisionBound, recovered }
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(results.acquired.outcome).toBe('ACQUIRED')
+    expect(results.activated).toMatchObject({ outcome: 'RECOVERED', action: 'ACTIVATED' })
+    expect(results.decisionBound).toMatchObject({
+      outcome: 'RECOVERED',
+      action: 'BOUND_DECISION',
+      cycle: {
+        state: CycleState.Active,
+        bindings: { snapshotId, decisionHash: expect.any(String) },
+      },
+    })
+    expect(results.recovered).toMatchObject({
+      outcome: 'RECOVERED',
+      action: 'NO_TRADE',
+      observedAt: afterCutoff,
+      cycle: {
+        state: CycleState.NoTrade,
+        terminalAt: afterCutoff,
+      },
+    })
+    if (results.recovered.outcome !== 'RECOVERED') throw new Error('recovery fixture must finish the bound decision')
+    expect(results.recovered.cycle.terminalReason).toBeUndefined()
+    expect(calendarReads).toBe(1)
+    expect(control.acquisitions).toHaveLength(1)
+    expect(control.binds).toBe(1)
+  })
+
+  test('uses runner-owned bind time and blocks a decision builder that completes after cutoff', async () => {
+    const control: StoreControl = { acquisitions: [], binds: 0 }
+    const store = cycleStore(control)
+    let calendarReads = 0
+    const read = brokerRead(() => {
+      calendarReads += 1
+      return Effect.succeed({ value: monthEndCalendar, evidence })
+    })
+    const inspection = finalizedPublicationInspection()
+    const marketData = marketDataService(Effect.succeed(finalizedPublication()), inspection)
+    const documentCreatedAt = '2026-02-02T14:20:00.000Z'
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse('2026-01-30T21:20:00.000Z'))
+        yield* provide(runAutonomousCyclePass(context()), read, store, marketData)
+        yield* TestClock.setTime(Date.parse('2026-01-30T21:21:00.000Z'))
+        yield* provide(runAutonomousCyclePass(context()), read, store, marketData)
+        yield* TestClock.setTime(Date.parse(documentCreatedAt))
+        return yield* provide(
+          runAutonomousCyclePass(
+            context(undefined, (cycle) =>
+              TestClock.adjust(9 * 60_000).pipe(Effect.as(makeNoTradeDecision(cycle, documentCreatedAt))),
+            ),
+          ),
+          read,
+          store,
+          marketData,
+        )
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(result).toMatchObject({
+      outcome: 'RECOVERED',
+      action: 'BLOCKED',
+      observedAt: '2026-02-02T14:29:00.000Z',
+      cycle: {
+        state: CycleState.Blocked,
+        bindings: { snapshotId },
+        terminalReason: CycleTerminalReason.MissedSubmission,
+        terminalAt: '2026-02-02T14:29:00.000Z',
+      },
+    })
+    if (result.outcome !== 'RECOVERED') throw new Error('late builder fixture must produce a recovery result')
+    expect(result.cycle.bindings.decisionHash).toBeUndefined()
+    expect(calendarReads).toBe(1)
+    expect(control.acquisitions).toHaveLength(1)
   })
 
   test('resumes the exact bind after a crash immediately following durable acquisition', async () => {
@@ -604,7 +1020,8 @@ describe('autonomous cycle runner', () => {
       calendarReads += 1
       return Effect.succeed({ value: monthEndCalendar, evidence })
     })
-    const marketData = marketDataService(Effect.succeed(finalizedPublication()))
+    const inspection = finalizedPublicationInspection()
+    const marketData = marketDataService(Effect.succeed(finalizedPublication()), inspection)
 
     const result = await Effect.runPromise(
       Effect.gen(function* () {
@@ -620,12 +1037,9 @@ describe('autonomous cycle runner', () => {
 
     expect(result.crashed._tag).toBe('Failure')
     expect(result.resumed).toMatchObject({
-      outcome: 'RESUMED',
-      readiness: {
-        outcome: 'BOUND',
-        snapshotId,
-        cycle: { bindings: { snapshotId } },
-      },
+      outcome: 'RECOVERED',
+      action: 'BOUND_SNAPSHOT',
+      cycle: { state: CycleState.Pending, bindings: { snapshotId } },
     })
     expect(calendarReads).toBe(1)
     expect(control.acquisitions).toHaveLength(1)
@@ -691,11 +1105,12 @@ describe('autonomous cycle runner', () => {
         const fiber = yield* provide(
           startAutonomousCycleLoop({
             context: Effect.succeed(context()),
+            observePass: ignorePass,
             pollIntervalMs: 100,
           }),
           read,
           store,
-          marketDataService(Effect.succeed(finalizedPublication())),
+          marketDataService(Effect.succeed(finalizedPublication()), finalizedPublicationInspection()),
         )
         yield* Effect.yieldNow
         expect(control.acquisitions).toHaveLength(1)
@@ -727,6 +1142,7 @@ describe('autonomous cycle runner', () => {
           yield* provide(
             startAutonomousCycleLoop({
               context: Effect.succeed(context()),
+              observePass: ignorePass,
               pollIntervalMs: 100,
             }),
             brokerRead(() => Effect.die(new Error('in-flight publication read must not reach the broker'))),
@@ -746,6 +1162,7 @@ describe('autonomous cycle runner', () => {
     const control: StoreControl = { acquisitions: [], binds: 0 }
     let contextLoads = 0
     const logs: Array<{ readonly message: unknown; readonly annotations: Record<string, unknown> }> = []
+    const observations: CyclePassObservation[] = []
     const logger = Logger.make<unknown, void>((options) => {
       logs.push({
         message: options.message,
@@ -761,6 +1178,7 @@ describe('autonomous cycle runner', () => {
               contextLoads += 1
               return contextLoads === 1 ? Effect.fail(contextFailure) : Effect.succeed(context())
             }),
+            observePass: (observation) => Effect.sync(() => observations.push(observation)),
             pollIntervalMs: 100,
           }),
           brokerRead(() => Effect.succeed({ value: monthEndCalendar, evidence })),
@@ -787,7 +1205,51 @@ describe('autonomous cycle runner', () => {
           entry.annotations.failure === 'context',
       ),
     ).toBe(true)
+    expect(observations).toHaveLength(2)
+    expect(observations[0]).toMatchObject({
+      outcome: 'FAILED',
+      observedAt: '2026-01-30T21:20:00.000Z',
+      error: {
+        _tag: 'CycleRunnerError',
+        operation: 'load-context',
+        failure: 'context',
+        cause: contextFailure,
+      },
+    })
+    expect(observations[1]).toMatchObject({
+      outcome: 'SUCCEEDED',
+      observedAt: '2026-01-30T21:20:00.100Z',
+      result: { outcome: 'ACQUIRED' },
+    })
     expect(control.binds).toBe(1)
+  })
+
+  test('leaves defects visible through the returned scoped fiber', async () => {
+    const defect = new Error('unexpected cycle-loop defect')
+    const observations: CyclePassObservation[] = []
+    const control: StoreControl = { acquisitions: [], binds: 0 }
+    const exit = await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fiber = yield* provide(
+            startAutonomousCycleLoop({
+              context: Effect.die(defect),
+              observePass: (observation) => Effect.sync(() => observations.push(observation)),
+              pollIntervalMs: 100,
+            }),
+            brokerRead(() => Effect.die(new Error('defective context must not read the broker'))),
+            cycleStore(control),
+            marketDataService(Effect.die(new Error('defective context must not inspect publications'))),
+          )
+          return yield* Fiber.await(fiber)
+        }),
+      ),
+    )
+
+    expect(exit._tag).toBe('Failure')
+    if (exit._tag === 'Failure') expect(Cause.pretty(exit.cause)).toContain(defect.message)
+    expect(observations).toEqual([])
+    expect(control).toEqual({ acquisitions: [], binds: 0 })
   })
 
   test('keeps repeated context failures scoped and interruptible without touching discovery or the broker', async () => {
@@ -799,6 +1261,7 @@ describe('autonomous cycle runner', () => {
           const fiber = yield* provide(
             startAutonomousCycleLoop({
               context: Effect.fail(contextFailure),
+              observePass: ignorePass,
               pollIntervalMs: 100,
             }),
             brokerRead(() => Effect.die(new Error('failed context must not read the broker'))),
@@ -822,6 +1285,7 @@ describe('autonomous cycle runner', () => {
             provide(
               startAutonomousCycleLoop({
                 context: Effect.succeed(context()),
+                observePass: ignorePass,
                 pollIntervalMs,
               }),
               brokerRead(() => Effect.die(new Error('invalid config must not read the broker'))),

--- a/services/bayn/src/cycle-runner.test.ts
+++ b/services/bayn/src/cycle-runner.test.ts
@@ -568,7 +568,42 @@ describe('autonomous cycle runner', () => {
         }),
       ),
     ).toEqual({ action: 'ACTIVATE', cycleId: bound.identity.cycleId, observedAt: bound.updatedAt })
-    expect(selectCycleRecovery(recoveryState(active))).toEqual({ action: 'BUILD_DECISION', cycle: active })
+    expect(selectCycleRecovery(recoveryState(active))).toEqual({
+      action: 'WAIT',
+      cycle: active,
+      observedAt: '2026-01-30T21:23:00.000Z',
+    })
+    expect(
+      selectCycleRecovery(
+        recoveryState(active, {
+          observedAt: active.window.submissionOpenAt,
+        }),
+      ),
+    ).toEqual({ action: 'BUILD_DECISION', cycle: active })
+    expect(
+      selectCycleRecovery(
+        recoveryState(active, {
+          observedAt: active.window.submissionCutoffAt,
+        }),
+      ),
+    ).toEqual({
+      action: 'BLOCK',
+      cycleId: active.identity.cycleId,
+      observedAt: active.window.submissionCutoffAt,
+      reason: CycleTerminalReason.MissedSubmission,
+    })
+    expect(
+      selectCycleRecovery(
+        recoveryState(active, {
+          strategyProtocolHash: 'f'.repeat(64),
+        }),
+      ),
+    ).toEqual({
+      action: 'BLOCK',
+      cycleId: active.identity.cycleId,
+      observedAt: '2026-01-30T21:23:00.000Z',
+      reason: CycleTerminalReason.ProvenanceMismatch,
+    })
     expect(() =>
       selectCycleRecovery(
         recoveryState({
@@ -694,6 +729,41 @@ describe('autonomous cycle runner', () => {
     )
 
     expect(result).toEqual({ outcome: 'NO_PUBLICATION', observedAt: '2026-01-30T21:01:00.000Z' })
+    expect(control).toEqual({ acquisitions: [], binds: 0 })
+  })
+
+  test('observes a missing publication as a healthy completed loop pass', async () => {
+    const control: StoreControl = { acquisitions: [], binds: 0 }
+    const observations: CyclePassObservation[] = []
+    const program = Effect.scoped(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse('2026-01-30T21:20:00.000Z'))
+        const fiber = yield* provide(
+          startAutonomousCycleLoop({
+            context: Effect.succeed(context()),
+            observePass: (observation) => Effect.sync(() => observations.push(observation)),
+            pollIntervalMs: 100,
+          }),
+          brokerRead(() => Effect.die(new Error('missing publication must not read the broker'))),
+          cycleStore(control),
+          marketDataService(Effect.succeed({ outcome: 'MISSING', observedAt: '2026-01-30T21:20:00.000Z' })),
+        )
+        yield* Effect.yieldNow
+        yield* Fiber.interrupt(fiber)
+      }),
+    ).pipe(Effect.provide(TestClock.layer()))
+
+    await Effect.runPromise(program)
+    expect(observations).toEqual([
+      {
+        outcome: 'SUCCEEDED',
+        observedAt: '2026-01-30T21:20:00.000Z',
+        result: {
+          outcome: 'NO_PUBLICATION',
+          observedAt: '2026-01-30T21:20:00.000Z',
+        },
+      },
+    ])
     expect(control).toEqual({ acquisitions: [], binds: 0 })
   })
 
@@ -1118,6 +1188,7 @@ describe('autonomous cycle runner', () => {
   test('runs immediately, repeats on Schedule.spaced, and avoids duplicate work after acquisition', async () => {
     const control: StoreControl = { acquisitions: [], binds: 0 }
     const store = cycleStore(control)
+    const observations: CyclePassObservation[] = []
     let calendarReads = 0
     const read = brokerRead(() => {
       calendarReads += 1
@@ -1129,7 +1200,7 @@ describe('autonomous cycle runner', () => {
         const fiber = yield* provide(
           startAutonomousCycleLoop({
             context: Effect.succeed(context()),
-            observePass: ignorePass,
+            observePass: (observation) => Effect.sync(() => observations.push(observation)),
             pollIntervalMs: 100,
           }),
           read,
@@ -1142,6 +1213,8 @@ describe('autonomous cycle runner', () => {
         expect(control.acquisitions).toHaveLength(1)
         yield* TestClock.adjust(1)
         expect(control.acquisitions).toHaveLength(1)
+        yield* TestClock.adjust(100)
+        expect(control.acquisitions).toHaveLength(1)
         yield* Fiber.interrupt(fiber)
       }),
     ).pipe(Effect.provide(TestClock.layer()))
@@ -1149,6 +1222,26 @@ describe('autonomous cycle runner', () => {
     await Effect.runPromise(program)
     expect(calendarReads).toBe(1)
     expect(control.binds).toBe(1)
+    expect(observations).toHaveLength(3)
+    expect(observations[0]).toMatchObject({
+      outcome: 'SUCCEEDED',
+      result: { outcome: 'ACQUIRED' },
+    })
+    expect(observations[1]).toMatchObject({
+      outcome: 'SUCCEEDED',
+      result: { outcome: 'RECOVERED', action: 'ACTIVATED' },
+    })
+    expect(observations[2]).toMatchObject({
+      outcome: 'SUCCEEDED',
+      result: {
+        outcome: 'RECOVERED',
+        action: 'WAITING',
+        cycle: {
+          state: CycleState.Active,
+          bindings: { snapshotId },
+        },
+      },
+    })
   })
 
   test('scope closure interrupts in-flight publication discovery', async () => {

--- a/services/bayn/src/cycle-runner.ts
+++ b/services/bayn/src/cycle-runner.ts
@@ -7,6 +7,8 @@ import {
   type MarketCalendarSession,
 } from './broker/alpaca'
 import {
+  CycleState,
+  isTerminalCycleState,
   makeCycleDraft,
   makeCycleIdentity,
   makeCycleWindow,
@@ -17,12 +19,15 @@ import {
 } from './cycle'
 import {
   bindFinalizedCyclePublication,
+  runCyclePublicationReadiness,
   type CyclePublicationReadiness,
   type CycleReadinessError,
 } from './cycle-readiness'
+import { selectCycleRecovery, type CycleRecoverySelection, type CycleRecoveryState } from './cycle-recovery'
 import { CycleStore, type CycleAcquireReceipt } from './db/cycle-store'
 import type { OperationalError } from './errors'
 import { MarketData, type MarketDataInspection, type SignalSessionRow } from './market-data'
+import type { ObserveShadowDecisionDocument } from './shadow-decision-contract'
 
 const calendarRangeDays = 31
 // This leaves at least 10 calendar days after the newest candidate inside Alpaca's 31-day observation bound.
@@ -36,6 +41,7 @@ export interface CycleRunContext {
   readonly strategyProtocolHash: string
   readonly accountId: string
   readonly executionPolicy: CycleExecutionPolicy
+  readonly buildDecision: (cycle: AutonomousCycle) => Effect.Effect<ObserveShadowDecisionDocument, unknown>
 }
 
 export interface CycleCandidate {
@@ -60,10 +66,29 @@ export type CycleRunResult =
       readonly cycle: CycleBindingResult['cycle']
     }
   | {
+      readonly outcome: 'ALREADY_TERMINAL'
+      readonly signalSessionDate: string
+      readonly observedAt: string
+      readonly cycle: AutonomousCycle
+    }
+  | {
       readonly outcome: 'RESUMED'
       readonly signalSessionDate: string
       readonly observedAt: string
       readonly readiness: CycleBindingResult
+    }
+  | {
+      readonly outcome: 'RECOVERED'
+      readonly action:
+        | 'ACTIVATED'
+        | 'BLOCKED'
+        | 'BOUND_DECISION'
+        | 'BOUND_SNAPSHOT'
+        | 'COMPLETED'
+        | 'NO_TRADE'
+        | 'WAITING'
+      readonly observedAt: string
+      readonly cycle: AutonomousCycle
     }
   | {
       readonly outcome: 'NOT_DUE'
@@ -88,12 +113,15 @@ export class CycleRunnerError extends Data.TaggedError('CycleRunnerError')<{
   readonly operation:
     | 'acquire-cycle'
     | 'bind-publication'
+    | 'build-decision'
     | 'build-cycle'
     | 'configure'
     | 'inspect-publication'
     | 'load-context'
     | 'market-calendar'
+    | 'read-oldest-unfinished'
     | 'read-authority-slot'
+    | 'recover-cycle'
     | 'select-session'
   readonly failure:
     | 'calendar-read'
@@ -107,8 +135,21 @@ export class CycleRunnerError extends Data.TaggedError('CycleRunnerError')<{
   readonly cause?: unknown
 }> {}
 
+export type CyclePassObservation =
+  | {
+      readonly outcome: 'SUCCEEDED'
+      readonly observedAt: string
+      readonly result: CycleRunResult
+    }
+  | {
+      readonly outcome: 'FAILED'
+      readonly observedAt: string
+      readonly error: CycleRunnerError
+    }
+
 export interface AutonomousCycleLoopOptions<E = never, R = never> {
-  readonly context: Effect.Effect<CycleRunContext | undefined, E, R>
+  readonly context: Effect.Effect<CycleRunContext, E, R>
+  readonly observePass: (observation: CyclePassObservation) => Effect.Effect<void>
   readonly pollIntervalMs: number
 }
 
@@ -226,7 +267,7 @@ export const makeDueCycleDraft = (
   return makeCycleDraft(identity, window)
 }
 
-export const runAutonomousCyclePass = (
+export const discoverAutonomousCyclePass = (
   context: CycleRunContext,
 ): Effect.Effect<CycleRunResult, CycleRunnerError, BrokerRead | CycleStore | MarketData> =>
   Effect.gen(function* () {
@@ -251,6 +292,8 @@ export const runAutonomousCyclePass = (
       catch: (cause) =>
         runnerError('inspect-publication', 'contract', 'bounded cycle publication discovery is invalid', cause),
     })
+    const unclaimed: MarketDataInspection[] = []
+    let latestTerminal: AutonomousCycle | undefined
     for (const publication of publications) {
       const signalSessionDate = publication.signalSession.session_date
       const existing = yield* store
@@ -264,7 +307,14 @@ export const runAutonomousCyclePass = (
             runnerError('read-authority-slot', 'store', 'durable autonomous cycle authority-slot read failed', cause),
           ),
         )
-      if (Option.isNone(existing)) continue
+      if (Option.isNone(existing)) {
+        unclaimed.push(publication)
+        continue
+      }
+      if (isTerminalCycleState(existing.value.state)) {
+        if (latestTerminal === undefined) latestTerminal = existing.value
+        continue
+      }
       if (existing.value.bindings.snapshotId === undefined) {
         const observedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
         const readiness = yield* bindDiscoveredPublication(existing.value, publication, observedAt)
@@ -282,8 +332,25 @@ export const runAutonomousCyclePass = (
         cycle: existing.value,
       }
     }
+    if (unclaimed.length === 0) {
+      if (latestTerminal === undefined) {
+        return yield* Effect.fail(
+          runnerError(
+            'read-authority-slot',
+            'contract',
+            'cycle discovery found no resumable or terminal authority slot',
+          ),
+        )
+      }
+      return {
+        outcome: 'ALREADY_TERMINAL',
+        signalSessionDate: latestTerminal.identity.signalSessionDate,
+        observedAt: discovery.observedAt,
+        cycle: latestTerminal,
+      }
+    }
     const query = yield* Effect.try({
-      try: () => marketCalendarQueryForPublications(publications),
+      try: () => marketCalendarQueryForPublications(unclaimed),
       catch: (cause) => runnerError('market-calendar', 'contract', 'cycle calendar query construction failed', cause),
     })
     const calendar = yield* broker
@@ -295,7 +362,7 @@ export const runAutonomousCyclePass = (
       )
     const observedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
     let latestNotDue: Extract<CycleRunResult, { readonly outcome: 'NOT_DUE' }> | undefined
-    for (const publication of publications) {
+    for (const publication of unclaimed) {
       const candidate: CycleCandidate = {
         qualificationRunId: context.qualificationRunId,
         strategyProtocolHash: context.strategyProtocolHash,
@@ -352,6 +419,203 @@ export const runAutonomousCyclePass = (
     )
   })
 
+const chooseRecovery = (state: CycleRecoveryState): Effect.Effect<CycleRecoverySelection, CycleRunnerError> =>
+  Effect.try({
+    try: () => selectCycleRecovery(state),
+    catch: (cause) => runnerError('recover-cycle', 'contract', 'autonomous cycle recovery state is invalid', cause),
+  })
+
+const readinessFailure = (cause: CycleReadinessError): CycleRunnerError['failure'] => {
+  switch (cause.failure) {
+    case 'store':
+      return 'store'
+    case 'market-data':
+      return 'market-data'
+    case 'contract':
+      return 'contract'
+  }
+}
+
+const recoverCycle = (
+  selection: CycleRecoverySelection,
+  context: CycleRunContext,
+  observedAt: string,
+): Effect.Effect<CycleRunResult, CycleRunnerError, BrokerRead | CycleStore | MarketData> => {
+  switch (selection.action) {
+    case 'DISCOVER':
+      return discoverAutonomousCyclePass(context)
+    case 'BLOCK':
+      return Effect.gen(function* () {
+        const store = yield* CycleStore
+        const blocked = yield* store
+          .block(selection.cycleId, selection.reason, selection.observedAt)
+          .pipe(
+            Effect.mapError((cause) =>
+              runnerError('recover-cycle', 'store', 'unfinished autonomous cycle blocking failed', cause),
+            ),
+          )
+        return {
+          outcome: 'RECOVERED',
+          action: 'BLOCKED',
+          observedAt: selection.observedAt,
+          cycle: blocked.cycle,
+        }
+      })
+    case 'READ_PUBLICATION':
+      return runCyclePublicationReadiness(selection.cycle).pipe(
+        Effect.mapError((cause: CycleReadinessError) =>
+          runnerError('recover-cycle', readinessFailure(cause), 'unfinished cycle publication recovery failed', cause),
+        ),
+        Effect.flatMap((readiness) =>
+          chooseRecovery({
+            qualificationRunId: context.qualificationRunId,
+            accountId: context.accountId,
+            strategyProtocolHash: context.strategyProtocolHash,
+            observedAt,
+            cycle: selection.cycle,
+            readiness,
+          }),
+        ),
+        Effect.flatMap((next) => recoverCycle(next, context, observedAt)),
+      )
+    case 'RETURN_READINESS':
+      return Effect.succeed({
+        outcome: 'RECOVERED',
+        action: selection.recoveryAction,
+        observedAt: selection.result.observedAt,
+        cycle: selection.result.cycle,
+      })
+    case 'ACTIVATE':
+      return Effect.gen(function* () {
+        const store = yield* CycleStore
+        const activation = yield* store
+          .activate(selection.cycleId, selection.observedAt)
+          .pipe(
+            Effect.mapError((cause) =>
+              runnerError('recover-cycle', 'store', 'snapshot-bound cycle activation failed', cause),
+            ),
+          )
+        return {
+          outcome: 'RECOVERED',
+          action: activation.cycle.state === CycleState.Blocked ? 'BLOCKED' : 'ACTIVATED',
+          observedAt: selection.observedAt,
+          cycle: activation.cycle,
+        }
+      })
+    case 'BUILD_DECISION':
+      return context.buildDecision(selection.cycle).pipe(
+        Effect.mapError((cause) =>
+          runnerError('build-decision', 'contract', 'OBSERVE shadow decision construction failed', cause),
+        ),
+        Effect.flatMap((document) =>
+          Effect.gen(function* () {
+            const store = yield* CycleStore
+            const bindObservedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
+            const binding = yield* store
+              .bindDecision(selection.cycle.identity.cycleId, document, bindObservedAt)
+              .pipe(
+                Effect.mapError((cause) =>
+                  runnerError('recover-cycle', 'store', 'durable shadow decision binding failed', cause),
+                ),
+              )
+            return {
+              outcome: 'RECOVERED',
+              action: binding.cycle.state === CycleState.Blocked ? 'BLOCKED' : 'BOUND_DECISION',
+              observedAt: binding.cycle.updatedAt,
+              cycle: binding.cycle,
+            }
+          }),
+        ),
+      )
+    case 'READ_DECISION':
+      return Effect.gen(function* () {
+        const store = yield* CycleStore
+        const document = yield* store
+          .readDecisionDocument(selection.cycle.identity.cycleId)
+          .pipe(
+            Effect.mapError((cause) =>
+              runnerError('recover-cycle', 'store', 'durable shadow decision read failed', cause),
+            ),
+          )
+        const next = yield* chooseRecovery({
+          qualificationRunId: context.qualificationRunId,
+          accountId: context.accountId,
+          strategyProtocolHash: context.strategyProtocolHash,
+          observedAt,
+          cycle: selection.cycle,
+          decisionDocument: Option.match(document, {
+            onNone: () => null,
+            onSome: (value) => value,
+          }),
+        })
+        return yield* recoverCycle(next, context, observedAt)
+      })
+    case 'FINISH':
+      return Effect.gen(function* () {
+        const store = yield* CycleStore
+        const finished = yield* store
+          .finish(selection.cycleId, selection.state, selection.observedAt)
+          .pipe(
+            Effect.mapError((cause) =>
+              runnerError('recover-cycle', 'store', 'shadow cycle terminal transition failed', cause),
+            ),
+          )
+        let action: Extract<CycleRunResult, { readonly outcome: 'RECOVERED' }>['action']
+        switch (finished.cycle.state) {
+          case CycleState.Completed:
+            action = 'COMPLETED'
+            break
+          case CycleState.NoTrade:
+            action = 'NO_TRADE'
+            break
+          case CycleState.Blocked:
+            action = 'BLOCKED'
+            break
+          default:
+            return yield* Effect.fail(
+              runnerError('recover-cycle', 'contract', 'cycle finish did not produce a terminal state'),
+            )
+        }
+        return {
+          outcome: 'RECOVERED',
+          action,
+          observedAt: selection.observedAt,
+          cycle: finished.cycle,
+        }
+      })
+  }
+}
+
+export const runAutonomousCyclePass = (
+  context: CycleRunContext,
+): Effect.Effect<CycleRunResult, CycleRunnerError, BrokerRead | CycleStore | MarketData> =>
+  Effect.gen(function* () {
+    const store = yield* CycleStore
+    const unfinished = yield* store
+      .readOldestUnfinished({
+        qualificationRunId: context.qualificationRunId,
+        accountId: context.accountId,
+      })
+      .pipe(
+        Effect.mapError((cause) =>
+          runnerError('read-oldest-unfinished', 'store', 'oldest unfinished autonomous cycle read failed', cause),
+        ),
+      )
+    const cycle = Option.match(unfinished, {
+      onNone: () => undefined,
+      onSome: (value) => value,
+    })
+    const observedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
+    const selection = yield* chooseRecovery({
+      qualificationRunId: context.qualificationRunId,
+      accountId: context.accountId,
+      strategyProtocolHash: context.strategyProtocolHash,
+      observedAt,
+      cycle,
+    })
+    return yield* recoverCycle(selection, context, observedAt)
+  })
+
 const logCompletedPass = (result: CycleRunResult): Effect.Effect<void> => {
   switch (result.outcome) {
     case 'NO_PUBLICATION':
@@ -359,6 +623,16 @@ const logCompletedPass = (result: CycleRunResult): Effect.Effect<void> => {
         Effect.annotateLogs({ outcome: result.outcome, observedAt: result.observedAt }),
       )
     case 'ALREADY_ACQUIRED':
+      return Effect.logInfo('Bayn autonomous cycle pass completed').pipe(
+        Effect.annotateLogs({
+          outcome: result.outcome,
+          signalSessionDate: result.signalSessionDate,
+          observedAt: result.observedAt,
+          cycleId: result.cycle.identity.cycleId,
+          cycleState: result.cycle.state,
+        }),
+      )
+    case 'ALREADY_TERMINAL':
       return Effect.logInfo('Bayn autonomous cycle pass completed').pipe(
         Effect.annotateLogs({
           outcome: result.outcome,
@@ -377,6 +651,16 @@ const logCompletedPass = (result: CycleRunResult): Effect.Effect<void> => {
           cycleId: result.readiness.cycle.identity.cycleId,
           cycleState: result.readiness.cycle.state,
           publicationReadiness: result.readiness.outcome,
+        }),
+      )
+    case 'RECOVERED':
+      return Effect.logInfo('Bayn autonomous cycle pass completed').pipe(
+        Effect.annotateLogs({
+          outcome: result.outcome,
+          recoveryAction: result.action,
+          observedAt: result.observedAt,
+          cycleId: result.cycle.identity.cycleId,
+          cycleState: result.cycle.state,
         }),
       )
     case 'NOT_DUE':
@@ -419,19 +703,17 @@ const logFailedPass = (error: CycleRunnerError): Effect.Effect<void> =>
   )
 
 const runLoopPass = <E, R>(
-  context: Effect.Effect<CycleRunContext | undefined, E, R>,
-): Effect.Effect<void, CycleRunnerError, BrokerRead | CycleStore | MarketData | R> =>
+  context: Effect.Effect<CycleRunContext, E, R>,
+): Effect.Effect<CycleRunResult, CycleRunnerError, BrokerRead | CycleStore | MarketData | R> =>
   context.pipe(
     Effect.mapError((cause) =>
       runnerError('load-context', 'context', 'autonomous cycle context loading failed', cause),
     ),
-    Effect.flatMap((value) =>
-      value === undefined
-        ? Effect.void
-        : runAutonomousCyclePass(value).pipe(Effect.tap(logCompletedPass), Effect.asVoid),
-    ),
+    Effect.flatMap(runAutonomousCyclePass),
     Effect.withLogSpan('autonomous-cycle'),
   )
+
+const observationTime = Clock.currentTimeMillis.pipe(Effect.map((millis) => new Date(millis).toISOString()))
 
 export const startAutonomousCycleLoop = <E, R>(
   options: AutonomousCycleLoopOptions<E, R>,
@@ -446,8 +728,18 @@ export const startAutonomousCycleLoop = <E, R>(
     )
   }
   return runLoopPass(options.context).pipe(
-    Effect.tapError(logFailedPass),
-    Effect.catch(() => Effect.void),
+    Effect.flatMap((result) =>
+      observationTime.pipe(
+        Effect.flatMap((observedAt) => options.observePass({ outcome: 'SUCCEEDED', observedAt, result })),
+        Effect.andThen(logCompletedPass(result)),
+      ),
+    ),
+    Effect.catch((error) =>
+      observationTime.pipe(
+        Effect.flatMap((observedAt) => options.observePass({ outcome: 'FAILED', observedAt, error })),
+        Effect.andThen(logFailedPass(error)),
+      ),
+    ),
     Effect.repeat(Schedule.spaced(Duration.millis(options.pollIntervalMs))),
     Effect.asVoid,
     Effect.forkScoped({ startImmediately: true }),

--- a/services/bayn/src/cycle-runner.ts
+++ b/services/bayn/src/cycle-runner.ts
@@ -360,7 +360,7 @@ export const discoverAutonomousCyclePass = (
           runnerError('market-calendar', 'calendar-read', 'authoritative broker calendar read failed', cause),
         ),
       )
-    const observedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
+    const calendarObservedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
     let latestNotDue: Extract<CycleRunResult, { readonly outcome: 'NOT_DUE' }> | undefined
     for (const publication of unclaimed) {
       const candidate: CycleCandidate = {
@@ -384,7 +384,6 @@ export const discoverAutonomousCyclePass = (
       const common = {
         signalSessionDate,
         executionSessionDate: executionSession.date,
-        observedAt,
         calendarResponseHash: calendar.value.normalizedResponseHash,
         calendarReadContentHash: calendar.evidence.contentHash,
       } as const
@@ -394,20 +393,23 @@ export const discoverAutonomousCyclePass = (
       })
       if (draft === undefined) {
         if (latestNotDue === undefined) {
-          latestNotDue = { outcome: 'NOT_DUE', ...common }
+          latestNotDue = { outcome: 'NOT_DUE', observedAt: calendarObservedAt, ...common }
         }
         continue
       }
+      const acquiredAt = new Date(yield* Clock.currentTimeMillis).toISOString()
       const receipt = yield* store
-        .acquire(draft, observedAt)
+        .acquire(draft, acquiredAt)
         .pipe(
           Effect.mapError((cause) =>
             runnerError('acquire-cycle', 'store', 'durable autonomous cycle acquisition failed', cause),
           ),
         )
-      const readiness = yield* bindDiscoveredPublication(receipt.cycle, publication, observedAt)
+      const bindingObservedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
+      const readiness = yield* bindDiscoveredPublication(receipt.cycle, publication, bindingObservedAt)
       return {
         outcome: receipt.created ? 'ACQUIRED' : 'REACQUIRED',
+        observedAt: bindingObservedAt,
         ...common,
         receipt,
         readiness,

--- a/services/bayn/src/cycle-runner.ts
+++ b/services/bayn/src/cycle-runner.ts
@@ -504,6 +504,13 @@ const recoverCycle = (
           cycle: activation.cycle,
         }
       })
+    case 'WAIT':
+      return Effect.succeed({
+        outcome: 'RECOVERED',
+        action: 'WAITING',
+        observedAt: selection.observedAt,
+        cycle: selection.cycle,
+      })
     case 'BUILD_DECISION':
       return context.buildDecision(selection.cycle).pipe(
         Effect.mapError((cause) =>

--- a/services/bayn/src/cycle.test.ts
+++ b/services/bayn/src/cycle.test.ts
@@ -5,6 +5,8 @@ import { Effect, Exit } from 'effect'
 import type { MarketCalendarObservation, MarketCalendarSession } from './broker/alpaca'
 import {
   CycleState,
+  CycleTerminalReason,
+  cycleTerminalReasonForTargetPlanBlock,
   decodeCycleDraft,
   decodeCycleIdentity,
   decodeCycleWindow,
@@ -12,6 +14,7 @@ import {
   isCycleStateTransitionAllowed,
   makeCycleDraft,
   makeCycleExecutionPolicy,
+  makeCycleExecutionPolicyFromModel,
   makeCycleIdentity,
   makeCycleWindow,
   makeExecutionCalendarObservation,
@@ -19,7 +22,10 @@ import {
   type CycleIdentityMaterial,
   type ExecutionCalendarObservation,
 } from './cycle'
+import { defaultExecutionModel } from './execution-model'
+import { canonicalHashV1 } from './hash'
 import type { SignalSessionRow } from './market-data'
+import { TargetPlanReason } from './target-planner'
 import type { IsoDate } from './types'
 
 const signalCalendarVersion = 'signal-XNYS-2026-v1'
@@ -97,6 +103,61 @@ const makeIdentityMaterial = (
 })
 
 describe('autonomous cycle identity and calendar', () => {
+  test('derives the one source-controlled runner policy from the loaded v2 execution model', () => {
+    if (defaultExecutionModel.schemaVersion !== 'bayn.execution-model.v2') {
+      throw new Error('default execution model must be the causal v2 contract')
+    }
+    const policy = makeCycleExecutionPolicyFromModel(defaultExecutionModel)
+
+    expect(policy).toMatchObject({
+      schemaVersion: 'bayn.autonomous-cycle-execution-policy.v1',
+      strategyExecutionModelHash: canonicalHashV1(defaultExecutionModel),
+      submissionWindowMs: 30 * 60_000,
+      submissionCutoffBeforeOpenMs: defaultExecutionModel.order.submissionCutoffLeadMinutes * 60_000,
+    })
+    expect(policy.executionPolicyHash).toBe(
+      canonicalHashV1({
+        schemaVersion: policy.schemaVersion,
+        strategyExecutionModelHash: policy.strategyExecutionModelHash,
+        submissionWindowMs: policy.submissionWindowMs,
+        submissionCutoffBeforeOpenMs: policy.submissionCutoffBeforeOpenMs,
+      }),
+    )
+  })
+
+  test('maps every blocked target-plan reason to its exact cycle terminal reason', () => {
+    expect([
+      cycleTerminalReasonForTargetPlanBlock(TargetPlanReason.SubmissionCutoffReached),
+      cycleTerminalReasonForTargetPlanBlock(TargetPlanReason.IdentityMismatch),
+      cycleTerminalReasonForTargetPlanBlock(TargetPlanReason.InputMismatch),
+      cycleTerminalReasonForTargetPlanBlock(TargetPlanReason.InputStale),
+      cycleTerminalReasonForTargetPlanBlock(TargetPlanReason.ReconciliationNotExact),
+      cycleTerminalReasonForTargetPlanBlock(TargetPlanReason.AccountNotActive),
+      cycleTerminalReasonForTargetPlanBlock(TargetPlanReason.UnknownOrder),
+      cycleTerminalReasonForTargetPlanBlock(TargetPlanReason.UnresolvedOrder),
+      cycleTerminalReasonForTargetPlanBlock(TargetPlanReason.BelowMinimumBuyNotional),
+      cycleTerminalReasonForTargetPlanBlock(TargetPlanReason.InsufficientBuyingPower),
+      cycleTerminalReasonForTargetPlanBlock(TargetPlanReason.NonPositiveEquity),
+      cycleTerminalReasonForTargetPlanBlock(TargetPlanReason.ShortPositionNotAllowed),
+    ]).toEqual([
+      CycleTerminalReason.MissedSubmission,
+      CycleTerminalReason.ProvenanceMismatch,
+      CycleTerminalReason.DataInvalid,
+      CycleTerminalReason.DataStale,
+      CycleTerminalReason.Reconciliation,
+      CycleTerminalReason.BrokerDisabled,
+      CycleTerminalReason.UnresolvedMutation,
+      CycleTerminalReason.UnresolvedMutation,
+      CycleTerminalReason.Risk,
+      CycleTerminalReason.Risk,
+      CycleTerminalReason.Risk,
+      CycleTerminalReason.Risk,
+    ])
+    expect(() => cycleTerminalReasonForTargetPlanBlock(TargetPlanReason.TargetsSatisfied)).toThrow(
+      'blocked target plan cannot use the no-trade reason',
+    )
+  })
+
   test('derives stable identities from all Signal, execution-calendar, account, and policy inputs', () => {
     const material = makeIdentityMaterial('2026-03-06')
     const first = makeCycleIdentity(material)
@@ -314,8 +375,8 @@ describe('autonomous cycle identity and calendar', () => {
 
     expect(isCycleStateTransitionAllowed(CycleState.Pending, CycleState.Active)).toBe(true)
     expect(isCycleStateTransitionAllowed(CycleState.Active, CycleState.Blocked)).toBe(true)
-    expect(isCycleStateTransitionAllowed(CycleState.Active, CycleState.NoTrade)).toBe(false)
-    expect(isCycleStateTransitionAllowed(CycleState.Active, CycleState.Completed)).toBe(false)
+    expect(isCycleStateTransitionAllowed(CycleState.Active, CycleState.NoTrade)).toBe(true)
+    expect(isCycleStateTransitionAllowed(CycleState.Active, CycleState.Completed)).toBe(true)
     expect(isCycleStateTransitionAllowed(CycleState.Blocked, CycleState.Blocked)).toBe(false)
   })
 })

--- a/services/bayn/src/cycle.ts
+++ b/services/bayn/src/cycle.ts
@@ -3,6 +3,7 @@ import { DateTime, Schema } from 'effect'
 import type { MarketCalendarObservation, MarketCalendarSession } from './broker/alpaca'
 import { canonicalHashV1 } from './hash'
 import type { SignalSessionRow } from './market-data'
+import type { CausalProtocol } from './protocol'
 import {
   IsoDateSchema,
   PositiveIntegerSchema,
@@ -11,7 +12,10 @@ import {
   UtcInstantSchema,
   strictParseOptions,
 } from './schemas'
+import { TargetPlanReason } from './target-planner'
+
 const cycleTimeZone = 'America/New_York' as const
+const autonomousCycleSubmissionWindowMs = 30 * 60_000
 const SubmissionWindowMsSchema = PositiveIntegerSchema.check(Schema.isLessThanOrEqualTo(86_400_000))
 const maximumSubmissionDurationMs = 86_400_000
 
@@ -50,6 +54,7 @@ export enum CycleState {
   NoTrade = 'NO_TRADE',
   Blocked = 'BLOCKED',
 }
+export type CycleCompletionState = CycleState.Completed | CycleState.NoTrade
 
 export enum CycleTerminalReason {
   MissedPublication = 'BLOCKED_MISSED_PUBLICATION_DEADLINE',
@@ -65,6 +70,33 @@ export enum CycleTerminalReason {
   UnresolvedMutation = 'BLOCKED_UNRESOLVED_MUTATION',
   Reconciliation = 'BLOCKED_RECONCILIATION',
   Risk = 'BLOCKED_RISK',
+}
+
+export const cycleTerminalReasonForTargetPlanBlock = (reason: TargetPlanReason): CycleTerminalReason => {
+  switch (reason) {
+    case TargetPlanReason.SubmissionCutoffReached:
+      return CycleTerminalReason.MissedSubmission
+    case TargetPlanReason.IdentityMismatch:
+      return CycleTerminalReason.ProvenanceMismatch
+    case TargetPlanReason.InputMismatch:
+      return CycleTerminalReason.DataInvalid
+    case TargetPlanReason.InputStale:
+      return CycleTerminalReason.DataStale
+    case TargetPlanReason.ReconciliationNotExact:
+      return CycleTerminalReason.Reconciliation
+    case TargetPlanReason.AccountNotActive:
+      return CycleTerminalReason.BrokerDisabled
+    case TargetPlanReason.UnknownOrder:
+    case TargetPlanReason.UnresolvedOrder:
+      return CycleTerminalReason.UnresolvedMutation
+    case TargetPlanReason.BelowMinimumBuyNotional:
+    case TargetPlanReason.InsufficientBuyingPower:
+    case TargetPlanReason.NonPositiveEquity:
+    case TargetPlanReason.ShortPositionNotAllowed:
+      return CycleTerminalReason.Risk
+    case TargetPlanReason.TargetsSatisfied:
+      throw new TypeError('blocked target plan cannot use the no-trade reason')
+  }
 }
 
 const ExecutionCalendarObservationMaterialBase = Schema.Struct({
@@ -376,6 +408,16 @@ export const makeCycleExecutionPolicy = (material: CycleExecutionPolicyMaterial)
   executionPolicyHash: canonicalHashV1(material),
 })
 
+export const makeCycleExecutionPolicyFromModel = (
+  executionModel: CausalProtocol['executionModel'],
+): CycleExecutionPolicy =>
+  makeCycleExecutionPolicy({
+    schemaVersion: 'bayn.autonomous-cycle-execution-policy.v1',
+    strategyExecutionModelHash: canonicalHashV1(executionModel),
+    submissionWindowMs: autonomousCycleSubmissionWindowMs,
+    submissionCutoffBeforeOpenMs: executionModel.order.submissionCutoffLeadMinutes * 60_000,
+  })
+
 export const makeExecutionCalendarObservation = (
   session: SelectedExecutionCalendarSession,
 ): ExecutionCalendarObservation => {
@@ -477,7 +519,9 @@ export const isTerminalCycleState = (state: CycleState): boolean =>
 
 export const isCycleStateTransitionAllowed = (from: CycleState, to: CycleState): boolean => {
   if (from === CycleState.Pending) return to === CycleState.Active || to === CycleState.Blocked
-  if (from === CycleState.Active) return to === CycleState.Blocked
+  if (from === CycleState.Active) {
+    return to === CycleState.Completed || to === CycleState.NoTrade || to === CycleState.Blocked
+  }
   return false
 }
 

--- a/services/bayn/src/db/cycle-store.integration.test.ts
+++ b/services/bayn/src/db/cycle-store.integration.test.ts
@@ -34,7 +34,7 @@ import { ReconciliationStatus } from '../paper'
 import { makeObserveShadowDecisionDocument } from '../shadow-decision-contract'
 import { TargetPlanReason, TargetPlanStatus } from '../target-planner'
 import { DataFeed, DataSource, PriceAdjustment, PublicationSchema, type InputManifest, type IsoDate } from '../types'
-import { CycleStore, CycleStoreLive } from './cycle-store'
+import { CycleStore, CycleStoreLive, type CycleStoreShape } from './cycle-store'
 import { PostgresClientLive } from './evidence-store'
 import { migrationLoader } from './migrations'
 
@@ -683,6 +683,58 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
           result.readiness.cycle.window.submissionCutoffAt < result.readiness.cycle.window.executionOpenAt,
       ),
     ).toBe(true)
+  })
+
+  test('samples a fresh Clock time after acquisition before binding a finalized publication', async () => {
+    const accountId = '10000000-0000-4000-8000-000000000005'
+    const beforeDeadline = '2026-02-02T13:57:59.999Z'
+    const deadline = '2026-02-02T13:58:00.000Z'
+    const result = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* CycleStore
+        const delayedStore: CycleStoreShape = {
+          ...store,
+          acquire: (draft, observedAt) => store.acquire(draft, observedAt).pipe(Effect.tap(() => TestClock.adjust(1))),
+        }
+        yield* TestClock.setTime(Date.parse(beforeDeadline))
+        const cycle = yield* runAutonomousCyclePass(runnerContext(accountId)).pipe(
+          Effect.provideService(BrokerRead, runnerBrokerRead([])),
+          Effect.provideService(CycleStore, delayedStore),
+        )
+        const sql = yield* PgClient.PgClient
+        const [counts] = yield* sql<{ cycles: number; references: number }>`
+          SELECT
+            (SELECT count(*)::integer FROM autonomous_cycles) AS cycles,
+            (SELECT count(*)::integer FROM snapshot_references) AS references
+        `
+        return { counts, cycle }
+      }).pipe(Effect.provideService(MarketData, runnerMarketData()), Effect.provide(TestClock.layer())),
+    )
+
+    expect(result.cycle).toMatchObject({
+      outcome: 'ACQUIRED',
+      observedAt: deadline,
+      receipt: {
+        cycle: {
+          state: CycleState.Pending,
+          bindings: {},
+          createdAt: beforeDeadline,
+          updatedAt: beforeDeadline,
+        },
+      },
+      readiness: {
+        outcome: 'BLOCKED',
+        observedAt: deadline,
+        cycle: {
+          state: CycleState.Blocked,
+          bindings: {},
+          terminalReason: CycleTerminalReason.MissedPublication,
+          terminalAt: deadline,
+          updatedAt: deadline,
+        },
+      },
+    })
+    expect(result.counts).toEqual({ cycles: 1, references: 0 })
   })
 
   test('reserves one capital-authority slot across changed calendar and policy inputs', async () => {

--- a/services/bayn/src/db/cycle-store.integration.test.ts
+++ b/services/bayn/src/db/cycle-store.integration.test.ts
@@ -71,8 +71,16 @@ const signalSession = (
 
 const makeDraft = (
   accountId = 'paper-account-1',
-  options: { readonly executionCloseAt?: string; readonly submissionWindowMs?: number } = {},
+  options: {
+    readonly executionCloseAt?: string
+    readonly executionOpenAt?: string
+    readonly executionSessionDate?: IsoDate
+    readonly signalSessionDate?: IsoDate
+    readonly submissionWindowMs?: number
+  } = {},
 ): CycleDraft => {
+  const signalSessionDate = options.signalSessionDate ?? '2026-03-06'
+  const executionSessionDate = options.executionSessionDate ?? '2026-03-09'
   const executionPolicy = makeCycleExecutionPolicy({
     schemaVersion: 'bayn.autonomous-cycle-execution-policy.v1',
     strategyExecutionModelHash: 'c'.repeat(64),
@@ -82,8 +90,8 @@ const makeDraft = (
   const executionCalendar = makeExecutionCalendarObservation({
     schemaVersion: 'bayn.alpaca-market-calendar-observation.v1',
     source: 'alpaca-v2-calendar',
-    date: '2026-03-09',
-    openAt: '2026-03-09T13:30:00.000Z',
+    date: executionSessionDate,
+    openAt: options.executionOpenAt ?? '2026-03-09T13:30:00.000Z',
     closeAt: options.executionCloseAt ?? '2026-03-09T20:00:00.000Z',
   })
   const identity = makeCycleIdentity({
@@ -92,7 +100,7 @@ const makeDraft = (
     qualificationRunId: 'a'.repeat(64),
     strategyProtocolHash: 'b'.repeat(64),
     accountId,
-    signalSessionDate: '2026-03-06',
+    signalSessionDate,
     signalCalendarVersion,
     executionSessionDate: executionCalendar.executionSessionDate,
     executionCalendarSchemaVersion: executionCalendar.executionCalendarSchemaVersion,
@@ -100,7 +108,7 @@ const makeDraft = (
     executionCalendarHash: executionCalendar.executionCalendarHash,
     executionPolicy,
   })
-  return makeCycleDraft(identity, makeCycleWindow(signalSession('2026-03-06'), executionCalendar, executionPolicy))
+  return makeCycleDraft(identity, makeCycleWindow(signalSession(signalSessionDate), executionCalendar, executionPolicy))
 }
 
 const insertSnapshotReference = (
@@ -231,6 +239,7 @@ const makeShadowDecision = (
   draft: CycleDraft,
   boundSnapshotId: string,
   options: {
+    readonly blockedReason?: Exclude<TargetPlanReason, TargetPlanReason.TargetsSatisfied>
     readonly createdAt?: string
     readonly snapshotContentHash?: string
     readonly strategyDecisionHash?: string
@@ -240,8 +249,8 @@ const makeShadowDecision = (
   const targetPlanMaterial = {
     schemaVersion: 'bayn.paper-reference-target-plan.v1' as const,
     inputHash: '1'.repeat(64),
-    status: TargetPlanStatus.NoTrade,
-    reason: TargetPlanReason.TargetsSatisfied,
+    status: options.blockedReason === undefined ? TargetPlanStatus.NoTrade : TargetPlanStatus.Blocked,
+    reason: options.blockedReason ?? TargetPlanReason.TargetsSatisfied,
     targets: [],
     intentTargets: [],
     requiredReferenceBuyNotionalMicros: '0',
@@ -317,6 +326,7 @@ const runnerContext = (accountId: string): CycleRunContext => ({
     submissionWindowMs: 30 * 60 * 1_000,
     submissionCutoffBeforeOpenMs: 2 * 60 * 1_000,
   }),
+  buildDecision: () => Effect.die(new Error('runner integration fixture built an unexpected decision')),
 })
 
 const runnerPublication = (): Extract<FinalizedPublicationInspection, { readonly outcome: 'FINALIZED' }> => ({
@@ -335,6 +345,7 @@ const runnerPublication = (): Extract<FinalizedPublicationInspection, { readonly
 
 const runnerMarketData = (): MarketDataService => {
   const unused = Effect.die(new Error('autonomous cycle runner must inspect only bounded publication candidates'))
+  const inspectExactPublication = () => Effect.succeed(runnerPublication())
   return {
     check: unused,
     inspect: unused,
@@ -343,8 +354,8 @@ const runnerMarketData = (): MarketDataService => {
       observedAt: runnerPublication().observedAt,
       publications: [runnerPublication().inspection],
     }),
-    inspectPublication: () => unused,
-    inspectSnapshotPublication: () => unused,
+    inspectPublication: inspectExactPublication,
+    inspectSnapshotPublication: inspectExactPublication,
     load: unused,
   }
 }
@@ -462,6 +473,58 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
     expect(observed.count).toBe(1)
   })
 
+  test('reads the oldest unfinished cycle inside one qualification and account scope', async () => {
+    const accountId = 'paper-account-recovery'
+    const older = makeDraft(accountId, {
+      signalSessionDate: '2026-01-30',
+      executionSessionDate: '2026-02-02',
+      executionOpenAt: '2026-02-02T14:30:00.000Z',
+      executionCloseAt: '2026-02-02T21:00:00.000Z',
+    })
+    const newer = makeDraft(accountId, {
+      signalSessionDate: '2026-02-27',
+      executionSessionDate: '2026-03-02',
+      executionOpenAt: '2026-03-02T14:30:00.000Z',
+      executionCloseAt: '2026-03-02T21:00:00.000Z',
+    })
+    const unrelated = makeDraft('paper-account-recovery-other')
+
+    const observed = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* CycleStore
+        yield* store.acquire(older, '2026-01-30T21:01:00.000Z')
+        yield* store.acquire(newer, '2026-02-27T21:01:00.000Z')
+        yield* store.acquire(unrelated, acquireAt)
+
+        const scope = { qualificationRunId: older.identity.qualificationRunId, accountId }
+        const first = yield* store.readOldestUnfinished(scope)
+        yield* store.block(
+          older.identity.cycleId,
+          CycleTerminalReason.MissedPublication,
+          older.window.publicationDeadlineAt,
+        )
+        const second = yield* store.readOldestUnfinished(scope)
+        yield* store.block(
+          newer.identity.cycleId,
+          CycleTerminalReason.MissedPublication,
+          newer.window.publicationDeadlineAt,
+        )
+        const none = yield* store.readOldestUnfinished(scope)
+        return { first, none, second }
+      }),
+    )
+
+    expect(Option.isSome(observed.first)).toBe(true)
+    if (Option.isSome(observed.first)) {
+      expect(observed.first.value.identity.cycleId).toBe(older.identity.cycleId)
+    }
+    expect(Option.isSome(observed.second)).toBe(true)
+    if (Option.isSome(observed.second)) {
+      expect(observed.second.value.identity.cycleId).toBe(newer.identity.cycleId)
+    }
+    expect(Option.isNone(observed.none)).toBe(true)
+  })
+
   test('concurrent runner passes and restart converge on one OBSERVE cycle', async () => {
     const context = runnerContext('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa')
     const queries: Array<{ readonly start: string; readonly end: string }> = []
@@ -472,7 +535,7 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
         const concurrent = yield* Effect.all(
           [
             runAutonomousCyclePass(context).pipe(Effect.provideService(BrokerRead, read)),
-            runAutonomousCyclePass(structuredClone(context)).pipe(Effect.provideService(BrokerRead, read)),
+            runAutonomousCyclePass({ ...context }).pipe(Effect.provideService(BrokerRead, read)),
           ],
           { concurrency: 'unbounded' },
         )
@@ -496,9 +559,10 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
       true,
     )
     expect(result.restarted).toMatchObject({
-      outcome: 'ALREADY_ACQUIRED',
+      outcome: 'RECOVERED',
+      action: 'ACTIVATED',
       cycle: {
-        state: CycleState.Pending,
+        state: CycleState.Active,
         bindings: { snapshotId: snapshotA },
         identity: {
           accountId: context.accountId,
@@ -553,12 +617,9 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
       cycle: { state: CycleState.Pending, bindings: {} },
     })
     expect(result.resumed).toMatchObject({
-      outcome: 'RESUMED',
-      readiness: {
-        outcome: 'BOUND',
-        snapshotId: snapshotA,
-        cycle: { bindings: { snapshotId: snapshotA } },
-      },
+      outcome: 'RECOVERED',
+      action: 'BOUND_SNAPSHOT',
+      cycle: { bindings: { snapshotId: snapshotA } },
     })
     expect(result.counts).toEqual({ cycles: 1, references: 1 })
   })
@@ -806,6 +867,8 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
     const document = makeShadowDecision(draft, snapshotA)
     const divergent = makeShadowDecision(draft, snapshotA, { strategyDecisionHash: '7'.repeat(64) })
     const wrongSnapshot = makeShadowDecision(draft, snapshotA, { snapshotContentHash: '7'.repeat(64) })
+    const backdated = makeShadowDecision(draft, snapshotA, { createdAt: snapshotAt })
+    const futureDated = makeShadowDecision(draft, snapshotA, { createdAt: terminalAt })
     const missingDocumentDraft = makeDraft('paper-account-shadow-missing-document')
     const orphanDocumentDraft = makeDraft('paper-account-shadow-orphan-document')
     const orphanDocument = makeShadowDecision(orphanDocumentDraft, snapshotB)
@@ -820,6 +883,8 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
         const missingEvidence = yield* Effect.exit(store.bindDecision(draft.identity.cycleId, document, decisionAt))
         yield* insertShadowReconciliation(draft)
         const wrongEvidence = yield* Effect.exit(store.bindDecision(draft.identity.cycleId, wrongSnapshot, decisionAt))
+        const backdatedBinding = yield* Effect.exit(store.bindDecision(draft.identity.cycleId, backdated, decisionAt))
+        const futureBinding = yield* Effect.exit(store.bindDecision(draft.identity.cycleId, futureDated, decisionAt))
         const bound = yield* store.bindDecision(draft.identity.cycleId, document, decisionAt)
         const replay = yield* store.bindDecision(draft.identity.cycleId, structuredClone(document), decisionAt)
         const storedDocument = yield* store.readDecisionDocument(draft.identity.cycleId)
@@ -901,12 +966,14 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
         `
         return {
           authoritySlot,
+          backdatedBinding,
           bound,
           conflict,
           counts,
           directDelete,
           directTruncate,
           directUpdate,
+          futureBinding,
           missingDocument,
           missingEvidence,
           orphanDocumentInsert,
@@ -934,6 +1001,8 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
     expect(Exit.isFailure(result.conflict)).toBe(true)
     expect(Exit.isFailure(result.missingEvidence)).toBe(true)
     expect(Exit.isFailure(result.wrongEvidence)).toBe(true)
+    expect(Exit.isFailure(result.backdatedBinding)).toBe(true)
+    expect(Exit.isFailure(result.futureBinding)).toBe(true)
     expect(Exit.isFailure(result.missingDocument)).toBe(true)
     expect(Exit.isFailure(result.orphanDocumentInsert)).toBe(true)
     expect(Exit.isFailure(result.directUpdate)).toBe(true)
@@ -954,9 +1023,10 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
     })
   })
 
-  test('keeps completion unreachable and preserves blocked terminal history across runtimes', async () => {
+  test('finishes the exact no-trade decision once after cutoff and preserves terminal history across runtimes', async () => {
     const draft = makeDraft()
     const shadowDecision = makeShadowDecision(draft, snapshotA)
+    const afterCutoff = new Date(Date.parse(draft.window.submissionCutoffAt) + 1).toISOString()
     const result = await runtime.runPromise(
       Effect.gen(function* () {
         const store = yield* CycleStore
@@ -976,35 +1046,38 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
             terminal_at = ${terminalAt}
           WHERE cycle_id = ${draft.identity.cycleId}
         `)
-        const directNoTrade = yield* Effect.exit(sql`
-          UPDATE autonomous_cycles
-          SET
-            state = ${CycleState.NoTrade},
-            state_version = state_version + 1,
-            updated_at = ${terminalAt},
-            terminal_at = ${terminalAt}
-          WHERE cycle_id = ${draft.identity.cycleId}
-        `)
-
-        const blocked = yield* store.block(draft.identity.cycleId, CycleTerminalReason.DataStale, terminalAt)
-        const retried = yield* store.block(draft.identity.cycleId, CycleTerminalReason.DataStale, terminalAt)
+        const mismatchedFinish = yield* Effect.exit(
+          store.finish(draft.identity.cycleId, CycleState.Completed, terminalAt),
+        )
+        const finishes = yield* Effect.all(
+          [
+            store.finish(draft.identity.cycleId, CycleState.NoTrade, afterCutoff),
+            store.finish(draft.identity.cycleId, CycleState.NoTrade, afterCutoff),
+          ],
+          { concurrency: 'unbounded' },
+        )
+        const finished = finishes.find((receipt) => receipt.changed)
+        const retried = finishes.find((receipt) => !receipt.changed)
+        if (finished === undefined || retried === undefined) {
+          return yield* Effect.die(new Error('concurrent finish fixture requires one mutation and one replay'))
+        }
         const rejectedRewrite = yield* Effect.exit(
-          store.block(draft.identity.cycleId, CycleTerminalReason.Reconciliation, terminalAt),
+          store.block(draft.identity.cycleId, CycleTerminalReason.Reconciliation, afterCutoff),
         )
         const directUpdate = yield* Effect.exit(sql`
           UPDATE autonomous_cycles
-          SET updated_at = ${'2026-03-06T21:06:00.000Z'}, state_version = state_version + 1
+          SET updated_at = ${new Date(Date.parse(afterCutoff) + 1).toISOString()}, state_version = state_version + 1
           WHERE cycle_id = ${draft.identity.cycleId}
         `)
         const directDelete = yield* Effect.exit(sql`
           DELETE FROM autonomous_cycles WHERE cycle_id = ${draft.identity.cycleId}
         `)
         return {
-          blocked,
           directCompleted,
           directDelete,
-          directNoTrade,
           directUpdate,
+          finished,
+          mismatchedFinish,
           rejectedRewrite,
           retried,
         }
@@ -1012,17 +1085,18 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
     )
 
     expect(Exit.isFailure(result.directCompleted)).toBe(true)
-    expect(Exit.isFailure(result.directNoTrade)).toBe(true)
-    expect(result.blocked.cycle).toMatchObject({
-      state: CycleState.Blocked,
+    expect(Exit.isFailure(result.mismatchedFinish)).toBe(true)
+    expect(result.finished.cycle).toMatchObject({
+      state: CycleState.NoTrade,
       bindings: {
         snapshotId: snapshotA,
         decisionHash: shadowDecision.contentHash,
       },
-      terminalReason: CycleTerminalReason.DataStale,
-      terminalAt,
+      terminalAt: afterCutoff,
     })
+    expect(result.finished.cycle.terminalReason).toBeUndefined()
     expect(result.retried.changed).toBe(false)
+    expect(result.retried.cycle).toEqual(result.finished.cycle)
     expect(Exit.isFailure(result.rejectedRewrite)).toBe(true)
     expect(Exit.isFailure(result.directUpdate)).toBe(true)
     expect(Exit.isFailure(result.directDelete)).toBe(true)
@@ -1039,9 +1113,84 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
     )
     await secondRuntime.dispose()
     expect(Option.isSome(durable.cycle)).toBe(true)
-    if (Option.isSome(durable.cycle)) expect(durable.cycle.value).toEqual(result.blocked.cycle)
+    if (Option.isSome(durable.cycle)) expect(durable.cycle.value).toEqual(result.finished.cycle)
     expect(Option.isSome(durable.document)).toBe(true)
     if (Option.isSome(durable.document)) expect(durable.document.value).toEqual(shadowDecision)
+  })
+
+  test('requires decision-bound blocking to match the exact target-plan reason', async () => {
+    const storeDraft = makeDraft('paper-account-blocked-store')
+    const directDraft = makeDraft('paper-account-blocked-direct')
+    const storeDocument = makeShadowDecision(storeDraft, snapshotA, {
+      blockedReason: TargetPlanReason.InputStale,
+    })
+    const directDocument = makeShadowDecision(directDraft, snapshotB, {
+      blockedReason: TargetPlanReason.InputStale,
+    })
+
+    const result = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* CycleStore
+        yield* store.acquire(storeDraft, acquireAt)
+        yield* store.bindSnapshot(storeDraft.identity.cycleId, makeInputManifest(snapshotA), snapshotAt)
+        yield* store.activate(storeDraft.identity.cycleId, activeAt)
+        yield* insertShadowReconciliation(storeDraft)
+        yield* store.bindDecision(storeDraft.identity.cycleId, storeDocument, decisionAt)
+        const storeMismatch = yield* Effect.exit(
+          store.block(storeDraft.identity.cycleId, CycleTerminalReason.Reconciliation, terminalAt),
+        )
+        const storeMatch = yield* store.block(storeDraft.identity.cycleId, CycleTerminalReason.DataStale, terminalAt)
+
+        yield* store.acquire(directDraft, acquireAt)
+        yield* store.bindSnapshot(directDraft.identity.cycleId, makeInputManifest(snapshotB), snapshotAt)
+        yield* store.activate(directDraft.identity.cycleId, activeAt)
+        yield* insertShadowReconciliation(directDraft)
+        yield* store.bindDecision(directDraft.identity.cycleId, directDocument, decisionAt)
+        const sql = yield* PgClient.PgClient
+        const directMismatch = yield* Effect.exit(sql`
+          UPDATE autonomous_cycles
+          SET
+            state = ${CycleState.Blocked},
+            terminal_reason = ${CycleTerminalReason.Reconciliation},
+            state_version = state_version + 1,
+            updated_at = ${terminalAt},
+            terminal_at = ${terminalAt}
+          WHERE cycle_id = ${directDraft.identity.cycleId}
+        `)
+        yield* sql`
+          UPDATE autonomous_cycles
+          SET
+            state = ${CycleState.Blocked},
+            terminal_reason = ${CycleTerminalReason.DataStale},
+            state_version = state_version + 1,
+            updated_at = ${terminalAt},
+            terminal_at = ${terminalAt}
+          WHERE cycle_id = ${directDraft.identity.cycleId}
+        `
+        return {
+          directCycle: yield* store.read(directDraft.identity.cycleId),
+          directMismatch,
+          storeMatch,
+          storeMismatch,
+        }
+      }),
+    )
+
+    expect(Exit.isFailure(result.storeMismatch)).toBe(true)
+    expect(result.storeMatch.cycle).toMatchObject({
+      state: CycleState.Blocked,
+      terminalReason: CycleTerminalReason.DataStale,
+      bindings: { decisionHash: storeDocument.contentHash },
+    })
+    expect(Exit.isFailure(result.directMismatch)).toBe(true)
+    expect(Option.isSome(result.directCycle)).toBe(true)
+    if (Option.isSome(result.directCycle)) {
+      expect(result.directCycle.value).toMatchObject({
+        state: CycleState.Blocked,
+        terminalReason: CycleTerminalReason.DataStale,
+        bindings: { decisionHash: directDocument.contentHash },
+      })
+    }
   })
 
   test('enforces initial lifecycle state and distinct publication and submission deadlines', async () => {

--- a/services/bayn/src/db/cycle-store.ts
+++ b/services/bayn/src/db/cycle-store.ts
@@ -6,11 +6,13 @@ import {
   CycleDraftSchema,
   CycleState,
   CycleTerminalReason,
+  cycleTerminalReasonForTargetPlanBlock,
   cycleDraftMatches,
   cycleDraftOf,
   decodeAutonomousCycle,
   isCycleStateTransitionAllowed,
   type AutonomousCycle,
+  type CycleCompletionState,
   type CycleDraft,
 } from '../cycle'
 import { decodeInputManifestArtifact } from '../evidence-contracts'
@@ -23,6 +25,7 @@ import {
   strictParseOptions,
 } from '../schemas'
 import { ObserveShadowDecisionDocumentSchema, type ObserveShadowDecisionDocument } from '../shadow-decision-contract'
+import { TargetPlanStatus } from '../target-planner'
 import type { InputManifest, IsoDate } from '../types'
 import { ensureSnapshotReference } from './snapshot-reference'
 
@@ -42,6 +45,11 @@ export interface CycleAuthoritySlot {
   readonly signalSessionDate: IsoDate
 }
 
+export interface CycleRecoveryScope {
+  readonly qualificationRunId: string
+  readonly accountId: string
+}
+
 export class CycleStoreError extends Data.TaggedError('CycleStoreError')<{
   readonly operation:
     | 'acquire'
@@ -49,9 +57,11 @@ export class CycleStoreError extends Data.TaggedError('CycleStoreError')<{
     | 'bind-decision'
     | 'bind-snapshot'
     | 'block'
+    | 'finish'
     | 'read'
     | 'read-authority-slot'
     | 'read-decision-document'
+    | 'read-oldest-unfinished'
   readonly failure: 'conflict' | 'decode' | 'invariant' | 'not-found' | 'query'
   readonly message: string
   readonly cause?: unknown
@@ -66,6 +76,9 @@ export interface CycleStoreShape {
   readonly readDecisionDocument: (
     cycleId: string,
   ) => Effect.Effect<Option.Option<ObserveShadowDecisionDocument>, CycleStoreError>
+  readonly readOldestUnfinished: (
+    scope: CycleRecoveryScope,
+  ) => Effect.Effect<Option.Option<AutonomousCycle>, CycleStoreError>
   readonly bindSnapshot: (
     cycleId: string,
     inputManifest: InputManifest,
@@ -75,6 +88,11 @@ export interface CycleStoreShape {
   readonly bindDecision: (
     cycleId: string,
     document: ObserveShadowDecisionDocument,
+    observedAt: string,
+  ) => Effect.Effect<CycleMutationReceipt, CycleStoreError>
+  readonly finish: (
+    cycleId: string,
+    state: CycleCompletionState,
     observedAt: string,
   ) => Effect.Effect<CycleMutationReceipt, CycleStoreError>
   readonly block: (
@@ -129,6 +147,10 @@ const CycleAuthoritySlotSchema = Schema.Struct({
   accountId: StrictNonEmptyStringSchema,
   signalSessionDate: IsoDateSchema,
 })
+const CycleRecoveryScopeSchema = Schema.Struct({
+  qualificationRunId: Sha256Schema,
+  accountId: StrictNonEmptyStringSchema,
+})
 const SnapshotInputSchema = Schema.Struct({
   cycleId: Sha256Schema,
   observedAt: UtcInstantSchema,
@@ -143,6 +165,11 @@ const BlockInputSchema = Schema.Struct({
   reason: Schema.Enum(CycleTerminalReason),
   observedAt: UtcInstantSchema,
 })
+const FinishInputSchema = Schema.Struct({
+  cycleId: Sha256Schema,
+  state: Schema.Literals([CycleState.Completed, CycleState.NoTrade]),
+  observedAt: UtcInstantSchema,
+})
 const MutationRowsSchema = Schema.Array(Schema.Struct({ cycle_id: Sha256Schema })).check(Schema.isMaxLength(1))
 const DecisionEvidenceMatchSchema = Schema.Tuple([Schema.Struct({ matches: Schema.Boolean })])
 const StoredDecisionDocumentRowsSchema = Schema.Array(Schema.Struct({ document: ObserveShadowDecisionDocumentSchema }))
@@ -150,9 +177,11 @@ const StoredDecisionDocumentRowsSchema = Schema.Array(Schema.Struct({ document: 
 const decodeStoredCycleRows = Schema.decodeUnknownEffect(Schema.Array(StoredCycleRowSchema), strictParseOptions)
 const decodeCycleIdInput = Schema.decodeUnknownEffect(CycleIdInputSchema, strictParseOptions)
 const decodeCycleAuthoritySlot = Schema.decodeUnknownEffect(CycleAuthoritySlotSchema, strictParseOptions)
+const decodeCycleRecoveryScope = Schema.decodeUnknownEffect(CycleRecoveryScopeSchema, strictParseOptions)
 const decodeSnapshotInput = Schema.decodeUnknownEffect(SnapshotInputSchema, strictParseOptions)
 const decodeDecisionInput = Schema.decodeUnknownEffect(DecisionInputSchema, strictParseOptions)
 const decodeBlockInput = Schema.decodeUnknownEffect(BlockInputSchema, strictParseOptions)
+const decodeFinishInput = Schema.decodeUnknownEffect(FinishInputSchema, strictParseOptions)
 const decodeCycleDraft = Schema.decodeUnknownEffect(CycleDraftSchema, strictParseOptions)
 const decodeMutationRows = Schema.decodeUnknownEffect(MutationRowsSchema, strictParseOptions)
 const decodeDecisionEvidenceMatch = Schema.decodeUnknownEffect(DecisionEvidenceMatchSchema, strictParseOptions)
@@ -331,6 +360,31 @@ const selectDecisionDocument = (
     WHERE cycle_id = ${cycleId}
   `.pipe(Effect.flatMap(decodeStoredDecisionDocumentRows))
 
+const selectOldestUnfinishedCycle = (
+  sql: PgClient.PgClient,
+  scope: CycleRecoveryScope,
+): Effect.Effect<readonly AutonomousCycle[], unknown> =>
+  sql<Record<string, unknown>>`
+    SELECT
+      cycle_id, schema_version, identity_schema_version, strategy_name,
+      qualification_run_id, strategy_protocol_hash, account_id,
+      signal_session_date::text AS signal_session_date, signal_calendar_version,
+      execution_policy_schema_version, execution_policy_hash,
+      strategy_execution_model_hash, submission_window_ms, submission_cutoff_before_open_ms,
+      window_schema_version, execution_calendar_schema_version,
+      execution_calendar_source, execution_calendar_hash,
+      execution_session_date::text AS execution_session_date,
+      signal_close_at, publication_deadline_at, submission_open_at,
+      execution_open_at, execution_close_at, submission_cutoff_at, state, snapshot_id,
+      decision_hash, terminal_reason, state_version, created_at, updated_at, terminal_at
+    FROM autonomous_cycles
+    WHERE qualification_run_id = ${scope.qualificationRunId}
+      AND account_id = ${scope.accountId}
+      AND state IN (${CycleState.Pending}, ${CycleState.Active})
+    ORDER BY signal_session_date ASC, cycle_id ASC
+    LIMIT 1
+  `.pipe(Effect.flatMap(decodeRows))
+
 const exactlyOne = (
   operation: CycleStoreError['operation'],
   rows: readonly AutonomousCycle[],
@@ -395,6 +449,38 @@ const makeCycleStore = Effect.gen(function* () {
       Effect.map(([match]) => match.matches),
     )
 
+  const verifyDecisionBoundBlock = (
+    cycle: AutonomousCycle,
+    reason: CycleTerminalReason,
+  ): Effect.Effect<void, unknown> =>
+    Effect.gen(function* () {
+      const storedRows = yield* selectDecisionDocument(sql, cycle.identity.cycleId)
+      const storedDocument = storedRows[0]?.document
+      const targetReason = storedDocument?.targetPlan.reason
+      if (
+        storedRows.length !== 1 ||
+        storedDocument === undefined ||
+        storedDocument.contentHash !== cycle.bindings.decisionHash ||
+        storedDocument.targetPlan.status !== TargetPlanStatus.Blocked ||
+        targetReason === null ||
+        targetReason === undefined
+      ) {
+        return yield* fail(
+          'block',
+          'invariant',
+          'decision-bound cycle may block only from its exact blocked shadow decision',
+        )
+      }
+      const expectedReason = yield* Effect.try({
+        try: () => cycleTerminalReasonForTargetPlanBlock(targetReason),
+        catch: () =>
+          storeError('block', 'invariant', 'decision-bound cycle shadow decision has an invalid blocked reason'),
+      })
+      if (reason !== expectedReason) {
+        return yield* fail('block', 'invariant', 'cycle blocked reason must match its exact durable shadow decision')
+      }
+    })
+
   const blockCycle = (
     operation: CycleStoreError['operation'],
     cycle: AutonomousCycle,
@@ -425,19 +511,24 @@ const makeCycleStore = Effect.gen(function* () {
     if (observedAt < cycle.updatedAt) {
       return fail(operation, 'conflict', 'cycle update time cannot move backward')
     }
-    return sql<Record<string, unknown>>`
-      UPDATE autonomous_cycles
-      SET
-        state = ${CycleState.Blocked},
-        terminal_reason = ${reason},
-        state_version = ${cycle.stateVersion + 1},
-        updated_at = ${observedAt},
-        terminal_at = ${observedAt}
-      WHERE cycle_id = ${cycle.identity.cycleId}
-        AND state = ${cycle.state}
-        AND state_version = ${cycle.stateVersion}
-      RETURNING cycle_id
-    `.pipe(
+    const verifyDecision =
+      cycle.state === CycleState.Active && cycle.bindings.decisionHash !== undefined
+        ? verifyDecisionBoundBlock(cycle, reason)
+        : Effect.void
+    return verifyDecision.pipe(
+      Effect.andThen(sql<Record<string, unknown>>`
+        UPDATE autonomous_cycles
+        SET
+          state = ${CycleState.Blocked},
+          terminal_reason = ${reason},
+          state_version = ${cycle.stateVersion + 1},
+          updated_at = ${observedAt},
+          terminal_at = ${observedAt}
+        WHERE cycle_id = ${cycle.identity.cycleId}
+          AND state = ${cycle.state}
+          AND state_version = ${cycle.stateVersion}
+        RETURNING cycle_id
+      `),
       Effect.flatMap((rows) => requireApplied(operation, rows)),
       Effect.flatMap(() => readLocked(operation, cycle.identity.cycleId)),
       Effect.map((updated) => ({ cycle: updated, changed: true })),
@@ -562,6 +653,17 @@ const makeCycleStore = Effect.gen(function* () {
           }
           return Effect.succeed(rows[0] === undefined ? Option.none() : Option.some(rows[0].document))
         }),
+      ),
+    )
+
+  const readOldestUnfinished = (
+    scope: CycleRecoveryScope,
+  ): Effect.Effect<Option.Option<AutonomousCycle>, CycleStoreError> =>
+    run(
+      'read-oldest-unfinished',
+      decodeCycleRecoveryScope(scope).pipe(
+        Effect.flatMap((decoded) => selectOldestUnfinishedCycle(sql, decoded)),
+        Effect.map((rows) => (rows[0] === undefined ? Option.none() : Option.some(rows[0]))),
       ),
     )
 
@@ -733,7 +835,8 @@ const makeCycleStore = Effect.gen(function* () {
                 input.document.bindings.snapshotId !== cycle.bindings.snapshotId ||
                 input.document.bindings.accountId !== cycle.identity.accountId ||
                 input.document.submissionCutoffAt !== cycle.window.submissionCutoffAt ||
-                input.document.createdAt !== input.observedAt
+                input.document.createdAt > input.observedAt ||
+                input.document.createdAt < cycle.updatedAt
               ) {
                 return yield* fail(
                   'bind-decision',
@@ -785,6 +888,67 @@ const makeCycleStore = Effect.gen(function* () {
       ),
     )
 
+  const finish = (
+    cycleId: string,
+    state: CycleCompletionState,
+    observedAt: string,
+  ): Effect.Effect<CycleMutationReceipt, CycleStoreError> =>
+    run(
+      'finish',
+      decodeFinishInput({ cycleId, state, observedAt }).pipe(
+        Effect.flatMap((input) =>
+          sql.withTransaction(
+            Effect.gen(function* () {
+              const cycle = yield* readLocked('finish', input.cycleId)
+              if (cycle.state === input.state) return { cycle, changed: false }
+              if (!isCycleStateTransitionAllowed(cycle.state, input.state)) {
+                return yield* fail('finish', 'conflict', 'only an active cycle may finish from its bound decision')
+              }
+              if (input.observedAt < cycle.updatedAt) {
+                return yield* fail('finish', 'conflict', 'cycle update time cannot move backward')
+              }
+              const decisionHash = cycle.bindings.decisionHash
+              if (decisionHash === undefined) {
+                return yield* fail('finish', 'invariant', 'cycle completion requires a bound shadow decision')
+              }
+              const storedRows = yield* selectDecisionDocument(sql, input.cycleId)
+              const storedDocument = storedRows[0]?.document
+              const expectedStatus =
+                input.state === CycleState.Completed ? TargetPlanStatus.Planned : TargetPlanStatus.NoTrade
+              if (
+                storedRows.length !== 1 ||
+                storedDocument === undefined ||
+                storedDocument.contentHash !== decisionHash ||
+                storedDocument.targetPlan.status !== expectedStatus
+              ) {
+                return yield* fail(
+                  'finish',
+                  'invariant',
+                  'cycle terminal state must match its exact durable shadow decision',
+                )
+              }
+              const updatedRows = yield* sql<Record<string, unknown>>`
+                UPDATE autonomous_cycles
+                SET
+                  state = ${input.state},
+                  state_version = ${cycle.stateVersion + 1},
+                  updated_at = ${input.observedAt},
+                  terminal_at = ${input.observedAt}
+                WHERE cycle_id = ${input.cycleId}
+                  AND state = ${CycleState.Active}
+                  AND state_version = ${cycle.stateVersion}
+                  AND decision_hash = ${decisionHash}
+                RETURNING cycle_id
+              `
+              yield* requireApplied('finish', updatedRows)
+              const updated = yield* readLocked('finish', input.cycleId)
+              return { cycle: updated, changed: true }
+            }),
+          ),
+        ),
+      ),
+    )
+
   const block = (
     cycleId: string,
     reason: CycleTerminalReason,
@@ -808,9 +972,11 @@ const makeCycleStore = Effect.gen(function* () {
     read,
     readAuthoritySlot,
     readDecisionDocument,
+    readOldestUnfinished,
     bindSnapshot,
     activate,
     bindDecision,
+    finish,
     block,
   } satisfies CycleStoreShape
 })

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -296,6 +296,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       { migration_id: 10, name: 'autonomous_cycles' },
       { migration_id: 11, name: 'causal_protocol' },
       { migration_id: 12, name: 'observe_shadow_decisions' },
+      { migration_id: 13, name: 'autonomous_cycle_terminal_transitions' },
     ])
   })
 

--- a/services/bayn/src/db/migrations.ts
+++ b/services/bayn/src/db/migrations.ts
@@ -12,6 +12,7 @@ import fillSourceTimestamp from '../../migrations/0009_fill_source_timestamp'
 import autonomousCycles from '../../migrations/0010_autonomous_cycles'
 import causalProtocol from '../../migrations/0011_causal_protocol'
 import observeShadowDecisions from '../../migrations/0012_observe_shadow_decisions'
+import autonomousCycleTerminalTransitions from '../../migrations/0013_autonomous_cycle_terminal_transitions'
 
 export const migrationLoader = PgMigrator.fromRecord({
   '1_initial_schema': initialSchema,
@@ -26,4 +27,5 @@ export const migrationLoader = PgMigrator.fromRecord({
   '10_autonomous_cycles': autonomousCycles,
   '11_causal_protocol': causalProtocol,
   '12_observe_shadow_decisions': observeShadowDecisions,
+  '13_autonomous_cycle_terminal_transitions': autonomousCycleTerminalTransitions,
 })


### PR DESCRIPTION
## Summary

- recover exactly one oldest unfinished autonomous cycle before bounded publication discovery, using a pure recovery decision and the existing direct CycleStore boundary
- bind the exact OBSERVE decision document with runner-owned Clock time, then resume its immutable terminal result across cutoff or runtime protocol changes
- enforce exact decision-backed COMPLETED, NO_TRADE, and BLOCKED transitions in PostgreSQL while preserving pre-decision deadline and provenance blocks
- keep the single scoped Effect loop alive after typed pass failures and expose one typed per-pass observation hook for Lane B health composition
- derive the cycle execution policy from the compiled protocol and retain zero Intent, broker mutation, or PAPER capability

## Related Issues

Linear: PROOMPT-383

## Testing

- `bunx oxfmt --check services/bayn`
- `bun run --cwd services/bayn tsc`
- `bun run --cwd services/bayn lint:oxlint`
- `bun run --cwd services/bayn lint:oxlint:type`
- `bun run --cwd services/bayn test` (314 passed, 66 PostgreSQL-only tests skipped)
- `bun test packages/scripts/src/bayn` (9 passed)
- `bun run --cwd services/bayn build`
- PostgreSQL 18: `bun test services/bayn/src/db/evidence-store.integration.test.ts` (36 passed)
- PostgreSQL 18: `bun test services/bayn/src/db/paper-store.integration.test.ts` (7 passed)
- PostgreSQL 18: `bun test services/bayn/src/db/cycle-store.integration.test.ts` (13 passed)

## Breaking Changes

None. Migration 0013 extends the existing autonomous-cycle lifecycle trigger and is applied through the normal Bayn migration path.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked. The exact-bound MarketData loader remains a focused composition dependency before Lane B runtime wiring.