### PR TITLE
feat(bayn): initialize observe authority generation

### DIFF
--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -386,7 +386,7 @@ describePostgres('paper accounting persistence', () => {
               kill_state = 'ACTIVE',
               reason = 'operator kill',
               version = version + 1,
-              updated_at = clock_timestamp() + interval '1 hour'
+              updated_at = clock_timestamp()
             WHERE singleton
             RETURNING updated_at
           `
@@ -409,6 +409,63 @@ describePostgres('paper accounting persistence', () => {
         updatedAt: expect.any(String),
       })
       expect(Date.parse(result.rotated.updatedAt)).toBeGreaterThan(Date.parse(result.killedAt))
+    } finally {
+      await runtime.dispose()
+    }
+  }, 15_000)
+
+  test('rejects a future durable authority timestamp without rotating it', async () => {
+    const runtime = makeStoreRuntime({ fail: false, planHashes: [] })
+    try {
+      const result = await runtime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* PaperStore
+          yield* store.ensureAuthorityGeneration({
+            generationHash: hash('future-authority-generation'),
+            maximum: Authority.Observe,
+          })
+          const sql = yield* PgClient.PgClient
+          yield* sql`
+            UPDATE authority_state
+            SET
+              version = version + 1,
+              updated_at = clock_timestamp() + interval '1 hour'
+            WHERE singleton
+          `
+          const [before] = yield* sql<{
+            generation_hash: string
+            tuple_id: string
+            updated_at: Date
+            version: number
+          }>`
+            SELECT generation_hash, xmin::text AS tuple_id, updated_at, version::integer
+            FROM authority_state
+          `
+          const failure = yield* Effect.flip(
+            store.ensureAuthorityGeneration({
+              generationHash: hash('rejected-future-authority-generation'),
+              maximum: Authority.Observe,
+            }),
+          )
+          const [after] = yield* sql<{
+            generation_hash: string
+            tuple_id: string
+            updated_at: Date
+            version: number
+          }>`
+            SELECT generation_hash, xmin::text AS tuple_id, updated_at, version::integer
+            FROM authority_state
+          `
+          return { before, failure, after }
+        }),
+      )
+
+      expect(result.failure).toMatchObject({
+        operation: 'authority',
+        failure: 'invariant',
+        message: 'durable authority update follows its database observation time',
+      })
+      expect(result.after).toEqual(result.before)
     } finally {
       await runtime.dispose()
     }

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -256,6 +256,231 @@ describePostgres('paper accounting persistence', () => {
     await migrations.dispose()
   }, 15_000)
 
+  test('initializes, exactly replays, and rotates one OBSERVE authority generation', async () => {
+    const runtime = makeStoreRuntime({ fail: false, planHashes: [] })
+    try {
+      const result = await runtime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* PaperStore
+          const sql = yield* PgClient.PgClient
+          const [databaseBefore] = yield* sql<{ observed_at: Date }>`
+            SELECT clock_timestamp() AS observed_at
+          `
+          const first = yield* store.ensureAuthorityGeneration({
+            generationHash: hash('authority-generation-a'),
+            maximum: Authority.Observe,
+          })
+          const [databaseAfter] = yield* sql<{ observed_at: Date }>`
+            SELECT clock_timestamp() AS observed_at
+          `
+          const [beforeReplay] = yield* sql<{ tuple_id: string; version: number }>`
+            SELECT xmin::text AS tuple_id, version::integer
+            FROM authority_state
+          `
+          const replay = yield* store.ensureAuthorityGeneration({
+            generationHash: hash('authority-generation-a'),
+            maximum: Authority.Observe,
+          })
+          const [afterReplay] = yield* sql<{ tuple_id: string; version: number }>`
+            SELECT xmin::text AS tuple_id, version::integer
+            FROM authority_state
+          `
+          const rotated = yield* store.ensureAuthorityGeneration({
+            generationHash: hash('authority-generation-b'),
+            maximum: Authority.Observe,
+          })
+          const [afterRotation] = yield* sql<{ rows: number; tuple_id: string; version: number }>`
+            SELECT
+              count(*) OVER ()::integer AS rows,
+              xmin::text AS tuple_id,
+              version::integer
+            FROM authority_state
+          `
+          return {
+            first,
+            replay,
+            rotated,
+            databaseBefore: databaseBefore.observed_at,
+            databaseAfter: databaseAfter.observed_at,
+            beforeReplay,
+            afterReplay,
+            afterRotation,
+          }
+        }),
+      )
+
+      expect(result.first).toEqual({
+        schemaVersion: 'bayn.paper-authority.v1',
+        generationHash: hash('authority-generation-a'),
+        maximum: Authority.Observe,
+        effective: Authority.Observe,
+        kill: KillState.Clear,
+        version: 1,
+        updatedAt: expect.any(String),
+      })
+      expect(Date.parse(result.first.updatedAt)).toBeGreaterThanOrEqual(result.databaseBefore.getTime())
+      expect(Date.parse(result.first.updatedAt)).toBeLessThanOrEqual(result.databaseAfter.getTime())
+      expect(result.replay).toEqual(result.first)
+      expect(result.afterReplay).toEqual(result.beforeReplay)
+      expect(result.rotated).toEqual({
+        ...result.first,
+        generationHash: hash('authority-generation-b'),
+        version: 2,
+        updatedAt: expect.any(String),
+      })
+      expect(Date.parse(result.rotated.updatedAt)).toBeGreaterThan(Date.parse(result.first.updatedAt))
+      expect(result.afterRotation).toMatchObject({ rows: 1, version: 2 })
+      expect(result.afterRotation.tuple_id).not.toBe(result.afterReplay.tuple_id)
+    } finally {
+      await runtime.dispose()
+    }
+  }, 15_000)
+
+  test('serializes concurrent absent-row authority initialization', async () => {
+    const runtime = makeStoreRuntime({ fail: false, planHashes: [] })
+    try {
+      const result = await runtime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* PaperStore
+          const states = yield* Effect.all(
+            Array.from({ length: 12 }, () =>
+              store.ensureAuthorityGeneration({
+                generationHash: hash('concurrent-authority-generation'),
+                maximum: Authority.Observe,
+              }),
+            ),
+            { concurrency: 'unbounded' },
+          )
+          const sql = yield* PgClient.PgClient
+          const [stored] = yield* sql<{ rows: number; version: number }>`
+            SELECT count(*) OVER ()::integer AS rows, version::integer
+            FROM authority_state
+          `
+          return { states, stored }
+        }),
+      )
+
+      expect(result.states).toHaveLength(12)
+      expect(result.states.every((state) => state.version === 1)).toBe(true)
+      expect(new Set(result.states.map((state) => JSON.stringify(state))).size).toBe(1)
+      expect(result.stored).toEqual({ rows: 1, version: 1 })
+    } finally {
+      await runtime.dispose()
+    }
+  }, 15_000)
+
+  test('rotates monotonically while preserving an active kill exactly', async () => {
+    const runtime = makeStoreRuntime({ fail: false, planHashes: [] })
+    try {
+      const result = await runtime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* PaperStore
+          yield* store.ensureAuthorityGeneration({
+            generationHash: hash('killed-authority-generation'),
+            maximum: Authority.Observe,
+          })
+          const sql = yield* PgClient.PgClient
+          const [killed] = yield* sql<{ updated_at: Date }>`
+            UPDATE authority_state
+            SET
+              kill_state = 'ACTIVE',
+              reason = 'operator kill',
+              version = version + 1,
+              updated_at = clock_timestamp() + interval '1 hour'
+            WHERE singleton
+            RETURNING updated_at
+          `
+          const rotated = yield* store.ensureAuthorityGeneration({
+            generationHash: hash('rotated-killed-authority-generation'),
+            maximum: Authority.Observe,
+          })
+          return { killedAt: killed.updated_at.toISOString(), rotated }
+        }),
+      )
+
+      expect(result.rotated).toEqual({
+        schemaVersion: 'bayn.paper-authority.v1',
+        generationHash: hash('rotated-killed-authority-generation'),
+        maximum: Authority.Observe,
+        effective: Authority.Observe,
+        kill: KillState.Active,
+        reason: 'operator kill',
+        version: 3,
+        updatedAt: expect.any(String),
+      })
+      expect(Date.parse(result.rotated.updatedAt)).toBeGreaterThan(Date.parse(result.killedAt))
+    } finally {
+      await runtime.dispose()
+    }
+  }, 15_000)
+
+  test('rejects maximum conflicts, invalid input, and every PAPER request without writing', async () => {
+    const runtime = makeStoreRuntime({ fail: false, planHashes: [] })
+    try {
+      const result = await runtime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* PaperStore
+          const invalid = yield* Effect.flip(
+            store.ensureAuthorityGeneration({
+              generationHash: 'not-a-sha256',
+              maximum: Authority.Observe,
+            }),
+          )
+          const paper = yield* Effect.flip(
+            store.ensureAuthorityGeneration({
+              generationHash: hash('paper-authority-generation'),
+              maximum: Authority.Paper,
+            }),
+          )
+          const sql = yield* PgClient.PgClient
+          const [empty] = yield* sql<{ rows: number }>`
+            SELECT count(*)::integer AS rows FROM authority_state
+          `
+          yield* sql`
+            INSERT INTO authority_state (
+              schema_version, generation_hash, maximum, effective, kill_state, reason, version, updated_at
+            ) VALUES (
+              'bayn.paper-authority.v1', ${hash('conflicting-authority-generation')},
+              'PAPER', 'PAPER', 'CLEAR', NULL, 1, clock_timestamp()
+            )
+          `
+          const [beforeConflict] = yield* sql<{ tuple_id: string; version: number }>`
+            SELECT xmin::text AS tuple_id, version::integer FROM authority_state
+          `
+          const conflict = yield* Effect.flip(
+            store.ensureAuthorityGeneration({
+              generationHash: hash('conflicting-authority-generation'),
+              maximum: Authority.Observe,
+            }),
+          )
+          const [afterConflict] = yield* sql<{ tuple_id: string; version: number }>`
+            SELECT xmin::text AS tuple_id, version::integer FROM authority_state
+          `
+          const rotated = yield* store.ensureAuthorityGeneration({
+            generationHash: hash('observe-authority-generation'),
+            maximum: Authority.Observe,
+          })
+          return { invalid, paper, empty, conflict, beforeConflict, afterConflict, rotated }
+        }),
+      )
+
+      expect(result.invalid).toMatchObject({ operation: 'authority', failure: 'decode' })
+      expect(result.paper).toMatchObject({ operation: 'authority', failure: 'invariant' })
+      expect(result.empty).toEqual({ rows: 0 })
+      expect(result.conflict).toMatchObject({ operation: 'authority', failure: 'conflict' })
+      expect(result.afterConflict).toEqual(result.beforeConflict)
+      expect(result.rotated).toMatchObject({
+        generationHash: hash('observe-authority-generation'),
+        maximum: Authority.Observe,
+        effective: Authority.Observe,
+        kill: KillState.Clear,
+        version: 2,
+      })
+    } finally {
+      await runtime.dispose()
+    }
+  }, 15_000)
+
   test('appends typed broker events once and rejects conflicting source reuse', async () => {
     const runtime = makeStoreRuntime({ fail: false, planHashes: [] })
     try {

--- a/services/bayn/src/db/paper-store.ts
+++ b/services/bayn/src/db/paper-store.ts
@@ -167,7 +167,12 @@ const AuthorityStateRow = Schema.Struct({
   version: Schema.String,
   updated_at: Schema.DateValid,
 })
+const AuthorityStateObservationRow = Schema.Struct({
+  ...AuthorityStateRow.fields,
+  observed_at: Schema.DateValid,
+})
 const AuthorityStateRows = Schema.Array(AuthorityStateRow).check(Schema.isMaxLength(1))
+const AuthorityStateObservationRows = Schema.Array(AuthorityStateObservationRow).check(Schema.isMaxLength(1))
 const AuthorityRestrictionInput = Schema.Struct({ reason: NonEmptyString, updatedAt: UtcInstant })
 
 const decodeEventInput = Schema.decodeUnknownEffect(BrokerEventInputSchema, strictParseOptions)
@@ -196,6 +201,10 @@ const decodeEnsureAuthorityGenerationInput = Schema.decodeUnknownEffect(
   strictParseOptions,
 )
 const decodeAuthorityStateRows = Schema.decodeUnknownEffect(AuthorityStateRows, strictParseOptions)
+const decodeAuthorityStateObservationRows = Schema.decodeUnknownEffect(
+  AuthorityStateObservationRows,
+  strictParseOptions,
+)
 const decodeBrokerEvent = Schema.decodeUnknownEffect(BrokerEventSchema, strictParseOptions)
 const decodeReceipt = Schema.decodeUnknownEffect(AccountingReceiptSchema, strictParseOptions)
 const decodeValuation = Schema.decodeUnknownEffect(ValuationSchema, strictParseOptions)
@@ -956,11 +965,11 @@ const makeStore = (config: Pick<RuntimeConfig, 'tigerBeetle'>) =>
                     const rows = yield* sql<Record<string, unknown>>`
                       SELECT
                         schema_version, generation_hash, maximum, effective, kill_state, reason,
-                        version::text AS version, updated_at
+                        version::text AS version, updated_at, clock_timestamp() AS observed_at
                       FROM authority_state
                       WHERE singleton
                       FOR UPDATE
-                    `.pipe(Effect.flatMap(decodeAuthorityStateRows))
+                    `.pipe(Effect.flatMap(decodeAuthorityStateObservationRows))
                     const currentRow = rows[0]
                     if (currentRow === undefined) {
                       const inserted = yield* sql<Record<string, unknown>>`
@@ -983,6 +992,13 @@ const makeStore = (config: Pick<RuntimeConfig, 'tigerBeetle'>) =>
                     }
 
                     const current = yield* authorityStateFromRow(currentRow)
+                    if (currentRow.updated_at.getTime() > currentRow.observed_at.getTime()) {
+                      return yield* fail(
+                        'authority',
+                        'invariant',
+                        'durable authority update follows its database observation time',
+                      )
+                    }
                     if (current.generationHash === input.generationHash) {
                       if (current.maximum !== input.maximum) {
                         return yield* fail(

--- a/services/bayn/src/db/paper-store.ts
+++ b/services/bayn/src/db/paper-store.ts
@@ -23,10 +23,14 @@ import { canonicalHashV1 } from '../hash'
 import { Journal } from '../ledger'
 import {
   AccountingReceiptSchema,
+  Authority,
   Broker,
   BrokerEventSchema,
+  KillState,
   ValuationSchema,
+  decodeAuthorityState,
   type AccountingReceipt,
+  type AuthorityState,
   type Valuation,
 } from '../paper'
 import {
@@ -63,6 +67,11 @@ export interface PositionSnapshotReceipt {
   readonly deduplicated: boolean
 }
 
+export interface EnsureAuthorityGenerationInput {
+  readonly generationHash: string
+  readonly maximum: Authority
+}
+
 export class PaperStoreError extends Data.TaggedError('PaperStoreError')<{
   readonly operation:
     | 'ingest'
@@ -87,6 +96,9 @@ export interface PaperStoreShape {
   readonly hasAccountBaseline: (accountId: string) => Effect.Effect<boolean, PaperStoreError>
   readonly bindings: (accountId: string) => Effect.Effect<readonly IntentBinding[], PaperStoreError>
   readonly reconcile: (snapshot: BrokerSnapshot) => Effect.Effect<ReconciliationWriteResult, PaperStoreError>
+  readonly ensureAuthorityGeneration: (
+    input: EnsureAuthorityGenerationInput,
+  ) => Effect.Effect<AuthorityState, PaperStoreError>
   readonly restrictAuthority: (reason: string, updatedAt: string) => Effect.Effect<void, PaperStoreError>
 }
 
@@ -141,6 +153,21 @@ const ValuationRow = Schema.Struct({
   equity_micros: Schema.String,
   as_of: Schema.DateValid,
 })
+const EnsureAuthorityGenerationInputSchema = Schema.Struct({
+  generationHash: Sha256,
+  maximum: Schema.Enum(Authority),
+})
+const AuthorityStateRow = Schema.Struct({
+  schema_version: Schema.Literal('bayn.paper-authority.v1'),
+  generation_hash: Sha256,
+  maximum: Schema.Enum(Authority),
+  effective: Schema.Enum(Authority),
+  kill_state: Schema.Enum(KillState),
+  reason: Schema.NullOr(NonEmptyString),
+  version: Schema.String,
+  updated_at: Schema.DateValid,
+})
+const AuthorityStateRows = Schema.Array(AuthorityStateRow).check(Schema.isMaxLength(1))
 const AuthorityRestrictionInput = Schema.Struct({ reason: NonEmptyString, updatedAt: UtcInstant })
 
 const decodeEventInput = Schema.decodeUnknownEffect(BrokerEventInputSchema, strictParseOptions)
@@ -164,6 +191,11 @@ const decodePositionSnapshotRows = Schema.decodeUnknownEffect(Schema.Array(Posit
 const decodeEventIdRows = Schema.decodeUnknownEffect(Schema.Array(EventIdRow), strictParseOptions)
 const decodeSnapshotIdRows = Schema.decodeUnknownEffect(Schema.Array(SnapshotIdRow), strictParseOptions)
 const decodeValuationRows = Schema.decodeUnknownEffect(Schema.Array(ValuationRow), strictParseOptions)
+const decodeEnsureAuthorityGenerationInput = Schema.decodeUnknownEffect(
+  EnsureAuthorityGenerationInputSchema,
+  strictParseOptions,
+)
+const decodeAuthorityStateRows = Schema.decodeUnknownEffect(AuthorityStateRows, strictParseOptions)
 const decodeBrokerEvent = Schema.decodeUnknownEffect(BrokerEventSchema, strictParseOptions)
 const decodeReceipt = Schema.decodeUnknownEffect(AccountingReceiptSchema, strictParseOptions)
 const decodeValuation = Schema.decodeUnknownEffect(ValuationSchema, strictParseOptions)
@@ -202,6 +234,25 @@ const fail = (
   failure: PaperStoreError['failure'],
   message: string,
 ): Effect.Effect<never, PaperStoreError> => Effect.fail(error(operation, failure, message))
+
+const authorityStateFromRow = (
+  row: typeof AuthorityStateRow.Type,
+): Effect.Effect<AuthorityState, PaperStoreError | Schema.SchemaError> => {
+  const version = Number(row.version)
+  if (!Number.isSafeInteger(version) || version <= 0) {
+    return fail('authority', 'invariant', 'durable authority version is not a safe positive integer')
+  }
+  return decodeAuthorityState({
+    schemaVersion: row.schema_version,
+    generationHash: row.generation_hash,
+    maximum: row.maximum,
+    effective: row.effective,
+    kill: row.kill_state,
+    ...(row.reason === null ? {} : { reason: row.reason }),
+    version,
+    updatedAt: row.updated_at.toISOString(),
+  })
+}
 
 const kindOf = (input: BrokerEventInput): typeof EventKind.Type => {
   switch (input._tag) {
@@ -888,6 +939,87 @@ const makeStore = (config: Pick<RuntimeConfig, 'tigerBeetle'>) =>
       )
     const bindings = (accountId: string) => run('bindings', reconciliation.bindings(accountId))
     const reconcile = (snapshot: BrokerSnapshot) => run('reconciliation', reconciliation.reconcile(snapshot))
+    const ensureAuthorityGeneration = (candidate: EnsureAuthorityGenerationInput) =>
+      run(
+        'authority',
+        decodeEnsureAuthorityGenerationInput(candidate).pipe(
+          Effect.flatMap((input) =>
+            input.maximum !== Authority.Observe
+              ? fail('authority', 'invariant', 'Phase A authority maximum must be OBSERVE')
+              : sql.withTransaction(
+                  Effect.gen(function* () {
+                    yield* sql`
+                      SELECT pg_advisory_xact_lock(
+                        hashtextextended('bayn.paper-authority-generation.v1', 0)
+                      )
+                    `
+                    const rows = yield* sql<Record<string, unknown>>`
+                      SELECT
+                        schema_version, generation_hash, maximum, effective, kill_state, reason,
+                        version::text AS version, updated_at
+                      FROM authority_state
+                      WHERE singleton
+                      FOR UPDATE
+                    `.pipe(Effect.flatMap(decodeAuthorityStateRows))
+                    const currentRow = rows[0]
+                    if (currentRow === undefined) {
+                      const inserted = yield* sql<Record<string, unknown>>`
+                        INSERT INTO authority_state (
+                          schema_version, generation_hash, maximum, effective, kill_state,
+                          reason, version, updated_at
+                        ) VALUES (
+                          'bayn.paper-authority.v1', ${input.generationHash}, ${input.maximum},
+                          'OBSERVE', 'CLEAR', NULL, 1, clock_timestamp()
+                        )
+                        RETURNING
+                          schema_version, generation_hash, maximum, effective, kill_state, reason,
+                          version::text AS version, updated_at
+                      `.pipe(Effect.flatMap(decodeAuthorityStateRows))
+                      const insertedRow = inserted[0]
+                      if (insertedRow === undefined) {
+                        return yield* fail('authority', 'invariant', 'authority generation was not initialized')
+                      }
+                      return yield* authorityStateFromRow(insertedRow)
+                    }
+
+                    const current = yield* authorityStateFromRow(currentRow)
+                    if (current.generationHash === input.generationHash) {
+                      if (current.maximum !== input.maximum) {
+                        return yield* fail(
+                          'authority',
+                          'conflict',
+                          'authority generation maximum conflicts with durable state',
+                        )
+                      }
+                      return current
+                    }
+
+                    const rotated = yield* sql<Record<string, unknown>>`
+                      UPDATE authority_state
+                      SET
+                        generation_hash = ${input.generationHash},
+                        maximum = ${input.maximum},
+                        effective = 'OBSERVE',
+                        version = version + 1,
+                        updated_at = greatest(
+                          clock_timestamp(),
+                          updated_at + interval '1 millisecond'
+                        )
+                      WHERE singleton
+                      RETURNING
+                        schema_version, generation_hash, maximum, effective, kill_state, reason,
+                        version::text AS version, updated_at
+                    `.pipe(Effect.flatMap(decodeAuthorityStateRows))
+                    const rotatedRow = rotated[0]
+                    if (rotatedRow === undefined) {
+                      return yield* fail('authority', 'invariant', 'authority generation was not rotated')
+                    }
+                    return yield* authorityStateFromRow(rotatedRow)
+                  }),
+                ),
+          ),
+        ),
+      )
     const lowerAuthority = (reason: string, updatedAt: string) =>
       run(
         'authority',
@@ -904,6 +1036,7 @@ const makeStore = (config: Pick<RuntimeConfig, 'tigerBeetle'>) =>
       hasAccountBaseline,
       bindings,
       reconcile,
+      ensureAuthorityGeneration,
       restrictAuthority: lowerAuthority,
     } satisfies PaperStoreShape
   })

--- a/services/bayn/src/reconciler.test.ts
+++ b/services/bayn/src/reconciler.test.ts
@@ -196,6 +196,7 @@ const makeStore = (control: StoreControl, hasAccountBaseline = true): PaperStore
       control.reconciliations.push(snapshot)
       return report(snapshot)
     }),
+  ensureAuthorityGeneration: () => Effect.die(new Error('unexpected authority generation initialization')),
   restrictAuthority: (reason) =>
     Effect.sync(() => {
       control.restrictions.push(reason)


### PR DESCRIPTION
## Summary

- add one runtime-decoded `PaperStore.ensureAuthorityGeneration` operation for OBSERVE-only singleton initialization and generation rotation
- serialize absent-row startup with a fixed transaction advisory lock, preserve active kill evidence, and keep same-generation replay write-free
- reject invalid/conflicting inputs and every PAPER request, with no config, runtime composition, authority service, migration, or GitOps change

## Related Issues

PROOMPT-375

## Testing

- `bun test services/bayn/src/reconciler.test.ts` (9 passed)
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:55482/bayn_test bun test services/bayn/src/db/paper-store.integration.test.ts` (11 passed)
- exact PostgreSQL CI sequence: evidence-store 36 passed, PaperStore 11 passed, cycle-store 13 passed
- `env -u BAYN_TEST_POSTGRES_URL bun run --filter @proompteng/bayn test` (318 passed, 70 PostgreSQL tests skipped)
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn build`
- `bun test packages/scripts/src/bayn` (9 passed)

## Breaking Changes

None. This is the source-only Phase A prerequisite; required runtime config/composition and any later qualification-gated PAPER transition remain separate reviewed work.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Runtime composition, GitOps wiring, and Phase B remain tracked by PROOMPT-375.