### PR TITLE
refactor(bayn): extract evidence recovery verifier

### DIFF
--- a/services/bayn/src/db/evidence-recovery.test.ts
+++ b/services/bayn/src/db/evidence-recovery.test.ts
@@ -1,0 +1,813 @@
+import assert from 'node:assert/strict'
+
+import { describe, expect, test } from 'bun:test'
+
+import { Result } from 'effect'
+
+import { fixtureEvaluation, provenance } from '../app-test-support'
+import { makeEquitySeriesArtifact, QualificationArtifactManifestSchema } from '../evidence-contracts'
+import { canonicalHashV1 } from '../hash'
+import { buildLedgerPlan } from '../ledger-plan'
+import { summarizeEvaluation } from '../risk-balanced-trend'
+import { fixtureProtocol } from '../test-fixtures'
+import type { EvaluationEvent } from '../types'
+import {
+  completeEvidenceRecovery,
+  evidenceRecoveryContract,
+  prepareEvidenceRecovery,
+  validateStoredEvidence,
+  type EvidenceRecoveryIssue,
+  type StoredEvidenceRows,
+} from './evidence-recovery'
+
+type QualificationArtifactManifest = typeof QualificationArtifactManifestSchema.Type
+type StoredArtifactRow = StoredEvidenceRows['artifacts'][number]
+type StoredSnapshotRow = Parameters<typeof completeEvidenceRecovery>[1]
+
+interface RecoveryFixture {
+  readonly runId: string
+  readonly rows: StoredEvidenceRows
+  readonly snapshot: StoredSnapshotRow
+}
+
+const artifact = (name: string, schemaVersion: string, payload: unknown, itemCount = 0) => ({
+  name,
+  schemaVersion,
+  payload,
+  itemCount,
+  contentHash: canonicalHashV1(payload),
+})
+
+const makeRecoveryFixture = (): RecoveryFixture => {
+  const evaluation = fixtureEvaluation
+  const ledger = buildLedgerPlan(evaluation, 1)
+  const reconciliation = {
+    runId: evaluation.runId,
+    accountCount: ledger.accounts.length,
+    transferCount: ledger.transfers.length,
+    exact: true as const,
+  }
+  const baseArtifacts = [
+    artifact('evaluation-summary', evidenceRecoveryContract.summarySchemaVersion, summarizeEvaluation(evaluation)),
+    artifact('input-manifest', evaluation.inputManifest.schemaVersion, evaluation.inputManifest),
+    artifact('strategy', 'bayn.performance-metrics.v2', evaluation.strategy),
+    artifact('buy-and-hold', 'bayn.performance-metrics.v2', evaluation.buyAndHold),
+    artifact('direct-volatility-timing', 'bayn.performance-metrics.v2', evaluation.directVolTiming),
+    artifact('double-cost-strategy', 'bayn.performance-metrics.v2', evaluation.doubleCostStrategy),
+    artifact(
+      'simulated-orders',
+      'bayn.simulated-orders.v2',
+      {
+        schemaVersion: 'bayn.simulated-orders.v2',
+        executionModel: evaluation.simulation.executionModel,
+        costMultiplierMicros: evaluation.simulation.costMultiplierMicros,
+        items: evaluation.simulation.orders,
+      },
+      evaluation.simulation.orders.length,
+    ),
+    artifact(
+      'cash-changes',
+      'bayn.cash-changes.v2',
+      { schemaVersion: 'bayn.cash-changes.v2', items: evaluation.simulation.cashChanges },
+      evaluation.simulation.cashChanges.length,
+    ),
+    artifact(
+      'daily-position-marks',
+      'bayn.daily-position-marks.v3',
+      { schemaVersion: 'bayn.daily-position-marks.v3', items: evaluation.simulation.dailyMarks },
+      evaluation.simulation.dailyMarks.length,
+    ),
+    artifact(
+      evidenceRecoveryContract.signalDecisionsArtifactName,
+      evidenceRecoveryContract.signalDecisionsSchemaVersion,
+      {
+        schemaVersion: evidenceRecoveryContract.signalDecisionsSchemaVersion,
+        items: evaluation.signalDecisions,
+      },
+      evaluation.signalDecisions.length,
+    ),
+    artifact(
+      'buy-and-hold-series',
+      'bayn.daily-performance-series.v1',
+      {
+        schemaVersion: 'bayn.daily-performance-series.v1',
+        series: 'buy-and-hold',
+        items: evaluation.benchmarkSeries.buyAndHold,
+      },
+      evaluation.benchmarkSeries.buyAndHold.length,
+    ),
+    artifact(
+      'direct-volatility-timing-series',
+      'bayn.daily-performance-series.v1',
+      {
+        schemaVersion: 'bayn.daily-performance-series.v1',
+        series: 'direct-volatility-timing',
+        items: evaluation.benchmarkSeries.directVolTiming,
+      },
+      evaluation.benchmarkSeries.directVolTiming.length,
+    ),
+    artifact(
+      'double-cost-strategy-series',
+      'bayn.daily-performance-series.v1',
+      {
+        schemaVersion: 'bayn.daily-performance-series.v1',
+        series: 'double-cost-strategy',
+        items: evaluation.benchmarkSeries.doubleCostStrategy,
+      },
+      evaluation.benchmarkSeries.doubleCostStrategy.length,
+    ),
+    artifact(
+      'equity-series',
+      'bayn.equity-series.v1',
+      makeEquitySeriesArtifact(evaluation.equitySeries),
+      evaluation.equitySeries.length,
+    ),
+    artifact(
+      'marked-equity-reconciliation',
+      evaluation.markedEquityReconciliation.schemaVersion,
+      evaluation.markedEquityReconciliation,
+    ),
+    artifact('reconciliation', 'bayn.reconciliation.v1', reconciliation),
+  ]
+  const events = evaluation.events.map((event, ordinal) => ({
+    ordinal,
+    event_id: event.id,
+    event_kind: event.kind,
+    content_hash: canonicalHashV1(event),
+    payload: event,
+  }))
+  const gates = evaluation.verdict.gates.map((gate, ordinal) => ({
+    ordinal,
+    gate_name: gate.name,
+    passed: gate.passed,
+    actual: gate.actual,
+    required: gate.required,
+    content_hash: canonicalHashV1(gate),
+  }))
+  const manifest: QualificationArtifactManifest = {
+    schemaVersion: 'bayn.qualification-artifact-manifest.v1',
+    identity: {
+      runId: evaluation.runId,
+      evaluationSchemaVersion: evaluation.schemaVersion,
+      protocolHash: evaluation.protocolHash,
+      sourceRevision: provenance.sourceRevision,
+      image: provenance.image,
+      snapshotId: evaluation.inputManifest.finalizedSnapshot.snapshotId,
+      publicationId: evaluation.inputManifest.finalizedSnapshot.publicationId,
+      inputManifestHash: evaluation.inputManifest.hash,
+      bounds: evaluation.inputManifest.bounds,
+      calendarVersion: evaluation.inputManifest.finalizedSnapshot.calendarVersion,
+    },
+    execution: {
+      parameterSchemaVersion: provenance.strategy.parameterSchemaVersion,
+      parameterHash: provenance.strategy.parameterHash,
+      simulationSchemaVersion: evaluation.simulation.schemaVersion,
+      executionModel: evaluation.simulation.executionModel,
+      costMultiplierMicros: evaluation.simulation.costMultiplierMicros,
+    },
+    artifacts: [...baseArtifacts]
+      .sort((left, right) => left.name.localeCompare(right.name))
+      .map(({ name, schemaVersion, itemCount, contentHash }) => ({
+        name,
+        schemaVersion,
+        itemCount,
+        contentHash,
+      })),
+    events: {
+      count: events.length,
+      contentHash: canonicalHashV1(
+        events.map(({ ordinal, event_id: id, event_kind: kind, content_hash: contentHash }) => ({
+          ordinal,
+          id,
+          kind,
+          contentHash,
+        })),
+      ),
+    },
+    gates: {
+      count: gates.length,
+      contentHash: canonicalHashV1(
+        gates.map(({ ordinal, gate_name: name, passed, content_hash: contentHash }) => ({
+          ordinal,
+          name,
+          passed,
+          contentHash,
+        })),
+      ),
+    },
+  }
+  const allArtifacts = [...baseArtifacts, artifact('qualification-artifact-manifest', manifest.schemaVersion, manifest)]
+    .sort((left, right) => left.name.localeCompare(right.name))
+    .map(
+      ({ name, schemaVersion, contentHash, payload }): StoredArtifactRow => ({
+        artifact_name: name,
+        schema_version: schemaVersion,
+        content_hash: contentHash,
+        payload,
+      }),
+    )
+
+  const snapshot = evaluation.inputManifest.finalizedSnapshot
+  return {
+    runId: evaluation.runId,
+    rows: {
+      receipts: [
+        {
+          run_id: evaluation.runId,
+          protocol_hash: evaluation.protocolHash,
+          snapshot_id: snapshot.snapshotId,
+          evaluation_schema_version: evaluation.schemaVersion,
+          source_revision: provenance.sourceRevision,
+          image_repository: provenance.image.repository,
+          image_digest: provenance.image.digest,
+          strategy_name: provenance.strategy.name,
+          initial_capital_micros: evaluation.initialCapitalMicros,
+          status: 'COMPLETE',
+          expected_artifact_count: allArtifacts.length,
+          expected_event_count: events.length,
+          expected_gate_count: gates.length,
+          artifact_count: allArtifacts.length,
+          event_count: events.length,
+          gate_count: gates.length,
+        },
+      ],
+      protocol: {
+        protocol_hash: evaluation.protocolHash,
+        schema_version: fixtureProtocol.schemaVersion,
+        strategy_name: provenance.strategy.name,
+        behavior_hash: provenance.strategy.behaviorHash,
+        parameter_hash: provenance.strategy.parameterHash,
+        parameters: fixtureProtocol,
+      },
+      artifacts: allArtifacts,
+      events,
+      gates,
+      statuses: [
+        {
+          status: 'WRITING',
+          detail: {
+            artifactCount: allArtifacts.length,
+            eventCount: events.length,
+            gateCount: gates.length,
+          },
+        },
+        {
+          status: 'COMPLETE',
+          detail: { reconciliationExact: true, verdict: evaluation.verdict.status },
+        },
+      ],
+    },
+    snapshot: {
+      snapshot_id: snapshot.snapshotId,
+      schema_version: snapshot.schemaVersion,
+      database_name: evaluation.inputManifest.database,
+      table_name: evaluation.inputManifest.tables.bars,
+      dataset_version: snapshot.publicationSchemaVersion,
+      source: snapshot.source,
+      source_feed: snapshot.sourceFeed,
+      adjustment: snapshot.adjustment,
+      content_hash: snapshot.contentHash,
+      row_count: snapshot.rowCount,
+      first_session: snapshot.firstSession,
+      last_session: snapshot.lastSession,
+      manifest: snapshot,
+    },
+  }
+}
+
+const withArtifactCount = (rows: StoredEvidenceRows, artifacts: readonly StoredArtifactRow[]): StoredEvidenceRows => {
+  const receipt = rows.receipts[0]
+  assert(receipt !== undefined)
+  return {
+    ...rows,
+    receipts: [
+      {
+        ...receipt,
+        expected_artifact_count: artifacts.length,
+        artifact_count: artifacts.length,
+      },
+    ],
+    artifacts,
+    statuses: rows.statuses.map((status) =>
+      status.status === 'WRITING'
+        ? { ...status, detail: { ...status.detail, artifactCount: artifacts.length } }
+        : status,
+    ),
+  }
+}
+
+const replaceArtifact = (
+  fixture: RecoveryFixture,
+  name: string,
+  payload: unknown,
+  refreshManifest: boolean,
+): RecoveryFixture => {
+  let artifacts = fixture.rows.artifacts.map((item) =>
+    item.artifact_name === name ? { ...item, payload, content_hash: canonicalHashV1(payload) } : item,
+  )
+  if (refreshManifest) {
+    const changed = artifacts.find((item) => item.artifact_name === name)
+    const manifestRow = artifacts.find((item) => item.artifact_name === 'qualification-artifact-manifest')
+    assert(changed !== undefined)
+    assert(manifestRow !== undefined)
+    const manifest = structuredClone(manifestRow.payload) as QualificationArtifactManifest
+    const refreshedManifest = {
+      ...manifest,
+      artifacts: manifest.artifacts.map((entry) =>
+        entry.name === name ? { ...entry, contentHash: changed.content_hash } : entry,
+      ),
+    }
+    artifacts = artifacts.map((item) =>
+      item.artifact_name === 'qualification-artifact-manifest'
+        ? {
+            ...item,
+            payload: refreshedManifest,
+            content_hash: canonicalHashV1(refreshedManifest),
+          }
+        : item,
+    )
+  }
+  return { ...fixture, rows: { ...fixture.rows, artifacts } }
+}
+
+const failureOf = <A>(result: Result.Result<A, EvidenceRecoveryIssue>): EvidenceRecoveryIssue => {
+  assert(Result.isFailure(result))
+  return result.failure
+}
+
+const prepare = (fixture: RecoveryFixture) =>
+  prepareEvidenceRecovery({
+    runId: fixture.runId,
+    provenance,
+    rows: fixture.rows,
+  })
+
+const verify = (fixture: RecoveryFixture) =>
+  Result.andThen(prepare(fixture), (prepared) => completeEvidenceRecovery(prepared, fixture.snapshot))
+
+describe('evidence recovery verifier', () => {
+  test('reconstructs byte-identical terminal evidence without mutating decoded rows', () => {
+    const fixture = makeRecoveryFixture()
+    const before = structuredClone(fixture)
+    const result = verify(fixture)
+
+    assert(Result.isSuccess(result))
+    expect(result.success.evaluation).toEqual(summarizeEvaluation(fixtureEvaluation))
+    expect(result.success.reconciliation.runId).toBe(fixtureEvaluation.runId)
+    expect(result.success.persistence).toEqual({
+      runId: fixtureEvaluation.runId,
+      deduplicated: true,
+      artifactCount: 17,
+      eventCount: fixtureEvaluation.events.length,
+      gateCount: fixtureEvaluation.verdict.gates.length,
+    })
+    expect(fixture).toEqual(before)
+  })
+
+  test('returns concrete stored graph issues for receipt, protocol, count, ordinal, hash, and status corruption', () => {
+    const fixture = makeRecoveryFixture()
+    const receipt = fixture.rows.receipts[0]
+    const firstEvent = fixture.rows.events[0]
+    const firstArtifact = fixture.rows.artifacts[0]
+    const writing = fixture.rows.statuses[0]
+    const complete = fixture.rows.statuses[1]
+    assert(receipt !== undefined)
+    assert(firstEvent !== undefined)
+    assert(firstArtifact !== undefined)
+    assert(writing?.status === 'WRITING')
+    assert(complete?.status === 'COMPLETE')
+
+    expect(failureOf(validateStoredEvidence(fixture.runId, { ...fixture.rows, receipts: [receipt, receipt] }))).toEqual(
+      {
+        _tag: 'RecoveryMismatch',
+        stage: 'stored-graph',
+        path: ['runs', fixture.runId, 'receiptCount'],
+        observed: 2,
+        expected: 1,
+      },
+    )
+    expect(
+      failureOf(
+        validateStoredEvidence(fixture.runId, {
+          ...fixture.rows,
+          protocol: { ...fixture.rows.protocol, parameter_hash: 'f'.repeat(64) },
+        }),
+      ),
+    ).toMatchObject({
+      _tag: 'RecoveryMismatch',
+      stage: 'stored-graph',
+      path: ['protocol', 'parameterHash'],
+      observed: 'f'.repeat(64),
+      expected: fixture.rows.protocol.parameter_hash,
+    })
+    expect(
+      failureOf(
+        validateStoredEvidence(fixture.runId, {
+          ...fixture.rows,
+          receipts: [{ ...receipt, expected_event_count: receipt.expected_event_count + 1 }],
+        }),
+      ),
+    ).toEqual({
+      _tag: 'RecoveryMismatch',
+      stage: 'stored-graph',
+      path: ['events', 'count'],
+      observed: { loadedCount: fixture.rows.events.length, receiptCount: receipt.event_count },
+      expected: {
+        loadedCount: receipt.expected_event_count + 1,
+        receiptCount: receipt.expected_event_count + 1,
+      },
+    })
+    expect(
+      failureOf(
+        validateStoredEvidence(fixture.runId, {
+          ...fixture.rows,
+          events: [{ ...firstEvent, ordinal: 1 }, ...fixture.rows.events.slice(1)],
+        }),
+      ),
+    ).toEqual({
+      _tag: 'RecoveryMismatch',
+      stage: 'stored-graph',
+      path: ['events', firstEvent.event_id, 'ordinal'],
+      observed: 1,
+      expected: 0,
+    })
+    expect(
+      failureOf(
+        validateStoredEvidence(fixture.runId, {
+          ...fixture.rows,
+          artifacts: [{ ...firstArtifact, content_hash: 'f'.repeat(64) }, ...fixture.rows.artifacts.slice(1)],
+        }),
+      ),
+    ).toMatchObject({
+      _tag: 'RecoveryMismatch',
+      stage: 'stored-graph',
+      path: ['artifacts', firstArtifact.artifact_name, 'contentHash'],
+      observed: 'f'.repeat(64),
+      expected: canonicalHashV1(firstArtifact.payload),
+    })
+    expect(
+      failureOf(
+        validateStoredEvidence(fixture.runId, {
+          ...fixture.rows,
+          statuses: [
+            {
+              status: 'WRITING',
+              detail: { ...writing.detail, artifactCount: 1 },
+            },
+            complete,
+          ],
+        }),
+      ),
+    ).toEqual({
+      _tag: 'RecoveryMismatch',
+      stage: 'stored-graph',
+      path: ['statuses', 0, 'detail'],
+      observed: { ...writing.detail, artifactCount: 1 },
+      expected: writing.detail,
+    })
+  })
+
+  test('reports missing, extra, duplicate, and wrong-schema artifacts with exact facts', () => {
+    const fixture = makeRecoveryFixture()
+    const strategy = fixture.rows.artifacts.find((item) => item.artifact_name === 'strategy')
+    assert(strategy !== undefined)
+
+    const missingRows = withArtifactCount(
+      fixture.rows,
+      fixture.rows.artifacts.filter((item) => item.artifact_name !== 'strategy'),
+    )
+    expect(failureOf(verify({ ...fixture, rows: missingRows }))).toMatchObject({
+      _tag: 'ArtifactSetFailure',
+      problem: {
+        _tag: 'MissingArtifact',
+        name: 'strategy',
+        expectedSchemaVersion: 'bayn.performance-metrics.v2',
+      },
+    })
+
+    const extra = {
+      artifact_name: 'unexpected',
+      schema_version: 'bayn.unexpected.v1',
+      content_hash: canonicalHashV1({ unexpected: true }),
+      payload: { unexpected: true },
+    }
+    expect(
+      failureOf(verify({ ...fixture, rows: withArtifactCount(fixture.rows, [...fixture.rows.artifacts, extra]) })),
+    ).toMatchObject({
+      _tag: 'ArtifactSetFailure',
+      problem: { _tag: 'ExtraArtifact', name: 'unexpected', observedSchemaVersion: 'bayn.unexpected.v1' },
+    })
+
+    expect(
+      failureOf(
+        verify({
+          ...fixture,
+          rows: withArtifactCount(fixture.rows, [...fixture.rows.artifacts, strategy]),
+        }),
+      ),
+    ).toMatchObject({
+      _tag: 'ArtifactSetFailure',
+      problem: { _tag: 'DuplicateArtifact', name: 'strategy', observedCount: 2, expectedCount: 1 },
+    })
+
+    expect(
+      failureOf(
+        verify({
+          ...fixture,
+          rows: {
+            ...fixture.rows,
+            artifacts: fixture.rows.artifacts.map((item) =>
+              item.artifact_name === 'strategy' ? { ...item, schema_version: 'bayn.performance-metrics.v1' } : item,
+            ),
+          },
+        }),
+      ),
+    ).toMatchObject({
+      _tag: 'ArtifactSetFailure',
+      problem: {
+        _tag: 'WrongArtifactSchema',
+        name: 'strategy',
+        observedSchemaVersion: 'bayn.performance-metrics.v1',
+        expectedSchemaVersion: 'bayn.performance-metrics.v2',
+      },
+    })
+  })
+
+  test('preserves contract, decode, protocol, remaining-decode, and manifest precedence', () => {
+    const fixture = makeRecoveryFixture()
+    const receipt = fixture.rows.receipts[0]
+    assert(receipt !== undefined)
+    const invalidEvaluation = replaceArtifact(fixture, 'evaluation-summary', {}, false)
+    const invalidCash = replaceArtifact(fixture, 'cash-changes', {}, false)
+
+    const contractAndRuntime = {
+      ...fixture,
+      rows: {
+        ...fixture.rows,
+        receipts: [{ ...receipt, strategy_name: 'legacy-strategy', source_revision: 'f'.repeat(40) }],
+        protocol: { ...fixture.rows.protocol, strategy_name: 'legacy-strategy' },
+      },
+    }
+    expect(failureOf(verify(contractAndRuntime))).toMatchObject({
+      _tag: 'RecoveryMismatch',
+      stage: 'contract',
+      path: ['strategyName'],
+      observed: 'legacy-strategy',
+      expected: 'risk-balanced-trend',
+    })
+    expect(
+      failureOf(
+        verify({
+          ...fixture,
+          rows: {
+            ...fixture.rows,
+            receipts: [{ ...receipt, source_revision: 'f'.repeat(40) }],
+          },
+        }),
+      ),
+    ).toMatchObject({
+      _tag: 'RecoveryMismatch',
+      stage: 'runtime',
+      path: ['sourceRevision'],
+      observed: 'f'.repeat(40),
+      expected: provenance.sourceRevision,
+    })
+
+    expect(
+      failureOf(
+        verify({
+          ...invalidEvaluation,
+          rows: {
+            ...invalidEvaluation.rows,
+            protocol: { ...invalidEvaluation.rows.protocol, behavior_hash: 'f'.repeat(64) },
+          },
+        }),
+      ),
+    ).toMatchObject({ _tag: 'DecodeFailure', artifactName: 'evaluation-summary' })
+
+    expect(
+      failureOf(
+        verify({
+          ...invalidCash,
+          rows: {
+            ...invalidCash.rows,
+            protocol: { ...invalidCash.rows.protocol, behavior_hash: 'f'.repeat(64) },
+          },
+        }),
+      ),
+    ).toMatchObject({ _tag: 'RecoveryMismatch', stage: 'protocol', path: ['behaviorHash'] })
+    expect(failureOf(verify(invalidCash))).toMatchObject({
+      _tag: 'DecodeFailure',
+      artifactName: 'cash-changes',
+    })
+
+    const manifestRow = fixture.rows.artifacts.find((item) => item.artifact_name === 'qualification-artifact-manifest')
+    assert(manifestRow !== undefined)
+    const manifest = structuredClone(manifestRow.payload) as QualificationArtifactManifest
+    const invalidManifest = replaceArtifact(
+      fixture,
+      'qualification-artifact-manifest',
+      { ...manifest, events: { ...manifest.events, contentHash: 'f'.repeat(64) } },
+      false,
+    )
+    expect(failureOf(verify(invalidManifest))).toMatchObject({
+      _tag: 'RecoveryMismatch',
+      stage: 'manifest',
+      path: ['qualificationArtifactManifest'],
+    })
+  })
+
+  test('checks snapshot before reconciliation and final components', () => {
+    const fixture = makeRecoveryFixture()
+    const reconciliationRow = fixture.rows.artifacts.find((item) => item.artifact_name === 'reconciliation')
+    assert(reconciliationRow !== undefined)
+    const reconciliation = reconciliationRow.payload as {
+      readonly runId: string
+      readonly accountCount: number
+      readonly transferCount: number
+      readonly exact: true
+    }
+    const changedCount = replaceArtifact(
+      fixture,
+      'reconciliation',
+      { ...reconciliation, accountCount: reconciliation.accountCount + 1 },
+      true,
+    )
+    const corrupted = {
+      ...changedCount,
+      snapshot: { ...fixture.snapshot, first_session: '1999-01-01' },
+    }
+    expect(failureOf(verify(corrupted))).toMatchObject({
+      _tag: 'RecoveryMismatch',
+      stage: 'snapshot',
+      path: ['firstSession'],
+      observed: '1999-01-01',
+      expected: fixture.snapshot.first_session,
+    })
+  })
+
+  test('rejects coherently rehashed reconciliation cardinality corruption', () => {
+    const fixture = makeRecoveryFixture()
+    const reconciliationRow = fixture.rows.artifacts.find((item) => item.artifact_name === 'reconciliation')
+    assert(reconciliationRow !== undefined)
+    const reconciliation = reconciliationRow.payload as {
+      readonly runId: string
+      readonly accountCount: number
+      readonly transferCount: number
+      readonly exact: true
+    }
+
+    const changedAccounts = replaceArtifact(
+      fixture,
+      'reconciliation',
+      { ...reconciliation, accountCount: reconciliation.accountCount + 1 },
+      true,
+    )
+    expect(failureOf(verify(changedAccounts))).toEqual({
+      _tag: 'RecoveryMismatch',
+      stage: 'reconciliation',
+      path: ['accountCount'],
+      observed: reconciliation.accountCount + 1,
+      expected: reconciliation.accountCount,
+    })
+
+    const changedTransfers = replaceArtifact(
+      fixture,
+      'reconciliation',
+      { ...reconciliation, transferCount: reconciliation.transferCount + 1 },
+      true,
+    )
+    expect(failureOf(verify(changedTransfers))).toEqual({
+      _tag: 'RecoveryMismatch',
+      stage: 'reconciliation',
+      path: ['transferCount'],
+      observed: reconciliation.transferCount + 1,
+      expected: reconciliation.transferCount,
+    })
+  })
+
+  test('totalizes ledger-plan construction with the original cause', () => {
+    const fixture = makeRecoveryFixture()
+    const prepared = prepare(fixture)
+    assert(Result.isSuccess(prepared))
+
+    const hostileManifest = new Proxy(prepared.success.decoded.inputManifest, {
+      get: (target, property, receiver) => {
+        if (property === 'symbols') throw new TypeError('ledger-plan symbols are unavailable')
+        return Reflect.get(target, property, receiver)
+      },
+    })
+    const ledgerFailure = completeEvidenceRecovery(
+      {
+        ...prepared.success,
+        decoded: { ...prepared.success.decoded, inputManifest: hostileManifest },
+      },
+      fixture.snapshot,
+    )
+    const issue = failureOf(ledgerFailure)
+    expect(issue).toMatchObject({
+      _tag: 'ComputationFailure',
+      operation: 'build-ledger-plan',
+    })
+    if (issue._tag === 'ComputationFailure') expect(issue.cause).toBeInstanceOf(TypeError)
+  })
+
+  test('retains typed reconciliation issues and reports final component and status drift', () => {
+    const fixture = makeRecoveryFixture()
+    const cashRow = fixture.rows.artifacts.find((item) => item.artifact_name === 'cash-changes')
+    assert(cashRow !== undefined)
+    const cashPayload = structuredClone(cashRow.payload) as {
+      schemaVersion: 'bayn.cash-changes.v2'
+      items: { amountMicros: string }[]
+    }
+    const firstCashChange = cashPayload.items[0]
+    assert(firstCashChange !== undefined)
+    cashPayload.items[0] = {
+      ...firstCashChange,
+      amountMicros: (BigInt(firstCashChange.amountMicros) + 1n).toString(),
+    }
+    const reconciliationFailure = failureOf(verify(replaceArtifact(fixture, 'cash-changes', cashPayload, true)))
+    expect(reconciliationFailure).toMatchObject({
+      _tag: 'SimulationFailure',
+      issues: [{ _tag: 'EvidenceMismatch', problem: { _tag: 'CashChange' } }],
+    })
+    if (reconciliationFailure._tag === 'SimulationFailure') {
+      expect(Object.isFrozen(reconciliationFailure.issues)).toBe(true)
+    }
+
+    const strategyRow = fixture.rows.artifacts.find((item) => item.artifact_name === 'strategy')
+    assert(strategyRow !== undefined)
+    const strategyPayload = structuredClone(strategyRow.payload) as { endingEquityMicros: string }
+    const componentFailure = failureOf(
+      verify(
+        replaceArtifact(
+          fixture,
+          'strategy',
+          {
+            ...strategyPayload,
+            endingEquityMicros: (BigInt(strategyPayload.endingEquityMicros) + 1n).toString(),
+          },
+          true,
+        ),
+      ),
+    )
+    expect(componentFailure).toMatchObject({
+      _tag: 'RecoveryMismatch',
+      stage: 'components',
+      path: ['artifacts', 'strategy', 'contentHash'],
+    })
+
+    const writing = fixture.rows.statuses[0]
+    const complete = fixture.rows.statuses[1]
+    assert(writing?.status === 'WRITING')
+    assert(complete?.status === 'COMPLETE')
+    const statusFailure = failureOf(
+      verify({
+        ...fixture,
+        rows: {
+          ...fixture.rows,
+          statuses: [
+            writing,
+            {
+              ...complete,
+              detail: {
+                ...complete.detail,
+                verdict: complete.detail.verdict === 'PASS' ? ('FAIL_CLOSED' as const) : ('PASS' as const),
+              },
+            },
+          ],
+        },
+      }),
+    )
+    expect(statusFailure).toMatchObject({
+      _tag: 'RecoveryMismatch',
+      stage: 'status',
+      path: ['complete', 'verdict'],
+    })
+  })
+
+  test('totalizes hostile canonicalization with the original cause and operation identity', () => {
+    const fixture = makeRecoveryFixture()
+    const firstEvent = fixture.rows.events[0]
+    assert(firstEvent?.payload.kind === 'decision')
+    const hostileEvent: EvaluationEvent = {
+      ...firstEvent.payload,
+      targetWeights: { ...firstEvent.payload.targetWeights, ['\ud800']: 0 },
+    }
+    const failure = failureOf(
+      verify({
+        ...fixture,
+        rows: {
+          ...fixture.rows,
+          events: [{ ...firstEvent, payload: hostileEvent }, ...fixture.rows.events.slice(1)],
+        },
+      }),
+    )
+    expect(failure).toMatchObject({
+      _tag: 'CanonicalizationFailure',
+      operation: 'stored-event-payload',
+      subject: firstEvent.event_id,
+    })
+    if (failure._tag === 'CanonicalizationFailure') expect(failure.cause).toBeInstanceOf(TypeError)
+  })
+})

--- a/services/bayn/src/db/evidence-recovery.ts
+++ b/services/bayn/src/db/evidence-recovery.ts
@@ -1,0 +1,1492 @@
+import { Result, Schema } from 'effect'
+
+import { type FinalizedSnapshotProvenance, makeStrategyProtocolHash, type RuntimeProvenance } from '../contracts'
+import {
+  CashChangesArtifactSchema,
+  DailyPerformanceSeriesArtifactSchema,
+  DailyPositionMarksArtifactSchema,
+  EquitySeriesArtifactSchema,
+  EvaluationEventsSchema,
+  EvaluationSummarySchema,
+  InputManifestArtifactSchema,
+  MarkedEquityReconciliationSchema,
+  QualificationArtifactManifestSchema,
+  ReconciliationResultSchema,
+  RiskBalancedTrendSignalDecisionsArtifactSchema,
+  SimulatedOrdersArtifactSchema,
+} from '../evidence-contracts'
+import { canonicalHashV1 } from '../hash'
+import { buildLedgerPlan } from '../ledger-plan'
+import { strictParseOptions } from '../schemas'
+import {
+  reconcileMarkedEquity,
+  type MarkedEquityProof,
+  type SimulationReconciliationIssue,
+} from '../simulation-reconciliation'
+import type {
+  EconomicVerdict,
+  EvaluationEvent,
+  EvaluationSummary,
+  InputManifest,
+  Protocol,
+  ReconciliationResult,
+} from '../types'
+
+export const evidenceRecoveryContract = {
+  strategyName: 'risk-balanced-trend',
+  evaluationSchemaVersion: 'bayn.evaluation.v6',
+  summarySchemaVersion: 'bayn.evaluation-summary.v5',
+  inputManifestSchemaVersion: 'bayn.input-manifest.v3',
+  signalDecisionsArtifactName: 'risk-balanced-trend-decisions',
+  signalDecisionsSchemaVersion: 'bayn.risk-balanced-trend-decisions.v1',
+  artifacts: [
+    { name: 'buy-and-hold', schemaVersion: 'bayn.performance-metrics.v2' },
+    { name: 'buy-and-hold-series', schemaVersion: 'bayn.daily-performance-series.v1' },
+    { name: 'cash-changes', schemaVersion: 'bayn.cash-changes.v2' },
+    { name: 'daily-position-marks', schemaVersion: 'bayn.daily-position-marks.v3' },
+    { name: 'direct-volatility-timing', schemaVersion: 'bayn.performance-metrics.v2' },
+    { name: 'direct-volatility-timing-series', schemaVersion: 'bayn.daily-performance-series.v1' },
+    { name: 'double-cost-strategy', schemaVersion: 'bayn.performance-metrics.v2' },
+    { name: 'double-cost-strategy-series', schemaVersion: 'bayn.daily-performance-series.v1' },
+    { name: 'equity-series', schemaVersion: 'bayn.equity-series.v1' },
+    { name: 'evaluation-summary', schemaVersion: 'bayn.evaluation-summary.v5' },
+    { name: 'input-manifest', schemaVersion: 'bayn.input-manifest.v3' },
+    { name: 'marked-equity-reconciliation', schemaVersion: 'bayn.marked-equity-reconciliation.v2' },
+    { name: 'qualification-artifact-manifest', schemaVersion: 'bayn.qualification-artifact-manifest.v1' },
+    { name: 'reconciliation', schemaVersion: 'bayn.reconciliation.v1' },
+    { name: 'risk-balanced-trend-decisions', schemaVersion: 'bayn.risk-balanced-trend-decisions.v1' },
+    { name: 'simulated-orders', schemaVersion: 'bayn.simulated-orders.v2' },
+    { name: 'strategy', schemaVersion: 'bayn.performance-metrics.v2' },
+  ],
+} as const
+
+// Ledger identity changes record metadata, not the plan cardinality recovered here.
+const cardinalityOnlyLedger = 1
+
+export interface PersistenceReceipt {
+  readonly runId: string
+  readonly deduplicated: boolean
+  readonly artifactCount: number
+  readonly eventCount: number
+  readonly gateCount: number
+}
+
+export interface StoredEvaluationEvidence {
+  readonly protocol: {
+    readonly protocolHash: string
+    readonly schemaVersion: string
+    readonly strategyName: string
+    readonly behaviorHash: string
+    readonly parameterHash: string
+    readonly parameters: Protocol
+  }
+  readonly run: {
+    readonly runId: string
+    readonly protocolHash: string
+    readonly snapshotId: string
+    readonly evaluationSchemaVersion: string
+    readonly sourceRevision: string
+    readonly imageRepository: string
+    readonly imageDigest: string
+    readonly strategyName: string
+    readonly initialCapitalMicros: string
+    readonly artifactCount: number
+    readonly eventCount: number
+    readonly gateCount: number
+  }
+  readonly artifacts: readonly StoredArtifact[]
+  readonly events: readonly StoredEvent[]
+  readonly gates: readonly StoredGate[]
+  readonly statuses: readonly StoredStatus[]
+}
+
+export interface RecoveredEvaluationEvidence {
+  readonly evaluation: EvaluationSummary
+  readonly reconciliation: ReconciliationResult
+  readonly persistence: PersistenceReceipt
+}
+
+interface StoredReceiptRow {
+  readonly run_id: string
+  readonly protocol_hash: string
+  readonly snapshot_id: string
+  readonly evaluation_schema_version: string
+  readonly source_revision: string
+  readonly image_repository: string
+  readonly image_digest: string
+  readonly strategy_name: string
+  readonly initial_capital_micros: string
+  readonly status: 'COMPLETE'
+  readonly expected_artifact_count: number
+  readonly expected_event_count: number
+  readonly expected_gate_count: number
+  readonly artifact_count: number
+  readonly event_count: number
+  readonly gate_count: number
+}
+
+interface StoredProtocolRow {
+  readonly protocol_hash: string
+  readonly schema_version: string
+  readonly strategy_name: string
+  readonly behavior_hash: string
+  readonly parameter_hash: string
+  readonly parameters: Protocol
+}
+
+interface StoredArtifactRow {
+  readonly artifact_name: string
+  readonly schema_version: string
+  readonly content_hash: string
+  readonly payload: unknown
+}
+
+interface StoredEventRow {
+  readonly ordinal: number
+  readonly event_id: string
+  readonly event_kind: EvaluationEvent['kind']
+  readonly content_hash: string
+  readonly payload: EvaluationEvent
+}
+
+interface StoredGateRow {
+  readonly ordinal: number
+  readonly gate_name: string
+  readonly passed: boolean
+  readonly actual: EconomicVerdict['gates'][number]['actual']
+  readonly required: EconomicVerdict['gates'][number]['required']
+  readonly content_hash: string
+}
+
+type StoredStatus =
+  | {
+      readonly status: 'WRITING'
+      readonly detail: { readonly artifactCount: number; readonly eventCount: number; readonly gateCount: number }
+    }
+  | {
+      readonly status: 'COMPLETE'
+      readonly detail: { readonly reconciliationExact: true; readonly verdict: 'PASS' | 'FAIL_CLOSED' }
+    }
+
+export interface StoredEvidenceRows {
+  readonly receipts: readonly StoredReceiptRow[]
+  readonly protocol: StoredProtocolRow
+  readonly artifacts: readonly StoredArtifactRow[]
+  readonly events: readonly StoredEventRow[]
+  readonly gates: readonly StoredGateRow[]
+  readonly statuses: readonly StoredStatus[]
+}
+
+interface StoredSnapshotRow {
+  readonly snapshot_id: string
+  readonly schema_version: 'bayn.finalized-snapshot.v3'
+  readonly database_name: 'signal'
+  readonly table_name: 'adjusted_daily_bars_v2'
+  readonly dataset_version: 'signal.adjusted-daily-snapshot.v2'
+  readonly source: 'alpaca'
+  readonly source_feed: 'sip'
+  readonly adjustment: 'all'
+  readonly content_hash: string
+  readonly row_count: number
+  readonly first_session: string
+  readonly last_session: string
+  readonly manifest: FinalizedSnapshotProvenance
+}
+
+interface StoredArtifact {
+  readonly name: string
+  readonly schemaVersion: string
+  readonly contentHash: string
+  readonly payload: unknown
+}
+
+interface StoredEvent {
+  readonly ordinal: number
+  readonly id: string
+  readonly kind: EvaluationEvent['kind']
+  readonly contentHash: string
+  readonly payload: EvaluationEvent
+}
+
+interface StoredGate {
+  readonly ordinal: number
+  readonly name: string
+  readonly passed: boolean
+  readonly actual: EconomicVerdict['gates'][number]['actual']
+  readonly required: EconomicVerdict['gates'][number]['required']
+  readonly contentHash: string
+}
+
+type ArtifactSetProblem =
+  | {
+      readonly _tag: 'DuplicateArtifact'
+      readonly name: string
+      readonly observedCount: number
+      readonly expectedCount: 1
+    }
+  | { readonly _tag: 'MissingArtifact'; readonly name: string; readonly expectedSchemaVersion: string }
+  | { readonly _tag: 'ExtraArtifact'; readonly name: string; readonly observedSchemaVersion: string }
+  | {
+      readonly _tag: 'WrongArtifactSchema'
+      readonly name: string
+      readonly observedSchemaVersion: string
+      readonly expectedSchemaVersion: string
+    }
+
+type RecoveryCanonicalizationOperation =
+  | 'artifact-manifest-expected'
+  | 'artifact-manifest-observed'
+  | 'evaluation-bounds'
+  | 'evaluation-input-symbols'
+  | 'evaluation-marked-equity'
+  | 'evaluation-metric'
+  | 'gate-outcome'
+  | 'marked-equity-proof'
+  | 'protocol-execution-model'
+  | 'protocol-parameters'
+  | 'recovered-equity-series'
+  | 'runtime-protocol-hash'
+  | 'signal-target-weights'
+  | 'snapshot-manifest'
+  | 'stored-artifact-payload'
+  | 'stored-event-payload'
+  | 'stored-gate-payload'
+  | 'stored-protocol-parameters'
+  | 'stored-writing-status'
+
+type RecoveryMismatchStage =
+  | 'components'
+  | 'contract'
+  | 'manifest'
+  | 'protocol'
+  | 'reconciliation'
+  | 'runtime'
+  | 'snapshot'
+  | 'status'
+  | 'stored-graph'
+
+type RecoveryPath = readonly [string, ...(number | string)[]]
+
+export type EvidenceRecoveryIssue =
+  | {
+      readonly _tag: 'RecoveryMismatch'
+      readonly stage: RecoveryMismatchStage
+      readonly path: RecoveryPath
+      readonly observed: unknown
+      readonly expected: unknown
+    }
+  | { readonly _tag: 'ArtifactSetFailure'; readonly problem: ArtifactSetProblem }
+  | {
+      readonly _tag: 'DecodeFailure'
+      readonly artifactName: string
+      readonly schemaVersion: string
+      readonly cause: unknown
+    }
+  | {
+      readonly _tag: 'CanonicalizationFailure'
+      readonly operation: RecoveryCanonicalizationOperation
+      readonly subject?: string
+      readonly cause: unknown
+    }
+  | {
+      readonly _tag: 'SimulationFailure'
+      readonly issues: readonly SimulationReconciliationIssue[]
+    }
+  | {
+      readonly _tag: 'ComputationFailure'
+      readonly operation: 'build-ledger-plan'
+      readonly cause: unknown
+    }
+
+interface ValidatedStoredGraph {
+  readonly receipt: StoredReceiptRow
+  readonly rows: StoredEvidenceRows
+}
+
+type ArtifactIndex = ReadonlyMap<string, StoredArtifact>
+
+interface InitialDecodedArtifacts {
+  readonly evaluation: typeof EvaluationSummarySchema.Type
+  readonly reconciliation: typeof ReconciliationResultSchema.Type
+  readonly markedEquity: typeof MarkedEquityReconciliationSchema.Type
+  readonly equitySeries: typeof EquitySeriesArtifactSchema.Type
+  readonly events: typeof EvaluationEventsSchema.Type
+  readonly orders: typeof SimulatedOrdersArtifactSchema.Type
+  readonly signalDecisions: typeof RiskBalancedTrendSignalDecisionsArtifactSchema.Type
+  readonly buyAndHoldSeries: typeof DailyPerformanceSeriesArtifactSchema.Type
+  readonly directVolatilitySeries: typeof DailyPerformanceSeriesArtifactSchema.Type
+  readonly doubleCostSeries: typeof DailyPerformanceSeriesArtifactSchema.Type
+  readonly artifactManifest: typeof QualificationArtifactManifestSchema.Type
+}
+
+interface RemainingDecodedArtifacts {
+  readonly cashChanges: typeof CashChangesArtifactSchema.Type
+  readonly dailyMarks: typeof DailyPositionMarksArtifactSchema.Type
+  readonly inputManifest: typeof InputManifestArtifactSchema.Type
+}
+
+interface PreparedEvidenceRecovery {
+  readonly runId: string
+  readonly provenance: RuntimeProvenance
+  readonly stored: StoredEvaluationEvidence
+  readonly artifacts: ArtifactIndex
+  readonly decoded: InitialDecodedArtifacts & RemainingDecodedArtifacts
+}
+
+const decodeEvaluationSummary = Schema.decodeUnknownResult(EvaluationSummarySchema, strictParseOptions)
+const decodeReconciliationResult = Schema.decodeUnknownResult(ReconciliationResultSchema, strictParseOptions)
+const decodeMarkedEquityReconciliation = Schema.decodeUnknownResult(
+  MarkedEquityReconciliationSchema,
+  strictParseOptions,
+)
+const decodeEquitySeriesArtifact = Schema.decodeUnknownResult(EquitySeriesArtifactSchema, strictParseOptions)
+const decodeEvaluationEvents = Schema.decodeUnknownResult(EvaluationEventsSchema, strictParseOptions)
+const decodeSimulatedOrdersArtifact = Schema.decodeUnknownResult(SimulatedOrdersArtifactSchema, strictParseOptions)
+const decodeSignalDecisionsArtifact = Schema.decodeUnknownResult(
+  RiskBalancedTrendSignalDecisionsArtifactSchema,
+  strictParseOptions,
+)
+const decodeDailyPerformanceSeriesArtifact = Schema.decodeUnknownResult(
+  DailyPerformanceSeriesArtifactSchema,
+  strictParseOptions,
+)
+const decodeQualificationArtifactManifest = Schema.decodeUnknownResult(
+  QualificationArtifactManifestSchema,
+  strictParseOptions,
+)
+const decodeCashChangesArtifact = Schema.decodeUnknownResult(CashChangesArtifactSchema, strictParseOptions)
+const decodeDailyPositionMarksArtifact = Schema.decodeUnknownResult(
+  DailyPositionMarksArtifactSchema,
+  strictParseOptions,
+)
+const decodeInputManifestArtifact = Schema.decodeUnknownResult(InputManifestArtifactSchema, strictParseOptions)
+
+const recoveryFailure = (issue: EvidenceRecoveryIssue): Result.Result<never, EvidenceRecoveryIssue> =>
+  Result.fail(issue)
+
+const mismatch = (
+  stage: RecoveryMismatchStage,
+  path: RecoveryPath,
+  observed: unknown,
+  expected: unknown,
+): Result.Result<never, EvidenceRecoveryIssue> =>
+  recoveryFailure({ _tag: 'RecoveryMismatch', stage, path, observed, expected })
+
+const canonicalize = <A>(
+  operation: RecoveryCanonicalizationOperation,
+  compute: () => A,
+  subject?: string,
+): Result.Result<A, EvidenceRecoveryIssue> =>
+  Result.try({
+    try: compute,
+    catch: (cause): EvidenceRecoveryIssue => ({
+      _tag: 'CanonicalizationFailure',
+      operation,
+      ...(subject === undefined ? {} : { subject }),
+      cause,
+    }),
+  })
+
+const canonicalHash = (
+  operation: RecoveryCanonicalizationOperation,
+  value: unknown,
+  subject?: string,
+): Result.Result<string, EvidenceRecoveryIssue> => canonicalize(operation, () => canonicalHashV1(value), subject)
+
+const validateStoredReceipt = (
+  runId: string,
+  receipts: readonly StoredReceiptRow[],
+): Result.Result<StoredReceiptRow, EvidenceRecoveryIssue> => {
+  if (receipts.length !== 1) {
+    return mismatch('stored-graph', ['runs', runId, 'receiptCount'], receipts.length, 1)
+  }
+  const receipt = receipts[0]
+  if (receipt === undefined) return mismatch('stored-graph', ['runs', runId, 'receiptCount'], 0, 1)
+  return Result.succeed(receipt)
+}
+
+const validateStoredProtocol = (
+  rows: StoredEvidenceRows,
+  receipt: StoredReceiptRow,
+): Result.Result<void, EvidenceRecoveryIssue> =>
+  Result.gen(function* () {
+    if (rows.protocol.protocol_hash !== receipt.protocol_hash) {
+      return yield* mismatch(
+        'stored-graph',
+        ['protocol', 'protocolHash'],
+        rows.protocol.protocol_hash,
+        receipt.protocol_hash,
+      )
+    }
+    if (rows.protocol.strategy_name !== receipt.strategy_name) {
+      return yield* mismatch(
+        'stored-graph',
+        ['protocol', 'strategyName'],
+        rows.protocol.strategy_name,
+        receipt.strategy_name,
+      )
+    }
+    const parameterHash = yield* canonicalHash(
+      'stored-protocol-parameters',
+      rows.protocol.parameters,
+      rows.protocol.protocol_hash,
+    )
+    if (rows.protocol.parameter_hash !== parameterHash) {
+      return yield* mismatch('stored-graph', ['protocol', 'parameterHash'], rows.protocol.parameter_hash, parameterHash)
+    }
+  })
+
+const validateStoredCounts = (
+  rows: StoredEvidenceRows,
+  receipt: StoredReceiptRow,
+): Result.Result<void, EvidenceRecoveryIssue> => {
+  const collections = [
+    ['artifacts', rows.artifacts.length, receipt.artifact_count, receipt.expected_artifact_count],
+    ['events', rows.events.length, receipt.event_count, receipt.expected_event_count],
+    ['gates', rows.gates.length, receipt.gate_count, receipt.expected_gate_count],
+  ] as const
+  for (const [name, loaded, recorded, expected] of collections) {
+    if (loaded !== expected || loaded !== recorded) {
+      return mismatch(
+        'stored-graph',
+        [name, 'count'],
+        { loadedCount: loaded, receiptCount: recorded },
+        { loadedCount: expected, receiptCount: expected },
+      )
+    }
+  }
+  return Result.void
+}
+
+const validateStoredArtifacts = (rows: StoredEvidenceRows): Result.Result<void, EvidenceRecoveryIssue> =>
+  Result.gen(function* () {
+    for (const artifact of rows.artifacts) {
+      const expectedHash = yield* canonicalHash('stored-artifact-payload', artifact.payload, artifact.artifact_name)
+      if (artifact.content_hash !== expectedHash) {
+        return yield* mismatch(
+          'stored-graph',
+          ['artifacts', artifact.artifact_name, 'contentHash'],
+          artifact.content_hash,
+          expectedHash,
+        )
+      }
+    }
+  })
+
+const validateStoredEvents = (rows: StoredEvidenceRows): Result.Result<void, EvidenceRecoveryIssue> =>
+  Result.gen(function* () {
+    for (const [index, event] of rows.events.entries()) {
+      if (event.ordinal !== index) {
+        return yield* mismatch('stored-graph', ['events', event.event_id, 'ordinal'], event.ordinal, index)
+      }
+      const expectedHash = yield* canonicalHash('stored-event-payload', event.payload, event.event_id)
+      if (event.content_hash !== expectedHash) {
+        return yield* mismatch(
+          'stored-graph',
+          ['events', event.event_id, 'contentHash'],
+          event.content_hash,
+          expectedHash,
+        )
+      }
+    }
+  })
+
+const validateStoredGates = (rows: StoredEvidenceRows): Result.Result<void, EvidenceRecoveryIssue> =>
+  Result.gen(function* () {
+    for (const [index, gate] of rows.gates.entries()) {
+      if (gate.ordinal !== index) {
+        return yield* mismatch('stored-graph', ['gates', gate.gate_name, 'ordinal'], gate.ordinal, index)
+      }
+      const expectedHash = yield* canonicalHash(
+        'stored-gate-payload',
+        { name: gate.gate_name, passed: gate.passed, actual: gate.actual, required: gate.required },
+        gate.gate_name,
+      )
+      if (gate.content_hash !== expectedHash) {
+        return yield* mismatch(
+          'stored-graph',
+          ['gates', gate.gate_name, 'contentHash'],
+          gate.content_hash,
+          expectedHash,
+        )
+      }
+    }
+  })
+
+const validateStoredStatuses = (
+  runId: string,
+  rows: StoredEvidenceRows,
+  receipt: StoredReceiptRow,
+): Result.Result<void, EvidenceRecoveryIssue> =>
+  Result.gen(function* () {
+    if (rows.statuses.length !== 2) {
+      return yield* mismatch('stored-graph', ['statuses', 'count'], rows.statuses.length, 2)
+    }
+    const writing = rows.statuses[0]
+    const complete = rows.statuses[1]
+    if (writing?.status !== 'WRITING') {
+      return yield* mismatch('stored-graph', ['statuses', 0, 'status'], writing?.status, 'WRITING')
+    }
+    const expectedDetail = {
+      artifactCount: receipt.artifact_count,
+      eventCount: receipt.event_count,
+      gateCount: receipt.gate_count,
+    }
+    const writingHash = yield* canonicalHash('stored-writing-status', writing.detail, runId)
+    const expectedHash = yield* canonicalHash('stored-writing-status', expectedDetail, runId)
+    if (writingHash !== expectedHash) {
+      return yield* mismatch('stored-graph', ['statuses', 0, 'detail'], writing.detail, expectedDetail)
+    }
+    if (complete?.status !== 'COMPLETE') {
+      return yield* mismatch('stored-graph', ['statuses', 1, 'status'], complete?.status, 'COMPLETE')
+    }
+  })
+
+const validateStoredGraph = (
+  runId: string,
+  rows: StoredEvidenceRows,
+): Result.Result<ValidatedStoredGraph, EvidenceRecoveryIssue> =>
+  Result.gen(function* () {
+    const receipt = yield* validateStoredReceipt(runId, rows.receipts)
+    yield* validateStoredProtocol(rows, receipt)
+    yield* validateStoredCounts(rows, receipt)
+    yield* validateStoredArtifacts(rows)
+    yield* validateStoredEvents(rows)
+    yield* validateStoredGates(rows)
+    yield* validateStoredStatuses(runId, rows, receipt)
+    return { receipt, rows }
+  })
+
+const toStoredEvidence = (graph: ValidatedStoredGraph): StoredEvaluationEvidence => {
+  const { receipt, rows } = graph
+  return {
+    protocol: {
+      protocolHash: rows.protocol.protocol_hash,
+      schemaVersion: rows.protocol.schema_version,
+      strategyName: rows.protocol.strategy_name,
+      behaviorHash: rows.protocol.behavior_hash,
+      parameterHash: rows.protocol.parameter_hash,
+      parameters: rows.protocol.parameters,
+    },
+    run: {
+      runId: receipt.run_id,
+      protocolHash: receipt.protocol_hash,
+      snapshotId: receipt.snapshot_id,
+      evaluationSchemaVersion: receipt.evaluation_schema_version,
+      sourceRevision: receipt.source_revision,
+      imageRepository: receipt.image_repository,
+      imageDigest: receipt.image_digest,
+      strategyName: receipt.strategy_name,
+      initialCapitalMicros: receipt.initial_capital_micros,
+      artifactCount: receipt.artifact_count,
+      eventCount: receipt.event_count,
+      gateCount: receipt.gate_count,
+    },
+    artifacts: rows.artifacts.map((artifact) => ({
+      name: artifact.artifact_name,
+      schemaVersion: artifact.schema_version,
+      contentHash: artifact.content_hash,
+      payload: artifact.payload,
+    })),
+    events: rows.events.map((event) => ({
+      ordinal: event.ordinal,
+      id: event.event_id,
+      kind: event.event_kind,
+      contentHash: event.content_hash,
+      payload: event.payload,
+    })),
+    gates: rows.gates.map((gate) => ({
+      ordinal: gate.ordinal,
+      name: gate.gate_name,
+      passed: gate.passed,
+      actual: gate.actual,
+      required: gate.required,
+      contentHash: gate.content_hash,
+    })),
+    statuses: rows.statuses,
+  }
+}
+
+export const validateStoredEvidence = (
+  runId: string,
+  rows: StoredEvidenceRows,
+): Result.Result<StoredEvaluationEvidence, EvidenceRecoveryIssue> =>
+  Result.andThen(validateStoredGraph(runId, rows), toStoredEvidence)
+
+const validateEvidenceContract = (stored: StoredEvaluationEvidence): Result.Result<void, EvidenceRecoveryIssue> => {
+  if (stored.run.strategyName !== evidenceRecoveryContract.strategyName) {
+    return mismatch('contract', ['strategyName'], stored.run.strategyName, evidenceRecoveryContract.strategyName)
+  }
+  if (stored.run.evaluationSchemaVersion !== evidenceRecoveryContract.evaluationSchemaVersion) {
+    return mismatch(
+      'contract',
+      ['evaluationSchemaVersion'],
+      stored.run.evaluationSchemaVersion,
+      evidenceRecoveryContract.evaluationSchemaVersion,
+    )
+  }
+  return Result.void
+}
+
+const validateArtifactSet = (
+  artifacts: readonly StoredArtifact[],
+): Result.Result<ArtifactIndex, EvidenceRecoveryIssue> => {
+  const artifactIndex = new Map<string, StoredArtifact>()
+  const artifactCounts = new Map<string, number>()
+  for (const artifact of artifacts) {
+    const observedCount = (artifactCounts.get(artifact.name) ?? 0) + 1
+    artifactCounts.set(artifact.name, observedCount)
+    if (observedCount > 1) {
+      return recoveryFailure({
+        _tag: 'ArtifactSetFailure',
+        problem: { _tag: 'DuplicateArtifact', name: artifact.name, observedCount, expectedCount: 1 },
+      })
+    }
+    artifactIndex.set(artifact.name, artifact)
+  }
+
+  for (const required of evidenceRecoveryContract.artifacts) {
+    if (!artifactIndex.has(required.name)) {
+      return recoveryFailure({
+        _tag: 'ArtifactSetFailure',
+        problem: {
+          _tag: 'MissingArtifact',
+          name: required.name,
+          expectedSchemaVersion: required.schemaVersion,
+        },
+      })
+    }
+  }
+  for (const artifact of artifacts) {
+    if (!evidenceRecoveryContract.artifacts.some((required) => required.name === artifact.name)) {
+      return recoveryFailure({
+        _tag: 'ArtifactSetFailure',
+        problem: {
+          _tag: 'ExtraArtifact',
+          name: artifact.name,
+          observedSchemaVersion: artifact.schemaVersion,
+        },
+      })
+    }
+  }
+  for (const required of evidenceRecoveryContract.artifacts) {
+    const artifact = artifactIndex.get(required.name)
+    if (artifact !== undefined && artifact.schemaVersion !== required.schemaVersion) {
+      return recoveryFailure({
+        _tag: 'ArtifactSetFailure',
+        problem: {
+          _tag: 'WrongArtifactSchema',
+          name: required.name,
+          observedSchemaVersion: artifact.schemaVersion,
+          expectedSchemaVersion: required.schemaVersion,
+        },
+      })
+    }
+  }
+  return Result.succeed(artifactIndex)
+}
+
+const validateRuntimeIdentity = (
+  runId: string,
+  provenance: RuntimeProvenance,
+  stored: StoredEvaluationEvidence,
+): Result.Result<void, EvidenceRecoveryIssue> =>
+  Result.gen(function* () {
+    const facts = [
+      ['runId', stored.run.runId, runId],
+      ['evaluationSchemaVersion', stored.run.evaluationSchemaVersion, provenance.contractVersions.evaluation],
+      ['sourceRevision', stored.run.sourceRevision, provenance.sourceRevision],
+      ['imageRepository', stored.run.imageRepository, provenance.image.repository],
+      ['imageDigest', stored.run.imageDigest, provenance.image.digest],
+      ['strategyName', stored.run.strategyName, provenance.strategy.name],
+    ] as const
+    for (const [path, observed, expected] of facts) {
+      if (observed !== expected) return yield* mismatch('runtime', [path], observed, expected)
+    }
+    const protocolHash = yield* canonicalize(
+      'runtime-protocol-hash',
+      () => makeStrategyProtocolHash(provenance.strategy),
+      runId,
+    )
+    if (stored.run.protocolHash !== protocolHash) {
+      return yield* mismatch('runtime', ['protocolHash'], stored.run.protocolHash, protocolHash)
+    }
+  })
+
+const requiredArtifact = (
+  artifacts: ArtifactIndex,
+  name: string,
+): Result.Result<StoredArtifact, EvidenceRecoveryIssue> => {
+  const artifact = artifacts.get(name)
+  if (artifact !== undefined) return Result.succeed(artifact)
+  const required = evidenceRecoveryContract.artifacts.find((candidate) => candidate.name === name)
+  return recoveryFailure({
+    _tag: 'ArtifactSetFailure',
+    problem: {
+      _tag: 'MissingArtifact',
+      name,
+      expectedSchemaVersion: required?.schemaVersion ?? 'unknown',
+    },
+  })
+}
+
+const decodePayload = <A>(
+  artifactName: string,
+  schemaVersion: string,
+  payload: unknown,
+  decoder: (input: unknown) => Result.Result<A, unknown>,
+): Result.Result<A, EvidenceRecoveryIssue> => {
+  const attempted = Result.try({
+    try: () => decoder(payload),
+    catch: (cause): EvidenceRecoveryIssue => ({
+      _tag: 'DecodeFailure',
+      artifactName,
+      schemaVersion,
+      cause,
+    }),
+  })
+  return Result.andThen(attempted, (decoded) =>
+    Result.mapError(
+      decoded,
+      (cause): EvidenceRecoveryIssue => ({
+        _tag: 'DecodeFailure',
+        artifactName,
+        schemaVersion,
+        cause,
+      }),
+    ),
+  )
+}
+
+const decodeArtifact = <A>(
+  artifacts: ArtifactIndex,
+  name: string,
+  decoder: (input: unknown) => Result.Result<A, unknown>,
+): Result.Result<A, EvidenceRecoveryIssue> =>
+  Result.gen(function* () {
+    const artifact = yield* requiredArtifact(artifacts, name)
+    return yield* decodePayload(artifact.name, artifact.schemaVersion, artifact.payload, decoder)
+  })
+
+const decodeCoreArtifacts = (stored: StoredEvaluationEvidence, artifacts: ArtifactIndex) =>
+  Result.gen(function* () {
+    const evaluation = yield* decodeArtifact(artifacts, 'evaluation-summary', decodeEvaluationSummary)
+    const reconciliation = yield* decodeArtifact(artifacts, 'reconciliation', decodeReconciliationResult)
+    const markedEquity = yield* decodeArtifact(
+      artifacts,
+      'marked-equity-reconciliation',
+      decodeMarkedEquityReconciliation,
+    )
+    const equitySeries = yield* decodeArtifact(artifacts, 'equity-series', decodeEquitySeriesArtifact)
+    const events = yield* decodePayload(
+      'evaluation-events',
+      'bayn.evaluation-event.v1[]',
+      stored.events.map((event) => event.payload),
+      decodeEvaluationEvents,
+    )
+    return { evaluation, reconciliation, markedEquity, equitySeries, events }
+  })
+
+const decodeExecutionArtifacts = (artifacts: ArtifactIndex) =>
+  Result.gen(function* () {
+    const orders = yield* decodeArtifact(artifacts, 'simulated-orders', decodeSimulatedOrdersArtifact)
+    const signalDecisions = yield* decodeArtifact(
+      artifacts,
+      evidenceRecoveryContract.signalDecisionsArtifactName,
+      decodeSignalDecisionsArtifact,
+    )
+    return { orders, signalDecisions }
+  })
+
+const decodeSeriesArtifacts = (artifacts: ArtifactIndex) =>
+  Result.gen(function* () {
+    const buyAndHoldSeries = yield* decodeArtifact(
+      artifacts,
+      'buy-and-hold-series',
+      decodeDailyPerformanceSeriesArtifact,
+    )
+    const directVolatilitySeries = yield* decodeArtifact(
+      artifacts,
+      'direct-volatility-timing-series',
+      decodeDailyPerformanceSeriesArtifact,
+    )
+    const doubleCostSeries = yield* decodeArtifact(
+      artifacts,
+      'double-cost-strategy-series',
+      decodeDailyPerformanceSeriesArtifact,
+    )
+    return { buyAndHoldSeries, directVolatilitySeries, doubleCostSeries }
+  })
+
+const decodeInitialArtifacts = (
+  stored: StoredEvaluationEvidence,
+  artifacts: ArtifactIndex,
+): Result.Result<InitialDecodedArtifacts, EvidenceRecoveryIssue> =>
+  Result.gen(function* () {
+    const core = yield* decodeCoreArtifacts(stored, artifacts)
+    const execution = yield* decodeExecutionArtifacts(artifacts)
+    const series = yield* decodeSeriesArtifacts(artifacts)
+    const artifactManifest = yield* decodeArtifact(
+      artifacts,
+      'qualification-artifact-manifest',
+      decodeQualificationArtifactManifest,
+    )
+    return { ...core, ...execution, ...series, artifactManifest }
+  })
+
+const validateProtocolExecutionLock = (
+  provenance: RuntimeProvenance,
+  stored: StoredEvaluationEvidence,
+  orders: typeof SimulatedOrdersArtifactSchema.Type,
+): Result.Result<void, EvidenceRecoveryIssue> =>
+  Result.gen(function* () {
+    const facts = [
+      ['parameterSchemaVersion', stored.protocol.schemaVersion, provenance.strategy.parameterSchemaVersion],
+      ['strategyName', stored.protocol.strategyName, provenance.strategy.name],
+      ['behaviorHash', stored.protocol.behaviorHash, provenance.strategy.behaviorHash],
+      ['parameterHash', stored.protocol.parameterHash, provenance.strategy.parameterHash],
+    ] as const
+    for (const [path, observed, expected] of facts) {
+      if (observed !== expected) return yield* mismatch('protocol', [path], observed, expected)
+    }
+    const parameterHash = yield* canonicalHash('protocol-parameters', stored.protocol.parameters, stored.run.runId)
+    if (parameterHash !== provenance.strategy.parameterHash) {
+      return yield* mismatch('protocol', ['parameterHash'], parameterHash, provenance.strategy.parameterHash)
+    }
+    const protocolExecutionHash = yield* canonicalHash(
+      'protocol-execution-model',
+      stored.protocol.parameters.executionModel,
+      stored.run.runId,
+    )
+    const ordersExecutionHash = yield* canonicalHash(
+      'protocol-execution-model',
+      orders.executionModel,
+      'simulated-orders',
+    )
+    if (protocolExecutionHash !== ordersExecutionHash) {
+      return yield* mismatch('protocol', ['executionModelHash'], ordersExecutionHash, protocolExecutionHash)
+    }
+    if (orders.costMultiplierMicros !== '1000000') {
+      return yield* mismatch('protocol', ['costMultiplierMicros'], orders.costMultiplierMicros, '1000000')
+    }
+  })
+
+const decodeRemainingArtifacts = (
+  artifacts: ArtifactIndex,
+): Result.Result<RemainingDecodedArtifacts, EvidenceRecoveryIssue> =>
+  Result.gen(function* () {
+    const cashChanges = yield* decodeArtifact(artifacts, 'cash-changes', decodeCashChangesArtifact)
+    const dailyMarks = yield* decodeArtifact(artifacts, 'daily-position-marks', decodeDailyPositionMarksArtifact)
+    const inputManifest = yield* decodeArtifact(artifacts, 'input-manifest', decodeInputManifestArtifact)
+    return { cashChanges, dailyMarks, inputManifest }
+  })
+
+type ManifestArtifactName = Exclude<
+  (typeof evidenceRecoveryContract.artifacts)[number]['name'],
+  'qualification-artifact-manifest'
+>
+
+const collectManifestArtifacts = (
+  artifacts: ArtifactIndex,
+  decoded: InitialDecodedArtifacts & RemainingDecodedArtifacts,
+): Result.Result<
+  readonly {
+    readonly name: string
+    readonly schemaVersion: string
+    readonly itemCount: number
+    readonly contentHash: string
+  }[],
+  EvidenceRecoveryIssue
+> =>
+  Result.gen(function* () {
+    const itemCounts: Readonly<Record<ManifestArtifactName, number>> = {
+      'buy-and-hold': 0,
+      'buy-and-hold-series': decoded.buyAndHoldSeries.items.length,
+      'cash-changes': decoded.cashChanges.items.length,
+      'daily-position-marks': decoded.dailyMarks.items.length,
+      'direct-volatility-timing': 0,
+      'direct-volatility-timing-series': decoded.directVolatilitySeries.items.length,
+      'double-cost-strategy': 0,
+      'double-cost-strategy-series': decoded.doubleCostSeries.items.length,
+      'equity-series': decoded.equitySeries.items.length,
+      'evaluation-summary': 0,
+      'input-manifest': 0,
+      'marked-equity-reconciliation': 0,
+      reconciliation: 0,
+      'risk-balanced-trend-decisions': decoded.signalDecisions.items.length,
+      'simulated-orders': decoded.orders.items.length,
+      strategy: 0,
+    }
+    const references = []
+    for (const required of evidenceRecoveryContract.artifacts) {
+      if (required.name === 'qualification-artifact-manifest') continue
+      const artifact = yield* requiredArtifact(artifacts, required.name)
+      references.push({
+        name: artifact.name,
+        schemaVersion: artifact.schemaVersion,
+        itemCount: itemCounts[required.name],
+        contentHash: artifact.contentHash,
+      })
+    }
+    return references
+  })
+
+const validateArtifactManifest = (
+  runId: string,
+  stored: StoredEvaluationEvidence,
+  artifacts: ArtifactIndex,
+  decoded: InitialDecodedArtifacts & RemainingDecodedArtifacts,
+): Result.Result<void, EvidenceRecoveryIssue> =>
+  Result.gen(function* () {
+    const manifestArtifacts = yield* collectManifestArtifacts(artifacts, decoded)
+    const eventReferencesHash = yield* canonicalHash(
+      'artifact-manifest-expected',
+      stored.events.map(({ ordinal, id, kind, contentHash }) => ({ ordinal, id, kind, contentHash })),
+      'events',
+    )
+    const gateReferencesHash = yield* canonicalHash(
+      'artifact-manifest-expected',
+      stored.gates.map(({ ordinal, name, passed, contentHash }) => ({ ordinal, name, passed, contentHash })),
+      'gates',
+    )
+    const expected = {
+      schemaVersion: 'bayn.qualification-artifact-manifest.v1',
+      identity: {
+        runId,
+        evaluationSchemaVersion: decoded.evaluation.evaluationSchemaVersion,
+        protocolHash: stored.run.protocolHash,
+        sourceRevision: stored.run.sourceRevision,
+        image: { repository: stored.run.imageRepository, digest: stored.run.imageDigest },
+        snapshotId: stored.run.snapshotId,
+        publicationId: decoded.inputManifest.finalizedSnapshot.publicationId,
+        inputManifestHash: decoded.inputManifest.hash,
+        bounds: decoded.inputManifest.bounds,
+        calendarVersion: decoded.inputManifest.finalizedSnapshot.calendarVersion,
+      },
+      execution: {
+        parameterSchemaVersion: stored.protocol.schemaVersion,
+        parameterHash: stored.protocol.parameterHash,
+        simulationSchemaVersion: 'bayn.simulation-trace.v3',
+        executionModel: decoded.orders.executionModel,
+        costMultiplierMicros: decoded.orders.costMultiplierMicros,
+      },
+      artifacts: manifestArtifacts,
+      events: { count: stored.events.length, contentHash: eventReferencesHash },
+      gates: { count: stored.gates.length, contentHash: gateReferencesHash },
+    }
+    const observedHash = yield* canonicalHash(
+      'artifact-manifest-observed',
+      decoded.artifactManifest,
+      'qualification-artifact-manifest',
+    )
+    const expectedHash = yield* canonicalHash('artifact-manifest-expected', expected, 'qualification-artifact-manifest')
+    if (observedHash !== expectedHash) {
+      return yield* mismatch('manifest', ['qualificationArtifactManifest'], observedHash, expectedHash)
+    }
+  })
+
+export const prepareEvidenceRecovery = (input: {
+  readonly runId: string
+  readonly provenance: RuntimeProvenance
+  readonly rows: StoredEvidenceRows
+}): Result.Result<PreparedEvidenceRecovery, EvidenceRecoveryIssue> =>
+  Result.gen(function* () {
+    const graph = yield* validateStoredGraph(input.runId, input.rows)
+    const stored = toStoredEvidence(graph)
+    yield* validateEvidenceContract(stored)
+    const artifacts = yield* validateArtifactSet(stored.artifacts)
+    yield* validateRuntimeIdentity(input.runId, input.provenance, stored)
+    const initialDecoded = yield* decodeInitialArtifacts(stored, artifacts)
+    yield* validateProtocolExecutionLock(input.provenance, stored, initialDecoded.orders)
+    const remainingDecoded = yield* decodeRemainingArtifacts(artifacts)
+    const decoded = { ...initialDecoded, ...remainingDecoded }
+    yield* validateArtifactManifest(input.runId, stored, artifacts, decoded)
+    return { runId: input.runId, provenance: input.provenance, stored, artifacts, decoded }
+  })
+
+const validateSnapshotReference = (
+  row: StoredSnapshotRow,
+  inputManifest: InputManifest,
+): Result.Result<void, EvidenceRecoveryIssue> =>
+  Result.gen(function* () {
+    const snapshot = inputManifest.finalizedSnapshot
+    const facts = [
+      ['snapshotId', row.snapshot_id, snapshot.snapshotId],
+      ['schemaVersion', row.schema_version, snapshot.schemaVersion],
+      ['databaseName', row.database_name, inputManifest.database],
+      ['tableName', row.table_name, inputManifest.tables.bars],
+      ['datasetVersion', row.dataset_version, snapshot.publicationSchemaVersion],
+      ['source', row.source, snapshot.source],
+      ['sourceFeed', row.source_feed, snapshot.sourceFeed],
+      ['adjustment', row.adjustment, snapshot.adjustment],
+      ['contentHash', row.content_hash, snapshot.contentHash],
+      ['rowCount', row.row_count, snapshot.rowCount],
+      ['firstSession', row.first_session, snapshot.firstSession],
+      ['lastSession', row.last_session, snapshot.lastSession],
+    ] as const
+    for (const [path, observed, expected] of facts) {
+      if (observed !== expected) return yield* mismatch('snapshot', [path], observed, expected)
+    }
+    const observedManifestHash = yield* canonicalHash('snapshot-manifest', row.manifest, 'stored')
+    const expectedManifestHash = yield* canonicalHash('snapshot-manifest', snapshot, 'input-manifest')
+    if (observedManifestHash !== expectedManifestHash) {
+      return yield* mismatch('snapshot', ['manifestHash'], observedManifestHash, expectedManifestHash)
+    }
+  })
+
+const reconcileRecoveredEvidence = (
+  prepared: PreparedEvidenceRecovery,
+): Result.Result<MarkedEquityProof, EvidenceRecoveryIssue> => {
+  const { decoded } = prepared
+  return Result.mapError(
+    reconcileMarkedEquity({
+      runId: prepared.runId,
+      initialCapitalMicros: decoded.evaluation.initialCapitalMicros,
+      evaluatorTotalFeesMicros: decoded.evaluation.strategy.totalFeesMicros,
+      evaluatorEndingEquityMicros: decoded.evaluation.strategy.endingEquityMicros,
+      events: decoded.events,
+      simulation: {
+        schemaVersion: 'bayn.simulation-trace.v3',
+        executionModel: decoded.orders.executionModel,
+        costMultiplierMicros: decoded.orders.costMultiplierMicros,
+        orders: decoded.orders.items,
+        cashChanges: decoded.cashChanges.items,
+        dailyMarks: decoded.dailyMarks.items,
+      },
+    }),
+    (issues): EvidenceRecoveryIssue => ({ _tag: 'SimulationFailure', issues }),
+  )
+}
+
+const componentMismatch = (
+  path: RecoveryPath,
+  observed: unknown,
+  expected: unknown,
+): Result.Result<never, EvidenceRecoveryIssue> => mismatch('components', path, observed, expected)
+
+const validateReconciliationShape = (prepared: PreparedEvidenceRecovery): Result.Result<void, EvidenceRecoveryIssue> =>
+  Result.gen(function* () {
+    const { reconciliation } = prepared.decoded
+    if (reconciliation.runId !== prepared.runId) {
+      return yield* mismatch('reconciliation', ['runId'], reconciliation.runId, prepared.runId)
+    }
+    const ledgerPlan = yield* Result.try({
+      try: () =>
+        buildLedgerPlan(
+          {
+            runId: prepared.runId,
+            initialCapitalMicros: prepared.decoded.evaluation.initialCapitalMicros,
+            inputManifest: prepared.decoded.inputManifest,
+            events: prepared.decoded.events,
+          },
+          cardinalityOnlyLedger,
+        ),
+      catch: (cause): EvidenceRecoveryIssue => ({
+        _tag: 'ComputationFailure',
+        operation: 'build-ledger-plan',
+        cause,
+      }),
+    })
+    if (reconciliation.accountCount !== ledgerPlan.accounts.length) {
+      return yield* mismatch(
+        'reconciliation',
+        ['accountCount'],
+        reconciliation.accountCount,
+        ledgerPlan.accounts.length,
+      )
+    }
+    if (reconciliation.transferCount !== ledgerPlan.transfers.length) {
+      return yield* mismatch(
+        'reconciliation',
+        ['transferCount'],
+        reconciliation.transferCount,
+        ledgerPlan.transfers.length,
+      )
+    }
+  })
+
+const validateEvaluationIdentity = (prepared: PreparedEvidenceRecovery): Result.Result<void, EvidenceRecoveryIssue> =>
+  Result.gen(function* () {
+    const { evaluation, inputManifest } = prepared.decoded
+    const facts = [
+      [['evaluation', 'runId'], evaluation.runId, prepared.runId],
+      [['evaluation', 'codeRevision'], evaluation.codeRevision, prepared.provenance.sourceRevision],
+      [['evaluation', 'protocolHash'], evaluation.protocolHash, prepared.stored.run.protocolHash],
+      [
+        ['evaluation', 'initialCapitalMicros'],
+        evaluation.initialCapitalMicros,
+        prepared.stored.run.initialCapitalMicros,
+      ],
+      [['evaluation', 'input', 'snapshotId'], evaluation.input.snapshotId, prepared.stored.run.snapshotId],
+      [['evaluation', 'input', 'snapshotId'], evaluation.input.snapshotId, inputManifest.finalizedSnapshot.snapshotId],
+      [
+        ['evaluation', 'input', 'publicationId'],
+        evaluation.input.publicationId,
+        inputManifest.finalizedSnapshot.publicationId,
+      ],
+      [['evaluation', 'input', 'manifestHash'], evaluation.input.manifestHash, inputManifest.hash],
+    ] as const
+    for (const [path, observed, expected] of facts) {
+      if (observed !== expected) return yield* componentMismatch(path, observed, expected)
+    }
+  })
+
+const validateEvaluationInput = (prepared: PreparedEvidenceRecovery): Result.Result<void, EvidenceRecoveryIssue> =>
+  Result.gen(function* () {
+    const { evaluation, inputManifest } = prepared.decoded
+    const evaluationBoundsHash = yield* canonicalHash('evaluation-bounds', evaluation.input.bounds, 'evaluation')
+    const manifestBoundsHash = yield* canonicalHash('evaluation-bounds', inputManifest.bounds, 'input-manifest')
+    if (evaluationBoundsHash !== manifestBoundsHash) {
+      return yield* componentMismatch(['evaluation', 'input', 'boundsHash'], evaluationBoundsHash, manifestBoundsHash)
+    }
+    const facts = [
+      [['evaluation', 'input', 'rowCount'], evaluation.input.rowCount, inputManifest.rowCount],
+      [['evaluation', 'input', 'sessionCount'], evaluation.input.sessionCount, inputManifest.sessionCount],
+    ] as const
+    for (const [path, observed, expected] of facts) {
+      if (observed !== expected) return yield* componentMismatch(path, observed, expected)
+    }
+    const evaluationSymbolsHash = yield* canonicalHash(
+      'evaluation-input-symbols',
+      evaluation.input.symbols,
+      'evaluation',
+    )
+    const manifestSymbolsHash = yield* canonicalHash(
+      'evaluation-input-symbols',
+      inputManifest.symbols.map((coverage) => coverage.symbol),
+      'input-manifest',
+    )
+    if (evaluationSymbolsHash !== manifestSymbolsHash) {
+      return yield* componentMismatch(
+        ['evaluation', 'input', 'symbolsHash'],
+        evaluationSymbolsHash,
+        manifestSymbolsHash,
+      )
+    }
+  })
+
+const validateEvaluationEvents = (prepared: PreparedEvidenceRecovery): Result.Result<void, EvidenceRecoveryIssue> => {
+  const { evaluation } = prepared.decoded
+  if (evaluation.eventCount !== prepared.stored.run.eventCount) {
+    return componentMismatch(['evaluation', 'eventCount'], evaluation.eventCount, prepared.stored.run.eventCount)
+  }
+  if (evaluation.eventCount !== prepared.decoded.events.length) {
+    return componentMismatch(['evaluation', 'eventCount'], evaluation.eventCount, prepared.decoded.events.length)
+  }
+  return Result.void
+}
+
+const validateEvaluationFacts = (prepared: PreparedEvidenceRecovery): Result.Result<void, EvidenceRecoveryIssue> =>
+  Result.gen(function* () {
+    yield* validateEvaluationIdentity(prepared)
+    yield* validateEvaluationInput(prepared)
+    yield* validateEvaluationEvents(prepared)
+  })
+
+const validateSignalDecisions = (prepared: PreparedEvidenceRecovery): Result.Result<void, EvidenceRecoveryIssue> =>
+  Result.gen(function* () {
+    const { decoded } = prepared
+    const decisions = decoded.signalDecisions.items
+    const events = decoded.events.filter((event) => event.kind === 'decision')
+    if (decoded.evaluation.signalDecisionCount !== decisions.length) {
+      return yield* componentMismatch(
+        ['evaluation', 'signalDecisionCount'],
+        decoded.evaluation.signalDecisionCount,
+        decisions.length,
+      )
+    }
+    if (decisions.length !== events.length) {
+      return yield* componentMismatch(['signalDecisions', 'length'], decisions.length, events.length)
+    }
+    for (const [index, decision] of decisions.entries()) {
+      const event = events[index]
+      if (event === undefined) {
+        return yield* componentMismatch(['signalDecisions', index], decision, 'decision event')
+      }
+      const facts = [
+        ['decisionId', decision.decisionId, event.id],
+        ['signalDate', decision.signalDate, event.signalDate],
+        ['executionDate', decision.executionDate, event.executionDate],
+      ] as const
+      for (const [path, observed, expected] of facts) {
+        if (observed !== expected) {
+          return yield* componentMismatch(['signalDecisions', index, path], observed, expected)
+        }
+      }
+      const decisionWeightsHash = yield* canonicalHash(
+        'signal-target-weights',
+        decision.targetWeights,
+        `decision:${decision.decisionId}`,
+      )
+      const eventWeightsHash = yield* canonicalHash('signal-target-weights', event.targetWeights, `event:${event.id}`)
+      if (decisionWeightsHash !== eventWeightsHash) {
+        return yield* componentMismatch(
+          ['signalDecisions', index, 'targetWeightsHash'],
+          decisionWeightsHash,
+          eventWeightsHash,
+        )
+      }
+    }
+  })
+
+const validateSimulationCardinality = (
+  prepared: PreparedEvidenceRecovery,
+): Result.Result<void, EvidenceRecoveryIssue> => {
+  const { decoded } = prepared
+  const facts = [
+    [['evaluation', 'orderCount'], decoded.evaluation.orderCount, decoded.orders.items.length],
+    [['evaluation', 'cashChangeCount'], decoded.evaluation.cashChangeCount, decoded.cashChanges.items.length],
+    [['evaluation', 'dailyMarkCount'], decoded.evaluation.dailyMarkCount, decoded.dailyMarks.items.length],
+    [['evaluation', 'dailyMarkCount'], decoded.evaluation.dailyMarkCount, decoded.evaluation.strategy.observations],
+  ] as const
+  for (const [path, observed, expected] of facts) {
+    if (observed !== expected) return componentMismatch(path, observed, expected)
+  }
+  return Result.void
+}
+
+const validateBenchmarkCardinality = (
+  prepared: PreparedEvidenceRecovery,
+): Result.Result<void, EvidenceRecoveryIssue> => {
+  const { decoded } = prepared
+  const facts = [
+    [
+      ['evaluation', 'benchmarkSeriesCounts', 'buyAndHold'],
+      decoded.evaluation.benchmarkSeriesCounts.buyAndHold,
+      decoded.buyAndHoldSeries.items.length,
+    ],
+    [
+      ['evaluation', 'benchmarkSeriesCounts', 'directVolTiming'],
+      decoded.evaluation.benchmarkSeriesCounts.directVolTiming,
+      decoded.directVolatilitySeries.items.length,
+    ],
+    [
+      ['evaluation', 'benchmarkSeriesCounts', 'doubleCostStrategy'],
+      decoded.evaluation.benchmarkSeriesCounts.doubleCostStrategy,
+      decoded.doubleCostSeries.items.length,
+    ],
+  ] as const
+  for (const [path, observed, expected] of facts) {
+    if (observed !== expected) return componentMismatch(path, observed, expected)
+  }
+  return Result.void
+}
+
+const validateBenchmarkDates = (prepared: PreparedEvidenceRecovery): Result.Result<void, EvidenceRecoveryIssue> => {
+  const { decoded } = prepared
+  const candidateDates = decoded.dailyMarks.items.map((point) => point.sessionDate)
+  const series = [
+    ['buyAndHold', decoded.buyAndHoldSeries.items],
+    ['directVolTiming', decoded.directVolatilitySeries.items],
+    ['doubleCostStrategy', decoded.doubleCostSeries.items],
+  ] as const
+  for (const [name, points] of series) {
+    if (points.length !== candidateDates.length) {
+      return componentMismatch(['benchmarkSeries', name, 'length'], points.length, candidateDates.length)
+    }
+    for (const [index, point] of points.entries()) {
+      if (point.sessionDate !== candidateDates[index]) {
+        return componentMismatch(
+          ['benchmarkSeries', name, index, 'sessionDate'],
+          point.sessionDate,
+          candidateDates[index],
+        )
+      }
+    }
+  }
+  return Result.void
+}
+
+const validateSignalAndSeriesFacts = (prepared: PreparedEvidenceRecovery): Result.Result<void, EvidenceRecoveryIssue> =>
+  Result.gen(function* () {
+    yield* validateSignalDecisions(prepared)
+    yield* validateSimulationCardinality(prepared)
+    yield* validateBenchmarkCardinality(prepared)
+    yield* validateBenchmarkDates(prepared)
+  })
+
+const validateMetricArtifact = (
+  prepared: PreparedEvidenceRecovery,
+  artifactName: 'buy-and-hold' | 'direct-volatility-timing' | 'double-cost-strategy' | 'strategy',
+  value: unknown,
+): Result.Result<void, EvidenceRecoveryIssue> =>
+  Result.gen(function* () {
+    const artifact = yield* requiredArtifact(prepared.artifacts, artifactName)
+    const expectedHash = yield* canonicalHash('evaluation-metric', value, artifactName)
+    if (artifact.contentHash !== expectedHash) {
+      return yield* componentMismatch(['artifacts', artifactName, 'contentHash'], artifact.contentHash, expectedHash)
+    }
+  })
+
+const validateMarkedEquityBinding = (
+  prepared: PreparedEvidenceRecovery,
+): Result.Result<string, EvidenceRecoveryIssue> =>
+  Result.gen(function* () {
+    const { evaluation, markedEquity } = prepared.decoded
+    if (evaluation.markedEquityReconciliation.runId !== prepared.runId) {
+      return yield* componentMismatch(
+        ['evaluation', 'markedEquityReconciliation', 'runId'],
+        evaluation.markedEquityReconciliation.runId,
+        prepared.runId,
+      )
+    }
+    const evaluationHash = yield* canonicalHash(
+      'evaluation-marked-equity',
+      evaluation.markedEquityReconciliation,
+      'evaluation',
+    )
+    const artifactHash = yield* canonicalHash('evaluation-marked-equity', markedEquity, 'artifact')
+    if (evaluationHash !== artifactHash) {
+      return yield* componentMismatch(['evaluation', 'markedEquityReconciliation'], evaluationHash, artifactHash)
+    }
+    return artifactHash
+  })
+
+const validateMetricArtifacts = (prepared: PreparedEvidenceRecovery): Result.Result<void, EvidenceRecoveryIssue> =>
+  Result.gen(function* () {
+    const { evaluation } = prepared.decoded
+    yield* validateMetricArtifact(prepared, 'strategy', evaluation.strategy)
+    yield* validateMetricArtifact(prepared, 'buy-and-hold', evaluation.buyAndHold)
+    yield* validateMetricArtifact(prepared, 'direct-volatility-timing', evaluation.directVolTiming)
+    yield* validateMetricArtifact(prepared, 'double-cost-strategy', evaluation.doubleCostStrategy)
+  })
+
+const validateRecoveredGates = (prepared: PreparedEvidenceRecovery): Result.Result<void, EvidenceRecoveryIssue> =>
+  Result.gen(function* () {
+    const { gates } = prepared.stored
+    const expectedGates = prepared.decoded.evaluation.verdict.gates
+    if (gates.length !== expectedGates.length) {
+      return yield* componentMismatch(['gates', 'length'], gates.length, expectedGates.length)
+    }
+    for (const [index, gate] of gates.entries()) {
+      const expectedGate = expectedGates[index]
+      if (expectedGate === undefined) return yield* componentMismatch(['gates', index], gate, 'evaluation gate')
+      const observedHash = yield* canonicalHash(
+        'gate-outcome',
+        { name: gate.name, passed: gate.passed, actual: gate.actual, required: gate.required },
+        `stored:${index}`,
+      )
+      const expectedHash = yield* canonicalHash('gate-outcome', expectedGate, `evaluation:${index}`)
+      if (observedHash !== expectedHash) {
+        return yield* componentMismatch(['gates', index], observedHash, expectedHash)
+      }
+    }
+  })
+
+const validateRecoveredEvents = (prepared: PreparedEvidenceRecovery): Result.Result<void, EvidenceRecoveryIssue> => {
+  for (const [index, event] of prepared.stored.events.entries()) {
+    const decodedEvent = prepared.decoded.events[index]
+    if (decodedEvent === undefined) return componentMismatch(['events', index], event, 'decoded event')
+    if (event.id !== decodedEvent.id) return componentMismatch(['events', index, 'id'], event.id, decodedEvent.id)
+    if (event.kind !== decodedEvent.kind) {
+      return componentMismatch(['events', index, 'kind'], event.kind, decodedEvent.kind)
+    }
+  }
+  return Result.void
+}
+
+const validateRecoveredIdentity = (prepared: PreparedEvidenceRecovery): Result.Result<void, EvidenceRecoveryIssue> => {
+  const { evaluation, markedEquity, equitySeries } = prepared.decoded
+  if (markedEquity.runId !== prepared.runId) {
+    return componentMismatch(['markedEquity', 'runId'], markedEquity.runId, prepared.runId)
+  }
+  if (equitySeries.items.length !== evaluation.dailyMarkCount) {
+    return componentMismatch(['equitySeries', 'length'], equitySeries.items.length, evaluation.dailyMarkCount)
+  }
+  return Result.void
+}
+
+const validateReconstructedProof = (
+  prepared: PreparedEvidenceRecovery,
+  proof: MarkedEquityProof,
+  storedMarkedHash: string,
+): Result.Result<void, EvidenceRecoveryIssue> =>
+  Result.gen(function* () {
+    const proofMarkedHash = yield* canonicalHash('marked-equity-proof', proof.reconciliation, 'reconstructed')
+    if (proofMarkedHash !== storedMarkedHash) {
+      return yield* componentMismatch(['markedEquity', 'proofHash'], proofMarkedHash, storedMarkedHash)
+    }
+    const proofEquityHash = yield* canonicalHash('recovered-equity-series', proof.equitySeries, 'reconstructed')
+    const storedEquityHash = yield* canonicalHash(
+      'recovered-equity-series',
+      prepared.decoded.equitySeries.items,
+      'artifact',
+    )
+    if (proofEquityHash !== storedEquityHash) {
+      return yield* componentMismatch(['equitySeries', 'proofHash'], proofEquityHash, storedEquityHash)
+    }
+  })
+
+const validateRecoveredComponents = (
+  prepared: PreparedEvidenceRecovery,
+  proof: MarkedEquityProof,
+): Result.Result<void, EvidenceRecoveryIssue> =>
+  Result.gen(function* () {
+    const storedMarkedHash = yield* validateMarkedEquityBinding(prepared)
+    yield* validateMetricArtifacts(prepared)
+    yield* validateRecoveredGates(prepared)
+    yield* validateRecoveredEvents(prepared)
+    yield* validateRecoveredIdentity(prepared)
+    yield* validateReconstructedProof(prepared, proof, storedMarkedHash)
+  })
+
+const validateFinalPoint = (
+  finalPoint: (typeof EquitySeriesArtifactSchema.Type)['items'][number],
+  markedEquity: typeof MarkedEquityReconciliationSchema.Type,
+): Result.Result<void, EvidenceRecoveryIssue> => {
+  const facts = [
+    ['evaluatorEquityMicros', finalPoint.evaluatorEquityMicros, markedEquity.evaluatorEndingEquityMicros],
+    ['reconstructedEquityMicros', finalPoint.reconstructedEquityMicros, markedEquity.reconstructedEndingEquityMicros],
+    ['differenceMicros', finalPoint.differenceMicros, markedEquity.differenceMicros],
+  ] as const
+  for (const [path, observed, expected] of facts) {
+    if (observed !== expected) {
+      return componentMismatch(['equitySeries', 'final', path], observed, expected)
+    }
+  }
+  return Result.void
+}
+
+const validateTerminalStatus = (
+  stored: StoredEvaluationEvidence,
+  evaluation: typeof EvaluationSummarySchema.Type,
+): Result.Result<void, EvidenceRecoveryIssue> => {
+  const complete = stored.statuses[1]
+  if (complete?.status !== 'COMPLETE') {
+    return mismatch('status', ['complete'], complete?.status, 'COMPLETE')
+  }
+  if (complete.detail.verdict !== evaluation.verdict.status) {
+    return mismatch('status', ['complete', 'verdict'], complete.detail.verdict, evaluation.verdict.status)
+  }
+  return Result.void
+}
+
+export const completeEvidenceRecovery = (
+  prepared: PreparedEvidenceRecovery,
+  snapshot: StoredSnapshotRow,
+): Result.Result<RecoveredEvaluationEvidence, EvidenceRecoveryIssue> =>
+  Result.gen(function* () {
+    yield* validateSnapshotReference(snapshot, prepared.decoded.inputManifest)
+    const reconciliation = yield* reconcileRecoveredEvidence(prepared)
+    yield* validateReconciliationShape(prepared)
+    const finalPoint = prepared.decoded.equitySeries.items.at(-1)
+    if (finalPoint === undefined) {
+      return yield* componentMismatch(['equitySeries', 'final'], undefined, 'present')
+    }
+    yield* validateEvaluationFacts(prepared)
+    yield* validateSignalAndSeriesFacts(prepared)
+    yield* validateRecoveredComponents(prepared, reconciliation)
+    yield* validateFinalPoint(finalPoint, prepared.decoded.markedEquity)
+    yield* validateTerminalStatus(prepared.stored, prepared.decoded.evaluation)
+    return {
+      evaluation: prepared.decoded.evaluation,
+      reconciliation: prepared.decoded.reconciliation,
+      persistence: {
+        runId: prepared.runId,
+        deduplicated: true,
+        artifactCount: prepared.stored.run.artifactCount,
+        eventCount: prepared.stored.run.eventCount,
+        gateCount: prepared.stored.run.gateCount,
+      },
+    }
+  })

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -9,7 +9,7 @@ import { Cause, Deferred, Duration, Effect, Exit, Fiber, Layer, ManagedRuntime, 
 import authorityBoundIntents from '../../migrations/0016_authority_bound_intents'
 import stablePaperAuthorityGeneration from '../../migrations/0017_stable_paper_authority_generation'
 import type { RuntimeConfig } from '../config'
-import { makeStrategyProtocolHash } from '../contracts'
+import { makeStrategyProtocolHash, type RuntimeProvenance } from '../contracts'
 import { IntentStore, IntentStoreLive, planPaperIntent, type IntentPlan } from '../execution/intents'
 import { MutationEventType, MutationStore, MutationStoreLive, mutationId } from '../execution/mutations'
 import {
@@ -4235,6 +4235,313 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       })
     }
     expect(Option.isNone(result.missing)).toBe(true)
+  })
+
+  test('returns missing recovery None before inspecting runtime provenance', async () => {
+    const hostileProvenance = new Proxy({} as RuntimeProvenance, {
+      get: () => {
+        throw new Error('missing recovery must not inspect provenance')
+      },
+    })
+    const recovered = await runtime.runPromise(
+      Effect.flatMap(EvidenceStore, (store) => store.recover('f'.repeat(64), hostileProvenance)),
+    )
+
+    expect(Option.isNone(recovered)).toBe(true)
+  })
+
+  test('rejects an invalid stored graph before looking up its corrupt snapshot', async () => {
+    const input = makeInput()
+    const failure = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* EvidenceStore
+        const sql = yield* PgClient.PgClient
+        yield* store.persist(input)
+        yield* sql`ALTER TABLE evaluation_runs DISABLE TRIGGER evaluation_runs_completion_only`
+        yield* sql`
+          UPDATE evaluation_runs
+          SET expected_artifact_count = expected_artifact_count + 1
+          WHERE run_id = ${input.evaluation.runId}
+        `
+        yield* sql`ALTER TABLE evaluation_runs ENABLE TRIGGER evaluation_runs_completion_only`
+        yield* sql`ALTER TABLE snapshot_references DISABLE TRIGGER snapshot_references_append_only`
+        yield* sql`
+          UPDATE snapshot_references
+          SET manifest = ${sql.json({})}
+          WHERE snapshot_id = ${input.evaluation.inputManifest.finalizedSnapshot.snapshotId}
+        `
+        yield* sql`ALTER TABLE snapshot_references ENABLE TRIGGER snapshot_references_append_only`
+        return yield* store.recover(input.evaluation.runId, input.provenance).pipe(Effect.flip)
+      }),
+    )
+
+    expect(failure).toBeInstanceOf(DatabaseError)
+    expect(failure).toMatchObject({
+      failure: 'invariant',
+      operation: 'recover-evidence',
+      cause: {
+        _tag: 'RecoveryMismatch',
+        stage: 'stored-graph',
+        path: ['artifacts', 'count'],
+        observed: { loadedCount: 17, receiptCount: 17 },
+        expected: { loadedCount: 18, receiptCount: 18 },
+      },
+    })
+  })
+
+  test('maps one concrete pure recovery issue to the public DatabaseError boundary', async () => {
+    const input = makeInput()
+    const failure = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* EvidenceStore
+        const sql = yield* PgClient.PgClient
+        yield* store.persist(input)
+        yield* sql`ALTER TABLE evaluation_artifacts DISABLE TRIGGER evaluation_artifacts_append_only`
+        yield* sql`
+          UPDATE evaluation_artifacts
+          SET schema_version = 'bayn.performance-metrics.v1'
+          WHERE run_id = ${input.evaluation.runId} AND artifact_name = 'strategy'
+        `
+        yield* sql`ALTER TABLE evaluation_artifacts ENABLE TRIGGER evaluation_artifacts_append_only`
+        return yield* store.recover(input.evaluation.runId, input.provenance).pipe(Effect.flip)
+      }),
+    )
+
+    expect(failure).toBeInstanceOf(DatabaseError)
+    expect(failure).toMatchObject({
+      failure: 'invariant',
+      operation: 'recover-evidence',
+      cause: {
+        _tag: 'ArtifactSetFailure',
+        problem: {
+          _tag: 'WrongArtifactSchema',
+          name: 'strategy',
+          observedSchemaVersion: 'bayn.performance-metrics.v1',
+          expectedSchemaVersion: 'bayn.performance-metrics.v2',
+        },
+      },
+    })
+  })
+
+  test('rejects coherently rehashed reconciliation counts at the public recovery boundary', async () => {
+    const input = makeInput()
+    const changedReconciliation = {
+      ...input.reconciliation,
+      accountCount: input.reconciliation.accountCount + 1,
+    }
+    const failure = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* EvidenceStore
+        const sql = yield* PgClient.PgClient
+        yield* store.persist(input)
+        const stored = yield* store.read(input.evaluation.runId)
+        if (Option.isNone(stored)) return yield* Effect.die(new Error('persisted recovery fixture is missing'))
+        const manifestArtifact = stored.value.artifacts.find(
+          (artifact) => artifact.name === 'qualification-artifact-manifest',
+        )
+        if (manifestArtifact === undefined) {
+          return yield* Effect.die(new Error('persisted qualification artifact manifest is missing'))
+        }
+        const reconciliationHash = canonicalHashV1(changedReconciliation)
+        const manifest = structuredClone(manifestArtifact.payload) as {
+          readonly artifacts: readonly {
+            readonly name: string
+            readonly schemaVersion: string
+            readonly itemCount: number
+            readonly contentHash: string
+          }[]
+        }
+        const changedManifest = {
+          ...manifest,
+          artifacts: manifest.artifacts.map((artifact) =>
+            artifact.name === 'reconciliation' ? { ...artifact, contentHash: reconciliationHash } : artifact,
+          ),
+        }
+        const manifestHash = canonicalHashV1(changedManifest)
+
+        yield* sql`ALTER TABLE evaluation_artifacts DISABLE TRIGGER evaluation_artifacts_append_only`
+        yield* sql`
+          UPDATE evaluation_artifacts
+          SET payload = ${sql.json(changedReconciliation)}, content_hash = ${reconciliationHash}
+          WHERE run_id = ${input.evaluation.runId} AND artifact_name = 'reconciliation'
+        `
+        yield* sql`
+          UPDATE evaluation_artifacts
+          SET payload = ${sql.json(changedManifest)}, content_hash = ${manifestHash}
+          WHERE run_id = ${input.evaluation.runId} AND artifact_name = 'qualification-artifact-manifest'
+        `
+        yield* sql`ALTER TABLE evaluation_artifacts ENABLE TRIGGER evaluation_artifacts_append_only`
+        return yield* store.recover(input.evaluation.runId, input.provenance).pipe(Effect.flip)
+      }),
+    )
+
+    expect(failure).toBeInstanceOf(DatabaseError)
+    expect(failure).toMatchObject({
+      failure: 'invariant',
+      operation: 'recover-evidence',
+      cause: {
+        _tag: 'RecoveryMismatch',
+        stage: 'reconciliation',
+        path: ['accountCount'],
+        observed: changedReconciliation.accountCount,
+        expected: input.reconciliation.accountCount,
+      },
+    })
+  })
+
+  test('retains structured reconciliation issues at the recovery failure boundary', async () => {
+    const input = makeInput()
+    const firstCashChange = input.evaluation.simulation.cashChanges[0]
+    assert(firstCashChange !== undefined)
+    const failure = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* EvidenceStore
+        const sql = yield* PgClient.PgClient
+        yield* store.persist(input)
+        const stored = yield* store.read(input.evaluation.runId)
+        if (Option.isNone(stored)) return yield* Effect.die(new Error('persisted recovery fixture is missing'))
+        const manifestArtifact = stored.value.artifacts.find(
+          (artifact) => artifact.name === 'qualification-artifact-manifest',
+        )
+        if (manifestArtifact === undefined) {
+          return yield* Effect.die(new Error('persisted qualification artifact manifest is missing'))
+        }
+        const cashPayload = {
+          schemaVersion: 'bayn.cash-changes.v2' as const,
+          items: input.evaluation.simulation.cashChanges.map((change, index) =>
+            index === 0 ? { ...change, amountMicros: (BigInt(change.amountMicros) + 1n).toString() } : change,
+          ),
+        }
+        const cashHash = canonicalHashV1(cashPayload)
+        const manifest = structuredClone(manifestArtifact.payload) as {
+          readonly artifacts: readonly {
+            readonly name: string
+            readonly schemaVersion: string
+            readonly itemCount: number
+            readonly contentHash: string
+          }[]
+        }
+        const manifestPayload = {
+          ...manifest,
+          artifacts: manifest.artifacts.map((artifact) =>
+            artifact.name === 'cash-changes' ? { ...artifact, contentHash: cashHash } : artifact,
+          ),
+        }
+        const manifestHash = canonicalHashV1(manifestPayload)
+
+        yield* sql`ALTER TABLE evaluation_artifacts DISABLE TRIGGER evaluation_artifacts_append_only`
+        yield* sql`
+          UPDATE evaluation_artifacts
+          SET payload = ${sql.json(cashPayload)}, content_hash = ${cashHash}
+          WHERE run_id = ${input.evaluation.runId} AND artifact_name = 'cash-changes'
+        `
+        yield* sql`
+          UPDATE evaluation_artifacts
+          SET payload = ${sql.json(manifestPayload)}, content_hash = ${manifestHash}
+          WHERE run_id = ${input.evaluation.runId} AND artifact_name = 'qualification-artifact-manifest'
+        `
+        yield* sql`ALTER TABLE evaluation_artifacts ENABLE TRIGGER evaluation_artifacts_append_only`
+        return yield* store.recover(input.evaluation.runId, input.provenance).pipe(Effect.flip)
+      }),
+    )
+
+    expect(failure).toBeInstanceOf(DatabaseError)
+    expect(failure).toMatchObject({
+      failure: 'invariant',
+      operation: 'recover-evidence',
+      cause: [
+        {
+          _tag: 'EvidenceMismatch',
+          problem: {
+            _tag: 'CashChange',
+            cashChangeId: firstCashChange.id,
+            sourceId: firstCashChange.sourceId,
+            field: 'amountMicros',
+            actual: (BigInt(firstCashChange.amountMicros) + 1n).toString(),
+            expected: firstCashChange.amountMicros,
+          },
+        },
+      ],
+    })
+  })
+
+  test('recovers through SELECT-only PostgreSQL access without changing the evidence graph', async () => {
+    const input = makeInput()
+    const result = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* EvidenceStore
+        const sql = yield* PgClient.PgClient
+        yield* store.persist(input)
+        const graph = () => sql<{
+          artifacts: unknown
+          events: unknown
+          gates: unknown
+          protocol: unknown
+          runs: unknown
+          snapshot: unknown
+          statuses: unknown
+        }>`
+          SELECT
+            (
+              SELECT jsonb_agg(
+                to_jsonb(run) || jsonb_build_object('_xmin', run.xmin::text)
+                ORDER BY run.run_id
+              )
+              FROM evaluation_runs AS run
+              WHERE run.run_id = ${input.evaluation.runId}
+            ) AS runs,
+            (
+              SELECT jsonb_agg(
+                to_jsonb(artifact) || jsonb_build_object('_xmin', artifact.xmin::text)
+                ORDER BY artifact.artifact_name
+              )
+              FROM evaluation_artifacts AS artifact
+              WHERE artifact.run_id = ${input.evaluation.runId}
+            ) AS artifacts,
+            (
+              SELECT jsonb_agg(
+                to_jsonb(event) || jsonb_build_object('_xmin', event.xmin::text)
+                ORDER BY event.ordinal
+              )
+              FROM evaluation_events AS event
+              WHERE event.run_id = ${input.evaluation.runId}
+            ) AS events,
+            (
+              SELECT jsonb_agg(
+                to_jsonb(gate) || jsonb_build_object('_xmin', gate.xmin::text)
+                ORDER BY gate.ordinal
+              )
+              FROM gate_outcomes AS gate
+              WHERE gate.run_id = ${input.evaluation.runId}
+            ) AS gates,
+            (
+              SELECT jsonb_agg(
+                to_jsonb(status) || jsonb_build_object('_xmin', status.xmin::text)
+                ORDER BY status.sequence
+              )
+              FROM status_history AS status
+              WHERE status.run_id = ${input.evaluation.runId}
+            ) AS statuses,
+            (
+              SELECT jsonb_agg(to_jsonb(protocol) || jsonb_build_object('_xmin', protocol.xmin::text))
+              FROM protocol_locks AS protocol
+              WHERE protocol.protocol_hash = ${input.evaluation.protocolHash}
+            ) AS protocol,
+            (
+              SELECT jsonb_agg(to_jsonb(snapshot) || jsonb_build_object('_xmin', snapshot.xmin::text))
+              FROM snapshot_references AS snapshot
+              WHERE snapshot.snapshot_id = ${input.evaluation.inputManifest.finalizedSnapshot.snapshotId}
+            ) AS snapshot
+        `
+        const before = yield* graph()
+        const recovered = yield* store.recover(input.evaluation.runId, input.provenance)
+        const after = yield* graph()
+        return { after: after[0], before: before[0], recovered }
+      }),
+    )
+
+    expect(Option.isSome(result.recovered)).toBe(true)
+    expect(result.after).toEqual(result.before)
   })
 
   test('persists and recovers the complete risk-balanced trend v6 evidence contract', async () => {

--- a/services/bayn/src/db/evidence-store.ts
+++ b/services/bayn/src/db/evidence-store.ts
@@ -10,22 +10,7 @@ import {
   makeStrategyProtocolHash,
   type RuntimeProvenance,
 } from '../contracts'
-import {
-  decodeCashChangesArtifact,
-  decodeDailyPerformanceSeriesArtifact,
-  decodeDailyPositionMarksArtifact,
-  decodeEquitySeriesArtifact,
-  decodeEvaluationEvents,
-  decodeEvaluationSummary,
-  decodeInputManifestArtifact,
-  decodeMarkedEquityReconciliation,
-  decodeQualificationArtifactManifest,
-  decodeReconciliationResult,
-  decodeRiskBalancedTrendSignalDecisionsArtifact,
-  decodeSimulatedOrdersArtifact,
-  EvaluationEventSchema,
-  makeEquitySeriesArtifact,
-} from '../evidence-contracts'
+import { EvaluationEventSchema, makeEquitySeriesArtifact } from '../evidence-contracts'
 import { canonicalHashV1 } from '../hash'
 import {
   QualificationLockSchema,
@@ -40,17 +25,22 @@ import {
   renderSimulationReconciliationIssues,
   type SimulationReconciliationIssue,
 } from '../simulation-reconciliation'
-import type {
-  EconomicVerdict,
-  EvaluationEvent,
-  EvaluationResult,
-  EvaluationSummary,
-  InputManifest,
-  Protocol,
-  ReconciliationResult,
-} from '../types'
+import type { EvaluationEvent, EvaluationResult, InputManifest, Protocol, ReconciliationResult } from '../types'
+import {
+  completeEvidenceRecovery,
+  evidenceRecoveryContract as evidenceContract,
+  prepareEvidenceRecovery,
+  validateStoredEvidence,
+  type EvidenceRecoveryIssue,
+  type PersistenceReceipt,
+  type RecoveredEvaluationEvidence,
+  type StoredEvidenceRows,
+  type StoredEvaluationEvidence,
+} from './evidence-recovery'
 import { migrationLoader } from './migrations'
 import { ensureSnapshotReference as ensureSnapshotReferenceRow } from './snapshot-reference'
+
+export type { PersistenceReceipt, RecoveredEvaluationEvidence, StoredEvaluationEvidence } from './evidence-recovery'
 
 export type DatabaseFailure = 'constraint' | 'decode' | 'invariant' | 'migration' | 'query' | 'unavailable'
 
@@ -60,14 +50,6 @@ export class DatabaseError extends Data.TaggedError('DatabaseError')<{
   readonly message: string
   readonly cause?: unknown
 }> {}
-
-export interface PersistenceReceipt {
-  readonly runId: string
-  readonly deduplicated: boolean
-  readonly artifactCount: number
-  readonly eventCount: number
-  readonly gateCount: number
-}
 
 export interface PersistEvaluationInput {
   readonly provenance: RuntimeProvenance
@@ -126,68 +108,6 @@ export interface EvidenceStoreService {
 
 export class EvidenceStore extends Context.Service<EvidenceStore, EvidenceStoreService>()('bayn/EvidenceStore') {}
 
-export interface StoredEvaluationEvidence {
-  readonly protocol: {
-    readonly protocolHash: string
-    readonly schemaVersion: string
-    readonly strategyName: string
-    readonly behaviorHash: string
-    readonly parameterHash: string
-    readonly parameters: Protocol
-  }
-  readonly run: {
-    readonly runId: string
-    readonly protocolHash: string
-    readonly snapshotId: string
-    readonly evaluationSchemaVersion: string
-    readonly sourceRevision: string
-    readonly imageRepository: string
-    readonly imageDigest: string
-    readonly strategyName: string
-    readonly initialCapitalMicros: string
-    readonly artifactCount: number
-    readonly eventCount: number
-    readonly gateCount: number
-  }
-  readonly artifacts: readonly {
-    readonly name: string
-    readonly schemaVersion: string
-    readonly contentHash: string
-    readonly payload: unknown
-  }[]
-  readonly events: readonly {
-    readonly ordinal: number
-    readonly id: string
-    readonly kind: 'decision' | 'fill' | 'fee' | 'cash-yield'
-    readonly contentHash: string
-    readonly payload: EvaluationEvent
-  }[]
-  readonly gates: readonly {
-    readonly ordinal: number
-    readonly name: string
-    readonly passed: boolean
-    readonly actual: EconomicVerdict['gates'][number]['actual']
-    readonly required: EconomicVerdict['gates'][number]['required']
-    readonly contentHash: string
-  }[]
-  readonly statuses: readonly (
-    | {
-        readonly status: 'WRITING'
-        readonly detail: { readonly artifactCount: number; readonly eventCount: number; readonly gateCount: number }
-      }
-    | {
-        readonly status: 'COMPLETE'
-        readonly detail: { readonly reconciliationExact: true; readonly verdict: 'PASS' | 'FAIL_CLOSED' }
-      }
-  )[]
-}
-
-export interface RecoveredEvaluationEvidence {
-  readonly evaluation: EvaluationSummary
-  readonly reconciliation: ReconciliationResult
-  readonly persistence: PersistenceReceipt
-}
-
 const Sha256 = Schema.String.check(Schema.isPattern(/^[0-9a-f]{64}$/))
 const GitRevision = Schema.String.check(Schema.isPattern(/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/))
 const ImageDigest = Schema.String.check(Schema.isPattern(/^sha256:[0-9a-f]{64}$/))
@@ -220,7 +140,6 @@ const SnapshotRow = Schema.Struct({
   last_session: Schema.String,
   manifest: FinalizedSnapshotProvenanceSchema,
 })
-const snapshotRowEquivalence = Schema.toEquivalence(SnapshotRow)
 const ReceiptRow = Schema.Struct({
   run_id: Sha256,
   protocol_hash: Sha256,
@@ -350,34 +269,6 @@ const runDatabase = <A, E, R>(operation: string, effect: Effect.Effect<A, E, R>)
 
 const ensure = (condition: boolean, operation: string, message: string): Effect.Effect<void, DatabaseError> =>
   condition ? Effect.void : Effect.fail(databaseError('invariant', operation, message))
-
-const snapshotReferenceMatches = (row: typeof SnapshotRow.Type, inputManifest: InputManifest): boolean => {
-  const snapshot = inputManifest.finalizedSnapshot
-  return snapshotRowEquivalence(row, {
-    snapshot_id: snapshot.snapshotId,
-    schema_version: snapshot.schemaVersion,
-    database_name: inputManifest.database,
-    table_name: inputManifest.tables.bars,
-    dataset_version: snapshot.publicationSchemaVersion,
-    source: snapshot.source,
-    source_feed: snapshot.sourceFeed,
-    adjustment: snapshot.adjustment,
-    content_hash: snapshot.contentHash,
-    row_count: snapshot.rowCount,
-    first_session: snapshot.firstSession,
-    last_session: snapshot.lastSession,
-    manifest: snapshot,
-  })
-}
-
-const evidenceContract = {
-  strategyName: 'risk-balanced-trend',
-  evaluationSchemaVersion: 'bayn.evaluation.v6',
-  summarySchemaVersion: 'bayn.evaluation-summary.v5',
-  inputManifestSchemaVersion: 'bayn.input-manifest.v3',
-  signalDecisionsArtifactName: 'risk-balanced-trend-decisions',
-  signalDecisionsSchemaVersion: 'bayn.risk-balanced-trend-decisions.v1',
-} as const
 
 const makeArtifact = (name: string, schemaVersion: string, payload: unknown, itemCount = 0) => ({
   name,
@@ -883,6 +774,39 @@ const persistencePlanDatabaseError = (operation: string, failure: PersistencePla
       )
   }
 }
+
+const recoveryIssueDatabaseError = (operation: string, issue: EvidenceRecoveryIssue): DatabaseError => {
+  switch (issue._tag) {
+    case 'RecoveryMismatch':
+      return databaseError(
+        'invariant',
+        operation,
+        `evidence recovery ${issue.stage} mismatch at ${issue.path.join('.')}`,
+        issue,
+      )
+    case 'ArtifactSetFailure':
+      return databaseError(
+        'invariant',
+        operation,
+        `stored artifact set failed with ${issue.problem._tag} for ${issue.problem.name}`,
+        issue,
+      )
+    case 'DecodeFailure':
+      return databaseError('decode', operation, `stored artifact ${issue.artifactName} failed decoding`, issue)
+    case 'CanonicalizationFailure':
+      return databaseError('invariant', operation, `evidence canonicalization failed during ${issue.operation}`, issue)
+    case 'SimulationFailure':
+      return reconciliationDatabaseError(operation, issue.issues)
+    case 'ComputationFailure':
+      return databaseError('invariant', operation, `evidence computation failed during ${issue.operation}`, issue)
+  }
+}
+
+const liftRecoveryResult = <A>(
+  operation: string,
+  result: Result.Result<A, EvidenceRecoveryIssue>,
+): Effect.Effect<A, DatabaseError> =>
+  Effect.fromResult(result).pipe(Effect.mapError((issue) => recoveryIssueDatabaseError(operation, issue)))
 
 const makeEvidenceStore = Effect.gen(function* () {
   const sql = yield* PgClient.PgClient
@@ -1399,130 +1323,29 @@ const makeEvidenceStore = Effect.gen(function* () {
       }
     })
 
-  const readStored = (runId: string) =>
+  const loadStoredRows = (runId: string) =>
     Effect.gen(function* () {
-      const rows = yield* getReceipt({ runId })
-      if (rows.length === 0) return Option.none<StoredEvaluationEvidence>()
-      yield* ensure(rows.length === 1, 'read-evidence', 'stored run receipt is duplicated')
-      const row = rows[0]
-      const protocol = yield* getProtocol({ protocolHash: row.protocol_hash })
+      const receipts = yield* getReceipt({ runId })
+      if (receipts.length === 0) return Option.none<StoredEvidenceRows>()
+      const receipt = receipts[0]
+      if (receipt === undefined) return Option.none<StoredEvidenceRows>()
+      const protocol = yield* getProtocol({ protocolHash: receipt.protocol_hash })
       const artifacts = yield* getArtifactReferences({ runId })
       const events = yield* getEventReferences({ runId })
       const gates = yield* getGateReferences({ runId })
       const statuses = yield* getStatusReferences({ runId })
-
-      yield* ensure(
-        row.strategy_name === protocol.strategy_name &&
-          canonicalHashV1(protocol.parameters) === protocol.parameter_hash,
-        'read-evidence',
-        'stored protocol lock diverged',
-      )
-
-      yield* ensure(
-        artifacts.length === row.expected_artifact_count && artifacts.length === row.artifact_count,
-        'read-evidence',
-        'stored artifact count is incomplete',
-      )
-      yield* ensure(
-        events.length === row.expected_event_count && events.length === row.event_count,
-        'read-evidence',
-        'stored event count is incomplete',
-      )
-      yield* ensure(
-        gates.length === row.expected_gate_count && gates.length === row.gate_count,
-        'read-evidence',
-        'stored gate count is incomplete',
-      )
-      yield* ensure(
-        artifacts.every((artifact) => canonicalHashV1(artifact.payload) === artifact.content_hash),
-        'read-evidence',
-        'stored artifact content hash diverged',
-      )
-      yield* ensure(
-        events.every(
-          (event, index) => event.ordinal === index && canonicalHashV1(event.payload) === event.content_hash,
-        ),
-        'read-evidence',
-        'stored event content hash or ordering diverged',
-      )
-      yield* ensure(
-        gates.every(
-          (gate, index) =>
-            gate.ordinal === index &&
-            canonicalHashV1({
-              name: gate.gate_name,
-              passed: gate.passed,
-              actual: gate.actual,
-              required: gate.required,
-            }) === gate.content_hash,
-        ),
-        'read-evidence',
-        'stored gate content hash or ordering diverged',
-      )
-      const [writing, complete] = statuses
-      yield* ensure(
-        statuses.length === 2 &&
-          writing?.status === 'WRITING' &&
-          canonicalHashV1(writing.detail) ===
-            canonicalHashV1({
-              artifactCount: row.artifact_count,
-              eventCount: row.event_count,
-              gateCount: row.gate_count,
-            }) &&
-          complete?.status === 'COMPLETE',
-        'read-evidence',
-        'stored status history is incomplete or divergent',
-      )
-
-      return Option.some({
-        protocol: {
-          protocolHash: protocol.protocol_hash,
-          schemaVersion: protocol.schema_version,
-          strategyName: protocol.strategy_name,
-          behaviorHash: protocol.behavior_hash,
-          parameterHash: protocol.parameter_hash,
-          parameters: protocol.parameters,
-        },
-        run: {
-          runId: row.run_id,
-          protocolHash: row.protocol_hash,
-          snapshotId: row.snapshot_id,
-          evaluationSchemaVersion: row.evaluation_schema_version,
-          sourceRevision: row.source_revision,
-          imageRepository: row.image_repository,
-          imageDigest: row.image_digest,
-          strategyName: row.strategy_name,
-          initialCapitalMicros: row.initial_capital_micros,
-          artifactCount: row.artifact_count,
-          eventCount: row.event_count,
-          gateCount: row.gate_count,
-        },
-        artifacts: artifacts.map((artifact) => ({
-          name: artifact.artifact_name,
-          schemaVersion: artifact.schema_version,
-          contentHash: artifact.content_hash,
-          payload: artifact.payload,
-        })),
-        events: events.map((event) => ({
-          ordinal: event.ordinal,
-          id: event.event_id,
-          kind: event.event_kind,
-          contentHash: event.content_hash,
-          payload: event.payload,
-        })),
-        gates: gates.map((gate) => ({
-          ordinal: gate.ordinal,
-          name: gate.gate_name,
-          passed: gate.passed,
-          actual: gate.actual,
-          required: gate.required,
-          contentHash: gate.content_hash,
-        })),
-        statuses,
-      } satisfies StoredEvaluationEvidence)
+      return Option.some({ receipts, protocol, artifacts, events, gates, statuses } satisfies StoredEvidenceRows)
     })
 
-  const read = (runId: string) => runDatabase('read-evidence', readStored(runId))
+  const readStored = (operation: string, runId: string) =>
+    Effect.gen(function* () {
+      const rows = yield* loadStoredRows(runId)
+      if (Option.isNone(rows)) return Option.none<StoredEvaluationEvidence>()
+      const stored = yield* liftRecoveryResult(operation, validateStoredEvidence(runId, rows.value))
+      return Option.some(stored)
+    })
+
+  const read = (runId: string) => runDatabase('read-evidence', readStored('read-evidence', runId))
 
   const listPriorTrials = runDatabase(
     'list-prior-trials',
@@ -1679,299 +1502,15 @@ const makeEvidenceStore = Effect.gen(function* () {
     runDatabase(
       'recover-evidence',
       Effect.gen(function* () {
-        const storedOption = yield* readStored(runId)
-        if (Option.isNone(storedOption)) return Option.none<RecoveredEvaluationEvidence>()
-        const stored = storedOption.value
-        yield* ensure(
-          stored.run.strategyName === evidenceContract.strategyName &&
-            stored.run.evaluationSchemaVersion === evidenceContract.evaluationSchemaVersion,
+        const rows = yield* loadStoredRows(runId)
+        if (Option.isNone(rows)) return Option.none<RecoveredEvaluationEvidence>()
+        const prepared = yield* liftRecoveryResult(
           'recover-evidence',
-          'stored run does not use the current evidence contract',
+          prepareEvidenceRecovery({ runId, provenance, rows: rows.value }),
         )
-        const requiredArtifacts = new Map([
-          ['buy-and-hold', 'bayn.performance-metrics.v2'],
-          ['buy-and-hold-series', 'bayn.daily-performance-series.v1'],
-          ['cash-changes', 'bayn.cash-changes.v2'],
-          ['daily-position-marks', 'bayn.daily-position-marks.v3'],
-          ['direct-volatility-timing', 'bayn.performance-metrics.v2'],
-          ['direct-volatility-timing-series', 'bayn.daily-performance-series.v1'],
-          ['double-cost-strategy', 'bayn.performance-metrics.v2'],
-          ['double-cost-strategy-series', 'bayn.daily-performance-series.v1'],
-          ['equity-series', 'bayn.equity-series.v1'],
-          ['evaluation-summary', evidenceContract.summarySchemaVersion],
-          ['input-manifest', evidenceContract.inputManifestSchemaVersion],
-          ['marked-equity-reconciliation', 'bayn.marked-equity-reconciliation.v2'],
-          ['qualification-artifact-manifest', 'bayn.qualification-artifact-manifest.v1'],
-          ['reconciliation', 'bayn.reconciliation.v1'],
-          ['simulated-orders', 'bayn.simulated-orders.v2'],
-          ['strategy', 'bayn.performance-metrics.v2'],
-          [evidenceContract.signalDecisionsArtifactName, evidenceContract.signalDecisionsSchemaVersion],
-        ])
-        const artifacts = new Map(stored.artifacts.map((artifact) => [artifact.name, artifact]))
-        const requiredValue = <A>(value: A | undefined, description: string): Effect.Effect<A, DatabaseError> =>
-          value === undefined
-            ? Effect.fail(databaseError('invariant', 'recover-evidence', `stored run is missing ${description}`))
-            : Effect.succeed(value)
-        const requiredArtifact = (name: string) => requiredValue(artifacts.get(name), `artifact ${name}`)
-        yield* ensure(
-          artifacts.size === requiredArtifacts.size &&
-            [...requiredArtifacts].every(
-              ([name, schemaVersion]) => artifacts.get(name)?.schemaVersion === schemaVersion,
-            ),
-          'recover-evidence',
-          'stored run does not have the exact strategy evidence contract',
-        )
-        yield* ensure(
-          stored.run.runId === runId &&
-            stored.run.evaluationSchemaVersion === evidenceContract.evaluationSchemaVersion &&
-            stored.run.evaluationSchemaVersion === provenance.contractVersions.evaluation &&
-            stored.run.sourceRevision === provenance.sourceRevision &&
-            stored.run.imageRepository === provenance.image.repository &&
-            stored.run.imageDigest === provenance.image.digest &&
-            stored.run.strategyName === provenance.strategy.name &&
-            stored.run.protocolHash === makeStrategyProtocolHash(provenance.strategy),
-          'recover-evidence',
-          'stored run does not match the current runtime identity',
-        )
-        const [
-          evaluationArtifact,
-          reconciliationArtifact,
-          markedEquityArtifact,
-          equitySeriesArtifact,
-          ordersArtifact,
-          signalDecisionsArtifact,
-          buyAndHoldSeriesArtifact,
-          directVolatilitySeriesArtifact,
-          doubleCostSeriesArtifact,
-          artifactManifestArtifact,
-          cashChangesArtifact,
-          dailyMarksArtifact,
-          inputManifestArtifact,
-          strategyArtifact,
-          buyAndHoldArtifact,
-          directVolatilityArtifact,
-          doubleCostArtifact,
-        ] = yield* Effect.all([
-          requiredArtifact('evaluation-summary'),
-          requiredArtifact('reconciliation'),
-          requiredArtifact('marked-equity-reconciliation'),
-          requiredArtifact('equity-series'),
-          requiredArtifact('simulated-orders'),
-          requiredArtifact(evidenceContract.signalDecisionsArtifactName),
-          requiredArtifact('buy-and-hold-series'),
-          requiredArtifact('direct-volatility-timing-series'),
-          requiredArtifact('double-cost-strategy-series'),
-          requiredArtifact('qualification-artifact-manifest'),
-          requiredArtifact('cash-changes'),
-          requiredArtifact('daily-position-marks'),
-          requiredArtifact('input-manifest'),
-          requiredArtifact('strategy'),
-          requiredArtifact('buy-and-hold'),
-          requiredArtifact('direct-volatility-timing'),
-          requiredArtifact('double-cost-strategy'),
-        ])
-        const evaluation = yield* decodeEvaluationSummary(evaluationArtifact.payload)
-        const reconciliation = yield* decodeReconciliationResult(reconciliationArtifact.payload)
-        const markedEquity = yield* decodeMarkedEquityReconciliation(markedEquityArtifact.payload)
-        const equitySeries = yield* decodeEquitySeriesArtifact(equitySeriesArtifact.payload)
-        const events = yield* decodeEvaluationEvents(stored.events.map((event) => event.payload))
-        const orders = yield* decodeSimulatedOrdersArtifact(ordersArtifact.payload)
-        const signalDecisions = yield* decodeRiskBalancedTrendSignalDecisionsArtifact(signalDecisionsArtifact.payload)
-        const buyAndHoldSeries = yield* decodeDailyPerformanceSeriesArtifact(buyAndHoldSeriesArtifact.payload)
-        const directVolatilitySeries = yield* decodeDailyPerformanceSeriesArtifact(
-          directVolatilitySeriesArtifact.payload,
-        )
-        const doubleCostSeries = yield* decodeDailyPerformanceSeriesArtifact(doubleCostSeriesArtifact.payload)
-        const artifactManifest = yield* decodeQualificationArtifactManifest(artifactManifestArtifact.payload)
-        yield* ensure(
-          stored.protocol.schemaVersion === provenance.strategy.parameterSchemaVersion &&
-            stored.protocol.strategyName === provenance.strategy.name &&
-            stored.protocol.behaviorHash === provenance.strategy.behaviorHash &&
-            stored.protocol.parameterHash === provenance.strategy.parameterHash &&
-            canonicalHashV1(stored.protocol.parameters) === provenance.strategy.parameterHash &&
-            canonicalHashV1(stored.protocol.parameters.executionModel) === canonicalHashV1(orders.executionModel) &&
-            orders.costMultiplierMicros === '1000000',
-          'recover-evidence',
-          'stored protocol lock or execution model diverged',
-        )
-        const cashChanges = yield* decodeCashChangesArtifact(cashChangesArtifact.payload)
-        const dailyMarks = yield* decodeDailyPositionMarksArtifact(dailyMarksArtifact.payload)
-        const inputManifest = yield* decodeInputManifestArtifact(inputManifestArtifact.payload)
-        const artifactItemCounts = new Map<string, number>([
-          ['evaluation-summary', 0],
-          ['input-manifest', 0],
-          ['strategy', 0],
-          ['buy-and-hold', 0],
-          ['direct-volatility-timing', 0],
-          ['double-cost-strategy', 0],
-          ['simulated-orders', orders.items.length],
-          ['cash-changes', cashChanges.items.length],
-          ['daily-position-marks', dailyMarks.items.length],
-          [evidenceContract.signalDecisionsArtifactName, signalDecisions.items.length],
-          ['buy-and-hold-series', buyAndHoldSeries.items.length],
-          ['direct-volatility-timing-series', directVolatilitySeries.items.length],
-          ['double-cost-strategy-series', doubleCostSeries.items.length],
-          ['equity-series', equitySeries.items.length],
-          ['marked-equity-reconciliation', 0],
-          ['reconciliation', 0],
-        ])
-        const manifestArtifacts = yield* Effect.forEach(
-          stored.artifacts
-            .filter((artifact) => artifact.name !== 'qualification-artifact-manifest')
-            .sort((left, right) => (left.name < right.name ? -1 : left.name > right.name ? 1 : 0)),
-          (artifact) =>
-            Effect.fromOption(Option.fromUndefinedOr(artifactItemCounts.get(artifact.name)), () =>
-              databaseError('invariant', 'recover-evidence', `unsupported qualification artifact: ${artifact.name}`),
-            ).pipe(
-              Effect.map((itemCount) => ({
-                name: artifact.name,
-                schemaVersion: artifact.schemaVersion,
-                itemCount,
-                contentHash: artifact.contentHash,
-              })),
-            ),
-        )
-        const expectedArtifactManifest = {
-          schemaVersion: 'bayn.qualification-artifact-manifest.v1',
-          identity: {
-            runId,
-            evaluationSchemaVersion: evaluation.evaluationSchemaVersion,
-            protocolHash: stored.run.protocolHash,
-            sourceRevision: stored.run.sourceRevision,
-            image: { repository: stored.run.imageRepository, digest: stored.run.imageDigest },
-            snapshotId: stored.run.snapshotId,
-            publicationId: inputManifest.finalizedSnapshot.publicationId,
-            inputManifestHash: inputManifest.hash,
-            bounds: inputManifest.bounds,
-            calendarVersion: inputManifest.finalizedSnapshot.calendarVersion,
-          },
-          execution: {
-            parameterSchemaVersion: stored.protocol.schemaVersion,
-            parameterHash: stored.protocol.parameterHash,
-            simulationSchemaVersion: 'bayn.simulation-trace.v3',
-            executionModel: orders.executionModel,
-            costMultiplierMicros: orders.costMultiplierMicros,
-          },
-          artifacts: manifestArtifacts,
-          events: {
-            count: stored.events.length,
-            contentHash: canonicalHashV1(
-              stored.events.map(({ ordinal, id, kind, contentHash }) => ({ ordinal, id, kind, contentHash })),
-            ),
-          },
-          gates: {
-            count: stored.gates.length,
-            contentHash: canonicalHashV1(
-              stored.gates.map(({ ordinal, name, passed, contentHash }) => ({ ordinal, name, passed, contentHash })),
-            ),
-          },
-        }
-        const storedSnapshot = yield* getSnapshot({ snapshotId: stored.run.snapshotId })
-        yield* ensure(
-          snapshotReferenceMatches(storedSnapshot, inputManifest),
-          'recover-evidence',
-          'stored snapshot reference diverged from the recovered input manifest',
-        )
-        const equityProof = yield* Effect.fromResult(
-          reconcileMarkedEquity({
-            runId,
-            initialCapitalMicros: evaluation.initialCapitalMicros,
-            evaluatorTotalFeesMicros: evaluation.strategy.totalFeesMicros,
-            evaluatorEndingEquityMicros: evaluation.strategy.endingEquityMicros,
-            events,
-            simulation: {
-              schemaVersion: 'bayn.simulation-trace.v3',
-              executionModel: orders.executionModel,
-              costMultiplierMicros: orders.costMultiplierMicros,
-              orders: orders.items,
-              cashChanges: cashChanges.items,
-              dailyMarks: dailyMarks.items,
-            },
-          }),
-        ).pipe(Effect.mapError((issue) => reconciliationDatabaseError('recover-evidence', issue)))
-        const finalPoint = yield* requiredValue(equitySeries.items.at(-1), 'final equity-series point')
-        const decisionEvents = events.filter((event) => event.kind === 'decision')
-        const candidateDates = dailyMarks.items.map((point) => point.sessionDate)
-        yield* ensure(
-          evaluation.runId === runId &&
-            evaluation.codeRevision === provenance.sourceRevision &&
-            evaluation.protocolHash === stored.run.protocolHash &&
-            evaluation.initialCapitalMicros === stored.run.initialCapitalMicros &&
-            evaluation.input.snapshotId === stored.run.snapshotId &&
-            evaluation.input.snapshotId === inputManifest.finalizedSnapshot.snapshotId &&
-            evaluation.input.publicationId === inputManifest.finalizedSnapshot.publicationId &&
-            evaluation.input.manifestHash === inputManifest.hash &&
-            canonicalHashV1(evaluation.input.bounds) === canonicalHashV1(inputManifest.bounds) &&
-            evaluation.input.rowCount === inputManifest.rowCount &&
-            evaluation.input.sessionCount === inputManifest.sessionCount &&
-            canonicalHashV1(evaluation.input.symbols) ===
-              canonicalHashV1(inputManifest.symbols.map((coverage) => coverage.symbol)) &&
-            evaluation.eventCount === stored.run.eventCount &&
-            evaluation.eventCount === events.length &&
-            evaluation.signalDecisionCount === signalDecisions.items.length &&
-            signalDecisions.items.length === decisionEvents.length &&
-            signalDecisions.items.every(
-              (decision, index) =>
-                decision.decisionId === decisionEvents[index]?.id &&
-                decision.signalDate === decisionEvents[index]?.signalDate &&
-                decision.executionDate === decisionEvents[index]?.executionDate &&
-                canonicalHashV1(decision.targetWeights) === canonicalHashV1(decisionEvents[index]?.targetWeights),
-            ) &&
-            evaluation.orderCount === orders.items.length &&
-            evaluation.cashChangeCount === cashChanges.items.length &&
-            evaluation.dailyMarkCount === dailyMarks.items.length &&
-            evaluation.dailyMarkCount === evaluation.strategy.observations &&
-            evaluation.benchmarkSeriesCounts.buyAndHold === buyAndHoldSeries.items.length &&
-            evaluation.benchmarkSeriesCounts.directVolTiming === directVolatilitySeries.items.length &&
-            evaluation.benchmarkSeriesCounts.doubleCostStrategy === doubleCostSeries.items.length &&
-            [buyAndHoldSeries.items, directVolatilitySeries.items, doubleCostSeries.items].every(
-              (series) =>
-                series.length === candidateDates.length &&
-                series.every((point, index) => point.sessionDate === candidateDates[index]),
-            ) &&
-            evaluation.markedEquityReconciliation.runId === runId &&
-            canonicalHashV1(evaluation.markedEquityReconciliation) === canonicalHashV1(markedEquity) &&
-            canonicalHashV1(evaluation.strategy) === strategyArtifact.contentHash &&
-            canonicalHashV1(evaluation.buyAndHold) === buyAndHoldArtifact.contentHash &&
-            canonicalHashV1(evaluation.directVolTiming) === directVolatilityArtifact.contentHash &&
-            canonicalHashV1(evaluation.doubleCostStrategy) === doubleCostArtifact.contentHash &&
-            stored.gates.length === evaluation.verdict.gates.length &&
-            stored.gates.every(
-              (gate, index) =>
-                canonicalHashV1({
-                  name: gate.name,
-                  passed: gate.passed,
-                  actual: gate.actual,
-                  required: gate.required,
-                }) === canonicalHashV1(evaluation.verdict.gates[index]),
-            ) &&
-            stored.events.every((event, index) => event.id === events[index].id && event.kind === events[index].kind) &&
-            reconciliation.runId === runId &&
-            markedEquity.runId === runId &&
-            equitySeries.items.length === evaluation.dailyMarkCount &&
-            canonicalHashV1(equityProof.reconciliation) === canonicalHashV1(markedEquity) &&
-            canonicalHashV1(equityProof.equitySeries) === canonicalHashV1(equitySeries.items) &&
-            finalPoint.evaluatorEquityMicros === markedEquity.evaluatorEndingEquityMicros &&
-            finalPoint.reconstructedEquityMicros === markedEquity.reconstructedEndingEquityMicros &&
-            finalPoint.differenceMicros === markedEquity.differenceMicros &&
-            canonicalHashV1(artifactManifest) === canonicalHashV1(expectedArtifactManifest) &&
-            canonicalHashV1(stored.statuses[1]?.detail) ===
-              canonicalHashV1({ reconciliationExact: true, verdict: evaluation.verdict.status }),
-          'recover-evidence',
-          'stored v4 evidence components diverge',
-        )
-
-        return Option.some({
-          evaluation,
-          reconciliation,
-          persistence: {
-            runId,
-            deduplicated: true,
-            artifactCount: stored.run.artifactCount,
-            eventCount: stored.run.eventCount,
-            gateCount: stored.run.gateCount,
-          },
-        } satisfies RecoveredEvaluationEvidence)
+        const snapshot = yield* getSnapshot({ snapshotId: prepared.stored.run.snapshotId })
+        const recovered = yield* liftRecoveryResult('recover-evidence', completeEvidenceRecovery(prepared, snapshot))
+        return Option.some(recovered)
       }),
     )
 


### PR DESCRIPTION
## Summary

- Extract EvidenceStore recovery into a total, fail-fast pure `Result` verifier with concrete typed facts and one public `DatabaseError` mapping.
- Preserve the exact seven PostgreSQL reads while validating the six-row stored graph before resolving the snapshot through the prepared run identity.
- Retain PROOMPT-411 reconciliation issues, derive exact ledger account/transfer cardinality, and totalize canonicalization and ledger-plan construction without new service or persistence abstractions.
- Add exhaustive pure precedence/immutability coverage plus PostgreSQL round-trip, missing-run, boundary-order, public-mapping, reconciliation, and no-write regressions.

## Related Issues

Tracks [PROOMPT-414](https://linear.app/proompteng/issue/PROOMPT-414/refactor-evidencestore-recovery-into-a-pure-verifier-and-bounded). The issue remains In Progress pending exact-head CI and review settlement.

## Testing

- `bun test services/bayn/src/db/evidence-recovery.test.ts` — 9 passed, 31 assertions.
- `BAYN_TEST_POSTGRES_URL=postgresql://gregkonush@127.0.0.1:5432/bayn_test bun test services/bayn/src/db/evidence-store.integration.test.ts` — 59 passed, 288 assertions.
- `bun run --filter @proompteng/bayn test` — 521 passed, 112 skipped, 0 failed, 2,518 assertions.
- `bun run --filter @proompteng/bayn tsc`.
- `bun run --filter @proompteng/bayn lint`.
- `bun run --filter @proompteng/bayn lint:oxlint`.
- `bun run --filter @proompteng/bayn lint:oxlint:type`.
- `bun run --filter @proompteng/bayn build`.
- `git diff --check` plus no-index checks for both new files.

## Breaking Changes

None. No migration, SQL schema, public service API, startup, health, simulation, qualification, GitOps, database-infrastructure, or trading changes.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.