### PR TITLE
fix(bayn): close autonomous cycle audit gaps

### DIFF
--- a/docs/bayn/architecture.md
+++ b/docs/bayn/architecture.md
@@ -15,8 +15,9 @@ The runtime has three external I/O boundaries:
 - a dedicated Bayn TigerBeetle cluster for deterministic simulation accounting; and
 - the existing `EvidenceStore` interface for durable qualification evidence.
 
-Alpaca is reachable only through the existing paper-host CONNECT proxy. Credential binding first performs a bounded,
-runtime-decoded GET-only preflight. Paper reconciliation and mutation remain separate authority-gated steps.
+Alpaca is reachable only through the existing paper-host CONNECT proxy. Credentials provide runtime-decoded GET-only
+broker access. Under `OBSERVE`, the canonical non-dispatchable autonomous shadow loop composes `PaperStore` and
+`WriterFence` and performs one same-pass reconciliation when it builds a decision; broker mutation remains absent.
 
 The implementation behind `EvidenceStore` is deliberately outside this document. Non-database cleanup must preserve
 that interface and every persisted evidence contract.
@@ -68,10 +69,10 @@ order identity, and consistency delay in PostgreSQL. Any unresolved submit or ca
 intents; terminal recovery releases that block. There is no scheduler, public order route, arbitrary order API, blind
 flatten, runtime registry, or alternate writer.
 
-This path is intentionally dormant: `src/index.ts` does not provide `BrokerMutation` or invoke the coordinator, and the
-current qualification is not execution authority. A credential mounted under `OBSERVE` performs GET-only preflight;
-the paper store, writer fence, and reconciliation loop are built only under `PAPER`. Enabling paper operation requires
-a separate reviewed change and an audited qualified result.
+This path is intentionally dormant: credentials provide GET-only broker access, while `OBSERVE` composes `PaperStore`
+and `WriterFence` for one same-pass reconciliation inside the canonical non-dispatchable autonomous shadow loop.
+`BrokerMutation`, `IntentStore`, `MutationStore`, and the coordinator remain absent. `PAPER` startup fails closed until
+the PROOMPT-375 Phase B authority generation and dispatch transition exists.
 
 ## Effect composition
 
@@ -94,9 +95,10 @@ Effect is used at resource and failure boundaries, not as a container for ordina
   operation.
 - HTTP receives the runtime state and the narrow evidence-read callback it needs. It does not depend on the strategy or
   the complete evidence service.
-- The Alpaca read adapter may enter runtime composition for GET-only preflight under `OBSERVE`. The mutation adapter,
-  intent and mutation stores, writer fence, reconciliation loop, and recovery coordinator remain outside composition
-  until the authority gates explicitly permit a paper slice.
+- The Alpaca read adapter enters runtime composition for GET-only access under `OBSERVE`. `PaperStore` and
+  `WriterFence` support one same-pass reconciliation inside the canonical non-dispatchable autonomous shadow loop.
+  `BrokerMutation`, `IntentStore`, `MutationStore`, and the coordinator remain outside composition, and `PAPER` startup
+  fails closed until the PROOMPT-375 Phase B authority generation and dispatch transition exists.
 
 Do not introduce a `Context.Service` or `Layer` for a pure value merely to make it injectable. Add an Effect service
 only when a capability needs acquisition, release, configuration, retry, concurrency, or typed I/O failure.

--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -82,9 +82,10 @@ paper mutation capability, execution entry point, and capital-promotion path rem
 - The current-only migration chain owns the unprefixed evidence, qualification, intent, and mutation schema. Startup
   rejects a legacy migration tracker or retired migration history after the hard cut; it never reads, converts, or
   falls back to legacy records.
-- The Alpaca read adapter may be acquired while maximum authority is `OBSERVE`, but it performs GET-only preflight and
-  does not build the paper store, reserve the writer fence, start reconciliation, or change PostgreSQL or TigerBeetle.
-  The mutation adapter and recovery coordinator remain dormant source foundations.
+- Credentials provide GET-only Alpaca access under `OBSERVE`. The canonical non-dispatchable autonomous shadow loop
+  composes `PaperStore` and `WriterFence` and performs one same-pass reconciliation when it builds a decision.
+  `BrokerMutation`, `IntentStore`, `MutationStore`, and the coordinator remain absent; `PAPER` startup fails closed until
+  the PROOMPT-375 Phase B authority generation and dispatch transition exists.
 - The bounded Alpaca calendar observation is content-hashed with its request range, source/version, and normalized UTC
   sessions. A causal execution-session binding retains and revalidates that complete observation, selects its first
   post-signal session, and binds the session's exact open, close, pre-open cutoff, finalized Signal identity, and

--- a/services/bayn/src/cycle-runner.test.ts
+++ b/services/bayn/src/cycle-runner.test.ts
@@ -992,7 +992,7 @@ describe('autonomous cycle runner', () => {
     expect(control.binds).toBe(1)
   })
 
-  test('finishes an exact pre-cutoff decision after cutoff and a runtime protocol change', async () => {
+  test('finishes an exact pre-cutoff decision at the post-read Clock time after cutoff and a protocol change', async () => {
     const control: StoreControl = { acquisitions: [], binds: 0 }
     const store = cycleStore(control)
     let calendarReads = 0
@@ -1004,6 +1004,7 @@ describe('autonomous cycle runner', () => {
     const marketData = marketDataService(Effect.succeed(finalizedPublication()), inspection)
     const decisionAt = '2026-02-02T14:20:00.000Z'
     const afterCutoff = '2026-02-02T14:29:00.000Z'
+    const afterDelayedRead = '2026-02-02T14:30:00.000Z'
 
     const results = await Effect.runPromise(
       Effect.gen(function* () {
@@ -1023,7 +1024,12 @@ describe('autonomous cycle runner', () => {
           ...context(),
           strategyProtocolHash: 'f'.repeat(64),
         }
-        const recovered = yield* provide(runAutonomousCyclePass(changedProtocol), read, store, marketData)
+        const delayedReadStore: CycleStoreShape = {
+          ...store,
+          readDecisionDocument: (cycleId) =>
+            TestClock.adjust(60_000).pipe(Effect.andThen(store.readDecisionDocument(cycleId))),
+        }
+        const recovered = yield* provide(runAutonomousCyclePass(changedProtocol), read, delayedReadStore, marketData)
         return { acquired, activated, decisionBound, recovered }
       }).pipe(Effect.provide(TestClock.layer())),
     )
@@ -1041,10 +1047,10 @@ describe('autonomous cycle runner', () => {
     expect(results.recovered).toMatchObject({
       outcome: 'RECOVERED',
       action: 'NO_TRADE',
-      observedAt: afterCutoff,
+      observedAt: afterDelayedRead,
       cycle: {
         state: CycleState.NoTrade,
-        terminalAt: afterCutoff,
+        terminalAt: afterDelayedRead,
       },
     })
     if (results.recovered.outcome !== 'RECOVERED') throw new Error('recovery fixture must finish the bound decision')
@@ -1115,8 +1121,10 @@ describe('autonomous cycle runner', () => {
       calendarReads += 1
       return Effect.succeed({ value: monthEndCalendar, evidence })
     })
-    const inspection = finalizedPublicationInspection()
-    const marketData = marketDataService(Effect.succeed(finalizedPublication()), inspection)
+    const correctionSnapshotId = 'e'.repeat(64)
+    const original = finalizedPublicationInspection()
+    const correction = finalizedPublicationInspection('2026-01-30', '2026-01-30T21:16:00.000Z', correctionSnapshotId)
+    const marketData = marketDataService(Effect.succeed(finalizedPublications([original])), correction)
 
     const result = await Effect.runPromise(
       Effect.gen(function* () {
@@ -1134,7 +1142,7 @@ describe('autonomous cycle runner', () => {
     expect(result.resumed).toMatchObject({
       outcome: 'RECOVERED',
       action: 'BOUND_SNAPSHOT',
-      cycle: { state: CycleState.Pending, bindings: { snapshotId } },
+      cycle: { state: CycleState.Pending, bindings: { snapshotId: correctionSnapshotId } },
     })
     expect(calendarReads).toBe(1)
     expect(control.acquisitions).toHaveLength(1)

--- a/services/bayn/src/cycle-runner.ts
+++ b/services/bayn/src/cycle-runner.ts
@@ -546,18 +546,19 @@ const recoverCycle = (
               runnerError('recover-cycle', 'store', 'durable shadow decision read failed', cause),
             ),
           )
+        const decisionObservedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
         const next = yield* chooseRecovery({
           qualificationRunId: context.qualificationRunId,
           accountId: context.accountId,
           strategyProtocolHash: context.strategyProtocolHash,
-          observedAt,
+          observedAt: decisionObservedAt,
           cycle: selection.cycle,
           decisionDocument: Option.match(document, {
             onNone: () => null,
             onSome: (value) => value,
           }),
         })
-        return yield* recoverCycle(next, context, observedAt)
+        return yield* recoverCycle(next, context, decisionObservedAt)
       })
     case 'FINISH':
       return Effect.gen(function* () {

--- a/services/bayn/src/health.test.ts
+++ b/services/bayn/src/health.test.ts
@@ -94,11 +94,18 @@ describe('Bayn continuous health', () => {
       executionEligible: false,
       executionDisabledReason: 'MAXIMUM_AUTHORITY_OBSERVE',
     }
-    const initial = {
+    const startedAt = new Date().toISOString()
+    const initial: RuntimeState = {
       ...readyState(),
-      broker: initialState(broker).broker,
+      autonomousCycleLoop: {
+        configured: true,
+        startedAt,
+        lastPass: { result: 'SUCCESS' as const, observedAt: startedAt, outcome: 'NO_PUBLICATION' as const },
+      },
+      broker: initialState(broker, true).broker,
     }
     const state = await Effect.runPromise(Ref.make(initial))
+    const cycleFiber = Effect.runFork(Effect.never)
     const dependencies = (
       effect: Effect.Effect<void, never, MarketData | Journal | EvidenceStore | CycleObservability>,
     ) =>
@@ -120,32 +127,70 @@ describe('Bayn continuous health', () => {
         Effect.provideService(CycleObservability, cycleObservability()),
       )
 
-    await Effect.runPromise(dependencies(probe(config, state, broker)))
-    expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
-      status: 'READY',
-      broker: {
-        configured: true,
-        expectedAccountId: brokerAccountId,
-        accountId: brokerAccountId,
-        accountBound: true,
-        readAvailable: true,
-        executionEligible: false,
-        executionDisabledReason: 'MAXIMUM_AUTHORITY_OBSERVE',
-        error: null,
-      },
-    })
+    try {
+      await Effect.runPromise(dependencies(probe(config, state, broker, cycleFiber)))
+      expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
+        status: 'READY',
+        broker: {
+          configured: true,
+          expectedAccountId: brokerAccountId,
+          accountId: brokerAccountId,
+          accountBound: true,
+          readAvailable: true,
+          executionEligible: false,
+          executionDisabledReason: 'MAXIMUM_AUTHORITY_OBSERVE',
+          error: null,
+        },
+      })
 
-    observedAccountId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
-    await Effect.runPromise(dependencies(probe(config, state, broker)))
+      observedAccountId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+      await Effect.runPromise(dependencies(probe(config, state, broker, cycleFiber)))
+      expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
+        status: 'DEGRADED',
+        broker: {
+          accountId: observedAccountId,
+          accountBound: false,
+          readAvailable: true,
+          error: `Alpaca account probe resolved ${observedAccountId}, expected ${brokerAccountId}`,
+        },
+        error: expect.stringContaining('broker: Alpaca account probe resolved'),
+      })
+    } finally {
+      await Effect.runPromise(Fiber.interrupt(cycleFiber))
+    }
+  })
+
+  test('degrades when Alpaca is configured without the autonomous cycle runner', async () => {
+    const broker: BrokerProbe = {
+      read: brokerRead(Effect.succeed(accountResult())),
+      expectedAccountId: brokerAccountId,
+      executionEligible: false,
+      executionDisabledReason: 'MAXIMUM_AUTHORITY_OBSERVE',
+    }
+    const initial: RuntimeState = {
+      ...readyState(),
+      autonomousCycleLoop: {
+        configured: false,
+        startedAt: null,
+        lastPass: null,
+      },
+      broker: initialState(broker).broker,
+    }
+    const state = await Effect.runPromise(Ref.make(initial))
+
+    await Effect.runPromise(provideHealthyDependencies(initial, probe(config, state, broker)))
+
     expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
       status: 'DEGRADED',
-      broker: {
-        accountId: observedAccountId,
-        accountBound: false,
-        readAvailable: true,
-        error: `Alpaca account probe resolved ${observedAccountId}, expected ${brokerAccountId}`,
+      health: {
+        dependencies: {
+          cycleRunner: {
+            status: 'UNAVAILABLE',
+            error: 'broker-configured Bayn runtime has no autonomous cycle loop',
+          },
+        },
       },
-      error: expect.stringContaining('broker: Alpaca account probe resolved'),
+      error: expect.stringContaining('cycleRunner: broker-configured Bayn runtime has no autonomous cycle loop'),
     })
   })
 

--- a/services/bayn/src/health.ts
+++ b/services/bayn/src/health.ts
@@ -143,10 +143,13 @@ const cycleLoopHealth = (
   checkedAt: string,
   checkedAtMs: number,
   stallThresholdMs: number,
+  required: boolean,
 ): DependencyHealth => {
   const available = (): DependencyHealth => ({ status: 'AVAILABLE', checkedAt, error: null })
   const unavailable = (error: string): DependencyHealth => ({ status: 'UNAVAILABLE', checkedAt, error })
-  if (!loop.configured) return available()
+  if (!loop.configured) {
+    return required ? unavailable('broker-configured Bayn runtime has no autonomous cycle loop') : available()
+  }
   if (fiber === undefined) return unavailable('configured autonomous cycle loop has no scoped fiber')
   if (Option.isSome(exit)) {
     if (Exit.isSuccess(exit.value)) return unavailable('autonomous cycle loop exited unexpectedly')
@@ -258,6 +261,7 @@ export const probe = (
         checkedAt,
         checkedAtMs,
         config.cycleStallThresholdMs,
+        broker !== undefined,
       )
       const cycle =
         cycleResult.error === null && cycleResult.value !== null

--- a/services/bayn/src/index.ts
+++ b/services/bayn/src/index.ts
@@ -4,8 +4,7 @@ import { Context, Effect, Layer, Logger, Redacted } from 'effect'
 
 import { run } from './app'
 import { riskBalancedTrendBehaviorHash } from './behavior'
-import { BrokerRead, alpacaHttpLayer, live as AlpacaReadLive } from './broker/alpaca'
-import { BrokerMutation, makeMutation } from './broker/alpaca-mutations'
+import { BrokerRead, live as AlpacaReadLive } from './broker/alpaca'
 import { verifyBehaviorHash, verifyParameterHash } from './build'
 import { loadConfig } from './config'
 import { makeRuntimeProvenance } from './contracts'
@@ -13,8 +12,6 @@ import { CycleObservabilityLive } from './db/cycle-observability'
 import { CycleStore, CycleStoreLive } from './db/cycle-store'
 import { EvidenceStoreLive } from './db/evidence-store'
 import { PaperStore, PaperStoreLive } from './db/paper-store'
-import { IntentStoreLive } from './execution/intents'
-import { MutationStoreLive } from './execution/mutations'
 import { WriterFence, WriterFenceLive } from './execution/writer-fence'
 import { operationalError } from './errors'
 import type { BrokerProbe } from './health'
@@ -24,7 +21,7 @@ import { makeObserveAutonomousCycleStartup } from './observe-composition'
 import { acquireSqlLayer } from './operations'
 import { Authority } from './paper'
 import { hashParameters, loadDefaultProtocol } from './protocol'
-import { runContinuously, runOnce } from './reconciler'
+import { runOnce } from './reconciler'
 import { makeStrategy } from './strategy'
 
 const main = Effect.gen(function* () {
@@ -68,7 +65,6 @@ const main = Effect.gen(function* () {
   const evidenceStore = yield* acquireSqlLayer(EvidenceStoreLive(config).pipe(Layer.provide(NodeServices.layer)))
   const cycleObservability = CycleObservabilityLive.pipe(Layer.provide(Layer.succeedContext(evidenceStore)))
   const journal = yield* acquireSqlLayer(JournalLive(config))
-  let reconciliation = Effect.void
   let broker: BrokerProbe | undefined
   let autonomousCycleStartup: Parameters<typeof run>[4]
   if (config.alpaca !== undefined) {
@@ -109,61 +105,30 @@ const main = Effect.gen(function* () {
       ),
     )
     const writerFence = Context.get(writerFenceContext, WriterFence)
-    if (config.maximumAuthority === Authority.Paper) {
-      const brokerMutation = yield* Layer.build(
-        Layer.effect(
-          BrokerMutation,
-          makeMutation({
-            expectedAccountId: config.alpaca.accountId,
-            maximumAuthority: config.maximumAuthority,
-            key: config.alpaca.key,
-            secret: config.alpaca.secret,
-            proxyUrl: config.alpaca.proxyUrl,
-            operationTimeoutMs: config.operationTimeoutMs,
-          }),
-        ).pipe(Layer.provide(alpacaHttpLayer(config.alpaca.proxyUrl))),
-      ).pipe(
-        Effect.mapError((cause) =>
-          operationalError('config', 'alpaca-mutation', 'Alpaca paper mutation binding failed', cause),
-        ),
-      )
-      const persistence = Layer.mergeAll(Layer.succeedContext(evidenceStore), Layer.succeed(WriterFence, writerFence))
-      const intentStore = yield* Layer.build(IntentStoreLive.pipe(Layer.provide(persistence)))
-      const mutationStore = yield* Layer.build(MutationStoreLive.pipe(Layer.provide(persistence)))
-      const paperExecution = Layer.mergeAll(
-        Layer.succeedContext(brokerReadContext),
-        Layer.succeedContext(brokerMutation),
-        Layer.succeedContext(paperStoreContext),
-        Layer.succeedContext(writerFenceContext),
-        Layer.succeedContext(intentStore),
-        Layer.succeedContext(mutationStore),
-      )
-      reconciliation = runContinuously(config.alpaca.reconciliationIntervalMs).pipe(Effect.provide(paperExecution))
-    } else {
-      const cycleStoreContext = yield* Layer.build(
-        CycleStoreLive.pipe(Layer.provide(Layer.succeedContext(evidenceStore))),
-      ).pipe(
-        Effect.mapError((cause) =>
-          operationalError('database', 'cycle-store', 'cycle persistence composition failed', cause),
-        ),
-      )
-      const reconcile = runOnce.pipe(
-        Effect.provideService(BrokerRead, brokerRead),
-        Effect.provideService(PaperStore, paperStore),
-        Effect.provideService(WriterFence, writerFence),
-      )
-      autonomousCycleStartup = makeObserveAutonomousCycleStartup({
-        accountId: config.alpaca.accountId,
-        authorityGenerationHash: config.alpaca.authorityGenerationHash,
-        brokerRead,
-        cycleStore: Context.get(cycleStoreContext, CycleStore),
-        marketData: marketDataService,
-        paperStore,
-        pollIntervalMs: config.cyclePollIntervalMs,
-        reconcile,
-        strategy,
-      })
-    }
+    const cycleStoreContext = yield* Layer.build(
+      CycleStoreLive.pipe(Layer.provide(Layer.succeedContext(evidenceStore))),
+    ).pipe(
+      Effect.mapError((cause) =>
+        operationalError('database', 'cycle-store', 'cycle persistence composition failed', cause),
+      ),
+    )
+    const reconcile = runOnce.pipe(
+      Effect.provideService(BrokerRead, brokerRead),
+      Effect.provideService(PaperStore, paperStore),
+      Effect.provideService(WriterFence, writerFence),
+    )
+    autonomousCycleStartup = makeObserveAutonomousCycleStartup({
+      accountId: config.alpaca.accountId,
+      authorityGenerationHash: config.alpaca.authorityGenerationHash,
+      brokerRead,
+      cycleStore: Context.get(cycleStoreContext, CycleStore),
+      marketData: marketDataService,
+      maximumAuthority: config.maximumAuthority,
+      paperStore,
+      pollIntervalMs: config.cyclePollIntervalMs,
+      reconcile,
+      strategy,
+    })
   }
   const dependencies = Layer.mergeAll(
     Layer.succeedContext(marketDataContext),
@@ -171,7 +136,7 @@ const main = Effect.gen(function* () {
     Layer.succeedContext(journal),
     Layer.succeedContext(evidenceStore),
   )
-  return yield* run(config, strategy, reconciliation, broker, autonomousCycleStartup).pipe(Effect.provide(dependencies))
+  return yield* run(config, strategy, Effect.void, broker, autonomousCycleStartup).pipe(Effect.provide(dependencies))
 }).pipe(Effect.scoped)
 
 const program = main.pipe(Effect.annotateLogs({ service: 'bayn' }), Effect.provide(Logger.layer([Logger.consoleJson])))

--- a/services/bayn/src/market-data.test.ts
+++ b/services/bayn/src/market-data.test.ts
@@ -312,6 +312,14 @@ const makeClickhouseFixture = (
         const matching = text.includes('AND calendar_version =')
           ? manifests.filter((manifest) => manifest.calendar_version === calendarVersion)
           : manifests
+        if (text.includes('ORDER BY finalized_at DESC, snapshot_id DESC')) {
+          return [...matching]
+            .sort((left, right) => {
+              if (left.finalized_at !== right.finalized_at) return right.finalized_at.localeCompare(left.finalized_at)
+              return right.snapshot_id.localeCompare(left.snapshot_id)
+            })
+            .slice(0, 1)
+        }
         if (!text.includes('ORDER BY publication_asof DESC')) return matching
         const ordered = [...matching].sort((left, right) => {
           if (left.publication_asof !== right.publication_asof) {
@@ -627,6 +635,82 @@ describe('finalized Signal snapshot reader', () => {
       expect(query.text).toContain('AND calendar_version =')
       expect(query.parameters).toContain(fixture.request.calendarVersion)
     }
+  })
+
+  test('deterministically selects the latest correction for an exact finalized publication', async () => {
+    const fixture = makeFixture()
+    const corrections = [
+      makePublicationRevision(fixture, {
+        barsContentHash: '4'.repeat(64),
+        finalizedAt: '2025-01-04 01:30:00.000',
+      }),
+      makePublicationRevision(fixture, {
+        barsContentHash: '5'.repeat(64),
+        finalizedAt: '2025-01-04 01:30:00.000',
+      }),
+    ]
+    const expected = [...corrections].sort((left, right) =>
+      right.manifest.snapshot_id.localeCompare(left.manifest.snapshot_id),
+    )[0]
+    if (expected === undefined) throw new Error('correction fixture must select one latest snapshot')
+    const queries: CapturedQuery[] = []
+    const client = makeClickhouseFixture(
+      [...fixture.rows.manifests, ...corrections.map((correction) => correction.manifest)],
+      [...fixture.rows.sessions, ...corrections.flatMap((correction) => correction.sessions)],
+      queries,
+    )
+    const layer = MarketDataLive(
+      {
+        operationTimeoutMs: 5_000,
+        clickhouse: {
+          url: 'http://clickhouse.test:8123',
+          username: 'bayn',
+          password: Redacted.make('secret'),
+          snapshotId,
+          publicationAsOf: fixture.request.publicationAsOf,
+          calendarVersion: fixture.request.calendarVersion,
+          bounds: fixture.request.bounds,
+        },
+      },
+      {
+        universeId: fixture.request.universeId,
+        universeSymbolHash: fixture.request.universeSymbolHash,
+        universe: fixture.request.universe,
+        historyStart: fixture.request.historyStart,
+        evaluationStart: fixture.request.evaluationStart,
+      },
+    ).pipe(Layer.provide(Layer.succeed(ClickhouseClient.ClickhouseClient, client)))
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const marketData = yield* MarketData
+        return yield* marketData.inspectPublication({
+          signalSessionDate: '2025-01-03',
+          signalCalendarVersion: fixture.request.calendarVersion,
+        })
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(result).toMatchObject({
+      outcome: 'FINALIZED',
+      inspection: {
+        manifest: {
+          finalizedSnapshot: {
+            snapshotId: expected.manifest.snapshot_id,
+            finalizedAt: '2025-01-04T01:30:00.000Z',
+          },
+        },
+      },
+    })
+    const manifestQueries = queries.filter((query) => query.kind === 'manifest')
+    expect(manifestQueries).toHaveLength(1)
+    expect(queries.filter((query) => query.kind === 'sessions')).toHaveLength(1)
+    expect(queries.filter((query) => query.kind === 'bars')).toHaveLength(0)
+    expect(manifestQueries[0]?.text).toContain('AND universe_symbol_hash =')
+    expect(manifestQueries[0]?.text).toContain('ORDER BY finalized_at DESC, snapshot_id DESC')
+    expect(manifestQueries[0]?.text).toContain('LIMIT 1')
+    expect(manifestQueries[0]?.parameters).toContain(fixture.request.universeSymbolHash)
+    expect(queries.find((query) => query.kind === 'sessions')?.parameters).toEqual([expected.manifest.snapshot_id])
   })
 
   test('discovers bounded exact finalized publications without using pinned snapshot or publication dates', async () => {

--- a/services/bayn/src/market-data.ts
+++ b/services/bayn/src/market-data.ts
@@ -690,10 +690,12 @@ const makeMarketData = (
           toString(finalized_at) AS finalized_at
         FROM signal.snapshot_manifests_v2
         WHERE universe_id = ${sql.param('String', contract.universeId)}
+          AND universe_symbol_hash = ${sql.param('String', contract.universeSymbolHash)}
           AND requested_start = toDate(${sql.param('String', contract.historyStart)})
           AND publication_asof = toDate(${sql.param('String', request.signalSessionDate)})
           AND calendar_version = ${sql.param('String', request.signalCalendarVersion)}
-        ORDER BY snapshot_id, finalized_at
+        ORDER BY finalized_at DESC, snapshot_id DESC
+        LIMIT 1
       `.pipe(sql.withQueryId(`bayn-cycle-manifest-${request.signalSessionDate}`))
 
     const loadCyclePublicationManifests = sql`

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'bun:test'
 import { Effect } from 'effect'
 import { TestClock } from 'effect/testing'
 
-import type { MarketCalendarObservation, ReadResult } from './broker/alpaca'
+import type { BrokerReadShape, MarketCalendarObservation, ReadResult } from './broker/alpaca'
 import {
   CycleState,
   decodeAutonomousCycle,
@@ -13,9 +13,15 @@ import {
   makeCycleWindow,
   makeExecutionCalendarObservation,
 } from './cycle'
+import type { CycleStoreShape } from './db/cycle-store'
+import type { PaperStoreShape } from './db/paper-store'
 import { canonicalHashV1 } from './hash'
 import type { MarketDataService, MarketDataSnapshot } from './market-data'
-import { buildObserveCycleDecision, loadObserveRiskPolicy } from './observe-composition'
+import {
+  buildObserveCycleDecision,
+  loadObserveRiskPolicy,
+  makeObserveAutonomousCycleStartup,
+} from './observe-composition'
 import {
   AccountStatus,
   Authority,
@@ -373,5 +379,78 @@ describe('OBSERVE runtime composition', () => {
 
     expect(exit.toString()).toContain('same-pass reconciliation did not return the configured OBSERVE authority')
     expect(strategyCalls).toBe(0)
+  })
+
+  test('fails PAPER startup before authority initialization or autonomous work can begin', async () => {
+    const unused = Effect.die(new Error('PAPER startup must fail before using runtime capabilities'))
+    let authorityInitializations = 0
+    const paperStore: PaperStoreShape = {
+      ingest: () => unused,
+      ingestPositions: () => unused,
+      account: () => unused,
+      value: () => unused,
+      hasAccountBaseline: () => unused,
+      bindings: () => unused,
+      reconcile: () => unused,
+      ensureAuthorityGeneration: () =>
+        Effect.sync(() => {
+          authorityInitializations += 1
+          throw new Error('PAPER startup must not initialize synthetic OBSERVE authority')
+        }),
+      restrictAuthority: () => unused,
+    }
+    const cycleStore: CycleStoreShape = {
+      acquire: () => unused,
+      read: () => unused,
+      readAuthoritySlot: () => unused,
+      readDecisionDocument: () => unused,
+      readOldestUnfinished: () => unused,
+      bindSnapshot: () => unused,
+      activate: () => unused,
+      bindDecision: () => unused,
+      finish: () => unused,
+      block: () => unused,
+    }
+    const brokerRead: BrokerReadShape = {
+      account: unused,
+      positions: unused,
+      orders: () => unused,
+      orderById: () => unused,
+      orderByClientId: () => unused,
+      fillActivities: () => unused,
+      marketCalendar: () => unused,
+    }
+    const startup = makeObserveAutonomousCycleStartup({
+      accountId,
+      authorityGenerationHash: generationHash,
+      brokerRead,
+      cycleStore,
+      marketData: marketData([]),
+      maximumAuthority: Authority.Paper,
+      paperStore,
+      pollIntervalMs: 30_000,
+      reconcile: unused,
+      strategy: {
+        currentDecision: () => {
+          throw new Error('PAPER startup must not compile a shadow decision')
+        },
+        parameters: fixtureProtocol,
+      },
+    })
+
+    const exit = await Effect.runPromiseExit(
+      Effect.scoped(
+        startup({
+          qualificationRunId: 'c'.repeat(64),
+          strategyProtocolHash: 'd'.repeat(64),
+          recordPass: () => unused,
+        }),
+      ),
+    )
+
+    expect(exit.toString()).toContain(
+      'PAPER autonomous startup requires the gated Phase B authority generation and dispatch transition',
+    )
+    expect(authorityInitializations).toBe(0)
   })
 })

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -250,6 +250,7 @@ export interface ObserveAutonomousCycleInput {
   readonly brokerRead: BrokerReadShape
   readonly cycleStore: CycleStoreShape
   readonly marketData: MarketDataService
+  readonly maximumAuthority: Authority
   readonly paperStore: PaperStoreShape
   readonly pollIntervalMs: number
   readonly reconcile: Effect.Effect<ReconciliationPassResult, unknown>
@@ -260,6 +261,15 @@ export const makeObserveAutonomousCycleStartup = (input: ObserveAutonomousCycleI
   const executionModel = input.strategy.parameters.executionModel
   return (startup) =>
     Effect.gen(function* () {
+      if (input.maximumAuthority !== Authority.Observe) {
+        return yield* Effect.fail(
+          operationalError(
+            'config',
+            'cycle-loop',
+            'PAPER autonomous startup requires the gated Phase B authority generation and dispatch transition',
+          ),
+        )
+      }
       if (executionModel.schemaVersion !== 'bayn.execution-model.v2') {
         return yield* Effect.fail(
           operationalError('strategy', 'cycle-loop', 'autonomous cycles require the causal v2 execution model'),


### PR DESCRIPTION
## Summary

- deterministically select the latest exact Signal correction by compiled universe identity, calendar, finalization time, and snapshot tie-breaker, including corrected recovery after a crash following acquisition
- resample Effect Clock after durable decision-document reads so terminal transitions record causal post-I/O time
- remove the PAPER-mode legacy reconciler/eager mutation composition, keep one durable cycle-runner composition, and fail PAPER startup before authority initialization until the gated Phase B transition exists
- make broker-configured health fail closed when the autonomous runner is absent while retaining unexpected-fiber-exit detection
- align the Bayn architecture and service documentation with the canonical GET-only, same-pass OBSERVE composition

## Related Issues

PROOMPT-380, PROOMPT-383, PROOMPT-405 (source safety fixes only; does not close runtime or GitOps gates)

## Testing

- `bun test services/bayn/src/observe-composition.test.ts services/bayn/src/health.test.ts services/bayn/src/market-data.test.ts services/bayn/src/cycle-runner.test.ts` — 51 passed, 0 failed
- `bun run --filter @proompteng/bayn test` — 338 passed, 0 failed; 71 PostgreSQL-gated tests skipped without `BAYN_TEST_POSTGRES_URL`
- `bunx oxfmt --check docs/bayn/architecture.md services/bayn/README.md`
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`

## Breaking Changes

None. PAPER remains intentionally unavailable until a separately gated Phase B authority generation and dispatch transition is composed.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.