### PR TITLE
fix(bayn): recover accepted orders to terminal

### DIFF
--- a/services/bayn/migrations/0015_acknowledged_submit_recovery.ts
+++ b/services/bayn/migrations/0015_acknowledged_submit_recovery.ts
@@ -1,0 +1,68 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient
+
+  yield* sql`
+    CREATE OR REPLACE FUNCTION enforce_mutation_event_transition()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+    DECLARE
+      previous mutation_events%ROWTYPE;
+    BEGIN
+      SELECT * INTO previous
+      FROM mutation_events
+      WHERE mutation_id = NEW.mutation_id
+      ORDER BY sequence DESC
+      LIMIT 1
+      FOR UPDATE;
+
+      IF NOT FOUND THEN
+        IF NEW.sequence <> 1 OR NEW.event_type NOT IN ('SUBMIT_STARTED', 'CANCEL_STARTED') THEN
+          RAISE EXCEPTION 'mutation must begin with its STARTED event' USING ERRCODE = '23514';
+        END IF;
+        RETURN NEW;
+      END IF;
+
+      IF NEW.sequence <> previous.sequence + 1
+        OR NEW.intent_id <> previous.intent_id
+        OR NEW.operation <> previous.operation
+        OR NEW.request_hash <> previous.request_hash
+        OR NEW.consistency_delay_ms <> previous.consistency_delay_ms
+        OR NEW.occurred_at < previous.occurred_at
+      THEN
+        RAISE EXCEPTION 'mutation identity and sequence must remain exact' USING ERRCODE = '23514';
+      END IF;
+
+      IF previous.broker_order_id IS NOT NULL
+        AND NEW.broker_order_id IS DISTINCT FROM previous.broker_order_id
+      THEN
+        RAISE EXCEPTION 'mutation broker order identity cannot change' USING ERRCODE = '23514';
+      END IF;
+
+      IF NOT (CASE previous.event_type
+        WHEN 'SUBMIT_STARTED' THEN NEW.event_type IN ('SUBMIT_ACCEPTED', 'SUBMIT_REJECTED', 'SUBMIT_UNKNOWN')
+        WHEN 'SUBMIT_ACCEPTED' THEN
+          previous.operation = 'SUBMIT'
+          AND NEW.event_type IN ('RECOVERY_FOUND', 'RECOVERY_NOT_FOUND', 'RECOVERY_UNKNOWN')
+        WHEN 'SUBMIT_UNKNOWN' THEN NEW.event_type IN ('RECOVERY_FOUND', 'RECOVERY_NOT_FOUND', 'RECOVERY_UNKNOWN')
+        WHEN 'CANCEL_STARTED' THEN NEW.event_type IN ('CANCEL_ACCEPTED', 'CANCEL_UNKNOWN')
+        WHEN 'CANCEL_ACCEPTED' THEN NEW.event_type IN ('RECOVERY_FOUND', 'RECOVERY_NOT_FOUND', 'RECOVERY_UNKNOWN')
+        WHEN 'CANCEL_UNKNOWN' THEN NEW.event_type IN ('RECOVERY_FOUND', 'RECOVERY_NOT_FOUND', 'RECOVERY_UNKNOWN')
+        WHEN 'RECOVERY_NOT_FOUND' THEN NEW.event_type IN ('RECOVERY_FOUND', 'RECOVERY_NOT_FOUND', 'RECOVERY_UNKNOWN')
+        WHEN 'RECOVERY_UNKNOWN' THEN NEW.event_type IN ('RECOVERY_FOUND', 'RECOVERY_NOT_FOUND', 'RECOVERY_UNKNOWN')
+        WHEN 'RECOVERY_FOUND' THEN
+          NEW.event_type IN ('RECOVERY_FOUND', 'RECOVERY_NOT_FOUND', 'RECOVERY_UNKNOWN')
+        ELSE false
+      END) THEN
+        RAISE EXCEPTION 'invalid mutation transition from % to %', previous.event_type, NEW.event_type
+          USING ERRCODE = '23514';
+      END IF;
+
+      RETURN NEW;
+    END
+    $function$
+  `
+})

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -1181,6 +1181,108 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     })
   })
 
+  test('does not let terminal submit recovery overtake a durable cancellation', async () => {
+    const execution = makeExecutionRuntime()
+    const intent = await Effect.runPromise(plan(intentPlan({ cycleId: '9'.repeat(64) })))
+    const decision = await Effect.runPromise(riskDecision(intent, RiskOutcome.Approved))
+    await execution.runPromise(
+      Effect.gen(function* () {
+        yield* Effect.flatMap(IntentStore, (store) => store.commit(intent, decision))
+      }),
+    )
+    await execution.dispose()
+    await activateAuditedPaperAuthority()
+
+    const mutation = makeMutationRuntime()
+    const submitHash = '7'.repeat(64)
+    const cancelHash = cancelRequestHash(orderId)
+    const base = Date.now() + 100
+    const observed = await mutation.runPromise(
+      Effect.gen(function* () {
+        const store = yield* MutationStore
+        yield* store.beginSubmit(intent.intentId, submitHash, 1_000, new Date(base).toISOString())
+        yield* store.submitAccepted(intent.intentId, submitHash, orderId, {
+          requestId: 'accepted-before-cancel',
+          status: 200,
+          contentHash: '6'.repeat(64),
+          observedAt: new Date(base + 1).toISOString(),
+        })
+        yield* store.beginCancel(intent.intentId, cancelHash, orderId, 1_000, new Date(base + 2).toISOString())
+        yield* store.cancelAccepted(intent.intentId, cancelHash, orderId, {
+          requestId: 'accepted-cancel',
+          status: 204,
+          contentHash: '5'.repeat(64),
+          observedAt: new Date(base + 3).toISOString(),
+        })
+        const submitRecovery = yield* Effect.exit(
+          store.recoveryFound(
+            intent.intentId,
+            MutationOperation.Submit,
+            submitHash,
+            orderId,
+            {
+              requestId: 'terminal-submit-during-cancel',
+              status: 200,
+              contentHash: '4'.repeat(64),
+              observedAt: new Date(base + 4).toISOString(),
+            },
+            TerminalOutcome.Filled,
+          ),
+        )
+        const afterSubmitRecovery = yield* sqlIntentState(intent.intentId)
+        const canceled = yield* store.recoveryFound(
+          intent.intentId,
+          MutationOperation.Cancel,
+          cancelHash,
+          orderId,
+          {
+            requestId: 'terminal-cancel-recovery',
+            status: 200,
+            contentHash: '3'.repeat(64),
+            observedAt: new Date(base + 5).toISOString(),
+          },
+          TerminalOutcome.Canceled,
+        )
+        const sql = yield* PgClient.PgClient
+        const [state] = yield* sql<{
+          events: number
+          state: string
+          state_version: number
+          terminal_outcome: string | null
+        }>`
+          SELECT
+            state,
+            state_version::integer,
+            terminal_outcome,
+            (SELECT count(*)::integer FROM mutation_events WHERE intent_id = ${intent.intentId}) AS events
+          FROM intents
+          WHERE intent_id = ${intent.intentId}
+        `
+        return { afterSubmitRecovery, canceled, state, submitRecovery }
+      }),
+    )
+    await mutation.dispose()
+
+    expect(Exit.isFailure(observed.submitRecovery)).toBe(true)
+    if (Exit.isFailure(observed.submitRecovery)) {
+      expect(Cause.pretty(observed.submitRecovery.cause)).toContain(
+        'terminal submit recovery cannot overtake a durable cancellation',
+      )
+    }
+    expect(observed.afterSubmitRecovery).toEqual({ state: 'ACKNOWLEDGED', state_version: 4 })
+    expect(observed.canceled).toMatchObject({
+      sequence: 3,
+      eventType: MutationEventType.RecoveryFound,
+      brokerOrderId: orderId,
+    })
+    expect(observed.state).toEqual({
+      state: 'TERMINAL',
+      state_version: 5,
+      terminal_outcome: 'CANCELED',
+      events: 5,
+    })
+  })
+
   test('retains acknowledged state for open recovery before a later exact terminal observation', async () => {
     const execution = makeExecutionRuntime()
     const intent = await Effect.runPromise(plan(intentPlan({ cycleId: '7'.repeat(64) })))

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -631,6 +631,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       { migration_id: 12, name: 'observe_shadow_decisions' },
       { migration_id: 13, name: 'autonomous_cycle_terminal_transitions' },
       { migration_id: 14, name: 'authority_generation_history' },
+      { migration_id: 15, name: 'acknowledged_submit_recovery' },
     ])
   })
 
@@ -1007,6 +1008,275 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     expect(observed.accepted.consistencyDelayMs).toBe(1_000)
     expect(observed.replay.eventId).toBe(observed.accepted.eventId)
     expect(observed.state).toEqual({ state: 'ACKNOWLEDGED', state_version: 4, events: 2 })
+  })
+
+  test('linearizes accepted submit terminal recovery and replays without another durable write', async () => {
+    const execution = makeExecutionRuntime()
+    const intent = await Effect.runPromise(plan(intentPlan({ cycleId: '6'.repeat(64) })))
+    const decision = await Effect.runPromise(riskDecision(intent, RiskOutcome.Approved))
+    await execution.runPromise(
+      Effect.gen(function* () {
+        yield* Effect.flatMap(IntentStore, (store) => store.commit(intent, decision))
+      }),
+    )
+    await execution.dispose()
+    await activateAuditedPaperAuthority()
+
+    const mutation = makeMutationRuntime()
+    const requestHash = '5'.repeat(64)
+    const base = Date.now() + 100
+    const acceptedEvidence = {
+      requestId: 'accepted-submit',
+      status: 200,
+      contentHash: '4'.repeat(64),
+      observedAt: new Date(base + 1).toISOString(),
+    }
+    const terminalEvidence = {
+      requestId: 'terminal-submit-recovery',
+      status: 200,
+      contentHash: '3'.repeat(64),
+      observedAt: new Date(base + 2).toISOString(),
+    }
+    const observed = await mutation.runPromise(
+      Effect.gen(function* () {
+        const store = yield* MutationStore
+        yield* store.beginSubmit(intent.intentId, requestHash, 1_000, new Date(base).toISOString())
+        yield* store.submitAccepted(intent.intentId, requestHash, orderId, acceptedEvidence)
+        const recovered = yield* Effect.all(
+          [
+            store.recoveryFound(
+              intent.intentId,
+              MutationOperation.Submit,
+              requestHash,
+              orderId,
+              terminalEvidence,
+              TerminalOutcome.Filled,
+            ),
+            store.recoveryFound(
+              intent.intentId,
+              MutationOperation.Submit,
+              requestHash,
+              orderId,
+              terminalEvidence,
+              TerminalOutcome.Filled,
+            ),
+          ],
+          { concurrency: 'unbounded' },
+        )
+        const sql = yield* PgClient.PgClient
+        const [state] = yield* sql<{
+          events: number
+          state: string
+          state_version: number
+          terminal_outcome: string | null
+        }>`
+          SELECT
+            state,
+            state_version::integer,
+            terminal_outcome,
+            (SELECT count(*)::integer FROM mutation_events WHERE intent_id = ${intent.intentId}) AS events
+          FROM intents
+          WHERE intent_id = ${intent.intentId}
+        `
+        return { recovered, state }
+      }),
+    )
+    await mutation.dispose()
+
+    expect(observed.recovered[0].eventId).toBe(observed.recovered[1].eventId)
+    expect(observed.recovered[0]).toMatchObject({
+      sequence: 3,
+      eventType: MutationEventType.RecoveryFound,
+      brokerOrderId: orderId,
+    })
+    expect(observed.state).toEqual({
+      state: 'TERMINAL',
+      state_version: 5,
+      terminal_outcome: 'FILLED',
+      events: 3,
+    })
+  })
+
+  test('keeps an accepted submit recoverable after a 404 with its exact broker order identity', async () => {
+    const execution = makeExecutionRuntime()
+    const intent = await Effect.runPromise(plan(intentPlan({ cycleId: '8'.repeat(64) })))
+    const decision = await Effect.runPromise(riskDecision(intent, RiskOutcome.Approved))
+    await execution.runPromise(
+      Effect.gen(function* () {
+        yield* Effect.flatMap(IntentStore, (store) => store.commit(intent, decision))
+      }),
+    )
+    await execution.dispose()
+    await activateAuditedPaperAuthority()
+
+    const mutation = makeMutationRuntime()
+    const requestHash = 'b'.repeat(64)
+    const base = Date.now() + 100
+    const observed = await mutation.runPromise(
+      Effect.gen(function* () {
+        const store = yield* MutationStore
+        yield* store.beginSubmit(intent.intentId, requestHash, 1_000, new Date(base).toISOString())
+        yield* store.submitAccepted(intent.intentId, requestHash, orderId, {
+          requestId: 'accepted-submit-before-404',
+          status: 200,
+          contentHash: 'a'.repeat(64),
+          observedAt: new Date(base + 1).toISOString(),
+        })
+        const notFound = yield* store.recoveryNotFound(intent.intentId, MutationOperation.Submit, requestHash, {
+          requestId: 'accepted-submit-not-found',
+          status: 404,
+          contentHash: '9'.repeat(64),
+          observedAt: new Date(base + 2).toISOString(),
+        })
+        const afterNotFound = yield* sqlIntentState(intent.intentId)
+        const terminal = yield* store.recoveryFound(
+          intent.intentId,
+          MutationOperation.Submit,
+          requestHash,
+          orderId,
+          {
+            requestId: 'accepted-submit-later-terminal',
+            status: 200,
+            contentHash: '8'.repeat(64),
+            observedAt: new Date(base + 3).toISOString(),
+          },
+          TerminalOutcome.Filled,
+        )
+        const sql = yield* PgClient.PgClient
+        const [state] = yield* sql<{
+          events: number
+          state: string
+          state_version: number
+          terminal_outcome: string | null
+        }>`
+          SELECT
+            state,
+            state_version::integer,
+            terminal_outcome,
+            (SELECT count(*)::integer FROM mutation_events WHERE intent_id = ${intent.intentId}) AS events
+          FROM intents
+          WHERE intent_id = ${intent.intentId}
+        `
+        return { afterNotFound, notFound, state, terminal }
+      }),
+    )
+    await mutation.dispose()
+
+    expect(observed.notFound).toMatchObject({
+      sequence: 3,
+      eventType: MutationEventType.RecoveryNotFound,
+      brokerOrderId: orderId,
+    })
+    expect(observed.afterNotFound).toEqual({ state: 'ACKNOWLEDGED', state_version: 4 })
+    expect(observed.terminal).toMatchObject({
+      sequence: 4,
+      eventType: MutationEventType.RecoveryFound,
+      brokerOrderId: orderId,
+    })
+    expect(observed.state).toEqual({
+      state: 'TERMINAL',
+      state_version: 5,
+      terminal_outcome: 'FILLED',
+      events: 4,
+    })
+  })
+
+  test('retains acknowledged state for open recovery before a later exact terminal observation', async () => {
+    const execution = makeExecutionRuntime()
+    const intent = await Effect.runPromise(plan(intentPlan({ cycleId: '7'.repeat(64) })))
+    const decision = await Effect.runPromise(riskDecision(intent, RiskOutcome.Approved))
+    await execution.runPromise(
+      Effect.gen(function* () {
+        yield* Effect.flatMap(IntentStore, (store) => store.commit(intent, decision))
+      }),
+    )
+    await execution.dispose()
+    await activateAuditedPaperAuthority()
+
+    const mutation = makeMutationRuntime()
+    const requestHash = '2'.repeat(64)
+    const otherOrderId = 'f93d3f58-0e70-4cd2-a9e1-2fcb89d76f74'
+    const base = Date.now() + 100
+    const observed = await mutation.runPromise(
+      Effect.gen(function* () {
+        const store = yield* MutationStore
+        yield* store.beginSubmit(intent.intentId, requestHash, 1_000, new Date(base).toISOString())
+        yield* store.submitAccepted(intent.intentId, requestHash, orderId, {
+          requestId: 'accepted-submit',
+          status: 200,
+          contentHash: '1'.repeat(64),
+          observedAt: new Date(base + 1).toISOString(),
+        })
+        const wrongIdentity = yield* Effect.exit(
+          store.recoveryFound(
+            intent.intentId,
+            MutationOperation.Submit,
+            requestHash,
+            otherOrderId,
+            {
+              requestId: 'wrong-order',
+              status: 200,
+              contentHash: '0'.repeat(64),
+              observedAt: new Date(base + 2).toISOString(),
+            },
+            TerminalOutcome.Filled,
+          ),
+        )
+        const afterWrongIdentity = yield* sqlIntentState(intent.intentId)
+        const open = yield* store.recoveryFound(intent.intentId, MutationOperation.Submit, requestHash, orderId, {
+          requestId: 'still-open',
+          status: 200,
+          contentHash: 'f'.repeat(64),
+          observedAt: new Date(base + 3).toISOString(),
+        })
+        const afterOpen = yield* sqlIntentState(intent.intentId)
+        const terminal = yield* store.recoveryFound(
+          intent.intentId,
+          MutationOperation.Submit,
+          requestHash,
+          orderId,
+          {
+            requestId: 'later-terminal',
+            status: 200,
+            contentHash: 'e'.repeat(64),
+            observedAt: new Date(base + 4).toISOString(),
+          },
+          TerminalOutcome.Expired,
+        )
+        const sql = yield* PgClient.PgClient
+        const [state] = yield* sql<{
+          events: number
+          state: string
+          state_version: number
+          terminal_outcome: string | null
+        }>`
+          SELECT
+            state,
+            state_version::integer,
+            terminal_outcome,
+            (SELECT count(*)::integer FROM mutation_events WHERE intent_id = ${intent.intentId}) AS events
+          FROM intents
+          WHERE intent_id = ${intent.intentId}
+        `
+        return { afterOpen, afterWrongIdentity, open, state, terminal, wrongIdentity }
+      }),
+    )
+    await mutation.dispose()
+
+    expect(Exit.isFailure(observed.wrongIdentity)).toBe(true)
+    if (Exit.isFailure(observed.wrongIdentity)) {
+      expect(Cause.pretty(observed.wrongIdentity.cause)).toContain('broker order identity cannot change')
+    }
+    expect(observed.afterWrongIdentity).toEqual({ state: 'ACKNOWLEDGED', state_version: 4 })
+    expect(observed.open).toMatchObject({ sequence: 3, eventType: MutationEventType.RecoveryFound })
+    expect(observed.afterOpen).toEqual({ state: 'ACKNOWLEDGED', state_version: 4 })
+    expect(observed.terminal).toMatchObject({ sequence: 4, eventType: MutationEventType.RecoveryFound })
+    expect(observed.state).toEqual({
+      state: 'TERMINAL',
+      state_version: 5,
+      terminal_outcome: 'EXPIRED',
+      events: 4,
+    })
   })
 
   test('serializes PAPER activation behind a writer-fenced mutation outcome and rechecks the baseline', async () => {

--- a/services/bayn/src/db/migrations.ts
+++ b/services/bayn/src/db/migrations.ts
@@ -14,6 +14,7 @@ import causalProtocol from '../../migrations/0011_causal_protocol'
 import observeShadowDecisions from '../../migrations/0012_observe_shadow_decisions'
 import autonomousCycleTerminalTransitions from '../../migrations/0013_autonomous_cycle_terminal_transitions'
 import authorityGenerationHistory from '../../migrations/0014_authority_generation_history'
+import acknowledgedSubmitRecovery from '../../migrations/0015_acknowledged_submit_recovery'
 
 export const migrationLoader = PgMigrator.fromRecord({
   '1_initial_schema': initialSchema,
@@ -30,4 +31,5 @@ export const migrationLoader = PgMigrator.fromRecord({
   '12_observe_shadow_decisions': observeShadowDecisions,
   '13_autonomous_cycle_terminal_transitions': autonomousCycleTerminalTransitions,
   '14_authority_generation_history': authorityGenerationHistory,
+  '15_acknowledged_submit_recovery': acknowledgedSubmitRecovery,
 })

--- a/services/bayn/src/execution/coordinator.test.ts
+++ b/services/bayn/src/execution/coordinator.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Cause, Effect, Exit, Option } from 'effect'
+import { Cause, Clock, Effect, Exit, Option } from 'effect'
 import { TestClock } from 'effect/testing'
 
 import {
@@ -131,6 +131,7 @@ interface HarnessOptions {
   readonly submitError?: BrokerMutationError
   readonly submittedOrder?: Order
   readonly lookupOrder?: Order
+  readonly lookupOrders?: readonly Order[]
 }
 
 const makeHarness = (options: HarnessOptions = {}) => {
@@ -382,29 +383,33 @@ const makeHarness = (options: HarnessOptions = {}) => {
     positions: Effect.die(new Error('unexpected positions read')),
     orders: () => Effect.die(new Error('unexpected orders read')),
     orderById: () => Effect.die(new Error('unexpected order-by-id read')),
-    orderByClientId: () => {
-      lookupCalls += 1
-      if (options.notFoundOnce && lookupCalls === 1) {
-        return Effect.fail(
-          new BrokerReadError({
-            operation: 'order-by-client-id',
-            kind: BrokerReadErrorKind.NotFound,
-            message: 'injected delayed visibility',
-            retryable: false,
-            status: 404,
-            requestId: 'lookup-not-found',
-            contentHash: canonicalHashV1({ code: 404, message: 'order not found' }),
-            observedAt: '1970-01-01T00:00:01.000Z',
-          }),
-        )
-      }
-      const value =
-        options.lookupOrder ??
-        (latest.get(MutationOperation.Cancel) === undefined
-          ? brokerOrder(OrderStatus.Accepted)
-          : brokerOrder(OrderStatus.Canceled))
-      return Effect.succeed({ value, evidence: evidence(200, '1970-01-01T00:00:02.000Z') })
-    },
+    orderByClientId: () =>
+      Effect.gen(function* () {
+        lookupCalls += 1
+        const observedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
+        if (options.notFoundOnce && lookupCalls === 1) {
+          return yield* Effect.fail(
+            new BrokerReadError({
+              operation: 'order-by-client-id',
+              kind: BrokerReadErrorKind.NotFound,
+              message: 'injected delayed visibility',
+              retryable: false,
+              status: 404,
+              requestId: 'lookup-not-found',
+              contentHash: canonicalHashV1({ code: 404, message: 'order not found' }),
+              observedAt,
+            }),
+          )
+        }
+        const selected =
+          options.lookupOrders?.[Math.min(lookupCalls - 1, options.lookupOrders.length - 1)] ??
+          options.lookupOrder ??
+          (latest.get(MutationOperation.Cancel) === undefined
+            ? brokerOrder(OrderStatus.Accepted)
+            : brokerOrder(OrderStatus.Canceled))
+        const value = { ...selected, observedAt }
+        return { value, evidence: evidence(200, observedAt) }
+      }),
     fillActivities: () => Effect.die(new Error('unexpected fill read')),
     marketCalendar: unusedMarketCalendar,
   }
@@ -442,6 +447,7 @@ const makeHarness = (options: HarnessOptions = {}) => {
     provide,
     provideIntentRead,
     calls: () => ({ submit: submitCalls, cancel: cancelCalls, lookup: lookupCalls }),
+    intent: () => stored.intent,
     state: () => stored.intent.state,
   }
 }
@@ -530,6 +536,125 @@ describe('paper execution coordinator', () => {
     expect(result.replay.eventId).toBe(result.accepted.eventId)
     expect(harness.calls()).toEqual({ submit: 1, cancel: 0, lookup: 0 })
     expect(harness.state()).toBe(IntentState.Acknowledged)
+  })
+
+  test('recovers an accepted order to terminal at the exact delay without another POST', async () => {
+    const harness = makeHarness({ lookupOrder: brokerOrder(OrderStatus.Filled) })
+    const result = await Effect.runPromise(
+      harness.provide(
+        Effect.gen(function* () {
+          const accepted = yield* submit(intentId, 1_000)
+          yield* TestClock.adjust(1_099)
+          const tooEarly = yield* Effect.flip(recover(intentId, MutationOperation.Submit))
+          yield* TestClock.adjust(1)
+          const terminal = yield* recover(intentId, MutationOperation.Submit)
+          const replay = yield* recover(intentId, MutationOperation.Submit)
+          return { accepted, replay, terminal, tooEarly }
+        }),
+      ),
+    )
+
+    expect(result.accepted.eventType).toBe(MutationEventType.SubmitAccepted)
+    expect(result.tooEarly).toMatchObject({
+      failure: ExecutionFailure.RecoveryTooEarly,
+      eligibleAt: '1970-01-01T00:00:01.100Z',
+    })
+    expect(result.terminal.eventType).toBe(MutationEventType.RecoveryFound)
+    expect(result.replay.eventId).toBe(result.terminal.eventId)
+    expect(harness.intent()).toMatchObject({
+      state: IntentState.Terminal,
+      terminalOutcome: TerminalOutcome.Filled,
+    })
+    expect(harness.calls()).toEqual({ submit: 1, cancel: 0, lookup: 1 })
+  })
+
+  test('retains an accepted open order and allows a later terminal recovery after the next delay', async () => {
+    const harness = makeHarness({
+      lookupOrders: [brokerOrder(OrderStatus.Accepted), brokerOrder(OrderStatus.Filled)],
+    })
+    const result = await Effect.runPromise(
+      harness.provide(
+        Effect.gen(function* () {
+          yield* submit(intentId, 1_000)
+          yield* TestClock.adjust(1_100)
+          const open = yield* recover(intentId, MutationOperation.Submit)
+          const tooEarly = yield* Effect.flip(recover(intentId, MutationOperation.Submit))
+          yield* TestClock.adjust(1_000)
+          const terminal = yield* recover(intentId, MutationOperation.Submit)
+          return { open, terminal, tooEarly }
+        }),
+      ),
+    )
+
+    expect(result.open.eventType).toBe(MutationEventType.RecoveryFound)
+    expect(result.tooEarly).toMatchObject({
+      failure: ExecutionFailure.RecoveryTooEarly,
+      eligibleAt: '1970-01-01T00:00:02.100Z',
+    })
+    expect(result.terminal.eventType).toBe(MutationEventType.RecoveryFound)
+    expect(harness.intent()).toMatchObject({
+      state: IntentState.Terminal,
+      terminalOutcome: TerminalOutcome.Filled,
+    })
+    expect(harness.calls()).toEqual({ submit: 1, cancel: 0, lookup: 2 })
+  })
+
+  test('retains an accepted broker order identity after a 404 and allows later terminal recovery', async () => {
+    const harness = makeHarness({
+      notFoundOnce: true,
+      lookupOrder: brokerOrder(OrderStatus.Filled),
+    })
+    const result = await Effect.runPromise(
+      harness.provide(
+        Effect.gen(function* () {
+          yield* submit(intentId, 1_000)
+          yield* TestClock.adjust(1_100)
+          const notFound = yield* recover(intentId, MutationOperation.Submit)
+          const afterNotFound = harness.intent()
+          yield* TestClock.adjust(1_000)
+          const terminal = yield* recover(intentId, MutationOperation.Submit)
+          return { afterNotFound, notFound, terminal }
+        }),
+      ),
+    )
+
+    expect(result.notFound).toMatchObject({
+      eventType: MutationEventType.RecoveryNotFound,
+      brokerOrderId: orderId,
+    })
+    expect(result.afterNotFound).toMatchObject({ state: IntentState.Acknowledged })
+    expect(result.terminal).toMatchObject({
+      eventType: MutationEventType.RecoveryFound,
+      brokerOrderId: orderId,
+    })
+    expect(harness.intent()).toMatchObject({
+      state: IntentState.Terminal,
+      terminalOutcome: TerminalOutcome.Filled,
+    })
+    expect(harness.calls()).toEqual({ submit: 1, cancel: 0, lookup: 2 })
+  })
+
+  test('keeps an accepted intent acknowledged when lookup returns a different broker order', async () => {
+    const otherOrderId = 'f93d3f58-0e70-4cd2-a9e1-2fcb89d76f74'
+    const harness = makeHarness({
+      lookupOrder: { ...brokerOrder(OrderStatus.Filled), brokerOrderId: otherOrderId },
+    })
+    const observed = await Effect.runPromise(
+      harness.provide(
+        Effect.gen(function* () {
+          yield* submit(intentId, 1_000)
+          yield* TestClock.adjust(1_100)
+          return yield* recover(intentId, MutationOperation.Submit)
+        }),
+      ),
+    )
+
+    expect(observed).toMatchObject({
+      eventType: MutationEventType.RecoveryUnknown,
+      brokerOrderId: orderId,
+    })
+    expect(harness.intent()).toMatchObject({ state: IntentState.Acknowledged })
+    expect(harness.calls()).toEqual({ submit: 1, cancel: 0, lookup: 1 })
   })
 
   test('rejects a submit replay whose committed consistency delay changes', async () => {

--- a/services/bayn/src/execution/coordinator.test.ts
+++ b/services/bayn/src/execution/coordinator.test.ts
@@ -634,6 +634,39 @@ describe('paper execution coordinator', () => {
     expect(harness.calls()).toEqual({ submit: 1, cancel: 0, lookup: 2 })
   })
 
+  test('recovers a durable cancellation before allowing submit history to resolve', async () => {
+    const harness = makeHarness()
+    const result = await Effect.runPromise(
+      harness.provide(
+        Effect.gen(function* () {
+          yield* submit(intentId, 1_000)
+          yield* cancel(intentId, 1_000)
+          yield* TestClock.adjust(1_100)
+          const blockedSubmit = yield* Effect.flip(recover(intentId, MutationOperation.Submit))
+          yield* TestClock.adjust(1_000)
+          const canceled = yield* recover(intentId, MutationOperation.Cancel)
+          const submitReplay = yield* recover(intentId, MutationOperation.Submit)
+          return { blockedSubmit, canceled, submitReplay }
+        }),
+      ),
+    )
+
+    expect(result.blockedSubmit).toMatchObject({
+      failure: ExecutionFailure.InvalidState,
+      message: 'submit recovery requires the durable cancellation to recover first',
+    })
+    expect(result.canceled).toMatchObject({
+      eventType: MutationEventType.RecoveryFound,
+      brokerOrderId: orderId,
+    })
+    expect(result.submitReplay.eventType).toBe(MutationEventType.SubmitAccepted)
+    expect(harness.intent()).toMatchObject({
+      state: IntentState.Terminal,
+      terminalOutcome: TerminalOutcome.Canceled,
+    })
+    expect(harness.calls()).toEqual({ submit: 1, cancel: 1, lookup: 1 })
+  })
+
   test('keeps an accepted intent acknowledged when lookup returns a different broker order', async () => {
     const otherOrderId = 'f93d3f58-0e70-4cd2-a9e1-2fcb89d76f74'
     const harness = makeHarness({

--- a/services/bayn/src/execution/coordinator.ts
+++ b/services/bayn/src/execution/coordinator.ts
@@ -380,6 +380,18 @@ export const recover = (intentId: string, operation: MutationOperation) =>
     ) {
       return latest
     }
+    if (
+      operation === MutationOperation.Submit &&
+      (yield* mutations.latest(intentId, MutationOperation.Cancel)) !== undefined
+    ) {
+      return yield* Effect.fail(
+        new ExecutionError({
+          operation,
+          failure: ExecutionFailure.InvalidState,
+          message: 'submit recovery requires the durable cancellation to recover first',
+        }),
+      )
+    }
     yield* validateRecovery(stored.intent, latest)
 
     const currentMillis = yield* Clock.currentTimeMillis

--- a/services/bayn/src/execution/coordinator.ts
+++ b/services/bayn/src/execution/coordinator.ts
@@ -127,10 +127,11 @@ const readErrorEvidence = (error: BrokerReadError): MutationEvidence | undefined
   return isCompleteEvidence(candidate) ? candidate : undefined
 }
 
-const isSubmitResolved = (event: MutationEvent): boolean =>
-  event.eventType === MutationEventType.SubmitAccepted ||
-  event.eventType === MutationEventType.SubmitRejected ||
-  event.eventType === MutationEventType.RecoveryFound
+const isSubmitResolved = (intent: Intent, event: MutationEvent): boolean =>
+  intent.state === IntentState.Terminal &&
+  (event.eventType === MutationEventType.SubmitAccepted ||
+    event.eventType === MutationEventType.SubmitRejected ||
+    event.eventType === MutationEventType.RecoveryFound)
 
 const requireActiveSubmitRiskDecision = (stored: StoredIntent, operationLabel = 'submission') =>
   Effect.gen(function* () {
@@ -201,7 +202,9 @@ const validateRecovery = (stored: Intent, event: MutationEvent) =>
           : cancelRequestHash(event.brokerOrderId)
     const validState =
       event.operation === MutationOperation.Submit
-        ? stored.state === IntentState.IoStarted || stored.state === IntentState.Unknown
+        ? stored.state === IntentState.IoStarted ||
+          stored.state === IntentState.Unknown ||
+          stored.state === IntentState.Acknowledged
         : stored.state === IntentState.Acknowledged ||
           (stored.state === IntentState.Unknown && event.brokerOrderId !== undefined)
     if (expectedHash === event.requestHash && validState) return
@@ -369,7 +372,7 @@ export const recover = (intentId: string, operation: MutationOperation) =>
         }),
       )
     }
-    if (operation === MutationOperation.Submit && isSubmitResolved(latest)) return latest
+    if (operation === MutationOperation.Submit && isSubmitResolved(stored.intent, latest)) return latest
     if (
       operation === MutationOperation.Cancel &&
       stored.intent.state === IntentState.Terminal &&
@@ -402,7 +405,9 @@ export const recover = (intentId: string, operation: MutationOperation) =>
             result.value.filledQuantityMicros === '0' &&
             outcome !== undefined &&
             outcome !== TerminalOutcome.Filled
-          if (!exactOrder(stored.intent, result.value) && !neutralizedMismatchedOrder) {
+          const exactBrokerOrderId =
+            interrupted.brokerOrderId === undefined || interrupted.brokerOrderId === result.value.brokerOrderId
+          if ((!exactBrokerOrderId || !exactOrder(stored.intent, result.value)) && !neutralizedMismatchedOrder) {
             return mutations.recoveryUnknown(
               intentId,
               operation,

--- a/services/bayn/src/execution/mutations.ts
+++ b/services/bayn/src/execution/mutations.ts
@@ -617,6 +617,20 @@ const makeStore = Effect.gen(function* () {
             ) {
               return previous
             }
+            if (
+              operation === MutationOperation.Submit &&
+              eventType === MutationEventType.RecoveryFound &&
+              fields.nextState === IntentState.Terminal &&
+              (yield* readLatest(input.intentId, MutationOperation.Cancel)) !== undefined
+            ) {
+              return yield* Effect.fail(
+                storeError(
+                  storeOperation,
+                  'conflict',
+                  'terminal submit recovery cannot overtake a durable cancellation',
+                ),
+              )
+            }
             yield* append(event)
 
             if (fields.recover === true) {

--- a/services/bayn/src/execution/mutations.ts
+++ b/services/bayn/src/execution/mutations.ts
@@ -626,12 +626,7 @@ const makeStore = Effect.gen(function* () {
                 WHERE intent_id = ${input.intentId} AND state = ${IntentState.Unknown}
                 RETURNING intent_id
               `
-              if (recovered.length !== 1) {
-                return yield* Effect.fail(
-                  storeError(storeOperation, 'conflict', 'unknown intent recovery lost its race'),
-                )
-              }
-              if (fields.nextState !== undefined) {
+              if (recovered.length === 1 && fields.nextState !== undefined) {
                 const transitioned = yield* sql<{ intent_id: string }>`
                   UPDATE intents
                   SET
@@ -650,6 +645,42 @@ const makeStore = Effect.gen(function* () {
                     storeError(storeOperation, 'conflict', 'recovered intent outcome lost its race'),
                   )
                 }
+              } else if (recovered.length === 0 && fields.nextState === IntentState.Terminal) {
+                const transitioned = yield* sql<{ intent_id: string }>`
+                  UPDATE intents
+                  SET
+                    state = ${IntentState.Terminal},
+                    terminal_outcome = ${fields.terminalOutcome ?? null},
+                    state_version = state_version + 1,
+                    updated_at = GREATEST(
+                      ${input.occurredAt}::timestamptz,
+                      updated_at + interval '1 microsecond'
+                    )
+                  WHERE intent_id = ${input.intentId} AND state = ${IntentState.Acknowledged}
+                  RETURNING intent_id
+                `
+                if (transitioned.length !== 1) {
+                  return yield* Effect.fail(
+                    storeError(storeOperation, 'conflict', 'acknowledged intent terminal recovery lost its race'),
+                  )
+                }
+              } else if (recovered.length === 0 && fields.nextState === IntentState.Acknowledged) {
+                const acknowledged = yield* sql<{ acknowledged: boolean }>`
+                  SELECT EXISTS (
+                    SELECT 1
+                    FROM intents
+                    WHERE intent_id = ${input.intentId} AND state = ${IntentState.Acknowledged}
+                  ) AS acknowledged
+                `
+                if (acknowledged[0]?.acknowledged !== true) {
+                  return yield* Effect.fail(
+                    storeError(storeOperation, 'conflict', 'submit recovery requires an unresolved durable intent'),
+                  )
+                }
+              } else if (recovered.length !== 1) {
+                return yield* Effect.fail(
+                  storeError(storeOperation, 'conflict', 'unknown intent recovery lost its race'),
+                )
               }
             } else if (fields.nextState !== undefined) {
               let fromState = fields.fromState ?? IntentState.IoStarted


### PR DESCRIPTION
## Summary

- keep exact nonterminal accepted submissions ACKNOWLEDGED and eligible for bounded GET-by-client-ID recovery after each durable consistency delay
- converge the same durable broker order to its mapped terminal outcome without another submit POST, while preserving replay, identity, and WriterFence behavior
- serialize submit recovery with any durable cancellation and add unit plus PostgreSQL regressions for terminal, still-open, 404, mismatch, replay, and concurrency paths

## Related Issues

PROOMPT-375 (Phase B prerequisite)

## Testing

- `bun test services/bayn/src/execution/coordinator.test.ts` (22 pass)
- `bun test services/bayn/src` (376 pass, 93 skip)
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:55434/bayn_test bun test --timeout 30000 services/bayn/src/db/evidence-store.integration.test.ts` (42 pass)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- `bunx oxfmt --check services/bayn/migrations/0015_acknowledged_submit_recovery.ts`

## Breaking Changes

Migration 15 replaces the mutation transition trigger so an accepted SUBMIT can append bounded recovery observations and converge terminal. It is applied by the existing Bayn migration loader; no operator action is required.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.