### PR TITLE
feat(bayn): run autonomous observe cycles

### DIFF
--- a/services/bayn/src/app-test-support.ts
+++ b/services/bayn/src/app-test-support.ts
@@ -286,6 +286,7 @@ export const readyState = (): RuntimeState => {
         tigerBeetle: { status: 'AVAILABLE', checkedAt: '2026-07-20T00:00:00.000Z', error: null },
         evidence: { status: 'AVAILABLE', checkedAt: '2026-07-20T00:00:00.000Z', error: null },
         cycle: { status: 'AVAILABLE', checkedAt: '2026-07-20T00:00:00.000Z', error: null },
+        cycleRunner: { status: 'AVAILABLE', checkedAt: '2026-07-20T00:00:00.000Z', error: null },
       },
     },
     cycle: deriveCycleOperationsStatus(
@@ -301,6 +302,11 @@ export const readyState = (): RuntimeState => {
       Authority.Observe,
       config,
     ),
+    autonomousCycleLoop: {
+      configured: false,
+      startedAt: null,
+      lastPass: null,
+    },
     broker: null,
     error: null,
   }

--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Cause, Effect, Exit } from 'effect'
+
+import {
+  config,
+  fixtureStrategy,
+  marketDataService,
+  successfulEvidenceStore,
+  successfulJournal,
+} from './app-test-support'
+import { run } from './app'
+import { CycleObservability } from './db/cycle-observability'
+import { EvidenceStore } from './db/evidence-store'
+import { operationalError } from './errors'
+import { Journal } from './ledger'
+import { MarketData } from './market-data'
+import { makeSnapshot } from './test-fixtures'
+
+const cycleObservability = {
+  read: () =>
+    Effect.succeed({
+      current: null,
+      last: null,
+      unfinishedCycleCount: 0,
+      authority: null,
+      reconciliation: null,
+      mutations: { eventCount: 0, unresolvedCount: 0, oldestUnresolvedAt: null, latestOccurredAt: null },
+    }),
+}
+
+describe('Bayn application composition', () => {
+  test('starts one scoped autonomous cycle background after initialization and before reconciliation', async () => {
+    const calls: string[] = []
+    let backgroundInterrupted = false
+    const marketData = marketDataService(
+      Effect.sync(() => {
+        calls.push('initialize')
+        return makeSnapshot()
+      }),
+    )
+    const autonomousCycleStartup = Effect.gen(function* () {
+      calls.push('autonomous-cycle')
+      const fiber = yield* Effect.never.pipe(
+        Effect.onInterrupt(() => Effect.sync(() => void (backgroundInterrupted = true))),
+        Effect.forkScoped({ startImmediately: true }),
+      )
+      yield* Effect.yieldNow
+      return fiber
+    })
+    const reconciliation = Effect.sync(() => {
+      calls.push('reconciliation')
+      throw new Error('stop after composition proof')
+    })
+
+    const exit = await Effect.runPromiseExit(
+      run(config, fixtureStrategy, reconciliation, undefined, autonomousCycleStartup).pipe(
+        Effect.provideService(MarketData, marketData),
+        Effect.provideService(Journal, successfulJournal),
+        Effect.provideService(EvidenceStore, successfulEvidenceStore),
+        Effect.provideService(CycleObservability, cycleObservability),
+        Effect.timeoutOrElse({
+          duration: 1_000,
+          orElse: () => Effect.fail(operationalError('http', 'test', 'composition proof remained alive')),
+        }),
+      ),
+    )
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) expect(Cause.pretty(exit.cause)).toContain('stop after composition proof')
+    expect(calls).toEqual(['initialize', 'autonomous-cycle', 'reconciliation'])
+    expect(backgroundInterrupted).toBe(true)
+  })
+})

--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -4,12 +4,13 @@ import { Cause, Clock, Effect, Exit } from 'effect'
 
 import {
   config,
+  fixtureEvaluation,
   fixtureStrategy,
   marketDataService,
   successfulEvidenceStore,
   successfulJournal,
 } from './app-test-support'
-import { run, type RecordAutonomousCyclePass } from './app'
+import { run, type AutonomousCycleStartupInput } from './app'
 import { CycleObservability } from './db/cycle-observability'
 import { EvidenceStore } from './db/evidence-store'
 import { operationalError } from './errors'
@@ -39,9 +40,11 @@ describe('Bayn application composition', () => {
         return makeSnapshot()
       }),
     )
-    const autonomousCycleStartup = (recordPass: RecordAutonomousCyclePass) =>
+    let startupQualificationRunId: string | undefined
+    const autonomousCycleStartup = ({ qualificationRunId, recordPass }: AutonomousCycleStartupInput) =>
       Effect.gen(function* () {
         calls.push('autonomous-cycle')
+        startupQualificationRunId = qualificationRunId
         yield* recordPass({
           result: 'SUCCESS',
           observedAt: new Date(yield* Clock.currentTimeMillis).toISOString(),
@@ -75,6 +78,7 @@ describe('Bayn application composition', () => {
     expect(Exit.isFailure(exit)).toBe(true)
     if (Exit.isFailure(exit)) expect(Cause.pretty(exit.cause)).toContain('stop after composition proof')
     expect(calls).toEqual(['initialize', 'autonomous-cycle', 'reconciliation'])
+    expect(startupQualificationRunId).toBe(fixtureEvaluation.runId)
     expect(backgroundInterrupted).toBe(true)
   })
 })

--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Cause, Effect, Exit } from 'effect'
+import { Cause, Clock, Effect, Exit } from 'effect'
 
 import {
   config,
@@ -9,7 +9,7 @@ import {
   successfulEvidenceStore,
   successfulJournal,
 } from './app-test-support'
-import { run } from './app'
+import { run, type RecordAutonomousCyclePass } from './app'
 import { CycleObservability } from './db/cycle-observability'
 import { EvidenceStore } from './db/evidence-store'
 import { operationalError } from './errors'
@@ -39,15 +39,21 @@ describe('Bayn application composition', () => {
         return makeSnapshot()
       }),
     )
-    const autonomousCycleStartup = Effect.gen(function* () {
-      calls.push('autonomous-cycle')
-      const fiber = yield* Effect.never.pipe(
-        Effect.onInterrupt(() => Effect.sync(() => void (backgroundInterrupted = true))),
-        Effect.forkScoped({ startImmediately: true }),
-      )
-      yield* Effect.yieldNow
-      return fiber
-    })
+    const autonomousCycleStartup = (recordPass: RecordAutonomousCyclePass) =>
+      Effect.gen(function* () {
+        calls.push('autonomous-cycle')
+        yield* recordPass({
+          result: 'SUCCESS',
+          observedAt: new Date(yield* Clock.currentTimeMillis).toISOString(),
+          outcome: 'NO_PUBLICATION',
+        })
+        const fiber = yield* Effect.never.pipe(
+          Effect.onInterrupt(() => Effect.sync(() => void (backgroundInterrupted = true))),
+          Effect.forkScoped({ startImmediately: true }),
+        )
+        yield* Effect.yieldNow
+        return fiber
+      })
     const reconciliation = Effect.sync(() => {
       calls.push('reconciliation')
       throw new Error('stop after composition proof')

--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -7,16 +7,21 @@ import {
   fixtureEvaluation,
   fixtureStrategy,
   marketDataService,
+  pinnedEvaluation,
+  pinnedRuntimeConfig,
+  pinnedStore,
   successfulEvidenceStore,
   successfulJournal,
 } from './app-test-support'
 import { run, type AutonomousCycleStartupInput } from './app'
+import { makeStrategyProtocolHash } from './contracts'
 import { CycleObservability } from './db/cycle-observability'
 import { EvidenceStore } from './db/evidence-store'
 import { operationalError } from './errors'
 import { Journal } from './ledger'
 import { MarketData } from './market-data'
-import { makeSnapshot } from './test-fixtures'
+import { makeStrategy } from './strategy'
+import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
 
 const cycleObservability = {
   read: () =>
@@ -41,10 +46,16 @@ describe('Bayn application composition', () => {
       }),
     )
     let startupQualificationRunId: string | undefined
-    const autonomousCycleStartup = ({ qualificationRunId, recordPass }: AutonomousCycleStartupInput) =>
+    let startupStrategyProtocolHash: string | undefined
+    const autonomousCycleStartup = ({
+      qualificationRunId,
+      strategyProtocolHash,
+      recordPass,
+    }: AutonomousCycleStartupInput) =>
       Effect.gen(function* () {
         calls.push('autonomous-cycle')
         startupQualificationRunId = qualificationRunId
+        startupStrategyProtocolHash = strategyProtocolHash
         yield* recordPass({
           result: 'SUCCESS',
           observedAt: new Date(yield* Clock.currentTimeMillis).toISOString(),
@@ -79,6 +90,50 @@ describe('Bayn application composition', () => {
     if (Exit.isFailure(exit)) expect(Cause.pretty(exit.cause)).toContain('stop after composition proof')
     expect(calls).toEqual(['initialize', 'autonomous-cycle', 'reconciliation'])
     expect(startupQualificationRunId).toBe(fixtureEvaluation.runId)
+    expect(startupStrategyProtocolHash).toBe(fixtureEvaluation.protocolHash)
     expect(backgroundInterrupted).toBe(true)
+  })
+
+  test('keeps the pinned qualification scope separate from the current decision protocol identity', async () => {
+    const currentStrategy = makeStrategy(
+      fixtureProtocol,
+      makeTestProvenance(fixtureProtocol, { behaviorHash: 'c'.repeat(64) }),
+    )
+    const currentProtocolHash = makeStrategyProtocolHash(currentStrategy.provenance.strategy)
+    expect(currentProtocolHash).not.toBe(pinnedEvaluation.protocolHash)
+
+    let startupQualificationRunId: string | undefined
+    let startupStrategyProtocolHash: string | undefined
+    const autonomousCycleStartup = ({ qualificationRunId, strategyProtocolHash }: AutonomousCycleStartupInput) =>
+      Effect.gen(function* () {
+        startupQualificationRunId = qualificationRunId
+        startupStrategyProtocolHash = strategyProtocolHash
+        return yield* Effect.never.pipe(Effect.forkScoped({ startImmediately: true }))
+      })
+    const reconciliation = Effect.sync(() => {
+      throw new Error('stop after pinned composition proof')
+    })
+
+    const exit = await Effect.runPromiseExit(
+      run(pinnedRuntimeConfig, currentStrategy, reconciliation, undefined, autonomousCycleStartup).pipe(
+        Effect.provideService(
+          MarketData,
+          marketDataService(Effect.die(new Error('pinned startup must not load Signal bars'))),
+        ),
+        Effect.provideService(Journal, successfulJournal),
+        Effect.provideService(EvidenceStore, pinnedStore()),
+        Effect.provideService(CycleObservability, cycleObservability),
+        Effect.timeoutOrElse({
+          duration: 1_000,
+          orElse: () => Effect.fail(operationalError('http', 'test', 'pinned composition proof remained alive')),
+        }),
+      ),
+    )
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) expect(Cause.pretty(exit.cause)).toContain('stop after pinned composition proof')
+    expect(startupQualificationRunId).toBe(pinnedEvaluation.runId)
+    expect(startupStrategyProtocolHash).toBe(currentProtocolHash)
+    expect(startupStrategyProtocolHash).not.toBe(pinnedEvaluation.protocolHash)
   })
 })

--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -1,6 +1,7 @@
 import { Clock, Effect, Fiber, Layer, Ref, Scope } from 'effect'
 
 import type { RuntimeConfig } from './config'
+import { makeStrategyProtocolHash } from './contracts'
 import { CycleObservability } from './db/cycle-observability'
 import { EvidenceStore } from './db/evidence-store'
 import { operationalError, type OperationalError } from './errors'
@@ -16,6 +17,7 @@ export type RecordAutonomousCyclePass = (observation: AutonomousCyclePassObserva
 
 export interface AutonomousCycleStartupInput {
   readonly qualificationRunId: string
+  readonly strategyProtocolHash: string
   readonly recordPass: RecordAutonomousCyclePass
 }
 
@@ -88,6 +90,7 @@ export const run = (
           }))
           autonomousCycleFiber = yield* autonomousCycleStartup({
             qualificationRunId: initialized.evidence.evaluation.runId,
+            strategyProtocolHash: makeStrategyProtocolHash(strategy.provenance.strategy),
             recordPass: (observation) => recordAutonomousCyclePass(state, observation),
           })
         }

--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -14,8 +14,13 @@ import type { Strategy } from './strategy'
 
 export type RecordAutonomousCyclePass = (observation: AutonomousCyclePassObservation) => Effect.Effect<void>
 
+export interface AutonomousCycleStartupInput {
+  readonly qualificationRunId: string
+  readonly recordPass: RecordAutonomousCyclePass
+}
+
 export type AutonomousCycleStartup = (
-  recordPass: RecordAutonomousCyclePass,
+  input: AutonomousCycleStartupInput,
 ) => Effect.Effect<Fiber.Fiber<void, never>, OperationalError, Scope.Scope>
 
 const cyclePassError = (observation: Extract<AutonomousCyclePassObservation, { readonly result: 'FAILURE' }>): string =>
@@ -74,14 +79,18 @@ export const run = (
       yield* initialize(config, state, strategy)
       let autonomousCycleFiber: Fiber.Fiber<void, never> | undefined
       if (autonomousCycleStartup !== undefined) {
-        const startedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
-        yield* Ref.update(state, (current) => ({
-          ...current,
-          autonomousCycleLoop: { ...current.autonomousCycleLoop, startedAt },
-        }))
-        autonomousCycleFiber = yield* autonomousCycleStartup((observation) =>
-          recordAutonomousCyclePass(state, observation),
-        )
+        const initialized = yield* Ref.get(state)
+        if (initialized.evidence !== null) {
+          const startedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
+          yield* Ref.update(state, (current) => ({
+            ...current,
+            autonomousCycleLoop: { ...current.autonomousCycleLoop, startedAt },
+          }))
+          autonomousCycleFiber = yield* autonomousCycleStartup({
+            qualificationRunId: initialized.evidence.evaluation.runId,
+            recordPass: (observation) => recordAutonomousCyclePass(state, observation),
+          })
+        }
       }
       yield* monitor(config, state, broker, autonomousCycleFiber).pipe(Effect.forkScoped({ startImmediately: true }))
       yield* reconciliation

--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer, Ref } from 'effect'
+import { Effect, Layer, Ref, Scope } from 'effect'
 
 import type { RuntimeConfig } from './config'
 import { CycleObservability } from './db/cycle-observability'
@@ -12,11 +12,14 @@ import { initialState } from './runtime-state'
 import { initialize } from './startup'
 import type { Strategy } from './strategy'
 
+export type AutonomousCycleStartup = Effect.Effect<unknown, OperationalError, Scope.Scope>
+
 export const run = (
   config: RuntimeConfig,
   strategy: Strategy,
   reconciliation: Effect.Effect<void> = Effect.void,
   broker?: BrokerProbe,
+  autonomousCycleStartup: AutonomousCycleStartup = Effect.void,
 ): Effect.Effect<never, OperationalError, MarketData | Journal | EvidenceStore | CycleObservability> =>
   Effect.scoped(
     Effect.gen(function* () {
@@ -27,6 +30,7 @@ export const run = (
       ).pipe(Effect.mapError((cause) => operationalError('http', 'listen', 'HTTP server failed to listen', cause)))
       yield* initialize(config, state, strategy)
       yield* monitor(config, state, broker).pipe(Effect.forkScoped({ startImmediately: true }))
+      yield* autonomousCycleStartup
       yield* reconciliation
       return yield* Effect.never
     }),

--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer, Ref, Scope } from 'effect'
+import { Clock, Effect, Fiber, Layer, Ref, Scope } from 'effect'
 
 import type { RuntimeConfig } from './config'
 import { CycleObservability } from './db/cycle-observability'
@@ -8,29 +8,82 @@ import { monitor, type BrokerProbe } from './health'
 import { makeHttpLayer } from './http'
 import { Journal } from './ledger'
 import { MarketData } from './market-data'
-import { initialState } from './runtime-state'
+import { initialState, type AutonomousCyclePassObservation, type RuntimeState } from './runtime-state'
 import { initialize } from './startup'
 import type { Strategy } from './strategy'
 
-export type AutonomousCycleStartup = Effect.Effect<unknown, OperationalError, Scope.Scope>
+export type RecordAutonomousCyclePass = (observation: AutonomousCyclePassObservation) => Effect.Effect<void>
+
+export type AutonomousCycleStartup = (
+  recordPass: RecordAutonomousCyclePass,
+) => Effect.Effect<Fiber.Fiber<void, never>, OperationalError, Scope.Scope>
+
+const cyclePassError = (observation: Extract<AutonomousCyclePassObservation, { readonly result: 'FAILURE' }>): string =>
+  `cycleRunner: ${observation.operation}/${observation.failure}: ${observation.message}`
+
+const cyclePassDependencyError = (
+  observation: Extract<AutonomousCyclePassObservation, { readonly result: 'FAILURE' }>,
+): string => `${observation.operation}/${observation.failure}: ${observation.message}`
+
+const recordAutonomousCyclePass = (
+  state: Ref.Ref<RuntimeState>,
+  observation: AutonomousCyclePassObservation,
+): Effect.Effect<void> =>
+  Ref.update(state, (current): RuntimeState => {
+    const dependencyError = observation.result === 'FAILURE' ? cyclePassDependencyError(observation) : null
+    const next: RuntimeState = {
+      ...current,
+      health: {
+        ...current.health,
+        dependencies: {
+          ...current.health.dependencies,
+          cycleRunner: {
+            status: observation.result === 'FAILURE' ? 'UNAVAILABLE' : 'AVAILABLE',
+            checkedAt: observation.observedAt,
+            error: dependencyError,
+          },
+        },
+      },
+      autonomousCycleLoop: {
+        ...current.autonomousCycleLoop,
+        lastPass: observation,
+      },
+    }
+    if (observation.result !== 'FAILURE' || current.evidence === null) return next
+    return {
+      ...next,
+      status: 'DEGRADED',
+      error: cyclePassError(observation),
+    }
+  })
 
 export const run = (
   config: RuntimeConfig,
   strategy: Strategy,
   reconciliation: Effect.Effect<void> = Effect.void,
   broker?: BrokerProbe,
-  autonomousCycleStartup: AutonomousCycleStartup = Effect.void,
+  autonomousCycleStartup?: AutonomousCycleStartup,
 ): Effect.Effect<never, OperationalError, MarketData | Journal | EvidenceStore | CycleObservability> =>
   Effect.scoped(
     Effect.gen(function* () {
       const evidenceStore = yield* EvidenceStore
-      const state = yield* Ref.make(initialState(broker))
+      const state = yield* Ref.make(initialState(broker, autonomousCycleStartup !== undefined))
       yield* Layer.build(
         makeHttpLayer(config, state, strategy.provenance, config.build.verification, evidenceStore.read),
       ).pipe(Effect.mapError((cause) => operationalError('http', 'listen', 'HTTP server failed to listen', cause)))
       yield* initialize(config, state, strategy)
-      yield* monitor(config, state, broker).pipe(Effect.forkScoped({ startImmediately: true }))
-      yield* autonomousCycleStartup
+      let autonomousCycleFiber: Fiber.Fiber<void, never> | undefined
+      if (autonomousCycleStartup !== undefined) {
+        const startedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
+        yield* Ref.update(state, (current) => ({
+          ...current,
+          autonomousCycleLoop: { ...current.autonomousCycleLoop, startedAt },
+        }))
+        autonomousCycleFiber = yield* autonomousCycleStartup((observation) =>
+          recordAutonomousCyclePass(state, observation),
+        )
+      }
+      yield* monitor(config, state, broker, autonomousCycleFiber).pipe(Effect.forkScoped({ startImmediately: true }))
       yield* reconciliation
       return yield* Effect.never
     }),

--- a/services/bayn/src/config.test.ts
+++ b/services/bayn/src/config.test.ts
@@ -209,6 +209,16 @@ describe('Effect configuration', () => {
     expect(
       (await Effect.runPromise(provideEnvironment(loadConfig(buildMetadata), configured))).cyclePollIntervalMs,
     ).toBe(15_000)
+
+    const incoherent = new Map(runtimeEnvironment)
+    incoherent.set('BAYN_CYCLE_POLL_INTERVAL_MS', '300000')
+    const error = await Effect.runPromise(Effect.flip(provideEnvironment(loadConfig(buildMetadata), incoherent)))
+    expect(error).toMatchObject({
+      _tag: 'OperationalError',
+      component: 'config',
+      operation: 'cycle-loop',
+      message: 'cycle poll interval must be shorter than the cycle stall threshold',
+    })
   })
 
   test('rejects an invalid pinned qualification run ID', async () => {

--- a/services/bayn/src/config.test.ts
+++ b/services/bayn/src/config.test.ts
@@ -93,9 +93,22 @@ describe('Effect configuration', () => {
     expect(config.qualificationRunId).toBe('e'.repeat(64))
   })
 
-  test('requires an explicit valid source-controlled authority generation hash', async () => {
+  test('allows no authority generation while autonomous cycle composition is disabled', async () => {
+    const environment = new Map(runtimeEnvironment)
+    environment.delete('BAYN_AUTHORITY_GENERATION_HASH')
+
+    const config = await Effect.runPromise(provideEnvironment(loadConfig(buildMetadata), environment))
+
+    expect(config.authorityGenerationHash).toBeUndefined()
+    expect(config.alpaca).toBeUndefined()
+  })
+
+  test('requires an explicit valid authority generation for OBSERVE broker composition', async () => {
     for (const value of [undefined, 'not-a-generation-hash']) {
       const environment = new Map(runtimeEnvironment)
+      environment.set('BAYN_ALPACA_ACCOUNT_ID', '61e69015-8549-4bfd-b9c3-01e75843f47d')
+      environment.set('BAYN_ALPACA_KEY_ID', 'paper-key')
+      environment.set('BAYN_ALPACA_SECRET_KEY', 'paper-secret')
       if (value === undefined) {
         environment.delete('BAYN_AUTHORITY_GENERATION_HASH')
       } else {
@@ -107,7 +120,7 @@ describe('Effect configuration', () => {
       expect(error).toMatchObject({
         _tag: 'OperationalError',
         component: 'config',
-        operation: 'load',
+        operation: value === undefined ? 'authority-generation' : 'load',
       })
     }
   })

--- a/services/bayn/src/config.test.ts
+++ b/services/bayn/src/config.test.ts
@@ -9,6 +9,7 @@ import { Authority } from './paper'
 const sourceRevision = 'a'.repeat(40)
 const imageRepository = 'registry.ide-newton.ts.net/lab/bayn'
 const imageDigest = `sha256:${'b'.repeat(64)}`
+const authorityGenerationHash = '1'.repeat(64)
 const buildMetadata: EmbeddedBuildMetadata = {
   sourceRevision,
   imageRepository,
@@ -22,6 +23,7 @@ const runtimeEnvironment = new Map([
   ['BAYN_IMAGE_DIGEST', imageDigest],
   ['BAYN_STRATEGY_BEHAVIOR_HASH', buildMetadata.strategyBehaviorHash],
   ['BAYN_STRATEGY_PARAMETER_HASH', buildMetadata.strategyParameterHash],
+  ['BAYN_AUTHORITY_GENERATION_HASH', authorityGenerationHash],
   ['BAYN_CLICKHOUSE_URL', 'http://clickhouse.test:8123'],
   ['BAYN_CLICKHOUSE_USERNAME', 'bayn'],
   ['BAYN_CLICKHOUSE_PASSWORD', 'secret'],
@@ -56,6 +58,7 @@ describe('Effect configuration', () => {
     expect(config.reconciliationStaleThresholdMs).toBe(120_000)
     expect(config.unknownMutationThresholdMs).toBe(300_000)
     expect(config.cyclePollIntervalMs).toBe(30_000)
+    expect(config.authorityGenerationHash).toBe(authorityGenerationHash)
     expect(config.alpaca).toBeUndefined()
     expect(config.clickhouse).toMatchObject({
       snapshotId: 'd'.repeat(64),
@@ -88,6 +91,25 @@ describe('Effect configuration', () => {
     const config = await Effect.runPromise(provideEnvironment(loadConfig(buildMetadata), pinned))
 
     expect(config.qualificationRunId).toBe('e'.repeat(64))
+  })
+
+  test('requires an explicit valid source-controlled authority generation hash', async () => {
+    for (const value of [undefined, 'not-a-generation-hash']) {
+      const environment = new Map(runtimeEnvironment)
+      if (value === undefined) {
+        environment.delete('BAYN_AUTHORITY_GENERATION_HASH')
+      } else {
+        environment.set('BAYN_AUTHORITY_GENERATION_HASH', value)
+      }
+
+      const error = await Effect.runPromise(Effect.flip(provideEnvironment(loadConfig(buildMetadata), environment)))
+
+      expect(error).toMatchObject({
+        _tag: 'OperationalError',
+        component: 'config',
+        operation: 'load',
+      })
+    }
   })
 
   test('loads one complete redacted Alpaca read binding', async () => {

--- a/services/bayn/src/config.test.ts
+++ b/services/bayn/src/config.test.ts
@@ -58,7 +58,6 @@ describe('Effect configuration', () => {
     expect(config.reconciliationStaleThresholdMs).toBe(120_000)
     expect(config.unknownMutationThresholdMs).toBe(300_000)
     expect(config.cyclePollIntervalMs).toBe(30_000)
-    expect(config.authorityGenerationHash).toBe(authorityGenerationHash)
     expect(config.alpaca).toBeUndefined()
     expect(config.clickhouse).toMatchObject({
       snapshotId: 'd'.repeat(64),
@@ -99,11 +98,10 @@ describe('Effect configuration', () => {
 
     const config = await Effect.runPromise(provideEnvironment(loadConfig(buildMetadata), environment))
 
-    expect(config.authorityGenerationHash).toBeUndefined()
     expect(config.alpaca).toBeUndefined()
   })
 
-  test('requires an explicit valid authority generation for OBSERVE broker composition', async () => {
+  test('requires an explicit valid authority generation to resolve an Alpaca binding', async () => {
     for (const value of [undefined, 'not-a-generation-hash']) {
       const environment = new Map(runtimeEnvironment)
       environment.set('BAYN_ALPACA_ACCOUNT_ID', '61e69015-8549-4bfd-b9c3-01e75843f47d')
@@ -135,6 +133,7 @@ describe('Effect configuration', () => {
 
     expect(config.alpaca).toMatchObject({
       accountId: '61e69015-8549-4bfd-b9c3-01e75843f47d',
+      authorityGenerationHash,
       proxyUrl: 'http://bayn-egress-proxy:3128',
       retryAttempts: 2,
       reconciliationIntervalMs: 30_000,

--- a/services/bayn/src/config.test.ts
+++ b/services/bayn/src/config.test.ts
@@ -55,6 +55,7 @@ describe('Effect configuration', () => {
     expect(config.cycleStallThresholdMs).toBe(300_000)
     expect(config.reconciliationStaleThresholdMs).toBe(120_000)
     expect(config.unknownMutationThresholdMs).toBe(300_000)
+    expect(config.cyclePollIntervalMs).toBe(30_000)
     expect(config.alpaca).toBeUndefined()
     expect(config.clickhouse).toMatchObject({
       snapshotId: 'd'.repeat(64),
@@ -184,11 +185,13 @@ describe('Effect configuration', () => {
     })
   })
 
-  test('keeps operational alert thresholds positive and bounded to one day', async () => {
+  test('keeps operational thresholds and the cycle poll interval bounded to one day', async () => {
     for (const [name, value] of [
       ['BAYN_CYCLE_STALL_THRESHOLD_MS', '999'],
       ['BAYN_RECONCILIATION_STALE_THRESHOLD_MS', '86400001'],
       ['BAYN_UNKNOWN_MUTATION_THRESHOLD_MS', '0'],
+      ['BAYN_CYCLE_POLL_INTERVAL_MS', '999'],
+      ['BAYN_CYCLE_POLL_INTERVAL_MS', '86400001'],
     ] as const) {
       const invalid = new Map(runtimeEnvironment)
       invalid.set(name, value)
@@ -200,6 +203,12 @@ describe('Effect configuration', () => {
         operation: 'load',
       })
     }
+
+    const configured = new Map(runtimeEnvironment)
+    configured.set('BAYN_CYCLE_POLL_INTERVAL_MS', '15000')
+    expect(
+      (await Effect.runPromise(provideEnvironment(loadConfig(buildMetadata), configured))).cyclePollIntervalMs,
+    ).toBe(15_000)
   })
 
   test('rejects an invalid pinned qualification run ID', async () => {

--- a/services/bayn/src/config.ts
+++ b/services/bayn/src/config.ts
@@ -63,7 +63,7 @@ export interface AutonomousCycleRuntimeConfig {
 }
 
 export interface AuthorityGenerationRuntimeConfig {
-  readonly authorityGenerationHash: string
+  readonly authorityGenerationHash?: string
 }
 
 export type LoadedRuntimeConfig = RuntimeConfig & AutonomousCycleRuntimeConfig & AuthorityGenerationRuntimeConfig
@@ -114,7 +114,7 @@ const runtimeConfig = Config.all({
   reconciliationStaleThresholdMs: operationalThreshold('BAYN_RECONCILIATION_STALE_THRESHOLD_MS', 120_000),
   unknownMutationThresholdMs: operationalThreshold('BAYN_UNKNOWN_MUTATION_THRESHOLD_MS', 300_000),
   cyclePollIntervalMs: operationalThreshold('BAYN_CYCLE_POLL_INTERVAL_MS', 30_000),
-  authorityGenerationHash: Config.schema(Sha256Schema, 'BAYN_AUTHORITY_GENERATION_HASH'),
+  authorityGenerationHash: Config.option(Config.schema(Sha256Schema, 'BAYN_AUTHORITY_GENERATION_HASH')),
   alpacaAccountId: Config.option(nonEmptyString('BAYN_ALPACA_ACCOUNT_ID')),
   alpacaKey: Config.option(secretString('BAYN_ALPACA_KEY_ID')),
   alpacaSecret: Config.option(secretString('BAYN_ALPACA_SECRET_KEY')),
@@ -162,7 +162,7 @@ const runtimeConfig = Config.all({
     reconciliationStaleThresholdMs: config.reconciliationStaleThresholdMs,
     unknownMutationThresholdMs: config.unknownMutationThresholdMs,
     cyclePollIntervalMs: config.cyclePollIntervalMs,
-    authorityGenerationHash: config.authorityGenerationHash,
+    authorityGenerationHash: Option.getOrUndefined(config.authorityGenerationHash),
     configuredAlpaca: {
       accountId: config.alpacaAccountId,
       key: config.alpacaKey,
@@ -254,6 +254,19 @@ export const loadConfig = (
       if (config.maximumAuthority === Authority.Paper && Option.isNone(alpaca)) {
         return Effect.fail(
           operationalError('config', 'alpaca', 'PAPER maximum authority requires a complete Alpaca account binding'),
+        )
+      }
+      if (
+        config.maximumAuthority === Authority.Observe &&
+        Option.isSome(alpaca) &&
+        config.authorityGenerationHash === undefined
+      ) {
+        return Effect.fail(
+          operationalError(
+            'config',
+            'authority-generation',
+            'OBSERVE autonomous cycle composition requires an authority generation hash',
+          ),
         )
       }
       const { configuredAlpaca: _configuredAlpaca, ...runtime } = config

--- a/services/bayn/src/config.ts
+++ b/services/bayn/src/config.ts
@@ -62,7 +62,11 @@ export interface AutonomousCycleRuntimeConfig {
   readonly cyclePollIntervalMs: number
 }
 
-export type LoadedRuntimeConfig = RuntimeConfig & AutonomousCycleRuntimeConfig
+export interface AuthorityGenerationRuntimeConfig {
+  readonly authorityGenerationHash: string
+}
+
+export type LoadedRuntimeConfig = RuntimeConfig & AutonomousCycleRuntimeConfig & AuthorityGenerationRuntimeConfig
 
 const ProvenanceMode = Schema.Literals(['production', 'development'])
 const RetryAttempts = Schema.Int.check(Schema.isBetween({ minimum: 0, maximum: 3 }))
@@ -110,6 +114,7 @@ const runtimeConfig = Config.all({
   reconciliationStaleThresholdMs: operationalThreshold('BAYN_RECONCILIATION_STALE_THRESHOLD_MS', 120_000),
   unknownMutationThresholdMs: operationalThreshold('BAYN_UNKNOWN_MUTATION_THRESHOLD_MS', 300_000),
   cyclePollIntervalMs: operationalThreshold('BAYN_CYCLE_POLL_INTERVAL_MS', 30_000),
+  authorityGenerationHash: Config.schema(Sha256Schema, 'BAYN_AUTHORITY_GENERATION_HASH'),
   alpacaAccountId: Config.option(nonEmptyString('BAYN_ALPACA_ACCOUNT_ID')),
   alpacaKey: Config.option(secretString('BAYN_ALPACA_KEY_ID')),
   alpacaSecret: Config.option(secretString('BAYN_ALPACA_SECRET_KEY')),
@@ -157,6 +162,7 @@ const runtimeConfig = Config.all({
     reconciliationStaleThresholdMs: config.reconciliationStaleThresholdMs,
     unknownMutationThresholdMs: config.unknownMutationThresholdMs,
     cyclePollIntervalMs: config.cyclePollIntervalMs,
+    authorityGenerationHash: config.authorityGenerationHash,
     configuredAlpaca: {
       accountId: config.alpacaAccountId,
       key: config.alpacaKey,

--- a/services/bayn/src/config.ts
+++ b/services/bayn/src/config.ts
@@ -31,6 +31,7 @@ export interface RuntimeConfig {
   readonly unknownMutationThresholdMs: number
   readonly alpaca?: {
     readonly accountId: string
+    readonly authorityGenerationHash: string
     readonly key: Redacted.Redacted<string>
     readonly secret: Redacted.Redacted<string>
     readonly proxyUrl: string
@@ -62,11 +63,7 @@ export interface AutonomousCycleRuntimeConfig {
   readonly cyclePollIntervalMs: number
 }
 
-export interface AuthorityGenerationRuntimeConfig {
-  readonly authorityGenerationHash?: string
-}
-
-export type LoadedRuntimeConfig = RuntimeConfig & AutonomousCycleRuntimeConfig & AuthorityGenerationRuntimeConfig
+export type LoadedRuntimeConfig = RuntimeConfig & AutonomousCycleRuntimeConfig
 
 const ProvenanceMode = Schema.Literals(['production', 'development'])
 const RetryAttempts = Schema.Int.check(Schema.isBetween({ minimum: 0, maximum: 3 }))
@@ -162,7 +159,7 @@ const runtimeConfig = Config.all({
     reconciliationStaleThresholdMs: config.reconciliationStaleThresholdMs,
     unknownMutationThresholdMs: config.unknownMutationThresholdMs,
     cyclePollIntervalMs: config.cyclePollIntervalMs,
-    authorityGenerationHash: Option.getOrUndefined(config.authorityGenerationHash),
+    authorityGenerationHash: config.authorityGenerationHash,
     configuredAlpaca: {
       accountId: config.alpacaAccountId,
       key: config.alpacaKey,
@@ -245,31 +242,35 @@ export const loadConfig = (
           operationalError('config', 'alpaca', 'Alpaca account ID, key ID, and secret key must be configured together'),
         )
       }
-      const alpaca = Option.map(credentials, (value) => ({
-        ...value,
-        proxyUrl: config.configuredAlpaca.proxyUrl,
-        retryAttempts: config.configuredAlpaca.retryAttempts,
-        reconciliationIntervalMs: config.configuredAlpaca.reconciliationIntervalMs,
-      }))
+      if (Option.isSome(credentials) && Option.isNone(config.authorityGenerationHash)) {
+        return Effect.fail(
+          operationalError(
+            'config',
+            'authority-generation',
+            'Alpaca account binding requires an authority generation hash',
+          ),
+        )
+      }
+      const alpaca = Option.map(
+        Option.all({ credentials, authorityGenerationHash: config.authorityGenerationHash }),
+        ({ credentials: value, authorityGenerationHash }) => ({
+          ...value,
+          authorityGenerationHash,
+          proxyUrl: config.configuredAlpaca.proxyUrl,
+          retryAttempts: config.configuredAlpaca.retryAttempts,
+          reconciliationIntervalMs: config.configuredAlpaca.reconciliationIntervalMs,
+        }),
+      )
       if (config.maximumAuthority === Authority.Paper && Option.isNone(alpaca)) {
         return Effect.fail(
           operationalError('config', 'alpaca', 'PAPER maximum authority requires a complete Alpaca account binding'),
         )
       }
-      if (
-        config.maximumAuthority === Authority.Observe &&
-        Option.isSome(alpaca) &&
-        config.authorityGenerationHash === undefined
-      ) {
-        return Effect.fail(
-          operationalError(
-            'config',
-            'authority-generation',
-            'OBSERVE autonomous cycle composition requires an authority generation hash',
-          ),
-        )
-      }
-      const { configuredAlpaca: _configuredAlpaca, ...runtime } = config
+      const {
+        configuredAlpaca: _configuredAlpaca,
+        authorityGenerationHash: _authorityGenerationHash,
+        ...runtime
+      } = config
       return Effect.succeed({ ...runtime, ...(Option.isSome(alpaca) ? { alpaca: alpaca.value } : {}) })
     }),
     Effect.flatMap((config) =>

--- a/services/bayn/src/config.ts
+++ b/services/bayn/src/config.ts
@@ -213,6 +213,17 @@ export const loadConfig = (
         catch: (cause) => operationalError('config', 'load', 'invalid Signal evaluation bounds', cause),
       }),
     ),
+    Effect.flatMap((config) =>
+      config.cyclePollIntervalMs < config.cycleStallThresholdMs
+        ? Effect.succeed(config)
+        : Effect.fail(
+            operationalError(
+              'config',
+              'cycle-loop',
+              'cycle poll interval must be shorter than the cycle stall threshold',
+            ),
+          ),
+    ),
     Effect.flatMap((config) => {
       const credentials = Option.all({
         accountId: config.configuredAlpaca.accountId,

--- a/services/bayn/src/config.ts
+++ b/services/bayn/src/config.ts
@@ -58,6 +58,12 @@ export interface RuntimeConfig {
   }
 }
 
+export interface AutonomousCycleRuntimeConfig {
+  readonly cyclePollIntervalMs: number
+}
+
+export type LoadedRuntimeConfig = RuntimeConfig & AutonomousCycleRuntimeConfig
+
 const ProvenanceMode = Schema.Literals(['production', 'development'])
 const RetryAttempts = Schema.Int.check(Schema.isBetween({ minimum: 0, maximum: 3 }))
 const OperationalThresholdMs = Schema.Int.check(Schema.isBetween({ minimum: 1_000, maximum: 86_400_000 }))
@@ -103,6 +109,7 @@ const runtimeConfig = Config.all({
   cycleStallThresholdMs: operationalThreshold('BAYN_CYCLE_STALL_THRESHOLD_MS', 300_000),
   reconciliationStaleThresholdMs: operationalThreshold('BAYN_RECONCILIATION_STALE_THRESHOLD_MS', 120_000),
   unknownMutationThresholdMs: operationalThreshold('BAYN_UNKNOWN_MUTATION_THRESHOLD_MS', 300_000),
+  cyclePollIntervalMs: operationalThreshold('BAYN_CYCLE_POLL_INTERVAL_MS', 30_000),
   alpacaAccountId: Config.option(nonEmptyString('BAYN_ALPACA_ACCOUNT_ID')),
   alpacaKey: Config.option(secretString('BAYN_ALPACA_KEY_ID')),
   alpacaSecret: Config.option(secretString('BAYN_ALPACA_SECRET_KEY')),
@@ -149,6 +156,7 @@ const runtimeConfig = Config.all({
     cycleStallThresholdMs: config.cycleStallThresholdMs,
     reconciliationStaleThresholdMs: config.reconciliationStaleThresholdMs,
     unknownMutationThresholdMs: config.unknownMutationThresholdMs,
+    cyclePollIntervalMs: config.cyclePollIntervalMs,
     configuredAlpaca: {
       accountId: config.alpacaAccountId,
       key: config.alpacaKey,
@@ -190,7 +198,7 @@ const decodeEmbeddedBuildMetadata = Schema.decodeUnknownSync(EmbeddedBuildMetada
 
 export const loadConfig = (
   embedded: EmbeddedBuildMetadata | undefined = embeddedBuildMetadata,
-): Effect.Effect<RuntimeConfig, OperationalError> =>
+): Effect.Effect<LoadedRuntimeConfig, OperationalError> =>
   runtimeConfig.pipe(
     Effect.mapError((cause) => operationalError('config', 'load', 'invalid runtime configuration', cause)),
     Effect.flatMap((config) =>
@@ -236,7 +244,7 @@ export const loadConfig = (
     }),
     Effect.flatMap((config) =>
       Effect.try({
-        try: (): RuntimeConfig => {
+        try: (): LoadedRuntimeConfig => {
           if (embedded === undefined && config.provenanceMode !== 'development') {
             throw new Error('production provenance requires compile-time build metadata')
           }

--- a/services/bayn/src/health.test.ts
+++ b/services/bayn/src/health.test.ts
@@ -14,7 +14,7 @@ import { EvidenceStore } from './db/evidence-store'
 import type { BrokerProbe } from './health'
 import { Journal, type JournalService } from './ledger'
 import { MarketData, type MarketDataService } from './market-data'
-import { initialState } from './runtime-state'
+import { initialState, type RuntimeState } from './runtime-state'
 import { makeSnapshot } from './test-fixtures'
 
 const brokerAccountId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
@@ -64,6 +64,25 @@ const emptyCycleProjection = (): CycleOperationsProjection => ({
 const cycleObservability = (
   read: CycleObservabilityShape['read'] = () => Effect.succeed(emptyCycleProjection()),
 ): CycleObservabilityShape => ({ read })
+
+const provideHealthyDependencies = (
+  initial: RuntimeState,
+  effect: Effect.Effect<void, never, MarketData | Journal | EvidenceStore | CycleObservability>,
+) =>
+  effect.pipe(
+    Effect.provideService(MarketData, {
+      check: Effect.succeed(makeSnapshot().manifest.finalizedSnapshot),
+      inspect: Effect.die(new Error('health probes must not inspect sessions')),
+      inspectCyclePublications: Effect.die(new Error('health probes must not inspect cycle publication candidates')),
+      inspectPublication: () => Effect.die(new Error('health probes must not inspect cycle publications')),
+      inspectSnapshotPublication: () =>
+        Effect.die(new Error('health probes must not inspect bound cycle publications')),
+      load: Effect.die(new Error('health probes must not load bars')),
+    }),
+    Effect.provideService(Journal, { ...successfulJournal, checkRun: () => Effect.void }),
+    Effect.provideService(EvidenceStore, recoveringStore(initial)),
+    Effect.provideService(CycleObservability, cycleObservability()),
+  )
 
 describe('Bayn continuous health', () => {
   test('requires the configured broker account GET while keeping execution disabled under OBSERVE', async () => {
@@ -289,6 +308,212 @@ describe('Bayn continuous health', () => {
     await Effect.runPromise(Deferred.await(started))
     await Effect.runPromise(Fiber.interrupt(fiber))
     expect(interrupted).toBe(true)
+  })
+
+  test('degrades on the latest cycle pass failure and requires a later success before the stall boundary', async () => {
+    const startedAt = '2026-07-20T00:00:00.000Z'
+    const initial: RuntimeState = {
+      ...readyState(),
+      autonomousCycleLoop: {
+        configured: true,
+        startedAt,
+        lastPass: {
+          result: 'FAILURE',
+          observedAt: '2026-07-20T00:00:59.000Z',
+          operation: 'market-calendar',
+          failure: 'calendar-read',
+          message: 'authoritative calendar unavailable',
+        },
+      },
+    }
+    const state = await Effect.runPromise(Ref.make(initial))
+    const program = Effect.scoped(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse('2026-07-20T00:01:00.000Z'))
+        const cycleFiber = yield* Effect.never.pipe(Effect.forkScoped({ startImmediately: true }))
+
+        yield* provideHealthyDependencies(initial, probe(config, state, undefined, cycleFiber))
+        expect(yield* Ref.get(state)).toMatchObject({
+          status: 'DEGRADED',
+          health: {
+            dependencies: {
+              cycleRunner: {
+                status: 'UNAVAILABLE',
+                error: 'market-calendar/calendar-read: authoritative calendar unavailable',
+              },
+            },
+          },
+          error: expect.stringContaining(
+            'cycleRunner: market-calendar/calendar-read: authoritative calendar unavailable',
+          ),
+        })
+
+        yield* Ref.update(
+          state,
+          (current): RuntimeState => ({
+            ...current,
+            autonomousCycleLoop: {
+              ...current.autonomousCycleLoop,
+              lastPass: {
+                result: 'SUCCESS',
+                observedAt: '2026-07-20T00:01:00.000Z',
+                outcome: 'NO_PUBLICATION',
+              },
+            },
+          }),
+        )
+        yield* provideHealthyDependencies(initial, probe(config, state, undefined, cycleFiber))
+        expect(yield* Ref.get(state)).toMatchObject({
+          status: 'READY',
+          health: { dependencies: { cycleRunner: { status: 'AVAILABLE', error: null } } },
+          error: null,
+        })
+
+        yield* TestClock.adjust(config.cycleStallThresholdMs - 1)
+        yield* provideHealthyDependencies(initial, probe(config, state, undefined, cycleFiber))
+        expect(yield* Ref.get(state)).toMatchObject({
+          status: 'READY',
+          health: { dependencies: { cycleRunner: { status: 'AVAILABLE' } } },
+        })
+
+        yield* TestClock.adjust(1)
+        yield* provideHealthyDependencies(initial, probe(config, state, undefined, cycleFiber))
+        expect(yield* Ref.get(state)).toMatchObject({
+          status: 'DEGRADED',
+          health: {
+            dependencies: {
+              cycleRunner: {
+                status: 'UNAVAILABLE',
+                error: `autonomous cycle loop has not completed a successful pass for ${config.cycleStallThresholdMs}ms`,
+              },
+            },
+          },
+        })
+      }),
+    ).pipe(Effect.provide(TestClock.layer()))
+
+    await Effect.runPromise(program)
+  })
+
+  test('surfaces an unexpected autonomous cycle fiber exit through existing health', async () => {
+    const initial: RuntimeState = {
+      ...readyState(),
+      autonomousCycleLoop: {
+        configured: true,
+        startedAt: '2026-07-20T00:00:00.000Z',
+        lastPass: {
+          result: 'SUCCESS',
+          observedAt: '2026-07-20T00:00:00.000Z',
+          outcome: 'NO_PUBLICATION',
+        },
+      },
+    }
+    const state = await Effect.runPromise(Ref.make(initial))
+    const program = Effect.scoped(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse('2026-07-20T00:00:01.000Z'))
+        const failedFiber = yield* Effect.die(new Error('injected autonomous cycle defect')).pipe(
+          Effect.forkScoped({ startImmediately: true }),
+        )
+        yield* Effect.yieldNow
+        yield* provideHealthyDependencies(initial, probe(config, state, undefined, failedFiber))
+        expect(yield* Ref.get(state)).toMatchObject({
+          status: 'DEGRADED',
+          health: {
+            dependencies: {
+              cycleRunner: {
+                status: 'UNAVAILABLE',
+                error: expect.stringContaining('injected autonomous cycle defect'),
+              },
+            },
+          },
+        })
+      }),
+    ).pipe(Effect.provide(TestClock.layer()))
+
+    await Effect.runPromise(program)
+  })
+
+  test('does not erase a loop failure recorded while a health probe is in flight', async () => {
+    const initial: RuntimeState = {
+      ...readyState(),
+      autonomousCycleLoop: {
+        configured: true,
+        startedAt: '2026-07-20T00:00:00.000Z',
+        lastPass: {
+          result: 'SUCCESS',
+          observedAt: '2026-07-20T00:00:00.000Z',
+          outcome: 'NO_PUBLICATION',
+        },
+      },
+    }
+    const state = await Effect.runPromise(Ref.make(initial))
+    const started = await Effect.runPromise(Deferred.make<void>())
+    const release = await Effect.runPromise(Deferred.make<void>())
+    const marketData: MarketDataService = {
+      check: Deferred.succeed(started, undefined).pipe(
+        Effect.andThen(Deferred.await(release)),
+        Effect.as(makeSnapshot().manifest.finalizedSnapshot),
+      ),
+      inspect: Effect.die(new Error('health probes must not inspect sessions')),
+      inspectCyclePublications: Effect.die(new Error('health probes must not inspect cycle publication candidates')),
+      inspectPublication: () => Effect.die(new Error('health probes must not inspect cycle publications')),
+      inspectSnapshotPublication: () =>
+        Effect.die(new Error('health probes must not inspect bound cycle publications')),
+      load: Effect.die(new Error('health probes must not load bars')),
+    }
+    const program = Effect.scoped(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse('2026-07-20T00:01:00.000Z'))
+        const cycleFiber = yield* Effect.never.pipe(Effect.forkScoped({ startImmediately: true }))
+        const healthFiber = yield* probe(config, state, undefined, cycleFiber).pipe(
+          Effect.provideService(MarketData, marketData),
+          Effect.provideService(Journal, { ...successfulJournal, checkRun: () => Effect.void }),
+          Effect.provideService(EvidenceStore, recoveringStore(initial)),
+          Effect.provideService(CycleObservability, cycleObservability()),
+          Effect.forkScoped({ startImmediately: true }),
+        )
+        yield* Deferred.await(started)
+        yield* Ref.update(
+          state,
+          (current): RuntimeState => ({
+            ...current,
+            autonomousCycleLoop: {
+              ...current.autonomousCycleLoop,
+              lastPass: {
+                result: 'FAILURE',
+                observedAt: '2026-07-20T00:01:00.000Z',
+                operation: 'market-calendar',
+                failure: 'calendar-read',
+                message: 'failure recorded during health I/O',
+              },
+            },
+          }),
+        )
+        yield* Deferred.succeed(release, undefined)
+        yield* Fiber.join(healthFiber)
+
+        expect(yield* Ref.get(state)).toMatchObject({
+          status: 'DEGRADED',
+          autonomousCycleLoop: {
+            lastPass: {
+              result: 'FAILURE',
+              message: 'failure recorded during health I/O',
+            },
+          },
+          health: {
+            dependencies: {
+              cycleRunner: {
+                status: 'UNAVAILABLE',
+                error: 'market-calendar/calendar-read: failure recorded during health I/O',
+              },
+            },
+          },
+        })
+      }),
+    ).pipe(Effect.provide(TestClock.layer()))
+
+    await Effect.runPromise(program)
   })
 
   test('treats the stall threshold as exclusive and clears only after a later terminal success', async () => {

--- a/services/bayn/src/health.test.ts
+++ b/services/bayn/src/health.test.ts
@@ -77,6 +77,7 @@ const provideHealthyDependencies = (
       inspectPublication: () => Effect.die(new Error('health probes must not inspect cycle publications')),
       inspectSnapshotPublication: () =>
         Effect.die(new Error('health probes must not inspect bound cycle publications')),
+      loadSnapshotPublication: () => Effect.die(new Error('health probes must not load bound cycle bars')),
       load: Effect.die(new Error('health probes must not load bars')),
     }),
     Effect.provideService(Journal, { ...successfulJournal, checkRun: () => Effect.void }),
@@ -460,6 +461,7 @@ describe('Bayn continuous health', () => {
       inspectPublication: () => Effect.die(new Error('health probes must not inspect cycle publications')),
       inspectSnapshotPublication: () =>
         Effect.die(new Error('health probes must not inspect bound cycle publications')),
+      loadSnapshotPublication: () => Effect.die(new Error('health probes must not load bound cycle bars')),
       load: Effect.die(new Error('health probes must not load bars')),
     }
     const program = Effect.scoped(

--- a/services/bayn/src/health.ts
+++ b/services/bayn/src/health.ts
@@ -1,4 +1,4 @@
-import { Cause, Clock, Duration, Effect, Exit, Option, Ref, Schedule } from 'effect'
+import { Cause, Clock, Duration, Effect, Exit, Fiber, Option, Ref, Schedule } from 'effect'
 
 import type { BrokerReadShape } from './broker/alpaca'
 import type { RuntimeConfig } from './config'
@@ -16,6 +16,7 @@ import { Journal } from './ledger'
 import { MarketData } from './market-data'
 import { databaseOperation, withinDeadline } from './operations'
 import type {
+  AutonomousCycleLoopStatus,
   BrokerConfiguration,
   BrokerStatus,
   DependencyHealth,
@@ -130,10 +131,46 @@ const dependencyHealth = (result: ProbeResult, checkedAt: string): DependencyHea
   error: result.error,
 })
 
+const cycleLoopAge = (instant: string, checkedAtMs: number): number | undefined => {
+  const age = checkedAtMs - Date.parse(instant)
+  return Number.isFinite(age) && age >= 0 ? age : undefined
+}
+
+const cycleLoopHealth = (
+  loop: AutonomousCycleLoopStatus,
+  fiber: Fiber.Fiber<void, never> | undefined,
+  exit: Option.Option<Exit.Exit<void, never>>,
+  checkedAt: string,
+  checkedAtMs: number,
+  stallThresholdMs: number,
+): DependencyHealth => {
+  const available = (): DependencyHealth => ({ status: 'AVAILABLE', checkedAt, error: null })
+  const unavailable = (error: string): DependencyHealth => ({ status: 'UNAVAILABLE', checkedAt, error })
+  if (!loop.configured) return available()
+  if (fiber === undefined) return unavailable('configured autonomous cycle loop has no scoped fiber')
+  if (Option.isSome(exit)) {
+    if (Exit.isSuccess(exit.value)) return unavailable('autonomous cycle loop exited unexpectedly')
+    const errors = Cause.prettyErrors(exit.value.cause).map((error) => error.message)
+    return unavailable(`autonomous cycle loop failed: ${errors.join('; ') || Cause.pretty(exit.value.cause)}`)
+  }
+  if (loop.lastPass?.result === 'FAILURE') {
+    return unavailable(`${loop.lastPass.operation}/${loop.lastPass.failure}: ${loop.lastPass.message}`)
+  }
+  const progressAt = loop.lastPass?.observedAt ?? loop.startedAt
+  if (progressAt === null) return unavailable('autonomous cycle loop start time is unavailable')
+  const ageMs = cycleLoopAge(progressAt, checkedAtMs)
+  if (ageMs === undefined) return unavailable('autonomous cycle loop progress time is invalid or in the future')
+  if (ageMs >= stallThresholdMs) {
+    return unavailable(`autonomous cycle loop has not completed a successful pass for ${ageMs}ms`)
+  }
+  return available()
+}
+
 export const probe = (
   config: RuntimeConfig,
   state: Ref.Ref<RuntimeState>,
   broker?: BrokerProbe,
+  autonomousCycleFiber?: Fiber.Fiber<void, never>,
 ): Effect.Effect<void, never, MarketData | Journal | EvidenceStore | CycleObservability> =>
   Effect.gen(function* () {
     const marketData = yield* MarketData
@@ -210,94 +247,114 @@ export const probe = (
       ],
       { concurrency: 'unbounded' },
     )
-    const checkedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
-    const cycle =
-      cycleResult.error === null && cycleResult.value !== null
-        ? deriveCycleOperationsStatus(cycleResult.value, Date.parse(checkedAt), config.maximumAuthority, config)
-        : {
-            ...unknownCycleOperationsStatus(cycleResult.error ?? 'cycle observability probe did not run'),
-            checkedAt,
-          }
-    let brokerStatus: BrokerStatus | null = current.broker
-    if (broker !== undefined) {
-      const result = brokerResult ?? { accountId: null, error: 'broker probe did not run' }
-      const accountBound = result.error === null && result.accountId === broker.expectedAccountId
-      const bindingError =
-        result.error ??
-        (accountBound
-          ? null
-          : `Alpaca account probe resolved ${result.accountId ?? 'no account'}, expected ${broker.expectedAccountId}`)
-      brokerStatus = {
-        configured: true,
-        expectedAccountId: broker.expectedAccountId,
-        accountId: result.accountId,
-        accountBound,
-        readAvailable: result.error === null,
+    const checkedAtMs = yield* Clock.currentTimeMillis
+    const checkedAt = new Date(checkedAtMs).toISOString()
+    const autonomousCycleExit = Option.fromNullishOr(autonomousCycleFiber?.pollUnsafe())
+    const transition = yield* Ref.modify(state, (latest) => {
+      const autonomousCycle = cycleLoopHealth(
+        latest.autonomousCycleLoop,
+        autonomousCycleFiber,
+        autonomousCycleExit,
         checkedAt,
-        error: bindingError,
-        executionEligible: broker.executionEligible,
-        executionDisabledReason: broker.executionDisabledReason,
+        checkedAtMs,
+        config.cycleStallThresholdMs,
+      )
+      const cycle =
+        cycleResult.error === null && cycleResult.value !== null
+          ? deriveCycleOperationsStatus(cycleResult.value, Date.parse(checkedAt), config.maximumAuthority, config)
+          : {
+              ...unknownCycleOperationsStatus(cycleResult.error ?? 'cycle observability probe did not run'),
+              checkedAt,
+            }
+      let brokerStatus: BrokerStatus | null = latest.broker
+      if (broker !== undefined) {
+        const result = brokerResult ?? { accountId: null, error: 'broker probe did not run' }
+        const accountBound = result.error === null && result.accountId === broker.expectedAccountId
+        const bindingError =
+          result.error ??
+          (accountBound
+            ? null
+            : `Alpaca account probe resolved ${result.accountId ?? 'no account'}, expected ${broker.expectedAccountId}`)
+        brokerStatus = {
+          configured: true,
+          expectedAccountId: broker.expectedAccountId,
+          accountId: result.accountId,
+          accountBound,
+          readAvailable: result.error === null,
+          checkedAt,
+          error: bindingError,
+          executionEligible: broker.executionEligible,
+          executionDisabledReason: broker.executionDisabledReason,
+        }
       }
-    }
-    const health: RuntimeHealth = {
-      sequence: current.health.sequence + 1,
-      checkedAt,
-      dependencies: {
-        postgresql: dependencyHealth(postgresql, checkedAt),
-        signal: dependencyHealth(signal, checkedAt),
-        tigerBeetle: dependencyHealth(tigerBeetle, checkedAt),
-        evidence: dependencyHealth(durableEvidence, checkedAt),
-        cycle: dependencyHealth(cycleResult, checkedAt),
-      },
-    }
-    const dependencyFailures = Object.entries(health.dependencies).filter(([, dependency]) => dependency.error !== null)
-    const failedDependencies = dependencyFailures.map(([name]) => name)
-    const failureMessages = dependencyFailures.map(([name, dependency]) => `${name}: ${dependency.error}`)
-    if (
-      brokerStatus !== null &&
-      (brokerStatus.error !== null || brokerStatus.accountBound !== true || brokerStatus.readAvailable !== true)
-    ) {
-      failedDependencies.push('broker')
-      failureMessages.push(`broker: ${brokerStatus.error ?? 'account binding unavailable'}`)
-    }
-    if (cycle.condition === CycleOperationsCondition.Stalled || cycle.condition === CycleOperationsCondition.Failed) {
-      if (!failedDependencies.includes('cycle')) failedDependencies.push('cycle')
-      failureMessages.push(`cycle: ${cycle.reason}`)
-    }
-    let next: RuntimeState = { ...current, health, cycle, broker: brokerStatus }
-    if (evidence !== null && failureMessages.length === 0) {
-      next = {
-        ...current,
-        status: 'READY',
-        health,
-        cycle,
-        broker: brokerStatus,
-        error: null,
+      const health: RuntimeHealth = {
+        sequence: latest.health.sequence + 1,
+        checkedAt,
+        dependencies: {
+          postgresql: dependencyHealth(postgresql, checkedAt),
+          signal: dependencyHealth(signal, checkedAt),
+          tigerBeetle: dependencyHealth(tigerBeetle, checkedAt),
+          evidence: dependencyHealth(durableEvidence, checkedAt),
+          cycle: dependencyHealth(cycleResult, checkedAt),
+          cycleRunner: autonomousCycle,
+        },
       }
-    } else if (evidence !== null) {
-      next = {
-        ...current,
-        status: 'DEGRADED',
-        health,
-        cycle,
-        broker: brokerStatus,
-        error: failureMessages.join('; '),
+      const dependencyFailures = Object.entries(health.dependencies).filter(
+        ([, dependency]) => dependency.error !== null,
+      )
+      const failedDependencies = dependencyFailures.map(([name]) => name)
+      const failureMessages = dependencyFailures.map(([name, dependency]) => `${name}: ${dependency.error}`)
+      if (
+        brokerStatus !== null &&
+        (brokerStatus.error !== null || brokerStatus.accountBound !== true || brokerStatus.readAvailable !== true)
+      ) {
+        failedDependencies.push('broker')
+        failureMessages.push(`broker: ${brokerStatus.error ?? 'account binding unavailable'}`)
       }
-    }
-    yield* Ref.set(state, next)
+      if (cycle.condition === CycleOperationsCondition.Stalled || cycle.condition === CycleOperationsCondition.Failed) {
+        if (!failedDependencies.includes('cycle')) failedDependencies.push('cycle')
+        failureMessages.push(`cycle: ${cycle.reason}`)
+      }
+      let next: RuntimeState = { ...latest, health, cycle, broker: brokerStatus }
+      if (evidence !== null && failureMessages.length === 0) {
+        next = {
+          ...latest,
+          status: 'READY',
+          health,
+          cycle,
+          broker: brokerStatus,
+          error: null,
+        }
+      } else if (evidence !== null) {
+        next = {
+          ...latest,
+          status: 'DEGRADED',
+          health,
+          cycle,
+          broker: brokerStatus,
+          error: failureMessages.join('; '),
+        }
+      }
+      return [{ current: latest, next, health, failedDependencies }, next] as const
+    })
 
-    if (next.status !== current.status) {
+    if (transition.next.status !== transition.current.status) {
+      const next = transition.next
       const log = next.status === 'READY' ? Effect.logInfo : Effect.logWarning
       yield* log(`Bayn health changed to ${next.status}`).pipe(
         Effect.annotateLogs({
           service: 'bayn',
           checkedAt,
-          probeSequence: health.sequence,
-          failedDependencies: failedDependencies.join(','),
+          probeSequence: transition.health.sequence,
+          failedDependencies: transition.failedDependencies.join(','),
         }),
       )
     }
-    if (next.cycle.condition !== current.cycle.condition || next.cycle.reason !== current.cycle.reason) {
+    if (
+      transition.next.cycle.condition !== transition.current.cycle.condition ||
+      transition.next.cycle.reason !== transition.current.cycle.reason
+    ) {
+      const next = transition.next
       const cycleObservationAvailable = next.cycle.condition !== CycleOperationsCondition.Unknown
       const log =
         next.cycle.condition === CycleOperationsCondition.Stalled ||
@@ -327,8 +384,9 @@ export const monitor = (
   config: RuntimeConfig,
   state: Ref.Ref<RuntimeState>,
   broker?: BrokerProbe,
+  autonomousCycleFiber?: Fiber.Fiber<void, never>,
 ): Effect.Effect<void, never, MarketData | Journal | EvidenceStore | CycleObservability> =>
-  probe(config, state, broker).pipe(
+  probe(config, state, broker, autonomousCycleFiber).pipe(
     Effect.repeat(Schedule.spaced(Duration.millis(config.healthIntervalMs))),
     Effect.asVoid,
   )

--- a/services/bayn/src/http.test.ts
+++ b/services/bayn/src/http.test.ts
@@ -110,7 +110,7 @@ describe('Bayn HTTP probes', () => {
           expect(metricsResponse.headers.get('content-type')).toContain('text/plain')
           expect(metrics).toContain('bayn_cycle_condition{condition="waiting"} 1')
           expect(metrics).toContain('bayn_autonomous_cycle_loop_configured 0')
-          expect(metrics).toContain('bayn_autonomous_cycle_loop_health_available 1')
+          expect(metrics).toContain('bayn_autonomous_cycle_loop_health_available 0')
           expect(metrics).toContain('bayn_autonomous_cycle_loop_last_pass{result="unknown"} 1')
           expect(metrics).toContain('bayn_mutation_events_total 0')
           expect(metrics).toContain('bayn_broker_orders_enabled 0')

--- a/services/bayn/src/http.test.ts
+++ b/services/bayn/src/http.test.ts
@@ -18,7 +18,7 @@ import { DatabaseError, type EvidenceStoreService } from './db/evidence-store'
 import type { BrokerProbe } from './health'
 import { makeHttpLayer, renderPrometheusMetrics } from './http'
 import { Authority } from './paper'
-import { initialState } from './runtime-state'
+import { initialState, type RuntimeState } from './runtime-state'
 
 describe('Bayn HTTP probes', () => {
   test('serves every route from the current runtime state and closes its socket', async () => {
@@ -75,6 +75,11 @@ describe('Bayn HTTP probes', () => {
                 zeroMutation: true,
                 mutations: { eventCount: 0, unresolvedCount: 0 },
               },
+              autonomousCycleLoop: {
+                configured: false,
+                startedAt: null,
+                lastPass: null,
+              },
               authority: { maximum: 'observe', brokerOrders: false, capitalPromotion: false },
               broker: {
                 configured: false,
@@ -104,6 +109,9 @@ describe('Bayn HTTP probes', () => {
           expect(metricsResponse.status).toBe(200)
           expect(metricsResponse.headers.get('content-type')).toContain('text/plain')
           expect(metrics).toContain('bayn_cycle_condition{condition="waiting"} 1')
+          expect(metrics).toContain('bayn_autonomous_cycle_loop_configured 0')
+          expect(metrics).toContain('bayn_autonomous_cycle_loop_health_available 1')
+          expect(metrics).toContain('bayn_autonomous_cycle_loop_last_pass{result="unknown"} 1')
           expect(metrics).toContain('bayn_mutation_events_total 0')
           expect(metrics).toContain('bayn_broker_orders_enabled 0')
           expect(metrics).toContain('bayn_capital_promotion_enabled 0')
@@ -165,6 +173,98 @@ describe('Bayn HTTP probes', () => {
       rejected = true
     }
     expect(rejected).toBe(true)
+  })
+
+  test('keeps a typed latest loop failure visible and makes readiness and metrics fail closed', async () => {
+    const failedAt = '2026-07-20T00:00:00.000Z'
+    const failedState: RuntimeState = {
+      ...readyState(),
+      status: 'DEGRADED',
+      health: {
+        ...readyState().health,
+        dependencies: {
+          ...readyState().health.dependencies,
+          cycleRunner: {
+            status: 'UNAVAILABLE',
+            checkedAt: failedAt,
+            error: 'market-calendar/calendar-read: authoritative calendar unavailable',
+          },
+        },
+      },
+      autonomousCycleLoop: {
+        configured: true,
+        startedAt: failedAt,
+        lastPass: {
+          result: 'FAILURE',
+          observedAt: failedAt,
+          operation: 'market-calendar',
+          failure: 'calendar-read',
+          message: 'authoritative calendar unavailable',
+        },
+      },
+      error: 'cycleRunner: market-calendar/calendar-read: authoritative calendar unavailable',
+    }
+
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const state = yield* Ref.make(failedState)
+          const context = yield* Layer.build(
+            makeHttpLayer(
+              {
+                cycleStallThresholdMs: config.cycleStallThresholdMs,
+                host: '127.0.0.1',
+                maximumAuthority: Authority.Observe,
+                operationTimeoutMs: 250,
+                port: 0,
+                reconciliationStaleThresholdMs: config.reconciliationStaleThresholdMs,
+                unknownMutationThresholdMs: config.unknownMutationThresholdMs,
+              },
+              state,
+              provenance,
+              'embedded',
+              successfulEvidenceStore.read,
+            ),
+          )
+          const address = Context.get(context, HttpServer.HttpServer).address
+          if (address._tag !== 'TcpAddress') throw new Error('test server did not bind a TCP port')
+
+          expect(yield* Effect.promise(() => fetchJson(address.port, '/readyz'))).toMatchObject({
+            status: 503,
+            body: {
+              ready: false,
+              status: 'DEGRADED',
+              failedDependencies: expect.arrayContaining(['cycleRunner']),
+            },
+          })
+          expect(yield* Effect.promise(() => fetchJson(address.port, '/v1/status'))).toMatchObject({
+            status: 200,
+            body: {
+              autonomousCycleLoop: {
+                configured: true,
+                startedAt: failedAt,
+                lastPass: {
+                  result: 'FAILURE',
+                  observedAt: failedAt,
+                  operation: 'market-calendar',
+                  failure: 'calendar-read',
+                  message: 'authoritative calendar unavailable',
+                },
+              },
+            },
+          })
+          const metrics = yield* Effect.promise(() =>
+            fetch(`http://127.0.0.1:${address.port}/metrics`).then((response) => response.text()),
+          )
+          expect(metrics).toContain('bayn_autonomous_cycle_loop_configured 1')
+          expect(metrics).toContain('bayn_autonomous_cycle_loop_health_available 0')
+          expect(metrics).toContain('bayn_autonomous_cycle_loop_last_pass{result="failure"} 1')
+          expect(metrics).toContain(
+            `bayn_autonomous_cycle_loop_last_pass_timestamp_seconds ${Date.parse(failedAt) / 1_000}`,
+          )
+        }),
+      ),
+    )
   })
 
   test('returns service unavailable when durable evidence cannot be read', async () => {

--- a/services/bayn/src/http.ts
+++ b/services/bayn/src/http.ts
@@ -97,6 +97,7 @@ const publicState = (
       reconciliation: state.evidence?.reconciliation ?? null,
     },
     cycle: publicCycleState(state),
+    autonomousCycleLoop: state.autonomousCycleLoop,
     broker: publicBrokerState(state),
     authority: {
       maximum: maximumAuthority === Authority.Paper ? 'paper' : 'observe',
@@ -164,6 +165,15 @@ export const renderPrometheusMetrics = (
   const conditions = Object.values(CycleOperationsCondition)
   const reasons = Object.values(CycleOperationsReason)
   const phases = ['unknown', 'none', ...Object.values(CycleState).map((phase) => phase.toLowerCase())]
+  const loopResults = ['unknown', 'success', 'failure'] as const
+  const loopResult = state.autonomousCycleLoop.lastPass?.result.toLowerCase() ?? 'unknown'
+  const loopHealthy =
+    state.health.dependencies.cycleRunner.status === 'AVAILABLE' &&
+    state.autonomousCycleLoop.lastPass?.result !== 'FAILURE'
+  const loopLastPassAgeMs =
+    state.autonomousCycleLoop.lastPass === null || state.health.checkedAt === null
+      ? undefined
+      : Math.max(0, Date.parse(state.health.checkedAt) - Date.parse(state.autonomousCycleLoop.lastPass.observedAt))
   const effectiveAuthority =
     state.cycle.authority === null
       ? 'unknown'
@@ -210,6 +220,27 @@ export const renderPrometheusMetrics = (
     '# HELP bayn_cycle_stall_threshold_seconds Configured attempt-stall threshold.',
     '# TYPE bayn_cycle_stall_threshold_seconds gauge',
     `bayn_cycle_stall_threshold_seconds ${prometheusNumber(config.cycleStallThresholdMs / 1_000)}`,
+    '# HELP bayn_autonomous_cycle_loop_configured Whether the in-process autonomous cycle loop is configured.',
+    '# TYPE bayn_autonomous_cycle_loop_configured gauge',
+    `bayn_autonomous_cycle_loop_configured ${state.autonomousCycleLoop.configured ? 1 : 0}`,
+    '# HELP bayn_autonomous_cycle_loop_health_available Whether the scoped loop is live and its latest pass succeeded.',
+    '# TYPE bayn_autonomous_cycle_loop_health_available gauge',
+    `bayn_autonomous_cycle_loop_health_available ${loopHealthy ? 1 : 0}`,
+    '# HELP bayn_autonomous_cycle_loop_last_pass Latest bounded autonomous cycle pass result.',
+    '# TYPE bayn_autonomous_cycle_loop_last_pass gauge',
+    ...loopResults.map(
+      (result) => `bayn_autonomous_cycle_loop_last_pass{result="${result}"} ${loopResult === result ? 1 : 0}`,
+    ),
+    ...(state.autonomousCycleLoop.lastPass === null
+      ? []
+      : [
+          '# HELP bayn_autonomous_cycle_loop_last_pass_timestamp_seconds Observation time of the latest cycle pass.',
+          '# TYPE bayn_autonomous_cycle_loop_last_pass_timestamp_seconds gauge',
+          `bayn_autonomous_cycle_loop_last_pass_timestamp_seconds ${prometheusNumber(epochSeconds(state.autonomousCycleLoop.lastPass.observedAt))}`,
+          '# HELP bayn_autonomous_cycle_loop_last_pass_age_seconds Age of the latest cycle pass at the last health probe.',
+          '# TYPE bayn_autonomous_cycle_loop_last_pass_age_seconds gauge',
+          `bayn_autonomous_cycle_loop_last_pass_age_seconds ${prometheusNumber((loopLastPassAgeMs ?? 0) / 1_000)}`,
+        ]),
     ...(cycleObservationAvailable
       ? [
           '# HELP bayn_mutation_events_total Durable broker mutation event count.',
@@ -324,6 +355,9 @@ export const makeHttpLayer = (
         current.cycle.condition === CycleOperationsCondition.Failed
       ) {
         if (!failedDependencies.includes('cycle')) failedDependencies.push('cycle')
+      }
+      if (current.autonomousCycleLoop.lastPass?.result === 'FAILURE' && !failedDependencies.includes('cycleRunner')) {
+        failedDependencies.push('cycleRunner')
       }
       return jsonResponse(
         {

--- a/services/bayn/src/http.ts
+++ b/services/bayn/src/http.ts
@@ -168,6 +168,7 @@ export const renderPrometheusMetrics = (
   const loopResults = ['unknown', 'success', 'failure'] as const
   const loopResult = state.autonomousCycleLoop.lastPass?.result.toLowerCase() ?? 'unknown'
   const loopHealthy =
+    state.autonomousCycleLoop.configured &&
     state.health.dependencies.cycleRunner.status === 'AVAILABLE' &&
     state.autonomousCycleLoop.lastPass?.result !== 'FAILURE'
   const loopLastPassAgeMs =
@@ -223,7 +224,7 @@ export const renderPrometheusMetrics = (
     '# HELP bayn_autonomous_cycle_loop_configured Whether the in-process autonomous cycle loop is configured.',
     '# TYPE bayn_autonomous_cycle_loop_configured gauge',
     `bayn_autonomous_cycle_loop_configured ${state.autonomousCycleLoop.configured ? 1 : 0}`,
-    '# HELP bayn_autonomous_cycle_loop_health_available Whether the scoped loop is live and its latest pass succeeded.',
+    '# HELP bayn_autonomous_cycle_loop_health_available Whether the configured scoped loop is live and its latest pass succeeded.',
     '# TYPE bayn_autonomous_cycle_loop_health_available gauge',
     `bayn_autonomous_cycle_loop_health_available ${loopHealthy ? 1 : 0}`,
     '# HELP bayn_autonomous_cycle_loop_last_pass Latest bounded autonomous cycle pass result.',

--- a/services/bayn/src/http.ts
+++ b/services/bayn/src/http.ts
@@ -224,7 +224,7 @@ export const renderPrometheusMetrics = (
     '# HELP bayn_autonomous_cycle_loop_configured Whether the in-process autonomous cycle loop is configured.',
     '# TYPE bayn_autonomous_cycle_loop_configured gauge',
     `bayn_autonomous_cycle_loop_configured ${state.autonomousCycleLoop.configured ? 1 : 0}`,
-    '# HELP bayn_autonomous_cycle_loop_health_available Whether the configured scoped loop is live and its latest pass succeeded.',
+    '# HELP bayn_autonomous_cycle_loop_health_available Whether the configured scoped loop is live and has not failed or stalled.',
     '# TYPE bayn_autonomous_cycle_loop_health_available gauge',
     `bayn_autonomous_cycle_loop_health_available ${loopHealthy ? 1 : 0}`,
     '# HELP bayn_autonomous_cycle_loop_last_pass Latest bounded autonomous cycle pass result.',

--- a/services/bayn/src/index.ts
+++ b/services/bayn/src/index.ts
@@ -140,16 +140,6 @@ const main = Effect.gen(function* () {
       )
       reconciliation = runContinuously(config.alpaca.reconciliationIntervalMs).pipe(Effect.provide(paperExecution))
     } else {
-      const authorityGenerationHash = config.authorityGenerationHash
-      if (authorityGenerationHash === undefined) {
-        return yield* Effect.fail(
-          operationalError(
-            'config',
-            'authority-generation',
-            'OBSERVE autonomous cycle composition requires an authority generation hash',
-          ),
-        )
-      }
       const cycleStoreContext = yield* Layer.build(
         CycleStoreLive.pipe(Layer.provide(Layer.succeedContext(evidenceStore))),
       ).pipe(
@@ -164,7 +154,7 @@ const main = Effect.gen(function* () {
       )
       autonomousCycleStartup = makeObserveAutonomousCycleStartup({
         accountId: config.alpaca.accountId,
-        authorityGenerationHash,
+        authorityGenerationHash: config.alpaca.authorityGenerationHash,
         brokerRead,
         cycleStore: Context.get(cycleStoreContext, CycleStore),
         marketData: marketDataService,

--- a/services/bayn/src/index.ts
+++ b/services/bayn/src/index.ts
@@ -10,19 +10,21 @@ import { verifyBehaviorHash, verifyParameterHash } from './build'
 import { loadConfig } from './config'
 import { makeRuntimeProvenance } from './contracts'
 import { CycleObservabilityLive } from './db/cycle-observability'
+import { CycleStore, CycleStoreLive } from './db/cycle-store'
 import { EvidenceStoreLive } from './db/evidence-store'
-import { PaperStoreLive } from './db/paper-store'
+import { PaperStore, PaperStoreLive } from './db/paper-store'
 import { IntentStoreLive } from './execution/intents'
 import { MutationStoreLive } from './execution/mutations'
-import { WriterFenceLive } from './execution/writer-fence'
+import { WriterFence, WriterFenceLive } from './execution/writer-fence'
 import { operationalError } from './errors'
 import type { BrokerProbe } from './health'
 import { JournalLive } from './ledger'
-import { MarketDataLive } from './market-data'
+import { MarketData, MarketDataLive } from './market-data'
+import { makeObserveAutonomousCycleStartup } from './observe-composition'
 import { acquireSqlLayer } from './operations'
 import { Authority } from './paper'
 import { hashParameters, loadDefaultProtocol } from './protocol'
-import { runContinuously } from './reconciler'
+import { runContinuously, runOnce } from './reconciler'
 import { makeStrategy } from './strategy'
 
 const main = Effect.gen(function* () {
@@ -61,13 +63,16 @@ const main = Effect.gen(function* () {
     Layer.provide(Layer.succeedContext(clickhouse)),
     Layer.provide(NodeHttpClient.layerNodeHttp),
   )
+  const marketDataContext = yield* Layer.build(marketData)
+  const marketDataService = Context.get(marketDataContext, MarketData)
   const evidenceStore = yield* acquireSqlLayer(EvidenceStoreLive(config).pipe(Layer.provide(NodeServices.layer)))
   const cycleObservability = CycleObservabilityLive.pipe(Layer.provide(Layer.succeedContext(evidenceStore)))
   const journal = yield* acquireSqlLayer(JournalLive(config))
   let reconciliation = Effect.void
   let broker: BrokerProbe | undefined
+  let autonomousCycleStartup: Parameters<typeof run>[4]
   if (config.alpaca !== undefined) {
-    const brokerRead = yield* Layer.build(
+    const brokerReadContext = yield* Layer.build(
       AlpacaReadLive({
         expectedAccountId: config.alpaca.accountId,
         key: config.alpaca.key,
@@ -79,8 +84,9 @@ const main = Effect.gen(function* () {
     ).pipe(
       Effect.mapError((cause) => operationalError('config', 'alpaca', 'Alpaca paper account binding failed', cause)),
     )
+    const brokerRead = Context.get(brokerReadContext, BrokerRead)
     broker = {
-      read: Context.get(brokerRead, BrokerRead),
+      read: brokerRead,
       expectedAccountId: config.alpaca.accountId,
       executionEligible: false,
       executionDisabledReason:
@@ -88,20 +94,22 @@ const main = Effect.gen(function* () {
           ? 'MAXIMUM_AUTHORITY_OBSERVE'
           : 'PAPER_DISPATCH_REQUIRES_CYCLE_GATES',
     }
+    const storage = Layer.mergeAll(Layer.succeedContext(evidenceStore), Layer.succeedContext(journal))
+    const paperStoreContext = yield* Layer.build(PaperStoreLive(config).pipe(Layer.provide(storage))).pipe(
+      Effect.mapError((cause) =>
+        operationalError('database', 'paper-store', 'paper persistence composition failed', cause),
+      ),
+    )
+    const paperStore = Context.get(paperStoreContext, PaperStore)
+    const writerFenceContext = yield* Layer.build(
+      WriterFenceLive.pipe(Layer.provide(Layer.succeedContext(evidenceStore))),
+    ).pipe(
+      Effect.mapError((cause) =>
+        operationalError('database', 'writer-fence', 'paper writer fence acquisition failed', cause),
+      ),
+    )
+    const writerFence = Context.get(writerFenceContext, WriterFence)
     if (config.maximumAuthority === Authority.Paper) {
-      const storage = Layer.mergeAll(Layer.succeedContext(evidenceStore), Layer.succeedContext(journal))
-      const paperStore = yield* Layer.build(PaperStoreLive(config).pipe(Layer.provide(storage))).pipe(
-        Effect.mapError((cause) =>
-          operationalError('database', 'paper-store', 'paper persistence composition failed', cause),
-        ),
-      )
-      const writerFence = yield* Layer.build(
-        WriterFenceLive.pipe(Layer.provide(Layer.succeedContext(evidenceStore))),
-      ).pipe(
-        Effect.mapError((cause) =>
-          operationalError('database', 'writer-fence', 'paper writer fence acquisition failed', cause),
-        ),
-      )
       const brokerMutation = yield* Layer.build(
         Layer.effect(
           BrokerMutation,
@@ -119,27 +127,51 @@ const main = Effect.gen(function* () {
           operationalError('config', 'alpaca-mutation', 'Alpaca paper mutation binding failed', cause),
         ),
       )
-      const persistence = Layer.mergeAll(Layer.succeedContext(evidenceStore), Layer.succeedContext(writerFence))
+      const persistence = Layer.mergeAll(Layer.succeedContext(evidenceStore), Layer.succeed(WriterFence, writerFence))
       const intentStore = yield* Layer.build(IntentStoreLive.pipe(Layer.provide(persistence)))
       const mutationStore = yield* Layer.build(MutationStoreLive.pipe(Layer.provide(persistence)))
       const paperExecution = Layer.mergeAll(
-        Layer.succeedContext(brokerRead),
+        Layer.succeedContext(brokerReadContext),
         Layer.succeedContext(brokerMutation),
-        Layer.succeedContext(paperStore),
-        Layer.succeedContext(writerFence),
+        Layer.succeedContext(paperStoreContext),
+        Layer.succeedContext(writerFenceContext),
         Layer.succeedContext(intentStore),
         Layer.succeedContext(mutationStore),
       )
       reconciliation = runContinuously(config.alpaca.reconciliationIntervalMs).pipe(Effect.provide(paperExecution))
+    } else {
+      const cycleStoreContext = yield* Layer.build(
+        CycleStoreLive.pipe(Layer.provide(Layer.succeedContext(evidenceStore))),
+      ).pipe(
+        Effect.mapError((cause) =>
+          operationalError('database', 'cycle-store', 'cycle persistence composition failed', cause),
+        ),
+      )
+      const reconcile = runOnce.pipe(
+        Effect.provideService(BrokerRead, brokerRead),
+        Effect.provideService(PaperStore, paperStore),
+        Effect.provideService(WriterFence, writerFence),
+      )
+      autonomousCycleStartup = makeObserveAutonomousCycleStartup({
+        accountId: config.alpaca.accountId,
+        authorityGenerationHash: config.authorityGenerationHash,
+        brokerRead,
+        cycleStore: Context.get(cycleStoreContext, CycleStore),
+        marketData: marketDataService,
+        paperStore,
+        pollIntervalMs: config.cyclePollIntervalMs,
+        reconcile,
+        strategy,
+      })
     }
   }
   const dependencies = Layer.mergeAll(
-    marketData,
+    Layer.succeedContext(marketDataContext),
     cycleObservability,
     Layer.succeedContext(journal),
     Layer.succeedContext(evidenceStore),
   )
-  return yield* run(config, strategy, reconciliation, broker).pipe(Effect.provide(dependencies))
+  return yield* run(config, strategy, reconciliation, broker, autonomousCycleStartup).pipe(Effect.provide(dependencies))
 }).pipe(Effect.scoped)
 
 const program = main.pipe(Effect.annotateLogs({ service: 'bayn' }), Effect.provide(Logger.layer([Logger.consoleJson])))

--- a/services/bayn/src/index.ts
+++ b/services/bayn/src/index.ts
@@ -140,6 +140,16 @@ const main = Effect.gen(function* () {
       )
       reconciliation = runContinuously(config.alpaca.reconciliationIntervalMs).pipe(Effect.provide(paperExecution))
     } else {
+      const authorityGenerationHash = config.authorityGenerationHash
+      if (authorityGenerationHash === undefined) {
+        return yield* Effect.fail(
+          operationalError(
+            'config',
+            'authority-generation',
+            'OBSERVE autonomous cycle composition requires an authority generation hash',
+          ),
+        )
+      }
       const cycleStoreContext = yield* Layer.build(
         CycleStoreLive.pipe(Layer.provide(Layer.succeedContext(evidenceStore))),
       ).pipe(
@@ -154,7 +164,7 @@ const main = Effect.gen(function* () {
       )
       autonomousCycleStartup = makeObserveAutonomousCycleStartup({
         accountId: config.alpaca.accountId,
-        authorityGenerationHash: config.authorityGenerationHash,
+        authorityGenerationHash,
         brokerRead,
         cycleStore: Context.get(cycleStoreContext, CycleStore),
         marketData: marketDataService,

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -1,0 +1,377 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Effect } from 'effect'
+import { TestClock } from 'effect/testing'
+
+import type { MarketCalendarObservation, ReadResult } from './broker/alpaca'
+import {
+  CycleState,
+  decodeAutonomousCycle,
+  makeCycleDraft,
+  makeCycleExecutionPolicyFromModel,
+  makeCycleIdentity,
+  makeCycleWindow,
+  makeExecutionCalendarObservation,
+} from './cycle'
+import { canonicalHashV1 } from './hash'
+import type { MarketDataService, MarketDataSnapshot } from './market-data'
+import { buildObserveCycleDecision, loadObserveRiskPolicy } from './observe-composition'
+import {
+  AccountStatus,
+  Authority,
+  KillState,
+  ReconciliationStatus,
+  RiskOutcome,
+  type AccountSnapshot,
+  type Reconciliation,
+} from './paper'
+import type { ReconciliationPassResult } from './reconciler'
+import { reconciledStateHash } from './reconciliation'
+import { Reason } from './risk'
+import { fixtureProtocol, makeSnapshot } from './test-fixtures'
+import type { DecisionPlan } from './types'
+
+const signalDate = '2020-04-30'
+const executionDate = '2020-05-01'
+const accountId = 'paper-account-1'
+const snapshotId = '7'.repeat(64)
+const generationHash = 'a'.repeat(64)
+const accountingHash = 'b'.repeat(64)
+const reconciledAt = '2020-05-01T12:45:01.000Z'
+const evaluatedAt = '2020-05-01T12:45:02.000Z'
+
+const calendarMaterial = {
+  schemaVersion: 'bayn.alpaca-market-calendar-observation.v1' as const,
+  source: 'alpaca-v2-calendar' as const,
+  requestedRange: { start: signalDate, end: '2020-05-30' },
+  timeZone: 'UTC' as const,
+  sessions: [
+    {
+      date: signalDate,
+      openAt: '2020-04-30T13:30:00.000Z',
+      closeAt: '2020-04-30T20:00:00.000Z',
+    },
+    {
+      date: executionDate,
+      openAt: '2020-05-01T13:30:00.000Z',
+      closeAt: '2020-05-01T20:00:00.000Z',
+    },
+  ],
+}
+
+const calendar: MarketCalendarObservation = {
+  ...calendarMaterial,
+  normalizedResponseHash: canonicalHashV1(calendarMaterial),
+}
+
+const executionPolicy = makeCycleExecutionPolicyFromModel(fixtureProtocol.executionModel)
+const executionCalendar = makeExecutionCalendarObservation({
+  schemaVersion: calendar.schemaVersion,
+  source: calendar.source,
+  ...calendar.sessions[1],
+})
+const identity = makeCycleIdentity({
+  schemaVersion: 'bayn.autonomous-cycle-identity.v1',
+  strategyName: 'risk-balanced-trend',
+  qualificationRunId: 'c'.repeat(64),
+  strategyProtocolHash: 'd'.repeat(64),
+  accountId,
+  signalSessionDate: signalDate,
+  signalCalendarVersion: 'fixture-calendar-v2',
+  executionSessionDate: executionDate,
+  executionCalendarSchemaVersion: executionCalendar.executionCalendarSchemaVersion,
+  executionCalendarSource: executionCalendar.executionCalendarSource,
+  executionCalendarHash: executionCalendar.executionCalendarHash,
+  executionPolicy,
+})
+const window = makeCycleWindow(
+  {
+    calendar_version: 'fixture-calendar-v2',
+    session_date: signalDate,
+    close_time: '16:00',
+    timezone: 'America/New_York',
+  },
+  executionCalendar,
+  executionPolicy,
+)
+const draft = makeCycleDraft(identity, window)
+const cycle = Effect.runSync(
+  decodeAutonomousCycle({
+    ...draft,
+    state: CycleState.Active,
+    bindings: { snapshotId },
+    stateVersion: 3,
+    createdAt: '2020-05-01T12:44:00.000Z',
+    updatedAt: window.submissionOpenAt,
+  }),
+)
+
+const sourceSnapshot = makeSnapshot(1_129)
+const snapshot: MarketDataSnapshot = {
+  bars: sourceSnapshot.bars,
+  manifest: {
+    ...sourceSnapshot.manifest,
+    finalizedSnapshot: {
+      ...sourceSnapshot.manifest.finalizedSnapshot,
+      snapshotId,
+      finalizedAt: '2020-04-30T22:00:00.000Z',
+    },
+  },
+}
+
+const account: AccountSnapshot = {
+  schemaVersion: 'bayn.paper-account-snapshot.v1',
+  accountId,
+  status: AccountStatus.Active,
+  currency: 'USD',
+  cashMicros: '1000000000',
+  equityMicros: '1000000000',
+  buyingPowerMicros: '1000000000',
+  observedAt: reconciledAt,
+}
+
+const reconciliation = (): Reconciliation => {
+  const stateHash = reconciledStateHash({
+    account,
+    positions: [],
+    positionsObservedAt: reconciledAt,
+    orders: [],
+    ordersObservedAt: reconciledAt,
+    accountingHash,
+  })
+  const material = {
+    schemaVersion: 'bayn.paper-reconciliation.v1' as const,
+    accountId,
+    expectedHash: stateHash,
+    observedHash: stateHash,
+    status: ReconciliationStatus.Exact,
+    discrepancies: [],
+    reconciledAt,
+  }
+  const reconciliationId = canonicalHashV1({
+    schemaVersion: 'bayn.paper-reconciliation-id.v1',
+    material,
+  })
+  return {
+    ...material,
+    reconciliationId,
+    contentHash: canonicalHashV1({ ...material, reconciliationId }),
+  }
+}
+
+const reconciliationResult = (authorityGenerationHash = generationHash): ReconciliationPassResult => {
+  const exact = reconciliation()
+  return {
+    report: {
+      reconciliation: exact,
+      metrics: {
+        brokerPollAgeMs: 0,
+        oldestUnknownMutationAgeMs: 0,
+        cashDifferenceMicros: '0',
+        positionDifferenceMicros: '0',
+        equityDifferenceMicros: '0',
+        accountingExact: true,
+        discrepancyCount: 0,
+      },
+    },
+    brokerState: {
+      account,
+      positions: [],
+      positionsObservedAt: reconciledAt,
+      orders: [],
+      ordersObservedAt: reconciledAt,
+      accountingHash,
+      reconciliation: exact,
+      unknownOrderCount: 0,
+    },
+    riskContext: {
+      tradingDate: executionDate,
+      authority: {
+        schemaVersion: 'bayn.paper-authority.v1',
+        generationHash: authorityGenerationHash,
+        maximum: Authority.Observe,
+        effective: Authority.Observe,
+        kill: KillState.Clear,
+        version: 1,
+        updatedAt: window.submissionOpenAt,
+      },
+      authorityObservedAt: reconciledAt,
+      unknownMutationCount: 0,
+      dailyTradedNotionalMicros: '0',
+      dayStartEquityMicros: account.equityMicros,
+      peakEquityMicros: account.equityMicros,
+    },
+  }
+}
+
+const targetWeights = Object.fromEntries(
+  fixtureProtocol.universe.map((symbol, index) => [symbol, index === 0 ? 0.5 : 0]),
+)
+const decision: DecisionPlan = {
+  schemaVersion: 'bayn.risk-balanced-trend-decision-plan.v1',
+  signalDate,
+  covarianceWindow: {
+    returnCount: 1,
+    firstSession: signalDate,
+    lastSession: signalDate,
+    sessionsHash: 'e'.repeat(64),
+  },
+  estimatedAnnualizedPortfolioVolatility: 0.1,
+  exposureScale: 1,
+  targetWeights,
+  signals: fixtureProtocol.universe.map((symbol, index) => ({
+    symbol,
+    horizons: [{ horizonSessions: 1, return: index === 0 ? 0.1 : 0, normalizedTrend: index === 0 ? 1 : 0 }],
+    dailyVolatility: 0.1,
+    annualizedVolatility: 0.1,
+    compositeScore: index === 0 ? 1 : 0,
+    positiveScore: index === 0 ? 1 : 0,
+    eligible: true,
+    uncappedWeight: index === 0 ? 0.5 : 0,
+    cappedWeight: index === 0 ? 0.5 : 0,
+    targetWeight: index === 0 ? 0.5 : 0,
+  })),
+}
+const priceMicros = Object.fromEntries(fixtureProtocol.universe.map((symbol) => [symbol, '100000000']))
+
+const marketData = (requests: unknown[]): MarketDataService => ({
+  check: Effect.die(new Error('decision building must not run the static snapshot check')),
+  inspect: Effect.die(new Error('decision building must not inspect the static snapshot')),
+  inspectCyclePublications: Effect.die(new Error('decision building must not discover publications')),
+  inspectPublication: () => Effect.die(new Error('decision building must not inspect another publication')),
+  inspectSnapshotPublication: () => Effect.die(new Error('decision building must not re-inspect metadata')),
+  loadSnapshotPublication: (request) =>
+    Effect.sync(() => {
+      requests.push(request)
+      return snapshot
+    }),
+  load: Effect.die(new Error('decision building must not load the static qualification snapshot')),
+})
+
+const calendarRead =
+  (
+    queries: unknown[],
+  ): ((query: {
+    readonly start: string
+    readonly end: string
+  }) => Effect.Effect<ReadResult<MarketCalendarObservation>>) =>
+  (query) =>
+    Effect.sync(() => {
+      queries.push(query)
+      return {
+        value: calendar,
+        evidence: {
+          requestId: 'calendar-request',
+          status: 200,
+          contentHash: 'f'.repeat(64),
+          observedAt: reconciledAt,
+        },
+      }
+    })
+
+describe('OBSERVE runtime composition', () => {
+  test('decodes the bounded source policy with the configured account and canonical universe', async () => {
+    const policy = await Effect.runPromise(loadObserveRiskPolicy(accountId, [...fixtureProtocol.universe].reverse()))
+
+    expect(policy).toMatchObject({
+      accountId,
+      allowedSymbols: fixtureProtocol.universe,
+      maxOrderNotionalMicros: '600000000',
+      maxGrossExposureMicros: '1000000000',
+      maxUnresolvedOrders: 0,
+    })
+  })
+
+  test('builds one exact cycle-bound non-dispatchable decision from same-pass inputs', async () => {
+    const snapshotRequests: unknown[] = []
+    const calendarQueries: unknown[] = []
+    let strategyCalls = 0
+    const policy = await Effect.runPromise(loadObserveRiskPolicy(accountId, fixtureProtocol.universe))
+    const program = Effect.gen(function* () {
+      yield* TestClock.setTime(Date.parse(evaluatedAt))
+      return yield* buildObserveCycleDecision({
+        authorityGenerationHash: generationHash,
+        cycle,
+        executionModel: fixtureProtocol.executionModel,
+        marketCalendar: calendarRead(calendarQueries),
+        marketData: marketData(snapshotRequests),
+        policy,
+        reconcile: Effect.succeed(reconciliationResult()),
+        strategy: {
+          currentDecision: (_bars, _manifest, binding) => {
+            strategyCalls += 1
+            expect(binding.signal.sessionDate).toBe(signalDate)
+            expect(binding.executionSession.date).toBe(executionDate)
+            expect(binding.submissionOpenAt).toBe(reconciledAt)
+            return { decision, priceMicros }
+          },
+        },
+      })
+    }).pipe(Effect.provide(TestClock.layer()))
+
+    const document = await Effect.runPromise(program)
+
+    expect(snapshotRequests).toEqual([
+      {
+        snapshotId,
+        signalSessionDate: signalDate,
+        signalCalendarVersion: 'fixture-calendar-v2',
+      },
+    ])
+    expect(calendarQueries).toEqual([{ start: signalDate, end: '2020-05-30' }])
+    expect(strategyCalls).toBe(1)
+    expect(document).toMatchObject({
+      mode: 'OBSERVE',
+      dispatchable: false,
+      bindings: {
+        cycleId: cycle.identity.cycleId,
+        snapshotId,
+        accountId,
+      },
+      targetPlan: {
+        status: 'PLANNED',
+        intentTargets: [{ symbol: fixtureProtocol.universe[0], side: 'BUY', quantityMicros: '5000000' }],
+      },
+      deltaRisk: [
+        {
+          evaluation: {
+            decision: {
+              outcome: RiskOutcome.Blocked,
+              reasonCodes: [Reason.AuthorityNotPaper],
+            },
+          },
+        },
+      ],
+      createdAt: evaluatedAt,
+      expiresAt: cycle.window.submissionCutoffAt,
+    })
+  })
+
+  test('fails closed when same-pass reconciliation observes another authority generation', async () => {
+    const policy = await Effect.runPromise(loadObserveRiskPolicy(accountId, fixtureProtocol.universe))
+    let strategyCalls = 0
+    const exit = await Effect.runPromiseExit(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse(evaluatedAt))
+        return yield* buildObserveCycleDecision({
+          authorityGenerationHash: generationHash,
+          cycle,
+          executionModel: fixtureProtocol.executionModel,
+          marketCalendar: calendarRead([]),
+          marketData: marketData([]),
+          policy,
+          reconcile: Effect.succeed(reconciliationResult('9'.repeat(64))),
+          strategy: {
+            currentDecision: () => {
+              strategyCalls += 1
+              return { decision, priceMicros }
+            },
+          },
+        })
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(exit.toString()).toContain('same-pass reconciliation did not return the configured OBSERVE authority')
+    expect(strategyCalls).toBe(0)
+  })
+})

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -1,0 +1,322 @@
+import { Clock, Effect } from 'effect'
+
+import type { AutonomousCycleStartup } from './app'
+import { BrokerRead, type BrokerReadShape } from './broker/alpaca'
+import { makeCycleExecutionPolicyFromModel, type AutonomousCycle } from './cycle'
+import { marketCalendarQueryForSignal, startAutonomousCycleLoop, type CyclePassObservation } from './cycle-runner'
+import { CycleStore, type CycleStoreShape } from './db/cycle-store'
+import type { PaperStoreShape } from './db/paper-store'
+import { bindCycleExecutionSession } from './execution-session'
+import { makeFillTerms, MICROS } from './execution-model'
+import { operationalError } from './errors'
+import { canonicalHashV1 } from './hash'
+import { MarketData, type MarketDataService } from './market-data'
+import { Authority, OrderSide, OrderType, TimeInForce, type AuthorityState } from './paper'
+import type { CausalProtocol } from './protocol'
+import type { ReconciliationPassResult } from './reconciler'
+import { reconciledStateHash } from './reconciliation'
+import { BrokerMode, decodePolicy, type Policy, type State } from './risk'
+import { buildObserveShadowDecision, type ShadowDeltaRiskInput } from './shadow-decision'
+import type { ObserveShadowDecisionDocument } from './shadow-decision-contract'
+import { planTargets, type SignalSessionReferencePrices, type TargetPlannerInput } from './target-planner'
+import type { Strategy } from './strategy'
+
+const observeRiskLimits = {
+  maxOrderNotionalMicros: '600000000',
+  maxSymbolExposureMicros: '600000000',
+  maxGrossExposureMicros: '1000000000',
+  maxNetExposureMicros: '1000000000',
+  maxDailyTradedNotionalMicros: '1000000000',
+  maxDailyLossMicros: '100000000',
+  maxDrawdownMicros: '100000000',
+  maxIntentAgeMs: 300_000,
+  maxBrokerStateAgeMs: 300_000,
+  maxMarketDataAgeMs: 300_000,
+  maxAdverseSlippageBps: 10,
+  maxUnresolvedOrders: 0,
+  decisionTtlMs: 300_000,
+} as const
+
+export const loadObserveRiskPolicy = (accountId: string, allowedSymbols: readonly string[]) =>
+  decodePolicy({
+    schemaVersion: 'bayn.paper-risk-policy.v1',
+    accountId,
+    brokerMode: BrokerMode.Paper,
+    allowedSymbols: [...allowedSymbols].sort(),
+    allowedOrderTypes: [OrderType.Market],
+    allowedTimeInForce: [TimeInForce.Day],
+    ...observeRiskLimits,
+  })
+
+type ObserveStrategy = Pick<Strategy, 'currentDecision'>
+
+export interface ObserveDecisionInput {
+  readonly authorityGenerationHash: string
+  readonly cycle: AutonomousCycle
+  readonly executionModel: CausalProtocol['executionModel']
+  readonly marketCalendar: BrokerReadShape['marketCalendar']
+  readonly marketData: MarketDataService
+  readonly policy: Policy
+  readonly reconcile: Effect.Effect<ReconciliationPassResult, unknown>
+  readonly strategy: ObserveStrategy
+}
+
+const referencePrices = (
+  signalDate: SignalSessionReferencePrices['signalDate'],
+  observedAt: string,
+  priceMicros: Readonly<Record<string, string>>,
+): SignalSessionReferencePrices => {
+  const material = {
+    schemaVersion: 'bayn.signal-session-reference-prices.v1' as const,
+    signalDate,
+    observedAt,
+    priceMicros,
+  }
+  return { ...material, contentHash: canonicalHashV1(material) }
+}
+
+const requireObserveAuthority = (
+  result: ReconciliationPassResult,
+  policy: Policy,
+  authorityGenerationHash: string,
+): Effect.Effect<{ readonly authority: AuthorityState; readonly observedAt: string }, Error> => {
+  const authority = result.riskContext.authority
+  if (
+    authority === null ||
+    result.riskContext.authorityObservedAt === null ||
+    authority.generationHash !== authorityGenerationHash ||
+    authority.maximum !== Authority.Observe ||
+    authority.effective !== Authority.Observe ||
+    result.brokerState.account.accountId !== policy.accountId
+  ) {
+    return Effect.fail(new Error('same-pass reconciliation did not return the configured OBSERVE authority'))
+  }
+  return Effect.succeed({ authority, observedAt: result.riskContext.authorityObservedAt })
+}
+
+export const buildObserveCycleDecision = (
+  input: ObserveDecisionInput,
+): Effect.Effect<ObserveShadowDecisionDocument, unknown> =>
+  Effect.gen(function* () {
+    const snapshotId = input.cycle.bindings.snapshotId
+    if (snapshotId === undefined) {
+      return yield* Effect.fail(new Error('active autonomous cycle has no immutable snapshot binding'))
+    }
+
+    const [snapshot, calendar, reconciliation] = yield* Effect.all(
+      [
+        input.marketData.loadSnapshotPublication({
+          snapshotId,
+          signalSessionDate: input.cycle.identity.signalSessionDate,
+          signalCalendarVersion: input.cycle.identity.signalCalendarVersion,
+        }),
+        input.marketCalendar(marketCalendarQueryForSignal(input.cycle.identity.signalSessionDate)),
+        input.reconcile,
+      ],
+      { concurrency: 3 },
+    )
+    const evaluatedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
+    const authorityObservation = yield* requireObserveAuthority(
+      reconciliation,
+      input.policy,
+      input.authorityGenerationHash,
+    )
+    const authority = authorityObservation.authority
+    const finalizedSnapshot = snapshot.manifest.finalizedSnapshot
+    const executionSession = yield* Effect.try({
+      try: () =>
+        bindCycleExecutionSession({
+          cycle: input.cycle,
+          signal: {
+            sessionDate: input.cycle.identity.signalSessionDate,
+            finalizedAt: finalizedSnapshot.finalizedAt,
+            contentHash: finalizedSnapshot.contentHash,
+          },
+          planningBrokerState: {
+            observedAt: reconciliation.brokerState.reconciliation.reconciledAt,
+            contentHash: reconciledStateHash(reconciliation.brokerState),
+          },
+          calendar: calendar.value,
+          executionModel: input.executionModel,
+        }),
+      catch: (cause) => new Error('cycle execution-session binding failed', { cause }),
+    })
+    const compiled = yield* Effect.try({
+      try: () => input.strategy.currentDecision(snapshot.bars, snapshot.manifest, executionSession),
+      catch: (cause) => new Error('current strategy decision compilation failed', { cause }),
+    })
+    const prices = referencePrices(compiled.decision.signalDate, evaluatedAt, compiled.priceMicros)
+    const policyHash = canonicalHashV1(input.policy)
+    const plannerInput: TargetPlannerInput = {
+      schemaVersion: 'bayn.paper-target-planner-input.v1',
+      strategyName: input.cycle.identity.strategyName,
+      cycleId: input.cycle.identity.cycleId,
+      decisionHash: canonicalHashV1(compiled.decision),
+      policyHash,
+      accountId: input.cycle.identity.accountId,
+      signalDate: input.cycle.identity.signalSessionDate,
+      targetWeights: compiled.decision.targetWeights,
+      referencePrices: prices,
+      brokerState: reconciliation.brokerState,
+      precision: input.executionModel.precision,
+      maximumInputAgeMs: Math.min(input.policy.maxBrokerStateAgeMs, input.policy.maxMarketDataAgeMs),
+      submissionCutoffAt: input.cycle.window.submissionCutoffAt,
+      observedAt: evaluatedAt,
+    }
+    const targetPlan = yield* Effect.try({
+      try: () => planTargets(plannerInput),
+      catch: (cause) => new Error('shadow target planning failed', { cause }),
+    })
+    const riskInputs = yield* Effect.try({
+      try: (): readonly ShadowDeltaRiskInput[] =>
+        targetPlan.intentTargets.map((target): ShadowDeltaRiskInput => {
+          const referencePrice = BigInt(prices.priceMicros[target.symbol])
+          const fillTerms = makeFillTerms(
+            target.side === OrderSide.Buy ? 'buy' : 'sell',
+            BigInt(target.quantityMicros),
+            referencePrice,
+            input.executionModel,
+            MICROS,
+          )
+          const state: State = {
+            schemaVersion: 'bayn.paper-risk-state.v2',
+            brokerMode: BrokerMode.Paper,
+            account: reconciliation.brokerState.account,
+            positions: reconciliation.brokerState.positions,
+            positionsObservedAt: reconciliation.brokerState.positionsObservedAt,
+            orders: reconciliation.brokerState.orders,
+            ordersObservedAt: reconciliation.brokerState.ordersObservedAt,
+            reconciliation: reconciliation.brokerState.reconciliation,
+            authority,
+            authorityObservedAt: authorityObservation.observedAt,
+            unknownMutationCount: reconciliation.riskContext.unknownMutationCount,
+            dailyTradedNotionalMicros: reconciliation.riskContext.dailyTradedNotionalMicros,
+            dayStartEquityMicros: reconciliation.riskContext.dayStartEquityMicros,
+            peakEquityMicros: reconciliation.riskContext.peakEquityMicros,
+            accountingHash: reconciliation.brokerState.accountingHash,
+            marketDataSymbol: target.symbol,
+            marketDataHash: finalizedSnapshot.contentHash,
+            referencePriceMicros: referencePrice.toString(),
+            expectedExecutionPriceMicros: fillTerms.fillPriceMicros.toString(),
+            marketDataObservedAt: evaluatedAt,
+            executionSession,
+            reservedBuyingPowerMicros: '0',
+            evaluatedAt,
+          }
+          return {
+            symbol: target.symbol,
+            notionalLimitMicros: fillTerms.notionalMicros.toString(),
+            state,
+          }
+        }),
+      catch: (cause) => new Error('shadow risk input construction failed', { cause }),
+    })
+    return yield* buildObserveShadowDecision({
+      cycle: input.cycle,
+      snapshot: {
+        snapshotId: finalizedSnapshot.snapshotId,
+        contentHash: finalizedSnapshot.contentHash,
+        finalizedAt: finalizedSnapshot.finalizedAt,
+      },
+      compiledDecision: compiled.decision,
+      plannerInput,
+      targetPlan,
+      policy: input.policy,
+      riskInputs,
+    })
+  })
+
+const observePass = (
+  recordPass: Parameters<AutonomousCycleStartup>[0]['recordPass'],
+  observation: CyclePassObservation,
+) =>
+  observation.outcome === 'SUCCEEDED'
+    ? recordPass({
+        result: 'SUCCESS',
+        observedAt: observation.observedAt,
+        outcome: observation.result.outcome,
+      })
+    : recordPass({
+        result: 'FAILURE',
+        observedAt: observation.observedAt,
+        operation: observation.error.operation,
+        failure: observation.error.failure,
+        message: observation.error.message,
+      })
+
+export interface ObserveAutonomousCycleInput {
+  readonly accountId: string
+  readonly authorityGenerationHash: string
+  readonly brokerRead: BrokerReadShape
+  readonly cycleStore: CycleStoreShape
+  readonly marketData: MarketDataService
+  readonly paperStore: PaperStoreShape
+  readonly pollIntervalMs: number
+  readonly reconcile: Effect.Effect<ReconciliationPassResult, unknown>
+  readonly strategy: Pick<Strategy, 'currentDecision' | 'parameters'>
+}
+
+export const makeObserveAutonomousCycleStartup = (input: ObserveAutonomousCycleInput): AutonomousCycleStartup => {
+  const executionModel = input.strategy.parameters.executionModel
+  return (startup) =>
+    Effect.gen(function* () {
+      if (executionModel.schemaVersion !== 'bayn.execution-model.v2') {
+        return yield* Effect.fail(
+          operationalError('strategy', 'cycle-loop', 'autonomous cycles require the causal v2 execution model'),
+        )
+      }
+      const executionPolicy = makeCycleExecutionPolicyFromModel(executionModel)
+      const policy = yield* loadObserveRiskPolicy(input.accountId, input.strategy.parameters.universe).pipe(
+        Effect.mapError((cause) =>
+          operationalError('strategy', 'risk-policy', 'source-controlled paper risk policy is invalid', cause),
+        ),
+      )
+      const authority = yield* input.paperStore
+        .ensureAuthorityGeneration({
+          generationHash: input.authorityGenerationHash,
+          maximum: Authority.Observe,
+        })
+        .pipe(
+          Effect.mapError((cause) =>
+            operationalError('database', 'authority', 'OBSERVE authority initialization failed', cause),
+          ),
+        )
+      if (
+        authority.generationHash !== input.authorityGenerationHash ||
+        authority.maximum !== Authority.Observe ||
+        authority.effective !== Authority.Observe
+      ) {
+        return yield* Effect.fail(
+          operationalError('database', 'authority', 'OBSERVE authority initialization returned incompatible state'),
+        )
+      }
+      return yield* startAutonomousCycleLoop({
+        context: Effect.succeed({
+          qualificationRunId: startup.qualificationRunId,
+          strategyProtocolHash: startup.strategyProtocolHash,
+          accountId: input.accountId,
+          executionPolicy,
+          buildDecision: (cycle) =>
+            buildObserveCycleDecision({
+              authorityGenerationHash: input.authorityGenerationHash,
+              cycle,
+              executionModel,
+              marketCalendar: input.brokerRead.marketCalendar,
+              marketData: input.marketData,
+              policy,
+              reconcile: input.reconcile,
+              strategy: input.strategy,
+            }),
+        }),
+        observePass: (observation) => observePass(startup.recordPass, observation),
+        pollIntervalMs: input.pollIntervalMs,
+      }).pipe(
+        Effect.provideService(BrokerRead, input.brokerRead),
+        Effect.provideService(CycleStore, input.cycleStore),
+        Effect.provideService(MarketData, input.marketData),
+        Effect.mapError((cause) =>
+          operationalError('strategy', 'cycle-loop', 'autonomous cycle loop failed to start', cause),
+        ),
+      )
+    })
+}

--- a/services/bayn/src/runtime-state.ts
+++ b/services/bayn/src/runtime-state.ts
@@ -4,6 +4,7 @@ import {
   type CycleOperationsStatus,
   unknownCycleOperationsStatus,
 } from './cycle-observability'
+import type { CycleRunnerError, CycleRunResult } from './cycle-runner'
 import type { QualificationResult } from './qualification'
 import type { EvaluationSummary, ReconciliationResult } from './types'
 
@@ -39,6 +40,7 @@ export interface RuntimeHealth {
     readonly tigerBeetle: DependencyHealth
     readonly evidence: DependencyHealth
     readonly cycle: DependencyHealth
+    readonly cycleRunner: DependencyHealth
   }
 }
 
@@ -57,18 +59,39 @@ export interface BrokerStatus extends BrokerConfiguration {
   readonly error: string | null
 }
 
+export type AutonomousCyclePassObservation =
+  | {
+      readonly result: 'SUCCESS'
+      readonly observedAt: string
+      readonly outcome: CycleRunResult['outcome']
+    }
+  | {
+      readonly result: 'FAILURE'
+      readonly observedAt: string
+      readonly operation: CycleRunnerError['operation']
+      readonly failure: CycleRunnerError['failure']
+      readonly message: string
+    }
+
+export interface AutonomousCycleLoopStatus {
+  readonly configured: boolean
+  readonly startedAt: string | null
+  readonly lastPass: AutonomousCyclePassObservation | null
+}
+
 export interface RuntimeState {
   readonly status: 'STARTING' | 'READY' | 'DEGRADED' | 'FAILED'
   readonly evidence: RuntimeEvidence | null
   readonly health: RuntimeHealth
   readonly cycle: CycleOperationsStatus
+  readonly autonomousCycleLoop: AutonomousCycleLoopStatus
   readonly broker: BrokerStatus | null
   readonly error: string | null
 }
 
 const unknownDependency = (): DependencyHealth => ({ status: 'UNKNOWN', checkedAt: null, error: null })
 
-export const initialState = (broker?: BrokerConfiguration): RuntimeState => ({
+export const initialState = (broker?: BrokerConfiguration, autonomousCycleLoopConfigured = false): RuntimeState => ({
   status: 'STARTING',
   evidence: null,
   health: {
@@ -80,9 +103,15 @@ export const initialState = (broker?: BrokerConfiguration): RuntimeState => ({
       tigerBeetle: unknownDependency(),
       evidence: unknownDependency(),
       cycle: unknownDependency(),
+      cycleRunner: unknownDependency(),
     },
   },
   cycle: unknownCycleOperationsStatus(),
+  autonomousCycleLoop: {
+    configured: autonomousCycleLoopConfigured,
+    startedAt: null,
+    lastPass: null,
+  },
   broker:
     broker === undefined
       ? null
@@ -106,5 +135,6 @@ export const isReady = (state: RuntimeState): boolean =>
   state.cycle.condition !== CycleOperationsCondition.Unknown &&
   state.cycle.condition !== CycleOperationsCondition.Stalled &&
   state.cycle.condition !== CycleOperationsCondition.Failed &&
+  state.autonomousCycleLoop.lastPass?.result !== 'FAILURE' &&
   (state.broker === null || (state.broker.accountBound === true && state.broker.readAvailable === true)) &&
   Object.values(state.health.dependencies).every((dependency) => dependency.status === 'AVAILABLE')

--- a/services/bayn/src/shadow-decision.test.ts
+++ b/services/bayn/src/shadow-decision.test.ts
@@ -37,7 +37,7 @@ import {
   type ObserveShadowDecisionInput,
   type ShadowDeltaRiskInput,
 } from './shadow-decision'
-import { TargetPlanReason, TargetPlanStatus, type TargetPlannerInput } from './target-planner'
+import { TargetPlanReason, TargetPlanStatus, planTargets, type TargetPlannerInput } from './target-planner'
 import type { DecisionPlan } from './types'
 
 const hash = (character: string): string => character.repeat(64)
@@ -348,6 +348,7 @@ const makeInput = (
     },
     compiledDecision,
     plannerInput,
+    targetPlan: planTargets(plannerInput),
     policy,
     riskInputs,
   }
@@ -470,12 +471,14 @@ describe('OBSERVE shadow decision', () => {
   test('persists deterministic NO_TRADE and pre-cutoff blocked planner results without ignored risk input', async () => {
     const noTrade = await build(makeInput({ AMD: 0.1, NVDA: 0.1 }))
     const staleInput = makeInput()
+    const stalePlannerInput = {
+      ...staleInput.plannerInput,
+      maximumInputAgeMs: 1,
+    }
     const stale = await build({
       ...staleInput,
-      plannerInput: {
-        ...staleInput.plannerInput,
-        maximumInputAgeMs: 1,
-      },
+      plannerInput: stalePlannerInput,
+      targetPlan: planTargets(stalePlannerInput),
       riskInputs: [],
     })
 
@@ -496,9 +499,11 @@ describe('OBSERVE shadow decision', () => {
   test('clamps blocked risk evidence at the last instant before the exclusive cycle cutoff', async () => {
     const input = makeInput()
     const createdAt = new Date(Date.parse(input.cycle.window.submissionCutoffAt) - 1).toISOString()
+    const plannerInput = { ...input.plannerInput, observedAt: createdAt }
     const document = await build({
       ...input,
-      plannerInput: { ...input.plannerInput, observedAt: createdAt },
+      plannerInput,
+      targetPlan: planTargets(plannerInput),
       riskInputs: input.riskInputs.map((riskInput) => ({
         ...riskInput,
         state: { ...riskInput.state, evaluatedAt: createdAt },
@@ -512,12 +517,19 @@ describe('OBSERVE shadow decision', () => {
     )
   })
 
-  test('fails closed on drift in cycle, snapshot, compiled decision, risk state, or OBSERVE authority', async () => {
+  test('fails closed on drift in cycle, snapshot, target plan, compiled decision, risk state, or authority', async () => {
     const input = makeInput()
     const variants: ObserveShadowDecisionInput[] = [
       {
         ...input,
         snapshot: { ...input.snapshot, snapshotId: hash('f') },
+      },
+      {
+        ...input,
+        targetPlan: planTargets({
+          ...input.plannerInput,
+          maximumInputAgeMs: input.plannerInput.maximumInputAgeMs + 1,
+        }),
       },
       {
         ...input,

--- a/services/bayn/src/shadow-decision.ts
+++ b/services/bayn/src/shadow-decision.ts
@@ -12,7 +12,12 @@ import {
   type DeltaRiskEvaluation,
   type ObserveShadowDecisionDocument,
 } from './shadow-decision-contract'
-import { TargetPlanStatus, planTargets, type PlannedTargetQuantity, type TargetPlannerInput } from './target-planner'
+import {
+  TargetPlanStatus,
+  type PlannedTargetQuantity,
+  type TargetPlannerInput,
+  type TargetPlanResult,
+} from './target-planner'
 import type { DecisionPlan } from './types'
 
 export interface ShadowSnapshotBinding {
@@ -32,6 +37,7 @@ export interface ObserveShadowDecisionInput {
   readonly snapshot: ShadowSnapshotBinding
   readonly compiledDecision: DecisionPlan
   readonly plannerInput: TargetPlannerInput
+  readonly targetPlan: TargetPlanResult
   readonly policy: Policy
   readonly riskInputs: readonly ShadowDeltaRiskInput[]
 }
@@ -195,10 +201,10 @@ export const buildObserveShadowDecision = (
     const bindingFailure = validateBindings(input, strategyDecisionHash, policyHash)
     if (bindingFailure !== null) return yield* fail('binding', bindingFailure)
 
-    const planner = yield* Effect.try({
-      try: () => planTargets(input.plannerInput),
-      catch: (cause) => error('contract', 'target planning failed', cause),
-    })
+    const planner = input.targetPlan
+    if (planner.inputHash !== canonicalHashV1(input.plannerInput)) {
+      return yield* fail('binding', 'target plan must match the exact planner input')
+    }
     if (planner.status !== TargetPlanStatus.Planned && input.riskInputs.length !== 0) {
       return yield* fail('binding', 'NO_TRADE and BLOCKED target plans cannot retain ignored risk inputs')
     }


### PR DESCRIPTION
## Summary

- start one scoped autonomous cycle loop after durable startup initialization, while keeping the current strategy protocol identity separate from a recovered qualification run
- compose the exact cycle-bound Signal snapshot, complete GET-only Alpaca calendar, and one same-pass reconciliation into the canonical target plan, risk evaluations, and non-dispatchable OBSERVE shadow document
- initialize the explicit OBSERVE authority generation once and keep BrokerMutation, IntentStore, and MutationStore structurally confined to the PAPER branch
- surface typed pass failures, unexpected fiber exits, stalls, and current cycle state through the existing health, readiness, status, and metrics surfaces
- pass the already-computed target plan into shadow persistence so the runtime invokes the pure planner exactly once

## Related Issues

PROOMPT-382, PROOMPT-383, PROOMPT-384, and the OBSERVE portion of PROOMPT-375.

This is source integration only. These issues must remain open through image publication, GitOps rollout, restart recovery, and live zero-mutation proof.

## Testing

- `bun run --filter @proompteng/bayn test` — 335 passed, 71 PostgreSQL-only skipped, 0 failed
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- `git diff --check`
- independent read-only authority/capability/same-pass and cycle/data/timing reviews found no actionable blocker

## Breaking Changes

Credential-free Bayn remains compatible without `BAYN_AUTHORITY_GENERATION_HASH`. When a complete Alpaca binding is configured, the hash is required and decoded into that resolved binding. The reviewed GitOps follow-up must wire the sealed Alpaca credentials, generation hash, and `BAYN_CYCLE_POLL_INTERVAL_MS` together before promotion. Maximum authority remains `OBSERVE`.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; this is a service/runtime change.
- [x] Breaking changes and required GitOps follow-up are documented.
- [x] Linear issues remain open for deployment and live acceptance.
