### PR TITLE
feat(bayn): load exact cycle decision inputs

### DIFF
--- a/services/bayn/src/app-test-support.ts
+++ b/services/bayn/src/app-test-support.ts
@@ -121,6 +121,7 @@ export const marketDataService = (
   inspectPublication: () => Effect.die(new Error('startup test market data must not inspect cycle publications')),
   inspectSnapshotPublication: () =>
     Effect.die(new Error('startup test market data must not inspect bound cycle publications')),
+  loadSnapshotPublication: () => load,
   load,
 })
 

--- a/services/bayn/src/cycle-readiness.test.ts
+++ b/services/bayn/src/cycle-readiness.test.ts
@@ -157,6 +157,7 @@ const marketDataService = (
     inspectCyclePublications: unused,
     inspectPublication,
     inspectSnapshotPublication,
+    loadSnapshotPublication: () => unused,
     load: unused,
   }
 }

--- a/services/bayn/src/cycle-runner.test.ts
+++ b/services/bayn/src/cycle-runner.test.ts
@@ -237,6 +237,7 @@ const marketDataService = (
     inspectCyclePublications,
     inspectPublication: inspectExactPublication,
     inspectSnapshotPublication: inspectExactPublication,
+    loadSnapshotPublication: () => unused,
     load: unused,
   }
 }

--- a/services/bayn/src/db/cycle-store.integration.test.ts
+++ b/services/bayn/src/db/cycle-store.integration.test.ts
@@ -356,6 +356,7 @@ const runnerMarketData = (): MarketDataService => {
     }),
     inspectPublication: inspectExactPublication,
     inspectSnapshotPublication: inspectExactPublication,
+    loadSnapshotPublication: () => unused,
     load: unused,
   }
 }

--- a/services/bayn/src/execution-session.test.ts
+++ b/services/bayn/src/execution-session.test.ts
@@ -3,12 +3,27 @@ import { describe, expect, test } from 'bun:test'
 import { Schema } from 'effect'
 
 import type { MarketCalendarObservation } from './broker/alpaca'
+import {
+  CycleState,
+  makeCycleDraft,
+  makeCycleExecutionPolicyFromModel,
+  makeCycleIdentity,
+  makeCycleWindow,
+  makeExecutionCalendarObservation,
+  type AutonomousCycle,
+} from './cycle'
 import { defaultExecutionModel } from './execution-model'
-import { bindExecutionSession, ExecutionSessionBindingSchema } from './execution-session'
+import { bindCycleExecutionSession, bindExecutionSession, ExecutionSessionBindingSchema } from './execution-session'
 import { canonicalHashV1 } from './hash'
 import { strictParseOptions } from './schemas'
 
 const hash = (character: string): string => character.repeat(64)
+const causalExecutionModel = (() => {
+  if (defaultExecutionModel.schemaVersion !== 'bayn.execution-model.v2') {
+    throw new Error('execution-session cycle fixtures require the causal v2 execution model')
+  }
+  return defaultExecutionModel
+})()
 
 const calendar = (
   sessions: MarketCalendarObservation['sessions'],
@@ -40,6 +55,89 @@ const bind = (observation: MarketCalendarObservation) =>
   })
 
 const decodeBinding = Schema.decodeUnknownSync(ExecutionSessionBindingSchema, strictParseOptions)
+
+const monthEndCalendar = calendar(
+  [
+    {
+      date: '2026-01-30',
+      openAt: '2026-01-30T14:30:00.000Z',
+      closeAt: '2026-01-30T21:00:00.000Z',
+    },
+    {
+      date: '2026-02-02',
+      openAt: '2026-02-02T14:30:00.000Z',
+      closeAt: '2026-02-02T21:00:00.000Z',
+    },
+    {
+      date: '2026-02-03',
+      openAt: '2026-02-03T14:30:00.000Z',
+      closeAt: '2026-02-03T21:00:00.000Z',
+    },
+  ],
+  { start: '2026-01-30', end: '2026-02-03' },
+)
+
+const makeActiveCycle = (): AutonomousCycle => {
+  const executionSession = monthEndCalendar.sessions[1]
+  if (executionSession === undefined) throw new Error('cycle fixture requires the first post-signal session')
+  const executionCalendar = makeExecutionCalendarObservation({
+    schemaVersion: monthEndCalendar.schemaVersion,
+    source: monthEndCalendar.source,
+    ...executionSession,
+  })
+  const executionPolicy = makeCycleExecutionPolicyFromModel(causalExecutionModel)
+  const identity = makeCycleIdentity({
+    schemaVersion: 'bayn.autonomous-cycle-identity.v1',
+    strategyName: 'risk-balanced-trend',
+    qualificationRunId: hash('1'),
+    strategyProtocolHash: hash('2'),
+    accountId: 'paper-account-1',
+    signalSessionDate: '2026-01-30',
+    signalCalendarVersion: 'signal-calendar-v1',
+    executionSessionDate: executionCalendar.executionSessionDate,
+    executionCalendarSchemaVersion: executionCalendar.executionCalendarSchemaVersion,
+    executionCalendarSource: executionCalendar.executionCalendarSource,
+    executionCalendarHash: executionCalendar.executionCalendarHash,
+    executionPolicy,
+  })
+  const window = makeCycleWindow(
+    {
+      calendar_version: 'signal-calendar-v1',
+      session_date: '2026-01-30',
+      close_time: '16:00',
+      timezone: 'America/New_York',
+    },
+    executionCalendar,
+    executionPolicy,
+  )
+  return {
+    ...makeCycleDraft(identity, window),
+    state: CycleState.Active,
+    bindings: { snapshotId: hash('3') },
+    stateVersion: 3,
+    createdAt: '2026-01-30T21:15:00.000Z',
+    updatedAt: window.submissionOpenAt,
+  }
+}
+
+const bindCycle = (overrides: Partial<Parameters<typeof bindCycleExecutionSession>[0]> = {}) => {
+  const cycle = makeActiveCycle()
+  return bindCycleExecutionSession({
+    cycle,
+    signal: {
+      sessionDate: cycle.identity.signalSessionDate,
+      finalizedAt: '2026-01-30T21:15:00.000Z',
+      contentHash: hash('a'),
+    },
+    planningBrokerState: {
+      observedAt: cycle.window.submissionOpenAt,
+      contentHash: hash('b'),
+    },
+    calendar: monthEndCalendar,
+    executionModel: causalExecutionModel,
+    ...overrides,
+  })
+}
 
 describe('causal execution-session binding', () => {
   test('binds a holiday gap, fixed pre-open cutoff, and early close without assuming session hours', () => {
@@ -206,5 +304,82 @@ describe('causal execution-session binding', () => {
         }),
       ),
     ).toThrow('market calendar request must start on or before the signal session')
+  })
+
+  test('binds one complete real calendar to the exact durable cycle and preserves adjacency evidence', () => {
+    const binding = bindCycle()
+
+    expect(binding).toMatchObject({
+      signal: { sessionDate: '2026-01-30' },
+      calendar: monthEndCalendar,
+      executionSession: {
+        date: '2026-02-02',
+        openAt: '2026-02-02T14:30:00.000Z',
+        closeAt: '2026-02-02T21:00:00.000Z',
+      },
+      submissionOpenAt: '2026-02-02T13:45:00.000Z',
+      submissionCutoffAt: '2026-02-02T14:15:00.000Z',
+      submissionCutoffLeadMinutes: 15,
+    })
+  })
+
+  test('allows later evidence to narrow but never widen the durable cycle submission window', () => {
+    expect(
+      bindCycle({
+        planningBrokerState: {
+          observedAt: '2026-02-02T14:00:00.000Z',
+          contentHash: hash('c'),
+        },
+      }).submissionOpenAt,
+    ).toBe('2026-02-02T14:00:00.000Z')
+
+    expect(() =>
+      bindCycle({
+        planningBrokerState: {
+          observedAt: '2026-02-02T13:44:59.999Z',
+          contentHash: hash('d'),
+        },
+      }),
+    ).toThrow('cannot widen the durable cycle submission window')
+  })
+
+  test('fails closed when the complete calendar no longer selects the cycle session', () => {
+    expect(() =>
+      bindCycle({
+        signal: {
+          sessionDate: '2026-01-31',
+          finalizedAt: '2026-01-30T21:15:00.000Z',
+          contentHash: hash('e'),
+        },
+      }),
+    ).toThrow('does not match the durable cycle calendar')
+
+    const changedHours = calendar(
+      monthEndCalendar.sessions.map((session) =>
+        session.date === '2026-02-02' ? { ...session, closeAt: '2026-02-02T18:00:00.000Z' } : session,
+      ),
+      monthEndCalendar.requestedRange,
+    )
+    expect(() => bindCycle({ calendar: changedHours })).toThrow('does not match the durable cycle calendar')
+
+    const skippedSession = calendar(
+      monthEndCalendar.sessions.filter((session) => session.date !== '2026-02-02'),
+      monthEndCalendar.requestedRange,
+    )
+    expect(() => bindCycle({ calendar: skippedSession })).toThrow('does not match the durable cycle calendar')
+  })
+
+  test('fails closed when the current execution model differs from the cycle policy', () => {
+    const changedModel = {
+      ...causalExecutionModel,
+      order: {
+        ...causalExecutionModel.order,
+        submissionCutoffLeadMinutes: causalExecutionModel.order.submissionCutoffLeadMinutes - 1,
+      },
+    }
+
+    expect(() => bindCycle({ executionModel: changedModel })).toThrow(
+      'does not match the durable cycle execution policy',
+    )
   })
 })

--- a/services/bayn/src/execution-session.ts
+++ b/services/bayn/src/execution-session.ts
@@ -1,6 +1,7 @@
 import { Schema } from 'effect'
 
 import type { MarketCalendarObservation } from './broker/alpaca'
+import { makeExecutionCalendarObservation, type AutonomousCycle } from './cycle'
 import { canonicalHashV1 } from './hash'
 import type { ExecutionModel } from './protocol'
 import { IsoDateSchema, Sha256Schema, UtcInstantSchema, strictParseOptions as StrictParseOptions } from './schemas'
@@ -155,6 +156,10 @@ export interface BindExecutionSessionInput {
   readonly executionModel: ExecutionModel
 }
 
+export interface BindCycleExecutionSessionInput extends BindExecutionSessionInput {
+  readonly cycle: AutonomousCycle
+}
+
 const decodeBinding = Schema.decodeUnknownSync(ExecutionSessionBindingSchema, StrictParseOptions)
 
 const observationMaterial = (observation: MarketCalendarObservation) => ({
@@ -214,4 +219,40 @@ export const bindExecutionSession = (input: BindExecutionSessionInput): Executio
     submissionCutoffLeadMinutes: cutoffLeadMinutes,
   } as const
   return decodeBinding({ ...material, bindingHash: canonicalHashV1(material) })
+}
+
+export const bindCycleExecutionSession = (input: BindCycleExecutionSessionInput): ExecutionSessionBinding => {
+  const binding = bindExecutionSession(input)
+  const cycle = input.cycle
+  const selectedObservation = makeExecutionCalendarObservation({
+    schemaVersion: binding.calendar.schemaVersion,
+    source: binding.calendar.source,
+    ...binding.executionSession,
+  })
+  if (
+    binding.signal.sessionDate !== cycle.identity.signalSessionDate ||
+    binding.executionSession.date !== cycle.identity.executionSessionDate ||
+    binding.executionSession.date !== cycle.window.executionSessionDate ||
+    binding.executionSession.openAt !== cycle.window.executionOpenAt ||
+    binding.executionSession.closeAt !== cycle.window.executionCloseAt ||
+    selectedObservation.executionCalendarSchemaVersion !== cycle.identity.executionCalendarSchemaVersion ||
+    selectedObservation.executionCalendarSchemaVersion !== cycle.window.executionCalendarSchemaVersion ||
+    selectedObservation.executionCalendarSource !== cycle.identity.executionCalendarSource ||
+    selectedObservation.executionCalendarSource !== cycle.window.executionCalendarSource ||
+    selectedObservation.executionCalendarHash !== cycle.identity.executionCalendarHash ||
+    selectedObservation.executionCalendarHash !== cycle.window.executionCalendarHash
+  ) {
+    throw new TypeError('execution-session binding does not match the durable cycle calendar')
+  }
+  if (
+    canonicalHashV1(input.executionModel) !== cycle.identity.executionPolicy.strategyExecutionModelHash ||
+    binding.submissionCutoffLeadMinutes * 60_000 !== cycle.identity.executionPolicy.submissionCutoffBeforeOpenMs ||
+    binding.submissionCutoffAt !== cycle.window.submissionCutoffAt
+  ) {
+    throw new TypeError('execution-session binding does not match the durable cycle execution policy')
+  }
+  if (binding.submissionOpenAt < cycle.window.submissionOpenAt) {
+    throw new TypeError('execution-session binding cannot widen the durable cycle submission window')
+  }
+  return binding
 }

--- a/services/bayn/src/health.test.ts
+++ b/services/bayn/src/health.test.ts
@@ -92,6 +92,7 @@ describe('Bayn continuous health', () => {
           inspectPublication: () => Effect.die(new Error('health probes must not inspect cycle publications')),
           inspectSnapshotPublication: () =>
             Effect.die(new Error('health probes must not inspect bound cycle publications')),
+          loadSnapshotPublication: () => Effect.die(new Error('health probes must not load bound cycle bars')),
           load: Effect.die(new Error('health probes must not load bars')),
         }),
         Effect.provideService(Journal, { ...successfulJournal, checkRun: () => Effect.void }),
@@ -147,6 +148,7 @@ describe('Bayn continuous health', () => {
       inspectPublication: () => Effect.die(new Error('health probes must not inspect cycle publications')),
       inspectSnapshotPublication: () =>
         Effect.die(new Error('health probes must not inspect bound cycle publications')),
+      loadSnapshotPublication: () => Effect.die(new Error('health probes must not load bound cycle bars')),
       load: Effect.die(new Error('health probes must not load bars')),
     }
     const journal: JournalService = {
@@ -232,6 +234,7 @@ describe('Bayn continuous health', () => {
       inspectPublication: () => Effect.die(new Error('health monitor must not inspect cycle publications')),
       inspectSnapshotPublication: () =>
         Effect.die(new Error('health monitor must not inspect bound cycle publications')),
+      loadSnapshotPublication: () => Effect.die(new Error('health monitor must not load bound cycle bars')),
       load: Effect.die(new Error('health monitor must not load bars')),
     }
     const journal: JournalService = { ...successfulJournal, checkRun: () => Effect.void }
@@ -272,6 +275,7 @@ describe('Bayn continuous health', () => {
       inspectPublication: () => Effect.die(new Error('health monitor must not inspect cycle publications')),
       inspectSnapshotPublication: () =>
         Effect.die(new Error('health monitor must not inspect bound cycle publications')),
+      loadSnapshotPublication: () => Effect.die(new Error('health monitor must not load bound cycle bars')),
       load: Effect.die(new Error('health monitor must not load bars')),
     }
     const fiber = Effect.runFork(
@@ -325,6 +329,7 @@ describe('Bayn continuous health', () => {
           inspectPublication: () => Effect.die(new Error('health probes must not inspect cycle publications')),
           inspectSnapshotPublication: () =>
             Effect.die(new Error('health probes must not inspect bound cycle publications')),
+          loadSnapshotPublication: () => Effect.die(new Error('health probes must not load bound cycle bars')),
           load: Effect.die(new Error('health probes must not load bars')),
         }),
         Effect.provideService(Journal, { ...successfulJournal, checkRun: () => Effect.void }),

--- a/services/bayn/src/market-data.test.ts
+++ b/services/bayn/src/market-data.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, test } from 'bun:test'
 
 import { ClickhouseClient } from '@effect/sql-clickhouse'
 import { Effect, Layer, Redacted } from 'effect'
+import { TestClock } from 'effect/testing'
 import { AuthorizationError, ConnectionError, SqlError } from 'effect/unstable/sql/SqlError'
 
+import type { OperationalError } from './errors'
 import { canonicalHashV1 } from './hash'
 import {
   MarketData,
@@ -286,16 +288,22 @@ interface ClickhouseParameter {
   readonly value: unknown
 }
 
+interface ClickhouseFixtureOptions {
+  readonly bars?: SnapshotRows['bars']
+  readonly beforeBarsReturn?: Effect.Effect<void>
+}
+
 const makeClickhouseFixture = (
   manifests: readonly SignalManifestRow[],
   sessions: readonly SignalSessionRow[],
   queries: CapturedQuery[],
+  options: ClickhouseFixtureOptions = {},
 ): ClickhouseClient.ClickhouseClient => {
   const statement = (
     strings: TemplateStringsArray,
     ...fragments: readonly ClickhouseParameter[]
   ): Effect.Effect<readonly unknown[]> =>
-    Effect.sync(() => {
+    Effect.gen(function* () {
       const text = strings.join('?')
       const parameters = fragments.map((fragment) => fragment.value)
       if (text.includes('FROM signal.snapshot_manifests_v2') && text.includes('WHERE universe_id')) {
@@ -334,6 +342,9 @@ const makeClickhouseFixture = (
       }
       if (text.includes('FROM signal.adjusted_daily_bars_v2')) {
         queries.push({ kind: 'bars', text, parameters })
+        if (options.beforeBarsReturn !== undefined) yield* options.beforeBarsReturn
+        const requestedSnapshotId = parameters[0]
+        return (options.bars ?? []).filter((bar) => bar.snapshot_id === requestedSnapshotId)
       }
       return []
     })
@@ -762,6 +773,127 @@ describe('finalized Signal snapshot reader', () => {
       snapshotId,
     ])
     expect(manifestQueries.every((query) => query.text.includes('WHERE snapshot_id ='))).toBe(true)
+  })
+
+  test('loads exact bound bars with contract-derived bounds after all snapshot queries complete', async () => {
+    const fixture = makeFixture()
+    const queries: CapturedQuery[] = []
+    const staticSnapshotId = '0'.repeat(64)
+    const client = makeClickhouseFixture(fixture.rows.manifests, fixture.rows.sessions, queries, {
+      bars: fixture.rows.bars,
+      beforeBarsReturn: TestClock.setTime(Date.parse('2025-01-04T01:00:01.000Z')),
+    })
+    const layer = MarketDataLive(
+      {
+        operationTimeoutMs: 5_000,
+        clickhouse: {
+          url: 'http://clickhouse.test:8123',
+          username: 'bayn',
+          password: Redacted.make('secret'),
+          snapshotId: staticSnapshotId,
+          publicationAsOf: '2024-12-31',
+          calendarVersion: 'static-calendar-v0',
+          bounds: {
+            ...fixture.request.bounds,
+            dataStart: '2024-01-02',
+            dataEnd: '2024-12-31',
+            lookbackStart: '2024-01-02',
+            evaluationStart: '2024-12-02',
+            evaluationEnd: '2024-12-31',
+          },
+        },
+      },
+      {
+        universeId: fixture.request.universeId,
+        universeSymbolHash: fixture.request.universeSymbolHash,
+        universe: fixture.request.universe,
+        historyStart: fixture.request.historyStart,
+        evaluationStart: fixture.request.evaluationStart,
+      },
+    ).pipe(Layer.provide(Layer.succeed(ClickhouseClient.ClickhouseClient, client)))
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse('2025-01-04T00:59:59.000Z'))
+        const marketData = yield* MarketData
+        return yield* marketData.loadSnapshotPublication({
+          snapshotId,
+          signalSessionDate: '2025-01-03',
+          signalCalendarVersion: fixture.request.calendarVersion,
+        })
+      }).pipe(Effect.provide(layer), Effect.provide(TestClock.layer())),
+    )
+
+    expect(result.bars).toHaveLength(fixture.rows.bars.length)
+    expect(result.manifest).toMatchObject({
+      bounds: fixture.request.bounds,
+      finalizedSnapshot: {
+        snapshotId,
+        asOfSession: fixture.request.publicationAsOf,
+        calendarVersion: fixture.request.calendarVersion,
+      },
+    })
+    expect(queries.map((query) => query.kind).sort()).toEqual(['bars', 'manifest', 'sessions'])
+    expect(queries.every((query) => query.parameters[0] === snapshotId)).toBe(true)
+    expect(queries.every((query) => !query.parameters.includes(staticSnapshotId))).toBe(true)
+  })
+
+  test('fails the exact bound load closed on snapshot, session, calendar, and content drift', async () => {
+    const fixture = makeFixture()
+    const baseRequest: SnapshotPublicationRequest = {
+      snapshotId,
+      signalSessionDate: '2025-01-03',
+      signalCalendarVersion: fixture.request.calendarVersion,
+    }
+    const load = (
+      request: SnapshotPublicationRequest,
+      rows: SnapshotRows = fixture.rows,
+    ): Promise<OperationalError> => {
+      const client = makeClickhouseFixture(rows.manifests, rows.sessions, [], { bars: rows.bars })
+      const layer = MarketDataLive(
+        {
+          operationTimeoutMs: 5_000,
+          clickhouse: {
+            url: 'http://clickhouse.test:8123',
+            username: 'bayn',
+            password: Redacted.make('secret'),
+            snapshotId: '0'.repeat(64),
+            publicationAsOf: fixture.request.publicationAsOf,
+            calendarVersion: fixture.request.calendarVersion,
+            bounds: fixture.request.bounds,
+          },
+        },
+        {
+          universeId: fixture.request.universeId,
+          universeSymbolHash: fixture.request.universeSymbolHash,
+          universe: fixture.request.universe,
+          historyStart: fixture.request.historyStart,
+          evaluationStart: fixture.request.evaluationStart,
+        },
+      ).pipe(Layer.provide(Layer.succeed(ClickhouseClient.ClickhouseClient, client)))
+      return Effect.runPromise(
+        Effect.flip(
+          Effect.gen(function* () {
+            const marketData = yield* MarketData
+            return yield* marketData.loadSnapshotPublication(request)
+          }).pipe(Effect.provide(layer)),
+        ),
+      )
+    }
+
+    const wrongId = await load({ ...baseRequest, snapshotId: 'f'.repeat(64) })
+    const wrongSession = await load({ ...baseRequest, signalSessionDate: '2025-01-02' })
+    const wrongCalendar = await load({ ...baseRequest, signalCalendarVersion: 'other-calendar-v1' })
+    const changedBars = [
+      { ...fixture.rows.bars[0], adjusted_volume: '1000099.00000000' },
+      ...fixture.rows.bars.slice(1),
+    ]
+    const changedContent = await load(baseRequest, { ...fixture.rows, bars: changedBars })
+
+    expect(wrongId.message).toContain('0 manifests; expected exactly one')
+    expect(wrongSession.message).toContain('does not match expected session')
+    expect(wrongCalendar.message).toContain('manifest calendar version does not match')
+    expect(changedContent.message).toContain('adjusted-bar content hash is invalid')
   })
 
   test('rejects duplicate manifests, sessions, and bars', () => {

--- a/services/bayn/src/market-data.ts
+++ b/services/bayn/src/market-data.ts
@@ -192,6 +192,9 @@ export interface MarketDataService {
   readonly inspectSnapshotPublication: (
     request: SnapshotPublicationRequest,
   ) => Effect.Effect<FinalizedPublicationInspection, OperationalError>
+  readonly loadSnapshotPublication: (
+    request: SnapshotPublicationRequest,
+  ) => Effect.Effect<MarketDataSnapshot, OperationalError>
   readonly load: Effect.Effect<MarketDataSnapshot, OperationalError>
 }
 
@@ -771,6 +774,28 @@ const makeMarketData = (
         ORDER BY session_date
       `.pipe(sql.withQueryId(`bayn-cycle-sessions-${snapshotId.slice(-32)}`))
 
+    const loadSnapshotPublicationBars = (snapshotId: string) =>
+      sql`
+        SELECT
+          snapshot_id,
+          symbol,
+          toString(session_date) AS session_date,
+          toDecimalString(adjusted_open, 8) AS adjusted_open,
+          toDecimalString(adjusted_high, 8) AS adjusted_high,
+          toDecimalString(adjusted_low, 8) AS adjusted_low,
+          toDecimalString(adjusted_close, 8) AS adjusted_close,
+          toDecimalString(adjusted_volume, 8) AS adjusted_volume,
+          toString(trade_count) AS trade_count,
+          if(isNull(vwap), NULL, toDecimalString(vwap, 8)) AS vwap,
+          provider,
+          source_feed,
+          adjustment,
+          toString(publication_asof) AS publication_asof
+        FROM signal.adjusted_daily_bars_v2
+        WHERE snapshot_id = ${sql.param('String', snapshotId)}
+        ORDER BY session_date, symbol
+      `.pipe(sql.withQueryId(`bayn-bound-bars-${snapshotId.slice(-32)}`))
+
     const loadCyclePublicationSessions = (snapshotIds: readonly string[]) =>
       sql`
         SELECT
@@ -803,6 +828,25 @@ const makeMarketData = (
         evaluationStart: contract.evaluationStart,
       }
     }
+    const snapshotPublicationRequest = (input: SnapshotPublicationRequest, observedAt: string): SnapshotRequest => ({
+      snapshotId: input.snapshotId,
+      publicationAsOf: input.signalSessionDate,
+      calendarVersion: input.signalCalendarVersion,
+      universe: contract.universe,
+      bounds: {
+        schemaVersion: 'bayn.evaluation-bounds.v1',
+        dataStart: contract.historyStart,
+        dataEnd: input.signalSessionDate,
+        lookbackStart: contract.historyStart,
+        evaluationStart: contract.evaluationStart,
+        evaluationEnd: input.signalSessionDate,
+      },
+      observedAt,
+      universeId: contract.universeId,
+      universeSymbolHash: contract.universeSymbolHash,
+      historyStart: contract.historyStart,
+      evaluationStart: contract.evaluationStart,
+    })
     const verify = <A>(operation: string, body: () => A): Effect.Effect<A, OperationalError> =>
       Effect.try({
         try: body,
@@ -970,6 +1014,32 @@ const makeMarketData = (
             marketDataOperationError(
               'inspect-publication',
               `failed to inspect bound finalized Signal publication ${input.snapshotId}`,
+              cause,
+            ),
+          ),
+        ),
+      loadSnapshotPublication: (input) =>
+        Effect.gen(function* () {
+          const [manifests, sessions, bars] = yield* Effect.all(
+            [
+              loadSnapshotPublicationManifest(input),
+              loadPublicationSessions(input.snapshotId),
+              loadSnapshotPublicationBars(input.snapshotId),
+            ],
+            { concurrency: 3 },
+          )
+          const observedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
+          return yield* verify('verify', () =>
+            verifyFinalizedSnapshot(
+              decodeSnapshotRows(bars, sessions, manifests),
+              snapshotPublicationRequest(input, observedAt),
+            ),
+          )
+        }).pipe(
+          Effect.mapError((cause) =>
+            marketDataOperationError(
+              'load',
+              `failed to load bound finalized Signal snapshot ${input.snapshotId}`,
               cause,
             ),
           ),

--- a/services/bayn/src/resources.test.ts
+++ b/services/bayn/src/resources.test.ts
@@ -86,6 +86,7 @@ const marketDataService = (load: MarketDataService['load']): MarketDataService =
   inspectPublication: () => Effect.die(new Error('resource lifecycle must not inspect cycle publications')),
   inspectSnapshotPublication: () =>
     Effect.die(new Error('resource lifecycle must not inspect bound cycle publications')),
+  loadSnapshotPublication: () => load,
   load,
 })
 

--- a/services/bayn/src/startup.test.ts
+++ b/services/bayn/src/startup.test.ts
@@ -74,6 +74,7 @@ describe('Bayn startup lifecycle', () => {
           inspectCyclePublications: forbidden('pinned startup must not inspect cycle publication candidates'),
           inspectPublication: () => forbidden('pinned startup must not inspect a cycle publication'),
           inspectSnapshotPublication: () => forbidden('pinned startup must not inspect a bound cycle publication'),
+          loadSnapshotPublication: () => forbidden('pinned startup must not load bound cycle bars'),
           load: forbidden('pinned startup must not load Signal bars'),
         }),
         Effect.provideService(Journal, {


### PR DESCRIPTION
## Summary

- load the exact cycle-bound finalized Signal snapshot by snapshot ID, with manifest, sessions, and bars verified against internally derived strategy bounds after all reads complete
- bind one complete real Alpaca calendar observation to the durable cycle and return the canonical execution-session binding only when date, hours, cutoff, policy, source, schema, and selected-session hash agree
- preserve full calendar adjacency evidence, reject window widening and provenance drift, and add focused regressions without adding runtime composition or broker mutation

## Related Issues

PROOMPT-382 dependency slice. PROOMPT-383 remains In Progress pending runtime composition and live restart/zero-mutation proof.

## Testing

- `bun test src/execution-session.test.ts src/market-data.test.ts` (28 pass, 0 fail)
- `bun run test` (324 pass, 66 PostgreSQL-only skips, 0 fail)
- `bun run tsc`
- `bunx oxfmt --check src/execution-session.ts src/execution-session.test.ts src/market-data.ts src/market-data.test.ts`
- `bun run lint:oxlint`
- `bun run lint:oxlint:type`
- `bun run build`
- `git diff --check`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
