### PR TITLE
refactor(bayn): separate HTTP decisions from effects

### DIFF
--- a/services/bayn/src/http.test.ts
+++ b/services/bayn/src/http.test.ts
@@ -1,47 +1,73 @@
+import { connect, type Socket } from 'node:net'
+
 import { describe, expect, test } from 'bun:test'
 
-import { Context, Effect, Layer, Ref } from 'effect'
+import { Cause, Context, Deferred, Effect, Exit, Fiber, Layer, Option, Ref } from 'effect'
+import { TestClock } from 'effect/testing'
 import { HttpServer } from 'effect/unstable/http'
 
 import {
   config,
-  provenance,
+  historicalEvidence,
   historicalRunId,
-  successfulEvidenceStore,
-  fixtureQualification,
-  fetchJson,
+  provenance,
   readyState,
+  successfulEvidenceStore,
 } from './app-test-support'
 import type { BrokerReadShape } from './broker/alpaca'
 import { unusedAssetBySymbol, unusedMarketCalendar } from './broker/alpaca-test-support'
-import { DatabaseError, type EvidenceStoreService } from './db/evidence-store'
 import { CycleOperationsCondition, CycleOperationsReason } from './cycle-observability'
 import { CycleState, CycleTerminalReason } from './cycle'
+import { DatabaseError, type EvidenceStoreService } from './db/evidence-store'
 import type { BrokerProbe } from './health'
-import { makeHttpLayer, renderPrometheusMetrics } from './http'
-import { Authority } from './paper'
+import {
+  fallbackResponseDecision,
+  historicalEvidenceResponseDecision,
+  historicalReadFailureDecision,
+  makeHttpLayer,
+  readHistoricalEvidence,
+  readinessResponseDecision,
+  renderPrometheusMetrics,
+  statusFacts,
+  statusResponseDecision,
+  validateHistoricalRunRequest,
+} from './http'
+import { Authority, KillState } from './paper'
 import { initialState, type RuntimeState } from './runtime-state'
 
 const metricValue = (metrics: string, name: string): number => {
   const line = metrics.split('\n').find((candidate) => candidate.startsWith(`${name} `))
-  if (line === undefined) throw new Error(`metric ${name} is missing`)
-  return Number(line.slice(name.length + 1))
+  expect(line).toBeDefined()
+  return line === undefined ? Number.NaN : Number(line.slice(name.length + 1))
 }
 
-describe('Bayn HTTP probes', () => {
-  test('serves every route from the current runtime state and closes its socket', async () => {
-    let port = 0
-    await Effect.runPromise(
-      Effect.scoped(
-        Effect.gen(function* () {
-          const state = yield* Ref.make(initialState())
-          const context = yield* Layer.build(
+interface TestServerOptions {
+  readonly state?: RuntimeState
+  readonly maximumAuthority?: Authority
+  readonly operationTimeoutMs?: number
+  readonly readEvidence?: EvidenceStoreService['read']
+}
+
+interface TestServer {
+  readonly port: number
+  readonly state: Ref.Ref<RuntimeState>
+}
+
+const withHttpServer = (
+  options: TestServerOptions,
+  use: (server: TestServer) => Effect.Effect<void, unknown>,
+): Promise<void> =>
+  Effect.runPromise(
+    Effect.scoped(
+      Ref.make(options.state ?? initialState()).pipe(
+        Effect.flatMap((state) =>
+          Layer.build(
             makeHttpLayer(
               {
                 cycleStallThresholdMs: config.cycleStallThresholdMs,
                 host: '127.0.0.1',
-                maximumAuthority: Authority.Observe,
-                operationTimeoutMs: 250,
+                maximumAuthority: options.maximumAuthority ?? Authority.Observe,
+                operationTimeoutMs: options.operationTimeoutMs ?? 250,
                 port: 0,
                 reconciliationStaleThresholdMs: config.reconciliationStaleThresholdMs,
                 unknownMutationThresholdMs: config.unknownMutationThresholdMs,
@@ -49,139 +75,726 @@ describe('Bayn HTTP probes', () => {
               state,
               provenance,
               'embedded',
-              successfulEvidenceStore.read,
+              options.readEvidence ?? successfulEvidenceStore.read,
             ),
-          )
-          const address = Context.get(context, HttpServer.HttpServer).address
-          if (address._tag !== 'TcpAddress') throw new Error('test server did not bind a TCP port')
-          port = address.port
+          ).pipe(
+            Effect.flatMap((context) => {
+              const address = Context.get(context, HttpServer.HttpServer).address
+              expect(address._tag).toBe('TcpAddress')
+              return address._tag === 'TcpAddress' ? use({ port: address.port, state }) : Effect.die('expected TCP')
+            }),
+          ),
+        ),
+      ),
+    ),
+  )
 
-          expect(yield* Effect.promise(() => fetchJson(port, '/livez'))).toEqual({
+const request = (port: number, path: string, method = 'GET') =>
+  Effect.tryPromise({
+    try: async (signal) => {
+      const response = await fetch(`http://127.0.0.1:${port}${path}`, { method, signal })
+      const contentType = response.headers.get('content-type')
+      const body = contentType?.includes('application/json') ? await response.json() : await response.text()
+      return {
+        status: response.status,
+        allow: response.headers.get('allow'),
+        cacheControl: response.headers.get('cache-control'),
+        contentType,
+        body,
+      }
+    },
+    catch: (cause) => cause,
+  })
+
+const connectSocket = (port: number): Effect.Effect<Socket> =>
+  Effect.callback<Socket>((resume) => {
+    const socket = connect({ host: '127.0.0.1', port })
+    const onConnect = () => {
+      socket.off('error', onError)
+      resume(Effect.succeed(socket))
+    }
+    const onError = (cause: unknown) => {
+      socket.off('connect', onConnect)
+      resume(Effect.die(cause))
+    }
+    socket.once('connect', onConnect)
+    socket.once('error', onError)
+    return Effect.sync(() => {
+      socket.off('connect', onConnect)
+      socket.off('error', onError)
+      socket.destroy()
+    })
+  })
+
+const withConnectedSocket = <A, E, R>(
+  port: number,
+  use: (socket: Socket) => Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> =>
+  Effect.scoped(
+    Effect.acquireRelease(connectSocket(port), (socket) => Effect.sync(() => socket.destroy())).pipe(
+      Effect.flatMap(use),
+    ),
+  )
+
+describe('Bayn HTTP pure decisions', () => {
+  test.each([
+    {
+      name: 'missing parameter',
+      runId: undefined,
+      expected: {
+        _tag: 'Respond',
+        response: { _tag: 'Json', status: 400, body: { error: 'invalid_run_id' } },
+      },
+    },
+    {
+      name: 'short parameter',
+      runId: 'a'.repeat(63),
+      expected: {
+        _tag: 'Respond',
+        response: { _tag: 'Json', status: 400, body: { error: 'invalid_run_id' } },
+      },
+    },
+    {
+      name: 'uppercase parameter',
+      runId: 'A'.repeat(64),
+      expected: {
+        _tag: 'Respond',
+        response: { _tag: 'Json', status: 400, body: { error: 'invalid_run_id' } },
+      },
+    },
+    {
+      name: 'non-hex parameter',
+      runId: `${'a'.repeat(63)}g`,
+      expected: {
+        _tag: 'Respond',
+        response: { _tag: 'Json', status: 400, body: { error: 'invalid_run_id' } },
+      },
+    },
+    {
+      name: 'canonical parameter',
+      runId: historicalRunId,
+      expected: { _tag: 'ReadEvidence', runId: historicalRunId },
+    },
+  ])('validates $name without I/O', ({ runId, expected }) => {
+    expect(validateHistoricalRunRequest(runId)).toEqual(expected)
+  })
+
+  test('decides historical evidence, fallback, and status responses from immutable values', () => {
+    const initial = initialState()
+    expect(historicalEvidenceResponseDecision(Option.some(historicalEvidence))).toEqual({
+      _tag: 'Json',
+      status: 200,
+      body: historicalEvidence,
+    })
+    expect(historicalEvidenceResponseDecision(Option.none())).toEqual({
+      _tag: 'Json',
+      status: 404,
+      body: { error: 'evaluation_not_found' },
+    })
+    expect(['GET', 'POST', 'HEAD'].map((method) => ({ method, decision: fallbackResponseDecision(method) }))).toEqual([
+      {
+        method: 'GET',
+        decision: { _tag: 'Json', status: 404, body: { error: 'not_found' } },
+      },
+      {
+        method: 'POST',
+        decision: {
+          _tag: 'Json',
+          status: 405,
+          body: { error: 'method_not_allowed' },
+          headers: { allow: 'GET' },
+        },
+      },
+      {
+        method: 'HEAD',
+        decision: {
+          _tag: 'Json',
+          status: 405,
+          body: { error: 'method_not_allowed' },
+          headers: { allow: 'GET' },
+        },
+      },
+    ])
+    expect(statusResponseDecision(initial, Authority.Observe, provenance, 'embedded')).toEqual({
+      _tag: 'Json',
+      status: 200,
+      body: statusFacts(initial, Authority.Observe, provenance, 'embedded'),
+    })
+  })
+
+  test('covers every readiness decision branch without mutating runtime facts', () => {
+    const healthy = readyState()
+    const checkedAt = healthy.health.checkedAt
+    const broker = {
+      configured: true as const,
+      expectedAccountId: 'paper-account-1',
+      accountId: 'paper-account-1',
+      accountBound: false,
+      readAvailable: true,
+      checkedAt,
+      error: 'binding unavailable',
+      executionEligible: false,
+      executionDisabledReason: 'MAXIMUM_AUTHORITY_OBSERVE',
+    }
+    const loopFailure: RuntimeState = {
+      ...healthy,
+      autonomousCycleLoop: {
+        configured: true,
+        startedAt: checkedAt,
+        lastPass: {
+          result: 'FAILURE',
+          observedAt: checkedAt ?? '2026-07-20T00:00:00.000Z',
+          operation: 'market-calendar',
+          failure: 'calendar-read',
+          message: 'calendar unavailable',
+        },
+      },
+    }
+    const failedDependency: RuntimeState = {
+      ...healthy,
+      health: {
+        ...healthy.health,
+        dependencies: {
+          ...healthy.health.dependencies,
+          signal: { status: 'UNAVAILABLE', checkedAt, error: 'signal unavailable' },
+        },
+      },
+    }
+    const cycleState = (condition: CycleOperationsCondition): RuntimeState => ({
+      ...healthy,
+      cycle: { ...healthy.cycle, condition },
+    })
+    const duplicateFailures: RuntimeState = {
+      ...loopFailure,
+      cycle: { ...healthy.cycle, condition: CycleOperationsCondition.Failed },
+      health: {
+        ...healthy.health,
+        dependencies: {
+          ...healthy.health.dependencies,
+          cycle: { status: 'UNAVAILABLE', checkedAt, error: 'cycle unavailable' },
+          cycleRunner: { status: 'UNAVAILABLE', checkedAt, error: 'runner unavailable' },
+        },
+      },
+    }
+    const cases: readonly {
+      readonly name: string
+      readonly state: RuntimeState
+      readonly ready: boolean
+      readonly status: 200 | 503
+      readonly failedDependencies: readonly string[]
+    }[] = [
+      { name: 'ready', state: healthy, ready: true, status: 200, failedDependencies: [] },
+      {
+        name: 'runtime status',
+        state: { ...healthy, status: 'DEGRADED' },
+        ready: false,
+        status: 503,
+        failedDependencies: [],
+      },
+      {
+        name: 'missing evidence',
+        state: { ...healthy, evidence: null },
+        ready: false,
+        status: 503,
+        failedDependencies: [],
+      },
+      {
+        name: 'dependency failure',
+        state: failedDependency,
+        ready: false,
+        status: 503,
+        failedDependencies: ['signal'],
+      },
+      {
+        name: 'broker binding',
+        state: { ...healthy, broker },
+        ready: false,
+        status: 503,
+        failedDependencies: ['broker'],
+      },
+      {
+        name: 'unknown cycle',
+        state: cycleState(CycleOperationsCondition.Unknown),
+        ready: false,
+        status: 503,
+        failedDependencies: ['cycle'],
+      },
+      {
+        name: 'stalled cycle',
+        state: cycleState(CycleOperationsCondition.Stalled),
+        ready: false,
+        status: 503,
+        failedDependencies: ['cycle'],
+      },
+      {
+        name: 'failed cycle',
+        state: cycleState(CycleOperationsCondition.Failed),
+        ready: false,
+        status: 503,
+        failedDependencies: ['cycle'],
+      },
+      {
+        name: 'loop failure',
+        state: loopFailure,
+        ready: false,
+        status: 503,
+        failedDependencies: ['cycleRunner'],
+      },
+      {
+        name: 'deduplicated observed failures',
+        state: duplicateFailures,
+        ready: false,
+        status: 503,
+        failedDependencies: ['cycle', 'cycleRunner'],
+      },
+      {
+        name: 'initial unknown dependencies',
+        state: initialState(),
+        ready: false,
+        status: 503,
+        failedDependencies: ['postgresql', 'signal', 'tigerBeetle', 'evidence', 'cycle', 'cycleRunner'],
+      },
+    ]
+
+    for (const testCase of cases) {
+      expect(readinessResponseDecision(testCase.state), testCase.name).toEqual({
+        _tag: 'Json',
+        status: testCase.status,
+        body: {
+          ready: testCase.ready,
+          status: testCase.state.status,
+          checkedAt: testCase.state.health.checkedAt,
+          probeSequence: testCase.state.health.sequence,
+          failedDependencies: testCase.failedDependencies,
+        },
+      })
+    }
+  })
+
+  test('covers every public status projection branch from immutable facts', () => {
+    const initial = initialState()
+    const healthy = readyState()
+    const checkedAt = healthy.health.checkedAt
+    const observedAt = checkedAt ?? '2026-07-20T00:00:00.000Z'
+    const unknownDependencies: RuntimeState = {
+      ...healthy,
+      health: {
+        ...healthy.health,
+        dependencies: {
+          ...healthy.health.dependencies,
+          signal: { status: 'UNKNOWN', checkedAt, error: null },
+          tigerBeetle: { status: 'UNKNOWN', checkedAt, error: null },
+          evidence: { status: 'UNKNOWN', checkedAt, error: null },
+        },
+      },
+    }
+    const unavailableDependencies: RuntimeState = {
+      ...healthy,
+      health: {
+        ...healthy.health,
+        dependencies: {
+          ...healthy.health.dependencies,
+          signal: { status: 'UNAVAILABLE', checkedAt, error: 'signal unavailable' },
+          tigerBeetle: { status: 'UNAVAILABLE', checkedAt, error: 'journal unavailable' },
+          evidence: { status: 'UNAVAILABLE', checkedAt, error: 'evidence unavailable' },
+        },
+      },
+    }
+    const configured: RuntimeState = {
+      ...healthy,
+      cycle: {
+        ...healthy.cycle,
+        authority: {
+          generationHash: 'a'.repeat(64),
+          maximum: Authority.Paper,
+          effective: Authority.Observe,
+          kill: KillState.Active,
+          reason: 'operator kill',
+          updatedAt: observedAt,
+        },
+      },
+      broker: {
+        configured: true,
+        expectedAccountId: 'paper-account-1',
+        accountId: 'paper-account-1',
+        accountBound: true,
+        readAvailable: true,
+        checkedAt,
+        error: null,
+        executionEligible: false,
+        executionDisabledReason: 'MAXIMUM_AUTHORITY_OBSERVE',
+      },
+    }
+    const cases = [
+      {
+        name: 'no evidence or observations',
+        state: initial,
+        maximum: Authority.Observe,
+        expected: {
+          data: 'UNKNOWN',
+          evidence: 'UNKNOWN',
+          accounting: 'UNKNOWN',
+          observationAvailable: false,
+          maximum: 'observe',
+          durable: { available: false },
+          broker: { configured: false, accountBound: false, readAvailable: false },
+        },
+      },
+      {
+        name: 'current evidence without durable authority',
+        state: healthy,
+        maximum: Authority.Observe,
+        expected: {
+          data: 'CURRENT',
+          evidence: 'CURRENT',
+          accounting: 'EXACT',
+          observationAvailable: true,
+          maximum: 'observe',
+          durable: {
+            available: true,
+            configured: false,
+            maximum: null,
+            effective: null,
+            kill: null,
+            reason: null,
+            updatedAt: null,
+          },
+          broker: { configured: false, accountBound: false, readAvailable: false },
+        },
+      },
+      {
+        name: 'unknown dependency verification',
+        state: unknownDependencies,
+        maximum: Authority.Observe,
+        expected: {
+          data: 'UNKNOWN',
+          evidence: 'UNKNOWN',
+          accounting: 'UNKNOWN',
+          observationAvailable: true,
+          maximum: 'observe',
+          durable: {
+            available: true,
+            configured: false,
+            maximum: null,
+            effective: null,
+            kill: null,
+            reason: null,
+            updatedAt: null,
+          },
+          broker: { configured: false, accountBound: false, readAvailable: false },
+        },
+      },
+      {
+        name: 'invalid dependency verification',
+        state: unavailableDependencies,
+        maximum: Authority.Observe,
+        expected: {
+          data: 'INVALID',
+          evidence: 'INVALID',
+          accounting: 'UNAVAILABLE',
+          observationAvailable: true,
+          maximum: 'observe',
+          durable: {
+            available: true,
+            configured: false,
+            maximum: null,
+            effective: null,
+            kill: null,
+            reason: null,
+            updatedAt: null,
+          },
+          broker: { configured: false, accountBound: false, readAvailable: false },
+        },
+      },
+      {
+        name: 'configured paper ceiling and durable observe kill',
+        state: configured,
+        maximum: Authority.Paper,
+        expected: {
+          data: 'CURRENT',
+          evidence: 'CURRENT',
+          accounting: 'EXACT',
+          observationAvailable: true,
+          maximum: 'paper',
+          durable: {
+            available: true,
+            configured: true,
+            maximum: 'paper',
+            effective: 'observe',
+            kill: 'active',
+            reason: 'operator kill',
+            updatedAt: observedAt,
+          },
+          broker: { configured: true, accountBound: true, readAvailable: true },
+        },
+      },
+    ] as const
+
+    for (const testCase of cases) {
+      const facts = statusFacts(testCase.state, testCase.maximum, provenance, 'embedded')
+      expect(
+        {
+          data: facts.data.status,
+          evidence: facts.evidence.status,
+          accounting: facts.accounting.status,
+          observationAvailable: facts.cycle.observationAvailable,
+          maximum: facts.authority.maximum,
+          durable: facts.authority.durable,
+          broker: {
+            configured: facts.broker.configured,
+            accountBound: facts.broker.accountBound,
+            readAvailable: facts.broker.readAvailable,
+          },
+        },
+        testCase.name,
+      ).toEqual(testCase.expected)
+    }
+  })
+
+  test('maps database and timeout failures to the typed operational boundary with the cause intact', async () => {
+    const databaseCause = new DatabaseError({
+      failure: 'unavailable',
+      operation: 'read-evidence',
+      message: 'database unavailable',
+    })
+    const databaseFailure = await Effect.runPromise(
+      Effect.flip(readHistoricalEvidence(Effect.fail(databaseCause), 250)),
+    )
+    expect(databaseFailure).toMatchObject({
+      _tag: 'OperationalError',
+      component: 'database',
+      operation: 'read-evidence',
+      message: 'PostgreSQL read-evidence failed: database unavailable',
+      retryable: true,
+    })
+    expect(databaseFailure.cause).toBe(databaseCause)
+    expect(historicalReadFailureDecision(historicalRunId, databaseFailure)).toEqual({
+      response: { _tag: 'Json', status: 503, body: { error: 'evidence_unavailable' } },
+      log: {
+        message: 'Bayn historical evidence read failed',
+        cause: databaseFailure,
+        annotations: {
+          service: 'bayn',
+          runId: historicalRunId,
+          component: 'database',
+          operation: 'read-evidence',
+          retryable: true,
+          error: 'PostgreSQL read-evidence failed: database unavailable',
+        },
+      },
+    })
+
+    const timeout = await Effect.runPromise(
+      Effect.gen(function* () {
+        const started = yield* Deferred.make<void>()
+        const finalizations = yield* Ref.make(0)
+        const read = Deferred.succeed(started, undefined).pipe(
+          Effect.andThen(Effect.never),
+          Effect.ensuring(Ref.update(finalizations, (count) => count + 1)),
+        )
+        const failureFiber = yield* Effect.flip(readHistoricalEvidence(read, 1_000)).pipe(
+          Effect.forkChild({ startImmediately: true }),
+        )
+        yield* Deferred.await(started)
+        yield* TestClock.adjust(1_000)
+        const error = yield* Fiber.join(failureFiber)
+        return { error, finalizations: yield* Ref.get(finalizations) }
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+    expect(timeout).toMatchObject({
+      error: {
+        _tag: 'OperationalError',
+        component: 'database',
+        operation: 'read-evidence',
+        message: 'read-evidence timed out after 1000ms',
+        retryable: true,
+      },
+      finalizations: 1,
+    })
+    expect(timeout.error.cause).toBeUndefined()
+  })
+
+  test('preserves a historical read defect as the identical Die cause', async () => {
+    const sentinel = { _tag: 'HistoricalReadDefect' } as const
+    const exit = await Effect.runPromise(Effect.exit(readHistoricalEvidence(Effect.die(sentinel), 250)))
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) {
+      expect(Cause.hasDies(exit.cause)).toBe(true)
+      expect(Cause.hasFails(exit.cause)).toBe(false)
+      const [reason] = exit.cause.reasons
+      expect(reason?._tag).toBe('Die')
+      if (reason?._tag === 'Die') expect(reason.defect).toBe(sentinel)
+    }
+  })
+})
+
+describe('Bayn HTTP probes', () => {
+  test('serves every route from the current runtime state and closes its socket', async () => {
+    const initial = initialState()
+    let port = 0
+    await withHttpServer({ state: initial }, (server) => {
+      port = server.port
+      const routeCases = [
+        {
+          name: 'liveness',
+          path: '/livez',
+          method: 'GET',
+          expected: {
             status: 200,
             allow: null,
+            cacheControl: null,
+            contentType: 'application/json',
             body: { service: 'bayn', live: true },
-          })
-          expect(yield* Effect.promise(() => fetchJson(port, '/readyz'))).toMatchObject({
+          },
+        },
+        {
+          name: 'readiness',
+          path: '/readyz',
+          method: 'GET',
+          expected: {
             status: 503,
-            body: { ready: false, status: 'STARTING' },
-          })
-
-          yield* Ref.set(state, readyState())
-          expect(yield* Effect.promise(() => fetchJson(port, '/readyz'))).toMatchObject({
+            allow: null,
+            cacheControl: null,
+            contentType: 'application/json',
+            body: readinessResponseDecision(initial).body,
+          },
+        },
+        {
+          name: 'metrics',
+          path: '/metrics',
+          method: 'GET',
+          expected: {
             status: 200,
-            body: { ready: true, status: 'READY' },
-          })
-          const statusResponse = yield* Effect.promise(() => fetchJson(port, '/v1/status'))
-          expect(statusResponse).toMatchObject({
+            allow: null,
+            cacheControl: 'no-store',
+            contentType: 'text/plain; version=0.0.4; charset=utf-8',
+            body: renderPrometheusMetrics(initial, config, provenance, 'embedded'),
+          },
+        },
+        {
+          name: 'status',
+          path: '/v1/status',
+          method: 'GET',
+          expected: {
             status: 200,
-            body: {
-              service: 'bayn',
-              operational: { status: 'READY', ready: true, probeSequence: 1 },
-              cycle: {
-                condition: 'WAITING',
-                reason: 'NO_CYCLE_RECORDED',
-                zeroMutation: true,
-                mutations: { eventCount: 0, unresolvedCount: 0 },
-              },
-              autonomousCycleLoop: {
-                configured: false,
-                startedAt: null,
-                lastPass: null,
-              },
-              authority: { maximum: 'observe', brokerOrders: false, capitalPromotion: false },
-              broker: {
-                configured: false,
-                accountBound: false,
-                readAvailable: false,
-                executionEligible: false,
-                executionDisabledReason: 'ALPACA_NOT_CONFIGURED',
-              },
-              build: { sourceRevision: provenance.sourceRevision, verification: 'embedded' },
-              data: { status: 'CURRENT' },
-              evidence: { status: 'CURRENT' },
-              economic: { verdict: fixtureQualification.evaluationVerdict },
-              qualification: {
-                verdict: 'REJECTED',
-                lockId: fixtureQualification.lockId,
-                resultHash: fixtureQualification.resultHash,
-                executionProvenance: provenance,
-              },
-              accounting: { status: 'EXACT' },
-            },
-          })
-          expect(statusResponse.body.economic).not.toHaveProperty('status')
-          expect(statusResponse.body.qualification).not.toHaveProperty('status')
-          expect(statusResponse.body.qualification).not.toHaveProperty('executable')
-          const metricsResponse = yield* Effect.promise(() => fetch(`http://127.0.0.1:${port}/metrics`))
-          const metrics = yield* Effect.promise(() => metricsResponse.text())
-          expect(metricsResponse.status).toBe(200)
-          expect(metricsResponse.headers.get('content-type')).toContain('text/plain')
-          expect(metrics).toContain('bayn_runtime_ready 1')
-          expect(metrics).toContain('bayn_cycle_condition{condition="waiting"} 1')
-          expect(metrics).toContain('bayn_autonomous_cycle_loop_configured 0')
-          expect(metrics).toContain('bayn_autonomous_cycle_loop_health_available 0')
-          expect(metrics).toContain('bayn_autonomous_cycle_loop_last_pass{result="unknown"} 1')
-          expect(metrics).toContain('bayn_mutation_events_total 0')
-          expect(metrics).toContain('bayn_broker_orders_enabled 0')
-          expect(metrics).toContain('bayn_capital_promotion_enabled 0')
-          expect(yield* Effect.promise(() => fetchJson(port, `/v1/evaluations/${historicalRunId}`))).toMatchObject({
+            allow: null,
+            cacheControl: null,
+            contentType: 'application/json',
+            body: statusFacts(initial, Authority.Observe, provenance, 'embedded'),
+          },
+        },
+        {
+          name: 'historical evidence',
+          path: `/v1/evaluations/${historicalRunId}`,
+          method: 'GET',
+          expected: {
             status: 200,
-            body: { run: { runId: historicalRunId } },
-          })
-          expect(yield* Effect.promise(() => fetchJson(port, '/v1/evaluations/not-a-run'))).toMatchObject({
+            allow: null,
+            cacheControl: null,
+            contentType: 'application/json',
+            body: historicalEvidence,
+          },
+        },
+        {
+          name: 'invalid historical run',
+          path: '/v1/evaluations/not-a-run',
+          method: 'GET',
+          expected: {
             status: 400,
+            allow: null,
+            cacheControl: null,
+            contentType: 'application/json',
             body: { error: 'invalid_run_id' },
-          })
-          expect(yield* Effect.promise(() => fetchJson(port, `/v1/evaluations/${'f'.repeat(64)}`))).toMatchObject({
+          },
+        },
+        {
+          name: 'missing historical run',
+          path: `/v1/evaluations/${'f'.repeat(64)}`,
+          method: 'GET',
+          expected: {
             status: 404,
+            allow: null,
+            cacheControl: null,
+            contentType: 'application/json',
             body: { error: 'evaluation_not_found' },
-          })
-          yield* Ref.set(state, { ...initialState(), status: 'FAILED', error: 'test failure' })
-          expect(yield* Effect.promise(() => fetchJson(port, '/readyz'))).toMatchObject({
-            status: 503,
-            body: { ready: false, status: 'FAILED' },
-          })
-          const failedStatus = yield* Effect.promise(() => fetchJson(port, '/v1/status'))
-          expect(failedStatus).toMatchObject({
-            status: 200,
-            body: {
-              operational: { status: 'FAILED' },
-              cycle: {
-                observationAvailable: false,
-                condition: 'UNKNOWN',
-                zeroMutation: null,
-              },
-              authority: { durable: { available: false } },
-              error: 'test failure',
-            },
-          })
-          const failedBody = failedStatus.body as {
-            readonly authority: { readonly durable: Record<string, unknown> }
-            readonly cycle: Record<string, unknown>
-          }
-          expect(failedBody.cycle).not.toHaveProperty('unfinishedCycleCount')
-          expect(failedBody.cycle).not.toHaveProperty('mutations')
-          expect(failedBody.authority.durable).not.toHaveProperty('configured')
-          expect(yield* Effect.promise(() => fetchJson(port, '/v1/evidence/latest'))).toMatchObject({
+          },
+        },
+        {
+          name: 'unknown route',
+          path: '/v1/evidence/latest',
+          method: 'GET',
+          expected: {
             status: 404,
+            allow: null,
+            cacheControl: null,
+            contentType: 'application/json',
             body: { error: 'not_found' },
-          })
-          expect(yield* Effect.promise(() => fetchJson(port, '/livez', 'POST'))).toEqual({
+          },
+        },
+        {
+          name: 'unsupported method',
+          path: '/livez',
+          method: 'POST',
+          expected: {
             status: 405,
             allow: 'GET',
+            cacheControl: null,
+            contentType: 'application/json',
             body: { error: 'method_not_allowed' },
-          })
-        }),
+          },
+        },
+      ] as const
+      const assertRoutes = Effect.forEach(
+        routeCases,
+        (testCase) =>
+          request(server.port, testCase.path, testCase.method).pipe(
+            Effect.tap((response) => Effect.sync(() => expect(response, testCase.name).toEqual(testCase.expected))),
+          ),
+        { discard: true },
+      )
+      const ready = readyState()
+      const assertCurrentState = Ref.set(server.state, ready).pipe(
+        Effect.andThen(request(server.port, '/readyz')),
+        Effect.tap((response) =>
+          Effect.sync(() =>
+            expect(response).toEqual({
+              status: 200,
+              allow: null,
+              cacheControl: null,
+              contentType: 'application/json',
+              body: readinessResponseDecision(ready).body,
+            }),
+          ),
+        ),
+        Effect.andThen(request(server.port, '/v1/status')),
+        Effect.tap((response) =>
+          Effect.sync(() =>
+            expect(response.body).toEqual(statusFacts(ready, Authority.Observe, provenance, 'embedded')),
+          ),
+        ),
+        Effect.asVoid,
+      )
+      return assertRoutes.pipe(Effect.andThen(assertCurrentState))
+    })
+
+    await Effect.runPromise(Effect.flip(request(port, '/livez')))
+  })
+
+  test('does not convert a historical read defect into an operational 503 response', async () => {
+    const sentinel = { _tag: 'HistoricalRouteDefect' } as const
+
+    await withHttpServer({ readEvidence: () => Effect.die(sentinel) }, ({ port }) =>
+      request(port, `/v1/evaluations/${historicalRunId}`).pipe(
+        Effect.tap((response) =>
+          Effect.sync(() => {
+            expect(response.status).not.toBe(503)
+            expect(response.body).not.toEqual({ error: 'evidence_unavailable' })
+          }),
+        ),
+        Effect.asVoid,
       ),
     )
-
-    let rejected = false
-    try {
-      await fetch(`http://127.0.0.1:${port}/livez`)
-    } catch {
-      rejected = true
-    }
-    expect(rejected).toBe(true)
   })
 
   test('keeps a typed latest loop failure visible and makes readiness and metrics fail closed', async () => {
@@ -214,65 +827,44 @@ describe('Bayn HTTP probes', () => {
       error: 'cycleRunner: market-calendar/calendar-read: authoritative calendar unavailable',
     }
 
-    await Effect.runPromise(
-      Effect.scoped(
-        Effect.gen(function* () {
-          const state = yield* Ref.make(failedState)
-          const context = yield* Layer.build(
-            makeHttpLayer(
-              {
-                cycleStallThresholdMs: config.cycleStallThresholdMs,
-                host: '127.0.0.1',
-                maximumAuthority: Authority.Observe,
-                operationTimeoutMs: 250,
-                port: 0,
-                reconciliationStaleThresholdMs: config.reconciliationStaleThresholdMs,
-                unknownMutationThresholdMs: config.unknownMutationThresholdMs,
+    await withHttpServer({ state: failedState }, ({ port }) =>
+      Effect.all([request(port, '/readyz'), request(port, '/v1/status'), request(port, '/metrics')]).pipe(
+        Effect.tap(([ready, status, metrics]) =>
+          Effect.sync(() => {
+            expect(ready).toMatchObject({
+              status: 503,
+              body: {
+                ready: false,
+                status: 'DEGRADED',
+                failedDependencies: expect.arrayContaining(['cycleRunner']),
               },
-              state,
-              provenance,
-              'embedded',
-              successfulEvidenceStore.read,
-            ),
-          )
-          const address = Context.get(context, HttpServer.HttpServer).address
-          if (address._tag !== 'TcpAddress') throw new Error('test server did not bind a TCP port')
-
-          expect(yield* Effect.promise(() => fetchJson(address.port, '/readyz'))).toMatchObject({
-            status: 503,
-            body: {
-              ready: false,
-              status: 'DEGRADED',
-              failedDependencies: expect.arrayContaining(['cycleRunner']),
-            },
-          })
-          expect(yield* Effect.promise(() => fetchJson(address.port, '/v1/status'))).toMatchObject({
-            status: 200,
-            body: {
-              autonomousCycleLoop: {
-                configured: true,
-                startedAt: failedAt,
-                lastPass: {
-                  result: 'FAILURE',
-                  observedAt: failedAt,
-                  operation: 'market-calendar',
-                  failure: 'calendar-read',
-                  message: 'authoritative calendar unavailable',
+            })
+            expect(status).toMatchObject({
+              status: 200,
+              body: {
+                autonomousCycleLoop: {
+                  configured: true,
+                  startedAt: failedAt,
+                  lastPass: {
+                    result: 'FAILURE',
+                    observedAt: failedAt,
+                    operation: 'market-calendar',
+                    failure: 'calendar-read',
+                    message: 'authoritative calendar unavailable',
+                  },
                 },
               },
-            },
-          })
-          const metrics = yield* Effect.promise(() =>
-            fetch(`http://127.0.0.1:${address.port}/metrics`).then((response) => response.text()),
-          )
-          expect(metrics).toContain('bayn_autonomous_cycle_loop_configured 1')
-          expect(metrics).toContain('bayn_autonomous_cycle_loop_health_available 0')
-          expect(metrics).toContain('bayn_runtime_ready 0')
-          expect(metrics).toContain('bayn_autonomous_cycle_loop_last_pass{result="failure"} 1')
-          expect(metrics).toContain(
-            `bayn_autonomous_cycle_loop_last_pass_timestamp_seconds ${Date.parse(failedAt) / 1_000}`,
-          )
-        }),
+            })
+            expect(metrics.body).toContain('bayn_autonomous_cycle_loop_configured 1')
+            expect(metrics.body).toContain('bayn_autonomous_cycle_loop_health_available 0')
+            expect(metrics.body).toContain('bayn_runtime_ready 0')
+            expect(metrics.body).toContain('bayn_autonomous_cycle_loop_last_pass{result="failure"} 1')
+            expect(metrics.body).toContain(
+              `bayn_autonomous_cycle_loop_last_pass_timestamp_seconds ${Date.parse(failedAt) / 1_000}`,
+            )
+          }),
+        ),
+        Effect.asVoid,
       ),
     )
   })
@@ -410,6 +1002,99 @@ describe('Bayn HTTP probes', () => {
     expect(metrics).toContain('bayn_cycle_terminal_reason{reason="blocked_data_stale"} 0')
   })
 
+  test('propagates interruption and finalizes a historical read exactly once', async () => {
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const started = yield* Deferred.make<void>()
+        const finalizations = yield* Ref.make(0)
+        const read = Deferred.succeed(started, undefined).pipe(
+          Effect.andThen(Effect.never),
+          Effect.ensuring(Ref.update(finalizations, (count) => count + 1)),
+        )
+        const readFiber = yield* readHistoricalEvidence(read, 5_000).pipe(Effect.forkChild({ startImmediately: true }))
+        yield* Deferred.await(started)
+        yield* Fiber.interrupt(readFiber)
+        return yield* Ref.get(finalizations)
+      }),
+    )
+
+    expect(result).toBe(1)
+  })
+
+  test('interrupts and finalizes a historical read when the real client socket disconnects', async () => {
+    const started = await Effect.runPromise(Deferred.make<void>())
+    const finalized = await Effect.runPromise(Deferred.make<void>())
+    const finalizations = await Effect.runPromise(Ref.make(0))
+    const responseChunks: Array<string> = []
+    const read = () =>
+      Deferred.succeed(started, undefined).pipe(
+        Effect.andThen(Effect.never),
+        Effect.ensuring(
+          Ref.update(finalizations, (count) => count + 1).pipe(Effect.andThen(Deferred.succeed(finalized, undefined))),
+        ),
+      )
+
+    await withHttpServer({ readEvidence: read, operationTimeoutMs: 5_000 }, ({ port }) =>
+      withConnectedSocket(port, (socket) => {
+        const onData = (chunk: Buffer) => responseChunks.push(chunk.toString())
+        return Effect.sync(() => {
+          socket.on('data', onData)
+          socket.write(
+            `GET /v1/evaluations/${historicalRunId} HTTP/1.1\r\nHost: 127.0.0.1:${port}\r\nConnection: close\r\n\r\n`,
+          )
+        }).pipe(
+          Effect.andThen(Deferred.await(started)),
+          Effect.andThen(Effect.sync(() => socket.destroy())),
+          Effect.andThen(
+            Deferred.await(finalized).pipe(
+              Effect.timeoutOrElse({
+                duration: 1_000,
+                orElse: () => Effect.die({ _tag: 'ClientDisconnectFinalizerTimeout' } as const),
+              }),
+            ),
+          ),
+          Effect.andThen(Effect.sleep(25)),
+          Effect.andThen(Ref.get(finalizations)),
+          Effect.tap((count) =>
+            Effect.sync(() => {
+              expect(count).toBe(1)
+              expect(responseChunks.join('')).not.toContain('503')
+            }),
+          ),
+          Effect.ensuring(Effect.sync(() => socket.off('data', onData))),
+          Effect.asVoid,
+        )
+      }),
+    )
+  })
+
+  test('interrupts and finalizes a timed-out historical read before rendering the bounded response', async () => {
+    const finalizations = await Effect.runPromise(Ref.make(0))
+    const read = () => Effect.never.pipe(Effect.ensuring(Ref.update(finalizations, (count) => count + 1)))
+
+    await withHttpServer({ readEvidence: read, operationTimeoutMs: 25 }, ({ port }) =>
+      request(port, `/v1/evaluations/${historicalRunId}`).pipe(
+        Effect.flatMap((response) =>
+          Ref.get(finalizations).pipe(
+            Effect.tap((count) =>
+              Effect.sync(() => {
+                expect(response).toEqual({
+                  status: 503,
+                  allow: null,
+                  cacheControl: null,
+                  contentType: 'application/json',
+                  body: { error: 'evidence_unavailable' },
+                })
+                expect(count).toBe(1)
+              }),
+            ),
+          ),
+        ),
+        Effect.asVoid,
+      ),
+    )
+  })
+
   test('returns service unavailable when durable evidence cannot be read', async () => {
     const unavailableStore: EvidenceStoreService = {
       ...successfulEvidenceStore,
@@ -423,74 +1108,36 @@ describe('Bayn HTTP probes', () => {
         ),
     }
 
-    await Effect.runPromise(
-      Effect.scoped(
-        Effect.gen(function* () {
-          const state = yield* Ref.make(initialState())
-          const context = yield* Layer.build(
-            makeHttpLayer(
-              {
-                cycleStallThresholdMs: config.cycleStallThresholdMs,
-                host: '127.0.0.1',
-                maximumAuthority: Authority.Observe,
-                operationTimeoutMs: 250,
-                port: 0,
-                reconciliationStaleThresholdMs: config.reconciliationStaleThresholdMs,
-                unknownMutationThresholdMs: config.unknownMutationThresholdMs,
-              },
-              state,
-              provenance,
-              'embedded',
-              unavailableStore.read,
-            ),
-          )
-          const address = Context.get(context, HttpServer.HttpServer).address
-          if (address._tag !== 'TcpAddress') throw new Error('test server did not bind a TCP port')
-
-          expect(
-            yield* Effect.promise(() => fetchJson(address.port, `/v1/evaluations/${historicalRunId}`)),
-          ).toMatchObject({ status: 503, body: { error: 'evidence_unavailable' } })
-        }),
+    await withHttpServer({ readEvidence: unavailableStore.read }, ({ port }) =>
+      request(port, `/v1/evaluations/${historicalRunId}`).pipe(
+        Effect.tap((response) =>
+          Effect.sync(() => {
+            expect(response).toMatchObject({ status: 503, body: { error: 'evidence_unavailable' } })
+          }),
+        ),
+        Effect.asVoid,
       ),
     )
   })
 
   test('reports the configured ceiling without implying broker capability', async () => {
-    await Effect.runPromise(
-      Effect.scoped(
-        Effect.gen(function* () {
-          const state = yield* Ref.make(initialState())
-          const context = yield* Layer.build(
-            makeHttpLayer(
-              {
-                cycleStallThresholdMs: config.cycleStallThresholdMs,
-                host: '127.0.0.1',
-                maximumAuthority: Authority.Paper,
-                operationTimeoutMs: 250,
-                port: 0,
-                reconciliationStaleThresholdMs: config.reconciliationStaleThresholdMs,
-                unknownMutationThresholdMs: config.unknownMutationThresholdMs,
-              },
-              state,
-              provenance,
-              'embedded',
-              successfulEvidenceStore.read,
-            ),
-          )
-          const address = Context.get(context, HttpServer.HttpServer).address
-          if (address._tag !== 'TcpAddress') throw new Error('test server did not bind a TCP port')
-
-          expect(yield* Effect.promise(() => fetchJson(address.port, '/v1/status'))).toMatchObject({
-            status: 200,
-            body: { authority: { maximum: 'paper', brokerOrders: false, capitalPromotion: false } },
-          })
-        }),
+    await withHttpServer({ maximumAuthority: Authority.Paper }, ({ port }) =>
+      request(port, '/v1/status').pipe(
+        Effect.tap((response) =>
+          Effect.sync(() => {
+            expect(response).toMatchObject({
+              status: 200,
+              body: { authority: { maximum: 'paper', brokerOrders: false, capitalPromotion: false } },
+            })
+          }),
+        ),
+        Effect.asVoid,
       ),
     )
   })
 
   test('keeps broker read capability out of runtime state and public status', async () => {
-    const unused = Effect.die(new Error('status must not invoke broker reads'))
+    const unused = Effect.die('status must not invoke broker reads')
     const read: BrokerReadShape = {
       account: unused,
       accountConfiguration: unused,
@@ -512,43 +1159,24 @@ describe('Bayn HTTP probes', () => {
     expect(runtimeState.broker).not.toHaveProperty('read')
     expect(Object.values(runtimeState.broker ?? {}).some((value) => typeof value === 'function')).toBe(false)
 
-    await Effect.runPromise(
-      Effect.scoped(
-        Effect.gen(function* () {
-          const state = yield* Ref.make(runtimeState)
-          const context = yield* Layer.build(
-            makeHttpLayer(
-              {
-                cycleStallThresholdMs: config.cycleStallThresholdMs,
-                host: '127.0.0.1',
-                maximumAuthority: Authority.Observe,
-                operationTimeoutMs: 250,
-                port: 0,
-                reconciliationStaleThresholdMs: config.reconciliationStaleThresholdMs,
-                unknownMutationThresholdMs: config.unknownMutationThresholdMs,
+    await withHttpServer({ state: runtimeState }, ({ port }) =>
+      request(port, '/v1/status').pipe(
+        Effect.tap((response) =>
+          Effect.sync(() => {
+            expect(response.body).toMatchObject({
+              broker: {
+                configured: true,
+                expectedAccountId: 'paper-account-1',
+                executionEligible: false,
+                executionDisabledReason: 'MAXIMUM_AUTHORITY_OBSERVE',
               },
-              state,
-              provenance,
-              'embedded',
-              successfulEvidenceStore.read,
-            ),
-          )
-          const address = Context.get(context, HttpServer.HttpServer).address
-          if (address._tag !== 'TcpAddress') throw new Error('test server did not bind a TCP port')
-
-          const response = yield* Effect.promise(() => fetchJson(address.port, '/v1/status'))
-          expect(response.body).toMatchObject({
-            broker: {
-              configured: true,
-              expectedAccountId: 'paper-account-1',
-              executionEligible: false,
-              executionDisabledReason: 'MAXIMUM_AUTHORITY_OBSERVE',
-            },
-          })
-          const publicBroker = response.body.broker as Record<string, unknown>
-          expect(publicBroker).not.toHaveProperty('read')
-          expect(Object.values(publicBroker).some((value) => typeof value === 'function')).toBe(false)
-        }),
+            })
+            const body = response.body as { readonly broker: Record<string, unknown> }
+            expect(body.broker).not.toHaveProperty('read')
+            expect(Object.values(body.broker).some((value) => typeof value === 'function')).toBe(false)
+          }),
+        ),
+        Effect.asVoid,
       ),
     )
   })

--- a/services/bayn/src/http.ts
+++ b/services/bayn/src/http.ts
@@ -1,21 +1,65 @@
 import { createServer } from 'node:http'
 
-import { NodeHttpServer } from '@effect/platform-node'
-import { Effect, Layer, Option, Ref } from 'effect'
+import { NodeHttpServer, NodeHttpServerRequest } from '@effect/platform-node'
+import { Deferred, Effect, Layer, Option, Ref } from 'effect'
 import { HttpRouter, HttpServerRequest, HttpServerResponse } from 'effect/unstable/http'
 
 import type { RuntimeBuildMetadata, RuntimeConfig } from './config'
 import type { RuntimeProvenance } from './contracts'
 import { CycleOperationsCondition, CycleOperationsReason } from './cycle-observability'
 import { CycleState, CycleTerminalReason } from './cycle'
+import type { OperationalError } from './errors'
+import { databaseOperation, withinDeadline } from './operations'
 import { Authority } from './paper'
 import { isReady, type DependencyHealth, type RuntimeState } from './runtime-state'
 
 type ReadEvidence = (runId: string) => Effect.Effect<Option.Option<unknown>, { readonly message: string }>
 
+export type HttpResponseDecision =
+  | {
+      readonly _tag: 'Json'
+      readonly body: unknown
+      readonly status: number
+      readonly headers?: Readonly<Record<string, string>>
+    }
+  | {
+      readonly _tag: 'Text'
+      readonly body: string
+      readonly status: number
+      readonly contentType: string
+      readonly headers?: Readonly<Record<string, string>>
+    }
+
+export type HistoricalRunRequestDecision =
+  | { readonly _tag: 'ReadEvidence'; readonly runId: string }
+  | { readonly _tag: 'Respond'; readonly response: HttpResponseDecision }
+
+const jsonDecision = (
+  body: unknown,
+  status = 200,
+  headers?: Readonly<Record<string, string>>,
+): HttpResponseDecision => ({ _tag: 'Json', body, status, ...(headers === undefined ? {} : { headers }) })
+
+const textDecision = (
+  body: string,
+  contentType: string,
+  headers?: Readonly<Record<string, string>>,
+): HttpResponseDecision => ({
+  _tag: 'Text',
+  body,
+  status: 200,
+  contentType,
+  ...(headers === undefined ? {} : { headers }),
+})
+
 const verifiedState = (state: RuntimeState, dependency: DependencyHealth) => {
   if (state.evidence === null || dependency.status === 'UNKNOWN') return 'UNKNOWN'
   return dependency.status === 'AVAILABLE' ? 'CURRENT' : 'INVALID'
+}
+
+const accountingState = (state: RuntimeState) => {
+  if (state.evidence === null || state.health.dependencies.tigerBeetle.status === 'UNKNOWN') return 'UNKNOWN'
+  return state.health.dependencies.tigerBeetle.status === 'AVAILABLE' ? 'EXACT' : 'UNAVAILABLE'
 }
 
 const publicBrokerState = (state: RuntimeState) =>
@@ -49,18 +93,12 @@ const publicCycleState = (state: RuntimeState) =>
         observationAvailable: true,
       }
 
-const publicState = (
+export const statusFacts = (
   state: RuntimeState,
   maximumAuthority: Authority,
   provenance: RuntimeProvenance,
   provenanceVerification: RuntimeBuildMetadata['verification'],
 ) => {
-  let accounting = 'UNKNOWN'
-  if (state.evidence !== null) {
-    if (state.health.dependencies.tigerBeetle.status === 'AVAILABLE') accounting = 'EXACT'
-    if (state.health.dependencies.tigerBeetle.status === 'UNAVAILABLE') accounting = 'UNAVAILABLE'
-  }
-
   return {
     service: 'bayn',
     operational: {
@@ -93,7 +131,7 @@ const publicState = (
       executionProvenance: state.evidence?.provenance ?? null,
     },
     accounting: {
-      status: accounting,
+      status: accountingState(state),
       reconciliation: state.evidence?.reconciliation ?? null,
     },
     cycle: publicCycleState(state),
@@ -134,8 +172,91 @@ const publicState = (
       verification: provenanceVerification,
     },
     error: state.error,
-  }
+  } as const
 }
+
+export const statusResponseDecision = (
+  state: RuntimeState,
+  maximumAuthority: Authority,
+  provenance: RuntimeProvenance,
+  provenanceVerification: RuntimeBuildMetadata['verification'],
+): HttpResponseDecision => jsonDecision(statusFacts(state, maximumAuthority, provenance, provenanceVerification))
+
+const appendFailure = (failures: readonly string[], name: string, failed: boolean): readonly string[] =>
+  failed && !failures.includes(name) ? [...failures, name] : failures
+
+export const readinessResponseDecision = (state: RuntimeState): HttpResponseDecision => {
+  const ready = isReady(state)
+  const dependencyFailures = Object.entries(state.health.dependencies)
+    .filter(([, dependency]) => dependency.status !== 'AVAILABLE')
+    .map(([name]) => name)
+  const brokerFailures = appendFailure(
+    dependencyFailures,
+    'broker',
+    state.broker !== null && (state.broker.accountBound !== true || state.broker.readAvailable !== true),
+  )
+  const cycleFailures = appendFailure(
+    brokerFailures,
+    'cycle',
+    state.cycle.condition === CycleOperationsCondition.Unknown ||
+      state.cycle.condition === CycleOperationsCondition.Stalled ||
+      state.cycle.condition === CycleOperationsCondition.Failed,
+  )
+  const failedDependencies = appendFailure(
+    cycleFailures,
+    'cycleRunner',
+    state.autonomousCycleLoop.lastPass?.result === 'FAILURE',
+  )
+  return jsonDecision(
+    {
+      ready,
+      status: state.status,
+      checkedAt: state.health.checkedAt,
+      probeSequence: state.health.sequence,
+      failedDependencies,
+    },
+    ready ? 200 : 503,
+  )
+}
+
+export const validateHistoricalRunRequest = (runId: string | undefined): HistoricalRunRequestDecision =>
+  runId !== undefined && /^[0-9a-f]{64}$/.test(runId)
+    ? { _tag: 'ReadEvidence', runId }
+    : { _tag: 'Respond', response: jsonDecision({ error: 'invalid_run_id' }, 400) }
+
+export const historicalEvidenceResponseDecision = (stored: Option.Option<unknown>): HttpResponseDecision =>
+  Option.match(stored, {
+    onNone: () => jsonDecision({ error: 'evaluation_not_found' }, 404),
+    onSome: (evidence) => jsonDecision(evidence),
+  })
+
+export const historicalReadFailureDecision = (runId: string, error: OperationalError) =>
+  ({
+    response: jsonDecision({ error: 'evidence_unavailable' }, 503),
+    log: {
+      message: 'Bayn historical evidence read failed',
+      cause: error,
+      annotations: {
+        service: 'bayn',
+        runId,
+        component: error.component,
+        operation: error.operation,
+        retryable: error.retryable,
+        error: error.message,
+      },
+    },
+  }) as const
+
+export const readHistoricalEvidence = <A, R>(
+  read: Effect.Effect<Option.Option<A>, { readonly message: string }, R>,
+  timeoutMs: number,
+): Effect.Effect<Option.Option<A>, OperationalError, R> =>
+  withinDeadline(databaseOperation(read, 'read-evidence'), timeoutMs, 'database', 'read-evidence')
+
+export const fallbackResponseDecision = (method: string): HttpResponseDecision =>
+  method === 'GET'
+    ? jsonDecision({ error: 'not_found' }, 404)
+    : jsonDecision({ error: 'method_not_allowed' }, 405, { allow: 'GET' })
 
 const prometheusLabel = (value: string): string =>
   value.replaceAll('\\', '\\\\').replaceAll('\n', '\\n').replaceAll('"', '\\"')
@@ -338,8 +459,63 @@ export const renderPrometheusMetrics = (
   return `${lines.join('\n')}\n`
 }
 
-const jsonResponse = (body: unknown, status = 200, headers?: Readonly<Record<string, string>>) =>
-  HttpServerResponse.json(body, { status, headers }).pipe(Effect.orDie)
+const interpretResponseDecision = (
+  decision: HttpResponseDecision,
+): Effect.Effect<HttpServerResponse.HttpServerResponse> =>
+  decision._tag === 'Json'
+    ? HttpServerResponse.json(decision.body, {
+        status: decision.status,
+        headers: decision.headers,
+      }).pipe(Effect.orDie)
+    : Effect.succeed(
+        HttpServerResponse.text(decision.body, {
+          status: decision.status,
+          contentType: decision.contentType,
+          headers: decision.headers,
+        }),
+      )
+
+const interpretHistoricalReadFailure = (
+  runId: string,
+  error: OperationalError,
+): Effect.Effect<HttpServerResponse.HttpServerResponse> => {
+  const decision = historicalReadFailureDecision(runId, error)
+  return Effect.logError(decision.log.message, decision.log.cause).pipe(
+    Effect.annotateLogs(decision.log.annotations),
+    Effect.andThen(interpretResponseDecision(decision.response)),
+  )
+}
+
+const clientDisconnect = (request: HttpServerRequest.HttpServerRequest): Effect.Effect<never> => {
+  const incoming = NodeHttpServerRequest.toIncomingMessage(request)
+  const socket = incoming.socket
+  return Effect.scoped(
+    Deferred.make<void>().pipe(
+      Effect.flatMap((disconnected) => {
+        const onDisconnect = () => {
+          Deferred.doneUnsafe(disconnected, Effect.void)
+        }
+        return Effect.acquireRelease(
+          Effect.sync(() => {
+            incoming.once('aborted', onDisconnect)
+            socket.once('close', onDisconnect)
+            if (incoming.aborted || socket.destroyed) onDisconnect()
+          }),
+          () =>
+            Effect.sync(() => {
+              incoming.off('aborted', onDisconnect)
+              socket.off('close', onDisconnect)
+            }),
+        ).pipe(Effect.andThen(Deferred.await(disconnected)), Effect.andThen(Effect.interrupt))
+      }),
+    ),
+  )
+}
+
+const interruptOnClientDisconnect = <A, E, R>(
+  request: HttpServerRequest.HttpServerRequest,
+  effect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> => Effect.raceFirst(effect, clientDisconnect(request)).pipe(Effect.interruptible)
 
 export const makeHttpLayer = (
   config: Pick<
@@ -357,83 +533,45 @@ export const makeHttpLayer = (
   provenanceVerification: RuntimeBuildMetadata['verification'],
   readEvidence: ReadEvidence,
 ): ReturnType<typeof NodeHttpServer.layer> => {
-  const ready = Ref.get(state).pipe(
-    Effect.flatMap((current) => {
-      const ready = isReady(current)
-      const failedDependencies = Object.entries(current.health.dependencies)
-        .filter(([, dependency]) => dependency.status !== 'AVAILABLE')
-        .map(([name]) => name)
-      if (current.broker !== null && (current.broker.accountBound !== true || current.broker.readAvailable !== true)) {
-        failedDependencies.push('broker')
-      }
-      if (
-        current.cycle.condition === CycleOperationsCondition.Unknown ||
-        current.cycle.condition === CycleOperationsCondition.Stalled ||
-        current.cycle.condition === CycleOperationsCondition.Failed
-      ) {
-        if (!failedDependencies.includes('cycle')) failedDependencies.push('cycle')
-      }
-      if (current.autonomousCycleLoop.lastPass?.result === 'FAILURE' && !failedDependencies.includes('cycleRunner')) {
-        failedDependencies.push('cycleRunner')
-      }
-      return jsonResponse(
-        {
-          ready,
-          status: current.status,
-          checkedAt: current.health.checkedAt,
-          probeSequence: current.health.sequence,
-          failedDependencies,
-        },
-        ready ? 200 : 503,
-      )
-    }),
-  )
+  const ready = Ref.get(state).pipe(Effect.map(readinessResponseDecision), Effect.flatMap(interpretResponseDecision))
   const status = Ref.get(state).pipe(
-    Effect.flatMap((current) =>
-      jsonResponse(publicState(current, config.maximumAuthority, provenance, provenanceVerification)),
+    Effect.map((current) =>
+      statusResponseDecision(current, config.maximumAuthority, provenance, provenanceVerification),
     ),
+    Effect.flatMap(interpretResponseDecision),
   )
   const metrics = Ref.get(state).pipe(
     Effect.map((current) =>
-      HttpServerResponse.text(renderPrometheusMetrics(current, config, provenance, provenanceVerification), {
-        contentType: 'text/plain; version=0.0.4; charset=utf-8',
-        headers: { 'cache-control': 'no-store' },
+      textDecision(
+        renderPrometheusMetrics(current, config, provenance, provenanceVerification),
+        'text/plain; version=0.0.4; charset=utf-8',
+        { 'cache-control': 'no-store' },
+      ),
+    ),
+    Effect.flatMap(interpretResponseDecision),
+  )
+  const historicalEvaluation = Effect.flatMap(HttpServerRequest.HttpServerRequest, (request) =>
+    HttpRouter.params.pipe(
+      Effect.map(({ runId }) => validateHistoricalRunRequest(runId)),
+      Effect.flatMap((decision) => {
+        if (decision._tag === 'Respond') return interpretResponseDecision(decision.response)
+        return interruptOnClientDisconnect(
+          request,
+          readHistoricalEvidence(readEvidence(decision.runId), config.operationTimeoutMs),
+        ).pipe(
+          Effect.map(historicalEvidenceResponseDecision),
+          Effect.flatMap(interpretResponseDecision),
+          Effect.catch((error) => interpretHistoricalReadFailure(decision.runId, error)),
+        )
       }),
     ),
-  )
-  const historicalEvaluation = HttpRouter.params.pipe(
-    Effect.flatMap(({ runId }) => {
-      if (runId === undefined || !/^[0-9a-f]{64}$/.test(runId)) {
-        return jsonResponse({ error: 'invalid_run_id' }, 400)
-      }
-      return readEvidence(runId).pipe(
-        Effect.timeoutOrElse({
-          duration: config.operationTimeoutMs,
-          orElse: () => Effect.fail(new Error(`evidence read timed out after ${config.operationTimeoutMs}ms`)),
-        }),
-        Effect.flatMap((stored) =>
-          Option.match(stored, {
-            onNone: () => jsonResponse({ error: 'evaluation_not_found' }, 404),
-            onSome: (evidence) => jsonResponse(evidence),
-          }),
-        ),
-        Effect.catch((error) =>
-          Effect.logError('Bayn historical evidence read failed').pipe(
-            Effect.annotateLogs({ service: 'bayn', runId, error: error.message }),
-            Effect.andThen(jsonResponse({ error: 'evidence_unavailable' }, 503)),
-          ),
-        ),
-      )
-    }),
   )
   const fallback = (
     request: HttpServerRequest.HttpServerRequest,
   ): Effect.Effect<HttpServerResponse.HttpServerResponse> =>
-    request.method === 'GET'
-      ? jsonResponse({ error: 'not_found' }, 404)
-      : jsonResponse({ error: 'method_not_allowed' }, 405, { allow: 'GET' })
+    interpretResponseDecision(fallbackResponseDecision(request.method))
   const routes = HttpRouter.addAll([
-    HttpRouter.route('GET', '/livez', jsonResponse({ service: 'bayn', live: true })),
+    HttpRouter.route('GET', '/livez', interpretResponseDecision(jsonDecision({ service: 'bayn', live: true }))),
     HttpRouter.route('GET', '/readyz', ready),
     HttpRouter.route('GET', '/metrics', metrics),
     HttpRouter.route('GET', '/v1/status', status),


### PR DESCRIPTION
## Summary

- Extract total immutable decisions for historical-run validation, readiness, status, and bounded HTTP responses.
- Render those decisions through small Effect boundaries while preserving every route, status, header, health semantic, and Prometheus metric name and label.
- Map expected database and timeout failures through the existing typed operational boundary while preserving structured causes and propagating defects unchanged.
- Scope historical reads to client lifetime so real socket disconnects interrupt only that request, remove listeners, finalize exactly once, and never render the operational 503.

## Related Issues

- [PROOMPT-435](https://linear.app/proompteng/issue/PROOMPT-435/make-bayn-http-readiness-and-status-rendering-total)

## Testing

- `bun test services/bayn/src/http.test.ts` — 22 passed, 0 failed, 117 assertions.
- `bun run --filter @proompteng/bayn test` — 459 passed, 106 PostgreSQL-gated skips, 0 failed, 2,318 assertions.
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:55435/bayn_test bun test services/bayn/src/db/evidence-store.integration.test.ts` — 53 passed.
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:55435/bayn_test bun test services/bayn/src/db/paper-store.integration.test.ts` — 27 passed.
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:55435/bayn_test bun test services/bayn/src/db/cycle-store.integration.test.ts` — 13 passed.
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- `bun test packages/scripts/src/bayn` — 20 passed, 0 failed, 61 assertions.
- `git diff --check`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; breaking changes are documented above.
- [x] Documentation and release notes are not required; follow-up and acceptance are tracked in PROOMPT-435.