### PR TITLE
fix(bayn): derive paper authority from durable evidence

### DIFF
--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -372,6 +372,12 @@ const makeMutationPaperAuthorityGeneration = (
   })
 }
 
+const proofBinding = (activation: PaperAuthorityGeneration) => ({
+  schemaVersion: 'bayn.paper-authority-proof-binding.v1' as const,
+  riskPolicyHash: activation.riskPolicyHash,
+  proofPlanHash: activation.proofPlanHash,
+})
+
 const makePaperActivationConfig = (activation: PaperAuthorityGeneration): RuntimeConfig => {
   const config = makeConfig()
   return {
@@ -516,7 +522,7 @@ const activateAuditedPaperAuthority = async () => {
           generationHash: observeGenerationHash,
           maximum: Authority.Observe,
         })
-        yield* store.activatePaperGeneration(activation)
+        yield* store.activatePaperGeneration(proofBinding(activation))
       }),
     )
   } finally {
@@ -1125,7 +1131,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
             }
 
             const activationFiber = yield* Effect.forkChild(
-              Effect.exit(paperStore.activatePaperGeneration(paperActivation)),
+              Effect.exit(paperStore.activatePaperGeneration(proofBinding(paperActivation))),
               { startImmediately: true },
             )
             yield* Effect.sleep(Duration.millis(20))
@@ -1148,7 +1154,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       expect(observed.activationFailure).toMatchObject({
         operation: 'authority',
         failure: 'invariant',
-        message: 'PAPER activation requires zero unresolved mutations covered by reconciliation',
+        message: 'PAPER generation requires zero unresolved mutations covered by reconciliation',
       })
       expect(observed.after).toEqual(observed.before)
     } finally {

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -387,6 +387,12 @@ const makeActivation = (
     ...overrides,
   })
 
+const proofBinding = (activation: PaperAuthorityGeneration) => ({
+  schemaVersion: 'bayn.paper-authority-proof-binding.v1' as const,
+  riskPolicyHash: activation.riskPolicyHash,
+  proofPlanHash: activation.proofPlanHash,
+})
+
 const paperRuntimeConfig = (
   activation: PaperAuthorityGeneration,
   overrides: Partial<RuntimeConfig> = {},
@@ -410,6 +416,22 @@ const paperRuntimeConfig = (
   },
   ...overrides,
 })
+
+const prepareRuntimeConfig = (activation: PaperAuthorityGeneration): RuntimeConfig => {
+  const runtimeConfig = paperRuntimeConfig(activation)
+  const alpaca = runtimeConfig.alpaca
+  if (alpaca === undefined) {
+    throw new Error('PAPER PREPARE fixture requires an Alpaca binding')
+  }
+  return {
+    ...runtimeConfig,
+    maximumAuthority: Authority.Observe,
+    alpaca: {
+      ...alpaca,
+      authorityGenerationHash: activation.previousGenerationHash,
+    },
+  }
+}
 
 const makeActivationRuntime = (
   control: JournalControl,
@@ -830,7 +852,7 @@ describePostgres('paper accounting persistence', () => {
             generationHash: observeGenerationHash,
             maximum: Authority.Observe,
           })
-          yield* store.activatePaperGeneration(activation)
+          yield* store.activatePaperGeneration(proofBinding(activation))
           const [beforeConflict] = yield* sql<{ tuple_id: string; version: number }>`
             SELECT xmin::text AS tuple_id, version::integer FROM authority_state
           `
@@ -865,6 +887,254 @@ describePostgres('paper accounting persistence', () => {
       expect(result.afterConflict).toEqual(result.beforeConflict)
     } finally {
       await runtime.dispose()
+    }
+  }, 15_000)
+
+  test('prepares one deterministic PAPER receipt without writes and activates it from unchanged durable inputs', async () => {
+    const initialGenerationHash = hash('prepared-paper-observe-generation')
+    const reconciliation = exactReconciliation('prepared-paper')
+    const expected = makeActivation(initialGenerationHash, qualifiedEvidence, reconciliation)
+    const prepareRuntime = makeStoreRuntime({ fail: false, planHashes: [] }, prepareRuntimeConfig(expected))
+    const preparation = await (async () => {
+      try {
+        return await prepareRuntime.runPromise(
+          Effect.gen(function* () {
+            const store = yield* PaperStore
+            const sql = yield* PgClient.PgClient
+            yield* seedQualificationEvidence(qualifiedEvidence)
+            yield* seedExactReconciliation(reconciliation)
+            yield* store.ensureAuthorityGeneration({
+              generationHash: initialGenerationHash,
+              maximum: Authority.Observe,
+            })
+            const readAuthorityEvidence = sql<{ authority: unknown; history: unknown }>`
+              SELECT
+                (
+                  SELECT jsonb_agg(
+                    jsonb_build_object('row', to_jsonb(authority), 'tupleId', authority.xmin::text)
+                  )
+                  FROM authority_state AS authority
+                ) AS authority,
+                (
+                  SELECT jsonb_agg(
+                    jsonb_build_object('row', to_jsonb(history), 'tupleId', history.xmin::text)
+                    ORDER BY history.authority_version
+                  )
+                  FROM authority_generations AS history
+                ) AS history
+            `
+            const [before] = yield* readAuthorityEvidence
+            const first = yield* store.preparePaperGeneration(proofBinding(expected))
+            const second = yield* store.preparePaperGeneration(proofBinding(expected))
+            const [after] = yield* readAuthorityEvidence
+            return { after, before, first, second }
+          }),
+        )
+      } finally {
+        await prepareRuntime.dispose()
+      }
+    })()
+
+    expect(preparation.first).toEqual(expected)
+    expect(preparation.second).toEqual(preparation.first)
+    expect(preparation.after).toEqual(preparation.before)
+
+    const activationRuntime = makeActivationRuntime({ fail: false, planHashes: [] }, preparation.first)
+    try {
+      const activated = await activationRuntime.runPromise(
+        Effect.flatMap(PaperStore, (store) => store.activatePaperGeneration(proofBinding(preparation.first))),
+      )
+      expect(activated).toMatchObject({
+        generationHash: preparation.first.generationHash,
+        maximum: Authority.Paper,
+        effective: Authority.Paper,
+        version: 2,
+      })
+    } finally {
+      await activationRuntime.dispose()
+    }
+  }, 15_000)
+
+  test('rejects PREPARE when configured OBSERVE generation is not current without writing', async () => {
+    const initialGenerationHash = hash('prepare-config-mismatch-observe')
+    const reconciliation = exactReconciliation('prepare-config-mismatch')
+    const expected = makeActivation(initialGenerationHash, qualifiedEvidence, reconciliation)
+    const setupRuntime = makeStoreRuntime({ fail: false, planHashes: [] }, prepareRuntimeConfig(expected))
+    try {
+      await setupRuntime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* PaperStore
+          yield* seedQualificationEvidence(qualifiedEvidence)
+          yield* seedExactReconciliation(reconciliation)
+          yield* store.ensureAuthorityGeneration({
+            generationHash: initialGenerationHash,
+            maximum: Authority.Observe,
+          })
+        }),
+      )
+    } finally {
+      await setupRuntime.dispose()
+    }
+
+    const validConfig = prepareRuntimeConfig(expected)
+    const validAlpaca = validConfig.alpaca
+    if (validAlpaca === undefined) {
+      throw new Error('PAPER PREPARE fixture requires an Alpaca binding')
+    }
+    const runtime = makeStoreRuntime(
+      { fail: false, planHashes: [] },
+      {
+        ...validConfig,
+        alpaca: {
+          ...validAlpaca,
+          authorityGenerationHash: hash('wrong-current-observe-generation'),
+        },
+      },
+    )
+    try {
+      const result = await runtime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* PaperStore
+          const sql = yield* PgClient.PgClient
+          const readAuthorityEvidence = sql<{ authority: unknown; history: unknown }>`
+            SELECT
+              (SELECT jsonb_agg(to_jsonb(authority)) FROM authority_state AS authority) AS authority,
+              (
+                SELECT jsonb_agg(to_jsonb(history) ORDER BY history.authority_version)
+                FROM authority_generations AS history
+              ) AS history
+          `
+          const [before] = yield* readAuthorityEvidence
+          const failure = yield* Effect.flip(store.preparePaperGeneration(proofBinding(expected)))
+          const [after] = yield* readAuthorityEvidence
+          return { after, before, failure }
+        }),
+      )
+      expect(result.failure).toMatchObject({
+        operation: 'authority',
+        failure: 'invariant',
+        message: 'PAPER PREPARE current authority differs from the configured OBSERVE generation',
+      })
+      expect(result.after).toEqual(result.before)
+    } finally {
+      await runtime.dispose()
+    }
+  }, 15_000)
+
+  test('rejects reconciliation drift between PREPARE and activation without authority writes', async () => {
+    const initialGenerationHash = hash('prepare-reconciliation-drift-observe')
+    const reconciliation = exactReconciliation('prepare-reconciliation-drift')
+    const expected = makeActivation(initialGenerationHash, qualifiedEvidence, reconciliation)
+    const prepareRuntime = makeStoreRuntime({ fail: false, planHashes: [] }, prepareRuntimeConfig(expected))
+    const prepared = await (async () => {
+      try {
+        return await prepareRuntime.runPromise(
+          Effect.gen(function* () {
+            const store = yield* PaperStore
+            yield* seedQualificationEvidence(qualifiedEvidence)
+            yield* seedExactReconciliation(reconciliation)
+            yield* store.ensureAuthorityGeneration({
+              generationHash: initialGenerationHash,
+              maximum: Authority.Observe,
+            })
+            const receipt = yield* store.preparePaperGeneration(proofBinding(expected))
+            yield* seedExactReconciliation(exactReconciliation('post-prepare-reconciliation'))
+            return receipt
+          }),
+        )
+      } finally {
+        await prepareRuntime.dispose()
+      }
+    })()
+
+    const activationRuntime = makeActivationRuntime({ fail: false, planHashes: [] }, prepared)
+    try {
+      const result = await activationRuntime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* PaperStore
+          const sql = yield* PgClient.PgClient
+          const readAuthorityEvidence = sql<{ authority: unknown; history: unknown }>`
+            SELECT
+              (SELECT jsonb_agg(to_jsonb(authority)) FROM authority_state AS authority) AS authority,
+              (
+                SELECT jsonb_agg(to_jsonb(history) ORDER BY history.authority_version)
+                FROM authority_generations AS history
+              ) AS history
+          `
+          const [before] = yield* readAuthorityEvidence
+          const failure = yield* Effect.flip(store.activatePaperGeneration(proofBinding(prepared)))
+          const [after] = yield* readAuthorityEvidence
+          return { after, before, failure }
+        }),
+      )
+      expect(result.failure).toMatchObject({
+        operation: 'authority',
+        failure: 'invariant',
+        message: 'derived PAPER generation differs from the configured generation',
+      })
+      expect(result.after).toEqual(result.before)
+    } finally {
+      await activationRuntime.dispose()
+    }
+  }, 15_000)
+
+  test('rejects current-generation drift between PREPARE and activation without further writes', async () => {
+    const initialGenerationHash = hash('prepare-generation-drift-observe')
+    const reconciliation = exactReconciliation('prepare-generation-drift')
+    const expected = makeActivation(initialGenerationHash, qualifiedEvidence, reconciliation)
+    const prepareRuntime = makeStoreRuntime({ fail: false, planHashes: [] }, prepareRuntimeConfig(expected))
+    const prepared = await (async () => {
+      try {
+        return await prepareRuntime.runPromise(
+          Effect.gen(function* () {
+            const store = yield* PaperStore
+            yield* seedQualificationEvidence(qualifiedEvidence)
+            yield* seedExactReconciliation(reconciliation)
+            yield* store.ensureAuthorityGeneration({
+              generationHash: initialGenerationHash,
+              maximum: Authority.Observe,
+            })
+            const receipt = yield* store.preparePaperGeneration(proofBinding(expected))
+            yield* store.ensureAuthorityGeneration({
+              generationHash: hash('post-prepare-observe-generation'),
+              maximum: Authority.Observe,
+            })
+            return receipt
+          }),
+        )
+      } finally {
+        await prepareRuntime.dispose()
+      }
+    })()
+
+    const activationRuntime = makeActivationRuntime({ fail: false, planHashes: [] }, prepared)
+    try {
+      const result = await activationRuntime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* PaperStore
+          const sql = yield* PgClient.PgClient
+          const readAuthorityEvidence = sql<{ authority: unknown; history: unknown }>`
+            SELECT
+              (SELECT jsonb_agg(to_jsonb(authority)) FROM authority_state AS authority) AS authority,
+              (
+                SELECT jsonb_agg(to_jsonb(history) ORDER BY history.authority_version)
+                FROM authority_generations AS history
+              ) AS history
+          `
+          const [before] = yield* readAuthorityEvidence
+          const failure = yield* Effect.flip(store.activatePaperGeneration(proofBinding(prepared)))
+          const [after] = yield* readAuthorityEvidence
+          return { after, before, failure }
+        }),
+      )
+      expect(result.failure).toMatchObject({
+        operation: 'authority',
+        failure: 'invariant',
+        message: 'derived PAPER generation differs from the configured generation',
+      })
+      expect(result.after).toEqual(result.before)
+    } finally {
+      await activationRuntime.dispose()
     }
   }, 15_000)
 
@@ -942,7 +1212,7 @@ describePostgres('paper accounting persistence', () => {
       try {
         failures.push(
           await runtime.runPromise(
-            Effect.flatMap(PaperStore, (store) => Effect.flip(store.activatePaperGeneration(activation))),
+            Effect.flatMap(PaperStore, (store) => Effect.flip(store.activatePaperGeneration(proofBinding(activation)))),
           ),
         )
       } finally {
@@ -956,7 +1226,9 @@ describePostgres('paper accounting persistence', () => {
     const wrongBuildFailure = await (async () => {
       try {
         return await wrongBuildRuntime.runPromise(
-          Effect.flatMap(PaperStore, (store) => Effect.flip(store.activatePaperGeneration(wrongBuildActivation))),
+          Effect.flatMap(PaperStore, (store) =>
+            Effect.flip(store.activatePaperGeneration(proofBinding(wrongBuildActivation))),
+          ),
         )
       } finally {
         await wrongBuildRuntime.dispose()
@@ -972,7 +1244,7 @@ describePostgres('paper accounting persistence', () => {
     const wrongStrategyFailure = await (async () => {
       try {
         return await wrongStrategyRuntime.runPromise(
-          Effect.flatMap(PaperStore, (store) => Effect.flip(store.activatePaperGeneration(activation))),
+          Effect.flatMap(PaperStore, (store) => Effect.flip(store.activatePaperGeneration(proofBinding(activation)))),
         )
       } finally {
         await wrongStrategyRuntime.dispose()
@@ -989,7 +1261,7 @@ describePostgres('paper accounting persistence', () => {
     const correctRuntime = makeActivationRuntime({ fail: false, planHashes: [] }, activation)
     try {
       const activated = await correctRuntime.runPromise(
-        Effect.flatMap(PaperStore, (store) => store.activatePaperGeneration(activation)),
+        Effect.flatMap(PaperStore, (store) => store.activatePaperGeneration(proofBinding(activation))),
       )
       expect(activated).toMatchObject({
         generationHash: activation.generationHash,
@@ -1006,19 +1278,17 @@ describePostgres('paper accounting persistence', () => {
       expect(failure).toMatchObject({
         operation: 'authority',
         failure: 'invariant',
-        message:
-          'PAPER activation differs from the configured authority, account, generation, or qualification binding',
       })
     }
     expect(wrongBuildFailure).toMatchObject({
       operation: 'authority',
       failure: 'invariant',
-      message: 'PAPER activation provenance differs from the current embedded build',
+      message: 'derived PAPER generation differs from the configured generation',
     })
     expect(wrongStrategyFailure).toMatchObject({
       operation: 'authority',
       failure: 'invariant',
-      message: 'PAPER activation strategy identity differs from the current embedded build',
+      message: 'PAPER generation differs from terminal qualification evidence or current strategy build',
     })
     expect(afterRejected).toEqual(before)
   }, 15_000)
@@ -1039,7 +1309,7 @@ describePostgres('paper accounting persistence', () => {
             generationHash: initialGenerationHash,
             maximum: Authority.Observe,
           })
-          const activated = yield* store.activatePaperGeneration(activation)
+          const activated = yield* store.activatePaperGeneration(proofBinding(activation))
           const [beforeReplay] = yield* sql<{
             authority_tuple: string
             history_count: number
@@ -1053,7 +1323,14 @@ describePostgres('paper accounting persistence', () => {
             JOIN authority_generations AS paper
               ON paper.generation_hash = authority.generation_hash
           `
-          const replay = yield* store.activatePaperGeneration(activation)
+          yield* seedExactReconciliation(exactReconciliation('paper-replay-later-reconciliation'))
+          const replay = yield* store.activatePaperGeneration(proofBinding(activation))
+          const changedProof = yield* Effect.flip(
+            store.activatePaperGeneration({
+              ...proofBinding(activation),
+              proofPlanHash: hash('paper-replay-changed-proof'),
+            }),
+          )
           const [afterReplay] = yield* sql<{
             authority_tuple: string
             history_count: number
@@ -1107,6 +1384,7 @@ describePostgres('paper accounting persistence', () => {
             activation,
             afterReplay,
             beforeReplay,
+            changedProof,
             deleteHistory,
             history,
             mutateHistory,
@@ -1126,6 +1404,7 @@ describePostgres('paper accounting persistence', () => {
         updatedAt: expect.any(String),
       })
       expect(result.replay).toEqual(result.activated)
+      expect(result.changedProof).toMatchObject({ operation: 'authority', failure: 'conflict' })
       expect(result.afterReplay).toEqual(result.beforeReplay)
       expect(Exit.isFailure(result.mutateHistory)).toBe(true)
       expect(Exit.isFailure(result.deleteHistory)).toBe(true)
@@ -1172,6 +1451,77 @@ describePostgres('paper accounting persistence', () => {
     }
   }, 15_000)
 
+  test('rejects changed configured replay identity byte-identically', async () => {
+    const initialGenerationHash = hash('paper-replay-config-observe-generation')
+    const reconciliation = exactReconciliation('paper-replay-config')
+    const activation = makeActivation(initialGenerationHash, qualifiedEvidence, reconciliation)
+    const activationRuntime = makeActivationRuntime({ fail: false, planHashes: [] }, activation)
+    try {
+      await activationRuntime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* PaperStore
+          yield* seedQualificationEvidence(qualifiedEvidence)
+          yield* seedExactReconciliation(reconciliation)
+          yield* store.ensureAuthorityGeneration({
+            generationHash: initialGenerationHash,
+            maximum: Authority.Observe,
+          })
+          yield* store.activatePaperGeneration(proofBinding(activation))
+        }),
+      )
+    } finally {
+      await activationRuntime.dispose()
+    }
+
+    const validConfig = paperRuntimeConfig(activation)
+    const validAlpaca = validConfig.alpaca
+    if (validAlpaca === undefined) {
+      throw new Error('PAPER replay fixture requires an Alpaca binding')
+    }
+    const replayRuntime = makeStoreRuntime(
+      { fail: false, planHashes: [] },
+      {
+        ...validConfig,
+        alpaca: {
+          ...validAlpaca,
+          accountId: 'changed-replay-account',
+        },
+      },
+    )
+    try {
+      const result = await replayRuntime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* PaperStore
+          const sql = yield* PgClient.PgClient
+          const readAuthorityEvidence = sql<{ authority: unknown; history: unknown }>`
+            SELECT
+              (
+                SELECT jsonb_agg(
+                  jsonb_build_object('row', to_jsonb(authority), 'tupleId', authority.xmin::text)
+                )
+                FROM authority_state AS authority
+              ) AS authority,
+              (
+                SELECT jsonb_agg(
+                  jsonb_build_object('row', to_jsonb(history), 'tupleId', history.xmin::text)
+                  ORDER BY history.authority_version
+                )
+                FROM authority_generations AS history
+              ) AS history
+          `
+          const [before] = yield* readAuthorityEvidence
+          const failure = yield* Effect.flip(store.activatePaperGeneration(proofBinding(activation)))
+          const [after] = yield* readAuthorityEvidence
+          return { after, before, failure }
+        }),
+      )
+      expect(result.failure).toMatchObject({ operation: 'authority', failure: 'conflict' })
+      expect(result.after).toEqual(result.before)
+    } finally {
+      await replayRuntime.dispose()
+    }
+  }, 15_000)
+
   test('rejects the exact reconciliation staleness boundary and future database time without writing', async () => {
     const initialGenerationHash = hash('reconciliation-time-observe-generation')
     const staleReconciliation = exactReconciliation('stale-reconciliation-time', config.reconciliationStaleThresholdMs)
@@ -1201,7 +1551,7 @@ describePostgres('paper accounting persistence', () => {
             })
             const before = yield* readAuthorityEvidence
             yield* seedExactReconciliation(staleReconciliation)
-            const failure = yield* Effect.flip(store.activatePaperGeneration(staleActivation))
+            const failure = yield* Effect.flip(store.activatePaperGeneration(proofBinding(staleActivation)))
             const after = yield* readAuthorityEvidence
             return { after, before, failure }
           }),
@@ -1218,7 +1568,7 @@ describePostgres('paper accounting persistence', () => {
         Effect.gen(function* () {
           const store = yield* PaperStore
           yield* seedExactReconciliation(futureReconciliation)
-          const failure = yield* Effect.flip(store.activatePaperGeneration(futureActivation))
+          const failure = yield* Effect.flip(store.activatePaperGeneration(proofBinding(futureActivation)))
           const after = yield* readAuthorityEvidence
           return { after, failure }
         }),
@@ -1227,12 +1577,12 @@ describePostgres('paper accounting persistence', () => {
       expect(staleResult.failure).toMatchObject({
         operation: 'authority',
         failure: 'invariant',
-        message: 'PAPER activation requires the latest fresh exact account reconciliation',
+        message: 'PAPER generation requires the latest fresh exact account reconciliation',
       })
       expect(futureResult.failure).toMatchObject({
         operation: 'authority',
         failure: 'invariant',
-        message: 'PAPER activation requires the latest fresh exact account reconciliation',
+        message: 'PAPER generation requires the latest fresh exact account reconciliation',
       })
       expect(staleResult.after).toEqual(staleResult.before)
       expect(futureResult.after).toEqual(staleResult.before)
@@ -1291,7 +1641,7 @@ describePostgres('paper accounting persistence', () => {
           yield* Deferred.await(lockHeld)
           return yield* Effect.gen(function* () {
             const activationFiber = yield* Effect.forkChild(
-              Effect.exit(store.activatePaperGeneration(paperActivation)),
+              Effect.exit(store.activatePaperGeneration(proofBinding(paperActivation))),
               { startImmediately: true },
             )
             let waiting = false
@@ -1326,7 +1676,7 @@ describePostgres('paper accounting persistence', () => {
       expect(Exit.isFailure(result.activationExit)).toBe(true)
       if (Exit.isFailure(result.activationExit)) {
         expect(Cause.pretty(result.activationExit.cause)).toContain(
-          'PAPER activation requires the latest fresh exact account reconciliation',
+          'PAPER generation requires the latest fresh exact account reconciliation',
         )
       }
       expect(result.after).toEqual(result.before)
@@ -1352,7 +1702,7 @@ describePostgres('paper accounting persistence', () => {
             maximum: Authority.Observe,
           })
           const states = yield* Effect.all(
-            Array.from({ length: 12 }, () => store.activatePaperGeneration(activation)),
+            Array.from({ length: 12 }, () => store.activatePaperGeneration(proofBinding(activation))),
             { concurrency: 'unbounded' },
           )
           const sql = yield* PgClient.PgClient
@@ -1413,7 +1763,7 @@ describePostgres('paper accounting persistence', () => {
             SELECT kill_state, reason, updated_at, version::integer
             FROM authority_state
           `
-          const activated = yield* store.activatePaperGeneration(activation)
+          const activated = yield* store.activatePaperGeneration(proofBinding(activation))
           return { activated, before }
         }),
       )
@@ -1431,7 +1781,7 @@ describePostgres('paper accounting persistence', () => {
     }
   }, 15_000)
 
-  test('rejects reused generations and every qualification or reconciliation mismatch without writing', async () => {
+  test('rejects changed proof material and reconciliation drift without writing', async () => {
     const initialGenerationHash = hash('mismatch-paper-observe-generation')
     const reconciliation = exactReconciliation('mismatch-paper-activation')
     const activation = makeActivation(initialGenerationHash, qualifiedEvidence, reconciliation)
@@ -1455,23 +1805,11 @@ describePostgres('paper accounting persistence', () => {
                 FROM authority_generations AS history
               ) AS history
           `
-          const mismatches = [
-            { qualificationSourceRevision: 'f'.repeat(40) },
-            { qualificationImageDigest: `sha256:${'e'.repeat(64)}` as const },
-            { activationSourceRevision: 'f'.repeat(40) },
-            { strategyBehaviorHash: hash('wrong-strategy-behavior') },
-            { strategyParameterHash: hash('wrong-strategy-parameters') },
-            { qualificationResultHash: hash('wrong-qualification-result') },
-            { qualificationExecutionPolicyHash: hash('wrong-execution-policy') },
-            { accountId: 'another-paper-account' },
-            { reconciliationContentHash: hash('wrong-reconciliation-content') },
-          ] as const
-          const failures = yield* Effect.forEach(mismatches, (overrides) =>
-            Effect.flip(
-              store.activatePaperGeneration(
-                makeActivation(initialGenerationHash, qualifiedEvidence, reconciliation, overrides),
-              ),
-            ),
+          const changedProof = yield* Effect.flip(
+            store.activatePaperGeneration({
+              ...proofBinding(activation),
+              proofPlanHash: hash('changed-paper-proof-plan'),
+            }),
           )
           yield* sql`
             INSERT INTO reconciliations (
@@ -1484,7 +1822,7 @@ describePostgres('paper accounting persistence', () => {
               clock_timestamp()
             )
           `
-          const stale = yield* Effect.flip(store.activatePaperGeneration(activation))
+          const stale = yield* Effect.flip(store.activatePaperGeneration(proofBinding(activation)))
           const [after] = yield* sql<{ authority: unknown; history: unknown }>`
             SELECT
               (SELECT jsonb_agg(to_jsonb(authority)) FROM authority_state AS authority) AS authority,
@@ -1493,12 +1831,11 @@ describePostgres('paper accounting persistence', () => {
                 FROM authority_generations AS history
               ) AS history
           `
-          return { after, before, failures, stale }
+          return { after, before, changedProof, stale }
         }),
       )
 
-      expect(result.failures).toHaveLength(9)
-      expect(result.failures.every((failure) => failure.operation === 'authority')).toBe(true)
+      expect(result.changedProof).toMatchObject({ operation: 'authority', failure: 'invariant' })
       expect(result.stale).toMatchObject({ operation: 'authority', failure: 'invariant' })
       expect(result.after).toEqual(result.before)
     } finally {
@@ -1523,7 +1860,7 @@ describePostgres('paper accounting persistence', () => {
               generationHash: initialGenerationHash,
               maximum: Authority.Observe,
             })
-            return yield* Effect.flip(store.activatePaperGeneration(rejectedActivation))
+            return yield* Effect.flip(store.activatePaperGeneration(proofBinding(rejectedActivation)))
           }),
         )
       } finally {
@@ -1562,7 +1899,7 @@ describePostgres('paper accounting persistence', () => {
             )
           `
           yield* seedQualificationEvidence(qualifiedEvidence)
-          const unresolved = yield* Effect.flip(store.activatePaperGeneration(qualifiedActivation))
+          const unresolved = yield* Effect.flip(store.activatePaperGeneration(proofBinding(qualifiedActivation)))
           const [stored] = yield* sql<{ generation_hash: string; history_count: number; version: number }>`
             SELECT
               generation_hash,
@@ -1602,7 +1939,7 @@ describePostgres('paper accounting persistence', () => {
             generationHash: firstObserveHash,
             maximum: Authority.Observe,
           })
-          yield* store.activatePaperGeneration(activation)
+          yield* store.activatePaperGeneration(proofBinding(activation))
           const returned = yield* store.ensureAuthorityGeneration({
             generationHash: returnObserveHash,
             maximum: Authority.Observe,
@@ -2306,7 +2643,7 @@ describePostgres('paper accounting persistence', () => {
         Effect.gen(function* () {
           const store = yield* PaperStore
           const sql = yield* PgClient.PgClient
-          const activated = yield* store.activatePaperGeneration(activation)
+          const activated = yield* store.activatePaperGeneration(proofBinding(activation))
           yield* sql`
             INSERT INTO valuations (
               valuation_id, schema_version, account_id, source_hash, cash_micros,

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -251,6 +251,27 @@ const makeClientRuntime = () => ManagedRuntime.make(PostgresClientLive(config).p
 
 const makeEvidenceRuntime = () => ManagedRuntime.make(EvidenceStoreLive(config).pipe(Layer.provide(NodeServices.layer)))
 
+const readAuthorityTupleEvidence = Effect.gen(function* () {
+  const sql = yield* PgClient.PgClient
+  const [evidence] = yield* sql<{ authority: unknown; history: unknown }>`
+    SELECT
+      (
+        SELECT jsonb_agg(
+          jsonb_build_object('row', to_jsonb(authority), 'tupleId', authority.xmin::text)
+        )
+        FROM authority_state AS authority
+      ) AS authority,
+      (
+        SELECT jsonb_agg(
+          jsonb_build_object('row', to_jsonb(history), 'tupleId', history.xmin::text)
+          ORDER BY history.authority_version
+        )
+        FROM authority_generations AS history
+      ) AS history
+  `
+  return evidence
+})
+
 const seedQualificationEvidence = (fixture: QualificationFixture) =>
   Effect.gen(function* () {
     const sql = yield* PgClient.PgClient
@@ -900,33 +921,16 @@ describePostgres('paper accounting persistence', () => {
         return await prepareRuntime.runPromise(
           Effect.gen(function* () {
             const store = yield* PaperStore
-            const sql = yield* PgClient.PgClient
             yield* seedQualificationEvidence(qualifiedEvidence)
             yield* seedExactReconciliation(reconciliation)
             yield* store.ensureAuthorityGeneration({
               generationHash: initialGenerationHash,
               maximum: Authority.Observe,
             })
-            const readAuthorityEvidence = sql<{ authority: unknown; history: unknown }>`
-              SELECT
-                (
-                  SELECT jsonb_agg(
-                    jsonb_build_object('row', to_jsonb(authority), 'tupleId', authority.xmin::text)
-                  )
-                  FROM authority_state AS authority
-                ) AS authority,
-                (
-                  SELECT jsonb_agg(
-                    jsonb_build_object('row', to_jsonb(history), 'tupleId', history.xmin::text)
-                    ORDER BY history.authority_version
-                  )
-                  FROM authority_generations AS history
-                ) AS history
-            `
-            const [before] = yield* readAuthorityEvidence
+            const before = yield* readAuthorityTupleEvidence
             const first = yield* store.preparePaperGeneration(proofBinding(expected))
             const second = yield* store.preparePaperGeneration(proofBinding(expected))
-            const [after] = yield* readAuthorityEvidence
+            const after = yield* readAuthorityTupleEvidence
             return { after, before, first, second }
           }),
         )
@@ -995,18 +999,9 @@ describePostgres('paper accounting persistence', () => {
       const result = await runtime.runPromise(
         Effect.gen(function* () {
           const store = yield* PaperStore
-          const sql = yield* PgClient.PgClient
-          const readAuthorityEvidence = sql<{ authority: unknown; history: unknown }>`
-            SELECT
-              (SELECT jsonb_agg(to_jsonb(authority)) FROM authority_state AS authority) AS authority,
-              (
-                SELECT jsonb_agg(to_jsonb(history) ORDER BY history.authority_version)
-                FROM authority_generations AS history
-              ) AS history
-          `
-          const [before] = yield* readAuthorityEvidence
+          const before = yield* readAuthorityTupleEvidence
           const failure = yield* Effect.flip(store.preparePaperGeneration(proofBinding(expected)))
-          const [after] = yield* readAuthorityEvidence
+          const after = yield* readAuthorityTupleEvidence
           return { after, before, failure }
         }),
       )
@@ -1052,18 +1047,9 @@ describePostgres('paper accounting persistence', () => {
       const result = await activationRuntime.runPromise(
         Effect.gen(function* () {
           const store = yield* PaperStore
-          const sql = yield* PgClient.PgClient
-          const readAuthorityEvidence = sql<{ authority: unknown; history: unknown }>`
-            SELECT
-              (SELECT jsonb_agg(to_jsonb(authority)) FROM authority_state AS authority) AS authority,
-              (
-                SELECT jsonb_agg(to_jsonb(history) ORDER BY history.authority_version)
-                FROM authority_generations AS history
-              ) AS history
-          `
-          const [before] = yield* readAuthorityEvidence
+          const before = yield* readAuthorityTupleEvidence
           const failure = yield* Effect.flip(store.activatePaperGeneration(proofBinding(prepared)))
-          const [after] = yield* readAuthorityEvidence
+          const after = yield* readAuthorityTupleEvidence
           return { after, before, failure }
         }),
       )
@@ -1112,18 +1098,9 @@ describePostgres('paper accounting persistence', () => {
       const result = await activationRuntime.runPromise(
         Effect.gen(function* () {
           const store = yield* PaperStore
-          const sql = yield* PgClient.PgClient
-          const readAuthorityEvidence = sql<{ authority: unknown; history: unknown }>`
-            SELECT
-              (SELECT jsonb_agg(to_jsonb(authority)) FROM authority_state AS authority) AS authority,
-              (
-                SELECT jsonb_agg(to_jsonb(history) ORDER BY history.authority_version)
-                FROM authority_generations AS history
-              ) AS history
-          `
-          const [before] = yield* readAuthorityEvidence
+          const before = yield* readAuthorityTupleEvidence
           const failure = yield* Effect.flip(store.activatePaperGeneration(proofBinding(prepared)))
-          const [after] = yield* readAuthorityEvidence
+          const after = yield* readAuthorityTupleEvidence
           return { after, before, failure }
         }),
       )
@@ -1492,26 +1469,9 @@ describePostgres('paper accounting persistence', () => {
       const result = await replayRuntime.runPromise(
         Effect.gen(function* () {
           const store = yield* PaperStore
-          const sql = yield* PgClient.PgClient
-          const readAuthorityEvidence = sql<{ authority: unknown; history: unknown }>`
-            SELECT
-              (
-                SELECT jsonb_agg(
-                  jsonb_build_object('row', to_jsonb(authority), 'tupleId', authority.xmin::text)
-                )
-                FROM authority_state AS authority
-              ) AS authority,
-              (
-                SELECT jsonb_agg(
-                  jsonb_build_object('row', to_jsonb(history), 'tupleId', history.xmin::text)
-                  ORDER BY history.authority_version
-                )
-                FROM authority_generations AS history
-              ) AS history
-          `
-          const [before] = yield* readAuthorityEvidence
+          const before = yield* readAuthorityTupleEvidence
           const failure = yield* Effect.flip(store.activatePaperGeneration(proofBinding(activation)))
-          const [after] = yield* readAuthorityEvidence
+          const after = yield* readAuthorityTupleEvidence
           return { after, before, failure }
         }),
       )
@@ -1797,14 +1757,7 @@ describePostgres('paper accounting persistence', () => {
             generationHash: initialGenerationHash,
             maximum: Authority.Observe,
           })
-          const [before] = yield* sql<{ authority: unknown; history: unknown }>`
-            SELECT
-              (SELECT jsonb_agg(to_jsonb(authority)) FROM authority_state AS authority) AS authority,
-              (
-                SELECT jsonb_agg(to_jsonb(history) ORDER BY history.authority_version)
-                FROM authority_generations AS history
-              ) AS history
-          `
+          const before = yield* readAuthorityTupleEvidence
           const changedProof = yield* Effect.flip(
             store.activatePaperGeneration({
               ...proofBinding(activation),
@@ -1823,14 +1776,7 @@ describePostgres('paper accounting persistence', () => {
             )
           `
           const stale = yield* Effect.flip(store.activatePaperGeneration(proofBinding(activation)))
-          const [after] = yield* sql<{ authority: unknown; history: unknown }>`
-            SELECT
-              (SELECT jsonb_agg(to_jsonb(authority)) FROM authority_state AS authority) AS authority,
-              (
-                SELECT jsonb_agg(to_jsonb(history) ORDER BY history.authority_version)
-                FROM authority_generations AS history
-              ) AS history
-          `
+          const after = yield* readAuthorityTupleEvidence
           return { after, before, changedProof, stale }
         }),
       )

--- a/services/bayn/src/db/paper-store.ts
+++ b/services/bayn/src/db/paper-store.ts
@@ -32,10 +32,13 @@ import {
   ReconciliationStatus,
   ValuationSchema,
   decodeAuthorityState,
+  decodePaperAuthorityProofBinding,
   decodePaperAuthorityGeneration,
+  makePaperAuthorityGeneration,
   type AccountingReceipt,
   type AuthorityState,
   type PaperAuthorityGeneration,
+  type PaperAuthorityProofBinding,
   type Valuation,
 } from '../paper'
 import { QualificationLockSchema, QualificationResultSchema } from '../qualification'
@@ -106,11 +109,21 @@ export interface PaperStoreShape {
     input: EnsureAuthorityGenerationInput,
   ) => Effect.Effect<AuthorityState, PaperStoreError>
   /**
-   * Sole supported cross-generation PAPER writer. Application code and operators must not issue direct DML against
+   * PREPARE operation: under configured OBSERVE, transactionally derives the complete canonical PAPER generation
+   * receipt from durable qualification, reconciliation, authority, and current-build evidence without writing
+   * authority state or history. Commit only its generationHash to the later PAPER configuration.
+   */
+  readonly preparePaperGeneration: (
+    proof: PaperAuthorityProofBinding,
+  ) => Effect.Effect<PaperAuthorityGeneration, PaperStoreError, WriterFence>
+  /**
+   * SUBMIT activation operation: under configured PAPER, transactionally re-derives the complete generation from the
+   * same proof binding and activates it only when its hash equals the configured generationHash. This is the sole
+   * supported cross-generation PAPER writer; application code and operators must not issue direct DML against
    * authority_state or authority_generations.
    */
   readonly activatePaperGeneration: (
-    input: PaperAuthorityGeneration,
+    proof: PaperAuthorityProofBinding,
   ) => Effect.Effect<AuthorityState, PaperStoreError, WriterFence>
   readonly restrictAuthority: (reason: string, updatedAt: string) => Effect.Effect<void, PaperStoreError>
 }
@@ -1285,387 +1298,451 @@ const makeStore = (config: PaperStoreRuntimeConfig) =>
         ),
       )
 
-    const activatePaperGeneration = (candidate: PaperAuthorityGeneration) =>
+    interface PaperGenerationRuntimeBinding {
+      readonly accountId: string
+      readonly configuredGenerationHash: string
+      readonly qualificationRunId: string
+    }
+
+    interface DerivedPaperGeneration {
+      readonly current: AuthorityState
+      readonly generation: PaperAuthorityGeneration
+      readonly reconciliation: typeof ActivationReconciliationRow.Type
+    }
+
+    const requirePaperGenerationRuntime = (
+      expectedMaximum: Authority,
+      operation: 'PREPARE' | 'activation',
+    ): Effect.Effect<PaperGenerationRuntimeBinding, PaperStoreError> => {
+      if (
+        config.maximumAuthority !== expectedMaximum ||
+        config.alpaca === undefined ||
+        config.qualificationRunId === undefined
+      ) {
+        return fail(
+          'authority',
+          'invariant',
+          `PAPER ${operation} requires the exact configured authority, account, generation, and qualification binding`,
+        )
+      }
+      return Effect.succeed({
+        accountId: config.alpaca.accountId,
+        configuredGenerationHash: config.alpaca.authorityGenerationHash,
+        qualificationRunId: config.qualificationRunId,
+      })
+    }
+
+    const lockPaperAuthority = (accountId: string) =>
+      Effect.gen(function* () {
+        yield* sql`
+          SELECT pg_advisory_xact_lock(
+            hashtextextended(${`ALPACA:${accountId}`}, 0)
+          )
+        `
+        yield* lockAuthorityGenerations
+        const currentRows = yield* sql<Record<string, unknown>>`
+          SELECT
+            schema_version, generation_hash, maximum, effective, kill_state, reason,
+            version::text AS version, updated_at, clock_timestamp() AS observed_at
+          FROM authority_state
+          WHERE singleton
+          FOR UPDATE
+        `.pipe(Effect.flatMap(decodeAuthorityStateObservationRows))
+        const currentRow = currentRows[0]
+        if (currentRow === undefined) {
+          return yield* fail('authority', 'invariant', 'PAPER generation requires initialized authority')
+        }
+        const current = yield* authorityStateFromRow(currentRow)
+        if (currentRow.updated_at.getTime() > currentRow.observed_at.getTime()) {
+          return yield* fail('authority', 'invariant', 'durable authority update follows its database observation time')
+        }
+        const history = (yield* readGeneration(current.generationHash))[0]
+        yield* verifyCurrentGenerationHistory(current, history)
+        if (history === undefined) {
+          return yield* fail('authority', 'invariant', 'current authority generation lacks immutable history')
+        }
+        return { current, history }
+      })
+
+    const derivePaperGeneration = (
+      proof: PaperAuthorityProofBinding,
+      binding: PaperGenerationRuntimeBinding,
+      current: AuthorityState,
+    ) =>
+      Effect.gen(function* () {
+        if (current.maximum !== Authority.Observe || current.effective !== Authority.Observe) {
+          return yield* fail('authority', 'invariant', 'PAPER generation requires current OBSERVE authority')
+        }
+
+        yield* sql`
+          LOCK TABLE
+            evaluation_artifacts,
+            evaluation_events,
+            gate_outcomes,
+            status_history
+          IN SHARE MODE
+        `
+        const evidenceRows = yield* sql<Record<string, unknown>>`
+          SELECT
+            lock.payload AS lock_payload,
+            result.payload AS result_payload,
+            run.status AS run_status,
+            run.expected_artifact_count,
+            run.expected_event_count,
+            run.expected_gate_count,
+            (
+              SELECT count(*)::integer
+              FROM evaluation_artifacts
+              WHERE run_id = run.run_id
+            ) AS artifact_count,
+            (
+              SELECT count(*)::integer
+              FROM evaluation_events
+              WHERE run_id = run.run_id
+            ) AS event_count,
+            (
+              SELECT count(*)::integer
+              FROM gate_outcomes
+              WHERE run_id = run.run_id
+            ) AS gate_count,
+            (
+              SELECT count(*)::integer
+              FROM status_history
+              WHERE run_id = run.run_id
+            ) AS status_count,
+            (
+              SELECT count(*)::integer
+              FROM status_history
+              WHERE run_id = run.run_id AND status = 'WRITING'
+            ) AS writing_status_count,
+            (
+              SELECT count(*)::integer
+              FROM status_history
+              WHERE run_id = run.run_id AND status = 'COMPLETE'
+            ) AS complete_status_count,
+            (
+              SELECT detail
+              FROM status_history
+              WHERE run_id = run.run_id AND status = 'WRITING'
+            ) AS writing_detail,
+            (
+              SELECT detail
+              FROM status_history
+              WHERE run_id = run.run_id AND status = 'COMPLETE'
+            ) AS complete_detail,
+            protocol.schema_version AS protocol_schema_version,
+            protocol.strategy_name,
+            protocol.behavior_hash,
+            protocol.parameter_hash,
+            protocol.parameters
+          FROM qualification_results AS result
+          JOIN qualification_locks AS lock
+            ON lock.lock_id = result.lock_id
+            AND lock.candidate_run_id = result.run_id
+          JOIN evaluation_runs AS run
+            ON run.run_id = result.run_id
+            AND run.protocol_hash = lock.protocol_hash
+            AND run.snapshot_id = lock.snapshot_id
+            AND run.source_revision = lock.source_revision
+            AND run.image_repository = lock.image_repository
+            AND run.image_digest = lock.image_digest
+          JOIN protocol_locks AS protocol
+            ON protocol.protocol_hash = run.protocol_hash
+            AND protocol.strategy_name = run.strategy_name
+          WHERE result.run_id = ${binding.qualificationRunId}
+          FOR SHARE OF result, lock, run, protocol
+        `.pipe(Effect.flatMap(decodeActivationEvidenceRows))
+        const evidence = evidenceRows[0]
+        if (evidence === undefined) {
+          return yield* fail('authority', 'invariant', 'exact terminal qualification evidence is unavailable')
+        }
+        const lock = evidence.lock_payload
+        const result = evidence.result_payload
+        const strategyProtocolHash = makeStrategyProtocolHash({
+          name: evidence.strategy_name,
+          behaviorHash: evidence.behavior_hash,
+          parameterHash: evidence.parameter_hash,
+          parameterSchemaVersion: evidence.protocol_schema_version,
+        })
+        if (
+          result.verdict !== 'QUALIFIED' ||
+          evidence.run_status !== 'COMPLETE' ||
+          evidence.expected_artifact_count !== evidence.artifact_count ||
+          evidence.expected_event_count !== evidence.event_count ||
+          evidence.expected_gate_count !== evidence.gate_count ||
+          evidence.status_count !== 2 ||
+          evidence.writing_status_count !== 1 ||
+          evidence.complete_status_count !== 1 ||
+          canonicalHashV1(evidence.writing_detail) !==
+            canonicalHashV1({
+              artifactCount: evidence.expected_artifact_count,
+              eventCount: evidence.expected_event_count,
+              gateCount: evidence.expected_gate_count,
+            }) ||
+          canonicalHashV1(evidence.complete_detail) !==
+            canonicalHashV1({
+              reconciliationExact: true,
+              verdict: result.evaluationVerdict.status,
+            }) ||
+          result.runId !== binding.qualificationRunId ||
+          result.lockId !== lock.lockId ||
+          lock.candidateRunId !== binding.qualificationRunId ||
+          evidence.protocol_schema_version !== 'bayn.risk-balanced-trend.protocol.v3' ||
+          evidence.strategy_name !== 'risk-balanced-trend' ||
+          evidence.behavior_hash !== config.build.strategyBehaviorHash ||
+          evidence.parameter_hash !== config.build.strategyParameterHash ||
+          canonicalHashV1(evidence.parameters) !== evidence.parameter_hash ||
+          strategyProtocolHash !== lock.protocolHash
+        ) {
+          return yield* fail(
+            'authority',
+            'invariant',
+            'PAPER generation differs from terminal qualification evidence or current strategy build',
+          )
+        }
+
+        const reconciliationRows = yield* sql<Record<string, unknown>>`
+          SELECT
+            reconciliation_id, account_id, content_hash, status, reconciled_at
+          FROM reconciliations
+          WHERE account_id = ${binding.accountId}
+          ORDER BY reconciled_at DESC, reconciliation_id DESC
+          LIMIT 1
+          FOR SHARE
+        `.pipe(Effect.flatMap(decodeActivationReconciliationRows))
+        const exactReconciliation = reconciliationRows[0]
+        if (
+          exactReconciliation === undefined ||
+          exactReconciliation.account_id !== binding.accountId ||
+          exactReconciliation.status !== ReconciliationStatus.Exact
+        ) {
+          return yield* fail(
+            'authority',
+            'invariant',
+            'PAPER generation requires the latest fresh exact account reconciliation',
+          )
+        }
+
+        const [mutationBaseline] = yield* sql<Record<string, unknown>>`
+          WITH latest AS (
+            SELECT DISTINCT ON (event.mutation_id)
+              event.operation,
+              event.event_type,
+              event.occurred_at,
+              intent.state
+            FROM mutation_events AS event
+            JOIN intents AS intent ON intent.intent_id = event.intent_id
+            WHERE intent.account_id = ${binding.accountId}
+            ORDER BY event.mutation_id, event.sequence DESC
+          )
+          SELECT
+            count(*) FILTER (
+              WHERE latest.event_type IN (
+                'SUBMIT_STARTED',
+                'SUBMIT_UNKNOWN',
+                'RECOVERY_NOT_FOUND',
+                'RECOVERY_UNKNOWN',
+                'CANCEL_STARTED',
+                'CANCEL_ACCEPTED',
+                'CANCEL_UNKNOWN'
+              )
+              OR (
+                latest.operation = 'CANCEL'
+                AND latest.event_type = 'RECOVERY_FOUND'
+                AND latest.state <> 'TERMINAL'
+              )
+            )::integer AS unresolved_count,
+            max(latest.occurred_at) AS latest_mutation_at
+          FROM latest
+        `.pipe(Effect.flatMap(decodeMutationBaseline))
+        if (
+          mutationBaseline.unresolved_count !== 0 ||
+          (mutationBaseline.latest_mutation_at !== null &&
+            mutationBaseline.latest_mutation_at.getTime() > exactReconciliation.reconciled_at.getTime())
+        ) {
+          return yield* fail(
+            'authority',
+            'invariant',
+            'PAPER generation requires zero unresolved mutations covered by reconciliation',
+          )
+        }
+
+        const generation = yield* Effect.try({
+          try: () =>
+            makePaperAuthorityGeneration({
+              schemaVersion: 'bayn.paper-authority-generation.v1',
+              maximum: Authority.Paper,
+              previousGenerationHash: current.generationHash,
+              qualificationRunId: result.runId,
+              qualificationLockId: result.lockId,
+              qualificationResultHash: result.resultHash,
+              protocolHash: lock.protocolHash,
+              qualificationExecutionPolicyHash: lock.policies.execution.contentHash,
+              qualificationSourceRevision: lock.sourceRevision,
+              qualificationImageRepository: lock.image.repository,
+              qualificationImageDigest: lock.image.digest,
+              activationSourceRevision: config.build.sourceRevision,
+              activationImageRepository: config.build.imageRepository,
+              activationImageDigest: config.build.imageDigest,
+              strategyName: evidence.strategy_name,
+              strategyBehaviorHash: evidence.behavior_hash,
+              strategyParameterHash: evidence.parameter_hash,
+              strategyParameterSchemaVersion: 'bayn.risk-balanced-trend.protocol.v3',
+              accountId: binding.accountId,
+              riskPolicyHash: proof.riskPolicyHash,
+              proofPlanHash: proof.proofPlanHash,
+              reconciliationId: exactReconciliation.reconciliation_id,
+              reconciliationContentHash: exactReconciliation.content_hash,
+            }),
+          catch: (cause) => error('authority', 'decode', 'derived PAPER generation is invalid', cause),
+        })
+        return { current, generation, reconciliation: exactReconciliation } satisfies DerivedPaperGeneration
+      })
+
+    const validatePaperGenerationFreshness = (derived: DerivedPaperGeneration) =>
+      Effect.gen(function* () {
+        const observedAt = yield* nextAuthorityInstant
+        if (
+          derived.reconciliation.reconciled_at.getTime() > observedAt.getTime() ||
+          observedAt.getTime() - derived.reconciliation.reconciled_at.getTime() >= config.reconciliationStaleThresholdMs
+        ) {
+          return yield* fail(
+            'authority',
+            'invariant',
+            'PAPER generation requires the latest fresh exact account reconciliation',
+          )
+        }
+        return observedAt
+      })
+
+    const preparePaperGeneration = (candidate: PaperAuthorityProofBinding) =>
       run(
         'authority',
-        decodePaperAuthorityGeneration(candidate).pipe(
-          Effect.flatMap((input) => {
-            if (
-              config.maximumAuthority !== Authority.Paper ||
-              config.alpaca === undefined ||
-              input.generationHash !== config.alpaca.authorityGenerationHash ||
-              input.accountId !== config.alpaca.accountId ||
-              input.qualificationRunId !== config.qualificationRunId
-            ) {
-              return fail(
-                'authority',
-                'invariant',
-                'PAPER activation differs from the configured authority, account, generation, or qualification binding',
-              )
-            }
-            if (
-              input.activationSourceRevision !== config.build.sourceRevision ||
-              input.activationImageRepository !== config.build.imageRepository ||
-              input.activationImageDigest !== config.build.imageDigest
-            ) {
-              return fail(
-                'authority',
-                'invariant',
-                'PAPER activation provenance differs from the current embedded build',
-              )
-            }
-            if (
-              input.strategyBehaviorHash !== config.build.strategyBehaviorHash ||
-              input.strategyParameterHash !== config.build.strategyParameterHash
-            ) {
-              return fail(
-                'authority',
-                'invariant',
-                'PAPER activation strategy identity differs from the current embedded build',
-              )
-            }
-            return Effect.succeed(input)
-          }),
-          Effect.flatMap((input) =>
-            Effect.flatMap(WriterFence, (fence) =>
-              fence.transaction(
-                Effect.gen(function* () {
-                  yield* sql`
-                  SELECT pg_advisory_xact_lock(
-                    hashtextextended(${`ALPACA:${input.accountId}`}, 0)
+        Effect.gen(function* () {
+          const proof = yield* decodePaperAuthorityProofBinding(candidate)
+          const binding = yield* requirePaperGenerationRuntime(Authority.Observe, 'PREPARE')
+          const fence = yield* WriterFence
+          return yield* fence.transaction(
+            Effect.gen(function* () {
+              const locked = yield* lockPaperAuthority(binding.accountId)
+              if (locked.current.generationHash !== binding.configuredGenerationHash) {
+                return yield* fail(
+                  'authority',
+                  'invariant',
+                  'PAPER PREPARE current authority differs from the configured OBSERVE generation',
+                )
+              }
+              const derived = yield* derivePaperGeneration(proof, binding, locked.current)
+              yield* validatePaperGenerationFreshness(derived)
+              return derived.generation
+            }),
+          )
+        }),
+      )
+
+    const activatePaperGeneration = (candidate: PaperAuthorityProofBinding) =>
+      run(
+        'authority',
+        Effect.gen(function* () {
+          const proof = yield* decodePaperAuthorityProofBinding(candidate)
+          const binding = yield* requirePaperGenerationRuntime(Authority.Paper, 'activation')
+          const fence = yield* WriterFence
+          return yield* fence.transaction(
+            Effect.gen(function* () {
+              const locked = yield* lockPaperAuthority(binding.accountId)
+              if (locked.current.maximum === Authority.Paper) {
+                if (locked.current.generationHash !== binding.configuredGenerationHash) {
+                  return yield* fail(
+                    'authority',
+                    'conflict',
+                    'durable PAPER generation differs from the configured generation',
                   )
-                `
-                  yield* lockAuthorityGenerations
-                  const currentRows = yield* sql<Record<string, unknown>>`
-                  SELECT
-                    schema_version, generation_hash, maximum, effective, kill_state, reason,
-                    version::text AS version, updated_at, clock_timestamp() AS observed_at
-                  FROM authority_state
-                  WHERE singleton
-                  FOR UPDATE
-                `.pipe(Effect.flatMap(decodeAuthorityStateObservationRows))
-                  const currentRow = currentRows[0]
-                  if (currentRow === undefined) {
-                    return yield* fail(
-                      'authority',
-                      'invariant',
-                      'PAPER activation requires an initialized OBSERVE authority',
-                    )
-                  }
-                  const current = yield* authorityStateFromRow(currentRow)
-                  if (currentRow.updated_at.getTime() > currentRow.observed_at.getTime()) {
-                    return yield* fail(
-                      'authority',
-                      'invariant',
-                      'durable authority update follows its database observation time',
-                    )
-                  }
-
-                  const currentHistory = (yield* readGeneration(current.generationHash))[0]
-                  yield* verifyCurrentGenerationHistory(current, currentHistory)
-                  if (current.generationHash === input.generationHash) {
-                    if (current.maximum !== Authority.Paper) {
-                      return yield* fail(
-                        'authority',
-                        'conflict',
-                        'PAPER generation conflicts with durable maximum authority',
-                      )
-                    }
-                    if (currentHistory === undefined) {
-                      return yield* fail('authority', 'invariant', 'PAPER authority history is missing')
-                    }
-                    const stored = yield* paperGenerationFromRow(currentHistory)
-                    if (canonicalHashV1(stored) !== canonicalHashV1(input)) {
-                      return yield* fail(
-                        'authority',
-                        'conflict',
-                        'PAPER generation history differs from deterministic replay',
-                      )
-                    }
-                    return current
-                  }
-
-                  if (current.maximum !== Authority.Observe || current.effective !== Authority.Observe) {
-                    return yield* fail('authority', 'invariant', 'PAPER activation requires current OBSERVE authority')
-                  }
-                  if (input.previousGenerationHash !== current.generationHash) {
-                    return yield* fail(
-                      'authority',
-                      'conflict',
-                      'PAPER generation does not extend the current authority generation',
-                    )
-                  }
-                  if ((yield* readGeneration(input.generationHash))[0] !== undefined) {
-                    return yield* fail('authority', 'conflict', 'authority generation hash was already used')
-                  }
-
-                  yield* sql`
-                  LOCK TABLE
-                    evaluation_artifacts,
-                    evaluation_events,
-                    gate_outcomes,
-                    status_history
-                  IN SHARE MODE
-                `
-                  const evidenceRows = yield* sql<Record<string, unknown>>`
-                  SELECT
-                    lock.payload AS lock_payload,
-                    result.payload AS result_payload,
-                    run.status AS run_status,
-                    run.expected_artifact_count,
-                    run.expected_event_count,
-                    run.expected_gate_count,
-                    (
-                      SELECT count(*)::integer
-                      FROM evaluation_artifacts
-                      WHERE run_id = run.run_id
-                    ) AS artifact_count,
-                    (
-                      SELECT count(*)::integer
-                      FROM evaluation_events
-                      WHERE run_id = run.run_id
-                    ) AS event_count,
-                    (
-                      SELECT count(*)::integer
-                      FROM gate_outcomes
-                      WHERE run_id = run.run_id
-                    ) AS gate_count,
-                    (
-                      SELECT count(*)::integer
-                      FROM status_history
-                      WHERE run_id = run.run_id
-                    ) AS status_count,
-                    (
-                      SELECT count(*)::integer
-                      FROM status_history
-                      WHERE run_id = run.run_id AND status = 'WRITING'
-                    ) AS writing_status_count,
-                    (
-                      SELECT count(*)::integer
-                      FROM status_history
-                      WHERE run_id = run.run_id AND status = 'COMPLETE'
-                    ) AS complete_status_count,
-                    (
-                      SELECT detail
-                      FROM status_history
-                      WHERE run_id = run.run_id AND status = 'WRITING'
-                    ) AS writing_detail,
-                    (
-                      SELECT detail
-                      FROM status_history
-                      WHERE run_id = run.run_id AND status = 'COMPLETE'
-                    ) AS complete_detail,
-                    protocol.schema_version AS protocol_schema_version,
-                    protocol.strategy_name,
-                    protocol.behavior_hash,
-                    protocol.parameter_hash,
-                    protocol.parameters
-                  FROM qualification_results AS result
-                  JOIN qualification_locks AS lock
-                    ON lock.lock_id = result.lock_id
-                    AND lock.candidate_run_id = result.run_id
-                  JOIN evaluation_runs AS run
-                    ON run.run_id = result.run_id
-                    AND run.protocol_hash = lock.protocol_hash
-                    AND run.snapshot_id = lock.snapshot_id
-                    AND run.source_revision = lock.source_revision
-                    AND run.image_repository = lock.image_repository
-                    AND run.image_digest = lock.image_digest
-                  JOIN protocol_locks AS protocol
-                    ON protocol.protocol_hash = run.protocol_hash
-                    AND protocol.strategy_name = run.strategy_name
-                  WHERE result.run_id = ${input.qualificationRunId}
-                  FOR SHARE OF result, lock, run, protocol
-                `.pipe(Effect.flatMap(decodeActivationEvidenceRows))
-                  const evidence = evidenceRows[0]
-                  if (evidence === undefined) {
-                    return yield* fail('authority', 'invariant', 'exact terminal qualification evidence is unavailable')
-                  }
-                  const lock = evidence.lock_payload
-                  const result = evidence.result_payload
-                  const strategyProtocolHash = makeStrategyProtocolHash({
-                    name: evidence.strategy_name,
-                    behaviorHash: evidence.behavior_hash,
-                    parameterHash: evidence.parameter_hash,
-                    parameterSchemaVersion: evidence.protocol_schema_version,
-                  })
-                  if (
-                    result.verdict !== 'QUALIFIED' ||
-                    evidence.run_status !== 'COMPLETE' ||
-                    evidence.expected_artifact_count !== evidence.artifact_count ||
-                    evidence.expected_event_count !== evidence.event_count ||
-                    evidence.expected_gate_count !== evidence.gate_count ||
-                    evidence.status_count !== 2 ||
-                    evidence.writing_status_count !== 1 ||
-                    evidence.complete_status_count !== 1 ||
-                    canonicalHashV1(evidence.writing_detail) !==
-                      canonicalHashV1({
-                        artifactCount: evidence.expected_artifact_count,
-                        eventCount: evidence.expected_event_count,
-                        gateCount: evidence.expected_gate_count,
-                      }) ||
-                    canonicalHashV1(evidence.complete_detail) !==
-                      canonicalHashV1({
-                        reconciliationExact: true,
-                        verdict: result.evaluationVerdict.status,
-                      }) ||
-                    result.runId !== input.qualificationRunId ||
-                    result.lockId !== input.qualificationLockId ||
-                    result.resultHash !== input.qualificationResultHash ||
-                    lock.lockId !== input.qualificationLockId ||
-                    lock.candidateRunId !== input.qualificationRunId ||
-                    lock.protocolHash !== input.protocolHash ||
-                    lock.policies.execution.contentHash !== input.qualificationExecutionPolicyHash ||
-                    lock.sourceRevision !== input.qualificationSourceRevision ||
-                    lock.image.repository !== input.qualificationImageRepository ||
-                    lock.image.digest !== input.qualificationImageDigest ||
-                    evidence.protocol_schema_version !== input.strategyParameterSchemaVersion ||
-                    evidence.strategy_name !== input.strategyName ||
-                    evidence.behavior_hash !== input.strategyBehaviorHash ||
-                    evidence.parameter_hash !== input.strategyParameterHash ||
-                    canonicalHashV1(evidence.parameters) !== input.strategyParameterHash ||
-                    strategyProtocolHash !== input.protocolHash
-                  ) {
-                    return yield* fail(
-                      'authority',
-                      'invariant',
-                      'PAPER generation differs from terminal qualification evidence',
-                    )
-                  }
-
-                  const reconciliationRows = yield* sql<Record<string, unknown>>`
-                  SELECT
-                    reconciliation_id, account_id, content_hash, status, reconciled_at
-                  FROM reconciliations
-                  WHERE account_id = ${input.accountId}
-                  ORDER BY reconciled_at DESC, reconciliation_id DESC
-                  LIMIT 1
-                  FOR SHARE
-                `.pipe(Effect.flatMap(decodeActivationReconciliationRows))
-                  const exactReconciliation = reconciliationRows[0]
-                  if (
-                    exactReconciliation === undefined ||
-                    exactReconciliation.reconciliation_id !== input.reconciliationId ||
-                    exactReconciliation.account_id !== input.accountId ||
-                    exactReconciliation.content_hash !== input.reconciliationContentHash ||
-                    exactReconciliation.status !== ReconciliationStatus.Exact
-                  ) {
-                    return yield* fail(
-                      'authority',
-                      'invariant',
-                      'PAPER activation requires the latest fresh exact account reconciliation',
-                    )
-                  }
-
-                  const [mutationBaseline] = yield* sql<Record<string, unknown>>`
-                  WITH latest AS (
-                    SELECT DISTINCT ON (event.mutation_id)
-                      event.operation,
-                      event.event_type,
-                      event.occurred_at,
-                      intent.state
-                    FROM mutation_events AS event
-                    JOIN intents AS intent ON intent.intent_id = event.intent_id
-                    WHERE intent.account_id = ${input.accountId}
-                    ORDER BY event.mutation_id, event.sequence DESC
+                }
+                const stored = yield* paperGenerationFromRow(locked.history)
+                if (
+                  stored.accountId !== binding.accountId ||
+                  stored.qualificationRunId !== binding.qualificationRunId ||
+                  stored.activationSourceRevision !== config.build.sourceRevision ||
+                  stored.activationImageRepository !== config.build.imageRepository ||
+                  stored.activationImageDigest !== config.build.imageDigest ||
+                  stored.strategyBehaviorHash !== config.build.strategyBehaviorHash ||
+                  stored.strategyParameterHash !== config.build.strategyParameterHash ||
+                  stored.riskPolicyHash !== proof.riskPolicyHash ||
+                  stored.proofPlanHash !== proof.proofPlanHash
+                ) {
+                  return yield* fail(
+                    'authority',
+                    'conflict',
+                    'PAPER generation history differs from deterministic replay',
                   )
-                  SELECT
-                    count(*) FILTER (
-                      WHERE latest.event_type IN (
-                        'SUBMIT_STARTED',
-                        'SUBMIT_UNKNOWN',
-                        'RECOVERY_NOT_FOUND',
-                        'RECOVERY_UNKNOWN',
-                        'CANCEL_STARTED',
-                        'CANCEL_ACCEPTED',
-                        'CANCEL_UNKNOWN'
-                      )
-                      OR (
-                        latest.operation = 'CANCEL'
-                        AND latest.event_type = 'RECOVERY_FOUND'
-                        AND latest.state <> 'TERMINAL'
-                      )
-                    )::integer AS unresolved_count,
-                    max(latest.occurred_at) AS latest_mutation_at
-                  FROM latest
-                `.pipe(Effect.flatMap(decodeMutationBaseline))
-                  if (
-                    mutationBaseline.unresolved_count !== 0 ||
-                    (mutationBaseline.latest_mutation_at !== null &&
-                      mutationBaseline.latest_mutation_at.getTime() > exactReconciliation.reconciled_at.getTime())
-                  ) {
-                    return yield* fail(
-                      'authority',
-                      'invariant',
-                      'PAPER activation requires zero unresolved mutations covered by reconciliation',
-                    )
-                  }
+                }
+                return locked.current
+              }
 
-                  const activatedAt = yield* nextAuthorityInstant
-                  if (
-                    exactReconciliation.reconciled_at.getTime() > activatedAt.getTime() ||
-                    activatedAt.getTime() - exactReconciliation.reconciled_at.getTime() >=
-                      config.reconciliationStaleThresholdMs
-                  ) {
-                    return yield* fail(
-                      'authority',
-                      'invariant',
-                      'PAPER activation requires the latest fresh exact account reconciliation',
-                    )
-                  }
-                  const nextVersion = current.version + 1
-                  yield* sql`
-                  INSERT INTO authority_generations (
-                    generation_hash, schema_version, activation_schema_version,
-                    previous_generation_hash, maximum, authority_version,
-                    qualification_run_id, qualification_lock_id, qualification_result_hash,
-                    protocol_hash, qualification_execution_policy_hash,
-                    qualification_source_revision, qualification_image_repository,
-                    qualification_image_digest, activation_source_revision,
-                    activation_image_repository, activation_image_digest,
-                    strategy_name, strategy_behavior_hash,
-                    strategy_parameter_hash, strategy_parameter_schema_version, account_id,
-                    risk_policy_hash, proof_plan_hash, reconciliation_id,
-                    reconciliation_content_hash, activated_at
-                  ) VALUES (
-                    ${input.generationHash}, 'bayn.authority-generation-history.v1',
-                    ${input.schemaVersion}, ${input.previousGenerationHash}, 'PAPER', ${nextVersion},
-                    ${input.qualificationRunId}, ${input.qualificationLockId},
-                    ${input.qualificationResultHash}, ${input.protocolHash},
-                    ${input.qualificationExecutionPolicyHash}, ${input.qualificationSourceRevision},
-                    ${input.qualificationImageRepository}, ${input.qualificationImageDigest},
-                    ${input.activationSourceRevision}, ${input.activationImageRepository},
-                    ${input.activationImageDigest}, ${input.strategyName},
-                    ${input.strategyBehaviorHash}, ${input.strategyParameterHash},
-                    ${input.strategyParameterSchemaVersion}, ${input.accountId},
-                    ${input.riskPolicyHash}, ${input.proofPlanHash}, ${input.reconciliationId},
-                    ${input.reconciliationContentHash}, ${activatedAt}
-                  )
-                `
-                  const effective = current.kill === KillState.Active ? Authority.Observe : Authority.Paper
-                  const activatedRows = yield* sql<Record<string, unknown>>`
-                  UPDATE authority_state
-                  SET
-                    generation_hash = ${input.generationHash},
-                    maximum = 'PAPER',
-                    effective = ${effective},
-                    version = version + 1,
-                    updated_at = ${activatedAt}
-                  WHERE singleton
-                  RETURNING
-                    schema_version, generation_hash, maximum, effective, kill_state, reason,
-                    version::text AS version, updated_at
-                `.pipe(Effect.flatMap(decodeAuthorityStateRows))
-                  const activatedRow = activatedRows[0]
-                  if (activatedRow === undefined) {
-                    return yield* fail('authority', 'invariant', 'PAPER authority was not activated')
-                  }
-                  return yield* authorityStateFromRow(activatedRow)
-                }),
-              ),
-            ),
-          ),
-        ),
+              const derived = yield* derivePaperGeneration(proof, binding, locked.current)
+              if (derived.generation.generationHash !== binding.configuredGenerationHash) {
+                return yield* fail(
+                  'authority',
+                  'invariant',
+                  'derived PAPER generation differs from the configured generation',
+                )
+              }
+              if ((yield* readGeneration(derived.generation.generationHash))[0] !== undefined) {
+                return yield* fail('authority', 'conflict', 'authority generation hash was already used')
+              }
+              const activatedAt = yield* validatePaperGenerationFreshness(derived)
+              const input = derived.generation
+              const nextVersion = derived.current.version + 1
+              yield* sql`
+                INSERT INTO authority_generations (
+                  generation_hash, schema_version, activation_schema_version,
+                  previous_generation_hash, maximum, authority_version,
+                  qualification_run_id, qualification_lock_id, qualification_result_hash,
+                  protocol_hash, qualification_execution_policy_hash,
+                  qualification_source_revision, qualification_image_repository,
+                  qualification_image_digest, activation_source_revision,
+                  activation_image_repository, activation_image_digest,
+                  strategy_name, strategy_behavior_hash,
+                  strategy_parameter_hash, strategy_parameter_schema_version, account_id,
+                  risk_policy_hash, proof_plan_hash, reconciliation_id,
+                  reconciliation_content_hash, activated_at
+                ) VALUES (
+                  ${input.generationHash}, 'bayn.authority-generation-history.v1',
+                  ${input.schemaVersion}, ${input.previousGenerationHash}, 'PAPER', ${nextVersion},
+                  ${input.qualificationRunId}, ${input.qualificationLockId},
+                  ${input.qualificationResultHash}, ${input.protocolHash},
+                  ${input.qualificationExecutionPolicyHash}, ${input.qualificationSourceRevision},
+                  ${input.qualificationImageRepository}, ${input.qualificationImageDigest},
+                  ${input.activationSourceRevision}, ${input.activationImageRepository},
+                  ${input.activationImageDigest}, ${input.strategyName},
+                  ${input.strategyBehaviorHash}, ${input.strategyParameterHash},
+                  ${input.strategyParameterSchemaVersion}, ${input.accountId},
+                  ${input.riskPolicyHash}, ${input.proofPlanHash}, ${input.reconciliationId},
+                  ${input.reconciliationContentHash}, ${activatedAt}
+                )
+              `
+              const effective = derived.current.kill === KillState.Active ? Authority.Observe : Authority.Paper
+              const activatedRows = yield* sql<Record<string, unknown>>`
+                UPDATE authority_state
+                SET
+                  generation_hash = ${input.generationHash},
+                  maximum = 'PAPER',
+                  effective = ${effective},
+                  version = version + 1,
+                  updated_at = ${activatedAt}
+                WHERE singleton
+                RETURNING
+                  schema_version, generation_hash, maximum, effective, kill_state, reason,
+                  version::text AS version, updated_at
+              `.pipe(Effect.flatMap(decodeAuthorityStateRows))
+              const activatedRow = activatedRows[0]
+              if (activatedRow === undefined) {
+                return yield* fail('authority', 'invariant', 'PAPER authority was not activated')
+              }
+              return yield* authorityStateFromRow(activatedRow)
+            }),
+          )
+        }),
       )
 
     const lowerAuthority = (reason: string, updatedAt: string) =>
@@ -1685,6 +1762,7 @@ const makeStore = (config: PaperStoreRuntimeConfig) =>
       bindings,
       reconcile,
       ensureAuthorityGeneration,
+      preparePaperGeneration,
       activatePaperGeneration,
       restrictAuthority: lowerAuthority,
     } satisfies PaperStoreShape

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -397,6 +397,7 @@ describe('OBSERVE runtime composition', () => {
           authorityInitializations += 1
           throw new Error('PAPER startup must not initialize synthetic OBSERVE authority')
         }),
+      preparePaperGeneration: () => unused,
       activatePaperGeneration: () => unused,
       restrictAuthority: () => unused,
     }

--- a/services/bayn/src/paper.test.ts
+++ b/services/bayn/src/paper.test.ts
@@ -25,6 +25,7 @@ import {
   decodeIntent,
   decodeOrder,
   decodePosition,
+  decodePaperAuthorityProofBinding,
   decodePaperAuthorityGeneration,
   decodeRateLimit,
   decodeReconciliation,
@@ -415,6 +416,11 @@ describe('paper contracts', () => {
   })
 
   test('binds a PAPER authority generation to exact qualification, runtime, account, policy, and proof evidence', async () => {
+    const proof = {
+      schemaVersion: 'bayn.paper-authority-proof-binding.v1' as const,
+      riskPolicyHash: hash('c'),
+      proofPlanHash: hash('d'),
+    }
     const material = {
       schemaVersion: 'bayn.paper-authority-generation.v1' as const,
       maximum: Authority.Paper as const,
@@ -435,13 +441,26 @@ describe('paper contracts', () => {
       strategyParameterHash: hash('b'),
       strategyParameterSchemaVersion: 'bayn.risk-balanced-trend.protocol.v3' as const,
       accountId: 'paper-account-1',
-      riskPolicyHash: hash('c'),
-      proofPlanHash: hash('d'),
+      riskPolicyHash: proof.riskPolicyHash,
+      proofPlanHash: proof.proofPlanHash,
       reconciliationId: hash('e'),
       reconciliationContentHash: hash('f'),
     }
     const generation = makePaperAuthorityGeneration(material)
 
+    expect(await Effect.runPromise(decodePaperAuthorityProofBinding(proof))).toEqual(proof)
+    await expectFailure(
+      decodePaperAuthorityProofBinding({
+        ...proof,
+        previousGenerationHash: material.previousGenerationHash,
+      }),
+    )
+    await expectFailure(
+      decodePaperAuthorityProofBinding({
+        ...proof,
+        reconciliationId: material.reconciliationId,
+      }),
+    )
     expect(await Effect.runPromise(decodePaperAuthorityGeneration(generation))).toEqual(generation)
     expect(generation.generationHash).toMatch(/^[0-9a-f]{64}$/)
     expect(makePaperAuthorityGeneration(structuredClone(material))).toEqual(generation)

--- a/services/bayn/src/paper.ts
+++ b/services/bayn/src/paper.ts
@@ -578,6 +578,13 @@ export const ReconciliationSchema = ReconciliationBase.check(
 )
 export type Reconciliation = typeof ReconciliationSchema.Type
 
+export const PaperAuthorityProofBindingSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.paper-authority-proof-binding.v1'),
+  riskPolicyHash: Sha256,
+  proofPlanHash: Sha256,
+})
+export type PaperAuthorityProofBinding = typeof PaperAuthorityProofBindingSchema.Type
+
 export const PaperAuthorityGenerationMaterialSchema = Schema.Struct({
   schemaVersion: Schema.Literal('bayn.paper-authority-generation.v1'),
   maximum: Schema.Literal(Authority.Paper),
@@ -679,6 +686,10 @@ export const decodeRiskDecision = Schema.decodeUnknownEffect(RiskDecisionSchema,
 export const decodeAccountingReceipt = Schema.decodeUnknownEffect(AccountingReceiptSchema, StrictParseOptions)
 export const decodeValuation = Schema.decodeUnknownEffect(ValuationSchema, StrictParseOptions)
 export const decodeReconciliation = Schema.decodeUnknownEffect(ReconciliationSchema, StrictParseOptions)
+export const decodePaperAuthorityProofBinding = Schema.decodeUnknownEffect(
+  PaperAuthorityProofBindingSchema,
+  StrictParseOptions,
+)
 export const decodePaperAuthorityGeneration = Schema.decodeUnknownEffect(
   PaperAuthorityGenerationSchema,
   StrictParseOptions,

--- a/services/bayn/src/reconciler.test.ts
+++ b/services/bayn/src/reconciler.test.ts
@@ -197,6 +197,7 @@ const makeStore = (control: StoreControl, hasAccountBaseline = true): PaperStore
       return report(snapshot)
     }),
   ensureAuthorityGeneration: () => Effect.die(new Error('unexpected authority generation initialization')),
+  preparePaperGeneration: () => Effect.die(new Error('unexpected PAPER authority preparation')),
   activatePaperGeneration: () => Effect.die(new Error('unexpected PAPER authority activation')),
   restrictAuthority: (reason) =>
     Effect.sync(() => {


### PR DESCRIPTION
## Summary

- add the versioned, proof-only `PaperAuthorityProofBinding` and a read-only `preparePaperGeneration` operation
- derive the complete canonical PAPER generation inside the existing WriterFence/account-serialized transaction from durable authority, terminal qualification, current build/account, and the latest fresh exact reconciliation
- make activation re-derive and match the configured generation before writes while retaining a distinct immutable-history replay path
- cover deterministic no-write PREPARE, unchanged activation, reconciliation/current-generation drift, configured/proof mismatch, replay, concurrency, freshness, mutation serialization, and active-kill preservation, with `xmin` proof of no tuple churn

## Related Issues

PROOMPT-375 Phase B prerequisite; does not close the issue.

## Testing

- `bunx oxfmt --check services/bayn/src`
- `bun run --cwd services/bayn lint:oxlint`
- `bun run --cwd services/bayn lint:oxlint:type`
- `bun run --cwd services/bayn tsc`
- `bun run --cwd services/bayn test` (354 passed, 87 PostgreSQL tests skipped in the non-PG pass)
- `bun run --cwd services/bayn build`
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:55439/bayn_test bun test services/bayn/src/db/paper-store.integration.test.ts` (26 passed)
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:55439/bayn_test bun test services/bayn/src/db/evidence-store.integration.test.ts` (38 passed)
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:55439/bayn_test bun test services/bayn/src/db/cycle-store.integration.test.ts` (13 passed)
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:55439/bayn_test bun test services/bayn/src/db/cycle-observability.integration.test.ts` (3 passed)
- `git diff --check`

## Breaking Changes

The internal, currently uncomposed `PaperStore.activatePaperGeneration` input changes from a caller-assembled full generation to `PaperAuthorityProofBinding`; `preparePaperGeneration` now produces the full receipt. No production composition or rollout is included.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] The PaperStore API JSDoc documents PREPARE and activation sequencing; no release or runtime change is included.
