### PR TITLE
fix(bayn): verify candidate PostgreSQL TLS identity

### DIFF
--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -212,18 +212,86 @@ principal for this pre-lock full read contaminates the candidate chronology. The
 with Signal bounds derived only from the compiled protocol and the supplied TigerBeetle identity. It does not publish
 Signal data, invoke a backfill, acquire a lock, run Bayn, or write PostgreSQL.
 
+When PostgreSQL TLS is enabled, `BAYN_CANDIDATE_POSTGRES_TLS_SERVER_NAME` is required and must be the DNS identity in
+the CNPG server certificate; for Bayn it is `bayn-db-rw.bayn`. Node-postgres replaces an explicit TLS server name when
+the connection host is a non-IP DNS name, so a local port-forward URI must use `127.0.0.1`, never `localhost`. A DNS
+connection host is accepted only when it exactly equals the configured certificate identity. TLS or routing query
+parameters are forbidden because connection-string parameters can override the explicit verified SSL object. Derive
+the authenticated `postgresql://...@127.0.0.1:<dynamic-port>/bayn` URI in memory from the approved CNPG secret, load
+the publisher password without echoing it, and keep shell tracing disabled. When PostgreSQL TLS is disabled, both
+TLS-only variables must be absent rather than silently ignored.
+
 ```sh
-BAYN_CANDIDATE_SIGNAL_PUBLICATION_DATE=<YYYY-MM-DD> \
-BAYN_CANDIDATE_CLICKHOUSE_URLS=<direct-replica-0-url>,<direct-replica-1-url> \
-BAYN_CANDIDATE_SIGNAL_PUBLISHER_USERNAME=<signal-publisher-user> \
-BAYN_CANDIDATE_SIGNAL_PUBLISHER_PASSWORD=<signal-publisher-password> \
-BAYN_CANDIDATE_POSTGRES_URL=<authenticated-postgres-uri> \
-BAYN_CANDIDATE_POSTGRES_TLS=true \
-BAYN_CANDIDATE_POSTGRES_CA_PATH=<postgres-ca-path> \
-BAYN_CANDIDATE_TIGERBEETLE_CLUSTER_ID=<cluster-id> \
-BAYN_CANDIDATE_TIGERBEETLE_ADDRESSES=<replica-0-address>,<replica-1-address>,<replica-2-address> \
-BAYN_CANDIDATE_TIGERBEETLE_LEDGER=<ledger> \
-  bun run --filter @proompteng/bayn candidate:qualification
+(
+  set -euo pipefail
+  set +x
+  umask 077
+
+  : "${BAYN_CANDIDATE_SIGNAL_PUBLICATION_DATE:?required}"
+  : "${BAYN_CANDIDATE_CLICKHOUSE_URLS:?required}"
+  : "${BAYN_CANDIDATE_SIGNAL_PUBLISHER_USERNAME:?required}"
+  : "${BAYN_CANDIDATE_SIGNAL_PUBLISHER_PASSWORD:?load securely without printing}"
+  : "${BAYN_CANDIDATE_POSTGRES_URL:?load securely without printing}"
+  : "${BAYN_CANDIDATE_POSTGRES_TLS:?required}"
+  : "${BAYN_CANDIDATE_TIGERBEETLE_CLUSTER_ID:?required}"
+  : "${BAYN_CANDIDATE_TIGERBEETLE_ADDRESSES:?required}"
+  : "${BAYN_CANDIDATE_TIGERBEETLE_LEDGER:?required}"
+  if [[ "${BAYN_CANDIDATE_POSTGRES_TLS}" == true ]]; then
+    : "${BAYN_CANDIDATE_POSTGRES_CA_PATH:?required with PostgreSQL TLS}"
+    : "${BAYN_CANDIDATE_POSTGRES_TLS_SERVER_NAME:?required with PostgreSQL TLS}"
+  fi
+
+  candidate_tmp_root="${TMPDIR:-/tmp}"
+  candidate_tmp_root="${candidate_tmp_root%/}"
+  candidate_tmp_dir="$(mktemp -d "${candidate_tmp_root}/bayn-candidate.XXXXXXXX")"
+  candidate_stderr="${candidate_tmp_dir}/verifier.stderr"
+  cleanup_candidate() {
+    rm -f -- "${candidate_stderr}"
+    rmdir -- "${candidate_tmp_dir}"
+  }
+  trap cleanup_candidate EXIT
+  trap 'exit 129' HUP
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+
+  if candidate_receipt="$(bun run --filter @proompteng/bayn candidate:qualification 2>"${candidate_stderr}")"; then
+    :
+  else
+    status=$?
+    # The command's typed stderr is credential-safe; emit it once before the EXIT trap deletes the private file.
+    cat -- "${candidate_stderr}" >&2
+    printf 'candidate verification failed with status %d; stop without retry\n' "${status}" >&2
+    exit "${status}"
+  fi
+
+  unset BAYN_CANDIDATE_SIGNAL_PUBLISHER_PASSWORD BAYN_CANDIDATE_POSTGRES_URL
+  jq -e \
+    --arg publication "${BAYN_CANDIDATE_SIGNAL_PUBLICATION_DATE}" \
+    --arg principal "${BAYN_CANDIDATE_SIGNAL_PUBLISHER_USERNAME}" '
+    .snapshotCanonicalHash as $snapshotHash
+    | .schemaVersion == "bayn.qualification-candidate.v1"
+    and .publicationDate == $publication
+    and .publisherPrincipal == $principal
+    and .qualificationLockCount == 0
+    and ($snapshotHash | test("^[a-f0-9]{64}$"))
+    and (.inputManifestHash | test("^[a-f0-9]{64}$"))
+    and (([.replicas[].replica] | sort) == [
+      "chi-torghut-clickhouse-default-0-0-0",
+      "chi-torghut-clickhouse-default-0-1-0"
+    ])
+    and (([.replicas[].endpointHost] | unique | length) == 2)
+    and (([.replicas[].snapshotCanonicalHash] | unique) == [$snapshotHash])
+    and (.candidateRuntime.BAYN_SIGNAL_SNAPSHOT_ID | test("^[a-f0-9]{64}$"))
+    and .candidateRuntime.BAYN_SIGNAL_PUBLICATION_ASOF == $publication
+    and .candidateRuntime.BAYN_SIGNAL_DATA_END == $publication
+    and .candidateRuntime.BAYN_SIGNAL_EVALUATION_END == $publication
+    and (.candidateRuntime | all(.[]; type == "string" and length > 0))
+  ' <<<"${candidate_receipt}" >/dev/null
+
+  # The separately authorized writer must be the next command in this subshell and consume candidate_receipt directly.
+  # Otherwise exit here and let the subshell discard it. Never tee or redirect the receipt into a repository,
+  # worktree, generated dossier, or persistent JSON file.
+)
 ```
 
 Set `BAYN_AUDIT_OUTPUT=dossier` on the same command to emit `bayn.qualification-dossier.v2`. The deterministic dossier

--- a/services/bayn/src/qualification-candidate-command.test.ts
+++ b/services/bayn/src/qualification-candidate-command.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from 'bun:test'
-import { Effect } from 'effect'
+import { ConfigProvider, Effect } from 'effect'
 
 import {
+  loadQualificationCandidateConfig,
+  makeCandidatePostgresSslOptions,
   QualificationCandidateError,
   verifyQualificationCandidate,
   type CandidateReplicaObservation,
@@ -17,6 +19,28 @@ const endpoints = [
 ] as const
 const snapshot = makeSnapshot(270)
 const publicationDate = snapshot.manifest.finalizedSnapshot.asOfSession
+
+const candidateEnvironment = (): Record<string, string> => ({
+  BAYN_CANDIDATE_SIGNAL_PUBLICATION_DATE: publicationDate,
+  BAYN_CANDIDATE_CLICKHOUSE_URLS: endpoints.map((endpoint) => endpoint.href).join(','),
+  BAYN_CANDIDATE_SIGNAL_PUBLISHER_USERNAME: publisherPrincipal,
+  BAYN_CANDIDATE_SIGNAL_PUBLISHER_PASSWORD: 'publisher-password',
+  BAYN_CANDIDATE_POSTGRES_URL: 'postgresql://bayn:password@127.0.0.1:5432/bayn',
+  BAYN_CANDIDATE_POSTGRES_TLS: 'true',
+  BAYN_CANDIDATE_POSTGRES_CA_PATH: '/tmp/bayn-ca.crt',
+  BAYN_CANDIDATE_POSTGRES_TLS_SERVER_NAME: 'bayn-db-rw.bayn',
+  BAYN_CANDIDATE_TIGERBEETLE_CLUSTER_ID: '122731676035874920802382025803517750735',
+  BAYN_CANDIDATE_TIGERBEETLE_ADDRESSES:
+    'ledger-0.ledger-headless.bayn.svc.cluster.local:3000,ledger-1.ledger-headless.bayn.svc.cluster.local:3000',
+  BAYN_CANDIDATE_TIGERBEETLE_LEDGER: '7001',
+})
+
+const loadCandidateConfig = (environment: Record<string, string>) =>
+  Effect.runPromise(
+    loadQualificationCandidateConfig.pipe(
+      Effect.provideService(ConfigProvider.ConfigProvider, ConfigProvider.fromUnknown(environment)),
+    ),
+  )
 
 const input = (overrides: Partial<QualificationCandidateInput> = {}): QualificationCandidateInput => ({
   publicationDate,
@@ -78,6 +102,178 @@ const failure = async (
   Effect.runPromise(Effect.flip(verifyQualificationCandidate(candidateInput, candidateReaders)))
 
 describe('qualification candidate command', () => {
+  test('requires a decoded PostgreSQL TLS server identity before candidate I/O', async () => {
+    const environment = candidateEnvironment()
+    delete environment.BAYN_CANDIDATE_POSTGRES_TLS_SERVER_NAME
+
+    const error = await Effect.runPromise(
+      Effect.flip(
+        loadQualificationCandidateConfig.pipe(
+          Effect.provideService(ConfigProvider.ConfigProvider, ConfigProvider.fromUnknown(environment)),
+        ),
+      ),
+    )
+
+    expect(error).toBeInstanceOf(QualificationCandidateError)
+    expect(error).toMatchObject({
+      operation: 'config',
+      message: 'BAYN_CANDIDATE_POSTGRES_TLS_SERVER_NAME is required when PostgreSQL TLS is enabled',
+    })
+  })
+
+  test.each([' ', '127.0.0.1', 'bayn-db-rw.bayn:5432', 'bayn_db_rw.bayn', '-bayn-db-rw.bayn'])(
+    'rejects invalid PostgreSQL TLS server identity %j',
+    async (serverName) => {
+      const environment = candidateEnvironment()
+      environment.BAYN_CANDIDATE_POSTGRES_TLS_SERVER_NAME = serverName
+
+      const error = await Effect.runPromise(
+        Effect.flip(
+          loadQualificationCandidateConfig.pipe(
+            Effect.provideService(ConfigProvider.ConfigProvider, ConfigProvider.fromUnknown(environment)),
+          ),
+        ),
+      )
+
+      expect(String(error)).toContain('BAYN_CANDIDATE_POSTGRES_TLS_SERVER_NAME')
+      expect(String(error)).toContain('non-empty DNS name')
+    },
+  )
+
+  test('allows missing PostgreSQL TLS identity only when TLS is disabled', async () => {
+    const environment = candidateEnvironment()
+    environment.BAYN_CANDIDATE_POSTGRES_TLS = 'false'
+    delete environment.BAYN_CANDIDATE_POSTGRES_CA_PATH
+    delete environment.BAYN_CANDIDATE_POSTGRES_TLS_SERVER_NAME
+
+    const loaded = await loadCandidateConfig(environment)
+
+    expect(loaded.postgresTls).toBeUndefined()
+  })
+
+  test.each([
+    ['CA path only', { BAYN_CANDIDATE_POSTGRES_CA_PATH: '/tmp/bayn-ca.crt' }],
+    ['server identity only', { BAYN_CANDIDATE_POSTGRES_TLS_SERVER_NAME: 'bayn-db-rw.bayn' }],
+    [
+      'CA path and server identity',
+      {
+        BAYN_CANDIDATE_POSTGRES_CA_PATH: '/tmp/bayn-ca.crt',
+        BAYN_CANDIDATE_POSTGRES_TLS_SERVER_NAME: 'bayn-db-rw.bayn',
+      },
+    ],
+  ])('rejects TLS-disabled config with %s before I/O', async (_description, tlsEnvironment) => {
+    const environment = candidateEnvironment()
+    environment.BAYN_CANDIDATE_POSTGRES_TLS = 'false'
+    delete environment.BAYN_CANDIDATE_POSTGRES_CA_PATH
+    delete environment.BAYN_CANDIDATE_POSTGRES_TLS_SERVER_NAME
+    Object.assign(environment, tlsEnvironment)
+
+    const error = await Effect.runPromise(
+      Effect.flip(
+        loadQualificationCandidateConfig.pipe(
+          Effect.provideService(ConfigProvider.ConfigProvider, ConfigProvider.fromUnknown(environment)),
+        ),
+      ),
+    )
+
+    expect(error).toBeInstanceOf(QualificationCandidateError)
+    expect(error).toMatchObject({
+      operation: 'config',
+      message:
+        'BAYN_CANDIDATE_POSTGRES_CA_PATH and BAYN_CANDIDATE_POSTGRES_TLS_SERVER_NAME must be absent when PostgreSQL TLS is disabled',
+    })
+  })
+
+  test('rejects a connection-string TLS override even when configured TLS is disabled', async () => {
+    const environment = candidateEnvironment()
+    environment.BAYN_CANDIDATE_POSTGRES_TLS = 'false'
+    environment.BAYN_CANDIDATE_POSTGRES_URL = 'postgresql://bayn:password@127.0.0.1:5432/bayn?sslmode=no-verify'
+    delete environment.BAYN_CANDIDATE_POSTGRES_CA_PATH
+    delete environment.BAYN_CANDIDATE_POSTGRES_TLS_SERVER_NAME
+
+    const error = await Effect.runPromise(
+      Effect.flip(
+        loadQualificationCandidateConfig.pipe(
+          Effect.provideService(ConfigProvider.ConfigProvider, ConfigProvider.fromUnknown(environment)),
+        ),
+      ),
+    )
+
+    expect(error).toBeInstanceOf(QualificationCandidateError)
+    expect(error).toMatchObject({
+      operation: 'config',
+      message: 'invalid BAYN_CANDIDATE_POSTGRES_URL',
+    })
+    expect(String(error.cause)).toContain('must not contain TLS or routing override parameter sslmode')
+  })
+
+  test('rejects a non-IP tunnel host that differs from the certificate identity before I/O', async () => {
+    const environment = candidateEnvironment()
+    environment.BAYN_CANDIDATE_POSTGRES_URL = 'postgresql://bayn:password@localhost:5432/bayn'
+
+    const error = await Effect.runPromise(
+      Effect.flip(
+        loadQualificationCandidateConfig.pipe(
+          Effect.provideService(ConfigProvider.ConfigProvider, ConfigProvider.fromUnknown(environment)),
+        ),
+      ),
+    )
+
+    expect(error).toBeInstanceOf(QualificationCandidateError)
+    expect(error).toMatchObject({
+      operation: 'config',
+      message: 'invalid BAYN_CANDIDATE_POSTGRES_URL',
+    })
+    expect(String(error.cause)).toContain('host must be an IP literal or exactly match')
+  })
+
+  test('accepts an IP-literal tunnel URL and resolves exact verified PostgreSQL TLS options', async () => {
+    const loaded = await loadCandidateConfig(candidateEnvironment())
+    if (loaded.postgresTls === undefined) throw new Error('TLS fixture must resolve PostgreSQL TLS options')
+
+    expect(loaded.postgresTls).toEqual({
+      caPath: '/tmp/bayn-ca.crt',
+      serverName: 'bayn-db-rw.bayn',
+    })
+    expect(makeCandidatePostgresSslOptions(loaded.postgresTls.serverName, 'test-ca')).toEqual({
+      ca: 'test-ca',
+      rejectUnauthorized: true,
+      servername: 'bayn-db-rw.bayn',
+    })
+  })
+
+  test('accepts a PostgreSQL DNS host exactly matching the certificate identity', async () => {
+    const environment = candidateEnvironment()
+    environment.BAYN_CANDIDATE_POSTGRES_URL = 'postgresql://bayn:password@bayn-db-rw.bayn:5432/bayn'
+
+    const loaded = await loadCandidateConfig(environment)
+
+    expect(loaded.postgresTls?.serverName).toBe('bayn-db-rw.bayn')
+  })
+
+  test.each(['sslmode=require', 'ssl=true', 'host=127.0.0.1'])(
+    'rejects PostgreSQL URL override query %s before I/O',
+    async (query) => {
+      const environment = candidateEnvironment()
+      environment.BAYN_CANDIDATE_POSTGRES_URL = `postgresql://bayn:password@127.0.0.1:5432/bayn?${query}`
+
+      const error = await Effect.runPromise(
+        Effect.flip(
+          loadQualificationCandidateConfig.pipe(
+            Effect.provideService(ConfigProvider.ConfigProvider, ConfigProvider.fromUnknown(environment)),
+          ),
+        ),
+      )
+
+      expect(error).toBeInstanceOf(QualificationCandidateError)
+      expect(error).toMatchObject({
+        operation: 'config',
+        message: 'invalid BAYN_CANDIDATE_POSTGRES_URL',
+      })
+      expect(String(error.cause)).toContain('must not contain TLS or routing override parameter')
+    },
+  )
+
   test('emits one deterministic complete runtime from direct physical hosts without topology metadata', async () => {
     let checkedSnapshotId: string | undefined
     const candidateReaders = readers()

--- a/services/bayn/src/qualification-candidate-command.ts
+++ b/services/bayn/src/qualification-candidate-command.ts
@@ -1,7 +1,10 @@
+import { isIP } from 'node:net'
+import type { ConnectionOptions } from 'node:tls'
+
 import { NodeHttpClient, NodeRuntime, NodeServices } from '@effect/platform-node'
 import { ClickhouseClient } from '@effect/sql-clickhouse'
 import { PgClient } from '@effect/sql-pg'
-import { Config, Data, Effect, FileSystem, Layer, Redacted, Schema, Stdio, Stream } from 'effect'
+import { Config, Data, Effect, FileSystem, Layer, Option, Redacted, Schema, Stdio, Stream } from 'effect'
 
 import type { BaynCandidateRuntime } from '../../../packages/scripts/src/bayn/update-manifests'
 
@@ -22,6 +25,8 @@ const maximumTigerBeetleClusterId = (1n << 128n) - 1n
 const maximumTigerBeetleLedger = 2 ** 32 - 1
 const canonicalDecimalPattern = /^(?:0|[1-9][0-9]*)$/
 const transportAddressesPattern = /^[A-Za-z0-9.[\]:_-]+(?:,[A-Za-z0-9.[\]:_-]+)*$/
+const dnsLabelPattern = /^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$/
+const postgresUrlRoutingParameters = new Set(['host', 'port'])
 const signalReplicaIdentities = [
   'chi-torghut-clickhouse-default-0-0-0',
   'chi-torghut-clickhouse-default-0-1-0',
@@ -31,6 +36,19 @@ const ExactReplicaUrls = Config.Array(Schema.URLFromString).check(
   Schema.makeFilter((urls: readonly URL[]) => urls.length === 2, {
     expected: 'exactly two direct ClickHouse replica URLs',
   }),
+)
+const PostgresTlsServerNameSchema = Schema.String.check(
+  Schema.makeFilter(
+    (value: string) =>
+      value.length > 0 &&
+      value.length <= 253 &&
+      value === value.trim() &&
+      isIP(value) === 0 &&
+      value.split('.').every((label) => label.length <= 63 && dnsLabelPattern.test(label)),
+    {
+      expected: 'a non-empty DNS name without surrounding whitespace',
+    },
+  ),
 )
 const CandidateRow = Schema.Struct({
   snapshot_id: Sha256Schema,
@@ -50,14 +68,17 @@ const decodeReplicaIdentity = Schema.decodeUnknownEffect(Schema.Tuple([ReplicaId
 const decodeReadOnlyRow = Schema.decodeUnknownEffect(Schema.Tuple([ReadOnlyRow]), strictParseOptions)
 const decodeLockCountRow = Schema.decodeUnknownEffect(Schema.Tuple([LockCountRow]), strictParseOptions)
 
-const config = Config.all({
+const rawConfig = Config.all({
   publicationDate: Config.schema(IsoDateSchema, 'BAYN_CANDIDATE_SIGNAL_PUBLICATION_DATE'),
   clickhouseUrls: Config.schema(ExactReplicaUrls, 'BAYN_CANDIDATE_CLICKHOUSE_URLS'),
   publisherUsername: Config.schema(TrimmedNonEmptyStringSchema, 'BAYN_CANDIDATE_SIGNAL_PUBLISHER_USERNAME'),
   publisherPassword: Config.redacted('BAYN_CANDIDATE_SIGNAL_PUBLISHER_PASSWORD'),
   postgresUrl: Config.redacted('BAYN_CANDIDATE_POSTGRES_URL'),
   postgresTls: Config.boolean('BAYN_CANDIDATE_POSTGRES_TLS').pipe(Config.withDefault(false)),
-  postgresCaPath: Config.string('BAYN_CANDIDATE_POSTGRES_CA_PATH').pipe(Config.withDefault('')),
+  postgresCaPath: Config.option(Config.schema(TrimmedNonEmptyStringSchema, 'BAYN_CANDIDATE_POSTGRES_CA_PATH')),
+  postgresTlsServerName: Config.option(
+    Config.schema(PostgresTlsServerNameSchema, 'BAYN_CANDIDATE_POSTGRES_TLS_SERVER_NAME'),
+  ),
   tigerBeetleClusterId: Config.schema(TrimmedNonEmptyStringSchema, 'BAYN_CANDIDATE_TIGERBEETLE_CLUSTER_ID'),
   tigerBeetleAddresses: Config.schema(TrimmedNonEmptyStringSchema, 'BAYN_CANDIDATE_TIGERBEETLE_ADDRESSES'),
   tigerBeetleLedger: Config.schema(TrimmedNonEmptyStringSchema, 'BAYN_CANDIDATE_TIGERBEETLE_LEDGER'),
@@ -66,7 +87,18 @@ const config = Config.all({
   ),
 })
 
-type CandidateConfig = Config.Success<typeof config>
+type RawCandidateConfig = Config.Success<typeof rawConfig>
+
+interface CandidatePostgresTlsConfig {
+  readonly caPath: string
+  readonly serverName: string
+}
+
+export const makeCandidatePostgresSslOptions = (serverName: string, ca: string): ConnectionOptions => ({
+  ca,
+  rejectUnauthorized: true,
+  servername: serverName,
+})
 
 export class QualificationCandidateError extends Data.TaggedError('QualificationCandidateError')<{
   readonly operation: 'config' | 'postgres' | 'replica' | 'runtime'
@@ -86,6 +118,95 @@ const preserveCandidateError = (
   cause: unknown,
 ): QualificationCandidateError =>
   cause instanceof QualificationCandidateError ? cause : candidateError(operation, message, cause)
+
+const validateCandidatePostgresUrl = (
+  redactedUrl: Redacted.Redacted<string>,
+  tls: CandidatePostgresTlsConfig | undefined,
+): Effect.Effect<void, QualificationCandidateError> =>
+  Effect.try({
+    try: () => {
+      let url: URL
+      try {
+        url = new URL(Redacted.value(redactedUrl))
+      } catch {
+        throw new TypeError('BAYN_CANDIDATE_POSTGRES_URL must be a valid PostgreSQL URL')
+      }
+      if ((url.protocol !== 'postgres:' && url.protocol !== 'postgresql:') || url.hostname.length === 0) {
+        throw new TypeError('BAYN_CANDIDATE_POSTGRES_URL must be a PostgreSQL URL with a host')
+      }
+      const overrideParameter = [...url.searchParams.keys()].find((key) => {
+        const normalized = key.toLowerCase()
+        return (
+          postgresUrlRoutingParameters.has(normalized) ||
+          normalized === 'uselibpqcompat' ||
+          normalized.startsWith('ssl') ||
+          normalized.startsWith('tls')
+        )
+      })
+      if (overrideParameter !== undefined) {
+        throw new TypeError(
+          `BAYN_CANDIDATE_POSTGRES_URL must not contain TLS or routing override parameter ${overrideParameter}`,
+        )
+      }
+      if (tls === undefined) return
+      const host = url.hostname.startsWith('[') && url.hostname.endsWith(']') ? url.hostname.slice(1, -1) : url.hostname
+      if (isIP(host) === 0 && host !== tls.serverName) {
+        throw new TypeError(
+          'BAYN_CANDIDATE_POSTGRES_URL host must be an IP literal or exactly match BAYN_CANDIDATE_POSTGRES_TLS_SERVER_NAME',
+        )
+      }
+    },
+    catch: (cause) => candidateError('config', 'invalid BAYN_CANDIDATE_POSTGRES_URL', cause),
+  })
+
+const validateQualificationCandidateConfig = (
+  input: RawCandidateConfig,
+): Effect.Effect<
+  Omit<RawCandidateConfig, 'postgresCaPath' | 'postgresTls' | 'postgresTlsServerName'> & {
+    readonly postgresTls: CandidatePostgresTlsConfig | undefined
+  },
+  QualificationCandidateError
+> =>
+  Effect.gen(function* () {
+    const { postgresCaPath, postgresTls, postgresTlsServerName, ...rest } = input
+    if (!postgresTls) {
+      yield* validateCandidatePostgresUrl(input.postgresUrl, undefined)
+      if (Option.isSome(postgresCaPath) || Option.isSome(postgresTlsServerName)) {
+        return yield* Effect.fail(
+          candidateError(
+            'config',
+            'BAYN_CANDIDATE_POSTGRES_CA_PATH and BAYN_CANDIDATE_POSTGRES_TLS_SERVER_NAME must be absent when PostgreSQL TLS is disabled',
+          ),
+        )
+      }
+      return { ...rest, postgresTls: undefined }
+    }
+    if (Option.isNone(postgresCaPath)) {
+      return yield* Effect.fail(
+        candidateError('config', 'BAYN_CANDIDATE_POSTGRES_CA_PATH is required when PostgreSQL TLS is enabled'),
+      )
+    }
+    if (Option.isNone(postgresTlsServerName)) {
+      return yield* Effect.fail(
+        candidateError('config', 'BAYN_CANDIDATE_POSTGRES_TLS_SERVER_NAME is required when PostgreSQL TLS is enabled'),
+      )
+    }
+    const resolvedPostgresTls = {
+      caPath: postgresCaPath.value,
+      serverName: postgresTlsServerName.value,
+    }
+    yield* validateCandidatePostgresUrl(input.postgresUrl, resolvedPostgresTls)
+    return {
+      ...rest,
+      postgresTls: resolvedPostgresTls,
+    }
+  })
+
+export const loadQualificationCandidateConfig = Effect.gen(function* () {
+  return yield* validateQualificationCandidateConfig(yield* rawConfig)
+})
+
+type CandidateConfig = Effect.Success<typeof loadQualificationCandidateConfig>
 
 export interface CandidateReplicaObservation {
   readonly endpointHost: string
@@ -384,20 +505,16 @@ const readReplica = (
 const postgresLayer = (input: CandidateConfig) =>
   Layer.unwrap(
     Effect.gen(function* () {
-      let ca: string | undefined
-      if (input.postgresTls) {
-        if (input.postgresCaPath.length === 0) {
-          return yield* Effect.fail(
-            candidateError('config', 'BAYN_CANDIDATE_POSTGRES_CA_PATH is required when PostgreSQL TLS is enabled'),
-          )
-        }
+      let ssl: ConnectionOptions | undefined
+      if (input.postgresTls !== undefined) {
         const fileSystem = yield* FileSystem.FileSystem
-        ca = yield* fileSystem.readFileString(input.postgresCaPath)
+        const ca = yield* fileSystem.readFileString(input.postgresTls.caPath)
+        ssl = makeCandidatePostgresSslOptions(input.postgresTls.serverName, ca)
       }
       return PgClient.layerFrom(
         PgClient.make({
           url: input.postgresUrl,
-          ssl: ca === undefined ? undefined : { ca, rejectUnauthorized: true },
+          ssl,
           applicationName: 'bayn-qualification-candidate',
           connectTimeout: input.operationTimeoutMs,
           idleTimeout: '30 seconds',
@@ -442,7 +559,7 @@ const readQualificationLocks = (
   )
 
 const main = Effect.gen(function* () {
-  const input = yield* config
+  const input = yield* loadQualificationCandidateConfig
   const protocol = yield* loadDefaultProtocol.pipe(
     Effect.mapError((cause) => candidateError('runtime', 'compiled Bayn protocol is invalid', cause)),
   )


### PR DESCRIPTION
## Summary

- require a strictly decoded PostgreSQL TLS DNS identity before qualification-candidate I/O when TLS is enabled
- pass the verified identity as `ssl.servername` together with the CNPG CA and `rejectUnauthorized: true`
- keep the one-shot candidate receipt in memory with private temporary stderr cleanup and no repository/worktree JSON artifact

## Related Issues

PROOMPT-403

## Testing

- `bun test services/bayn/src/qualification-candidate-command.test.ts` — 22 passed
- `bun run --filter @proompteng/bayn test` — 401 passed, 94 PostgreSQL-gated tests skipped, 0 failed
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- `bunx oxfmt --check services/bayn/src/qualification-candidate-command.ts services/bayn/src/qualification-candidate-command.test.ts services/bayn/README.md`
- dynamically allocated `kubectl -n bayn port-forward --address 127.0.0.1 service/bayn-db-rw :5432`; the exact Effect/pg TLS options with `servername=bayn-db-rw.bayn` returned `transaction_read_only=on` from one `REPEATABLE READ READ ONLY` transaction on local port 63899; no qualification or Signal table was queried
- inspected the four Bayn worktrees for untracked or ignored candidate/audit/dossier JSON artifacts; none found

## Breaking Changes

`BAYN_CANDIDATE_POSTGRES_TLS_SERVER_NAME` is now required when the operator-only qualification candidate command enables PostgreSQL TLS. For the current Bayn CNPG certificate, set it to `bayn-db-rw.bayn`. The deployed Bayn runtime is unchanged.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
