### PR TITLE
fix(bayn): resolve terminal cancel mutations

### DIFF
--- a/services/bayn/src/db/cycle-observability.integration.test.ts
+++ b/services/bayn/src/db/cycle-observability.integration.test.ts
@@ -211,6 +211,90 @@ const seedAcceptedMutation = (occurredAt = '2026-03-06T21:03:00.000Z') =>
   `
   })
 
+const seedTerminalCanceledMutation = Effect.gen(function* () {
+  const sql = yield* PgClient.PgClient
+  yield* seedUnresolvedMutation()
+  yield* sql.withTransaction(
+    Effect.gen(function* () {
+      yield* sql`
+        INSERT INTO risk_decisions (
+          decision_id, schema_version, input_hash, intent_id, policy_hash,
+          outcome, reason_codes, decided_at, expires_at
+        ) VALUES (
+          ${'1'.repeat(64)}, 'bayn.paper-risk-decision.v1', ${'b'.repeat(64)}, ${'2'.repeat(64)},
+          ${'a'.repeat(64)}, 'APPROVED', ARRAY[]::text[],
+          '2026-03-06T21:01:00.000Z', '2099-01-01T00:00:00.000Z'
+        )
+      `
+      yield* sql`
+        UPDATE intents
+        SET
+          risk_decision_id = ${'1'.repeat(64)},
+          state = 'APPROVED',
+          state_version = 2,
+          updated_at = '2026-03-06T21:02:00.001Z'
+        WHERE intent_id = ${'2'.repeat(64)}
+      `
+      yield* sql`
+        UPDATE intents
+        SET state = 'IO_STARTED', state_version = 3, updated_at = '2026-03-06T21:02:00.002Z'
+        WHERE intent_id = ${'2'.repeat(64)}
+      `
+      yield* sql`
+        UPDATE intents
+        SET state = 'UNKNOWN', state_version = 4, updated_at = '2026-03-06T21:03:00.000Z'
+        WHERE intent_id = ${'2'.repeat(64)}
+      `
+      yield* sql`
+        INSERT INTO mutation_events (
+          event_id, schema_version, mutation_id, intent_id, sequence, operation,
+          event_type, request_hash, consistency_delay_ms, broker_order_id,
+          request_id, response_status, response_content_hash, occurred_at
+        ) VALUES
+          (
+            ${'b'.repeat(64)}, 'bayn.paper-mutation-event.v1', ${'4'.repeat(64)}, ${'2'.repeat(64)}, 2,
+            'SUBMIT', 'SUBMIT_UNKNOWN', ${'5'.repeat(64)}, 1000, 'broker-order-observability',
+            'mismatched-submit', 200, ${'c'.repeat(64)}, '2026-03-06T21:03:00.000Z'
+          ),
+          (
+            ${'c'.repeat(64)}, 'bayn.paper-mutation-event.v1', ${'4'.repeat(64)}, ${'2'.repeat(64)}, 3,
+            'SUBMIT', 'RECOVERY_NOT_FOUND', ${'5'.repeat(64)}, 1000, 'broker-order-observability',
+            'submit-not-found', 404, ${'d'.repeat(64)}, '2026-03-06T21:04:00.000Z'
+          ),
+          (
+            ${'e'.repeat(64)}, 'bayn.paper-mutation-event.v1', ${'6'.repeat(64)}, ${'2'.repeat(64)}, 1,
+            'CANCEL', 'CANCEL_STARTED', ${'7'.repeat(64)}, 1000, 'broker-order-observability',
+            NULL, NULL, NULL, '2026-03-06T21:05:00.000Z'
+          ),
+          (
+            ${'f'.repeat(64)}, 'bayn.paper-mutation-event.v1', ${'6'.repeat(64)}, ${'2'.repeat(64)}, 2,
+            'CANCEL', 'CANCEL_ACCEPTED', ${'7'.repeat(64)}, 1000, 'broker-order-observability',
+            'cancel-accepted', 204, ${'8'.repeat(64)}, '2026-03-06T21:06:00.000Z'
+          ),
+          (
+            ${'0'.repeat(64)}, 'bayn.paper-mutation-event.v1', ${'6'.repeat(64)}, ${'2'.repeat(64)}, 3,
+            'CANCEL', 'RECOVERY_FOUND', ${'7'.repeat(64)}, 1000, 'broker-order-observability',
+            'cancel-terminal', 200, ${'9'.repeat(64)}, '2026-03-06T21:07:00.000Z'
+          )
+      `
+      yield* sql`
+        UPDATE intents
+        SET state = 'RECOVERED', state_version = 5, updated_at = '2026-03-06T21:07:00.000Z'
+        WHERE intent_id = ${'2'.repeat(64)}
+      `
+      yield* sql`
+        UPDATE intents
+        SET
+          state = 'TERMINAL',
+          terminal_outcome = 'CANCELED',
+          state_version = 6,
+          updated_at = '2026-03-06T21:07:00.001Z'
+        WHERE intent_id = ${'2'.repeat(64)}
+      `
+    }),
+  )
+})
+
 describePostgres('PostgreSQL cycle observability projection', () => {
   let runtime: ReturnType<typeof makeRuntime>
 
@@ -447,6 +531,42 @@ describePostgres('PostgreSQL cycle observability projection', () => {
       reason: CycleOperationsReason.ReconciliationPredatesMutation,
       reconciliationCoversLatestMutation: false,
       alerts: { reconciliationBlocked: true, unknownMutationStale: false },
+    })
+  })
+
+  test('retains terminal cancel history without projecting its neutralized submit as unresolved', async () => {
+    const result = await runtime.runPromise(
+      Effect.gen(function* () {
+        const observability = yield* CycleObservability
+        const sql = yield* PgClient.PgClient
+        yield* seedSafetyState('2026-03-06T21:08:00.000Z')
+        yield* seedTerminalCanceledMutation
+        const projection = yield* observability.read(qualificationRunId, accountId)
+        const [history] = yield* sql<{ event_count: number; mutation_count: number }>`
+          SELECT
+            count(*)::integer AS event_count,
+            count(DISTINCT mutation_id)::integer AS mutation_count
+          FROM mutation_events
+          WHERE intent_id = ${'2'.repeat(64)}
+        `
+        return { history, projection }
+      }),
+    )
+
+    expect(result.history).toEqual({ event_count: 6, mutation_count: 2 })
+    expect(result.projection).toMatchObject({
+      reconciliation: {
+        accountId,
+        reconciliationId,
+        status: 'EXACT',
+        coversLatestMutation: true,
+      },
+      mutations: {
+        eventCount: 6,
+        unresolvedCount: 0,
+        oldestUnresolvedAt: null,
+        latestOccurredAt: '2026-03-06T21:07:00.000Z',
+      },
     })
   })
 })

--- a/services/bayn/src/db/cycle-observability.integration.test.ts
+++ b/services/bayn/src/db/cycle-observability.integration.test.ts
@@ -213,7 +213,36 @@ const seedAcceptedMutation = (occurredAt = '2026-03-06T21:03:00.000Z') =>
 
 const seedTerminalCanceledMutation = Effect.gen(function* () {
   const sql = yield* PgClient.PgClient
-  yield* seedUnresolvedMutation()
+  const intentId = '2'.repeat(64)
+  yield* sql`
+    INSERT INTO intents (
+      intent_id, schema_version, risk_decision_id, strategy_name, cycle_id,
+      decision_hash, policy_hash, account_id, client_order_id,
+      symbol, side, order_type, time_in_force, quantity_micros, notional_limit_micros,
+      state, terminal_outcome, state_version, created_at, updated_at
+    ) VALUES (
+      ${intentId},
+      'bayn.paper-intent.v2',
+      NULL,
+      'risk-balanced-trend',
+      ${'8'.repeat(64)},
+      ${'9'.repeat(64)},
+      ${'a'.repeat(64)},
+      ${accountId},
+      'bayn-observability-test-order',
+      'SPY',
+      'BUY',
+      'MARKET',
+      'DAY',
+      1000000,
+      1000000,
+      'PLANNED',
+      NULL,
+      1,
+      '2026-03-06T21:02:00.000Z',
+      '2026-03-06T21:02:00.000Z'
+    )
+  `
   yield* sql.withTransaction(
     Effect.gen(function* () {
       yield* sql`
@@ -221,9 +250,9 @@ const seedTerminalCanceledMutation = Effect.gen(function* () {
           decision_id, schema_version, input_hash, intent_id, policy_hash,
           outcome, reason_codes, decided_at, expires_at
         ) VALUES (
-          ${'1'.repeat(64)}, 'bayn.paper-risk-decision.v1', ${'b'.repeat(64)}, ${'2'.repeat(64)},
+          ${'1'.repeat(64)}, 'bayn.paper-risk-decision.v1', ${'b'.repeat(64)}, ${intentId},
           ${'a'.repeat(64)}, 'APPROVED', ARRAY[]::text[],
-          '2026-03-06T21:01:00.000Z', '2099-01-01T00:00:00.000Z'
+          '2026-03-06T21:02:00.001Z', '2099-01-01T00:00:00.000Z'
         )
       `
       yield* sql`
@@ -232,55 +261,89 @@ const seedTerminalCanceledMutation = Effect.gen(function* () {
           risk_decision_id = ${'1'.repeat(64)},
           state = 'APPROVED',
           state_version = 2,
-          updated_at = '2026-03-06T21:02:00.001Z'
-        WHERE intent_id = ${'2'.repeat(64)}
-      `
-      yield* sql`
-        UPDATE intents
-        SET state = 'IO_STARTED', state_version = 3, updated_at = '2026-03-06T21:02:00.002Z'
-        WHERE intent_id = ${'2'.repeat(64)}
-      `
-      yield* sql`
-        UPDATE intents
-        SET state = 'UNKNOWN', state_version = 4, updated_at = '2026-03-06T21:03:00.000Z'
-        WHERE intent_id = ${'2'.repeat(64)}
+          updated_at = '2026-03-06T21:02:00.002Z'
+        WHERE intent_id = ${intentId}
       `
       yield* sql`
         INSERT INTO mutation_events (
           event_id, schema_version, mutation_id, intent_id, sequence, operation,
           event_type, request_hash, consistency_delay_ms, broker_order_id,
           request_id, response_status, response_content_hash, occurred_at
-        ) VALUES
-          (
-            ${'b'.repeat(64)}, 'bayn.paper-mutation-event.v1', ${'4'.repeat(64)}, ${'2'.repeat(64)}, 2,
-            'SUBMIT', 'SUBMIT_UNKNOWN', ${'5'.repeat(64)}, 1000, 'broker-order-observability',
-            'mismatched-submit', 200, ${'c'.repeat(64)}, '2026-03-06T21:03:00.000Z'
-          ),
-          (
-            ${'c'.repeat(64)}, 'bayn.paper-mutation-event.v1', ${'4'.repeat(64)}, ${'2'.repeat(64)}, 3,
-            'SUBMIT', 'RECOVERY_NOT_FOUND', ${'5'.repeat(64)}, 1000, 'broker-order-observability',
-            'submit-not-found', 404, ${'d'.repeat(64)}, '2026-03-06T21:04:00.000Z'
-          ),
-          (
-            ${'e'.repeat(64)}, 'bayn.paper-mutation-event.v1', ${'6'.repeat(64)}, ${'2'.repeat(64)}, 1,
-            'CANCEL', 'CANCEL_STARTED', ${'7'.repeat(64)}, 1000, 'broker-order-observability',
-            NULL, NULL, NULL, '2026-03-06T21:05:00.000Z'
-          ),
-          (
-            ${'f'.repeat(64)}, 'bayn.paper-mutation-event.v1', ${'6'.repeat(64)}, ${'2'.repeat(64)}, 2,
-            'CANCEL', 'CANCEL_ACCEPTED', ${'7'.repeat(64)}, 1000, 'broker-order-observability',
-            'cancel-accepted', 204, ${'8'.repeat(64)}, '2026-03-06T21:06:00.000Z'
-          ),
-          (
-            ${'0'.repeat(64)}, 'bayn.paper-mutation-event.v1', ${'6'.repeat(64)}, ${'2'.repeat(64)}, 3,
-            'CANCEL', 'RECOVERY_FOUND', ${'7'.repeat(64)}, 1000, 'broker-order-observability',
-            'cancel-terminal', 200, ${'9'.repeat(64)}, '2026-03-06T21:07:00.000Z'
-          )
+        ) VALUES (
+          ${'3'.repeat(64)}, 'bayn.paper-mutation-event.v1', ${'4'.repeat(64)}, ${intentId}, 1,
+          'SUBMIT', 'SUBMIT_STARTED', ${'5'.repeat(64)}, 1000, NULL,
+          NULL, NULL, NULL, '2026-03-06T21:02:00.003Z'
+        )
+      `
+      yield* sql`
+        UPDATE intents
+        SET state = 'IO_STARTED', state_version = 3, updated_at = '2026-03-06T21:02:00.003Z'
+        WHERE intent_id = ${intentId}
+      `
+      yield* sql`
+        INSERT INTO mutation_events (
+          event_id, schema_version, mutation_id, intent_id, sequence, operation,
+          event_type, request_hash, consistency_delay_ms, broker_order_id,
+          request_id, response_status, response_content_hash, occurred_at
+        ) VALUES (
+          ${'b'.repeat(64)}, 'bayn.paper-mutation-event.v1', ${'4'.repeat(64)}, ${intentId}, 2,
+          'SUBMIT', 'SUBMIT_UNKNOWN', ${'5'.repeat(64)}, 1000, 'broker-order-observability',
+          'mismatched-submit', 200, ${'c'.repeat(64)}, '2026-03-06T21:03:00.000Z'
+        )
+      `
+      yield* sql`
+        UPDATE intents
+        SET state = 'UNKNOWN', state_version = 4, updated_at = '2026-03-06T21:03:00.000Z'
+        WHERE intent_id = ${intentId}
+      `
+      yield* sql`
+        INSERT INTO mutation_events (
+          event_id, schema_version, mutation_id, intent_id, sequence, operation,
+          event_type, request_hash, consistency_delay_ms, broker_order_id,
+          request_id, response_status, response_content_hash, occurred_at
+        ) VALUES (
+          ${'c'.repeat(64)}, 'bayn.paper-mutation-event.v1', ${'4'.repeat(64)}, ${intentId}, 3,
+          'SUBMIT', 'RECOVERY_NOT_FOUND', ${'5'.repeat(64)}, 1000, 'broker-order-observability',
+          'submit-not-found', 404, ${'d'.repeat(64)}, '2026-03-06T21:04:00.000Z'
+        )
+      `
+      yield* sql`
+        INSERT INTO mutation_events (
+          event_id, schema_version, mutation_id, intent_id, sequence, operation,
+          event_type, request_hash, consistency_delay_ms, broker_order_id,
+          request_id, response_status, response_content_hash, occurred_at
+        ) VALUES (
+          ${'e'.repeat(64)}, 'bayn.paper-mutation-event.v1', ${'6'.repeat(64)}, ${intentId}, 1,
+          'CANCEL', 'CANCEL_STARTED', ${'7'.repeat(64)}, 1000, 'broker-order-observability',
+          NULL, NULL, NULL, '2026-03-06T21:05:00.000Z'
+        )
+      `
+      yield* sql`
+        INSERT INTO mutation_events (
+          event_id, schema_version, mutation_id, intent_id, sequence, operation,
+          event_type, request_hash, consistency_delay_ms, broker_order_id,
+          request_id, response_status, response_content_hash, occurred_at
+        ) VALUES (
+          ${'f'.repeat(64)}, 'bayn.paper-mutation-event.v1', ${'6'.repeat(64)}, ${intentId}, 2,
+          'CANCEL', 'CANCEL_ACCEPTED', ${'7'.repeat(64)}, 1000, 'broker-order-observability',
+          'cancel-accepted', 204, ${'8'.repeat(64)}, '2026-03-06T21:06:00.000Z'
+        )
+      `
+      yield* sql`
+        INSERT INTO mutation_events (
+          event_id, schema_version, mutation_id, intent_id, sequence, operation,
+          event_type, request_hash, consistency_delay_ms, broker_order_id,
+          request_id, response_status, response_content_hash, occurred_at
+        ) VALUES (
+          ${'0'.repeat(64)}, 'bayn.paper-mutation-event.v1', ${'6'.repeat(64)}, ${intentId}, 3,
+          'CANCEL', 'RECOVERY_FOUND', ${'7'.repeat(64)}, 1000, 'broker-order-observability',
+          'cancel-terminal', 200, ${'9'.repeat(64)}, '2026-03-06T21:07:00.000Z'
+        )
       `
       yield* sql`
         UPDATE intents
         SET state = 'RECOVERED', state_version = 5, updated_at = '2026-03-06T21:07:00.000Z'
-        WHERE intent_id = ${'2'.repeat(64)}
+        WHERE intent_id = ${intentId}
       `
       yield* sql`
         UPDATE intents
@@ -288,8 +351,8 @@ const seedTerminalCanceledMutation = Effect.gen(function* () {
           state = 'TERMINAL',
           terminal_outcome = 'CANCELED',
           state_version = 6,
-          updated_at = '2026-03-06T21:07:00.001Z'
-        WHERE intent_id = ${'2'.repeat(64)}
+          updated_at = '2026-03-06T21:07:00.000001Z'
+        WHERE intent_id = ${intentId}
       `
     }),
   )

--- a/services/bayn/src/db/cycle-observability.ts
+++ b/services/bayn/src/db/cycle-observability.ts
@@ -299,20 +299,21 @@ const makeCycleObservability = Effect.gen(function* () {
           unresolved_mutations AS (
             SELECT occurred_at
             FROM latest_mutations
-            WHERE
-              event_type IN (
-                'SUBMIT_STARTED',
-                'SUBMIT_UNKNOWN',
-                'RECOVERY_NOT_FOUND',
-                'RECOVERY_UNKNOWN',
-                'CANCEL_STARTED',
-                'CANCEL_ACCEPTED',
-                'CANCEL_UNKNOWN'
-              )
-              OR (
-                operation = 'CANCEL'
-                AND event_type = 'RECOVERY_FOUND'
-                AND state <> 'TERMINAL'
+            WHERE state <> 'TERMINAL'
+              AND (
+                event_type IN (
+                  'SUBMIT_STARTED',
+                  'SUBMIT_UNKNOWN',
+                  'RECOVERY_NOT_FOUND',
+                  'RECOVERY_UNKNOWN',
+                  'CANCEL_STARTED',
+                  'CANCEL_ACCEPTED',
+                  'CANCEL_UNKNOWN'
+                )
+                OR (
+                  operation = 'CANCEL'
+                  AND event_type = 'RECOVERY_FOUND'
+                )
               )
           )
           SELECT

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -1641,10 +1641,16 @@ describePostgres('PostgreSQL evaluation evidence', () => {
   test('cancels an identified mismatched order while its submit remains UNKNOWN', async () => {
     const execution = makeExecutionRuntime()
     const intent = await Effect.runPromise(plan(intentPlan({ cycleId: '8'.repeat(64) })))
+    const laterIntent = await Effect.runPromise(
+      plan(intentPlan({ cycleId: '7'.repeat(64), decisionHash: 'f'.repeat(64) })),
+    )
     const decision = await Effect.runPromise(riskDecision(intent, RiskOutcome.Approved))
+    const laterDecision = await Effect.runPromise(riskDecision(laterIntent, RiskOutcome.Approved))
     await execution.runPromise(
       Effect.gen(function* () {
-        yield* Effect.flatMap(IntentStore, (store) => store.commit(intent, decision))
+        const store = yield* IntentStore
+        yield* store.commit(intent, decision)
+        yield* store.commit(laterIntent, laterDecision)
       }),
     )
     await execution.dispose()
@@ -1702,7 +1708,27 @@ describePostgres('PostgreSQL evaluation evidence', () => {
           },
           TerminalOutcome.Canceled,
         )
-        return { cancelStarted, canceled, notFound, state: yield* sqlIntentState(intent.intentId), unknown }
+        const laterStarted = yield* store.beginSubmit(
+          laterIntent.intentId,
+          '1'.repeat(64),
+          1_000,
+          new Date(base + 6).toISOString(),
+        )
+        const sql = yield* PgClient.PgClient
+        const [history] = yield* sql<{ event_count: number }>`
+          SELECT count(*)::integer AS event_count
+          FROM mutation_events
+          WHERE intent_id = ${intent.intentId}
+        `
+        return {
+          cancelStarted,
+          canceled,
+          history,
+          laterStarted,
+          notFound,
+          state: yield* sqlIntentState(intent.intentId),
+          unknown,
+        }
       }),
     )
     await mutation.dispose()
@@ -1718,6 +1744,14 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     expect(observed.cancelStarted.started).toBe(true)
     expect(observed.canceled.eventType).toBe(MutationEventType.RecoveryFound)
     expect(observed.state.state).toBe('TERMINAL')
+    expect(observed.history.event_count).toBe(6)
+    expect(observed.laterStarted).toMatchObject({
+      started: true,
+      event: {
+        eventType: MutationEventType.SubmitStarted,
+        intentId: laterIntent.intentId,
+      },
+    })
   })
 
   test('allows expired identified cancellation under an active kill while blocking new submission', async () => {

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -375,6 +375,119 @@ const seedExactReconciliation = (fixture: ReconciliationFixture, reconciliationA
     `
   })
 
+const seedTerminalCanceledMutation = Effect.gen(function* () {
+  const sql = yield* PgClient.PgClient
+  const intentId = hash('terminal-canceled-intent')
+  const decisionId = hash('terminal-canceled-risk-decision')
+  const submitMutationId = hash('terminal-canceled-submit')
+  const cancelMutationId = hash('terminal-canceled-cancel')
+  const brokerOrderId = '61e69015-8549-4bfd-b9c3-01e75843f47d'
+  yield* sql`
+    INSERT INTO intents (
+      intent_id, schema_version, account_id, client_order_id, symbol, side,
+      order_type, time_in_force, quantity_micros, notional_limit_micros,
+      state, terminal_outcome, state_version, created_at, updated_at,
+      strategy_name, cycle_id, decision_hash, policy_hash
+    ) VALUES (
+      ${intentId}, 'bayn.paper-intent.v2', ${accountId},
+      'terminal-canceled-client-order', 'SPY', 'BUY', 'MARKET', 'DAY', 1000000, 100000000,
+      'PLANNED', NULL, 1, '2026-07-22T15:30:00.000Z', '2026-07-22T15:30:00.000Z',
+      'risk-balanced-trend', ${hash('terminal-canceled-cycle')},
+      ${hash('terminal-canceled-decision')}, ${hash('terminal-canceled-policy')}
+    )
+  `
+  yield* sql.withTransaction(
+    Effect.gen(function* () {
+      yield* sql`
+        INSERT INTO risk_decisions (
+          decision_id, schema_version, input_hash, intent_id, policy_hash,
+          outcome, reason_codes, decided_at, expires_at
+        ) VALUES (
+          ${decisionId}, 'bayn.paper-risk-decision.v1', ${hash('terminal-canceled-risk-input')}, ${intentId},
+          ${hash('terminal-canceled-policy')}, 'APPROVED', ARRAY[]::text[],
+          '2026-07-22T15:29:59.000Z', '2099-01-01T00:00:00.000Z'
+        )
+      `
+      yield* sql`
+        UPDATE intents
+        SET
+          risk_decision_id = ${decisionId},
+          state = 'APPROVED',
+          state_version = 2,
+          updated_at = '2026-07-22T15:30:00.001Z'
+        WHERE intent_id = ${intentId}
+      `
+      yield* sql`
+        UPDATE intents
+        SET state = 'IO_STARTED', state_version = 3, updated_at = '2026-07-22T15:30:01.000Z'
+        WHERE intent_id = ${intentId}
+      `
+      yield* sql`
+        UPDATE intents
+        SET state = 'UNKNOWN', state_version = 4, updated_at = '2026-07-22T15:30:02.000Z'
+        WHERE intent_id = ${intentId}
+      `
+      yield* sql`
+        INSERT INTO mutation_events (
+          event_id, schema_version, mutation_id, intent_id, sequence, operation,
+          event_type, request_hash, consistency_delay_ms, broker_order_id,
+          request_id, response_status, response_content_hash, occurred_at
+        ) VALUES
+          (
+            ${hash('terminal-canceled-submit-started')}, 'bayn.paper-mutation-event.v1',
+            ${submitMutationId}, ${intentId}, 1, 'SUBMIT', 'SUBMIT_STARTED',
+            ${hash('terminal-canceled-submit-request')}, 1000, NULL,
+            NULL, NULL, NULL, '2026-07-22T15:30:01.000Z'
+          ),
+          (
+            ${hash('terminal-canceled-submit-unknown')}, 'bayn.paper-mutation-event.v1',
+            ${submitMutationId}, ${intentId}, 2, 'SUBMIT', 'SUBMIT_UNKNOWN',
+            ${hash('terminal-canceled-submit-request')}, 1000, ${brokerOrderId},
+            'mismatched-submit', 200, ${hash('terminal-canceled-submit-response')}, '2026-07-22T15:30:02.000Z'
+          ),
+          (
+            ${hash('terminal-canceled-submit-not-found')}, 'bayn.paper-mutation-event.v1',
+            ${submitMutationId}, ${intentId}, 3, 'SUBMIT', 'RECOVERY_NOT_FOUND',
+            ${hash('terminal-canceled-submit-request')}, 1000, ${brokerOrderId},
+            'submit-not-found', 404, ${hash('terminal-canceled-submit-lookup')}, '2026-07-22T15:30:03.000Z'
+          ),
+          (
+            ${hash('terminal-canceled-cancel-started')}, 'bayn.paper-mutation-event.v1',
+            ${cancelMutationId}, ${intentId}, 1, 'CANCEL', 'CANCEL_STARTED',
+            ${hash('terminal-canceled-cancel-request')}, 1000, ${brokerOrderId},
+            NULL, NULL, NULL, '2026-07-22T15:30:04.000Z'
+          ),
+          (
+            ${hash('terminal-canceled-cancel-accepted')}, 'bayn.paper-mutation-event.v1',
+            ${cancelMutationId}, ${intentId}, 2, 'CANCEL', 'CANCEL_ACCEPTED',
+            ${hash('terminal-canceled-cancel-request')}, 1000, ${brokerOrderId},
+            'cancel-accepted', 204, ${hash('terminal-canceled-cancel-response')}, '2026-07-22T15:30:05.000Z'
+          ),
+          (
+            ${hash('terminal-canceled-cancel-found')}, 'bayn.paper-mutation-event.v1',
+            ${cancelMutationId}, ${intentId}, 3, 'CANCEL', 'RECOVERY_FOUND',
+            ${hash('terminal-canceled-cancel-request')}, 1000, ${brokerOrderId},
+            'cancel-terminal', 200, ${hash('terminal-canceled-cancel-lookup')}, '2026-07-22T15:30:06.000Z'
+          )
+      `
+      yield* sql`
+        UPDATE intents
+        SET state = 'RECOVERED', state_version = 5, updated_at = '2026-07-22T15:30:06.000Z'
+        WHERE intent_id = ${intentId}
+      `
+      yield* sql`
+        UPDATE intents
+        SET
+          state = 'TERMINAL',
+          terminal_outcome = 'CANCELED',
+          state_version = 6,
+          updated_at = '2026-07-22T15:30:06.001Z'
+        WHERE intent_id = ${intentId}
+      `
+    }),
+  )
+})
+
 const makeActivation = (
   previousGenerationHash: string,
   qualification: QualificationFixture,
@@ -950,6 +1063,72 @@ describePostgres('paper accounting persistence', () => {
       )
       expect(activated).toMatchObject({
         generationHash: preparation.first.generationHash,
+        maximum: Authority.Paper,
+        effective: Authority.Paper,
+        version: 2,
+      })
+    } finally {
+      await activationRuntime.dispose()
+    }
+  }, 15_000)
+
+  test('activates PAPER after fresh exact reconciliation covers terminal cancel mutation history', async () => {
+    const initialGenerationHash = hash('terminal-canceled-observe-generation')
+    const reconciliation = exactReconciliation('terminal-canceled-paper')
+    const expected = makeActivation(initialGenerationHash, qualifiedEvidence, reconciliation)
+    const prepareRuntime = makeStoreRuntime({ fail: false, planHashes: [] }, prepareRuntimeConfig(expected))
+    const preparation = await (async () => {
+      try {
+        return await prepareRuntime.runPromise(
+          Effect.gen(function* () {
+            const store = yield* PaperStore
+            const sql = yield* PgClient.PgClient
+            yield* seedQualificationEvidence(qualifiedEvidence)
+            yield* store.ensureAuthorityGeneration({
+              generationHash: initialGenerationHash,
+              maximum: Authority.Observe,
+            })
+            yield* seedTerminalCanceledMutation
+            yield* seedExactReconciliation(reconciliation)
+            const prepared = yield* store.preparePaperGeneration(proofBinding(expected))
+            const [history] = yield* sql<{ event_count: number; latest_mutation_at: Date }>`
+              SELECT
+                count(*)::integer AS event_count,
+                max(occurred_at) AS latest_mutation_at
+              FROM mutation_events
+            `
+            return { history, prepared }
+          }),
+        )
+      } finally {
+        await prepareRuntime.dispose()
+      }
+    })()
+
+    expect(preparation.prepared).toEqual(expected)
+    expect(preparation.history.event_count).toBe(6)
+
+    const activationRuntime = makeActivationRuntime({ fail: false, planHashes: [] }, preparation.prepared)
+    try {
+      const result = await activationRuntime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* PaperStore
+          const sql = yield* PgClient.PgClient
+          const [reconciliationRow] = yield* sql<{ reconciled_at: Date }>`
+            SELECT reconciled_at
+            FROM reconciliations
+            WHERE reconciliation_id = ${reconciliation.reconciliationId}
+          `
+          const activated = yield* store.activatePaperGeneration(proofBinding(preparation.prepared))
+          return { activated, reconciliationRow }
+        }),
+      )
+
+      expect(result.reconciliationRow.reconciled_at.getTime()).toBeGreaterThanOrEqual(
+        preparation.history.latest_mutation_at.getTime(),
+      )
+      expect(result.activated).toMatchObject({
+        generationHash: preparation.prepared.generationHash,
         maximum: Authority.Paper,
         effective: Authority.Paper,
         version: 2,

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -405,7 +405,7 @@ const seedTerminalCanceledMutation = Effect.gen(function* () {
         ) VALUES (
           ${decisionId}, 'bayn.paper-risk-decision.v1', ${hash('terminal-canceled-risk-input')}, ${intentId},
           ${hash('terminal-canceled-policy')}, 'APPROVED', ARRAY[]::text[],
-          '2026-07-22T15:29:59.000Z', '2099-01-01T00:00:00.000Z'
+          '2026-07-22T15:30:00.001Z', '2099-01-01T00:00:00.000Z'
         )
       `
       yield* sql`
@@ -414,13 +414,37 @@ const seedTerminalCanceledMutation = Effect.gen(function* () {
           risk_decision_id = ${decisionId},
           state = 'APPROVED',
           state_version = 2,
-          updated_at = '2026-07-22T15:30:00.001Z'
+          updated_at = '2026-07-22T15:30:00.002Z'
         WHERE intent_id = ${intentId}
+      `
+      yield* sql`
+        INSERT INTO mutation_events (
+          event_id, schema_version, mutation_id, intent_id, sequence, operation,
+          event_type, request_hash, consistency_delay_ms, broker_order_id,
+          request_id, response_status, response_content_hash, occurred_at
+        ) VALUES (
+          ${hash('terminal-canceled-submit-started')}, 'bayn.paper-mutation-event.v1',
+          ${submitMutationId}, ${intentId}, 1, 'SUBMIT', 'SUBMIT_STARTED',
+          ${hash('terminal-canceled-submit-request')}, 1000, NULL,
+          NULL, NULL, NULL, '2026-07-22T15:30:01.000Z'
+        )
       `
       yield* sql`
         UPDATE intents
         SET state = 'IO_STARTED', state_version = 3, updated_at = '2026-07-22T15:30:01.000Z'
         WHERE intent_id = ${intentId}
+      `
+      yield* sql`
+        INSERT INTO mutation_events (
+          event_id, schema_version, mutation_id, intent_id, sequence, operation,
+          event_type, request_hash, consistency_delay_ms, broker_order_id,
+          request_id, response_status, response_content_hash, occurred_at
+        ) VALUES (
+          ${hash('terminal-canceled-submit-unknown')}, 'bayn.paper-mutation-event.v1',
+          ${submitMutationId}, ${intentId}, 2, 'SUBMIT', 'SUBMIT_UNKNOWN',
+          ${hash('terminal-canceled-submit-request')}, 1000, ${brokerOrderId},
+          'mismatched-submit', 200, ${hash('terminal-canceled-submit-response')}, '2026-07-22T15:30:02.000Z'
+        )
       `
       yield* sql`
         UPDATE intents
@@ -432,43 +456,48 @@ const seedTerminalCanceledMutation = Effect.gen(function* () {
           event_id, schema_version, mutation_id, intent_id, sequence, operation,
           event_type, request_hash, consistency_delay_ms, broker_order_id,
           request_id, response_status, response_content_hash, occurred_at
-        ) VALUES
-          (
-            ${hash('terminal-canceled-submit-started')}, 'bayn.paper-mutation-event.v1',
-            ${submitMutationId}, ${intentId}, 1, 'SUBMIT', 'SUBMIT_STARTED',
-            ${hash('terminal-canceled-submit-request')}, 1000, NULL,
-            NULL, NULL, NULL, '2026-07-22T15:30:01.000Z'
-          ),
-          (
-            ${hash('terminal-canceled-submit-unknown')}, 'bayn.paper-mutation-event.v1',
-            ${submitMutationId}, ${intentId}, 2, 'SUBMIT', 'SUBMIT_UNKNOWN',
-            ${hash('terminal-canceled-submit-request')}, 1000, ${brokerOrderId},
-            'mismatched-submit', 200, ${hash('terminal-canceled-submit-response')}, '2026-07-22T15:30:02.000Z'
-          ),
-          (
-            ${hash('terminal-canceled-submit-not-found')}, 'bayn.paper-mutation-event.v1',
-            ${submitMutationId}, ${intentId}, 3, 'SUBMIT', 'RECOVERY_NOT_FOUND',
-            ${hash('terminal-canceled-submit-request')}, 1000, ${brokerOrderId},
-            'submit-not-found', 404, ${hash('terminal-canceled-submit-lookup')}, '2026-07-22T15:30:03.000Z'
-          ),
-          (
-            ${hash('terminal-canceled-cancel-started')}, 'bayn.paper-mutation-event.v1',
-            ${cancelMutationId}, ${intentId}, 1, 'CANCEL', 'CANCEL_STARTED',
-            ${hash('terminal-canceled-cancel-request')}, 1000, ${brokerOrderId},
-            NULL, NULL, NULL, '2026-07-22T15:30:04.000Z'
-          ),
-          (
-            ${hash('terminal-canceled-cancel-accepted')}, 'bayn.paper-mutation-event.v1',
-            ${cancelMutationId}, ${intentId}, 2, 'CANCEL', 'CANCEL_ACCEPTED',
-            ${hash('terminal-canceled-cancel-request')}, 1000, ${brokerOrderId},
-            'cancel-accepted', 204, ${hash('terminal-canceled-cancel-response')}, '2026-07-22T15:30:05.000Z'
-          ),
-          (
-            ${hash('terminal-canceled-cancel-found')}, 'bayn.paper-mutation-event.v1',
-            ${cancelMutationId}, ${intentId}, 3, 'CANCEL', 'RECOVERY_FOUND',
-            ${hash('terminal-canceled-cancel-request')}, 1000, ${brokerOrderId},
-            'cancel-terminal', 200, ${hash('terminal-canceled-cancel-lookup')}, '2026-07-22T15:30:06.000Z'
-          )
+        ) VALUES (
+          ${hash('terminal-canceled-submit-not-found')}, 'bayn.paper-mutation-event.v1',
+          ${submitMutationId}, ${intentId}, 3, 'SUBMIT', 'RECOVERY_NOT_FOUND',
+          ${hash('terminal-canceled-submit-request')}, 1000, ${brokerOrderId},
+          'submit-not-found', 404, ${hash('terminal-canceled-submit-lookup')}, '2026-07-22T15:30:03.000Z'
+        )
+      `
+      yield* sql`
+        INSERT INTO mutation_events (
+          event_id, schema_version, mutation_id, intent_id, sequence, operation,
+          event_type, request_hash, consistency_delay_ms, broker_order_id,
+          request_id, response_status, response_content_hash, occurred_at
+        ) VALUES (
+          ${hash('terminal-canceled-cancel-started')}, 'bayn.paper-mutation-event.v1',
+          ${cancelMutationId}, ${intentId}, 1, 'CANCEL', 'CANCEL_STARTED',
+          ${hash('terminal-canceled-cancel-request')}, 1000, ${brokerOrderId},
+          NULL, NULL, NULL, '2026-07-22T15:30:04.000Z'
+        )
+      `
+      yield* sql`
+        INSERT INTO mutation_events (
+          event_id, schema_version, mutation_id, intent_id, sequence, operation,
+          event_type, request_hash, consistency_delay_ms, broker_order_id,
+          request_id, response_status, response_content_hash, occurred_at
+        ) VALUES (
+          ${hash('terminal-canceled-cancel-accepted')}, 'bayn.paper-mutation-event.v1',
+          ${cancelMutationId}, ${intentId}, 2, 'CANCEL', 'CANCEL_ACCEPTED',
+          ${hash('terminal-canceled-cancel-request')}, 1000, ${brokerOrderId},
+          'cancel-accepted', 204, ${hash('terminal-canceled-cancel-response')}, '2026-07-22T15:30:05.000Z'
+        )
+      `
+      yield* sql`
+        INSERT INTO mutation_events (
+          event_id, schema_version, mutation_id, intent_id, sequence, operation,
+          event_type, request_hash, consistency_delay_ms, broker_order_id,
+          request_id, response_status, response_content_hash, occurred_at
+        ) VALUES (
+          ${hash('terminal-canceled-cancel-found')}, 'bayn.paper-mutation-event.v1',
+          ${cancelMutationId}, ${intentId}, 3, 'CANCEL', 'RECOVERY_FOUND',
+          ${hash('terminal-canceled-cancel-request')}, 1000, ${brokerOrderId},
+          'cancel-terminal', 200, ${hash('terminal-canceled-cancel-lookup')}, '2026-07-22T15:30:06.000Z'
+        )
       `
       yield* sql`
         UPDATE intents
@@ -481,7 +510,7 @@ const seedTerminalCanceledMutation = Effect.gen(function* () {
           state = 'TERMINAL',
           terminal_outcome = 'CANCELED',
           state_version = 6,
-          updated_at = '2026-07-22T15:30:06.001Z'
+          updated_at = '2026-07-22T15:30:06.000001Z'
         WHERE intent_id = ${intentId}
       `
     }),

--- a/services/bayn/src/db/paper-store.ts
+++ b/services/bayn/src/db/paper-store.ts
@@ -1537,21 +1537,23 @@ const makeStore = (config: PaperStoreRuntimeConfig) =>
           )
           SELECT
             count(*) FILTER (
-              WHERE latest.event_type IN (
-                'SUBMIT_STARTED',
-                'SUBMIT_UNKNOWN',
-                'RECOVERY_NOT_FOUND',
-                'RECOVERY_UNKNOWN',
-                'CANCEL_STARTED',
-                'CANCEL_ACCEPTED',
-                'CANCEL_UNKNOWN'
-              )
-              OR (
-                latest.operation = 'CANCEL'
-                AND latest.event_type = 'RECOVERY_FOUND'
-                AND latest.state <> 'TERMINAL'
-              )
-            )::integer AS unresolved_count,
+              WHERE latest.state <> 'TERMINAL'
+                AND (
+                  latest.event_type IN (
+                    'SUBMIT_STARTED',
+                    'SUBMIT_UNKNOWN',
+                    'RECOVERY_NOT_FOUND',
+                    'RECOVERY_UNKNOWN',
+                    'CANCEL_STARTED',
+                    'CANCEL_ACCEPTED',
+                    'CANCEL_UNKNOWN'
+                  )
+                  OR (
+                    latest.operation = 'CANCEL'
+                    AND latest.event_type = 'RECOVERY_FOUND'
+                  )
+                )
+              )::integer AS unresolved_count,
             max(latest.occurred_at) AS latest_mutation_at
           FROM latest
         `.pipe(Effect.flatMap(decodeMutationBaseline))

--- a/services/bayn/src/execution/mutations.ts
+++ b/services/bayn/src/execution/mutations.ts
@@ -435,6 +435,7 @@ const makeStore = Effect.gen(function* () {
             ORDER BY events.mutation_id, events.sequence DESC
           ) AS latest
           WHERE latest.intent_id <> ${intentId}
+            AND latest.state <> 'TERMINAL'
             AND (
               latest.event_type IN (
                 'SUBMIT_STARTED',
@@ -448,7 +449,6 @@ const makeStore = Effect.gen(function* () {
               OR (
                 latest.operation = 'CANCEL'
                 AND latest.event_type = 'RECOVERY_FOUND'
-                AND latest.state <> 'TERMINAL'
               )
             )
         ) AS unresolved


### PR DESCRIPTION
## Summary

- Treat every durable TERMINAL intent as resolving its prior submit and cancel mutation history in the MutationStore interlock, PaperStore activation gate, and cycle operations projection.
- Preserve the append-only mutation history and keep the latest mutation timestamp in the fresh exact reconciliation coverage gate.
- Add real PostgreSQL regressions for the zero-fill identified cancel path, later-intent admission without broker capability, PAPER activation after covering reconciliation, and unresolvedCount zero observability.

## Related Issues

PROOMPT-375

## Testing

- BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:64284/bayn_test bun test services/bayn/src/db/evidence-store.integration.test.ts services/bayn/src/db/paper-store.integration.test.ts services/bayn/src/db/cycle-observability.integration.test.ts
- BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:64284/bayn_test bun run --filter @proompteng/bayn test
- bun run --filter @proompteng/bayn tsc
- bun run --filter @proompteng/bayn lint
- bun run --filter @proompteng/bayn lint:oxlint
- bun run --filter @proompteng/bayn lint:oxlint:type
- bun run --filter @proompteng/bayn build
- git diff --check

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] No documentation or release-note change is required; authority-generation intent binding remains the separately assigned follow-up.