### PR TITLE
fix(bayn): align Alpaca read contracts

### DIFF
--- a/services/bayn/src/broker/alpaca.test.ts
+++ b/services/bayn/src/broker/alpaca.test.ts
@@ -58,6 +58,12 @@ const accountResponse = {
   options_buying_power: '0',
 }
 
+const accountConfigurationResponse = {
+  fractional_trading: true,
+  no_shorting: true,
+  suspend_trade: false,
+}
+
 const positionResponse = {
   asset_id: assetId,
   symbol: 'AAPL',
@@ -199,6 +205,7 @@ describe('Alpaca paper reads', () => {
     expect(inspected).not.toContain('paper-secret')
     expect(surface).toEqual([
       'account',
+      'accountConfiguration',
       'assetBySymbol',
       'fillActivities',
       'marketCalendar',
@@ -226,6 +233,102 @@ describe('Alpaca paper reads', () => {
         reset: '1784664000',
         retryAfter: undefined,
       },
+    })
+  })
+
+  test('reads and hashes the current fractional-trading account configuration with GET only', async () => {
+    const requests: Array<{ method: string; url: URL; key: string; secret: string }> = []
+    let releaseBody: (() => void) | undefined
+    const client = HttpClient.make((request, url) => {
+      requests.push({
+        method: request.method,
+        url,
+        key: request.headers['apca-api-key-id'] ?? '',
+        secret: request.headers['apca-api-secret-key'] ?? '',
+      })
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          releaseBody = () => {
+            controller.enqueue(new TextEncoder().encode(JSON.stringify(accountConfigurationResponse)))
+            controller.close()
+          }
+        },
+      })
+      return Effect.succeed(
+        HttpClientResponse.fromWeb(
+          request,
+          new Response(body, {
+            status: 200,
+            headers: responseHeaders,
+          }),
+        ),
+      )
+    })
+
+    const program = withClient(
+      client,
+      (read) =>
+        Effect.gen(function* () {
+          const fiber = yield* read.accountConfiguration.pipe(Effect.forkChild)
+          yield* Effect.yieldNow
+          yield* TestClock.adjust(1_000)
+          releaseBody?.()
+          return yield* Fiber.join(fiber)
+        }),
+      { ...options, operationTimeoutMs: 5_000 },
+    ).pipe(Effect.provide(TestClock.layer()))
+    const result = await Effect.runPromise(program)
+
+    expect(requests).toEqual([
+      {
+        method: 'GET',
+        url: new URL('https://paper-api.alpaca.markets/v2/account/configurations'),
+        key: 'paper-key',
+        secret: 'paper-secret',
+      },
+    ])
+    const requestHash = canonicalHashV1({
+      schemaVersion: 'bayn.alpaca-account-configuration-observation.v1',
+      source: 'alpaca-v2-account-configurations',
+      method: 'GET',
+      path: '/v2/account/configurations',
+    })
+    const normalized = {
+      schemaVersion: 'bayn.alpaca-account-configuration-observation.v1',
+      source: 'alpaca-v2-account-configurations',
+      requestHash,
+      fractionalTrading: true,
+    } as const
+    expect(result.value).toEqual({
+      ...normalized,
+      observedAt: '1970-01-01T00:00:01.000Z',
+      normalizedResponseHash: canonicalHashV1(normalized),
+    })
+    expect(result.evidence).toMatchObject({
+      requestId: 'req-123',
+      status: 200,
+      contentHash: canonicalHashV1(accountConfigurationResponse),
+      observedAt: '1970-01-01T00:00:01.000Z',
+    })
+    expect(requests.some(({ method }) => method === 'PATCH' || method === 'POST' || method === 'DELETE')).toBe(false)
+  })
+
+  test('rejects a malformed fractional-trading account configuration with typed response evidence', async () => {
+    const response = { ...accountConfigurationResponse, fractional_trading: 'true' }
+    const client = HttpClient.make((request) => Effect.succeed(jsonResponse(request, response)))
+
+    const failure = await Effect.runPromise(
+      Effect.flip(withClient(client, (read) => read.accountConfiguration)).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(failure).toMatchObject({
+      operation: 'account-configuration',
+      kind: BrokerReadErrorKind.InvalidResponse,
+      retryable: false,
+      status: 200,
+      requestId: 'req-123',
+      contentHash: canonicalHashV1(response),
+      observedAt: '1970-01-01T00:00:00.000Z',
     })
   })
 
@@ -772,6 +875,124 @@ describe('Alpaca paper reads', () => {
     }
   })
 
+  test('uses canonical order type when the deprecated alias is absent across every order read', async () => {
+    const { order_type: _orderType, ...responseWithoutAlias } = orderResponse
+    const client = HttpClient.make((request, url) =>
+      Effect.succeed(
+        jsonResponse(request, url.pathname === '/v2/orders' ? [responseWithoutAlias] : responseWithoutAlias),
+      ),
+    )
+
+    const reads = await Effect.runPromise(
+      withClient(client, (read) =>
+        Effect.all([read.orders(), read.orderById(orderId), read.orderByClientId(clientOrderId)]),
+      ),
+    )
+
+    for (const read of reads) {
+      const order = Array.isArray(read.value) ? read.value[0] : read.value
+      expect(order?.orderType).toBe(OrderType.Market)
+    }
+  })
+
+  test('rejects a present deprecated order type alias that disagrees with canonical type', async () => {
+    const response = { ...orderResponse, order_type: 'limit' }
+    const client = HttpClient.make((request, url) =>
+      Effect.succeed(jsonResponse(request, url.pathname === '/v2/orders' ? [response] : response)),
+    )
+
+    const failures = await Effect.runPromise(
+      withClient(client, (read) =>
+        Effect.all([
+          Effect.flip(read.orders()),
+          Effect.flip(read.orderById(orderId)),
+          Effect.flip(read.orderByClientId(clientOrderId)),
+        ]),
+      ),
+    )
+
+    expect(failures).toMatchObject([
+      { operation: 'orders', kind: BrokerReadErrorKind.InvalidResponse, retryable: false },
+      { operation: 'order-by-id', kind: BrokerReadErrorKind.InvalidResponse, retryable: false },
+      { operation: 'order-by-client-id', kind: BrokerReadErrorKind.InvalidResponse, retryable: false },
+    ])
+  })
+
+  test('retains causal read evidence when pending order timestamps are null or absent', async () => {
+    const { updated_at: _updatedAt, submitted_at: _submittedAt, ...responseWithoutPendingTimestamps } = orderResponse
+    const client = HttpClient.make((request, url) => {
+      if (url.pathname === '/v2/orders') {
+        return Effect.succeed(jsonResponse(request, [{ ...orderResponse, updated_at: null, submitted_at: null }]))
+      }
+      if (url.pathname === `/v2/orders/${orderId}`) {
+        return Effect.succeed(jsonResponse(request, responseWithoutPendingTimestamps))
+      }
+      return Effect.succeed(jsonResponse(request, { ...responseWithoutPendingTimestamps, updated_at: null }))
+    })
+
+    const reads = await Effect.runPromise(
+      withClient(client, (read) =>
+        Effect.all([read.orders(), read.orderById(orderId), read.orderByClientId(clientOrderId)]),
+      ),
+    )
+
+    for (const read of reads) {
+      const order = Array.isArray(read.value) ? read.value[0] : read.value
+      expect(order).toMatchObject({
+        createdAt: orderResponse.created_at,
+        observedAt: read.evidence.observedAt,
+      })
+      expect(order?.updatedAt).toBeUndefined()
+      expect(order?.submittedAt).toBeUndefined()
+      expect(read.evidence.observedAt).toMatch(/Z$/)
+    }
+  })
+
+  test('accepts external client order IDs through 128 characters and rejects longer values', async () => {
+    let calls = 0
+    let responseClientOrderId = 'e'.repeat(49)
+    let requestedClientOrderId = ''
+    const client = HttpClient.make((request, url) => {
+      calls += 1
+      requestedClientOrderId = url.searchParams.get('client_order_id') ?? ''
+      const body =
+        url.pathname === '/v2/orders'
+          ? [{ ...orderResponse, client_order_id: responseClientOrderId }]
+          : { ...orderResponse, client_order_id: responseClientOrderId }
+      return Effect.succeed(jsonResponse(request, body))
+    })
+
+    const external49 = await Effect.runPromise(withClient(client, (read) => read.orders()))
+    expect(external49.value[0]?.clientOrderId).toBe('e'.repeat(49))
+
+    responseClientOrderId = 'f'.repeat(128)
+    const external128 = await Effect.runPromise(
+      withClient(client, (read) => Effect.all([read.orderById(orderId), read.orderByClientId(responseClientOrderId)])),
+    )
+    expect(external128.map((read) => read.value.clientOrderId)).toEqual([responseClientOrderId, responseClientOrderId])
+    expect(requestedClientOrderId).toBe(responseClientOrderId)
+
+    responseClientOrderId = 'g'.repeat(129)
+    const responseFailures = await Effect.runPromise(
+      withClient(client, (read) => Effect.all([Effect.flip(read.orders()), Effect.flip(read.orderById(orderId))])),
+    )
+    expect(responseFailures).toMatchObject([
+      { operation: 'orders', kind: BrokerReadErrorKind.InvalidResponse, retryable: false },
+      { operation: 'order-by-id', kind: BrokerReadErrorKind.InvalidResponse, retryable: false },
+    ])
+
+    const callsBeforeInvalidLookup = calls
+    const lookupFailure = await Effect.runPromise(
+      Effect.flip(withClient(client, (read) => read.orderByClientId('h'.repeat(129)))),
+    )
+    expect(lookupFailure).toMatchObject({
+      operation: 'order-by-client-id',
+      kind: BrokerReadErrorKind.InvalidRequest,
+      retryable: false,
+    })
+    expect(calls).toBe(callsBeforeInvalidLookup)
+  })
+
   test('reads a bounded fill page and derives the documented page token', async () => {
     let requestedUrl: URL | undefined
     const client = HttpClient.make((request, url) => {
@@ -1022,16 +1243,21 @@ describe('Alpaca paper reads', () => {
 })
 
 describe('Alpaca proxy lifecycle', () => {
-  test('owns and releases its Undici proxy dispatcher exactly once', async () => {
+  test('keeps its Undici proxy dispatcher alive until the owning scope exits and releases it exactly once', async () => {
     let releases = 0
     await Effect.runPromise(
       Effect.scoped(
-        makeProxyDispatcher('http://proxy.test:3128', {
-          create: (url) => new Undici.ProxyAgent({ uri: url.toString() }),
-          destroy: () => {
-            releases += 1
-            return Promise.resolve()
-          },
+        Effect.gen(function* () {
+          yield* makeProxyDispatcher('http://proxy.test:3128', {
+            create: (url) => new Undici.ProxyAgent({ uri: url.toString() }),
+            destroy: () => {
+              releases += 1
+              return Promise.resolve()
+            },
+          })
+          expect(releases).toBe(0)
+          yield* Effect.yieldNow
+          expect(releases).toBe(0)
         }),
       ),
     )

--- a/services/bayn/src/broker/alpaca.test.ts
+++ b/services/bayn/src/broker/alpaca.test.ts
@@ -918,6 +918,34 @@ describe('Alpaca paper reads', () => {
     ])
   })
 
+  test('validates every non-market order shape from canonical type when the deprecated alias is absent', async () => {
+    const malformed = [
+      { label: 'limit', response: { ...orderResponse, type: 'limit', limit_price: null } },
+      { label: 'stop', response: { ...orderResponse, type: 'stop', stop_price: null } },
+      {
+        label: 'stop-limit',
+        response: { ...orderResponse, type: 'stop_limit', limit_price: null, stop_price: null },
+      },
+      {
+        label: 'trailing-stop',
+        response: { ...orderResponse, type: 'trailing_stop', trail_percent: null, trail_price: null },
+      },
+    ] as const
+
+    for (const { label, response } of malformed) {
+      const { order_type: _orderType, ...responseWithoutAlias } = response
+      const client = HttpClient.make((request) => Effect.succeed(jsonResponse(request, responseWithoutAlias)))
+
+      const failure = await Effect.runPromise(Effect.flip(withClient(client, (read) => read.orderById(orderId))))
+
+      expect(failure, label).toMatchObject({
+        operation: 'order-by-id',
+        kind: BrokerReadErrorKind.InvalidResponse,
+        retryable: false,
+      })
+    }
+  })
+
   test('retains causal read evidence when pending order timestamps are null or absent', async () => {
     const { updated_at: _updatedAt, submitted_at: _submittedAt, ...responseWithoutPendingTimestamps } = orderResponse
     const client = HttpClient.make((request, url) => {

--- a/services/bayn/src/broker/alpaca.ts
+++ b/services/bayn/src/broker/alpaca.ts
@@ -14,6 +14,8 @@ const defaultFillActivitiesPageSize = 100
 const maxMarketCalendarRangeDays = 31
 const marketCalendarPreflightRangeDays = 14
 const millisecondsPerDay = 86_400_000
+const accountConfigurationObservationSchemaVersion = 'bayn.alpaca-account-configuration-observation.v1' as const
+const accountConfigurationObservationSource = 'alpaca-v2-account-configurations' as const
 const assetObservationSchemaVersion = 'bayn.alpaca-asset-observation.v1' as const
 const assetObservationSource = 'alpaca-v2-asset' as const
 const marketCalendarSchemaVersion = 'bayn.alpaca-market-calendar-observation.v1' as const
@@ -55,9 +57,9 @@ const isUtcTimestamp = (value: string): boolean => {
   )
 }
 const Timestamp = Schema.String.check(Schema.makeFilter(isUtcTimestamp, { expected: 'an RFC 3339 UTC timestamp' }))
-const ClientOrderId = Schema.String.check(
+const ExternalClientOrderId = Schema.String.check(
   Schema.isMinLength(1),
-  Schema.isMaxLength(48),
+  Schema.isMaxLength(128),
   Schema.makeFilter((value: string) => value.trim() === value, {
     expected: 'a non-empty client order ID without surrounding whitespace',
   }),
@@ -216,6 +218,7 @@ export type BrokerReadOperation =
   | 'proxy'
   | 'preflight'
   | 'account'
+  | 'account-configuration'
   | 'positions'
   | 'orders'
   | 'order-by-id'
@@ -283,6 +286,15 @@ export interface Account {
   readonly observedAt: string
 }
 
+export interface AccountConfigurationObservation {
+  readonly schemaVersion: typeof accountConfigurationObservationSchemaVersion
+  readonly source: typeof accountConfigurationObservationSource
+  readonly requestHash: string
+  readonly fractionalTrading: boolean
+  readonly observedAt: string
+  readonly normalizedResponseHash: string
+}
+
 export interface Position {
   readonly accountId: string
   readonly assetId: string
@@ -303,8 +315,8 @@ export interface Order {
   readonly brokerOrderId: string
   readonly clientOrderId: string
   readonly createdAt: string
-  readonly updatedAt: string
-  readonly submittedAt: string
+  readonly updatedAt?: string
+  readonly submittedAt?: string
   readonly filledAt?: string
   readonly expiredAt?: string
   readonly canceledAt?: string
@@ -414,6 +426,7 @@ export interface FillActivitiesQuery {
 
 export interface BrokerReadShape {
   readonly account: Effect.Effect<ReadResult<Account>, BrokerReadError>
+  readonly accountConfiguration: Effect.Effect<ReadResult<AccountConfigurationObservation>, BrokerReadError>
   readonly assetBySymbol: (symbol: string) => Effect.Effect<ReadResult<AssetObservation>, BrokerReadError>
   readonly positions: Effect.Effect<ReadResult<readonly Position[]>, BrokerReadError>
   readonly orders: (query?: OrdersQuery) => Effect.Effect<ReadResult<readonly Order[]>, BrokerReadError>
@@ -456,6 +469,10 @@ const AccountResponseSchema = Schema.Struct({
   trade_suspended_by_user: Schema.Boolean,
 })
 
+const AccountConfigurationResponseSchema = Schema.Struct({
+  fractional_trading: Schema.Boolean,
+})
+
 const PositionResponseSchema = Schema.Struct({
   asset_id: Uuid,
   symbol: SymbolName,
@@ -496,10 +513,10 @@ const AssetResponseSchema = Schema.Struct({
 
 export const OrderResponseSchema = Schema.Struct({
   id: Uuid,
-  client_order_id: ClientOrderId,
+  client_order_id: ExternalClientOrderId,
   created_at: Timestamp,
-  updated_at: Timestamp,
-  submitted_at: Timestamp,
+  updated_at: Schema.optionalKey(Schema.NullOr(Timestamp)),
+  submitted_at: Schema.optionalKey(Schema.NullOr(Timestamp)),
   filled_at: Schema.NullOr(Timestamp),
   expired_at: Schema.NullOr(Timestamp),
   canceled_at: Schema.NullOr(Timestamp),
@@ -515,7 +532,7 @@ export const OrderResponseSchema = Schema.Struct({
   filled_qty: Decimal,
   filled_avg_price: Schema.NullOr(Decimal),
   order_class: Schema.Union([Schema.Literal(''), Schema.Enum(OrderClass)]),
-  order_type: Schema.Enum(OrderType),
+  order_type: Schema.optionalKey(Schema.Enum(OrderType)),
   type: Schema.Enum(OrderType),
   side: Schema.Enum(OrderSide),
   time_in_force: Schema.Enum(TimeInForce),
@@ -621,6 +638,7 @@ const RuntimeOptionsSchema = Schema.Struct({
 type Decoder<A> = (input: unknown) => Effect.Effect<A, unknown>
 
 const decodeAccount = Schema.decodeUnknownEffect(AccountResponseSchema, responseParseOptions)
+const decodeAccountConfiguration = Schema.decodeUnknownEffect(AccountConfigurationResponseSchema, responseParseOptions)
 const decodeAsset = Schema.decodeUnknownEffect(AssetResponseSchema, responseParseOptions)
 const decodePositions = Schema.decodeUnknownEffect(Schema.Array(PositionResponseSchema), responseParseOptions)
 const decodeOrders = Schema.decodeUnknownEffect(Schema.Array(OrderResponseSchema), responseParseOptions)
@@ -634,7 +652,7 @@ const decodeFillActivitiesQuery = Schema.decodeUnknownEffect(FillActivitiesQuery
 const decodeMarketCalendarQuery = Schema.decodeUnknownEffect(MarketCalendarQuerySchema, inputParseOptions)
 const decodeAssetSymbol = Schema.decodeUnknownEffect(SymbolName)
 const decodeOrderId = Schema.decodeUnknownEffect(Uuid)
-const decodeClientOrderId = Schema.decodeUnknownEffect(ClientOrderId)
+const decodeExternalClientOrderId = Schema.decodeUnknownEffect(ExternalClientOrderId)
 const decodeRuntimeOptions = Schema.decodeUnknownEffect(RuntimeOptionsSchema, inputParseOptions)
 
 const redactDiagnostic = (value: string, sensitiveValues: readonly string[]): string =>
@@ -834,6 +852,30 @@ const normalizeAccount = (
   }
 }
 
+const accountConfigurationRequestMaterial = {
+  schemaVersion: accountConfigurationObservationSchemaVersion,
+  source: accountConfigurationObservationSource,
+  method: 'GET',
+  path: '/v2/account/configurations',
+} as const
+
+const normalizeAccountConfiguration = (
+  raw: typeof AccountConfigurationResponseSchema.Type,
+  observedAt: string,
+): AccountConfigurationObservation => {
+  const normalized = {
+    schemaVersion: accountConfigurationObservationSchemaVersion,
+    source: accountConfigurationObservationSource,
+    requestHash: canonicalHashV1(accountConfigurationRequestMaterial),
+    fractionalTrading: raw.fractional_trading,
+  }
+  return {
+    ...normalized,
+    observedAt,
+    normalizedResponseHash: canonicalHashV1(normalized),
+  }
+}
+
 const normalizePosition = (
   raw: typeof PositionResponseSchema.Type,
   accountId: string,
@@ -900,7 +942,9 @@ export const normalizeOrder = (raw: typeof OrderResponseSchema.Type, accountId: 
   if (raw.asset_class !== AssetClass.UsEquity) throw new Error(`unsupported order asset class ${raw.asset_class}`)
   if ((raw.qty === null) === (raw.notional === null))
     throw new Error('order must contain exactly one of qty or notional')
-  if (raw.order_type !== raw.type) throw new Error('deprecated order_type does not match type')
+  if (raw.order_type !== undefined && raw.order_type !== raw.type) {
+    throw new Error('deprecated order_type does not match type')
+  }
   if (raw.order_class === OrderClass.MultiLeg) throw new Error('multi-leg orders are outside the Bayn equity contract')
 
   const quantityMicros = raw.qty === null ? undefined : positiveMicros(raw.qty, 'order quantity')
@@ -923,6 +967,8 @@ export const normalizeOrder = (raw: typeof OrderResponseSchema.Type, accountId: 
   }
 
   const filledAt = optionalTimestamp(raw.filled_at)
+  const updatedAt = raw.updated_at ?? undefined
+  const submittedAt = raw.submitted_at ?? undefined
   const expiredAt = optionalTimestamp(raw.expired_at)
   const canceledAt = optionalTimestamp(raw.canceled_at)
   const failedAt = optionalTimestamp(raw.failed_at)
@@ -941,8 +987,8 @@ export const normalizeOrder = (raw: typeof OrderResponseSchema.Type, accountId: 
     brokerOrderId: raw.id,
     clientOrderId: raw.client_order_id,
     createdAt: raw.created_at,
-    updatedAt: raw.updated_at,
-    submittedAt: raw.submitted_at,
+    ...(updatedAt === undefined ? {} : { updatedAt }),
+    ...(submittedAt === undefined ? {} : { submittedAt }),
     ...(filledAt === undefined ? {} : { filledAt }),
     ...(expiredAt === undefined ? {} : { expiredAt }),
     ...(canceledAt === undefined ? {} : { canceledAt }),
@@ -958,7 +1004,7 @@ export const normalizeOrder = (raw: typeof OrderResponseSchema.Type, accountId: 
     filledQuantityMicros,
     ...(filledAveragePriceMicros === undefined ? {} : { filledAveragePriceMicros }),
     orderClass: raw.order_class === '' ? OrderClass.Simple : raw.order_class,
-    orderType: raw.order_type,
+    orderType: raw.type,
     side: raw.side,
     timeInForce: raw.time_in_force,
     ...(limitPriceMicros === undefined ? {} : { limitPriceMicros }),
@@ -1285,6 +1331,18 @@ export const make = (options: ReadOptions): Effect.Effect<BrokerReadShape, Broke
       ),
     )
 
+    const accountConfiguration = readJson(
+      'account-configuration',
+      new URL(accountConfigurationRequestMaterial.path, paperTradingUrl),
+      decodeAccountConfiguration,
+    ).pipe(
+      Effect.flatMap((result) =>
+        normalize('account-configuration', result.evidence, () =>
+          normalizeAccountConfiguration(result.value, result.evidence.observedAt),
+        ),
+      ),
+    )
+
     const positions = readJson('positions', new URL('/v2/positions', paperTradingUrl), decodePositions).pipe(
       Effect.flatMap((result) =>
         normalize('positions', result.evidence, () =>
@@ -1357,7 +1415,12 @@ export const make = (options: ReadOptions): Effect.Effect<BrokerReadShape, Broke
       )
 
     const orderByClientId = (clientOrderId: string) =>
-      decodeInput('order-by-client-id', decodeClientOrderId, clientOrderId, 'invalid Alpaca client order ID').pipe(
+      decodeInput(
+        'order-by-client-id',
+        decodeExternalClientOrderId,
+        clientOrderId,
+        'invalid Alpaca client order ID',
+      ).pipe(
         Effect.flatMap((decoded) => {
           const url = new URL('/v2/orders:by_client_order_id', paperTradingUrl)
           url.searchParams.set('client_order_id', decoded)
@@ -1397,7 +1460,17 @@ export const make = (options: ReadOptions): Effect.Effect<BrokerReadShape, Broke
         ),
       )
 
-    return { account, assetBySymbol, positions, orders, orderById, orderByClientId, fillActivities, marketCalendar }
+    return {
+      account,
+      accountConfiguration,
+      assetBySymbol,
+      positions,
+      orders,
+      orderById,
+      orderByClientId,
+      fillActivities,
+      marketCalendar,
+    }
   })
 
 const missingOrderId = '00000000-0000-4000-8000-000000000000'

--- a/services/bayn/src/broker/alpaca.ts
+++ b/services/bayn/src/broker/alpaca.ts
@@ -953,16 +953,16 @@ export const normalizeOrder = (raw: typeof OrderResponseSchema.Type, accountId: 
   if (quantityMicros !== undefined && BigInt(filledQuantityMicros) > BigInt(quantityMicros)) {
     throw new Error('filled quantity exceeds order quantity')
   }
-  if (raw.order_type === OrderType.Limit && raw.limit_price === null) {
+  if (raw.type === OrderType.Limit && raw.limit_price === null) {
     throw new Error('limit order is missing limit_price')
   }
-  if (raw.order_type === OrderType.Stop && raw.stop_price === null) {
+  if (raw.type === OrderType.Stop && raw.stop_price === null) {
     throw new Error('stop order is missing stop_price')
   }
-  if (raw.order_type === OrderType.StopLimit && (raw.limit_price === null || raw.stop_price === null)) {
+  if (raw.type === OrderType.StopLimit && (raw.limit_price === null || raw.stop_price === null)) {
     throw new Error('stop-limit order is missing limit_price or stop_price')
   }
-  if (raw.order_type === OrderType.TrailingStop && (raw.trail_price === null) === (raw.trail_percent === null)) {
+  if (raw.type === OrderType.TrailingStop && (raw.trail_price === null) === (raw.trail_percent === null)) {
     throw new Error('trailing-stop order must contain exactly one trailing offset')
   }
 

--- a/services/bayn/src/broker/alpaca.ts
+++ b/services/bayn/src/broker/alpaca.ts
@@ -1614,5 +1614,8 @@ export const verifyReadAccess = (read: BrokerReadShape): Effect.Effect<ReadPrefl
 export const layer = (options: ReadOptions): Layer.Layer<BrokerRead, BrokerReadError, HttpClient.HttpClient> =>
   Layer.effect(BrokerRead, make(options).pipe(Effect.tap(verifyReadAccess)))
 
+export const scopedReadAdapterLayer = (options: ReadOptions): Layer.Layer<BrokerRead, BrokerReadError> =>
+  Layer.effect(BrokerRead, make(options)).pipe(Layer.provide(alpacaHttpLayer(options.proxyUrl)))
+
 export const live = (options: ReadOptions): Layer.Layer<BrokerRead, BrokerReadError> =>
   layer(options).pipe(Layer.provide(alpacaHttpLayer(options.proxyUrl)))

--- a/services/bayn/src/broker/observations.test.ts
+++ b/services/bayn/src/broker/observations.test.ts
@@ -165,6 +165,9 @@ describe('paper broker observations', () => {
     expect(() => orderObservation({ ...order, extendedHours: true }, evidence)).toThrow(
       'paper execution requires extended hours to be disabled',
     )
+    expect(() => orderObservation({ ...order, updatedAt: undefined }, evidence)).toThrow(
+      'paper order event requires Alpaca updated_at',
+    )
   })
 
   test('binds a fill to its order and defaults paper fees to zero', () => {

--- a/services/bayn/src/broker/observations.ts
+++ b/services/bayn/src/broker/observations.ts
@@ -271,6 +271,8 @@ export const orderObservation = (value: AlpacaOrder, evidence: ReadEvidence, int
     throw new Error('paper accounting requires a quantity order')
   }
   if (value.extendedHours) throw new Error('paper execution requires extended hours to be disabled')
+  if (value.updatedAt === undefined) throw new Error('paper order event requires Alpaca updated_at')
+  const updatedAt = value.updatedAt
   const order = {
     schemaVersion: 'bayn.paper-order.v1' as const,
     accountId: value.accountId,
@@ -287,16 +289,16 @@ export const orderObservation = (value: AlpacaOrder, evidence: ReadEvidence, int
     status: orderStatus(value.status, value.filledQuantityMicros, value.quantityMicros),
     observedAt: value.observedAt,
   }
-  const occurredAt = canonicalInstant(value.updatedAt)
+  const occurredAt = canonicalInstant(updatedAt)
   return decodeEvent({
     _tag: 'Order',
     broker: Broker.Alpaca,
     accountId: order.accountId,
-    sourceEventId: `order:${order.brokerOrderId}:${value.updatedAt}`,
+    sourceEventId: `order:${order.brokerOrderId}:${updatedAt}`,
     contentHash: canonicalHashV1({
       schemaVersion: 'bayn.paper-order-source.v1',
       order: withoutObservedAt(order),
-      brokerUpdatedAt: value.updatedAt,
+      brokerUpdatedAt: updatedAt,
     }),
     occurredAt,
     observedAt: order.observedAt,

--- a/services/bayn/src/cycle-runner.test.ts
+++ b/services/bayn/src/cycle-runner.test.ts
@@ -123,6 +123,7 @@ const brokerRead = (marketCalendar: BrokerReadShape['marketCalendar']): BrokerRe
   const unused = Effect.die(new Error('cycle runner must use only the broker calendar read'))
   return {
     account: unused,
+    accountConfiguration: unused,
     assetBySymbol: unusedAssetBySymbol,
     positions: unused,
     orders: () => unused,

--- a/services/bayn/src/db/cycle-store.integration.test.ts
+++ b/services/bayn/src/db/cycle-store.integration.test.ts
@@ -388,6 +388,7 @@ const runnerBrokerRead = (queries: Array<{ readonly start: string; readonly end:
   const unused = Effect.die(new Error('autonomous cycle runner must use only marketCalendar'))
   return {
     account: unused,
+    accountConfiguration: unused,
     assetBySymbol: unusedAssetBySymbol,
     positions: unused,
     orders: () => unused,

--- a/services/bayn/src/execution/coordinator.test.ts
+++ b/services/bayn/src/execution/coordinator.test.ts
@@ -379,6 +379,7 @@ const makeHarness = (options: HarnessOptions = {}) => {
 
   const read: BrokerReadShape = {
     account: Effect.die(new Error('unexpected account read')),
+    accountConfiguration: Effect.die(new Error('unexpected account configuration read')),
     assetBySymbol: unusedAssetBySymbol,
     positions: Effect.die(new Error('unexpected positions read')),
     orders: () => Effect.die(new Error('unexpected orders read')),

--- a/services/bayn/src/health.test.ts
+++ b/services/bayn/src/health.test.ts
@@ -43,6 +43,7 @@ const brokerRead = (account: BrokerReadShape['account']): BrokerReadShape => {
   const unused = Effect.die(new Error('continuous broker health must only read the account'))
   return {
     account,
+    accountConfiguration: unused,
     assetBySymbol: unusedAssetBySymbol,
     positions: unused,
     orders: () => unused,

--- a/services/bayn/src/http.test.ts
+++ b/services/bayn/src/http.test.ts
@@ -350,6 +350,7 @@ describe('Bayn HTTP probes', () => {
     const unused = Effect.die(new Error('status must not invoke broker reads'))
     const read: BrokerReadShape = {
       account: unused,
+      accountConfiguration: unused,
       assetBySymbol: unusedAssetBySymbol,
       positions: unused,
       orders: () => unused,

--- a/services/bayn/src/index.ts
+++ b/services/bayn/src/index.ts
@@ -5,7 +5,7 @@ import { Context, Effect, Layer, Logger, Redacted, Schema, Stdio, Stream } from 
 
 import { run } from './app'
 import { riskBalancedTrendBehaviorHash } from './behavior'
-import { BrokerRead, alpacaHttpLayer, live as AlpacaReadLive, make as makeAlpacaRead } from './broker/alpaca'
+import { BrokerRead, live as AlpacaReadLive } from './broker/alpaca'
 import { verifyBehaviorHash, verifyParameterHash } from './build'
 import { loadConfig, type LoadedRuntimeConfig } from './config'
 import { makeRuntimeProvenance, makeStrategyProtocolHash } from './contracts'
@@ -169,17 +169,19 @@ const runPaperProofDiscovery = (config: LoadedRuntimeConfig, strategy: Strategy)
     const postgresLayer = Layer.succeedContext(postgres)
     const observabilityContext = yield* Layer.build(CycleObservabilityLive.pipe(Layer.provide(postgresLayer)))
     const cycleStoreContext = yield* Layer.build(CycleStoreLive.pipe(Layer.provide(postgresLayer)))
-    const brokerRead = yield* makeAlpacaRead({
-      expectedAccountId: alpaca.accountId,
-      key: alpaca.key,
-      secret: alpaca.secret,
-      proxyUrl: alpaca.proxyUrl,
-      operationTimeoutMs: config.operationTimeoutMs,
-      retryAttempts: alpaca.retryAttempts,
-    }).pipe(
-      Effect.provide(alpacaHttpLayer(alpaca.proxyUrl)),
+    const brokerReadContext = yield* Layer.build(
+      AlpacaReadLive({
+        expectedAccountId: alpaca.accountId,
+        key: alpaca.key,
+        secret: alpaca.secret,
+        proxyUrl: alpaca.proxyUrl,
+        operationTimeoutMs: config.operationTimeoutMs,
+        retryAttempts: alpaca.retryAttempts,
+      }),
+    ).pipe(
       Effect.mapError((cause) => operationalError('config', 'alpaca', 'Alpaca paper account binding failed', cause)),
     )
+    const brokerRead = Context.get(brokerReadContext, BrokerRead)
     const receipt = yield* discoverPaperProofCandidates({
       sourceRevision: config.build.sourceRevision,
       image: {

--- a/services/bayn/src/index.ts
+++ b/services/bayn/src/index.ts
@@ -5,7 +5,7 @@ import { Context, Effect, Layer, Logger, Redacted, Schema, Stdio, Stream } from 
 
 import { run } from './app'
 import { riskBalancedTrendBehaviorHash } from './behavior'
-import { BrokerRead, live as AlpacaReadLive } from './broker/alpaca'
+import { BrokerRead, live as AlpacaReadLive, scopedReadAdapterLayer } from './broker/alpaca'
 import { verifyBehaviorHash, verifyParameterHash } from './build'
 import { loadConfig, type LoadedRuntimeConfig } from './config'
 import { makeRuntimeProvenance, makeStrategyProtocolHash } from './contracts'
@@ -170,7 +170,7 @@ const runPaperProofDiscovery = (config: LoadedRuntimeConfig, strategy: Strategy)
     const observabilityContext = yield* Layer.build(CycleObservabilityLive.pipe(Layer.provide(postgresLayer)))
     const cycleStoreContext = yield* Layer.build(CycleStoreLive.pipe(Layer.provide(postgresLayer)))
     const brokerReadContext = yield* Layer.build(
-      AlpacaReadLive({
+      scopedReadAdapterLayer({
         expectedAccountId: alpaca.accountId,
         key: alpaca.key,
         secret: alpaca.secret,

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -416,6 +416,7 @@ describe('OBSERVE runtime composition', () => {
     }
     const brokerRead: BrokerReadShape = {
       account: unused,
+      accountConfiguration: unused,
       assetBySymbol: unusedAssetBySymbol,
       positions: unused,
       orders: () => unused,

--- a/services/bayn/src/paper-proof-discovery.test.ts
+++ b/services/bayn/src/paper-proof-discovery.test.ts
@@ -11,6 +11,7 @@ import {
   AssetExchange,
   AssetStatus,
   BrokerRead,
+  type AccountConfigurationObservation,
   type AssetObservation,
   type BrokerReadShape,
   type ReadEvidence,
@@ -243,6 +244,22 @@ const account = (suffix = 'a', time = observedAt): BrokerReadShape['account'] =>
     evidence: evidence(suffix, time),
   })
 
+const accountConfiguration = (
+  suffix = 'configuration',
+  time = observedAt,
+  fractionalTrading = true,
+): ReadResult<AccountConfigurationObservation> => ({
+  value: {
+    schemaVersion: 'bayn.alpaca-account-configuration-observation.v1',
+    source: 'alpaca-v2-account-configurations',
+    requestHash: hash('a'),
+    fractionalTrading,
+    observedAt: time,
+    normalizedResponseHash: hash(fractionalTrading ? 'b' : 'c'),
+  },
+  evidence: evidence(suffix, time),
+})
+
 const asset = (symbol: string, suffix = symbol.toLowerCase(), time = observedAt): ReadResult<AssetObservation> => {
   const eligible = symbol === 'VNQ'
   return {
@@ -268,6 +285,7 @@ const asset = (symbol: string, suffix = symbol.toLowerCase(), time = observedAt)
 
 interface TestControl {
   assetSymbols: string[]
+  brokerAccountConfigurationReads: number
   brokerAccountReads: number
   cycleReads: number
   decisionReads: number
@@ -278,6 +296,7 @@ interface TestControl {
 
 const control = (): TestControl => ({
   assetSymbols: [],
+  brokerAccountConfigurationReads: 0,
   brokerAccountReads: 0,
   cycleReads: 0,
   decisionReads: 0,
@@ -350,12 +369,16 @@ const stores = (state: TestControl, input: Fixture) => {
   return { observability, cycleStore }
 }
 
-const broker = (state: TestControl, suffix = 'a', time = observedAt): BrokerReadShape => {
+const broker = (state: TestControl, suffix = 'a', time = observedAt, fractionalTrading = true): BrokerReadShape => {
   const unexpected = Effect.die(new Error('unexpected broker read'))
   return {
     account: Effect.sync(() => {
       state.brokerAccountReads += 1
     }).pipe(Effect.andThen(account(suffix, time))),
+    accountConfiguration: Effect.sync(() => {
+      state.brokerAccountConfigurationReads += 1
+      return accountConfiguration(`${suffix}-configuration`, time, fractionalTrading)
+    }),
     assetBySymbol: (symbol) =>
       Effect.sync(() => {
         state.assetSymbols.push(symbol)
@@ -401,8 +424,10 @@ describe('paper proof DISCOVER', () => {
     expect(state.cycleReads).toBe(1)
     expect(state.decisionReads).toBe(1)
     expect(state.brokerAccountReads).toBe(1)
+    expect(state.brokerAccountConfigurationReads).toBe(1)
     expect(state.assetSymbols).toEqual([...symbols])
     expect(receipt).toMatchObject({
+      schemaVersion: 'bayn.paper-proof-discovery.v2',
       command: 'PREPARE',
       phase: 'DISCOVER',
       authority: Authority.Observe,
@@ -413,6 +438,10 @@ describe('paper proof DISCOVER', () => {
         document: { reconciliationId, policyHash },
       },
       candidateFacts: {
+        schemaVersion: 'bayn.paper-proof-candidate-facts.v2',
+        accountConfiguration: {
+          fractionalTrading: true,
+        },
         consistencyDelayMs: { status: 'REQUIRED_UNBOUND' },
         candidates: [
           {
@@ -422,6 +451,7 @@ describe('paper proof DISCOVER', () => {
             observedPlannedQuantityMicros: '1250000',
             observedReferencePriceMicros: '100123500',
             assetEligibility: { eligible: true, reasons: [] },
+            fractionalTradingEligible: true,
           },
           {
             ordinal: 1,
@@ -439,8 +469,15 @@ describe('paper proof DISCOVER', () => {
                 PaperProofCandidateIneligibility.PtpNoException,
               ],
             },
+            fractionalTradingEligible: false,
           },
         ],
+      },
+      observationReceiptSchemaVersion: 'bayn.paper-proof-observation-receipt.v2',
+      observations: {
+        accountConfiguration: {
+          value: { fractionalTrading: true },
+        },
       },
     })
     const serialized = JSON.stringify(receipt)
@@ -475,6 +512,20 @@ describe('paper proof DISCOVER', () => {
           evidence: { ...result.evidence, rateLimit: undefined },
         })),
       ),
+      accountConfiguration: read.accountConfiguration.pipe(
+        Effect.map((result) => ({
+          ...result,
+          evidence: {
+            ...result.evidence,
+            rateLimit: {
+              limit: '200',
+              remaining: '199',
+              reset: undefined,
+              retryAfter: undefined,
+            },
+          },
+        })),
+      ),
       assetBySymbol: (symbol) =>
         read.assetBySymbol(symbol).pipe(
           Effect.map((result) => ({
@@ -504,12 +555,30 @@ describe('paper proof DISCOVER', () => {
           },
         })),
       ),
+      accountConfiguration: normalizedRead.accountConfiguration.pipe(
+        Effect.map((result) => ({
+          ...result,
+          evidence: {
+            requestId: result.evidence.requestId,
+            status: result.evidence.status,
+            contentHash: result.evidence.contentHash,
+            observedAt: result.evidence.observedAt,
+            rateLimit: { limit: '200', remaining: '199' },
+          },
+        })),
+      ),
     }
 
     const receipt = await Effect.runPromise(program(state, fixture(), adapterShaped))
     const normalizedReceipt = await Effect.runPromise(program(normalizedState, fixture(), alreadyNormalized))
 
     expect(receipt.observations.account.evidence).not.toHaveProperty('rateLimit')
+    expect(receipt.observations.accountConfiguration.evidence.rateLimit).toEqual({
+      limit: '200',
+      remaining: '199',
+    })
+    expect(receipt.observations.accountConfiguration.evidence.rateLimit).not.toHaveProperty('reset')
+    expect(receipt.observations.accountConfiguration.evidence.rateLimit).not.toHaveProperty('retryAfter')
     expect(receipt.observations.assets[0]?.evidence.rateLimit).toEqual({ limit: '200', remaining: '199' })
     expect(receipt.observations.assets[0]?.evidence.rateLimit).not.toHaveProperty('reset')
     expect(receipt.observations.assets[0]?.evidence.rateLimit).not.toHaveProperty('retryAfter')
@@ -534,6 +603,41 @@ describe('paper proof DISCOVER', () => {
     expect(error).toMatchObject({
       _tag: 'PaperProofDiscoveryError',
       failure: 'account-mismatch',
+    })
+    expect(state.brokerAccountReads).toBe(1)
+    expect(state.brokerAccountConfigurationReads).toBe(0)
+    expect(state.assetSymbols).toEqual([])
+  })
+
+  test('retains candidates but never marks them fractional-trading eligible when the account setting is disabled', async () => {
+    const state = control()
+    const receipt = await Effect.runPromise(program(state, fixture(), broker(state, 'a', observedAt, false)))
+
+    expect(receipt.candidateFacts.accountConfiguration.fractionalTrading).toBe(false)
+    expect(receipt.candidateFacts.candidates).toHaveLength(symbols.length)
+    expect(receipt.candidateFacts.candidates[0]).toMatchObject({
+      symbol: 'VNQ',
+      assetEligibility: { eligible: true, reasons: [] },
+      fractionalTradingEligible: false,
+    })
+    expect(receipt.candidateFacts.candidates.every((candidate) => !candidate.fractionalTradingEligible)).toBe(true)
+  })
+
+  test('fails typed before asset reads when account configuration evidence is not causal', async () => {
+    const state = control()
+    const read = broker(state)
+    const nonCausal: BrokerReadShape = {
+      ...read,
+      accountConfiguration: Effect.succeed(
+        accountConfiguration('configuration-before-account', '2099-07-24T11:59:59.999Z'),
+      ),
+    }
+
+    const error = await Effect.runPromise(Effect.flip(program(state, fixture(), nonCausal)))
+
+    expect(error).toMatchObject({
+      _tag: 'PaperProofDiscoveryError',
+      failure: 'broker',
     })
     expect(state.brokerAccountReads).toBe(1)
     expect(state.assetSymbols).toEqual([])
@@ -652,6 +756,7 @@ describe('paper proof DISCOVER', () => {
         failure: expectedFailure,
       })
       expect(state.brokerAccountReads, label).toBe(0)
+      expect(state.brokerAccountConfigurationReads, label).toBe(0)
       expect(state.assetSymbols, label).toEqual([])
     }
   })

--- a/services/bayn/src/paper-proof-discovery.test.ts
+++ b/services/bayn/src/paper-proof-discovery.test.ts
@@ -2,8 +2,9 @@ import { describe, expect, test } from 'bun:test'
 
 import { NodeServices } from '@effect/platform-node'
 import { PgClient } from '@effect/sql-pg'
-import { Cause, Effect, Exit, Layer, ManagedRuntime, Option, Redacted } from 'effect'
+import { Cause, Context, Effect, Exit, Layer, ManagedRuntime, Option, Redacted } from 'effect'
 import { TestClock } from 'effect/testing'
+import { HttpClient, HttpClientResponse } from 'effect/unstable/http'
 
 import {
   AccountStatus,
@@ -11,10 +12,12 @@ import {
   AssetExchange,
   AssetStatus,
   BrokerRead,
+  make as makeAlpacaRead,
   type AccountConfigurationObservation,
   type AssetObservation,
   type BrokerReadShape,
   type ReadEvidence,
+  type ReadOptions,
   type ReadResult,
 } from './broker/alpaca'
 import { makeStrategyProtocolHash, type RuntimeProvenance } from './contracts'
@@ -483,6 +486,84 @@ describe('paper proof DISCOVER', () => {
     const serialized = JSON.stringify(receipt)
     expect(serialized).not.toContain('account_number')
     expect(serialized).not.toContain('paper-secret')
+  })
+
+  test('constructs the read adapter without preflight and receipts only bounded DISCOVER GETs', async () => {
+    const state = control()
+    const requests: Array<{ method: string; path: string }> = []
+    const readOptions: ReadOptions = {
+      expectedAccountId: accountId,
+      key: Redacted.make('paper-key'),
+      secret: Redacted.make('paper-secret'),
+      proxyUrl: 'http://bayn-egress-proxy:3128',
+      operationTimeoutMs: 1_000,
+      retryAttempts: 0,
+    }
+    const client = HttpClient.make((request, url) => {
+      requests.push({ method: request.method, path: url.pathname })
+      let body: unknown
+      if (url.pathname === '/v2/account') {
+        body = {
+          id: accountId,
+          account_number: 'REDACTED',
+          status: 'ACTIVE',
+          currency: 'USD',
+          cash: '500',
+          equity: '1000',
+          buying_power: '500',
+          account_blocked: false,
+          trading_blocked: false,
+          trade_suspended_by_user: false,
+        }
+      } else if (url.pathname === '/v2/account/configurations') {
+        body = { fractional_trading: true }
+      } else {
+        const symbol = decodeURIComponent(url.pathname.slice('/v2/assets/'.length))
+        body = {
+          id: symbol === 'VNQ' ? '6ecbbd80-1456-4ae5-a623-97c007054f86' : 'f21fcb6b-92f2-46ba-9979-d5f4c73570d1',
+          class: 'us_equity',
+          exchange: 'ARCA',
+          symbol,
+          status: 'active',
+          tradable: true,
+          fractionable: true,
+          attributes: [],
+        }
+      }
+      return Effect.succeed(
+        HttpClientResponse.fromWeb(
+          request,
+          new Response(JSON.stringify(body), {
+            status: 200,
+            headers: { 'content-type': 'application/json', 'x-request-id': `request-${requests.length}` },
+          }),
+        ),
+      )
+    })
+
+    const receipt = await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const brokerContext = yield* Layer.build(
+            Layer.effect(BrokerRead, makeAlpacaRead(readOptions)).pipe(
+              Layer.provide(Layer.succeed(HttpClient.HttpClient, client)),
+            ),
+          )
+          expect(requests).toEqual([])
+          return yield* program(state, fixture(), Context.get(brokerContext, BrokerRead))
+        }),
+      ),
+    )
+
+    expect(receipt.candidateFacts.candidates).toHaveLength(symbols.length)
+    expect(requests.slice(0, 2)).toEqual([
+      { method: 'GET', path: '/v2/account' },
+      { method: 'GET', path: '/v2/account/configurations' },
+    ])
+    expect(requests.slice(2).sort((left, right) => left.path.localeCompare(right.path))).toEqual([
+      { method: 'GET', path: '/v2/assets/SPY' },
+      { method: 'GET', path: '/v2/assets/VNQ' },
+    ])
   })
 
   test('keeps immutable and semantic hashes stable while fresh GET evidence changes the receipt', async () => {

--- a/services/bayn/src/paper-proof-discovery.ts
+++ b/services/bayn/src/paper-proof-discovery.ts
@@ -8,6 +8,7 @@ import {
   AssetStatus,
   BrokerRead,
   type Account,
+  type AccountConfigurationObservation,
   type AssetObservation,
   type AssetObservationExchange,
   type ReadEvidence,
@@ -40,10 +41,10 @@ import {
 import type { ObserveShadowDecisionDocument } from './shadow-decision-contract'
 import { TargetPlanStatus } from './target-planner'
 
-const discoverySchemaVersion = 'bayn.paper-proof-discovery.v1' as const
+const discoverySchemaVersion = 'bayn.paper-proof-discovery.v2' as const
 const bindingSchemaVersion = 'bayn.paper-proof-discovery-binding.v1' as const
-const candidateFactsSchemaVersion = 'bayn.paper-proof-candidate-facts.v1' as const
-const observationReceiptSchemaVersion = 'bayn.paper-proof-observation-receipt.v1' as const
+const candidateFactsSchemaVersion = 'bayn.paper-proof-candidate-facts.v2' as const
+const observationReceiptSchemaVersion = 'bayn.paper-proof-observation-receipt.v2' as const
 const assetReadConcurrency = 3
 const AssetObservationExchangeSchema = Schema.Enum(AssetExchange).pipe(
   Schema.refine((exchange): exchange is AssetObservationExchange => exchange !== AssetExchange.Empty, {
@@ -77,6 +78,15 @@ const AccountObservationSchema = Schema.Struct({
   tradingBlocked: Schema.Boolean,
   tradeSuspendedByUser: Schema.Boolean,
   observedAt: UtcInstantSchema,
+})
+
+const AccountConfigurationObservationSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.alpaca-account-configuration-observation.v1'),
+  source: Schema.Literal('alpaca-v2-account-configurations'),
+  requestHash: Sha256Schema,
+  fractionalTrading: Schema.Boolean,
+  observedAt: UtcInstantSchema,
+  normalizedResponseHash: Sha256Schema,
 })
 
 const AssetObservationSchema = Schema.Struct({
@@ -164,6 +174,14 @@ const AccountFactsSchema = Schema.Struct({
   tradeSuspendedByUser: Schema.Boolean,
 })
 
+const AccountConfigurationFactsSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.alpaca-account-configuration-observation.v1'),
+  source: Schema.Literal('alpaca-v2-account-configurations'),
+  requestHash: Sha256Schema,
+  fractionalTrading: Schema.Boolean,
+  normalizedResponseHash: Sha256Schema,
+})
+
 const AssetFactsSchema = Schema.Struct({
   schemaVersion: Schema.Literal('bayn.alpaca-asset-observation.v1'),
   source: Schema.Literal('alpaca-v2-asset'),
@@ -201,12 +219,14 @@ const CandidateFactsSchema = Schema.Struct({
     eligible: Schema.Boolean,
     reasons: Schema.Array(CandidateIneligibilitySchema),
   }),
+  fractionalTradingEligible: Schema.Boolean,
 })
 
 const CandidateFactsMaterialSchema = Schema.Struct({
   schemaVersion: Schema.Literal(candidateFactsSchemaVersion),
   immutableBindingHash: Sha256Schema,
   account: AccountFactsSchema,
+  accountConfiguration: AccountConfigurationFactsSchema,
   candidates: Schema.Array(CandidateFactsSchema),
   consistencyDelayMs: Schema.Struct({
     status: Schema.Literal('REQUIRED_UNBOUND'),
@@ -217,6 +237,10 @@ export type PaperProofCandidateFactsMaterial = typeof CandidateFactsMaterialSche
 const BrokerObservationsSchema = Schema.Struct({
   account: Schema.Struct({
     value: AccountObservationSchema,
+    evidence: ReadEvidenceSchema,
+  }),
+  accountConfiguration: Schema.Struct({
+    value: AccountConfigurationObservationSchema,
     evidence: ReadEvidenceSchema,
   }),
   assets: Schema.Array(
@@ -531,6 +555,16 @@ const accountFacts = (account: Account): typeof AccountFactsSchema.Type => ({
   tradeSuspendedByUser: account.tradeSuspendedByUser,
 })
 
+const accountConfigurationFacts = (
+  configuration: AccountConfigurationObservation,
+): typeof AccountConfigurationFactsSchema.Type => ({
+  schemaVersion: configuration.schemaVersion,
+  source: configuration.source,
+  requestHash: configuration.requestHash,
+  fractionalTrading: configuration.fractionalTrading,
+  normalizedResponseHash: configuration.normalizedResponseHash,
+})
+
 const assetFacts = (asset: AssetObservation): typeof AssetFactsSchema.Type => ({
   schemaVersion: asset.schemaVersion,
   source: asset.source,
@@ -594,11 +628,18 @@ const makeReceipt = (
   snapshot: DiscoverySnapshot,
   binding: PaperProofDiscoveryBinding,
   account: ReadResult<Account>,
+  accountConfiguration: ReadResult<AccountConfigurationObservation>,
   assets: readonly ReadResult<AssetObservation>[],
   capturedAt: string,
 ): PaperProofDiscoveryReceipt => {
   requireInvariant(account.value.id === identity.accountId, 'account-mismatch', 'Alpaca account identity mismatch')
   validateReadEvidence(account, 'account')
+  validateReadEvidence(accountConfiguration, 'account configuration')
+  requireInvariant(
+    Date.parse(accountConfiguration.value.observedAt) >= Date.parse(account.value.observedAt),
+    'broker',
+    'Alpaca account configuration observation precedes the bound account observation',
+  )
   const candidates = snapshot.document.targetPlan.intentTargets.map((intent, ordinal) => {
     const target = snapshot.document.targetPlan.targets.find((candidate) => candidate.symbol === intent.symbol)
     const risk = snapshot.document.deltaRisk[ordinal]
@@ -612,6 +653,12 @@ const makeReceipt = (
       'broker',
       `asset observation does not match planned symbol ${intent.symbol}`,
     )
+    requireInvariant(
+      Date.parse(asset.value.observedAt) >= Date.parse(accountConfiguration.value.observedAt),
+      'broker',
+      `asset observation precedes the account configuration observation for ${intent.symbol}`,
+    )
+    const eligibility = assetEligibility(asset.value)
     return {
       ordinal,
       observedPlanIntentId: risk.evaluation.input.intentId,
@@ -629,7 +676,8 @@ const makeReceipt = (
       observedRiskDecisionId: risk.evaluation.decision.decisionId,
       observedRiskInputHash: risk.evaluation.input.inputHash,
       asset: assetFacts(asset.value),
-      assetEligibility: assetEligibility(asset.value),
+      assetEligibility: eligibility,
+      fractionalTradingEligible: accountConfiguration.value.fractionalTrading && eligibility.eligible,
     }
   })
   const immutableBindingHash = canonicalHashV1(binding)
@@ -637,6 +685,7 @@ const makeReceipt = (
     schemaVersion: candidateFactsSchemaVersion,
     immutableBindingHash,
     account: accountFacts(account.value),
+    accountConfiguration: accountConfigurationFacts(accountConfiguration.value),
     candidates,
     consistencyDelayMs: { status: 'REQUIRED_UNBOUND' as const },
   }
@@ -653,6 +702,10 @@ const makeReceipt = (
     candidateFactsHash,
     observations: {
       account: { value: account.value, evidence: normalizedReadEvidence(account.evidence) },
+      accountConfiguration: {
+        value: accountConfiguration.value,
+        evidence: normalizedReadEvidence(accountConfiguration.evidence),
+      },
       assets: assets.map((asset, ordinal) => ({
         ordinal,
         value: asset.value,
@@ -712,6 +765,25 @@ export const discoverPaperProofCandidates = (
           ? cause
           : fail('validate', 'account-mismatch', 'Alpaca account observation is invalid', cause),
     })
+    const accountConfiguration = yield* broker.accountConfiguration.pipe(
+      Effect.mapError((cause) =>
+        fail('broker-read', 'broker', 'Alpaca account configuration discovery read failed', cause),
+      ),
+    )
+    yield* Effect.try({
+      try: () => {
+        validateReadEvidence(accountConfiguration, 'account configuration')
+        requireInvariant(
+          Date.parse(accountConfiguration.value.observedAt) >= Date.parse(account.value.observedAt),
+          'broker',
+          'Alpaca account configuration observation precedes the bound account observation',
+        )
+      },
+      catch: (cause) =>
+        cause instanceof PaperProofDiscoveryError
+          ? cause
+          : fail('validate', 'broker', 'Alpaca account configuration observation is invalid', cause),
+    })
     const assets = yield* Effect.forEach(
       snapshot.document.targetPlan.intentTargets,
       (intent) => broker.assetBySymbol(intent.symbol),
@@ -725,7 +797,7 @@ export const discoverPaperProofCandidates = (
       'shadow document reached its exclusive submission cutoff during broker observation',
     )
     return yield* Effect.try({
-      try: () => makeReceipt(identity, snapshot, binding, account, assets, capturedAt),
+      try: () => makeReceipt(identity, snapshot, binding, account, accountConfiguration, assets, capturedAt),
       catch: (cause) =>
         cause instanceof PaperProofDiscoveryError
           ? cause

--- a/services/bayn/src/reconciler.test.ts
+++ b/services/bayn/src/reconciler.test.ts
@@ -207,6 +207,7 @@ const makeStore = (control: StoreControl, hasAccountBaseline = true): PaperStore
 
 const emptyRead = (): BrokerReadShape => ({
   account: Effect.succeed({ value: account, evidence: evidence('account') }),
+  accountConfiguration: Effect.die(new Error('unexpected account configuration read')),
   assetBySymbol: unusedAssetBySymbol,
   positions: Effect.succeed({ value: [], evidence: evidence('positions') }),
   orders: () => Effect.succeed({ value: [], evidence: evidence('orders') }),
@@ -299,6 +300,26 @@ describe('paper reconciliation loop', () => {
       _tag: 'ReconciliationError',
       operation: 'snapshot',
       message: 'paper account has fill history before Bayn established an opening cash baseline',
+    })
+    expect(control.writes).toBe(0)
+    expect(control.reconciliations).toEqual([])
+    expect(control.restrictions).toEqual(['reconciliation pass incomplete'])
+  })
+
+  test('fails closed before persistence when an order omits submitted_at', async () => {
+    const pendingOrder = { ...order(0), submittedAt: undefined }
+    const read: BrokerReadShape = {
+      ...emptyRead(),
+      orders: () => Effect.succeed({ value: [pendingOrder], evidence: evidence('orders') }),
+    }
+    const control: StoreControl = { writes: 0, reconciliations: [], restrictions: [] }
+
+    const failure = await Effect.runPromise(provide(read, makeStore(control)).pipe(Effect.flip))
+
+    expect(failure).toMatchObject({
+      _tag: 'ReconciliationError',
+      operation: 'pagination',
+      message: `Alpaca order ${pendingOrder.brokerOrderId} is missing submitted_at`,
     })
     expect(control.writes).toBe(0)
     expect(control.reconciliations).toEqual([])

--- a/services/bayn/src/reconciler.ts
+++ b/services/bayn/src/reconciler.ts
@@ -92,13 +92,16 @@ const readOrders = (
       if (page.value.length === 0) return { rows, observedAt }
 
       for (const order of page.value) {
-        if (
-          previousSubmittedAt !== undefined &&
-          sourceTimestamp(order.submittedAt) < sourceTimestamp(previousSubmittedAt)
-        ) {
+        const submittedAt = order.submittedAt
+        if (submittedAt === undefined) {
+          return yield* Effect.fail(
+            failure('pagination', `Alpaca order ${order.brokerOrderId} is missing submitted_at`),
+          )
+        }
+        if (previousSubmittedAt !== undefined && sourceTimestamp(submittedAt) < sourceTimestamp(previousSubmittedAt)) {
           return yield* Effect.fail(failure('pagination', 'Alpaca order history is not ascending'))
         }
-        if (cursor !== undefined && sourceTimestamp(order.submittedAt) <= sourceTimestamp(cursor)) {
+        if (cursor !== undefined && sourceTimestamp(submittedAt) <= sourceTimestamp(cursor)) {
           return yield* Effect.fail(failure('pagination', 'Alpaca order timestamp cursor did not advance'))
         }
         if (ids.has(order.brokerOrderId)) {
@@ -106,7 +109,7 @@ const readOrders = (
         }
         ids.add(order.brokerOrderId)
         rows.push({ value: order, evidence: page.evidence })
-        previousSubmittedAt = order.submittedAt
+        previousSubmittedAt = submittedAt
         if (rows.length > maximumRows) {
           return yield* Effect.fail(failure('pagination', `Alpaca order history exceeds ${maximumRows} rows`))
         }


### PR DESCRIPTION
## Summary

- Adds one typed GET-only `/v2/account/configurations` observation and binds `fractional_trading` into the non-authorizing PREPARE DISCOVER candidate facts.
- Accepts external Alpaca `client_order_id` values through 128 characters while leaving the deterministic Bayn-generated 46-character contract unchanged.
- Treats canonical `type` as required, makes deprecated `order_type` consistency-only, and accepts absent/null pending-order timestamps without inventing timestamp fallbacks.
- Keeps the DISCOVER Alpaca dispatcher scoped through `scopedReadAdapterLayer` without the ordinary startup preflight; the normal OBSERVE service retains unchanged `AlpacaReadLive` preflight behavior.

Official contracts: [Get Account Configurations](https://docs.alpaca.markets/us/reference/getaccountconfig-1), [Create an Order](https://docs.alpaca.markets/us/reference/postorder), [Get Order by Client Order ID](https://docs.alpaca.markets/us/reference/getorderbyclientorderid), and [Trading API order type deprecation](https://docs.alpaca.markets/us/docs/brokerapi-trading).

## Related Issues

PROOMPT-375 and PROOMPT-378 (source prerequisite only; does not close either issue).

## Testing

- `bun test services/bayn/src/broker/alpaca.test.ts services/bayn/src/broker/observations.test.ts services/bayn/src/reconciler.test.ts services/bayn/src/paper-proof-discovery.test.ts` (55 pass, 1 PostgreSQL-gated skip, 0 fail)
- `bun run --filter @proompteng/bayn test` (387 pass, 93 PostgreSQL-gated skips, 0 fail)
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:55433/bayn_test bun test services/bayn/src/paper-proof-discovery.test.ts services/bayn/src/db/evidence-store.integration.test.ts services/bayn/src/db/paper-store.integration.test.ts services/bayn/src/db/cycle-store.integration.test.ts` against isolated PostgreSQL 18 (pass)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- `git diff --check origin/main...HEAD`

## Breaking Changes

The ephemeral PREPARE DISCOVER receipt, candidate-facts, and observation-receipt schema versions advance from v1 to v2 to bind account configuration evidence. No durable records or compatibility migration exist for these operator-only receipts.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; this is a backend contract change.
- [x] Breaking Changes are documented above.
- [x] Documentation and follow-up scope are linked above.