### PR TITLE
fix(buzz): allow CNPG status proxy

### DIFF
--- a/argocd/applications/buzz/networkpolicy.yaml
+++ b/argocd/applications/buzz/networkpolicy.yaml
@@ -69,6 +69,30 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  name: allow-kubernetes-api-cnpg-status
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: buzz-db
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        # kube-apiserver is host-networked, so cross-node pod proxy requests
+        # arrive from the three control-plane node addresses.
+        - ipBlock:
+            cidr: 100.100.244.141/32
+        - ipBlock:
+            cidr: 100.100.244.142/32
+        - ipBlock:
+            cidr: 100.100.244.190/32
+      ports:
+        - port: 8000
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
   name: allow-database-operators
 spec:
   podSelector: {}

--- a/docs/runbooks/buzz-production.md
+++ b/docs/runbooks/buzz-production.md
@@ -46,6 +46,10 @@ The two OBCs, CNPG cluster, Redis PVC, and generated runtime Secret have explici
 
 Run every Kubernetes command with the namespace explicitly set.
 
+The CNPG status endpoint is reachable only from the three host-networked kube-apiserver node addresses listed in
+`allow-kubernetes-api-cnpg-status`. Update those `/32` entries whenever a control-plane node address changes; otherwise
+cross-node `kubectl cnpg status` pod-proxy requests will fail while same-node requests can appear healthy.
+
 ```sh
 kubectl -n buzz get externalsecret,secretstore
 kubectl -n buzz get objectbucketclaim

--- a/packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts
+++ b/packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts
@@ -114,6 +114,11 @@ describe('Buzz production GitOps contract', () => {
     expect(networkPolicy).toContain('name: default-deny-ingress')
     expect(networkPolicy).toContain('app.kubernetes.io/name: observability-cluster-metrics-alloy')
     expect(networkPolicy).toContain('port: 9187')
+    expect(networkPolicy).toContain('name: allow-kubernetes-api-cnpg-status')
+    for (const controlPlaneAddress of ['100.100.244.141/32', '100.100.244.142/32', '100.100.244.190/32']) {
+      expect(networkPolicy).toContain(`cidr: ${controlPlaneAddress}`)
+    }
+    expect(networkPolicy).toContain('port: 8000')
   })
 
   test('keeps credentials out of Git and combines generated credentials through External Secrets', () => {


### PR DESCRIPTION
## Summary

- Allow the three host-networked kube-apiserver node addresses to reach the CNPG status port.
- Keep the exception scoped to Buzz database pods, TCP 8000, and exact `/32` source addresses.
- Document node-address maintenance and enforce the policy contract in tests.

## Related Issues

None

## Testing

- Reproduced `kubectl cnpg status -n buzz buzz-db --verbose` with cross-node pod-proxy failures for buzz-db-1 and buzz-db-2 while the same-node buzz-db-3 status succeeded.
- Verified all three control-plane InternalIP addresses from live Node objects and kube-apiserver host-network pod placement.
- `bun test packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts`
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts`
- `bun run lint:argocd`
- `kustomize build --enable-helm argocd/applications/buzz | kubectl apply -n buzz --server-side --dry-run=server --field-manager=argocd-controller -f -`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed because this is a NetworkPolicy-only operational fix; Breaking Changes is filled in.
- [x] Documentation records the required control-plane address maintenance.