### PR TITLE
fix(bayn): align durable observability evidence

### DIFF
--- a/services/bayn/src/cycle-observability.test.ts
+++ b/services/bayn/src/cycle-observability.test.ts
@@ -212,6 +212,7 @@ describe('autonomous cycle operations classification', () => {
     const readyPaper = deriveCycleOperationsStatus(
       projection({
         authority: {
+          generationHash: '4'.repeat(64),
           maximum: Authority.Paper,
           effective: Authority.Observe,
           kill: KillState.Clear,
@@ -245,6 +246,7 @@ describe('autonomous cycle operations classification', () => {
     expect(readyPaper).toMatchObject({
       condition: CycleOperationsCondition.Waiting,
       reason: CycleOperationsReason.NoCycleRecorded,
+      authority: { generationHash: '4'.repeat(64) },
       alerts: { authorityIncoherent: false, reconciliationBlocked: false },
     })
   })
@@ -280,6 +282,7 @@ describe('autonomous cycle operations classification', () => {
 
   test('requires PAPER reconciliation to cover the latest selected-account mutation', () => {
     const authority = {
+      generationHash: '4'.repeat(64),
       maximum: Authority.Paper,
       effective: Authority.Paper,
       kill: KillState.Clear,
@@ -324,6 +327,7 @@ describe('autonomous cycle operations classification', () => {
 
   test('blocks PAPER on discrepancy and exact reconciliation staleness boundaries', () => {
     const authority = {
+      generationHash: '4'.repeat(64),
       maximum: Authority.Paper,
       effective: Authority.Paper,
       kill: KillState.Clear,

--- a/services/bayn/src/cycle-observability.ts
+++ b/services/bayn/src/cycle-observability.ts
@@ -26,6 +26,7 @@ export interface CycleOperationsSnapshot {
 }
 
 export interface DurableAuthorityObservation {
+  readonly generationHash: string
   readonly maximum: Authority
   readonly effective: Authority
   readonly kill: KillState

--- a/services/bayn/src/db/cycle-observability.integration.test.ts
+++ b/services/bayn/src/db/cycle-observability.integration.test.ts
@@ -292,6 +292,7 @@ describePostgres('PostgreSQL cycle observability projection', () => {
       last: null,
       unfinishedCycleCount: 1,
       authority: {
+        generationHash: 'f'.repeat(64),
         maximum: Authority.Observe,
         effective: Authority.Observe,
         kill: KillState.Clear,
@@ -353,6 +354,45 @@ describePostgres('PostgreSQL cycle observability projection', () => {
       failure: 'invariant',
       message: `configured account ${accountId} differs from the projected current or last cycle`,
     })
+  })
+
+  test('uses the canonical reconciliation-id tie-break for equal timestamps', async () => {
+    const higherReconciliationId = 'f'.repeat(64)
+    const result = await runtime.runPromise(
+      Effect.gen(function* () {
+        const observability = yield* CycleObservability
+        const sql = yield* PgClient.PgClient
+        yield* seedSafetyState()
+        yield* sql`
+          INSERT INTO reconciliations (
+            reconciliation_id, schema_version, account_id, expected_hash, observed_hash,
+            content_hash, status, discrepancies, reconciled_at
+          ) VALUES (
+            ${higherReconciliationId},
+            'bayn.paper-reconciliation.v1',
+            ${accountId},
+            ${reconciliationHash},
+            ${reconciliationHash},
+            ${'2'.repeat(64)},
+            'EXACT',
+            ${sql.json(JSON.stringify([]))},
+            ${'2026-03-06T21:00:00.000Z'}
+          )
+        `
+        const projection = yield* observability.read(qualificationRunId, accountId)
+        const [historyLatest] = yield* sql<{ reconciliation_id: string }>`
+          SELECT reconciliation_id
+          FROM reconciliations
+          WHERE account_id = ${accountId}
+          ORDER BY reconciled_at DESC, reconciliation_id DESC
+          LIMIT 1
+        `
+        return { historyLatest, projection }
+      }),
+    )
+
+    expect(result.historyLatest?.reconciliation_id).toBe(higherReconciliationId)
+    expect(result.projection.reconciliation?.reconciliationId).toBe(result.historyLatest?.reconciliation_id)
   })
 
   test('keeps PAPER blocked when a sub-millisecond resolved mutation follows exact reconciliation', async () => {

--- a/services/bayn/src/db/cycle-observability.ts
+++ b/services/bayn/src/db/cycle-observability.ts
@@ -77,6 +77,7 @@ const ProjectionRowSchema = Schema.Struct({
   selected_account_id: Schema.NullOr(StrictNonEmptyStringSchema),
   account_mismatch: Schema.Boolean,
   unfinished_cycle_count: NonNegativeIntegerSchema,
+  authority_generation_hash: NullableSha256,
   authority_maximum: Schema.NullOr(Schema.Enum(Authority)),
   authority_effective: Schema.NullOr(Schema.Enum(Authority)),
   authority_kill: Schema.NullOr(Schema.Enum(KillState)),
@@ -162,10 +163,16 @@ const snapshotFromRow = (row: ProjectionRow, prefix: 'current' | 'last'): CycleO
 
 const authorityFromRow = (row: ProjectionRow): DurableAuthorityObservation | null => {
   if (row.authority_maximum === null) return null
-  if (row.authority_effective === null || row.authority_kill === null || row.authority_updated_at === null) {
+  if (
+    row.authority_generation_hash === null ||
+    row.authority_effective === null ||
+    row.authority_kill === null ||
+    row.authority_updated_at === null
+  ) {
     throw readError('invariant', 'durable authority projection is incomplete')
   }
   return {
+    generationHash: row.authority_generation_hash,
     maximum: row.authority_maximum,
     effective: row.authority_effective,
     kill: row.authority_kill,
@@ -269,7 +276,7 @@ const makeCycleObservability = Effect.gen(function* () {
             SELECT *
             FROM reconciliations
             WHERE account_id = (SELECT account_id FROM selected_account)
-            ORDER BY reconciled_at DESC, reconciliation_id
+            ORDER BY reconciled_at DESC, reconciliation_id DESC
             LIMIT 1
           ),
           account_mutation_events AS (
@@ -359,6 +366,7 @@ const makeCycleObservability = Effect.gen(function* () {
               FROM scoped_cycles
               WHERE state IN ('PENDING', 'ACTIVE')
             ) AS unfinished_cycle_count,
+            authority.generation_hash AS authority_generation_hash,
             authority.maximum AS authority_maximum,
             authority.effective AS authority_effective,
             authority.kill_state AS authority_kill,


### PR DESCRIPTION
## Summary

- project the durable authority generation hash through `CycleObservability.read` with strict SHA-256 row decoding
- select the canonical latest reconciliation with `reconciled_at DESC, reconciliation_id DESC`
- cover authority hash readback and equal-timestamp reconciliation selection in focused unit and PostgreSQL tests

## Related Issues

Supports PROOMPT-375 and the non-mutating DISCOVER prerequisite in #13178.

## Testing

- `bun test services/bayn/src/cycle-observability.test.ts`
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:<local-port>/bayn_test bun test services/bayn/src/db/cycle-observability.integration.test.ts`
- `bun run --filter @proompteng/bayn test` (359 passed, 88 PostgreSQL-gated skipped)
- PostgreSQL 18 workflow-equivalent integration suite: evidence-store 38/38, paper-store 26/26, cycle-store 13/13
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (screenshots are not applicable; Breaking Changes is filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked (no user-facing documentation change; #13178 tracks consumption).