### PR TITLE
feat(bayn): close autonomous cycle alert gaps

### DIFF
--- a/argocd/applications/observability/bayn-cycle-operations-dashboard-configmap.yaml
+++ b/argocd/applications/observability/bayn-cycle-operations-dashboard-configmap.yaml
@@ -192,9 +192,255 @@ data:
               "expr": "bayn_capital_promotion_enabled{job=\"bayn\",namespace=\"bayn\",service=\"bayn\"}",
               "legendFormat": "capital promotion enabled",
               "refId": "D"
+            },
+            {
+              "expr": "bayn_authority_kill_active{job=\"bayn\",namespace=\"bayn\",service=\"bayn\"}",
+              "legendFormat": "kill active",
+              "refId": "E"
+            },
+            {
+              "expr": "bayn_authority_coherent{job=\"bayn\",namespace=\"bayn\",service=\"bayn\"}",
+              "legendFormat": "authority coherent",
+              "refId": "F"
+            },
+            {
+              "expr": "bayn_reconciliation_exact{job=\"bayn\",namespace=\"bayn\",service=\"bayn\"}",
+              "legendFormat": "reconciliation exact",
+              "refId": "G"
+            },
+            {
+              "expr": "bayn_reconciliation_covers_latest_mutation{job=\"bayn\",namespace=\"bayn\",service=\"bayn\"}",
+              "legendFormat": "reconciliation covers mutation",
+              "refId": "H"
             }
           ],
           "title": "Authority and mutation facts",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 0,
+            "y": 5
+          },
+          "id": 8,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "targets": [
+            {
+              "expr": "bayn_runtime_ready{job=\"bayn\",namespace=\"bayn\",service=\"bayn\"}",
+              "legendFormat": "runtime ready",
+              "refId": "A"
+            }
+          ],
+          "title": "Runtime readiness",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 6,
+            "y": 5
+          },
+          "id": 9,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "targets": [
+            {
+              "expr": "bayn_autonomous_cycle_loop_configured{job=\"bayn\",namespace=\"bayn\",service=\"bayn\"}",
+              "legendFormat": "loop configured",
+              "refId": "A"
+            },
+            {
+              "expr": "bayn_autonomous_cycle_loop_health_available{job=\"bayn\",namespace=\"bayn\",service=\"bayn\"}",
+              "legendFormat": "loop healthy",
+              "refId": "B"
+            }
+          ],
+          "title": "Autonomous loop",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 12,
+            "y": 5
+          },
+          "id": 10,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "targets": [
+            {
+              "expr": "bayn_broker_configured{job=\"bayn\",namespace=\"bayn\",service=\"bayn\"}",
+              "legendFormat": "broker configured",
+              "refId": "A"
+            },
+            {
+              "expr": "bayn_broker_read_available{job=\"bayn\",namespace=\"bayn\",service=\"bayn\"}",
+              "legendFormat": "GET available",
+              "refId": "B"
+            },
+            {
+              "expr": "bayn_broker_account_bound{job=\"bayn\",namespace=\"bayn\",service=\"bayn\"}",
+              "legendFormat": "account bound",
+              "refId": "C"
+            }
+          ],
+          "title": "Broker read binding",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "mappings": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 18,
+            "y": 5
+          },
+          "id": 11,
+          "options": {
+            "colorMode": "none",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "name",
+            "wideLayout": true
+          },
+          "targets": [
+            {
+              "expr": "bayn_build_info{job=\"bayn\",namespace=\"bayn\",service=\"bayn\"}",
+              "legendFormat": "{{source_revision}} {{image_digest}} {{verification}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Verified build",
           "type": "stat"
         },
         {
@@ -208,9 +454,9 @@ data:
           },
           "gridPos": {
             "h": 8,
-            "w": 8,
+            "w": 6,
             "x": 0,
-            "y": 5
+            "y": 10
           },
           "id": 4,
           "options": {
@@ -249,9 +495,9 @@ data:
           },
           "gridPos": {
             "h": 8,
-            "w": 8,
-            "x": 8,
-            "y": 5
+            "w": 6,
+            "x": 6,
+            "y": 10
           },
           "id": 5,
           "options": {
@@ -290,9 +536,9 @@ data:
           },
           "gridPos": {
             "h": 8,
-            "w": 8,
-            "x": 16,
-            "y": 5
+            "w": 6,
+            "x": 12,
+            "y": 10
           },
           "id": 6,
           "options": {
@@ -326,6 +572,47 @@ data:
             "uid": "prom"
           },
           "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 10
+          },
+          "id": 12,
+          "options": {
+            "alignValue": "left",
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.9,
+            "showValue": "auto",
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "bayn_cycle_terminal_reason{job=\"bayn\",namespace=\"bayn\",service=\"bayn\"} == 1",
+              "legendFormat": "{{reason}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Latest terminal reason",
+          "type": "state-timeline"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom"
+          },
+          "fieldConfig": {
             "defaults": {
               "unit": "s"
             },
@@ -335,7 +622,7 @@ data:
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 13
+            "y": 18
           },
           "id": 7,
           "options": {
@@ -354,9 +641,24 @@ data:
               "expr": "bayn_cycle_attempt_age_seconds{job=\"bayn\",namespace=\"bayn\",service=\"bayn\"}",
               "legendFormat": "attempt age",
               "refId": "A"
+            },
+            {
+              "expr": "bayn_oldest_unresolved_mutation_age_seconds{job=\"bayn\",namespace=\"bayn\",service=\"bayn\"}",
+              "legendFormat": "oldest unresolved mutation",
+              "refId": "B"
+            },
+            {
+              "expr": "bayn_reconciliation_age_seconds{job=\"bayn\",namespace=\"bayn\",service=\"bayn\"}",
+              "legendFormat": "reconciliation age",
+              "refId": "C"
+            },
+            {
+              "expr": "bayn_autonomous_cycle_loop_last_pass_age_seconds{job=\"bayn\",namespace=\"bayn\",service=\"bayn\"}",
+              "legendFormat": "loop pass age",
+              "refId": "D"
             }
           ],
-          "title": "Current cycle attempt age",
+          "title": "Cycle and recovery ages",
           "type": "timeseries"
         }
       ],

--- a/argocd/applications/observability/graf-mimir-rules.yaml
+++ b/argocd/applications/observability/graf-mimir-rules.yaml
@@ -2765,6 +2765,53 @@ data:
               summary: Bayn cycle projection is unavailable
               description: The bounded autonomous-cycle PostgreSQL projection has failed for two minutes.
               runbook_url: docs/runbooks/bayn-cycle-operations.md
+          - alert: BaynRuntimeDegraded
+            expr: |
+              (
+                bayn_runtime_ready{
+                  job="bayn",
+                  namespace="bayn",
+                  service="bayn"
+                } == 0
+              )
+              and on(job, namespace, service, instance)
+              (
+                bayn_cycle_observation_available{
+                  job="bayn",
+                  namespace="bayn",
+                  service="bayn"
+                } == 1
+              )
+              and on(job, namespace, service, instance)
+              (
+                bayn_cycle_condition{
+                  job="bayn",
+                  namespace="bayn",
+                  service="bayn",
+                  condition="stalled"
+                } == 0
+              )
+              and on(job, namespace, service, instance)
+              (
+                bayn_cycle_condition{
+                  job="bayn",
+                  namespace="bayn",
+                  service="bayn",
+                  condition="failed"
+                } == 0
+              )
+            for: 1m
+            labels:
+              severity: critical
+              team: trading
+              service: bayn
+              notify: email
+            annotations:
+              summary: Bayn runtime is degraded
+              description: |
+                Bayn readiness is blocked by a required dependency, autonomous-loop,
+                or broker-read/account-binding failure.
+              runbook_url: docs/runbooks/bayn-cycle-operations.md
           - alert: BaynCycleStalled
             expr: |
               bayn_cycle_condition{

--- a/docs/runbooks/bayn-cycle-operations.md
+++ b/docs/runbooks/bayn-cycle-operations.md
@@ -14,12 +14,19 @@ Bayn remains fail-closed. A healthy pod, a clear alert, or a terminal cycle does
 ## Alert actions
 
 - `BaynMetricsUnavailable`: verify the Bayn pod, the observability Alloy pod-discovery target, and the NetworkPolicy.
+  If Bayn failed before HTTP startup, inspect startup logs and compare configured provenance with the embedded
+  source revision, image digest, strategy behavior hash, and strategy parameter hash.
 - `BaynCycleObservationUnavailable`: inspect `cycle.error` in `GET /v1/status`, then restore the existing PostgreSQL
   projection path. Do not substitute cached or synthetic state.
+- `BaynRuntimeDegraded`: inspect `operational`, all `dependencies` (including `cycleRunner`), `autonomousCycleLoop`,
+  and the broker read/account-binding facts in `GET /v1/status`. Restore the failed dependency or the existing scoped
+  loop; do not bypass OBSERVE or create a replacement scheduler.
 - `BaynCycleStalled`: branch on `cycle.reason` in `GET /v1/status`. `submissionCutoffAt` is a deadline only while the
   cycle is `PENDING`; an `ACTIVE` cycle remains expected through `executionCloseAt`.
 - `BaynCycleFailed`: preserve `cycle.reason` and the terminal cycle identity. Resolve the underlying authority,
-  reconciliation, mutation, broker, or durable-cycle state through its existing writer contract; never clear the
-  alert by editing monitoring state.
+  reconciliation, mutation, or durable-cycle state through its existing writer contract. When
+  `cycle.reason=LAST_CYCLE_BLOCKED`, branch on the exact persisted `cycle.last.terminalReason`; never clear the alert
+  by editing monitoring state.
 
-An alert clears only when its source-of-truth state changes and the next bounded projection confirms recovery.
+An alert clears only when its source-of-truth state changes and the next bounded projection or health probe confirms
+recovery.

--- a/packages/scripts/src/shared/__tests__/bayn-cycle-observability-contract.test.ts
+++ b/packages/scripts/src/shared/__tests__/bayn-cycle-observability-contract.test.ts
@@ -27,11 +27,12 @@ const baynRules = (): readonly MimirRule[] => {
 }
 
 describe('Bayn cycle operations alert contract', () => {
-  test('alerts only on scrape health and canonical service conditions', () => {
+  test('alerts only on scrape health, bounded runtime readiness, and canonical cycle conditions', () => {
     const rules = baynRules()
     expect(rules.map(({ alert }) => alert)).toEqual([
       'BaynMetricsUnavailable',
       'BaynCycleObservationUnavailable',
+      'BaynRuntimeDegraded',
       'BaynCycleStalled',
       'BaynCycleFailed',
     ])
@@ -40,6 +41,12 @@ describe('Bayn cycle operations alert contract', () => {
     const expressions = Object.fromEntries(rules.map((rule) => [rule.alert, rule.expr]))
     expect(expressions.BaynMetricsUnavailable).toContain('up{')
     expect(expressions.BaynCycleObservationUnavailable).toContain('bayn_cycle_observation_available')
+    expect(expressions.BaynCycleObservationUnavailable).not.toContain('absent(')
+    expect(expressions.BaynRuntimeDegraded).toContain('bayn_runtime_ready')
+    expect(expressions.BaynRuntimeDegraded).toMatch(/bayn_cycle_observation_available\{[^}]+\} == 1/s)
+    expect(expressions.BaynRuntimeDegraded).toMatch(/condition="stalled"\s*\} == 0/)
+    expect(expressions.BaynRuntimeDegraded).toMatch(/condition="failed"\s*\} == 0/)
+    expect(expressions.BaynRuntimeDegraded.match(/and on\(job, namespace, service, instance\)/g)).toHaveLength(3)
     expect(expressions.BaynCycleStalled).toContain('condition="stalled"')
     expect(expressions.BaynCycleFailed).toContain('condition="failed"')
     expect(rules.map(({ expr }) => expr).join('\n')).not.toMatch(
@@ -85,7 +92,10 @@ describe('Bayn cycle operations alert contract', () => {
     ) as Record<string, any>
     const dashboard = JSON.parse(dashboardConfigMap.data['bayn-cycle-operations-dashboard.json']) as {
       readonly uid: string
-      readonly panels: readonly { readonly targets?: readonly { readonly expr?: string }[] }[]
+      readonly panels: readonly {
+        readonly title: string
+        readonly targets?: readonly { readonly expr?: string }[]
+      }[]
     }
     const dashboardExpressions = dashboard.panels.flatMap(({ targets = [] }) =>
       targets.flatMap(({ expr }) => (expr === undefined ? [] : [expr])),
@@ -94,10 +104,57 @@ describe('Bayn cycle operations alert contract', () => {
     const grafanaValues = readRepoFile('argocd/applications/observability/grafana-values.yaml')
 
     expect(dashboard.uid).toBe('bayn-cycle-operations')
+    expect(dashboard.panels.map(({ title }) => title)).toEqual(
+      expect.arrayContaining([
+        'Runtime readiness',
+        'Autonomous loop',
+        'Broker read binding',
+        'Verified build',
+        'Latest terminal reason',
+      ]),
+    )
+    expect(dashboardExpressions).toEqual(
+      expect.arrayContaining([
+        'bayn_runtime_ready{job="bayn",namespace="bayn",service="bayn"}',
+        'bayn_autonomous_cycle_loop_configured{job="bayn",namespace="bayn",service="bayn"}',
+        'bayn_autonomous_cycle_loop_health_available{job="bayn",namespace="bayn",service="bayn"}',
+        'bayn_broker_configured{job="bayn",namespace="bayn",service="bayn"}',
+        'bayn_broker_read_available{job="bayn",namespace="bayn",service="bayn"}',
+        'bayn_broker_account_bound{job="bayn",namespace="bayn",service="bayn"}',
+        'bayn_build_info{job="bayn",namespace="bayn",service="bayn"}',
+        'bayn_cycle_terminal_reason{job="bayn",namespace="bayn",service="bayn"} == 1',
+        'bayn_authority_kill_active{job="bayn",namespace="bayn",service="bayn"}',
+        'bayn_authority_coherent{job="bayn",namespace="bayn",service="bayn"}',
+        'bayn_reconciliation_exact{job="bayn",namespace="bayn",service="bayn"}',
+        'bayn_reconciliation_covers_latest_mutation{job="bayn",namespace="bayn",service="bayn"}',
+        'bayn_oldest_unresolved_mutation_age_seconds{job="bayn",namespace="bayn",service="bayn"}',
+        'bayn_reconciliation_age_seconds{job="bayn",namespace="bayn",service="bayn"}',
+        'bayn_autonomous_cycle_loop_last_pass_age_seconds{job="bayn",namespace="bayn",service="bayn"}',
+      ]),
+    )
     expect(kustomization).toContain('bayn-cycle-operations-dashboard-configmap.yaml')
     expect(grafanaValues).toContain('bayn-cycle-operations-dashboard: bayn-cycle-operations-dashboard')
     expect([...rules.map(({ expr }) => expr), ...dashboardExpressions].join('\n')).not.toMatch(
       /cycle_id|account_id|decision_hash|mutation_id|client_order_id/,
     )
+  })
+
+  test('routes every bounded alert through one source-of-truth recovery contract', () => {
+    const runbook = readRepoFile('docs/runbooks/bayn-cycle-operations.md')
+    const normalizedRunbook = runbook.replaceAll(/\s+/g, ' ')
+
+    for (const { alert } of baynRules()) {
+      expect(runbook).toContain(`\`${alert}\``)
+    }
+    expect(normalizedRunbook).toContain(
+      'An alert clears only when its source-of-truth state changes and the next bounded projection or health probe confirms recovery.',
+    )
+    expect(normalizedRunbook).toContain(
+      'When `cycle.reason=LAST_CYCLE_BLOCKED`, branch on the exact persisted `cycle.last.terminalReason`',
+    )
+    expect(normalizedRunbook).toContain(
+      'compare configured provenance with the embedded source revision, image digest, strategy behavior hash, and strategy parameter hash',
+    )
+    expect(runbook).not.toMatch(/clear.*(Prometheus|Mimir|Grafana)|restart.*autonomous cycle loop/i)
   })
 })

--- a/services/bayn/src/cycle-observability.test.ts
+++ b/services/bayn/src/cycle-observability.test.ts
@@ -160,6 +160,42 @@ describe('autonomous cycle operations classification', () => {
     })
   })
 
+  test('raises missed-submission at the exact cutoff and clears only on a later terminal cycle', () => {
+    const pending = snapshot(CycleState.Pending, {
+      snapshotId: '2'.repeat(64),
+      submissionOpenAt: '2026-07-20T11:30:00.000Z',
+      submissionCutoffAt: now,
+    })
+    const missed = deriveCycleOperationsStatus(
+      projection({ current: pending, unfinishedCycleCount: 1 }),
+      Date.parse(now),
+      Authority.Observe,
+      thresholds,
+    )
+    const recovered = deriveCycleOperationsStatus(
+      projection({
+        last: snapshot(CycleState.Completed, {
+          updatedAt: '2026-07-20T12:00:01.000Z',
+          terminalAt: '2026-07-20T12:00:01.000Z',
+        }),
+      }),
+      Date.parse('2026-07-20T12:00:01.000Z'),
+      Authority.Observe,
+      thresholds,
+    )
+
+    expect(missed).toMatchObject({
+      condition: CycleOperationsCondition.Stalled,
+      reason: CycleOperationsReason.MissedSubmissionCutoff,
+      alerts: { cycleStalled: true },
+    })
+    expect(recovered).toMatchObject({
+      condition: CycleOperationsCondition.Waiting,
+      reason: CycleOperationsReason.LastCycleCompleted,
+      alerts: { cycleStalled: false, cycleFailed: false },
+    })
+  })
+
   test('keeps a blocked terminal result failed through a later attempt and clears on confirmed terminal success', () => {
     const blocked = snapshot(CycleState.Blocked)
     const recovering = deriveCycleOperationsStatus(
@@ -278,6 +314,96 @@ describe('autonomous cycle operations classification', () => {
       oldestUnresolvedMutationAgeMs: 300_000,
       alerts: { unknownMutationStale: true },
     })
+
+    const cleared = deriveCycleOperationsStatus(projection(), Date.parse(now), Authority.Observe, thresholds)
+    expect(cleared).toMatchObject({
+      condition: CycleOperationsCondition.Waiting,
+      reason: CycleOperationsReason.NoCycleRecorded,
+      alerts: { cycleFailed: false, unknownMutationStale: false },
+    })
+  })
+
+  test('injects and clears kill, discrepancy, stale-data, and provenance failures through canonical state', () => {
+    const observeAuthority = {
+      generationHash: '4'.repeat(64),
+      maximum: Authority.Observe,
+      effective: Authority.Observe,
+      kill: KillState.Clear,
+      reason: null,
+      updatedAt: now,
+    } as const
+    const paperAuthority = {
+      ...observeAuthority,
+      maximum: Authority.Paper,
+      effective: Authority.Paper,
+    } as const
+    const exactReconciliation = {
+      accountId: 'paper-account-1',
+      reconciliationId: '5'.repeat(64),
+      status: ReconciliationStatus.Exact,
+      discrepancyCount: 0,
+      reconciledAt: now,
+      coversLatestMutation: true,
+    } as const
+    const observeClear = projection({ authority: observeAuthority })
+    const paperClear = projection({ authority: paperAuthority, reconciliation: exactReconciliation })
+    const scenarios = [
+      {
+        name: 'kill',
+        maximum: Authority.Observe,
+        injected: projection({ authority: { ...observeAuthority, kill: KillState.Active, reason: 'operator kill' } }),
+        cleared: observeClear,
+        reason: CycleOperationsReason.KillActive,
+        terminalReason: null,
+      },
+      {
+        name: 'reconciliation discrepancy',
+        maximum: Authority.Paper,
+        injected: projection({
+          authority: paperAuthority,
+          reconciliation: {
+            ...exactReconciliation,
+            status: ReconciliationStatus.Discrepancy,
+            discrepancyCount: 1,
+          },
+        }),
+        cleared: paperClear,
+        reason: CycleOperationsReason.ReconciliationDiscrepancy,
+        terminalReason: null,
+      },
+      {
+        name: 'stale data',
+        maximum: Authority.Observe,
+        injected: projection({
+          last: snapshot(CycleState.Blocked, { terminalReason: CycleTerminalReason.DataStale }),
+        }),
+        cleared: projection({ last: snapshot(CycleState.Completed) }),
+        reason: CycleOperationsReason.LastCycleBlocked,
+        terminalReason: CycleTerminalReason.DataStale,
+      },
+      {
+        name: 'provenance mismatch',
+        maximum: Authority.Observe,
+        injected: projection({
+          last: snapshot(CycleState.Blocked, { terminalReason: CycleTerminalReason.ProvenanceMismatch }),
+        }),
+        cleared: projection({ last: snapshot(CycleState.Completed) }),
+        reason: CycleOperationsReason.LastCycleBlocked,
+        terminalReason: CycleTerminalReason.ProvenanceMismatch,
+      },
+    ] as const
+
+    for (const scenario of scenarios) {
+      const injected = deriveCycleOperationsStatus(scenario.injected, Date.parse(now), scenario.maximum, thresholds)
+      const cleared = deriveCycleOperationsStatus(scenario.cleared, Date.parse(now), scenario.maximum, thresholds)
+
+      expect(injected.condition, scenario.name).toBe(CycleOperationsCondition.Failed)
+      expect(injected.reason, scenario.name).toBe(scenario.reason)
+      expect(injected.alerts.cycleFailed, scenario.name).toBe(true)
+      expect(injected.last?.terminalReason ?? null, scenario.name).toBe(scenario.terminalReason)
+      expect(cleared.condition, scenario.name).toBe(CycleOperationsCondition.Waiting)
+      expect(cleared.alerts.cycleFailed, scenario.name).toBe(false)
+    }
   })
 
   test('requires PAPER reconciliation to cover the latest selected-account mutation', () => {
@@ -377,6 +503,28 @@ describe('autonomous cycle operations classification', () => {
       reason: CycleOperationsReason.ReconciliationStale,
       reconciliationAgeMs: 120_000,
       alerts: { reconciliationBlocked: true },
+    })
+
+    const cleared = deriveCycleOperationsStatus(
+      projection({
+        authority,
+        reconciliation: {
+          accountId: 'paper-account-1',
+          reconciliationId: '8'.repeat(64),
+          status: ReconciliationStatus.Exact,
+          discrepancyCount: 0,
+          reconciledAt: now,
+          coversLatestMutation: true,
+        },
+      }),
+      Date.parse(now),
+      Authority.Paper,
+      thresholds,
+    )
+    expect(cleared).toMatchObject({
+      condition: CycleOperationsCondition.Waiting,
+      reason: CycleOperationsReason.NoCycleRecorded,
+      alerts: { cycleFailed: false, reconciliationBlocked: false },
     })
   })
 })

--- a/services/bayn/src/health.test.ts
+++ b/services/bayn/src/health.test.ts
@@ -90,8 +90,15 @@ const provideHealthyDependencies = (
 describe('Bayn continuous health', () => {
   test('requires the configured broker account GET while keeping execution disabled under OBSERVE', async () => {
     let observedAccountId = brokerAccountId
+    let brokerAvailable = true
     const broker: BrokerProbe = {
-      read: brokerRead(Effect.sync(() => accountResult(observedAccountId))),
+      read: brokerRead(
+        Effect.suspend(() =>
+          brokerAvailable
+            ? Effect.succeed(accountResult(observedAccountId))
+            : Effect.die(new Error('injected Alpaca GET failure')),
+        ),
+      ),
       expectedAccountId: brokerAccountId,
       executionEligible: false,
       executionDisabledReason: 'MAXIMUM_AUTHORITY_OBSERVE',
@@ -156,6 +163,45 @@ describe('Bayn continuous health', () => {
           error: `Alpaca account probe resolved ${observedAccountId}, expected ${brokerAccountId}`,
         },
         error: expect.stringContaining('broker: Alpaca account probe resolved'),
+      })
+
+      observedAccountId = brokerAccountId
+      await Effect.runPromise(dependencies(probe(config, state, broker, cycleFiber)))
+      expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
+        status: 'READY',
+        broker: {
+          accountId: brokerAccountId,
+          accountBound: true,
+          readAvailable: true,
+          error: null,
+        },
+        error: null,
+      })
+
+      brokerAvailable = false
+      await Effect.runPromise(dependencies(probe(config, state, broker, cycleFiber)))
+      expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
+        status: 'DEGRADED',
+        broker: {
+          accountId: null,
+          accountBound: false,
+          readAvailable: false,
+          error: 'injected Alpaca GET failure',
+        },
+        error: expect.stringContaining('broker: injected Alpaca GET failure'),
+      })
+
+      brokerAvailable = true
+      await Effect.runPromise(dependencies(probe(config, state, broker, cycleFiber)))
+      expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
+        status: 'READY',
+        broker: {
+          accountId: brokerAccountId,
+          accountBound: true,
+          readAvailable: true,
+          error: null,
+        },
+        error: null,
       })
     } finally {
       await Effect.runPromise(Fiber.interrupt(cycleFiber))
@@ -436,6 +482,27 @@ describe('Bayn continuous health', () => {
               },
             },
           },
+        })
+
+        yield* Ref.update(
+          state,
+          (current): RuntimeState => ({
+            ...current,
+            autonomousCycleLoop: {
+              ...current.autonomousCycleLoop,
+              lastPass: {
+                result: 'SUCCESS',
+                observedAt: '2026-07-20T00:06:00.000Z',
+                outcome: 'NO_PUBLICATION',
+              },
+            },
+          }),
+        )
+        yield* provideHealthyDependencies(initial, probe(config, state, undefined, cycleFiber))
+        expect(yield* Ref.get(state)).toMatchObject({
+          status: 'READY',
+          health: { dependencies: { cycleRunner: { status: 'AVAILABLE', error: null } } },
+          error: null,
         })
       }),
     ).pipe(Effect.provide(TestClock.layer()))

--- a/services/bayn/src/http.test.ts
+++ b/services/bayn/src/http.test.ts
@@ -15,10 +15,18 @@ import {
 import type { BrokerReadShape } from './broker/alpaca'
 import { unusedAssetBySymbol, unusedMarketCalendar } from './broker/alpaca-test-support'
 import { DatabaseError, type EvidenceStoreService } from './db/evidence-store'
+import { CycleOperationsCondition, CycleOperationsReason } from './cycle-observability'
+import { CycleState, CycleTerminalReason } from './cycle'
 import type { BrokerProbe } from './health'
 import { makeHttpLayer, renderPrometheusMetrics } from './http'
 import { Authority } from './paper'
 import { initialState, type RuntimeState } from './runtime-state'
+
+const metricValue = (metrics: string, name: string): number => {
+  const line = metrics.split('\n').find((candidate) => candidate.startsWith(`${name} `))
+  if (line === undefined) throw new Error(`metric ${name} is missing`)
+  return Number(line.slice(name.length + 1))
+}
 
 describe('Bayn HTTP probes', () => {
   test('serves every route from the current runtime state and closes its socket', async () => {
@@ -108,6 +116,7 @@ describe('Bayn HTTP probes', () => {
           const metrics = yield* Effect.promise(() => metricsResponse.text())
           expect(metricsResponse.status).toBe(200)
           expect(metricsResponse.headers.get('content-type')).toContain('text/plain')
+          expect(metrics).toContain('bayn_runtime_ready 1')
           expect(metrics).toContain('bayn_cycle_condition{condition="waiting"} 1')
           expect(metrics).toContain('bayn_autonomous_cycle_loop_configured 0')
           expect(metrics).toContain('bayn_autonomous_cycle_loop_health_available 0')
@@ -258,6 +267,7 @@ describe('Bayn HTTP probes', () => {
           )
           expect(metrics).toContain('bayn_autonomous_cycle_loop_configured 1')
           expect(metrics).toContain('bayn_autonomous_cycle_loop_health_available 0')
+          expect(metrics).toContain('bayn_runtime_ready 0')
           expect(metrics).toContain('bayn_autonomous_cycle_loop_last_pass{result="failure"} 1')
           expect(metrics).toContain(
             `bayn_autonomous_cycle_loop_last_pass_timestamp_seconds ${Date.parse(failedAt) / 1_000}`,
@@ -265,6 +275,139 @@ describe('Bayn HTTP probes', () => {
         }),
       ),
     )
+  })
+
+  test('injects and clears bounded runtime readiness for loop and broker failures', () => {
+    const observedAt = '2026-07-20T00:00:00.000Z'
+    const broker = {
+      configured: true as const,
+      expectedAccountId: 'paper-account-1',
+      accountId: 'paper-account-1',
+      accountBound: true,
+      readAvailable: true,
+      checkedAt: observedAt,
+      error: null,
+      executionEligible: false,
+      executionDisabledReason: 'MAXIMUM_AUTHORITY_OBSERVE',
+    }
+    const healthy: RuntimeState = {
+      ...readyState(),
+      autonomousCycleLoop: {
+        configured: true,
+        startedAt: observedAt,
+        lastPass: { result: 'SUCCESS', observedAt, outcome: 'NO_PUBLICATION' },
+      },
+      broker,
+    }
+    const loopFailure: RuntimeState = {
+      ...healthy,
+      status: 'DEGRADED',
+      health: {
+        ...healthy.health,
+        dependencies: {
+          ...healthy.health.dependencies,
+          cycleRunner: {
+            status: 'UNAVAILABLE',
+            checkedAt: observedAt,
+            error: 'market-calendar/calendar-read: authoritative calendar unavailable',
+          },
+        },
+      },
+      autonomousCycleLoop: {
+        ...healthy.autonomousCycleLoop,
+        lastPass: {
+          result: 'FAILURE',
+          observedAt,
+          operation: 'market-calendar',
+          failure: 'calendar-read',
+          message: 'authoritative calendar unavailable',
+        },
+      },
+    }
+    const brokerReadFailure: RuntimeState = {
+      ...healthy,
+      status: 'DEGRADED',
+      broker: {
+        ...broker,
+        accountId: null,
+        accountBound: false,
+        readAvailable: false,
+        error: 'Alpaca account unavailable',
+      },
+    }
+    const brokerBindingFailure: RuntimeState = {
+      ...healthy,
+      status: 'DEGRADED',
+      broker: {
+        ...broker,
+        accountId: 'other-paper-account',
+        accountBound: false,
+        error: 'Alpaca account binding mismatch',
+      },
+    }
+    const render = (state: RuntimeState) => renderPrometheusMetrics(state, config, provenance, 'embedded')
+
+    const healthyBefore = render(healthy)
+    const loopInjected = render(loopFailure)
+    const loopCleared = render(healthy)
+    const brokerReadInjected = render(brokerReadFailure)
+    const brokerReadCleared = render(healthy)
+    const brokerBindingInjected = render(brokerBindingFailure)
+    const brokerBindingCleared = render(healthy)
+
+    expect(metricValue(healthyBefore, 'bayn_runtime_ready')).toBe(1)
+    expect(metricValue(loopInjected, 'bayn_runtime_ready')).toBe(0)
+    expect(metricValue(loopInjected, 'bayn_autonomous_cycle_loop_health_available')).toBe(0)
+    expect(metricValue(loopCleared, 'bayn_runtime_ready')).toBe(1)
+    expect(metricValue(loopCleared, 'bayn_autonomous_cycle_loop_health_available')).toBe(1)
+
+    expect(metricValue(brokerReadInjected, 'bayn_runtime_ready')).toBe(0)
+    expect(metricValue(brokerReadInjected, 'bayn_broker_read_available')).toBe(0)
+    expect(metricValue(brokerReadCleared, 'bayn_runtime_ready')).toBe(1)
+    expect(metricValue(brokerReadCleared, 'bayn_broker_read_available')).toBe(1)
+
+    expect(metricValue(brokerBindingInjected, 'bayn_runtime_ready')).toBe(0)
+    expect(metricValue(brokerBindingInjected, 'bayn_broker_account_bound')).toBe(0)
+    expect(metricValue(brokerBindingCleared, 'bayn_runtime_ready')).toBe(1)
+    expect(metricValue(brokerBindingCleared, 'bayn_broker_account_bound')).toBe(1)
+  })
+
+  test('renders the exact bounded terminal reason behind the canonical blocked condition', () => {
+    const base = readyState()
+    const blocked: RuntimeState = {
+      ...base,
+      status: 'DEGRADED',
+      cycle: {
+        ...base.cycle,
+        last: {
+          cycleId: '1'.repeat(64),
+          accountId: 'paper-account-1',
+          signalSessionDate: '2026-07-17',
+          executionSessionDate: '2026-07-20',
+          phase: CycleState.Blocked,
+          snapshotId: '2'.repeat(64),
+          decisionHash: null,
+          terminalReason: CycleTerminalReason.ProvenanceMismatch,
+          submissionOpenAt: '2026-07-20T11:30:00.000Z',
+          submissionCutoffAt: '2026-07-20T12:30:00.000Z',
+          executionOpenAt: '2026-07-20T12:32:00.000Z',
+          executionCloseAt: '2026-07-20T20:00:00.000Z',
+          createdAt: '2026-07-20T11:29:00.000Z',
+          updatedAt: '2026-07-20T12:00:00.000Z',
+          terminalAt: '2026-07-20T12:00:00.000Z',
+        },
+        condition: CycleOperationsCondition.Failed,
+        reason: CycleOperationsReason.LastCycleBlocked,
+        alerts: { ...base.cycle.alerts, cycleFailed: true },
+      },
+    }
+
+    const metrics = renderPrometheusMetrics(blocked, config, provenance, 'embedded')
+
+    expect(metrics).toContain('bayn_cycle_condition{condition="failed"} 1')
+    expect(metrics).toContain('bayn_cycle_reason{reason="last_cycle_blocked"} 1')
+    expect(metrics).toContain('bayn_cycle_terminal_reason{reason="blocked_provenance_mismatch"} 1')
+    expect(metrics).toContain('bayn_cycle_terminal_reason{reason="blocked_data_stale"} 0')
   })
 
   test('returns service unavailable when durable evidence cannot be read', async () => {
@@ -417,6 +560,7 @@ describe('Bayn HTTP probes', () => {
     expect(metrics).toContain('bayn_cycle_condition{condition="unknown"} 1')
     expect(metrics).toContain('bayn_cycle_reason{reason="observation_unavailable"} 1')
     expect(metrics).toContain('bayn_cycle_phase{phase="unknown"} 1')
+    expect(metrics).toContain('bayn_cycle_terminal_reason{reason="unknown"} 1')
     expect(metrics).toContain('bayn_zero_mutation_confirmed 0')
     expect(metrics).not.toContain('bayn_cycle_unfinished_count ')
     expect(metrics).not.toContain('bayn_mutation_events_total ')

--- a/services/bayn/src/http.ts
+++ b/services/bayn/src/http.ts
@@ -7,7 +7,7 @@ import { HttpRouter, HttpServerRequest, HttpServerResponse } from 'effect/unstab
 import type { RuntimeBuildMetadata, RuntimeConfig } from './config'
 import type { RuntimeProvenance } from './contracts'
 import { CycleOperationsCondition, CycleOperationsReason } from './cycle-observability'
-import { CycleState } from './cycle'
+import { CycleState, CycleTerminalReason } from './cycle'
 import { Authority } from './paper'
 import { isReady, type DependencyHealth, type RuntimeState } from './runtime-state'
 
@@ -157,6 +157,7 @@ export const renderPrometheusMetrics = (
   provenanceVerification: RuntimeBuildMetadata['verification'],
 ): string => {
   const publicBroker = publicBrokerState(state)
+  const runtimeReady = isReady(state)
   const cycleObservationAvailable = state.cycle.condition !== CycleOperationsCondition.Unknown
   const cyclePhase =
     cycleObservationAvailable === false
@@ -165,6 +166,13 @@ export const renderPrometheusMetrics = (
   const conditions = Object.values(CycleOperationsCondition)
   const reasons = Object.values(CycleOperationsReason)
   const phases = ['unknown', 'none', ...Object.values(CycleState).map((phase) => phase.toLowerCase())]
+  const terminalReasons = [
+    'unknown',
+    'none',
+    ...Object.values(CycleTerminalReason).map((reason) => reason.toLowerCase()),
+  ]
+  const cycleTerminalReason =
+    cycleObservationAvailable === false ? 'unknown' : (state.cycle.last?.terminalReason?.toLowerCase() ?? 'none')
   const loopResults = ['unknown', 'success', 'failure'] as const
   const loopResult = state.autonomousCycleLoop.lastPass?.result.toLowerCase() ?? 'unknown'
   const loopHealthy =
@@ -182,6 +190,9 @@ export const renderPrometheusMetrics = (
         ? 'paper'
         : 'observe'
   const lines = [
+    '# HELP bayn_runtime_ready Whether the bounded runtime state and required dependencies are operationally ready.',
+    '# TYPE bayn_runtime_ready gauge',
+    `bayn_runtime_ready ${runtimeReady ? 1 : 0}`,
     '# HELP bayn_cycle_observation_available Whether the bounded PostgreSQL cycle projection is current.',
     '# TYPE bayn_cycle_observation_available gauge',
     `bayn_cycle_observation_available ${cycleObservationAvailable ? 1 : 0}`,
@@ -199,6 +210,11 @@ export const renderPrometheusMetrics = (
     '# HELP bayn_cycle_phase Current unfinished cycle phase, or the latest terminal phase when idle.',
     '# TYPE bayn_cycle_phase gauge',
     ...phases.map((phase) => `bayn_cycle_phase{phase="${phase}"} ${cyclePhase === phase ? 1 : 0}`),
+    '# HELP bayn_cycle_terminal_reason Exact bounded terminal reason of the latest cycle.',
+    '# TYPE bayn_cycle_terminal_reason gauge',
+    ...terminalReasons.map(
+      (reason) => `bayn_cycle_terminal_reason{reason="${reason}"} ${cycleTerminalReason === reason ? 1 : 0}`,
+    ),
     ...(cycleObservationAvailable
       ? [
           '# HELP bayn_cycle_unfinished_count Number of unfinished cycles for the bound qualification run.',


### PR DESCRIPTION
## Summary

- export label-free runtime readiness and bounded exact terminal-reason evidence without changing the canonical cycle condition/reason model
- add one non-overlapping runtime-degraded alert plus compact loop, broker, build, authority, reconciliation, mutation-age, and terminal-reason dashboard coverage
- prove inject-and-clear behavior for cutoff, stale/provenance, kill, mutation, reconciliation, loop, and broker conditions and document source-of-truth recovery

## Related Issues

Relates to PROOMPT-384

## Testing

- bun test services/bayn/src/cycle-observability.test.ts services/bayn/src/health.test.ts services/bayn/src/http.test.ts packages/scripts/src/shared/__tests__/bayn-cycle-observability-contract.test.ts
- bun run --filter @proompteng/bayn test
- BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:55433/bayn_test bun test services/bayn/src/db/cycle-observability.integration.test.ts
- bun run --filter @proompteng/bayn tsc
- bun run --filter @proompteng/bayn lint
- bun run --filter @proompteng/bayn lint:oxlint
- bun run --filter @proompteng/bayn lint:oxlint:type
- bun run --filter @proompteng/bayn build
- bun run --filter @proompteng/scripts lint
- bun run --filter @proompteng/scripts lint:oxlint:type
- kustomize build --enable-helm argocd/applications/observability
- kubeconform -strict -ignore-missing-schemas -summary /tmp/bayn-observability-render.yaml
- bun run lint:argocd

## Rollout and Impact

- Argo reconciliation activates the fifth Mimir rule; this PR does not deploy Bayn, change broker access, or change authority.
- The currently deployed old 6e36949 image returns /metrics 404, so only BaynMetricsUnavailable fires before the held Bayn rollout; BaynRuntimeDegraded has no input series and does not duplicate it.
- After a metrics-capable image is scraped, runtime_ready=0 must remain true for one minute before the new critical email fires. Instance-safe joins suppress it while CycleObservationUnavailable, CycleStalled, or CycleFailed owns the condition.
- Removing or reverting the rule clears the notification after Mimir Ruler reconciliation; source-of-truth recovery clears it after the next successful bounded health probe.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable to this source-controlled dashboard and alert contract.
- [x] Documentation, release notes, and follow-ups are updated or tracked.