### PR TITLE
chore(bayn): stage autonomous observe rollout

### DIFF
--- a/.github/workflows/bayn-release.yml
+++ b/.github/workflows/bayn-release.yml
@@ -129,7 +129,7 @@ jobs:
               --strategy-parameter-hash "$strategy_parameter_hash" \
               --rollout-timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           )"
-          jq -e '(.promotionAction == "promote" or .promotionAction == "hold") and (.qualificationMode == "preserve" or .qualificationMode == "replace")' <<< "$promotion"
+          jq -e '(.promotionAction == "promote" or .promotionAction == "hold") and (.qualificationMode == "preserve" or .qualificationMode == "replace" or .qualificationMode == "install")' <<< "$promotion"
           {
             echo "promotion_action=$(jq -r '.promotionAction' <<< "$promotion")"
             echo "promotion_reason=$(jq -r '.promotionReason' <<< "$promotion")"
@@ -219,10 +219,13 @@ jobs:
             This is a one-way current-contract runtime release. Databases with the old migration tracker are rejected;
             there is no schema fallback or automatic rename. `preserve` keeps the terminal run only when compiled
             behavior, protocol parameters, Signal inputs, TigerBeetle cluster ID, and TigerBeetle ledger all match.
-            Replica addresses are transport and are rewritten without relabeling qualification evidence. `replace`
-            removes an existing incompatible pin only for a fresh Signal snapshot. Once that one-shot release is
-            unpinned, a different source revision is rejected until the terminal run is pinned or the snapshot
-            advances. Promotion never creates a qualification pin.
+            Replica addresses are transport and an explicit candidate may change them without relabeling qualification
+            evidence. `replace` removes an existing incompatible pin only for a fresh Signal snapshot. `install` is
+            available only to a controlled invocation that supplies the complete reviewed candidate runtime and exact
+            independently accepted terminal run ID; automatic image promotion supplies neither and therefore never
+            creates a pin. Installation can pin only the source already deployed for that unpinned snapshot. A
+            different source revision remains rejected until the terminal run is installed in a separate change or
+            the snapshot advances.
 
             ## Checklist
 

--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -60,6 +60,26 @@ spec:
               value: "7a521052ff039376267eb16f222023edf5d72f308af380c71f2d50da6e6a1b32"
             - name: BAYN_MAXIMUM_AUTHORITY
               value: OBSERVE
+            # sha256("bayn/authority-generation/autonomous-observe-v1")
+            - name: BAYN_AUTHORITY_GENERATION_HASH
+              value: "d290539ec85334d8ce267f98919c139cb382068101042d69b5433832136dc063"
+            - name: BAYN_CYCLE_POLL_INTERVAL_MS
+              value: "30000"
+            - name: BAYN_ALPACA_ACCOUNT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: bayn-alpaca-auth
+                  key: account-id
+            - name: BAYN_ALPACA_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: bayn-alpaca-auth
+                  key: key-id
+            - name: BAYN_ALPACA_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: bayn-alpaca-auth
+                  key: secret-key
             - name: BAYN_HEALTH_INTERVAL_MS
               value: "30000"
             - name: BAYN_OPERATION_TIMEOUT_MS

--- a/docs/bayn/architecture.md
+++ b/docs/bayn/architecture.md
@@ -194,7 +194,10 @@ must remain available, accounting must be exact, and HTTP status must retain obs
 Outside an explicit one-shot qualification release, GitOps pins `BAYN_QUALIFICATION_RUN_ID` to one terminal run. The
 release writer preserves that pin while compiled strategy identity, Signal identity and bounds, TigerBeetle cluster
 ID, and TigerBeetle ledger remain identical. TigerBeetle replica addresses are transport routing, not qualification
-identity, so the writer may restore replica-index order without relabeling terminal evidence. A cluster-ID or ledger
-change still requires a fresh Signal snapshot. After a fresh snapshot removes the pin for its one allowed source
-revision, promotion rejects a different source revision on that same unpinned snapshot; operational releases therefore
-cannot create extra qualification trials.
+identity, so an explicit reviewed candidate may change them without relabeling terminal evidence. A cluster-ID or
+ledger change still requires a fresh Signal snapshot. The writer has no source-coded current snapshot: ordinary image
+promotion reads the deployed runtime, while a qualification transition must supply the complete candidate runtime.
+After a fresh snapshot removes the pin for its one allowed source revision, promotion rejects a different source
+revision. A controlled invocation may install the exact independently accepted terminal run only for that already
+deployed source and complete runtime. A later pinned operational release may change source while preserving identical
+compiled strategy and qualification identity. Automatic image promotion never creates a qualification pin.

--- a/packages/scripts/src/bayn/update-manifests.test.ts
+++ b/packages/scripts/src/bayn/update-manifests.test.ts
@@ -3,7 +3,12 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { updateBaynManifests, type UpdateBaynManifestOptions } from './update-manifests'
+import {
+  parseUpdateBaynManifestArguments,
+  updateBaynManifests,
+  type BaynCandidateRuntime,
+  type UpdateBaynManifestOptions,
+} from './update-manifests'
 
 const currentSnapshotId = '840c75885270b349d4a992e003918ce7e6fe39730f981a20b2e88ae2db45a2e2'
 const strategyBehaviorHash = '1'.repeat(64)
@@ -22,7 +27,7 @@ const currentBindings = {
   BAYN_TIGERBEETLE_ADDRESSES:
     'ledger-0.ledger-headless.bayn.svc.cluster.local:3000,ledger-1.ledger-headless.bayn.svc.cluster.local:3000,ledger-2.ledger-headless.bayn.svc.cluster.local:3000',
   BAYN_TIGERBEETLE_LEDGER: '7001',
-} as const
+} as const satisfies BaynCandidateRuntime
 
 interface FixtureOptions {
   readonly snapshotId?: string
@@ -31,7 +36,7 @@ interface FixtureOptions {
   readonly tigerBeetleAddresses?: string
   readonly behaviorHash?: string
   readonly parameterHash?: string
-  readonly qualificationRunId?: string | undefined
+  readonly qualificationRunId?: string | null
 }
 
 interface FixturePaths {
@@ -71,7 +76,7 @@ const makeFixture = (options: FixtureOptions = {}): FixturePaths => {
     environmentBlock('BAYN_IMAGE_DIGEST', `sha256:${'0'.repeat(64)}`),
     environmentBlock('BAYN_STRATEGY_BEHAVIOR_HASH', options.behaviorHash ?? strategyBehaviorHash),
     environmentBlock('BAYN_STRATEGY_PARAMETER_HASH', options.parameterHash ?? strategyParameterHash),
-    pin === undefined ? '' : environmentBlock('BAYN_QUALIFICATION_RUN_ID', pin),
+    pin === null ? '' : environmentBlock('BAYN_QUALIFICATION_RUN_ID', pin),
     ...Object.entries(bindings).map(([name, value]) => environmentBlock(name, value)),
   ].join('')
 
@@ -92,7 +97,12 @@ const makeFixture = (options: FixtureOptions = {}): FixturePaths => {
 
 const promote = (
   paths: FixturePaths,
-  overrides: Partial<Pick<UpdateBaynManifestOptions, 'strategyBehaviorHash' | 'strategyParameterHash'>> = {},
+  overrides: Partial<
+    Pick<
+      UpdateBaynManifestOptions,
+      'strategyBehaviorHash' | 'strategyParameterHash' | 'candidateRuntime' | 'acceptedQualificationRunId'
+    >
+  > & { readonly useDeployedRuntime?: boolean } = {},
   sourceSha = 'a'.repeat(40),
 ) => {
   return updateBaynManifests({
@@ -102,6 +112,12 @@ const promote = (
     strategyBehaviorHash: overrides.strategyBehaviorHash ?? strategyBehaviorHash,
     strategyParameterHash: overrides.strategyParameterHash ?? strategyParameterHash,
     rolloutTimestamp: '2026-07-22T10:00:00Z',
+    ...(overrides.useDeployedRuntime === true
+      ? {}
+      : { candidateRuntime: overrides.candidateRuntime ?? currentBindings }),
+    ...(overrides.acceptedQualificationRunId === undefined
+      ? {}
+      : { acceptedQualificationRunId: overrides.acceptedQualificationRunId }),
     ...paths,
   })
 }
@@ -247,6 +263,187 @@ describe('Bayn manifest promotion', () => {
     )
     expect(Object.values(paths).map((path) => readFileSync(path, 'utf8'))).toEqual(beforeSecondRelease)
     expect(readFileSync(paths.deploymentPath, 'utf8')).not.toContain('BAYN_QUALIFICATION_RUN_ID')
+  })
+
+  test('atomically installs an accepted run with its explicit fresh runtime', () => {
+    const paths = makeFixture()
+    const freshRunId = '8'.repeat(64)
+    const freshRuntime = {
+      ...currentBindings,
+      BAYN_SIGNAL_SNAPSHOT_ID: '4'.repeat(64),
+      BAYN_SIGNAL_PUBLICATION_ASOF: '2026-07-23',
+      BAYN_SIGNAL_DATA_END: '2026-07-23',
+      BAYN_SIGNAL_EVALUATION_END: '2026-07-23',
+    } satisfies BaynCandidateRuntime
+
+    expect(
+      promote(paths, {
+        strategyParameterHash: '3'.repeat(64),
+        candidateRuntime: freshRuntime,
+        acceptedQualificationRunId: freshRunId,
+      }),
+    ).toMatchObject({
+      promotionAction: 'promote',
+      qualificationMode: 'install',
+      hadQualificationPin: true,
+      deployedQualificationRunId: qualificationRunId,
+      candidateQualificationRunId: freshRunId,
+      qualificationBindingsMatch: false,
+      snapshotChanged: true,
+      candidateSnapshotId: freshRuntime.BAYN_SIGNAL_SNAPSHOT_ID,
+    })
+    const deployment = readFileSync(paths.deploymentPath, 'utf8')
+    expect(deployment).toContain(environmentBlock('BAYN_QUALIFICATION_RUN_ID', freshRunId).trim())
+    expect(deployment).not.toContain(environmentBlock('BAYN_QUALIFICATION_RUN_ID', qualificationRunId).trim())
+    for (const [name, value] of Object.entries(freshRuntime)) {
+      expect(deployment).toContain(environmentBlock(name, value).trim())
+    }
+  })
+
+  test('installs the terminal result of the one allowed unpinned release', () => {
+    const paths = makeFixture({ qualificationRunId: null })
+    const acceptedRunId = '8'.repeat(64)
+
+    expect(promote(paths, { acceptedQualificationRunId: acceptedRunId }, '0'.repeat(40))).toMatchObject({
+      promotionAction: 'promote',
+      qualificationMode: 'install',
+      hadQualificationPin: false,
+      deployedQualificationRunId: null,
+      candidateQualificationRunId: acceptedRunId,
+      snapshotChanged: false,
+    })
+    expect(readFileSync(paths.deploymentPath, 'utf8')).toContain(
+      environmentBlock('BAYN_QUALIFICATION_RUN_ID', acceptedRunId).trim(),
+    )
+  })
+
+  test('rejects using an accepted run to change an unpinned source', () => {
+    const paths = makeFixture({ qualificationRunId: null })
+    const before = Object.values(paths).map((path) => readFileSync(path, 'utf8'))
+
+    expect(() =>
+      promote(
+        paths,
+        {
+          acceptedQualificationRunId: '8'.repeat(64),
+        },
+        'c'.repeat(40),
+      ),
+    ).toThrow('an unpinned qualification snapshot cannot accept a second source release')
+    expect(Object.values(paths).map((path) => readFileSync(path, 'utf8'))).toEqual(before)
+  })
+
+  test('requires an explicit complete runtime before installing an accepted run', () => {
+    const paths = makeFixture({ qualificationRunId: null })
+    const before = Object.values(paths).map((path) => readFileSync(path, 'utf8'))
+
+    expect(() =>
+      promote(paths, {
+        acceptedQualificationRunId: '8'.repeat(64),
+        useDeployedRuntime: true,
+      }),
+    ).toThrow('installing an accepted qualification run requires an explicit candidate runtime')
+    expect(Object.values(paths).map((path) => readFileSync(path, 'utf8'))).toEqual(before)
+  })
+
+  test('rejects replacing a pinned run on the same snapshot', () => {
+    const paths = makeFixture()
+    const before = Object.values(paths).map((path) => readFileSync(path, 'utf8'))
+
+    expect(() =>
+      promote(paths, {
+        acceptedQualificationRunId: '8'.repeat(64),
+      }),
+    ).toThrow('qualification run replacement requires a fresh BAYN_SIGNAL_SNAPSHOT_ID')
+    expect(Object.values(paths).map((path) => readFileSync(path, 'utf8'))).toEqual(before)
+  })
+
+  test('uses the deployed runtime when no explicit candidate is supplied', () => {
+    const deployedSnapshotId = '4'.repeat(64)
+    const paths = makeFixture({ snapshotId: deployedSnapshotId })
+
+    expect(promote(paths, { useDeployedRuntime: true })).toMatchObject({
+      promotionAction: 'promote',
+      qualificationMode: 'preserve',
+      qualificationBindingsMatch: true,
+      snapshotChanged: false,
+      deployedSnapshotId,
+      candidateSnapshotId: deployedSnapshotId,
+    })
+  })
+
+  test('parses a complete explicit candidate and accepted run and rejects partial candidates', () => {
+    const base = [
+      '--source-sha',
+      'a'.repeat(40),
+      '--tag',
+      `sha-${'a'.repeat(40)}`,
+      '--digest',
+      `sha256:${'b'.repeat(64)}`,
+      '--strategy-behavior-hash',
+      strategyBehaviorHash,
+      '--strategy-parameter-hash',
+      strategyParameterHash,
+      '--rollout-timestamp',
+      '2026-07-23T22:30:00Z',
+    ]
+    const candidate = [
+      '--signal-snapshot-id',
+      currentBindings.BAYN_SIGNAL_SNAPSHOT_ID,
+      '--signal-publication-asof',
+      currentBindings.BAYN_SIGNAL_PUBLICATION_ASOF,
+      '--signal-calendar-version',
+      currentBindings.BAYN_SIGNAL_CALENDAR_VERSION,
+      '--signal-data-start',
+      currentBindings.BAYN_SIGNAL_DATA_START,
+      '--signal-data-end',
+      currentBindings.BAYN_SIGNAL_DATA_END,
+      '--signal-lookback-start',
+      currentBindings.BAYN_SIGNAL_LOOKBACK_START,
+      '--signal-evaluation-start',
+      currentBindings.BAYN_SIGNAL_EVALUATION_START,
+      '--signal-evaluation-end',
+      currentBindings.BAYN_SIGNAL_EVALUATION_END,
+      '--tigerbeetle-cluster-id',
+      currentBindings.BAYN_TIGERBEETLE_CLUSTER_ID,
+      '--tigerbeetle-addresses',
+      currentBindings.BAYN_TIGERBEETLE_ADDRESSES,
+      '--tigerbeetle-ledger',
+      currentBindings.BAYN_TIGERBEETLE_LEDGER,
+      '--accepted-qualification-run-id',
+      qualificationRunId,
+    ]
+
+    expect(parseUpdateBaynManifestArguments([...base, ...candidate])).toMatchObject({
+      candidateRuntime: currentBindings,
+      acceptedQualificationRunId: qualificationRunId,
+    })
+    expect(() =>
+      parseUpdateBaynManifestArguments([...base, '--signal-snapshot-id', currentBindings.BAYN_SIGNAL_SNAPSHOT_ID]),
+    ).toThrow('candidate runtime flags must be provided together')
+    expect(() =>
+      parseUpdateBaynManifestArguments([...base, '--accepted-qualification-run-id', qualificationRunId]),
+    ).toThrow('--accepted-qualification-run-id requires the complete candidate runtime')
+  })
+
+  test('rejects malformed explicit qualification material before writing', () => {
+    const paths = makeFixture()
+    const before = Object.values(paths).map((path) => readFileSync(path, 'utf8'))
+
+    expect(() =>
+      promote(paths, {
+        candidateRuntime: {
+          ...currentBindings,
+          BAYN_SIGNAL_SNAPSHOT_ID: 'not-a-snapshot',
+        },
+      }),
+    ).toThrow('invalid candidate Signal snapshot ID')
+    expect(() =>
+      promote(paths, {
+        acceptedQualificationRunId: 'not-a-run',
+      }),
+    ).toThrow('invalid accepted qualification run ID')
+    expect(Object.values(paths).map((path) => readFileSync(path, 'utf8'))).toEqual(before)
   })
 
   test('rejects malformed release metadata', () => {

--- a/packages/scripts/src/bayn/update-manifests.ts
+++ b/packages/scripts/src/bayn/update-manifests.ts
@@ -7,28 +7,25 @@ const digestPattern = /^sha256:[0-9a-f]{64}$/
 const hashPattern = /^[0-9a-f]{64}$/
 const sourceShaPattern = /^[0-9a-f]{40}$/
 const tagPattern = /^[A-Za-z0-9._-]{1,128}$/
-const currentCandidateIdentity = {
-  BAYN_SIGNAL_SNAPSHOT_ID: '840c75885270b349d4a992e003918ce7e6fe39730f981a20b2e88ae2db45a2e2',
-  BAYN_SIGNAL_PUBLICATION_ASOF: '2026-07-22',
-  BAYN_SIGNAL_CALENDAR_VERSION: 'alpaca-us-equity-calendar-v1',
-  BAYN_SIGNAL_DATA_START: '2016-01-04',
-  BAYN_SIGNAL_DATA_END: '2026-07-22',
-  BAYN_SIGNAL_LOOKBACK_START: '2016-01-04',
-  BAYN_SIGNAL_EVALUATION_START: '2017-01-03',
-  BAYN_SIGNAL_EVALUATION_END: '2026-07-22',
-  BAYN_TIGERBEETLE_CLUSTER_ID: '122731676035874920802382025803517750735',
-  BAYN_TIGERBEETLE_LEDGER: '7001',
-} as const
+const isoDatePattern = /^\d{4}-\d{2}-\d{2}$/
+const decimalPattern = /^[0-9]+$/
+const transportAddressesPattern = /^[A-Za-z0-9.[\]:_-]+(?:,[A-Za-z0-9.[\]:_-]+)*$/
+const maximumTigerBeetleClusterId = (1n << 128n) - 1n
+const maximumTigerBeetleLedger = 2 ** 32 - 1
 
-const currentTransportConfiguration = {
-  BAYN_TIGERBEETLE_ADDRESSES:
-    'ledger-0.ledger-headless.bayn.svc.cluster.local:3000,ledger-1.ledger-headless.bayn.svc.cluster.local:3000,ledger-2.ledger-headless.bayn.svc.cluster.local:3000',
-} as const
-
-const currentRuntimeConfiguration = {
-  ...currentCandidateIdentity,
-  ...currentTransportConfiguration,
-} as const
+export interface BaynCandidateRuntime {
+  readonly BAYN_SIGNAL_SNAPSHOT_ID: string
+  readonly BAYN_SIGNAL_PUBLICATION_ASOF: string
+  readonly BAYN_SIGNAL_CALENDAR_VERSION: string
+  readonly BAYN_SIGNAL_DATA_START: string
+  readonly BAYN_SIGNAL_DATA_END: string
+  readonly BAYN_SIGNAL_LOOKBACK_START: string
+  readonly BAYN_SIGNAL_EVALUATION_START: string
+  readonly BAYN_SIGNAL_EVALUATION_END: string
+  readonly BAYN_TIGERBEETLE_CLUSTER_ID: string
+  readonly BAYN_TIGERBEETLE_ADDRESSES: string
+  readonly BAYN_TIGERBEETLE_LEDGER: string
+}
 
 export interface UpdateBaynManifestOptions {
   readonly sourceSha: string
@@ -37,6 +34,8 @@ export interface UpdateBaynManifestOptions {
   readonly strategyBehaviorHash: string
   readonly strategyParameterHash: string
   readonly rolloutTimestamp: string
+  readonly candidateRuntime?: BaynCandidateRuntime
+  readonly acceptedQualificationRunId?: string
   readonly kustomizationPath?: string
   readonly deploymentPath?: string
   readonly applicationSetPath?: string
@@ -45,10 +44,12 @@ export interface UpdateBaynManifestOptions {
 export interface BaynManifestUpdate {
   readonly promotionAction: 'promote' | 'hold'
   readonly promotionReason: 'eligible' | 'strategy-identity-change-requires-fresh-snapshot'
-  readonly qualificationMode: 'preserve' | 'replace'
+  readonly qualificationMode: 'preserve' | 'replace' | 'install'
   readonly hadQualificationPin: boolean
   readonly qualificationBindingsMatch: boolean
   readonly snapshotChanged: boolean
+  readonly deployedQualificationRunId: string | null
+  readonly candidateQualificationRunId: string | null
   readonly deployedSnapshotId: string
   readonly candidateSnapshotId: string
   readonly deployedSourceSha: string
@@ -74,17 +75,109 @@ const environmentValue = (deployment: string, name: string): string => {
 }
 
 const qualificationPin = /            - name: BAYN_QUALIFICATION_RUN_ID\n              value: [^\n]+\n/
+const qualificationIdentityNames = [
+  'BAYN_SIGNAL_SNAPSHOT_ID',
+  'BAYN_SIGNAL_PUBLICATION_ASOF',
+  'BAYN_SIGNAL_CALENDAR_VERSION',
+  'BAYN_SIGNAL_DATA_START',
+  'BAYN_SIGNAL_DATA_END',
+  'BAYN_SIGNAL_LOOKBACK_START',
+  'BAYN_SIGNAL_EVALUATION_START',
+  'BAYN_SIGNAL_EVALUATION_END',
+  'BAYN_TIGERBEETLE_CLUSTER_ID',
+  'BAYN_TIGERBEETLE_LEDGER',
+] as const
+
+const runtimeFromDeployment = (deployment: string): BaynCandidateRuntime => ({
+  BAYN_SIGNAL_SNAPSHOT_ID: environmentValue(deployment, 'BAYN_SIGNAL_SNAPSHOT_ID'),
+  BAYN_SIGNAL_PUBLICATION_ASOF: environmentValue(deployment, 'BAYN_SIGNAL_PUBLICATION_ASOF'),
+  BAYN_SIGNAL_CALENDAR_VERSION: environmentValue(deployment, 'BAYN_SIGNAL_CALENDAR_VERSION'),
+  BAYN_SIGNAL_DATA_START: environmentValue(deployment, 'BAYN_SIGNAL_DATA_START'),
+  BAYN_SIGNAL_DATA_END: environmentValue(deployment, 'BAYN_SIGNAL_DATA_END'),
+  BAYN_SIGNAL_LOOKBACK_START: environmentValue(deployment, 'BAYN_SIGNAL_LOOKBACK_START'),
+  BAYN_SIGNAL_EVALUATION_START: environmentValue(deployment, 'BAYN_SIGNAL_EVALUATION_START'),
+  BAYN_SIGNAL_EVALUATION_END: environmentValue(deployment, 'BAYN_SIGNAL_EVALUATION_END'),
+  BAYN_TIGERBEETLE_CLUSTER_ID: environmentValue(deployment, 'BAYN_TIGERBEETLE_CLUSTER_ID'),
+  BAYN_TIGERBEETLE_ADDRESSES: environmentValue(deployment, 'BAYN_TIGERBEETLE_ADDRESSES'),
+  BAYN_TIGERBEETLE_LEDGER: environmentValue(deployment, 'BAYN_TIGERBEETLE_LEDGER'),
+})
+
+const validateIsoDate = (name: string, value: string): void => {
+  const parsed = new Date(`${value}T00:00:00.000Z`)
+  if (!isoDatePattern.test(value) || Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== value) {
+    throw new Error(`invalid ${name}: ${value}`)
+  }
+}
+
+const validateCandidateRuntime = (runtime: BaynCandidateRuntime): void => {
+  if (!hashPattern.test(runtime.BAYN_SIGNAL_SNAPSHOT_ID)) {
+    throw new Error(`invalid candidate Signal snapshot ID: ${runtime.BAYN_SIGNAL_SNAPSHOT_ID}`)
+  }
+  if (!tagPattern.test(runtime.BAYN_SIGNAL_CALENDAR_VERSION)) {
+    throw new Error(`invalid candidate Signal calendar version: ${runtime.BAYN_SIGNAL_CALENDAR_VERSION}`)
+  }
+  validateIsoDate('candidate Signal publication date', runtime.BAYN_SIGNAL_PUBLICATION_ASOF)
+  validateIsoDate('candidate Signal data start', runtime.BAYN_SIGNAL_DATA_START)
+  validateIsoDate('candidate Signal data end', runtime.BAYN_SIGNAL_DATA_END)
+  validateIsoDate('candidate Signal lookback start', runtime.BAYN_SIGNAL_LOOKBACK_START)
+  validateIsoDate('candidate Signal evaluation start', runtime.BAYN_SIGNAL_EVALUATION_START)
+  validateIsoDate('candidate Signal evaluation end', runtime.BAYN_SIGNAL_EVALUATION_END)
+  if (
+    runtime.BAYN_SIGNAL_DATA_END !== runtime.BAYN_SIGNAL_PUBLICATION_ASOF ||
+    runtime.BAYN_SIGNAL_EVALUATION_END !== runtime.BAYN_SIGNAL_PUBLICATION_ASOF
+  ) {
+    throw new Error('candidate Signal data and evaluation end must equal publication date')
+  }
+  if (
+    runtime.BAYN_SIGNAL_DATA_START > runtime.BAYN_SIGNAL_LOOKBACK_START ||
+    runtime.BAYN_SIGNAL_LOOKBACK_START > runtime.BAYN_SIGNAL_EVALUATION_START ||
+    runtime.BAYN_SIGNAL_EVALUATION_START > runtime.BAYN_SIGNAL_EVALUATION_END
+  ) {
+    throw new Error('candidate Signal bounds are not ordered')
+  }
+  if (!decimalPattern.test(runtime.BAYN_TIGERBEETLE_CLUSTER_ID)) {
+    throw new Error(`invalid candidate TigerBeetle cluster ID: ${runtime.BAYN_TIGERBEETLE_CLUSTER_ID}`)
+  }
+  const clusterId = BigInt(runtime.BAYN_TIGERBEETLE_CLUSTER_ID)
+  if (clusterId <= 0n || clusterId > maximumTigerBeetleClusterId) {
+    throw new Error(`invalid candidate TigerBeetle cluster ID: ${runtime.BAYN_TIGERBEETLE_CLUSTER_ID}`)
+  }
+  if (!transportAddressesPattern.test(runtime.BAYN_TIGERBEETLE_ADDRESSES)) {
+    throw new Error(`invalid candidate TigerBeetle addresses: ${runtime.BAYN_TIGERBEETLE_ADDRESSES}`)
+  }
+  if (!decimalPattern.test(runtime.BAYN_TIGERBEETLE_LEDGER)) {
+    throw new Error(`invalid candidate TigerBeetle ledger: ${runtime.BAYN_TIGERBEETLE_LEDGER}`)
+  }
+  const ledger = Number(runtime.BAYN_TIGERBEETLE_LEDGER)
+  if (!Number.isSafeInteger(ledger) || ledger <= 0 || ledger > maximumTigerBeetleLedger) {
+    throw new Error(`invalid candidate TigerBeetle ledger: ${runtime.BAYN_TIGERBEETLE_LEDGER}`)
+  }
+}
 
 const transitionQualificationPin = (
   deployment: string,
-  mode: 'preserve' | 'replace',
+  mode: 'preserve' | 'replace' | 'install',
   hadQualificationPin: boolean,
+  acceptedQualificationRunId: string | undefined,
 ): string => {
   if (mode === 'preserve') {
     if (!hadQualificationPin) throw new Error('cannot preserve a missing BAYN_QUALIFICATION_RUN_ID block')
     return deployment
   }
-  return hadQualificationPin ? deployment.replace(qualificationPin, '') : deployment
+  if (mode === 'replace') return hadQualificationPin ? deployment.replace(qualificationPin, '') : deployment
+  if (acceptedQualificationRunId === undefined) {
+    throw new Error('cannot install a missing accepted qualification run ID')
+  }
+  const block =
+    `            - name: BAYN_QUALIFICATION_RUN_ID\n` +
+    `              value: ${JSON.stringify(acceptedQualificationRunId)}\n`
+  if (hadQualificationPin) return deployment.replace(qualificationPin, block)
+  return replaceExactlyOnce(
+    deployment,
+    /(            - name: BAYN_STRATEGY_PARAMETER_HASH\n              value: [^\n]+\n)/,
+    `$1${block}`,
+    'BAYN_STRATEGY_PARAMETER_HASH block',
+  )
 }
 
 export const updateBaynManifests = (options: UpdateBaynManifestOptions): BaynManifestUpdate => {
@@ -97,6 +190,9 @@ export const updateBaynManifests = (options: UpdateBaynManifestOptions): BaynMan
   if (!hashPattern.test(options.strategyParameterHash)) {
     throw new Error(`invalid strategy parameter hash: ${options.strategyParameterHash}`)
   }
+  if (options.acceptedQualificationRunId !== undefined && !hashPattern.test(options.acceptedQualificationRunId)) {
+    throw new Error(`invalid accepted qualification run ID: ${options.acceptedQualificationRunId}`)
+  }
   if (Number.isNaN(Date.parse(options.rolloutTimestamp))) throw new Error('rollout timestamp must be ISO-8601')
 
   const kustomizationPath = options.kustomizationPath ?? 'argocd/applications/bayn/kustomization.yaml'
@@ -107,27 +203,72 @@ export const updateBaynManifests = (options: UpdateBaynManifestOptions): BaynMan
   const qualificationPins = [...deployment.matchAll(new RegExp(qualificationPin.source, 'g'))]
   if (qualificationPins.length > 1) throw new Error('expected at most one BAYN_QUALIFICATION_RUN_ID block')
   const hadQualificationPin = qualificationPins.length === 1
-  if (hadQualificationPin && !hashPattern.test(environmentValue(deployment, 'BAYN_QUALIFICATION_RUN_ID'))) {
+  const deployedQualificationRunId = hadQualificationPin
+    ? environmentValue(deployment, 'BAYN_QUALIFICATION_RUN_ID')
+    : null
+  if (deployedQualificationRunId !== null && !hashPattern.test(deployedQualificationRunId)) {
     throw new Error('invalid deployed BAYN_QUALIFICATION_RUN_ID')
   }
+  const candidateRuntime = options.candidateRuntime ?? runtimeFromDeployment(deployment)
+  validateCandidateRuntime(candidateRuntime)
   const deployedSourceSha = environmentValue(deployment, 'BAYN_CODE_REVISION')
   const deployedBehaviorHash = environmentValue(deployment, 'BAYN_STRATEGY_BEHAVIOR_HASH')
   const deployedParameterHash = environmentValue(deployment, 'BAYN_STRATEGY_PARAMETER_HASH')
   const deployedSnapshotId = environmentValue(deployment, 'BAYN_SIGNAL_SNAPSHOT_ID')
-  const candidateSnapshotId = currentRuntimeConfiguration.BAYN_SIGNAL_SNAPSHOT_ID
+  const candidateSnapshotId = candidateRuntime.BAYN_SIGNAL_SNAPSHOT_ID
   const snapshotChanged = deployedSnapshotId !== candidateSnapshotId
-  const qualificationBindingsMatch = Object.entries(currentCandidateIdentity).every(
-    ([name, value]) => environmentValue(deployment, name) === value,
+  const qualificationBindingsMatch = qualificationIdentityNames.every(
+    (name) => environmentValue(deployment, name) === candidateRuntime[name],
   )
   const strategyIdentityMatches =
     deployedBehaviorHash === options.strategyBehaviorHash && deployedParameterHash === options.strategyParameterHash
-  const qualificationMode =
-    hadQualificationPin && strategyIdentityMatches && qualificationBindingsMatch ? 'preserve' : 'replace'
+  const acceptedQualificationRunId = options.acceptedQualificationRunId
+  const acceptedRunAlreadyPinned =
+    acceptedQualificationRunId !== undefined && deployedQualificationRunId === acceptedQualificationRunId
+  if (acceptedQualificationRunId !== undefined && !acceptedRunAlreadyPinned && options.candidateRuntime === undefined) {
+    throw new Error('installing an accepted qualification run requires an explicit candidate runtime')
+  }
+  if (acceptedRunAlreadyPinned && (!strategyIdentityMatches || !qualificationBindingsMatch)) {
+    throw new Error('an accepted qualification pin cannot be rebound to different strategy or runtime identity')
+  }
+  if (
+    acceptedQualificationRunId !== undefined &&
+    !acceptedRunAlreadyPinned &&
+    hadQualificationPin &&
+    !snapshotChanged
+  ) {
+    throw new Error('qualification run replacement requires a fresh BAYN_SIGNAL_SNAPSHOT_ID')
+  }
+  if (
+    acceptedQualificationRunId !== undefined &&
+    !acceptedRunAlreadyPinned &&
+    !qualificationBindingsMatch &&
+    !snapshotChanged
+  ) {
+    throw new Error('qualification installation requires identical bindings or a fresh BAYN_SIGNAL_SNAPSHOT_ID')
+  }
+  let qualificationMode: BaynManifestUpdate['qualificationMode']
+  if (acceptedQualificationRunId !== undefined && !acceptedRunAlreadyPinned) {
+    qualificationMode = 'install'
+  } else if (hadQualificationPin && strategyIdentityMatches && qualificationBindingsMatch) {
+    qualificationMode = 'preserve'
+  } else {
+    qualificationMode = 'replace'
+  }
+  let candidateQualificationRunId: string | null = null
+  if (qualificationMode === 'install') {
+    if (acceptedQualificationRunId === undefined) throw new Error('accepted qualification run ID is missing')
+    candidateQualificationRunId = acceptedQualificationRunId
+  } else if (qualificationMode === 'preserve') {
+    candidateQualificationRunId = deployedQualificationRunId
+  }
   const updateDetails = {
     qualificationMode,
     hadQualificationPin,
     qualificationBindingsMatch,
     snapshotChanged,
+    deployedQualificationRunId,
+    candidateQualificationRunId,
     deployedSnapshotId,
     candidateSnapshotId,
     deployedSourceSha,
@@ -182,8 +323,13 @@ export const updateBaynManifests = (options: UpdateBaynManifestOptions): BaynMan
     `$1${JSON.stringify(options.strategyParameterHash)}`,
     'BAYN_STRATEGY_PARAMETER_HASH value',
   )
-  updatedDeployment = transitionQualificationPin(updatedDeployment, qualificationMode, hadQualificationPin)
-  for (const [name, value] of Object.entries(currentRuntimeConfiguration)) {
+  updatedDeployment = transitionQualificationPin(
+    updatedDeployment,
+    qualificationMode,
+    hadQualificationPin,
+    acceptedQualificationRunId,
+  )
+  for (const [name, value] of Object.entries(candidateRuntime)) {
     updatedDeployment = replaceExactlyOnce(
       updatedDeployment,
       new RegExp(`(            - name: ${name}\\n              value: )[^\\n]+`),
@@ -216,18 +362,73 @@ export const updateBaynManifests = (options: UpdateBaynManifestOptions): BaynMan
   }
 }
 
-const parseArguments = (argumentsToParse: readonly string[]): UpdateBaynManifestOptions => {
+const candidateRuntimeFlags = {
+  '--signal-snapshot-id': 'BAYN_SIGNAL_SNAPSHOT_ID',
+  '--signal-publication-asof': 'BAYN_SIGNAL_PUBLICATION_ASOF',
+  '--signal-calendar-version': 'BAYN_SIGNAL_CALENDAR_VERSION',
+  '--signal-data-start': 'BAYN_SIGNAL_DATA_START',
+  '--signal-data-end': 'BAYN_SIGNAL_DATA_END',
+  '--signal-lookback-start': 'BAYN_SIGNAL_LOOKBACK_START',
+  '--signal-evaluation-start': 'BAYN_SIGNAL_EVALUATION_START',
+  '--signal-evaluation-end': 'BAYN_SIGNAL_EVALUATION_END',
+  '--tigerbeetle-cluster-id': 'BAYN_TIGERBEETLE_CLUSTER_ID',
+  '--tigerbeetle-addresses': 'BAYN_TIGERBEETLE_ADDRESSES',
+  '--tigerbeetle-ledger': 'BAYN_TIGERBEETLE_LEDGER',
+} as const
+
+const requiredFlags = [
+  '--source-sha',
+  '--tag',
+  '--digest',
+  '--strategy-behavior-hash',
+  '--strategy-parameter-hash',
+  '--rollout-timestamp',
+] as const
+
+export const parseUpdateBaynManifestArguments = (argumentsToParse: readonly string[]): UpdateBaynManifestOptions => {
   const values = new Map<string, string>()
+  const allowedFlags = new Set([
+    ...requiredFlags,
+    ...Object.keys(candidateRuntimeFlags),
+    '--accepted-qualification-run-id',
+  ])
   for (let index = 0; index < argumentsToParse.length; index += 2) {
     const flag = argumentsToParse[index]
     const value = argumentsToParse[index + 1]
     if (!flag?.startsWith('--') || value === undefined) throw new Error(`invalid argument near ${flag ?? '<end>'}`)
+    if (!allowedFlags.has(flag)) throw new Error(`unknown argument: ${flag}`)
+    if (values.has(flag)) throw new Error(`duplicate argument: ${flag}`)
     values.set(flag, value)
   }
   const required = (flag: string): string => {
     const value = values.get(flag)?.trim()
     if (!value) throw new Error(`${flag} is required`)
     return value
+  }
+  const providedCandidateFlags = Object.keys(candidateRuntimeFlags).filter((flag) => values.has(flag))
+  let candidateRuntime: BaynCandidateRuntime | undefined
+  if (providedCandidateFlags.length > 0) {
+    const missingCandidateFlags = Object.keys(candidateRuntimeFlags).filter((flag) => !values.has(flag))
+    if (missingCandidateFlags.length > 0) {
+      throw new Error(`candidate runtime flags must be provided together; missing ${missingCandidateFlags.join(', ')}`)
+    }
+    candidateRuntime = {
+      BAYN_SIGNAL_SNAPSHOT_ID: required('--signal-snapshot-id'),
+      BAYN_SIGNAL_PUBLICATION_ASOF: required('--signal-publication-asof'),
+      BAYN_SIGNAL_CALENDAR_VERSION: required('--signal-calendar-version'),
+      BAYN_SIGNAL_DATA_START: required('--signal-data-start'),
+      BAYN_SIGNAL_DATA_END: required('--signal-data-end'),
+      BAYN_SIGNAL_LOOKBACK_START: required('--signal-lookback-start'),
+      BAYN_SIGNAL_EVALUATION_START: required('--signal-evaluation-start'),
+      BAYN_SIGNAL_EVALUATION_END: required('--signal-evaluation-end'),
+      BAYN_TIGERBEETLE_CLUSTER_ID: required('--tigerbeetle-cluster-id'),
+      BAYN_TIGERBEETLE_ADDRESSES: required('--tigerbeetle-addresses'),
+      BAYN_TIGERBEETLE_LEDGER: required('--tigerbeetle-ledger'),
+    }
+  }
+  const acceptedQualificationRunId = values.get('--accepted-qualification-run-id')?.trim()
+  if (acceptedQualificationRunId && candidateRuntime === undefined) {
+    throw new Error('--accepted-qualification-run-id requires the complete candidate runtime')
   }
   return {
     sourceSha: required('--source-sha'),
@@ -236,12 +437,14 @@ const parseArguments = (argumentsToParse: readonly string[]): UpdateBaynManifest
     strategyBehaviorHash: required('--strategy-behavior-hash'),
     strategyParameterHash: required('--strategy-parameter-hash'),
     rolloutTimestamp: required('--rollout-timestamp'),
+    ...(candidateRuntime === undefined ? {} : { candidateRuntime }),
+    ...(acceptedQualificationRunId ? { acceptedQualificationRunId } : {}),
   }
 }
 
 if (import.meta.main) {
   try {
-    process.stdout.write(JSON.stringify(updateBaynManifests(parseArguments(process.argv.slice(2)))))
+    process.stdout.write(JSON.stringify(updateBaynManifests(parseUpdateBaynManifestArguments(process.argv.slice(2)))))
   } catch (cause) {
     console.error(cause instanceof Error ? cause.message : String(cause))
     process.exitCode = 1

--- a/packages/scripts/src/shared/__tests__/bayn-cycle-observability-contract.test.ts
+++ b/packages/scripts/src/shared/__tests__/bayn-cycle-observability-contract.test.ts
@@ -26,7 +26,41 @@ const baynRules = (): readonly MimirRule[] => {
   return group.rules
 }
 
-describe('Bayn cycle operations alert contract', () => {
+describe('Bayn cycle operations contract', () => {
+  test('keeps autonomous broker observation explicitly bounded to OBSERVE authority', () => {
+    const deployment = YAML.parse(readRepoFile('argocd/applications/bayn/deployment.yaml')) as Record<string, any>
+    const container = deployment.spec.template.spec.containers.find(
+      ({ name }: { readonly name: string }) => name === 'bayn',
+    )
+    const environment = Object.fromEntries(container.env.map((entry: { readonly name: string }) => [entry.name, entry]))
+    const generationHash = createHash('sha256').update('bayn/authority-generation/autonomous-observe-v1').digest('hex')
+
+    expect(environment.BAYN_MAXIMUM_AUTHORITY).toEqual({
+      name: 'BAYN_MAXIMUM_AUTHORITY',
+      value: 'OBSERVE',
+    })
+    expect(environment.BAYN_AUTHORITY_GENERATION_HASH).toEqual({
+      name: 'BAYN_AUTHORITY_GENERATION_HASH',
+      value: generationHash,
+    })
+    expect(environment.BAYN_CYCLE_POLL_INTERVAL_MS).toEqual({
+      name: 'BAYN_CYCLE_POLL_INTERVAL_MS',
+      value: '30000',
+    })
+    expect(environment.BAYN_ALPACA_ACCOUNT_ID.valueFrom.secretKeyRef).toEqual({
+      name: 'bayn-alpaca-auth',
+      key: 'account-id',
+    })
+    expect(environment.BAYN_ALPACA_KEY_ID.valueFrom.secretKeyRef).toEqual({
+      name: 'bayn-alpaca-auth',
+      key: 'key-id',
+    })
+    expect(environment.BAYN_ALPACA_SECRET_KEY.valueFrom.secretKeyRef).toEqual({
+      name: 'bayn-alpaca-auth',
+      key: 'secret-key',
+    })
+  })
+
   test('alerts only on scrape health and canonical service conditions', () => {
     const rules = baynRules()
     expect(rules.map(({ alert }) => alert)).toEqual([

--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -51,7 +51,10 @@ paper mutation capability, execution entry point, and capital-promotion path rem
   verifies the stored strategy and Signal bindings, then recovers it without inspecting bars, opening a lock,
   evaluating, journaling, or persisting.
 - Production GitOps carries that pin outside an explicit one-shot qualification release. The release writer refuses a
-  second source revision on the same unpinned snapshot, preventing operational releases from creating new trials.
+  second source revision on the same unpinned snapshot. A controlled invocation may pin the exact independently
+  accepted terminal run only for that already deployed source and complete reviewed runtime; automatic image promotion
+  supplies neither. Once pinned, a later operational release may change source only while preserving compiled strategy
+  and qualification identity. This prevents extra trials or rebinding evidence to implicit inputs.
 - The compiled risk-balanced trend decision function records every normalized trend horizon, volatility estimate,
   portfolio-volatility scale, and target weight at a month-end close. Quantities are planned only after that Signal
   session is finalized, using its close prices and reconciled broker state observed before planning. Ordinary


### PR DESCRIPTION
## Summary

- stage the existing sealed Alpaca paper-account references, deterministic OBSERVE authority generation, and 30-second cycle poll interval while keeping `BAYN_MAXIMUM_AUTHORITY=OBSERVE`
- remove the release writer hard-coded Signal candidate; automatic promotion now reads the deployed runtime and cannot create a qualification pin
- require one complete explicit Signal/TigerBeetle tuple to select a candidate, and install an independently accepted terminal run only for the already-deployed unpinned source
- preserve the second-source lock, same-snapshot pin-replacement rejection, and no-write hold/error behavior with focused regressions
- retain one YAML-semantic contract test for the authority, poll interval, and exact SealedSecret key references

## Related Issues

PROOMPT-375, PROOMPT-382, PROOMPT-383, PROOMPT-384, and PROOMPT-404.

This draft is the held rollout vessel. Do not merge it against the current old image. After the first untouched natural Signal publication, the qualification release must deploy exactly one reviewed source and fresh snapshot unpinned. The terminal run must then be independently audited and pinned for that same deployed source. Only after that pin exists may a later operational release change source while preserving identical compiled strategy and qualification identity.

Stale release PR #13137 was closed; it targeted an obsolete image/source tuple and must not be revived as a competing rollout.

## Testing

- `bun test packages/scripts/src/bayn/update-manifests.test.ts` — 17 passed, 0 failed
- `bun test packages/scripts/src/bayn packages/scripts/src/shared/__tests__/bayn-cycle-observability-contract.test.ts` — 20 passed, 0 failed
- isolated strict TypeScript for the changed writer and tests
- focused and package-wide Oxlint, type-aware Oxlint, and Oxfmt
- `actionlint -shellcheck "" -pyflakes "" .github/workflows/bayn-release.yml`
- `bun run lint:argocd`
- `kustomize build argocd/applications/bayn`
- `kubectl apply --dry-run=client` against the rendered Bayn manifests
- `git diff --check`
- independent release-safety review approved the corrected pin-first source lock

## Screenshots (if applicable)

N/A.

## Breaking Changes

When the fresh qualification pin and approved image are present, the rollout will activate GET-only Alpaca preflight and the autonomous OBSERVE loop. BrokerMutation, IntentStore, and MutationStore remain absent under OBSERVE. Automatic image promotion never creates a qualification pin, and an accepted run cannot authorize a second source on an unpinned snapshot.

## Checklist

- [x] Testing documents the exact validation performed.
- [x] No plaintext credentials, broker mutation authority, or PAPER authority are added.
- [x] Source, snapshot, and qualification transitions remain explicit and fail closed.
- [x] The PR remains draft until the fresh terminal qualification and final immutable release tuple exist.
