### PR TITLE
fix(buzz): allow CNPG proxy SNAT

### DIFF
--- a/argocd/applications/buzz/networkpolicy.yaml
+++ b/argocd/applications/buzz/networkpolicy.yaml
@@ -78,14 +78,14 @@ spec:
     - Ingress
   ingress:
     - from:
-        # kube-apiserver is host-networked, so cross-node pod proxy requests
-        # arrive from the three control-plane node addresses.
+        # kube-router SNATs host-networked kube-apiserver pod-proxy traffic to
+        # the destination node's pod-CIDR gateway.
         - ipBlock:
-            cidr: 100.100.244.141/32
+            cidr: 10.244.0.1/32
         - ipBlock:
-            cidr: 100.100.244.142/32
+            cidr: 10.244.3.1/32
         - ipBlock:
-            cidr: 100.100.244.190/32
+            cidr: 10.244.5.1/32
       ports:
         - port: 8000
           protocol: TCP

--- a/docs/runbooks/buzz-production.md
+++ b/docs/runbooks/buzz-production.md
@@ -46,9 +46,10 @@ The two OBCs, CNPG cluster, Redis PVC, and generated runtime Secret have explici
 
 Run every Kubernetes command with the namespace explicitly set.
 
-The CNPG status endpoint is reachable only from the three host-networked kube-apiserver node addresses listed in
-`allow-kubernetes-api-cnpg-status`. Update those `/32` entries whenever a control-plane node address changes; otherwise
-cross-node `kubectl cnpg status` pod-proxy requests will fail while same-node requests can appear healthy.
+The CNPG status endpoint is reachable only from the three pod-CIDR gateway addresses listed in
+`allow-kubernetes-api-cnpg-status`. Kube-router SNATs host-networked kube-apiserver pod-proxy traffic to the destination
+node's gateway. Update those `/32` entries whenever a node pod CIDR changes; otherwise cross-node
+`kubectl cnpg status` requests will fail while same-node requests can appear healthy.
 
 ```sh
 kubectl -n buzz get externalsecret,secretstore

--- a/packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts
+++ b/packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts
@@ -115,8 +115,8 @@ describe('Buzz production GitOps contract', () => {
     expect(networkPolicy).toContain('app.kubernetes.io/name: observability-cluster-metrics-alloy')
     expect(networkPolicy).toContain('port: 9187')
     expect(networkPolicy).toContain('name: allow-kubernetes-api-cnpg-status')
-    for (const controlPlaneAddress of ['100.100.244.141/32', '100.100.244.142/32', '100.100.244.190/32']) {
-      expect(networkPolicy).toContain(`cidr: ${controlPlaneAddress}`)
+    for (const nodeGatewayAddress of ['10.244.0.1/32', '10.244.3.1/32', '10.244.5.1/32']) {
+      expect(networkPolicy).toContain(`cidr: ${nodeGatewayAddress}`)
     }
     expect(networkPolicy).toContain('port: 8000')
   })


### PR DESCRIPTION
## Summary

- Replace ineffective kube-apiserver node `/32`s with the actual kube-router SNAT gateway addresses observed on port 8000 flows.
- Keep the CNPG status exception scoped to Buzz database pods, TCP 8000, and three exact node gateway addresses.
- Update the production contract and runbook with the pod-CIDR maintenance requirement.

## Related Issues

None

## Testing

- Reproduced cross-node `kubectl cnpg status -n buzz buzz-db --verbose` pod-proxy failures after the previous node-address policy.
- Traced repeated API pod-proxy requests through the destination-node kube-router conntrack table and observed `src=10.244.0.1 dst=10.244.0.186 dport=8000`.
- Confirmed node pod CIDRs `10.244.0.0/24`, `10.244.3.0/24`, and `10.244.5.0/24`, yielding gateway `/32`s `10.244.0.1`, `10.244.3.1`, and `10.244.5.1`.
- `bun test packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts`
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts`
- `bun run lint:argocd`
- `kustomize build --enable-helm argocd/applications/buzz | kubectl apply -n buzz --server-side --dry-run=server --field-manager=argocd-controller -f -`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed because this is a NetworkPolicy correction; Breaking Changes is filled in.
- [x] Documentation records the pod-CIDR gateway maintenance requirement.