### PR TITLE
refactor(bayn): extract health functional core

### DIFF
--- a/services/bayn/src/health.test.ts
+++ b/services/bayn/src/health.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Deferred, Effect, Fiber, Ref } from 'effect'
+import { Deferred, Effect, Fiber, Ref, Result } from 'effect'
 import { TestClock } from 'effect/testing'
 
-import { config, successfulJournal, readyState, recoveringStore } from './app-test-support'
+import { config, fixtureLock, successfulJournal, readyState, recoveringStore } from './app-test-support'
 import { monitor, probe } from './app'
 import { AccountStatus, type BrokerReadShape, type ReadResult, type Account } from './broker/alpaca'
 import { unusedAssetBySymbol, unusedMarketCalendar } from './broker/alpaca-test-support'
@@ -11,7 +11,17 @@ import { CycleOperationsCondition, CycleOperationsReason, type CycleOperationsPr
 import { CycleState } from './cycle'
 import { CycleObservability, type CycleObservabilityShape } from './db/cycle-observability'
 import { EvidenceStore } from './db/evidence-store'
-import type { BrokerProbe } from './health'
+import {
+  deriveHealthLogDecisions,
+  deriveHealthTransition,
+  type BrokerProbe,
+  ensureDurableEvidence,
+  ensureSignalIdentity,
+  renderDurableEvidenceFailure,
+  renderSignalIdentityFailure,
+  validateDurableEvidence,
+  validateSignalIdentity,
+} from './health'
 import { Journal, type JournalService } from './ledger'
 import { MarketData, type MarketDataService } from './market-data'
 import { initialState, type RuntimeState } from './runtime-state'
@@ -63,6 +73,25 @@ const emptyCycleProjection = (): CycleOperationsProjection => ({
   mutations: { eventCount: 0, unresolvedCount: 0, oldestUnresolvedAt: null, latestOccurredAt: null },
 })
 
+const pendingCycle = (updatedAt: string) =>
+  ({
+    cycleId: '1'.repeat(64),
+    accountId: 'paper-account-1',
+    signalSessionDate: '2026-07-17',
+    executionSessionDate: '2026-07-20',
+    phase: CycleState.Pending,
+    snapshotId: '2'.repeat(64),
+    decisionHash: null,
+    terminalReason: null,
+    submissionOpenAt: '2026-07-20T00:00:00.000Z',
+    submissionCutoffAt: '2026-07-20T01:00:00.000Z',
+    executionOpenAt: '2026-07-20T01:02:00.000Z',
+    executionCloseAt: '2026-07-20T20:00:00.000Z',
+    createdAt: updatedAt,
+    updatedAt,
+    terminalAt: null,
+  }) as const
+
 const cycleObservability = (
   read: CycleObservabilityShape['read'] = () => Effect.succeed(emptyCycleProjection()),
 ): CycleObservabilityShape => ({ read })
@@ -88,6 +117,322 @@ const provideHealthyDependencies = (
   )
 
 describe('Bayn continuous health', () => {
+  test('returns structured signal and durable evidence invariant failures', () => {
+    const current = readyState()
+    const evidence = current.evidence
+    expect(evidence).not.toBeNull()
+    if (evidence === null) return
+    const snapshot = makeSnapshot().manifest.finalizedSnapshot
+    const observedSnapshotId = 'f'.repeat(64)
+    const observedPublicationId = 'e'.repeat(64)
+
+    expect(validateSignalIdentity(snapshot, null)).toEqual(Result.fail({ _tag: 'EvidenceUnavailable' }))
+    expect(renderSignalIdentityFailure({ _tag: 'EvidenceUnavailable' })).toBe('startup evidence is unavailable')
+    expect(validateSignalIdentity({ ...snapshot, snapshotId: observedSnapshotId }, evidence)).toEqual(
+      Result.fail({
+        _tag: 'SnapshotMismatch',
+        observedSnapshotId,
+        expectedSnapshotId: evidence.evaluation.input.snapshotId,
+      }),
+    )
+    expect(
+      renderSignalIdentityFailure({
+        _tag: 'SnapshotMismatch',
+        observedSnapshotId,
+        expectedSnapshotId: evidence.evaluation.input.snapshotId,
+      }),
+    ).toBe(
+      `configured Signal snapshot ${observedSnapshotId} differs from active run snapshot ${evidence.evaluation.input.snapshotId}`,
+    )
+    expect(validateSignalIdentity({ ...snapshot, publicationId: observedPublicationId }, evidence)).toEqual(
+      Result.fail({
+        _tag: 'PublicationMismatch',
+        observedPublicationId,
+        expectedPublicationId: evidence.evaluation.input.publicationId,
+      }),
+    )
+    expect(
+      renderSignalIdentityFailure({
+        _tag: 'PublicationMismatch',
+        observedPublicationId,
+        expectedPublicationId: evidence.evaluation.input.publicationId,
+      }),
+    ).toBe(
+      `configured Signal publication ${observedPublicationId} differs from active run publication ${evidence.evaluation.input.publicationId}`,
+    )
+    expect(validateSignalIdentity(snapshot, evidence)).toEqual(Result.succeed(undefined))
+
+    const recovered = {
+      evaluation: evidence.evaluation,
+      reconciliation: evidence.reconciliation,
+      persistence: { ...evidence.persistence, deduplicated: true },
+    }
+    const qualification = {
+      state: 'TERMINAL' as const,
+      lock: fixtureLock,
+      result: evidence.qualification,
+    }
+    expect(validateDurableEvidence(null, null, null)).toEqual(Result.fail({ _tag: 'EvidenceUnavailable' }))
+    expect(renderDurableEvidenceFailure({ _tag: 'EvidenceUnavailable' })).toBe('startup evidence is unavailable')
+    expect(validateDurableEvidence(null, qualification, evidence)).toEqual(
+      Result.fail({
+        _tag: 'RunMissing',
+        runId: evidence.evaluation.runId,
+      }),
+    )
+    expect(renderDurableEvidenceFailure({ _tag: 'RunMissing', runId: evidence.evaluation.runId })).toBe(
+      `durable run ${evidence.evaluation.runId} is missing`,
+    )
+    expect(validateDurableEvidence(recovered, null, evidence)).toEqual(
+      Result.fail({
+        _tag: 'TerminalQualificationMissing',
+        runId: evidence.evaluation.runId,
+        observedState: null,
+      }),
+    )
+    expect(
+      renderDurableEvidenceFailure({
+        _tag: 'TerminalQualificationMissing',
+        runId: evidence.evaluation.runId,
+        observedState: null,
+      }),
+    ).toBe(`terminal qualification ${evidence.evaluation.runId} is missing`)
+    const incompleteQualification = { state: 'OPENED_INCOMPLETE' as const, lock: fixtureLock }
+    expect(validateDurableEvidence(recovered, incompleteQualification, evidence)).toEqual(
+      Result.fail({
+        _tag: 'TerminalQualificationMissing',
+        runId: evidence.evaluation.runId,
+        observedState: 'OPENED_INCOMPLETE',
+      }),
+    )
+    expect(
+      renderDurableEvidenceFailure({
+        _tag: 'TerminalQualificationMissing',
+        runId: evidence.evaluation.runId,
+        observedState: 'OPENED_INCOMPLETE',
+      }),
+    ).toBe(`qualification ${evidence.evaluation.runId} is OPENED_INCOMPLETE, expected TERMINAL`)
+    const mismatch = validateDurableEvidence(
+      {
+        ...recovered,
+        persistence: { ...recovered.persistence, eventCount: recovered.persistence.eventCount + 1 },
+      },
+      qualification,
+      evidence,
+    )
+    expect(Result.isFailure(mismatch)).toBe(true)
+    expect(Result.isFailure(mismatch) ? mismatch.failure._tag : null).toBe('RunMismatch')
+    if (Result.isFailure(mismatch) && mismatch.failure._tag === 'RunMismatch') {
+      expect(mismatch.failure).toMatchObject({
+        runId: evidence.evaluation.runId,
+        observedDurableHash: expect.stringMatching(/^[0-9a-f]{64}$/),
+        expectedDurableHash: expect.stringMatching(/^[0-9a-f]{64}$/),
+      })
+      expect(mismatch.failure.observedDurableHash).not.toBe(mismatch.failure.expectedDurableHash)
+      expect(renderDurableEvidenceFailure(mismatch.failure)).toBe(
+        `durable run ${evidence.evaluation.runId} hash ${mismatch.failure.observedDurableHash} differs from active proof hash ${mismatch.failure.expectedDurableHash}`,
+      )
+    }
+
+    const qualificationMismatch = validateDurableEvidence(
+      recovered,
+      {
+        ...qualification,
+        result: { ...qualification.result, resultHash: '0'.repeat(64) },
+      },
+      evidence,
+    )
+    expect(Result.isFailure(qualificationMismatch)).toBe(true)
+    expect(Result.isFailure(qualificationMismatch) ? qualificationMismatch.failure._tag : null).toBe(
+      'TerminalQualificationMismatch',
+    )
+    if (
+      Result.isFailure(qualificationMismatch) &&
+      qualificationMismatch.failure._tag === 'TerminalQualificationMismatch'
+    ) {
+      expect(qualificationMismatch.failure).toMatchObject({
+        runId: evidence.evaluation.runId,
+        observedQualificationHash: expect.stringMatching(/^[0-9a-f]{64}$/),
+        expectedQualificationHash: expect.stringMatching(/^[0-9a-f]{64}$/),
+      })
+      expect(qualificationMismatch.failure.observedQualificationHash).not.toBe(
+        qualificationMismatch.failure.expectedQualificationHash,
+      )
+      expect(renderDurableEvidenceFailure(qualificationMismatch.failure)).toBe(
+        `terminal qualification ${evidence.evaluation.runId} hash ${qualificationMismatch.failure.observedQualificationHash} differs from active proof hash ${qualificationMismatch.failure.expectedQualificationHash}`,
+      )
+    }
+
+    const malformedEvidence = {
+      ...evidence,
+      persistence: { ...evidence.persistence, runId: '\ud800' },
+    }
+    const totality = Result.try(() => validateDurableEvidence(recovered, qualification, malformedEvidence))
+    expect(Result.isSuccess(totality)).toBe(true)
+    if (Result.isSuccess(totality)) {
+      const canonicalization = totality.success
+      expect(Result.isFailure(canonicalization) ? canonicalization.failure._tag : null).toBe('CanonicalizationFailed')
+      if (Result.isFailure(canonicalization) && canonicalization.failure._tag === 'CanonicalizationFailed') {
+        expect(canonicalization.failure.runId).toBe(evidence.evaluation.runId)
+        expect(canonicalization.failure.material).toBe('EXPECTED_DURABLE_EVIDENCE')
+        expect(canonicalization.failure.cause).toBeInstanceOf(TypeError)
+        expect(String(canonicalization.failure.cause)).toBe(
+          'TypeError: $.persistence.runId contains an invalid Unicode surrogate',
+        )
+        expect(renderDurableEvidenceFailure(canonicalization.failure)).toBe(
+          `canonicalization of EXPECTED_DURABLE_EVIDENCE for run ${evidence.evaluation.runId} failed: TypeError: $.persistence.runId contains an invalid Unicode surrogate`,
+        )
+      }
+    }
+    expect(validateDurableEvidence(recovered, qualification, evidence)).toEqual(Result.succeed(undefined))
+  })
+
+  test('retains structured invariant failures as OperationalError causes', async () => {
+    const current = readyState()
+    const evidence = current.evidence
+    expect(evidence).not.toBeNull()
+    if (evidence === null) return
+    const snapshot = makeSnapshot().manifest.finalizedSnapshot
+    const observedSnapshotId = 'f'.repeat(64)
+    const signalFailure = {
+      _tag: 'SnapshotMismatch' as const,
+      observedSnapshotId,
+      expectedSnapshotId: evidence.evaluation.input.snapshotId,
+    }
+
+    const signalError = await Effect.runPromise(
+      Effect.flip(ensureSignalIdentity({ ...snapshot, snapshotId: observedSnapshotId }, evidence)),
+    )
+    expect(signalError).toMatchObject({
+      component: 'market-data',
+      operation: 'check-identity',
+      message: `Signal identity check failed: ${renderSignalIdentityFailure(signalFailure)}`,
+      retryable: false,
+      cause: signalFailure,
+    })
+
+    const recovered = {
+      evaluation: evidence.evaluation,
+      reconciliation: evidence.reconciliation,
+      persistence: { ...evidence.persistence, deduplicated: true },
+    }
+    const qualification = {
+      state: 'TERMINAL' as const,
+      lock: fixtureLock,
+      result: evidence.qualification,
+    }
+    const malformedEvidence = {
+      ...evidence,
+      persistence: { ...evidence.persistence, runId: '\ud800' },
+    }
+    const durableError = await Effect.runPromise(
+      Effect.flip(ensureDurableEvidence(recovered, qualification, malformedEvidence)),
+    )
+    expect(durableError).toMatchObject({
+      component: 'database',
+      operation: 'verify-evidence',
+      retryable: false,
+      cause: {
+        _tag: 'CanonicalizationFailed',
+        runId: evidence.evaluation.runId,
+        material: 'EXPECTED_DURABLE_EVIDENCE',
+      },
+    })
+    const durableCause = durableError.cause
+    if (
+      durableCause !== null &&
+      typeof durableCause === 'object' &&
+      '_tag' in durableCause &&
+      durableCause._tag === 'CanonicalizationFailed' &&
+      'cause' in durableCause
+    ) {
+      expect(durableCause.cause).toBeInstanceOf(TypeError)
+    }
+    expect(durableError.message).toBe(
+      `durable evidence verification failed: canonicalization of EXPECTED_DURABLE_EVIDENCE for run ${evidence.evaluation.runId} failed: TypeError: $.persistence.runId contains an invalid Unicode surrogate`,
+    )
+  })
+
+  test('derives immutable runtime transitions and exact log decisions from probe data', () => {
+    const current = readyState()
+    const original = structuredClone(current)
+    const checkedAt = '2026-07-20T00:04:00.000Z'
+    const checkedAtMs = Date.parse(checkedAt)
+    const pending = pendingCycle('2026-07-20T00:03:30.000Z')
+    const transition = deriveHealthTransition(current, {
+      config,
+      evidenceAvailable: true,
+      results: {
+        postgresql: { _tag: 'Available', value: undefined },
+        signal: { _tag: 'Unavailable', error: 'Signal identity mismatch' },
+        tigerBeetle: { _tag: 'Available', value: undefined },
+        durableEvidence: { _tag: 'Available', value: undefined },
+        cycle: {
+          _tag: 'Available',
+          value: {
+            ...emptyCycleProjection(),
+            current: pending,
+            unfinishedCycleCount: 1,
+          },
+        },
+        broker: null,
+      },
+      broker: undefined,
+      cycleFiber: { _tag: 'NotProvided' },
+      checkedAt,
+      checkedAtMs,
+    })
+
+    expect(current).toEqual(original)
+    expect(transition).toMatchObject({
+      current,
+      next: {
+        status: 'DEGRADED',
+        error: 'signal: Signal identity mismatch',
+        health: { sequence: 2 },
+        cycle: {
+          condition: CycleOperationsCondition.Running,
+          reason: CycleOperationsReason.AwaitingActivation,
+          attemptAgeMs: 30_000,
+        },
+      },
+      failedDependencies: ['signal'],
+      checkedAt,
+    })
+    expect(deriveHealthLogDecisions(transition)).toEqual([
+      {
+        _tag: 'RuntimeStatusChanged',
+        level: 'WARNING',
+        message: 'Bayn health changed to DEGRADED',
+        annotations: {
+          service: 'bayn',
+          checkedAt,
+          probeSequence: 2,
+          failedDependencies: 'signal',
+        },
+      },
+      {
+        _tag: 'CycleOperationsChanged',
+        level: 'INFO',
+        message: 'Bayn cycle operations changed to RUNNING',
+        annotations: {
+          service: 'bayn',
+          checkedAt,
+          cycleCondition: CycleOperationsCondition.Running,
+          cycleReason: CycleOperationsReason.AwaitingActivation,
+          currentCycleId: pending.cycleId,
+          currentPhase: CycleState.Pending,
+          signalSessionDate: pending.signalSessionDate,
+          submissionCutoffAt: pending.submissionCutoffAt,
+          attemptAgeMs: 30_000,
+          unfinishedCycleCount: 1,
+          unresolvedMutationCount: 0,
+          zeroMutation: true,
+        },
+      },
+    ])
+  })
+
   test('requires the configured broker account GET while keeping execution disabled under OBSERVE', async () => {
     let observedAccountId = brokerAccountId
     let brokerAvailable = true
@@ -206,6 +551,63 @@ describe('Bayn continuous health', () => {
     } finally {
       await Effect.runPromise(Fiber.interrupt(cycleFiber))
     }
+  })
+
+  test('times out and interrupts the broker account probe exactly once', async () => {
+    const startedAt = '2026-07-20T00:00:00.000Z'
+    let finalizations = 0
+    const program = Effect.scoped(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse(startedAt))
+        const accountStarted = yield* Deferred.make<void>()
+        const broker: BrokerProbe = {
+          read: brokerRead(
+            Deferred.succeed(accountStarted, undefined).pipe(
+              Effect.andThen(Effect.never),
+              Effect.onInterrupt(() => Effect.sync(() => void (finalizations += 1))),
+            ),
+          ),
+          expectedAccountId: brokerAccountId,
+          executionEligible: false,
+          executionDisabledReason: 'MAXIMUM_AUTHORITY_OBSERVE',
+        }
+        const initial: RuntimeState = {
+          ...readyState(),
+          autonomousCycleLoop: {
+            configured: true,
+            startedAt,
+            lastPass: { result: 'SUCCESS', observedAt: startedAt, outcome: 'NO_PUBLICATION' },
+          },
+          broker: initialState(broker, true).broker,
+        }
+        const state = yield* Ref.make(initial)
+        const cycleFiber = yield* Effect.never.pipe(Effect.forkScoped({ startImmediately: true }))
+        const healthFiber = yield* provideHealthyDependencies(initial, probe(config, state, broker, cycleFiber)).pipe(
+          Effect.forkScoped({ startImmediately: true }),
+        )
+
+        yield* Deferred.await(accountStarted)
+        yield* TestClock.adjust(config.operationTimeoutMs - 1)
+        expect(finalizations).toBe(0)
+        yield* TestClock.adjust(1)
+        yield* Fiber.join(healthFiber)
+
+        expect(finalizations).toBe(1)
+        expect(yield* Ref.get(state)).toMatchObject({
+          status: 'DEGRADED',
+          broker: {
+            accountId: null,
+            accountBound: false,
+            readAvailable: false,
+            error: `Alpaca account probe timed out after ${config.operationTimeoutMs}ms`,
+          },
+          error: `broker: Alpaca account probe timed out after ${config.operationTimeoutMs}ms`,
+        })
+      }),
+    ).pipe(Effect.provide(TestClock.layer()))
+
+    await Effect.runPromise(program)
+    expect(finalizations).toBe(1)
   })
 
   test('degrades when Alpaca is configured without the autonomous cycle runner', async () => {
@@ -549,6 +951,45 @@ describe('Bayn continuous health', () => {
     await Effect.runPromise(program)
   })
 
+  test('surfaces an interrupted autonomous cycle fiber as a runner failure', async () => {
+    const initial: RuntimeState = {
+      ...readyState(),
+      autonomousCycleLoop: {
+        configured: true,
+        startedAt: '2026-07-20T00:00:00.000Z',
+        lastPass: {
+          result: 'SUCCESS',
+          observedAt: '2026-07-20T00:00:00.000Z',
+          outcome: 'NO_PUBLICATION',
+        },
+      },
+    }
+    const state = await Effect.runPromise(Ref.make(initial))
+    const program = Effect.scoped(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse('2026-07-20T00:00:01.000Z'))
+        const interruptedFiber = yield* Effect.never.pipe(Effect.forkScoped({ startImmediately: true }))
+        yield* Fiber.interrupt(interruptedFiber)
+        yield* provideHealthyDependencies(initial, probe(config, state, undefined, interruptedFiber))
+
+        expect(yield* Ref.get(state)).toMatchObject({
+          status: 'DEGRADED',
+          health: {
+            dependencies: {
+              cycleRunner: {
+                status: 'UNAVAILABLE',
+                error: 'autonomous cycle loop failed: All fibers interrupted without error',
+              },
+            },
+          },
+          error: 'cycleRunner: autonomous cycle loop failed: All fibers interrupted without error',
+        })
+      }),
+    ).pipe(Effect.provide(TestClock.layer()))
+
+    await Effect.runPromise(program)
+  })
+
   test('does not erase a loop failure recorded while a health probe is in flight', async () => {
     const initial: RuntimeState = {
       ...readyState(),
@@ -635,23 +1076,7 @@ describe('Bayn continuous health', () => {
   test('treats the stall threshold as exclusive and clears only after a later terminal success', async () => {
     const initial = readyState()
     const state = await Effect.runPromise(Ref.make(initial))
-    const pending = {
-      cycleId: '1'.repeat(64),
-      accountId: 'paper-account-1',
-      signalSessionDate: '2026-07-17',
-      executionSessionDate: '2026-07-20',
-      phase: CycleState.Pending,
-      snapshotId: '2'.repeat(64),
-      decisionHash: null,
-      terminalReason: null,
-      submissionOpenAt: '2026-07-20T00:00:00.000Z',
-      submissionCutoffAt: '2026-07-20T01:00:00.000Z',
-      executionOpenAt: '2026-07-20T01:02:00.000Z',
-      executionCloseAt: '2026-07-20T20:00:00.000Z',
-      createdAt: '2026-07-20T00:00:00.000Z',
-      updatedAt: '2026-07-20T00:00:00.000Z',
-      terminalAt: null,
-    } as const
+    const pending = pendingCycle('2026-07-20T00:00:00.000Z')
     let projection: CycleOperationsProjection = {
       ...emptyCycleProjection(),
       current: pending,

--- a/services/bayn/src/health.ts
+++ b/services/bayn/src/health.ts
@@ -1,4 +1,4 @@
-import { Cause, Clock, Duration, Effect, Exit, Fiber, Option, Ref, Schedule } from 'effect'
+import { Cause, Clock, Duration, Effect, Exit, Fiber, Option, Ref, Result, Schedule } from 'effect'
 
 import type { BrokerReadShape } from './broker/alpaca'
 import type { RuntimeConfig } from './config'
@@ -6,11 +6,13 @@ import type { FinalizedSnapshotProvenance } from './contracts'
 import {
   CycleOperationsCondition,
   deriveCycleOperationsStatus,
+  type CycleOperationsProjection,
+  type CycleOperationsStatus,
   unknownCycleOperationsStatus,
 } from './cycle-observability'
 import { CycleObservability } from './db/cycle-observability'
 import { EvidenceStore, type QualificationRecord, type RecoveredEvaluationEvidence } from './db/evidence-store'
-import { operationalError, type OperationalError } from './errors'
+import { OperationalError, operationalError } from './errors'
 import { canonicalHashV1 } from './hash'
 import { Journal } from './ledger'
 import { MarketData } from './market-data'
@@ -25,72 +27,198 @@ import type {
   RuntimeState,
 } from './runtime-state'
 
-interface ProbeResult {
-  readonly error: string | null
+type ProbeResult<A> =
+  | { readonly _tag: 'Available'; readonly value: A }
+  | { readonly _tag: 'Unavailable'; readonly error: string }
+
+interface HealthProbeResults {
+  readonly postgresql: ProbeResult<void>
+  readonly signal: ProbeResult<void>
+  readonly tigerBeetle: ProbeResult<void>
+  readonly durableEvidence: ProbeResult<void>
+  readonly cycle: ProbeResult<CycleOperationsProjection>
+  readonly broker: ProbeResult<string> | null
 }
 
-interface BrokerProbeResult extends ProbeResult {
-  readonly accountId: string | null
+export type SignalIdentityFailure =
+  | { readonly _tag: 'EvidenceUnavailable' }
+  | {
+      readonly _tag: 'SnapshotMismatch'
+      readonly observedSnapshotId: string
+      readonly expectedSnapshotId: string
+    }
+  | {
+      readonly _tag: 'PublicationMismatch'
+      readonly observedPublicationId: string
+      readonly expectedPublicationId: string
+    }
+
+export type DurableEvidenceFailure =
+  | { readonly _tag: 'EvidenceUnavailable' }
+  | { readonly _tag: 'RunMissing'; readonly runId: string }
+  | {
+      readonly _tag: 'TerminalQualificationMissing'
+      readonly runId: string
+      readonly observedState: Exclude<QualificationRecord['state'], 'TERMINAL'> | null
+    }
+  | {
+      readonly _tag: 'RunMismatch'
+      readonly runId: string
+      readonly observedDurableHash: string
+      readonly expectedDurableHash: string
+    }
+  | {
+      readonly _tag: 'TerminalQualificationMismatch'
+      readonly runId: string
+      readonly observedQualificationHash: string
+      readonly expectedQualificationHash: string
+    }
+  | {
+      readonly _tag: 'CanonicalizationFailed'
+      readonly runId: string
+      readonly material:
+        | 'EXPECTED_DURABLE_EVIDENCE'
+        | 'OBSERVED_DURABLE_EVIDENCE'
+        | 'EXPECTED_QUALIFICATION'
+        | 'OBSERVED_QUALIFICATION'
+      readonly cause: unknown
+    }
+
+export type HealthDependencyName = keyof RuntimeHealth['dependencies'] | 'broker'
+
+export type AutonomousCycleFiberObservation =
+  | { readonly _tag: 'NotProvided' }
+  | { readonly _tag: 'Running' }
+  | { readonly _tag: 'ExitedSuccessfully' }
+  | { readonly _tag: 'ExitedWithFailure'; readonly error: string }
+
+interface HealthTransitionInput {
+  readonly config: RuntimeConfig
+  readonly evidenceAvailable: boolean
+  readonly results: HealthProbeResults
+  readonly broker: BrokerConfiguration | undefined
+  readonly cycleFiber: AutonomousCycleFiberObservation
+  readonly checkedAt: string
+  readonly checkedAtMs: number
 }
 
-interface ValueProbeResult<A> extends ProbeResult {
-  readonly value: A | null
+interface HealthFailureSummary {
+  readonly failedDependencies: readonly HealthDependencyName[]
+  readonly messages: readonly string[]
+}
+
+export interface HealthTransition {
+  readonly current: RuntimeState
+  readonly next: RuntimeState
+  readonly health: RuntimeHealth
+  readonly failedDependencies: readonly HealthDependencyName[]
+  readonly checkedAt: string
+}
+
+type LogAnnotation = string | number | boolean
+
+export interface HealthLogDecision {
+  readonly _tag: 'RuntimeStatusChanged' | 'CycleOperationsChanged'
+  readonly level: 'INFO' | 'WARNING'
+  readonly message: string
+  readonly annotations: Readonly<Record<string, LogAnnotation>>
+}
+
+export const validateSignalIdentity = (
+  snapshot: FinalizedSnapshotProvenance,
+  evidence: RuntimeEvidence | null,
+): Result.Result<void, SignalIdentityFailure> => {
+  if (evidence === null) {
+    return Result.fail({ _tag: 'EvidenceUnavailable' })
+  }
+  if (snapshot.snapshotId !== evidence.evaluation.input.snapshotId) {
+    return Result.fail({
+      _tag: 'SnapshotMismatch',
+      observedSnapshotId: snapshot.snapshotId,
+      expectedSnapshotId: evidence.evaluation.input.snapshotId,
+    })
+  }
+  if (snapshot.publicationId !== evidence.evaluation.input.publicationId) {
+    return Result.fail({
+      _tag: 'PublicationMismatch',
+      observedPublicationId: snapshot.publicationId,
+      expectedPublicationId: evidence.evaluation.input.publicationId,
+    })
+  }
+  return Result.succeed(undefined)
+}
+
+export const renderSignalIdentityFailure = (failure: SignalIdentityFailure): string => {
+  switch (failure._tag) {
+    case 'EvidenceUnavailable':
+      return 'startup evidence is unavailable'
+    case 'SnapshotMismatch':
+      return `configured Signal snapshot ${failure.observedSnapshotId} differs from active run snapshot ${failure.expectedSnapshotId}`
+    case 'PublicationMismatch':
+      return `configured Signal publication ${failure.observedPublicationId} differs from active run publication ${failure.expectedPublicationId}`
+  }
+  const exhaustive: never = failure
+  return exhaustive
 }
 
 export interface BrokerProbe extends BrokerConfiguration {
   readonly read: BrokerReadShape
 }
 
-const observe = <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<ProbeResult, never, R> =>
-  Effect.gen(function* () {
-    const exit = yield* Effect.exit(effect)
-    if (Exit.isSuccess(exit)) return { error: null }
-    if (Cause.hasInterrupts(exit.cause)) return yield* Effect.interrupt
-    const errors = Cause.prettyErrors(exit.cause).map((error) => error.message)
-    return { error: errors.join('; ') || 'unknown probe failure' }
+const probeFailureMessage = <E>(cause: Cause.Cause<E>, fallback: string): string => {
+  const errors = Cause.prettyErrors(cause).map((error) => error.message)
+  return errors.join('; ') || fallback
+}
+
+const observe = <A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+  fallback = 'unknown probe failure',
+): Effect.Effect<ProbeResult<A>, never, R> =>
+  Effect.flatMap(Effect.exit(effect), (exit): Effect.Effect<ProbeResult<A>> => {
+    if (Exit.isSuccess(exit)) return Effect.succeed({ _tag: 'Available', value: exit.value })
+    if (Cause.hasInterrupts(exit.cause)) return Effect.interrupt
+    return Effect.succeed({ _tag: 'Unavailable', error: probeFailureMessage(exit.cause, fallback) })
   })
 
-const observeBroker = (read: BrokerReadShape, timeoutMs: number): Effect.Effect<BrokerProbeResult> =>
-  Effect.gen(function* () {
-    const exit = yield* Effect.exit(
+const observeBroker = (read: BrokerReadShape, timeoutMs: number): Effect.Effect<ProbeResult<string>> =>
+  Effect.map(
+    observe(
       read.account.pipe(
+        Effect.map((value) => ({ _tag: 'AccountRead' as const, value })),
         Effect.timeoutOrElse({
           duration: timeoutMs,
-          orElse: () => Effect.fail(new Error(`Alpaca account probe timed out after ${timeoutMs}ms`)),
+          orElse: () => Effect.succeed({ _tag: 'TimedOut' as const }),
         }),
       ),
-    )
-    if (Exit.isSuccess(exit)) return { accountId: exit.value.value.id, error: null }
-    if (Cause.hasInterrupts(exit.cause)) return yield* Effect.interrupt
-    const errors = Cause.prettyErrors(exit.cause).map((error) => error.message)
-    return { accountId: null, error: errors.join('; ') || 'unknown broker probe failure' }
-  })
+      'unknown broker probe failure',
+    ),
+    (result): ProbeResult<string> => {
+      if (result._tag === 'Unavailable') return result
+      if (result.value._tag === 'TimedOut') {
+        return {
+          _tag: 'Unavailable',
+          error: `Alpaca account probe timed out after ${timeoutMs}ms`,
+        }
+      }
+      return { _tag: 'Available', value: result.value.value.value.id }
+    },
+  )
 
-const observeValue = <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<ValueProbeResult<A>, never, R> =>
-  Effect.gen(function* () {
-    const exit = yield* Effect.exit(effect)
-    if (Exit.isSuccess(exit)) return { value: exit.value, error: null }
-    if (Cause.hasInterrupts(exit.cause)) return yield* Effect.interrupt
-    const errors = Cause.prettyErrors(exit.cause).map((error) => error.message)
-    return { value: null, error: errors.join('; ') || 'unknown probe failure' }
-  })
-
-const ensureSignalIdentity = (
+export const ensureSignalIdentity = (
   snapshot: FinalizedSnapshotProvenance,
   evidence: RuntimeEvidence | null,
 ): Effect.Effect<void, OperationalError> =>
-  Effect.try({
-    try: () => {
-      if (evidence === null) throw new Error('startup evidence is unavailable')
-      if (snapshot.snapshotId !== evidence.evaluation.input.snapshotId) {
-        throw new Error('configured Signal snapshot differs from the active run')
-      }
-      if (snapshot.publicationId !== evidence.evaluation.input.publicationId) {
-        throw new Error('configured Signal publication differs from the active run')
-      }
-    },
-    catch: (cause) => operationalError('market-data', 'check-identity', 'Signal identity check failed', cause),
-  })
+  Effect.mapError(
+    Effect.fromResult(validateSignalIdentity(snapshot, evidence)),
+    (failure) =>
+      new OperationalError({
+        component: 'market-data',
+        operation: 'check-identity',
+        message: `Signal identity check failed: ${renderSignalIdentityFailure(failure)}`,
+        retryable: false,
+        cause: failure,
+      }),
+  )
 
 const durableMaterial = (evidence: RuntimeEvidence | RecoveredEvaluationEvidence) => ({
   evaluation: evidence.evaluation,
@@ -103,43 +231,130 @@ const durableMaterial = (evidence: RuntimeEvidence | RecoveredEvaluationEvidence
   },
 })
 
-const ensureDurableEvidence = (
-  recovered: Option.Option<RecoveredEvaluationEvidence>,
-  qualification: Option.Option<QualificationRecord>,
-  evidence: RuntimeEvidence | null,
-): Effect.Effect<void, OperationalError> =>
-  Effect.try({
-    try: () => {
-      if (evidence === null) throw new Error('startup evidence is unavailable')
-      if (Option.isNone(recovered)) throw new Error(`durable run ${evidence.evaluation.runId} is missing`)
-      if (Option.isNone(qualification) || qualification.value.state !== 'TERMINAL') {
-        throw new Error(`terminal qualification ${evidence.evaluation.runId} is missing`)
-      }
-      if (canonicalHashV1(durableMaterial(recovered.value)) !== canonicalHashV1(durableMaterial(evidence))) {
-        throw new Error(`durable run ${evidence.evaluation.runId} differs from the active proof`)
-      }
-      if (canonicalHashV1(qualification.value.result) !== canonicalHashV1(evidence.qualification)) {
-        throw new Error(`terminal qualification ${evidence.evaluation.runId} differs from the active proof`)
-      }
-    },
-    catch: (cause) => operationalError('database', 'verify-evidence', 'durable evidence verification failed', cause),
+const canonicalHashResult = (
+  runId: string,
+  material: Extract<DurableEvidenceFailure, { readonly _tag: 'CanonicalizationFailed' }>['material'],
+  value: unknown,
+): Result.Result<string, DurableEvidenceFailure> =>
+  Result.try({
+    try: () => canonicalHashV1(value),
+    catch: (cause): DurableEvidenceFailure => ({ _tag: 'CanonicalizationFailed', runId, material, cause }),
   })
 
-const dependencyHealth = (result: ProbeResult, checkedAt: string): DependencyHealth => ({
-  status: result.error === null ? 'AVAILABLE' : 'UNAVAILABLE',
+export const validateDurableEvidence = (
+  recovered: RecoveredEvaluationEvidence | null,
+  qualification: QualificationRecord | null,
+  evidence: RuntimeEvidence | null,
+): Result.Result<void, DurableEvidenceFailure> => {
+  if (evidence === null) {
+    return Result.fail({ _tag: 'EvidenceUnavailable' })
+  }
+  if (recovered === null) {
+    return Result.fail({
+      _tag: 'RunMissing',
+      runId: evidence.evaluation.runId,
+    })
+  }
+  if (qualification === null || qualification.state !== 'TERMINAL') {
+    return Result.fail({
+      _tag: 'TerminalQualificationMissing',
+      runId: evidence.evaluation.runId,
+      observedState: qualification?.state ?? null,
+    })
+  }
+
+  const durableHashes = Result.all({
+    expected: canonicalHashResult(evidence.evaluation.runId, 'EXPECTED_DURABLE_EVIDENCE', durableMaterial(evidence)),
+    observed: canonicalHashResult(evidence.evaluation.runId, 'OBSERVED_DURABLE_EVIDENCE', durableMaterial(recovered)),
+  })
+  if (Result.isFailure(durableHashes)) return Result.fail(durableHashes.failure)
+  const expectedRunHash = durableHashes.success.expected
+  const observedRunHash = durableHashes.success.observed
+  if (observedRunHash !== expectedRunHash) {
+    return Result.fail({
+      _tag: 'RunMismatch',
+      runId: evidence.evaluation.runId,
+      observedDurableHash: observedRunHash,
+      expectedDurableHash: expectedRunHash,
+    })
+  }
+
+  const qualificationHashes = Result.all({
+    expected: canonicalHashResult(evidence.evaluation.runId, 'EXPECTED_QUALIFICATION', evidence.qualification),
+    observed: canonicalHashResult(evidence.evaluation.runId, 'OBSERVED_QUALIFICATION', qualification.result),
+  })
+  if (Result.isFailure(qualificationHashes)) return Result.fail(qualificationHashes.failure)
+  const expectedQualificationHash = qualificationHashes.success.expected
+  const observedQualificationHash = qualificationHashes.success.observed
+  if (observedQualificationHash !== expectedQualificationHash) {
+    return Result.fail({
+      _tag: 'TerminalQualificationMismatch',
+      runId: evidence.evaluation.runId,
+      observedQualificationHash,
+      expectedQualificationHash,
+    })
+  }
+  return Result.succeed(undefined)
+}
+
+export const renderDurableEvidenceFailure = (failure: DurableEvidenceFailure): string => {
+  switch (failure._tag) {
+    case 'EvidenceUnavailable':
+      return 'startup evidence is unavailable'
+    case 'RunMissing':
+      return `durable run ${failure.runId} is missing`
+    case 'TerminalQualificationMissing':
+      return failure.observedState === null
+        ? `terminal qualification ${failure.runId} is missing`
+        : `qualification ${failure.runId} is ${failure.observedState}, expected TERMINAL`
+    case 'RunMismatch':
+      return `durable run ${failure.runId} hash ${failure.observedDurableHash} differs from active proof hash ${failure.expectedDurableHash}`
+    case 'TerminalQualificationMismatch':
+      return `terminal qualification ${failure.runId} hash ${failure.observedQualificationHash} differs from active proof hash ${failure.expectedQualificationHash}`
+    case 'CanonicalizationFailed':
+      return `canonicalization of ${failure.material} for run ${failure.runId} failed: ${String(failure.cause)}`
+  }
+  const exhaustive: never = failure
+  return exhaustive
+}
+
+export const ensureDurableEvidence = (
+  recovered: RecoveredEvaluationEvidence | null,
+  qualification: QualificationRecord | null,
+  evidence: RuntimeEvidence | null,
+): Effect.Effect<void, OperationalError> =>
+  Effect.mapError(
+    Effect.fromResult(validateDurableEvidence(recovered, qualification, evidence)),
+    (failure) =>
+      new OperationalError({
+        component: 'database',
+        operation: 'verify-evidence',
+        message: `durable evidence verification failed: ${renderDurableEvidenceFailure(failure)}`,
+        retryable: false,
+        cause: failure,
+      }),
+  )
+
+const dependencyHealth = <A>(result: ProbeResult<A>, checkedAt: string): DependencyHealth => ({
+  status: result._tag === 'Available' ? 'AVAILABLE' : 'UNAVAILABLE',
   checkedAt,
-  error: result.error,
+  error: result._tag === 'Available' ? null : result.error,
 })
 
-const cycleLoopAge = (instant: string, checkedAtMs: number): number | undefined => {
-  const age = checkedAtMs - Date.parse(instant)
-  return Number.isFinite(age) && age >= 0 ? age : undefined
+const sampleAutonomousCycleFiber = (fiber: Fiber.Fiber<void, never> | undefined): AutonomousCycleFiberObservation => {
+  if (fiber === undefined) return { _tag: 'NotProvided' }
+  const exit = fiber.pollUnsafe()
+  if (exit === undefined) return { _tag: 'Running' }
+  if (Exit.isSuccess(exit)) return { _tag: 'ExitedSuccessfully' }
+  return {
+    _tag: 'ExitedWithFailure',
+    error: probeFailureMessage(exit.cause, Cause.pretty(exit.cause)),
+  }
 }
 
 const cycleLoopHealth = (
   loop: AutonomousCycleLoopStatus,
-  fiber: Fiber.Fiber<void, never> | undefined,
-  exit: Option.Option<Exit.Exit<void, never>>,
+  fiber: AutonomousCycleFiberObservation,
   checkedAt: string,
   checkedAtMs: number,
   stallThresholdMs: number,
@@ -150,24 +365,306 @@ const cycleLoopHealth = (
   if (!loop.configured) {
     return required ? unavailable('broker-configured Bayn runtime has no autonomous cycle loop') : available()
   }
-  if (fiber === undefined) return unavailable('configured autonomous cycle loop has no scoped fiber')
-  if (Option.isSome(exit)) {
-    if (Exit.isSuccess(exit.value)) return unavailable('autonomous cycle loop exited unexpectedly')
-    const errors = Cause.prettyErrors(exit.value.cause).map((error) => error.message)
-    return unavailable(`autonomous cycle loop failed: ${errors.join('; ') || Cause.pretty(exit.value.cause)}`)
-  }
+  if (fiber._tag === 'NotProvided') return unavailable('configured autonomous cycle loop has no scoped fiber')
+  if (fiber._tag === 'ExitedSuccessfully') return unavailable('autonomous cycle loop exited unexpectedly')
+  if (fiber._tag === 'ExitedWithFailure') return unavailable(`autonomous cycle loop failed: ${fiber.error}`)
   if (loop.lastPass?.result === 'FAILURE') {
     return unavailable(`${loop.lastPass.operation}/${loop.lastPass.failure}: ${loop.lastPass.message}`)
   }
   const progressAt = loop.lastPass?.observedAt ?? loop.startedAt
   if (progressAt === null) return unavailable('autonomous cycle loop start time is unavailable')
-  const ageMs = cycleLoopAge(progressAt, checkedAtMs)
-  if (ageMs === undefined) return unavailable('autonomous cycle loop progress time is invalid or in the future')
+  const ageMs = checkedAtMs - Date.parse(progressAt)
+  if (!Number.isFinite(ageMs) || ageMs < 0) {
+    return unavailable('autonomous cycle loop progress time is invalid or in the future')
+  }
   if (ageMs >= stallThresholdMs) {
     return unavailable(`autonomous cycle loop has not completed a successful pass for ${ageMs}ms`)
   }
   return available()
 }
+
+const brokerConfiguration = (broker: BrokerProbe | undefined): BrokerConfiguration | undefined =>
+  broker === undefined
+    ? undefined
+    : {
+        expectedAccountId: broker.expectedAccountId,
+        executionEligible: broker.executionEligible,
+        executionDisabledReason: broker.executionDisabledReason,
+      }
+
+const deriveBrokerStatus = (
+  current: BrokerStatus | null,
+  broker: BrokerConfiguration | undefined,
+  result: ProbeResult<string> | null,
+  checkedAt: string,
+): BrokerStatus | null => {
+  if (broker === undefined) return current
+  const observed = result ?? { _tag: 'Unavailable', error: 'broker probe did not run' }
+  const accountId = observed._tag === 'Available' ? observed.value : null
+  const accountBound = observed._tag === 'Available' && accountId === broker.expectedAccountId
+  const bindingError =
+    observed._tag === 'Unavailable'
+      ? observed.error
+      : accountBound
+        ? null
+        : `Alpaca account probe resolved ${accountId}, expected ${broker.expectedAccountId}`
+  return {
+    configured: true,
+    expectedAccountId: broker.expectedAccountId,
+    accountId,
+    accountBound,
+    readAvailable: observed._tag === 'Available',
+    checkedAt,
+    error: bindingError,
+    executionEligible: broker.executionEligible,
+    executionDisabledReason: broker.executionDisabledReason,
+  }
+}
+
+const deriveCycleStatus = (
+  result: ProbeResult<CycleOperationsProjection>,
+  config: RuntimeConfig,
+  checkedAt: string,
+  checkedAtMs: number,
+): CycleOperationsStatus => {
+  if (result._tag === 'Available') {
+    return deriveCycleOperationsStatus(result.value, checkedAtMs, config.maximumAuthority, config)
+  }
+  return { ...unknownCycleOperationsStatus(result.error), checkedAt }
+}
+
+const deriveRuntimeHealth = (
+  current: RuntimeState,
+  results: HealthProbeResults,
+  cycleRunner: DependencyHealth,
+  checkedAt: string,
+): RuntimeHealth => ({
+  sequence: current.health.sequence + 1,
+  checkedAt,
+  dependencies: {
+    postgresql: dependencyHealth(results.postgresql, checkedAt),
+    signal: dependencyHealth(results.signal, checkedAt),
+    tigerBeetle: dependencyHealth(results.tigerBeetle, checkedAt),
+    evidence: dependencyHealth(results.durableEvidence, checkedAt),
+    cycle: dependencyHealth(results.cycle, checkedAt),
+    cycleRunner,
+  },
+})
+
+const summarizeHealthFailures = (
+  health: RuntimeHealth,
+  broker: BrokerStatus | null,
+  cycle: CycleOperationsStatus,
+): HealthFailureSummary => {
+  const dependencyFailures = (
+    Object.entries(health.dependencies) as readonly [keyof RuntimeHealth['dependencies'], DependencyHealth][]
+  ).filter(([, dependency]) => dependency.error !== null)
+  const dependencyNames = dependencyFailures.map(([name]) => name)
+  const brokerFailure =
+    broker !== null && (broker.error !== null || broker.accountBound !== true || broker.readAvailable !== true)
+      ? `broker: ${broker.error ?? 'account binding unavailable'}`
+      : null
+  const cycleFailure =
+    cycle.condition === CycleOperationsCondition.Stalled || cycle.condition === CycleOperationsCondition.Failed
+      ? `cycle: ${cycle.reason}`
+      : null
+  const brokerDependencies: readonly HealthDependencyName[] = brokerFailure === null ? [] : ['broker']
+  const cycleDependencies: readonly HealthDependencyName[] =
+    cycleFailure === null || dependencyNames.includes('cycle') ? [] : ['cycle']
+  return {
+    failedDependencies: [...dependencyNames, ...brokerDependencies, ...cycleDependencies],
+    messages: [
+      ...dependencyFailures.map(([name, dependency]) => `${name}: ${dependency.error}`),
+      ...(brokerFailure === null ? [] : [brokerFailure]),
+      ...(cycleFailure === null ? [] : [cycleFailure]),
+    ],
+  }
+}
+
+const deriveNextRuntimeState = (
+  current: RuntimeState,
+  evidenceAvailable: boolean,
+  health: RuntimeHealth,
+  cycle: CycleOperationsStatus,
+  broker: BrokerStatus | null,
+  failures: HealthFailureSummary,
+): RuntimeState => {
+  if (!evidenceAvailable) return { ...current, health, cycle, broker }
+  if (failures.messages.length === 0) {
+    return { ...current, status: 'READY', health, cycle, broker, error: null }
+  }
+  return { ...current, status: 'DEGRADED', health, cycle, broker, error: failures.messages.join('; ') }
+}
+
+export const deriveHealthTransition = (current: RuntimeState, input: HealthTransitionInput): HealthTransition => {
+  const cycleRunner = cycleLoopHealth(
+    current.autonomousCycleLoop,
+    input.cycleFiber,
+    input.checkedAt,
+    input.checkedAtMs,
+    input.config.cycleStallThresholdMs,
+    input.broker !== undefined,
+  )
+  const cycle = deriveCycleStatus(input.results.cycle, input.config, input.checkedAt, input.checkedAtMs)
+  const broker = deriveBrokerStatus(current.broker, input.broker, input.results.broker, input.checkedAt)
+  const health = deriveRuntimeHealth(current, input.results, cycleRunner, input.checkedAt)
+  const failures = summarizeHealthFailures(health, broker, cycle)
+  const next = deriveNextRuntimeState(current, input.evidenceAvailable, health, cycle, broker, failures)
+  return {
+    current,
+    next,
+    health,
+    failedDependencies: failures.failedDependencies,
+    checkedAt: input.checkedAt,
+  }
+}
+
+const runtimeStatusLogDecision = (transition: HealthTransition): HealthLogDecision | null => {
+  if (transition.next.status === transition.current.status) return null
+  return {
+    _tag: 'RuntimeStatusChanged',
+    level: transition.next.status === 'READY' ? 'INFO' : 'WARNING',
+    message: `Bayn health changed to ${transition.next.status}`,
+    annotations: {
+      service: 'bayn',
+      checkedAt: transition.checkedAt,
+      probeSequence: transition.health.sequence,
+      failedDependencies: transition.failedDependencies.join(','),
+    },
+  }
+}
+
+const cycleOperationsLogDecision = (transition: HealthTransition): HealthLogDecision | null => {
+  if (
+    transition.next.cycle.condition === transition.current.cycle.condition &&
+    transition.next.cycle.reason === transition.current.cycle.reason
+  ) {
+    return null
+  }
+  const cycle = transition.next.cycle
+  const observationAvailable = cycle.condition !== CycleOperationsCondition.Unknown
+  return {
+    _tag: 'CycleOperationsChanged',
+    level:
+      cycle.condition === CycleOperationsCondition.Stalled || cycle.condition === CycleOperationsCondition.Failed
+        ? 'WARNING'
+        : 'INFO',
+    message: `Bayn cycle operations changed to ${cycle.condition}`,
+    annotations: {
+      service: 'bayn',
+      checkedAt: transition.checkedAt,
+      cycleCondition: cycle.condition,
+      cycleReason: cycle.reason,
+      currentCycleId: cycle.current?.cycleId ?? '',
+      currentPhase: cycle.current?.phase ?? '',
+      signalSessionDate: cycle.current?.signalSessionDate ?? '',
+      submissionCutoffAt: cycle.current?.submissionCutoffAt ?? '',
+      attemptAgeMs: cycle.attemptAgeMs ?? -1,
+      unfinishedCycleCount: observationAvailable ? cycle.unfinishedCycleCount : 'unknown',
+      unresolvedMutationCount: observationAvailable ? cycle.mutations.unresolvedCount : 'unknown',
+      zeroMutation: observationAvailable ? (cycle.zeroMutation ?? 'unknown') : 'unknown',
+    },
+  }
+}
+
+export const deriveHealthLogDecisions = (transition: HealthTransition): readonly HealthLogDecision[] => {
+  const runtimeStatus = runtimeStatusLogDecision(transition)
+  const cycleOperations = cycleOperationsLogDecision(transition)
+  return [...(runtimeStatus === null ? [] : [runtimeStatus]), ...(cycleOperations === null ? [] : [cycleOperations])]
+}
+
+const interpretHealthLogs = (decisions: readonly HealthLogDecision[]): Effect.Effect<void> =>
+  Effect.forEach(
+    decisions,
+    (decision) => {
+      const log = decision.level === 'INFO' ? Effect.logInfo : Effect.logWarning
+      return log(decision.message).pipe(Effect.annotateLogs(decision.annotations))
+    },
+    { discard: true },
+  )
+
+const collectHealthProbeResults = (
+  config: RuntimeConfig,
+  evidence: RuntimeEvidence | null,
+  marketData: MarketData['Service'],
+  journal: Journal['Service'],
+  evidenceStore: EvidenceStore['Service'],
+  cycleObservability: CycleObservability['Service'],
+  broker: BrokerProbe | undefined,
+): Effect.Effect<HealthProbeResults, never> =>
+  Effect.map(
+    Effect.all(
+      [
+        observe(
+          withinDeadline(
+            databaseOperation(evidenceStore.check, 'continuous-health'),
+            config.operationTimeoutMs,
+            'database',
+            'continuous-health',
+          ),
+        ),
+        observe(
+          withinDeadline(marketData.check, config.operationTimeoutMs, 'market-data', 'continuous-health').pipe(
+            Effect.flatMap((snapshot) => ensureSignalIdentity(snapshot, evidence)),
+          ),
+        ),
+        observe(
+          withinDeadline(
+            evidence === null ? journal.check : journal.checkRun(evidence.reconciliation),
+            config.operationTimeoutMs,
+            'journal',
+            'continuous-health',
+          ),
+        ),
+        observe(
+          evidence === null
+            ? Effect.fail(operationalError('database', 'verify-evidence', 'startup evidence is unavailable'))
+            : withinDeadline(
+                Effect.all([
+                  databaseOperation(
+                    evidenceStore.recover(evidence.evaluation.runId, evidence.provenance),
+                    'continuous-recovery',
+                  ),
+                  databaseOperation(
+                    evidenceStore.readQualification(evidence.evaluation.runId),
+                    'continuous-qualification',
+                  ),
+                ]),
+                config.operationTimeoutMs,
+                'database',
+                'continuous-recovery',
+              ).pipe(
+                Effect.flatMap(([recovered, qualification]) =>
+                  ensureDurableEvidence(Option.getOrNull(recovered), Option.getOrNull(qualification), evidence),
+                ),
+              ),
+        ),
+        observe(
+          evidence === null
+            ? Effect.fail(operationalError('database', 'cycle-observability', 'startup evidence is unavailable'))
+            : withinDeadline(
+                databaseOperation(
+                  cycleObservability.read(evidence.evaluation.runId, broker?.expectedAccountId),
+                  'cycle-observability',
+                ),
+                config.operationTimeoutMs,
+                'database',
+                'cycle-observability',
+              ),
+        ),
+        broker === undefined ? Effect.succeed(null) : observeBroker(broker.read, config.operationTimeoutMs),
+      ],
+      { concurrency: 'unbounded' },
+    ),
+    ([postgresql, signal, tigerBeetle, durableEvidence, cycle, brokerResult]) => ({
+      postgresql,
+      signal,
+      tigerBeetle,
+      durableEvidence,
+      cycle,
+      broker: brokerResult,
+    }),
+  )
 
 export const probe = (
   config: RuntimeConfig,
@@ -180,208 +677,32 @@ export const probe = (
     const journal = yield* Journal
     const evidenceStore = yield* EvidenceStore
     const cycleObservability = yield* CycleObservability
-    const current = yield* Ref.get(state)
-    const evidence = current.evidence
-    const [[postgresql, signal, tigerBeetle, durableEvidence, cycleResult], brokerResult] = yield* Effect.all(
-      [
-        Effect.all(
-          [
-            observe(
-              withinDeadline(
-                databaseOperation(evidenceStore.check, 'continuous-health'),
-                config.operationTimeoutMs,
-                'database',
-                'continuous-health',
-              ),
-            ),
-            observe(
-              withinDeadline(marketData.check, config.operationTimeoutMs, 'market-data', 'continuous-health').pipe(
-                Effect.flatMap((snapshot) => ensureSignalIdentity(snapshot, evidence)),
-              ),
-            ),
-            observe(
-              withinDeadline(
-                evidence === null ? journal.check : journal.checkRun(evidence.reconciliation),
-                config.operationTimeoutMs,
-                'journal',
-                'continuous-health',
-              ),
-            ),
-            observe(
-              evidence === null
-                ? Effect.fail(operationalError('database', 'verify-evidence', 'startup evidence is unavailable'))
-                : withinDeadline(
-                    Effect.all([
-                      databaseOperation(
-                        evidenceStore.recover(evidence.evaluation.runId, evidence.provenance),
-                        'continuous-recovery',
-                      ),
-                      databaseOperation(
-                        evidenceStore.readQualification(evidence.evaluation.runId),
-                        'continuous-qualification',
-                      ),
-                    ]),
-                    config.operationTimeoutMs,
-                    'database',
-                    'continuous-recovery',
-                  ).pipe(
-                    Effect.flatMap(([recovered, qualification]) =>
-                      ensureDurableEvidence(recovered, qualification, evidence),
-                    ),
-                  ),
-            ),
-            observeValue(
-              evidence === null
-                ? Effect.fail(operationalError('database', 'cycle-observability', 'startup evidence is unavailable'))
-                : withinDeadline(
-                    databaseOperation(
-                      cycleObservability.read(evidence.evaluation.runId, broker?.expectedAccountId),
-                      'cycle-observability',
-                    ),
-                    config.operationTimeoutMs,
-                    'database',
-                    'cycle-observability',
-                  ),
-            ),
-          ],
-          { concurrency: 'unbounded' },
-        ),
-        broker === undefined ? Effect.succeed(undefined) : observeBroker(broker.read, config.operationTimeoutMs),
-      ],
-      { concurrency: 'unbounded' },
+    const initial = yield* Ref.get(state)
+    const results = yield* collectHealthProbeResults(
+      config,
+      initial.evidence,
+      marketData,
+      journal,
+      evidenceStore,
+      cycleObservability,
+      broker,
     )
     const checkedAtMs = yield* Clock.currentTimeMillis
     const checkedAt = new Date(checkedAtMs).toISOString()
-    const autonomousCycleExit = Option.fromNullishOr(autonomousCycleFiber?.pollUnsafe())
-    const transition = yield* Ref.modify(state, (latest) => {
-      const autonomousCycle = cycleLoopHealth(
-        latest.autonomousCycleLoop,
-        autonomousCycleFiber,
-        autonomousCycleExit,
+    const cycleFiber = sampleAutonomousCycleFiber(autonomousCycleFiber)
+    const transition = yield* Ref.modify(state, (current) => {
+      const decision = deriveHealthTransition(current, {
+        config,
+        evidenceAvailable: initial.evidence !== null,
+        results,
+        broker: brokerConfiguration(broker),
+        cycleFiber,
         checkedAt,
         checkedAtMs,
-        config.cycleStallThresholdMs,
-        broker !== undefined,
-      )
-      const cycle =
-        cycleResult.error === null && cycleResult.value !== null
-          ? deriveCycleOperationsStatus(cycleResult.value, Date.parse(checkedAt), config.maximumAuthority, config)
-          : {
-              ...unknownCycleOperationsStatus(cycleResult.error ?? 'cycle observability probe did not run'),
-              checkedAt,
-            }
-      let brokerStatus: BrokerStatus | null = latest.broker
-      if (broker !== undefined) {
-        const result = brokerResult ?? { accountId: null, error: 'broker probe did not run' }
-        const accountBound = result.error === null && result.accountId === broker.expectedAccountId
-        const bindingError =
-          result.error ??
-          (accountBound
-            ? null
-            : `Alpaca account probe resolved ${result.accountId ?? 'no account'}, expected ${broker.expectedAccountId}`)
-        brokerStatus = {
-          configured: true,
-          expectedAccountId: broker.expectedAccountId,
-          accountId: result.accountId,
-          accountBound,
-          readAvailable: result.error === null,
-          checkedAt,
-          error: bindingError,
-          executionEligible: broker.executionEligible,
-          executionDisabledReason: broker.executionDisabledReason,
-        }
-      }
-      const health: RuntimeHealth = {
-        sequence: latest.health.sequence + 1,
-        checkedAt,
-        dependencies: {
-          postgresql: dependencyHealth(postgresql, checkedAt),
-          signal: dependencyHealth(signal, checkedAt),
-          tigerBeetle: dependencyHealth(tigerBeetle, checkedAt),
-          evidence: dependencyHealth(durableEvidence, checkedAt),
-          cycle: dependencyHealth(cycleResult, checkedAt),
-          cycleRunner: autonomousCycle,
-        },
-      }
-      const dependencyFailures = Object.entries(health.dependencies).filter(
-        ([, dependency]) => dependency.error !== null,
-      )
-      const failedDependencies = dependencyFailures.map(([name]) => name)
-      const failureMessages = dependencyFailures.map(([name, dependency]) => `${name}: ${dependency.error}`)
-      if (
-        brokerStatus !== null &&
-        (brokerStatus.error !== null || brokerStatus.accountBound !== true || brokerStatus.readAvailable !== true)
-      ) {
-        failedDependencies.push('broker')
-        failureMessages.push(`broker: ${brokerStatus.error ?? 'account binding unavailable'}`)
-      }
-      if (cycle.condition === CycleOperationsCondition.Stalled || cycle.condition === CycleOperationsCondition.Failed) {
-        if (!failedDependencies.includes('cycle')) failedDependencies.push('cycle')
-        failureMessages.push(`cycle: ${cycle.reason}`)
-      }
-      let next: RuntimeState = { ...latest, health, cycle, broker: brokerStatus }
-      if (evidence !== null && failureMessages.length === 0) {
-        next = {
-          ...latest,
-          status: 'READY',
-          health,
-          cycle,
-          broker: brokerStatus,
-          error: null,
-        }
-      } else if (evidence !== null) {
-        next = {
-          ...latest,
-          status: 'DEGRADED',
-          health,
-          cycle,
-          broker: brokerStatus,
-          error: failureMessages.join('; '),
-        }
-      }
-      return [{ current: latest, next, health, failedDependencies }, next] as const
+      })
+      return [decision, decision.next] as const
     })
-
-    if (transition.next.status !== transition.current.status) {
-      const next = transition.next
-      const log = next.status === 'READY' ? Effect.logInfo : Effect.logWarning
-      yield* log(`Bayn health changed to ${next.status}`).pipe(
-        Effect.annotateLogs({
-          service: 'bayn',
-          checkedAt,
-          probeSequence: transition.health.sequence,
-          failedDependencies: transition.failedDependencies.join(','),
-        }),
-      )
-    }
-    if (
-      transition.next.cycle.condition !== transition.current.cycle.condition ||
-      transition.next.cycle.reason !== transition.current.cycle.reason
-    ) {
-      const next = transition.next
-      const cycleObservationAvailable = next.cycle.condition !== CycleOperationsCondition.Unknown
-      const log =
-        next.cycle.condition === CycleOperationsCondition.Stalled ||
-        next.cycle.condition === CycleOperationsCondition.Failed
-          ? Effect.logWarning
-          : Effect.logInfo
-      yield* log(`Bayn cycle operations changed to ${next.cycle.condition}`).pipe(
-        Effect.annotateLogs({
-          service: 'bayn',
-          checkedAt,
-          cycleCondition: next.cycle.condition,
-          cycleReason: next.cycle.reason,
-          currentCycleId: next.cycle.current?.cycleId ?? '',
-          currentPhase: next.cycle.current?.phase ?? '',
-          signalSessionDate: next.cycle.current?.signalSessionDate ?? '',
-          submissionCutoffAt: next.cycle.current?.submissionCutoffAt ?? '',
-          attemptAgeMs: next.cycle.attemptAgeMs ?? -1,
-          unfinishedCycleCount: cycleObservationAvailable ? next.cycle.unfinishedCycleCount : 'unknown',
-          unresolvedMutationCount: cycleObservationAvailable ? next.cycle.mutations.unresolvedCount : 'unknown',
-          zeroMutation: cycleObservationAvailable ? next.cycle.zeroMutation : 'unknown',
-        }),
-      )
-    }
+    yield* interpretHealthLogs(deriveHealthLogDecisions(transition))
   }).pipe(Effect.withLogSpan('health'))
 
 export const monitor = (


### PR DESCRIPTION
## Summary

- replace the monolithic continuous-health orchestration with typed pure validation, immutable state transitions, and pure log decisions behind one bounded Effect shell
- preserve fact-bearing Signal and durable-evidence failures, total canonicalization, structured OperationalError causes, broker status semantics, and Ref/Fiber race behavior
- add deterministic regressions for canonicalization defects, cause retention, broker timeout cancellation/finalization, and interrupted autonomous-cycle fibers

## Related Issues

PROOMPT-412

## Testing

- `bun test services/bayn/src/health.test.ts` (14 pass, 0 fail, 71 assertions)
- `bun run --filter @proompteng/bayn test` (419 pass, 104 skip, 0 fail, 1975 assertions)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- `git diff --check`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked in PROOMPT-412.
