### PR TITLE
feat(bayn): add paper authority activation history

### DIFF
--- a/services/bayn/migrations/0014_authority_generation_history.ts
+++ b/services/bayn/migrations/0014_authority_generation_history.ts
@@ -1,0 +1,237 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient
+
+  yield* sql`
+    DO $block$
+    BEGIN
+      IF EXISTS (
+        SELECT 1
+        FROM authority_state
+        WHERE maximum = 'PAPER'
+      ) THEN
+        RAISE EXCEPTION 'cannot create authority generation history from unaudited PAPER state'
+          USING ERRCODE = '23514';
+      END IF;
+    END;
+    $block$
+  `
+
+  yield* sql`
+    CREATE TABLE authority_generations (
+      generation_hash text PRIMARY KEY CHECK (generation_hash ~ '^[0-9a-f]{64}$'),
+      schema_version text NOT NULL CHECK (schema_version = 'bayn.authority-generation-history.v1'),
+      activation_schema_version text CHECK (
+        activation_schema_version = 'bayn.paper-authority-generation.v1'
+      ),
+      previous_generation_hash text REFERENCES authority_generations(generation_hash) ON DELETE RESTRICT,
+      maximum text NOT NULL CHECK (maximum IN ('OBSERVE', 'PAPER')),
+      authority_version bigint NOT NULL UNIQUE CHECK (authority_version > 0),
+      qualification_run_id text REFERENCES qualification_results(run_id) ON DELETE RESTRICT,
+      qualification_lock_id text REFERENCES qualification_results(lock_id) ON DELETE RESTRICT,
+      qualification_result_hash text REFERENCES qualification_results(result_hash) ON DELETE RESTRICT,
+      protocol_hash text REFERENCES protocol_locks(protocol_hash) ON DELETE RESTRICT,
+      qualification_execution_policy_hash text CHECK (
+        qualification_execution_policy_hash ~ '^[0-9a-f]{64}$'
+      ),
+      qualification_source_revision text CHECK (
+        qualification_source_revision ~ '^([0-9a-f]{40}|[0-9a-f]{64})$'
+      ),
+      qualification_image_repository text CHECK (
+        length(qualification_image_repository) > 0
+        AND qualification_image_repository = btrim(qualification_image_repository)
+      ),
+      qualification_image_digest text CHECK (
+        qualification_image_digest ~ '^sha256:[0-9a-f]{64}$'
+      ),
+      activation_source_revision text CHECK (
+        activation_source_revision ~ '^([0-9a-f]{40}|[0-9a-f]{64})$'
+      ),
+      activation_image_repository text CHECK (
+        length(activation_image_repository) > 0
+        AND activation_image_repository = btrim(activation_image_repository)
+      ),
+      activation_image_digest text CHECK (
+        activation_image_digest ~ '^sha256:[0-9a-f]{64}$'
+      ),
+      strategy_name text CHECK (strategy_name = 'risk-balanced-trend'),
+      strategy_behavior_hash text CHECK (strategy_behavior_hash ~ '^[0-9a-f]{64}$'),
+      strategy_parameter_hash text CHECK (strategy_parameter_hash ~ '^[0-9a-f]{64}$'),
+      strategy_parameter_schema_version text CHECK (
+        strategy_parameter_schema_version = 'bayn.risk-balanced-trend.protocol.v3'
+      ),
+      account_id text CHECK (length(account_id) > 0 AND account_id = btrim(account_id)),
+      risk_policy_hash text CHECK (risk_policy_hash ~ '^[0-9a-f]{64}$'),
+      proof_plan_hash text CHECK (proof_plan_hash ~ '^[0-9a-f]{64}$'),
+      reconciliation_id text REFERENCES reconciliations(reconciliation_id) ON DELETE RESTRICT,
+      reconciliation_content_hash text CHECK (reconciliation_content_hash ~ '^[0-9a-f]{64}$'),
+      activated_at timestamptz NOT NULL,
+      CHECK (
+        (
+          maximum = 'OBSERVE'
+          AND activation_schema_version IS NULL
+          AND qualification_run_id IS NULL
+          AND qualification_lock_id IS NULL
+          AND qualification_result_hash IS NULL
+          AND protocol_hash IS NULL
+          AND qualification_execution_policy_hash IS NULL
+          AND qualification_source_revision IS NULL
+          AND qualification_image_repository IS NULL
+          AND qualification_image_digest IS NULL
+          AND activation_source_revision IS NULL
+          AND activation_image_repository IS NULL
+          AND activation_image_digest IS NULL
+          AND strategy_name IS NULL
+          AND strategy_behavior_hash IS NULL
+          AND strategy_parameter_hash IS NULL
+          AND strategy_parameter_schema_version IS NULL
+          AND account_id IS NULL
+          AND risk_policy_hash IS NULL
+          AND proof_plan_hash IS NULL
+          AND reconciliation_id IS NULL
+          AND reconciliation_content_hash IS NULL
+        )
+        OR (
+          maximum = 'PAPER'
+          AND previous_generation_hash IS NOT NULL
+          AND activation_schema_version IS NOT NULL
+          AND qualification_run_id IS NOT NULL
+          AND qualification_lock_id IS NOT NULL
+          AND qualification_result_hash IS NOT NULL
+          AND protocol_hash IS NOT NULL
+          AND qualification_execution_policy_hash IS NOT NULL
+          AND qualification_source_revision IS NOT NULL
+          AND qualification_image_repository IS NOT NULL
+          AND qualification_image_digest IS NOT NULL
+          AND activation_source_revision IS NOT NULL
+          AND activation_image_repository IS NOT NULL
+          AND activation_image_digest IS NOT NULL
+          AND strategy_name IS NOT NULL
+          AND strategy_behavior_hash IS NOT NULL
+          AND strategy_parameter_hash IS NOT NULL
+          AND strategy_parameter_schema_version IS NOT NULL
+          AND account_id IS NOT NULL
+          AND risk_policy_hash IS NOT NULL
+          AND proof_plan_hash IS NOT NULL
+          AND reconciliation_id IS NOT NULL
+          AND reconciliation_content_hash IS NOT NULL
+        )
+      )
+    )
+  `
+
+  yield* sql`
+    INSERT INTO authority_generations (
+      generation_hash, schema_version, previous_generation_hash, maximum,
+      authority_version, activated_at
+    )
+    SELECT
+      generation_hash, 'bayn.authority-generation-history.v1', NULL, maximum,
+      version, updated_at
+    FROM authority_state
+    WHERE singleton AND maximum = 'OBSERVE'
+  `
+
+  yield* sql`
+    CREATE TRIGGER authority_generations_append_only
+    BEFORE UPDATE OR DELETE ON authority_generations
+    FOR EACH ROW EXECUTE FUNCTION reject_evidence_mutation()
+  `
+  yield* sql`
+    CREATE TRIGGER authority_generations_reject_truncate
+    BEFORE TRUNCATE ON authority_generations
+    FOR EACH STATEMENT EXECUTE FUNCTION reject_evidence_mutation()
+  `
+
+  yield* sql`
+    CREATE OR REPLACE FUNCTION enforce_authority_transition()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+    BEGIN
+      IF TG_OP = 'DELETE' THEN
+        RAISE EXCEPTION 'authority state cannot be deleted' USING ERRCODE = '55000';
+      END IF;
+
+      IF TG_OP = 'INSERT' THEN
+        IF NEW.version <> 1
+          OR NEW.maximum <> 'OBSERVE'
+          OR NEW.effective <> 'OBSERVE'
+          OR NEW.kill_state <> 'CLEAR'
+          OR NEW.reason IS NOT NULL
+        THEN
+          RAISE EXCEPTION 'authority state must begin as clear OBSERVE at version 1'
+            USING ERRCODE = '23514';
+        END IF;
+        IF NOT EXISTS (
+          SELECT 1
+          FROM authority_generations AS generation
+          WHERE generation.generation_hash = NEW.generation_hash
+            AND generation.previous_generation_hash IS NULL
+            AND generation.maximum = 'OBSERVE'
+            AND generation.authority_version = 1
+            AND generation.activated_at = NEW.updated_at
+        ) THEN
+          RAISE EXCEPTION 'initial authority state lacks matching immutable OBSERVE history'
+            USING ERRCODE = '23514';
+        END IF;
+        RETURN NEW;
+      END IF;
+
+      IF NEW.singleton <> OLD.singleton
+        OR NEW.schema_version <> OLD.schema_version
+        OR NEW.version <> OLD.version + 1
+        OR NEW.updated_at <= OLD.updated_at
+      THEN
+        RAISE EXCEPTION 'invalid authority state version' USING ERRCODE = '23514';
+      END IF;
+
+      IF NEW.generation_hash = OLD.generation_hash THEN
+        IF NEW.maximum <> OLD.maximum
+          OR (OLD.effective = 'OBSERVE' AND NEW.effective = 'PAPER')
+          OR (OLD.kill_state = 'ACTIVE' AND NEW.kill_state = 'CLEAR')
+        THEN
+          RAISE EXCEPTION 'authority can only decrease within a GitOps generation' USING ERRCODE = '23514';
+        END IF;
+        RETURN NEW;
+      END IF;
+
+      IF NEW.kill_state IS DISTINCT FROM OLD.kill_state
+        OR NEW.reason IS DISTINCT FROM OLD.reason
+      THEN
+        RAISE EXCEPTION 'authority generation changes must preserve kill state exactly'
+          USING ERRCODE = '23514';
+      END IF;
+
+      IF NOT EXISTS (
+        SELECT 1
+        FROM authority_generations AS generation
+        WHERE generation.generation_hash = NEW.generation_hash
+          AND generation.previous_generation_hash = OLD.generation_hash
+          AND generation.maximum = NEW.maximum
+          AND generation.authority_version = NEW.version
+          AND generation.activated_at = NEW.updated_at
+      ) THEN
+        RAISE EXCEPTION 'authority generation change lacks matching immutable history'
+          USING ERRCODE = '23514';
+      END IF;
+
+      IF NEW.maximum = 'PAPER' THEN
+        IF OLD.maximum <> 'OBSERVE'
+          OR NEW.effective <> (
+            CASE WHEN NEW.kill_state = 'ACTIVE' THEN 'OBSERVE' ELSE 'PAPER' END
+          )
+        THEN
+          RAISE EXCEPTION 'invalid PAPER authority generation transition' USING ERRCODE = '23514';
+        END IF;
+      ELSIF NEW.effective <> 'OBSERVE' THEN
+        RAISE EXCEPTION 'OBSERVE generation must remain effectively OBSERVE' USING ERRCODE = '23514';
+      END IF;
+
+      RETURN NEW;
+    END
+    $function$
+  `
+})

--- a/services/bayn/src/db/cycle-observability.integration.test.ts
+++ b/services/bayn/src/db/cycle-observability.integration.test.ts
@@ -83,21 +83,26 @@ const makeDraft = (dedicatedAccountId = accountId) => {
   return makeCycleDraft(identity, makeCycleWindow(signalSession('2026-03-06'), executionCalendar, executionPolicy))
 }
 
-const seedSafetyState = (
-  maximum = Authority.Observe,
-  effective = Authority.Observe,
-  reconciledAt = '2026-03-06T21:00:00.000Z',
-) =>
+const seedSafetyState = (reconciledAt = '2026-03-06T21:00:00.000Z') =>
   Effect.gen(function* () {
     const sql = yield* PgClient.PgClient
+    yield* sql`
+      INSERT INTO authority_generations (
+        generation_hash, schema_version, previous_generation_hash, maximum,
+        authority_version, activated_at
+      ) VALUES (
+        ${'f'.repeat(64)}, 'bayn.authority-generation-history.v1', NULL,
+        'OBSERVE', 1, '2026-03-06T21:00:00.000Z'
+      )
+    `
     yield* sql`
     INSERT INTO authority_state (
       schema_version, generation_hash, maximum, effective, kill_state, reason, version, updated_at
     ) VALUES (
       'bayn.paper-authority.v1',
       ${'f'.repeat(64)},
-      ${maximum},
-      ${effective},
+      ${Authority.Observe},
+      ${Authority.Observe},
       ${KillState.Clear},
       NULL,
       1,
@@ -116,7 +121,7 @@ const seedSafetyState = (
       ${reconciliationHash},
       ${'1'.repeat(64)},
       'EXACT',
-      ${sql.json([])},
+      ${sql.json(JSON.stringify([]))},
       ${reconciledAt}
     )
   `
@@ -128,13 +133,18 @@ const seedUnresolvedMutation = (mutationAccountId = accountId) =>
     const intentId = '2'.repeat(64)
     yield* sql`
     INSERT INTO intents (
-      intent_id, schema_version, risk_decision_id, account_id, client_order_id,
+      intent_id, schema_version, risk_decision_id, strategy_name, cycle_id,
+      decision_hash, policy_hash, account_id, client_order_id,
       symbol, side, order_type, time_in_force, quantity_micros, notional_limit_micros,
       state, terminal_outcome, state_version, created_at, updated_at
     ) VALUES (
       ${intentId},
-      'bayn.paper-intent.v1',
+      'bayn.paper-intent.v2',
       NULL,
+      'risk-balanced-trend',
+      ${'8'.repeat(64)},
+      ${'9'.repeat(64)},
+      ${'a'.repeat(64)},
       ${mutationAccountId},
       'bayn-observability-test-order',
       'SPY',
@@ -349,16 +359,32 @@ describePostgres('PostgreSQL cycle observability projection', () => {
     const result = await runtime.runPromise(
       Effect.gen(function* () {
         const observability = yield* CycleObservability
-        yield* seedSafetyState(Authority.Paper, Authority.Paper, '2026-03-06T21:02:00.000000Z')
+        yield* seedSafetyState('2026-03-06T21:02:00.000000Z')
         yield* seedUnresolvedMutation()
         yield* seedAcceptedMutation('2026-03-06T21:02:00.000500Z')
         const projected = yield* observability.read(qualificationRunId, accountId)
-        const status = deriveCycleOperationsStatus(projected, Date.parse('2026-03-06T21:03:30.000Z'), Authority.Paper, {
-          cycleStallThresholdMs: 300_000,
-          reconciliationStaleThresholdMs: 300_000,
-          unknownMutationThresholdMs: 300_000,
-        })
-        return { projected, status }
+        if (projected.authority === null) {
+          return yield* Effect.die(new Error('authority projection is unavailable'))
+        }
+        const paperProjection = {
+          ...projected,
+          authority: {
+            ...projected.authority,
+            maximum: Authority.Paper,
+            effective: Authority.Paper,
+          },
+        }
+        const status = deriveCycleOperationsStatus(
+          paperProjection,
+          Date.parse('2026-03-06T21:03:30.000Z'),
+          Authority.Paper,
+          {
+            cycleStallThresholdMs: 300_000,
+            reconciliationStaleThresholdMs: 300_000,
+            unknownMutationThresholdMs: 300_000,
+          },
+        )
+        return { projected: paperProjection, status }
       }),
     )
 

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -5,23 +5,31 @@ import { PgClient } from '@effect/sql-pg'
 import { Cause, Deferred, Duration, Effect, Exit, Fiber, Layer, ManagedRuntime, Option, Redacted } from 'effect'
 
 import type { RuntimeConfig } from '../config'
+import { makeStrategyProtocolHash } from '../contracts'
 import { IntentStore, IntentStoreLive, plan, type IntentPlan } from '../execution/intents'
 import { MutationEventType, MutationStore, MutationStoreLive } from '../execution/mutations'
 import { MutationOperation, cancelRequestHash } from '../broker/alpaca-mutations'
 import { WriterFence, WriterFenceLive } from '../execution/writer-fence'
 import { canonicalHashV1 } from '../hash'
-import { buildLedgerPlan } from '../ledger'
+import { buildLedgerPlan, Journal, type JournalService } from '../ledger'
 import {
   Authority,
   decodeRiskDecision,
+  makePaperAuthorityGeneration,
   OrderSide,
   OrderType,
   RiskOutcome,
   TerminalOutcome,
   TimeInForce,
   type Intent,
+  type PaperAuthorityGeneration,
 } from '../paper'
-import { makeQualificationResult } from '../qualification'
+import { makeQualificationLock, makeQualificationPolicyDocument, makeQualificationResult } from '../qualification'
+import {
+  analyzeQualification,
+  defaultQualificationStatisticsPolicy,
+  type QualificationSeries,
+} from '../qualification-statistics'
 import { evaluateRiskBalancedTrend } from '../risk-balanced-trend'
 import { makeStrategy } from '../strategy'
 import { makeSnapshot, makeTestProvenance, fixtureProtocol } from '../test-fixtures'
@@ -33,6 +41,7 @@ import {
   PostgresClientLive,
   type PersistEvaluationInput,
 } from './evidence-store'
+import { PaperStore, PaperStoreLive } from './paper-store'
 
 const postgresUrl = process.env.BAYN_TEST_POSTGRES_URL
 const testUrl = postgresUrl ?? 'postgresql://bayn:bayn@127.0.0.1:5432/bayn_test'
@@ -95,6 +104,34 @@ const makeMutationRuntime = (config = makeConfig()) =>
   ManagedRuntime.make(
     MutationStoreLive.pipe(
       Layer.provideMerge(WriterFenceLive),
+      Layer.provideMerge(PostgresClientLive(config)),
+      Layer.provide(NodeServices.layer),
+    ),
+  )
+
+const unusedJournal: JournalService = {
+  post: () => Effect.die(new Error('unexpected accounting journal write')),
+  verifyAccount: () => Effect.die(new Error('unexpected accounting journal verification')),
+  journalAndReconcile: () => Effect.die(new Error('unexpected simulation journal write')),
+  check: Effect.die(new Error('unexpected accounting journal health check')),
+  checkRun: () => Effect.die(new Error('unexpected simulation journal verification')),
+}
+
+const makePaperStoreRuntime = (config = makeConfig()) =>
+  ManagedRuntime.make(
+    PaperStoreLive(config).pipe(
+      Layer.provideMerge(WriterFenceLive),
+      Layer.provideMerge(Layer.succeed(Journal, unusedJournal)),
+      Layer.provideMerge(PostgresClientLive(config)),
+      Layer.provide(NodeServices.layer),
+    ),
+  )
+
+const makeAuthorityMutationRuntime = (config = makeConfig()) =>
+  ManagedRuntime.make(
+    Layer.mergeAll(PaperStoreLive(config), IntentStoreLive, MutationStoreLive).pipe(
+      Layer.provideMerge(WriterFenceLive),
+      Layer.provideMerge(Layer.succeed(Journal, unusedJournal)),
       Layer.provideMerge(PostgresClientLive(config)),
       Layer.provide(NodeServices.layer),
     ),
@@ -198,6 +235,295 @@ const makeLockedInput = (input: PersistEvaluationInput, priorTrialRunIds: readon
   }
 }
 
+const fixtureHash = (value: string): string => canonicalHashV1({ value })
+
+const passingQualificationSeries = (runId: string): QualificationSeries => {
+  const sessionDate = (index: number): `${number}-${number}-${number}` => {
+    const date = new Date('2000-01-01T00:00:00.000Z')
+    date.setUTCDate(date.getUTCDate() + index)
+    return date.toISOString().slice(0, 10) as `${number}-${number}-${number}`
+  }
+  const blockCount = 90
+  return {
+    schemaVersion: 'bayn.qualification-series.v1',
+    runId,
+    observations: Array.from({ length: blockCount * 21 + 10 }, (_, index) => {
+      const noise = (((index * 17) % 23) - 11) / 100_000
+      return {
+        sessionDate: sessionDate(index),
+        strategyReturn: 0.0005 + noise,
+        cashReturn: 0,
+        buyAndHoldReturn: 0.00015 + noise * 1.1,
+        directVolatilityReturn: 0.0001 + noise * 0.8,
+      }
+    }),
+    rebalanceExecutionDates: Array.from({ length: blockCount + 1 }, (_, index) => sessionDate(index * 21)),
+  }
+}
+
+const mutationQualificationProvenance = makeTestProvenance()
+const mutationQualificationRunId = fixtureHash('mutation-authority-qualification-run')
+const mutationQualificationSnapshotId = fixtureHash('mutation-authority-qualification-snapshot')
+const mutationQualificationLock = makeQualificationLock({
+  schemaVersion: 'bayn.qualification-lock.v3',
+  candidateRunId: mutationQualificationRunId,
+  protocolHash: makeStrategyProtocolHash(mutationQualificationProvenance.strategy),
+  sourceRevision: mutationQualificationProvenance.sourceRevision,
+  image: mutationQualificationProvenance.image,
+  universeId: fixtureProtocol.universeId,
+  universeSymbolHash: fixtureProtocol.universeSymbolHash,
+  universe: fixtureProtocol.universe,
+  universeRationale: 'Deterministic qualified evidence for mutation persistence tests.',
+  data: {
+    snapshotId: mutationQualificationSnapshotId,
+    publicationId: fixtureHash('mutation-authority-qualification-publication'),
+    inputManifestHash: fixtureHash('mutation-authority-qualification-manifest'),
+    contentHash: fixtureHash('mutation-authority-qualification-content'),
+    sessionsContentHash: fixtureHash('mutation-authority-qualification-sessions'),
+    provider: 'alpaca',
+    sourceFeed: 'sip',
+    adjustment: 'all',
+    calendarVersion: 'alpaca-us-equity-calendar-v1',
+    firstSession: '2016-01-04',
+    lastSession: '2026-07-21',
+    selectedSessionCount: 1_900,
+    selectedRebalanceCount: 91,
+    bounds: {
+      schemaVersion: 'bayn.evaluation-bounds.v1',
+      dataStart: '2016-01-04',
+      dataEnd: '2026-07-21',
+      lookbackStart: '2016-01-04',
+      evaluationStart: '2017-01-03',
+      evaluationEnd: '2026-07-21',
+    },
+  },
+  policies: {
+    benchmark: makeQualificationPolicyDocument('bayn.mutation-benchmark-policy.v1', {
+      schemaVersion: 'bayn.mutation-benchmark-policy.v1',
+      enabled: true,
+    }),
+    thresholds: makeQualificationPolicyDocument('bayn.mutation-threshold-policy.v1', {
+      schemaVersion: 'bayn.mutation-threshold-policy.v1',
+      enabled: true,
+    }),
+    uncertainty: makeQualificationPolicyDocument('bayn.mutation-uncertainty-policy.v1', {
+      schemaVersion: 'bayn.mutation-uncertainty-policy.v1',
+      enabled: true,
+    }),
+    execution: makeQualificationPolicyDocument(
+      fixtureProtocol.executionModel.schemaVersion,
+      fixtureProtocol.executionModel,
+    ),
+  },
+  priorTrialRunIds: [],
+})
+const mutationQualificationResult = makeQualificationResult(
+  mutationQualificationLock,
+  {
+    status: 'PASS',
+    gates: [{ name: 'mutation_authority_fixture', passed: true, actual: 1, required: 1 }],
+  },
+  analyzeQualification(
+    passingQualificationSeries(mutationQualificationRunId),
+    defaultQualificationStatisticsPolicy,
+    [],
+  ),
+)
+
+const makeMutationPaperAuthorityGeneration = (
+  previousGenerationHash: string,
+  reconciliationId: string,
+  reconciliationContentHash: string,
+) => {
+  if (mutationQualificationResult.verdict !== 'QUALIFIED') {
+    throw new Error('audited mutation fixture requires QUALIFIED evidence')
+  }
+  const strategy = mutationQualificationProvenance.strategy
+  const strategyParameterSchemaVersion = strategy.parameterSchemaVersion
+  if (strategyParameterSchemaVersion !== 'bayn.risk-balanced-trend.protocol.v3') {
+    throw new Error('audited mutation fixture requires the current strategy parameter contract')
+  }
+
+  const config = makeConfig()
+  return makePaperAuthorityGeneration({
+    schemaVersion: 'bayn.paper-authority-generation.v1',
+    maximum: Authority.Paper,
+    previousGenerationHash,
+    qualificationRunId: mutationQualificationResult.runId,
+    qualificationLockId: mutationQualificationLock.lockId,
+    qualificationResultHash: mutationQualificationResult.resultHash,
+    protocolHash: mutationQualificationLock.protocolHash,
+    qualificationExecutionPolicyHash: mutationQualificationLock.policies.execution.contentHash,
+    qualificationSourceRevision: mutationQualificationLock.sourceRevision,
+    qualificationImageRepository: mutationQualificationLock.image.repository,
+    qualificationImageDigest: mutationQualificationLock.image.digest,
+    activationSourceRevision: config.build.sourceRevision,
+    activationImageRepository: config.build.imageRepository,
+    activationImageDigest: config.build.imageDigest,
+    strategyName: strategy.name,
+    strategyBehaviorHash: strategy.behaviorHash,
+    strategyParameterHash: strategy.parameterHash,
+    strategyParameterSchemaVersion,
+    accountId: 'paper-account-1',
+    riskPolicyHash: fixtureHash('mutation-risk-policy'),
+    proofPlanHash: fixtureHash('mutation-proof-plan'),
+    reconciliationId,
+    reconciliationContentHash,
+  })
+}
+
+const makePaperActivationConfig = (activation: PaperAuthorityGeneration): RuntimeConfig => {
+  const config = makeConfig()
+  return {
+    ...config,
+    maximumAuthority: Authority.Paper,
+    qualificationRunId: activation.qualificationRunId,
+    build: {
+      ...config.build,
+      strategyBehaviorHash: activation.strategyBehaviorHash,
+      strategyParameterHash: activation.strategyParameterHash,
+    },
+    alpaca: {
+      accountId: activation.accountId,
+      authorityGenerationHash: activation.generationHash,
+      key: Redacted.make('unused'),
+      secret: Redacted.make('unused'),
+      proxyUrl: 'http://bayn-egress-proxy.invalid',
+      retryAttempts: 0,
+      reconciliationIntervalMs: 30_000,
+    },
+  }
+}
+
+const activateAuditedPaperAuthority = async () => {
+  const observeGenerationHash = fixtureHash('mutation-observe-authority-generation')
+  const reconciliationId = fixtureHash('mutation-authority-reconciliation')
+  const reconciliationContentHash = fixtureHash('mutation-authority-reconciliation-content')
+  const activation = makeMutationPaperAuthorityGeneration(
+    observeGenerationHash,
+    reconciliationId,
+    reconciliationContentHash,
+  )
+  const config = makePaperActivationConfig(activation)
+  const strategy = mutationQualificationProvenance.strategy
+  const paperRuntime = makePaperStoreRuntime(config)
+  try {
+    await paperRuntime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* PaperStore
+        const sql = yield* PgClient.PgClient
+        const accountStateHash = fixtureHash('mutation-authority-account-state')
+        yield* sql`
+          INSERT INTO protocol_locks (
+            protocol_hash, schema_version, strategy_name, behavior_hash, parameter_hash, parameters
+          ) VALUES (
+            ${mutationQualificationLock.protocolHash}, ${fixtureProtocol.schemaVersion},
+            ${strategy.name}, ${strategy.behaviorHash}, ${strategy.parameterHash},
+            ${sql.json(fixtureProtocol)}
+          )
+        `
+        yield* sql`
+          INSERT INTO snapshot_references (
+            snapshot_id, schema_version, database_name, table_name, dataset_version, source,
+            source_feed, adjustment, content_hash, row_count, first_session, last_session, manifest
+          ) VALUES (
+            ${mutationQualificationLock.data.snapshotId}, 'bayn.finalized-snapshot.v3',
+            'signal', 'adjusted_daily_bars_v2', 'signal.adjusted-daily-snapshot.v2',
+            'alpaca', 'sip', 'all', ${mutationQualificationLock.data.contentHash},
+            ${mutationQualificationLock.data.selectedSessionCount * mutationQualificationLock.universe.length},
+            ${mutationQualificationLock.data.firstSession}, ${mutationQualificationLock.data.lastSession},
+            ${sql.json(mutationQualificationLock.data)}
+          )
+        `
+        yield* sql`
+          INSERT INTO evaluation_runs (
+            run_id, protocol_hash, snapshot_id, evaluation_schema_version, source_revision,
+            image_repository, image_digest, strategy_name, initial_capital_micros,
+            expected_artifact_count, expected_event_count, expected_gate_count,
+            status, completed_at
+          ) VALUES (
+            ${mutationQualificationResult.runId}, ${mutationQualificationLock.protocolHash},
+            ${mutationQualificationLock.data.snapshotId}, 'bayn.evaluation.v6',
+            ${mutationQualificationLock.sourceRevision}, ${mutationQualificationLock.image.repository},
+            ${mutationQualificationLock.image.digest}, ${strategy.name}, 1000000000000,
+            1, 0, 1, 'COMPLETE', clock_timestamp()
+          )
+        `
+        yield* sql`
+          INSERT INTO evaluation_artifacts (
+            run_id, artifact_name, schema_version, content_hash, payload
+          ) VALUES (
+            ${mutationQualificationResult.runId}, 'qualification-artifact-manifest',
+            'bayn.qualification-artifact-manifest.v1',
+            ${fixtureHash('mutation-authority-qualification-artifact')},
+            ${sql.json({ runId: mutationQualificationResult.runId })}
+          )
+        `
+        yield* sql`
+          INSERT INTO gate_outcomes (
+            run_id, ordinal, gate_name, passed, actual, required, content_hash
+          ) VALUES (
+            ${mutationQualificationResult.runId}, 0, 'mutation_authority_fixture', true,
+            ${sql.json('1')}, ${sql.json('1')},
+            ${fixtureHash('mutation-authority-qualification-gate')}
+          )
+        `
+        yield* sql`
+          INSERT INTO status_history (run_id, status, detail)
+          VALUES
+            (
+              ${mutationQualificationResult.runId}, 'WRITING',
+              ${sql.json({ artifactCount: 1, eventCount: 0, gateCount: 1 })}
+            ),
+            (
+              ${mutationQualificationResult.runId}, 'COMPLETE',
+              ${sql.json({ reconciliationExact: true, verdict: 'PASS' })}
+            )
+        `
+        yield* sql`
+          INSERT INTO qualification_locks (
+            lock_id, schema_version, candidate_run_id, protocol_hash, snapshot_id,
+            source_revision, image_repository, image_digest, payload
+          ) VALUES (
+            ${mutationQualificationLock.lockId}, ${mutationQualificationLock.schemaVersion},
+            ${mutationQualificationLock.candidateRunId}, ${mutationQualificationLock.protocolHash},
+            ${mutationQualificationLock.data.snapshotId}, ${mutationQualificationLock.sourceRevision},
+            ${mutationQualificationLock.image.repository}, ${mutationQualificationLock.image.digest},
+            ${sql.json(mutationQualificationLock)}
+          )
+        `
+        yield* sql`
+          INSERT INTO qualification_results (
+            lock_id, schema_version, run_id, verdict, analysis_hash, result_hash, payload
+          ) VALUES (
+            ${mutationQualificationResult.lockId}, ${mutationQualificationResult.schemaVersion},
+            ${mutationQualificationResult.runId}, ${mutationQualificationResult.verdict},
+            ${mutationQualificationResult.analysis.analysisHash}, ${mutationQualificationResult.resultHash},
+            ${sql.json(mutationQualificationResult)}
+          )
+        `
+        yield* sql`
+          INSERT INTO reconciliations (
+            reconciliation_id, schema_version, account_id, expected_hash, observed_hash,
+            content_hash, status, discrepancies, reconciled_at
+          ) VALUES (
+            ${reconciliationId}, 'bayn.paper-reconciliation.v1', 'paper-account-1',
+            ${accountStateHash}, ${accountStateHash}, ${reconciliationContentHash},
+            'EXACT', ${sql.json(JSON.stringify([]))}, clock_timestamp()
+          )
+        `
+        yield* store.ensureAuthorityGeneration({
+          generationHash: observeGenerationHash,
+          maximum: Authority.Observe,
+        })
+        yield* store.activatePaperGeneration(activation)
+      }),
+    )
+  } finally {
+    await paperRuntime.dispose()
+  }
+}
+
 describePostgres('PostgreSQL evaluation evidence', () => {
   let runtime: ReturnType<typeof makeEvidenceRuntime>
 
@@ -256,6 +582,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       'account_snapshots',
       'accounting_receipts',
       'accounting_transactions',
+      'authority_generations',
       'authority_state',
       'autonomous_cycle_shadow_decisions',
       'autonomous_cycles',
@@ -297,6 +624,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       { migration_id: 11, name: 'causal_protocol' },
       { migration_id: 12, name: 'observe_shadow_decisions' },
       { migration_id: 13, name: 'autonomous_cycle_terminal_transitions' },
+      { migration_id: 14, name: 'authority_generation_history' },
     ])
   })
 
@@ -625,18 +953,10 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     await execution.runPromise(
       Effect.gen(function* () {
         yield* Effect.flatMap(IntentStore, (store) => store.commit(intent, decision))
-        const sql = yield* PgClient.PgClient
-        yield* sql`
-          INSERT INTO authority_state (
-            schema_version, generation_hash, maximum, effective, kill_state, version, updated_at
-          ) VALUES (
-            'bayn.paper-authority.v1', ${'9'.repeat(64)}, 'PAPER', 'PAPER', 'CLEAR', 1,
-            ${new Date(Date.now() + 1).toISOString()}
-          )
-        `
       }),
     )
     await execution.dispose()
+    await activateAuditedPaperAuthority()
 
     const mutation = makeMutationRuntime()
     const startedAt = new Date(Date.now() + 100).toISOString()
@@ -683,6 +1003,160 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     expect(observed.state).toEqual({ state: 'ACKNOWLEDGED', state_version: 4, events: 2 })
   })
 
+  test('serializes PAPER activation behind a writer-fenced mutation outcome and rechecks the baseline', async () => {
+    await activateAuditedPaperAuthority()
+
+    const observeGenerationHash = fixtureHash('writer-fenced-return-observe-generation')
+    const reconciliationId = fixtureHash('writer-fenced-reconciliation')
+    const reconciliationContentHash = fixtureHash('writer-fenced-reconciliation-content')
+    const paperActivation = makeMutationPaperAuthorityGeneration(
+      observeGenerationHash,
+      reconciliationId,
+      reconciliationContentHash,
+    )
+    const authority = makeAuthorityMutationRuntime(makePaperActivationConfig(paperActivation))
+    const blocker = makeClientRuntime()
+    const base = Date.now()
+    const intent = await Effect.runPromise(
+      plan(
+        intentPlan({
+          cycleId: '9'.repeat(64),
+          createdAt: new Date(base - 5_000).toISOString(),
+        }),
+      ),
+    )
+    const decision = await Effect.runPromise(
+      riskDecision(intent, RiskOutcome.Approved, {
+        decidedAt: new Date(base - 4_000).toISOString(),
+        expiresAt: new Date(base + 60_000).toISOString(),
+      }),
+    )
+    try {
+      const observed = await authority.runPromise(
+        Effect.gen(function* () {
+          const intentStore = yield* IntentStore
+          const mutationStore = yield* MutationStore
+          const paperStore = yield* PaperStore
+          const sql = yield* PgClient.PgClient
+          const requestHash = fixtureHash('writer-fenced-late-submit-outcome')
+          yield* intentStore.commit(intent, decision)
+          yield* mutationStore.beginSubmit(intent.intentId, requestHash, 1_000, new Date(base - 3_000).toISOString())
+
+          yield* paperStore.ensureAuthorityGeneration({
+            generationHash: observeGenerationHash,
+            maximum: Authority.Observe,
+          })
+          const accountStateHash = fixtureHash('writer-fenced-account-state')
+          const [reconciliation] = yield* sql<{ reconciled_at: Date }>`
+            INSERT INTO reconciliations (
+              reconciliation_id, schema_version, account_id, expected_hash, observed_hash,
+              content_hash, status, discrepancies, reconciled_at
+            ) VALUES (
+              ${reconciliationId}, 'bayn.paper-reconciliation.v1', 'paper-account-1',
+              ${accountStateHash}, ${accountStateHash}, ${reconciliationContentHash},
+              'EXACT', ${sql.json(JSON.stringify([]))}, clock_timestamp()
+            )
+            RETURNING reconciled_at
+          `
+          if (reconciliation === undefined) {
+            return yield* Effect.fail('exact reconciliation was not persisted')
+          }
+          const readAuthorityEvidence = sql<{ authority: unknown; history: unknown }>`
+            SELECT
+              (SELECT jsonb_agg(to_jsonb(authority)) FROM authority_state AS authority) AS authority,
+              (
+                SELECT jsonb_agg(to_jsonb(history) ORDER BY history.authority_version)
+                FROM authority_generations AS history
+              ) AS history
+          `
+          const [before] = yield* readAuthorityEvidence
+          const lockHeld = yield* Deferred.make<void>()
+          const releaseLock = yield* Deferred.make<void>()
+          const lockHolder = yield* Effect.forkChild(
+            Effect.promise(() =>
+              blocker.runPromise(
+                Effect.gen(function* () {
+                  const blockerSql = yield* PgClient.PgClient
+                  yield* blockerSql.withTransaction(
+                    Effect.gen(function* () {
+                      yield* blockerSql`LOCK TABLE mutation_events IN ACCESS EXCLUSIVE MODE`
+                      yield* Deferred.succeed(lockHeld, undefined)
+                      yield* Deferred.await(releaseLock)
+                    }),
+                  )
+                }),
+              ),
+            ),
+            { startImmediately: true },
+          )
+          yield* Deferred.await(lockHeld)
+
+          return yield* Effect.gen(function* () {
+            const acceptedAt = new Date(reconciliation.reconciled_at.getTime() + 1).toISOString()
+            const outcome = yield* Effect.forkChild(
+              Effect.exit(
+                mutationStore.submitAccepted(intent.intentId, requestHash, orderId, {
+                  requestId: 'writer-fenced-submit-outcome',
+                  status: 200,
+                  contentHash: fixtureHash('writer-fenced-submit-response'),
+                  observedAt: acceptedAt,
+                }),
+              ),
+              { startImmediately: true },
+            )
+            let mutationWaiting = false
+            for (let attempt = 0; attempt < 200; attempt += 1) {
+              const activities = yield* sql<{ query: string; wait_event_type: string | null }>`
+                SELECT query, wait_event_type
+                FROM pg_stat_activity
+                WHERE pid <> pg_backend_pid()
+                  AND datname = current_database()
+                  AND wait_event_type = 'Lock'
+                  AND query ILIKE '%FROM mutation_events%'
+              `
+              if (activities[0] !== undefined) {
+                mutationWaiting = true
+                break
+              }
+              yield* Effect.sleep(Duration.millis(10))
+            }
+            if (!mutationWaiting) {
+              return yield* Effect.fail('mutation outcome did not wait while holding the writer fence')
+            }
+
+            const activationFiber = yield* Effect.forkChild(
+              Effect.exit(paperStore.activatePaperGeneration(paperActivation)),
+              { startImmediately: true },
+            )
+            yield* Effect.sleep(Duration.millis(20))
+            const activationWaited = activationFiber.pollUnsafe() === undefined
+            yield* Deferred.succeed(releaseLock, undefined)
+            yield* Fiber.join(lockHolder)
+            const outcomeExit = yield* Fiber.join(outcome)
+            const activationExit = yield* Fiber.join(activationFiber)
+            const activationFailure = Exit.isFailure(activationExit)
+              ? Option.getOrUndefined(Cause.findErrorOption(activationExit.cause))
+              : undefined
+            const [after] = yield* readAuthorityEvidence
+            return { activationFailure, activationWaited, after, before, outcomeExit }
+          }).pipe(Effect.ensuring(Deferred.succeed(releaseLock, undefined).pipe(Effect.ignore)))
+        }),
+      )
+
+      expect(observed.activationWaited).toBe(true)
+      expect(Exit.isSuccess(observed.outcomeExit)).toBe(true)
+      expect(observed.activationFailure).toMatchObject({
+        operation: 'authority',
+        failure: 'invariant',
+        message: 'PAPER activation requires zero unresolved mutations covered by reconciliation',
+      })
+      expect(observed.after).toEqual(observed.before)
+    } finally {
+      await authority.dispose()
+      await blocker.dispose()
+    }
+  }, 20_000)
+
   test('does not append a mutation start after its approved risk decision expires', async () => {
     const execution = makeExecutionRuntime()
     const intent = await Effect.runPromise(plan(intentPlan({ cycleId: '0'.repeat(64) })))
@@ -693,18 +1167,10 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     await execution.runPromise(
       Effect.gen(function* () {
         yield* Effect.flatMap(IntentStore, (store) => store.commit(intent, decision))
-        const sql = yield* PgClient.PgClient
-        yield* sql`
-          INSERT INTO authority_state (
-            schema_version, generation_hash, maximum, effective, kill_state, version, updated_at
-          ) VALUES (
-            'bayn.paper-authority.v1', ${'9'.repeat(64)}, 'PAPER', 'PAPER', 'CLEAR', 1,
-            ${new Date(Date.now() + 1).toISOString()}
-          )
-        `
       }),
     )
     await execution.dispose()
+    await activateAuditedPaperAuthority()
     await Bun.sleep(Math.max(0, expiresAtMillis - Date.now() + 50))
 
     const mutation = makeMutationRuntime()
@@ -741,18 +1207,10 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     await execution.runPromise(
       Effect.gen(function* () {
         yield* Effect.flatMap(IntentStore, (store) => store.commit(intent, decision))
-        const sql = yield* PgClient.PgClient
-        yield* sql`
-          INSERT INTO authority_state (
-            schema_version, generation_hash, maximum, effective, kill_state, version, updated_at
-          ) VALUES (
-            'bayn.paper-authority.v1', ${'9'.repeat(64)}, 'PAPER', 'PAPER', 'CLEAR', 1,
-            ${new Date(Date.now() + 1).toISOString()}
-          )
-        `
       }),
     )
     await execution.dispose()
+    await activateAuditedPaperAuthority()
 
     const mutation = makeMutationRuntime()
     const requestHash = '6'.repeat(64)
@@ -794,18 +1252,10 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     await execution.runPromise(
       Effect.gen(function* () {
         yield* Effect.flatMap(IntentStore, (store) => store.commit(intent, decision))
-        const sql = yield* PgClient.PgClient
-        yield* sql`
-          INSERT INTO authority_state (
-            schema_version, generation_hash, maximum, effective, kill_state, version, updated_at
-          ) VALUES (
-            'bayn.paper-authority.v1', ${'9'.repeat(64)}, 'PAPER', 'PAPER', 'CLEAR', 1,
-            ${new Date(Date.now() + 1).toISOString()}
-          )
-        `
       }),
     )
     await execution.dispose()
+    await activateAuditedPaperAuthority()
 
     const mutation = makeMutationRuntime()
     const submitHash = '6'.repeat(64)
@@ -891,18 +1341,10 @@ describePostgres('PostgreSQL evaluation evidence', () => {
         const store = yield* IntentStore
         yield* store.commit(intent, decision)
         yield* store.commit(blockedIntent, blockedDecision)
-        const sql = yield* PgClient.PgClient
-        yield* sql`
-          INSERT INTO authority_state (
-            schema_version, generation_hash, maximum, effective, kill_state, version, updated_at
-          ) VALUES (
-            'bayn.paper-authority.v1', ${'9'.repeat(64)}, 'PAPER', 'PAPER', 'CLEAR', 1,
-            ${new Date(Date.now() + 1).toISOString()}
-          )
-        `
       }),
     )
     await execution.dispose()
+    await activateAuditedPaperAuthority()
 
     const mutation = makeMutationRuntime()
     const submitHash = '3'.repeat(64)
@@ -921,7 +1363,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
         const sql = yield* PgClient.PgClient
         yield* sql`
           UPDATE authority_state
-          SET effective = 'OBSERVE', kill_state = 'ACTIVE', reason = 'operator kill', version = 2,
+          SET effective = 'OBSERVE', kill_state = 'ACTIVE', reason = 'operator kill', version = 3,
               updated_at = ${new Date(base + 2).toISOString()}
           WHERE singleton
         `
@@ -979,18 +1421,10 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     await execution.runPromise(
       Effect.gen(function* () {
         yield* Effect.flatMap(IntentStore, (store) => store.commit(intent, decision))
-        const sql = yield* PgClient.PgClient
-        yield* sql`
-          INSERT INTO authority_state (
-            schema_version, generation_hash, maximum, effective, kill_state, version, updated_at
-          ) VALUES (
-            'bayn.paper-authority.v1', ${'9'.repeat(64)}, 'PAPER', 'PAPER', 'CLEAR', 1,
-            ${new Date(Date.now() + 1).toISOString()}
-          )
-        `
       }),
     )
     await execution.dispose()
+    await activateAuditedPaperAuthority()
 
     const mutation = makeMutationRuntime()
     const submitHash = 'a'.repeat(64)
@@ -1049,18 +1483,10 @@ describePostgres('PostgreSQL evaluation evidence', () => {
         const store = yield* IntentStore
         yield* store.commit(first, firstDecision)
         yield* store.commit(second, secondDecision)
-        const sql = yield* PgClient.PgClient
-        yield* sql`
-          INSERT INTO authority_state (
-            schema_version, generation_hash, maximum, effective, kill_state, version, updated_at
-          ) VALUES (
-            'bayn.paper-authority.v1', ${'9'.repeat(64)}, 'PAPER', 'PAPER', 'CLEAR', 1,
-            ${new Date(Date.now() + 1).toISOString()}
-          )
-        `
       }),
     )
     await execution.dispose()
+    await activateAuditedPaperAuthority()
 
     const mutation = makeMutationRuntime()
     const firstSubmitHash = 'a'.repeat(64)
@@ -1708,6 +2134,15 @@ describePostgres('PostgreSQL evaluation evidence', () => {
           )
         `
         yield* sql`
+          INSERT INTO authority_generations (
+            generation_hash, schema_version, previous_generation_hash, maximum,
+            authority_version, activated_at
+          ) VALUES (
+            ${'a'.repeat(64)}, 'bayn.authority-generation-history.v1', NULL,
+            'OBSERVE', 1, '2026-07-22T06:00:00.000Z'
+          )
+        `
+        yield* sql`
           INSERT INTO authority_state (
             schema_version, generation_hash, maximum, effective, kill_state, version, updated_at
           ) VALUES (
@@ -1764,27 +2199,23 @@ describePostgres('PostgreSQL evaluation evidence', () => {
             '2026-07-22T06:01:00.000Z'
           )
         `)
-        yield* sql`
+        const paperWithoutHistory = yield* Effect.exit(sql`
           UPDATE authority_state
           SET generation_hash = ${'b'.repeat(64)}, maximum = 'PAPER', effective = 'PAPER',
               version = 2, updated_at = '2026-07-22T06:01:00.000Z'
-        `
-        yield* sql`
-          UPDATE authority_state
-          SET effective = 'OBSERVE', version = 3, updated_at = '2026-07-22T06:02:00.000Z'
-        `
+        `)
         const escalation = yield* Effect.exit(sql`
           UPDATE authority_state
-          SET effective = 'PAPER', version = 4, updated_at = '2026-07-22T06:03:00.000Z'
+          SET effective = 'PAPER', version = 2, updated_at = '2026-07-22T06:02:00.000Z'
         `)
         yield* sql`
           UPDATE authority_state
-          SET kill_state = 'ACTIVE', reason = 'operator kill', version = 4,
+          SET kill_state = 'ACTIVE', reason = 'operator kill', version = 2,
               updated_at = '2026-07-22T06:03:00.000Z'
         `
         const clearKill = yield* Effect.exit(sql`
           UPDATE authority_state
-          SET kill_state = 'CLEAR', reason = NULL, version = 5,
+          SET kill_state = 'CLEAR', reason = NULL, version = 3,
               updated_at = '2026-07-22T06:04:00.000Z'
         `)
         const mutateReceipt = yield* Effect.exit(sql`
@@ -1804,6 +2235,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
           nullIdentifier,
           badValuation,
           badReconciliation,
+          paperWithoutHistory,
           escalation,
           clearKill,
           mutateReceipt,
@@ -1817,10 +2249,11 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     expect(Exit.isFailure(result.nullIdentifier)).toBe(true)
     expect(Exit.isFailure(result.badValuation)).toBe(true)
     expect(Exit.isFailure(result.badReconciliation)).toBe(true)
+    expect(Exit.isFailure(result.paperWithoutHistory)).toBe(true)
     expect(Exit.isFailure(result.escalation)).toBe(true)
     expect(Exit.isFailure(result.clearKill)).toBe(true)
     expect(Exit.isFailure(result.mutateReceipt)).toBe(true)
-    expect(result.authority).toEqual({ maximum: 'PAPER', effective: 'OBSERVE', kill_state: 'ACTIVE', version: 4 })
+    expect(result.authority).toEqual({ maximum: 'OBSERVE', effective: 'OBSERVE', kill_state: 'ACTIVE', version: 2 })
   })
 
   test('rejects the legacy migration tracker instead of creating a parallel schema', async () => {

--- a/services/bayn/src/db/migrations.ts
+++ b/services/bayn/src/db/migrations.ts
@@ -13,6 +13,7 @@ import autonomousCycles from '../../migrations/0010_autonomous_cycles'
 import causalProtocol from '../../migrations/0011_causal_protocol'
 import observeShadowDecisions from '../../migrations/0012_observe_shadow_decisions'
 import autonomousCycleTerminalTransitions from '../../migrations/0013_autonomous_cycle_terminal_transitions'
+import authorityGenerationHistory from '../../migrations/0014_authority_generation_history'
 
 export const migrationLoader = PgMigrator.fromRecord({
   '1_initial_schema': initialSchema,
@@ -28,4 +29,5 @@ export const migrationLoader = PgMigrator.fromRecord({
   '11_causal_protocol': causalProtocol,
   '12_observe_shadow_decisions': observeShadowDecisions,
   '13_autonomous_cycle_terminal_transitions': autonomousCycleTerminalTransitions,
+  '14_authority_generation_history': authorityGenerationHistory,
 })

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -2,10 +2,12 @@ import { beforeAll, beforeEach, describe, expect, test } from 'bun:test'
 
 import { NodeServices } from '@effect/platform-node'
 import { PgClient } from '@effect/sql-pg'
-import { Cause, Effect, Exit, Layer, ManagedRuntime, Redacted } from 'effect'
+import { Cause, Deferred, Duration, Effect, Exit, Fiber, Layer, ManagedRuntime, Redacted } from 'effect'
 
 import type { RuntimeConfig } from '../config'
+import { makeStrategyProtocolHash } from '../contracts'
 import { operationalError } from '../errors'
+import { WriterFenceLive } from '../execution/writer-fence'
 import { canonicalHashV1 } from '../hash'
 import { hashLedgerPlan } from '../ledger-plan'
 import { Journal, type JournalService } from '../ledger'
@@ -20,7 +22,22 @@ import {
   OrderType,
   ReconciliationStatus,
   TimeInForce,
+  makePaperAuthorityGeneration,
+  type PaperAuthorityGeneration,
 } from '../paper'
+import {
+  makeQualificationLock,
+  makeQualificationPolicyDocument,
+  makeQualificationResult,
+  type QualificationLock,
+  type QualificationResult,
+} from '../qualification'
+import {
+  analyzeQualification,
+  defaultQualificationStatisticsPolicy,
+  type QualificationSeries,
+} from '../qualification-statistics'
+import { fixtureProtocol } from '../test-fixtures'
 import {
   sourceTimestamp,
   type BrokerEventInput,
@@ -39,6 +56,130 @@ const accountId = 'paper-account-1'
 const observedAt = '2026-07-22T15:30:01.000Z'
 const occurredAt = '2026-07-22T15:30:00.000Z'
 const hash = (value: string): string => canonicalHashV1({ value })
+const qualifiedSourceRevision = '1'.repeat(40)
+const qualifiedImageRepository = 'registry.example.test/lab/bayn'
+const qualifiedImageDigest = `sha256:${'2'.repeat(64)}` as const
+const qualifiedStrategyBehaviorHash = hash('qualified-strategy-behavior')
+const qualifiedStrategyParameterHash = canonicalHashV1(fixtureProtocol)
+const qualifiedProtocolHash = makeStrategyProtocolHash({
+  name: 'risk-balanced-trend',
+  behaviorHash: qualifiedStrategyBehaviorHash,
+  parameterHash: qualifiedStrategyParameterHash,
+  parameterSchemaVersion: fixtureProtocol.schemaVersion,
+})
+
+const qualificationPolicy = (name: string) =>
+  makeQualificationPolicyDocument(`bayn.${name}.v1`, {
+    schemaVersion: `bayn.${name}.v1`,
+    enabled: true,
+  })
+
+const qualificationSeries = (runId: string): QualificationSeries => {
+  const sessionDate = (index: number): `${number}-${number}-${number}` => {
+    const date = new Date('2000-01-01T00:00:00.000Z')
+    date.setUTCDate(date.getUTCDate() + index)
+    return date.toISOString().slice(0, 10) as `${number}-${number}-${number}`
+  }
+  const blockCount = 90
+  return {
+    schemaVersion: 'bayn.qualification-series.v1',
+    runId,
+    observations: Array.from({ length: blockCount * 21 + 10 }, (_, index) => {
+      const noise = (((index * 17) % 23) - 11) / 100_000
+      return {
+        sessionDate: sessionDate(index),
+        strategyReturn: 0.0005 + noise,
+        cashReturn: 0,
+        buyAndHoldReturn: 0.00015 + noise * 1.1,
+        directVolatilityReturn: 0.0001 + noise * 0.8,
+      }
+    }),
+    rebalanceExecutionDates: Array.from({ length: blockCount + 1 }, (_, index) => sessionDate(index * 21)),
+  }
+}
+
+interface QualificationFixture {
+  readonly lock: QualificationLock
+  readonly result: QualificationResult
+}
+
+const makeQualificationFixture = (name: string, qualified: boolean): QualificationFixture => {
+  const runId = hash(`${name}-run`)
+  const snapshotId = hash(`${name}-snapshot`)
+  const lock = makeQualificationLock({
+    schemaVersion: 'bayn.qualification-lock.v3',
+    candidateRunId: runId,
+    protocolHash: qualifiedProtocolHash,
+    sourceRevision: qualifiedSourceRevision,
+    image: {
+      repository: qualifiedImageRepository,
+      digest: qualifiedImageDigest,
+    },
+    universeId: fixtureProtocol.universeId,
+    universeSymbolHash: fixtureProtocol.universeSymbolHash,
+    universe: fixtureProtocol.universe,
+    universeRationale: 'Precommitted cross-asset universe for the authority activation persistence test.',
+    data: {
+      snapshotId,
+      publicationId: hash(`${name}-publication`),
+      inputManifestHash: hash(`${name}-manifest`),
+      contentHash: hash(`${name}-content`),
+      sessionsContentHash: hash(`${name}-sessions`),
+      provider: 'alpaca',
+      sourceFeed: 'sip',
+      adjustment: 'all',
+      calendarVersion: 'alpaca-us-equity-calendar-v1',
+      firstSession: '2016-01-04',
+      lastSession: '2026-07-21',
+      selectedSessionCount: 1_900,
+      selectedRebalanceCount: 91,
+      bounds: {
+        schemaVersion: 'bayn.evaluation-bounds.v1',
+        dataStart: '2016-01-04',
+        dataEnd: '2026-07-21',
+        lookbackStart: '2016-01-04',
+        evaluationStart: '2017-01-03',
+        evaluationEnd: '2026-07-21',
+      },
+    },
+    policies: {
+      benchmark: qualificationPolicy(`${name}-benchmark-policy`),
+      thresholds: qualificationPolicy(`${name}-threshold-policy`),
+      uncertainty: qualificationPolicy(`${name}-uncertainty-policy`),
+      execution: makeQualificationPolicyDocument(
+        fixtureProtocol.executionModel.schemaVersion,
+        fixtureProtocol.executionModel,
+      ),
+    },
+    priorTrialRunIds: [],
+  })
+  const analysis = analyzeQualification(qualificationSeries(runId), defaultQualificationStatisticsPolicy, [])
+  const evaluationVerdict = qualified
+    ? {
+        status: 'PASS' as const,
+        gates: [{ name: 'paper_activation_fixture', passed: true, actual: 1, required: 1 }],
+      }
+    : {
+        status: 'FAIL_CLOSED' as const,
+        gates: [{ name: 'paper_activation_fixture', passed: false, actual: 0, required: 1 }],
+      }
+  return { lock, result: makeQualificationResult(lock, evaluationVerdict, analysis) }
+}
+
+const qualifiedEvidence = makeQualificationFixture('qualified-authority', true)
+const rejectedEvidence = makeQualificationFixture('rejected-authority', false)
+
+interface ReconciliationFixture {
+  readonly reconciliationId: string
+  readonly contentHash: string
+  readonly databaseAgeMs: number
+}
+
+const exactReconciliation = (name: string, databaseAgeMs = 0): ReconciliationFixture => ({
+  reconciliationId: hash(`${name}-reconciliation`),
+  contentHash: hash(`${name}-reconciliation-content`),
+  databaseAgeMs,
+})
 
 const config: RuntimeConfig = {
   host: '127.0.0.1',
@@ -96,11 +237,12 @@ const journal = (control: JournalControl): JournalService => ({
   checkRun: () => Effect.void,
 })
 
-const makeStoreRuntime = (control: JournalControl) =>
+const makeStoreRuntime = (control: JournalControl, runtimeConfig: RuntimeConfig = config) =>
   ManagedRuntime.make(
-    PaperStoreLive(config).pipe(
+    PaperStoreLive(runtimeConfig).pipe(
+      Layer.provideMerge(WriterFenceLive),
       Layer.provideMerge(Layer.succeed(Journal, journal(control))),
-      Layer.provideMerge(PostgresClientLive(config)),
+      Layer.provideMerge(PostgresClientLive(runtimeConfig)),
       Layer.provide(NodeServices.layer),
     ),
   )
@@ -108,6 +250,172 @@ const makeStoreRuntime = (control: JournalControl) =>
 const makeClientRuntime = () => ManagedRuntime.make(PostgresClientLive(config).pipe(Layer.provide(NodeServices.layer)))
 
 const makeEvidenceRuntime = () => ManagedRuntime.make(EvidenceStoreLive(config).pipe(Layer.provide(NodeServices.layer)))
+
+const seedQualificationEvidence = (fixture: QualificationFixture) =>
+  Effect.gen(function* () {
+    const sql = yield* PgClient.PgClient
+    const { lock, result } = fixture
+    yield* sql`
+      INSERT INTO protocol_locks (
+        protocol_hash, schema_version, strategy_name, behavior_hash, parameter_hash, parameters
+      ) VALUES (
+        ${lock.protocolHash}, ${fixtureProtocol.schemaVersion}, 'risk-balanced-trend',
+        ${qualifiedStrategyBehaviorHash}, ${qualifiedStrategyParameterHash}, ${sql.json(fixtureProtocol)}
+      )
+      ON CONFLICT (protocol_hash) DO NOTHING
+    `
+    yield* sql`
+      INSERT INTO snapshot_references (
+        snapshot_id, schema_version, database_name, table_name, dataset_version, source,
+        source_feed, adjustment, content_hash, row_count, first_session, last_session, manifest
+      ) VALUES (
+        ${lock.data.snapshotId}, 'bayn.finalized-snapshot.v3', 'signal', 'adjusted_daily_bars_v2',
+        'signal.adjusted-daily-snapshot.v2', 'alpaca', 'sip', 'all', ${lock.data.contentHash},
+        ${lock.data.selectedSessionCount * lock.universe.length}, ${lock.data.firstSession},
+        ${lock.data.lastSession}, ${sql.json(lock.data)}
+      )
+    `
+    yield* sql`
+      INSERT INTO evaluation_runs (
+        run_id, protocol_hash, snapshot_id, evaluation_schema_version, source_revision,
+        image_repository, image_digest, strategy_name, initial_capital_micros,
+        expected_artifact_count, expected_event_count, expected_gate_count,
+        status, completed_at
+      ) VALUES (
+        ${result.runId}, ${lock.protocolHash}, ${lock.data.snapshotId}, 'bayn.evaluation.v6',
+        ${lock.sourceRevision}, ${lock.image.repository}, ${lock.image.digest}, 'risk-balanced-trend',
+        1000000000000, 1, 0, 1, 'COMPLETE', clock_timestamp()
+      )
+    `
+    yield* sql`
+      INSERT INTO evaluation_artifacts (
+        run_id, artifact_name, schema_version, content_hash, payload
+      ) VALUES (
+        ${result.runId}, 'qualification-artifact-manifest', 'bayn.qualification-artifact-manifest.v1',
+        ${hash(`${result.runId}-artifact`)}, ${sql.json({ runId: result.runId })}
+      )
+    `
+    yield* sql`
+      INSERT INTO gate_outcomes (
+        run_id, ordinal, gate_name, passed, actual, required, content_hash
+      ) VALUES (
+        ${result.runId}, 0, 'paper_activation_fixture',
+        ${result.evaluationVerdict.gates[0].passed},
+        ${sql.json(JSON.stringify(result.evaluationVerdict.gates[0].actual))},
+        ${sql.json(JSON.stringify(result.evaluationVerdict.gates[0].required))},
+        ${hash(`${result.runId}-gate`)}
+      )
+    `
+    yield* sql`
+      INSERT INTO status_history (run_id, status, detail)
+      VALUES
+        (
+          ${result.runId}, 'WRITING',
+          ${sql.json({ artifactCount: 1, eventCount: 0, gateCount: 1 })}
+        ),
+        (
+          ${result.runId}, 'COMPLETE',
+          ${sql.json({ reconciliationExact: true, verdict: result.evaluationVerdict.status })}
+        )
+    `
+    yield* sql`
+      INSERT INTO qualification_locks (
+        lock_id, schema_version, candidate_run_id, protocol_hash, snapshot_id,
+        source_revision, image_repository, image_digest, payload
+      ) VALUES (
+        ${lock.lockId}, ${lock.schemaVersion}, ${lock.candidateRunId}, ${lock.protocolHash},
+        ${lock.data.snapshotId}, ${lock.sourceRevision}, ${lock.image.repository},
+        ${lock.image.digest}, ${sql.json(lock)}
+      )
+    `
+    yield* sql`
+      INSERT INTO qualification_results (
+        lock_id, schema_version, run_id, verdict, analysis_hash, result_hash, payload
+      ) VALUES (
+        ${result.lockId}, ${result.schemaVersion}, ${result.runId}, ${result.verdict},
+        ${result.analysis.analysisHash}, ${result.resultHash}, ${sql.json(result)}
+      )
+    `
+  })
+
+const seedExactReconciliation = (fixture: ReconciliationFixture, reconciliationAccountId = accountId) =>
+  Effect.gen(function* () {
+    const sql = yield* PgClient.PgClient
+    const stateHash = hash(`${fixture.reconciliationId}-state`)
+    yield* sql`
+      INSERT INTO reconciliations (
+        reconciliation_id, schema_version, account_id, expected_hash, observed_hash,
+        content_hash, status, discrepancies, reconciled_at
+      ) VALUES (
+        ${fixture.reconciliationId}, 'bayn.paper-reconciliation.v1', ${reconciliationAccountId},
+        ${stateHash}, ${stateHash}, ${fixture.contentHash}, 'EXACT', ${sql.json(JSON.stringify([]))},
+        clock_timestamp() - (${fixture.databaseAgeMs} * interval '1 millisecond')
+      )
+    `
+  })
+
+const makeActivation = (
+  previousGenerationHash: string,
+  qualification: QualificationFixture,
+  reconciliation: Pick<ReconciliationFixture, 'contentHash' | 'reconciliationId'>,
+  overrides: Partial<Parameters<typeof makePaperAuthorityGeneration>[0]> = {},
+) =>
+  makePaperAuthorityGeneration({
+    schemaVersion: 'bayn.paper-authority-generation.v1',
+    maximum: Authority.Paper,
+    previousGenerationHash,
+    qualificationRunId: qualification.result.runId,
+    qualificationLockId: qualification.lock.lockId,
+    qualificationResultHash: qualification.result.resultHash,
+    protocolHash: qualification.lock.protocolHash,
+    qualificationExecutionPolicyHash: qualification.lock.policies.execution.contentHash,
+    qualificationSourceRevision: qualification.lock.sourceRevision,
+    qualificationImageRepository: qualification.lock.image.repository,
+    qualificationImageDigest: qualification.lock.image.digest,
+    activationSourceRevision: config.build.sourceRevision,
+    activationImageRepository: config.build.imageRepository,
+    activationImageDigest: config.build.imageDigest,
+    strategyName: 'risk-balanced-trend',
+    strategyBehaviorHash: qualifiedStrategyBehaviorHash,
+    strategyParameterHash: qualifiedStrategyParameterHash,
+    strategyParameterSchemaVersion: fixtureProtocol.schemaVersion,
+    accountId,
+    riskPolicyHash: hash('paper-risk-policy'),
+    proofPlanHash: hash('bounded-paper-proof-plan'),
+    reconciliationId: reconciliation.reconciliationId,
+    reconciliationContentHash: reconciliation.contentHash,
+    ...overrides,
+  })
+
+const paperRuntimeConfig = (
+  activation: PaperAuthorityGeneration,
+  overrides: Partial<RuntimeConfig> = {},
+): RuntimeConfig => ({
+  ...config,
+  maximumAuthority: Authority.Paper,
+  qualificationRunId: activation.qualificationRunId,
+  build: {
+    ...config.build,
+    strategyBehaviorHash: activation.strategyBehaviorHash,
+    strategyParameterHash: activation.strategyParameterHash,
+  },
+  alpaca: {
+    accountId: activation.accountId,
+    authorityGenerationHash: activation.generationHash,
+    key: Redacted.make('unused'),
+    secret: Redacted.make('unused'),
+    proxyUrl: 'http://bayn-egress-proxy.invalid',
+    retryAttempts: 0,
+    reconciliationIntervalMs: 30_000,
+  },
+  ...overrides,
+})
+
+const makeActivationRuntime = (
+  control: JournalControl,
+  activation: PaperAuthorityGeneration,
+  overrides: Partial<RuntimeConfig> = {},
+) => makeStoreRuntime(control, paperRuntimeConfig(activation, overrides))
 
 const accountEvent = (eventAccountId = accountId): Extract<BrokerEventInput, { readonly _tag: 'Account' }> => ({
   _tag: 'Account',
@@ -472,7 +780,10 @@ describePostgres('paper accounting persistence', () => {
   }, 15_000)
 
   test('rejects maximum conflicts, invalid input, and every PAPER request without writing', async () => {
-    const runtime = makeStoreRuntime({ fail: false, planHashes: [] })
+    const observeGenerationHash = hash('conflicting-observe-generation')
+    const reconciliation = exactReconciliation('maximum-conflict')
+    const activation = makeActivation(observeGenerationHash, qualifiedEvidence, reconciliation)
+    const runtime = makeActivationRuntime({ fail: false, planHashes: [] }, activation)
     try {
       const result = await runtime.runPromise(
         Effect.gen(function* () {
@@ -490,49 +801,836 @@ describePostgres('paper accounting persistence', () => {
             }),
           )
           const sql = yield* PgClient.PgClient
-          const [empty] = yield* sql<{ rows: number }>`
-            SELECT count(*)::integer AS rows FROM authority_state
-          `
-          yield* sql`
+          const directPaper = yield* Effect.exit(sql`
             INSERT INTO authority_state (
-              schema_version, generation_hash, maximum, effective, kill_state, reason, version, updated_at
+              schema_version, generation_hash, maximum, effective, kill_state,
+              reason, version, updated_at
             ) VALUES (
-              'bayn.paper-authority.v1', ${hash('conflicting-authority-generation')},
+              'bayn.paper-authority.v1', ${hash('direct-initial-paper')},
               'PAPER', 'PAPER', 'CLEAR', NULL, 1, clock_timestamp()
             )
+          `)
+          const directObserveWithoutHistory = yield* Effect.exit(sql`
+            INSERT INTO authority_state (
+              schema_version, generation_hash, maximum, effective, kill_state,
+              reason, version, updated_at
+            ) VALUES (
+              'bayn.paper-authority.v1', ${hash('direct-initial-observe-without-history')},
+              'OBSERVE', 'OBSERVE', 'CLEAR', NULL, 1, clock_timestamp()
+            )
+          `)
+          const [empty] = yield* sql<{ authority_rows: number; history_rows: number }>`
+            SELECT
+              (SELECT count(*)::integer FROM authority_state) AS authority_rows,
+              (SELECT count(*)::integer FROM authority_generations) AS history_rows
           `
+          yield* seedQualificationEvidence(qualifiedEvidence)
+          yield* seedExactReconciliation(reconciliation)
+          yield* store.ensureAuthorityGeneration({
+            generationHash: observeGenerationHash,
+            maximum: Authority.Observe,
+          })
+          yield* store.activatePaperGeneration(activation)
           const [beforeConflict] = yield* sql<{ tuple_id: string; version: number }>`
             SELECT xmin::text AS tuple_id, version::integer FROM authority_state
           `
           const conflict = yield* Effect.flip(
             store.ensureAuthorityGeneration({
-              generationHash: hash('conflicting-authority-generation'),
+              generationHash: activation.generationHash,
               maximum: Authority.Observe,
             }),
           )
           const [afterConflict] = yield* sql<{ tuple_id: string; version: number }>`
             SELECT xmin::text AS tuple_id, version::integer FROM authority_state
           `
-          const rotated = yield* store.ensureAuthorityGeneration({
-            generationHash: hash('observe-authority-generation'),
-            maximum: Authority.Observe,
-          })
-          return { invalid, paper, empty, conflict, beforeConflict, afterConflict, rotated }
+          return {
+            invalid,
+            paper,
+            directObserveWithoutHistory,
+            directPaper,
+            empty,
+            conflict,
+            beforeConflict,
+            afterConflict,
+          }
         }),
       )
 
       expect(result.invalid).toMatchObject({ operation: 'authority', failure: 'decode' })
       expect(result.paper).toMatchObject({ operation: 'authority', failure: 'invariant' })
-      expect(result.empty).toEqual({ rows: 0 })
+      expect(Exit.isFailure(result.directPaper)).toBe(true)
+      expect(Exit.isFailure(result.directObserveWithoutHistory)).toBe(true)
+      expect(result.empty).toEqual({ authority_rows: 0, history_rows: 0 })
       expect(result.conflict).toMatchObject({ operation: 'authority', failure: 'conflict' })
       expect(result.afterConflict).toEqual(result.beforeConflict)
-      expect(result.rotated).toMatchObject({
-        generationHash: hash('observe-authority-generation'),
-        maximum: Authority.Observe,
-        effective: Authority.Observe,
-        kill: KillState.Clear,
+    } finally {
+      await runtime.dispose()
+    }
+  }, 15_000)
+
+  test('requires the exact configured PAPER activation binding before any authority write', async () => {
+    const initialGenerationHash = hash('configured-paper-binding-observe-generation')
+    const reconciliation = exactReconciliation('configured-paper-binding')
+    const activation = makeActivation(initialGenerationHash, qualifiedEvidence, reconciliation)
+    const setupRuntime = makeStoreRuntime({ fail: false, planHashes: [] })
+    const validConfig = paperRuntimeConfig(activation)
+    const validAlpaca = validConfig.alpaca
+    if (validAlpaca === undefined) {
+      throw new Error('valid PAPER activation config requires an Alpaca binding')
+    }
+    const { alpaca: _alpaca, ...missingAlpacaConfig } = validConfig
+    const invalidConfigs: readonly RuntimeConfig[] = [
+      { ...validConfig, maximumAuthority: Authority.Observe },
+      missingAlpacaConfig,
+      {
+        ...validConfig,
+        alpaca: {
+          ...validAlpaca,
+          authorityGenerationHash: hash('wrong-configured-paper-generation'),
+        },
+      },
+      {
+        ...validConfig,
+        alpaca: {
+          ...validAlpaca,
+          accountId: 'wrong-configured-paper-account',
+        },
+      },
+      { ...validConfig, qualificationRunId: hash('wrong-configured-qualification-run') },
+    ]
+    const readAuthorityEvidence = Effect.gen(function* () {
+      const sql = yield* PgClient.PgClient
+      const [evidence] = yield* sql<{ authority: unknown; history: unknown }>`
+        SELECT
+          (
+            SELECT jsonb_agg(
+              jsonb_build_object('row', to_jsonb(authority), 'tupleId', authority.xmin::text)
+            )
+            FROM authority_state AS authority
+          ) AS authority,
+          (
+            SELECT jsonb_agg(
+              jsonb_build_object('row', to_jsonb(history), 'tupleId', history.xmin::text)
+              ORDER BY history.authority_version
+            )
+            FROM authority_generations AS history
+          ) AS history
+      `
+      return evidence
+    })
+    const before = await (async () => {
+      try {
+        return await setupRuntime.runPromise(
+          Effect.gen(function* () {
+            const store = yield* PaperStore
+            yield* seedQualificationEvidence(qualifiedEvidence)
+            yield* seedExactReconciliation(reconciliation)
+            yield* store.ensureAuthorityGeneration({
+              generationHash: initialGenerationHash,
+              maximum: Authority.Observe,
+            })
+            return yield* readAuthorityEvidence
+          }),
+        )
+      } finally {
+        await setupRuntime.dispose()
+      }
+    })()
+    const failures = []
+    for (const invalidConfig of invalidConfigs) {
+      const runtime = makeStoreRuntime({ fail: false, planHashes: [] }, invalidConfig)
+      try {
+        failures.push(
+          await runtime.runPromise(
+            Effect.flatMap(PaperStore, (store) => Effect.flip(store.activatePaperGeneration(activation))),
+          ),
+        )
+      } finally {
+        await runtime.dispose()
+      }
+    }
+    const wrongBuildActivation = makeActivation(initialGenerationHash, qualifiedEvidence, reconciliation, {
+      activationSourceRevision: 'f'.repeat(40),
+    })
+    const wrongBuildRuntime = makeActivationRuntime({ fail: false, planHashes: [] }, wrongBuildActivation)
+    const wrongBuildFailure = await (async () => {
+      try {
+        return await wrongBuildRuntime.runPromise(
+          Effect.flatMap(PaperStore, (store) => Effect.flip(store.activatePaperGeneration(wrongBuildActivation))),
+        )
+      } finally {
+        await wrongBuildRuntime.dispose()
+      }
+    })()
+    const correctBuild = paperRuntimeConfig(activation).build
+    const wrongStrategyRuntime = makeActivationRuntime({ fail: false, planHashes: [] }, activation, {
+      build: {
+        ...correctBuild,
+        strategyBehaviorHash: hash('wrong-current-strategy-behavior'),
+      },
+    })
+    const wrongStrategyFailure = await (async () => {
+      try {
+        return await wrongStrategyRuntime.runPromise(
+          Effect.flatMap(PaperStore, (store) => Effect.flip(store.activatePaperGeneration(activation))),
+        )
+      } finally {
+        await wrongStrategyRuntime.dispose()
+      }
+    })()
+    const client = makeClientRuntime()
+    const afterRejected = await (async () => {
+      try {
+        return await client.runPromise(readAuthorityEvidence)
+      } finally {
+        await client.dispose()
+      }
+    })()
+    const correctRuntime = makeActivationRuntime({ fail: false, planHashes: [] }, activation)
+    try {
+      const activated = await correctRuntime.runPromise(
+        Effect.flatMap(PaperStore, (store) => store.activatePaperGeneration(activation)),
+      )
+      expect(activated).toMatchObject({
+        generationHash: activation.generationHash,
+        maximum: Authority.Paper,
+        effective: Authority.Paper,
         version: 2,
       })
+    } finally {
+      await correctRuntime.dispose()
+    }
+
+    expect(failures).toHaveLength(5)
+    for (const failure of failures) {
+      expect(failure).toMatchObject({
+        operation: 'authority',
+        failure: 'invariant',
+        message:
+          'PAPER activation differs from the configured authority, account, generation, or qualification binding',
+      })
+    }
+    expect(wrongBuildFailure).toMatchObject({
+      operation: 'authority',
+      failure: 'invariant',
+      message: 'PAPER activation provenance differs from the current embedded build',
+    })
+    expect(wrongStrategyFailure).toMatchObject({
+      operation: 'authority',
+      failure: 'invariant',
+      message: 'PAPER activation strategy identity differs from the current embedded build',
+    })
+    expect(afterRejected).toEqual(before)
+  }, 15_000)
+
+  test('activates one exact QUALIFIED PAPER generation and replays it without writing', async () => {
+    const initialGenerationHash = hash('paper-activation-observe-generation')
+    const reconciliation = exactReconciliation('paper-activation')
+    const activation = makeActivation(initialGenerationHash, qualifiedEvidence, reconciliation)
+    const runtime = makeActivationRuntime({ fail: false, planHashes: [] }, activation)
+    try {
+      const result = await runtime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* PaperStore
+          const sql = yield* PgClient.PgClient
+          yield* seedQualificationEvidence(qualifiedEvidence)
+          yield* seedExactReconciliation(reconciliation)
+          const observe = yield* store.ensureAuthorityGeneration({
+            generationHash: initialGenerationHash,
+            maximum: Authority.Observe,
+          })
+          const activated = yield* store.activatePaperGeneration(activation)
+          const [beforeReplay] = yield* sql<{
+            authority_tuple: string
+            history_count: number
+            paper_tuple: string
+          }>`
+            SELECT
+              authority.xmin::text AS authority_tuple,
+              paper.xmin::text AS paper_tuple,
+              (SELECT count(*)::integer FROM authority_generations) AS history_count
+            FROM authority_state AS authority
+            JOIN authority_generations AS paper
+              ON paper.generation_hash = authority.generation_hash
+          `
+          const replay = yield* store.activatePaperGeneration(activation)
+          const [afterReplay] = yield* sql<{
+            authority_tuple: string
+            history_count: number
+            paper_tuple: string
+          }>`
+            SELECT
+              authority.xmin::text AS authority_tuple,
+              paper.xmin::text AS paper_tuple,
+              (SELECT count(*)::integer FROM authority_generations) AS history_count
+            FROM authority_state AS authority
+            JOIN authority_generations AS paper
+              ON paper.generation_hash = authority.generation_hash
+          `
+          const history = yield* sql<{
+            account_id: string | null
+            activation_image_digest: string | null
+            activation_image_repository: string | null
+            activation_source_revision: string | null
+            authority_version: number
+            generation_hash: string
+            maximum: string
+            previous_generation_hash: string | null
+            proof_plan_hash: string | null
+            qualification_image_digest: string | null
+            qualification_image_repository: string | null
+            qualification_result_hash: string | null
+            qualification_source_revision: string | null
+            risk_policy_hash: string | null
+          }>`
+            SELECT
+              generation_hash, previous_generation_hash, maximum,
+              authority_version::integer, qualification_result_hash, account_id,
+              risk_policy_hash, proof_plan_hash, qualification_source_revision,
+              qualification_image_repository, qualification_image_digest,
+              activation_source_revision, activation_image_repository, activation_image_digest
+            FROM authority_generations
+            ORDER BY authority_version
+          `
+          const mutateHistory = yield* Effect.exit(sql`
+            UPDATE authority_generations
+            SET proof_plan_hash = ${hash('mutated-proof-plan')}
+            WHERE generation_hash = ${activation.generationHash}
+          `)
+          const deleteHistory = yield* Effect.exit(sql`
+            DELETE FROM authority_generations
+            WHERE generation_hash = ${activation.generationHash}
+          `)
+          const truncateHistory = yield* Effect.exit(sql`TRUNCATE authority_generations CASCADE`)
+          return {
+            activated,
+            activation,
+            afterReplay,
+            beforeReplay,
+            deleteHistory,
+            history,
+            mutateHistory,
+            observe,
+            replay,
+            truncateHistory,
+          }
+        }),
+      )
+
+      expect(result.activated).toEqual({
+        ...result.observe,
+        generationHash: result.activation.generationHash,
+        maximum: Authority.Paper,
+        effective: Authority.Paper,
+        version: 2,
+        updatedAt: expect.any(String),
+      })
+      expect(result.replay).toEqual(result.activated)
+      expect(result.afterReplay).toEqual(result.beforeReplay)
+      expect(Exit.isFailure(result.mutateHistory)).toBe(true)
+      expect(Exit.isFailure(result.deleteHistory)).toBe(true)
+      expect(Exit.isFailure(result.truncateHistory)).toBe(true)
+      expect(result.history).toEqual([
+        {
+          generation_hash: result.observe.generationHash,
+          previous_generation_hash: null,
+          maximum: Authority.Observe,
+          authority_version: 1,
+          qualification_result_hash: null,
+          account_id: null,
+          risk_policy_hash: null,
+          proof_plan_hash: null,
+          qualification_source_revision: null,
+          qualification_image_repository: null,
+          qualification_image_digest: null,
+          activation_source_revision: null,
+          activation_image_repository: null,
+          activation_image_digest: null,
+        },
+        {
+          generation_hash: result.activation.generationHash,
+          previous_generation_hash: result.observe.generationHash,
+          maximum: Authority.Paper,
+          authority_version: 2,
+          qualification_result_hash: qualifiedEvidence.result.resultHash,
+          account_id: accountId,
+          risk_policy_hash: result.activation.riskPolicyHash,
+          proof_plan_hash: result.activation.proofPlanHash,
+          qualification_source_revision: qualifiedEvidence.lock.sourceRevision,
+          qualification_image_repository: qualifiedEvidence.lock.image.repository,
+          qualification_image_digest: qualifiedEvidence.lock.image.digest,
+          activation_source_revision: config.build.sourceRevision,
+          activation_image_repository: config.build.imageRepository,
+          activation_image_digest: config.build.imageDigest,
+        },
+      ])
+      expect(result.activation.qualificationSourceRevision).not.toBe(result.activation.activationSourceRevision)
+      expect(result.activation.qualificationImageRepository).not.toBe(result.activation.activationImageRepository)
+      expect(result.activation.qualificationImageDigest).not.toBe(result.activation.activationImageDigest)
+    } finally {
+      await runtime.dispose()
+    }
+  }, 15_000)
+
+  test('rejects the exact reconciliation staleness boundary and future database time without writing', async () => {
+    const initialGenerationHash = hash('reconciliation-time-observe-generation')
+    const staleReconciliation = exactReconciliation('stale-reconciliation-time', config.reconciliationStaleThresholdMs)
+    const staleActivation = makeActivation(initialGenerationHash, qualifiedEvidence, staleReconciliation)
+    const staleRuntime = makeActivationRuntime({ fail: false, planHashes: [] }, staleActivation)
+    const readAuthorityEvidence = Effect.gen(function* () {
+      const sql = yield* PgClient.PgClient
+      const [evidence] = yield* sql<{ authority: unknown; history: unknown }>`
+        SELECT
+          (SELECT jsonb_agg(to_jsonb(authority)) FROM authority_state AS authority) AS authority,
+          (
+            SELECT jsonb_agg(to_jsonb(history) ORDER BY history.authority_version)
+            FROM authority_generations AS history
+          ) AS history
+      `
+      return evidence
+    })
+    const staleResult = await (async () => {
+      try {
+        return await staleRuntime.runPromise(
+          Effect.gen(function* () {
+            const store = yield* PaperStore
+            yield* seedQualificationEvidence(qualifiedEvidence)
+            yield* store.ensureAuthorityGeneration({
+              generationHash: initialGenerationHash,
+              maximum: Authority.Observe,
+            })
+            const before = yield* readAuthorityEvidence
+            yield* seedExactReconciliation(staleReconciliation)
+            const failure = yield* Effect.flip(store.activatePaperGeneration(staleActivation))
+            const after = yield* readAuthorityEvidence
+            return { after, before, failure }
+          }),
+        )
+      } finally {
+        await staleRuntime.dispose()
+      }
+    })()
+    const futureReconciliation = exactReconciliation('future-reconciliation-time', -60_000)
+    const futureActivation = makeActivation(initialGenerationHash, qualifiedEvidence, futureReconciliation)
+    const futureRuntime = makeActivationRuntime({ fail: false, planHashes: [] }, futureActivation)
+    try {
+      const futureResult = await futureRuntime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* PaperStore
+          yield* seedExactReconciliation(futureReconciliation)
+          const failure = yield* Effect.flip(store.activatePaperGeneration(futureActivation))
+          const after = yield* readAuthorityEvidence
+          return { after, failure }
+        }),
+      )
+
+      expect(staleResult.failure).toMatchObject({
+        operation: 'authority',
+        failure: 'invariant',
+        message: 'PAPER activation requires the latest fresh exact account reconciliation',
+      })
+      expect(futureResult.failure).toMatchObject({
+        operation: 'authority',
+        failure: 'invariant',
+        message: 'PAPER activation requires the latest fresh exact account reconciliation',
+      })
+      expect(staleResult.after).toEqual(staleResult.before)
+      expect(futureResult.after).toEqual(staleResult.before)
+    } finally {
+      await futureRuntime.dispose()
+    }
+  }, 15_000)
+
+  test('resamples database time after prerequisite lock waits before accepting reconciliation freshness', async () => {
+    const initialGenerationHash = hash('delayed-reconciliation-observe-generation')
+    const reconciliation = exactReconciliation('delayed-reconciliation')
+    const paperActivation = makeActivation(initialGenerationHash, qualifiedEvidence, reconciliation)
+    const runtime = makeActivationRuntime({ fail: false, planHashes: [] }, paperActivation, {
+      reconciliationStaleThresholdMs: 250,
+    })
+    const blocker = makeClientRuntime()
+    try {
+      const result = await runtime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* PaperStore
+          const sql = yield* PgClient.PgClient
+          yield* seedQualificationEvidence(qualifiedEvidence)
+          yield* seedExactReconciliation(reconciliation)
+          yield* store.ensureAuthorityGeneration({
+            generationHash: initialGenerationHash,
+            maximum: Authority.Observe,
+          })
+          const readAuthorityEvidence = sql<{ authority: unknown; history: unknown }>`
+            SELECT
+              (SELECT jsonb_agg(to_jsonb(authority)) FROM authority_state AS authority) AS authority,
+              (
+                SELECT jsonb_agg(to_jsonb(history) ORDER BY history.authority_version)
+                FROM authority_generations AS history
+              ) AS history
+          `
+          const [before] = yield* readAuthorityEvidence
+          const lockHeld = yield* Deferred.make<void>()
+          const releaseLock = yield* Deferred.make<void>()
+          const lockHolder = yield* Effect.forkChild(
+            Effect.promise(() =>
+              blocker.runPromise(
+                Effect.gen(function* () {
+                  const blockerSql = yield* PgClient.PgClient
+                  yield* blockerSql.withTransaction(
+                    Effect.gen(function* () {
+                      yield* blockerSql`LOCK TABLE status_history IN ACCESS EXCLUSIVE MODE`
+                      yield* Deferred.succeed(lockHeld, undefined)
+                      yield* Deferred.await(releaseLock)
+                    }),
+                  )
+                }),
+              ),
+            ),
+            { startImmediately: true },
+          )
+          yield* Deferred.await(lockHeld)
+          return yield* Effect.gen(function* () {
+            const activationFiber = yield* Effect.forkChild(
+              Effect.exit(store.activatePaperGeneration(paperActivation)),
+              { startImmediately: true },
+            )
+            let waiting = false
+            for (let attempt = 0; attempt < 200; attempt += 1) {
+              const activities = yield* sql<{ query: string; wait_event_type: string | null }>`
+                SELECT query, wait_event_type
+                FROM pg_stat_activity
+                WHERE pid <> pg_backend_pid()
+                  AND datname = current_database()
+                  AND wait_event_type = 'Lock'
+                  AND query ILIKE '%LOCK TABLE%status_history%'
+              `
+              if (activities[0] !== undefined) {
+                waiting = true
+                break
+              }
+              yield* Effect.sleep(Duration.millis(10))
+            }
+            if (!waiting) {
+              return yield* Effect.fail('PAPER activation did not wait on the qualification evidence lock')
+            }
+            yield* sql`SELECT pg_sleep(0.3)`
+            yield* Deferred.succeed(releaseLock, undefined)
+            yield* Fiber.join(lockHolder)
+            const activationExit = yield* Fiber.join(activationFiber)
+            const [after] = yield* readAuthorityEvidence
+            return { activationExit, after, before }
+          }).pipe(Effect.ensuring(Deferred.succeed(releaseLock, undefined).pipe(Effect.ignore)))
+        }),
+      )
+
+      expect(Exit.isFailure(result.activationExit)).toBe(true)
+      if (Exit.isFailure(result.activationExit)) {
+        expect(Cause.pretty(result.activationExit.cause)).toContain(
+          'PAPER activation requires the latest fresh exact account reconciliation',
+        )
+      }
+      expect(result.after).toEqual(result.before)
+    } finally {
+      await blocker.dispose()
+      await runtime.dispose()
+    }
+  }, 15_000)
+
+  test('serializes concurrent PAPER activation into one history row and state transition', async () => {
+    const initialGenerationHash = hash('concurrent-paper-observe-generation')
+    const reconciliation = exactReconciliation('concurrent-paper-activation')
+    const activation = makeActivation(initialGenerationHash, qualifiedEvidence, reconciliation)
+    const runtime = makeActivationRuntime({ fail: false, planHashes: [] }, activation)
+    try {
+      const result = await runtime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* PaperStore
+          yield* seedQualificationEvidence(qualifiedEvidence)
+          yield* seedExactReconciliation(reconciliation)
+          yield* store.ensureAuthorityGeneration({
+            generationHash: initialGenerationHash,
+            maximum: Authority.Observe,
+          })
+          const states = yield* Effect.all(
+            Array.from({ length: 12 }, () => store.activatePaperGeneration(activation)),
+            { concurrency: 'unbounded' },
+          )
+          const sql = yield* PgClient.PgClient
+          const [stored] = yield* sql<{ history_count: number; paper_count: number; version: number }>`
+            SELECT
+              authority.version::integer AS version,
+              (SELECT count(*)::integer FROM authority_generations) AS history_count,
+              (
+                SELECT count(*)::integer
+                FROM authority_generations
+                WHERE maximum = 'PAPER'
+              ) AS paper_count
+            FROM authority_state AS authority
+          `
+          return { states, stored }
+        }),
+      )
+
+      expect(result.states).toHaveLength(12)
+      expect(new Set(result.states.map((state) => JSON.stringify(state))).size).toBe(1)
+      expect(result.states[0]).toMatchObject({
+        maximum: Authority.Paper,
+        effective: Authority.Paper,
+        version: 2,
+      })
+      expect(result.stored).toEqual({ history_count: 2, paper_count: 1, version: 2 })
+    } finally {
+      await runtime.dispose()
+    }
+  }, 15_000)
+
+  test('preserves an active kill exactly while rotating maximum authority to PAPER', async () => {
+    const initialGenerationHash = hash('killed-paper-observe-generation')
+    const reconciliation = exactReconciliation('killed-paper-activation')
+    const activation = makeActivation(initialGenerationHash, qualifiedEvidence, reconciliation)
+    const runtime = makeActivationRuntime({ fail: false, planHashes: [] }, activation)
+    try {
+      const result = await runtime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* PaperStore
+          const sql = yield* PgClient.PgClient
+          yield* seedQualificationEvidence(qualifiedEvidence)
+          yield* seedExactReconciliation(reconciliation)
+          yield* store.ensureAuthorityGeneration({
+            generationHash: initialGenerationHash,
+            maximum: Authority.Observe,
+          })
+          yield* sql`
+            UPDATE authority_state
+            SET
+              kill_state = 'ACTIVE',
+              reason = 'operator kill',
+              version = version + 1,
+              updated_at = greatest(clock_timestamp(), updated_at + interval '1 millisecond')
+            WHERE singleton
+          `
+          const [before] = yield* sql<{ kill_state: string; reason: string; updated_at: Date; version: number }>`
+            SELECT kill_state, reason, updated_at, version::integer
+            FROM authority_state
+          `
+          const activated = yield* store.activatePaperGeneration(activation)
+          return { activated, before }
+        }),
+      )
+
+      expect(result.activated).toMatchObject({
+        maximum: Authority.Paper,
+        effective: Authority.Observe,
+        kill: KillState.Active,
+        reason: result.before.reason,
+        version: result.before.version + 1,
+      })
+      expect(Date.parse(result.activated.updatedAt)).toBeGreaterThan(result.before.updated_at.getTime())
+    } finally {
+      await runtime.dispose()
+    }
+  }, 15_000)
+
+  test('rejects reused generations and every qualification or reconciliation mismatch without writing', async () => {
+    const initialGenerationHash = hash('mismatch-paper-observe-generation')
+    const reconciliation = exactReconciliation('mismatch-paper-activation')
+    const activation = makeActivation(initialGenerationHash, qualifiedEvidence, reconciliation)
+    const runtime = makeActivationRuntime({ fail: false, planHashes: [] }, activation)
+    try {
+      const result = await runtime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* PaperStore
+          const sql = yield* PgClient.PgClient
+          yield* seedQualificationEvidence(qualifiedEvidence)
+          yield* seedExactReconciliation(reconciliation)
+          yield* store.ensureAuthorityGeneration({
+            generationHash: initialGenerationHash,
+            maximum: Authority.Observe,
+          })
+          const [before] = yield* sql<{ authority: unknown; history: unknown }>`
+            SELECT
+              (SELECT jsonb_agg(to_jsonb(authority)) FROM authority_state AS authority) AS authority,
+              (
+                SELECT jsonb_agg(to_jsonb(history) ORDER BY history.authority_version)
+                FROM authority_generations AS history
+              ) AS history
+          `
+          const mismatches = [
+            { qualificationSourceRevision: 'f'.repeat(40) },
+            { qualificationImageDigest: `sha256:${'e'.repeat(64)}` as const },
+            { activationSourceRevision: 'f'.repeat(40) },
+            { strategyBehaviorHash: hash('wrong-strategy-behavior') },
+            { strategyParameterHash: hash('wrong-strategy-parameters') },
+            { qualificationResultHash: hash('wrong-qualification-result') },
+            { qualificationExecutionPolicyHash: hash('wrong-execution-policy') },
+            { accountId: 'another-paper-account' },
+            { reconciliationContentHash: hash('wrong-reconciliation-content') },
+          ] as const
+          const failures = yield* Effect.forEach(mismatches, (overrides) =>
+            Effect.flip(
+              store.activatePaperGeneration(
+                makeActivation(initialGenerationHash, qualifiedEvidence, reconciliation, overrides),
+              ),
+            ),
+          )
+          yield* sql`
+            INSERT INTO reconciliations (
+              reconciliation_id, schema_version, account_id, expected_hash, observed_hash,
+              content_hash, status, discrepancies, reconciled_at
+            ) VALUES (
+              ${hash('later-discrepancy')}, 'bayn.paper-reconciliation.v1', ${accountId},
+              ${hash('expected-state')}, ${hash('observed-state')}, ${hash('later-discrepancy-content')},
+              'DISCREPANCY', ${sql.json(JSON.stringify([{ discrepancyId: hash('discrepancy') }]))},
+              clock_timestamp()
+            )
+          `
+          const stale = yield* Effect.flip(store.activatePaperGeneration(activation))
+          const [after] = yield* sql<{ authority: unknown; history: unknown }>`
+            SELECT
+              (SELECT jsonb_agg(to_jsonb(authority)) FROM authority_state AS authority) AS authority,
+              (
+                SELECT jsonb_agg(to_jsonb(history) ORDER BY history.authority_version)
+                FROM authority_generations AS history
+              ) AS history
+          `
+          return { after, before, failures, stale }
+        }),
+      )
+
+      expect(result.failures).toHaveLength(9)
+      expect(result.failures.every((failure) => failure.operation === 'authority')).toBe(true)
+      expect(result.stale).toMatchObject({ operation: 'authority', failure: 'invariant' })
+      expect(result.after).toEqual(result.before)
+    } finally {
+      await runtime.dispose()
+    }
+  }, 15_000)
+
+  test('rejects REJECTED evidence and unresolved mutation state without changing authority history', async () => {
+    const initialGenerationHash = hash('rejected-paper-observe-generation')
+    const reconciliation = exactReconciliation('rejected-paper-activation')
+    const rejectedActivation = makeActivation(initialGenerationHash, rejectedEvidence, reconciliation)
+    const qualifiedActivation = makeActivation(initialGenerationHash, qualifiedEvidence, reconciliation)
+    const rejectedRuntime = makeActivationRuntime({ fail: false, planHashes: [] }, rejectedActivation)
+    const rejected = await (async () => {
+      try {
+        return await rejectedRuntime.runPromise(
+          Effect.gen(function* () {
+            const store = yield* PaperStore
+            yield* seedQualificationEvidence(rejectedEvidence)
+            yield* seedExactReconciliation(reconciliation)
+            yield* store.ensureAuthorityGeneration({
+              generationHash: initialGenerationHash,
+              maximum: Authority.Observe,
+            })
+            return yield* Effect.flip(store.activatePaperGeneration(rejectedActivation))
+          }),
+        )
+      } finally {
+        await rejectedRuntime.dispose()
+      }
+    })()
+    const qualifiedRuntime = makeActivationRuntime({ fail: false, planHashes: [] }, qualifiedActivation)
+    try {
+      const result = await qualifiedRuntime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* PaperStore
+          const sql = yield* PgClient.PgClient
+          yield* sql`
+            INSERT INTO intents (
+              intent_id, schema_version, account_id, client_order_id, symbol, side,
+              order_type, time_in_force, quantity_micros, notional_limit_micros,
+              state, state_version, created_at, updated_at,
+              strategy_name, cycle_id, decision_hash, policy_hash
+            ) VALUES (
+              ${hash('unresolved-intent')}, 'bayn.paper-intent.v2', ${accountId},
+              'unresolved-client-order', 'SPY', 'BUY', 'MARKET', 'DAY', 1000000, 100000000,
+              'PLANNED', 1, '2026-07-22T15:30:03.000Z', '2026-07-22T15:30:03.000Z',
+              'risk-balanced-trend', ${hash('unresolved-cycle')},
+              ${hash('unresolved-decision')}, ${hash('unresolved-policy')}
+            )
+          `
+          yield* sql`
+            INSERT INTO mutation_events (
+              event_id, schema_version, mutation_id, intent_id, sequence, operation, event_type,
+              request_hash, consistency_delay_ms, occurred_at
+            ) VALUES (
+              ${hash('unresolved-event')}, 'bayn.paper-mutation-event.v1',
+              ${hash('unresolved-mutation')}, ${hash('unresolved-intent')}, 1,
+              'SUBMIT', 'SUBMIT_STARTED', ${hash('unresolved-request')}, 1000,
+              '2026-07-22T15:30:04.000Z'
+            )
+          `
+          yield* seedQualificationEvidence(qualifiedEvidence)
+          const unresolved = yield* Effect.flip(store.activatePaperGeneration(qualifiedActivation))
+          const [stored] = yield* sql<{ generation_hash: string; history_count: number; version: number }>`
+            SELECT
+              generation_hash,
+              version::integer,
+              (SELECT count(*)::integer FROM authority_generations) AS history_count
+            FROM authority_state
+          `
+          return { stored, unresolved }
+        }),
+      )
+
+      expect(rejected).toMatchObject({ operation: 'authority', failure: 'invariant' })
+      expect(result.unresolved).toMatchObject({ operation: 'authority', failure: 'invariant' })
+      expect(result.stored).toEqual({
+        generation_hash: hash('rejected-paper-observe-generation'),
+        version: 1,
+        history_count: 1,
+      })
+    } finally {
+      await qualifiedRuntime.dispose()
+    }
+  }, 15_000)
+
+  test('rejects A to B to A generation reuse after an OBSERVE return', async () => {
+    const firstObserveHash = hash('authority-generation-a')
+    const reconciliation = exactReconciliation('generation-reuse')
+    const activation = makeActivation(firstObserveHash, qualifiedEvidence, reconciliation)
+    const runtime = makeActivationRuntime({ fail: false, planHashes: [] }, activation)
+    try {
+      const result = await runtime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* PaperStore
+          const returnObserveHash = hash('authority-generation-c')
+          yield* seedQualificationEvidence(qualifiedEvidence)
+          yield* seedExactReconciliation(reconciliation)
+          yield* store.ensureAuthorityGeneration({
+            generationHash: firstObserveHash,
+            maximum: Authority.Observe,
+          })
+          yield* store.activatePaperGeneration(activation)
+          const returned = yield* store.ensureAuthorityGeneration({
+            generationHash: returnObserveHash,
+            maximum: Authority.Observe,
+          })
+          const reused = yield* Effect.flip(
+            store.ensureAuthorityGeneration({
+              generationHash: firstObserveHash,
+              maximum: Authority.Observe,
+            }),
+          )
+          const sql = yield* PgClient.PgClient
+          const history = yield* sql<{ generation_hash: string }>`
+            SELECT generation_hash
+            FROM authority_generations
+            ORDER BY authority_version
+          `
+          return { history, returned, reused }
+        }),
+      )
+
+      expect(result.returned).toMatchObject({
+        generationHash: hash('authority-generation-c'),
+        maximum: Authority.Observe,
+        effective: Authority.Observe,
+        version: 3,
+      })
+      expect(result.reused).toMatchObject({ operation: 'authority', failure: 'conflict' })
+      expect(new Set(result.history.map((row) => row.generation_hash)).size).toBe(3)
     } finally {
       await runtime.dispose()
     }
@@ -888,14 +1986,10 @@ describePostgres('paper accounting persistence', () => {
                 '2026-07-22T15:30:30.000Z'
               )
           `
-          yield* sql`
-            INSERT INTO authority_state (
-              schema_version, generation_hash, maximum, effective, kill_state, version, updated_at
-            ) VALUES (
-              'bayn.paper-authority.v1', ${hash('observe-generation')}, 'OBSERVE', 'OBSERVE', 'CLEAR', 1,
-              '2026-07-22T15:30:02.000Z'
-            )
-          `
+          yield* store.ensureAuthorityGeneration({
+            generationHash: hash('observe-generation'),
+            maximum: Authority.Observe,
+          })
           const [observationBefore] = yield* sql<{ observed_at: Date }>`
             SELECT clock_timestamp() AS observed_at
           `
@@ -931,7 +2025,7 @@ describePostgres('paper accounting persistence', () => {
           effective: Authority.Observe,
           kill: KillState.Clear,
           version: 1,
-          updatedAt: '2026-07-22T15:30:02.000Z',
+          updatedAt: expect.any(String),
         },
         unknownMutationCount: 0,
         dailyTradedNotionalMicros: '420000000',
@@ -1154,59 +2248,96 @@ describePostgres('paper accounting persistence', () => {
   }, 15_000)
 
   test('keeps discrepancy history in immutable reconciliation rows and never restores authority', async () => {
-    const runtime = makeStoreRuntime({ fail: false, planHashes: [] })
+    const setupRuntime = makeStoreRuntime(
+      { fail: false, planHashes: [] },
+      { ...config, reconciliationStaleThresholdMs: Number.MAX_SAFE_INTEGER },
+    )
     const exactAccount = {
       ...accountEvent(),
       account: { ...accountEvent().account, equityMicros: accountEvent().account.cashMicros },
     } satisfies BrokerEventInput
+    let runtime: ReturnType<typeof makeStoreRuntime> | undefined
     try {
+      const setup = await (async () => {
+        try {
+          return await setupRuntime.runPromise(
+            Effect.gen(function* () {
+              const store = yield* PaperStore
+              const accountReceipt = yield* store.ingest(exactAccount)
+              const positionsReceipt = yield* store.ingestPositions(
+                positionSnapshotInput(hash('reconciliation-empty-positions'), []),
+              )
+              const valuation = yield* store.value({
+                accountEventId: accountReceipt.eventId,
+                positionSnapshotId: positionsReceipt.snapshotId,
+              })
+              const baseline = {
+                account: exactAccount.account,
+                positions: [],
+                positionsObservedAt: observedAt,
+                orders: [],
+                ordersObservedAt: observedAt,
+                fills: [],
+                valuation,
+                reconciledAt: '2026-07-22T15:30:02.000Z',
+              } as const
+              const exact = yield* store.reconcile(baseline)
+              const observeGenerationHash = hash('reconciliation-observe-generation')
+              yield* seedQualificationEvidence(qualifiedEvidence)
+              yield* store.ensureAuthorityGeneration({
+                generationHash: observeGenerationHash,
+                maximum: Authority.Observe,
+              })
+              return { baseline, exact, observeGenerationHash, valuation }
+            }),
+          )
+        } finally {
+          await setupRuntime.dispose()
+        }
+      })()
+      const activation = makeActivation(setup.observeGenerationHash, qualifiedEvidence, {
+        reconciliationId: setup.exact.reconciliation.reconciliationId,
+        contentHash: setup.exact.reconciliation.contentHash,
+      })
+      runtime = makeActivationRuntime({ fail: false, planHashes: [] }, activation, {
+        reconciliationStaleThresholdMs: Number.MAX_SAFE_INTEGER,
+      })
       const result = await runtime.runPromise(
         Effect.gen(function* () {
           const store = yield* PaperStore
-          const accountReceipt = yield* store.ingest(exactAccount)
-          const positionsReceipt = yield* store.ingestPositions(
-            positionSnapshotInput(hash('reconciliation-empty-positions'), []),
-          )
-          const valuation = yield* store.value({
-            accountEventId: accountReceipt.eventId,
-            positionSnapshotId: positionsReceipt.snapshotId,
-          })
-          const baseline = {
-            account: exactAccount.account,
-            positions: [],
-            positionsObservedAt: observedAt,
-            orders: [],
-            ordersObservedAt: observedAt,
-            fills: [],
-            valuation,
-            reconciledAt: '2026-07-22T15:30:02.000Z',
-          } as const
-          const exact = yield* store.reconcile(baseline)
-
           const sql = yield* PgClient.PgClient
+          const activated = yield* store.activatePaperGeneration(activation)
           yield* sql`
-            INSERT INTO authority_state (
-              schema_version, generation_hash, maximum, effective, kill_state, version, updated_at
+            INSERT INTO valuations (
+              valuation_id, schema_version, account_id, source_hash, cash_micros,
+              long_market_value_micros, short_market_value_micros, equity_micros, as_of
             ) VALUES (
-              'bayn.paper-authority.v1', ${hash('paper-generation')}, 'PAPER', 'PAPER', 'CLEAR', 1,
-              '2026-07-22T15:30:02.500Z'
+              ${hash('paper-activation-day-valuation')}, ${setup.valuation.schemaVersion},
+              ${setup.valuation.accountId}, ${hash('paper-activation-day-source')},
+              ${setup.valuation.cashMicros}, ${setup.valuation.longMarketValueMicros},
+              ${setup.valuation.shortMarketValueMicros}, ${setup.valuation.equityMicros},
+              ${activated.updatedAt}
             )
           `
+          const activationTime = Date.parse(activated.updatedAt)
+          const mismatchObservedAt = new Date(activationTime + 1).toISOString()
+          const ongoingObservedAt = new Date(activationTime + 2).toISOString()
+          const resolvedObservedAt = new Date(activationTime + 3).toISOString()
 
           const mismatchInput = {
-            ...baseline,
+            ...setup.baseline,
             orders: [orderEvent().order],
-            reconciledAt: '2026-07-22T15:30:03.000Z',
+            reconciledAt: mismatchObservedAt,
           } as const
           const mismatch = yield* store.reconcile(mismatchInput)
           const replay = yield* store.reconcile(mismatchInput)
           const ongoing = yield* store.reconcile({
             ...mismatchInput,
-            reconciledAt: '2026-07-22T15:30:04.000Z',
+            reconciledAt: ongoingObservedAt,
           })
           const resolved = yield* store.reconcile({
-            ...baseline,
-            reconciledAt: '2026-07-22T15:30:05.000Z',
+            ...setup.baseline,
+            reconciledAt: resolvedObservedAt,
           })
 
           const rows = yield* sql<{ discrepancy_count: number; status: string }>`
@@ -1229,7 +2360,7 @@ describePostgres('paper accounting persistence', () => {
             WHERE reconciliation_id = ${mismatch.reconciliation.reconciliationId}
           `)
           return {
-            exact,
+            exact: setup.exact,
             mismatch,
             replay,
             ongoing,
@@ -1237,6 +2368,8 @@ describePostgres('paper accounting persistence', () => {
             rows,
             authority,
             mutateReconciliation,
+            mismatchObservedAt,
+            ongoingObservedAt,
           }
         }),
       )
@@ -1261,8 +2394,8 @@ describePostgres('paper accounting persistence', () => {
       expect(result.mismatch.reconciliation.discrepancies).toHaveLength(1)
       expect(result.ongoing.reconciliation.discrepancies[0]).toMatchObject({
         discrepancyId: result.mismatch.reconciliation.discrepancies[0]?.discrepancyId,
-        firstObservedAt: '2026-07-22T15:30:03.000Z',
-        lastObservedAt: '2026-07-22T15:30:04.000Z',
+        firstObservedAt: result.mismatchObservedAt,
+        lastObservedAt: result.ongoingObservedAt,
       })
       expect(result.resolved.reconciliation.status).toBe(ReconciliationStatus.Exact)
       expect(result.resolved.reconciliation.discrepancies).toEqual([])
@@ -1276,11 +2409,11 @@ describePostgres('paper accounting persistence', () => {
         effective: 'OBSERVE',
         kill_state: 'ACTIVE',
         reason: `reconciliation discrepancy ${result.mismatch.reconciliation.reconciliationId}`,
-        version: 2,
+        version: 3,
       })
       expect(Exit.isFailure(result.mutateReconciliation)).toBe(true)
     } finally {
-      await runtime.dispose()
+      await runtime?.dispose()
     }
   }, 15_000)
 })

--- a/services/bayn/src/db/paper-store.ts
+++ b/services/bayn/src/db/paper-store.ts
@@ -19,6 +19,8 @@ import {
   type ValuationInput,
 } from '../broker/observations'
 import type { RuntimeConfig } from '../config'
+import { makeStrategyProtocolHash } from '../contracts'
+import { WriterFence } from '../execution/writer-fence'
 import { canonicalHashV1 } from '../hash'
 import { Journal } from '../ledger'
 import {
@@ -27,12 +29,16 @@ import {
   Broker,
   BrokerEventSchema,
   KillState,
+  ReconciliationStatus,
   ValuationSchema,
   decodeAuthorityState,
+  decodePaperAuthorityGeneration,
   type AccountingReceipt,
   type AuthorityState,
+  type PaperAuthorityGeneration,
   type Valuation,
 } from '../paper'
+import { QualificationLockSchema, QualificationResultSchema } from '../qualification'
 import {
   Sha256Schema as Sha256,
   StrictNonEmptyStringSchema as NonEmptyString,
@@ -99,6 +105,13 @@ export interface PaperStoreShape {
   readonly ensureAuthorityGeneration: (
     input: EnsureAuthorityGenerationInput,
   ) => Effect.Effect<AuthorityState, PaperStoreError>
+  /**
+   * Sole supported cross-generation PAPER writer. Application code and operators must not issue direct DML against
+   * authority_state or authority_generations.
+   */
+  readonly activatePaperGeneration: (
+    input: PaperAuthorityGeneration,
+  ) => Effect.Effect<AuthorityState, PaperStoreError, WriterFence>
   readonly restrictAuthority: (reason: string, updatedAt: string) => Effect.Effect<void, PaperStoreError>
 }
 
@@ -173,6 +186,75 @@ const AuthorityStateObservationRow = Schema.Struct({
 })
 const AuthorityStateRows = Schema.Array(AuthorityStateRow).check(Schema.isMaxLength(1))
 const AuthorityStateObservationRows = Schema.Array(AuthorityStateObservationRow).check(Schema.isMaxLength(1))
+const AuthorityGenerationRow = Schema.Struct({
+  generation_hash: Sha256,
+  activation_schema_version: Schema.NullOr(Schema.Literal('bayn.paper-authority-generation.v1')),
+  previous_generation_hash: Schema.NullOr(Sha256),
+  maximum: Schema.Enum(Authority),
+  authority_version: Schema.String,
+  qualification_run_id: Schema.NullOr(Sha256),
+  qualification_lock_id: Schema.NullOr(Sha256),
+  qualification_result_hash: Schema.NullOr(Sha256),
+  protocol_hash: Schema.NullOr(Sha256),
+  qualification_execution_policy_hash: Schema.NullOr(Sha256),
+  qualification_source_revision: Schema.NullOr(Schema.String),
+  qualification_image_repository: Schema.NullOr(NonEmptyString),
+  qualification_image_digest: Schema.NullOr(Schema.String),
+  activation_source_revision: Schema.NullOr(Schema.String),
+  activation_image_repository: Schema.NullOr(NonEmptyString),
+  activation_image_digest: Schema.NullOr(Schema.String),
+  strategy_name: Schema.NullOr(Schema.Literal('risk-balanced-trend')),
+  strategy_behavior_hash: Schema.NullOr(Sha256),
+  strategy_parameter_hash: Schema.NullOr(Sha256),
+  strategy_parameter_schema_version: Schema.NullOr(Schema.Literal('bayn.risk-balanced-trend.protocol.v3')),
+  account_id: Schema.NullOr(NonEmptyString),
+  risk_policy_hash: Schema.NullOr(Sha256),
+  proof_plan_hash: Schema.NullOr(Sha256),
+  reconciliation_id: Schema.NullOr(Sha256),
+  reconciliation_content_hash: Schema.NullOr(Sha256),
+  activated_at: Schema.DateValid,
+})
+const AuthorityGenerationRows = Schema.Array(AuthorityGenerationRow).check(Schema.isMaxLength(1))
+const ActivationEvidenceRow = Schema.Struct({
+  lock_payload: QualificationLockSchema,
+  result_payload: QualificationResultSchema,
+  run_status: Schema.Literals(['WRITING', 'COMPLETE']),
+  expected_artifact_count: Schema.Int,
+  expected_event_count: Schema.Int,
+  expected_gate_count: Schema.Int,
+  artifact_count: Schema.Int,
+  event_count: Schema.Int,
+  gate_count: Schema.Int,
+  status_count: Schema.Int,
+  writing_status_count: Schema.Int,
+  complete_status_count: Schema.Int,
+  writing_detail: Schema.Unknown,
+  complete_detail: Schema.Unknown,
+  protocol_schema_version: Schema.Literals([
+    'bayn.risk-balanced-trend.protocol.v2',
+    'bayn.risk-balanced-trend.protocol.v3',
+  ]),
+  strategy_name: Schema.Literal('risk-balanced-trend'),
+  behavior_hash: Sha256,
+  parameter_hash: Sha256,
+  parameters: Schema.Unknown,
+})
+const ActivationEvidenceRows = Schema.Array(ActivationEvidenceRow).check(Schema.isMaxLength(1))
+const ActivationReconciliationRow = Schema.Struct({
+  reconciliation_id: Sha256,
+  account_id: NonEmptyString,
+  content_hash: Sha256,
+  status: Schema.Enum(ReconciliationStatus),
+  reconciled_at: Schema.DateValid,
+})
+const ActivationReconciliationRows = Schema.Array(ActivationReconciliationRow).check(Schema.isMaxLength(1))
+const MutationBaselineRow = Schema.Tuple([
+  Schema.Struct({
+    unresolved_count: Schema.Int,
+    latest_mutation_at: Schema.NullOr(Schema.DateValid),
+  }),
+])
+const DatabaseInstantRow = Schema.Tuple([Schema.Struct({ activated_at: Schema.DateValid })])
 const AuthorityRestrictionInput = Schema.Struct({ reason: NonEmptyString, updatedAt: UtcInstant })
 
 const decodeEventInput = Schema.decodeUnknownEffect(BrokerEventInputSchema, strictParseOptions)
@@ -205,6 +287,11 @@ const decodeAuthorityStateObservationRows = Schema.decodeUnknownEffect(
   AuthorityStateObservationRows,
   strictParseOptions,
 )
+const decodeAuthorityGenerationRows = Schema.decodeUnknownEffect(AuthorityGenerationRows, strictParseOptions)
+const decodeActivationEvidenceRows = Schema.decodeUnknownEffect(ActivationEvidenceRows, strictParseOptions)
+const decodeActivationReconciliationRows = Schema.decodeUnknownEffect(ActivationReconciliationRows, strictParseOptions)
+const decodeMutationBaseline = Schema.decodeUnknownEffect(MutationBaselineRow, strictParseOptions)
+const decodeDatabaseInstant = Schema.decodeUnknownEffect(DatabaseInstantRow, strictParseOptions)
 const decodeBrokerEvent = Schema.decodeUnknownEffect(BrokerEventSchema, strictParseOptions)
 const decodeReceipt = Schema.decodeUnknownEffect(AccountingReceiptSchema, strictParseOptions)
 const decodeValuation = Schema.decodeUnknownEffect(ValuationSchema, strictParseOptions)
@@ -263,6 +350,70 @@ const authorityStateFromRow = (
   })
 }
 
+const positiveSafeVersion = (value: string, message: string): Effect.Effect<number, PaperStoreError> => {
+  const version = Number(value)
+  return Number.isSafeInteger(version) && version > 0
+    ? Effect.succeed(version)
+    : fail('authority', 'invariant', message)
+}
+
+const paperGenerationFromRow = (
+  row: typeof AuthorityGenerationRow.Type,
+): Effect.Effect<PaperAuthorityGeneration, PaperStoreError | Schema.SchemaError> => {
+  if (
+    row.activation_schema_version === null ||
+    row.previous_generation_hash === null ||
+    row.qualification_run_id === null ||
+    row.qualification_lock_id === null ||
+    row.qualification_result_hash === null ||
+    row.protocol_hash === null ||
+    row.qualification_execution_policy_hash === null ||
+    row.qualification_source_revision === null ||
+    row.qualification_image_repository === null ||
+    row.qualification_image_digest === null ||
+    row.activation_source_revision === null ||
+    row.activation_image_repository === null ||
+    row.activation_image_digest === null ||
+    row.strategy_name === null ||
+    row.strategy_behavior_hash === null ||
+    row.strategy_parameter_hash === null ||
+    row.strategy_parameter_schema_version === null ||
+    row.account_id === null ||
+    row.risk_policy_hash === null ||
+    row.proof_plan_hash === null ||
+    row.reconciliation_id === null ||
+    row.reconciliation_content_hash === null
+  ) {
+    return fail('authority', 'invariant', 'PAPER authority generation history is incomplete')
+  }
+  return decodePaperAuthorityGeneration({
+    schemaVersion: row.activation_schema_version,
+    generationHash: row.generation_hash,
+    maximum: row.maximum,
+    previousGenerationHash: row.previous_generation_hash,
+    qualificationRunId: row.qualification_run_id,
+    qualificationLockId: row.qualification_lock_id,
+    qualificationResultHash: row.qualification_result_hash,
+    protocolHash: row.protocol_hash,
+    qualificationExecutionPolicyHash: row.qualification_execution_policy_hash,
+    qualificationSourceRevision: row.qualification_source_revision,
+    qualificationImageRepository: row.qualification_image_repository,
+    qualificationImageDigest: row.qualification_image_digest,
+    activationSourceRevision: row.activation_source_revision,
+    activationImageRepository: row.activation_image_repository,
+    activationImageDigest: row.activation_image_digest,
+    strategyName: row.strategy_name,
+    strategyBehaviorHash: row.strategy_behavior_hash,
+    strategyParameterHash: row.strategy_parameter_hash,
+    strategyParameterSchemaVersion: row.strategy_parameter_schema_version,
+    accountId: row.account_id,
+    riskPolicyHash: row.risk_policy_hash,
+    proofPlanHash: row.proof_plan_hash,
+    reconciliationId: row.reconciliation_id,
+    reconciliationContentHash: row.reconciliation_content_hash,
+  })
+}
+
 const kindOf = (input: BrokerEventInput): typeof EventKind.Type => {
   switch (input._tag) {
     case 'Account':
@@ -311,7 +462,14 @@ const stableReceipt = (receipt: AccountingReceipt) => ({
   contentHash: receipt.contentHash,
 })
 
-const makeStore = (config: Pick<RuntimeConfig, 'tigerBeetle'>) =>
+type PaperStoreRuntimeConfig = Pick<
+  RuntimeConfig,
+  'build' | 'maximumAuthority' | 'qualificationRunId' | 'reconciliationStaleThresholdMs' | 'tigerBeetle'
+> & {
+  readonly alpaca?: Pick<NonNullable<RuntimeConfig['alpaca']>, 'accountId' | 'authorityGenerationHash'>
+}
+
+const makeStore = (config: PaperStoreRuntimeConfig) =>
   Effect.gen(function* () {
     const sql = yield* PgClient.PgClient
     const journal = yield* Journal
@@ -948,6 +1106,70 @@ const makeStore = (config: Pick<RuntimeConfig, 'tigerBeetle'>) =>
       )
     const bindings = (accountId: string) => run('bindings', reconciliation.bindings(accountId))
     const reconcile = (snapshot: BrokerSnapshot) => run('reconciliation', reconciliation.reconcile(snapshot))
+
+    const lockAuthorityGenerations = Effect.gen(function* () {
+      yield* sql`
+        SELECT pg_advisory_xact_lock(
+          hashtextextended('bayn.paper-authority-generation.v1', 0)
+        )
+      `
+      yield* sql`LOCK TABLE authority_generations IN SHARE ROW EXCLUSIVE MODE`
+    })
+
+    const readGeneration = (generationHash: string) =>
+      sql<Record<string, unknown>>`
+        SELECT
+          generation_hash, activation_schema_version, previous_generation_hash, maximum,
+          authority_version::text AS authority_version, qualification_run_id,
+          qualification_lock_id, qualification_result_hash, protocol_hash,
+          qualification_execution_policy_hash, qualification_source_revision,
+          qualification_image_repository, qualification_image_digest,
+          activation_source_revision, activation_image_repository, activation_image_digest,
+          strategy_name, strategy_behavior_hash, strategy_parameter_hash,
+          strategy_parameter_schema_version, account_id, risk_policy_hash, proof_plan_hash,
+          reconciliation_id, reconciliation_content_hash, activated_at
+        FROM authority_generations
+        WHERE generation_hash = ${generationHash}
+      `.pipe(Effect.flatMap(decodeAuthorityGenerationRows))
+
+    const verifyCurrentGenerationHistory = (
+      current: AuthorityState,
+      history: typeof AuthorityGenerationRow.Type | undefined,
+    ) =>
+      Effect.gen(function* () {
+        if (history === undefined) {
+          return yield* fail('authority', 'invariant', 'current authority generation lacks immutable history')
+        }
+        const historyVersion = yield* positiveSafeVersion(
+          history.authority_version,
+          'authority generation history version is not a safe positive integer',
+        )
+        if (
+          history.generation_hash !== current.generationHash ||
+          history.maximum !== current.maximum ||
+          historyVersion > current.version ||
+          history.activated_at.toISOString() > current.updatedAt
+        ) {
+          return yield* fail('authority', 'invariant', 'current authority generation history differs from state')
+        }
+      })
+
+    const nextAuthorityInstant = sql<Record<string, unknown>>`
+      SELECT greatest(
+        clock_timestamp(),
+        updated_at + interval '1 millisecond'
+      ) AS activated_at
+      FROM authority_state
+      WHERE singleton
+    `.pipe(
+      Effect.flatMap(decodeDatabaseInstant),
+      Effect.flatMap((rows) =>
+        rows[0] === undefined
+          ? fail('authority', 'invariant', 'authority update time is unavailable')
+          : Effect.succeed(rows[0].activated_at),
+      ),
+    )
+
     const ensureAuthorityGeneration = (candidate: EnsureAuthorityGenerationInput) =>
       run(
         'authority',
@@ -957,11 +1179,7 @@ const makeStore = (config: Pick<RuntimeConfig, 'tigerBeetle'>) =>
               ? fail('authority', 'invariant', 'Phase A authority maximum must be OBSERVE')
               : sql.withTransaction(
                   Effect.gen(function* () {
-                    yield* sql`
-                      SELECT pg_advisory_xact_lock(
-                        hashtextextended('bayn.paper-authority-generation.v1', 0)
-                      )
-                    `
+                    yield* lockAuthorityGenerations
                     const rows = yield* sql<Record<string, unknown>>`
                       SELECT
                         schema_version, generation_hash, maximum, effective, kill_state, reason,
@@ -972,13 +1190,31 @@ const makeStore = (config: Pick<RuntimeConfig, 'tigerBeetle'>) =>
                     `.pipe(Effect.flatMap(decodeAuthorityStateObservationRows))
                     const currentRow = rows[0]
                     if (currentRow === undefined) {
+                      if ((yield* readGeneration(input.generationHash))[0] !== undefined) {
+                        return yield* fail('authority', 'conflict', 'authority generation hash was already used')
+                      }
+                      const [databaseTime] = yield* sql<Record<string, unknown>>`
+                        SELECT clock_timestamp() AS activated_at
+                      `.pipe(Effect.flatMap(decodeDatabaseInstant))
+                      if (databaseTime === undefined) {
+                        return yield* fail('authority', 'invariant', 'authority initialization time is unavailable')
+                      }
+                      yield* sql`
+                        INSERT INTO authority_generations (
+                          generation_hash, schema_version, previous_generation_hash, maximum,
+                          authority_version, activated_at
+                        ) VALUES (
+                          ${input.generationHash}, 'bayn.authority-generation-history.v1', NULL,
+                          'OBSERVE', 1, ${databaseTime.activated_at}
+                        )
+                      `
                       const inserted = yield* sql<Record<string, unknown>>`
                         INSERT INTO authority_state (
                           schema_version, generation_hash, maximum, effective, kill_state,
                           reason, version, updated_at
                         ) VALUES (
                           'bayn.paper-authority.v1', ${input.generationHash}, ${input.maximum},
-                          'OBSERVE', 'CLEAR', NULL, 1, clock_timestamp()
+                          'OBSERVE', 'CLEAR', NULL, 1, ${databaseTime.activated_at}
                         )
                         RETURNING
                           schema_version, generation_hash, maximum, effective, kill_state, reason,
@@ -1007,9 +1243,24 @@ const makeStore = (config: Pick<RuntimeConfig, 'tigerBeetle'>) =>
                           'authority generation maximum conflicts with durable state',
                         )
                       }
+                      yield* verifyCurrentGenerationHistory(current, (yield* readGeneration(current.generationHash))[0])
                       return current
                     }
 
+                    yield* verifyCurrentGenerationHistory(current, (yield* readGeneration(current.generationHash))[0])
+                    if ((yield* readGeneration(input.generationHash))[0] !== undefined) {
+                      return yield* fail('authority', 'conflict', 'authority generation hash was already used')
+                    }
+                    const activatedAt = yield* nextAuthorityInstant
+                    yield* sql`
+                      INSERT INTO authority_generations (
+                        generation_hash, schema_version, previous_generation_hash, maximum,
+                        authority_version, activated_at
+                      ) VALUES (
+                        ${input.generationHash}, 'bayn.authority-generation-history.v1',
+                        ${current.generationHash}, 'OBSERVE', ${current.version + 1}, ${activatedAt}
+                      )
+                    `
                     const rotated = yield* sql<Record<string, unknown>>`
                       UPDATE authority_state
                       SET
@@ -1017,10 +1268,7 @@ const makeStore = (config: Pick<RuntimeConfig, 'tigerBeetle'>) =>
                         maximum = ${input.maximum},
                         effective = 'OBSERVE',
                         version = version + 1,
-                        updated_at = greatest(
-                          clock_timestamp(),
-                          updated_at + interval '1 millisecond'
-                        )
+                        updated_at = ${activatedAt}
                       WHERE singleton
                       RETURNING
                         schema_version, generation_hash, maximum, effective, kill_state, reason,
@@ -1036,6 +1284,390 @@ const makeStore = (config: Pick<RuntimeConfig, 'tigerBeetle'>) =>
           ),
         ),
       )
+
+    const activatePaperGeneration = (candidate: PaperAuthorityGeneration) =>
+      run(
+        'authority',
+        decodePaperAuthorityGeneration(candidate).pipe(
+          Effect.flatMap((input) => {
+            if (
+              config.maximumAuthority !== Authority.Paper ||
+              config.alpaca === undefined ||
+              input.generationHash !== config.alpaca.authorityGenerationHash ||
+              input.accountId !== config.alpaca.accountId ||
+              input.qualificationRunId !== config.qualificationRunId
+            ) {
+              return fail(
+                'authority',
+                'invariant',
+                'PAPER activation differs from the configured authority, account, generation, or qualification binding',
+              )
+            }
+            if (
+              input.activationSourceRevision !== config.build.sourceRevision ||
+              input.activationImageRepository !== config.build.imageRepository ||
+              input.activationImageDigest !== config.build.imageDigest
+            ) {
+              return fail(
+                'authority',
+                'invariant',
+                'PAPER activation provenance differs from the current embedded build',
+              )
+            }
+            if (
+              input.strategyBehaviorHash !== config.build.strategyBehaviorHash ||
+              input.strategyParameterHash !== config.build.strategyParameterHash
+            ) {
+              return fail(
+                'authority',
+                'invariant',
+                'PAPER activation strategy identity differs from the current embedded build',
+              )
+            }
+            return Effect.succeed(input)
+          }),
+          Effect.flatMap((input) =>
+            Effect.flatMap(WriterFence, (fence) =>
+              fence.transaction(
+                Effect.gen(function* () {
+                  yield* sql`
+                  SELECT pg_advisory_xact_lock(
+                    hashtextextended(${`ALPACA:${input.accountId}`}, 0)
+                  )
+                `
+                  yield* lockAuthorityGenerations
+                  const currentRows = yield* sql<Record<string, unknown>>`
+                  SELECT
+                    schema_version, generation_hash, maximum, effective, kill_state, reason,
+                    version::text AS version, updated_at, clock_timestamp() AS observed_at
+                  FROM authority_state
+                  WHERE singleton
+                  FOR UPDATE
+                `.pipe(Effect.flatMap(decodeAuthorityStateObservationRows))
+                  const currentRow = currentRows[0]
+                  if (currentRow === undefined) {
+                    return yield* fail(
+                      'authority',
+                      'invariant',
+                      'PAPER activation requires an initialized OBSERVE authority',
+                    )
+                  }
+                  const current = yield* authorityStateFromRow(currentRow)
+                  if (currentRow.updated_at.getTime() > currentRow.observed_at.getTime()) {
+                    return yield* fail(
+                      'authority',
+                      'invariant',
+                      'durable authority update follows its database observation time',
+                    )
+                  }
+
+                  const currentHistory = (yield* readGeneration(current.generationHash))[0]
+                  yield* verifyCurrentGenerationHistory(current, currentHistory)
+                  if (current.generationHash === input.generationHash) {
+                    if (current.maximum !== Authority.Paper) {
+                      return yield* fail(
+                        'authority',
+                        'conflict',
+                        'PAPER generation conflicts with durable maximum authority',
+                      )
+                    }
+                    if (currentHistory === undefined) {
+                      return yield* fail('authority', 'invariant', 'PAPER authority history is missing')
+                    }
+                    const stored = yield* paperGenerationFromRow(currentHistory)
+                    if (canonicalHashV1(stored) !== canonicalHashV1(input)) {
+                      return yield* fail(
+                        'authority',
+                        'conflict',
+                        'PAPER generation history differs from deterministic replay',
+                      )
+                    }
+                    return current
+                  }
+
+                  if (current.maximum !== Authority.Observe || current.effective !== Authority.Observe) {
+                    return yield* fail('authority', 'invariant', 'PAPER activation requires current OBSERVE authority')
+                  }
+                  if (input.previousGenerationHash !== current.generationHash) {
+                    return yield* fail(
+                      'authority',
+                      'conflict',
+                      'PAPER generation does not extend the current authority generation',
+                    )
+                  }
+                  if ((yield* readGeneration(input.generationHash))[0] !== undefined) {
+                    return yield* fail('authority', 'conflict', 'authority generation hash was already used')
+                  }
+
+                  yield* sql`
+                  LOCK TABLE
+                    evaluation_artifacts,
+                    evaluation_events,
+                    gate_outcomes,
+                    status_history
+                  IN SHARE MODE
+                `
+                  const evidenceRows = yield* sql<Record<string, unknown>>`
+                  SELECT
+                    lock.payload AS lock_payload,
+                    result.payload AS result_payload,
+                    run.status AS run_status,
+                    run.expected_artifact_count,
+                    run.expected_event_count,
+                    run.expected_gate_count,
+                    (
+                      SELECT count(*)::integer
+                      FROM evaluation_artifacts
+                      WHERE run_id = run.run_id
+                    ) AS artifact_count,
+                    (
+                      SELECT count(*)::integer
+                      FROM evaluation_events
+                      WHERE run_id = run.run_id
+                    ) AS event_count,
+                    (
+                      SELECT count(*)::integer
+                      FROM gate_outcomes
+                      WHERE run_id = run.run_id
+                    ) AS gate_count,
+                    (
+                      SELECT count(*)::integer
+                      FROM status_history
+                      WHERE run_id = run.run_id
+                    ) AS status_count,
+                    (
+                      SELECT count(*)::integer
+                      FROM status_history
+                      WHERE run_id = run.run_id AND status = 'WRITING'
+                    ) AS writing_status_count,
+                    (
+                      SELECT count(*)::integer
+                      FROM status_history
+                      WHERE run_id = run.run_id AND status = 'COMPLETE'
+                    ) AS complete_status_count,
+                    (
+                      SELECT detail
+                      FROM status_history
+                      WHERE run_id = run.run_id AND status = 'WRITING'
+                    ) AS writing_detail,
+                    (
+                      SELECT detail
+                      FROM status_history
+                      WHERE run_id = run.run_id AND status = 'COMPLETE'
+                    ) AS complete_detail,
+                    protocol.schema_version AS protocol_schema_version,
+                    protocol.strategy_name,
+                    protocol.behavior_hash,
+                    protocol.parameter_hash,
+                    protocol.parameters
+                  FROM qualification_results AS result
+                  JOIN qualification_locks AS lock
+                    ON lock.lock_id = result.lock_id
+                    AND lock.candidate_run_id = result.run_id
+                  JOIN evaluation_runs AS run
+                    ON run.run_id = result.run_id
+                    AND run.protocol_hash = lock.protocol_hash
+                    AND run.snapshot_id = lock.snapshot_id
+                    AND run.source_revision = lock.source_revision
+                    AND run.image_repository = lock.image_repository
+                    AND run.image_digest = lock.image_digest
+                  JOIN protocol_locks AS protocol
+                    ON protocol.protocol_hash = run.protocol_hash
+                    AND protocol.strategy_name = run.strategy_name
+                  WHERE result.run_id = ${input.qualificationRunId}
+                  FOR SHARE OF result, lock, run, protocol
+                `.pipe(Effect.flatMap(decodeActivationEvidenceRows))
+                  const evidence = evidenceRows[0]
+                  if (evidence === undefined) {
+                    return yield* fail('authority', 'invariant', 'exact terminal qualification evidence is unavailable')
+                  }
+                  const lock = evidence.lock_payload
+                  const result = evidence.result_payload
+                  const strategyProtocolHash = makeStrategyProtocolHash({
+                    name: evidence.strategy_name,
+                    behaviorHash: evidence.behavior_hash,
+                    parameterHash: evidence.parameter_hash,
+                    parameterSchemaVersion: evidence.protocol_schema_version,
+                  })
+                  if (
+                    result.verdict !== 'QUALIFIED' ||
+                    evidence.run_status !== 'COMPLETE' ||
+                    evidence.expected_artifact_count !== evidence.artifact_count ||
+                    evidence.expected_event_count !== evidence.event_count ||
+                    evidence.expected_gate_count !== evidence.gate_count ||
+                    evidence.status_count !== 2 ||
+                    evidence.writing_status_count !== 1 ||
+                    evidence.complete_status_count !== 1 ||
+                    canonicalHashV1(evidence.writing_detail) !==
+                      canonicalHashV1({
+                        artifactCount: evidence.expected_artifact_count,
+                        eventCount: evidence.expected_event_count,
+                        gateCount: evidence.expected_gate_count,
+                      }) ||
+                    canonicalHashV1(evidence.complete_detail) !==
+                      canonicalHashV1({
+                        reconciliationExact: true,
+                        verdict: result.evaluationVerdict.status,
+                      }) ||
+                    result.runId !== input.qualificationRunId ||
+                    result.lockId !== input.qualificationLockId ||
+                    result.resultHash !== input.qualificationResultHash ||
+                    lock.lockId !== input.qualificationLockId ||
+                    lock.candidateRunId !== input.qualificationRunId ||
+                    lock.protocolHash !== input.protocolHash ||
+                    lock.policies.execution.contentHash !== input.qualificationExecutionPolicyHash ||
+                    lock.sourceRevision !== input.qualificationSourceRevision ||
+                    lock.image.repository !== input.qualificationImageRepository ||
+                    lock.image.digest !== input.qualificationImageDigest ||
+                    evidence.protocol_schema_version !== input.strategyParameterSchemaVersion ||
+                    evidence.strategy_name !== input.strategyName ||
+                    evidence.behavior_hash !== input.strategyBehaviorHash ||
+                    evidence.parameter_hash !== input.strategyParameterHash ||
+                    canonicalHashV1(evidence.parameters) !== input.strategyParameterHash ||
+                    strategyProtocolHash !== input.protocolHash
+                  ) {
+                    return yield* fail(
+                      'authority',
+                      'invariant',
+                      'PAPER generation differs from terminal qualification evidence',
+                    )
+                  }
+
+                  const reconciliationRows = yield* sql<Record<string, unknown>>`
+                  SELECT
+                    reconciliation_id, account_id, content_hash, status, reconciled_at
+                  FROM reconciliations
+                  WHERE account_id = ${input.accountId}
+                  ORDER BY reconciled_at DESC, reconciliation_id DESC
+                  LIMIT 1
+                  FOR SHARE
+                `.pipe(Effect.flatMap(decodeActivationReconciliationRows))
+                  const exactReconciliation = reconciliationRows[0]
+                  if (
+                    exactReconciliation === undefined ||
+                    exactReconciliation.reconciliation_id !== input.reconciliationId ||
+                    exactReconciliation.account_id !== input.accountId ||
+                    exactReconciliation.content_hash !== input.reconciliationContentHash ||
+                    exactReconciliation.status !== ReconciliationStatus.Exact
+                  ) {
+                    return yield* fail(
+                      'authority',
+                      'invariant',
+                      'PAPER activation requires the latest fresh exact account reconciliation',
+                    )
+                  }
+
+                  const [mutationBaseline] = yield* sql<Record<string, unknown>>`
+                  WITH latest AS (
+                    SELECT DISTINCT ON (event.mutation_id)
+                      event.operation,
+                      event.event_type,
+                      event.occurred_at,
+                      intent.state
+                    FROM mutation_events AS event
+                    JOIN intents AS intent ON intent.intent_id = event.intent_id
+                    WHERE intent.account_id = ${input.accountId}
+                    ORDER BY event.mutation_id, event.sequence DESC
+                  )
+                  SELECT
+                    count(*) FILTER (
+                      WHERE latest.event_type IN (
+                        'SUBMIT_STARTED',
+                        'SUBMIT_UNKNOWN',
+                        'RECOVERY_NOT_FOUND',
+                        'RECOVERY_UNKNOWN',
+                        'CANCEL_STARTED',
+                        'CANCEL_ACCEPTED',
+                        'CANCEL_UNKNOWN'
+                      )
+                      OR (
+                        latest.operation = 'CANCEL'
+                        AND latest.event_type = 'RECOVERY_FOUND'
+                        AND latest.state <> 'TERMINAL'
+                      )
+                    )::integer AS unresolved_count,
+                    max(latest.occurred_at) AS latest_mutation_at
+                  FROM latest
+                `.pipe(Effect.flatMap(decodeMutationBaseline))
+                  if (
+                    mutationBaseline.unresolved_count !== 0 ||
+                    (mutationBaseline.latest_mutation_at !== null &&
+                      mutationBaseline.latest_mutation_at.getTime() > exactReconciliation.reconciled_at.getTime())
+                  ) {
+                    return yield* fail(
+                      'authority',
+                      'invariant',
+                      'PAPER activation requires zero unresolved mutations covered by reconciliation',
+                    )
+                  }
+
+                  const activatedAt = yield* nextAuthorityInstant
+                  if (
+                    exactReconciliation.reconciled_at.getTime() > activatedAt.getTime() ||
+                    activatedAt.getTime() - exactReconciliation.reconciled_at.getTime() >=
+                      config.reconciliationStaleThresholdMs
+                  ) {
+                    return yield* fail(
+                      'authority',
+                      'invariant',
+                      'PAPER activation requires the latest fresh exact account reconciliation',
+                    )
+                  }
+                  const nextVersion = current.version + 1
+                  yield* sql`
+                  INSERT INTO authority_generations (
+                    generation_hash, schema_version, activation_schema_version,
+                    previous_generation_hash, maximum, authority_version,
+                    qualification_run_id, qualification_lock_id, qualification_result_hash,
+                    protocol_hash, qualification_execution_policy_hash,
+                    qualification_source_revision, qualification_image_repository,
+                    qualification_image_digest, activation_source_revision,
+                    activation_image_repository, activation_image_digest,
+                    strategy_name, strategy_behavior_hash,
+                    strategy_parameter_hash, strategy_parameter_schema_version, account_id,
+                    risk_policy_hash, proof_plan_hash, reconciliation_id,
+                    reconciliation_content_hash, activated_at
+                  ) VALUES (
+                    ${input.generationHash}, 'bayn.authority-generation-history.v1',
+                    ${input.schemaVersion}, ${input.previousGenerationHash}, 'PAPER', ${nextVersion},
+                    ${input.qualificationRunId}, ${input.qualificationLockId},
+                    ${input.qualificationResultHash}, ${input.protocolHash},
+                    ${input.qualificationExecutionPolicyHash}, ${input.qualificationSourceRevision},
+                    ${input.qualificationImageRepository}, ${input.qualificationImageDigest},
+                    ${input.activationSourceRevision}, ${input.activationImageRepository},
+                    ${input.activationImageDigest}, ${input.strategyName},
+                    ${input.strategyBehaviorHash}, ${input.strategyParameterHash},
+                    ${input.strategyParameterSchemaVersion}, ${input.accountId},
+                    ${input.riskPolicyHash}, ${input.proofPlanHash}, ${input.reconciliationId},
+                    ${input.reconciliationContentHash}, ${activatedAt}
+                  )
+                `
+                  const effective = current.kill === KillState.Active ? Authority.Observe : Authority.Paper
+                  const activatedRows = yield* sql<Record<string, unknown>>`
+                  UPDATE authority_state
+                  SET
+                    generation_hash = ${input.generationHash},
+                    maximum = 'PAPER',
+                    effective = ${effective},
+                    version = version + 1,
+                    updated_at = ${activatedAt}
+                  WHERE singleton
+                  RETURNING
+                    schema_version, generation_hash, maximum, effective, kill_state, reason,
+                    version::text AS version, updated_at
+                `.pipe(Effect.flatMap(decodeAuthorityStateRows))
+                  const activatedRow = activatedRows[0]
+                  if (activatedRow === undefined) {
+                    return yield* fail('authority', 'invariant', 'PAPER authority was not activated')
+                  }
+                  return yield* authorityStateFromRow(activatedRow)
+                }),
+              ),
+            ),
+          ),
+        ),
+      )
+
     const lowerAuthority = (reason: string, updatedAt: string) =>
       run(
         'authority',
@@ -1053,9 +1685,9 @@ const makeStore = (config: Pick<RuntimeConfig, 'tigerBeetle'>) =>
       bindings,
       reconcile,
       ensureAuthorityGeneration,
+      activatePaperGeneration,
       restrictAuthority: lowerAuthority,
     } satisfies PaperStoreShape
   })
 
-export const PaperStoreLive = (config: Pick<RuntimeConfig, 'tigerBeetle'>) =>
-  Layer.effect(PaperStore, makeStore(config))
+export const PaperStoreLive = (config: PaperStoreRuntimeConfig) => Layer.effect(PaperStore, makeStore(config))

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -397,6 +397,7 @@ describe('OBSERVE runtime composition', () => {
           authorityInitializations += 1
           throw new Error('PAPER startup must not initialize synthetic OBSERVE authority')
         }),
+      activatePaperGeneration: () => unused,
       restrictAuthority: () => unused,
     }
     const cycleStore: CycleStoreShape = {

--- a/services/bayn/src/paper.test.ts
+++ b/services/bayn/src/paper.test.ts
@@ -25,12 +25,14 @@ import {
   decodeIntent,
   decodeOrder,
   decodePosition,
+  decodePaperAuthorityGeneration,
   decodeRateLimit,
   decodeReconciliation,
   decodeRiskDecision,
   decodeRiskInput,
   decodeValuation,
   isIntentTransitionAllowed,
+  makePaperAuthorityGeneration,
 } from './paper'
 
 const instant = '2026-07-22T06:00:00.000Z'
@@ -410,5 +412,62 @@ describe('paper contracts', () => {
         decodeAuthorityState({ ...observe, maximum: Authority.Paper, kill: KillState.Active, reason: 'operator kill' }),
       ),
     ).toMatchObject({ effective: Authority.Observe, kill: KillState.Active })
+  })
+
+  test('binds a PAPER authority generation to exact qualification, runtime, account, policy, and proof evidence', async () => {
+    const material = {
+      schemaVersion: 'bayn.paper-authority-generation.v1' as const,
+      maximum: Authority.Paper as const,
+      previousGenerationHash: hash('0'),
+      qualificationRunId: hash('1'),
+      qualificationLockId: hash('2'),
+      qualificationResultHash: hash('3'),
+      protocolHash: hash('4'),
+      qualificationExecutionPolicyHash: hash('5'),
+      qualificationSourceRevision: '6'.repeat(40),
+      qualificationImageRepository: 'registry.example.test/lab/bayn-qualification',
+      qualificationImageDigest: `sha256:${hash('7')}` as const,
+      activationSourceRevision: '8'.repeat(40),
+      activationImageRepository: 'registry.example.test/lab/bayn-activation',
+      activationImageDigest: `sha256:${hash('9')}` as const,
+      strategyName: 'risk-balanced-trend' as const,
+      strategyBehaviorHash: hash('a'),
+      strategyParameterHash: hash('b'),
+      strategyParameterSchemaVersion: 'bayn.risk-balanced-trend.protocol.v3' as const,
+      accountId: 'paper-account-1',
+      riskPolicyHash: hash('c'),
+      proofPlanHash: hash('d'),
+      reconciliationId: hash('e'),
+      reconciliationContentHash: hash('f'),
+    }
+    const generation = makePaperAuthorityGeneration(material)
+
+    expect(await Effect.runPromise(decodePaperAuthorityGeneration(generation))).toEqual(generation)
+    expect(generation.generationHash).toMatch(/^[0-9a-f]{64}$/)
+    expect(makePaperAuthorityGeneration(structuredClone(material))).toEqual(generation)
+    expect(
+      makePaperAuthorityGeneration({
+        ...material,
+        proofPlanHash: hash('0'),
+      }).generationHash,
+    ).not.toBe(generation.generationHash)
+    expect(
+      makePaperAuthorityGeneration({
+        ...material,
+        activationSourceRevision: '2'.repeat(40),
+      }).generationHash,
+    ).not.toBe(generation.generationHash)
+    await expectFailure(
+      decodePaperAuthorityGeneration({
+        ...generation,
+        generationHash: hash('1'),
+      }),
+    )
+    expect(() =>
+      makePaperAuthorityGeneration({
+        ...material,
+        strategyParameterSchemaVersion: 'bayn.risk-balanced-trend.protocol.v2' as never,
+      }),
+    ).toThrow()
   })
 })

--- a/services/bayn/src/paper.ts
+++ b/services/bayn/src/paper.ts
@@ -1,7 +1,10 @@
 import { Schema } from 'effect'
 
+import { canonicalHashV1 } from './hash'
 import {
+  ImageDigestSchema as ImageDigest,
   Sha256Schema as Sha256,
+  SourceRevisionSchema as SourceRevision,
   StrictNonEmptyStringSchema as NonEmptyString,
   SymbolSchema as SymbolName,
   UtcInstantSchema as UtcInstant,
@@ -575,6 +578,63 @@ export const ReconciliationSchema = ReconciliationBase.check(
 )
 export type Reconciliation = typeof ReconciliationSchema.Type
 
+export const PaperAuthorityGenerationMaterialSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.paper-authority-generation.v1'),
+  maximum: Schema.Literal(Authority.Paper),
+  previousGenerationHash: Sha256,
+  qualificationRunId: Sha256,
+  qualificationLockId: Sha256,
+  qualificationResultHash: Sha256,
+  protocolHash: Sha256,
+  qualificationExecutionPolicyHash: Sha256,
+  qualificationSourceRevision: SourceRevision,
+  qualificationImageRepository: NonEmptyString,
+  qualificationImageDigest: ImageDigest,
+  activationSourceRevision: SourceRevision,
+  activationImageRepository: NonEmptyString,
+  activationImageDigest: ImageDigest,
+  strategyName: Schema.Literal('risk-balanced-trend'),
+  strategyBehaviorHash: Sha256,
+  strategyParameterHash: Sha256,
+  strategyParameterSchemaVersion: Schema.Literal('bayn.risk-balanced-trend.protocol.v3'),
+  accountId: NonEmptyString,
+  riskPolicyHash: Sha256,
+  proofPlanHash: Sha256,
+  reconciliationId: Sha256,
+  reconciliationContentHash: Sha256,
+})
+export type PaperAuthorityGenerationMaterial = typeof PaperAuthorityGenerationMaterialSchema.Type
+
+const PaperAuthorityGenerationBase = Schema.Struct({
+  ...PaperAuthorityGenerationMaterialSchema.fields,
+  generationHash: Sha256,
+})
+
+export const PaperAuthorityGenerationSchema = PaperAuthorityGenerationBase.check(
+  Schema.makeFilter(
+    (generation: typeof PaperAuthorityGenerationBase.Type) => {
+      const { generationHash, ...material } = generation
+      return generationHash === canonicalHashV1(material)
+    },
+    { expected: 'a generation hash matching the complete PAPER authority material' },
+  ),
+)
+export type PaperAuthorityGeneration = typeof PaperAuthorityGenerationSchema.Type
+
+const decodePaperAuthorityGenerationMaterialSync = Schema.decodeUnknownSync(
+  PaperAuthorityGenerationMaterialSchema,
+  StrictParseOptions,
+)
+const decodePaperAuthorityGenerationSync = Schema.decodeUnknownSync(PaperAuthorityGenerationSchema, StrictParseOptions)
+
+export const makePaperAuthorityGeneration = (input: PaperAuthorityGenerationMaterial): PaperAuthorityGeneration => {
+  const material = decodePaperAuthorityGenerationMaterialSync(input)
+  return decodePaperAuthorityGenerationSync({
+    ...material,
+    generationHash: canonicalHashV1(material),
+  })
+}
+
 const AuthorityStateBase = Schema.Struct({
   schemaVersion: Schema.Literal('bayn.paper-authority.v1'),
   generationHash: Sha256,
@@ -619,4 +679,8 @@ export const decodeRiskDecision = Schema.decodeUnknownEffect(RiskDecisionSchema,
 export const decodeAccountingReceipt = Schema.decodeUnknownEffect(AccountingReceiptSchema, StrictParseOptions)
 export const decodeValuation = Schema.decodeUnknownEffect(ValuationSchema, StrictParseOptions)
 export const decodeReconciliation = Schema.decodeUnknownEffect(ReconciliationSchema, StrictParseOptions)
+export const decodePaperAuthorityGeneration = Schema.decodeUnknownEffect(
+  PaperAuthorityGenerationSchema,
+  StrictParseOptions,
+)
 export const decodeAuthorityState = Schema.decodeUnknownEffect(AuthorityStateSchema, StrictParseOptions)

--- a/services/bayn/src/reconciler.test.ts
+++ b/services/bayn/src/reconciler.test.ts
@@ -197,6 +197,7 @@ const makeStore = (control: StoreControl, hasAccountBaseline = true): PaperStore
       return report(snapshot)
     }),
   ensureAuthorityGeneration: () => Effect.die(new Error('unexpected authority generation initialization')),
+  activatePaperGeneration: () => Effect.die(new Error('unexpected PAPER authority activation')),
   restrictAuthority: (reason) =>
     Effect.sync(() => {
       control.restrictions.push(reason)


### PR DESCRIPTION
## Summary

- Add the canonical `bayn.paper-authority-generation.v1` contract binding the previous generation, exact qualification/runtime/strategy evidence, account reconciliation, risk policy, and bounded proof plan.
- Add append-only `authority_generations` history and structural database transition checks that prevent unaudited initialization and generation reuse while preserving kill state and reason.
- Add one WriterFence-serialized `PaperStore.activatePaperGeneration` transaction that independently validates the configured PAPER/account/generation/qualification/running-strategy binding, terminal QUALIFIED evidence, final-time reconciliation freshness, and zero unresolved mutation before rotating maximum authority to PAPER; identical replay is no-write.

## Related Issues

Related to PROOMPT-375. This source-only prerequisite does not close the issue and is not composed into production.

## Testing

- `bun run test` in `services/bayn` — 354 passed, 82 PostgreSQL-gated tests skipped, 0 failed.
- PostgreSQL 18 EvidenceStore integration — 38 passed.
- PostgreSQL 18 PaperStore integration — 21 passed.
- PostgreSQL 18 CycleStore integration — 13 passed.
- PostgreSQL 18 cycle observability integration — 3 passed.
- `bun test packages/scripts/src/bayn` — 20 passed.
- `bun run lint`, `bun run lint:oxlint`, `bun run lint:oxlint:type`, `bun run tsc`, and `bun run build` in `services/bayn`.
- Exact-head CI, PostgreSQL, amd64 image, and arm64 image checks passed.

## Breaking Changes

Migration 0014 adds immutable authority generation history and intentionally rejects migration from an already-PAPER singleton because that state lacks audited activation history. No production caller, credentials, capital authority, broker mutation, or deployment configuration is added. Direct authority DML remains unsupported; `activatePaperGeneration` is the sole application writer.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; no UI changed.
- [x] Breaking Changes are documented; remaining composition and live proof stay tracked by PROOMPT-375.
