### PR TITLE
fix(buzz): restore through Barman plugin source

### DIFF
--- a/argocd/applications/buzz/postgres-restore-proof.yaml
+++ b/argocd/applications/buzz/postgres-restore-proof.yaml
@@ -8,6 +8,9 @@ metadata:
     app.kubernetes.io/component: restore-proof
   annotations:
     argocd.argoproj.io/sync-wave: "5"
+    # This is a disposable proof cluster. Recreate it when its recovery
+    # definition changes so a failed bootstrap Job or empty PVC is not reused.
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
   description: Temporary restore proof for the Buzz production backup
   instances: 1
@@ -28,8 +31,16 @@ spec:
     resizeInUseVolumes: true
   bootstrap:
     recovery:
-      backup:
-        name: buzz-db-acceptance-20260723t091130z
+      source: buzz-db-backup
+      database: buzz
+      owner: buzz
+  externalClusters:
+    - name: buzz-db-backup
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: buzz-db
+          serverName: buzz-db-live
   postgresql:
     parameters:
       password_encryption: scram-sha-256

--- a/docs/runbooks/buzz-production.md
+++ b/docs/runbooks/buzz-production.md
@@ -95,9 +95,9 @@ kubectl -n buzz get backup.postgresql.cnpg.io \
 kubectl cnpg status buzz-db -n buzz
 ```
 
-Before desktop onboarding, commit a named on-demand `Backup` and a temporary restore cluster to the Buzz GitOps
-application. The restore cluster must reference that exact backup so it cannot race the backup and accidentally select
-an older recovery point:
+Before desktop onboarding, commit a named on-demand `Backup` to the Buzz GitOps application and wait for it to become
+`completed`. Only then commit the temporary restore cluster. Keeping these as two reconciliations ensures the Barman
+plugin selects the new backup as the latest completed recovery point:
 
 ```yaml
 apiVersion: postgresql.cnpg.io/v1
@@ -119,8 +119,16 @@ metadata:
 spec:
   bootstrap:
     recovery:
-      backup:
-        name: buzz-db-acceptance-UTC_TIMESTAMP
+      source: buzz-db-backup
+      database: buzz
+      owner: buzz
+  externalClusters:
+    - name: buzz-db-backup
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: buzz-db
+          serverName: buzz-db-live
 ```
 
 Never restore over `buzz-db`. The proof cluster uses the same pinned PostgreSQL image and a new 20 GiB


### PR DESCRIPTION
## Summary

- recover the temporary proof cluster through the supported Barman Cloud plugin external-cluster path
- replace the disposable proof cluster when its bootstrap definition changes so the failed legacy recovery Job and empty PVC are not reused
- document the required two-phase GitOps backup-then-restore reconciliation

## Related Issues

None

## Testing

- reproduced the failed proof safely: the direct `recovery.backup.name` path exited before data restore with `ObjectStoreConfiguration invalid: no credentials defined`
- confirmed the named plugin backup completed successfully on standby `buzz-db-2` with backup ID `20260723T091624`
- `PATH=/nix/store/xx21h4bmbmhncdlhw5q7gp3wx50x0y5g-kubernetes-helm-3.19.1/bin:$PATH kustomize build --enable-helm argocd/applications/buzz`
- `kubectl apply --namespace buzz --dry-run=server --server-side --field-manager=buzz-acceptance-validation -f /tmp/buzz-render-plugin-restore.yaml`
- `bun run lint:argocd` (zero invalid resources or errors)
- `git diff --check`

## Breaking Changes

None. Only the disposable restore-proof cluster is force-recreated. Production `buzz-db`, its PVCs, the OBC, bucket, WAL archive, and completed backups are untouched.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation and cleanup follow-up are updated.