### PR TITLE
test(buzz): restore production backup through GitOps

### DIFF
--- a/argocd/applications/buzz/kustomization.yaml
+++ b/argocd/applications/buzz/kustomization.yaml
@@ -9,6 +9,8 @@ resources:
   - postgres-objectstore.yaml
   - postgres-cluster.yaml
   - postgres-scheduled-backup.yaml
+  - postgres-acceptance-backup.yaml
+  - postgres-restore-proof.yaml
   - redis-config.yaml
   - redis.yaml
   - buzz-externalsecret.yaml

--- a/argocd/applications/buzz/postgres-acceptance-backup.yaml
+++ b/argocd/applications/buzz/postgres-acceptance-backup.yaml
@@ -1,0 +1,17 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Backup
+metadata:
+  name: buzz-db-acceptance-20260723t091130z
+  labels:
+    app.kubernetes.io/name: buzz-db
+    app.kubernetes.io/part-of: buzz
+    app.kubernetes.io/component: acceptance-backup
+  annotations:
+    argocd.argoproj.io/sync-wave: "-4"
+spec:
+  cluster:
+    name: buzz-db
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
+  target: prefer-standby

--- a/argocd/applications/buzz/postgres-restore-proof.yaml
+++ b/argocd/applications/buzz/postgres-restore-proof.yaml
@@ -1,0 +1,36 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: buzz-db-restore-proof
+  labels:
+    app.kubernetes.io/name: buzz-db-restore-proof
+    app.kubernetes.io/part-of: buzz
+    app.kubernetes.io/component: restore-proof
+  annotations:
+    argocd.argoproj.io/sync-wave: "5"
+spec:
+  description: Temporary restore proof for the Buzz production backup
+  instances: 1
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.7-system-trixie@sha256:08775f8bdeb112878b8f2ef63578c47959ee332fc9e076d5d6735a710c4500e2
+  imagePullPolicy: IfNotPresent
+  enablePDB: false
+  enableSuperuserAccess: false
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: "2"
+      memory: 2Gi
+  storage:
+    storageClass: rook-ceph-block
+    size: 20Gi
+    resizeInUseVolumes: true
+  bootstrap:
+    recovery:
+      backup:
+        name: buzz-db-acceptance-20260723t091130z
+  postgresql:
+    parameters:
+      password_encryption: scram-sha-256
+      ssl_min_protocol_version: TLSv1.3

--- a/docs/runbooks/buzz-production.md
+++ b/docs/runbooks/buzz-production.md
@@ -95,38 +95,39 @@ kubectl -n buzz get backup.postgresql.cnpg.io \
 kubectl cnpg status buzz-db -n buzz
 ```
 
-After the desktop smoke test has created representative data, take a named on-demand backup and wait for its phase to
-become `completed`:
-
-```sh
-kubectl cnpg backup buzz-db -n buzz \
-  --method plugin \
-  --plugin-name barman-cloud.cloudnative-pg.io \
-  --backup-target prefer-standby \
-  --backup-name buzz-db-acceptance-UTC_TIMESTAMP
-```
-
-For acceptance, restore into a temporary cluster named `buzz-db-restore-proof`; never restore over `buzz-db`. Use the
-same pinned PostgreSQL image, a new 20 GiB `rook-ceph-block` volume, and this recovery bootstrap:
+Before desktop onboarding, commit a named on-demand `Backup` and a temporary restore cluster to the Buzz GitOps
+application. The restore cluster must reference that exact backup so it cannot race the backup and accidentally select
+an older recovery point:
 
 ```yaml
-bootstrap:
-  recovery:
-    source: buzz-db-backup
-    database: buzz
-    owner: buzz
-externalClusters:
-  - name: buzz-db-backup
-    plugin:
-      name: barman-cloud.cloudnative-pg.io
-      parameters:
-        barmanObjectName: buzz-db
-        serverName: buzz-db-live
+apiVersion: postgresql.cnpg.io/v1
+kind: Backup
+metadata:
+  name: buzz-db-acceptance-UTC_TIMESTAMP
+spec:
+  cluster:
+    name: buzz-db
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
+  target: prefer-standby
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: buzz-db-restore-proof
+spec:
+  bootstrap:
+    recovery:
+      backup:
+        name: buzz-db-acceptance-UTC_TIMESTAMP
 ```
 
-Apply the proof resource through a temporary committed GitOps change or an explicitly approved emergency procedure.
-Wait for it to become healthy, connect with `kubectl cnpg psql`, and verify representative relay rows. Delete only the
-temporary proof cluster after recording evidence; never delete the source OBC or bucket.
+Never restore over `buzz-db`. The proof cluster uses the same pinned PostgreSQL image and a new 20 GiB
+`rook-ceph-block` volume. Wait for both resources to complete, connect with `kubectl cnpg psql`, and compare the
+migration count plus hashes of representative community and membership rows with the source snapshot. Remove the
+temporary proof resources through a follow-up Git change after recording evidence; never delete the source OBC or
+bucket.
 
 ## Resilience proof
 


### PR DESCRIPTION
## Summary

- create a named plugin backup of the live Buzz CNPG cluster on a standby
- restore that exact backup into a temporary single-instance CNPG cluster on a new 20 GiB Ceph RBD volume
- document the pre-desktop GitOps restore proof and exact-backup validation workflow

## Related Issues

None

## Testing

- `PATH=/nix/store/xx21h4bmbmhncdlhw5q7gp3wx50x0y5g-kubernetes-helm-3.19.1/bin:$PATH kustomize build --enable-helm argocd/applications/buzz` (31 rendered objects; no Namespace or Secret)
- `kubectl apply --namespace buzz --dry-run=server --server-side --field-manager=buzz-acceptance-validation -f /tmp/buzz-render.yaml` (31 objects accepted)
- `bun run lint:argocd` (all resources valid; zero invalid/errors)
- `git diff --check`
- source snapshot: 24 successful migrations, 1 community, 1 relay member, 1 event; recorded deterministic community and member hashes for restore comparison

## Breaking Changes

None. The proof cluster and named acceptance backup are temporary and will be removed through a follow-up Git change after validation; the production cluster, OBC, bucket, and retained backups are unchanged.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation and cleanup follow-up are documented.