### PR TITLE
fix(buzz): enforce Redis memory ceiling

### DIFF
--- a/argocd/applications/buzz/redis-config.yaml
+++ b/argocd/applications/buzz/redis-config.yaml
@@ -8,4 +8,8 @@ data:
   redis-additional.conf: |
     appendonly yes
     appendfsync everysec
+    # The operator exports REDIS_MAX_MEMORY but the pinned Redis image does
+    # not translate it into redis.conf. Keep this equal to 75% of the 512 MiB
+    # container limit so Redis has headroom for allocator and AOF overhead.
+    maxmemory 384mb
     maxmemory-policy allkeys-lru

--- a/docs/runbooks/buzz-production.md
+++ b/docs/runbooks/buzz-production.md
@@ -67,7 +67,8 @@ Required state:
 - `buzz-kubernetes`, `buzz-redis-auth`, and `buzz-secrets` are `Ready`.
 - `buzz-db` reports three ready instances, one primary, one synchronous standby, and a healthy continuous archive.
 - The immediate `buzz-db-daily-*` backup is `completed`.
-- `buzz-redis` is ready, accepts only authenticated commands, and has AOF enabled.
+- `buzz-redis` is ready, accepts only authenticated commands, has AOF enabled, and reports
+  `maxmemory=402653184` (384 MiB).
 - Two Buzz relay pods are Ready on different nodes.
 - The Tailscale Ingress has an assigned device and a valid tailnet TLS certificate.
 


### PR DESCRIPTION
## Summary

- explicitly set Redis `maxmemory` to 384 MiB, matching 75% of its 512 MiB container limit
- preserve 128 MiB of headroom for allocator, fork, and AOF overhead
- document the runtime value required by Buzz production acceptance

## Related Issues

None

## Testing

- reproduced runtime `maxmemory=0` even though the operator generated `REDIS_MAX_MEMORY=402653184`
- confirmed Redis is authenticated, Ready, AOF-enabled, and reports successful AOF write/rewrite status
- Helm 3/Kustomize render contains exactly `maxmemory 384mb` in `buzz-redis-config`
- server-side dry-run accepted all 29 remaining Buzz resources using the Argo field manager
- `bun run lint:argocd` (zero invalid resources or errors)
- `git diff --check`

## Breaking Changes

None. Redis requires a controlled pod restart after Argo reconciliation to load the static config. The retained 5 GiB AOF PVC is unchanged.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation and follow-up restart verification are documented.