### PR TITLE
fix(bayn): bind mutations to paper account

### DIFF
--- a/services/bayn/src/broker/alpaca-mutations.test.ts
+++ b/services/bayn/src/broker/alpaca-mutations.test.ts
@@ -218,6 +218,30 @@ describe('Alpaca paper mutations', () => {
     })
   })
 
+  test('rejects a wrong-account intent before making a mutation request', async () => {
+    let mutationRequests = 0
+    const client = HttpClient.make(() => {
+      mutationRequests += 1
+      return Effect.die(new Error('wrong-account intent must not make a mutation request'))
+    })
+    const wrongAccountIntent = {
+      ...intent,
+      accountId: '40b22fc4-23bc-446c-bf07-bea43b5d6c35',
+    }
+
+    const failure = await Effect.runPromise(
+      Effect.flip(withMutation(client, (mutation) => mutation.submit(wrongAccountIntent))),
+    )
+
+    expect(failure).toMatchObject({
+      operation: MutationOperation.Submit,
+      failure: MutationFailure.InvalidRequest,
+      outcome: MutationOutcome.Known,
+      message: 'order intent account does not match the configured Alpaca account',
+    })
+    expect(mutationRequests).toBe(0)
+  })
+
   test('samples submit evidence after the complete response body', async () => {
     let releaseBody: () => void = () => {
       throw new Error('submit response body reader did not start')

--- a/services/bayn/src/broker/alpaca-mutations.ts
+++ b/services/bayn/src/broker/alpaca-mutations.ts
@@ -321,6 +321,14 @@ export const makeMutation = (
         const intent = yield* decodeIntent(input).pipe(
           Effect.mapError((cause) => invalidRequest(MutationOperation.Submit, 'invalid order intent', cause)),
         )
+        if (intent.accountId !== runtime.expectedAccountId) {
+          return yield* Effect.fail(
+            invalidRequest(
+              MutationOperation.Submit,
+              'order intent account does not match the configured Alpaca account',
+            ),
+          )
+        }
         const body = yield* Effect.try({
           try: () => submitBody(intent),
           catch: (cause) => invalidRequest(MutationOperation.Submit, 'order intent cannot be submitted', cause),

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -7,8 +7,14 @@ import { Cause, Deferred, Duration, Effect, Exit, Fiber, Layer, ManagedRuntime, 
 import type { RuntimeConfig } from '../config'
 import { makeStrategyProtocolHash } from '../contracts'
 import { IntentStore, IntentStoreLive, plan, type IntentPlan } from '../execution/intents'
-import { MutationEventType, MutationStore, MutationStoreLive } from '../execution/mutations'
-import { MutationOperation, cancelRequestHash } from '../broker/alpaca-mutations'
+import { MutationEventType, MutationStore, MutationStoreLive, mutationId } from '../execution/mutations'
+import {
+  BrokerMutation,
+  MutationOperation,
+  cancelRequestHash,
+  type BrokerMutationShape,
+} from '../broker/alpaca-mutations'
+import { cancel, submit } from '../execution/coordinator'
 import { WriterFence, WriterFenceLive } from '../execution/writer-fence'
 import { canonicalHashV1 } from '../hash'
 import { buildLedgerPlan, Journal, type JournalService } from '../ledger'
@@ -103,6 +109,15 @@ const makeExecutionRuntime = (config = makeConfig()) =>
 const makeMutationRuntime = (config = makeConfig()) =>
   ManagedRuntime.make(
     MutationStoreLive.pipe(
+      Layer.provideMerge(WriterFenceLive),
+      Layer.provideMerge(PostgresClientLive(config)),
+      Layer.provide(NodeServices.layer),
+    ),
+  )
+
+const makeCoordinatorRuntime = (broker: BrokerMutationShape, config = makeConfig()) =>
+  ManagedRuntime.make(
+    Layer.mergeAll(IntentStoreLive, MutationStoreLive, Layer.succeed(BrokerMutation, broker)).pipe(
       Layer.provideMerge(WriterFenceLive),
       Layer.provideMerge(PostgresClientLive(config)),
       Layer.provide(NodeServices.layer),
@@ -1791,6 +1806,158 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     })
     expect(observed.state).toEqual({ state: 'TERMINAL', state_version: 5 })
   }, 20_000)
+
+  test('rejects mismatched-account submit and identified cancel without durable or broker writes', async () => {
+    const mismatchedAccountId = 'paper-account-2'
+    const submitIntent = await Effect.runPromise(
+      plan(intentPlan({ accountId: mismatchedAccountId, cycleId: 'c'.repeat(64) })),
+    )
+    const cancelIntent = await Effect.runPromise(
+      plan(intentPlan({ accountId: mismatchedAccountId, cycleId: 'd'.repeat(64) })),
+    )
+    const submitDecision = await Effect.runPromise(riskDecision(submitIntent, RiskOutcome.Approved))
+    const cancelDecision = await Effect.runPromise(riskDecision(cancelIntent, RiskOutcome.Approved))
+    const execution = makeExecutionRuntime()
+    await execution.runPromise(
+      Effect.gen(function* () {
+        const store = yield* IntentStore
+        yield* store.commit(submitIntent, submitDecision)
+        yield* store.commit(cancelIntent, cancelDecision)
+      }),
+    )
+    await execution.dispose()
+    await activateAuditedPaperAuthority()
+
+    const brokerCalls = { cancel: 0, submit: 0 }
+    const broker: BrokerMutationShape = {
+      submit: () => {
+        brokerCalls.submit += 1
+        return Effect.die(new Error('mismatched-account submit must not reach the broker'))
+      },
+      cancel: () => {
+        brokerCalls.cancel += 1
+        return Effect.die(new Error('mismatched-account cancel must not reach the broker'))
+      },
+    }
+    const coordinator = makeCoordinatorRuntime(broker)
+    const acceptedAt = Date.now() + 100
+
+    try {
+      const observed = await coordinator.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* PgClient.PgClient
+          const readEvidence = (intentId: string) =>
+            sql<{ authority: unknown; events: unknown; history: unknown; intent: unknown }>`
+              SELECT
+                (
+                  SELECT jsonb_build_object('row', to_jsonb(intent), 'tupleId', intent.xmin::text)
+                  FROM intents AS intent
+                  WHERE intent.intent_id = ${intentId}
+                ) AS intent,
+                (
+                  SELECT coalesce(
+                    jsonb_agg(
+                      jsonb_build_object('row', to_jsonb(event), 'tupleId', event.xmin::text)
+                      ORDER BY event.operation, event.sequence
+                    ),
+                    '[]'::jsonb
+                  )
+                  FROM mutation_events AS event
+                  WHERE event.intent_id = ${intentId}
+                ) AS events,
+                (
+                  SELECT jsonb_build_object('row', to_jsonb(authority), 'tupleId', authority.xmin::text)
+                  FROM authority_state AS authority
+                  WHERE authority.singleton
+                ) AS authority,
+                (
+                  SELECT jsonb_agg(
+                    jsonb_build_object('row', to_jsonb(history), 'tupleId', history.xmin::text)
+                    ORDER BY history.authority_version
+                  )
+                  FROM authority_generations AS history
+                ) AS history
+            `
+
+          const [submitBefore] = yield* readEvidence(submitIntent.intentId)
+          const submitExit = yield* Effect.exit(submit(submitIntent.intentId, 1_000))
+          const [submitAfter] = yield* readEvidence(submitIntent.intentId)
+
+          const cancelMutationId = mutationId(cancelIntent.intentId, MutationOperation.Submit)
+          const cancelSubmitHash = fixtureHash('mismatched-account-identified-submit')
+          const startedAt = new Date(acceptedAt).toISOString()
+          const completedAt = new Date(acceptedAt + 1).toISOString()
+          yield* sql.withTransaction(
+            Effect.gen(function* () {
+              yield* sql`
+                UPDATE intents
+                SET state = 'IO_STARTED', state_version = state_version + 1, updated_at = ${startedAt}
+                WHERE intent_id = ${cancelIntent.intentId} AND state = 'APPROVED'
+              `
+              yield* sql`
+                UPDATE intents
+                SET state = 'ACKNOWLEDGED', state_version = state_version + 1, updated_at = ${completedAt}
+                WHERE intent_id = ${cancelIntent.intentId} AND state = 'IO_STARTED'
+              `
+              yield* sql`
+                INSERT INTO mutation_events (
+                  event_id, schema_version, mutation_id, intent_id, sequence, operation, event_type,
+                  request_hash, consistency_delay_ms, broker_order_id, request_id, response_status,
+                  response_content_hash, occurred_at
+                ) VALUES
+                  (
+                    ${fixtureHash('mismatched-account-submit-started')},
+                    'bayn.paper-mutation-event.v1', ${cancelMutationId}, ${cancelIntent.intentId}, 1,
+                    'SUBMIT', 'SUBMIT_STARTED', ${cancelSubmitHash}, 1000, NULL, NULL, NULL, NULL,
+                    ${startedAt}
+                  ),
+                  (
+                    ${fixtureHash('mismatched-account-submit-accepted')},
+                    'bayn.paper-mutation-event.v1', ${cancelMutationId}, ${cancelIntent.intentId}, 2,
+                    'SUBMIT', 'SUBMIT_ACCEPTED', ${cancelSubmitHash}, 1000, ${orderId},
+                    'mismatched-account-submit', 200,
+                    ${fixtureHash('mismatched-account-submit-response')}, ${completedAt}
+                  )
+              `
+              yield* sql`
+                UPDATE authority_state
+                SET
+                  effective = 'OBSERVE',
+                  kill_state = 'ACTIVE',
+                  reason = 'account-binding cancellation regression',
+                  version = version + 1,
+                  updated_at = greatest(clock_timestamp(), updated_at + interval '1 millisecond')
+                WHERE singleton
+              `
+            }),
+          )
+
+          const [cancelBefore] = yield* readEvidence(cancelIntent.intentId)
+          const cancelExit = yield* Effect.exit(cancel(cancelIntent.intentId, 1_000))
+          const [cancelAfter] = yield* readEvidence(cancelIntent.intentId)
+          return { cancelAfter, cancelBefore, cancelExit, submitAfter, submitBefore, submitExit }
+        }),
+      )
+
+      expect(Exit.isFailure(observed.submitExit)).toBe(true)
+      expect(Exit.isFailure(observed.cancelExit)).toBe(true)
+      if (Exit.isFailure(observed.submitExit)) {
+        expect(Cause.pretty(observed.submitExit.cause)).toContain(
+          'intent account does not match the active PAPER authority generation',
+        )
+      }
+      if (Exit.isFailure(observed.cancelExit)) {
+        expect(Cause.pretty(observed.cancelExit.cause)).toContain(
+          'intent account does not match the active PAPER authority generation',
+        )
+      }
+      expect(observed.submitAfter).toEqual(observed.submitBefore)
+      expect(observed.cancelAfter).toEqual(observed.cancelBefore)
+      expect(brokerCalls).toEqual({ cancel: 0, submit: 0 })
+    } finally {
+      await coordinator.dispose()
+    }
+  })
 
   test('rejects non-submitted and mismatched broker order identities before cancellation starts', async () => {
     const execution = makeExecutionRuntime()

--- a/services/bayn/src/execution/mutations.ts
+++ b/services/bayn/src/execution/mutations.ts
@@ -370,11 +370,24 @@ const makeStore = Effect.gen(function* () {
   const assertAuthority = (operation: MutationOperation) =>
     Effect.gen(function* () {
       const storeOperation = operation === MutationOperation.Submit ? 'begin-submit' : 'begin-cancel'
-      const rows = yield* sql<{ effective: string; kill_state: string; maximum: string }>`
-        SELECT maximum, effective, kill_state
-        FROM authority_state
-        WHERE singleton
-        FOR UPDATE
+      const rows = yield* sql<{
+        effective: string
+        generation_account_id: string | null
+        generation_maximum: string | null
+        kill_state: string
+        maximum: string
+      }>`
+        SELECT
+          authority.maximum,
+          authority.effective,
+          authority.kill_state,
+          generation.maximum AS generation_maximum,
+          generation.account_id AS generation_account_id
+        FROM authority_state AS authority
+        LEFT JOIN authority_generations AS generation
+          ON generation.generation_hash = authority.generation_hash
+        WHERE authority.singleton
+        FOR UPDATE OF authority
       `
       const authority = rows[0]
       if (authority === undefined) {
@@ -398,6 +411,12 @@ const makeStore = Effect.gen(function* () {
           storeError('begin-cancel', 'authority', 'cancellation requires PAPER authority or an active kill'),
         )
       }
+      if (authority.generation_maximum !== Authority.Paper || authority.generation_account_id === null) {
+        return yield* Effect.fail(
+          storeError(storeOperation, 'authority', 'active PAPER authority lacks its immutable account binding'),
+        )
+      }
+      return authority.generation_account_id
     })
 
   const assertNoOtherUnresolved = (intentId: string) =>
@@ -477,10 +496,13 @@ const makeStore = Effect.gen(function* () {
               return { event: existing, started: false } satisfies StartReceipt
             }
 
-            yield* assertAuthority(operation)
+            const authorityAccountId = yield* assertAuthority(operation)
             if (operation === MutationOperation.Submit) yield* assertNoOtherUnresolved(input.intentId)
-            const intents = yield* sql<{ state: string; updated_at: string }>`
-              SELECT state, to_char(updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS updated_at
+            const intents = yield* sql<{ account_id: string; state: string; updated_at: string }>`
+              SELECT
+                account_id,
+                state,
+                to_char(updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS updated_at
               FROM intents
               WHERE intent_id = ${input.intentId}
               FOR UPDATE
@@ -488,6 +510,15 @@ const makeStore = Effect.gen(function* () {
             const intent = intents[0]
             if (intent === undefined) {
               return yield* Effect.fail(storeError(storeOperation, 'invariant', 'intent does not exist'))
+            }
+            if (intent.account_id !== authorityAccountId) {
+              return yield* Effect.fail(
+                storeError(
+                  storeOperation,
+                  'authority',
+                  'intent account does not match the active PAPER authority generation',
+                ),
+              )
             }
             const requiredState =
               operation === MutationOperation.Submit


### PR DESCRIPTION
## Summary

- bind every SUBMIT/CANCEL start to the immutable account on the active PAPER authority generation inside the existing WriterFence transaction
- reject wrong-account Alpaca submissions before request construction or client execution
- prove mismatched submit and active-kill identified cancel preserve intent, mutation, and authority history byte-for-byte with zero broker calls

## Related Issues

PROOMPT-375

## Testing

- `bun test services/bayn/src/broker/alpaca-mutations.test.ts` — 12 passed
- `bun run --cwd services/bayn test` — 393 passed, 94 PostgreSQL-gated tests skipped
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:55433/bayn_test bun test services/bayn/src/db/evidence-store.integration.test.ts` — 43 passed
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:55433/bayn_test bun test services/bayn/src/db/paper-store.integration.test.ts` — 26 passed
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:55433/bayn_test bun test services/bayn/src/db/cycle-store.integration.test.ts` — 13 passed
- `bunx oxfmt --check services/bayn/src`
- `bun run --cwd services/bayn lint:oxlint`
- `bun run --cwd services/bayn lint:oxlint:type`
- `bun run --cwd services/bayn tsc`
- `bun run --cwd services/bayn build`
- `git diff --check`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; this is a backend safety boundary.
- [x] No documentation, release-note, migration, or operator-contract update is required.