### PR TITLE
refactor(bayn): make simulation reconciliation total

### DIFF
--- a/services/bayn/src/app-test-support.ts
+++ b/services/bayn/src/app-test-support.ts
@@ -1,6 +1,8 @@
+import assert from 'node:assert/strict'
+
 import { expect } from 'bun:test'
 
-import { Effect, Option, Redacted } from 'effect'
+import { Effect, Option, Redacted, Result } from 'effect'
 
 import type { RuntimeConfig } from './config'
 import { deriveCycleOperationsStatus } from './cycle-observability'
@@ -145,7 +147,9 @@ export const successfulEvidenceStore: EvidenceStoreService = {
 
 export const fixtureSnapshot = makeSnapshot()
 export const fixtureStrategy = makeStrategy(fixtureProtocol, provenance)
-export const fixtureEvaluation = fixtureStrategy.evaluate(fixtureSnapshot.bars, fixtureSnapshot.manifest)
+const fixtureEvaluationResult = fixtureStrategy.evaluate(fixtureSnapshot.bars, fixtureSnapshot.manifest)
+assert(Result.isSuccess(fixtureEvaluationResult), 'fixture strategy evaluation must succeed')
+export const fixtureEvaluation = fixtureEvaluationResult.success
 export const fixtureLock = fixtureStrategy.prepareLock(
   fixtureSnapshot.manifest,
   [...new Set(fixtureSnapshot.bars.map((bar) => bar.sessionDate))].sort(),
@@ -162,7 +166,9 @@ export const pinnedExecutionProvenance = {
   image: { repository: provenance.image.repository, digest: `sha256:${'f'.repeat(64)}` },
 }
 export const pinnedStrategy = makeStrategy(fixtureProtocol, pinnedExecutionProvenance)
-export const pinnedEvaluation = pinnedStrategy.evaluate(fixtureSnapshot.bars, fixtureSnapshot.manifest)
+const pinnedEvaluationResult = pinnedStrategy.evaluate(fixtureSnapshot.bars, fixtureSnapshot.manifest)
+assert(Result.isSuccess(pinnedEvaluationResult), 'pinned strategy evaluation must succeed')
+export const pinnedEvaluation = pinnedEvaluationResult.success
 export const pinnedLock = pinnedStrategy.prepareLock(
   fixtureSnapshot.manifest,
   [...new Set(fixtureSnapshot.bars.map((bar) => bar.sessionDate))].sort(),

--- a/services/bayn/src/audit/audit.ts
+++ b/services/bayn/src/audit/audit.ts
@@ -1,11 +1,15 @@
-import { Schema } from 'effect'
+import { Result, Schema } from 'effect'
 
 import { makeRuntimeProvenance } from '../contracts'
 import { ReconciliationResultSchema } from '../evidence-contracts'
 import { canonicalHashV1 } from '../hash'
 import type { QualificationLock, QualificationResult } from '../qualification'
 import { strictParseOptions as StrictParseOptions } from '../schemas'
-import { reconcileMarkedEquity } from '../simulation-reconciliation'
+import {
+  reconcileMarkedEquity,
+  renderSimulationReconciliationIssues,
+  type MarkedEquityProof,
+} from '../simulation-reconciliation'
 import {
   ContractVersion,
   type DailyBar,
@@ -201,7 +205,7 @@ const makeSummary = (
   input: QualificationAuditInput,
   reference: ReferenceEvaluation,
   trace: SimulationTrace,
-  markedEquity: ReturnType<typeof reconcileMarkedEquity>['reconciliation'],
+  markedEquity: MarkedEquityProof['reconciliation'],
 ) => {
   return {
     schemaVersion: contract.summarySchemaVersion,
@@ -238,19 +242,64 @@ const makeSummary = (
   }
 }
 
-export const auditQualification = (input: QualificationAuditInput): QualificationAuditReport => {
-  const checks: AuditCheck[] = []
-  const check = (name: string, passed: boolean, evidence: string): void => {
-    checks.push({ name, passed, evidence })
-  }
+const MICROS_STRING = '1000000'
+
+const makeAuditCheck = (name: string, passed: boolean, evidence: string): AuditCheck => ({ name, passed, evidence })
+
+const makePolicyDocuments = (lock: QualificationLock) =>
+  (
+    [
+      ['benchmark', lock.policies.benchmark],
+      ['execution', lock.policies.execution],
+      ['thresholds', lock.policies.thresholds],
+      ['uncertainty', lock.policies.uncertainty],
+    ] as const
+  ).map(([name, policy]) => ({ name, ...policy }))
+
+type MarkedEquityAuditMaterial =
+  | { readonly _tag: 'Available'; readonly proof: MarkedEquityProof }
+  | { readonly _tag: 'Unavailable'; readonly evidence: string }
+
+interface QualificationAuditFacts {
+  readonly input: QualificationAuditInput
+  readonly database: AuditDatabaseSnapshot
+  readonly artifact: ReadonlyMap<string, StoredArtifact>
+  readonly lock: QualificationLock
+  readonly result: QualificationResult
+  readonly reference: ReferenceEvaluation
+  readonly trace: SimulationTrace
+  readonly provenance: ReturnType<typeof makeRuntimeProvenance>
+  readonly policyDocuments: ReturnType<typeof makePolicyDocuments>
+  readonly sortedReplicas: readonly string[]
+  readonly replicaSet: ReadonlySet<string>
+  readonly sortedAccess: readonly SignalAccessRecord[]
+  readonly publisherSet: ReadonlySet<string>
+  readonly markedEquity: MarkedEquityAuditMaterial
+}
+
+const makeMarkedEquityAuditMaterial = (
+  input: QualificationAuditInput,
+  reference: ReferenceEvaluation,
+  trace: SimulationTrace,
+): MarkedEquityAuditMaterial => {
+  const result = reconcileMarkedEquity({
+    runId: reference.runId,
+    initialCapitalMicros: input.protocol.initialCapitalMicros,
+    evaluatorTotalFeesMicros: reference.strategy.metrics.totalFeesMicros,
+    evaluatorEndingEquityMicros: reference.strategy.metrics.endingEquityMicros,
+    events: reference.strategy.events,
+    simulation: trace,
+  })
+  return Result.isSuccess(result)
+    ? { _tag: 'Available', proof: result.success }
+    : {
+        _tag: 'Unavailable',
+        evidence: `reconciliation unavailable: ${renderSimulationReconciliationIssues(result.failure)}`,
+      }
+}
+
+const makeAuditFacts = (input: QualificationAuditInput): QualificationAuditFacts => {
   const database = input.database
-  const artifact = new Map(database.artifacts.map((value) => [value.name, value]))
-  const lock = database.qualification.lock
-  const { lockId, ...lockMaterial } = lock
-  const result = database.qualification.result
-  const { resultHash, ...resultMaterial } = result
-  const analysis = result.analysis
-  const { analysisHash, ...analysisMaterial } = analysis
   if (database.protocol.strategyName !== contract.name || database.run.strategyName !== contract.name) {
     throw new Error('stored qualification uses an unsupported strategy contract')
   }
@@ -273,49 +322,34 @@ export const auditQualification = (input: QualificationAuditInput): Qualificatio
     },
   })
   const reference = evaluateReference(input.bars, input.manifest, input.protocol, provenance)
-  if (reference.strategy.trace === null) throw new Error('reference evaluation omitted its candidate trace')
-  const markedEquity = reconcileMarkedEquity({
-    runId: reference.runId,
-    initialCapitalMicros: input.protocol.initialCapitalMicros,
-    evaluatorTotalFeesMicros: reference.strategy.metrics.totalFeesMicros,
-    evaluatorEndingEquityMicros: reference.strategy.metrics.endingEquityMicros,
-    events: reference.strategy.events,
-    simulation: reference.strategy.trace,
+  const trace = reference.strategy.trace
+  if (trace === null) throw new Error('reference evaluation omitted its candidate trace')
+  const sortedReplicas = [...input.signalReplicas].sort()
+  const sortedAccess = [...input.signalAccess].sort((left, right) => {
+    if (left.queryStartTime !== right.queryStartTime) return left.queryStartTime < right.queryStartTime ? -1 : 1
+    if (left.replica !== right.replica) return left.replica < right.replica ? -1 : 1
+    return left.queryId < right.queryId ? -1 : left.queryId > right.queryId ? 1 : 0
   })
+  return {
+    input,
+    database,
+    artifact: new Map(database.artifacts.map((value) => [value.name, value])),
+    lock: database.qualification.lock,
+    result: database.qualification.result,
+    reference,
+    trace,
+    provenance,
+    policyDocuments: makePolicyDocuments(database.qualification.lock),
+    sortedReplicas,
+    replicaSet: new Set(sortedReplicas),
+    sortedAccess,
+    publisherSet: new Set(input.signalPrincipals.publishers),
+    markedEquity: makeMarkedEquityAuditMaterial(input, reference, trace),
+  }
+}
 
-  check('postgres-transaction-read-only', database.transactionReadOnly, 'transaction_read_only=on')
-  check(
-    'protocol-content',
-    same(input.protocol, database.protocol.parameters) &&
-      canonicalHashV1(input.protocol) === database.protocol.parameterHash &&
-      reference.protocolHash === database.protocol.protocolHash,
-    `parameterHash=${database.protocol.parameterHash}`,
-  )
-  check(
-    'run-identity',
-    reference.runId === database.run.runId &&
-      reference.protocolHash === database.run.protocolHash &&
-      input.manifest.finalizedSnapshot.snapshotId === database.run.snapshotId &&
-      database.protocol.strategyName === contract.name &&
-      database.run.strategyName === contract.name &&
-      database.run.evaluationSchemaVersion === contract.evaluationSchemaVersion &&
-      provenance.contractVersions.evaluation === contract.evaluationSchemaVersion &&
-      database.run.initialCapitalMicros === input.protocol.initialCapitalMicros &&
-      database.run.status === 'COMPLETE',
-    `runId=${database.run.runId}`,
-  )
-  check(
-    'evidence-counts',
-    database.artifacts.length === database.run.artifactCount &&
-      database.events.length === database.run.eventCount &&
-      database.gates.length === database.run.gateCount,
-    `${database.artifacts.length}/${database.events.length}/${database.gates.length}`,
-  )
-  check(
-    'artifact-hashes',
-    database.artifacts.every((value) => canonicalHashV1(value.payload) === value.contentHash),
-    `${database.artifacts.length} artifacts`,
-  )
+const auditStoredEvidence = (facts: QualificationAuditFacts): readonly AuditCheck[] => {
+  const { database, input, provenance, reference } = facts
   const expectedArtifactSchemas = new Map<string, string>([
     ['evaluation-summary', contract.summarySchemaVersion],
     ['input-manifest', input.manifest.schemaVersion],
@@ -331,53 +365,109 @@ export const auditQualification = (input: QualificationAuditInput): Qualificatio
     ['direct-volatility-timing-series', 'bayn.daily-performance-series.v1'],
     ['double-cost-strategy-series', 'bayn.daily-performance-series.v1'],
     ['equity-series', 'bayn.equity-series.v1'],
-    ['marked-equity-reconciliation', markedEquity.reconciliation.schemaVersion],
+    ['marked-equity-reconciliation', 'bayn.marked-equity-reconciliation.v2'],
     ['reconciliation', 'bayn.reconciliation.v1'],
     ['qualification-artifact-manifest', 'bayn.qualification-artifact-manifest.v1'],
   ])
-  check(
-    'artifact-schema-versions',
-    database.artifacts.length === expectedArtifactSchemas.size &&
-      database.artifacts.every((value) => expectedArtifactSchemas.get(value.name) === value.schemaVersion),
-    `${database.artifacts.length} versioned artifacts`,
-  )
-  check(
-    'event-hashes-and-order',
-    database.events.every(
-      (value, index) =>
-        value.ordinal === index &&
-        value.id === value.payload.id &&
-        value.kind === value.payload.kind &&
-        canonicalHashV1(value.payload) === value.contentHash,
+  return [
+    makeAuditCheck('postgres-transaction-read-only', database.transactionReadOnly, 'transaction_read_only=on'),
+    makeAuditCheck(
+      'protocol-content',
+      same(input.protocol, database.protocol.parameters) &&
+        canonicalHashV1(input.protocol) === database.protocol.parameterHash &&
+        reference.protocolHash === database.protocol.protocolHash,
+      `parameterHash=${database.protocol.parameterHash}`,
     ),
-    `${database.events.length} events`,
-  )
-  check(
-    'gate-hashes-and-order',
-    database.gates.every(
-      (value, index) =>
-        value.ordinal === index &&
-        canonicalHashV1({ name: value.name, passed: value.passed, actual: value.actual, required: value.required }) ===
-          value.contentHash,
+    makeAuditCheck(
+      'run-identity',
+      reference.runId === database.run.runId &&
+        reference.protocolHash === database.run.protocolHash &&
+        input.manifest.finalizedSnapshot.snapshotId === database.run.snapshotId &&
+        database.protocol.strategyName === contract.name &&
+        database.run.strategyName === contract.name &&
+        database.run.evaluationSchemaVersion === contract.evaluationSchemaVersion &&
+        provenance.contractVersions.evaluation === contract.evaluationSchemaVersion &&
+        database.run.initialCapitalMicros === input.protocol.initialCapitalMicros &&
+        database.run.status === 'COMPLETE',
+      `runId=${database.run.runId}`,
     ),
-    `${database.gates.length} gates`,
-  )
-  check(
-    'status-history',
-    database.statuses.length === 2 &&
-      database.statuses[0].status === 'WRITING' &&
-      database.statuses[1].status === 'COMPLETE' &&
-      same(database.statuses[0].detail, {
-        artifactCount: database.run.artifactCount,
-        eventCount: database.run.eventCount,
-        gateCount: database.run.gateCount,
-      }) &&
-      same(database.statuses[1].detail, { reconciliationExact: true, verdict: reference.verdict.status }),
-    database.statuses.map((status) => status.status).join(' -> '),
-  )
+    makeAuditCheck(
+      'evidence-counts',
+      database.artifacts.length === database.run.artifactCount &&
+        database.events.length === database.run.eventCount &&
+        database.gates.length === database.run.gateCount,
+      `${database.artifacts.length}/${database.events.length}/${database.gates.length}`,
+    ),
+    makeAuditCheck(
+      'artifact-hashes',
+      database.artifacts.every((value) => canonicalHashV1(value.payload) === value.contentHash),
+      `${database.artifacts.length} artifacts`,
+    ),
+    makeAuditCheck(
+      'artifact-schema-versions',
+      database.artifacts.length === expectedArtifactSchemas.size &&
+        database.artifacts.every((value) => expectedArtifactSchemas.get(value.name) === value.schemaVersion),
+      `${database.artifacts.length} versioned artifacts`,
+    ),
+    makeAuditCheck(
+      'event-hashes-and-order',
+      database.events.every(
+        (value, index) =>
+          value.ordinal === index &&
+          value.id === value.payload.id &&
+          value.kind === value.payload.kind &&
+          canonicalHashV1(value.payload) === value.contentHash,
+      ),
+      `${database.events.length} events`,
+    ),
+    makeAuditCheck(
+      'gate-hashes-and-order',
+      database.gates.every(
+        (value, index) =>
+          value.ordinal === index &&
+          canonicalHashV1({
+            name: value.name,
+            passed: value.passed,
+            actual: value.actual,
+            required: value.required,
+          }) === value.contentHash,
+      ),
+      `${database.gates.length} gates`,
+    ),
+    makeAuditCheck(
+      'status-history',
+      database.statuses.length === 2 &&
+        database.statuses[0].status === 'WRITING' &&
+        database.statuses[1].status === 'COMPLETE' &&
+        same(database.statuses[0].detail, {
+          artifactCount: database.run.artifactCount,
+          eventCount: database.run.eventCount,
+          gateCount: database.run.gateCount,
+        }) &&
+        same(database.statuses[1].detail, { reconciliationExact: true, verdict: reference.verdict.status }),
+      database.statuses.map((status) => status.status).join(' -> '),
+    ),
+  ]
+}
 
+const auditReferenceArtifacts = (facts: QualificationAuditFacts): readonly AuditCheck[] => {
+  const { artifact, database, input, markedEquity, reference, trace } = facts
+  const checks: AuditCheck[] = []
+  const checkArtifact = (name: string, expected: unknown): void => {
+    checks.push(
+      makeAuditCheck(
+        `reference-${name}`,
+        same(artifact.get(name)?.payload, expected),
+        `contentHash=${canonicalHashV1(expected)}`,
+      ),
+    )
+  }
+  if (markedEquity._tag === 'Unavailable') {
+    checks.push(makeAuditCheck('reference-evaluation-summary', false, markedEquity.evidence))
+  } else {
+    checkArtifact('evaluation-summary', makeSummary(input, reference, trace, markedEquity.proof.reconciliation))
+  }
   const expectedArtifacts = new Map<string, unknown>([
-    ['evaluation-summary', makeSummary(input, reference, reference.strategy.trace, markedEquity.reconciliation)],
     ['input-manifest', input.manifest],
     ['strategy', reference.strategy.metrics],
     ['buy-and-hold', reference.buyAndHold.metrics],
@@ -389,14 +479,11 @@ export const auditQualification = (input: QualificationAuditInput): Qualificatio
         schemaVersion: 'bayn.simulated-orders.v2',
         executionModel: input.protocol.executionModel,
         costMultiplierMicros: MICROS_STRING,
-        items: reference.strategy.trace.orders,
+        items: trace.orders,
       },
     ],
-    ['cash-changes', { schemaVersion: 'bayn.cash-changes.v2', items: reference.strategy.trace.cashChanges }],
-    [
-      'daily-position-marks',
-      { schemaVersion: 'bayn.daily-position-marks.v3', items: reference.strategy.trace.dailyMarks },
-    ],
+    ['cash-changes', { schemaVersion: 'bayn.cash-changes.v2', items: trace.cashChanges }],
+    ['daily-position-marks', { schemaVersion: 'bayn.daily-position-marks.v3', items: trace.dailyMarks }],
     [
       contract.decisionArtifactName,
       { schemaVersion: contract.decisionArtifactSchemaVersion, items: reference.strategy.decisions },
@@ -425,35 +512,55 @@ export const auditQualification = (input: QualificationAuditInput): Qualificatio
         items: reference.doubleCostStrategy.daily,
       },
     ],
-    ['equity-series', { schemaVersion: 'bayn.equity-series.v1', items: markedEquity.equitySeries }],
-    ['marked-equity-reconciliation', markedEquity.reconciliation],
   ])
-  for (const [name, expected] of expectedArtifacts) {
-    check(`reference-${name}`, same(artifact.get(name)?.payload, expected), `contentHash=${canonicalHashV1(expected)}`)
+  for (const [name, expected] of expectedArtifacts) checkArtifact(name, expected)
+  if (markedEquity._tag === 'Unavailable') {
+    checks.push(
+      makeAuditCheck('reference-equity-series', false, markedEquity.evidence),
+      makeAuditCheck('reference-marked-equity-reconciliation', false, markedEquity.evidence),
+    )
+  } else {
+    checkArtifact('equity-series', {
+      schemaVersion: 'bayn.equity-series.v1',
+      items: markedEquity.proof.equitySeries,
+    })
+    checkArtifact('marked-equity-reconciliation', markedEquity.proof.reconciliation)
   }
-  check(
-    'reference-events',
-    same(
-      database.events.map((value) => value.payload),
-      reference.strategy.events,
+  checks.push(
+    makeAuditCheck(
+      'reference-events',
+      same(
+        database.events.map((value) => value.payload),
+        reference.strategy.events,
+      ),
+      `contentHash=${canonicalHashV1(reference.strategy.events)}`,
     ),
-    `contentHash=${canonicalHashV1(reference.strategy.events)}`,
-  )
-  check(
-    'reference-gates',
-    same(
-      database.gates.map(({ name, passed, actual, required }) => ({ name, passed, actual, required })),
-      reference.verdict.gates,
+    makeAuditCheck(
+      'reference-gates',
+      same(
+        database.gates.map(({ name, passed, actual, required }) => ({ name, passed, actual, required })),
+        reference.verdict.gates,
+      ),
+      `economicStatus=${reference.verdict.status}`,
     ),
-    `economicStatus=${reference.verdict.status}`,
   )
+  return checks
+}
 
+const auditArtifactManifest = (facts: QualificationAuditFacts): readonly AuditCheck[] => {
+  const { artifact, database, input, markedEquity, reference, trace } = facts
   const reconciliation = decodeReconciliation(artifact.get('reconciliation')?.payload)
-  check(
-    'accounting-reconciliation-identity',
-    reconciliation.runId === database.run.runId && reconciliation.exact === true,
-    `runId=${reconciliation.runId} exact=${reconciliation.exact}`,
-  )
+  const checks = [
+    makeAuditCheck(
+      'accounting-reconciliation-identity',
+      reconciliation.runId === database.run.runId && reconciliation.exact === true,
+      `runId=${reconciliation.runId} exact=${reconciliation.exact}`,
+    ),
+  ]
+  if (markedEquity._tag === 'Unavailable') {
+    checks.push(makeAuditCheck('qualification-artifact-manifest', false, markedEquity.evidence))
+    return checks
+  }
   const artifactItemCounts = new Map<string, number>([
     ['evaluation-summary', 0],
     ['input-manifest', 0],
@@ -461,14 +568,14 @@ export const auditQualification = (input: QualificationAuditInput): Qualificatio
     ['buy-and-hold', 0],
     ['direct-volatility-timing', 0],
     ['double-cost-strategy', 0],
-    ['simulated-orders', reference.strategy.trace.orders.length],
-    ['cash-changes', reference.strategy.trace.cashChanges.length],
-    ['daily-position-marks', reference.strategy.trace.dailyMarks.length],
+    ['simulated-orders', trace.orders.length],
+    ['cash-changes', trace.cashChanges.length],
+    ['daily-position-marks', trace.dailyMarks.length],
     [contract.decisionArtifactName, reference.strategy.decisions.length],
     ['buy-and-hold-series', reference.buyAndHold.daily.length],
     ['direct-volatility-timing-series', reference.directVolTiming.daily.length],
     ['double-cost-strategy-series', reference.doubleCostStrategy.daily.length],
-    ['equity-series', markedEquity.equitySeries.length],
+    ['equity-series', markedEquity.proof.equitySeries.length],
     ['marked-equity-reconciliation', 0],
     ['reconciliation', 0],
   ])
@@ -520,104 +627,102 @@ export const auditQualification = (input: QualificationAuditInput): Qualificatio
       ),
     },
   }
-  check(
-    'qualification-artifact-manifest',
-    same(artifact.get('qualification-artifact-manifest')?.payload, qualificationManifest),
-    `contentHash=${canonicalHashV1(qualificationManifest)}`,
+  checks.push(
+    makeAuditCheck(
+      'qualification-artifact-manifest',
+      same(artifact.get('qualification-artifact-manifest')?.payload, qualificationManifest),
+      `contentHash=${canonicalHashV1(qualificationManifest)}`,
+    ),
   )
+  return checks
+}
 
-  check('lock-hash', canonicalHashV1(lockMaterial) === lockId, `lockId=${lockId}`)
-  check(
-    'qualification-row-binding',
-    database.qualification.storedLockId === lockId &&
-      database.qualification.storedAnalysisHash === result.analysis.analysisHash &&
-      database.qualification.storedResultHash === resultHash &&
-      database.qualification.storedVerdict === result.verdict,
-    `storedResultHash=${database.qualification.storedResultHash}`,
-  )
+const auditQualificationBindings = (facts: QualificationAuditFacts): readonly AuditCheck[] => {
+  const { database, input, lock, policyDocuments, reference, result } = facts
+  const { lockId, ...lockMaterial } = lock
+  const { resultHash, ...resultMaterial } = result
+  const analysis = result.analysis
+  const { analysisHash, ...analysisMaterial } = analysis
   const lockData = lock.data
   const lockContractBinding =
     lock.schemaVersion === 'bayn.qualification-lock.v3' &&
     lock.universeId === input.protocol.universeId &&
     lock.universeSymbolHash === input.protocol.universeSymbolHash &&
     lockData.inputManifestHash === input.manifest.hash
-  const policyDocuments = (
-    [
-      ['benchmark', lock.policies.benchmark],
-      ['execution', lock.policies.execution],
-      ['thresholds', lock.policies.thresholds],
-      ['uncertainty', lock.policies.uncertainty],
-    ] as const
-  ).map(([name, policy]) => ({ name, ...policy }))
-  check(
-    'lock-candidate-binding',
-    lock.candidateRunId === database.run.runId &&
-      lock.protocolHash === database.run.protocolHash &&
-      lock.sourceRevision === database.run.sourceRevision &&
-      same(lock.image, { repository: database.run.imageRepository, digest: database.run.imageDigest }) &&
-      lockContractBinding &&
-      same(lock.universe, input.protocol.universe),
-    `candidateRunId=${String(lock.candidateRunId)}`,
-  )
-  check(
-    'lock-data-binding',
-    lockData.snapshotId === input.manifest.finalizedSnapshot.snapshotId &&
-      lockData.publicationId === input.manifest.finalizedSnapshot.publicationId &&
-      lockData.contentHash === input.manifest.finalizedSnapshot.contentHash &&
-      lockData.sessionsContentHash === input.manifest.finalizedSnapshot.sessionsContentHash &&
-      lockData.selectedSessionCount === reference.strategy.metrics.observations &&
-      lockData.selectedRebalanceCount === reference.strategy.decisions.length &&
-      same(lockData.bounds, input.manifest.bounds),
-    `snapshotId=${String(lockData.snapshotId)}`,
-  )
-  check(
-    'lock-policy-hashes',
-    same(
-      policyDocuments.map((policy) => policy.name),
-      ['benchmark', 'execution', 'thresholds', 'uncertainty'],
-    ) && policyDocuments.every((policy) => policy.contentHash === canonicalHashV1(policy.content)),
-    `${policyDocuments.length} policies policySetHash=${canonicalHashV1(policyDocuments)}`,
-  )
-  check(
-    'locked-prior-trial-lineage',
-    same(lock.priorTrialRunIds, [...database.priorTrialRunIds].sort()),
-    `${database.priorTrialRunIds.length} prior trials`,
-  )
-
-  check('analysis-hash', canonicalHashV1(analysisMaterial) === analysisHash, `analysisHash=${analysisHash}`)
-  check('result-hash', canonicalHashV1(resultMaterial) === resultHash, `resultHash=${resultHash}`)
   const economicPass = reference.verdict.gates.every((gate) => gate.passed)
   const analysisPass = analysis.status === 'PASS'
   const expectedQualification = economicPass && analysisPass ? 'QUALIFIED' : 'REJECTED'
   const expectedEconomicReasons = reference.verdict.gates
     .filter((gate) => !gate.passed)
     .map((gate) => expectedResultReason(gate.name))
-  const reasonCodes = result.reasonCodes
-  const analysisReasonCodes = analysis.reasonCodes
-  const expectedReasonCodes = [...new Set([...expectedEconomicReasons, ...analysisReasonCodes])].sort()
-  check(
-    'analysis-lineage',
-    analysis.runId === database.run.runId &&
-      same(analysis.priorTrialRunIds, lock.priorTrialRunIds) &&
-      analysis.candidateOrdinal === database.priorTrialRunIds.length + 1,
-    `candidateOrdinal=${String(analysis.candidateOrdinal)}`,
-  )
-  check(
-    'terminal-result-binding',
-    result.lockId === lockId &&
-      result.runId === database.run.runId &&
-      result.verdict === expectedQualification &&
-      same(result.evaluationVerdict, reference.verdict) &&
-      same(reasonCodes, expectedReasonCodes),
-    `verdict=${String(result.verdict)} reasons=${reasonCodes.join(',')}`,
-  )
+  const expectedReasonCodes = [...new Set([...expectedEconomicReasons, ...analysis.reasonCodes])].sort()
+  return [
+    makeAuditCheck('lock-hash', canonicalHashV1(lockMaterial) === lockId, `lockId=${lockId}`),
+    makeAuditCheck(
+      'qualification-row-binding',
+      database.qualification.storedLockId === lockId &&
+        database.qualification.storedAnalysisHash === analysis.analysisHash &&
+        database.qualification.storedResultHash === resultHash &&
+        database.qualification.storedVerdict === result.verdict,
+      `storedResultHash=${database.qualification.storedResultHash}`,
+    ),
+    makeAuditCheck(
+      'lock-candidate-binding',
+      lock.candidateRunId === database.run.runId &&
+        lock.protocolHash === database.run.protocolHash &&
+        lock.sourceRevision === database.run.sourceRevision &&
+        same(lock.image, { repository: database.run.imageRepository, digest: database.run.imageDigest }) &&
+        lockContractBinding &&
+        same(lock.universe, input.protocol.universe),
+      `candidateRunId=${String(lock.candidateRunId)}`,
+    ),
+    makeAuditCheck(
+      'lock-data-binding',
+      lockData.snapshotId === input.manifest.finalizedSnapshot.snapshotId &&
+        lockData.publicationId === input.manifest.finalizedSnapshot.publicationId &&
+        lockData.contentHash === input.manifest.finalizedSnapshot.contentHash &&
+        lockData.sessionsContentHash === input.manifest.finalizedSnapshot.sessionsContentHash &&
+        lockData.selectedSessionCount === reference.strategy.metrics.observations &&
+        lockData.selectedRebalanceCount === reference.strategy.decisions.length &&
+        same(lockData.bounds, input.manifest.bounds),
+      `snapshotId=${String(lockData.snapshotId)}`,
+    ),
+    makeAuditCheck(
+      'lock-policy-hashes',
+      same(
+        policyDocuments.map((policy) => policy.name),
+        ['benchmark', 'execution', 'thresholds', 'uncertainty'],
+      ) && policyDocuments.every((policy) => policy.contentHash === canonicalHashV1(policy.content)),
+      `${policyDocuments.length} policies policySetHash=${canonicalHashV1(policyDocuments)}`,
+    ),
+    makeAuditCheck(
+      'locked-prior-trial-lineage',
+      same(lock.priorTrialRunIds, [...database.priorTrialRunIds].sort()),
+      `${database.priorTrialRunIds.length} prior trials`,
+    ),
+    makeAuditCheck('analysis-hash', canonicalHashV1(analysisMaterial) === analysisHash, `analysisHash=${analysisHash}`),
+    makeAuditCheck('result-hash', canonicalHashV1(resultMaterial) === resultHash, `resultHash=${resultHash}`),
+    makeAuditCheck(
+      'analysis-lineage',
+      analysis.runId === database.run.runId &&
+        same(analysis.priorTrialRunIds, lock.priorTrialRunIds) &&
+        analysis.candidateOrdinal === database.priorTrialRunIds.length + 1,
+      `candidateOrdinal=${String(analysis.candidateOrdinal)}`,
+    ),
+    makeAuditCheck(
+      'terminal-result-binding',
+      result.lockId === lockId &&
+        result.runId === database.run.runId &&
+        result.verdict === expectedQualification &&
+        same(result.evaluationVerdict, reference.verdict) &&
+        same(result.reasonCodes, expectedReasonCodes),
+      `verdict=${String(result.verdict)} reasons=${result.reasonCodes.join(',')}`,
+    ),
+  ]
+}
 
-  const sortedReplicas = [...input.signalReplicas].sort()
-  const sortedAccess = [...input.signalAccess].sort((left, right) => {
-    if (left.queryStartTime !== right.queryStartTime) return left.queryStartTime < right.queryStartTime ? -1 : 1
-    if (left.replica !== right.replica) return left.replica < right.replica ? -1 : 1
-    return left.queryId < right.queryId ? -1 : left.queryId > right.queryId ? 1 : 0
-  })
+const auditSignalAndRepository = (facts: QualificationAuditFacts): readonly AuditCheck[] => {
+  const { database, input, publisherSet, replicaSet, sortedAccess, sortedReplicas } = facts
   const candidateAccess = sortedAccess.filter((value) => value.user === input.signalPrincipals.candidate)
   const candidateBarReads = candidateAccess.filter((value) => value.kind === 'bars')
   const candidateSessionReads = candidateAccess.filter((value) => value.kind === 'sessions')
@@ -641,59 +746,61 @@ export const auditQualification = (input: QualificationAuditInput): Qualificatio
       value.queryStartTime >= database.qualification.lockCreatedAt &&
       value.queryStartTime <= database.qualification.resultCommittedAt,
   )
-  check(
-    'signal-query-log-replica-coverage',
-    sortedReplicas.length >= 2 &&
-      new Set(sortedReplicas).size === sortedReplicas.length &&
-      sortedAccess.every((value) => sortedReplicas.includes(value.replica)),
-    `${sortedReplicas.length} replicas=${sortedReplicas.join(',')}`,
-  )
-  check(
-    'signal-lock-before-candidate-bars',
-    preLockBarReads.length === 0 &&
-      candidateBarReads.length === 1 &&
-      candidateBarReads.every(
-        (value) =>
-          value.queryStartTime >= database.qualification.lockCreatedAt &&
-          value.queryStartTime <= database.qualification.resultCommittedAt,
-      ),
-    `lock=${database.qualification.lockCreatedAt} barReads=${candidateBarReads
-      .map((value) => `${value.replica}@${value.queryStartTime}`)
-      .join(',')}`,
-  )
-  check(
-    'signal-calendar-inspected-before-lock',
-    preLockSessionReads.length >= 1 && lockedSessionReads.length >= 1,
-    `preLock=${preLockSessionReads.length} locked=${lockedSessionReads.length}`,
-  )
-  check(
-    'signal-manifest-inspected-before-lock',
-    preLockManifestReads.length >= 1 && lockedManifestReads.length >= 1,
-    `preLock=${preLockManifestReads.length} locked=${lockedManifestReads.length}`,
-  )
-  check(
-    'signal-read-principals',
-    input.signalPrincipals.candidate.length > 0 &&
-      input.signalPrincipals.publishers.length > 0 &&
-      new Set([input.signalPrincipals.candidate, ...input.signalPrincipals.publishers]).size ===
-        input.signalPrincipals.publishers.length + 1 &&
-      sortedAccess.every(
-        (value) =>
-          value.user === input.signalPrincipals.candidate || input.signalPrincipals.publishers.includes(value.user),
-      ),
-    [...new Set(sortedAccess.map((value) => value.user))].join(','),
-  )
-  check(
-    'source-revision-in-repository',
-    input.repository.sourceCommitExists && input.repository.sourceCommitAncestorOfMain,
-    `sourceRevision=${database.run.sourceRevision}`,
-  )
-  check(
-    'no-pre-lock-result-reference',
-    input.repository.preLockResultReferences.length === 0,
-    input.repository.preLockResultReferences.join(',') || 'none',
-  )
+  return [
+    makeAuditCheck(
+      'signal-query-log-replica-coverage',
+      sortedReplicas.length >= 2 &&
+        replicaSet.size === sortedReplicas.length &&
+        sortedAccess.every((value) => replicaSet.has(value.replica)),
+      `${sortedReplicas.length} replicas=${sortedReplicas.join(',')}`,
+    ),
+    makeAuditCheck(
+      'signal-lock-before-candidate-bars',
+      preLockBarReads.length === 0 &&
+        candidateBarReads.length === 1 &&
+        candidateBarReads.every(
+          (value) =>
+            value.queryStartTime >= database.qualification.lockCreatedAt &&
+            value.queryStartTime <= database.qualification.resultCommittedAt,
+        ),
+      `lock=${database.qualification.lockCreatedAt} barReads=${candidateBarReads
+        .map((value) => `${value.replica}@${value.queryStartTime}`)
+        .join(',')}`,
+    ),
+    makeAuditCheck(
+      'signal-calendar-inspected-before-lock',
+      preLockSessionReads.length >= 1 && lockedSessionReads.length >= 1,
+      `preLock=${preLockSessionReads.length} locked=${lockedSessionReads.length}`,
+    ),
+    makeAuditCheck(
+      'signal-manifest-inspected-before-lock',
+      preLockManifestReads.length >= 1 && lockedManifestReads.length >= 1,
+      `preLock=${preLockManifestReads.length} locked=${lockedManifestReads.length}`,
+    ),
+    makeAuditCheck(
+      'signal-read-principals',
+      input.signalPrincipals.candidate.length > 0 &&
+        publisherSet.size === input.signalPrincipals.publishers.length &&
+        input.signalPrincipals.publishers.length > 0 &&
+        !publisherSet.has(input.signalPrincipals.candidate) &&
+        sortedAccess.every((value) => value.user === input.signalPrincipals.candidate || publisherSet.has(value.user)),
+      [...new Set(sortedAccess.map((value) => value.user))].join(','),
+    ),
+    makeAuditCheck(
+      'source-revision-in-repository',
+      input.repository.sourceCommitExists && input.repository.sourceCommitAncestorOfMain,
+      `sourceRevision=${database.run.sourceRevision}`,
+    ),
+    makeAuditCheck(
+      'no-pre-lock-result-reference',
+      input.repository.preLockResultReferences.length === 0,
+      input.repository.preLockResultReferences.join(',') || 'none',
+    ),
+  ]
+}
 
+const makeAuditReport = (facts: QualificationAuditFacts, checks: readonly AuditCheck[]): QualificationAuditReport => {
+  const { database, input, lock, policyDocuments, reference, result, sortedAccess, sortedReplicas } = facts
   const material = {
     schemaVersion: 'bayn.qualification-audit.v2' as const,
     runId: database.run.runId,
@@ -707,12 +814,12 @@ export const auditQualification = (input: QualificationAuditInput): Qualificatio
       artifactCount: database.artifacts.length,
       eventCount: database.events.length,
       gateCount: database.gates.length,
-      lockId,
-      resultHash,
+      lockId: lock.lockId,
+      resultHash: result.resultHash,
     },
     policies: {
       declaredAt: database.qualification.lockCreatedAt,
-      lockId,
+      lockId: lock.lockId,
       policySetHash: canonicalHashV1(policyDocuments),
       documents: policyDocuments,
     },
@@ -729,4 +836,14 @@ export const auditQualification = (input: QualificationAuditInput): Qualificatio
   return { ...material, auditHash: canonicalHashV1(material) }
 }
 
-const MICROS_STRING = '1000000'
+export const auditQualification = (input: QualificationAuditInput): QualificationAuditReport => {
+  const facts = makeAuditFacts(input)
+  const checks = [
+    ...auditStoredEvidence(facts),
+    ...auditReferenceArtifacts(facts),
+    ...auditArtifactManifest(facts),
+    ...auditQualificationBindings(facts),
+    ...auditSignalAndRepository(facts),
+  ]
+  return makeAuditReport(facts, checks)
+}

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -1,8 +1,10 @@
+import assert from 'node:assert/strict'
+
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test'
 
 import { NodeServices } from '@effect/platform-node'
 import { PgClient } from '@effect/sql-pg'
-import { Cause, Deferred, Duration, Effect, Exit, Fiber, Layer, ManagedRuntime, Option, Redacted } from 'effect'
+import { Cause, Deferred, Duration, Effect, Exit, Fiber, Layer, ManagedRuntime, Option, Redacted, Result } from 'effect'
 
 import authorityBoundIntents from '../../migrations/0016_authority_bound_intents'
 import stablePaperAuthorityGeneration from '../../migrations/0017_stable_paper_authority_generation'
@@ -41,7 +43,7 @@ import {
   defaultQualificationStatisticsPolicy,
   type QualificationSeries,
 } from '../qualification-statistics'
-import { evaluateRiskBalancedTrend } from '../risk-balanced-trend'
+import { evaluateRiskBalancedTrend, summarizeEvaluation } from '../risk-balanced-trend'
 import { makeStrategy } from '../strategy'
 import { makeSnapshot, makeTestProvenance, fixtureProtocol } from '../test-fixtures'
 import type { CausalProtocol, Protocol } from '../types'
@@ -349,12 +351,14 @@ const makeInput = (
   protocol: Protocol = fixtureProtocol,
 ): PersistEvaluationInput => {
   const provenance = makeTestProvenance(protocol, { sourceRevision, behaviorHash })
-  const evaluation = evaluateRiskBalancedTrend(
+  const evaluationResult = evaluateRiskBalancedTrend(
     riskBalancedTrendSnapshot.bars,
     riskBalancedTrendSnapshot.manifest,
     protocol,
     provenance,
   )
+  assert(Result.isSuccess(evaluationResult), 'strategy evaluation fixture must succeed')
+  const evaluation = evaluationResult.success
   const ledger = buildLedgerPlan(evaluation, 7_001)
   return {
     provenance,
@@ -3965,6 +3969,70 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     expect(result.recovered.value.evaluation.markedEquityReconciliation.exact).toBe(true)
   })
 
+  test('preserves structured reconciliation issues at the persistence failure boundary', async () => {
+    const input = makeInput()
+    const firstChange = input.evaluation.simulation.cashChanges[0]
+    const evaluation = {
+      ...input.evaluation,
+      simulation: {
+        ...input.evaluation.simulation,
+        cashChanges: input.evaluation.simulation.cashChanges.map((change, index) =>
+          index === 0 ? { ...change, amountMicros: (BigInt(change.amountMicros) + 1n).toString() } : change,
+        ),
+      },
+    }
+    const failure = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* EvidenceStore
+        return yield* store.persist({ ...input, evaluation }).pipe(Effect.flip)
+      }),
+    )
+
+    expect(failure).toBeInstanceOf(DatabaseError)
+    expect(failure).toMatchObject({
+      failure: 'invariant',
+      operation: 'plan',
+      cause: [
+        {
+          _tag: 'EvidenceMismatch',
+          problem: {
+            _tag: 'CashChange',
+            cashChangeId: firstChange.id,
+            sourceId: firstChange.sourceId,
+            field: 'amountMicros',
+            actual: (BigInt(firstChange.amountMicros) + 1n).toString(),
+            expected: firstChange.amountMicros,
+          },
+        },
+      ],
+    })
+  })
+
+  test('returns persistence-plan canonicalization failures through the typed channel without writes', async () => {
+    const input = makeInput()
+    const failure = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* EvidenceStore
+        const error = yield* store
+          .persist({
+            ...input,
+            parameters: { ...input.parameters, initialCapitalMicros: '\ud800' },
+          })
+          .pipe(Effect.flip)
+        return { error, stored: yield* store.read(input.evaluation.runId) }
+      }),
+    )
+
+    expect(failure.error).toBeInstanceOf(DatabaseError)
+    expect(failure.error).toMatchObject({
+      failure: 'invariant',
+      operation: 'plan',
+    })
+    expect(failure.error.message).toContain('persistence plan computation failed during construct-persistence-evidence')
+    expect(failure.error.cause).toBeInstanceOf(TypeError)
+    expect(Option.isNone(failure.stored)).toBe(true)
+  })
+
   test('burns observed runs and preserves qualification state as append-only', async () => {
     const input = makeInput()
     const result = await runtime.runPromise(
@@ -4123,6 +4191,19 @@ describePostgres('PostgreSQL evaluation evidence', () => {
         'simulated-orders',
         'strategy',
       ])
+      expect(
+        result.stored.value.artifacts.every((artifact) => canonicalHashV1(artifact.payload) === artifact.contentHash),
+      ).toBe(true)
+      expect(result.stored.value.events.map((event) => event.payload)).toEqual([...input.evaluation.events])
+      expect(
+        result.stored.value.gates.map(({ ordinal, name, passed, actual, required }) => ({
+          ordinal,
+          name,
+          passed,
+          actual,
+          required,
+        })),
+      ).toEqual(input.evaluation.verdict.gates.map((gate, ordinal) => ({ ordinal, ...gate })))
       const manifest = result.stored.value.artifacts.find(
         (artifact) => artifact.name === 'qualification-artifact-manifest',
       )
@@ -4143,6 +4224,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     }
     expect(Option.isSome(result.recovered)).toBe(true)
     if (Option.isSome(result.recovered)) {
+      expect(result.recovered.value.evaluation).toEqual(summarizeEvaluation(input.evaluation))
       expect(result.recovered.value).toMatchObject({
         evaluation: {
           runId: input.evaluation.runId,
@@ -4254,8 +4336,10 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     })
   })
 
-  test('rejects a simulation whose declared costs diverge from its locked protocol', async () => {
+  test('rejects a locked execution-model mismatch before reconciling other tampered simulation evidence', async () => {
     const input = makeInput()
+    const firstCashChange = input.evaluation.simulation.cashChanges[0]
+    assert(firstCashChange !== undefined, 'evaluation fixture must contain a cash change')
     const error = await runtime.runPromise(
       Effect.gen(function* () {
         const store = yield* EvidenceStore
@@ -4266,6 +4350,14 @@ describePostgres('PostgreSQL evaluation evidence', () => {
               ...input.evaluation,
               simulation: {
                 ...input.evaluation.simulation,
+                cashChanges: input.evaluation.simulation.cashChanges.map((change, index) =>
+                  index === 0
+                    ? {
+                        ...change,
+                        amountMicros: (BigInt(firstCashChange.amountMicros) + 1n).toString(),
+                      }
+                    : change,
+                ),
                 executionModel: {
                   ...input.evaluation.simulation.executionModel,
                   priceImpact: {

--- a/services/bayn/src/db/evidence-store.ts
+++ b/services/bayn/src/db/evidence-store.ts
@@ -1,5 +1,5 @@
 import { PgClient, PgMigrator } from '@effect/sql-pg'
-import { Context, Data, Effect, FileSystem, Layer, Match, Option, Schema } from 'effect'
+import { Context, Data, Effect, FileSystem, Layer, Match, Option, Result, Schema } from 'effect'
 import { SqlSchema } from 'effect/unstable/sql'
 import { isSqlError, type SqlErrorReason } from 'effect/unstable/sql/SqlError'
 
@@ -35,7 +35,11 @@ import {
 } from '../qualification'
 import { ProtocolSchema } from '../protocol'
 import { summarizeEvaluation } from '../risk-balanced-trend'
-import { reconcileMarkedEquity } from '../simulation-reconciliation'
+import {
+  reconcileMarkedEquity,
+  renderSimulationReconciliationIssues,
+  type SimulationReconciliationIssue,
+} from '../simulation-reconciliation'
 import type {
   EconomicVerdict,
   EvaluationEvent,
@@ -383,6 +387,71 @@ const makeArtifact = (name: string, schemaVersion: string, payload: unknown, ite
   itemCount,
 })
 
+type PersistencePlan = Omit<PersistEvaluationInput, 'qualification'> & {
+  readonly qualification: PersistEvaluationInput['qualification']
+  readonly strategyName: string
+  readonly protocolHash: string
+  readonly snapshotId: string
+  readonly artifacts: readonly ReturnType<typeof makeArtifact>[]
+  readonly events: readonly ({
+    readonly ordinal: number
+    readonly contentHash: string
+    readonly payload: EvaluationEvent
+  } & Pick<EvaluationEvent, 'id' | 'kind'>)[]
+  readonly gates: readonly ({
+    readonly ordinal: number
+    readonly contentHash: string
+  } & EvaluationResult['verdict']['gates'][number])[]
+}
+
+const persistencePlanInvariantMessages = {
+  'evaluation-schema-version': 'evaluation schema version does not match runtime provenance',
+  'input-manifest-schema-version': 'input manifest schema version does not match the evidence contract',
+  'parameter-hash': 'strategy parameters and provenance disagree on parameter hash',
+  'execution-model': 'simulation execution model does not match strategy parameters',
+  'cost-multiplier': 'candidate simulation must use the base execution-cost multiplier',
+  'protocol-hash': 'evaluation and provenance disagree on protocol hash',
+  'source-revision': 'evaluation code revision does not match runtime provenance',
+  'accounting-reconciliation': 'reconciliation does not exactly match the evaluation run',
+  'input-manifest-hash': 'input manifest hash does not match its content',
+  'run-identity': 'run ID does not match runtime and input provenance',
+  'marked-equity-proof': 'independent marked-equity proof diverges from the evaluation evidence',
+  'signal-decisions': 'strategy signal decisions diverge from durable decision events',
+  'daily-series': 'candidate and benchmark daily series are not exactly aligned',
+  'events-empty': 'evaluation produced no durable events',
+  'gates-empty': 'evaluation produced no economic gate outcomes',
+  'qualification-evidence': 'qualification evidence is malformed or diverges from its candidate runtime',
+  'qualification-result': 'qualification result diverges from the locked evaluation',
+} as const
+
+type PersistencePlanInvariant = keyof typeof persistencePlanInvariantMessages
+
+type PersistencePlanFailure =
+  | {
+      readonly _tag: 'InvalidPersistencePlan'
+      readonly invariant: PersistencePlanInvariant
+      readonly cause?: unknown
+    }
+  | {
+      readonly _tag: 'SimulationReconciliationFailed'
+      readonly issues: readonly SimulationReconciliationIssue[]
+    }
+  | {
+      readonly _tag: 'PersistencePlanComputationFailed'
+      readonly operation: 'construct-persistence-evidence'
+      readonly cause: unknown
+    }
+
+const invalidPersistencePlan = (
+  invariant: PersistencePlanInvariant,
+  cause?: unknown,
+): Result.Result<never, PersistencePlanFailure> =>
+  Result.fail({
+    _tag: 'InvalidPersistencePlan',
+    invariant,
+    ...(cause === undefined ? {} : { cause }),
+  })
+
 const validateQualificationOpenInput = (input: OpenQualificationInput) => {
   const lock = decodeQualificationLock(input.lock)
   const { inputManifest, parameters, provenance } = input
@@ -442,39 +511,51 @@ const validateQualificationOpenInput = (input: OpenQualificationInput) => {
   return { ...input, lock }
 }
 
-const makePersistencePlan = (input: PersistEvaluationInput) => {
+interface ValidatedPersistenceEvaluation {
+  readonly protocolHash: string
+  readonly snapshotId: string
+}
+
+interface PersistenceEvidenceMaterial {
+  readonly baseArtifacts: readonly ReturnType<typeof makeArtifact>[]
+  readonly events: PersistencePlan['events']
+  readonly gates: PersistencePlan['gates']
+}
+
+const validatePersistenceEvaluation = (
+  input: PersistEvaluationInput,
+): Result.Result<ValidatedPersistenceEvaluation, PersistencePlanFailure> => {
   const { evaluation, parameters, provenance, reconciliation } = input
   if (evaluation.schemaVersion !== provenance.contractVersions.evaluation) {
-    throw new TypeError('evaluation schema version does not match runtime provenance')
+    return invalidPersistencePlan('evaluation-schema-version')
   }
   if (
     evaluation.inputManifest.schemaVersion !== evidenceContract.inputManifestSchemaVersion ||
     provenance.contractVersions.inputManifest !== evidenceContract.inputManifestSchemaVersion
   ) {
-    throw new TypeError('input manifest schema version does not match the evidence contract')
+    return invalidPersistencePlan('input-manifest-schema-version')
   }
   const parameterHash = canonicalHashV1(parameters)
   if (parameterHash !== provenance.strategy.parameterHash) {
-    throw new TypeError('strategy parameters and provenance disagree on parameter hash')
+    return invalidPersistencePlan('parameter-hash')
   }
   if (canonicalHashV1(evaluation.simulation.executionModel) !== canonicalHashV1(parameters.executionModel)) {
-    throw new TypeError('simulation execution model does not match strategy parameters')
+    return invalidPersistencePlan('execution-model')
   }
   if (evaluation.simulation.costMultiplierMicros !== '1000000') {
-    throw new TypeError('candidate simulation must use the base execution-cost multiplier')
+    return invalidPersistencePlan('cost-multiplier')
   }
   const protocolHash = makeStrategyProtocolHash(provenance.strategy)
-  if (protocolHash !== evaluation.protocolHash)
-    throw new TypeError('evaluation and provenance disagree on protocol hash')
+  if (protocolHash !== evaluation.protocolHash) return invalidPersistencePlan('protocol-hash')
   if (evaluation.codeRevision !== provenance.sourceRevision) {
-    throw new TypeError('evaluation code revision does not match runtime provenance')
+    return invalidPersistencePlan('source-revision')
   }
   if (reconciliation.runId !== evaluation.runId || reconciliation.exact !== true) {
-    throw new TypeError('reconciliation does not exactly match the evaluation run')
+    return invalidPersistencePlan('accounting-reconciliation')
   }
   const { hash: inputManifestHash, ...manifestMaterial } = evaluation.inputManifest
   if (canonicalHashV1(manifestMaterial) !== inputManifestHash) {
-    throw new TypeError('input manifest hash does not match its content')
+    return invalidPersistencePlan('input-manifest-hash')
   }
   const snapshotId = evaluation.inputManifest.finalizedSnapshot.snapshotId
   const expectedRunId = makeRunIdentity({
@@ -490,9 +571,9 @@ const makePersistencePlan = (input: PersistEvaluationInput) => {
     calendarVersion: evaluation.inputManifest.finalizedSnapshot.calendarVersion,
     bounds: evaluation.inputManifest.bounds,
   }).runId
-  if (evaluation.runId !== expectedRunId) throw new TypeError('run ID does not match runtime and input provenance')
+  if (evaluation.runId !== expectedRunId) return invalidPersistencePlan('run-identity')
 
-  const equityProof = reconcileMarkedEquity({
+  const equityProofResult = reconcileMarkedEquity({
     runId: evaluation.runId,
     initialCapitalMicros: evaluation.initialCapitalMicros,
     evaluatorTotalFeesMicros: evaluation.strategy.totalFeesMicros,
@@ -500,11 +581,15 @@ const makePersistencePlan = (input: PersistEvaluationInput) => {
     events: evaluation.events,
     simulation: evaluation.simulation,
   })
+  if (Result.isFailure(equityProofResult)) {
+    return Result.fail({ _tag: 'SimulationReconciliationFailed', issues: equityProofResult.failure })
+  }
+  const equityProof = equityProofResult.success
   if (
     canonicalHashV1(equityProof.reconciliation) !== canonicalHashV1(evaluation.markedEquityReconciliation) ||
     canonicalHashV1(equityProof.equitySeries) !== canonicalHashV1(evaluation.equitySeries)
   ) {
-    throw new TypeError('independent marked-equity proof diverges from the evaluation evidence')
+    return invalidPersistencePlan('marked-equity-proof')
   }
 
   const decisionEvents = evaluation.events.filter((event) => event.kind === 'decision')
@@ -518,7 +603,7 @@ const makePersistencePlan = (input: PersistEvaluationInput) => {
         canonicalHashV1(decision.targetWeights) !== canonicalHashV1(decisionEvents[index]?.targetWeights),
     )
   ) {
-    throw new TypeError('strategy signal decisions diverge from durable decision events')
+    return invalidPersistencePlan('signal-decisions')
   }
   const candidateDates = evaluation.simulation.dailyMarks.map((point) => point.sessionDate)
   const benchmarkSeries = Object.values(evaluation.benchmarkSeries)
@@ -530,9 +615,16 @@ const makePersistencePlan = (input: PersistEvaluationInput) => {
         series.some((point, index) => point.sessionDate !== candidateDates[index]),
     )
   ) {
-    throw new TypeError('candidate and benchmark daily series are not exactly aligned')
+    return invalidPersistencePlan('daily-series')
   }
 
+  return Result.succeed({ protocolHash, snapshotId })
+}
+
+const makePersistenceEvidence = (
+  input: PersistEvaluationInput,
+): Result.Result<PersistenceEvidenceMaterial, PersistencePlanFailure> => {
+  const { evaluation, reconciliation } = input
   const baseArtifacts = [
     makeArtifact('evaluation-summary', evidenceContract.summarySchemaVersion, summarizeEvaluation(evaluation)),
     makeArtifact('input-manifest', evaluation.inputManifest.schemaVersion, evaluation.inputManifest),
@@ -627,42 +719,65 @@ const makePersistencePlan = (input: PersistEvaluationInput) => {
     required: gate.required,
     contentHash: canonicalHashV1(gate),
   }))
-  if (events.length === 0) throw new TypeError('evaluation produced no durable events')
-  if (gates.length === 0) throw new TypeError('evaluation produced no economic gate outcomes')
+  if (events.length === 0) return invalidPersistencePlan('events-empty')
+  if (gates.length === 0) return invalidPersistencePlan('gates-empty')
+  return Result.succeed({ baseArtifacts, events, gates })
+}
 
-  let qualification = input.qualification
-  if (qualification !== undefined) {
-    const lock = validateQualificationOpenInput({
-      lock: qualification.lock,
-      inputManifest: evaluation.inputManifest,
-      parameters,
-      provenance,
-    }).lock
-    const result = decodeQualificationResult(qualification.result)
-    if (
-      lock.candidateRunId !== evaluation.runId ||
-      lock.data.selectedSessionCount !== evaluation.strategy.observations ||
-      lock.data.selectedSessionCount !== evaluation.simulation.dailyMarks.length ||
-      lock.data.selectedRebalanceCount !== evaluation.signalDecisions.length ||
-      result.lockId !== lock.lockId ||
-      result.runId !== evaluation.runId ||
-      canonicalHashV1(result.evaluationVerdict) !== canonicalHashV1(evaluation.verdict) ||
-      canonicalHashV1(result.analysis.priorTrialRunIds) !== canonicalHashV1(lock.priorTrialRunIds)
-    ) {
-      throw new TypeError('qualification result diverges from the locked evaluation')
-    }
-    qualification = { lock, result }
+const validatePersistenceQualification = (
+  input: PersistEvaluationInput,
+): Result.Result<PersistEvaluationInput['qualification'], PersistencePlanFailure> => {
+  const suppliedQualification = input.qualification
+  if (suppliedQualification === undefined) return Result.succeed(undefined)
+  const { evaluation, parameters, provenance } = input
+  const decodedQualification = Result.try({
+    try: () => ({
+      lock: validateQualificationOpenInput({
+        lock: suppliedQualification.lock,
+        inputManifest: evaluation.inputManifest,
+        parameters,
+        provenance,
+      }).lock,
+      result: decodeQualificationResult(suppliedQualification.result),
+    }),
+    catch: (cause): PersistencePlanFailure => ({
+      _tag: 'InvalidPersistencePlan',
+      invariant: 'qualification-evidence',
+      cause,
+    }),
+  })
+  if (Result.isFailure(decodedQualification)) return Result.fail(decodedQualification.failure)
+  const { lock, result } = decodedQualification.success
+  if (
+    lock.candidateRunId !== evaluation.runId ||
+    lock.data.selectedSessionCount !== evaluation.strategy.observations ||
+    lock.data.selectedSessionCount !== evaluation.simulation.dailyMarks.length ||
+    lock.data.selectedRebalanceCount !== evaluation.signalDecisions.length ||
+    result.lockId !== lock.lockId ||
+    result.runId !== evaluation.runId ||
+    canonicalHashV1(result.evaluationVerdict) !== canonicalHashV1(evaluation.verdict) ||
+    canonicalHashV1(result.analysis.priorTrialRunIds) !== canonicalHashV1(lock.priorTrialRunIds)
+  ) {
+    return invalidPersistencePlan('qualification-result')
   }
+  return Result.succeed({ lock, result })
+}
 
-  const artifactManifest = {
+const makePersistenceArtifactManifest = (
+  input: PersistEvaluationInput,
+  validated: ValidatedPersistenceEvaluation,
+  evidence: PersistenceEvidenceMaterial,
+) => {
+  const { evaluation, provenance } = input
+  return {
     schemaVersion: 'bayn.qualification-artifact-manifest.v1',
     identity: {
       runId: evaluation.runId,
       evaluationSchemaVersion: evaluation.schemaVersion,
-      protocolHash,
+      protocolHash: validated.protocolHash,
       sourceRevision: provenance.sourceRevision,
       image: provenance.image,
-      snapshotId,
+      snapshotId: validated.snapshotId,
       publicationId: evaluation.inputManifest.finalizedSnapshot.publicationId,
       inputManifestHash: evaluation.inputManifest.hash,
       bounds: evaluation.inputManifest.bounds,
@@ -675,7 +790,7 @@ const makePersistencePlan = (input: PersistEvaluationInput) => {
       executionModel: evaluation.simulation.executionModel,
       costMultiplierMicros: evaluation.simulation.costMultiplierMicros,
     },
-    artifacts: [...baseArtifacts]
+    artifacts: [...evidence.baseArtifacts]
       .sort((left, right) => (left.name < right.name ? -1 : left.name > right.name ? 1 : 0))
       .map((artifact) => ({
         name: artifact.name,
@@ -684,36 +799,90 @@ const makePersistencePlan = (input: PersistEvaluationInput) => {
         contentHash: artifact.contentHash,
       })),
     events: {
-      count: events.length,
+      count: evidence.events.length,
       contentHash: canonicalHashV1(
-        events.map(({ ordinal, id, kind, contentHash }) => ({ ordinal, id, kind, contentHash })),
+        evidence.events.map(({ ordinal, id, kind, contentHash }) => ({ ordinal, id, kind, contentHash })),
       ),
     },
     gates: {
-      count: gates.length,
+      count: evidence.gates.length,
       contentHash: canonicalHashV1(
-        gates.map(({ ordinal, name, passed, contentHash }) => ({ ordinal, name, passed, contentHash })),
+        evidence.gates.map(({ ordinal, name, passed, contentHash }) => ({ ordinal, name, passed, contentHash })),
       ),
     },
   }
+}
+
+const buildPersistencePlan = (
+  input: PersistEvaluationInput,
+): Result.Result<PersistencePlan, PersistencePlanFailure> => {
+  const validated = validatePersistenceEvaluation(input)
+  if (Result.isFailure(validated)) return Result.fail(validated.failure)
+  const evidence = makePersistenceEvidence(input)
+  if (Result.isFailure(evidence)) return Result.fail(evidence.failure)
+  const qualification = validatePersistenceQualification(input)
+  if (Result.isFailure(qualification)) return Result.fail(qualification.failure)
+  const artifactManifest = makePersistenceArtifactManifest(input, validated.success, evidence.success)
   const artifacts = [
-    ...baseArtifacts,
+    ...evidence.success.baseArtifacts,
     makeArtifact('qualification-artifact-manifest', artifactManifest.schemaVersion, artifactManifest),
   ]
 
-  return {
+  return Result.succeed({
     ...input,
-    qualification,
-    strategyName: provenance.strategy.name,
-    protocolHash,
-    snapshotId,
+    qualification: qualification.success,
+    strategyName: input.provenance.strategy.name,
+    protocolHash: validated.success.protocolHash,
+    snapshotId: validated.success.snapshotId,
     artifacts,
-    events,
-    gates,
-  }
+    events: evidence.success.events,
+    gates: evidence.success.gates,
+  })
 }
 
-type PersistencePlan = ReturnType<typeof makePersistencePlan>
+const makePersistencePlan = (input: PersistEvaluationInput): Result.Result<PersistencePlan, PersistencePlanFailure> => {
+  const attempted = Result.try({
+    try: () => buildPersistencePlan(input),
+    catch: (cause): PersistencePlanFailure => ({
+      _tag: 'PersistencePlanComputationFailed',
+      operation: 'construct-persistence-evidence',
+      cause,
+    }),
+  })
+  return Result.isFailure(attempted) ? Result.fail(attempted.failure) : attempted.success
+}
+
+const reconciliationDatabaseError = (
+  operation: string,
+  issues: readonly SimulationReconciliationIssue[],
+): DatabaseError =>
+  databaseError(
+    'invariant',
+    operation,
+    `marked-equity reconciliation failed: ${renderSimulationReconciliationIssues(issues)}`,
+    issues,
+  )
+
+const persistencePlanDatabaseError = (operation: string, failure: PersistencePlanFailure): DatabaseError => {
+  switch (failure._tag) {
+    case 'InvalidPersistencePlan':
+      return databaseError(
+        'invariant',
+        operation,
+        persistencePlanInvariantMessages[failure.invariant],
+        failure.cause ?? failure,
+      )
+    case 'SimulationReconciliationFailed':
+      return reconciliationDatabaseError(operation, failure.issues)
+    case 'PersistencePlanComputationFailed':
+      return databaseError(
+        'invariant',
+        operation,
+        `persistence plan computation failed during ${failure.operation}`,
+        failure.cause,
+      )
+  }
+}
 
 const makeEvidenceStore = Effect.gen(function* () {
   const sql = yield* PgClient.PgClient
@@ -1703,26 +1872,23 @@ const makeEvidenceStore = Effect.gen(function* () {
           'recover-evidence',
           'stored snapshot reference diverged from the recovered input manifest',
         )
-        const equityProof = yield* Effect.try({
-          try: () =>
-            reconcileMarkedEquity({
-              runId,
-              initialCapitalMicros: evaluation.initialCapitalMicros,
-              evaluatorTotalFeesMicros: evaluation.strategy.totalFeesMicros,
-              evaluatorEndingEquityMicros: evaluation.strategy.endingEquityMicros,
-              events,
-              simulation: {
-                schemaVersion: 'bayn.simulation-trace.v3',
-                executionModel: orders.executionModel,
-                costMultiplierMicros: orders.costMultiplierMicros,
-                orders: orders.items,
-                cashChanges: cashChanges.items,
-                dailyMarks: dailyMarks.items,
-              },
-            }),
-          catch: (cause) =>
-            databaseError('invariant', 'recover-evidence', 'stored marked-equity reconstruction failed', cause),
-        })
+        const equityProof = yield* Effect.fromResult(
+          reconcileMarkedEquity({
+            runId,
+            initialCapitalMicros: evaluation.initialCapitalMicros,
+            evaluatorTotalFeesMicros: evaluation.strategy.totalFeesMicros,
+            evaluatorEndingEquityMicros: evaluation.strategy.endingEquityMicros,
+            events,
+            simulation: {
+              schemaVersion: 'bayn.simulation-trace.v3',
+              executionModel: orders.executionModel,
+              costMultiplierMicros: orders.costMultiplierMicros,
+              orders: orders.items,
+              cashChanges: cashChanges.items,
+              dailyMarks: dailyMarks.items,
+            },
+          }),
+        ).pipe(Effect.mapError((issue) => reconciliationDatabaseError('recover-evidence', issue)))
         const finalPoint = yield* requiredValue(equitySeries.items.at(-1), 'final equity-series point')
         const decisionEvents = events.filter((event) => event.kind === 'decision')
         const candidateDates = dailyMarks.items.map((point) => point.sessionDate)
@@ -1813,10 +1979,9 @@ const makeEvidenceStore = Effect.gen(function* () {
     runDatabase(
       'persist',
       Effect.gen(function* () {
-        const plan = yield* Effect.try({
-          try: () => makePersistencePlan(input),
-          catch: (cause) => databaseError('invariant', 'plan', 'invalid evaluation persistence input', cause),
-        })
+        const plan = yield* Effect.fromResult(makePersistencePlan(input)).pipe(
+          Effect.mapError((failure) => persistencePlanDatabaseError('plan', failure)),
+        )
 
         return yield* sql.withTransaction(
           Effect.gen(function* () {

--- a/services/bayn/src/ledger.test.ts
+++ b/services/bayn/src/ledger.test.ts
@@ -1,5 +1,7 @@
+import assert from 'node:assert/strict'
+
 import { describe, expect, test } from 'bun:test'
-import { Effect, Redacted } from 'effect'
+import { Effect, Redacted, Result } from 'effect'
 import { CreateAccountStatus, CreateTransferStatus, type Account, type Transfer } from 'tigerbeetle-node'
 
 import { prepareAccounting, rebuildAccountingLedger } from './accounting'
@@ -17,6 +19,11 @@ import {
 } from './ledger'
 import { evaluateRiskBalancedTrend } from './risk-balanced-trend'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
+
+const assertSuccess = <A, E>(result: Result.Result<A, E>): A => {
+  assert(Result.isSuccess(result), 'strategy evaluation fixture must succeed')
+  return result.success
+}
 
 const materializeAccounts = (plan: ReturnType<typeof buildLedgerPlan>): Account[] => {
   const balances = new Map(plan.accounts.map((account) => [account.id, { debits: 0n, credits: 0n }]))
@@ -126,7 +133,9 @@ const withJournal = <A, E>(client: TigerBeetleClient, use: (journal: JournalServ
 describe('TigerBeetle simulation journal', () => {
   test('plans deterministic double-entry transfers and reconciles exact sets and balances', () => {
     const snapshot = makeSnapshot()
-    const result = evaluateRiskBalancedTrend(snapshot.bars, snapshot.manifest, fixtureProtocol, makeTestProvenance())
+    const result = assertSuccess(
+      evaluateRiskBalancedTrend(snapshot.bars, snapshot.manifest, fixtureProtocol, makeTestProvenance()),
+    )
     const first = buildLedgerPlan(result, 7001)
     const second = buildLedgerPlan(result, 7001)
     expect(first).toEqual(second)
@@ -140,7 +149,9 @@ describe('TigerBeetle simulation journal', () => {
 
   test('fails closed on extra transfers or mismatched balances', () => {
     const snapshot = makeSnapshot()
-    const result = evaluateRiskBalancedTrend(snapshot.bars, snapshot.manifest, fixtureProtocol, makeTestProvenance())
+    const result = assertSuccess(
+      evaluateRiskBalancedTrend(snapshot.bars, snapshot.manifest, fixtureProtocol, makeTestProvenance()),
+    )
     const plan = buildLedgerPlan(result, 7001)
     const accounts = materializeAccounts(plan)
     const transfers = materializeTransfers(plan)
@@ -158,7 +169,9 @@ describe('TigerBeetle simulation journal', () => {
 
   test('creates an empty target exactly once and verifies an idempotent replay', async () => {
     const snapshot = makeSnapshot()
-    const result = evaluateRiskBalancedTrend(snapshot.bars, snapshot.manifest, fixtureProtocol, makeTestProvenance())
+    const result = assertSuccess(
+      evaluateRiskBalancedTrend(snapshot.bars, snapshot.manifest, fixtureProtocol, makeTestProvenance()),
+    )
     const plan = buildLedgerPlan(result, journalConfig.tigerBeetle.ledger)
     const target = makeLedgerClient()
 
@@ -286,7 +299,9 @@ describe('TigerBeetle simulation journal', () => {
 
   test('rejects a mismatched existing account before creating transfers', async () => {
     const snapshot = makeSnapshot()
-    const result = evaluateRiskBalancedTrend(snapshot.bars, snapshot.manifest, fixtureProtocol, makeTestProvenance())
+    const result = assertSuccess(
+      evaluateRiskBalancedTrend(snapshot.bars, snapshot.manifest, fixtureProtocol, makeTestProvenance()),
+    )
     const plan = buildLedgerPlan(result, journalConfig.tigerBeetle.ledger)
     const target = makeLedgerClient()
     target.accounts.set(plan.accounts[0].id, { ...plan.accounts[0], code: plan.accounts[0].code + 1, timestamp: 1n })
@@ -302,7 +317,9 @@ describe('TigerBeetle simulation journal', () => {
   test('checks the persisted run read-only and rejects changed TigerBeetle balances', async () => {
     const snapshot = makeSnapshot()
     const provenance = makeTestProvenance()
-    const result = evaluateRiskBalancedTrend(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance)
+    const result = assertSuccess(
+      evaluateRiskBalancedTrend(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance),
+    )
     const plan = buildLedgerPlan(result, 7001)
     let accounts = materializeAccounts(plan)
     const transfers = materializeTransfers(plan)

--- a/services/bayn/src/qualification-audit.test.ts
+++ b/services/bayn/src/qualification-audit.test.ts
@@ -1,6 +1,10 @@
+import assert from 'node:assert/strict'
+
 import { describe, expect, test } from 'bun:test'
+import { Result } from 'effect'
 
 import { makeEquitySeriesArtifact } from './evidence-contracts'
+import { makeStrategyProtocolHash } from './contracts'
 import { canonicalHashV1 } from './hash'
 import { makeQualificationResult } from './qualification'
 import {
@@ -19,7 +23,9 @@ const fixture = (priorTrialRunIds: readonly string[] = []): QualificationAuditIn
   const protocol = fixtureProtocol
   const provenance = makeTestProvenance()
   const strategy = makeStrategy(protocol, provenance)
-  const evaluation = strategy.evaluate(snapshot.bars, snapshot.manifest)
+  const evaluationResult = strategy.evaluate(snapshot.bars, snapshot.manifest)
+  assert(Result.isSuccess(evaluationResult), 'strategy evaluation fixture must succeed')
+  const evaluation = evaluationResult.success
   const sessionDates = [...new Set(snapshot.bars.map((bar) => bar.sessionDate))].sort()
   const lock = strategy.prepareLock(snapshot.manifest, sessionDates, priorTrialRunIds)
   const analysis = strategy.analyze(evaluation, priorTrialRunIds)
@@ -322,6 +328,7 @@ describe('qualification audit', () => {
     ])
     expect(first.policies.policySetHash).toBe(canonicalHashV1(first.policies.documents))
     expect(second.auditHash).toBe(first.auditHash)
+    expect(first.auditHash).toBe('b3a9ee416e1a97794acebb9ad071da4a01b1513f1ba6c87cc5f206c76b168043')
   })
 
   test('passes for a later candidate when prior terminal result lineage is complete', () => {
@@ -350,6 +357,40 @@ describe('qualification audit', () => {
     expect(report.status).toBe('FAIL')
     expect(report.checks.find((check) => check.name === 'artifact-hashes')?.passed).toBe(false)
     expect(report.checks.find((check) => check.name === 'reference-strategy')?.passed).toBe(false)
+  })
+
+  test('continues independent checks when public input cannot be reconciled', () => {
+    const input = fixture()
+    const protocol = { ...input.protocol, initialCapitalMicros: '+1000000000000' }
+    const provenance = makeTestProvenance(protocol)
+    const audited = () =>
+      auditQualification({
+        ...input,
+        protocol,
+        database: {
+          ...input.database,
+          protocol: {
+            ...input.database.protocol,
+            protocolHash: makeStrategyProtocolHash(provenance.strategy),
+            behaviorHash: provenance.strategy.behaviorHash,
+            parameterHash: provenance.strategy.parameterHash,
+            parameters: protocol,
+          },
+        },
+        repository: { ...input.repository, sourceCommitAncestorOfMain: false },
+      })
+
+    expect(audited).not.toThrow()
+    const report = audited()
+    expect(report.status).toBe('FAIL')
+    expect(report.checks.find((check) => check.name === 'reference-equity-series')?.passed).toBe(false)
+    expect(report.checks.find((check) => check.name === 'reference-marked-equity-reconciliation')?.passed).toBe(false)
+    expect(report.checks.find((check) => check.name === 'qualification-artifact-manifest')?.passed).toBe(false)
+    expect(report.checks.find((check) => check.name === 'source-revision-in-repository')?.passed).toBe(false)
+    expect(report.checks.find((check) => check.name === 'reference-equity-series')?.evidence).toContain(
+      'initialCapitalMicros',
+    )
+    expect(report.checks.at(-1)?.name).toBe('no-pre-lock-result-reference')
   })
 
   test('requires the source-pinned auditor for immutable protocol v2 evidence', () => {

--- a/services/bayn/src/qualification-reference.test.ts
+++ b/services/bayn/src/qualification-reference.test.ts
@@ -1,15 +1,25 @@
+import assert from 'node:assert/strict'
+
 import { describe, expect, test } from 'bun:test'
+import { Result } from 'effect'
 
 import { canonicalHashV1 } from './hash'
 import { evaluateReference } from './audit/reference'
 import { evaluateRiskBalancedTrend } from './risk-balanced-trend'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
 
+const assertSuccess = <A, E>(result: Result.Result<A, E>): A => {
+  assert(Result.isSuccess(result), 'strategy evaluation fixture must succeed')
+  return result.success
+}
+
 describe('independent qualification reference', () => {
   test('reproduces every persisted strategy and benchmark artifact', () => {
     const snapshot = makeSnapshot(900)
     const provenance = makeTestProvenance()
-    const actual = evaluateRiskBalancedTrend(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance)
+    const actual = assertSuccess(
+      evaluateRiskBalancedTrend(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance),
+    )
     const reference = evaluateReference(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance)
 
     expect(reference.runId).toBe(actual.runId)
@@ -40,7 +50,9 @@ describe('independent qualification reference', () => {
   test('independently keeps planned quantities invariant to future execution OHLC', () => {
     const snapshot = makeSnapshot(900)
     const provenance = makeTestProvenance()
-    const actual = evaluateRiskBalancedTrend(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance)
+    const actual = assertSuccess(
+      evaluateRiskBalancedTrend(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance),
+    )
     const executionDate = actual.signalDecisions[0].executionDate
     const changedBars = snapshot.bars.map((bar) => {
       if (bar.sessionDate !== executionDate) return bar
@@ -54,7 +66,9 @@ describe('independent qualification reference', () => {
         close,
       }
     })
-    const changedActual = evaluateRiskBalancedTrend(changedBars, snapshot.manifest, fixtureProtocol, provenance)
+    const changedActual = assertSuccess(
+      evaluateRiskBalancedTrend(changedBars, snapshot.manifest, fixtureProtocol, provenance),
+    )
     const changedReference = evaluateReference(changedBars, snapshot.manifest, fixtureProtocol, provenance)
     const requests = (orders: typeof actual.simulation.orders) =>
       orders

--- a/services/bayn/src/qualification-statistics.test.ts
+++ b/services/bayn/src/qualification-statistics.test.ts
@@ -1,6 +1,8 @@
+import assert from 'node:assert/strict'
+
 import { describe, expect, test } from 'bun:test'
 
-import { Schema } from 'effect'
+import { Result, Schema } from 'effect'
 
 import {
   QualificationAnalysisSchema,
@@ -295,12 +297,14 @@ describe('walk-forward and terminal qualification semantics', () => {
 describe('evaluation adapter', () => {
   test('prepares exact aligned strategy, cash, benchmark, and rebalance dates from decoded evidence', () => {
     const snapshot = makeSnapshot()
-    const evaluation = evaluateRiskBalancedTrend(
+    const evaluationResult = evaluateRiskBalancedTrend(
       snapshot.bars,
       snapshot.manifest,
       fixtureProtocol,
       makeTestProvenance(),
     )
+    assert(Result.isSuccess(evaluationResult), 'strategy evaluation fixture must succeed')
+    const evaluation = evaluationResult.success
     const series = prepareQualificationSeries(evaluation)
 
     expect(series.runId).toBe(evaluation.runId)

--- a/services/bayn/src/risk-balanced-trend.test.ts
+++ b/services/bayn/src/risk-balanced-trend.test.ts
@@ -1,4 +1,7 @@
+import assert from 'node:assert/strict'
+
 import { describe, expect, test } from 'bun:test'
+import { Result } from 'effect'
 
 import type { MarketCalendarObservation } from './broker/alpaca'
 import { referencePriceMicros } from './execution-model'
@@ -13,6 +16,11 @@ import {
 import { makeStrategy } from './strategy'
 import { makeSnapshot, makeTestProvenance, fixtureProtocol } from './test-fixtures'
 import type { CausalProtocol, IsoDate } from './types'
+
+const assertSuccess = <A, E>(result: Result.Result<A, E>): A => {
+  assert(Result.isSuccess(result), 'strategy evaluation fixture must succeed')
+  return result.success
+}
 
 const shortProtocol = (overrides: Partial<CausalProtocol> = {}): CausalProtocol => ({
   ...fixtureProtocol,
@@ -60,6 +68,26 @@ const currentDecisionBinding = (
 }
 
 describe('risk-balanced trend candidate', () => {
+  test('preserves pre-reconciliation strategy failures behind the transitional Result boundary', () => {
+    const snapshot = makeSnapshot()
+    const evaluate = () =>
+      evaluateRiskBalancedTrend(snapshot.bars.slice(1), snapshot.manifest, fixtureProtocol, makeTestProvenance())
+
+    expect(evaluate).not.toThrow()
+    const result = evaluate()
+    assert(Result.isFailure(result), 'malformed strategy evidence must fail explicitly')
+    expect(result.failure).toHaveLength(1)
+    const [issue] = result.failure
+    expect(issue).toEqual(
+      expect.objectContaining({
+        _tag: 'RiskBalancedTrendCompatibilityFailure',
+        phase: 'prepare',
+      }),
+    )
+    assert(issue._tag === 'RiskBalancedTrendCompatibilityFailure', 'compatibility failure must retain its cause')
+    expect(issue.cause).toBeInstanceOf(Error)
+  })
+
   test('matches a hand-calculated multi-symbol continuous normalized trend', () => {
     const protocol = shortProtocol({
       horizons: [1],
@@ -218,7 +246,9 @@ describe('risk-balanced trend candidate', () => {
 
     const snapshot = makeSnapshot()
     const provenance = makeTestProvenance()
-    const baseline = evaluateRiskBalancedTrend(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance)
+    const baseline = assertSuccess(
+      evaluateRiskBalancedTrend(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance),
+    )
     const finalSession = snapshot.manifest.lastSession
     const changedFuture = snapshot.bars.map((bar) =>
       bar.sessionDate === finalSession && bar.symbol === 'DBC'
@@ -231,7 +261,9 @@ describe('risk-balanced trend candidate', () => {
           }
         : bar,
     )
-    const changed = evaluateRiskBalancedTrend(changedFuture, snapshot.manifest, fixtureProtocol, provenance)
+    const changed = assertSuccess(
+      evaluateRiskBalancedTrend(changedFuture, snapshot.manifest, fixtureProtocol, provenance),
+    )
 
     expect(baseline.signalDecisions[0].signalDate < finalSession).toBe(true)
     expect(changed.signalDecisions[0]).toEqual(baseline.signalDecisions[0])
@@ -375,6 +407,15 @@ describe('risk-balanced trend candidate', () => {
     }
     const strategy = makeStrategy(fixtureProtocol, makeTestProvenance())
 
+    const evaluation = strategy.evaluate(snapshot.bars, mismatchedManifest)
+    assert(Result.isFailure(evaluation), 'strategy evaluation must preserve manifest failure as Result data')
+    expect(evaluation.failure).toEqual([
+      expect.objectContaining({
+        _tag: 'RiskBalancedTrendCompatibilityFailure',
+        phase: 'prepare',
+        cause: expect.any(TypeError),
+      }),
+    ])
     expect(() => strategy.prepareLock(mismatchedManifest, [], [])).toThrow(
       'Signal snapshot universe does not match the compiled strategy universe',
     )
@@ -383,8 +424,12 @@ describe('risk-balanced trend candidate', () => {
   test('evaluates deterministically with complete evidence and a calendar-only precommit', () => {
     const snapshot = makeSnapshot()
     const provenance = makeTestProvenance()
-    const first = evaluateRiskBalancedTrend(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance)
-    const second = evaluateRiskBalancedTrend(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance)
+    const first = assertSuccess(
+      evaluateRiskBalancedTrend(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance),
+    )
+    const second = assertSuccess(
+      evaluateRiskBalancedTrend(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance),
+    )
     const sessionDates = [...new Set(snapshot.bars.map((bar) => bar.sessionDate))].sort()
     const precommit = prepareRiskBalancedTrendQualification(
       sessionDates,

--- a/services/bayn/src/risk-balanced-trend.ts
+++ b/services/bayn/src/risk-balanced-trend.ts
@@ -1,11 +1,15 @@
-import { Schema } from 'effect'
+import { Result, Schema } from 'effect'
 
 import type { RuntimeProvenance } from './contracts'
 import { MICROS, referencePriceMicros } from './execution-model'
 import { ExecutionSessionBindingSchema, type ExecutionSessionBinding } from './execution-session'
 import { canonicalHashV1 } from './hash'
 import { strictParseOptions } from './schemas'
-import { reconcileMarkedEquity } from './simulation-reconciliation'
+import {
+  reconcileMarkedEquity,
+  renderSimulationReconciliationIssue,
+  type SimulationReconciliationIssue,
+} from './simulation-reconciliation'
 import {
   alignBars,
   buildVerdict,
@@ -29,6 +33,7 @@ import {
   type IsoDate,
   type DecisionPlan,
   type Protocol,
+  type SignalDecision,
 } from './types'
 
 const WEIGHT_SCALE = 1_000_000_000_000
@@ -371,48 +376,74 @@ export const prepareRiskBalancedTrendQualification = (
   }
 }
 
-export const evaluateRiskBalancedTrend = (
+export interface RiskBalancedTrendCompatibilityFailure {
+  readonly _tag: 'RiskBalancedTrendCompatibilityFailure'
+  readonly phase: 'finalize' | 'prepare'
+  readonly cause: unknown
+}
+
+export type RiskBalancedTrendEvaluationIssue = SimulationReconciliationIssue | RiskBalancedTrendCompatibilityFailure
+
+interface PreparedEvaluation {
+  readonly runId: string
+  readonly protocolHash: string
+  readonly strategy: ReturnType<typeof simulate>
+  readonly buyAndHold: ReturnType<typeof simulate>
+  readonly directVolTiming: ReturnType<typeof simulate>
+  readonly doubleCost: ReturnType<typeof simulate>
+  readonly simulation: NonNullable<ReturnType<typeof simulate>['simulation']>
+  readonly signalDecisions: readonly SignalDecision[]
+}
+
+// PROOMPT-419 owns replacing this compatibility boundary with total strategy and simulation functions.
+const prepareEvaluation = (
   bars: readonly DailyBar[],
   inputManifest: InputManifest,
   protocol: Protocol,
   provenance: RuntimeProvenance,
-): EvaluationResult => {
+): PreparedEvaluation => {
   const { runId, protocolHash } = makeEvaluationIdentity(inputManifest, protocol, provenance)
   const sessions = alignBars(bars, protocol.universe, inputManifest)
   const sessionDates = sessions.map((session) => session.date)
-  const historySessions = requiredHistory(protocol)
   const window = selectEvaluationWindow(
     sessionDates,
     inputManifest,
-    historySessions,
+    requiredHistory(protocol),
     protocol.thresholds.minimumObservations,
   )
-  const { signalIndices, startIndex } = window
   const evaluationSessions = sessions.slice(0, window.evaluationEndExclusive)
-  const strategyTargets: SimulationTarget[] = signalIndices.map((signalIndex) => {
+  const strategyTargets: SimulationTarget[] = window.signalIndices.map((signalIndex) => {
     const decision = decisionFromAlignedSessions(sessions, signalIndex, protocol)
     return { signalIndex, executionIndex: signalIndex + 1, weights: decision.targetWeights, decision }
   })
   const equalWeight = roundWeight(1 / protocol.universe.length)
   const buyAndHoldTargets: SimulationTarget[] = [
     {
-      signalIndex: startIndex - 1,
-      executionIndex: startIndex,
+      signalIndex: window.startIndex - 1,
+      executionIndex: window.startIndex,
       weights: Object.fromEntries(protocol.universe.map((symbol) => [symbol, equalWeight])),
     },
   ]
-  const directVolTargets: SimulationTarget[] = signalIndices.map((signalIndex) => ({
+  const directVolTargets: SimulationTarget[] = window.signalIndices.map((signalIndex) => ({
     signalIndex,
     executionIndex: signalIndex + 1,
     weights: directVolatilityWeights(sessions, signalIndex, protocol),
   }))
-  const strategy = simulate(evaluationSessions, strategyTargets, startIndex, protocol, MICROS, runId, true)
-  const buyAndHold = simulate(evaluationSessions, buyAndHoldTargets, startIndex, protocol, MICROS, runId, false)
-  const directVolTiming = simulate(evaluationSessions, directVolTargets, startIndex, protocol, MICROS, runId, false)
+  const strategy = simulate(evaluationSessions, strategyTargets, window.startIndex, protocol, MICROS, runId, true)
+  const buyAndHold = simulate(evaluationSessions, buyAndHoldTargets, window.startIndex, protocol, MICROS, runId, false)
+  const directVolTiming = simulate(
+    evaluationSessions,
+    directVolTargets,
+    window.startIndex,
+    protocol,
+    MICROS,
+    runId,
+    false,
+  )
   const doubleCost = simulate(
     evaluationSessions,
     strategyTargets,
-    startIndex,
+    window.startIndex,
     protocol,
     BigInt(protocol.executionModel.doubleCostMultiplier) * MICROS,
     runId,
@@ -425,38 +456,93 @@ export const evaluateRiskBalancedTrend = (
     }
     return decision
   })
-  const markedEquity = reconcileMarkedEquity({
-    runId,
-    initialCapitalMicros: protocol.initialCapitalMicros,
-    evaluatorTotalFeesMicros: strategy.metrics.totalFeesMicros,
-    evaluatorEndingEquityMicros: strategy.metrics.endingEquityMicros,
-    events: strategy.events,
-    simulation: strategy.simulation,
-  })
-
   return {
-    schemaVersion: ContractVersion.Evaluation,
     runId,
-    codeRevision: provenance.sourceRevision,
     protocolHash,
-    initialCapitalMicros: protocol.initialCapitalMicros,
-    inputManifest,
-    strategy: strategy.metrics,
-    buyAndHold: buyAndHold.metrics,
-    directVolTiming: directVolTiming.metrics,
-    doubleCostStrategy: doubleCost.metrics,
-    verdict: buildVerdict(strategy.metrics, buyAndHold.metrics, directVolTiming.metrics, doubleCost.metrics, protocol),
-    events: strategy.events,
-    signalDecisions,
+    strategy,
+    buyAndHold,
+    directVolTiming,
+    doubleCost,
     simulation: strategy.simulation,
-    benchmarkSeries: {
-      buyAndHold: buyAndHold.dailyPerformance,
-      directVolTiming: directVolTiming.dailyPerformance,
-      doubleCostStrategy: doubleCost.dailyPerformance,
-    },
-    equitySeries: markedEquity.equitySeries,
-    markedEquityReconciliation: markedEquity.reconciliation,
+    signalDecisions,
   }
+}
+
+export const riskBalancedTrendCompatibilityFailure = (
+  phase: RiskBalancedTrendCompatibilityFailure['phase'],
+  cause: unknown,
+): readonly RiskBalancedTrendEvaluationIssue[] =>
+  Object.freeze([Object.freeze({ _tag: 'RiskBalancedTrendCompatibilityFailure' as const, phase, cause })])
+
+const renderCompatibilityCause = (cause: unknown): string => {
+  const rendered = Result.try({
+    try: () => String(cause instanceof Error ? cause.message : cause),
+    catch: () => undefined,
+  })
+  return Result.isSuccess(rendered) ? rendered.success : 'unrenderable cause'
+}
+
+export const renderRiskBalancedTrendEvaluationIssues = (issues: readonly RiskBalancedTrendEvaluationIssue[]): string =>
+  issues
+    .map((issue) => {
+      if (issue._tag === 'RiskBalancedTrendCompatibilityFailure') return renderCompatibilityCause(issue.cause)
+      return renderSimulationReconciliationIssue(issue)
+    })
+    .join('; ')
+
+export const evaluateRiskBalancedTrend = (
+  bars: readonly DailyBar[],
+  inputManifest: InputManifest,
+  protocol: Protocol,
+  provenance: RuntimeProvenance,
+): Result.Result<EvaluationResult, readonly RiskBalancedTrendEvaluationIssue[]> => {
+  const prepared = Result.try({
+    try: () => prepareEvaluation(bars, inputManifest, protocol, provenance),
+    catch: (cause) => riskBalancedTrendCompatibilityFailure('prepare', cause),
+  })
+  if (Result.isFailure(prepared)) return Result.fail(prepared.failure)
+  const markedEquity = reconcileMarkedEquity({
+    runId: prepared.success.runId,
+    initialCapitalMicros: protocol.initialCapitalMicros,
+    evaluatorTotalFeesMicros: prepared.success.strategy.metrics.totalFeesMicros,
+    evaluatorEndingEquityMicros: prepared.success.strategy.metrics.endingEquityMicros,
+    events: prepared.success.strategy.events,
+    simulation: prepared.success.simulation,
+  })
+  if (Result.isFailure(markedEquity)) return Result.fail(markedEquity.failure)
+
+  return Result.try({
+    try: (): EvaluationResult => ({
+      schemaVersion: ContractVersion.Evaluation,
+      runId: prepared.success.runId,
+      codeRevision: provenance.sourceRevision,
+      protocolHash: prepared.success.protocolHash,
+      initialCapitalMicros: protocol.initialCapitalMicros,
+      inputManifest,
+      strategy: prepared.success.strategy.metrics,
+      buyAndHold: prepared.success.buyAndHold.metrics,
+      directVolTiming: prepared.success.directVolTiming.metrics,
+      doubleCostStrategy: prepared.success.doubleCost.metrics,
+      verdict: buildVerdict(
+        prepared.success.strategy.metrics,
+        prepared.success.buyAndHold.metrics,
+        prepared.success.directVolTiming.metrics,
+        prepared.success.doubleCost.metrics,
+        protocol,
+      ),
+      events: prepared.success.strategy.events,
+      signalDecisions: prepared.success.signalDecisions,
+      simulation: prepared.success.simulation,
+      benchmarkSeries: {
+        buyAndHold: prepared.success.buyAndHold.dailyPerformance,
+        directVolTiming: prepared.success.directVolTiming.dailyPerformance,
+        doubleCostStrategy: prepared.success.doubleCost.dailyPerformance,
+      },
+      equitySeries: markedEquity.success.equitySeries,
+      markedEquityReconciliation: markedEquity.success.reconciliation,
+    }),
+    catch: (cause) => riskBalancedTrendCompatibilityFailure('finalize', cause),
+  })
 }
 
 export const summarizeEvaluation = (evaluation: EvaluationResult): EvaluationSummary => ({

--- a/services/bayn/src/simulation-reconciliation.test.ts
+++ b/services/bayn/src/simulation-reconciliation.test.ts
@@ -1,195 +1,1325 @@
+import assert from 'node:assert/strict'
+
 import { describe, expect, test } from 'bun:test'
+import { Result } from 'effect'
 
-import { MARKED_EQUITY_TOLERANCE_MICROS, reconcileMarkedEquity } from './simulation-reconciliation'
 import { canonicalHashV1 } from './hash'
+import { makeFillTerms } from './execution-model'
 import { evaluateRiskBalancedTrend } from './risk-balanced-trend'
+import {
+  MARKED_EQUITY_TOLERANCE_MICROS,
+  reconcileMarkedEquity,
+  renderSimulationReconciliationIssue,
+  type MarkedEquityReconciliationInput,
+  type SimulationReconciliationIssue,
+  type SimulationReconciliationResult,
+} from './simulation-reconciliation'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
-import type { EvaluationEvent, SimulationTrace } from './types'
+import type { EvaluationEvent, Protocol, SimulationTrace } from './types'
 
-const evaluation = (() => {
-  const snapshot = makeSnapshot(800)
-  return evaluateRiskBalancedTrend(
-    snapshot.bars,
-    snapshot.manifest,
-    fixtureProtocol,
-    makeTestProvenance(fixtureProtocol),
-  )
-})()
+const snapshot = makeSnapshot(800)
+const evaluationResult = evaluateRiskBalancedTrend(
+  snapshot.bars,
+  snapshot.manifest,
+  fixtureProtocol,
+  makeTestProvenance(fixtureProtocol),
+)
+assert(Result.isSuccess(evaluationResult), 'evaluation fixture must reconcile successfully')
+const evaluation = evaluationResult.success
 
 const reconcile = (
   overrides: {
+    readonly runId?: string
+    readonly initialCapitalMicros?: string
     readonly events?: readonly EvaluationEvent[]
     readonly simulation?: SimulationTrace
     readonly evaluatorEndingEquityMicros?: string
     readonly evaluatorTotalFeesMicros?: string
   } = {},
-) =>
+): SimulationReconciliationResult =>
   reconcileMarkedEquity({
-    runId: evaluation.runId,
-    initialCapitalMicros: evaluation.initialCapitalMicros,
+    runId: overrides.runId ?? evaluation.runId,
+    initialCapitalMicros: overrides.initialCapitalMicros ?? evaluation.initialCapitalMicros,
     evaluatorTotalFeesMicros: overrides.evaluatorTotalFeesMicros ?? evaluation.strategy.totalFeesMicros,
     evaluatorEndingEquityMicros: overrides.evaluatorEndingEquityMicros ?? evaluation.strategy.endingEquityMicros,
     events: overrides.events ?? evaluation.events,
     simulation: overrides.simulation ?? evaluation.simulation,
   })
 
-describe('independent marked-equity reconciliation', () => {
-  test('reconstructs every daily point from orders, fills, cash, positions, and close marks', () => {
-    const proof = reconcile()
-    const fills = evaluation.events.filter((event) => event.kind === 'fill')
+const expectIssue = (
+  result: SimulationReconciliationResult,
+  expected: { readonly _tag: SimulationReconciliationIssue['_tag']; readonly [key: string]: unknown },
+): SimulationReconciliationIssue => {
+  assert(Result.isFailure(result), 'expected reconciliation to fail')
+  expect(result.failure).toContainEqual(expect.objectContaining(expected))
+  const issue = result.failure.find((candidate) => candidate._tag === expected._tag)
+  assert(issue !== undefined, `expected reconciliation issue ${expected._tag}`)
+  expect(issue).not.toBeInstanceOf(Error)
+  return issue
+}
 
-    expect(proof).toEqual({
+const expectExactIssues = (
+  result: SimulationReconciliationResult,
+  expected: readonly SimulationReconciliationIssue[],
+): void => {
+  assert(Result.isFailure(result), 'expected reconciliation to fail')
+  expect(result.failure).toEqual(expected)
+  for (const issue of result.failure) expect(issue).not.toBeInstanceOf(Error)
+}
+
+const firstEvent = <K extends EvaluationEvent['kind']>(kind: K): Extract<EvaluationEvent, { readonly kind: K }> => {
+  const event = evaluation.events.find(
+    (candidate): candidate is Extract<EvaluationEvent, { readonly kind: K }> => candidate.kind === kind,
+  )
+  assert(event !== undefined, `evaluation fixture must contain ${kind}`)
+  return event
+}
+
+const makeEmptyInput = (): MarkedEquityReconciliationInput => {
+  const mark = evaluation.simulation.dailyMarks[0]
+  const capital = '1000000000000'
+  return {
+    runId: evaluation.runId,
+    initialCapitalMicros: capital,
+    evaluatorTotalFeesMicros: '0',
+    evaluatorEndingEquityMicros: capital,
+    events: [],
+    simulation: {
+      ...evaluation.simulation,
+      orders: [],
+      cashChanges: [],
+      dailyMarks: [
+        {
+          ...mark,
+          sessionDate: '2026-01-02',
+          equityMicros: capital,
+          turnoverMicros: '0',
+          cumulativeTurnoverMicros: '0',
+          feeMicros: '0',
+          cumulativeFeesMicros: '0',
+          spreadCostMicros: '0',
+          cumulativeSpreadCostMicros: '0',
+          slippageCostMicros: '0',
+          cumulativeSlippageCostMicros: '0',
+          cashYieldMicros: '0',
+          cumulativeCashYieldMicros: '0',
+          cashMicros: capital,
+          positions: [],
+        },
+      ],
+    },
+  }
+}
+
+const makeRoundTripInput = (dayCount: number): MarkedEquityReconciliationInput => {
+  const sessionDates = [
+    '2026-02-01',
+    '2026-02-02',
+    '2026-02-03',
+    '2026-02-04',
+    '2026-02-05',
+    '2026-02-06',
+    '2026-02-07',
+    '2026-02-08',
+    '2026-02-09',
+    '2026-02-10',
+  ] as const
+  assert(dayCount <= sessionDates.length, 'round-trip fixture day count must be bounded')
+  const input = makeEmptyInput()
+  const markTemplate = input.simulation.dailyMarks[0]
+  const events: EvaluationEvent[] = []
+  const orders: SimulationTrace['orders'][number][] = []
+  const cashChanges: SimulationTrace['cashChanges'][number][] = []
+  const dailyMarks: SimulationTrace['dailyMarks'][number][] = []
+  const costMultiplierMicros = BigInt(input.simulation.costMultiplierMicros)
+  const quantityMicros = 1_000_000n
+  const referencePriceMicros = 100_000_000n
+  let cashMicros = BigInt(input.initialCapitalMicros)
+  let cumulativeTurnoverMicros = 0n
+  let cumulativeSpreadCostMicros = 0n
+  let cumulativeSlippageCostMicros = 0n
+
+  for (let dayIndex = 0; dayIndex < dayCount; dayIndex += 1) {
+    const sessionDate = sessionDates[dayIndex]
+    const signalDate = sessionDate
+    const symbol = `S${String(dayIndex + 1).padStart(3, '0')}`
+    const decisionPayload = { signalDate, executionDate: sessionDate, targetWeights: { [symbol]: 0 } }
+    const decisionId = canonicalHashV1({ runId: input.runId, kind: 'decision', ...decisionPayload })
+    events.push({ kind: 'decision', id: decisionId, ...decisionPayload })
+    let dailyTurnoverMicros = 0n
+    let dailySpreadCostMicros = 0n
+    let dailySlippageCostMicros = 0n
+
+    for (const side of ['buy', 'sell'] as const) {
+      const orderPayload = {
+        decisionId,
+        sessionDate,
+        symbol,
+        side,
+        requestedQuantityMicros: quantityMicros.toString(),
+        filledQuantityMicros: quantityMicros.toString(),
+        status: 'filled' as const,
+        rejectionReason: null,
+        unfilledRemainder: 'none' as const,
+      }
+      const orderId = canonicalHashV1({ runId: input.runId, kind: 'order', ...orderPayload })
+      orders.push({ id: orderId, ...orderPayload })
+      const terms = makeFillTerms(
+        side,
+        quantityMicros,
+        referencePriceMicros,
+        input.simulation.executionModel,
+        costMultiplierMicros,
+      )
+      const fillPayload = {
+        orderId,
+        decisionId,
+        sessionDate,
+        symbol,
+        side,
+        quantityMicros: quantityMicros.toString(),
+        referencePriceMicros: referencePriceMicros.toString(),
+        priceMicros: terms.fillPriceMicros.toString(),
+        notionalMicros: terms.notionalMicros.toString(),
+        spreadCostMicros: terms.spreadCostMicros.toString(),
+        slippageCostMicros: terms.slippageCostMicros.toString(),
+        costBasisMicros: terms.notionalMicros.toString(),
+      }
+      const fillId = canonicalHashV1({ runId: input.runId, kind: 'fill', ...fillPayload })
+      events.push({ kind: 'fill', id: fillId, ...fillPayload })
+      const amountMicros = side === 'buy' ? -terms.notionalMicros : terms.notionalMicros
+      cashMicros += amountMicros
+      const cashChangePayload = {
+        sourceKind: 'fill' as const,
+        sourceId: fillId,
+        sessionDate,
+        amountMicros: amountMicros.toString(),
+        cashAfterMicros: cashMicros.toString(),
+      }
+      cashChanges.push({
+        id: canonicalHashV1({ runId: input.runId, kind: 'cash-change', ...cashChangePayload }),
+        ...cashChangePayload,
+      })
+      cumulativeTurnoverMicros += terms.notionalMicros
+      cumulativeSpreadCostMicros += terms.spreadCostMicros
+      cumulativeSlippageCostMicros += terms.slippageCostMicros
+      dailyTurnoverMicros += terms.notionalMicros
+      dailySpreadCostMicros += terms.spreadCostMicros
+      dailySlippageCostMicros += terms.slippageCostMicros
+    }
+    dailyMarks.push({
+      ...markTemplate,
+      sessionDate,
+      equityMicros: cashMicros.toString(),
+      turnoverMicros: dailyTurnoverMicros.toString(),
+      cumulativeTurnoverMicros: cumulativeTurnoverMicros.toString(),
+      feeMicros: '0',
+      cumulativeFeesMicros: '0',
+      spreadCostMicros: dailySpreadCostMicros.toString(),
+      cumulativeSpreadCostMicros: cumulativeSpreadCostMicros.toString(),
+      slippageCostMicros: dailySlippageCostMicros.toString(),
+      cumulativeSlippageCostMicros: cumulativeSlippageCostMicros.toString(),
+      cashYieldMicros: '0',
+      cumulativeCashYieldMicros: '0',
+      cashMicros: cashMicros.toString(),
+      positions: [],
+    })
+  }
+
+  return {
+    ...input,
+    evaluatorEndingEquityMicros: cashMicros.toString(),
+    events,
+    simulation: { ...input.simulation, orders, cashChanges, dailyMarks },
+  }
+}
+
+type IssueLeaf =
+  | 'InvalidInteger/unsigned-integer'
+  | 'InvalidInteger/positive-unsigned-integer'
+  | 'InvalidInteger/signed-integer'
+  | 'InvalidIdentity/InvalidFormat'
+  | 'InvalidIdentity/HashMismatch'
+  | 'InvalidIdentity/CanonicalizationFailed'
+  | 'MissingReference/OrderDecision'
+  | 'MissingReference/FillOrder'
+  | 'MissingReference/MonetaryEventCashChange'
+  | 'EvidenceMismatch/OrderExecutionSession'
+  | 'EvidenceMismatch/FillBinding'
+  | 'EvidenceMismatch/FillQuantity'
+  | 'EvidenceMismatch/FillTerms'
+  | 'EvidenceMismatch/FeeComponents'
+  | 'EvidenceMismatch/FeeSchedule'
+  | 'EvidenceMismatch/CashChange'
+  | 'EvidenceMismatch/CashYield'
+  | 'EvidenceMismatch/DailyMark'
+  | 'EvidenceMismatch/PositionMark'
+  | 'InvalidEvidenceState/DuplicateIdentity'
+  | 'InvalidEvidenceState/DuplicateFillForOrder'
+  | 'InvalidEvidenceState/DuplicateCashChangeForEvent'
+  | 'InvalidEvidenceState/InvalidOrder'
+  | 'InvalidEvidenceState/InvalidMarkOrder'
+  | 'InvalidEvidenceState/DuplicateMarkedPosition'
+  | 'InvalidEvidenceState/UnsortedMarkedPositions'
+  | 'InvalidEvidenceState/NegativeCash'
+  | 'InvalidEvidenceState/NegativeLongPosition'
+  | 'InvalidEvidenceState/DailyOutsideTolerance'
+  | 'InvalidEvidenceState/FinalOutsideTolerance'
+  | 'InvalidEvidenceState/NegativeTolerance'
+  | 'InvalidEvidenceState/UnsupportedSimulationSchema'
+  | 'IncompleteEvidence/EmptyDailyMarks'
+  | 'IncompleteEvidence/CashChangeCountMismatch'
+  | 'IncompleteEvidence/MissingSessionMark'
+  | 'IncompleteEvidence/MissingOpenPositionMark'
+  | 'IncompleteEvidence/MonetaryEventsAfterFinalMark'
+  | 'ComputationFailed/FillTerms'
+  | 'ComputationFailed/FeeSchedule'
+  | 'ComputationFailed/CashYield'
+
+const issueLeaf = (issue: SimulationReconciliationIssue): IssueLeaf => {
+  switch (issue._tag) {
+    case 'InvalidInteger':
+      return `InvalidInteger/${issue.expected}`
+    case 'InvalidIdentity':
+      return `InvalidIdentity/${issue.problem._tag}`
+    case 'MissingReference':
+      return `MissingReference/${issue.problem._tag}`
+    case 'EvidenceMismatch':
+      return `EvidenceMismatch/${issue.problem._tag}`
+    case 'InvalidEvidenceState':
+      return `InvalidEvidenceState/${issue.problem._tag}`
+    case 'IncompleteEvidence':
+      return `IncompleteEvidence/${issue.problem._tag}`
+    case 'ComputationFailed':
+      return `ComputationFailed/${issue.computation._tag}`
+  }
+}
+
+describe('independent marked-equity reconciliation', () => {
+  test('reconstructs the byte-identical proof from complete evidence', () => {
+    const result = reconcile()
+    assert(Result.isSuccess(result), 'valid fixture must reconcile successfully')
+    expect(result.success).toEqual({
       reconciliation: evaluation.markedEquityReconciliation,
       equitySeries: evaluation.equitySeries,
     })
-    expect(proof.equitySeries).toHaveLength(evaluation.strategy.observations)
-    expect(evaluation.simulation.orders.length).toBeGreaterThanOrEqual(fills.length)
+    expect(result.success.reconciliation.withinTolerance).toBe(true)
+    expect(result.success.equitySeries).toHaveLength(evaluation.strategy.observations)
+    expect(Object.isFrozen(result.success)).toBe(true)
+    expect(Object.isFrozen(result.success.reconciliation)).toBe(true)
+    expect(Object.isFrozen(result.success.equitySeries)).toBe(true)
+    expect(result.success.equitySeries.every(Object.isFrozen)).toBe(true)
+    expect(result.success.reconciliation).not.toBe(evaluation.markedEquityReconciliation)
+    expect(result.success.equitySeries).not.toBe(evaluation.equitySeries)
+    expect(result.success.equitySeries[0]).not.toBe(evaluation.equitySeries[0])
+    expect(Reflect.set(result.success.reconciliation, 'exact', false)).toBe(false)
+    expect(Reflect.set(result.success.equitySeries[0], 'differenceMicros', '1')).toBe(false)
     expect(evaluation.simulation.cashChanges).toHaveLength(
       evaluation.events.filter((event) => event.kind !== 'decision').length,
     )
-    expect(evaluation.simulation.dailyMarks).toHaveLength(evaluation.strategy.observations)
-    expect(proof.reconciliation.withinTolerance).toBe(true)
-    expect(BigInt(proof.reconciliation.maximumDailyDifferenceMicros)).toBeLessThanOrEqual(
-      MARKED_EQUITY_TOLERANCE_MICROS,
+  })
+
+  test('drops closed positions across growing same-session round trips', () => {
+    const oneDay = makeRoundTripInput(1)
+    const tenDays = makeRoundTripInput(10)
+    const oneDayResult = reconcileMarkedEquity(oneDay)
+    const tenDayResult = reconcileMarkedEquity(tenDays)
+
+    assert(Result.isSuccess(oneDayResult), 'one-day round-trip fixture must reconcile')
+    assert(Result.isSuccess(tenDayResult), 'ten-day round-trip fixture must reconcile')
+    expect(oneDayResult.success.equitySeries.at(-1)?.reconstructedEquityMicros).toBe(oneDay.evaluatorEndingEquityMicros)
+    expect(tenDayResult.success.equitySeries.at(-1)?.reconstructedEquityMicros).toBe(
+      tenDays.evaluatorEndingEquityMicros,
     )
   })
 
-  test('rejects cash, fill, mark, lineage, and completeness tampering', () => {
+  test('returns immutable plain issues and preserves them through Result.match', () => {
     const firstChange = evaluation.simulation.cashChanges[0]
+    const simulation: SimulationTrace = {
+      ...evaluation.simulation,
+      cashChanges: evaluation.simulation.cashChanges.map((change, index) =>
+        index === 0 ? { ...change, amountMicros: (BigInt(change.amountMicros) + 1n).toString() } : change,
+      ),
+    }
+    const result = reconcile({ simulation })
+    const issue = expectIssue(result, {
+      _tag: 'EvidenceMismatch',
+      problem: expect.objectContaining({
+        _tag: 'CashChange',
+        cashChangeId: firstChange.id,
+        field: 'amountMicros',
+        actual: (BigInt(firstChange.amountMicros) + 1n).toString(),
+        expected: firstChange.amountMicros,
+      }),
+    })
+    expect(Object.isFrozen(issue)).toBe(true)
+    assert(issue._tag === 'EvidenceMismatch', 'cash change must produce an evidence mismatch')
+    expect(Object.isFrozen(issue.problem)).toBe(true)
+    expect(Reflect.set(issue.problem, 'field', 'cashAfterMicros')).toBe(false)
+    expect(issue.problem).toEqual(expect.objectContaining({ _tag: 'CashChange', field: 'amountMicros' }))
+    const propagated = Result.match(result, { onFailure: (failure) => failure, onSuccess: () => undefined })
+    assert(Result.isFailure(result), 'expected reconciliation to fail')
+    expect(Object.isFrozen(result.failure)).toBe(true)
+    expect(propagated).toBe(result.failure)
+  })
+
+  test('freezes every known nested issue payload without freezing the original unknown cause', () => {
+    const markIndex = evaluation.simulation.dailyMarks.findIndex((mark) => mark.positions.length > 0)
+    assert(markIndex >= 0, 'evaluation fixture must contain a position mark')
+    const mark = evaluation.simulation.dailyMarks[markIndex]
+    const firstPosition = mark.positions[0]
+    const simulation: SimulationTrace = {
+      ...evaluation.simulation,
+      dailyMarks: evaluation.simulation.dailyMarks.map((candidate, index) =>
+        index === markIndex ? { ...candidate, positions: [firstPosition, firstPosition] } : candidate,
+      ),
+    }
+    const issue = expectIssue(reconcile({ simulation }), {
+      _tag: 'InvalidEvidenceState',
+      problem: expect.objectContaining({ _tag: 'DuplicateMarkedPosition' }),
+    })
+    assert(issue._tag === 'InvalidEvidenceState', 'duplicate mark must produce invalid evidence state')
+    assert(issue.problem._tag === 'DuplicateMarkedPosition', 'duplicate mark must retain its symbols')
+    expect(Object.isFrozen(issue.problem)).toBe(true)
+    expect(Object.isFrozen(issue.problem.symbols)).toBe(true)
+    expect(Reflect.set(issue.problem.symbols, 0, 'MUTATED')).toBe(false)
+    expect(issue.problem.symbols[0]).toBe(firstPosition.symbol)
+  })
+
+  test('returns closed integer, identity, and reference failures', () => {
+    const integerIssue = expectIssue(reconcile({ initialCapitalMicros: 'not-an-integer' }), {
+      _tag: 'InvalidInteger',
+      expected: 'unsigned-integer',
+      evidence: {
+        kind: 'input',
+        field: 'initialCapitalMicros',
+        value: 'not-an-integer',
+      },
+    })
+    assert(integerIssue._tag === 'InvalidInteger', 'malformed capital must produce an integer issue')
+    expect(Object.isFrozen(integerIssue.evidence)).toBe(true)
+    expect(Reflect.set(integerIssue.evidence, 'value', '0')).toBe(false)
+    expect(integerIssue.evidence.value).toBe('not-an-integer')
+
+    const identityIssue = expectIssue(reconcile({ runId: 'not-a-run-id' }), {
+      _tag: 'InvalidIdentity',
+      evidence: { kind: 'run', id: 'not-a-run-id' },
+      problem: { _tag: 'InvalidFormat', expected: 'lowercase-sha256' },
+    })
+    assert(identityIssue._tag === 'InvalidIdentity', 'malformed run ID must produce an identity issue')
+    expect(Object.isFrozen(identityIssue.evidence)).toBe(true)
+    expect(Object.isFrozen(identityIssue.problem)).toBe(true)
+    expect(Reflect.set(identityIssue.evidence, 'id', evaluation.runId)).toBe(false)
+    expect(identityIssue.evidence.id).toBe('not-a-run-id')
+
+    const firstOrder = evaluation.simulation.orders[0]
+    const simulation: SimulationTrace = {
+      ...evaluation.simulation,
+      orders: [{ ...firstOrder, decisionId: 'f'.repeat(64) }, ...evaluation.simulation.orders.slice(1)],
+    }
+    expectIssue(reconcile({ simulation }), {
+      _tag: 'MissingReference',
+      problem: { _tag: 'OrderDecision', orderId: firstOrder.id, decisionId: 'f'.repeat(64) },
+    })
+
+    const zeroCostMultiplier: SimulationTrace = { ...evaluation.simulation, costMultiplierMicros: '0' }
+    expectExactIssues(reconcile({ simulation: zeroCostMultiplier }), [
+      {
+        _tag: 'InvalidInteger',
+        expected: 'positive-unsigned-integer',
+        evidence: { kind: 'simulation', field: 'costMultiplierMicros', value: '0' },
+      },
+    ])
+
+    const firstChange = evaluation.simulation.cashChanges[0]
+    const malformedCash: SimulationTrace = {
+      ...evaluation.simulation,
+      cashChanges: evaluation.simulation.cashChanges.map((change, index) =>
+        index === 0 ? { ...change, amountMicros: '1.5' } : change,
+      ),
+    }
+    expectExactIssues(reconcile({ simulation: malformedCash }), [
+      {
+        _tag: 'InvalidInteger',
+        expected: 'signed-integer',
+        evidence: {
+          kind: 'cash-change',
+          cashChangeId: firstChange.id,
+          field: 'amountMicros',
+          value: '1.5',
+        },
+      },
+    ])
+  })
+
+  test('retains canonicalization facts and the original cause without throwing', () => {
+    const decisionIndex = evaluation.events.findIndex((event) => event.kind === 'decision')
+    const decision = evaluation.events[decisionIndex]
+    assert(decision?.kind === 'decision', 'evaluation fixture must contain a decision')
+    const events = evaluation.events.map((event, index) =>
+      index === decisionIndex ? { ...decision, targetWeights: { ...decision.targetWeights, ['\ud800']: 0 } } : event,
+    )
+    const run = () => reconcile({ events })
+    expect(run).not.toThrow()
+    const issue = expectIssue(run(), {
+      _tag: 'InvalidIdentity',
+      evidence: expect.objectContaining({ kind: 'decision', id: decision.id }),
+      problem: expect.objectContaining({ _tag: 'CanonicalizationFailed' }),
+    })
+    assert(issue._tag === 'InvalidIdentity', 'canonicalization must produce an identity issue')
+    assert(issue.problem._tag === 'CanonicalizationFailed', 'identity issue must retain its cause')
+    expect(issue.problem.cause).toBeInstanceOf(TypeError)
+    expect(Object.isFrozen(issue.problem)).toBe(true)
+    expect(Object.isFrozen(issue.problem.cause as object)).toBe(false)
+
+    const hostileCause = Object.create(null)
+    Object.defineProperty(hostileCause, Symbol.toPrimitive, {
+      value: () => {
+        throw new TypeError('cause cannot be rendered')
+      },
+    })
+    const render = () =>
+      renderSimulationReconciliationIssue({
+        _tag: 'InvalidIdentity',
+        evidence: { kind: 'decision', id: evaluation.runId, signalDate: '2026-01-30' },
+        problem: { _tag: 'CanonicalizationFailed', cause: hostileCause },
+      })
+    expect(render).not.toThrow()
+    expect(render()).toEndWith('unrenderable cause')
+  })
+
+  test('captures canonical calculation failures without duplicating execution-model validation', () => {
+    const zeroPriceIncrement: SimulationTrace = {
+      ...evaluation.simulation,
+      executionModel: {
+        ...evaluation.simulation.executionModel,
+        precision: { ...evaluation.simulation.executionModel.precision, priceIncrementMicros: '0' },
+      },
+    }
+    const priceRun = () => reconcile({ simulation: zeroPriceIncrement })
+    expect(priceRun).not.toThrow()
+    const fillIssue = expectIssue(priceRun(), {
+      _tag: 'ComputationFailed',
+      computation: expect.objectContaining({ _tag: 'FillTerms' }),
+    })
+    assert(fillIssue._tag === 'ComputationFailed', 'fill calculation must retain its failure')
+    expect(Object.isFrozen(fillIssue.computation)).toBe(true)
+    expect(Reflect.set(fillIssue.computation, 'costMultiplierMicros', '0')).toBe(false)
+    expect(fillIssue.cause).toEqual(expect.objectContaining({ message: 'price increment must be positive' }))
+    expect(Object.isFrozen(fillIssue.cause as object)).toBe(false)
+
+    const zeroFeeIncrement: SimulationTrace = {
+      ...evaluation.simulation,
+      executionModel: {
+        ...evaluation.simulation.executionModel,
+        fees: { ...evaluation.simulation.executionModel.fees, roundingIncrementMicros: '0' },
+      },
+    }
+    const feeRun = () => reconcile({ simulation: zeroFeeIncrement })
+    expect(feeRun).not.toThrow()
+    expectIssue(feeRun(), {
+      _tag: 'ComputationFailed',
+      computation: expect.objectContaining({ _tag: 'FeeSchedule' }),
+    })
+  })
+
+  test('preserves fail-fast baseline precedence for multiply malformed fill and fee evidence', () => {
+    const fillIndex = evaluation.events.findIndex((event) => event.kind === 'fill')
+    const fill = evaluation.events[fillIndex]
+    assert(fill?.kind === 'fill', 'evaluation fixture must contain a fill')
+    const order = evaluation.simulation.orders.find((candidate) => candidate.id === fill.orderId)
+    assert(order !== undefined, 'fill must retain its order')
+
+    const badBindingEvents = evaluation.events.map((event, index) =>
+      index === fillIndex ? { ...fill, decisionId: 'f'.repeat(64), referencePriceMicros: 'bad' } : event,
+    )
+    expectExactIssues(reconcile({ events: badBindingEvents }), [
+      {
+        _tag: 'EvidenceMismatch',
+        problem: {
+          _tag: 'FillBinding',
+          fillId: fill.id,
+          orderId: order.id,
+          field: 'decisionId',
+          actual: 'f'.repeat(64),
+          expected: order.decisionId,
+        },
+      },
+    ])
+
+    const badQuantityEvents = evaluation.events.map((event, index) =>
+      index === fillIndex ? { ...fill, quantityMicros: (BigInt(fill.quantityMicros) + 1n).toString() } : event,
+    )
+    const badQuantitySimulation: SimulationTrace = {
+      ...evaluation.simulation,
+      executionModel: {
+        ...evaluation.simulation.executionModel,
+        precision: { ...evaluation.simulation.executionModel.precision, priceIncrementMicros: '0' },
+      },
+    }
+    expectExactIssues(reconcile({ events: badQuantityEvents, simulation: badQuantitySimulation }), [
+      {
+        _tag: 'EvidenceMismatch',
+        problem: {
+          _tag: 'FillQuantity',
+          fillId: fill.id,
+          orderId: order.id,
+          actualQuantityMicros: (BigInt(fill.quantityMicros) + 1n).toString(),
+          expectedQuantityMicros: order.filledQuantityMicros,
+        },
+      },
+    ])
+
+    const feeIndex = evaluation.events.findIndex((event) => event.kind === 'fee')
+    const fee = evaluation.events[feeIndex]
+    assert(fee?.kind === 'fee', 'evaluation fixture must contain a fee')
+    const badFeeEvents = evaluation.events.map((event, index) =>
+      index === feeIndex ? { ...fee, totalMicros: (BigInt(fee.totalMicros) + 1n).toString() } : event,
+    )
+    const badFeeSimulation: SimulationTrace = {
+      ...evaluation.simulation,
+      executionModel: {
+        ...evaluation.simulation.executionModel,
+        fees: { ...evaluation.simulation.executionModel.fees, roundingIncrementMicros: '0' },
+      },
+    }
+    const expectedFeeTotal = (
+      BigInt(fee.commissionMicros) +
+      BigInt(fee.secMicros) +
+      BigInt(fee.tafMicros) +
+      BigInt(fee.catMicros)
+    ).toString()
+    expectExactIssues(reconcile({ events: badFeeEvents, simulation: badFeeSimulation }), [
+      {
+        _tag: 'EvidenceMismatch',
+        problem: {
+          _tag: 'FeeComponents',
+          feeId: fee.id,
+          actualTotalMicros: (BigInt(fee.totalMicros) + 1n).toString(),
+          expectedTotalMicros: expectedFeeTotal,
+        },
+      },
+    ])
+  })
+
+  test('preserves fail-fast baseline precedence for cash, yield, and position evidence', () => {
+    const firstChange = evaluation.simulation.cashChanges[0]
+    const wrongKind = firstChange.sourceKind === 'fill' ? 'fee' : 'fill'
     const badCash: SimulationTrace = {
       ...evaluation.simulation,
       cashChanges: evaluation.simulation.cashChanges.map((change, index) =>
-        index === 0 ? { ...change, amountMicros: (BigInt(firstChange.amountMicros) + 1n).toString() } : change,
+        index === 0 ? { ...change, sourceKind: wrongKind, amountMicros: 'bad' } : change,
       ),
     }
-    expect(() => reconcile({ simulation: badCash })).toThrow('cash change')
+    const firstSource = evaluation.events.find((event) => event.id === firstChange.sourceId)
+    assert(firstSource !== undefined && firstSource.kind !== 'decision', 'cash change must retain its monetary source')
+    expectExactIssues(reconcile({ simulation: badCash }), [
+      {
+        _tag: 'EvidenceMismatch',
+        problem: {
+          _tag: 'CashChange',
+          cashChangeId: firstChange.id,
+          sourceId: firstSource.id,
+          field: 'sourceKind',
+          actual: wrongKind,
+          expected: firstSource.kind,
+        },
+      },
+    ])
 
-    const firstFillIndex = evaluation.events.findIndex((event) => event.kind === 'fill')
-    const firstFill = evaluation.events[firstFillIndex]
-    if (firstFill.kind !== 'fill') throw new Error('fixture has no fill')
-    const badFill = evaluation.events.map((event, index) =>
-      index === firstFillIndex
-        ? { ...firstFill, quantityMicros: (BigInt(firstFill.quantityMicros) + 1n).toString() }
-        : event,
-    )
-    expect(() => reconcile({ events: badFill })).toThrow('order')
-
-    const secondFillIndex = evaluation.events.findIndex(
-      (event, index) => index > firstFillIndex && event.kind === 'fill',
-    )
-    const secondFill = evaluation.events[secondFillIndex]
-    if (secondFill.kind !== 'fill') throw new Error('fixture has only one fill')
-    const duplicateFillForOrder = evaluation.events.map((event, index) =>
-      index === secondFillIndex ? { ...secondFill, orderId: firstFill.orderId } : event,
-    )
-    expect(() => reconcile({ events: duplicateFillForOrder })).toThrow('multiple fills')
-
-    const changedNotionalPayload = {
-      ...firstFill,
-      notionalMicros: (BigInt(firstFill.notionalMicros) + 20_000n).toString(),
+    const yieldProtocol: Protocol = {
+      ...fixtureProtocol,
+      executionModel: {
+        ...fixtureProtocol.executionModel,
+        cash: { ...fixtureProtocol.executionModel.cash, annualYieldBps: 50 },
+      },
     }
-    const { id: _, kind: __, ...fillIdentityPayload } = changedNotionalPayload
-    const badNotional = evaluation.events.map((event, index) =>
-      index === firstFillIndex
-        ? {
-            ...changedNotionalPayload,
-            id: canonicalHashV1({ runId: evaluation.runId, kind: 'fill', ...fillIdentityPayload }),
-          }
+    const yieldResult = evaluateRiskBalancedTrend(
+      snapshot.bars,
+      snapshot.manifest,
+      yieldProtocol,
+      makeTestProvenance(yieldProtocol),
+    )
+    assert(Result.isSuccess(yieldResult), 'cash-yield evaluation fixture must succeed')
+    const yieldEventIndex = yieldResult.success.events.findIndex((event) => event.kind === 'cash-yield')
+    const yieldEvent = yieldResult.success.events[yieldEventIndex]
+    assert(yieldEvent?.kind === 'cash-yield', 'cash-yield fixture must contain a yield event')
+    const malformedYieldEvents = yieldResult.success.events.map((event, index) =>
+      index === yieldEventIndex
+        ? { ...yieldEvent, annualYieldBps: yieldEvent.annualYieldBps + 1, elapsedDays: -1 }
         : event,
     )
-    expect(() => reconcile({ events: badNotional })).toThrow('notional diverges')
+    const yieldReconciliation = reconcileMarkedEquity({
+      runId: yieldResult.success.runId,
+      initialCapitalMicros: yieldResult.success.initialCapitalMicros,
+      evaluatorTotalFeesMicros: yieldResult.success.strategy.totalFeesMicros,
+      evaluatorEndingEquityMicros: yieldResult.success.strategy.endingEquityMicros,
+      events: malformedYieldEvents,
+      simulation: yieldResult.success.simulation,
+    })
+    expectExactIssues(yieldReconciliation, [
+      {
+        _tag: 'EvidenceMismatch',
+        problem: {
+          _tag: 'CashYield',
+          cashYieldId: yieldEvent.id,
+          field: 'annualYieldBps',
+          actual: String(yieldEvent.annualYieldBps + 1),
+          expected: String(yieldResult.success.simulation.executionModel.cash.annualYieldBps),
+        },
+      },
+    ])
+    const invalidElapsedEvents = yieldResult.success.events.map((event, index) =>
+      index === yieldEventIndex ? { ...yieldEvent, elapsedDays: -1 } : event,
+    )
+    const invalidElapsed = () =>
+      reconcileMarkedEquity({
+        runId: yieldResult.success.runId,
+        initialCapitalMicros: yieldResult.success.initialCapitalMicros,
+        evaluatorTotalFeesMicros: yieldResult.success.strategy.totalFeesMicros,
+        evaluatorEndingEquityMicros: yieldResult.success.strategy.endingEquityMicros,
+        events: invalidElapsedEvents,
+        simulation: yieldResult.success.simulation,
+      })
+    expect(invalidElapsed).not.toThrow()
+    expectIssue(invalidElapsed(), {
+      _tag: 'ComputationFailed',
+      computation: expect.objectContaining({ _tag: 'CashYield', cashYieldId: yieldEvent.id }),
+    })
 
-    const firstFeeIndex = evaluation.events.findIndex((event) => event.kind === 'fee')
-    const firstFee = evaluation.events[firstFeeIndex]
-    if (firstFee.kind !== 'fee') throw new Error('fixture has no fee event')
-    const changedFeePayload = {
-      ...firstFee,
-      secMicros: (BigInt(firstFee.secMicros) + 10_000n).toString(),
-      totalMicros: (BigInt(firstFee.totalMicros) + 10_000n).toString(),
+    const markIndex = evaluation.simulation.dailyMarks.findIndex((mark) =>
+      mark.positions.some((position) => position.quantityMicros !== '0'),
+    )
+    assert(markIndex >= 0, 'evaluation fixture must contain a marked position')
+    const positionIndex = evaluation.simulation.dailyMarks[markIndex].positions.findIndex(
+      (position) => position.quantityMicros !== '0',
+    )
+    const position = evaluation.simulation.dailyMarks[markIndex].positions[positionIndex]
+    const badPosition: SimulationTrace = {
+      ...evaluation.simulation,
+      dailyMarks: evaluation.simulation.dailyMarks.map((mark, index) =>
+        index === markIndex
+          ? {
+              ...mark,
+              positions: mark.positions.map((candidate, candidateIndex) =>
+                candidateIndex === positionIndex
+                  ? {
+                      ...candidate,
+                      quantityMicros: (BigInt(candidate.quantityMicros) + 1n).toString(),
+                      costBasisMicros: 'bad',
+                      marketValueMicros: 'bad',
+                    }
+                  : candidate,
+              ),
+            }
+          : mark,
+      ),
     }
-    const { id: ___, kind: ____, ...feeIdentityPayload } = changedFeePayload
-    const badFee = evaluation.events.map((event, index) =>
-      index === firstFeeIndex
-        ? {
-            ...changedFeePayload,
-            id: canonicalHashV1({ runId: evaluation.runId, kind: 'fee', ...feeIdentityPayload }),
-          }
-        : event,
-    )
-    expect(() => reconcile({ events: badFee })).toThrow('SEC component diverges')
+    const positionMark = evaluation.simulation.dailyMarks[markIndex]
+    expectExactIssues(reconcile({ simulation: badPosition }), [
+      {
+        _tag: 'EvidenceMismatch',
+        problem: {
+          _tag: 'PositionMark',
+          sessionDate: positionMark.sessionDate,
+          field: 'quantityMicros',
+          symbol: position.symbol,
+          actualMicros: (BigInt(position.quantityMicros) + 1n).toString(),
+          expectedMicros: position.quantityMicros,
+        },
+      },
+    ])
+  })
 
-    expect(() =>
-      reconcile({
-        evaluatorTotalFeesMicros: (
-          BigInt(evaluation.strategy.totalFeesMicros) +
-          MARKED_EQUITY_TOLERANCE_MICROS +
-          1n
-        ).toString(),
+  test('accumulates independent quantity and market-value comparisons for one position', () => {
+    const markIndex = evaluation.simulation.dailyMarks.findIndex((mark) =>
+      mark.positions.some((position) => position.quantityMicros !== '0'),
+    )
+    assert(markIndex >= 0, 'evaluation fixture must contain a marked position')
+    const positionIndex = evaluation.simulation.dailyMarks[markIndex].positions.findIndex(
+      (position) => position.quantityMicros !== '0',
+    )
+    const position = evaluation.simulation.dailyMarks[markIndex].positions[positionIndex]
+    const simulation: SimulationTrace = {
+      ...evaluation.simulation,
+      dailyMarks: evaluation.simulation.dailyMarks.map((mark, index) =>
+        index === markIndex
+          ? {
+              ...mark,
+              positions: mark.positions.map((candidate, candidateIndex) =>
+                candidateIndex === positionIndex
+                  ? {
+                      ...candidate,
+                      quantityMicros: (BigInt(candidate.quantityMicros) + 1n).toString(),
+                      marketValueMicros: (BigInt(candidate.marketValueMicros) + 1n).toString(),
+                    }
+                  : candidate,
+              ),
+            }
+          : mark,
+      ),
+    }
+    const mark = evaluation.simulation.dailyMarks[markIndex]
+    expectExactIssues(reconcile({ simulation }), [
+      {
+        _tag: 'EvidenceMismatch',
+        problem: {
+          _tag: 'PositionMark',
+          sessionDate: mark.sessionDate,
+          field: 'quantityMicros',
+          symbol: position.symbol,
+          actualMicros: (BigInt(position.quantityMicros) + 1n).toString(),
+          expectedMicros: position.quantityMicros,
+        },
+      },
+      {
+        _tag: 'EvidenceMismatch',
+        problem: {
+          _tag: 'PositionMark',
+          sessionDate: mark.sessionDate,
+          field: 'marketValueMicros',
+          symbol: position.symbol,
+          actualMicros: (BigInt(position.marketValueMicros) + 1n).toString(),
+          expectedMicros: position.marketValueMicros,
+        },
+      },
+    ])
+  })
+
+  test('reaches every structural leaf in the public issue algebra', () => {
+    const observed = new Set<IssueLeaf>()
+    const capture = (expected: IssueLeaf, result: SimulationReconciliationResult): void => {
+      assert(Result.isFailure(result), `expected ${expected} fixture to fail`)
+      const actual = result.failure.map(issueLeaf)
+      expect(actual).toContain(expected)
+      const issue = result.failure.find((candidate) => issueLeaf(candidate) === expected)
+      assert(issue !== undefined, `expected ${expected} issue`)
+      expect(Object.isFrozen(issue)).toBe(true)
+      if (issue._tag === 'InvalidInteger' || issue._tag === 'InvalidIdentity') {
+        expect(Object.isFrozen(issue.evidence)).toBe(true)
+      }
+      if (issue._tag === 'InvalidIdentity') expect(Object.isFrozen(issue.problem)).toBe(true)
+      if (
+        issue._tag === 'MissingReference' ||
+        issue._tag === 'EvidenceMismatch' ||
+        issue._tag === 'InvalidEvidenceState' ||
+        issue._tag === 'IncompleteEvidence'
+      ) {
+        expect(Object.isFrozen(issue.problem)).toBe(true)
+      }
+      if (
+        issue._tag === 'InvalidEvidenceState' &&
+        (issue.problem._tag === 'DuplicateMarkedPosition' || issue.problem._tag === 'UnsortedMarkedPositions')
+      ) {
+        expect(Object.isFrozen(issue.problem.symbols)).toBe(true)
+      }
+      if (issue._tag === 'ComputationFailed') expect(Object.isFrozen(issue.computation)).toBe(true)
+      observed.add(expected)
+    }
+
+    const empty = makeEmptyInput()
+    const roundTrip = makeRoundTripInput(1)
+    const roundTripDecision = roundTrip.events.find((event) => event.kind === 'decision')
+    const roundTripFills = roundTrip.events.filter((event) => event.kind === 'fill')
+    const buyFill = roundTripFills.find((event) => event.side === 'buy')
+    const sellFill = roundTripFills.find((event) => event.side === 'sell')
+    assert(roundTripDecision?.kind === 'decision', 'round-trip fixture must contain a decision')
+    assert(buyFill !== undefined && sellFill !== undefined, 'round-trip fixture must contain buy and sell fills')
+    const firstOrder = roundTrip.simulation.orders[0]
+    const firstChange = roundTrip.simulation.cashChanges[0]
+
+    capture('InvalidInteger/unsigned-integer', reconcileMarkedEquity({ ...empty, initialCapitalMicros: 'bad' }))
+    capture(
+      'InvalidInteger/positive-unsigned-integer',
+      reconcileMarkedEquity({
+        ...empty,
+        simulation: { ...empty.simulation, costMultiplierMicros: '0' },
       }),
-    ).toThrow('reconstructed fees exceed')
+    )
+    capture(
+      'InvalidInteger/signed-integer',
+      reconcileMarkedEquity({
+        ...roundTrip,
+        simulation: {
+          ...roundTrip.simulation,
+          cashChanges: [{ ...firstChange, amountMicros: 'bad' }, ...roundTrip.simulation.cashChanges.slice(1)],
+        },
+      }),
+    )
+    capture('InvalidIdentity/InvalidFormat', reconcileMarkedEquity({ ...empty, runId: 'bad' }))
+    capture(
+      'InvalidIdentity/HashMismatch',
+      reconcileMarkedEquity({
+        ...roundTrip,
+        events: roundTrip.events.map((event) =>
+          event.id === roundTripDecision.id
+            ? { ...roundTripDecision, targetWeights: { ...roundTripDecision.targetWeights, EXTRA: 1 } }
+            : event,
+        ),
+      }),
+    )
+    capture(
+      'InvalidIdentity/CanonicalizationFailed',
+      reconcileMarkedEquity({
+        ...roundTrip,
+        events: roundTrip.events.map((event) =>
+          event.id === roundTripDecision.id
+            ? { ...roundTripDecision, targetWeights: { ...roundTripDecision.targetWeights, ['\ud800']: 0 } }
+            : event,
+        ),
+      }),
+    )
+
+    capture(
+      'MissingReference/OrderDecision',
+      reconcileMarkedEquity({
+        ...roundTrip,
+        simulation: {
+          ...roundTrip.simulation,
+          orders: [{ ...firstOrder, decisionId: 'f'.repeat(64) }, ...roundTrip.simulation.orders.slice(1)],
+        },
+      }),
+    )
+    capture(
+      'MissingReference/FillOrder',
+      reconcileMarkedEquity({
+        ...roundTrip,
+        events: [...roundTrip.events, { ...buyFill, id: 'e'.repeat(64), orderId: 'd'.repeat(64) }],
+      }),
+    )
+    capture(
+      'MissingReference/MonetaryEventCashChange',
+      reconcileMarkedEquity({
+        ...roundTrip,
+        simulation: {
+          ...roundTrip.simulation,
+          cashChanges: [{ ...firstChange, sourceId: 'f'.repeat(64) }, ...roundTrip.simulation.cashChanges.slice(1)],
+        },
+      }),
+    )
+
+    capture(
+      'EvidenceMismatch/OrderExecutionSession',
+      reconcileMarkedEquity({
+        ...roundTrip,
+        simulation: {
+          ...roundTrip.simulation,
+          orders: [{ ...firstOrder, sessionDate: '2026-02-02' }, ...roundTrip.simulation.orders.slice(1)],
+        },
+      }),
+    )
+    capture(
+      'EvidenceMismatch/FillBinding',
+      reconcileMarkedEquity({
+        ...roundTrip,
+        events: roundTrip.events.map((event) =>
+          event.id === buyFill.id ? { ...buyFill, decisionId: 'f'.repeat(64) } : event,
+        ),
+      }),
+    )
+    capture(
+      'EvidenceMismatch/FillQuantity',
+      reconcileMarkedEquity({
+        ...roundTrip,
+        events: roundTrip.events.map((event) =>
+          event.id === buyFill.id
+            ? { ...buyFill, quantityMicros: (BigInt(buyFill.quantityMicros) + 1n).toString() }
+            : event,
+        ),
+      }),
+    )
+    capture(
+      'EvidenceMismatch/FillTerms',
+      reconcileMarkedEquity({
+        ...roundTrip,
+        events: roundTrip.events.map((event) =>
+          event.id === buyFill.id
+            ? { ...buyFill, notionalMicros: (BigInt(buyFill.notionalMicros) + 1n).toString() }
+            : event,
+        ),
+      }),
+    )
+
+    const fee = firstEvent('fee')
+    const feeIndex = evaluation.events.findIndex((event) => event.id === fee.id)
+    capture(
+      'EvidenceMismatch/FeeComponents',
+      reconcile({
+        events: evaluation.events.map((event, index) =>
+          index === feeIndex ? { ...fee, totalMicros: (BigInt(fee.totalMicros) + 1n).toString() } : event,
+        ),
+      }),
+    )
+    capture(
+      'EvidenceMismatch/FeeSchedule',
+      reconcile({
+        events: evaluation.events.map((event, index) =>
+          index === feeIndex
+            ? {
+                ...fee,
+                commissionMicros: (BigInt(fee.commissionMicros) + 1n).toString(),
+                totalMicros: (BigInt(fee.totalMicros) + 1n).toString(),
+              }
+            : event,
+        ),
+      }),
+    )
+    capture(
+      'EvidenceMismatch/CashChange',
+      reconcileMarkedEquity({
+        ...roundTrip,
+        simulation: {
+          ...roundTrip.simulation,
+          cashChanges: [{ ...firstChange, sourceKind: 'fee' }, ...roundTrip.simulation.cashChanges.slice(1)],
+        },
+      }),
+    )
+
+    const yieldProtocol: Protocol = {
+      ...fixtureProtocol,
+      executionModel: {
+        ...fixtureProtocol.executionModel,
+        cash: { ...fixtureProtocol.executionModel.cash, annualYieldBps: 50 },
+      },
+    }
+    const yieldResult = evaluateRiskBalancedTrend(
+      snapshot.bars,
+      snapshot.manifest,
+      yieldProtocol,
+      makeTestProvenance(yieldProtocol),
+    )
+    assert(Result.isSuccess(yieldResult), 'cash-yield leaf fixture must evaluate')
+    const yieldEvent = yieldResult.success.events.find((event) => event.kind === 'cash-yield')
+    assert(yieldEvent?.kind === 'cash-yield', 'cash-yield leaf fixture must contain a yield event')
+    const reconcileYield = (replacement: EvaluationEvent): SimulationReconciliationResult =>
+      reconcileMarkedEquity({
+        runId: yieldResult.success.runId,
+        initialCapitalMicros: yieldResult.success.initialCapitalMicros,
+        evaluatorTotalFeesMicros: yieldResult.success.strategy.totalFeesMicros,
+        evaluatorEndingEquityMicros: yieldResult.success.strategy.endingEquityMicros,
+        events: yieldResult.success.events.map((event) => (event.id === yieldEvent.id ? replacement : event)),
+        simulation: yieldResult.success.simulation,
+      })
+    capture(
+      'EvidenceMismatch/CashYield',
+      reconcileYield({ ...yieldEvent, annualYieldBps: yieldEvent.annualYieldBps + 1 }),
+    )
+    capture(
+      'EvidenceMismatch/DailyMark',
+      reconcileMarkedEquity({
+        ...empty,
+        simulation: {
+          ...empty.simulation,
+          dailyMarks: [{ ...empty.simulation.dailyMarks[0], turnoverMicros: '1' }],
+        },
+      }),
+    )
+    const positionMarkIndex = evaluation.simulation.dailyMarks.findIndex((mark) => mark.positions.length > 0)
+    const positionMark = evaluation.simulation.dailyMarks[positionMarkIndex]
+    const markedPosition = positionMark.positions[0]
+    capture(
+      'EvidenceMismatch/PositionMark',
+      reconcile({
+        simulation: {
+          ...evaluation.simulation,
+          dailyMarks: evaluation.simulation.dailyMarks.map((mark, index) =>
+            index === positionMarkIndex
+              ? {
+                  ...mark,
+                  positions: [
+                    {
+                      ...markedPosition,
+                      marketValueMicros: (BigInt(markedPosition.marketValueMicros) + 1n).toString(),
+                    },
+                    ...mark.positions.slice(1),
+                  ],
+                }
+              : mark,
+          ),
+        },
+      }),
+    )
+
+    capture(
+      'InvalidEvidenceState/DuplicateIdentity',
+      reconcileMarkedEquity({ ...roundTrip, events: [...roundTrip.events, roundTripDecision] }),
+    )
+    capture(
+      'InvalidEvidenceState/DuplicateFillForOrder',
+      reconcileMarkedEquity({
+        ...roundTrip,
+        events: [...roundTrip.events, { ...buyFill, id: 'f'.repeat(64) }],
+      }),
+    )
+    capture(
+      'InvalidEvidenceState/DuplicateCashChangeForEvent',
+      reconcileMarkedEquity({
+        ...roundTrip,
+        simulation: {
+          ...roundTrip.simulation,
+          cashChanges: [...roundTrip.simulation.cashChanges, { ...firstChange, id: 'f'.repeat(64) }],
+        },
+      }),
+    )
+    capture(
+      'InvalidEvidenceState/InvalidOrder',
+      reconcileMarkedEquity({
+        ...roundTrip,
+        simulation: {
+          ...roundTrip.simulation,
+          orders: [
+            {
+              ...firstOrder,
+              status: 'rejected',
+              rejectionReason: 'zero-after-rounding',
+              unfilledRemainder: 'canceled',
+            },
+            ...roundTrip.simulation.orders.slice(1),
+          ],
+        },
+      }),
+    )
+    capture(
+      'InvalidEvidenceState/InvalidMarkOrder',
+      reconcileMarkedEquity({
+        ...empty,
+        simulation: {
+          ...empty.simulation,
+          dailyMarks: [empty.simulation.dailyMarks[0], { ...empty.simulation.dailyMarks[0] }],
+        },
+      }),
+    )
+    capture(
+      'InvalidEvidenceState/DuplicateMarkedPosition',
+      reconcile({
+        simulation: {
+          ...evaluation.simulation,
+          dailyMarks: evaluation.simulation.dailyMarks.map((mark, index) =>
+            index === positionMarkIndex ? { ...mark, positions: [markedPosition, markedPosition] } : mark,
+          ),
+        },
+      }),
+    )
+    capture(
+      'InvalidEvidenceState/UnsortedMarkedPositions',
+      reconcile({
+        simulation: {
+          ...evaluation.simulation,
+          dailyMarks: evaluation.simulation.dailyMarks.map((mark, index) =>
+            index === positionMarkIndex ? { ...mark, positions: [...mark.positions].reverse() } : mark,
+          ),
+        },
+      }),
+    )
+    capture('InvalidEvidenceState/NegativeCash', reconcileMarkedEquity({ ...roundTrip, initialCapitalMicros: '0' }))
+    capture(
+      'InvalidEvidenceState/NegativeLongPosition',
+      reconcileMarkedEquity({
+        ...roundTrip,
+        events: [roundTripDecision, sellFill, buyFill],
+      }),
+    )
+    capture(
+      'InvalidEvidenceState/DailyOutsideTolerance',
+      reconcileMarkedEquity({
+        ...empty,
+        simulation: {
+          ...empty.simulation,
+          dailyMarks: [
+            {
+              ...empty.simulation.dailyMarks[0],
+              cashMicros: (BigInt(empty.initialCapitalMicros) + 1n).toString(),
+            },
+          ],
+        },
+      }),
+    )
+    capture(
+      'InvalidEvidenceState/FinalOutsideTolerance',
+      reconcileMarkedEquity({
+        ...empty,
+        evaluatorEndingEquityMicros: (BigInt(empty.evaluatorEndingEquityMicros) + 1n).toString(),
+      }),
+    )
+    capture('InvalidEvidenceState/NegativeTolerance', reconcileMarkedEquity({ ...empty, toleranceMicros: -1n }))
+    const unsupportedSimulation = { ...empty.simulation }
+    expect(Reflect.set(unsupportedSimulation, 'schemaVersion', 'bayn.simulation-trace.v2')).toBe(true)
+    capture(
+      'InvalidEvidenceState/UnsupportedSimulationSchema',
+      reconcileMarkedEquity({ ...empty, simulation: unsupportedSimulation }),
+    )
+
+    capture(
+      'IncompleteEvidence/EmptyDailyMarks',
+      reconcileMarkedEquity({ ...empty, simulation: { ...empty.simulation, dailyMarks: [] } }),
+    )
+    capture(
+      'IncompleteEvidence/CashChangeCountMismatch',
+      reconcileMarkedEquity({
+        ...roundTrip,
+        simulation: { ...roundTrip.simulation, cashChanges: roundTrip.simulation.cashChanges.slice(1) },
+      }),
+    )
+    capture(
+      'IncompleteEvidence/MissingSessionMark',
+      reconcileMarkedEquity({
+        ...roundTrip,
+        simulation: {
+          ...roundTrip.simulation,
+          dailyMarks: [{ ...roundTrip.simulation.dailyMarks[0], sessionDate: '2026-02-02' }],
+        },
+      }),
+    )
+    const nonzeroPositionIndex = positionMark.positions.findIndex((position) => position.quantityMicros !== '0')
+    assert(nonzeroPositionIndex >= 0, 'position leaf fixture must contain an open position')
+    capture(
+      'IncompleteEvidence/MissingOpenPositionMark',
+      reconcile({
+        simulation: {
+          ...evaluation.simulation,
+          dailyMarks: evaluation.simulation.dailyMarks.map((mark, index) =>
+            index === positionMarkIndex
+              ? {
+                  ...mark,
+                  positions: mark.positions.filter((_, positionIndex) => positionIndex !== nonzeroPositionIndex),
+                }
+              : mark,
+          ),
+        },
+      }),
+    )
+    capture(
+      'IncompleteEvidence/MonetaryEventsAfterFinalMark',
+      reconcileMarkedEquity({
+        ...roundTrip,
+        simulation: {
+          ...roundTrip.simulation,
+          dailyMarks: [{ ...empty.simulation.dailyMarks[0], sessionDate: '2026-01-30' }],
+        },
+      }),
+    )
+
+    capture(
+      'ComputationFailed/FillTerms',
+      reconcileMarkedEquity({
+        ...roundTrip,
+        simulation: {
+          ...roundTrip.simulation,
+          executionModel: {
+            ...roundTrip.simulation.executionModel,
+            precision: { ...roundTrip.simulation.executionModel.precision, priceIncrementMicros: '0' },
+          },
+        },
+      }),
+    )
+    capture(
+      'ComputationFailed/FeeSchedule',
+      reconcile({
+        simulation: {
+          ...evaluation.simulation,
+          executionModel: {
+            ...evaluation.simulation.executionModel,
+            fees: { ...evaluation.simulation.executionModel.fees, roundingIncrementMicros: '0' },
+          },
+        },
+      }),
+    )
+    capture('ComputationFailed/CashYield', reconcileYield({ ...yieldEvent, elapsedDays: -1 }))
+
+    const everyLeaf = [
+      'InvalidInteger/unsigned-integer',
+      'InvalidInteger/positive-unsigned-integer',
+      'InvalidInteger/signed-integer',
+      'InvalidIdentity/InvalidFormat',
+      'InvalidIdentity/HashMismatch',
+      'InvalidIdentity/CanonicalizationFailed',
+      'MissingReference/OrderDecision',
+      'MissingReference/FillOrder',
+      'MissingReference/MonetaryEventCashChange',
+      'EvidenceMismatch/OrderExecutionSession',
+      'EvidenceMismatch/FillBinding',
+      'EvidenceMismatch/FillQuantity',
+      'EvidenceMismatch/FillTerms',
+      'EvidenceMismatch/FeeComponents',
+      'EvidenceMismatch/FeeSchedule',
+      'EvidenceMismatch/CashChange',
+      'EvidenceMismatch/CashYield',
+      'EvidenceMismatch/DailyMark',
+      'EvidenceMismatch/PositionMark',
+      'InvalidEvidenceState/DuplicateIdentity',
+      'InvalidEvidenceState/DuplicateFillForOrder',
+      'InvalidEvidenceState/DuplicateCashChangeForEvent',
+      'InvalidEvidenceState/InvalidOrder',
+      'InvalidEvidenceState/InvalidMarkOrder',
+      'InvalidEvidenceState/DuplicateMarkedPosition',
+      'InvalidEvidenceState/UnsortedMarkedPositions',
+      'InvalidEvidenceState/NegativeCash',
+      'InvalidEvidenceState/NegativeLongPosition',
+      'InvalidEvidenceState/DailyOutsideTolerance',
+      'InvalidEvidenceState/FinalOutsideTolerance',
+      'InvalidEvidenceState/NegativeTolerance',
+      'InvalidEvidenceState/UnsupportedSimulationSchema',
+      'IncompleteEvidence/EmptyDailyMarks',
+      'IncompleteEvidence/CashChangeCountMismatch',
+      'IncompleteEvidence/MissingSessionMark',
+      'IncompleteEvidence/MissingOpenPositionMark',
+      'IncompleteEvidence/MonetaryEventsAfterFinalMark',
+      'ComputationFailed/FillTerms',
+      'ComputationFailed/FeeSchedule',
+      'ComputationFailed/CashYield',
+    ] as const satisfies readonly IssueLeaf[]
+    expect(everyLeaf).toHaveLength(40)
+    expect(new Set(everyLeaf).size).toBe(everyLeaf.length)
+    expect([...observed].sort()).toEqual([...everyLeaf].sort())
+  })
+
+  test('classifies lineage, schedule, completeness, and tolerance failures', () => {
+    const fill = firstEvent('fill')
+    const changedNotional = { ...fill, notionalMicros: (BigInt(fill.notionalMicros) + 20_000n).toString() }
+    const { id: _, kind: __, ...fillPayload } = changedNotional
+    const events = evaluation.events.map((event) =>
+      event.id === fill.id
+        ? { ...changedNotional, id: canonicalHashV1({ runId: evaluation.runId, kind: 'fill', ...fillPayload }) }
+        : event,
+    )
+    expectIssue(reconcile({ events }), {
+      _tag: 'EvidenceMismatch',
+      problem: expect.objectContaining({ _tag: 'FillTerms', field: 'notionalMicros' }),
+    })
 
     const duplicateOrder: SimulationTrace = {
       ...evaluation.simulation,
       orders: [...evaluation.simulation.orders, evaluation.simulation.orders[0]],
     }
-    expect(() => reconcile({ simulation: duplicateOrder })).toThrow('duplicate ID')
+    expectIssue(reconcile({ simulation: duplicateOrder }), {
+      _tag: 'InvalidEvidenceState',
+      problem: expect.objectContaining({ _tag: 'DuplicateIdentity', entity: 'order' }),
+    })
 
-    const firstMarkedPosition = evaluation.simulation.dailyMarks.findIndex((mark) =>
-      mark.positions.some((position) => position.quantityMicros !== '0'),
-    )
-    const badMark: SimulationTrace = {
-      ...evaluation.simulation,
-      dailyMarks: evaluation.simulation.dailyMarks.map((mark, index) =>
-        index === firstMarkedPosition
-          ? {
-              ...mark,
-              positions: mark.positions.map((position, positionIndex) =>
-                positionIndex === 0
-                  ? { ...position, marketValueMicros: (BigInt(position.marketValueMicros) + 20_000n).toString() }
-                  : position,
-              ),
-            }
-          : mark,
-      ),
-    }
-    expect(() => reconcile({ simulation: badMark })).toThrow('position value')
-
-    const badQuantity: SimulationTrace = {
-      ...evaluation.simulation,
-      dailyMarks: evaluation.simulation.dailyMarks.map((mark, index) =>
-        index === firstMarkedPosition
-          ? {
-              ...mark,
-              positions: mark.positions.map((position, positionIndex) =>
-                positionIndex === 0
-                  ? { ...position, quantityMicros: (BigInt(position.quantityMicros) + 1_000n).toString() }
-                  : position,
-              ),
-            }
-          : mark,
-      ),
-    }
-    expect(() => reconcile({ simulation: badQuantity })).toThrow('position quantity')
-
-    const fillSession = firstFill.sessionDate
     const missingMark: SimulationTrace = {
       ...evaluation.simulation,
-      dailyMarks: evaluation.simulation.dailyMarks.filter((mark) => mark.sessionDate !== fillSession),
+      dailyMarks: evaluation.simulation.dailyMarks.filter((mark) => mark.sessionDate !== fill.sessionDate),
     }
-    expect(() => reconcile({ simulation: missingMark })).toThrow('has no mark for its session')
-  })
+    expectIssue(reconcile({ simulation: missingMark }), {
+      _tag: 'IncompleteEvidence',
+      problem: expect.objectContaining({ _tag: 'MissingSessionMark' }),
+    })
 
-  test('enforces the declared final-equity tolerance at the micro boundary', () => {
     const baseline = reconcile()
-    const reconstructed = BigInt(baseline.reconciliation.reconstructedEndingEquityMicros)
+    assert(Result.isSuccess(baseline), 'baseline must reconcile successfully')
+    const reconstructed = BigInt(baseline.success.reconciliation.reconstructedEndingEquityMicros)
     const atBoundary = reconcile({
       evaluatorEndingEquityMicros: (reconstructed + MARKED_EQUITY_TOLERANCE_MICROS).toString(),
     })
-    expect(atBoundary.reconciliation.differenceMicros).toBe(MARKED_EQUITY_TOLERANCE_MICROS.toString())
-    expect(() =>
+    assert(Result.isSuccess(atBoundary), 'declared tolerance boundary must succeed')
+    expectIssue(
       reconcile({
         evaluatorEndingEquityMicros: (reconstructed + MARKED_EQUITY_TOLERANCE_MICROS + 1n).toString(),
       }),
-    ).toThrow('final marked equity exceeds')
+      {
+        _tag: 'InvalidEvidenceState',
+        problem: expect.objectContaining({ _tag: 'FinalOutsideTolerance', measure: 'final-equity' }),
+      },
+    )
   })
 })

--- a/services/bayn/src/simulation-reconciliation.ts
+++ b/services/bayn/src/simulation-reconciliation.ts
@@ -1,3 +1,5 @@
+import { Result } from 'effect'
+
 import { accrueCashYield, calculateSessionFees, makeFillTerms, notionalMicros, type FeeInput } from './execution-model'
 import { canonicalHashV1 } from './hash'
 import type {
@@ -16,181 +18,373 @@ import type {
 
 export const MARKED_EQUITY_TOLERANCE_MICROS = 0n
 
-const ensure = (condition: boolean, message: string): void => {
-  if (!condition) throw new Error(message)
+type UnsignedIntegerEvidence =
+  | {
+      readonly kind: 'input'
+      readonly field: 'evaluatorEndingEquityMicros' | 'evaluatorTotalFeesMicros' | 'initialCapitalMicros'
+      readonly value: string
+    }
+  | {
+      readonly kind: 'order'
+      readonly orderId: string
+      readonly field: 'filledQuantityMicros' | 'requestedQuantityMicros'
+      readonly value: string
+    }
+  | {
+      readonly kind: 'fill'
+      readonly fillId: string
+      readonly field:
+        | 'costBasisMicros'
+        | 'notionalMicros'
+        | 'priceMicros'
+        | 'quantityMicros'
+        | 'referencePriceMicros'
+        | 'slippageCostMicros'
+        | 'spreadCostMicros'
+      readonly value: string
+    }
+  | {
+      readonly kind: 'fee'
+      readonly feeId: string
+      readonly field: 'catMicros' | 'commissionMicros' | 'secMicros' | 'tafMicros' | 'totalMicros'
+      readonly value: string
+    }
+  | {
+      readonly kind: 'cash-yield'
+      readonly cashYieldId: string
+      readonly field: 'amountMicros'
+      readonly value: string
+    }
+  | {
+      readonly kind: 'daily-mark'
+      readonly sessionDate: string
+      readonly field:
+        | 'cashMicros'
+        | 'cashYieldMicros'
+        | 'cumulativeCashYieldMicros'
+        | 'cumulativeFeesMicros'
+        | 'cumulativeSlippageCostMicros'
+        | 'cumulativeSpreadCostMicros'
+        | 'cumulativeTurnoverMicros'
+        | 'equityMicros'
+        | 'feeMicros'
+        | 'slippageCostMicros'
+        | 'spreadCostMicros'
+        | 'turnoverMicros'
+      readonly value: string
+    }
+  | {
+      readonly kind: 'position'
+      readonly sessionDate: string
+      readonly symbol: string
+      readonly field: 'costBasisMicros' | 'marketValueMicros' | 'priceMicros' | 'quantityMicros'
+      readonly value: string
+    }
+
+type PositiveUnsignedIntegerEvidence = {
+  readonly kind: 'simulation'
+  readonly field: 'costMultiplierMicros'
+  readonly value: string
 }
 
-const unsigned = (value: string, name: string): bigint => {
-  ensure(/^\d+$/.test(value), `${name} must be an unsigned integer string`)
-  return BigInt(value)
+type SignedIntegerEvidence = {
+  readonly kind: 'cash-change'
+  readonly cashChangeId: string
+  readonly field: 'amountMicros' | 'cashAfterMicros'
+  readonly value: string
 }
 
-const signed = (value: string, name: string): bigint => {
-  ensure(/^-?\d+$/.test(value), `${name} must be an integer string`)
-  return BigInt(value)
+type RunIdentityEvidence = { readonly kind: 'run'; readonly id: string }
+
+type CanonicalIdentityEvidence =
+  | { readonly kind: 'decision'; readonly id: string; readonly signalDate: string }
+  | { readonly kind: 'order'; readonly id: string; readonly sessionDate: string }
+  | { readonly kind: 'fill'; readonly id: string; readonly sessionDate: string }
+  | { readonly kind: 'fee'; readonly id: string; readonly sessionDate: string }
+  | { readonly kind: 'cash-yield'; readonly id: string; readonly sessionDate: string }
+  | { readonly kind: 'cash-change'; readonly id: string; readonly sourceId: string; readonly sessionDate: string }
+
+type IdentityEvidence = RunIdentityEvidence | CanonicalIdentityEvidence
+
+type InvalidIdentityIssue =
+  | {
+      readonly _tag: 'InvalidIdentity'
+      readonly evidence: RunIdentityEvidence
+      readonly problem: { readonly _tag: 'InvalidFormat'; readonly expected: 'lowercase-sha256' }
+    }
+  | {
+      readonly _tag: 'InvalidIdentity'
+      readonly evidence: CanonicalIdentityEvidence
+      readonly problem:
+        | { readonly _tag: 'InvalidFormat'; readonly expected: 'lowercase-sha256' }
+        | { readonly _tag: 'HashMismatch'; readonly expected: string }
+        | { readonly _tag: 'CanonicalizationFailed'; readonly cause: unknown }
+    }
+
+type CanonicalIdentityProblem =
+  | { readonly _tag: 'HashMismatch'; readonly expected: string }
+  | { readonly _tag: 'CanonicalizationFailed'; readonly cause: unknown }
+
+type MissingReferenceProblem =
+  | { readonly _tag: 'OrderDecision'; readonly orderId: string; readonly decisionId: string }
+  | { readonly _tag: 'FillOrder'; readonly fillId: string; readonly orderId: string }
+  | {
+      readonly _tag: 'MonetaryEventCashChange'
+      readonly eventId: string
+      readonly eventKind: FillEvent['kind'] | FeeEvent['kind'] | CashYieldEvent['kind']
+    }
+
+type EvidenceMismatchProblem =
+  | {
+      readonly _tag: 'OrderExecutionSession'
+      readonly orderId: string
+      readonly decisionId: string
+      readonly actualSessionDate: string
+      readonly expectedSessionDate: string
+    }
+  | {
+      readonly _tag: 'FillBinding'
+      readonly fillId: string
+      readonly orderId: string
+      readonly field: 'decisionId' | 'sessionDate' | 'side' | 'symbol'
+      readonly actual: string
+      readonly expected: string
+    }
+  | {
+      readonly _tag: 'FillQuantity'
+      readonly fillId: string
+      readonly orderId: string
+      readonly actualQuantityMicros: string
+      readonly expectedQuantityMicros: string
+    }
+  | {
+      readonly _tag: 'FillTerms'
+      readonly fillId: string
+      readonly field: 'notionalMicros' | 'priceMicros' | 'slippageCostMicros' | 'spreadCostMicros'
+      readonly actualMicros: string
+      readonly expectedMicros: string
+    }
+  | {
+      readonly _tag: 'FeeComponents'
+      readonly feeId: string
+      readonly actualTotalMicros: string
+      readonly expectedTotalMicros: string
+    }
+  | {
+      readonly _tag: 'FeeSchedule'
+      readonly feeId: string
+      readonly field: 'catMicros' | 'commissionMicros' | 'secMicros' | 'tafMicros' | 'totalMicros'
+      readonly actualMicros: string
+      readonly expectedMicros: string
+    }
+  | {
+      readonly _tag: 'CashChange'
+      readonly cashChangeId: string
+      readonly sourceId: string
+      readonly field: 'amountMicros' | 'cashAfterMicros' | 'sessionDate' | 'sourceKind'
+      readonly actual: string
+      readonly expected: string
+    }
+  | {
+      readonly _tag: 'CashYield'
+      readonly cashYieldId: string
+      readonly field: 'amountMicros' | 'annualYieldBps'
+      readonly actual: string
+      readonly expected: string
+    }
+  | {
+      readonly _tag: 'DailyMark'
+      readonly sessionDate: string
+      readonly field:
+        | 'cashYieldMicros'
+        | 'cumulativeCashYieldMicros'
+        | 'cumulativeFeesMicros'
+        | 'cumulativeSlippageCostMicros'
+        | 'cumulativeSpreadCostMicros'
+        | 'cumulativeTurnoverMicros'
+        | 'feeMicros'
+        | 'slippageCostMicros'
+        | 'spreadCostMicros'
+        | 'turnoverMicros'
+      readonly actualMicros: string
+      readonly expectedMicros: string
+    }
+  | {
+      readonly _tag: 'PositionMark'
+      readonly sessionDate: string
+      readonly symbol: string
+      readonly field: 'marketValueMicros' | 'quantityMicros'
+      readonly actualMicros: string
+      readonly expectedMicros: string
+    }
+
+type InvalidEvidenceStateProblem =
+  | {
+      readonly _tag: 'DuplicateIdentity'
+      readonly entity: 'cash-change' | 'cash-yield' | 'decision' | 'fee' | 'fill' | 'order'
+      readonly id: string
+    }
+  | { readonly _tag: 'DuplicateFillForOrder'; readonly orderId: string; readonly secondFillId: string }
+  | { readonly _tag: 'DuplicateCashChangeForEvent'; readonly eventId: string; readonly secondCashChangeId: string }
+  | {
+      readonly _tag: 'InvalidOrder'
+      readonly rule: 'fill-presence' | 'filled-not-over-requested' | 'status-consistency'
+      readonly orderId: string
+      readonly status: SimulatedOrder['status']
+      readonly requestedQuantityMicros: string
+      readonly filledQuantityMicros: string
+      readonly rejectionReason: SimulatedOrder['rejectionReason']
+      readonly unfilledRemainder: SimulatedOrder['unfilledRemainder']
+      readonly fillPresent: boolean
+    }
+  | {
+      readonly _tag: 'InvalidMarkOrder'
+      readonly previousSessionDate: string
+      readonly sessionDate: string
+    }
+  | { readonly _tag: 'DuplicateMarkedPosition'; readonly sessionDate: string; readonly symbols: readonly string[] }
+  | { readonly _tag: 'UnsortedMarkedPositions'; readonly sessionDate: string; readonly symbols: readonly string[] }
+  | {
+      readonly _tag: 'NegativeCash'
+      readonly eventId: string
+      readonly actualMicros: string
+      readonly minimumMicros: string
+    }
+  | {
+      readonly _tag: 'NegativeLongPosition'
+      readonly fillId: string
+      readonly symbol: string
+      readonly actualQuantityMicros: string
+    }
+  | {
+      readonly _tag: 'DailyOutsideTolerance'
+      readonly measure: 'daily-cash' | 'daily-equity'
+      readonly sessionDate: string
+      readonly differenceMicros: string
+      readonly toleranceMicros: string
+    }
+  | {
+      readonly _tag: 'FinalOutsideTolerance'
+      readonly measure: 'final-equity' | 'final-fees'
+      readonly differenceMicros: string
+      readonly toleranceMicros: string
+    }
+  | { readonly _tag: 'NegativeTolerance'; readonly toleranceMicros: string }
+  | {
+      readonly _tag: 'UnsupportedSimulationSchema'
+      readonly actual: string
+      readonly expected: 'bayn.simulation-trace.v3'
+    }
+
+type IncompleteEvidenceProblem =
+  | { readonly _tag: 'EmptyDailyMarks' }
+  | {
+      readonly _tag: 'CashChangeCountMismatch'
+      readonly cashChangeCount: number
+      readonly monetaryEventCount: number
+    }
+  | {
+      readonly _tag: 'MissingSessionMark'
+      readonly eventId: string
+      readonly eventSessionDate: string
+      readonly nextMarkSessionDate: string
+    }
+  | {
+      readonly _tag: 'MissingOpenPositionMark'
+      readonly sessionDate: string
+      readonly symbol: string
+      readonly quantityMicros: string
+    }
+  | {
+      readonly _tag: 'MonetaryEventsAfterFinalMark'
+      readonly firstEventId: string
+      readonly firstEventSessionDate: string
+    }
+
+type FailedComputation =
+  | {
+      readonly _tag: 'FillTerms'
+      readonly fillId: string
+      readonly side: FillEvent['side']
+      readonly quantityMicros: string
+      readonly referencePriceMicros: string
+      readonly costMultiplierMicros: string
+    }
+  | {
+      readonly _tag: 'FeeSchedule'
+      readonly feeId: string
+      readonly fillCount: number
+      readonly costMultiplierMicros: string
+    }
+  | {
+      readonly _tag: 'CashYield'
+      readonly cashYieldId: string
+      readonly cashMicros: string
+      readonly elapsedDays: number
+      readonly annualYieldBps: number
+    }
+
+type InvalidIntegerIssue =
+  | {
+      readonly _tag: 'InvalidInteger'
+      readonly expected: 'unsigned-integer'
+      readonly evidence: UnsignedIntegerEvidence
+    }
+  | {
+      readonly _tag: 'InvalidInteger'
+      readonly expected: 'positive-unsigned-integer'
+      readonly evidence: PositiveUnsignedIntegerEvidence
+    }
+  | {
+      readonly _tag: 'InvalidInteger'
+      readonly expected: 'signed-integer'
+      readonly evidence: SignedIntegerEvidence
+    }
+
+export type SimulationReconciliationIssue =
+  | InvalidIntegerIssue
+  | InvalidIdentityIssue
+  | { readonly _tag: 'MissingReference'; readonly problem: MissingReferenceProblem }
+  | { readonly _tag: 'EvidenceMismatch'; readonly problem: EvidenceMismatchProblem }
+  | { readonly _tag: 'InvalidEvidenceState'; readonly problem: InvalidEvidenceStateProblem }
+  | { readonly _tag: 'IncompleteEvidence'; readonly problem: IncompleteEvidenceProblem }
+  | { readonly _tag: 'ComputationFailed'; readonly computation: FailedComputation; readonly cause: unknown }
+
+const renderUnknownCause = (cause: unknown): string => {
+  const rendered = Result.try({
+    try: () => (cause instanceof Error ? `${cause.name}: ${cause.message}` : String(cause)),
+    catch: () => 'unrenderable cause',
+  })
+  return Result.isSuccess(rendered) ? rendered.success : rendered.failure
 }
 
-const absolute = (value: bigint): bigint => (value < 0n ? -value : value)
-
-const uniqueById = <A extends { readonly id: string }>(values: readonly A[], name: string): Map<string, A> => {
-  const byId = new Map<string, A>()
-  for (const value of values) {
-    ensure(/^[0-9a-f]{64}$/.test(value.id), `${name} has an invalid ID`)
-    ensure(!byId.has(value.id), `${name} contains duplicate ID ${value.id}`)
-    byId.set(value.id, value)
+export const renderSimulationReconciliationIssue = (issue: SimulationReconciliationIssue): string => {
+  switch (issue._tag) {
+    case 'InvalidInteger':
+      return `invalid integer (${issue.expected}): ${JSON.stringify(issue.evidence)}`
+    case 'InvalidIdentity': {
+      if (issue.problem._tag !== 'CanonicalizationFailed') {
+        return `invalid identity: ${JSON.stringify({ evidence: issue.evidence, problem: issue.problem }, null, 0)}`
+      }
+      return `identity canonicalization failed for ${JSON.stringify(issue.evidence)}: ${renderUnknownCause(issue.problem.cause)}`
+    }
+    case 'MissingReference':
+      return `missing reference: ${JSON.stringify(issue.problem)}`
+    case 'EvidenceMismatch':
+      return `evidence mismatch: ${JSON.stringify(issue.problem)}`
+    case 'InvalidEvidenceState':
+      return `invalid evidence state: ${JSON.stringify(issue.problem)}`
+    case 'IncompleteEvidence':
+      return `incomplete evidence: ${JSON.stringify(issue.problem)}`
+    case 'ComputationFailed':
+      return `${issue.computation._tag} calculation failed for ${JSON.stringify(issue.computation)}: ${renderUnknownCause(issue.cause)}`
   }
-  return byId
 }
 
-const validateDecisionIdentity = (runId: string, decision: DecisionEvent): void => {
-  const { id: _, kind: __, ...payload } = decision
-  ensure(
-    decision.id === canonicalHashV1({ runId, kind: 'decision', ...payload }),
-    `decision ${decision.id} has an invalid identity`,
-  )
-}
+export const renderSimulationReconciliationIssues = (issues: readonly SimulationReconciliationIssue[]): string =>
+  issues.map(renderSimulationReconciliationIssue).join('; ')
 
-const validateFill = (runId: string, fill: FillEvent, order: SimulatedOrder, trace: SimulationTrace): void => {
-  ensure(fill.orderId === order.id, `fill ${fill.id} does not reference its order`)
-  ensure(fill.decisionId === order.decisionId, `fill ${fill.id} and order ${order.id} disagree on decision`)
-  ensure(fill.sessionDate === order.sessionDate, `fill ${fill.id} and order ${order.id} disagree on session`)
-  ensure(fill.symbol === order.symbol, `fill ${fill.id} and order ${order.id} disagree on symbol`)
-  ensure(fill.side === order.side, `fill ${fill.id} and order ${order.id} disagree on side`)
-  const filledQuantity = unsigned(fill.quantityMicros, 'fill quantity')
-  ensure(filledQuantity === unsigned(order.filledQuantityMicros, 'filled order quantity'), 'order and fill diverge')
-  const terms = makeFillTerms(
-    fill.side,
-    filledQuantity,
-    unsigned(fill.referencePriceMicros, 'fill reference price'),
-    trace.executionModel,
-    unsigned(trace.costMultiplierMicros, 'cost multiplier'),
-  )
-  ensure(terms.fillPriceMicros === unsigned(fill.priceMicros, 'fill price'), `fill ${fill.id} price diverges`)
-  ensure(terms.notionalMicros === unsigned(fill.notionalMicros, 'fill notional'), `fill ${fill.id} notional diverges`)
-  ensure(
-    terms.spreadCostMicros === unsigned(fill.spreadCostMicros, 'fill spread cost'),
-    `fill ${fill.id} spread cost diverges`,
-  )
-  ensure(
-    terms.slippageCostMicros === unsigned(fill.slippageCostMicros, 'fill slippage cost'),
-    `fill ${fill.id} slippage cost diverges`,
-  )
-  unsigned(fill.costBasisMicros, 'fill cost basis')
-  const { id: _, kind: __, ...payload } = fill
-  ensure(fill.id === canonicalHashV1({ runId, kind: 'fill', ...payload }), `fill ${fill.id} has an invalid identity`)
-}
-
-const validateOrder = (
-  runId: string,
-  order: SimulatedOrder,
-  fill: FillEvent | undefined,
-  decisions: ReadonlyMap<string, DecisionEvent>,
-  trace: SimulationTrace,
-): void => {
-  const decision = decisions.get(order.decisionId)
-  if (decision === undefined) throw new Error(`order ${order.id} references an unknown decision`)
-  ensure(decision.executionDate === order.sessionDate, `order ${order.id} is outside its decision execution session`)
-  const requested = unsigned(order.requestedQuantityMicros, 'requested order quantity')
-  const filled = unsigned(order.filledQuantityMicros, 'filled order quantity')
-  ensure(filled <= requested, `order ${order.id} filled more than requested`)
-  if (order.status === 'filled') {
-    ensure(requested > 0n && filled === requested, `filled order ${order.id} has inconsistent quantities`)
-    ensure(
-      order.rejectionReason === null && order.unfilledRemainder === 'none',
-      `filled order ${order.id} is malformed`,
-    )
-  } else if (order.status === 'partially-filled') {
-    ensure(filled > 0n && filled < requested, `partial order ${order.id} has inconsistent quantities`)
-    ensure(
-      order.rejectionReason === null && order.unfilledRemainder === 'canceled',
-      `partial order ${order.id} is malformed`,
-    )
-  } else {
-    ensure(filled === 0n && order.rejectionReason !== null, `rejected order ${order.id} is malformed`)
-    ensure(order.unfilledRemainder === 'canceled', `rejected order ${order.id} must cancel its remainder`)
-  }
-  ensure((fill === undefined) === (filled === 0n), `order ${order.id} fill presence diverges from its status`)
-  const { id: _, ...payload } = order
-  ensure(
-    order.id === canonicalHashV1({ runId, kind: 'order', ...payload }),
-    `order ${order.id} has an invalid identity`,
-  )
-  if (fill !== undefined) validateFill(runId, fill, order, trace)
-}
-
-const validateFee = (
-  runId: string,
-  fee: FeeEvent,
-  sessionFills: readonly FillEvent[],
-  trace: SimulationTrace,
-): void => {
-  const components =
-    unsigned(fee.commissionMicros, 'commission fee') +
-    unsigned(fee.secMicros, 'SEC fee') +
-    unsigned(fee.tafMicros, 'TAF fee') +
-    unsigned(fee.catMicros, 'CAT fee')
-  ensure(components === unsigned(fee.totalMicros, 'total fee'), `fee ${fee.id} components do not sum`)
-  const inputs: FeeInput[] = sessionFills.map((fill) => ({
-    side: fill.side,
-    quantityMicros: unsigned(fill.quantityMicros, 'fill quantity'),
-    notionalMicros: unsigned(fill.notionalMicros, 'fill notional'),
-  }))
-  const expected = calculateSessionFees(
-    inputs,
-    trace.executionModel,
-    unsigned(trace.costMultiplierMicros, 'cost multiplier'),
-  )
-  ensure(expected.commissionMicros === BigInt(fee.commissionMicros), `fee ${fee.id} commission diverges`)
-  ensure(expected.secMicros === BigInt(fee.secMicros), `fee ${fee.id} SEC component diverges`)
-  ensure(expected.tafMicros === BigInt(fee.tafMicros), `fee ${fee.id} TAF component diverges`)
-  ensure(expected.catMicros === BigInt(fee.catMicros), `fee ${fee.id} CAT component diverges`)
-  ensure(expected.totalMicros === BigInt(fee.totalMicros), `fee ${fee.id} total diverges`)
-  const { id: _, kind: __, ...payload } = fee
-  ensure(fee.id === canonicalHashV1({ runId, kind: 'fee', ...payload }), `fee ${fee.id} has an invalid identity`)
-}
-
-const validateCashChange = (
-  runId: string,
-  change: CashChange,
-  event: FillEvent | FeeEvent | CashYieldEvent,
-  amount: bigint,
-  expectedCash: bigint,
-): void => {
-  ensure(change.sourceKind === event.kind, `cash change ${change.id} references the wrong source kind`)
-  ensure(change.sourceId === event.id, `cash change ${change.id} references the wrong source`)
-  ensure(change.sessionDate === event.sessionDate, `cash change ${change.id} references the wrong session`)
-  ensure(signed(change.amountMicros, 'cash change amount') === amount, `cash change ${change.id} amount diverges`)
-  ensure(
-    signed(change.cashAfterMicros, 'cash after event') === expectedCash,
-    `cash change ${change.id} balance diverges`,
-  )
-  const { id: _, ...payload } = change
-  ensure(
-    change.id === canonicalHashV1({ runId, kind: 'cash-change', ...payload }),
-    `cash change ${change.id} has an invalid identity`,
-  )
-}
-
-const validateMarks = (marks: readonly DailyPositionMark[]): void => {
-  ensure(marks.length > 0, 'simulation has no daily marks')
-  for (let index = 0; index < marks.length; index += 1) {
-    const mark = marks[index]
-    if (index > 0) ensure(marks[index - 1].sessionDate < mark.sessionDate, 'daily marks are not strictly ordered')
-    const symbols = mark.positions.map((position) => position.symbol)
-    ensure(new Set(symbols).size === symbols.length, `daily mark ${mark.sessionDate} contains duplicate positions`)
-    ensure(
-      symbols.every((symbol, symbolIndex) => symbolIndex === 0 || symbols[symbolIndex - 1] < symbol),
-      `daily mark ${mark.sessionDate} positions are not sorted`,
-    )
-  }
-}
-
-export interface MarkedEquityProof {
-  readonly reconciliation: MarkedEquityReconciliation
-  readonly equitySeries: readonly EquityPoint[]
-}
-
-export const reconcileMarkedEquity = (input: {
+export interface MarkedEquityReconciliationInput {
   readonly runId: string
   readonly initialCapitalMicros: string
   readonly evaluatorTotalFeesMicros: string
@@ -198,215 +392,1412 @@ export const reconcileMarkedEquity = (input: {
   readonly events: readonly EvaluationEvent[]
   readonly simulation: SimulationTrace
   readonly toleranceMicros?: bigint
-}): MarkedEquityProof => {
-  const tolerance = input.toleranceMicros ?? MARKED_EQUITY_TOLERANCE_MICROS
-  ensure(tolerance >= 0n, 'marked-equity tolerance must not be negative')
-  ensure(/^[0-9a-f]{64}$/.test(input.runId), 'marked-equity run ID is invalid')
-  ensure(input.simulation.schemaVersion === 'bayn.simulation-trace.v3', 'simulation trace version is unsupported')
-  ensure(unsigned(input.simulation.costMultiplierMicros, 'cost multiplier') > 0n, 'cost multiplier must be positive')
+}
 
-  const decisions = uniqueById(
-    input.events.filter((event): event is DecisionEvent => event.kind === 'decision'),
-    'decision events',
-  )
-  for (const decision of decisions.values()) validateDecisionIdentity(input.runId, decision)
-  const fills = input.events.filter((event): event is FillEvent => event.kind === 'fill')
-  uniqueById(fills, 'fill events')
-  const fillsByOrder = new Map<string, FillEvent>()
-  for (const fill of fills) {
-    ensure(!fillsByOrder.has(fill.orderId), `order ${fill.orderId} has multiple fills`)
-    fillsByOrder.set(fill.orderId, fill)
-  }
-  const orders = uniqueById(input.simulation.orders, 'simulated orders')
-  for (const order of orders.values()) {
-    validateOrder(input.runId, order, fillsByOrder.get(order.id), decisions, input.simulation)
-  }
-  for (const fill of fills) ensure(orders.has(fill.orderId), `fill ${fill.id} references an unknown order`)
+export interface MarkedEquityProof {
+  readonly reconciliation: MarkedEquityReconciliation
+  readonly equitySeries: readonly EquityPoint[]
+}
 
-  const fees = input.events.filter((event): event is FeeEvent => event.kind === 'fee')
-  const cashYields = input.events.filter((event): event is CashYieldEvent => event.kind === 'cash-yield')
-  uniqueById(fees, 'fee events')
-  uniqueById(cashYields, 'cash-yield events')
-  for (const fee of fees) {
-    validateFee(
-      input.runId,
-      fee,
-      fills.filter((fill) => fill.sessionDate === fee.sessionDate),
-      input.simulation,
-    )
-  }
+export type SimulationReconciliationResult = Result.Result<MarkedEquityProof, readonly SimulationReconciliationIssue[]>
 
-  const monetaryEvents = input.events.filter(
-    (event): event is FillEvent | FeeEvent | CashYieldEvent => event.kind !== 'decision',
-  )
-  const changes = uniqueById(input.simulation.cashChanges, 'cash changes')
-  const changesBySource = new Map<string, CashChange>()
-  for (const change of changes.values()) {
-    ensure(!changesBySource.has(change.sourceId), `event ${change.sourceId} has multiple cash changes`)
-    changesBySource.set(change.sourceId, change)
-  }
-  ensure(changes.size === monetaryEvents.length, 'cash change count does not match monetary event count')
-  for (const event of monetaryEvents) ensure(changesBySource.has(event.id), `event ${event.id} has no cash change`)
-  validateMarks(input.simulation.dailyMarks)
+type Validation<A> = Result.Result<A, readonly SimulationReconciliationIssue[]>
 
-  let cash = unsigned(input.initialCapitalMicros, 'initial capital')
-  const quantities = new Map<string, bigint>()
-  let eventIndex = 0
-  let maximumDifference = 0n
-  let finalPositionValue = 0n
-  let reconstructedTotalFees = 0n
-  let cumulativeTurnover = 0n
-  let cumulativeSpread = 0n
-  let cumulativeSlippage = 0n
-  let cumulativeCashYield = 0n
-  const equitySeries: EquityPoint[] = []
-
-  for (const mark of input.simulation.dailyMarks) {
-    const turnoverBefore = cumulativeTurnover
-    const feesBefore = reconstructedTotalFees
-    const spreadBefore = cumulativeSpread
-    const slippageBefore = cumulativeSlippage
-    const yieldBefore = cumulativeCashYield
-    while (eventIndex < monetaryEvents.length && monetaryEvents[eventIndex].sessionDate <= mark.sessionDate) {
-      const event = monetaryEvents[eventIndex]
-      ensure(event.sessionDate === mark.sessionDate, `event ${event.id} has no mark for its session`)
-      let amount: bigint
-      if (event.kind === 'fill') {
-        const notional = unsigned(event.notionalMicros, 'fill notional')
-        amount = event.side === 'buy' ? -notional : notional
-        cumulativeTurnover += notional
-        cumulativeSpread += unsigned(event.spreadCostMicros, 'fill spread cost')
-        cumulativeSlippage += unsigned(event.slippageCostMicros, 'fill slippage cost')
-        const quantity = unsigned(event.quantityMicros, 'fill quantity')
-        const current = quantities.get(event.symbol) ?? 0n
-        const next = event.side === 'buy' ? current + quantity : current - quantity
-        ensure(next >= 0n, `fill ${event.id} creates a negative long-only position`)
-        quantities.set(event.symbol, next)
-      } else if (event.kind === 'fee') {
-        const total = unsigned(event.totalMicros, 'fee total')
-        amount = -total
-        reconstructedTotalFees += total
-      } else {
-        ensure(
-          event.annualYieldBps === input.simulation.executionModel.cash.annualYieldBps,
-          `cash-yield event ${event.id} rate diverges from the model`,
-        )
-        const expected = accrueCashYield(cash, event.elapsedDays, input.simulation.executionModel)
-        ensure(expected === unsigned(event.amountMicros, 'cash-yield amount'), `cash-yield event ${event.id} diverges`)
-        amount = expected
-        cumulativeCashYield += expected
-        const { id: _, kind: __, ...payload } = event
-        ensure(
-          event.id === canonicalHashV1({ runId: input.runId, kind: 'cash-yield', ...payload }),
-          `cash-yield event ${event.id} has an invalid identity`,
-        )
+const freezePublicIssue = (issue: SimulationReconciliationIssue): SimulationReconciliationIssue => {
+  switch (issue._tag) {
+    case 'InvalidInteger': {
+      switch (issue.expected) {
+        case 'unsigned-integer':
+        case 'positive-unsigned-integer':
+        case 'signed-integer':
+          return Object.freeze(Object.assign({}, issue, { evidence: Object.freeze({ ...issue.evidence }) }))
       }
-      cash += amount
-      ensure(cash >= -tolerance, `event ${event.id} spends unavailable reconstructed cash`)
-      const change = changesBySource.get(event.id)
-      if (change === undefined) throw new Error(`event ${event.id} has no cash change`)
-      validateCashChange(input.runId, change, event, amount, cash)
-      eventIndex += 1
     }
+    case 'InvalidIdentity': {
+      switch (issue.problem._tag) {
+        case 'InvalidFormat':
+        case 'HashMismatch':
+        case 'CanonicalizationFailed':
+          return Object.freeze(
+            Object.assign({}, issue, {
+              evidence: Object.freeze({ ...issue.evidence }),
+              problem: Object.freeze({ ...issue.problem }),
+            }),
+          )
+      }
+    }
+    case 'MissingReference': {
+      switch (issue.problem._tag) {
+        case 'OrderDecision':
+        case 'FillOrder':
+        case 'MonetaryEventCashChange':
+          return Object.freeze(Object.assign({}, issue, { problem: Object.freeze({ ...issue.problem }) }))
+      }
+    }
+    case 'EvidenceMismatch': {
+      switch (issue.problem._tag) {
+        case 'OrderExecutionSession':
+        case 'FillBinding':
+        case 'FillQuantity':
+        case 'FillTerms':
+        case 'FeeComponents':
+        case 'FeeSchedule':
+        case 'CashChange':
+        case 'CashYield':
+        case 'DailyMark':
+        case 'PositionMark':
+          return Object.freeze(Object.assign({}, issue, { problem: Object.freeze({ ...issue.problem }) }))
+      }
+    }
+    case 'InvalidEvidenceState': {
+      switch (issue.problem._tag) {
+        case 'DuplicateMarkedPosition':
+        case 'UnsortedMarkedPositions':
+          return Object.freeze(
+            Object.assign({}, issue, {
+              problem: Object.freeze({ ...issue.problem, symbols: Object.freeze([...issue.problem.symbols]) }),
+            }),
+          )
+        case 'DuplicateIdentity':
+        case 'DuplicateFillForOrder':
+        case 'DuplicateCashChangeForEvent':
+        case 'InvalidOrder':
+        case 'InvalidMarkOrder':
+        case 'NegativeCash':
+        case 'NegativeLongPosition':
+        case 'DailyOutsideTolerance':
+        case 'FinalOutsideTolerance':
+        case 'NegativeTolerance':
+        case 'UnsupportedSimulationSchema':
+          return Object.freeze(Object.assign({}, issue, { problem: Object.freeze({ ...issue.problem }) }))
+      }
+    }
+    case 'IncompleteEvidence': {
+      switch (issue.problem._tag) {
+        case 'EmptyDailyMarks':
+        case 'CashChangeCountMismatch':
+        case 'MissingSessionMark':
+        case 'MissingOpenPositionMark':
+        case 'MonetaryEventsAfterFinalMark':
+          return Object.freeze(Object.assign({}, issue, { problem: Object.freeze({ ...issue.problem }) }))
+      }
+    }
+    case 'ComputationFailed': {
+      switch (issue.computation._tag) {
+        case 'FillTerms':
+        case 'FeeSchedule':
+        case 'CashYield':
+          return Object.freeze(Object.assign({}, issue, { computation: Object.freeze({ ...issue.computation }) }))
+      }
+    }
+  }
+}
 
-    ensure(
-      unsigned(mark.turnoverMicros, 'daily turnover') === cumulativeTurnover - turnoverBefore,
-      'daily turnover diverges',
-    )
-    ensure(
-      unsigned(mark.cumulativeTurnoverMicros, 'cumulative turnover') === cumulativeTurnover,
-      'cumulative turnover diverges',
-    )
-    ensure(unsigned(mark.feeMicros, 'daily fees') === reconstructedTotalFees - feesBefore, 'daily fees diverge')
-    ensure(unsigned(mark.cumulativeFeesMicros, 'cumulative fees') === reconstructedTotalFees, 'cumulative fees diverge')
-    ensure(unsigned(mark.spreadCostMicros, 'daily spread') === cumulativeSpread - spreadBefore, 'daily spread diverges')
-    ensure(
-      unsigned(mark.cumulativeSpreadCostMicros, 'cumulative spread') === cumulativeSpread,
-      'cumulative spread diverges',
-    )
-    ensure(
-      unsigned(mark.slippageCostMicros, 'daily slippage') === cumulativeSlippage - slippageBefore,
-      'daily slippage diverges',
-    )
-    ensure(
-      unsigned(mark.cumulativeSlippageCostMicros, 'cumulative slippage') === cumulativeSlippage,
-      'cumulative slippage diverges',
-    )
-    ensure(
-      unsigned(mark.cashYieldMicros, 'daily cash yield') === cumulativeCashYield - yieldBefore,
-      'daily cash yield diverges',
-    )
-    ensure(
-      unsigned(mark.cumulativeCashYieldMicros, 'cumulative cash yield') === cumulativeCashYield,
-      'cumulative cash yield diverges',
-    )
-    const markCash = unsigned(mark.cashMicros, 'daily cash')
-    ensure(absolute(markCash - cash) <= tolerance, `daily cash diverges on ${mark.sessionDate}`)
-    let reconstructedPositionValue = 0n
-    const markedSymbols = new Set<string>()
-    for (const position of mark.positions) {
-      markedSymbols.add(position.symbol)
-      const price = unsigned(position.priceMicros, 'position mark price')
-      const reconstructedQuantity = quantities.get(position.symbol) ?? 0n
-      ensure(
-        unsigned(position.quantityMicros, 'position quantity') === reconstructedQuantity,
-        `position quantity diverges for ${position.symbol} on ${mark.sessionDate}`,
-      )
-      unsigned(position.costBasisMicros, 'position cost basis')
-      const reconstructedValue = notionalMicros(reconstructedQuantity, price)
-      reconstructedPositionValue += reconstructedValue
-      ensure(
-        unsigned(position.marketValueMicros, 'position market value') === reconstructedValue,
-        `position value diverges for ${position.symbol} on ${mark.sessionDate}`,
-      )
-    }
-    for (const [symbol, quantity] of quantities) {
-      ensure(
-        quantity === 0n || markedSymbols.has(symbol),
-        `daily mark ${mark.sessionDate} omits open position ${symbol}`,
-      )
-    }
-    const reconstructedEquity = cash + reconstructedPositionValue
-    const evaluatorEquity = unsigned(mark.equityMicros, 'daily evaluator equity')
-    const difference = absolute(reconstructedEquity - evaluatorEquity)
-    ensure(difference <= tolerance, `daily marked equity diverges on ${mark.sessionDate}`)
-    maximumDifference = maximumDifference > difference ? maximumDifference : difference
-    finalPositionValue = reconstructedPositionValue
-    equitySeries.push({
-      sessionDate: mark.sessionDate,
-      evaluatorEquityMicros: evaluatorEquity.toString(),
-      reconstructedEquityMicros: reconstructedEquity.toString(),
-      differenceMicros: difference.toString(),
+const freezePublicIssues = (
+  issues: readonly SimulationReconciliationIssue[],
+): readonly SimulationReconciliationIssue[] => Object.freeze(issues.map(freezePublicIssue))
+
+const freezePublicProof = (proof: MarkedEquityProof): MarkedEquityProof =>
+  Object.freeze({
+    reconciliation: Object.freeze({ ...proof.reconciliation }),
+    equitySeries: Object.freeze(proof.equitySeries.map((point) => Object.freeze({ ...point }))),
+  })
+
+const failIssues = <A = never>(issues: readonly SimulationReconciliationIssue[]): Validation<A> => Result.fail(issues)
+
+const fail = <A = never>(
+  issueOrIssues: SimulationReconciliationIssue | readonly SimulationReconciliationIssue[],
+): Validation<A> =>
+  failIssues(
+    Array.isArray(issueOrIssues)
+      ? (issueOrIssues as readonly SimulationReconciliationIssue[])
+      : [issueOrIssues as SimulationReconciliationIssue],
+  )
+
+const unsigned = (evidence: UnsignedIntegerEvidence): Validation<bigint> =>
+  /^\d+$/.test(evidence.value)
+    ? Result.succeed(BigInt(evidence.value))
+    : fail({ _tag: 'InvalidInteger', expected: 'unsigned-integer', evidence })
+
+const positiveUnsigned = (evidence: PositiveUnsignedIntegerEvidence): Validation<bigint> => {
+  if (!/^\d+$/.test(evidence.value)) {
+    return fail({ _tag: 'InvalidInteger', expected: 'positive-unsigned-integer', evidence })
+  }
+  const value = BigInt(evidence.value)
+  return value > 0n
+    ? Result.succeed(value)
+    : fail({ _tag: 'InvalidInteger', expected: 'positive-unsigned-integer', evidence })
+}
+
+const signed = (evidence: SignedIntegerEvidence): Validation<bigint> =>
+  /^-?\d+$/.test(evidence.value)
+    ? Result.succeed(BigInt(evidence.value))
+    : fail({ _tag: 'InvalidInteger', expected: 'signed-integer', evidence })
+
+type OrderIntegerField = Extract<UnsignedIntegerEvidence, { readonly kind: 'order' }>['field']
+type FillIntegerField = Extract<UnsignedIntegerEvidence, { readonly kind: 'fill' }>['field']
+type FeeIntegerField = Extract<UnsignedIntegerEvidence, { readonly kind: 'fee' }>['field']
+type MarkIntegerField = Extract<UnsignedIntegerEvidence, { readonly kind: 'daily-mark' }>['field']
+type PositionIntegerField = Extract<UnsignedIntegerEvidence, { readonly kind: 'position' }>['field']
+
+const orderUnsigned = (order: SimulatedOrder, field: OrderIntegerField): Validation<bigint> =>
+  unsigned({ kind: 'order', orderId: order.id, field, value: order[field] })
+
+const fillUnsigned = (fill: FillEvent, field: FillIntegerField): Validation<bigint> =>
+  unsigned({ kind: 'fill', fillId: fill.id, field, value: fill[field] })
+
+const feeUnsigned = (fee: FeeEvent, field: FeeIntegerField): Validation<bigint> =>
+  unsigned({ kind: 'fee', feeId: fee.id, field, value: fee[field] })
+
+const markUnsigned = (mark: DailyPositionMark, field: MarkIntegerField): Validation<bigint> =>
+  unsigned({ kind: 'daily-mark', sessionDate: mark.sessionDate, field, value: mark[field] })
+
+const positionUnsigned = (
+  mark: DailyPositionMark,
+  position: DailyPositionMark['positions'][number],
+  field: PositionIntegerField,
+): Validation<bigint> =>
+  unsigned({ kind: 'position', sessionDate: mark.sessionDate, symbol: position.symbol, field, value: position[field] })
+
+const absolute = (value: bigint): bigint => (value < 0n ? -value : value)
+
+const invalidIdentityFormat = (evidence: IdentityEvidence): Validation<never> => {
+  if (evidence.kind === 'run') {
+    return fail({
+      _tag: 'InvalidIdentity',
+      evidence,
+      problem: { _tag: 'InvalidFormat', expected: 'lowercase-sha256' },
     })
   }
-  ensure(eventIndex === monetaryEvents.length, 'simulation has monetary events after its final daily mark')
+  return fail({
+    _tag: 'InvalidIdentity',
+    evidence,
+    problem: { _tag: 'InvalidFormat', expected: 'lowercase-sha256' },
+  })
+}
 
-  const evaluatorEnding = unsigned(input.evaluatorEndingEquityMicros, 'evaluator ending equity')
-  const evaluatorTotalFees = unsigned(input.evaluatorTotalFeesMicros, 'evaluator total fees')
-  const feeDifference = absolute(reconstructedTotalFees - evaluatorTotalFees)
-  ensure(feeDifference <= tolerance, 'reconstructed fees exceed the declared tolerance')
-  const reconstructedEnding = cash + finalPositionValue
-  const finalDifference = absolute(reconstructedEnding - evaluatorEnding)
-  ensure(finalDifference <= tolerance, 'final marked equity exceeds the declared tolerance')
-  maximumDifference = maximumDifference > finalDifference ? maximumDifference : finalDifference
+const invalidCanonicalIdentity = (
+  evidence: CanonicalIdentityEvidence,
+  problem: CanonicalIdentityProblem,
+): Validation<never> =>
+  fail({
+    _tag: 'InvalidIdentity',
+    evidence,
+    problem,
+  })
 
-  return {
+const validateIdentityFormat = (evidence: IdentityEvidence): Validation<void> =>
+  /^[0-9a-f]{64}$/.test(evidence.id) ? Result.succeed(undefined) : invalidIdentityFormat(evidence)
+
+const validateCanonicalIdentity = (evidence: CanonicalIdentityEvidence, material: unknown): Validation<void> => {
+  const expectedResult = Result.try({
+    try: () => canonicalHashV1(material),
+    catch: (cause): readonly SimulationReconciliationIssue[] => [
+      {
+        _tag: 'InvalidIdentity',
+        evidence,
+        problem: { _tag: 'CanonicalizationFailed', cause },
+      },
+    ],
+  })
+  if (Result.isFailure(expectedResult)) return failIssues(expectedResult.failure)
+  return evidence.id === expectedResult.success
+    ? Result.succeed(undefined)
+    : invalidCanonicalIdentity(evidence, {
+        _tag: 'HashMismatch',
+        expected: expectedResult.success,
+      })
+}
+
+type IndexedIdentity = CanonicalIdentityEvidence
+
+const indexUnique = <A extends { readonly id: string }>(
+  values: readonly A[],
+  entity: Extract<InvalidEvidenceStateProblem, { readonly _tag: 'DuplicateIdentity' }>['entity'],
+  evidenceFor: (value: A) => IndexedIdentity,
+): Validation<ReadonlyMap<string, A>> => {
+  const byId = new Map<string, A>()
+  for (const value of values) {
+    const identity = evidenceFor(value)
+    const format = validateIdentityFormat(identity)
+    if (Result.isFailure(format)) return failIssues(format.failure)
+    if (byId.has(value.id)) {
+      return fail({ _tag: 'InvalidEvidenceState', problem: { _tag: 'DuplicateIdentity', entity, id: value.id } })
+    }
+    byId.set(value.id, value)
+  }
+  return Result.succeed(byId)
+}
+
+const validateDecisionIdentity = (runId: string, decision: DecisionEvent): Validation<void> => {
+  const { id: _, kind: __, ...payload } = decision
+  return validateCanonicalIdentity(
+    { kind: 'decision', id: decision.id, signalDate: decision.signalDate },
+    { runId, kind: 'decision', ...payload },
+  )
+}
+
+const fillBindingIssue = (
+  fill: FillEvent,
+  order: SimulatedOrder,
+  field: Extract<EvidenceMismatchProblem, { readonly _tag: 'FillBinding' }>['field'],
+  actual: string,
+  expected: string,
+): SimulationReconciliationIssue => ({
+  _tag: 'EvidenceMismatch',
+  problem: { _tag: 'FillBinding', fillId: fill.id, orderId: order.id, field, actual, expected },
+})
+
+interface ValidatedFill {
+  readonly kind: 'fill'
+  readonly event: FillEvent
+  readonly quantityMicros: bigint
+  readonly notionalMicros: bigint
+  readonly spreadCostMicros: bigint
+  readonly slippageCostMicros: bigint
+}
+
+const computeFillTerms = (
+  fill: FillEvent,
+  quantityMicros: bigint,
+  referencePriceMicros: bigint,
+  simulation: SimulationTrace,
+  costMultiplierMicros: bigint,
+): Validation<ReturnType<typeof makeFillTerms>> => {
+  const computation: FailedComputation = {
+    _tag: 'FillTerms',
+    fillId: fill.id,
+    side: fill.side,
+    quantityMicros: quantityMicros.toString(),
+    referencePriceMicros: referencePriceMicros.toString(),
+    costMultiplierMicros: costMultiplierMicros.toString(),
+  }
+  return Result.try({
+    try: () =>
+      makeFillTerms(fill.side, quantityMicros, referencePriceMicros, simulation.executionModel, costMultiplierMicros),
+    catch: (cause): readonly SimulationReconciliationIssue[] => [{ _tag: 'ComputationFailed', computation, cause }],
+  })
+}
+
+const validateFill = (
+  runId: string,
+  fill: FillEvent,
+  order: SimulatedOrder,
+  orderQuantityMicros: bigint,
+  simulation: SimulationTrace,
+  costMultiplierMicros: bigint,
+): Validation<ValidatedFill> => {
+  const bindingIssues: SimulationReconciliationIssue[] = []
+  if (fill.decisionId !== order.decisionId) {
+    bindingIssues.push(fillBindingIssue(fill, order, 'decisionId', fill.decisionId, order.decisionId))
+  }
+  if (fill.sessionDate !== order.sessionDate) {
+    bindingIssues.push(fillBindingIssue(fill, order, 'sessionDate', fill.sessionDate, order.sessionDate))
+  }
+  if (fill.symbol !== order.symbol) {
+    bindingIssues.push(fillBindingIssue(fill, order, 'symbol', fill.symbol, order.symbol))
+  }
+  if (fill.side !== order.side) {
+    bindingIssues.push(fillBindingIssue(fill, order, 'side', fill.side, order.side))
+  }
+  if (bindingIssues.length > 0) return failIssues(bindingIssues)
+
+  const quantity = fillUnsigned(fill, 'quantityMicros')
+  if (Result.isFailure(quantity)) return failIssues(quantity.failure)
+  if (quantity.success !== orderQuantityMicros) {
+    return fail({
+      _tag: 'EvidenceMismatch',
+      problem: {
+        _tag: 'FillQuantity',
+        fillId: fill.id,
+        orderId: order.id,
+        actualQuantityMicros: quantity.success.toString(),
+        expectedQuantityMicros: orderQuantityMicros.toString(),
+      },
+    })
+  }
+
+  const referencePrice = fillUnsigned(fill, 'referencePriceMicros')
+  if (Result.isFailure(referencePrice)) return failIssues(referencePrice.failure)
+  const terms = computeFillTerms(fill, quantity.success, referencePrice.success, simulation, costMultiplierMicros)
+  if (Result.isFailure(terms)) return failIssues(terms.failure)
+
+  const termIssues: SimulationReconciliationIssue[] = []
+  const termIssue = (
+    field: Extract<EvidenceMismatchProblem, { readonly _tag: 'FillTerms' }>['field'],
+    actualMicros: bigint,
+    expectedMicros: bigint,
+  ): void => {
+    if (actualMicros !== expectedMicros) {
+      termIssues.push({
+        _tag: 'EvidenceMismatch',
+        problem: {
+          _tag: 'FillTerms',
+          fillId: fill.id,
+          field,
+          actualMicros: actualMicros.toString(),
+          expectedMicros: expectedMicros.toString(),
+        },
+      })
+    }
+  }
+  const price = fillUnsigned(fill, 'priceMicros')
+  if (Result.isFailure(price)) return failIssues(price.failure)
+  termIssue('priceMicros', price.success, terms.success.fillPriceMicros)
+  const notional = fillUnsigned(fill, 'notionalMicros')
+  if (Result.isFailure(notional)) return termIssues.length > 0 ? failIssues(termIssues) : failIssues(notional.failure)
+  termIssue('notionalMicros', notional.success, terms.success.notionalMicros)
+  const spread = fillUnsigned(fill, 'spreadCostMicros')
+  if (Result.isFailure(spread)) return termIssues.length > 0 ? failIssues(termIssues) : failIssues(spread.failure)
+  termIssue('spreadCostMicros', spread.success, terms.success.spreadCostMicros)
+  const slippage = fillUnsigned(fill, 'slippageCostMicros')
+  if (Result.isFailure(slippage)) return termIssues.length > 0 ? failIssues(termIssues) : failIssues(slippage.failure)
+  termIssue('slippageCostMicros', slippage.success, terms.success.slippageCostMicros)
+  if (termIssues.length > 0) return failIssues(termIssues)
+
+  const costBasis = fillUnsigned(fill, 'costBasisMicros')
+  if (Result.isFailure(costBasis)) return failIssues(costBasis.failure)
+  const { id: _, kind: __, ...payload } = fill
+  const identity = validateCanonicalIdentity(
+    { kind: 'fill', id: fill.id, sessionDate: fill.sessionDate },
+    { runId, kind: 'fill', ...payload },
+  )
+  if (Result.isFailure(identity)) return failIssues(identity.failure)
+  return Result.succeed({
+    kind: 'fill',
+    event: fill,
+    quantityMicros: quantity.success,
+    notionalMicros: notional.success,
+    spreadCostMicros: spread.success,
+    slippageCostMicros: slippage.success,
+  })
+}
+
+const invalidOrder = (
+  order: SimulatedOrder,
+  fill: FillEvent | undefined,
+  rule: Extract<InvalidEvidenceStateProblem, { readonly _tag: 'InvalidOrder' }>['rule'],
+): Validation<never> =>
+  fail({
+    _tag: 'InvalidEvidenceState',
+    problem: {
+      _tag: 'InvalidOrder',
+      rule,
+      orderId: order.id,
+      status: order.status,
+      requestedQuantityMicros: order.requestedQuantityMicros,
+      filledQuantityMicros: order.filledQuantityMicros,
+      rejectionReason: order.rejectionReason,
+      unfilledRemainder: order.unfilledRemainder,
+      fillPresent: fill !== undefined,
+    },
+  })
+
+const validateOrder = (
+  runId: string,
+  order: SimulatedOrder,
+  fill: FillEvent | undefined,
+  decisions: ReadonlyMap<string, DecisionEvent>,
+  simulation: SimulationTrace,
+  costMultiplierMicros: bigint,
+): Validation<ValidatedFill | undefined> => {
+  const decision = decisions.get(order.decisionId)
+  if (decision === undefined) {
+    return fail({
+      _tag: 'MissingReference',
+      problem: { _tag: 'OrderDecision', orderId: order.id, decisionId: order.decisionId },
+    })
+  }
+  if (decision.executionDate !== order.sessionDate) {
+    return fail({
+      _tag: 'EvidenceMismatch',
+      problem: {
+        _tag: 'OrderExecutionSession',
+        orderId: order.id,
+        decisionId: decision.id,
+        actualSessionDate: order.sessionDate,
+        expectedSessionDate: decision.executionDate,
+      },
+    })
+  }
+
+  const requested = orderUnsigned(order, 'requestedQuantityMicros')
+  if (Result.isFailure(requested)) return failIssues(requested.failure)
+  const filled = orderUnsigned(order, 'filledQuantityMicros')
+  if (Result.isFailure(filled)) return failIssues(filled.failure)
+  if (filled.success > requested.success) return invalidOrder(order, fill, 'filled-not-over-requested')
+  if (order.status === 'filled') {
+    if (
+      requested.success <= 0n ||
+      filled.success !== requested.success ||
+      order.rejectionReason !== null ||
+      order.unfilledRemainder !== 'none'
+    ) {
+      return invalidOrder(order, fill, 'status-consistency')
+    }
+  } else if (order.status === 'partially-filled') {
+    if (
+      filled.success <= 0n ||
+      filled.success >= requested.success ||
+      order.rejectionReason !== null ||
+      order.unfilledRemainder !== 'canceled'
+    ) {
+      return invalidOrder(order, fill, 'status-consistency')
+    }
+  } else if (filled.success !== 0n || order.rejectionReason === null || order.unfilledRemainder !== 'canceled') {
+    return invalidOrder(order, fill, 'status-consistency')
+  }
+  if ((fill === undefined) !== (filled.success === 0n)) return invalidOrder(order, fill, 'fill-presence')
+
+  const { id: _, ...payload } = order
+  const identity = validateCanonicalIdentity(
+    { kind: 'order', id: order.id, sessionDate: order.sessionDate },
+    { runId, kind: 'order', ...payload },
+  )
+  if (Result.isFailure(identity)) return failIssues(identity.failure)
+  return fill === undefined
+    ? Result.succeed(undefined)
+    : validateFill(runId, fill, order, filled.success, simulation, costMultiplierMicros)
+}
+
+interface ValidatedFee {
+  readonly kind: 'fee'
+  readonly event: FeeEvent
+  readonly totalMicros: bigint
+}
+
+const feeSchedule = (
+  fee: FeeEvent,
+  inputs: readonly FeeInput[],
+  simulation: SimulationTrace,
+  costMultiplierMicros: bigint,
+): Validation<ReturnType<typeof calculateSessionFees>> => {
+  const computation: FailedComputation = {
+    _tag: 'FeeSchedule',
+    feeId: fee.id,
+    fillCount: inputs.length,
+    costMultiplierMicros: costMultiplierMicros.toString(),
+  }
+  return Result.try({
+    try: () => calculateSessionFees(inputs, simulation.executionModel, costMultiplierMicros),
+    catch: (cause): readonly SimulationReconciliationIssue[] => [{ _tag: 'ComputationFailed', computation, cause }],
+  })
+}
+
+const validateFee = (
+  runId: string,
+  fee: FeeEvent,
+  sessionFills: readonly ValidatedFill[],
+  simulation: SimulationTrace,
+  costMultiplierMicros: bigint,
+): Validation<ValidatedFee> => {
+  const commission = feeUnsigned(fee, 'commissionMicros')
+  if (Result.isFailure(commission)) return failIssues(commission.failure)
+  const sec = feeUnsigned(fee, 'secMicros')
+  if (Result.isFailure(sec)) return failIssues(sec.failure)
+  const taf = feeUnsigned(fee, 'tafMicros')
+  if (Result.isFailure(taf)) return failIssues(taf.failure)
+  const cat = feeUnsigned(fee, 'catMicros')
+  if (Result.isFailure(cat)) return failIssues(cat.failure)
+  const total = feeUnsigned(fee, 'totalMicros')
+  if (Result.isFailure(total)) return failIssues(total.failure)
+  const componentTotal = commission.success + sec.success + taf.success + cat.success
+  if (componentTotal !== total.success) {
+    return fail({
+      _tag: 'EvidenceMismatch',
+      problem: {
+        _tag: 'FeeComponents',
+        feeId: fee.id,
+        actualTotalMicros: total.success.toString(),
+        expectedTotalMicros: componentTotal.toString(),
+      },
+    })
+  }
+
+  const inputs: FeeInput[] = sessionFills.map((fill) => ({
+    side: fill.event.side,
+    quantityMicros: fill.quantityMicros,
+    notionalMicros: fill.notionalMicros,
+  }))
+  const expected = feeSchedule(fee, inputs, simulation, costMultiplierMicros)
+  if (Result.isFailure(expected)) return failIssues(expected.failure)
+
+  const comparisons: readonly [
+    Extract<EvidenceMismatchProblem, { readonly _tag: 'FeeSchedule' }>['field'],
+    bigint,
+    bigint,
+  ][] = [
+    ['commissionMicros', commission.success, expected.success.commissionMicros],
+    ['secMicros', sec.success, expected.success.secMicros],
+    ['tafMicros', taf.success, expected.success.tafMicros],
+    ['catMicros', cat.success, expected.success.catMicros],
+    ['totalMicros', total.success, expected.success.totalMicros],
+  ]
+  const scheduleIssues: SimulationReconciliationIssue[] = []
+  for (const [field, actual, calculated] of comparisons) {
+    if (actual !== calculated) {
+      scheduleIssues.push({
+        _tag: 'EvidenceMismatch',
+        problem: {
+          _tag: 'FeeSchedule',
+          feeId: fee.id,
+          field,
+          actualMicros: actual.toString(),
+          expectedMicros: calculated.toString(),
+        },
+      })
+    }
+  }
+  if (scheduleIssues.length > 0) return failIssues(scheduleIssues)
+  const { id: _, kind: __, ...payload } = fee
+  const identity = validateCanonicalIdentity(
+    { kind: 'fee', id: fee.id, sessionDate: fee.sessionDate },
+    { runId, kind: 'fee', ...payload },
+  )
+  if (Result.isFailure(identity)) return failIssues(identity.failure)
+  return Result.succeed({
+    kind: 'fee',
+    event: fee,
+    totalMicros: total.success,
+  })
+}
+
+const validateCashChange = (
+  runId: string,
+  change: CashChange,
+  event: FillEvent | FeeEvent | CashYieldEvent,
+  amountMicros: bigint,
+  cashAfterMicros: bigint,
+): Validation<void> => {
+  const mismatch = (
+    field: Extract<EvidenceMismatchProblem, { readonly _tag: 'CashChange' }>['field'],
+    actual: string,
+    expected: string,
+  ): SimulationReconciliationIssue => ({
+    _tag: 'EvidenceMismatch',
+    problem: {
+      _tag: 'CashChange',
+      cashChangeId: change.id,
+      sourceId: event.id,
+      field,
+      actual,
+      expected,
+    },
+  })
+  const bindingIssues: SimulationReconciliationIssue[] = []
+  if (change.sourceKind !== event.kind) bindingIssues.push(mismatch('sourceKind', change.sourceKind, event.kind))
+  if (change.sessionDate !== event.sessionDate) {
+    bindingIssues.push(mismatch('sessionDate', change.sessionDate, event.sessionDate))
+  }
+  if (bindingIssues.length > 0) return failIssues(bindingIssues)
+  const amount = signed({
+    kind: 'cash-change',
+    cashChangeId: change.id,
+    field: 'amountMicros',
+    value: change.amountMicros,
+  })
+  if (Result.isFailure(amount)) return failIssues(amount.failure)
+  const valueIssues: SimulationReconciliationIssue[] = []
+  if (amount.success !== amountMicros) {
+    valueIssues.push(mismatch('amountMicros', amount.success.toString(), amountMicros.toString()))
+  }
+  const cashAfter = signed({
+    kind: 'cash-change',
+    cashChangeId: change.id,
+    field: 'cashAfterMicros',
+    value: change.cashAfterMicros,
+  })
+  if (Result.isFailure(cashAfter)) {
+    return valueIssues.length > 0 ? failIssues(valueIssues) : Result.fail(cashAfter.failure)
+  }
+  if (cashAfter.success !== cashAfterMicros) {
+    valueIssues.push(mismatch('cashAfterMicros', cashAfter.success.toString(), cashAfterMicros.toString()))
+  }
+  if (valueIssues.length > 0) return failIssues(valueIssues)
+  const { id: _, ...payload } = change
+  return validateCanonicalIdentity(
+    { kind: 'cash-change', id: change.id, sourceId: change.sourceId, sessionDate: change.sessionDate },
+    { runId, kind: 'cash-change', ...payload },
+  )
+}
+
+const validateMarks = (marks: readonly DailyPositionMark[]): Validation<void> => {
+  if (marks.length === 0) return fail({ _tag: 'IncompleteEvidence', problem: { _tag: 'EmptyDailyMarks' } })
+  for (let index = 0; index < marks.length; index += 1) {
+    const mark = marks[index]
+    const previous = marks[index - 1]
+    if (previous !== undefined && previous.sessionDate >= mark.sessionDate) {
+      return fail({
+        _tag: 'InvalidEvidenceState',
+        problem: {
+          _tag: 'InvalidMarkOrder',
+          previousSessionDate: previous.sessionDate,
+          sessionDate: mark.sessionDate,
+        },
+      })
+    }
+    const symbols = mark.positions.map((position) => position.symbol)
+    if (new Set(symbols).size !== symbols.length) {
+      return fail({
+        _tag: 'InvalidEvidenceState',
+        problem: { _tag: 'DuplicateMarkedPosition', sessionDate: mark.sessionDate, symbols },
+      })
+    }
+    if (symbols.some((symbol, symbolIndex) => symbolIndex > 0 && symbols[symbolIndex - 1] >= symbol)) {
+      return fail({
+        _tag: 'InvalidEvidenceState',
+        problem: { _tag: 'UnsortedMarkedPositions', sessionDate: mark.sessionDate, symbols },
+      })
+    }
+  }
+  return Result.succeed(undefined)
+}
+
+interface PreparedReconciliation {
+  readonly input: MarkedEquityReconciliationInput
+  readonly toleranceMicros: bigint
+  readonly monetaryEvents: readonly PreparedMonetaryEvent[]
+}
+
+const validateDecisions = (
+  runId: string,
+  events: readonly EvaluationEvent[],
+): Validation<ReadonlyMap<string, DecisionEvent>> => {
+  const decisionValues = events.filter((event): event is DecisionEvent => event.kind === 'decision')
+  const decisions = indexUnique(decisionValues, 'decision', (decision) => ({
+    kind: 'decision',
+    id: decision.id,
+    signalDate: decision.signalDate,
+  }))
+  if (Result.isFailure(decisions)) return failIssues(decisions.failure)
+  for (const decision of decisions.success.values()) {
+    const identity = validateDecisionIdentity(runId, decision)
+    if (Result.isFailure(identity)) return failIssues(identity.failure)
+  }
+  return decisions
+}
+
+const validateOrdersAndFills = (
+  runId: string,
+  events: readonly EvaluationEvent[],
+  simulation: SimulationTrace,
+  decisions: ReadonlyMap<string, DecisionEvent>,
+  costMultiplierMicros: bigint,
+): Validation<readonly ValidatedFill[]> => {
+  const fills = events.filter((event): event is FillEvent => event.kind === 'fill')
+  const indexedFills = indexUnique(fills, 'fill', (fill) => ({
+    kind: 'fill',
+    id: fill.id,
+    sessionDate: fill.sessionDate,
+  }))
+  if (Result.isFailure(indexedFills)) return failIssues(indexedFills.failure)
+  const fillsByOrder = new Map<string, { readonly event: FillEvent; readonly eventIndex: number }>()
+  for (let eventIndex = 0; eventIndex < fills.length; eventIndex += 1) {
+    const fill = fills[eventIndex]
+    if (fillsByOrder.has(fill.orderId)) {
+      return fail({
+        _tag: 'InvalidEvidenceState',
+        problem: { _tag: 'DuplicateFillForOrder', orderId: fill.orderId, secondFillId: fill.id },
+      })
+    }
+    fillsByOrder.set(fill.orderId, { event: fill, eventIndex })
+  }
+
+  const orders = indexUnique(simulation.orders, 'order', (order) => ({
+    kind: 'order',
+    id: order.id,
+    sessionDate: order.sessionDate,
+  }))
+  if (Result.isFailure(orders)) return failIssues(orders.failure)
+  const preparedFills: { readonly eventIndex: number; readonly fill: ValidatedFill }[] = []
+  for (const order of orders.success.values()) {
+    const indexedFill = fillsByOrder.get(order.id)
+    const valid = validateOrder(runId, order, indexedFill?.event, decisions, simulation, costMultiplierMicros)
+    if (Result.isFailure(valid)) return failIssues(valid.failure)
+    if (valid.success !== undefined && indexedFill !== undefined) {
+      preparedFills.push({ eventIndex: indexedFill.eventIndex, fill: valid.success })
+    }
+  }
+  for (const fill of fills) {
+    if (!orders.success.has(fill.orderId)) {
+      return fail({
+        _tag: 'MissingReference',
+        problem: { _tag: 'FillOrder', fillId: fill.id, orderId: fill.orderId },
+      })
+    }
+  }
+  preparedFills.sort((left, right) => left.eventIndex - right.eventIndex)
+  return Result.succeed(preparedFills.map(({ fill }) => fill))
+}
+
+const validateFeesAndYields = (
+  runId: string,
+  events: readonly EvaluationEvent[],
+  fills: readonly ValidatedFill[],
+  simulation: SimulationTrace,
+  costMultiplierMicros: bigint,
+): Validation<readonly ValidatedFee[]> => {
+  const fees = events.filter((event): event is FeeEvent => event.kind === 'fee')
+  const indexedFees = indexUnique(fees, 'fee', (fee) => ({
+    kind: 'fee',
+    id: fee.id,
+    sessionDate: fee.sessionDate,
+  }))
+  if (Result.isFailure(indexedFees)) return failIssues(indexedFees.failure)
+  const cashYields = events.filter((event): event is CashYieldEvent => event.kind === 'cash-yield')
+  const indexedCashYields = indexUnique(cashYields, 'cash-yield', (event) => ({
+    kind: 'cash-yield',
+    id: event.id,
+    sessionDate: event.sessionDate,
+  }))
+  if (Result.isFailure(indexedCashYields)) return failIssues(indexedCashYields.failure)
+  const fillsBySession = new Map<string, ValidatedFill[]>()
+  for (const fill of fills) {
+    const sessionFills = fillsBySession.get(fill.event.sessionDate)
+    if (sessionFills === undefined) {
+      fillsBySession.set(fill.event.sessionDate, [fill])
+    } else {
+      sessionFills.push(fill)
+    }
+  }
+  const preparedFees: ValidatedFee[] = []
+  for (const fee of fees) {
+    const valid = validateFee(runId, fee, fillsBySession.get(fee.sessionDate) ?? [], simulation, costMultiplierMicros)
+    if (Result.isFailure(valid)) return failIssues(valid.failure)
+    preparedFees.push(valid.success)
+  }
+  return Result.succeed(preparedFees)
+}
+
+interface PreparedFill extends ValidatedFill {
+  readonly cashChange: CashChange
+}
+
+interface PreparedFee extends ValidatedFee {
+  readonly cashChange: CashChange
+}
+
+interface PreparedCashYield {
+  readonly kind: 'cash-yield'
+  readonly event: CashYieldEvent
+  readonly cashChange: CashChange
+}
+
+type PreparedMonetaryEvent = PreparedFill | PreparedFee | PreparedCashYield
+
+interface MonetaryEvidence {
+  readonly events: readonly PreparedMonetaryEvent[]
+}
+
+const validateMonetaryEvidence = (
+  events: readonly EvaluationEvent[],
+  cashChanges: readonly CashChange[],
+  fills: readonly ValidatedFill[],
+  fees: readonly ValidatedFee[],
+): Validation<MonetaryEvidence> => {
+  const sourceEvents = events.filter(
+    (event): event is FillEvent | FeeEvent | CashYieldEvent => event.kind !== 'decision',
+  )
+  const changes = indexUnique(cashChanges, 'cash-change', (change) => ({
+    kind: 'cash-change',
+    id: change.id,
+    sourceId: change.sourceId,
+    sessionDate: change.sessionDate,
+  }))
+  if (Result.isFailure(changes)) return failIssues(changes.failure)
+  const cashChangesBySource = new Map<string, CashChange>()
+  for (const change of changes.success.values()) {
+    if (cashChangesBySource.has(change.sourceId)) {
+      return fail({
+        _tag: 'InvalidEvidenceState',
+        problem: {
+          _tag: 'DuplicateCashChangeForEvent',
+          eventId: change.sourceId,
+          secondCashChangeId: change.id,
+        },
+      })
+    }
+    cashChangesBySource.set(change.sourceId, change)
+  }
+  if (changes.success.size !== sourceEvents.length) {
+    return fail({
+      _tag: 'IncompleteEvidence',
+      problem: {
+        _tag: 'CashChangeCountMismatch',
+        cashChangeCount: changes.success.size,
+        monetaryEventCount: sourceEvents.length,
+      },
+    })
+  }
+  const monetaryEvents: PreparedMonetaryEvent[] = []
+  let fillIndex = 0
+  let feeIndex = 0
+  for (const event of sourceEvents) {
+    const cashChange = cashChangesBySource.get(event.id)
+    if (cashChange === undefined) {
+      return fail({
+        _tag: 'MissingReference',
+        problem: { _tag: 'MonetaryEventCashChange', eventId: event.id, eventKind: event.kind },
+      })
+    }
+    if (event.kind === 'cash-yield') {
+      monetaryEvents.push({ kind: 'cash-yield', event, cashChange })
+      continue
+    }
+    if (event.kind === 'fill') {
+      monetaryEvents.push({ ...fills[fillIndex], cashChange })
+      fillIndex += 1
+    } else {
+      monetaryEvents.push({ ...fees[feeIndex], cashChange })
+      feeIndex += 1
+    }
+  }
+  return Result.succeed({ events: monetaryEvents })
+}
+
+const prepareReconciliation = (input: MarkedEquityReconciliationInput): Validation<PreparedReconciliation> => {
+  const toleranceMicros = input.toleranceMicros ?? MARKED_EQUITY_TOLERANCE_MICROS
+  if (toleranceMicros < 0n) {
+    return fail({
+      _tag: 'InvalidEvidenceState',
+      problem: { _tag: 'NegativeTolerance', toleranceMicros: toleranceMicros.toString() },
+    })
+  }
+  const runIdentity = validateIdentityFormat({ kind: 'run', id: input.runId })
+  if (Result.isFailure(runIdentity)) return failIssues(runIdentity.failure)
+  if (input.simulation.schemaVersion !== 'bayn.simulation-trace.v3') {
+    return fail({
+      _tag: 'InvalidEvidenceState',
+      problem: {
+        _tag: 'UnsupportedSimulationSchema',
+        actual: input.simulation.schemaVersion,
+        expected: 'bayn.simulation-trace.v3',
+      },
+    })
+  }
+  const costMultiplierMicros = positiveUnsigned({
+    kind: 'simulation',
+    field: 'costMultiplierMicros',
+    value: input.simulation.costMultiplierMicros,
+  })
+  if (Result.isFailure(costMultiplierMicros)) return failIssues(costMultiplierMicros.failure)
+  const decisions = validateDecisions(input.runId, input.events)
+  if (Result.isFailure(decisions)) return failIssues(decisions.failure)
+  const fills = validateOrdersAndFills(
+    input.runId,
+    input.events,
+    input.simulation,
+    decisions.success,
+    costMultiplierMicros.success,
+  )
+  if (Result.isFailure(fills)) return failIssues(fills.failure)
+  const fees = validateFeesAndYields(
+    input.runId,
+    input.events,
+    fills.success,
+    input.simulation,
+    costMultiplierMicros.success,
+  )
+  if (Result.isFailure(fees)) return failIssues(fees.failure)
+  const monetaryEvidence = validateMonetaryEvidence(
+    input.events,
+    input.simulation.cashChanges,
+    fills.success,
+    fees.success,
+  )
+  if (Result.isFailure(monetaryEvidence)) return failIssues(monetaryEvidence.failure)
+  const marks = validateMarks(input.simulation.dailyMarks)
+  if (Result.isFailure(marks)) return failIssues(marks.failure)
+
+  return Result.succeed({
+    input,
+    toleranceMicros,
+    monetaryEvents: monetaryEvidence.success.events,
+  })
+}
+
+interface MutableReconstructionState {
+  cashMicros: bigint
+  readonly quantities: Map<string, bigint>
+  eventIndex: number
+  reconstructedTotalFeesMicros: bigint
+  cumulativeTurnoverMicros: bigint
+  cumulativeSpreadMicros: bigint
+  cumulativeSlippageMicros: bigint
+  cumulativeCashYieldMicros: bigint
+  maximumDifferenceMicros: bigint
+  finalPositionValueMicros: bigint
+  readonly equitySeries: EquityPoint[]
+}
+
+interface EventTransition {
+  readonly amountMicros: bigint
+  readonly quantityChange?: { readonly symbol: string; readonly quantityMicros: bigint }
+  readonly feeMicros: bigint
+  readonly turnoverMicros: bigint
+  readonly spreadMicros: bigint
+  readonly slippageMicros: bigint
+  readonly cashYieldMicros: bigint
+}
+
+const fillTransition = (state: MutableReconstructionState, fill: PreparedFill): Validation<EventTransition> => {
+  const event = fill.event
+  const current = state.quantities.get(event.symbol) ?? 0n
+  const next = event.side === 'buy' ? current + fill.quantityMicros : current - fill.quantityMicros
+  if (next < 0n) {
+    return fail({
+      _tag: 'InvalidEvidenceState',
+      problem: {
+        _tag: 'NegativeLongPosition',
+        fillId: event.id,
+        symbol: event.symbol,
+        actualQuantityMicros: next.toString(),
+      },
+    })
+  }
+  return Result.succeed({
+    amountMicros: event.side === 'buy' ? -fill.notionalMicros : fill.notionalMicros,
+    quantityChange: { symbol: event.symbol, quantityMicros: next },
+    feeMicros: 0n,
+    turnoverMicros: fill.notionalMicros,
+    spreadMicros: fill.spreadCostMicros,
+    slippageMicros: fill.slippageCostMicros,
+    cashYieldMicros: 0n,
+  })
+}
+
+const feeTransition = (fee: PreparedFee): EventTransition => ({
+  amountMicros: -fee.totalMicros,
+  feeMicros: fee.totalMicros,
+  turnoverMicros: 0n,
+  spreadMicros: 0n,
+  slippageMicros: 0n,
+  cashYieldMicros: 0n,
+})
+
+const cashYieldTransition = (
+  runId: string,
+  cashMicros: bigint,
+  event: CashYieldEvent,
+  simulation: SimulationTrace,
+): Validation<EventTransition> => {
+  if (event.annualYieldBps !== simulation.executionModel.cash.annualYieldBps) {
+    return fail({
+      _tag: 'EvidenceMismatch',
+      problem: {
+        _tag: 'CashYield',
+        cashYieldId: event.id,
+        field: 'annualYieldBps',
+        actual: String(event.annualYieldBps),
+        expected: String(simulation.executionModel.cash.annualYieldBps),
+      },
+    })
+  }
+  const computation: FailedComputation = {
+    _tag: 'CashYield',
+    cashYieldId: event.id,
+    cashMicros: cashMicros.toString(),
+    elapsedDays: event.elapsedDays,
+    annualYieldBps: simulation.executionModel.cash.annualYieldBps,
+  }
+  const expected = Result.try({
+    try: () => accrueCashYield(cashMicros, event.elapsedDays, simulation.executionModel),
+    catch: (cause): readonly SimulationReconciliationIssue[] => [{ _tag: 'ComputationFailed', computation, cause }],
+  })
+  if (Result.isFailure(expected)) return failIssues(expected.failure)
+  const amount = unsigned({
+    kind: 'cash-yield',
+    cashYieldId: event.id,
+    field: 'amountMicros',
+    value: event.amountMicros,
+  })
+  if (Result.isFailure(amount)) return failIssues(amount.failure)
+  if (amount.success !== expected.success) {
+    return fail({
+      _tag: 'EvidenceMismatch',
+      problem: {
+        _tag: 'CashYield',
+        cashYieldId: event.id,
+        field: 'amountMicros',
+        actual: amount.success.toString(),
+        expected: expected.success.toString(),
+      },
+    })
+  }
+  const { id: _, kind: __, ...payload } = event
+  const identity = validateCanonicalIdentity(
+    { kind: 'cash-yield', id: event.id, sessionDate: event.sessionDate },
+    { runId, kind: 'cash-yield', ...payload },
+  )
+  if (Result.isFailure(identity)) return failIssues(identity.failure)
+  return Result.succeed({
+    amountMicros: expected.success,
+    feeMicros: 0n,
+    turnoverMicros: 0n,
+    spreadMicros: 0n,
+    slippageMicros: 0n,
+    cashYieldMicros: expected.success,
+  })
+}
+
+const eventTransition = (
+  prepared: PreparedReconciliation,
+  state: MutableReconstructionState,
+  preparedEvent: PreparedMonetaryEvent,
+): Validation<EventTransition> => {
+  switch (preparedEvent.kind) {
+    case 'fill':
+      return fillTransition(state, preparedEvent)
+    case 'fee':
+      return Result.succeed(feeTransition(preparedEvent))
+    case 'cash-yield':
+      return cashYieldTransition(prepared.input.runId, state.cashMicros, preparedEvent.event, prepared.input.simulation)
+  }
+}
+
+const applyEvent = (
+  prepared: PreparedReconciliation,
+  state: MutableReconstructionState,
+  preparedEvent: PreparedMonetaryEvent,
+): Validation<void> => {
+  const event = preparedEvent.event
+  const transition = eventTransition(prepared, state, preparedEvent)
+  if (Result.isFailure(transition)) return failIssues(transition.failure)
+  const cashMicros = state.cashMicros + transition.success.amountMicros
+  if (cashMicros < -prepared.toleranceMicros) {
+    return fail({
+      _tag: 'InvalidEvidenceState',
+      problem: {
+        _tag: 'NegativeCash',
+        eventId: event.id,
+        actualMicros: cashMicros.toString(),
+        minimumMicros: (-prepared.toleranceMicros).toString(),
+      },
+    })
+  }
+  const validChange = validateCashChange(
+    prepared.input.runId,
+    preparedEvent.cashChange,
+    event,
+    transition.success.amountMicros,
+    cashMicros,
+  )
+  if (Result.isFailure(validChange)) return failIssues(validChange.failure)
+  const quantityChange = transition.success.quantityChange
+  if (quantityChange !== undefined) {
+    if (quantityChange.quantityMicros === 0n) {
+      state.quantities.delete(quantityChange.symbol)
+    } else {
+      state.quantities.set(quantityChange.symbol, quantityChange.quantityMicros)
+    }
+  }
+  state.cashMicros = cashMicros
+  state.eventIndex += 1
+  state.reconstructedTotalFeesMicros += transition.success.feeMicros
+  state.cumulativeTurnoverMicros += transition.success.turnoverMicros
+  state.cumulativeSpreadMicros += transition.success.spreadMicros
+  state.cumulativeSlippageMicros += transition.success.slippageMicros
+  state.cumulativeCashYieldMicros += transition.success.cashYieldMicros
+  return Result.succeed(undefined)
+}
+
+interface MarkBaselines {
+  readonly turnoverMicros: bigint
+  readonly feeMicros: bigint
+  readonly spreadMicros: bigint
+  readonly slippageMicros: bigint
+  readonly cashYieldMicros: bigint
+}
+
+const validateDailyMarkCounters = (
+  mark: DailyPositionMark,
+  state: MutableReconstructionState,
+  baselines: MarkBaselines,
+): Validation<void> => {
+  const checks: readonly [Extract<EvidenceMismatchProblem, { readonly _tag: 'DailyMark' }>['field'], bigint][] = [
+    ['turnoverMicros', state.cumulativeTurnoverMicros - baselines.turnoverMicros],
+    ['cumulativeTurnoverMicros', state.cumulativeTurnoverMicros],
+    ['feeMicros', state.reconstructedTotalFeesMicros - baselines.feeMicros],
+    ['cumulativeFeesMicros', state.reconstructedTotalFeesMicros],
+    ['spreadCostMicros', state.cumulativeSpreadMicros - baselines.spreadMicros],
+    ['cumulativeSpreadCostMicros', state.cumulativeSpreadMicros],
+    ['slippageCostMicros', state.cumulativeSlippageMicros - baselines.slippageMicros],
+    ['cumulativeSlippageCostMicros', state.cumulativeSlippageMicros],
+    ['cashYieldMicros', state.cumulativeCashYieldMicros - baselines.cashYieldMicros],
+    ['cumulativeCashYieldMicros', state.cumulativeCashYieldMicros],
+  ]
+  const counterIssues: SimulationReconciliationIssue[] = []
+  for (const [field, expected] of checks) {
+    const actual = markUnsigned(mark, field)
+    if (Result.isFailure(actual)) {
+      return counterIssues.length > 0 ? failIssues(counterIssues) : Result.fail(actual.failure)
+    }
+    if (actual.success !== expected) {
+      counterIssues.push({
+        _tag: 'EvidenceMismatch',
+        problem: {
+          _tag: 'DailyMark',
+          sessionDate: mark.sessionDate,
+          field,
+          actualMicros: actual.success.toString(),
+          expectedMicros: expected.toString(),
+        },
+      })
+    }
+  }
+  return counterIssues.length > 0 ? failIssues(counterIssues) : Result.succeed(undefined)
+}
+
+const valueMarkedPositions = (state: MutableReconstructionState, mark: DailyPositionMark): Validation<bigint> => {
+  let reconstructedPositionValueMicros = 0n
+  const markedSymbols = new Set<string>()
+  for (const position of mark.positions) {
+    markedSymbols.add(position.symbol)
+    const price = positionUnsigned(mark, position, 'priceMicros')
+    if (Result.isFailure(price)) return failIssues(price.failure)
+    const quantity = state.quantities.get(position.symbol) ?? 0n
+    const markedQuantity = positionUnsigned(mark, position, 'quantityMicros')
+    if (Result.isFailure(markedQuantity)) return failIssues(markedQuantity.failure)
+    const positionIssues: SimulationReconciliationIssue[] = []
+    if (markedQuantity.success !== quantity) {
+      positionIssues.push({
+        _tag: 'EvidenceMismatch',
+        problem: {
+          _tag: 'PositionMark',
+          sessionDate: mark.sessionDate,
+          symbol: position.symbol,
+          field: 'quantityMicros',
+          actualMicros: markedQuantity.success.toString(),
+          expectedMicros: quantity.toString(),
+        },
+      })
+    }
+    const costBasis = positionUnsigned(mark, position, 'costBasisMicros')
+    if (Result.isFailure(costBasis)) {
+      return positionIssues.length > 0 ? failIssues(positionIssues) : Result.fail(costBasis.failure)
+    }
+    // Both operands are parsed unsigned integers and notionalMicros divides by the fixed non-zero MICROS constant.
+    const reconstructedValue = notionalMicros(quantity, price.success)
+    reconstructedPositionValueMicros += reconstructedValue
+    const marketValue = positionUnsigned(mark, position, 'marketValueMicros')
+    if (Result.isFailure(marketValue)) {
+      return positionIssues.length > 0 ? failIssues(positionIssues) : Result.fail(marketValue.failure)
+    }
+    if (marketValue.success !== reconstructedValue) {
+      positionIssues.push({
+        _tag: 'EvidenceMismatch',
+        problem: {
+          _tag: 'PositionMark',
+          sessionDate: mark.sessionDate,
+          symbol: position.symbol,
+          field: 'marketValueMicros',
+          actualMicros: marketValue.success.toString(),
+          expectedMicros: reconstructedValue.toString(),
+        },
+      })
+    }
+    if (positionIssues.length > 0) return failIssues(positionIssues)
+  }
+  for (const [symbol, quantityMicros] of state.quantities) {
+    if (!markedSymbols.has(symbol)) {
+      return fail({
+        _tag: 'IncompleteEvidence',
+        problem: {
+          _tag: 'MissingOpenPositionMark',
+          sessionDate: mark.sessionDate,
+          symbol,
+          quantityMicros: quantityMicros.toString(),
+        },
+      })
+    }
+  }
+  return Result.succeed(reconstructedPositionValueMicros)
+}
+
+const reconcileDailyMark = (
+  prepared: PreparedReconciliation,
+  state: MutableReconstructionState,
+  mark: DailyPositionMark,
+): Validation<void> => {
+  const baselines: MarkBaselines = {
+    turnoverMicros: state.cumulativeTurnoverMicros,
+    feeMicros: state.reconstructedTotalFeesMicros,
+    spreadMicros: state.cumulativeSpreadMicros,
+    slippageMicros: state.cumulativeSlippageMicros,
+    cashYieldMicros: state.cumulativeCashYieldMicros,
+  }
+  while (
+    state.eventIndex < prepared.monetaryEvents.length &&
+    prepared.monetaryEvents[state.eventIndex].event.sessionDate <= mark.sessionDate
+  ) {
+    const preparedEvent = prepared.monetaryEvents[state.eventIndex]
+    const event = preparedEvent.event
+    if (event.sessionDate !== mark.sessionDate) {
+      return fail({
+        _tag: 'IncompleteEvidence',
+        problem: {
+          _tag: 'MissingSessionMark',
+          eventId: event.id,
+          eventSessionDate: event.sessionDate,
+          nextMarkSessionDate: mark.sessionDate,
+        },
+      })
+    }
+    const applied = applyEvent(prepared, state, preparedEvent)
+    if (Result.isFailure(applied)) return failIssues(applied.failure)
+  }
+
+  const counters = validateDailyMarkCounters(mark, state, baselines)
+  if (Result.isFailure(counters)) return failIssues(counters.failure)
+  const markCash = markUnsigned(mark, 'cashMicros')
+  if (Result.isFailure(markCash)) return failIssues(markCash.failure)
+  const cashDifference = absolute(markCash.success - state.cashMicros)
+  if (cashDifference > prepared.toleranceMicros) {
+    return fail({
+      _tag: 'InvalidEvidenceState',
+      problem: {
+        _tag: 'DailyOutsideTolerance',
+        measure: 'daily-cash',
+        sessionDate: mark.sessionDate,
+        differenceMicros: cashDifference.toString(),
+        toleranceMicros: prepared.toleranceMicros.toString(),
+      },
+    })
+  }
+  const positionValue = valueMarkedPositions(state, mark)
+  if (Result.isFailure(positionValue)) return failIssues(positionValue.failure)
+  const reconstructedEquityMicros = state.cashMicros + positionValue.success
+  const evaluatorEquity = markUnsigned(mark, 'equityMicros')
+  if (Result.isFailure(evaluatorEquity)) return failIssues(evaluatorEquity.failure)
+  const equityDifference = absolute(reconstructedEquityMicros - evaluatorEquity.success)
+  if (equityDifference > prepared.toleranceMicros) {
+    return fail({
+      _tag: 'InvalidEvidenceState',
+      problem: {
+        _tag: 'DailyOutsideTolerance',
+        measure: 'daily-equity',
+        sessionDate: mark.sessionDate,
+        differenceMicros: equityDifference.toString(),
+        toleranceMicros: prepared.toleranceMicros.toString(),
+      },
+    })
+  }
+  state.maximumDifferenceMicros =
+    state.maximumDifferenceMicros > equityDifference ? state.maximumDifferenceMicros : equityDifference
+  state.finalPositionValueMicros = positionValue.success
+  state.equitySeries.push({
+    sessionDate: mark.sessionDate,
+    evaluatorEquityMicros: evaluatorEquity.success.toString(),
+    reconstructedEquityMicros: reconstructedEquityMicros.toString(),
+    differenceMicros: equityDifference.toString(),
+  })
+  return Result.succeed(undefined)
+}
+
+const reconstructMarkedEquity = (prepared: PreparedReconciliation): Validation<MarkedEquityProof> => {
+  const initialCapital = unsigned({
+    kind: 'input',
+    field: 'initialCapitalMicros',
+    value: prepared.input.initialCapitalMicros,
+  })
+  if (Result.isFailure(initialCapital)) return failIssues(initialCapital.failure)
+  const state: MutableReconstructionState = {
+    cashMicros: initialCapital.success,
+    quantities: new Map(),
+    eventIndex: 0,
+    reconstructedTotalFeesMicros: 0n,
+    cumulativeTurnoverMicros: 0n,
+    cumulativeSpreadMicros: 0n,
+    cumulativeSlippageMicros: 0n,
+    cumulativeCashYieldMicros: 0n,
+    maximumDifferenceMicros: 0n,
+    finalPositionValueMicros: 0n,
+    equitySeries: [],
+  }
+  for (const mark of prepared.input.simulation.dailyMarks) {
+    const reconciled = reconcileDailyMark(prepared, state, mark)
+    if (Result.isFailure(reconciled)) return failIssues(reconciled.failure)
+  }
+  if (state.eventIndex !== prepared.monetaryEvents.length) {
+    const firstEvent = prepared.monetaryEvents[state.eventIndex].event
+    return fail({
+      _tag: 'IncompleteEvidence',
+      problem: {
+        _tag: 'MonetaryEventsAfterFinalMark',
+        firstEventId: firstEvent.id,
+        firstEventSessionDate: firstEvent.sessionDate,
+      },
+    })
+  }
+
+  const evaluatorEnding = unsigned({
+    kind: 'input',
+    field: 'evaluatorEndingEquityMicros',
+    value: prepared.input.evaluatorEndingEquityMicros,
+  })
+  if (Result.isFailure(evaluatorEnding)) return failIssues(evaluatorEnding.failure)
+  const evaluatorTotalFees = unsigned({
+    kind: 'input',
+    field: 'evaluatorTotalFeesMicros',
+    value: prepared.input.evaluatorTotalFeesMicros,
+  })
+  if (Result.isFailure(evaluatorTotalFees)) return failIssues(evaluatorTotalFees.failure)
+  const feeDifferenceMicros = absolute(state.reconstructedTotalFeesMicros - evaluatorTotalFees.success)
+  if (feeDifferenceMicros > prepared.toleranceMicros) {
+    return fail({
+      _tag: 'InvalidEvidenceState',
+      problem: {
+        _tag: 'FinalOutsideTolerance',
+        measure: 'final-fees',
+        differenceMicros: feeDifferenceMicros.toString(),
+        toleranceMicros: prepared.toleranceMicros.toString(),
+      },
+    })
+  }
+  const reconstructedEndingEquityMicros = state.cashMicros + state.finalPositionValueMicros
+  const finalDifferenceMicros = absolute(reconstructedEndingEquityMicros - evaluatorEnding.success)
+  if (finalDifferenceMicros > prepared.toleranceMicros) {
+    return fail({
+      _tag: 'InvalidEvidenceState',
+      problem: {
+        _tag: 'FinalOutsideTolerance',
+        measure: 'final-equity',
+        differenceMicros: finalDifferenceMicros.toString(),
+        toleranceMicros: prepared.toleranceMicros.toString(),
+      },
+    })
+  }
+  const maximumDifferenceMicros =
+    state.maximumDifferenceMicros > finalDifferenceMicros ? state.maximumDifferenceMicros : finalDifferenceMicros
+  return Result.succeed({
     reconciliation: {
       schemaVersion: 'bayn.marked-equity-reconciliation.v2',
-      runId: input.runId,
-      toleranceMicros: tolerance.toString(),
-      maximumDailyDifferenceMicros: maximumDifference.toString(),
-      reconstructedCashMicros: cash.toString(),
-      reconstructedPositionValueMicros: finalPositionValue.toString(),
-      evaluatorTotalFeesMicros: evaluatorTotalFees.toString(),
-      reconstructedTotalFeesMicros: reconstructedTotalFees.toString(),
-      feeDifferenceMicros: feeDifference.toString(),
-      evaluatorEndingEquityMicros: evaluatorEnding.toString(),
-      reconstructedEndingEquityMicros: reconstructedEnding.toString(),
-      differenceMicros: finalDifference.toString(),
-      exact: maximumDifference === 0n && feeDifference === 0n,
+      runId: prepared.input.runId,
+      toleranceMicros: prepared.toleranceMicros.toString(),
+      maximumDailyDifferenceMicros: maximumDifferenceMicros.toString(),
+      reconstructedCashMicros: state.cashMicros.toString(),
+      reconstructedPositionValueMicros: state.finalPositionValueMicros.toString(),
+      evaluatorTotalFeesMicros: evaluatorTotalFees.success.toString(),
+      reconstructedTotalFeesMicros: state.reconstructedTotalFeesMicros.toString(),
+      feeDifferenceMicros: feeDifferenceMicros.toString(),
+      evaluatorEndingEquityMicros: evaluatorEnding.success.toString(),
+      reconstructedEndingEquityMicros: reconstructedEndingEquityMicros.toString(),
+      differenceMicros: finalDifferenceMicros.toString(),
+      exact: maximumDifferenceMicros === 0n && feeDifferenceMicros === 0n,
       withinTolerance: true,
     },
-    equitySeries,
-  }
+    equitySeries: state.equitySeries,
+  })
+}
+
+const runReconciliation = (input: MarkedEquityReconciliationInput): Validation<MarkedEquityProof> => {
+  const prepared = prepareReconciliation(input)
+  return Result.isFailure(prepared) ? failIssues(prepared.failure) : reconstructMarkedEquity(prepared.success)
+}
+
+export const reconcileMarkedEquity = (input: MarkedEquityReconciliationInput): SimulationReconciliationResult => {
+  const result = runReconciliation(input)
+  return Result.isFailure(result)
+    ? Result.fail(freezePublicIssues(result.failure))
+    : Result.succeed(freezePublicProof(result.success))
 }

--- a/services/bayn/src/startup.test.ts
+++ b/services/bayn/src/startup.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test'
+import assert from 'node:assert/strict'
 import { randomUUID } from 'node:crypto'
 
 import { NodeServices } from '@effect/platform-node'
@@ -42,7 +43,11 @@ import { Journal, type JournalService } from './ledger'
 import { MarketData } from './market-data'
 import { defaultProtocolDocument, loadProtocol } from './protocol'
 import { makeQualificationLock, makeQualificationResult } from './qualification'
-import { evaluateRiskBalancedTrend, summarizeEvaluation } from './risk-balanced-trend'
+import {
+  evaluateRiskBalancedTrend,
+  riskBalancedTrendCompatibilityFailure,
+  summarizeEvaluation,
+} from './risk-balanced-trend'
 import { initialState } from './runtime-state'
 import {
   decidePinnedQualification,
@@ -541,7 +546,7 @@ describe('Bayn startup pure decisions', () => {
     const evaluationRunId = '0'.repeat(64)
     const strategy: Strategy = {
       ...fixtureStrategy,
-      evaluate: () => ({ ...fixtureEvaluation, runId: evaluationRunId }),
+      evaluate: () => Result.succeed({ ...fixtureEvaluation, runId: evaluationRunId }),
     }
     const mismatch = decisionFailure(
       evaluateLockedSnapshot(strategy, candidateQualification.inspection, fixtureLock, fixtureSnapshot),
@@ -577,9 +582,7 @@ describe('Bayn startup pure decisions', () => {
           evaluateLockedSnapshot(
             {
               ...fixtureStrategy,
-              evaluate: () => {
-                throw evaluationCause
-              },
+              evaluate: () => Result.fail(riskBalancedTrendCompatibilityFailure('prepare', evaluationCause)),
             },
             candidateQualification.inspection,
             fixtureLock,
@@ -652,7 +655,7 @@ describe('Bayn startup pure decisions', () => {
     for (const cause of [hostileString, hostileMessage]) {
       const failure: StartupDecisionFailure = {
         _tag: 'StrategyOperationFailed',
-        operation: 'evaluate',
+        operation: 'analyze',
         strategyName: fixtureStrategy.name,
         cause,
       }
@@ -661,8 +664,8 @@ describe('Bayn startup pure decisions', () => {
       }).not.toThrow()
       expectRenderedFailure(failure, {
         component: 'strategy',
-        operation: 'evaluate',
-        message: `${fixtureStrategy.name} evaluation failed: unrenderable cause`,
+        operation: 'analyze',
+        message: `${fixtureStrategy.name} analysis failed: unrenderable cause`,
       })
     }
   })
@@ -926,7 +929,9 @@ describe('Bayn startup lifecycle', () => {
 
   test('recovers a complete run without evaluating, journaling, or persisting again', async () => {
     const snapshot = makeSnapshot()
-    const evaluation = evaluateRiskBalancedTrend(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance)
+    const evaluationResult = evaluateRiskBalancedTrend(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance)
+    assert(Result.isSuccess(evaluationResult), 'recovery fixture evaluation must succeed')
+    const evaluation = evaluationResult.success
     let evaluations = 0
     let journalWrites = 0
     let persistenceWrites = 0
@@ -934,7 +939,7 @@ describe('Bayn startup lifecycle', () => {
       ...fixtureStrategy,
       evaluate: () => {
         evaluations += 1
-        return evaluation
+        return Result.succeed(evaluation)
       },
     }
     const journal: JournalService = {
@@ -1047,7 +1052,9 @@ describe('Bayn startup lifecycle', () => {
       ...fixtureStrategy,
       evaluate: () => {
         evaluations += 1
-        throw new Error('incomplete qualification must not evaluate')
+        return Result.fail(
+          riskBalancedTrendCompatibilityFailure('prepare', new Error('incomplete qualification must not evaluate')),
+        )
       },
     }
     const journal: JournalService = {
@@ -1101,7 +1108,12 @@ describe('Bayn startup lifecycle', () => {
       ...fixtureStrategy,
       evaluate: () => {
         evaluations += 1
-        throw new Error('corrupt recovery must not fall back to evaluation')
+        return Result.fail(
+          riskBalancedTrendCompatibilityFailure(
+            'prepare',
+            new Error('corrupt recovery must not fall back to evaluation'),
+          ),
+        )
       },
     }
     const store: EvidenceStoreService = {

--- a/services/bayn/src/startup.ts
+++ b/services/bayn/src/startup.ts
@@ -17,7 +17,11 @@ import { Journal, type JournalService } from './ledger'
 import { MarketData, type MarketDataInspection, type MarketDataService, type MarketDataSnapshot } from './market-data'
 import { databaseOperation, withinDeadline } from './operations'
 import { makeQualificationResult, type QualificationLock, type QualificationResult } from './qualification'
-import { summarizeEvaluation } from './risk-balanced-trend'
+import {
+  renderRiskBalancedTrendEvaluationIssues,
+  summarizeEvaluation,
+  type RiskBalancedTrendEvaluationIssue,
+} from './risk-balanced-trend'
 import type { RuntimeEvidence, RuntimeState } from './runtime-state'
 import type { Strategy } from './strategy'
 import type { EvaluationResult, ReconciliationResult } from './types'
@@ -210,7 +214,13 @@ export type StartupDecisionFailure =
     }
   | {
       readonly _tag: 'StrategyOperationFailed'
-      readonly operation: 'prepare-lock' | 'evaluate' | 'analyze' | 'qualify'
+      readonly operation: 'evaluate'
+      readonly strategyName: string
+      readonly cause: readonly RiskBalancedTrendEvaluationIssue[]
+    }
+  | {
+      readonly _tag: 'StrategyOperationFailed'
+      readonly operation: 'prepare-lock' | 'analyze' | 'qualify'
       readonly strategyName: string
       readonly cause: unknown
     }
@@ -396,11 +406,11 @@ const startupFailurePresentation = (failure: StartupDecisionFailure): StartupFai
         analyze: 'analysis',
         qualify: 'qualification',
       }[failure.operation]
-      return presentFailure(
-        'strategy',
-        failure.operation,
-        `${failure.strategyName} ${label} failed: ${causeMessage(failure.cause)}`,
-      )
+      const detail =
+        failure.operation === 'evaluate'
+          ? renderRiskBalancedTrendEvaluationIssues(failure.cause)
+          : causeMessage(failure.cause)
+      return presentFailure('strategy', failure.operation, `${failure.strategyName} ${label} failed: ${detail}`)
     }
   }
 }
@@ -813,16 +823,15 @@ export const evaluateLockedSnapshot = (
       },
     })
   }
-  const evaluationResult = Result.try({
-    try: () => strategy.evaluate(snapshot.bars, snapshot.manifest),
-    catch: (cause): StartupDecisionFailure => ({
+  const evaluationResult = strategy.evaluate(snapshot.bars, snapshot.manifest)
+  if (Result.isFailure(evaluationResult)) {
+    return Result.fail({
       _tag: 'StrategyOperationFailed',
       operation: 'evaluate',
       strategyName: strategy.name,
-      cause,
-    }),
-  })
-  if (Result.isFailure(evaluationResult)) return evaluationResult
+      cause: evaluationResult.failure,
+    })
+  }
   if (evaluationResult.success.runId !== lock.candidateRunId) {
     return Result.fail({
       _tag: 'BindingMismatch',
@@ -833,7 +842,7 @@ export const evaluateLockedSnapshot = (
       },
     })
   }
-  return evaluationResult
+  return Result.succeed(evaluationResult.success)
 }
 
 export const qualifyEvaluation = (

--- a/services/bayn/src/strategy.ts
+++ b/services/bayn/src/strategy.ts
@@ -1,4 +1,4 @@
-import { Schema } from 'effect'
+import { Result, Schema } from 'effect'
 
 import type { RuntimeProvenance } from './contracts'
 import { InputManifestArtifactSchema } from './evidence-contracts'
@@ -18,8 +18,10 @@ import {
   compileCurrentRiskBalancedTrendDecision,
   evaluateRiskBalancedTrend,
   prepareRiskBalancedTrendQualification,
+  riskBalancedTrendCompatibilityFailure,
   type CurrentDecisionCycleBinding,
   type CurrentRiskBalancedTrendDecision,
+  type RiskBalancedTrendEvaluationIssue,
 } from './risk-balanced-trend'
 import { strictParseOptions } from './schemas'
 import type { DailyBar, EvaluationResult, InputManifest, IsoDate, Protocol } from './types'
@@ -31,7 +33,10 @@ export interface Strategy {
   readonly name: string
   readonly parameters: Protocol
   readonly provenance: RuntimeProvenance
-  readonly evaluate: (bars: readonly DailyBar[], manifest: InputManifest) => EvaluationResult
+  readonly evaluate: (
+    bars: readonly DailyBar[],
+    manifest: InputManifest,
+  ) => Result.Result<EvaluationResult, readonly RiskBalancedTrendEvaluationIssue[]>
   readonly currentDecision: (
     bars: readonly DailyBar[],
     manifest: InputManifest,
@@ -92,8 +97,16 @@ export const makeStrategy = (protocol: Protocol, provenance: RuntimeProvenance):
     name: 'risk-balanced-trend',
     parameters: protocol,
     provenance,
-    evaluate: (bars, manifest) =>
-      evaluateRiskBalancedTrend(bars, requireMatchingUniverse(manifest, protocol), protocol, provenance),
+    evaluate: (bars, manifest) => {
+      // PROOMPT-419 owns totalizing manifest and pre-reconciliation strategy validation.
+      const inputManifest = Result.try({
+        try: () => requireMatchingUniverse(manifest, protocol),
+        catch: (cause) => riskBalancedTrendCompatibilityFailure('prepare', cause),
+      })
+      return Result.isFailure(inputManifest)
+        ? Result.fail(inputManifest.failure)
+        : evaluateRiskBalancedTrend(bars, inputManifest.success, protocol, provenance)
+    },
     currentDecision: (bars, manifest, cycleBinding) =>
       compileCurrentRiskBalancedTrendDecision(
         bars,


### PR DESCRIPTION
## Summary

- Replace exception-based simulation reconciliation with a total pure `Result<MarkedEquityProof, readonly SimulationReconciliationIssue[]>` boundary and a closed, fact-bearing issue algebra.
- Preserve dependency-first validation precedence while accumulating genuinely independent comparison failures and keeping reconstruction linear with invocation-local state that never escapes.
- Propagate structured reconciliation failures through audit, persistence, risk, Strategy, and startup without message parsing or hidden reconciliation throws; independent audit checks still continue when reconciliation is unavailable.
- Reuse one shared reconciliation-to-`DatabaseError` adapter for persistence and recovery while preserving byte-identical valid proofs, audit hashes, and stored evidence.

## Related Issues

- [PROOMPT-411](https://linear.app/proompteng/issue/PROOMPT-411/replace-simulation-reconciliation-throws-with-a-total-result-algebra)
- Broader Strategy/qualification totalization remains tracked by [PROOMPT-419](https://linear.app/proompteng/issue/PROOMPT-419/make-strategy-simulation-and-qualification-decisions-total-and).

## Testing

- `bun test services/bayn/src/simulation-reconciliation.test.ts services/bayn/src/qualification-audit.test.ts services/bayn/src/startup.test.ts` — 65 passed, 0 failed.
- `bun run --filter @proompteng/bayn test` — 445 passed, 106 skipped PostgreSQL tests, 0 failed.
- `BAYN_TEST_POSTGRES_URL=<test database> bun test services/bayn/src/db/evidence-store.integration.test.ts` — 53 passed, 0 failed.
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- `git diff --check`

## Breaking Changes

None. Valid reconciliation output, audit hashes, and persisted evidence bytes remain unchanged.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is completed above.
- [x] Follow-up broad Strategy/qualification totalization remains tracked in PROOMPT-419.