### PR TITLE
fix(bayn): avoid privileged candidate topology reads

### DIFF
--- a/services/bayn/src/qualification-candidate-command.test.ts
+++ b/services/bayn/src/qualification-candidate-command.test.ts
@@ -35,14 +35,14 @@ const observations = (
 ): readonly CandidateReplicaObservation[] => [
   {
     endpointHost: endpoints[0].hostname,
-    replica: 'signal-clickhouse-0',
+    replica: 'chi-torghut-clickhouse-default-0-0-0',
     principal: publisherPrincipal,
     snapshot,
     ...overrides[0],
   },
   {
     endpointHost: endpoints[1].hostname,
-    replica: 'signal-clickhouse-1',
+    replica: 'chi-torghut-clickhouse-default-0-1-0',
     principal: publisherPrincipal,
     snapshot,
     ...overrides[1],
@@ -114,7 +114,10 @@ describe('qualification candidate command', () => {
         BAYN_TIGERBEETLE_LEDGER: input().tigerBeetleLedger,
       },
     })
-    expect(report.replicas.map((replica) => replica.replica)).toEqual(['signal-clickhouse-0', 'signal-clickhouse-1'])
+    expect(report.replicas.map((replica) => replica.replica)).toEqual([
+      'chi-torghut-clickhouse-default-0-0-0',
+      'chi-torghut-clickhouse-default-0-1-0',
+    ])
     expect(new Set(report.replicas.map((replica) => replica.snapshotCanonicalHash)).size).toBe(1)
   })
 
@@ -153,10 +156,23 @@ describe('qualification candidate command', () => {
   })
 
   test('rejects duplicate observed physical hostnames', async () => {
-    const error = await failure(input(), readers(observations([{}, { replica: 'signal-clickhouse-0' }])))
+    const error = await failure(
+      input(),
+      readers(observations([{}, { replica: 'chi-torghut-clickhouse-default-0-0-0' }])),
+    )
 
     expect(error.message).toBe('Signal replica candidate verification failed')
     expect(String(error.cause)).toContain('same physical replica')
+  })
+
+  test('rejects distinct physical hosts outside the source-controlled replica pair', async () => {
+    const error = await failure(
+      input(),
+      readers(observations([{}, { replica: 'chi-another-clickhouse-default-0-1-0' }])),
+    )
+
+    expect(error.message).toBe('Signal replica candidate verification failed')
+    expect(String(error.cause)).toContain('source-controlled physical replica identities')
   })
 
   test('rejects canonical snapshot divergence across replicas', async () => {

--- a/services/bayn/src/qualification-candidate-command.test.ts
+++ b/services/bayn/src/qualification-candidate-command.test.ts
@@ -35,16 +35,14 @@ const observations = (
 ): readonly CandidateReplicaObservation[] => [
   {
     endpointHost: endpoints[0].hostname,
-    replica: 'signal-0',
-    topology: ['signal-0', 'signal-1'],
+    replica: 'signal-clickhouse-0',
     principal: publisherPrincipal,
     snapshot,
     ...overrides[0],
   },
   {
     endpointHost: endpoints[1].hostname,
-    replica: 'signal-1',
-    topology: ['signal-0', 'signal-1'],
+    replica: 'signal-clickhouse-1',
     principal: publisherPrincipal,
     snapshot,
     ...overrides[1],
@@ -80,7 +78,7 @@ const failure = async (
   Effect.runPromise(Effect.flip(verifyQualificationCandidate(candidateInput, candidateReaders)))
 
 describe('qualification candidate command', () => {
-  test('emits one deterministic complete runtime after two-replica consensus and an unconsumed check', async () => {
+  test('emits one deterministic complete runtime from direct physical hosts without topology metadata', async () => {
     let checkedSnapshotId: string | undefined
     const candidateReaders = readers()
     const report = await Effect.runPromise(
@@ -116,7 +114,7 @@ describe('qualification candidate command', () => {
         BAYN_TIGERBEETLE_LEDGER: input().tigerBeetleLedger,
       },
     })
-    expect(report.replicas.map((replica) => replica.replica)).toEqual(['signal-0', 'signal-1'])
+    expect(report.replicas.map((replica) => replica.replica)).toEqual(['signal-clickhouse-0', 'signal-clickhouse-1'])
     expect(new Set(report.replicas.map((replica) => replica.snapshotCanonicalHash)).size).toBe(1)
   })
 
@@ -154,11 +152,11 @@ describe('qualification candidate command', () => {
     expect(reads).toBe(0)
   })
 
-  test('rejects divergent physical-replica topology', async () => {
-    const error = await failure(input(), readers(observations([{}, { topology: ['signal-0', 'signal-2'] }])))
+  test('rejects duplicate observed physical hostnames', async () => {
+    const error = await failure(input(), readers(observations([{}, { replica: 'signal-clickhouse-0' }])))
 
     expect(error.message).toBe('Signal replica candidate verification failed')
-    expect(String(error.cause)).toContain('reported divergent topology')
+    expect(String(error.cause)).toContain('same physical replica')
   })
 
   test('rejects canonical snapshot divergence across replicas', async () => {
@@ -179,6 +177,25 @@ describe('qualification candidate command', () => {
 
     expect(error.message).toBe('Signal replica candidate verification failed')
     expect(String(error.cause)).toContain('declared Signal publisher principal')
+  })
+
+  test('does not start a sibling replica read after a normal replica failure', async () => {
+    const reads: string[] = []
+    const error = await failure(input(), {
+      readReplica: (endpoint) => {
+        reads.push(endpoint.hostname)
+        return Effect.fail(
+          new QualificationCandidateError({
+            operation: 'replica',
+            message: `failed ${endpoint.hostname}`,
+          }),
+        )
+      },
+      readQualificationLocks: () => Effect.die(new Error('failed replica must stop before PostgreSQL')),
+    })
+
+    expect(error.message).toBe(`failed ${endpoints[0].hostname}`)
+    expect(reads).toEqual([endpoints[0].hostname])
   })
 
   test.each([

--- a/services/bayn/src/qualification-candidate-command.ts
+++ b/services/bayn/src/qualification-candidate-command.ts
@@ -36,7 +36,6 @@ const ReplicaIdentityRow = Schema.Struct({
   replica: TrimmedNonEmptyStringSchema,
   principal: TrimmedNonEmptyStringSchema,
 })
-const ReplicaTopologyRow = Schema.Struct({ replica: TrimmedNonEmptyStringSchema })
 const ReadOnlyRow = Schema.Struct({ read_only: Schema.Boolean })
 const LockCountRow = Schema.Struct({
   lock_count: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
@@ -44,7 +43,6 @@ const LockCountRow = Schema.Struct({
 
 const decodeCandidateRow = Schema.decodeUnknownEffect(Schema.Tuple([CandidateRow]), strictParseOptions)
 const decodeReplicaIdentity = Schema.decodeUnknownEffect(Schema.Tuple([ReplicaIdentityRow]), strictParseOptions)
-const decodeReplicaTopology = Schema.decodeUnknownEffect(Schema.Array(ReplicaTopologyRow), strictParseOptions)
 const decodeReadOnlyRow = Schema.decodeUnknownEffect(Schema.Tuple([ReadOnlyRow]), strictParseOptions)
 const decodeLockCountRow = Schema.decodeUnknownEffect(Schema.Tuple([LockCountRow]), strictParseOptions)
 
@@ -88,7 +86,6 @@ const preserveCandidateError = (
 export interface CandidateReplicaObservation {
   readonly endpointHost: string
   readonly replica: string
-  readonly topology: readonly string[]
   readonly principal: string
   readonly snapshot: MarketDataSnapshot
 }
@@ -236,20 +233,6 @@ const compareReplicaObservations = (
   if (new Set(observedReplicas).size !== observedReplicas.length) {
     throw new TypeError('ClickHouse endpoints resolved to the same physical replica')
   }
-  const expectedTopology = [...(observations[0]?.topology ?? [])].sort()
-  if (expectedTopology.length !== 2 || new Set(expectedTopology).size !== expectedTopology.length) {
-    throw new TypeError('ClickHouse topology must contain exactly two distinct physical replicas')
-  }
-  if (
-    observations.some(
-      (observation) => canonicalJsonV1([...observation.topology].sort()) !== canonicalJsonV1(expectedTopology),
-    )
-  ) {
-    throw new TypeError('ClickHouse replica endpoints reported divergent topology')
-  }
-  if (canonicalJsonV1(observedReplicas) !== canonicalJsonV1(expectedTopology)) {
-    throw new TypeError('ClickHouse endpoints do not cover the complete two-replica topology')
-  }
   const canonicalSnapshots = observations.map((observation) => canonicalJsonV1(observation.snapshot))
   const canonicalSnapshot = canonicalSnapshots[0]
   if (canonicalSnapshot === undefined || canonicalSnapshots.some((value) => value !== canonicalSnapshot)) {
@@ -287,7 +270,7 @@ export const verifyQualificationCandidate = (
       try: () => validateCandidateEndpoints(input.clickhouseUrls),
       catch: (cause) => candidateError('config', 'invalid candidate replica endpoints', cause),
     })
-    const observations = yield* Effect.all(endpoints.map(readers.readReplica), { concurrency: 2 })
+    const observations = [yield* readers.readReplica(endpoints[0]), yield* readers.readReplica(endpoints[1])] as const
     const consensus = yield* Effect.try({
       try: () => compareReplicaObservations(input, observations),
       catch: (cause) => candidateError('replica', 'Signal replica candidate verification failed', cause),
@@ -333,38 +316,22 @@ const readReplica = (
   }).pipe(Layer.provide(NodeHttpClient.layerNodeHttp))
   const program = Effect.gen(function* () {
     const sql = yield* ClickhouseClient.ClickhouseClient
-    const [identityRows, topology, candidateRows] = yield* Effect.all(
-      [
-        decodeReplicaIdentity(
-          yield* sql`
-            SELECT host_name AS replica, currentUser() AS principal
-            FROM system.clusters
-            WHERE cluster = 'default' AND is_local
-            ORDER BY host_name
-          `.pipe(sql.withQueryId('bayn-candidate-replica-identity')),
-        ),
-        decodeReplicaTopology(
-          yield* sql`
-            SELECT host_name AS replica
-            FROM system.clusters
-            WHERE cluster = 'default'
-            ORDER BY shard_num, replica_num
-          `.pipe(sql.withQueryId('bayn-candidate-replica-topology')),
-        ),
-        decodeCandidateRow(
-          yield* sql`
-            SELECT snapshot_id, calendar_version
-            FROM signal.snapshot_manifests_v2
-            WHERE universe_id = ${sql.param('String', input.protocol.universeId)}
-              AND universe_symbol_hash = ${sql.param('String', input.protocol.universeSymbolHash)}
-              AND requested_start = toDate(${sql.param('String', input.protocol.historyStart)})
-              AND publication_asof = toDate(${sql.param('String', input.publicationDate)})
-            ORDER BY finalized_at DESC, snapshot_id DESC
-            LIMIT 1
-          `.pipe(sql.withQueryId(`bayn-candidate-select-${input.publicationDate}`)),
-        ),
-      ],
-      { concurrency: 3 },
+    const identityRows = yield* decodeReplicaIdentity(
+      yield* sql`
+        SELECT hostName() AS replica, currentUser() AS principal
+      `.pipe(sql.withQueryId('bayn-candidate-replica-identity')),
+    )
+    const candidateRows = yield* decodeCandidateRow(
+      yield* sql`
+        SELECT snapshot_id, calendar_version
+        FROM signal.snapshot_manifests_v2
+        WHERE universe_id = ${sql.param('String', input.protocol.universeId)}
+          AND universe_symbol_hash = ${sql.param('String', input.protocol.universeSymbolHash)}
+          AND requested_start = toDate(${sql.param('String', input.protocol.historyStart)})
+          AND publication_asof = toDate(${sql.param('String', input.publicationDate)})
+        ORDER BY finalized_at DESC, snapshot_id DESC
+        LIMIT 1
+      `.pipe(sql.withQueryId(`bayn-candidate-select-${input.publicationDate}`)),
     )
     const [identity] = identityRows
     const [candidate] = candidateRows
@@ -395,7 +362,6 @@ const readReplica = (
     return {
       endpointHost: endpoint.hostname,
       replica: identity.replica,
-      topology: topology.map((row) => row.replica),
       principal: identity.principal,
       snapshot,
     }

--- a/services/bayn/src/qualification-candidate-command.ts
+++ b/services/bayn/src/qualification-candidate-command.ts
@@ -22,6 +22,10 @@ const maximumTigerBeetleClusterId = (1n << 128n) - 1n
 const maximumTigerBeetleLedger = 2 ** 32 - 1
 const canonicalDecimalPattern = /^(?:0|[1-9][0-9]*)$/
 const transportAddressesPattern = /^[A-Za-z0-9.[\]:_-]+(?:,[A-Za-z0-9.[\]:_-]+)*$/
+const signalReplicaIdentities = [
+  'chi-torghut-clickhouse-default-0-0-0',
+  'chi-torghut-clickhouse-default-0-1-0',
+] as const
 
 const ExactReplicaUrls = Config.Array(Schema.URLFromString).check(
   Schema.makeFilter((urls: readonly URL[]) => urls.length === 2, {
@@ -232,6 +236,9 @@ const compareReplicaObservations = (
   const observedReplicas = observations.map((observation) => observation.replica).sort()
   if (new Set(observedReplicas).size !== observedReplicas.length) {
     throw new TypeError('ClickHouse endpoints resolved to the same physical replica')
+  }
+  if (canonicalJsonV1(observedReplicas) !== canonicalJsonV1(signalReplicaIdentities)) {
+    throw new TypeError('ClickHouse endpoints do not cover the source-controlled physical replica identities')
   }
   const canonicalSnapshots = observations.map((observation) => canonicalJsonV1(observation.snapshot))
   const canonicalSnapshot = canonicalSnapshots[0]


### PR DESCRIPTION
## Summary

- replace privileged `system.clusters` reads with direct `hostName()` and `currentUser()` identity on each supplied endpoint
- bind both returned hostnames to the source-controlled closed Signal replica pair without coupling DNS aliases or port forwards to ClickHouse names
- serialize endpoint reads and per-endpoint identity/candidate queries so an ordinary failure cannot interrupt a sibling ClickHouse query
- retain request timeouts, `readonly=1`, full two-replica snapshot verification, canonical consensus, and the PostgreSQL read-only zero-lock check

Effect beta.100 evidence: `/Users/gregkonush/github.com/effect/packages/sql/clickhouse/src/ClickhouseClient.ts:237-256` passes the query AbortSignal and its interruption finalizer calls `controller.abort()` followed by `KILL QUERY WHERE query_id = ...`. The local Effect checkout is `4.0.0-beta.100` at `017f384b1e40eeac220cff6781feb02e89fda349`, matching Bayn.

The README wording follow-up remains intentionally outside this two-file source-only PR after #13178.

## Related Issues

PROOMPT-403

## Testing

- `bun test services/bayn/src/qualification-candidate-command.test.ts` (14 pass)
- `bun run --filter @proompteng/bayn test` (369 pass, 89 PostgreSQL-gated skips)
- `bun test packages/scripts/src/bayn` (20 pass)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`

## Breaking Changes

None. The command no longer requires `SELECT` on ClickHouse system tables; no grant change is required.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] Documentation follow-up is tracked above without expanding this PR beyond its two-file source scope.