### PR TITLE
feat(bayn): stabilize paper authority generation identity

### DIFF
--- a/services/bayn/migrations/0017_stable_paper_authority_generation.ts
+++ b/services/bayn/migrations/0017_stable_paper_authority_generation.ts
@@ -1,0 +1,38 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient
+
+  yield* sql`
+    DO $migration$
+    BEGIN
+      IF EXISTS (SELECT 1 FROM intents) OR EXISTS (SELECT 1 FROM risk_decisions) THEN
+        RAISE EXCEPTION 'stable PAPER authority generation hard cut requires empty intents and risk_decisions'
+          USING ERRCODE = '55000';
+      END IF;
+
+      IF EXISTS (
+        SELECT 1
+        FROM authority_generations
+        WHERE maximum = 'PAPER'
+      ) OR EXISTS (
+        SELECT 1
+        FROM authority_state
+        WHERE maximum = 'PAPER'
+      ) THEN
+        RAISE EXCEPTION 'stable PAPER authority generation hard cut requires no existing PAPER authority'
+          USING ERRCODE = '55000';
+      END IF;
+    END
+    $migration$
+  `
+
+  yield* sql`
+    ALTER TABLE authority_generations
+      DROP CONSTRAINT authority_generations_activation_schema_version_check,
+      ADD CONSTRAINT authority_generations_activation_schema_version_check CHECK (
+        activation_schema_version = 'bayn.paper-authority-generation.v2'
+      )
+  `
+})

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -5,6 +5,7 @@ import { PgClient } from '@effect/sql-pg'
 import { Cause, Deferred, Duration, Effect, Exit, Fiber, Layer, ManagedRuntime, Option, Redacted } from 'effect'
 
 import authorityBoundIntents from '../../migrations/0016_authority_bound_intents'
+import stablePaperAuthorityGeneration from '../../migrations/0017_stable_paper_authority_generation'
 import type { RuntimeConfig } from '../config'
 import { makeStrategyProtocolHash } from '../contracts'
 import { IntentStore, IntentStoreLive, planPaperIntent, type IntentPlan } from '../execution/intents'
@@ -502,7 +503,7 @@ const makeMutationPaperAuthorityGeneration = (
 
   const config = makeConfig()
   return makePaperAuthorityGeneration({
-    schemaVersion: 'bayn.paper-authority-generation.v1',
+    schemaVersion: 'bayn.paper-authority-generation.v2',
     maximum: Authority.Paper,
     previousGenerationHash,
     qualificationRunId: mutationQualificationResult.runId,
@@ -877,10 +878,11 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       { migration_id: 14, name: 'authority_generation_history' },
       { migration_id: 15, name: 'acknowledged_submit_recovery' },
       { migration_id: 16, name: 'authority_bound_intents' },
+      { migration_id: 17, name: 'stable_paper_authority_generation' },
     ])
   })
 
-  test('hard-fails the authority-bound intent migration before touching nonempty intent history', async () => {
+  test('hard-fails both intent hard cuts before touching nonempty intent history or generation DDL', async () => {
     const observed = await runtime.runPromise(
       Effect.gen(function* () {
         const sql = yield* PgClient.PgClient
@@ -934,7 +936,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
           }),
         )
         const readEvidence = () =>
-          sql<{ intents: unknown; risk_decisions: unknown }>`
+          sql<{ constraint_definition: string; intents: unknown; risk_decisions: unknown }>`
             SELECT
               (
                 SELECT jsonb_agg(
@@ -949,11 +951,73 @@ describePostgres('PostgreSQL evaluation evidence', () => {
                   ORDER BY decision.decision_id
                 )
                 FROM risk_decisions AS decision
-              ) AS risk_decisions
+              ) AS risk_decisions,
+              pg_get_constraintdef(constraint_record.oid) AS constraint_definition
+            FROM pg_constraint AS constraint_record
+            WHERE constraint_record.conrelid = 'authority_generations'::regclass
+              AND constraint_record.conname = 'authority_generations_activation_schema_version_check'
           `
-        const before = yield* readEvidence()
-        const migration = yield* Effect.exit(authorityBoundIntents)
-        const after = yield* readEvidence()
+        const [before] = yield* readEvidence()
+        const authorityBoundMigration = yield* Effect.exit(authorityBoundIntents)
+        const [afterAuthorityBound] = yield* readEvidence()
+        const stableGenerationMigration = yield* Effect.exit(stablePaperAuthorityGeneration)
+        const [afterStableGeneration] = yield* readEvidence()
+        return {
+          afterAuthorityBound,
+          afterStableGeneration,
+          authorityBoundMigration,
+          before,
+          stableGenerationMigration,
+        }
+      }),
+    )
+
+    expect(Exit.isFailure(observed.authorityBoundMigration)).toBe(true)
+    if (Exit.isFailure(observed.authorityBoundMigration)) {
+      expect(Cause.pretty(observed.authorityBoundMigration.cause)).toContain(
+        'authority-bound intent hard cut requires empty intents and risk_decisions',
+      )
+    }
+    expect(Exit.isFailure(observed.stableGenerationMigration)).toBe(true)
+    if (Exit.isFailure(observed.stableGenerationMigration)) {
+      expect(Cause.pretty(observed.stableGenerationMigration.cause)).toContain(
+        'stable PAPER authority generation hard cut requires empty intents and risk_decisions',
+      )
+    }
+    expect(observed.afterAuthorityBound).toEqual(observed.before)
+    expect(observed.afterStableGeneration).toEqual(observed.before)
+    expect(observed.afterStableGeneration.constraint_definition).toContain('bayn.paper-authority-generation.v2')
+  })
+
+  test('hard-fails the stable authority-generation migration before reinterpreting PAPER history', async () => {
+    await activateAuditedPaperAuthority()
+    const observed = await runtime.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* PgClient.PgClient
+        const readEvidence = () =>
+          sql<{ authority: unknown; constraint_definition: string; history: unknown }>`
+            SELECT
+              (
+                SELECT jsonb_agg(
+                  jsonb_build_object('row', to_jsonb(authority), 'tupleId', authority.xmin::text)
+                )
+                FROM authority_state AS authority
+              ) AS authority,
+              (
+                SELECT jsonb_agg(
+                  jsonb_build_object('row', to_jsonb(history), 'tupleId', history.xmin::text)
+                  ORDER BY history.authority_version
+                )
+                FROM authority_generations AS history
+              ) AS history,
+              pg_get_constraintdef(oid) AS constraint_definition
+            FROM pg_constraint
+            WHERE conrelid = 'authority_generations'::regclass
+              AND conname = 'authority_generations_activation_schema_version_check'
+          `
+        const [before] = yield* readEvidence()
+        const migration = yield* Effect.exit(stablePaperAuthorityGeneration)
+        const [after] = yield* readEvidence()
         return { after, before, migration }
       }),
     )
@@ -961,10 +1025,11 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     expect(Exit.isFailure(observed.migration)).toBe(true)
     if (Exit.isFailure(observed.migration)) {
       expect(Cause.pretty(observed.migration.cause)).toContain(
-        'authority-bound intent hard cut requires empty intents and risk_decisions',
+        'stable PAPER authority generation hard cut requires no existing PAPER authority',
       )
     }
     expect(observed.after).toEqual(observed.before)
+    expect(observed.after.constraint_definition).toContain('bayn.paper-authority-generation.v2')
   })
 
   test('atomically commits one deterministic approved intent under one writer fence', async () => {

--- a/services/bayn/src/db/migrations.ts
+++ b/services/bayn/src/db/migrations.ts
@@ -16,6 +16,7 @@ import autonomousCycleTerminalTransitions from '../../migrations/0013_autonomous
 import authorityGenerationHistory from '../../migrations/0014_authority_generation_history'
 import acknowledgedSubmitRecovery from '../../migrations/0015_acknowledged_submit_recovery'
 import authorityBoundIntents from '../../migrations/0016_authority_bound_intents'
+import stablePaperAuthorityGeneration from '../../migrations/0017_stable_paper_authority_generation'
 
 export const migrationLoader = PgMigrator.fromRecord({
   '1_initial_schema': initialSchema,
@@ -34,4 +35,5 @@ export const migrationLoader = PgMigrator.fromRecord({
   '14_authority_generation_history': authorityGenerationHistory,
   '15_acknowledged_submit_recovery': acknowledgedSubmitRecovery,
   '16_authority_bound_intents': authorityBoundIntents,
+  '17_stable_paper_authority_generation': stablePaperAuthorityGeneration,
 })

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -525,7 +525,7 @@ const makeActivation = (
   overrides: Partial<Parameters<typeof makePaperAuthorityGeneration>[0]> = {},
 ) =>
   makePaperAuthorityGeneration({
-    schemaVersion: 'bayn.paper-authority-generation.v1',
+    schemaVersion: 'bayn.paper-authority-generation.v2',
     maximum: Authority.Paper,
     previousGenerationHash,
     qualificationRunId: qualification.result.runId,
@@ -1225,12 +1225,13 @@ describePostgres('paper accounting persistence', () => {
     }
   }, 15_000)
 
-  test('rejects reconciliation drift between PREPARE and activation without authority writes', async () => {
+  test('keeps generation identity stable while activation records the latest exact reconciliation', async () => {
     const initialGenerationHash = hash('prepare-reconciliation-drift-observe')
     const reconciliation = exactReconciliation('prepare-reconciliation-drift')
+    const activationReconciliation = exactReconciliation('post-prepare-reconciliation')
     const expected = makeActivation(initialGenerationHash, qualifiedEvidence, reconciliation)
     const prepareRuntime = makeStoreRuntime({ fail: false, planHashes: [] }, prepareRuntimeConfig(expected))
-    const prepared = await (async () => {
+    const preparation = await (async () => {
       try {
         return await prepareRuntime.runPromise(
           Effect.gen(function* () {
@@ -1241,9 +1242,12 @@ describePostgres('paper accounting persistence', () => {
               generationHash: initialGenerationHash,
               maximum: Authority.Observe,
             })
-            const receipt = yield* store.preparePaperGeneration(proofBinding(expected))
-            yield* seedExactReconciliation(exactReconciliation('post-prepare-reconciliation'))
-            return receipt
+            const before = yield* readAuthorityTupleEvidence
+            const prepared = yield* store.preparePaperGeneration(proofBinding(expected))
+            yield* seedExactReconciliation(activationReconciliation)
+            const refreshed = yield* store.preparePaperGeneration(proofBinding(expected))
+            const after = yield* readAuthorityTupleEvidence
+            return { after, before, prepared, refreshed }
           }),
         )
       } finally {
@@ -1251,23 +1255,41 @@ describePostgres('paper accounting persistence', () => {
       }
     })()
 
-    const activationRuntime = makeActivationRuntime({ fail: false, planHashes: [] }, prepared)
+    expect(preparation.after).toEqual(preparation.before)
+    expect(preparation.refreshed.generationHash).toBe(preparation.prepared.generationHash)
+    expect(preparation.refreshed).toMatchObject({
+      reconciliationContentHash: activationReconciliation.contentHash,
+      reconciliationId: activationReconciliation.reconciliationId,
+    })
+
+    const activationRuntime = makeActivationRuntime({ fail: false, planHashes: [] }, preparation.prepared)
     try {
       const result = await activationRuntime.runPromise(
         Effect.gen(function* () {
           const store = yield* PaperStore
           const before = yield* readAuthorityTupleEvidence
-          const failure = yield* Effect.flip(store.activatePaperGeneration(proofBinding(prepared)))
+          const activated = yield* store.activatePaperGeneration(proofBinding(preparation.prepared))
           const after = yield* readAuthorityTupleEvidence
-          return { after, before, failure }
+          const sql = yield* PgClient.PgClient
+          const [history] = yield* sql<{ reconciliation_content_hash: string; reconciliation_id: string }>`
+            SELECT reconciliation_id, reconciliation_content_hash
+            FROM authority_generations
+            WHERE generation_hash = ${preparation.prepared.generationHash}
+          `
+          return { activated, after, before, history }
         }),
       )
-      expect(result.failure).toMatchObject({
-        operation: 'authority',
-        failure: 'invariant',
-        message: 'derived PAPER generation differs from the configured generation',
+      expect(result.activated).toMatchObject({
+        generationHash: preparation.prepared.generationHash,
+        maximum: Authority.Paper,
+        effective: Authority.Paper,
       })
-      expect(result.after).toEqual(result.before)
+      expect(result.after).not.toEqual(result.before)
+      expect(result.history).toEqual({
+        reconciliation_id: activationReconciliation.reconciliationId,
+        reconciliation_content_hash: activationReconciliation.contentHash,
+      })
+      expect(result.history.reconciliation_id).not.toBe(preparation.prepared.reconciliationId)
     } finally {
       await activationRuntime.dispose()
     }
@@ -1500,10 +1522,14 @@ describePostgres('paper accounting persistence', () => {
             authority_tuple: string
             history_count: number
             paper_tuple: string
+            reconciliation_content_hash: string
+            reconciliation_id: string
           }>`
             SELECT
               authority.xmin::text AS authority_tuple,
               paper.xmin::text AS paper_tuple,
+              paper.reconciliation_id,
+              paper.reconciliation_content_hash,
               (SELECT count(*)::integer FROM authority_generations) AS history_count
             FROM authority_state AS authority
             JOIN authority_generations AS paper
@@ -1521,10 +1547,14 @@ describePostgres('paper accounting persistence', () => {
             authority_tuple: string
             history_count: number
             paper_tuple: string
+            reconciliation_content_hash: string
+            reconciliation_id: string
           }>`
             SELECT
               authority.xmin::text AS authority_tuple,
               paper.xmin::text AS paper_tuple,
+              paper.reconciliation_id,
+              paper.reconciliation_content_hash,
               (SELECT count(*)::integer FROM authority_generations) AS history_count
             FROM authority_state AS authority
             JOIN authority_generations AS paper
@@ -1592,6 +1622,10 @@ describePostgres('paper accounting persistence', () => {
       expect(result.replay).toEqual(result.activated)
       expect(result.changedProof).toMatchObject({ operation: 'authority', failure: 'conflict' })
       expect(result.afterReplay).toEqual(result.beforeReplay)
+      expect(result.afterReplay).toMatchObject({
+        reconciliation_content_hash: reconciliation.contentHash,
+        reconciliation_id: reconciliation.reconciliationId,
+      })
       expect(Exit.isFailure(result.mutateHistory)).toBe(true)
       expect(Exit.isFailure(result.deleteHistory)).toBe(true)
       expect(Exit.isFailure(result.truncateHistory)).toBe(true)

--- a/services/bayn/src/db/paper-store.ts
+++ b/services/bayn/src/db/paper-store.ts
@@ -109,18 +109,19 @@ export interface PaperStoreShape {
     input: EnsureAuthorityGenerationInput,
   ) => Effect.Effect<AuthorityState, PaperStoreError>
   /**
-   * PREPARE operation: under configured OBSERVE, transactionally derives the complete canonical PAPER generation
-   * receipt from durable qualification, reconciliation, authority, and current-build evidence without writing
-   * authority state or history. Commit only its generationHash to the later PAPER configuration.
+   * PREPARE operation: under configured OBSERVE, transactionally derives the stable canonical PAPER generation
+   * identity plus the current reconciliation evidence without writing authority state or history. Commit only its
+   * generationHash to the later PAPER configuration.
    */
   readonly preparePaperGeneration: (
     proof: PaperAuthorityProofBinding,
   ) => Effect.Effect<PaperAuthorityGeneration, PaperStoreError, WriterFence>
   /**
-   * SUBMIT activation operation: under configured PAPER, transactionally re-derives the complete generation from the
-   * same proof binding and activates it only when its hash equals the configured generationHash. This is the sole
-   * supported cross-generation PAPER writer; application code and operators must not issue direct DML against
-   * authority_state or authority_generations.
+   * SUBMIT activation operation: under configured PAPER, transactionally re-derives the stable generation identity
+   * from the same proof binding, requires its hash to equal the configured generationHash, and records the latest
+   * fresh exact reconciliation as immutable activation evidence. This is the sole supported cross-generation PAPER
+   * writer; application code and operators must not issue direct DML against authority_state or
+   * authority_generations.
    */
   readonly activatePaperGeneration: (
     proof: PaperAuthorityProofBinding,
@@ -201,7 +202,7 @@ const AuthorityStateRows = Schema.Array(AuthorityStateRow).check(Schema.isMaxLen
 const AuthorityStateObservationRows = Schema.Array(AuthorityStateObservationRow).check(Schema.isMaxLength(1))
 const AuthorityGenerationRow = Schema.Struct({
   generation_hash: Sha256,
-  activation_schema_version: Schema.NullOr(Schema.Literal('bayn.paper-authority-generation.v1')),
+  activation_schema_version: Schema.NullOr(Schema.Literal('bayn.paper-authority-generation.v2')),
   previous_generation_hash: Schema.NullOr(Sha256),
   maximum: Schema.Enum(Authority),
   authority_version: Schema.String,
@@ -1572,7 +1573,7 @@ const makeStore = (config: PaperStoreRuntimeConfig) =>
         const generation = yield* Effect.try({
           try: () =>
             makePaperAuthorityGeneration({
-              schemaVersion: 'bayn.paper-authority-generation.v1',
+              schemaVersion: 'bayn.paper-authority-generation.v2',
               maximum: Authority.Paper,
               previousGenerationHash: current.generationHash,
               qualificationRunId: result.runId,

--- a/services/bayn/src/execution/intents.test.ts
+++ b/services/bayn/src/execution/intents.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'bun:test'
 import { Effect, Exit } from 'effect'
 
 import { Authority, IntentState, KillState, OrderSide, OrderType, TimeInForce } from '../paper'
-import { plan, planPaperIntent, type IntentPlan } from './intents'
+import { paperIntentIdForPlan, plan, planPaperIntent, type IntentPlan } from './intents'
 
 const hash = (digit: string): string => digit.repeat(64)
 
@@ -93,15 +93,17 @@ describe('deterministic paper intents', () => {
   })
 
   test('binds a durable PAPER identity to the exact risk-state authority generation', async () => {
-    const [first, replay, rotated] = await Effect.runPromise(
+    const [first, replay, rotated, derivedId] = await Effect.runPromise(
       Effect.all([
         planPaperIntent(input, riskState()),
         planPaperIntent({ ...input }, riskState()),
         planPaperIntent(input, riskState(hash('b'))),
+        paperIntentIdForPlan(input, hash('a')),
       ]),
     )
 
     expect(first).toEqual(replay)
+    expect(derivedId).toBe(first.intentId)
     expect(first).toMatchObject({
       schemaVersion: 'bayn.paper-intent.v3',
       authorityGenerationHash: hash('a'),
@@ -110,6 +112,23 @@ describe('deterministic paper intents', () => {
     expect(rotated.authorityGenerationHash).toBe(hash('b'))
     expect(rotated.intentId).not.toBe(first.intentId)
     expect(rotated.clientOrderId).not.toBe(first.clientOrderId)
+  })
+
+  test('derives the v3 identity without authority state and rejects malformed material', async () => {
+    const [baseline, changedTime, changedGeneration] = await Effect.runPromise(
+      Effect.all([
+        paperIntentIdForPlan(input, hash('a')),
+        paperIntentIdForPlan({ ...input, createdAt: '2026-07-22T10:00:01.000Z' }, hash('a')),
+        paperIntentIdForPlan(input, hash('b')),
+      ]),
+    )
+
+    expect(changedTime).toBe(baseline)
+    expect(changedGeneration).not.toBe(baseline)
+    expect(
+      Exit.isFailure(await Effect.runPromiseExit(paperIntentIdForPlan({ ...input, extra: true }, hash('a')))),
+    ).toBe(true)
+    expect(Exit.isFailure(await Effect.runPromiseExit(paperIntentIdForPlan(input, 'not-a-hash')))).toBe(true)
   })
 
   test('refuses to create a durable intent from OBSERVE authority', async () => {

--- a/services/bayn/src/execution/intents.ts
+++ b/services/bayn/src/execution/intents.ts
@@ -51,6 +51,7 @@ export const IntentPlanSchema = Schema.Struct({
 export type IntentPlan = typeof IntentPlanSchema.Type
 
 const decodePlan = Schema.decodeUnknownEffect(IntentPlanSchema, strictParseOptions)
+const decodeAuthorityGenerationHash = Schema.decodeUnknownEffect(Sha256, strictParseOptions)
 const intentEquivalent = Schema.toEquivalence(IntentSchema)
 const decisionEquivalent = Schema.toEquivalence(RiskDecisionSchema)
 
@@ -83,7 +84,15 @@ const paperIdentityMaterial = (input: IntentPlan, authorityGenerationHash: strin
   notionalLimitMicros: input.notionalLimitMicros,
 })
 
+const paperIntentId = (input: IntentPlan, authorityGenerationHash: string): string =>
+  canonicalHashV1(paperIdentityMaterial(input, authorityGenerationHash))
+
 export const intentIdForPlan = (input: IntentPlan): string => canonicalHashV1(referenceIdentityMaterial(input))
+
+export const paperIntentIdForPlan = (input: unknown, authorityGenerationHash: string) =>
+  Effect.all([decodePlan(input), decodeAuthorityGenerationHash(authorityGenerationHash)]).pipe(
+    Effect.map(([decoded, generationHash]) => paperIntentId(decoded, generationHash)),
+  )
 
 const clientOrderId = (intentId: string): string => `b1_${Buffer.from(intentId, 'hex').toString('base64url')}`
 
@@ -113,7 +122,7 @@ const makePaperIntent = (
   decoded: IntentPlan,
   authorityGenerationHash: string,
 ): Effect.Effect<Intent, Schema.SchemaError> => {
-  const intentId = canonicalHashV1(paperIdentityMaterial(decoded, authorityGenerationHash))
+  const intentId = paperIntentId(decoded, authorityGenerationHash)
   return decodeIntent({
     schemaVersion: 'bayn.paper-intent.v3',
     authorityGenerationHash,

--- a/services/bayn/src/paper.test.ts
+++ b/services/bayn/src/paper.test.ts
@@ -423,7 +423,7 @@ describe('paper contracts', () => {
       proofPlanHash: hash('d'),
     }
     const material = {
-      schemaVersion: 'bayn.paper-authority-generation.v1' as const,
+      schemaVersion: 'bayn.paper-authority-generation.v2' as const,
       maximum: Authority.Paper as const,
       previousGenerationHash: hash('0'),
       qualificationRunId: hash('1'),
@@ -477,10 +477,23 @@ describe('paper contracts', () => {
         activationSourceRevision: '2'.repeat(40),
       }).generationHash,
     ).not.toBe(generation.generationHash)
+    expect(
+      makePaperAuthorityGeneration({
+        ...material,
+        reconciliationId: hash('0'),
+        reconciliationContentHash: hash('1'),
+      }).generationHash,
+    ).toBe(generation.generationHash)
     await expectFailure(
       decodePaperAuthorityGeneration({
         ...generation,
         generationHash: hash('1'),
+      }),
+    )
+    await expectFailure(
+      decodePaperAuthorityGeneration({
+        ...generation,
+        schemaVersion: 'bayn.paper-authority-generation.v1',
       }),
     )
     expect(() =>

--- a/services/bayn/src/paper.ts
+++ b/services/bayn/src/paper.ts
@@ -600,8 +600,8 @@ export const PaperAuthorityProofBindingSchema = Schema.Struct({
 })
 export type PaperAuthorityProofBinding = typeof PaperAuthorityProofBindingSchema.Type
 
-export const PaperAuthorityGenerationMaterialSchema = Schema.Struct({
-  schemaVersion: Schema.Literal('bayn.paper-authority-generation.v1'),
+const PaperAuthorityGenerationIdentityMaterialSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.paper-authority-generation.v2'),
   maximum: Schema.Literal(Authority.Paper),
   previousGenerationHash: Sha256,
   qualificationRunId: Sha256,
@@ -622,10 +622,23 @@ export const PaperAuthorityGenerationMaterialSchema = Schema.Struct({
   accountId: NonEmptyString,
   riskPolicyHash: Sha256,
   proofPlanHash: Sha256,
+})
+
+export const PaperAuthorityGenerationMaterialSchema = Schema.Struct({
+  ...PaperAuthorityGenerationIdentityMaterialSchema.fields,
   reconciliationId: Sha256,
   reconciliationContentHash: Sha256,
 })
 export type PaperAuthorityGenerationMaterial = typeof PaperAuthorityGenerationMaterialSchema.Type
+
+const paperAuthorityGenerationIdentity = (material: PaperAuthorityGenerationMaterial) => {
+  const {
+    reconciliationContentHash: _reconciliationContentHash,
+    reconciliationId: _reconciliationId,
+    ...identity
+  } = material
+  return identity
+}
 
 const PaperAuthorityGenerationBase = Schema.Struct({
   ...PaperAuthorityGenerationMaterialSchema.fields,
@@ -636,9 +649,9 @@ export const PaperAuthorityGenerationSchema = PaperAuthorityGenerationBase.check
   Schema.makeFilter(
     (generation: typeof PaperAuthorityGenerationBase.Type) => {
       const { generationHash, ...material } = generation
-      return generationHash === canonicalHashV1(material)
+      return generationHash === canonicalHashV1(paperAuthorityGenerationIdentity(material))
     },
-    { expected: 'a generation hash matching the complete PAPER authority material' },
+    { expected: 'a generation hash matching the stable PAPER authority identity' },
   ),
 )
 export type PaperAuthorityGeneration = typeof PaperAuthorityGenerationSchema.Type
@@ -653,7 +666,7 @@ export const makePaperAuthorityGeneration = (input: PaperAuthorityGenerationMate
   const material = decodePaperAuthorityGenerationMaterialSync(input)
   return decodePaperAuthorityGenerationSync({
     ...material,
-    generationHash: canonicalHashV1(material),
+    generationHash: canonicalHashV1(paperAuthorityGenerationIdentity(material)),
   })
 }
 


### PR DESCRIPTION
## Summary

- introduce `bayn.paper-authority-generation.v2`, whose generation hash binds stable qualification, build, strategy, account, risk-policy, and proof-plan identity while excluding reconciliation evidence
- retain the latest fresh exact reconciliation as immutable activation history and preserve transactionally checked freshness, mutation coverage, concurrency, kill, and replay behavior
- add migration 0017 with a fail-closed hard cut for any PAPER authority/history or any intents/risk decisions, plus export `paperIntentIdForPlan` for pure v3 replay lookup

## Related Issues

PROOMPT-408

## Testing

- `bun test services/bayn/src/paper.test.ts services/bayn/src/execution/intents.test.ts` — 16 passed
- `BAYN_TEST_POSTGRES_URL=postgresql://gregkonush@127.0.0.1:5432/bayn_test bun test services/bayn/src/db/paper-store.integration.test.ts` — 27 passed
- `BAYN_TEST_POSTGRES_URL=postgresql://gregkonush@127.0.0.1:5432/bayn_test bun test services/bayn/src/db/evidence-store.integration.test.ts` — 51 passed
- `bun run --cwd services/bayn test` — 414 passed, 104 PostgreSQL-gated tests skipped
- `bun run --cwd services/bayn tsc`
- `bun run --cwd services/bayn lint`
- `bun run --cwd services/bayn lint:oxlint`
- `bun run --cwd services/bayn lint:oxlint:type`
- `bun run --cwd services/bayn build`
- `bun test packages/scripts/src/bayn` — 20 passed
- Full local cycle-store PostgreSQL validation retained 12 passing tests and reproduced the existing unrelated restart assertion (`WAITING` observed where the test expects `ACTIVATED`); this PR does not touch cycle-runner/store behavior or weaken that assertion.

## Breaking Changes

Migration 0017 deliberately refuses to reinterpret an existing PAPER authority generation or any intent/risk history. It only upgrades a clean OBSERVE authority boundary; operators must not backfill or bypass the hard cut.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (screenshots are not applicable; the hard cut is documented above).
- [x] Documentation, release notes, and follow-ups are updated or tracked (the PaperStore API contract is updated in source; command composition remains in the separately owned follow-up).