### PR TITLE
feat(bayn): bind paper intents to authority generations

### DIFF
--- a/services/bayn/migrations/0016_authority_bound_intents.ts
+++ b/services/bayn/migrations/0016_authority_bound_intents.ts
@@ -1,0 +1,30 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient
+
+  yield* sql`
+    DO $migration$
+    BEGIN
+      IF EXISTS (SELECT 1 FROM intents) OR EXISTS (SELECT 1 FROM risk_decisions) THEN
+        RAISE EXCEPTION 'authority-bound intent hard cut requires empty intents and risk_decisions'
+          USING ERRCODE = '55000';
+      END IF;
+    END
+    $migration$
+  `
+
+  yield* sql`
+    ALTER TABLE intents
+      DROP CONSTRAINT intents_schema_version_check,
+      ADD COLUMN authority_generation_hash text NOT NULL CHECK (
+        authority_generation_hash ~ '^[0-9a-f]{64}$'
+      ),
+      ADD CONSTRAINT intents_schema_version_check CHECK (schema_version = 'bayn.paper-intent.v3'),
+      ADD CONSTRAINT intents_authority_generation_fk
+        FOREIGN KEY (authority_generation_hash)
+        REFERENCES authority_generations(generation_hash)
+        ON DELETE RESTRICT
+  `
+})

--- a/services/bayn/src/broker/alpaca-mutations.test.ts
+++ b/services/bayn/src/broker/alpaca-mutations.test.ts
@@ -43,8 +43,9 @@ const options: MutationOptions = {
 }
 
 const intent: Intent = {
-  schemaVersion: 'bayn.paper-intent.v2',
+  schemaVersion: 'bayn.paper-intent.v3',
   intentId: 'a'.repeat(64),
+  authorityGenerationHash: 'f'.repeat(64),
   riskDecisionId: 'b'.repeat(64),
   strategyName: 'risk-balanced-trend',
   cycleId: 'c'.repeat(64),

--- a/services/bayn/src/db/cycle-observability.integration.test.ts
+++ b/services/bayn/src/db/cycle-observability.integration.test.ts
@@ -133,13 +133,14 @@ const seedUnresolvedMutation = (mutationAccountId = accountId) =>
     const intentId = '2'.repeat(64)
     yield* sql`
     INSERT INTO intents (
-      intent_id, schema_version, risk_decision_id, strategy_name, cycle_id,
+      intent_id, schema_version, authority_generation_hash, risk_decision_id, strategy_name, cycle_id,
       decision_hash, policy_hash, account_id, client_order_id,
       symbol, side, order_type, time_in_force, quantity_micros, notional_limit_micros,
       state, terminal_outcome, state_version, created_at, updated_at
     ) VALUES (
       ${intentId},
-      'bayn.paper-intent.v2',
+      'bayn.paper-intent.v3',
+      ${'f'.repeat(64)},
       NULL,
       'risk-balanced-trend',
       ${'8'.repeat(64)},
@@ -216,13 +217,14 @@ const seedTerminalCanceledMutation = Effect.gen(function* () {
   const intentId = '2'.repeat(64)
   yield* sql`
     INSERT INTO intents (
-      intent_id, schema_version, risk_decision_id, strategy_name, cycle_id,
+      intent_id, schema_version, authority_generation_hash, risk_decision_id, strategy_name, cycle_id,
       decision_hash, policy_hash, account_id, client_order_id,
       symbol, side, order_type, time_in_force, quantity_micros, notional_limit_micros,
       state, terminal_outcome, state_version, created_at, updated_at
     ) VALUES (
       ${intentId},
-      'bayn.paper-intent.v2',
+      'bayn.paper-intent.v3',
+      ${'f'.repeat(64)},
       NULL,
       'risk-balanced-trend',
       ${'8'.repeat(64)},

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -8,7 +8,7 @@ import authorityBoundIntents from '../../migrations/0016_authority_bound_intents
 import type { RuntimeConfig } from '../config'
 import { makeStrategyProtocolHash } from '../contracts'
 import { IntentStore, IntentStoreLive, planPaperIntent, type IntentPlan } from '../execution/intents'
-import { MutationEventType, MutationStore, MutationStoreLive } from '../execution/mutations'
+import { MutationEventType, MutationStore, MutationStoreLive, mutationId } from '../execution/mutations'
 import {
   BrokerMutation,
   MutationOperation,
@@ -32,6 +32,7 @@ import {
   TimeInForce,
   type Intent,
   type PaperAuthorityGeneration,
+  type RiskDecision,
 } from '../paper'
 import { makeQualificationLock, makeQualificationPolicyDocument, makeQualificationResult } from '../qualification'
 import {
@@ -160,7 +161,7 @@ const intentPlan = (overrides: Partial<IntentPlan> = {}): IntentPlan => ({
   strategyName: 'risk-balanced-trend',
   cycleId: 'a'.repeat(64),
   decisionHash: 'b'.repeat(64),
-  policyHash: 'c'.repeat(64),
+  policyHash: fixtureHash('mutation-risk-policy'),
   accountId: 'paper-account-1',
   symbol: 'NVDA',
   side: OrderSide.Buy,
@@ -209,6 +210,7 @@ const paperIntentEvidence = Effect.gen(function* () {
     authority: unknown
     history: unknown
     intents: unknown
+    mutation_events: unknown
     risk_decisions: unknown
   }>`
     SELECT
@@ -233,6 +235,13 @@ const paperIntentEvidence = Effect.gen(function* () {
       ) AS intents,
       (
         SELECT jsonb_agg(
+          jsonb_build_object('row', to_jsonb(event), 'tupleId', event.xmin::text)
+          ORDER BY event.event_id
+        )
+        FROM mutation_events AS event
+      ) AS mutation_events,
+      (
+        SELECT jsonb_agg(
           jsonb_build_object('row', to_jsonb(decision), 'tupleId', decision.xmin::text)
           ORDER BY decision.decision_id
         )
@@ -243,6 +252,93 @@ const paperIntentEvidence = Effect.gen(function* () {
   if (evidence === undefined) return yield* Effect.die(new Error('paper intent evidence query returned no row'))
   return evidence
 })
+
+const seedApprovedIntent = (intent: Intent, decision: RiskDecision) =>
+  Effect.gen(function* () {
+    const sql = yield* PgClient.PgClient
+    yield* sql.withTransaction(
+      Effect.gen(function* () {
+        yield* sql`
+          INSERT INTO intents (
+            intent_id, schema_version, authority_generation_hash, strategy_name, cycle_id,
+            decision_hash, policy_hash, account_id, client_order_id, symbol, side, order_type,
+            time_in_force, quantity_micros, notional_limit_micros, state, created_at, updated_at
+          ) VALUES (
+            ${intent.intentId}, ${intent.schemaVersion}, ${intent.authorityGenerationHash},
+            ${intent.strategyName}, ${intent.cycleId}, ${intent.decisionHash}, ${intent.policyHash},
+            ${intent.accountId}, ${intent.clientOrderId}, ${intent.symbol}, ${intent.side},
+            ${intent.orderType}, ${intent.timeInForce}, ${intent.quantityMicros},
+            ${intent.notionalLimitMicros}, ${intent.state}, ${intent.createdAt}, ${intent.createdAt}
+          )
+        `
+        yield* sql`
+          INSERT INTO risk_decisions (
+            decision_id, schema_version, input_hash, intent_id, policy_hash, outcome,
+            reason_codes, decided_at, expires_at
+          ) VALUES (
+            ${decision.decisionId}, ${decision.schemaVersion}, ${decision.inputHash},
+            ${decision.intentId}, ${decision.policyHash}, ${decision.outcome},
+            ${decision.reasonCodes}, ${decision.decidedAt}, ${decision.expiresAt}
+          )
+        `
+        yield* sql`
+          UPDATE intents
+          SET
+            risk_decision_id = ${decision.decisionId},
+            state = ${IntentState.Approved},
+            state_version = 2,
+            updated_at = ${decision.decidedAt}
+          WHERE intent_id = ${intent.intentId}
+        `
+      }),
+    )
+  })
+
+const seedAcceptedSubmit = (intent: Intent, decision: RiskDecision, fixture: string) =>
+  Effect.gen(function* () {
+    const sql = yield* PgClient.PgClient
+    const requestHash = fixtureHash(`${fixture}-request`)
+    const startedAt = new Date(Date.parse(decision.decidedAt) + 1).toISOString()
+    const acceptedAt = new Date(Date.parse(decision.decidedAt) + 2).toISOString()
+    yield* sql.withTransaction(
+      Effect.gen(function* () {
+        yield* sql`
+          INSERT INTO mutation_events (
+            event_id, schema_version, mutation_id, intent_id, sequence, operation,
+            event_type, request_hash, consistency_delay_ms, broker_order_id,
+            request_id, response_status, response_content_hash, occurred_at
+          ) VALUES (
+            ${fixtureHash(`${fixture}-started`)}, 'bayn.paper-mutation-event.v1',
+            ${mutationId(intent.intentId, MutationOperation.Submit)}, ${intent.intentId},
+            1, 'SUBMIT', 'SUBMIT_STARTED', ${requestHash}, 1000, NULL,
+            NULL, NULL, NULL, ${startedAt}
+          )
+        `
+        yield* sql`
+          UPDATE intents
+          SET state = 'IO_STARTED', state_version = 3, updated_at = ${startedAt}
+          WHERE intent_id = ${intent.intentId}
+        `
+        yield* sql`
+          INSERT INTO mutation_events (
+            event_id, schema_version, mutation_id, intent_id, sequence, operation,
+            event_type, request_hash, consistency_delay_ms, broker_order_id,
+            request_id, response_status, response_content_hash, occurred_at
+          ) VALUES (
+            ${fixtureHash(`${fixture}-accepted`)}, 'bayn.paper-mutation-event.v1',
+            ${mutationId(intent.intentId, MutationOperation.Submit)}, ${intent.intentId},
+            2, 'SUBMIT', 'SUBMIT_ACCEPTED', ${requestHash}, 1000, ${orderId},
+            ${`${fixture}-request-id`}, 200, ${fixtureHash(`${fixture}-response`)}, ${acceptedAt}
+          )
+        `
+        yield* sql`
+          UPDATE intents
+          SET state = 'ACKNOWLEDGED', state_version = 4, updated_at = ${acceptedAt}
+          WHERE intent_id = ${intent.intentId}
+        `
+      }),
+    )
+  })
 
 const riskBalancedTrendSnapshot = makeSnapshot(800)
 
@@ -1064,7 +1160,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       expect(Exit.isFailure(observed.staleCommit)).toBe(true)
       if (Exit.isFailure(observed.staleCommit)) {
         expect(Cause.pretty(observed.staleCommit.cause)).toContain(
-          'PAPER intent does not match the current immutable authority-generation account binding',
+          'PAPER intent does not match the current immutable authority-generation bindings',
         )
       }
       expect(observed.afterFailure).toEqual(observed.before)
@@ -1126,6 +1222,55 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     }
   })
 
+  test('rejects first-commit policy or strategy drift from the current authority generation without writes', async () => {
+    const generation = await activateAuditedPaperAuthority()
+    const variants = await Effect.runPromise(
+      Effect.forEach(
+        [
+          intentPlan({
+            cycleId: fixtureHash('generation-policy-drift-cycle'),
+            policyHash: fixtureHash('unbound-risk-policy'),
+          }),
+          intentPlan({
+            cycleId: fixtureHash('generation-strategy-drift-cycle'),
+            strategyName: 'unbound-strategy',
+          }),
+        ],
+        (input) =>
+          planForGeneration(input, generation.generationHash).pipe(
+            Effect.flatMap((intent) =>
+              riskDecision(intent, RiskOutcome.Approved).pipe(Effect.map((decision) => ({ decision, intent }))),
+            ),
+          ),
+      ),
+    )
+    const execution = makeExecutionRuntime()
+    try {
+      for (const variant of variants) {
+        const observed = await execution.runPromise(
+          Effect.gen(function* () {
+            const before = yield* paperIntentEvidence
+            const commit = yield* Effect.exit(
+              Effect.flatMap(IntentStore, (store) => store.commit(variant.intent, variant.decision)),
+            )
+            const after = yield* paperIntentEvidence
+            return { after, before, commit }
+          }),
+        )
+
+        expect(Exit.isFailure(observed.commit)).toBe(true)
+        if (Exit.isFailure(observed.commit)) {
+          expect(Cause.pretty(observed.commit.cause)).toContain(
+            'PAPER intent does not match the current immutable authority-generation bindings',
+          )
+        }
+        expect(observed.after).toEqual(observed.before)
+      }
+    } finally {
+      await execution.dispose()
+    }
+  })
+
   test('rejects an intent whose generation history binds a different account without writing', async () => {
     await activateAuditedPaperAuthority()
     const intent = await Effect.runPromise(
@@ -1155,7 +1300,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       expect(Exit.isFailure(observed.commit)).toBe(true)
       if (Exit.isFailure(observed.commit)) {
         expect(Cause.pretty(observed.commit.cause)).toContain(
-          'PAPER intent does not match the current immutable authority-generation account binding',
+          'PAPER intent does not match the current immutable authority-generation bindings',
         )
       }
       expect(observed.after).toEqual(observed.before)
@@ -2213,6 +2358,100 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     expect(intent.authorityGenerationHash).toBe(originalGeneration.generationHash)
     expect(observed.state).toEqual({ state: 'TERMINAL', state_version: 5 })
   }, 20_000)
+
+  test('rejects intent policy or strategy drift before submit, identified cancel, or broker writes', async () => {
+    const generation = await activateAuditedPaperAuthority()
+    const now = Date.now()
+    const createdAt = new Date(now - 2_000).toISOString()
+    const decidedAt = new Date(now - 1_000).toISOString()
+    const expiresAt = new Date(now + 60_000).toISOString()
+    const variants = await Effect.runPromise(
+      Effect.forEach(
+        [
+          intentPlan({
+            createdAt,
+            cycleId: fixtureHash('mutation-generation-policy-drift-cycle'),
+            policyHash: fixtureHash('mutation-unbound-risk-policy'),
+          }),
+          intentPlan({
+            createdAt,
+            cycleId: fixtureHash('mutation-generation-strategy-drift-cycle'),
+            strategyName: 'mutation-unbound-strategy',
+          }),
+        ],
+        (input) =>
+          planForGeneration(input, generation.generationHash).pipe(
+            Effect.flatMap((intent) =>
+              riskDecision(intent, RiskOutcome.Approved, { decidedAt, expiresAt }).pipe(
+                Effect.map((decision) => ({ decision, intent })),
+              ),
+            ),
+          ),
+      ),
+    )
+    await runtime.runPromise(Effect.forEach(variants, ({ decision, intent }) => seedApprovedIntent(intent, decision)))
+
+    const brokerCalls = { cancel: 0, submit: 0 }
+    const coordinator = makeCoordinatorRuntime({
+      submit: () => {
+        brokerCalls.submit += 1
+        return Effect.die(new Error('generation-binding failure must not reach the broker'))
+      },
+      cancel: () => {
+        brokerCalls.cancel += 1
+        return Effect.die(new Error('generation-binding failure must not reach the broker'))
+      },
+    })
+    try {
+      for (const variant of variants) {
+        const observed = await coordinator.runPromise(
+          Effect.gen(function* () {
+            const before = yield* paperIntentEvidence
+            const submission = yield* Effect.exit(submit(variant.intent.intentId, 1_000))
+            const after = yield* paperIntentEvidence
+            return { after, before, submission }
+          }),
+        )
+
+        expect(Exit.isFailure(observed.submission)).toBe(true)
+        if (Exit.isFailure(observed.submission)) {
+          expect(Cause.pretty(observed.submission.cause)).toContain(
+            'intent does not match its immutable PAPER authority-generation bindings',
+          )
+        }
+        expect(observed.after).toEqual(observed.before)
+      }
+
+      const cancelVariant = variants[0]
+      if (cancelVariant === undefined) throw new Error('policy-drift cancel fixture is missing')
+      await runtime.runPromise(
+        seedAcceptedSubmit(
+          cancelVariant.intent,
+          cancelVariant.decision,
+          'mutation-generation-policy-drift-identified-submit',
+        ),
+      )
+      const cancelObserved = await coordinator.runPromise(
+        Effect.gen(function* () {
+          const before = yield* paperIntentEvidence
+          const cancellation = yield* Effect.exit(cancel(cancelVariant.intent.intentId, 1_000))
+          const after = yield* paperIntentEvidence
+          return { after, before, cancellation }
+        }),
+      )
+
+      expect(Exit.isFailure(cancelObserved.cancellation)).toBe(true)
+      if (Exit.isFailure(cancelObserved.cancellation)) {
+        expect(Cause.pretty(cancelObserved.cancellation.cause)).toContain(
+          'intent does not match its immutable PAPER authority-generation bindings',
+        )
+      }
+      expect(cancelObserved.after).toEqual(cancelObserved.before)
+      expect(brokerCalls).toEqual({ cancel: 0, submit: 0 })
+    } finally {
+      await coordinator.dispose()
+    }
+  })
 
   test('rejects a same-account historical generation before submit or broker writes', async () => {
     const originalGeneration = await activateAuditedPaperAuthority()

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -4,10 +4,11 @@ import { NodeServices } from '@effect/platform-node'
 import { PgClient } from '@effect/sql-pg'
 import { Cause, Deferred, Duration, Effect, Exit, Fiber, Layer, ManagedRuntime, Option, Redacted } from 'effect'
 
+import authorityBoundIntents from '../../migrations/0016_authority_bound_intents'
 import type { RuntimeConfig } from '../config'
 import { makeStrategyProtocolHash } from '../contracts'
-import { IntentStore, IntentStoreLive, plan, type IntentPlan } from '../execution/intents'
-import { MutationEventType, MutationStore, MutationStoreLive, mutationId } from '../execution/mutations'
+import { IntentStore, IntentStoreLive, planPaperIntent, type IntentPlan } from '../execution/intents'
+import { MutationEventType, MutationStore, MutationStoreLive } from '../execution/mutations'
 import {
   BrokerMutation,
   MutationOperation,
@@ -21,6 +22,8 @@ import { buildLedgerPlan, Journal, type JournalService } from '../ledger'
 import {
   Authority,
   decodeRiskDecision,
+  IntentState,
+  KillState,
   makePaperAuthorityGeneration,
   OrderSide,
   OrderType,
@@ -200,6 +203,47 @@ const sqlIntentState = (intentId: string) =>
     return rows[0]
   })
 
+const paperIntentEvidence = Effect.gen(function* () {
+  const sql = yield* PgClient.PgClient
+  const rows = yield* sql<{
+    authority: unknown
+    history: unknown
+    intents: unknown
+    risk_decisions: unknown
+  }>`
+    SELECT
+      (
+        SELECT jsonb_build_object('row', to_jsonb(authority), 'tupleId', authority.xmin::text)
+        FROM authority_state AS authority
+        WHERE authority.singleton
+      ) AS authority,
+      (
+        SELECT jsonb_agg(
+          jsonb_build_object('row', to_jsonb(history), 'tupleId', history.xmin::text)
+          ORDER BY history.authority_version
+        )
+        FROM authority_generations AS history
+      ) AS history,
+      (
+        SELECT jsonb_agg(
+          jsonb_build_object('row', to_jsonb(intent), 'tupleId', intent.xmin::text)
+          ORDER BY intent.intent_id
+        )
+        FROM intents AS intent
+      ) AS intents,
+      (
+        SELECT jsonb_agg(
+          jsonb_build_object('row', to_jsonb(decision), 'tupleId', decision.xmin::text)
+          ORDER BY decision.decision_id
+        )
+        FROM risk_decisions AS decision
+      ) AS risk_decisions
+  `
+  const evidence = rows[0]
+  if (evidence === undefined) return yield* Effect.die(new Error('paper intent evidence query returned no row'))
+  return evidence
+})
+
 const riskBalancedTrendSnapshot = makeSnapshot(800)
 
 const makeInput = (
@@ -349,6 +393,7 @@ const makeMutationPaperAuthorityGeneration = (
   previousGenerationHash: string,
   reconciliationId: string,
   reconciliationContentHash: string,
+  accountId = 'paper-account-1',
 ) => {
   if (mutationQualificationResult.verdict !== 'QUALIFIED') {
     throw new Error('audited mutation fixture requires QUALIFIED evidence')
@@ -379,13 +424,37 @@ const makeMutationPaperAuthorityGeneration = (
     strategyBehaviorHash: strategy.behaviorHash,
     strategyParameterHash: strategy.parameterHash,
     strategyParameterSchemaVersion,
-    accountId: 'paper-account-1',
+    accountId,
     riskPolicyHash: fixtureHash('mutation-risk-policy'),
     proofPlanHash: fixtureHash('mutation-proof-plan'),
     reconciliationId,
     reconciliationContentHash,
   })
 }
+
+const mutationObserveGenerationHash = fixtureHash('mutation-observe-authority-generation')
+const mutationReconciliationId = fixtureHash('mutation-authority-reconciliation')
+const mutationReconciliationContentHash = fixtureHash('mutation-authority-reconciliation-content')
+const mutationPaperActivation = () =>
+  makeMutationPaperAuthorityGeneration(
+    mutationObserveGenerationHash,
+    mutationReconciliationId,
+    mutationReconciliationContentHash,
+  )
+const planForGeneration = (input: IntentPlan, generationHash: string) => {
+  return planPaperIntent(input, {
+    authority: {
+      schemaVersion: 'bayn.paper-authority.v1',
+      generationHash,
+      maximum: Authority.Paper,
+      effective: Authority.Paper,
+      kill: KillState.Clear,
+      version: 2,
+      updatedAt: '2026-07-22T10:00:00.000Z',
+    },
+  })
+}
+const plan = (input: IntentPlan) => planForGeneration(input, mutationPaperActivation().generationHash)
 
 const proofBinding = (activation: PaperAuthorityGeneration) => ({
   schemaVersion: 'bayn.paper-authority-proof-binding.v1' as const,
@@ -417,14 +486,7 @@ const makePaperActivationConfig = (activation: PaperAuthorityGeneration): Runtim
 }
 
 const activateAuditedPaperAuthority = async () => {
-  const observeGenerationHash = fixtureHash('mutation-observe-authority-generation')
-  const reconciliationId = fixtureHash('mutation-authority-reconciliation')
-  const reconciliationContentHash = fixtureHash('mutation-authority-reconciliation-content')
-  const activation = makeMutationPaperAuthorityGeneration(
-    observeGenerationHash,
-    reconciliationId,
-    reconciliationContentHash,
-  )
+  const activation = mutationPaperActivation()
   const config = makePaperActivationConfig(activation)
   const strategy = mutationQualificationProvenance.strategy
   const paperRuntime = makePaperStoreRuntime(config)
@@ -528,13 +590,13 @@ const activateAuditedPaperAuthority = async () => {
             reconciliation_id, schema_version, account_id, expected_hash, observed_hash,
             content_hash, status, discrepancies, reconciled_at
           ) VALUES (
-            ${reconciliationId}, 'bayn.paper-reconciliation.v1', 'paper-account-1',
-            ${accountStateHash}, ${accountStateHash}, ${reconciliationContentHash},
+            ${mutationReconciliationId}, 'bayn.paper-reconciliation.v1', 'paper-account-1',
+            ${accountStateHash}, ${accountStateHash}, ${mutationReconciliationContentHash},
             'EXACT', ${sql.json(JSON.stringify([]))}, clock_timestamp()
           )
         `
         yield* store.ensureAuthorityGeneration({
-          generationHash: observeGenerationHash,
+          generationHash: mutationObserveGenerationHash,
           maximum: Authority.Observe,
         })
         yield* store.activatePaperGeneration(proofBinding(activation))
@@ -543,6 +605,77 @@ const activateAuditedPaperAuthority = async () => {
   } finally {
     await paperRuntime.dispose()
   }
+  return activation
+}
+
+const rotateAuditedPaperAuthority = (
+  accountId: string,
+  options: { readonly activateKill?: boolean; readonly reason?: string } = {},
+) => {
+  const previousGeneration = mutationPaperActivation()
+  const observeGenerationHash = fixtureHash(
+    `canonical-rotation-observe-${previousGeneration.generationHash}-${accountId}-${options.activateKill === true}`,
+  )
+  const reconciliationId = fixtureHash(`canonical-rotation-reconciliation-${observeGenerationHash}-${accountId}`)
+  const reconciliationContentHash = fixtureHash(
+    `canonical-rotation-reconciliation-content-${observeGenerationHash}-${accountId}`,
+  )
+  const reconciliationStateHash = fixtureHash(
+    `canonical-rotation-reconciliation-state-${observeGenerationHash}-${accountId}`,
+  )
+  const paperGeneration = makeMutationPaperAuthorityGeneration(
+    observeGenerationHash,
+    reconciliationId,
+    reconciliationContentHash,
+    accountId,
+  )
+  const paperRuntime = makePaperStoreRuntime(makePaperActivationConfig(paperGeneration))
+  return paperRuntime
+    .runPromise(
+      Effect.gen(function* () {
+        const store = yield* PaperStore
+        const sql = yield* PgClient.PgClient
+        if (options.activateKill === true) {
+          const [databaseTime] = yield* sql<{ updated_at: Date }>`
+            SELECT greatest(
+              clock_timestamp(),
+              updated_at + interval '1 millisecond'
+            ) AS updated_at
+            FROM authority_state
+            WHERE singleton
+          `
+          if (databaseTime === undefined) {
+            return yield* Effect.die(new Error('rotation fixture requires initialized authority'))
+          }
+          yield* store.restrictAuthority(
+            options.reason ?? 'authority rotation fixture kill',
+            databaseTime.updated_at.toISOString(),
+          )
+        }
+        yield* store.ensureAuthorityGeneration({
+          generationHash: observeGenerationHash,
+          maximum: Authority.Observe,
+        })
+        yield* sql`
+          INSERT INTO reconciliations (
+            reconciliation_id, schema_version, account_id, expected_hash, observed_hash,
+            content_hash, status, discrepancies, reconciled_at
+          ) VALUES (
+            ${reconciliationId}, 'bayn.paper-reconciliation.v1', ${accountId},
+            ${reconciliationStateHash}, ${reconciliationStateHash}, ${reconciliationContentHash},
+            'EXACT', ${sql.json(JSON.stringify([]))}, clock_timestamp()
+          )
+        `
+        const activated = yield* store.activatePaperGeneration(proofBinding(paperGeneration))
+        return {
+          generationHash: activated.generationHash,
+          accountId,
+          kill: activated.kill,
+          version: activated.version,
+        }
+      }),
+    )
+    .finally(() => paperRuntime.dispose())
 }
 
 describePostgres('PostgreSQL evaluation evidence', () => {
@@ -647,10 +780,99 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       { migration_id: 13, name: 'autonomous_cycle_terminal_transitions' },
       { migration_id: 14, name: 'authority_generation_history' },
       { migration_id: 15, name: 'acknowledged_submit_recovery' },
+      { migration_id: 16, name: 'authority_bound_intents' },
     ])
   })
 
+  test('hard-fails the authority-bound intent migration before touching nonempty intent history', async () => {
+    const observed = await runtime.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* PgClient.PgClient
+        const authorityGenerationHash = fixtureHash('hard-cut-authority-generation')
+        const intentId = fixtureHash('hard-cut-intent')
+        const decisionId = fixtureHash('hard-cut-decision')
+        yield* sql`
+          INSERT INTO authority_generations (
+            generation_hash, schema_version, previous_generation_hash, maximum,
+            authority_version, activated_at
+          ) VALUES (
+            ${authorityGenerationHash}, 'bayn.authority-generation-history.v1', NULL,
+            'OBSERVE', 1, '2026-07-22T06:00:00.000Z'
+          )
+        `
+        yield* sql.withTransaction(
+          Effect.gen(function* () {
+            yield* sql`
+              INSERT INTO intents (
+                intent_id, schema_version, authority_generation_hash, strategy_name, cycle_id,
+                decision_hash, policy_hash, account_id, client_order_id, symbol, side, order_type,
+                time_in_force, quantity_micros, notional_limit_micros, state, created_at, updated_at
+              ) VALUES (
+                ${intentId}, 'bayn.paper-intent.v3', ${authorityGenerationHash}, 'risk-balanced-trend',
+                ${fixtureHash('hard-cut-cycle')}, ${fixtureHash('hard-cut-strategy-decision')},
+                ${fixtureHash('hard-cut-policy')}, 'paper-account-1', 'hard-cut-order',
+                'NVDA', 'BUY', 'MARKET', 'DAY', 1000000, 200000000, 'PLANNED',
+                '2026-07-22T06:00:00.000Z', '2026-07-22T06:00:00.000Z'
+              )
+            `
+            yield* sql`
+              INSERT INTO risk_decisions (
+                decision_id, schema_version, input_hash, intent_id, policy_hash, outcome,
+                reason_codes, decided_at, expires_at
+              ) VALUES (
+                ${decisionId}, 'bayn.paper-risk-decision.v1', ${fixtureHash('hard-cut-risk-input')},
+                ${intentId}, ${fixtureHash('hard-cut-policy')}, 'BLOCKED', ARRAY['KILL_ACTIVE'],
+                '2026-07-22T06:00:00.001Z', '2099-01-01T00:00:00.000Z'
+              )
+            `
+            yield* sql`
+              UPDATE intents
+              SET
+                risk_decision_id = ${decisionId},
+                state = 'TERMINAL',
+                terminal_outcome = 'BLOCKED',
+                state_version = 2,
+                updated_at = '2026-07-22T06:00:00.002Z'
+              WHERE intent_id = ${intentId}
+            `
+          }),
+        )
+        const readEvidence = () =>
+          sql<{ intents: unknown; risk_decisions: unknown }>`
+            SELECT
+              (
+                SELECT jsonb_agg(
+                  jsonb_build_object('row', to_jsonb(intent), 'tupleId', intent.xmin::text)
+                  ORDER BY intent.intent_id
+                )
+                FROM intents AS intent
+              ) AS intents,
+              (
+                SELECT jsonb_agg(
+                  jsonb_build_object('row', to_jsonb(decision), 'tupleId', decision.xmin::text)
+                  ORDER BY decision.decision_id
+                )
+                FROM risk_decisions AS decision
+              ) AS risk_decisions
+          `
+        const before = yield* readEvidence()
+        const migration = yield* Effect.exit(authorityBoundIntents)
+        const after = yield* readEvidence()
+        return { after, before, migration }
+      }),
+    )
+
+    expect(Exit.isFailure(observed.migration)).toBe(true)
+    if (Exit.isFailure(observed.migration)) {
+      expect(Cause.pretty(observed.migration.cause)).toContain(
+        'authority-bound intent hard cut requires empty intents and risk_decisions',
+      )
+    }
+    expect(observed.after).toEqual(observed.before)
+  })
+
   test('atomically commits one deterministic approved intent under one writer fence', async () => {
+    await activateAuditedPaperAuthority()
     const execution = makeExecutionRuntime()
     const secondOwner = makeExecutionRuntime()
     const intent = await Effect.runPromise(plan(intentPlan()))
@@ -746,6 +968,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
   })
 
   test('atomically blocks rejected risk and rejects divergent deterministic reuse', async () => {
+    await activateAuditedPaperAuthority()
     const execution = makeExecutionRuntime()
     const input = intentPlan({ cycleId: 'e'.repeat(64) })
     const intent = await Effect.runPromise(plan(input))
@@ -803,7 +1026,147 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     expect(observed.counts).toEqual({ decisions: 1, intents: 1 })
   })
 
+  test('rejects a stale generation before its first commit and accepts the same target on the current generation', async () => {
+    const originalGeneration = await activateAuditedPaperAuthority()
+    const input = intentPlan({ cycleId: fixtureHash('generation-race-cycle') })
+    const staleIntent = await Effect.runPromise(planForGeneration(input, originalGeneration.generationHash))
+    const staleDecision = await Effect.runPromise(riskDecision(staleIntent, RiskOutcome.Approved))
+
+    const rotated = await rotateAuditedPaperAuthority(staleIntent.accountId)
+    const currentIntent = await Effect.runPromise(planForGeneration(input, rotated.generationHash))
+    const currentDecision = await Effect.runPromise(riskDecision(currentIntent, RiskOutcome.Approved))
+    const execution = makeExecutionRuntime()
+    try {
+      const observed = await execution.runPromise(
+        Effect.gen(function* () {
+          const before = yield* paperIntentEvidence
+          const staleCommit = yield* Effect.exit(
+            Effect.flatMap(IntentStore, (store) => store.commit(staleIntent, staleDecision)),
+          )
+          const afterFailure = yield* paperIntentEvidence
+          const currentCommit = yield* Effect.flatMap(IntentStore, (store) =>
+            store.commit(currentIntent, currentDecision),
+          )
+          const afterCurrentCommit = yield* paperIntentEvidence
+          return { afterCurrentCommit, afterFailure, before, currentCommit, staleCommit }
+        }),
+      )
+
+      expect(rotated.generationHash).not.toBe(originalGeneration.generationHash)
+      expect(currentIntent.intentId).not.toBe(staleIntent.intentId)
+      expect(currentIntent).toMatchObject({
+        authorityGenerationHash: rotated.generationHash,
+        accountId: staleIntent.accountId,
+        cycleId: staleIntent.cycleId,
+        decisionHash: staleIntent.decisionHash,
+        symbol: staleIntent.symbol,
+      })
+      expect(Exit.isFailure(observed.staleCommit)).toBe(true)
+      if (Exit.isFailure(observed.staleCommit)) {
+        expect(Cause.pretty(observed.staleCommit.cause)).toContain(
+          'PAPER intent does not match the current immutable authority-generation account binding',
+        )
+      }
+      expect(observed.afterFailure).toEqual(observed.before)
+      expect(observed.currentCommit).toMatchObject({
+        deduplicated: false,
+        record: {
+          intent: {
+            authorityGenerationHash: rotated.generationHash,
+            intentId: currentIntent.intentId,
+            state: IntentState.Approved,
+          },
+        },
+      })
+      expect(observed.afterCurrentCommit.intents).not.toEqual(observed.before.intents)
+      expect(observed.afterCurrentCommit.risk_decisions).not.toEqual(observed.before.risk_decisions)
+      expect(observed.afterCurrentCommit.authority).toEqual(observed.before.authority)
+      expect(observed.afterCurrentCommit.history).toEqual(observed.before.history)
+    } finally {
+      await execution.dispose()
+    }
+  })
+
+  test('exactly replays an already committed intent without writes after authority rotates', async () => {
+    const originalGeneration = await activateAuditedPaperAuthority()
+    const input = intentPlan({ cycleId: fixtureHash('generation-replay-cycle') })
+    const intent = await Effect.runPromise(planForGeneration(input, originalGeneration.generationHash))
+    const decision = await Effect.runPromise(riskDecision(intent, RiskOutcome.Approved))
+    const initialRuntime = makeExecutionRuntime()
+    await initialRuntime.runPromise(Effect.flatMap(IntentStore, (store) => store.commit(intent, decision)))
+    await initialRuntime.dispose()
+
+    const rotated = await rotateAuditedPaperAuthority(intent.accountId)
+    const replayRuntime = makeExecutionRuntime()
+    try {
+      const observed = await replayRuntime.runPromise(
+        Effect.gen(function* () {
+          const before = yield* paperIntentEvidence
+          const replay = yield* Effect.flatMap(IntentStore, (store) => store.commit(intent, decision))
+          const after = yield* paperIntentEvidence
+          return { after, before, replay }
+        }),
+      )
+
+      expect(rotated.generationHash).not.toBe(originalGeneration.generationHash)
+      expect(intent.authorityGenerationHash).toBe(originalGeneration.generationHash)
+      expect(observed.replay).toMatchObject({
+        deduplicated: true,
+        record: {
+          intent: {
+            authorityGenerationHash: originalGeneration.generationHash,
+            intentId: intent.intentId,
+          },
+          decision: { decisionId: decision.decisionId },
+        },
+      })
+      expect(observed.after).toEqual(observed.before)
+    } finally {
+      await replayRuntime.dispose()
+    }
+  })
+
+  test('rejects an intent whose generation history binds a different account without writing', async () => {
+    await activateAuditedPaperAuthority()
+    const intent = await Effect.runPromise(
+      plan(intentPlan({ accountId: 'paper-account-2', cycleId: fixtureHash('wrong-generation-account-cycle') })),
+    )
+    const decision = await Effect.runPromise(riskDecision(intent, RiskOutcome.Approved))
+    const execution = makeExecutionRuntime()
+    try {
+      const observed = await execution.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* PgClient.PgClient
+          const before = yield* sql<{ decisions: number; intents: number }>`
+            SELECT
+              (SELECT count(*)::integer FROM intents) AS intents,
+              (SELECT count(*)::integer FROM risk_decisions) AS decisions
+          `
+          const commit = yield* Effect.exit(Effect.flatMap(IntentStore, (store) => store.commit(intent, decision)))
+          const after = yield* sql<{ decisions: number; intents: number }>`
+            SELECT
+              (SELECT count(*)::integer FROM intents) AS intents,
+              (SELECT count(*)::integer FROM risk_decisions) AS decisions
+          `
+          return { after: after[0], before: before[0], commit }
+        }),
+      )
+
+      expect(Exit.isFailure(observed.commit)).toBe(true)
+      if (Exit.isFailure(observed.commit)) {
+        expect(Cause.pretty(observed.commit.cause)).toContain(
+          'PAPER intent does not match the current immutable authority-generation account binding',
+        )
+      }
+      expect(observed.after).toEqual(observed.before)
+      expect(observed.after).toEqual({ decisions: 0, intents: 0 })
+    } finally {
+      await execution.dispose()
+    }
+  })
+
   test('rolls back both records when an approval is stale at commit', async () => {
+    await activateAuditedPaperAuthority()
     const execution = makeExecutionRuntime()
     const now = Date.now()
     const intent = await Effect.runPromise(
@@ -847,6 +1210,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
   })
 
   test('runs mutations on the lease session and rolls back when that session dies', async () => {
+    await activateAuditedPaperAuthority()
     const execution = makeExecutionRuntime()
     const nextOwner = makeExecutionRuntime()
     const blocker = makeClientRuntime()
@@ -896,10 +1260,9 @@ describePostgres('PostgreSQL evaluation evidence', () => {
                     return yield* sql<WaitingMutation>`
                       SELECT pid::integer, query
                       FROM pg_stat_activity
-                      WHERE pid <> pg_backend_pid()
+                      WHERE pid = ${backendPid}
                         AND datname = current_database()
                         AND wait_event_type = 'Lock'
-                        AND query ILIKE '%INSERT INTO intents%'
                     `
                   }),
                 ),
@@ -969,6 +1332,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
   })
 
   test('linearizes one submit and records its exact acknowledged outcome', async () => {
+    await activateAuditedPaperAuthority()
     const execution = makeExecutionRuntime()
     const intent = await Effect.runPromise(plan(intentPlan({ cycleId: '1'.repeat(64) })))
     const decision = await Effect.runPromise(riskDecision(intent, RiskOutcome.Approved))
@@ -978,8 +1342,6 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       }),
     )
     await execution.dispose()
-    await activateAuditedPaperAuthority()
-
     const mutation = makeMutationRuntime()
     const startedAt = new Date(Date.now() + 100).toISOString()
     const requestHash = '8'.repeat(64)
@@ -1026,6 +1388,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
   })
 
   test('linearizes accepted submit terminal recovery and replays without another durable write', async () => {
+    await activateAuditedPaperAuthority()
     const execution = makeExecutionRuntime()
     const intent = await Effect.runPromise(plan(intentPlan({ cycleId: '6'.repeat(64) })))
     const decision = await Effect.runPromise(riskDecision(intent, RiskOutcome.Approved))
@@ -1035,8 +1398,6 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       }),
     )
     await execution.dispose()
-    await activateAuditedPaperAuthority()
-
     const mutation = makeMutationRuntime()
     const requestHash = '5'.repeat(64)
     const base = Date.now() + 100
@@ -1113,6 +1474,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
   })
 
   test('keeps an accepted submit recoverable after a 404 with its exact broker order identity', async () => {
+    await activateAuditedPaperAuthority()
     const execution = makeExecutionRuntime()
     const intent = await Effect.runPromise(plan(intentPlan({ cycleId: '8'.repeat(64) })))
     const decision = await Effect.runPromise(riskDecision(intent, RiskOutcome.Approved))
@@ -1122,8 +1484,6 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       }),
     )
     await execution.dispose()
-    await activateAuditedPaperAuthority()
-
     const mutation = makeMutationRuntime()
     const requestHash = 'b'.repeat(64)
     const base = Date.now() + 100
@@ -1197,6 +1557,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
   })
 
   test('does not let terminal submit recovery overtake a durable cancellation', async () => {
+    await activateAuditedPaperAuthority()
     const execution = makeExecutionRuntime()
     const intent = await Effect.runPromise(plan(intentPlan({ cycleId: '9'.repeat(64) })))
     const decision = await Effect.runPromise(riskDecision(intent, RiskOutcome.Approved))
@@ -1206,7 +1567,6 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       }),
     )
     await execution.dispose()
-    await activateAuditedPaperAuthority()
 
     const mutation = makeMutationRuntime()
     const submitHash = '7'.repeat(64)
@@ -1299,6 +1659,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
   })
 
   test('retains acknowledged state for open recovery before a later exact terminal observation', async () => {
+    await activateAuditedPaperAuthority()
     const execution = makeExecutionRuntime()
     const intent = await Effect.runPromise(plan(intentPlan({ cycleId: '7'.repeat(64) })))
     const decision = await Effect.runPromise(riskDecision(intent, RiskOutcome.Approved))
@@ -1308,7 +1669,6 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       }),
     )
     await execution.dispose()
-    await activateAuditedPaperAuthority()
 
     const mutation = makeMutationRuntime()
     const requestHash = '2'.repeat(64)
@@ -1551,6 +1911,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
   }, 20_000)
 
   test('does not append a mutation start after its approved risk decision expires', async () => {
+    await activateAuditedPaperAuthority()
     const execution = makeExecutionRuntime()
     const intent = await Effect.runPromise(plan(intentPlan({ cycleId: '0'.repeat(64) })))
     const expiresAtMillis = Date.now() + 1_000
@@ -1563,7 +1924,6 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       }),
     )
     await execution.dispose()
-    await activateAuditedPaperAuthority()
     await Bun.sleep(Math.max(0, expiresAtMillis - Date.now() + 50))
 
     const mutation = makeMutationRuntime()
@@ -1594,6 +1954,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
   })
 
   test('keeps an ambiguous submit UNKNOWN until lookup recovers the exact broker order', async () => {
+    await activateAuditedPaperAuthority()
     const execution = makeExecutionRuntime()
     const intent = await Effect.runPromise(plan(intentPlan({ cycleId: '2'.repeat(64) })))
     const decision = await Effect.runPromise(riskDecision(intent, RiskOutcome.Approved))
@@ -1603,7 +1964,6 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       }),
     )
     await execution.dispose()
-    await activateAuditedPaperAuthority()
 
     const mutation = makeMutationRuntime()
     const requestHash = '6'.repeat(64)
@@ -1639,6 +1999,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
   })
 
   test('cancels an identified mismatched order while its submit remains UNKNOWN', async () => {
+    await activateAuditedPaperAuthority()
     const execution = makeExecutionRuntime()
     const intent = await Effect.runPromise(plan(intentPlan({ cycleId: '8'.repeat(64) })))
     const laterIntent = await Effect.runPromise(
@@ -1654,7 +2015,6 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       }),
     )
     await execution.dispose()
-    await activateAuditedPaperAuthority()
 
     const mutation = makeMutationRuntime()
     const submitHash = '6'.repeat(64)
@@ -1755,6 +2115,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
   })
 
   test('allows expired identified cancellation under an active kill while blocking new submission', async () => {
+    const originalGeneration = await activateAuditedPaperAuthority()
     const execution = makeExecutionRuntime()
     const intent = await Effect.runPromise(plan(intentPlan({ cycleId: '3'.repeat(64) })))
     const blockedIntent = await Effect.runPromise(plan(intentPlan({ cycleId: 'b'.repeat(64) })))
@@ -1771,13 +2132,12 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       }),
     )
     await execution.dispose()
-    await activateAuditedPaperAuthority()
 
     const mutation = makeMutationRuntime()
     const submitHash = '3'.repeat(64)
     const cancelHash = '2'.repeat(64)
-    const base = Date.now() + 100
-    const observed = await mutation.runPromise(
+    const base = Date.now()
+    await mutation.runPromise(
       Effect.gen(function* () {
         const store = yield* MutationStore
         yield* store.beginSubmit(intent.intentId, submitHash, 1_000, new Date(base).toISOString())
@@ -1787,14 +2147,21 @@ describePostgres('PostgreSQL evaluation evidence', () => {
           contentHash: '1'.repeat(64),
           observedAt: new Date(base + 1).toISOString(),
         })
-        const sql = yield* PgClient.PgClient
-        yield* sql`
-          UPDATE authority_state
-          SET effective = 'OBSERVE', kill_state = 'ACTIVE', reason = 'operator kill', version = 3,
-              updated_at = ${new Date(base + 2).toISOString()}
-          WHERE singleton
-        `
-        yield* sql`SELECT pg_sleep_until(${new Date(expiresAtMillis + 10).toISOString()}::timestamptz)`
+      }),
+    )
+    await mutation.dispose()
+    await Bun.sleep(5)
+
+    const rotated = await rotateAuditedPaperAuthority('paper-account-1', {
+      activateKill: true,
+      reason: 'operator kill',
+    })
+    await Bun.sleep(Math.max(0, expiresAtMillis - Date.now() + 10))
+
+    const cancellation = makeMutationRuntime()
+    const observed = await cancellation.runPromise(
+      Effect.gen(function* () {
+        const store = yield* MutationStore
         const blockedSubmit = yield* Effect.exit(
           store.beginSubmit(
             blockedIntent.intentId,
@@ -1828,7 +2195,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
         return { blockedSubmit, notFound, state: yield* sqlIntentState(intent.intentId) }
       }),
     )
-    await mutation.dispose()
+    await cancellation.dispose()
 
     expect(Exit.isFailure(observed.blockedSubmit)).toBe(true)
     if (Exit.isFailure(observed.blockedSubmit)) {
@@ -1838,17 +2205,101 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       eventType: MutationEventType.RecoveryNotFound,
       brokerOrderId: orderId,
     })
+    expect(rotated).toMatchObject({
+      accountId: intent.accountId,
+      kill: KillState.Active,
+    })
+    expect(rotated.generationHash).not.toBe(originalGeneration.generationHash)
+    expect(intent.authorityGenerationHash).toBe(originalGeneration.generationHash)
     expect(observed.state).toEqual({ state: 'TERMINAL', state_version: 5 })
   }, 20_000)
 
-  test('rejects mismatched-account submit and identified cancel without durable or broker writes', async () => {
-    const mismatchedAccountId = 'paper-account-2'
-    const submitIntent = await Effect.runPromise(
-      plan(intentPlan({ accountId: mismatchedAccountId, cycleId: 'c'.repeat(64) })),
-    )
-    const cancelIntent = await Effect.runPromise(
-      plan(intentPlan({ accountId: mismatchedAccountId, cycleId: 'd'.repeat(64) })),
-    )
+  test('rejects a same-account historical generation before submit or broker writes', async () => {
+    const originalGeneration = await activateAuditedPaperAuthority()
+    const intent = await Effect.runPromise(plan(intentPlan({ cycleId: fixtureHash('stale-generation-cycle') })))
+    const decision = await Effect.runPromise(riskDecision(intent, RiskOutcome.Approved))
+    const execution = makeExecutionRuntime()
+    await execution.runPromise(Effect.flatMap(IntentStore, (store) => store.commit(intent, decision)))
+    await execution.dispose()
+
+    const rotated = await rotateAuditedPaperAuthority(intent.accountId)
+
+    let brokerCalls = 0
+    const coordinator = makeCoordinatorRuntime({
+      submit: () => {
+        brokerCalls += 1
+        return Effect.die(new Error('historical-generation submit must not reach the broker'))
+      },
+      cancel: () => Effect.die(new Error('unexpected cancel')),
+    })
+    try {
+      const observed = await coordinator.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* PgClient.PgClient
+          const readEvidence = () =>
+            sql<{ evidence: unknown }>`
+              SELECT jsonb_build_object(
+                'intent',
+                (
+                  SELECT jsonb_build_object('row', to_jsonb(stored), 'tupleId', stored.xmin::text)
+                  FROM intents AS stored
+                  WHERE stored.intent_id = ${intent.intentId}
+                ),
+                'events',
+                (
+                  SELECT coalesce(
+                    jsonb_agg(
+                      jsonb_build_object('row', to_jsonb(event), 'tupleId', event.xmin::text)
+                      ORDER BY event.operation, event.sequence
+                    ),
+                    '[]'::jsonb
+                  )
+                  FROM mutation_events AS event
+                  WHERE event.intent_id = ${intent.intentId}
+                ),
+                'authority',
+                (
+                  SELECT jsonb_build_object('row', to_jsonb(authority), 'tupleId', authority.xmin::text)
+                  FROM authority_state AS authority
+                  WHERE authority.singleton
+                ),
+                'history',
+                (
+                  SELECT jsonb_agg(
+                    jsonb_build_object('row', to_jsonb(history), 'tupleId', history.xmin::text)
+                    ORDER BY history.authority_version
+                  )
+                  FROM authority_generations AS history
+                )
+              ) AS evidence
+            `
+          const before = yield* readEvidence()
+          const submitExit = yield* Effect.exit(submit(intent.intentId, 1_000))
+          const after = yield* readEvidence()
+          return { after, before, submitExit }
+        }),
+      )
+
+      expect(rotated.accountId).toBe(intent.accountId)
+      expect(rotated.generationHash).not.toBe(originalGeneration.generationHash)
+      expect(intent.authorityGenerationHash).toBe(originalGeneration.generationHash)
+      expect(Exit.isFailure(observed.submitExit)).toBe(true)
+      if (Exit.isFailure(observed.submitExit)) {
+        expect(Cause.pretty(observed.submitExit.cause)).toContain(
+          'intent authority generation is not the active PAPER generation',
+        )
+      }
+      expect(observed.after).toEqual(observed.before)
+      expect(brokerCalls).toBe(0)
+    } finally {
+      await coordinator.dispose()
+    }
+  })
+
+  test('rejects cross-account rotation before submit or identified cancel writes', async () => {
+    const originalGeneration = await activateAuditedPaperAuthority()
+    const submitIntent = await Effect.runPromise(plan(intentPlan({ cycleId: 'c'.repeat(64) })))
+    const cancelIntent = await Effect.runPromise(plan(intentPlan({ cycleId: 'd'.repeat(64) })))
     const submitDecision = await Effect.runPromise(riskDecision(submitIntent, RiskOutcome.Approved))
     const cancelDecision = await Effect.runPromise(riskDecision(cancelIntent, RiskOutcome.Approved))
     const execution = makeExecutionRuntime()
@@ -1860,7 +2311,25 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       }),
     )
     await execution.dispose()
-    await activateAuditedPaperAuthority()
+
+    const acceptedAt = Date.now() + 100
+    const mutation = makeMutationRuntime()
+    await mutation.runPromise(
+      Effect.gen(function* () {
+        const store = yield* MutationStore
+        const requestHash = fixtureHash('cross-account-identified-submit')
+        yield* store.beginSubmit(cancelIntent.intentId, requestHash, 1_000, new Date(acceptedAt).toISOString())
+        yield* store.submitAccepted(cancelIntent.intentId, requestHash, orderId, {
+          requestId: 'cross-account-submit',
+          status: 200,
+          contentHash: fixtureHash('cross-account-submit-response'),
+          observedAt: new Date(acceptedAt + 1).toISOString(),
+        })
+      }),
+    )
+    await mutation.dispose()
+
+    const rotated = await rotateAuditedPaperAuthority('paper-account-2')
 
     const brokerCalls = { cancel: 0, submit: 0 }
     const broker: BrokerMutationShape = {
@@ -1874,7 +2343,6 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       },
     }
     const coordinator = makeCoordinatorRuntime(broker)
-    const acceptedAt = Date.now() + 100
 
     try {
       const observed = await coordinator.runPromise(
@@ -1917,55 +2385,6 @@ describePostgres('PostgreSQL evaluation evidence', () => {
           const submitExit = yield* Effect.exit(submit(submitIntent.intentId, 1_000))
           const [submitAfter] = yield* readEvidence(submitIntent.intentId)
 
-          const cancelMutationId = mutationId(cancelIntent.intentId, MutationOperation.Submit)
-          const cancelSubmitHash = fixtureHash('mismatched-account-identified-submit')
-          const startedAt = new Date(acceptedAt).toISOString()
-          const completedAt = new Date(acceptedAt + 1).toISOString()
-          yield* sql.withTransaction(
-            Effect.gen(function* () {
-              yield* sql`
-                UPDATE intents
-                SET state = 'IO_STARTED', state_version = state_version + 1, updated_at = ${startedAt}
-                WHERE intent_id = ${cancelIntent.intentId} AND state = 'APPROVED'
-              `
-              yield* sql`
-                UPDATE intents
-                SET state = 'ACKNOWLEDGED', state_version = state_version + 1, updated_at = ${completedAt}
-                WHERE intent_id = ${cancelIntent.intentId} AND state = 'IO_STARTED'
-              `
-              yield* sql`
-                INSERT INTO mutation_events (
-                  event_id, schema_version, mutation_id, intent_id, sequence, operation, event_type,
-                  request_hash, consistency_delay_ms, broker_order_id, request_id, response_status,
-                  response_content_hash, occurred_at
-                ) VALUES
-                  (
-                    ${fixtureHash('mismatched-account-submit-started')},
-                    'bayn.paper-mutation-event.v1', ${cancelMutationId}, ${cancelIntent.intentId}, 1,
-                    'SUBMIT', 'SUBMIT_STARTED', ${cancelSubmitHash}, 1000, NULL, NULL, NULL, NULL,
-                    ${startedAt}
-                  ),
-                  (
-                    ${fixtureHash('mismatched-account-submit-accepted')},
-                    'bayn.paper-mutation-event.v1', ${cancelMutationId}, ${cancelIntent.intentId}, 2,
-                    'SUBMIT', 'SUBMIT_ACCEPTED', ${cancelSubmitHash}, 1000, ${orderId},
-                    'mismatched-account-submit', 200,
-                    ${fixtureHash('mismatched-account-submit-response')}, ${completedAt}
-                  )
-              `
-              yield* sql`
-                UPDATE authority_state
-                SET
-                  effective = 'OBSERVE',
-                  kill_state = 'ACTIVE',
-                  reason = 'account-binding cancellation regression',
-                  version = version + 1,
-                  updated_at = greatest(clock_timestamp(), updated_at + interval '1 millisecond')
-                WHERE singleton
-              `
-            }),
-          )
-
           const [cancelBefore] = yield* readEvidence(cancelIntent.intentId)
           const cancelExit = yield* Effect.exit(cancel(cancelIntent.intentId, 1_000))
           const [cancelAfter] = yield* readEvidence(cancelIntent.intentId)
@@ -1973,6 +2392,8 @@ describePostgres('PostgreSQL evaluation evidence', () => {
         }),
       )
 
+      expect(rotated.accountId).toBe('paper-account-2')
+      expect(rotated.generationHash).not.toBe(originalGeneration.generationHash)
       expect(Exit.isFailure(observed.submitExit)).toBe(true)
       expect(Exit.isFailure(observed.cancelExit)).toBe(true)
       if (Exit.isFailure(observed.submitExit)) {
@@ -1994,6 +2415,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
   })
 
   test('rejects non-submitted and mismatched broker order identities before cancellation starts', async () => {
+    await activateAuditedPaperAuthority()
     const execution = makeExecutionRuntime()
     const intent = await Effect.runPromise(plan(intentPlan({ cycleId: 'e'.repeat(64) })))
     const decision = await Effect.runPromise(riskDecision(intent, RiskOutcome.Approved))
@@ -2003,7 +2425,6 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       }),
     )
     await execution.dispose()
-    await activateAuditedPaperAuthority()
 
     const mutation = makeMutationRuntime()
     const submitHash = 'a'.repeat(64)
@@ -2052,6 +2473,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
   })
 
   test('blocks later exposure only while an earlier mutation outcome remains unresolved', async () => {
+    await activateAuditedPaperAuthority()
     const execution = makeExecutionRuntime()
     const first = await Effect.runPromise(plan(intentPlan({ cycleId: '4'.repeat(64) })))
     const second = await Effect.runPromise(plan(intentPlan({ cycleId: '5'.repeat(64) })))
@@ -2065,7 +2487,6 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       }),
     )
     await execution.dispose()
-    await activateAuditedPaperAuthority()
 
     const mutation = makeMutationRuntime()
     const firstSubmitHash = 'a'.repeat(64)
@@ -2244,13 +2665,25 @@ describePostgres('PostgreSQL evaluation evidence', () => {
         const sql = yield* PgClient.PgClient
         const intentId = '1'.repeat(64)
         const decisionId = '2'.repeat(64)
+        const authorityGenerationHash = fixtureHash('intent-contract-authority-generation')
+        yield* sql`
+          INSERT INTO authority_generations (
+            generation_hash, schema_version, previous_generation_hash, maximum,
+            authority_version, activated_at
+          ) VALUES (
+            ${authorityGenerationHash}, 'bayn.authority-generation-history.v1', NULL,
+            'OBSERVE', 1, '2026-07-22T06:00:00.000Z'
+          )
+        `
         yield* sql`
           INSERT INTO intents (
-            intent_id, schema_version, strategy_name, cycle_id, decision_hash, policy_hash,
+            intent_id, schema_version, authority_generation_hash, strategy_name, cycle_id,
+            decision_hash, policy_hash,
             account_id, client_order_id, symbol, side, order_type,
             time_in_force, quantity_micros, notional_limit_micros, state, created_at, updated_at
           ) VALUES (
-            ${intentId}, 'bayn.paper-intent.v2', 'risk-balanced-trend', ${intentId}, ${'5'.repeat(64)},
+            ${intentId}, 'bayn.paper-intent.v3', ${authorityGenerationHash},
+            'risk-balanced-trend', ${intentId}, ${'5'.repeat(64)},
             ${'6'.repeat(64)}, 'paper-account-1', 'client-order-1', 'NVDA', 'BUY',
             'MARKET', 'DAY', 1000000, 200000000, 'PLANNED',
             '2026-07-22T06:00:00.000Z', '2026-07-22T06:00:00.000Z'
@@ -2258,12 +2691,14 @@ describePostgres('PostgreSQL evaluation evidence', () => {
         `
         const invalidInitial = yield* Effect.exit(sql`
           INSERT INTO intents (
-            intent_id, schema_version, risk_decision_id, strategy_name, cycle_id, decision_hash,
+            intent_id, schema_version, authority_generation_hash, risk_decision_id, strategy_name,
+            cycle_id, decision_hash,
             policy_hash, account_id, client_order_id, symbol, side, order_type, time_in_force,
             quantity_micros, notional_limit_micros, state,
             created_at, updated_at
           ) VALUES (
-            ${'3'.repeat(64)}, 'bayn.paper-intent.v2', ${'4'.repeat(64)}, 'risk-balanced-trend',
+            ${'3'.repeat(64)}, 'bayn.paper-intent.v3', ${authorityGenerationHash},
+            ${'4'.repeat(64)}, 'risk-balanced-trend',
             ${'3'.repeat(64)}, ${'4'.repeat(64)}, ${'5'.repeat(64)}, 'paper-account-1',
             'client-order-2', 'NVDA', 'BUY', 'MARKET', 'DAY', 1000000, 200000000, 'APPROVED',
             '2026-07-22T06:00:00.000Z', '2026-07-22T06:00:00.000Z'
@@ -2311,11 +2746,13 @@ describePostgres('PostgreSQL evaluation evidence', () => {
           Effect.gen(function* () {
             yield* sql`
               INSERT INTO intents (
-                intent_id, schema_version, strategy_name, cycle_id, decision_hash, policy_hash,
+                intent_id, schema_version, authority_generation_hash, strategy_name, cycle_id,
+                decision_hash, policy_hash,
                 account_id, client_order_id, symbol, side, order_type,
                 time_in_force, quantity_micros, notional_limit_micros, state, created_at, updated_at
               ) VALUES (
-                ${staleIntentId}, 'bayn.paper-intent.v2', 'risk-balanced-trend', ${staleIntentId},
+                ${staleIntentId}, 'bayn.paper-intent.v3', ${authorityGenerationHash},
+                'risk-balanced-trend', ${staleIntentId},
                 ${'4'.repeat(64)}, ${'3'.repeat(64)}, 'paper-account-1', 'client-order-stale',
                 'NVDA', 'BUY', 'MARKET', 'DAY', 1000000, 200000000, 'PLANNED',
                 statement_timestamp() - interval '1 minute', statement_timestamp() - interval '1 minute'
@@ -2426,11 +2863,13 @@ describePostgres('PostgreSQL evaluation evidence', () => {
             Effect.gen(function* () {
               yield* sql`
                 INSERT INTO intents (
-                  intent_id, schema_version, strategy_name, cycle_id, decision_hash, policy_hash,
+                  intent_id, schema_version, authority_generation_hash, strategy_name, cycle_id,
+                  decision_hash, policy_hash,
                   account_id, client_order_id, symbol, side, order_type,
                   time_in_force, quantity_micros, notional_limit_micros, state, created_at, updated_at
                 ) VALUES (
-                  ${'b'.repeat(64)}, 'bayn.paper-intent.v2', 'risk-balanced-trend', ${'b'.repeat(64)},
+                  ${'b'.repeat(64)}, 'bayn.paper-intent.v3', ${authorityGenerationHash},
+                  'risk-balanced-trend', ${'b'.repeat(64)},
                   ${'d'.repeat(64)}, ${'e'.repeat(64)}, 'paper-account-1', 'client-order-4',
                   'AMD', 'BUY', 'MARKET', 'DAY', 1000000, 200000000, 'PLANNED',
                   '2026-07-22T06:00:00.000Z', '2026-07-22T06:00:00.000Z'
@@ -2460,11 +2899,13 @@ describePostgres('PostgreSQL evaluation evidence', () => {
             Effect.gen(function* () {
               yield* sql`
                 INSERT INTO intents (
-                  intent_id, schema_version, strategy_name, cycle_id, decision_hash, policy_hash,
+                  intent_id, schema_version, authority_generation_hash, strategy_name, cycle_id,
+                  decision_hash, policy_hash,
                   account_id, client_order_id, symbol, side, order_type,
                   time_in_force, quantity_micros, notional_limit_micros, state, created_at, updated_at
                 ) VALUES (
-                  ${'f'.repeat(64)}, 'bayn.paper-intent.v2', 'risk-balanced-trend', ${'f'.repeat(64)},
+                  ${'f'.repeat(64)}, 'bayn.paper-intent.v3', ${authorityGenerationHash},
+                  'risk-balanced-trend', ${'f'.repeat(64)},
                   ${'1'.repeat(64)}, ${'2'.repeat(64)}, 'paper-account-1', 'client-order-5',
                   'AMD', 'BUY', 'MARKET', 'DAY', 1000000, 200000000, 'PLANNED',
                   '2026-07-22T06:00:00.000Z', '2026-07-22T06:00:00.000Z'
@@ -2493,11 +2934,13 @@ describePostgres('PostgreSQL evaluation evidence', () => {
           Effect.gen(function* () {
             yield* sql`
               INSERT INTO intents (
-                intent_id, schema_version, strategy_name, cycle_id, decision_hash, policy_hash,
+                intent_id, schema_version, authority_generation_hash, strategy_name, cycle_id,
+                decision_hash, policy_hash,
                 account_id, client_order_id, symbol, side, order_type,
                 time_in_force, quantity_micros, notional_limit_micros, state, created_at, updated_at
               ) VALUES (
-                ${'a'.repeat(64)}, 'bayn.paper-intent.v2', 'risk-balanced-trend', ${'a'.repeat(64)},
+                ${'a'.repeat(64)}, 'bayn.paper-intent.v3', ${authorityGenerationHash},
+                'risk-balanced-trend', ${'a'.repeat(64)},
                 ${'8'.repeat(64)}, ${'7'.repeat(64)}, 'paper-account-1', 'client-order-6',
                 'AMD', 'BUY', 'MARKET', 'DAY', 1000000, 200000000, 'PLANNED',
                 '2026-07-22T06:00:00.000Z', '2026-07-22T06:00:00.000Z'
@@ -2526,11 +2969,13 @@ describePostgres('PostgreSQL evaluation evidence', () => {
             Effect.gen(function* () {
               yield* sql`
                 INSERT INTO intents (
-                  intent_id, schema_version, strategy_name, cycle_id, decision_hash, policy_hash,
+                  intent_id, schema_version, authority_generation_hash, strategy_name, cycle_id,
+                  decision_hash, policy_hash,
                   account_id, client_order_id, symbol, side, order_type,
                   time_in_force, quantity_micros, notional_limit_micros, state, created_at, updated_at
                 ) VALUES (
-                  ${'7'.repeat(64)}, 'bayn.paper-intent.v2', 'risk-balanced-trend', ${'7'.repeat(64)},
+                  ${'7'.repeat(64)}, 'bayn.paper-intent.v3', ${authorityGenerationHash},
+                  'risk-balanced-trend', ${'7'.repeat(64)},
                   ${'9'.repeat(64)}, ${'a'.repeat(64)}, 'paper-account-1', 'client-order-3',
                   'AMD', 'BUY', 'MARKET', 'DAY', 1000000, 200000000, 'PLANNED',
                   '2026-07-22T06:00:00.000Z', '2026-07-22T06:00:00.000Z'
@@ -3707,17 +4152,29 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     const observed = await runtime.runPromise(
       Effect.gen(function* () {
         const sql = yield* PgClient.PgClient
+        const authorityGenerationHash = fixtureHash('interrupted-intent-authority-generation')
+        yield* sql`
+          INSERT INTO authority_generations (
+            generation_hash, schema_version, previous_generation_hash, maximum,
+            authority_version, activated_at
+          ) VALUES (
+            ${authorityGenerationHash}, 'bayn.authority-generation-history.v1', NULL,
+            'OBSERVE', 1, statement_timestamp()
+          )
+        `
         const inserted = yield* Deferred.make<void>()
         const sleeper = yield* Effect.forkChild(
           sql.withTransaction(
             Effect.gen(function* () {
               yield* sql`
                 INSERT INTO intents (
-                  intent_id, schema_version, strategy_name, cycle_id, decision_hash, policy_hash,
+                  intent_id, schema_version, authority_generation_hash, strategy_name, cycle_id,
+                  decision_hash, policy_hash,
                   account_id, client_order_id, symbol, side, order_type, time_in_force,
                   quantity_micros, notional_limit_micros, state, created_at, updated_at
                 ) VALUES (
-                  ${'6'.repeat(64)}, 'bayn.paper-intent.v2', 'risk-balanced-trend', ${'7'.repeat(64)},
+                  ${'6'.repeat(64)}, 'bayn.paper-intent.v3', ${authorityGenerationHash},
+                  'risk-balanced-trend', ${'7'.repeat(64)},
                   ${'8'.repeat(64)}, ${'9'.repeat(64)}, 'paper-account-1', 'interrupted-order',
                   'NVDA', 'BUY', 'MARKET', 'DAY', 1000000, 200000000, 'PLANNED',
                   statement_timestamp(), statement_timestamp()

--- a/services/bayn/src/db/migrations.ts
+++ b/services/bayn/src/db/migrations.ts
@@ -15,6 +15,7 @@ import observeShadowDecisions from '../../migrations/0012_observe_shadow_decisio
 import autonomousCycleTerminalTransitions from '../../migrations/0013_autonomous_cycle_terminal_transitions'
 import authorityGenerationHistory from '../../migrations/0014_authority_generation_history'
 import acknowledgedSubmitRecovery from '../../migrations/0015_acknowledged_submit_recovery'
+import authorityBoundIntents from '../../migrations/0016_authority_bound_intents'
 
 export const migrationLoader = PgMigrator.fromRecord({
   '1_initial_schema': initialSchema,
@@ -32,4 +33,5 @@ export const migrationLoader = PgMigrator.fromRecord({
   '13_autonomous_cycle_terminal_transitions': autonomousCycleTerminalTransitions,
   '14_authority_generation_history': authorityGenerationHistory,
   '15_acknowledged_submit_recovery': acknowledgedSubmitRecovery,
+  '16_authority_bound_intents': authorityBoundIntents,
 })

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -375,30 +375,31 @@ const seedExactReconciliation = (fixture: ReconciliationFixture, reconciliationA
     `
   })
 
-const seedTerminalCanceledMutation = Effect.gen(function* () {
-  const sql = yield* PgClient.PgClient
-  const intentId = hash('terminal-canceled-intent')
-  const decisionId = hash('terminal-canceled-risk-decision')
-  const submitMutationId = hash('terminal-canceled-submit')
-  const cancelMutationId = hash('terminal-canceled-cancel')
-  const brokerOrderId = '61e69015-8549-4bfd-b9c3-01e75843f47d'
-  yield* sql`
+const seedTerminalCanceledMutation = (authorityGenerationHash: string) =>
+  Effect.gen(function* () {
+    const sql = yield* PgClient.PgClient
+    const intentId = hash('terminal-canceled-intent')
+    const decisionId = hash('terminal-canceled-risk-decision')
+    const submitMutationId = hash('terminal-canceled-submit')
+    const cancelMutationId = hash('terminal-canceled-cancel')
+    const brokerOrderId = '61e69015-8549-4bfd-b9c3-01e75843f47d'
+    yield* sql`
     INSERT INTO intents (
-      intent_id, schema_version, account_id, client_order_id, symbol, side,
+      intent_id, schema_version, authority_generation_hash, account_id, client_order_id, symbol, side,
       order_type, time_in_force, quantity_micros, notional_limit_micros,
       state, terminal_outcome, state_version, created_at, updated_at,
       strategy_name, cycle_id, decision_hash, policy_hash
     ) VALUES (
-      ${intentId}, 'bayn.paper-intent.v2', ${accountId},
+      ${intentId}, 'bayn.paper-intent.v3', ${authorityGenerationHash}, ${accountId},
       'terminal-canceled-client-order', 'SPY', 'BUY', 'MARKET', 'DAY', 1000000, 100000000,
       'PLANNED', NULL, 1, '2026-07-22T15:30:00.000Z', '2026-07-22T15:30:00.000Z',
       'risk-balanced-trend', ${hash('terminal-canceled-cycle')},
       ${hash('terminal-canceled-decision')}, ${hash('terminal-canceled-policy')}
     )
-  `
-  yield* sql.withTransaction(
-    Effect.gen(function* () {
-      yield* sql`
+    `
+    yield* sql.withTransaction(
+      Effect.gen(function* () {
+        yield* sql`
         INSERT INTO risk_decisions (
           decision_id, schema_version, input_hash, intent_id, policy_hash,
           outcome, reason_codes, decided_at, expires_at
@@ -408,7 +409,7 @@ const seedTerminalCanceledMutation = Effect.gen(function* () {
           '2026-07-22T15:30:00.001Z', '2099-01-01T00:00:00.000Z'
         )
       `
-      yield* sql`
+        yield* sql`
         UPDATE intents
         SET
           risk_decision_id = ${decisionId},
@@ -417,7 +418,7 @@ const seedTerminalCanceledMutation = Effect.gen(function* () {
           updated_at = '2026-07-22T15:30:00.002Z'
         WHERE intent_id = ${intentId}
       `
-      yield* sql`
+        yield* sql`
         INSERT INTO mutation_events (
           event_id, schema_version, mutation_id, intent_id, sequence, operation,
           event_type, request_hash, consistency_delay_ms, broker_order_id,
@@ -429,12 +430,12 @@ const seedTerminalCanceledMutation = Effect.gen(function* () {
           NULL, NULL, NULL, '2026-07-22T15:30:01.000Z'
         )
       `
-      yield* sql`
+        yield* sql`
         UPDATE intents
         SET state = 'IO_STARTED', state_version = 3, updated_at = '2026-07-22T15:30:01.000Z'
         WHERE intent_id = ${intentId}
       `
-      yield* sql`
+        yield* sql`
         INSERT INTO mutation_events (
           event_id, schema_version, mutation_id, intent_id, sequence, operation,
           event_type, request_hash, consistency_delay_ms, broker_order_id,
@@ -446,12 +447,12 @@ const seedTerminalCanceledMutation = Effect.gen(function* () {
           'mismatched-submit', 200, ${hash('terminal-canceled-submit-response')}, '2026-07-22T15:30:02.000Z'
         )
       `
-      yield* sql`
+        yield* sql`
         UPDATE intents
         SET state = 'UNKNOWN', state_version = 4, updated_at = '2026-07-22T15:30:02.000Z'
         WHERE intent_id = ${intentId}
       `
-      yield* sql`
+        yield* sql`
         INSERT INTO mutation_events (
           event_id, schema_version, mutation_id, intent_id, sequence, operation,
           event_type, request_hash, consistency_delay_ms, broker_order_id,
@@ -463,7 +464,7 @@ const seedTerminalCanceledMutation = Effect.gen(function* () {
           'submit-not-found', 404, ${hash('terminal-canceled-submit-lookup')}, '2026-07-22T15:30:03.000Z'
         )
       `
-      yield* sql`
+        yield* sql`
         INSERT INTO mutation_events (
           event_id, schema_version, mutation_id, intent_id, sequence, operation,
           event_type, request_hash, consistency_delay_ms, broker_order_id,
@@ -475,7 +476,7 @@ const seedTerminalCanceledMutation = Effect.gen(function* () {
           NULL, NULL, NULL, '2026-07-22T15:30:04.000Z'
         )
       `
-      yield* sql`
+        yield* sql`
         INSERT INTO mutation_events (
           event_id, schema_version, mutation_id, intent_id, sequence, operation,
           event_type, request_hash, consistency_delay_ms, broker_order_id,
@@ -487,7 +488,7 @@ const seedTerminalCanceledMutation = Effect.gen(function* () {
           'cancel-accepted', 204, ${hash('terminal-canceled-cancel-response')}, '2026-07-22T15:30:05.000Z'
         )
       `
-      yield* sql`
+        yield* sql`
         INSERT INTO mutation_events (
           event_id, schema_version, mutation_id, intent_id, sequence, operation,
           event_type, request_hash, consistency_delay_ms, broker_order_id,
@@ -499,12 +500,12 @@ const seedTerminalCanceledMutation = Effect.gen(function* () {
           'cancel-terminal', 200, ${hash('terminal-canceled-cancel-lookup')}, '2026-07-22T15:30:06.000Z'
         )
       `
-      yield* sql`
+        yield* sql`
         UPDATE intents
         SET state = 'RECOVERED', state_version = 5, updated_at = '2026-07-22T15:30:06.000Z'
         WHERE intent_id = ${intentId}
       `
-      yield* sql`
+        yield* sql`
         UPDATE intents
         SET
           state = 'TERMINAL',
@@ -513,9 +514,9 @@ const seedTerminalCanceledMutation = Effect.gen(function* () {
           updated_at = '2026-07-22T15:30:06.000001Z'
         WHERE intent_id = ${intentId}
       `
-    }),
-  )
-})
+      }),
+    )
+  })
 
 const makeActivation = (
   previousGenerationHash: string,
@@ -1117,7 +1118,7 @@ describePostgres('paper accounting persistence', () => {
               generationHash: initialGenerationHash,
               maximum: Authority.Observe,
             })
-            yield* seedTerminalCanceledMutation
+            yield* seedTerminalCanceledMutation(initialGenerationHash)
             yield* seedExactReconciliation(reconciliation)
             const prepared = yield* store.preparePaperGeneration(proofBinding(expected))
             const [history] = yield* sql<{ event_count: number; latest_mutation_at: Date }>`
@@ -2029,12 +2030,12 @@ describePostgres('paper accounting persistence', () => {
           const sql = yield* PgClient.PgClient
           yield* sql`
             INSERT INTO intents (
-              intent_id, schema_version, account_id, client_order_id, symbol, side,
+              intent_id, schema_version, authority_generation_hash, account_id, client_order_id, symbol, side,
               order_type, time_in_force, quantity_micros, notional_limit_micros,
               state, state_version, created_at, updated_at,
               strategy_name, cycle_id, decision_hash, policy_hash
             ) VALUES (
-              ${hash('unresolved-intent')}, 'bayn.paper-intent.v2', ${accountId},
+              ${hash('unresolved-intent')}, 'bayn.paper-intent.v3', ${initialGenerationHash}, ${accountId},
               'unresolved-client-order', 'SPY', 'BUY', 'MARKET', 'DAY', 1000000, 100000000,
               'PLANNED', 1, '2026-07-22T15:30:03.000Z', '2026-07-22T15:30:03.000Z',
               'risk-balanced-trend', ${hash('unresolved-cycle')},
@@ -2185,15 +2186,26 @@ describePostgres('paper accounting persistence', () => {
             accountEventId: accountReceipt.eventId,
             positionSnapshotId: positionsReceipt.snapshotId,
           })
+          const authorityGenerationHash = hash('mutation-ordering-authority')
           const sql = yield* PgClient.PgClient
           yield* sql`
+            INSERT INTO authority_generations (
+              generation_hash, schema_version, previous_generation_hash, maximum,
+              authority_version, activated_at
+            ) VALUES (
+              ${authorityGenerationHash}, 'bayn.authority-generation-history.v1', NULL,
+              'OBSERVE', 1, ${occurredAt}
+            )
+          `
+          yield* sql`
             INSERT INTO intents (
-              intent_id, schema_version, account_id, client_order_id, symbol, side,
+              intent_id, schema_version, authority_generation_hash, account_id, client_order_id, symbol, side,
               order_type, time_in_force, quantity_micros, notional_limit_micros,
               state, state_version, created_at, updated_at,
               strategy_name, cycle_id, decision_hash, policy_hash
             ) VALUES (
-              ${intentId}, 'bayn.paper-intent.v2', ${accountId}, ${orderEvent().order.clientOrderId},
+              ${intentId}, 'bayn.paper-intent.v3', ${authorityGenerationHash}, ${accountId},
+              ${orderEvent().order.clientOrderId},
               ${orderEvent().order.symbol}, 'BUY', 'MARKET', 'DAY', 3000000, 300000000,
               'PLANNED', 1, ${occurredAt}, ${occurredAt},
               'tsmom-v1', ${'9'.repeat(64)}, ${'b'.repeat(64)}, ${'c'.repeat(64)}

--- a/services/bayn/src/execution/coordinator.test.ts
+++ b/services/bayn/src/execution/coordinator.test.ts
@@ -50,8 +50,9 @@ const accountId = 'e6fe16f3-64a4-4921-8928-cadf02f92f98'
 const initialTime = '1969-12-31T23:59:59.000Z'
 
 const intent: Intent = {
-  schemaVersion: 'bayn.paper-intent.v2',
+  schemaVersion: 'bayn.paper-intent.v3',
   intentId,
+  authorityGenerationHash: 'f'.repeat(64),
   riskDecisionId: 'b'.repeat(64),
   strategyName: 'risk-balanced-trend',
   cycleId: 'c'.repeat(64),

--- a/services/bayn/src/execution/intents.test.ts
+++ b/services/bayn/src/execution/intents.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, test } from 'bun:test'
 
 import { Effect, Exit } from 'effect'
 
-import { IntentState, OrderSide, OrderType, TimeInForce } from '../paper'
-import { plan, type IntentPlan } from './intents'
+import { Authority, IntentState, KillState, OrderSide, OrderType, TimeInForce } from '../paper'
+import { plan, planPaperIntent, type IntentPlan } from './intents'
 
 const hash = (digit: string): string => digit.repeat(64)
 
@@ -23,6 +23,18 @@ const input: IntentPlan = {
   createdAt: '2026-07-22T10:00:00.000Z',
 }
 
+const riskState = (generationHash = hash('a'), maximum = Authority.Paper) => ({
+  authority: {
+    schemaVersion: 'bayn.paper-authority.v1' as const,
+    generationHash,
+    maximum,
+    effective: maximum,
+    kill: KillState.Clear,
+    version: 1,
+    updatedAt: '2026-07-22T09:59:00.000Z',
+  },
+})
+
 describe('deterministic paper intents', () => {
   test('derives one stable full intent identity and Alpaca-bounded client order ID', async () => {
     const [first, second] = await Effect.runPromise(Effect.all([plan(input), plan({ ...input })]))
@@ -33,6 +45,7 @@ describe('deterministic paper intents', () => {
     expect(first.clientOrderId).toHaveLength(46)
     expect(first.state).toBe(IntentState.Planned)
     expect(first.riskDecisionId).toBeUndefined()
+    expect(first.schemaVersion).toBe('bayn.paper-intent.v2')
   })
 
   test('binds account, strategy, cycle, decision, and target material', async () => {
@@ -75,6 +88,32 @@ describe('deterministic paper intents', () => {
     const result = await Effect.runPromiseExit(
       plan({ ...input, cycleId: 'not-a-hash', quantityMicros: '0', extra: true }),
     )
+
+    expect(Exit.isFailure(result)).toBe(true)
+  })
+
+  test('binds a durable PAPER identity to the exact risk-state authority generation', async () => {
+    const [first, replay, rotated] = await Effect.runPromise(
+      Effect.all([
+        planPaperIntent(input, riskState()),
+        planPaperIntent({ ...input }, riskState()),
+        planPaperIntent(input, riskState(hash('b'))),
+      ]),
+    )
+
+    expect(first).toEqual(replay)
+    expect(first).toMatchObject({
+      schemaVersion: 'bayn.paper-intent.v3',
+      authorityGenerationHash: hash('a'),
+      state: IntentState.Planned,
+    })
+    expect(rotated.authorityGenerationHash).toBe(hash('b'))
+    expect(rotated.intentId).not.toBe(first.intentId)
+    expect(rotated.clientOrderId).not.toBe(first.clientOrderId)
+  })
+
+  test('refuses to create a durable intent from OBSERVE authority', async () => {
+    const result = await Effect.runPromiseExit(planPaperIntent(input, riskState(hash('c'), Authority.Observe)))
 
     expect(Exit.isFailure(result)).toBe(true)
   })

--- a/services/bayn/src/execution/intents.ts
+++ b/services/bayn/src/execution/intents.ts
@@ -483,13 +483,17 @@ const makeStore = Effect.gen(function* () {
               generation_account_id: string | null
               generation_hash: string
               generation_maximum: string | null
+              generation_risk_policy_hash: string | null
+              generation_strategy_name: string | null
               maximum: string
             }>`
               SELECT
                 authority.maximum,
                 authority.generation_hash,
                 generation.maximum AS generation_maximum,
-                generation.account_id AS generation_account_id
+                generation.account_id AS generation_account_id,
+                generation.risk_policy_hash AS generation_risk_policy_hash,
+                generation.strategy_name AS generation_strategy_name
               FROM authority_state AS authority
               LEFT JOIN authority_generations AS generation
                 ON generation.generation_hash = authority.generation_hash
@@ -502,13 +506,15 @@ const makeStore = Effect.gen(function* () {
               authority.maximum !== Authority.Paper ||
               authority.generation_hash !== inputIntent.authorityGenerationHash ||
               authority.generation_maximum !== Authority.Paper ||
-              authority.generation_account_id !== inputIntent.accountId
+              authority.generation_account_id !== inputIntent.accountId ||
+              authority.generation_risk_policy_hash !== inputIntent.policyHash ||
+              authority.generation_strategy_name !== inputIntent.strategyName
             ) {
               return yield* Effect.fail(
                 storeError(
                   'invariant',
                   'commit',
-                  'PAPER intent does not match the current immutable authority-generation account binding',
+                  'PAPER intent does not match the current immutable authority-generation bindings',
                 ),
               )
             }

--- a/services/bayn/src/execution/intents.ts
+++ b/services/bayn/src/execution/intents.ts
@@ -6,7 +6,9 @@ import type { Fragment } from 'effect/unstable/sql/Statement'
 
 import { canonicalHashV1 } from '../hash'
 import {
+  Authority,
   decodeIntent,
+  decodeReferenceIntent,
   decodeRiskDecision,
   IntentSchema,
   IntentState,
@@ -18,8 +20,10 @@ import {
   TerminalOutcome,
   TimeInForce,
   type Intent,
+  type ReferenceIntent,
   type RiskDecision,
 } from '../paper'
+import type { State } from '../risk'
 import {
   Sha256Schema as Sha256,
   StrictNonEmptyStringSchema as NonEmptyString,
@@ -50,7 +54,7 @@ const decodePlan = Schema.decodeUnknownEffect(IntentPlanSchema, strictParseOptio
 const intentEquivalent = Schema.toEquivalence(IntentSchema)
 const decisionEquivalent = Schema.toEquivalence(RiskDecisionSchema)
 
-const identityMaterial = (input: IntentPlan) => ({
+const referenceIdentityMaterial = (input: IntentPlan) => ({
   schemaVersion: 'bayn.paper-intent-identity.v1',
   strategyName: input.strategyName,
   cycleId: input.cycleId,
@@ -64,34 +68,91 @@ const identityMaterial = (input: IntentPlan) => ({
   notionalLimitMicros: input.notionalLimitMicros,
 })
 
-export const intentIdForPlan = (input: IntentPlan): string => canonicalHashV1(identityMaterial(input))
+const paperIdentityMaterial = (input: IntentPlan, authorityGenerationHash: string) => ({
+  schemaVersion: 'bayn.paper-intent-identity.v2',
+  authorityGenerationHash,
+  strategyName: input.strategyName,
+  cycleId: input.cycleId,
+  decisionHash: input.decisionHash,
+  accountId: input.accountId,
+  symbol: input.symbol,
+  side: input.side,
+  orderType: input.orderType,
+  timeInForce: input.timeInForce,
+  quantityMicros: input.quantityMicros,
+  notionalLimitMicros: input.notionalLimitMicros,
+})
+
+export const intentIdForPlan = (input: IntentPlan): string => canonicalHashV1(referenceIdentityMaterial(input))
 
 const clientOrderId = (intentId: string): string => `b1_${Buffer.from(intentId, 'hex').toString('base64url')}`
 
-export const plan = (input: unknown) =>
-  decodePlan(input).pipe(
-    Effect.flatMap((decoded) => {
-      const intentId = intentIdForPlan(decoded)
-      return decodeIntent({
-        schemaVersion: 'bayn.paper-intent.v2',
-        intentId,
-        strategyName: decoded.strategyName,
-        cycleId: decoded.cycleId,
-        decisionHash: decoded.decisionHash,
-        policyHash: decoded.policyHash,
-        accountId: decoded.accountId,
-        clientOrderId: clientOrderId(intentId),
-        symbol: decoded.symbol,
-        side: decoded.side,
-        orderType: decoded.orderType,
-        timeInForce: decoded.timeInForce,
-        quantityMicros: decoded.quantityMicros,
-        notionalLimitMicros: decoded.notionalLimitMicros,
-        state: IntentState.Planned,
-        createdAt: decoded.createdAt,
-      })
-    }),
-  )
+const makeReferenceIntent = (decoded: IntentPlan): Effect.Effect<ReferenceIntent, Schema.SchemaError> => {
+  const intentId = intentIdForPlan(decoded)
+  return decodeReferenceIntent({
+    schemaVersion: 'bayn.paper-intent.v2',
+    intentId,
+    strategyName: decoded.strategyName,
+    cycleId: decoded.cycleId,
+    decisionHash: decoded.decisionHash,
+    policyHash: decoded.policyHash,
+    accountId: decoded.accountId,
+    clientOrderId: clientOrderId(intentId),
+    symbol: decoded.symbol,
+    side: decoded.side,
+    orderType: decoded.orderType,
+    timeInForce: decoded.timeInForce,
+    quantityMicros: decoded.quantityMicros,
+    notionalLimitMicros: decoded.notionalLimitMicros,
+    state: IntentState.Planned,
+    createdAt: decoded.createdAt,
+  })
+}
+
+const makePaperIntent = (
+  decoded: IntentPlan,
+  authorityGenerationHash: string,
+): Effect.Effect<Intent, Schema.SchemaError> => {
+  const intentId = canonicalHashV1(paperIdentityMaterial(decoded, authorityGenerationHash))
+  return decodeIntent({
+    schemaVersion: 'bayn.paper-intent.v3',
+    authorityGenerationHash,
+    intentId,
+    strategyName: decoded.strategyName,
+    cycleId: decoded.cycleId,
+    decisionHash: decoded.decisionHash,
+    policyHash: decoded.policyHash,
+    accountId: decoded.accountId,
+    clientOrderId: clientOrderId(intentId),
+    symbol: decoded.symbol,
+    side: decoded.side,
+    orderType: decoded.orderType,
+    timeInForce: decoded.timeInForce,
+    quantityMicros: decoded.quantityMicros,
+    notionalLimitMicros: decoded.notionalLimitMicros,
+    state: IntentState.Planned,
+    createdAt: decoded.createdAt,
+  })
+}
+
+export const plan = (input: unknown) => decodePlan(input).pipe(Effect.flatMap(makeReferenceIntent))
+
+export class PaperIntentBindingError extends Data.TaggedError('PaperIntentBindingError')<{
+  readonly message: string
+}> {}
+
+export const planPaperIntent = (input: unknown, state: Pick<State, 'authority'>) =>
+  Effect.gen(function* () {
+    const decoded = yield* decodePlan(input)
+    if (state.authority.maximum !== Authority.Paper) {
+      return yield* Effect.fail(
+        new PaperIntentBindingError({
+          message: 'a durable PAPER intent requires a PAPER authority generation from risk state',
+        }),
+      )
+    }
+    return yield* makePaperIntent(decoded, state.authority.generationHash)
+  })
 
 export class IntentStoreError extends Data.TaggedError('IntentStoreError')<{
   readonly failure: 'conflict' | 'decode' | 'invariant' | 'query'
@@ -127,9 +188,10 @@ export interface IntentStoreService {
 export class IntentStore extends Context.Service<IntentStore, IntentStoreService>()('bayn/IntentStore') {}
 
 const intentRowFields = {
-  schema_version: Schema.Literal('bayn.paper-intent.v2'),
+  schema_version: Schema.Literal('bayn.paper-intent.v3'),
   intent_id: Sha256,
   risk_decision_id: Schema.NullOr(Sha256),
+  authority_generation_hash: Sha256,
   strategy_name: NonEmptyString,
   cycle_id: Sha256,
   decision_hash: Sha256,
@@ -180,6 +242,7 @@ const selectRows = (sql: PgClient.PgClient, predicate: Fragment) => sql`
     intent.schema_version,
     intent.intent_id,
     intent.risk_decision_id,
+    intent.authority_generation_hash,
     intent.strategy_name,
     intent.cycle_id,
     intent.decision_hash,
@@ -215,6 +278,7 @@ const toRecord = (row: StoredRow) =>
       schemaVersion: row.schema_version,
       intentId: row.intent_id,
       ...(row.risk_decision_id === null ? {} : { riskDecisionId: row.risk_decision_id }),
+      authorityGenerationHash: row.authority_generation_hash,
       strategyName: row.strategy_name,
       cycleId: row.cycle_id,
       decisionHash: row.decision_hash,
@@ -252,6 +316,7 @@ const immutableIntentHash = (intent: Intent): string =>
   canonicalHashV1({
     schemaVersion: intent.schemaVersion,
     intentId: intent.intentId,
+    authorityGenerationHash: intent.authorityGenerationHash,
     strategyName: intent.strategyName,
     cycleId: intent.cycleId,
     decisionHash: intent.decisionHash,
@@ -323,21 +388,24 @@ const makeStore = Effect.gen(function* () {
     run(
       'commit',
       Effect.gen(function* () {
-        const expectedIntent = yield* plan({
-          schemaVersion: 'bayn.paper-intent-plan.v1',
-          strategyName: inputIntent.strategyName,
-          cycleId: inputIntent.cycleId,
-          decisionHash: inputIntent.decisionHash,
-          policyHash: inputIntent.policyHash,
-          accountId: inputIntent.accountId,
-          symbol: inputIntent.symbol,
-          side: inputIntent.side,
-          orderType: inputIntent.orderType,
-          timeInForce: inputIntent.timeInForce,
-          quantityMicros: inputIntent.quantityMicros,
-          notionalLimitMicros: inputIntent.notionalLimitMicros,
-          createdAt: inputIntent.createdAt,
-        }).pipe(Effect.mapError((cause) => storeError('decode', 'commit', 'invalid planned intent', cause)))
+        const expectedIntent = yield* makePaperIntent(
+          {
+            schemaVersion: 'bayn.paper-intent-plan.v1',
+            strategyName: inputIntent.strategyName,
+            cycleId: inputIntent.cycleId,
+            decisionHash: inputIntent.decisionHash,
+            policyHash: inputIntent.policyHash,
+            accountId: inputIntent.accountId,
+            symbol: inputIntent.symbol,
+            side: inputIntent.side,
+            orderType: inputIntent.orderType,
+            timeInForce: inputIntent.timeInForce,
+            quantityMicros: inputIntent.quantityMicros,
+            notionalLimitMicros: inputIntent.notionalLimitMicros,
+            createdAt: inputIntent.createdAt,
+          },
+          inputIntent.authorityGenerationHash,
+        ).pipe(Effect.mapError((cause) => storeError('decode', 'commit', 'invalid planned intent', cause)))
         if (!intentEquivalent(inputIntent, expectedIntent)) {
           return yield* Effect.fail(
             storeError('invariant', 'commit', 'planned intent does not match its deterministic identity'),
@@ -360,50 +428,10 @@ const makeStore = Effect.gen(function* () {
 
         return yield* withFence(
           Effect.gen(function* () {
-            yield* sql`
-              INSERT INTO intents (
-                intent_id,
-                schema_version,
-                strategy_name,
-                cycle_id,
-                decision_hash,
-                policy_hash,
-                account_id,
-                client_order_id,
-                symbol,
-                side,
-                order_type,
-                time_in_force,
-                quantity_micros,
-                notional_limit_micros,
-                state,
-                created_at,
-                updated_at
-              ) VALUES (
-                ${inputIntent.intentId},
-                ${inputIntent.schemaVersion},
-                ${inputIntent.strategyName},
-                ${inputIntent.cycleId},
-                ${inputIntent.decisionHash},
-                ${inputIntent.policyHash},
-                ${inputIntent.accountId},
-                ${inputIntent.clientOrderId},
-                ${inputIntent.symbol},
-                ${inputIntent.side},
-                ${inputIntent.orderType},
-                ${inputIntent.timeInForce},
-                ${inputIntent.quantityMicros},
-                ${inputIntent.notionalLimitMicros},
-                ${inputIntent.state},
-                ${inputIntent.createdAt},
-                ${inputIntent.createdAt}
-              )
-              ON CONFLICT DO NOTHING
-            `
-
-            const conflictRows = yield* selectRows(
-              sql,
-              sql`
+            const readConflicts = () =>
+              selectRows(
+                sql,
+                sql`
                 intent.intent_id = ${inputIntent.intentId}
                 OR (intent.account_id = ${inputIntent.accountId} AND intent.client_order_id = ${inputIntent.clientOrderId})
                 OR (
@@ -414,7 +442,122 @@ const makeStore = Effect.gen(function* () {
                   AND intent.symbol = ${inputIntent.symbol}
                 )
               `,
-            ).pipe(Effect.flatMap((rows) => decodeStored('commit', rows)))
+              ).pipe(Effect.flatMap((rows) => decodeStored('commit', rows)))
+
+            let conflictRows = yield* readConflicts()
+            if (conflictRows.length > 1) {
+              return yield* Effect.fail(
+                storeError('conflict', 'commit', 'intent uniqueness boundary resolved to multiple records'),
+              )
+            }
+            const preexisting = conflictRows[0]
+            if (preexisting !== undefined) {
+              if (immutableIntentHash(preexisting.intent) !== immutableIntentHash(inputIntent)) {
+                return yield* Effect.fail(
+                  storeError('conflict', 'commit', 'deterministic intent identity was reused with different content'),
+                )
+              }
+              if (preexisting.decision !== undefined) {
+                const stateMatchesDecision =
+                  decision.outcome === RiskOutcome.Approved
+                    ? preexisting.intent.state !== IntentState.Planned
+                    : preexisting.intent.state === IntentState.Terminal &&
+                      preexisting.intent.terminalOutcome === TerminalOutcome.Blocked
+                if (
+                  !decisionEquivalent(preexisting.decision, decision) ||
+                  preexisting.intent.riskDecisionId !== decision.decisionId ||
+                  !stateMatchesDecision
+                ) {
+                  return yield* Effect.fail(
+                    storeError('conflict', 'commit', 'stored intent decision diverges from the requested decision'),
+                  )
+                }
+                return { record: preexisting, deduplicated: true } satisfies IntentReceipt
+              }
+              if (preexisting.intent.state !== IntentState.Planned || preexisting.intent.riskDecisionId !== undefined) {
+                return yield* Effect.fail(storeError('invariant', 'commit', 'intent without a decision is not PLANNED'))
+              }
+            }
+
+            const authorityRows = yield* sql<{
+              generation_account_id: string | null
+              generation_hash: string
+              generation_maximum: string | null
+              maximum: string
+            }>`
+              SELECT
+                authority.maximum,
+                authority.generation_hash,
+                generation.maximum AS generation_maximum,
+                generation.account_id AS generation_account_id
+              FROM authority_state AS authority
+              LEFT JOIN authority_generations AS generation
+                ON generation.generation_hash = authority.generation_hash
+              WHERE authority.singleton
+              FOR UPDATE OF authority
+            `
+            const authority = authorityRows[0]
+            if (
+              authority === undefined ||
+              authority.maximum !== Authority.Paper ||
+              authority.generation_hash !== inputIntent.authorityGenerationHash ||
+              authority.generation_maximum !== Authority.Paper ||
+              authority.generation_account_id !== inputIntent.accountId
+            ) {
+              return yield* Effect.fail(
+                storeError(
+                  'invariant',
+                  'commit',
+                  'PAPER intent does not match the current immutable authority-generation account binding',
+                ),
+              )
+            }
+
+            if (preexisting === undefined) {
+              yield* sql`
+                INSERT INTO intents (
+                  intent_id,
+                  schema_version,
+                  authority_generation_hash,
+                  strategy_name,
+                  cycle_id,
+                  decision_hash,
+                  policy_hash,
+                  account_id,
+                  client_order_id,
+                  symbol,
+                  side,
+                  order_type,
+                  time_in_force,
+                  quantity_micros,
+                  notional_limit_micros,
+                  state,
+                  created_at,
+                  updated_at
+                ) VALUES (
+                  ${inputIntent.intentId},
+                  ${inputIntent.schemaVersion},
+                  ${inputIntent.authorityGenerationHash},
+                  ${inputIntent.strategyName},
+                  ${inputIntent.cycleId},
+                  ${inputIntent.decisionHash},
+                  ${inputIntent.policyHash},
+                  ${inputIntent.accountId},
+                  ${inputIntent.clientOrderId},
+                  ${inputIntent.symbol},
+                  ${inputIntent.side},
+                  ${inputIntent.orderType},
+                  ${inputIntent.timeInForce},
+                  ${inputIntent.quantityMicros},
+                  ${inputIntent.notionalLimitMicros},
+                  ${inputIntent.state},
+                  ${inputIntent.createdAt},
+                  ${inputIntent.createdAt}
+                )
+                ON CONFLICT DO NOTHING
+              `
+              conflictRows = yield* readConflicts()
+            }
             if (conflictRows.length !== 1) {
               return yield* Effect.fail(
                 storeError('conflict', 'commit', 'intent uniqueness boundary did not resolve to one record'),

--- a/services/bayn/src/execution/mutations.ts
+++ b/services/bayn/src/execution/mutations.ts
@@ -508,15 +508,23 @@ const makeStore = Effect.gen(function* () {
               authority_generation_hash: string
               generation_account_id: string | null
               generation_maximum: string | null
+              generation_risk_policy_hash: string | null
+              generation_strategy_name: string | null
+              policy_hash: string
               state: string
+              strategy_name: string
               updated_at: string
             }>`
               SELECT
                 intent.account_id,
                 intent.authority_generation_hash,
+                intent.policy_hash,
                 intent.state,
+                intent.strategy_name,
                 generation.account_id AS generation_account_id,
                 generation.maximum AS generation_maximum,
+                generation.risk_policy_hash AS generation_risk_policy_hash,
+                generation.strategy_name AS generation_strategy_name,
                 to_char(intent.updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS updated_at
               FROM intents AS intent
               LEFT JOIN authority_generations AS generation
@@ -531,13 +539,15 @@ const makeStore = Effect.gen(function* () {
             if (
               intent.generation_maximum !== Authority.Paper ||
               intent.generation_account_id === null ||
-              intent.generation_account_id !== intent.account_id
+              intent.generation_account_id !== intent.account_id ||
+              intent.generation_risk_policy_hash !== intent.policy_hash ||
+              intent.generation_strategy_name !== intent.strategy_name
             ) {
               return yield* Effect.fail(
                 storeError(
                   storeOperation,
                   'authority',
-                  'intent lacks an immutable PAPER authority-generation account binding',
+                  'intent does not match its immutable PAPER authority-generation bindings',
                 ),
               )
             }

--- a/services/bayn/src/execution/mutations.ts
+++ b/services/bayn/src/execution/mutations.ts
@@ -372,6 +372,7 @@ const makeStore = Effect.gen(function* () {
       const storeOperation = operation === MutationOperation.Submit ? 'begin-submit' : 'begin-cancel'
       const rows = yield* sql<{
         effective: string
+        generation_hash: string
         generation_account_id: string | null
         generation_maximum: string | null
         kill_state: string
@@ -381,6 +382,7 @@ const makeStore = Effect.gen(function* () {
           authority.maximum,
           authority.effective,
           authority.kill_state,
+          authority.generation_hash,
           generation.maximum AS generation_maximum,
           generation.account_id AS generation_account_id
         FROM authority_state AS authority
@@ -416,7 +418,10 @@ const makeStore = Effect.gen(function* () {
           storeError(storeOperation, 'authority', 'active PAPER authority lacks its immutable account binding'),
         )
       }
-      return authority.generation_account_id
+      return {
+        accountId: authority.generation_account_id,
+        generationHash: authority.generation_hash,
+      } as const
     })
 
   const assertNoOtherUnresolved = (intentId: string) =>
@@ -496,27 +501,64 @@ const makeStore = Effect.gen(function* () {
               return { event: existing, started: false } satisfies StartReceipt
             }
 
-            const authorityAccountId = yield* assertAuthority(operation)
+            const authority = yield* assertAuthority(operation)
             if (operation === MutationOperation.Submit) yield* assertNoOtherUnresolved(input.intentId)
-            const intents = yield* sql<{ account_id: string; state: string; updated_at: string }>`
+            const intents = yield* sql<{
+              account_id: string
+              authority_generation_hash: string
+              generation_account_id: string | null
+              generation_maximum: string | null
+              state: string
+              updated_at: string
+            }>`
               SELECT
-                account_id,
-                state,
-                to_char(updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS updated_at
-              FROM intents
-              WHERE intent_id = ${input.intentId}
-              FOR UPDATE
+                intent.account_id,
+                intent.authority_generation_hash,
+                intent.state,
+                generation.account_id AS generation_account_id,
+                generation.maximum AS generation_maximum,
+                to_char(intent.updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS updated_at
+              FROM intents AS intent
+              LEFT JOIN authority_generations AS generation
+                ON generation.generation_hash = intent.authority_generation_hash
+              WHERE intent.intent_id = ${input.intentId}
+              FOR UPDATE OF intent
             `
             const intent = intents[0]
             if (intent === undefined) {
               return yield* Effect.fail(storeError(storeOperation, 'invariant', 'intent does not exist'))
             }
-            if (intent.account_id !== authorityAccountId) {
+            if (
+              intent.generation_maximum !== Authority.Paper ||
+              intent.generation_account_id === null ||
+              intent.generation_account_id !== intent.account_id
+            ) {
+              return yield* Effect.fail(
+                storeError(
+                  storeOperation,
+                  'authority',
+                  'intent lacks an immutable PAPER authority-generation account binding',
+                ),
+              )
+            }
+            if (intent.account_id !== authority.accountId) {
               return yield* Effect.fail(
                 storeError(
                   storeOperation,
                   'authority',
                   'intent account does not match the active PAPER authority generation',
+                ),
+              )
+            }
+            if (
+              operation === MutationOperation.Submit &&
+              intent.authority_generation_hash !== authority.generationHash
+            ) {
+              return yield* Effect.fail(
+                storeError(
+                  'begin-submit',
+                  'authority',
+                  'intent authority generation is not the active PAPER generation',
                 ),
               )
             }

--- a/services/bayn/src/paper.test.ts
+++ b/services/bayn/src/paper.test.ts
@@ -133,8 +133,9 @@ const source = {
 }
 
 const intent = {
-  schemaVersion: 'bayn.paper-intent.v2' as const,
+  schemaVersion: 'bayn.paper-intent.v3' as const,
   intentId: hash('4'),
+  authorityGenerationHash: hash('8'),
   strategyName: 'risk-balanced-trend',
   cycleId: hash('5'),
   decisionHash: hash('6'),

--- a/services/bayn/src/paper.ts
+++ b/services/bayn/src/paper.ts
@@ -351,8 +351,7 @@ export const BrokerEventSchema = BrokerEventBase.check(
 )
 export type BrokerEvent = typeof BrokerEventSchema.Type
 
-const IntentBase = Schema.Struct({
-  schemaVersion: Schema.Literal('bayn.paper-intent.v2'),
+const intentFields = {
   intentId: Sha256,
   riskDecisionId: Schema.optionalKey(Sha256),
   strategyName: NonEmptyString,
@@ -370,28 +369,44 @@ const IntentBase = Schema.Struct({
   state: Schema.Enum(IntentState),
   terminalOutcome: Schema.optionalKey(Schema.Enum(TerminalOutcome)),
   createdAt: UtcInstant,
+} as const
+
+const ReferenceIntentBase = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.paper-intent.v2'),
+  ...intentFields,
 })
 
-export const IntentSchema = IntentBase.check(
-  Schema.makeFilter((intent: typeof IntentBase.Type): readonly Schema.FilterIssue[] => {
-    const issues: Schema.FilterIssue[] = []
-    const terminal = intent.state === IntentState.Terminal
-    if (terminal !== (intent.terminalOutcome !== undefined)) {
-      issues.push({
-        path: ['terminalOutcome'],
-        issue: terminal ? 'is required for a terminal intent' : 'must be absent before terminal state',
-      })
-    }
-    const planned = intent.state === IntentState.Planned
-    if (planned === (intent.riskDecisionId !== undefined)) {
-      issues.push({
-        path: ['riskDecisionId'],
-        issue: planned ? 'must be absent before risk evaluation' : 'is required after risk evaluation',
-      })
-    }
-    return issues
-  }),
-)
+const IntentBase = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.paper-intent.v3'),
+  authorityGenerationHash: Sha256,
+  ...intentFields,
+})
+
+type IntentContract = typeof ReferenceIntentBase.Type | typeof IntentBase.Type
+
+const intentContractIssues = (intent: IntentContract): readonly Schema.FilterIssue[] => {
+  const issues: Schema.FilterIssue[] = []
+  const terminal = intent.state === IntentState.Terminal
+  if (terminal !== (intent.terminalOutcome !== undefined)) {
+    issues.push({
+      path: ['terminalOutcome'],
+      issue: terminal ? 'is required for a terminal intent' : 'must be absent before terminal state',
+    })
+  }
+  const planned = intent.state === IntentState.Planned
+  if (planned === (intent.riskDecisionId !== undefined)) {
+    issues.push({
+      path: ['riskDecisionId'],
+      issue: planned ? 'must be absent before risk evaluation' : 'is required after risk evaluation',
+    })
+  }
+  return issues
+}
+
+export const ReferenceIntentSchema = ReferenceIntentBase.check(Schema.makeFilter(intentContractIssues))
+export type ReferenceIntent = typeof ReferenceIntentSchema.Type
+
+export const IntentSchema = IntentBase.check(Schema.makeFilter(intentContractIssues))
 export type Intent = typeof IntentSchema.Type
 
 const allowedTransitions: Readonly<Record<IntentState, readonly IntentState[]>> = {
@@ -680,6 +695,7 @@ export const decodeOrder = Schema.decodeUnknownEffect(OrderSchema, StrictParseOp
 export const decodeFill = Schema.decodeUnknownEffect(FillSchema, StrictParseOptions)
 export const decodeBrokerError = Schema.decodeUnknownEffect(BrokerErrorSchema, StrictParseOptions)
 export const decodeRateLimit = Schema.decodeUnknownEffect(RateLimitSchema, StrictParseOptions)
+export const decodeReferenceIntent = Schema.decodeUnknownEffect(ReferenceIntentSchema, StrictParseOptions)
 export const decodeIntent = Schema.decodeUnknownEffect(IntentSchema, StrictParseOptions)
 export const decodeRiskInput = Schema.decodeUnknownEffect(RiskInputSchema, StrictParseOptions)
 export const decodeRiskDecision = Schema.decodeUnknownEffect(RiskDecisionSchema, StrictParseOptions)

--- a/services/bayn/src/risk.test.ts
+++ b/services/bayn/src/risk.test.ts
@@ -14,10 +14,12 @@ import {
   OrderStatus,
   OrderType,
   ReconciliationStatus,
+  ReferenceIntentSchema,
   RiskOutcome,
   TerminalOutcome,
   TimeInForce,
   type Intent,
+  type ReferenceIntent,
 } from './paper'
 import { reconciledStateHash } from './reconciliation'
 import { BrokerMode, PolicySchema, Reason, StateSchema, evaluate, type Policy, type State } from './risk'
@@ -30,6 +32,7 @@ const hash = (character: string): string => character.repeat(64)
 const decodePolicy = Schema.decodeUnknownSync(PolicySchema, strictParseOptions)
 const decodeState = Schema.decodeUnknownSync(StateSchema, strictParseOptions)
 const decodeIntent = Schema.decodeUnknownSync(IntentSchema, strictParseOptions)
+const decodeReferenceIntent = Schema.decodeUnknownSync(ReferenceIntentSchema, strictParseOptions)
 
 const rehashExecutionSession = (
   binding: Omit<State['executionSession'], 'bindingHash'>,
@@ -257,8 +260,9 @@ const makeState = (overrides: Partial<State> = {}): State => {
 
 const makeIntent = (overrides: Partial<Intent> = {}): Intent =>
   decodeIntent({
-    schemaVersion: 'bayn.paper-intent.v2',
+    schemaVersion: 'bayn.paper-intent.v3',
     intentId: hash('6'),
+    authorityGenerationHash: hash('4'),
     strategyName: 'risk-balanced-trend',
     cycleId: hash('7'),
     decisionHash: hash('8'),
@@ -276,7 +280,17 @@ const makeIntent = (overrides: Partial<Intent> = {}): Intent =>
     ...overrides,
   })
 
-const expectBlocked = (reason: Reason, intent = makeIntent(), state = makeState(), policy = makePolicy()): void => {
+const makeReferenceIntent = (): ReferenceIntent => {
+  const { authorityGenerationHash: _, ...intent } = makeIntent()
+  return decodeReferenceIntent({ ...intent, schemaVersion: 'bayn.paper-intent.v2' })
+}
+
+const expectBlocked = (
+  reason: Reason,
+  intent: Intent | ReferenceIntent = makeIntent(),
+  state = makeState(),
+  policy = makePolicy(),
+): void => {
   const result = evaluate(intent, state, policy)
   expect(result.decision.outcome).toBe(RiskOutcome.Blocked)
   expect(result.decision.reasonCodes).toContain(reason)
@@ -623,7 +637,7 @@ describe('bounded paper risk', () => {
     )
     expectBlocked(
       Reason.AuthorityNotPaper,
-      makeIntent(),
+      makeReferenceIntent(),
       makeState({
         authority: {
           ...baseState().authority,
@@ -731,5 +745,49 @@ describe('bounded paper risk', () => {
     expect(freshnessCapped.input.freshUntil).toBe('2026-07-21T21:00:00.001Z')
     expect(cutoffCapped.input.freshUntil).toBe('2026-07-21T21:00:00.001Z')
     expect(intentCapped.input.freshUntil).toBe('2026-07-21T21:00:00.001Z')
+  })
+
+  test('requires the exact authority generation for PAPER evaluation and hashes that binding', () => {
+    const baselineState = makeState()
+    const baseline = evaluate(makeIntent(), baselineState, makePolicy())
+    const rotatedAuthority = { ...baselineState.authority, generationHash: hash('9') }
+    const rotatedState = makeState({ authority: rotatedAuthority })
+    const rotated = evaluate(makeIntent({ authorityGenerationHash: hash('9') }), rotatedState, makePolicy())
+
+    expect(rotated.input.inputHash).not.toBe(baseline.input.inputHash)
+    expect(rotated.gates.find((gate) => gate.name === 'reconciliation')?.passed).toBe(true)
+    expect(() => evaluate(makeIntent(), rotatedState, makePolicy())).toThrow(
+      'PAPER risk intent must bind the exact PAPER authority generation from risk state',
+    )
+    expect(() => evaluate(makeReferenceIntent(), baselineState, makePolicy())).toThrow(
+      'PAPER risk evaluation requires an authority-generation-bound intent',
+    )
+    expect(() =>
+      evaluate(
+        makeReferenceIntent(),
+        makeState({
+          authority: {
+            ...baselineState.authority,
+            effective: Authority.Observe,
+            kill: KillState.Active,
+            reason: 'operator kill',
+          },
+        }),
+        makePolicy(),
+      ),
+    ).toThrow('PAPER risk evaluation requires an authority-generation-bound intent')
+    expect(() =>
+      evaluate(
+        makeIntent(),
+        makeState({
+          authority: {
+            ...baselineState.authority,
+            maximum: Authority.Observe,
+            effective: Authority.Observe,
+          },
+        }),
+        makePolicy(),
+      ),
+    ).toThrow('authority-generation-bound risk intent requires PAPER maximum authority')
   })
 })

--- a/services/bayn/src/risk.ts
+++ b/services/bayn/src/risk.ts
@@ -24,6 +24,7 @@ import {
   TimeInForce,
   UnsignedMicrosSchema,
   type Intent,
+  type ReferenceIntent,
 } from './paper'
 import { reconciledStateHash } from './reconciliation'
 import {
@@ -351,6 +352,7 @@ export const EvaluationSchema = EvaluationBase.check(
   }),
 )
 export type Evaluation = typeof EvaluationSchema.Type
+export type RiskIntent = Intent | ReferenceIntent
 
 const decodeInput = Schema.decodeUnknownSync(RiskInputSchema, StrictParseOptions)
 const decodeDecision = Schema.decodeUnknownSync(RiskDecisionSchema, StrictParseOptions)
@@ -376,11 +378,21 @@ const isUnresolved = (status: OrderStatus): boolean =>
   status === OrderStatus.New || status === OrderStatus.PartiallyFilled || status === OrderStatus.Pending
 
 export const evaluate = (
-  intent: Intent,
+  intent: RiskIntent,
   state: State,
   policy: Policy,
   proposedPositions: State['positions'] = state.positions,
 ): Evaluation => {
+  if (intent.schemaVersion === 'bayn.paper-intent.v3') {
+    if (state.authority.maximum !== Authority.Paper) {
+      throw new Error('authority-generation-bound risk intent requires PAPER maximum authority')
+    }
+    if (intent.authorityGenerationHash !== state.authority.generationHash) {
+      throw new Error('PAPER risk intent must bind the exact PAPER authority generation from risk state')
+    }
+  } else if (state.authority.maximum === Authority.Paper) {
+    throw new Error('PAPER risk evaluation requires an authority-generation-bound intent')
+  }
   const evaluatedAt = instant(state.evaluatedAt)
   const policyHash = canonicalHashV1(policy)
   const referencePrice = BigInt(state.referencePriceMicros)
@@ -671,7 +683,10 @@ export const evaluate = (
     executionSession: state.executionSession,
   })
   const inputMaterial = {
-    schemaVersion: 'bayn.paper-risk-evaluation-input.v2',
+    schemaVersion:
+      intent.schemaVersion === 'bayn.paper-intent.v3'
+        ? 'bayn.paper-risk-evaluation-input.v3'
+        : 'bayn.paper-risk-evaluation-input.v2',
     intent,
     policy,
     state,

--- a/services/bayn/src/shadow-decision.test.ts
+++ b/services/bayn/src/shadow-decision.test.ts
@@ -294,7 +294,7 @@ const makeRiskState = (cycle: AutonomousCycle, symbol: string): State => {
     authority: {
       schemaVersion: 'bayn.paper-authority.v1',
       generationHash: hash('6'),
-      maximum: Authority.Paper,
+      maximum: Authority.Observe,
       effective: Authority.Observe,
       kill: KillState.Clear,
       version: 1,


### PR DESCRIPTION
## Summary

- keep OBSERVE reference targets non-dispatchable while binding every durable PAPER intent and risk preimage to the exact authority generation
- hard-cut empty intent history to the v3 schema with an immutable generation foreign key and generation-independent decision-target uniqueness
- require the current PAPER generation account, risk-policy hash, and strategy before first intent insertion; require each SUBMIT/CANCEL intent to match its own immutable generation while preserving exact replay and same-account historical CANCEL under an active kill
- prove stale-generation and policy/strategy drift no-write behavior, current-generation replacement, post-rotation replay, account isolation, migration refusal, and recovery semantics on PostgreSQL 18

## Related Issues

PROOMPT-375

## Testing

- `bun run --filter @proompteng/bayn test` (413 pass, 103 PostgreSQL-gated skip, 0 fail)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- `BAYN_TEST_POSTGRES_URL=<local-postgresql-18-test-url> bun test services/bayn/src/db/evidence-store.integration.test.ts` (50 pass)
- `BAYN_TEST_POSTGRES_URL=<local-postgresql-18-test-url> bun test services/bayn/src/db/paper-store.integration.test.ts` (27 pass)
- `BAYN_TEST_POSTGRES_URL=<local-postgresql-18-test-url> bun test services/bayn/src/db/cycle-store.integration.test.ts` (13 pass)
- `BAYN_TEST_POSTGRES_URL=<local-postgresql-18-test-url> bun test services/bayn/src/db/cycle-observability.integration.test.ts` (5 pass)
- `BAYN_TEST_POSTGRES_URL=<local-postgresql-18-test-url> bun test services/bayn/src/paper-proof-discovery.test.ts -t "PostgreSQL transaction"` (1 pass)

## Breaking Changes

Migration 0016 intentionally fails closed when `intents` or `risk_decisions` contains history; deployment requires the separately verified production prerequisite that both tables remain empty. It does not fabricate an authority binding for historical rows.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation and remaining live acceptance stay tracked by PROOMPT-375.