### PR TITLE
fix(bayn): authorize identified cancellation after cutoff

### DIFF
--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -94,9 +94,11 @@ paper mutation capability, execution entry point, and capital-promotion path rem
   sessions. A causal execution-session binding retains and revalidates that complete observation, selects its first
   post-signal session, and binds the session's exact open, close, pre-open cutoff, finalized Signal identity, and
   reconciled planning-state identity. Paper risk approves only in `[submissionOpenAt, submissionCutoffAt)` and
-  reserves aggregate buying power across planned buys. The coordinator rechecks the committed risk-decision expiry
+  reserves aggregate buying power across planned buys. The submit path rechecks the committed risk-decision expiry
   with the Effect clock, then atomically revalidates it in the fenced mutation-start transaction immediately before
-  POST or DELETE; the cutoff instant itself permits zero broker mutations and no durable STARTED event.
+  POST; the cutoff instant permits no new exposure and no durable `SUBMIT_STARTED` event. Cancellation is restricted
+  to the exact broker order identified by the durable submit, the writer fence, maximum `PAPER`, and mutation-store
+  authority. That de-risking path remains available after cutoff or approval expiry and while the kill is active.
 - The execution path and independent reducer use integer micros for cash, quantity, prices, spread, slippage, fees,
   cash yield, positions, and every marked-equity point. Full, partial, and rejected orders are durable. Evaluation and
   recovery require exact zero-difference cash, fee, position, and equity reconstruction.

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -881,7 +881,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     const execution = makeExecutionRuntime()
     const intent = await Effect.runPromise(plan(intentPlan({ cycleId: '3'.repeat(64) })))
     const blockedIntent = await Effect.runPromise(plan(intentPlan({ cycleId: 'b'.repeat(64) })))
-    const expiresAtMillis = Date.now() + 1_000
+    const expiresAtMillis = Date.now() + 10_000
     const decision = await Effect.runPromise(
       riskDecision(intent, RiskOutcome.Approved, { expiresAt: new Date(expiresAtMillis).toISOString() }),
     )

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -970,7 +970,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       brokerOrderId: orderId,
     })
     expect(observed.state).toEqual({ state: 'TERMINAL', state_version: 5 })
-  })
+  }, 20_000)
 
   test('rejects non-submitted and mismatched broker order identities before cancellation starts', async () => {
     const execution = makeExecutionRuntime()

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -877,13 +877,20 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     expect(observed.state.state).toBe('TERMINAL')
   })
 
-  test('allows kill-mode cancellation of an identified order and resolves the cancel race', async () => {
+  test('allows expired identified cancellation under an active kill while blocking new submission', async () => {
     const execution = makeExecutionRuntime()
     const intent = await Effect.runPromise(plan(intentPlan({ cycleId: '3'.repeat(64) })))
-    const decision = await Effect.runPromise(riskDecision(intent, RiskOutcome.Approved))
+    const blockedIntent = await Effect.runPromise(plan(intentPlan({ cycleId: 'b'.repeat(64) })))
+    const expiresAtMillis = Date.now() + 1_000
+    const decision = await Effect.runPromise(
+      riskDecision(intent, RiskOutcome.Approved, { expiresAt: new Date(expiresAtMillis).toISOString() }),
+    )
+    const blockedDecision = await Effect.runPromise(riskDecision(blockedIntent, RiskOutcome.Approved))
     await execution.runPromise(
       Effect.gen(function* () {
-        yield* Effect.flatMap(IntentStore, (store) => store.commit(intent, decision))
+        const store = yield* IntentStore
+        yield* store.commit(intent, decision)
+        yield* store.commit(blockedIntent, blockedDecision)
         const sql = yield* PgClient.PgClient
         yield* sql`
           INSERT INTO authority_state (
@@ -918,13 +925,23 @@ describePostgres('PostgreSQL evaluation evidence', () => {
               updated_at = ${new Date(base + 2).toISOString()}
           WHERE singleton
         `
-        yield* store.beginCancel(intent.intentId, cancelHash, orderId, 1_000, new Date(base + 3).toISOString())
-        yield* store.cancelUnknown(intent.intentId, cancelHash, orderId, new Date(base + 4).toISOString())
+        yield* sql`SELECT pg_sleep_until(${new Date(expiresAtMillis + 10).toISOString()}::timestamptz)`
+        const blockedSubmit = yield* Effect.exit(
+          store.beginSubmit(
+            blockedIntent.intentId,
+            '4'.repeat(64),
+            1_000,
+            new Date(Math.max(Date.now(), base + 3)).toISOString(),
+          ),
+        )
+        const cancelBase = Math.max(Date.now(), base + 4)
+        yield* store.beginCancel(intent.intentId, cancelHash, orderId, 1_000, new Date(cancelBase).toISOString())
+        yield* store.cancelUnknown(intent.intentId, cancelHash, orderId, new Date(cancelBase + 1).toISOString())
         const notFound = yield* store.recoveryNotFound(intent.intentId, MutationOperation.Cancel, cancelHash, {
           requestId: 'cancel-lookup-not-found',
           status: 404,
           contentHash: 'f'.repeat(64),
-          observedAt: new Date(base + 5).toISOString(),
+          observedAt: new Date(cancelBase + 2).toISOString(),
         })
         yield* store.recoveryFound(
           intent.intentId,
@@ -935,20 +952,90 @@ describePostgres('PostgreSQL evaluation evidence', () => {
             requestId: 'cancel-lookup',
             status: 200,
             contentHash: '0'.repeat(64),
-            observedAt: new Date(base + 6).toISOString(),
+            observedAt: new Date(cancelBase + 3).toISOString(),
           },
           TerminalOutcome.Canceled,
         )
-        return { notFound, state: yield* sqlIntentState(intent.intentId) }
+        return { blockedSubmit, notFound, state: yield* sqlIntentState(intent.intentId) }
       }),
     )
     await mutation.dispose()
 
+    expect(Exit.isFailure(observed.blockedSubmit)).toBe(true)
+    if (Exit.isFailure(observed.blockedSubmit)) {
+      expect(Cause.pretty(observed.blockedSubmit.cause)).toContain('effective authority is not PAPER and clear')
+    }
     expect(observed.notFound).toMatchObject({
       eventType: MutationEventType.RecoveryNotFound,
       brokerOrderId: orderId,
     })
     expect(observed.state).toEqual({ state: 'TERMINAL', state_version: 5 })
+  })
+
+  test('rejects non-submitted and mismatched broker order identities before cancellation starts', async () => {
+    const execution = makeExecutionRuntime()
+    const intent = await Effect.runPromise(plan(intentPlan({ cycleId: 'e'.repeat(64) })))
+    const decision = await Effect.runPromise(riskDecision(intent, RiskOutcome.Approved))
+    await execution.runPromise(
+      Effect.gen(function* () {
+        yield* Effect.flatMap(IntentStore, (store) => store.commit(intent, decision))
+        const sql = yield* PgClient.PgClient
+        yield* sql`
+          INSERT INTO authority_state (
+            schema_version, generation_hash, maximum, effective, kill_state, version, updated_at
+          ) VALUES (
+            'bayn.paper-authority.v1', ${'9'.repeat(64)}, 'PAPER', 'PAPER', 'CLEAR', 1,
+            ${new Date(Date.now() + 1).toISOString()}
+          )
+        `
+      }),
+    )
+    await execution.dispose()
+
+    const mutation = makeMutationRuntime()
+    const submitHash = 'a'.repeat(64)
+    const otherOrderId = 'f93d3f58-0e70-4cd2-a9e1-2fcb89d76f74'
+    const base = Date.now() + 100
+    const observed = await mutation.runPromise(
+      Effect.gen(function* () {
+        const store = yield* MutationStore
+        const nonSubmitted = yield* Effect.exit(
+          store.beginCancel(intent.intentId, cancelRequestHash(orderId), orderId, 1_000, new Date(base).toISOString()),
+        )
+        yield* store.beginSubmit(intent.intentId, submitHash, 1_000, new Date(base + 1).toISOString())
+        yield* store.submitAccepted(intent.intentId, submitHash, orderId, {
+          requestId: 'submit-request',
+          status: 200,
+          contentHash: '1'.repeat(64),
+          observedAt: new Date(base + 2).toISOString(),
+        })
+        const mismatched = yield* Effect.exit(
+          store.beginCancel(
+            intent.intentId,
+            cancelRequestHash(otherOrderId),
+            otherOrderId,
+            1_000,
+            new Date(base + 3).toISOString(),
+          ),
+        )
+        return {
+          latest: yield* store.latest(intent.intentId, MutationOperation.Cancel),
+          mismatched,
+          nonSubmitted,
+        }
+      }),
+    )
+    await mutation.dispose()
+
+    expect(Exit.isFailure(observed.nonSubmitted)).toBe(true)
+    if (Exit.isFailure(observed.nonSubmitted)) {
+      expect(Cause.pretty(observed.nonSubmitted.cause)).toContain('exact durable submitted order identity')
+    }
+    expect(Exit.isFailure(observed.mismatched)).toBe(true)
+    if (Exit.isFailure(observed.mismatched)) {
+      expect(Cause.pretty(observed.mismatched.cause)).toContain('exact durable submitted order identity')
+    }
+    expect(observed.latest).toBeUndefined()
   })
 
   test('blocks later exposure only while an earlier mutation outcome remains unresolved', async () => {

--- a/services/bayn/src/execution/coordinator.test.ts
+++ b/services/bayn/src/execution/coordinator.test.ts
@@ -125,6 +125,7 @@ const completeEvidence = (response: Partial<MutationEvidence> | undefined): Muta
 interface HarnessOptions {
   readonly crashAfterSubmit?: boolean
   readonly lostFence?: boolean
+  readonly lostFenceAfterSubmit?: boolean
   readonly notFoundOnce?: boolean
   readonly unknownSubmit?: boolean
   readonly submitError?: BrokerMutationError
@@ -407,6 +408,19 @@ const makeHarness = (options: HarnessOptions = {}) => {
     marketCalendar: unusedMarketCalendar,
   }
 
+  const fenceCheck = Effect.suspend(() => {
+    if (!options.lostFence && !(options.lostFenceAfterSubmit && latest.has(MutationOperation.Submit))) {
+      return Effect.void
+    }
+    return Effect.fail(
+      new WriterFenceError({
+        failure: 'unavailable',
+        operation: 'check',
+        message: 'injected writer-fence loss',
+      }),
+    )
+  })
+
   const provide = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
     effect.pipe(
       Effect.provideService(IntentStore, intentStore),
@@ -415,15 +429,7 @@ const makeHarness = (options: HarnessOptions = {}) => {
       Effect.provideService(BrokerRead, read),
       Effect.provideService(WriterFence, {
         backendPid: 1,
-        check: options.lostFence
-          ? Effect.fail(
-              new WriterFenceError({
-                failure: 'unavailable',
-                operation: 'check',
-                message: 'injected writer-fence loss',
-              }),
-            )
-          : Effect.void,
+        check: fenceCheck,
         transaction: (effect) => effect,
       }),
       Effect.provide(TestClock.layer()),
@@ -704,24 +710,72 @@ describe('paper execution coordinator', () => {
     expect(harness.calls()).toEqual({ submit: 1, cancel: 1, lookup: 0 })
   })
 
-  test('makes zero DELETE calls when the risk decision expires exactly at cancellation', async () => {
+  test('cancels the exact identified order after its new-exposure risk decision expires', async () => {
     const harness = makeHarness()
-    const failure = await Effect.runPromise(
+    const result = await Effect.runPromise(
       harness.provide(
         Effect.gen(function* () {
           yield* submit(intentId, 1_000)
           yield* TestClock.adjust(600_000)
+          return yield* cancel(intentId, 1_000)
+        }),
+      ),
+    )
+
+    expect(result).toMatchObject({
+      eventType: MutationEventType.CancelAccepted,
+      brokerOrderId: orderId,
+    })
+    expect(harness.calls()).toEqual({ submit: 1, cancel: 1, lookup: 0 })
+    expect(harness.state()).toBe(IntentState.Acknowledged)
+  })
+
+  test('makes no DELETE call when the writer fence is lost after the durable submit', async () => {
+    const harness = makeHarness({ lostFenceAfterSubmit: true })
+    const failure = await Effect.runPromise(
+      harness.provide(
+        Effect.gen(function* () {
+          yield* submit(intentId, 1_000)
           return yield* Effect.flip(cancel(intentId, 1_000))
+        }),
+      ),
+    )
+
+    expect(failure).toBeInstanceOf(WriterFenceError)
+    expect(harness.calls()).toEqual({ submit: 1, cancel: 0, lookup: 0 })
+    expect(harness.state()).toBe(IntentState.Acknowledged)
+  })
+
+  test('rejects cancellation when no durable submitted order exists', async () => {
+    const harness = makeHarness()
+    const failure = await Effect.runPromise(harness.provide(Effect.flip(cancel(intentId, 1_000))))
+
+    expect(failure).toBeInstanceOf(ExecutionError)
+    expect(failure).toMatchObject({
+      failure: ExecutionFailure.InvalidState,
+      message: 'cancellation requires a positively identified broker order',
+    })
+    expect(harness.calls()).toEqual({ submit: 0, cancel: 0, lookup: 0 })
+    expect(harness.state()).toBe(IntentState.Approved)
+  })
+
+  test('rejects cancellation when the durable submit belongs to a different intent identity', async () => {
+    const harness = makeHarness()
+    const otherIntentId = '0'.repeat(64)
+    const failure = await Effect.runPromise(
+      harness.provide(
+        Effect.gen(function* () {
+          yield* submit(intentId, 1_000)
+          return yield* Effect.flip(cancel(otherIntentId, 1_000))
         }),
       ),
     )
 
     expect(failure).toBeInstanceOf(ExecutionError)
     expect(failure).toMatchObject({
-      failure: ExecutionFailure.InvalidState,
-      message: `cancellation risk decision expired at ${riskDecision.expiresAt}`,
+      failure: ExecutionFailure.IntentNotFound,
+      message: `intent ${otherIntentId} does not exist`,
     })
     expect(harness.calls()).toEqual({ submit: 1, cancel: 0, lookup: 0 })
-    expect(harness.state()).toBe(IntentState.Acknowledged)
   })
 })

--- a/services/bayn/src/execution/coordinator.ts
+++ b/services/bayn/src/execution/coordinator.ts
@@ -132,27 +132,17 @@ const isSubmitResolved = (event: MutationEvent): boolean =>
   event.eventType === MutationEventType.SubmitRejected ||
   event.eventType === MutationEventType.RecoveryFound
 
-const requireActiveRiskDecision = (
-  operation: MutationOperation,
-  stored: StoredIntent,
-  operationLabel = operation === MutationOperation.Submit ? 'submission' : 'cancellation',
-  allowIoStarted = false,
-) =>
+const requireActiveSubmitRiskDecision = (stored: StoredIntent, operationLabel = 'submission') =>
   Effect.gen(function* () {
     const decision = stored.decision
-    const validIntentState =
-      operation === MutationOperation.Submit
-        ? stored.intent.state === IntentState.Approved ||
-          (allowIoStarted && stored.intent.state === IntentState.IoStarted)
-        : stored.intent.state === IntentState.Acknowledged || stored.intent.state === IntentState.Unknown
     if (
-      !validIntentState ||
+      stored.intent.state !== IntentState.Approved ||
       decision?.outcome !== RiskOutcome.Approved ||
       stored.intent.riskDecisionId !== decision.decisionId
     ) {
       return yield* Effect.fail(
         new ExecutionError({
-          operation,
+          operation: MutationOperation.Submit,
           failure: ExecutionFailure.InvalidState,
           message: `${operationLabel} requires one committed approved intent and matching risk decision`,
         }),
@@ -162,7 +152,7 @@ const requireActiveRiskDecision = (
     if (currentTime >= Date.parse(decision.expiresAt)) {
       return yield* Effect.fail(
         new ExecutionError({
-          operation,
+          operation: MutationOperation.Submit,
           failure: ExecutionFailure.InvalidState,
           message: `${operationLabel} risk decision expired at ${decision.expiresAt}`,
         }),
@@ -177,7 +167,7 @@ export const dryRunSubmit = (
   readIntent(MutationOperation.Submit, intentId).pipe(
     Effect.flatMap((stored) =>
       Effect.gen(function* () {
-        yield* requireActiveRiskDecision(MutationOperation.Submit, stored, 'dry-run submission')
+        yield* requireActiveSubmitRiskDecision(stored, 'dry-run submission')
         return yield* Effect.try({
           try: (): DryRunSubmit => {
             const request = orderRequestBody(stored.intent)
@@ -237,7 +227,7 @@ export const submit = (intentId: string, consistencyDelayMs: number) =>
       return replay.event
     }
     yield* fence.check
-    yield* requireActiveRiskDecision(MutationOperation.Submit, before)
+    yield* requireActiveSubmitRiskDecision(before)
     const current = yield* now
     const started = yield* mutations.beginSubmit(
       intentId,
@@ -313,7 +303,6 @@ export const cancel = (intentId: string, consistencyDelayMs: number) =>
     }
     const intent = yield* readIntent(MutationOperation.Cancel, intentId)
     yield* fence.check
-    yield* requireActiveRiskDecision(MutationOperation.Cancel, intent)
     const current = yield* now
     const started = yield* mutations.beginCancel(
       intentId,

--- a/services/bayn/src/execution/mutations.ts
+++ b/services/bayn/src/execution/mutations.ts
@@ -220,13 +220,30 @@ export interface MutationStoreShape {
 
 export class MutationStore extends Context.Service<MutationStore, MutationStoreShape>()('bayn/MutationStore') {}
 
-const isIdentifiedUnresolvedSubmit = (event: MutationEvent | undefined, brokerOrderId: string): boolean => {
-  if (event?.operation !== MutationOperation.Submit || event.brokerOrderId !== brokerOrderId) return false
-  return (
-    event.eventType === MutationEventType.SubmitUnknown ||
-    event.eventType === MutationEventType.RecoveryNotFound ||
-    event.eventType === MutationEventType.RecoveryUnknown
-  )
+const intentStateForIdentifiedSubmit = (
+  event: MutationEvent | undefined,
+  intentId: string,
+  brokerOrderId: string,
+): IntentState | undefined => {
+  if (
+    event?.operation !== MutationOperation.Submit ||
+    event.intentId !== intentId ||
+    event.mutationId !== mutationId(intentId, MutationOperation.Submit) ||
+    event.brokerOrderId !== brokerOrderId
+  ) {
+    return undefined
+  }
+  switch (event.eventType) {
+    case MutationEventType.SubmitAccepted:
+    case MutationEventType.RecoveryFound:
+      return IntentState.Acknowledged
+    case MutationEventType.SubmitUnknown:
+    case MutationEventType.RecoveryNotFound:
+    case MutationEventType.RecoveryUnknown:
+      return IntentState.Unknown
+    default:
+      return undefined
+  }
 }
 
 const storeError = (
@@ -473,16 +490,21 @@ const makeStore = Effect.gen(function* () {
               return yield* Effect.fail(storeError(storeOperation, 'invariant', 'intent does not exist'))
             }
             const requiredState =
-              operation === MutationOperation.Submit ? IntentState.Approved : IntentState.Acknowledged
-            const identifiedUnknownSubmit =
-              operation === MutationOperation.Cancel &&
-              intent.state === IntentState.Unknown &&
-              input.brokerOrderId !== undefined &&
-              isIdentifiedUnresolvedSubmit(
-                yield* readLatest(input.intentId, MutationOperation.Submit),
-                input.brokerOrderId,
+              operation === MutationOperation.Submit
+                ? IntentState.Approved
+                : input.brokerOrderId === undefined
+                  ? undefined
+                  : intentStateForIdentifiedSubmit(
+                      yield* readLatest(input.intentId, MutationOperation.Submit),
+                      input.intentId,
+                      input.brokerOrderId,
+                    )
+            if (requiredState === undefined) {
+              return yield* Effect.fail(
+                storeError('begin-cancel', 'invariant', 'cancel requires the exact durable submitted order identity'),
               )
-            if (intent.state !== requiredState && !identifiedUnknownSubmit) {
+            }
+            if (intent.state !== requiredState) {
               return yield* Effect.fail(
                 storeError(
                   storeOperation,
@@ -511,7 +533,7 @@ const makeStore = Effect.gen(function* () {
               ...(input.brokerOrderId === undefined ? {} : { brokerOrderId: input.brokerOrderId }),
               occurredAt: input.occurredAt,
             })
-            yield* append(event, true)
+            yield* append(event, operation === MutationOperation.Submit)
             if (operation === MutationOperation.Submit) {
               const transitioned = yield* sql<{ intent_id: string }>`
                 UPDATE intents


### PR DESCRIPTION
## Summary

- Allow cancellation of an exact durable submitted order after its new-exposure approval expires, without weakening submit approval/cutoff checks.
- Keep cancellation behind the writer fence, maximum-PAPER/kill-aware mutation authorization, and an exact intent-to-broker-order identity match.
- Cover post-expiry and kill-active cancellation, blocked submit under kill, fence loss, and mismatched or non-submitted identities.

## Related Issues

PROOMPT-375

## Testing

- `bun test services/bayn/src/execution/coordinator.test.ts` (17 pass)
- `bun run --filter @proompteng/bayn test` (353 pass, 72 PostgreSQL tests skipped because `BAYN_TEST_POSTGRES_URL` is unavailable locally)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- PostgreSQL regressions are included for CI execution in the supported database environment.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (screenshots are not applicable).
- [x] Documentation, release notes, and follow-ups are updated or tracked (no operator contract change; PROOMPT-375 tracks the gated Phase B follow-up).