### PR TITLE
fix(buzz): allow CNPG Flannel sources

### DIFF
--- a/argocd/applications/buzz/networkpolicy.yaml
+++ b/argocd/applications/buzz/networkpolicy.yaml
@@ -78,14 +78,15 @@ spec:
     - Ingress
   ingress:
     - from:
-        # kube-router SNATs host-networked kube-apiserver pod-proxy traffic to
-        # the destination node's pod-CIDR gateway.
+        # Cross-node host traffic uses the node's Flannel VTEP (.0); local
+        # host traffic uses its CNI gateway (.1). Each /31 is limited to those
+        # two node-local addresses.
         - ipBlock:
-            cidr: 10.244.0.1/32
+            cidr: 10.244.0.0/31
         - ipBlock:
-            cidr: 10.244.3.1/32
+            cidr: 10.244.3.0/31
         - ipBlock:
-            cidr: 10.244.5.1/32
+            cidr: 10.244.5.0/31
       ports:
         - port: 8000
           protocol: TCP

--- a/docs/runbooks/buzz-production.md
+++ b/docs/runbooks/buzz-production.md
@@ -46,10 +46,11 @@ The two OBCs, CNPG cluster, Redis PVC, and generated runtime Secret have explici
 
 Run every Kubernetes command with the namespace explicitly set.
 
-The CNPG status endpoint is reachable only from the three pod-CIDR gateway addresses listed in
-`allow-kubernetes-api-cnpg-status`. Kube-router SNATs host-networked kube-apiserver pod-proxy traffic to the destination
-node's gateway. Update those `/32` entries whenever a node pod CIDR changes; otherwise cross-node
-`kubectl cnpg status` requests will fail while same-node requests can appear healthy.
+The CNPG status endpoint is reachable only from the three node-local pod-CIDR ranges listed in
+`allow-kubernetes-api-cnpg-status`. Cross-node kube-apiserver pod-proxy traffic uses the source node's Flannel VTEP
+address (`.0`), while local host traffic uses the CNI gateway (`.1`), so each exception is a tight `/31`. Update these
+ranges whenever a node pod CIDR changes; otherwise cross-node `kubectl cnpg status` requests will fail while same-node
+requests can appear healthy.
 
 ```sh
 kubectl -n buzz get externalsecret,secretstore

--- a/packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts
+++ b/packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts
@@ -115,8 +115,8 @@ describe('Buzz production GitOps contract', () => {
     expect(networkPolicy).toContain('app.kubernetes.io/name: observability-cluster-metrics-alloy')
     expect(networkPolicy).toContain('port: 9187')
     expect(networkPolicy).toContain('name: allow-kubernetes-api-cnpg-status')
-    for (const nodeGatewayAddress of ['10.244.0.1/32', '10.244.3.1/32', '10.244.5.1/32']) {
-      expect(networkPolicy).toContain(`cidr: ${nodeGatewayAddress}`)
+    for (const nodeHostRange of ['10.244.0.0/31', '10.244.3.0/31', '10.244.5.0/31']) {
+      expect(networkPolicy).toContain(`cidr: ${nodeHostRange}`)
     }
     expect(networkPolicy).toContain('port: 8000')
   })


### PR DESCRIPTION
## Summary

- Expand each CNPG status source exception from the CNI gateway `/32` to the exact Flannel VTEP plus gateway `/31`.
- Match the source addresses selected by the live host route for cross-node kube-apiserver pod-proxy traffic.
- Update the production contract and runbook with the Flannel VTEP behavior.

## Related Issues

None

## Testing

- Confirmed the `/32` gateway policy installed correctly but did not match cross-node status traffic.
- Inspected live route selection on all nodes: remote pod routes use `src 10.244.0.0`, `src 10.244.3.0`, or `src 10.244.5.0`; local routes use the corresponding `.1` CNI gateway.
- Confirmed all nine pod-to-pod CNPG TLS checks on TCP 8000 succeed and the remaining failure is the host-networked API proxy path.
- `bun test packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts`
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts`
- `bun run lint:argocd`
- `kustomize build --enable-helm argocd/applications/buzz | kubectl apply -n buzz --server-side --dry-run=server --field-manager=argocd-controller -f -`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed because this is a NetworkPolicy correction; Breaking Changes is filled in.
- [x] Documentation records the Flannel VTEP and CNI gateway maintenance requirement.