### PR TITLE
refactor(bayn): make runtime config resolution total

### DIFF
--- a/services/bayn/src/config.test.ts
+++ b/services/bayn/src/config.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, test } from 'bun:test'
 
-import { ConfigProvider, Effect, Redacted } from 'effect'
+import { ConfigProvider, Effect, Redacted, Result } from 'effect'
 
 import type { EmbeddedBuildMetadata } from './build'
-import { loadConfig } from './config'
+import {
+  loadConfig,
+  resolveRuntimeConfig,
+  type ParsedRuntimeConfig,
+  type RuntimeConfigResolutionFailure,
+  type RuntimeConfigResolutionInput,
+} from './config'
 import { Authority } from './paper'
 
 const sourceRevision = 'a'.repeat(40)
@@ -16,6 +22,85 @@ const buildMetadata: EmbeddedBuildMetadata = {
   strategyBehaviorHash: 'c'.repeat(64),
   strategyParameterHash: 'f'.repeat(64),
 }
+const qualificationRunId = 'e'.repeat(64)
+const alpacaAccountId = '61e69015-8549-4bfd-b9c3-01e75843f47d'
+const alpacaKey = 'paper-key-must-remain-redacted'
+const alpacaSecret = 'paper-secret-must-remain-redacted'
+const clickhousePassword = 'clickhouse-password-must-remain-redacted'
+const postgresUrl = 'postgresql://bayn:postgres-secret-must-remain-redacted@postgres.test:5432/bayn'
+
+const baseParsedConfig: ParsedRuntimeConfig = {
+  host: '0.0.0.0',
+  port: 8080,
+  qualificationRunId: undefined,
+  configuredPaperProofCommand: undefined,
+  configuredPaperProofPhase: undefined,
+  maximumAuthority: Authority.Observe,
+  configuredBuild: {
+    ...buildMetadata,
+    imageDigest,
+  },
+  provenanceMode: 'production',
+  healthIntervalMs: 30_000,
+  operationTimeoutMs: 30_000,
+  cycleStallThresholdMs: 300_000,
+  reconciliationStaleThresholdMs: 120_000,
+  unknownMutationThresholdMs: 300_000,
+  cyclePollIntervalMs: 30_000,
+  authorityGenerationHash,
+  configuredAlpaca: {
+    accountId: undefined,
+    key: undefined,
+    secret: undefined,
+    proxyUrl: 'http://bayn-egress-proxy:3128',
+    retryAttempts: 2,
+    reconciliationIntervalMs: 30_000,
+  },
+  clickhouse: {
+    url: 'http://clickhouse.test:8123',
+    username: 'bayn',
+    password: Redacted.make(clickhousePassword),
+    snapshotId: 'd'.repeat(64),
+    publicationAsOf: '2026-07-17',
+    calendarVersion: 'alpaca-us-equity-calendar-v1',
+    bounds: {
+      schemaVersion: 'bayn.evaluation-bounds.v1',
+      dataStart: '2017-01-03',
+      dataEnd: '2026-07-17',
+      lookbackStart: '2017-01-03',
+      evaluationStart: '2018-01-03',
+      evaluationEnd: '2026-07-17',
+    },
+  },
+  postgres: {
+    url: Redacted.make(postgresUrl),
+    tls: true,
+    caPath: '/var/run/secrets/bayn/postgres/ca.crt',
+  },
+  tigerBeetle: {
+    clusterId: 2001n,
+    replicaAddresses: ['tigerbeetle.test:3000'],
+    ledger: 7001,
+  },
+}
+
+const completeAlpacaConfig: ParsedRuntimeConfig['configuredAlpaca'] = {
+  ...baseParsedConfig.configuredAlpaca,
+  accountId: alpacaAccountId,
+  key: Redacted.make(alpacaKey),
+  secret: Redacted.make(alpacaSecret),
+}
+
+const resolutionInput = (
+  overrides: Partial<ParsedRuntimeConfig> = {},
+  embedded: EmbeddedBuildMetadata | null = buildMetadata,
+): RuntimeConfigResolutionInput => ({
+  parsed: {
+    ...baseParsedConfig,
+    ...overrides,
+  },
+  embeddedBuildMetadata: embedded === null ? undefined : embedded,
+})
 
 const runtimeEnvironment = new Map([
   ['BAYN_CODE_REVISION', sourceRevision],
@@ -43,6 +128,664 @@ const provideEnvironment = <A, E>(effect: Effect.Effect<A, E>, environment: Map<
   effect.pipe(
     Effect.provideService(ConfigProvider.ConfigProvider, ConfigProvider.fromUnknown(Object.fromEntries(environment))),
   )
+
+const expectResolutionFailure = (
+  input: RuntimeConfigResolutionInput,
+  expected: RuntimeConfigResolutionFailure,
+): void => {
+  const result = resolveRuntimeConfig(input)
+  expect(Result.isFailure(result)).toBe(true)
+  if (Result.isFailure(result)) {
+    expect(result.failure).toEqual(expected)
+  }
+}
+
+describe('pure runtime configuration resolution', () => {
+  const validModes = [
+    {
+      name: 'production OBSERVE without an Alpaca binding',
+      input: resolutionInput({ authorityGenerationHash: undefined }),
+      expected: {
+        maximumAuthority: Authority.Observe,
+        verification: 'embedded',
+        hasAlpaca: false,
+        hasPaperProofCommand: false,
+      },
+    },
+    {
+      name: 'production OBSERVE with an Alpaca read binding',
+      input: resolutionInput({ configuredAlpaca: completeAlpacaConfig }),
+      expected: {
+        maximumAuthority: Authority.Observe,
+        verification: 'embedded',
+        hasAlpaca: true,
+        hasPaperProofCommand: false,
+      },
+    },
+    {
+      name: 'production OBSERVE PREPARE DISCOVER',
+      input: resolutionInput({
+        qualificationRunId,
+        configuredPaperProofCommand: 'PREPARE',
+        configuredPaperProofPhase: 'DISCOVER',
+        configuredAlpaca: completeAlpacaConfig,
+      }),
+      expected: {
+        maximumAuthority: Authority.Observe,
+        verification: 'embedded',
+        hasAlpaca: true,
+        hasPaperProofCommand: true,
+      },
+    },
+    {
+      name: 'production PAPER with a complete Alpaca binding',
+      input: resolutionInput({
+        maximumAuthority: Authority.Paper,
+        configuredAlpaca: completeAlpacaConfig,
+      }),
+      expected: {
+        maximumAuthority: Authority.Paper,
+        verification: 'embedded',
+        hasAlpaca: true,
+        hasPaperProofCommand: false,
+      },
+    },
+    {
+      name: 'development OBSERVE without an Alpaca binding',
+      input: resolutionInput(
+        {
+          provenanceMode: 'development',
+          authorityGenerationHash: undefined,
+          postgres: { ...baseParsedConfig.postgres, tls: false },
+        },
+        null,
+      ),
+      expected: {
+        maximumAuthority: Authority.Observe,
+        verification: 'development-configured',
+        hasAlpaca: false,
+        hasPaperProofCommand: false,
+      },
+    },
+    {
+      name: 'development OBSERVE with an Alpaca read binding',
+      input: resolutionInput(
+        {
+          provenanceMode: 'development',
+          configuredAlpaca: completeAlpacaConfig,
+        },
+        null,
+      ),
+      expected: {
+        maximumAuthority: Authority.Observe,
+        verification: 'development-configured',
+        hasAlpaca: true,
+        hasPaperProofCommand: false,
+      },
+    },
+    {
+      name: 'development OBSERVE PREPARE DISCOVER',
+      input: resolutionInput(
+        {
+          provenanceMode: 'development',
+          qualificationRunId,
+          configuredPaperProofCommand: 'PREPARE',
+          configuredPaperProofPhase: 'DISCOVER',
+          configuredAlpaca: completeAlpacaConfig,
+        },
+        null,
+      ),
+      expected: {
+        maximumAuthority: Authority.Observe,
+        verification: 'development-configured',
+        hasAlpaca: true,
+        hasPaperProofCommand: true,
+      },
+    },
+    {
+      name: 'development PAPER with a complete Alpaca binding',
+      input: resolutionInput(
+        {
+          provenanceMode: 'development',
+          maximumAuthority: Authority.Paper,
+          configuredAlpaca: completeAlpacaConfig,
+        },
+        null,
+      ),
+      expected: {
+        maximumAuthority: Authority.Paper,
+        verification: 'development-configured',
+        hasAlpaca: true,
+        hasPaperProofCommand: false,
+      },
+    },
+  ] as const
+
+  for (const mode of validModes) {
+    test(mode.name, () => {
+      const result = resolveRuntimeConfig(mode.input)
+
+      expect(Result.isSuccess(result)).toBe(true)
+      if (Result.isSuccess(result)) {
+        expect({
+          maximumAuthority: result.success.maximumAuthority,
+          verification: result.success.build.verification,
+          hasAlpaca: result.success.alpaca !== undefined,
+          hasPaperProofCommand: result.success.paperProofCommand !== undefined,
+        }).toEqual(mode.expected)
+        expect(result.success.build.imageDigest).toBe(imageDigest)
+        expect(Redacted.isRedacted(result.success.clickhouse.password)).toBe(true)
+        expect(Redacted.isRedacted(result.success.postgres.url)).toBe(true)
+        if (result.success.alpaca !== undefined) {
+          expect(Redacted.isRedacted(result.success.alpaca.key)).toBe(true)
+          expect(Redacted.isRedacted(result.success.alpaca.secret)).toBe(true)
+        }
+      }
+    })
+  }
+
+  const partialCredentialCases = [
+    ['account ID only', true, false, false],
+    ['key ID only', false, true, false],
+    ['secret key only', false, false, true],
+    ['account ID and key ID', true, true, false],
+    ['account ID and secret key', true, false, true],
+    ['key ID and secret key', false, true, true],
+  ] as const
+
+  for (const [name, hasAccountId, hasKeyId, hasSecretKey] of partialCredentialCases) {
+    test(`rejects partial Alpaca credentials with ${name}`, () => {
+      const input = resolutionInput({
+        configuredAlpaca: {
+          ...baseParsedConfig.configuredAlpaca,
+          accountId: hasAccountId ? alpacaAccountId : undefined,
+          key: hasKeyId ? Redacted.make(alpacaKey) : undefined,
+          secret: hasSecretKey ? Redacted.make(alpacaSecret) : undefined,
+        },
+      })
+
+      expectResolutionFailure(input, {
+        _tag: 'IncompleteAlpacaCredentials',
+        configured: {
+          accountId: hasAccountId,
+          keyId: hasKeyId,
+          secretKey: hasSecretKey,
+        },
+      })
+    })
+  }
+
+  const relationalFailures = [
+    {
+      name: 'cycle poll interval equal to stall threshold',
+      input: resolutionInput({ cyclePollIntervalMs: 300_000 }),
+      expected: {
+        _tag: 'CyclePollIntervalNotShorterThanStallThreshold',
+        cyclePollIntervalMs: 300_000,
+        cycleStallThresholdMs: 300_000,
+      },
+    },
+    {
+      name: 'cycle poll interval greater than stall threshold',
+      input: resolutionInput({ cyclePollIntervalMs: 300_001 }),
+      expected: {
+        _tag: 'CyclePollIntervalNotShorterThanStallThreshold',
+        cyclePollIntervalMs: 300_001,
+        cycleStallThresholdMs: 300_000,
+      },
+    },
+    {
+      name: 'complete Alpaca credentials without an authority generation',
+      input: resolutionInput({
+        authorityGenerationHash: undefined,
+        configuredAlpaca: completeAlpacaConfig,
+      }),
+      expected: {
+        _tag: 'MissingAlpacaAuthorityGeneration',
+        accountId: alpacaAccountId,
+      },
+    },
+    {
+      name: 'PAPER without an Alpaca binding',
+      input: resolutionInput({ maximumAuthority: Authority.Paper }),
+      expected: {
+        _tag: 'PaperAuthorityRequiresAlpacaBinding',
+        maximumAuthority: Authority.Paper,
+      },
+    },
+    {
+      name: 'paper command without its phase',
+      input: resolutionInput({ configuredPaperProofCommand: 'PREPARE' }),
+      expected: {
+        _tag: 'IncompletePaperProofCommand',
+        commandConfigured: true,
+        phaseConfigured: false,
+      },
+    },
+    {
+      name: 'paper phase without its command',
+      input: resolutionInput({ configuredPaperProofPhase: 'DISCOVER' }),
+      expected: {
+        _tag: 'IncompletePaperProofCommand',
+        commandConfigured: false,
+        phaseConfigured: true,
+      },
+    },
+    {
+      name: 'PREPARE DISCOVER with PAPER authority',
+      input: resolutionInput({
+        maximumAuthority: Authority.Paper,
+        configuredAlpaca: completeAlpacaConfig,
+        configuredPaperProofCommand: 'PREPARE',
+        configuredPaperProofPhase: 'DISCOVER',
+      }),
+      expected: {
+        _tag: 'PaperProofCommandRequiresObserveAuthority',
+        maximumAuthority: Authority.Paper,
+      },
+    },
+    {
+      name: 'PREPARE DISCOVER without a qualification run',
+      input: resolutionInput({
+        configuredAlpaca: completeAlpacaConfig,
+        configuredPaperProofCommand: 'PREPARE',
+        configuredPaperProofPhase: 'DISCOVER',
+      }),
+      expected: {
+        _tag: 'PaperProofCommandRequiresQualificationRun',
+      },
+    },
+    {
+      name: 'PREPARE DISCOVER without an Alpaca read binding',
+      input: resolutionInput({
+        qualificationRunId,
+        configuredPaperProofCommand: 'PREPARE',
+        configuredPaperProofPhase: 'DISCOVER',
+      }),
+      expected: {
+        _tag: 'PaperProofCommandRequiresAlpacaBinding',
+      },
+    },
+    {
+      name: 'production provenance without embedded metadata',
+      input: resolutionInput({}, null),
+      expected: {
+        _tag: 'ProductionProvenanceRequiresEmbeddedMetadata',
+        provenanceMode: 'production',
+      },
+    },
+    {
+      name: 'development provenance with embedded metadata',
+      input: resolutionInput({ provenanceMode: 'development' }),
+      expected: {
+        _tag: 'EmbeddedMetadataRequiresProductionProvenance',
+        provenanceMode: 'development',
+      },
+    },
+    {
+      name: 'production PostgreSQL without TLS',
+      input: resolutionInput({
+        postgres: { ...baseParsedConfig.postgres, tls: false },
+      }),
+      expected: {
+        _tag: 'ProductionPostgresRequiresTls',
+        postgresTls: false,
+      },
+    },
+    {
+      name: 'configured source revision mismatch',
+      input: resolutionInput({
+        configuredBuild: {
+          ...baseParsedConfig.configuredBuild,
+          sourceRevision: 'd'.repeat(40),
+        },
+      }),
+      expected: {
+        _tag: 'SourceRevisionMismatch',
+        configuredSourceRevision: 'd'.repeat(40),
+        embeddedSourceRevision: sourceRevision,
+      },
+    },
+    {
+      name: 'configured image repository mismatch',
+      input: resolutionInput({
+        configuredBuild: {
+          ...baseParsedConfig.configuredBuild,
+          imageRepository: 'registry.example.invalid/bayn',
+        },
+      }),
+      expected: {
+        _tag: 'ImageRepositoryMismatch',
+        configuredImageRepository: 'registry.example.invalid/bayn',
+        embeddedImageRepository: imageRepository,
+      },
+    },
+    {
+      name: 'configured strategy behavior hash mismatch',
+      input: resolutionInput({
+        configuredBuild: {
+          ...baseParsedConfig.configuredBuild,
+          strategyBehaviorHash: 'd'.repeat(64),
+        },
+      }),
+      expected: {
+        _tag: 'StrategyBehaviorHashMismatch',
+        configuredStrategyBehaviorHash: 'd'.repeat(64),
+        embeddedStrategyBehaviorHash: buildMetadata.strategyBehaviorHash,
+      },
+    },
+    {
+      name: 'configured strategy parameter hash mismatch',
+      input: resolutionInput({
+        configuredBuild: {
+          ...baseParsedConfig.configuredBuild,
+          strategyParameterHash: 'e'.repeat(64),
+        },
+      }),
+      expected: {
+        _tag: 'StrategyParameterHashMismatch',
+        configuredStrategyParameterHash: 'e'.repeat(64),
+        embeddedStrategyParameterHash: buildMetadata.strategyParameterHash,
+      },
+    },
+  ] as const satisfies ReadonlyArray<{
+    readonly name: string
+    readonly input: RuntimeConfigResolutionInput
+    readonly expected: RuntimeConfigResolutionFailure
+  }>
+
+  for (const invalid of relationalFailures) {
+    test(`rejects ${invalid.name}`, () => {
+      expectResolutionFailure(invalid.input, invalid.expected)
+    })
+  }
+
+  const invalidBounds = [
+    {
+      name: 'data start after data end',
+      bounds: {
+        ...baseParsedConfig.clickhouse.bounds,
+        dataStart: '2026-07-18',
+        lookbackStart: '2026-07-18',
+        evaluationStart: '2026-07-18',
+        evaluationEnd: '2026-07-18',
+      },
+      message: 'must not be after dataEnd\n  at ["dataStart"]\nmust not follow dataEnd\n  at ["evaluationEnd"]',
+    },
+    {
+      name: 'lookback start before data start',
+      bounds: {
+        ...baseParsedConfig.clickhouse.bounds,
+        dataStart: '2018-01-03',
+      },
+      message: 'must not precede dataStart\n  at ["lookbackStart"]',
+    },
+    {
+      name: 'evaluation start before lookback start',
+      bounds: {
+        ...baseParsedConfig.clickhouse.bounds,
+        lookbackStart: '2019-01-03',
+      },
+      message: 'must not precede lookbackStart\n  at ["evaluationStart"]',
+    },
+    {
+      name: 'evaluation end before evaluation start',
+      bounds: {
+        ...baseParsedConfig.clickhouse.bounds,
+        evaluationStart: '2025-01-03',
+        evaluationEnd: '2024-01-03',
+      },
+      message: 'must not precede evaluationStart\n  at ["evaluationEnd"]',
+    },
+    {
+      name: 'evaluation end after data end',
+      bounds: {
+        ...baseParsedConfig.clickhouse.bounds,
+        dataEnd: '2025-01-03',
+      },
+      message: 'must not follow dataEnd\n  at ["evaluationEnd"]',
+    },
+  ] as const
+
+  for (const invalid of invalidBounds) {
+    test(`preserves the structured Schema cause for ${invalid.name}`, () => {
+      const result = resolveRuntimeConfig(
+        resolutionInput({
+          clickhouse: {
+            ...baseParsedConfig.clickhouse,
+            bounds: invalid.bounds,
+          },
+        }),
+      )
+
+      expect(Result.isFailure(result)).toBe(true)
+      if (Result.isFailure(result)) {
+        expect(result.failure._tag).toBe('InvalidEvaluationBounds')
+        if (result.failure._tag === 'InvalidEvaluationBounds') {
+          expect(result.failure.cause._tag).toBe('SchemaError')
+          expect(result.failure.cause.issue._tag).toBe('Composite')
+          expect(result.failure.cause.message).toBe(invalid.message)
+        }
+      }
+    })
+  }
+
+  test('preserves the structured Schema cause for malformed embedded metadata', () => {
+    const result = resolveRuntimeConfig(resolutionInput({}, { ...buildMetadata, sourceRevision: 'incomplete' }))
+
+    expect(Result.isFailure(result)).toBe(true)
+    if (Result.isFailure(result)) {
+      expect(result.failure._tag).toBe('InvalidEmbeddedBuildMetadata')
+      if (result.failure._tag === 'InvalidEmbeddedBuildMetadata') {
+        expect(result.failure.cause._tag).toBe('SchemaError')
+        expect(result.failure.cause.issue._tag).toBe('Composite')
+        expect(result.failure.cause.message).toBe(
+          'Expected a string matching the RegExp ^[a-f0-9]{40}$, got "incomplete"\n  at ["sourceRevision"]',
+        )
+      }
+    }
+  })
+
+  const precedenceCases = [
+    {
+      name: 'evaluation bounds before cycle timing',
+      input: resolutionInput({
+        cyclePollIntervalMs: 300_000,
+        clickhouse: {
+          ...baseParsedConfig.clickhouse,
+          bounds: {
+            ...baseParsedConfig.clickhouse.bounds,
+            evaluationStart: '2026-07-18',
+          },
+        },
+      }),
+      expectedTag: 'InvalidEvaluationBounds',
+    },
+    {
+      name: 'cycle timing before Alpaca credential completeness',
+      input: resolutionInput({
+        cyclePollIntervalMs: 300_000,
+        configuredAlpaca: {
+          ...baseParsedConfig.configuredAlpaca,
+          key: Redacted.make(alpacaKey),
+        },
+      }),
+      expectedTag: 'CyclePollIntervalNotShorterThanStallThreshold',
+    },
+    {
+      name: 'credential completeness before authority generation',
+      input: resolutionInput({
+        maximumAuthority: Authority.Paper,
+        authorityGenerationHash: undefined,
+        configuredAlpaca: {
+          ...baseParsedConfig.configuredAlpaca,
+          key: Redacted.make(alpacaKey),
+        },
+      }),
+      expectedTag: 'IncompleteAlpacaCredentials',
+    },
+    {
+      name: 'authority generation before PAPER binding',
+      input: resolutionInput({
+        maximumAuthority: Authority.Paper,
+        authorityGenerationHash: undefined,
+        configuredAlpaca: completeAlpacaConfig,
+      }),
+      expectedTag: 'MissingAlpacaAuthorityGeneration',
+    },
+    {
+      name: 'PAPER binding before paper command completeness',
+      input: resolutionInput({
+        maximumAuthority: Authority.Paper,
+        configuredPaperProofCommand: 'PREPARE',
+      }),
+      expectedTag: 'PaperAuthorityRequiresAlpacaBinding',
+    },
+    {
+      name: 'paper command completeness before provenance',
+      input: resolutionInput({
+        configuredPaperProofCommand: 'PREPARE',
+        provenanceMode: 'development',
+      }),
+      expectedTag: 'IncompletePaperProofCommand',
+    },
+    {
+      name: 'paper command authority before qualification pin',
+      input: resolutionInput({
+        maximumAuthority: Authority.Paper,
+        configuredAlpaca: completeAlpacaConfig,
+        configuredPaperProofCommand: 'PREPARE',
+        configuredPaperProofPhase: 'DISCOVER',
+      }),
+      expectedTag: 'PaperProofCommandRequiresObserveAuthority',
+    },
+    {
+      name: 'qualification pin before Alpaca read binding',
+      input: resolutionInput({
+        configuredPaperProofCommand: 'PREPARE',
+        configuredPaperProofPhase: 'DISCOVER',
+      }),
+      expectedTag: 'PaperProofCommandRequiresQualificationRun',
+    },
+    {
+      name: 'Alpaca read binding before provenance',
+      input: resolutionInput({
+        qualificationRunId,
+        configuredPaperProofCommand: 'PREPARE',
+        configuredPaperProofPhase: 'DISCOVER',
+        provenanceMode: 'development',
+      }),
+      expectedTag: 'PaperProofCommandRequiresAlpacaBinding',
+    },
+    {
+      name: 'missing embedded metadata before PostgreSQL TLS',
+      input: resolutionInput(
+        {
+          postgres: { ...baseParsedConfig.postgres, tls: false },
+        },
+        null,
+      ),
+      expectedTag: 'ProductionProvenanceRequiresEmbeddedMetadata',
+    },
+    {
+      name: 'provenance mode before PostgreSQL TLS',
+      input: resolutionInput({
+        provenanceMode: 'development',
+        postgres: { ...baseParsedConfig.postgres, tls: false },
+      }),
+      expectedTag: 'EmbeddedMetadataRequiresProductionProvenance',
+    },
+    {
+      name: 'PostgreSQL TLS before embedded metadata decoding',
+      input: resolutionInput(
+        {
+          postgres: { ...baseParsedConfig.postgres, tls: false },
+        },
+        { ...buildMetadata, sourceRevision: 'incomplete' },
+      ),
+      expectedTag: 'ProductionPostgresRequiresTls',
+    },
+    {
+      name: 'embedded metadata decoding before provenance mismatches',
+      input: resolutionInput(
+        {
+          configuredBuild: {
+            ...baseParsedConfig.configuredBuild,
+            sourceRevision: 'd'.repeat(40),
+          },
+        },
+        { ...buildMetadata, sourceRevision: 'incomplete' },
+      ),
+      expectedTag: 'InvalidEmbeddedBuildMetadata',
+    },
+    {
+      name: 'source revision before image repository',
+      input: resolutionInput({
+        configuredBuild: {
+          ...baseParsedConfig.configuredBuild,
+          sourceRevision: 'd'.repeat(40),
+          imageRepository: 'registry.example.invalid/bayn',
+        },
+      }),
+      expectedTag: 'SourceRevisionMismatch',
+    },
+    {
+      name: 'image repository before strategy behavior hash',
+      input: resolutionInput({
+        configuredBuild: {
+          ...baseParsedConfig.configuredBuild,
+          imageRepository: 'registry.example.invalid/bayn',
+          strategyBehaviorHash: 'd'.repeat(64),
+        },
+      }),
+      expectedTag: 'ImageRepositoryMismatch',
+    },
+    {
+      name: 'strategy behavior hash before strategy parameter hash',
+      input: resolutionInput({
+        configuredBuild: {
+          ...baseParsedConfig.configuredBuild,
+          strategyBehaviorHash: 'd'.repeat(64),
+          strategyParameterHash: 'e'.repeat(64),
+        },
+      }),
+      expectedTag: 'StrategyBehaviorHashMismatch',
+    },
+  ] as const satisfies ReadonlyArray<{
+    readonly name: string
+    readonly input: RuntimeConfigResolutionInput
+    readonly expectedTag: RuntimeConfigResolutionFailure['_tag']
+  }>
+
+  for (const precedence of precedenceCases) {
+    test(`preserves precedence: ${precedence.name}`, () => {
+      const result = resolveRuntimeConfig(precedence.input)
+
+      expect(Result.isFailure(result)).toBe(true)
+      if (Result.isFailure(result)) {
+        expect(result.failure._tag).toBe(precedence.expectedTag)
+      }
+    })
+  }
+
+  test('does not render any configured secret in a failure', () => {
+    const result = resolveRuntimeConfig(
+      resolutionInput({
+        configuredAlpaca: {
+          ...baseParsedConfig.configuredAlpaca,
+          key: Redacted.make(alpacaKey),
+          secret: Redacted.make(alpacaSecret),
+        },
+      }),
+    )
+    const rendered = JSON.stringify(result)
+
+    expect(Result.isFailure(result)).toBe(true)
+    for (const secret of [alpacaKey, alpacaSecret, clickhousePassword, postgresUrl]) {
+      expect(rendered).not.toContain(secret)
+    }
+  })
+})
 
 describe('Effect configuration', () => {
   test('loads runtime configuration with validated defaults', async () => {
@@ -218,14 +961,16 @@ describe('Effect configuration', () => {
       retryAttempts: 2,
       reconciliationIntervalMs: 30_000,
     })
-    if (config.alpaca === undefined) throw new Error('expected an Alpaca configuration')
-    expect(Redacted.isRedacted(config.alpaca.key)).toBe(true)
-    expect(Redacted.isRedacted(config.alpaca.secret)).toBe(true)
+    expect(config.alpaca).toBeDefined()
+    if (config.alpaca !== undefined) {
+      expect(Redacted.isRedacted(config.alpaca.key)).toBe(true)
+      expect(Redacted.isRedacted(config.alpaca.secret)).toBe(true)
+    }
   })
 
   test('rejects a partial Alpaca credential binding instead of silently staying dormant', async () => {
     const partial = new Map(runtimeEnvironment)
-    partial.set('BAYN_ALPACA_KEY_ID', 'paper-key')
+    partial.set('BAYN_ALPACA_KEY_ID', alpacaKey)
 
     const error = await Effect.runPromise(Effect.flip(provideEnvironment(loadConfig(buildMetadata), partial)))
 
@@ -233,7 +978,18 @@ describe('Effect configuration', () => {
       _tag: 'OperationalError',
       component: 'config',
       operation: 'alpaca',
+      message: 'Alpaca account ID, key ID, and secret key must be configured together',
+      cause: {
+        _tag: 'IncompleteAlpacaCredentials',
+        configured: {
+          accountId: false,
+          keyId: true,
+          secretKey: false,
+        },
+      },
     })
+    expect(JSON.stringify(error)).not.toContain(alpacaKey)
+    expect(String(error)).not.toContain(alpacaKey)
   })
 
   test('requires a complete Alpaca binding for PAPER while allowing credential-free OBSERVE', async () => {
@@ -376,6 +1132,17 @@ describe('Effect configuration', () => {
       _tag: 'OperationalError',
       component: 'config',
       operation: 'load',
+      message: 'invalid Signal evaluation bounds: must not precede evaluationStart\n  at ["evaluationEnd"]',
+      cause: {
+        _tag: 'InvalidEvaluationBounds',
+        cause: {
+          _tag: 'SchemaError',
+          message: 'must not precede evaluationStart\n  at ["evaluationEnd"]',
+          issue: {
+            _tag: 'Composite',
+          },
+        },
+      },
     })
   })
 

--- a/services/bayn/src/config.test.ts
+++ b/services/bayn/src/config.test.ts
@@ -342,7 +342,6 @@ describe('pure runtime configuration resolution', () => {
       }),
       expected: {
         _tag: 'MissingAlpacaAuthorityGeneration',
-        accountId: alpacaAccountId,
       },
     },
     {
@@ -927,7 +926,7 @@ describe('Effect configuration', () => {
   test('requires an explicit valid authority generation to resolve an Alpaca binding', async () => {
     for (const value of [undefined, 'not-a-generation-hash']) {
       const environment = new Map(runtimeEnvironment)
-      environment.set('BAYN_ALPACA_ACCOUNT_ID', '61e69015-8549-4bfd-b9c3-01e75843f47d')
+      environment.set('BAYN_ALPACA_ACCOUNT_ID', alpacaAccountId)
       environment.set('BAYN_ALPACA_KEY_ID', 'paper-key')
       environment.set('BAYN_ALPACA_SECRET_KEY', 'paper-secret')
       if (value === undefined) {
@@ -943,6 +942,15 @@ describe('Effect configuration', () => {
         component: 'config',
         operation: value === undefined ? 'authority-generation' : 'load',
       })
+      if (value === undefined) {
+        expect(error).toMatchObject({
+          cause: {
+            _tag: 'MissingAlpacaAuthorityGeneration',
+          },
+        })
+        expect(JSON.stringify(error)).not.toContain(alpacaAccountId)
+        expect(String(error)).not.toContain(alpacaAccountId)
+      }
     }
   })
 

--- a/services/bayn/src/config.ts
+++ b/services/bayn/src/config.ts
@@ -129,7 +129,6 @@ export type RuntimeConfigResolutionFailure =
     }
   | {
       readonly _tag: 'MissingAlpacaAuthorityGeneration'
-      readonly accountId: string
     }
   | {
       readonly _tag: 'PaperAuthorityRequiresAlpacaBinding'
@@ -369,10 +368,7 @@ export const resolveRuntimeConfig = ({
     alpaca = undefined
   } else {
     if (config.authorityGenerationHash === undefined) {
-      return Result.fail({
-        _tag: 'MissingAlpacaAuthorityGeneration',
-        accountId: credentials.accountId,
-      })
+      return Result.fail({ _tag: 'MissingAlpacaAuthorityGeneration' })
     }
     alpaca = {
       ...credentials,

--- a/services/bayn/src/config.ts
+++ b/services/bayn/src/config.ts
@@ -1,8 +1,8 @@
-import { Config, Effect, Option, Redacted, Schema, SchemaTransformation } from 'effect'
+import { Config, Effect, Option, Redacted, Result, Schema, SchemaTransformation } from 'effect'
 
 import { EmbeddedBuildMetadataSchema, embeddedBuildMetadata, type EmbeddedBuildMetadata } from './build'
 import { EvaluationBoundsSchema, IsoDateSchema, Sha256Schema, type EvaluationBounds } from './contracts'
-import { operationalError, type OperationalError } from './errors'
+import { OperationalError, operationalError } from './errors'
 import { Authority } from './paper'
 import {
   GitSourceRevisionSchema as SourceRevision,
@@ -70,6 +70,122 @@ export interface AutonomousCycleRuntimeConfig {
 }
 
 export type LoadedRuntimeConfig = RuntimeConfig & AutonomousCycleRuntimeConfig
+
+export interface ParsedRuntimeConfig {
+  readonly host: string
+  readonly port: number
+  readonly qualificationRunId: string | undefined
+  readonly configuredPaperProofCommand: 'PREPARE' | undefined
+  readonly configuredPaperProofPhase: 'DISCOVER' | undefined
+  readonly maximumAuthority: Authority
+  readonly configuredBuild: EmbeddedBuildMetadata & {
+    readonly imageDigest: string
+  }
+  readonly provenanceMode: 'production' | 'development'
+  readonly healthIntervalMs: number
+  readonly operationTimeoutMs: number
+  readonly cycleStallThresholdMs: number
+  readonly reconciliationStaleThresholdMs: number
+  readonly unknownMutationThresholdMs: number
+  readonly cyclePollIntervalMs: number
+  readonly authorityGenerationHash: string | undefined
+  readonly configuredAlpaca: {
+    readonly accountId: string | undefined
+    readonly key: Redacted.Redacted<string> | undefined
+    readonly secret: Redacted.Redacted<string> | undefined
+    readonly proxyUrl: string
+    readonly retryAttempts: number
+    readonly reconciliationIntervalMs: number
+  }
+  readonly clickhouse: RuntimeConfig['clickhouse']
+  readonly postgres: RuntimeConfig['postgres']
+  readonly tigerBeetle: RuntimeConfig['tigerBeetle']
+}
+
+export interface RuntimeConfigResolutionInput {
+  readonly parsed: ParsedRuntimeConfig
+  readonly embeddedBuildMetadata: EmbeddedBuildMetadata | undefined
+}
+
+interface AlpacaCredentialPresence {
+  readonly accountId: boolean
+  readonly keyId: boolean
+  readonly secretKey: boolean
+}
+
+export type RuntimeConfigResolutionFailure =
+  | {
+      readonly _tag: 'InvalidEvaluationBounds'
+      readonly cause: Schema.SchemaError
+    }
+  | {
+      readonly _tag: 'CyclePollIntervalNotShorterThanStallThreshold'
+      readonly cyclePollIntervalMs: number
+      readonly cycleStallThresholdMs: number
+    }
+  | {
+      readonly _tag: 'IncompleteAlpacaCredentials'
+      readonly configured: AlpacaCredentialPresence
+    }
+  | {
+      readonly _tag: 'MissingAlpacaAuthorityGeneration'
+      readonly accountId: string
+    }
+  | {
+      readonly _tag: 'PaperAuthorityRequiresAlpacaBinding'
+      readonly maximumAuthority: Authority.Paper
+    }
+  | {
+      readonly _tag: 'IncompletePaperProofCommand'
+      readonly commandConfigured: boolean
+      readonly phaseConfigured: boolean
+    }
+  | {
+      readonly _tag: 'PaperProofCommandRequiresObserveAuthority'
+      readonly maximumAuthority: Authority.Paper
+    }
+  | {
+      readonly _tag: 'PaperProofCommandRequiresQualificationRun'
+    }
+  | {
+      readonly _tag: 'PaperProofCommandRequiresAlpacaBinding'
+    }
+  | {
+      readonly _tag: 'ProductionProvenanceRequiresEmbeddedMetadata'
+      readonly provenanceMode: 'production'
+    }
+  | {
+      readonly _tag: 'EmbeddedMetadataRequiresProductionProvenance'
+      readonly provenanceMode: 'development'
+    }
+  | {
+      readonly _tag: 'ProductionPostgresRequiresTls'
+      readonly postgresTls: false
+    }
+  | {
+      readonly _tag: 'InvalidEmbeddedBuildMetadata'
+      readonly cause: Schema.SchemaError
+    }
+  | {
+      readonly _tag: 'SourceRevisionMismatch'
+      readonly configuredSourceRevision: string
+      readonly embeddedSourceRevision: string
+    }
+  | {
+      readonly _tag: 'ImageRepositoryMismatch'
+      readonly configuredImageRepository: string
+      readonly embeddedImageRepository: string
+    }
+  | {
+      readonly _tag: 'StrategyBehaviorHashMismatch'
+      readonly configuredStrategyBehaviorHash: string
+      readonly embeddedStrategyBehaviorHash: string
+    }
+  | {
+      readonly _tag: 'StrategyParameterHashMismatch'
+      readonly configuredStrategyParameterHash: string
+      readonly embeddedStrategyParameterHash: string
+    }
 
 const ProvenanceMode = Schema.Literals(['production', 'development'])
 const RetryAttempts = Schema.Int.check(Schema.isBetween({ minimum: 0, maximum: 3 }))
@@ -148,237 +264,369 @@ const runtimeConfig = Config.all({
   tigerBeetleReplicaAddresses: Config.schema(ReplicaAddresses, 'BAYN_TIGERBEETLE_ADDRESSES'),
   tigerBeetleLedger: positiveInteger('BAYN_TIGERBEETLE_LEDGER', 7001),
 }).pipe(
-  Config.map((config) => ({
-    host: config.host,
-    port: config.port,
-    qualificationRunId: Option.getOrUndefined(config.qualificationRunId),
-    configuredPaperProofCommand: config.paperProofCommand,
-    configuredPaperProofPhase: config.paperProofPhase,
-    maximumAuthority: config.maximumAuthority,
-    configuredBuild: {
-      sourceRevision: config.sourceRevision,
-      imageRepository: config.imageRepository,
-      imageDigest: config.imageDigest,
-      strategyBehaviorHash: config.strategyBehaviorHash,
-      strategyParameterHash: config.strategyParameterHash,
-    },
-    provenanceMode: config.provenanceMode,
-    healthIntervalMs: config.healthIntervalMs,
-    operationTimeoutMs: config.operationTimeoutMs,
-    cycleStallThresholdMs: config.cycleStallThresholdMs,
-    reconciliationStaleThresholdMs: config.reconciliationStaleThresholdMs,
-    unknownMutationThresholdMs: config.unknownMutationThresholdMs,
-    cyclePollIntervalMs: config.cyclePollIntervalMs,
-    authorityGenerationHash: config.authorityGenerationHash,
-    configuredAlpaca: {
-      accountId: config.alpacaAccountId,
-      key: config.alpacaKey,
-      secret: config.alpacaSecret,
-      proxyUrl: config.alpacaProxyUrl,
-      retryAttempts: config.alpacaRetryAttempts,
-      reconciliationIntervalMs: config.reconciliationIntervalMs,
-    },
-    clickhouse: {
-      url: config.clickhouseUrl,
-      username: config.clickhouseUsername,
-      password: config.clickhousePassword,
-      snapshotId: config.snapshotId,
-      publicationAsOf: config.publicationAsOf,
-      calendarVersion: config.calendarVersion,
-      bounds: {
-        schemaVersion: 'bayn.evaluation-bounds.v1',
-        dataStart: config.dataStart,
-        dataEnd: config.dataEnd,
-        lookbackStart: config.lookbackStart,
-        evaluationStart: config.evaluationStart,
-        evaluationEnd: config.evaluationEnd,
+  Config.map(
+    (config): ParsedRuntimeConfig => ({
+      host: config.host,
+      port: config.port,
+      qualificationRunId: Option.getOrUndefined(config.qualificationRunId),
+      configuredPaperProofCommand: Option.getOrUndefined(config.paperProofCommand),
+      configuredPaperProofPhase: Option.getOrUndefined(config.paperProofPhase),
+      maximumAuthority: config.maximumAuthority,
+      configuredBuild: {
+        sourceRevision: config.sourceRevision,
+        imageRepository: config.imageRepository,
+        imageDigest: config.imageDigest,
+        strategyBehaviorHash: config.strategyBehaviorHash,
+        strategyParameterHash: config.strategyParameterHash,
       },
-    },
-    postgres: {
-      url: config.postgresUrl,
-      tls: config.postgresTls,
-      caPath: config.postgresCaPath,
-    },
-    tigerBeetle: {
-      clusterId: config.tigerBeetleClusterId,
-      replicaAddresses: config.tigerBeetleReplicaAddresses,
-      ledger: config.tigerBeetleLedger,
-    },
-  })),
+      provenanceMode: config.provenanceMode,
+      healthIntervalMs: config.healthIntervalMs,
+      operationTimeoutMs: config.operationTimeoutMs,
+      cycleStallThresholdMs: config.cycleStallThresholdMs,
+      reconciliationStaleThresholdMs: config.reconciliationStaleThresholdMs,
+      unknownMutationThresholdMs: config.unknownMutationThresholdMs,
+      cyclePollIntervalMs: config.cyclePollIntervalMs,
+      authorityGenerationHash: Option.getOrUndefined(config.authorityGenerationHash),
+      configuredAlpaca: {
+        accountId: Option.getOrUndefined(config.alpacaAccountId),
+        key: Option.getOrUndefined(config.alpacaKey),
+        secret: Option.getOrUndefined(config.alpacaSecret),
+        proxyUrl: config.alpacaProxyUrl,
+        retryAttempts: config.alpacaRetryAttempts,
+        reconciliationIntervalMs: config.reconciliationIntervalMs,
+      },
+      clickhouse: {
+        url: config.clickhouseUrl,
+        username: config.clickhouseUsername,
+        password: config.clickhousePassword,
+        snapshotId: config.snapshotId,
+        publicationAsOf: config.publicationAsOf,
+        calendarVersion: config.calendarVersion,
+        bounds: {
+          schemaVersion: 'bayn.evaluation-bounds.v1',
+          dataStart: config.dataStart,
+          dataEnd: config.dataEnd,
+          lookbackStart: config.lookbackStart,
+          evaluationStart: config.evaluationStart,
+          evaluationEnd: config.evaluationEnd,
+        },
+      },
+      postgres: {
+        url: config.postgresUrl,
+        tls: config.postgresTls,
+        caPath: config.postgresCaPath,
+      },
+      tigerBeetle: {
+        clusterId: config.tigerBeetleClusterId,
+        replicaAddresses: config.tigerBeetleReplicaAddresses,
+        ledger: config.tigerBeetleLedger,
+      },
+    }),
+  ),
 )
 
-const decodeEmbeddedBuildMetadata = Schema.decodeUnknownSync(EmbeddedBuildMetadataSchema, StrictParseOptions)
+const decodeEvaluationBounds = Schema.decodeUnknownResult(EvaluationBoundsSchema)
+const decodeEmbeddedBuildMetadata = Schema.decodeUnknownResult(EmbeddedBuildMetadataSchema, StrictParseOptions)
+
+export const resolveRuntimeConfig = ({
+  parsed: config,
+  embeddedBuildMetadata: embedded,
+}: RuntimeConfigResolutionInput): Result.Result<LoadedRuntimeConfig, RuntimeConfigResolutionFailure> => {
+  const boundsResult = decodeEvaluationBounds(config.clickhouse.bounds)
+  if (Result.isFailure(boundsResult)) {
+    return Result.fail({ _tag: 'InvalidEvaluationBounds', cause: boundsResult.failure })
+  }
+  if (config.cyclePollIntervalMs >= config.cycleStallThresholdMs) {
+    return Result.fail({
+      _tag: 'CyclePollIntervalNotShorterThanStallThreshold',
+      cyclePollIntervalMs: config.cyclePollIntervalMs,
+      cycleStallThresholdMs: config.cycleStallThresholdMs,
+    })
+  }
+
+  const credentialPresence = {
+    accountId: config.configuredAlpaca.accountId !== undefined,
+    keyId: config.configuredAlpaca.key !== undefined,
+    secretKey: config.configuredAlpaca.secret !== undefined,
+  } satisfies AlpacaCredentialPresence
+  const anyCredential = credentialPresence.accountId || credentialPresence.keyId || credentialPresence.secretKey
+  const credentials =
+    config.configuredAlpaca.accountId !== undefined &&
+    config.configuredAlpaca.key !== undefined &&
+    config.configuredAlpaca.secret !== undefined
+      ? {
+          accountId: config.configuredAlpaca.accountId,
+          key: config.configuredAlpaca.key,
+          secret: config.configuredAlpaca.secret,
+        }
+      : undefined
+  if (anyCredential && credentials === undefined) {
+    return Result.fail({ _tag: 'IncompleteAlpacaCredentials', configured: credentialPresence })
+  }
+
+  let alpaca: RuntimeConfig['alpaca']
+  if (credentials === undefined) {
+    alpaca = undefined
+  } else {
+    if (config.authorityGenerationHash === undefined) {
+      return Result.fail({
+        _tag: 'MissingAlpacaAuthorityGeneration',
+        accountId: credentials.accountId,
+      })
+    }
+    alpaca = {
+      ...credentials,
+      authorityGenerationHash: config.authorityGenerationHash,
+      proxyUrl: config.configuredAlpaca.proxyUrl,
+      retryAttempts: config.configuredAlpaca.retryAttempts,
+      reconciliationIntervalMs: config.configuredAlpaca.reconciliationIntervalMs,
+    }
+  }
+  if (config.maximumAuthority === Authority.Paper && alpaca === undefined) {
+    return Result.fail({
+      _tag: 'PaperAuthorityRequiresAlpacaBinding',
+      maximumAuthority: Authority.Paper,
+    })
+  }
+
+  const commandConfigured = config.configuredPaperProofCommand !== undefined
+  const phaseConfigured = config.configuredPaperProofPhase !== undefined
+  if (commandConfigured !== phaseConfigured) {
+    return Result.fail({
+      _tag: 'IncompletePaperProofCommand',
+      commandConfigured,
+      phaseConfigured,
+    })
+  }
+
+  let paperProofCommand: PaperProofRuntimeCommand | undefined
+  if (config.configuredPaperProofCommand !== undefined && config.configuredPaperProofPhase !== undefined) {
+    if (config.maximumAuthority !== Authority.Observe) {
+      return Result.fail({
+        _tag: 'PaperProofCommandRequiresObserveAuthority',
+        maximumAuthority: config.maximumAuthority,
+      })
+    }
+    if (config.qualificationRunId === undefined) {
+      return Result.fail({ _tag: 'PaperProofCommandRequiresQualificationRun' })
+    }
+    if (alpaca === undefined) {
+      return Result.fail({ _tag: 'PaperProofCommandRequiresAlpacaBinding' })
+    }
+    paperProofCommand = {
+      command: config.configuredPaperProofCommand,
+      phase: config.configuredPaperProofPhase,
+    }
+  }
+
+  if (embedded === undefined && config.provenanceMode !== 'development') {
+    return Result.fail({
+      _tag: 'ProductionProvenanceRequiresEmbeddedMetadata',
+      provenanceMode: 'production',
+    })
+  }
+  if (embedded !== undefined && config.provenanceMode !== 'production') {
+    return Result.fail({
+      _tag: 'EmbeddedMetadataRequiresProductionProvenance',
+      provenanceMode: 'development',
+    })
+  }
+  if (embedded !== undefined && !config.postgres.tls) {
+    return Result.fail({
+      _tag: 'ProductionPostgresRequiresTls',
+      postgresTls: false,
+    })
+  }
+
+  let decodedBuild: EmbeddedBuildMetadata
+  if (embedded === undefined) {
+    decodedBuild = {
+      sourceRevision: config.configuredBuild.sourceRevision,
+      imageRepository: config.configuredBuild.imageRepository,
+      strategyBehaviorHash: config.configuredBuild.strategyBehaviorHash,
+      strategyParameterHash: config.configuredBuild.strategyParameterHash,
+    }
+  } else {
+    const decodedBuildResult = decodeEmbeddedBuildMetadata(embedded)
+    if (Result.isFailure(decodedBuildResult)) {
+      return Result.fail({
+        _tag: 'InvalidEmbeddedBuildMetadata',
+        cause: decodedBuildResult.failure,
+      })
+    }
+    decodedBuild = decodedBuildResult.success
+    if (config.configuredBuild.sourceRevision !== decodedBuild.sourceRevision) {
+      return Result.fail({
+        _tag: 'SourceRevisionMismatch',
+        configuredSourceRevision: config.configuredBuild.sourceRevision,
+        embeddedSourceRevision: decodedBuild.sourceRevision,
+      })
+    }
+    if (config.configuredBuild.imageRepository !== decodedBuild.imageRepository) {
+      return Result.fail({
+        _tag: 'ImageRepositoryMismatch',
+        configuredImageRepository: config.configuredBuild.imageRepository,
+        embeddedImageRepository: decodedBuild.imageRepository,
+      })
+    }
+    if (config.configuredBuild.strategyBehaviorHash !== decodedBuild.strategyBehaviorHash) {
+      return Result.fail({
+        _tag: 'StrategyBehaviorHashMismatch',
+        configuredStrategyBehaviorHash: config.configuredBuild.strategyBehaviorHash,
+        embeddedStrategyBehaviorHash: decodedBuild.strategyBehaviorHash,
+      })
+    }
+    if (config.configuredBuild.strategyParameterHash !== decodedBuild.strategyParameterHash) {
+      return Result.fail({
+        _tag: 'StrategyParameterHashMismatch',
+        configuredStrategyParameterHash: config.configuredBuild.strategyParameterHash,
+        embeddedStrategyParameterHash: decodedBuild.strategyParameterHash,
+      })
+    }
+  }
+
+  const {
+    configuredAlpaca: _configuredAlpaca,
+    authorityGenerationHash: _authorityGenerationHash,
+    configuredPaperProofCommand: _configuredPaperProofCommand,
+    configuredPaperProofPhase: _configuredPaperProofPhase,
+    configuredBuild,
+    provenanceMode,
+    ...runtime
+  } = config
+  const resolved: LoadedRuntimeConfig = {
+    ...runtime,
+    clickhouse: {
+      ...runtime.clickhouse,
+      bounds: boundsResult.success,
+    },
+    build: {
+      ...decodedBuild,
+      imageDigest: configuredBuild.imageDigest,
+      verification: provenanceMode === 'production' ? 'embedded' : 'development-configured',
+    },
+    ...(paperProofCommand === undefined ? {} : { paperProofCommand }),
+    ...(alpaca === undefined ? {} : { alpaca }),
+  }
+  return Result.succeed(resolved)
+}
+
+interface RuntimeConfigFailurePresentation {
+  readonly operation: string
+  readonly message: string
+}
+
+const presentRuntimeConfigFailure = (failure: RuntimeConfigResolutionFailure): RuntimeConfigFailurePresentation => {
+  switch (failure._tag) {
+    case 'InvalidEvaluationBounds':
+      return {
+        operation: 'load',
+        message: `invalid Signal evaluation bounds: ${failure.cause.message}`,
+      }
+    case 'CyclePollIntervalNotShorterThanStallThreshold':
+      return {
+        operation: 'cycle-loop',
+        message: 'cycle poll interval must be shorter than the cycle stall threshold',
+      }
+    case 'IncompleteAlpacaCredentials':
+      return {
+        operation: 'alpaca',
+        message: 'Alpaca account ID, key ID, and secret key must be configured together',
+      }
+    case 'MissingAlpacaAuthorityGeneration':
+      return {
+        operation: 'authority-generation',
+        message: 'Alpaca account binding requires an authority generation hash',
+      }
+    case 'PaperAuthorityRequiresAlpacaBinding':
+      return {
+        operation: 'alpaca',
+        message: 'PAPER maximum authority requires a complete Alpaca account binding',
+      }
+    case 'IncompletePaperProofCommand':
+      return {
+        operation: 'paper-command',
+        message: 'BAYN_PAPER_COMMAND and BAYN_PAPER_PREPARE_PHASE must be configured together',
+      }
+    case 'PaperProofCommandRequiresObserveAuthority':
+      return {
+        operation: 'paper-command',
+        message: 'PREPARE DISCOVER requires OBSERVE maximum authority',
+      }
+    case 'PaperProofCommandRequiresQualificationRun':
+      return {
+        operation: 'paper-command',
+        message: 'PREPARE DISCOVER requires a pinned terminal qualification run',
+      }
+    case 'PaperProofCommandRequiresAlpacaBinding':
+      return {
+        operation: 'paper-command',
+        message: 'PREPARE DISCOVER requires a complete Alpaca read binding',
+      }
+    case 'ProductionProvenanceRequiresEmbeddedMetadata':
+      return {
+        operation: 'provenance',
+        message: 'invalid build provenance: production provenance requires compile-time build metadata',
+      }
+    case 'EmbeddedMetadataRequiresProductionProvenance':
+      return {
+        operation: 'provenance',
+        message: 'invalid build provenance: development provenance cannot override embedded production metadata',
+      }
+    case 'ProductionPostgresRequiresTls':
+      return {
+        operation: 'provenance',
+        message: 'invalid build provenance: production PostgreSQL connections require verified TLS',
+      }
+    case 'InvalidEmbeddedBuildMetadata':
+      return {
+        operation: 'provenance',
+        message: `invalid build provenance: ${failure.cause.message}`,
+      }
+    case 'SourceRevisionMismatch':
+      return {
+        operation: 'provenance',
+        message: `invalid build provenance: configured source revision ${failure.configuredSourceRevision} does not match embedded revision ${failure.embeddedSourceRevision}`,
+      }
+    case 'ImageRepositoryMismatch':
+      return {
+        operation: 'provenance',
+        message: `invalid build provenance: configured image repository ${failure.configuredImageRepository} does not match embedded repository ${failure.embeddedImageRepository}`,
+      }
+    case 'StrategyBehaviorHashMismatch':
+      return {
+        operation: 'provenance',
+        message: 'invalid build provenance: configured strategy behavior hash does not match embedded build metadata',
+      }
+    case 'StrategyParameterHashMismatch':
+      return {
+        operation: 'provenance',
+        message: 'invalid build provenance: configured strategy parameter hash does not match embedded build metadata',
+      }
+  }
+  const exhaustive: never = failure
+  return exhaustive
+}
+
+const resolutionFailureToOperationalError = (failure: RuntimeConfigResolutionFailure): OperationalError => {
+  const presentation = presentRuntimeConfigFailure(failure)
+  return new OperationalError({
+    component: 'config',
+    operation: presentation.operation,
+    message: presentation.message,
+    retryable: false,
+    cause: failure,
+  })
+}
 
 export const loadConfig = (
   embedded: EmbeddedBuildMetadata | undefined = embeddedBuildMetadata,
 ): Effect.Effect<LoadedRuntimeConfig, OperationalError> =>
   runtimeConfig.pipe(
     Effect.mapError((cause) => operationalError('config', 'load', 'invalid runtime configuration', cause)),
-    Effect.flatMap((config) =>
-      Effect.try({
-        try: () => ({
-          ...config,
-          clickhouse: {
-            ...config.clickhouse,
-            bounds: Schema.decodeUnknownSync(EvaluationBoundsSchema)(config.clickhouse.bounds),
-          },
-        }),
-        catch: (cause) => operationalError('config', 'load', 'invalid Signal evaluation bounds', cause),
-      }),
-    ),
-    Effect.flatMap((config) =>
-      config.cyclePollIntervalMs < config.cycleStallThresholdMs
-        ? Effect.succeed(config)
-        : Effect.fail(
-            operationalError(
-              'config',
-              'cycle-loop',
-              'cycle poll interval must be shorter than the cycle stall threshold',
-            ),
-          ),
-    ),
-    Effect.flatMap((config) => {
-      const credentials = Option.all({
-        accountId: config.configuredAlpaca.accountId,
-        key: config.configuredAlpaca.key,
-        secret: config.configuredAlpaca.secret,
-      })
-      const anyCredential =
-        Option.isSome(config.configuredAlpaca.accountId) ||
-        Option.isSome(config.configuredAlpaca.key) ||
-        Option.isSome(config.configuredAlpaca.secret)
-      if (anyCredential && Option.isNone(credentials)) {
-        return Effect.fail(
-          operationalError('config', 'alpaca', 'Alpaca account ID, key ID, and secret key must be configured together'),
-        )
-      }
-      if (Option.isSome(credentials) && Option.isNone(config.authorityGenerationHash)) {
-        return Effect.fail(
-          operationalError(
-            'config',
-            'authority-generation',
-            'Alpaca account binding requires an authority generation hash',
-          ),
-        )
-      }
-      const alpaca = Option.map(
-        Option.all({ credentials, authorityGenerationHash: config.authorityGenerationHash }),
-        ({ credentials: value, authorityGenerationHash }) => ({
-          ...value,
-          authorityGenerationHash,
-          proxyUrl: config.configuredAlpaca.proxyUrl,
-          retryAttempts: config.configuredAlpaca.retryAttempts,
-          reconciliationIntervalMs: config.configuredAlpaca.reconciliationIntervalMs,
-        }),
-      )
-      if (config.maximumAuthority === Authority.Paper && Option.isNone(alpaca)) {
-        return Effect.fail(
-          operationalError('config', 'alpaca', 'PAPER maximum authority requires a complete Alpaca account binding'),
-        )
-      }
-      const commandConfigured = Option.isSome(config.configuredPaperProofCommand)
-      const phaseConfigured = Option.isSome(config.configuredPaperProofPhase)
-      if (commandConfigured !== phaseConfigured) {
-        return Effect.fail(
-          operationalError(
-            'config',
-            'paper-command',
-            'BAYN_PAPER_COMMAND and BAYN_PAPER_PREPARE_PHASE must be configured together',
-          ),
-        )
-      }
-      if (commandConfigured) {
-        if (config.maximumAuthority !== Authority.Observe) {
-          return Effect.fail(
-            operationalError('config', 'paper-command', 'PREPARE DISCOVER requires OBSERVE maximum authority'),
-          )
-        }
-        if (config.qualificationRunId === undefined) {
-          return Effect.fail(
-            operationalError(
-              'config',
-              'paper-command',
-              'PREPARE DISCOVER requires a pinned terminal qualification run',
-            ),
-          )
-        }
-        if (Option.isNone(alpaca)) {
-          return Effect.fail(
-            operationalError('config', 'paper-command', 'PREPARE DISCOVER requires a complete Alpaca read binding'),
-          )
-        }
-      }
-      const paperProofCommand =
-        Option.isSome(config.configuredPaperProofCommand) && Option.isSome(config.configuredPaperProofPhase)
-          ? {
-              command: config.configuredPaperProofCommand.value,
-              phase: config.configuredPaperProofPhase.value,
-            }
-          : undefined
-      const {
-        configuredAlpaca: _configuredAlpaca,
-        authorityGenerationHash: _authorityGenerationHash,
-        configuredPaperProofCommand: _configuredPaperProofCommand,
-        configuredPaperProofPhase: _configuredPaperProofPhase,
-        ...runtime
-      } = config
-      return Effect.succeed({
-        ...runtime,
-        ...(paperProofCommand === undefined ? {} : { paperProofCommand }),
-        ...(Option.isSome(alpaca) ? { alpaca: alpaca.value } : {}),
-      })
-    }),
-    Effect.flatMap((config) =>
-      Effect.try({
-        try: (): LoadedRuntimeConfig => {
-          if (embedded === undefined && config.provenanceMode !== 'development') {
-            throw new Error('production provenance requires compile-time build metadata')
-          }
-          if (embedded !== undefined && config.provenanceMode !== 'production') {
-            throw new Error('development provenance cannot override embedded production metadata')
-          }
-          if (embedded !== undefined && !config.postgres.tls) {
-            throw new Error('production PostgreSQL connections require verified TLS')
-          }
-          const decodedBuild =
-            embedded === undefined
-              ? {
-                  sourceRevision: config.configuredBuild.sourceRevision,
-                  imageRepository: config.configuredBuild.imageRepository,
-                  strategyBehaviorHash: config.configuredBuild.strategyBehaviorHash,
-                  strategyParameterHash: config.configuredBuild.strategyParameterHash,
-                }
-              : decodeEmbeddedBuildMetadata(embedded)
-          if (embedded !== undefined) {
-            if (config.configuredBuild.sourceRevision !== decodedBuild.sourceRevision) {
-              throw new Error(
-                `configured source revision ${config.configuredBuild.sourceRevision} does not match embedded revision ${decodedBuild.sourceRevision}`,
-              )
-            }
-            if (config.configuredBuild.imageRepository !== decodedBuild.imageRepository) {
-              throw new Error(
-                `configured image repository ${config.configuredBuild.imageRepository} does not match embedded repository ${decodedBuild.imageRepository}`,
-              )
-            }
-            if (config.configuredBuild.strategyBehaviorHash !== decodedBuild.strategyBehaviorHash) {
-              throw new Error('configured strategy behavior hash does not match embedded build metadata')
-            }
-            if (config.configuredBuild.strategyParameterHash !== decodedBuild.strategyParameterHash) {
-              throw new Error('configured strategy parameter hash does not match embedded build metadata')
-            }
-          }
-          const { configuredBuild, provenanceMode, ...runtime } = config
-          return {
-            ...runtime,
-            clickhouse: runtime.clickhouse,
-            build: {
-              ...decodedBuild,
-              imageDigest: configuredBuild.imageDigest,
-              verification: provenanceMode === 'production' ? 'embedded' : 'development-configured',
-            },
-          }
-        },
-        catch: (cause) => operationalError('config', 'provenance', 'invalid build provenance', cause),
-      }),
+    Effect.flatMap((parsed) =>
+      Effect.fromResult(resolveRuntimeConfig({ parsed, embeddedBuildMetadata: embedded })).pipe(
+        Effect.mapError(resolutionFailureToOperationalError),
+      ),
     ),
   )


### PR DESCRIPTION
## Summary

- Extract Bayn runtime configuration resolution into one total pure resolver over readonly parsed inputs.
- Model every invalid configuration as a concrete closed tagged failure while preserving validation precedence, defaults, environment names, public API, and secret redaction.
- Convert the pure `Result` once at the Effect boundary and retain the complete typed resolution failure as the operational cause.
- Add table-driven pure and Effect-boundary coverage for every runtime mode, invalid combination, structured cause, precedence rule, and redaction contract.

## Related Issues

- Resolves [PROOMPT-431](https://linear.app/proompteng/issue/PROOMPT-431/make-bayn-runtime-configuration-resolution-total-and-typed)

## Testing

- `bun test services/bayn/src/config.test.ts` — 71 passed, 0 failed.
- `bun run --filter @proompteng/bayn test` — 498 passed, 106 PostgreSQL-gated skips, 0 failed.
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- `git diff --check`

## Screenshots (if applicable)

N/A — configuration-only refactor with no visual surface.

## Breaking Changes

None. Runtime environment names, defaults, validation and failure precedence, redaction, authority restrictions, timeout relationships, and public API are preserved.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked; no documentation change is required for this behavior-preserving refactor.