### PR TITLE
feat(buzz): expose admin UI through Tailscale

### DIFF
--- a/argocd/applications/buzz/admin-ingress.yaml
+++ b/argocd/applications/buzz/admin-ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: buzz-admin
+  annotations:
+    tailscale.com/tags: tag:k8s
+spec:
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - buzz-admin.ide-newton.ts.net
+  rules:
+    - host: buzz-admin.ide-newton.ts.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: buzz
+                port:
+                  number: 3000

--- a/argocd/applications/buzz/kustomization.yaml
+++ b/argocd/applications/buzz/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: buzz
 
 resources:
+  - admin-ingress.yaml
   - objectbucketclaims.yaml
   - secret-store.yaml
   - redis-auth-externalsecret.yaml

--- a/argocd/applications/buzz/networkpolicy.yaml
+++ b/argocd/applications/buzz/networkpolicy.yaml
@@ -40,6 +40,13 @@ spec:
             matchLabels:
               tailscale.com/parent-resource-ns: buzz
               tailscale.com/parent-resource: buzz
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: tailscale
+          podSelector:
+            matchLabels:
+              tailscale.com/parent-resource-ns: buzz
+              tailscale.com/parent-resource: buzz-admin
       ports:
         - port: 3000
           protocol: TCP

--- a/argocd/applications/buzz/values.yaml
+++ b/argocd/applications/buzz/values.yaml
@@ -30,6 +30,10 @@ relay:
   extraEnv:
     - name: BUZZ_GIT_S3_COMPATIBILITY
       value: ceph-rgw
+    - name: BUZZ_ADMIN_HOST
+      value: buzz-admin.ide-newton.ts.net
+    - name: BUZZ_ADMIN_WEB_DIR
+      value: /srv/buzz/admin-web
   topologySpreadConstraints:
     - maxSkew: 1
       topologyKey: kubernetes.io/hostname

--- a/docs/runbooks/buzz-production.md
+++ b/docs/runbooks/buzz-production.md
@@ -1,7 +1,8 @@
 # Buzz production operations
 
 Buzz is deployed to the `buzz` namespace by the `buzz` Argo CD application. It is private to the
-`ide-newton.ts.net` tailnet at `wss://buzz.ide-newton.ts.net`.
+`ide-newton.ts.net` tailnet at `wss://buzz.ide-newton.ts.net`. Its read-only moderation and product-feedback UI is
+available only inside the tailnet at `https://buzz-admin.ide-newton.ts.net`.
 
 ## Ownership and immutable inputs
 
@@ -58,7 +59,7 @@ kubectl -n buzz get objectbucketclaim
 kubectl -n buzz get cluster.postgresql.cnpg.io,scheduledbackup.postgresql.cnpg.io,backup.postgresql.cnpg.io
 kubectl -n buzz get redis.redis.redis.opstreelabs.in
 kubectl -n buzz get deployment,pod -o wide
-kubectl -n buzz get ingress buzz
+kubectl -n buzz get ingress buzz buzz-admin
 ```
 
 Required state:
@@ -70,7 +71,7 @@ Required state:
 - `buzz-redis` is ready, accepts only authenticated commands, has AOF enabled, and reports
   `maxmemory=402653184` (384 MiB).
 - Two Buzz relay pods are Ready on different nodes.
-- The Tailscale Ingress has an assigned device and a valid tailnet TLS certificate.
+- Both Tailscale Ingresses have assigned devices and valid tailnet TLS certificates.
 
 Validate the relay from a tailnet-connected workstation:
 
@@ -78,12 +79,20 @@ Validate the relay from a tailnet-connected workstation:
 curl --fail --silent --show-error \
   --header 'Accept: application/nostr+json' \
   https://buzz.ide-newton.ts.net/
+curl --fail --silent --show-error \
+  --header 'Accept: text/html' \
+  https://buzz-admin.ide-newton.ts.net/
 ```
 
 Use a Nostr client that supports NIP-42 to confirm an unauthenticated request is challenged and the dedicated owner
 identity authenticates successfully. Verify `up{job="buzz-relay",namespace="buzz"}` and
 `redis_up{job="buzz-redis",namespace="buzz"}` in Mimir. The general `CloudNativePgWalArchiveBacklog` alert covers Buzz
 WAL archival; `BuzzPostgresBackupStale` covers the daily backup.
+
+The admin API is read-only and the relay serves it only when the request has the exact configured admin host and a
+same-origin browser request. The separate `buzz-admin` Tailscale Ingress and default-deny NetworkPolicy are the
+authentication boundary: do not expose this hostname through a public ingress or relax the Tailscale proxy selector.
+The normal relay hostname must continue returning NIP-11 metadata instead of the admin SPA.
 
 ## Backup and restore proof
 

--- a/packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts
+++ b/packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts
@@ -121,6 +121,24 @@ describe('Buzz production GitOps contract', () => {
     expect(networkPolicy).toContain('port: 8000')
   })
 
+  test('exposes the read-only admin UI only through its dedicated Tailscale host', () => {
+    const values = buzzFile('values.yaml')
+    const kustomization = buzzFile('kustomization.yaml')
+    const ingress = buzzFile('admin-ingress.yaml')
+    const networkPolicy = buzzFile('networkpolicy.yaml')
+
+    expect(values).toContain('name: BUZZ_ADMIN_HOST\n      value: buzz-admin.ide-newton.ts.net')
+    expect(values).toContain('name: BUZZ_ADMIN_WEB_DIR\n      value: /srv/buzz/admin-web')
+    expect(kustomization).toContain('- admin-ingress.yaml')
+    expect(ingress).toContain('name: buzz-admin')
+    expect(ingress).toContain('ingressClassName: tailscale')
+    expect(ingress).toContain('tailscale.com/tags: tag:k8s')
+    expect(ingress.match(/buzz-admin\.ide-newton\.ts\.net/g)).toHaveLength(2)
+    expect(ingress).toContain('name: buzz')
+    expect(ingress).toContain('number: 3000')
+    expect(networkPolicy).toContain('tailscale.com/parent-resource: buzz-admin')
+  })
+
   test('keeps credentials out of Git and combines generated credentials through External Secrets', () => {
     const runtime = buzzFile('redis-auth-externalsecret.yaml')
     const aggregate = buzzFile('buzz-externalsecret.yaml')


### PR DESCRIPTION
## Summary

- enable Buzz's bundled read-only admin SPA only for `buzz-admin.ide-newton.ts.net`
- add a dedicated Tailscale Ingress and restrict relay access to the matching Tailscale proxy
- document the security boundary and enforce the production contract with focused tests

## Related Issues

None.

## Testing

- `bun test packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts`
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts argocd/applications/buzz/values.yaml argocd/applications/buzz/kustomization.yaml argocd/applications/buzz/networkpolicy.yaml argocd/applications/buzz/admin-ingress.yaml docs/runbooks/buzz-production.md`
- `bun run lint:argocd`
- pinned Helm 3.19.1/Kustomize 5.8.0 render piped to `kubectl apply -n buzz --server-side --dry-run=server --field-manager=argocd-controller -f -`
- confirmed `/srv/buzz/admin-web/index.html` exists in the running digest-pinned relay image

## Screenshots (if applicable)

N/A — GitOps infrastructure change; the live tailnet endpoint will be verified after merge and Argo reconciliation.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
