### PR TITLE
feat(bayn): add exact Alpaca asset observations

### DIFF
--- a/docs/bayn/architecture.md
+++ b/docs/bayn/architecture.md
@@ -18,6 +18,7 @@ The runtime has three external I/O boundaries:
 Alpaca is reachable only through the existing paper-host CONNECT proxy. Credentials provide runtime-decoded GET-only
 broker access. Under `OBSERVE`, the canonical non-dispatchable autonomous shadow loop composes `PaperStore` and
 `WriterFence` and performs one same-pass reconciliation when it builds a decision; broker mutation remains absent.
+Exact asset reads retain status, tradability, fractionability, and normalized attributes as policy-neutral evidence.
 
 The implementation behind `EvidenceStore` is deliberately outside this document. Non-database cleanup must preserve
 that interface and every persisted evidence contract.

--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -90,6 +90,8 @@ paper mutation capability, execution entry point, and capital-promotion path rem
   composes `PaperStore` and `WriterFence` and performs one same-pass reconciliation when it builds a decision.
   `BrokerMutation`, `IntentStore`, `MutationStore`, and the coordinator remain absent; `PAPER` startup fails closed until
   the PROOMPT-375 Phase B authority generation and dispatch transition exists.
+- Exact Alpaca asset reads preserve the returned status, tradability, fractionability, and normalized attributes as
+  content-hashed evidence; the read adapter does not decide execution eligibility.
 - The bounded Alpaca calendar observation is content-hashed with its request range, source/version, and normalized UTC
   sessions. A causal execution-session binding retains and revalidates that complete observation, selects its first
   post-signal session, and binds the session's exact open, close, pre-open cutoff, finalized Signal identity, and

--- a/services/bayn/src/broker/alpaca-test-support.ts
+++ b/services/bayn/src/broker/alpaca-test-support.ts
@@ -2,5 +2,8 @@ import { Effect } from 'effect'
 
 import type { BrokerReadShape } from './alpaca'
 
+export const unusedAssetBySymbol: BrokerReadShape['assetBySymbol'] = () =>
+  Effect.die(new Error('unexpected Alpaca asset read'))
+
 export const unusedMarketCalendar: BrokerReadShape['marketCalendar'] = () =>
   Effect.die(new Error('unexpected Alpaca market calendar read'))

--- a/services/bayn/src/broker/alpaca.test.ts
+++ b/services/bayn/src/broker/alpaca.test.ts
@@ -10,6 +10,7 @@ import {
   AccountStatus,
   AssetClass,
   AssetExchange,
+  AssetStatus,
   BrokerRead,
   BrokerReadError,
   BrokerReadErrorKind,
@@ -69,6 +70,18 @@ const positionResponse = {
   unrealized_pl: '100.0',
   current_price: '120.0',
   cost_basis: '500.0',
+}
+
+const assetResponse = {
+  id: assetId,
+  class: 'us_equity',
+  exchange: 'NASDAQ',
+  symbol: 'AAPL',
+  status: 'active',
+  tradable: true,
+  fractionable: true,
+  attributes: ['has_options'],
+  name: 'Apple Inc.',
 }
 
 const orderResponse = {
@@ -186,6 +199,7 @@ describe('Alpaca paper reads', () => {
     expect(inspected).not.toContain('paper-secret')
     expect(surface).toEqual([
       'account',
+      'assetBySymbol',
       'fillActivities',
       'marketCalendar',
       'orderByClientId',
@@ -213,6 +227,211 @@ describe('Alpaca paper reads', () => {
         retryAfter: undefined,
       },
     })
+  })
+
+  test('reads exact asset evidence with GET-only auth and samples time after the complete body', async () => {
+    const requestedSymbol = 'BRK.B'
+    const response = {
+      ...assetResponse,
+      symbol: requestedSymbol,
+      status: 'inactive',
+      tradable: false,
+      fractionable: false,
+      attributes: ['ipo'],
+    }
+    const requests: Array<{ method: string; url: URL; key: string; secret: string }> = []
+    let releaseBody: (() => void) | undefined
+    const client = HttpClient.make((request, url) => {
+      requests.push({
+        method: request.method,
+        url,
+        key: request.headers['apca-api-key-id'] ?? '',
+        secret: request.headers['apca-api-secret-key'] ?? '',
+      })
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          releaseBody = () => {
+            controller.enqueue(new TextEncoder().encode(JSON.stringify(response)))
+            controller.close()
+          }
+        },
+      })
+      return Effect.succeed(
+        HttpClientResponse.fromWeb(
+          request,
+          new Response(body, {
+            status: 200,
+            headers: responseHeaders,
+          }),
+        ),
+      )
+    })
+
+    const program = withClient(
+      client,
+      (read) =>
+        Effect.gen(function* () {
+          const fiber = yield* read.assetBySymbol(requestedSymbol).pipe(Effect.forkChild)
+          yield* Effect.yieldNow
+          yield* TestClock.adjust(2_000)
+          releaseBody?.()
+          return yield* Fiber.join(fiber)
+        }),
+      { ...options, operationTimeoutMs: 5_000 },
+    ).pipe(Effect.provide(TestClock.layer()))
+    const result = await Effect.runPromise(program)
+
+    expect(requests).toEqual([
+      {
+        method: 'GET',
+        url: new URL(`https://paper-api.alpaca.markets/v2/assets/${encodeURIComponent(requestedSymbol)}`),
+        key: 'paper-key',
+        secret: 'paper-secret',
+      },
+    ])
+    const requestHash = canonicalHashV1({
+      schemaVersion: 'bayn.alpaca-asset-observation.v1',
+      source: 'alpaca-v2-asset',
+      method: 'GET',
+      path: `/v2/assets/${encodeURIComponent(requestedSymbol)}`,
+      requestedSymbol,
+    })
+    const normalized = {
+      schemaVersion: 'bayn.alpaca-asset-observation.v1',
+      source: 'alpaca-v2-asset',
+      requestedSymbol,
+      requestHash,
+      assetId,
+      symbol: requestedSymbol,
+      assetClass: AssetClass.UsEquity,
+      exchange: AssetExchange.Nasdaq,
+      status: AssetStatus.Inactive,
+      tradable: false,
+      fractionable: false,
+      attributes: ['ipo'],
+    } as const
+    expect(result.value).toEqual({
+      ...normalized,
+      observedAt: '1970-01-01T00:00:02.000Z',
+      normalizedResponseHash: canonicalHashV1(normalized),
+    })
+    expect(result.evidence).toMatchObject({
+      requestId: 'req-123',
+      status: 200,
+      contentHash: canonicalHashV1(response),
+      observedAt: '1970-01-01T00:00:02.000Z',
+    })
+    expect(requests.some(({ method }) => method === 'POST' || method === 'DELETE')).toBe(false)
+  })
+
+  test('canonicalizes asset attributes into deterministic sorted-unique response evidence', async () => {
+    let response: unknown = { ...assetResponse, attributes: ['ipo', 'has_options', 'ipo'] }
+    const client = HttpClient.make((request) => Effect.succeed(jsonResponse(request, response)))
+
+    const first = await Effect.runPromise(
+      withClient(client, (read) => read.assetBySymbol('AAPL')).pipe(Effect.provide(TestClock.layer())),
+    )
+    response = { ...assetResponse, attributes: ['has_options', 'ipo'] }
+    const second = await Effect.runPromise(
+      withClient(client, (read) => read.assetBySymbol('AAPL')).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(first.value.attributes).toEqual(['has_options', 'ipo'])
+    expect(first.value.requestHash).toBe(second.value.requestHash)
+    expect(first.value.normalizedResponseHash).toBe(second.value.normalizedResponseHash)
+    expect(first.evidence.contentHash).not.toBe(second.evidence.contentHash)
+  })
+
+  test('normalizes absent or null asset attributes to immutable empty evidence', async () => {
+    const { attributes: _attributes, ...withoutAttributes } = assetResponse
+    let response: unknown = withoutAttributes
+    const client = HttpClient.make((request) => Effect.succeed(jsonResponse(request, response)))
+
+    const absent = await Effect.runPromise(withClient(client, (read) => read.assetBySymbol('AAPL')))
+    response = { ...assetResponse, attributes: null }
+    const nullAttributes = await Effect.runPromise(withClient(client, (read) => read.assetBySymbol('AAPL')))
+
+    expect(absent.value.attributes).toEqual([])
+    expect(nullAttributes.value.attributes).toEqual([])
+    expect(absent.value.normalizedResponseHash).toBe(nullAttributes.value.normalizedResponseHash)
+  })
+
+  test('fails typed with post-response evidence for malformed or mismatched assets', async () => {
+    let calls = 0
+    let response: unknown = { ...assetResponse, fractionable: 'false' }
+    const client = HttpClient.make((request) => {
+      calls += 1
+      return Effect.succeed(jsonResponse(request, response))
+    })
+    const readFailure = (symbol: string) =>
+      Effect.flip(withClient(client, (read) => read.assetBySymbol(symbol))).pipe(Effect.provide(TestClock.layer()))
+
+    const malformed = await Effect.runPromise(readFailure('AAPL'))
+    expect(malformed).toMatchObject({
+      operation: 'asset-by-symbol',
+      kind: BrokerReadErrorKind.InvalidResponse,
+      retryable: false,
+      status: 200,
+      requestId: 'req-123',
+      contentHash: canonicalHashV1(response),
+      observedAt: '1970-01-01T00:00:00.000Z',
+    })
+
+    response = { ...assetResponse, symbol: 'MSFT' }
+    const mismatch = await Effect.runPromise(readFailure('AAPL'))
+    expect(mismatch).toMatchObject({
+      operation: 'asset-by-symbol',
+      kind: BrokerReadErrorKind.InvalidResponse,
+      retryable: false,
+      status: 200,
+      requestId: 'req-123',
+      contentHash: canonicalHashV1(response),
+      observedAt: '1970-01-01T00:00:00.000Z',
+      cause: {
+        message: 'asset lookup returned symbol MSFT, expected AAPL',
+      },
+    })
+
+    const callsBeforeInvalidSymbol = calls
+    const invalidSymbol = await Effect.runPromise(readFailure('../AAPL'))
+    expect(invalidSymbol).toMatchObject({
+      operation: 'asset-by-symbol',
+      kind: BrokerReadErrorKind.InvalidRequest,
+      retryable: false,
+    })
+    expect(calls).toBe(callsBeforeInvalidSymbol)
+
+    response = { ...assetResponse, exchange: '' }
+    const emptyExchange = await Effect.runPromise(readFailure('AAPL'))
+    expect(emptyExchange).toMatchObject({
+      operation: 'asset-by-symbol',
+      kind: BrokerReadErrorKind.InvalidResponse,
+      retryable: false,
+      contentHash: canonicalHashV1(response),
+      observedAt: '1970-01-01T00:00:00.000Z',
+    })
+  })
+
+  test('uses the bounded transient GET retry policy for exact asset reads', async () => {
+    const methods: string[] = []
+    let calls = 0
+    const client = HttpClient.make((request) => {
+      methods.push(request.method)
+      calls += 1
+      return Effect.succeed(
+        calls === 1
+          ? jsonResponse(request, { code: 50010000, message: 'temporary failure' }, 500)
+          : jsonResponse(request, assetResponse),
+      )
+    })
+
+    const result = await Effect.runPromise(
+      withClient(client, (read) => read.assetBySymbol('AAPL'), { ...options, retryAttempts: 1 }),
+    )
+
+    expect(result.value.symbol).toBe('AAPL')
+    expect(calls).toBe(2)
+    expect(methods).toEqual(['GET', 'GET'])
   })
 
   test('reads one bounded market calendar range and returns deterministic UTC observation evidence', async () => {
@@ -323,7 +542,7 @@ describe('Alpaca paper reads', () => {
     })
   })
 
-  test('preflights the complete GET-only surface without persisting or inventing an order', async () => {
+  test('preflights the startup GET-only surface without persisting or inventing an order', async () => {
     const requests: Array<{ method: string; url: URL }> = []
     const client = HttpClient.make((request, url) => {
       requests.push({ method: request.method, url })

--- a/services/bayn/src/broker/alpaca.ts
+++ b/services/bayn/src/broker/alpaca.ts
@@ -14,6 +14,8 @@ const defaultFillActivitiesPageSize = 100
 const maxMarketCalendarRangeDays = 31
 const marketCalendarPreflightRangeDays = 14
 const millisecondsPerDay = 86_400_000
+const assetObservationSchemaVersion = 'bayn.alpaca-asset-observation.v1' as const
+const assetObservationSource = 'alpaca-v2-asset' as const
 const marketCalendarSchemaVersion = 'bayn.alpaca-market-calendar-observation.v1' as const
 const marketCalendarSource = 'alpaca-v2-calendar' as const
 const marketCalendarTimeZone = 'America/New_York' as const
@@ -115,6 +117,13 @@ export enum AssetExchange {
   Empty = '',
 }
 
+export enum AssetStatus {
+  Active = 'active',
+  Inactive = 'inactive',
+}
+
+export type AssetObservationExchange = Exclude<AssetExchange, AssetExchange.Empty>
+
 export enum PositionSide {
   Long = 'long',
   Short = 'short',
@@ -212,6 +221,7 @@ export type BrokerReadOperation =
   | 'order-by-id'
   | 'order-by-client-id'
   | 'fill-activities'
+  | 'asset-by-symbol'
   | 'market-calendar'
 
 export class BrokerReadError extends Data.TaggedError('BrokerReadError')<{
@@ -348,6 +358,23 @@ export interface MarketCalendarQuery {
   readonly end: string
 }
 
+export interface AssetObservation {
+  readonly schemaVersion: typeof assetObservationSchemaVersion
+  readonly source: typeof assetObservationSource
+  readonly requestedSymbol: string
+  readonly requestHash: string
+  readonly assetId: string
+  readonly symbol: string
+  readonly assetClass: AssetClass
+  readonly exchange: AssetObservationExchange
+  readonly status: AssetStatus
+  readonly tradable: boolean
+  readonly fractionable: boolean
+  readonly attributes: readonly string[]
+  readonly observedAt: string
+  readonly normalizedResponseHash: string
+}
+
 export interface MarketCalendarSession {
   readonly date: string
   readonly openAt: string
@@ -387,6 +414,7 @@ export interface FillActivitiesQuery {
 
 export interface BrokerReadShape {
   readonly account: Effect.Effect<ReadResult<Account>, BrokerReadError>
+  readonly assetBySymbol: (symbol: string) => Effect.Effect<ReadResult<AssetObservation>, BrokerReadError>
   readonly positions: Effect.Effect<ReadResult<readonly Position[]>, BrokerReadError>
   readonly orders: (query?: OrdersQuery) => Effect.Effect<ReadResult<readonly Order[]>, BrokerReadError>
   readonly orderById: (orderId: string) => Effect.Effect<ReadResult<Order>, BrokerReadError>
@@ -439,6 +467,31 @@ const PositionResponseSchema = Schema.Struct({
   market_value: Decimal,
   unrealized_pl: Decimal,
   current_price: Decimal,
+})
+
+const AssetResponseSchema = Schema.Struct({
+  id: Uuid,
+  class: Schema.Enum(AssetClass),
+  exchange: Schema.Union([
+    Schema.Literal(AssetExchange.Amex),
+    Schema.Literal(AssetExchange.Arca),
+    Schema.Literal(AssetExchange.Ascx),
+    Schema.Literal(AssetExchange.Bats),
+    Schema.Literal(AssetExchange.Nyse),
+    Schema.Literal(AssetExchange.Nasdaq),
+    Schema.Literal(AssetExchange.NyseArca),
+    Schema.Literal(AssetExchange.Ftxu),
+    Schema.Literal(AssetExchange.Coinbase),
+    Schema.Literal(AssetExchange.Gnss),
+    Schema.Literal(AssetExchange.Erisx),
+    Schema.Literal(AssetExchange.Otc),
+    Schema.Literal(AssetExchange.Crypto),
+  ]),
+  symbol: SymbolName,
+  status: Schema.Enum(AssetStatus),
+  tradable: Schema.Boolean,
+  fractionable: Schema.Boolean,
+  attributes: Schema.optionalKey(Schema.NullOr(Schema.Array(NonEmptyString))),
 })
 
 export const OrderResponseSchema = Schema.Struct({
@@ -568,6 +621,7 @@ const RuntimeOptionsSchema = Schema.Struct({
 type Decoder<A> = (input: unknown) => Effect.Effect<A, unknown>
 
 const decodeAccount = Schema.decodeUnknownEffect(AccountResponseSchema, responseParseOptions)
+const decodeAsset = Schema.decodeUnknownEffect(AssetResponseSchema, responseParseOptions)
 const decodePositions = Schema.decodeUnknownEffect(Schema.Array(PositionResponseSchema), responseParseOptions)
 const decodeOrders = Schema.decodeUnknownEffect(Schema.Array(OrderResponseSchema), responseParseOptions)
 const decodeOrder = Schema.decodeUnknownEffect(OrderResponseSchema, responseParseOptions)
@@ -578,6 +632,7 @@ const decodeErrorResponse = Schema.decodeUnknownEffect(ErrorResponseSchema, resp
 const decodeOrdersQuery = Schema.decodeUnknownEffect(OrdersQuerySchema, inputParseOptions)
 const decodeFillActivitiesQuery = Schema.decodeUnknownEffect(FillActivitiesQuerySchema, inputParseOptions)
 const decodeMarketCalendarQuery = Schema.decodeUnknownEffect(MarketCalendarQuerySchema, inputParseOptions)
+const decodeAssetSymbol = Schema.decodeUnknownEffect(SymbolName)
 const decodeOrderId = Schema.decodeUnknownEffect(Uuid)
 const decodeClientOrderId = Schema.decodeUnknownEffect(ClientOrderId)
 const decodeRuntimeOptions = Schema.decodeUnknownEffect(RuntimeOptionsSchema, inputParseOptions)
@@ -647,6 +702,7 @@ const invalidResponse = (
     status: evidence?.status,
     requestId: evidence?.requestId,
     contentHash: evidence?.contentHash,
+    observedAt: evidence?.observedAt,
     cause: cause === undefined ? undefined : safeCause(cause),
   })
 
@@ -799,6 +855,44 @@ const normalizePosition = (
     marketValueMicros,
     unrealizedPnlMicros: decimalToMicros(raw.unrealized_pl, true, 'unrealized PnL'),
     observedAt,
+  }
+}
+
+const assetRequestMaterial = (requestedSymbol: string) => ({
+  schemaVersion: assetObservationSchemaVersion,
+  source: assetObservationSource,
+  method: 'GET' as const,
+  path: `/v2/assets/${encodeURIComponent(requestedSymbol)}`,
+  requestedSymbol,
+})
+
+const normalizeAsset = (
+  raw: typeof AssetResponseSchema.Type,
+  requestedSymbol: string,
+  observedAt: string,
+): AssetObservation => {
+  if (raw.symbol !== requestedSymbol) {
+    throw new Error(`asset lookup returned symbol ${raw.symbol}, expected ${requestedSymbol}`)
+  }
+  const requestHash = canonicalHashV1(assetRequestMaterial(requestedSymbol))
+  const normalized = {
+    schemaVersion: assetObservationSchemaVersion,
+    source: assetObservationSource,
+    requestedSymbol,
+    requestHash,
+    assetId: raw.id,
+    symbol: raw.symbol,
+    assetClass: raw.class,
+    exchange: raw.exchange,
+    status: raw.status,
+    tradable: raw.tradable,
+    fractionable: raw.fractionable,
+    attributes: [...new Set(raw.attributes ?? [])].sort(),
+  }
+  return {
+    ...normalized,
+    observedAt,
+    normalizedResponseHash: canonicalHashV1(normalized),
   }
 }
 
@@ -1085,7 +1179,6 @@ export const make = (options: ReadOptions): Effect.Effect<BrokerReadShape, Broke
         const response = yield* client
           .execute(request)
           .pipe(Effect.mapError((cause) => transportError(operation, cause, sensitiveValues)))
-        const observedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
         const headers = yield* decodeResponseHeaders(response).pipe(
           Effect.mapError((cause) =>
             invalidResponse(
@@ -1116,13 +1209,14 @@ export const make = (options: ReadOptions): Effect.Effect<BrokerReadShape, Broke
               cause,
             ),
         })
+        const observedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
         const evidence = yield* Effect.try({
           try: () => responseEvidence(headers, response.status, contentHash, observedAt),
           catch: (cause) =>
             invalidResponse(
               operation,
               `Alpaca ${operation} rate-limit metadata is invalid`,
-              { status: response.status, requestId: headers['x-request-id'], contentHash },
+              { status: response.status, requestId: headers['x-request-id'], contentHash, observedAt },
               cause,
             ),
         })
@@ -1200,6 +1294,20 @@ export const make = (options: ReadOptions): Effect.Effect<BrokerReadShape, Broke
         ),
       ),
     )
+
+    const assetBySymbol = (symbol: string) =>
+      decodeInput('asset-by-symbol', decodeAssetSymbol, symbol, 'invalid Alpaca asset symbol').pipe(
+        Effect.flatMap((decoded) => {
+          const request = assetRequestMaterial(decoded)
+          return readJson('asset-by-symbol', new URL(request.path, paperTradingUrl), decodeAsset).pipe(
+            Effect.flatMap((result) =>
+              normalize('asset-by-symbol', result.evidence, () =>
+                normalizeAsset(result.value, decoded, result.evidence.observedAt),
+              ),
+            ),
+          )
+        }),
+      )
 
     const marketCalendar = (query: MarketCalendarQuery) =>
       decodeInput('market-calendar', decodeMarketCalendarQuery, query, 'invalid Alpaca market calendar query').pipe(
@@ -1289,7 +1397,7 @@ export const make = (options: ReadOptions): Effect.Effect<BrokerReadShape, Broke
         ),
       )
 
-    return { account, positions, orders, orderById, orderByClientId, fillActivities, marketCalendar }
+    return { account, assetBySymbol, positions, orders, orderById, orderByClientId, fillActivities, marketCalendar }
   })
 
 const missingOrderId = '00000000-0000-4000-8000-000000000000'

--- a/services/bayn/src/cycle-runner.test.ts
+++ b/services/bayn/src/cycle-runner.test.ts
@@ -11,6 +11,7 @@ import {
   type MarketCalendarObservation,
   type MarketCalendarQuery,
 } from './broker/alpaca'
+import { unusedAssetBySymbol } from './broker/alpaca-test-support'
 import {
   CycleState,
   CycleTerminalReason,
@@ -122,6 +123,7 @@ const brokerRead = (marketCalendar: BrokerReadShape['marketCalendar']): BrokerRe
   const unused = Effect.die(new Error('cycle runner must use only the broker calendar read'))
   return {
     account: unused,
+    assetBySymbol: unusedAssetBySymbol,
     positions: unused,
     orders: () => unused,
     orderById: () => unused,

--- a/services/bayn/src/db/cycle-store.integration.test.ts
+++ b/services/bayn/src/db/cycle-store.integration.test.ts
@@ -6,6 +6,7 @@ import { Cause, Effect, Exit, Layer, ManagedRuntime, Option, Redacted } from 'ef
 import { TestClock } from 'effect/testing'
 
 import { BrokerRead, type BrokerReadShape, type MarketCalendarObservation } from '../broker/alpaca'
+import { unusedAssetBySymbol } from '../broker/alpaca-test-support'
 import {
   CycleState,
   CycleTerminalReason,
@@ -387,6 +388,7 @@ const runnerBrokerRead = (queries: Array<{ readonly start: string; readonly end:
   const unused = Effect.die(new Error('autonomous cycle runner must use only marketCalendar'))
   return {
     account: unused,
+    assetBySymbol: unusedAssetBySymbol,
     positions: unused,
     orders: () => unused,
     orderById: () => unused,

--- a/services/bayn/src/execution/coordinator.test.ts
+++ b/services/bayn/src/execution/coordinator.test.ts
@@ -26,7 +26,7 @@ import {
   type BrokerReadShape,
   type Order,
 } from '../broker/alpaca'
-import { unusedMarketCalendar } from '../broker/alpaca-test-support'
+import { unusedAssetBySymbol, unusedMarketCalendar } from '../broker/alpaca-test-support'
 import { canonicalHashV1 } from '../hash'
 import {
   IntentState,
@@ -378,6 +378,7 @@ const makeHarness = (options: HarnessOptions = {}) => {
 
   const read: BrokerReadShape = {
     account: Effect.die(new Error('unexpected account read')),
+    assetBySymbol: unusedAssetBySymbol,
     positions: Effect.die(new Error('unexpected positions read')),
     orders: () => Effect.die(new Error('unexpected orders read')),
     orderById: () => Effect.die(new Error('unexpected order-by-id read')),

--- a/services/bayn/src/health.test.ts
+++ b/services/bayn/src/health.test.ts
@@ -6,7 +6,7 @@ import { TestClock } from 'effect/testing'
 import { config, successfulJournal, readyState, recoveringStore } from './app-test-support'
 import { monitor, probe } from './app'
 import { AccountStatus, type BrokerReadShape, type ReadResult, type Account } from './broker/alpaca'
-import { unusedMarketCalendar } from './broker/alpaca-test-support'
+import { unusedAssetBySymbol, unusedMarketCalendar } from './broker/alpaca-test-support'
 import { CycleOperationsCondition, CycleOperationsReason, type CycleOperationsProjection } from './cycle-observability'
 import { CycleState } from './cycle'
 import { CycleObservability, type CycleObservabilityShape } from './db/cycle-observability'
@@ -43,6 +43,7 @@ const brokerRead = (account: BrokerReadShape['account']): BrokerReadShape => {
   const unused = Effect.die(new Error('continuous broker health must only read the account'))
   return {
     account,
+    assetBySymbol: unusedAssetBySymbol,
     positions: unused,
     orders: () => unused,
     orderById: () => unused,

--- a/services/bayn/src/http.test.ts
+++ b/services/bayn/src/http.test.ts
@@ -13,7 +13,7 @@ import {
   readyState,
 } from './app-test-support'
 import type { BrokerReadShape } from './broker/alpaca'
-import { unusedMarketCalendar } from './broker/alpaca-test-support'
+import { unusedAssetBySymbol, unusedMarketCalendar } from './broker/alpaca-test-support'
 import { DatabaseError, type EvidenceStoreService } from './db/evidence-store'
 import type { BrokerProbe } from './health'
 import { makeHttpLayer, renderPrometheusMetrics } from './http'
@@ -350,6 +350,7 @@ describe('Bayn HTTP probes', () => {
     const unused = Effect.die(new Error('status must not invoke broker reads'))
     const read: BrokerReadShape = {
       account: unused,
+      assetBySymbol: unusedAssetBySymbol,
       positions: unused,
       orders: () => unused,
       orderById: () => unused,

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -4,6 +4,7 @@ import { Effect } from 'effect'
 import { TestClock } from 'effect/testing'
 
 import type { BrokerReadShape, MarketCalendarObservation, ReadResult } from './broker/alpaca'
+import { unusedAssetBySymbol } from './broker/alpaca-test-support'
 import {
   CycleState,
   decodeAutonomousCycle,
@@ -415,6 +416,7 @@ describe('OBSERVE runtime composition', () => {
     }
     const brokerRead: BrokerReadShape = {
       account: unused,
+      assetBySymbol: unusedAssetBySymbol,
       positions: unused,
       orders: () => unused,
       orderById: () => unused,

--- a/services/bayn/src/reconciler.test.ts
+++ b/services/bayn/src/reconciler.test.ts
@@ -21,7 +21,7 @@ import {
   type Order as BrokerOrder,
   type ReadEvidence,
 } from './broker/alpaca'
-import { unusedMarketCalendar } from './broker/alpaca-test-support'
+import { unusedAssetBySymbol, unusedMarketCalendar } from './broker/alpaca-test-support'
 import { canonicalHashV1 } from './hash'
 import { ReconciliationStatus, type AccountingReceipt, type Valuation } from './paper'
 import { PaperStore, type PaperStoreShape } from './db/paper-store'
@@ -207,6 +207,7 @@ const makeStore = (control: StoreControl, hasAccountBaseline = true): PaperStore
 
 const emptyRead = (): BrokerReadShape => ({
   account: Effect.succeed({ value: account, evidence: evidence('account') }),
+  assetBySymbol: unusedAssetBySymbol,
   positions: Effect.succeed({ value: [], evidence: evidence('positions') }),
   orders: () => Effect.succeed({ value: [], evidence: evidence('orders') }),
   fillActivities: () => Effect.succeed({ value: { items: [] }, evidence: evidence('fills') }),


### PR DESCRIPTION
## Summary

- add one strict GET-only `BrokerRead.assetBySymbol` capability with exact symbol matching, policy-neutral asset facts, canonical request/normalized response hashes, and raw HTTP evidence
- preserve inactive, non-tradable, non-fractionable, nullable attributes, and `ipo` truth while rejecting malformed responses and the internal empty-exchange sentinel
- sample shared broker-read time after complete body consumption and raw hashing, retaining that causal timestamp on typed invalid-response failures
- update BrokerRead test doubles and the narrow Bayn read-boundary documentation without composing the capability into runtime policy

## Related Issues

PROOMPT-375 prerequisite; does not close the issue.

## Testing

- `bun test src/broker/alpaca.test.ts` (25 passed)
- `bun test` (359 passed, 87 PostgreSQL integration tests skipped because no local test database was configured)
- `bun run lint`
- `bun run lint:oxlint`
- `bun run lint:oxlint:type`
- `bun run tsc`
- `bun run build`
- `git diff --check`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.