### PR TITLE
fix(bayn): timestamp mutation evidence after response bodies

### DIFF
--- a/services/bayn/src/broker/alpaca-mutations.test.ts
+++ b/services/bayn/src/broker/alpaca-mutations.test.ts
@@ -218,6 +218,42 @@ describe('Alpaca paper mutations', () => {
     })
   })
 
+  test('samples submit evidence after the complete response body', async () => {
+    let releaseBody: () => void = () => {
+      throw new Error('submit response body reader did not start')
+    }
+    const client = HttpClient.make((request) => {
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          releaseBody = () => {
+            controller.enqueue(new TextEncoder().encode(JSON.stringify(orderResponse)))
+            controller.close()
+          }
+        },
+      })
+      return Effect.succeed(
+        HttpClientResponse.fromWeb(request, new Response(body, { status: 200, headers: responseHeaders })),
+      )
+    })
+
+    const program = withMutation(
+      client,
+      (mutation) =>
+        Effect.gen(function* () {
+          const fiber = yield* mutation.submit(intent).pipe(Effect.forkChild)
+          yield* Effect.yieldNow
+          yield* TestClock.adjust(2_000)
+          releaseBody()
+          return yield* Fiber.join(fiber)
+        }),
+      { ...options, operationTimeoutMs: 5_000 },
+    ).pipe(Effect.provide(TestClock.layer()))
+
+    const receipt = await Effect.runPromise(program)
+    expect(receipt.evidence.observedAt).toBe('1970-01-01T00:00:02.000Z')
+    expect(receipt.order.observedAt).toBe('1970-01-01T00:00:02.000Z')
+  })
+
   test('preserves the broker order ID when Alpaca accepts a mismatched order', async () => {
     const mismatched = { ...orderResponse, symbol: 'NVDA' }
     const client = HttpClient.make((request) => Effect.succeed(response(request, mismatched)))
@@ -375,5 +411,51 @@ describe('Alpaca paper mutations', () => {
       { method: 'DELETE', url: `https://paper-api.alpaca.markets/v2/orders/${orderId}` },
       { method: 'DELETE', url: `https://paper-api.alpaca.markets/v2/orders/${orderId}` },
     ])
+  })
+
+  test('samples ambiguous cancel evidence after the complete response body', async () => {
+    const error = { code: 50010000, message: 'unknown' }
+    let releaseBody: () => void = () => {
+      throw new Error('cancel response body reader did not start')
+    }
+    const client = HttpClient.make((request) => {
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          releaseBody = () => {
+            controller.enqueue(new TextEncoder().encode(JSON.stringify(error)))
+            controller.close()
+          }
+        },
+      })
+      return Effect.succeed(
+        HttpClientResponse.fromWeb(request, new Response(body, { status: 500, headers: responseHeaders })),
+      )
+    })
+
+    const program = withMutation(
+      client,
+      (mutation) =>
+        Effect.gen(function* () {
+          const fiber = yield* Effect.flip(mutation.cancel(orderId)).pipe(Effect.forkChild)
+          yield* Effect.yieldNow
+          yield* TestClock.adjust(2_000)
+          releaseBody()
+          return yield* Fiber.join(fiber)
+        }),
+      { ...options, operationTimeoutMs: 5_000 },
+    ).pipe(Effect.provide(TestClock.layer()))
+
+    const failure = await Effect.runPromise(program)
+    expect(failure).toMatchObject({
+      operation: MutationOperation.Cancel,
+      failure: MutationFailure.Unknown,
+      outcome: MutationOutcome.Unknown,
+      evidence: {
+        contentHash: canonicalHashV1(error),
+        observedAt: '1970-01-01T00:00:02.000Z',
+        requestId: 'req-123',
+        status: 500,
+      },
+    })
   })
 })

--- a/services/bayn/src/broker/alpaca-mutations.ts
+++ b/services/bayn/src/broker/alpaca-mutations.ts
@@ -343,7 +343,6 @@ export const makeMutation = (
           runtime.operationTimeoutMs,
           Effect.gen(function* () {
             const response = yield* client.execute(request)
-            const observedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
             const headers = yield* decodeHeaders(response).pipe(
               Effect.mapError((cause) =>
                 unknownOutcome(
@@ -366,6 +365,7 @@ export const makeMutation = (
                 ),
               ),
             )
+            const observedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
             const contentHash = yield* Effect.try({
               try: () => canonicalHashV1(raw),
               catch: (cause) =>
@@ -463,7 +463,6 @@ export const makeMutation = (
           runtime.operationTimeoutMs,
           Effect.gen(function* () {
             const response = yield* client.execute(request)
-            const observedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
             const headers = yield* decodeHeaders(response).pipe(
               Effect.mapError((cause) =>
                 unknownOutcome(
@@ -495,6 +494,7 @@ export const makeMutation = (
                       ),
                     ),
                   )
+            const observedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
             const evidence = responseEvidence(headers['x-request-id'], response.status, contentHash, observedAt)
             if (response.status !== 204) {
               return yield* Effect.fail(


### PR DESCRIPTION
## Summary

- sample Alpaca submit evidence only after the complete JSON response body has been consumed
- sample ambiguous cancel evidence only after the complete response body has been consumed
- prove causal timestamps with delayed streaming-response regressions under Effect TestClock

## Related Issues

PROOMPT-375

## Testing

- `bun test services/bayn/src/broker/alpaca-mutations.test.ts` (11 pass, 0 fail)
- `bun run --filter @proompteng/bayn test` (371 pass, 89 environment-gated PostgreSQL skips, 0 fail)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:type-aware`
- `bun run --filter @proompteng/bayn build`
- `bunx oxfmt --check services/bayn/src/broker/alpaca-mutations.ts services/bayn/src/broker/alpaca-mutations.test.ts`
- `git diff --check origin/main...HEAD`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation and release notes are not required for this internal evidence-timestamp correction.