### PR TITLE
feat(bayn): expose same-pass planning evidence

### DIFF
--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -14,6 +14,7 @@ import {
   Authority,
   Broker,
   DiscrepancyKind,
+  KillState,
   OrderSide,
   OrderStatus,
   OrderType,
@@ -108,17 +109,17 @@ const makeClientRuntime = () => ManagedRuntime.make(PostgresClientLive(config).p
 
 const makeEvidenceRuntime = () => ManagedRuntime.make(EvidenceStoreLive(config).pipe(Layer.provide(NodeServices.layer)))
 
-const accountEvent = (): Extract<BrokerEventInput, { readonly _tag: 'Account' }> => ({
+const accountEvent = (eventAccountId = accountId): Extract<BrokerEventInput, { readonly _tag: 'Account' }> => ({
   _tag: 'Account',
   broker: Broker.Alpaca,
-  accountId,
+  accountId: eventAccountId,
   sourceEventId: 'account-response-1',
   contentHash: hash('account-response-1'),
   occurredAt,
   observedAt,
   account: {
     schemaVersion: 'bayn.paper-account-snapshot.v1',
-    accountId,
+    accountId: eventAccountId,
     status: AccountStatus.Active,
     currency: 'USD',
     cashMicros: '1000000000',
@@ -159,10 +160,12 @@ const fillEvent = (
   priceMicros: string,
   eventOccurredAt = occurredAt,
   brokerTimestamp = sourceTimestamp(eventOccurredAt),
+  eventAccountId = accountId,
+  eventObservedAt = observedAt,
 ): FillEventInput => {
   const fill = {
     schemaVersion: 'bayn.paper-fill.v1' as const,
-    accountId,
+    accountId: eventAccountId,
     fillId: id,
     brokerOrderId: `order-${id}`,
     clientOrderId: `client-${id}`,
@@ -176,7 +179,7 @@ const fillEvent = (
   return {
     _tag: 'Fill',
     broker: Broker.Alpaca,
-    accountId,
+    accountId: eventAccountId,
     sourceEventId: id,
     sourceTimestamp: brokerTimestamp,
     contentHash: canonicalHashV1({
@@ -185,7 +188,7 @@ const fillEvent = (
       brokerTransactionTime: brokerTimestamp,
     }),
     occurredAt: eventOccurredAt,
-    observedAt,
+    observedAt: eventObservedAt,
     fill,
   }
 }
@@ -220,10 +223,12 @@ const positionEvent = (
 const positionSnapshotInput = (
   sourceHash: string,
   positions: readonly PositionEventInput[],
+  snapshotAccountId = accountId,
+  snapshotObservedAt = observedAt,
 ): PositionSnapshotInput => ({
-  accountId,
+  accountId: snapshotAccountId,
   sourceHash,
-  observedAt,
+  observedAt: snapshotObservedAt,
   positions,
 })
 
@@ -368,33 +373,126 @@ describePostgres('paper accounting persistence', () => {
         observed: `UNKNOWN:${occurredAt}`,
       })
       expect(result.metrics.oldestUnknownMutationAgeMs).toBe(3_000)
+      expect(result.riskContext).toMatchObject({
+        tradingDate: '2026-07-22',
+        authority: null,
+        authorityObservedAt: null,
+        unknownMutationCount: 1,
+        dailyTradedNotionalMicros: '0',
+        dayStartEquityMicros: accountEvent().account.cashMicros,
+        peakEquityMicros: accountEvent().account.cashMicros,
+      })
     } finally {
       await runtime.dispose()
     }
   }, 15_000)
 
   test('recovers the PostgreSQL-to-TigerBeetle crash window without duplicate accounting', async () => {
-    const control: JournalControl = { fail: true, planHashes: [] }
+    const control: JournalControl = { fail: false, planHashes: [] }
     const runtime = makeStoreRuntime(control)
     const buy = fillEvent('fill-buy', OrderSide.Buy, '3000000', '100000000')
     const sell = fillEvent('fill-sell', OrderSide.Sell, '1000000', '120000000')
+    const priorBuy = fillEvent(
+      'fill-prior-buy',
+      OrderSide.Buy,
+      '1000000',
+      '70000000',
+      '2026-07-21T19:58:00.000Z',
+      sourceTimestamp('2026-07-21T19:58:00.000Z'),
+      accountId,
+      '2026-07-21T19:58:01.000Z',
+    )
+    const priorSell = fillEvent(
+      'fill-prior-sell',
+      OrderSide.Sell,
+      '1000000',
+      '70000000',
+      '2026-07-21T19:59:00.000Z',
+      sourceTimestamp('2026-07-21T19:59:00.000Z'),
+      accountId,
+      '2026-07-21T19:59:01.000Z',
+    )
+    const otherAccountId = 'paper-account-2'
+    const otherFill = fillEvent(
+      'fill-other-account',
+      OrderSide.Buy,
+      '1000000',
+      '70000000',
+      occurredAt,
+      sourceTimestamp(occurredAt),
+      otherAccountId,
+    )
     try {
       await runtime.runPromise(
-        Effect.flatMap(PaperStore, (store) =>
-          store.ingest({
+        Effect.gen(function* () {
+          const store = yield* PaperStore
+          const opening = {
             ...accountEvent(),
             sourceEventId: 'opening-account',
             contentHash: hash('opening-account'),
-            occurredAt: '2026-07-22T15:29:59.000Z',
-            observedAt: '2026-07-22T15:29:59.000Z',
+            occurredAt: '2026-07-21T19:57:00.000Z',
+            observedAt: '2026-07-21T19:57:01.000Z',
             account: {
               ...accountEvent().account,
               equityMicros: accountEvent().account.cashMicros,
-              observedAt: '2026-07-22T15:29:59.000Z',
+              observedAt: '2026-07-21T19:57:01.000Z',
             },
-          }),
-        ),
+          } satisfies BrokerEventInput
+          const openingReceipt = yield* store.ingest(opening)
+          const openingPositions = yield* store.ingestPositions(
+            positionSnapshotInput(hash('opening-empty-positions'), [], accountId, '2026-07-21T19:57:01.000Z'),
+          )
+          yield* store.value({
+            accountEventId: openingReceipt.eventId,
+            positionSnapshotId: openingPositions.snapshotId,
+          })
+
+          const otherOpening = {
+            ...accountEvent(otherAccountId),
+            sourceEventId: 'other-opening-account',
+            contentHash: hash('other-opening-account'),
+            account: {
+              ...accountEvent(otherAccountId).account,
+              equityMicros: accountEvent(otherAccountId).account.cashMicros,
+            },
+          } satisfies BrokerEventInput
+          const otherReceipt = yield* store.ingest(otherOpening)
+          const otherPositions = yield* store.ingestPositions(
+            positionSnapshotInput(hash('other-opening-empty-positions'), [], otherAccountId),
+          )
+          yield* store.value({
+            accountEventId: otherReceipt.eventId,
+            positionSnapshotId: otherPositions.snapshotId,
+          })
+
+          yield* store.account(priorBuy)
+          yield* store.account(priorSell)
+
+          const dayStartObservedAt = '2026-07-22T13:30:00.000Z'
+          const dayStartAccount = {
+            ...accountEvent(),
+            sourceEventId: 'day-start-account',
+            contentHash: hash('day-start-account'),
+            occurredAt: dayStartObservedAt,
+            observedAt: dayStartObservedAt,
+            account: {
+              ...accountEvent().account,
+              cashMicros: '999999800',
+              equityMicros: '999999800',
+              observedAt: dayStartObservedAt,
+            },
+          } satisfies BrokerEventInput
+          const dayStartReceipt = yield* store.ingest(dayStartAccount)
+          const dayStartPositions = yield* store.ingestPositions(
+            positionSnapshotInput(hash('day-start-empty-positions'), [], accountId, dayStartObservedAt),
+          )
+          yield* store.value({
+            accountEventId: dayStartReceipt.eventId,
+            positionSnapshotId: dayStartPositions.snapshotId,
+          })
+        }),
       )
+      control.fail = true
       const failed = await runtime.runPromiseExit(Effect.flatMap(PaperStore, (store) => store.account(buy)))
       expect(Exit.isFailure(failed)).toBe(true)
 
@@ -409,26 +507,28 @@ describePostgres('paper accounting persistence', () => {
           return counts
         }),
       )
-      expect(afterFailure).toEqual({ transactions: 1, receipts: 0 })
+      expect(afterFailure).toEqual({ transactions: 3, receipts: 2 })
 
       control.fail = false
       const outOfOrder = await runtime.runPromiseExit(Effect.flatMap(PaperStore, (store) => store.account(sell)))
       expect(Exit.isFailure(outOfOrder)).toBe(true)
       if (Exit.isFailure(outOfOrder)) expect(Cause.pretty(outOfOrder.cause)).toContain('earlier fill')
-      expect(control.planHashes).toHaveLength(1)
+      expect(control.planHashes).toHaveLength(3)
 
-      const [receipt, replay, sale] = await runtime.runPromise(
+      const [receipt, replay, sale, otherAccountFill] = await runtime.runPromise(
         Effect.gen(function* () {
           const store = yield* PaperStore
           const receipt = yield* store.account(buy)
           const replay = yield* store.account(buy)
           const sale = yield* store.account(sell)
-          return [receipt, replay, sale] as const
+          const otherAccountFill = yield* store.account(otherFill)
+          return [receipt, replay, sale, otherAccountFill] as const
         }),
       )
       expect(replay).toEqual(receipt)
       expect(sale.brokerEventId).not.toBe(receipt.brokerEventId)
-      expect(new Set(control.planHashes.slice(0, 3)).size).toBe(1)
+      expect(otherAccountFill.brokerEventId).not.toBe(sale.brokerEventId)
+      expect(new Set(control.planHashes.slice(2, 5)).size).toBe(1)
 
       const stored = await runtime.runPromise(
         Effect.gen(function* () {
@@ -463,11 +563,11 @@ describePostgres('paper accounting persistence', () => {
         ]),
       )
       expect(stored.transactions.every((transaction) => /^[a-f0-9]{64}$/.test(transaction.ledger_plan_hash))).toBe(true)
-      expect(stored.counts).toEqual({ events: 3, transactions: 2, receipts: 2 })
+      expect(stored.counts).toEqual({ events: 8, transactions: 5, receipts: 5 })
       expect(Exit.isFailure(stored.immutable)).toBe(true)
       expect(Exit.isFailure(stored.truncate)).toBe(true)
 
-      const exact = await runtime.runPromise(
+      const result = await runtime.runPromise(
         Effect.gen(function* () {
           const store = yield* PaperStore
           const currentAccount = {
@@ -476,8 +576,8 @@ describePostgres('paper accounting persistence', () => {
             contentHash: hash('current-account'),
             account: {
               ...accountEvent().account,
-              cashMicros: '819999800',
-              equityMicros: '1019999800',
+              cashMicros: '819999600',
+              equityMicros: '1019999600',
             },
           } satisfies BrokerEventInput
           const accountReceipt = yield* store.ingest(currentAccount)
@@ -489,20 +589,77 @@ describePostgres('paper accounting persistence', () => {
             accountEventId: accountReceipt.eventId,
             positionSnapshotId: positionsReceipt.snapshotId,
           })
-          return yield* store.reconcile({
+          const sql = yield* PgClient.PgClient
+          yield* sql`
+            INSERT INTO valuations (
+              valuation_id, schema_version, account_id, source_hash, cash_micros,
+              long_market_value_micros, short_market_value_micros, equity_micros, as_of
+            ) VALUES
+              (
+                ${hash('future-primary-valuation')}, 'bayn.paper-valuation.v1', ${accountId},
+                ${hash('future-primary-source')}, 9000000000, 0, 0, 9000000000,
+                '2026-07-22T16:00:00.000Z'
+              ),
+              (
+                ${hash('other-account-valuation')}, 'bayn.paper-valuation.v1', ${otherAccountId},
+                ${hash('other-account-source')}, 8000000000, 0, 0, 8000000000,
+                '2026-07-22T15:30:30.000Z'
+              )
+          `
+          yield* sql`
+            INSERT INTO authority_state (
+              schema_version, generation_hash, maximum, effective, kill_state, version, updated_at
+            ) VALUES (
+              'bayn.paper-authority.v1', ${hash('observe-generation')}, 'OBSERVE', 'OBSERVE', 'CLEAR', 1,
+              '2026-07-22T15:30:02.000Z'
+            )
+          `
+          const [observationBefore] = yield* sql<{ observed_at: Date }>`
+            SELECT clock_timestamp() AS observed_at
+          `
+          const exact = yield* store.reconcile({
             account: currentAccount.account,
             positions: [position.position],
             positionsObservedAt: observedAt,
             orders: [],
             ordersObservedAt: observedAt,
-            fills: [buy.fill, sell.fill],
+            fills: [priorBuy.fill, priorSell.fill, buy.fill, sell.fill],
             valuation,
             reconciledAt: '2026-07-22T15:31:00.000Z',
           })
+          const [observationAfter] = yield* sql<{ observed_at: Date }>`
+            SELECT clock_timestamp() AS observed_at
+          `
+          return {
+            exact,
+            observationBefore: observationBefore.observed_at,
+            observationAfter: observationAfter.observed_at,
+          }
         }),
       )
+      const { exact, observationBefore, observationAfter } = result
       expect(exact.reconciliation.status).toBe(ReconciliationStatus.Exact)
       expect(exact.reconciliation.discrepancies).toEqual([])
+      const { authorityObservedAt, ...riskContext } = exact.riskContext
+      expect(riskContext).toMatchObject({
+        tradingDate: '2026-07-22',
+        authority: {
+          generationHash: hash('observe-generation'),
+          maximum: Authority.Observe,
+          effective: Authority.Observe,
+          kill: KillState.Clear,
+          version: 1,
+          updatedAt: '2026-07-22T15:30:02.000Z',
+        },
+        unknownMutationCount: 0,
+        dailyTradedNotionalMicros: '420000000',
+        dayStartEquityMicros: '999999800',
+        peakEquityMicros: '1019999600',
+      })
+      if (authorityObservedAt === null) throw new Error('expected a durable authority observation')
+      expect(Date.parse(authorityObservedAt)).toBeGreaterThanOrEqual(observationBefore.getTime())
+      expect(Date.parse(authorityObservedAt)).toBeLessThanOrEqual(observationAfter.getTime())
+      expect(Date.parse(authorityObservedAt)).toBeGreaterThanOrEqual(Date.parse('2026-07-22T15:30:02.000Z'))
     } finally {
       await runtime.dispose()
     }
@@ -804,7 +961,21 @@ describePostgres('paper accounting persistence', () => {
 
       expect(result.exact.reconciliation.status).toBe(ReconciliationStatus.Exact)
       expect(result.mismatch.reconciliation.status).toBe(ReconciliationStatus.Discrepancy)
-      expect(result.replay).toEqual(result.mismatch)
+      const mismatchRiskContext = result.mismatch.riskContext
+      const replayRiskContext = result.replay.riskContext
+      if (mismatchRiskContext.authorityObservedAt === null || replayRiskContext.authorityObservedAt === null) {
+        throw new Error('expected authority observations for discrepancy replay')
+      }
+      expect(result.replay).toEqual({
+        ...result.mismatch,
+        riskContext: {
+          ...mismatchRiskContext,
+          authorityObservedAt: replayRiskContext.authorityObservedAt,
+        },
+      })
+      expect(Date.parse(replayRiskContext.authorityObservedAt)).toBeGreaterThanOrEqual(
+        Date.parse(mismatchRiskContext.authorityObservedAt),
+      )
       expect(result.mismatch.reconciliation.discrepancies).toHaveLength(1)
       expect(result.ongoing.reconciliation.discrepancies[0]).toMatchObject({
         discrepancyId: result.mismatch.reconciliation.discrepancies[0]?.discrepancyId,

--- a/services/bayn/src/db/paper-store.ts
+++ b/services/bayn/src/db/paper-store.ts
@@ -46,7 +46,7 @@ import {
   restrictAuthority,
   type BrokerSnapshot,
   type IntentBinding,
-  type ReconciliationReport,
+  type ReconciliationWriteResult,
 } from './reconciliation'
 
 export const VALUATION_SNAPSHOT_MAX_SKEW_MS = 30_000
@@ -86,7 +86,7 @@ export interface PaperStoreShape {
   readonly value: (input: ValuationInput) => Effect.Effect<Valuation, PaperStoreError>
   readonly hasAccountBaseline: (accountId: string) => Effect.Effect<boolean, PaperStoreError>
   readonly bindings: (accountId: string) => Effect.Effect<readonly IntentBinding[], PaperStoreError>
-  readonly reconcile: (snapshot: BrokerSnapshot) => Effect.Effect<ReconciliationReport, PaperStoreError>
+  readonly reconcile: (snapshot: BrokerSnapshot) => Effect.Effect<ReconciliationWriteResult, PaperStoreError>
   readonly restrictAuthority: (reason: string, updatedAt: string) => Effect.Effect<void, PaperStoreError>
 }
 

--- a/services/bayn/src/db/reconciliation.ts
+++ b/services/bayn/src/db/reconciliation.ts
@@ -7,14 +7,19 @@ import type { RuntimeConfig } from '../config'
 import { canonicalHashV1 } from '../hash'
 import type { JournalService } from '../ledger'
 import {
+  Authority,
   DiscrepancySchema,
   IntentState,
+  KillState,
   OrderSide,
   OrderType,
   ReconciliationStatus,
+  SignedMicrosSchema,
   TerminalOutcome,
   TimeInForce,
+  UnsignedMicrosSchema,
   decodeAccountingReceipt,
+  decodeAuthorityState,
   decodeReconciliation,
   type AccountSnapshot,
   type AccountingReceipt,
@@ -30,8 +35,10 @@ import {
   reconciledStateHash,
   type IntentExpectation,
   type ReconciliationMetrics,
+  type ReconciliationRiskContext,
 } from '../reconciliation'
 import {
+  IsoDateSchema,
   Sha256Schema as Sha256,
   StrictNonEmptyStringSchema as NonEmptyString,
   UtcInstantSchema as UtcInstant,
@@ -64,6 +71,11 @@ export interface BrokerSnapshot {
 export interface ReconciliationReport {
   readonly reconciliation: Reconciliation
   readonly metrics: ReconciliationMetrics
+}
+
+export interface ReconciliationWriteResult extends ReconciliationReport {
+  readonly accountingHash: string
+  readonly riskContext: ReconciliationRiskContext
 }
 
 const IntentBindingRow = Schema.Struct({ intent_id: Sha256, client_order_id: NonEmptyString })
@@ -99,6 +111,23 @@ const PreviousReconciliationRows = Schema.Array(
   Schema.Struct({ discrepancies: Schema.Array(DiscrepancySchema) }),
 ).check(Schema.isMaxLength(1))
 const ReconciliationContentRow = Schema.Tuple([Schema.Struct({ content_hash: Sha256 })])
+const ReconciliationRiskContextRow = Schema.Tuple([
+  Schema.Struct({
+    trading_date: IsoDateSchema,
+    authority_schema_version: Schema.NullOr(Schema.Literal('bayn.paper-authority.v1')),
+    authority_generation_hash: Schema.NullOr(Sha256),
+    authority_maximum: Schema.NullOr(Schema.Enum(Authority)),
+    authority_effective: Schema.NullOr(Schema.Enum(Authority)),
+    authority_kill: Schema.NullOr(Schema.Enum(KillState)),
+    authority_reason: Schema.NullOr(NonEmptyString),
+    authority_version: Schema.NullOr(Schema.String),
+    authority_updated_at: Schema.NullOr(Schema.DateValid),
+    authority_observed_at: Schema.NullOr(Schema.DateValid),
+    daily_traded_notional_micros: UnsignedMicrosSchema,
+    day_start_equity_micros: SignedMicrosSchema,
+    peak_equity_micros: SignedMicrosSchema,
+  }),
+])
 
 const decodeBindings = Schema.decodeUnknownEffect(Schema.Array(IntentBindingRow), strictParseOptions)
 const decodeIntents = Schema.decodeUnknownEffect(Schema.Array(IntentRow), strictParseOptions)
@@ -109,10 +138,74 @@ const decodeTransactions = Schema.decodeUnknownEffect(Schema.Array(AccountingTra
 const decodeReceipts = Schema.decodeUnknownEffect(Schema.Array(AccountingReceiptRowSchema), strictParseOptions)
 const decodePreviousReconciliation = Schema.decodeUnknownEffect(PreviousReconciliationRows, strictParseOptions)
 const decodeContent = Schema.decodeUnknownEffect(ReconciliationContentRow, strictParseOptions)
+const decodeRiskContext = Schema.decodeUnknownEffect(ReconciliationRiskContextRow, strictParseOptions)
 const encodeDiscrepancies = Schema.encodeSync(Schema.fromJsonString(Schema.Array(DiscrepancySchema)))
 
 const attempt = <A>(evaluate: () => A): Effect.Effect<A, unknown> =>
   Effect.try({ try: evaluate, catch: (cause) => cause })
+
+const riskContextFromRow = (
+  row: (typeof ReconciliationRiskContextRow.Type)[0],
+  unknownMutationCount: number,
+): Effect.Effect<ReconciliationRiskContext, unknown> =>
+  Effect.gen(function* () {
+    const requiredAuthority = [
+      row.authority_schema_version,
+      row.authority_generation_hash,
+      row.authority_maximum,
+      row.authority_effective,
+      row.authority_kill,
+      row.authority_version,
+      row.authority_updated_at,
+    ]
+    const authorityMissing = requiredAuthority.every((value) => value === null)
+    if (authorityMissing && (row.authority_reason !== null || row.authority_observed_at !== null)) {
+      return yield* Effect.fail(new Error('authority evidence exists without durable authority state'))
+    }
+    if (
+      !authorityMissing &&
+      (requiredAuthority.some((value) => value === null) || row.authority_observed_at === null)
+    ) {
+      return yield* Effect.fail(new Error('durable authority state is incomplete'))
+    }
+
+    const authority = authorityMissing
+      ? null
+      : yield* Effect.gen(function* () {
+          const version = Number(row.authority_version)
+          if (!Number.isSafeInteger(version) || version <= 0) {
+            return yield* Effect.fail(new Error('durable authority version is not a safe positive integer'))
+          }
+          return yield* decodeAuthorityState({
+            schemaVersion: row.authority_schema_version,
+            generationHash: row.authority_generation_hash,
+            maximum: row.authority_maximum,
+            effective: row.authority_effective,
+            kill: row.authority_kill,
+            ...(row.authority_reason === null ? {} : { reason: row.authority_reason }),
+            version,
+            updatedAt: row.authority_updated_at?.toISOString(),
+          })
+        })
+
+    const material = {
+      tradingDate: row.trading_date,
+      unknownMutationCount,
+      dailyTradedNotionalMicros: row.daily_traded_notional_micros,
+      dayStartEquityMicros: row.day_start_equity_micros,
+      peakEquityMicros: row.peak_equity_micros,
+    }
+    if (authority === null) return { ...material, authority: null, authorityObservedAt: null }
+    const authorityObservedAt = row.authority_observed_at
+    if (authorityObservedAt === null) {
+      return yield* Effect.fail(new Error('durable authority observation time is missing'))
+    }
+    const authorityObservedAtIso = authorityObservedAt.toISOString()
+    if (authority.updatedAt > authorityObservedAtIso) {
+      return yield* Effect.fail(new Error('durable authority update follows its observation time'))
+    }
+    return { ...material, authority, authorityObservedAt: authorityObservedAtIso }
+  })
 
 const unresolvedEvents = new Set<MutationEventType>([
   MutationEventType.SubmitStarted,
@@ -194,7 +287,7 @@ export const makeReconciliation = (
       Effect.map((rows) => rows.map((row) => ({ intentId: row.intent_id, clientOrderId: row.client_order_id }))),
     )
 
-  const reconcile = (snapshot: BrokerSnapshot): Effect.Effect<ReconciliationReport, unknown> =>
+  const reconcile = (snapshot: BrokerSnapshot): Effect.Effect<ReconciliationWriteResult, unknown> =>
     sql.withTransaction(
       Effect.gen(function* () {
         const accountId = snapshot.account.accountId
@@ -258,6 +351,7 @@ export const makeReconciliation = (
             ? { unknownSince: row.mutation_occurred_at }
             : {}),
         }))
+        const unknownMutationCount = intents.filter((intent) => intent.unknownSince !== undefined).length
 
         const transactionRows = yield* sql<Record<string, unknown>>`
           SELECT
@@ -356,7 +450,7 @@ export const makeReconciliation = (
           ORDER BY event.source_sequence
           LIMIT 1
         `.pipe(Effect.flatMap(decodeOpeningCash))
-        const comparison = yield* attempt(() => {
+        const { accountingHash, comparison } = yield* attempt(() => {
           if (transactions.some((transaction) => transaction.occurredAt < openingCash.observed_at)) {
             throw new Error('paper accounting predates the opening cash snapshot')
           }
@@ -379,22 +473,25 @@ export const makeReconciliation = (
             ordersObservedAt: snapshot.ordersObservedAt,
             accountingHash,
           })
-          return compareReconciliation({
-            accountId,
-            stateHash,
-            account: snapshot.account,
-            positions: snapshot.positions,
-            orders: snapshot.orders,
-            fills: snapshot.fills,
-            intents,
-            durableFills,
-            projectedPositions,
-            expectedCashMicros,
-            valuation: snapshot.valuation,
+          return {
             accountingHash,
-            ledgerExact,
-            reconciledAt: snapshot.reconciledAt,
-          })
+            comparison: compareReconciliation({
+              accountId,
+              stateHash,
+              account: snapshot.account,
+              positions: snapshot.positions,
+              orders: snapshot.orders,
+              fills: snapshot.fills,
+              intents,
+              durableFills,
+              projectedPositions,
+              expectedCashMicros,
+              valuation: snapshot.valuation,
+              accountingHash,
+              ledgerExact,
+              reconciledAt: snapshot.reconciledAt,
+            }),
+          }
         })
 
         const [previous] = yield* sql<Record<string, unknown>>`
@@ -463,7 +560,49 @@ export const makeReconciliation = (
           yield* restrictAuthority(sql, `reconciliation discrepancy ${reconciliationId}`, snapshot.reconciledAt)
         }
 
-        return { reconciliation, metrics: comparison.metrics }
+        const [riskContextRow] = yield* sql<Record<string, unknown>>`
+          WITH boundary AS (
+            SELECT (${snapshot.reconciledAt}::timestamptz AT TIME ZONE 'America/New_York')::date AS trading_date
+          )
+          SELECT
+            boundary.trading_date::text AS trading_date,
+            authority.schema_version AS authority_schema_version,
+            authority.generation_hash AS authority_generation_hash,
+            authority.maximum AS authority_maximum,
+            authority.effective AS authority_effective,
+            authority.kill_state AS authority_kill,
+            authority.reason AS authority_reason,
+            authority.version::text AS authority_version,
+            authority.updated_at AS authority_updated_at,
+            CASE WHEN authority.singleton IS NULL THEN NULL ELSE clock_timestamp() END AS authority_observed_at,
+            coalesce((
+              SELECT sum(transaction.notional_micros)::text
+              FROM accounting_transactions AS transaction
+              WHERE transaction.account_id = ${accountId}
+                AND transaction.occurred_at <= ${snapshot.reconciledAt}
+                AND (transaction.occurred_at AT TIME ZONE 'America/New_York')::date = boundary.trading_date
+            ), '0') AS daily_traded_notional_micros,
+            (
+              SELECT valuation.equity_micros::text
+              FROM valuations AS valuation
+              WHERE valuation.account_id = ${accountId}
+                AND valuation.as_of <= ${snapshot.reconciledAt}
+                AND (valuation.as_of AT TIME ZONE 'America/New_York')::date = boundary.trading_date
+              ORDER BY valuation.as_of, valuation.valuation_id
+              LIMIT 1
+            ) AS day_start_equity_micros,
+            (
+              SELECT max(valuation.equity_micros)::text
+              FROM valuations AS valuation
+              WHERE valuation.account_id = ${accountId}
+                AND valuation.as_of <= ${snapshot.reconciledAt}
+            ) AS peak_equity_micros
+          FROM boundary
+          LEFT JOIN authority_state AS authority ON authority.singleton
+        `.pipe(Effect.flatMap(decodeRiskContext))
+        const riskContext = yield* riskContextFromRow(riskContextRow, unknownMutationCount)
+
+        return { reconciliation, metrics: comparison.metrics, accountingHash, riskContext }
       }),
     )
 

--- a/services/bayn/src/reconciler.test.ts
+++ b/services/bayn/src/reconciler.test.ts
@@ -25,9 +25,10 @@ import { unusedMarketCalendar } from './broker/alpaca-test-support'
 import { canonicalHashV1 } from './hash'
 import { ReconciliationStatus, type AccountingReceipt, type Valuation } from './paper'
 import { PaperStore, type PaperStoreShape } from './db/paper-store'
-import type { BrokerSnapshot, ReconciliationReport } from './db/reconciliation'
+import type { BrokerSnapshot, ReconciliationWriteResult } from './db/reconciliation'
 import { WriterFence, type WriterFenceService } from './execution/writer-fence'
 import { ReconciliationError, runContinuously, runOnce } from './reconciler'
+import { reconciledStateHash } from './reconciliation'
 
 const accountId = '61e69015-8549-4bfd-b9c3-01e75843f47d'
 const observedAt = '1970-01-01T00:00:00.000Z'
@@ -116,28 +117,49 @@ const receipt: AccountingReceipt = {
   recordedAt: observedAt,
 }
 
-const report = (snapshot: BrokerSnapshot): ReconciliationReport => ({
-  reconciliation: {
-    schemaVersion: 'bayn.paper-reconciliation.v1',
-    reconciliationId: hash('reconciliation'),
-    accountId,
-    expectedHash: hash('state'),
-    observedHash: hash('state'),
-    contentHash: hash('reconciliation-content'),
-    status: ReconciliationStatus.Exact,
-    discrepancies: [],
-    reconciledAt: snapshot.reconciledAt,
-  },
-  metrics: {
-    brokerPollAgeMs: 0,
-    oldestUnknownMutationAgeMs: 0,
-    cashDifferenceMicros: '0',
-    positionDifferenceMicros: '0',
-    equityDifferenceMicros: '0',
-    accountingExact: true,
-    discrepancyCount: 0,
-  },
-})
+const report = (snapshot: BrokerSnapshot): ReconciliationWriteResult => {
+  const accountingHash = hash('accounting-state')
+  const stateHash = reconciledStateHash({
+    account: snapshot.account,
+    positions: snapshot.positions,
+    positionsObservedAt: snapshot.positionsObservedAt,
+    orders: snapshot.orders,
+    ordersObservedAt: snapshot.ordersObservedAt,
+    accountingHash,
+  })
+  return {
+    reconciliation: {
+      schemaVersion: 'bayn.paper-reconciliation.v1',
+      reconciliationId: hash('reconciliation'),
+      accountId,
+      expectedHash: stateHash,
+      observedHash: stateHash,
+      contentHash: hash('reconciliation-content'),
+      status: ReconciliationStatus.Exact,
+      discrepancies: [],
+      reconciledAt: snapshot.reconciledAt,
+    },
+    metrics: {
+      brokerPollAgeMs: 0,
+      oldestUnknownMutationAgeMs: 0,
+      cashDifferenceMicros: '0',
+      positionDifferenceMicros: '0',
+      equityDifferenceMicros: '0',
+      accountingExact: true,
+      discrepancyCount: 0,
+    },
+    accountingHash,
+    riskContext: {
+      tradingDate: '1969-12-31',
+      authority: null,
+      authorityObservedAt: null,
+      unknownMutationCount: 0,
+      dailyTradedNotionalMicros: '0',
+      dayStartEquityMicros: snapshot.account.equityMicros,
+      peakEquityMicros: snapshot.account.equityMicros,
+    },
+  }
+}
 
 interface StoreControl {
   writes: number
@@ -232,7 +254,7 @@ describe('paper reconciliation loop', () => {
     }
     const control: StoreControl = { writes: 0, reconciliations: [], restrictions: [] }
 
-    await Effect.runPromise(provide(read, makeStore(control)))
+    const result = await Effect.runPromise(provide(read, makeStore(control)))
 
     expect(orderCursors).toEqual([undefined, allOrders[499].submittedAt, undefined, allOrders[499].submittedAt])
     expect(fillCursors).toEqual([undefined, allFills[99].activityId, undefined, allFills[99].activityId])
@@ -241,6 +263,19 @@ describe('paper reconciliation loop', () => {
     expect(control.reconciliations[0].fills).toHaveLength(101)
     expect(control.reconciliations[0].orders[0].intentId).toBe(hash('intent'))
     expect(control.reconciliations[0].fills[0].intentId).toBe(hash('intent'))
+    expect(result.brokerState.orders.map((candidate) => candidate.brokerOrderId)).toEqual(
+      allOrders.map((candidate) => candidate.brokerOrderId).sort(),
+    )
+    expect(result.brokerState.unknownOrderCount).toBe(500)
+    const stateHash = reconciledStateHash(result.brokerState)
+    expect(result.report.reconciliation.expectedHash).toBe(stateHash)
+    expect(result.report.reconciliation.observedHash).toBe(stateHash)
+    expect(result.brokerState.reconciliation).toEqual(result.report.reconciliation)
+    expect(result.riskContext).toMatchObject({
+      authority: null,
+      authorityObservedAt: null,
+      unknownMutationCount: 0,
+    })
     expect(control.restrictions).toEqual([])
   })
 

--- a/services/bayn/src/reconciler.ts
+++ b/services/bayn/src/reconciler.ts
@@ -23,6 +23,7 @@ import { PaperStore, type PaperStoreError, type PaperStoreShape } from './db/pap
 import type { BrokerSnapshot, ReconciliationReport } from './db/reconciliation'
 import { WriterFence, type WriterFenceError, type WriterFenceService } from './execution/writer-fence'
 import { canonicalHashV1 } from './hash'
+import type { ReconciledBrokerState, ReconciliationRiskContext } from './reconciliation'
 
 const maximumRows = 10_000
 const ordersPageSize = 500
@@ -41,6 +42,12 @@ interface OrderRead {
 interface BrokerHistory {
   readonly orders: OrderRead
   readonly fills: readonly Observed<FillActivity>[]
+}
+
+export interface ReconciliationPassResult {
+  readonly report: ReconciliationReport
+  readonly brokerState: ReconciledBrokerState
+  readonly riskContext: ReconciliationRiskContext
 }
 
 export class ReconciliationError extends Data.TaggedError('ReconciliationError')<{
@@ -180,7 +187,10 @@ const run = (
   read: BrokerReadShape,
   store: PaperStoreShape,
   fence: WriterFenceService,
-): Effect.Effect<ReconciliationReport, BrokerReadError | PaperStoreError | ReconciliationError | WriterFenceError> =>
+): Effect.Effect<
+  ReconciliationPassResult,
+  BrokerReadError | PaperStoreError | ReconciliationError | WriterFenceError
+> =>
   Effect.gen(function* () {
     const beforeUntil = new Date(yield* Clock.currentTimeMillis).toISOString()
     const before = yield* readHistory(read, beforeUntil)
@@ -268,16 +278,37 @@ const run = (
           positionSnapshotId: positionsReceipt.snapshotId,
         })
         const reconciledAt = new Date(yield* Clock.currentTimeMillis).toISOString()
-        const report = yield* store.reconcile({
+        const positions = normalized.positions.positions
+          .map((event) => event.position)
+          .sort((left, right) => compareText(left.symbol, right.symbol))
+        const reconciledOrders = normalized.orderEvents
+          .map((event) => event.order)
+          .sort((left, right) => compareText(left.brokerOrderId, right.brokerOrderId))
+        const unknownOrderCount = reconciledOrders.filter((order) => order.intentId === undefined).length
+        const persisted = yield* store.reconcile({
           account: normalized.account.account,
-          positions: normalized.positions.positions.map((event) => event.position),
+          positions,
           positionsObservedAt: normalized.positions.observedAt,
-          orders: normalized.orderEvents.map((event) => event.order),
+          orders: reconciledOrders,
           ordersObservedAt: orders.observedAt,
           fills: normalized.fillEvents.map((event) => event.fill),
           valuation,
           reconciledAt,
         } satisfies BrokerSnapshot)
+        const report: ReconciliationReport = {
+          reconciliation: persisted.reconciliation,
+          metrics: persisted.metrics,
+        }
+        const brokerState: ReconciledBrokerState = {
+          account: normalized.account.account,
+          positions,
+          positionsObservedAt: normalized.positions.observedAt,
+          orders: reconciledOrders,
+          ordersObservedAt: orders.observedAt,
+          accountingHash: persisted.accountingHash,
+          reconciliation: persisted.reconciliation,
+          unknownOrderCount,
+        }
 
         yield* Effect.logInfo('Paper account reconciliation completed').pipe(
           Effect.annotateLogs({
@@ -292,13 +323,13 @@ const run = (
             accountingExact: report.metrics.accountingExact,
           }),
         )
-        return report
+        return { report, brokerState, riskContext: persisted.riskContext }
       }),
     )
   }).pipe(Effect.withLogSpan('reconciliation'))
 
 export const runOnce: Effect.Effect<
-  ReconciliationReport,
+  ReconciliationPassResult,
   BrokerReadError | PaperStoreError | ReconciliationError | WriterFenceError,
   BrokerRead | PaperStore | WriterFence
 > = Effect.gen(function* () {

--- a/services/bayn/src/reconciliation.ts
+++ b/services/bayn/src/reconciliation.ts
@@ -6,11 +6,14 @@ import {
   OrderStatus,
   TerminalOutcome,
   type AccountSnapshot,
+  type AuthorityState,
   type Fill,
   type Order,
   type Position,
+  type Reconciliation,
   type Valuation,
 } from './paper'
+import type { IsoDate } from './schemas'
 
 export interface IntentExpectation {
   readonly intentId: string
@@ -64,6 +67,31 @@ export interface ReconciledStateMaterial {
   readonly ordersObservedAt: string
   readonly accountingHash: string
 }
+
+export interface ReconciledBrokerState extends ReconciledStateMaterial {
+  readonly reconciliation: Reconciliation
+  readonly unknownOrderCount: number
+}
+
+interface ReconciliationRiskMaterial {
+  readonly tradingDate: IsoDate
+  readonly unknownMutationCount: number
+  readonly dailyTradedNotionalMicros: string
+  readonly dayStartEquityMicros: string
+  readonly peakEquityMicros: string
+}
+
+export type ReconciliationRiskContext = ReconciliationRiskMaterial &
+  (
+    | {
+        readonly authority: AuthorityState
+        readonly authorityObservedAt: string
+      }
+    | {
+        readonly authority: null
+        readonly authorityObservedAt: null
+      }
+  )
 
 export interface DiscrepancyInput {
   readonly discrepancyId: string

--- a/services/bayn/src/risk-balanced-trend.test.ts
+++ b/services/bayn/src/risk-balanced-trend.test.ts
@@ -207,7 +207,10 @@ describe('risk-balanced trend candidate', () => {
         ? { ...bar, close: 100.123456 }
         : bar,
     )
-    const current = strategy.currentDecision(bars, snapshot.manifest)
+    const current = strategy.currentDecision(bars, snapshot.manifest, {
+      signalSessionDate: snapshot.manifest.lastSession,
+      executionSessionDate: '2020-05-01',
+    })
     const sessionDates = [...new Set(snapshot.bars.map((bar) => bar.sessionDate))].sort()
     const historyLength = Math.max(fixtureProtocol.volatilityWindow, ...fixtureProtocol.horizons) + 1
     const historyDates = sessionDates.slice(-historyLength)
@@ -244,14 +247,46 @@ describe('risk-balanced trend candidate', () => {
     expect(Object.values(current.priceMicros).every((price) => /^[1-9][0-9]*$/.test(price))).toBe(true)
   })
 
+  test('rejects a current decision outside the bound month-end cycle', () => {
+    const snapshot = makeSnapshot()
+    const strategy = makeStrategy(fixtureProtocol, makeTestProvenance())
+
+    expect(() =>
+      strategy.currentDecision(snapshot.bars, snapshot.manifest, {
+        signalSessionDate: snapshot.manifest.lastSession,
+        executionSessionDate: '2020-04-22',
+      }),
+    ).toThrow('current strategy decision requires a month-end due cycle')
+    expect(() =>
+      strategy.currentDecision(snapshot.bars, snapshot.manifest, {
+        signalSessionDate: '2020-04-20',
+        executionSessionDate: '2020-05-01',
+      }),
+    ).toThrow('current strategy decision must end on the due cycle Signal terminal session')
+    expect(() =>
+      strategy.currentDecision(snapshot.bars, snapshot.manifest, {
+        signalSessionDate: snapshot.manifest.lastSession,
+        executionSessionDate: '2020-04-20',
+      }),
+    ).toThrow('current strategy execution session must follow its Signal session')
+  })
+
   test('rejects an invalid or snapshot-divergent manifest before compiling a current decision', () => {
     const snapshot = makeSnapshot()
     const strategy = makeStrategy(fixtureProtocol, makeTestProvenance())
+    const cycleBinding = {
+      signalSessionDate: snapshot.manifest.lastSession,
+      executionSessionDate: '2020-05-01',
+    } as const
     expect(() =>
-      strategy.currentDecision(snapshot.bars, {
-        ...snapshot.manifest,
-        hash: '0'.repeat(64),
-      }),
+      strategy.currentDecision(
+        snapshot.bars,
+        {
+          ...snapshot.manifest,
+          hash: '0'.repeat(64),
+        },
+        cycleBinding,
+      ),
     ).toThrow()
 
     const priorSession = snapshot.bars
@@ -276,7 +311,7 @@ describe('risk-balanced trend candidate', () => {
       hash: canonicalHashV1(divergentMaterial),
     }
 
-    expect(() => strategy.currentDecision(snapshot.bars, divergent)).toThrow(
+    expect(() => strategy.currentDecision(snapshot.bars, divergent, cycleBinding)).toThrow(
       'Signal manifest does not match its finalized snapshot bounds',
     )
   })

--- a/services/bayn/src/risk-balanced-trend.test.ts
+++ b/services/bayn/src/risk-balanced-trend.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, test } from 'bun:test'
 
+import type { MarketCalendarObservation } from './broker/alpaca'
 import { referencePriceMicros } from './execution-model'
+import { bindExecutionSession } from './execution-session'
 import { canonicalHashV1 } from './hash'
 import {
   evaluateRiskBalancedTrend,
-  makeCurrentDecisionCycleBinding,
   makeRiskBalancedTrendDecision,
   prepareRiskBalancedTrendQualification,
+  type CurrentDecisionCycleBinding,
 } from './risk-balanced-trend'
 import { makeStrategy } from './strategy'
 import { makeSnapshot, makeTestProvenance, fixtureProtocol } from './test-fixtures'
@@ -21,6 +23,41 @@ const shortProtocol = (overrides: Partial<CausalProtocol> = {}): CausalProtocol 
   maximumPortfolioVolatility: 0.1,
   ...overrides,
 })
+
+const calendarSession = (date: IsoDate): MarketCalendarObservation['sessions'][number] => ({
+  date,
+  openAt: `${date}T13:30:00.000Z`,
+  closeAt: `${date}T20:00:00.000Z`,
+})
+
+const currentDecisionBinding = (
+  signalSessionDate: IsoDate,
+  calendarSessionDates: readonly IsoDate[],
+): CurrentDecisionCycleBinding => {
+  const sessions = calendarSessionDates.map(calendarSession)
+  const rangeEnd = sessions.at(-1)?.date
+  if (rangeEnd === undefined) throw new Error('current-decision fixture requires calendar sessions')
+  const material = {
+    schemaVersion: 'bayn.alpaca-market-calendar-observation.v1',
+    source: 'alpaca-v2-calendar',
+    requestedRange: { start: signalSessionDate, end: rangeEnd },
+    timeZone: 'UTC',
+    sessions,
+  } as const
+  return bindExecutionSession({
+    signal: {
+      sessionDate: signalSessionDate,
+      finalizedAt: `${signalSessionDate}T20:01:00.000Z`,
+      contentHash: 'a'.repeat(64),
+    },
+    planningBrokerState: {
+      observedAt: `${signalSessionDate}T20:02:00.000Z`,
+      contentHash: 'b'.repeat(64),
+    },
+    calendar: { ...material, normalizedResponseHash: canonicalHashV1(material) },
+    executionModel: fixtureProtocol.executionModel,
+  })
+}
 
 describe('risk-balanced trend candidate', () => {
   test('matches a hand-calculated multi-symbol continuous normalized trend', () => {
@@ -211,11 +248,7 @@ describe('risk-balanced trend candidate', () => {
     const current = strategy.currentDecision(
       bars,
       snapshot.manifest,
-      makeCurrentDecisionCycleBinding({
-        signalSessionDate: snapshot.manifest.lastSession,
-        executionSessionDate: '2020-05-01',
-        calendarSessionDates: ['2020-04-30', '2020-05-01', '2020-05-04'],
-      }),
+      currentDecisionBinding(snapshot.manifest.lastSession, ['2020-04-30', '2020-05-01', '2020-05-04']),
     )
     const sessionDates = [...new Set(snapshot.bars.map((bar) => bar.sessionDate))].sort()
     const historyLength = Math.max(fixtureProtocol.volatilityWindow, ...fixtureProtocol.horizons) + 1
@@ -258,57 +291,36 @@ describe('risk-balanced trend candidate', () => {
     const strategy = makeStrategy(fixtureProtocol, makeTestProvenance())
 
     expect(() =>
-      strategy.currentDecision(snapshot.bars, snapshot.manifest, {
-        signalSessionDate: snapshot.manifest.lastSession,
-        executionSessionDate: '2020-04-22',
-        calendarSessionDates: ['2020-04-21', '2020-04-22', '2020-05-01'],
-      }),
+      strategy.currentDecision(
+        snapshot.bars,
+        snapshot.manifest,
+        currentDecisionBinding(snapshot.manifest.lastSession, ['2020-04-21', '2020-04-22', '2020-05-01']),
+      ),
     ).toThrow('current strategy decision requires a month-end due cycle')
     expect(() =>
       strategy.currentDecision(snapshot.bars, snapshot.manifest, {
         signalSessionDate: snapshot.manifest.lastSession,
         executionSessionDate: '2020-05-01',
-        calendarSessionDates: ['2020-04-21', '2020-04-22', '2020-05-01'],
-      }),
-    ).toThrow('current strategy execution session must be the first post-signal calendar session')
+        calendarSessionDates: [snapshot.manifest.lastSession, '2020-05-01'],
+      } as unknown as CurrentDecisionCycleBinding),
+    ).toThrow('Unexpected key')
     expect(() =>
-      strategy.currentDecision(snapshot.bars, snapshot.manifest, {
-        signalSessionDate: '2020-04-20',
-        executionSessionDate: '2020-04-21',
-        calendarSessionDates: ['2020-04-20', '2020-04-21', '2020-04-22'],
-      }),
+      strategy.currentDecision(
+        snapshot.bars,
+        snapshot.manifest,
+        currentDecisionBinding('2020-04-20', ['2020-04-20', '2020-04-21', '2020-04-22']),
+      ),
     ).toThrow('current strategy decision must end on the due cycle Signal terminal session')
-    expect(() =>
-      makeCurrentDecisionCycleBinding({
-        signalSessionDate: snapshot.manifest.lastSession,
-        executionSessionDate: '2020-04-20',
-        calendarSessionDates: ['2020-04-20', '2020-04-21'],
-      }),
-    ).toThrow('current strategy execution session must follow its Signal session')
-    expect(() =>
-      makeCurrentDecisionCycleBinding({
-        signalSessionDate: snapshot.manifest.lastSession,
-        executionSessionDate: '2020-05-01',
-        calendarSessionDates: ['2020-05-01', '2020-05-04'],
-      }),
-    ).toThrow('current strategy calendar sessions must contain the Signal session')
-    expect(() =>
-      makeCurrentDecisionCycleBinding({
-        signalSessionDate: snapshot.manifest.lastSession,
-        executionSessionDate: '2020-05-01',
-        calendarSessionDates: ['2020-04-21', '2020-05-01', '2020-04-22'],
-      }),
-    ).toThrow('current strategy calendar sessions must be unique and strictly ordered')
   })
 
   test('rejects an invalid or snapshot-divergent manifest before compiling a current decision', () => {
     const snapshot = makeSnapshot(1_129)
     const strategy = makeStrategy(fixtureProtocol, makeTestProvenance())
-    const cycleBinding = makeCurrentDecisionCycleBinding({
-      signalSessionDate: snapshot.manifest.lastSession,
-      executionSessionDate: '2020-05-01',
-      calendarSessionDates: ['2020-04-30', '2020-05-01', '2020-05-04'],
-    })
+    const cycleBinding = currentDecisionBinding(snapshot.manifest.lastSession, [
+      '2020-04-30',
+      '2020-05-01',
+      '2020-05-04',
+    ])
     expect(() =>
       strategy.currentDecision(
         snapshot.bars,

--- a/services/bayn/src/risk-balanced-trend.test.ts
+++ b/services/bayn/src/risk-balanced-trend.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
+import { referencePriceMicros } from './execution-model'
 import { canonicalHashV1 } from './hash'
 import {
   evaluateRiskBalancedTrend,
@@ -196,6 +197,88 @@ describe('risk-balanced trend candidate', () => {
 
     expect(baseline.signalDecisions[0].signalDate < finalSession).toBe(true)
     expect(changed.signalDecisions[0]).toEqual(baseline.signalDecisions[0])
+  })
+
+  test('compiles one current decision with exact quantized terminal-session prices', () => {
+    const snapshot = makeSnapshot()
+    const strategy = makeStrategy(fixtureProtocol, makeTestProvenance())
+    const bars = snapshot.bars.map((bar) =>
+      bar.sessionDate === snapshot.manifest.lastSession && bar.symbol === fixtureProtocol.universe[0]
+        ? { ...bar, close: 100.123456 }
+        : bar,
+    )
+    const current = strategy.currentDecision(bars, snapshot.manifest)
+    const sessionDates = [...new Set(snapshot.bars.map((bar) => bar.sessionDate))].sort()
+    const historyLength = Math.max(fixtureProtocol.volatilityWindow, ...fixtureProtocol.horizons) + 1
+    const historyDates = sessionDates.slice(-historyLength)
+    const closesBySymbolAndDate = new Map(
+      bars.map((bar) => [`${bar.symbol}\u001f${bar.sessionDate}`, bar.close] as const),
+    )
+    const expectedPrices = Object.fromEntries(
+      fixtureProtocol.universe.map((symbol) => {
+        const close = closesBySymbolAndDate.get(`${symbol}\u001f${snapshot.manifest.finalizedSnapshot.lastSession}`)
+        if (close === undefined) throw new Error(`fixture is missing terminal close for ${symbol}`)
+        return [symbol, referencePriceMicros(close, fixtureProtocol.executionModel).toString()]
+      }),
+    )
+    const expectedDecision = makeRiskBalancedTrendDecision(
+      snapshot.manifest.finalizedSnapshot.lastSession,
+      historyDates,
+      Object.fromEntries(
+        fixtureProtocol.universe.map((symbol) => [
+          symbol,
+          historyDates.map((date) => {
+            const close = closesBySymbolAndDate.get(`${symbol}\u001f${date}`)
+            if (close === undefined) throw new Error(`fixture is missing ${symbol} ${date}`)
+            return close
+          }),
+        ]),
+      ),
+      fixtureProtocol,
+    )
+
+    expect(current).toEqual({ decision: expectedDecision, priceMicros: expectedPrices })
+    expect(current.decision.signalDate).toBe(snapshot.manifest.finalizedSnapshot.lastSession)
+    expect(current.priceMicros[fixtureProtocol.universe[0]]).toBe('100123500')
+    expect(Object.keys(current.priceMicros)).toEqual([...fixtureProtocol.universe])
+    expect(Object.values(current.priceMicros).every((price) => /^[1-9][0-9]*$/.test(price))).toBe(true)
+  })
+
+  test('rejects an invalid or snapshot-divergent manifest before compiling a current decision', () => {
+    const snapshot = makeSnapshot()
+    const strategy = makeStrategy(fixtureProtocol, makeTestProvenance())
+    expect(() =>
+      strategy.currentDecision(snapshot.bars, {
+        ...snapshot.manifest,
+        hash: '0'.repeat(64),
+      }),
+    ).toThrow()
+
+    const priorSession = snapshot.bars
+      .map((bar) => bar.sessionDate)
+      .filter((date) => date < snapshot.manifest.lastSession)
+      .sort()
+      .at(-1)
+    if (priorSession === undefined) throw new Error('fixture requires a prior session')
+    const { hash: _, ...material } = snapshot.manifest
+    const divergentMaterial = {
+      ...material,
+      bounds: {
+        ...material.bounds,
+        dataEnd: priorSession,
+        evaluationEnd: priorSession,
+      },
+      lastSession: priorSession,
+      symbols: material.symbols.map((coverage) => ({ ...coverage, lastSession: priorSession })),
+    }
+    const divergent = {
+      ...divergentMaterial,
+      hash: canonicalHashV1(divergentMaterial),
+    }
+
+    expect(() => strategy.currentDecision(snapshot.bars, divergent)).toThrow(
+      'Signal manifest does not match its finalized snapshot bounds',
+    )
   })
 
   test('rejects a Signal manifest for a different universe before qualification', () => {

--- a/services/bayn/src/risk-balanced-trend.test.ts
+++ b/services/bayn/src/risk-balanced-trend.test.ts
@@ -4,6 +4,7 @@ import { referencePriceMicros } from './execution-model'
 import { canonicalHashV1 } from './hash'
 import {
   evaluateRiskBalancedTrend,
+  makeCurrentDecisionCycleBinding,
   makeRiskBalancedTrendDecision,
   prepareRiskBalancedTrendQualification,
 } from './risk-balanced-trend'
@@ -200,17 +201,22 @@ describe('risk-balanced trend candidate', () => {
   })
 
   test('compiles one current decision with exact quantized terminal-session prices', () => {
-    const snapshot = makeSnapshot()
+    const snapshot = makeSnapshot(1_129)
     const strategy = makeStrategy(fixtureProtocol, makeTestProvenance())
     const bars = snapshot.bars.map((bar) =>
       bar.sessionDate === snapshot.manifest.lastSession && bar.symbol === fixtureProtocol.universe[0]
         ? { ...bar, close: 100.123456 }
         : bar,
     )
-    const current = strategy.currentDecision(bars, snapshot.manifest, {
-      signalSessionDate: snapshot.manifest.lastSession,
-      executionSessionDate: '2020-05-01',
-    })
+    const current = strategy.currentDecision(
+      bars,
+      snapshot.manifest,
+      makeCurrentDecisionCycleBinding({
+        signalSessionDate: snapshot.manifest.lastSession,
+        executionSessionDate: '2020-05-01',
+        calendarSessionDates: ['2020-04-30', '2020-05-01', '2020-05-04'],
+      }),
+    )
     const sessionDates = [...new Set(snapshot.bars.map((bar) => bar.sessionDate))].sort()
     const historyLength = Math.max(fixtureProtocol.volatilityWindow, ...fixtureProtocol.horizons) + 1
     const historyDates = sessionDates.slice(-historyLength)
@@ -255,29 +261,54 @@ describe('risk-balanced trend candidate', () => {
       strategy.currentDecision(snapshot.bars, snapshot.manifest, {
         signalSessionDate: snapshot.manifest.lastSession,
         executionSessionDate: '2020-04-22',
+        calendarSessionDates: ['2020-04-21', '2020-04-22', '2020-05-01'],
       }),
     ).toThrow('current strategy decision requires a month-end due cycle')
     expect(() =>
       strategy.currentDecision(snapshot.bars, snapshot.manifest, {
-        signalSessionDate: '2020-04-20',
+        signalSessionDate: snapshot.manifest.lastSession,
         executionSessionDate: '2020-05-01',
+        calendarSessionDates: ['2020-04-21', '2020-04-22', '2020-05-01'],
+      }),
+    ).toThrow('current strategy execution session must be the first post-signal calendar session')
+    expect(() =>
+      strategy.currentDecision(snapshot.bars, snapshot.manifest, {
+        signalSessionDate: '2020-04-20',
+        executionSessionDate: '2020-04-21',
+        calendarSessionDates: ['2020-04-20', '2020-04-21', '2020-04-22'],
       }),
     ).toThrow('current strategy decision must end on the due cycle Signal terminal session')
     expect(() =>
-      strategy.currentDecision(snapshot.bars, snapshot.manifest, {
+      makeCurrentDecisionCycleBinding({
         signalSessionDate: snapshot.manifest.lastSession,
         executionSessionDate: '2020-04-20',
+        calendarSessionDates: ['2020-04-20', '2020-04-21'],
       }),
     ).toThrow('current strategy execution session must follow its Signal session')
+    expect(() =>
+      makeCurrentDecisionCycleBinding({
+        signalSessionDate: snapshot.manifest.lastSession,
+        executionSessionDate: '2020-05-01',
+        calendarSessionDates: ['2020-05-01', '2020-05-04'],
+      }),
+    ).toThrow('current strategy calendar sessions must contain the Signal session')
+    expect(() =>
+      makeCurrentDecisionCycleBinding({
+        signalSessionDate: snapshot.manifest.lastSession,
+        executionSessionDate: '2020-05-01',
+        calendarSessionDates: ['2020-04-21', '2020-05-01', '2020-04-22'],
+      }),
+    ).toThrow('current strategy calendar sessions must be unique and strictly ordered')
   })
 
   test('rejects an invalid or snapshot-divergent manifest before compiling a current decision', () => {
-    const snapshot = makeSnapshot()
+    const snapshot = makeSnapshot(1_129)
     const strategy = makeStrategy(fixtureProtocol, makeTestProvenance())
-    const cycleBinding = {
+    const cycleBinding = makeCurrentDecisionCycleBinding({
       signalSessionDate: snapshot.manifest.lastSession,
       executionSessionDate: '2020-05-01',
-    } as const
+      calendarSessionDates: ['2020-04-30', '2020-05-01', '2020-05-04'],
+    })
     expect(() =>
       strategy.currentDecision(
         snapshot.bars,

--- a/services/bayn/src/risk-balanced-trend.ts
+++ b/services/bayn/src/risk-balanced-trend.ts
@@ -1,5 +1,5 @@
 import type { RuntimeProvenance } from './contracts'
-import { MICROS } from './execution-model'
+import { MICROS, referencePriceMicros } from './execution-model'
 import { canonicalHashV1 } from './hash'
 import { reconcileMarkedEquity } from './simulation-reconciliation'
 import {
@@ -13,6 +13,7 @@ import {
   selectEvaluationWindow,
   simulate,
   TRADING_DAYS,
+  type AlignedSession,
   type SimulationTarget,
 } from './simulation'
 import {
@@ -263,6 +264,65 @@ export const makeRiskBalancedTrendDecision = (
   }
 }
 
+const decisionFromAlignedSessions = (
+  sessions: readonly AlignedSession[],
+  signalIndex: number,
+  protocol: Protocol,
+): DecisionPlan => {
+  const signalSession = sessions[signalIndex]
+  if (signalSession === undefined) throw new Error('risk-balanced trend signal session is missing')
+  const historySessions = requiredHistory(protocol)
+  const history = sessions.slice(signalIndex - historySessions, signalIndex + 1)
+  return makeRiskBalancedTrendDecision(
+    signalSession.date,
+    history.map((session) => session.date),
+    Object.fromEntries(
+      protocol.universe.map((symbol) => [symbol, history.map((session) => session.bars[symbol].close)]),
+    ),
+    protocol,
+  )
+}
+
+export interface CurrentRiskBalancedTrendDecision {
+  readonly decision: DecisionPlan
+  readonly priceMicros: Readonly<Record<string, string>>
+}
+
+export const compileCurrentRiskBalancedTrendDecision = (
+  bars: readonly DailyBar[],
+  inputManifest: InputManifest,
+  protocol: Protocol,
+): CurrentRiskBalancedTrendDecision => {
+  const sessions = alignBars(bars, protocol.universe, inputManifest)
+  const signalIndex = sessions.length - 1
+  const terminalSession = sessions[signalIndex]
+  if (
+    terminalSession === undefined ||
+    terminalSession.date !== inputManifest.finalizedSnapshot.lastSession ||
+    terminalSession.date !== inputManifest.lastSession
+  ) {
+    throw new Error('current strategy decision must end on the bound Signal terminal session')
+  }
+  const decision = decisionFromAlignedSessions(sessions, signalIndex, protocol)
+  const priceMicros = Object.fromEntries(
+    protocol.universe.map((symbol) => [
+      symbol,
+      referencePriceMicros(terminalSession.bars[symbol].close, protocol.executionModel).toString(),
+    ]),
+  )
+  const priceSymbols = Object.keys(priceMicros)
+  if (
+    decision.signalDate !== terminalSession.date ||
+    priceSymbols.length !== protocol.universe.length ||
+    protocol.universe.some(
+      (symbol) => !Object.hasOwn(priceMicros, symbol) || !/^[1-9][0-9]*$/.test(priceMicros[symbol]),
+    )
+  ) {
+    throw new Error('current strategy decision and terminal closes do not cover one compiled universe session')
+  }
+  return { decision, priceMicros }
+}
+
 export interface QualificationPrecommit {
   readonly candidateRunId: string
   readonly protocolHash: string
@@ -314,15 +374,7 @@ export const evaluateRiskBalancedTrend = (
   const { signalIndices, startIndex } = window
   const evaluationSessions = sessions.slice(0, window.evaluationEndExclusive)
   const strategyTargets: SimulationTarget[] = signalIndices.map((signalIndex) => {
-    const history = sessions.slice(signalIndex - historySessions, signalIndex + 1)
-    const decision = makeRiskBalancedTrendDecision(
-      sessions[signalIndex].date,
-      history.map((session) => session.date),
-      Object.fromEntries(
-        protocol.universe.map((symbol) => [symbol, history.map((session) => session.bars[symbol].close)]),
-      ),
-      protocol,
-    )
+    const decision = decisionFromAlignedSessions(sessions, signalIndex, protocol)
     return { signalIndex, executionIndex: signalIndex + 1, weights: decision.targetWeights, decision }
   })
   const equalWeight = roundWeight(1 / protocol.universe.length)

--- a/services/bayn/src/risk-balanced-trend.ts
+++ b/services/bayn/src/risk-balanced-trend.ts
@@ -2,8 +2,9 @@ import { Schema } from 'effect'
 
 import type { RuntimeProvenance } from './contracts'
 import { MICROS, referencePriceMicros } from './execution-model'
+import { ExecutionSessionBindingSchema, type ExecutionSessionBinding } from './execution-session'
 import { canonicalHashV1 } from './hash'
-import { IsoDateSchema, strictParseOptions } from './schemas'
+import { strictParseOptions } from './schemas'
 import { reconcileMarkedEquity } from './simulation-reconciliation'
 import {
   alignBars,
@@ -291,38 +292,8 @@ export interface CurrentRiskBalancedTrendDecision {
   readonly priceMicros: Readonly<Record<string, string>>
 }
 
-const CurrentDecisionCycleBindingSchema = Schema.Struct({
-  signalSessionDate: IsoDateSchema,
-  executionSessionDate: IsoDateSchema,
-  calendarSessionDates: Schema.Array(IsoDateSchema).check(Schema.isMinLength(2)),
-})
-export type CurrentDecisionCycleBinding = typeof CurrentDecisionCycleBindingSchema.Type
-const decodeCurrentDecisionCycleBinding = Schema.decodeUnknownSync(
-  CurrentDecisionCycleBindingSchema,
-  strictParseOptions,
-)
-
-export const makeCurrentDecisionCycleBinding = (input: CurrentDecisionCycleBinding): CurrentDecisionCycleBinding => {
-  const binding = decodeCurrentDecisionCycleBinding(input)
-  for (let index = 1; index < binding.calendarSessionDates.length; index += 1) {
-    if (binding.calendarSessionDates[index - 1] >= binding.calendarSessionDates[index]) {
-      throw new TypeError('current strategy calendar sessions must be unique and strictly ordered')
-    }
-  }
-  if (!binding.calendarSessionDates.includes(binding.signalSessionDate)) {
-    throw new TypeError('current strategy calendar sessions must contain the Signal session')
-  }
-  if (binding.executionSessionDate <= binding.signalSessionDate) {
-    throw new TypeError('current strategy execution session must follow its Signal session')
-  }
-  const firstPostSignalSession = binding.calendarSessionDates.find(
-    (sessionDate) => sessionDate > binding.signalSessionDate,
-  )
-  if (firstPostSignalSession !== binding.executionSessionDate) {
-    throw new TypeError('current strategy execution session must be the first post-signal calendar session')
-  }
-  return binding
-}
+export type CurrentDecisionCycleBinding = ExecutionSessionBinding
+const decodeCurrentDecisionCycleBinding = Schema.decodeUnknownSync(ExecutionSessionBindingSchema, strictParseOptions)
 
 export const compileCurrentRiskBalancedTrendDecision = (
   bars: readonly DailyBar[],
@@ -330,7 +301,7 @@ export const compileCurrentRiskBalancedTrendDecision = (
   protocol: Protocol,
   cycleBinding: CurrentDecisionCycleBinding,
 ): CurrentRiskBalancedTrendDecision => {
-  const binding = makeCurrentDecisionCycleBinding(cycleBinding)
+  const binding = decodeCurrentDecisionCycleBinding(cycleBinding)
   const sessions = alignBars(bars, protocol.universe, inputManifest)
   const signalIndex = sessions.length - 1
   const terminalSession = sessions[signalIndex]
@@ -338,13 +309,13 @@ export const compileCurrentRiskBalancedTrendDecision = (
     terminalSession === undefined ||
     terminalSession.date !== inputManifest.finalizedSnapshot.lastSession ||
     terminalSession.date !== inputManifest.lastSession ||
-    terminalSession.date !== binding.signalSessionDate
+    terminalSession.date !== binding.signal.sessionDate
   ) {
     throw new Error('current strategy decision must end on the due cycle Signal terminal session')
   }
   if (
     protocol.rebalance === 'month-end' &&
-    binding.signalSessionDate.slice(0, 7) === binding.executionSessionDate.slice(0, 7)
+    binding.signal.sessionDate.slice(0, 7) === binding.executionSession.date.slice(0, 7)
   ) {
     throw new Error('current strategy decision requires a month-end due cycle')
   }

--- a/services/bayn/src/risk-balanced-trend.ts
+++ b/services/bayn/src/risk-balanced-trend.ts
@@ -294,6 +294,7 @@ export interface CurrentRiskBalancedTrendDecision {
 const CurrentDecisionCycleBindingSchema = Schema.Struct({
   signalSessionDate: IsoDateSchema,
   executionSessionDate: IsoDateSchema,
+  calendarSessionDates: Schema.Array(IsoDateSchema).check(Schema.isMinLength(2)),
 })
 export type CurrentDecisionCycleBinding = typeof CurrentDecisionCycleBindingSchema.Type
 const decodeCurrentDecisionCycleBinding = Schema.decodeUnknownSync(
@@ -301,13 +302,35 @@ const decodeCurrentDecisionCycleBinding = Schema.decodeUnknownSync(
   strictParseOptions,
 )
 
+export const makeCurrentDecisionCycleBinding = (input: CurrentDecisionCycleBinding): CurrentDecisionCycleBinding => {
+  const binding = decodeCurrentDecisionCycleBinding(input)
+  for (let index = 1; index < binding.calendarSessionDates.length; index += 1) {
+    if (binding.calendarSessionDates[index - 1] >= binding.calendarSessionDates[index]) {
+      throw new TypeError('current strategy calendar sessions must be unique and strictly ordered')
+    }
+  }
+  if (!binding.calendarSessionDates.includes(binding.signalSessionDate)) {
+    throw new TypeError('current strategy calendar sessions must contain the Signal session')
+  }
+  if (binding.executionSessionDate <= binding.signalSessionDate) {
+    throw new TypeError('current strategy execution session must follow its Signal session')
+  }
+  const firstPostSignalSession = binding.calendarSessionDates.find(
+    (sessionDate) => sessionDate > binding.signalSessionDate,
+  )
+  if (firstPostSignalSession !== binding.executionSessionDate) {
+    throw new TypeError('current strategy execution session must be the first post-signal calendar session')
+  }
+  return binding
+}
+
 export const compileCurrentRiskBalancedTrendDecision = (
   bars: readonly DailyBar[],
   inputManifest: InputManifest,
   protocol: Protocol,
   cycleBinding: CurrentDecisionCycleBinding,
 ): CurrentRiskBalancedTrendDecision => {
-  const binding = decodeCurrentDecisionCycleBinding(cycleBinding)
+  const binding = makeCurrentDecisionCycleBinding(cycleBinding)
   const sessions = alignBars(bars, protocol.universe, inputManifest)
   const signalIndex = sessions.length - 1
   const terminalSession = sessions[signalIndex]
@@ -318,9 +341,6 @@ export const compileCurrentRiskBalancedTrendDecision = (
     terminalSession.date !== binding.signalSessionDate
   ) {
     throw new Error('current strategy decision must end on the due cycle Signal terminal session')
-  }
-  if (binding.executionSessionDate <= binding.signalSessionDate) {
-    throw new Error('current strategy execution session must follow its Signal session')
   }
   if (
     protocol.rebalance === 'month-end' &&

--- a/services/bayn/src/risk-balanced-trend.ts
+++ b/services/bayn/src/risk-balanced-trend.ts
@@ -1,6 +1,9 @@
+import { Schema } from 'effect'
+
 import type { RuntimeProvenance } from './contracts'
 import { MICROS, referencePriceMicros } from './execution-model'
 import { canonicalHashV1 } from './hash'
+import { IsoDateSchema, strictParseOptions } from './schemas'
 import { reconcileMarkedEquity } from './simulation-reconciliation'
 import {
   alignBars,
@@ -288,20 +291,42 @@ export interface CurrentRiskBalancedTrendDecision {
   readonly priceMicros: Readonly<Record<string, string>>
 }
 
+const CurrentDecisionCycleBindingSchema = Schema.Struct({
+  signalSessionDate: IsoDateSchema,
+  executionSessionDate: IsoDateSchema,
+})
+export type CurrentDecisionCycleBinding = typeof CurrentDecisionCycleBindingSchema.Type
+const decodeCurrentDecisionCycleBinding = Schema.decodeUnknownSync(
+  CurrentDecisionCycleBindingSchema,
+  strictParseOptions,
+)
+
 export const compileCurrentRiskBalancedTrendDecision = (
   bars: readonly DailyBar[],
   inputManifest: InputManifest,
   protocol: Protocol,
+  cycleBinding: CurrentDecisionCycleBinding,
 ): CurrentRiskBalancedTrendDecision => {
+  const binding = decodeCurrentDecisionCycleBinding(cycleBinding)
   const sessions = alignBars(bars, protocol.universe, inputManifest)
   const signalIndex = sessions.length - 1
   const terminalSession = sessions[signalIndex]
   if (
     terminalSession === undefined ||
     terminalSession.date !== inputManifest.finalizedSnapshot.lastSession ||
-    terminalSession.date !== inputManifest.lastSession
+    terminalSession.date !== inputManifest.lastSession ||
+    terminalSession.date !== binding.signalSessionDate
   ) {
-    throw new Error('current strategy decision must end on the bound Signal terminal session')
+    throw new Error('current strategy decision must end on the due cycle Signal terminal session')
+  }
+  if (binding.executionSessionDate <= binding.signalSessionDate) {
+    throw new Error('current strategy execution session must follow its Signal session')
+  }
+  if (
+    protocol.rebalance === 'month-end' &&
+    binding.signalSessionDate.slice(0, 7) === binding.executionSessionDate.slice(0, 7)
+  ) {
+    throw new Error('current strategy decision requires a month-end due cycle')
   }
   const decision = decisionFromAlignedSessions(sessions, signalIndex, protocol)
   const priceMicros = Object.fromEntries(

--- a/services/bayn/src/strategy.ts
+++ b/services/bayn/src/strategy.ts
@@ -18,19 +18,25 @@ import {
   compileCurrentRiskBalancedTrendDecision,
   evaluateRiskBalancedTrend,
   prepareRiskBalancedTrendQualification,
+  type CurrentDecisionCycleBinding,
   type CurrentRiskBalancedTrendDecision,
 } from './risk-balanced-trend'
 import { strictParseOptions } from './schemas'
 import type { DailyBar, EvaluationResult, InputManifest, IsoDate, Protocol } from './types'
 
 export type CurrentStrategyDecision = CurrentRiskBalancedTrendDecision
+export type CurrentStrategyDecisionCycleBinding = CurrentDecisionCycleBinding
 
 export interface Strategy {
   readonly name: string
   readonly parameters: Protocol
   readonly provenance: RuntimeProvenance
   readonly evaluate: (bars: readonly DailyBar[], manifest: InputManifest) => EvaluationResult
-  readonly currentDecision: (bars: readonly DailyBar[], manifest: InputManifest) => CurrentStrategyDecision
+  readonly currentDecision: (
+    bars: readonly DailyBar[],
+    manifest: InputManifest,
+    cycleBinding: CurrentStrategyDecisionCycleBinding,
+  ) => CurrentStrategyDecision
   readonly prepareLock: (
     manifest: InputManifest,
     sessionDates: readonly IsoDate[],
@@ -88,8 +94,13 @@ export const makeStrategy = (protocol: Protocol, provenance: RuntimeProvenance):
     provenance,
     evaluate: (bars, manifest) =>
       evaluateRiskBalancedTrend(bars, requireMatchingUniverse(manifest, protocol), protocol, provenance),
-    currentDecision: (bars, manifest) =>
-      compileCurrentRiskBalancedTrendDecision(bars, requireMatchingUniverse(manifest, protocol), protocol),
+    currentDecision: (bars, manifest, cycleBinding) =>
+      compileCurrentRiskBalancedTrendDecision(
+        bars,
+        requireMatchingUniverse(manifest, protocol),
+        protocol,
+        cycleBinding,
+      ),
     prepareLock: (manifest, sessionDates, priorTrialRunIds) => {
       const inputManifest = requireMatchingUniverse(manifest, protocol)
       const precommit = prepareRiskBalancedTrendQualification(sessionDates, inputManifest, protocol, provenance)

--- a/services/bayn/src/strategy.ts
+++ b/services/bayn/src/strategy.ts
@@ -17,6 +17,7 @@ import {
 import {
   compileCurrentRiskBalancedTrendDecision,
   evaluateRiskBalancedTrend,
+  makeCurrentDecisionCycleBinding,
   prepareRiskBalancedTrendQualification,
   type CurrentDecisionCycleBinding,
   type CurrentRiskBalancedTrendDecision,
@@ -26,6 +27,7 @@ import type { DailyBar, EvaluationResult, InputManifest, IsoDate, Protocol } fro
 
 export type CurrentStrategyDecision = CurrentRiskBalancedTrendDecision
 export type CurrentStrategyDecisionCycleBinding = CurrentDecisionCycleBinding
+export const makeCurrentStrategyDecisionCycleBinding = makeCurrentDecisionCycleBinding
 
 export interface Strategy {
   readonly name: string

--- a/services/bayn/src/strategy.ts
+++ b/services/bayn/src/strategy.ts
@@ -1,4 +1,7 @@
+import { Schema } from 'effect'
+
 import type { RuntimeProvenance } from './contracts'
+import { InputManifestArtifactSchema } from './evidence-contracts'
 import {
   defaultQualificationStatisticsPolicyDocument,
   makeQualificationLock,
@@ -11,14 +14,23 @@ import {
   prepareQualificationSeries,
   type QualificationAnalysis,
 } from './qualification-statistics'
-import { evaluateRiskBalancedTrend, prepareRiskBalancedTrendQualification } from './risk-balanced-trend'
+import {
+  compileCurrentRiskBalancedTrendDecision,
+  evaluateRiskBalancedTrend,
+  prepareRiskBalancedTrendQualification,
+  type CurrentRiskBalancedTrendDecision,
+} from './risk-balanced-trend'
+import { strictParseOptions } from './schemas'
 import type { DailyBar, EvaluationResult, InputManifest, IsoDate, Protocol } from './types'
+
+export type CurrentStrategyDecision = CurrentRiskBalancedTrendDecision
 
 export interface Strategy {
   readonly name: string
   readonly parameters: Protocol
   readonly provenance: RuntimeProvenance
   readonly evaluate: (bars: readonly DailyBar[], manifest: InputManifest) => EvaluationResult
+  readonly currentDecision: (bars: readonly DailyBar[], manifest: InputManifest) => CurrentStrategyDecision
   readonly prepareLock: (
     manifest: InputManifest,
     sessionDates: readonly IsoDate[],
@@ -26,6 +38,8 @@ export interface Strategy {
   ) => QualificationLock
   readonly analyze: (evaluation: EvaluationResult, priorTrialRunIds: readonly string[]) => QualificationAnalysis
 }
+
+const decodeManifest = Schema.decodeUnknownSync(InputManifestArtifactSchema, strictParseOptions)
 
 const requireMatchingUniverse = (manifest: InputManifest, protocol: Protocol): InputManifest => {
   const snapshot = manifest.finalizedSnapshot
@@ -36,7 +50,16 @@ const requireMatchingUniverse = (manifest: InputManifest, protocol: Protocol): I
   ) {
     throw new TypeError('Signal snapshot universe does not match the compiled strategy universe')
   }
-  return manifest
+  const decoded = decodeManifest(manifest)
+  if (
+    decoded.firstSession !== snapshot.firstSession ||
+    decoded.lastSession !== snapshot.lastSession ||
+    decoded.rowCount !== snapshot.rowCount ||
+    decoded.sessionCount !== snapshot.sessionCount
+  ) {
+    throw new TypeError('Signal manifest does not match its finalized snapshot bounds')
+  }
+  return decoded
 }
 
 const universeRationale =
@@ -65,6 +88,8 @@ export const makeStrategy = (protocol: Protocol, provenance: RuntimeProvenance):
     provenance,
     evaluate: (bars, manifest) =>
       evaluateRiskBalancedTrend(bars, requireMatchingUniverse(manifest, protocol), protocol, provenance),
+    currentDecision: (bars, manifest) =>
+      compileCurrentRiskBalancedTrendDecision(bars, requireMatchingUniverse(manifest, protocol), protocol),
     prepareLock: (manifest, sessionDates, priorTrialRunIds) => {
       const inputManifest = requireMatchingUniverse(manifest, protocol)
       const precommit = prepareRiskBalancedTrendQualification(sessionDates, inputManifest, protocol, provenance)

--- a/services/bayn/src/strategy.ts
+++ b/services/bayn/src/strategy.ts
@@ -17,7 +17,6 @@ import {
 import {
   compileCurrentRiskBalancedTrendDecision,
   evaluateRiskBalancedTrend,
-  makeCurrentDecisionCycleBinding,
   prepareRiskBalancedTrendQualification,
   type CurrentDecisionCycleBinding,
   type CurrentRiskBalancedTrendDecision,
@@ -27,7 +26,6 @@ import type { DailyBar, EvaluationResult, InputManifest, IsoDate, Protocol } fro
 
 export type CurrentStrategyDecision = CurrentRiskBalancedTrendDecision
 export type CurrentStrategyDecisionCycleBinding = CurrentDecisionCycleBinding
-export const makeCurrentStrategyDecisionCycleBinding = makeCurrentDecisionCycleBinding
 
 export interface Strategy {
   readonly name: string

--- a/services/bayn/src/target-planner.ts
+++ b/services/bayn/src/target-planner.ts
@@ -3,17 +3,9 @@ import { Schema } from 'effect'
 import { IntentPlanSchema, type IntentPlan } from './execution/intents'
 import { desiredQuantityMicros, MICROS } from './execution-model'
 import { canonicalHashV1 } from './hash'
-import {
-  AccountStatus,
-  OrderSide,
-  OrderStatus,
-  OrderType,
-  ReconciliationStatus,
-  TimeInForce,
-  type Reconciliation,
-} from './paper'
+import { AccountStatus, OrderSide, OrderStatus, OrderType, ReconciliationStatus, TimeInForce } from './paper'
 import type { ExecutionModel } from './protocol'
-import { reconciledStateHash, type ReconciledStateMaterial } from './reconciliation'
+import { reconciledStateHash, type ReconciledBrokerState } from './reconciliation'
 import {
   PositiveMicrosSchema,
   Sha256Schema,
@@ -35,10 +27,7 @@ export interface SignalSessionReferencePrices {
   readonly priceMicros: Readonly<Record<string, string>>
 }
 
-export interface TargetPlannerBrokerState extends ReconciledStateMaterial {
-  readonly reconciliation: Reconciliation
-  readonly unknownOrderCount: number
-}
+export type TargetPlannerBrokerState = ReconciledBrokerState
 
 export interface TargetPlannerInput {
   readonly schemaVersion: 'bayn.paper-target-planner-input.v1'


### PR DESCRIPTION
## Summary

- return the exact same-pass reconciled broker state and risk context from the existing one-shot reconciler without a second read path
- derive bounded trading-day, immutable valuation, mutation, and jointly nullable authority evidence inside the reconciliation transaction
- compile one pure terminal-session strategy decision only from the existing decoded, content-hashed causal execution-session binding, requiring its first post-signal session to cross the month-end boundary and quantizing reference prices with the execution model

## Related Issues

PROOMPT-382

## Testing

- `bun test services/bayn/src/risk-balanced-trend.test.ts` (10 passed)
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn tsc`
- `env -u BAYN_TEST_POSTGRES_URL bun run --filter @proompteng/bayn test` (311 passed, 63 PostgreSQL tests skipped)
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:55482/bayn_test bun test services/bayn/src/db/paper-store.integration.test.ts` (7 passed)
- `bun test packages/scripts/src/bayn` (9 passed)
- `bun run --filter @proompteng/bayn build`

## Breaking Changes

None. The reconciler result and pure Strategy operation are intentionally extended for the pending OBSERVE composition slice; no runtime wiring or dispatch authority changes are included.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation and rollout follow-ups remain tracked by PROOMPT-382.