### PR TITLE
fix(bayn): freeze unpinned qualification candidate

### DIFF
--- a/docs/bayn/architecture.md
+++ b/docs/bayn/architecture.md
@@ -199,8 +199,9 @@ ID, and TigerBeetle ledger remain identical. TigerBeetle replica addresses are t
 identity, so an explicit reviewed candidate may change them without relabeling terminal evidence. A cluster-ID or
 ledger change still requires a fresh Signal snapshot. The writer has no source-coded current snapshot: ordinary image
 promotion reads the deployed runtime, while a qualification transition must supply the complete candidate runtime.
-After a fresh snapshot removes the pin for its one allowed source revision, promotion rejects a different source
-revision. A controlled invocation may install the exact independently accepted terminal run only for that already
-deployed unpinned source, image digest, compiled strategy, and complete runtime. It cannot replace an old pin and
-advance to a fresh candidate in the same change. A later pinned operational release may change source while preserving
-identical compiled strategy and qualification identity. Automatic image promotion never creates a qualification pin.
+After a fresh snapshot removes the pin, the complete deployed candidate becomes immutable: source, image digest,
+compiled strategy, Signal and TigerBeetle runtime may only be replayed exactly until its terminal run is pinned. A
+controlled invocation may install the exact independently accepted terminal run only for that deployed candidate. It
+cannot replace an old pin and advance to a fresh candidate in the same change. A later pinned operational release may
+change source while preserving identical compiled strategy and qualification identity. Automatic image promotion
+never creates a qualification pin.

--- a/packages/scripts/src/bayn/update-manifests.test.ts
+++ b/packages/scripts/src/bayn/update-manifests.test.ts
@@ -236,7 +236,7 @@ describe('Bayn manifest promotion', () => {
     expect(() => promote(paths)).toThrow('qualification replacement requires a fresh BAYN_SIGNAL_SNAPSHOT_ID')
   })
 
-  test('replaces a pin for a fresh snapshot and rejects a second unpinned source release', () => {
+  test('replaces a pin for a fresh snapshot and makes an exact unpinned replay a no-op', () => {
     const paths = makeFixture({ snapshotId: '4'.repeat(64), publicationAsOf: '2026-07-19' })
     const changedParameterHash = '3'.repeat(64)
     const first = promote(paths, { strategyParameterHash: changedParameterHash })
@@ -256,6 +256,7 @@ describe('Bayn manifest promotion', () => {
       environmentBlock('BAYN_SIGNAL_SNAPSHOT_ID', currentSnapshotId).trim(),
     )
 
+    const beforeReplay = Object.values(paths).map((path) => readFileSync(path, 'utf8'))
     expect(promote(paths, { strategyParameterHash: changedParameterHash })).toMatchObject({
       promotionAction: 'promote',
       promotionReason: 'eligible',
@@ -264,12 +265,58 @@ describe('Bayn manifest promotion', () => {
       snapshotChanged: false,
       deployedSourceSha: 'a'.repeat(40),
     })
+    expect(Object.values(paths).map((path) => readFileSync(path, 'utf8'))).toEqual(beforeReplay)
+  })
 
-    const beforeSecondRelease = Object.values(paths).map((path) => readFileSync(path, 'utf8'))
-    expect(() => promote(paths, { strategyParameterHash: changedParameterHash }, 'c'.repeat(40))).toThrow(
-      'an unpinned qualification snapshot cannot accept a second source release',
+  test('freezes the complete unpinned candidate until its terminal run is pinned', () => {
+    const paths = makeFixture({ snapshotId: '4'.repeat(64), publicationAsOf: '2026-07-19' })
+    const changedParameterHash = '3'.repeat(64)
+    promote(paths, { strategyParameterHash: changedParameterHash })
+    const before = Object.values(paths).map((path) => readFileSync(path, 'utf8'))
+    const secondSnapshot = {
+      ...currentBindings,
+      BAYN_SIGNAL_SNAPSHOT_ID: '5'.repeat(64),
+      BAYN_SIGNAL_PUBLICATION_ASOF: '2026-07-23',
+      BAYN_SIGNAL_DATA_END: '2026-07-23',
+      BAYN_SIGNAL_EVALUATION_END: '2026-07-23',
+    } satisfies BaynCandidateRuntime
+
+    expect(() =>
+      promote(paths, {
+        strategyParameterHash: changedParameterHash,
+        candidateRuntime: secondSnapshot,
+      }),
+    ).toThrow('an unpinned qualification candidate is immutable until its terminal run is pinned')
+    expect(Object.values(paths).map((path) => readFileSync(path, 'utf8'))).toEqual(before)
+
+    expect(() => promote(paths, { strategyParameterHash: '6'.repeat(64) })).toThrow(
+      'an unpinned qualification candidate is immutable until its terminal run is pinned',
     )
-    expect(Object.values(paths).map((path) => readFileSync(path, 'utf8'))).toEqual(beforeSecondRelease)
+    expect(Object.values(paths).map((path) => readFileSync(path, 'utf8'))).toEqual(before)
+
+    expect(() =>
+      promote(paths, {
+        strategyParameterHash: changedParameterHash,
+        digest: `sha256:${'c'.repeat(64)}`,
+      }),
+    ).toThrow('an unpinned qualification candidate is immutable until its terminal run is pinned')
+    expect(Object.values(paths).map((path) => readFileSync(path, 'utf8'))).toEqual(before)
+
+    expect(() =>
+      promote(paths, {
+        strategyParameterHash: changedParameterHash,
+        candidateRuntime: {
+          ...currentBindings,
+          BAYN_TIGERBEETLE_ADDRESSES: 'different-ledger.bayn.svc.cluster.local:3000',
+        },
+      }),
+    ).toThrow('an unpinned qualification candidate is immutable until its terminal run is pinned')
+    expect(Object.values(paths).map((path) => readFileSync(path, 'utf8'))).toEqual(before)
+
+    expect(() => promote(paths, { strategyParameterHash: changedParameterHash }, 'c'.repeat(40))).toThrow(
+      'an unpinned qualification candidate is immutable until its terminal run is pinned',
+    )
+    expect(Object.values(paths).map((path) => readFileSync(path, 'utf8'))).toEqual(before)
     expect(readFileSync(paths.deploymentPath, 'utf8')).not.toContain('BAYN_QUALIFICATION_RUN_ID')
   })
 

--- a/packages/scripts/src/bayn/update-manifests.ts
+++ b/packages/scripts/src/bayn/update-manifests.ts
@@ -250,6 +250,16 @@ export const updateBaynManifests = (options: UpdateBaynManifestOptions): BaynMan
       throw new Error('qualification installation must pin the exact deployed source, image, strategy, and runtime')
     }
   }
+  const unpinnedCandidateReplay = !hadQualificationPin && acceptedQualificationRunId === undefined
+  if (
+    unpinnedCandidateReplay &&
+    (deployedSourceSha !== options.sourceSha ||
+      deployedImageDigest !== options.digest ||
+      !strategyIdentityMatches ||
+      !candidateRuntimeMatchesDeployment)
+  ) {
+    throw new Error('an unpinned qualification candidate is immutable until its terminal run is pinned')
+  }
   let qualificationMode: BaynManifestUpdate['qualificationMode']
   if (acceptedQualificationRunId !== undefined && !acceptedRunAlreadyPinned) {
     qualificationMode = 'install'
@@ -290,8 +300,12 @@ export const updateBaynManifests = (options: UpdateBaynManifestOptions): BaynMan
   if (qualificationMode === 'replace' && hadQualificationPin && !snapshotChanged) {
     throw new Error('qualification replacement requires a fresh BAYN_SIGNAL_SNAPSHOT_ID')
   }
-  if (!hadQualificationPin && !snapshotChanged && deployedSourceSha !== options.sourceSha) {
-    throw new Error('an unpinned qualification snapshot cannot accept a second source release')
+  if (unpinnedCandidateReplay) {
+    return {
+      promotionAction: 'promote',
+      promotionReason: 'eligible',
+      ...updateDetails,
+    }
   }
   const imageBlock =
     /(  - name: registry\.ide-newton\.ts\.net\/lab\/bayn\n    newName: registry\.ide-newton\.ts\.net\/lab\/bayn\n    newTag: )[^\n]+(?:\n    digest: [^\n]+)?/

--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -50,12 +50,12 @@ paper mutation capability, execution entry point, and capital-promotion path rem
 - `BAYN_QUALIFICATION_RUN_ID` optionally pins one terminal qualification across operational image updates. Startup
   verifies the stored strategy and Signal bindings, then recovers it without inspecting bars, opening a lock,
   evaluating, journaling, or persisting.
-- Production GitOps carries that pin outside an explicit one-shot qualification release. The release writer refuses a
-  second source revision on the same unpinned snapshot. A controlled invocation may pin the exact independently
-  accepted terminal run only for the already deployed unpinned source, image digest, compiled strategy, and complete
-  reviewed runtime; it cannot combine fresh-candidate deployment with pin installation. Automatic image promotion
-  supplies neither. Once pinned, a later operational release may change source only while preserving compiled strategy
-  and qualification identity. This prevents extra trials or rebinding evidence to implicit inputs.
+- Production GitOps carries that pin outside an explicit one-shot qualification release. Once a fresh candidate is
+  deployed without a pin, its source, image digest, compiled strategy, and complete runtime are immutable until the
+  exact independently accepted terminal run is pinned. Fresh-candidate deployment and pin installation cannot be
+  combined, and automatic image promotion supplies neither candidate material nor a run ID. Once pinned, a later
+  operational release may change source only while preserving compiled strategy and qualification identity. This
+  prevents extra trials or rebinding evidence to implicit inputs.
 - The compiled risk-balanced trend decision function records every normalized trend horizon, volatility estimate,
   portfolio-volatility scale, and target weight at a month-end close. Quantities are planned only after that Signal
   session is finalized, using its close prices and reconciled broker state observed before planning. Ordinary


### PR DESCRIPTION
## Summary

- freeze the complete deployed qualification candidate while its terminal run is still unpinned: source, image digest, compiled strategy, Signal bindings, and TigerBeetle runtime must remain identical
- make an exact unpinned replay a true no-write operation and permit only the exact terminal pin installation to advance the release state
- add byte-equivalent no-write regressions for a second snapshot, source, image, strategy, and runtime change
- document the immutable unpinned-candidate contract in the Bayn architecture and operator README

## Related Issues

PROOMPT-403

## Testing

- `bun test packages/scripts/src/bayn/update-manifests.test.ts` — 20 passed, 0 failed
- isolated strict TypeScript check for `update-manifests.ts` and its test
- `bunx oxlint --type-aware packages/scripts/src/bayn/update-manifests.ts packages/scripts/src/bayn/update-manifests.test.ts`
- `bunx oxfmt --check packages/scripts/src/bayn/update-manifests.ts packages/scripts/src/bayn/update-manifests.test.ts docs/bayn/architecture.md services/bayn/README.md`
- `actionlint .github/workflows/bayn-release.yml`
- `git diff --check`

## Breaking Changes

A deployed unpinned qualification candidate can no longer be replaced or partially updated. Operators must either replay the identical candidate without writes or install its exact independently accepted terminal run before any later candidate or operational release.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed because not applicable; Breaking Changes is filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.