### PR TITLE
refactor(bayn): make startup qualification functional

### DIFF
--- a/services/bayn/src/startup.test.ts
+++ b/services/bayn/src/startup.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test'
 import { randomUUID } from 'node:crypto'
 
 import { NodeServices } from '@effect/platform-node'
-import { Cause, Effect, Exit, Layer, Option, Ref } from 'effect'
+import { Cause, Effect, Exit, Layer, Option, Ref, Result } from 'effect'
 import { AuthenticationError, SqlError } from 'effect/unstable/sql/SqlError'
 
 import {
@@ -11,7 +11,9 @@ import {
   successfulJournal,
   marketDataService,
   successfulEvidenceStore,
+  fixtureEvaluation,
   fixtureStrategy,
+  fixtureSnapshot,
   fixtureLock,
   fixtureQualification,
   pinnedExecutionProvenance,
@@ -35,12 +37,23 @@ import {
   type StoredEvaluationEvidence,
 } from './db/evidence-store'
 import { operationalError } from './errors'
+import { canonicalHashV1 } from './hash'
 import { Journal, type JournalService } from './ledger'
 import { MarketData } from './market-data'
 import { defaultProtocolDocument, loadProtocol } from './protocol'
 import { makeQualificationLock, makeQualificationResult } from './qualification'
 import { evaluateRiskBalancedTrend, summarizeEvaluation } from './risk-balanced-trend'
 import { initialState } from './runtime-state'
+import {
+  decidePinnedQualification,
+  decidePinnedRecovery,
+  decideQualificationPath,
+  decideTerminalRecovery,
+  evaluateLockedSnapshot,
+  qualifyEvaluation,
+  renderStartupDecisionFailure,
+  type StartupDecisionFailure,
+} from './startup'
 import type { Strategy } from './strategy'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
 
@@ -55,6 +68,630 @@ const cycleObservability = {
       mutations: { eventCount: 0, unresolvedCount: 0, oldestUnresolvedAt: null, latestOccurredAt: null },
     }),
 }
+
+const recoveredFixture = (runId = fixtureEvaluation.runId) => ({
+  evaluation: { ...summarizeEvaluation(fixtureEvaluation), runId },
+  reconciliation: {
+    runId,
+    accountCount: 13,
+    transferCount: fixtureEvaluation.events.length,
+    exact: true as const,
+  },
+  persistence: {
+    runId,
+    deduplicated: true,
+    artifactCount: 17,
+    eventCount: fixtureEvaluation.events.length,
+    gateCount: fixtureEvaluation.verdict.gates.length,
+  },
+})
+
+const verdictWithCanonicalDrift = (verdict: typeof fixtureEvaluation.verdict): typeof fixtureEvaluation.verdict => ({
+  ...verdict,
+  gates: verdict.gates.map((gate, index) => (index === 0 ? { ...gate, actual: `drift:${String(gate.actual)}` } : gate)),
+})
+
+const candidateQualification = {
+  inspection: {
+    manifest: fixtureSnapshot.manifest,
+    sessionDates: [...new Set(fixtureSnapshot.bars.map((bar) => bar.sessionDate))].sort(),
+    signalSession: {
+      calendar_version: fixtureSnapshot.manifest.finalizedSnapshot.calendarVersion,
+      session_date: fixtureSnapshot.manifest.lastSession,
+      close_time: '16:00',
+      timezone: 'America/New_York',
+    },
+  },
+  lock: fixtureLock,
+} satisfies {
+  readonly inspection: Parameters<typeof evaluateLockedSnapshot>[1]
+  readonly lock: typeof fixtureLock
+}
+
+const malformedPinnedStoredEvidence = (): StoredEvaluationEvidence =>
+  ({
+    ...pinnedStoredEvidence,
+    protocol: {
+      ...pinnedStoredEvidence.protocol,
+      parameters: { ...pinnedStoredEvidence.protocol.parameters, universeId: '\ud800' },
+    },
+  }) as unknown as StoredEvaluationEvidence
+
+const decisionFailure = <A>(result: Result.Result<A, StartupDecisionFailure>): StartupDecisionFailure => {
+  expect(Result.isFailure(result)).toBe(true)
+  if (Result.isFailure(result)) return result.failure
+  throw new Error('expected startup decision failure')
+}
+
+const decisionSuccess = <A>(result: Result.Result<A, StartupDecisionFailure>): A => {
+  expect(Result.isSuccess(result)).toBe(true)
+  if (Result.isSuccess(result)) return result.success
+  throw new Error('expected startup decision success')
+}
+
+const expectRenderedFailure = (
+  failure: StartupDecisionFailure,
+  expected: { readonly component: string; readonly operation: string; readonly message: unknown },
+): void => {
+  expect(renderStartupDecisionFailure(failure)).toMatchObject({ ...expected, cause: failure })
+}
+
+describe('Bayn startup pure decisions', () => {
+  test('rejects unsupported and malformed stored provenance with exact facts', () => {
+    const unsupported = {
+      ...pinnedStoredEvidence,
+      protocol: { ...pinnedStoredEvidence.protocol, strategyName: 'unsupported-strategy' },
+    } as unknown as StoredEvaluationEvidence
+    const malformed = {
+      ...pinnedStoredEvidence,
+      run: { ...pinnedStoredEvidence.run, sourceRevision: 'invalid-source-revision' },
+    } as unknown as StoredEvaluationEvidence
+
+    for (const [stored, reason] of [
+      [unsupported, 'unsupported-contract'],
+      [malformed, 'malformed'],
+    ] as const) {
+      const failure = decisionFailure(
+        decidePinnedQualification(pinnedRuntimeConfig, pinnedEvaluation.runId, {
+          stored: Option.some(stored),
+          qualification: Option.some({ state: 'TERMINAL', lock: pinnedLock, result: pinnedQualification }),
+        }),
+      )
+      expect(failure).toMatchObject({
+        _tag: 'StoredProvenanceInvalid',
+        identity: {
+          runId: pinnedEvaluation.runId,
+          strategyName: stored.protocol.strategyName,
+          schemaVersion: stored.protocol.schemaVersion,
+        },
+        issue: { reason },
+      })
+      expectRenderedFailure(failure, {
+        component: 'database',
+        operation: 'recover-pinned-qualification',
+        message:
+          reason === 'unsupported-contract'
+            ? 'stored qualification provenance is invalid: stored evaluation uses an unsupported strategy contract'
+            : expect.stringContaining('stored qualification provenance is invalid:'),
+      })
+    }
+  })
+
+  test('decides pinned recovery from immutable facts and renders a missing stored evaluation exactly', () => {
+    const qualification = Option.some({ state: 'TERMINAL' as const, lock: pinnedLock, result: pinnedQualification })
+    const decision = decisionSuccess(
+      decidePinnedQualification(pinnedRuntimeConfig, pinnedEvaluation.runId, {
+        stored: Option.some(pinnedStoredEvidence),
+        qualification,
+      }),
+    )
+    expect(decision).toMatchObject({
+      _tag: 'RecoverPinned',
+      executionProvenance: pinnedExecutionProvenance,
+      qualification: { result: { runId: pinnedEvaluation.runId } },
+    })
+
+    const missing = decisionFailure(
+      decidePinnedQualification(pinnedRuntimeConfig, pinnedEvaluation.runId, {
+        stored: Option.none(),
+        qualification,
+      }),
+    )
+    expect(missing).toEqual({
+      _tag: 'QualificationStateInvalid',
+      details: {
+        reason: 'evidence-missing',
+        phase: 'read-pinned',
+        runId: pinnedEvaluation.runId,
+      },
+    })
+    expectRenderedFailure(missing, {
+      component: 'database',
+      operation: 'read-pinned-qualification',
+      message: `pinned evaluation ${pinnedEvaluation.runId} is missing`,
+    })
+  })
+
+  test('returns a structured pinned-recovery mismatch instead of accepting divergent durable run identities', () => {
+    const decision = decisionSuccess(
+      decidePinnedQualification(pinnedRuntimeConfig, pinnedEvaluation.runId, {
+        stored: Option.some(pinnedStoredEvidence),
+        qualification: Option.some({ state: 'TERMINAL', lock: pinnedLock, result: pinnedQualification }),
+      }),
+    )
+    const wrongPersistenceRunId = '0'.repeat(64)
+    const recovered = recoveredFixture()
+    const mismatch = decisionFailure(
+      decidePinnedRecovery(
+        decision,
+        Option.some({
+          ...recovered,
+          evaluation: summarizeEvaluation(pinnedEvaluation),
+          reconciliation: { ...recovered.reconciliation, runId: pinnedEvaluation.runId },
+          persistence: { ...recovered.persistence, runId: wrongPersistenceRunId },
+        }),
+      ),
+    )
+    expect(mismatch).toMatchObject({
+      _tag: 'BindingMismatch',
+      details: {
+        binding: 'recovery',
+        phase: 'pinned',
+        expectedRunId: pinnedEvaluation.runId,
+        recoveredRunIds: {
+          evaluation: pinnedEvaluation.runId,
+          reconciliation: pinnedEvaluation.runId,
+          persistence: wrongPersistenceRunId,
+        },
+      },
+    })
+    expectRenderedFailure(mismatch, {
+      component: 'database',
+      operation: 'recover-pinned-qualification',
+      message: 'pinned qualification recovery failed: recovered evidence differs from the terminal qualification',
+    })
+  })
+
+  test('rejects pinned run and lock drift with exact binding facts', () => {
+    const wrongRunId = '0'.repeat(64)
+    const wrongSourceRevision = '0'.repeat(40)
+    const cases = [
+      {
+        binding: 'pinned-run',
+        stored: {
+          ...pinnedStoredEvidence,
+          run: { ...pinnedStoredEvidence.run, runId: wrongRunId },
+        } as StoredEvaluationEvidence,
+        lock: pinnedLock,
+        message: 'pinned qualification binding failed: stored evaluation and terminal qualification run IDs differ',
+      },
+      {
+        binding: 'pinned-lock',
+        stored: pinnedStoredEvidence,
+        lock: { ...pinnedLock, sourceRevision: wrongSourceRevision },
+        message: 'pinned qualification binding failed: qualification lock differs from the stored execution provenance',
+      },
+    ] as const
+
+    for (const testCase of cases) {
+      const failure = decisionFailure(
+        decidePinnedQualification(pinnedRuntimeConfig, pinnedEvaluation.runId, {
+          stored: Option.some(testCase.stored),
+          qualification: Option.some({
+            state: 'TERMINAL',
+            lock: testCase.lock,
+            result: pinnedQualification,
+          }),
+        }),
+      )
+      expect(failure).toMatchObject({
+        _tag: 'BindingMismatch',
+        details: { binding: testCase.binding },
+      })
+      expectRenderedFailure(failure, {
+        component: 'database',
+        operation: 'recover-pinned-qualification',
+        message: testCase.message,
+      })
+    }
+  })
+
+  test('makes every qualification-path branch explicit and renders incomplete-lock refusal exactly', () => {
+    const { lockId: _fixtureLockId, ...fixtureLockMaterial } = fixtureLock
+    const driftedLock = makeQualificationLock({
+      ...fixtureLockMaterial,
+      sourceRevision: '0'.repeat(40),
+    })
+    expect(driftedLock.candidateRunId).toBe(fixtureLock.candidateRunId)
+
+    expect(decideQualificationPath(fixtureLock, { state: 'ACQUIRED', lock: fixtureLock })).toEqual(
+      Result.succeed({ _tag: 'EvaluateAcquired' }),
+    )
+    expect(
+      decideQualificationPath(fixtureLock, {
+        state: 'TERMINAL',
+        lock: fixtureLock,
+        result: fixtureQualification,
+      }),
+    ).toEqual(
+      Result.succeed({
+        _tag: 'RecoverTerminal',
+        runId: fixtureLock.candidateRunId,
+        result: fixtureQualification,
+      }),
+    )
+
+    const incomplete = decisionFailure(
+      decideQualificationPath(driftedLock, { state: 'OPENED_INCOMPLETE', lock: fixtureLock }),
+    )
+    expect(incomplete).toEqual({
+      _tag: 'QualificationStateInvalid',
+      details: { reason: 'opened-incomplete', lockId: fixtureLock.lockId },
+    })
+    expectRenderedFailure(incomplete, {
+      component: 'database',
+      operation: 'open-qualification',
+      message: `qualification ${fixtureLock.lockId} was opened without a terminal result`,
+    })
+
+    const lockMismatch = decisionFailure(decideQualificationPath(fixtureLock, { state: 'ACQUIRED', lock: driftedLock }))
+    expect(lockMismatch).toEqual({
+      _tag: 'BindingMismatch',
+      details: {
+        binding: 'qualification-lock',
+        expected: fixtureLock,
+        observed: driftedLock,
+      },
+    })
+    expectRenderedFailure(lockMismatch, {
+      component: 'database',
+      operation: 'open-qualification',
+      message: 'qualification lock binding failed: store returned a different candidate lock',
+    })
+
+    const terminalMismatch = decisionFailure(
+      decideQualificationPath(fixtureLock, {
+        state: 'TERMINAL',
+        lock: fixtureLock,
+        result: pinnedQualification,
+      }),
+    )
+    expect(terminalMismatch).toEqual({
+      _tag: 'BindingMismatch',
+      details: {
+        binding: 'terminal-run',
+        terminalRunId: fixtureLock.candidateRunId,
+        qualificationRunId: pinnedQualification.runId,
+      },
+    })
+    expectRenderedFailure(terminalMismatch, {
+      component: 'database',
+      operation: 'recover-qualification',
+      message: 'qualification recovery failed: terminal lock and result run IDs differ',
+    })
+  })
+
+  test('recovers only terminal evidence with the exact run binding', () => {
+    const path = {
+      _tag: 'RecoverTerminal' as const,
+      runId: fixtureLock.candidateRunId,
+      result: fixtureQualification,
+    }
+    const exact = decisionSuccess(
+      decideTerminalRecovery(fixtureStrategy.provenance, path, Option.some(recoveredFixture())),
+    )
+    expect(exact).toMatchObject({
+      _tag: 'TerminalRecovered',
+      evidence: { startupMode: 'recovered', evaluation: { runId: fixtureEvaluation.runId } },
+    })
+
+    const missing = decisionFailure(decideTerminalRecovery(fixtureStrategy.provenance, path, Option.none()))
+    expect(missing).toEqual({
+      _tag: 'QualificationStateInvalid',
+      details: {
+        reason: 'evidence-missing',
+        phase: 'recover-terminal',
+        runId: fixtureQualification.runId,
+      },
+    })
+    expectRenderedFailure(missing, {
+      component: 'database',
+      operation: 'recover-evaluation',
+      message: `terminal qualification run ${fixtureQualification.runId} is missing`,
+    })
+
+    const forgedPath = decisionFailure(
+      decideTerminalRecovery(
+        fixtureStrategy.provenance,
+        { ...path, runId: pinnedQualification.runId },
+        Option.some(recoveredFixture()),
+      ),
+    )
+    expect(forgedPath).toEqual({
+      _tag: 'BindingMismatch',
+      details: {
+        binding: 'terminal-run',
+        terminalRunId: pinnedQualification.runId,
+        qualificationRunId: fixtureQualification.runId,
+      },
+    })
+
+    const recoveredRunId = '0'.repeat(64)
+    for (const field of ['evaluation', 'reconciliation', 'persistence'] as const) {
+      const recovered = recoveredFixture()
+      const mismatch = decisionFailure(
+        decideTerminalRecovery(
+          fixtureStrategy.provenance,
+          path,
+          Option.some({
+            ...recovered,
+            [field]: { ...recovered[field], runId: recoveredRunId },
+          }),
+        ),
+      )
+      expect(mismatch).toMatchObject({
+        _tag: 'BindingMismatch',
+        details: {
+          binding: 'recovery',
+          phase: 'terminal',
+          expectedRunId: fixtureQualification.runId,
+          recoveredRunIds: { [field]: recoveredRunId },
+        },
+      })
+      expectRenderedFailure(mismatch, {
+        component: 'database',
+        operation: 'recover-qualification',
+        message: 'qualification recovery failed: terminal qualification differs from the recovered evaluation',
+      })
+    }
+  })
+
+  test('rejects verdict-only drift for pinned and terminal recovery with unchanged run IDs', () => {
+    const pinnedDecision = decisionSuccess(
+      decidePinnedQualification(pinnedRuntimeConfig, pinnedEvaluation.runId, {
+        stored: Option.some(pinnedStoredEvidence),
+        qualification: Option.some({ state: 'TERMINAL', lock: pinnedLock, result: pinnedQualification }),
+      }),
+    )
+    const pinnedRecovered = recoveredFixture(pinnedEvaluation.runId)
+    const pinnedMismatch = decisionFailure(
+      decidePinnedRecovery(
+        pinnedDecision,
+        Option.some({
+          ...pinnedRecovered,
+          evaluation: {
+            ...summarizeEvaluation(pinnedEvaluation),
+            verdict: verdictWithCanonicalDrift(pinnedEvaluation.verdict),
+          },
+        }),
+      ),
+    )
+    expect(pinnedMismatch).toMatchObject({
+      _tag: 'BindingMismatch',
+      details: {
+        binding: 'recovery',
+        phase: 'pinned',
+        expectedRunId: pinnedEvaluation.runId,
+        recoveredRunIds: {
+          evaluation: pinnedEvaluation.runId,
+          reconciliation: pinnedEvaluation.runId,
+          persistence: pinnedEvaluation.runId,
+        },
+      },
+    })
+
+    const terminalPath = {
+      _tag: 'RecoverTerminal' as const,
+      runId: fixtureLock.candidateRunId,
+      result: fixtureQualification,
+    }
+    const terminalRecovered = recoveredFixture()
+    const terminalMismatch = decisionFailure(
+      decideTerminalRecovery(
+        fixtureStrategy.provenance,
+        terminalPath,
+        Option.some({
+          ...terminalRecovered,
+          evaluation: {
+            ...terminalRecovered.evaluation,
+            verdict: verdictWithCanonicalDrift(fixtureEvaluation.verdict),
+          },
+        }),
+      ),
+    )
+    expect(terminalMismatch).toMatchObject({
+      _tag: 'BindingMismatch',
+      details: {
+        binding: 'recovery',
+        phase: 'terminal',
+        expectedRunId: fixtureEvaluation.runId,
+        recoveredRunIds: {
+          evaluation: fixtureEvaluation.runId,
+          reconciliation: fixtureEvaluation.runId,
+          persistence: fixtureEvaluation.runId,
+        },
+      },
+    })
+  })
+
+  test('rejects a loaded manifest mismatch before evaluation with canonical fact hashes', () => {
+    const loaded = {
+      ...fixtureSnapshot,
+      manifest: { ...fixtureSnapshot.manifest, hash: '0'.repeat(64) },
+    }
+    const mismatch = decisionFailure(
+      evaluateLockedSnapshot(fixtureStrategy, candidateQualification.inspection, fixtureLock, loaded),
+    )
+    expect(mismatch).toEqual({
+      _tag: 'BindingMismatch',
+      details: {
+        binding: 'locked-manifest',
+        inspectedManifestHash: canonicalHashV1(candidateQualification.inspection.manifest),
+        loadedManifestHash: canonicalHashV1(loaded.manifest),
+      },
+    })
+    expectRenderedFailure(mismatch, {
+      component: 'market-data',
+      operation: 'load-locked',
+      message: 'locked Signal load failed: loaded Signal manifest differs from the locked inspection',
+    })
+  })
+
+  test('returns an exact evaluation-run mismatch without throwing or journaling', () => {
+    const evaluationRunId = '0'.repeat(64)
+    const strategy: Strategy = {
+      ...fixtureStrategy,
+      evaluate: () => ({ ...fixtureEvaluation, runId: evaluationRunId }),
+    }
+    const mismatch = decisionFailure(
+      evaluateLockedSnapshot(strategy, candidateQualification.inspection, fixtureLock, fixtureSnapshot),
+    )
+    expect(mismatch).toEqual({
+      _tag: 'BindingMismatch',
+      details: {
+        binding: 'evaluation-run',
+        lockedRunId: fixtureLock.candidateRunId,
+        evaluationRunId,
+      },
+    })
+    expectRenderedFailure(mismatch, {
+      component: 'strategy',
+      operation: 'evaluate',
+      message: 'evaluation run identity differs from the qualification lock',
+    })
+  })
+
+  test('renders evaluate, analyze, and qualify failures with baseline operation text', () => {
+    const evaluationCause = new Error('evaluation exploded')
+    const analysisCause = new Error('analysis exploded')
+    const reconciliation = recoveredFixture().reconciliation
+    const cases: readonly {
+      readonly operation: 'evaluate' | 'analyze' | 'qualify'
+      readonly message: string
+      readonly decide: () => Result.Result<unknown, StartupDecisionFailure>
+    }[] = [
+      {
+        operation: 'evaluate',
+        message: `${fixtureStrategy.name} evaluation failed: ${evaluationCause.message}`,
+        decide: () =>
+          evaluateLockedSnapshot(
+            {
+              ...fixtureStrategy,
+              evaluate: () => {
+                throw evaluationCause
+              },
+            },
+            candidateQualification.inspection,
+            fixtureLock,
+            fixtureSnapshot,
+          ),
+      },
+      {
+        operation: 'analyze',
+        message: `${fixtureStrategy.name} analysis failed: ${analysisCause.message}`,
+        decide: () =>
+          qualifyEvaluation(
+            {
+              ...fixtureStrategy,
+              analyze: () => {
+                throw analysisCause
+              },
+            },
+            fixtureLock,
+            fixtureEvaluation,
+            reconciliation,
+          ),
+      },
+      {
+        operation: 'qualify',
+        message: `${fixtureStrategy.name} qualification failed: qualification analysis must use the locked prior-trial lineage`,
+        decide: () =>
+          qualifyEvaluation(
+            {
+              ...fixtureStrategy,
+              analyze: (evaluation, priorTrialRunIds) => ({
+                ...fixtureStrategy.analyze(evaluation, priorTrialRunIds),
+                priorTrialRunIds: ['0'.repeat(64)],
+              }),
+            },
+            fixtureLock,
+            fixtureEvaluation,
+            reconciliation,
+          ),
+      },
+    ]
+
+    for (const testCase of cases) {
+      const failure = decisionFailure(testCase.decide())
+      expect(failure).toMatchObject({
+        _tag: 'StrategyOperationFailed',
+        operation: testCase.operation,
+        strategyName: fixtureStrategy.name,
+      })
+      expectRenderedFailure(failure, {
+        component: 'strategy',
+        operation: testCase.operation,
+        message: testCase.message,
+      })
+    }
+  })
+
+  test('renders hostile causes with a deterministic fallback without losing the original cause', () => {
+    const hostileString = {
+      toString: () => {
+        throw new Error('hostile toString')
+      },
+    }
+    const hostileMessage = new Error('hidden')
+    Object.defineProperty(hostileMessage, 'message', {
+      get: () => {
+        throw new Error('hostile message getter')
+      },
+    })
+
+    for (const cause of [hostileString, hostileMessage]) {
+      const failure: StartupDecisionFailure = {
+        _tag: 'StrategyOperationFailed',
+        operation: 'evaluate',
+        strategyName: fixtureStrategy.name,
+        cause,
+      }
+      expect(() => {
+        renderStartupDecisionFailure(failure)
+      }).not.toThrow()
+      expectRenderedFailure(failure, {
+        component: 'strategy',
+        operation: 'evaluate',
+        message: `${fixtureStrategy.name} evaluation failed: unrenderable cause`,
+      })
+    }
+  })
+
+  test('captures malformed persisted canonical material as data instead of a defect', () => {
+    const malformed = malformedPinnedStoredEvidence()
+    const decide = () =>
+      decidePinnedQualification(pinnedRuntimeConfig, pinnedEvaluation.runId, {
+        stored: Option.some(malformed),
+        qualification: Option.some({ state: 'TERMINAL', lock: pinnedLock, result: pinnedQualification }),
+      })
+
+    expect(decide).not.toThrow()
+    const failure = decisionFailure(decide())
+    expect(failure).toMatchObject({
+      _tag: 'CanonicalizationFailed',
+      details: {
+        target: 'stored-protocol-parameters',
+        side: 'stored',
+      },
+    })
+    expect(failure._tag === 'CanonicalizationFailed' && failure.details.cause instanceof TypeError).toBe(true)
+    expectRenderedFailure(failure, {
+      component: 'database',
+      operation: 'recover-pinned-qualification',
+      message: expect.stringContaining('contains an invalid Unicode surrogate'),
+    })
+  })
+})
 
 describe('Bayn startup lifecycle', () => {
   test('recovers a pinned terminal qualification without inspecting data or writing state', async () => {
@@ -266,6 +903,27 @@ describe('Bayn startup lifecycle', () => {
     }
   })
 
+  test('converts malformed persisted canonical material to a terminal failure without a defect', async () => {
+    const state = await Effect.runPromise(Ref.make(initialState()))
+    const exit = await Effect.runPromiseExit(
+      initialize(pinnedRuntimeConfig, state, fixtureStrategy).pipe(
+        Effect.provideService(MarketData, marketDataService(Effect.die(new Error('must not load bars')))),
+        Effect.provideService(Journal, successfulJournal),
+        Effect.provideService(EvidenceStore, {
+          ...pinnedStore(),
+          read: () => Effect.succeed(Option.some(malformedPinnedStoredEvidence())),
+        }),
+      ),
+    )
+
+    expect(Exit.isSuccess(exit)).toBe(true)
+    expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
+      status: 'FAILED',
+      evidence: null,
+      error: expect.stringContaining('contains an invalid Unicode surrogate'),
+    })
+  })
+
   test('recovers a complete run without evaluating, journaling, or persisting again', async () => {
     const snapshot = makeSnapshot()
     const evaluation = evaluateRiskBalancedTrend(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance)
@@ -336,6 +994,47 @@ describe('Bayn startup lifecycle', () => {
         evaluation: { runId: evaluation.runId },
         persistence: { deduplicated: true },
       },
+    })
+  })
+
+  test('rejects an unrelated terminal qualification before recovery or publication', async () => {
+    const snapshot = makeSnapshot()
+    let recoverCalls = 0
+    let persistenceWrites = 0
+    const store: EvidenceStoreService = {
+      ...successfulEvidenceStore,
+      openQualification: (input) =>
+        Effect.sync(() => {
+          expect(input.lock).toEqual(fixtureLock)
+          return { state: 'TERMINAL', lock: pinnedLock, result: pinnedQualification }
+        }),
+      recover: () => {
+        recoverCalls += 1
+        return Effect.die(new Error('unrelated terminal qualification must not be recovered'))
+      },
+      persist: () => {
+        persistenceWrites += 1
+        return Effect.die(new Error('unrelated terminal qualification must not be persisted'))
+      },
+    }
+    const state = await Effect.runPromise(Ref.make(initialState()))
+
+    await Effect.runPromise(
+      initialize(config, state, fixtureStrategy).pipe(
+        Effect.provideService(
+          MarketData,
+          marketDataService(Effect.die(new Error('unrelated terminal qualification must not load bars')), snapshot),
+        ),
+        Effect.provideService(Journal, successfulJournal),
+        Effect.provideService(EvidenceStore, store),
+      ),
+    )
+
+    expect({ recoverCalls, persistenceWrites }).toEqual({ recoverCalls: 0, persistenceWrites: 0 })
+    expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
+      status: 'FAILED',
+      evidence: null,
+      error: expect.stringContaining('qualification lock binding failed'),
     })
   })
 
@@ -488,10 +1187,103 @@ describe('Bayn startup lifecycle', () => {
 
     const current = await Effect.runPromise(Ref.get(state))
     expect(current.status).toBe('STARTING')
-    if (current.evidence !== null) {
-      expect(current.evidence.reconciliation.exact).toBe(true)
-      expect(current.evidence.evaluation.eventCount).toBeGreaterThan(0)
+    expect(current.evidence).toMatchObject({
+      startupMode: 'evaluated',
+      evaluation: { runId: fixtureEvaluation.runId },
+      reconciliation: { runId: fixtureEvaluation.runId, exact: true },
+      persistence: { runId: fixtureEvaluation.runId },
+      qualification: {
+        runId: fixtureEvaluation.runId,
+        resultHash: fixtureQualification.resultHash,
+      },
+    })
+  })
+
+  test('keeps dependency, lock, evaluation, journal, and persistence phases in fail-closed order', async () => {
+    const calls: string[] = []
+    const snapshot = makeSnapshot()
+    const baseMarketData = marketDataService(Effect.succeed(snapshot), snapshot)
+    const marketData = {
+      ...baseMarketData,
+      inspect: Effect.sync(() => calls.push('inspect')).pipe(Effect.andThen(baseMarketData.inspect)),
+      load: Effect.sync(() => calls.push('load')).pipe(Effect.andThen(Effect.succeed(snapshot))),
     }
+    const strategy: Strategy = {
+      ...fixtureStrategy,
+      prepareLock: (manifest, sessionDates, priorTrialRunIds) => {
+        calls.push('prepare-lock')
+        return fixtureStrategy.prepareLock(manifest, sessionDates, priorTrialRunIds)
+      },
+      evaluate: (bars, manifest) => {
+        calls.push('evaluate')
+        return fixtureStrategy.evaluate(bars, manifest)
+      },
+      analyze: (evaluation, priorTrialRunIds) => {
+        calls.push('analyze')
+        return fixtureStrategy.analyze(evaluation, priorTrialRunIds)
+      },
+    }
+    const journal: JournalService = {
+      ...successfulJournal,
+      check: Effect.sync(() => calls.push('journal-check')),
+      journalAndReconcile: (evaluation) =>
+        Effect.sync(() => {
+          calls.push('journal')
+          return {
+            runId: evaluation.runId,
+            accountCount: evaluation.inputManifest.symbols.length + 5,
+            transferCount: evaluation.events.length,
+            exact: true as const,
+          }
+        }),
+    }
+    const store: EvidenceStoreService = {
+      ...successfulEvidenceStore,
+      check: Effect.sync(() => calls.push('database-check')),
+      listPriorTrials: Effect.sync(() => {
+        calls.push('list-prior-trials')
+        return []
+      }),
+      openQualification: ({ lock }) =>
+        Effect.sync(() => {
+          calls.push('open-qualification')
+          return { state: 'ACQUIRED' as const, lock }
+        }),
+      persist: ({ evaluation }) =>
+        Effect.sync(() => {
+          calls.push('persist')
+          return {
+            runId: evaluation.runId,
+            deduplicated: false,
+            artifactCount: 17,
+            eventCount: evaluation.events.length,
+            gateCount: evaluation.verdict.gates.length,
+          }
+        }),
+    }
+    const state = await Effect.runPromise(Ref.make(initialState()))
+
+    await Effect.runPromise(
+      initialize(config, state, strategy).pipe(
+        Effect.provideService(MarketData, marketData),
+        Effect.provideService(Journal, journal),
+        Effect.provideService(EvidenceStore, store),
+      ),
+    )
+
+    expect(calls).toEqual([
+      'journal-check',
+      'database-check',
+      'inspect',
+      'list-prior-trials',
+      'prepare-lock',
+      'open-qualification',
+      'load',
+      'evaluate',
+      'journal',
+      'analyze',
+      'persist',
+    ])
   })
 
   test('rejects an underpowered calendar before opening a qualification lock', async () => {

--- a/services/bayn/src/startup.ts
+++ b/services/bayn/src/startup.ts
@@ -1,17 +1,232 @@
-import { Effect, Option, Ref } from 'effect'
+import { Effect, Option, Ref, Result } from 'effect'
 
 import type { RuntimeConfig } from './config'
 import { makeRuntimeProvenance, makeStrategyProtocolHash, type RuntimeProvenance } from './contracts'
-import { EvidenceStore, type StoredEvaluationEvidence } from './db/evidence-store'
-import { formatError, operationalError, type OperationalError } from './errors'
+import {
+  EvidenceStore,
+  type EvidenceStoreService,
+  type PersistenceReceipt,
+  type QualificationOpen,
+  type QualificationRecord,
+  type RecoveredEvaluationEvidence,
+  type StoredEvaluationEvidence,
+} from './db/evidence-store'
+import { OperationalError, formatError, type Component } from './errors'
 import { canonicalHashV1 } from './hash'
-import { Journal } from './ledger'
-import { MarketData } from './market-data'
+import { Journal, type JournalService } from './ledger'
+import { MarketData, type MarketDataInspection, type MarketDataService, type MarketDataSnapshot } from './market-data'
 import { databaseOperation, withinDeadline } from './operations'
-import { makeQualificationResult } from './qualification'
+import { makeQualificationResult, type QualificationLock, type QualificationResult } from './qualification'
 import { summarizeEvaluation } from './risk-balanced-trend'
-import type { RuntimeState } from './runtime-state'
+import type { RuntimeEvidence, RuntimeState } from './runtime-state'
 import type { Strategy } from './strategy'
+import type { EvaluationResult, ReconciliationResult } from './types'
+
+type TerminalQualificationRecord = Extract<QualificationRecord, { readonly state: 'TERMINAL' }>
+
+interface StartupDependencies {
+  readonly marketData: MarketDataService
+  readonly journal: JournalService
+  readonly evidenceStore: EvidenceStoreService
+}
+
+interface EvaluationWorkflow {
+  readonly config: RuntimeConfig
+  readonly strategy: Strategy
+  readonly dependencies: StartupDependencies
+}
+
+interface CandidateQualification {
+  readonly inspection: MarketDataInspection
+  readonly lock: QualificationLock
+}
+
+type QualificationPath =
+  | { readonly _tag: 'EvaluateAcquired' }
+  | {
+      readonly _tag: 'RecoverTerminal'
+      readonly runId: string
+      readonly result: QualificationResult
+    }
+
+interface EvaluationEvidence {
+  readonly evaluation: EvaluationResult
+  readonly reconciliation: ReconciliationResult
+  readonly qualification: QualificationResult
+}
+
+interface PinnedQualificationFacts {
+  readonly stored: Option.Option<StoredEvaluationEvidence>
+  readonly qualification: Option.Option<QualificationRecord>
+}
+
+interface PinnedQualificationDecision {
+  readonly _tag: 'RecoverPinned'
+  readonly executionProvenance: RuntimeProvenance
+  readonly qualification: TerminalQualificationRecord
+}
+
+type StartupCompletion =
+  | {
+      readonly _tag: 'PinnedRecovered'
+      readonly evidence: RuntimeEvidence
+    }
+  | {
+      readonly _tag: 'TerminalRecovered'
+      readonly evidence: RuntimeEvidence
+    }
+  | {
+      readonly _tag: 'Evaluated'
+      readonly evidence: RuntimeEvidence
+      readonly markedEquityDifferenceMicros: string
+    }
+
+type StartupCanonicalizationContext =
+  | { readonly target: 'stored-protocol-parameters'; readonly side: 'stored' }
+  | { readonly target: 'qualification-lock'; readonly side: 'expected' | 'observed' }
+  | { readonly target: 'pinned-lock'; readonly side: 'lock' | 'runtime' }
+  | { readonly target: 'pinned-snapshot'; readonly side: 'lock' | 'configured' }
+  | { readonly target: 'pinned-verdict' | 'terminal-verdict'; readonly side: 'qualification' | 'recovered' }
+  | { readonly target: 'locked-manifest'; readonly side: 'inspection' | 'loaded' }
+
+type StartupCanonicalizationFailure = StartupCanonicalizationContext & { readonly cause: unknown }
+type StartupCanonicalizationInput = readonly [context: StartupCanonicalizationContext, value: unknown]
+
+type StartupQualificationFailure =
+  | {
+      readonly reason: 'evidence-missing'
+      readonly phase: 'read-pinned' | 'recover-pinned' | 'recover-terminal'
+      readonly runId: string
+    }
+  | {
+      readonly reason: 'pinned-not-terminal'
+      readonly runId: string
+      readonly observedState: 'MISSING' | 'OPENED_INCOMPLETE'
+    }
+  | { readonly reason: 'opened-incomplete'; readonly lockId: string }
+
+type StartupBindingMismatch =
+  | {
+      readonly binding: 'qualification-lock'
+      readonly expected: QualificationLock
+      readonly observed: QualificationLock
+    }
+  | {
+      readonly binding: 'pinned-run'
+      readonly expectedRunId: string
+      readonly storedRunId: string
+      readonly qualificationRunId: string
+    }
+  | {
+      readonly binding: 'pinned-lock'
+      readonly expected: {
+        readonly candidateRunId: string
+        readonly protocolHash: string
+        readonly sourceRevision: string
+        readonly image: RuntimeProvenance['image']
+      }
+      readonly observed: {
+        readonly candidateRunId: string
+        readonly protocolHash: string
+        readonly sourceRevision: string
+        readonly image: RuntimeProvenance['image']
+      }
+    }
+  | {
+      readonly binding: 'pinned-snapshot'
+      readonly expected: {
+        readonly snapshotId: string
+        readonly lastSession: string
+        readonly calendarVersion: string
+        readonly bounds: RuntimeConfig['clickhouse']['bounds']
+      }
+      readonly observed: {
+        readonly snapshotId: string
+        readonly lastSession: string
+        readonly calendarVersion: string
+        readonly bounds: QualificationLock['data']['bounds']
+      }
+    }
+  | {
+      readonly binding: 'recovery'
+      readonly phase: 'pinned' | 'terminal'
+      readonly expectedRunId: string
+      readonly recoveredRunIds: {
+        readonly evaluation: string
+        readonly reconciliation: string
+        readonly persistence: string
+      }
+      readonly expectedVerdict: QualificationResult['evaluationVerdict']
+      readonly recoveredVerdict: RecoveredEvaluationEvidence['evaluation']['verdict']
+    }
+  | {
+      readonly binding: 'terminal-run'
+      readonly terminalRunId: string
+      readonly qualificationRunId: string
+    }
+  | {
+      readonly binding: 'locked-manifest'
+      readonly inspectedManifestHash: string
+      readonly loadedManifestHash: string
+    }
+  | {
+      readonly binding: 'evaluation-run'
+      readonly lockedRunId: string
+      readonly evaluationRunId: string
+    }
+
+export type StartupDecisionFailure =
+  | {
+      readonly _tag: 'StoredProvenanceInvalid'
+      readonly identity: {
+        readonly runId: string
+        readonly strategyName: string
+        readonly schemaVersion: string
+      }
+      readonly issue:
+        | { readonly reason: 'unsupported-contract' }
+        | { readonly reason: 'malformed'; readonly cause: unknown }
+        | {
+            readonly reason: 'protocol-mismatch'
+            readonly stored: {
+              readonly parameterHash: string
+              readonly protocolHash: string
+              readonly runProtocolHash: string
+            }
+            readonly computed: { readonly parameterHash: string; readonly protocolHash: string }
+          }
+    }
+  | {
+      readonly _tag: 'CanonicalizationFailed'
+      readonly details: StartupCanonicalizationFailure
+    }
+  | {
+      readonly _tag: 'QualificationStateInvalid'
+      readonly details: StartupQualificationFailure
+    }
+  | {
+      readonly _tag: 'BindingMismatch'
+      readonly details: StartupBindingMismatch
+    }
+  | {
+      readonly _tag: 'StrategyOperationFailed'
+      readonly operation: 'prepare-lock' | 'evaluate' | 'analyze' | 'qualify'
+      readonly strategyName: string
+      readonly cause: unknown
+    }
+
+const failStartupState = (current: RuntimeState, error: OperationalError): RuntimeState => ({
+  ...current,
+  status: 'FAILED',
+  evidence: null,
+  error: formatError(error),
+})
+
+const completeStartupState = (current: RuntimeState, completion: StartupCompletion): RuntimeState => ({
+  ...current,
+  evidence: completion.evidence,
+  error: null,
+})
 
 const failStartup = (state: Ref.Ref<RuntimeState>, error: OperationalError): Effect.Effect<void> =>
   Effect.logError('Bayn startup failed').pipe(
@@ -21,377 +236,956 @@ const failStartup = (state: Ref.Ref<RuntimeState>, error: OperationalError): Eff
       operation: error.operation,
       error: error.message,
     }),
-    Effect.andThen(
-      Ref.update(
-        state,
-        (current): RuntimeState => ({
-          ...current,
-          status: 'FAILED',
-          evidence: null,
-          error: formatError(error),
-        }),
-      ),
-    ),
+    Effect.andThen(Ref.update(state, (current) => failStartupState(current, error))),
   )
 
-const provenanceFromStored = (stored: StoredEvaluationEvidence): RuntimeProvenance => {
+const causeMessage = (cause: unknown): string => {
+  const rendered = Result.try({
+    try: () => String(cause instanceof Error ? cause.message : cause),
+    catch: () => undefined,
+  })
+  return Result.isSuccess(rendered) ? rendered.success : 'unrenderable cause'
+}
+
+interface StartupFailurePresentation {
+  readonly component: Component
+  readonly operation: string
+  readonly message: string
+}
+
+const presentFailure = (component: Component, operation: string, message: string): StartupFailurePresentation => ({
+  component,
+  operation,
+  message,
+})
+
+const renderCanonicalizationFailure = (
+  failure: Extract<StartupDecisionFailure, { readonly _tag: 'CanonicalizationFailed' }>,
+): StartupFailurePresentation => {
+  const detail = causeMessage(failure.details.cause)
+  switch (failure.details.target) {
+    case 'stored-protocol-parameters':
+      return presentFailure(
+        'database',
+        'recover-pinned-qualification',
+        `stored qualification provenance is invalid: ${detail}`,
+      )
+    case 'qualification-lock':
+      return presentFailure('database', 'open-qualification', `qualification lock binding failed: ${detail}`)
+    case 'pinned-lock':
+    case 'pinned-snapshot':
+      return presentFailure(
+        'database',
+        'recover-pinned-qualification',
+        `pinned qualification binding failed: ${detail}`,
+      )
+    case 'pinned-verdict':
+      return presentFailure(
+        'database',
+        'recover-pinned-qualification',
+        `pinned qualification recovery failed: ${detail}`,
+      )
+    case 'terminal-verdict':
+      return presentFailure('database', 'recover-qualification', `qualification recovery failed: ${detail}`)
+    case 'locked-manifest':
+      return presentFailure('market-data', 'load-locked', `locked Signal load failed: ${detail}`)
+  }
+}
+
+const startupFailurePresentation = (failure: StartupDecisionFailure): StartupFailurePresentation => {
+  switch (failure._tag) {
+    case 'StoredProvenanceInvalid': {
+      const detail =
+        failure.issue.reason === 'unsupported-contract'
+          ? 'stored evaluation uses an unsupported strategy contract'
+          : failure.issue.reason === 'malformed'
+            ? causeMessage(failure.issue.cause)
+            : 'stored evaluation protocol does not match its own provenance'
+      return presentFailure(
+        'database',
+        'recover-pinned-qualification',
+        `stored qualification provenance is invalid: ${detail}`,
+      )
+    }
+    case 'CanonicalizationFailed':
+      return renderCanonicalizationFailure(failure)
+    case 'QualificationStateInvalid':
+      switch (failure.details.reason) {
+        case 'evidence-missing':
+          return failure.details.phase === 'recover-terminal'
+            ? presentFailure(
+                'database',
+                'recover-evaluation',
+                `terminal qualification run ${failure.details.runId} is missing`,
+              )
+            : presentFailure(
+                'database',
+                failure.details.phase === 'read-pinned' ? 'read-pinned-qualification' : 'recover-pinned-qualification',
+                `pinned evaluation ${failure.details.runId} is missing`,
+              )
+        case 'pinned-not-terminal':
+          return presentFailure(
+            'database',
+            'read-pinned-qualification',
+            `pinned qualification ${failure.details.runId} is not terminal`,
+          )
+        case 'opened-incomplete':
+          return presentFailure(
+            'database',
+            'open-qualification',
+            `qualification ${failure.details.lockId} was opened without a terminal result`,
+          )
+      }
+    case 'BindingMismatch':
+      switch (failure.details.binding) {
+        case 'qualification-lock':
+          return presentFailure(
+            'database',
+            'open-qualification',
+            'qualification lock binding failed: store returned a different candidate lock',
+          )
+        case 'pinned-run':
+          return presentFailure(
+            'database',
+            'recover-pinned-qualification',
+            'pinned qualification binding failed: stored evaluation and terminal qualification run IDs differ',
+          )
+        case 'pinned-lock':
+          return presentFailure(
+            'database',
+            'recover-pinned-qualification',
+            'pinned qualification binding failed: qualification lock differs from the stored execution provenance',
+          )
+        case 'pinned-snapshot':
+          return presentFailure(
+            'database',
+            'recover-pinned-qualification',
+            'pinned qualification binding failed: configured Signal snapshot differs from the pinned qualification',
+          )
+        case 'recovery':
+          return failure.details.phase === 'pinned'
+            ? presentFailure(
+                'database',
+                'recover-pinned-qualification',
+                'pinned qualification recovery failed: recovered evidence differs from the terminal qualification',
+              )
+            : presentFailure(
+                'database',
+                'recover-qualification',
+                'qualification recovery failed: terminal qualification differs from the recovered evaluation',
+              )
+        case 'terminal-run':
+          return presentFailure(
+            'database',
+            'recover-qualification',
+            'qualification recovery failed: terminal lock and result run IDs differ',
+          )
+        case 'locked-manifest':
+          return presentFailure(
+            'market-data',
+            'load-locked',
+            'locked Signal load failed: loaded Signal manifest differs from the locked inspection',
+          )
+        case 'evaluation-run':
+          return presentFailure('strategy', 'evaluate', 'evaluation run identity differs from the qualification lock')
+      }
+    case 'StrategyOperationFailed': {
+      const label = {
+        'prepare-lock': 'lock preparation',
+        evaluate: 'evaluation',
+        analyze: 'analysis',
+        qualify: 'qualification',
+      }[failure.operation]
+      return presentFailure(
+        'strategy',
+        failure.operation,
+        `${failure.strategyName} ${label} failed: ${causeMessage(failure.cause)}`,
+      )
+    }
+  }
+}
+
+export const renderStartupDecisionFailure = (failure: StartupDecisionFailure): OperationalError =>
+  new OperationalError({
+    ...startupFailurePresentation(failure),
+    retryable: false,
+    cause: failure,
+  })
+
+const fromStartupDecision = <A>(
+  decision: Result.Result<A, StartupDecisionFailure>,
+): Effect.Effect<A, OperationalError> => Effect.fromResult(decision).pipe(Effect.mapError(renderStartupDecisionFailure))
+
+const canonicalStartupHash = (
+  context: StartupCanonicalizationContext,
+  value: unknown,
+): Result.Result<string, StartupDecisionFailure> =>
+  Result.try({
+    try: () => canonicalHashV1(value),
+    catch: (cause): StartupDecisionFailure => ({
+      _tag: 'CanonicalizationFailed',
+      details: { ...context, cause },
+    }),
+  })
+
+const validateCanonicalBinding = (
+  left: StartupCanonicalizationInput,
+  right: StartupCanonicalizationInput,
+  mismatch: Extract<StartupDecisionFailure, { readonly _tag: 'BindingMismatch' }>,
+): Result.Result<void, StartupDecisionFailure> => {
+  const leftHash = canonicalStartupHash(left[0], left[1])
+  if (Result.isFailure(leftHash)) return Result.fail(leftHash.failure)
+  const rightHash = canonicalStartupHash(right[0], right[1])
+  if (Result.isFailure(rightHash)) return Result.fail(rightHash.failure)
+  return leftHash.success === rightHash.success ? Result.succeed(undefined) : Result.fail(mismatch)
+}
+
+const provenanceFromStored = (
+  stored: StoredEvaluationEvidence,
+): Result.Result<RuntimeProvenance, StartupDecisionFailure> => {
+  const identity = {
+    runId: stored.run.runId,
+    strategyName: stored.protocol.strategyName,
+    schemaVersion: stored.protocol.schemaVersion,
+  }
   if (
     stored.protocol.strategyName !== 'risk-balanced-trend' ||
     (stored.protocol.schemaVersion !== 'bayn.risk-balanced-trend.protocol.v2' &&
       stored.protocol.schemaVersion !== 'bayn.risk-balanced-trend.protocol.v3')
   ) {
-    throw new Error('stored evaluation uses an unsupported strategy contract')
+    return Result.fail({
+      _tag: 'StoredProvenanceInvalid',
+      identity,
+      issue: { reason: 'unsupported-contract' },
+    })
   }
-  const provenance = makeRuntimeProvenance({
-    sourceRevision: stored.run.sourceRevision,
-    image: { repository: stored.run.imageRepository, digest: stored.run.imageDigest },
-    strategy: {
-      name: stored.protocol.strategyName,
-      behaviorHash: stored.protocol.behaviorHash,
-      parameterHash: stored.protocol.parameterHash,
-      parameterSchemaVersion: stored.protocol.schemaVersion,
-    },
+  const parameterSchemaVersion =
+    stored.protocol.schemaVersion === 'bayn.risk-balanced-trend.protocol.v2'
+      ? 'bayn.risk-balanced-trend.protocol.v2'
+      : 'bayn.risk-balanced-trend.protocol.v3'
+  const provenanceResult = Result.try({
+    try: () =>
+      makeRuntimeProvenance({
+        sourceRevision: stored.run.sourceRevision,
+        image: { repository: stored.run.imageRepository, digest: stored.run.imageDigest },
+        strategy: {
+          name: 'risk-balanced-trend',
+          behaviorHash: stored.protocol.behaviorHash,
+          parameterHash: stored.protocol.parameterHash,
+          parameterSchemaVersion,
+        },
+      }),
+    catch: (cause): StartupDecisionFailure => ({
+      _tag: 'StoredProvenanceInvalid',
+      identity,
+      issue: { reason: 'malformed', cause },
+    }),
   })
+  if (Result.isFailure(provenanceResult)) return provenanceResult
+  const provenance = provenanceResult.success
+  const parameterHashResult = canonicalStartupHash(
+    { target: 'stored-protocol-parameters', side: 'stored' },
+    stored.protocol.parameters,
+  )
+  if (Result.isFailure(parameterHashResult)) return Result.fail(parameterHashResult.failure)
+  const protocolHash = makeStrategyProtocolHash(provenance.strategy)
   if (
-    canonicalHashV1(stored.protocol.parameters) !== provenance.strategy.parameterHash ||
-    stored.protocol.protocolHash !== makeStrategyProtocolHash(provenance.strategy) ||
+    parameterHashResult.success !== provenance.strategy.parameterHash ||
+    stored.protocol.protocolHash !== protocolHash ||
     stored.run.protocolHash !== stored.protocol.protocolHash
   ) {
-    throw new Error('stored evaluation protocol does not match its own provenance')
+    return Result.fail({
+      _tag: 'StoredProvenanceInvalid',
+      identity,
+      issue: {
+        reason: 'protocol-mismatch',
+        stored: {
+          parameterHash: stored.protocol.parameterHash,
+          protocolHash: stored.protocol.protocolHash,
+          runProtocolHash: stored.run.protocolHash,
+        },
+        computed: {
+          parameterHash: parameterHashResult.success,
+          protocolHash,
+        },
+      },
+    })
   }
-  return provenance
+  return Result.succeed(provenance)
 }
+
+export const decidePinnedQualification = (
+  config: RuntimeConfig,
+  runId: string,
+  facts: PinnedQualificationFacts,
+): Result.Result<PinnedQualificationDecision, StartupDecisionFailure> => {
+  if (Option.isNone(facts.stored)) {
+    return Result.fail({
+      _tag: 'QualificationStateInvalid',
+      details: { reason: 'evidence-missing', phase: 'read-pinned', runId },
+    })
+  }
+  if (Option.isNone(facts.qualification) || facts.qualification.value.state !== 'TERMINAL') {
+    return Result.fail({
+      _tag: 'QualificationStateInvalid',
+      details: {
+        reason: 'pinned-not-terminal',
+        runId,
+        observedState: Option.isNone(facts.qualification) ? 'MISSING' : 'OPENED_INCOMPLETE',
+      },
+    })
+  }
+  const stored = facts.stored.value
+  const qualification = facts.qualification.value
+  const provenanceResult = provenanceFromStored(stored)
+  if (Result.isFailure(provenanceResult)) return Result.fail(provenanceResult.failure)
+  const executionProvenance = provenanceResult.success
+  if (stored.run.runId !== runId || qualification.result.runId !== runId) {
+    return Result.fail({
+      _tag: 'BindingMismatch',
+      details: {
+        binding: 'pinned-run',
+        expectedRunId: runId,
+        storedRunId: stored.run.runId,
+        qualificationRunId: qualification.result.runId,
+      },
+    })
+  }
+  const expectedLock = {
+    candidateRunId: runId,
+    protocolHash: stored.run.protocolHash,
+    sourceRevision: executionProvenance.sourceRevision,
+    image: executionProvenance.image,
+  }
+  const observedLock = {
+    candidateRunId: qualification.lock.candidateRunId,
+    protocolHash: qualification.lock.protocolHash,
+    sourceRevision: qualification.lock.sourceRevision,
+    image: qualification.lock.image,
+  }
+  const lockBinding = validateCanonicalBinding(
+    [{ target: 'pinned-lock', side: 'lock' }, observedLock],
+    [{ target: 'pinned-lock', side: 'runtime' }, expectedLock],
+    {
+      _tag: 'BindingMismatch',
+      details: { binding: 'pinned-lock', expected: expectedLock, observed: observedLock },
+    },
+  )
+  if (Result.isFailure(lockBinding)) return Result.fail(lockBinding.failure)
+  const expectedSnapshot = {
+    snapshotId: config.clickhouse.snapshotId,
+    lastSession: config.clickhouse.publicationAsOf,
+    calendarVersion: config.clickhouse.calendarVersion,
+    bounds: config.clickhouse.bounds,
+  }
+  const observedSnapshot = {
+    snapshotId: qualification.lock.data.snapshotId,
+    lastSession: qualification.lock.data.lastSession,
+    calendarVersion: qualification.lock.data.calendarVersion,
+    bounds: qualification.lock.data.bounds,
+  }
+  const snapshotBinding = validateCanonicalBinding(
+    [{ target: 'pinned-snapshot', side: 'lock' }, observedSnapshot],
+    [{ target: 'pinned-snapshot', side: 'configured' }, expectedSnapshot],
+    {
+      _tag: 'BindingMismatch',
+      details: { binding: 'pinned-snapshot', expected: expectedSnapshot, observed: observedSnapshot },
+    },
+  )
+  if (Result.isFailure(snapshotBinding)) return Result.fail(snapshotBinding.failure)
+  return Result.succeed({
+    _tag: 'RecoverPinned',
+    executionProvenance,
+    qualification,
+  })
+}
+
+export const decidePinnedRecovery = (
+  decision: PinnedQualificationDecision,
+  recovered: Option.Option<RecoveredEvaluationEvidence>,
+): Result.Result<StartupCompletion, StartupDecisionFailure> => {
+  const runId = decision.qualification.result.runId
+  const recoveredResult = validateRecoveredEvaluation(
+    {
+      phase: 'pinned',
+      missingRunId: runId,
+      expectedRunId: runId,
+      expectedVerdict: decision.qualification.result.evaluationVerdict,
+    },
+    recovered,
+  )
+  if (Result.isFailure(recoveredResult)) return Result.fail(recoveredResult.failure)
+  const evidence = recoveredResult.success
+  return Result.succeed({
+    _tag: 'PinnedRecovered',
+    evidence: {
+      startupMode: 'pinned',
+      provenance: decision.executionProvenance,
+      evaluation: evidence.evaluation,
+      reconciliation: evidence.reconciliation,
+      persistence: evidence.persistence,
+      qualification: decision.qualification.result,
+    },
+  })
+}
+
+const prepareQualificationLock = (
+  strategy: Strategy,
+  inspection: MarketDataInspection,
+  priorTrialRunIds: readonly string[],
+): Result.Result<QualificationLock, StartupDecisionFailure> =>
+  Result.try({
+    try: () => strategy.prepareLock(inspection.manifest, inspection.sessionDates, priorTrialRunIds),
+    catch: (cause): StartupDecisionFailure => ({
+      _tag: 'StrategyOperationFailed',
+      operation: 'prepare-lock',
+      strategyName: strategy.name,
+      cause,
+    }),
+  })
+
+export const decideQualificationPath = (
+  expectedLock: QualificationLock,
+  opened: QualificationOpen,
+): Result.Result<QualificationPath, StartupDecisionFailure> => {
+  if (opened.state === 'OPENED_INCOMPLETE') {
+    return Result.fail({
+      _tag: 'QualificationStateInvalid',
+      details: { reason: 'opened-incomplete', lockId: opened.lock.lockId },
+    })
+  }
+  const lockBinding = validateCanonicalBinding(
+    [{ target: 'qualification-lock', side: 'expected' }, expectedLock],
+    [{ target: 'qualification-lock', side: 'observed' }, opened.lock],
+    {
+      _tag: 'BindingMismatch',
+      details: {
+        binding: 'qualification-lock',
+        expected: expectedLock,
+        observed: opened.lock,
+      },
+    },
+  )
+  if (Result.isFailure(lockBinding)) return Result.fail(lockBinding.failure)
+  if (opened.state === 'ACQUIRED') return Result.succeed({ _tag: 'EvaluateAcquired' })
+  if (opened.lock.candidateRunId !== opened.result.runId) {
+    return Result.fail({
+      _tag: 'BindingMismatch',
+      details: {
+        binding: 'terminal-run',
+        terminalRunId: opened.lock.candidateRunId,
+        qualificationRunId: opened.result.runId,
+      },
+    })
+  }
+  return Result.succeed({
+    _tag: 'RecoverTerminal',
+    runId: opened.lock.candidateRunId,
+    result: opened.result,
+  })
+}
+
+interface RecoveryExpectation {
+  readonly phase: 'pinned' | 'terminal'
+  readonly missingRunId: string
+  readonly expectedRunId: string
+  readonly expectedVerdict: QualificationResult['evaluationVerdict']
+}
+
+const validateRecoveredEvaluation = (
+  expectation: RecoveryExpectation,
+  recovered: Option.Option<RecoveredEvaluationEvidence>,
+): Result.Result<RecoveredEvaluationEvidence, StartupDecisionFailure> => {
+  if (Option.isNone(recovered)) {
+    return Result.fail({
+      _tag: 'QualificationStateInvalid',
+      details: {
+        reason: 'evidence-missing',
+        phase: expectation.phase === 'pinned' ? 'recover-pinned' : 'recover-terminal',
+        runId: expectation.missingRunId,
+      },
+    })
+  }
+  const evidence = recovered.value
+  const mismatch: StartupDecisionFailure = {
+    _tag: 'BindingMismatch',
+    details: {
+      binding: 'recovery',
+      phase: expectation.phase,
+      expectedRunId: expectation.expectedRunId,
+      recoveredRunIds: {
+        evaluation: evidence.evaluation.runId,
+        reconciliation: evidence.reconciliation.runId,
+        persistence: evidence.persistence.runId,
+      },
+      expectedVerdict: expectation.expectedVerdict,
+      recoveredVerdict: evidence.evaluation.verdict,
+    },
+  }
+  const runMatches =
+    evidence.evaluation.runId === expectation.expectedRunId &&
+    evidence.reconciliation.runId === expectation.expectedRunId &&
+    evidence.persistence.runId === expectation.expectedRunId
+  if (!runMatches) return Result.fail(mismatch)
+  const verdictBinding = validateCanonicalBinding(
+    [
+      {
+        target: expectation.phase === 'pinned' ? 'pinned-verdict' : 'terminal-verdict',
+        side: 'qualification',
+      },
+      expectation.expectedVerdict,
+    ],
+    [
+      {
+        target: expectation.phase === 'pinned' ? 'pinned-verdict' : 'terminal-verdict',
+        side: 'recovered',
+      },
+      evidence.evaluation.verdict,
+    ],
+    mismatch,
+  )
+  return Result.isFailure(verdictBinding) ? Result.fail(verdictBinding.failure) : Result.succeed(evidence)
+}
+
+export const decideTerminalRecovery = (
+  provenance: RuntimeProvenance,
+  path: Extract<QualificationPath, { readonly _tag: 'RecoverTerminal' }>,
+  recovered: Option.Option<RecoveredEvaluationEvidence>,
+): Result.Result<StartupCompletion, StartupDecisionFailure> => {
+  if (path.runId !== path.result.runId) {
+    return Result.fail({
+      _tag: 'BindingMismatch',
+      details: {
+        binding: 'terminal-run',
+        terminalRunId: path.runId,
+        qualificationRunId: path.result.runId,
+      },
+    })
+  }
+  const runId = path.runId
+  const recoveredResult = validateRecoveredEvaluation(
+    {
+      phase: 'terminal',
+      missingRunId: runId,
+      expectedRunId: runId,
+      expectedVerdict: path.result.evaluationVerdict,
+    },
+    recovered,
+  )
+  if (Result.isFailure(recoveredResult)) return Result.fail(recoveredResult.failure)
+  const evidence = recoveredResult.success
+  return Result.succeed({
+    _tag: 'TerminalRecovered',
+    evidence: {
+      startupMode: 'recovered',
+      provenance,
+      evaluation: evidence.evaluation,
+      reconciliation: evidence.reconciliation,
+      persistence: evidence.persistence,
+      qualification: path.result,
+    },
+  })
+}
+
+export const evaluateLockedSnapshot = (
+  strategy: Strategy,
+  inspection: MarketDataInspection,
+  lock: QualificationLock,
+  snapshot: MarketDataSnapshot,
+): Result.Result<EvaluationResult, StartupDecisionFailure> => {
+  const inspectedManifestHashResult = canonicalStartupHash(
+    { target: 'locked-manifest', side: 'inspection' },
+    inspection.manifest,
+  )
+  if (Result.isFailure(inspectedManifestHashResult)) return Result.fail(inspectedManifestHashResult.failure)
+  const loadedManifestHashResult = canonicalStartupHash(
+    { target: 'locked-manifest', side: 'loaded' },
+    snapshot.manifest,
+  )
+  if (Result.isFailure(loadedManifestHashResult)) return Result.fail(loadedManifestHashResult.failure)
+  if (loadedManifestHashResult.success !== inspectedManifestHashResult.success) {
+    return Result.fail({
+      _tag: 'BindingMismatch',
+      details: {
+        binding: 'locked-manifest',
+        inspectedManifestHash: inspectedManifestHashResult.success,
+        loadedManifestHash: loadedManifestHashResult.success,
+      },
+    })
+  }
+  const evaluationResult = Result.try({
+    try: () => strategy.evaluate(snapshot.bars, snapshot.manifest),
+    catch: (cause): StartupDecisionFailure => ({
+      _tag: 'StrategyOperationFailed',
+      operation: 'evaluate',
+      strategyName: strategy.name,
+      cause,
+    }),
+  })
+  if (Result.isFailure(evaluationResult)) return evaluationResult
+  if (evaluationResult.success.runId !== lock.candidateRunId) {
+    return Result.fail({
+      _tag: 'BindingMismatch',
+      details: {
+        binding: 'evaluation-run',
+        lockedRunId: lock.candidateRunId,
+        evaluationRunId: evaluationResult.success.runId,
+      },
+    })
+  }
+  return evaluationResult
+}
+
+export const qualifyEvaluation = (
+  strategy: Strategy,
+  lock: QualificationLock,
+  evaluation: EvaluationResult,
+  reconciliation: ReconciliationResult,
+): Result.Result<EvaluationEvidence, StartupDecisionFailure> => {
+  const analysisResult = Result.try({
+    try: () => strategy.analyze(evaluation, lock.priorTrialRunIds),
+    catch: (cause): StartupDecisionFailure => ({
+      _tag: 'StrategyOperationFailed',
+      operation: 'analyze',
+      strategyName: strategy.name,
+      cause,
+    }),
+  })
+  if (Result.isFailure(analysisResult)) return Result.fail(analysisResult.failure)
+  const qualificationResult = Result.try({
+    try: () => makeQualificationResult(lock, evaluation.verdict, analysisResult.success),
+    catch: (cause): StartupDecisionFailure => ({
+      _tag: 'StrategyOperationFailed',
+      operation: 'qualify',
+      strategyName: strategy.name,
+      cause,
+    }),
+  })
+  return Result.isFailure(qualificationResult)
+    ? Result.fail(qualificationResult.failure)
+    : Result.succeed({ evaluation, reconciliation, qualification: qualificationResult.success })
+}
+
+const evaluatedCompletion = (
+  strategy: Strategy,
+  evidence: EvaluationEvidence,
+  persistence: PersistenceReceipt,
+): StartupCompletion => ({
+  _tag: 'Evaluated',
+  evidence: {
+    startupMode: 'evaluated',
+    provenance: strategy.provenance,
+    evaluation: summarizeEvaluation(evidence.evaluation),
+    reconciliation: evidence.reconciliation,
+    persistence,
+    qualification: evidence.qualification,
+  },
+  markedEquityDifferenceMicros: evidence.evaluation.markedEquityReconciliation.differenceMicros,
+})
+
+const readPinnedQualification = (
+  config: RuntimeConfig,
+  runId: string,
+  evidenceStore: EvidenceStoreService,
+): Effect.Effect<PinnedQualificationFacts, OperationalError> =>
+  withinDeadline(
+    databaseOperation(
+      Effect.all({
+        stored: evidenceStore.read(runId),
+        qualification: evidenceStore.readQualification(runId),
+      }),
+      'read-pinned-qualification',
+    ),
+    config.operationTimeoutMs,
+    'database',
+    'read-pinned-qualification',
+  )
+
+const checkStartupDependencies = (workflow: EvaluationWorkflow): Effect.Effect<void, OperationalError> =>
+  withinDeadline(
+    workflow.dependencies.journal.check,
+    workflow.config.operationTimeoutMs,
+    'journal',
+    'connectivity-check',
+  ).pipe(
+    Effect.andThen(
+      withinDeadline(
+        databaseOperation(workflow.dependencies.evidenceStore.check, 'health-check'),
+        workflow.config.operationTimeoutMs,
+        'database',
+        'health-check',
+      ),
+    ),
+  )
+
+const inspectSignalSnapshot = (workflow: EvaluationWorkflow): Effect.Effect<MarketDataInspection, OperationalError> =>
+  withinDeadline(
+    workflow.dependencies.marketData.inspect,
+    workflow.config.operationTimeoutMs,
+    'market-data',
+    'inspect',
+  ).pipe(
+    Effect.tap((inspection) =>
+      Effect.logInfo('Bayn signal snapshot inspected').pipe(
+        Effect.annotateLogs({
+          service: 'bayn',
+          inputManifestHash: inspection.manifest.hash,
+          rowCount: inspection.manifest.rowCount,
+        }),
+      ),
+    ),
+  )
+
+const prepareQualification = (
+  workflow: EvaluationWorkflow,
+  inspection: MarketDataInspection,
+): Effect.Effect<CandidateQualification, OperationalError> =>
+  withinDeadline(
+    databaseOperation(workflow.dependencies.evidenceStore.listPriorTrials, 'list-prior-trials'),
+    workflow.config.operationTimeoutMs,
+    'database',
+    'list-prior-trials',
+  ).pipe(
+    Effect.flatMap((priorTrialRunIds) =>
+      fromStartupDecision(prepareQualificationLock(workflow.strategy, inspection, priorTrialRunIds)),
+    ),
+    Effect.map((lock) => ({ inspection, lock })),
+  )
+
+const openQualification = (
+  workflow: EvaluationWorkflow,
+  candidate: CandidateQualification,
+): Effect.Effect<QualificationPath, OperationalError> =>
+  withinDeadline(
+    databaseOperation(
+      workflow.dependencies.evidenceStore.openQualification({
+        lock: candidate.lock,
+        inputManifest: candidate.inspection.manifest,
+        parameters: workflow.strategy.parameters,
+        provenance: workflow.strategy.provenance,
+      }),
+      'open-qualification',
+    ),
+    workflow.config.operationTimeoutMs,
+    'database',
+    'open-qualification',
+  ).pipe(Effect.flatMap((opened) => fromStartupDecision(decideQualificationPath(candidate.lock, opened))))
+
+const recoverTerminalQualification = (
+  workflow: EvaluationWorkflow,
+  path: Extract<QualificationPath, { readonly _tag: 'RecoverTerminal' }>,
+): Effect.Effect<StartupCompletion, OperationalError> =>
+  withinDeadline(
+    databaseOperation(
+      workflow.dependencies.evidenceStore.recover(path.runId, workflow.strategy.provenance),
+      'recover-evaluation',
+    ),
+    workflow.config.operationTimeoutMs,
+    'database',
+    'recover-evaluation',
+  ).pipe(
+    Effect.flatMap((recovered) =>
+      fromStartupDecision(decideTerminalRecovery(workflow.strategy.provenance, path, recovered)),
+    ),
+  )
+
+const loadAndEvaluate = (
+  workflow: EvaluationWorkflow,
+  candidate: CandidateQualification,
+): Effect.Effect<EvaluationResult, OperationalError> =>
+  withinDeadline(workflow.dependencies.marketData.load, workflow.config.operationTimeoutMs, 'market-data', 'load').pipe(
+    Effect.flatMap((snapshot) =>
+      fromStartupDecision(evaluateLockedSnapshot(workflow.strategy, candidate.inspection, candidate.lock, snapshot)),
+    ),
+    Effect.tap((evaluation) =>
+      Effect.logInfo('Bayn strategy evaluation completed').pipe(
+        Effect.annotateLogs({
+          service: 'bayn',
+          runId: evaluation.runId,
+          strategy: workflow.strategy.name,
+          verdict: evaluation.verdict.status,
+          eventCount: evaluation.events.length,
+        }),
+      ),
+    ),
+  )
+
+const persistEvaluation = (
+  workflow: EvaluationWorkflow,
+  candidate: CandidateQualification,
+  evidence: EvaluationEvidence,
+): Effect.Effect<StartupCompletion, OperationalError> =>
+  withinDeadline(
+    databaseOperation(
+      workflow.dependencies.evidenceStore.persist({
+        provenance: workflow.strategy.provenance,
+        parameters: workflow.strategy.parameters,
+        evaluation: evidence.evaluation,
+        reconciliation: evidence.reconciliation,
+        qualification: { lock: candidate.lock, result: evidence.qualification },
+      }),
+      'persist-evaluation',
+    ),
+    workflow.config.operationTimeoutMs,
+    'database',
+    'persist-evaluation',
+  ).pipe(Effect.map((persistence) => evaluatedCompletion(workflow.strategy, evidence, persistence)))
+
+const evaluateAcquiredQualification = (
+  workflow: EvaluationWorkflow,
+  candidate: CandidateQualification,
+): Effect.Effect<StartupCompletion, OperationalError> =>
+  loadAndEvaluate(workflow, candidate).pipe(
+    Effect.flatMap((evaluation) =>
+      withinDeadline(
+        workflow.dependencies.journal.journalAndReconcile(evaluation),
+        workflow.config.operationTimeoutMs,
+        'journal',
+        'journal-and-reconcile',
+      ).pipe(
+        Effect.flatMap((reconciliation) =>
+          fromStartupDecision(qualifyEvaluation(workflow.strategy, candidate.lock, evaluation, reconciliation)),
+        ),
+      ),
+    ),
+    Effect.flatMap((evidence) => persistEvaluation(workflow, candidate, evidence)),
+  )
+
+const runQualificationPath = (
+  workflow: EvaluationWorkflow,
+  candidate: CandidateQualification,
+  path: QualificationPath,
+): Effect.Effect<StartupCompletion, OperationalError> =>
+  path._tag === 'RecoverTerminal'
+    ? recoverTerminalQualification(workflow, path)
+    : evaluateAcquiredQualification(workflow, candidate)
+
+const logStartupCompletion = (completion: StartupCompletion): Effect.Effect<void> => {
+  switch (completion._tag) {
+    case 'PinnedRecovered':
+      return Effect.logInfo('Bayn pinned qualification recovered').pipe(
+        Effect.annotateLogs({
+          service: 'bayn',
+          runId: completion.evidence.evaluation.runId,
+          qualification: completion.evidence.qualification.verdict,
+          executionSourceRevision: completion.evidence.provenance.sourceRevision,
+          executionImageDigest: completion.evidence.provenance.image.digest,
+        }),
+      )
+    case 'TerminalRecovered':
+      return Effect.logInfo('Bayn startup proof recovered').pipe(
+        Effect.annotateLogs({
+          service: 'bayn',
+          runId: completion.evidence.evaluation.runId,
+          qualification: completion.evidence.qualification.verdict,
+          artifactCount: completion.evidence.persistence.artifactCount,
+          eventCount: completion.evidence.persistence.eventCount,
+          gateCount: completion.evidence.persistence.gateCount,
+        }),
+      )
+    case 'Evaluated':
+      return Effect.logInfo('Bayn startup proof is durable').pipe(
+        Effect.annotateLogs({
+          service: 'bayn',
+          runId: completion.evidence.evaluation.runId,
+          accountCount: completion.evidence.reconciliation.accountCount,
+          transferCount: completion.evidence.reconciliation.transferCount,
+          persistenceDeduplicated: completion.evidence.persistence.deduplicated,
+          qualification: completion.evidence.qualification.verdict,
+          qualificationResultHash: completion.evidence.qualification.resultHash,
+          markedEquityDifferenceMicros: completion.markedEquityDifferenceMicros,
+        }),
+      )
+  }
+}
+
+const publishStartupCompletion = (state: Ref.Ref<RuntimeState>, completion: StartupCompletion): Effect.Effect<void> =>
+  Ref.update(state, (current) => completeStartupState(current, completion)).pipe(
+    Effect.andThen(logStartupCompletion(completion)),
+  )
 
 const recoverPinnedQualification = (
   config: RuntimeConfig,
   runId: string,
   state: Ref.Ref<RuntimeState>,
 ): Effect.Effect<void, OperationalError, EvidenceStore> =>
-  Effect.gen(function* () {
-    const evidenceStore = yield* EvidenceStore
-    yield* Effect.logInfo('Bayn pinned qualification recovery started').pipe(
-      Effect.annotateLogs({
-        service: 'bayn',
-        runId,
-        currentSourceRevision: config.build.sourceRevision,
-        currentImageDigest: config.build.imageDigest,
-      }),
-    )
-    const [storedOption, qualificationOption] = yield* withinDeadline(
-      databaseOperation(
-        Effect.all([evidenceStore.read(runId), evidenceStore.readQualification(runId)]),
-        'read-pinned-qualification',
+  EvidenceStore.pipe(
+    Effect.tap(() =>
+      Effect.logInfo('Bayn pinned qualification recovery started').pipe(
+        Effect.annotateLogs({
+          service: 'bayn',
+          runId,
+          currentSourceRevision: config.build.sourceRevision,
+          currentImageDigest: config.build.imageDigest,
+        }),
       ),
-      config.operationTimeoutMs,
-      'database',
-      'read-pinned-qualification',
-    )
-    if (Option.isNone(storedOption)) {
-      return yield* Effect.fail(
-        operationalError('database', 'read-pinned-qualification', `pinned evaluation ${runId} is missing`),
-      )
-    }
-    if (Option.isNone(qualificationOption) || qualificationOption.value.state !== 'TERMINAL') {
-      return yield* Effect.fail(
-        operationalError('database', 'read-pinned-qualification', `pinned qualification ${runId} is not terminal`),
-      )
-    }
-    const stored = storedOption.value
-    const qualification = qualificationOption.value
-    const executionProvenance = yield* Effect.try({
-      try: () => provenanceFromStored(stored),
-      catch: (cause) =>
-        operationalError(
-          'database',
-          'recover-pinned-qualification',
-          'stored qualification provenance is invalid',
-          cause,
+    ),
+    Effect.flatMap((evidenceStore) =>
+      readPinnedQualification(config, runId, evidenceStore).pipe(
+        Effect.flatMap((facts) => fromStartupDecision(decidePinnedQualification(config, runId, facts))),
+        Effect.flatMap((decision) =>
+          withinDeadline(
+            databaseOperation(
+              evidenceStore.recover(runId, decision.executionProvenance),
+              'recover-pinned-qualification',
+            ),
+            config.operationTimeoutMs,
+            'database',
+            'recover-pinned-qualification',
+          ).pipe(Effect.flatMap((recovered) => fromStartupDecision(decidePinnedRecovery(decision, recovered)))),
         ),
-    })
-    yield* Effect.try({
-      try: () => {
-        if (stored.run.runId !== runId || qualification.result.runId !== runId) {
-          throw new Error('stored evaluation and terminal qualification run IDs differ')
-        }
-        if (
-          qualification.lock.candidateRunId !== runId ||
-          qualification.lock.protocolHash !== stored.run.protocolHash ||
-          qualification.lock.sourceRevision !== executionProvenance.sourceRevision ||
-          canonicalHashV1(qualification.lock.image) !== canonicalHashV1(executionProvenance.image)
-        ) {
-          throw new Error('qualification lock differs from the stored execution provenance')
-        }
-        if (
-          qualification.lock.data.snapshotId !== config.clickhouse.snapshotId ||
-          qualification.lock.data.lastSession !== config.clickhouse.publicationAsOf ||
-          qualification.lock.data.calendarVersion !== config.clickhouse.calendarVersion ||
-          canonicalHashV1(qualification.lock.data.bounds) !== canonicalHashV1(config.clickhouse.bounds)
-        ) {
-          throw new Error('configured Signal snapshot differs from the pinned qualification')
-        }
-      },
-      catch: (cause) =>
-        operationalError('database', 'recover-pinned-qualification', 'pinned qualification binding failed', cause),
-    })
-    const recoveredOption = yield* withinDeadline(
-      databaseOperation(evidenceStore.recover(runId, executionProvenance), 'recover-pinned-qualification'),
-      config.operationTimeoutMs,
-      'database',
-      'recover-pinned-qualification',
-    )
-    if (Option.isNone(recoveredOption)) {
-      return yield* Effect.fail(
-        operationalError('database', 'recover-pinned-qualification', `pinned evaluation ${runId} is missing`),
-      )
-    }
-    const recovered = recoveredOption.value
-    yield* Effect.try({
-      try: () => {
-        if (
-          recovered.evaluation.runId !== runId ||
-          recovered.reconciliation.runId !== runId ||
-          recovered.persistence.runId !== runId ||
-          canonicalHashV1(recovered.evaluation.verdict) !== canonicalHashV1(qualification.result.evaluationVerdict)
-        ) {
-          throw new Error('recovered evidence differs from the terminal qualification')
-        }
-      },
-      catch: (cause) =>
-        operationalError('database', 'recover-pinned-qualification', 'pinned qualification recovery failed', cause),
-    })
-    yield* Ref.update(
-      state,
-      (current): RuntimeState => ({
-        ...current,
-        evidence: {
-          startupMode: 'pinned',
-          provenance: executionProvenance,
-          evaluation: recovered.evaluation,
-          reconciliation: recovered.reconciliation,
-          persistence: recovered.persistence,
-          qualification: qualification.result,
-        },
-        error: null,
-      }),
-    )
-    yield* Effect.logInfo('Bayn pinned qualification recovered').pipe(
-      Effect.annotateLogs({
-        service: 'bayn',
-        runId,
-        qualification: qualification.result.verdict,
-        executionSourceRevision: executionProvenance.sourceRevision,
-        executionImageDigest: executionProvenance.image.digest,
-      }),
-    )
-  }).pipe(Effect.withLogSpan('startup'))
+      ),
+    ),
+    Effect.flatMap((completion) => publishStartupCompletion(state, completion)),
+    Effect.withLogSpan('startup'),
+  )
+
+const runEvaluationWorkflow = (workflow: EvaluationWorkflow): Effect.Effect<StartupCompletion, OperationalError> =>
+  checkStartupDependencies(workflow).pipe(
+    Effect.andThen(inspectSignalSnapshot(workflow)),
+    Effect.flatMap((inspection) => prepareQualification(workflow, inspection)),
+    Effect.flatMap((candidate) =>
+      openQualification(workflow, candidate).pipe(
+        Effect.flatMap((path) => runQualificationPath(workflow, candidate, path)),
+      ),
+    ),
+  )
 
 const evaluateAndJournal = (
   config: RuntimeConfig,
   state: Ref.Ref<RuntimeState>,
   strategy: Strategy,
 ): Effect.Effect<void, OperationalError, MarketData | Journal | EvidenceStore> =>
-  Effect.gen(function* () {
-    const marketData = yield* MarketData
-    const journal = yield* Journal
-    const evidenceStore = yield* EvidenceStore
-    yield* Effect.logInfo('Bayn startup evaluation started').pipe(
-      Effect.annotateLogs({
-        service: 'bayn',
-        sourceRevision: config.build.sourceRevision,
-        imageDigest: config.build.imageDigest,
-        strategyBehaviorHash: strategy.provenance.strategy.behaviorHash,
-        parameterHash: strategy.provenance.strategy.parameterHash,
-        snapshotId: config.clickhouse.snapshotId,
-        evaluationStart: config.clickhouse.bounds.evaluationStart,
-        evaluationEnd: config.clickhouse.bounds.evaluationEnd,
+  Effect.all({
+    marketData: MarketData,
+    journal: Journal,
+    evidenceStore: EvidenceStore,
+  }).pipe(
+    Effect.map(
+      (dependencies): EvaluationWorkflow => ({
+        config,
+        strategy,
+        dependencies,
       }),
-    )
-    yield* withinDeadline(journal.check, config.operationTimeoutMs, 'journal', 'connectivity-check')
-    yield* withinDeadline(
-      databaseOperation(evidenceStore.check, 'health-check'),
-      config.operationTimeoutMs,
-      'database',
-      'health-check',
-    )
-    const inspection = yield* withinDeadline(marketData.inspect, config.operationTimeoutMs, 'market-data', 'inspect')
-    yield* Effect.logInfo('Bayn signal snapshot inspected').pipe(
-      Effect.annotateLogs({
-        service: 'bayn',
-        inputManifestHash: inspection.manifest.hash,
-        rowCount: inspection.manifest.rowCount,
-      }),
-    )
-    const priorTrialRunIds = yield* withinDeadline(
-      databaseOperation(evidenceStore.listPriorTrials, 'list-prior-trials'),
-      config.operationTimeoutMs,
-      'database',
-      'list-prior-trials',
-    )
-    const lock = yield* Effect.try({
-      try: () => strategy.prepareLock(inspection.manifest, inspection.sessionDates, priorTrialRunIds),
-      catch: (cause) => operationalError('strategy', 'prepare-lock', `${strategy.name} lock preparation failed`, cause),
-    })
-    const opened = yield* withinDeadline(
-      databaseOperation(
-        evidenceStore.openQualification({
-          lock,
-          inputManifest: inspection.manifest,
-          parameters: strategy.parameters,
-          provenance: strategy.provenance,
-        }),
-        'open-qualification',
-      ),
-      config.operationTimeoutMs,
-      'database',
-      'open-qualification',
-    )
-    if (opened.state === 'OPENED_INCOMPLETE') {
-      return yield* Effect.fail(
-        operationalError(
-          'database',
-          'open-qualification',
-          `qualification ${opened.lock.lockId} was opened without a terminal result`,
-        ),
-      )
-    }
-    if (opened.state === 'TERMINAL') {
-      const recovered = yield* withinDeadline(
-        databaseOperation(evidenceStore.recover(lock.candidateRunId, strategy.provenance), 'recover-evaluation'),
-        config.operationTimeoutMs,
-        'database',
-        'recover-evaluation',
-      )
-      if (Option.isNone(recovered)) {
-        return yield* Effect.fail(
-          operationalError(
-            'database',
-            'recover-evaluation',
-            `terminal qualification run ${lock.candidateRunId} is missing`,
-          ),
-        )
-      }
-      yield* Effect.try({
-        try: () => {
-          if (
-            opened.result.runId !== recovered.value.evaluation.runId ||
-            canonicalHashV1(opened.result.evaluationVerdict) !== canonicalHashV1(recovered.value.evaluation.verdict)
-          ) {
-            throw new Error('terminal qualification differs from the recovered evaluation')
-          }
-        },
-        catch: (cause) => operationalError('database', 'recover-qualification', 'qualification recovery failed', cause),
-      })
-      yield* Ref.update(
-        state,
-        (current): RuntimeState => ({
-          ...current,
-          evidence: {
-            startupMode: 'recovered',
-            provenance: strategy.provenance,
-            evaluation: recovered.value.evaluation,
-            reconciliation: recovered.value.reconciliation,
-            persistence: recovered.value.persistence,
-            qualification: opened.result,
-          },
-          error: null,
-        }),
-      )
-      yield* Effect.logInfo('Bayn startup proof recovered').pipe(
+    ),
+    Effect.tap(() =>
+      Effect.logInfo('Bayn startup evaluation started').pipe(
         Effect.annotateLogs({
           service: 'bayn',
-          runId: lock.candidateRunId,
-          qualification: opened.result.verdict,
-          artifactCount: recovered.value.persistence.artifactCount,
-          eventCount: recovered.value.persistence.eventCount,
-          gateCount: recovered.value.persistence.gateCount,
+          sourceRevision: config.build.sourceRevision,
+          imageDigest: config.build.imageDigest,
+          strategyBehaviorHash: strategy.provenance.strategy.behaviorHash,
+          parameterHash: strategy.provenance.strategy.parameterHash,
+          snapshotId: config.clickhouse.snapshotId,
+          evaluationStart: config.clickhouse.bounds.evaluationStart,
+          evaluationEnd: config.clickhouse.bounds.evaluationEnd,
         }),
-      )
-      return
-    }
-    const snapshot = yield* withinDeadline(marketData.load, config.operationTimeoutMs, 'market-data', 'load')
-    yield* Effect.try({
-      try: () => {
-        if (canonicalHashV1(snapshot.manifest) !== canonicalHashV1(inspection.manifest)) {
-          throw new Error('loaded Signal manifest differs from the locked inspection')
-        }
-      },
-      catch: (cause) => operationalError('market-data', 'load-locked', 'locked Signal load failed', cause),
-    })
-    const evaluation = yield* Effect.try({
-      try: () => strategy.evaluate(snapshot.bars, snapshot.manifest),
-      catch: (cause) => operationalError('strategy', 'evaluate', `${strategy.name} evaluation failed`, cause),
-    })
-    if (evaluation.runId !== lock.candidateRunId) {
-      return yield* Effect.fail(
-        operationalError('strategy', 'evaluate', 'evaluation run identity differs from the qualification lock'),
-      )
-    }
-    yield* Effect.logInfo('Bayn strategy evaluation completed').pipe(
-      Effect.annotateLogs({
-        service: 'bayn',
-        runId: evaluation.runId,
-        strategy: strategy.name,
-        verdict: evaluation.verdict.status,
-        eventCount: evaluation.events.length,
-      }),
-    )
-    const reconciliation = yield* withinDeadline(
-      journal.journalAndReconcile(evaluation),
-      config.operationTimeoutMs,
-      'journal',
-      'journal-and-reconcile',
-    )
-    const analysis = yield* Effect.try({
-      try: () => strategy.analyze(evaluation, lock.priorTrialRunIds),
-      catch: (cause) => operationalError('strategy', 'analyze', `${strategy.name} analysis failed`, cause),
-    })
-    const qualification = yield* Effect.try({
-      try: () => makeQualificationResult(lock, evaluation.verdict, analysis),
-      catch: (cause) => operationalError('strategy', 'qualify', `${strategy.name} qualification failed`, cause),
-    })
-    const persistence = yield* withinDeadline(
-      databaseOperation(
-        evidenceStore.persist({
-          provenance: strategy.provenance,
-          parameters: strategy.parameters,
-          evaluation,
-          reconciliation,
-          qualification: { lock, result: qualification },
-        }),
-        'persist-evaluation',
       ),
-      config.operationTimeoutMs,
-      'database',
-      'persist-evaluation',
-    )
-    yield* Ref.update(
-      state,
-      (current): RuntimeState => ({
-        ...current,
-        evidence: {
-          startupMode: 'evaluated',
-          provenance: strategy.provenance,
-          evaluation: summarizeEvaluation(evaluation),
-          reconciliation,
-          persistence,
-          qualification,
-        },
-        error: null,
-      }),
-    )
-    yield* Effect.logInfo('Bayn startup proof is durable').pipe(
-      Effect.annotateLogs({
-        service: 'bayn',
-        runId: evaluation.runId,
-        accountCount: reconciliation.accountCount,
-        transferCount: reconciliation.transferCount,
-        persistenceDeduplicated: persistence.deduplicated,
-        qualification: qualification.verdict,
-        qualificationResultHash: qualification.resultHash,
-        markedEquityDifferenceMicros: evaluation.markedEquityReconciliation.differenceMicros,
-      }),
-    )
-  }).pipe(Effect.withLogSpan('startup'))
+    ),
+    Effect.flatMap(runEvaluationWorkflow),
+    Effect.flatMap((completion) => publishStartupCompletion(state, completion)),
+    Effect.withLogSpan('startup'),
+  )
 
 export const initialize = (
   config: RuntimeConfig,


### PR DESCRIPTION
## Summary

- replace the monolithic Bayn startup qualification generators with total `Result` decisions and bounded named Effect phases
- preserve lock acquisition, incomplete-lock refusal, pinned/terminal recovery, evaluation, journaling, persistence, runtime-state, and log semantics
- bind requested, opened, terminal, recovered, and pinned qualification identities with fact-bearing fail-closed errors and direct branch regressions

## Related Issues

PROOMPT-415

## Testing

- `bun test services/bayn/src/startup.test.ts` — 32 passed, 130 assertions
- `bun run --filter @proompteng/bayn test` — 434 passed, 104 expected PostgreSQL integration skips, 0 failed
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bunx oxfmt --check services/bayn/src/startup.ts services/bayn/src/startup.test.ts`
- `bun run --filter @proompteng/bayn build`
- `git diff --check`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (screenshots not applicable; breaking changes are none).
- [x] Documentation, release notes, and follow-ups are updated or tracked (PROOMPT-415 tracks the refactor evidence and review).