### PR TITLE
feat(bayn): verify qualification candidates

### DIFF
--- a/nix/images/bayn.nix
+++ b/nix/images/bayn.nix
@@ -28,6 +28,7 @@ import ./bun-workspace-service.nix {
   ];
   sourcePaths = [
     "services/bayn"
+    "packages/scripts/src/bayn/update-manifests.ts"
   ];
   buildCommands = [
     "bun --cwd=services/bayn run tsc"

--- a/nix/images/bayn.nix
+++ b/nix/images/bayn.nix
@@ -20,8 +20,8 @@ import ./bun-workspace-service.nix {
   serviceName = "bayn";
   packageName = "@proompteng/bayn";
   depsHash = {
-    x86_64-linux = "sha256-3T9NleNP3UBEZPRTft2TnFqWzjiElCQClS+tS+RJJJ8=";
-    aarch64-linux = "sha256-hROeunyxMcEa5uVtPM+AHHkuYvzV1aqx7YYeEK1EsWs=";
+    x86_64-linux = "sha256-rHuG2j4rs9YZ1FIz6QCNnF8Nj0/10oUeMUZdqMeKi7I=";
+    aarch64-linux = "sha256-pn7Lh1Y8RLuKGy5erc/da0DbWgUvoipnaMMWGgzM9+Q=";
   };
   installFilters = [
     "@proompteng/bayn"

--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -163,6 +163,35 @@ read-only identity. Any recorded bars-table access takes fail-closed precedence 
 cannot relabel a read. The log cannot retroactively prove that an operator query returned only bounded count/hash
 evidence, so any Signal-table read by a principal other than the candidate or declared publisher makes the audit fail.
 
+Before the one-shot qualification release, `candidate:qualification` verifies one exact natural Signal publication
+without opening a qualification lock or changing any system. It requires two direct physical ClickHouse endpoints and
+uses the declared Signal publisher principal to select the latest correction for the compiled Bayn universe on each
+replica with ClickHouse `readonly=1`. It then fully loads and cryptographically verifies the manifest, sessions, bars,
+duplicate keys, cardinalities, and content hashes on both replicas; requires identical canonical snapshot bytes and
+complete topology coverage; and checks in a PostgreSQL `REPEATABLE READ, READ ONLY` transaction that the snapshot has no
+qualification lock.
+
+The publisher principal is deliberate: this command reads candidate bars before Bayn opens the lock, so the later
+qualification audit must receive the same value as `BAYN_AUDIT_SIGNAL_PUBLISHER_USERNAME`. Using the ordinary Bayn
+principal for this pre-lock full read contaminates the candidate chronology. The command emits deterministic
+`bayn.qualification-candidate.v1` JSON containing the complete `BaynCandidateRuntime` expected by the release writer,
+with Signal bounds derived only from the compiled protocol and the supplied TigerBeetle identity. It does not publish
+Signal data, invoke a backfill, acquire a lock, run Bayn, or write PostgreSQL.
+
+```sh
+BAYN_CANDIDATE_SIGNAL_PUBLICATION_DATE=<YYYY-MM-DD> \
+BAYN_CANDIDATE_CLICKHOUSE_URLS=<direct-replica-0-url>,<direct-replica-1-url> \
+BAYN_CANDIDATE_SIGNAL_PUBLISHER_USERNAME=<signal-publisher-user> \
+BAYN_CANDIDATE_SIGNAL_PUBLISHER_PASSWORD=<signal-publisher-password> \
+BAYN_CANDIDATE_POSTGRES_URL=<authenticated-postgres-uri> \
+BAYN_CANDIDATE_POSTGRES_TLS=true \
+BAYN_CANDIDATE_POSTGRES_CA_PATH=<postgres-ca-path> \
+BAYN_CANDIDATE_TIGERBEETLE_CLUSTER_ID=<cluster-id> \
+BAYN_CANDIDATE_TIGERBEETLE_ADDRESSES=<replica-0-address>,<replica-1-address>,<replica-2-address> \
+BAYN_CANDIDATE_TIGERBEETLE_LEDGER=<ledger> \
+  bun run --filter @proompteng/bayn candidate:qualification
+```
+
 Set `BAYN_AUDIT_OUTPUT=dossier` on the same command to emit `bayn.qualification-dossier.v2`. The deterministic dossier
 binds the full audited subject, evidence-set hashes, immutable lock/result, prior trials, contamination records,
 verdict, and observe-only authority. It is ephemeral operator/CI evidence, not runtime configuration. Runtime recovery

--- a/services/bayn/package.json
+++ b/services/bayn/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "audit:qualification": "bun src/qualification-audit-command.ts",
+    "candidate:qualification": "bun src/qualification-candidate-command.ts",
     "build": "bun build src/index.ts --target=node --external tigerbeetle-node --outdir=dist",
     "dev": "BAYN_PROVENANCE_MODE=development bun --watch src/index.ts",
     "start": "BAYN_PROVENANCE_MODE=development node dist/index.js",

--- a/services/bayn/src/qualification-candidate-command.test.ts
+++ b/services/bayn/src/qualification-candidate-command.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, test } from 'bun:test'
+import { Effect } from 'effect'
+
+import {
+  QualificationCandidateError,
+  verifyQualificationCandidate,
+  type CandidateReplicaObservation,
+  type QualificationCandidateInput,
+  type QualificationCandidateReaders,
+} from './qualification-candidate-command'
+import { fixtureProtocol, makeSnapshot } from './test-fixtures'
+
+const publisherPrincipal = 'signal_publisher'
+const endpoints = [
+  new URL('http://signal-clickhouse-0.signal.svc:8123'),
+  new URL('http://signal-clickhouse-1.signal.svc:8123'),
+] as const
+const snapshot = makeSnapshot(270)
+const publicationDate = snapshot.manifest.finalizedSnapshot.asOfSession
+
+const input = (overrides: Partial<QualificationCandidateInput> = {}): QualificationCandidateInput => ({
+  publicationDate,
+  clickhouseUrls: endpoints,
+  publisherPrincipal,
+  protocol: fixtureProtocol,
+  tigerBeetleClusterId: '122731676035874920802382025803517750735',
+  tigerBeetleAddresses:
+    'ledger-0.ledger-headless.bayn.svc.cluster.local:3000,ledger-1.ledger-headless.bayn.svc.cluster.local:3000',
+  tigerBeetleLedger: '7001',
+  ...overrides,
+})
+
+const observations = (
+  overrides: Partial<CandidateReplicaObservation>[] = [],
+): readonly CandidateReplicaObservation[] => [
+  {
+    endpointHost: endpoints[0].hostname,
+    replica: 'signal-0',
+    topology: ['signal-0', 'signal-1'],
+    principal: publisherPrincipal,
+    snapshot,
+    ...overrides[0],
+  },
+  {
+    endpointHost: endpoints[1].hostname,
+    replica: 'signal-1',
+    topology: ['signal-0', 'signal-1'],
+    principal: publisherPrincipal,
+    snapshot,
+    ...overrides[1],
+  },
+]
+
+const readers = (
+  replicaObservations: readonly CandidateReplicaObservation[] = observations(),
+  lockCount = 0,
+): QualificationCandidateReaders => ({
+  readReplica: (endpoint) => {
+    const observation = replicaObservations.find((candidate) => candidate.endpointHost === endpoint.hostname)
+    return observation === undefined
+      ? Effect.fail(
+          new QualificationCandidateError({
+            operation: 'replica',
+            message: `missing fixture for ${endpoint.hostname}`,
+          }),
+        )
+      : Effect.succeed(observation)
+  },
+  readQualificationLocks: () =>
+    Effect.succeed({
+      transactionReadOnly: true,
+      count: lockCount,
+    }),
+})
+
+const failure = async (
+  candidateInput: QualificationCandidateInput,
+  candidateReaders: QualificationCandidateReaders,
+): Promise<QualificationCandidateError> =>
+  Effect.runPromise(Effect.flip(verifyQualificationCandidate(candidateInput, candidateReaders)))
+
+describe('qualification candidate command', () => {
+  test('emits one deterministic complete runtime after two-replica consensus and an unconsumed check', async () => {
+    let checkedSnapshotId: string | undefined
+    const candidateReaders = readers()
+    const report = await Effect.runPromise(
+      verifyQualificationCandidate(input(), {
+        ...candidateReaders,
+        readQualificationLocks: (snapshotId) => {
+          checkedSnapshotId = snapshotId
+          return candidateReaders.readQualificationLocks(snapshotId)
+        },
+      }),
+    )
+
+    expect(checkedSnapshotId).toBe(snapshot.manifest.finalizedSnapshot.snapshotId)
+    expect(report).toMatchObject({
+      schemaVersion: 'bayn.qualification-candidate.v1',
+      publicationDate,
+      publisherPrincipal,
+      inputManifestHash: snapshot.manifest.hash,
+      rowCount: snapshot.manifest.rowCount,
+      sessionCount: snapshot.manifest.sessionCount,
+      qualificationLockCount: 0,
+      candidateRuntime: {
+        BAYN_SIGNAL_SNAPSHOT_ID: snapshot.manifest.finalizedSnapshot.snapshotId,
+        BAYN_SIGNAL_PUBLICATION_ASOF: publicationDate,
+        BAYN_SIGNAL_CALENDAR_VERSION: snapshot.manifest.finalizedSnapshot.calendarVersion,
+        BAYN_SIGNAL_DATA_START: fixtureProtocol.historyStart,
+        BAYN_SIGNAL_DATA_END: publicationDate,
+        BAYN_SIGNAL_LOOKBACK_START: fixtureProtocol.historyStart,
+        BAYN_SIGNAL_EVALUATION_START: fixtureProtocol.evaluationStart,
+        BAYN_SIGNAL_EVALUATION_END: publicationDate,
+        BAYN_TIGERBEETLE_CLUSTER_ID: input().tigerBeetleClusterId,
+        BAYN_TIGERBEETLE_ADDRESSES: input().tigerBeetleAddresses,
+        BAYN_TIGERBEETLE_LEDGER: input().tigerBeetleLedger,
+      },
+    })
+    expect(report.replicas.map((replica) => replica.replica)).toEqual(['signal-0', 'signal-1'])
+    expect(new Set(report.replicas.map((replica) => replica.snapshotCanonicalHash)).size).toBe(1)
+  })
+
+  test.each([
+    {
+      name: 'duplicate endpoint',
+      urls: [endpoints[0], endpoints[0]],
+      expected: 'ClickHouse replica endpoints must be distinct',
+    },
+    {
+      name: 'duplicate host',
+      urls: [endpoints[0], new URL('https://signal-clickhouse-0.signal.svc:8443')],
+      expected: 'ClickHouse replica endpoint hosts must be distinct',
+    },
+    {
+      name: 'credential-bearing endpoint',
+      urls: [new URL('http://signal_publisher:secret@signal-clickhouse-0.signal.svc:8123'), endpoints[1]],
+      expected: 'direct credential-free HTTP(S) origin',
+      forbidden: 'secret',
+    },
+  ])('rejects a $name before any replica read', async ({ urls, expected, forbidden }) => {
+    let reads = 0
+    const candidateReaders: QualificationCandidateReaders = {
+      readReplica: () => {
+        reads += 1
+        return Effect.die(new Error('invalid endpoints must fail before reading'))
+      },
+      readQualificationLocks: () => Effect.die(new Error('invalid endpoints must fail before PostgreSQL')),
+    }
+
+    const error = await failure(input({ clickhouseUrls: urls }), candidateReaders)
+    expect(error.message).toBe('invalid candidate replica endpoints')
+    expect(String(error.cause)).toContain(expected)
+    if (forbidden !== undefined) expect(String(error.cause)).not.toContain(forbidden)
+    expect(reads).toBe(0)
+  })
+
+  test('rejects divergent physical-replica topology', async () => {
+    const error = await failure(input(), readers(observations([{}, { topology: ['signal-0', 'signal-2'] }])))
+
+    expect(error.message).toBe('Signal replica candidate verification failed')
+    expect(String(error.cause)).toContain('reported divergent topology')
+  })
+
+  test('rejects canonical snapshot divergence across replicas', async () => {
+    const [firstBar, ...remainingBars] = snapshot.bars
+    if (firstBar === undefined) throw new Error('snapshot fixture requires at least one bar')
+    const divergentSnapshot = {
+      ...snapshot,
+      bars: [{ ...firstBar, close: firstBar.close + 1 }, ...remainingBars],
+    }
+    const error = await failure(input(), readers(observations([{}, { snapshot: divergentSnapshot }])))
+
+    expect(error.message).toBe('Signal replica candidate verification failed')
+    expect(String(error.cause)).toContain('snapshots diverge across physical replicas')
+  })
+
+  test('rejects a read performed by a principal other than the declared Signal publisher', async () => {
+    const error = await failure(input(), readers(observations([{}, { principal: 'bayn' }])))
+
+    expect(error.message).toBe('Signal replica candidate verification failed')
+    expect(String(error.cause)).toContain('declared Signal publisher principal')
+  })
+
+  test.each([
+    {
+      name: 'cluster ID',
+      overrides: { tigerBeetleClusterId: '0' },
+      expected: 'outside the unsigned 128-bit range',
+    },
+    {
+      name: 'transport addresses',
+      overrides: { tigerBeetleAddresses: 'ledger-0:3000, ledger-1:3000' },
+      expected: 'canonical comma-separated transport list',
+    },
+    {
+      name: 'ledger',
+      overrides: { tigerBeetleLedger: String(2 ** 32) },
+      expected: 'outside the unsigned 32-bit range',
+    },
+  ])('rejects malformed candidate runtime $name', async ({ overrides, expected }) => {
+    const error = await failure(input(overrides), readers())
+
+    expect(error.message).toBe('Signal replica candidate verification failed')
+    expect(String(error.cause)).toContain(expected)
+  })
+
+  test('rejects a snapshot already consumed by a qualification lock', async () => {
+    const error = await failure(input(), readers(observations(), 1))
+
+    expect(error.operation).toBe('postgres')
+    expect(error.message).toContain('is already consumed by 1 qualification lock(s)')
+  })
+
+  test('rejects a qualification-lock check that was not transactionally read-only', async () => {
+    const candidateReaders = readers()
+    const error = await failure(input(), {
+      ...candidateReaders,
+      readQualificationLocks: () => Effect.succeed({ transactionReadOnly: false, count: 0 }),
+    })
+
+    expect(error.operation).toBe('postgres')
+    expect(error.message).toBe('qualification-lock check was not read-only')
+  })
+})

--- a/services/bayn/src/qualification-candidate-command.ts
+++ b/services/bayn/src/qualification-candidate-command.ts
@@ -1,0 +1,497 @@
+import { NodeHttpClient, NodeRuntime, NodeServices } from '@effect/platform-node'
+import { ClickhouseClient } from '@effect/sql-clickhouse'
+import { PgClient } from '@effect/sql-pg'
+import { Config, Data, Effect, FileSystem, Layer, Redacted, Schema, Stdio, Stream } from 'effect'
+
+import type { BaynCandidateRuntime } from '../../../packages/scripts/src/bayn/update-manifests'
+
+import { canonicalHashV1, canonicalJsonV1 } from './hash'
+import { MarketData, MarketDataLive, type MarketDataSnapshot } from './market-data'
+import { loadDefaultProtocol } from './protocol'
+import {
+  IsoDateSchema,
+  PositiveIntegerSchema,
+  Sha256Schema,
+  TrimmedNonEmptyStringSchema,
+  strictParseOptions,
+  type IsoDate,
+} from './schemas'
+import type { CausalProtocol } from './types'
+
+const maximumTigerBeetleClusterId = (1n << 128n) - 1n
+const maximumTigerBeetleLedger = 2 ** 32 - 1
+const canonicalDecimalPattern = /^(?:0|[1-9][0-9]*)$/
+const transportAddressesPattern = /^[A-Za-z0-9.[\]:_-]+(?:,[A-Za-z0-9.[\]:_-]+)*$/
+
+const ExactReplicaUrls = Config.Array(Schema.URLFromString).check(
+  Schema.makeFilter((urls: readonly URL[]) => urls.length === 2, {
+    expected: 'exactly two direct ClickHouse replica URLs',
+  }),
+)
+const CandidateRow = Schema.Struct({
+  snapshot_id: Sha256Schema,
+  calendar_version: TrimmedNonEmptyStringSchema,
+})
+const ReplicaIdentityRow = Schema.Struct({
+  replica: TrimmedNonEmptyStringSchema,
+  principal: TrimmedNonEmptyStringSchema,
+})
+const ReplicaTopologyRow = Schema.Struct({ replica: TrimmedNonEmptyStringSchema })
+const ReadOnlyRow = Schema.Struct({ read_only: Schema.Boolean })
+const LockCountRow = Schema.Struct({
+  lock_count: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+})
+
+const decodeCandidateRow = Schema.decodeUnknownEffect(Schema.Tuple([CandidateRow]), strictParseOptions)
+const decodeReplicaIdentity = Schema.decodeUnknownEffect(Schema.Tuple([ReplicaIdentityRow]), strictParseOptions)
+const decodeReplicaTopology = Schema.decodeUnknownEffect(Schema.Array(ReplicaTopologyRow), strictParseOptions)
+const decodeReadOnlyRow = Schema.decodeUnknownEffect(Schema.Tuple([ReadOnlyRow]), strictParseOptions)
+const decodeLockCountRow = Schema.decodeUnknownEffect(Schema.Tuple([LockCountRow]), strictParseOptions)
+
+const config = Config.all({
+  publicationDate: Config.schema(IsoDateSchema, 'BAYN_CANDIDATE_SIGNAL_PUBLICATION_DATE'),
+  clickhouseUrls: Config.schema(ExactReplicaUrls, 'BAYN_CANDIDATE_CLICKHOUSE_URLS'),
+  publisherUsername: Config.schema(TrimmedNonEmptyStringSchema, 'BAYN_CANDIDATE_SIGNAL_PUBLISHER_USERNAME'),
+  publisherPassword: Config.redacted('BAYN_CANDIDATE_SIGNAL_PUBLISHER_PASSWORD'),
+  postgresUrl: Config.redacted('BAYN_CANDIDATE_POSTGRES_URL'),
+  postgresTls: Config.boolean('BAYN_CANDIDATE_POSTGRES_TLS').pipe(Config.withDefault(false)),
+  postgresCaPath: Config.string('BAYN_CANDIDATE_POSTGRES_CA_PATH').pipe(Config.withDefault('')),
+  tigerBeetleClusterId: Config.schema(TrimmedNonEmptyStringSchema, 'BAYN_CANDIDATE_TIGERBEETLE_CLUSTER_ID'),
+  tigerBeetleAddresses: Config.schema(TrimmedNonEmptyStringSchema, 'BAYN_CANDIDATE_TIGERBEETLE_ADDRESSES'),
+  tigerBeetleLedger: Config.schema(TrimmedNonEmptyStringSchema, 'BAYN_CANDIDATE_TIGERBEETLE_LEDGER'),
+  operationTimeoutMs: Config.schema(PositiveIntegerSchema, 'BAYN_CANDIDATE_OPERATION_TIMEOUT_MS').pipe(
+    Config.withDefault(60_000),
+  ),
+})
+
+type CandidateConfig = Config.Success<typeof config>
+
+export class QualificationCandidateError extends Data.TaggedError('QualificationCandidateError')<{
+  readonly operation: 'config' | 'postgres' | 'replica' | 'runtime'
+  readonly message: string
+  readonly cause?: unknown
+}> {}
+
+const candidateError = (
+  operation: QualificationCandidateError['operation'],
+  message: string,
+  cause?: unknown,
+): QualificationCandidateError => new QualificationCandidateError({ operation, message, cause })
+
+const preserveCandidateError = (
+  operation: QualificationCandidateError['operation'],
+  message: string,
+  cause: unknown,
+): QualificationCandidateError =>
+  cause instanceof QualificationCandidateError ? cause : candidateError(operation, message, cause)
+
+export interface CandidateReplicaObservation {
+  readonly endpointHost: string
+  readonly replica: string
+  readonly topology: readonly string[]
+  readonly principal: string
+  readonly snapshot: MarketDataSnapshot
+}
+
+export interface QualificationLockObservation {
+  readonly transactionReadOnly: boolean
+  readonly count: number
+}
+
+export interface QualificationCandidateInput {
+  readonly publicationDate: IsoDate
+  readonly clickhouseUrls: readonly URL[]
+  readonly publisherPrincipal: string
+  readonly protocol: CausalProtocol
+  readonly tigerBeetleClusterId: string
+  readonly tigerBeetleAddresses: string
+  readonly tigerBeetleLedger: string
+}
+
+export interface QualificationCandidateReaders {
+  readonly readReplica: (endpoint: URL) => Effect.Effect<CandidateReplicaObservation, QualificationCandidateError>
+  readonly readQualificationLocks: (
+    snapshotId: string,
+  ) => Effect.Effect<QualificationLockObservation, QualificationCandidateError>
+}
+
+export interface QualificationCandidateReport {
+  readonly schemaVersion: 'bayn.qualification-candidate.v1'
+  readonly publicationDate: string
+  readonly publisherPrincipal: string
+  readonly snapshotCanonicalHash: string
+  readonly inputManifestHash: string
+  readonly rowCount: number
+  readonly sessionCount: number
+  readonly replicas: readonly {
+    readonly endpointHost: string
+    readonly replica: string
+    readonly snapshotCanonicalHash: string
+  }[]
+  readonly qualificationLockCount: 0
+  readonly candidateRuntime: BaynCandidateRuntime
+}
+
+export const validateCandidateEndpoints = (urls: readonly URL[]): readonly [URL, URL] => {
+  if (urls.length !== 2) throw new TypeError('exactly two direct ClickHouse replica URLs are required')
+  const [first, second] = urls
+  if (first === undefined || second === undefined) {
+    throw new TypeError('exactly two direct ClickHouse replica URLs are required')
+  }
+  for (const url of urls) {
+    if (
+      (url.protocol !== 'http:' && url.protocol !== 'https:') ||
+      url.username.length > 0 ||
+      url.password.length > 0 ||
+      (url.pathname !== '' && url.pathname !== '/') ||
+      url.search.length > 0 ||
+      url.hash.length > 0
+    ) {
+      throw new TypeError(
+        `ClickHouse endpoint for host ${url.hostname || '<missing>'} is not a direct credential-free HTTP(S) origin`,
+      )
+    }
+  }
+  if (first.href === second.href) throw new TypeError('ClickHouse replica endpoints must be distinct')
+  if (first.hostname === second.hostname) throw new TypeError('ClickHouse replica endpoint hosts must be distinct')
+  return [first, second]
+}
+
+const validateTigerBeetleRuntime = (clusterId: string, addresses: string, ledgerValue: string): void => {
+  if (!canonicalDecimalPattern.test(clusterId)) {
+    throw new TypeError('TigerBeetle cluster ID must be a canonical unsigned decimal')
+  }
+  const parsedClusterId = BigInt(clusterId)
+  if (parsedClusterId <= 0n || parsedClusterId > maximumTigerBeetleClusterId) {
+    throw new TypeError('TigerBeetle cluster ID is outside the unsigned 128-bit range')
+  }
+  if (!transportAddressesPattern.test(addresses)) {
+    throw new TypeError('TigerBeetle addresses are not a canonical comma-separated transport list')
+  }
+  const addressList = addresses.split(',')
+  if (new Set(addressList).size !== addressList.length) {
+    throw new TypeError('TigerBeetle transport addresses must be unique')
+  }
+  if (!canonicalDecimalPattern.test(ledgerValue)) {
+    throw new TypeError('TigerBeetle ledger must be a canonical unsigned decimal')
+  }
+  const ledger = Number(ledgerValue)
+  if (!Number.isSafeInteger(ledger) || ledger <= 0 || ledger > maximumTigerBeetleLedger) {
+    throw new TypeError('TigerBeetle ledger is outside the unsigned 32-bit range')
+  }
+}
+
+export const makeCandidateRuntime = (
+  input: QualificationCandidateInput,
+  snapshot: MarketDataSnapshot,
+): BaynCandidateRuntime => {
+  validateTigerBeetleRuntime(input.tigerBeetleClusterId, input.tigerBeetleAddresses, input.tigerBeetleLedger)
+  const finalized = snapshot.manifest.finalizedSnapshot
+  const bounds = snapshot.manifest.bounds
+  if (
+    finalized.universeId !== input.protocol.universeId ||
+    finalized.universeSymbolHash !== input.protocol.universeSymbolHash ||
+    finalized.asOfSession !== input.publicationDate ||
+    finalized.lastSession !== input.publicationDate ||
+    finalized.requestedStart !== input.protocol.historyStart ||
+    bounds.dataStart !== input.protocol.historyStart ||
+    bounds.lookbackStart !== input.protocol.historyStart ||
+    bounds.evaluationStart !== input.protocol.evaluationStart ||
+    bounds.dataEnd !== input.publicationDate ||
+    bounds.evaluationEnd !== input.publicationDate
+  ) {
+    throw new TypeError('verified Signal snapshot does not match the source-controlled candidate contract')
+  }
+  return {
+    BAYN_SIGNAL_SNAPSHOT_ID: finalized.snapshotId,
+    BAYN_SIGNAL_PUBLICATION_ASOF: input.publicationDate,
+    BAYN_SIGNAL_CALENDAR_VERSION: finalized.calendarVersion,
+    BAYN_SIGNAL_DATA_START: input.protocol.historyStart,
+    BAYN_SIGNAL_DATA_END: input.publicationDate,
+    BAYN_SIGNAL_LOOKBACK_START: input.protocol.historyStart,
+    BAYN_SIGNAL_EVALUATION_START: input.protocol.evaluationStart,
+    BAYN_SIGNAL_EVALUATION_END: input.publicationDate,
+    BAYN_TIGERBEETLE_CLUSTER_ID: input.tigerBeetleClusterId,
+    BAYN_TIGERBEETLE_ADDRESSES: input.tigerBeetleAddresses,
+    BAYN_TIGERBEETLE_LEDGER: input.tigerBeetleLedger,
+  }
+}
+
+const compareReplicaObservations = (
+  input: QualificationCandidateInput,
+  observations: readonly CandidateReplicaObservation[],
+): Omit<QualificationCandidateReport, 'qualificationLockCount'> => {
+  if (observations.length !== 2) throw new TypeError('exactly two replica observations are required')
+  const endpointHosts = validateCandidateEndpoints(input.clickhouseUrls)
+    .map((url) => url.hostname)
+    .sort()
+  const observedEndpointHosts = observations.map((observation) => observation.endpointHost).sort()
+  if (canonicalJsonV1(observedEndpointHosts) !== canonicalJsonV1(endpointHosts)) {
+    throw new TypeError('replica observations do not match the requested direct endpoint hosts')
+  }
+  if (observations.some((observation) => observation.principal !== input.publisherPrincipal)) {
+    throw new TypeError('a replica read did not use the declared Signal publisher principal')
+  }
+  const observedReplicas = observations.map((observation) => observation.replica).sort()
+  if (new Set(observedReplicas).size !== observedReplicas.length) {
+    throw new TypeError('ClickHouse endpoints resolved to the same physical replica')
+  }
+  const expectedTopology = [...(observations[0]?.topology ?? [])].sort()
+  if (expectedTopology.length !== 2 || new Set(expectedTopology).size !== expectedTopology.length) {
+    throw new TypeError('ClickHouse topology must contain exactly two distinct physical replicas')
+  }
+  if (
+    observations.some(
+      (observation) => canonicalJsonV1([...observation.topology].sort()) !== canonicalJsonV1(expectedTopology),
+    )
+  ) {
+    throw new TypeError('ClickHouse replica endpoints reported divergent topology')
+  }
+  if (canonicalJsonV1(observedReplicas) !== canonicalJsonV1(expectedTopology)) {
+    throw new TypeError('ClickHouse endpoints do not cover the complete two-replica topology')
+  }
+  const canonicalSnapshots = observations.map((observation) => canonicalJsonV1(observation.snapshot))
+  const canonicalSnapshot = canonicalSnapshots[0]
+  if (canonicalSnapshot === undefined || canonicalSnapshots.some((value) => value !== canonicalSnapshot)) {
+    throw new TypeError('fully verified Signal snapshots diverge across physical replicas')
+  }
+  const snapshot = observations[0]?.snapshot
+  if (snapshot === undefined) throw new TypeError('verified Signal snapshot is missing')
+  const snapshotCanonicalHash = canonicalHashV1(snapshot)
+  const candidateRuntime = makeCandidateRuntime(input, snapshot)
+  return {
+    schemaVersion: 'bayn.qualification-candidate.v1',
+    publicationDate: input.publicationDate,
+    publisherPrincipal: input.publisherPrincipal,
+    snapshotCanonicalHash,
+    inputManifestHash: snapshot.manifest.hash,
+    rowCount: snapshot.manifest.rowCount,
+    sessionCount: snapshot.manifest.sessionCount,
+    replicas: [...observations]
+      .sort((left, right) => left.replica.localeCompare(right.replica))
+      .map((observation) => ({
+        endpointHost: observation.endpointHost,
+        replica: observation.replica,
+        snapshotCanonicalHash: canonicalHashV1(observation.snapshot),
+      })),
+    candidateRuntime,
+  }
+}
+
+export const verifyQualificationCandidate = (
+  input: QualificationCandidateInput,
+  readers: QualificationCandidateReaders,
+): Effect.Effect<QualificationCandidateReport, QualificationCandidateError> =>
+  Effect.gen(function* () {
+    const endpoints = yield* Effect.try({
+      try: () => validateCandidateEndpoints(input.clickhouseUrls),
+      catch: (cause) => candidateError('config', 'invalid candidate replica endpoints', cause),
+    })
+    const observations = yield* Effect.all(endpoints.map(readers.readReplica), { concurrency: 2 })
+    const consensus = yield* Effect.try({
+      try: () => compareReplicaObservations(input, observations),
+      catch: (cause) => candidateError('replica', 'Signal replica candidate verification failed', cause),
+    })
+    const locks = yield* readers.readQualificationLocks(consensus.candidateRuntime.BAYN_SIGNAL_SNAPSHOT_ID)
+    if (!locks.transactionReadOnly) {
+      return yield* Effect.fail(candidateError('postgres', 'qualification-lock check was not read-only'))
+    }
+    if (locks.count !== 0) {
+      return yield* Effect.fail(
+        candidateError(
+          'postgres',
+          `Signal snapshot ${consensus.candidateRuntime.BAYN_SIGNAL_SNAPSHOT_ID} is already consumed by ${locks.count} qualification lock(s)`,
+        ),
+      )
+    }
+    return { ...consensus, qualificationLockCount: 0 }
+  })
+
+const candidateBounds = (protocol: CausalProtocol, publicationDate: IsoDate) => ({
+  schemaVersion: 'bayn.evaluation-bounds.v1' as const,
+  dataStart: protocol.historyStart,
+  dataEnd: publicationDate,
+  lookbackStart: protocol.historyStart,
+  evaluationStart: protocol.evaluationStart,
+  evaluationEnd: publicationDate,
+})
+
+const readReplica = (
+  input: QualificationCandidateInput,
+  endpoint: URL,
+  password: Redacted.Redacted<string>,
+  operationTimeoutMs: number,
+): Effect.Effect<CandidateReplicaObservation, QualificationCandidateError> => {
+  const clickhouse = ClickhouseClient.layer({
+    url: endpoint.href,
+    username: input.publisherPrincipal,
+    password: Redacted.value(password),
+    database: 'signal',
+    application: 'bayn-qualification-candidate',
+    request_timeout: operationTimeoutMs,
+    clickhouse_settings: { readonly: '1' },
+  }).pipe(Layer.provide(NodeHttpClient.layerNodeHttp))
+  const program = Effect.gen(function* () {
+    const sql = yield* ClickhouseClient.ClickhouseClient
+    const [identityRows, topology, candidateRows] = yield* Effect.all(
+      [
+        decodeReplicaIdentity(
+          yield* sql`
+            SELECT host_name AS replica, currentUser() AS principal
+            FROM system.clusters
+            WHERE cluster = 'default' AND is_local
+            ORDER BY host_name
+          `.pipe(sql.withQueryId('bayn-candidate-replica-identity')),
+        ),
+        decodeReplicaTopology(
+          yield* sql`
+            SELECT host_name AS replica
+            FROM system.clusters
+            WHERE cluster = 'default'
+            ORDER BY shard_num, replica_num
+          `.pipe(sql.withQueryId('bayn-candidate-replica-topology')),
+        ),
+        decodeCandidateRow(
+          yield* sql`
+            SELECT snapshot_id, calendar_version
+            FROM signal.snapshot_manifests_v2
+            WHERE universe_id = ${sql.param('String', input.protocol.universeId)}
+              AND universe_symbol_hash = ${sql.param('String', input.protocol.universeSymbolHash)}
+              AND requested_start = toDate(${sql.param('String', input.protocol.historyStart)})
+              AND publication_asof = toDate(${sql.param('String', input.publicationDate)})
+            ORDER BY finalized_at DESC, snapshot_id DESC
+            LIMIT 1
+          `.pipe(sql.withQueryId(`bayn-candidate-select-${input.publicationDate}`)),
+        ),
+      ],
+      { concurrency: 3 },
+    )
+    const [identity] = identityRows
+    const [candidate] = candidateRows
+    const marketData = yield* MarketData.pipe(
+      Effect.provide(
+        MarketDataLive(
+          {
+            operationTimeoutMs,
+            clickhouse: {
+              url: endpoint.href,
+              username: input.publisherPrincipal,
+              password,
+              snapshotId: candidate.snapshot_id,
+              publicationAsOf: input.publicationDate,
+              calendarVersion: candidate.calendar_version,
+              bounds: candidateBounds(input.protocol, input.publicationDate),
+            },
+          },
+          input.protocol,
+        ),
+      ),
+    )
+    const snapshot = yield* marketData.loadSnapshotPublication({
+      snapshotId: candidate.snapshot_id,
+      signalSessionDate: input.publicationDate,
+      signalCalendarVersion: candidate.calendar_version,
+    })
+    return {
+      endpointHost: endpoint.hostname,
+      replica: identity.replica,
+      topology: topology.map((row) => row.replica),
+      principal: identity.principal,
+      snapshot,
+    }
+  })
+  return program.pipe(
+    Effect.provide(clickhouse),
+    Effect.mapError((cause) =>
+      preserveCandidateError('replica', `candidate read failed for ClickHouse host ${endpoint.hostname}`, cause),
+    ),
+  )
+}
+
+const postgresLayer = (input: CandidateConfig) =>
+  Layer.unwrap(
+    Effect.gen(function* () {
+      let ca: string | undefined
+      if (input.postgresTls) {
+        if (input.postgresCaPath.length === 0) {
+          return yield* Effect.fail(
+            candidateError('config', 'BAYN_CANDIDATE_POSTGRES_CA_PATH is required when PostgreSQL TLS is enabled'),
+          )
+        }
+        const fileSystem = yield* FileSystem.FileSystem
+        ca = yield* fileSystem.readFileString(input.postgresCaPath)
+      }
+      return PgClient.layerFrom(
+        PgClient.make({
+          url: input.postgresUrl,
+          ssl: ca === undefined ? undefined : { ca, rejectUnauthorized: true },
+          applicationName: 'bayn-qualification-candidate',
+          connectTimeout: input.operationTimeoutMs,
+          idleTimeout: '30 seconds',
+          maxConnections: 1,
+          minConnections: 0,
+          transformJson: false,
+        }),
+      )
+    }),
+  )
+
+const readQualificationLocks = (
+  input: CandidateConfig,
+  snapshotId: string,
+): Effect.Effect<QualificationLockObservation, QualificationCandidateError, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const sql = yield* PgClient.PgClient
+    return yield* sql.withTransaction(
+      Effect.gen(function* () {
+        yield* sql`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY`
+        const [readOnlyRows, countRows] = yield* Effect.all(
+          [
+            decodeReadOnlyRow(yield* sql`SELECT current_setting('transaction_read_only') = 'on' AS read_only`),
+            decodeLockCountRow(
+              yield* sql`
+                SELECT count(*)::integer AS lock_count
+                FROM qualification_locks
+                WHERE snapshot_id = ${snapshotId}
+              `,
+            ),
+          ],
+          { concurrency: 1 },
+        )
+        const [readOnly] = readOnlyRows
+        const [count] = countRows
+        return { transactionReadOnly: readOnly.read_only, count: count.lock_count }
+      }),
+    )
+  }).pipe(
+    Effect.provide(postgresLayer(input)),
+    Effect.mapError((cause) => preserveCandidateError('postgres', 'read-only qualification-lock check failed', cause)),
+  )
+
+const main = Effect.gen(function* () {
+  const input = yield* config
+  const protocol = yield* loadDefaultProtocol.pipe(
+    Effect.mapError((cause) => candidateError('runtime', 'compiled Bayn protocol is invalid', cause)),
+  )
+  const candidateInput: QualificationCandidateInput = {
+    publicationDate: input.publicationDate,
+    clickhouseUrls: input.clickhouseUrls,
+    publisherPrincipal: input.publisherUsername,
+    protocol,
+    tigerBeetleClusterId: input.tigerBeetleClusterId,
+    tigerBeetleAddresses: input.tigerBeetleAddresses,
+    tigerBeetleLedger: input.tigerBeetleLedger,
+  }
+  const fileSystem = yield* FileSystem.FileSystem
+  const report = yield* verifyQualificationCandidate(candidateInput, {
+    readReplica: (endpoint) => readReplica(candidateInput, endpoint, input.publisherPassword, input.operationTimeoutMs),
+    readQualificationLocks: (snapshotId) =>
+      readQualificationLocks(input, snapshotId).pipe(Effect.provideService(FileSystem.FileSystem, fileSystem)),
+  })
+  const stdio = yield* Stdio.Stdio
+  yield* Stream.run(Stream.make(`${canonicalJsonV1(report)}\n`), stdio.stdout())
+})
+
+if (import.meta.main) {
+  NodeRuntime.runMain(main.pipe(Effect.provide(NodeServices.layer)))
+}


### PR DESCRIPTION
## Summary

- add one bounded, operator-only qualification-candidate command for an exact natural Signal publication
- verify the latest compiled-universe correction across exactly two physical ClickHouse replicas with the declared publisher principal, server-enforced read-only queries, full snapshot hashes/cardinality, canonical equality, and topology coverage
- reject consumed snapshots through a PostgreSQL `REPEATABLE READ, READ ONLY` check and emit the merged release writer’s complete `BaynCandidateRuntime` contract
- document the publisher-principal chronology invariant and no-live/no-mutation operator boundary
- refresh only the two runner-reported Bayn Bun fixed-output hashes required by the command dependency closure

## Related Issues

PROOMPT-403 (prerequisite; does not close the issue)

## Testing

- `bun test services/bayn/src/qualification-candidate-command.test.ts` (12 passed)
- `bun run --filter @proompteng/bayn test` (350 passed, 71 PostgreSQL environment-gated tests skipped)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- `bun build services/bayn/src/qualification-candidate-command.ts --target=node --external tigerbeetle-node --outfile /dev/null`
- `nix-instantiate --parse nix/images/bayn.nix`
- `git diff --check`

## Breaking Changes

None. This adds an operator-only read path; it was not invoked against live Signal and changes no runtime or GitOps state.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.