### PR TITLE
feat(bayn): add paper proof discovery

### DIFF
--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -131,7 +131,8 @@ strategy or target planner, or compose `PaperStore`, `WriterFence`, any intent/m
 latest cycle must be `COMPLETED` with zero unfinished cycles, and its strict persisted shadow document must remain
 `PLANNED`, unexpired, bound to the same cycle, operational snapshot, account, terminal qualification, strategy,
 source-controlled risk policy, and latest exact reconciliation. Durable maximum and effective authority must both be
-`OBSERVE`, and every delta must have only the mandatory `AuthorityNotPaper` risk failure.
+`OBSERVE`, the durable authority generation must match the configured decoded generation hash, and every delta must
+have only the mandatory `AuthorityNotPaper` risk failure.
 
 After that immutable read snapshot, DISCOVER performs exactly one account GET and one asset GET for every ordered
 persisted target delta, with bounded concurrency and restored document order. It emits every candidate without

--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -117,6 +117,35 @@ paper mutation capability, execution entry point, and capital-promotion path rem
   the PostgreSQL commit, and one successful continuous check. Strategy rejection is an auditable economic
   `FAIL_CLOSED`; it remains separate from operational health and never expands authority.
 
+## PAPER proof discovery
+
+The production executable has one explicit non-mutating proof-discovery mode. With neither `BAYN_PAPER_COMMAND` nor
+`BAYN_PAPER_PREPARE_PHASE` set, Bayn follows its existing OBSERVE service and HTTP lifecycle unchanged. The only
+accepted command pair is `BAYN_PAPER_COMMAND=PREPARE` with `BAYN_PAPER_PREPARE_PHASE=DISCOVER`; it has no default,
+requires maximum authority `OBSERVE`, a terminal qualification pin, and a complete GET-only Alpaca account binding,
+and exits before the HTTP application or autonomous loop is constructed.
+
+DISCOVER opens one PostgreSQL `REPEATABLE READ, READ ONLY` transaction through the shared client and uses only
+`CycleObservability` and `CycleStore` domain reads. It does not run migrations, create a reconciliation, re-run the
+strategy or target planner, or compose `PaperStore`, `WriterFence`, any intent/mutation store, or broker mutation. The
+latest cycle must be `COMPLETED` with zero unfinished cycles, and its strict persisted shadow document must remain
+`PLANNED`, unexpired, bound to the same cycle, operational snapshot, account, terminal qualification, strategy,
+source-controlled risk policy, and latest exact reconciliation. Every delta must have only the mandatory
+`AuthorityNotPaper` risk failure.
+
+After that immutable read snapshot, DISCOVER performs exactly one account GET and one asset GET for every ordered
+persisted target delta, with bounded concurrency and restored document order. It emits every candidate without
+selecting or filtering one. Persisted quantity, reference-price, notional, and risk values are labeled as historical
+OBSERVE plan facts; they are non-authorizing and are not a future quantity cap. Asset eligibility is an explicit
+review fact covering US equity class, active, tradable, fractionable, non-OTC, no `ipo`, and no `ptp_no_exception`;
+ineligible assets remain in the receipt with all reasons and raw normalized evidence.
+
+The ephemeral typed receipt contains an immutable cycle/document binding hash, a semantic `candidateFactsHash` that
+excludes volatile observation timestamps and request metadata, and a complete observation receipt hash that changes
+with fresh broker evidence. It exposes no Alpaca account number or credentials, writes no dossier, and reports
+`consistencyDelayMs.status=REQUIRED_UNBOUND`; final PREPARE/SUBMIT/CANCEL/RECOVER and fresh SUBMIT-time planning remain
+separate gated work.
+
 ## Endpoints
 
 - `GET /livez`: process liveness.

--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -130,8 +130,8 @@ DISCOVER opens one PostgreSQL `REPEATABLE READ, READ ONLY` transaction through t
 strategy or target planner, or compose `PaperStore`, `WriterFence`, any intent/mutation store, or broker mutation. The
 latest cycle must be `COMPLETED` with zero unfinished cycles, and its strict persisted shadow document must remain
 `PLANNED`, unexpired, bound to the same cycle, operational snapshot, account, terminal qualification, strategy,
-source-controlled risk policy, and latest exact reconciliation. Every delta must have only the mandatory
-`AuthorityNotPaper` risk failure.
+source-controlled risk policy, and latest exact reconciliation. Durable maximum and effective authority must both be
+`OBSERVE`, and every delta must have only the mandatory `AuthorityNotPaper` risk failure.
 
 After that immutable read snapshot, DISCOVER performs exactly one account GET and one asset GET for every ordered
 persisted target delta, with bounded concurrency and restored document order. It emits every candidate without

--- a/services/bayn/src/config.test.ts
+++ b/services/bayn/src/config.test.ts
@@ -51,6 +51,7 @@ describe('Effect configuration', () => {
     expect(config.host).toBe('0.0.0.0')
     expect(config.port).toBe(8080)
     expect(config.qualificationRunId).toBeUndefined()
+    expect(config.paperProofCommand).toBeUndefined()
     expect(config.maximumAuthority).toBe(Authority.Observe)
     expect(config.healthIntervalMs).toBe(30_000)
     expect(config.operationTimeoutMs).toBe(30_000)
@@ -90,6 +91,85 @@ describe('Effect configuration', () => {
     const config = await Effect.runPromise(provideEnvironment(loadConfig(buildMetadata), pinned))
 
     expect(config.qualificationRunId).toBe('e'.repeat(64))
+  })
+
+  test('enables only an explicit OBSERVE PREPARE DISCOVER command', async () => {
+    const configured = new Map(runtimeEnvironment)
+    configured.set('BAYN_QUALIFICATION_RUN_ID', 'e'.repeat(64))
+    configured.set('BAYN_ALPACA_ACCOUNT_ID', '61e69015-8549-4bfd-b9c3-01e75843f47d')
+    configured.set('BAYN_ALPACA_KEY_ID', 'paper-key')
+    configured.set('BAYN_ALPACA_SECRET_KEY', 'paper-secret')
+    configured.set('BAYN_PAPER_COMMAND', 'PREPARE')
+    configured.set('BAYN_PAPER_PREPARE_PHASE', 'DISCOVER')
+
+    const config = await Effect.runPromise(provideEnvironment(loadConfig(buildMetadata), configured))
+
+    expect(config.paperProofCommand).toEqual({ command: 'PREPARE', phase: 'DISCOVER' })
+    expect(config.maximumAuthority).toBe(Authority.Observe)
+  })
+
+  test('rejects invalid, incomplete, and PAPER discovery commands before runtime composition', async () => {
+    const complete = new Map(runtimeEnvironment)
+    complete.set('BAYN_QUALIFICATION_RUN_ID', 'e'.repeat(64))
+    complete.set('BAYN_ALPACA_ACCOUNT_ID', '61e69015-8549-4bfd-b9c3-01e75843f47d')
+    complete.set('BAYN_ALPACA_KEY_ID', 'paper-key')
+    complete.set('BAYN_ALPACA_SECRET_KEY', 'paper-secret')
+
+    const invalid = new Map(complete)
+    invalid.set('BAYN_PAPER_COMMAND', 'SUBMIT')
+    invalid.set('BAYN_PAPER_PREPARE_PHASE', 'DISCOVER')
+    expect(await Effect.runPromise(Effect.flip(provideEnvironment(loadConfig(buildMetadata), invalid)))).toMatchObject({
+      _tag: 'OperationalError',
+      component: 'config',
+      operation: 'load',
+    })
+
+    const incomplete = new Map(complete)
+    incomplete.set('BAYN_PAPER_COMMAND', 'PREPARE')
+    expect(
+      await Effect.runPromise(Effect.flip(provideEnvironment(loadConfig(buildMetadata), incomplete))),
+    ).toMatchObject({
+      _tag: 'OperationalError',
+      component: 'config',
+      operation: 'paper-command',
+    })
+
+    const missingPin = new Map(complete)
+    missingPin.delete('BAYN_QUALIFICATION_RUN_ID')
+    missingPin.set('BAYN_PAPER_COMMAND', 'PREPARE')
+    missingPin.set('BAYN_PAPER_PREPARE_PHASE', 'DISCOVER')
+    expect(
+      await Effect.runPromise(Effect.flip(provideEnvironment(loadConfig(buildMetadata), missingPin))),
+    ).toMatchObject({
+      _tag: 'OperationalError',
+      component: 'config',
+      operation: 'paper-command',
+      message: 'PREPARE DISCOVER requires a pinned terminal qualification run',
+    })
+
+    const missingBroker = new Map(runtimeEnvironment)
+    missingBroker.set('BAYN_QUALIFICATION_RUN_ID', 'e'.repeat(64))
+    missingBroker.set('BAYN_PAPER_COMMAND', 'PREPARE')
+    missingBroker.set('BAYN_PAPER_PREPARE_PHASE', 'DISCOVER')
+    expect(
+      await Effect.runPromise(Effect.flip(provideEnvironment(loadConfig(buildMetadata), missingBroker))),
+    ).toMatchObject({
+      _tag: 'OperationalError',
+      component: 'config',
+      operation: 'paper-command',
+      message: 'PREPARE DISCOVER requires a complete Alpaca read binding',
+    })
+
+    const paper = new Map(complete)
+    paper.set('BAYN_PAPER_COMMAND', 'PREPARE')
+    paper.set('BAYN_PAPER_PREPARE_PHASE', 'DISCOVER')
+    paper.set('BAYN_MAXIMUM_AUTHORITY', Authority.Paper)
+    expect(await Effect.runPromise(Effect.flip(provideEnvironment(loadConfig(buildMetadata), paper)))).toMatchObject({
+      _tag: 'OperationalError',
+      component: 'config',
+      operation: 'paper-command',
+      message: 'PREPARE DISCOVER requires OBSERVE maximum authority',
+    })
   })
 
   test('allows no authority generation while autonomous cycle composition is disabled', async () => {

--- a/services/bayn/src/config.ts
+++ b/services/bayn/src/config.ts
@@ -18,10 +18,16 @@ export interface RuntimeBuildMetadata extends EmbeddedBuildMetadata {
   readonly verification: 'embedded' | 'development-configured'
 }
 
+export interface PaperProofRuntimeCommand {
+  readonly command: 'PREPARE'
+  readonly phase: 'DISCOVER'
+}
+
 export interface RuntimeConfig {
   readonly host: string
   readonly port: number
   readonly qualificationRunId?: string
+  readonly paperProofCommand?: PaperProofRuntimeCommand
   readonly maximumAuthority: Authority
   readonly build: RuntimeBuildMetadata
   readonly healthIntervalMs: number
@@ -102,6 +108,8 @@ const runtimeConfig = Config.all({
   strategyParameterHash: Config.schema(Sha256Schema, 'BAYN_STRATEGY_PARAMETER_HASH'),
   provenanceMode: Config.schema(ProvenanceMode, 'BAYN_PROVENANCE_MODE').pipe(Config.withDefault('production')),
   qualificationRunId: Config.option(Config.schema(Sha256Schema, 'BAYN_QUALIFICATION_RUN_ID')),
+  paperProofCommand: Config.option(Config.schema(Schema.Literal('PREPARE'), 'BAYN_PAPER_COMMAND')),
+  paperProofPhase: Config.option(Config.schema(Schema.Literal('DISCOVER'), 'BAYN_PAPER_PREPARE_PHASE')),
   maximumAuthority: Config.schema(Schema.Enum(Authority), 'BAYN_MAXIMUM_AUTHORITY').pipe(
     Config.withDefault(Authority.Observe),
   ),
@@ -144,6 +152,8 @@ const runtimeConfig = Config.all({
     host: config.host,
     port: config.port,
     qualificationRunId: Option.getOrUndefined(config.qualificationRunId),
+    configuredPaperProofCommand: config.paperProofCommand,
+    configuredPaperProofPhase: config.paperProofPhase,
     maximumAuthority: config.maximumAuthority,
     configuredBuild: {
       sourceRevision: config.sourceRevision,
@@ -266,12 +276,57 @@ export const loadConfig = (
           operationalError('config', 'alpaca', 'PAPER maximum authority requires a complete Alpaca account binding'),
         )
       }
+      const commandConfigured = Option.isSome(config.configuredPaperProofCommand)
+      const phaseConfigured = Option.isSome(config.configuredPaperProofPhase)
+      if (commandConfigured !== phaseConfigured) {
+        return Effect.fail(
+          operationalError(
+            'config',
+            'paper-command',
+            'BAYN_PAPER_COMMAND and BAYN_PAPER_PREPARE_PHASE must be configured together',
+          ),
+        )
+      }
+      if (commandConfigured) {
+        if (config.maximumAuthority !== Authority.Observe) {
+          return Effect.fail(
+            operationalError('config', 'paper-command', 'PREPARE DISCOVER requires OBSERVE maximum authority'),
+          )
+        }
+        if (config.qualificationRunId === undefined) {
+          return Effect.fail(
+            operationalError(
+              'config',
+              'paper-command',
+              'PREPARE DISCOVER requires a pinned terminal qualification run',
+            ),
+          )
+        }
+        if (Option.isNone(alpaca)) {
+          return Effect.fail(
+            operationalError('config', 'paper-command', 'PREPARE DISCOVER requires a complete Alpaca read binding'),
+          )
+        }
+      }
+      const paperProofCommand =
+        Option.isSome(config.configuredPaperProofCommand) && Option.isSome(config.configuredPaperProofPhase)
+          ? {
+              command: config.configuredPaperProofCommand.value,
+              phase: config.configuredPaperProofPhase.value,
+            }
+          : undefined
       const {
         configuredAlpaca: _configuredAlpaca,
         authorityGenerationHash: _authorityGenerationHash,
+        configuredPaperProofCommand: _configuredPaperProofCommand,
+        configuredPaperProofPhase: _configuredPaperProofPhase,
         ...runtime
       } = config
-      return Effect.succeed({ ...runtime, ...(Option.isSome(alpaca) ? { alpaca: alpaca.value } : {}) })
+      return Effect.succeed({
+        ...runtime,
+        ...(paperProofCommand === undefined ? {} : { paperProofCommand }),
+        ...(Option.isSome(alpaca) ? { alpaca: alpaca.value } : {}),
+      })
     }),
     Effect.flatMap((config) =>
       Effect.try({

--- a/services/bayn/src/index.ts
+++ b/services/bayn/src/index.ts
@@ -1,28 +1,31 @@
 import { NodeHttpClient, NodeRuntime, NodeServices } from '@effect/platform-node'
 import { ClickhouseClient } from '@effect/sql-clickhouse'
-import { Context, Effect, Layer, Logger, Redacted } from 'effect'
+import { PgClient } from '@effect/sql-pg'
+import { Context, Effect, Layer, Logger, Redacted, Schema, Stdio, Stream } from 'effect'
 
 import { run } from './app'
 import { riskBalancedTrendBehaviorHash } from './behavior'
-import { BrokerRead, live as AlpacaReadLive } from './broker/alpaca'
+import { BrokerRead, alpacaHttpLayer, live as AlpacaReadLive, make as makeAlpacaRead } from './broker/alpaca'
 import { verifyBehaviorHash, verifyParameterHash } from './build'
-import { loadConfig } from './config'
-import { makeRuntimeProvenance } from './contracts'
-import { CycleObservabilityLive } from './db/cycle-observability'
+import { loadConfig, type LoadedRuntimeConfig } from './config'
+import { makeRuntimeProvenance, makeStrategyProtocolHash } from './contracts'
+import { CycleObservability, CycleObservabilityLive } from './db/cycle-observability'
 import { CycleStore, CycleStoreLive } from './db/cycle-store'
-import { EvidenceStoreLive } from './db/evidence-store'
+import { EvidenceStoreLive, PostgresClientLive } from './db/evidence-store'
 import { PaperStore, PaperStoreLive } from './db/paper-store'
 import { WriterFence, WriterFenceLive } from './execution/writer-fence'
 import { operationalError } from './errors'
+import { canonicalHashV1 } from './hash'
 import type { BrokerProbe } from './health'
 import { JournalLive } from './ledger'
 import { MarketData, MarketDataLive } from './market-data'
-import { makeObserveAutonomousCycleStartup } from './observe-composition'
+import { loadObserveRiskPolicy, makeObserveAutonomousCycleStartup } from './observe-composition'
 import { acquireSqlLayer } from './operations'
 import { Authority } from './paper'
+import { discoverPaperProofCandidates } from './paper-proof-discovery'
 import { hashParameters, loadDefaultProtocol } from './protocol'
 import { runOnce } from './reconciler'
-import { makeStrategy } from './strategy'
+import { makeStrategy, type Strategy } from './strategy'
 
 const main = Effect.gen(function* () {
   const config = yield* loadConfig()
@@ -46,6 +49,9 @@ const main = Effect.gen(function* () {
     },
   })
   const strategy = makeStrategy(protocol, provenance)
+  if (config.paperProofCommand !== undefined) {
+    return yield* runPaperProofDiscovery(config, strategy)
+  }
   const clickhouse = yield* acquireSqlLayer(
     ClickhouseClient.layer({
       url: config.clickhouse.url,
@@ -138,6 +144,63 @@ const main = Effect.gen(function* () {
   )
   return yield* run(config, strategy, Effect.void, broker, autonomousCycleStartup).pipe(Effect.provide(dependencies))
 }).pipe(Effect.scoped)
+
+const encodeJson = Schema.encodeUnknownEffect(Schema.fromJsonString(Schema.Json))
+
+const runPaperProofDiscovery = (config: LoadedRuntimeConfig, strategy: Strategy) =>
+  Effect.gen(function* () {
+    const alpaca = config.alpaca
+    const qualificationRunId = config.qualificationRunId
+    if (alpaca === undefined || qualificationRunId === undefined) {
+      return yield* Effect.fail(
+        operationalError(
+          'config',
+          'paper-command',
+          'PREPARE DISCOVER requires Alpaca reads and a pinned qualification',
+        ),
+      )
+    }
+    const policy = yield* loadObserveRiskPolicy(alpaca.accountId, strategy.parameters.universe).pipe(
+      Effect.mapError((cause) =>
+        operationalError('config', 'paper-command', 'source-controlled OBSERVE risk policy is invalid', cause),
+      ),
+    )
+    const postgres = yield* acquireSqlLayer(PostgresClientLive(config).pipe(Layer.provide(NodeServices.layer)))
+    const postgresLayer = Layer.succeedContext(postgres)
+    const observabilityContext = yield* Layer.build(CycleObservabilityLive.pipe(Layer.provide(postgresLayer)))
+    const cycleStoreContext = yield* Layer.build(CycleStoreLive.pipe(Layer.provide(postgresLayer)))
+    const brokerRead = yield* makeAlpacaRead({
+      expectedAccountId: alpaca.accountId,
+      key: alpaca.key,
+      secret: alpaca.secret,
+      proxyUrl: alpaca.proxyUrl,
+      operationTimeoutMs: config.operationTimeoutMs,
+      retryAttempts: alpaca.retryAttempts,
+    }).pipe(
+      Effect.provide(alpacaHttpLayer(alpaca.proxyUrl)),
+      Effect.mapError((cause) => operationalError('config', 'alpaca', 'Alpaca paper account binding failed', cause)),
+    )
+    const receipt = yield* discoverPaperProofCandidates({
+      sourceRevision: config.build.sourceRevision,
+      image: {
+        repository: config.build.imageRepository,
+        digest: config.build.imageDigest,
+      },
+      strategy: strategy.provenance.strategy,
+      strategyProtocolHash: makeStrategyProtocolHash(strategy.provenance.strategy),
+      qualificationRunId,
+      accountId: alpaca.accountId,
+      policyHash: canonicalHashV1(policy),
+    }).pipe(
+      Effect.provideService(PgClient.PgClient, Context.get(postgres, PgClient.PgClient)),
+      Effect.provideService(CycleObservability, Context.get(observabilityContext, CycleObservability)),
+      Effect.provideService(CycleStore, Context.get(cycleStoreContext, CycleStore)),
+      Effect.provideService(BrokerRead, brokerRead),
+    )
+    const output = yield* encodeJson(receipt)
+    const stdio = yield* Stdio.Stdio
+    yield* Stream.run(Stream.make(`${output}\n`), stdio.stdout())
+  }).pipe(Effect.provide(NodeServices.layer))
 
 const program = main.pipe(Effect.annotateLogs({ service: 'bayn' }), Effect.provide(Logger.layer([Logger.consoleJson])))
 

--- a/services/bayn/src/index.ts
+++ b/services/bayn/src/index.ts
@@ -190,6 +190,7 @@ const runPaperProofDiscovery = (config: LoadedRuntimeConfig, strategy: Strategy)
       strategyProtocolHash: makeStrategyProtocolHash(strategy.provenance.strategy),
       qualificationRunId,
       accountId: alpaca.accountId,
+      authorityGenerationHash: alpaca.authorityGenerationHash,
       policyHash: canonicalHashV1(policy),
     }).pipe(
       Effect.provideService(PgClient.PgClient, Context.get(postgres, PgClient.PgClient)),

--- a/services/bayn/src/paper-proof-discovery.test.ts
+++ b/services/bayn/src/paper-proof-discovery.test.ts
@@ -23,7 +23,7 @@ import { CycleObservability, type CycleObservabilityShape } from './db/cycle-obs
 import { CycleStore, type CycleStoreShape } from './db/cycle-store'
 import { PostgresClientLive } from './db/evidence-store'
 import { canonicalHashV1 } from './hash'
-import { Authority, OrderSide, OrderType, ReconciliationStatus, RiskOutcome, TimeInForce } from './paper'
+import { Authority, KillState, OrderSide, OrderType, ReconciliationStatus, RiskOutcome, TimeInForce } from './paper'
 import {
   PaperProofCandidateIneligibility,
   discoverPaperProofCandidates,
@@ -109,7 +109,13 @@ const projection = (): CycleOperationsProjection => ({
     updatedAt: '2099-07-23T20:10:00.000Z',
     terminalAt: '2099-07-23T20:10:00.000Z',
   },
-  authority: null,
+  authority: {
+    maximum: Authority.Observe,
+    effective: Authority.Observe,
+    kill: KillState.Clear,
+    reason: null,
+    updatedAt: '2099-07-23T20:04:00.000Z',
+  },
   reconciliation: {
     accountId,
     reconciliationId,
@@ -543,6 +549,30 @@ describe('paper proof DISCOVER', () => {
       ['missing cycle', (base) => ({ ...base, cycle: Option.none() }), 'cycle-missing', observedAt],
       ['missing document', (base) => ({ ...base, document: Option.none() }), 'document-missing', observedAt],
       ['stale document', (base) => base, 'document-stale', '2099-07-24T13:15:00.000Z'],
+      [
+        'missing durable authority',
+        (base) => ({ ...base, projection: { ...base.projection, authority: null } }),
+        'authority-mismatch',
+        observedAt,
+      ],
+      [
+        'PAPER durable authority',
+        (base) => ({
+          ...base,
+          projection: {
+            ...base.projection,
+            authority: {
+              maximum: Authority.Paper,
+              effective: Authority.Paper,
+              kill: KillState.Clear,
+              reason: null,
+              updatedAt: '2099-07-23T20:04:00.000Z',
+            },
+          },
+        }),
+        'authority-mismatch',
+        observedAt,
+      ],
       [
         'mismatched policy',
         (base) => ({

--- a/services/bayn/src/paper-proof-discovery.test.ts
+++ b/services/bayn/src/paper-proof-discovery.test.ts
@@ -42,6 +42,7 @@ const documentHash = hash('4')
 const policyHash = hash('5')
 const reconciliationId = hash('6')
 const reconciliationHash = hash('7')
+const authorityGenerationHash = hash('e')
 const cutoff = '2099-07-24T13:15:00.000Z'
 const observedAt = '2099-07-24T12:00:00.000Z'
 const strategy: RuntimeProvenance['strategy'] = {
@@ -60,6 +61,7 @@ const identity: PaperProofDiscoveryIdentity = {
   strategyProtocolHash: makeStrategyProtocolHash(strategy),
   qualificationRunId,
   accountId,
+  authorityGenerationHash,
   policyHash,
 }
 
@@ -110,6 +112,7 @@ const projection = (): CycleOperationsProjection => ({
     terminalAt: '2099-07-23T20:10:00.000Z',
   },
   authority: {
+    generationHash: authorityGenerationHash,
     maximum: Authority.Observe,
     effective: Authority.Observe,
     kill: KillState.Clear,
@@ -405,6 +408,7 @@ describe('paper proof DISCOVER', () => {
       authority: Authority.Observe,
       dispatchable: false,
       binding: {
+        runtime: { authorityGenerationHash },
         cycle: { cycleId, decisionHash: documentHash },
         document: { reconciliationId, policyHash },
       },
@@ -550,8 +554,23 @@ describe('paper proof DISCOVER', () => {
       ['missing document', (base) => ({ ...base, document: Option.none() }), 'document-missing', observedAt],
       ['stale document', (base) => base, 'document-stale', '2099-07-24T13:15:00.000Z'],
       [
-        'missing durable authority',
+        'missing durable authority generation',
         (base) => ({ ...base, projection: { ...base.projection, authority: null } }),
+        'authority-mismatch',
+        observedAt,
+      ],
+      [
+        'mismatched durable authority generation',
+        (base) => ({
+          ...base,
+          projection: {
+            ...base.projection,
+            authority: {
+              ...base.projection.authority!,
+              generationHash: hash('f'),
+            },
+          },
+        }),
         'authority-mismatch',
         observedAt,
       ],
@@ -562,6 +581,7 @@ describe('paper proof DISCOVER', () => {
           projection: {
             ...base.projection,
             authority: {
+              generationHash: authorityGenerationHash,
               maximum: Authority.Paper,
               effective: Authority.Paper,
               kill: KillState.Clear,

--- a/services/bayn/src/paper-proof-discovery.test.ts
+++ b/services/bayn/src/paper-proof-discovery.test.ts
@@ -1,0 +1,717 @@
+import { describe, expect, test } from 'bun:test'
+
+import { NodeServices } from '@effect/platform-node'
+import { PgClient } from '@effect/sql-pg'
+import { Cause, Effect, Exit, Layer, ManagedRuntime, Option, Redacted } from 'effect'
+import { TestClock } from 'effect/testing'
+
+import {
+  AccountStatus,
+  AssetClass,
+  AssetExchange,
+  AssetStatus,
+  BrokerRead,
+  type AssetObservation,
+  type BrokerReadShape,
+  type ReadEvidence,
+  type ReadResult,
+} from './broker/alpaca'
+import { makeStrategyProtocolHash, type RuntimeProvenance } from './contracts'
+import { CycleState, type AutonomousCycle } from './cycle'
+import type { CycleOperationsProjection } from './cycle-observability'
+import { CycleObservability, type CycleObservabilityShape } from './db/cycle-observability'
+import { CycleStore, type CycleStoreShape } from './db/cycle-store'
+import { PostgresClientLive } from './db/evidence-store'
+import { canonicalHashV1 } from './hash'
+import { Authority, OrderSide, OrderType, ReconciliationStatus, RiskOutcome, TimeInForce } from './paper'
+import {
+  PaperProofCandidateIneligibility,
+  discoverPaperProofCandidates,
+  type PaperProofDiscoveryIdentity,
+} from './paper-proof-discovery'
+import { Gate, Reason } from './risk'
+import type { ObserveShadowDecisionDocument } from './shadow-decision-contract'
+import { TargetPlanStatus } from './target-planner'
+
+const hash = (character: string): string => character.repeat(64)
+const accountId = '61e69015-8549-4bfd-b9c3-01e75843f47d'
+const qualificationRunId = hash('1')
+const snapshotId = hash('2')
+const cycleId = hash('3')
+const documentHash = hash('4')
+const policyHash = hash('5')
+const reconciliationId = hash('6')
+const reconciliationHash = hash('7')
+const cutoff = '2099-07-24T13:15:00.000Z'
+const observedAt = '2099-07-24T12:00:00.000Z'
+const strategy: RuntimeProvenance['strategy'] = {
+  name: 'risk-balanced-trend',
+  behaviorHash: hash('8'),
+  parameterHash: hash('9'),
+  parameterSchemaVersion: 'bayn.risk-balanced-trend.protocol.v3',
+}
+const identity: PaperProofDiscoveryIdentity = {
+  sourceRevision: 'a'.repeat(40),
+  image: {
+    repository: 'registry.ide-newton.ts.net/lab/bayn',
+    digest: `sha256:${hash('b')}`,
+  },
+  strategy,
+  strategyProtocolHash: makeStrategyProtocolHash(strategy),
+  qualificationRunId,
+  accountId,
+  policyHash,
+}
+
+const cycle = (): AutonomousCycle =>
+  ({
+    schemaVersion: 'bayn.autonomous-cycle.v1',
+    identity: {
+      cycleId,
+      strategyName: 'risk-balanced-trend',
+      qualificationRunId,
+      strategyProtocolHash: identity.strategyProtocolHash,
+      accountId,
+      signalSessionDate: '2099-07-23',
+      executionSessionDate: '2099-07-24',
+    },
+    window: {
+      submissionOpenAt: '2099-07-23T20:05:00.000Z',
+      submissionCutoffAt: cutoff,
+      executionOpenAt: '2099-07-24T13:30:00.000Z',
+      executionCloseAt: '2099-07-24T20:00:00.000Z',
+    },
+    state: CycleState.Completed,
+    bindings: { snapshotId, decisionHash: documentHash },
+    stateVersion: 4,
+    createdAt: '2099-07-23T20:05:00.000Z',
+    updatedAt: '2099-07-23T20:10:00.000Z',
+    terminalAt: '2099-07-23T20:10:00.000Z',
+  }) as unknown as AutonomousCycle
+
+const projection = (): CycleOperationsProjection => ({
+  current: null,
+  unfinishedCycleCount: 0,
+  last: {
+    cycleId,
+    accountId,
+    signalSessionDate: '2099-07-23',
+    executionSessionDate: '2099-07-24',
+    phase: CycleState.Completed,
+    snapshotId,
+    decisionHash: documentHash,
+    terminalReason: null,
+    submissionOpenAt: '2099-07-23T20:05:00.000Z',
+    submissionCutoffAt: cutoff,
+    executionOpenAt: '2099-07-24T13:30:00.000Z',
+    executionCloseAt: '2099-07-24T20:00:00.000Z',
+    createdAt: '2099-07-23T20:05:00.000Z',
+    updatedAt: '2099-07-23T20:10:00.000Z',
+    terminalAt: '2099-07-23T20:10:00.000Z',
+  },
+  authority: null,
+  reconciliation: {
+    accountId,
+    reconciliationId,
+    status: ReconciliationStatus.Exact,
+    discrepancyCount: 0,
+    reconciledAt: '2099-07-23T20:04:00.000Z',
+    coversLatestMutation: true,
+  },
+  mutations: {
+    eventCount: 0,
+    unresolvedCount: 0,
+    oldestUnresolvedAt: null,
+    latestOccurredAt: null,
+  },
+})
+
+const symbols = ['VNQ', 'SPY'] as const
+
+const risk = (ordinal: number) =>
+  ({
+    notionalLimitMicros: ordinal === 0 ? '125000000' : '200000000',
+    evaluation: {
+      policyHash,
+      input: {
+        inputHash: hash(ordinal === 0 ? 'c' : 'd'),
+        intentId: hash(ordinal === 0 ? 'e' : 'f'),
+      },
+      decision: {
+        decisionId: hash(ordinal === 0 ? 'a' : 'b'),
+        outcome: RiskOutcome.Blocked,
+        reasonCodes: [Reason.AuthorityNotPaper],
+      },
+      gates: Object.values(Gate).map((name) => ({
+        name,
+        passed: name !== Gate.Authority,
+        reason: name === Gate.Authority ? Reason.AuthorityNotPaper : Reason.KillActive,
+      })),
+      metrics: {
+        orderNotionalMicros: ordinal === 0 ? '100000000' : '150000000',
+      },
+    },
+  }) as unknown as ObserveShadowDecisionDocument['deltaRisk'][number]
+
+const document = (): ObserveShadowDecisionDocument =>
+  ({
+    schemaVersion: 'bayn.observe-shadow-decision.v1',
+    mode: 'OBSERVE',
+    dispatchable: false,
+    contentHash: documentHash,
+    bindings: {
+      strategyName: 'risk-balanced-trend',
+      cycleId,
+      strategyProtocolHash: identity.strategyProtocolHash,
+      snapshotId,
+      snapshotContentHash: hash('0'),
+      snapshotFinalizedAt: '2099-07-23T20:01:00.000Z',
+      strategyDecisionHash: hash('a'),
+      policyHash,
+      accountId,
+      planningBrokerStateHash: hash('b'),
+      reconciliationId,
+      reconciliationHash,
+    },
+    targetPlan: {
+      schemaVersion: 'bayn.paper-reference-target-plan.v1',
+      inputHash: hash('c'),
+      outputHash: hash('d'),
+      status: TargetPlanStatus.Planned,
+      reason: null,
+      targets: symbols.map((symbol, ordinal) => ({
+        symbol,
+        targetWeight: ordinal === 0 ? 0.4 : 0.6,
+        referencePriceMicros: ordinal === 0 ? '100123500' : '200000000',
+        currentQuantityMicros: '1000000',
+        targetQuantityMicros: ordinal === 0 ? '2250000' : '2000000',
+      })),
+      intentTargets: symbols.map((symbol, ordinal) => ({
+        strategyName: 'risk-balanced-trend',
+        cycleId,
+        decisionHash: hash('a'),
+        policyHash,
+        accountId,
+        symbol,
+        side: OrderSide.Buy,
+        orderType: OrderType.Market,
+        timeInForce: TimeInForce.Day,
+        quantityMicros: ordinal === 0 ? '1250000' : '1000000',
+        createdAt: '2099-07-23T20:05:00.000Z',
+      })),
+      requiredReferenceBuyNotionalMicros: '250000000',
+      availableBuyingPowerMicros: '500000000',
+      residualBuyingPowerMicros: '250000000',
+    },
+    deltaRisk: symbols.map((_, ordinal) => risk(ordinal)),
+    createdAt: '2099-07-23T20:05:00.000Z',
+    submissionCutoffAt: cutoff,
+    expiresAt: cutoff,
+  }) as unknown as ObserveShadowDecisionDocument
+
+const evidence = (suffix: string, time: string): ReadEvidence => ({
+  requestId: `request-${suffix}`,
+  status: 200,
+  contentHash: canonicalHashV1({ suffix }),
+  observedAt: time,
+  rateLimit: { limit: '200', remaining: '199' },
+})
+
+const account = (suffix = 'a', time = observedAt): BrokerReadShape['account'] =>
+  Effect.succeed({
+    value: {
+      id: accountId,
+      status: AccountStatus.Active,
+      currency: 'USD',
+      cashMicros: '500000000',
+      equityMicros: '1000000000',
+      buyingPowerMicros: '500000000',
+      accountBlocked: false,
+      tradingBlocked: false,
+      tradeSuspendedByUser: false,
+      observedAt: time,
+    },
+    evidence: evidence(suffix, time),
+  })
+
+const asset = (symbol: string, suffix = symbol.toLowerCase(), time = observedAt): ReadResult<AssetObservation> => {
+  const eligible = symbol === 'VNQ'
+  return {
+    value: {
+      schemaVersion: 'bayn.alpaca-asset-observation.v1',
+      source: 'alpaca-v2-asset',
+      requestedSymbol: symbol,
+      requestHash: symbol === 'VNQ' ? hash('1') : hash('2'),
+      assetId: symbol === 'VNQ' ? 'asset-vnq' : 'asset-spy',
+      symbol,
+      assetClass: eligible ? AssetClass.UsEquity : AssetClass.UsOption,
+      exchange: eligible ? AssetExchange.Arca : AssetExchange.Otc,
+      status: eligible ? AssetStatus.Active : AssetStatus.Inactive,
+      tradable: eligible,
+      fractionable: eligible,
+      attributes: eligible ? [] : ['ipo', 'ptp_no_exception'],
+      observedAt: time,
+      normalizedResponseHash: symbol === 'VNQ' ? hash('3') : hash('4'),
+    },
+    evidence: evidence(suffix, time),
+  }
+}
+
+interface TestControl {
+  assetSymbols: string[]
+  brokerAccountReads: number
+  cycleReads: number
+  decisionReads: number
+  inTransaction: boolean
+  statements: string[]
+  transactions: number
+}
+
+const control = (): TestControl => ({
+  assetSymbols: [],
+  brokerAccountReads: 0,
+  cycleReads: 0,
+  decisionReads: 0,
+  inTransaction: false,
+  statements: [],
+  transactions: 0,
+})
+
+const fakeSql = (state: TestControl): PgClient.PgClient => {
+  const sql = ((strings: TemplateStringsArray) => {
+    state.statements.push(strings.join('?').replace(/\s+/g, ' ').trim())
+    return Effect.succeed([])
+  }) as unknown as PgClient.PgClient
+  return Object.assign(sql, {
+    withTransaction: <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+      Effect.sync(() => {
+        state.transactions += 1
+        state.inTransaction = true
+      }).pipe(
+        Effect.andThen(effect),
+        Effect.ensuring(
+          Effect.sync(() => {
+            state.inTransaction = false
+          }),
+        ),
+      ),
+  }) as PgClient.PgClient
+}
+
+interface Fixture {
+  readonly projection: CycleOperationsProjection
+  readonly cycle: Option.Option<AutonomousCycle>
+  readonly document: Option.Option<ObserveShadowDecisionDocument>
+}
+
+const fixture = (): Fixture => ({
+  projection: projection(),
+  cycle: Option.some(cycle()),
+  document: Option.some(document()),
+})
+
+const stores = (state: TestControl, input: Fixture) => {
+  const inReadTransaction = <A>(value: A, operation: 'cycle' | 'document') =>
+    Effect.sync(() => {
+      if (!state.inTransaction) throw new Error(`${operation} read escaped the transaction`)
+      if (operation === 'cycle') state.cycleReads += 1
+      else state.decisionReads += 1
+      return value
+    })
+  const unexpected = () => Effect.die(new Error('unexpected CycleStore mutation or unrelated read'))
+  const observability: CycleObservabilityShape = {
+    read: () =>
+      Effect.sync(() => {
+        if (!state.inTransaction) throw new Error('observability read escaped the transaction')
+        return input.projection
+      }),
+  }
+  const cycleStore: CycleStoreShape = {
+    acquire: unexpected,
+    read: () => inReadTransaction(input.cycle, 'cycle'),
+    readAuthoritySlot: unexpected,
+    readDecisionDocument: () => inReadTransaction(input.document, 'document'),
+    readOldestUnfinished: unexpected,
+    bindSnapshot: unexpected,
+    activate: unexpected,
+    bindDecision: unexpected,
+    finish: unexpected,
+    block: unexpected,
+  }
+  return { observability, cycleStore }
+}
+
+const broker = (state: TestControl, suffix = 'a', time = observedAt): BrokerReadShape => {
+  const unexpected = Effect.die(new Error('unexpected broker read'))
+  return {
+    account: Effect.sync(() => {
+      state.brokerAccountReads += 1
+    }).pipe(Effect.andThen(account(suffix, time))),
+    assetBySymbol: (symbol) =>
+      Effect.sync(() => {
+        state.assetSymbols.push(symbol)
+        return asset(symbol, `${suffix}-${symbol.toLowerCase()}`, time)
+      }),
+    positions: unexpected,
+    orders: () => unexpected,
+    orderById: () => unexpected,
+    orderByClientId: () => unexpected,
+    fillActivities: () => unexpected,
+    marketCalendar: () => unexpected,
+  }
+}
+
+const program = (
+  state: TestControl,
+  input: Fixture = fixture(),
+  read: BrokerReadShape = broker(state),
+  now = observedAt,
+  sql: PgClient.PgClient = fakeSql(state),
+  candidateIdentity: PaperProofDiscoveryIdentity = identity,
+) => {
+  const { observability, cycleStore } = stores(state, input)
+  return Effect.gen(function* () {
+    yield* TestClock.setTime(Date.parse(now))
+    return yield* discoverPaperProofCandidates(candidateIdentity)
+  }).pipe(
+    Effect.provideService(PgClient.PgClient, sql),
+    Effect.provideService(CycleObservability, observability),
+    Effect.provideService(CycleStore, cycleStore),
+    Effect.provideService(BrokerRead, read),
+    Effect.provide(TestClock.layer()),
+  )
+}
+
+describe('paper proof DISCOVER', () => {
+  test('reads one immutable snapshot and emits every ordered candidate without mutation capabilities', async () => {
+    const state = control()
+    const receipt = await Effect.runPromise(program(state))
+
+    expect(state.transactions).toBe(1)
+    expect(state.statements).toEqual(['SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY'])
+    expect(state.cycleReads).toBe(1)
+    expect(state.decisionReads).toBe(1)
+    expect(state.brokerAccountReads).toBe(1)
+    expect(state.assetSymbols).toEqual([...symbols])
+    expect(receipt).toMatchObject({
+      command: 'PREPARE',
+      phase: 'DISCOVER',
+      authority: Authority.Observe,
+      dispatchable: false,
+      binding: {
+        cycle: { cycleId, decisionHash: documentHash },
+        document: { reconciliationId, policyHash },
+      },
+      candidateFacts: {
+        consistencyDelayMs: { status: 'REQUIRED_UNBOUND' },
+        candidates: [
+          {
+            ordinal: 0,
+            observedPlanIntentId: hash('e'),
+            symbol: 'VNQ',
+            observedPlannedQuantityMicros: '1250000',
+            observedReferencePriceMicros: '100123500',
+            assetEligibility: { eligible: true, reasons: [] },
+          },
+          {
+            ordinal: 1,
+            symbol: 'SPY',
+            observedPlannedQuantityMicros: '1000000',
+            assetEligibility: {
+              eligible: false,
+              reasons: [
+                PaperProofCandidateIneligibility.AssetClass,
+                PaperProofCandidateIneligibility.Inactive,
+                PaperProofCandidateIneligibility.NotTradable,
+                PaperProofCandidateIneligibility.NotFractionable,
+                PaperProofCandidateIneligibility.Otc,
+                PaperProofCandidateIneligibility.Ipo,
+                PaperProofCandidateIneligibility.PtpNoException,
+              ],
+            },
+          },
+        ],
+      },
+    })
+    const serialized = JSON.stringify(receipt)
+    expect(serialized).not.toContain('account_number')
+    expect(serialized).not.toContain('paper-secret')
+  })
+
+  test('keeps immutable and semantic hashes stable while fresh GET evidence changes the receipt', async () => {
+    const firstState = control()
+    const secondState = control()
+    const first = await Effect.runPromise(program(firstState))
+    const second = await Effect.runPromise(
+      program(secondState, fixture(), broker(secondState, 'z', '2099-07-24T12:01:00.000Z'), '2099-07-24T12:01:00.000Z'),
+    )
+
+    expect(second.immutableBindingHash).toBe(first.immutableBindingHash)
+    expect(second.candidateFactsHash).toBe(first.candidateFactsHash)
+    expect(second.observationReceiptHash).not.toBe(first.observationReceiptHash)
+    expect(second.observations.account.evidence.requestId).not.toBe(first.observations.account.evidence.requestId)
+  })
+
+  test('normalizes adapter-shaped optional rate-limit evidence before hashing the receipt', async () => {
+    const state = control()
+    const read = broker(state)
+    const normalizedState = control()
+    const normalizedRead = broker(normalizedState)
+    const adapterShaped: BrokerReadShape = {
+      ...read,
+      account: read.account.pipe(
+        Effect.map((result) => ({
+          ...result,
+          evidence: { ...result.evidence, rateLimit: undefined },
+        })),
+      ),
+      assetBySymbol: (symbol) =>
+        read.assetBySymbol(symbol).pipe(
+          Effect.map((result) => ({
+            ...result,
+            evidence: {
+              ...result.evidence,
+              rateLimit: {
+                limit: '200',
+                remaining: '199',
+                reset: undefined,
+                retryAfter: undefined,
+              },
+            },
+          })),
+        ),
+    }
+    const alreadyNormalized: BrokerReadShape = {
+      ...normalizedRead,
+      account: normalizedRead.account.pipe(
+        Effect.map((result) => ({
+          ...result,
+          evidence: {
+            requestId: result.evidence.requestId,
+            status: result.evidence.status,
+            contentHash: result.evidence.contentHash,
+            observedAt: result.evidence.observedAt,
+          },
+        })),
+      ),
+    }
+
+    const receipt = await Effect.runPromise(program(state, fixture(), adapterShaped))
+    const normalizedReceipt = await Effect.runPromise(program(normalizedState, fixture(), alreadyNormalized))
+
+    expect(receipt.observations.account.evidence).not.toHaveProperty('rateLimit')
+    expect(receipt.observations.assets[0]?.evidence.rateLimit).toEqual({ limit: '200', remaining: '199' })
+    expect(receipt.observations.assets[0]?.evidence.rateLimit).not.toHaveProperty('reset')
+    expect(receipt.observations.assets[0]?.evidence.rateLimit).not.toHaveProperty('retryAfter')
+    expect(receipt.observationReceiptHash).toBe(normalizedReceipt.observationReceiptHash)
+  })
+
+  test('does not start asset reads when the account observation mismatches the configured account', async () => {
+    const state = control()
+    const read = broker(state)
+    const wrongAccount: BrokerReadShape = {
+      ...read,
+      account: read.account.pipe(
+        Effect.map((result) => ({
+          ...result,
+          value: { ...result.value, id: '0f52e894-e17a-4b30-9a8f-e9f1f6fb701e' },
+        })),
+      ),
+    }
+
+    const error = await Effect.runPromise(Effect.flip(program(state, fixture(), wrongAccount)))
+
+    expect(error).toMatchObject({
+      _tag: 'PaperProofDiscoveryError',
+      failure: 'account-mismatch',
+    })
+    expect(state.brokerAccountReads).toBe(1)
+    expect(state.assetSymbols).toEqual([])
+  })
+
+  test('fails typed before broker reads for unfinished, missing, stale, and mismatched evidence', async () => {
+    const cases: readonly [string, (base: Fixture) => Fixture, string, string][] = [
+      [
+        'unfinished cycle',
+        (base) => ({
+          ...base,
+          projection: { ...base.projection, unfinishedCycleCount: 1, current: base.projection.last },
+        }),
+        'cycle-unfinished',
+        observedAt,
+      ],
+      ['missing cycle', (base) => ({ ...base, cycle: Option.none() }), 'cycle-missing', observedAt],
+      ['missing document', (base) => ({ ...base, document: Option.none() }), 'document-missing', observedAt],
+      ['stale document', (base) => base, 'document-stale', '2099-07-24T13:15:00.000Z'],
+      [
+        'mismatched policy',
+        (base) => ({
+          ...base,
+          document: Option.map(base.document, (value) => ({
+            ...value,
+            bindings: { ...value.bindings, policyHash: hash('f') },
+          })),
+        }),
+        'document-mismatch',
+        observedAt,
+      ],
+      [
+        'mismatched operational snapshot',
+        (base) => ({
+          ...base,
+          projection: {
+            ...base.projection,
+            last: base.projection.last === null ? null : { ...base.projection.last, snapshotId: hash('f') },
+          },
+        }),
+        'document-mismatch',
+        observedAt,
+      ],
+      [
+        'additional risk block',
+        (base) => ({
+          ...base,
+          document: Option.map(base.document, (value) => ({
+            ...value,
+            deltaRisk: value.deltaRisk.map((entry, index) =>
+              index === 0
+                ? {
+                    ...entry,
+                    evaluation: {
+                      ...entry.evaluation,
+                      decision: {
+                        ...entry.evaluation.decision,
+                        reasonCodes: [Reason.AuthorityNotPaper, Reason.KillActive],
+                      },
+                    },
+                  }
+                : entry,
+            ),
+          })),
+        }),
+        'risk-mismatch',
+        observedAt,
+      ],
+    ]
+
+    for (const [label, mutate, expectedFailure, now] of cases) {
+      const state = control()
+      const error = await Effect.runPromise(Effect.flip(program(state, mutate(fixture()), broker(state), now)))
+      expect(error, label).toMatchObject({
+        _tag: 'PaperProofDiscoveryError',
+        failure: expectedFailure,
+      })
+      expect(state.brokerAccountReads, label).toBe(0)
+      expect(state.assetSymbols, label).toEqual([])
+    }
+  })
+
+  test('reports invalid protocol identity and a cutoff crossed during broker I/O as typed failures', async () => {
+    const invalidState = control()
+    const invalidIdentity = { ...identity, strategyProtocolHash: hash('f') }
+    const invalidExit = await Effect.runPromiseExit(
+      program(invalidState, fixture(), broker(invalidState), observedAt, fakeSql(invalidState), invalidIdentity),
+    )
+    expect(Exit.isFailure(invalidExit)).toBe(true)
+    if (Exit.isSuccess(invalidExit)) throw new Error('expected invalid protocol failure')
+    const invalidFailure = Cause.findErrorOption(invalidExit.cause)
+    expect(Option.isSome(invalidFailure)).toBe(true)
+    if (Option.isNone(invalidFailure)) throw new Error('invalid protocol became a defect')
+    expect(invalidFailure.value).toMatchObject({
+      _tag: 'PaperProofDiscoveryError',
+      failure: 'invalid-input',
+    })
+    expect(invalidState.transactions).toBe(0)
+    expect(invalidState.brokerAccountReads).toBe(0)
+
+    const delayedState = control()
+    const delayed = broker(delayedState)
+    const cutoffDuringRead: BrokerReadShape = {
+      ...delayed,
+      account: delayed.account.pipe(Effect.tap(() => TestClock.setTime(Date.parse(cutoff)))),
+    }
+    const cutoffExit = await Effect.runPromiseExit(program(delayedState, fixture(), cutoffDuringRead))
+    expect(Exit.isFailure(cutoffExit)).toBe(true)
+    if (Exit.isSuccess(cutoffExit)) throw new Error('expected cutoff failure')
+    const cutoffFailure = Cause.findErrorOption(cutoffExit.cause)
+    expect(Option.isSome(cutoffFailure)).toBe(true)
+    if (Option.isNone(cutoffFailure)) throw new Error('post-read cutoff became a defect')
+    expect(cutoffFailure.value).toMatchObject({
+      _tag: 'PaperProofDiscoveryError',
+      failure: 'document-stale',
+    })
+  })
+})
+
+const postgresUrl = process.env.BAYN_TEST_POSTGRES_URL
+const describePostgres = postgresUrl === undefined ? describe.skip : describe
+
+describePostgres('paper proof DISCOVER PostgreSQL transaction', () => {
+  test('runs every domain read in one repeatable-read read-only transaction', async () => {
+    const runtime = ManagedRuntime.make(
+      PostgresClientLive({
+        operationTimeoutMs: 5_000,
+        postgres: {
+          url: Redacted.make(postgresUrl ?? ''),
+          tls: false,
+          caPath: '/unused',
+        },
+      }).pipe(Layer.provide(NodeServices.layer)),
+    )
+    const modes: { isolation: string; readOnly: boolean }[] = []
+    const state = control()
+
+    try {
+      await runtime.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* PgClient.PgClient
+          const observeMode = sql<{ isolation: string; read_only: boolean }>`
+            SELECT
+              current_setting('transaction_isolation') AS isolation,
+              current_setting('transaction_read_only') = 'on' AS read_only
+          `.pipe(
+            Effect.orDie,
+            Effect.tap((rows) =>
+              Effect.sync(() => {
+                const mode = rows[0]
+                if (mode !== undefined) modes.push({ isolation: mode.isolation, readOnly: mode.read_only })
+              }),
+            ),
+            Effect.asVoid,
+          )
+          const input = fixture()
+          const observability: CycleObservabilityShape = {
+            read: () => observeMode.pipe(Effect.as(input.projection)),
+          }
+          const unexpected = () => Effect.die(new Error('unexpected CycleStore operation'))
+          const cycleStore: CycleStoreShape = {
+            acquire: unexpected,
+            read: () => observeMode.pipe(Effect.as(input.cycle)),
+            readAuthoritySlot: unexpected,
+            readDecisionDocument: () => observeMode.pipe(Effect.as(input.document)),
+            readOldestUnfinished: unexpected,
+            bindSnapshot: unexpected,
+            activate: unexpected,
+            bindDecision: unexpected,
+            finish: unexpected,
+            block: unexpected,
+          }
+          yield* TestClock.setTime(Date.parse(observedAt))
+          return yield* discoverPaperProofCandidates(identity).pipe(
+            Effect.provideService(CycleObservability, observability),
+            Effect.provideService(CycleStore, cycleStore),
+            Effect.provideService(BrokerRead, broker(state)),
+          )
+        }).pipe(Effect.provide(TestClock.layer())),
+      )
+    } finally {
+      await runtime.dispose()
+    }
+
+    expect(modes).toEqual([
+      { isolation: 'repeatable read', readOnly: true },
+      { isolation: 'repeatable read', readOnly: true },
+      { isolation: 'repeatable read', readOnly: true },
+    ])
+  })
+})

--- a/services/bayn/src/paper-proof-discovery.ts
+++ b/services/bayn/src/paper-proof-discovery.ts
@@ -252,6 +252,7 @@ export class PaperProofDiscoveryError extends Data.TaggedError('PaperProofDiscov
   readonly operation: 'broker-read' | 'decode' | 'read-snapshot' | 'validate'
   readonly failure:
     | 'account-mismatch'
+    | 'authority-mismatch'
     | 'broker'
     | 'cycle-mismatch'
     | 'cycle-missing'
@@ -427,6 +428,13 @@ const validateSnapshot = (
     document.bindings.policyHash === identity.policyHash,
     'document-mismatch',
     'shadow document policy does not match the current source-controlled risk policy',
+  )
+  requireInvariant(
+    projection.authority !== null &&
+      projection.authority.maximum === Authority.Observe &&
+      projection.authority.effective === Authority.Observe,
+    'authority-mismatch',
+    'durable authority must be present with OBSERVE maximum and effective authority',
   )
   requireInvariant(
     document.targetPlan.status === TargetPlanStatus.Planned && document.targetPlan.intentTargets.length > 0,

--- a/services/bayn/src/paper-proof-discovery.ts
+++ b/services/bayn/src/paper-proof-discovery.ts
@@ -118,6 +118,7 @@ const RuntimeIdentitySchema = Schema.Struct({
   strategyProtocolHash: Sha256Schema,
   qualificationRunId: Sha256Schema,
   accountId: StrictNonEmptyStringSchema,
+  authorityGenerationHash: Sha256Schema,
   policyHash: Sha256Schema,
 })
 export type PaperProofDiscoveryIdentity = typeof RuntimeIdentitySchema.Type
@@ -431,10 +432,11 @@ const validateSnapshot = (
   )
   requireInvariant(
     projection.authority !== null &&
+      projection.authority.generationHash === identity.authorityGenerationHash &&
       projection.authority.maximum === Authority.Observe &&
       projection.authority.effective === Authority.Observe,
     'authority-mismatch',
-    'durable authority must be present with OBSERVE maximum and effective authority',
+    'durable authority must match the configured generation with OBSERVE maximum and effective authority',
   )
   requireInvariant(
     document.targetPlan.status === TargetPlanStatus.Planned && document.targetPlan.intentTargets.length > 0,

--- a/services/bayn/src/paper-proof-discovery.ts
+++ b/services/bayn/src/paper-proof-discovery.ts
@@ -1,0 +1,724 @@
+import { PgClient } from '@effect/sql-pg'
+import { Clock, Data, Effect, Option, Schema } from 'effect'
+
+import {
+  AccountStatus,
+  AssetClass,
+  AssetExchange,
+  AssetStatus,
+  BrokerRead,
+  type Account,
+  type AssetObservation,
+  type AssetObservationExchange,
+  type ReadEvidence,
+  type ReadResult,
+} from './broker/alpaca'
+import { RuntimeProvenanceSchema, makeStrategyProtocolHash } from './contracts'
+import { CycleState, type AutonomousCycle } from './cycle'
+import type { CycleOperationsProjection } from './cycle-observability'
+import { CycleObservability } from './db/cycle-observability'
+import { CycleStore } from './db/cycle-store'
+import { canonicalHashV1 } from './hash'
+import { Authority, OrderSide, OrderType, RiskOutcome, TimeInForce } from './paper'
+import { Gate, Reason } from './risk'
+import {
+  GitSourceRevisionSchema,
+  ImageDigestSchema,
+  ImageRepositorySchema,
+  IsoDateSchema,
+  NonNegativeIntegerSchema,
+  PositiveMicrosSchema,
+  Sha256Schema,
+  SignedMicrosSchema,
+  StrictNonEmptyStringSchema,
+  SymbolSchema,
+  UnitIntervalSchema,
+  UnsignedMicrosSchema,
+  UtcInstantSchema,
+  strictParseOptions,
+} from './schemas'
+import type { ObserveShadowDecisionDocument } from './shadow-decision-contract'
+import { TargetPlanStatus } from './target-planner'
+
+const discoverySchemaVersion = 'bayn.paper-proof-discovery.v1' as const
+const bindingSchemaVersion = 'bayn.paper-proof-discovery-binding.v1' as const
+const candidateFactsSchemaVersion = 'bayn.paper-proof-candidate-facts.v1' as const
+const observationReceiptSchemaVersion = 'bayn.paper-proof-observation-receipt.v1' as const
+const assetReadConcurrency = 3
+const AssetObservationExchangeSchema = Schema.Enum(AssetExchange).pipe(
+  Schema.refine((exchange): exchange is AssetObservationExchange => exchange !== AssetExchange.Empty, {
+    expected: 'an Alpaca asset exchange other than the empty sentinel',
+  }),
+)
+
+const ReadEvidenceSchema = Schema.Struct({
+  requestId: StrictNonEmptyStringSchema,
+  status: NonNegativeIntegerSchema,
+  contentHash: Sha256Schema,
+  observedAt: UtcInstantSchema,
+  rateLimit: Schema.optionalKey(
+    Schema.Struct({
+      limit: Schema.optionalKey(Schema.String),
+      remaining: Schema.optionalKey(Schema.String),
+      reset: Schema.optionalKey(Schema.String),
+      retryAfter: Schema.optionalKey(Schema.String),
+    }),
+  ),
+})
+
+const AccountObservationSchema = Schema.Struct({
+  id: StrictNonEmptyStringSchema,
+  status: Schema.Enum(AccountStatus),
+  currency: Schema.Literal('USD'),
+  cashMicros: SignedMicrosSchema,
+  equityMicros: SignedMicrosSchema,
+  buyingPowerMicros: SignedMicrosSchema,
+  accountBlocked: Schema.Boolean,
+  tradingBlocked: Schema.Boolean,
+  tradeSuspendedByUser: Schema.Boolean,
+  observedAt: UtcInstantSchema,
+})
+
+const AssetObservationSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.alpaca-asset-observation.v1'),
+  source: Schema.Literal('alpaca-v2-asset'),
+  requestedSymbol: SymbolSchema,
+  requestHash: Sha256Schema,
+  assetId: StrictNonEmptyStringSchema,
+  symbol: SymbolSchema,
+  assetClass: Schema.Enum(AssetClass),
+  exchange: AssetObservationExchangeSchema,
+  status: Schema.Enum(AssetStatus),
+  tradable: Schema.Boolean,
+  fractionable: Schema.Boolean,
+  attributes: Schema.Array(StrictNonEmptyStringSchema),
+  observedAt: UtcInstantSchema,
+  normalizedResponseHash: Sha256Schema,
+})
+
+export enum PaperProofCandidateIneligibility {
+  AssetClass = 'ASSET_CLASS_NOT_US_EQUITY',
+  Inactive = 'ASSET_INACTIVE',
+  Ipo = 'ASSET_IPO',
+  NotFractionable = 'ASSET_NOT_FRACTIONABLE',
+  NotTradable = 'ASSET_NOT_TRADABLE',
+  Otc = 'ASSET_OTC',
+  PtpNoException = 'ASSET_PTP_NO_EXCEPTION',
+}
+
+const CandidateIneligibilitySchema = Schema.Enum(PaperProofCandidateIneligibility)
+
+const RuntimeIdentitySchema = Schema.Struct({
+  sourceRevision: GitSourceRevisionSchema,
+  image: Schema.Struct({
+    repository: ImageRepositorySchema,
+    digest: ImageDigestSchema,
+  }),
+  strategy: RuntimeProvenanceSchema.fields.strategy,
+  strategyProtocolHash: Sha256Schema,
+  qualificationRunId: Sha256Schema,
+  accountId: StrictNonEmptyStringSchema,
+  policyHash: Sha256Schema,
+})
+export type PaperProofDiscoveryIdentity = typeof RuntimeIdentitySchema.Type
+
+const DiscoveryBindingSchema = Schema.Struct({
+  schemaVersion: Schema.Literal(bindingSchemaVersion),
+  runtime: RuntimeIdentitySchema,
+  cycle: Schema.Struct({
+    cycleId: Sha256Schema,
+    signalSessionDate: IsoDateSchema,
+    executionSessionDate: IsoDateSchema,
+    snapshotId: Sha256Schema,
+    decisionHash: Sha256Schema,
+    submissionCutoffAt: UtcInstantSchema,
+    terminalAt: UtcInstantSchema,
+  }),
+  document: Schema.Struct({
+    contentHash: Sha256Schema,
+    snapshotContentHash: Sha256Schema,
+    snapshotFinalizedAt: UtcInstantSchema,
+    strategyDecisionHash: Sha256Schema,
+    policyHash: Sha256Schema,
+    planningBrokerStateHash: Sha256Schema,
+    reconciliationId: Sha256Schema,
+    reconciliationHash: Sha256Schema,
+    targetPlanInputHash: Sha256Schema,
+    targetPlanOutputHash: Sha256Schema,
+    createdAt: UtcInstantSchema,
+    expiresAt: UtcInstantSchema,
+  }),
+})
+export type PaperProofDiscoveryBinding = typeof DiscoveryBindingSchema.Type
+
+const AccountFactsSchema = Schema.Struct({
+  id: StrictNonEmptyStringSchema,
+  status: Schema.Enum(AccountStatus),
+  currency: Schema.Literal('USD'),
+  cashMicros: SignedMicrosSchema,
+  equityMicros: SignedMicrosSchema,
+  buyingPowerMicros: SignedMicrosSchema,
+  accountBlocked: Schema.Boolean,
+  tradingBlocked: Schema.Boolean,
+  tradeSuspendedByUser: Schema.Boolean,
+})
+
+const AssetFactsSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.alpaca-asset-observation.v1'),
+  source: Schema.Literal('alpaca-v2-asset'),
+  requestedSymbol: SymbolSchema,
+  requestHash: Sha256Schema,
+  assetId: StrictNonEmptyStringSchema,
+  symbol: SymbolSchema,
+  assetClass: Schema.Enum(AssetClass),
+  exchange: AssetObservationExchangeSchema,
+  status: Schema.Enum(AssetStatus),
+  tradable: Schema.Boolean,
+  fractionable: Schema.Boolean,
+  attributes: Schema.Array(StrictNonEmptyStringSchema),
+  normalizedResponseHash: Sha256Schema,
+})
+
+const CandidateFactsSchema = Schema.Struct({
+  ordinal: NonNegativeIntegerSchema,
+  observedPlanIntentId: Sha256Schema,
+  symbol: SymbolSchema,
+  side: Schema.Enum(OrderSide),
+  orderType: Schema.Enum(OrderType),
+  timeInForce: Schema.Enum(TimeInForce),
+  observedPlannedQuantityMicros: PositiveMicrosSchema,
+  observedReferencePriceMicros: PositiveMicrosSchema,
+  observedNotionalLimitMicros: PositiveMicrosSchema,
+  observedEvaluatedOrderNotionalMicros: UnsignedMicrosSchema,
+  observedTargetWeight: UnitIntervalSchema,
+  observedCurrentQuantityMicros: SignedMicrosSchema,
+  observedTargetQuantityMicros: SignedMicrosSchema,
+  observedRiskDecisionId: Sha256Schema,
+  observedRiskInputHash: Sha256Schema,
+  asset: AssetFactsSchema,
+  assetEligibility: Schema.Struct({
+    eligible: Schema.Boolean,
+    reasons: Schema.Array(CandidateIneligibilitySchema),
+  }),
+})
+
+const CandidateFactsMaterialSchema = Schema.Struct({
+  schemaVersion: Schema.Literal(candidateFactsSchemaVersion),
+  immutableBindingHash: Sha256Schema,
+  account: AccountFactsSchema,
+  candidates: Schema.Array(CandidateFactsSchema),
+  consistencyDelayMs: Schema.Struct({
+    status: Schema.Literal('REQUIRED_UNBOUND'),
+  }),
+})
+export type PaperProofCandidateFactsMaterial = typeof CandidateFactsMaterialSchema.Type
+
+const BrokerObservationsSchema = Schema.Struct({
+  account: Schema.Struct({
+    value: AccountObservationSchema,
+    evidence: ReadEvidenceSchema,
+  }),
+  assets: Schema.Array(
+    Schema.Struct({
+      ordinal: NonNegativeIntegerSchema,
+      value: AssetObservationSchema,
+      evidence: ReadEvidenceSchema,
+    }),
+  ),
+})
+
+const DiscoveryReceiptMaterialSchema = Schema.Struct({
+  schemaVersion: Schema.Literal(discoverySchemaVersion),
+  command: Schema.Literal('PREPARE'),
+  phase: Schema.Literal('DISCOVER'),
+  authority: Schema.Literal(Authority.Observe),
+  dispatchable: Schema.Literal(false),
+  binding: DiscoveryBindingSchema,
+  immutableBindingHash: Sha256Schema,
+  candidateFacts: CandidateFactsMaterialSchema,
+  candidateFactsHash: Sha256Schema,
+  observations: BrokerObservationsSchema,
+  capturedAt: UtcInstantSchema,
+  observationReceiptSchemaVersion: Schema.Literal(observationReceiptSchemaVersion),
+})
+
+const DiscoveryReceiptSchema = Schema.Struct({
+  ...DiscoveryReceiptMaterialSchema.fields,
+  observationReceiptHash: Sha256Schema,
+})
+export type PaperProofDiscoveryReceipt = typeof DiscoveryReceiptSchema.Type
+
+export class PaperProofDiscoveryError extends Data.TaggedError('PaperProofDiscoveryError')<{
+  readonly operation: 'broker-read' | 'decode' | 'read-snapshot' | 'validate'
+  readonly failure:
+    | 'account-mismatch'
+    | 'broker'
+    | 'cycle-mismatch'
+    | 'cycle-missing'
+    | 'cycle-unfinished'
+    | 'document-mismatch'
+    | 'document-missing'
+    | 'document-stale'
+    | 'invalid-input'
+    | 'output'
+    | 'risk-mismatch'
+    | 'transaction'
+  readonly message: string
+  readonly cause?: unknown
+}> {}
+
+interface DiscoverySnapshot {
+  readonly projection: CycleOperationsProjection
+  readonly cycle: AutonomousCycle
+  readonly document: ObserveShadowDecisionDocument
+}
+
+const fail = (
+  operation: PaperProofDiscoveryError['operation'],
+  failure: PaperProofDiscoveryError['failure'],
+  message: string,
+  cause?: unknown,
+): PaperProofDiscoveryError => new PaperProofDiscoveryError({ operation, failure, message, cause })
+
+const requireInvariant: (
+  condition: boolean,
+  failure: PaperProofDiscoveryError['failure'],
+  message: string,
+) => asserts condition = (condition, failure, message) => {
+  if (!condition) throw fail('validate', failure, message)
+}
+
+const validateIdentity = (input: PaperProofDiscoveryIdentity) =>
+  Schema.decodeUnknownEffect(
+    RuntimeIdentitySchema,
+    strictParseOptions,
+  )(input).pipe(
+    Effect.mapError((cause) => fail('decode', 'invalid-input', 'paper proof discovery identity is invalid', cause)),
+  )
+
+const ensure = (
+  condition: boolean,
+  failure: PaperProofDiscoveryError['failure'],
+  message: string,
+): Effect.Effect<void, PaperProofDiscoveryError> =>
+  condition ? Effect.void : Effect.fail(fail('validate', failure, message))
+
+const readDiscoverySnapshot = (
+  identity: PaperProofDiscoveryIdentity,
+): Effect.Effect<DiscoverySnapshot, PaperProofDiscoveryError, PgClient.PgClient | CycleObservability | CycleStore> =>
+  Effect.gen(function* () {
+    const sql = yield* PgClient.PgClient
+    const observability = yield* CycleObservability
+    const store = yield* CycleStore
+    return yield* sql.withTransaction(
+      Effect.gen(function* () {
+        yield* sql`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY`
+        const projection = yield* observability.read(identity.qualificationRunId, identity.accountId)
+        if (projection.unfinishedCycleCount !== 0 || projection.current !== null) {
+          return yield* Effect.fail(
+            fail('read-snapshot', 'cycle-unfinished', 'paper proof discovery requires zero unfinished cycles'),
+          )
+        }
+        const last = projection.last
+        if (last === null) {
+          return yield* Effect.fail(
+            fail('read-snapshot', 'cycle-missing', 'paper proof discovery requires a completed terminal cycle'),
+          )
+        }
+        const cycle = yield* store.read(last.cycleId).pipe(
+          Effect.flatMap(
+            Option.match({
+              onNone: () =>
+                Effect.fail(
+                  fail('read-snapshot', 'cycle-missing', 'latest completed cycle is missing from CycleStore'),
+                ),
+              onSome: Effect.succeed,
+            }),
+          ),
+        )
+        const document = yield* store.readDecisionDocument(last.cycleId).pipe(
+          Effect.flatMap(
+            Option.match({
+              onNone: () =>
+                Effect.fail(
+                  fail(
+                    'read-snapshot',
+                    'document-missing',
+                    'latest completed cycle has no persisted shadow decision document',
+                  ),
+                ),
+              onSome: Effect.succeed,
+            }),
+          ),
+        )
+        return { projection, cycle, document }
+      }),
+    )
+  }).pipe(
+    Effect.mapError((cause) =>
+      cause instanceof PaperProofDiscoveryError
+        ? cause
+        : fail('read-snapshot', 'transaction', 'read-only discovery transaction failed', cause),
+    ),
+  )
+
+const validateSnapshot = (
+  identity: PaperProofDiscoveryIdentity,
+  snapshot: DiscoverySnapshot,
+  now: number,
+): PaperProofDiscoveryBinding => {
+  const { projection, cycle, document } = snapshot
+  const last = projection.last
+  requireInvariant(last !== null, 'cycle-missing', 'completed terminal cycle disappeared during validation')
+  requireInvariant(last.phase === CycleState.Completed, 'cycle-mismatch', 'latest terminal cycle is not COMPLETED')
+  requireInvariant(cycle.state === CycleState.Completed, 'cycle-mismatch', 'CycleStore cycle is not COMPLETED')
+  requireInvariant(cycle.terminalAt !== undefined, 'cycle-mismatch', 'completed cycle has no terminal timestamp')
+  requireInvariant(last.cycleId === cycle.identity.cycleId, 'cycle-mismatch', 'cycle projection identity mismatch')
+  requireInvariant(last.accountId === identity.accountId, 'cycle-mismatch', 'cycle projection account mismatch')
+  requireInvariant(
+    last.signalSessionDate === cycle.identity.signalSessionDate &&
+      last.executionSessionDate === cycle.identity.executionSessionDate &&
+      last.submissionOpenAt === cycle.window.submissionOpenAt &&
+      last.submissionCutoffAt === cycle.window.submissionCutoffAt &&
+      last.executionOpenAt === cycle.window.executionOpenAt &&
+      last.executionCloseAt === cycle.window.executionCloseAt &&
+      last.terminalAt === cycle.terminalAt,
+    'cycle-mismatch',
+    'cycle projection chronology does not match the immutable CycleStore record',
+  )
+  requireInvariant(
+    cycle.identity.accountId === identity.accountId,
+    'cycle-mismatch',
+    'cycle account does not match configured Alpaca account',
+  )
+  requireInvariant(
+    cycle.identity.qualificationRunId === identity.qualificationRunId,
+    'cycle-mismatch',
+    'cycle qualification run does not match the configured terminal pin',
+  )
+  requireInvariant(
+    cycle.identity.strategyProtocolHash === identity.strategyProtocolHash,
+    'cycle-mismatch',
+    'cycle strategy protocol does not match the current strategy',
+  )
+  requireInvariant(
+    cycle.bindings.snapshotId !== undefined &&
+      cycle.bindings.snapshotId === last.snapshotId &&
+      cycle.bindings.snapshotId === document.bindings.snapshotId,
+    'document-mismatch',
+    'cycle projection, CycleStore, and shadow document Signal snapshots do not match',
+  )
+  requireInvariant(
+    cycle.bindings.decisionHash !== undefined &&
+      cycle.bindings.decisionHash === last.decisionHash &&
+      cycle.bindings.decisionHash === document.contentHash,
+    'document-mismatch',
+    'cycle decision hash does not bind the persisted shadow document',
+  )
+  requireInvariant(
+    document.bindings.cycleId === cycle.identity.cycleId &&
+      document.bindings.accountId === identity.accountId &&
+      document.bindings.strategyName === identity.strategy.name &&
+      document.bindings.strategyProtocolHash === identity.strategyProtocolHash,
+    'document-mismatch',
+    'shadow document identity bindings do not match the cycle and runtime',
+  )
+  requireInvariant(
+    document.bindings.policyHash === identity.policyHash,
+    'document-mismatch',
+    'shadow document policy does not match the current source-controlled risk policy',
+  )
+  requireInvariant(
+    document.targetPlan.status === TargetPlanStatus.Planned && document.targetPlan.intentTargets.length > 0,
+    'document-mismatch',
+    'shadow document does not contain a PLANNED target plan',
+  )
+  requireInvariant(
+    document.deltaRisk.length === document.targetPlan.intentTargets.length,
+    'risk-mismatch',
+    'shadow document risk evaluations do not align with the ordered target deltas',
+  )
+  requireInvariant(
+    document.submissionCutoffAt === cycle.window.submissionCutoffAt &&
+      document.expiresAt === cycle.window.submissionCutoffAt,
+    'document-mismatch',
+    'shadow document expiry does not match the immutable cycle cutoff',
+  )
+  requireInvariant(
+    now < Date.parse(document.expiresAt),
+    'document-stale',
+    'shadow document has reached its exclusive submission cutoff',
+  )
+  const reconciliation = projection.reconciliation
+  requireInvariant(reconciliation !== null, 'document-mismatch', 'latest reconciliation is unavailable')
+  requireInvariant(
+    reconciliation.accountId === identity.accountId &&
+      reconciliation.reconciliationId === document.bindings.reconciliationId &&
+      reconciliation.status === 'EXACT' &&
+      reconciliation.discrepancyCount === 0 &&
+      reconciliation.coversLatestMutation,
+    'document-mismatch',
+    'latest exact reconciliation does not match the document binding',
+  )
+  requireInvariant(
+    projection.mutations.unresolvedCount === 0,
+    'document-mismatch',
+    'unresolved broker mutations remain after the document-bound reconciliation',
+  )
+
+  for (const [index, risk] of document.deltaRisk.entries()) {
+    const failed = risk.evaluation.gates.filter((gate) => !gate.passed)
+    requireInvariant(
+      risk.evaluation.decision.outcome === RiskOutcome.Blocked &&
+        risk.evaluation.decision.reasonCodes.length === 1 &&
+        risk.evaluation.decision.reasonCodes[0] === Reason.AuthorityNotPaper &&
+        failed.length === 1 &&
+        failed[0]?.name === Gate.Authority &&
+        failed[0]?.reason === Reason.AuthorityNotPaper,
+      'risk-mismatch',
+      `shadow delta ${index} is not blocked only by AuthorityNotPaper`,
+    )
+  }
+
+  return {
+    schemaVersion: bindingSchemaVersion,
+    runtime: identity,
+    cycle: {
+      cycleId: cycle.identity.cycleId,
+      signalSessionDate: cycle.identity.signalSessionDate,
+      executionSessionDate: cycle.identity.executionSessionDate,
+      snapshotId: cycle.bindings.snapshotId,
+      decisionHash: document.contentHash,
+      submissionCutoffAt: cycle.window.submissionCutoffAt,
+      terminalAt: cycle.terminalAt,
+    },
+    document: {
+      contentHash: document.contentHash,
+      snapshotContentHash: document.bindings.snapshotContentHash,
+      snapshotFinalizedAt: document.bindings.snapshotFinalizedAt,
+      strategyDecisionHash: document.bindings.strategyDecisionHash,
+      policyHash: document.bindings.policyHash,
+      planningBrokerStateHash: document.bindings.planningBrokerStateHash,
+      reconciliationId: document.bindings.reconciliationId,
+      reconciliationHash: document.bindings.reconciliationHash,
+      targetPlanInputHash: document.targetPlan.inputHash,
+      targetPlanOutputHash: document.targetPlan.outputHash,
+      createdAt: document.createdAt,
+      expiresAt: document.expiresAt,
+    },
+  }
+}
+
+const accountFacts = (account: Account): typeof AccountFactsSchema.Type => ({
+  id: account.id,
+  status: account.status,
+  currency: account.currency,
+  cashMicros: account.cashMicros,
+  equityMicros: account.equityMicros,
+  buyingPowerMicros: account.buyingPowerMicros,
+  accountBlocked: account.accountBlocked,
+  tradingBlocked: account.tradingBlocked,
+  tradeSuspendedByUser: account.tradeSuspendedByUser,
+})
+
+const assetFacts = (asset: AssetObservation): typeof AssetFactsSchema.Type => ({
+  schemaVersion: asset.schemaVersion,
+  source: asset.source,
+  requestedSymbol: asset.requestedSymbol,
+  requestHash: asset.requestHash,
+  assetId: asset.assetId,
+  symbol: asset.symbol,
+  assetClass: asset.assetClass,
+  exchange: asset.exchange,
+  status: asset.status,
+  tradable: asset.tradable,
+  fractionable: asset.fractionable,
+  attributes: asset.attributes,
+  normalizedResponseHash: asset.normalizedResponseHash,
+})
+
+const assetEligibility = (asset: AssetObservation) => {
+  const reasons: PaperProofCandidateIneligibility[] = []
+  if (asset.assetClass !== AssetClass.UsEquity) reasons.push(PaperProofCandidateIneligibility.AssetClass)
+  if (asset.status !== AssetStatus.Active) reasons.push(PaperProofCandidateIneligibility.Inactive)
+  if (!asset.tradable) reasons.push(PaperProofCandidateIneligibility.NotTradable)
+  if (!asset.fractionable) reasons.push(PaperProofCandidateIneligibility.NotFractionable)
+  if (asset.exchange === AssetExchange.Otc) reasons.push(PaperProofCandidateIneligibility.Otc)
+  if (asset.attributes.includes('ipo')) reasons.push(PaperProofCandidateIneligibility.Ipo)
+  if (asset.attributes.includes('ptp_no_exception')) reasons.push(PaperProofCandidateIneligibility.PtpNoException)
+  return { eligible: reasons.length === 0, reasons } as const
+}
+
+const validateReadEvidence = <A extends { readonly observedAt: string }>(
+  result: ReadResult<A>,
+  label: string,
+): void => {
+  requireInvariant(
+    result.value.observedAt === result.evidence.observedAt,
+    'broker',
+    `${label} value and evidence observation times do not match`,
+  )
+}
+
+const normalizedReadEvidence = (evidence: ReadEvidence): typeof ReadEvidenceSchema.Type => {
+  const rateLimit =
+    evidence.rateLimit === undefined
+      ? {}
+      : {
+          ...(evidence.rateLimit.limit === undefined ? {} : { limit: evidence.rateLimit.limit }),
+          ...(evidence.rateLimit.remaining === undefined ? {} : { remaining: evidence.rateLimit.remaining }),
+          ...(evidence.rateLimit.reset === undefined ? {} : { reset: evidence.rateLimit.reset }),
+          ...(evidence.rateLimit.retryAfter === undefined ? {} : { retryAfter: evidence.rateLimit.retryAfter }),
+        }
+  return {
+    requestId: evidence.requestId,
+    status: evidence.status,
+    contentHash: evidence.contentHash,
+    observedAt: evidence.observedAt,
+    ...(Object.keys(rateLimit).length === 0 ? {} : { rateLimit }),
+  }
+}
+
+const makeReceipt = (
+  identity: PaperProofDiscoveryIdentity,
+  snapshot: DiscoverySnapshot,
+  binding: PaperProofDiscoveryBinding,
+  account: ReadResult<Account>,
+  assets: readonly ReadResult<AssetObservation>[],
+  capturedAt: string,
+): PaperProofDiscoveryReceipt => {
+  requireInvariant(account.value.id === identity.accountId, 'account-mismatch', 'Alpaca account identity mismatch')
+  validateReadEvidence(account, 'account')
+  const candidates = snapshot.document.targetPlan.intentTargets.map((intent, ordinal) => {
+    const target = snapshot.document.targetPlan.targets.find((candidate) => candidate.symbol === intent.symbol)
+    const risk = snapshot.document.deltaRisk[ordinal]
+    const asset = assets[ordinal]
+    requireInvariant(target !== undefined, 'document-mismatch', `planned target ${intent.symbol} is missing`)
+    requireInvariant(risk !== undefined, 'risk-mismatch', `risk evaluation ${ordinal} is missing`)
+    requireInvariant(asset !== undefined, 'broker', `asset observation ${ordinal} is missing`)
+    validateReadEvidence(asset, `asset ${intent.symbol}`)
+    requireInvariant(
+      asset.value.requestedSymbol === intent.symbol && asset.value.symbol === intent.symbol,
+      'broker',
+      `asset observation does not match planned symbol ${intent.symbol}`,
+    )
+    return {
+      ordinal,
+      observedPlanIntentId: risk.evaluation.input.intentId,
+      symbol: intent.symbol,
+      side: intent.side,
+      orderType: intent.orderType,
+      timeInForce: intent.timeInForce,
+      observedPlannedQuantityMicros: intent.quantityMicros,
+      observedReferencePriceMicros: target.referencePriceMicros,
+      observedNotionalLimitMicros: risk.notionalLimitMicros,
+      observedEvaluatedOrderNotionalMicros: risk.evaluation.metrics.orderNotionalMicros,
+      observedTargetWeight: target.targetWeight,
+      observedCurrentQuantityMicros: target.currentQuantityMicros,
+      observedTargetQuantityMicros: target.targetQuantityMicros,
+      observedRiskDecisionId: risk.evaluation.decision.decisionId,
+      observedRiskInputHash: risk.evaluation.input.inputHash,
+      asset: assetFacts(asset.value),
+      assetEligibility: assetEligibility(asset.value),
+    }
+  })
+  const immutableBindingHash = canonicalHashV1(binding)
+  const candidateFacts = {
+    schemaVersion: candidateFactsSchemaVersion,
+    immutableBindingHash,
+    account: accountFacts(account.value),
+    candidates,
+    consistencyDelayMs: { status: 'REQUIRED_UNBOUND' as const },
+  }
+  const candidateFactsHash = canonicalHashV1(candidateFacts)
+  const material = {
+    schemaVersion: discoverySchemaVersion,
+    command: 'PREPARE' as const,
+    phase: 'DISCOVER' as const,
+    authority: Authority.Observe,
+    dispatchable: false as const,
+    binding,
+    immutableBindingHash,
+    candidateFacts,
+    candidateFactsHash,
+    observations: {
+      account: { value: account.value, evidence: normalizedReadEvidence(account.evidence) },
+      assets: assets.map((asset, ordinal) => ({
+        ordinal,
+        value: asset.value,
+        evidence: normalizedReadEvidence(asset.evidence),
+      })),
+    },
+    capturedAt,
+    observationReceiptSchemaVersion,
+  }
+  return Schema.decodeUnknownSync(
+    DiscoveryReceiptSchema,
+    strictParseOptions,
+  )({
+    ...material,
+    observationReceiptHash: canonicalHashV1(material),
+  })
+}
+
+export const discoverPaperProofCandidates = (
+  candidateIdentity: PaperProofDiscoveryIdentity,
+): Effect.Effect<
+  PaperProofDiscoveryReceipt,
+  PaperProofDiscoveryError,
+  PgClient.PgClient | CycleObservability | CycleStore | BrokerRead
+> =>
+  Effect.gen(function* () {
+    const identity = yield* validateIdentity(candidateIdentity)
+    yield* ensure(
+      identity.strategyProtocolHash === makeStrategyProtocolHash(identity.strategy),
+      'invalid-input',
+      'paper proof discovery strategy protocol hash is invalid',
+    )
+    const snapshot = yield* readDiscoverySnapshot(identity)
+    const startedAt = yield* Clock.currentTimeMillis
+    const binding = yield* Effect.try({
+      try: () => validateSnapshot(identity, snapshot, startedAt),
+      catch: (cause) =>
+        cause instanceof PaperProofDiscoveryError
+          ? cause
+          : fail('validate', 'document-mismatch', 'paper proof discovery binding validation failed', cause),
+    })
+    const broker = yield* BrokerRead
+    const account = yield* broker.account.pipe(
+      Effect.mapError((cause) => fail('broker-read', 'broker', 'Alpaca discovery read failed', cause)),
+    )
+    yield* Effect.try({
+      try: () => {
+        requireInvariant(
+          account.value.id === identity.accountId,
+          'account-mismatch',
+          'Alpaca account identity mismatch',
+        )
+        validateReadEvidence(account, 'account')
+      },
+      catch: (cause) =>
+        cause instanceof PaperProofDiscoveryError
+          ? cause
+          : fail('validate', 'account-mismatch', 'Alpaca account observation is invalid', cause),
+    })
+    const assets = yield* Effect.forEach(
+      snapshot.document.targetPlan.intentTargets,
+      (intent) => broker.assetBySymbol(intent.symbol),
+      { concurrency: assetReadConcurrency },
+    ).pipe(Effect.mapError((cause) => fail('broker-read', 'broker', 'Alpaca asset discovery read failed', cause)))
+    const capturedAtMs = yield* Clock.currentTimeMillis
+    const capturedAt = new Date(capturedAtMs).toISOString()
+    yield* ensure(
+      capturedAtMs < Date.parse(snapshot.document.expiresAt),
+      'document-stale',
+      'shadow document reached its exclusive submission cutoff during broker observation',
+    )
+    return yield* Effect.try({
+      try: () => makeReceipt(identity, snapshot, binding, account, assets, capturedAt),
+      catch: (cause) =>
+        cause instanceof PaperProofDiscoveryError
+          ? cause
+          : fail('decode', 'output', 'paper proof discovery receipt is invalid', cause),
+    })
+  })


### PR DESCRIPTION
## Summary

- add an explicit no-default, OBSERVE-only `PREPARE` / `DISCOVER` command that exits before Bayn's HTTP, migration, reconciliation, loop, and mutation capabilities while leaving the no-command service path unchanged
- read the latest terminal cycle and strict shadow decision through `CycleObservability` and `CycleStore` in one shared PostgreSQL `REPEATABLE READ, READ ONLY` transaction, with exact immutable binding and `AuthorityNotPaper`-only validation
- read the configured account once, then fetch every persisted plan asset with bounded concurrency and emit an ordered, non-authorizing typed receipt with semantic and observation hashes, raw facts, and asset-only eligibility reasons
- normalize adapter-shaped optional broker evidence before hashing, document the ephemeral discovery boundary, and cover typed failures, ordering, replay, no-mutation capability, and transaction semantics

## Related Issues

PROOMPT-375 (dependency slice; does not complete the issue)

## Testing

- `bun test services/bayn/src/config.test.ts services/bayn/src/paper-proof-discovery.test.ts` (24 passed, 1 PostgreSQL-gated skip)
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:59495/bayn_test bun test services/bayn/src/paper-proof-discovery.test.ts` against PostgreSQL 18 (7 passed)
- PostgreSQL 18 integration: `bun test services/bayn/src/db/evidence-store.integration.test.ts` (38 passed), `bun test services/bayn/src/db/paper-store.integration.test.ts` (26 passed), and `bun test services/bayn/src/db/cycle-store.integration.test.ts` (13 passed)
- `bun run --filter @proompteng/bayn test` (367 passed, 88 environment-gated skips, 0 failed)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`

## Breaking Changes

None. The command has no default; existing service startup is unchanged when the command variables are absent.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
